### PR TITLE
feat(observability): emit llm_call usage events from every server-side LLM path

### DIFF
--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -203,6 +203,7 @@ export default async function handler(req: Request): Promise<Response> {
       temperature: 0.35,
       timeoutMs: 25_000,
       signal: req.signal,
+      stage: 'chat-analyst',
     });
 
     // Always prepend a meta event so the client knows which sources are live

--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -234,6 +234,7 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
       maxTokens: 260,
       temperature: 0.4,
       timeoutMs: 15_000,
+      stage: 'brief-why-matters-analyst',
       // Provider is pinned via LLM_REASONING_PROVIDER env var (already
       // set to 'openrouter' in prod). `callLlmReasoning` routes through
       // the resolveProviderChain based on that env.
@@ -271,6 +272,7 @@ async function runGeminiPath(story: StoryPayload): Promise<string | null> {
       maxTokens: 120,
       temperature: 0.4,
       timeoutMs: 10_000,
+      stage: 'brief-why-matters-gemini',
       // Note: no `validate` option. The post-call parseWhyMatters check
       // below handles rejection by returning null. Using validate inside
       // callLlmReasoning would walk the provider chain on parse-reject,

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -1,6 +1,22 @@
 import { CHROME_UA } from './constants';
 import { isProviderAvailable } from './llm-health';
 import { sanitizeForPrompt } from './llm-sanitize.js';
+import { buildLlmCallEvent, deliverUsageEvents, type LlmCallEvent } from './usage';
+
+function promptChars(messages: Array<{ role: string; content: string }>): number {
+  return messages.reduce((sum, m) => sum + (m.content?.length ?? 0), 0);
+}
+
+// Best-effort, awaited: one POST per logical call (all provider attempts
+// batched). deliverUsageEvents no-ops unless USAGE_TELEMETRY=1; awaiting a
+// ≤1.5s-bounded telemetry write is noise next to a multi-second completion
+// and survives Edge isolate teardown (no dangling promise).
+async function flushLlmEvents(events: LlmCallEvent[]): Promise<void> {
+  if (events.length === 0) return;
+  try {
+    await deliverUsageEvents(events);
+  } catch { /* telemetry must never affect the call result */ }
+}
 
 export interface ProviderCredentials {
   apiUrl: string;
@@ -141,6 +157,8 @@ export interface LlmCallOptions {
   validate?: (content: string) => boolean;
   /** Optional text to append to the system message (index 0). Appended as \n\n---\n\n<systemAppend>. No-op if no system message at index 0. */
   systemAppend?: string;
+  /** Caller surface tag for llm_call usage telemetry (e.g. 'classify-event'). */
+  stage?: string;
 }
 
 export interface LlmCallResult {
@@ -242,6 +260,10 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
   const enc = new TextEncoder();
   let activeController: AbortController | null = null;
   let streamClosed = false;
+  const stage = opts.stage || 'unknown';
+  const inputChars = promptChars(messages);
+  const events: LlmCallEvent[] = [];
+  let attemptIndex = 0;
 
   return new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -253,6 +275,13 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
         if (streamClosed) return;
         streamClosed = true;
         controller.close();
+      };
+      // Flush AFTER the stream is closed so telemetry latency never delays
+      // the client's terminal event. Token counts are unavailable on the SSE
+      // path — prompt_chars + duration still attribute the spend surface.
+      const closeAndFlush = async () => {
+        closeStream();
+        await flushLlmEvents(events);
       };
 
       for (const providerName of providerOrder) {
@@ -273,6 +302,23 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
         const timeoutId = setTimeout(() => activeController?.abort(), timeoutMs);
         if (clientSignal?.aborted) { clearTimeout(timeoutId); break; }
         clientSignal?.addEventListener('abort', () => activeController?.abort(), { once: true });
+
+        const t0 = Date.now();
+        const fallbackIndex = attemptIndex;
+        attemptIndex += 1;
+        const record = (ok: boolean, reason = '') => {
+          events.push(buildLlmCallEvent({
+            provider: providerName,
+            model: creds.model,
+            stage,
+            ok,
+            durationMs: Date.now() - t0,
+            promptChars: inputChars,
+            maxTokens,
+            fallbackIndex,
+            reason,
+          }));
+        };
 
         let hasContent = false;
         try {
@@ -295,6 +341,7 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
             clearTimeout(timeoutId);
             const errBody = resp.body ? await resp.text().catch(() => '') : '';
             console.warn(`[llm-stream:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody.slice(0, 300)}`);
+            record(false, `http_${resp.status}`);
             continue;
           }
 
@@ -328,26 +375,31 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
           clearTimeout(timeoutId);
 
           if (hasContent) {
+            record(true);
             emit({ done: true });
-            closeStream();
+            await closeAndFlush();
             return;
           }
+          record(false, 'empty');
         } catch (err) {
           clearTimeout(timeoutId);
           if (hasContent) {
             // Partial stream — close without done so the client sees it as truncated, not success
-            closeStream();
+            record(false, 'truncated');
+            await closeAndFlush();
             return;
           }
-          if (streamClosed) return;
+          if (streamClosed) { await flushLlmEvents(events); return; }
           console.warn(`[llm-stream:${providerName}] ${(err as Error).message}`);
+          const name = (err as Error).name;
+          record(false, name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'fetch_error');
         }
       }
 
       if (!streamClosed) {
         emit({ error: 'llm_unavailable' });
-        closeStream();
       }
+      await closeAndFlush();
     },
     cancel() {
       // Client disconnected — abort the active provider fetch immediately
@@ -384,79 +436,118 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
   }
 
   const providers = resolveProviderChain({ forcedProvider, providerOrder });
+  const stage = opts.stage || 'unknown';
+  const inputChars = promptChars(messages);
+  const events: LlmCallEvent[] = [];
+  let attemptIndex = 0;
 
-  for (const providerName of providers) {
-    const creds = getProviderCredentials(providerName, {
-      model: modelOverrides?.[providerName as LlmProviderName],
-    });
-    if (!creds) {
-      if (forcedProvider) return null;
-      continue;
-    }
-
-    // Health gate: skip provider if endpoint is unreachable
-    if (!(await isProviderAvailable(creds.apiUrl))) {
-      console.warn(`[llm:${providerName}] Offline, skipping`);
-      if (forcedProvider) return null;
-      continue;
-    }
-
-    try {
-      const resp = await fetch(creds.apiUrl, {
-        method: 'POST',
-        headers: { ...creds.headers, 'User-Agent': CHROME_UA },
-        body: JSON.stringify({
-          ...creds.extraBody,
-          model: creds.model,
-          messages,
-          temperature,
-          max_tokens: maxTokens,
-        }),
-        signal: AbortSignal.timeout(timeoutMs),
+  try {
+    for (const providerName of providers) {
+      const creds = getProviderCredentials(providerName, {
+        model: modelOverrides?.[providerName as LlmProviderName],
       });
-
-      if (!resp.ok) {
-        console.warn(`[llm:${providerName}] HTTP ${resp.status}`);
+      if (!creds) {
         if (forcedProvider) return null;
         continue;
       }
 
-      const data = (await resp.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
-        usage?: { total_tokens?: number };
+      // Health gate: skip provider if endpoint is unreachable
+      if (!(await isProviderAvailable(creds.apiUrl))) {
+        console.warn(`[llm:${providerName}] Offline, skipping`);
+        if (forcedProvider) return null;
+        continue;
+      }
+
+      // Skipped providers (no creds / offline) never sent the prompt, so
+      // only real attempts get an event and advance the fallback index.
+      const t0 = Date.now();
+      const fallbackIndex = attemptIndex;
+      attemptIndex += 1;
+      const record = (ok: boolean, extra: { reason?: string; tokensTotal?: number; tokensPrompt?: number; tokensCompletion?: number } = {}) => {
+        events.push(buildLlmCallEvent({
+          provider: providerName,
+          model: creds.model,
+          stage,
+          ok,
+          durationMs: Date.now() - t0,
+          promptChars: inputChars,
+          maxTokens,
+          fallbackIndex,
+          ...extra,
+        }));
       };
 
-      let content = data.choices?.[0]?.message?.content?.trim() || '';
-      if (!content) {
-        if (forcedProvider) return null;
-        continue;
-      }
+      try {
+        const resp = await fetch(creds.apiUrl, {
+          method: 'POST',
+          headers: { ...creds.headers, 'User-Agent': CHROME_UA },
+          body: JSON.stringify({
+            ...creds.extraBody,
+            model: creds.model,
+            messages,
+            temperature,
+            max_tokens: maxTokens,
+          }),
+          signal: AbortSignal.timeout(timeoutMs),
+        });
 
-      const tokens = data.usage?.total_tokens ?? 0;
-
-      if (shouldStrip) {
-        content = stripThinkingTags(content);
-        if (!content) {
+        if (!resp.ok) {
+          console.warn(`[llm:${providerName}] HTTP ${resp.status}`);
+          record(false, { reason: `http_${resp.status}` });
           if (forcedProvider) return null;
           continue;
         }
-      }
 
-      // Strip markdown code fences (e.g. ```json ... ```) that some models add
-      content = content.replace(/^```(?:\w+)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+        const data = (await resp.json()) as {
+          choices?: Array<{ message?: { content?: string } }>;
+          usage?: { total_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
+        };
+        const tokensExtra = {
+          tokensTotal: data.usage?.total_tokens ?? 0,
+          tokensPrompt: data.usage?.prompt_tokens ?? 0,
+          tokensCompletion: data.usage?.completion_tokens ?? 0,
+        };
 
-      if (validate && !validate(content)) {
-        console.warn(`[llm:${providerName}] validate() rejected response, trying next`);
+        let content = data.choices?.[0]?.message?.content?.trim() || '';
+        if (!content) {
+          record(false, { ...tokensExtra, reason: 'empty' });
+          if (forcedProvider) return null;
+          continue;
+        }
+
+        const tokens = data.usage?.total_tokens ?? 0;
+
+        if (shouldStrip) {
+          content = stripThinkingTags(content);
+          if (!content) {
+            record(false, { ...tokensExtra, reason: 'stripped_empty' });
+            if (forcedProvider) return null;
+            continue;
+          }
+        }
+
+        // Strip markdown code fences (e.g. ```json ... ```) that some models add
+        content = content.replace(/^```(?:\w+)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+
+        if (validate && !validate(content)) {
+          console.warn(`[llm:${providerName}] validate() rejected response, trying next`);
+          record(false, { ...tokensExtra, reason: 'validate_reject' });
+          if (forcedProvider) return null;
+          continue;
+        }
+
+        record(true, tokensExtra);
+        return { content, model: creds.model, provider: providerName, tokens };
+      } catch (err) {
+        const name = (err as Error).name;
+        console.warn(`[llm:${providerName}] ${(err as Error).message}`);
+        record(false, { reason: name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'fetch_error' });
         if (forcedProvider) return null;
-        continue;
       }
-
-      return { content, model: creds.model, provider: providerName, tokens };
-    } catch (err) {
-      console.warn(`[llm:${providerName}] ${(err as Error).message}`);
-      if (forcedProvider) return null;
     }
-  }
 
-  return null;
+    return null;
+  } finally {
+    await flushLlmEvents(events);
+  }
 }

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -151,9 +151,65 @@ export interface UpstreamEvent {
   cache_status: CacheStatus;
 }
 
-export type UsageEvent = RequestEvent | UpstreamEvent;
+// #4895 — per-completion LLM spend attribution. One event per PROVIDER
+// ATTEMPT (not per logical call): a fallback chain that re-sends the prompt
+// shows up as fallback_index 0..n, making retry amplification queryable.
+export interface LlmCallEvent {
+  _time: string;
+  event_type: 'llm_call';
+  provider: string;
+  model: string;
+  /** Caller surface tag, e.g. 'classify-event', 'country-intel-brief'. 'unknown' when untagged. */
+  stage: string;
+  ok: boolean;
+  duration_ms: number;
+  tokens_total: number;
+  tokens_prompt: number;
+  tokens_completion: number;
+  /** Input size in characters — recorded even when the provider omits usage. */
+  prompt_chars: number;
+  max_tokens: number;
+  /** 0 = first provider attempted; 1+ = fallbacks (each re-sends the full prompt). */
+  fallback_index: number;
+  /** '' on success; 'http_<status>' | 'timeout' | 'fetch_error' | 'empty' | 'stripped_empty' | 'validate_reject'. */
+  reason: string;
+}
+
+export type UsageEvent = RequestEvent | UpstreamEvent | LlmCallEvent;
 
 // ---------- Builders (allowlisted primitives only) ----------
+
+export function buildLlmCallEvent(p: {
+  provider: string;
+  model: string;
+  stage: string;
+  ok: boolean;
+  durationMs: number;
+  tokensTotal?: number;
+  tokensPrompt?: number;
+  tokensCompletion?: number;
+  promptChars: number;
+  maxTokens: number;
+  fallbackIndex: number;
+  reason?: string;
+}): LlmCallEvent {
+  return {
+    _time: new Date().toISOString(),
+    event_type: 'llm_call',
+    provider: p.provider,
+    model: p.model,
+    stage: p.stage,
+    ok: p.ok,
+    duration_ms: Math.round(p.durationMs),
+    tokens_total: p.tokensTotal ?? 0,
+    tokens_prompt: p.tokensPrompt ?? 0,
+    tokens_completion: p.tokensCompletion ?? 0,
+    prompt_chars: p.promptChars,
+    max_tokens: p.maxTokens,
+    fallback_index: p.fallbackIndex,
+    reason: p.reason ?? '',
+  };
+}
 
 export function buildRequestEvent(p: {
   requestId: string;

--- a/server/worldmonitor/intelligence/v1/classify-event.ts
+++ b/server/worldmonitor/intelligence/v1/classify-event.ts
@@ -88,6 +88,7 @@ Return: {"level":"...","category":"..."}`;
           temperature: 0,
           maxTokens: 50,
           timeoutMs: UPSTREAM_TIMEOUT_MS,
+          stage: 'classify-event',
           validate: (content) => {
             try {
               let parsed: { level?: string; category?: string };

--- a/server/worldmonitor/intelligence/v1/deduct-situation.ts
+++ b/server/worldmonitor/intelligence/v1/deduct-situation.ts
@@ -123,6 +123,7 @@ export async function deductSituation(
                 temperature: 0.3,
                 maxTokens: 1500,
                 timeoutMs: DEDUCT_TIMEOUT_MS,
+                stage: 'deduct-situation',
                 systemAppend: framework || undefined,
             });
 

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -234,6 +234,7 @@ Rules:
         maxTokens: 1100,
         timeoutMs: UPSTREAM_TIMEOUT_MS,
         systemAppend: frameworkRaw || undefined,
+        stage: 'country-intel-brief',
       });
 
       if (!llmResult) return null;

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -1015,6 +1015,7 @@ async function buildAiOverlay(
     temperature: 0.2,
     maxTokens: 500,
     timeoutMs: 20_000,
+    stage: 'analyze-stock',
     providerOrder: ['openrouter', 'generic'],
     validate: (content) => {
       try {

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -16,6 +16,32 @@ import { isProviderAvailable } from '../../../_shared/llm-health';
 import { sanitizeHeadlinesLight, sanitizeHeadlines, sanitizeForPrompt } from '../../../_shared/llm-sanitize.js';
 import { isCallerPremium } from '../../../_shared/premium-check';
 import { stripThinkingTags } from '../../../_shared/llm';
+import { buildLlmCallEvent, deliverUsageEvents } from '../../../_shared/usage';
+
+// Best-effort llm_call telemetry (#4895). This handler bypasses callLlm (the
+// client picks the provider), so it emits its own events.
+async function emitSummarizeLlmEvent(p: {
+  provider: string; model: string; ok: boolean; durationMs: number;
+  promptChars: number; usage?: { total_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
+  reason?: string;
+}): Promise<void> {
+  try {
+    await deliverUsageEvents([buildLlmCallEvent({
+      provider: p.provider,
+      model: p.model,
+      stage: 'summarize-article',
+      ok: p.ok,
+      durationMs: p.durationMs,
+      tokensTotal: p.usage?.total_tokens ?? 0,
+      tokensPrompt: p.usage?.prompt_tokens ?? 0,
+      tokensCompletion: p.usage?.completion_tokens ?? 0,
+      promptChars: p.promptChars,
+      maxTokens: 100,
+      fallbackIndex: 0,
+      reason: p.reason,
+    })]);
+  } catch { /* telemetry must never affect the summary */ }
+}
 
 // ======================================================================
 // Reasoning preamble detection
@@ -178,6 +204,8 @@ export async function summarizeArticle(
           ? `${systemPrompt}\n\n---\n\n${sanitizedAppend}`
           : systemPrompt;
 
+        const llmStartMs = Date.now();
+        const llmPromptChars = effectiveSystemPrompt.length + userPrompt.length;
         const response = await fetch(apiUrl, {
           method: 'POST',
           headers: { ...providerHeaders, 'User-Agent': CHROME_UA },
@@ -198,25 +226,30 @@ export async function summarizeArticle(
         if (!response.ok) {
           const errorText = await response.text();
           console.error(`[SummarizeArticle:${provider}] API error:`, response.status, errorText);
+          await emitSummarizeLlmEvent({ provider, model, ok: false, durationMs: Date.now() - llmStartMs, promptChars: llmPromptChars, reason: `http_${response.status}` });
           throw new Error(response.status === 429 ? 'Rate limited' : `${provider} API error`);
         }
 
         const data = await response.json() as any;
         const tokens = (data.usage?.total_tokens as number) || 0;
+        const usage = data.usage as { total_tokens?: number; prompt_tokens?: number; completion_tokens?: number } | undefined;
         const message = data.choices?.[0]?.message;
         const rawText = typeof message?.content === 'string' ? message.content.trim() : '';
         const rawContent = stripThinkingTags(rawText);
 
         if (['brief', 'analysis'].includes(mode) && rawContent.length < 20) {
           console.warn(`[SummarizeArticle:${provider}] Output too short after stripping (${rawContent.length} chars), rejecting`);
+          await emitSummarizeLlmEvent({ provider, model, ok: false, durationMs: Date.now() - llmStartMs, promptChars: llmPromptChars, usage, reason: 'stripped_empty' });
           return null;
         }
 
         if (['brief', 'analysis'].includes(mode) && hasReasoningPreamble(rawContent)) {
           console.warn(`[SummarizeArticle:${provider}] Reasoning preamble detected, rejecting`);
+          await emitSummarizeLlmEvent({ provider, model, ok: false, durationMs: Date.now() - llmStartMs, promptChars: llmPromptChars, usage, reason: 'validate_reject' });
           return null;
         }
 
+        await emitSummarizeLlmEvent({ provider, model, ok: Boolean(rawContent), durationMs: Date.now() - llmStartMs, promptChars: llmPromptChars, usage, reason: rawContent ? '' : 'empty' });
         return rawContent ? { summary: rawContent, model, tokens } : null;
       },
     );

--- a/tests/llm-usage-telemetry.test.mts
+++ b/tests/llm-usage-telemetry.test.mts
@@ -1,0 +1,154 @@
+// LLM usage telemetry (#4895): every callLlm provider attempt emits an
+// `llm_call` event (provider, model, stage, tokens, duration, fallback index)
+// through the existing wm_api_usage Axiom pipeline. Before this, llm.ts
+// returned `tokens` and nobody recorded it — spend attribution required
+// forensic duration_ms inference.
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { callLlm } from '../server/_shared/llm.ts';
+
+const ENV_KEYS = [
+  'GROQ_API_KEY', 'OPENROUTER_API_KEY', 'OLLAMA_API_URL', 'LLM_API_URL', 'LLM_API_KEY',
+  'USAGE_TELEMETRY', 'AXIOM_API_TOKEN',
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k] as string;
+  }
+});
+
+interface CapturedIngest {
+  events: Array<Record<string, unknown>>;
+}
+
+function installFetchMock(opts: {
+  groqStatus?: number;
+  captured: CapturedIngest;
+}) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if ((init?.method || 'GET') === 'GET') {
+      return new Response('', { status: 200 });
+    }
+    if (url.includes('api.axiom.co')) {
+      opts.captured.events.push(...JSON.parse(String(init?.body || '[]')));
+      return new Response('{}', { status: 200 });
+    }
+    if (url.includes('api.groq.com')) {
+      if (opts.groqStatus && opts.groqStatus !== 200) {
+        return new Response('groq down', { status: opts.groqStatus });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'groq answer' } }],
+        model: 'llama-3.1-8b-instant',
+        usage: { prompt_tokens: 120, completion_tokens: 40, total_tokens: 160 },
+      }), { status: 200 });
+    }
+    if (url.includes('openrouter.ai')) {
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'openrouter answer' } }],
+        model: 'google/gemini-2.5-flash',
+        usage: { prompt_tokens: 130, completion_tokens: 55, total_tokens: 185 },
+      }), { status: 200 });
+    }
+    throw new Error(`unexpected URL ${url}`);
+  }) as typeof fetch;
+}
+
+function baseEnv() {
+  process.env.GROQ_API_KEY = 'groq-test-key';
+  process.env.OPENROUTER_API_KEY = 'or-test-key';
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  delete process.env.OLLAMA_API_URL;
+  delete process.env.LLM_API_URL;
+  delete process.env.LLM_API_KEY;
+}
+
+describe('llm usage telemetry', () => {
+  it('emits one llm_call event for a first-provider success', async () => {
+    baseEnv();
+    const captured: CapturedIngest = { events: [] };
+    installFetchMock({ captured });
+
+    const result = await callLlm({
+      messages: [
+        { role: 'system', content: 'sys prompt' },
+        { role: 'user', content: 'user prompt' },
+      ],
+      stage: 'test-stage',
+    });
+
+    assert.equal(result?.content, 'groq answer');
+    assert.equal(captured.events.length, 1, 'exactly one event for one attempt');
+    const ev = captured.events[0];
+    assert.equal(ev.event_type, 'llm_call');
+    assert.equal(ev.provider, 'groq');
+    assert.equal(ev.stage, 'test-stage');
+    assert.equal(ev.ok, true);
+    assert.equal(ev.tokens_total, 160);
+    assert.equal(ev.tokens_prompt, 120);
+    assert.equal(ev.tokens_completion, 40);
+    assert.equal(ev.fallback_index, 0);
+    assert.equal(typeof ev.duration_ms, 'number');
+    assert.ok((ev.prompt_chars as number) > 0, 'prompt size must be recorded');
+    assert.ok(typeof ev.model === 'string' && (ev.model as string).length > 0);
+  });
+
+  it('records the failed attempt AND the fallback success', async () => {
+    baseEnv();
+    const captured: CapturedIngest = { events: [] };
+    installFetchMock({ groqStatus: 500, captured });
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'user prompt' }],
+      stage: 'test-stage',
+    });
+
+    assert.equal(result?.content, 'openrouter answer');
+    assert.equal(captured.events.length, 2, 'failed attempt + fallback must both be visible');
+    const [fail, ok] = captured.events;
+    assert.equal(fail.provider, 'groq');
+    assert.equal(fail.ok, false);
+    assert.equal(fail.reason, 'http_500');
+    assert.equal(fail.fallback_index, 0);
+    assert.equal(ok.provider, 'openrouter');
+    assert.equal(ok.ok, true);
+    assert.equal(ok.fallback_index, 1);
+    assert.equal(ok.tokens_total, 185);
+  });
+
+  it('emits nothing when USAGE_TELEMETRY is off', async () => {
+    baseEnv();
+    delete process.env.USAGE_TELEMETRY;
+    const captured: CapturedIngest = { events: [] };
+    installFetchMock({ captured });
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'user prompt' }],
+      stage: 'test-stage',
+    });
+
+    assert.equal(result?.content, 'groq answer');
+    assert.equal(captured.events.length, 0, 'telemetry must be opt-in');
+  });
+
+  it('defaults the stage to "unknown" for untagged callers', async () => {
+    baseEnv();
+    const captured: CapturedIngest = { events: [] };
+    installFetchMock({ captured });
+
+    await callLlm({ messages: [{ role: 'user', content: 'user prompt' }] });
+
+    assert.equal(captured.events.length, 1);
+    assert.equal(captured.events[0].stage, 'unknown');
+  });
+});


### PR DESCRIPTION
## Problem (#4895)

`callLlm` returns per-call token usage and nothing records it. Attributing this week's OpenRouter spend required forensic inference (Axiom `duration_ms` histograms + Railway log archaeology). One event per LLM call makes "which surface burns tokens" a single APL query.

## What ships

New `llm_call` event type through the **existing** `wm_api_usage` Axiom pipeline (same `USAGE_TELEMETRY=1` gate, circuit breaker, and 1.5s-bounded delivery — both env vars already live on Vercel prod):

- One event per **provider attempt**, not per logical call — a fallback chain that re-sends the full prompt shows up as `fallback_index` 0..n, so retry amplification is queryable instead of invisible.
- Fields: `provider`, `model`, `stage` (caller surface), `ok`/`reason` (`http_<status>`/`timeout`/`empty`/`stripped_empty`/`validate_reject`/`truncated`), `tokens_total/prompt/completion`, `prompt_chars` (recorded even when the provider omits usage), `max_tokens`, `duration_ms`.
- Instrumented paths: `callLlm` (all consumers inherit), `callLlmReasoningStream` (events flush **after** stream close so telemetry never delays the client's terminal SSE event), and `summarize-article`'s direct-fetch path (it bypasses callLlm because the client picks the provider).
- Stage tags at every server call site: `classify-event`, `country-intel-brief`, `deduct-situation`, `analyze-stock`, `chat-analyst`, `brief-why-matters-analyst`/`-gemini`, `summarize-article`. Untagged callers emit `stage='unknown'`.
- Delivery is awaited (bounded ≤1.5s, typically ~50ms — noise next to a multi-second completion) so events survive Edge isolate teardown; failures are swallowed and can never affect the call result.

## Example query

```
['wm_api_usage'] | where event_type == "llm_call" | where _time > ago(1d)
| summarize calls=count(), tokens=sum(tokens_total) by stage, provider, model
```

## Out of scope (noted on #4895)

Railway seeder chains (`brief-llm.mjs`, `callForecastLLM`) — they need `AXIOM_API_TOKEN` distributed to the seeder services first.

## Tests

New `tests/llm-usage-telemetry.test.mts` (4 cases): single-attempt success event with token fields, failed-attempt + fallback-success pair with correct `fallback_index`, opt-in gating (no env → zero events), and the `unknown` stage default. Affected suites green: 50/50 (`shared-llm`, `redis-caching`, `country-intel-brief-cache-key`). `typecheck:api` ✓, biome ✓, `docs-stats --check` ✓.

Closes #4895

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih