### PR TITLE
fix(forecast): stop false SEED_ERROR when market_implications is starved of the shared LLM run budget (#4978)

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14524,9 +14524,8 @@ function getRemainingForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
   const stageRemaining = budgetStartedAtMs + stageBudgetMs - Date.now();
   // The run deadline (when set) caps cumulative LLM time across all stages so
   // the seed can't outlive its 180s lock; whichever budget is tighter wins.
-  const runRemaining = forecastLlmRunDeadlineMs == null
-    ? Infinity
-    : forecastLlmRunDeadlineMs - Date.now();
+  // Single source of truth for run-remaining lives in getRemainingForecastLlmRunBudgetMs.
+  const runRemaining = getRemainingForecastLlmRunBudgetMs();
   return Math.max(0, Math.min(stageRemaining, runRemaining));
 }
 
@@ -14615,6 +14614,16 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
   const llmMaxTokens = options.maxTokens || 1500;
   const llmEvents = [];
   let llmAttemptIndex = 0;
+  // Failure-reason classification invariant (#4978): callForecastLLM returns
+  // FORECAST_LLM_FAILURE_BUDGET_EXHAUSTED (a benign starve — the market_implications
+  // caller preserves last-good and writes NO SEED_ERROR) ONLY when the sole cause
+  // was the shared run budget draining (a pre-call/pre-fetch budget pre-emption, or
+  // a budget-CAPPED timeout that never gave the provider its full window). Every
+  // GENUINE provider-failure branch below (HTTP error, invalid/empty response, fetch
+  // error, or a timeout that got the provider's full window) MUST set
+  // `sawProviderFailure = true` so the result is FORECAST_LLM_FAILURE_PROVIDER_FAILED
+  // and /api/health surfaces SEED_ERROR. A new provider-failure branch that forgets
+  // to set this flag would silently misreport a real outage as a benign starve.
   let sawProviderFailure = false;
   let sawBudgetCappedTimeout = false;
   const recordLlmAttempt = (providerName, model, ok, startedAtMs, extra = {}) => {
@@ -14688,6 +14697,14 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
               err.__llmAttemptRecorded = true;
               const name = err?.name;
               const timedOut = name === 'TimeoutError' || name === 'AbortError';
+              // Attribute a timeout to the run budget (not the provider) ONLY when
+              // this attempt's timeout was itself CAPPED below the provider's own
+              // timeout (attemptTimeoutMs < provider.timeout) AND the run budget is
+              // now exhausted — i.e. we never gave the provider its full window, so
+              // we cannot call this a provider failure. When the call gets the full
+              // provider.timeout (the MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS >= 30s
+              // guard guarantees this for admitted market_implications calls), a
+              // timeout is unambiguously a provider failure -> sawProviderFailure.
               const budgetCappedTimeout = timedOut
                 && attemptTimeoutMs < provider.timeout
                 && getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) <= 0;
@@ -16415,12 +16432,18 @@ const MARKET_IMPLICATIONS_META_TTL = 86400 * 7;
 // fingerprint is not model-sensitive, so retire old-model rows explicitly.
 const MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX = 'forecast:llm-market-implications:v2:';
 
-// A market_implications completion needs ~20s wall-clock (observed 2026-07-06).
-// When the shared run budget (#4978) is below this as the tail stage begins, the
-// call would be aborted by the budget-capped timeout and then misreported as a
-// SEED_ERROR — so skip gracefully and preserve last-good instead of attempting a
-// doomed call. Tunable: raise it if 20s calls still start and time out.
-const MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS = 20_000;
+// A market_implications completion needs ~20s wall-clock (observed 2026-07-06),
+// and the primary provider (openrouter deepseek-v4-flash) has a 25s call timeout.
+// Admit the tail stage only when the shared run budget (#4978) still covers the
+// FULL provider timeout PLUS the 5s stage guard that getUsableForecastLlmBudgetMs
+// subtracts (25_000 + 5_000 = 30_000). Below that, an admitted call is timeout-
+// CAPPED below the provider's own timeout, which is indistinguishable from a
+// genuinely hung provider — so it would either waste a doomed request (needs
+// ~20s, gets <20s) OR misreport a real provider timeout as a benign starve and
+// suppress a legitimate SEED_ERROR. Skipping instead preserves last-good honestly
+// (age-based STALE_SEED still escalates past 2h). Keep >= max(provider.timeout in
+// FORECAST_LLM_PROVIDERS) + FORECAST_LLM_STAGE_BUDGET_GUARD_MS.
+const MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS = 30_000;
 
 // Input-hash guard for the market_implications LLM stage (#4894). This was
 // the only forecast stage with no pre-call cache — a 2,500-token completion

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14547,6 +14547,15 @@ function isForecastLlmBudgetError(err) {
   return Boolean(err?.forecastLlmBudgetExhausted);
 }
 
+const FORECAST_LLM_FAILURE_BUDGET_EXHAUSTED = 'budget_exhausted';
+const FORECAST_LLM_FAILURE_PROVIDER_FAILED = 'provider_failed';
+
+function createForecastLlmFailureResult(options, failureReason) {
+  return options.returnFailureReason
+    ? { text: '', model: '', provider: '', failureReason }
+    : null;
+}
+
 function createForecastLlmHttpError(resp, usableBudgetMs = Infinity) {
   const err = new Error(`HTTP ${resp.status}`);
   err.status = resp.status;
@@ -14606,6 +14615,8 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
   const llmMaxTokens = options.maxTokens || 1500;
   const llmEvents = [];
   let llmAttemptIndex = 0;
+  let sawProviderFailure = false;
+  let sawBudgetCappedTimeout = false;
   const recordLlmAttempt = (providerName, model, ok, startedAtMs, extra = {}) => {
     llmEvents.push({
       _time: new Date().toISOString(),
@@ -14638,6 +14649,7 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
         const resp = await withRetry(async () => {
           const usableBudgetMs = getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs);
           if (usableBudgetMs <= 0) throw createForecastLlmBudgetError(stage, budgetStartedAtMs, stageBudgetMs);
+          const attemptTimeoutMs = Math.max(1, Math.min(provider.timeout, usableBudgetMs));
           attemptT0 = Date.now();
           try {
             const response = await forecastFetch(provider.apiUrl, {
@@ -14658,9 +14670,10 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
                 temperature: options.temperature ?? 0.3,
                 ...(provider.extraBody || {}),
               }),
-              signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usableBudgetMs))),
+              signal: AbortSignal.timeout(attemptTimeoutMs),
             });
             if (!response.ok) {
+              sawProviderFailure = true;
               recordLlmAttempt(provider.name, provider.model, false, attemptT0, { reason: `http_${response.status}` });
               const httpErr = createForecastLlmHttpError(
                 response,
@@ -14674,8 +14687,14 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
             if (!err?.__llmAttemptRecorded && !isForecastLlmBudgetError(err)) {
               err.__llmAttemptRecorded = true;
               const name = err?.name;
+              const timedOut = name === 'TimeoutError' || name === 'AbortError';
+              const budgetCappedTimeout = timedOut
+                && attemptTimeoutMs < provider.timeout
+                && getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) <= 0;
+              if (budgetCappedTimeout) sawBudgetCappedTimeout = true;
+              else sawProviderFailure = true;
               recordLlmAttempt(provider.name, provider.model, false, attemptT0, {
-                reason: name === 'TimeoutError' || name === 'AbortError' ? 'timeout' : 'fetch_error',
+                reason: timedOut ? 'timeout' : 'fetch_error',
               });
             }
             throw err;
@@ -14687,6 +14706,7 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
           json = await resp.json();
         } catch (err) {
           console.warn(`  [LLM:${stage}] ${provider.name} invalid response: ${err.message}`);
+          sawProviderFailure = true;
           recordLlmAttempt(provider.name, provider.model, false, attemptT0, { reason: 'invalid_json' });
           continue;
         }
@@ -14697,6 +14717,7 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
         };
         const text = json.choices?.[0]?.message?.content?.trim();
         if (!text || text.length < 20) {
+          sawProviderFailure = true;
           recordLlmAttempt(provider.name, provider.model, false, attemptT0, { ...tokensExtra, reason: 'empty' });
           continue;
         }
@@ -14708,10 +14729,22 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
         // All real attempts were recorded inside the retry callback; budget
         // pre-emptions never sent the prompt, so nothing to record here.
         console.warn(`  [LLM:${stage}] ${provider.name} ${err.message}`);
-        if (isForecastLlmBudgetError(err)) return null;
+        if (isForecastLlmBudgetError(err)) {
+          return createForecastLlmFailureResult(
+            options,
+            sawProviderFailure ? FORECAST_LLM_FAILURE_PROVIDER_FAILED : FORECAST_LLM_FAILURE_BUDGET_EXHAUSTED,
+          );
+        }
       }
     }
-    return null;
+    return createForecastLlmFailureResult(
+      options,
+      sawProviderFailure
+        ? FORECAST_LLM_FAILURE_PROVIDER_FAILED
+        : sawBudgetCappedTimeout
+          ? FORECAST_LLM_FAILURE_BUDGET_EXHAUSTED
+          : FORECAST_LLM_FAILURE_PROVIDER_FAILED,
+    );
   } finally {
     await emitForecastLlmEvents(llmEvents);
   }
@@ -16438,17 +16471,37 @@ async function writeMarketImplicationsFailureMeta(reason) {
 
 // A budget-starve is NOT a producer failure — it's resource contention from
 // slow upstream stages consuming the shared 150s run budget before this tail
-// stage runs (#4978). Unlike writeMarketImplicationsFailureMeta, this leaves
-// seed-meta untouched so the last-good fetchedAt stays put: age-based
+// stage runs (#4978). Unlike writeMarketImplicationsFailureMeta, this preserves
+// last-good seed-meta without advancing fetchedAt: existing OK meta is TTL-
+// refreshed, and stale error meta is replaced only when the canonical payload
+// still contains last-good cards with a generatedAt timestamp. Age-based
 // STALE_SEED (maxStaleMin=120) still escalates if the starve persists past 2h,
 // exactly like the gpsjam preserve-last-good design, while a single starved
-// tick stays green. EXPIRE-refresh both keys so the cards + meta outlive a run
-// of consecutive starves rather than TTLing out to EMPTY mid-contention.
+// tick stays green.
 async function preserveMarketImplicationsLastGoodOnStarve() {
   const { url, token } = getRedisCredentials();
+  let currentMeta = null;
+  let lastGoodMeta = null;
+  try {
+    currentMeta = await redisGet(url, token, MARKET_IMPLICATIONS_META_KEY);
+    if (currentMeta?.status !== 'ok') {
+      const currentPayload = await redisGet(url, token, MARKET_IMPLICATIONS_KEY);
+      const cards = Array.isArray(currentPayload?.cards) ? currentPayload.cards : [];
+      const generatedAtMs = Date.parse(currentPayload?.generatedAt || '');
+      if (cards.length > 0 && Number.isFinite(generatedAtMs)) {
+        lastGoodMeta = { fetchedAt: generatedAtMs, recordCount: cards.length, status: 'ok' };
+      }
+    }
+  } catch (err) {
+    console.warn(`  [MarketImplications] last-good meta read failed during starve preserve: ${err.message}`);
+  }
   try {
     await redisCommand(url, token, ['EXPIRE', MARKET_IMPLICATIONS_KEY, String(MARKET_IMPLICATIONS_TTL)]);
-    await redisCommand(url, token, ['EXPIRE', MARKET_IMPLICATIONS_META_KEY, String(MARKET_IMPLICATIONS_META_TTL)]);
+    if (currentMeta?.status === 'ok') {
+      await redisCommand(url, token, ['EXPIRE', MARKET_IMPLICATIONS_META_KEY, String(MARKET_IMPLICATIONS_META_TTL)]);
+    } else if (lastGoodMeta) {
+      await redisSet(url, token, MARKET_IMPLICATIONS_META_KEY, lastGoodMeta, MARKET_IMPLICATIONS_META_TTL);
+    }
   } catch (err) {
     console.warn(`  [MarketImplications] last-good preserve refresh failed: ${err.message}`);
   }
@@ -16501,14 +16554,14 @@ async function buildAndSeedMarketImplications(inputs) {
     stage: 'market_implications',
     maxTokens: 2500,
     temperature: 0.25,
+    returnFailureReason: true,
   });
 
   if (!result?.text) {
-    // A null result with the run budget now exhausted is the same benign starve
-    // as the pre-call guard (budget hit zero mid-call) — preserve last-good
-    // rather than flip to SEED_ERROR. A null with budget remaining is a genuine
-    // provider failure and DOES warrant the error seed-meta. (#4978)
-    if (getRemainingForecastLlmRunBudgetMs() <= 0) {
+    // A budget-exhausted result is the same benign starve as the pre-call guard.
+    // Genuine provider failures stay visible even if they consume the last run
+    // milliseconds before returning. (#4978)
+    if (result?.failureReason === FORECAST_LLM_FAILURE_BUDGET_EXHAUSTED) {
       console.warn('  [MarketImplications] LLM run budget exhausted mid-call — preserving last-good, no SEED_ERROR');
       await preserveMarketImplicationsLastGoodOnStarve();
       return;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14534,6 +14534,15 @@ function getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
   return Math.max(0, getRemainingForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) - FORECAST_LLM_STAGE_BUDGET_GUARD_MS);
 }
 
+// Remaining RUN-level LLM budget in ms (Infinity when no run deadline is set —
+// tests and the deep-forecast worker, which have only the per-stage budget).
+// market_implications runs LAST in afterPublish, so this is the budget that
+// starves it when upstream stages are slow (e.g. deepseek-v4-flash 30s
+// timeouts drain the shared 150s run budget before the tail stage runs). #4978.
+function getRemainingForecastLlmRunBudgetMs() {
+  return forecastLlmRunDeadlineMs == null ? Infinity : forecastLlmRunDeadlineMs - Date.now();
+}
+
 function isForecastLlmBudgetError(err) {
   return Boolean(err?.forecastLlmBudgetExhausted);
 }
@@ -16373,6 +16382,13 @@ const MARKET_IMPLICATIONS_META_TTL = 86400 * 7;
 // fingerprint is not model-sensitive, so retire old-model rows explicitly.
 const MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX = 'forecast:llm-market-implications:v2:';
 
+// A market_implications completion needs ~20s wall-clock (observed 2026-07-06).
+// When the shared run budget (#4978) is below this as the tail stage begins, the
+// call would be aborted by the budget-capped timeout and then misreported as a
+// SEED_ERROR — so skip gracefully and preserve last-good instead of attempting a
+// doomed call. Tunable: raise it if 20s calls still start and time out.
+const MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS = 20_000;
+
 // Input-hash guard for the market_implications LLM stage (#4894). This was
 // the only forecast stage with no pre-call cache — a 2,500-token completion
 // regenerated every hourly run (plus every triggered re-run) even when the
@@ -16420,6 +16436,24 @@ async function writeMarketImplicationsFailureMeta(reason) {
   }
 }
 
+// A budget-starve is NOT a producer failure — it's resource contention from
+// slow upstream stages consuming the shared 150s run budget before this tail
+// stage runs (#4978). Unlike writeMarketImplicationsFailureMeta, this leaves
+// seed-meta untouched so the last-good fetchedAt stays put: age-based
+// STALE_SEED (maxStaleMin=120) still escalates if the starve persists past 2h,
+// exactly like the gpsjam preserve-last-good design, while a single starved
+// tick stays green. EXPIRE-refresh both keys so the cards + meta outlive a run
+// of consecutive starves rather than TTLing out to EMPTY mid-contention.
+async function preserveMarketImplicationsLastGoodOnStarve() {
+  const { url, token } = getRedisCredentials();
+  try {
+    await redisCommand(url, token, ['EXPIRE', MARKET_IMPLICATIONS_KEY, String(MARKET_IMPLICATIONS_TTL)]);
+    await redisCommand(url, token, ['EXPIRE', MARKET_IMPLICATIONS_META_KEY, String(MARKET_IMPLICATIONS_META_TTL)]);
+  } catch (err) {
+    console.warn(`  [MarketImplications] last-good preserve refresh failed: ${err.message}`);
+  }
+}
+
 async function buildAndSeedMarketImplications(inputs) {
   const startMs = Date.now();
   console.log('  [MarketImplications] Building world-state context...');
@@ -16444,6 +16478,21 @@ async function buildAndSeedMarketImplications(inputs) {
     }
   } catch { /* guard is best-effort — fall through to live generation */ }
 
+  // Tail-stage budget guard (#4978): market_implications is the LAST forecast
+  // LLM stage under the shared 150s run budget. When upstream stages are slow
+  // (e.g. deepseek-v4-flash 30s timeouts) they drain that budget before this
+  // stage runs; callForecastLLM would then throw a budget error, return null,
+  // and we'd (mis)write a SEED_ERROR for benign, self-healing resource
+  // contention. Skip gracefully and preserve last-good instead.
+  const runBudgetRemainingMs = getRemainingForecastLlmRunBudgetMs();
+  if (runBudgetRemainingMs < MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS) {
+    const remaining = Math.max(0, Math.round(runBudgetRemainingMs));
+    console.warn(`  [MarketImplications] Skipped: shared LLM run budget exhausted (${remaining}ms left, need ${MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS}ms) — preserving last-good, no SEED_ERROR`);
+    console.log(JSON.stringify({ event: 'llm_market_implications', skipped: 'run_budget_exhausted', remainingMs: remaining }));
+    await preserveMarketImplicationsLastGoodOnStarve();
+    return;
+  }
+
   const userPrompt = `World state as of ${new Date().toISOString()}:\n\n${context}\n\nAllowed tickers: ${[...ALL_ALLOWED_TICKERS].join(', ')}`;
 
   const llmOptions = getForecastLlmCallOptions('market_implications');
@@ -16455,6 +16504,15 @@ async function buildAndSeedMarketImplications(inputs) {
   });
 
   if (!result?.text) {
+    // A null result with the run budget now exhausted is the same benign starve
+    // as the pre-call guard (budget hit zero mid-call) — preserve last-good
+    // rather than flip to SEED_ERROR. A null with budget remaining is a genuine
+    // provider failure and DOES warrant the error seed-meta. (#4978)
+    if (getRemainingForecastLlmRunBudgetMs() <= 0) {
+      console.warn('  [MarketImplications] LLM run budget exhausted mid-call — preserving last-good, no SEED_ERROR');
+      await preserveMarketImplicationsLastGoodOnStarve();
+      return;
+    }
     console.warn('  [MarketImplications] LLM returned no response — writing error seed-meta');
     await writeMarketImplicationsFailureMeta('llm_no_response');
     return;
@@ -16556,6 +16614,19 @@ if (_isDirectRun) {
       if (triggerContext.triggerRequest) {
         await clearForecastRefreshRequestIfUnchanged(triggerContext.triggerRequest);
       }
+
+      // market_implications is the last remaining LLM stage and shares the 150s
+      // run budget (#4978). Run it BEFORE the best-effort telemetry below
+      // (history + deep-forecast snapshots, ~20s R2 trace export) so their
+      // wall-clock can't push the tail stage past the run deadline and starve
+      // it into a (pre-fix) SEED_ERROR. Independent of that telemetry — it reads
+      // data.inputs and publishes to its own key.
+      try {
+        await buildAndSeedMarketImplications(data.inputs || {});
+      } catch (err) {
+        console.warn(`  [MarketImplications] Stage failed: ${err.message}`);
+      }
+
       try {
         const snapshot = await appendHistorySnapshot(data);
         console.log(`  History appended: ${snapshot.predictions.length} forecasts -> ${HISTORY_KEY}`);
@@ -16637,12 +16708,6 @@ if (_isDirectRun) {
       } catch (err) {
         console.warn(`  [Trace] Export failed: ${err.message}`);
         if (err.stack) console.warn(`  [Trace] Stack: ${err.stack.split('\n').slice(0, 3).join(' | ')}`);
-      }
-
-      try {
-        await buildAndSeedMarketImplications(data.inputs || {});
-      } catch (err) {
-        console.warn(`  [MarketImplications] Stage failed: ${err.message}`);
       }
     },
     extraKeys: FORECAST_EXTRA_KEYS,

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -1,0 +1,87 @@
+// market_implications budget-starve handling (#4978).
+//
+// market_implications is the LAST forecast LLM stage (afterPublish) and shares
+// the single 150s run budget with every upstream stage. When upstream stages
+// are slow (e.g. deepseek-v4-flash 30s timeouts, #4944) they drain that budget
+// before this stage runs; callForecastLLM then throws a budget error and
+// returns null. The bug: the caller treated that starve identically to a real
+// LLM failure and wrote a `status:'error'` seed-meta, so /api/health flipped to
+// SEED_ERROR for benign, self-healing resource contention. A budget-starve must
+// instead PRESERVE last-good (leaving seed-meta.fetchedAt untouched) so
+// age-based STALE_SEED still escalates only if the starve persists past 2h.
+
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAndSeedMarketImplications,
+  __setRedisStoreForTests,
+  __setForecastLlmRunDeadlineForTests,
+} from '../scripts/seed-forecasts.mjs';
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  __setRedisStoreForTests(null);
+  __setForecastLlmRunDeadlineForTests(null);
+});
+
+const LAST_GOOD = [{
+  ticker: 'LMT', name: 'Lockheed Martin', direction: 'long', timeframe: '1-3m',
+  confidence: 0.7, title: 'Defense demand', narrative: 'n', risk_caveat: '', driver: '', transmission_chain: [],
+}];
+
+function seedLastGood(store) {
+  store['intelligence:market-implications:v1'] = { cards: LAST_GOOD, generatedAt: '2026-07-06T13:00:00.000Z', model: 'prev-model' };
+  store['seed-meta:intelligence:market-implications'] = { fetchedAt: 1783340000000, recordCount: 1, status: 'ok' };
+}
+
+// A fetch mock that treats any LLM-provider call as a test failure but lets the
+// redis EXPIRE preserve-refresh (redisCommand always hits real fetch) succeed.
+function budgetStarveFetch(onLlmCall) {
+  return async (u) => {
+    const s = String(u ?? '');
+    if (/openrouter|groq|chat\/completions|\/api\//i.test(s) && !/upstash|redis/i.test(s)) {
+      onLlmCall(s);
+      throw new Error(`LLM must not be called when the run budget is exhausted: ${s}`);
+    }
+    return { ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' };
+  };
+}
+
+test('run-budget starve preserves last-good and does NOT write a SEED_ERROR', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+
+  // Shared 150s run budget already blown before this tail stage runs.
+  __setForecastLlmRunDeadlineForTests(Date.now() - 1000);
+
+  let llmCalls = 0;
+  global.fetch = budgetStarveFetch(() => { llmCalls += 1; });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(llmCalls, 0, 'budget-starved tail stage must not call the LLM');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'ok', 'a budget starve must NOT flip seed-meta to error — age-based STALE_SEED escalates instead');
+  assert.equal(meta.recordCount, 1, 'last-good record count is preserved (fetchedAt untouched)');
+  assert.equal(meta.fetchedAt, 1783340000000, 'seed-meta.fetchedAt must not advance on a starve, else STALE_SEED never fires');
+  assert.deepEqual(store['intelligence:market-implications:v1'].cards, LAST_GOOD, 'last-good cards preserved');
+  assert.ok(
+    !Object.keys(store).some((k) => k.startsWith('forecast:llm-market-implications:')),
+    'no stage cache entry written on a budget-starved skip',
+  );
+});
+
+test('a genuine provider failure (budget remaining) still writes a SEED_ERROR', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  // No run deadline set → budget is effectively unlimited, so a null result is a
+  // real provider failure, not a starve.
+  global.fetch = async () => { throw new Error('provider down'); };
+
+  await buildAndSeedMarketImplications({});
+
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'error', 'a real LLM failure with budget remaining must still surface SEED_ERROR');
+});

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -17,7 +17,13 @@ import {
   __setRedisStoreForTests,
   __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,
+  __setForecastLlmCallOverrideForTests,
 } from '../scripts/seed-forecasts.mjs';
+
+// callForecastLLM's failure-reason contract (mirrors the FORECAST_LLM_FAILURE_*
+// constants in seed-forecasts.mjs; not exported, asserted here as the wire value).
+const BUDGET_EXHAUSTED = 'budget_exhausted';
+const PROVIDER_FAILED = 'provider_failed';
 
 const ENV_KEYS = ['OPENROUTER_API_KEY', 'FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER'];
 const originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
@@ -27,6 +33,7 @@ afterEach(() => {
   __setRedisStoreForTests(null);
   __setForecastLlmTransportForTests(null);
   __setForecastLlmRunDeadlineForTests(null);
+  __setForecastLlmCallOverrideForTests(null);
   for (const k of ENV_KEYS) {
     if (originalEnv[k] === undefined) delete process.env[k];
     else process.env[k] = originalEnv[k];
@@ -43,33 +50,31 @@ function seedLastGood(store) {
   store['seed-meta:intelligence:market-implications'] = { fetchedAt: 1783340000000, recordCount: 1, status: 'ok' };
 }
 
-// A fetch mock that treats any LLM-provider call as a test failure but lets the
-// redis EXPIRE preserve-refresh (redisCommand always hits real fetch) succeed.
-function budgetStarveFetch(onLlmCall) {
-  return async (u) => {
-    const s = String(u ?? '');
-    if (/openrouter|groq|chat\/completions|\/api\//i.test(s) && !/upstash|redis/i.test(s)) {
-      onLlmCall(s);
-      throw new Error(`LLM must not be called when the run budget is exhausted: ${s}`);
-    }
-    return { ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' };
-  };
-}
-
 test('run-budget starve preserves last-good and does NOT write a SEED_ERROR', async () => {
   const store = {};
   __setRedisStoreForTests(store);
   seedLastGood(store);
 
+  // Real provider config so the LLM WOULD be invoked if the pre-call guard failed
+  // to fire. Without a key, callForecastLLM's `if (!apiKey) continue` short-circuits
+  // and llmCalls===0 would prove nothing — the vacuous-tripwire trap. Counting via
+  // the transport override makes this assertion actually exercise the guard.
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+
   // Shared 150s run budget already blown before this tail stage runs.
   __setForecastLlmRunDeadlineForTests(Date.now() - 1000);
 
   let llmCalls = 0;
-  global.fetch = budgetStarveFetch(() => { llmCalls += 1; });
+  __setForecastLlmTransportForTests({
+    fetch: async () => { llmCalls += 1; throw new Error('LLM must not be called when the run budget is exhausted'); },
+  });
+  // redis EXPIRE/SET preserve-refresh (redisCommand always hits real fetch) succeeds.
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
 
   await buildAndSeedMarketImplications({});
 
-  assert.equal(llmCalls, 0, 'budget-starved tail stage must not call the LLM');
+  assert.equal(llmCalls, 0, 'the pre-call run-budget guard must skip before the LLM transport is invoked');
   const meta = store['seed-meta:intelligence:market-implications'];
   assert.equal(meta.status, 'ok', 'a budget starve must NOT flip seed-meta to error — age-based STALE_SEED escalates instead');
   assert.equal(meta.recordCount, 1, 'last-good record count is preserved (fetchedAt untouched)');
@@ -146,7 +151,9 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
-  __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
+  // >= 30_000 so the pre-call guard admits the call; the mock then drains the
+  // deadline mid-flight to prove a real failure is not reclassified as a starve.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 35_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -163,4 +170,79 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   assert.equal(providerCalls, 1, 'provider failure path must run before the deadline is drained');
   const meta = store['seed-meta:intelligence:market-implications'];
   assert.equal(meta.status, 'error', 'provider failure must not be reclassified as budget starve just because the deadline is now exhausted');
+});
+
+test('pre-call guard skips in the 20-30s band — needs the full provider timeout, not just 20s (#1/#4)', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+  // Real provider config so a broken/too-low guard would actually invoke the transport.
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+
+  // 25s run budget: the OLD 20s threshold would (wrongly) admit this and then time
+  // out CAPPED below the 25s provider timeout — indistinguishable from a hung
+  // provider. The fix requires the full provider timeout + 5s stage guard (30s), so
+  // a 25s budget must now SKIP cleanly instead of attempting an ambiguous call.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
+
+  let providerCalls = 0;
+  __setForecastLlmTransportForTests({
+    fetch: async () => { providerCalls += 1; throw Object.assign(new Error('timeout'), { name: 'TimeoutError' }); },
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(providerCalls, 0, 'a call with < 30s run budget must be skipped, not attempted with a capped (ambiguous) timeout');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'ok', 'skipping in the 20-30s band preserves last-good, no SEED_ERROR');
+  assert.equal(meta.fetchedAt, 1783340000000, 'fetchedAt untouched on a skip');
+});
+
+test('mid-call budget_exhausted result preserves last-good, no SEED_ERROR (#5 defensive branch)', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+
+  // Admit the call (>= 30s guard), then have callForecastLLM report a run-budget
+  // exhaustion mid-flight. This drives the caller's mid-call preserve branch
+  // (result.failureReason === BUDGET_EXHAUSTED) directly via the call-override seam
+  // — the one branch no organic path reaches now that admitted calls get the full
+  // provider timeout, but which is retained as defense-in-depth for env-overridden
+  // provider chains.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  let overrideCalls = 0;
+  __setForecastLlmCallOverrideForTests(() => {
+    overrideCalls += 1;
+    return { text: '', model: '', provider: '', failureReason: BUDGET_EXHAUSTED };
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(overrideCalls, 1, 'the guard must admit the call so the mid-call budget path is exercised');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'ok', 'a mid-call budget exhaustion is a starve — preserve last-good, no SEED_ERROR');
+  assert.equal(meta.recordCount, 1, 'last-good record count preserved');
+  assert.equal(meta.fetchedAt, 1783340000000, 'fetchedAt must not advance on a mid-call starve');
+  assert.ok(
+    !Object.keys(store).some((k) => k.startsWith('forecast:llm-market-implications:')),
+    'no stage cache entry written on a mid-call starve',
+  );
+});
+
+test('mid-call provider_failed result still writes a SEED_ERROR (#5 classification symmetry)', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+
+  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  __setForecastLlmCallOverrideForTests(() => ({ text: '', model: '', provider: '', failureReason: PROVIDER_FAILED }));
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'error', 'a genuine provider failure (even textless) must surface SEED_ERROR, not be preserved as a starve');
 });

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -15,14 +15,22 @@ import assert from 'node:assert/strict';
 import {
   buildAndSeedMarketImplications,
   __setRedisStoreForTests,
+  __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,
 } from '../scripts/seed-forecasts.mjs';
 
+const ENV_KEYS = ['OPENROUTER_API_KEY', 'FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER'];
+const originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
 const realFetch = global.fetch;
 afterEach(() => {
   global.fetch = realFetch;
   __setRedisStoreForTests(null);
+  __setForecastLlmTransportForTests(null);
   __setForecastLlmRunDeadlineForTests(null);
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
 });
 
 const LAST_GOOD = [{
@@ -73,15 +81,86 @@ test('run-budget starve preserves last-good and does NOT write a SEED_ERROR', as
   );
 });
 
+test('run-budget starve restores stale OK meta when previous tick wrote SEED_ERROR', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+  store['seed-meta:intelligence:market-implications'] = {
+    fetchedAt: Date.now(),
+    recordCount: 0,
+    status: 'error',
+    errorReason: 'llm_no_response',
+  };
+
+  __setForecastLlmRunDeadlineForTests(Date.now() - 1000);
+
+  const redisCommands = [];
+  global.fetch = async (_url, init = {}) => {
+    redisCommands.push(JSON.parse(String(init.body || '[]')));
+    return { ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' };
+  };
+
+  await buildAndSeedMarketImplications({});
+
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'ok', 'a later budget starve must not preserve a prior producer-error meta');
+  assert.equal(meta.recordCount, LAST_GOOD.length);
+  assert.equal(meta.fetchedAt, Date.parse('2026-07-06T13:00:00.000Z'), 'restored meta keeps last-good age');
+  assert.ok(
+    redisCommands.some((command) => command[0] === 'EXPIRE' && command[1] === 'intelligence:market-implications:v1'),
+    'canonical last-good payload TTL is still refreshed',
+  );
+  assert.ok(
+    !redisCommands.some((command) => command[0] === 'EXPIRE' && command[1] === 'seed-meta:intelligence:market-implications'),
+    'stale error meta must not be TTL-refreshed',
+  );
+});
+
 test('a genuine provider failure (budget remaining) still writes a SEED_ERROR', async () => {
   const store = {};
   __setRedisStoreForTests(store);
   // No run deadline set → budget is effectively unlimited, so a null result is a
   // real provider failure, not a starve.
-  global.fetch = async () => { throw new Error('provider down'); };
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+
+  let providerCalls = 0;
+  __setForecastLlmTransportForTests({
+    fetch: async () => {
+      providerCalls += 1;
+      return { ok: false, status: 401, headers: { get: () => null }, text: async () => 'provider down' };
+    },
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
 
   await buildAndSeedMarketImplications({});
 
+  assert.equal(providerCalls, 1, 'the regression must exercise a real provider request');
   const meta = store['seed-meta:intelligence:market-implications'];
   assert.equal(meta.status, 'error', 'a real LLM failure with budget remaining must still surface SEED_ERROR');
+});
+
+test('a genuine provider failure that drains the run deadline still writes a SEED_ERROR', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+  __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
+
+  let providerCalls = 0;
+  __setForecastLlmTransportForTests({
+    fetch: async () => {
+      providerCalls += 1;
+      __setForecastLlmRunDeadlineForTests(Date.now() - 1);
+      return { ok: false, status: 401, headers: { get: () => null }, text: async () => 'provider down' };
+    },
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(providerCalls, 1, 'provider failure path must run before the deadline is drained');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'error', 'provider failure must not be reclassified as budget starve just because the deadline is now exhausted');
 });

--- a/tests/market-implications-seed-health.test.mjs
+++ b/tests/market-implications-seed-health.test.mjs
@@ -67,3 +67,17 @@ test('market implications success path still writes a healthy seed-meta', () => 
   assert.match(buildRegion, /recordCount: cards\.length, status: 'ok'/);
   assert.match(buildRegion, /await redisSet\(url, token, MARKET_IMPLICATIONS_META_KEY, meta, MARKET_IMPLICATIONS_META_TTL\)/);
 });
+
+test('market_implications runs before the best-effort R2 trace export (#4978 tail-stage budget)', () => {
+  const afterPublish = sourceBetween('afterPublish: async (data, meta)', 'extraKeys: FORECAST_EXTRA_KEYS');
+  const miIndex = afterPublish.indexOf('await buildAndSeedMarketImplications(');
+  const traceIndex = afterPublish.indexOf('[Trace] Starting R2 export');
+  assert.notEqual(miIndex, -1, 'market_implications must be invoked in afterPublish');
+  assert.notEqual(traceIndex, -1, 'the R2 trace export marker must exist in afterPublish');
+  // The tail LLM stage shares the 150s run budget; it must run BEFORE the ~20s
+  // trace export so best-effort telemetry cannot push it past the run deadline.
+  assert.ok(
+    miIndex < traceIndex,
+    'market_implications must run BEFORE the R2 trace export (#4978), else telemetry wall-clock starves the tail LLM stage',
+  );
+});


### PR DESCRIPTION
Closes #4978.

## Problem

`/api/health` intermittently reports `marketImplications: SEED_ERROR`. The market-implications LLM stage is **not failing on its own merits** — it is being **starved of the shared 150s forecast LLM run budget** and then mislabels that starve as a producer failure.

`market_implications` runs LAST (in `afterPublish`) and shares one run budget (`FORECAST_LLM_RUN_BUDGET_MS = 150_000`) with every upstream LLM stage. When `combined`/`scenario` breach the 25s `deepseek/deepseek-v4-flash` call timeout (the #4944 model), they drain that budget before the tail stage runs; `callForecastLLM` throws a budget error and returns `null`. Pre-fix the caller treated that `null` identically to a real failure and wrote a `status:'error'` seed-meta → health `SEED_ERROR`. It self-heals next tick whenever upstream returns under the timeout.

Evidence (one seed-forecasts container, 2 consecutive runs, 2026-07-06):
- **14:03:32 (failed):** `combined`+`scenario` timed out → `[LLM:market_implications] budget exhausted after 1ms` → `writing error seed-meta`.
- **14:15:16 (next tick):** upstream fast → market_implications published 5 cards. Self-healed.

## Changes

1. **Distinguish budget-starve from real failure.** A pre-call guard skips the LLM when the remaining run budget is below what a market-implications call needs (~20s); a `null` result with the run budget now `<=0` is treated the same. On a starve we **preserve last-good WITHOUT rewriting `seed-meta.fetchedAt`**, so age-based `STALE_SEED` (maxStaleMin=120) still escalates if the starve persists past 2h — the gpsjam preserve-last-good design. Genuine provider failures (budget remaining) still surface `SEED_ERROR`.
2. **Reorder.** Run `market_implications` **before** the best-effort telemetry in `afterPublish` (history + deep-forecast snapshots, ~20s R2 trace export) so their wall-clock can't push the tail stage past the run deadline. Recovers the ~20s that tipped the failing run over the 150s deadline. Trace export is unaffected (verified by `forecast-trace-export.test.mjs`).

## Not in this PR (env follow-up)

The root trigger — deepseek-v4-flash latency draining the shared budget — is #4944 territory. A complementary **combined-stage groq fallback** is a 1-line Railway env change (`FORECAST_LLM_COMBINED_PROVIDER_ORDER=openrouter,groq`), deliberately left out of code to respect the intentional #4944 provider pin. Recommend applying it so a combined timeout stops wasting ~25s *and* degrading forecast narratives to `fallbackNarratives`.

## Test plan

- `tests/market-implications-budget-starve.test.mjs` (new): starve → `status:'ok'` preserved, `fetchedAt` untouched, no stage-cache write; genuine failure (budget remaining) → still `SEED_ERROR`. Failing-test-first per Bug Fix Protocol (failed `'error' !== 'ok'` pre-fix).
- Ordering guard added to `market-implications-seed-health.test.mjs`.
- `node --test` across market-implications + forecast suites: **336 pass**.

https://claude.ai/code/session_019uhnqAKEHTws3QMaUvq58N