### PR TITLE
perf(map): time-box marker pulse animations — settle to static after the attention window (#4669)

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -118,6 +118,12 @@ interface WorldTopology extends Topology {
 export class MapComponent {
   private static readonly MOBILE_MIN_EARTHQUAKE_MAGNITUDE = 5;
   private static readonly MOBILE_MAX_IRAN_EVENTS = 50;
+  // #4669: how long markers pulse after a render before settling to static.
+  // Infinite opacity pulses hold a permanent compositing layer per marker
+  // (385 of 517 desktop layers; Layerize ~34% of the main thread scales with
+  // the count), so after the attention window the pulses are switched off via
+  // the .markers-settled class. Any overlay re-render re-arms the window.
+  private static readonly MARKER_SETTLE_MS = 6000;
   private static readonly LAYER_ZOOM_THRESHOLDS: Partial<
     Record<keyof MapLayers, { minZoom: number; showLabels?: number }>
   > = {
@@ -132,6 +138,7 @@ export class MapComponent {
   private svg: d3.Selection<SVGSVGElement, unknown, null, undefined>;
   private wrapper: HTMLElement;
   private overlays: HTMLElement;
+  private markerSettleTimer: ReturnType<typeof setTimeout> | null = null;
   private clusterCanvas: HTMLCanvasElement;
   private clusterGl: WebGLRenderingContext | null = null;
   private state: MapState;
@@ -348,6 +355,10 @@ export class MapComponent {
   public destroy(): void {
     this.destroyed = true;
     this.listenerAbort.abort();
+    if (this.markerSettleTimer !== null) {
+      clearTimeout(this.markerSettleTimer);
+      this.markerSettleTimer = null;
+    }
     window.removeEventListener('theme-changed', this.handleThemeChange);
     document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
     if (this.resizeObserver) {
@@ -3129,7 +3140,21 @@ export class MapComponent {
     } finally {
       this.overlayAppendTarget = previousTarget;
       this.overlays.appendChild(fragment);
+      this.armMarkerSettle();
     }
+  }
+
+  // #4669: let freshly-rendered markers pulse for the attention window, then
+  // add .markers-settled on the wrapper so main.css stops the infinite pulses
+  // and their compositing layers are released while the map is idle.
+  private armMarkerSettle(): void {
+    this.wrapper.classList.remove('markers-settled');
+    if (this.markerSettleTimer !== null) clearTimeout(this.markerSettleTimer);
+    this.markerSettleTimer = setTimeout(() => {
+      this.markerSettleTimer = null;
+      if (this.destroyed) return;
+      this.wrapper.classList.add('markers-settled');
+    }, MapComponent.MARKER_SETTLE_MS);
   }
 
   private renderConflictEventMarkers(projection: d3.GeoProjection): void {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -25870,3 +25870,37 @@ body.map-width-resizing {
   color: var(--settings-text);
   border-color: var(--settings-border-strong);
 }
+
+/* ============================================
+   Marker pulse settle (#4669)
+   Each infinite opacity pulse below holds a permanent compositing layer per
+   marker (385 of 517 desktop layers; Layerize main-thread cost scales with
+   the count). MapComponent adds .markers-settled to .map-wrapper after the
+   on-appearance attention window and removes it on every overlay re-render,
+   so markers still pulse when they appear or update but release their layers
+   at idle. Intentionally NOT settled: .cable-path:hover (animates only while
+   hovered) and .asset-highlight variants (user-intent single-asset highlight,
+   #4538). A guard test (tests/marker-pulse-settle.test.mjs) keeps this list
+   in sync with the pulses declared above.
+   ============================================ */
+.markers-settled .hotspot-marker.high,
+.markers-settled .hotspot-breaking,
+.markers-settled .breaking-tag,
+.markers-settled .cable-path.cable-health-fault,
+.markers-settled .cable-advisory-marker.fault,
+.markers-settled .protest-marker.high,
+.markers-settled .outage-marker.total,
+.markers-settled .conflict-zone,
+.markers-settled .iran-event-marker,
+.markers-settled .earthquake-marker,
+.markers-settled .nuclear-marker.active,
+.markers-settled .nuclear-marker.contested,
+.markers-settled .weather-marker.extreme .weather-icon,
+.markers-settled .flight-delay-marker.major,
+.markers-settled .flight-delay-marker.severe,
+.markers-settled .military-vessel-marker.dark-vessel,
+.markers-settled .military-vessel-marker.interesting,
+.markers-settled .dark-vessel-indicator,
+.markers-settled .tech-event-marker.upcoming-soon::after {
+  animation: none;
+}

--- a/tests/marker-pulse-settle.test.mjs
+++ b/tests/marker-pulse-settle.test.mjs
@@ -1,0 +1,121 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const css = readFileSync(resolve(repoRoot, 'src/styles/main.css'), 'utf8');
+const mapSrc = readFileSync(resolve(repoRoot, 'src/components/Map.ts'), 'utf8');
+
+// #4669: every map-scoped infinite pulse must stop once the map settles, so the
+// per-marker compositing layers are released (385 of 517 desktop layers were
+// held by these animations; Layerize scaled with the count). Markers still
+// pulse on appearance — MapComponent re-arms the settle window per render.
+const SETTLED_SELECTORS = [
+  '.hotspot-marker.high',
+  '.hotspot-breaking',
+  '.breaking-tag',
+  '.cable-path.cable-health-fault',
+  '.cable-advisory-marker.fault',
+  '.protest-marker.high',
+  '.outage-marker.total',
+  '.conflict-zone',
+  '.iran-event-marker',
+  '.earthquake-marker',
+  '.nuclear-marker.active',
+  '.nuclear-marker.contested',
+  '.weather-marker.extreme .weather-icon',
+  '.flight-delay-marker.major',
+  '.flight-delay-marker.severe',
+  '.military-vessel-marker.dark-vessel',
+  '.military-vessel-marker.interesting',
+  '.dark-vessel-indicator',
+  '.tech-event-marker.upcoming-soon::after',
+];
+
+// Map-scoped infinite animations that intentionally KEEP running after settle.
+const SETTLE_EXEMPT = [
+  '.cable-path:hover', // interaction-bounded: animates only while hovered
+  '.cable-path.asset-highlight', // user-intent single-asset highlight (#4538: don't demote genuine animation)
+  '.pipeline-path.asset-highlight',
+  '.asset-highlight',
+];
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Scan main.css: selector of every rule whose block declares an infinite animation.
+function infiniteAnimationSelectors() {
+  const selectors = [];
+  let current = '';
+  for (const line of css.split('\n')) {
+    if (/^[^\s@}].*\{/.test(line)) {
+      current = line.replace(/\s*\{.*$/, '').trim();
+    }
+    if (/animation:[^;]*\binfinite\b/.test(line)) {
+      selectors.push(current);
+    }
+  }
+  return selectors;
+}
+
+describe('marker pulse settle (#4669)', () => {
+  it('main.css settles every listed marker pulse under .markers-settled', () => {
+    for (const sel of SETTLED_SELECTORS) {
+      const settled = new RegExp(`\\.markers-settled ${escapeRegExp(sel)}`);
+      assert.match(
+        css,
+        settled,
+        `expected a ".markers-settled ${sel}" rule in src/styles/main.css — ` +
+          'every marker pulse must be released after the settle window',
+      );
+    }
+    const block = css.match(/\.markers-settled [^{]+\{([^}]+)\}/);
+    assert.ok(block, 'expected the .markers-settled rule block to exist');
+    assert.match(block[1], /animation:\s*none/, 'the settle block must set animation: none');
+  });
+
+  it('every map-scoped infinite pulse in main.css is either settled or exempt', () => {
+    const mapScoped = infiniteAnimationSelectors().filter((sel) =>
+      /marker|hotspot|conflict-zone|breaking-tag|dark-vessel|cable-path/i.test(sel),
+    );
+    assert.ok(mapScoped.length >= SETTLED_SELECTORS.length - 2, 'scan should find the marker pulses');
+    for (const sel of mapScoped) {
+      const parts = sel.split(',').map((s) => s.trim()).filter(Boolean);
+      for (const part of parts) {
+        const covered =
+          SETTLED_SELECTORS.includes(part) ||
+          SETTLE_EXEMPT.some((ex) => part === ex || part.endsWith(ex));
+        assert.ok(
+          covered,
+          `"${part}" declares an infinite animation but is neither in SETTLED_SELECTORS nor ` +
+            'SETTLE_EXEMPT — a new marker pulse must be added to the .markers-settled block ' +
+            '(and this test) or explicitly exempted with a reason (#4669)',
+        );
+      }
+    }
+  });
+
+  it('MapComponent arms the settle window on overlay renders', () => {
+    assert.match(mapSrc, /MARKER_SETTLE_MS/, 'Map.ts must define MARKER_SETTLE_MS');
+    assert.match(
+      mapSrc,
+      /classList\.remove\('markers-settled'\)/,
+      'renders must clear the settled state so fresh markers pulse',
+    );
+    assert.match(
+      mapSrc,
+      /classList\.add\('markers-settled'\)/,
+      'the settle timer must add the settled class',
+    );
+    assert.match(
+      mapSrc,
+      /armMarkerSettle\(\)/,
+      'renderOverlays must arm the marker settle window',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Map markers now pulse on appearance/update for a 6s attention window, then settle to static: `MapComponent` adds a `.markers-settled` class on the map wrapper once overlay renders go quiet, and a single CSS block turns off the ~19 infinite marker pulse animations. Any overlay re-render clears the class first, so new/updated markers still pulse — the win is idle and sustained-load compositing.

Mechanism per the issue's chosen direction (single-point overlay settle): one timer, one class, one CSS rule block — no per-animation edits, no changes to marker internals.

Intentionally NOT settled: `.cable-path:hover` (animates only while hovered) and the `.asset-highlight` variants (user-intent single-asset highlight, #4538). `tests/marker-pulse-settle.test.mjs` guards the list: any new map-scoped infinite pulse must be added to the settle block or explicitly exempted.

## Measured (local `vite preview`, scripts from #4668)

**Composited layers** (`measure-composited-layers.mjs`, `--settle 25000` so capture lands after the settle window; baseline is time-invariant — infinite pulses never release):

| | baseline | fixed |
|---|---|---|
| total layers | 313 | **34 (−89%)** |
| "active accelerated opacity animation" layers | 228 | **1** |
| nuclear-marker.active owners | 226 | 0 |
| overlap-promoted neighbors (decommissioned/construction) | 52 | 0 |

**Steady-state compositor cost** (CDP trace of a 20s post-settle window at 4× CPU throttle — the whole-load `measure-desktop-mainthread.mjs` trace is boot-dominated and its run-to-run variance (±2×, live feeds) drowns the signal; the issue's own framing is "the win is idle + sustained-load"):

| 20s window, cpu 4× | baseline | fixed (2 runs) |
|---|---|---|
| Layerize | 7,982ms | **4,147 / 3,752ms (−48/−53%)** |
| Commit | 1,861ms | 697 / 671ms (−63%) |
| PrePaint | 707ms | 435 / 443ms (−38%) |
| Layerize per event | 7.6ms | **3.5ms** |

Commit rate is unchanged (~60/s — other always-on UI animations drive it); each commit just layerizes 34 layers instead of 313.

**Behavior verified live** (Playwright probe): markers render at ~2s, boot data waves re-arm the window until ~8s, `.markers-settled` lands ~14s, `getComputedStyle(.nuclear-marker.active).animationName === 'none'` after settle; markers stay visible at base styles (pulses animate opacity 0.7–1 around a default-1 base).

## Notes

- `.breaking-tag` / `.hotspot-breaking` have no TS creation site (dead CSS) — settled anyway so they behave if revived.
- The settle window restarts on every overlay re-render by design (issue: "re-pulse on pan/data-update is fine"); under continuous sub-6s data churn markers keep pulsing — that state is the existing baseline behavior, not a regression.
- Sibling residual #4545 (mobile marker density caps) unchanged.

## Validation

- `tsx --test tests/marker-pulse-settle.test.mjs` (3 new guard tests)
- `npm run typecheck`
- before/after measurement runs above on local `vite preview` builds (`VITE_VARIANT=full`)

Fixes #4669.

https://claude.ai/code/session_01JJWff847w1wnfes5CqjDbu
