### PR TITLE
fix(forecast): stable semantic-slot ids for military and state-derived forecasts (#4933)

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -825,6 +825,18 @@ function forecastId(domain, region, title) {
   return `fc-${domain}-${hash}`;
 }
 
+// Stable id for forecasts whose titles embed run-varying data (military
+// dominantCountry/surgeType, state-derived cluster labels). The id must key
+// on the semantic slot, not the display title, or the same evolving
+// situation splits across ids between runs — breaking trend continuity and
+// outcome matching.
+function forecastIdFromKey(domain, slotKey) {
+  const hash = crypto.createHash('sha256')
+    .update(`${domain}:${slotKey}`)
+    .digest('hex').slice(0, 8);
+  return `fc-${domain}-${hash}`;
+}
+
 function normalize(value, min, max) {
   if (max <= min) return 0;
   return Math.max(0, Math.min(1, (value - min) / (max - min)));
@@ -1452,6 +1464,7 @@ function buildStateDerivedForecast(stateUnit, domain, bucket, candidate, marketC
     domain === 'supply_chain' ? '7d' : '30d',
     signals,
   );
+  prediction.id = forecastIdFromKey(domain, `state:${bucket.id}:${stateUnit?.dominantRegion || stateUnit?.regions?.[0] || ''}`);
   prediction.generationOrigin = 'state_derived';
   prediction.feedSummary = buildStateDerivedFeedSummary(
     domain,
@@ -1604,10 +1617,18 @@ function deriveStateDrivenForecasts({
     }
   }
 
+  // Slot ids make same (domain, bucket, dominantRegion) forecasts share an id
+  // regardless of cluster label — keep only the best-ranked one per id.
+  const seenSlotIds = new Set();
   return crossDeduped
     .sort((a, b) => (Number(a.stateDerivedBackfill) - Number(b.stateDerivedBackfill))
       || (b.probability * b.confidence) - (a.probability * a.confidence)
-      || a.title.localeCompare(b.title));
+      || a.title.localeCompare(b.title))
+    .filter((pred) => {
+      if (seenSlotIds.has(pred.id)) return false;
+      seenSlotIds.add(pred.id);
+      return true;
+    });
 }
 
 function detectPoliticalScenarios(inputs) {
@@ -1787,11 +1808,13 @@ function detectMilitaryScenarios(inputs) {
       ? buildMilitaryForecastTitle(theaterId, theaterLabel, highestSurge)
       : `Military posture escalation: ${region}`;
 
-    predictions.push(makePrediction(
+    const milPred = makePrediction(
       'military', region,
       title,
       prob, confidence, '7d', signals,
-    ));
+    );
+    milPred.id = forecastIdFromKey('military', `theater:${theaterId}`);
+    predictions.push(milPred);
   }
 
   return predictions;
@@ -17665,6 +17688,8 @@ export {
   PRIOR_KEY,
   HISTORY_KEY,
   HISTORY_MAX_RUNS,
+  forecastIdFromKey,
+  buildStateDerivedForecast,
   HISTORY_MAX_FORECASTS,
   TRACE_LATEST_KEY,
   TRACE_RUNS_KEY,

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -1464,7 +1464,11 @@ function buildStateDerivedForecast(stateUnit, domain, bucket, candidate, marketC
     domain === 'supply_chain' ? '7d' : '30d',
     signals,
   );
-  prediction.id = forecastIdFromKey(domain, `state:${bucket.id}:${stateUnit?.dominantRegion || stateUnit?.regions?.[0] || ''}`);
+  // Key on the canonical state-unit identity (content hash over structural
+  // fields, NOT the display label) plus bucket: label churn no longer moves
+  // the id, while two distinct same-region/same-bucket units keep distinct
+  // ids — the cross-state dedup intentionally publishes up to 2 such bets.
+  prediction.id = forecastIdFromKey(domain, `state:${bucket.id}:${stateUnit?.id || stateUnit?.dominantRegion || stateUnit?.regions?.[0] || ''}`);
   prediction.generationOrigin = 'state_derived';
   prediction.feedSummary = buildStateDerivedFeedSummary(
     domain,

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -3,6 +3,8 @@ import { afterEach, describe, it } from 'node:test';
 
 import {
   forecastId,
+  forecastIdFromKey,
+  buildStateDerivedForecast,
   normalize,
   makePrediction,
   resolveCascades,
@@ -3154,4 +3156,74 @@ describe('forecast quality gating', () => {
     assert.ok(worldState.situationClusters.every((cluster) => !/fc-[a-z]+-[0-9a-f]{8}/.test(cluster.label)));
   });
 
+});
+
+describe('stable forecast ids: semantic slots, not volatile titles (#4933)', () => {
+  const now = Date.now();
+  const milInputs = (country, type) => ({
+    militaryForecastInputs: {
+      fetchedAt: now,
+      theaters: [{ id: 'iran-theater', postureLevel: 'elevated', assessedAt: now }],
+      surges: [{
+        theaterId: 'iran-theater', surgeType: type, dominantCountry: country,
+        fighters: 5, strikeCapable: true, persistent: true, surgeMultiple: 4, assessedAt: now,
+      }],
+    },
+    temporalAnomalies: [],
+  });
+
+  it('military id is stable across surge-type and country changes in the same theater', () => {
+    const a = detectMilitaryScenarios(milInputs('US', 'fighter'));
+    const b = detectMilitaryScenarios(milInputs('Israel', 'airlift'));
+    assert.equal(a.length, 1);
+    assert.equal(b.length, 1);
+    assert.notEqual(a[0].title, b[0].title);
+    assert.equal(a[0].id, b[0].id);
+  });
+
+  it('military ids differ across theaters', () => {
+    const preds = detectMilitaryScenarios({
+      militaryForecastInputs: {
+        fetchedAt: now,
+        theaters: [
+          { id: 'iran-theater', postureLevel: 'elevated', assessedAt: now },
+          { id: 'taiwan-theater', postureLevel: 'elevated', assessedAt: now },
+        ],
+        surges: [],
+      },
+      temporalAnomalies: [],
+    });
+    assert.equal(preds.length, 2);
+    assert.notEqual(preds[0].id, preds[1].id);
+  });
+
+  it('trend continuity survives a military title change', () => {
+    const a = detectMilitaryScenarios(milInputs('US', 'fighter'));
+    const b = detectMilitaryScenarios(milInputs('Israel', 'airlift'));
+    const priorSnap = buildPriorForecastSnapshot({ ...a[0], probability: 0.1 });
+    computeTrends(b, { predictions: [priorSnap] });
+    assert.equal(b[0].trend, 'rising');
+    assert.equal(b[0].priorProbability, 0.1);
+  });
+
+  it('state-derived id keys on domain+bucket+dominantRegion, not the volatile cluster label', () => {
+    const mkUnit = (label) => ({
+      id: `state-${label}`, label, stateKind: 'market_stress',
+      dominantRegion: 'Middle East', regions: ['Middle East'],
+      avgProbability: 0.5, avgConfidence: 0.5,
+      situationCount: 2, forecastCount: 3,
+    });
+    const bucket = { id: 'energy', label: 'Energy', pressureScore: 0.6, confidence: 0.5 };
+    const candidate = { score: 0.6, criticalLift: 0, primarySignalType: 'energy_supply_shock', primaryChannel: 'energy' };
+    const a = buildStateDerivedForecast(mkUnit('Hormuz pressure complex'), 'market', bucket, candidate, null);
+    const b = buildStateDerivedForecast(mkUnit('Gulf energy stress cluster'), 'market', bucket, candidate, null);
+    assert.notEqual(a.title, b.title);
+    assert.equal(a.id, b.id);
+  });
+
+  it('forecastIdFromKey is deterministic, domain-scoped, and keeps the fc-<domain>-<8hex> format', () => {
+    assert.equal(forecastIdFromKey('military', 'theater:iran-theater'), forecastIdFromKey('military', 'theater:iran-theater'));
+    assert.notEqual(forecastIdFromKey('military', 'theater:iran-theater'), forecastIdFromKey('conflict', 'theater:iran-theater'));
+    assert.match(forecastIdFromKey('military', 'theater:iran-theater'), /^fc-military-[0-9a-f]{8}$/);
+  });
 });

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -3206,9 +3206,9 @@ describe('stable forecast ids: semantic slots, not volatile titles (#4933)', () 
     assert.equal(b[0].priorProbability, 0.1);
   });
 
-  it('state-derived id keys on domain+bucket+dominantRegion, not the volatile cluster label', () => {
+  it('state-derived id keys on the stable state-unit identity, not the volatile cluster label', () => {
     const mkUnit = (label) => ({
-      id: `state-${label}`, label, stateKind: 'market_stress',
+      id: 'state-abc123', label, stateKind: 'market_stress',
       dominantRegion: 'Middle East', regions: ['Middle East'],
       avgProbability: 0.5, avgConfidence: 0.5,
       situationCount: 2, forecastCount: 3,
@@ -3219,6 +3219,20 @@ describe('stable forecast ids: semantic slots, not volatile titles (#4933)', () 
     const b = buildStateDerivedForecast(mkUnit('Gulf energy stress cluster'), 'market', bucket, candidate, null);
     assert.notEqual(a.title, b.title);
     assert.equal(a.id, b.id);
+  });
+
+  it('two DISTINCT state units in the same region+bucket keep distinct ids (no slot collapse)', () => {
+    const mkUnit = (id, label) => ({
+      id, label, stateKind: 'market_stress',
+      dominantRegion: 'Middle East', regions: ['Middle East'],
+      avgProbability: 0.5, avgConfidence: 0.5,
+      situationCount: 2, forecastCount: 3,
+    });
+    const bucket = { id: 'energy', label: 'Energy', pressureScore: 0.6, confidence: 0.5 };
+    const candidate = { score: 0.6, criticalLift: 0, primarySignalType: 'energy_supply_shock', primaryChannel: 'energy' };
+    const a = buildStateDerivedForecast(mkUnit('state-hormuz1', 'Hormuz pressure complex'), 'market', bucket, candidate, null);
+    const b = buildStateDerivedForecast(mkUnit('state-redsea2', 'Red Sea freight stress'), 'market', bucket, candidate, null);
+    assert.notEqual(a.id, b.id);
   });
 
   it('forecastIdFromKey is deterministic, domain-scoped, and keeps the fc-<domain>-<8hex> format', () => {


### PR DESCRIPTION
## What

PR-C of the #4933 hardening batch — the last P1 prerequisite for the #4930 resolver clock. Forecast ids hash the title (`forecastId = fc-<domain>-sha256(domain:region:title)[0:8]`), and two title builders embed run-varying data:

- military titles carry `dominantCountry` + `surgeType` ("US-linked fighter surge…" → "Israel-linked airlift surge…" for the same theater)
- state-derived titles carry the data-driven cluster label

So the same evolving situation split across ids between runs: `computeTrends` found no prior (trend reset to 'stable' on every flip), benchmark candidate extraction couldn't match snapshots, and the future outcome resolver would fragment one situation across ids.

## How (design approved: semantic-slot ids)

New `forecastIdFromKey(domain, slotKey)`:
- **military** → `theater:<theaterId>` (fixed registry key; one identity per theater)
- **state-derived** → `state:<bucketId>:<dominantRegion>`

Titles stay rich and display-only. `deriveStateDrivenForecasts` now dedupes by slot id after ranking, so two cluster labels landing in the same slot keep only the best-ranked forecast (this hazard was audit finding #6 — slot ids made it likelier, so the guard ships in the same PR). All other detector families keep title-derived ids: their titles are static templates over stable identifiers.

**Migration**: one-run trend reset for these two families only. They churn every few runs today (that's the bug), so no durable continuity is lost.

## Tests

5 RED-first tests: title-varies-id-stable (same theater across surge changes), per-theater uniqueness, cross-run trend continuity through a title change (`rising` computed against the prior, not reset), state-derived label-independence, id format/determinism/domain-scoping.

- forecast-detectors 224/224 · trace-export 310/310 · history/integrity/resilience/narrative/ticker/telemetry/prediction-scoring suites green · evaluate-forecast-benchmark 6/6

Part of #4933 (fix 3 of 3 P1 prerequisites for #4930). Branched off main after #4969 merged — no stack.

https://claude.ai/code/session_01XhvRdRjkLqtkRBZi9ZYAu2