### PR TITLE
fix(llm): reasoning-off for short brief stages — v4-pro empty-content 80% (#4983)

### DIFF
--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -238,6 +238,12 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
       // v2 prompt is 2–3 sentences / 40–70 words — roughly 3× v1's
       // single-sentence output, so bump maxTokens proportionally.
       maxTokens: 260,
+      // Reasoning OFF (#4983): a 2–3 sentence blurb needs no chain-of-thought,
+      // and an actual reasoning model (deepseek-v4-pro) would burn this whole
+      // 260-token budget on hidden reasoning and return empty content (~80%
+      // empty at the pre-fix budget). Off = full budget for the answer + no
+      // 6–9s reasoning latency × N stories. Uses the same LLM_REASONING_MODEL.
+      enableReasoning: false,
       temperature: 0.4,
       timeoutMs: 15_000,
       stage: 'brief-why-matters-analyst',
@@ -276,6 +282,9 @@ async function runGeminiPath(story: StoryPayload): Promise<string | null> {
         { role: 'user', content: user },
       ],
       maxTokens: 120,
+      // Reasoning OFF (#4983) — see analyst path above. This path's 120-token
+      // budget is even tighter, so a reasoning model returns empty ~100%.
+      enableReasoning: false,
       temperature: 0.4,
       timeoutMs: 10_000,
       stage: 'brief-why-matters-gemini',

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -249,9 +249,17 @@ function callLlmProfile(
 export const callLlmTool = (opts: Omit<LlmCallOptions, 'providerOrder' | 'modelOverrides'>) =>
   callLlmProfile(opts, 'LLM_TOOL_PROVIDER', 'LLM_TOOL_MODEL', 'groq');
 
-/** Powerful model for synthesis and reasoning tasks. Configurable via LLM_REASONING_PROVIDER / LLM_REASONING_MODEL. */
+/**
+ * Powerful model for synthesis and reasoning tasks. Configurable via
+ * LLM_REASONING_PROVIDER / LLM_REASONING_MODEL. Reasoning is ON by default,
+ * but a caller may pass `enableReasoning: false` to use the same
+ * high-quality model with reasoning DISABLED — required for short-output
+ * stages (a 2–3 sentence brief blurb) where an actual reasoning model
+ * (e.g. deepseek-v4-pro) would otherwise spend its whole small max_tokens
+ * budget on hidden reasoning tokens and return empty content (#4983).
+ */
 export const callLlmReasoning = (opts: Omit<LlmCallOptions, 'providerOrder' | 'modelOverrides'>) =>
-  callLlmProfile({ ...opts, enableReasoning: true }, 'LLM_REASONING_PROVIDER', 'LLM_REASONING_MODEL', 'openrouter');
+  callLlmProfile({ enableReasoning: true, ...opts }, 'LLM_REASONING_PROVIDER', 'LLM_REASONING_MODEL', 'openrouter');
 
 // enableReasoning is omitted too: the reasoning stream hardcodes it on —
 // exposing the knob on the stream type would be a silent no-op for callers.

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -9,9 +9,17 @@ const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 const originalOllamaApiUrl = process.env.OLLAMA_API_URL;
 const originalLlmApiUrl = process.env.LLM_API_URL;
 const originalLlmApiKey = process.env.LLM_API_KEY;
+const originalLlmReasoningProvider = process.env.LLM_REASONING_PROVIDER;
+const originalLlmReasoningModel = process.env.LLM_REASONING_MODEL;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+
+  if (originalLlmReasoningProvider === undefined) delete process.env.LLM_REASONING_PROVIDER;
+  else process.env.LLM_REASONING_PROVIDER = originalLlmReasoningProvider;
+
+  if (originalLlmReasoningModel === undefined) delete process.env.LLM_REASONING_MODEL;
+  else process.env.LLM_REASONING_MODEL = originalLlmReasoningModel;
 
   if (originalGroqApiKey === undefined) delete process.env.GROQ_API_KEY;
   else process.env.GROQ_API_KEY = originalGroqApiKey;
@@ -146,9 +154,8 @@ describe('callLlm', () => {
     });
     assert.ok(on);
     assert.equal('reasoning' in (bodies[0] ?? {}), false, 'default leaves reasoning on (no disable body)');
-
-    delete process.env.LLM_REASONING_PROVIDER;
-    delete process.env.LLM_REASONING_MODEL;
+    // LLM_REASONING_* are restored by the shared afterEach (snapshot-based),
+    // which runs even if an assertion above throws — no manual cleanup here.
   });
 
   it('ignores DeepSeek reasoning message fields and serves content untouched', async () => {

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
-import { callLlm } from '../server/_shared/llm.ts';
+import { callLlm, callLlmReasoning } from '../server/_shared/llm.ts';
 
 const originalFetch = globalThis.fetch;
 const originalGroqApiKey = process.env.GROQ_API_KEY;
@@ -106,6 +106,49 @@ describe('callLlm', () => {
     assert.equal(postBodies.length, 1);
     // Opt-in leaves the model's own reasoning default in effect.
     assert.equal('reasoning' in (postBodies[0] ?? {}), false);
+  });
+
+  it('callLlmReasoning honors enableReasoning:false to disable reasoning on the reasoning-tier model (#4983)', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.LLM_REASONING_PROVIDER = 'openrouter';
+    process.env.LLM_REASONING_MODEL = 'deepseek/deepseek-v4-pro';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      bodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'Closure would choke a fifth of seaborne crude.' } }],
+        usage: { total_tokens: 30 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    // Short-stage caller opts OUT of reasoning: the tiny max_tokens budget
+    // must go to the answer, not hidden reasoning tokens (the #4983 bug).
+    const off = await callLlmReasoning({
+      messages: [{ role: 'user', content: 'Why does this matter?' }],
+      maxTokens: 260,
+      enableReasoning: false,
+    });
+    assert.ok(off);
+    assert.equal(off.model, 'deepseek/deepseek-v4-pro', 'still uses the reasoning-tier model');
+    assert.deepEqual(bodies[0]?.reasoning, { enabled: false }, 'reasoning must be disabled on the wire');
+
+    // Default (no override) keeps reasoning on for genuinely analytical stages.
+    bodies.length = 0;
+    const on = await callLlmReasoning({
+      messages: [{ role: 'user', content: 'Deduce the situation.' }],
+      maxTokens: 1500,
+    });
+    assert.ok(on);
+    assert.equal('reasoning' in (bodies[0] ?? {}), false, 'default leaves reasoning on (no disable body)');
+
+    delete process.env.LLM_REASONING_PROVIDER;
+    delete process.env.LLM_REASONING_MODEL;
   });
 
   it('ignores DeepSeek reasoning message fields and serves content untouched', async () => {


### PR DESCRIPTION
Fixes #4983. Resolves the U3 reasoning-tier failure surfaced by post-deploy Axiom telemetry.

## Problem (live in prod since ~14:30Z)
`LLM_REASONING_MODEL=deepseek/deepseek-v4-pro` made the reasoning tier an *actual* reasoning model. The `brief-why-matters` stages cap output at 120–260 tokens (fine for the old non-reasoning gemini-3-flash). v4-pro spent that entire budget on hidden reasoning tokens → empty `message.content` → **~80% failure**, falling back to groq-70B every time.

Proof (Axiom `wm_api_usage`): failed calls had `tokens_completion == max_tokens` exactly (190/190); the 4/20 that succeeded got 352 completion tokens. **Not a DeepSeek problem — a budget/mode mismatch.** The utility tier (`deepseek-v4-flash`: classify/summarize/forecast) had 0 failures throughout.

## Fix (Option B)
- `callLlmReasoning` now honors a caller `enableReasoning: false` (was hardcoded on).
- The two short `brief-why-matters` stages opt out → they keep the **same** reasoning-tier model (`LLM_REASONING_MODEL`) but with reasoning disabled: full token budget goes to the answer, and no 6.7–9.5s reasoning latency × ~8 stories per brief.
- `chat-analyst` (600 tok) and `deduct-situation` (1500 tok) keep reasoning **ON** — they're genuinely analytical and have the budget.

## Verification
- Regression: `callLlmReasoning({enableReasoning:false})` sends `reasoning:{enabled:false}` on the wire while keeping the reasoning-tier model; default leaves reasoning on. shared-llm **9/9**, brief endpoint **64/64**, typecheck:api clean.
- Post-merge to confirm: Axiom `brief-why-matters-*` empty-rate → ~0, latency drops to sub-second, `producedBy` shows the reasoning model not the groq fallback.

## Landing
Standalone fix for the **already-live** U3 env flip — independent of #4967 (U4 shadow gate). Users are currently shielded by the groq fallback, so no outage; this stops the waste and makes the reasoning tier actually serve DeepSeek. Manual review/merge.

https://claude.ai/code/session_01Xs7LsyQQJqngcqjt5oGcpx