### PR TITLE
chore(llm): cache-identity churn batch 2 — summary pair-dedup v7, market-brief context quantization, forecast prompt-hash cache, whyMatters v8 cross-read (#4914)

### DIFF
--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -106,12 +106,15 @@ const BRIEF_LLM_SKIP_PROVIDERS = ['ollama', 'groq'];
 /**
  * Resolve a `whyMatters` sentence for one story.
  *
- * Three-layer graceful degradation:
+ * Four-layer graceful degradation:
  *   1. `deps.callAnalystWhyMatters(story)` — the analyst-context edge
  *      endpoint (brief:llm:whymatters:v8 cache lives there). Preferred.
- *   2. Legacy direct-Gemini chain: cacheGet (v4) → callLLM → cacheSet.
+ *   2. Direct read of the endpoint's v8 envelope cache (#4914) — the
+ *      endpoint CALL can fail while its cached envelope is still valid;
+ *      reusing it avoids a paid duplicate generation.
+ *   3. Legacy direct-Gemini chain: cacheGet (v5) → callLLM → cacheSet.
  *      Runs whenever the analyst call is missing, returns null, or throws.
- *   3. Caller (enrichBriefEnvelopeWithLLM) uses the baseline stub if
+ *   4. Caller (enrichBriefEnvelopeWithLLM) uses the baseline stub if
  *      this function returns null.
  *
  * Returns null on all-layer failure.
@@ -153,6 +156,29 @@ export async function generateWhyMatters(story, deps) {
     }
   }
 
+  // #4914: before paying a direct-Gemini generation, check the analyst
+  // endpoint's OWN cache namespace. api/internal/brief-why-matters.ts
+  // stores its envelope at brief:llm:whymatters:v8:{hash} under the same
+  // hashBriefStory identity — when the endpoint CALL failed transiently
+  // (or no endpoint is configured), the story may already have a paid,
+  // validated envelope sitting in Redis. Read-only: this fallback's own
+  // single-sentence output stays in the legacy v5 namespace below, so the
+  // two prompt contracts never cross-contaminate in the write direction.
+  const storyHash = await hashBriefStory(story);
+  try {
+    const v8 = await deps.cacheGet(`brief:llm:whymatters:v8:${storyHash}`);
+    if (v8 && typeof v8 === 'object' && typeof v8.whyMatters === 'string') {
+      const v8Trimmed = v8.whyMatters.trim();
+      // Same acceptance bounds as the live-endpoint path above.
+      if (
+        v8Trimmed.length >= 30 && v8Trimmed.length <= 500
+        && !/^story flagged by your sensitivity/i.test(v8Trimmed)
+      ) {
+        return v8Trimmed;
+      }
+    }
+  } catch { /* treat as miss */ }
+
   // Fallback path: legacy direct-Gemini chain with the v4 cache.
   // Bumped v3→v4 on 2026-05-14 alongside the F6 date-grounding line:
   // every v3 row was produced from a buildWhyMattersPrompt prompt with
@@ -168,7 +194,7 @@ export async function generateWhyMatters(story, deps) {
   // persisted on story:track:v1), post-PR carries the per-story
   // Title-Cased EventCategory value. Every v4 cache row is now stale.
   // Bump invalidates them cleanly.
-  const key = `brief:llm:whymatters:v5:${await hashBriefStory(story)}`;
+  const key = `brief:llm:whymatters:v5:${storyHash}`;
   try {
     const hit = await deps.cacheGet(key);
     if (typeof hit === 'string' && hit.length > 0) return hit;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14626,19 +14626,26 @@ async function redisSet(url, token, key, data, ttlSeconds) {
   } catch (err) { console.warn(`  [Redis] Cache write failed for ${key}: ${err.message}`); }
 }
 
-function buildCacheHash(preds) {
+// #4914: cache identity = the exact prompt text (system + user) — the same
+// pattern as the regional narrative cache (#4911). The previous hash covered
+// raw values the prompt never renders (probability floats vs the prompt's
+// integer percents, every newsContext entry vs the prompt's top-3, cascade
+// probability floats) so hourly drift minted a fresh key for a
+// byte-identical prompt and the seeder paid a full generation every run.
+// Hashing the prompt makes staleness impossible by construction: any
+// prompt-visible change (including a deploy-time system-prompt edit) is a
+// new key.
+function buildNarrativeCacheHash(systemPrompt, userPrompt) {
   return crypto.createHash('sha256')
-    .update(JSON.stringify(preds.map(p => ({
-      id: p.id, d: p.domain, r: p.region, p: p.probability,
-      s: p.signals.map(s => s.value).join(','),
-      c: p.calibration?.drift,
-      n: (p.newsContext || []).join(','),
-      t: p.trend,
-      j: p.projections ? `${p.projections.h24}|${p.projections.d7}|${p.projections.d30}` : '',
-      g: (p.cascades || []).map(cascade => `${cascade.domain}:${cascade.effect}:${cascade.probability}`).join(','),
-    }))))
+    .update(`${systemPrompt}\u0000${userPrompt}`)
     .digest('hex').slice(0, 16);
 }
+
+// Prompt-hash keys self-invalidate on any input change, so the TTL is only
+// an eviction bound, not a freshness control. The old 3600s TTL expired
+// between hourly runs, guaranteeing a paid regeneration even for an
+// unchanged prompt.
+const NARRATIVE_CACHE_TTL_SEC = 24 * 60 * 60;
 
 function buildUserPrompt(preds) {
   const predsText = preds.map((p, i) => {
@@ -14943,7 +14950,7 @@ async function enrichScenariosWithLLM(predictions) {
 
   // Call 1: Combined scenario + perspectives for top-2
   if (topWithPerspectives.length > 0) {
-    const hash = buildCacheHash(topWithPerspectives);
+    const hash = buildNarrativeCacheHash(COMBINED_SYSTEM_PROMPT, buildUserPrompt(topWithPerspectives));
     const cacheKey = `forecast:llm-combined:${hash}`;
     console.log(`  [LLM:combined] start selected=${topWithPerspectives.length} cacheKey=${cacheKey}`);
     const cached = await redisGet(url, token, cacheKey);
@@ -15078,7 +15085,7 @@ async function enrichScenariosWithLLM(predictions) {
           latencyMs: Math.round(Date.now() - t0), cached: false,
         }));
 
-        if (items.length > 0) await redisSet(url, token, cacheKey, { items }, 3600);
+        if (items.length > 0) await redisSet(url, token, cacheKey, { items }, NARRATIVE_CACHE_TTL_SEC);
       } else {
         enrichmentMeta.combined.failureReason = 'call_failed';
         console.warn('  [LLM:combined] call failed');
@@ -15090,7 +15097,7 @@ async function enrichScenariosWithLLM(predictions) {
 
   // Call 2: Scenario-only for predictions 3-4
   if (scenarioOnly.length > 0) {
-    const hash = buildCacheHash(scenarioOnly);
+    const hash = buildNarrativeCacheHash(SCENARIO_SYSTEM_PROMPT, buildUserPrompt(scenarioOnly));
     const cacheKey = `forecast:llm-scenarios:${hash}`;
     console.log(`  [LLM:scenario] start selected=${scenarioOnly.length} cacheKey=${cacheKey}`);
     const cached = await redisGet(url, token, cacheKey);
@@ -15188,7 +15195,7 @@ async function enrichScenariosWithLLM(predictions) {
               ...(c.contrarianCase ? { contrarianCase: c.contrarianCase } : {}),
             });
           }
-          await redisSet(url, token, cacheKey, { scenarios }, 3600);
+          await redisSet(url, token, cacheKey, { scenarios }, NARRATIVE_CACHE_TTL_SEC);
         }
       } else {
         enrichmentMeta.scenario.failureReason = 'call_failed';
@@ -17649,6 +17656,7 @@ export {
   computeHeadlineRelevance,
   computeMarketMatchScore,
   buildUserPrompt,
+  buildNarrativeCacheHash,
   buildForecastCase,
   buildForecastCases,
   buildPriorForecastSnapshot,

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -257,10 +257,23 @@ function getStance(change: number | null): DailyMarketBriefItem['stance'] {
   return 'neutral';
 }
 
+// #4914: every value interpolated into the summarizer context is quantized.
+// The context string becomes the summary cache key's `:g` segment
+// (src/utils/summary-cache-key.ts) and all users read the same seeded
+// quotes/regime, so raw 5-min-tick floats (VIX 18.24 → 18.31) minted a
+// fresh key per tick and per user, defeating the 24h-class TTL. Bucket
+// widths are chosen so the prompt only shifts on market-meaningful moves.
+function quantize(value: number, step: number): number {
+  return Math.round(value / step) * step;
+}
+
 function formatSignedPercent(value: number | null): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 'flat';
-  const sign = value > 0 ? '+' : '';
-  return `${sign}${value.toFixed(1)}%`;
+  // Quarter-point buckets (see quantize note above): +1.84% and +1.87%
+  // both render as +1.75%.
+  const q = quantize(value, 0.25);
+  const sign = q > 0 ? '+' : '';
+  return `${sign}${q.toFixed(2)}%`;
 }
 
 function buildItemNote(change: number | null, relatedHeadline?: string): string {
@@ -351,9 +364,9 @@ function buildExtendedMarketContext(
     const lines = [
       `Fear & Greed: ${regime.compositeScore.toFixed(0)} (${regime.compositeLabel})`,
     ];
-    if (regime.fsiValue > 0) lines.push(`FSI: ${regime.fsiValue.toFixed(2)} (${regime.fsiLabel})`);
-    if (regime.vix > 0) lines.push(`VIX: ${regime.vix.toFixed(1)}`);
-    if (regime.hySpread > 0) lines.push(`HY Spread: ${regime.hySpread.toFixed(0)}bps`);
+    if (regime.fsiValue > 0) lines.push(`FSI: ${regime.fsiValue.toFixed(1)} (${regime.fsiLabel})`);
+    if (regime.vix > 0) lines.push(`VIX: ${Math.round(regime.vix)}`);
+    if (regime.hySpread > 0) lines.push(`HY Spread: ${quantize(regime.hySpread, 10).toFixed(0)}bps`);
     if (regime.cnnFearGreed > 0) lines.push(`CNN F&G: ${regime.cnnFearGreed.toFixed(0)} (${regime.cnnLabel})`);
     if (regime.momentum) lines.push(`Momentum: ${regime.momentum.score.toFixed(0)}/100`);
     if (regime.sentiment) lines.push(`Sentiment: ${regime.sentiment.score.toFixed(0)}/100`);
@@ -361,19 +374,22 @@ function buildExtendedMarketContext(
   }
 
   if (yieldCurve && yieldCurve.rate10y > 0) {
-    const spreadStr = (yieldCurve.spread2s10s >= 0 ? '+' : '') + yieldCurve.spread2s10s.toFixed(0);
+    const spread5 = quantize(yieldCurve.spread2s10s, 5);
+    const spreadStr = (spread5 >= 0 ? '+' : '') + spread5.toFixed(0);
     parts.push([
       `Yield Curve: ${yieldCurve.inverted ? 'INVERTED' : 'NORMAL'} (2s/10s ${spreadStr}bps)`,
-      `2Y: ${yieldCurve.rate2y.toFixed(2)}%  10Y: ${yieldCurve.rate10y.toFixed(2)}%  30Y: ${yieldCurve.rate30y.toFixed(2)}%`,
+      `2Y: ${yieldCurve.rate2y.toFixed(1)}%  10Y: ${yieldCurve.rate10y.toFixed(1)}%  30Y: ${yieldCurve.rate30y.toFixed(1)}%`,
     ].join('\n'));
   }
 
   if (sector && sector.total > 0) {
-    const topSign = sector.topChange >= 0 ? '+' : '';
-    const worstSign = sector.worstChange >= 0 ? '+' : '';
+    const topQ = quantize(sector.topChange, 0.5);
+    const worstQ = quantize(sector.worstChange, 0.5);
+    const topSign = topQ >= 0 ? '+' : '';
+    const worstSign = worstQ >= 0 ? '+' : '';
     parts.push([
       `Sectors: ${sector.countPositive}/${sector.total} positive`,
-      `Top: ${sector.topName} ${topSign}${sector.topChange.toFixed(1)}%  Worst: ${sector.worstName} ${worstSign}${sector.worstChange.toFixed(1)}%`,
+      `Top: ${sector.topName} ${topSign}${topQ.toFixed(1)}%  Worst: ${sector.worstName} ${worstSign}${worstQ.toFixed(1)}%`,
     ].join('\n'));
   }
 

--- a/src/utils/summary-cache-key.ts
+++ b/src/utils/summary-cache-key.ts
@@ -4,13 +4,16 @@
 // or client/server cache keys will silently diverge.
 import { hashString } from './hash';
 
-// Bumped v5 → v6 on 2026-04-24 alongside the RSS-description-grounding fix.
-// Even callers that DON'T pass `bodies` see a forced cold-start here so the
-// pre-grounding headline-only rows age out cleanly on first tick after
-// deploy (they were produced from different prompts than what the handler
-// now builds when bodies are present). See
+// Bumped v6 → v7 on 2026-07-05 (#4914): identical (headline, body) pairs now
+// dedup before the top-5 slice, so v6 rows keyed over a duplicate-bearing
+// composition would never be hit again anyway — the bump retires them
+// cleanly instead of leaving orphans to age out.
+//
+// v5 → v6 (2026-04-24): RSS-description-grounding fix. Even callers that
+// DON'T pass `bodies` saw a forced cold-start so the pre-grounding
+// headline-only rows aged out cleanly on first tick after deploy. See
 // docs/plans/2026-04-24-001-fix-rss-description-end-to-end-plan.md U6.
-export const CACHE_VERSION = 'v6';
+export const CACHE_VERSION = 'v7';
 
 const MAX_HEADLINE_LEN = 500;
 const MAX_HEADLINES_FOR_KEY = 5;
@@ -77,7 +80,21 @@ export function buildSummaryCacheKey(
     if (a.b > b.b) return 1;
     return 0;
   });
-  const topPairs = pairs.slice(0, MAX_HEADLINES_FOR_KEY);
+  // #4914: dedup identical (headline, body) pairs BEFORE the top-5 slice.
+  // The server prompt path (summarize-article.ts) dedups pairs AFTER this
+  // key is computed, so the same unique story set with a different
+  // duplicate composition minted distinct keys for an identical prompt —
+  // every composition variant was a paid cache miss. Exact-pair dedup only:
+  // a repeated headline with a different body stays distinct (the prompt
+  // keeps first-arrival bodies, so merging those keys could serve a summary
+  // generated from other body content). Pairs are sorted, so identical
+  // pairs are adjacent.
+  const dedupedPairs = pairs.filter((p, i) => {
+    if (i === 0) return true;
+    const prev = pairs[i - 1];
+    return prev === undefined || p.h !== prev.h || p.b !== prev.b;
+  });
+  const topPairs = dedupedPairs.slice(0, MAX_HEADLINES_FOR_KEY);
   const sortedHeadlines = topPairs.map(p => p.h).join('|');
 
   const anyBody = topPairs.some(p => p.b.length > 0);

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -1749,3 +1749,79 @@ describe('generateStoryDescription — sanitisation + prefix bump (U5)', () => {
     assert.strictEqual(v3Keys.length, 1);
   });
 });
+
+// ── generateWhyMatters — v8 endpoint-cache cross-read (#4914) ──────────────
+//
+// The analyst endpoint (api/internal/brief-why-matters.ts) caches its
+// envelope at brief:llm:whymatters:v8:{hashBriefStory} — the SAME story
+// identity as the cron's legacy v5 namespace. When the endpoint CALL fails
+// transiently, the envelope may still be sitting in Redis; the fallback
+// must read it before paying a direct-Gemini generation.
+
+describe('generateWhyMatters — v8 endpoint-cache cross-read (#4914)', () => {
+  const V8_PROSE = 'Closure of the Strait of Hormuz would freeze a fifth of seaborne crude and force allied navies to respond.';
+
+  async function seedV8(cache, s, envelopeOverrides = {}) {
+    const hash = await hashBriefStory(s);
+    cache.store.set(`brief:llm:whymatters:v8:${hash}`, {
+      whyMatters: V8_PROSE,
+      producedBy: 'analyst',
+      ...envelopeOverrides,
+    });
+    return hash;
+  }
+
+  it('reuses the v8 envelope when the analyst endpoint call fails — no paid LLM call', async () => {
+    const cache = makeCache();
+    const s = story();
+    await seedV8(cache, s);
+    const llm = makeLLM(() => { throw new Error('must not pay direct-Gemini when v8 is warm'); });
+    const out = await generateWhyMatters(s, {
+      ...cache,
+      callLLM: llm.callLLM,
+      callAnalystWhyMatters: async () => { throw new Error('endpoint down'); },
+    });
+    assert.equal(out, V8_PROSE);
+    assert.equal(llm.calls.length, 0, 'v8 hit must short-circuit the legacy chain');
+  });
+
+  it('reuses the v8 envelope when no analyst endpoint is configured at all', async () => {
+    const cache = makeCache();
+    const s = story();
+    await seedV8(cache, s);
+    const llm = makeLLM(() => { throw new Error('must not pay'); });
+    const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, V8_PROSE);
+    assert.equal(llm.calls.length, 0);
+  });
+
+  it('malformed v8 envelope falls through to the legacy chain', async () => {
+    const cache = makeCache();
+    const s = story();
+    const hash = await hashBriefStory(s);
+    cache.store.set(`brief:llm:whymatters:v8:${hash}`, { whyMatters: 'too short' });
+    const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
+    const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, 'Closure of the Strait of Hormuz would spike oil prices globally.');
+    assert.equal(llm.calls.length, 1, 'invalid v8 payload must not be served — legacy chain pays once');
+  });
+
+  it('v8 sensitivity-stub prose is rejected, not served', async () => {
+    const cache = makeCache();
+    const s = story();
+    await seedV8(cache, s, { whyMatters: 'Story flagged by your sensitivity settings. Open for context and details.' });
+    const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
+    const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, 'Closure of the Strait of Hormuz would spike oil prices globally.');
+    assert.equal(llm.calls.length, 1);
+  });
+
+  it('v8 read is read-only — the legacy path must not copy into or overwrite the v8 namespace', async () => {
+    const cache = makeCache();
+    const s = story();
+    const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
+    await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
+    const v8Keys = [...cache.store.keys()].filter((k) => k.startsWith('brief:llm:whymatters:v8:'));
+    assert.equal(v8Keys.length, 0, 'legacy single-sentence output must stay in the v5 namespace');
+  });
+});

--- a/tests/daily-market-brief.test.mts
+++ b/tests/daily-market-brief.test.mts
@@ -287,3 +287,76 @@ describe('buildDailyMarketBrief', () => {
     assert.ok(elapsed < 5_000, `elapsed ${elapsed}ms — withTimeout did not fire`);
   });
 });
+
+describe('summarizer geoContext cache identity (#4914)', () => {
+  // The geoContext string becomes the summary cache key's :g segment
+  // (summary-cache-key.ts), shared across every user reading the same
+  // seeded quotes/regime. Raw 5-min-tick floats (VIX 18.24 → 18.31,
+  // AAPL +1.84% → +1.87%) minted a fresh key per tick and per user,
+  // defeating the 24h TTL. Values interpolated into the prompt must be
+  // quantized so trivially-drifted inputs produce a byte-identical
+  // context — and therefore one shared paid generation.
+  const news = {
+    markets: [makeNewsItem('Apple extends gains after stronger iPhone cycle outlook')],
+    economic: [makeNewsItem('Treasury yields steady ahead of inflation data', 'WSJ', '2026-03-08T03:00:00.000Z')],
+  };
+
+  function contexts(drift: number): {
+    markets: MarketData[];
+    regimeContext: import('../src/services/daily-market-brief.ts').RegimeMacroContext;
+    yieldCurveContext: import('../src/services/daily-market-brief.ts').YieldCurveContext;
+    sectorContext: import('../src/services/daily-market-brief.ts').SectorBriefContext;
+  } {
+    return {
+      markets: [
+        { symbol: 'AAPL', name: 'Apple', display: 'AAPL', price: 212.45 + drift, change: 1.84 + drift },
+        { symbol: 'MSFT', name: 'Microsoft', display: 'MSFT', price: 468.12 - drift, change: -1.26 + drift },
+      ],
+      regimeContext: {
+        compositeScore: 55.3 + drift, compositeLabel: 'Neutral',
+        fsiValue: 1.21 + drift, fsiLabel: 'Calm',
+        vix: 18.24 + drift, hySpread: 341 + 100 * drift,
+        cnnFearGreed: 61.2 + drift, cnnLabel: 'Greed',
+        momentum: { score: 63.2 + drift }, sentiment: { score: 47.1 + drift },
+      } as import('../src/services/daily-market-brief.ts').RegimeMacroContext,
+      yieldCurveContext: {
+        rate2y: 4.31 + drift, rate10y: 4.41 + drift, rate30y: 4.61 + drift,
+        spread2s10s: -14.2 + 10 * drift, inverted: true,
+      } as import('../src/services/daily-market-brief.ts').YieldCurveContext,
+      sectorContext: {
+        total: 11, countPositive: 7,
+        topName: 'Energy', topChange: 2.13 + drift,
+        worstName: 'Utilities', worstChange: -1.41 + drift,
+      } as import('../src/services/daily-market-brief.ts').SectorBriefContext,
+    };
+  }
+
+  async function captureGeoContext(drift: number): Promise<string> {
+    let captured = '';
+    await buildDailyMarketBrief({
+      ...contexts(drift),
+      newsByCategory: news,
+      timezone: 'UTC',
+      now: new Date('2026-03-08T10:30:00.000Z'),
+      targets: [{ symbol: 'AAPL', name: 'Apple', display: 'AAPL' }],
+      summarize: async (_headlines, _onProgress, geoContext) => {
+        captured = geoContext ?? '';
+        return { summary: 'Stable enough summary for the capture test.', provider: 'test', model: 'test', cached: false };
+      },
+    });
+    return captured;
+  }
+
+  it('trivially-drifted quote/regime floats produce a byte-identical geoContext', async () => {
+    const a = await captureGeoContext(0);
+    const b = await captureGeoContext(0.03);
+    assert.ok(a.length > 0, 'stub must have captured a geoContext');
+    assert.equal(b, a, 'sub-bucket drift must not shift the summary cache identity');
+  });
+
+  it('a material regime move still shifts the geoContext', async () => {
+    const a = await captureGeoContext(0);
+    const c = await captureGeoContext(3);
+    assert.notEqual(c, a, 'a real move (VIX +3, HY +300bps) must produce a fresh prompt and key');
+  });
+});

--- a/tests/forecast-narrative-cache-hash.test.mjs
+++ b/tests/forecast-narrative-cache-hash.test.mjs
@@ -1,0 +1,74 @@
+// Forecast narrative cache identity (#4914).
+//
+// The combined/scenario narrative caches (forecast:llm-combined:{hash},
+// forecast:llm-scenarios:{hash}) previously hashed raw prediction values the
+// prompt never renders — probability floats (the prompt shows integer
+// percents), every newsContext entry (the prompt shows the top 3), cascade
+// probability floats. Hourly drift minted a fresh key for a byte-identical
+// prompt, so the seeder paid a full narrative generation every run.
+//
+// The fix keys the cache on the exact prompt text (system + user) — the same
+// pattern as the regional narrative cache (#4911): byte-identical prompt →
+// cache hit; any prompt-visible change → new key.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildUserPrompt,
+  buildNarrativeCacheHash,
+} from '../scripts/seed-forecasts.mjs';
+
+function makePred(overrides = {}) {
+  return {
+    id: 'pred-1',
+    title: 'Hormuz shipping disruption escalates',
+    domain: 'energy',
+    region: 'Middle East',
+    probability: 0.521,
+    confidence: 0.68,
+    trend: 'rising',
+    timeHorizon: '7d',
+    signals: [{ value: 'Tanker reroutings up 40% week-over-week' }],
+    newsContext: ['Strait transit volumes fall', 'Insurers raise war-risk premiums', 'Naval escorts expand'],
+    ...overrides,
+  };
+}
+
+describe('buildNarrativeCacheHash (#4914)', () => {
+  const SYSTEM = 'You are a senior geopolitical intelligence analyst.';
+
+  it('probability drift within the same rendered integer percent keeps the same key', () => {
+    // 0.521 and 0.524 both render as "52%" — the prompt is byte-identical,
+    // so the cache identity must be too.
+    const a = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ probability: 0.521 })]));
+    const b = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ probability: 0.524 })]));
+    assert.equal(a, b, 'sub-percent probability drift must not bust the narrative cache');
+  });
+
+  it('a material probability change produces a different key', () => {
+    const a = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ probability: 0.52 })]));
+    const b = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ probability: 0.57 })]));
+    assert.notEqual(a, b);
+  });
+
+  it('newsContext entries beyond the prompt-rendered top-3 do not shift the key', () => {
+    const top3 = ['Strait transit volumes fall', 'Insurers raise war-risk premiums', 'Naval escorts expand'];
+    const a = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ newsContext: top3 })]));
+    const b = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ newsContext: [...top3, 'A fourth headline the prompt never sees'] })]));
+    assert.equal(a, b, 'the prompt renders newsContext.slice(0, 3) — invisible tail entries must not bust the cache');
+  });
+
+  it('a different system prompt produces a different key (deploy-time prompt changes self-invalidate)', () => {
+    const user = buildUserPrompt([makePred()]);
+    assert.notEqual(
+      buildNarrativeCacheHash(SYSTEM, user),
+      buildNarrativeCacheHash(`${SYSTEM} Write in bullet points.`, user),
+    );
+  });
+
+  it('a changed signal value (prompt-visible) produces a different key', () => {
+    const a = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred()]));
+    const b = buildNarrativeCacheHash(SYSTEM, buildUserPrompt([makePred({ signals: [{ value: 'Tanker reroutings up 60% week-over-week' }] })]));
+    assert.notEqual(a, b);
+  });
+});

--- a/tests/summarize-reasoning.test.mjs
+++ b/tests/summarize-reasoning.test.mjs
@@ -253,11 +253,12 @@ describe('Fix 3: hasReasoningPreamble', () => {
 describe('Fix 4: cache version bump', () => {
   const src = readSrc('src/utils/summary-cache-key.ts');
 
-  it('CACHE_VERSION is v6', () => {
-    // Bumped v5 → v6 on 2026-04-24 for the RSS-description grounding fix (U6).
-    // Callers now thread per-headline article bodies through SummarizeArticle;
-    // pre-grounding rows were built from different prompts and must age out.
-    assert.match(src, /CACHE_VERSION\s*=\s*'v6'/,
-      'CACHE_VERSION must be v6 to invalidate pre-RSS-grounding cached summaries');
+  it('CACHE_VERSION is v7', () => {
+    // Bumped v6 → v7 on 2026-07-05 (#4914): identical (headline, body) pairs
+    // now dedup before the top-5 slice; v6 rows keyed over duplicate-bearing
+    // compositions must age out. (v5 → v6 on 2026-04-24 for the
+    // RSS-description grounding fix, U6.)
+    assert.match(src, /CACHE_VERSION\s*=\s*'v7'/,
+      'CACHE_VERSION must be v7 to retire pre-pair-dedup cached summaries');
   });
 });

--- a/tests/summary-cache-key.test.mts
+++ b/tests/summary-cache-key.test.mts
@@ -31,8 +31,9 @@ describe('buildSummaryCacheKey', () => {
 
   it('systemAppend suffix does not break existing namespace', () => {
     const base = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
-    // v5 → v6 on 2026-04-24 (RSS-description grounding fix, U6).
-    assert.match(base, /^summary:v6:/);
+    // v6 → v7 on 2026-07-05 (#4914 pair-dedup); v5 → v6 on 2026-04-24
+    // (RSS-description grounding fix, U6).
+    assert.match(base, /^summary:v7:/);
     assert.doesNotMatch(base, /:fw/);
   });
 
@@ -85,7 +86,7 @@ describe('buildSummaryCacheKey', () => {
 
   it('bodies.length < headlines.length is padded (no crash)', () => {
     const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, ['only first']);
-    assert.ok(k.startsWith('summary:v6:brief:'));
+    assert.ok(k.startsWith('summary:v7:brief:'));
   });
 
   it('translate mode ignores bodies (no :b segment)', () => {
@@ -99,5 +100,35 @@ describe('buildSummaryCacheKey', () => {
     const keyA = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, [bodyA, '', '']);
     const keyB = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, [bodyB, '', '']);
     assert.equal(keyA, keyB, 'canonicalizeSummaryInputs clips to 400 before hashing — tails must not shift identity');
+  });
+});
+
+describe('duplicate-composition stability (#4914)', () => {
+  // The server prompt path (summarize-article.ts) dedups headline/body
+  // pairs AFTER the key is computed, so the same unique story set with a
+  // different duplicate composition produced an identical prompt under
+  // distinct keys — every composition variant was a paid cache miss.
+  it('same unique headline set with different duplicate composition produces the same key', () => {
+    const base = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
+    const dupFirst = buildSummaryCacheKey([HEADLINES[0], ...HEADLINES], 'brief', 'US', 'full', 'en');
+    const dupSecond = buildSummaryCacheKey([HEADLINES[0], HEADLINES[1], HEADLINES[1], HEADLINES[2]], 'brief', 'US', 'full', 'en');
+    assert.equal(dupFirst, base, 'a duplicated first headline must not shift identity');
+    assert.equal(dupSecond, base, 'a duplicated middle headline must not shift identity');
+  });
+
+  it('duplicates must not displace unique headlines from the top-5 key window', () => {
+    const uniques = ['Alpha story', 'Beta story', 'Gamma story', 'Delta story', 'Epsilon story'];
+    const padded = ['Alpha story', 'Alpha story', 'Alpha story', ...uniques];
+    assert.equal(
+      buildSummaryCacheKey(padded, 'brief', 'US', 'full', 'en'),
+      buildSummaryCacheKey(uniques, 'brief', 'US', 'full', 'en'),
+      'exact-pair dedup must run before the slice so dups cannot crowd out unique stories',
+    );
+  });
+
+  it('a repeated headline with a DIFFERENT body stays distinct (only exact pairs dedup)', () => {
+    const withTwoBodies = buildSummaryCacheKey(['Same headline', 'Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one', 'body two']);
+    const withOneBody = buildSummaryCacheKey(['Same headline'], 'brief', 'US', 'full', 'en', undefined, ['body one']);
+    assert.notEqual(withTwoBodies, withOneBody, 'distinct bodies are distinct prompt content — keys must not merge');
   });
 });


### PR DESCRIPTION
Closes #4914. Follow-up to the 2026-07-05 spend investigation: #4892 fixed the dominant burner (country-intel contextHash), #4911 the regional narratives, #4909 the whyMatters shadow double. This batch removes the same "volatile value folded into cache identity → TTL defeated → paid churn" class from the three remaining sites, plus one cross-namespace blind spot.

## Changes

**1. Summary cache key dedups identical (headline, body) pairs — `src/utils/summary-cache-key.ts`, v6→v7**
The server prompt path (`summarize-article.ts:171-193`) dedups pairs AFTER the key is computed (`:156`), so the same unique story set with a different duplicate composition minted distinct keys for an identical prompt — every composition variant was a paid cache miss. Dedup now runs pre-slice in the shared builder (client + server stay aligned). Exact pairs only: a repeated headline with a different body stays a distinct key. Version bump retires the old rows cleanly.

**2. Daily market brief quantizes the summarizer geoContext — `src/services/daily-market-brief.ts`**
`VIX: 18.24`, `HY Spread: 342bps`, yields to 2dp, sector moves to 0.1pp, index changes to 0.1pp all fed the key's `:g` segment; every 5-min quote/regime tick and every user minted a fresh key against a 24h-class TTL. All prompt-interpolated floats are now bucketed (index 0.25pp, VIX 1pt, HY 10bps, 2s10s 5bps, yields 0.1pp, sector 0.5pp) so the prompt — and therefore the key — only shifts on market-meaningful moves. Prompt/key consistency is by construction (same string).

**3. Forecast narrative caches key on the exact prompt text — `scripts/seed-forecasts.mjs`**
`buildCacheHash` hashed raw probability floats, ALL newsContext entries, and cascade floats while the prompt renders integer percents and the top-3 headlines — hourly drift minted fresh keys for byte-identical prompts, and the 3600s TTL expired between hourly runs anyway. Now `buildNarrativeCacheHash(SYSTEM_PROMPT, buildUserPrompt(preds))` (the #4911 pattern; a system-prompt edit self-invalidates), TTL 24h (prompt-hash keys make staleness impossible; TTL is only an eviction bound).

**4. whyMatters cron fallback reads the endpoint's v8 envelope — `scripts/lib/brief-llm.mjs`**
`brief:llm:whymatters:v5` (cron fallback) and `:v8` (analyst endpoint) share `hashBriefStory` identity but were disjoint: a transient endpoint failure paid a direct-Gemini generation for a story with a valid v8 envelope already in Redis. The fallback now reads v8 first (bounds-validated, sensitivity-stub rejected). Read-only — the legacy single-sentence output stays in v5, so the two prompt contracts never cross-contaminate in the write direction.

## Verification
- New failing-first tests, all green after the fix: `tests/summary-cache-key.test.mts` (18), `tests/daily-market-brief.test.mts` (12, incl. geoContext byte-identity under drift + material-move busting), `tests/forecast-narrative-cache-hash.test.mjs` (5, new), `tests/brief-llm.test.mjs` (107, incl. v8 reuse / malformed-envelope fall-through / read-only namespace).
- Sibling suites green: `summary-cache-capacity` (3), `forecast-llm-telemetry` (4).
- `npm run typecheck` + `npm run typecheck:api` + biome: clean.

Remaining item from the investigation — the digest generator running paid synthesis for every eligible user on every 30-min tick regardless of `isDue` — is product-behavioral (dashboard-refresh contract) and tracked for its own PR in #4914's closing note.

https://claude.ai/code/session_01WmhkGjZrb9RbV7pV3muFxP
