### PR TITLE
fix(summarization): entitlement-gate the summarize provider chain — stop the anon 401 flood + 3x fan-out (#4913)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 160
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 160 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (195 service modules and domain directories)
+│   ├── services/           # Business logic (196 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 160,
-  "serviceTopLevelEntries": 195,
+  "serviceTopLevelEntries": 196,
   "apiEndpointEntries": 86,
   "panelClasses": 104,
   "protoFiles": 278,

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -14,11 +14,17 @@ import { BETA_MODE } from '@/config/beta';
 import { isFeatureAvailable, type RuntimeFeatureId } from './runtime-config';
 import { trackLLMUsage, trackLLMFailure } from './analytics';
 import { getCurrentLanguage } from './i18n';
-import type { SummarizeArticleResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
+import { ApiError, type SummarizeArticleResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
 import { buildSummaryCacheKey } from '@/utils/summary-cache-key';
 import { NewsServiceClient } from '@/services/generated-rpc-clients';
 import { premiumFetch } from '@/services/premium-fetch';
+import {
+  canAttemptServerSummarization,
+  configureSummarizeGate,
+  suppressServerSummarization,
+} from '@/services/summarize-gate';
+import { hasPremiumAccess } from '@/services/panel-gating';
 
 export type SummarizationProvider = 'ollama' | 'groq' | 'openrouter' | 'browser' | 'cache';
 
@@ -49,6 +55,16 @@ const newsClient = new NewsServiceClient(getRpcBaseUrl(), { fetch: (...args) => 
 const premiumNewsClient = new NewsServiceClient(getRpcBaseUrl(), {
   fetch: (input, init) => premiumFetch(input, { ...init, forcePremium: true }),
 });
+
+// #4913: summarize-article LLM spend is premium-gated server-side (#4687).
+// Gate every API-provider dispatch on the client-side entitlement signal so
+// anon/free principals fall straight to the browser-T5 provider with ZERO
+// network attempts — before this gate, every summarize attempt fanned out up
+// to 3 doomed RPCs (ollama→groq→openrouter through the same gated endpoint).
+// panel-gating's hasPremiumAccess is the dual-signal source of truth.
+// translateText is deliberately NOT gated: it uses mode='translate' via the
+// plain newsClient, which the server allows for non-premium callers.
+configureSummarizeGate(() => hasPremiumAccess());
 const summaryBreaker = createCircuitBreaker<SummarizeArticleResponse>({ name: 'News Summarization', cacheTtlMs: 0 });
 
 const summaryResultBreaker = createCircuitBreaker<SummarizationResult | null>({
@@ -86,19 +102,32 @@ async function tryApiProvider(
   bodies?: string[],
 ): Promise<SummarizationResult | null> {
   if (!isFeatureAvailable(providerDef.featureId)) return null;
+  // Entitlement/suppression gate BEFORE any network dispatch (#4913) — a
+  // denial returns null so the chain falls through to browser T5.
+  if (!canAttemptServerSummarization()) return null;
   lastAttemptedProvider = providerDef.provider;
   try {
     const resp: SummarizeArticleResponse = await summaryBreaker.execute(async () => {
-      return premiumNewsClient.summarizeArticle({
-        provider: providerDef.provider,
-        headlines,
-        mode: 'brief',
-        geoContext: geoContext || '',
-        variant: SITE_VARIANT,
-        lang: lang || 'en',
-        systemAppend: '',
-        bodies: bodies ?? [],
-      });
+      try {
+        return await premiumNewsClient.summarizeArticle({
+          provider: providerDef.provider,
+          headlines,
+          mode: 'brief',
+          geoContext: geoContext || '',
+          variant: SITE_VARIANT,
+          lang: lang || 'en',
+          systemAppend: '',
+          bodies: bodies ?? [],
+        });
+      } catch (error) {
+        // Entitlement drift: probe said entitled, server said no. Suppress
+        // the whole provider chain for a window so drift can't recreate the
+        // flood at news-refresh rate; the breaker still counts the failure.
+        if (error instanceof ApiError && error.statusCode === 403) {
+          suppressServerSummarization();
+        }
+        throw error;
+      }
     }, emptySummaryFallback);
 
     // Provider skipped (credentials missing) or signaled fallback

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -8,13 +8,13 @@
  */
 
 import { mlWorker } from './ml-worker';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { getRpcBaseUrl, getRpcErrorStatusCode } from '@/services/rpc-client';
 import { SITE_VARIANT } from '@/config';
 import { BETA_MODE } from '@/config/beta';
 import { isFeatureAvailable, type RuntimeFeatureId } from './runtime-config';
 import { trackLLMUsage, trackLLMFailure } from './analytics';
 import { getCurrentLanguage } from './i18n';
-import { ApiError, type SummarizeArticleResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
+import type { SummarizeArticleResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
 import { buildSummaryCacheKey } from '@/utils/summary-cache-key';
 import { NewsServiceClient } from '@/services/generated-rpc-clients';
@@ -123,7 +123,10 @@ async function tryApiProvider(
         // Entitlement drift: probe said entitled, server said no. Suppress
         // the whole provider chain for a window so drift can't recreate the
         // flood at news-refresh rate; the breaker still counts the failure.
-        if (error instanceof ApiError && error.statusCode === 403) {
+        // Duck-typed via getRpcErrorStatusCode — a value import of the
+        // generated client's ApiError would pull the RPC client chunk into
+        // the main static graph (eager-chunk budget).
+        if (getRpcErrorStatusCode(error) === 403) {
           suppressServerSummarization();
         }
         throw error;

--- a/src/services/summarize-gate.ts
+++ b/src/services/summarize-gate.ts
@@ -1,0 +1,72 @@
+/**
+ * Session gate for server-side news summarization (#4913).
+ *
+ * summarize-article's LLM spend was premium-gated server-side (#4675/#4687)
+ * but the client kept dispatching the RPC for every summarize attempt
+ * regardless of entitlement — and the ollama→groq→openrouter provider
+ * fan-out routes through the SAME gated endpoint, so one attempt burned up
+ * to three doomed requests (console/Sentry 401 noise on every anonymous
+ * dashboard) before landing on the browser-T5 fallback it would use anyway.
+ *
+ * Two mechanisms, both consulted by summarization.ts before any network
+ * attempt; a denial falls through to the browser-T5 provider (the designed
+ * anon path — free users keep their summaries, minus the wasted requests):
+ *
+ *   1. Entitlement probe — injected by summarization.ts (wired to
+ *      panel-gating's `hasPremiumAccess`, the dual-signal source of truth).
+ *      Anon/free principals dispatch ZERO server requests. Fails OPEN when
+ *      the probe throws or is unconfigured — the server still gates, and a
+ *      client-side gating bug must never silence summaries for paying users.
+ *
+ *   2. Timed suppression — set on a server 403. Covers entitlement-signal
+ *      drift (probe says entitled, server disagrees); a timed window rather
+ *      than a session-permanent kill so a mid-session upgrade self-heals on
+ *      the next attempt after the window. 401 deliberately does NOT suppress:
+ *      the only in-practice 401 source once the probe gates anon dispatch is
+ *      a signed-in user racing the session bootstrap (see premium-fetch.ts
+ *      boot-window note), and benching a Pro user for a full window over a
+ *      transient race would visibly degrade their summaries.
+ *
+ * Pure module (zero imports) so it is loadable under `tsx --test` —
+ * summarization.ts itself imports @/services/i18n etc. and cannot be, hence
+ * the wiring is covered by source-grep assertions
+ * (tests/summarize-entitlement-gate). Deliberately a sibling of
+ * classify-gate.ts with separate state: a summarize 403 must not silence
+ * classification, and vice versa.
+ */
+
+export const SUMMARIZE_SUPPRESS_MS = 15 * 60 * 1000;
+
+type EntitlementProbe = () => boolean;
+
+let entitlementProbe: EntitlementProbe | null = null;
+let suppressedUntil = 0;
+
+/** Inject the entitlement signal. Called once at summarization module init. */
+export function configureSummarizeGate(probe: EntitlementProbe): void {
+  entitlementProbe = probe;
+}
+
+/**
+ * Whether a server summarization attempt may be dispatched right now.
+ * Suppression wins over the probe; an unconfigured/throwing probe allows.
+ */
+export function canAttemptServerSummarization(now: number = Date.now()): boolean {
+  if (now < suppressedUntil) return false;
+  if (!entitlementProbe) return true;
+  try {
+    return entitlementProbe();
+  } catch {
+    return true;
+  }
+}
+
+/** Suppress all attempts for SUMMARIZE_SUPPRESS_MS (called on a server 403). */
+export function suppressServerSummarization(now: number = Date.now()): void {
+  suppressedUntil = now + SUMMARIZE_SUPPRESS_MS;
+}
+
+export function __resetSummarizeGateForTests(): void {
+  entitlementProbe = null;
+  suppressedUntil = 0;
+}

--- a/tests/summarize-entitlement-gate.test.mts
+++ b/tests/summarize-entitlement-gate.test.mts
@@ -1,0 +1,135 @@
+/**
+ * #4913 — anonymous dashboards flooded the premium-gated summarize-article
+ * endpoint after #4675/#4687 gated its LLM spend server-side without a
+ * client-side entitlement gate: every summarize attempt fanned out up to 3
+ * doomed RPCs (ollama→groq→openrouter through the same gated endpoint)
+ * before landing on the browser-T5 fallback anon users get anyway.
+ *
+ * Two layers under test (same shape as tests/classify-entitlement-gate for
+ * #4865 — the sibling instance of this flood class):
+ *   1. src/services/summarize-gate.ts — pure session gate (probe + timed
+ *      suppression), node-test-safe (summarization.ts itself imports
+ *      @/services/i18n etc. and cannot be loaded under tsx --test).
+ *   2. Source-grep wiring assertions on summarization.ts — the gate is only
+ *      effective if the dispatch path consults it and the 403 branch
+ *      suppresses the chain.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  canAttemptServerSummarization,
+  configureSummarizeGate,
+  suppressServerSummarization,
+  SUMMARIZE_SUPPRESS_MS,
+  __resetSummarizeGateForTests,
+} from '../src/services/summarize-gate.ts';
+
+describe('summarize-gate — entitlement probe + timed suppression', () => {
+  beforeEach(() => {
+    __resetSummarizeGateForTests();
+  });
+
+  it('allows by default when no probe is configured (fail-open; server still gates)', () => {
+    assert.equal(canAttemptServerSummarization(), true);
+  });
+
+  it('denies when the probe reports not entitled', () => {
+    configureSummarizeGate(() => false);
+    assert.equal(canAttemptServerSummarization(), false);
+  });
+
+  it('allows when the probe reports entitled', () => {
+    configureSummarizeGate(() => true);
+    assert.equal(canAttemptServerSummarization(), true);
+  });
+
+  it('fails OPEN when the probe throws — a gating bug must not silence Pro summaries', () => {
+    configureSummarizeGate(() => { throw new Error('gating module exploded'); });
+    assert.equal(canAttemptServerSummarization(), true);
+  });
+
+  it('suppression denies even an entitled probe for the full window', () => {
+    configureSummarizeGate(() => true);
+    const t0 = 1_000_000;
+    suppressServerSummarization(t0);
+    assert.equal(canAttemptServerSummarization(t0), false);
+    assert.equal(canAttemptServerSummarization(t0 + SUMMARIZE_SUPPRESS_MS - 1), false);
+  });
+
+  it('suppression expires after the window — self-heals a mid-session upgrade without event plumbing', () => {
+    configureSummarizeGate(() => true);
+    const t0 = 1_000_000;
+    suppressServerSummarization(t0);
+    assert.equal(canAttemptServerSummarization(t0 + SUMMARIZE_SUPPRESS_MS), true);
+  });
+
+  it('post-suppression attempts still consult the probe (free user stays denied)', () => {
+    configureSummarizeGate(() => false);
+    const t0 = 1_000_000;
+    suppressServerSummarization(t0);
+    assert.equal(canAttemptServerSummarization(t0 + SUMMARIZE_SUPPRESS_MS), false);
+  });
+
+  it('suppression window is long enough to matter (>= 5 minutes)', () => {
+    assert.ok(SUMMARIZE_SUPPRESS_MS >= 5 * 60_000, `window too short: ${SUMMARIZE_SUPPRESS_MS}`);
+  });
+
+  it('keeps state separate from classify-gate — a summarize 403 must not silence classification', async () => {
+    const classifyGate = await import('../src/services/classify-gate.ts');
+    classifyGate.__resetClassifyGateForTests();
+    suppressServerSummarization();
+    assert.equal(classifyGate.canAttemptAiClassification(), true);
+    __resetSummarizeGateForTests();
+  });
+});
+
+describe('summarization.ts wiring (source-grep — module not loadable under node:test)', () => {
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(
+    path.join(dirname, '..', 'src', 'services', 'summarization.ts'),
+    'utf8',
+  );
+
+  it('tryApiProvider consults canAttemptServerSummarization() before dispatching the RPC', () => {
+    const fn = src.slice(src.indexOf('async function tryApiProvider'));
+    const gateIdx = fn.indexOf('canAttemptServerSummarization()');
+    const rpcIdx = fn.indexOf('premiumNewsClient.summarizeArticle');
+    assert.ok(gateIdx > -1, 'tryApiProvider must call canAttemptServerSummarization()');
+    assert.ok(rpcIdx > -1, 'expected premiumNewsClient.summarizeArticle in tryApiProvider');
+    assert.ok(gateIdx < rpcIdx, 'the gate must run BEFORE the RPC is dispatched');
+  });
+
+  it('a server 403 suppresses the provider chain (entitlement drift must not recreate the flood)', () => {
+    assert.match(src, /statusCode === 403/, 'must branch on 403 explicitly');
+    const branch = src.slice(src.indexOf('statusCode === 403'));
+    assert.ok(
+      branch.indexOf('suppressServerSummarization()') > -1,
+      '403 branch must call suppressServerSummarization()',
+    );
+  });
+
+  it('gate probe is wired to hasPremiumAccess (dual-signal entitlement)', () => {
+    assert.match(src, /configureSummarizeGate\(\s*\(\)\s*=>\s*hasPremiumAccess\(\)/);
+  });
+
+  it('every premium dispatch flows through tryApiProvider (single choke point)', () => {
+    // If a second call site of premiumNewsClient.summarizeArticle appears
+    // outside tryApiProvider, it bypasses the gate — force the author here.
+    const matches = src.match(/premiumNewsClient\.summarizeArticle/g) ?? [];
+    assert.equal(matches.length, 1, 'premiumNewsClient.summarizeArticle must have exactly one call site (inside tryApiProvider)');
+  });
+
+  it('translateText stays ungated — mode=translate is the server-allowed anon path', () => {
+    const fn = src.slice(src.indexOf('export async function translateText'));
+    assert.ok(fn.indexOf("mode: 'translate'") > -1, 'translateText must use mode=translate');
+    assert.ok(
+      fn.indexOf('newsClient.summarizeArticle') > -1,
+      'translateText must use the plain newsClient (anon-allowed), not the premium client',
+    );
+    const nextFnIdx = fn.indexOf('canAttemptServerSummarization');
+    assert.equal(nextFnIdx, -1, 'translateText must not consult the premium gate');
+  });
+});

--- a/tests/summarize-entitlement-gate.test.mts
+++ b/tests/summarize-entitlement-gate.test.mts
@@ -103,8 +103,11 @@ describe('summarization.ts wiring (source-grep — module not loadable under nod
   });
 
   it('a server 403 suppresses the provider chain (entitlement drift must not recreate the flood)', () => {
-    assert.match(src, /statusCode === 403/, 'must branch on 403 explicitly');
-    const branch = src.slice(src.indexOf('statusCode === 403'));
+    // Duck-typed status check: a value import of the generated client's
+    // ApiError would pull the RPC client chunk into the main static graph
+    // and fail the eager-chunk budget (caught on PR #4915's first CI run).
+    assert.match(src, /getRpcErrorStatusCode\(error\) === 403/, 'must branch on 403 explicitly via the duck-typed helper');
+    const branch = src.slice(src.indexOf('getRpcErrorStatusCode(error) === 403'));
     assert.ok(
       branch.indexOf('suppressServerSummarization()') > -1,
       '403 branch must call suppressServerSummarization()',


### PR DESCRIPTION
Fixes #4913. Third instance of the server-gate-without-client-sweep flood class (#4865 classify-event → fixed by #4869; #4902 health → fixed by #4905). Found live on the anonymous /desktop console while verifying #4907.

## Problem

#4675 → PR #4687 premium-gated `/api/news/v1/summarize-article`'s LLM spend server-side, but `src/services/summarization.ts` kept dispatching for every principal via `premiumNewsClient` (`premiumFetch` is auth injection, not an entitlement gate). Anonymous dashboards fanned out up to **3 doomed RPCs per summarize attempt** (ollama → groq → openrouter through the same gated endpoint) — repeating 401 console/Sentry noise — before landing on the browser-T5 fallback they'd get anyway.

## Fix (the proven #4869 shape)

- **`src/services/summarize-gate.ts`** — pure zero-import session gate: entitlement probe + 15-min timed suppression, fail-OPEN on probe errors (a client gating bug must never silence Pro summaries; the server still gates). Deliberately separate state from `classify-gate.ts` — a summarize 403 must not silence classification.
- **Single choke point**: `tryApiProvider` consults the gate before any dispatch, covering `runApiChain` and the beta fire-and-forget call; probe wired to `panel-gating.hasPremiumAccess()` (dual-signal) at module init.
- **Server 403 → suppress the whole chain** for a window, so entitlement-signal drift can't recreate the flood at news-refresh rate; window expiry self-heals a mid-session upgrade. 401 deliberately does **not** suppress: post-gate, the only in-practice 401 is a signed-in user racing session bootstrap (the `premium-fetch.ts` boot-window race), and benching a Pro user 15 min over a transient race is worse than one logged retry.
- **`translateText` stays ungated** — `mode='translate'` via the plain `newsClient` is the server-allowed anon path (`requiresPremium = mode !== 'translate'`).

## Product behavior

No visible change for any tier. Free/anon users keep their summaries (browser T5, the designed anon path since #4687) — this removes only the wasted network round-trips and the console/Sentry noise. Pro users are unaffected (probe true → dispatch as today).

## Verification

- `tests/summarize-entitlement-gate.test.mts`: 9 pure-gate tests (probe deny/allow/fail-open, suppression window + expiry + probe-after, cross-gate isolation from classify-gate) + 5 source-grep wiring pins (gate before RPC, 403 suppression, probe wiring, **exactly one** `premiumNewsClient.summarizeArticle` call site so a new dispatch path can't bypass the gate, translate-path ungated). 14/14 pass; classify sibling suite 11/11 still green.
- `npm run typecheck` clean; `docs-stats --check` green (AGENTS.md service count 195→196 + stats.json regen for the new module); tiered pre-push gate green.

https://claude.ai/code/session_01YKrVoDp8TfEKLYXo83kPFV
