### PR TITLE
perf(pwa): keep blog OG covers out of the dashboard SW precache (#4891)

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -168,6 +168,11 @@ describe('deploy/cache configuration guardrails', () => {
     assertGlobIgnore('pro/**');
     assertGlobIgnore('favico/**');
     assertGlobIgnore('textures/**');
+    // #4891: blog OG covers exist only in prod builds (blog generated at
+    // deploy), so a local dist/sw.js never exposes the regression — guard the
+    // config directly. Without this ignore, every first dashboard visit
+    // precached ~40 blog PNGs (~700KB) through the service worker.
+    assertGlobIgnore('blog/**');
   });
 
   it('keeps the lazy Clerk SDK out of the PWA precache', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -979,6 +979,12 @@ export default defineConfig(({ mode }) => {
             'pro/**',
             'favico/**',
             'textures/**',
+            // #4891: blog OG covers + post images are generated into the prod
+            // build (absent locally), and the png glob was precaching all ~40
+            // of them (~700KB) on every first dashboard visit — and again on
+            // each SW update after a blog deploy. Blog pages fetch their own
+            // images on demand; the dashboard never needs them.
+            'blog/**',
           ],
           // globe.gl + three.js grows main bundle past the 2 MiB default limit
           maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,


### PR DESCRIPTION
## Summary

One-line root-cause fix for #4891: add `blog/**` to the workbox `globIgnores` so the dashboard service worker stops precaching the blog's OG cover images.

## Root cause (not what the issue guessed)

The issue assumed news cards were rendering full-size OG images. The actual mechanism is the **service worker precache**: prod builds generate the blog (39 OG covers + post images, ~700KB) into the build output, and the `**/*.png` glob swept them into the SW install manifest. Every first-time dashboard visitor downloaded the entire blog cover catalog through the SW (the DebugBear waterfall's 39 sequential `fetch`es at ~80ms cadence in manifest order), and every blog deploy that regenerates covers re-downloaded them on SW update.

Verified against prod: `www.worldmonitor.app/sw.js` precaches exactly 39 `blog/og/*.png` + 1 `blog/images/*.png` — matching the waterfall byte-for-byte. Local builds never showed it because the blog is generated at deploy (no `public/blog` locally), which is also why the guard test asserts the config directly instead of the built `sw.js`.

## Verification

- Failing-test-first: `assertGlobIgnore('blog/**')` added to the existing off-page-precache guard in `tests/deploy-config.test.mjs` — red before the config change, green after (109 pass).
- End-to-end: planted a `public/blog/og/fake-post.png`, built — the file ships in `dist/blog/og/` (blog serving unaffected) and `dist/sw.js` contains **0** blog references.
- `npm run typecheck` clean.

## Impact

~700KB and 40 requests removed from every first dashboard visit and from every post-blog-deploy SW update, mobile included. The rss-proxy (401KB/20 calls) and bootstrap (553KB/7 calls) observations from #4891 are separate audits and stay open there.

Fixes #4891.

https://claude.ai/code/session_01JJWff847w1wnfes5CqjDbu
