### PR TITLE
fix(classify): stop free/anon users flooding the premium-gated classify-event endpoint (#4865)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 160
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 160 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (194 service modules and domain directories)
+│   ├── services/           # Business logic (195 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 160,
-  "serviceTopLevelEntries": 194,
+  "serviceTopLevelEntries": 195,
   "apiEndpointEntries": 86,
   "panelClasses": 104,
   "protoFiles": 278,

--- a/src/services/classify-gate.ts
+++ b/src/services/classify-gate.ts
@@ -1,0 +1,66 @@
+/**
+ * Session gate for AI event classification (#4865).
+ *
+ * classify-event was premium-gated server-side (#4779) but the client kept
+ * enqueueing a classification RPC for every incoming headline regardless of
+ * entitlement: signed-in free users generated ~95k tier_403s/day (the batch
+ * loop had no 403 handling at all) and anonymous users ~475k 401s/day (the
+ * 120s-pause loop retried forever as new headlines refilled the queue).
+ *
+ * Two mechanisms, both consulted by threat-classifier before any network
+ * attempt; a denial resolves to the keyword-classification fallback:
+ *
+ *   1. Entitlement probe — injected by threat-classifier (wired to
+ *      panel-gating's `hasPremiumAccess`, the dual-signal source of truth).
+ *      Kills the flood at the source for anon/free principals: zero requests.
+ *      Fails OPEN when the probe throws or is unconfigured — the server still
+ *      gates, and a client-side gating bug must never silence classification
+ *      for paying users.
+ *
+ *   2. Timed suppression — set by the batch loop on a server 403. Covers
+ *      entitlement-signal drift (probe says entitled, server disagrees):
+ *      without it, drift recreates the flood at headline-arrival rate. A
+ *      timed window rather than a session-permanent kill so a mid-session
+ *      upgrade self-heals on the next enqueue after the window — no
+ *      auth-event plumbing, worst case one probe request per window.
+ *
+ * Pure module (zero imports) so it is loadable under `tsx --test` —
+ * threat-classifier itself imports @/utils and cannot be, hence the wiring
+ * is covered by source-grep assertions (tests/classify-entitlement-gate).
+ */
+
+export const CLASSIFY_SUPPRESS_MS = 15 * 60 * 1000;
+
+type EntitlementProbe = () => boolean;
+
+let entitlementProbe: EntitlementProbe | null = null;
+let suppressedUntil = 0;
+
+/** Inject the entitlement signal. Called once at threat-classifier init. */
+export function configureClassifyGate(probe: EntitlementProbe): void {
+  entitlementProbe = probe;
+}
+
+/**
+ * Whether an AI-classification attempt may be enqueued right now.
+ * Suppression wins over the probe; an unconfigured/throwing probe allows.
+ */
+export function canAttemptAiClassification(now: number = Date.now()): boolean {
+  if (now < suppressedUntil) return false;
+  if (!entitlementProbe) return true;
+  try {
+    return entitlementProbe();
+  } catch {
+    return true;
+  }
+}
+
+/** Suppress all attempts for CLASSIFY_SUPPRESS_MS (called on a server 403). */
+export function suppressAiClassification(now: number = Date.now()): void {
+  suppressedUntil = now + CLASSIFY_SUPPRESS_MS;
+}
+
+export function __resetClassifyGateForTests(): void {
+  entitlementProbe = null;
+  suppressedUntil = 0;
+}

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -377,8 +377,22 @@ export function classifyByKeyword(title: string, variant = 'full'): ThreatClassi
 import type { ClassifyEventResponse } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
 import { IntelligenceServiceClient } from '@/services/generated-rpc-clients';
+import {
+  canAttemptAiClassification,
+  configureClassifyGate,
+  suppressAiClassification,
+} from '@/services/classify-gate';
+import { hasPremiumAccess } from '@/services/panel-gating';
 
 const classifyClient = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
+
+// #4865: classify-event is premium-gated server-side (#4779). Gate every
+// enqueue on the client-side entitlement signal so anon/free principals fall
+// back to keyword classification with ZERO network attempts — before this
+// gate, every incoming headline fired an RPC that 401/403'd (~570k wasted
+// requests/day). panel-gating's hasPremiumAccess is the dual-signal source
+// of truth (API key, tester keys, Clerk role, Convex entitlement).
+configureClassifyGate(() => hasPremiumAccess());
 
 const classifyBreaker = createCircuitBreaker<ThreatClassification | null>({
   name: 'AIClassify',
@@ -463,6 +477,21 @@ function flushBatch(): void {
           job.resolve(toThreat(resp));
         } catch (err) {
           const statusCode = getRpcErrorStatusCode(err);
+          if (statusCode === 403) {
+            // #4865: a 403 is a deterministic entitlement rejection for this
+            // principal — retrying per headline recreated the flood (the
+            // pre-fix loop resolved null and kept firing at full cadence).
+            // Suppress ALL attempts for the gate window, drain everything to
+            // the keyword fallback, and let the gate re-probe after the
+            // window (self-heals a mid-session upgrade).
+            suppressAiClassification();
+            console.warn('[Classify] 403 (subscription required) — AI classification suppressed, falling back to keyword classification');
+            job.resolve(null);
+            for (const rest of batch.slice(i + 1)) rest.resolve(null);
+            for (const queued of batchQueue.splice(0)) queued.resolve(null);
+            batchInFlight = false;
+            return;
+          }
           if (statusCode === 401 || statusCode === 429 || (statusCode !== undefined && statusCode >= 500)) {
             batchPaused = true;
             let delay: number;
@@ -521,6 +550,13 @@ function classifyWithAIUncached(
   variant: string
 ): Promise<ThreatClassification | null> {
   return new Promise((resolve) => {
+    // #4865: entitlement gate — anon/free principals (and any principal
+    // inside the post-403 suppression window) resolve straight to null so
+    // callers keep their keyword classification. No request is made.
+    if (!canAttemptAiClassification()) {
+      resolve(null);
+      return;
+    }
     if (batchQueue.length >= MAX_QUEUE_LENGTH) {
       console.warn(`[Classify] Queue full (${MAX_QUEUE_LENGTH}), dropping classification for: ${title.slice(0, 60)}`);
       resolve(null);

--- a/tests/classify-entitlement-gate.test.mts
+++ b/tests/classify-entitlement-gate.test.mts
@@ -1,0 +1,116 @@
+/**
+ * #4865 — free/anon users flooded the premium-gated classify-event endpoint
+ * (~95k tier_403/day from signed-in free users with NO 403 backoff, plus
+ * ~475k/day anon 401s from the retry loop) after #4779 premium-gated it
+ * server-side without a client-side entitlement gate.
+ *
+ * Two layers under test:
+ *   1. src/services/classify-gate.ts — pure session gate (probe + timed
+ *      suppression), node-test-safe (threat-classifier itself imports
+ *      @/utils and cannot be loaded under tsx --test).
+ *   2. Source-grep wiring assertions on threat-classifier.ts — the gate is
+ *      only effective if the enqueue path consults it and the 403 branch
+ *      suppresses + drains (the project's source-grep regression pattern).
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  canAttemptAiClassification,
+  configureClassifyGate,
+  suppressAiClassification,
+  CLASSIFY_SUPPRESS_MS,
+  __resetClassifyGateForTests,
+} from '../src/services/classify-gate.ts';
+
+describe('classify-gate — entitlement probe + timed suppression', () => {
+  beforeEach(() => {
+    __resetClassifyGateForTests();
+  });
+
+  it('allows by default when no probe is configured (fail-open; server still gates)', () => {
+    assert.equal(canAttemptAiClassification(), true);
+  });
+
+  it('denies when the probe reports not entitled', () => {
+    configureClassifyGate(() => false);
+    assert.equal(canAttemptAiClassification(), false);
+  });
+
+  it('allows when the probe reports entitled', () => {
+    configureClassifyGate(() => true);
+    assert.equal(canAttemptAiClassification(), true);
+  });
+
+  it('fails OPEN when the probe throws — a gating bug must not silence Pro classification', () => {
+    configureClassifyGate(() => { throw new Error('gating module exploded'); });
+    assert.equal(canAttemptAiClassification(), true);
+  });
+
+  it('suppression denies even an entitled probe for the full window', () => {
+    configureClassifyGate(() => true);
+    const t0 = 1_000_000;
+    suppressAiClassification(t0);
+    assert.equal(canAttemptAiClassification(t0), false);
+    assert.equal(canAttemptAiClassification(t0 + CLASSIFY_SUPPRESS_MS - 1), false);
+  });
+
+  it('suppression expires after the window — self-heals a mid-session upgrade without event plumbing', () => {
+    configureClassifyGate(() => true);
+    const t0 = 1_000_000;
+    suppressAiClassification(t0);
+    assert.equal(canAttemptAiClassification(t0 + CLASSIFY_SUPPRESS_MS), true);
+  });
+
+  it('post-suppression attempts still consult the probe (free user stays denied)', () => {
+    configureClassifyGate(() => false);
+    const t0 = 1_000_000;
+    suppressAiClassification(t0);
+    assert.equal(canAttemptAiClassification(t0 + CLASSIFY_SUPPRESS_MS), false);
+  });
+
+  it('suppression window is long enough to matter (>= 5 minutes)', () => {
+    // The flood ran at ~1 request per ~2s per user; the suppression window is
+    // the worst-case retry cadence under persistent signal drift. Guard the
+    // constant so a refactor can't quietly turn it back into a hot loop.
+    assert.ok(CLASSIFY_SUPPRESS_MS >= 5 * 60_000, `window too short: ${CLASSIFY_SUPPRESS_MS}`);
+  });
+});
+
+describe('threat-classifier wiring (source-grep — module not loadable under node:test)', () => {
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(
+    path.join(dirname, '..', 'src', 'services', 'threat-classifier.ts'),
+    'utf8',
+  );
+
+  it('enqueue path consults canAttemptAiClassification() before queueing', () => {
+    const uncached = src.slice(src.indexOf('function classifyWithAIUncached'));
+    const gateIdx = uncached.indexOf('canAttemptAiClassification()');
+    const pushIdx = uncached.indexOf('batchQueue.push');
+    assert.ok(gateIdx > -1, 'classifyWithAIUncached must call canAttemptAiClassification()');
+    assert.ok(pushIdx > -1, 'expected batchQueue.push in classifyWithAIUncached');
+    assert.ok(gateIdx < pushIdx, 'the gate must run BEFORE the job is queued');
+  });
+
+  it('batch loop handles 403 by suppressing + draining (never retrying)', () => {
+    assert.match(src, /statusCode === 403/, 'must branch on 403 explicitly');
+    const branch = src.slice(src.indexOf('statusCode === 403'));
+    assert.ok(
+      branch.indexOf('suppressAiClassification()') > -1 &&
+        branch.indexOf('suppressAiClassification()') < branch.indexOf('statusCode === 401'),
+      '403 branch must call suppressAiClassification()',
+    );
+    assert.ok(
+      branch.indexOf('batchQueue.splice(0)') > -1 &&
+        branch.indexOf('batchQueue.splice(0)') < branch.indexOf('statusCode === 401'),
+      '403 branch must drain the entire queue (resolve nulls → keyword fallback)',
+    );
+  });
+
+  it('gate probe is wired to hasPremiumAccess (dual-signal entitlement)', () => {
+    assert.match(src, /configureClassifyGate\(\s*\(\)\s*=>\s*hasPremiumAccess\(\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4865. After #4779 premium-gated `/api/intelligence/v1/classify-event` server-side, the client kept enqueueing a classification RPC for **every incoming headline** regardless of entitlement:

| cohort | status | volume (Jul 5, Axiom) | mechanism |
|---|---|---|---|
| signed-in free (331 users) | 403 | 95,645/day | batch loop had NO 403 handling — resolved null, kept firing at full cadence |
| anonymous (801 IPs) | 401 | 474,741/day | 120s-pause loop retried forever as new headlines refilled the queue |

~570k wasted edge requests/day, and free/anon event classification silently failing where it used to be served (pre-gate baseline: ~130k anon 200s/day of LLM spend — the server gate is deliberate cost protection; the client never learned to stop asking).

## Fix — two layers, both landing on the existing keyword-classification fallback

1. **Enqueue gate** (`src/services/classify-gate.ts`, new pure module): `classifyWithAIUncached` consults an entitlement probe wired to panel-gating's `hasPremiumAccess` (the dual-signal source of truth). Anon/free principals resolve straight to null — **zero requests**. Fails OPEN if the probe throws: the server still gates, and a client-side gating bug must never silence classification for paying users.
2. **403 branch in the batch loop**: a 403 is a deterministic entitlement rejection — suppress all AI-classification attempts for 15 minutes, drain the in-flight batch + entire queue to nulls, never retry the job. This covers entitlement-signal drift (probe says entitled, server disagrees), which would otherwise recreate the flood at headline-arrival rate. The timed window self-heals a mid-session upgrade with a worst case of one probe request per 15 minutes — no auth-event plumbing.

The gate is a zero-import module because `threat-classifier` imports `@/utils` and cannot load under `tsx --test`; the wiring is pinned by source-grep assertions (existing project pattern).

## UX for free/anon users

Unchanged from the post-#4779 server reality: they get keyword classification (`classifyByKeyword`), which is what the null-resolution fallback already produced — minus the half-million failing requests.

## Tests

`tests/classify-entitlement-gate.test.mts` — 11 cases, written failing-first: probe allow/deny/throw-fail-open, suppression window entry/expiry/probe-recheck, window-length guard, and three source-grep wiring assertions (gate before `batchQueue.push`, 403 → suppress + full drain, probe wired to `hasPremiumAccess`). Adjacent suites green (`ai-classify-queue`, news-classifier ×3 — 86 tests); full `typecheck` + biome clean; docs stats regenerated for the new service module.

## Post-deploy verification

Axiom: free-user 403s and anon 401s on `/api/intelligence/v1/classify-event` should collapse to ~0 within an hour of the frontend deploy reaching clients (stale tabs decay as sessions reload).

https://claude.ai/code/session_01Ex9zkdxdbxYMogHmEK2YXZ
