### PR TITLE
chore(llm): regional hygiene — narrative prompt-hash cache + brief retry-budget cap

### DIFF
--- a/scripts/regional-snapshot/narrative.mjs
+++ b/scripts/regional-snapshot/narrative.mjs
@@ -20,8 +20,10 @@
 //   - `callLlm` is dependency-injected so unit tests can exercise the full
 //     prompt + parser without network.
 
+import { createHash } from 'node:crypto';
+
 import { extractFirstJsonObject, cleanJsonText } from '../_llm-json.mjs';
-import { withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError } from '../_seed-utils.mjs';
+import { withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError, getRedisCredentials } from '../_seed-utils.mjs';
 
 const CHROME_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
@@ -404,11 +406,28 @@ export async function generateRegionalNarrative(region, snapshot, evidence, opts
   }
 
   const callLlm = opts.callLlm ?? callLlmDefault;
+  const cache = opts.cache ?? defaultNarrativeCache();
   // Slice evidence once so the prompt and the parser's whitelist agree on
   // exactly which IDs are citable. See selectPromptEvidence docstring.
   const promptEvidence = selectPromptEvidence(evidence);
   const prompt = buildNarrativePrompt(region, snapshot, promptEvidence);
   const validEvidenceIds = promptEvidence.map((e) => e.id);
+
+  // Prompt-hash cache (#4896 item 1): the LLM call used to fire before any
+  // content-identity check, so byte-identical world state regenerated the
+  // same ~900-token narrative every 6h run, and same-15min-bucket re-runs
+  // burned it just for persistSnapshot's dedup to discard the result. The
+  // prompt's only volatile input is a day-granular date, so identical world
+  // state within a day hashes to the same key.
+  const promptText = typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
+  const cacheKey = `${NARRATIVE_CACHE_PREFIX}${region.id}:${createHash('sha256').update(promptText).digest('hex').slice(0, 16)}`;
+  try {
+    const hit = await cache.get(cacheKey);
+    if (hit && typeof hit === 'object' && hit.narrative && typeof hit.narrative === 'object') {
+      console.log(`[narrative] ${region.id}: prompt-hash cache hit, skipping LLM`);
+      return { narrative: hit.narrative, provider: 'cache', model: typeof hit.model === 'string' ? hit.model : '' };
+    }
+  } catch { /* cache is best-effort — fall through to live generation */ }
 
   // Validator for the default provider-chain caller: a response is
   // acceptable iff parseNarrativeJson returns valid=true against the
@@ -435,5 +454,40 @@ export async function generateRegionalNarrative(region, snapshot, evidence, opts
     return { narrative: emptyNarrative(), provider: '', model: '' };
   }
 
+  // Only VALID parsed narratives feed the cache — an empty/garbage response
+  // must never be pinned for the TTL.
+  try {
+    await cache.set(cacheKey, { narrative, model: result.model }, NARRATIVE_CACHE_TTL_SEC);
+  } catch { /* cache write failures don't matter */ }
+
   return { narrative, provider: result.provider, model: result.model };
+}
+
+// ── Prompt-hash narrative cache plumbing (#4896 item 1) ────────────────────
+
+const NARRATIVE_CACHE_PREFIX = 'intelligence:narrative-cache:v1:';
+const NARRATIVE_CACHE_TTL_SEC = 86_400;
+
+function defaultNarrativeCache() {
+  return {
+    async get(key) {
+      const { url, token } = getRedisCredentials();
+      const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(3_000),
+      });
+      if (!resp.ok) return null;
+      const data = await resp.json();
+      return data?.result ? JSON.parse(data.result) : null;
+    },
+    async set(key, value, ttlSeconds) {
+      const { url, token } = getRedisCredentials();
+      await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(['SET', key, JSON.stringify(value), 'EX', String(ttlSeconds)]),
+        signal: AbortSignal.timeout(3_000),
+      });
+    },
+  };
 }

--- a/scripts/regional-snapshot/narrative.mjs
+++ b/scripts/regional-snapshot/narrative.mjs
@@ -23,7 +23,7 @@
 import { createHash } from 'node:crypto';
 
 import { extractFirstJsonObject, cleanJsonText } from '../_llm-json.mjs';
-import { withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError, getRedisCredentials } from '../_seed-utils.mjs';
+import { withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError } from '../_seed-utils.mjs';
 
 const CHROME_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
@@ -469,9 +469,15 @@ const NARRATIVE_CACHE_PREFIX = 'intelligence:narrative-cache:v1:';
 const NARRATIVE_CACHE_TTL_SEC = 86_400;
 
 function defaultNarrativeCache() {
+  // Read env directly — getRedisCredentials() process.exit(1)s when creds
+  // are missing, which would kill the test runner (and any credless local
+  // run) the moment the generator touches the cache. No creds → no cache,
+  // generation proceeds exactly as before this cache existed.
   return {
     async get(key) {
-      const { url, token } = getRedisCredentials();
+      const url = process.env.UPSTASH_REDIS_REST_URL;
+      const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+      if (!url || !token) return null;
       const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
         headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(3_000),
@@ -481,7 +487,9 @@ function defaultNarrativeCache() {
       return data?.result ? JSON.parse(data.result) : null;
     },
     async set(key, value, ttlSeconds) {
-      const { url, token } = getRedisCredentials();
+      const url = process.env.UPSTASH_REDIS_REST_URL;
+      const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+      if (!url || !token) return;
       await fetch(url, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/scripts/seed-bundle-regional.mjs
+++ b/scripts/seed-bundle-regional.mjs
@@ -36,6 +36,45 @@ loadEnvFile(import.meta.url);
 const BRIEF_COOLDOWN_MS = 6.5 * 24 * 60 * 60 * 1000; // 6.5 days
 const BRIEF_META_KEY = 'seed-meta:intelligence:regional-briefs';
 
+// Retry-budget cap on the coverage-fail bypass (#4896 item 2). Each failed
+// attempt refreshes the meta's fetchedAt, so the bypass alone re-ran ALL
+// region briefs on every 6h tick for as long as an outage lasted (~28 LLM
+// calls/day, timed exactly to provider incidents). The budget allows the
+// fast self-heal (#2989) for transients — first retry on the next tick,
+// one more after that — then pauses until the rolling 24h window expires.
+const BRIEF_RETRY_BUDGET_KEY = 'intelligence:brief-retry-budget:v1';
+const BRIEF_RETRY_BUDGET_PER_DAY = 2;
+const BRIEF_RETRY_BUDGET_WINDOW_SEC = 86_400;
+
+/**
+ * Consume one unit of the rolling 24h bypass budget. Fails OPEN (returns
+ * true) on any Redis error so a telemetry hiccup can never block the
+ * self-healing path — the cap only bites when Redis positively reports the
+ * budget as exhausted.
+ */
+async function consumeBriefRetryBudget(url, token) {
+  try {
+    const resp = await fetch(`${url}/pipeline`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify([
+        ['INCR', BRIEF_RETRY_BUDGET_KEY],
+        // NX: only stamp the TTL when INCR just created the key, so the
+        // window doesn't slide forward on every attempt.
+        ['EXPIRE', BRIEF_RETRY_BUDGET_KEY, String(BRIEF_RETRY_BUDGET_WINDOW_SEC), 'NX'],
+      ]),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!resp.ok) return true;
+    const json = await resp.json();
+    const count = Number(json?.[0]?.result);
+    if (!Number.isFinite(count)) return true;
+    return count <= BRIEF_RETRY_BUDGET_PER_DAY;
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Check if the weekly brief seeder should run by reading its seed-meta.
  * Returns true when:
@@ -72,8 +111,14 @@ async function shouldRunBriefs() {
     }
     // Bypass the cooldown when the last run failed coverage so a transient
     // failure self-heals on the next 6h tick instead of staying a crit for
-    // the remainder of the cooldown window.
+    // the remainder of the cooldown window — bounded by the rolling 24h
+    // retry budget so a sustained outage can't burn the brief fleet on
+    // every tick until it ends.
     if (Number(meta?.recordCount ?? 0) === 0) {
+      if (!(await consumeBriefRetryBudget(url, token))) {
+        console.log(`[bundle] briefs: last run failed coverage but the retry budget (${BRIEF_RETRY_BUDGET_PER_DAY}/24h) is exhausted, skipping until it resets`);
+        return false;
+      }
       console.log(`[bundle] briefs: last run ${(age / 86_400_000).toFixed(1)} days ago but failed coverage (recordCount=0), bypassing cooldown to retry`);
       return true;
     }

--- a/tests/regional-narrative-cache.test.mjs
+++ b/tests/regional-narrative-cache.test.mjs
@@ -1,0 +1,119 @@
+// Regional narrative prompt-hash cache (#4896 item 1).
+//
+// generateRegionalNarrative fired its ~900-token LLM call before any
+// content-identity check: byte-identical world state (7 regions × 4 runs/day
+// via seed-bundle-regional) regenerated the same narrative every 6h, and
+// same-bucket re-runs burned it just to have persistSnapshot discard the
+// result. The generator now caches the parsed narrative under a hash of the
+// exact prompt (whose only volatile input is a day-granular date) so an
+// unchanged world reuses the narrative instead of re-billing it.
+
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  generateRegionalNarrative,
+  emptyNarrative,
+} from '../scripts/regional-snapshot/narrative.mjs';
+
+const REGION = { id: 'mena', name: 'Middle East & North Africa' };
+
+function snapshotFixture() {
+  return {
+    region_id: 'mena',
+    actors: [{ name: 'Actor A', role: 'state', leverage_score: 0.8 }],
+    scenario_sets: [],
+    transmission_paths: [],
+    triggers: { active: [] },
+    regime: { label: 'contested' },
+    balance: {
+      coercive_pressure: 0.5, domestic_fragility: 0.3, capital_stress: 0.2,
+      energy_vulnerability: 0.4, alliance_cohesion: 0.6, maritime_access: 0.7,
+      energy_leverage: 0.5, net_balance: 0.1,
+    },
+    narrative: emptyNarrative(),
+  };
+}
+
+const VALID_LLM_TEXT = JSON.stringify({
+  situation: { text: 'Something is happening in the region.', evidence_ids: [] },
+});
+
+function makeCache() {
+  const store = new Map();
+  return {
+    store,
+    gets: 0,
+    sets: 0,
+    async get(key) { this.gets += 1; return store.get(key)?.value ?? null; },
+    async set(key, value, ttlSeconds) { this.sets += 1; store.set(key, { value, ttlSeconds }); },
+  };
+}
+
+afterEach(() => { /* no globals mutated — everything is injected */ });
+
+test('identical inputs hit the cache: one LLM call, second result served as provider=cache', async () => {
+  const cache = makeCache();
+  let llmCalls = 0;
+  const callLlm = async () => { llmCalls += 1; return { text: VALID_LLM_TEXT, provider: 'groq', model: 'llama-70b' }; };
+
+  const first = await generateRegionalNarrative(REGION, snapshotFixture(), [], { callLlm, cache });
+  const second = await generateRegionalNarrative(REGION, snapshotFixture(), [], { callLlm, cache });
+
+  assert.equal(llmCalls, 1, 'byte-identical prompt must not re-bill the LLM');
+  assert.equal(first.narrative.situation.text, 'Something is happening in the region.');
+  assert.deepEqual(second.narrative, first.narrative, 'cached narrative must round-trip');
+  assert.equal(second.provider, 'cache');
+  assert.equal(second.model, 'llama-70b', 'cached entry must preserve the producing model');
+  assert.equal(cache.sets, 1);
+  const [, entry] = [...cache.store.entries()][0];
+  assert.ok(entry.ttlSeconds > 0, 'cache writes must carry a TTL');
+});
+
+test('changed snapshot content misses the cache and generates fresh', async () => {
+  const cache = makeCache();
+  let llmCalls = 0;
+  const callLlm = async () => { llmCalls += 1; return { text: VALID_LLM_TEXT, provider: 'groq', model: 'llama-70b' }; };
+
+  await generateRegionalNarrative(REGION, snapshotFixture(), [], { callLlm, cache });
+  const changed = snapshotFixture();
+  changed.actors = [{ name: 'Actor B', role: 'state', leverage_score: 0.4 }];
+  await generateRegionalNarrative(REGION, changed, [], { callLlm, cache });
+
+  assert.equal(llmCalls, 2, 'different world state must regenerate');
+});
+
+test('failed/invalid generations are never cached', async () => {
+  const cache = makeCache();
+  const callLlm = async () => ({ text: 'not json at all', provider: 'groq', model: 'llama-70b' });
+
+  const result = await generateRegionalNarrative(REGION, snapshotFixture(), [], { callLlm, cache });
+
+  assert.deepEqual(result.narrative, emptyNarrative());
+  assert.equal(cache.sets, 0, 'an empty/invalid narrative must not be pinned for the TTL');
+});
+
+test('a throwing cache never blocks generation', async () => {
+  const cache = {
+    async get() { throw new Error('redis down'); },
+    async set() { throw new Error('redis down'); },
+  };
+  let llmCalls = 0;
+  const callLlm = async () => { llmCalls += 1; return { text: VALID_LLM_TEXT, provider: 'groq', model: 'llama-70b' }; };
+
+  const result = await generateRegionalNarrative(REGION, snapshotFixture(), [], { callLlm, cache });
+
+  assert.equal(llmCalls, 1);
+  assert.equal(result.narrative.situation.text, 'Something is happening in the region.');
+});
+
+test('global region still short-circuits without touching cache or LLM', async () => {
+  const cache = makeCache();
+  let llmCalls = 0;
+  const callLlm = async () => { llmCalls += 1; return { text: VALID_LLM_TEXT, provider: 'groq', model: 'x' }; };
+
+  const result = await generateRegionalNarrative({ id: 'global', name: 'Global' }, snapshotFixture(), [], { callLlm, cache });
+
+  assert.deepEqual(result.narrative, emptyNarrative());
+  assert.equal(llmCalls, 0);
+  assert.equal(cache.gets, 0);
+});

--- a/tests/seed-bundle-regional-briefs-cooldown.test.mjs
+++ b/tests/seed-bundle-regional-briefs-cooldown.test.mjs
@@ -51,12 +51,23 @@ describe('seed-bundle-regional shouldRunBriefs — behavior', () => {
   // wrapped in the Upstash `{ result }` envelope. The seed-meta is bare
   // shape `{ fetchedAt, recordCount }` (NOT enveloped), matching writeSeedMeta.
   let nextMeta = null;
-  function stubFetch(meta) {
+  // The retry-budget guard (#4896) issues a POST /pipeline (INCR+EXPIRE)
+  // when the coverage-fail bypass fires; `incrResult` controls the count the
+  // stub reports back (default 1 = budget available).
+  function stubFetch(meta, { incrResult = 1, pipelineOk = true } = {}) {
     nextMeta = meta;
-    global.fetch = async () => ({
-      ok: true,
-      json: async () => ({ result: nextMeta === null ? null : JSON.stringify(nextMeta) }),
-    });
+    global.fetch = async (_url, init = {}) => {
+      if ((init.method || 'GET') === 'POST') {
+        return {
+          ok: pipelineOk,
+          json: async () => [{ result: incrResult }, { result: 1 }],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: nextMeta === null ? null : JSON.stringify(nextMeta) }),
+      };
+    };
   }
 
   before(async () => {
@@ -111,5 +122,30 @@ describe('seed-bundle-regional shouldRunBriefs — behavior', () => {
   it('runs defensively when Redis returns a non-ok response', async () => {
     global.fetch = async () => ({ ok: false, json: async () => ({}) });
     assert.equal(await shouldRunBriefs(), true);
+  });
+
+  // ── Retry-budget cap on the coverage-fail bypass (#4896 item 2) ──
+  // Without it, a sustained OpenRouter outage re-ran all 7 region briefs on
+  // every 6h tick (~28 LLM calls/day) until the outage ended — a burn spike
+  // timed exactly to provider incidents.
+
+  it('coverage-fail bypass still fires while the 24h retry budget has room', async () => {
+    stubFetch({ fetchedAt: Date.now() - 60_000, recordCount: 0 }, { incrResult: 2 });
+    assert.equal(await shouldRunBriefs(), true);
+  });
+
+  it('coverage-fail bypass is capped once the rolling 24h retry budget is exhausted', async () => {
+    stubFetch({ fetchedAt: Date.now() - 60_000, recordCount: 0 }, { incrResult: 3 });
+    assert.equal(await shouldRunBriefs(), false, 'third bypass within 24h must be suppressed');
+  });
+
+  it('budget check fails OPEN so a Redis hiccup cannot block self-healing', async () => {
+    stubFetch({ fetchedAt: Date.now() - 60_000, recordCount: 0 }, { pipelineOk: false });
+    assert.equal(await shouldRunBriefs(), true);
+  });
+
+  it('the budget does not gate the normal weekly cadence', async () => {
+    stubFetch({ fetchedAt: Date.now() - (BRIEF_COOLDOWN_MS + 60_000), recordCount: 6 }, { incrResult: 99 });
+    assert.equal(await shouldRunBriefs(), true, 'scheduled runs must never consult the retry budget');
   });
 });


### PR DESCRIPTION
## What ships (#4896 items 1–2)

**1. Narrative prompt-hash cache.** `generateRegionalNarrative` fired its ~900-token LLM call before any content-identity check: byte-identical world state (7 regions × 4 `seed-bundle-regional` runs/day) regenerated the same narrative every 6h, and same-15-min-bucket re-runs burned the call just for `persistSnapshot`'s idempotency guard to discard the result. The generator now caches the **parsed** narrative under `intelligence:narrative-cache:v1:<region>:<sha16(prompt)>` (24h TTL — the prompt's only volatile input is a day-granular date). Injectable `opts.cache` for tests; best-effort on Redis failure; **only valid parsed narratives are cached** so a garbage response can't be pinned.

**2. Retry-budget cap on the weekly-brief coverage-fail bypass.** The #2989 self-heal bypass re-ran all 7 region briefs on **every 6h tick** for as long as an OpenRouter outage lasted (~28 LLM calls/day, timed exactly to provider incidents), because each failed attempt refreshes `fetchedAt`. A rolling 24h budget (`INCR` + `EXPIRE NX`, 2 bypasses/window) keeps the fast transient self-heal — first retry on the next tick, one more after — then pauses until the window expires. Fails **open** on Redis errors (a hiccup can never block self-healing); the scheduled weekly cadence never consults the budget.

## Tests

- New `tests/regional-narrative-cache.test.mjs` (5): cache hit serves `provider=cache` with the producing model and zero LLM calls; changed content misses; invalid generations never cached; throwing cache never blocks generation; `global` region short-circuits untouched.
- `tests/seed-bundle-regional-briefs-cooldown.test.mjs` +4: bypass fires with budget room, suppressed at exhaustion, fails open on pipeline errors, and the weekly cadence never consults the budget. Full regional suites 115/115 ✓, biome ✓.

Refs #4896 (items 3–5 dispositioned on the issue)

https://claude.ai/code/session_01YTm4GsLG2M7ZuaHF9MpZih