### PR TITLE
fix(health-freshness): revalidate every poll — CF browser-TTL rewrite oscillates synthesized-OK sources to stale (#4910)

### DIFF
--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -101,6 +101,12 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
     : (await import('@/services/runtime')).toApiUrl(endpoint);
   const resp = await fetchFn(url, {
     headers: { Accept: 'application/json' },
+    // Cloudflare's zone Browser-Cache-TTL override rewrites the origin's
+    // max-age=0 to 30min (#4910); a browser-cached body older than the 15-min
+    // FRESH_THRESHOLD would flip every synthesized-OK source to stale.
+    // no-cache = revalidate every poll; the CDN's 60s edge cache (#4907)
+    // still absorbs the origin cost.
+    cache: 'no-cache',
     signal: options.signal,
   });
 

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -277,6 +277,24 @@ describe('health freshness ingestion', () => {
     assert.deepEqual(seenUrls, ['/api/health?compact=1']);
   });
 
+  // Cloudflare's zone Browser-Cache-TTL override rewrites the origin's
+  // max-age=0 to 30min on this path (#4910). A browser-cached body older than
+  // the 15-min FRESH_THRESHOLD would flip every synthesized-OK source to
+  // stale in oscillating waves, so the poller must revalidate every tick —
+  // the CDN's 60s edge cache still absorbs the origin cost.
+  it('forces browser revalidation on every poll (cache: no-cache)', async () => {
+    __resetHealthFreshnessForTests();
+    let seenInit: RequestInit | undefined;
+    await refreshDataFreshnessFromHealth({
+      urlResolver: (path) => path,
+      fetchFn: async (_url, init) => {
+        seenInit = init;
+        return jsonResponse({ status: 'HEALTHY', checkedAt: new Date().toISOString() });
+      },
+    });
+    assert.equal(seenInit?.cache, 'no-cache');
+  });
+
   it('hydrates from a compact payload: problems degrade, absent mapped checks read healthy', async () => {
     __resetHealthFreshnessForTests();
     const mappedSources = new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat());


### PR DESCRIPTION
Fixes #4910. Post-deploy follow-up to #4907 / PR #4908.

## Problem

Live probing after #4908 deployed showed the Cloudflare zone's Browser Cache TTL override rewrites the compact health endpoint's `Cache-Control: public, max-age=0, must-revalidate` to `public, max-age=1800, must-revalidate` — browsers cache the body for up to 30 minutes. Since PR #4905, healthy checks are synthesized as OK-as-of-`checkedAt` and compared against the 15-min `FRESH_THRESHOLD`, so a tab reading a 15–30-min-old cached body computes age > threshold and flips **every healthy source badge to `stale`**, then back to `fresh` when the browser cache window rolls — oscillating ~30-min waves.

(The CDN side works as intended: `CDN-Cache-Control: public, s-maxage=60` is respected — `cf-cache-status: HIT` + `x-vercel-cache: HIT` observed, origin collapse confirmed.)

## Fix

`cache: 'no-cache'` on the client health fetch: the browser revalidates every poll, Cloudflare answers from its 60s edge cache, so the #4907 origin collapse is intact and `checkedAt` stays ≤ ~60s + poll interval old — far under threshold. This is also the correct standing declaration for a freshness poller and is robust against future CF browser-TTL config drift.

## Verification

- New failing-first test pins `cache: 'no-cache'` on the fetch init; 14/14 pass in `tests/data-freshness-health.test.mts`.
- `npm run typecheck` clean; tiered pre-push gate green.

https://claude.ai/code/session_01YKrVoDp8TfEKLYXo83kPFV
