### PR TITLE
chore(digest): reuse prior envelope prose on non-due compose ticks — stop ~48 unused paid syntheses/user/day (#4917)

### DIFF
--- a/scripts/lib/brief-synthesis-reuse.mjs
+++ b/scripts/lib/brief-synthesis-reuse.mjs
@@ -1,0 +1,85 @@
+/**
+ * #4917 — non-due synthesis reuse decision.
+ *
+ * The compose pass (`composeAndStoreBriefForUser`) runs for EVERY eligible
+ * user every ~30-min tick so the dashboard "Latest Brief" preview stays
+ * fresh — but the canonical synthesis + public-lead calls inside it are
+ * paid LLM generations whose cache key includes the accumulator pool hash,
+ * which churns as stories arrive. Pre-fix, a weekly subscriber's preview
+ * could burn up to ~48 paid syntheses/day that no email ever used.
+ *
+ * When NO candidate rule is due this tick, the prose from the user's
+ * previously stored envelope is reused instead — provided it is young
+ * enough AND still grounds against the CURRENT story pool. Due ticks
+ * always synthesize fresh: delivered digests never carry reused prose.
+ *
+ * Pure module: no I/O. The orchestrator resolves the prior envelope from
+ * Upstash (`brief:latest:{userId}` → `brief:{userId}:{slot}`) and passes
+ * it here.
+ */
+
+import { checkLeadGrounding } from './brief-llm.mjs';
+
+// Default freshness budget for reused prose on non-due ticks. Overridable
+// via DIGEST_NONDUE_SYNTHESIS_REUSE_MIN (minutes; 0 disables reuse and
+// restores the every-tick synthesis behavior).
+export const DEFAULT_NONDUE_SYNTHESIS_REUSE_MIN = 360;
+
+/**
+ * Decide whether a prior envelope's prose can stand in for a fresh
+ * synthesis on a non-due tick.
+ *
+ * @param {object|null} priorEnvelope Parsed brief envelope (or null).
+ * @param {{ nowMs: number; maxAgeMs: number; currentStories: Array<{ headline?: string }> }} opts
+ *   `currentStories` is the SYNTHESIS-shaped pool ({ headline, ... }) the
+ *   fresh path would have prompted with — grounding must be judged against
+ *   what the user will actually see this tick.
+ * @returns {{ reuse: false; reason: string } | {
+ *   reuse: true; reason: 'ok'; ageMs: number;
+ *   synthesis: { lead: string; threads: unknown[]; signals: unknown[] };
+ *   publicLead: { lead: string; threads: unknown[]; signals: unknown[] } | null;
+ * }}
+ */
+export function resolveNonDueSynthesisReuse(priorEnvelope, { nowMs, maxAgeMs, currentStories }) {
+  if (!priorEnvelope || typeof priorEnvelope !== 'object') {
+    return { reuse: false, reason: 'no_prior_envelope' };
+  }
+  const issuedAt = priorEnvelope.issuedAt;
+  if (typeof issuedAt !== 'number' || !Number.isFinite(issuedAt)) {
+    return { reuse: false, reason: 'no_issued_at' };
+  }
+  const ageMs = nowMs - issuedAt;
+  // Negative age = clock skew or a corrupted row; treat as unusable rather
+  // than "infinitely fresh".
+  if (ageMs < 0 || ageMs > maxAgeMs) {
+    return { reuse: false, reason: 'stale' };
+  }
+  const digest = priorEnvelope.data?.digest;
+  const lead = typeof digest?.lead === 'string' ? digest.lead.trim() : '';
+  // Floor mirrors the fresh path's notion of a substantive lead — a
+  // missing/short lead means the prior compose degraded; regenerate.
+  if (lead.length < 40) {
+    return { reuse: false, reason: 'no_lead' };
+  }
+  const synthesis = {
+    lead,
+    threads: Array.isArray(digest.threads) ? digest.threads : [],
+    signals: Array.isArray(digest.signals) ? digest.signals : [],
+  };
+  // The reused lead must still be ABOUT the current pool. A rotated pool —
+  // or an L3 stub lead, which carries no proper-noun anchors — fails here
+  // and the caller pays a fresh generation. Reuse never ships prose the
+  // fresh path's own grounding gate would reject.
+  if (!checkLeadGrounding(synthesis, currentStories)) {
+    return { reuse: false, reason: 'ungrounded' };
+  }
+  const publicLeadText = typeof digest.publicLead === 'string' ? digest.publicLead.trim() : '';
+  const publicLead = publicLeadText.length > 0
+    ? {
+        lead: publicLeadText,
+        threads: Array.isArray(digest.publicThreads) ? digest.publicThreads : [],
+        signals: Array.isArray(digest.publicSignals) ? digest.publicSignals : [],
+      }
+    : null;
+  return { reuse: true, reason: 'ok', ageMs, synthesis, publicLead };
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -69,6 +69,10 @@ import {
   leadGroundsAgainstStory,
 } from './lib/brief-llm.mjs';
 import { parseDigestOnlyUser } from './lib/digest-only-user.mjs';
+import {
+  resolveNonDueSynthesisReuse,
+  DEFAULT_NONDUE_SYNTHESIS_REUSE_MIN,
+} from './lib/brief-synthesis-reuse.mjs';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { signBriefUrl, BriefUrlError } from './lib/brief-url-sign.mjs';
 import {
@@ -190,6 +194,15 @@ const BRIEF_SIGNING_SECRET_MISSING =
 // toggled independently (e.g. kill the brief LLM without silencing
 // the email's AI summary during a provider outage).
 const BRIEF_LLM_ENABLED = process.env.BRIEF_LLM_ENABLED !== '0';
+// #4917: freshness budget for reusing the prior envelope's prose on
+// non-due compose ticks (minutes; 0 disables reuse and restores the
+// pre-#4917 synthesize-every-tick behavior). Due ticks always
+// synthesize fresh regardless of this setting.
+const NONDUE_SYNTHESIS_REUSE_MS = (() => {
+  const raw = Number.parseInt(process.env.DIGEST_NONDUE_SYNTHESIS_REUSE_MIN ?? '', 10);
+  const minutes = Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_NONDUE_SYNTHESIS_REUSE_MIN;
+  return minutes * 60_000;
+})();
 
 // Free-tier follow limit (PR C / U10). Mirrors the UI cap at
 // `src/components/FollowCountryButton.ts` and the server-side mutation
@@ -319,6 +332,25 @@ const briefLlmDeps = {
 };
 
 // ── Redis helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * #4917: read the user's most recent stored brief envelope via the
+ * latest-pointer. Returns null on any miss/parse failure — callers treat
+ * null as "no prior envelope" and pay a fresh synthesis.
+ */
+async function fetchLatestBriefEnvelope(userId) {
+  try {
+    const rawPtr = await upstashRest('GET', `brief:latest:${userId}`);
+    if (typeof rawPtr !== 'string' || rawPtr.length === 0) return null;
+    const ptr = JSON.parse(rawPtr);
+    if (!ptr || typeof ptr.issueSlot !== 'string' || ptr.issueSlot.length === 0) return null;
+    const rawEnv = await upstashRest('GET', `brief:${userId}:${ptr.issueSlot}`);
+    if (typeof rawEnv !== 'string' || rawEnv.length === 0) return null;
+    return JSON.parse(rawEnv);
+  } catch {
+    return null;
+  }
+}
 
 async function upstashRest(...args) {
   const res = await fetch(`${UPSTASH_URL}/${args.map(encodeURIComponent).join('/')}`, {
@@ -1804,8 +1836,8 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
   let synthesis = null;
   let publicLead = null;
   let synthesisLevel = 3;  // pessimistic default; bumped on success
+  let synthesisReused = false;
   if (BRIEF_LLM_ENABLED) {
-    const ctx = await buildSynthesisCtx(winner.rule, nowMs);
     // Synthesis-boundary adapter. `winnerStories` is the raw
     // buildDigest pool ({ title, severity, sources }); the synthesis
     // path (buildDigestPrompt / checkLeadGrounding / hashDigestInput)
@@ -1818,42 +1850,75 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
     // `winnerStories` (digestStoryToUpstreamTopStory expects the raw
     // shape). See plan 2026-05-14-001 F2 / Phase 2.
     const synthesisStories = winnerStories.map(digestStoryToSynthesisShape);
-    const result = await runSynthesisWithFallback(
-      userId,
-      synthesisStories,
-      sensitivity,
-      ctx,
-      briefLlmDeps,
-      (level, kind, err) => {
-        if (kind === 'throw') {
-          console.warn(
-            `[digest] brief: synthesis L${level} threw for ${userId} — falling to L${level + 1}:`,
-            err?.message,
-          );
-        } else if (kind === 'success' && level === 2) {
-          console.log(`[digest] synthesis level=2_degraded user=${userId}`);
-        } else if (kind === 'success' && level === 3) {
-          console.log(`[digest] synthesis level=3_stub user=${userId}`);
-        }
-      },
-    );
-    synthesis = result.synthesis;
-    synthesisLevel = result.level;
-    // Public synthesis — parallel call. Profile-stripped; cache-
-    // shared across all users for the same (date, sensitivity,
-    // story-pool). Captures the FULL prose object (lead + signals +
-    // threads) since each personalised counterpart in the envelope
-    // can carry profile bias and the public surface needs sibling
-    // safe-versions of all three. Failure is non-fatal — the
-    // renderer's public-mode fail-safes (omit pull-quote / omit
-    // signals page / category-derived threads stub) handle absence
-    // rather than leaking the personalised version. Same adapted
-    // pool as the personalised synthesis.
-    try {
-      const pub = await generateDigestProsePublic(synthesisStories, sensitivity, briefLlmDeps);
-      if (pub) publicLead = pub;  // { lead, threads, signals, rankedStoryHashes }
-    } catch (err) {
-      console.warn(`[digest] brief: publicLead generation failed for ${userId}:`, err?.message);
+
+    // #4917: on a non-due tick the compose only refreshes the dashboard
+    // preview — nothing is delivered — so a young prior envelope's prose
+    // can stand in for the paid synthesis + public-lead calls, provided
+    // it still grounds against the CURRENT pool (pool rotation or an L3
+    // stub lead fails the gate and pays a fresh generation). Due ticks
+    // never enter this branch: delivered digests are always fresh
+    // (`winner.due` is preferred by pickWinningCandidateWithPool, so a
+    // due candidate with stories is always the winner).
+    if (!winner.due && NONDUE_SYNTHESIS_REUSE_MS > 0) {
+      const prior = await fetchLatestBriefEnvelope(userId);
+      const decision = resolveNonDueSynthesisReuse(prior, {
+        nowMs,
+        maxAgeMs: NONDUE_SYNTHESIS_REUSE_MS,
+        currentStories: synthesisStories,
+      });
+      if (decision.reuse) {
+        synthesis = decision.synthesis;
+        publicLead = decision.publicLead;
+        synthesisLevel = 1;
+        synthesisReused = true;
+        console.log(
+          `[digest] synthesis reused user=${userId} ` +
+            `age_min=${Math.round(decision.ageMs / 60_000)} public=${publicLead ? 1 : 0}`,
+        );
+      } else if (decision.reason !== 'no_prior_envelope') {
+        console.log(`[digest] synthesis reuse declined user=${userId} reason=${decision.reason}`);
+      }
+    }
+
+    if (!synthesisReused) {
+      const ctx = await buildSynthesisCtx(winner.rule, nowMs);
+      const result = await runSynthesisWithFallback(
+        userId,
+        synthesisStories,
+        sensitivity,
+        ctx,
+        briefLlmDeps,
+        (level, kind, err) => {
+          if (kind === 'throw') {
+            console.warn(
+              `[digest] brief: synthesis L${level} threw for ${userId} — falling to L${level + 1}:`,
+              err?.message,
+            );
+          } else if (kind === 'success' && level === 2) {
+            console.log(`[digest] synthesis level=2_degraded user=${userId}`);
+          } else if (kind === 'success' && level === 3) {
+            console.log(`[digest] synthesis level=3_stub user=${userId}`);
+          }
+        },
+      );
+      synthesis = result.synthesis;
+      synthesisLevel = result.level;
+      // Public synthesis — parallel call. Profile-stripped; cache-
+      // shared across all users for the same (date, sensitivity,
+      // story-pool). Captures the FULL prose object (lead + signals +
+      // threads) since each personalised counterpart in the envelope
+      // can carry profile bias and the public surface needs sibling
+      // safe-versions of all three. Failure is non-fatal — the
+      // renderer's public-mode fail-safes (omit pull-quote / omit
+      // signals page / category-derived threads stub) handle absence
+      // rather than leaking the personalised version. Same adapted
+      // pool as the personalised synthesis.
+      try {
+        const pub = await generateDigestProsePublic(synthesisStories, sensitivity, briefLlmDeps);
+        if (pub) publicLead = pub;  // { lead, threads, signals, rankedStoryHashes }
+      } catch (err) {
+        console.warn(`[digest] brief: publicLead generation failed for ${userId}:`, err?.message);
+      }
     }
   }
 

--- a/tests/brief-synthesis-reuse.test.mjs
+++ b/tests/brief-synthesis-reuse.test.mjs
@@ -1,0 +1,124 @@
+// #4917 — non-due synthesis reuse decision (pure module).
+//
+// Reuse must be conservative: only a young-enough prior envelope whose
+// lead still grounds against the CURRENT story pool may stand in for a
+// paid synthesis, and only on non-due ticks (the orchestrator gates on
+// `winner.due`; this module only judges the envelope).
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  resolveNonDueSynthesisReuse,
+  DEFAULT_NONDUE_SYNTHESIS_REUSE_MIN,
+} from '../scripts/lib/brief-synthesis-reuse.mjs';
+
+const NOW = 1_751_700_000_000;
+const MAX_AGE = 6 * 60 * 60 * 1000;
+
+// Stories with proper-noun anchors the leads below reference.
+const CURRENT_STORIES = [
+  { headline: 'Iran threatens to close Strait of Hormuz if US blockade continues' },
+  { headline: 'Pakistan and India exchange artillery fire across Kashmir line' },
+  { headline: 'European Union advances sanctions package against Belarus' },
+];
+
+const GROUNDED_LEAD =
+  'Iran’s threat to close the Strait of Hormuz dominates the desk today, with escalation risk spreading from Kashmir to the European Union’s Belarus sanctions track.';
+
+function envelope(overrides = {}, digestOverrides = {}) {
+  return {
+    version: 3,
+    issuedAt: NOW - 60 * 60 * 1000, // 1h old
+    data: {
+      digest: {
+        greeting: 'Good afternoon.',
+        lead: GROUNDED_LEAD,
+        threads: [{ tag: 'Diplomacy', teaser: 'Threads teaser.' }],
+        signals: [{ label: 'Escalation', value: 'rising' }],
+        ...digestOverrides,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveNonDueSynthesisReuse (#4917)', () => {
+  it('reuses a young, grounded prior envelope', () => {
+    const out = resolveNonDueSynthesisReuse(envelope(), {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES,
+    });
+    assert.equal(out.reuse, true);
+    assert.equal(out.synthesis.lead, GROUNDED_LEAD);
+    assert.deepEqual(out.synthesis.threads, [{ tag: 'Diplomacy', teaser: 'Threads teaser.' }]);
+    assert.equal(out.publicLead, null, 'no stored public prose → null, caller renders without it');
+    assert.equal(out.ageMs, 60 * 60 * 1000);
+  });
+
+  it('carries the public prose trio when the prior envelope stored it', () => {
+    const out = resolveNonDueSynthesisReuse(
+      envelope({}, {
+        publicLead: 'Iran’s Hormuz threat leads a tense day across three theatres.',
+        publicThreads: [{ tag: 'Security', teaser: 'Public teaser.' }],
+        publicSignals: [{ label: 'Risk', value: 'elevated' }],
+      }),
+      { nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES },
+    );
+    assert.equal(out.reuse, true);
+    assert.match(out.publicLead.lead, /Hormuz/);
+    assert.equal(out.publicLead.threads.length, 1);
+    assert.equal(out.publicLead.signals.length, 1);
+  });
+
+  it('declines when the envelope is older than the budget', () => {
+    const old = envelope({ issuedAt: NOW - MAX_AGE - 1 });
+    const out = resolveNonDueSynthesisReuse(old, {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES,
+    });
+    assert.deepEqual(out, { reuse: false, reason: 'stale' });
+  });
+
+  it('declines a future-dated issuedAt (clock skew is not "fresh")', () => {
+    const future = envelope({ issuedAt: NOW + 60_000 });
+    const out = resolveNonDueSynthesisReuse(future, {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES,
+    });
+    assert.deepEqual(out, { reuse: false, reason: 'stale' });
+  });
+
+  it('declines when there is no prior envelope', () => {
+    const out = resolveNonDueSynthesisReuse(null, {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES,
+    });
+    assert.deepEqual(out, { reuse: false, reason: 'no_prior_envelope' });
+  });
+
+  it('declines an envelope without a numeric issuedAt', () => {
+    const out = resolveNonDueSynthesisReuse(envelope({ issuedAt: 'yesterday' }), {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES,
+    });
+    assert.deepEqual(out, { reuse: false, reason: 'no_issued_at' });
+  });
+
+  it('declines a missing or trivial lead (prior compose degraded — regenerate)', () => {
+    const out = resolveNonDueSynthesisReuse(envelope({}, { lead: 'Short.' }), {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: CURRENT_STORIES,
+    });
+    assert.deepEqual(out, { reuse: false, reason: 'no_lead' });
+  });
+
+  it('declines when the pool rotated and the prior lead no longer grounds', () => {
+    const rotated = [
+      { headline: 'Argentina central bank surprises with emergency rate hike' },
+      { headline: 'Taiwan reports record incursion by PLA aircraft' },
+      { headline: 'Nigeria fuel subsidy protests spread to Lagos' },
+    ];
+    const out = resolveNonDueSynthesisReuse(envelope(), {
+      nowMs: NOW, maxAgeMs: MAX_AGE, currentStories: rotated,
+    });
+    assert.deepEqual(out, { reuse: false, reason: 'ungrounded' });
+  });
+
+  it('exports a sane default budget (used by the orchestrator env parse)', () => {
+    assert.equal(DEFAULT_NONDUE_SYNTHESIS_REUSE_MIN, 360);
+  });
+});


### PR DESCRIPTION
Closes #4917. Split from #4914 (item 5) — the last piece of the 2026-07-05 cache/cost batch, product-behavioral so it ships separately from #4916.

## Problem
`composeAndStoreBriefForUser` runs the paid canonical-synthesis chain (personalised ~900-tok gemini call + the parallel `generateDigestProsePublic` call) for EVERY user with eligible rules on EVERY ~30-min tick. `due` only influences winner selection — deliberately, so the dashboard "Latest Brief" preview refreshes off-schedule — but the LLM spend rides along unthrottled, and the prose cache key (`…digest:v8:{userId}:{sensitivity}:{poolHash}`) churns as the accumulator pool grows. A weekly subscriber could burn up to ~48 paid syntheses/day that no email ever used.

## Fix
New pure module `scripts/lib/brief-synthesis-reuse.mjs`: on a tick where NO candidate rule is due, the prose from the user's stored envelope (`brief:latest:{userId}` → `brief:{userId}:{slot}`) stands in for a fresh synthesis when it is (a) younger than a budget — default 6h, `DIGEST_NONDUE_SYNTHESIS_REUSE_MIN`, 0 disables — and (b) still passes `checkLeadGrounding` against the CURRENT story pool. Pool rotation or an L3 stub lead (no proper-noun anchors) fails the gate and pays a fresh generation, so reuse never ships prose the fresh path's own grounding gate would reject.

Contract preserved:
- **Due ticks always synthesize fresh** — delivered digests never carry reused prose (`winner.due` gates the branch; pickWinningCandidateWithPool prefers due candidates).
- **Stories keep refreshing every tick** — compose stays pure JS; only the paid prose is throttled.
- The F7 derived-threads pass still re-derives threads from the NEW story walk after splice-in, so reused threads never go stale in the rendered magazine.
- Telemetry: `[digest] synthesis reused user=… age_min=… public=…` / `synthesis reuse declined … reason=…` lines for spend attribution.

## Verification
- New `tests/brief-synthesis-reuse.test.mjs` (9 tests): reuse happy path + public-trio carry, stale/future-dated/missing envelope, missing lead, rotated-pool ungrounded decline, default budget.
- Digest-adjacent suites green: brief-llm (102), brief-from-digest-stories (118), digest-cooldown-decision (56), digest-delivered-log (58).
- `node --check` + biome clean on the orchestrator.

https://claude.ai/code/session_01WmhkGjZrb9RbV7pV3muFxP
