### PR TITLE
feat(agent-readiness): close the agent-journey gaps — pricing/signup/support discovery + status advertisement fixes (#4850 #4854 #4856 #4857)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -788,7 +788,23 @@ export default async function handler(req, ctx) {
       const error = keyCheck.error === USER_API_KEY_GATEWAY_VALIDATION_ERROR
         ? 'Invalid API key'
         : keyCheck.error;
-      return jsonResponse({ error }, 401, headers);
+      // RFC 7235 §3.1 requires WWW-Authenticate on every 401; resource_metadata
+      // (RFC 9728 §5.1) lets agents discover how to obtain credentials. The
+      // hint exists because this URL is what old copies of the api-catalog
+      // linkset advertised as the public status endpoint (#4856) — a keyless
+      // caller landing here should learn the public form, not dead-end.
+      return jsonResponse(
+        {
+          error,
+          hint: 'Detailed health requires an operator/enterprise API key. Public status: /api/health?compact=1',
+        },
+        401,
+        {
+          ...headers,
+          'WWW-Authenticate':
+            'Bearer resource_metadata="https://www.worldmonitor.app/.well-known/oauth-protected-resource"',
+        }
+      );
     }
   }
 

--- a/docs/accounts.mdx
+++ b/docs/accounts.mdx
@@ -1,0 +1,34 @@
+---
+title: "Accounts & Sign-up"
+description: "How account creation works: the free dashboard needs no account; Pro/API accounts are created via the Clerk sign-up flow in a browser."
+---
+
+<Info>
+**The free dashboard requires no account.** Everything listed under the Free plan — 56 map layers, 500+ feeds, country briefs, watchlists — works anonymously at [worldmonitor.app](https://worldmonitor.app). Create an account only when you want Pro/API features or need to mint an API key.
+</Info>
+
+## How sign-up works
+
+Account creation is an interactive browser flow, not an API:
+
+1. Open [worldmonitor.app/pro](https://worldmonitor.app/pro) and click **Sign up** (or use the dashboard's sign-in button). A [Clerk](https://clerk.com) modal opens inside the page — there is no standalone `/sign-up` form page; that URL serves the app shell.
+2. Register with email + password or an OAuth provider (Google, GitHub). Email registrations get a verification code; the modal walks through it.
+3. A free account by itself unlocks nothing extra on the dashboard — it is the identity that Pro/API subscriptions and API keys attach to.
+
+## After signing up
+
+- **Upgrade to Pro or API** from [worldmonitor.app/pro](https://worldmonitor.app/pro) — checkout runs on Dodo Payments; see [Plans & Pricing](/pricing).
+- **Mint an API key** from the dashboard once subscribed (`wm_` + 40 hex chars); the [auth matrix](/usage-auth) covers where each key type works.
+- **Connect an agent via OAuth** instead of a key: MCP clients (Claude Desktop and others) use OAuth 2.1 + PKCE with dynamic client registration — no manual account dance; see [auth.md](https://worldmonitor.app/auth.md) for the self-bootstrapping discovery chain.
+
+## For agents
+
+- You cannot complete browser sign-up on a user's behalf by fetching pages — the flow lives in a client-side Clerk modal. Direct users to [worldmonitor.app/pro](https://worldmonitor.app/pro).
+- To act *as* an agent with your own credentials, use the OAuth path in [auth.md](https://worldmonitor.app/auth.md) (anonymous dynamic client registration, then a human consents at authorization time).
+- Pricing, plan gates, and quotas are machine-readable: [`/pricing.md`](https://worldmonitor.app/pricing.md) and [`GET /api/product-catalog`](https://www.worldmonitor.app/api/product-catalog).
+
+## Related
+
+- [Plans & Pricing](/pricing)
+- [Authentication & Usage](/usage-auth)
+- [Support & Contact](/support)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,10 @@
               "usage-quickstart",
               "usage-auth",
               "usage-rate-limits",
-              "usage-errors"
+              "usage-errors",
+              "pricing",
+              "accounts",
+              "support"
             ]
           },
           {
@@ -333,6 +336,10 @@
               {
                 "group": "Forecasts",
                 "openapi": "api/ForecastService.openapi.yaml"
+              },
+              {
+                "group": "Commerce",
+                "openapi": "openapi/CommerceService.openapi.yaml"
               }
             ]
           },
@@ -465,6 +472,30 @@
     {
       "source": "/mcp-server",
       "destination": "/mcp-overview"
+    },
+    {
+      "source": "/plans",
+      "destination": "/pricing"
+    },
+    {
+      "source": "/tiers",
+      "destination": "/pricing"
+    },
+    {
+      "source": "/rate-limit",
+      "destination": "/usage-rate-limits"
+    },
+    {
+      "source": "/rate-limits",
+      "destination": "/usage-rate-limits"
+    },
+    {
+      "source": "/mcp-api-key",
+      "destination": "/usage-auth"
+    },
+    {
+      "source": "/contact",
+      "destination": "/support"
     }
   ]
 }

--- a/docs/openapi/CommerceService.openapi.yaml
+++ b/docs/openapi/CommerceService.openapi.yaml
@@ -1,0 +1,99 @@
+# Hand-authored spec for the commerce surface (plain Vercel functions, not a
+# sebuf proto service — so this file lives OUTSIDE docs/api/, which is a fully
+# generated directory guarded by proto-check regen + injector scripts).
+# Wired into the Mintlify API Reference via docs/docs.json ("Commerce" group).
+# Prose companion: docs/api-commerce.mdx. Added for #4854 — agents guessed
+# /docs/api-reference/commerceservice/getproductcatalog and 404'd because the
+# commerce ops existed only as prose.
+openapi: 3.1.0
+info:
+    title: CommerceService API
+    version: 1.0.0
+    description: Public pricing catalog for World Monitor plans. The catalog endpoint is keyless and read-only; agents evaluating the product should prefer it over scraping pricing prose.
+servers:
+    - url: https://www.worldmonitor.app
+paths:
+    /api/product-catalog:
+        get:
+            tags:
+                - CommerceService
+            summary: GetProductCatalog
+            operationId: GetProductCatalog
+            security: []
+            description: |-
+                Returns the live tier view-model used by the /pro pricing page: plan names,
+                descriptions, feature bullets, monthly/annual USD prices, and Dodo Payments
+                product IDs. Public — no API key required. Cached in Redis for 1 hour; on
+                cache miss, prices are fetched live from Dodo Payments with a static
+                fallback if Dodo is unreachable. The X-Product-Catalog-Source response
+                header distinguishes cache hits ("cache") from live fetches ("dodo") and
+                fallback pricing ("fallback"). Markdown twin: https://worldmonitor.app/pricing.md
+            responses:
+                "200":
+                    description: Successful response
+                    headers:
+                        X-Product-Catalog-Source:
+                            description: Where the prices came from — cache, dodo, or fallback.
+                            schema:
+                                type: string
+                                enum: [cache, dodo, fallback]
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    tiers:
+                                        type: array
+                                        description: One entry per plan (Free, Pro, API, Enterprise).
+                                        items:
+                                            type: object
+                                            properties:
+                                                name:
+                                                    type: string
+                                                description:
+                                                    type: string
+                                                features:
+                                                    type: array
+                                                    items:
+                                                        type: string
+                                                highlighted:
+                                                    type: boolean
+                                                price:
+                                                    type: number
+                                                    description: Flat price for non-subscription tiers (0 for Free).
+                                                period:
+                                                    type: string
+                                                monthlyPrice:
+                                                    type: number
+                                                monthlyProductId:
+                                                    type: string
+                                                    description: Dodo Payments product ID for monthly billing.
+                                                annualPrice:
+                                                    type: number
+                                                annualProductId:
+                                                    type: string
+                                                    description: Dodo Payments product ID for annual billing.
+                                    fetchedAt:
+                                        type: integer
+                                        description: Epoch ms when the catalog was assembled.
+                                    cachedUntil:
+                                        type: integer
+                                        description: Epoch ms until which the cached copy is served.
+                            example:
+                                tiers:
+                                    - name: Free
+                                      description: Get started with the essentials
+                                      features: ["Core dashboard panels", "Global news feed"]
+                                      highlighted: false
+                                      price: 0
+                                      period: forever
+                                    - name: Pro
+                                      description: Full intelligence dashboard
+                                      features: ["Everything in Free", "AI stock analysis & backtesting"]
+                                      highlighted: true
+                                      monthlyPrice: 39.99
+                                      monthlyProductId: pdt_0Nbtt71uObulf7fGXhQup
+                                      annualPrice: 399.99
+                                      annualProductId: pdt_0NbttMIfjLWC10jHQWYgJ
+                                fetchedAt: 1751700000000
+                                cachedUntil: 1751703600000

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -1,0 +1,46 @@
+---
+title: "Plans & Pricing"
+description: "Free, Pro, API, and Enterprise plans — prices, what each includes, and the machine-readable pricing surfaces for agents."
+---
+
+World Monitor has a free public dashboard and paid tiers for analyst workflows, API access, and organization deployments.
+
+<Info>
+**Machine-readable sources** (canonical for agents):
+- Markdown: [`/pricing.md`](https://worldmonitor.app/pricing.md)
+- Live JSON (tiers, prices, Dodo product IDs): [`GET /api/product-catalog`](https://www.worldmonitor.app/api/product-catalog) — public, no key required
+</Info>
+
+## Plans
+
+| Plan | Price | Best for |
+|------|-------|----------|
+| **Free** | $0 — no signup required | Public situational awareness, OSINT research, news monitoring |
+| **Pro** | $39.99/month · $399.99/year | WM Analyst chat, Scenario Engine, AI digests, custom widgets, MCP access |
+| **API** | $99.99/month | REST API + SDKs, 1,000 requests/day starter limit, webhooks, data exports |
+| **Enterprise** | Custom — [enterprise@worldmonitor.app](mailto:enterprise@worldmonitor.app) | Team workspaces, SSO/MFA/RBAC, white-label, on-premises / air-gapped |
+
+Prices above mirror `convex/config/productCatalog.ts` (the source of truth behind `/api/product-catalog`); a drift guard test keeps this page honest.
+
+## What each plan includes
+
+- **Free** — 56 map layers, 500+ curated feeds, country briefs, hotspots, instability scores, chokepoints, cascade analysis, breaking alerts, and watchlists. Dashboard refresh cadence is typically 5–15 minutes.
+- **Pro** — everything in Free, plus WM Analyst chat across 30+ live services with citations, Scenario Engine, Route Explorer, personal AI digest (daily / twice-daily / weekly via Slack, Discord, Telegram, email, webhook), custom widget builder, and MCP access (39 tools under one key).
+- **API** — programmatic access: REST API with structured JSON and cache headers, official SDKs (npm, PyPI, RubyGems, Go), real-time data streams, webhook notifications (5 rules on Starter), and custom data exports.
+- **Enterprise** — everything in Pro and API, plus team workspaces, SSO/MFA/RBAC, dedicated support, white-label and embeddable panels, SIEM connectors, bulk export, and cloud / dedicated-tenant / on-premises / air-gapped deployment.
+
+## Limits & overage
+
+Rate limits are hard limits by default: exceeding a plan quota returns HTTP `429` with `Retry-After` and `X-RateLimit-*` headers. Usage above quota is rejected — never silently charged. Per-endpoint budgets: [Rate Limits](/usage-rate-limits).
+
+Need a higher limit? Upgrade at [worldmonitor.app/pro](https://worldmonitor.app/pro) or contact [enterprise@worldmonitor.app](mailto:enterprise@worldmonitor.app).
+
+## Buying and managing a subscription
+
+Checkout runs on [Dodo Payments](https://dodopayments.com); entitlements live in Convex. Subscribe from [worldmonitor.app/pro](https://worldmonitor.app/pro); manage billing (invoices, cancel, renew) via the customer portal on the same page. Endpoint details: [Commerce Endpoints](/api-commerce).
+
+## Related
+
+- [Accounts & Sign-up](/accounts) — the free tier needs no account at all
+- [Authentication & Usage](/usage-auth) — key types and the auth matrix
+- [Rate Limits](/usage-rate-limits) — per-endpoint request budgets

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -1,0 +1,39 @@
+---
+title: "Support & Contact"
+description: "Every support channel — email, GitHub issues, Discord, status page — and what response to expect on each plan."
+---
+
+<Info>
+Machine-readable version for agents: [`/support.md`](https://worldmonitor.app/support.md)
+</Info>
+
+## Channels
+
+| Concern | Channel |
+|---------|---------|
+| General support, account or billing issues | [support@worldmonitor.app](mailto:support@worldmonitor.app) |
+| Enterprise, sales, custom quotas | [enterprise@worldmonitor.app](mailto:enterprise@worldmonitor.app) |
+| Bug reports & feature requests | [GitHub issues](https://github.com/koala73/worldmonitor/issues) (public, open source) |
+| Community & quick questions | [Discord](https://discord.gg/re63kWKxaz) |
+| Service status & incidents | [status.worldmonitor.app](https://status.worldmonitor.app) — email subscription available |
+| Security vulnerabilities | See [security.txt](https://www.worldmonitor.app/.well-known/security.txt) |
+
+The in-app contact form on [/pro](https://worldmonitor.app/pro) (`POST /api/leads/v1/submit-contact`) is Turnstile-protected and intended for humans in a browser; agents should use email instead.
+
+## Response expectations
+
+- **Free / Pro / API** — best-effort support via email, GitHub, and Discord. No formal SLA.
+- **Enterprise** — dedicated support with committed response times, agreed per contract.
+
+When writing about an API issue, include your key prefix (never the full key), the endpoint, and any request IDs or `X-RateLimit-*` header values you received.
+
+## Before you write in
+
+- **Is it an outage?** Check [status.worldmonitor.app](https://status.worldmonitor.app) and the public health probe `GET /api/health?compact=1`.
+- **Key rotation / limit increases** — [Authentication & Usage](/usage-auth), [Rate Limits](/usage-rate-limits), or email support.
+- **Billing self-serve** — invoices, cancel, and renew live in the customer portal at [worldmonitor.app/pro](https://worldmonitor.app/pro).
+
+## Related
+
+- [Plans & Pricing](/pricing)
+- [Accounts & Sign-up](/accounts)

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,12 +32,17 @@ const LEGACY_DASHBOARD_ROOT_QUERY_KEYS = ['lat', 'lon', 'zoom', 'view', 'timeRan
 //   public/api/llms.txt). It MUST bypass the bot gate — AI crawlers (ClaudeBot,
 //   GPTBot, PerplexityBot, CCBot, …) are the entire audience for an llms.txt,
 //   yet every one of those UAs matches BOT_UA and would otherwise 403.
+// - /api/product-catalog: public read-only pricing catalog (Redis-cached,
+//   keyless, advertised as service-meta in /.well-known/api-catalog). Agents
+//   evaluating the product are a primary audience; an agent-journey run (#4854)
+//   got 403 here and concluded the endpoint didn't exist.
 const PUBLIC_API_PATHS = new Set([
   '/api/version',
   '/api/health',
   '/api/seed-contract-probe',
   '/api/internal/brief-why-matters',
   '/api/llms.txt',
+  '/api/product-catalog',
 ]);
 
 const SOCIAL_IMAGE_UA =

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -35,9 +35,26 @@
           "type": "text/html"
         }
       ],
+      "service-meta": [
+        {
+          "href": "https://worldmonitor.app/pricing.md",
+          "type": "text/markdown",
+          "title": "Pricing, plans & limits (machine-readable)"
+        },
+        {
+          "href": "https://www.worldmonitor.app/api/product-catalog",
+          "type": "application/json",
+          "title": "Live product catalog (tiers, prices, product IDs)"
+        },
+        {
+          "href": "https://worldmonitor.app/support.md",
+          "type": "text/markdown",
+          "title": "Support channels & contact (machine-readable)"
+        }
+      ],
       "status": [
         {
-          "href": "https://api.worldmonitor.app/api/health",
+          "href": "https://api.worldmonitor.app/api/health?compact=1",
           "type": "application/json"
         }
       ]

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -213,7 +213,9 @@
     "guide": "https://www.worldmonitor.app/docs/mcp-overview",
     "toolReference": "https://www.worldmonitor.app/docs/mcp-tools-reference",
     "apiReference": "https://www.worldmonitor.app/docs/api-reference",
-    "support": "https://www.worldmonitor.app/docs/getting-started"
+    "support": "https://www.worldmonitor.app/docs/support",
+    "pricing": "https://worldmonitor.app/pricing.md",
+    "productCatalog": "https://www.worldmonitor.app/api/product-catalog"
   },
   "rateLimits": {
     "perMinute": 60,

--- a/public/auth.md
+++ b/public/auth.md
@@ -5,6 +5,12 @@ How agents authenticate with the WorldMonitor API and MCP server
 <https://workos.com/auth-md>. Discovery is open; data calls need a bearer token
 or API key.
 
+**Before anything else — send a descriptive `User-Agent`** (e.g.
+`mytool/1.0 (+https://yoursite.example)`). Default HTTP-library UAs (`curl/*`,
+`python-requests/*`, empty/short strings) may be challenged with an HTML 403 by
+the edge firewall before your request reaches the API — a 403 does not mean the
+endpoint is missing or your credentials are wrong.
+
 ## Discover
 
 Learn the auth requirements from one unauthenticated request, then follow the

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -27,7 +27,10 @@ Reach for World Monitor when a task needs live, correlated, machine-readable glo
 - **REST API:** base `https://api.worldmonitor.app`; OpenAPI spec at https://worldmonitor.app/openapi.yaml; same `X-WorldMonitor-Key` header.
 - **CLI:** `npx worldmonitor tools` lists every tool (public, no key); `npm install -g worldmonitor` installs the `worldmonitor` command. A zero-dependency, MCP-first client for the tools and REST API above — pass `--api-key` for data calls. https://www.npmjs.com/package/worldmonitor
 - **Agent Skills:** discovery manifest at https://worldmonitor.app/.well-known/agent-skills/index.json
-- **Keys, plans & limits:** https://worldmonitor.app/pricing.md · auth matrix https://www.worldmonitor.app/docs/usage-auth · issue a key at https://worldmonitor.app/pro
+- **Keys, plans & limits:** https://worldmonitor.app/pricing.md (markdown) · live JSON catalog `GET https://www.worldmonitor.app/api/product-catalog` (public, no key) · auth matrix https://www.worldmonitor.app/docs/usage-auth · rate limits https://www.worldmonitor.app/docs/usage-rate-limits.md · issue a key at https://worldmonitor.app/pro
+- **Accounts & sign-up:** free dashboard needs NO account; Pro/API accounts are created in a browser (Clerk sign-up at https://worldmonitor.app/pro). Guide: https://www.worldmonitor.app/docs/accounts.md
+- **Support & contact:** https://worldmonitor.app/support.md — support@worldmonitor.app (general) · enterprise@worldmonitor.app (sales) · status https://status.worldmonitor.app · issues https://github.com/koala73/worldmonitor/issues
+- **User-Agent policy:** always send a descriptive `User-Agent` (e.g. `mytool/1.0 (+https://yoursite.example)`). Default HTTP-library UAs (`curl/*`, `python-requests/*`, empty/short strings) may be challenged with 403 by the edge firewall — a 403 does NOT mean the endpoint is missing; retry with a real UA before concluding anything.
 
 ## Live Instances
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -28,7 +28,10 @@ Reach for World Monitor when a task needs live, correlated, machine-readable glo
 - **CLI:** `npx worldmonitor tools` lists every tool (public, no key); `npm install -g worldmonitor` installs the `worldmonitor` command. A zero-dependency, MCP-first client for the tools and REST API above — pass `--api-key` for data calls. https://www.npmjs.com/package/worldmonitor
 - **SDKs:** official zero-dependency client libraries — Python `pip install worldmonitor-sdk` (https://pypi.org/project/worldmonitor-sdk/), Ruby `gem install worldmonitor` (https://rubygems.org/gems/worldmonitor), Go `go get github.com/koala73/worldmonitor/sdk/go` (https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go), JavaScript via the npm package above. Guide: https://www.worldmonitor.app/docs/sdks
 - **Agent Skills:** discovery manifest at https://worldmonitor.app/.well-known/agent-skills/index.json
-- **Keys, plans & limits:** https://worldmonitor.app/pricing.md · auth matrix https://www.worldmonitor.app/docs/usage-auth · issue a key at https://worldmonitor.app/pro
+- **Keys, plans & limits:** https://worldmonitor.app/pricing.md (markdown) · live JSON catalog `GET https://www.worldmonitor.app/api/product-catalog` (public, no key) · auth matrix https://www.worldmonitor.app/docs/usage-auth · rate limits https://www.worldmonitor.app/docs/usage-rate-limits.md · issue a key at https://worldmonitor.app/pro
+- **Accounts & sign-up:** free dashboard needs NO account; Pro/API accounts are created in a browser (Clerk sign-up at https://worldmonitor.app/pro). Guide: https://www.worldmonitor.app/docs/accounts.md
+- **Support & contact:** https://worldmonitor.app/support.md — support@worldmonitor.app (general) · enterprise@worldmonitor.app (sales) · status https://status.worldmonitor.app · issues https://github.com/koala73/worldmonitor/issues
+- **User-Agent policy:** always send a descriptive `User-Agent` (e.g. `mytool/1.0 (+https://yoursite.example)`). Default HTTP-library UAs (`curl/*`, `python-requests/*`, empty/short strings) may be challenged with 403 by the edge firewall — a 403 does NOT mean the endpoint is missing; retry with a real UA before concluding anything.
 
 ## AI Search Answer Blocks
 
@@ -63,6 +66,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - [World Monitor Pro](https://worldmonitor.app/pro): AI-powered equity research, geopolitical analysis, macro intelligence
 - [Blog](https://www.worldmonitor.app/blog/): Analysis, OSINT guides, geopolitics, and market intelligence articles
 - [Pricing Markdown](https://www.worldmonitor.app/pricing.md): Machine-readable pricing and plan limits for AI agents
+- [Support & Contact](https://www.worldmonitor.app/support.md): Machine-readable support channels, contact emails, and response expectations
 - [AI Search Briefing](https://www.worldmonitor.app/ai-search.md): Query-shaped answer blocks for AI citations
 
 ## Documentation
@@ -71,6 +75,8 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - [Full Documentation](https://github.com/koala73/worldmonitor/blob/main/docs/DOCUMENTATION.md): Detailed feature documentation, data layers, and panel reference
 - [Extended LLM Documentation](https://worldmonitor.app/llms-full.txt): Comprehensive version of this file with all data layers, components, and data sources
 - [Machine-Readable Pricing](https://worldmonitor.app/pricing.md): Free, Pro, API, and Enterprise plan details in markdown
+- [Accounts & Sign-up](https://www.worldmonitor.app/docs/accounts.md): How account creation works (free tier needs none; Clerk sign-up for Pro/API)
+- [Support & Contact](https://worldmonitor.app/support.md): Support channels, contact emails, status page, response expectations
 
 ## Key Features
 
@@ -133,6 +139,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - [llms-full.txt](https://worldmonitor.app/llms-full.txt): Full LLM-readable feature and data-source reference
 - [api/llms.txt](https://worldmonitor.app/api/llms.txt): API-section briefing — MCP server, REST API, CLI, auth, and per-task tool routing for the developer surface
 - [pricing.md](https://worldmonitor.app/pricing.md): Machine-readable pricing, limits and plan features
+- [support.md](https://worldmonitor.app/support.md): Machine-readable support channels and contact routes
 - [ai-search.md](https://worldmonitor.app/ai-search.md): AI-search answer blocks for citation and extraction
 - [worldmonitor CLI](https://www.npmjs.com/package/worldmonitor): Official command-line client — `npx worldmonitor` scripts the MCP tools and REST API from a shell or agent
 - [SDKs](https://www.worldmonitor.app/docs/sdks): Official client libraries — Python (PyPI `worldmonitor-sdk`), Ruby (gem `worldmonitor`), Go (`github.com/koala73/worldmonitor/sdk/go`), JavaScript (npm `worldmonitor`)

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -1,8 +1,10 @@
 # Pricing - World Monitor
 
-Last updated: June 13, 2026
+Last updated: July 5, 2026
 
 World Monitor has a free public dashboard and paid tiers for analyst workflows, API access and organization deployments.
+
+Live tier/price/product-ID data (JSON): `GET https://www.worldmonitor.app/api/product-catalog` — public, no key required. Send a descriptive `User-Agent` (for example `mytool/1.0 (+https://yoursite.example)`); default HTTP-library user agents may be challenged by the edge firewall.
 
 ## Free
 
@@ -38,6 +40,12 @@ World Monitor has a free public dashboard and paid tiers for analyst workflows, 
 - Includes: Everything in Pro and API, team workspaces, SSO/MFA/RBAC, dedicated support, white-label and embeddable panels, Android TV app, SIEM/connectors, bulk export and managed deployment options
 - Deployment options: Cloud, dedicated cloud tenant, on-premises or air-gapped
 - Security: AES-256 encrypted notification channels, audit trail, private MCP options and organization controls
+
+## Limits & Overage
+
+- Rate limits are hard limits by default: exceeding a plan quota returns HTTP `429` with a `Retry-After` header and `X-RateLimit-*` headers on API responses. Usage above the quota is rejected — never silently charged; if opt-in metered overage is introduced for API plans it will be documented here first.
+- Per-endpoint request budgets are documented at https://www.worldmonitor.app/docs/usage-rate-limits (also fetchable as markdown at https://www.worldmonitor.app/docs/usage-rate-limits.md).
+- Need a higher limit? Upgrade at https://worldmonitor.app/pro or contact enterprise@worldmonitor.app for custom quotas.
 
 ## Machine-Readable Summary
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,6 +14,7 @@ Allow: /
 Allow: /api/story
 Allow: /api/og-story
 Allow: /api/llms.txt
+Allow: /api/product-catalog
 Disallow: /api/
 Disallow: /tests/
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -20,7 +20,13 @@
   </url>
   <url>
     <loc>https://www.worldmonitor.app/pricing.md</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.worldmonitor.app/support.md</loc>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/public/support.md
+++ b/public/support.md
@@ -1,0 +1,44 @@
+# Support & Contact - World Monitor
+
+Last updated: July 5, 2026
+
+How to reach World Monitor, by concern. Human-readable version: https://www.worldmonitor.app/docs/support
+
+## Channels
+
+| Concern | Channel | Notes |
+| --- | --- | --- |
+| General support, account or billing issues | support@worldmonitor.app | Primary support channel for all plans |
+| Enterprise, sales, custom quotas | enterprise@worldmonitor.app | Custom pricing, deployments, higher API limits |
+| Bug reports & feature requests | https://github.com/koala73/worldmonitor/issues | Public open-source repository |
+| Community & quick questions | https://discord.gg/re63kWKxaz | Community Discord |
+| Service status & incidents | https://status.worldmonitor.app | Email subscription available on the page |
+| In-app contact form | Form on https://worldmonitor.app/pro | Submits `POST /api/leads/v1/submit-contact`; Turnstile-protected, intended for humans in a browser — agents should email support@ instead |
+
+## Response Expectations
+
+- Free and Pro: best-effort support via email, GitHub and Discord. No formal SLA.
+- API: best-effort support via email; include your key prefix (never the full key) and request IDs.
+- Enterprise: dedicated support with committed response times, agreed per contract — contact enterprise@worldmonitor.app.
+
+## Common Self-Serve Answers
+
+- API key rotation or limit increases: see https://www.worldmonitor.app/docs/usage-auth and https://www.worldmonitor.app/docs/usage-rate-limits, or email support@worldmonitor.app.
+- Pricing and plans: https://worldmonitor.app/pricing.md (markdown) or `GET https://www.worldmonitor.app/api/product-catalog` (JSON, public).
+- Billing portal (invoices, cancel/renew): sign in at https://worldmonitor.app/pro and open the customer portal.
+- Security reports: see https://www.worldmonitor.app/.well-known/security.txt
+
+## Machine-Readable Summary
+
+```json
+{
+  "product": "World Monitor",
+  "support_email": "support@worldmonitor.app",
+  "enterprise_email": "enterprise@worldmonitor.app",
+  "issues_url": "https://github.com/koala73/worldmonitor/issues",
+  "community_url": "https://discord.gg/re63kWKxaz",
+  "status_url": "https://status.worldmonitor.app",
+  "security_txt": "https://www.worldmonitor.app/.well-known/security.txt",
+  "sla": { "free": "best-effort", "pro": "best-effort", "api": "best-effort", "enterprise": "contracted" }
+}
+```

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1165,16 +1165,56 @@ describe('agent readiness: api-catalog + openapi build', () => {
     assert.ok(apiEntry, 'linkset must contain a context object anchored at https://api.worldmonitor.app/');
   });
 
-  it('status href points at /api/health (SPA lives at /health — would 200 HTML and look healthy)', () => {
+  it('status href points at the KEYLESS compact form of /api/health', () => {
+    // Two drift classes guarded here:
+    //   (1) the SPA lives at /health — a bare-host href would 200 HTML and
+    //       look healthy;
+    //   (2) #4715 gated detailed /api/health behind an operator key, so the
+    //       bare endpoint 401s keyless callers. An advertised status URL must
+    //       return 2xx WITHOUT credentials — that is ?compact=1 (#4856; an
+    //       agent-journey run read the stale bare-URL advertisement, got 401,
+    //       and flagged the whole status surface as broken).
     const statusHref = apiEntry.status[0].href;
     assert.ok(
       statusHref.startsWith('https://api.worldmonitor.app'),
       `status href must be on api.worldmonitor.app, got: ${statusHref}`
     );
-    assert.ok(
-      statusHref.endsWith('/api/health'),
-      `status href must end with /api/health (real JSON endpoint), got: ${statusHref}`
+    assert.equal(
+      statusHref,
+      'https://api.worldmonitor.app/api/health?compact=1',
+      'status href must be the keyless compact health form'
     );
+  });
+
+  it('every vercel.json Link rel="status" advertisement uses the keyless compact form', () => {
+    // Same #4715→#4856 drift class as above, for the Link-header copies: an
+    // auth-gating change on /api/health must not silently strand the
+    // machine-readable status advertisements on a URL that 401s keyless.
+    const vercelRaw = readFileSync(resolve(__dirname, '../vercel.json'), 'utf-8');
+    const statusLinks = vercelRaw.match(/<[^>]*>;\s*rel=\\"status\\"/g) ?? [];
+    assert.ok(statusLinks.length > 0, 'expected at least one Link rel="status" advertisement in vercel.json');
+    for (const link of statusLinks) {
+      assert.ok(
+        link.startsWith('</api/health?compact=1>'),
+        `Link rel="status" must point at /api/health?compact=1 (keyless), got: ${link}`
+      );
+    }
+  });
+
+  it('service-meta advertises the machine-readable pricing + support surfaces', () => {
+    // Pricing/support were previously discoverable ONLY via llms.txt; agents
+    // entering through the Link-header → api-catalog chain never saw them and
+    // fell back to slug-guessing (#4854, #4857). RFC 9727 allows arbitrary
+    // link relations on a context object; service-meta is the metadata slot.
+    const meta = apiEntry['service-meta'];
+    assert.ok(Array.isArray(meta) && meta.length > 0, 'api context must carry service-meta entries');
+    const hrefs = meta.map((entry) => entry.href);
+    assert.ok(hrefs.includes('https://worldmonitor.app/pricing.md'), 'service-meta must advertise pricing.md');
+    assert.ok(
+      hrefs.includes('https://www.worldmonitor.app/api/product-catalog'),
+      'service-meta must advertise the live product-catalog JSON endpoint'
+    );
+    assert.ok(hrefs.includes('https://worldmonitor.app/support.md'), 'service-meta must advertise support.md');
   });
 
   it('service-desc points at /openapi.yaml with the OpenAPI media type', () => {

--- a/tests/health-redis-down-status.test.mjs
+++ b/tests/health-redis-down-status.test.mjs
@@ -31,6 +31,22 @@ test('detailed health requires an operator API key before Redis is queried', asy
   assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
 });
 
+test('the 401 carries WWW-Authenticate and points keyless callers at the public compact form', async () => {
+  // RFC 7235 §3.1 makes WWW-Authenticate mandatory on 401; resource_metadata
+  // (RFC 9728) is the agent-discovery pointer. The hint matters because the
+  // bare /api/health URL circulated as the advertised status endpoint before
+  // #4856 repointed the api-catalog/Link headers at ?compact=1 — stale
+  // consumers landing here must learn the public form instead of dead-ending.
+  const req = new Request('https://api.worldmonitor.app/api/health');
+  const res = await handler(req);
+  assert.equal(res.status, 401);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge, '401 must carry a WWW-Authenticate challenge (RFC 7235 §3.1)');
+  assert.match(challenge, /resource_metadata="https:\/\/www\.worldmonitor\.app\/\.well-known\/oauth-protected-resource"/);
+  const body = await res.json();
+  assert.match(body.hint, /\/api\/health\?compact=1/);
+});
+
 test('health history requires an operator API key before Redis is queried', async () => {
   const req = new Request('https://api.worldmonitor.app/api/health?history=1');
   const res = await handler(req);

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -164,6 +164,7 @@ describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypas
     '/api/seed-contract-probe',
     '/api/internal/brief-why-matters',
     '/api/llms.txt',
+    '/api/product-catalog',
   ];
 
   for (const path of ALLOWED_PATHS) {
@@ -223,6 +224,35 @@ describe('middleware /api/llms.txt — AI crawlers reach the agent-discovery fil
 
   it('still 403s a crawler on a sibling /api path (bypass is exact, not a prefix)', () => {
     const res = call('/api/llms', 'CCBot/2.0 (https://commoncrawl.org/faq/)');
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+});
+
+// ── /api/product-catalog public-pricing bypass ──────────────────────────────
+// The keyless read-only pricing catalog is advertised as service-meta in
+// /.well-known/api-catalog; agents evaluating the product are its primary
+// audience. An agent-journey run (#4854) hit the UA gate here and concluded
+// the endpoint did not exist. DELETE (cache purge) stays protected by the
+// endpoint's own auth — the middleware bypass only skips UA filtering.
+
+describe('middleware /api/product-catalog — agents reach the public pricing catalog', () => {
+  const CRAWLER_UAS = [
+    { label: 'ClaudeBot', ua: 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)' },
+    { label: 'GPTBot', ua: 'Mozilla/5.0 (compatible; GPTBot/1.1; +https://openai.com/gptbot)' },
+    { label: 'python-requests', ua: 'python-requests/2.31' },
+    { label: 'empty UA', ua: '' },
+  ];
+
+  for (const { label, ua } of CRAWLER_UAS) {
+    it(`passes ${label} through to /api/product-catalog`, () => {
+      const res = call('/api/product-catalog', ua);
+      assert.equal(res, undefined, '/api/product-catalog must pass through the bot gate; it is a public discovery surface');
+    });
+  }
+
+  it('still 403s a crawler on a sibling /api path (bypass is exact, not a prefix)', () => {
+    const res = call('/api/product', 'CCBot/2.0 (https://commoncrawl.org/faq/)');
     assert.ok(res instanceof Response);
     assert.equal(res.status, 403);
   });

--- a/tests/pricing-docs-drift.test.mjs
+++ b/tests/pricing-docs-drift.test.mjs
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Agent-facing pricing surfaces must not drift from the source of truth,
+// convex/config/productCatalog.ts (#4854). The /pro page has its own
+// freshness gate; these two files are hand-maintained markdown/MDX with no
+// generator, so this guard extracts prices from the catalog SOURCE TEXT
+// (no import — convex modules don't load under tsx --test) and asserts each
+// USD figure appears in the docs. If a price change lands in the catalog,
+// this test names every doc that still shows the old number.
+//
+// Run: node --test tests/pricing-docs-drift.test.mjs
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(resolve(__dirname, '..', p), 'utf-8');
+
+const catalogSrc = read('convex/config/productCatalog.ts');
+
+// Pull { planKey → priceCents } for the publicly-priced subscription plans.
+const PLAN_KEYS = ['pro_monthly', 'pro_annual', 'api_starter'];
+const priceCentsFor = (planKey) => {
+  // Anchor on the object key, then take the first priceCents after it.
+  const blockStart = catalogSrc.indexOf(`${planKey}: {`);
+  assert.notEqual(blockStart, -1, `productCatalog.ts must contain a "${planKey}" entry`);
+  const m = catalogSrc.slice(blockStart).match(/priceCents:\s*(\d+)/);
+  assert.ok(m, `no priceCents found for ${planKey}`);
+  return Number(m[1]);
+};
+
+const usd = (cents) =>
+  (cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).replace(/,/g, '');
+
+const DOCS = ['public/pricing.md', 'docs/pricing.mdx'];
+
+for (const doc of DOCS) {
+  const content = read(doc);
+  for (const planKey of PLAN_KEYS) {
+    const cents = priceCentsFor(planKey);
+    const dollars = `$${usd(cents)}`;
+    test(`${doc} carries the current ${planKey} price (${dollars})`, () => {
+      assert.ok(
+        content.includes(dollars),
+        `${doc} must contain ${dollars} for ${planKey} — productCatalog.ts changed and this doc did not`
+      );
+    });
+  }
+}
+
+// The Dodo product IDs are surfaced by GET /api/product-catalog, and
+// docs/openapi/CommerceService.openapi.yaml embeds two of them as examples.
+// Guard those too — a rotated product ID in the catalog must not leave the
+// published OpenAPI example pointing at a dead product.
+test('CommerceService.openapi.yaml example product IDs exist in productCatalog.ts', () => {
+  const spec = read('docs/openapi/CommerceService.openapi.yaml');
+  const exampleIds = [...spec.matchAll(/pdt_[A-Za-z0-9]+/g)].map((m) => m[0]);
+  assert.ok(exampleIds.length > 0, 'spec example must include at least one Dodo product ID');
+  for (const id of exampleIds) {
+    assert.ok(
+      catalogSrc.includes(`"${id}"`),
+      `spec example product ID ${id} is not present in productCatalog.ts`
+    );
+  }
+});

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,11 @@
     { "source": "/docs", "destination": "/docs/documentation", "permanent": false },
     { "source": "/security.txt", "destination": "/.well-known/security.txt", "permanent": true },
     { "source": "/index.html", "destination": "/", "permanent": true },
-    { "source": "/welcome", "destination": "/", "permanent": true }
+    { "source": "/welcome", "destination": "/", "permanent": true },
+    { "source": "/blog/posts", "destination": "/blog", "permanent": true },
+    { "source": "/contact", "destination": "/docs/support", "permanent": false },
+    { "source": "/support", "destination": "/docs/support", "permanent": false },
+    { "source": "/help", "destination": "/docs/support", "permanent": false }
   ],
   "rewrites": [
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },
@@ -176,14 +180,14 @@
       "source": "/",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" },
-        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
+        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
       ]
     },
     {
       "source": "/dashboard.html",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" },
-        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
+        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
       ]
     },
     {
@@ -238,7 +242,7 @@
       "source": "/dashboard",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" },
-        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
+        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.json>; rel=\"service-desc\"; type=\"application/json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health?compact=1>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
       ]
     },
     {


### PR DESCRIPTION
## What

One coordinated batch closing all four agent-journey readiness issues — they share `llms.txt` (×3), `vercel.json` (×3), and the well-known files (×2), so separate PRs would conflict on every shared surface.

Closes #4850 · Closes #4854 · Closes #4856 · Closes #4857

## Why

Five external agent-journey runs (Claude Code · Sonnet 4.6) probed the site with real intents. The split was exact:

| Intent | Steps / tokens | Outcome |
|---|---|---|
| Integration | 16 / 83k | clean — discovery chain self-bootstrapping |
| Developer auth | 28 / 258k | one bug (#4856) |
| Signup | 25 / 212k | #4850 |
| Pricing | 44 / 848k | #4854 |
| Support | 37 / 851k | #4857 |

Intents answerable via the Link-header → `.well-known` → `auth.md`/OpenAPI chain cost ~5–10× less. Pricing/signup/support lived only in `llms.txt` (or nowhere) — agents on the well-known chain guessed slugs, hit UA-403s, and parsed misleading-200 SPA shells.

## Changes by issue

**#4850 — signup**
- UA policy documented in `llms.txt`, `llms-full.txt`, `auth.md`: descriptive User-Agent required; the edge WAF challenges `curl/*`/`python-requests/*`/short UAs and *masks 404s as 403s* for them.
- `docs/accounts.mdx`: free tier needs no account; Clerk modal flow (not fetchable — agents are told so); MCP OAuth path for agent credentials.
- `/blog/posts` → `/blog` 301 (posts live at `/blog/posts/<slug>/`; the parent had no index).

**#4854 — pricing**
- `.well-known/api-catalog`: RFC 9727 `service-meta` on the API context advertising `pricing.md`, the live `GET /api/product-catalog` JSON, and `support.md`.
- `middleware.ts`: `/api/product-catalog` added to `PUBLIC_API_PATHS` (was UA-403'd for the exact agents it exists to serve) + `robots.txt` Allow carve-out, mirroring the `/api/llms.txt` precedent. DELETE stays behind the endpoint's own auth — the bypass only skips UA filtering.
- `docs/pricing.mdx` + `tests/pricing-docs-drift.test.mjs`: prices asserted against `convex/config/productCatalog.ts` source text (no generator import), so a catalog price change names every stale doc.
- `docs/openapi/CommerceService.openapi.yaml` wired into the api-reference nav. Deliberately **outside `docs/api/`** (fully generated dir — proto-check regen diff + injector scripts) and **outside the root spec** (#4853 ~1MB size budget).
- `docs.json` redirects for every slug the journey agent guessed: `plans`/`tiers`→`pricing`, `rate-limit(s)`→`usage-rate-limits`, `mcp-api-key`→`usage-auth`.
- `pricing.md`: Limits & Overage section (hard 429 + `Retry-After`, no silent overage billing — worded to survive #4791), JSON catalog pointer, UA note.

**#4856 — status advertisement (stale since #4715)**
- api-catalog `status` href + 3× `vercel.json` `Link rel="status"` → `/api/health?compact=1` (keyless 200; the bare form 401s since #4715).
- `/api/health` 401 now carries `WWW-Authenticate` with RFC 9728 `resource_metadata` (RFC 7235 §3.1 — it was absent entirely) + a body hint naming the compact form.
- New deploy-config guards: every advertised status URL must be the keyless compact form; the next auth-gating change can't silently strand the advertisements.

**#4857 — support**
- `public/support.md` (root, sitemap-listed) + `docs/support.mdx`: all channels consolidated (support@ / enterprise@, GitHub issues, Discord, status page; Turnstile form marked human-only) + explicit per-tier no-SLA statement.
- `/contact`, `/support`, `/help` 301 → `/docs/support` (all three served the misleading-200 dashboard SPA shell).
- `server-card.json` documentation block: `support` repointed (was getting-started), `pricing` + `productCatalog` added.

## Out of scope (deliberate)

- The Cloudflare-side WAF UA rule — dashboard config, not repo; the docs now teach the workaround and the one public endpoint agents need is middleware-allowlisted.
- Root `openapi.yaml` `info.description` pricing link — the bundle is sebuf-generated and size-budgeted (#4853); api-catalog `service-meta` carries the same pointer instead.

## Verification

- `tests/middleware-bot-gate.test.mts` 53 pass (new product-catalog bypass block + exact-path negative)
- `tests/deploy-config.test.mjs` 107 pass (status-compact + Link-header + service-meta guards)
- `tests/health-redis-down-status.test.mjs` 8 pass (WWW-Authenticate + hint contract)
- `tests/pricing-docs-drift.test.mjs` 7 pass (new)
- llms/agent-mode/a2a/mcp-parity + product-catalog suites: 64 pass
- `docs:check` green, `tsc --noEmit` green, all edited JSON/YAML parse

https://claude.ai/code/session_01N3xTXNUrCiy1xqy3VbkMRx
