### PR TITLE
fix(forecast): word-boundary term matching — stop substring country false positives corrupting probabilities (#4933)

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -1163,7 +1163,7 @@ function detectSupplyChainScenarios(inputs) {
 
     const aisGaps = anomalies.filter(a =>
       (a.type === 'ais_gaps' || a.type === 'ais_gap') &&
-      (a.region || a.zone || '').toLowerCase().includes(route.toLowerCase()),
+      textIncludesTerm((a.region || a.zone || '').toLowerCase(), route.toLowerCase()),
     );
     if (aisGaps.length > 0) {
       signals.push({ type: 'ais_gap', value: `${aisGaps.length} AIS gap anomalies near ${route}`, weight: 0.3 });
@@ -1171,7 +1171,7 @@ function detectSupplyChainScenarios(inputs) {
     }
 
     const nearbyJam = jamming.filter(j =>
-      (j.region || j.zone || j.name || '').toLowerCase().includes(route.toLowerCase()),
+      textIncludesTerm((j.region || j.zone || j.name || '').toLowerCase(), route.toLowerCase()),
     );
     if (nearbyJam.length > 0) {
       signals.push({ type: 'gps_jamming', value: `GPS interference near ${route}`, weight: 0.2 });
@@ -1643,7 +1643,7 @@ function detectPoliticalScenarios(inputs) {
 
     const protestAnomalies = anomalies.filter(a =>
       (a.type === 'protest' || a.type === 'unrest') &&
-      (a.country || a.region || '').toLowerCase().includes(countryName),
+      textIncludesTerm((a.country || a.region || '').toLowerCase(), countryName),
     );
     if (protestAnomalies.length > 0) {
       const maxZ = Math.max(...protestAnomalies.map(a => a.zScore || a.z_score || 0));
@@ -1711,7 +1711,7 @@ function detectMilitaryScenarios(inputs) {
 
     const milFlights = anomalies.filter(a =>
       (a.type === 'military_flights' || a.type === 'military') &&
-      [region, theaterLabel, theaterId].some((part) => part && (a.region || a.theater || '').toLowerCase().includes(part.toLowerCase())),
+      [region, theaterLabel, theaterId].some((part) => part && textIncludesTerm((a.region || a.theater || '').toLowerCase(), part.toLowerCase())),
     );
     if (milFlights.length > 0) {
       const maxZ = Math.max(...milFlights.map(a => a.zScore || a.z_score || 0));
@@ -1823,7 +1823,7 @@ function detectInfraScenarios(inputs) {
     let sourceCount = 1;
 
     const relatedCyber = cyber.filter(t =>
-      (t.country || t.target || t.region || '').toLowerCase().includes(countryLower),
+      textIncludesTerm((t.country || t.target || t.region || '').toLowerCase(), countryLower),
     );
     if (relatedCyber.length > 0) {
       signals.push({ type: 'cyber', value: `${relatedCyber.length} cyber threats targeting ${country}`, weight: 0.3 });
@@ -1831,7 +1831,7 @@ function detectInfraScenarios(inputs) {
     }
 
     const nearbyJam = jamming.filter(j =>
-      (j.country || j.region || j.name || '').toLowerCase().includes(countryLower),
+      textIncludesTerm((j.country || j.region || j.name || '').toLowerCase(), countryLower),
     );
     if (nearbyJam.length > 0) {
       signals.push({ type: 'gps_jamming', value: `GPS interference in ${country}`, weight: 0.2 });
@@ -2057,6 +2057,23 @@ function tokenizeText(text) {
     .filter(token => token.length >= 3);
 }
 
+// Word-boundary term matching to prevent substring false positives
+// (Mali matching Somalia, Niger matching Nigeria, Iran matching Tirana).
+// Boundary class mirrors the tokenizeText delimiter so both matchers agree.
+const TERM_MATCH_REGEX_CACHE_MAX = 4000;
+const termMatchRegexCache = new Map();
+function textIncludesTerm(lowerText, lowerTerm) {
+  if (!lowerText || !lowerTerm) return false;
+  let re = termMatchRegexCache.get(lowerTerm);
+  if (!re) {
+    if (termMatchRegexCache.size >= TERM_MATCH_REGEX_CACHE_MAX) termMatchRegexCache.clear();
+    const escaped = lowerTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    re = new RegExp(`(?:^|[^a-z0-9])${escaped}(?:[^a-z0-9]|$)`);
+    termMatchRegexCache.set(lowerTerm, re);
+  }
+  return re.test(lowerText);
+}
+
 function uniqueLowerTerms(terms) {
   return [...new Set((terms || [])
     .map(term => (term || '').toLowerCase().trim())
@@ -2069,7 +2086,7 @@ function countTermMatches(text, terms) {
   let score = 0;
   for (const term of uniqueLowerTerms(terms)) {
     if (term.length < 3) continue;
-    if (!lower.includes(term)) continue;
+    if (!textIncludesTerm(lower, term)) continue;
     hits += 1;
     score += term.length > 8 ? 4 : term.length > 5 ? 3 : 2;
   }
@@ -2137,7 +2154,7 @@ function computeMarketMatchScore(pred, marketTitle, regionTerms, options = {}) {
   let score = regionScore + (tagOverlap ? 2 : 0) - (tagMismatch ? 5 : 0);
   let domainHits = 0;
   for (const hint of getDomainTerms(pred.domain)) {
-    if (lower.includes(hint)) {
+    if (textIncludesTerm(lower, hint)) {
       domainHits += 1;
       score += 1;
     }
@@ -2145,7 +2162,7 @@ function computeMarketMatchScore(pred, marketTitle, regionTerms, options = {}) {
   let titleHits = 0;
   const titleTokens = options.titleTokens || extractMeaningfulTokens(pred.title, regionTerms);
   for (const token of titleTokens) {
-    if (lower.includes(token)) {
+    if (textIncludesTerm(lower, token)) {
       titleHits += 1;
       score += 2;
     }

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2060,9 +2060,10 @@ function tokenizeText(text) {
 // Word-boundary term matching to prevent substring false positives
 // (Mali matching Somalia, Niger matching Nigeria, Iran matching Tirana).
 // Boundary class mirrors the tokenizeText delimiter so both matchers agree.
-// A plural suffix (s/es) on the text side still counts — attacks/elections
-// must match the singular hints — but a term nested inside a DIFFERENT word
-// never does.
+// A plural suffix on the text side still counts — attacks/elections must
+// match the singular hints — but a term nested inside a DIFFERENT word
+// never does. "es" is only a plural after sibilants (gas→gases, tax→taxes);
+// allowing it globally made "war" match "wares".
 const TERM_MATCH_REGEX_CACHE_MAX = 4000;
 const termMatchRegexCache = new Map();
 function textIncludesTerm(lowerText, lowerTerm) {
@@ -2073,7 +2074,8 @@ function textIncludesTerm(lowerText, lowerTerm) {
       termMatchRegexCache.delete(termMatchRegexCache.keys().next().value);
     }
     const escaped = lowerTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    re = new RegExp(`(?:^|[^a-z0-9])${escaped}(?:s|es)?(?:[^a-z0-9]|$)`);
+    const pluralSuffix = /(?:s|x|z|ch|sh)$/.test(lowerTerm) ? '(?:es)?' : 's?';
+    re = new RegExp(`(?:^|[^a-z0-9])${escaped}${pluralSuffix}(?:[^a-z0-9]|$)`);
     termMatchRegexCache.set(lowerTerm, re);
   }
   return re.test(lowerText);

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2066,7 +2066,9 @@ function textIncludesTerm(lowerText, lowerTerm) {
   if (!lowerText || !lowerTerm) return false;
   let re = termMatchRegexCache.get(lowerTerm);
   if (!re) {
-    if (termMatchRegexCache.size >= TERM_MATCH_REGEX_CACHE_MAX) termMatchRegexCache.clear();
+    if (termMatchRegexCache.size >= TERM_MATCH_REGEX_CACHE_MAX) {
+      termMatchRegexCache.delete(termMatchRegexCache.keys().next().value);
+    }
     const escaped = lowerTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     re = new RegExp(`(?:^|[^a-z0-9])${escaped}(?:[^a-z0-9]|$)`);
     termMatchRegexCache.set(lowerTerm, re);
@@ -2127,16 +2129,16 @@ function computeHeadlineRelevance(headline, terms, domain, options = {}) {
   const tagMismatch = headlineTags.length > 0 && expectedTags.size > 0 && !tagOverlap;
   let score = regionScore + (tagOverlap ? 3 : 0) - (tagMismatch ? 4 : 0);
   for (const hint of getDomainTerms(domain)) {
-    if (lower.includes(hint)) score += 1;
+    if (textIncludesTerm(lower, hint)) score += 1;
   }
   const titleTokens = options.titleTokens || [];
   for (const token of titleTokens) {
-    if (lower.includes(token)) score += 2;
+    if (textIncludesTerm(lower, token)) score += 2;
   }
   if (options.requireRegion && regionHits === 0 && !tagOverlap) return 0;
   if (options.requireSemantic) {
-    const domainHits = getDomainTerms(domain).filter(hint => lower.includes(hint)).length;
-    const titleHits = titleTokens.filter(token => lower.includes(token)).length;
+    const domainHits = getDomainTerms(domain).filter(hint => textIncludesTerm(lower, hint)).length;
+    const titleHits = titleTokens.filter(token => textIncludesTerm(lower, token)).length;
     if (domainHits === 0 && titleHits === 0) return 0;
   }
   return Math.max(0, score);
@@ -2433,7 +2435,7 @@ function getSearchTermsForRegion(region) {
     const regionBase = region.replace(/\s*\([^)]*\)\s*$/, '').toLowerCase(); // strip "(Zaire)", "(Burma)", etc.
     for (const [, entry] of Object.entries(codes)) {
       const nameLower = entry.name.toLowerCase();
-      if (nameLower === regionLower || nameLower === regionBase || regionLower.includes(nameLower)) {
+      if (nameLower === regionLower || nameLower === regionBase || textIncludesTerm(regionLower, nameLower)) {
         terms.push(entry.name);
         terms.push(...entry.keywords);
         break;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2060,6 +2060,9 @@ function tokenizeText(text) {
 // Word-boundary term matching to prevent substring false positives
 // (Mali matching Somalia, Niger matching Nigeria, Iran matching Tirana).
 // Boundary class mirrors the tokenizeText delimiter so both matchers agree.
+// A plural suffix (s/es) on the text side still counts — attacks/elections
+// must match the singular hints — but a term nested inside a DIFFERENT word
+// never does.
 const TERM_MATCH_REGEX_CACHE_MAX = 4000;
 const termMatchRegexCache = new Map();
 function textIncludesTerm(lowerText, lowerTerm) {
@@ -2070,7 +2073,7 @@ function textIncludesTerm(lowerText, lowerTerm) {
       termMatchRegexCache.delete(termMatchRegexCache.keys().next().value);
     }
     const escaped = lowerTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    re = new RegExp(`(?:^|[^a-z0-9])${escaped}(?:[^a-z0-9]|$)`);
+    re = new RegExp(`(?:^|[^a-z0-9])${escaped}(?:s|es)?(?:[^a-z0-9]|$)`);
     termMatchRegexCache.set(lowerTerm, re);
   }
   return re.test(lowerText);
@@ -2433,13 +2436,24 @@ function getSearchTermsForRegion(region) {
   if (!countryEntry) {
     const regionLower = region.toLowerCase();
     const regionBase = region.replace(/\s*\([^)]*\)\s*$/, '').toLowerCase(); // strip "(Zaire)", "(Burma)", etc.
+    // Exact name match always wins; containment falls back to the LONGEST
+    // contained name so "DR Congo" resolves to DR Congo, never Congo, and
+    // "Guinea-Bissau" / "Papua New Guinea" never inherit Guinea's terms.
+    let matched = null;
     for (const [, entry] of Object.entries(codes)) {
       const nameLower = entry.name.toLowerCase();
-      if (nameLower === regionLower || nameLower === regionBase || textIncludesTerm(regionLower, nameLower)) {
-        terms.push(entry.name);
-        terms.push(...entry.keywords);
+      if (nameLower === regionLower || nameLower === regionBase) {
+        matched = entry;
         break;
       }
+      if (textIncludesTerm(regionLower, nameLower)
+        && (!matched || nameLower.length > matched.name.length)) {
+        matched = entry;
+      }
+    }
+    if (matched) {
+      terms.push(matched.name);
+      terms.push(...matched.keywords);
     }
   }
 

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -311,6 +311,139 @@ describe('calibrateWithMarkets', () => {
   });
 });
 
+describe('word-boundary term matching: no substring false positives (#4933)', () => {
+  it('calibrateWithMarkets: Mali forecast is not calibrated by a Somalia market', () => {
+    const pred = makePrediction('political', 'Mali', 'Political instability: Mali', 0.7, 0.6, '30d', []);
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: "Will Somalia's government collapse in 2026?", yesPrice: 30, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.7);
+  });
+
+  it('calibrateWithMarkets: Niger forecast is not calibrated by a Nigeria market', () => {
+    const pred = makePrediction('political', 'Niger', 'Political instability: Niger', 0.7, 0.6, '30d', []);
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Nigeria hold peaceful elections in 2026?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.7);
+  });
+
+  it('detectInfraScenarios: Somalia cyber threat does not boost a Mali outage', () => {
+    const preds = detectInfraScenarios({
+      outages: [{ country: 'Mali', severity: 'major' }],
+      cyberThreats: [{ country: 'Somalia', type: 'ddos' }],
+      gpsJamming: [],
+    });
+    assert.equal(preds.length, 1);
+    assert.equal(preds[0].probability, 0.4);
+    assert.deepEqual(preds[0].signals.map(s => s.type), ['outage']);
+  });
+
+  it('detectInfraScenarios: same-country cyber threat still boosts (positive control)', () => {
+    const preds = detectInfraScenarios({
+      outages: [{ country: 'Mali', severity: 'major' }],
+      cyberThreats: [{ country: 'Mali', type: 'ddos' }],
+      gpsJamming: [],
+    });
+    assert.equal(preds[0].probability, 0.55);
+    assert.ok(preds[0].signals.some(s => s.type === 'cyber'));
+  });
+
+  it('detectInfraScenarios: possessive form still matches across the boundary', () => {
+    const preds = detectInfraScenarios({
+      outages: [{ country: 'Mali', severity: 'major' }],
+      cyberThreats: [{ target: "Mali's banking sector", type: 'ddos' }],
+      gpsJamming: [],
+    });
+    assert.ok(preds[0].signals.some(s => s.type === 'cyber'));
+  });
+
+  it('detectPoliticalScenarios: Nigeria protest anomaly does not boost a Niger forecast', () => {
+    const preds = detectPoliticalScenarios({
+      ciiScores: [{ code: 'NE', name: 'Niger', score: 70, level: 'high', trend: 'rising', components: { unrest: 60 } }],
+      unrestEvents: [],
+      temporalAnomalies: [{ type: 'protest', country: 'Nigeria', zScore: 3.2 }],
+    });
+    assert.equal(preds.length, 1);
+    assert.ok(!preds[0].signals.some(s => s.type === 'anomaly'));
+  });
+
+  it('detectPoliticalScenarios: same-country protest anomaly still boosts (positive control)', () => {
+    const preds = detectPoliticalScenarios({
+      ciiScores: [{ code: 'NE', name: 'Niger', score: 70, level: 'high', trend: 'rising', components: { unrest: 60 } }],
+      unrestEvents: [],
+      temporalAnomalies: [{ type: 'protest', country: 'Niger', zScore: 3.2 }],
+    });
+    assert.ok(preds[0].signals.some(s => s.type === 'anomaly'));
+  });
+
+  it('detectSupplyChainScenarios: route name nested in another word does not attach AIS signals', () => {
+    const preds = detectSupplyChainScenarios({
+      chokepoints: { routes: [{ route: 'Suez', riskScore: 80 }] },
+      temporalAnomalies: [{ type: 'ais_gaps', region: 'Suezmax anchorage zone' }],
+      gpsJamming: [],
+    });
+    assert.equal(preds.length, 1);
+    assert.ok(!preds[0].signals.some(s => s.type === 'ais_gap'));
+  });
+
+  it('detectSupplyChainScenarios: route name as a standalone word still matches (positive control)', () => {
+    const preds = detectSupplyChainScenarios({
+      chokepoints: { routes: [{ route: 'Suez', riskScore: 80 }] },
+      temporalAnomalies: [{ type: 'ais_gaps', region: 'Suez canal north entrance' }],
+      gpsJamming: [],
+    });
+    assert.ok(preds[0].signals.some(s => s.type === 'ais_gap'));
+  });
+
+  it('detectMilitaryScenarios: theater name nested in another word does not attach flight anomalies', () => {
+    const now = Date.now();
+    const preds = detectMilitaryScenarios({
+      militaryForecastInputs: {
+        fetchedAt: now,
+        theaters: [{ id: 'sahel-theater', name: 'Mali', postureLevel: 'elevated', assessedAt: now }],
+        surges: [],
+      },
+      temporalAnomalies: [{ type: 'military_flights', region: 'Somalia border strip', zScore: 3.0 }],
+    });
+    assert.equal(preds.length, 1);
+    assert.ok(!preds[0].signals.some(s => s.type === 'mil_flights'));
+  });
+
+  it('detectMilitaryScenarios: same-theater flight anomaly still attaches (positive control)', () => {
+    const now = Date.now();
+    const preds = detectMilitaryScenarios({
+      militaryForecastInputs: {
+        fetchedAt: now,
+        theaters: [{ id: 'sahel-theater', name: 'Mali', postureLevel: 'elevated', assessedAt: now }],
+        surges: [],
+      },
+      temporalAnomalies: [{ type: 'military_flights', region: 'Mali airspace', zScore: 3.0 }],
+    });
+    assert.ok(preds[0].signals.some(s => s.type === 'mil_flights'));
+  });
+
+  it('computeMarketMatchScore: "Iran" title token does not hit inside "Tirana"', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Escalation risk: Iran', 0.7, 0.6, '7d', []);
+    const score = computeMarketMatchScore(pred, 'Will Tirana host the 2027 summit?', ['middle east']);
+    assert.equal(score.titleHits, 0);
+  });
+
+  it('computeMarketMatchScore: exact "Iran" title token still hits (positive control)', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Escalation risk: Iran', 0.7, 0.6, '7d', []);
+    const score = computeMarketMatchScore(pred, 'Will Iran strike back in 2026?', ['middle east']);
+    assert.ok(score.titleHits >= 1);
+  });
+
+  it('computeMarketMatchScore: multi-word region term still matches across word boundaries', () => {
+    const pred = makePrediction('market', 'Middle East', 'Oil disruption', 0.6, 0.5, '7d', []);
+    const score = computeMarketMatchScore(pred, 'Will the Strait of Hormuz close in 2026?', ['strait of hormuz']);
+    assert.ok(score.regionHits >= 1);
+  });
+});
+
 describe('computeTrends', () => {
   it('no prior: all trends set to stable', () => {
     const pred = makePrediction('conflict', 'Iran', 'Test', 0.6, 0.5, '7d', []);

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -519,6 +519,27 @@ describe('word-boundary term matching: no substring false positives (#4933)', ()
     const terms = getSearchTermsForRegion('Papua New Guinea').map(t => t.toLowerCase());
     assert.ok(!terms.includes('conakry'), `Papua New Guinea leaked Guinea terms: ${terms.join(', ')}`);
   });
+
+  it('computeMarketMatchScore: "war" hint does not hit inside "wares" (es only after sibilants)', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Escalation risk: Iran', 0.7, 0.6, '7d', []);
+    const score = computeMarketMatchScore(pred, 'Will Iran export more wares in 2026?', ['iran', 'middle east']);
+    assert.equal(score.domainHits, 0);
+  });
+
+  it('calibrateWithMarkets: Iran conflict forecast not calibrated by an unrelated wares market', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Escalation risk: Iran', 0.7, 0.6, '7d', []);
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Iran export more wares in 2026?', yesPrice: 30, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.7);
+  });
+
+  it('computeMarketMatchScore: sibilant plural still matches ("gas" hint vs "gases")', () => {
+    const pred = makePrediction('market', 'Europe', 'Energy price shock: Europe', 0.6, 0.5, '7d', []);
+    const score = computeMarketMatchScore(pred, 'Will greenhouse gases regulation raise Europe energy prices?', ['europe']);
+    assert.ok(score.domainHits >= 1);
+  });
 });
 
 describe('computeTrends', () => {

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -486,6 +486,39 @@ describe('word-boundary term matching: no substring false positives (#4933)', ()
     });
     assert.ok(score > 0);
   });
+
+  it('computeHeadlineRelevance: plural form of a domain hint still scores (attacks vs attack)', () => {
+    const score = computeHeadlineRelevance('Missile attacks intensify near border', [], 'conflict', {
+      requireSemantic: true,
+    });
+    assert.ok(score > 0);
+  });
+
+  it('calibrateWithMarkets: plural domain hint still calibrates (elections vs election)', () => {
+    const pred = makePrediction('political', 'Nigeria', 'Political instability: Nigeria', 0.7, 0.6, '30d', []);
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Nigeria hold peaceful elections in 2026?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null);
+    assert.equal(pred.probability, +(0.4 * 0.8 + 0.6 * 0.7).toFixed(3));
+  });
+
+  it('getSearchTermsForRegion: DR Congo resolves to DR Congo, not Congo-Brazzaville', () => {
+    const terms = getSearchTermsForRegion('DR Congo').map(t => t.toLowerCase());
+    assert.ok(!terms.includes('brazzaville'), `DR Congo leaked Congo-Brazzaville terms: ${terms.join(', ')}`);
+    assert.ok(terms.includes('kinshasa'), `DR Congo lost its own keywords: ${terms.join(', ')}`);
+  });
+
+  it('getSearchTermsForRegion: Guinea-Bissau does not inherit Guinea/Conakry terms', () => {
+    const terms = getSearchTermsForRegion('Guinea-Bissau').map(t => t.toLowerCase());
+    assert.ok(!terms.includes('conakry'), `Guinea-Bissau leaked Guinea terms: ${terms.join(', ')}`);
+    assert.ok(terms.includes('guinea-bissau'));
+  });
+
+  it('getSearchTermsForRegion: Papua New Guinea does not inherit Guinea/Conakry terms', () => {
+    const terms = getSearchTermsForRegion('Papua New Guinea').map(t => t.toLowerCase());
+    assert.ok(!terms.includes('conakry'), `Papua New Guinea leaked Guinea terms: ${terms.join(', ')}`);
+  });
 });
 
 describe('computeTrends', () => {

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -27,6 +27,7 @@ import {
   computeConfidence,
   computeHeadlineRelevance,
   computeMarketMatchScore,
+  getSearchTermsForRegion,
   sanitizeForPrompt,
   parseLLMScenarios,
   validateScenarios,
@@ -441,6 +442,49 @@ describe('word-boundary term matching: no substring false positives (#4933)', ()
     const pred = makePrediction('market', 'Middle East', 'Oil disruption', 0.6, 0.5, '7d', []);
     const score = computeMarketMatchScore(pred, 'Will the Strait of Hormuz close in 2026?', ['strait of hormuz']);
     assert.ok(score.regionHits >= 1);
+  });
+
+  it('getSearchTermsForRegion: Somalia does not inherit Mali terms via reverse substring lookup', () => {
+    const terms = getSearchTermsForRegion('Somalia').map(t => t.toLowerCase());
+    assert.ok(!terms.includes('bamako'), `Somalia terms leaked Mali keywords: ${terms.join(', ')}`);
+    assert.ok(!terms.some(t => t === 'mali'), `Somalia terms leaked Mali name: ${terms.join(', ')}`);
+    assert.ok(terms.includes('mogadishu'), `Somalia lost its own keywords to the substring break: ${terms.join(', ')}`);
+  });
+
+  it('getSearchTermsForRegion: Nigeria does not inherit Niger terms via reverse substring lookup', () => {
+    const terms = getSearchTermsForRegion('Nigeria').map(t => t.toLowerCase());
+    assert.ok(!terms.includes('niamey'), `Nigeria terms leaked Niger keywords: ${terms.join(', ')}`);
+    assert.ok(!terms.some(t => t === 'niger'), `Nigeria terms leaked Niger name: ${terms.join(', ')}`);
+  });
+
+  it('getSearchTermsForRegion: parenthetical suffix regions still resolve (positive control)', () => {
+    const terms = getSearchTermsForRegion('Myanmar (Burma)').map(t => t.toLowerCase());
+    assert.ok(terms.includes('myanmar'));
+  });
+
+  it('calibrateWithMarkets: Nigeria forecast is not calibrated by a Niger market (reverse-lookup poisoning)', () => {
+    const pred = makePrediction('political', 'Nigeria', 'Political instability: Nigeria', 0.7, 0.6, '30d', []);
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: "Will Niger's junta lose power in 2026?", yesPrice: 30, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.7);
+  });
+
+  it('computeHeadlineRelevance: "war" hint does not hit inside "award", "iran" token not inside "Tirana"', () => {
+    const score = computeHeadlineRelevance('Award season kicks off in Tirana', [], 'conflict', {
+      titleTokens: ['iran'],
+      requireSemantic: true,
+    });
+    assert.equal(score, 0);
+  });
+
+  it('computeHeadlineRelevance: exact domain hint and title token still score (positive control)', () => {
+    const score = computeHeadlineRelevance('War fears grow as Iran mobilizes reservists', ['iran'], 'conflict', {
+      titleTokens: ['iran'],
+      requireSemantic: true,
+    });
+    assert.ok(score > 0);
   });
 });
 


### PR DESCRIPTION
## What

Fixes the HIGH finding from the #4933 adversarial audit: bare `String.includes` term matching let a country name nested inside another silently contaminate the forecast probability spine. Only `detectConflictScenarios` ever received the word-boundary guard ("prevent substring false positives (IL matching Chile)"); the shared matcher and the other detectors did not.

**Live-reproduced corruption this PR eliminates** (all asserted by new regression tests):

| Path | Before | After |
|---|---|---|
| Mali political 0.70 vs "Will **Somalia**'s government collapse…" | market-blended to **0.54**, `calibration` set | untouched 0.70, no calibration |
| Niger political 0.70 vs "Will **Nigeria** hold elections…" | blended to 0.74 | untouched 0.70 |
| Mali major outage + **Somalia** cyber threat | 0.40 → **0.55** + bogus `cyber` signal | 0.40, `outage` only |
| Niger CII + **Nigeria** protest anomaly | +0.10 bogus `anomaly` boost | no boost |
| "Suez" route vs "**Suezmax** anchorage" AIS anomaly | bogus `ais_gap` signal | none |
| Mali theater vs "**Somalia** border strip" flight anomaly | bogus `mil_flights` signal | none |
| "Iran" title token vs "**Tirana** host…" market | `titleHits: 1` | 0 |

## How

New `textIncludesTerm(lowerText, lowerTerm)` helper — cached word-boundary regex, boundary class `[^a-z0-9]` mirroring the `tokenizeText` delimiter so both matchers agree (possessives like "Mali's" still match; multi-word terms like "strait of hormuz" still match). Swapped in at all nine bare-`.includes` sites:

- `countTermMatches` — shared by `computeMarketMatchScore` (market calibration regionHits) and `computeHeadlineRelevance`/`attachNewsContext` (news corroboration)
- `computeMarketMatchScore` — domain hints + title tokens
- `detectPoliticalScenarios` protestAnomalies, `detectInfraScenarios` relatedCyber + nearbyJam, `detectSupplyChainScenarios` aisGaps + nearbyJam, `detectMilitaryScenarios` milFlights

## Tests

Bug-fix protocol: 13 new tests written first, 7 confirmed RED against the old code (exactly the negative cases), 6 positive controls green before and after (same-country matches, possessive boundary, multi-word terms).

- `tests/forecast-detectors.test.mjs`: 200/200 (was 193 + 7 red)
- Adjacent suites: forecast-trace-export 310/310, forecast-history 7/7, forecast-integrity-provenance 6/6, forecast-seed-resilience 11/11, forecast-llm-telemetry 4/4, forecast-narrative-cache-hash 5/5, forecasts-ticker-set-envelope-unwrap 5/5
- `scripts/evaluate-forecast-benchmark.mjs`: 6/6 (generation-quality fixtures unaffected)

## Why it matters

This is fix 1 of 3 P1 prerequisites for the #4930 verified-forecasting epic — the blend corruption writes wrong probabilities into `forecast:predictions:v2` and the 45-day history that the future resolution/Brier system will score.

Part of #4933.

https://claude.ai/code/session_01XhvRdRjkLqtkRBZi9ZYAu2
