### PR TITLE
chore(sdk/go): bump Version to 0.1.1 — publish-go tag guard

### DIFF
--- a/sdk/go/worldmonitor.go
+++ b/sdk/go/worldmonitor.go
@@ -35,7 +35,7 @@ import (
 
 // Version of this SDK. The release workflow checks it against the
 // sdk/go/vX.Y.Z tag before warming the module proxy.
-const Version = "0.1.0"
+const Version = "0.1.1"
 
 // UserAgent identifies the SDK on every request. Cloudflare's WAF challenges
 // generic library User-Agents (Go-http-client, curl, empty) on the API edge,


### PR DESCRIPTION
The `sdk/go/v0.1.1` publish failed its version-parity guard: #4882 bumped npm/PyPI/gem versions but missed the `Version` const in `sdk/go/worldmonitor.go` (the workflow checks it against the tag — good guard, caught a real miss). One-line bump; gofmt/vet clean. After merge the tag gets re-pointed at the new commit and re-pushed (individually — the >3-tags-in-one-push event suppression is now in the napkin).

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry