### PR TITLE
feat(llm): core chain to OpenRouter DeepSeek V4 Flash + output-shape hardening (#4944 U1+U2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -570,11 +570,20 @@ ANTHROPIC_API_KEY=
 OLLAMA_API_KEY=
 
 # Optional reasoning-model routing for server/_shared/llm.ts. Overrides the
-# provider/model used for "reasoning" LLM calls.
+# provider/model used for "reasoning" LLM calls (brief-why-matters analyst,
+# chat-analyst stream, deduct-situation). Reasoning stays enabled for this
+# profile; utility calls send reasoning-off.
 # Examples: LLM_REASONING_PROVIDER=openrouter
-#           LLM_REASONING_MODEL=anthropic/claude-3.5-sonnet
+#           LLM_REASONING_MODEL=deepseek/deepseek-v4-pro
 LLM_REASONING_PROVIDER=
 LLM_REASONING_MODEL=
+
+# Optional tool-model routing for server/_shared/llm.ts (callLlmTool profile:
+# cheap extraction/parsing tasks — no callers today, config kept valid).
+# Examples: LLM_TOOL_PROVIDER=openrouter
+#           LLM_TOOL_MODEL=deepseek/deepseek-v4-flash
+LLM_TOOL_PROVIDER=
+LLM_TOOL_MODEL=
 
 # Forecast impact-stage LLM routing (sibling of the FORECAST_LLM_* knobs above).
 # Precedence matches the combined/critical overrides.
@@ -817,6 +826,13 @@ FOLLOWED_BIAS_MULTIPLIER=
 # BRIEF_SHARE_SECRET: signs public brief share tokens.
 # BRIEF_URL_SIGNING_SECRET (+ _PREV for rotation): signs per-user brief URLs.
 # BRIEF_WHY_MATTERS_ENDPOINT_URL: optional endpoint for "why it matters" text.
+# BRIEF_WHY_MATTERS_PRIMARY: which path serves whyMatters — 'analyst' (default)
+#   or 'gemini' (stable fallback prompt); unknown values fall back to gemini.
+# BRIEF_WHY_MATTERS_SHADOW: '1' runs BOTH paths on cache miss and records
+#   shadow pairs for offline comparison. DOUBLES spend while on (#4893) —
+#   enable only for a bounded A/B window, then unset.
+# BRIEF_WHY_MATTERS_SHADOW_SAMPLE_PCT: 0-100 sampling for the shadow run
+#   (default 100).
 BRIEF_COMPOSE_ENABLED=
 BRIEF_LLM_ENABLED=
 BRIEF_VALIDATOR_MODE=
@@ -824,6 +840,9 @@ BRIEF_SHARE_SECRET=
 BRIEF_URL_SIGNING_SECRET=
 BRIEF_URL_SIGNING_SECRET_PREV=
 BRIEF_WHY_MATTERS_ENDPOINT_URL=
+BRIEF_WHY_MATTERS_PRIMARY=
+BRIEF_WHY_MATTERS_SHADOW=
+BRIEF_WHY_MATTERS_SHADOW_SAMPLE_PCT=
 
 # Destination address for contact-form submissions (server leads RPC).
 CONTACT_NOTIFY_EMAIL=

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -229,7 +229,9 @@ export const callLlmTool = (opts: Omit<LlmCallOptions, 'providerOrder' | 'modelO
 export const callLlmReasoning = (opts: Omit<LlmCallOptions, 'providerOrder' | 'modelOverrides'>) =>
   callLlmProfile({ ...opts, enableReasoning: true }, 'LLM_REASONING_PROVIDER', 'LLM_REASONING_MODEL', 'openrouter');
 
-export type LlmStreamOptions = Omit<LlmCallOptions, 'stripThinkingTags' | 'validate' | 'providerOrder' | 'modelOverrides' | 'provider'> & {
+// enableReasoning is omitted too: the reasoning stream hardcodes it on —
+// exposing the knob on the stream type would be a silent no-op for callers.
+export type LlmStreamOptions = Omit<LlmCallOptions, 'stripThinkingTags' | 'validate' | 'providerOrder' | 'modelOverrides' | 'provider' | 'enableReasoning'> & {
   /** When fired, aborts the active provider fetch and stops the stream. */
   signal?: AbortSignal;
 };

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -29,6 +29,8 @@ export type LlmProviderName = 'ollama' | 'groq' | 'openrouter' | 'generic';
 
 export interface ProviderCredentialOverrides {
   model?: string;
+  /** OpenRouter only: let reasoning-capable models reason (reasoning profile). Default false — utility calls must not pay reasoning tokens. */
+  enableReasoning?: boolean;
 }
 
 const OLLAMA_HOST_ALLOWLIST = new Set([
@@ -77,7 +79,7 @@ export function getProviderCredentials(
     if (!apiKey) return null;
     return {
       apiUrl: 'https://api.groq.com/openai/v1/chat/completions',
-      model: overrides.model || 'llama-3.1-8b-instant',
+      model: overrides.model || 'llama-3.3-70b-versatile',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
@@ -90,13 +92,18 @@ export function getProviderCredentials(
     if (!apiKey) return null;
     return {
       apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
-      model: overrides.model || 'google/gemini-2.5-flash',
+      model: overrides.model || 'deepseek/deepseek-v4-flash',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
         'HTTP-Referer': 'https://worldmonitor.app',
         'X-Title': 'World Monitor',
       },
+      // Hybrid-reasoning models (DeepSeek V4) reason by default via
+      // OpenRouter's normalized `reasoning` param; utility calls must not
+      // pay reasoning tokens. The reasoning profile opts back in, letting
+      // the model's own default apply.
+      extraBody: overrides.enableReasoning ? undefined : { reasoning: { enabled: false } },
     };
   }
 
@@ -140,7 +147,11 @@ export function stripThinkingTags(text: string): string {
 }
 
 
-const PROVIDER_CHAIN = ['ollama', 'groq', 'openrouter', 'generic'] as const;
+// openrouter ahead of groq since #4944: core surfaces run DeepSeek V4 Flash
+// via OpenRouter; groq (llama-3.3-70b-versatile) is the free-tier/outage
+// fallback. Ollama stays first so self-hosted deployments are untouched —
+// it is skipped in cloud where OLLAMA_API_URL is unset.
+const PROVIDER_CHAIN = ['ollama', 'openrouter', 'groq', 'generic'] as const;
 const PROVIDER_SET = new Set<string>(PROVIDER_CHAIN);
 
 export interface LlmCallOptions {
@@ -159,6 +170,8 @@ export interface LlmCallOptions {
   systemAppend?: string;
   /** Caller surface tag for llm_call usage telemetry (e.g. 'classify-event'). */
   stage?: string;
+  /** Let reasoning-capable OpenRouter models reason. Set by the reasoning profile; utility calls stay reasoning-off. */
+  enableReasoning?: boolean;
 }
 
 export interface LlmCallResult {
@@ -214,7 +227,7 @@ export const callLlmTool = (opts: Omit<LlmCallOptions, 'providerOrder' | 'modelO
 
 /** Powerful model for synthesis and reasoning tasks. Configurable via LLM_REASONING_PROVIDER / LLM_REASONING_MODEL. */
 export const callLlmReasoning = (opts: Omit<LlmCallOptions, 'providerOrder' | 'modelOverrides'>) =>
-  callLlmProfile(opts, 'LLM_REASONING_PROVIDER', 'LLM_REASONING_MODEL', 'openrouter');
+  callLlmProfile({ ...opts, enableReasoning: true }, 'LLM_REASONING_PROVIDER', 'LLM_REASONING_MODEL', 'openrouter');
 
 export type LlmStreamOptions = Omit<LlmCallOptions, 'stripThinkingTags' | 'validate' | 'providerOrder' | 'modelOverrides' | 'provider'> & {
   /** When fired, aborts the active provider fetch and stops the stream. */
@@ -289,6 +302,8 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
 
         const creds = getProviderCredentials(providerName, {
           model: modelOverrides?.[providerName as LlmProviderName],
+          // Streaming variant of callLlmReasoning — the reasoning profile opts in.
+          enableReasoning: true,
         });
         if (!creds) continue;
 
@@ -421,6 +436,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
     stripThinkingTags: shouldStrip = true,
     validate,
     systemAppend,
+    enableReasoning = false,
   } = opts;
 
   let messages = rawMessages;
@@ -445,6 +461,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
     for (const providerName of providers) {
       const creds = getProviderCredentials(providerName, {
         model: modelOverrides?.[providerName as LlmProviderName],
+        enableReasoning,
       });
       if (!creds) {
         if (forcedProvider) return null;

--- a/server/worldmonitor/intelligence/v1/_country-brief-context.ts
+++ b/server/worldmonitor/intelligence/v1/_country-brief-context.ts
@@ -47,15 +47,17 @@ export interface CountryIntelCacheKeyOpts {
 }
 
 export function deriveCountryIntelCacheKey(opts: CountryIntelCacheKeyOpts): string {
+  // v4 → v5 (2026-07-06, #4944): intel briefs moved to deepseek-v4-flash;
+  // v4 rows carry old-model prose and must age out at cutover.
   const energyTag = opts.energyYear ? `:e${opts.energyYear}` : '';
   if (!opts.isPremium) {
     // Anonymous tier: caller inputs must not reach the key, or the shared
     // cache degenerates back into a per-caller one (and one caller's
     // context could mint entries served to everyone).
-    return `ci-sebuf:v4:${opts.countryCode}:${opts.lang}:shared${energyTag}`;
+    return `ci-sebuf:v5:${opts.countryCode}:${opts.lang}:shared${energyTag}`;
   }
   const fw = opts.frameworkHash ? `:${opts.frameworkHash}` : '';
-  return `ci-sebuf:v4:${opts.countryCode}:${opts.lang}:${opts.contextHash}${fw}${energyTag}`;
+  return `ci-sebuf:v5:${opts.countryCode}:${opts.lang}:${opts.contextHash}${fw}${energyTag}`;
 }
 
 interface DigestItemForBrief {

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -1224,7 +1224,9 @@ export async function analyzeStock(
   const name = (req.name || symbol).trim().slice(0, 120) || symbol;
   const includeNews = req.includeNews === true;
   const nameSuffix = name !== symbol ? `:${name.replace(/[^a-zA-Z0-9]/g, '').slice(0, 30).toLowerCase()}` : '';
-  const cacheKey = `market:analyze-stock:v3:${symbol}:${includeNews ? 'news' : 'no-news'}${nameSuffix}`;
+  // v3 → v4 (2026-07-06, #4944): LLM analysis moved to deepseek-v4-flash;
+  // v3 rows carry old-model output and must age out at cutover.
+  const cacheKey = `market:analyze-stock:v4:${symbol}:${includeNews ? 'news' : 'no-news'}${nameSuffix}`;
 
   const cached = await cachedFetchJson<AnalyzeStockResponse>(cacheKey, CACHE_TTL_SECONDS, async () => {
     const [history, analystData] = await Promise.all([

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -60,7 +60,7 @@ const premiumNewsClient = new NewsServiceClient(getRpcBaseUrl(), {
 // Gate every API-provider dispatch on the client-side entitlement signal so
 // anon/free principals fall straight to the browser-T5 provider with ZERO
 // network attempts — before this gate, every summarize attempt fanned out up
-// to 3 doomed RPCs (ollama→groq→openrouter through the same gated endpoint).
+// to 3 doomed RPCs (ollama→openrouter→groq through the same gated endpoint).
 // panel-gating's hasPremiumAccess is the dual-signal source of truth.
 // translateText is deliberately NOT gated: it uses mode='translate' via the
 // plain newsClient, which the server allows for non-premium callers.
@@ -84,10 +84,13 @@ interface ApiProviderDef {
   label: string;
 }
 
+// Order matches the server's default chain since #4944: OpenRouter
+// (DeepSeek V4 Flash) ahead of Groq — the RPC honors the client-supplied
+// provider, so the client's try-order decides which model summarizes.
 const API_PROVIDERS: ApiProviderDef[] = [
   { featureId: 'aiOllama',      provider: 'ollama',     label: 'Ollama' },
-  { featureId: 'aiGroq',        provider: 'groq',       label: 'Groq AI' },
   { featureId: 'aiOpenRouter',  provider: 'openrouter', label: 'OpenRouter' },
+  { featureId: 'aiGroq',        provider: 'groq',       label: 'Groq AI' },
 ];
 
 let lastAttemptedProvider = 'none';

--- a/src/utils/summary-cache-key.ts
+++ b/src/utils/summary-cache-key.ts
@@ -4,7 +4,12 @@
 // or client/server cache keys will silently diverge.
 import { hashString } from './hash';
 
-// Bumped v6 → v7 on 2026-07-05 (#4914): identical (headline, body) pairs now
+// Bumped v7 → v8 on 2026-07-06 (#4944): the summarize provider chain moved
+// from groq llama-3.1-8b-instant-first to OpenRouter deepseek-v4-flash-first,
+// so v7 rows carry old-model voice — retire them cleanly at cutover instead
+// of serving mixed-model summaries for the TTL.
+//
+// v6 → v7 (2026-07-05, #4914): identical (headline, body) pairs now
 // dedup before the top-5 slice, so v6 rows keyed over a duplicate-bearing
 // composition would never be hit again anyway — the bump retires them
 // cleanly instead of leaving orphans to age out.
@@ -13,7 +18,7 @@ import { hashString } from './hash';
 // DON'T pass `bodies` saw a forced cold-start so the pre-grounding
 // headline-only rows aged out cleanly on first tick after deploy. See
 // docs/plans/2026-04-24-001-fix-rss-description-end-to-end-plan.md U6.
-export const CACHE_VERSION = 'v7';
+export const CACHE_VERSION = 'v8';
 
 const MAX_HEADLINE_LEN = 500;
 const MAX_HEADLINES_FOR_KEY = 5;

--- a/tests/country-intel-brief-cache-key.test.mjs
+++ b/tests/country-intel-brief-cache-key.test.mjs
@@ -21,7 +21,7 @@ describe('country intel brief cache key derivation', () => {
       contextHash: 'bbbbbbbbbbbbbbbb', frameworkHash: '', energyYear: '2024',
     });
     assert.equal(a, b, 'anon key must not vary with client context');
-    assert.ok(a.startsWith('ci-sebuf:v4:FR:en:shared'), `anon key should use shared namespace, got ${a}`);
+    assert.ok(a.startsWith('ci-sebuf:v5:FR:en:shared'), `anon key should use shared namespace, got ${a}`);
   });
 
   it('anon key ignores framework hash (framework is premium-only input)', () => {
@@ -52,7 +52,7 @@ describe('country intel brief cache key derivation', () => {
     assert.notEqual(mk('aaaaaaaaaaaaaaaa', ''), mk('bbbbbbbbbbbbbbbb', ''), 'premium context must personalize the key');
     assert.equal(mk('aaaaaaaaaaaaaaaa', ''), mk('aaaaaaaaaaaaaaaa', ''), 'same premium context must share the key');
     assert.notEqual(mk('aaaaaaaaaaaaaaaa', 'deadbeef'), mk('aaaaaaaaaaaaaaaa', ''), 'framework must personalize the key');
-    assert.ok(mk('aaaaaaaaaaaaaaaa', '').startsWith('ci-sebuf:v4:FR:en:aaaaaaaaaaaaaaaa'));
+    assert.ok(mk('aaaaaaaaaaaaaaaa', '').startsWith('ci-sebuf:v5:FR:en:aaaaaaaaaaaaaaaa'));
     assert.ok(!mk('aaaaaaaaaaaaaaaa', '').includes(':shared'));
   });
 });

--- a/tests/llm-usage-telemetry.test.mts
+++ b/tests/llm-usage-telemetry.test.mts
@@ -29,7 +29,7 @@ interface CapturedIngest {
 }
 
 function installFetchMock(opts: {
-  groqStatus?: number;
+  openrouterStatus?: number;
   captured: CapturedIngest;
 }) {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -43,19 +43,19 @@ function installFetchMock(opts: {
       return new Response('{}', { status: 200 });
     }
     if (url.includes('api.groq.com')) {
-      if (opts.groqStatus && opts.groqStatus !== 200) {
-        return new Response('groq down', { status: opts.groqStatus });
-      }
       return new Response(JSON.stringify({
         choices: [{ message: { content: 'groq answer' } }],
-        model: 'llama-3.1-8b-instant',
+        model: 'llama-3.3-70b-versatile',
         usage: { prompt_tokens: 120, completion_tokens: 40, total_tokens: 160 },
       }), { status: 200 });
     }
     if (url.includes('openrouter.ai')) {
+      if (opts.openrouterStatus && opts.openrouterStatus !== 200) {
+        return new Response('openrouter down', { status: opts.openrouterStatus });
+      }
       return new Response(JSON.stringify({
         choices: [{ message: { content: 'openrouter answer' } }],
-        model: 'google/gemini-2.5-flash',
+        model: 'deepseek/deepseek-v4-flash',
         usage: { prompt_tokens: 130, completion_tokens: 55, total_tokens: 185 },
       }), { status: 200 });
     }
@@ -87,16 +87,16 @@ describe('llm usage telemetry', () => {
       stage: 'test-stage',
     });
 
-    assert.equal(result?.content, 'groq answer');
+    assert.equal(result?.content, 'openrouter answer');
     assert.equal(captured.events.length, 1, 'exactly one event for one attempt');
     const ev = captured.events[0];
     assert.equal(ev.event_type, 'llm_call');
-    assert.equal(ev.provider, 'groq');
+    assert.equal(ev.provider, 'openrouter');
     assert.equal(ev.stage, 'test-stage');
     assert.equal(ev.ok, true);
-    assert.equal(ev.tokens_total, 160);
-    assert.equal(ev.tokens_prompt, 120);
-    assert.equal(ev.tokens_completion, 40);
+    assert.equal(ev.tokens_total, 185);
+    assert.equal(ev.tokens_prompt, 130);
+    assert.equal(ev.tokens_completion, 55);
     assert.equal(ev.fallback_index, 0);
     assert.equal(typeof ev.duration_ms, 'number');
     assert.ok((ev.prompt_chars as number) > 0, 'prompt size must be recorded');
@@ -106,24 +106,24 @@ describe('llm usage telemetry', () => {
   it('records the failed attempt AND the fallback success', async () => {
     baseEnv();
     const captured: CapturedIngest = { events: [] };
-    installFetchMock({ groqStatus: 500, captured });
+    installFetchMock({ openrouterStatus: 500, captured });
 
     const result = await callLlm({
       messages: [{ role: 'user', content: 'user prompt' }],
       stage: 'test-stage',
     });
 
-    assert.equal(result?.content, 'openrouter answer');
+    assert.equal(result?.content, 'groq answer');
     assert.equal(captured.events.length, 2, 'failed attempt + fallback must both be visible');
     const [fail, ok] = captured.events;
-    assert.equal(fail.provider, 'groq');
+    assert.equal(fail.provider, 'openrouter');
     assert.equal(fail.ok, false);
     assert.equal(fail.reason, 'http_500');
     assert.equal(fail.fallback_index, 0);
-    assert.equal(ok.provider, 'openrouter');
+    assert.equal(ok.provider, 'groq');
     assert.equal(ok.ok, true);
     assert.equal(ok.fallback_index, 1);
-    assert.equal(ok.tokens_total, 185);
+    assert.equal(ok.tokens_total, 160);
   });
 
   it('emits nothing when USAGE_TELEMETRY is off', async () => {
@@ -137,7 +137,7 @@ describe('llm usage telemetry', () => {
       stage: 'test-stage',
     });
 
-    assert.equal(result?.content, 'groq answer');
+    assert.equal(result?.content, 'openrouter answer');
     assert.equal(captured.events.length, 0, 'telemetry must be opt-in');
   });
 

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1142,6 +1142,11 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
 
   const INTEL_TEST_ENV = {
     GROQ_API_KEY: 'test-key',
+    // The default chain is openrouter-first since #4944; clear these so the
+    // groq-only fetch mock deterministically sees groq as the first provider
+    // regardless of ambient shell env.
+    OPENROUTER_API_KEY: undefined,
+    OLLAMA_API_URL: undefined,
     UPSTASH_REDIS_REST_URL: 'https://redis.test',
     UPSTASH_REDIS_REST_TOKEN: 'token',
     VERCEL_ENV: undefined,
@@ -1176,7 +1181,7 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
 
       assert.equal(counters.groqCalls, 1, 'anon context variations must share one cache entry');
       assert.equal(setKeys.length, 1, 'one shared cache write');
-      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v4:IL:en:shared'), `anon key should use the shared v4 namespace, got ${setKeys[0]}`);
+      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v5:IL:en:shared'), `anon key should use the shared v5 namespace, got ${setKeys[0]}`);
       assert.equal(alpha.brief, 'brief-1');
       assert.equal(beta.brief, 'brief-1', 'second anon caller must be served from cache');
       assert.ok(!userPrompts[0]?.includes('alpha'), 'anon caller context must not reach the prompt');
@@ -1211,7 +1216,7 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
       assert.equal(counters.groqCalls, 2, 'different premium contexts should not share one cache entry');
       assert.equal(setKeys.length, 2, 'one cache write per unique premium context');
       assert.notEqual(setKeys[0], setKeys[1], 'context hash should differentiate premium cache keys');
-      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v4:IL:'), 'cache key should use the v4 country-intel namespace');
+      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v5:IL:'), 'cache key should use the v5 country-intel namespace');
       assert.ok(!setKeys[0]?.includes(':shared'), 'premium keys must not use the shared namespace');
       assert.equal(alpha.brief, 'brief-1');
       assert.equal(beta.brief, 'brief-2');
@@ -1229,6 +1234,10 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
     const { module, cleanup } = await importCountryIntelBrief();
     const restoreEnv = withEnv({
       GROQ_API_KEY: 'test-key',
+      // Deterministic groq-first for this groq-only mock (chain is
+      // openrouter-first since #4944).
+      OPENROUTER_API_KEY: undefined,
+      OLLAMA_API_URL: undefined,
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
       UPSTASH_REDIS_REST_TOKEN: 'token',
       VERCEL_ENV: undefined,
@@ -1272,7 +1281,7 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
 
       assert.equal(groqCalls, 1, 'blank context should reuse the shared cache entry');
       assert.equal(setKeys.length, 1);
-      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v4:US:en:shared'), `anon callers land on the shared key, got ${setKeys[0]}`);
+      assert.ok(setKeys[0]?.startsWith('ci-sebuf:v5:US:en:shared'), `anon callers land on the shared key, got ${setKeys[0]}`);
       assert.ok(!userPrompts[0]?.includes('Context snapshot:'), 'prompt should omit context block when digest grounding is unavailable');
       assert.equal(first.brief, 'base-brief');
       assert.equal(second.brief, 'base-brief');

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 describe('callLlm', () => {
-  it('preserves the default provider order', async () => {
+  it('preserves the default provider order (openrouter-first since #4944)', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'or-test-key';
     delete process.env.OLLAMA_API_URL;
@@ -38,6 +38,7 @@ describe('callLlm', () => {
     delete process.env.LLM_API_KEY;
 
     const postUrls: string[] = [];
+    const postBodies: Array<Record<string, unknown>> = [];
 
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
@@ -47,6 +48,7 @@ describe('callLlm', () => {
       }
 
       postUrls.push(url);
+      postBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
       if (url.includes('api.groq.com')) {
         return new Response(JSON.stringify({
           choices: [{ message: { content: 'groq response' } }],
@@ -65,11 +67,45 @@ describe('callLlm', () => {
     });
 
     assert.ok(result);
-    assert.equal(result.provider, 'groq');
-    assert.equal(result.model, 'llama-3.1-8b-instant');
+    assert.equal(result.provider, 'openrouter');
+    assert.equal(result.model, 'deepseek/deepseek-v4-flash');
     assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
-      'https://api.groq.com/openai/v1/chat/completions',
+      'https://openrouter.ai/api/v1/chat/completions',
     ]);
+    // Utility calls must not pay reasoning tokens on hybrid-reasoning models.
+    assert.deepEqual(postBodies[0]?.reasoning, { enabled: false });
+  });
+
+  it('omits the reasoning-off body when the reasoning profile opts in', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postBodies: Array<Record<string, unknown>> = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+      postBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'reasoning-tier response' } }],
+        usage: { total_tokens: 7 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Reason about the setup.' }],
+      enableReasoning: true,
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'openrouter');
+    assert.equal(postBodies.length, 1);
+    // Opt-in leaves the model's own reasoning default in effect.
+    assert.equal('reasoning' in (postBodies[0] ?? {}), false);
   });
 
   it('supports explicitly bypassing groq with a stronger model override', async () => {
@@ -118,6 +154,7 @@ describe('callLlm', () => {
     assert.equal(postBodies.length, 1);
     assert.equal(postBodies[0]?.url, 'https://openrouter.ai/api/v1/chat/completions');
     assert.equal(postBodies[0]?.body.model, 'google/gemini-2.5-pro');
+    assert.deepEqual(postBodies[0]?.body.reasoning, { enabled: false });
   });
 
   it('falls back within an explicit provider order when the upper model fails', async () => {
@@ -157,7 +194,7 @@ describe('callLlm', () => {
 
     assert.ok(result);
     assert.equal(result.provider, 'groq');
-    assert.equal(result.model, 'llama-3.1-8b-instant');
+    assert.equal(result.model, 'llama-3.3-70b-versatile');
     assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
       'https://openrouter.ai/api/v1/chat/completions',
       'https://api.groq.com/openai/v1/chat/completions',

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -108,6 +108,73 @@ describe('callLlm', () => {
     assert.equal('reasoning' in (postBodies[0] ?? {}), false);
   });
 
+  it('ignores DeepSeek reasoning message fields and serves content untouched', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+      // Live-captured DeepSeek V4 shape (2026-07-06): reasoning arrives as
+      // separate message fields, never inline tags; content stays clean.
+      return new Response(JSON.stringify({
+        choices: [{ message: {
+          role: 'assistant',
+          content: 'Paris',
+          reasoning: 'We need to reply with exactly one word.',
+          reasoning_details: [{ type: 'reasoning.text', text: 'We need to reply.' }],
+        } }],
+        usage: { total_tokens: 30, prompt_tokens: 14, completion_tokens: 16 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Capital of France, one word.' }],
+      enableReasoning: true,
+    });
+
+    assert.ok(result);
+    assert.equal(result.content, 'Paris');
+  });
+
+  it('falls through when a provider returns only reasoning with empty content', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+      if (url.includes('openrouter.ai')) {
+        // Degenerate case: model burned its budget on reasoning, empty content.
+        return new Response(JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: '', reasoning: 'endless deliberation…' } }],
+          usage: { total_tokens: 60, prompt_tokens: 14, completion_tokens: 46 },
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'groq fallback answer' } }],
+        usage: { total_tokens: 20 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Answer briefly.' }],
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'groq');
+    assert.equal(result.content, 'groq fallback answer');
+  });
+
   it('supports explicitly bypassing groq with a stronger model override', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'or-test-key';

--- a/tests/summarize-reasoning.test.mjs
+++ b/tests/summarize-reasoning.test.mjs
@@ -253,12 +253,11 @@ describe('Fix 3: hasReasoningPreamble', () => {
 describe('Fix 4: cache version bump', () => {
   const src = readSrc('src/utils/summary-cache-key.ts');
 
-  it('CACHE_VERSION is v7', () => {
-    // Bumped v6 → v7 on 2026-07-05 (#4914): identical (headline, body) pairs
-    // now dedup before the top-5 slice; v6 rows keyed over duplicate-bearing
-    // compositions must age out. (v5 → v6 on 2026-04-24 for the
-    // RSS-description grounding fix, U6.)
-    assert.match(src, /CACHE_VERSION\s*=\s*'v7'/,
-      'CACHE_VERSION must be v7 to retire pre-pair-dedup cached summaries');
+  it('CACHE_VERSION is v8', () => {
+    // Bumped v7 → v8 on 2026-07-06 (#4944): summarize chain moved to
+    // OpenRouter deepseek-v4-flash-first; v7 rows carry old-model voice and
+    // must age out. (v6 → v7 on 2026-07-05 for pair-dedup, #4914.)
+    assert.match(src, /CACHE_VERSION\s*=\s*'v8'/,
+      'CACHE_VERSION must be v8 to retire pre-DeepSeek cached summaries');
   });
 });

--- a/tests/summary-cache-key.test.mts
+++ b/tests/summary-cache-key.test.mts
@@ -31,9 +31,9 @@ describe('buildSummaryCacheKey', () => {
 
   it('systemAppend suffix does not break existing namespace', () => {
     const base = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en');
-    // v6 → v7 on 2026-07-05 (#4914 pair-dedup); v5 → v6 on 2026-04-24
-    // (RSS-description grounding fix, U6).
-    assert.match(base, /^summary:v7:/);
+    // v7 → v8 on 2026-07-06 (#4944 DeepSeek cutover); v6 → v7 on 2026-07-05
+    // (#4914 pair-dedup); v5 → v6 on 2026-04-24 (RSS grounding fix, U6).
+    assert.match(base, /^summary:v8:/);
     assert.doesNotMatch(base, /:fw/);
   });
 
@@ -86,7 +86,7 @@ describe('buildSummaryCacheKey', () => {
 
   it('bodies.length < headlines.length is padded (no crash)', () => {
     const k = buildSummaryCacheKey(HEADLINES, 'brief', 'US', 'full', 'en', undefined, ['only first']);
-    assert.ok(k.startsWith('summary:v7:brief:'));
+    assert.ok(k.startsWith('summary:v8:brief:'));
   });
 
   it('translate mode ignores bodies (no :b segment)', () => {


### PR DESCRIPTION
Implements U1 + U2 of the LLM stack migration plan (#4944, plan: `docs/plans/2026-07-06-001-feat-llm-stack-deepseek-migration-plan.md`).

## U1 — core chain migration (Layer A)
- `getProviderCredentials`: OpenRouter default → `deepseek/deepseek-v4-flash` with a **reasoning-off `extraBody`** (mirrors the Ollama `think:false` idiom); Groq default → `llama-3.3-70b-versatile`. Fixes the dead-config class from #4947 (env change below completes it).
- `PROVIDER_CHAIN` reorder: `ollama → openrouter → groq → generic` — core surfaces (classify-event, summarize-article, country-intel-brief, analyze-stock) come off Groq 8B; Groq stays as the free-tier/outage fallback; Ollama-first preserved for self-hosted.
- Reasoning opt-in plumbed through `callLlmReasoning` / `callLlmReasoningStream` (utility calls stay reasoning-off).
- **Model-swap cache bumps** (R9): summary `v7→v8`, `ci-sebuf v4→v5` (plan cited v3 — main had already moved to v4 in #4914-era churn), `market:analyze-stock v3→v4`. Sweep proof: `rg 'summary:v7|ci-sebuf:v4|analyze-stock:v3'` → only historical comments remain (the sweep caught one pin file the plan missed: `tests/summary-cache-key.test.mts`).
- `.env.example`: documents `LLM_TOOL_*` and `BRIEF_WHY_MATTERS_*`, fixes the stale reasoning-model example.

## U2 — DeepSeek output-shape hardening
Live multi-provider capture (2026-07-06): reasoning-off honored by every provider that responded (GMICloud / SiliconFlow / StreamLake / auto-routing → `reasoning_tokens: 0`, bare `role`+`content`); DeepInfra & Baidu were 429-rate-limited at probe time and auto-routing worked around them. Reasoning-on delivers `reasoning`/`reasoning_details` as **separate message fields, never inline tags** → parsers reading `message.content` inherently ignore it; no stripper extension needed. Two live-shaped fixture tests lock this in (reasoning fields ignored; reasoning-only/empty-content falls through to Groq).

Stripper topology (R7 verification): canonical strip = `server/_shared/llm.ts`; `deduction-prompt.ts` keeps a defensive subset post-pass (pure, import-free, own tests); seeder-local copies are by design (seeders don't import `server/_shared`) — those move in U6.

## Verification
- `test:data`: **13,420 pass / 0 fail** (6 pre-existing skips); `typecheck` + `typecheck:api` green.
- Live smoke through the new chain: routed `openrouter → deepseek/deepseek-v4-flash`, 49 tokens total, clean single-word output, no reasoning leakage.
- Post-deploy (deploy-time checklist): anon `/desktop` console 401/403 sweep; Axiom `llm_call` by stage/model; OpenRouter daily-usage envelope.

## Deploy notes
- Vercel env: `LLM_TOOL_MODEL=deepseek/deepseek-v4-flash` (replacing dead `x-ai/grok-4.1-fast`; `LLM_TOOL_PROVIDER` already `openrouter`) — binds on this PR's deploy.
- ⚠️ Ops gate before merge/deploy: **top up OpenRouter credits + enable auto-topup** (~$17 of 1260 remaining) per the plan's stop condition 3.
- Manual review/merge only (no auto-merge). U3 (reasoning-tier flip + brief shadow window) follows via env once this lands.

Refs #4944 (umbrella), #4947.

https://claude.ai/code/session_01Xs7LsyQQJqngcqjt5oGcpx