### PR TITLE
feat(markets): macro-print actuals, earnings in the daily brief, finance-demotion seam (#4922)

### DIFF
--- a/scripts/_clustering.mjs
+++ b/scripts/_clustering.mjs
@@ -322,6 +322,15 @@ export function computeEntityCorroboration(clusters, nowMs = Date.now()) {
  *   each gate dropped — previously all three gates were silent.
  */
 export function selectTopStories(clusters, maxCount = 8, stats, opts = {}) {
+  // Positional-arg guard (#4929 external review): a caller passing
+  // { demoteFinance } in the stats slot would silently get default
+  // demotion AND a stats-shaped object mutated with counters. Detect the
+  // opts shape and shift.
+  if (stats && typeof stats === 'object' && 'demoteFinance' in stats
+      && (!opts || Object.keys(opts).length === 0)) {
+    opts = stats;
+    stats = undefined;
+  }
   const nowMs = Date.now();
   computeEntityCorroboration(clusters, nowMs);
   const admissible = [];

--- a/scripts/_clustering.mjs
+++ b/scripts/_clustering.mjs
@@ -187,7 +187,16 @@ function hasStrongNonKeywordSignal(cluster) {
   return isLlmThreatSource(cluster.threat?.source) && (level === 'high' || level === 'critical');
 }
 
-export function scoreImportance(cluster) {
+/**
+ * @param {object} cluster
+ * @param {{ demoteFinance?: boolean }} [opts] #4922 (f): the ×0.35 finance
+ *   demotion is correct for the geopolitical World Brief but backwards for
+ *   a finance-focused ranking surface. Pass demoteFinance:false to rank
+ *   finance neutrally. NOTE: the only live consumer today (seed-insights)
+ *   runs the full variant and keeps the default — this parameter is the
+ *   seam a finance-variant insights run plugs into (tracked in #4922).
+ */
+export function scoreImportance(cluster, opts = {}) {
   let score = 0;
   const titleLower = normalizedMatchText(cluster.primaryTitle);
   const upstream = finiteNumber(cluster.upstreamImportanceScore, 0);
@@ -228,7 +237,8 @@ export function scoreImportance(cluster) {
   if (crisisN > 0) score += 15 + crisisN * 5;
 
   const demoteN = countMatches(titleLower, DEMOTE_KEYWORDS);
-  if (demoteN > 0 && !cluster.entityCorroboration && !hasStrongNonKeywordSignal(cluster)) score *= 0.35;
+  const demoteFinance = opts.demoteFinance !== false;
+  if (demoteFinance && demoteN > 0 && !cluster.entityCorroboration && !hasStrongNonKeywordSignal(cluster)) score *= 0.35;
 
   return score;
 }
@@ -311,13 +321,13 @@ export function computeEntityCorroboration(clusters, nowMs = Date.now()) {
  *   #4920 coverage ledger: when provided, populated with how many clusters
  *   each gate dropped — previously all three gates were silent.
  */
-export function selectTopStories(clusters, maxCount = 8, stats) {
+export function selectTopStories(clusters, maxCount = 8, stats, opts = {}) {
   const nowMs = Date.now();
   computeEntityCorroboration(clusters, nowMs);
   const admissible = [];
   let admissibilityDropped = 0;
   for (const c of clusters) {
-    const score = scoreImportance(c);
+    const score = scoreImportance(c, opts);
     if (isTopStoriesAdmissible(c, score)) {
       admissible.push({ cluster: c, score, effectiveScore: score * recencyWeight(c, nowMs) });
     } else {

--- a/scripts/_econ-actuals.mjs
+++ b/scripts/_econ-actuals.mjs
@@ -28,6 +28,16 @@ function parseObs(observation) {
   return Number.isFinite(value) ? { date: observation.date, value } : null;
 }
 
+/** Consecutive-period guard: pct_mom/diff_k compare ADJACENT periods; a
+ * missing month in between would silently mislabel a 2-month change as
+ * month-over-month (review finding). 45 days tolerates publication
+ * jitter on monthly series. */
+const MAX_ADJACENT_GAP_MS = 45 * 86400_000;
+function isAdjacent(newer, older) {
+  const gap = new Date(newer.date).getTime() - new Date(older.date).getTime();
+  return Number.isFinite(gap) && gap > 0 && gap <= MAX_ADJACENT_GAP_MS;
+}
+
 /**
  * @param {Array<{ date: string; value: string }>} observations DESC-sorted
  *   FRED observations (newest first).
@@ -36,38 +46,44 @@ function parseObs(observation) {
  *   Empty strings when there is not enough usable data.
  */
 export function computePrintValues(observations, transform) {
-  const usable = (Array.isArray(observations) ? observations : [])
-    .map(parseObs)
-    .filter(Boolean);
   const empty = { actual: '', previous: '', obsDate: '' };
-  if (usable.length === 0) return empty;
+  const raw = Array.isArray(observations) ? observations : [];
+  // The LEADING observation must be parseable — if the newest value is a
+  // '.' placeholder, the print is not out yet; do NOT fall back to an
+  // older row and present it as current (review finding).
+  const lead = parseObs(raw[0]);
+  if (!lead) return empty;
+  const usable = raw.map(parseObs).filter(Boolean);
 
+  // Values are UNITLESS — event.unit already carries '%'/'K' and the
+  // calendar renderer appends it; embedding the unit here double-renders.
   if (transform === 'direct') {
+    const prev = usable.length > 1 ? usable[1] : null;
     return {
-      actual: usable[0].value.toFixed(1),
-      previous: usable.length > 1 ? usable[1].value.toFixed(1) : '',
-      obsDate: usable[0].date,
+      actual: lead.value.toFixed(1),
+      previous: prev ? prev.value.toFixed(1) : '',
+      obsDate: lead.date,
     };
   }
+  if (usable.length < 2 || !isAdjacent(usable[0], usable[1])) return empty;
   if (transform === 'diff_k') {
-    if (usable.length < 2) return empty;
     const actual = usable[0].value - usable[1].value;
-    const previous = usable.length > 2 ? usable[1].value - usable[2].value : null;
+    const hasPrev = usable.length > 2 && isAdjacent(usable[1], usable[2]);
+    const previous = hasPrev ? usable[1].value - usable[2].value : null;
     return {
-      actual: `${actual >= 0 ? '+' : ''}${Math.round(actual)}K`,
-      previous: previous === null ? '' : `${previous >= 0 ? '+' : ''}${Math.round(previous)}K`,
+      actual: `${actual >= 0 ? '+' : ''}${Math.round(actual)}`,
+      previous: previous === null ? '' : `${previous >= 0 ? '+' : ''}${Math.round(previous)}`,
       obsDate: usable[0].date,
     };
   }
   // pct_mom
-  if (usable.length < 2 || usable[1].value === 0) return empty;
+  if (usable[1].value === 0) return empty;
   const actual = (usable[0].value / usable[1].value - 1) * 100;
-  const previous = usable.length > 2 && usable[2].value !== 0
-    ? (usable[1].value / usable[2].value - 1) * 100
-    : null;
+  const hasPrev = usable.length > 2 && isAdjacent(usable[1], usable[2]) && usable[2].value !== 0;
+  const previous = hasPrev ? (usable[1].value / usable[2].value - 1) * 100 : null;
   return {
-    actual: `${actual >= 0 ? '+' : ''}${actual.toFixed(1)}%`,
-    previous: previous === null ? '' : `${previous >= 0 ? '+' : ''}${previous.toFixed(1)}%`,
+    actual: `${actual >= 0 ? '+' : ''}${actual.toFixed(1)}`,
+    previous: previous === null ? '' : `${previous >= 0 ? '+' : ''}${previous.toFixed(1)}`,
     obsDate: usable[0].date,
   };
 }

--- a/scripts/_econ-actuals.mjs
+++ b/scripts/_econ-actuals.mjs
@@ -15,12 +15,31 @@
  */
 
 export const EVENT_SERIES = {
-  CPI: { series: 'CPIAUCSL', transform: 'pct_mom' },
-  'Nonfarm Payrolls': { series: 'PAYEMS', transform: 'diff_k' },
-  GDP: { series: 'A191RL1Q225SBEA', transform: 'direct' },
-  PCE: { series: 'PCEPI', transform: 'pct_mom' },
-  'Retail Sales': { series: 'RSAFS', transform: 'pct_mom' },
+  CPI: { series: 'CPIAUCSL', transform: 'pct_mom', freq: 'm' },
+  'Nonfarm Payrolls': { series: 'PAYEMS', transform: 'diff_k', freq: 'm' },
+  GDP: { series: 'A191RL1Q225SBEA', transform: 'direct', freq: 'q' },
+  PCE: { series: 'PCEPI', transform: 'pct_mom', freq: 'm' },
+  'Retail Sales': { series: 'RSAFS', transform: 'pct_mom', freq: 'm' },
 };
+
+/**
+ * #4929 external review (P1): on release day BEFORE the print lands,
+ * FRED's latest observation is still the PRIOR period — filling the
+ * event with it would present a stale number as today's print. The
+ * observation must belong to the period the release reports: monthly
+ * releases report the previous calendar month (diff == 1); quarterly
+ * GDP estimates report the previous quarter (1..5 months back across
+ * advance/second/third estimates).
+ */
+export function observationMatchesRelease(eventDateISO, obsDateISO, freq) {
+  const eventDate = new Date(eventDateISO);
+  const obsDate = new Date(obsDateISO);
+  if (!Number.isFinite(eventDate.getTime()) || !Number.isFinite(obsDate.getTime())) return false;
+  const monthDiff = (eventDate.getUTCFullYear() - obsDate.getUTCFullYear()) * 12
+    + (eventDate.getUTCMonth() - obsDate.getUTCMonth());
+  if (freq === 'q') return monthDiff >= 1 && monthDiff <= 5;
+  return monthDiff === 1;
+}
 
 /** FRED marks missing observations with the string '.'. */
 function parseObs(observation) {
@@ -102,11 +121,15 @@ export function fillEventActuals(events, printsByEvent, todayISO) {
     if (event.actual) continue;
     const print = printsByEvent[event.event];
     if (!print || !print.actual) continue;
-    if (typeof event.date === 'string' && event.date <= todayISO) {
-      event.actual = print.actual;
-      if (!event.previous && print.previous) event.previous = print.previous;
-      filled++;
-    }
+    if (typeof event.date !== 'string' || event.date > todayISO) continue;
+    // Stale-print guard: the observation must belong to the period THIS
+    // release reports — pre-print on release day, the latest obs is the
+    // prior period and must not be presented as today's number.
+    const freq = EVENT_SERIES[event.event]?.freq ?? 'm';
+    if (!observationMatchesRelease(event.date, print.obsDate, freq)) continue;
+    event.actual = print.actual;
+    if (!event.previous && print.previous) event.previous = print.previous;
+    filled++;
   }
   return filled;
 }

--- a/scripts/_econ-actuals.mjs
+++ b/scripts/_econ-actuals.mjs
@@ -1,0 +1,96 @@
+/**
+ * #4922 (b): macro-print actuals — pure helpers.
+ *
+ * The economic calendar previously shipped every event with
+ * actual:'', estimate:'', previous:'' forever — the print itself (the
+ * single most market-moving datum) was never captured. FRED publishes
+ * the values same-day in series observations; these helpers turn the
+ * latest observations into event-ready actual/previous strings.
+ *
+ * Series/transform map (release calendars use RELEASE ids; values need
+ * SERIES ids — they are different namespaces):
+ *   - CPI / PCE / Retail Sales: index levels → month-over-month % change
+ *   - Nonfarm Payrolls: level in thousands → monthly change in K
+ *   - GDP: A191RL1Q225SBEA is already the headline annualized % change
+ */
+
+export const EVENT_SERIES = {
+  CPI: { series: 'CPIAUCSL', transform: 'pct_mom' },
+  'Nonfarm Payrolls': { series: 'PAYEMS', transform: 'diff_k' },
+  GDP: { series: 'A191RL1Q225SBEA', transform: 'direct' },
+  PCE: { series: 'PCEPI', transform: 'pct_mom' },
+  'Retail Sales': { series: 'RSAFS', transform: 'pct_mom' },
+};
+
+/** FRED marks missing observations with the string '.'. */
+function parseObs(observation) {
+  const value = Number.parseFloat(observation?.value);
+  return Number.isFinite(value) ? { date: observation.date, value } : null;
+}
+
+/**
+ * @param {Array<{ date: string; value: string }>} observations DESC-sorted
+ *   FRED observations (newest first).
+ * @param {'pct_mom'|'diff_k'|'direct'} transform
+ * @returns {{ actual: string; previous: string; obsDate: string }}
+ *   Empty strings when there is not enough usable data.
+ */
+export function computePrintValues(observations, transform) {
+  const usable = (Array.isArray(observations) ? observations : [])
+    .map(parseObs)
+    .filter(Boolean);
+  const empty = { actual: '', previous: '', obsDate: '' };
+  if (usable.length === 0) return empty;
+
+  if (transform === 'direct') {
+    return {
+      actual: usable[0].value.toFixed(1),
+      previous: usable.length > 1 ? usable[1].value.toFixed(1) : '',
+      obsDate: usable[0].date,
+    };
+  }
+  if (transform === 'diff_k') {
+    if (usable.length < 2) return empty;
+    const actual = usable[0].value - usable[1].value;
+    const previous = usable.length > 2 ? usable[1].value - usable[2].value : null;
+    return {
+      actual: `${actual >= 0 ? '+' : ''}${Math.round(actual)}K`,
+      previous: previous === null ? '' : `${previous >= 0 ? '+' : ''}${Math.round(previous)}K`,
+      obsDate: usable[0].date,
+    };
+  }
+  // pct_mom
+  if (usable.length < 2 || usable[1].value === 0) return empty;
+  const actual = (usable[0].value / usable[1].value - 1) * 100;
+  const previous = usable.length > 2 && usable[2].value !== 0
+    ? (usable[1].value / usable[2].value - 1) * 100
+    : null;
+  return {
+    actual: `${actual >= 0 ? '+' : ''}${actual.toFixed(1)}%`,
+    previous: previous === null ? '' : `${previous >= 0 ? '+' : ''}${previous.toFixed(1)}%`,
+    obsDate: usable[0].date,
+  };
+}
+
+/**
+ * Fill actual/previous on calendar events whose print is available:
+ * an event matches when its `event` name has a series mapping and its
+ * date is today or earlier (the calendar window starts at today, so in
+ * practice this fills print-day rows on the runs after the release).
+ *
+ * @returns {number} count of events filled.
+ */
+export function fillEventActuals(events, printsByEvent, todayISO) {
+  let filled = 0;
+  for (const event of Array.isArray(events) ? events : []) {
+    if (event.actual) continue;
+    const print = printsByEvent[event.event];
+    if (!print || !print.actual) continue;
+    if (typeof event.date === 'string' && event.date <= todayISO) {
+      event.actual = print.actual;
+      if (!event.previous && print.previous) event.previous = print.previous;
+      filled++;
+    }
+  }
+  return filled;
+}

--- a/scripts/seed-earnings-calendar.mjs
+++ b/scripts/seed-earnings-calendar.mjs
@@ -19,6 +19,10 @@ async function fetchAll() {
   }
 
   const from = new Date();
+  // #4922/#4929 review: include the past week so brief consumers can show
+  // recent beats/misses — a today-forward window can only ever contain
+  // same-day morning reporters.
+  from.setDate(from.getDate() - 7);
   const to = new Date();
   to.setDate(to.getDate() + 14);
 

--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -297,6 +297,11 @@ async function fetchEconomicCalendar() {
   );
 
   // #4922 (b): capture the PRINTS. Release calendars carry dates only;
+  // NOTE consumer scope: the RPC (get-economic-calendar.ts) reconstructs
+  // its proto response and does NOT forward recentPrints — it is a
+  // Redis-side block for seeders/ops until the proto gains a field
+  // (tracked in #4922). The user-visible win flows through the EVENT
+  // actual/previous fields, which the proto already carries.
   // the values live in series observations and land same-day. Publish a
   // recentPrints block (always useful to market-brief consumers) and fill
   // actual/previous on any in-window event whose print is out.

--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, fredFetchJson } from './_seed-utils.mjs';
+import { EVENT_SERIES, computePrintValues, fillEventActuals } from './_econ-actuals.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -295,11 +296,37 @@ async function fetchEconomicCalendar() {
     }),
   );
 
+  // #4922 (b): capture the PRINTS. Release calendars carry dates only;
+  // the values live in series observations and land same-day. Publish a
+  // recentPrints block (always useful to market-brief consumers) and fill
+  // actual/previous on any in-window event whose print is out.
+  const recentPrints = [];
+  const printsByEvent = {};
+  await Promise.all(
+    Object.entries(EVENT_SERIES).map(async ([eventName, { series, transform }]) => {
+      try {
+        const url = `https://api.stlouisfed.org/fred/series/observations?series_id=${series}` +
+          `&api_key=${apiKey}&file_type=json&sort_order=desc&limit=4`;
+        const json = await fredFetchJson(url, _proxyAuth);
+        const print = computePrintValues(json?.observations, transform);
+        if (print.actual) {
+          const unit = FRED_RELEASES.find((release) => release.event === eventName)?.unit ?? '';
+          printsByEvent[eventName] = print;
+          recentPrints.push({ event: eventName, series, obsDate: print.obsDate, actual: print.actual, previous: print.previous, unit });
+        }
+      } catch (err) {
+        console.warn(`  FRED observations ${series} (${eventName}) failed: ${err.message} — skipping print`);
+      }
+    }),
+  );
+  const filled = fillEventActuals(events, printsByEvent, today);
+  console.log(`  Prints: ${recentPrints.length} series captured, ${filled} event(s) filled with actuals`);
+
   events.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 
   console.log(`  Total events: ${events.length}`);
 
-  return { events, fromDate: today, toDate, total: events.length };
+  return { events, recentPrints, fromDate: today, toDate, total: events.length };
 }
 
 function validate(data) {

--- a/scripts/seed-recall-benchmark.mjs
+++ b/scripts/seed-recall-benchmark.mjs
@@ -87,9 +87,26 @@ async function main() {
   // 2. External reference set from GDELT.
   const seenUrls = new Set();
   const externalItems = [];
+  // #4929 external review: production retry defaults (3 retries × 10s
+  // backoff + 5 proxy attempts, ×4 sequential queries) could consume much
+  // of the 25-minute workflow. Benchmark-grade fast-fail limits + a shared
+  // wall-clock deadline: partial reference sets are fine, a hung workflow
+  // is not.
+  const GDELT_DEADLINE_MS = 4 * 60 * 1000;
+  const gdeltStartedAt = Date.now();
   for (const { label, q } of REFERENCE_QUERIES) {
+    if (Date.now() - gdeltStartedAt > GDELT_DEADLINE_MS) {
+      console.warn(`  [gdelt:${label}] skipped — shared 4-min GDELT deadline exhausted`);
+      continue;
+    }
     try {
-      const json = await fetchGdeltJson(gdeltUrl(q), { label: `recall-${label}` });
+      const json = await fetchGdeltJson(gdeltUrl(q), {
+        label: `recall-${label}`,
+        timeoutMs: 10_000,
+        maxRetries: 1,
+        retryBaseMs: 2_000,
+        proxyMaxAttempts: 1,
+      });
       const articles = Array.isArray(json?.articles) ? json.articles : [];
       for (const article of articles) {
         const title = article?.title;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2260,15 +2260,8 @@ export class DataLoaderManager implements AppModule {
       });
       const earnings = resp.earnings ?? [];
       if (resp.unavailable || earnings.length === 0) return undefined;
-      const todayISO = today.toISOString().slice(0, 10);
-      const recent = earnings
-        .filter((entry) => entry.hasActuals && (entry.surpriseDirection === 'beat' || entry.surpriseDirection === 'miss'))
-        .sort((a, b) => (a.date < b.date ? 1 : -1))
-        .slice(0, 5)
-        .map((entry) => ({ symbol: entry.symbol, direction: entry.surpriseDirection as 'beat' | 'miss' }));
-      const upcomingCount = earnings.filter((entry) => entry.date >= todayISO && !entry.hasActuals).length;
-      if (recent.length === 0 && upcomingCount === 0) return undefined;
-      return { recent, upcomingCount };
+      const { buildEarningsBriefContext } = await import('@/services/daily-market-brief');
+      return buildEarningsBriefContext(earnings, today.toISOString().slice(0, 10));
     } catch {
       return undefined;
     }

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2066,14 +2066,16 @@ export class DataLoaderManager implements AppModule {
       // 60s budget for the actual LLM call.
       // `_collectSectorContext` is sync (reads only hydrated data) so it
       // needs no wrapping; allSettled accepts non-promises directly.
-      const [r0, r1, r2] = await Promise.allSettled([
+      const [r0, r1, r2, r3] = await Promise.allSettled([
         withTimeout(this._collectRegimeContext(), 8_000, 'daily-brief-regime-context'),
         withTimeout(this._collectYieldCurveContext(), 8_000, 'daily-brief-yield-context'),
         this._collectSectorContext(),
+        withTimeout(this._collectEarningsContext(), 8_000, 'daily-brief-earnings-context'),
       ]);
       const regimeContext = r0.status === 'fulfilled' ? r0.value : undefined;
       const yieldCurveContext = r1.status === 'fulfilled' ? r1.value : undefined;
       const sectorContext = r2.status === 'fulfilled' ? r2.value : undefined;
+      const earningsContext = r3.status === 'fulfilled' ? r3.value : undefined;
 
       // Wall-clock budget on the whole build. The inner summarizer has its
       // own 45s cap (SUMMARIZER_TIMEOUT_MS in daily-market-brief.ts) and
@@ -2090,6 +2092,7 @@ export class DataLoaderManager implements AppModule {
           regimeContext,
           yieldCurveContext,
           sectorContext,
+          earningsContext,
           frameworkAppend: getActiveFrameworkForPanel('daily-market-brief')?.systemPromptAppend,
           newsCategories: SITE_VARIANT === 'commodity'
             ? ['commodity-news', 'gold-silver', 'mining-news', 'energy', 'critical-minerals']
@@ -2235,6 +2238,37 @@ export class DataLoaderManager implements AppModule {
         countPositive,
         total: sorted.length,
       };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** #4922 (c): recent earnings surprises + upcoming density for the brief.
+   * RPC-backed (earnings are not bootstrap-hydrated); failures degrade to
+   * undefined — the brief simply omits the earnings block. */
+  private async _collectEarningsContext(): Promise<import('@/services/daily-market-brief').EarningsBriefContext | undefined> {
+    try {
+      const { MarketServiceClient } = await import('@/generated/client/worldmonitor/market/v1/service_client');
+      const { getRpcBaseUrl } = await import('@/services/rpc-client');
+      const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+      const today = new Date();
+      const past = new Date(today.getTime() - 7 * 86400_000);
+      const future = new Date(today.getTime() + 14 * 86400_000);
+      const resp = await client.listEarningsCalendar({
+        fromDate: past.toISOString().slice(0, 10),
+        toDate: future.toISOString().slice(0, 10),
+      });
+      const earnings = resp.earnings ?? [];
+      if (resp.unavailable || earnings.length === 0) return undefined;
+      const todayISO = today.toISOString().slice(0, 10);
+      const recent = earnings
+        .filter((entry) => entry.hasActuals && (entry.surpriseDirection === 'beat' || entry.surpriseDirection === 'miss'))
+        .sort((a, b) => (a.date < b.date ? 1 : -1))
+        .slice(0, 5)
+        .map((entry) => ({ symbol: entry.symbol, direction: entry.surpriseDirection as 'beat' | 'miss' }));
+      const upcomingCount = earnings.filter((entry) => entry.date >= todayISO && !entry.hasActuals).length;
+      if (recent.length === 0 && upcomingCount === 0) return undefined;
+      return { recent, upcomingCount };
     } catch {
       return undefined;
     }

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -70,6 +70,25 @@ export interface EarningsBriefContext {
   upcomingCount: number;
 }
 
+/**
+ * Pure transform from raw earnings-calendar entries to the brief context
+ * (#4929 review: business logic must not live inside an RPC-coupled
+ * private collector). Returns undefined when there is nothing to say.
+ */
+export function buildEarningsBriefContext(
+  earnings: Array<{ symbol: string; date: string; hasActuals?: boolean; surpriseDirection?: string }>,
+  todayISO: string,
+): EarningsBriefContext | undefined {
+  const recent = earnings
+    .filter((entry) => entry.hasActuals && (entry.surpriseDirection === 'beat' || entry.surpriseDirection === 'miss'))
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .slice(0, 5)
+    .map((entry) => ({ symbol: entry.symbol, direction: entry.surpriseDirection as 'beat' | 'miss' }));
+  const upcomingCount = earnings.filter((entry) => entry.date >= todayISO && !entry.hasActuals).length;
+  if (recent.length === 0 && upcomingCount === 0) return undefined;
+  return { recent, upcomingCount };
+}
+
 export interface SectorBriefContext {
   topName: string;
   topChange: number;

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -64,6 +64,12 @@ export interface YieldCurveContext {
   rate30y: number;
 }
 
+/** #4922 (c): recent earnings surprises + upcoming density for the brief. */
+export interface EarningsBriefContext {
+  recent: Array<{ symbol: string; direction: 'beat' | 'miss' }>;
+  upcomingCount: number;
+}
+
 export interface SectorBriefContext {
   topName: string;
   topChange: number;
@@ -82,6 +88,7 @@ export interface BuildDailyMarketBriefOptions {
   regimeContext?: RegimeMacroContext;
   yieldCurveContext?: YieldCurveContext;
   sectorContext?: SectorBriefContext;
+  earningsContext?: EarningsBriefContext;
   frameworkAppend?: string;
   newsCategories?: string[];
   /** Override the per-call summarizer budget. Defaults to
@@ -357,6 +364,7 @@ function buildExtendedMarketContext(
   regime?: RegimeMacroContext,
   yieldCurve?: YieldCurveContext,
   sector?: SectorBriefContext,
+  earnings?: EarningsBriefContext,
 ): string {
   const parts: string[] = [`Markets: ${baseContext}`];
 
@@ -391,6 +399,23 @@ function buildExtendedMarketContext(
       `Sectors: ${sector.countPositive}/${sector.total} positive`,
       `Top: ${sector.topName} ${topSign}${topQ.toFixed(1)}%  Worst: ${sector.worstName} ${worstSign}${worstQ.toFixed(1)}%`,
     ].join('\n'));
+  }
+
+  // #4922 (c): earnings finally reach the brief. Symbols + direction only —
+  // stable per reporting date, so the summary cache identity (#4914) does
+  // not churn intraday.
+  if (earnings && (earnings.recent.length > 0 || earnings.upcomingCount > 0)) {
+    const lines: string[] = [];
+    if (earnings.recent.length > 0) {
+      lines.push(`Earnings: ${earnings.recent
+        .slice(0, 5)
+        .map((entry) => `${entry.symbol} ${entry.direction}`)
+        .join(', ')}`);
+    }
+    if (earnings.upcomingCount > 0) {
+      lines.push(`Upcoming earnings (14d): ${earnings.upcomingCount}`);
+    }
+    parts.push(lines.join('\n'));
   }
 
   return parts.join('\n\n');
@@ -469,7 +494,7 @@ export async function buildDailyMarketBrief(options: BuildDailyMarketBriefOption
   }
 
   const { headlines: summaryHeadlines, marketContext } = buildSummaryInputs(items, relevantHeadlines);
-  let extendedContext = buildExtendedMarketContext(marketContext, options.regimeContext, options.yieldCurveContext, options.sectorContext);
+  let extendedContext = buildExtendedMarketContext(marketContext, options.regimeContext, options.yieldCurveContext, options.sectorContext, options.earningsContext);
   if (options.frameworkAppend) {
     extendedContext = `${extendedContext}\n\n---\nAnalytical Framework:\n${options.frameworkAppend}`;
   }

--- a/tests/markets-news-wiring.test.mjs
+++ b/tests/markets-news-wiring.test.mjs
@@ -93,19 +93,19 @@ describe('fillEventActuals (#4922b)', () => {
       { event: 'CPI', date: '2026-07-20', actual: '', previous: '' },
       { event: 'FOMC Rate Decision', date: '2026-07-06', actual: '', previous: '' },
     ];
-    const filled = fillEventActuals(events, { CPI: { actual: '+0.3%', previous: '+0.2%' } }, TODAY);
+    const filled = fillEventActuals(events, { CPI: { actual: '+0.3', previous: '+0.2', obsDate: '2026-06-01' } }, TODAY);
     assert.equal(filled, 1);
-    assert.equal(events[0].actual, '+0.3%');
-    assert.equal(events[0].previous, '+0.2%');
+    assert.equal(events[0].actual, '+0.3');
+    assert.equal(events[0].previous, '+0.2');
     assert.equal(events[1].actual, '', 'future release stays empty');
     assert.equal(events[2].actual, '', 'unmapped event untouched');
   });
 
   it('never overwrites an existing actual', () => {
-    const events = [{ event: 'CPI', date: '2026-07-06', actual: '+0.9%', previous: '' }];
-    const filled = fillEventActuals(events, { CPI: { actual: '+0.3%', previous: '+0.2%' } }, TODAY);
+    const events = [{ event: 'CPI', date: '2026-07-06', actual: '+0.9', previous: '' }];
+    const filled = fillEventActuals(events, { CPI: { actual: '+0.3', previous: '+0.2', obsDate: '2026-06-01' } }, TODAY);
     assert.equal(filled, 0);
-    assert.equal(events[0].actual, '+0.9%');
+    assert.equal(events[0].actual, '+0.9');
   });
 });
 
@@ -214,5 +214,51 @@ describe('selectTopStories opts pass-through (#4929 review)', () => {
     const dScore = demoted.find((s) => s.primarySource === 'TechCrunch').importanceScore;
     const nScore = neutral.find((s) => s.primarySource === 'TechCrunch').importanceScore;
     assert.ok(nScore > dScore, 'opts must thread through selectTopStories to scoreImportance');
+  });
+});
+
+// ── #4929 external-review round ────────────────────────────────────────────
+
+import { observationMatchesRelease } from '../scripts/_econ-actuals.mjs';
+
+describe('release-day stale-print guard (#4929 external review P1)', () => {
+  it('REGRESSION: pre-print on release day, the prior-period observation is NOT presented as the print', () => {
+    // July 15 CPI release reports JUNE. Before 08:30 ET the latest FRED
+    // obs is still MAY — filling with it showed a stale number as today's.
+    const events = [{ event: 'CPI', date: '2026-07-15', actual: '', previous: '' }];
+    const stale = fillEventActuals(events, { CPI: { actual: '+0.2', previous: '+0.3', obsDate: '2026-05-01' } }, '2026-07-15');
+    assert.equal(stale, 0, 'May observation must not fill the June-reporting release');
+    assert.equal(events[0].actual, '');
+
+    const fresh = fillEventActuals(events, { CPI: { actual: '+0.3', previous: '+0.2', obsDate: '2026-06-01' } }, '2026-07-15');
+    assert.equal(fresh, 1, 'June observation fills the June-reporting release');
+  });
+
+  it('quarterly GDP tolerates the advance/second/third estimate window', () => {
+    assert.equal(observationMatchesRelease('2026-07-30', '2026-04-01', 'q'), true, 'advance estimate: Q2 obs, July release');
+    assert.equal(observationMatchesRelease('2026-09-25', '2026-04-01', 'q'), true, 'third estimate');
+    assert.equal(observationMatchesRelease('2026-07-30', '2026-01-01', 'q'), false, 'stale prior quarter rejected');
+  });
+});
+
+describe('misplaced-opts guard (#4929 external review)', () => {
+  it('passing { demoteFinance:false } in the stats slot still disables demotion', () => {
+    const finance = {
+      primaryTitle: 'Startup CEO announces record quarterly revenue and IPO plans today',
+      primarySource: 'TechCrunch', primaryLink: 'https://t/1',
+      pubDate: new Date().toISOString(), sources: ['TechCrunch', 'The Verge'], isAlert: true, tier: 2,
+    };
+    const shifted = selectTopStories([finance], 8, { demoteFinance: false });
+    const explicit = selectTopStories([finance], 8, undefined, { demoteFinance: false });
+    assert.equal(shifted[0].importanceScore, explicit[0].importanceScore, 'opts in the stats slot must auto-shift');
+  });
+});
+
+describe('recall benchmark fast-fail wiring (source-textual)', () => {
+  it('uses benchmark-grade limits and a shared GDELT deadline', () => {
+    const src = readSrc('scripts/seed-recall-benchmark.mjs');
+    assert.match(src, /maxRetries: 1/);
+    assert.match(src, /proxyMaxAttempts: 1/);
+    assert.match(src, /GDELT_DEADLINE_MS = 4 \* 60 \* 1000/);
   });
 });

--- a/tests/markets-news-wiring.test.mjs
+++ b/tests/markets-news-wiring.test.mjs
@@ -21,8 +21,8 @@ describe('computePrintValues (#4922b)', () => {
       { date: '2026-04-01', value: '319.9' },
     ];
     const out = computePrintValues(obs, 'pct_mom');
-    assert.equal(out.actual, '+0.4%');
-    assert.equal(out.previous, '+0.1%');
+    assert.equal(out.actual, '+0.4', 'unitless — event.unit carries the % (double-render fix)');
+    assert.equal(out.previous, '+0.1');
     assert.equal(out.obsDate, '2026-06-01');
   });
 
@@ -33,8 +33,8 @@ describe('computePrintValues (#4922b)', () => {
       { date: '2026-04-01', value: '159305' },
     ];
     const out = computePrintValues(obs, 'diff_k');
-    assert.equal(out.actual, '+222K');
-    assert.equal(out.previous, '-115K');
+    assert.equal(out.actual, '+222', 'unitless — event.unit carries the K');
+    assert.equal(out.previous, '-115');
   });
 
   it('direct: headline % series passes through', () => {
@@ -50,6 +50,30 @@ describe('computePrintValues (#4922b)', () => {
     assert.equal(computePrintValues([{ date: '2026-06-01', value: '.' }], 'pct_mom').actual, '');
     assert.equal(computePrintValues([{ date: '2026-06-01', value: '321.5' }], 'pct_mom').actual, '');
     assert.equal(computePrintValues([], 'direct').actual, '');
+  });
+
+  it("a '.' LEADING observation never falls back to an older row as 'current'", () => {
+    const out = computePrintValues([
+      { date: '2026-06-01', value: '.' },
+      { date: '2026-05-01', value: '320.2' },
+      { date: '2026-04-01', value: '319.9' },
+    ], 'pct_mom');
+    assert.equal(out.actual, '', 'print not out yet — must not present the prior month as current');
+  });
+
+  it('a mid-series month gap rejects the pair instead of mislabeling a 2-month change', () => {
+    const out = computePrintValues([
+      { date: '2026-06-01', value: '321.5' },
+      { date: '2026-03-01', value: '318.0' },
+    ], 'pct_mom');
+    assert.equal(out.actual, '', 'non-adjacent periods must not compute as MoM');
+  });
+
+  it('EVENT_SERIES keys stay in lockstep with FRED_RELEASES event names', async () => {
+    const src = readSrc('scripts/seed-economic-calendar.mjs');
+    for (const eventName of Object.keys(EVENT_SERIES)) {
+      assert.ok(src.includes(`event: '${eventName}'`), `FRED_RELEASES must contain '${eventName}' — the maps correlate by name`);
+    }
   });
 
   it('every mapped event has a series and transform', () => {
@@ -119,5 +143,76 @@ describe('wiring (source-textual)', () => {
     const loader = readSrc('src/app/data-loader.ts');
     assert.match(loader, /_collectEarningsContext/);
     assert.match(loader, /listEarningsCalendar\(\{/);
+  });
+});
+
+// ── #4929 review-round additions ───────────────────────────────────────────
+
+import { buildEarningsBriefContext } from '../src/services/daily-market-brief.ts';
+import { selectTopStories } from '../scripts/_clustering.mjs';
+
+describe('buildEarningsBriefContext (pure, #4929 review)', () => {
+  const TODAY = '2026-07-06';
+  const entries = [
+    { symbol: 'MSFT', date: '2026-07-03', hasActuals: true, surpriseDirection: 'beat' },
+    { symbol: 'TSLA', date: '2026-07-05', hasActuals: true, surpriseDirection: 'miss' },
+    { symbol: 'ORCL', date: '2026-07-01', hasActuals: true, surpriseDirection: '' },
+    { symbol: 'AAPL', date: '2026-07-10', hasActuals: false },
+    { symbol: 'NVDA', date: '2026-07-12', hasActuals: false },
+  ];
+
+  it('collects recent beats/misses newest-first and counts upcoming', () => {
+    const out = buildEarningsBriefContext(entries, TODAY);
+    assert.ok(out);
+    assert.deepEqual(out.recent.map((r) => r.symbol), ['TSLA', 'MSFT'], 'no-surprise reporters excluded');
+    assert.equal(out.upcomingCount, 2);
+  });
+
+  it('returns undefined when there is nothing to say', () => {
+    assert.equal(buildEarningsBriefContext([], TODAY), undefined);
+    assert.equal(buildEarningsBriefContext([{ symbol: 'X', date: '2026-06-01', hasActuals: true, surpriseDirection: '' }], TODAY), undefined);
+  });
+});
+
+describe('earnings context in the brief prompt (#4929 review)', () => {
+  it('renders the earnings block into geoContext and is stable across rebuilds', async () => {
+    const { buildDailyMarketBrief } = await import('../src/services/daily-market-brief.ts');
+    const captured = [];
+    const opts = {
+      markets: [{ symbol: 'AAPL', name: 'Apple', display: 'AAPL', price: 212, change: 1.0 }],
+      newsByCategory: { markets: [{ source: 'Reuters', title: 'Apple extends gains after strong outlook', link: 'https://x', pubDate: new Date('2026-07-06T01:00:00Z'), isAlert: false }] },
+      timezone: 'UTC',
+      now: new Date('2026-07-06T10:30:00.000Z'),
+      earningsContext: { recent: [{ symbol: 'MSFT', direction: 'beat' }, { symbol: 'TSLA', direction: 'miss' }], upcomingCount: 12 },
+      summarize: async (_h, _p, geoContext) => {
+        captured.push(geoContext ?? '');
+        return { summary: 'A stable-enough one liner for the earnings capture test.', provider: 't', model: 't', cached: false };
+      },
+    };
+    await buildDailyMarketBrief(opts);
+    await buildDailyMarketBrief(opts);
+    assert.match(captured[0], /Earnings: MSFT beat, TSLA miss/);
+    assert.match(captured[0], /Upcoming earnings \(14d\): 12/);
+    assert.equal(captured[1], captured[0], 'earnings block must not churn the cache identity across rebuilds');
+  });
+});
+
+describe('selectTopStories opts pass-through (#4929 review)', () => {
+  it('demoteFinance:false changes the ranking through the selection path', () => {
+    const finance = {
+      primaryTitle: 'Startup CEO announces record quarterly revenue and IPO plans today',
+      primarySource: 'TechCrunch', primaryLink: 'https://t/1',
+      pubDate: new Date().toISOString(), sources: ['TechCrunch', 'The Verge'], isAlert: true, tier: 2,
+    };
+    const geo = {
+      primaryTitle: 'Border clashes escalate along disputed frontier region overnight',
+      primarySource: 'Reuters', primaryLink: 'https://r/2',
+      pubDate: new Date().toISOString(), sources: ['Reuters', 'BBC'], isAlert: true, tier: 2,
+    };
+    const demoted = selectTopStories([finance, geo], 8);
+    const neutral = selectTopStories([finance, geo], 8, undefined, { demoteFinance: false });
+    const dScore = demoted.find((s) => s.primarySource === 'TechCrunch').importanceScore;
+    const nScore = neutral.find((s) => s.primarySource === 'TechCrunch').importanceScore;
+    assert.ok(nScore > dScore, 'opts must thread through selectTopStories to scoreImportance');
   });
 });

--- a/tests/markets-news-wiring.test.mjs
+++ b/tests/markets-news-wiring.test.mjs
@@ -1,0 +1,123 @@
+// #4922: markets↔news wiring — macro-print actuals, earnings into the
+// daily market brief, and the finance-demotion seam.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { EVENT_SERIES, computePrintValues, fillEventActuals } from '../scripts/_econ-actuals.mjs';
+import { scoreImportance } from '../scripts/_clustering.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readSrc = (rel) => readFileSync(resolve(root, rel), 'utf-8');
+
+describe('computePrintValues (#4922b)', () => {
+  it('pct_mom: index levels become MoM % change with a previous period', () => {
+    const obs = [
+      { date: '2026-06-01', value: '321.5' },
+      { date: '2026-05-01', value: '320.2' },
+      { date: '2026-04-01', value: '319.9' },
+    ];
+    const out = computePrintValues(obs, 'pct_mom');
+    assert.equal(out.actual, '+0.4%');
+    assert.equal(out.previous, '+0.1%');
+    assert.equal(out.obsDate, '2026-06-01');
+  });
+
+  it('diff_k: payroll levels become monthly change in K', () => {
+    const obs = [
+      { date: '2026-06-01', value: '159412' },
+      { date: '2026-05-01', value: '159190' },
+      { date: '2026-04-01', value: '159305' },
+    ];
+    const out = computePrintValues(obs, 'diff_k');
+    assert.equal(out.actual, '+222K');
+    assert.equal(out.previous, '-115K');
+  });
+
+  it('direct: headline % series passes through', () => {
+    const out = computePrintValues([
+      { date: '2026-04-01', value: '2.8' },
+      { date: '2026-01-01', value: '3.1' },
+    ], 'direct');
+    assert.equal(out.actual, '2.8');
+    assert.equal(out.previous, '3.1');
+  });
+
+  it("FRED '.' missing markers and short series degrade to empty strings", () => {
+    assert.equal(computePrintValues([{ date: '2026-06-01', value: '.' }], 'pct_mom').actual, '');
+    assert.equal(computePrintValues([{ date: '2026-06-01', value: '321.5' }], 'pct_mom').actual, '');
+    assert.equal(computePrintValues([], 'direct').actual, '');
+  });
+
+  it('every mapped event has a series and transform', () => {
+    for (const [event, mapping] of Object.entries(EVENT_SERIES)) {
+      assert.ok(mapping.series.length > 2, `${event} series`);
+      assert.ok(['pct_mom', 'diff_k', 'direct'].includes(mapping.transform), `${event} transform`);
+    }
+  });
+});
+
+describe('fillEventActuals (#4922b)', () => {
+  const TODAY = '2026-07-06';
+
+  it('fills print-day events and counts them; leaves future events empty', () => {
+    const events = [
+      { event: 'CPI', date: '2026-07-06', actual: '', previous: '' },
+      { event: 'CPI', date: '2026-07-20', actual: '', previous: '' },
+      { event: 'FOMC Rate Decision', date: '2026-07-06', actual: '', previous: '' },
+    ];
+    const filled = fillEventActuals(events, { CPI: { actual: '+0.3%', previous: '+0.2%' } }, TODAY);
+    assert.equal(filled, 1);
+    assert.equal(events[0].actual, '+0.3%');
+    assert.equal(events[0].previous, '+0.2%');
+    assert.equal(events[1].actual, '', 'future release stays empty');
+    assert.equal(events[2].actual, '', 'unmapped event untouched');
+  });
+
+  it('never overwrites an existing actual', () => {
+    const events = [{ event: 'CPI', date: '2026-07-06', actual: '+0.9%', previous: '' }];
+    const filled = fillEventActuals(events, { CPI: { actual: '+0.3%', previous: '+0.2%' } }, TODAY);
+    assert.equal(filled, 0);
+    assert.equal(events[0].actual, '+0.9%');
+  });
+});
+
+describe('finance demotion seam (#4922f)', () => {
+  const financeCluster = {
+    primaryTitle: 'Startup CEO announces record quarterly revenue and IPO plans',
+    primarySource: 'TechCrunch',
+    primaryLink: 'https://t/1',
+    pubDate: new Date().toISOString(),
+    sources: ['TechCrunch'],
+    isAlert: false,
+    tier: 3,
+  };
+
+  it('demotes finance-keyword clusters by default, ranks neutrally when disabled', () => {
+    const demoted = scoreImportance({ ...financeCluster });
+    const neutral = scoreImportance({ ...financeCluster }, { demoteFinance: false });
+    assert.ok(neutral > demoted, `neutral (${neutral}) must exceed demoted (${demoted})`);
+    assert.ok(Math.abs(demoted / neutral - 0.35) < 0.01, 'default demotion is the documented ×0.35');
+  });
+});
+
+describe('wiring (source-textual)', () => {
+  it('economic calendar publishes recentPrints and fills actuals', () => {
+    const src = readSrc('scripts/seed-economic-calendar.mjs');
+    assert.match(src, /fred\/series\/observations\?series_id=/);
+    assert.match(src, /fillEventActuals\(events, printsByEvent, today\)/);
+    assert.match(src, /recentPrints/);
+  });
+
+  it('daily market brief consumes earnings context in prompt and options', () => {
+    const src = readSrc('src/services/daily-market-brief.ts');
+    assert.match(src, /earningsContext\?: EarningsBriefContext/);
+    assert.match(src, /Upcoming earnings \(14d\)/);
+    const loader = readSrc('src/app/data-loader.ts');
+    assert.match(loader, /_collectEarningsContext/);
+    assert.match(loader, /listEarningsCalendar\(\{/);
+  });
+});


### PR DESCRIPTION
Refs #4922 (Bet 4 of the strategic news-pipeline review — the no-proto slice; ticker tagging on the wire + watchlist story alerts need a NewsItem proto field and stay tracked in the epic). **Do not auto-merge — held for review.** ⚠️ **Stacked on #4928 → #4927 → #4924.**

## What lands

**(b) Macro actuals** — the calendar shipped `actual:'', estimate:'', previous:''` forever; the CPI/NFP/FOMC *print* — the single most market-moving datum — was never captured. The seeder now pulls FRED series observations (release-ids ≠ series-ids; per-event transform map: CPI/PCE/Retail index→MoM%, NFP level→ΔK, GDP headline % direct), publishes `recentPrints`, and fills print-day events. The proto already has the fields — values reach the client with zero schema change.

**(c) Earnings reach a brief for the first time** — `EarningsBriefContext` (recent beats/misses + 14-day upcoming count) collected via the earnings RPC (8s budget, degrade-to-absent) into the Daily Market Brief prompt. Symbols + direction only — stable per reporting date, so the #4914 cache identity doesn't churn.

**(f) Finance-demotion seam** — `scoreImportance`/`selectTopStories` accept `{demoteFinance:false}`; ×0.35 stays default for the geopolitical brief. Honest scope note: the only live consumer runs the full variant today — this is the seam a finance-variant insights run plugs into (epic follow-up), not a behavior change.

## Verification
`tests/markets-news-wiring.test.mjs` (10): transforms incl. FRED `'.'` markers, fill semantics (no-overwrite / future-stays-empty), ×0.35 default vs neutral, prompt block + wiring. Adjacent suites green (daily-market-brief 12, clustering 16, completeness 21, brief-contract 26). Both typechecks + biome.

https://claude.ai/code/session_01WmhkGjZrb9RbV7pV3muFxP