### PR TITLE
fix(fred): pipeline batch seed reads

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -287,16 +287,29 @@ function readLocalPositiveFallback(key: string): unknown | undefined {
  * Batch GET using Upstash pipeline API — single HTTP round-trip for N keys.
  * Returns a Map of key → parsed JSON value (missing/failed/sentinel keys omitted).
  */
-export async function getCachedJsonBatch(keys: string[]): Promise<Map<string, unknown>> {
+export async function getCachedJsonBatch(keys: string[], raw = false): Promise<Map<string, unknown>> {
   const result = new Map<string, unknown>();
   if (keys.length === 0) return result;
+
+  if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
+    try {
+      const { sidecarCacheGet } = await import('./sidecar-cache');
+      for (const key of keys) {
+        const value = sidecarCacheGet(key);
+        if (value != null) result.set(key, value);
+      }
+    } catch (error) {
+      console.warn('[redis] getCachedJsonBatch failed:', errMsg(error));
+    }
+    return result;
+  }
 
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return result;
 
   try {
-    const pipeline = keys.map((k) => ['GET', prefixKey(k)]);
+    const pipeline = keys.map((k) => ['GET', raw ? k : prefixKey(k)]);
     const resp = await fetch(`${url}/pipeline`, {
       method: 'POST',
       headers: {
@@ -306,14 +319,17 @@ export async function getCachedJsonBatch(keys: string[]): Promise<Map<string, un
       body: JSON.stringify(pipeline),
       signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
     });
-    if (!resp.ok) return result;
+    if (!resp.ok) {
+      console.warn(`[redis] getCachedJsonBatch HTTP ${resp.status}`);
+      return result;
+    }
 
     const data = (await resp.json()) as Array<{ result?: string }>;
     for (let i = 0; i < keys.length; i++) {
-      const raw = data[i]?.result;
-      if (raw) {
+      const rawResult = data[i]?.result;
+      if (rawResult) {
         try {
-          const parsed = JSON.parse(raw);
+          const parsed = JSON.parse(rawResult);
           if (parsed === NEG_SENTINEL) continue;
           // Envelope-aware: unwrap contract-mode canonical keys; legacy values
           // pass through.
@@ -324,7 +340,12 @@ export async function getCachedJsonBatch(keys: string[]): Promise<Map<string, un
       }
     }
   } catch (err) {
-    console.warn('[redis] getCachedJsonBatch failed:', errMsg(err));
+    const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
+    if (isTimeout) {
+      console.error(`[REDIS-TIMEOUT] getCachedJsonBatch keys=${keys.length} timeoutMs=${REDIS_PIPELINE_TIMEOUT_MS}`);
+    } else {
+      console.warn('[redis] getCachedJsonBatch failed:', errMsg(err));
+    }
   }
   return result;
 }

--- a/server/worldmonitor/economic/v1/get-fred-series-batch.ts
+++ b/server/worldmonitor/economic/v1/get-fred-series-batch.ts
@@ -10,7 +10,7 @@ import type {
   FredSeries,
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
-import { getCachedJson } from '../../../_shared/redis';
+import { getCachedJsonBatch } from '../../../_shared/redis';
 import { toUniqueSortedLimited } from '../../../_shared/normalize-list';
 import { applyFredObservationLimit, fredSeedKey, normalizeFredLimit } from './_fred-shared';
 
@@ -35,16 +35,12 @@ export async function getFredSeriesBatch(
     const limitedList = toUniqueSortedLimited(normalized, 20);
     const limit = normalizeFredLimit(req.limit);
 
-    const settled = await Promise.allSettled(
-      limitedList.map((id) => getCachedJson(fredSeedKey(id), true)),
-    );
+    const keysById = new Map(limitedList.map((id) => [id, fredSeedKey(id)]));
+    const cachedByKey = await getCachedJsonBatch([...keysById.values()], true);
 
     const results: Record<string, FredSeries> = {};
-    for (let i = 0; i < limitedList.length; i++) {
-      const id = limitedList[i]!;
-      const entry = settled[i];
-      if (entry?.status !== 'fulfilled' || !entry.value) continue;
-      const cached = entry.value as { series?: FredSeries };
+    for (const id of limitedList) {
+      const cached = cachedByKey.get(keysById.get(id)!) as { series?: FredSeries } | undefined;
       if (cached?.series) results[id] = applyFredObservationLimit(cached.series, limit);
     }
 

--- a/tests/fred-series-batch.test.mts
+++ b/tests/fred-series-batch.test.mts
@@ -1,0 +1,175 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getCachedJsonBatch } from '../server/_shared/redis';
+import { sidecarCacheSet } from '../server/_shared/sidecar-cache';
+import { getFredSeriesBatch } from '../server/worldmonitor/economic/v1/get-fred-series-batch';
+
+const ORIGINAL_ENV = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+  VERCEL_GIT_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA,
+  LOCAL_API_MODE: process.env.LOCAL_API_MODE,
+};
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_CONSOLE_WARN = console.warn;
+const ORIGINAL_CONSOLE_ERROR = console.error;
+
+function restoreEnv(name: keyof typeof ORIGINAL_ENV): void {
+  const value = ORIGINAL_ENV[name];
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  console.warn = ORIGINAL_CONSOLE_WARN;
+  console.error = ORIGINAL_CONSOLE_ERROR;
+  restoreEnv('UPSTASH_REDIS_REST_URL');
+  restoreEnv('UPSTASH_REDIS_REST_TOKEN');
+  restoreEnv('VERCEL_ENV');
+  restoreEnv('VERCEL_GIT_COMMIT_SHA');
+  restoreEnv('LOCAL_API_MODE');
+});
+
+function fredSeries(seriesId: string) {
+  return {
+    seriesId,
+    title: seriesId,
+    units: 'Percent',
+    frequency: 'Monthly',
+    lastUpdated: '2026-07-01',
+    observations: [
+      { date: '2026-04-01', value: 1 },
+      { date: '2026-05-01', value: 2 },
+      { date: '2026-06-01', value: 3 },
+    ],
+  };
+}
+
+function configureRemoteRedis(): void {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  process.env.VERCEL_ENV = 'preview';
+  process.env.VERCEL_GIT_COMMIT_SHA = 'abcdef123456';
+  delete process.env.LOCAL_API_MODE;
+}
+
+function stubPipelineFetch(results: Array<{ result?: string }>): Array<{ url: string; init: RequestInit | undefined }> {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify(results), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return calls;
+}
+
+describe('getFredSeriesBatch', () => {
+  it('reads seeded FRED series through one raw Redis pipeline request', async () => {
+    configureRemoteRedis();
+
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      const commands = JSON.parse(String(init?.body));
+      assert.deepEqual(commands, [
+        ['GET', 'economic:fred:v1:CPIAUCSL:0'],
+        ['GET', 'economic:fred:v1:FEDFUNDS:0'],
+      ]);
+      return new Response(JSON.stringify([
+        { result: JSON.stringify({ series: fredSeries('CPIAUCSL') }) },
+        { result: JSON.stringify({ series: fredSeries('FEDFUNDS') }) },
+      ]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+
+    const response = await getFredSeriesBatch(
+      {} as never,
+      { seriesIds: ['FEDFUNDS', 'CPIAUCSL', 'NOPE', 'fedfunds'], limit: 2 },
+    );
+
+    assert.equal(calls.length, 1, 'one batch RPC should produce one Redis HTTP request');
+    assert.equal(calls[0]!.url, 'https://redis.example.test/pipeline');
+    assert.equal(response.requested, 2);
+    assert.equal(response.fetched, 2);
+    assert.deepEqual(Object.keys(response.results), ['CPIAUCSL', 'FEDFUNDS']);
+    assert.deepEqual(response.results.FEDFUNDS?.observations, [
+      { date: '2026-05-01', value: 2 },
+      { date: '2026-06-01', value: 3 },
+    ]);
+  });
+
+  it('keeps partial Redis misses out of results without changing requested count', async () => {
+    configureRemoteRedis();
+    stubPipelineFetch([
+      { result: JSON.stringify({ series: fredSeries('CPIAUCSL') }) },
+      {},
+    ]);
+
+    const response = await getFredSeriesBatch(
+      {} as never,
+      { seriesIds: ['FEDFUNDS', 'CPIAUCSL'], limit: 2 },
+    );
+
+    assert.equal(response.requested, 2);
+    assert.equal(response.fetched, 1);
+    assert.deepEqual(Object.keys(response.results), ['CPIAUCSL']);
+  });
+
+  it('returns an empty success response when every Redis key misses', async () => {
+    configureRemoteRedis();
+    stubPipelineFetch([{}, {}]);
+
+    const response = await getFredSeriesBatch(
+      {} as never,
+      { seriesIds: ['FEDFUNDS', 'CPIAUCSL'], limit: 2 },
+    );
+
+    assert.deepEqual(response, { results: {}, fetched: 0, requested: 2 });
+  });
+
+  it('logs Redis pipeline HTTP status failures', async () => {
+    configureRemoteRedis();
+    const warnings: string[] = [];
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(' ')); }) as typeof console.warn;
+    globalThis.fetch = (async () => new Response('nope', { status: 503 })) as typeof fetch;
+
+    const result = await getCachedJsonBatch(['economic:fred:v1:FEDFUNDS:0'], true);
+
+    assert.equal(result.size, 0);
+    assert.ok(warnings.some((line) => line.includes('[redis] getCachedJsonBatch HTTP 503')));
+  });
+
+  it('logs Redis pipeline timeout failures with the timeout marker', async () => {
+    configureRemoteRedis();
+    const errors: string[] = [];
+    console.error = ((...args: unknown[]) => { errors.push(args.map(String).join(' ')); }) as typeof console.error;
+    const timeout = new Error('deadline exceeded');
+    timeout.name = 'TimeoutError';
+    globalThis.fetch = (async () => { throw timeout; }) as typeof fetch;
+
+    const result = await getCachedJsonBatch(['economic:fred:v1:FEDFUNDS:0'], true);
+
+    assert.equal(result.size, 0);
+    assert.ok(errors.some((line) => line.includes('[REDIS-TIMEOUT] getCachedJsonBatch keys=1')));
+  });
+
+  it('reads raw seed keys from the Tauri sidecar cache branch', async () => {
+    process.env.LOCAL_API_MODE = 'tauri-sidecar';
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    sidecarCacheSet('economic:fred:v1:FEDFUNDS:0', { series: fredSeries('FEDFUNDS') }, 60);
+
+    const response = await getFredSeriesBatch(
+      {} as never,
+      { seriesIds: ['FEDFUNDS', 'CPIAUCSL'], limit: 2 },
+    );
+
+    assert.equal(response.requested, 2);
+    assert.equal(response.fetched, 1);
+    assert.deepEqual(Object.keys(response.results), ['FEDFUNDS']);
+  });
+});


### PR DESCRIPTION
## Summary

FRED batch requests now read seeded series with a single Upstash pipeline call instead of one REST request per series. That reduces origin pressure on the dashboard startup path behind Sentry `WORLDMONITOR-P4`, where production browsers were seeing Cloudflare `520` responses from `/api/economic/v1/get-fred-series-batch`.

The Redis batch helper now supports raw seed keys so seed-script cache entries keep bypassing preview key prefixes, and the FRED handler preserves the existing allowlist, dedupe, limit, and empty-cache fallback behavior.

Related: Sentry `WORLDMONITOR-P4`

## Validation

- `node --import tsx --test tests/fred-series-batch.test.mts`
- local edge POST smoke for `/api/economic/v1/get-fred-series-batch` returned `200 {"results":{},"fetched":0,"requested":2}` without Redis credentials
- `npm run typecheck:api`
- pre-push gate: frontend typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policy, premium-fetch parity, server handler tests, changed FRED test, version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
