### PR TITLE
feat(ux): persistent read-state — NEW tags survive reload (#4923, slice a)

### DIFF
--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -535,10 +535,20 @@ export class NewsPanel extends Panel {
     let newItemIds: Set<string>;
 
     if (this.isFirstRender) {
-      // First render: mark all items as seen
+      // #4923: returning-user continuity. Stories that first appeared
+      // AFTER the previous visit stay NEW on the first render; everything
+      // older is marked seen. First-ever visits (no persisted state)
+      // keep the old mark-everything-seen behavior.
       activityTracker.updateItems(this.panelId, clusterIds);
-      activityTracker.markAsSeen(this.panelId);
-      newItemIds = new Set();
+      const prevVisitAt = activityTracker.getPreviousVisitTime();
+      const newSinceAway = prevVisitAt > 0
+        ? sorted.filter((c) => new Date(c.firstSeen).getTime() > prevVisitAt).map((c) => c.id)
+        : [];
+      newItemIds = new Set(newSinceAway);
+      activityTracker.markItemsSeen(
+        this.panelId,
+        clusterIds.filter((id) => !newItemIds.has(id)),
+      );
       this.isFirstRender = false;
     } else {
       // Subsequent renders: track new items

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -4,6 +4,7 @@ import type { NewsItem, ClusteredEvent, DeviationLevel, RelatedAsset, RelatedAss
 import { THREAT_PRIORITY } from '@/services/threat-classifier';
 import { formatTime, getCSSColor } from '@/utils';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
+import { computeNewSinceVisit } from '@/utils/new-since-visit';
 import { analysisWorker, enrichWithVelocityML, getClusterAssetContext, MAX_DISTANCE_KM, activityTracker, generateSummary, translateText, preloadRelatedAssetTables } from '@/services';
 import { getSourcePropagandaRisk, getSourceTier, getSourceType } from '@/config/feeds';
 import { SITE_VARIANT } from '@/config';
@@ -36,6 +37,9 @@ export class NewsPanel extends Panel {
   private onRelatedAssetsFocus?: (assets: RelatedAsset[], originLabel: string) => void;
   private onRelatedAssetsClear?: () => void;
   private isFirstRender = true;
+  /** Cluster ids that arrived while the user was away (#4923) — their NEW
+   * ribbons persist until seen instead of expiring with the 2-min window. */
+  private newSinceAwayIds = new Set<string>();
   private windowedList: WindowedList<PreparedCluster> | null = null;
   private useVirtualScroll = true;
   private renderRequestId = 0;
@@ -538,17 +542,19 @@ export class NewsPanel extends Panel {
       // #4923: returning-user continuity. Stories that first appeared
       // AFTER the previous visit stay NEW on the first render; everything
       // older is marked seen. First-ever visits (no persisted state)
-      // keep the old mark-everything-seen behavior.
+      // keep the old mark-everything-seen behavior. Partition logic lives
+      // in computeNewSinceVisit (pure, unit-tested).
       activityTracker.updateItems(this.panelId, clusterIds);
-      const prevVisitAt = activityTracker.getPreviousVisitTime();
-      const newSinceAway = prevVisitAt > 0
-        ? sorted.filter((c) => new Date(c.firstSeen).getTime() > prevVisitAt).map((c) => c.id)
-        : [];
-      newItemIds = new Set(newSinceAway);
-      activityTracker.markItemsSeen(
-        this.panelId,
-        clusterIds.filter((id) => !newItemIds.has(id)),
+      const { newIds, seenIds } = computeNewSinceVisit(
+        sorted,
+        activityTracker.getPreviousVisitTime(),
       );
+      newItemIds = new Set(newIds);
+      // Away-item NEW ribbons persist until actually seen — NOT limited to
+      // the 2-minute arrival window that gates streaming-item tags (the
+      // badge and ribbon would otherwise diverge after 2 minutes).
+      for (const id of newIds) this.newSinceAwayIds.add(id);
+      activityTracker.markItemsSeen(this.panelId, seenIds);
       this.isFirstRender = false;
     } else {
       // Subsequent renders: track new items
@@ -560,7 +566,8 @@ export class NewsPanel extends Panel {
     const prepared: PreparedCluster[] = sorted.map(cluster => {
       const isNew = newItemIds.has(cluster.id);
       const shouldHighlight = activityTracker.shouldHighlight(this.panelId, cluster.id);
-      const showNewTag = activityTracker.isNewItem(this.panelId, cluster.id) && isNew;
+      const showNewTag = isNew
+        && (activityTracker.isNewItem(this.panelId, cluster.id) || this.newSinceAwayIds.has(cluster.id));
 
       return {
         cluster,

--- a/src/services/activity-tracker.ts
+++ b/src/services/activity-tracker.ts
@@ -17,6 +17,23 @@ export interface ActivityState {
 /** Duration to show "NEW" tag on items (2 minutes) */
 export const NEW_TAG_DURATION_MS = 2 * 60 * 1000;
 
+/**
+ * #4923: persisted read-state. Holds the timestamp of the user's previous
+ * visit so a returning session can distinguish "new since you were last
+ * here" from "new to this page load". Listed in CLOUD_SYNC_KEYS, so
+ * signed-in users get it synced across devices via cloud-prefs-sync with
+ * zero extra wiring here.
+ */
+export const READ_STATE_KEY = 'wm-read-state-v1';
+
+/** Throttle for lastVisitAt writes — markAsSeen fires per scroll/click. */
+const READ_STATE_PERSIST_INTERVAL_MS = 30 * 1000;
+
+interface PersistedReadState {
+  v: 1;
+  lastVisitAt: number;
+}
+
 /** Duration for highlight glow effect (30 seconds) */
 export const HIGHLIGHT_DURATION_MS = 30 * 1000;
 
@@ -24,6 +41,65 @@ class ActivityTracker {
   private panels: Map<string, ActivityState> = new Map();
   private observers: Map<string, IntersectionObserver> = new Map();
   private onChangeCallbacks: Map<string, (newCount: number) => void> = new Map();
+  /** lastVisitAt from the PREVIOUS session, read once at load (0 = none). */
+  private previousVisitAt = 0;
+  private lastPersistAt = 0;
+
+  constructor() {
+    this.loadReadState();
+    if (typeof window !== 'undefined') {
+      // Flush on the way out so the next session's "previous visit" is
+      // accurate even if the throttle window was open.
+      window.addEventListener('beforeunload', () => this.persistLastVisit(true));
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') this.persistLastVisit(true);
+      });
+    }
+  }
+
+  private loadReadState(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const raw = localStorage.getItem(READ_STATE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Partial<PersistedReadState>;
+      if (parsed && typeof parsed.lastVisitAt === 'number' && Number.isFinite(parsed.lastVisitAt)) {
+        this.previousVisitAt = parsed.lastVisitAt;
+      }
+    } catch {
+      // Corrupt state degrades to "no previous visit" — old behavior.
+    }
+  }
+
+  /**
+   * Timestamp of the previous session's last activity (0 when unknown).
+   * Panels use this to keep items that arrived while the user was away
+   * flagged NEW on the first render instead of blanket-marking everything
+   * seen (#4923 — the "every visit is a stateless snapshot" bug).
+   */
+  getPreviousVisitTime(): number {
+    return this.previousVisitAt;
+  }
+
+  private persistLastVisit(force = false): void {
+    if (typeof localStorage === 'undefined') return;
+    const now = Date.now();
+    if (!force && now - this.lastPersistAt < READ_STATE_PERSIST_INTERVAL_MS) return;
+    this.lastPersistAt = now;
+    try {
+      const state: PersistedReadState = { v: 1, lastVisitAt: now };
+      localStorage.setItem(READ_STATE_KEY, JSON.stringify(state));
+    } catch {
+      // Quota/privacy-mode failures degrade to session-only behavior.
+    }
+  }
+
+  /** Test hook: re-read persisted state after stubbing localStorage. */
+  reloadReadStateForTests(): void {
+    this.previousVisitAt = 0;
+    this.lastPersistAt = 0;
+    this.loadReadState();
+  }
 
   /**
    * Initialize tracking for a panel
@@ -96,11 +172,38 @@ class ActivityTracker {
 
     state.newCount = 0;
     state.lastInteraction = Date.now();
+    this.persistLastVisit();
 
     // Notify listeners
     const callback = this.onChangeCallbacks.get(panelId);
     if (callback) {
       callback(0);
+    }
+  }
+
+  /**
+   * Mark a SUBSET of items as seen (#4923). Used on a returning user's
+   * first render: items older than the previous visit are seen, items
+   * that arrived while away keep their NEW state.
+   */
+  markItemsSeen(panelId: string, itemIds: string[]): void {
+    const state = this.panels.get(panelId);
+    if (!state) return;
+
+    for (const id of itemIds) {
+      state.seenIds.add(id);
+    }
+    let unseen = 0;
+    for (const id of state.firstSeenTime.keys()) {
+      if (!state.seenIds.has(id)) unseen++;
+    }
+    state.newCount = unseen;
+    state.lastInteraction = Date.now();
+    this.persistLastVisit();
+
+    const callback = this.onChangeCallbacks.get(panelId);
+    if (callback) {
+      callback(state.newCount);
     }
   }
 

--- a/src/services/activity-tracker.ts
+++ b/src/services/activity-tracker.ts
@@ -34,6 +34,20 @@ interface PersistedReadState {
   lastVisitAt: number;
 }
 
+/**
+ * #4926 external review: in sandboxed iframes / blocked-storage modes the
+ * `localStorage` accessor ITSELF throws (SecurityError) — `typeof` does
+ * not guard property-getter throws, only undeclared identifiers. All
+ * storage access goes through this helper; null = session-only mode.
+ */
+function getSafeLocalStorage(): Storage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
 /** Duration for highlight glow effect (30 seconds) */
 export const HIGHLIGHT_DURATION_MS = 30 * 1000;
 
@@ -44,6 +58,14 @@ class ActivityTracker {
   /** lastVisitAt from the PREVIOUS session, read once at load (0 = none). */
   private previousVisitAt = 0;
   private lastPersistAt = 0;
+  /**
+   * #4926 external review (acknowledgement model): the persisted
+   * timestamp advances ONLY on genuine user interaction (scroll/click/
+   * visibility via markAsSeen) — never on the programmatic first-render
+   * markItemsSeen. A session with zero interaction persists NOTHING, so
+   * any number of reloads keeps away-stories NEW.
+   */
+  private lastInteractionAt: number | null = null;
   private lifecycleInstalled = false;
 
   constructor() {
@@ -90,9 +112,10 @@ class ActivityTracker {
   }
 
   private loadReadState(): void {
-    if (typeof localStorage === 'undefined') return;
+    const storage = getSafeLocalStorage();
+    if (!storage) return;
     try {
-      const raw = localStorage.getItem(READ_STATE_KEY);
+      const raw = storage.getItem(READ_STATE_KEY);
       if (!raw) return;
       const parsed = JSON.parse(raw) as Partial<PersistedReadState>;
       if (parsed && typeof parsed.lastVisitAt === 'number' && Number.isFinite(parsed.lastVisitAt)) {
@@ -120,13 +143,18 @@ class ActivityTracker {
   }
 
   private persistLastVisit(force = false): void {
-    if (typeof localStorage === 'undefined') return;
+    // Nothing to persist until the user actually interacted this session
+    // — flushing "now" on unload/hide would mark away-stories seen after
+    // a plain F5 with zero acknowledgement.
+    if (this.lastInteractionAt === null) return;
+    const storage = getSafeLocalStorage();
+    if (!storage) return;
     const now = Date.now();
     if (!force && now - this.lastPersistAt < READ_STATE_PERSIST_INTERVAL_MS) return;
     this.lastPersistAt = now;
     try {
-      const state: PersistedReadState = { v: 1, lastVisitAt: now };
-      localStorage.setItem(READ_STATE_KEY, JSON.stringify(state));
+      const state: PersistedReadState = { v: 1, lastVisitAt: this.lastInteractionAt };
+      storage.setItem(READ_STATE_KEY, JSON.stringify(state));
     } catch {
       // Quota/privacy-mode failures degrade to session-only behavior.
     }
@@ -136,6 +164,7 @@ class ActivityTracker {
   _reloadReadStateForTests(): void {
     this.previousVisitAt = 0;
     this.lastPersistAt = 0;
+    this.lastInteractionAt = null;
     this.loadReadState();
   }
 
@@ -144,6 +173,10 @@ class ActivityTracker {
    */
   register(panelId: string): void {
     this.installLifecycleListeners();
+    // Cloud prefs may have applied between module load and the first
+    // panel registering — re-read (monotonic) so the first partition
+    // sees a cross-device visit that landed in that window.
+    this.refreshPreviousVisitFromStorage();
     if (!this.panels.has(panelId)) {
       this.panels.set(panelId, {
         seenIds: new Set(),
@@ -211,6 +244,7 @@ class ActivityTracker {
 
     state.newCount = 0;
     state.lastInteraction = Date.now();
+    this.lastInteractionAt = Date.now();
     this.persistLastVisit();
 
     // Notify listeners
@@ -238,7 +272,8 @@ class ActivityTracker {
     }
     state.newCount = unseen;
     state.lastInteraction = Date.now();
-    this.persistLastVisit();
+    // Deliberately NO persistence here: this is programmatic bootstrap
+    // marking, not user acknowledgement (#4926 external review P1).
 
     const callback = this.onChangeCallbacks.get(panelId);
     if (callback) {

--- a/src/services/activity-tracker.ts
+++ b/src/services/activity-tracker.ts
@@ -44,17 +44,49 @@ class ActivityTracker {
   /** lastVisitAt from the PREVIOUS session, read once at load (0 = none). */
   private previousVisitAt = 0;
   private lastPersistAt = 0;
+  private lifecycleInstalled = false;
 
   constructor() {
+    // Constructor stays side-effect-light (a single localStorage read);
+    // window/document listeners install lazily on first register() —
+    // mirrors the repo's explicit-install convention (cloud-prefs-sync
+    // install()) without adding a bootstrap call site.
     this.loadReadState();
-    if (typeof window !== 'undefined') {
-      // Flush on the way out so the next session's "previous visit" is
-      // accurate even if the throttle window was open.
-      window.addEventListener('beforeunload', () => this.persistLastVisit(true));
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'hidden') this.persistLastVisit(true);
-      });
-    }
+  }
+
+  private installLifecycleListeners(): void {
+    if (this.lifecycleInstalled || typeof window === 'undefined') return;
+    this.lifecycleInstalled = true;
+    // Flush on the way out so the next session's "previous visit" is
+    // accurate even if the throttle window was open. visibilitychange is
+    // the reliable signal on mobile Safari; beforeunload is the desktop
+    // belt-and-braces.
+    window.addEventListener('beforeunload', () => this.persistLastVisit(true));
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') this.persistLastVisit(true);
+    });
+    // Cross-device continuity: when cloud prefs land AFTER module load
+    // (sign-in mid-session, another device visited more recently), adopt
+    // the newer previous-visit timestamp — otherwise the cloud value is
+    // silently ignored until the next full reload.
+    window.addEventListener('wm:cloud-prefs-applied', (event) => {
+      const keys = (event as CustomEvent<{ keys?: string[] }>).detail?.keys;
+      if (Array.isArray(keys) && keys.includes(READ_STATE_KEY)) {
+        this.refreshPreviousVisitFromStorage();
+      }
+    });
+  }
+
+  /** Adopt a LATER previous-visit timestamp written by cloud sync. */
+  private refreshPreviousVisitFromStorage(): void {
+    const before = this.previousVisitAt;
+    const current = this.previousVisitAt;
+    this.previousVisitAt = 0;
+    this.loadReadState();
+    // Monotonic: another device's more recent visit advances the marker;
+    // an older cloud value must not resurrect already-seen NEW state.
+    if (this.previousVisitAt < current) this.previousVisitAt = current;
+    if (this.previousVisitAt !== before) this.lastPersistAt = 0;
   }
 
   private loadReadState(): void {
@@ -64,7 +96,13 @@ class ActivityTracker {
       if (!raw) return;
       const parsed = JSON.parse(raw) as Partial<PersistedReadState>;
       if (parsed && typeof parsed.lastVisitAt === 'number' && Number.isFinite(parsed.lastVisitAt)) {
-        this.previousVisitAt = parsed.lastVisitAt;
+        // Clock-skew guard: a future timestamp (device clock jumped back
+        // after writing, or a corrupt cloud value) would blank every NEW
+        // tag for the whole session. Tolerate small skew, ignore beyond it.
+        const maxPlausible = Date.now() + 10 * 60 * 1000;
+        if (parsed.lastVisitAt <= maxPlausible) {
+          this.previousVisitAt = parsed.lastVisitAt;
+        }
       }
     } catch {
       // Corrupt state degrades to "no previous visit" — old behavior.
@@ -95,7 +133,7 @@ class ActivityTracker {
   }
 
   /** Test hook: re-read persisted state after stubbing localStorage. */
-  reloadReadStateForTests(): void {
+  _reloadReadStateForTests(): void {
     this.previousVisitAt = 0;
     this.lastPersistAt = 0;
     this.loadReadState();
@@ -105,6 +143,7 @@ class ActivityTracker {
    * Initialize tracking for a panel
    */
   register(panelId: string): void {
+    this.installLifecycleListeners();
     if (!this.panels.has(panelId)) {
       this.panels.set(panelId, {
         seenIds: new Set(),

--- a/src/utils/new-since-visit.ts
+++ b/src/utils/new-since-visit.ts
@@ -1,0 +1,37 @@
+/**
+ * #4923: pure "new since your last visit" partition, extracted from
+ * NewsPanel's first render so the behavior is unit-testable (review
+ * finding on PR #4926 — a source-regex test cannot catch broken wiring).
+ *
+ * SEMANTIC DECISION (explicit, revisit deliberately): a cluster counts as
+ * new-since-away when its `firstSeen` — the EARLIEST article in the
+ * cluster — postdates the previous visit. Genuinely new stories flag NEW;
+ * a long-running story that merely gained an update while away does NOT
+ * (using lastUpdated would keep rolling stories perpetually NEW on every
+ * return, which trains users to ignore the signal).
+ *
+ * prevVisitAt <= 0 means "no known previous visit" — everything is seen,
+ * matching the pre-#4923 first-render behavior.
+ */
+
+export interface NewSinceVisitCluster {
+  id: string;
+  firstSeen: Date | string | number;
+}
+
+export function computeNewSinceVisit(
+  clusters: readonly NewSinceVisitCluster[],
+  prevVisitAt: number,
+): { newIds: string[]; seenIds: string[] } {
+  const newIds: string[] = [];
+  const seenIds: string[] = [];
+  for (const cluster of clusters) {
+    const firstSeenMs = new Date(cluster.firstSeen).getTime();
+    if (prevVisitAt > 0 && Number.isFinite(firstSeenMs) && firstSeenMs > prevVisitAt) {
+      newIds.push(cluster.id);
+    } else {
+      seenIds.push(cluster.id);
+    }
+  }
+  return { newIds, seenIds };
+}

--- a/src/utils/sync-keys.ts
+++ b/src/utils/sync-keys.ts
@@ -36,6 +36,10 @@ export const CLOUD_SYNC_KEYS = [
   'wm-map-theme:carto',
   // Live-stream mode
   'wm-live-streams-always-on',
+  // #4923 read-state: previous-visit timestamp driving "new since you were
+  // last here" — synced so a phone visit doesn't re-flag stories already
+  // read on desktop.
+  'wm-read-state-v1',
 ] as const;
 
 export type CloudSyncKey = (typeof CLOUD_SYNC_KEYS)[number];

--- a/tests/activity-tracker-read-state.test.mts
+++ b/tests/activity-tracker-read-state.test.mts
@@ -1,0 +1,93 @@
+// #4923 (a): persistent read-state — a returning user must see NEW tags
+// for stories that arrived while away, instead of the first render
+// blanket-marking everything seen.
+
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Stub localStorage BEFORE the module under test reads it at import time.
+const store = new Map<string, string>();
+(globalThis as Record<string, unknown>).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+const { activityTracker, READ_STATE_KEY } = await import('../src/services/activity-tracker.ts');
+
+describe('persisted read-state (#4923)', () => {
+  beforeEach(() => {
+    store.clear();
+    activityTracker.clear();
+    activityTracker.reloadReadStateForTests();
+  });
+
+  it('reads the previous visit timestamp from localStorage', () => {
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 1_751_000_000_000 }));
+    activityTracker.reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 1_751_000_000_000);
+  });
+
+  it('returns 0 (old behavior) when no state or corrupt state exists', () => {
+    assert.equal(activityTracker.getPreviousVisitTime(), 0);
+    store.set(READ_STATE_KEY, '{not json');
+    activityTracker.reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 0);
+  });
+
+  it('markAsSeen persists lastVisitAt so the NEXT session knows this one happened', () => {
+    activityTracker.register('panel');
+    activityTracker.updateItems('panel', ['a']);
+    const before = Date.now();
+    activityTracker.markAsSeen('panel');
+    const raw = store.get(READ_STATE_KEY);
+    assert.ok(raw, 'read-state must be written');
+    const parsed = JSON.parse(raw!);
+    assert.equal(parsed.v, 1);
+    assert.ok(parsed.lastVisitAt >= before, 'lastVisitAt must be fresh');
+  });
+
+  it('markItemsSeen marks a subset and leaves the rest counted as new', () => {
+    let reported = -1;
+    activityTracker.register('panel');
+    activityTracker.onChange('panel', (n) => { reported = n; });
+    activityTracker.updateItems('panel', ['old1', 'old2', 'fresh']);
+    activityTracker.markItemsSeen('panel', ['old1', 'old2']);
+    assert.equal(activityTracker.getNewCount('panel'), 1, 'the unseen item stays new');
+    assert.equal(reported, 1, 'onChange reports the remaining count');
+    assert.equal(activityTracker.shouldHighlight('panel', 'fresh'), true);
+    assert.equal(activityTracker.shouldHighlight('panel', 'old1'), false);
+  });
+
+  it('a second updateItems keeps subset-seen state intact', () => {
+    activityTracker.register('panel');
+    activityTracker.updateItems('panel', ['old1', 'fresh']);
+    activityTracker.markItemsSeen('panel', ['old1']);
+    const newIds = activityTracker.updateItems('panel', ['old1', 'fresh']);
+    assert.deepEqual(newIds, ['fresh'], 'only the never-seen item reports as new');
+  });
+});
+
+describe('NewsPanel first-render wiring (source-textual)', () => {
+  const src = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '../src/components/NewsPanel.ts'),
+    'utf-8',
+  );
+
+  it('first render consults the previous visit instead of blanket-marking seen', () => {
+    assert.match(src, /getPreviousVisitTime\(\)/, 'must read the persisted previous visit');
+    assert.match(src, /markItemsSeen\(/, 'must use subset-seen, not markAsSeen(all)');
+    assert.doesNotMatch(src, /First render: mark all items as seen/, 'old blanket branch must be gone');
+  });
+
+  it('read-state key is cloud-synced', () => {
+    const syncSrc = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '../src/utils/sync-keys.ts'),
+      'utf-8',
+    );
+    assert.match(syncSrc, /'wm-read-state-v1'/);
+  });
+});

--- a/tests/activity-tracker-read-state.test.mts
+++ b/tests/activity-tracker-read-state.test.mts
@@ -1,6 +1,8 @@
 // #4923 (a): persistent read-state — a returning user must see NEW tags
 // for stories that arrived while away, instead of the first render
-// blanket-marking everything seen.
+// blanket-marking everything seen. Extended per the PR #4926 review round:
+// throttle, force-flush, quota-throw, wrong-shape, cloud-refresh, and the
+// pure computeNewSinceVisit partition.
 
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach } from 'node:test';
@@ -8,34 +10,56 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Stub localStorage BEFORE the module under test reads it at import time.
+// Stub browser globals BEFORE the module under test touches them.
 const store = new Map<string, string>();
+let setItemImpl = (k: string, v: string) => { store.set(k, String(v)); };
 (globalThis as Record<string, unknown>).localStorage = {
   getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  setItem: (k: string, v: string) => setItemImpl(k, v),
   removeItem: (k: string) => { store.delete(k); },
+};
+const windowHandlers = new Map<string, (event?: unknown) => void>();
+(globalThis as Record<string, unknown>).window = {
+  addEventListener: (name: string, fn: (event?: unknown) => void) => { windowHandlers.set(name, fn); },
+  dispatchEvent: () => true,
+};
+const documentHandlers = new Map<string, () => void>();
+(globalThis as Record<string, unknown>).document = {
+  visibilityState: 'hidden',
+  addEventListener: (name: string, fn: () => void) => { documentHandlers.set(name, fn); },
 };
 
 const { activityTracker, READ_STATE_KEY } = await import('../src/services/activity-tracker.ts');
+const { computeNewSinceVisit } = await import('../src/utils/new-since-visit.ts');
 
 describe('persisted read-state (#4923)', () => {
   beforeEach(() => {
     store.clear();
+    setItemImpl = (k, v) => { store.set(k, String(v)); };
     activityTracker.clear();
-    activityTracker.reloadReadStateForTests();
+    activityTracker._reloadReadStateForTests();
   });
 
   it('reads the previous visit timestamp from localStorage', () => {
     store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 1_751_000_000_000 }));
-    activityTracker.reloadReadStateForTests();
+    activityTracker._reloadReadStateForTests();
     assert.equal(activityTracker.getPreviousVisitTime(), 1_751_000_000_000);
   });
 
-  it('returns 0 (old behavior) when no state or corrupt state exists', () => {
+  it('returns 0 for missing, corrupt, wrong-shape, and far-future state', () => {
     assert.equal(activityTracker.getPreviousVisitTime(), 0);
+
     store.set(READ_STATE_KEY, '{not json');
-    activityTracker.reloadReadStateForTests();
-    assert.equal(activityTracker.getPreviousVisitTime(), 0);
+    activityTracker._reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 0, 'corrupt JSON degrades to 0');
+
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1 }));
+    activityTracker._reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 0, 'valid JSON missing lastVisitAt degrades to 0');
+
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: Date.now() + 60 * 60 * 1000 }));
+    activityTracker._reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 0, 'clock-skew guard: far-future timestamp ignored');
   });
 
   it('markAsSeen persists lastVisitAt so the NEXT session knows this one happened', () => {
@@ -50,6 +74,59 @@ describe('persisted read-state (#4923)', () => {
     assert.ok(parsed.lastVisitAt >= before, 'lastVisitAt must be fresh');
   });
 
+  it('throttles repeat writes within the persist interval', () => {
+    activityTracker.register('panel');
+    activityTracker.updateItems('panel', ['a']);
+    activityTracker.markAsSeen('panel');
+    const first = store.get(READ_STATE_KEY);
+    store.delete(READ_STATE_KEY);
+    activityTracker.markAsSeen('panel'); // within 30s window
+    assert.equal(store.has(READ_STATE_KEY), false, 'second write inside the throttle window is skipped');
+    assert.ok(first, 'first write happened');
+  });
+
+  it('visibilitychange:hidden force-flushes past the throttle', () => {
+    activityTracker.register('panel'); // lazy-installs lifecycle listeners
+    activityTracker.updateItems('panel', ['a']);
+    activityTracker.markAsSeen('panel');
+    store.delete(READ_STATE_KEY);
+    const onVisibility = documentHandlers.get('visibilitychange');
+    assert.ok(onVisibility, 'visibilitychange listener installed on first register');
+    onVisibility!();
+    assert.ok(store.has(READ_STATE_KEY), 'hidden-tab flush bypasses the throttle');
+  });
+
+  it('localStorage quota/privacy failures degrade silently', () => {
+    activityTracker.register('panel');
+    activityTracker.updateItems('panel', ['a']);
+    setItemImpl = () => { throw new Error('QuotaExceededError'); };
+    assert.doesNotThrow(() => activityTracker.markAsSeen('panel'));
+    assert.equal(activityTracker.getNewCount('panel'), 0, 'in-memory state still updated');
+  });
+
+  it('cloud-prefs-applied refresh adopts a NEWER cross-device visit, never an older one', () => {
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 1_000 }));
+    activityTracker._reloadReadStateForTests();
+    activityTracker.register('panel'); // installs the cloud-applied listener
+    const onApplied = windowHandlers.get('wm:cloud-prefs-applied');
+    assert.ok(onApplied, 'cloud-prefs-applied listener installed');
+
+    // Newer cloud value advances the marker.
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 2_000 }));
+    onApplied!({ detail: { keys: [READ_STATE_KEY] } });
+    assert.equal(activityTracker.getPreviousVisitTime(), 2_000);
+
+    // Older cloud value must NOT roll the marker back.
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 500 }));
+    onApplied!({ detail: { keys: [READ_STATE_KEY] } });
+    assert.equal(activityTracker.getPreviousVisitTime(), 2_000, 'monotonic across devices');
+
+    // Unrelated keys are ignored.
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 9_000 }));
+    onApplied!({ detail: { keys: ['worldmonitor-theme'] } });
+    assert.equal(activityTracker.getPreviousVisitTime(), 2_000);
+  });
+
   it('markItemsSeen marks a subset and leaves the rest counted as new', () => {
     let reported = -1;
     activityTracker.register('panel');
@@ -62,6 +139,11 @@ describe('persisted read-state (#4923)', () => {
     assert.equal(activityTracker.shouldHighlight('panel', 'old1'), false);
   });
 
+  it('markItemsSeen on an unregistered panel is a safe no-op', () => {
+    assert.doesNotThrow(() => activityTracker.markItemsSeen('never-registered', ['x']));
+    assert.equal(activityTracker.getNewCount('never-registered'), 0);
+  });
+
   it('a second updateItems keeps subset-seen state intact', () => {
     activityTracker.register('panel');
     activityTracker.updateItems('panel', ['old1', 'fresh']);
@@ -71,16 +153,51 @@ describe('persisted read-state (#4923)', () => {
   });
 });
 
+describe('computeNewSinceVisit (pure partition, #4926 review)', () => {
+  const clusters = [
+    { id: 'old-story', firstSeen: new Date('2026-07-05T08:00:00Z') },
+    { id: 'away-story', firstSeen: new Date('2026-07-05T12:00:00Z') },
+    { id: 'fresh-story', firstSeen: '2026-07-05T13:30:00Z' },
+  ];
+  const prevVisit = new Date('2026-07-05T10:00:00Z').getTime();
+
+  it('returning user: stories first seen after the previous visit are NEW, older are seen', () => {
+    const { newIds, seenIds } = computeNewSinceVisit(clusters, prevVisit);
+    assert.deepEqual(newIds, ['away-story', 'fresh-story']);
+    assert.deepEqual(seenIds, ['old-story']);
+  });
+
+  it('first-ever visit (prev=0): everything is seen — old behavior preserved', () => {
+    const { newIds, seenIds } = computeNewSinceVisit(clusters, 0);
+    assert.deepEqual(newIds, []);
+    assert.equal(seenIds.length, 3);
+  });
+
+  it('unparseable firstSeen falls into seen (never a stuck NEW tag)', () => {
+    const { newIds, seenIds } = computeNewSinceVisit(
+      [{ id: 'weird', firstSeen: 'not-a-date' }],
+      prevVisit,
+    );
+    assert.deepEqual(newIds, []);
+    assert.deepEqual(seenIds, ['weird']);
+  });
+});
+
 describe('NewsPanel first-render wiring (source-textual)', () => {
   const src = readFileSync(
     resolve(dirname(fileURLToPath(import.meta.url)), '../src/components/NewsPanel.ts'),
     'utf-8',
   );
 
-  it('first render consults the previous visit instead of blanket-marking seen', () => {
+  it('first render consults the pure partition instead of blanket-marking seen', () => {
+    assert.match(src, /computeNewSinceVisit\(/, 'must use the tested pure partition');
     assert.match(src, /getPreviousVisitTime\(\)/, 'must read the persisted previous visit');
     assert.match(src, /markItemsSeen\(/, 'must use subset-seen, not markAsSeen(all)');
     assert.doesNotMatch(src, /First render: mark all items as seen/, 'old blanket branch must be gone');
+  });
+
+  it('away-item NEW ribbons are not gated on the 2-minute arrival window', () => {
+    assert.match(src, /newSinceAwayIds\.has\(cluster\.id\)/, 'ribbon persists for away items until seen');
   });
 
   it('read-state key is cloud-synced', () => {

--- a/tests/activity-tracker-read-state.test.mts
+++ b/tests/activity-tracker-read-state.test.mts
@@ -85,15 +85,22 @@ describe('persisted read-state (#4923)', () => {
     assert.ok(first, 'first write happened');
   });
 
-  it('visibilitychange:hidden force-flushes past the throttle', () => {
+  it('visibilitychange:hidden force-flushes past the throttle — but ONLY after genuine interaction', () => {
     activityTracker.register('panel'); // lazy-installs lifecycle listeners
-    activityTracker.updateItems('panel', ['a']);
-    activityTracker.markAsSeen('panel');
-    store.delete(READ_STATE_KEY);
     const onVisibility = documentHandlers.get('visibilitychange');
     assert.ok(onVisibility, 'visibilitychange listener installed on first register');
+
+    // No interaction yet: the flush must persist NOTHING (#4926 review P1
+    // — a minted "now" here marked away-stories seen without acknowledgement).
+    activityTracker.updateItems('panel', ['a']);
+    activityTracker.markItemsSeen('panel', ['a']);
     onVisibility!();
-    assert.ok(store.has(READ_STATE_KEY), 'hidden-tab flush bypasses the throttle');
+    assert.equal(store.has(READ_STATE_KEY), false, 'zero-interaction session persists nothing');
+
+    activityTracker.markAsSeen('panel');
+    store.delete(READ_STATE_KEY);
+    onVisibility!();
+    assert.ok(store.has(READ_STATE_KEY), 'post-interaction flush bypasses the throttle');
   });
 
   it('localStorage quota/privacy failures degrade silently', () => {
@@ -206,5 +213,70 @@ describe('NewsPanel first-render wiring (source-textual)', () => {
       'utf-8',
     );
     assert.match(syncSrc, /'wm-read-state-v1'/);
+  });
+});
+
+describe('acknowledgement model (#4926 external review P1)', () => {
+  it('REGRESSION: F5 before any interaction keeps away-stories NEW (markItemsSeen persists nothing)', () => {
+    store.clear();
+    activityTracker.clear();
+    // Session 1: previous visit was yesterday; first render partitions and
+    // programmatically marks old items seen. User hits F5 WITHOUT ever
+    // scrolling/clicking.
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 1_000 }));
+    activityTracker._reloadReadStateForTests();
+    activityTracker.register('panel');
+    activityTracker.updateItems('panel', ['old', 'away']);
+    activityTracker.markItemsSeen('panel', ['old']);
+    assert.equal(store.get(READ_STATE_KEY), JSON.stringify({ v: 1, lastVisitAt: 1_000 }),
+      'programmatic bootstrap marking must not advance the persisted visit');
+
+    // Session 2 (the reload): previous visit is STILL yesterday.
+    activityTracker.clear();
+    activityTracker._reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 1_000, 'away stories stay NEW after F5');
+  });
+
+  it('genuine interaction advances the persisted visit to the interaction time', () => {
+    store.clear();
+    activityTracker.clear();
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 1_000 }));
+    activityTracker._reloadReadStateForTests();
+    activityTracker.register('panel');
+    activityTracker.updateItems('panel', ['a']);
+    const before = Date.now();
+    activityTracker.markAsSeen('panel');
+    const persisted = JSON.parse(store.get(READ_STATE_KEY)!);
+    assert.ok(persisted.lastVisitAt >= before, 'interaction persists the acknowledgement time');
+  });
+
+  it('register() re-reads storage so a cloud value landing pre-first-render is seen (#4926-2)', () => {
+    store.clear();
+    activityTracker.clear();
+    activityTracker._reloadReadStateForTests();
+    assert.equal(activityTracker.getPreviousVisitTime(), 0);
+    // Cloud blob applies between module load and first panel registration.
+    store.set(READ_STATE_KEY, JSON.stringify({ v: 1, lastVisitAt: 5_000 }));
+    activityTracker.register('late-panel');
+    assert.equal(activityTracker.getPreviousVisitTime(), 5_000, 'first partition must see the cloud visit');
+  });
+});
+
+describe('sandboxed-storage safety (#4926 external review #3)', () => {
+  it('a THROWING localStorage accessor degrades to session-only instead of crashing', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')!;
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() { throw new Error('SecurityError: access denied'); },
+    });
+    try {
+      assert.doesNotThrow(() => activityTracker._reloadReadStateForTests());
+      assert.equal(activityTracker.getPreviousVisitTime(), 0);
+      activityTracker.register('panel');
+      activityTracker.updateItems('panel', ['a']);
+      assert.doesNotThrow(() => activityTracker.markAsSeen('panel'));
+    } finally {
+      Object.defineProperty(globalThis, 'localStorage', descriptor);
+    }
   });
 });


### PR DESCRIPTION
First slice of #4923 (durable continuity). **Do not auto-merge — held for review.**

## What
- `src/services/activity-tracker.ts`: persists `lastVisitAt` (localStorage `wm-read-state-v1`, throttled + flushed on hide/unload); new `getPreviousVisitTime()` + subset `markItemsSeen()`.
- `src/components/NewsPanel.ts`: first render now marks seen only clusters whose `firstSeen` predates the previous visit — stories that arrived while the user was away keep NEW badge/tag/highlight. First-ever visits behave exactly as before.
- `src/utils/sync-keys.ts`: key added to `CLOUD_SYNC_KEYS` → signed-in cross-device sync rides the existing cloud-prefs engine + `userPreferences` table (no new Convex module — avoids the offline-codegen trap).

## Verification
- `tests/activity-tracker-read-state.test.mts` (7 tests): persisted-visit load, corrupt-state degrade, write-on-seen, subset-seen semantics, source-textual wiring assertions.
- `npm run typecheck` + biome clean.

Remaining #4923 slices (catch-up strip, follow-a-story, high-severity push, since cursor) are mapped in the epic with the proto-regen items deliberately split out.

https://claude.ai/code/session_01WmhkGjZrb9RbV7pV3muFxP