### PR TITLE
feat(telemetry): llm_call events for the telemetry-dark seeder transports (#4944 U5)

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -28,6 +28,9 @@ RUN npm ci --prefix scripts --omit=dev --omit=optional --ignore-scripts
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
 COPY scripts/_proxy-utils.cjs ./scripts/_proxy-utils.cjs
 COPY scripts/lib/usni-fleet-parser.cjs ./scripts/lib/usni-fleet-parser.cjs
+# llm-telemetry.cjs is transitively imported by _seed-utils.mjs (SIGTERM
+# telemetry flush, #4954) — missing it = silent startup crash in the image.
+COPY scripts/lib/llm-telemetry.cjs ./scripts/lib/llm-telemetry.cjs
 COPY scripts/shared/country-name-to-iso2.cjs ./scripts/shared/country-name-to-iso2.cjs
 COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
 # _seed-envelope-source.mjs and _seed-contract.mjs are transitively imported

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -6,6 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { flushPendingLlmEvents } from './lib/llm-telemetry.cjs';
 
 import { buildEnvelope, unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveRecordCount } from './_seed-contract.mjs';
@@ -1361,6 +1362,10 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     } catch (err) {
       console.error(`  [${domain}:${resource}] SIGTERM cleanup error: ${err?.message || err}`);
     } finally {
+      // process.exit does not drain in-flight promises — flush any
+      // fire-and-forget llm_call telemetry (bounded by its 1.5s fetch
+      // timeout; the runner's 5s SIGKILL grace leaves room).
+      try { await flushPendingLlmEvents(); } catch { /* never block exit */ }
       process.exit(143);
     }
   };

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -11,6 +11,15 @@ import { flushPendingLlmEvents } from './lib/llm-telemetry.cjs';
 import { buildEnvelope, unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveRecordCount } from './_seed-contract.mjs';
 
+// process.exit does not drain in-flight promises — drain any fire-and-forget
+// llm_call telemetry first (bounded by its 1.5s fetch timeout; a no-op when
+// nothing is pending). Used by every runSeed exit reachable after fetchFn,
+// where seeder LLM calls may have emitted events (#4954 review).
+async function exitAfterTelemetryFlush(code) {
+  try { await flushPendingLlmEvents(); } catch { /* never block exit */ }
+  process.exit(code);
+}
+
 const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36';
 const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024; // 5MB per key
 
@@ -1405,7 +1414,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     await extendExistingTtl(keys, ttl);
 
     console.log(`\n=== Failed gracefully (${Math.round(durationMs)}ms) ===`);
-    process.exit(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+    await exitAfterTelemetryFlush(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
   }
   // Transition to publish phase — handler stays installed but switches
   // behavior via the phase tracker.
@@ -1454,7 +1463,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         // Contract violation — declareRecords returned non-int / threw. HARD FAIL.
         await releaseLock(`${domain}:${resource}`, runId);
         console.error(`  CONTRACT VIOLATION: ${err.message || err}`);
-        process.exit(1);
+        await exitAfterTelemetryFlush(1);
       }
       if (contractRecordCount > 0) {
         contractState = 'OK';
@@ -1493,7 +1502,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       console.log(`  RETRY: declareRecords returned 0 (zeroIsValid=false) — envelope unchanged, TTL extended, bundle will retry next cycle`);
       console.log(`\n=== Done (${Math.round(durationMs)}ms, RETRY) ===`);
       await releaseLock(`${domain}:${resource}`, runId);
-      process.exit(0);
+      await exitAfterTelemetryFlush(0);
     }
 
     const publishResult = await atomicPublish(canonicalKey, publishData, validateFn, ttlSeconds, { envelopeMeta });
@@ -1561,7 +1570,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       await releaseLock(`${domain}:${resource}`, runId);
       // Strict path exits non-zero so _bundle-runner counts it as failed++
       // (otherwise the bundle summary hides upstream outages behind ran++).
-      process.exit(strictFailure ? 1 : 0);
+      await exitAfterTelemetryFlush(strictFailure ? 1 : 0);
     }
     const { payloadBytes } = publishResult;
     const topicArticleCount = Array.isArray(data?.topics)
@@ -1597,7 +1606,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           } catch (err) {
             await releaseLock(`${domain}:${resource}`, runId);
             console.error(`  CONTRACT VIOLATION on extraKey ${ek.key}: ${err.message || err}`);
-            process.exit(1);
+            await exitAfterTelemetryFlush(1);
           }
           // Opt-in skip-empty: don't overwrite a good cached extra-key payload
           // with a recordCount=0 write on a partial fetch (e.g. a token panel
@@ -1671,7 +1680,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
 
     console.log(`\n=== Done (${Math.round(durationMs)}ms) ===`);
     await releaseLock(`${domain}:${resource}`, runId);
-    process.exit(0);
+    await exitAfterTelemetryFlush(0);
   } catch (err) {
     await releaseLock(`${domain}:${resource}`, runId);
     throw err;

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -216,6 +216,7 @@ export async function generateWhyMatters(story, deps) {
       temperature: 0.4,
       timeoutMs: 10_000,
       skipProviders: BRIEF_LLM_SKIP_PROVIDERS,
+      stage: 'brief-whymatters-cron',
     });
   } catch {
     return null;
@@ -347,6 +348,7 @@ export async function generateStoryDescription(story, deps) {
       temperature: 0.4,
       timeoutMs: 10_000,
       skipProviders: BRIEF_LLM_SKIP_PROVIDERS,
+      stage: 'brief-description-cron',
     });
   } catch {
     return null;
@@ -758,6 +760,7 @@ export async function generateDigestProse(userId, stories, sensitivity, deps, ct
       temperature: 0.4,
       timeoutMs: 15_000,
       skipProviders: BRIEF_LLM_SKIP_PROVIDERS,
+      stage: 'brief-digest-cron',
     });
   } catch (err) {
     // LLM-side failure (timeout, provider down, network). Distinct

--- a/scripts/lib/llm-chain.cjs
+++ b/scripts/lib/llm-chain.cjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const { buildLlmCallEvent, emitLlmEvents } = require('./llm-telemetry.cjs');
+
 const SERVICE_UA = 'worldmonitor-llm/1.0';
 
 const TASK_NARRATION = /^(we need to|i need to|let me|i'll |i should|i will |the task is|the instructions|according to the rules|so we need to|okay[,.]\s*(i'll|let me|so|we need|the task|i should|i will)|sure[,.]\s*(i'll|let me|so|we need|the task|i should|i will|here)|first[, ]+(i|we|let)|to summarize (the headlines|the task|this)|my task (is|was|:)|step \d)/i;
@@ -57,11 +59,16 @@ const LLM_PROVIDERS = [
  * @param {number} [opts.maxTokens=500]
  * @param {number} [opts.temperature=0.3]
  * @param {number} [opts.timeoutMs] - Override per-provider timeout
+ * @param {string} [opts.stage] - llm_call telemetry surface tag (#4944 U5)
  * @returns {Promise<string|null>} Generated text, or null if all providers fail
  */
 async function callLLM(systemPrompt, userPrompt, opts = {}) {
-  const { maxTokens = 500, temperature = 0.3, timeoutMs, skipProviders } = opts;
+  const { maxTokens = 500, temperature = 0.3, timeoutMs, skipProviders, stage = 'llm-chain' } = opts;
   const skipSet = skipProviders ? new Set(skipProviders) : null;
+
+  const promptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
+  const events = [];
+  let attemptIndex = 0;
 
   for (const provider of LLM_PROVIDERS) {
     if (skipSet?.has(provider.name)) continue;
@@ -71,6 +78,18 @@ async function callLLM(systemPrompt, userPrompt, opts = {}) {
     const apiUrl = provider.apiUrlFn ? provider.apiUrlFn(envVal) : provider.apiUrl;
     const model = typeof provider.model === 'function' ? provider.model() : provider.model;
     const timeout = timeoutMs ?? provider.timeout;
+
+    // Skipped/unconfigured providers never sent the prompt — only real
+    // attempts get an event and advance the fallback index.
+    const t0 = Date.now();
+    const record = (ok, extra = {}) => {
+      events.push(buildLlmCallEvent({
+        provider: provider.name, model, stage, ok,
+        durationMs: Date.now() - t0, promptChars, maxTokens,
+        fallbackIndex: attemptIndex++,
+        ...extra,
+      }));
+    };
 
     try {
       const resp = await fetch(apiUrl, {
@@ -91,25 +110,36 @@ async function callLLM(systemPrompt, userPrompt, opts = {}) {
 
       if (!resp.ok) {
         console.warn(`[llm-chain] ${provider.name} API error: ${resp.status}`);
+        record(false, { reason: `http_${resp.status}` });
         continue;
       }
 
       const json = await resp.json();
+      const usage = {
+        tokensTotal: json.usage?.total_tokens ?? 0,
+        tokensPrompt: json.usage?.prompt_tokens ?? 0,
+        tokensCompletion: json.usage?.completion_tokens ?? 0,
+      };
       const rawText = json.choices?.[0]?.message?.content?.trim();
       if (!rawText) {
         console.warn(`[llm-chain] ${provider.name}: empty response`);
+        record(false, { ...usage, reason: 'empty' });
         continue;
       }
 
       const text = stripReasoningPreamble(rawText);
       console.log(`[llm-chain] ${provider.name} OK (${text.length} chars)`);
+      record(true, usage);
+      await emitLlmEvents(events);
       return text;
     } catch (err) {
       console.warn(`[llm-chain] ${provider.name} failed: ${err.message}`);
+      record(false, { reason: err?.name === 'TimeoutError' || err?.name === 'AbortError' ? 'timeout' : 'fetch_error' });
     }
   }
 
   console.warn('[llm-chain] all providers failed');
+  await emitLlmEvents(events);
   return null;
 }
 

--- a/scripts/lib/llm-chain.cjs
+++ b/scripts/lib/llm-chain.cjs
@@ -130,7 +130,7 @@ async function callLLM(systemPrompt, userPrompt, opts = {}) {
       const text = stripReasoningPreamble(rawText);
       console.log(`[llm-chain] ${provider.name} OK (${text.length} chars)`);
       record(true, usage);
-      await emitLlmEvents(events);
+      void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
       return text;
     } catch (err) {
       console.warn(`[llm-chain] ${provider.name} failed: ${err.message}`);
@@ -139,7 +139,7 @@ async function callLLM(systemPrompt, userPrompt, opts = {}) {
   }
 
   console.warn('[llm-chain] all providers failed');
-  await emitLlmEvents(events);
+  void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
   return null;
 }
 

--- a/scripts/lib/llm-telemetry.cjs
+++ b/scripts/lib/llm-telemetry.cjs
@@ -40,31 +40,52 @@ function buildLlmCallEvent(p) {
   };
 }
 
+// In-flight deliveries. Fire-and-forget callers race explicit
+// process.exit() paths (which do NOT drain pending promises) —
+// flushPendingLlmEvents() lets exit sites drain within the fetch timeout.
+const pendingDeliveries = new Set();
+
 /**
  * Deliver events to the wm_api_usage dataset. No-op unless USAGE_TELEMETRY=1
  * and AXIOM_API_TOKEN are set. Never throws.
  *
  * Callers fire-and-forget (`void emitLlmEvents(events)`) so telemetry never
- * adds latency to the LLM return path. Safe in Node seeders: a pending fetch
- * keeps the event loop alive, and the 1.5s timeout bounds any exit delay.
+ * adds latency to the LLM return path. Seeders that exit explicitly must
+ * `await flushPendingLlmEvents()` before process.exit() or in-flight POSTs
+ * are dropped.
  * @param {Array<Record<string, unknown>>} events
  */
-async function emitLlmEvents(events) {
-  if (process.env.USAGE_TELEMETRY !== '1' || !Array.isArray(events) || events.length === 0) return;
+function emitLlmEvents(events) {
+  if (process.env.USAGE_TELEMETRY !== '1' || !Array.isArray(events) || events.length === 0) return Promise.resolve();
   const token = process.env.AXIOM_API_TOKEN;
-  if (!token) return;
-  try {
-    await fetch(AXIOM_WM_API_USAGE_INGEST_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'User-Agent': 'worldmonitor-seeder-telemetry/1.0',
-      },
-      body: JSON.stringify(events),
-      signal: AbortSignal.timeout(1_500),
-    });
-  } catch { /* telemetry must never affect the seed */ }
+  if (!token) return Promise.resolve();
+  const delivery = (async () => {
+    try {
+      await fetch(AXIOM_WM_API_USAGE_INGEST_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'worldmonitor-seeder-telemetry/1.0',
+        },
+        body: JSON.stringify(events),
+        signal: AbortSignal.timeout(1_500),
+      });
+    } catch { /* telemetry must never affect the seed */ }
+  })();
+  pendingDeliveries.add(delivery);
+  delivery.finally(() => pendingDeliveries.delete(delivery));
+  return delivery;
 }
 
-module.exports = { buildLlmCallEvent, emitLlmEvents, AXIOM_WM_API_USAGE_INGEST_URL };
+/**
+ * Bounded drain of in-flight telemetry POSTs — call before explicit
+ * process.exit(). Each delivery is capped by its own 1.5s fetch timeout and
+ * swallows errors, so this resolves quickly and never throws.
+ */
+async function flushPendingLlmEvents() {
+  if (pendingDeliveries.size === 0) return;
+  await Promise.allSettled([...pendingDeliveries]);
+}
+
+module.exports = { buildLlmCallEvent, emitLlmEvents, flushPendingLlmEvents, AXIOM_WM_API_USAGE_INGEST_URL };

--- a/scripts/lib/llm-telemetry.cjs
+++ b/scripts/lib/llm-telemetry.cjs
@@ -1,0 +1,62 @@
+'use strict';
+
+// Seeder-side llm_call telemetry shared helper (#4944 U5, refs #4948).
+//
+// Mirrors server/_shared/usage.ts LlmCallEvent field-for-field (and
+// seed-forecasts.mjs's local emitter, #4895/post-#4901) so seeder events
+// unify with the Vercel-side stream in one wm_api_usage APL query. Gated on
+// USAGE_TELEMETRY=1 + AXIOM_API_TOKEN. Best-effort: one bounded POST per
+// logical call, never throws, never fails a seed.
+//
+// CommonJS on purpose: consumed by both CJS (scripts/lib/llm-chain.cjs) and
+// ESM (seed-insights, regional-snapshot/*) — Node ESM imports CJS natively;
+// the reverse needs dynamic import.
+
+const AXIOM_WM_API_USAGE_INGEST_URL = 'https://api.axiom.co/v1/datasets/wm_api_usage/ingest';
+
+/**
+ * Build one llm_call event for a single provider attempt.
+ * @param {{ provider: string, model: string, stage: string, ok: boolean,
+ *   durationMs: number, tokensTotal?: number, tokensPrompt?: number,
+ *   tokensCompletion?: number, promptChars?: number, maxTokens?: number,
+ *   fallbackIndex?: number, reason?: string }} p
+ */
+function buildLlmCallEvent(p) {
+  return {
+    _time: new Date().toISOString(),
+    event_type: 'llm_call',
+    provider: p.provider,
+    model: p.model,
+    stage: p.stage,
+    ok: p.ok,
+    duration_ms: Math.round(p.durationMs || 0),
+    tokens_total: p.tokensTotal ?? 0,
+    tokens_prompt: p.tokensPrompt ?? 0,
+    tokens_completion: p.tokensCompletion ?? 0,
+    prompt_chars: p.promptChars ?? 0,
+    max_tokens: p.maxTokens ?? 0,
+    fallback_index: p.fallbackIndex ?? 0,
+    reason: p.reason || '',
+  };
+}
+
+/**
+ * Deliver events to the wm_api_usage dataset. No-op unless USAGE_TELEMETRY=1
+ * and AXIOM_API_TOKEN are set. Never throws.
+ * @param {Array<Record<string, unknown>>} events
+ */
+async function emitLlmEvents(events) {
+  if (process.env.USAGE_TELEMETRY !== '1' || !Array.isArray(events) || events.length === 0) return;
+  const token = process.env.AXIOM_API_TOKEN;
+  if (!token) return;
+  try {
+    await fetch(AXIOM_WM_API_USAGE_INGEST_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(events),
+      signal: AbortSignal.timeout(1_500),
+    });
+  } catch { /* telemetry must never affect the seed */ }
+}
+
+module.exports = { buildLlmCallEvent, emitLlmEvents, AXIOM_WM_API_USAGE_INGEST_URL };

--- a/scripts/lib/llm-telemetry.cjs
+++ b/scripts/lib/llm-telemetry.cjs
@@ -43,6 +43,10 @@ function buildLlmCallEvent(p) {
 /**
  * Deliver events to the wm_api_usage dataset. No-op unless USAGE_TELEMETRY=1
  * and AXIOM_API_TOKEN are set. Never throws.
+ *
+ * Callers fire-and-forget (`void emitLlmEvents(events)`) so telemetry never
+ * adds latency to the LLM return path. Safe in Node seeders: a pending fetch
+ * keeps the event loop alive, and the 1.5s timeout bounds any exit delay.
  * @param {Array<Record<string, unknown>>} events
  */
 async function emitLlmEvents(events) {
@@ -52,7 +56,11 @@ async function emitLlmEvents(events) {
   try {
     await fetch(AXIOM_WM_API_USAGE_INGEST_URL, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-seeder-telemetry/1.0',
+      },
       body: JSON.stringify(events),
       signal: AbortSignal.timeout(1_500),
     });

--- a/scripts/regional-snapshot/narrative.mjs
+++ b/scripts/regional-snapshot/narrative.mjs
@@ -24,6 +24,7 @@ import { createHash } from 'node:crypto';
 
 import { extractFirstJsonObject, cleanJsonText } from '../_llm-json.mjs';
 import { withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError } from '../_seed-utils.mjs';
+import { buildLlmCallEvent, emitLlmEvents } from '../lib/llm-telemetry.cjs';
 
 const CHROME_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
@@ -320,9 +321,25 @@ export async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
   const budgetStartedAtMs = Date.now();
   const usableBudgetMs = () => Math.max(0, budgetStartedAtMs + callBudgetMs - Date.now() - NARRATIVE_LLM_CALL_BUDGET_GUARD_MS);
 
+  // llm_call telemetry (#4944 U5): one event per provider OUTCOME (the
+  // withRetry duration covers in-provider retries), unified with the
+  // Vercel-side stream via scripts/lib/llm-telemetry.cjs.
+  const promptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
+  const events = [];
+  let attemptIndex = 0;
+
   for (const provider of DEFAULT_PROVIDERS) {
     const envVal = process.env[provider.envKey];
     if (!envVal) continue;
+    const t0 = Date.now();
+    const record = (ok, extra = {}) => {
+      events.push(buildLlmCallEvent({
+        provider: provider.name, model: provider.model, stage: 'regional-narrative', ok,
+        durationMs: Date.now() - t0, promptChars, maxTokens: NARRATIVE_MAX_TOKENS,
+        fallbackIndex: attemptIndex++,
+        ...extra,
+      }));
+    };
     try {
       const resp = await withRetry(async () => {
         const usable = usableBudgetMs();
@@ -349,15 +366,22 @@ export async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
       }, NARRATIVE_LLM_MAX_RETRIES, retryDelayMs);
 
       const json = /** @type {any} */ (await resp.json());
+      const usage = {
+        tokensTotal: json?.usage?.total_tokens ?? 0,
+        tokensPrompt: json?.usage?.prompt_tokens ?? 0,
+        tokensCompletion: json?.usage?.completion_tokens ?? 0,
+      };
       const text = json?.choices?.[0]?.message?.content;
       if (typeof text !== 'string' || text.trim().length === 0) {
         console.warn(`[narrative] ${provider.name}: empty response`);
+        record(false, { ...usage, reason: 'empty' });
         continue;
       }
 
       const trimmed = text.trim();
       if (validate && !validate(trimmed)) {
         console.warn(`[narrative] ${provider.name}: response failed validation, trying next provider`);
+        record(false, { ...usage, reason: 'validate_reject' });
         continue;
       }
 
@@ -366,14 +390,27 @@ export async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
         ? json.model
         : provider.model;
 
+      record(true, { ...usage, model: actualModel });
+      await emitLlmEvents(events);
       return { text: trimmed, provider: provider.name, model: actualModel };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[narrative] ${provider.name}: ${msg}`);
+      const httpMatch = /HTTP (\d{3})/.exec(msg);
+      record(false, {
+        reason: isLlmBudgetError(err) ? 'budget_exhausted'
+          : err?.name === 'TimeoutError' || err?.name === 'AbortError' ? 'timeout'
+          : httpMatch ? `http_${httpMatch[1]}`
+          : 'fetch_error',
+      });
       // Budget spent — give up rather than burning the next provider's timeout.
-      if (isLlmBudgetError(err)) return null;
+      if (isLlmBudgetError(err)) {
+        await emitLlmEvents(events);
+        return null;
+      }
     }
   }
+  await emitLlmEvents(events);
   return null;
 }
 

--- a/scripts/regional-snapshot/narrative.mjs
+++ b/scripts/regional-snapshot/narrative.mjs
@@ -391,7 +391,7 @@ export async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
         : provider.model;
 
       record(true, { ...usage, model: actualModel });
-      await emitLlmEvents(events);
+      void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
       return { text: trimmed, provider: provider.name, model: actualModel };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -405,12 +405,12 @@ export async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
       });
       // Budget spent — give up rather than burning the next provider's timeout.
       if (isLlmBudgetError(err)) {
-        await emitLlmEvents(events);
+        void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
         return null;
       }
     }
   }
-  await emitLlmEvents(events);
+  void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
   return null;
 }
 

--- a/scripts/regional-snapshot/weekly-brief.mjs
+++ b/scripts/regional-snapshot/weekly-brief.mjs
@@ -273,7 +273,7 @@ async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
         ? json.model
         : provider.model;
       record(true, { ...usage, model: actualModel });
-      await emitLlmEvents(events);
+      void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
       return { text: trimmed, provider: provider.name, model: actualModel };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -281,7 +281,7 @@ async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
       record(false, { reason: err?.name === 'TimeoutError' || err?.name === 'AbortError' ? 'timeout' : 'fetch_error' });
     }
   }
-  await emitLlmEvents(events);
+  void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
   return null;
 }
 

--- a/scripts/regional-snapshot/weekly-brief.mjs
+++ b/scripts/regional-snapshot/weekly-brief.mjs
@@ -13,6 +13,7 @@
 // Same provider chain + injectable-callLlm pattern as narrative.mjs.
 
 import { extractFirstJsonObject, cleanJsonText } from '../_llm-json.mjs';
+import { buildLlmCallEvent, emitLlmEvents } from '../lib/llm-telemetry.cjs';
 
 const CHROME_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
@@ -212,9 +213,23 @@ export function parseBriefJson(text) {
  */
 async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
   const validate = opts.validate;
+  // llm_call telemetry (#4944 U5): one event per provider attempt, unified
+  // with the Vercel-side stream via scripts/lib/llm-telemetry.cjs.
+  const promptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
+  const events = [];
+  let attemptIndex = 0;
   for (const provider of DEFAULT_PROVIDERS) {
     const envVal = process.env[provider.envKey];
     if (!envVal) continue;
+    const t0 = Date.now();
+    const record = (ok, extra = {}) => {
+      events.push(buildLlmCallEvent({
+        provider: provider.name, model: provider.model, stage: 'regional-weekly-brief', ok,
+        durationMs: Date.now() - t0, promptChars, maxTokens: BRIEF_MAX_TOKENS,
+        fallbackIndex: attemptIndex++,
+        ...extra,
+      }));
+    };
     try {
       const resp = await fetch(provider.apiUrl, {
         method: 'POST',
@@ -233,28 +248,40 @@ async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
       });
       if (!resp.ok) {
         console.warn(`[weekly-brief] ${provider.name}: HTTP ${resp.status}`);
+        record(false, { reason: `http_${resp.status}` });
         continue;
       }
       const json = /** @type {any} */ (await resp.json());
+      const usage = {
+        tokensTotal: json?.usage?.total_tokens ?? 0,
+        tokensPrompt: json?.usage?.prompt_tokens ?? 0,
+        tokensCompletion: json?.usage?.completion_tokens ?? 0,
+      };
       const text = json?.choices?.[0]?.message?.content;
       if (typeof text !== 'string' || text.trim().length === 0) {
         console.warn(`[weekly-brief] ${provider.name}: empty response`);
+        record(false, { ...usage, reason: 'empty' });
         continue;
       }
       const trimmed = text.trim();
       if (validate && !validate(trimmed)) {
         console.warn(`[weekly-brief] ${provider.name}: response failed validation, trying next`);
+        record(false, { ...usage, reason: 'validate_reject' });
         continue;
       }
       const actualModel = typeof json?.model === 'string' && json.model.length > 0
         ? json.model
         : provider.model;
+      record(true, { ...usage, model: actualModel });
+      await emitLlmEvents(events);
       return { text: trimmed, provider: provider.name, model: actualModel };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[weekly-brief] ${provider.name}: ${msg}`);
+      record(false, { reason: err?.name === 'TimeoutError' || err?.name === 'AbortError' ? 'timeout' : 'fetch_error' });
     }
   }
+  await emitLlmEvents(events);
   return null;
 }
 

--- a/scripts/seed-bundle-regional.mjs
+++ b/scripts/seed-bundle-regional.mjs
@@ -30,6 +30,7 @@ import { loadEnvFile, getRedisCredentials } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { main as runSnapshots } from './seed-regional-snapshots.mjs';
 import { main as runBriefs } from './seed-regional-briefs.mjs';
+import { flushPendingLlmEvents } from './lib/llm-telemetry.cjs';
 
 loadEnvFile(import.meta.url);
 
@@ -174,6 +175,9 @@ async function main() {
   // detect broken runs. PR #3001 review H1.
   if (snapshotFailed) {
     console.error(`[bundle] Done in ${elapsed}s with ERRORS`);
+    // process.exit does not drain in-flight promises — flush fire-and-forget
+    // llm_call telemetry first (bounded by the 1.5s fetch timeout).
+    await flushPendingLlmEvents();
     process.exit(1);
   }
   console.log(`[bundle] Done in ${elapsed}s`);
@@ -181,8 +185,9 @@ async function main() {
 
 const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
-  main().catch((err) => {
+  main().catch(async (err) => {
     console.error('[bundle] Fatal:', err);
+    await flushPendingLlmEvents();
     process.exit(1);
   });
 }

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -32,6 +32,7 @@ const {
   postJsonWithPinnedAddress,
 } = require('./lib/notification-webhook-ssrf.cjs');
 const { callLLM } = require('./lib/llm-chain.cjs');
+const { flushPendingLlmEvents } = require('./lib/llm-telemetry.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { fetchFollowedCountries } = require('./lib/followed-countries-fetch.cjs');
 const { Resend } = require('resend');
@@ -3056,6 +3057,9 @@ async function main() {
       sentCount,
       errorReason: `brief_compose_failed:${composeFailed}:success:${composeSuccess}`,
     });
+    // process.exit does not drain in-flight promises — flush fire-and-forget
+    // llm_call telemetry first (bounded by the 1.5s fetch timeout).
+    await flushPendingLlmEvents();
     process.exit(1);
   }
 
@@ -3071,5 +3075,6 @@ main().catch(async (err) => {
     status: 'error',
     errorReason: `fatal:${err?.message ?? err}`,
   });
+  await flushPendingLlmEvents();
   process.exit(1);
 });

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -18,6 +18,7 @@ import {
   synthesisUserPrompt,
   composeSynthesizedBrief,
 } from './_insights-brief.mjs';
+import { buildLlmCallEvent, emitLlmEvents } from './lib/llm-telemetry.cjs';
 // Import from the scripts mirror (`scripts/shared/`) — NOT the repo-root
 // `shared/`. Railway services with nixpacks `rootDirectory=scripts` only
 // package files under scripts/; a `../shared/` import resolves to
@@ -268,12 +269,28 @@ async function callLLM(headline, options = {}) {
   const budgetStartedAtMs = Date.now();
   const usableBudgetMs = () => Math.max(0, budgetStartedAtMs + callBudgetMs - Date.now() - INSIGHTS_LLM_CALL_BUDGET_GUARD_MS);
 
+  // llm_call telemetry (#4944 U5): one event per provider OUTCOME (the
+  // withRetry duration covers in-provider retries), unified with the
+  // Vercel-side stream via scripts/lib/llm-telemetry.cjs.
+  const promptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
+  const events = [];
+  let attemptIndex = 0;
+
   for (const provider of LLM_PROVIDERS) {
     const envVal = process.env[provider.envKey];
     if (!envVal) continue;
 
     const apiUrl = provider.apiUrlFn ? provider.apiUrlFn(envVal) : provider.apiUrl;
     const model = typeof provider.model === 'function' ? provider.model() : provider.model;
+    const t0 = Date.now();
+    const record = (ok, extra = {}) => {
+      events.push(buildLlmCallEvent({
+        provider: provider.name, model, stage: 'seed-insights', ok,
+        durationMs: Date.now() - t0, promptChars, maxTokens: 300,
+        fallbackIndex: attemptIndex++,
+        ...extra,
+      }));
+    };
 
     try {
       const resp = await withRetry(async () => {
@@ -301,9 +318,15 @@ async function callLLM(headline, options = {}) {
       }, INSIGHTS_LLM_MAX_RETRIES, retryDelayMs);
 
       const json = await resp.json();
+      const usage = {
+        tokensTotal: json.usage?.total_tokens ?? 0,
+        tokensPrompt: json.usage?.prompt_tokens ?? 0,
+        tokensCompletion: json.usage?.completion_tokens ?? 0,
+      };
       const rawText = json.choices?.[0]?.message?.content?.trim();
       if (!rawText) {
         console.warn(`  ${provider.name}: empty response`);
+        record(false, { ...usage, reason: 'empty' });
         continue;
       }
 
@@ -315,17 +338,31 @@ async function callLLM(headline, options = {}) {
 
       if (text.length < 20) {
         console.warn(`  ${provider.name}: output too short (${text.length} chars)`);
+        record(false, { ...usage, reason: 'too_short' });
         continue;
       }
 
+      record(true, { ...usage, model: json.model || model });
+      await emitLlmEvents(events);
       return { text, model: json.model || model, provider: provider.name };
     } catch (err) {
       console.warn(`  ${provider.name} failed: ${err.message}`);
+      const httpMatch = /HTTP (\d{3})/.exec(err.message || '');
+      record(false, {
+        reason: isLlmBudgetError(err) ? 'budget_exhausted'
+          : err?.name === 'TimeoutError' || err?.name === 'AbortError' ? 'timeout'
+          : httpMatch ? `http_${httpMatch[1]}`
+          : 'fetch_error',
+      });
       // Budget spent — give up rather than burning the next provider's timeout.
-      if (isLlmBudgetError(err)) return null;
+      if (isLlmBudgetError(err)) {
+        await emitLlmEvents(events);
+        return null;
+      }
     }
   }
 
+  await emitLlmEvents(events);
   return null;
 }
 

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -343,7 +343,7 @@ async function callLLM(headline, options = {}) {
       }
 
       record(true, { ...usage, model: json.model || model });
-      await emitLlmEvents(events);
+      void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
       return { text, model: json.model || model, provider: provider.name };
     } catch (err) {
       console.warn(`  ${provider.name} failed: ${err.message}`);
@@ -356,13 +356,13 @@ async function callLLM(headline, options = {}) {
       });
       // Budget spent — give up rather than burning the next provider's timeout.
       if (isLlmBudgetError(err)) {
-        await emitLlmEvents(events);
+        void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
         return null;
       }
     }
   }
 
-  await emitLlmEvents(events);
+  void emitLlmEvents(events); // fire-and-forget: telemetry never delays the return path
   return null;
 }
 

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -18,7 +18,7 @@ import {
   synthesisUserPrompt,
   composeSynthesizedBrief,
 } from './_insights-brief.mjs';
-import { buildLlmCallEvent, emitLlmEvents } from './lib/llm-telemetry.cjs';
+import { buildLlmCallEvent, emitLlmEvents, flushPendingLlmEvents } from './lib/llm-telemetry.cjs';
 // Import from the scripts mirror (`scripts/shared/`) — NOT the repo-root
 // `shared/`. Railway services with nixpacks `rootDirectory=scripts` only
 // package files under scripts/; a `../shared/` import resolves to
@@ -682,9 +682,12 @@ if (_isDirectRun) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 30,
-  }).catch((err) => {
+  }).catch(async (err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-    // Exit gracefully for cron — health endpoint flags stale data via seed-meta.
+    // Exit gracefully for cron — health endpoint flags stale data via
+    // seed-meta. process.exit does not drain in-flight promises — flush
+    // llm_call telemetry first (bounded by the 1.5s fetch timeout).
+    await flushPendingLlmEvents();
     process.exit(0);
   });
 }

--- a/tests/seeder-llm-telemetry.test.mjs
+++ b/tests/seeder-llm-telemetry.test.mjs
@@ -10,7 +10,7 @@
 import assert from 'node:assert/strict';
 import { test, afterEach } from 'node:test';
 
-import { buildLlmCallEvent } from '../scripts/lib/llm-telemetry.cjs';
+import { buildLlmCallEvent, emitLlmEvents, flushPendingLlmEvents } from '../scripts/lib/llm-telemetry.cjs';
 import { callLLM } from '../scripts/lib/llm-chain.cjs';
 import { callLlmDefault as callNarrativeLlm, __setNarrativeTransportForTests } from '../scripts/regional-snapshot/narrative.mjs';
 
@@ -105,6 +105,30 @@ test('llm-chain: emits nothing when USAGE_TELEMETRY is off', async () => {
   const text = await callLLM('system', 'user prompt', {});
   assert.equal(text, 'answer text here');
   assert.equal(captured.length, 0, 'telemetry must stay opt-in');
+});
+
+test('flushPendingLlmEvents drains in-flight deliveries before an explicit exit', async () => {
+  baseEnv();
+  let delivered = false;
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  global.fetch = async (url) => {
+    if (String(url).includes('api.axiom.co')) {
+      await gate;
+      delivered = true;
+      return { ok: true, json: async () => ({}) };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  // Fire-and-forget (what the transports do) — delivery is still in flight.
+  void emitLlmEvents([buildLlmCallEvent({ provider: 'openrouter', model: 'm', stage: 's', ok: true, durationMs: 1 })]);
+  assert.equal(delivered, false, 'delivery must still be pending');
+
+  const flush = flushPendingLlmEvents();
+  release();
+  await flush;
+  assert.equal(delivered, true, 'flush must drain the pending delivery');
 });
 
 test('llm-chain: a telemetry delivery failure never fails the call', async () => {

--- a/tests/seeder-llm-telemetry.test.mjs
+++ b/tests/seeder-llm-telemetry.test.mjs
@@ -1,0 +1,160 @@
+// Seeder-side llm_call telemetry parity (#4944 U5, refs #4948).
+//
+// seed-forecasts already emits per-attempt llm_call events; seed-insights,
+// the brief-llm injected chain (scripts/lib/llm-chain.cjs), and the
+// regional-snapshot narrative/weekly-brief transports were dark on cost.
+// They now emit the same events through scripts/lib/llm-telemetry.cjs,
+// gated on USAGE_TELEMETRY=1 + AXIOM_API_TOKEN, best-effort (a telemetry
+// failure must never fail the seed).
+
+import assert from 'node:assert/strict';
+import { test, afterEach } from 'node:test';
+
+import { buildLlmCallEvent } from '../scripts/lib/llm-telemetry.cjs';
+import { callLLM } from '../scripts/lib/llm-chain.cjs';
+import { callLlmDefault as callNarrativeLlm, __setNarrativeTransportForTests } from '../scripts/regional-snapshot/narrative.mjs';
+
+const ENV_KEYS = ['USAGE_TELEMETRY', 'AXIOM_API_TOKEN', 'GROQ_API_KEY', 'OPENROUTER_API_KEY', 'OLLAMA_API_URL'];
+const originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+const realFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = realFetch;
+  __setNarrativeTransportForTests(null);
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+});
+
+function baseEnv() {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  process.env.GROQ_API_KEY = 'groq-test';
+  process.env.OPENROUTER_API_KEY = 'or-test';
+  delete process.env.OLLAMA_API_URL;
+}
+
+function llmJson(content, usage = { total_tokens: 30, prompt_tokens: 20, completion_tokens: 10 }) {
+  return { choices: [{ message: { content } }], usage };
+}
+
+test('llm-telemetry: buildLlmCallEvent mirrors the LlmCallEvent field shape', () => {
+  const ev = buildLlmCallEvent({
+    provider: 'openrouter', model: 'm', stage: 's', ok: false,
+    durationMs: 12.6, tokensTotal: 3, tokensPrompt: 2, tokensCompletion: 1,
+    promptChars: 40, maxTokens: 500, fallbackIndex: 1, reason: 'http_500',
+  });
+  assert.equal(ev.event_type, 'llm_call');
+  assert.deepEqual(
+    Object.keys(ev).sort(),
+    ['_time', 'duration_ms', 'event_type', 'fallback_index', 'max_tokens', 'model', 'ok',
+      'prompt_chars', 'provider', 'reason', 'stage', 'tokens_completion', 'tokens_prompt', 'tokens_total'].sort(),
+  );
+  assert.equal(ev.duration_ms, 13);
+  assert.equal(ev.reason, 'http_500');
+});
+
+test('llm-chain: fallback emits one event per attempt with the caller stage', async () => {
+  baseEnv();
+  const captured = [];
+  global.fetch = async (url, init = {}) => {
+    const raw = String(url);
+    if (raw.includes('api.axiom.co')) {
+      captured.push(...JSON.parse(String(init.body || '[]')));
+      return { ok: true, json: async () => ({}) };
+    }
+    if (raw.includes('api.groq.com')) {
+      return { ok: false, status: 500, json: async () => ({}) };
+    }
+    if (raw.includes('openrouter.ai')) {
+      return { ok: true, json: async () => llmJson('brief prose output') };
+    }
+    throw new Error(`unexpected fetch: ${raw}`);
+  };
+
+  const text = await callLLM('system', 'user prompt', { stage: 'brief-digest-cron' });
+  assert.equal(text, 'brief prose output');
+  assert.equal(captured.length, 2, 'failed groq attempt + openrouter success');
+  const [fail, ok] = captured;
+  assert.equal(fail.provider, 'groq');
+  assert.equal(fail.ok, false);
+  assert.equal(fail.reason, 'http_500');
+  assert.equal(fail.fallback_index, 0);
+  assert.equal(fail.stage, 'brief-digest-cron');
+  assert.equal(ok.provider, 'openrouter');
+  assert.equal(ok.ok, true);
+  assert.equal(ok.fallback_index, 1);
+  assert.equal(ok.tokens_total, 30);
+  assert.ok(fail.prompt_chars > 0);
+});
+
+test('llm-chain: emits nothing when USAGE_TELEMETRY is off', async () => {
+  baseEnv();
+  delete process.env.USAGE_TELEMETRY;
+  const captured = [];
+  global.fetch = async (url, init = {}) => {
+    const raw = String(url);
+    if (raw.includes('api.axiom.co')) {
+      captured.push(...JSON.parse(String(init.body || '[]')));
+      return { ok: true, json: async () => ({}) };
+    }
+    return { ok: true, json: async () => llmJson('answer text here') };
+  };
+
+  const text = await callLLM('system', 'user prompt', {});
+  assert.equal(text, 'answer text here');
+  assert.equal(captured.length, 0, 'telemetry must stay opt-in');
+});
+
+test('llm-chain: a telemetry delivery failure never fails the call', async () => {
+  baseEnv();
+  global.fetch = async (url) => {
+    const raw = String(url);
+    if (raw.includes('api.axiom.co')) {
+      throw new Error('axiom down');
+    }
+    return { ok: true, json: async () => llmJson('resilient output text') };
+  };
+
+  const text = await callLLM('system', 'user prompt', { stage: 'brief-whymatters-cron' });
+  assert.equal(text, 'resilient output text', 'telemetry failure must not affect the result');
+});
+
+test('narrative: validate_reject and success attempts both reach the ingest', async () => {
+  baseEnv();
+  const captured = [];
+  global.fetch = async (url, init = {}) => {
+    const raw = String(url);
+    if (raw.includes('api.axiom.co')) {
+      captured.push(...JSON.parse(String(init.body || '[]')));
+      return { ok: true, json: async () => ({}) };
+    }
+    throw new Error(`unexpected global fetch: ${raw}`);
+  };
+  // Provider transport is injected: groq answers but fails validation,
+  // openrouter answers with the accepted payload.
+  __setNarrativeTransportForTests({
+    fetch: async (url) => {
+      const raw = String(url);
+      if (raw.includes('api.groq.com')) {
+        return { ok: true, json: async () => llmJson('not-json narrative') };
+      }
+      return { ok: true, json: async () => llmJson('{"ok":true}') };
+    },
+  });
+
+  const res = await callNarrativeLlm(
+    { systemPrompt: 'sys', userPrompt: 'user' },
+    { validate: (text) => text.startsWith('{') },
+  );
+  assert.ok(res);
+  assert.equal(res.provider, 'openrouter');
+  assert.equal(captured.length, 2);
+  assert.equal(captured[0].stage, 'regional-narrative');
+  assert.equal(captured[0].ok, false);
+  assert.equal(captured[0].reason, 'validate_reject');
+  assert.equal(captured[0].fallback_index, 0);
+  assert.equal(captured[1].ok, true);
+  assert.equal(captured[1].fallback_index, 1);
+});


### PR DESCRIPTION
Implements U5 of the LLM stack migration plan (#4944; closes #4948). **Must merge before the U6 seeder model cutover** so the migration is observable in Axiom.

## What
seed-forecasts already emits per-attempt `llm_call` events; three seeder transports were dark on LLM cost/failures. Now instrumented via a shared **`scripts/lib/llm-telemetry.cjs`** (field-for-field mirror of `server/_shared/usage.ts` `LlmCallEvent`, same `USAGE_TELEMETRY=1` + `AXIOM_API_TOKEN` gating, best-effort — never fails a seed):

| Transport | Stage tags |
|---|---|
| `scripts/lib/llm-chain.cjs` (brief-llm injected chain) | `brief-whymatters-cron` / `brief-description-cron` / `brief-digest-cron` (threaded through `brief-llm.mjs` opts; default `llm-chain`) |
| `scripts/seed-insights.mjs` | `seed-insights` |
| `scripts/regional-snapshot/narrative.mjs` | `regional-narrative` |
| `scripts/regional-snapshot/weekly-brief.mjs` | `regional-weekly-brief` |

Granularity: the flat llm-chain loop records one event per attempt; the `withRetry` transports (insights/narrative) record one event per provider outcome, with the retry window inside `duration_ms`.

## Packaging safety
- Helper is CJS so both CJS and ESM seeders import it; lives inside `scripts/` per the nixpacks `rootDirectory=scripts` rule.
- `Dockerfile.digest-notifications` copies `scripts/lib/` wholesale → ships automatically (`dockerfile-digest-notifications-imports` test green).

## Verification
- New `tests/seeder-llm-telemetry.test.mjs`: 5/5 (per-attempt fallback events with stages, opt-in gating, delivery-failure resilience, validate_reject visibility).
- Regression battery (insights/regional/brief-llm/dockerfile suites): 232/232.
- No model or provider-order changes in this PR — pure observability (models move in U6).

Refs #4944 (U5). Closes #4948. Manual review/merge only.

https://claude.ai/code/session_01Xs7LsyQQJqngcqjt5oGcpx