### PR TITLE
perf(forecasts): input-hash cache guard for the market_implications LLM stage

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -16169,6 +16169,24 @@ function validateMarketImplications(cards, allowedTickers = ALL_ALLOWED_TICKERS)
 
 const MARKET_IMPLICATIONS_META_KEY = 'seed-meta:intelligence:market-implications';
 const MARKET_IMPLICATIONS_META_TTL = 86400 * 7;
+const MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX = 'forecast:llm-market-implications:';
+
+// Input-hash guard for the market_implications LLM stage (#4894). This was
+// the only forecast stage with no pre-call cache — a 2,500-token completion
+// regenerated every hourly run (plus every triggered re-run) even when the
+// world state hadn't moved. Numbers are quantized to ONE significant digit
+// before hashing: routine price ticks don't defeat the guard, while a
+// bucket-flipping move OR any text change (new signal, sector leadership,
+// theater alert) still regenerates. Percent-change fields — the semantically
+// load-bearing numbers — live in the 0.1–10 range where one significant
+// digit still separates 0.3% from 0.9% from 8%.
+function buildMarketImplicationsFingerprint(context) {
+  const quantized = String(context ?? '').replace(/-?\d+(?:\.\d+)?/g, (match) => {
+    const n = Number(match);
+    return Number.isFinite(n) && n !== 0 ? Number(n).toPrecision(1) : '0';
+  });
+  return crypto.createHash('sha256').update(quantized).digest('hex').slice(0, 16);
+}
 
 function marketImplicationsMetaErrorReason(reason) {
   return String(reason || 'unknown').replace(/\s+/g, ' ').slice(0, 240);
@@ -16204,6 +16222,26 @@ async function buildAndSeedMarketImplications(inputs) {
   const startMs = Date.now();
   console.log('  [MarketImplications] Building world-state context...');
   const context = buildMarketImplicationsContext(inputs);
+
+  const { url, token } = getRedisCredentials();
+
+  // Input-hash guard: unchanged world state → republish the cached cards
+  // (keeps the canonical key + seed-meta fresh) and skip the LLM entirely.
+  const fingerprint = buildMarketImplicationsFingerprint(context);
+  const stageCacheKey = `${MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX}${fingerprint}`;
+  try {
+    const cachedStage = await redisGet(url, token, stageCacheKey);
+    if (Array.isArray(cachedStage?.cards) && cachedStage.cards.length > 0) {
+      const payload = { cards: cachedStage.cards, generatedAt: new Date().toISOString(), model: cachedStage.model || '' };
+      await redisSet(url, token, MARKET_IMPLICATIONS_KEY, payload, MARKET_IMPLICATIONS_TTL);
+      const meta = { fetchedAt: Date.now(), recordCount: cachedStage.cards.length, status: 'ok' };
+      await redisSet(url, token, MARKET_IMPLICATIONS_META_KEY, meta, MARKET_IMPLICATIONS_META_TTL);
+      console.log(JSON.stringify({ event: 'llm_market_implications', cached: true, hash: fingerprint, count: cachedStage.cards.length }));
+      console.log(`  [MarketImplications] Republished ${cachedStage.cards.length} cached cards (inputs unchanged, ${Math.round(Date.now() - startMs)}ms)`);
+      return;
+    }
+  } catch { /* guard is best-effort — fall through to live generation */ }
+
   const userPrompt = `World state as of ${new Date().toISOString()}:\n\n${context}\n\nAllowed tickers: ${[...ALL_ALLOWED_TICKERS].join(', ')}`;
 
   const llmOptions = getForecastLlmCallOptions('market_implications');
@@ -16228,8 +16266,6 @@ async function buildAndSeedMarketImplications(inputs) {
     await writeMarketImplicationsFailureMeta('no_parseable_cards');
     return;
   }
-
-  const { url, token } = getRedisCredentials();
 
   // Extend the curated static allowlist with tradeable equity symbols from Redis.
   // ALL_ALLOWED_TICKERS is always preserved (ETFs, defense, commodities, forex, rates, crypto).
@@ -16265,6 +16301,10 @@ async function buildAndSeedMarketImplications(inputs) {
 
   const meta = { fetchedAt: Date.now(), recordCount: cards.length, status: 'ok' };
   await redisSet(url, token, MARKET_IMPLICATIONS_META_KEY, meta, MARKET_IMPLICATIONS_META_TTL);
+
+  // Only validated live generations feed the input-hash guard; failures above
+  // returned early so a bad run can never pin bad cards for the TTL.
+  await redisSet(url, token, stageCacheKey, { cards, model: result.model || '' }, MARKET_IMPLICATIONS_TTL);
 
   const durationMs = Date.now() - startMs;
   console.log(`  [MarketImplications] Published ${cards.length} cards to ${MARKET_IMPLICATIONS_KEY} (${Math.round(durationMs)}ms, model=${result.model || 'unknown'})`);
@@ -17702,4 +17742,6 @@ export {
   __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,
   __setRedisStoreForTests,
+  buildMarketImplicationsFingerprint,
+  buildAndSeedMarketImplications,
 };

--- a/tests/market-implications-cache-guard.test.mjs
+++ b/tests/market-implications-cache-guard.test.mjs
@@ -1,0 +1,89 @@
+// market_implications input-hash cache guard (#4894).
+//
+// Before this guard, buildAndSeedMarketImplications was the ONLY forecast LLM
+// stage with no pre-call cache: it regenerated a 2,500-token completion every
+// hourly run (plus every triggered re-run) even when the world-state inputs
+// had not moved. The guard fingerprints the built context (numbers quantized
+// to 2 significant digits so routine price ticks don't defeat it) and
+// republishes the cached cards on a hit.
+
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildMarketImplicationsFingerprint,
+  buildAndSeedMarketImplications,
+  __setRedisStoreForTests,
+} from '../scripts/seed-forecasts.mjs';
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  __setRedisStoreForTests(null);
+});
+
+test('fingerprint is stable across routine price ticks', () => {
+  const a = buildMarketImplicationsFingerprint('[COMMODITIES]\nWTI Crude: 87.42 (+1.27%)\n[EQUITIES]\nSPX: 4512.34 (+0.31%)');
+  const b = buildMarketImplicationsFingerprint('[COMMODITIES]\nWTI Crude: 87.61 (+1.29%)\n[EQUITIES]\nSPX: 4515.10 (+0.33%)');
+  assert.equal(a, b, 'sub-precision price moves must not change the fingerprint');
+});
+
+test('fingerprint changes on a material price move', () => {
+  const a = buildMarketImplicationsFingerprint('[COMMODITIES]\nWTI Crude: 87.42 (+1.2%)');
+  const b = buildMarketImplicationsFingerprint('[COMMODITIES]\nWTI Crude: 95.10 (+9.8%)');
+  assert.notEqual(a, b);
+});
+
+test('fingerprint changes when signal text changes', () => {
+  const a = buildMarketImplicationsFingerprint('[CRITICAL INTELLIGENCE SIGNALS]\n- Red Sea shipping disruption strength=80%');
+  const b = buildMarketImplicationsFingerprint('[CRITICAL INTELLIGENCE SIGNALS]\n- Hormuz transit closure strength=80%');
+  assert.notEqual(a, b);
+});
+
+test('cache hit republishes cached cards without any LLM fetch', async () => {
+  const cards = [{
+    ticker: 'LMT', name: 'Lockheed Martin', direction: 'long', timeframe: '1-3m',
+    confidence: 0.7, title: 'Defense demand', narrative: 'n', risk_caveat: '', driver: '', transmission_chain: [],
+  }];
+  const store = {};
+  __setRedisStoreForTests(store);
+
+  // Seed the stage cache under the fingerprint the run will derive.
+  // Empty inputs make buildMarketImplicationsContext return this literal.
+  const inputs = {};
+  const fingerprint = buildMarketImplicationsFingerprint('No live world state available.');
+  store[`forecast:llm-market-implications:${fingerprint}`] = { cards, model: 'cached-model' };
+
+  let fetchCalls = 0;
+  global.fetch = async (url) => {
+    fetchCalls += 1;
+    throw new Error(`unexpected fetch on cache hit: ${url}`);
+  };
+
+  await buildAndSeedMarketImplications(inputs);
+
+  assert.equal(fetchCalls, 0, 'cache hit must not reach any provider');
+  const published = store['intelligence:market-implications:v1'];
+  assert.ok(published, 'canonical cards key must be republished on cache hit');
+  assert.deepEqual(published.cards, cards);
+  assert.equal(published.model, 'cached-model');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.ok(meta, 'seed meta must stay green on cache hit');
+  assert.equal(meta.status, 'ok');
+  assert.equal(meta.recordCount, 1);
+});
+
+test('cache miss with no provider writes error meta and no stage cache entry', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  global.fetch = async () => { throw new Error('no providers in test'); };
+
+  await buildAndSeedMarketImplications({});
+
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.ok(meta, 'failure meta must be written');
+  assert.equal(meta.status, 'error');
+  assert.ok(
+    !Object.keys(store).some((k) => k.startsWith('forecast:llm-market-implications:')),
+    'no stage cache entry may be written on failure',
+  );
+});


### PR DESCRIPTION
## Problem (#4894)

`buildAndSeedMarketImplications` was the only forecast LLM stage with no pre-call cache — it ran unconditionally in `afterPublish` on every hourly cron run **and** every triggered re-run (`[Trigger] source=military_chain ...`), a 2,500-max-token `gemini-2.5-flash` completion (~13–14s observed) regardless of whether the world-state inputs moved. Every other stage (combined, scenario, critical_signals) already checks a content-hash Redis cache first.

## Fix

- `buildMarketImplicationsFingerprint(context)`: sha256 of the built context with numeric tokens quantized to **one significant digit** — routine price ticks don't defeat the guard, while a bucket-flipping move or any text change (new critical signal, sector rotation, theater alert) regenerates. Percent-change fields (the semantically load-bearing numbers) live in the 0.1–10 range where one significant digit still separates 0.3% / 0.9% / 8%.
- Cache hit → republish the cached **validated** cards (fresh `generatedAt`, canonical key + seed-meta rewritten) so the health/freshness machinery stays green with zero LLM cost.
- Only validated live generations write the guard entry (failures return early above it) — a bad run can never pin bad cards for the TTL (180 min, matched to the canonical cards' lifetime).

Expected effect: weekend/quiet-hour runs and triggered re-runs skip entirely; ~24 unconditional calls/day drop to roughly the number of genuine world-state changes.

## Tests

New `tests/market-implications-cache-guard.test.mjs` (5 cases) using the module's existing `__setRedisStoreForTests` hook: fingerprint stability across sub-bucket ticks, sensitivity to material moves and signal-text changes, cache-hit republish with **zero** provider fetches, and failure paths writing error meta without polluting the guard.

Forecast regression suites (`forecast-seed-resilience`, `forecast-detectors`, `forecasts-ticker-set-envelope-unwrap`, `forecast-history`, `forecast-trace-export`): 519/519 ✓. Biome ✓.

Closes #4894

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih