### PR TITLE
fix(widget): persist Pro widget HTML across reloads

### DIFF
--- a/e2e/widget-builder.spec.ts
+++ b/e2e/widget-builder.spec.ts
@@ -542,12 +542,10 @@ test.describe('AI widget builder — PRO tier', () => {
     });
 
     expect(storage).not.toBeNull();
-    // Main array must carry the generated HTML so reload does not depend only on
-    // the compatibility side key.
+    // Main array is canonical; the legacy side key should not be needed for new saves.
     expect(storage!.entry.tier).toBe('pro');
     expect(storage!.entry.html).toContain('pro-crypto');
-    // HTML also remains in the separate key for existing sandbox handoff paths.
-    expect(storage!.proHtmlStored).toContain('pro-crypto');
+    expect(storage!.proHtmlStored).toBeNull();
 
     await page.reload();
     await expect(page.locator('.custom-widget-panel', {

--- a/e2e/widget-builder.spec.ts
+++ b/e2e/widget-builder.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 type MockWidgetResponse = {
   delayMs?: number;
@@ -10,6 +10,11 @@ type MockWidgetResponse = {
 const widgetKey = 'test-widget-key';
 const createPrompt = "Show me today's crude oil price versus gold";
 const modifyPrompt = 'Turn this into a flight delay summary instead';
+
+function expectLegacyWidgetHeaderIfPresent(headers: Record<string, string>): void {
+  const header = headers['x-widget-key'];
+  if (header !== undefined) expect(header).toBe(widgetKey);
+}
 
 function buildTallWidgetHtml(title: string, markerClass: string): string {
   const rows = Array.from({ length: 24 }, (_, index) => {
@@ -65,7 +70,7 @@ async function installWidgetAgentMocks(
       await new Promise((resolve) => setTimeout(resolve, healthDelayMs));
     }
 
-    expect(route.request().headers()['x-widget-key']).toBe(widgetKey);
+    expectLegacyWidgetHeaderIfPresent(route.request().headers());
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -135,7 +140,7 @@ async function installProWidgetAgentMocks(
   proKeyConfigured = true,
 ): Promise<void> {
   await page.route('**/widget-agent/health', async (route) => {
-    expect(route.request().headers()['x-widget-key']).toBe(widgetKey);
+    expectLegacyWidgetHeaderIfPresent(route.request().headers());
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -170,6 +175,20 @@ async function installProWidgetAgentMocks(
   });
 }
 
+async function closeMissionPresetPromptIfOpen(page: Page): Promise<void> {
+  const closeButton = page.locator('.mission-preset-popover [data-mission-close]');
+  if (await closeButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await closeButton.click({ force: true });
+    await expect(page.locator('.mission-preset-popover')).toBeHidden({ timeout: 5_000 });
+  }
+}
+
+async function clickWidgetBuilderBlock(page: Page, selector: string): Promise<void> {
+  await expect(page.locator(selector)).toBeVisible({ timeout: 30_000 });
+  await closeMissionPresetPromptIfOpen(page);
+  await page.locator(selector).click();
+}
+
 test.describe('AI widget builder', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript((key) => {
@@ -177,6 +196,7 @@ test.describe('AI widget builder', () => {
         localStorage.clear();
         sessionStorage.clear();
         localStorage.setItem('worldmonitor-variant', 'happy');
+        localStorage.setItem('worldmonitor-mission-preset-dismissed-v1', '1');
         localStorage.setItem('wm-widget-key', key);
         sessionStorage.setItem('__widget_e2e_init__', '1');
         return;
@@ -205,9 +225,7 @@ test.describe('AI widget builder', () => {
     );
 
     await page.goto('/');
-    await expect(page.locator('#panelsGrid .ai-widget-block')).toBeVisible({ timeout: 30000 });
-
-    await page.locator('#panelsGrid .ai-widget-block').click();
+    await clickWidgetBuilderBlock(page, '#panelsGrid .ai-widget-block');
 
     const modal = page.locator('.widget-chat-modal');
     const sendButton = modal.locator('.widget-chat-send');
@@ -309,9 +327,7 @@ test.describe('AI widget builder', () => {
     ], requestBodies);
 
     await page.goto('/');
-    await expect(page.locator('#panelsGrid .ai-widget-block')).toBeVisible({ timeout: 30000 });
-
-    await page.locator('#panelsGrid .ai-widget-block').click();
+    await clickWidgetBuilderBlock(page, '#panelsGrid .ai-widget-block');
     const modal = page.locator('.widget-chat-modal');
     await expect(modal.locator('.widget-chat-readiness')).toContainText('Connected to the widget agent');
 
@@ -452,8 +468,7 @@ test.describe('AI widget builder — PRO tier', () => {
     ]);
 
     await page.goto('/');
-    await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible({ timeout: 30000 });
-    await page.locator('#panelsGrid .ai-widget-block-pro').click();
+    await clickWidgetBuilderBlock(page, '#panelsGrid .ai-widget-block-pro');
 
     const modal = page.locator('.widget-chat-modal');
     await expect(modal).toBeVisible();
@@ -487,7 +502,7 @@ test.describe('AI widget builder — PRO tier', () => {
     expect(iframeHeight).toBeGreaterThanOrEqual(390);
   });
 
-  test('PRO widget stores HTML in wm-pro-html-{id} key and tier:pro in main array', async ({
+  test('PRO widget persists HTML in the main array and survives reload', async ({
     page,
   }) => {
     const proHtml = buildProWidgetBody('Crypto Table', 'pro-crypto');
@@ -500,8 +515,7 @@ test.describe('AI widget builder — PRO tier', () => {
     ]);
 
     await page.goto('/');
-    await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible({ timeout: 30000 });
-    await page.locator('#panelsGrid .ai-widget-block-pro').click();
+    await clickWidgetBuilderBlock(page, '#panelsGrid .ai-widget-block-pro');
 
     const modal = page.locator('.widget-chat-modal');
     await expect(modal.locator('.widget-chat-readiness')).toContainText('Connected', { timeout: 15000 });
@@ -528,11 +542,17 @@ test.describe('AI widget builder — PRO tier', () => {
     });
 
     expect(storage).not.toBeNull();
-    // Main array must have tier: 'pro' but NO html field
+    // Main array must carry the generated HTML so reload does not depend only on
+    // the compatibility side key.
     expect(storage!.entry.tier).toBe('pro');
-    expect(storage!.entry.html).toBeUndefined();
-    // HTML must be in the separate key
+    expect(storage!.entry.html).toContain('pro-crypto');
+    // HTML also remains in the separate key for existing sandbox handoff paths.
     expect(storage!.proHtmlStored).toContain('pro-crypto');
+
+    await page.reload();
+    await expect(page.locator('.custom-widget-panel', {
+      has: page.locator('.panel-title', { hasText: 'Crypto Table' }),
+    })).toBeVisible({ timeout: 20000 });
   });
 
   test('modify PRO widget: tier preserved, history passed to server', async ({ page }) => {
@@ -555,8 +575,7 @@ test.describe('AI widget builder — PRO tier', () => {
     );
 
     await page.goto('/');
-    await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible({ timeout: 30000 });
-    await page.locator('#panelsGrid .ai-widget-block-pro').click();
+    await clickWidgetBuilderBlock(page, '#panelsGrid .ai-widget-block-pro');
 
     const modal = page.locator('.widget-chat-modal');
     await expect(modal.locator('.widget-chat-readiness')).toContainText('Connected', { timeout: 15000 });
@@ -608,8 +627,7 @@ test.describe('AI widget builder — PRO tier', () => {
     await installProWidgetAgentMocks(page, [], [], false);
 
     await page.goto('/');
-    await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible({ timeout: 30000 });
-    await page.locator('#panelsGrid .ai-widget-block-pro').click();
+    await clickWidgetBuilderBlock(page, '#panelsGrid .ai-widget-block-pro');
 
     const modal = page.locator('.widget-chat-modal');
     await expect(modal).toBeVisible();

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -39,15 +39,12 @@ export function loadWidgets(): CustomWidgetSpec[] {
     if (tier === 'pro') {
       const sideKeyHtml = localStorage.getItem(proHtmlKey(w.id));
       const storedHtml = typeof w.html === 'string' ? w.html : '';
-      const proHtml = sideKeyHtml || storedHtml;
+      const proHtml = storedHtml || sideKeyHtml;
       if (!proHtml) {
         // HTML missing — drop widget and clean up spans
         clearPanelSpanEntry(w.id);
         clearPanelColSpanEntry(w.id);
         continue;
-      }
-      if (!sideKeyHtml && storedHtml) {
-        try { localStorage.setItem(proHtmlKey(w.id), storedHtml); } catch { /* best-effort side-key repair */ }
       }
       result.push({ ...w, tier, html: proHtml });
     } else {
@@ -60,12 +57,6 @@ export function loadWidgets(): CustomWidgetSpec[] {
 export function saveWidget(spec: CustomWidgetSpec): void {
   if (spec.tier === 'pro') {
     const proHtml = spec.html.slice(0, MAX_HTML_CHARS_PRO);
-    // Write HTML first (raw localStorage — must be catchable for rollback)
-    try {
-      localStorage.setItem(proHtmlKey(spec.id), proHtml);
-    } catch {
-      throw new Error('Storage quota exceeded saving PRO widget HTML');
-    }
     const meta: CustomWidgetSpec = {
       ...spec,
       html: proHtml,
@@ -75,10 +66,9 @@ export function saveWidget(spec: CustomWidgetSpec): void {
     const updated = [...existing, meta].slice(-MAX_WIDGETS);
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      try { localStorage.removeItem(proHtmlKey(spec.id)); } catch { /* ignore legacy side-key cleanup */ }
     } catch {
-      // Rollback HTML write
-      localStorage.removeItem(proHtmlKey(spec.id));
-      throw new Error('Storage quota exceeded saving PRO widget metadata');
+      throw new Error('Storage quota exceeded saving PRO widget');
     }
   } else {
     const trimmed: CustomWidgetSpec = {

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -37,12 +37,17 @@ export function loadWidgets(): CustomWidgetSpec[] {
   for (const w of raw) {
     const tier = w.tier === 'pro' ? 'pro' : 'basic';
     if (tier === 'pro') {
-      const proHtml = localStorage.getItem(proHtmlKey(w.id));
+      const sideKeyHtml = localStorage.getItem(proHtmlKey(w.id));
+      const storedHtml = typeof w.html === 'string' ? w.html : '';
+      const proHtml = sideKeyHtml || storedHtml;
       if (!proHtml) {
         // HTML missing — drop widget and clean up spans
         clearPanelSpanEntry(w.id);
         clearPanelColSpanEntry(w.id);
         continue;
+      }
+      if (!sideKeyHtml && storedHtml) {
+        try { localStorage.setItem(proHtmlKey(w.id), storedHtml); } catch { /* best-effort side-key repair */ }
       }
       result.push({ ...w, tier, html: proHtml });
     } else {
@@ -61,10 +66,9 @@ export function saveWidget(spec: CustomWidgetSpec): void {
     } catch {
       throw new Error('Storage quota exceeded saving PRO widget HTML');
     }
-    // Build metadata entry (no html field)
-    const meta: Omit<CustomWidgetSpec, 'html'> & { html: string } = {
+    const meta: CustomWidgetSpec = {
       ...spec,
-      html: '',
+      html: proHtml,
       conversationHistory: spec.conversationHistory.slice(-MAX_HISTORY),
     };
     const existing = loadFromStorage<CustomWidgetSpec[]>(STORAGE_KEY, []).filter(w => w.id !== spec.id);

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1113,29 +1113,29 @@ describe('PRO widget — store and sanitizer', () => {
     );
   });
 
-  it('PRO HTML stored in separate wm-pro-html-{id} key', () => {
+  it('legacy wm-pro-html-{id} key remains supported for old PRO widgets', () => {
     assert.ok(
       store.includes('wm-pro-html-'),
-      "PRO HTML must be stored in 'wm-pro-html-{id}' separate localStorage key",
+      "PRO HTML must still know the legacy 'wm-pro-html-{id}' localStorage key",
     );
   });
 
-  it('loadWidgets hydrates PRO HTML from separate key', () => {
+  it('loadWidgets can hydrate legacy PRO HTML from the side key', () => {
     const loadIdx = store.indexOf('function loadWidgets');
     assert.ok(loadIdx !== -1, 'loadWidgets not found');
     const loadBody = store.slice(loadIdx, loadIdx + 600);
     assert.ok(
-      loadBody.includes('proHtml') || loadBody.includes('wm-pro-html'),
-      'loadWidgets must read PRO HTML from separate key',
+      /localStorage\.getItem\(proHtmlKey\(w\.id\)\)/.test(loadBody),
+      'loadWidgets must read legacy PRO HTML from the side key',
     );
   });
 
-  it('loadWidgets falls back to canonical PRO HTML when wm-pro-html-{id} is missing', () => {
+  it('loadWidgets treats canonical PRO HTML as primary before legacy side key', () => {
     const loadIdx = store.indexOf('function loadWidgets');
     const loadBody = store.slice(loadIdx, loadIdx + 900);
     assert.ok(
-      loadBody.includes('sideKeyHtml || storedHtml'),
-      'loadWidgets must use the canonical widget entry as the PRO HTML fallback',
+      loadBody.includes('storedHtml || sideKeyHtml'),
+      'loadWidgets must prefer canonical widget HTML before the legacy side key',
     );
   });
 
@@ -1158,12 +1158,16 @@ describe('PRO widget — store and sanitizer', () => {
     );
   });
 
-  it('saveWidget for PRO rolls back HTML key if metadata write fails', () => {
+  it('saveWidget for PRO does not duplicate HTML into the legacy side key', () => {
     const saveIdx = store.indexOf('function saveWidget');
     const saveBody = store.slice(saveIdx, saveIdx + 800);
     assert.ok(
-      saveBody.includes('removeItem') || saveBody.includes('rollback'),
-      'saveWidget must rollback (removeItem) PRO HTML key if metadata write throws',
+      !saveBody.includes('localStorage.setItem(proHtmlKey'),
+      'saveWidget must not write duplicate PRO HTML to the legacy side key',
+    );
+    assert.ok(
+      saveBody.includes('localStorage.removeItem(proHtmlKey'),
+      'saveWidget should clean up legacy PRO HTML side keys after a canonical save',
     );
   });
 

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1130,12 +1130,21 @@ describe('PRO widget — store and sanitizer', () => {
     );
   });
 
-  it("loadWidgets drops PRO entry when wm-pro-html-{id} is missing", () => {
+  it('loadWidgets falls back to canonical PRO HTML when wm-pro-html-{id} is missing', () => {
     const loadIdx = store.indexOf('function loadWidgets');
-    const loadBody = store.slice(loadIdx, loadIdx + 600);
+    const loadBody = store.slice(loadIdx, loadIdx + 900);
     assert.ok(
-      loadBody.includes('continue') || loadBody.includes('skip'),
-      'loadWidgets must skip/drop PRO entries with missing HTML key',
+      loadBody.includes('sideKeyHtml || storedHtml'),
+      'loadWidgets must use the canonical widget entry as the PRO HTML fallback',
+    );
+  });
+
+  it('loadWidgets drops PRO entry only when no persisted HTML remains', () => {
+    const loadIdx = store.indexOf('function loadWidgets');
+    const loadBody = store.slice(loadIdx, loadIdx + 900);
+    assert.ok(
+      loadBody.includes('if (!proHtml)') && loadBody.includes('continue'),
+      'loadWidgets must skip/drop PRO entries only when no HTML exists in either storage path',
     );
   });
 

--- a/tests/widget-store.test.mts
+++ b/tests/widget-store.test.mts
@@ -132,6 +132,10 @@ function installLocalStorage(initial: Record<string, string> = {}): Map<string, 
   return values;
 }
 
+function proHtmlKey(id: string): string {
+  return `wm-pro-html-${id}`;
+}
+
 function makeProWidget(overrides: Partial<CustomWidgetSpec> = {}): CustomWidgetSpec {
   return {
     id: 'cw-pro-reload',
@@ -152,7 +156,7 @@ function makeProWidget(overrides: Partial<CustomWidgetSpec> = {}): CustomWidgetS
 
 describe('widget-store PRO persistence', () => {
   it('saveWidget persists PRO generated HTML in the canonical widget entry', async () => {
-    installLocalStorage();
+    const storage = installLocalStorage();
     const { saveWidget } = await loadWidgetStore();
 
     saveWidget(makeProWidget());
@@ -160,6 +164,7 @@ describe('widget-store PRO persistence', () => {
     const stored = JSON.parse(localStorage.getItem('wm-custom-widgets') ?? '[]') as Array<{ html?: string }>;
     assert.equal(stored.length, 1);
     assert.match(stored[0]?.html ?? '', /reload-marker/);
+    assert.equal(storage.has(proHtmlKey('cw-pro-reload')), false);
   });
 
   it('loadWidgets restores PRO HTML from the canonical entry when the side key is absent', async () => {
@@ -174,5 +179,49 @@ describe('widget-store PRO persistence', () => {
     assert.equal(widgets.length, 1);
     assert.equal(widgets[0]?.id, spec.id);
     assert.match(widgets[0]?.html ?? '', /reload-marker/);
+  });
+
+  it('loadWidgets restores legacy PRO HTML from the side key when canonical HTML is absent', async () => {
+    const spec = makeProWidget({ html: '' });
+    installLocalStorage({
+      'wm-custom-widgets': JSON.stringify([spec]),
+      [proHtmlKey(spec.id)]: '<div class="legacy-side-key">legacy widget</div>',
+    });
+    const { loadWidgets } = await loadWidgetStore();
+
+    const widgets = loadWidgets();
+
+    assert.equal(widgets.length, 1);
+    assert.equal(widgets[0]?.id, spec.id);
+    assert.match(widgets[0]?.html ?? '', /legacy-side-key/);
+  });
+
+  it('loadWidgets prefers canonical PRO HTML over a stale side key', async () => {
+    const spec = makeProWidget({
+      html: '<div class="canonical-html">current widget</div>',
+    });
+    installLocalStorage({
+      'wm-custom-widgets': JSON.stringify([spec]),
+      [proHtmlKey(spec.id)]: '<div class="stale-side-key">old widget</div>',
+    });
+    const { loadWidgets } = await loadWidgetStore();
+
+    const widgets = loadWidgets();
+
+    assert.equal(widgets.length, 1);
+    assert.match(widgets[0]?.html ?? '', /canonical-html/);
+    assert.doesNotMatch(widgets[0]?.html ?? '', /stale-side-key/);
+  });
+
+  it('loadWidgets drops PRO widgets when no persisted HTML remains', async () => {
+    const spec = makeProWidget({ html: '' });
+    installLocalStorage({
+      'wm-custom-widgets': JSON.stringify([spec]),
+    });
+    const { loadWidgets } = await loadWidgetStore();
+
+    const widgets = loadWidgets();
+
+    assert.equal(widgets.length, 0);
   });
 });

--- a/tests/widget-store.test.mts
+++ b/tests/widget-store.test.mts
@@ -1,0 +1,178 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { CustomWidgetSpec } from '../src/services/widget-store.ts';
+
+type WidgetStore = typeof import('../src/services/widget-store.ts');
+
+type GlobalSnapshot = { exists: boolean; value: unknown };
+
+function snapshotGlobal(name: string): GlobalSnapshot {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: (globalThis as Record<string, unknown>)[name],
+  };
+}
+
+function restoreGlobal(name: string, snapshot: GlobalSnapshot): void {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete (globalThis as Record<string, unknown>)[name];
+}
+
+const localStorageSnapshot = snapshotGlobal('localStorage');
+
+afterEach(() => {
+  restoreGlobal('localStorage', localStorageSnapshot);
+});
+
+async function loadWidgetStore(): Promise<WidgetStore> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-widget-store-'));
+  const outfile = join(tempDir, 'widget-store.bundle.mjs');
+  const entry = resolve(process.cwd(), 'src/services/widget-store.ts');
+
+  const stubModules = new Map([
+    ['utils-stub', `
+      export function loadFromStorage(key, fallback) {
+        try {
+          const raw = localStorage.getItem(key);
+          return raw == null ? fallback : JSON.parse(raw);
+        } catch {
+          return fallback;
+        }
+      }
+      export function saveToStorage(key, value) {
+        localStorage.setItem(key, JSON.stringify(value));
+      }
+    `],
+    ['panel-storage-stub', `
+      export function clearPanelSpanEntry(id) {
+        globalThis.__clearedPanelSpans = globalThis.__clearedPanelSpans || [];
+        globalThis.__clearedPanelSpans.push(id);
+      }
+      export function clearPanelColSpanEntry(id) {
+        globalThis.__clearedPanelColSpans = globalThis.__clearedPanelColSpans || [];
+        globalThis.__clearedPanelColSpans.push(id);
+      }
+    `],
+    ['widget-sanitizer-stub', `export function sanitizeWidgetHtml(html) { return String(html); }`],
+    ['auth-state-stub', `export function getAuthState() { return { user: { role: 'pro' } }; }`],
+    ['entitlements-stub', `export function isEntitled() { return true; }`],
+    ['browser-key-session-stub', `
+      export function clearLegacyKeyStorage() {}
+      export function migrateLegacyKeysToHttpOnlySession() { return Promise.resolve(); }
+      export function readLegacySessionKey() { return ''; }
+    `],
+  ]);
+
+  const aliasMap = new Map([
+    ['@/utils', 'utils-stub'],
+    ['@/utils/panel-storage', 'panel-storage-stub'],
+    ['@/utils/widget-sanitizer', 'widget-sanitizer-stub'],
+    ['@/services/auth-state', 'auth-state-stub'],
+    ['@/services/entitlements', 'entitlements-stub'],
+    ['@/services/browser-key-session', 'browser-key-session-stub'],
+  ]);
+
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [{
+      name: 'widget-store-test-stubs',
+      setup(buildApi) {
+        buildApi.onResolve({ filter: /.*/ }, (args) => {
+          const target = aliasMap.get(args.path);
+          return target ? { path: target, namespace: 'stub' } : null;
+        });
+        buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+          contents: stubModules.get(args.path),
+          loader: 'js',
+        }));
+      },
+    }],
+  });
+
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
+  const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  rmSync(tempDir, { recursive: true, force: true });
+  return mod as WidgetStore;
+}
+
+function installLocalStorage(initial: Record<string, string> = {}): Map<string, string> {
+  const values = new Map(Object.entries(initial));
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    writable: true,
+    value: {
+      getItem(key: string) {
+        return values.get(key) ?? null;
+      },
+      setItem(key: string, value: string) {
+        values.set(key, String(value));
+      },
+      removeItem(key: string) {
+        values.delete(key);
+      },
+    },
+  });
+  return values;
+}
+
+function makeProWidget(overrides: Partial<CustomWidgetSpec> = {}): CustomWidgetSpec {
+  return {
+    id: 'cw-pro-reload',
+    title: 'Reloadable Pro Widget',
+    html: '<div class="reload-marker">survives reload</div>',
+    prompt: 'Build a reloadable widget',
+    tier: 'pro',
+    accentColor: null,
+    conversationHistory: [
+      { role: 'user', content: 'Build a reloadable widget' },
+      { role: 'assistant', content: 'Generated Reloadable Pro Widget' },
+    ],
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_001,
+    ...overrides,
+  };
+}
+
+describe('widget-store PRO persistence', () => {
+  it('saveWidget persists PRO generated HTML in the canonical widget entry', async () => {
+    installLocalStorage();
+    const { saveWidget } = await loadWidgetStore();
+
+    saveWidget(makeProWidget());
+
+    const stored = JSON.parse(localStorage.getItem('wm-custom-widgets') ?? '[]') as Array<{ html?: string }>;
+    assert.equal(stored.length, 1);
+    assert.match(stored[0]?.html ?? '', /reload-marker/);
+  });
+
+  it('loadWidgets restores PRO HTML from the canonical entry when the side key is absent', async () => {
+    const spec = makeProWidget();
+    installLocalStorage({
+      'wm-custom-widgets': JSON.stringify([spec]),
+    });
+    const { loadWidgets } = await loadWidgetStore();
+
+    const widgets = loadWidgets();
+
+    assert.equal(widgets.length, 1);
+    assert.equal(widgets[0]?.id, spec.id);
+    assert.match(widgets[0]?.html ?? '', /reload-marker/);
+  });
+});


### PR DESCRIPTION
## Summary
- Persist generated Pro widget HTML in canonical `wm-custom-widgets` entries so panels can reload without the legacy side key.
- Keep `wm-pro-html-{id}` reads/deletes only as legacy support for widgets saved by the older side-key scheme, and clean that key after a successful canonical save.
- Add focused store coverage for canonical save/load, legacy side-key fallback, canonical-over-stale precedence, and dropping Pro widgets only when both persisted HTML paths are missing.
- Extend the Pro Widget Builder browser regression to create a widget, assert canonical HTML storage, reload the dashboard, and verify the panel remains visible.

Fixes #4979.

## Validation
- `node --import tsx/esm --test tests/widget-store.test.mts`
- `node --test tests/widget-builder.test.mjs`
- `npm run typecheck`
- `npx playwright test e2e/widget-builder.spec.ts -g "PRO widget persists HTML"`
- `git diff --check`
- pre-push hook: typecheck, API typecheck, boundaries, safe-html, rate-limit policy, premium-fetch, changed tests, edge function tests, version sync