### PR TITLE
fix(intelligence): share the anon country-brief cache per country+lang — stop hashing caller context into the key

### DIFF
--- a/server/worldmonitor/intelligence/v1/_country-brief-context.ts
+++ b/server/worldmonitor/intelligence/v1/_country-brief-context.ts
@@ -1,0 +1,189 @@
+// Shared (anonymous-tier) grounding context for the country intel brief.
+//
+// Why this exists: the v3 cache key hashed the CALLER-supplied context
+// snapshot. Anonymous dashboard traffic rebuilds that snapshot from live
+// data, so every visitor minted a fresh key and the 6h TTL was illusory —
+// ~6.4k uncached LLM generations/day (#4892). Anonymous callers now share
+// one server-grounded cache entry per (country, lang, energy-year); the
+// caller-personalized path is reserved for premium requests, whose volume
+// is small and whose auth makes per-context keys affordable.
+//
+// The grounding assembly mirrors the MCP `get_country_brief` tool
+// (api/mcp/registry/rpc-tools.ts), which already built the same
+// "Brief source articles / Headlines" block from the news digest — the
+// server is simply the right place to do it once for everyone.
+
+import { getCachedJson } from '../../../_shared/redis';
+
+const DIGEST_KEY_EN = 'news:digest:v1:full:en';
+const MAX_GROUNDING_ITEMS = 15;
+const MAX_SOURCES = 6;
+const MAX_CONTEXT_CHARS = 4000;
+
+export interface SharedBriefSource {
+  title: string;
+  source: string;
+  url: string;
+  publishedAt: string;
+}
+
+export interface SharedCountryContext {
+  contextSnapshot: string;
+  sources: SharedBriefSource[];
+}
+
+const EMPTY_CONTEXT: SharedCountryContext = { contextSnapshot: '', sources: [] };
+
+export interface CountryIntelCacheKeyOpts {
+  countryCode: string;
+  lang: string;
+  isPremium: boolean;
+  /** 16-char sha prefix of the caller context, or 'base' when absent. Premium-only input. */
+  contextHash: string;
+  /** 8-char sha prefix of the premium framework, or ''. Premium-only input. */
+  frameworkHash: string;
+  /** OWID energy data-year, or '' when unavailable. */
+  energyYear: string;
+}
+
+export function deriveCountryIntelCacheKey(opts: CountryIntelCacheKeyOpts): string {
+  const energyTag = opts.energyYear ? `:e${opts.energyYear}` : '';
+  if (!opts.isPremium) {
+    // Anonymous tier: caller inputs must not reach the key, or the shared
+    // cache degenerates back into a per-caller one (and one caller's
+    // context could mint entries served to everyone).
+    return `ci-sebuf:v4:${opts.countryCode}:${opts.lang}:shared${energyTag}`;
+  }
+  const fw = opts.frameworkHash ? `:${opts.frameworkHash}` : '';
+  return `ci-sebuf:v4:${opts.countryCode}:${opts.lang}:${opts.contextHash}${fw}${energyTag}`;
+}
+
+interface DigestItemForBrief {
+  title?: unknown;
+  snippet?: unknown;
+  source?: unknown;
+  link?: unknown;
+  url?: unknown;
+  pubDate?: unknown;
+  publishedAt?: unknown;
+  date?: unknown;
+}
+
+// Local copy of chat-analyst-context's flattenDigest: importing that module
+// here would pull the whole analyst context assembly into this handler's
+// edge bundle for 15 lines of shape-tolerant flattening.
+function flattenDigest(digest: unknown): DigestItemForBrief[] {
+  if (!digest || typeof digest !== 'object') return [];
+  if (Array.isArray(digest)) return digest as DigestItemForBrief[];
+  const d = digest as Record<string, unknown>;
+  if (d.categories && typeof d.categories === 'object') {
+    const items: DigestItemForBrief[] = [];
+    for (const bucket of Object.values(d.categories as Record<string, unknown>)) {
+      const b = bucket as Record<string, unknown>;
+      if (Array.isArray(b.items)) items.push(...(b.items as DigestItemForBrief[]));
+    }
+    return items;
+  }
+  if (Array.isArray(d.items)) return d.items as DigestItemForBrief[];
+  return [];
+}
+
+function clipText(value: unknown, maxLen: number): string {
+  if (typeof value !== 'string') return '';
+  const text = value.replace(/\s+/g, ' ').trim();
+  return text.length > maxLen ? `${text.slice(0, maxLen - 1).trim()}...` : text;
+}
+
+function normalizeUrl(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : '';
+  } catch {
+    return '';
+  }
+}
+
+function normalizeDate(value: unknown): string {
+  if (typeof value !== 'string' && typeof value !== 'number') return '';
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : '';
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function includesCountryTerm(text: string, term: string): boolean {
+  const normalizedTerm = term.trim().toLowerCase();
+  if (!normalizedTerm) return false;
+  return new RegExp(`(^|[^a-z0-9])${escapeRegExp(normalizedTerm)}(?=$|[^a-z0-9])`, 'i').test(text);
+}
+
+export function countryBriefSearchTerms(countryCode: string): string[] {
+  const terms = [countryCode.toLowerCase()];
+  try {
+    const name = new Intl.DisplayNames(['en'], { type: 'region' }).of(countryCode);
+    if (name) terms.push(name.toLowerCase());
+  } catch {
+    /* Intl.DisplayNames can be missing in constrained runtimes. */
+  }
+  return [...new Set(terms.filter(Boolean))];
+}
+
+function collectBriefSources(items: DigestItemForBrief[], maxSources = MAX_SOURCES): SharedBriefSource[] {
+  const out: SharedBriefSource[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const url = normalizeUrl(item.link ?? item.url);
+    const title = clipText(item.title, 160);
+    const source = clipText(item.source, 80);
+    if (!url || !title || !source || seen.has(url)) continue;
+    out.push({ title, source, url, publishedAt: normalizeDate(item.publishedAt ?? item.pubDate ?? item.date) });
+    seen.add(url);
+    if (out.length >= maxSources) break;
+  }
+  return out;
+}
+
+function briefSourceContextLines(sources: SharedBriefSource[]): string[] {
+  return sources.map((source, index) => {
+    const payload: Record<string, string> = { title: source.title, source: source.source, url: source.url };
+    if (source.publishedAt) payload.publishedAt = source.publishedAt;
+    return `Source [${index + 1}]: ${JSON.stringify(payload)}`;
+  });
+}
+
+export function buildSharedCountryContext(digest: unknown, countryCode: string): SharedCountryContext {
+  const allItems = flattenDigest(digest).filter(
+    (item) => typeof item.title === 'string' && item.title.length > 0,
+  );
+  if (allItems.length === 0) return EMPTY_CONTEXT;
+
+  const terms = countryBriefSearchTerms(countryCode);
+  const countryItems = allItems.filter((item) => {
+    const text = `${typeof item.title === 'string' ? item.title : ''} ${typeof item.snippet === 'string' ? item.snippet : ''}`.toLowerCase();
+    return terms.some((term) => includesCountryTerm(text, term));
+  });
+
+  // No country match → ground on the top global items instead. A generic
+  // world-situation brief beats an empty prompt (mirrors the MCP tool).
+  const groundingItems = (countryItems.length > 0 ? countryItems : allItems).slice(0, MAX_GROUNDING_ITEMS);
+  const sources = collectBriefSources(groundingItems);
+  const sourceLines = sources.length > 0 ? ['Brief source articles:', ...briefSourceContextLines(sources)] : [];
+  const headlineLines = groundingItems
+    .map((item) => (typeof item.title === 'string' ? item.title : ''))
+    .filter(Boolean);
+  const contextSnapshot = [...sourceLines, 'Headlines:', ...headlineLines].join('\n').slice(0, MAX_CONTEXT_CHARS);
+  return { contextSnapshot, sources };
+}
+
+/** Read the shared digest and build country grounding. Failure → empty context (brief still generates). */
+export async function fetchSharedCountryContext(countryCode: string): Promise<SharedCountryContext> {
+  try {
+    const digest = await getCachedJson(DIGEST_KEY_EN, true);
+    return buildSharedCountryContext(digest, countryCode);
+  } catch {
+    return EMPTY_CONTEXT;
+  }
+}

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -11,8 +11,15 @@ import { callLlm } from '../../../_shared/llm';
 import { isCallerPremium } from '../../../_shared/premium-check';
 import { sanitizeForPrompt } from '../../../_shared/llm-sanitize.js';
 import { ENERGY_SPINE_KEY_PREFIX } from '../../../_shared/cache-keys';
+import { deriveCountryIntelCacheKey, fetchSharedCountryContext } from './_country-brief-context';
 
 const INTEL_CACHE_TTL = 21600;
+
+// Anonymous cache keys are minted from caller-controlled inputs, so both
+// dimensions must be bounded: ISO-2 country code and a well-formed BCP-47-ish
+// lang tag. Anything else gets the empty response / the 'en' brief.
+const COUNTRY_CODE_RE = /^[A-Za-z]{2}$/;
+const LANG_RE = /^[a-z]{2}(-[a-z]{2})?$/;
 
 function cleanSourceText(value: unknown, maxLen: number): string {
   if (typeof value !== 'string') return '';
@@ -91,25 +98,34 @@ export async function getCountryIntelBrief(
     sources,
   };
 
-  if (!req.countryCode) return empty;
+  if (!req.countryCode || !COUNTRY_CODE_RE.test(req.countryCode)) return empty;
 
+  const isPremium = await isCallerPremium(ctx.request);
+
+  // Caller-supplied context only personalizes premium requests. Anonymous
+  // briefs are grounded server-side (news digest) and share one cache entry
+  // per country+lang — hashing anon caller context into the key was the #4892
+  // cost bug (every dashboard visitor minted a fresh key), and folding anon
+  // caller text into a shared entry would let one caller shape everyone's brief.
   let contextSnapshot = '';
   let lang = 'en';
   try {
     const url = new URL(ctx.request.url);
-    // MCP sends `context` in the signed POST body; the gateway promotes scalar
-    // body fields into query params before this generated GET handler runs.
-    const rawContextSnapshot = (url.searchParams.get('context') || '').trim().slice(0, 4000);
-    sources = parseCountryBriefSources(rawContextSnapshot);
-    contextSnapshot = sanitizeForPrompt(rawContextSnapshot);
-    lang = url.searchParams.get('lang') || 'en';
+    const rawLang = (url.searchParams.get('lang') || 'en').toLowerCase();
+    lang = LANG_RE.test(rawLang) ? rawLang : 'en';
+    if (isPremium) {
+      // MCP sends `context` in the signed POST body; the gateway promotes scalar
+      // body fields into query params before this generated GET handler runs.
+      const rawContextSnapshot = (url.searchParams.get('context') || '').trim().slice(0, 4000);
+      sources = parseCountryBriefSources(rawContextSnapshot);
+      contextSnapshot = sanitizeForPrompt(rawContextSnapshot);
+    }
   } catch {
     contextSnapshot = '';
     sources = [];
   }
   empty.sources = sources;
 
-  const isPremium = await isCallerPremium(ctx.request);
   const frameworkRaw = isPremium && typeof req.framework === 'string' ? req.framework.slice(0, 2000) : '';
 
   // Fetch energy mix early so its data-year can be included in the cache key.
@@ -136,11 +152,15 @@ export async function getCountryIntelBrief(
     contextSnapshot ? sha256Hex(contextSnapshot) : Promise.resolve('base'),
     frameworkRaw    ? sha256Hex(frameworkRaw)    : Promise.resolve(''),
   ]);
-  const contextHash = contextSnapshot ? contextHashFull.slice(0, 16) : 'base';
-  const frameworkHash = frameworkRaw ? frameworkHashFull.slice(0, 8) : '';
-  const energyTag = energyYear ? `:e${energyYear}` : '';
-  const cacheKey = `ci-sebuf:v3:${req.countryCode}:${lang}:${contextHash}${frameworkHash ? `:${frameworkHash}` : ''}${energyTag}`;
-  const countryName = TIER1_COUNTRIES[req.countryCode] || req.countryCode;
+  const cacheKey = deriveCountryIntelCacheKey({
+    countryCode: req.countryCode.toUpperCase(),
+    lang,
+    isPremium,
+    contextHash: contextSnapshot ? contextHashFull.slice(0, 16) : 'base',
+    frameworkHash: frameworkRaw ? frameworkHashFull.slice(0, 8) : '',
+    energyYear,
+  });
+  const countryName = TIER1_COUNTRIES[req.countryCode.toUpperCase()] || req.countryCode;
   const dateStr = new Date().toISOString().split('T')[0];
 
   const systemPrompt = `You are a senior intelligence analyst. Current date: ${dateStr}.
@@ -177,24 +197,34 @@ Rules:
 - If "Brief source articles" are provided, cite supporting claims with bracket markers like [1] or [2]. Do not invent source numbers or URLs.
 - No speculation beyond what data supports.${lang === 'fr' ? '\n- IMPORTANT: You MUST respond ENTIRELY in French language.' : ''}`;
 
-  const userPromptParts = [`Country: ${countryName} (${req.countryCode})`];
-
-  if (energyMixData) {
-    const yr = energyYear || '';
-    userPromptParts.push(
-      `Energy generation mix (${yr}): coal ${energyMixData.coalShare ?? '?'}%, ` +
-      `gas ${energyMixData.gasShare ?? '?'}%, renewables ${energyMixData.renewShare ?? '?'}%, ` +
-      `nuclear ${energyMixData.nuclearShare ?? '?'}%, net import dependency ${energyMixData.importShare ?? '?'}%.`,
-    );
-  }
-
-  if (contextSnapshot) {
-    userPromptParts.push(`Context snapshot:\n${contextSnapshot}`);
-  }
-
   let result: GetCountryIntelBriefResponse | null = null;
   try {
     result = await cachedFetchJson<GetCountryIntelBriefResponse>(cacheKey, INTEL_CACHE_TTL, async () => {
+      // Grounding is resolved inside the fetcher so shared-path callers pay
+      // the digest read only on a cache miss (once per country+lang per TTL).
+      let promptContext = contextSnapshot;
+      let entrySources = sources;
+      if (!isPremium) {
+        const shared = await fetchSharedCountryContext(req.countryCode.toUpperCase());
+        promptContext = shared.contextSnapshot;
+        entrySources = shared.sources;
+      }
+
+      const userPromptParts = [`Country: ${countryName} (${req.countryCode})`];
+
+      if (energyMixData) {
+        const yr = energyYear || '';
+        userPromptParts.push(
+          `Energy generation mix (${yr}): coal ${energyMixData.coalShare ?? '?'}%, ` +
+          `gas ${energyMixData.gasShare ?? '?'}%, renewables ${energyMixData.renewShare ?? '?'}%, ` +
+          `nuclear ${energyMixData.nuclearShare ?? '?'}%, net import dependency ${energyMixData.importShare ?? '?'}%.`,
+        );
+      }
+
+      if (promptContext) {
+        userPromptParts.push(`Context snapshot:\n${promptContext}`);
+      }
+
       const llmResult = await callLlm({
         messages: [
           { role: 'system', content: systemPrompt },
@@ -214,7 +244,7 @@ Rules:
         brief: llmResult.content,
         model: llmResult.model,
         generatedAt: Date.now(),
-        sources,
+        sources: entrySources,
       };
     });
   } catch {
@@ -222,6 +252,11 @@ Rules:
   }
 
   if (!result) return empty;
+  if (!isPremium) {
+    // Shared entries carry server-derived sources; never backfill them with
+    // this caller's parsed context (the brief text didn't see it).
+    return { ...result, sources: Array.isArray(result.sources) ? result.sources : [] };
+  }
   return {
     ...result,
     sources: Array.isArray(result.sources) && result.sources.length > 0 ? result.sources : sources,

--- a/tests/country-intel-brief-cache-key.test.mjs
+++ b/tests/country-intel-brief-cache-key.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  deriveCountryIntelCacheKey,
+  buildSharedCountryContext,
+  countryBriefSearchTerms,
+  includesCountryTerm,
+} from '../server/worldmonitor/intelligence/v1/_country-brief-context.ts';
+
+describe('country intel brief cache key derivation', () => {
+  it('anon callers share one key per country+lang regardless of client context', () => {
+    const a = deriveCountryIntelCacheKey({
+      countryCode: 'FR', lang: 'en', isPremium: false,
+      contextHash: 'aaaaaaaaaaaaaaaa', frameworkHash: '', energyYear: '2024',
+    });
+    const b = deriveCountryIntelCacheKey({
+      countryCode: 'FR', lang: 'en', isPremium: false,
+      contextHash: 'bbbbbbbbbbbbbbbb', frameworkHash: '', energyYear: '2024',
+    });
+    assert.equal(a, b, 'anon key must not vary with client context');
+    assert.ok(a.startsWith('ci-sebuf:v4:FR:en:shared'), `anon key should use shared namespace, got ${a}`);
+  });
+
+  it('anon key ignores framework hash (framework is premium-only input)', () => {
+    const base = deriveCountryIntelCacheKey({
+      countryCode: 'FR', lang: 'en', isPremium: false,
+      contextHash: 'base', frameworkHash: '', energyYear: '',
+    });
+    const withFw = deriveCountryIntelCacheKey({
+      countryCode: 'FR', lang: 'en', isPremium: false,
+      contextHash: 'base', frameworkHash: 'deadbeef', energyYear: '',
+    });
+    assert.equal(base, withFw);
+  });
+
+  it('anon keys separate by country, lang, and energy data-year', () => {
+    const mk = (countryCode, lang, energyYear) => deriveCountryIntelCacheKey({
+      countryCode, lang, isPremium: false, contextHash: 'base', frameworkHash: '', energyYear,
+    });
+    assert.notEqual(mk('FR', 'en', '2024'), mk('DE', 'en', '2024'));
+    assert.notEqual(mk('FR', 'en', '2024'), mk('FR', 'fr', '2024'));
+    assert.notEqual(mk('FR', 'en', '2024'), mk('FR', 'en', '2023'));
+  });
+
+  it('premium callers keep per-context and per-framework keys', () => {
+    const mk = (contextHash, frameworkHash) => deriveCountryIntelCacheKey({
+      countryCode: 'FR', lang: 'en', isPremium: true, contextHash, frameworkHash, energyYear: '2024',
+    });
+    assert.notEqual(mk('aaaaaaaaaaaaaaaa', ''), mk('bbbbbbbbbbbbbbbb', ''), 'premium context must personalize the key');
+    assert.equal(mk('aaaaaaaaaaaaaaaa', ''), mk('aaaaaaaaaaaaaaaa', ''), 'same premium context must share the key');
+    assert.notEqual(mk('aaaaaaaaaaaaaaaa', 'deadbeef'), mk('aaaaaaaaaaaaaaaa', ''), 'framework must personalize the key');
+    assert.ok(mk('aaaaaaaaaaaaaaaa', '').startsWith('ci-sebuf:v4:FR:en:aaaaaaaaaaaaaaaa'));
+    assert.ok(!mk('aaaaaaaaaaaaaaaa', '').includes(':shared'));
+  });
+});
+
+describe('shared country context from the news digest', () => {
+  const digest = {
+    categories: {
+      politics: {
+        items: [
+          { title: 'France announces new energy plan', source: 'Reuters', link: 'https://example.com/fr-energy', pubDate: '2026-07-05T08:00:00.000Z' },
+          { title: 'Unrelated market rally continues', source: 'Bloomberg', link: 'https://example.com/markets' },
+        ],
+      },
+      conflict: {
+        items: [
+          { title: 'Strikes reported near France-Spain border corridor', source: 'AFP', link: 'https://example.com/border' },
+        ],
+      },
+    },
+  };
+
+  it('filters digest items to the country and emits source lines + headlines', () => {
+    const { contextSnapshot, sources } = buildSharedCountryContext(digest, 'FR');
+    assert.ok(contextSnapshot.includes('France announces new energy plan'));
+    assert.ok(contextSnapshot.includes('Source [1]:'), 'context should carry parseable source lines');
+    assert.ok(!contextSnapshot.includes('Unrelated market rally'), 'non-matching items should be excluded when matches exist');
+    assert.equal(sources.length, 2);
+    assert.equal(sources[0].url, 'https://example.com/fr-energy');
+    assert.equal(sources[0].publishedAt, '2026-07-05T08:00:00.000Z');
+  });
+
+  it('falls back to top digest items when nothing matches the country', () => {
+    const { contextSnapshot, sources } = buildSharedCountryContext(digest, 'JP');
+    assert.ok(contextSnapshot.includes('Headlines:'));
+    assert.ok(sources.length > 0, 'fallback grounding should still surface sources');
+  });
+
+  it('returns empty context for an empty or malformed digest', () => {
+    assert.deepEqual(buildSharedCountryContext(null, 'FR'), { contextSnapshot: '', sources: [] });
+    assert.deepEqual(buildSharedCountryContext({ nope: true }, 'FR'), { contextSnapshot: '', sources: [] });
+  });
+
+  it('caps the context snapshot at 4000 chars', () => {
+    const bigItems = Array.from({ length: 200 }, (_, i) => ({
+      title: `France update ${i} ${'x'.repeat(120)}`,
+      source: 'Wire',
+      link: `https://example.com/${i}`,
+    }));
+    const { contextSnapshot } = buildSharedCountryContext({ items: bigItems }, 'FR');
+    assert.ok(contextSnapshot.length <= 4000, `snapshot must stay bounded, got ${contextSnapshot.length}`);
+  });
+});
+
+describe('country term matching', () => {
+  it('derives code + display-name terms', () => {
+    const terms = countryBriefSearchTerms('FR');
+    assert.ok(terms.includes('fr'));
+    assert.ok(terms.includes('france'));
+  });
+
+  it('matches on word boundaries only', () => {
+    assert.equal(includesCountryTerm('france announces plan', 'france'), true);
+    assert.equal(includesCountryTerm('shipment from rotterdam', 'fr'), false, '"fr" inside "from" must not match');
+    assert.equal(includesCountryTerm('deal with fr counterpart', 'fr'), true);
+  });
+});

--- a/tests/helpers/premium-check-stub-true.ts
+++ b/tests/helpers/premium-check-stub-true.ts
@@ -1,0 +1,3 @@
+export async function isCallerPremium(): Promise<boolean> {
+  return true;
+}

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1081,15 +1081,19 @@ describe('theater posture caching behavior', { concurrency: 1 }, () => {
 });
 
 describe('country intel brief caching behavior', { concurrency: 1 }, () => {
-  async function importCountryIntelBrief() {
+  async function importCountryIntelBrief({ premium = false } = {}) {
     return importPatchedTsModule('server/worldmonitor/intelligence/v1/get-country-intel-brief.ts', {
       './_shared': resolve(root, 'server/worldmonitor/intelligence/v1/_shared.ts'),
+      './_country-brief-context': resolve(root, 'server/worldmonitor/intelligence/v1/_country-brief-context.ts'),
       '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
       '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
       '../../../_shared/llm-health': resolve(root, 'tests/helpers/llm-health-stub.ts'),
       '../../../_shared/llm': resolve(root, 'server/_shared/llm.ts'),
       '../../../_shared/hash': resolve(root, 'server/_shared/hash.ts'),
-      '../../../_shared/premium-check': resolve(root, 'tests/helpers/premium-check-stub.ts'),
+      '../../../_shared/premium-check': resolve(
+        root,
+        premium ? 'tests/helpers/premium-check-stub-true.ts' : 'tests/helpers/premium-check-stub.ts',
+      ),
       '../../../_shared/llm-sanitize.js': resolve(root, 'server/_shared/llm-sanitize.js'),
       '../../../_shared/cache-keys': resolve(root, 'server/_shared/cache-keys.ts'),
     });
@@ -1106,26 +1110,17 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
     return { request: new Request(url) };
   }
 
-  it('uses distinct cache keys for distinct context snapshots', async () => {
-    const { module, cleanup } = await importCountryIntelBrief();
-    const restoreEnv = withEnv({
-      GROQ_API_KEY: 'test-key',
-      UPSTASH_REDIS_REST_URL: 'https://redis.test',
-      UPSTASH_REDIS_REST_TOKEN: 'token',
-      VERCEL_ENV: undefined,
-      VERCEL_GIT_COMMIT_SHA: undefined,
-    });
-    const originalFetch = globalThis.fetch;
-
-    const store = new Map();
-    const setKeys = [];
-    const userPrompts = [];
-    let groqCalls = 0;
-
+  function installIntelFetchMock({ store, setKeys, userPrompts, counters }) {
     globalThis.fetch = async (url, init = {}) => {
       const raw = String(url);
       if (raw === 'https://api.groq.com') {
         return jsonResponse({});
+      }
+      if (raw.includes('api.groq.com/openai/v1/chat/completions')) {
+        counters.groqCalls += 1;
+        const body = JSON.parse(String(init.body || '{}'));
+        userPrompts.push(body.messages?.[1]?.content || '');
+        return jsonResponse({ choices: [{ message: { content: `brief-${counters.groqCalls}` } }] });
       }
       if (raw.includes('/get/')) {
         const key = parseRedisKey(raw, 'get');
@@ -1137,14 +1132,71 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
         if (!key.startsWith('seed-meta:')) setKeys.push(key);
         return jsonResponse({ result: 'OK' });
       }
-      if (raw.includes('api.groq.com/openai/v1/chat/completions')) {
-        groqCalls += 1;
-        const body = JSON.parse(String(init.body || '{}'));
-        userPrompts.push(body.messages?.[1]?.content || '');
-        return jsonResponse({ choices: [{ message: { content: `brief-${groqCalls}` } }] });
-      }
       throw new Error(`Unexpected fetch URL: ${raw}`);
     };
+  }
+
+  const INTEL_TEST_ENV = {
+    GROQ_API_KEY: 'test-key',
+    UPSTASH_REDIS_REST_URL: 'https://redis.test',
+    UPSTASH_REDIS_REST_TOKEN: 'token',
+    VERCEL_ENV: undefined,
+    VERCEL_GIT_COMMIT_SHA: undefined,
+  };
+
+  it('anon callers share one digest-grounded cache entry regardless of client context', async () => {
+    const { module, cleanup } = await importCountryIntelBrief();
+    const restoreEnv = withEnv(INTEL_TEST_ENV);
+    const originalFetch = globalThis.fetch;
+
+    const store = new Map();
+    store.set('news:digest:v1:full:en', JSON.stringify({
+      categories: {
+        conflict: {
+          items: [
+            { title: 'Israel announces new security framework', source: 'Reuters', link: 'https://example.com/il-1', pubDate: '2026-07-05T06:00:00.000Z' },
+            { title: 'Unrelated commodity report', source: 'Bloomberg', link: 'https://example.com/other' },
+          ],
+        },
+      },
+    }));
+    const setKeys = [];
+    const userPrompts = [];
+    const counters = { groqCalls: 0 };
+    installIntelFetchMock({ store, setKeys, userPrompts, counters });
+
+    try {
+      const req = { countryCode: 'IL' };
+      const alpha = await module.getCountryIntelBrief(makeCtx('https://example.com/api/intelligence/v1/get-country-intel-brief?country_code=IL&context=alpha'), req);
+      const beta = await module.getCountryIntelBrief(makeCtx('https://example.com/api/intelligence/v1/get-country-intel-brief?country_code=IL&context=beta'), req);
+
+      assert.equal(counters.groqCalls, 1, 'anon context variations must share one cache entry');
+      assert.equal(setKeys.length, 1, 'one shared cache write');
+      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v4:IL:en:shared'), `anon key should use the shared v4 namespace, got ${setKeys[0]}`);
+      assert.equal(alpha.brief, 'brief-1');
+      assert.equal(beta.brief, 'brief-1', 'second anon caller must be served from cache');
+      assert.ok(!userPrompts[0]?.includes('alpha'), 'anon caller context must not reach the prompt');
+      assert.match(userPrompts[0], /Israel announces new security framework/, 'prompt should be grounded on the server-side digest');
+      assert.ok(!userPrompts[0]?.includes('Unrelated commodity report'), 'digest grounding should be country-filtered');
+      assert.equal(alpha.sources[0]?.url, 'https://example.com/il-1', 'sources should be server-derived');
+      assert.deepEqual(beta.sources, alpha.sources, 'cached sources are shared');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('premium callers keep per-context personalized cache keys', async () => {
+    const { module, cleanup } = await importCountryIntelBrief({ premium: true });
+    const restoreEnv = withEnv(INTEL_TEST_ENV);
+    const originalFetch = globalThis.fetch;
+
+    const store = new Map();
+    const setKeys = [];
+    const userPrompts = [];
+    const counters = { groqCalls: 0 };
+    installIntelFetchMock({ store, setKeys, userPrompts, counters });
 
     try {
       const req = { countryCode: 'IL' };
@@ -1152,14 +1204,14 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
       const beta = await module.getCountryIntelBrief(makeCtx('https://example.com/api/intelligence/v1/get-country-intel-brief?country_code=IL&context=beta'), req);
       const alphaCached = await module.getCountryIntelBrief(makeCtx('https://example.com/api/intelligence/v1/get-country-intel-brief?country_code=IL&context=alpha'), req);
 
-      assert.equal(groqCalls, 2, 'different contexts should not share one cache entry');
-      assert.equal(setKeys.length, 2, 'one cache write per unique context');
-      assert.notEqual(setKeys[0], setKeys[1], 'context hash should differentiate cache keys');
-      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v3:IL:'), 'cache key should use v3 country-intel namespace');
-      assert.ok(setKeys[1]?.startsWith('ci-sebuf:v3:IL:'), 'cache key should use v3 country-intel namespace');
+      assert.equal(counters.groqCalls, 2, 'different premium contexts should not share one cache entry');
+      assert.equal(setKeys.length, 2, 'one cache write per unique premium context');
+      assert.notEqual(setKeys[0], setKeys[1], 'context hash should differentiate premium cache keys');
+      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v4:IL:'), 'cache key should use the v4 country-intel namespace');
+      assert.ok(!setKeys[0]?.includes(':shared'), 'premium keys must not use the shared namespace');
       assert.equal(alpha.brief, 'brief-1');
       assert.equal(beta.brief, 'brief-2');
-      assert.equal(alphaCached.brief, 'brief-1', 'same context should hit cache');
+      assert.equal(alphaCached.brief, 'brief-1', 'same premium context should hit cache');
       assert.match(userPrompts[0], /Context snapshot:\s*alpha/);
       assert.match(userPrompts[1], /Context snapshot:\s*beta/);
     } finally {
@@ -1214,10 +1266,10 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
       const first = await module.getCountryIntelBrief(makeCtx('https://example.com/api/intelligence/v1/get-country-intel-brief?country_code=US'), req);
       const second = await module.getCountryIntelBrief(makeCtx('https://example.com/api/intelligence/v1/get-country-intel-brief?country_code=US&context=%20%20%20'), req);
 
-      assert.equal(groqCalls, 1, 'blank context should reuse base cache entry');
+      assert.equal(groqCalls, 1, 'blank context should reuse the shared cache entry');
       assert.equal(setKeys.length, 1);
-      assert.ok(setKeys[0]?.endsWith(':base'), 'missing context should use :base cache suffix');
-      assert.ok(!userPrompts[0]?.includes('Context snapshot:'), 'prompt should omit context block when absent');
+      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v4:US:en:shared'), `anon callers land on the shared key, got ${setKeys[0]}`);
+      assert.ok(!userPrompts[0]?.includes('Context snapshot:'), 'prompt should omit context block when digest grounding is unavailable');
       assert.equal(first.brief, 'base-brief');
       assert.equal(second.brief, 'base-brief');
     } finally {


### PR DESCRIPTION
## Problem (#4892)

`get-country-intel-brief`'s cache key hashed the **caller-supplied context snapshot**. Anonymous dashboard traffic rebuilds that snapshot from live data, so every visitor minted a fresh key — the 6h TTL was illusory. Axiom (7d to 07-05): **~6,400 real LLM generations/day** (44.8k responses >1.5s, p95 ≈ 5s), ~100% anon; with Groq free-tier spillover landing on OpenRouter `gemini-2.5-flash` this was **~$6–8/day**, the dominant share of the ~$9.8/day key burn. MCP `get_country_brief` feeds the same handler with its own context — same flaw, unreachable by client-side gating.

## Fix — two-tier caching

- **Anonymous**: one shared entry per (country, lang, energy-year): `ci-sebuf:v4:<CC>:<lang>:shared[:eYYYY]`. Grounding is built **server-side from the news digest** (the exact assembly the MCP tool already did client-of-the-API-side: country-filtered items → `Brief source articles` + `Headlines`), inside the cache-miss fetcher so hits pay no digest read. Caller text can neither fragment the key nor shape the shared brief (cross-user injection is structurally off).
- **Premium**: unchanged semantics — caller context + framework personalize the key (volume is tiny and authenticated).
- Key-space bounding: ISO-2 `countryCode` validated, `lang` normalized/validated — both were previously interpolated raw into Redis keys by anonymous callers.

Worst-case anon LLM volume is now ~(active countries × langs × 4/day) instead of ~1 per dashboard visit.

## Tests

- New `tests/country-intel-brief-cache-key.test.mjs` (10 cases): anon key ignores context/framework; separates by country/lang/energy-year; premium keeps per-context+framework keys; digest grounding filters by country with word-boundary matching, falls back to top items, caps at 4000 chars.
- `tests/redis-caching.test.mjs`: the old "distinct keys per context" test **encoded the cost bug** (its premium stub returns false, i.e. it asserted anon fragmentation); rewritten as anon-shared + a new premium-path test (per-context keys preserved, via a `premium-check-stub-true` helper).
- Gates run locally: `typecheck:api` ✓, biome ✓, `docs-stats --check` ✓, scoped tsx tests 44/44 ✓.

## Notes

- v3→v4 prefix bump orphans old entries; they age out within the 6h TTL.
- Follow-up (not this PR): the MCP tool still fetches the digest to build context that the server now ignores for non-premium keys — that assembly can be dropped from `rpc-tools.ts` for a small latency win.
- #4893/#4894/#4895 (shadow-mode 2×, market-implications cache guard, LLM telemetry) ship separately.

Closes #4892

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih