### PR TITLE
fix(sentry): CSP noise filters — Doubao KaTeX fonts (310k ev), injected Google Fonts CSS, content-filter frame vendors (#4942)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -180,7 +180,24 @@ function shouldSuppressCspViolation(
   // surrounding signal filters.
   if (directive === 'frame-src') {
     try {
-      if (new URL(blockedURI).hostname === 'gateway.zscloud.net') return true;
+      const frameHost = new URL(blockedURI).hostname;
+      if (frameHost === 'gateway.zscloud.net') return true;
+      // Same class, other vendors (WORLDMONITOR-HT long tail): NetSTAR inSITE
+      // (gw-*.iss.netstar-inc.com), Techloq (filter.techloq.com — kosher
+      // content filter), Trend Micro password-manager/agent asset frames
+      // (pwm-image.trendmicro.com). All are filter/security agents framing
+      // their own vendor hosts into every page; we never frame any of them.
+      // Parsed-hostname suffix match with a leading `.` so lookalike
+      // registrable domains (netstar-inc.com.evil.com) do not match.
+      if (frameHost === 'netstar-inc.com' || frameHost.endsWith('.netstar-inc.com')) return true;
+      if (frameHost === 'techloq.com' || frameHost.endsWith('.techloq.com')) return true;
+      if (frameHost === 'trendmicro.com' || frameHost.endsWith('.trendmicro.com')) return true;
+      // Google-internal extension/API hosts (`*.clients6.google.com`, e.g.
+      // toolytics.pa.clients6.google.com) framed by Google-account browser
+      // surfaces and extensions. We never frame Google API hosts — but keep
+      // accounts.google.com / support.google.com SURFACED: a future first-party
+      // Google sign-in embed regression must not be masked.
+      if (frameHost.endsWith('.clients6.google.com')) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // Browser extensions or injected scripts. `ms-browser-extension://` is Edge's
@@ -215,6 +232,13 @@ function shouldSuppressCspViolation(
       // third-party suppression, so an unexpected font injection from any other
       // host still surfaces (WORLDMONITOR-TR: 1065 events / 83 users).
       if (url.protocol === 'https:' && url.hostname === 'frontend-cdn.perplexity.ai' && /\.woff2?$/.test(url.pathname)) return true;
+      // ByteDance's Doubao AI-assistant browser/extension injects its overlay's
+      // KaTeX math fonts (lf-flow-web-cdn.doubao.com/obj/flow-doubao/...) into
+      // every page — .woff2/.woff/.ttf fallback chain, so all three extensions
+      // appear. We never load it; exact host + font-file path like the rules
+      // above, NOT a blanket third-party suppression (WORLDMONITOR-TR round 2:
+      // 310k events / 308 users in 11 days).
+      if (url.protocol === 'https:' && url.hostname === 'lf-flow-web-cdn.doubao.com' && /\.(?:woff2?|ttf)$/.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.
@@ -231,6 +255,26 @@ function shouldSuppressCspViolation(
   // injection (WORLDMONITOR-J0 — antd@4 CSS injection, 270 events / 26
   // users on finance.worldmonitor.app).
   if (/^style-src(-elem)?$/.test(directive) && /^https:\/\/cdn\.jsdelivr\.net\//.test(blockedURI)) return true;
+  // Google Fonts CSS injected by extensions/user-style themes (DM Sans, Syne,
+  // Roboto… — families we never reference). The dashboard self-hosts all fonts
+  // and the deploy/config tests keep Google Fonts out of our source/CSP
+  // surfaces, so a style-src* block on fonts.googleapis.com/css* is by
+  // definition third-party injection — the stylesheet counterpart of the
+  // fonts.gstatic.com font-src rule above (WORLDMONITOR-J0 round 2). Exact
+  // host + /css path; Google Fonts under any other directive still surfaces.
+  if (/^style-src(-elem)?$/.test(directive)) {
+    try {
+      const url = new URL(blockedURI);
+      if (url.protocol === 'https:' && url.hostname === 'fonts.googleapis.com' && /^\/css2?$/.test(url.pathname)) return true;
+      // Chinese-market extension CDN injecting its overlay stylesheet
+      // (www.6ppn.com/ext/assets/style.<hash>.css — the /ext/ path is the
+      // extension's own asset root). Exact host + .css path (WORLDMONITOR-J0).
+      if (url.protocol === 'https:' && url.hostname === 'www.6ppn.com' && /\.css$/.test(url.pathname)) return true;
+    } catch { /* unparseable values fall through */ }
+    // Extension bug: a literal unsubstituted `[email]` template placeholder as
+    // the stylesheet URL. Not a parseable host; can never be first-party.
+    if (blockedURI === 'https://[email]') return true;
+  }
   // Inline script blocks from extensions/in-app browsers.
   if (blockedURI === 'inline' && directive === 'script-src-elem') return true;
   // Null blocked URI from in-app browsers.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -239,6 +239,19 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/app.js', '', false));
     });
 
+    it('suppresses Doubao AI-assistant overlay KaTeX font injection (WORLDMONITOR-TR round 2)', () => {
+      // ByteDance Doubao extension injects KaTeX fonts with a woff2/woff/ttf
+      // fallback chain — all three extensions must be covered.
+      assert.ok(suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/flow-ext-doubao/cdn-media-assets/KaTeX_Fraktur-Regular.7c187121.woff', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/flow-ext-doubao/cdn-media-assets/KaTeX_Fraktur-Regular.d3c882a6.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/flow-ext-doubao/cdn-media-assets/KaTeX_Fraktur-Bold.b18f59e1.ttf', '', false));
+    });
+
+    it('does NOT suppress a doubao.com lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/app.js', '', false));
+    });
+
     it('does NOT suppress Google Fonts under unrelated directives', () => {
       assert.ok(!suppress('enforce', 'script-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2', '', false));
     });
@@ -278,6 +291,31 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       // vendor-CDN CSP regression we want to see.
       assert.ok(!suppress('enforce', 'script-src', 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js', '', false));
       assert.ok(!suppress('enforce', 'connect-src', 'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-50m.json', '', false));
+    });
+
+    it('suppresses Google Fonts CSS injection under style-src* (WORLDMONITOR-J0 round 2)', () => {
+      // Extensions/user-style themes inject <link> stylesheets for families we
+      // never reference (DM Sans, Syne, Roboto). We self-host all fonts, so a
+      // style-src* block on fonts.googleapis.com/css* is always injection.
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap', '', false));
+      assert.ok(suppress('enforce', 'style-src', 'https://fonts.googleapis.com/css?family=Roboto:wght@400;500&display=swap', '', false));
+    });
+
+    it('does NOT suppress fonts.googleapis.com under other directives or non-css paths', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.googleapis.com/css2?family=DM+Sans', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://fonts.googleapis.com/icon.js', '', false));
+    });
+
+    it('suppresses 6ppn.com extension stylesheet injection (WORLDMONITOR-J0)', () => {
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://www.6ppn.com/ext/assets/style.CMoYtLrp.css?v=uTaroZOITRdUkyChp', '', false));
+    });
+
+    it('suppresses literal [email] placeholder stylesheet URL from a broken extension template', () => {
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://[email]', '', false));
+    });
+
+    it('does NOT suppress arbitrary third-party style-src hosts', () => {
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://styles.evil.example/inject.css', '', false));
     });
   });
 
@@ -353,6 +391,39 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
 
     it('does NOT suppress connect-src to Zscaler (only frame-src is the injection)', () => {
       assert.ok(!suppress('enforce', 'connect-src', 'https://gateway.zscloud.net/api', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('suppresses frame-src for content-filter/security agent vendor frames (WORLDMONITOR-HT)', () => {
+      // NetSTAR inSITE, Techloq, Trend Micro agents frame their own vendor
+      // hosts into every page. frame-src reports origin-only for cross-origin
+      // frames, so these are origin-shaped blockedURIs.
+      assert.ok(suppress('enforce', 'frame-src', 'https://gw-3z9x.iss.netstar-inc.com', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(suppress('enforce', 'frame-src', 'https://filter.techloq.com', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(suppress('enforce', 'frame-src', 'https://pwm-image.trendmicro.com', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('suppresses frame-src for Google-internal extension API hosts (*.clients6.google.com)', () => {
+      assert.ok(suppress('enforce', 'frame-src', 'https://toolytics.pa.clients6.google.com', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress frame-src for lookalike filter-vendor hosts', () => {
+      assert.ok(!suppress('enforce', 'frame-src', 'https://netstar-inc.com.evil.com', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'https://clients6.google.com.evil.com', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress frame-src for arbitrary third-party hosts (rotating extension long tail stays surfaced)', () => {
+      // WORLDMONITOR-HT's rotating merchant-domain tail is deliberately NOT
+      // blanket-suppressed — a future first-party embed regression must surface.
+      assert.ok(!suppress('enforce', 'frame-src', 'https://www.service.com.au', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress frame-src for accounts.google.com / support.google.com (potential first-party sign-in embeds)', () => {
+      assert.ok(!suppress('enforce', 'frame-src', 'https://accounts.google.com', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'https://support.google.com', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress connect-src to the filter vendors (only frame-src is the injection)', () => {
+      assert.ok(!suppress('enforce', 'connect-src', 'https://filter.techloq.com/api', '', false, FIRST_PARTY_CONVEX));
     });
 
     // First-party img-src suppression — same pattern as connect-src+Convex above.


### PR DESCRIPTION
Closes #4942.

## What

2026-07-06 `/sentry-triage` round: three exact-host additions to `shouldSuppressCspViolation` (src/main.ts), per the allowlist policy — no blanket third-party suppression.

| Sentry issue | Noise source | Filter added |
|---|---|---|
| WORLDMONITOR-TR (round 2) — **310,925 ev / 308 users / 11 days** | ByteDance Doubao AI-assistant extension injecting overlay KaTeX fonts | font-src: exact host `lf-flow-web-cdn.doubao.com` + `.woff/.woff2/.ttf` path |
| WORLDMONITOR-J0 (round 2) — 1,364 ev / 221 users | Extensions injecting Google Fonts CSS (DM Sans/Syne/Roboto — we self-host all fonts), `www.6ppn.com` extension stylesheet, literal `https://[email]` template placeholder | style-src*-scoped: exact host `fonts.googleapis.com` + `/css|/css2` path; exact host `www.6ppn.com` + `.css`; literal match |
| WORLDMONITOR-HT — 5,797 ev / 1,484 users since March | Content-filter/security agents framing their vendor hosts (NetSTAR inSITE, Techloq, Trend Micro) + Google-internal extension API hosts | frame-src-scoped: parsed-hostname suffix matches for `netstar-inc.com`, `techloq.com`, `trendmicro.com`, `*.clients6.google.com` |

## Deliberately NOT suppressed

- `accounts.google.com` / `support.google.com` frame blocks — a future first-party Google sign-in embed regression must not be masked (explicit negative tests).
- HT's rotating merchant-domain long tail (~50 distinct hosts per 100-event sample) — blanket frame-src suppression is policy-forbidden; WORLDMONITOR-HT stays open as the ambient bucket.

## Tests

10 new cases in tests/csp-filter.test.mjs: each rule's positive path plus lookalike-host (`*.evil.com`) and wrong-directive negatives. `tsx --test tests/csp-filter.test.mjs tests/sentry-beforesend.test.mjs` → 271/271 pass. `tsc --noEmit` clean.

## Triage context (no code change needed)

Same round resolved in Sentry without code: WORLDMONITOR-VF (operator artifact — bare guard-query runs with partial args, same IP, 2s apart), VG (Upstash Lua timeout absorbed by rate-limit fail-open), VA (CF 520 warning-downgrade working as designed), VE (transient 504, client falls back). Left open as intentional telemetry: INP/CLS web-vitals, Dodo checkout declined, Clerk ui.browser.js load-failure alarm.

https://claude.ai/code/session_016eFTLVt198t74MK65J87Nf
