### PR TITLE
fix(mcp): accept customer wm_ API keys on /mcp + guard pro-token validate (#4859, #4860)

### DIFF
--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -16,6 +16,7 @@ import {
   signInternalMcpRequest,
 } from '../../server/_shared/mcp-internal-hmac';
 import { validateProMcpTokenOrNull } from '../../server/_shared/pro-mcp-token';
+import { validateUserApiKey } from '../../server/_shared/user-api-key';
 import { rpcError, withMcpNoStore } from './rpc';
 import type {
   AuthResolution,
@@ -101,7 +102,11 @@ export async function buildAuthHeaders(
   url: string,
   body: BodyInit | null | undefined,
 ): Promise<Record<string, string>> {
-  if (context.kind === 'env_key') {
+  if (context.kind === 'env_key' || context.kind === 'user_key') {
+    // user_key (#4859): the downstream REST gateway validates the raw key
+    // itself (Convex hash lookup + the #4611 apiAccess gate + per-account
+    // limits), so usage attributes to the key owner exactly like a direct
+    // REST call — no internal-HMAC identity smuggling needed.
     return { 'X-WorldMonitor-Key': context.apiKey };
   }
   // context.kind === 'pro'
@@ -131,6 +136,7 @@ export const PRODUCTION_DEPS: McpHandlerDeps = {
   // to distinguish revoked from transient (F3 of the U7+U8 review pass).
   validateProMcpToken: validateProMcpTokenOrNull,
   getEntitlements,
+  validateUserApiKey,
   redisPipeline: rawRedisPipeline,
 };
 
@@ -188,16 +194,44 @@ export async function resolveAuthContext(
     };
   }
   const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-  if (!await timingSafeIncludes(candidateKey, validKeys)) {
-    return {
-      ok: false,
-      response: new Response(
-        JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Invalid API key' } }),
-        { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
-      ),
-    };
+  if (await timingSafeIncludes(candidateKey, validKeys)) {
+    return { ok: true, context: { kind: 'env_key', apiKey: candidateKey } };
   }
-  return { ok: true, context: { kind: 'env_key', apiKey: candidateKey } };
+
+  // #4859: customer-issued dashboard keys (Convex userApiKeys). The env
+  // allowlist above holds only legacy operator keys; every key a user mints
+  // in the dashboard lives in Convex — before this fallback, ALL of them got
+  // "Invalid API key" here while the same keys worked on the REST gateway.
+  // Identity resolution only: the owner's mcpAccess entitlement is enforced
+  // at the gated-method pre-check (runUserKeyPreChecks), symmetric with the
+  // pro path, so a lapsed owner can still list tools but never call them.
+  if (candidateKey.startsWith('wm_')) {
+    let userKey: { userId: string } | null = null;
+    try {
+      userKey = await deps.validateUserApiKey(candidateKey);
+    } catch {
+      // Production validateUserApiKey fail-softs to null; a throw means the
+      // auth backend itself is unreachable — 503 mirrors the bearer path.
+      return {
+        ok: false,
+        response: new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32603, message: 'Auth service temporarily unavailable. Try again.' } }),
+          { status: 503, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders }) },
+        ),
+      };
+    }
+    if (userKey) {
+      return { ok: true, context: { kind: 'user_key', apiKey: candidateKey, userId: userKey.userId } };
+    }
+  }
+
+  return {
+    ok: false,
+    response: new Response(
+      JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Invalid API key' } }),
+      { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
+    ),
+  };
 }
 
 /**
@@ -227,7 +261,20 @@ export async function runProPreChecks(
     );
   }
 
-  const validation = await deps.validateProMcpToken(context.mcpTokenId);
+  // #4860: this await was the only unguarded step on the gated path — the
+  // wired helper never rejects today, but a rejection here previously escaped
+  // mcpHandler (no top-level catch) as a raw 500 with zero Sentry. Fail
+  // closed with the same retryable 503 shape as the bearer-resolve catch.
+  let validation: Awaited<ReturnType<typeof deps.validateProMcpToken>> = null;
+  try {
+    validation = await deps.validateProMcpToken(context.mcpTokenId);
+  } catch (err) {
+    captureSilentError(err, { tags: { route: 'api/mcp', step: 'pro-token-validate' }, ctx });
+    return new Response(
+      JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32603, message: 'Service temporarily unavailable, retry in a moment.' } }),
+      { status: 503, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders }) },
+    );
+  }
   if (!validation || validation.userId !== context.userId) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'MCP authorization revoked. Re-authorize at https://worldmonitor.app/mcp-grant.' } }),
@@ -235,32 +282,90 @@ export async function runProPreChecks(
     );
   }
 
+  return checkMcpEntitlementGate(context.userId, deps, resourceMetadataUrl, corsHeaders, 'pro-entitlement-recheck', ctx);
+}
+
+/**
+ * Shared mcpAccess entitlement gate for identity-resolved contexts (pro AND
+ * user_key). Fail-closed per memory `entitlement-signal-server-outlier-sweep`.
+ * Returns null when the owner has an active tier>=1 + mcpAccess entitlement;
+ * a 401 Response otherwise.
+ */
+async function checkMcpEntitlementGate(
+  userId: string,
+  deps: McpHandlerDeps,
+  resourceMetadataUrl: string,
+  corsHeaders: Record<string, string>,
+  sentryStep: string,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response | null> {
+  const rejected = () => new Response(
+    JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Subscription not active.' } }),
+    { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
+  );
+
   let ent: Awaited<ReturnType<typeof deps.getEntitlements>> = null;
   try {
-    ent = await deps.getEntitlements(context.userId);
+    ent = await deps.getEntitlements(userId);
   } catch (err) {
-    // Fail-closed per memory `entitlement-signal-server-outlier-sweep`.
-    captureSilentError(err, { tags: { route: 'api/mcp', step: 'pro-entitlement-recheck' }, ctx });
-    return new Response(
-      JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Subscription not active.' } }),
-      { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
-    );
+    captureSilentError(err, { tags: { route: 'api/mcp', step: sentryStep }, ctx });
+    return rejected();
   }
   const tier = ent?.features?.tier ?? 0;
   const mcpAccess = ent?.features?.mcpAccess === true;
   const validUntil = ent?.validUntil ?? 0;
   if (!ent || tier < 1 || !mcpAccess || validUntil < Date.now()) {
-    return new Response(
-      JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Subscription not active.' } }),
-      { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
-    );
+    return rejected();
+  }
+  return null;
+}
+
+/**
+ * user_key (#4859) pre-check: the key row proved identity at auth-resolution
+ * time; data methods must additionally verify the OWNER still has an active
+ * mcpAccess entitlement. Without this, a user_key context would be the one
+ * credential class that skips the entitlement gate (env_key is operator-owned
+ * and intentionally ungated; pro re-checks on every gated call).
+ */
+export async function runUserKeyPreChecks(
+  context: Extract<McpAuthContext, { kind: 'user_key' }>,
+  deps: McpHandlerDeps,
+  resourceMetadataUrl: string,
+  corsHeaders: Record<string, string>,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response | null> {
+  return checkMcpEntitlementGate(context.userId, deps, resourceMetadataUrl, corsHeaders, 'user-key-entitlement', ctx);
+}
+
+/**
+ * Kind-dispatched pre-checks for gated (data/quota) methods. env_key needs
+ * none; pro and user_key each run their own. Single entry point so a future
+ * context kind can't silently ship without deciding its gate (the tracer
+ * finding on #4859: mapping user keys onto env_key would have bypassed
+ * entitlements entirely).
+ */
+export async function runContextPreChecks(
+  context: McpAuthContext,
+  deps: McpHandlerDeps,
+  resourceMetadataUrl: string,
+  corsHeaders: Record<string, string>,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response | null> {
+  if (context.kind === 'pro') {
+    return runProPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
+  }
+  if (context.kind === 'user_key') {
+    return runUserKeyPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
   }
   return null;
 }
 
 /** Per-minute rate limit. Both paths fail-OPEN on Upstash error (graceful);
  *  the daily quota is the hard-cap fail-CLOSED gate. Returns null on success
- *  or pass-through, a Response on a real 60/min limit hit. */
+ *  or pass-through, a Response on a real 60/min limit hit.
+ *  user_key (#4859) shares the per-USER limiter with pro — the principal is
+ *  the key OWNER, so a user with an OAuth connection and a dashboard key gets
+ *  one combined 60/min budget instead of two stackable ones. */
 export async function applyPerMinuteLimit(context: McpAuthContext, headers: Record<string, string> = {}): Promise<Response | null> {
   if (context.kind === 'env_key') {
     const rl = getMcpRatelimit();
@@ -275,7 +380,7 @@ export async function applyPerMinuteLimit(context: McpAuthContext, headers: Reco
   if (!rl) return null;
   try {
     const { success } = await rl.limit(`pro-user:${context.userId}`);
-    if (!success) return rpcError(null, -32029, 'Rate limit exceeded. Max 60 requests per minute per Pro user.', headers);
+    if (!success) return rpcError(null, -32029, 'Rate limit exceeded. Max 60 requests per minute per user.', headers);
   } catch { /* graceful degradation */ }
   return null;
 }

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -134,7 +134,12 @@ export async function dispatchToolsCall(
   // 50/day cap from even seeing tool definitions. Exempt by name; rate-
   // limiter (60/min) still applies as the abuse guard.
   const isMetadataTool = p.name === 'describe_tool';
-  if (context.kind === 'pro' && !isMetadataTool) {
+  // user_key (#4859) consumes the same per-user daily quota as pro: cache
+  // tools read Upstash directly (no downstream gateway metering), so an
+  // unquota'd user_key would be an unmetered data loophole bounded only by
+  // the 60/min limiter. Raising API-plan MCP allowances above the Pro cap is
+  // a deliberate follow-up, not a default.
+  if ((context.kind === 'pro' || context.kind === 'user_key') && !isMetadataTool) {
     const reservation = await reserveQuota(context.userId, deps.redisPipeline);
     if (!reservation.ok) {
       if (reservation.reason === 'cap-exceeded') {

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -5,7 +5,7 @@ import {
   applyPerMinuteLimit,
   PRODUCTION_DEPS,
   resolveAuthContext,
-  runProPreChecks,
+  runContextPreChecks,
   wwwAuthHeader,
 } from './auth';
 import {
@@ -399,10 +399,8 @@ export async function mcpHandler(
     }
     const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
     if (!auth.ok) return auth.response;
-    if (auth.context.kind === 'pro') {
-      const proCheck = await runProPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
-      if (proCheck) return proCheck;
-    }
+    const getPreCheck = await runContextPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
+    if (getPreCheck) return getPreCheck;
     const getLimited = await applyPerMinuteLimit(auth.context, corsHeaders);
     if (getLimited) return getLimited;
     return handleSseReplay(req, corsHeaders);
@@ -467,10 +465,8 @@ export async function mcpHandler(
     const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
     if (!auth.ok) return auth.response;
     context = auth.context;
-    if (context.kind === 'pro') {
-      const proCheck = await runProPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
-      if (proCheck) return proCheck;
-    }
+    const preCheck = await runContextPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
+    if (preCheck) return preCheck;
     const limited = await applyPerMinuteLimit(context, corsHeaders);
     if (limited) return limited;
   }

--- a/api/mcp/telemetry.ts
+++ b/api/mcp/telemetry.ts
@@ -71,11 +71,12 @@ export const MCP_TOOLS_LIST_TELEMETRY_KEYS = Object.freeze([
 ] as const);
 
 // Log-safe principal id derived from the resolved auth context:
-//   - Pro:     raw Clerk `userId` (internal ID, not a secret; matches the
-//              REST gateway's `customer_id` convention).
+//   - Pro / user_key: raw Clerk `userId` (internal ID, not a secret; matches
+//              the REST gateway's `customer_id` convention — user_key carries
+//              the resolved key OWNER, #4859).
 //   - env_key: FNV-64 hash of the API key (secret — never log raw key
 //              material; mirrors `principal_id` in
 //              server/_shared/usage-identity.ts).
 export function principalIdForLog(context: McpAuthContext): string {
-  return context.kind === 'pro' ? context.userId : hashKeySync(context.apiKey);
+  return context.kind === 'env_key' ? hashKeySync(context.apiKey) : context.userId;
 }

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -11,7 +11,14 @@
 
 export type McpAuthContext =
   | { kind: 'env_key'; apiKey: string }
-  | { kind: 'pro'; userId: string; mcpTokenId: string };
+  | { kind: 'pro'; userId: string; mcpTokenId: string }
+  // Customer-issued dashboard key (Convex userApiKeys, #4859). Carries BOTH
+  // the raw key (downstream _execute fetches authenticate as the owner via
+  // X-WorldMonitor-Key, so REST metering/limits attribute to them) AND the
+  // resolved owner userId (per-user rate limit + daily quota + the mcpAccess
+  // entitlement pre-check — a user_key context must NEVER skip that gate the
+  // way env_key does).
+  | { kind: 'user_key'; apiKey: string; userId: string };
 
 // ---------------------------------------------------------------------------
 // Tool registry types
@@ -229,6 +236,11 @@ export interface McpHandlerDeps {
   resolveBearerToContext: (token: string) => Promise<McpAuthContext | null>;
   validateProMcpToken: (tokenId: string) => Promise<{ userId: string } | null>;
   getEntitlements: (userId: string) => Promise<{ planKey?: string; features: { tier: number; mcpAccess?: boolean }; validUntil: number } | null>;
+  // #4859: Convex userApiKeys hash lookup (same shared helper as the REST
+  // gateway). Returns the key owner, or null for unknown/revoked keys. The
+  // production impl fail-softs to null internally; a THROW from a dep is
+  // treated as auth-backend-transient (503), mirroring resolveBearerToContext.
+  validateUserApiKey: (key: string) => Promise<{ userId: string } | null>;
   redisPipeline: PipelineFn;
 }
 

--- a/tests/helpers/mcp-pro-deps.mjs
+++ b/tests/helpers/mcp-pro-deps.mjs
@@ -89,6 +89,10 @@ export function makeProDeps(overrides = {}) {
         features: { tier: 1, mcpAccess: true },
         validUntil: Date.now() + 86_400_000,
       })),
+      // #4859 user-key path. Default rejects every key so pre-existing suites
+      // keep their exact 401 behaviour; user-key tests override with a
+      // fixture-matching resolver.
+      validateUserApiKey: overrides.validateUserApiKey ?? (async () => null),
       redisPipeline: pipe.pipeline,
     },
     pipe,

--- a/tests/mcp-user-key-auth.test.mjs
+++ b/tests/mcp-user-key-auth.test.mjs
@@ -1,0 +1,185 @@
+// #4859 — /mcp must accept customer-issued wm_ API keys (Convex userApiKeys)
+// on X-WorldMonitor-Key, with the owner's mcpAccess entitlement gating data
+// methods exactly like the Pro OAuth path (a user_key context must NEVER
+// bypass the entitlement pre-check — see the #4859 fix-design comment).
+// #4860 — a rejecting validateProMcpToken must surface a structured 503,
+// never escape mcpHandler as a raw 500.
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  BASE_URL,
+  HMAC_SECRET,
+  makeProDeps,
+  proReq,
+  callBody,
+} from './helpers/mcp-pro-deps.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+// Canonical dashboard key shape (wm_ + 40 hex) — NOT in WORLDMONITOR_VALID_KEYS.
+const USER_KEY = `wm_${'ab12'.repeat(10)}`;
+const USER_KEY_USER_ID = 'user_apiplan_abc';
+const ENV_KEY = 'wm_env_operator_key_999';
+
+/** Deps bundle where USER_KEY resolves to USER_KEY_USER_ID (api_starter-like owner). */
+function makeUserKeyDeps(overrides = {}) {
+  return makeProDeps({
+    validateUserApiKey: async (key) => (key === USER_KEY ? { userId: USER_KEY_USER_ID } : null),
+    getEntitlements: async () => ({
+      planKey: 'api_starter',
+      features: { tier: 2, mcpAccess: true },
+      validUntil: Date.now() + 86_400_000,
+    }),
+    ...overrides,
+  });
+}
+
+function userKeyReq(body, headers = {}) {
+  return new Request(BASE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-WorldMonitor-Key': USER_KEY,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('api/mcp — user API keys on /mcp (#4859) + pre-check hardening (#4860)', () => {
+  let mcpHandler;
+
+  beforeEach(async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = ENV_KEY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    mcpHandler = mod.mcpHandler;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  // ── #4860 — runProPreChecks must not let a validateProMcpToken rejection escape ──
+
+  it('#4860: validateProMcpToken rejects → structured 503 -32603, not a thrown-through 500', async () => {
+    const { deps } = makeProDeps({
+      validateProMcpToken: async () => { throw new Error('redis exploded'); },
+    });
+    const res = await mcpHandler(proReq('POST', callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
+    assert.equal(res.status, 503, 'must fail closed with a retryable 503');
+    assert.ok(res.headers.get('Retry-After'), 'transient failure must carry Retry-After');
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+  });
+
+  // ── #4859 — user keys accepted, entitlement-gated ──
+
+  it('happy: valid user key + mcpAccess entitlement → describe_tool 200', async () => {
+    const { deps, pipe } = makeUserKeyDeps();
+    const res = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content?.[0]?.text?.includes('get_market_data'));
+    assert.equal(pipe.count, 0, 'describe_tool is quota-exempt for user keys too');
+  });
+
+  it('happy: valid user key, data tool → 200 and daily quota reserved (counter at 1)', async () => {
+    const { deps, pipe } = makeUserKeyDeps();
+    process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'stub';
+    globalThis.fetch = async () => new Response(JSON.stringify({ result: JSON.stringify({ ok: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    const res = await mcpHandler(userKeyReq(callBody('get_market_data')), deps);
+    assert.equal(res.status, 200);
+    assert.equal(pipe.count, 1, 'user_key tools/call must consume the daily quota (no unmetered cache-tool loophole)');
+  });
+
+  it('cap: user key with 50 calls today → 51st rejected 429 -32029, counter back at 50', async () => {
+    const { deps, pipe } = makeUserKeyDeps({ pipelineOpts: { initialCount: 50 } });
+    const res = await mcpHandler(userKeyReq(callBody('get_market_data')), deps);
+    assert.equal(res.status, 429);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32029);
+    assert.equal(pipe.count, 50);
+  });
+
+  it('entitlement gate: valid user key whose owner is free/no-mcpAccess → tools/call 401, tools/list still 200', async () => {
+    const { deps } = makeUserKeyDeps({
+      getEntitlements: async () => ({ planKey: 'free', features: { tier: 0, mcpAccess: false }, validUntil: 0 }),
+    });
+    const call = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
+    assert.equal(call.status, 401, 'lapsed owner must not reach any tools/call');
+    const callBodyJson = await call.json();
+    assert.equal(callBodyJson.error?.code, -32001);
+    assert.match(callBodyJson.error?.message ?? '', /Subscription not active/);
+
+    const list = await mcpHandler(userKeyReq({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }), deps);
+    assert.equal(list.status, 200, 'metadata discovery stays available (symmetric with the pro path)');
+  });
+
+  it('entitlement gate: getEntitlements throws for a user key → 401 fail-closed', async () => {
+    const { deps } = makeUserKeyDeps({
+      getEntitlements: async () => { throw new Error('convex down'); },
+    });
+    const res = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32001);
+  });
+
+  it('unknown wm_ key (not env, not a user key) → 401 -32001 Invalid API key', async () => {
+    const { deps } = makeUserKeyDeps();
+    const res = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' }), { 'X-WorldMonitor-Key': 'wm_totally_unknown_key' }), deps);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32001);
+    assert.match(body.error?.message ?? '', /Invalid API key/);
+  });
+
+  it('validateUserApiKey dep throws → 503 (auth backend transient, mirrors bearer-resolve)', async () => {
+    const { deps } = makeUserKeyDeps({
+      validateUserApiKey: async () => { throw new Error('redis down'); },
+    });
+    const res = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+  });
+
+  it('env allowlist key still authenticates without touching the user-key resolver', async () => {
+    let userKeyCalls = 0;
+    const { deps } = makeUserKeyDeps({
+      validateUserApiKey: async () => { userKeyCalls += 1; return null; },
+    });
+    const res = await mcpHandler(userKeyReq(callBody('describe_tool', { tool_name: 'get_market_data' }), { 'X-WorldMonitor-Key': ENV_KEY }), deps);
+    assert.equal(res.status, 200);
+    assert.equal(userKeyCalls, 0, 'env-key hit must short-circuit before the Convex-backed resolver');
+  });
+
+  it('_execute downstream fetch carries the user key header, never internal-HMAC headers', async () => {
+    const { deps } = makeUserKeyDeps();
+    const captured = [];
+    globalThis.fetch = async (url, init) => {
+      captured.push(new Request(url, init));
+      return new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+    await mcpHandler(userKeyReq(callBody('get_country_risk', { country_code: 'US' })), deps);
+    // Filter to the sibling REST fetch: an earlier test in this file may have
+    // instantiated the module-memoized Upstash rate limiter, whose Redis POST
+    // is also captured here and legitimately carries no key header.
+    const apiFetches = captured.filter((r) => new URL(r.url).pathname.startsWith('/api/'));
+    assert.ok(apiFetches.length > 0, 'RPC tool must fetch the downstream REST endpoint');
+    for (const dsReq of apiFetches) {
+      assert.equal(dsReq.headers.get('x-worldmonitor-key'), USER_KEY, 'downstream must authenticate as the key owner');
+      assert.equal(dsReq.headers.get('x-wm-mcp-internal'), null, 'internal HMAC headers are pro-context only');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two P0s surfaced by a paying-customer support ticket (2026-07-05). Closes #4859, closes #4860.

**#4859 — `/mcp` rejected every customer-issued `wm_` API key.** The `X-WorldMonitor-Key` path validated only against the static `WORLDMONITOR_VALID_KEYS` env allowlist (legacy operator keys) and never consulted Convex `userApiKeys` — structural since inception. Every dashboard key got `401 -32001 "Invalid API key"` on `/mcp` while the same keys worked on REST (verified for the affected customer: 153 × 200 key-authed REST requests, MCP always rejected). The endpoint's own no-credentials 401 hint — and the published docs (`docs/mcp-overview.mdx` auth method 2, `mcp-quickstart` curl examples) — told users to send exactly that header.

**#4860 — a `validateProMcpToken` rejection escaped as a raw 500.** The await in `runProPreChecks` was the only unguarded step on the gated path, with no top-level catch in `mcpHandler` behind it. A rejection produced the exact fingerprint of the customer's second symptom: every `tools/call` (incl. `describe_tool`) → raw HTTP 500, `tools/list` unaffected, zero Sentry. Latent today (the wired helper fail-softs internally) — protection now lives at the call site, not by convention.

## Design (per the #4859 fix-design constraints)

- New `user_key` context kind — **not** mapped onto `env_key`, which skips pre-checks entirely; a lapsed key owner must never bypass the entitlement gate.
- Env-allowlist miss → fallback to the gateway-shared `validateUserApiKey` (same Convex hash lookup + Redis cache the REST gateway uses). Identity only; a dep throw → 503, mirroring bearer-resolve.
- Gated methods run `runUserKeyPreChecks` → shared fail-closed `mcpAccess`/tier/`validUntil` gate (factored out of `runProPreChecks`, same "Subscription not active." 401). `tools/list` stays available to a lapsed owner, symmetric with pro.
- Per-user 60/min limiter (shared bucket with pro for the same principal) + the pro **daily quota**: cache tools read Upstash directly with no downstream gateway metering, so an unquota'd `user_key` would be an unmetered data loophole. Raising API-plan MCP allowances above the Pro cap is a deliberate follow-up.
- `_execute` fetches send the raw user key downstream — the REST gateway re-validates and meters the owner (`auth_kind=user_api_key`), including the #4611 apiAccess gate.
- `runContextPreChecks` is now the single kind-dispatched entry point so a future context kind can't ship without deciding its gate.
- #4860: the await is wrapped → `captureSilentError` (`step: pro-token-validate`) → structured 503 + `Retry-After`, so any recurrence is visible in Sentry instead of a silent platform 500.

## Tests

- New `tests/mcp-user-key-auth.test.mjs` (10 cases, written failing-first: 7 failed on the old code): happy path, quota reserve + cap + describe_tool exemption, entitlement-lapsed 401 with tools/list still 200, entitlement-throw fail-closed, unknown-key 401 shape preserved, dep-throw 503, env-key short-circuit (no Convex touch), downstream header contract (user key present, internal-HMAC absent), and the #4860 rejection → 503.
- Regression: mcp / quota×3 / protocol+transport conformance / tool-output contracts / telemetry schema / resources / gateway-internal-mcp / oauth-token / pro-mcp-token — 360 tests green. `typecheck:api` + biome clean.

## Verification against the live incident

Live probes during diagnosis confirmed the failure shape this PR fixes: bogus and valid user keys both got `-32001 "Invalid API key"` on `/mcp` while the pro OAuth path (verified end-to-end with a minted pro bearer incl. SSE framing and `_execute` HMAC hop) and REST user-key auth were healthy. Post-deploy plan: re-probe `/mcp` with an unknown key (same 401 shape), env key (200), and a fresh pro bearer (200).

https://claude.ai/code/session_01Ex9zkdxdbxYMogHmEK2YXZ
