### PR TITLE
feat(observability): emit llm_call events from callForecastLLM — the seeder path #4901 missed

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14446,6 +14446,27 @@ function createForecastLlmHttpError(resp, usableBudgetMs = Infinity) {
   return err;
 }
 
+// Seeder-side llm_call telemetry (#4895, post-#4901 review P1). Mirrors
+// server/_shared/usage.ts LlmCallEvent field-for-field and shares its gating
+// (USAGE_TELEMETRY=1 + AXIOM_API_TOKEN) so seeder events unify with the
+// Vercel-side stream in one APL query. Best-effort: one bounded POST per
+// logical call, never throws, never delays the seed meaningfully.
+const AXIOM_WM_API_USAGE_INGEST_URL = 'https://api.axiom.co/v1/datasets/wm_api_usage/ingest';
+
+async function emitForecastLlmEvents(events) {
+  if (process.env.USAGE_TELEMETRY !== '1' || events.length === 0) return;
+  const token = process.env.AXIOM_API_TOKEN;
+  if (!token) return;
+  try {
+    await fetch(AXIOM_WM_API_USAGE_INGEST_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(events),
+      signal: AbortSignal.timeout(1_500),
+    });
+  } catch { /* telemetry must never affect the seed */ }
+}
+
 async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
   if (forecastLlmCallOverrideForTests) {
     return await forecastLlmCallOverrideForTests(systemPrompt, userPrompt, options);
@@ -14459,63 +14480,121 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
     : providers.map(provider => provider.name).join(',');
   console.log(`  [LLM:${stage}] providerOrder=${requestedOrder} modelOverrides=${JSON.stringify(options.modelOverrides || {})}`);
 
-  for (const provider of providers) {
-    const apiKey = process.env[provider.envKey];
-    if (!apiKey) continue;
-    try {
-      const forecastFetch = forecastLlmFetchForTests || ((...args) => globalThis.fetch(...args));
-      const retryDelayMs = Number.isFinite(options.retryDelayMs)
-        ? Math.max(0, Math.floor(options.retryDelayMs))
-        : FORECAST_LLM_RETRY_BASE_MS;
-      const resp = await withRetry(async () => {
-        const usableBudgetMs = getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs);
-        if (usableBudgetMs <= 0) throw createForecastLlmBudgetError(stage, budgetStartedAtMs, stageBudgetMs);
-        const response = await forecastFetch(provider.apiUrl, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-            'User-Agent': CHROME_UA,
-            ...(provider.name === 'openrouter' ? { 'HTTP-Referer': 'https://worldmonitor.app', 'X-Title': 'World Monitor' } : {}),
-          },
-          body: JSON.stringify({
-            model: provider.model,
-            messages: [
-              { role: 'system', content: systemPrompt },
-              { role: 'user', content: userPrompt },
-            ],
-            max_tokens: options.maxTokens || 1500,
-            temperature: options.temperature ?? 0.3,
-          }),
-          signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usableBudgetMs))),
-        });
-        if (!response.ok) {
-          throw createForecastLlmHttpError(
-            response,
-            getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs),
-          );
-        }
-        return response;
-      }, FORECAST_LLM_PROVIDER_MAX_RETRIES, retryDelayMs);
+  // One event per ATTEMPT: every withRetry retry and every provider fallback
+  // re-sends the full prompt, so each gets its own fallback_index. Budget
+  // pre-emptions (thrown before the fetch) are not attempts and emit nothing.
+  const llmPromptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
+  const llmMaxTokens = options.maxTokens || 1500;
+  const llmEvents = [];
+  let llmAttemptIndex = 0;
+  const recordLlmAttempt = (providerName, model, ok, startedAtMs, extra = {}) => {
+    llmEvents.push({
+      _time: new Date().toISOString(),
+      event_type: 'llm_call',
+      provider: providerName,
+      model,
+      stage,
+      ok,
+      duration_ms: Date.now() - startedAtMs,
+      tokens_total: extra.tokensTotal ?? 0,
+      tokens_prompt: extra.tokensPrompt ?? 0,
+      tokens_completion: extra.tokensCompletion ?? 0,
+      prompt_chars: llmPromptChars,
+      max_tokens: llmMaxTokens,
+      fallback_index: llmAttemptIndex++,
+      reason: extra.reason || '',
+    });
+  };
 
-      let json;
+  try {
+    for (const provider of providers) {
+      const apiKey = process.env[provider.envKey];
+      if (!apiKey) continue;
+      let attemptT0 = Date.now();
       try {
-        json = await resp.json();
+        const forecastFetch = forecastLlmFetchForTests || ((...args) => globalThis.fetch(...args));
+        const retryDelayMs = Number.isFinite(options.retryDelayMs)
+          ? Math.max(0, Math.floor(options.retryDelayMs))
+          : FORECAST_LLM_RETRY_BASE_MS;
+        const resp = await withRetry(async () => {
+          const usableBudgetMs = getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs);
+          if (usableBudgetMs <= 0) throw createForecastLlmBudgetError(stage, budgetStartedAtMs, stageBudgetMs);
+          attemptT0 = Date.now();
+          try {
+            const response = await forecastFetch(provider.apiUrl, {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+                'User-Agent': CHROME_UA,
+                ...(provider.name === 'openrouter' ? { 'HTTP-Referer': 'https://worldmonitor.app', 'X-Title': 'World Monitor' } : {}),
+              },
+              body: JSON.stringify({
+                model: provider.model,
+                messages: [
+                  { role: 'system', content: systemPrompt },
+                  { role: 'user', content: userPrompt },
+                ],
+                max_tokens: options.maxTokens || 1500,
+                temperature: options.temperature ?? 0.3,
+              }),
+              signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usableBudgetMs))),
+            });
+            if (!response.ok) {
+              recordLlmAttempt(provider.name, provider.model, false, attemptT0, { reason: `http_${response.status}` });
+              const httpErr = createForecastLlmHttpError(
+                response,
+                getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs),
+              );
+              httpErr.__llmAttemptRecorded = true;
+              throw httpErr;
+            }
+            return response;
+          } catch (err) {
+            if (!err?.__llmAttemptRecorded && !isForecastLlmBudgetError(err)) {
+              err.__llmAttemptRecorded = true;
+              const name = err?.name;
+              recordLlmAttempt(provider.name, provider.model, false, attemptT0, {
+                reason: name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'fetch_error',
+              });
+            }
+            throw err;
+          }
+        }, FORECAST_LLM_PROVIDER_MAX_RETRIES, retryDelayMs);
+
+        let json;
+        try {
+          json = await resp.json();
+        } catch (err) {
+          console.warn(`  [LLM:${stage}] ${provider.name} invalid response: ${err.message}`);
+          recordLlmAttempt(provider.name, provider.model, false, attemptT0, { reason: 'invalid_json' });
+          continue;
+        }
+        const tokensExtra = {
+          tokensTotal: json.usage?.total_tokens ?? 0,
+          tokensPrompt: json.usage?.prompt_tokens ?? 0,
+          tokensCompletion: json.usage?.completion_tokens ?? 0,
+        };
+        const text = json.choices?.[0]?.message?.content?.trim();
+        if (!text || text.length < 20) {
+          recordLlmAttempt(provider.name, provider.model, false, attemptT0, { ...tokensExtra, reason: 'empty' });
+          continue;
+        }
+        const model = json.model || provider.model;
+        console.log(`  [LLM:${stage}] ${provider.name} success model=${model}`);
+        recordLlmAttempt(provider.name, model, true, attemptT0, tokensExtra);
+        return { text, model, provider: provider.name };
       } catch (err) {
-        console.warn(`  [LLM:${stage}] ${provider.name} invalid response: ${err.message}`);
-        continue;
+        // All real attempts were recorded inside the retry callback; budget
+        // pre-emptions never sent the prompt, so nothing to record here.
+        console.warn(`  [LLM:${stage}] ${provider.name} ${err.message}`);
+        if (isForecastLlmBudgetError(err)) return null;
       }
-      const text = json.choices?.[0]?.message?.content?.trim();
-      if (!text || text.length < 20) continue;
-      const model = json.model || provider.model;
-      console.log(`  [LLM:${stage}] ${provider.name} success model=${model}`);
-      return { text, model, provider: provider.name };
-    } catch (err) {
-      console.warn(`  [LLM:${stage}] ${provider.name} ${err.message}`);
-      if (isForecastLlmBudgetError(err)) return null;
     }
+    return null;
+  } finally {
+    await emitForecastLlmEvents(llmEvents);
   }
-  return null;
 }
 
 async function redisSet(url, token, key, data, ttlSeconds) {
@@ -17740,6 +17819,7 @@ export {
   __redisSetForTests,
   __setForecastLlmCallOverrideForTests,
   __setForecastLlmTransportForTests,
+  callForecastLLM,
   __setForecastLlmRunDeadlineForTests,
   __setRedisStoreForTests,
   buildMarketImplicationsFingerprint,

--- a/tests/forecast-llm-telemetry.test.mjs
+++ b/tests/forecast-llm-telemetry.test.mjs
@@ -1,0 +1,160 @@
+// Seeder-side llm_call telemetry (#4895 follow-up, post-#4901 review P1).
+//
+// server/_shared/llm.ts emits llm_call events, but the forecast seeder has
+// its own transport (callForecastLLM) — the cost-heavy stages
+// (market_implications, combined, scenario, critical_signals) were invisible
+// in wm_api_usage. callForecastLLM now emits the same per-ATTEMPT events:
+// every retry and provider fallback re-sends the full prompt and gets its
+// own fallback_index, with token usage captured when the provider returns it.
+
+import assert from 'node:assert/strict';
+import { test, afterEach } from 'node:test';
+import {
+  callForecastLLM,
+  __setForecastLlmTransportForTests,
+} from '../scripts/seed-forecasts.mjs';
+
+const ENV_KEYS = ['USAGE_TELEMETRY', 'AXIOM_API_TOKEN', 'GROQ_API_KEY', 'OPENROUTER_API_KEY'];
+const originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+const realFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = realFetch;
+  __setForecastLlmTransportForTests(null);
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+});
+
+function baseEnv() {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  process.env.GROQ_API_KEY = 'groq-test';
+  process.env.OPENROUTER_API_KEY = 'or-test';
+}
+
+function captureAxiom() {
+  const captured = [];
+  global.fetch = async (url, init = {}) => {
+    if (String(url).includes('api.axiom.co')) {
+      captured.push(...JSON.parse(String(init.body || '[]')));
+      return { ok: true, json: async () => ({}) };
+    }
+    throw new Error(`unexpected global fetch: ${url}`);
+  };
+  return captured;
+}
+
+function llmResponse(body, status = 200) {
+  return {
+    ok: status === 200,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+test('success on first attempt emits one ok event with token usage', async () => {
+  baseEnv();
+  const captured = captureAxiom();
+  __setForecastLlmTransportForTests({
+    fetch: async () => llmResponse({
+      choices: [{ message: { content: 'a forecast narrative that is long enough' } }],
+      model: 'google/gemini-2.5-flash',
+      usage: { prompt_tokens: 900, completion_tokens: 300, total_tokens: 1200 },
+    }),
+  });
+
+  const result = await callForecastLLM('system', 'user prompt', { stage: 'market_implications', providerOrder: ['openrouter'] });
+
+  assert.ok(result?.text);
+  assert.equal(captured.length, 1);
+  const ev = captured[0];
+  assert.equal(ev.event_type, 'llm_call');
+  assert.equal(ev.stage, 'market_implications');
+  assert.equal(ev.provider, 'openrouter');
+  assert.equal(ev.ok, true);
+  assert.equal(ev.fallback_index, 0);
+  assert.equal(ev.tokens_total, 1200);
+  assert.equal(ev.tokens_prompt, 900);
+  assert.equal(ev.tokens_completion, 300);
+  assert.ok(ev.prompt_chars > 0);
+});
+
+test('every retry attempt gets its own event and fallback_index', async () => {
+  baseEnv();
+  const captured = captureAxiom();
+  let calls = 0;
+  __setForecastLlmTransportForTests({
+    fetch: async () => {
+      calls += 1;
+      if (calls === 1) return llmResponse({ error: 'transient' }, 500);
+      return llmResponse({
+        choices: [{ message: { content: 'a forecast narrative that is long enough' } }],
+        model: 'google/gemini-2.5-flash',
+        usage: { total_tokens: 100 },
+      });
+    },
+  });
+
+  const result = await callForecastLLM('system', 'user prompt', {
+    stage: 'combined', providerOrder: ['openrouter'], retryDelayMs: 0,
+  });
+
+  assert.ok(result?.text);
+  assert.equal(captured.length, 2, 'the failed retry attempt must be visible');
+  assert.equal(captured[0].ok, false);
+  assert.equal(captured[0].reason, 'http_500');
+  assert.equal(captured[0].fallback_index, 0);
+  assert.equal(captured[1].ok, true);
+  assert.equal(captured[1].fallback_index, 1);
+});
+
+test('provider fallback chains keep incrementing the index', async () => {
+  baseEnv();
+  const captured = captureAxiom();
+  __setForecastLlmTransportForTests({
+    fetch: async (url) => {
+      if (String(url).includes('api.groq.com')) return llmResponse({ error: 'down' }, 503);
+      return llmResponse({
+        choices: [{ message: { content: 'a forecast narrative that is long enough' } }],
+        model: 'google/gemini-2.5-flash',
+      });
+    },
+  });
+
+  const result = await callForecastLLM('system', 'user prompt', {
+    stage: 'scenario', providerOrder: ['groq', 'openrouter'], retryDelayMs: 0,
+  });
+
+  assert.ok(result?.text);
+  assert.ok(captured.length >= 2, 'groq attempts + openrouter success must all be recorded');
+  const last = captured[captured.length - 1];
+  assert.equal(last.provider, 'openrouter');
+  assert.equal(last.ok, true);
+  for (const [i, ev] of captured.entries()) {
+    assert.equal(ev.fallback_index, i, 'indexes must be strictly sequential across retries and providers');
+    if (i < captured.length - 1) {
+      assert.equal(ev.provider, 'groq');
+      assert.equal(ev.ok, false);
+    }
+  }
+});
+
+test('telemetry is opt-in: no env → no Axiom traffic', async () => {
+  baseEnv();
+  delete process.env.USAGE_TELEMETRY;
+  const captured = captureAxiom();
+  __setForecastLlmTransportForTests({
+    fetch: async () => llmResponse({
+      choices: [{ message: { content: 'a forecast narrative that is long enough' } }],
+    }),
+  });
+
+  const result = await callForecastLLM('system', 'user prompt', { stage: 'combined', providerOrder: ['openrouter'] });
+
+  assert.ok(result?.text);
+  assert.equal(captured.length, 0);
+});


### PR DESCRIPTION
## Problem (post-#4901 review finding P1)

`server/_shared/llm.ts` emits `llm_call` events, but `scripts/seed-forecasts.mjs` uses its own `callForecastLLM` transport — so **market_implications, combined, scenario, and critical_signals** (exactly the cost-heavy, OpenRouter-pinned stages) were invisible in `wm_api_usage`.

## What ships

- One event per **attempt**: every `withRetry` retry and every provider fallback re-sends the full prompt, so each gets its own `fallback_index` — the forecast path's retry amplification (up to 4 attempts × 2 providers) is now queryable instead of invisible.
- Token usage (`tokens_total/prompt/completion`) captured when the provider returns it; `prompt_chars` always. Reasons: `http_<status>` / `timeout` / `fetch_error` / `invalid_json` / `empty`.
- Events mirror `server/_shared/usage.ts`'s `LlmCallEvent` **field-for-field** and share its gating (`USAGE_TELEMETRY=1` + `AXIOM_API_TOKEN`) — seeder and Vercel streams unify in one APL query:
  ```
  ['wm_api_usage'] | where event_type == "llm_call" | summarize sum(tokens_total) by stage, provider
  ```
- Budget pre-emptions thrown **before** the fetch are not attempts and emit nothing. Emission is one bounded (1.5s) best-effort POST per logical call in a `finally` — it can never affect the seed or meaningfully delay it.

## Ops (already done)

`USAGE_TELEMETRY=1` + `AXIOM_API_TOKEN` set and verified on the **seed-forecasts** and **deep-forecast-worker** Railway services; the token's ingest capability against `wm_api_usage` was probe-verified (HTTP 200, `ingested:1`). Cron ticks boot fresh containers, so the next runs emit without a redeploy.

## Out of scope

`brief-llm.mjs` / seed-insights seeder chains — tracked on #4895.

## Tests

New `tests/forecast-llm-telemetry.test.mjs` (4 cases) via the existing `__setForecastLlmTransportForTests` hook: first-attempt success with token fields; a 500-then-success retry producing **two** events with sequential `fallback_index`; a groq→openrouter fallback chain with strictly increasing indexes; and opt-in gating (no env → zero Axiom traffic). Forecast regression suites 207/207 ✓, biome ✓.

Refs #4895

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih