### PR TITLE
fix(intelligence): stop ISO stopword-codes (IN/US/AT/NO) over-matching shared brief grounding

### DIFF
--- a/server/worldmonitor/intelligence/v1/_country-brief-context.ts
+++ b/server/worldmonitor/intelligence/v1/_country-brief-context.ts
@@ -114,21 +114,53 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** Case-insensitive word-boundary match — for display NAMES only. */
 export function includesCountryTerm(text: string, term: string): boolean {
   const normalizedTerm = term.trim().toLowerCase();
   if (!normalizedTerm) return false;
   return new RegExp(`(^|[^a-z0-9])${escapeRegExp(normalizedTerm)}(?=$|[^a-z0-9])`, 'i').test(text);
 }
 
-export function countryBriefSearchTerms(countryCode: string): string[] {
-  const terms = [countryCode.toLowerCase()];
+/**
+ * ISO codes match ONLY as uppercase tokens in the raw (non-lowercased) text.
+ * Codes like IN, US, AT, NO collide with common English words — a
+ * case-insensitive match swept "rally in Europe" into India's shared brief
+ * (post-#4898 review, P2). Real code mentions in headlines are uppercase
+ * ("US announces…", "exports from IN"); anything else is prose.
+ */
+export function includesCountryCodeToken(text: string, code: string): boolean {
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) return false;
+  return new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(normalized)}(?=$|[^A-Za-z0-9])`).test(text);
+}
+
+export interface CountryMatchTerms {
+  code: string;
+  names: string[];
+}
+
+export function countryBriefSearchTerms(countryCode: string): CountryMatchTerms {
+  const code = countryCode.trim().toUpperCase();
+  const names: string[] = [];
   try {
-    const name = new Intl.DisplayNames(['en'], { type: 'region' }).of(countryCode);
-    if (name) terms.push(name.toLowerCase());
+    const name = new Intl.DisplayNames(['en'], { type: 'region' }).of(code);
+    // Unknown regions come back as a code echo or the ICU "Unknown Region"
+    // sentinel — neither is a real name, and an echoed code as a lowercase
+    // word-match term would reintroduce the stopword collision this split
+    // exists to prevent.
+    if (name && name.toUpperCase() !== code && name.toLowerCase() !== 'unknown region') {
+      names.push(name.toLowerCase());
+    }
   } catch {
     /* Intl.DisplayNames can be missing in constrained runtimes. */
   }
-  return [...new Set(terms.filter(Boolean))];
+  return { code, names };
+}
+
+/** Display name is the primary signal; the ISO code counts only as an uppercase token. */
+export function matchesCountry(rawText: string, terms: CountryMatchTerms): boolean {
+  if (terms.names.some((name) => includesCountryTerm(rawText, name))) return true;
+  return includesCountryCodeToken(rawText, terms.code);
 }
 
 function collectBriefSources(items: DigestItemForBrief[], maxSources = MAX_SOURCES): SharedBriefSource[] {
@@ -161,9 +193,11 @@ export function buildSharedCountryContext(digest: unknown, countryCode: string):
   if (allItems.length === 0) return EMPTY_CONTEXT;
 
   const terms = countryBriefSearchTerms(countryCode);
+  // Raw text, NOT lowercased — the uppercase-token code match depends on the
+  // original casing surviving to this point.
   const countryItems = allItems.filter((item) => {
-    const text = `${typeof item.title === 'string' ? item.title : ''} ${typeof item.snippet === 'string' ? item.snippet : ''}`.toLowerCase();
-    return terms.some((term) => includesCountryTerm(text, term));
+    const text = `${typeof item.title === 'string' ? item.title : ''} ${typeof item.snippet === 'string' ? item.snippet : ''}`;
+    return matchesCountry(text, terms);
   });
 
   // No country match → ground on the top global items instead. A generic

--- a/tests/country-intel-brief-cache-key.test.mjs
+++ b/tests/country-intel-brief-cache-key.test.mjs
@@ -6,6 +6,8 @@ import {
   buildSharedCountryContext,
   countryBriefSearchTerms,
   includesCountryTerm,
+  includesCountryCodeToken,
+  matchesCountry,
 } from '../server/worldmonitor/intelligence/v1/_country-brief-context.ts';
 
 describe('country intel brief cache key derivation', () => {
@@ -105,15 +107,54 @@ describe('shared country context from the news digest', () => {
 });
 
 describe('country term matching', () => {
-  it('derives code + display-name terms', () => {
-    const terms = countryBriefSearchTerms('FR');
-    assert.ok(terms.includes('fr'));
-    assert.ok(terms.includes('france'));
+  it('derives an uppercase code + lowercase display names', () => {
+    const terms = countryBriefSearchTerms('fr');
+    assert.equal(terms.code, 'FR');
+    assert.deepEqual(terms.names, ['france']);
   });
 
-  it('matches on word boundaries only', () => {
-    assert.equal(includesCountryTerm('france announces plan', 'france'), true);
-    assert.equal(includesCountryTerm('shipment from rotterdam', 'fr'), false, '"fr" inside "from" must not match');
-    assert.equal(includesCountryTerm('deal with fr counterpart', 'fr'), true);
+  it('does not treat the Intl code echo for unknown regions as a name', () => {
+    const terms = countryBriefSearchTerms('ZZ');
+    assert.equal(terms.code, 'ZZ');
+    assert.deepEqual(terms.names, [], 'an echoed code must not become a lowercase word-match term');
+  });
+
+  it('matches display names on word boundaries, case-insensitively', () => {
+    assert.equal(includesCountryTerm('France announces plan', 'france'), true);
+    assert.equal(includesCountryTerm('shipment from Indiana port', 'india'), false, '"india" inside "Indiana" must not match');
+  });
+
+  it('matches ISO codes only as uppercase tokens in the raw text', () => {
+    assert.equal(includesCountryCodeToken('Exports from IN surge on new deal', 'IN'), true);
+    assert.equal(includesCountryCodeToken('Prices rise in Europe as inflation cools', 'IN'), false, 'lowercase "in" must not match the IN code');
+    assert.equal(includesCountryCodeToken('US announces sanctions package', 'US'), true);
+    assert.equal(includesCountryCodeToken('tell us more about the plan', 'US'), false);
+    assert.equal(includesCountryCodeToken('INDIA expands exports', 'IN'), false, 'code token must not match inside a longer uppercase word');
+  });
+
+  it('matchesCountry rejects the stopword-collision codes that over-matched shared briefs', () => {
+    const cases = [
+      { cc: 'IN', hit: 'India launches lunar mission', miss: 'Markets rally in Europe' },
+      { cc: 'US', hit: 'United States imposes tariffs', miss: 'tell us what happened next' },
+      { cc: 'NO', hit: 'Norway boosts energy exports', miss: 'no deal reached in talks' },
+      { cc: 'AT', hit: 'Austria tightens border rules', miss: 'explosion at refinery injures three' },
+    ];
+    for (const { cc, hit, miss } of cases) {
+      const terms = countryBriefSearchTerms(cc);
+      assert.equal(matchesCountry(hit, terms), true, `${cc} should match "${hit}"`);
+      assert.equal(matchesCountry(miss, terms), false, `${cc} must NOT match "${miss}"`);
+    }
+  });
+
+  it('shared context no longer sweeps unrelated items into stopword-code briefs', () => {
+    const digest = {
+      items: [
+        { title: 'Markets rally in Europe on rate-cut hopes', source: 'Reuters', link: 'https://example.com/eu' },
+        { title: 'India launches lunar mission', source: 'AFP', link: 'https://example.com/india' },
+      ],
+    };
+    const { sources } = buildSharedCountryContext(digest, 'IN');
+    assert.equal(sources.length, 1, 'only the India item should ground the IN brief');
+    assert.equal(sources[0].url, 'https://example.com/india');
   });
 });


### PR DESCRIPTION
## Problem (post-#4898 review finding P2)

`_country-brief-context.ts` included the raw two-letter ISO code as a lowercase word-boundary search term applied to lowercased titles/snippets. Codes that collide with common English words — **IN, US, AT, NO** (also DO, BE, IT, BY, TO…) — matched ordinary prose: "Markets rally **in** Europe" grounded India's brief, "**no** deal reached" grounded Norway's. Since #4898 made anonymous grounding shared and cached, one over-match mislabels the brief for **every viewer** of that country+lang for the 6h TTL.

## Fix

- Display name (`Intl.DisplayNames`) is the **primary** match — case-insensitive, word-boundary (`"India launches…"`, `"Norway boosts…"`).
- The ISO code matches **only as an uppercase token in the raw, non-lowercased text** (`"US announces sanctions"`, `"exports from IN"`); prose `us/in/at/no` never matches, and the token can't match inside longer uppercase words (`INDIA`).
- Unknown-region codes contribute no name term — the ICU code-echo and `"Unknown Region"` sentinel are filtered so they can't reintroduce the collision.
- `countryBriefSearchTerms` now returns `{ code, names }`; matching goes through a single `matchesCountry(rawText, terms)`.

## Tests

7 new/updated cases in `tests/country-intel-brief-cache-key.test.mjs`: the four stopword-collision codes each with a hit + a must-not-hit headline, uppercase-token semantics (incl. no match inside `INDIA`), the unknown-region guard, `Indiana`/`india` boundary, and an end-to-end `buildSharedCountryContext` case proving an `IN` brief no longer sweeps in "Markets rally in Europe". Full affected suites: 47/47 ✓, `typecheck:api` ✓, biome ✓.

Note: the MCP tool's own context assembly (`rpc-tools.ts`) has the same lowercase-code matching for the *premium personalized* path — lower stakes (per-caller, not shared/cached); tracked as a follow-up in #4896.

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih