### PR TITLE
fix(middleware): stop bot-gating /favico/* — public brand assets must be world-readable

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -233,8 +233,17 @@ export default function middleware(request: Request) {
     }
   }
 
-  // Only apply bot filtering to /api/* and /favico/* paths
-  if (!path.startsWith('/api/') && !path.startsWith('/favico/')) {
+  // Only apply bot filtering to /api/* paths.
+  //
+  // /favico/* is deliberately NOT gated: it serves public static brand
+  // assets (favicons, app icons, the email logo) that must be retrievable
+  // by ANY client — browsers, email clients and their image proxies, link
+  // unfurlers, preview scrapers. Bot-gating it broke the logo in
+  // transactional emails when a client/proxy fetched with a script-like UA
+  // (the same reason Cloudflare's "Block API Bots" rule was narrowed to
+  // /api/* only). /favico/* is also removed from the matcher below so the
+  // middleware never runs on it.
+  if (!path.startsWith('/api/')) {
     return;
   }
 
@@ -254,7 +263,6 @@ export default function middleware(request: Request) {
   // this allowlist is defence-in-depth for any well-shaped request
   // whose UA happens to be in SOCIAL_IMAGE_UA.
   if (
-    path.startsWith('/favico/') ||
     path.endsWith('.png') ||
     BRIEF_CAROUSEL_PATH_RE.test(path)
   ) {
@@ -307,5 +315,5 @@ export default function middleware(request: Request) {
 }
 
 export const config = {
-  matcher: ['/', '/api/:path*', '/favico/:path*'],
+  matcher: ['/', '/api/:path*'],
 };


### PR DESCRIPTION
## What / why
The dunning + welcome email logo rendered **broken** because `/favico/android-chrome-192x192.png` was blocked for script-like user agents. Root cause was two bot-gating layers on `/favico/*`:

1. **Cloudflare** — a firewall rule literally named *"Block API Bots"* whose path scope was `(/api/* OR /favico/*)` + a bot/short-UA match. **Already fixed on the zone**: narrowed to `/api/*` only (rollback saved). Verified: `/favico/*` now returns 200 for curl/python/wget/empty-UA; `/api/*` bot-block still 403s.
2. **This middleware** — `config.matcher` included `/favico/:path*` and the `BOT_UA` / short-UA gate 403'd it on cache-miss.

Favicons, app icons, and the email logo are public static assets that must be retrievable by **any** client (browsers, email clients + their image proxies, link unfurlers, preview scrapers). This PR removes `/favico/` from the matcher and the bot-filter scope entirely — only `/api/*` is gated now. `/api` protection + the social-image/carousel allowlists are unchanged.

## Verification
- `tests/middleware-bot-gate.test.mts` — 53/0 (all `/api/` assertions intact)
- `npm run typecheck` clean
- Live (post-Cloudflare-fix): `/favico/*` = 200 for curl/python/wget/empty-UA; `api.worldmonitor.app/api/mcp` still 403 for curl

## Why the logo broke only on our emails
Login/verification emails are **Clerk's** (separate infra, Clerk-hosted logo) — they never hit our WAF. Only our Resend transactional emails referenced the WAF-gated `/favico/` asset.

This is the real fix; the earlier CID-embed workaround (#4986) is closed in favour of it.

https://claude.ai/code/session_0161Cso3K8pbtf276Q9WPM3s