### PR TITLE
fix(health-freshness): read the keyless compact health endpoint — stop the anon 401-per-minute flood (#4902)

### DIFF
--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -20,6 +20,23 @@ interface HealthResponse {
   status?: string;
   checkedAt?: string;
   checks?: Record<string, HealthCheck>;
+  problems?: Record<string, HealthCheck>;
+}
+
+// Detailed /api/health (full `checks`) is operator/enterprise-key-gated since
+// #4715 — an anonymous dashboard calling it 401s on every tick (#4902). The
+// compact variant is keyless: same per-check shape, but only non-OK entries
+// land in `problems` and healthy checks are omitted entirely.
+const PUBLIC_HEALTH_ENDPOINT = '/api/health?compact=1';
+
+// One 401/403 per window is enough signal that the endpoint got (re-)gated;
+// without suppression the 60s scheduler re-errors every tick, flooding the
+// console and Sentry (same caller-sweep flood class as #4865).
+const AUTH_GATE_SUPPRESS_MS = 15 * 60_000;
+let authGateSuppressedUntilMs = 0;
+
+export function __resetHealthFreshnessForTests(): void {
+  authGateSuppressedUntilMs = 0;
 }
 
 export interface RefreshHealthFreshnessOptions {
@@ -76,8 +93,9 @@ function getMappedSourceIds(): DataSourceId[] {
 }
 
 export async function refreshDataFreshnessFromHealth(options: RefreshHealthFreshnessOptions = {}): Promise<number> {
+  if (Date.now() < authGateSuppressedUntilMs) return 0;
   const fetchFn = options.fetchFn ?? ((...args) => globalThis.fetch(...args));
-  const endpoint = options.endpoint ?? '/api/health';
+  const endpoint = options.endpoint ?? PUBLIC_HEALTH_ENDPOINT;
   const url = options.urlResolver
     ? options.urlResolver(endpoint)
     : (await import('@/services/runtime')).toApiUrl(endpoint);
@@ -85,6 +103,11 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
     headers: { Accept: 'application/json' },
     signal: options.signal,
   });
+
+  if (resp.status === 401 || resp.status === 403) {
+    authGateSuppressedUntilMs = Date.now() + AUTH_GATE_SUPPRESS_MS;
+    throw new Error(`health freshness fetch failed: ${resp.status} (endpoint is auth-gated; suppressing retries)`);
+  }
 
   // REDIS_DOWN now returns HTTP 503 with a JSON body {status:'REDIS_DOWN', ...}
   // and no `checks` (see api/health.js). Parse the body first and only treat a
@@ -103,7 +126,7 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
   const checkedAtMs = payload.checkedAt ? Date.parse(payload.checkedAt) : Date.now();
   const checkedAt = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const updatesBySource = new Map<DataSourceId, SeedHealthUpdate>();
-  const checks = payload.checks ?? {};
+  const checks: Record<string, HealthCheck> = payload.checks ?? { ...(payload.problems ?? {}) };
 
   if (Object.keys(checks).length === 0 && isRedisOutageStatus(payload.status)) {
     const status = payload.status;
@@ -115,6 +138,17 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
     }));
     dataFreshness.recordSeedHealth(updates);
     return updates.length;
+  }
+
+  // Compact responses omit healthy checks (only non-OK entries land in
+  // `problems`), so a mapped check that is absent was evaluated server-side
+  // and found within budget. Synthesize OK-as-of-checkedAt for those:
+  // seedAgeMin 0 is required because recordSeedHealth keeps lastUpdate null
+  // on an age-less update and calculateStatus then reports no_data.
+  if (!payload.checks && typeof payload.status === 'string') {
+    for (const checkName of Object.keys(HEALTH_CHECK_SOURCE_MAP)) {
+      if (!(checkName in checks)) checks[checkName] = { status: 'OK', seedAgeMin: 0 };
+    }
   }
 
   for (const [checkName, check] of Object.entries(checks)) {

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { dataFreshness } from '../src/services/data-freshness.ts';
 import {
+  __resetHealthFreshnessForTests,
   HEALTH_CHECK_SOURCE_MAP,
   refreshDataFreshnessFromHealth,
 } from '../src/services/health-freshness.ts';
@@ -258,6 +259,112 @@ describe('health freshness ingestion', () => {
     assert.equal(bls?.lastError, null);
     assert.equal(bls?.maxStaleMin, 60);
     assert.equal(bls?.lastUpdate?.toISOString(), new Date(checkedAtMs - 90 * 60_000).toISOString());
+  });
+
+  // Detailed /api/health was operator-key-gated by #4715; the anonymous
+  // dashboard must read the keyless compact variant or every visitor 401s
+  // once a minute and the seed-health pipeline goes silently dead (#4902).
+  it('defaults to the keyless compact endpoint', async () => {
+    __resetHealthFreshnessForTests();
+    const seenUrls: string[] = [];
+    await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async (url) => {
+        seenUrls.push(String(url));
+        return jsonResponse({ status: 'HEALTHY', checkedAt: new Date().toISOString() });
+      },
+    });
+    assert.deepEqual(seenUrls, ['/api/health?compact=1']);
+  });
+
+  it('hydrates from a compact payload: problems degrade, absent mapped checks read healthy', async () => {
+    __resetHealthFreshnessForTests();
+    const mappedSources = new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat());
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        status: 'DEGRADED',
+        summary: { total: 196, ok: 195, warn: 0, onDemandWarn: 0, staleContent: 0, crit: 1 },
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        problems: {
+          gdeltIntel: { status: 'STALE_SEED', records: 6, seedAgeMin: 900, maxStaleMin: 720 },
+        },
+      }),
+    });
+
+    // Every mapped source gets an update: the problem entry for gdelt, a
+    // synthesized server-vouched OK for the rest.
+    assert.equal(applied, mappedSources.size);
+
+    const gdelt = dataFreshness.getSource('gdelt');
+    assert.equal(gdelt?.status, 'stale');
+    assert.equal(gdelt?.healthStatus, 'STALE_SEED');
+    assert.equal(gdelt?.itemCount, 6);
+
+    // weather maps from weatherAlerts, which is absent from `problems` — the
+    // server evaluated it and found it within budget. It must read fresh as of
+    // checkedAt, NOT no_data (a bare OK with no age would leave lastUpdate
+    // null and calculateStatus reports no_data).
+    const weather = dataFreshness.getSource('weather');
+    assert.equal(weather?.status, 'fresh');
+    assert.equal(weather?.healthStatus, 'OK');
+    assert.equal(weather?.lastUpdate?.toISOString(), new Date(checkedAtMs).toISOString());
+  });
+
+  it('marks all mapped sources healthy on a compact payload with no problems key', async () => {
+    __resetHealthFreshnessForTests();
+    const mappedSources = new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat());
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        status: 'HEALTHY',
+        summary: { total: 196, ok: 196, warn: 0, onDemandWarn: 0, staleContent: 0, crit: 0 },
+        checkedAt: new Date(checkedAtMs).toISOString(),
+      }),
+    });
+
+    assert.equal(applied, mappedSources.size);
+
+    // cyber_threats carried SEED_ERROR from an earlier ingest above — a
+    // healthy compact snapshot must clear it.
+    const cyber = dataFreshness.getSource('cyber_threats');
+    assert.equal(cyber?.status, 'fresh');
+    assert.equal(cyber?.healthStatus, 'OK');
+    assert.equal(cyber?.lastError, null);
+  });
+
+  it('suppresses refetch for a window after an auth-gated 401 instead of erroring every tick', async () => {
+    __resetHealthFreshnessForTests();
+    let calls = 0;
+    const fetchFn = async () => {
+      calls++;
+      return jsonResponse({ error: 'API key required' }, 401);
+    };
+
+    await assert.rejects(
+      refreshDataFreshnessFromHealth({ urlResolver: (p) => p, fetchFn }),
+      /401/,
+    );
+    assert.equal(calls, 1);
+
+    // Within the suppression window: no request, no throw — the scheduler
+    // keeps ticking every 60s and must not re-error each tick (#4902).
+    const applied = await refreshDataFreshnessFromHealth({ urlResolver: (p) => p, fetchFn });
+    assert.equal(applied, 0);
+    assert.equal(calls, 1, 'suppression window must not issue another request');
+
+    // After the window (reset here), the probe runs — and errors — again, so
+    // a persistent re-gate stays visible at 1 event per window per tab.
+    __resetHealthFreshnessForTests();
+    await assert.rejects(
+      refreshDataFreshnessFromHealth({ urlResolver: (p) => p, fetchFn }),
+      /401/,
+    );
+    assert.equal(calls, 2);
+
+    __resetHealthFreshnessForTests();
   });
 
   it('polls health freshness from the app scheduler instead of StrategicRiskPanel', () => {


### PR DESCRIPTION
Fixes #4902.

## Problem

#4715 key-gated detailed `/api/health` (operator/enterprise only) but never swept the dashboard caller: `src/services/health-freshness.ts` kept fetching the bare endpoint anonymously. Since the gate deployed (2026-07-04), every anonymous tab 401s once a minute (`REFRESH_INTERVALS.healthFreshness = 60s`, `runImmediately: true`, all variants), each failure flows to Sentry, and the seed-health → data-freshness pipeline is silently dead — `refreshDataFreshnessFromHealth()` throws before `recordSeedHealth()`, so panel freshness badges never see STALE_SEED / REDIS_DOWN. Same caller-sweep flood class as #4865 (→ #4869); the #4856 sweep fixed only the *advertised* consumers of this endpoint.

## Fix

- Default the client to the keyless `/api/health?compact=1` (server already pins this variant as public — `tests/health-redis-down-status.test.mjs`). `problems` carries the same per-check shape as `checks` but only non-OK entries; a mapped check absent from it was evaluated server-side and found within budget, so the client synthesizes OK-as-of-`checkedAt` (`seedAgeMin: 0` — an age-less OK would leave `lastUpdate` null and `calculateStatus` reports `no_data`).
- 401/403 → throw once, then suppress refetch for 15 min: one visible error per window per tab instead of one per tick if the endpoint ever gets (re-)gated.
- Detailed-`checks` parsing and the REDIS_DOWN 503 body-first branch are unchanged (REDIS_DOWN short-circuits server-side before the compact branch, still no `checks`/`problems`).

## Verification

- 4 new tests in `tests/data-freshness-health.test.mts` (failing-first): default-endpoint pin, compact problems + synthesized-OK hydration, healthy-compact clears prior errors, 401 suppression window. 13/13 pass; existing detailed-payload tests untouched and green.
- Exercised end-to-end against live prod: 24 mapped sources hydrate from the real compact payload; the genuinely stale `gdeltIntel` maps to `very_stale`, absent checks read `fresh` as of `checkedAt`.
- `npm run typecheck` clean; tiered pre-push gate green (unit incl. changed tests, edge bundle, boundaries).

https://claude.ai/code/session_01YKrVoDp8TfEKLYXo83kPFV
