### PR TITLE
feat(llm): never serve OpenRouter inference from China-hosted providers

### DIFF
--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -42,6 +42,25 @@ function isLocalDeployment(): boolean {
   return mode.includes('sidecar') || mode.includes('docker');
 }
 
+// OpenRouter provider routing. WorldMonitor is a geopolitical product, so
+// inference must never physically run on a China-hosted provider — one could
+// log queries or bias outputs on the exact topics we cover (Taiwan, Xinjiang,
+// the South China Sea, etc.). We BLOCK the known China-based providers and let
+// OpenRouter serve the model (DeepSeek weights are fine; hosting is the
+// concern) from the fastest of the rest.
+//   - `ignore`: blocklist. RE-AUDIT against OpenRouter's provider list
+//     periodically — a new China-based entrant would otherwise be eligible.
+//   - `sort: throughput`: also steers off OpenRouter's cheapest-but-slowest
+//     default (DeepInfra ~17 tok/s) to the fastest eligible provider, which is
+//     the brief-latency win we were chasing (#4983 follow-up).
+const OPENROUTER_BLOCKED_PROVIDERS = [
+  'Baidu', 'Alibaba', 'DeepSeek', 'SiliconFlow', 'StreamLake', 'Novita',
+];
+const OPENROUTER_PROVIDER_ROUTING = {
+  ignore: OPENROUTER_BLOCKED_PROVIDERS,
+  sort: 'throughput',
+} as const;
+
 export function getProviderCredentials(
   provider: string,
   overrides: ProviderCredentialOverrides = {},
@@ -102,8 +121,12 @@ export function getProviderCredentials(
       // Hybrid-reasoning models (DeepSeek V4) reason by default via
       // OpenRouter's normalized `reasoning` param; utility calls must not
       // pay reasoning tokens. The reasoning profile opts back in, letting
-      // the model's own default apply.
-      extraBody: overrides.enableReasoning ? undefined : { reasoning: { enabled: false } },
+      // the model's own default apply. `provider` routing is always sent —
+      // the China-provider exclusion is not optional (see the constant).
+      extraBody: {
+        ...(overrides.enableReasoning ? {} : { reasoning: { enabled: false } }),
+        provider: OPENROUTER_PROVIDER_ROUTING,
+      },
     };
   }
 

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -48,13 +48,17 @@ function isLocalDeployment(): boolean {
 // the South China Sea, etc.). We BLOCK the known China-based providers and let
 // OpenRouter serve the model (DeepSeek weights are fine; hosting is the
 // concern) from the fastest of the rest.
-//   - `ignore`: blocklist. RE-AUDIT against OpenRouter's provider list
-//     periodically — a new China-based entrant would otherwise be eligible.
+//   - `ignore`: blocklist. These MUST be OpenRouter's lowercase provider
+//     SLUGS (from GET /api/v1/providers), NOT display names — OpenRouter
+//     silently drops unrecognized entries, so a display name like "DeepSeek"
+//     matches nothing and the block is a no-op (caught in #4993 review).
+//     Verified against /providers 2026-07-07. RE-AUDIT periodically — a new
+//     China-based entrant would otherwise be eligible.
 //   - `sort: throughput`: also steers off OpenRouter's cheapest-but-slowest
 //     default (DeepInfra ~17 tok/s) to the fastest eligible provider, which is
 //     the brief-latency win we were chasing (#4983 follow-up).
 const OPENROUTER_BLOCKED_PROVIDERS = [
-  'Baidu', 'Alibaba', 'DeepSeek', 'SiliconFlow', 'StreamLake', 'Novita',
+  'baidu', 'alibaba', 'deepseek', 'siliconflow', 'streamlake', 'novita',
 ];
 const OPENROUTER_PROVIDER_ROUTING = {
   ignore: OPENROUTER_BLOCKED_PROVIDERS,

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -38,6 +38,37 @@ afterEach(() => {
 });
 
 describe('callLlm', () => {
+  it('excludes China-hosted providers and sorts by throughput on every OpenRouter call', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      bodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
+      return new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }], usage: { total_tokens: 5 } }), { status: 200 });
+    }) as typeof fetch;
+
+    // Utility (reasoning off) AND reasoning-on must both carry the exclusion.
+    await callLlm({ messages: [{ role: 'user', content: 'x' }] });
+    await callLlm({ messages: [{ role: 'user', content: 'y' }], enableReasoning: true });
+
+    for (const b of bodies) {
+      const prov = b.provider as { ignore?: string[]; sort?: string } | undefined;
+      assert.ok(prov, 'every OpenRouter body must carry provider routing');
+      assert.equal(prov.sort, 'throughput');
+      for (const cn of ['Baidu', 'Alibaba', 'DeepSeek', 'SiliconFlow', 'StreamLake', 'Novita']) {
+        assert.ok(prov.ignore?.includes(cn), `China provider ${cn} must be excluded`);
+      }
+    }
+    // reasoning-off body still disables reasoning; reasoning-on omits it.
+    assert.deepEqual(bodies[0]?.reasoning, { enabled: false });
+    assert.equal('reasoning' in (bodies[1] ?? {}), false);
+  });
+
   it('preserves the default provider order (openrouter-first since #4944)', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'or-test-key';

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -60,8 +60,11 @@ describe('callLlm', () => {
       const prov = b.provider as { ignore?: string[]; sort?: string } | undefined;
       assert.ok(prov, 'every OpenRouter body must carry provider routing');
       assert.equal(prov.sort, 'throughput');
-      for (const cn of ['Baidu', 'Alibaba', 'DeepSeek', 'SiliconFlow', 'StreamLake', 'Novita']) {
-        assert.ok(prov.ignore?.includes(cn), `China provider ${cn} must be excluded`);
+      // Lowercase OpenRouter provider SLUGS (verified via GET /providers) —
+      // display-name casing is silently ignored by OpenRouter (#4993 review).
+      for (const cn of ['baidu', 'alibaba', 'deepseek', 'siliconflow', 'streamlake', 'novita']) {
+        assert.ok(prov.ignore?.includes(cn), `China provider slug ${cn} must be excluded`);
+        assert.equal(cn, cn.toLowerCase(), 'slug must be lowercase to match OpenRouter');
       }
     }
     // reasoning-off body still disables reasoning; reasoning-on omits it.


### PR DESCRIPTION
Addresses the geopolitical-trust concern from the DeepSeek latency thread. **No model change** — DeepSeek stays; the fix is purely *where* it's hosted.

## Why
WorldMonitor is a geopolitical intelligence product. Inference must never physically run on a China-based provider that could log queries or shape outputs on the exact topics we cover (Taiwan, Xinjiang, South China Sea, etc.). OpenRouter's default routing optimizes for price, which was landing our DeepSeek calls on providers like Baidu/DeepSeek-CN.

## Change
Every OpenRouter request now carries provider routing:
- **`ignore`** — blocklists the known China-hosted providers: Baidu, Alibaba, DeepSeek (its own API), SiliconFlow, StreamLake, Novita. OpenRouter serves the model from a non-China provider instead. (Model weights being China-origin is fine per the requirement — *hosting* was the concern.)
- **`sort: throughput`** — bonus: also steers off OpenRouter's cheapest-but-slowest default (DeepInfra ~17 tok/s) to the fastest eligible provider, which is the brief-latency improvement from the #4983 thread (fastest non-China DeepSeek providers run ~64–72 tok/s).

Applies to **all** stages (utility + reasoning), reasoning-on and reasoning-off.

## Caveat (documented in-code)
`ignore` is a blocklist — re-audit against OpenRouter's provider list periodically; a new China-based entrant would otherwise be eligible. (A strict allowlist was considered but risks breaking a model not served by the listed providers.)

## Verification
Regression asserts every OpenRouter body (both reasoning modes) carries the ignore list + throughput sort. shared-llm **10/10**, typecheck:api clean. Post-deploy: Axiom `provider`/model on llm_call should show only non-China upstreams and throughput on the fast tier.

Manual review/merge.

https://claude.ai/code/session_01Xs7LsyQQJqngcqjt5oGcpx