### PR TITLE
fix(portwatch): prioritize never-cached countries so port-activity coverage reaches 174 (turns health green)

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -867,6 +867,26 @@ async function redisMgetJson(keys) {
 // `progress` (optional) is mutated in-place so a SIGTERM handler in main()
 // can report which batch / country we died on.
 //
+// Orders the cold-fetch queue no-prior-cache-FIRST (shuffled within each group
+// for rotation fairness). Never-cached countries have no served-stale fallback,
+// so they must win cold-fetch slots ahead of cached-but-stale ones — otherwise
+// the random shuffle starves them out of the canonical (coverage frozen < 174).
+// Pure + exported for unit testing; rng is injectable for determinism. #4293.
+export function orderColdFetchQueue(needsFetch, rng = Math.random) {
+  const shuffle = (arr) => {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  };
+  const hasCache = (it) => Boolean(it && it.prevPayload && typeof it.prevPayload === 'object');
+  const noCache = needsFetch.filter((it) => !hasCache(it));
+  const cached = needsFetch.filter(hasCache);
+  return [...shuffle(noCache), ...shuffle(cached)];
+}
+
 // fetchAll is the orchestrator (refs → schema → preflight → cache-partition
 // → batched fetch → finalise); splitting it would move complexity into a
 // hidden seam and obscure the linear pipeline. Each stage is short and
@@ -988,14 +1008,16 @@ export async function fetchAll(progress, { signal } = {}) {
 
   if (needsFetch.length > MAX_COLD_FETCH_PER_RUN) {
     capTriggered = true;
-    // Deterministic-ish shuffle: Fisher-Yates with Math.random — fine here
-    // because we just need "different subset each run", not crypto strength.
-    const shuffled = [...needsFetch];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    const deferred = shuffled.slice(MAX_COLD_FETCH_PER_RUN);
+    // Order the queue no-prior-cache-FIRST, shuffled within each group for
+    // rotation fairness. Never-cached countries have no served-stale fallback:
+    // if deferred past the cap they're dropped entirely (droppedNoCache),
+    // whereas cached-but-stale countries survive the deferral via served-stale.
+    // A plain random shuffle therefore repeatedly starved the same uncached
+    // countries (MY, IE, EC, …) out of the canonical, freezing coverage below
+    // the 174 target. Prioritising them guarantees each a fetch slot every run
+    // (uncached count << cap), so they get cached and then held over. See #4293.
+    const ordered = orderColdFetchQueue(needsFetch);
+    const deferred = ordered.slice(MAX_COLD_FETCH_PER_RUN);
     let servedStale = 0;
     let droppedTooOld = 0;
     let droppedNoCache = 0;
@@ -1024,7 +1046,7 @@ export async function fetchAll(progress, { signal } = {}) {
       countryData.set(item.iso2, { ...prev, staleAsof: true });
       servedStale++;
     }
-    needsFetch = shuffled.slice(0, MAX_COLD_FETCH_PER_RUN);
+    needsFetch = ordered.slice(0, MAX_COLD_FETCH_PER_RUN);
     // Rotation arithmetic uses MAX_COLD_FETCH_PER_RUN directly rather than
     // needsFetch.length — needsFetch was just reassigned to the cap-sized
     // slice, so the two are numerically equal here, but using the constant

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { orderColdFetchQueue } from '../scripts/seed-portwatch-port-activity.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -1121,7 +1122,7 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
     // shuffle and the needsFetch reassignment) — using a multi-line regex
     // that requires shuffle → cacheWrittenAt → MAX_CACHE_AGE_MS in order.
     const capBlock = src.match(
-      /needsFetch\.length\s*>\s*MAX_COLD_FETCH_PER_RUN[\s\S]+?needsFetch\s*=\s*shuffled\.slice/,
+      /needsFetch\.length\s*>\s*MAX_COLD_FETCH_PER_RUN[\s\S]+?needsFetch\s*=\s*ordered\.slice/,
     );
     assert.ok(capBlock, 'cap block found');
     assert.match(
@@ -1182,8 +1183,9 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
     // Pre-fix needsFetch was const. This regression-guards a future cleanup
     // that switches it back without realizing the cap path mutates it.
     assert.match(src, /let needsFetch\s*=\s*\[\]/);
-    // And the reassignment in the cap path:
-    assert.match(src, /needsFetch\s*=\s*shuffled\.slice\(0,\s*MAX_COLD_FETCH_PER_RUN\)/);
+    // And the reassignment in the cap path (now sourced from the
+    // never-cached-first orderColdFetchQueue instead of a plain shuffle):
+    assert.match(src, /needsFetch\s*=\s*ordered\.slice\(0,\s*MAX_COLD_FETCH_PER_RUN\)/);
   });
 
   it('full rotation is computable: ~ceil(174 / 30) = 6 runs ≈ 3 days at 12h cadence', () => {
@@ -1198,5 +1200,37 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
     assert.equal(runs, 6);
     assert.equal(fullRotationHours, 72, 'full rotation must stay under MAX_CACHE_AGE_MS (7d = 168h)');
     assert.ok(fullRotationHours < 168, 'rotation must complete before MAX_CACHE_AGE_MS forces hard drops');
+  });
+});
+
+// ── cold-fetch prioritisation (WM #4293 coverage-freeze fix) ──────────────────
+// Never-cached countries (prevPayload=null) have no served-stale fallback, so if
+// the random cap deferred them they were dropped entirely (droppedNoCache),
+// freezing /api/health coverage below the 174 target (observed stuck at 158).
+// orderColdFetchQueue must sort them ahead of cached-but-stale countries so they
+// always win a cold-fetch slot (uncached count << MAX_COLD_FETCH_PER_RUN).
+describe('orderColdFetchQueue — never-cached-first prioritisation', () => {
+  const noCache = (iso2) => ({ iso2, prevPayload: null });
+  const cached = (iso2) => ({ iso2, prevPayload: { asof: '2026-06-26', cacheWrittenAt: Date.now() } });
+
+  it('places every no-prior-cache country ahead of every cached one', () => {
+    const q = [cached('US'), noCache('MY'), cached('GB'), noCache('IE'), noCache('EC')];
+    const ordered = orderColdFetchQueue(q, () => 0);
+    const firstCachedIdx = ordered.findIndex((it) => it.prevPayload);
+    const noCacheIdxs = ordered.flatMap((it, i) => (it.prevPayload ? [] : [i]));
+    assert.ok(Math.max(...noCacheIdxs) < firstCachedIdx, 'all uncached must sort before all cached');
+    assert.deepEqual(ordered.slice(0, 3).map((it) => it.iso2).sort(), ['EC', 'IE', 'MY']);
+  });
+
+  it('is a permutation and fits all uncached within the 30-slot cap (16 < 30)', () => {
+    const q = Array.from({ length: 16 }, (_, i) => noCache('N' + i))
+      .concat(Array.from({ length: 140 }, (_, i) => cached('C' + i)));
+    const ordered = orderColdFetchQueue(q);
+    assert.equal(ordered.length, q.length, 'no drops');
+    assert.equal(new Set(ordered.map((it) => it.iso2)).size, q.length, 'no dups');
+    const inCap = new Set(ordered.slice(0, 30).map((it) => it.iso2));
+    for (let i = 0; i < 16; i++) {
+      assert.ok(inCap.has('N' + i), `uncached N${i} must be within the cold-fetch cap, not deferred/dropped`);
+    }
   });
 });


### PR DESCRIPTION
## Problem

`/api/health` is stuck at `portwatchPortActivity: COVERAGE_PARTIAL 158/174` — the **only** thing keeping the endpoint `WARNING` instead of `HEALTHY` (`onDemandWarn` keys are subtracted from `realWarnCount`, so newsRecallBenchmark/serviceStatuses don't block green). Fixing coverage to 174 → `realWarnCount = 0` → **HEALTHY**.

## Investigation (against live prod + IMF ArcGIS)

- **The 16 missing countries:** AO, AW, DJ, EC, GM, GW, IE, KM, KY, KZ, MO, MY, NA, TC, TG, VC — including **Malaysia, Ireland, Ecuador, Angola, Kazakhstan**.
- **All 16 have activity data** in PortWatch's EP3 endpoint (Malaysia 112k rows … Djibouti 2.7k). So this is a fetch-**completeness** problem, not data availability.
- Each of the 16 has **no per-country cache key** (a present country like US carries `{iso2,ports,fetchedAt,asof,cacheWrittenAt}`) — they've never been cached.
- **Reproduced the seeder's exact per-country EP3 query** for the missing countries: all succeed in 1–2s (MYS 1.5s, DJI 1.7s, IRL 1.3s). The fetch is **not failing**.

## Root cause

`fetchAll`'s cold-fetch cap (`MAX_COLD_FETCH_PER_RUN = 30`) shuffles `needsFetch` **randomly** and defers the overflow. Deferred countries **with** prior cache are served-stale (kept in the canonical); deferred countries **without** cache (the 16) hit `droppedNoCache` — removed entirely. So never-cached countries have no fallback yet compete on equal random footing, and are repeatedly starved out — freezing coverage at 158.

## Fix

`orderColdFetchQueue()` orders the queue **no-prior-cache-first** (shuffled within each group for rotation fairness). 16 uncached ≪ the 30 cap, so they now win a fetch slot **every** run, get cached, then held over via served-stale — coverage climbs to 174 and stays.

**Pure reorder** — no threshold/budget/cache-age changes, nothing faked. The served-stale `MAX_CACHE_AGE_MS` hard-drop and the cap size are unchanged.

## Test plan

- `orderColdFetchQueue` unit tests: every uncached country sorts ahead of every cached one; all 16 uncached fit within the 30-slot cap; result is a permutation (no drops/dups).
- Updated the two source-guards that pinned the old `shuffled.slice` form to `ordered.slice`.
- **102/102** pass. Investigation queries + per-country fetch reproduction documented above.

## Rollout note

Like the gpsjam fix, this takes effect once the Railway `seed-bundle-portwatch-port-activity` service redeploys with this code and runs (next 12h cron, or a manual trigger). Coverage should reach 174 within one capped run (all 16 uncached fetched) and health flip to HEALTHY.

Independent of the other open PRs (branched off current `main`).

https://claude.ai/code/session_019uhnqAKEHTws3QMaUvq58N