### PR TITLE
fix(forecast): non-finite probability guards — NaN can no longer enter or anchor the probability spine (#4933)

### DIFF
--- a/scripts/_prediction-scoring.mjs
+++ b/scripts/_prediction-scoring.mjs
@@ -46,11 +46,33 @@ export function parseYesPrice(market) {
 
 // Kalshi mirror of parseYesPrice: null for unreadable prices — a fabricated
 // default (e.g. 50) would flow downstream as a finite anchor and calibrate
-// forecasts against invented data.
+// forecasts against invented data. Whole-string validation: parseFloat would
+// accept malformed prefixes ('0.62oops' → 0.62, '0,62' → 0).
 export function parseKalshiYesPrice(market) {
-  const p = parseFloat(market?.last_price_dollars);
+  const raw = market?.last_price_dollars;
+  const str = typeof raw === 'number' ? raw : String(raw ?? '').trim();
+  const p = str === '' ? NaN : Number(str);
   if (!Number.isFinite(p) || p < 0 || p > 1) return null;
   return +(p * 100).toFixed(1);
+}
+
+// Pick the highest-volume PRICED market of a Kalshi event; an unpriced
+// top-volume market must not sink the whole event when a priced sibling exists.
+export function selectPricedKalshiMarket(markets) {
+  let best = null;
+  let bestPrice = null;
+  let bestVol = -1;
+  for (const m of markets || []) {
+    const price = parseKalshiYesPrice(m);
+    if (price === null) continue;
+    const vol = parseFloat(m.volume_fp) || 0;
+    if (vol > bestVol) {
+      best = m;
+      bestVol = vol;
+      bestPrice = price;
+    }
+  }
+  return best ? { market: best, yesPrice: bestPrice } : null;
 }
 
 export function shouldInclude(m, relaxed = false) {

--- a/scripts/_prediction-scoring.mjs
+++ b/scripts/_prediction-scoring.mjs
@@ -44,6 +44,15 @@ export function parseYesPrice(market) {
   return null;
 }
 
+// Kalshi mirror of parseYesPrice: null for unreadable prices — a fabricated
+// default (e.g. 50) would flow downstream as a finite anchor and calibrate
+// forecasts against invented data.
+export function parseKalshiYesPrice(market) {
+  const p = parseFloat(market?.last_price_dollars);
+  if (!Number.isFinite(p) || p < 0 || p > 1) return null;
+  return +(p * 100).toFixed(1);
+}
+
 export function shouldInclude(m, relaxed = false) {
   const minPrice = relaxed ? 5 : 10;
   const maxPrice = relaxed ? 95 : 90;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -920,8 +920,8 @@ function makePrediction(domain, region, title, probability, confidence, timeHori
     title,
     scenario: '',
     feedSummary: '',
-    probability: Math.round(Math.max(0, Math.min(1, probability)) * 1000) / 1000,
-    confidence: Math.round(Math.max(0, Math.min(1, confidence)) * 1000) / 1000,
+    probability: Math.round(Math.max(0, Math.min(1, Number.isFinite(probability) ? probability : 0)) * 1000) / 1000,
+    confidence: Math.round(Math.max(0, Math.min(1, Number.isFinite(confidence) ? confidence : 0)) * 1000) / 1000,
     timeHorizon,
     signals,
     cascades: [],
@@ -2189,7 +2189,8 @@ function detectFromPredictionMarkets(inputs) {
   const markets = inputs.predictionMarkets?.geopolitical || [];
 
   for (const m of markets) {
-    const yesPrice = (m.yesPrice || 50) / 100;
+    if (!Number.isFinite(m?.yesPrice)) continue;
+    const yesPrice = m.yesPrice / 100;
     if (yesPrice < 0.6 || yesPrice > 0.9) continue;
     const tags = tagRegions(m.title);
     if (tags.length === 0) continue;
@@ -2360,6 +2361,7 @@ function calibrateWithMarkets(predictions, markets) {
         return { market: m, sameMacroRegion, ...match };
       })
       .filter(item => {
+        if (!Number.isFinite(item.market.yesPrice)) return false; // a price-less anchor would blend toward a fabricated 50%
         if (item.tagMismatch && item.regionHits === 0) return false;
         const hasSpecificRegionSignal = item.regionHits > 0 || item.tagOverlap;
         const hasSemanticOverlap = item.titleHits > 0 || item.domainHits > 0;
@@ -2375,7 +2377,7 @@ function calibrateWithMarkets(predictions, markets) {
     const best = candidates[0];
     const match = best?.market || null;
     if (match) {
-      const marketProb = (match.yesPrice || 50) / 100;
+      const marketProb = match.yesPrice / 100;
       pred.calibration = {
         marketTitle: match.title,
         marketPrice: +marketProb.toFixed(3),

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -2,7 +2,7 @@
 
 import { loadEnvFile, CHROME_UA, sleep, runSeed } from './_seed-utils.mjs';
 import {
-  isExcluded, isMemeCandidate, tagRegions, parseYesPrice, parseKalshiYesPrice,
+  isExcluded, isMemeCandidate, tagRegions, parseYesPrice, selectPricedKalshiMarket,
   shouldInclude, scoreMarket, filterAndScore, isExpired,
 } from './_prediction-scoring.mjs';
 import predictionTags from './data/prediction-tags.json' with { type: 'json' };
@@ -89,17 +89,12 @@ async function fetchKalshiMarkets() {
     );
     if (binaryActive.length === 0) continue;
 
-    const topMarket = binaryActive.reduce((best, m) => {
-      const vol = parseFloat(m.volume_fp) || 0;
-      const bestVol = parseFloat(best.volume_fp) || 0;
-      return vol > bestVol ? m : best;
-    });
+    const selected = selectPricedKalshiMarket(binaryActive);
+    if (!selected) continue;
+    const { market: topMarket, yesPrice } = selected;
 
     const volume = parseFloat(topMarket.volume_fp) || 0;
     if (volume <= 5000) continue;
-
-    const yesPrice = parseKalshiYesPrice(topMarket);
-    if (yesPrice === null) continue;
 
     const marketTitle = topMarket.yes_sub_title || topMarket.title || '';
     const title = kalshiTitle(marketTitle, event.title);

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -2,7 +2,7 @@
 
 import { loadEnvFile, CHROME_UA, sleep, runSeed } from './_seed-utils.mjs';
 import {
-  isExcluded, isMemeCandidate, tagRegions, parseYesPrice,
+  isExcluded, isMemeCandidate, tagRegions, parseYesPrice, parseKalshiYesPrice,
   shouldInclude, scoreMarket, filterAndScore, isExpired,
 } from './_prediction-scoring.mjs';
 import predictionTags from './data/prediction-tags.json' with { type: 'json' };
@@ -98,8 +98,8 @@ async function fetchKalshiMarkets() {
     const volume = parseFloat(topMarket.volume_fp) || 0;
     if (volume <= 5000) continue;
 
-    const rawPrice = parseFloat(topMarket.last_price_dollars);
-    const yesPrice = Number.isFinite(rawPrice) ? +(rawPrice * 100).toFixed(1) : 50;
+    const yesPrice = parseKalshiYesPrice(topMarket);
+    if (yesPrice === null) continue;
 
     const marketTitle = topMarket.yes_sub_title || topMarket.title || '';
     const title = kalshiTitle(marketTitle, event.title);

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -542,6 +542,48 @@ describe('word-boundary term matching: no substring false positives (#4933)', ()
   });
 });
 
+describe('non-finite probability guards (#4933)', () => {
+  it('makePrediction: NaN probability is coerced to a finite value, never serialized as null', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Test', NaN, 0.5, '7d', []);
+    assert.ok(Number.isFinite(pred.probability), `probability is ${pred.probability}`);
+    assert.equal(JSON.parse(JSON.stringify(pred)).probability, pred.probability);
+  });
+
+  it('makePrediction: undefined probability and NaN confidence are coerced to finite values', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Test', undefined, NaN, '7d', []);
+    assert.ok(Number.isFinite(pred.probability));
+    assert.ok(Number.isFinite(pred.confidence));
+  });
+
+  it('detectFromPredictionMarkets: non-numeric yesPrice row is skipped, not published with NaN', () => {
+    const preds = detectFromPredictionMarkets({
+      predictionMarkets: {
+        geopolitical: [{ title: 'Will Iran attack escalate in 2026?', yesPrice: 'oops', source: 'polymarket' }],
+      },
+    });
+    assert.equal(preds.length, 0);
+  });
+
+  it('detectFromPredictionMarkets: finite yesPrice in band still emits (positive control)', () => {
+    const preds = detectFromPredictionMarkets({
+      predictionMarkets: {
+        geopolitical: [{ title: 'Will Iran attack escalate in 2026?', yesPrice: 75, source: 'polymarket' }],
+      },
+    });
+    assert.equal(preds.length, 1);
+    assert.equal(preds[0].probability, 0.75);
+  });
+
+  it('calibrateWithMarkets: matching market with a non-finite price is skipped, not anchored at 50%', () => {
+    const pred = makePrediction('conflict', 'Middle East', 'Escalation', 0.7, 0.6, '7d', []);
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.7);
+  });
+});
+
 describe('computeTrends', () => {
   it('no prior: all trends set to stable', () => {
     const pred = makePrediction('conflict', 'Iran', 'Test', 0.6, 0.5, '7d', []);

--- a/tests/prediction-scoring.test.mjs
+++ b/tests/prediction-scoring.test.mjs
@@ -7,6 +7,7 @@ import {
   tagRegions,
   parseYesPrice,
   parseKalshiYesPrice,
+  selectPricedKalshiMarket,
   shouldInclude,
   scoreMarket,
   filterAndScore,
@@ -40,6 +41,44 @@ describe('parseKalshiYesPrice', () => {
 
   it('keeps a genuine zero price (filtered downstream, not fabricated)', () => {
     assert.equal(parseKalshiYesPrice({ last_price_dollars: '0' }), 0);
+  });
+
+  it('rejects malformed numeric prefixes (whole-string validation)', () => {
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: '0.62oops' }), null);
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: '0,62' }), null);
+  });
+
+  it('accepts plain numbers and whitespace-padded numeric strings', () => {
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: 0.62 }), 62);
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: ' 0.62 ' }), 62);
+  });
+});
+
+describe('selectPricedKalshiMarket', () => {
+  it('falls back to a lower-volume priced sibling when the top-volume market is unpriced', () => {
+    const result = selectPricedKalshiMarket([
+      { ticker: 'HIGH', volume_fp: '10000' },
+      { ticker: 'VALID', volume_fp: '6000', last_price_dollars: '0.64' },
+    ]);
+    assert.equal(result.market.ticker, 'VALID');
+    assert.equal(result.yesPrice, 64);
+  });
+
+  it('picks the highest-volume market among priced ones', () => {
+    const result = selectPricedKalshiMarket([
+      { ticker: 'A', volume_fp: '6000', last_price_dollars: '0.30' },
+      { ticker: 'B', volume_fp: '9000', last_price_dollars: '0.70' },
+    ]);
+    assert.equal(result.market.ticker, 'B');
+    assert.equal(result.yesPrice, 70);
+  });
+
+  it('returns null when no market has a readable price', () => {
+    assert.equal(selectPricedKalshiMarket([
+      { ticker: 'A', volume_fp: '10000' },
+      { ticker: 'B', volume_fp: '9000', last_price_dollars: 'oops' },
+    ]), null);
+    assert.equal(selectPricedKalshiMarket([]), null);
   });
 });
 

--- a/tests/prediction-scoring.test.mjs
+++ b/tests/prediction-scoring.test.mjs
@@ -6,6 +6,7 @@ import {
   isMemeCandidate,
   tagRegions,
   parseYesPrice,
+  parseKalshiYesPrice,
   shouldInclude,
   scoreMarket,
   filterAndScore,
@@ -18,6 +19,29 @@ import {
 function market(title, yesPrice, volume, opts = {}) {
   return { title, yesPrice, volume, ...opts };
 }
+
+describe('parseKalshiYesPrice', () => {
+  it('converts 0-1 dollar scale to 0-100', () => {
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: '0.62' }), 62);
+  });
+
+  it('returns null for a missing price instead of fabricating 50', () => {
+    assert.equal(parseKalshiYesPrice({}), null);
+  });
+
+  it('returns null for a non-numeric price instead of fabricating 50', () => {
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: 'oops' }), null);
+  });
+
+  it('returns null for out-of-range prices', () => {
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: '1.50' }), null);
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: '-0.10' }), null);
+  });
+
+  it('keeps a genuine zero price (filtered downstream, not fabricated)', () => {
+    assert.equal(parseKalshiYesPrice({ last_price_dollars: '0' }), 0);
+  });
+});
 
 describe('parseYesPrice', () => {
   it('converts 0-1 scale to 0-100', () => {


### PR DESCRIPTION
## What

PR-B of the #4933 hardening batch (MEDIUM audit finding): three sites let a malformed Redis market row inject NaN into the probability spine or anchor the market blend at a fabricated 50%.

| Site | Before | After |
|---|---|---|
| `makePrediction` | NaN/undefined probability survived the clamp chain as NaN → serialized `null` → forecast silently vanished at the publish filter | coerced to 0 (finite, deterministic) |
| `detectFromPredictionMarkets` | `('oops'\|\|50)/100 = NaN` passed the band gate (NaN comparisons are false) → null-probability forecast emitted | non-finite `yesPrice` row skipped |
| `calibrateWithMarkets` | matching market without a price anchored the 0.4/0.6 blend at 50% | price-less markets excluded from candidates; second-best priced market can still match |

## Tests

Bug-fix protocol: 5 tests written first, 4 confirmed RED (NaN coercion ×2, NaN-emit skip, 50%-anchor skip), 1 positive control (finite in-band price still emits at 0.75).

- forecast-detectors 219/219 · trace-export 310/310 · history/integrity/resilience/narrative/ticker/telemetry suites green · evaluate-forecast-benchmark 6/6

Part of #4933 (fix 2 of 3 P1/MEDIUM prerequisites for #4930). Branched off main AFTER #4939 merged — no stack.

https://claude.ai/code/session_01XhvRdRjkLqtkRBZi9ZYAu2