### PR TITLE
fix(llm): pin regions on the two unpinned LLM edge routes + log provider error bodies (#4944 U7)

### DIFF
--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -34,7 +34,10 @@
  * and does not apply here.
  */
 
-export const config = { runtime: 'edge' };
+// Regions pinned (#4944 U7): both whyMatters paths reach OpenRouter — LLM
+// calls from restricted-region edge nodes fail with geo-keyed 403s. Mirrors
+// api/news/v1/[rpc].ts and api/intelligence/v1/[rpc].ts.
+export const config = { runtime: 'edge', regions: ['iad1', 'lhr1', 'fra1', 'sfo1'] };
 
 import { authenticateInternalRequest } from '../../server/_shared/internal-auth';
 import { normalizeCountryToIso2 } from '../../server/_shared/country-normalize';

--- a/api/market/v1/[rpc].ts
+++ b/api/market/v1/[rpc].ts
@@ -1,4 +1,7 @@
-export const config = { runtime: 'edge' };
+// Regions pinned (#4944 U7): analyze-stock reaches callLlm — OpenRouter/LLM
+// calls from restricted-region edge nodes fail with geo-keyed 403s. Mirrors
+// api/news/v1/[rpc].ts and api/intelligence/v1/[rpc].ts.
+export const config = { runtime: 'edge', regions: ['iad1', 'lhr1', 'fra1', 'sfo1'] };
 
 import { createDomainGateway, serverOptions } from '../../../server/gateway';
 import { createMarketServiceRoutes } from '../../../src/generated/server/worldmonitor/market/v1/service_server';

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -511,7 +511,11 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
         });
 
         if (!resp.ok) {
-          console.warn(`[llm:${providerName}] HTTP ${resp.status}`);
+          // Log a bounded body slice (like the stream path already does) —
+          // region-403s and provider errors are undiagnosable from the
+          // status code alone (#4944 U7).
+          const errBody = await resp.text().catch(() => '');
+          console.warn(`[llm:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody.slice(0, 300)}`);
           record(false, { reason: `http_${resp.status}` });
           if (forcedProvider) return null;
           continue;

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -125,6 +125,30 @@ export function getProviderCredentials(
   return null;
 }
 
+/**
+ * Read AT MOST ~`cap` characters of a provider error body, then cancel the
+ * stream — a large or slow error body must never delay the next-provider
+ * fallback (#4966 review). The request's own AbortSignal still bounds a
+ * pathological first-chunk stall.
+ */
+async function readBoundedErrorBody(resp: Response, cap: number): Promise<string> {
+  const body = resp.body;
+  if (!body) return '';
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let out = '';
+  try {
+    while (out.length < cap) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out += decoder.decode(value, { stream: true });
+    }
+  } catch { /* best-effort diagnostics only */ } finally {
+    try { void reader.cancel(); } catch { /* already closed */ }
+  }
+  return out.slice(0, cap);
+}
+
 export function stripThinkingTags(text: string): string {
   let s = text
     .replace(/<think>[\s\S]*?<\/think>/gi, '')
@@ -513,9 +537,10 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
         if (!resp.ok) {
           // Log a bounded body slice (like the stream path already does) —
           // region-403s and provider errors are undiagnosable from the
-          // status code alone (#4944 U7).
-          const errBody = await resp.text().catch(() => '');
-          console.warn(`[llm:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody.slice(0, 300)}`);
+          // status code alone (#4944 U7). Bounded READ, not just bounded
+          // log: never consume a huge/slow error body before falling back.
+          const errBody = await readBoundedErrorBody(resp, 300).catch(() => '');
+          console.warn(`[llm:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody}`);
           record(false, { reason: `http_${resp.status}` });
           if (forcedProvider) return null;
           continue;

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -224,6 +224,43 @@ describe('callLlm', () => {
     assert.deepEqual(postBodies[0]?.body.reasoning, { enabled: false });
   });
 
+  it('logs a bounded error-body slice on non-stream provider failure', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const warns: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+      if (url.includes('openrouter.ai')) {
+        return new Response(JSON.stringify({ error: { message: 'This model is not available in your region' } }), { status: 403 });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'groq fallback' } }],
+        usage: { total_tokens: 5 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const result = await callLlm({ messages: [{ role: 'user', content: 'hi' }] });
+      assert.ok(result);
+      assert.equal(result.provider, 'groq');
+      const errLine = warns.find((w) => w.includes('HTTP 403'));
+      assert.ok(errLine, 'a 403 warn line must be emitted');
+      assert.ok(errLine.includes('not available in your region'), 'the error body must be visible in the log');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('falls back within an explicit provider order when the upper model fails', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'or-test-key';

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -261,6 +261,61 @@ describe('callLlm', () => {
     }
   });
 
+  it('reads at most the cap from an oversized/never-ending error body before falling back', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const warns: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+
+    let cancelled = false;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+      if (url.includes('openrouter.ai')) {
+        // First chunk exceeds the cap; a second read would hang forever.
+        // The bounded reader must stop after chunk one and cancel — if it
+        // tried to consume the full body (resp.text()), this test hangs.
+        const enc = new TextEncoder();
+        const body = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (!cancelled) {
+              controller.enqueue(enc.encode(`REGION_BLOCK ${'x'.repeat(4000)}`));
+            }
+            // Never close: subsequent pulls stall until cancel.
+            return new Promise(() => { /* hang */ });
+          },
+          cancel() { cancelled = true; },
+        });
+        return new Response(body, { status: 403 });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'groq fallback' } }],
+        usage: { total_tokens: 5 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const result = await callLlm({ messages: [{ role: 'user', content: 'hi' }] });
+      assert.ok(result, 'fallback must complete despite the never-ending error body');
+      assert.equal(result.provider, 'groq');
+      const errLine = warns.find((w) => w.includes('HTTP 403'));
+      assert.ok(errLine, 'a 403 warn line must be emitted');
+      assert.ok(errLine.includes('REGION_BLOCK'), 'the leading body slice must be visible');
+      const bodyPart = errLine.slice(errLine.indexOf('body=') + 5);
+      assert.ok(bodyPart.length <= 300, `logged body must be capped at 300 chars, got ${bodyPart.length}`);
+      assert.ok(cancelled, 'the error-body stream must be cancelled after the bounded read');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('falls back within an explicit provider order when the upper model fails', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'or-test-key';


### PR DESCRIPTION
Implements U7 of the LLM stack migration (#4944). **Stacked on #4950 (U1+U2)** — base is `feat/llm-stack-deepseek-migration`; GitHub retargets to `main` when it merges. Merge order: #4950 → this.

## What
- **Region pinning sweep**: every Edge route whose handler reaches `callLlm`/`getProviderCredentials` was audited. Already pinned: `api/news/v1/[rpc].ts`, `api/intelligence/v1/[rpc].ts`, `api/chat-analyst.ts`. The two gaps get `regions: ['iad1','lhr1','fra1','sfo1']`:
  - `api/market/v1/[rpc].ts` (analyze-stock reaches `callLlm`; config was only `{ runtime: 'edge' }`)
  - `api/internal/brief-why-matters.ts` (both whyMatters paths reach OpenRouter)
  Rationale: OpenRouter/LLM calls from restricted-region edge nodes fail with intermittent geo-keyed 403s (documented gotcha).
- **403 diagnosability**: `callLlm`'s non-stream failure path now logs a bounded 300-char error-body slice (matching the stream path), so "model not available in your region" stops masquerading as a bare 403.

## Verification
- New test: 403 body visibility in the warn line + clean groq fallback; shared-llm + telemetry suites 11/11; `typecheck` + `typecheck:api` green.
- Post-deploy: `vercel inspect` region list on the two functions.

Refs #4944 (U7). Manual review/merge only.

https://claude.ai/code/session_01Xs7LsyQQJqngcqjt5oGcpx