### PR TITLE
fix(notifications): coalesce repeated alert events

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -32,6 +32,10 @@ COPY scripts/lib/usni-fleet-parser.cjs ./scripts/lib/usni-fleet-parser.cjs
 # telemetry flush, #4954) — missing it = silent startup crash in the image.
 COPY scripts/lib/llm-telemetry.cjs ./scripts/lib/llm-telemetry.cjs
 COPY scripts/shared/country-name-to-iso2.cjs ./scripts/shared/country-name-to-iso2.cjs
+# notification-dedup.cjs is required by ais-relay.cjs and notification-relay.cjs
+# (Slot B dedup-material helper, #4985). Missing it = ERR_MODULE_NOT_FOUND at
+# relay startup. Guarded by tests/dockerfile-relay-imports.test.mjs.
+COPY scripts/shared/notification-dedup.cjs ./scripts/shared/notification-dedup.cjs
 COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
 # _seed-envelope-source.mjs and _seed-contract.mjs are transitively imported
 # by _seed-utils.mjs (lines 9-10) and by seed-chokepoint-flows.mjs /

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -572,6 +572,11 @@ function normalizeNotificationCountryCode(raw) {
   return countryNameToIso2(raw) ?? undefined;
 }
 
+function marketAlertCoalesceKey(assetClass, identifier, direction, severity) {
+  const stableIdentifier = String(identifier || 'unknown').trim().toLowerCase();
+  return `market:${assetClass}:${stableIdentifier}:${direction}:${severity}`;
+}
+
 /**
  * Slot B helper: derive a coalesce-family key from an NWS VTEC string.
  *
@@ -2145,10 +2150,15 @@ async function seedMarketQuotes() {
   for (const q of movingStocks.slice(0, 3)) {
     const pct = Math.round(q.change);
     const dir = q.change < 0 ? 'decline' : 'surge';
+    const severity = Math.abs(q.change) >= 10 ? 'critical' : 'high';
     publishNotificationEvent({
       eventType: 'market_alert',
-      payload: { title: `${q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`, source: 'Equity Market' },
-      severity: Math.abs(q.change) >= 10 ? 'critical' : 'high',
+      payload: {
+        title: `${q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`,
+        source: 'Equity Market',
+        coalesceKey: marketAlertCoalesceKey('equity', q.symbol, dir, severity),
+      },
+      severity,
       variant: undefined,
       dedupTtl: 3600,
     }).catch(e => console.warn('[Notify] Market stock publish error:', e?.message));
@@ -2199,10 +2209,15 @@ async function seedCommodityQuotes() {
   for (const q of movingCommodities.slice(0, 3)) {
     const pct = Math.round(q.change);
     const dir = q.change < 0 ? 'decline' : 'surge';
+    const severity = Math.abs(q.change) >= 10 ? 'critical' : 'high';
     publishNotificationEvent({
       eventType: 'market_alert',
-      payload: { title: `${q.name || q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`, source: 'Commodity Market' },
-      severity: Math.abs(q.change) >= 10 ? 'critical' : 'high',
+      payload: {
+        title: `${q.name || q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`,
+        source: 'Commodity Market',
+        coalesceKey: marketAlertCoalesceKey('commodity', q.symbol || q.name, dir, severity),
+      },
+      severity,
       variant: undefined,
       dedupTtl: 3600,
     }).catch(e => console.warn('[Notify] Commodity publish error:', e?.message));
@@ -2498,10 +2513,15 @@ async function seedCryptoQuotes() {
   for (const q of movingCrypto.slice(0, 3)) {
     const pct = Math.round(q.change);
     const dir = q.change < 0 ? 'decline' : 'surge';
+    const severity = Math.abs(q.change) >= 20 ? 'critical' : 'high';
     publishNotificationEvent({
       eventType: 'market_alert',
-      payload: { title: `${q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`, source: 'Crypto Market' },
-      severity: Math.abs(q.change) >= 20 ? 'critical' : 'high',
+      payload: {
+        title: `${q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`,
+        source: 'Crypto Market',
+        coalesceKey: marketAlertCoalesceKey('crypto', q.symbol || q.name, dir, severity),
+      },
+      severity,
       variant: undefined,
       dedupTtl: 3600,
     }).catch(e => console.warn('[Notify] Crypto publish error:', e?.message));

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -28,6 +28,7 @@ const v8 = require('v8');
 const { WebSocketServer, WebSocket } = require('ws');
 const { parseProxyConfig, resolveProxyString } = require('./_proxy-utils.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
+const { buildDedupMaterial } = require('./shared/notification-dedup.cjs');
 const parseProxyUrl = parseProxyConfig;
 
 const httpsKeepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 6, timeout: 60_000 });
@@ -613,9 +614,7 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
     // event collapse at the publisher (queue stays clean) instead of N times
     // per recipient at the relay.
     const variantSuffix = variant ? `:${variant}` : '';
-    const dedupMaterial = payload?.coalesceKey
-      ? `coalesce:${payload.coalesceKey}`
-      : `${eventType}:${payload.title ?? ''}`;
+    const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
     const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifySimpleHash(dedupMaterial)}`;
     const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
     if (!isNew) {

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -12,6 +12,7 @@ const {
 const { callLLM } = require('./lib/llm-chain.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
+const { buildDedupMaterial } = require('./shared/notification-dedup.cjs');
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -79,7 +80,7 @@ async function checkDedup(userId, eventType, title, coalesceKey) {
   // into one notification per user — the title-based dedup misses these
   // because each zone produces a slightly different title.
   // See docs/archive/plans/forbid-realtime-all-events.md "Out of scope: Slot B".
-  const keyMaterial = coalesceKey ? `coalesce:${coalesceKey}` : `${eventType}:${title}`;
+  const keyMaterial = buildDedupMaterial(eventType, title, coalesceKey);
   const hash = sha256Hex(keyMaterial);
   const key = `wm:notif:dedup:${userId}:${hash}`;
   const result = await upstashRest('SET', key, '1', 'NX', 'EX', '1800');

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -38,7 +38,10 @@ import {
   getRedisCredentials,
   readCanonicalValue,
 } from './_seed-utils.mjs';
+import notificationDedup from './shared/notification-dedup.cjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+
+const { buildDedupMaterial } = notificationDedup;
 
 loadEnvFile(import.meta.url);
 
@@ -349,9 +352,7 @@ function notifyHash(str) {
 async function publishNotificationEvent({ eventType, payload, severity, variant, dedupTtl = 1800 }) {
   try {
     const variantSuffix = variant ? `:${variant}` : '';
-    const dedupMaterial = payload?.coalesceKey
-      ? `coalesce:${payload.coalesceKey}`
-      : `${eventType}:${payload.title ?? ''}`;
+    const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
     const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifyHash(dedupMaterial)}`;
     const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
     if (!isNew) {
@@ -791,14 +792,19 @@ async function dispatchAviationNotifications(alerts) {
   await upstashSet(AVIATION_PREV_ALERTED_KEY, [...currentIatas], PREV_STATE_TTL);
 
   for (const a of newAlerts.slice(0, 3)) {
+    const severity = a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high';
     await publishNotificationEvent({
       eventType: 'aviation_closure',
       payload: {
         title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`,
         source: 'AviationStack',
-        coalesceKey: `aviation:delay:${a.iata}`,
+        // Coalesce by airport + severity band: repeated same-band disruptions
+        // collapse, but a post-recovery MAJOR->SEVERE re-escalation still fires
+        // (mirrors marketAlertCoalesceKey's severity segment; prefix matches the
+        // aviation_closure eventType and the notam:closure sibling). PR #4985 #1/#3.
+        coalesceKey: `aviation:closure:${a.iata}:${severity}`,
       },
-      severity: a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high',
+      severity,
       variant: undefined,
       dedupTtl: 14_400, // 4h
     });

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -783,25 +783,33 @@ async function dispatchAviationNotifications(alerts) {
   const severeAlerts = alerts.filter(a =>
     a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' || a.severity === 'FLIGHT_DELAY_SEVERITY_MAJOR',
   );
-  const currentIatas = new Set(severeAlerts.map(a => a.iata).filter(Boolean));
+  // Diff identity MUST match the publisher coalesce key (airport + severity band).
+  // Diffing by airport alone would filter a MAJOR->SEVERE escalation for an
+  // already-alerted airport out HERE — before the severity-aware coalesce key is
+  // ever reached — so the escalation would never publish (PR #4985 review P1).
+  const aviationSeverityBand = a => (a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high');
+  const aviationAlertKey = a => `${a.iata}:${aviationSeverityBand(a)}`;
+  const currentKeys = new Set(severeAlerts.filter(a => a.iata).map(aviationAlertKey));
   const prev = await upstashGet(AVIATION_PREV_ALERTED_KEY);
   const prevSet = new Set(Array.isArray(prev) ? prev : []);
-  const newAlerts = severeAlerts.filter(a => a.iata && !prevSet.has(a.iata));
+  const newAlerts = severeAlerts.filter(a => a.iata && !prevSet.has(aviationAlertKey(a)));
 
   // Persist current set for next tick's diff (24h TTL guards restarts).
-  await upstashSet(AVIATION_PREV_ALERTED_KEY, [...currentIatas], PREV_STATE_TTL);
+  // Keyed by airport+severity so a later band change is seen as a new state.
+  await upstashSet(AVIATION_PREV_ALERTED_KEY, [...currentKeys], PREV_STATE_TTL);
 
   for (const a of newAlerts.slice(0, 3)) {
-    const severity = a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high';
+    const severity = aviationSeverityBand(a);
     await publishNotificationEvent({
       eventType: 'aviation_closure',
       payload: {
         title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`,
         source: 'AviationStack',
         // Coalesce by airport + severity band: repeated same-band disruptions
-        // collapse, but a post-recovery MAJOR->SEVERE re-escalation still fires
-        // (mirrors marketAlertCoalesceKey's severity segment; prefix matches the
-        // aviation_closure eventType and the notam:closure sibling). PR #4985 #1/#3.
+        // collapse, but a MAJOR->SEVERE escalation produces a distinct key — and
+        // the prev-state diff above uses the SAME identity, so the escalation is
+        // not filtered upstream (mirrors marketAlertCoalesceKey; prefix matches
+        // the aviation_closure eventType and the notam:closure sibling). PR #4985.
         coalesceKey: `aviation:closure:${a.iata}:${severity}`,
       },
       severity,

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -349,7 +349,10 @@ function notifyHash(str) {
 async function publishNotificationEvent({ eventType, payload, severity, variant, dedupTtl = 1800 }) {
   try {
     const variantSuffix = variant ? `:${variant}` : '';
-    const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifyHash(`${eventType}:${payload.title ?? ''}`)}`;
+    const dedupMaterial = payload?.coalesceKey
+      ? `coalesce:${payload.coalesceKey}`
+      : `${eventType}:${payload.title ?? ''}`;
+    const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifyHash(dedupMaterial)}`;
     const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
     if (!isNew) {
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
@@ -790,7 +793,11 @@ async function dispatchAviationNotifications(alerts) {
   for (const a of newAlerts.slice(0, 3)) {
     await publishNotificationEvent({
       eventType: 'aviation_closure',
-      payload: { title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`, source: 'AviationStack' },
+      payload: {
+        title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`,
+        source: 'AviationStack',
+        coalesceKey: `aviation:delay:${a.iata}`,
+      },
       severity: a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high',
       variant: undefined,
       dedupTtl: 14_400, // 4h
@@ -808,7 +815,11 @@ async function dispatchNotamNotifications(closedIcaos, reasons) {
   for (const icao of newClosures.slice(0, 3)) {
     await publishNotificationEvent({
       eventType: 'notam_closure',
-      payload: { title: `NOTAM: ${icao} — ${reasons[icao] || 'Airport closure'}`, source: 'ICAO NOTAM' },
+      payload: {
+        title: `NOTAM: ${icao} — ${reasons[icao] || 'Airport closure'}`,
+        source: 'ICAO NOTAM',
+        coalesceKey: `notam:closure:${icao}`,
+      },
       severity: 'high',
       variant: undefined,
       dedupTtl: 21_600, // 6h

--- a/scripts/shared/notification-dedup.cjs
+++ b/scripts/shared/notification-dedup.cjs
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Slot B dedup-material builder — the single source of truth shared by every
+ * notification publisher.
+ *
+ * When a coalesceKey is set (an NWS VTEC family string, a market asset-family
+ * key, an airport/ICAO key, ...) the dedup key is derived from it so adjacent
+ * or repeated same-family events collapse to one notification. Otherwise it
+ * falls back to the eventType:title hash.
+ *
+ * Extracted from the three previously byte-identical inline copies in
+ * ais-relay.cjs, seed-aviation.mjs, and notification-relay.cjs so the
+ * coalesce/fallback formula changes in one place (WM PR #4985 review, finding #2).
+ *
+ * @param {string} eventType         producer event type (e.g. 'market_alert')
+ * @param {string|undefined} title   payload title; coerced to '' when absent
+ * @param {string|undefined} coalesceKey  family key; when truthy it wins
+ * @returns {string} the material to hash into the dedup key
+ */
+function buildDedupMaterial(eventType, title, coalesceKey) {
+  return coalesceKey ? `coalesce:${coalesceKey}` : `${eventType}:${title ?? ''}`;
+}
+
+module.exports = { buildDedupMaterial };

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -25,6 +25,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'), 'utf-8');
 const aisRelaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf-8');
 const seedAviationSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'seed-aviation.mjs'), 'utf-8');
+const notificationDedupSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'shared', 'notification-dedup.cjs'), 'utf-8');
 
 describe('notification-relay checkDedup — Slot B coalesce key', () => {
   it('checkDedup signature accepts an optional coalesceKey parameter', () => {
@@ -39,8 +40,8 @@ describe('notification-relay checkDedup — Slot B coalesce key', () => {
     // Both branches must be present: coalesce-key path and title-hash path.
     assert.match(
       relaySrc,
-      /coalesceKey\s*\?\s*`coalesce:\$\{coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{title\}`/,
-      'checkDedup keyMaterial must use coalesceKey when set, else fall back to eventType:title',
+      /const keyMaterial = buildDedupMaterial\(eventType,\s*title,\s*coalesceKey\)/,
+      'checkDedup must derive keyMaterial via the shared buildDedupMaterial helper',
     );
   });
 
@@ -65,12 +66,36 @@ describe('notification-relay checkDedup — Slot B coalesce key', () => {
   });
 });
 
+describe('shared notification-dedup helper — buildDedupMaterial', () => {
+  it('keys on coalesceKey when set, else falls back to eventType:title', () => {
+    assert.match(
+      notificationDedupSrc,
+      /coalesceKey\s*\?\s*`coalesce:\$\{coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{title\s*\?\?\s*''\}`/,
+      'buildDedupMaterial must use coalesceKey when set, else eventType:title',
+    );
+  });
+
+  it('is exported for reuse by all publishers', () => {
+    assert.match(
+      notificationDedupSrc,
+      /module\.exports\s*=\s*\{\s*buildDedupMaterial\s*\}/,
+      'buildDedupMaterial must be exported',
+    );
+  });
+
+  it('all three publishers import/require the shared helper (no re-inlined copies)', () => {
+    assert.match(relaySrc, /require\('\.\/shared\/notification-dedup\.cjs'\)/, 'notification-relay.cjs must require the shared helper');
+    assert.match(aisRelaySrc, /require\('\.\/shared\/notification-dedup\.cjs'\)/, 'ais-relay.cjs must require the shared helper');
+    assert.match(seedAviationSrc, /from '\.\/shared\/notification-dedup\.cjs'/, 'seed-aviation.mjs must import the shared helper');
+  });
+});
+
 describe('ais-relay publishNotificationEvent — Slot B publisher dedup', () => {
   it('publisher dedup key uses coalesceKey when set, else falls back to title', () => {
     assert.match(
       aisRelaySrc,
-      /payload\?\.coalesceKey\s*\?\s*`coalesce:\$\{payload\.coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{payload\.title\s*\?\?\s*''\}`/,
-      'publishNotificationEvent dedupMaterial must use coalesceKey when set',
+      /const dedupMaterial = buildDedupMaterial\(eventType,\s*payload\?\.title,\s*payload\?\.coalesceKey\)/,
+      'publishNotificationEvent must derive dedupMaterial via the shared buildDedupMaterial helper',
     );
   });
 });
@@ -86,6 +111,15 @@ describe('market alert producer — asset-family coalesce key', () => {
       aisRelaySrc,
       /return `market:\$\{assetClass\}:\$\{stableIdentifier\}:\$\{direction\}:\$\{severity\}`/,
       'market coalesce key must separate asset class, instrument, direction, and severity band',
+    );
+    // Lock the normalization line itself so a source change (dropping the
+    // 'unknown' fallback or the trim/lowercase) is caught — the behavioral test
+    // below re-derives this logic inline, so without this assertion the two
+    // could drift together silently. PR #4985 review finding #4.
+    assert.match(
+      aisRelaySrc,
+      /const stableIdentifier = String\(identifier \|\| 'unknown'\)\.trim\(\)\.toLowerCase\(\)/,
+      'market coalesce key must normalize identifier: fallback to unknown, then trim + lowercase',
     );
   });
 
@@ -119,16 +153,16 @@ describe('seed-aviation publishNotificationEvent — Slot B publisher dedup', ()
   it('publisher dedup key uses coalesceKey when set, else falls back to title', () => {
     assert.match(
       seedAviationSrc,
-      /payload\?\.coalesceKey\s*\?\s*`coalesce:\$\{payload\.coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{payload\.title\s*\?\?\s*''\}`/,
-      'seed-aviation publishNotificationEvent must use coalesceKey when set',
+      /const dedupMaterial = buildDedupMaterial\(eventType,\s*payload\?\.title,\s*payload\?\.coalesceKey\)/,
+      'seed-aviation publishNotificationEvent must derive dedupMaterial via the shared buildDedupMaterial helper',
     );
   });
 
   it('aviation and NOTAM notification payloads include coalesceKey', () => {
     assert.match(
       seedAviationSrc,
-      /coalesceKey:\s*`aviation:delay:\$\{a\.iata\}`/,
-      'airport delay notifications must coalesce by airport family',
+      /coalesceKey:\s*`aviation:closure:\$\{a\.iata\}:\$\{severity\}`/,
+      'airport disruption notifications must coalesce by airport + severity band so a MAJOR->SEVERE escalation re-notifies',
     );
     assert.match(
       seedAviationSrc,

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -170,6 +170,34 @@ describe('seed-aviation publishNotificationEvent — Slot B publisher dedup', ()
       'NOTAM closure notifications must coalesce by ICAO closure family',
     );
   });
+
+  it('aviation prev-state diff keys on airport + severity so escalations survive the upstream filter', () => {
+    // P1 (PR #4985 review): the coalesce key is severity-aware, but the upstream
+    // prevSet diff must use the SAME identity — else a MAJOR->SEVERE escalation
+    // for an already-alerted airport is filtered by !prevSet.has(a.iata) BEFORE
+    // the severity-aware coalesce key is ever reached, so the escalation never
+    // publishes.
+    assert.match(
+      seedAviationSrc,
+      /const aviationAlertKey = a => `\$\{a\.iata\}:\$\{aviationSeverityBand\(a\)\}`/,
+      'aviation must build an airport+severity identity matching the coalesce key',
+    );
+    assert.match(
+      seedAviationSrc,
+      /const newAlerts = severeAlerts\.filter\(a => a\.iata && !prevSet\.has\(aviationAlertKey\(a\)\)\)/,
+      'newAlerts must diff by airport+severity identity, not iata alone',
+    );
+    assert.match(
+      seedAviationSrc,
+      /new Set\(severeAlerts\.filter\(a => a\.iata\)\.map\(aviationAlertKey\)\)/,
+      'persisted prev-state must store the same airport+severity identity for next tick',
+    );
+    assert.doesNotMatch(
+      seedAviationSrc,
+      /!prevSet\.has\(a\.iata\)\)/,
+      'the airport-only prevSet filter (which drops escalations) must be gone',
+    );
+  });
 });
 
 describe('ais-relay deriveWeatherCoalesceKey — VTEC parser', () => {

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'), 'utf-8');
 const aisRelaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf-8');
+const seedAviationSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'seed-aviation.mjs'), 'utf-8');
 
 describe('notification-relay checkDedup — Slot B coalesce key', () => {
   it('checkDedup signature accepts an optional coalesceKey parameter', () => {
@@ -70,6 +71,69 @@ describe('ais-relay publishNotificationEvent — Slot B publisher dedup', () => 
       aisRelaySrc,
       /payload\?\.coalesceKey\s*\?\s*`coalesce:\$\{payload\.coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{payload\.title\s*\?\?\s*''\}`/,
       'publishNotificationEvent dedupMaterial must use coalesceKey when set',
+    );
+  });
+});
+
+describe('market alert producer — asset-family coalesce key', () => {
+  it('defines a stable market alert coalesce helper', () => {
+    assert.match(
+      aisRelaySrc,
+      /function marketAlertCoalesceKey\(assetClass,\s*identifier,\s*direction,\s*severity\)/,
+      'market alerts must build hidden family keys rather than deduping on the rounded subject',
+    );
+    assert.match(
+      aisRelaySrc,
+      /return `market:\$\{assetClass\}:\$\{stableIdentifier\}:\$\{direction\}:\$\{severity\}`/,
+      'market coalesce key must separate asset class, instrument, direction, and severity band',
+    );
+  });
+
+  it('all market_alert publishers pass coalesceKey through the payload', () => {
+    const marketBlocks = [...aisRelaySrc.matchAll(/eventType:\s*'market_alert'[\s\S]*?dedupTtl:\s*3600,/g)].map(m => m[0]);
+    assert.equal(marketBlocks.length, 3, 'expected equity, commodity, and crypto market_alert producers');
+    for (const block of marketBlocks) {
+      assert.match(
+        block,
+        /coalesceKey:\s*marketAlertCoalesceKey\(/,
+        `market_alert block must pass coalesceKey:\n${block}`,
+      );
+    }
+  });
+
+  it('rounded percent changes within the same critical commodity surge collapse to one family', () => {
+    const coalesce = (assetClass, identifier, direction, severity) =>
+      `market:${assetClass}:${String(identifier || 'unknown').trim().toLowerCase()}:${direction}:${severity}`;
+    const coffee11 = coalesce('commodity', 'KC=F', 'surge', 'critical');
+    const coffee13 = coalesce('commodity', 'KC=F', 'surge', 'critical');
+    assert.equal(coffee11, coffee13, 'Coffee +11% and +13% critical surge must share one dedup family');
+    assert.notEqual(
+      coffee11,
+      coalesce('commodity', 'KC=F', 'surge', 'high'),
+      'a high-to-critical threshold crossing may notify as a severity upgrade',
+    );
+  });
+});
+
+describe('seed-aviation publishNotificationEvent — Slot B publisher dedup', () => {
+  it('publisher dedup key uses coalesceKey when set, else falls back to title', () => {
+    assert.match(
+      seedAviationSrc,
+      /payload\?\.coalesceKey\s*\?\s*`coalesce:\$\{payload\.coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{payload\.title\s*\?\?\s*''\}`/,
+      'seed-aviation publishNotificationEvent must use coalesceKey when set',
+    );
+  });
+
+  it('aviation and NOTAM notification payloads include coalesceKey', () => {
+    assert.match(
+      seedAviationSrc,
+      /coalesceKey:\s*`aviation:delay:\$\{a\.iata\}`/,
+      'airport delay notifications must coalesce by airport family',
+    );
+    assert.match(
+      seedAviationSrc,
+      /coalesceKey:\s*`notam:closure:\$\{icao\}`/,
+      'NOTAM closure notifications must coalesce by ICAO closure family',
     );
   });
 });


### PR DESCRIPTION
## Summary
Repeated market alert emails now collapse by asset family instead of the rounded percent in the subject. Coffee +11%, +12%, and +13% critical surge updates share one Redis coalesce family during the existing publisher/user dedupe window, while a high-to-critical threshold crossing can still notify as a real severity upgrade.

Aviation and NOTAM producers now use the same coalesce-key branch in their local publisher copy, so airport delay or closure subjects can change without bypassing scan dedupe.

## Validation
- `node --test tests/notification-relay-coalesce-key.test.mjs`
- `node --test tests/notification-relay-payload-audit.test.mjs`
- `node --check scripts/ais-relay.cjs`
- `node --check scripts/seed-aviation.mjs`
- `git diff --check`
- `git push -u origin HEAD` pre-push hook: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundary lint, safe-HTML lint, Sentry coverage gate, rate-limit policy lint, premium-fetch parity, edge bundle check, changed coalesce test, and version sync all passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
