### PR TITLE
chore(digest): flip BRIEF_WHY_MATTERS_SHADOW to opt-in — default-on doubled gemini spend

### DIFF
--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -78,8 +78,11 @@ function readConfig(env: Record<string, string | undefined> = process.env as Rec
     invalidPrimaryRaw = rawPrimary;
   }
 
-  // SHADOW: default-on kill switch. Only exactly '0' disables.
-  const shadowEnabled = env.BRIEF_WHY_MATTERS_SHADOW !== '0';
+  // SHADOW: opt-in. Only exactly '1' enables. The original default-on
+  // rollout ran BOTH the analyst and gemini paths on every cache miss and
+  // silently kept doubling gemini spend after the comparison window ended
+  // (#4893) — a fresh deploy must never pay 2× unless someone asked for it.
+  const shadowEnabled = env.BRIEF_WHY_MATTERS_SHADOW === '1';
 
   // SAMPLE_PCT: default 100. Invalid/out-of-range → 100 + warn.
   const rawSample = env.BRIEF_WHY_MATTERS_SHADOW_SAMPLE_PCT;

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -813,7 +813,7 @@ describe('endpoint env flag parsing', () => {
       primary = 'gemini';
       invalidPrimaryRaw = rawPrimary;
     }
-    const shadowEnabled = env.BRIEF_WHY_MATTERS_SHADOW !== '0';
+    const shadowEnabled = env.BRIEF_WHY_MATTERS_SHADOW === '1';
     const rawSample = env.BRIEF_WHY_MATTERS_SHADOW_SAMPLE_PCT;
     let samplePct = 100;
     let invalidSamplePctRaw = null;
@@ -828,10 +828,10 @@ describe('endpoint env flag parsing', () => {
     return { primary, invalidPrimaryRaw, shadowEnabled, samplePct, invalidSamplePctRaw };
   }
 
-  it('defaults: primary=analyst, shadow=on, sample=100', () => {
+  it('defaults: primary=analyst, shadow=OFF (opt-in), sample=100', () => {
     const c = readConfig({});
     assert.equal(c.primary, 'analyst');
-    assert.equal(c.shadowEnabled, true);
+    assert.equal(c.shadowEnabled, false, 'shadow must be opt-in — default-on silently doubled gemini spend (#4893)');
     assert.equal(c.samplePct, 100);
   });
 
@@ -846,11 +846,24 @@ describe('endpoint env flag parsing', () => {
     assert.equal(c.invalidPrimaryRaw, 'analust');
   });
 
-  it('SHADOW disabled only by exact "0"', () => {
-    for (const v of ['yes', '1', 'true', '', 'on']) {
-      assert.equal(readConfig({ BRIEF_WHY_MATTERS_SHADOW: v }).shadowEnabled, true, `value=${v}`);
+  it('SHADOW enabled only by exact "1"', () => {
+    for (const v of ['yes', '0', 'true', '', 'on']) {
+      assert.equal(readConfig({ BRIEF_WHY_MATTERS_SHADOW: v }).shadowEnabled, false, `value=${v}`);
     }
-    assert.equal(readConfig({ BRIEF_WHY_MATTERS_SHADOW: '0' }).shadowEnabled, false);
+    assert.equal(readConfig({ BRIEF_WHY_MATTERS_SHADOW: '1' }).shadowEnabled, true);
+  });
+
+  it('handler source uses the same opt-in expression as this mirror (drift pin)', async () => {
+    // The mirror above is handwritten; without this pin, flipping the
+    // handler default would leave these expectations silently asserting
+    // the wrong semantics (that is exactly how default-on shipped in
+    // the first place — #4893).
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('../api/internal/brief-why-matters.ts', import.meta.url), 'utf8');
+    assert.ok(
+      src.includes("env.BRIEF_WHY_MATTERS_SHADOW === '1'"),
+      'brief-why-matters.ts must gate shadow with the opt-in expression mirrored in readConfig()',
+    );
   });
 
   it('SAMPLE_PCT accepts integer 0–100; invalid → 100', () => {


### PR DESCRIPTION
## Problem (#4893)

`api/internal/brief-why-matters.ts` shipped shadow mode **default-on at 100% sampling**: every cache-miss story ran `Promise.allSettled([analystPath, geminiPath])` — two gemini completions, one used, one stored only as an observability diff. The env flip (`BRIEF_WHY_MATTERS_SHADOW=0`, already live on Vercel prod) protects the current deployment, but the code default meant any fresh environment silently pays 2× again.

## Fix

- Shadow is now **opt-in**: only exactly `'1'` enables (`env.BRIEF_WHY_MATTERS_SHADOW === '1'`). Prod's explicit `0` is unchanged/redundant-safe.
- **Drift pin**: the test suite's handwritten `readConfig` mirror now also asserts the handler source contains the same opt-in expression — the mirror asserting stale semantics unnoticed is exactly how default-on shipped in the first place.

## Tests

`tests/brief-why-matters-analyst.test.mjs`: default expectation flipped (`shadow=OFF`), enable-token semantics inverted (`'1'` enables; `yes/0/true/''/on` don't), plus the source-text drift pin. 64/64 ✓, `typecheck:api` ✓, biome ✓.

Closes #4893

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih