### PR TITLE
feat(content): global-intelligence glossary — 20 crawlable DefinedTerm pages (#4960)

### DIFF
--- a/blog-site/src/data/glossary.ts
+++ b/blog-site/src/data/glossary.ts
@@ -14,6 +14,15 @@ export interface GlossaryLink {
   href: string;
 }
 
+export const GLOSSARY_CATEGORIES = [
+  'Scoring & Indices',
+  'Signals & Detection',
+  'Maritime & Chokepoints',
+  'OSINT & Methodology',
+] as const;
+
+export type GlossaryCategory = (typeof GLOSSARY_CATEGORIES)[number];
+
 export interface GlossaryTerm {
   /** URL slug under /blog/glossary/<slug>. */
   slug: string;
@@ -21,8 +30,8 @@ export interface GlossaryTerm {
   term: string;
   /** Abbreviation, if the term is commonly cited by acronym. */
   abbr?: string;
-  /** Grouping key — must match one of GLOSSARY_CATEGORIES. */
-  category: string;
+  /** Grouping key — one of GLOSSARY_CATEGORIES (compile-time checked). */
+  category: GlossaryCategory;
   /**
    * One-sentence definition. Used verbatim as the DefinedTerm `description`,
    * the list-page blurb, and the meta description — so it must read as a
@@ -36,13 +45,6 @@ export interface GlossaryTerm {
   /** Authoritative "learn more" pointers (methodology docs, dashboard, blog). */
   learnMore?: GlossaryLink[];
 }
-
-export const GLOSSARY_CATEGORIES = [
-  'Scoring & Indices',
-  'Signals & Detection',
-  'Maritime & Chokepoints',
-  'OSINT & Methodology',
-] as const;
 
 export const GLOSSARY_TERMS: GlossaryTerm[] = [
   // ── Scoring & Indices ─────────────────────────────────────────────
@@ -69,16 +71,16 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     abbr: 'CRI',
     category: 'Scoring & Indices',
     short:
-      'The Country Resilience Index (CRI) is a composite 0–100 score of a country’s structural ability to absorb and recover from shocks, computed across six weighted domains for the rankable universe of roughly 196 countries.',
+      'The Country Resilience Index (CRI) is a composite 0–100 score of a country’s structural ability to absorb and recover from shocks, refreshed every six hours across six weighted domains and 20 active dimensions for a fixed 196-country rankable universe.',
     body: [
-      'The Country Resilience Index (CRI) is a composite 0–100 score of a country’s structural ability to absorb and recover from shocks. Where the CII measures short-term instability, the CRI measures durable capacity — economic, infrastructural, energy, social-governance, health-and-food, and recovery strength.',
-      'The overall score is a weighted aggregate of six domains: economic (0.17), infrastructure (0.15), energy (0.11), social-governance (0.19), health-food (0.13), and recovery (0.25). Recovery carries the highest single weight, which is the mechanical reason fiscally strong small states cluster near the top while fragile states separate toward the bottom.',
-      'CRI is published for the rankable universe of roughly 196 countries with sufficient data coverage (out of about 217 assessed); a country whose mean dimension coverage falls below 0.4 is greyed out rather than ranked. Scores are exposed through the get-resilience-score and get-resilience-ranking endpoints and the get_country_risk MCP tool.',
+      'The Country Resilience Index (CRI) is a composite 0–100 score of a country’s structural ability to absorb and recover from shocks. Where the CII measures short-term instability, the CRI measures durable capacity — economic, infrastructure, energy, social-governance, health-and-food, and recovery strength — refreshed every six hours from official sources with full coverage and imputation provenance.',
+      'The six domains carry design weights — economic 0.17, infrastructure 0.15, energy 0.11, social-governance 0.19, health-food 0.13, recovery 0.25 (sum 1.00) — and are regrouped into three pillars (structural readiness, live-shock exposure, recovery capacity) that combine into the headline score through a non-compensatory formula with a min-pillar penalty. Recovery carries the largest single-domain weight, which is the mechanical reason fiscally strong smaller states cluster near the top while fragile states separate cleanly at the bottom.',
+      'CRI covers a fixed 196-country public rankable universe (a committed UN-member and SAR whitelist); low-confidence or headline-ineligible countries are routed to a separate greyed-out list rather than dropped, and every response exposes per-dimension coverage plus a four-class imputation taxonomy so an analyst can see how much of a score is real data. Scores are served through the get-resilience-score and get-resilience-ranking endpoints and the get_country_risk MCP tool.',
     ],
     related: ['country-instability-index', 'dimension-coverage', 'strategic-risk'],
     learnMore: [
+      { label: 'CRI methodology (full reference)', href: 'https://www.worldmonitor.app/docs/methodology/country-resilience-index' },
       { label: 'CRI methodology explainer (blog)', href: 'https://www.worldmonitor.app/blog/posts/country-resilience-index-methodology-explained/' },
-      { label: 'Resilience score API', href: 'https://www.worldmonitor.app/docs/documentation' },
     ],
   },
   {
@@ -101,12 +103,15 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     term: 'Dimension Coverage',
     category: 'Scoring & Indices',
     short:
-      'Dimension coverage is the share of a country’s resilience dimensions backed by real underlying data — the mean of the per-dimension coverage values used to decide whether a CRI score is reliable enough to rank.',
+      'Dimension coverage is the share of a country’s resilience dimensions backed by real observed data rather than imputed — the mean of the 20 active per-dimension coverage values, used to gauge how much of a CRI score is real.',
     body: [
-      'Dimension coverage is the share of a country’s resilience dimensions that are backed by real underlying data, reported as the mean of the 19 per-dimension coverage values. It is deliberately labelled "dimension coverage" rather than "data coverage" to be precise about what is being measured.',
-      'Coverage acts as a confidence gate: when a country’s mean dimension coverage falls below 0.4, its Country Resilience Index score is greyed out rather than published in the ranking, so thin-data countries are never presented as if they were confidently scored.',
+      'Dimension coverage is the share of a country’s resilience dimensions that are backed by real observed data rather than imputed, reported as the mean of the 20 active per-dimension coverage values (structurally-retired dimensions are excluded from the average). It is deliberately labelled "dimension coverage" rather than "data coverage" to be precise about what is measured.',
+      'Coverage drives a confidence gate: when a country’s average dimension coverage falls below 0.55 — or too much of its score is imputed — the Country Resilience Index marks that score low-confidence, and countries that also fail the headline-eligibility thresholds are routed to a separate greyed-out list rather than the public ranking. Thin-data countries are never presented as if they were confidently scored.',
     ],
     related: ['country-resilience-index'],
+    learnMore: [
+      { label: 'CRI methodology (coverage & imputation)', href: 'https://www.worldmonitor.app/docs/methodology/country-resilience-index' },
+    ],
   },
   {
     slug: 'pentagon-pizza-index',

--- a/blog-site/src/data/glossary.ts
+++ b/blog-site/src/data/glossary.ts
@@ -1,0 +1,336 @@
+/**
+ * Glossary of global-intelligence / OSINT terms rendered as crawlable
+ * DefinedTerm pages under /blog/glossary (#4960 — content corpus).
+ *
+ * Every definition is sourced from WorldMonitor's own methodology docs or
+ * product surfaces — do NOT invent capabilities here. In particular, no term
+ * may claim forecast calibration / Brier scoring, which does not exist yet
+ * (see issue #4930). This file is pure TypeScript (no `astro:` imports) so the
+ * main test suite can import and validate it via tsx.
+ */
+
+export interface GlossaryLink {
+  label: string;
+  href: string;
+}
+
+export interface GlossaryTerm {
+  /** URL slug under /blog/glossary/<slug>. */
+  slug: string;
+  /** Full display term. */
+  term: string;
+  /** Abbreviation, if the term is commonly cited by acronym. */
+  abbr?: string;
+  /** Grouping key — must match one of GLOSSARY_CATEGORIES. */
+  category: string;
+  /**
+   * One-sentence definition. Used verbatim as the DefinedTerm `description`,
+   * the list-page blurb, and the meta description — so it must read as a
+   * complete, standalone answer ("X is …").
+   */
+  short: string;
+  /** Body paragraphs. First paragraph should restate the crisp definition. */
+  body: string[];
+  /** Slugs of related terms (must resolve to another entry). */
+  related: string[];
+  /** Authoritative "learn more" pointers (methodology docs, dashboard, blog). */
+  learnMore?: GlossaryLink[];
+}
+
+export const GLOSSARY_CATEGORIES = [
+  'Scoring & Indices',
+  'Signals & Detection',
+  'Maritime & Chokepoints',
+  'OSINT & Methodology',
+] as const;
+
+export const GLOSSARY_TERMS: GlossaryTerm[] = [
+  // ── Scoring & Indices ─────────────────────────────────────────────
+  {
+    slug: 'country-instability-index',
+    term: 'Country Instability Index',
+    abbr: 'CII',
+    category: 'Scoring & Indices',
+    short:
+      'The Country Instability Index (CII) is a high-frequency instability score that WorldMonitor maintains for 31 Tier-1 countries by blending an editorial baseline with live event pressure.',
+    body: [
+      'The Country Instability Index (CII) is a high-frequency instability score that WorldMonitor maintains for the 31 Tier-1 countries tracked by its Strategic Risk system. Rather than relying on static ratings, CII blends a curated editorial baseline with live event pressure — unrest, conflict, security, and information signals — and publishes a signed 24-hour movement delta so operators can see which direction a country is moving.',
+      'Tier-1 membership is curated rather than algorithmic: a country is included when it has sustained global-risk relevance, active or recent armed conflict, severe domestic instability, or high regional escalation potential. The score is computed server-side and exposed through the GetRiskScores RPC and the get_country_risk MCP tool.',
+    ],
+    related: ['country-resilience-index', 'strategic-risk', 'focal-point-detection'],
+    learnMore: [
+      { label: 'CII methodology', href: 'https://www.worldmonitor.app/docs/country-instability-index' },
+      { label: 'CII methodology explainer (blog)', href: 'https://www.worldmonitor.app/blog/posts/country-instability-index-methodology-explained/' },
+    ],
+  },
+  {
+    slug: 'country-resilience-index',
+    term: 'Country Resilience Index',
+    abbr: 'CRI',
+    category: 'Scoring & Indices',
+    short:
+      'The Country Resilience Index (CRI) is a composite 0–100 score of a country’s structural ability to absorb and recover from shocks, computed across six weighted domains for the rankable universe of roughly 196 countries.',
+    body: [
+      'The Country Resilience Index (CRI) is a composite 0–100 score of a country’s structural ability to absorb and recover from shocks. Where the CII measures short-term instability, the CRI measures durable capacity — economic, infrastructural, energy, social-governance, health-and-food, and recovery strength.',
+      'The overall score is a weighted aggregate of six domains: economic (0.17), infrastructure (0.15), energy (0.11), social-governance (0.19), health-food (0.13), and recovery (0.25). Recovery carries the highest single weight, which is the mechanical reason fiscally strong small states cluster near the top while fragile states separate toward the bottom.',
+      'CRI is published for the rankable universe of roughly 196 countries with sufficient data coverage (out of about 217 assessed); a country whose mean dimension coverage falls below 0.4 is greyed out rather than ranked. Scores are exposed through the get-resilience-score and get-resilience-ranking endpoints and the get_country_risk MCP tool.',
+    ],
+    related: ['country-instability-index', 'dimension-coverage', 'strategic-risk'],
+    learnMore: [
+      { label: 'CRI methodology explainer (blog)', href: 'https://www.worldmonitor.app/blog/posts/country-resilience-index-methodology-explained/' },
+      { label: 'Resilience score API', href: 'https://www.worldmonitor.app/docs/documentation' },
+    ],
+  },
+  {
+    slug: 'strategic-risk',
+    term: 'Strategic Risk',
+    category: 'Scoring & Indices',
+    short:
+      'Strategic Risk is WorldMonitor’s composite triage layer that synthesizes instability, convergence, infrastructure, theater posture, sanctions, and breaking-news signals into a single headline risk read.',
+    body: [
+      'Strategic Risk is WorldMonitor’s composite triage layer for global risk. Its server-published headline score is a top-five Country Instability Index roll-up, around which the panel layers additional convergence, infrastructure cascade, theater posture, breaking-news, sanctions, and radiation-watch context.',
+      'The purpose is fast triage: rather than reading each intelligence module separately, an operator sees one fused assessment that flags where multiple independent signals are pointing at the same place at the same time.',
+    ],
+    related: ['country-instability-index', 'geographic-convergence', 'infrastructure-cascade', 'pentagon-pizza-index'],
+    learnMore: [
+      { label: 'Strategic Risk methodology', href: 'https://www.worldmonitor.app/docs/strategic-risk' },
+    ],
+  },
+  {
+    slug: 'dimension-coverage',
+    term: 'Dimension Coverage',
+    category: 'Scoring & Indices',
+    short:
+      'Dimension coverage is the share of a country’s resilience dimensions backed by real underlying data — the mean of the per-dimension coverage values used to decide whether a CRI score is reliable enough to rank.',
+    body: [
+      'Dimension coverage is the share of a country’s resilience dimensions that are backed by real underlying data, reported as the mean of the 19 per-dimension coverage values. It is deliberately labelled "dimension coverage" rather than "data coverage" to be precise about what is being measured.',
+      'Coverage acts as a confidence gate: when a country’s mean dimension coverage falls below 0.4, its Country Resilience Index score is greyed out rather than published in the ranking, so thin-data countries are never presented as if they were confidently scored.',
+    ],
+    related: ['country-resilience-index'],
+  },
+  {
+    slug: 'pentagon-pizza-index',
+    term: 'Pentagon Pizza Index',
+    category: 'Scoring & Indices',
+    short:
+      'The Pentagon Pizza Index is an open-source-intelligence activity proxy that watches late-night demand signals near key government facilities as a rough tell for unusual operational tempo.',
+    body: [
+      'The Pentagon Pizza Index is an open-source-intelligence activity proxy — a light-hearted but long-observed heuristic that unusual late-night food-delivery demand near defense and government facilities can correlate with elevated operational tempo before any official signal appears.',
+      'In WorldMonitor it is one of several ambient indicators fused into the Strategic Risk context rather than a standalone forecast. It illustrates the platform’s broader thesis: correlating many weak, independent signals surfaces convergence earlier than any single authoritative source.',
+    ],
+    related: ['strategic-risk', 'osint'],
+  },
+
+  // ── Signals & Detection ───────────────────────────────────────────
+  {
+    slug: 'focal-point-detection',
+    term: 'Focal Point Detection',
+    category: 'Signals & Detection',
+    short:
+      'Focal point detection is the synthesis layer that correlates news entities with live map signals to identify the "main characters" — the people, places, and organizations driving current events.',
+    body: [
+      'Focal point detection is WorldMonitor’s intelligence-synthesis layer. A focal point is an entity — a person, place, or organization — that appears in both news coverage and map signals at the same time. Surfacing those overlaps identifies the "main characters" driving the current situation.',
+      'The detector enriches AI analysis with this cross-referenced context, so a generated brief reasons about entities that are simultaneously in the headlines and on the map, rather than treating text and geospatial signals as separate worlds.',
+    ],
+    related: ['geographic-convergence', 'world-brief', 'threat-classification'],
+    learnMore: [
+      { label: 'AI intelligence methodology', href: 'https://www.worldmonitor.app/docs/ai-intelligence' },
+    ],
+  },
+  {
+    slug: 'geographic-convergence',
+    term: 'Geographic Convergence',
+    category: 'Signals & Detection',
+    short:
+      'Geographic convergence is when three or more distinct event types co-occur inside the same one-degree map cell within 24 hours, which fires a convergence alert flagging an area where separate signals are stacking up.',
+    body: [
+      'Geographic convergence detection bins events — protests, military flights, vessels, earthquakes, and more — into 1°×1° geographic cells over a rolling 24-hour window. When three or more distinct event types converge in a single cell, a convergence alert fires.',
+      'Alert severity is driven by type diversity (about 25 points per unique event type) plus event-count bonuses (capped at 25). Four converging types, or a score of 90 or above, is treated as critical; three-type alerts below 90 are high priority. Each alert is reverse-geocoded to a human-readable place name using conflict-zone, waterway, and hotspot databases.',
+    ],
+    related: ['focal-point-detection', 'infrastructure-cascade', 'strategic-risk', 'hotspot'],
+  },
+  {
+    slug: 'infrastructure-cascade',
+    term: 'Infrastructure Cascade',
+    category: 'Signals & Detection',
+    short:
+      'An infrastructure cascade is a modeled chain reaction in which the disruption of one critical node — a cable, pipeline, port, or chokepoint — propagates through its dependency graph to threaten downstream systems.',
+    body: [
+      'An infrastructure cascade is a chain reaction across dependent critical systems. WorldMonitor models the dependency graph linking cables, pipelines, ports, and chokepoints so that damage or disruption at one node can be traced to the downstream nodes it puts at risk.',
+      'Cascade incidents feed the Strategic Risk score and the alert-fusion pipeline: cascade alerts are merged with convergence alerts, CII spikes, sanctions pressure, and radiation watch when they occur close together in time and space, so a single fused alert captures a multi-domain event.',
+    ],
+    related: ['geographic-convergence', 'strategic-risk', 'maritime-chokepoint'],
+    learnMore: [
+      { label: 'Infrastructure cascade methodology', href: 'https://www.worldmonitor.app/docs/infrastructure-cascade' },
+    ],
+  },
+  {
+    slug: 'hotspot',
+    term: 'Hotspot',
+    category: 'Signals & Detection',
+    short:
+      'A hotspot is a watched location whose displayed activity level is computed in real time from news correlation, rather than being a fixed, static threat rating.',
+    body: [
+      'A hotspot is a location WorldMonitor watches continuously. Crucially, a hotspot’s activity level is not a static threat rating — it is calculated in real time based on how strongly current news correlates with the keywords that define that location.',
+      'This keeps the map honest: a normally quiet location lights up only when live coverage says something is actually happening there, and a chronically tense location can read as calm during a genuine lull.',
+    ],
+    related: ['geographic-convergence', 'focal-point-detection'],
+    learnMore: [
+      { label: 'Hotspots methodology', href: 'https://www.worldmonitor.app/docs/hotspots' },
+    ],
+  },
+  {
+    slug: 'threat-classification',
+    term: 'Threat Classification',
+    category: 'Signals & Detection',
+    short:
+      'Threat classification is the hybrid AI step that labels incoming events by type and severity, combining fast rule-based tagging with model-based analysis to keep the live feed structured.',
+    body: [
+      'Threat classification is the step that turns raw incoming events into a structured, labelled feed. WorldMonitor uses a hybrid approach: fast rule-based tagging handles the common, unambiguous cases, while model-based classification handles nuance and ambiguity.',
+      'Consistent type and severity labels are what make downstream correlation possible — convergence detection, focal-point synthesis, and Strategic Risk all depend on events already being classified into comparable categories.',
+    ],
+    related: ['focal-point-detection', 'world-brief'],
+  },
+
+  // ── Maritime & Chokepoints ────────────────────────────────────────
+  {
+    slug: 'maritime-chokepoint',
+    term: 'Maritime Chokepoint',
+    category: 'Maritime & Chokepoints',
+    short:
+      'A maritime chokepoint is a narrow passage through which a large share of global trade, energy, food, or military movement must pass, so a disruption there removes optionality from the whole system.',
+    body: [
+      'A maritime chokepoint is a narrow passage where a large share of global trade, energy, food, or military movement must pass through a small physical space. If ships can choose among several similar routes, a disruption is manageable; when many routes collapse into one narrow passage, the same disruption can become systemic.',
+      'The essential idea is that a chokepoint is where geography removes optionality — the risk is not just today’s traffic, but how little room the system has when that traffic changes. WorldMonitor tracks 13 waterways, of which seven currently publish live flow estimates.',
+    ],
+    related: ['strait-of-hormuz', 'strait-of-malacca', 'suez-canal', 'ais', 'chokepoint-congestion'],
+    learnMore: [
+      { label: 'What is a maritime chokepoint? (blog)', href: 'https://www.worldmonitor.app/blog/posts/what-is-a-maritime-chokepoint/' },
+      { label: 'Maritime intelligence methodology', href: 'https://www.worldmonitor.app/docs/maritime-intelligence' },
+    ],
+  },
+  {
+    slug: 'strait-of-hormuz',
+    term: 'Strait of Hormuz',
+    category: 'Maritime & Chokepoints',
+    short:
+      'The Strait of Hormuz is the maritime chokepoint between the Persian Gulf and the Gulf of Oman through which a large share of the world’s seaborne crude oil and LNG must transit.',
+    body: [
+      'The Strait of Hormuz is the narrow waterway connecting the Persian Gulf to the Gulf of Oman and the open ocean. It is the single most closely watched energy chokepoint on Earth because a very large share of seaborne crude oil and liquefied natural gas has no alternative route out of the Gulf.',
+      'In WorldMonitor, Hormuz is one of the chokepoints with live flow estimates: vessel activity, congestion, and disruption signals are correlated against energy markets so an operator can see whether a Gulf tension event has a plausible transmission path into oil and gas prices.',
+    ],
+    related: ['maritime-chokepoint', 'ais', 'chokepoint-congestion'],
+    learnMore: [
+      { label: 'Energy shock monitoring (blog)', href: 'https://www.worldmonitor.app/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/' },
+    ],
+  },
+  {
+    slug: 'strait-of-malacca',
+    term: 'Strait of Malacca',
+    category: 'Maritime & Chokepoints',
+    short:
+      'The Strait of Malacca is the primary shipping lane between the Indian and Pacific Oceans, carrying a large share of container traffic and energy imports bound for East Asia.',
+    body: [
+      'The Strait of Malacca runs between the Malay Peninsula and Sumatra, linking the Indian Ocean to the South China Sea and the Pacific. It is one of the busiest shipping lanes in the world and the main artery for energy and container flows into East Asia.',
+      'Its width and traffic density make it a textbook chokepoint: alternative routes exist but are longer and lower-capacity, so congestion or disruption in Malacca reverberates through Asian supply chains and freight costs.',
+    ],
+    related: ['maritime-chokepoint', 'suez-canal', 'ais'],
+  },
+  {
+    slug: 'suez-canal',
+    term: 'Suez Canal',
+    category: 'Maritime & Chokepoints',
+    short:
+      'The Suez Canal is the artificial waterway linking the Mediterranean and the Red Sea that lets shipping move between Europe and Asia without rounding Africa.',
+    body: [
+      'The Suez Canal connects the Mediterranean Sea to the Red Sea, providing the shortest maritime route between Europe and Asia and removing the need to sail around the Cape of Good Hope. Its southern approach runs through the Bab-el-Mandeb strait, so instability in the Red Sea affects both.',
+      'As a chokepoint, Suez concentrates a large share of Europe–Asia trade into a single canal; a blockage or a security threat that reroutes traffic around Africa adds days of transit and materially raises freight costs, which WorldMonitor tracks alongside the physical disruption signals.',
+    ],
+    related: ['maritime-chokepoint', 'strait-of-malacca', 'chokepoint-congestion'],
+    learnMore: [
+      { label: 'Tracking global trade routes (blog)', href: 'https://www.worldmonitor.app/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/' },
+    ],
+  },
+  {
+    slug: 'ais',
+    term: 'Automatic Identification System',
+    abbr: 'AIS',
+    category: 'Maritime & Chokepoints',
+    short:
+      'AIS (Automatic Identification System) is the transponder standard that broadcasts a ship’s identity, position, and course, and is the primary data source for tracking vessel traffic through chokepoints.',
+    body: [
+      'The Automatic Identification System (AIS) is a maritime transponder standard that continuously broadcasts a vessel’s identity, position, speed, and course. It exists for collision avoidance, but it also makes near-real-time ship tracking possible for anyone receiving the signals.',
+      'WorldMonitor uses AIS positions to watch tanker and cargo movement inside chokepoint bounding boxes, detect congestion, and flag disruptions such as coverage gaps. Because AIS can be switched off or spoofed, sudden gaps are themselves treated as a signal worth surfacing.',
+    ],
+    related: ['maritime-chokepoint', 'chokepoint-congestion', 'strait-of-hormuz'],
+  },
+  {
+    slug: 'chokepoint-congestion',
+    term: 'Chokepoint Congestion',
+    category: 'Maritime & Chokepoints',
+    short:
+      'Chokepoint congestion is an above-normal build-up of vessel traffic waiting to transit a strait or canal, detected from AIS activity and used as an early sign of disruption.',
+    body: [
+      'Chokepoint congestion is an above-baseline accumulation of ships waiting to transit a strait or canal. WorldMonitor detects it from AIS activity inside each chokepoint’s bounding box and treats a congestion spike as one of its AIS disruption types.',
+      'Congestion is an early-warning signal: queues often build before a disruption becomes headline news, so a rising congestion reading at Hormuz, Suez, or Malacca can precede the trade and energy-price effects that follow.',
+    ],
+    related: ['maritime-chokepoint', 'ais', 'strait-of-hormuz'],
+  },
+
+  // ── OSINT & Methodology ───────────────────────────────────────────
+  {
+    slug: 'osint',
+    term: 'Open-Source Intelligence',
+    abbr: 'OSINT',
+    category: 'OSINT & Methodology',
+    short:
+      'Open-source intelligence (OSINT) is intelligence produced from publicly available sources — news, social media, satellite imagery, transponder feeds, and public records — rather than from classified collection.',
+    body: [
+      'Open-source intelligence (OSINT) is intelligence derived entirely from publicly available information: news reporting, social media, satellite and aerial imagery, ship and aircraft transponders, and public records. Its power comes not from secrecy but from correlation — combining many open signals into a picture no single source shows.',
+      'WorldMonitor is an OSINT platform by construction: every layer is sourced from public feeds with documented provenance, which is what lets it publish source-attributed briefs and scores that a reader can trace back to the underlying evidence.',
+    ],
+    related: ['provenance', 'world-brief', 'focal-point-detection'],
+    learnMore: [
+      { label: 'OSINT for everyone (blog)', href: 'https://www.worldmonitor.app/blog/posts/osint-for-everyone-open-source-intelligence-democratized/' },
+    ],
+  },
+  {
+    slug: 'provenance',
+    term: 'Provenance & Source Attribution',
+    category: 'OSINT & Methodology',
+    short:
+      'Provenance is the documented chain from a published score or brief back to the specific public sources it was built from, so any claim can be traced to its underlying evidence.',
+    body: [
+      'Provenance, or source attribution, is the discipline of keeping a documented chain from every published output back to the specific public sources behind it. For an OSINT product it is the difference between an assertion and a citation.',
+      'WorldMonitor carries provenance through its briefs, scores, and cached operational data with documented methodology, so a reader — or an AI agent consuming the API — can see not just what the platform concluded but which sources support it.',
+    ],
+    related: ['osint', 'world-brief'],
+  },
+  {
+    slug: 'world-brief',
+    term: 'World Brief',
+    category: 'OSINT & Methodology',
+    short:
+      'The World Brief is WorldMonitor’s AI-generated, source-attributed summary of the current global situation, synthesized from correlated live signals rather than a single news feed.',
+    body: [
+      'The World Brief is a source-attributed situational summary generated from WorldMonitor’s correlated live signals — news, map events, focal points, and classified threats. It answers "what is happening right now, globally" in a form an operator or an agent can consume directly.',
+      'It is available through the get_world_brief MCP tool and the dashboard, and it draws on the same focal-point and classification layers that power the map, so the narrative and the geospatial view stay consistent.',
+    ],
+    related: ['focal-point-detection', 'threat-classification', 'provenance', 'osint'],
+  },
+  {
+    slug: 'prediction-market',
+    term: 'Prediction Market',
+    category: 'OSINT & Methodology',
+    short:
+      'A prediction market is a marketplace where participants trade contracts on the outcome of future events, and the market price acts as a crowd-sourced probability estimate.',
+    body: [
+      'A prediction market is a marketplace in which participants buy and sell contracts tied to the outcome of a future event. Because a contract pays out based on what actually happens, its trading price behaves as a continuously updated, crowd-sourced probability for that outcome.',
+      'WorldMonitor surfaces prediction-market context — for example via the get_prediction_markets tool — as an external probability signal to sit alongside its own scenario forecasts, giving a market-implied read on geopolitical questions next to the platform’s analysis.',
+    ],
+    related: ['world-brief', 'strategic-risk'],
+    learnMore: [
+      { label: 'Prediction markets & AI forecasting (blog)', href: 'https://www.worldmonitor.app/blog/posts/prediction-markets-ai-forecasting-geopolitics/' },
+    ],
+  },
+];

--- a/blog-site/src/layouts/Base.astro
+++ b/blog-site/src/layouts/Base.astro
@@ -102,6 +102,7 @@ function stringifyJsonLd(value: Record<string, unknown>): string {
         </a>
         <ul class="nav-links">
           <li><a href="/blog/">Blog</a></li>
+          <li><a href="/blog/glossary/">Glossary</a></li>
           <li><a href="https://www.worldmonitor.app" target="_blank" rel="noopener noreferrer">Dashboard</a></li>
           <li><a href="https://www.worldmonitor.app/pro" target="_blank" rel="noopener noreferrer">Pro</a></li>
           <li><a href="https://www.worldmonitor.app/docs" target="_blank" rel="noopener noreferrer">Docs</a></li>

--- a/blog-site/src/pages/glossary/[slug].astro
+++ b/blog-site/src/pages/glossary/[slug].astro
@@ -1,0 +1,228 @@
+---
+import Base from '../../layouts/Base.astro';
+import { GLOSSARY_TERMS } from '../../data/glossary';
+
+export function getStaticPaths() {
+  return GLOSSARY_TERMS.map((term) => ({
+    params: { slug: term.slug },
+    props: { term },
+  }));
+}
+
+const { term } = Astro.props;
+const bySlug = new Map(GLOSSARY_TERMS.map((t) => [t.slug, t]));
+const related = term.related.map((slug) => bySlug.get(slug)).filter((t) => t != null);
+
+const pageUrl = `https://www.worldmonitor.app/blog/glossary/${term.slug}/`;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTerm',
+  name: term.term,
+  ...(term.abbr ? { alternateName: term.abbr } : {}),
+  description: term.short,
+  url: pageUrl,
+  inLanguage: 'en-US',
+  inDefinedTermSet: {
+    '@type': 'DefinedTermSet',
+    name: 'World Monitor Global Intelligence Glossary',
+    url: 'https://www.worldmonitor.app/blog/glossary/',
+  },
+};
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Blog', item: 'https://www.worldmonitor.app/blog/' },
+    { '@type': 'ListItem', position: 2, name: 'Glossary', item: 'https://www.worldmonitor.app/blog/glossary/' },
+    { '@type': 'ListItem', position: 3, name: term.term, item: pageUrl },
+  ],
+};
+
+const faqLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: `What is ${term.term}${term.abbr ? ` (${term.abbr})` : ''}?`,
+      acceptedAnswer: { '@type': 'Answer', text: term.short },
+    },
+  ],
+};
+---
+
+<Base
+  title={`What is ${term.term}${term.abbr ? ` (${term.abbr})` : ''}?`}
+  description={term.short}
+  metaTitle={`${term.term}${term.abbr ? ` (${term.abbr})` : ''} — Definition | World Monitor Glossary`}
+  ogType="article"
+  section="Glossary"
+  jsonLd={jsonLd}
+  breadcrumbLd={breadcrumbLd}
+  faqLd={faqLd}
+>
+  <article class="glossary-term">
+    <nav class="glossary-breadcrumb" aria-label="Breadcrumb">
+      <a href="/blog/">Blog</a>
+      <span aria-hidden="true">/</span>
+      <a href="/blog/glossary/">Glossary</a>
+      <span aria-hidden="true">/</span>
+      <span>{term.term}</span>
+    </nav>
+
+    <header class="glossary-term-header">
+      <div class="glossary-term-cat">{term.category}</div>
+      <h1>
+        {term.term}
+        {term.abbr && <span class="glossary-abbr">{term.abbr}</span>}
+      </h1>
+      <p class="glossary-lede">{term.short}</p>
+    </header>
+
+    <div class="prose">
+      {term.body.map((para) => (
+        <p>{para}</p>
+      ))}
+    </div>
+
+    {term.learnMore && term.learnMore.length > 0 && (
+      <div class="glossary-learn">
+        <h2>Learn more</h2>
+        <ul>
+          {term.learnMore.map((link) => (
+            <li><a href={link.href}>{link.label}</a></li>
+          ))}
+        </ul>
+      </div>
+    )}
+
+    {related.length > 0 && (
+      <div class="glossary-related">
+        <h2>Related terms</h2>
+        <div class="glossary-related-grid">
+          {related.map((t) => (
+            <a href={`/blog/glossary/${t.slug}/`} class="glossary-card">
+              <h3>
+                {t.term}
+                {t.abbr && <span class="glossary-abbr">{t.abbr}</span>}
+              </h3>
+              <p>{t.short}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    )}
+
+    <div class="cta-banner glossary-cta">
+      <h3>See it live</h3>
+      <p>
+        World Monitor tracks this and hundreds of other signals in real time on one map —
+        free, no account required.
+      </p>
+      <a href="https://www.worldmonitor.app" class="btn" target="_blank" rel="noopener noreferrer">
+        Open Dashboard
+      </a>
+    </div>
+  </article>
+
+  <style>
+    .glossary-term {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 1.5rem 1.25rem 4rem;
+    }
+    .glossary-breadcrumb {
+      font-size: 0.8rem;
+      opacity: 0.65;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1.5rem;
+    }
+    .glossary-breadcrumb a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .glossary-breadcrumb a:hover {
+      color: var(--wm-green, #4ade80);
+    }
+    .glossary-term-cat {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--wm-green, #4ade80);
+      margin-bottom: 0.5rem;
+    }
+    .glossary-term-header h1 {
+      margin: 0 0 0.75rem;
+      display: flex;
+      align-items: baseline;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+    }
+    .glossary-lede {
+      font-size: 1.1rem;
+      line-height: 1.5;
+      opacity: 0.9;
+      margin: 0 0 1.5rem;
+    }
+    .glossary-abbr {
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: var(--wm-green, #4ade80);
+      border: 1px solid currentColor;
+      border-radius: 4px;
+      padding: 0.1rem 0.4rem;
+    }
+    .glossary-learn,
+    .glossary-related {
+      margin-top: 2.5rem;
+    }
+    .glossary-learn h2,
+    .glossary-related h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      opacity: 0.8;
+    }
+    .glossary-related-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+    .glossary-card {
+      display: block;
+      padding: 1rem 1.1rem;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.15s ease, transform 0.15s ease;
+    }
+    .glossary-card:hover {
+      border-color: var(--wm-green, #4ade80);
+      transform: translateY(-2px);
+    }
+    .glossary-card h3 {
+      margin: 0 0 0.4rem;
+      font-size: 0.95rem;
+      display: flex;
+      align-items: baseline;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .glossary-card p {
+      margin: 0;
+      font-size: 0.82rem;
+      line-height: 1.45;
+      opacity: 0.75;
+    }
+    .glossary-cta {
+      margin-top: 3rem;
+    }
+  </style>
+</Base>

--- a/blog-site/src/pages/glossary/index.astro
+++ b/blog-site/src/pages/glossary/index.astro
@@ -1,0 +1,140 @@
+---
+import Base from '../../layouts/Base.astro';
+import { GLOSSARY_TERMS, GLOSSARY_CATEGORIES } from '../../data/glossary';
+
+const sorted = [...GLOSSARY_TERMS].sort((a, b) => a.term.localeCompare(b.term));
+const byCategory = GLOSSARY_CATEGORIES.map((category) => ({
+  category,
+  terms: sorted.filter((t) => t.category === category),
+}));
+
+const pageUrl = 'https://www.worldmonitor.app/blog/glossary/';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'DefinedTermSet',
+  name: 'World Monitor Global Intelligence Glossary',
+  description:
+    'Definitions of the global-intelligence, OSINT, resilience-scoring, and maritime-chokepoint terms used across World Monitor.',
+  url: pageUrl,
+  inLanguage: 'en-US',
+  hasDefinedTerm: sorted.map((t) => ({
+    '@type': 'DefinedTerm',
+    name: t.term,
+    ...(t.abbr ? { alternateName: t.abbr } : {}),
+    description: t.short,
+    url: `https://www.worldmonitor.app/blog/glossary/${t.slug}/`,
+  })),
+};
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Blog', item: 'https://www.worldmonitor.app/blog/' },
+    { '@type': 'ListItem', position: 2, name: 'Glossary', item: pageUrl },
+  ],
+};
+---
+
+<Base
+  title="Global Intelligence Glossary"
+  description="Definitions of the global-intelligence, OSINT, country-resilience, and maritime-chokepoint terms used across World Monitor — the Country Instability Index, Country Resilience Index, geographic convergence, focal points, chokepoints, and more."
+  metaTitle="Global Intelligence & OSINT Glossary | World Monitor"
+  keywords="OSINT glossary, country instability index, country resilience index, maritime chokepoint, geographic convergence, focal point detection"
+  jsonLd={jsonLd}
+  breadcrumbLd={breadcrumbLd}
+>
+  <div class="blog-hero">
+    <div class="badge">
+      <span class="dot"></span>
+      Reference
+    </div>
+    <h1>Intelligence<span class="green">.</span>Glossary</h1>
+    <p class="subtitle">
+      Plain-English definitions of the scoring indices, detection signals, maritime chokepoints,
+      and OSINT methodology terms used across World Monitor. Each entry links to the methodology
+      behind it.
+    </p>
+  </div>
+
+  <div class="blog-list glossary-index">
+    {byCategory.map(({ category, terms }) => (
+      <section class="glossary-group">
+        <h2 class="glossary-group-title">{category}</h2>
+        <div class="glossary-grid">
+          {terms.map((t) => (
+            <a href={`/blog/glossary/${t.slug}/`} class="glossary-card">
+              <h3>
+                {t.term}
+                {t.abbr && <span class="glossary-abbr">{t.abbr}</span>}
+              </h3>
+              <p>{t.short}</p>
+            </a>
+          ))}
+        </div>
+      </section>
+    ))}
+  </div>
+
+  <style>
+    .glossary-index {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0 1.25rem 4rem;
+    }
+    .glossary-group {
+      margin-top: 2.5rem;
+    }
+    .glossary-group-title {
+      font-size: 1.1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--wm-green, #4ade80);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.25rem;
+    }
+    .glossary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+    .glossary-card {
+      display: block;
+      padding: 1rem 1.1rem;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.15s ease, transform 0.15s ease;
+    }
+    .glossary-card:hover {
+      border-color: var(--wm-green, #4ade80);
+      transform: translateY(-2px);
+    }
+    .glossary-card h3 {
+      margin: 0 0 0.4rem;
+      font-size: 1rem;
+      display: flex;
+      align-items: baseline;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .glossary-abbr {
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: var(--wm-green, #4ade80);
+      border: 1px solid currentColor;
+      border-radius: 4px;
+      padding: 0.05rem 0.35rem;
+    }
+    .glossary-card p {
+      margin: 0;
+      font-size: 0.85rem;
+      line-height: 1.45;
+      opacity: 0.75;
+    }
+  </style>
+</Base>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -74,6 +74,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - [README](https://github.com/koala73/worldmonitor/blob/main/README.md): Full project documentation with architecture details
 - [Full Documentation](https://github.com/koala73/worldmonitor/blob/main/docs/DOCUMENTATION.md): Detailed feature documentation, data layers, and panel reference
 - [Extended LLM Documentation](https://worldmonitor.app/llms-full.txt): Comprehensive version of this file with all data layers, components, and data sources
+- [Global Intelligence Glossary](https://www.worldmonitor.app/blog/glossary/): Definitions of the scoring indices (CII, CRI), detection signals (geographic convergence, focal points), maritime chokepoints, and OSINT methodology terms — one citable DefinedTerm page per concept
 - [Machine-Readable Pricing](https://worldmonitor.app/pricing.md): Free, Pro, API, and Enterprise plan details in markdown
 - [Accounts & Sign-up](https://www.worldmonitor.app/docs/accounts.md): How account creation works (free tier needs none; Clerk sign-up for Pro/API)
 - [Support & Contact](https://worldmonitor.app/support.md): Support channels, contact emails, status page, response expectations

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -192,4 +192,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://www.worldmonitor.app/blog/glossary/</loc>
+    <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/tests/glossary-data.test.mjs
+++ b/tests/glossary-data.test.mjs
@@ -69,6 +69,29 @@ describe('glossary data integrity', () => {
     }
   });
 
+  it('states the current CRI contract, not the stale April-snapshot figures (#4968 review)', () => {
+    // The first draft sourced from docs/snapshots/resilience-ranking-2026-04-21
+    // (a dated claim artifact) and shipped 19 dimensions + a 0.4 grey-out gate.
+    // The live contract (server/.../resilience/v1/_shared.ts + methodology doc)
+    // is 20 active dimensions, a 0.55 low-confidence coverage gate, and a
+    // pillar-combined penalized formula. Pin it so the stale figures can't
+    // return unnoticed.
+    const cov = GLOSSARY_TERMS.find((t) => t.slug === 'dimension-coverage');
+    const cri = GLOSSARY_TERMS.find((t) => t.slug === 'country-resilience-index');
+    assert.ok(cov && cri, 'CRI + dimension-coverage terms must exist');
+    const covBlob = [cov.short, ...cov.body].join(' ');
+    const criBlob = [cri.short, ...cri.body].join(' ');
+
+    assert.match(covBlob, /\b20\b/, 'dimension-coverage must state 20 active dimensions');
+    assert.match(covBlob, /0\.55/, 'dimension-coverage must state the 0.55 low-confidence gate');
+    assert.doesNotMatch(covBlob, /\b19 per-dimension/, 'stale 19-dimension figure must not return');
+    assert.doesNotMatch(covBlob, /falls below 0\.4\b/, 'stale 0.4 grey-out gate must not return');
+
+    assert.match(criBlob, /196/, 'CRI must state the 196-country rankable universe');
+    assert.doesNotMatch(criBlob, /aggregate of six domains/, 'CRI must describe the pillar-combined formula, not the retired flat aggregate as live');
+    assert.doesNotMatch(criBlob, /out of about 217/, 'stale "196 of 217" framing must not return');
+  });
+
   it('claims no forecast-calibration capability that does not exist (#4930)', () => {
     // No Brier/resolution/calibration scoring exists yet; the glossary must
     // not imply WorldMonitor computes it. "prediction market" is fine.

--- a/tests/glossary-data.test.mjs
+++ b/tests/glossary-data.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { GLOSSARY_TERMS, GLOSSARY_CATEGORIES } from '../blog-site/src/data/glossary.ts';
+
+// The glossary (#4960) renders one crawlable DefinedTerm page per entry under
+// /blog/glossary. These guards keep the data self-consistent (every related
+// slug resolves, every category is real) so the Astro getStaticPaths fan-out
+// and the DefinedTermSet JSON-LD never point at a 404, and enforce the
+// no-invented-capabilities rule that applies to every agent-facing surface.
+
+describe('glossary data integrity', () => {
+  const slugs = GLOSSARY_TERMS.map((t) => t.slug);
+  const slugSet = new Set(slugs);
+
+  it('has a non-trivial number of terms', () => {
+    assert.ok(GLOSSARY_TERMS.length >= 15, `expected >= 15 terms, got ${GLOSSARY_TERMS.length}`);
+  });
+
+  it('every slug is unique and URL-safe', () => {
+    assert.equal(slugSet.size, slugs.length, 'duplicate slug(s) present');
+    for (const slug of slugs) {
+      assert.match(slug, /^[a-z0-9]+(?:-[a-z0-9]+)*$/, `slug not URL-safe: ${slug}`);
+    }
+  });
+
+  it('every term carries the required fields', () => {
+    for (const t of GLOSSARY_TERMS) {
+      assert.ok(t.term && typeof t.term === 'string', `missing term for ${t.slug}`);
+      assert.ok(t.short && t.short.length >= 40, `short definition too thin for ${t.slug}`);
+      assert.ok(Array.isArray(t.body) && t.body.length >= 1, `missing body for ${t.slug}`);
+      assert.ok(Array.isArray(t.related), `related must be an array for ${t.slug}`);
+    }
+  });
+
+  it('the short definition restates the term (answer-block shape)', () => {
+    // AEO/citation surfaces read the first sentence as a standalone answer;
+    // it should name the thing it defines, not open with a pronoun.
+    for (const t of GLOSSARY_TERMS) {
+      const needle = (t.abbr || t.term.split(' ')[0]).toLowerCase();
+      assert.ok(
+        t.short.toLowerCase().includes(needle),
+        `short definition for ${t.slug} should name the term (looked for "${needle}")`
+      );
+    }
+  });
+
+  it('every category is one of the declared categories', () => {
+    const valid = new Set(GLOSSARY_CATEGORIES);
+    for (const t of GLOSSARY_TERMS) {
+      assert.ok(valid.has(t.category), `unknown category "${t.category}" on ${t.slug}`);
+    }
+  });
+
+  it('every related slug resolves to another term', () => {
+    for (const t of GLOSSARY_TERMS) {
+      for (const rel of t.related) {
+        assert.ok(slugSet.has(rel), `${t.slug} references unknown related slug "${rel}"`);
+        assert.notEqual(rel, t.slug, `${t.slug} lists itself as related`);
+      }
+    }
+  });
+
+  it('learnMore links are absolute https URLs', () => {
+    for (const t of GLOSSARY_TERMS) {
+      for (const link of t.learnMore ?? []) {
+        assert.ok(link.label, `learnMore link missing label on ${t.slug}`);
+        assert.match(link.href, /^https:\/\//, `learnMore href not absolute https on ${t.slug}: ${link.href}`);
+      }
+    }
+  });
+
+  it('claims no forecast-calibration capability that does not exist (#4930)', () => {
+    // No Brier/resolution/calibration scoring exists yet; the glossary must
+    // not imply WorldMonitor computes it. "prediction market" is fine.
+    const forbidden = /\bbrier\b|\bcalibration score|\bresolution score|\bwe (?:compute|calculate|score) (?:brier|calibration)/i;
+    for (const t of GLOSSARY_TERMS) {
+      const blob = [t.short, ...t.body].join(' ');
+      assert.ok(!forbidden.test(blob), `${t.slug} implies a forecast-calibration capability that does not exist yet`);
+    }
+  });
+});


### PR DESCRIPTION
## What

First tranche of the content-corpus work (#4960). The dashboard is a WebGL SPA that yields nothing to a crawler, so the moat — CII/CRI scoring, geographic convergence, chokepoints, OSINT methodology — has been invisible to search and to LLM citation corpora. This adds a static, crawlable **glossary** under the existing Astro blog pipeline.

- **`/blog/glossary`** — index grouped into four categories, `DefinedTermSet` JSON-LD
- **`/blog/glossary/<term>`** — 20 per-term pages, each an answer-block definition ("X is …"), cross-links, and `DefinedTerm` + `BreadcrumbList` + `FAQPage` JSON-LD
- Grows the crawlable sitemap from ~32 to ~53 URLs

### Why under `/blog/`

Hosting under the existing Astro base means it inherits `@astrojs/sitemap`, the deploy-time build+copy, and the existing SPA catch-all carve-out — **no `vercel.json` / catch-all / test-mirror changes**, which is the risky coupling I deliberately avoided.

### Sourcing discipline

Every definition is sourced from WorldMonitor's own methodology docs (CII, CRI, hotspots, infrastructure-cascade, maritime-intelligence, ai-intelligence) — **all `learnMore` doc links and blog links verified 200 on prod**, nothing invented. Per #4930 (no Brier/resolution exists yet) the glossary makes **no forecast-calibration claim** — enforced by a test guard.

## Files

- `blog-site/src/data/glossary.ts` — 20 terms × 4 categories (pure TS, no `astro:` imports, so the main suite imports + validates it)
- `blog-site/src/pages/glossary/{index,[slug]}.astro` — index + `getStaticPaths` fan-out
- `blog-site/src/layouts/Base.astro` — Glossary nav link
- `public/llms.txt` — glossary in the Documentation section; `public/sitemap.xml` — index entry
- `tests/glossary-data.test.mjs` — slug uniqueness/URL-safety, related-slug resolution, answer-block shape, no-invented-capability guard (8 tests)

## Verification

- `npx astro build` → 61 pages, 20 glossary term pages + index all emitted, all in `/blog/sitemap-index.xml`; verified `DefinedTerm`/`DefinedTermSet`/`BreadcrumbList`/`FAQPage` in the rendered HTML
- `npx tsx --test tests/deploy-config.test.mjs tests/glossary-data.test.mjs` → 124/124
- All doc/blog cross-links checked 200 on prod

## Follow-ups on #4960 (not in this PR)

- Chokepoint pages (static, same pattern)
- ~196 country risk/resilience pages — need a CI-freeze-with-key data pipeline (the resilience API is 401 anonymous, so the build cannot fetch prod directly)

Part of #4960

https://claude.ai/code/session_014bmm7eUWr3BM8iyaSRDcbq