### PR TITLE
fix(agent-readiness): post-#4867 review findings — honest health-401/product-catalog contracts, pinned pricing/support markdown, API annual plan

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -788,8 +788,11 @@ export default async function handler(req, ctx) {
       const error = keyCheck.error === USER_API_KEY_GATEWAY_VALIDATION_ERROR
         ? 'Invalid API key'
         : keyCheck.error;
-      // RFC 7235 §3.1 requires WWW-Authenticate on every 401; resource_metadata
-      // (RFC 9728 §5.1) lets agents discover how to obtain credentials. The
+      // RFC 7235 §3.1 requires WWW-Authenticate on every 401. The challenge
+      // must reflect what this gate actually accepts: validateApiKey reads the
+      // X-WorldMonitor-Key / X-Api-Key headers (or tester cookies) — never
+      // Authorization: Bearer — so advertising a Bearer/OAuth challenge here
+      // sent agents down a flow that cannot succeed (post-#4867 review). The
       // hint exists because this URL is what old copies of the api-catalog
       // linkset advertised as the public status endpoint (#4856) — a keyless
       // caller landing here should learn the public form, not dead-end.
@@ -801,8 +804,7 @@ export default async function handler(req, ctx) {
         401,
         {
           ...headers,
-          'WWW-Authenticate':
-            'Bearer resource_metadata="https://www.worldmonitor.app/.well-known/oauth-protected-resource"',
+          'WWW-Authenticate': 'ApiKey realm="worldmonitor-health", header="X-WorldMonitor-Key"',
         }
       );
     }

--- a/api/product-catalog.js
+++ b/api/product-catalog.js
@@ -270,7 +270,9 @@ export default async function handler(req) {
       const result = { tiers, fetchedAt: now, cachedUntil: now + CACHE_TTL * 1000, priceSource };
       // Don't write to Redis — let the Railway seed own that key with its longer TTL.
       // Just return the result with short cache so the next Railway cycle repopulates properly.
-      return json(result, 200, cors, 'public, max-age=60, s-maxage=60', 'dodo');
+      // Header must carry the SAME source as the body: a partial Dodo read
+      // stamped 'dodo' here made probes read a degraded response as fully live.
+      return json(result, 200, cors, 'public, max-age=60, s-maxage=60', priceSource);
     }
   }
 

--- a/docs/openapi/CommerceService.openapi.yaml
+++ b/docs/openapi/CommerceService.openapi.yaml
@@ -33,10 +33,10 @@ paths:
                     description: Successful response
                     headers:
                         X-Product-Catalog-Source:
-                            description: Where the prices came from — cache, dodo, or fallback.
+                            description: Where the prices came from — cache (Redis hit), dodo (all live prices), partial (some Dodo prices missing, gaps filled from static fallback), or fallback (Dodo unreachable, all static). Matches the body's priceSource except on cache hits, where the header says cache and the body retains the priceSource stored at seed time.
                             schema:
                                 type: string
-                                enum: [cache, dodo, fallback]
+                                enum: [cache, dodo, partial, fallback]
                     content:
                         application/json:
                             schema:
@@ -59,8 +59,8 @@ paths:
                                                 highlighted:
                                                     type: boolean
                                                 price:
-                                                    type: number
-                                                    description: Flat price for non-subscription tiers (0 for Free).
+                                                    type: [number, "null"]
+                                                    description: Flat price for non-subscription tiers — 0 for Free, null for Enterprise (custom pricing). Absent on subscription tiers, which carry monthlyPrice/annualPrice instead.
                                                 period:
                                                     type: string
                                                 monthlyPrice:
@@ -79,6 +79,10 @@ paths:
                                     cachedUntil:
                                         type: integer
                                         description: Epoch ms until which the cached copy is served.
+                                    priceSource:
+                                        type: string
+                                        enum: [dodo, partial, fallback]
+                                        description: Provenance of the prices in this payload — dodo (all live), partial (some live, gaps from static fallback), fallback (all static). Cache hits retain the value stored at seed time; the X-Product-Catalog-Source header additionally reports cache.
                             example:
                                 tiers:
                                     - name: Free
@@ -97,3 +101,4 @@ paths:
                                       annualProductId: pdt_0NbttMIfjLWC10jHQWYgJ
                                 fetchedAt: 1751700000000
                                 cachedUntil: 1751703600000
+                                priceSource: dodo

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -17,7 +17,7 @@ World Monitor has a free public dashboard and paid tiers for analyst workflows, 
 |------|-------|----------|
 | **Free** | $0 — no signup required | Public situational awareness, OSINT research, news monitoring |
 | **Pro** | $39.99/month · $399.99/year | WM Analyst chat, Scenario Engine, AI digests, custom widgets, MCP access |
-| **API** | $99.99/month | REST API + SDKs, 1,000 requests/day starter limit, webhooks, data exports |
+| **API** | $99.99/month · $999/year | REST API + SDKs, 1,000 requests/day starter limit, webhooks, data exports |
 | **Enterprise** | Custom — [enterprise@worldmonitor.app](mailto:enterprise@worldmonitor.app) | Team workspaces, SSO/MFA/RBAC, white-label, on-premises / air-gapped |
 
 Prices above mirror `convex/config/productCatalog.ts` (the source of truth behind `/api/product-catalog`); a drift guard test keeps this page honest.

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -47,6 +47,11 @@
           "title": "Live product catalog (tiers, prices, product IDs)"
         },
         {
+          "href": "https://www.worldmonitor.app/docs/openapi/CommerceService.openapi.yaml",
+          "type": "application/vnd.oai.openapi",
+          "title": "Commerce/pricing endpoints OpenAPI (separate from the root bundle)"
+        },
+        {
           "href": "https://worldmonitor.app/support.md",
           "type": "text/markdown",
           "title": "Support channels & contact (machine-readable)"

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -27,6 +27,8 @@ Live tier/price/product-ID data (JSON): `GET https://www.worldmonitor.app/api/pr
 ## API
 
 - Price: $99.99/month
+- Annual price: $999/year
+- Annual savings: about 17 percent versus monthly billing
 - Best for: Developers and teams that want programmatic access to World Monitor intelligence data
 - Includes: REST API access, structured JSON, cache headers, OpenAPI docs, real-time data streams, webhook notifications and custom data exports
 - Starter limit: 1,000 requests/day
@@ -70,6 +72,7 @@ Live tier/price/product-ID data (JSON): `GET https://www.worldmonitor.app/api/pr
     {
       "name": "API",
       "price_usd_monthly": 99.99,
+      "price_usd_yearly": 999,
       "features": ["REST API", "1,000 requests/day starter limit", "webhooks", "structured JSON", "OpenAPI docs"]
     },
     {

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -16,7 +16,7 @@ const middlewareSource = readFileSync(resolve(__dirname, '../middleware.ts'), 'u
 const dockerfileSource = readFileSync(resolve(__dirname, '../Dockerfile'), 'utf-8');
 const dockerNginxSource = readFileSync(resolve(__dirname, '../docker/nginx.conf'), 'utf-8');
 const frontendDockerfileSource = readFileSync(resolve(__dirname, '../docker/Dockerfile'), 'utf-8');
-const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
+const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
 const GLOBAL_SECURITY_HEADER_SOURCE = '/((?!docs|embed|embed\\.html).*)';
 const APP_ROOT_HOST_PATTERN = '^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$';
 const GLOBAL_CSP_INLINE_SCRIPT_HTML_FILES = [
@@ -1215,6 +1215,14 @@ describe('agent readiness: api-catalog + openapi build', () => {
       'service-meta must advertise the live product-catalog JSON endpoint'
     );
     assert.ok(hrefs.includes('https://worldmonitor.app/support.md'), 'service-meta must advertise support.md');
+    // The Commerce spec lives outside the root openapi bundle (size budget,
+    // #4853) — without this link no advertised descriptor reaches it
+    // (post-#4867 review finding); Mintlify serves the raw YAML at this URL.
+    const commerceSpec = meta.find(
+      (entry) => entry.href === 'https://www.worldmonitor.app/docs/openapi/CommerceService.openapi.yaml'
+    );
+    assert.ok(commerceSpec, 'service-meta must link the Commerce OpenAPI spec');
+    assert.equal(commerceSpec.type, 'application/vnd.oai.openapi');
   });
 
   it('service-desc points at /openapi.yaml with the OpenAPI media type', () => {
@@ -1591,6 +1599,28 @@ describe('agent readiness: auth.md walkthrough', () => {
     assert.ok(catchAll.source.includes('|auth\\.md|'), 'SPA catch-all rewrite must exclude /auth.md');
     assert.ok(SPA_HTML_CACHE_SOURCE.includes('|auth\\.md|'), 'HTML cache catch-all must exclude /auth.md');
   });
+
+  // pricing.md and support.md are advertised in api-catalog service-meta and
+  // llms.txt (#4854/#4857), so they get the same three-way pinning as auth.md:
+  // explicit markdown Content-Type + CORS, catch-all exclusion (deleting or
+  // renaming the static file must 404, not silently serve the dashboard HTML
+  // misleading-200 the journey runs flagged), and this guard.
+  for (const mdPath of ['/pricing.md', '/support.md']) {
+    it(`serves ${mdPath} as markdown and keeps it off the SPA catch-all`, () => {
+      assert.equal(getHeaderValueForSource(mdPath, 'Content-Type'), 'text/markdown; charset=utf-8');
+      assert.equal(getHeaderValueForSource(mdPath, 'Access-Control-Allow-Origin'), '*');
+      const catchAll = vercelConfig.rewrites.find((r) =>
+        r.destination === DASHBOARD_HTML_DESTINATION && r.source.startsWith('/((?!')
+      );
+      const frag = `|${mdPath.slice(1).replace('.', '\\.')}|`;
+      assert.ok(catchAll.source.includes(frag), `SPA catch-all rewrite must exclude ${mdPath}`);
+      assert.ok(SPA_HTML_CACHE_SOURCE.includes(frag), `HTML cache catch-all must exclude ${mdPath}`);
+      assert.ok(
+        existsSync(resolve(__dirname, `../public${mdPath}`)),
+        `public${mdPath} must exist — it is advertised in api-catalog service-meta and llms.txt`
+      );
+    });
+  }
 });
 
 // PR history: #3204 / #3206 forced the resvg linux-x64-gnu native

--- a/tests/health-redis-down-status.test.mjs
+++ b/tests/health-redis-down-status.test.mjs
@@ -31,18 +31,22 @@ test('detailed health requires an operator API key before Redis is queried', asy
   assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
 });
 
-test('the 401 carries WWW-Authenticate and points keyless callers at the public compact form', async () => {
-  // RFC 7235 §3.1 makes WWW-Authenticate mandatory on 401; resource_metadata
-  // (RFC 9728) is the agent-discovery pointer. The hint matters because the
-  // bare /api/health URL circulated as the advertised status endpoint before
-  // #4856 repointed the api-catalog/Link headers at ?compact=1 — stale
-  // consumers landing here must learn the public form instead of dead-ending.
+test('the 401 carries an HONEST WWW-Authenticate and points keyless callers at the public compact form', async () => {
+  // RFC 7235 §3.1 makes WWW-Authenticate mandatory on 401 — and the challenge
+  // must name a scheme the endpoint actually accepts. validateApiKey reads
+  // X-WorldMonitor-Key / X-Api-Key headers, never Authorization: Bearer, so a
+  // Bearer/OAuth challenge here (shipped in #4867, caught in review) pointed
+  // agents at a flow that cannot succeed. The hint matters because the bare
+  // /api/health URL circulated as the advertised status endpoint before #4856
+  // repointed the api-catalog/Link headers at ?compact=1.
   const req = new Request('https://api.worldmonitor.app/api/health');
   const res = await handler(req);
   assert.equal(res.status, 401);
   const challenge = res.headers.get('WWW-Authenticate');
   assert.ok(challenge, '401 must carry a WWW-Authenticate challenge (RFC 7235 §3.1)');
-  assert.match(challenge, /resource_metadata="https:\/\/www\.worldmonitor\.app\/\.well-known\/oauth-protected-resource"/);
+  assert.match(challenge, /^ApiKey /, 'challenge scheme must be the API-key mechanism the gate accepts');
+  assert.match(challenge, /header="X-WorldMonitor-Key"/, 'challenge must name the accepted header');
+  assert.ok(!/Bearer/.test(challenge), 'must not advertise Bearer — the health gate never reads Authorization');
   const body = await res.json();
   assert.match(body.hint, /\/api\/health\?compact=1/);
 });

--- a/tests/pricing-docs-drift.test.mjs
+++ b/tests/pricing-docs-drift.test.mjs
@@ -6,11 +6,15 @@ import { fileURLToPath } from 'node:url';
 
 // Agent-facing pricing surfaces must not drift from the source of truth,
 // convex/config/productCatalog.ts (#4854). The /pro page has its own
-// freshness gate; these two files are hand-maintained markdown/MDX with no
+// freshness gate; these files are hand-maintained markdown/MDX with no
 // generator, so this guard extracts prices from the catalog SOURCE TEXT
-// (no import — convex modules don't load under tsx --test) and asserts each
-// USD figure appears in the docs. If a price change lands in the catalog,
-// this test names every doc that still shows the old number.
+// (no import — convex modules don't load under tsx --test) and checks them
+// three ways (hardened after the post-#4867 review flagged the original
+// contains()-only version as brittle):
+//   1. prose: each USD figure appears, tolerating thousands separators;
+//   2. pricing.md's embedded ```json block: numeric field comparison, so a
+//      stale machine-readable summary fails even when the prose was updated;
+//   3. the Commerce OpenAPI example product IDs still exist in the catalog.
 //
 // Run: node --test tests/pricing-docs-drift.test.mjs
 
@@ -19,10 +23,10 @@ const read = (p) => readFileSync(resolve(__dirname, '..', p), 'utf-8');
 
 const catalogSrc = read('convex/config/productCatalog.ts');
 
-// Pull { planKey → priceCents } for the publicly-priced subscription plans.
-const PLAN_KEYS = ['pro_monthly', 'pro_annual', 'api_starter'];
+// planKey → priceCents for every publicly-priced subscription plan,
+// including the annual API plan the original docs omitted entirely.
+const PLAN_KEYS = ['pro_monthly', 'pro_annual', 'api_starter', 'api_starter_annual'];
 const priceCentsFor = (planKey) => {
-  // Anchor on the object key, then take the first priceCents after it.
   const blockStart = catalogSrc.indexOf(`${planKey}: {`);
   assert.notEqual(blockStart, -1, `productCatalog.ts must contain a "${planKey}" entry`);
   const m = catalogSrc.slice(blockStart).match(/priceCents:\s*(\d+)/);
@@ -30,8 +34,22 @@ const priceCentsFor = (planKey) => {
   return Number(m[1]);
 };
 
-const usd = (cents) =>
-  (cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).replace(/,/g, '');
+// $999 for even dollars, $39.99 otherwise — matching how the docs and the
+// live /api/product-catalog payload both render whole-dollar prices.
+const usdText = (cents) =>
+  cents % 100 === 0 ? String(cents / 100) : (cents / 100).toFixed(2);
+
+// Prose matcher: "$1299.99" or "$1,299.99" both count; the dot is escaped.
+const proseRegexFor = (cents) => {
+  const [int, frac] = usdText(cents).split('.');
+  const intWithOptionalCommas = int
+    .split('')
+    .reverse()
+    .map((ch, i) => (i > 0 && i % 3 === 0 ? `${ch},?` : ch))
+    .reverse()
+    .join('');
+  return new RegExp(`\\$${intWithOptionalCommas}${frac ? `\\.${frac}` : '(?![.\\d])'}`);
+};
 
 const DOCS = ['public/pricing.md', 'docs/pricing.mdx'];
 
@@ -39,20 +57,47 @@ for (const doc of DOCS) {
   const content = read(doc);
   for (const planKey of PLAN_KEYS) {
     const cents = priceCentsFor(planKey);
-    const dollars = `$${usd(cents)}`;
-    test(`${doc} carries the current ${planKey} price (${dollars})`, () => {
-      assert.ok(
-        content.includes(dollars),
-        `${doc} must contain ${dollars} for ${planKey} — productCatalog.ts changed and this doc did not`
+    test(`${doc} carries the current ${planKey} price ($${usdText(cents)})`, () => {
+      assert.match(
+        content,
+        proseRegexFor(cents),
+        `${doc} must contain $${usdText(cents)} for ${planKey} — productCatalog.ts changed and this doc did not`
       );
     });
   }
 }
 
+// pricing.md's Machine-Readable Summary is what agents actually parse — a
+// stale number there passes a doc-wide contains() check as long as the prose
+// was updated, so compare the JSON numerically, field by field.
+test('pricing.md machine-readable JSON block matches productCatalog.ts numerically', () => {
+  const pricingMd = read('public/pricing.md');
+  const jsonBlock = pricingMd.match(/```json\n([\s\S]*?)```/);
+  assert.ok(jsonBlock, 'pricing.md must contain a ```json machine-readable summary block');
+  const summary = JSON.parse(jsonBlock[1]);
+  const planByName = Object.fromEntries(summary.plans.map((p) => [p.name, p]));
+
+  const EXPECT = [
+    ['Pro', 'price_usd_monthly', 'pro_monthly'],
+    ['Pro', 'price_usd_yearly', 'pro_annual'],
+    ['API', 'price_usd_monthly', 'api_starter'],
+    ['API', 'price_usd_yearly', 'api_starter_annual'],
+  ];
+  for (const [plan, field, planKey] of EXPECT) {
+    assert.ok(planByName[plan], `JSON summary must have a "${plan}" plan`);
+    assert.equal(
+      planByName[plan][field],
+      priceCentsFor(planKey) / 100,
+      `JSON summary ${plan}.${field} is stale vs productCatalog.ts ${planKey}`
+    );
+  }
+  assert.equal(planByName.Free?.price_usd_monthly, 0, 'Free plan must stay $0 in the JSON summary');
+});
+
 // The Dodo product IDs are surfaced by GET /api/product-catalog, and
 // docs/openapi/CommerceService.openapi.yaml embeds two of them as examples.
-// Guard those too — a rotated product ID in the catalog must not leave the
-// published OpenAPI example pointing at a dead product.
+// A rotated product ID in the catalog must not leave the published OpenAPI
+// example pointing at a dead product.
 test('CommerceService.openapi.yaml example product IDs exist in productCatalog.ts', () => {
   const spec = read('docs/openapi/CommerceService.openapi.yaml');
   const exampleIds = [...spec.matchAll(/pdt_[A-Za-z0-9]+/g)].map((m) => m[0]);

--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,7 @@
     { "source": "/.well-known/mcp.json", "destination": "/api/mcp" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
-    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
+    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [
     {
@@ -107,6 +107,22 @@
     },
     {
       "source": "/auth.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
+      "source": "/pricing.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
+      "source": "/support.md",
       "headers": [
         { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
         { "key": "Access-Control-Allow-Origin", "value": "*" },
@@ -203,7 +219,7 @@
       ]
     },
     {
-      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
+      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]


### PR DESCRIPTION
## What

Fixes the confirmed findings from the post-merge review of #4867. Verdicts, each verified against head + live probes before touching anything:

| Finding | Verdict | Evidence |
|---|---|---|
| P1 Commerce spec not discoverable from advertised descriptors | **Confirmed (residue)** — the raw spec IS live at `/docs/openapi/CommerceService.openapi.yaml` (200, text/yaml via the Mintlify proxy), but no descriptor linked it | probe + api-catalog inspection |
| P1 Contract mismatch: Enterprise `price: null`, partial-Dodo header/body disagree | **Confirmed, both halves** — live Enterprise tier returns `"price": null` vs spec `type: number`; `api/product-catalog.js:273` hardcoded header source `'dodo'` on the branch whose body says `priceSource: "partial"` | live JSON + code |
| P2 Health 401 advertises Bearer it can't satisfy | **Confirmed** — `validateApiKey` reads `X-WorldMonitor-Key`/`X-Api-Key`/tester cookies, never `Authorization` | `api/_api-key.js:18,65-67` |
| P2 pricing.md/support.md not pinned like auth.md | **Confirmed** — absent from both catch-all regex copies, no header rules, no deploy-config guards | vercel.json + test grep |
| P2 API annual plan omitted | **Confirmed** — `api_starter_annual` is `currentForCheckout: true, publicVisible: true` ($999) and live in `/api/product-catalog`, absent from pricing.md prose + JSON and docs/pricing.mdx | catalog source + live JSON |
| P3 Drift test brittle | **Confirmed** — contains()-only, comma-stripping, JSON block unchecked | inspection |

## Changes

- **`api/product-catalog.js`** — partial-Dodo branch now stamps the header with the computed `priceSource` instead of hardcoded `'dodo'`; a degraded response no longer reads as fully live to probes. (No test pinned the old value — verified before changing.)
- **`api/health.js`** — 401 challenge is now `ApiKey realm="worldmonitor-health", header="X-WorldMonitor-Key"`; the Bearer/resource_metadata challenge advertised an OAuth flow this gate cannot accept. Test asserts the scheme, the named header, and Bearer's absence.
- **Commerce spec** — `price` nullable (`[number, "null"]`), body `priceSource` documented (`dodo|partial|fallback` + cache-hit semantics), header enum gains `partial`, example updated.
- **api-catalog** — `service-meta` entry linking the Commerce spec URL (`application/vnd.oai.openapi`), guarded in deploy-config.
- **vercel.json** — `pricing\.md|support\.md` added to both SPA catch-all regex copies + explicit `text/markdown` + CORS + cache header rules (the auth.md treatment); deploy-config pins all three ways plus file existence.
- **Pricing surfaces** — API annual plan added to pricing.md prose (`$999/year`, ~17% savings) and JSON summary (`price_usd_yearly: 999`) and docs/pricing.mdx.
- **`tests/pricing-docs-drift.test.mjs`** — numeric field-by-field comparison of pricing.md's ```json block against catalog cents (stale machine-readable JSON now fails independently of prose), comma-tolerant prose regex, `api_starter_annual` covered.

## Verification

- pricing-drift + product-catalog ×3 + health suites: 40 pass
- deploy-config: 109 pass (2 new pin tests + service-meta extension)
- `docs:check` green; vercel.json/api-catalog JSON + spec YAML parse

https://claude.ai/code/session_01N3xTXNUrCiy1xqy3VbkMRx
