### PR TITLE
fix(seo): correct datePublished — launched January 2026, not October 2024

### DIFF
--- a/pro-test/index.html
+++ b/pro-test/index.html
@@ -69,7 +69,7 @@
         "sameAs": ["https://x.com/eliehabib", "https://github.com/koala73", "https://www.linkedin.com/in/elie-habib-7047b931", "https://www.wikidata.org/wiki/Q121365724", "https://www.crunchbase.com/person/elie-habib-2"]
       },
       "screenshot": "https://www.worldmonitor.app/favico/og-image.png",
-      "datePublished": "2024-10-01",
+      "datePublished": "2026-01",
       "offers": [
         { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Free", "description": "Full dashboard with 500+ news feeds, 65+ external data sources, 50+ map layers, BYOK AI" },
         { "@type": "Offer", "price": "39.99", "priceCurrency": "USD", "name": "Pro Monthly", "description": "WM Analyst chat, AI digest (daily/twice-daily/weekly), custom widget builder, MCP connectors, equity research, macro analytics, flight search — 30+ services under one key" },

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -176,7 +176,7 @@
         "sameAs": ["https://x.com/eliehabib", "https://github.com/koala73", "https://www.linkedin.com/in/elie-habib-7047b931", "https://www.wikidata.org/wiki/Q121365724", "https://www.crunchbase.com/person/elie-habib-2"]
       },
       "screenshot": "https://www.worldmonitor.app/favico/og-image.png",
-      "datePublished": "2024-10-01",
+      "datePublished": "2026-01",
       "offers": [
         { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Free", "description": "Full dashboard with 500+ news feeds, 65+ external data sources, 56 map layers, six monitor variants, BYOK AI — no signup required" },
         { "@type": "Offer", "price": "39.99", "priceCurrency": "USD", "name": "Pro Monthly", "description": "WM Analyst chat, Scenario Engine, Route Explorer, AI digest (daily/twice-daily/weekly), custom widget builder, MCP connectors, equity research, macro analytics — 30+ services under one key" },

--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -69,7 +69,7 @@
         "sameAs": ["https://x.com/eliehabib", "https://github.com/koala73", "https://www.linkedin.com/in/elie-habib-7047b931", "https://www.wikidata.org/wiki/Q121365724", "https://www.crunchbase.com/person/elie-habib-2"]
       },
       "screenshot": "https://www.worldmonitor.app/favico/og-image.png",
-      "datePublished": "2024-10-01",
+      "datePublished": "2026-01",
       "offers": [
         { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Free", "description": "Full dashboard with 500+ news feeds, 65+ external data sources, 50+ map layers, BYOK AI" },
         { "@type": "Offer", "price": "39.99", "priceCurrency": "USD", "name": "Pro Monthly", "description": "WM Analyst chat, AI digest (daily/twice-daily/weekly), custom widget builder, MCP connectors, equity research, macro analytics, flight search — 30+ services under one key" },

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -176,7 +176,7 @@
         "sameAs": ["https://x.com/eliehabib", "https://github.com/koala73", "https://www.linkedin.com/in/elie-habib-7047b931", "https://www.wikidata.org/wiki/Q121365724", "https://www.crunchbase.com/person/elie-habib-2"]
       },
       "screenshot": "https://www.worldmonitor.app/favico/og-image.png",
-      "datePublished": "2024-10-01",
+      "datePublished": "2026-01",
       "offers": [
         { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Free", "description": "Full dashboard with 500+ news feeds, 65+ external data sources, 56 map layers, six monitor variants, BYOK AI — no signup required" },
         { "@type": "Offer", "price": "39.99", "priceCurrency": "USD", "name": "Pro Monthly", "description": "WM Analyst chat, Scenario Engine, Route Explorer, AI digest (daily/twice-daily/weekly), custom widget builder, MCP connectors, equity research, macro analytics — 30+ services under one key" },


### PR DESCRIPTION
The homepage + /pro `SoftwareApplication` JSON-LD claimed `datePublished: 2024-10-01` — wrong. Ground truth: World Monitor launched **January 2026** (repo created 2026-01-08; owner-confirmed). Corrected to `2026-01` (month precision — what we can evidence). Matters now because the new Wikidata item (Q140439514) carries inception 2026 and knowledge graphs cross-check exactly this pair; disagreeing launch dates undermine both. Pro bundle rebuilt; diff is the one line in both sources + built outputs.

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry