### PR TITLE
perf(health): CDN-cache compact health, 5-min client cadence, idle-deferred first hydration (#4907)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1012,9 +1012,26 @@ export default async function handler(req, ctx) {
     if (Object.keys(problems).length > 0) body.problems = problems;
   }
 
+  // Compact is the public keyless form polled by every dashboard tab (#4907):
+  // a short shared cache collapses per-tab polling onto ~one 196-key Redis
+  // pipeline per cache window per edge region. Browsers stay revalidate-always
+  // so a recovering tab sees fresh state within one poll. Everything else —
+  // the key-gated detailed response, the 401, the REDIS_DOWN 503 — keeps the
+  // no-store defaults from `headers` (caching a 401 would pin an auth failure;
+  // caching a 503 would mask recovery from HTTP monitors).
+  let responseHeaders = headers;
+  if (compact) {
+    const { 'CF-Cache-Status': _bypassMarker, ...cacheable } = headers;
+    responseHeaders = {
+      ...cacheable,
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+      'CDN-Cache-Control': 'public, s-maxage=60',
+    };
+  }
+
   return new Response(JSON.stringify(body, null, compact ? 0 : 2), {
     status: httpStatus,
-    headers,
+    headers: responseHeaders,
   });
 }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -98,6 +98,7 @@ import { DesktopUpdater } from '@/app/desktop-updater';
 import { CountryIntelManager } from '@/app/country-intel';
 import { registerWebMcpTools } from '@/services/webmcp';
 import { refreshDataFreshnessFromHealth } from '@/services/health-freshness';
+import { scheduleAfterFirstPaint } from '@/utils/after-paint';
 import type { SearchManager } from '@/app/search-manager';
 import { RefreshScheduler } from '@/app/refresh-scheduler';
 import { PanelLayoutManager } from '@/app/panel-layout';
@@ -1967,13 +1968,18 @@ export class App {
   private setupRefreshIntervals(): void {
     // Always refresh news for all variants
     this.refreshScheduler.scheduleRefresh('news', () => this.dataLoader.loadNews(), REFRESH_INTERVALS.feeds);
-    this.refreshScheduler.scheduleRefresh(
-      'health-freshness',
-      async () => { await refreshDataFreshnessFromHealth(); },
-      REFRESH_INTERVALS.healthFreshness,
-      undefined,
-      { runImmediately: true },
-    );
+    // Registration (and its immediate first hydration) is deferred to
+    // post-paint idle: freshness badges are below-the-fold decoration, so the
+    // fetch must not compete with the LCP-window requests (#4907, #4890).
+    scheduleAfterFirstPaint(() => {
+      this.refreshScheduler.scheduleRefresh(
+        'health-freshness',
+        async () => { await refreshDataFreshnessFromHealth(); },
+        REFRESH_INTERVALS.healthFreshness,
+        undefined,
+        { runImmediately: true },
+      );
+    });
 
     // Happy variant only refreshes news -- skip all geopolitical/financial/military refreshes
     if (SITE_VARIANT !== 'happy') {

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -39,7 +39,11 @@ export const REFRESH_INTERVALS = {
   fearGreed: 30 * 60 * 1000,
   strategicPosture: 15 * 60 * 1000,
   strategicRisk: 5 * 60 * 1000,
-  healthFreshness: 60 * 1000,
+  // Seed cadences are 6-24h and badge decay is computed client-side from
+  // lastUpdate, so 5min loses nothing vs 60s; must stay under the 15min
+  // FRESH_THRESHOLD or synthesized-OK sources (compact health carries no age
+  // for healthy checks) would decay to stale between polls (#4907).
+  healthFreshness: 5 * 60 * 1000,
   temporalBaseline: 10 * 60 * 1000,
   tradePolicy: 60 * 60 * 1000,
   supplyChain: 60 * 60 * 1000,

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -378,8 +378,8 @@ describe('health freshness ingestion', () => {
     );
     assert.match(
       appSrc,
-      /scheduleRefresh\(\s*['"]health-freshness['"][\s\S]*refreshDataFreshnessFromHealth\(\)[\s\S]*REFRESH_INTERVALS\.healthFreshness[\s\S]*runImmediately:\s*true/,
-      'App scheduler should poll /api/health freshness immediately and on an interval, independent of panel visibility',
+      /scheduleAfterFirstPaint\(\(\)\s*=>\s*\{[\s\S]*?scheduleRefresh\(\s*['"]health-freshness['"][\s\S]*?refreshDataFreshnessFromHealth\(\)[\s\S]*?REFRESH_INTERVALS\.healthFreshness[\s\S]*?runImmediately:\s*true/,
+      'App scheduler should hydrate health freshness at post-paint idle (never in the LCP window — #4907) and then on an interval, independent of panel visibility',
     );
   });
 });

--- a/tests/health-compact-cdn-cache.test.mjs
+++ b/tests/health-compact-cdn-cache.test.mjs
@@ -1,0 +1,75 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Compact /api/health is the public keyless form polled by every dashboard
+// tab. #4907 makes its 200s CDN-cacheable (short s-maxage) so per-tab polling
+// collapses onto ~one origin Redis pipeline per cache window per edge region.
+// Everything else must STAY no-store: caching the key-gated detailed response
+// could leak an operator view across the shared cache, caching a 401 would
+// pin an auth failure, and caching the REDIS_DOWN 503 would mask recovery
+// from HTTP monitors.
+//
+// Run: node --test tests/health-compact-cdn-cache.test.mjs
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://mock-upstash.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
+process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
+
+const { default: handler } = await import('../api/health.js');
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+// redisPipeline POSTs `${url}/pipeline` with a JSON array of commands and
+// expects a same-length array of { result } entries (api/_upstash-json.js).
+function mockRedisPipeline() {
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    const results = commands.map(([op]) => {
+      if (op === 'STRLEN') return { result: 100 }; // non-sentinel data present
+      if (op === 'GET') return { result: null };
+      return { result: 'OK' };
+    });
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+}
+
+test('compact 200 is CDN-cacheable with a short shared TTL', async () => {
+  mockRedisPipeline();
+  const res = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('CDN-Cache-Control'), 'public, s-maxage=60');
+  const cacheControl = res.headers.get('Cache-Control');
+  assert.match(cacheControl, /public/, 'shared caches must be allowed to store the compact form');
+  assert.doesNotMatch(cacheControl, /no-store/);
+  assert.match(cacheControl, /max-age=0/, 'browsers must revalidate so a tab sees recovery within one poll');
+  assert.equal(res.headers.get('CF-Cache-Status'), null, 'no hardcoded BYPASS marker on the cacheable response');
+});
+
+test('detailed (key-authenticated) 200 stays no-store', async () => {
+  mockRedisPipeline();
+  const res = await handler(new Request('https://api.worldmonitor.app/api/health', {
+    headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
+  }));
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('Cache-Control'), /no-store/);
+  assert.equal(res.headers.get('CDN-Cache-Control'), 'no-store');
+});
+
+test('keyless detailed 401 stays no-store', async () => {
+  mockRedisPipeline();
+  const res = await handler(new Request('https://api.worldmonitor.app/api/health'));
+  assert.equal(res.status, 401);
+  assert.match(res.headers.get('Cache-Control'), /no-store/);
+  assert.equal(res.headers.get('CDN-Cache-Control'), 'no-store');
+});
+
+test('compact REDIS_DOWN 503 stays no-store', async () => {
+  globalThis.fetch = async () => { throw new Error('upstash unreachable'); };
+  const res = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  assert.equal(res.status, 503);
+  const body = await res.json();
+  assert.equal(body.status, 'REDIS_DOWN');
+  assert.match(res.headers.get('Cache-Control'), /no-store/);
+  assert.equal(res.headers.get('CDN-Cache-Control'), 'no-store');
+});


### PR DESCRIPTION
Fixes #4907. Follow-up to #4902 / PR #4905.

## Problem

Every `/api/health` invocation runs a ~196-key Upstash pipeline (STRLEN+GET per check) and every response was `no-store` end to end — so origin probe cost scaled linearly with open dashboard tabs (60s cadence, `runImmediately: true`, all variants), and the first fetch sat in the startup critical window (relevant to field-LCP issue #4890). The underlying seed cadences are 6–24h; per-minute per-tab probing buys nothing.

## Changes

1. **CDN-cache the compact form** (`api/health.js`): compact 200s get `Cache-Control: public, max-age=0, must-revalidate` + `CDN-Cache-Control: public, s-maxage=60`, and drop the hardcoded `CF-Cache-Status: BYPASS` marker. All tabs/users collapse onto ~one origin probe per cache window per edge region. Key-gated detailed responses, 401s, and the REDIS_DOWN 503 keep `no-store` — caching the detailed form could leak an operator view across a shared cache, caching a 401 pins an auth failure, caching a 503 masks recovery from HTTP monitors.
2. **Client cadence 60s → 5min** (`src/config/variants/base.ts`): safe margin under the 15-min `FRESH_THRESHOLD`, so synthesized-OK sources (age-less since PR #4905) cannot decay to `stale` between polls. Staleness-onset detection goes ≤1min → ≤6min (poll + cache window) — noise at 6–24h seed cadences. The 15-min 401/403 suppression window from #4905 still spans ~3 ticks.
3. **Idle-defer the first hydration** (`src/App.ts`): the `health-freshness` registration (including its immediate first run) now goes through `scheduleAfterFirstPaint`, keeping the fetch out of the LCP window. Freshness badges are below-the-fold decoration; the scheduler's `pauseWhenHidden` behavior is unchanged.

## Verification

- New `tests/health-compact-cdn-cache.test.mjs` (handler-level, mocked Upstash pipeline): compact-200 cache headers; no-store pinned on detailed-200 / keyless-401 / REDIS_DOWN-503. 4/4 pass.
- Scheduler-shape pin in `tests/data-freshness-health.test.mts` updated to require the post-paint defer; 13/13 pass. Existing health server suites (11/11) green.
- `npm run typecheck`, `docs-stats --check`, `lint:api-contract` clean; tiered pre-push gate green.
- Post-deploy: will re-probe prod `?compact=1` headers (a Cloudflare cache rule is already active on this path — `cf-cache-status: EXPIRED` observed — so live behavior needs confirming; origin intent is now correct for Vercel edge cache + CF respect-origin either way).

https://claude.ai/code/session_01YKrVoDp8TfEKLYXo83kPFV
