### PR TITLE
feat(mcp): emit wm_api_usage request events from /mcp — auth rejections + raw 500s become visible (#4866)

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -59,6 +59,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/usage.ts",
+      "category": "external-protocol",
+      "reason": "MCP wm_api_usage emission (#4866) — phase-to-reason mapper + ctx.waitUntil RequestEvent emitter for the /mcp funnel. Ops/observability plumbing for the same external-protocol handler, not a JSON data API; reuses server/_shared/usage.ts builders.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp/registry/cache-tools.ts",
       "category": "external-protocol",
       "reason": "MCP TOOL_REGISTRY cache-tool entries (no _execute). Extracted from api/mcp.ts during the structural split; same external-protocol constraint as the parent shim.",

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -28,6 +28,7 @@ import {
 import { rpcError, rpcOk, withMcpNoStore } from './rpc';
 import { buildUiResourceRead, isUiResourceUri, UI_RESOURCE_LIST_RESPONSE } from './ui/registry';
 import { emitTelemetry, principalIdForLog } from './telemetry';
+import { createMcpUsage, emitMcpRequestEvent, setUsageContext, type McpUsage } from './usage';
 import type { McpAuthContext, McpHandlerDeps } from './types';
 
 // MCP methods servable WITHOUT authentication. These are the zero-data
@@ -332,18 +333,44 @@ async function serveServerCard(req: Request, corsHeaders: Record<string, string>
 // ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
+// Thin emission wrapper (#4866): one wm_api_usage RequestEvent per servable
+// request, registered on ctx.waitUntil AFTER the response is computed. An
+// uncaught throw from the inner handler (the raw-500 class hardened in #4860)
+// still emits — with status 500 — before re-throwing, so platform 500s are
+// visible in Axiom even though they bypass every structured error path.
 export async function mcpHandler(
   req: Request,
   deps: McpHandlerDeps,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
+  const t0 = Date.now();
+  const usage = createMcpUsage();
+  let res: Response;
+  try {
+    res = await mcpHandlerInner(req, deps, usage, ctx);
+  } catch (err) {
+    emitMcpRequestEvent(req, new Response(null, { status: 500 }), usage, Date.now() - t0, ctx);
+    throw err;
+  }
+  emitMcpRequestEvent(req, res, usage, Date.now() - t0, ctx);
+  return res;
+}
+
+async function mcpHandlerInner(
+  req: Request,
+  deps: McpHandlerDeps,
+  usage: McpUsage,
   ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   // MCP is a public API endpoint secured by API key — allow all origins (claude.ai, Claude Desktop, custom agents)
   const corsHeaders = getMcpCorsHeaders();
 
   if (req.method === 'OPTIONS') {
+    usage.skip = true;
     return new Response(null, { status: 204, headers: withMcpNoStore(corsHeaders) });
   }
   if (req.method === 'HEAD') {
+    usage.skip = true;
     return new Response(null, { status: 200, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) });
   }
 
@@ -357,6 +384,7 @@ export async function mcpHandler(
     !req.headers.get('last-event-id') &&
     !(req.headers.get('accept') ?? '').includes('text/event-stream')
   ) {
+    usage.skip = true;
     return serveServerCard(req, corsHeaders);
   }
 
@@ -368,6 +396,7 @@ export async function mcpHandler(
   // browser-context client AFTER their preflight had already succeeded.
 
   if (req.method !== 'POST' && req.method !== 'GET') {
+    usage.phase = 'transport';
     return new Response(null, { status: 405, headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }) });
   }
 
@@ -392,18 +421,31 @@ export async function mcpHandler(
   //      fully authenticated (never a discovery surface).
   if (req.method === 'GET') {
     if (!req.headers.get('last-event-id')) {
+      usage.phase = 'transport';
       return new Response(null, {
         status: 405,
         headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }),
       });
     }
     const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
-    if (!auth.ok) return auth.response;
+    if (!auth.ok) {
+      usage.phase = 'auth';
+      return auth.response;
+    }
+    setUsageContext(usage, auth.context);
     const getPreCheck = await runContextPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
-    if (getPreCheck) return getPreCheck;
+    if (getPreCheck) {
+      usage.phase = 'precheck';
+      return getPreCheck;
+    }
     const getLimited = await applyPerMinuteLimit(auth.context, corsHeaders);
-    if (getLimited) return getLimited;
-    return handleSseReplay(req, corsHeaders);
+    if (getLimited) {
+      usage.phase = 'limit';
+      return getLimited;
+    }
+    const replay = handleSseReplay(req, corsHeaders);
+    if (replay.status !== 200) usage.phase = 'transport';
+    return replay;
   }
 
   // Parse body BEFORE auth: the method decides whether credentials are required
@@ -414,10 +456,12 @@ export async function mcpHandler(
   try {
     body = await req.json();
   } catch {
+    usage.phase = 'malformed';
     return rpcError(null, -32600, 'Invalid request: malformed JSON', corsHeaders);
   }
 
   if (!body || typeof body.method !== 'string') {
+    usage.phase = 'malformed';
     return rpcError(body?.id ?? null, -32600, 'Invalid request: missing method', corsHeaders);
   }
 
@@ -453,22 +497,42 @@ export async function mcpHandler(
       // present-but-invalid key surfaces a 401 instead of a silent anon
       // downgrade; a valid principal is attributed for telemetry + limits.
       const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
-      if (!auth.ok) return auth.response;
+      if (!auth.ok) {
+        usage.phase = 'auth';
+        return auth.response;
+      }
       context = auth.context;
+      setUsageContext(usage, context);
       const limited = await applyPerMinuteLimit(context, corsHeaders);
-      if (limited) return limited;
+      if (limited) {
+        usage.phase = 'limit';
+        return limited;
+      }
     } else {
       const anonLimited = await applyAnonDiscoveryLimit(req, corsHeaders);
-      if (anonLimited) return anonLimited;
+      if (anonLimited) {
+        usage.phase = 'limit';
+        return anonLimited;
+      }
     }
   } else {
     const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
-    if (!auth.ok) return auth.response;
+    if (!auth.ok) {
+      usage.phase = 'auth';
+      return auth.response;
+    }
     context = auth.context;
+    setUsageContext(usage, context);
     const preCheck = await runContextPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
-    if (preCheck) return preCheck;
+    if (preCheck) {
+      usage.phase = 'precheck';
+      return preCheck;
+    }
     const limited = await applyPerMinuteLimit(context, corsHeaders);
-    if (limited) return limited;
+    if (limited) {
+      usage.phase = 'limit';
+      return limited;
+    }
   }
 
   // Dispatch
@@ -523,11 +587,17 @@ export async function mcpHandler(
       return maybeStreamJsonRpcResponse(req, rpcOk(id, {}, corsHeaders));
     case 'tools/list':
       return maybeStreamJsonRpcResponse(req, rpcOk(id, { tools: TOOL_LIST_RESPONSE }, corsHeaders));
-    case 'tools/call':
+    case 'tools/call': {
       // context is always set here — tools/call is never a PUBLIC_MCP_METHOD.
       // The guard narrows the type and hard-fails closed if that ever changes.
-      if (!context) return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
-      return maybeStreamJsonRpcResponse(req, await dispatchToolsCall(req, context, deps, body, corsHeaders, ctx));
+      if (!context) {
+        usage.phase = 'auth';
+        return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
+      }
+      const dispatched = await dispatchToolsCall(req, context, deps, body, corsHeaders, ctx);
+      if (dispatched.status === 429 || dispatched.status === 503) usage.phase = 'dispatch';
+      return maybeStreamJsonRpcResponse(req, dispatched);
+    }
     // Prompts are metadata-class — they ship a workflow template, not data.
     // Symmetric posture with `describe_tool`: quota-exempt (counting template
     // fetches against the 50/day cap would discourage exploration, which
@@ -584,8 +654,15 @@ export async function mcpHandler(
       // routes through dispatchToolsCall, inheriting the reservation +
       // telemetry path. `context` is always set here — a non-public
       // resources/read runs the gated path above; the guard fails closed.
-      if (!context) return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
-      return maybeStreamJsonRpcResponse(req, await buildResourceResponse(req, context, deps, body, corsHeaders, ctx));
+      if (!context) {
+        usage.phase = 'auth';
+        return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
+      }
+      {
+        const resourceRes = await buildResourceResponse(req, context, deps, body, corsHeaders, ctx);
+        if (resourceRes.status === 429 || resourceRes.status === 503) usage.phase = 'dispatch';
+        return maybeStreamJsonRpcResponse(req, resourceRes);
+      }
     case 'logging/setLevel': {
       const level = (body.params as { level?: string } | null)?.level;
       if (typeof level !== 'string' || !MCP_LOG_LEVELS.has(level)) {

--- a/api/mcp/usage.ts
+++ b/api/mcp/usage.ts
@@ -1,0 +1,152 @@
+// #4866 — wm_api_usage emission for the MCP surface.
+//
+// /mcp rewrites straight to this handler and never passes server/gateway.ts,
+// so before this module the endpoint had ZERO rows in Axiom: auth rejections,
+// quota 429s, and successes were all invisible (the #4859 paying-customer
+// diagnosis had to be reconstructed from REST-side rows). One RequestEvent is
+// emitted per POST / SSE-replay GET via ctx.waitUntil, reusing the gateway's
+// builders so the envelope is byte-compatible with REST rows and joinable on
+// customer_id.
+import {
+  buildRequestEvent,
+  deriveAcceptLanguage,
+  deriveCountry,
+  deriveExecutionRegion,
+  deriveHost,
+  deriveIp,
+  deriveIpCity,
+  deriveIpRegion,
+  deriveReferer,
+  deriveReqBytes,
+  deriveRequestId,
+  deriveSentryTraceId,
+  deriveUserAgent,
+  emitUsageEvents,
+  type RequestReason,
+  type WaitUntilCtx,
+} from '../../server/_shared/usage';
+import type { AuthKind } from '../../server/_shared/usage-identity';
+import type { McpAuthContext } from './types';
+
+// Which stage of the /mcp funnel produced the terminal Response. Set by the
+// handler at each return site; combined with the HTTP status it maps onto the
+// closed RequestReason union without parsing response bodies.
+export type McpPhase =
+  | 'auth'       // credential resolution rejected (invalid key/bearer, backend down)
+  | 'precheck'   // identity ok, entitlement/token pre-check rejected
+  | 'limit'      // per-minute rate limit
+  | 'dispatch'   // tools/call quota (429) / reservation unavailable (503)
+  | 'malformed'  // unparseable JSON-RPC envelope
+  | 'transport'  // method/SSE-transport level (405, replay 4xx)
+  | 'ok';        // served (JSON-RPC-level errors still ride HTTP 200 → ok)
+
+export interface McpUsage {
+  phase: McpPhase;
+  authKind: AuthKind;
+  customerId: string | null;
+  principalId: string | null;
+  /** Set true for surfaces that must not emit (OPTIONS/HEAD, manifest GET). */
+  skip: boolean;
+}
+
+export function createMcpUsage(): McpUsage {
+  return { phase: 'ok', authKind: 'anon', customerId: null, principalId: null, skip: false };
+}
+
+/** Attribute the resolved principal. env_key principals are operator keys —
+ *  never log raw key material; the hashed principal is already covered by the
+ *  gateway's convention of leaving customer_id null for enterprise keys. */
+export function setUsageContext(usage: McpUsage, context: McpAuthContext): void {
+  if (context.kind === 'pro') {
+    usage.authKind = 'mcp_oauth';
+    usage.customerId = context.userId;
+    usage.principalId = context.userId;
+    return;
+  }
+  if (context.kind === 'user_key') {
+    usage.authKind = 'user_api_key';
+    usage.customerId = context.userId;
+    usage.principalId = context.userId;
+    return;
+  }
+  usage.authKind = 'enterprise_api_key';
+}
+
+export function mcpReasonFor(phase: McpPhase, status: number): RequestReason {
+  switch (phase) {
+    case 'auth':
+      return status === 503 ? 'auth_unavailable' : 'auth_401';
+    case 'precheck':
+      return status === 503 ? 'auth_unavailable' : 'tier_403';
+    case 'limit':
+      return 'rate_limit_429';
+    case 'dispatch':
+      if (status === 429) return 'rate_limit_429';
+      if (status === 503) return 'rate_limit_degraded';
+      return 'ok';
+    case 'malformed':
+      return 'malformed_request';
+    case 'transport':
+      return status === 405 ? 'method_not_allowed' : 'malformed_request';
+    default:
+      return 'ok';
+  }
+}
+
+/**
+ * Build + register the request event on ctx.waitUntil. Must NEVER throw or
+ * delay the response — all failure modes are swallowed (emitUsageEvents
+ * already no-ops without USAGE_TELEMETRY/token and circuit-breaks on sink
+ * errors).
+ */
+export function emitMcpRequestEvent(
+  req: Request,
+  res: Response,
+  usage: McpUsage,
+  durationMs: number,
+  ctx?: WaitUntilCtx,
+): void {
+  if (!ctx || usage.skip) return;
+  try {
+    const pathname = (() => {
+      try { return new URL(req.url).pathname; } catch { return '/mcp'; }
+    })();
+    const resBytesRaw = Number(res.headers.get('content-length'));
+    const event = buildRequestEvent({
+      requestId: deriveRequestId(req),
+      domain: 'mcp',
+      route: pathname,
+      method: req.method,
+      status: res.status,
+      durationMs,
+      reqBytes: deriveReqBytes(req),
+      resBytes: Number.isFinite(resBytesRaw) && resBytesRaw >= 0 ? resBytesRaw : 0,
+      customerId: usage.customerId,
+      principalId: usage.principalId,
+      authKind: usage.authKind,
+      // Tier/planKey are not re-resolved here — the pre-checks consume the
+      // entitlement internally and the extra lookup isn't worth a second
+      // Convex round-trip per request. Join on customer_id in Axiom instead.
+      tier: 0,
+      planKey: null,
+      country: deriveCountry(req),
+      ipCity: deriveIpCity(req),
+      ipRegion: deriveIpRegion(req),
+      executionRegion: deriveExecutionRegion(req),
+      executionPlane: 'vercel-edge',
+      originKind: 'mcp',
+      cacheTier: 'no-store',
+      ip: deriveIp(req),
+      userAgent: deriveUserAgent(req),
+      uaHash: null,
+      referer: deriveReferer(req),
+      acceptLanguage: deriveAcceptLanguage(req),
+      host: deriveHost(req),
+      sentryTraceId: deriveSentryTraceId(req),
+      reason: mcpReasonFor(usage.phase, res.status),
+    });
+    emitUsageEvents(ctx, [event]);
+  } catch {
+    // Telemetry must never affect the response path.
+  }
+}

--- a/server/_shared/usage-identity.ts
+++ b/server/_shared/usage-identity.ts
@@ -13,6 +13,10 @@ export type AuthKind =
   | 'user_api_key'
   | 'enterprise_api_key'
   | 'widget_key'
+  // #4866 — MCP OAuth bearer (the `kind: 'pro'` context on /mcp). Distinct
+  // from clerk_jwt so MCP-connector traffic never conflates with dashboard
+  // JWT traffic in Axiom; customer_id carries the same Clerk userId.
+  | 'mcp_oauth'
   | 'anon';
 
 export interface UsageIdentity {

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -90,7 +90,12 @@ export type RequestReason =
   | 'idempotency_invalid'
   | 'idempotent_replay'
   | 'idempotency_conflict'
-  | 'idempotency_mismatch';
+  | 'idempotency_mismatch'
+  // #4866 — auth backend (Convex/Redis) unreachable during credential or
+  // entitlement resolution on /mcp: the caller was told 503 + Retry-After.
+  // Distinct from auth_401 so a backend outage never reads as a wave of
+  // invalid credentials.
+  | 'auth_unavailable';
 
 export interface RequestEvent {
   _time: string;

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -1,0 +1,184 @@
+// #4866 — /mcp emits wm_api_usage RequestEvents so MCP auth rejections,
+// quota hits, and successes are visible in Axiom (they were fully invisible
+// during the #4859 diagnosis: no gateway pass-through, no log drain).
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  BASE_URL,
+  HMAC_SECRET,
+  PRO_BEARER,
+  makeProDeps,
+  proReq,
+  callBody,
+} from './helpers/mcp-pro-deps.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+const USER_KEY = `wm_${'cd34'.repeat(10)}`;
+const USER_KEY_USER_ID = 'user_apiplan_xyz';
+
+function makeCtx() {
+  const pending = [];
+  return {
+    ctx: { waitUntil: (p) => pending.push(p) },
+    settle: () => Promise.allSettled(pending),
+  };
+}
+
+function captureAxiom() {
+  const events = [];
+  globalThis.fetch = async (url, init) => {
+    const href = String(url);
+    if (href.includes('axiom.co')) {
+      for (const ev of JSON.parse(init.body)) events.push(ev);
+      return new Response('{}', { status: 200 });
+    }
+    return new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+  return events;
+}
+
+describe('api/mcp — usage telemetry (#4866)', () => {
+  let mcpHandler;
+
+  beforeEach(async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = 'wm_env_key_1';
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'stub-token';
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    mcpHandler = mod.mcpHandler;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('anonymous tools/list emits an ok request event with origin_kind mcp', async () => {
+    const { deps } = makeProDeps();
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    const res = await mcpHandler(
+      new Request(BASE_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }) }),
+      deps,
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    await settle();
+    assert.equal(events.length, 1, 'exactly one request event per POST');
+    const ev = events[0];
+    assert.equal(ev.event_type, 'request');
+    assert.equal(ev.route, '/mcp');
+    assert.equal(ev.domain, 'mcp');
+    assert.equal(ev.origin_kind, 'mcp');
+    assert.equal(ev.method, 'POST');
+    assert.equal(ev.status, 200);
+    assert.equal(ev.auth_kind, 'anon');
+    assert.equal(ev.reason, 'ok');
+  });
+
+  it('invalid wm_ key on tools/call emits status 401 reason auth_401 (the #4859 symptom, now visible)', async () => {
+    const { deps } = makeProDeps();
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    const res = await mcpHandler(
+      new Request(BASE_URL, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': 'wm_bogus_key' }, body: JSON.stringify(callBody('describe_tool', { tool_name: 'get_market_data' })) }),
+      deps,
+      ctx,
+    );
+    assert.equal(res.status, 401);
+    await settle();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].status, 401);
+    assert.equal(events[0].reason, 'auth_401');
+    assert.equal(events[0].auth_kind, 'anon');
+  });
+
+  it('pro bearer with lapsed entitlement emits tier_403 attributed to the userId', async () => {
+    const { deps } = makeProDeps({
+      getEntitlements: async () => ({ planKey: 'free', features: { tier: 0, mcpAccess: false }, validUntil: 0 }),
+    });
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    const res = await mcpHandler(proReq('POST', callBody('describe_tool', { tool_name: 'get_market_data' })), deps, ctx);
+    assert.equal(res.status, 401);
+    await settle();
+    assert.equal(events.length, 1);
+    const ev = events[0];
+    assert.equal(ev.reason, 'tier_403');
+    assert.equal(ev.auth_kind, 'mcp_oauth');
+    assert.equal(ev.customer_id, 'user_pro_xyz');
+  });
+
+  it('user_key describe_tool success attributes the key owner', async () => {
+    const { deps } = makeProDeps({
+      validateUserApiKey: async (k) => (k === USER_KEY ? { userId: USER_KEY_USER_ID } : null),
+      getEntitlements: async () => ({ planKey: 'api_starter', features: { tier: 2, mcpAccess: true }, validUntil: Date.now() + 86_400_000 }),
+    });
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    const res = await mcpHandler(
+      new Request(BASE_URL, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': USER_KEY }, body: JSON.stringify(callBody('describe_tool', { tool_name: 'get_market_data' })) }),
+      deps,
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    await settle();
+    assert.equal(events.length, 1);
+    const ev = events[0];
+    assert.equal(ev.reason, 'ok');
+    assert.equal(ev.auth_kind, 'user_api_key');
+    assert.equal(ev.customer_id, USER_KEY_USER_ID);
+  });
+
+  it('pro bearer quota cap emits rate_limit_429', async () => {
+    const { deps } = makeProDeps({ pipelineOpts: { initialCount: 50 } });
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps, ctx);
+    assert.equal(res.status, 429);
+    await settle();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].reason, 'rate_limit_429');
+    assert.equal(events[0].status, 429);
+  });
+
+  it('OPTIONS preflight emits nothing', async () => {
+    const { deps } = makeProDeps();
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    await mcpHandler(new Request(BASE_URL, { method: 'OPTIONS' }), deps, ctx);
+    await settle();
+    assert.equal(events.length, 0);
+  });
+
+  it('USAGE_TELEMETRY off emits nothing', async () => {
+    process.env.USAGE_TELEMETRY = '0';
+    const { deps } = makeProDeps();
+    const events = captureAxiom();
+    const { ctx, settle } = makeCtx();
+    await mcpHandler(proReq('POST', callBody('describe_tool', { tool_name: 'get_market_data' })), deps, ctx);
+    await settle();
+    assert.equal(events.length, 0);
+  });
+
+  it('emission failure never breaks the response (Axiom down)', async () => {
+    const { deps } = makeProDeps();
+    globalThis.fetch = async (url) => {
+      if (String(url).includes('axiom.co')) throw new Error('axiom exploded');
+      return new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+    const { ctx, settle } = makeCtx();
+    const res = await mcpHandler(proReq('POST', callBody('describe_tool', { tool_name: 'get_market_data' })), deps, ctx);
+    assert.equal(res.status, 200);
+    await settle();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4866. `/mcp` rewrites straight to the handler and never passes `server/gateway.ts`, so the MCP surface had **zero rows in `wm_api_usage`** — auth rejections, quota 429s, and successes were all invisible (the #4859 paying-customer diagnosis had to be reconstructed from REST-side rows and Convex `lastUsedAt` timestamps), and no Vercel log drain exists to catch the `console.log` telemetry lines.

This PR emits one gateway-compatible `RequestEvent` per servable `/mcp` request (POST + SSE-replay GET) via `ctx.waitUntil`, reusing `server/_shared/usage.ts` builders so rows are byte-compatible with REST rows and joinable on `customer_id`.

## What lands in Axiom

- `domain: mcp`, `origin_kind: mcp`, `route` = actual pathname (`/mcp` or the well-known alias).
- **auth_kind**: `anon` / `enterprise_api_key` (env keys) / `user_api_key` (#4863 customer keys — owner userId attributed) / new **`mcp_oauth`** (pro bearers — Clerk userId as `customer_id`, kept distinct from `clerk_jwt` so connector traffic never conflates with dashboard traffic).
- **reason** derived from (funnel phase × status), no response-body parsing: `auth_401`, `tier_403`, `rate_limit_429`, `rate_limit_degraded`, `method_not_allowed`, `malformed_request`, `ok`, and new **`auth_unavailable`** (auth backend down → 503; never reads as an invalid-credential wave).
- **Uncaught throws** (the #4860 raw-500 class) emit a status-500 event before re-throwing — the last blind spot closed: a recurrence of the customer's "every tools/call → 500" now shows up in Axiom with principal attribution.
- OPTIONS/HEAD and the static manifest GET are skipped; emission is fail-silent, gated on `USAGE_TELEMETRY`, and rides the existing circuit breaker.

Deliberately NOT included: per-request tier/planKey resolution (would add a Convex round-trip per request — join on `customer_id` instead); JSON-RPC-level error taxonomy (those ride HTTP 200 by spec; the `mcp.toolcall` console telemetry still covers per-tool detail).

## Structure

- New `api/mcp/usage.ts` — phase→reason mapper + emitter; handler split into a thin emitting wrapper (`mcpHandler`, public signature unchanged) around `mcpHandlerInner`, which tags the funnel phase at each terminal return.
- `AuthKind` + `RequestReason` unions extended (`mcp_oauth`, `auth_unavailable`) — no exhaustive switches exist over either, verified by grep.

## Tests

`tests/mcp-usage-telemetry.test.mjs` (8 cases, failing-first): anon tools/list `ok`; invalid key → `auth_401` (the exact #4859 symptom, now visible); lapsed pro → `tier_403` with `customer_id`; user-key success attribution; quota cap → `rate_limit_429`; OPTIONS + telemetry-off silence; Axiom-down never breaks the response. MCP family regression green (251 tests); `typecheck:api` + biome clean; docs-stats unaffected.

## After merge

Once deployed, an `invalid_key`-spike alert per principal/IP becomes possible — the query that would have surfaced the #4859 customer on day one:
`['wm_api_usage'] | where domain == 'mcp' and reason == 'auth_401' | summarize count() by ip, bin(_time, 1h)`

https://claude.ai/code/session_01Ex9zkdxdbxYMogHmEK2YXZ
