### PR TITLE
fix(seeders): stop gdelt-intel/grocery-basket/supply-chain-trade tripping the #4786 240s fetch-deadline (#4864)

### DIFF
--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -12,6 +12,19 @@ const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
 const INTER_TOPIC_DELAY_MS = 20_000; // 20s between topics on success
 const POST_EXHAUST_DELAY_MS = 120_000; // 2min extra cooldown after a topic exhausts all retries
 
+// Wall-clock soft budget for the whole fetch phase (issue #4864). Kept well
+// under runSeed's hard #4786 deadline (lockTtlMs 120s + 120s margin = 240s) so
+// that under a GDELT/Decodo throttle storm the loop stops fetching and falls
+// through to the cached-snapshot merge below — publishing partial+cached data
+// and exiting 0 — instead of two independent budget-blowers pushing the phase
+// past 240s and tripping the deadline into a graceful exit-75 "crash" email:
+//   1. a single topic's fetchGdeltJson can churn ~3.5min under full retry
+//      exhaustion (4×15s direct + 60s backoff + 5×15s proxy + 20s backoff);
+//   2. the inter-topic (20s×5) + post-exhaust (120s) cooldowns alone exceed 240s.
+// The 24h CACHE_TTL guarantees a prior snapshot exists to merge from.
+const FETCH_SOFT_BUDGET_MS = 150_000; // 2.5min — >80s headroom under the 240s hard deadline for merge + publish
+const MIN_TOPIC_BUDGET_MS = 25_000;   // don't start a topic we can't plausibly finish before the budget
+
 const INTEL_TOPICS = [
   { id: 'military',     query: '(military exercise OR troop deployment OR airstrike OR "naval exercise") sourcelang:eng' },
   { id: 'cyber',        query: '(cyberattack OR ransomware OR hacking OR "data breach" OR APT) sourcelang:eng' },
@@ -122,42 +135,106 @@ async function fetchWithRetry(topic) {
   }
 }
 
-async function fetchAllTopics() {
+// Resolve `promise` but never let it run past `budgetMs`; on timeout resolve to
+// `fallback` (and run `onTimeout` for a log line). Unlike raceFetchDeadline this
+// RESOLVES rather than rejects, because a topic that overruns is not a failure —
+// the caller backfills it from the cached snapshot. The abandoned fetch keeps
+// running but every socket underneath it is bounded by AbortSignal.timeout /
+// curl --max-time, so it settles and is GC'd (no leak).
+function withBudget(promise, budgetMs, fallback, onTimeout) {
+  if (!(budgetMs > 0)) return Promise.resolve(fallback);
+  let timer;
+  const budget = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      if (onTimeout) onTimeout();
+      resolve(fallback);
+    }, budgetMs);
+  });
+  return Promise.race([Promise.resolve(promise), budget]).finally(() => clearTimeout(timer));
+}
+
+// Exported for tests. Deps are injectable so the soft-budget + cache-merge
+// behaviour can be driven without a real GDELT/Redis.
+export async function fetchAllTopics(deps = {}) {
+  const {
+    _now = () => Date.now(),
+    _sleep = sleep,
+    _fetchArticles = fetchWithRetry,
+    _fetchTimeline = fetchTopicTimeline,
+    _loadPrevious = () => verifySeedKey(CANONICAL_KEY).catch(() => null),
+    _softBudgetMs = FETCH_SOFT_BUDGET_MS,
+    _minTopicBudgetMs = MIN_TOPIC_BUDGET_MS,
+    _interTopicDelayMs = INTER_TOPIC_DELAY_MS,
+    _postExhaustDelayMs = POST_EXHAUST_DELAY_MS,
+  } = deps;
+  const deadlineAt = _now() + _softBudgetMs;
+  const remaining = () => deadlineAt - _now();
+
   const topics = [];
   for (let i = 0; i < INTEL_TOPICS.length; i++) {
-    if (i > 0) await sleep(INTER_TOPIC_DELAY_MS);
+    // Stop fetching once we can't plausibly finish another topic in time — the
+    // cache-merge below backfills every topic we skip from the prior snapshot,
+    // so the run publishes partial+cached data and exits 0 instead of churning
+    // past the hard #4786 deadline into a graceful exit-75 crash (issue #4864).
+    if (remaining() < _minTopicBudgetMs) {
+      console.log(`  Soft budget (${Math.round(_softBudgetMs / 1000)}s) reached after ${i}/${INTEL_TOPICS.length} topic(s) — remaining ${INTEL_TOPICS.length - i} will fall back to cached snapshot`);
+      break;
+    }
+    if (i > 0) await _sleep(Math.min(_interTopicDelayMs, Math.max(0, remaining() - _minTopicBudgetMs)));
     console.log(`  Fetching ${INTEL_TOPICS[i].id}...`);
-    const result = await fetchWithRetry(INTEL_TOPICS[i]);
+    // Bound this single topic against the remaining budget: its own retry ladder
+    // can reach ~3.5min under a 429 storm, which alone would blow the phase.
+    const emptyTopic = () => ({ id: INTEL_TOPICS[i].id, articles: [], fetchedAt: new Date().toISOString() });
+    const result = await withBudget(
+      _fetchArticles(INTEL_TOPICS[i]),
+      remaining(),
+      { ...emptyTopic(), budgetExceeded: true },
+      () => console.warn(`    ${INTEL_TOPICS[i].id}: article budget reached — falling back to cached`),
+    );
     console.log(`    ${result.articles.length} articles`);
-    // Fetch tone/vol timelines in parallel — best-effort, 429s silently return []
-    const [tone, vol] = await Promise.all([
-      fetchTopicTimeline(INTEL_TOPICS[i], 'TimelineTone'),
-      fetchTopicTimeline(INTEL_TOPICS[i], 'TimelineVol'),
-    ]);
+    // Fetch tone/vol timelines in parallel — best-effort, 429s silently return [].
+    // Also bounded so a slow timeline pair can't overrun the phase.
+    const [tone, vol] = await withBudget(
+      Promise.all([
+        _fetchTimeline(INTEL_TOPICS[i], 'TimelineTone'),
+        _fetchTimeline(INTEL_TOPICS[i], 'TimelineVol'),
+      ]),
+      remaining(),
+      [[], []],
+      () => console.warn(`    ${INTEL_TOPICS[i].id}: timeline budget reached — skipping timelines`),
+    );
     result._tone = tone;
     result._vol = vol;
     console.log(`    timeline: ${tone.length} tone pts, ${vol.length} vol pts`);
     topics.push(result);
     // After a topic exhausts all retries, give GDELT a longer cooldown before hitting
-    // it again with the next topic — the rate limit window for popular queries exceeds 50s
-    if (result.exhausted && i < INTEL_TOPICS.length - 1) {
-      console.log(`    Rate-limit cooldown: waiting ${POST_EXHAUST_DELAY_MS / 1000}s before next topic...`);
-      await sleep(POST_EXHAUST_DELAY_MS);
+    // it again with the next topic — the rate limit window for popular queries exceeds 50s.
+    // Skip the cooldown when it would eat the remaining budget.
+    if (result.exhausted && i < INTEL_TOPICS.length - 1 && remaining() - _postExhaustDelayMs >= _minTopicBudgetMs) {
+      console.log(`    Rate-limit cooldown: waiting ${_postExhaustDelayMs / 1000}s before next topic...`);
+      await _sleep(_postExhaustDelayMs);
     }
   }
 
-  // For topics that returned 0 articles (rate-limited), preserve the previous
-  // snapshot's articles rather than publishing empty results over good cached data.
+  // Represent every topic so the cache-merge can backfill both the ones we
+  // skipped (soft budget) and the ones that came back empty (429).
+  const fetchedIds = new Set(topics.map((t) => t.id));
+  for (const t of INTEL_TOPICS) {
+    if (!fetchedIds.has(t.id)) topics.push({ id: t.id, articles: [], fetchedAt: new Date().toISOString() });
+  }
+
+  // For topics that returned 0 articles (rate-limited or budget-skipped), preserve
+  // the previous snapshot's articles rather than publishing empty over good cached data.
   const emptyTopics = topics.filter((t) => t.articles.length === 0);
   if (emptyTopics.length > 0) {
-    const previous = await verifySeedKey(CANONICAL_KEY).catch(() => null);
+    const previous = await _loadPrevious();
     if (previous && Array.isArray(previous.topics)) {
       const prevMap = new Map(previous.topics.map((t) => [t.id, t]));
       for (const topic of topics) {
         if (topic.articles.length === 0 && prevMap.has(topic.id)) {
           const prev = prevMap.get(topic.id);
           if (prev.articles?.length > 0) {
-            console.log(`    ${topic.id}: rate-limited — using ${prev.articles.length} cached articles from previous snapshot`);
+            console.log(`    ${topic.id}: no fresh articles — using ${prev.articles.length} cached articles from previous snapshot`);
             topic.articles = prev.articles;
             topic.fetchedAt = prev.fetchedAt;
           }
@@ -165,6 +242,10 @@ async function fetchAllTopics() {
       }
     }
   }
+
+  // Restore canonical topic order (backfilled entries were appended out of order).
+  const order = new Map(INTEL_TOPICS.map((t, idx) => [t.id, idx]));
+  topics.sort((a, b) => (order.get(a.id) ?? INTEL_TOPICS.length) - (order.get(b.id) ?? INTEL_TOPICS.length));
 
   return { topics, fetchedAt: new Date().toISOString() };
 }

--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -461,6 +461,17 @@ export function declareRecords(data) {
 
 await runSeed('economic', 'grocery-basket', CANONICAL_KEY, () => fetchGroceryBasketPrices(prevSnapshot), {
   ttlSeconds: CACHE_TTL,
+  // 24 countries are fetched SERIALLY (items within a country run concurrently);
+  // per-country critical path is ~8s healthy but ~25s degraded (direct 8s fails →
+  // EXA 15s / Firecrawl 30s on the priced item), so a full run is ~192s healthy but
+  // ~600s degraded — routinely over the default 240s fetch-phase deadline (lockTtlMs
+  // 120s + 120s margin), tripping the #4786 backstop into a graceful exit-75 "crash"
+  // (issue #4864). Every fetch is individually bounded (8/15/30s AbortSignal.timeout),
+  // so this is legitimate serialized latency, not a hang. Size lockTtlMs to the real
+  // worst-case runtime so the deadline (lockTtlMs + 120s = 14min) is a genuine-hang
+  // backstop again — and so the lock outlives the run instead of lapsing at 120s.
+  lockTtlMs: 720_000, // 12min
+
   validateFn: (data) => {
     if (!data?.countries?.length) return false;
     const minItems = Math.ceil(config.items.length * 0.4); // 40% item coverage per country

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -22,6 +22,15 @@ const KEYS = {
   customsRevenue: 'trade:customs-revenue:v1',
 };
 
+// NOTE (issue #4864): these TTLs are DELIBERATELY left at 8h. The data-loss fix
+// ("manual seed required" — canonical key lapsed and could not be recreated) is the
+// lockTtlMs bump in runSeed opts below, which lets slow-but-legit runs complete and
+// reach atomicPublish again — restoring republishing every 6h so the key stays alive
+// and, once lost, is RECOVERABLE on the next good run (before, it never republished).
+// Widening these TTLs for extra gap-buffer is a valid follow-up but NOT free: each is
+// co-pinned to a health-check maxStaleMin (see tests/trade-policy-tariffs.test.mjs —
+// data-key TTL must satisfy maxStaleMin ∈ [TTL_min, TTL_min+120] or it opens a silent
+// EMPTY / false-STALE window), so raising a TTL means moving its maxStaleMin in lockstep.
 const SHIPPING_TTL = 28800; // 8h — 2h buffer over 6h cron cadence (was 1h = 5h expired gap)
 const TRADE_TTL = 28800; // 8h — 2h buffer over 6h cron cadence (was 6h = 0 buffer)
 const TARIFF_TTL = 28800; // 8h — 2h buffer over 6h cron cadence (was TRADE_TTL=6h = 0 buffer)
@@ -807,6 +816,15 @@ if (process.argv[1]?.endsWith('seed-supply-chain-trade.mjs')) {
   runSeed('supply_chain', 'shipping', KEYS.shipping, fetchAll, {
     validateFn: validate,
     ttlSeconds: SHIPPING_TTL,
+    // fetchAll runs 9 fetchers via Promise.allSettled, so total = the slowest branch;
+    // the WTO branches (barriers/restrictions/flows over ~239 reporters) were budgeted
+    // for the 6h cron ("~10min worst case") and routinely exceed the default 240s
+    // fetch-phase deadline (lockTtlMs 120s + 120s margin), tripping the #4786 backstop
+    // WITHOUT ever reaching atomicPublish (issue #4864). Every fetch is bounded (15/20/60s
+    // AbortSignal.timeout) — no non-settling await — so this is legitimate cumulative
+    // latency. Size lockTtlMs to the WTO design budget so slow-but-legit runs complete and
+    // republish (which recreates an expired key and restores the graceful self-heal).
+    lockTtlMs: 900_000, // 15min → deadline 17min
     sourceVersion: 'fred-wto-sse-bdi-budgetlab',
 
     declareRecords,

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -1,0 +1,60 @@
+// Regression guard for issue #4864. Three seeders tripped the #4786 fetch-phase
+// deadline (raceFetchDeadline in _seed-utils.mjs: default = lockTtlMs 120s + 120s
+// margin = 240s) on legitimate slow-retry runs, exiting 75 (a Railway "crash"
+// email) — and seed-supply-chain-trade additionally lost its last-good data
+// because it never republished and its 8h TTL only buffered one 6h cron cycle.
+//
+// The fixes are config values sized to each seeder's real worst-case runtime and
+// cron cadence. These invariants pin those values so a future edit can't silently
+// re-shrink them below the runtime/cadence and reopen the bug. Values are read
+// from source text (the seeders execute Redis at import, so we don't import them).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = fileURLToPath(new URL('../scripts/', import.meta.url));
+const read = (f) => readFileSync(scriptsDir + f, 'utf8');
+const num = (s) => Number(String(s).replace(/_/g, ''));
+
+// Pull `name: 12_345` / `const NAME = 12345;` numeric literals out of source.
+function optValue(src, key) {
+  const m = src.match(new RegExp(`${key}\\s*[:=]\\s*(\\d[\\d_]*)`));
+  return m ? num(m[1]) : null;
+}
+
+const FETCH_PHASE_MARGIN_MS = 120_000; // _seed-utils.mjs FETCH_PHASE_DEADLINE_MARGIN_MS
+const deadlineFromLock = (lockMs) => lockMs + FETCH_PHASE_MARGIN_MS;
+
+describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
+  it('gdelt-intel: soft budget fires before the hard deadline, leaving merge+publish headroom', () => {
+    const src = read('seed-gdelt-intel.mjs');
+    const soft = optValue(src, 'FETCH_SOFT_BUDGET_MS');
+    const minTopic = optValue(src, 'MIN_TOPIC_BUDGET_MS');
+    assert.ok(soft, 'FETCH_SOFT_BUDGET_MS must be defined');
+    // gdelt keeps the default lock (120s) → hard deadline 240s. The soft budget must
+    // trip well before that so the cache-merge + publish complete inside the deadline.
+    const hardDeadline = deadlineFromLock(120_000);
+    assert.ok(soft + 60_000 <= hardDeadline, `soft budget ${soft}ms + merge headroom must stay under the ${hardDeadline}ms hard deadline`);
+    assert.ok(minTopic && minTopic > 0 && minTopic < soft, 'MIN_TOPIC_BUDGET_MS must be a positive fraction of the soft budget');
+  });
+
+  it('grocery-basket: lock/deadline covers its ~600s degraded serial runtime (24 serial countries)', () => {
+    const src = read('seed-grocery-basket.mjs');
+    const lock = optValue(src, 'lockTtlMs');
+    assert.ok(lock, 'grocery-basket runSeed must set lockTtlMs (default 120s → 240s deadline is below its serial runtime)');
+    // Degraded run ≈ 600s (24 countries × ~25s critical path). Deadline must clear it.
+    assert.ok(deadlineFromLock(lock) >= 600_000, `deadline ${deadlineFromLock(lock)}ms must cover the ~600s degraded runtime`);
+  });
+
+  it('supply-chain-trade: lock/deadline covers the WTO ~10min budget so runs complete + republish', () => {
+    // This is the data-loss fix: fetchAll must reach atomicPublish (republish) so the
+    // canonical key stays alive / is recreatable, instead of always tripping the 240s
+    // deadline before publishing (which made "manual seed required" loss permanent).
+    const src = read('seed-supply-chain-trade.mjs');
+    const lock = optValue(src, 'lockTtlMs');
+    assert.ok(lock, 'supply-chain runSeed must set lockTtlMs (WTO reporter scan far exceeds the 240s default)');
+    assert.ok(deadlineFromLock(lock) >= 600_000, `deadline ${deadlineFromLock(lock)}ms must clear the ~10min WTO design budget`);
+  });
+});

--- a/tests/seed-gdelt-intel-fetch-budget.test.mjs
+++ b/tests/seed-gdelt-intel-fetch-budget.test.mjs
@@ -1,0 +1,106 @@
+// Regression test for issue #4864: seed-gdelt-intel tripped the #4786 240s
+// fetch-phase deadline under a GDELT/Decodo 429 storm and exited 75 (a Railway
+// "crash" email) instead of falling through to its 24h cached-snapshot merge.
+//
+// The bug: the hard raceFetchDeadline wraps the WHOLE fetch phase, so a slow
+// topic ladder (~3.5min each) plus the inter-topic (20s×5) + post-exhaust (120s)
+// cooldowns pushed fetchAllTopics past 240s and it was killed BEFORE reaching the
+// cache-merge that backfills 429'd topics from the prior snapshot.
+//
+// The fix: an internal wall-clock soft budget that (a) bounds each single topic
+// fetch and (b) stops starting new topics once the budget is spent, then always
+// runs the cache-merge so the run publishes partial+cached data and exits 0.
+//
+// These tests would hang on the pre-fix code: `_fetchArticles` never settling
+// had no bound, so fetchAllTopics never returned.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchAllTopics } from '../scripts/seed-gdelt-intel.mjs';
+
+const TOPIC_IDS = ['military', 'cyber', 'nuclear', 'sanctions', 'intelligence', 'maritime'];
+const cachedSnapshot = () => ({
+  topics: TOPIC_IDS.map((id) => ({
+    id,
+    articles: [{ title: `cached ${id}`, url: `https://example.test/${id}` }],
+    fetchedAt: 'PREV',
+  })),
+});
+
+describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
+  it('budget spent up front → every topic backfilled from cache, returns immediately (no deadline churn)', async () => {
+    const started = Date.now();
+    const out = await fetchAllTopics({
+      _softBudgetMs: 40,            // spent before the first topic can start
+      _sleep: async () => {},
+      _fetchArticles: () => new Promise(() => {}), // would hang forever on old code
+      _fetchTimeline: async () => [],
+      _loadPrevious: async () => cachedSnapshot(),
+    });
+    const elapsed = Date.now() - started;
+
+    assert.ok(elapsed < 3000, `should be bounded by the soft budget, took ${elapsed}ms`);
+    assert.deepEqual(out.topics.map((t) => t.id), TOPIC_IDS, 'all 6 topics represented, in canonical order');
+    for (const t of out.topics) {
+      assert.equal(t.articles[0]?.title, `cached ${t.id}`, `${t.id} carries cached articles`);
+    }
+  });
+
+  it('a hanging topic fetch is bounded per-topic, then backfilled from cache', async () => {
+    let attempts = 0;
+    const started = Date.now();
+    const out = await fetchAllTopics({
+      _softBudgetMs: 150,
+      _minTopicBudgetMs: 20,       // allow one topic to be attempted, then break
+      _sleep: async () => {},
+      _fetchArticles: () => { attempts++; return new Promise(() => {}); }, // never settles
+      _fetchTimeline: async () => [],
+      _loadPrevious: async () => cachedSnapshot(),
+    });
+    const elapsed = Date.now() - started;
+
+    assert.ok(attempts >= 1, 'at least one topic fetch was attempted and bounded');
+    assert.ok(elapsed < 3000, `per-topic budget bounded the hang, took ${elapsed}ms`);
+    assert.deepEqual(out.topics.map((t) => t.id), TOPIC_IDS);
+    for (const t of out.topics) {
+      assert.equal(t.articles[0]?.title, `cached ${t.id}`, `${t.id} fell back to cache`);
+    }
+  });
+
+  it('happy path: topics that succeed in time publish FRESH articles (transparent, no cache read)', async () => {
+    const out = await fetchAllTopics({
+      _softBudgetMs: 60_000,
+      _sleep: async () => {},
+      _fetchArticles: async (topic) => ({
+        id: topic.id,
+        articles: [{ title: `fresh ${topic.id}`, url: `https://example.test/live/${topic.id}` }],
+        fetchedAt: 'NOW',
+      }),
+      _fetchTimeline: async () => [{ date: '2026-07-05', value: 1 }],
+      _loadPrevious: async () => { throw new Error('cache must not be consulted on the happy path'); },
+    });
+    assert.deepEqual(out.topics.map((t) => t.id), TOPIC_IDS);
+    for (const t of out.topics) {
+      assert.equal(t.articles[0].title, `fresh ${t.id}`);
+      assert.ok(Array.isArray(t._tone) && Array.isArray(t._vol), 'timelines attached');
+    }
+  });
+
+  it('mixed: fresh where the fetch succeeds, cached where it 429s', async () => {
+    let n = 0;
+    const out = await fetchAllTopics({
+      _softBudgetMs: 60_000,
+      _sleep: async () => {},
+      _fetchArticles: async (topic) => {
+        n++;
+        if (n <= 2) return { id: topic.id, articles: [{ title: `fresh ${topic.id}`, url: `https://x/${topic.id}` }], fetchedAt: 'NOW' };
+        return { id: topic.id, articles: [], fetchedAt: 'NOW', exhausted: true }; // 429 → empty
+      },
+      _fetchTimeline: async () => [],
+      _loadPrevious: async () => cachedSnapshot(),
+    });
+    assert.equal(out.topics.find((t) => t.id === TOPIC_IDS[0]).articles[0].title, `fresh ${TOPIC_IDS[0]}`);
+    assert.equal(out.topics.find((t) => t.id === TOPIC_IDS[5]).articles[0].title, `cached ${TOPIC_IDS[5]}`);
+  });
+});


### PR DESCRIPTION
Fixes #4864.

## Problem

`seed-gdelt-intel`, `seed-grocery-basket`, and `seed-supply-chain-trade` repeatedly exit **75** and fire Railway "Deployment crashed" emails. The `diagnose-railway-seeders` classifier buckets them `GRACEFUL` (correct at the exit-code layer), but the root cause is a **retry/serial budget outrunning the `#4786` fetch-phase deadline** (`raceFetchDeadline`: `lockTtlMs 120s + 120s margin = 240s`), **not** a non-settling await — every fetch in all three is already bounded by `AbortSignal.timeout`/`--max-time`. `seed-supply-chain-trade` additionally suffers real **data loss** (`manual seed required`).

Verified against the live Railway crash logs (deploys `48ecec76…`, `1fb4bd25…`, `70e7a8c0…`), each exiting at ~240xxx ms.

## Fixes

| Seeder | Root cause | Fix |
|--------|-----------|-----|
| **gdelt-intel** | The 240s hard deadline aborts `fetchAllTopics` **before** its 24h cache-merge fallback runs — a single topic's retry ladder (~3.5min) + the 20s×5 inter-topic / 120s post-exhaust cooldowns blow the budget. | Internal **wall-clock soft budget** bounds each topic fetch and yields to the existing cache-merge before the deadline → a throttle storm publishes partial+cached data and exits **0**. `fetchAllTopics` exported + dependency-injectable. |
| **grocery-basket** | 24 countries fetched **serially** (~192s healthy / ~600s degraded) routinely clear 240s. | `lockTtlMs` → 12min so the deadline covers the real serial runtime (also fixes a latent bug where the 120s lock lapses mid-run). |
| **supply-chain-trade** | `fetchAll` scans **~239 WTO reporters**, so it can't finish under 240s when WTO is slow → never reaches `atomicPublish` → the 8h canonical key lapses and is **never recreated** (permanent loss). | `lockTtlMs` → 15min so slow-but-legit runs **complete and republish** — making the loss *recoverable* instead of permanent. |

## Scope note — TTL widening deferred (deliberate)

I originally proposed *raising the supply-chain TTLs* for extra gap-buffer, but `TARIFF_TTL` is **co-pinned** to a health-check `maxStaleMin` (`tests/trade-policy-tariffs.test.mjs`) that guards a real 2026-04-27 "silent EMPTY window" bug — the data-key TTL must satisfy `maxStaleMin ∈ [TTL_min, TTL_min+120]`. Raising a TTL without moving its `maxStaleMin` in lockstep would reopen that window. So the TTLs stay at 8h and the budget fix (which restores republishing — the actual root cause of the *permanent* loss) carries the data-loss fix. Documented inline + in #4864 as a scoped follow-up.

## Tests

- `tests/seed-gdelt-intel-fetch-budget.test.mjs` — 4 behavioral tests: storm→cache backfill, per-topic hang bound, happy path (fresh), mixed fresh/cached.
- `tests/seed-fetch-deadline-budget-invariants.test.mjs` — guards that each seeder's soft-budget/lock-deadline covers its documented runtime (fails on the pre-fix default 240s).
- 48 existing seeder tests green; `trade-policy-tariffs` co-pin test green (TTLs unchanged).

https://claude.ai/code/session_01GRtiowtr1FVsXD9r5Xaoc8
