### PR TITLE
perf(CLS): shift-class environment fields on field CLS reports (#4580)

### DIFF
--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -30,12 +30,49 @@ export interface ClsMetricLike {
 }
 
 /**
+ * Environment facts that split the field-only CLS classes (#4580): a
+ * background-tab load revealed all at once, a top-of-page banner push, or a
+ * below-fold panel swap all produce different (hiddenAtLoad, scrollY) pairs
+ * that `largestShiftTarget` alone cannot distinguish. Injectable for tests.
+ */
+export interface ClsReportEnv {
+  /** Document was hidden when CLS reporting registered (≈ background-tab load). */
+  hiddenAtLoad?: boolean;
+  /** Document went hidden at least once before this report. */
+  hadHiddenPeriod?: boolean;
+  /** document.visibilityState at report time. */
+  visibilityState?: string;
+  /** window.scrollY at report time, rounded (0 ≈ top-of-page shift class). */
+  scrollY?: number;
+  /** `${innerWidth}x${innerHeight}` at report time. */
+  viewport?: string;
+}
+
+// Set once by registerClsReporting(); module-scope so collectClsReportEnv()
+// can answer "was this a background-tab load" long after boot.
+let hiddenAtLoad: boolean | undefined;
+let hadHiddenPeriod = false;
+
+/** Snapshot the reporting environment. Safe in non-browser contexts. */
+export function collectClsReportEnv(): ClsReportEnv {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return {};
+  return {
+    hiddenAtLoad,
+    hadHiddenPeriod,
+    visibilityState: document.visibilityState,
+    scrollY: Math.round(window.scrollY),
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+  };
+}
+
+/**
  * Report one field CLS measurement to Sentry. `enqueue` is injectable for tests;
  * in production it defaults to the deferred-Sentry queue.
  */
 export function reportClsMetric(
   metric: ClsMetricLike,
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
+  env: ClsReportEnv = collectClsReportEnv(),
 ): void {
   // Volume trim: skip 'good' (<0.1) CLS and report needs-improvement / poor /
   // unknown only, so field attribution stays focused on actionable shifts.
@@ -54,6 +91,11 @@ export function reportClsMetric(
         largestShiftValue: a.largestShiftValue,
         largestShiftTime: roundMs(a.largestShiftTime),
         loadState: a.loadState,
+        hiddenAtLoad: env.hiddenAtLoad,
+        hadHiddenPeriod: env.hadHiddenPeriod,
+        visibilityState: env.visibilityState,
+        scrollY: env.scrollY,
+        viewport: env.viewport,
       },
     });
   });
@@ -67,6 +109,14 @@ export function reportClsMetric(
  */
 export function registerClsReporting(): void {
   if (typeof window === 'undefined') return;
+  // Track visibility synchronously at boot: registration runs from main.ts, so
+  // hidden-here ≈ the tab was opened in the background (cmd-click). The
+  // listener stays for the page's life to catch later hide/reveal cycles.
+  hiddenAtLoad = document.visibilityState === 'hidden';
+  hadHiddenPeriod = hiddenAtLoad;
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') hadHiddenPeriod = true;
+  });
   void import('web-vitals/attribution')
     .then(({ onCLS }) => {
       onCLS((metric) => reportClsMetric(metric as unknown as ClsMetricLike));

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -1,15 +1,21 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { registerClsReporting, reportClsMetric, type ClsMetricLike } from '@/bootstrap/cls-report';
+import {
+  collectClsReportEnv,
+  registerClsReporting,
+  reportClsMetric,
+  type ClsMetricLike,
+  type ClsReportEnv,
+} from '@/bootstrap/cls-report';
 
 // Capture what reportClsMetric would send, by injecting a fake enqueue that
 // immediately invokes the closure with a fake Sentry namespace.
-function capture(metric: ClsMetricLike): { msg: string; ctx: any } {
+function capture(metric: ClsMetricLike, env?: ClsReportEnv): { msg: string; ctx: any } {
   let out: { msg: string; ctx: any } | null = null;
   const fakeEnqueue = ((fn: (s: any) => void) => {
     fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportClsMetric(metric, fakeEnqueue);
+  reportClsMetric(metric, fakeEnqueue, env);
   assert.ok(out, 'reportClsMetric must call enqueue exactly once');
   return out!;
 }
@@ -63,6 +69,33 @@ test('reportClsMetric still reports unknown/undefined-rated CLS conservatively',
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
   reportClsMetric({ value: 0.17 }, fakeEnqueue);
   assert.equal(calls, 1, 'unknown/undefined rating still reports; do not drop unknowns');
+});
+
+test('reportClsMetric includes the shift-class environment fields (#4580)', () => {
+  const { ctx } = capture(
+    { value: 0.24, rating: 'poor', attribution: { largestShiftTarget: '#panelsGrid' } },
+    {
+      hiddenAtLoad: true,
+      hadHiddenPeriod: true,
+      visibilityState: 'visible',
+      scrollY: 0,
+      viewport: '1440x900',
+    },
+  );
+  assert.equal(ctx.extra.hiddenAtLoad, true, 'background-tab load flag must reach Sentry');
+  assert.equal(ctx.extra.hadHiddenPeriod, true);
+  assert.equal(ctx.extra.visibilityState, 'visible');
+  assert.equal(ctx.extra.scrollY, 0);
+  assert.equal(ctx.extra.viewport, '1440x900');
+});
+
+test('collectClsReportEnv is safe (empty) in non-browser contexts', () => {
+  // Node test runner has no window/document; the collector must not throw and
+  // the report path must still work with the resulting empty env.
+  const env = collectClsReportEnv();
+  assert.deepEqual(env, {});
+  const { ctx } = capture({ value: 0.2, rating: 'poor' }, env);
+  assert.equal(ctx.extra.hiddenAtLoad, undefined);
 });
 
 test('registerClsReporting returns without importing in non-browser contexts', () => {


### PR DESCRIPTION
## Summary

Adds five environment fields to every field CLS report so the remaining bad-CLS classes can be told apart: `hiddenAtLoad` (tab was hidden when reporting registered ≈ background-tab load), `hadHiddenPeriod`, `visibilityState`, `scrollY`, and `viewport`.

## Why attribution-first (again)

Post-#4652 field data still shows panel-grid targets in ~half of bad-CLS events (last-24h pull: `#panelsGrid` 7× @ 0.439 median, `.panel.span-2` 7×), each event being one dominant shift at `loadState=complete`. But lab reproduction **disproved** the two mechanical hypotheses:

- **First-arrival growth: disproven.** Panel heights are pinned at exactly 200px (span-2: 404px) from t=4s through t=25s with content fully loaded — grid rows never grow, at 4× CPU throttle, on both preview and prod.
- **Scroll-swap shifts: disproven.** A full 30-step scroll through the grid (deferred shells swapping to live panels) produced zero layout-shift entries.

Total lab CLS in every condition: ~0.003 vs field p75 0.14–0.15. The remaining candidates — background-tab reveal (rendering throttled while hidden, one giant layout pass on tab switch), top-of-page banner push, below-fold swap under real-world timing — produce different `(hiddenAtLoad, scrollY)` signatures that `largestShiftTarget` alone cannot distinguish. Background-tab reveal could not be lab-tested (headless pages report `visibilityState: visible` regardless of focus), so the field has to answer.

This is the same play that cracked INP (#4537's sub-part decomposition reframed it from handler-tuning to render-axis): enrich attribution, let 24–48h of field data rank the fix.

## Implementation

- `collectClsReportEnv()` snapshots the env at report time; visibility history is tracked from `registerClsReporting()` (synchronous at boot, before the web-vitals dynamic import).
- Injectable env param keeps the module node-loadable and unit-testable; safe-empty in non-browser contexts.
- 3 new tests (7 total pass).

## Validation

- `tsx --test tests/cls-report.test.mts` — 7 pass
- `npm run typecheck`

Part of #4580 (attribution round 2; the fix PR follows the field verdict).

https://claude.ai/code/session_01JJWff847w1wnfes5CqjDbu
