### PR TITLE
fix(gpsjam): restore the free gpsjam.org source, retire the Wingbits quota dependency

### DIFF
--- a/api/gpsjam.js
+++ b/api/gpsjam.js
@@ -14,44 +14,47 @@ const CACHE_TTL = 300_000;
 let negUntil = 0;
 const NEG_TTL = 60_000;
 
+// Normalize any stored hex to the web-UI shape the map reads (pct + affected/total
+// aircraft), regardless of which schema produced it: new gpsjam.org v2 (pct),
+// legacy Wingbits v2 (npAvg, still lingering under its 48h TTL right after the
+// 2026-07 source switch), or the v1 dual-write (pct/good/bad/total).
+export function toWebHex(hex) {
+  const base = { h3: hex.h3, lat: hex.lat, lon: hex.lon, level: hex.level, region: hex.region };
+  if (Number.isFinite(hex.pct)) {
+    return {
+      ...base,
+      pct: hex.pct,
+      affectedAircraft: hex.affectedAircraft ?? hex.bad ?? hex.sampleCount ?? 0,
+      totalAircraft: hex.totalAircraft ?? hex.total ?? hex.aircraftCount ?? 0,
+    };
+  }
+  // Legacy Wingbits v2 (npAvg, no pct): derive a coarse pct from the level buckets.
+  const npAvg = Number.isFinite(hex.npAvg) ? hex.npAvg : 2;
+  return {
+    ...base,
+    pct: npAvg <= 0.5 ? 15 : npAvg <= 1.0 ? 5 : 0,
+    affectedAircraft: hex.sampleCount ?? 0,
+    totalAircraft: hex.aircraftCount ?? 0,
+  };
+}
+
 async function fetchGpsJamData() {
   const now = Date.now();
   if (cached && now - cachedAt < CACHE_TTL) return cached;
   if (now < negUntil) return null;
 
-  let data;
-  try { data = await readJsonFromUpstash(REDIS_KEY); } catch { data = null; }
-
-  if (!data) {
-    let v1;
-    try { v1 = await readJsonFromUpstash(REDIS_KEY_V1); } catch { v1 = null; }
-    if (v1?.hexes) {
-      data = {
-        ...v1,
-        source: v1.source || 'gpsjam.org (normalized)',
-        hexes: v1.hexes.map(hex => {
-          if ('npAvg' in hex) return hex;
-          const pct = hex.pct || 0;
-          return {
-            h3: hex.h3,
-            lat: hex.lat,
-            lon: hex.lon,
-            level: hex.level,
-            region: hex.region,
-            npAvg: pct > 10 ? 0.3 : pct >= 2 ? 0.8 : 1.5,
-            sampleCount: hex.bad || 0,
-            aircraftCount: hex.total || 0,
-          };
-        }),
-      };
-    }
+  let raw;
+  try { raw = await readJsonFromUpstash(REDIS_KEY); } catch { raw = null; }
+  if (!raw) {
+    try { raw = await readJsonFromUpstash(REDIS_KEY_V1); } catch { raw = null; }
   }
 
-  if (!data) {
+  if (!raw?.hexes) {
     negUntil = now + NEG_TTL;
     return null;
   }
 
+  const data = { ...raw, source: raw.source || 'gpsjam.org', hexes: raw.hexes.map(toWebHex) };
   cached = data;
   cachedAt = now;
   return data;

--- a/scripts/_gpsjam-parse.mjs
+++ b/scripts/_gpsjam-parse.mjs
@@ -1,0 +1,110 @@
+// Pure gpsjam.org CSV parser, extracted from fetch-gpsjam.mjs so it can be
+// unit-tested without running the seeder's main()/network path.
+
+import { cellToLatLng, isValidCell } from 'h3-js';
+
+export function classifyRegion(lat, lon) {
+  if (lat >= 29 && lat <= 42 && lon >= 43 && lon <= 63) return 'iran-iraq';
+  if (lat >= 31 && lat <= 37 && lon >= 35 && lon <= 43) return 'levant';
+  if (lat >= 28 && lat <= 34 && lon >= 29 && lon <= 36) return 'israel-sinai';
+  if (lat >= 44 && lat <= 53 && lon >= 22 && lon <= 41) return 'ukraine-russia';
+  if (lat >= 54 && lat <= 70 && lon >= 27 && lon <= 60) return 'russia-north';
+  if (lat >= 36 && lat <= 42 && lon >= 26 && lon <= 45) return 'turkey-caucasus';
+  if (lat >= 32 && lat <= 38 && lon >= 63 && lon <= 75) return 'afghanistan-pakistan';
+  if (lat >= 10 && lat <= 20 && lon >= 42 && lon <= 55) return 'yemen-horn';
+  if (lat >= 0 && lat <= 12 && lon >= 32 && lon <= 48) return 'east-africa';
+  if (lat >= 15 && lat <= 24 && lon >= 25 && lon <= 40) return 'sudan-sahel';
+  if (lat >= 50 && lat <= 72 && lon >= -10 && lon <= 25) return 'northern-europe';
+  if (lat >= 35 && lat <= 50 && lon >= -10 && lon <= 25) return 'western-europe';
+  if (lat >= 1 && lat <= 8 && lon >= 95 && lon <= 108) return 'southeast-asia';
+  if (lat >= 20 && lat <= 45 && lon >= 100 && lon <= 145) return 'east-asia';
+  if (lat >= 25 && lat <= 50 && lon >= -125 && lon <= -65) return 'north-america';
+  return 'other';
+}
+
+// Daily H3 res-4 CSV → medium/high hexes in the v2 shape the consumers read.
+export function processHexes(csv, minAircraft = 3) {
+  const lines = csv.trim().split('\n');
+  const header = lines[0]; // hex,count_good_aircraft,count_bad_aircraft
+  if (!header.includes('hex')) throw new Error(`Unexpected CSV header: ${header}`);
+
+  const results = [];
+  let skippedLowSample = 0;
+  let skippedLow = 0;
+  // h3Attempts counts ONLY the rows that survive the minAircraft + interference
+  // filters and actually reach cellToLatLng — the correct denominator for the
+  // corruption guard. Comparing failures against all CSV rows (lines.length-1)
+  // made the guard unreachable: only ~4% of rows ever attempt H3 conversion.
+  let h3Attempts = 0;
+  let h3Failures = 0;
+
+  for (let i = 1; i < lines.length; i++) {
+    const parts = lines[i].split(',');
+    if (parts.length < 3) continue;
+
+    const hex = parts[0];
+    const good = parseInt(parts[1], 10);
+    const bad = parseInt(parts[2], 10);
+    if (!Number.isFinite(good) || !Number.isFinite(bad)) continue;
+    const total = good + bad;
+
+    if (total < minAircraft) { skippedLowSample++; continue; }
+
+    const pctRaw = (bad / total) * 100;
+    let level;
+    if (pctRaw > 10) level = 'high';
+    else if (pctRaw >= 2) level = 'medium';
+    else { skippedLow++; continue; }
+
+    h3Attempts++;
+    // h3-js cellToLatLng silently returns a bogus centroid for non-hex garbage
+    // (it only throws on hex-parseable-but-invalid cells), so validate first —
+    // otherwise corrupt rows seed as fake hexes at a fixed location AND never
+    // register as failures, defeating the abort guard below.
+    if (!isValidCell(hex)) { h3Failures++; continue; }
+    let lat, lon;
+    try {
+      const [lt, ln] = cellToLatLng(hex);
+      lat = Math.round(lt * 1e5) / 1e5;
+      lon = Math.round(ln * 1e5) / 1e5;
+    } catch {
+      h3Failures++;
+      continue;
+    }
+
+    const pct = Math.round(pctRaw * 10) / 10;
+    results.push({
+      h3: hex,
+      lat,
+      lon,
+      level,
+      region: classifyRegion(lat, lon),
+      // Web-UI fields (api/gpsjam.js → gps-interference.ts): the honest gpsjam.org metric.
+      pct,
+      affectedAircraft: bad,
+      totalAircraft: total,
+      // Public-API compat: list-gps-interference.ts + gps_jamming.proto still expose
+      // np_avg/sample_count/aircraft_count. Keep that contract stable (no proto regen)
+      // by carrying them here. np_avg has no gpsjam.org equivalent, so it's a pct-bucketed
+      // proxy — same mapping api/gpsjam.js already uses for the v1 fallback.
+      npAvg: pctRaw > 10 ? 0.3 : pctRaw >= 2 ? 0.8 : 1.5,
+      sampleCount: bad,
+      aircraftCount: total,
+    });
+  }
+
+  // Abort if a majority of ATTEMPTED conversions failed — a real upstream
+  // format/precision break, not a handful of bad hexes. Guarded on h3Attempts>0
+  // so an all-low-interference day doesn't divide-by-zero into a false abort.
+  if (h3Attempts > 0 && h3Failures > h3Attempts * 0.5) {
+    throw new Error(`>50% of attempted hexes failed h3 conversion (${h3Failures}/${h3Attempts}) — aborting seed`);
+  }
+
+  // High first, then by interference % descending (worst first).
+  results.sort((a, b) => {
+    if (a.level !== b.level) return a.level === 'high' ? -1 : 1;
+    return b.pct - a.pct;
+  });
+
+  return { results, skippedLowSample, skippedLow, h3Attempts, h3Failures, totalRows: lines.length - 1 };
+}

--- a/scripts/_gpsjam-parse.mjs
+++ b/scripts/_gpsjam-parse.mjs
@@ -24,6 +24,9 @@ export function classifyRegion(lat, lon) {
 
 // Daily H3 res-4 CSV → medium/high hexes in the v2 shape the consumers read.
 export function processHexes(csv, minAircraft = 3) {
+  // Coalesce an invalid threshold (e.g. NaN from a bad --min-aircraft) to 3.
+  // `total < NaN` is always false, which would silently disable the low-sample filter.
+  const minAir = Number.isFinite(minAircraft) && minAircraft > 0 ? minAircraft : 3;
   const lines = csv.trim().split('\n');
   const header = lines[0]; // hex,count_good_aircraft,count_bad_aircraft
   if (!header.includes('hex')) throw new Error(`Unexpected CSV header: ${header}`);
@@ -48,7 +51,7 @@ export function processHexes(csv, minAircraft = 3) {
     if (!Number.isFinite(good) || !Number.isFinite(bad)) continue;
     const total = good + bad;
 
-    if (total < minAircraft) { skippedLowSample++; continue; }
+    if (total < minAir) { skippedLowSample++; continue; }
 
     const pctRaw = (bad / total) * 100;
     let level;

--- a/scripts/fetch-gpsjam.mjs
+++ b/scripts/fetch-gpsjam.mjs
@@ -34,7 +34,9 @@ function getArg(name, fallback) {
 }
 
 const requestedDate = getArg('date', null);
-const minAircraft = parseInt(getArg('min-aircraft', '3'), 10);
+const minAircraftRaw = parseInt(getArg('min-aircraft', '3'), 10);
+// Guard against a typo'd --min-aircraft (NaN) silently disabling the low-sample filter.
+const minAircraft = Number.isFinite(minAircraftRaw) && minAircraftRaw > 0 ? minAircraftRaw : 3;
 const outputPath = getArg('output', null);
 
 function maskToken(token) {

--- a/scripts/fetch-gpsjam.mjs
+++ b/scripts/fetch-gpsjam.mjs
@@ -12,11 +12,11 @@
  * Run:  node scripts/fetch-gpsjam.mjs [--date YYYY-MM-DD] [--min-aircraft 3] [--output path.json]
  */
 
-import { cellToLatLng } from 'h3-js';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { extendExistingTtl } from './_seed-utils.mjs';
+import { processHexes } from './_gpsjam-parse.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.resolve(__dirname, 'data');
@@ -36,25 +36,6 @@ function getArg(name, fallback) {
 const requestedDate = getArg('date', null);
 const minAircraft = parseInt(getArg('min-aircraft', '3'), 10);
 const outputPath = getArg('output', null);
-
-function classifyRegion(lat, lon) {
-  if (lat >= 29 && lat <= 42 && lon >= 43 && lon <= 63) return 'iran-iraq';
-  if (lat >= 31 && lat <= 37 && lon >= 35 && lon <= 43) return 'levant';
-  if (lat >= 28 && lat <= 34 && lon >= 29 && lon <= 36) return 'israel-sinai';
-  if (lat >= 44 && lat <= 53 && lon >= 22 && lon <= 41) return 'ukraine-russia';
-  if (lat >= 54 && lat <= 70 && lon >= 27 && lon <= 60) return 'russia-north';
-  if (lat >= 36 && lat <= 42 && lon >= 26 && lon <= 45) return 'turkey-caucasus';
-  if (lat >= 32 && lat <= 38 && lon >= 63 && lon <= 75) return 'afghanistan-pakistan';
-  if (lat >= 10 && lat <= 20 && lon >= 42 && lon <= 55) return 'yemen-horn';
-  if (lat >= 0 && lat <= 12 && lon >= 32 && lon <= 48) return 'east-africa';
-  if (lat >= 15 && lat <= 24 && lon >= 25 && lon <= 40) return 'sudan-sahel';
-  if (lat >= 50 && lat <= 72 && lon >= -10 && lon <= 25) return 'northern-europe';
-  if (lat >= 35 && lat <= 50 && lon >= -10 && lon <= 25) return 'western-europe';
-  if (lat >= 1 && lat <= 8 && lon >= 95 && lon <= 108) return 'southeast-asia';
-  if (lat >= 20 && lat <= 45 && lon >= 100 && lon <= 145) return 'east-asia';
-  if (lat >= 25 && lat <= 50 && lon >= -125 && lon <= -65) return 'north-america';
-  return 'other';
-}
 
 function maskToken(token) {
   if (!token || token.length < 8) return '***';
@@ -78,79 +59,6 @@ async function getLatestDate() {
   const date = last.split(',')[0];
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new Error(`Unexpected manifest tail: ${last.slice(0, 80)}`);
   return date;
-}
-
-// Daily H3 res-4 CSV → medium/high hexes in the v2 shape the consumers read.
-function processHexes(csv) {
-  const lines = csv.trim().split('\n');
-  const header = lines[0]; // hex,count_good_aircraft,count_bad_aircraft
-  if (!header.includes('hex')) throw new Error(`Unexpected CSV header: ${header}`);
-
-  const results = [];
-  let skippedLowSample = 0;
-  let skippedLow = 0;
-  let h3Failures = 0;
-
-  for (let i = 1; i < lines.length; i++) {
-    const parts = lines[i].split(',');
-    if (parts.length < 3) continue;
-
-    const hex = parts[0];
-    const good = parseInt(parts[1], 10);
-    const bad = parseInt(parts[2], 10);
-    if (!Number.isFinite(good) || !Number.isFinite(bad)) continue;
-    const total = good + bad;
-
-    if (total < minAircraft) { skippedLowSample++; continue; }
-
-    const pctRaw = (bad / total) * 100;
-    let level;
-    if (pctRaw > 10) level = 'high';
-    else if (pctRaw >= 2) level = 'medium';
-    else { skippedLow++; continue; }
-
-    let lat, lon;
-    try {
-      const [lt, ln] = cellToLatLng(hex);
-      lat = Math.round(lt * 1e5) / 1e5;
-      lon = Math.round(ln * 1e5) / 1e5;
-    } catch {
-      h3Failures++;
-      continue;
-    }
-
-    const pct = Math.round(pctRaw * 10) / 10;
-    results.push({
-      h3: hex,
-      lat,
-      lon,
-      level,
-      region: classifyRegion(lat, lon),
-      // Web-UI fields (api/gpsjam.js → gps-interference.ts): the honest gpsjam.org metric.
-      pct,
-      affectedAircraft: bad,
-      totalAircraft: total,
-      // Public-API compat: list-gps-interference.ts + gps_jamming.proto still expose
-      // np_avg/sample_count/aircraft_count. Keep that contract stable (no proto regen)
-      // by carrying them here. np_avg has no gpsjam.org equivalent, so it's a pct-bucketed
-      // proxy — same mapping api/gpsjam.js already uses for the v1 fallback.
-      npAvg: pctRaw > 10 ? 0.3 : pctRaw >= 2 ? 0.8 : 1.5,
-      sampleCount: bad,
-      aircraftCount: total,
-    });
-  }
-
-  if (h3Failures > (lines.length - 1) * 0.5) {
-    throw new Error(`>50% of hexes failed h3 conversion (${h3Failures}/${lines.length - 1}) — aborting seed`);
-  }
-
-  // High first, then by interference % descending (worst first).
-  results.sort((a, b) => {
-    if (a.level !== b.level) return a.level === 'high' ? -1 : 1;
-    return b.pct - a.pct;
-  });
-
-  return { results, skippedLowSample, skippedLow, totalRows: lines.length - 1 };
 }
 
 async function seedRedis(output) {
@@ -240,7 +148,7 @@ async function main() {
   const url = `${BASE_URL}/${date}-h3_4.csv`;
   console.error(`[gpsjam] Fetching ${url}`);
   const csv = await fetchText(url);
-  const { results, skippedLowSample, skippedLow, totalRows } = processHexes(csv);
+  const { results, skippedLowSample, skippedLow, totalRows } = processHexes(csv, minAircraft);
 
   const highCount = results.filter(r => r.level === 'high').length;
   const mediumCount = results.filter(r => r.level === 'medium').length;

--- a/scripts/fetch-gpsjam.mjs
+++ b/scripts/fetch-gpsjam.mjs
@@ -1,5 +1,19 @@
+/**
+ * Fetches GPS/GNSS interference data from gpsjam.org (the free, no-auth source
+ * the layer is named after; ADS-B Exchange derived). Restored 2026-07 from the
+ * Wingbits customer API (#1240), which hit recurring monthly-quota (HTTP 402)
+ * exhaustion → silent staleness. gpsjam.org has no key and no quota.
+ *
+ * Source:  gpsjam.org/data/manifest.csv (latest date) + {date}-h3_4.csv
+ * Format:  H3 res-4 hexes, columns hex,count_good_aircraft,count_bad_aircraft.
+ * Metric:  pct = bad/total aircraft with GPS issues. Low <2%, Medium 2-10%, High >10%.
+ * Cadence: daily (updates once/day; the seed refreshes seed-meta.fetchedAt each run).
+ *
+ * Run:  node scripts/fetch-gpsjam.mjs [--date YYYY-MM-DD] [--min-aircraft 3] [--output path.json]
+ */
+
 import { cellToLatLng } from 'h3-js';
-import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { extendExistingTtl } from './_seed-utils.mjs';
@@ -10,6 +24,8 @@ const DATA_DIR = path.resolve(__dirname, 'data');
 const REDIS_KEY_V2 = 'intelligence:gpsjam:v2';
 const REDIS_KEY_V1 = 'intelligence:gpsjam:v1';
 const REDIS_TTL = 172800; // 48h
+const BASE_URL = 'https://gpsjam.org/data';
+const UA = 'Mozilla/5.0 (compatible; WorldMonitor/1.0)';
 
 const args = process.argv.slice(2);
 function getArg(name, fallback) {
@@ -17,6 +33,8 @@ function getArg(name, fallback) {
   return idx >= 0 && args[idx + 1] ? args[idx + 1] : fallback;
 }
 
+const requestedDate = getArg('date', null);
+const minAircraft = parseInt(getArg('min-aircraft', '3'), 10);
 const outputPath = getArg('output', null);
 
 function classifyRegion(lat, lon) {
@@ -38,122 +56,101 @@ function classifyRegion(lat, lon) {
   return 'other';
 }
 
-function loadEnvFile() {
-  const envPath = path.join(__dirname, '..', '.env.local');
-  if (!existsSync(envPath)) return;
-  const lines = readFileSync(envPath, 'utf8').split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIdx = trimmed.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = trimmed.slice(0, eqIdx).trim();
-    let val = trimmed.slice(eqIdx + 1).trim();
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1);
-    }
-    if (!process.env[key]) process.env[key] = val;
-  }
-}
-
 function maskToken(token) {
   if (!token || token.length < 8) return '***';
   return token.slice(0, 4) + '***' + token.slice(-4);
 }
 
-async function fetchWingbits(apiKey) {
-  const url = 'https://customer-api.wingbits.com/v1/gps/jam';
-  console.error(`[gpsjam] Fetching ${url}`);
-
+async function fetchText(url) {
   const resp = await fetch(url, {
-    headers: {
-      'x-api-key': apiKey,
-      'User-Agent': 'WorldMonitor/1.0',
-    },
+    headers: { 'User-Agent': UA, 'Accept-Encoding': 'gzip, deflate' },
     signal: AbortSignal.timeout(30_000),
   });
-
-  if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status} from Wingbits API`);
-  }
-
-  const body = await resp.json();
-
-  if (!Array.isArray(body.hexes)) {
-    throw new Error(`Invalid response: body.hexes is not an array`);
-  }
-
-  return body;
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${url}`);
+  return resp.text();
 }
 
-function processHexes(rawHexes) {
+// Latest available date is the last row of the manifest (date,suspect,num_bad_hexes).
+async function getLatestDate() {
+  const csv = await fetchText(`${BASE_URL}/manifest.csv`);
+  const lines = csv.trim().split('\n');
+  const last = lines[lines.length - 1];
+  const date = last.split(',')[0];
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new Error(`Unexpected manifest tail: ${last.slice(0, 80)}`);
+  return date;
+}
+
+// Daily H3 res-4 CSV → medium/high hexes in the v2 shape the consumers read.
+function processHexes(csv) {
+  const lines = csv.trim().split('\n');
+  const header = lines[0]; // hex,count_good_aircraft,count_bad_aircraft
+  if (!header.includes('hex')) throw new Error(`Unexpected CSV header: ${header}`);
+
   const results = [];
-  let skipped = 0;
+  let skippedLowSample = 0;
+  let skippedLow = 0;
   let h3Failures = 0;
 
-  for (const hex of rawHexes) {
-    if (typeof hex.h3Index !== 'string') {
-      console.error(`[gpsjam] WARN: skipping hex with non-string h3Index: ${JSON.stringify(hex).slice(0, 100)}`);
-      skipped++;
-      continue;
-    }
-    if (!Number.isFinite(hex.npAvg)) {
-      console.error(`[gpsjam] WARN: skipping hex ${hex.h3Index} — npAvg not finite: ${hex.npAvg}`);
-      skipped++;
-      continue;
-    }
-    if (!Number.isInteger(hex.sampleCount) || hex.sampleCount < 0) {
-      console.error(`[gpsjam] WARN: skipping hex ${hex.h3Index} — invalid sampleCount: ${hex.sampleCount}`);
-      skipped++;
-      continue;
-    }
-    if (!Number.isInteger(hex.aircraftCount) || hex.aircraftCount < 0) {
-      console.error(`[gpsjam] WARN: skipping hex ${hex.h3Index} — invalid aircraftCount: ${hex.aircraftCount}`);
-      skipped++;
-      continue;
-    }
+  for (let i = 1; i < lines.length; i++) {
+    const parts = lines[i].split(',');
+    if (parts.length < 3) continue;
 
+    const hex = parts[0];
+    const good = parseInt(parts[1], 10);
+    const bad = parseInt(parts[2], 10);
+    if (!Number.isFinite(good) || !Number.isFinite(bad)) continue;
+    const total = good + bad;
+
+    if (total < minAircraft) { skippedLowSample++; continue; }
+
+    const pctRaw = (bad / total) * 100;
     let level;
-    if (hex.npAvg <= 0.5) level = 'high';
-    else if (hex.npAvg <= 1.0) level = 'medium';
-    else continue; // skip low interference
+    if (pctRaw > 10) level = 'high';
+    else if (pctRaw >= 2) level = 'medium';
+    else { skippedLow++; continue; }
 
     let lat, lon;
     try {
-      const [lt, ln] = cellToLatLng(hex.h3Index);
+      const [lt, ln] = cellToLatLng(hex);
       lat = Math.round(lt * 1e5) / 1e5;
       lon = Math.round(ln * 1e5) / 1e5;
     } catch {
-      console.error(`[gpsjam] WARN: h3 conversion failed for ${hex.h3Index}`);
       h3Failures++;
       continue;
     }
 
+    const pct = Math.round(pctRaw * 10) / 10;
     results.push({
-      h3: hex.h3Index,
+      h3: hex,
       lat,
       lon,
       level,
-      npAvg: hex.npAvg,
-      sampleCount: hex.sampleCount,
-      aircraftCount: hex.aircraftCount,
       region: classifyRegion(lat, lon),
+      // Web-UI fields (api/gpsjam.js → gps-interference.ts): the honest gpsjam.org metric.
+      pct,
+      affectedAircraft: bad,
+      totalAircraft: total,
+      // Public-API compat: list-gps-interference.ts + gps_jamming.proto still expose
+      // np_avg/sample_count/aircraft_count. Keep that contract stable (no proto regen)
+      // by carrying them here. np_avg has no gpsjam.org equivalent, so it's a pct-bucketed
+      // proxy — same mapping api/gpsjam.js already uses for the v1 fallback.
+      npAvg: pctRaw > 10 ? 0.3 : pctRaw >= 2 ? 0.8 : 1.5,
+      sampleCount: bad,
+      aircraftCount: total,
     });
   }
 
-  if (h3Failures > rawHexes.length * 0.5) {
-    throw new Error(`>50% of hexes failed h3 conversion (${h3Failures}/${rawHexes.length}) — aborting seed`);
+  if (h3Failures > (lines.length - 1) * 0.5) {
+    throw new Error(`>50% of hexes failed h3 conversion (${h3Failures}/${lines.length - 1}) — aborting seed`);
   }
 
-  // Sort: high first, then by npAvg ascending (lower = worse)
+  // High first, then by interference % descending (worst first).
   results.sort((a, b) => {
     if (a.level !== b.level) return a.level === 'high' ? -1 : 1;
-    return a.npAvg - b.npAvg;
+    return b.pct - a.pct;
   });
 
-  console.error(`[gpsjam] Processed ${rawHexes.length} hexes → ${results.length} kept, ${skipped} invalid, ${h3Failures} h3 failures`);
-
-  return results;
+  return { results, skippedLowSample, skippedLow, totalRows: lines.length - 1 };
 }
 
 async function seedRedis(output) {
@@ -171,15 +168,12 @@ async function seedRedis(output) {
 
   const payload = JSON.stringify(output);
 
-  // Write v2
-  const v2Body = JSON.stringify(['SET', REDIS_KEY_V2, payload, 'EX', REDIS_TTL]);
   const v2Resp = await fetch(redisUrl, {
     method: 'POST',
     headers: { Authorization: `Bearer ${redisToken}`, 'Content-Type': 'application/json' },
-    body: v2Body,
+    body: JSON.stringify(['SET', REDIS_KEY_V2, payload, 'EX', REDIS_TTL]),
     signal: AbortSignal.timeout(15_000),
   });
-
   if (!v2Resp.ok) {
     const text = await v2Resp.text().catch(() => '');
     console.error(`[gpsjam] Redis SET v2 failed: HTTP ${v2Resp.status} — ${text.slice(0, 200)}`);
@@ -187,30 +181,28 @@ async function seedRedis(output) {
   }
   console.error(`[gpsjam] Redis SET v2 result:`, await v2Resp.json());
 
-  // Dual-write v1 in old schema shape so pre-deploy code can parse it
+  // Dual-write v1 in the original gpsjam.org schema (good/bad/total) for any
+  // reader still on the pre-migration shape.
   const v1Output = {
     ...output,
-    source: output.source || 'wingbits',
     hexes: output.hexes.map(hex => ({
       h3: hex.h3,
       lat: hex.lat,
       lon: hex.lon,
       level: hex.level,
       region: hex.region,
-      pct: hex.npAvg <= 0.5 ? 15 : hex.npAvg <= 1.0 ? 5 : 0,
-      good: Math.max(0, hex.aircraftCount - hex.sampleCount),
-      bad: hex.sampleCount,
-      total: hex.aircraftCount,
+      pct: hex.pct,
+      good: Math.max(0, hex.totalAircraft - hex.affectedAircraft),
+      bad: hex.affectedAircraft,
+      total: hex.totalAircraft,
     })),
   };
-  const v1Body = JSON.stringify(['SET', REDIS_KEY_V1, JSON.stringify(v1Output), 'EX', REDIS_TTL]);
   const v1Resp = await fetch(redisUrl, {
     method: 'POST',
     headers: { Authorization: `Bearer ${redisToken}`, 'Content-Type': 'application/json' },
-    body: v1Body,
+    body: JSON.stringify(['SET', REDIS_KEY_V1, JSON.stringify(v1Output), 'EX', REDIS_TTL]),
     signal: AbortSignal.timeout(15_000),
   });
-
   if (!v1Resp.ok) {
     const text = await v1Resp.text().catch(() => '');
     console.error(`[gpsjam] Redis SET v1 failed: HTTP ${v1Resp.status} — ${text.slice(0, 200)}`);
@@ -218,7 +210,6 @@ async function seedRedis(output) {
     console.error(`[gpsjam] Redis SET v1 result:`, await v1Resp.json());
   }
 
-  // Verify v2
   const getResp = await fetch(`${redisUrl}/get/${encodeURIComponent(REDIS_KEY_V2)}`, {
     headers: { Authorization: `Bearer ${redisToken}` },
     signal: AbortSignal.timeout(5_000),
@@ -227,57 +218,44 @@ async function seedRedis(output) {
     const getData = await getResp.json();
     if (getData.result) {
       const parsed = JSON.parse(getData.result);
-      console.error(`[gpsjam] Verified: ${parsed.hexes?.length} hexes in Redis (source: ${parsed.source})`);
+      console.error(`[gpsjam] Verified: ${parsed.hexes?.length} hexes in Redis (date: ${parsed.date})`);
     }
   }
 
-  // Write seed-meta
   const metaKey = 'seed-meta:intelligence:gpsjam';
   const meta = { fetchedAt: Date.now(), recordCount: output.hexes?.length || 0 };
-  const metaBody = JSON.stringify(['SET', metaKey, JSON.stringify(meta), 'EX', 604800]);
   await fetch(redisUrl, {
     method: 'POST',
     headers: { Authorization: `Bearer ${redisToken}`, 'Content-Type': 'application/json' },
-    body: metaBody,
+    body: JSON.stringify(['SET', metaKey, JSON.stringify(meta), 'EX', 604800]),
     signal: AbortSignal.timeout(5_000),
   }).catch(() => console.error('[gpsjam] seed-meta write failed'));
   console.error(`[gpsjam] Wrote seed-meta: ${metaKey}`);
 }
 
 async function main() {
-  loadEnvFile();
-  const apiKey = process.env.WINGBITS_API_KEY;
-  if (!apiKey) {
-    console.error('[gpsjam] WINGBITS_API_KEY not set — cannot fetch data');
-    process.exit(1);
-  }
+  const date = requestedDate || await getLatestDate();
+  console.error(`[gpsjam] Date: ${date}, min aircraft: ${minAircraft}`);
 
-  let body;
-  try {
-    body = await fetchWingbits(apiKey);
-  } catch (err) {
-    console.error(`[gpsjam] Fetch failed: ${err.message} — extending TTL on stale data`);
-    await extendExistingTtl([REDIS_KEY_V2, REDIS_KEY_V1, 'seed-meta:intelligence:gpsjam'], REDIS_TTL);
-    process.exit(0);
-  }
+  const url = `${BASE_URL}/${date}-h3_4.csv`;
+  console.error(`[gpsjam] Fetching ${url}`);
+  const csv = await fetchText(url);
+  const { results, skippedLowSample, skippedLow, totalRows } = processHexes(csv);
 
-  const hexes = processHexes(body.hexes);
-
-  const highCount = hexes.filter(r => r.level === 'high').length;
-  const mediumCount = hexes.filter(r => r.level === 'medium').length;
+  const highCount = results.filter(r => r.level === 'high').length;
+  const mediumCount = results.filter(r => r.level === 'medium').length;
 
   const output = {
+    date,
     fetchedAt: new Date().toISOString(),
-    source: 'wingbits',
-    stats: {
-      totalHexes: body.hexes.length,
-      highCount,
-      mediumCount,
-    },
-    hexes,
+    source: 'gpsjam.org',
+    attribution: 'Data derived from ADS-B Exchange via gpsjam.org',
+    minAircraftThreshold: minAircraft,
+    stats: { totalHexes: totalRows, highCount, mediumCount, skippedLowSample, skippedLow },
+    hexes: results,
   };
 
-  console.error(`[gpsjam] ${body.hexes.length} total hexes → ${highCount} high, ${mediumCount} medium`);
+  console.error(`[gpsjam] ${totalRows} total hexes → ${highCount} high, ${mediumCount} medium (skipped: ${skippedLowSample} low-sample, ${skippedLow} low-interference)`);
 
   if (outputPath) {
     mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
@@ -294,7 +272,14 @@ async function main() {
   await seedRedis(output);
 }
 
-main().catch(err => {
-  console.error(`[gpsjam] Fatal: ${err.message}`);
-  process.exit(1);
+main().catch(async err => {
+  // Preserve-last-good: gpsjam.org is a daily feed; a transient fetch/parse
+  // failure must not blow away yesterday's hexes. Extend the existing TTLs and
+  // exit 0 (graceful), matching the seeder convention. seed-meta.fetchedAt is
+  // intentionally NOT refreshed, so a persistent outage still surfaces via the
+  // age-based STALE_SEED alarm (api/health.js gpsjam maxStaleMin=1440).
+  console.error(`[gpsjam] Fetch failed: ${err.message} — extending TTL on stale data`);
+  await extendExistingTtl([REDIS_KEY_V2, REDIS_KEY_V1, 'seed-meta:intelligence:gpsjam'], REDIS_TTL)
+    .catch(e => console.error(`[gpsjam] TTL extend failed: ${e.message}`));
+  process.exit(0);
 });

--- a/scripts/regional-snapshot/freshness.mjs
+++ b/scripts/regional-snapshot/freshness.mjs
@@ -52,7 +52,7 @@ export const FRESHNESS_REGISTRY = [
   { key: 'aviation:delays:faa:v1',               maxAgeMin: 60,    feedsAxes: ['mobility'], metaKey: 'seed-meta:aviation:faa' },
   { key: 'aviation:delays:intl:v3',              maxAgeMin: 90,    feedsAxes: ['mobility'], metaKey: 'seed-meta:aviation:intl' },
   { key: 'aviation:notam:closures:v2',           maxAgeMin: 120,   feedsAxes: ['mobility'], metaKey: 'seed-meta:aviation:notam' },
-  { key: 'intelligence:gpsjam:v2',               maxAgeMin: 240,   feedsAxes: ['mobility', 'airspace'], metaKey: 'seed-meta:intelligence:gpsjam' },
+  { key: 'intelligence:gpsjam:v2',               maxAgeMin: 1440,  feedsAxes: ['mobility', 'airspace'], metaKey: 'seed-meta:intelligence:gpsjam' }, // gpsjam.org is a DAILY source (restored from Wingbits, PR #4987); 1440min matches api/health.js gpsjam.maxStaleMin so snapshots don't mark it stale hours after a healthy daily seed.
   // military:flights:v1 already carries top-level fetchedAt, no metaKey needed.
   { key: 'military:flights:v1',                  maxAgeMin: 30,    feedsAxes: ['mobility', 'reroute_intensity'] },
 ];

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4826,7 +4826,7 @@ export class DeckGLMap {
       case 'ais-disruptions-layer':
         return { html: `<div class="deckgl-tooltip"><strong>AIS ${text(obj.type || t('components.deckgl.tooltip.disruption'))}</strong><br/>${text(obj.severity)} ${t('popups.severity')}<br/>${text(obj.description)}</div>` };
       case 'gps-jamming-layer':
-        return { html: `<div class="deckgl-tooltip"><strong>GPS Jamming</strong><br/>${text(obj.level)} · NP avg: ${Number(obj.npAvg).toFixed(2)}<br/>H3: ${text(obj.h3)}</div>` };
+        return { html: `<div class="deckgl-tooltip"><strong>GPS Jamming</strong><br/>${text(obj.level)} · aircraft affected: ${Number(obj.pct).toFixed(1)}%<br/>H3: ${text(obj.h3)}</div>` };
       case 'cable-advisories-layer': {
         const cableName = UNDERSEA_CABLES.find(c => c.id === obj.cableId)?.name || obj.cableId;
         return { html: `<div class="deckgl-tooltip"><strong>${text(cableName)}</strong><br/>${text(obj.severity || t('components.deckgl.tooltip.advisory'))}<br/>${text(obj.description)}</div>` };

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -212,7 +212,7 @@ interface GpsJamMarker extends BaseMarker {
   _kind: 'gpsjam';
   id: string;
   level: string;
-  npAvg: number;
+  pct: number;
 }
 interface TechMarker extends BaseMarker {
   _kind: 'tech';
@@ -1487,7 +1487,7 @@ export class GlobeMap {
       const gc = d.level === 'high' ? '#ff2020' : '#ff8800';
       html = `<span style="color:${gc};font-weight:bold;">📡 GPS Jamming</span>` +
              `<br><span style="opacity:.7;">Level: ${esc(d.level)}</span>` +
-             `<br><span style="opacity:.5;">Avg satellites visible: ${d.npAvg.toFixed(1)}</span>`;
+             `<br><span style="opacity:.5;">Aircraft affected: ${d.pct.toFixed(1)}%</span>`;
     } else if (d._kind === 'tech') {
       html = `<span style="color:#44aaff;font-weight:bold;">💻 ${esc(d.title.slice(0, 50))}</span>` +
              `<br><span style="opacity:.7;">${esc(d.country)}</span>` +
@@ -3287,7 +3287,7 @@ export class GlobeMap {
       _lng: h.lon,
       id: h.h3,
       level: h.level,
-      npAvg: h.npAvg ?? 0,
+      pct: h.pct ?? 0,
     }));
     this.flushMarkers();
   }

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -126,9 +126,9 @@ interface GpsJammingPopupData {
   lat: number;
   lon: number;
   level: 'medium' | 'high';
-  npAvg: number;
-  sampleCount: number;
-  aircraftCount: number;
+  pct: number;
+  affectedAircraft: number;
+  totalAircraft: number;
 }
 
 interface IranEventPopupData {
@@ -3513,15 +3513,15 @@ ${isFeatureAvailable('wingbitsEnrichment') ? '<div class="wingbits-live-section"
         <div class="popup-stats">
           <div class="popup-stat">
             <span class="stat-label">${t('popups.gpsJamming.navPerformance')}</span>
-            <span class="stat-value">${Number(data.npAvg).toFixed(2)}</span>
+            <span class="stat-value">${Number(data.pct).toFixed(1)}%</span>
           </div>
           <div class="popup-stat">
             <span class="stat-label">${t('popups.gpsJamming.samples')}</span>
-            <span class="stat-value">${data.sampleCount}</span>
+            <span class="stat-value">${data.affectedAircraft}</span>
           </div>
           <div class="popup-stat">
             <span class="stat-label">${t('popups.gpsJamming.aircraft')}</span>
-            <span class="stat-value">${data.aircraftCount}</span>
+            <span class="stat-value">${data.totalAircraft}</span>
           </div>
           <div class="popup-stat">
             <span class="stat-label">${t('popups.gpsJamming.h3Hex')}</span>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2454,9 +2454,9 @@
     },
     "gpsJamming": {
       "title": "GPS/GNSS Interference",
-      "navPerformance": "Nav Performance",
-      "samples": "ADS-B Samples",
-      "aircraft": "Aircraft",
+      "navPerformance": "Aircraft Affected",
+      "samples": "Affected Count",
+      "aircraft": "Aircraft Seen",
       "h3Hex": "H3 Hex"
     },
     "flight": {

--- a/src/services/gps-interference.ts
+++ b/src/services/gps-interference.ts
@@ -5,9 +5,11 @@ export interface GpsJamHex {
   lat: number;
   lon: number;
   level: 'medium' | 'high';
-  npAvg: number;
-  sampleCount: number;
-  aircraftCount: number;
+  // gpsjam.org metric (restored 2026-07): share of aircraft in the hex reporting
+  // GPS interference. pct = affectedAircraft / totalAircraft * 100.
+  pct: number;
+  affectedAircraft: number;
+  totalAircraft: number;
 }
 
 export interface GpsJamData {
@@ -46,9 +48,9 @@ export async function fetchGpsInterference(): Promise<GpsJamData | null> {
       lat: h.lat,
       lon: h.lon,
       level: h.level as 'medium' | 'high',
-      npAvg: Number.isFinite(h.npAvg) ? h.npAvg : 0,
-      sampleCount: Number.isFinite(h.sampleCount) ? h.sampleCount : 0,
-      aircraftCount: Number.isFinite(h.aircraftCount) ? h.aircraftCount : 0,
+      pct: Number.isFinite(h.pct) ? h.pct : 0,
+      affectedAircraft: Number.isFinite(h.affectedAircraft) ? h.affectedAircraft : 0,
+      totalAircraft: Number.isFinite(h.totalAircraft) ? h.totalAircraft : 0,
     }));
 
     cachedData = {

--- a/tests/globe-tooltip-enrichment.test.mjs
+++ b/tests/globe-tooltip-enrichment.test.mjs
@@ -111,9 +111,12 @@ describe('GlobeMap tooltip enrichment', () => {
     assert.ok(src.includes('Heading:'), 'flight tooltip must display Heading label');
   });
 
-  it('GPS jamming tooltip uses human-readable satellite label', () => {
-    assert.ok(src.includes('Avg satellites visible'), 'gpsjam must show readable label');
-    assert.ok(!src.includes('NP avg:'), 'gpsjam must not use cryptic NP avg label');
+  it('GPS jamming tooltip uses the gpsjam.org interference metric (% aircraft affected)', () => {
+    // Source reverted from Wingbits (np_avg / "satellites visible") to gpsjam.org,
+    // whose native metric is the share of aircraft reporting GPS interference.
+    assert.ok(src.includes('Aircraft affected'), 'gpsjam must show the readable % aircraft affected label');
+    assert.ok(!src.includes('NP avg:'), 'gpsjam must not use the cryptic NP avg label');
+    assert.ok(!src.includes('Avg satellites visible'), 'gpsjam.org has no satellite-visibility metric');
   });
 
   it('extends hide delay to 6s for rich tooltip kinds', () => {

--- a/tests/gpsjam-org-restore.test.mjs
+++ b/tests/gpsjam-org-restore.test.mjs
@@ -88,6 +88,17 @@ describe('gpsjam.org CSV parser (_gpsjam-parse.mjs)', () => {
     assert.equal(typeof h.region, 'string');
   });
 
+  test('coalesces an invalid minAircraft (NaN) to the default so the low-sample filter stays active', () => {
+    const csv = [
+      CSV_HEADER,
+      `${VALID_H3},0,10`, // total 10 → high, kept
+      `${VALID_H3},1,1`,  // total 2 → would leak in if the threshold were NaN
+    ].join('\n');
+    const { results, skippedLowSample } = processHexes(csv, NaN);
+    assert.equal(skippedLowSample, 1, 'total-2 row must still be dropped under the default-3 threshold');
+    assert.equal(results.length, 1);
+  });
+
   test('drops <2% interference rows and rows below minAircraft', () => {
     const csv = [
       CSV_HEADER,

--- a/tests/gpsjam-org-restore.test.mjs
+++ b/tests/gpsjam-org-restore.test.mjs
@@ -14,9 +14,13 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { toWebHex } from '../api/gpsjam.js';
+import { processHexes } from '../scripts/_gpsjam-parse.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const read = (p) => readFileSync(resolve(repoRoot, p), 'utf8');
+
+const CSV_HEADER = 'hex,count_good_aircraft,count_bad_aircraft';
+const VALID_H3 = '841f41dffffffff'; // res-4 cell (from live gpsjam.org data)
 
 describe('api/gpsjam.js toWebHex — normalizes every stored shape to the web-UI shape', () => {
   test('new gpsjam.org v2 hex passes pct/affected/total through', () => {
@@ -40,14 +44,10 @@ describe('api/gpsjam.js toWebHex — normalizes every stored shape to the web-UI
 });
 
 describe('gpsjam.org restore — source wiring guards', () => {
-  test('fetcher pulls gpsjam.org (free, no key) and emits the superset shape', () => {
+  test('fetcher pulls gpsjam.org (free, no key)', () => {
     const src = read('scripts/fetch-gpsjam.mjs');
     assert.match(src, /BASE_URL = 'https:\/\/gpsjam\.org\/data'/);
     assert.doesNotMatch(src, /WINGBITS_API_KEY|customer-api\.wingbits\.com|x-api-key/, 'Wingbits dependency must be gone');
-    // superset: web-UI fields + public-API proto fields on the same hex.
-    for (const field of ['pct', 'affectedAircraft', 'totalAircraft', 'npAvg', 'sampleCount', 'aircraftCount']) {
-      assert.match(src, new RegExp(`${field}[,:]`), `fetcher hex must carry ${field}`);
-    }
   });
 
   test('fetcher preserves last-good on failure (extendExistingTtl + exit 0), no fetchedAt refresh', () => {
@@ -65,5 +65,57 @@ describe('gpsjam.org restore — source wiring guards', () => {
   test('public proto API contract is unchanged (still reads npAvg / np_avg)', () => {
     assert.match(read('server/worldmonitor/intelligence/v1/list-gps-interference.ts'), /npAvg: toNumber\(hex\.npAvg\)/);
     assert.match(read('proto/worldmonitor/intelligence/v1/gps_jamming.proto'), /double np_avg = 5/);
+  });
+});
+
+describe('gpsjam.org CSV parser (_gpsjam-parse.mjs)', () => {
+  test('parses a row into the superset hex shape + classifies level by pct', () => {
+    const csv = [
+      CSV_HEADER,
+      `${VALID_H3},0,10`, // 100% bad → high
+      `${VALID_H3},1,1`,  // total 2 < minAircraft(3) → skipped low-sample
+    ].join('\n');
+    const { results, skippedLowSample } = processHexes(csv, 3);
+    assert.equal(results.length, 1);
+    assert.equal(skippedLowSample, 1);
+    const h = results[0];
+    // web-UI fields + public-API proto fields on the same hex.
+    assert.deepEqual(
+      { pct: h.pct, affectedAircraft: h.affectedAircraft, totalAircraft: h.totalAircraft, npAvg: h.npAvg, sampleCount: h.sampleCount, aircraftCount: h.aircraftCount, level: h.level },
+      { pct: 100, affectedAircraft: 10, totalAircraft: 10, npAvg: 0.3, sampleCount: 10, aircraftCount: 10, level: 'high' },
+    );
+    assert.equal(typeof h.lat, 'number');
+    assert.equal(typeof h.region, 'string');
+  });
+
+  test('drops <2% interference rows and rows below minAircraft', () => {
+    const csv = [
+      CSV_HEADER,
+      `${VALID_H3},99,1`,  // 1% → below 2% → skipped low-interference
+      `${VALID_H3},95,5`,  // 5% → medium
+    ].join('\n');
+    const { results, skippedLow } = processHexes(csv, 3);
+    assert.equal(skippedLow, 1);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].level, 'medium');
+  });
+
+  // Regression for the ce-code-review #4987 P2 finding: the h3-conversion abort
+  // guard must use ATTEMPTED conversions as the denominator, not all CSV rows.
+  // Here every attempted hex has an invalid H3, padded by many rows that never
+  // attempt conversion — the old `> (lines.length-1) * 0.5` guard would never
+  // trip; the `> h3Attempts * 0.5` guard must.
+  test('aborts when a majority of ATTEMPTED h3 conversions fail (not vs all rows)', () => {
+    const rows = [CSV_HEADER];
+    for (let i = 0; i < 3; i++) rows.push(`not-a-valid-h3-${i},0,10`); // high, attempts h3, fails
+    for (let i = 0; i < 50; i++) rows.push(`${VALID_H3},99,1`);        // 1% → never attempts h3
+    assert.throws(() => processHexes(rows.join('\n'), 3), /attempted hexes failed h3 conversion \(3\/3\)/);
+  });
+
+  test('does NOT abort when failures are a minority of attempts', () => {
+    const rows = [CSV_HEADER, `bad-h3,0,10`]; // 1 attempt, fails
+    for (let i = 0; i < 4; i++) rows.push(`${VALID_H3},0,10`); // 4 attempts succeed
+    const { results } = processHexes(rows.join('\n'), 3);
+    assert.equal(results.length, 4); // 1/5 failure < 50% → no abort
   });
 });

--- a/tests/gpsjam-org-restore.test.mjs
+++ b/tests/gpsjam-org-restore.test.mjs
@@ -1,0 +1,69 @@
+// gpsjam.org restore (2026-07): the GPS-interference layer's source reverted
+// from the quota-limited Wingbits API back to the free gpsjam.org daily CSV.
+//
+// The fetcher emits a SUPERSET hex so BOTH consumer paths keep working with no
+// breaking change:
+//   - web UI  (api/gpsjam.js → gps-interference.ts → map): the honest gpsjam.org
+//     metric — pct + affected/total aircraft.
+//   - public API (list-gps-interference.ts + gps_jamming.proto): the stable
+//     np_avg/sample_count/aircraft_count contract (no proto regen).
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { toWebHex } from '../api/gpsjam.js';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => readFileSync(resolve(repoRoot, p), 'utf8');
+
+describe('api/gpsjam.js toWebHex — normalizes every stored shape to the web-UI shape', () => {
+  test('new gpsjam.org v2 hex passes pct/affected/total through', () => {
+    const h = toWebHex({ h3: 'a', lat: 1, lon: 2, level: 'high', region: 'levant', pct: 15.3, affectedAircraft: 5, totalAircraft: 30, npAvg: 0.3, sampleCount: 5, aircraftCount: 30 });
+    assert.deepEqual(h, { h3: 'a', lat: 1, lon: 2, level: 'high', region: 'levant', pct: 15.3, affectedAircraft: 5, totalAircraft: 30 });
+  });
+
+  test('legacy Wingbits v2 hex (npAvg, no pct) is converted during the transition window', () => {
+    const h = toWebHex({ h3: 'b', lat: 1, lon: 2, level: 'high', region: 'other', npAvg: 0.3, sampleCount: 7, aircraftCount: 40 });
+    assert.equal(h.pct, 15, 'npAvg<=0.5 → high bucket pct');
+    assert.equal(h.affectedAircraft, 7, 'sampleCount → affectedAircraft');
+    assert.equal(h.totalAircraft, 40, 'aircraftCount → totalAircraft');
+  });
+
+  test('v1 dual-write hex (good/bad/total) maps bad→affected, total→total', () => {
+    const h = toWebHex({ h3: 'c', lat: 1, lon: 2, level: 'medium', region: 'ukraine-russia', pct: 8, good: 20, bad: 4, total: 24 });
+    assert.equal(h.pct, 8);
+    assert.equal(h.affectedAircraft, 4);
+    assert.equal(h.totalAircraft, 24);
+  });
+});
+
+describe('gpsjam.org restore — source wiring guards', () => {
+  test('fetcher pulls gpsjam.org (free, no key) and emits the superset shape', () => {
+    const src = read('scripts/fetch-gpsjam.mjs');
+    assert.match(src, /BASE_URL = 'https:\/\/gpsjam\.org\/data'/);
+    assert.doesNotMatch(src, /WINGBITS_API_KEY|customer-api\.wingbits\.com|x-api-key/, 'Wingbits dependency must be gone');
+    // superset: web-UI fields + public-API proto fields on the same hex.
+    for (const field of ['pct', 'affectedAircraft', 'totalAircraft', 'npAvg', 'sampleCount', 'aircraftCount']) {
+      assert.match(src, new RegExp(`${field}[,:]`), `fetcher hex must carry ${field}`);
+    }
+  });
+
+  test('fetcher preserves last-good on failure (extendExistingTtl + exit 0), no fetchedAt refresh', () => {
+    const src = read('scripts/fetch-gpsjam.mjs');
+    assert.match(src, /extendExistingTtl\(\[REDIS_KEY_V2, REDIS_KEY_V1, 'seed-meta:intelligence:gpsjam'\]/);
+    assert.match(src, /process\.exit\(0\)/);
+  });
+
+  test('web UI reads the gpsjam.org metric (pct), not npAvg', () => {
+    assert.match(read('src/services/gps-interference.ts'), /pct: number;[\s\S]*affectedAircraft: number;[\s\S]*totalAircraft: number;/);
+    assert.doesNotMatch(read('src/services/gps-interference.ts'), /npAvg/);
+    assert.match(read('src/components/MapPopup.ts'), /Number\(data\.pct\)\.toFixed\(1\)/);
+  });
+
+  test('public proto API contract is unchanged (still reads npAvg / np_avg)', () => {
+    assert.match(read('server/worldmonitor/intelligence/v1/list-gps-interference.ts'), /npAvg: toNumber\(hex\.npAvg\)/);
+    assert.match(read('proto/worldmonitor/intelligence/v1/gps_jamming.proto'), /double np_avg = 5/);
+  });
+});

--- a/tests/regional-snapshot-mobility.test.mjs
+++ b/tests/regional-snapshot-mobility.test.mjs
@@ -603,6 +603,25 @@ describe('classifyInputs metaKey fallback (PR #2976 P2 #2)', () => {
     assert.ok(!result.fresh.includes('aviation:delays:faa:v1'));
   });
 
+  // PR #4987: gpsjam restored to the DAILY gpsjam.org source. Its freshness
+  // budget must match the daily cadence / api/health.js (1440min), not the old
+  // 240min (4h) that marked a healthy daily seed stale hours after it ran.
+  it('gpsjam seed ~5h old stays fresh under the daily-source budget', () => {
+    const meta = { fetchedAt: Date.now() - 5 * 60 * 60_000 }; // 5h old — was > 240min, now < 1440min
+    const result = classifyInputs(
+      { 'intelligence:gpsjam:v2': { hexes: [] } },
+      { 'seed-meta:intelligence:gpsjam': meta },
+    );
+    assert.ok(result.fresh.includes('intelligence:gpsjam:v2'), 'gpsjam 5h-old must be fresh under the 1440min daily budget');
+    assert.ok(!result.stale.includes('intelligence:gpsjam:v2'));
+  });
+
+  it('gpsjam freshness budget matches the daily cadence / api/health.js (1440min)', () => {
+    const spec = FRESHNESS_REGISTRY.find((s) => s.key === 'intelligence:gpsjam:v2');
+    assert.ok(spec);
+    assert.equal(spec.maxAgeMin, 1440);
+  });
+
   it('missing payload → classified as missing regardless of meta', () => {
     const result = classifyInputs(
       { 'aviation:delays:faa:v1': null },


### PR DESCRIPTION
## Why

The GPS-interference layer (named after **gpsjam.org**) was migrated to the **Wingbits customer API** in #1240. Wingbits enforces a monthly quota → recurring **HTTP 402** exhaustion → the seeder's graceful preserve-last-good path silently froze the data (observed **~10 days stale**, and currently a `STALE_SEED` WARNING on `/api/health`). gpsjam.org is the original **free, no-auth, daily** ADS-B-derived source with no quota — verified live and fresh today (2026-07-05, 47.6k hexes).

## What

**One key design point:** gpsjam has *two* consumer paths — the **web UI** (`api/gpsjam.js` → `gps-interference.ts` → map) and a **public proto RPC** (`list-gps-interference` / `gps_jamming.proto`, exposing `np_avg/sample_count/aircraft_count`). To restore the honest metric on the UI **without a breaking API change / proto regen**, the fetcher emits a **superset hex**:

| Path | Fields | Notes |
|---|---|---|
| Web UI | `pct`, `affectedAircraft`, `totalAircraft` | The real gpsjam.org metric — share of aircraft reporting GPS interference |
| Public API | `npAvg`, `sampleCount`, `aircraftCount` | Contract kept stable; `np_avg` is a pct-bucketed proxy (same mapping `api/gpsjam.js` already used for the v1 fallback) |

Changes:
- **`scripts/fetch-gpsjam.mjs`** — fetch gpsjam.org (`manifest.csv` → `{date}-h3_4.csv`), drop `WINGBITS_API_KEY`, emit the superset. Keeps preserve-last-good (`extendExistingTtl` + `exit 0`; `fetchedAt` not refreshed on failure, so a persistent outage still trips age-based `STALE_SEED`).
- **`api/gpsjam.js`** — `toWebHex` normalizes any stored shape (new pct-v2, **legacy Wingbits npAvg-v2** still lingering under its 48h TTL during the switch, or v1) to the web-UI pct shape.
- **UI** (`gps-interference.ts`, `MapPopup`, `GlobeMap`, `DeckGLMap`) — show **"% aircraft affected"** instead of "NP avg" / "satellites visible". en.json labels repurposed (locales keep their strings → no key drift).
- **CII unchanged** — `get-risk-scores` counts by `hex.level` only, which the pct thresholds still populate.
- **Proto/RPC untouched** — no `gps_jamming.proto` change, no regen.

## Test plan

- `tests/gpsjam-org-restore.test.mjs` — `toWebHex` 3-shape normalization (new/legacy/v1) + source guards (free source, no Wingbits, superset emitted, preserve-last-good, UI on pct, **proto contract still on np_avg**).
- `globe-tooltip-enrichment` label test updated.
- **Fetcher verified end-to-end against live gpsjam.org** (934 high + 870 medium hexes, correct superset shape). `tsc --noEmit` clean. Regression-checked: mission-presets, forecast-detectors, resilience, regional-snapshot, mcp-parity (tsx) — all green.

Independent of #4980 / #4982 (branched off current `main`).

https://claude.ai/code/session_019uhnqAKEHTws3QMaUvq58N