### PR TITLE
feat(agent-readiness): three-tier AI-crawler policy in robots.txt + real /agents.md (#4952)

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -55,6 +55,11 @@
           "href": "https://worldmonitor.app/support.md",
           "type": "text/markdown",
           "title": "Support channels & contact (machine-readable)"
+        },
+        {
+          "href": "https://worldmonitor.app/agents.md",
+          "type": "text/markdown",
+          "title": "Agent operations guide (surfaces, auth, crawl policy)"
         }
       ],
       "status": [

--- a/public/agents.md
+++ b/public/agents.md
@@ -1,0 +1,39 @@
+# World Monitor — Agent Guide
+
+> How AI agents should work with worldmonitor.app: machine surfaces, authentication, crawl policy, rate limits, and discovery endpoints. Prefer the structured surfaces below over scraping the HTML dashboard — the dashboard is a WebGL SPA and yields nothing useful to a text parser.
+
+World Monitor is a real-time global intelligence dashboard: 500+ news feeds, 56 map layer types, country risk/resilience scores, AI briefs, forecasts, and market/supply-chain correlation, served as machine-readable JSON with documented methodology and provenance.
+
+## Machine surfaces (use these)
+
+- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **REST API:** base `https://api.worldmonitor.app` — OpenAPI spec: https://worldmonitor.app/openapi.yaml (JSON: /openapi.json) · API catalog: https://worldmonitor.app/.well-known/api-catalog
+- **NLWeb:** `POST https://www.worldmonitor.app/ask` (supports SSE) for natural-language questions; machine-readable dashboard view at `https://www.worldmonitor.app/?mode=agent`
+- **Agent Skills:** discovery index at https://worldmonitor.app/.well-known/agent-skills/index.json · install via `npx skills add koala73/worldmonitor` (https://skills.sh/koala73/worldmonitor)
+- **CLI:** `npx worldmonitor tools` lists every tool (public, no key) — https://www.npmjs.com/package/worldmonitor
+- **SDKs:** Python `pip install worldmonitor-sdk` · Ruby `gem install worldmonitor` · Go `go get github.com/koala73/worldmonitor/sdk/go` · JavaScript npm `worldmonitor` — guide: https://www.worldmonitor.app/docs/sdks
+- **LLM briefings:** https://worldmonitor.app/llms.txt (overview) · https://worldmonitor.app/llms-full.txt (full reference) · https://worldmonitor.app/api/llms.txt (API section)
+
+## Authentication
+
+- **Anonymous** works for discovery endpoints, `tools/list`, and public data (world brief, product catalog, story pages).
+- **API key:** header `X-WorldMonitor-Key: wm_<40-hex>` for REST and MCP data calls — issue one at https://worldmonitor.app/pro. Full agent walkthrough: https://worldmonitor.app/auth.md
+- **OAuth2** for MCP (`scope=mcp`), with dynamic client registration at `/oauth/register`. Details in auth.md.
+
+## Crawl & content-usage policy
+
+- **robots.txt** (https://www.worldmonitor.app/robots.txt): AI search/assistant agents (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, DuckAssistBot, MistralAI-User) are explicitly allowed; bulk training-only scrapers (CCBot, Bytespider, anthropic-ai) are disallowed. `/api/` is off-limits to crawlers except the allowlisted story/OG/llms.txt/product-catalog routes.
+- **Content-Signal:** `ai-train=no, search=yes, ai-input=yes` — declared as a robots.txt group directive and as an origin-wide HTTP response header. Search indexing and assistant grounding/citation are welcome; bulk model training is opted out.
+- **User-Agent:** always send a descriptive `User-Agent` (e.g. `mytool/1.0 (+https://yoursite.example)`). Default HTTP-library UAs (`curl/*`, `python-requests/*`, empty strings) may get a 403 from the edge firewall — a 403 does NOT mean the endpoint is missing; retry with a real UA.
+
+## Rate limits & plans
+
+- Machine-readable pricing and plan limits: https://worldmonitor.app/pricing.md · live JSON catalog: `GET https://www.worldmonitor.app/api/product-catalog` (public, no key)
+- Rate-limit documentation: https://www.worldmonitor.app/docs/usage-rate-limits.md · auth matrix: https://www.worldmonitor.app/docs/usage-auth
+- Plan-limit responses include upgrade guidance; back off on 429 and honor `Retry-After`.
+
+## Support & escalation
+
+- https://worldmonitor.app/support.md — support@worldmonitor.app (general) · enterprise@worldmonitor.app (sales)
+- Status: https://status.worldmonitor.app · Issues: https://github.com/koala73/worldmonitor/issues
+- Source (AGPL-3.0): https://github.com/koala73/worldmonitor

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -135,6 +135,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 
 ## AI Agent Files
 
+- [agents.md](https://worldmonitor.app/agents.md): Agent operations guide — machine surfaces, auth, crawl policy, rate limits, and discovery endpoints
 - [llms.txt](https://worldmonitor.app/llms.txt): Short LLM-readable briefing
 - [llms-full.txt](https://worldmonitor.app/llms-full.txt): Full LLM-readable feature and data-source reference
 - [api/llms.txt](https://worldmonitor.app/api/llms.txt): API-section briefing — MCP server, REST API, CLI, auth, and per-task tool routing for the developer surface

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,14 @@
 # World Monitor - protect API routes from crawlers
+#
+# Three-tier AI crawler policy (#4952):
+#   1. `User-agent: *` — default rules + Content-Signal usage preferences.
+#   2. AI search/assistant agents — explicitly welcomed: they drive citations,
+#      grounding, and referral traffic (the point of the agent-readiness
+#      program). A named group REPLACES `*` for that crawler, so it must
+#      restate the full rule set — rule parity with `*` is guarded in
+#      tests/deploy-config.test.mjs.
+#   3. Bulk training-only scrapers (no user-facing assistant, no citations) —
+#      disallowed entirely, consistent with ai-train=no.
 
 # AI content-usage preferences (contentsignals.org draft RFC) are declared BOTH
 # as the Content-Signal group directive below (what agent-readiness scanners
@@ -17,6 +27,37 @@ Allow: /api/llms.txt
 Allow: /api/product-catalog
 Disallow: /api/
 Disallow: /tests/
+
+# Tier 2 — AI search & assistant agents: welcome. Same path rules as `*`,
+# restated because a matching named group makes a crawler ignore `*` entirely.
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+User-agent: ClaudeBot
+User-agent: Claude-User
+User-agent: Claude-SearchBot
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Google-Extended
+User-agent: Applebot-Extended
+User-agent: DuckAssistBot
+User-agent: MistralAI-User
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Allow: /api/story
+Allow: /api/og-story
+Allow: /api/llms.txt
+Allow: /api/product-catalog
+Disallow: /api/
+Disallow: /tests/
+
+# Tier 3 — bulk training-only scrapers: no assistant surface, no citations,
+# nothing given back. anthropic-ai is Anthropic's legacy training UA
+# (ClaudeBot above is the one that powers Claude citations).
+User-agent: CCBot
+User-agent: Bytespider
+User-agent: anthropic-ai
+Disallow: /
 
 Sitemap: https://www.worldmonitor.app/sitemap.xml
 Sitemap: https://www.worldmonitor.app/blog/sitemap-index.xml

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -16,7 +16,7 @@ const middlewareSource = readFileSync(resolve(__dirname, '../middleware.ts'), 'u
 const dockerfileSource = readFileSync(resolve(__dirname, '../Dockerfile'), 'utf-8');
 const dockerNginxSource = readFileSync(resolve(__dirname, '../docker/nginx.conf'), 'utf-8');
 const frontendDockerfileSource = readFileSync(resolve(__dirname, '../docker/Dockerfile'), 'utf-8');
-const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
+const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
 const GLOBAL_SECURITY_HEADER_SOURCE = '/((?!docs|embed|embed\\.html).*)';
 const APP_ROOT_HOST_PATTERN = '^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$';
 const GLOBAL_CSP_INLINE_SCRIPT_HTML_FILES = [
@@ -1220,6 +1220,7 @@ describe('agent readiness: api-catalog + openapi build', () => {
       'service-meta must advertise the live product-catalog JSON endpoint'
     );
     assert.ok(hrefs.includes('https://worldmonitor.app/support.md'), 'service-meta must advertise support.md');
+    assert.ok(hrefs.includes('https://worldmonitor.app/agents.md'), 'service-meta must advertise agents.md (#4952)');
     // The Commerce spec lives outside the root openapi bundle (size budget,
     // #4853) — without this link no advertised descriptor reaches it
     // (post-#4867 review finding); Mintlify serves the raw YAML at this URL.
@@ -1606,11 +1607,12 @@ describe('agent readiness: auth.md walkthrough', () => {
   });
 
   // pricing.md and support.md are advertised in api-catalog service-meta and
-  // llms.txt (#4854/#4857), so they get the same three-way pinning as auth.md:
+  // llms.txt (#4854/#4857), agents.md is the agent-discovery entry point
+  // (#4952), so they get the same three-way pinning as auth.md:
   // explicit markdown Content-Type + CORS, catch-all exclusion (deleting or
   // renaming the static file must 404, not silently serve the dashboard HTML
   // misleading-200 the journey runs flagged), and this guard.
-  for (const mdPath of ['/pricing.md', '/support.md']) {
+  for (const mdPath of ['/pricing.md', '/support.md', '/agents.md']) {
     it(`serves ${mdPath} as markdown and keeps it off the SPA catch-all`, () => {
       assert.equal(getHeaderValueForSource(mdPath, 'Content-Type'), 'text/markdown; charset=utf-8');
       assert.equal(getHeaderValueForSource(mdPath, 'Access-Control-Allow-Origin'), '*');
@@ -1785,6 +1787,141 @@ describe('agent readiness: Content-Signal declarations', () => {
       headerValue(),
       'robots.txt Content-Signal must match the vercel.json header value'
     );
+  });
+
+  it('every Content-Signal line in robots.txt matches the header (multi-group)', () => {
+    // The AI-agent groups added in #4952 carry their own Content-Signal
+    // directive; none of the copies may drift from the origin-wide header.
+    const signalLines = robotsSource
+      .split('\n')
+      .filter((l) => l.startsWith('Content-Signal:'));
+    assert.ok(signalLines.length >= 1, 'robots.txt must declare Content-Signal');
+    for (const line of signalLines) {
+      assert.strictEqual(
+        line.slice('Content-Signal:'.length).trim(),
+        headerValue(),
+        'every robots.txt Content-Signal must match the vercel.json header value'
+      );
+    }
+  });
+});
+
+// #4952 — three-tier AI crawler policy. A named `User-agent` group REPLACES
+// the `*` group for that crawler (robots.txt groups do not inherit), so the
+// AI search/assistant allow-group must restate the full `*` rule set or those
+// crawlers would lose the /api/ protections. The training-only group must
+// stay a hard `Disallow: /`.
+describe('agent readiness: robots.txt AI crawler policy', () => {
+  const robotsSource = readFileSync(resolve(__dirname, '../public/robots.txt'), 'utf-8');
+
+  // Minimal robots.txt group parser: consecutive User-agent lines share one
+  // group; a blank line or a User-agent line following rules starts a new one;
+  // comments never end a group.
+  const parseGroups = (source) => {
+    const groups = [];
+    let current = null;
+    for (const raw of source.split('\n')) {
+      const line = raw.trim();
+      if (line === '') {
+        current = null;
+        continue;
+      }
+      if (line.startsWith('#')) continue;
+      const colon = line.indexOf(':');
+      if (colon === -1) continue;
+      const key = line.slice(0, colon).trim().toLowerCase();
+      const value = line.slice(colon + 1).trim();
+      if (key === 'user-agent') {
+        if (!current || current.rules.length > 0) {
+          current = { agents: [], rules: [] };
+          groups.push(current);
+        }
+        current.agents.push(value.toLowerCase());
+      } else if (current && (key === 'allow' || key === 'disallow')) {
+        current.rules.push(`${key}: ${value}`);
+      }
+    }
+    return groups;
+  };
+
+  const groups = parseGroups(robotsSource);
+  const starGroup = groups.find((g) => g.agents.includes('*'));
+  const aiAllowGroup = groups.find((g) => g.agents.includes('gptbot'));
+  const trainingBlockGroup = groups.find((g) => g.agents.includes('ccbot'));
+
+  // The agents AEO scanners score by name (search/assistant tier).
+  const REQUIRED_AI_SEARCH_AGENTS = [
+    'gptbot',
+    'claudebot',
+    'chatgpt-user',
+    'perplexitybot',
+    'google-extended',
+    'applebot-extended',
+  ];
+  const BLOCKED_TRAINING_AGENTS = ['ccbot', 'bytespider', 'anthropic-ai'];
+
+  it('explicitly allows the AI search/assistant agents in one named group', () => {
+    assert.ok(aiAllowGroup, 'robots.txt must have a named AI search/assistant group (GPTBot et al.)');
+    for (const agent of REQUIRED_AI_SEARCH_AGENTS) {
+      assert.ok(
+        aiAllowGroup.agents.includes(agent),
+        `AI search/assistant group must include User-agent: ${agent}`
+      );
+    }
+    assert.ok(
+      aiAllowGroup.rules.includes('allow: /'),
+      'AI search/assistant group must Allow: /'
+    );
+  });
+
+  it('keeps the AI allow-group rules in parity with the `*` group', () => {
+    assert.ok(starGroup, 'robots.txt must have a `User-agent: *` group');
+    assert.deepStrictEqual(
+      [...aiAllowGroup.rules].sort(),
+      [...starGroup.rules].sort(),
+      'the AI allow-group must restate the exact `*` rule set — named groups do not inherit, so a drift here silently opens /api/ (or blocks paths) for AI crawlers'
+    );
+  });
+
+  it('disallows the bulk training-only scrapers entirely', () => {
+    assert.ok(trainingBlockGroup, 'robots.txt must have a training-scraper block group (CCBot et al.)');
+    for (const agent of BLOCKED_TRAINING_AGENTS) {
+      assert.ok(
+        trainingBlockGroup.agents.includes(agent),
+        `training block group must include User-agent: ${agent}`
+      );
+    }
+    assert.deepStrictEqual(
+      trainingBlockGroup.rules,
+      ['disallow: /'],
+      'training-only scrapers must be blocked with exactly `Disallow: /`'
+    );
+  });
+
+  it('never lists an allowed AI agent in the blocked group (and vice versa)', () => {
+    for (const agent of REQUIRED_AI_SEARCH_AGENTS) {
+      assert.ok(
+        !trainingBlockGroup.agents.includes(agent),
+        `${agent} drives citations and must not be in the blocked group`
+      );
+    }
+    for (const agent of BLOCKED_TRAINING_AGENTS) {
+      assert.ok(
+        !aiAllowGroup.agents.includes(agent),
+        `${agent} is training-only and must not be in the allow group`
+      );
+    }
+  });
+
+  it('every crawl-permitting group keeps /api/ protected', () => {
+    for (const group of groups) {
+      if (group.rules.includes('allow: /')) {
+        assert.ok(
+          group.rules.includes('disallow: /api/'),
+          `group [${group.agents.join(', ')}] allows crawling but does not restate Disallow: /api/`
+        );
+      }
+    }
   });
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,7 @@
     { "source": "/.well-known/mcp.json", "destination": "/api/mcp" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
-    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
+    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [
     {
@@ -130,6 +130,14 @@
       ]
     },
     {
+      "source": "/agents.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
       "source": "/docs/:path*",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
@@ -219,7 +227,7 @@
       ]
     },
     {
-      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
+      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]


### PR DESCRIPTION
## What

Fixes the two in-repo findings from the 2026-07-06 orank AEO audit (#4952):

### 1. robots.txt — granular AI-crawler policy (was: single `User-agent: *` group)

Three tiers, each commented in the file:

- **`*`** — unchanged rules + Content-Signal (`ai-train=no, search=yes, ai-input=yes`).
- **AI search/assistant agents** (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, DuckAssistBot, MistralAI-User) — explicitly allowed. The full `*` rule set is **restated** because a named group replaces `*` for that crawler (no inheritance); without it they'd lose the `/api/` protections. Parity is test-guarded.
- **Bulk training-only scrapers** (CCBot, Bytespider, anthropic-ai) — `Disallow: /`, consistent with `ai-train=no`. `anthropic-ai` is the legacy Anthropic training UA; ClaudeBot (allowed) is what powers Claude citations. Meta agents deliberately left on the `*` default — Meta AI is an assistant surface, and the audit's restricted class is only the give-nothing-back trio.

### 2. `/agents.md` — was a soft-404

`curl https://www.worldmonitor.app/agents.md` returned **200 `text/html`** (the SPA catch-all rewrite serving dashboard.html) — a misleading-200 to agent-discovery probes, same class as the pricing/support gap in #4854/#4867. Now a real agent operations guide (machine surfaces, auth, crawl policy, rate limits, support — key facts front-loaded for ~5KB scanners) with the established three-way pinning:

- markdown Content-Type + CORS headers block in vercel.json
- exclusion from **both** catch-all regexes (rewrite + HTML-cache headers)
- advertised in llms.txt "AI Agent Files" and api-catalog `service-meta`

Self-hosted nginx needs no change (`try_files $uri` serves the static file first).

## Test guards (tests/deploy-config.test.mjs, +6 tests)

- AI allow-group exists and names the six audit-scored agents; `Allow: /`
- AI allow-group rule set **deep-equals** the `*` group (drift = silently opening `/api/`)
- Training group is exactly `Disallow: /` and never contains an allowed agent (and vice versa)
- Every crawl-permitting group restates `Disallow: /api/`
- **All** Content-Signal copies (now 2 groups) match the vercel.json header
- agents.md three-way pinning + service-meta advertisement

## Verification

- `npx tsx --test tests/deploy-config.test.mjs` → 116/116 pass
- Sibling suites reading llms.txt/api-catalog/robots (agent-mode-view, agent-skills-index, llms-txt-mcp-tools, nlweb-ask, middleware-bot-gate, brief-magazine-render, cli-package, sdk-packages) → 202/202 pass
- `node scripts/docs-stats.mjs --check` → 75/75 claims OK
- Dry-ran the robots group parser against the new file: 3 groups, tier-2 parity confirmed

## Out of scope

- `/skills.sh` is an external registry (we're live at skills.sh/koala73/worldmonitor, #4814); no site-local file convention exists.
- Developer-resource discoverability by name (2/6 resource types) → filed as #4953.

Closes #4952

https://claude.ai/code/session_014bmm7eUWr3BM8iyaSRDcbq