### PR TITLE
fix(seo): self-canonicalize variant subdomain dashboards + canonical Link headers for sitemap .md pages (#4996, #4999)

### DIFF
--- a/src/config/variant-dashboard-html.ts
+++ b/src/config/variant-dashboard-html.ts
@@ -1,0 +1,155 @@
+import { VARIANT_META, type VariantMeta } from './variant-meta';
+
+// Variants that are served from their own worldmonitor.app subdomain by the
+// single web deployment (vercel.json host-based rewrites map
+// <variant>.worldmonitor.app/dashboard → /dashboard-<variant>.html).
+// Desktop/self-host variant builds are NOT in scope — they run
+// htmlVariantPlugin at build time with VITE_VARIANT set.
+export const WEB_DASHBOARD_VARIANTS = ['tech', 'finance', 'commodity', 'happy', 'energy'] as const;
+
+export function variantDashboardFileName(variant: string): string {
+  return `dashboard-${variant}.html`;
+}
+
+// HTML-escape for text content and double-quoted attribute values (same
+// contexts as middleware.ts escHtml — VARIANT_META values are hand-edited
+// prose; '&' already occurs in the tech title).
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+interface CountBounds {
+  min: number;
+  max: number;
+}
+
+// Replace with occurrence-count assertion. The web deploy serves the 'full'
+// build to every host, so the variant HTML is derived from the BUILT
+// dist/dashboard.html — if index.html or htmlVariantPlugin drift and an
+// anchor stops matching, the build must fail loudly rather than silently
+// shipping full-brand meta on variant subdomains again (#4996).
+function replaceCounted(
+  html: string,
+  pattern: RegExp,
+  replacer: (...groups: string[]) => string,
+  bounds: CountBounds,
+  label: string,
+): string {
+  let count = 0;
+  const result = html.replace(pattern, (...args) => {
+    count += 1;
+    // drop the offset/whole-string trailing args; keep match + capture groups
+    const groups = args.slice(0, -2) as string[];
+    return replacer(...groups);
+  });
+  if (count < bounds.min || count > bounds.max) {
+    throw new Error(
+      `[variant-dashboard-html] anchor "${label}" matched ${count} time(s), expected ${bounds.min}..${bounds.max} — dist/dashboard.html markup drifted; update src/config/variant-dashboard-html.ts`,
+    );
+  }
+  return result;
+}
+
+const ONE: CountBounds = { min: 1, max: 1 };
+const TWO: CountBounds = { min: 2, max: 2 };
+
+// Derive a variant subdomain dashboard page from the built full-variant
+// dashboard.html. Only identity/meta surfaces change: title/description/
+// keywords/subject/classification metas, canonical + hreflang cluster,
+// og/twitter cards, the WebApplication JSON-LD block, and the visually
+// hidden <h1>. The Organization/WebSite JSON-LD blocks intentionally keep
+// the World Monitor identity (each variant isPartOf World Monitor — same
+// modelling as the middleware.ts crawler stub).
+export function renderVariantDashboardHtml(fullDashboardHtml: string, variant: string): string {
+  const meta: VariantMeta | undefined = VARIANT_META[variant];
+  if (!meta || variant === 'full') {
+    throw new Error(`[variant-dashboard-html] unknown web dashboard variant "${variant}"`);
+  }
+  const origin = new URL(meta.url).origin;
+  const ogImage = `${origin}/favico/${variant}/og-image.png`;
+
+  let html = fullDashboardHtml;
+
+  // Titles
+  html = replaceCounted(html, /(<title>)[^<]*(<\/title>)/g, (_m, a, b) => `${a}${escHtml(meta.title)}${b}`, ONE, '<title>');
+  html = replaceCounted(html, /(<meta name="title" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.title)}${b}`, ONE, 'meta title');
+  html = replaceCounted(html, /(<meta property="og:title" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.title)}${b}`, ONE, 'og:title');
+  html = replaceCounted(html, /(<meta name="twitter:title" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.title)}${b}`, ONE, 'twitter:title');
+
+  // Descriptions + keywords + subject/classification
+  html = replaceCounted(html, /(<meta name="description" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.description)}${b}`, ONE, 'meta description');
+  html = replaceCounted(html, /(<meta property="og:description" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.description)}${b}`, ONE, 'og:description');
+  html = replaceCounted(html, /(<meta name="twitter:description" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.description)}${b}`, ONE, 'twitter:description');
+  html = replaceCounted(html, /(<meta name="keywords" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.keywords)}${b}`, ONE, 'meta keywords');
+  html = replaceCounted(html, /(<meta name="subject" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.subject)}${b}`, ONE, 'meta subject');
+  html = replaceCounted(html, /(<meta name="classification" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.classification)}${b}`, ONE, 'meta classification');
+
+  // Site name (og:site_name + application-name)
+  html = replaceCounted(
+    html,
+    /(<meta (?:property="og:site_name"|name="application-name") content=")[^"]*(" \/>)/g,
+    (_m, a, b) => `${a}${escHtml(meta.siteName)}${b}`,
+    TWO,
+    'site name metas',
+  );
+
+  // Canonical + URL cards — the core #4996 fix: the page must self-canonicalize
+  // on its own subdomain instead of pointing crawlers back at www.
+  html = replaceCounted(html, /(<link rel="canonical" href=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.url)}${b}`, ONE, 'canonical');
+  html = replaceCounted(html, /(<meta property="og:url" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.url)}${b}`, ONE, 'og:url');
+  html = replaceCounted(html, /(<meta name="twitter:url" content=")[^"]*(" \/>)/g, (_m, a, b) => `${a}${escHtml(meta.url)}${b}`, ONE, 'twitter:url');
+
+  // hreflang cluster: alternates of THIS page live on the same subdomain;
+  // preserve the ?lang= suffix per entry.
+  html = replaceCounted(
+    html,
+    /(<link rel="alternate" hreflang="[^"]+" href=")https:\/\/www\.worldmonitor\.app\/dashboard((?:\?[^"]*)?" \/>)/g,
+    (_m, a, b) => `${a}${escHtml(meta.url)}${b}`,
+    { min: 1, max: 80 },
+    'hreflang alternates',
+  );
+
+  // Social card images (per-variant OG assets exist under public/favico/<variant>/,
+  // same files middleware.ts VARIANT_OG points at).
+  html = replaceCounted(
+    html,
+    /(<meta (?:property="og:image"|name="twitter:image") content=")[^"]*(" \/>)/g,
+    (_m, a, b) => `${a}${escHtml(ogImage)}${b}`,
+    TWO,
+    'og/twitter image',
+  );
+
+  // WebApplication JSON-LD block: name, url, screenshot, featureList.
+  html = replaceCounted(
+    html,
+    /("@type": "WebApplication",\s*"name": )"[^"]*"/g,
+    (_m, a) => `${a}${JSON.stringify(meta.siteName)}`,
+    ONE,
+    'WebApplication name',
+  );
+  html = replaceCounted(
+    html,
+    /("@type": "WebApplication",[\s\S]{0,600}?"url": )"[^"]*"/g,
+    (_m, a) => `${a}${JSON.stringify(meta.url)}`,
+    ONE,
+    'WebApplication url',
+  );
+  html = replaceCounted(html, /("screenshot": )"[^"]*"/g, (_m, a) => `${a}${JSON.stringify(ogImage)}`, ONE, 'WebApplication screenshot');
+  html = replaceCounted(
+    html,
+    /("featureList": )\[[\s\S]*?\]/g,
+    (_m, a) => `${a}${JSON.stringify(meta.features, null, 8).replace(/\n/g, '\n      ')}`,
+    ONE,
+    'WebApplication featureList',
+  );
+
+  // Visually-hidden <h1> — the topic signal crawlers read on this page.
+  html = replaceCounted(html, /(<h1 class="app-heading">)[^<]*(<\/h1>)/g, (_m, a, b) => `${a}${escHtml(meta.title)}${b}`, ONE, 'app-heading h1');
+
+  return html;
+}

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -347,8 +347,10 @@ describe('welcome landing page routing', () => {
   });
 
   it('rewrites /dashboard to the existing SPA shell', () => {
-    const rewrite = vercelConfig.rewrites.find((r) => r.source === '/dashboard');
-    assert.ok(rewrite, 'expected a rewrite for /dashboard');
+    // Host-conditioned variant rules (#4996) sit in front; the fallback for
+    // every other host is the un-conditioned rule.
+    const rewrite = vercelConfig.rewrites.find((r) => r.source === '/dashboard' && !r.has);
+    assert.ok(rewrite, 'expected an un-conditioned rewrite for /dashboard');
     assert.equal(rewrite.destination, DASHBOARD_HTML_DESTINATION);
   });
 
@@ -2124,5 +2126,90 @@ describe('agent readiness: registry branding + ARD catalog', () => {
         aiCatalog.entries.some((e) => e.url.endsWith('/.well-known/agent-skills/index.json')),
       'agent-skills entry must exist iff the skills index is published'
     );
+  });
+});
+
+describe('variant subdomain dashboard SEO (#4996)', () => {
+  const WEB_DASHBOARD_VARIANTS = ['tech', 'finance', 'commodity', 'happy', 'energy'];
+  const dashboardRewrites = vercelConfig.rewrites.filter((r) => r.source === '/dashboard');
+
+  it('rewrites each variant host /dashboard to its generated variant HTML', () => {
+    for (const variant of WEB_DASHBOARD_VARIANTS) {
+      const rule = dashboardRewrites.find((r) =>
+        (r.has ?? []).some((h) => h.type === 'host' && h.value === `${variant}.worldmonitor.app`)
+      );
+      assert.ok(rule, `missing host rewrite for ${variant}.worldmonitor.app /dashboard`);
+      assert.strictEqual(
+        rule.destination,
+        `/dashboard-${variant}.html`,
+        `${variant} host rewrite must target the build-generated variant file`
+      );
+    }
+  });
+
+  it('keeps the host-specific rules BEFORE the generic /dashboard rewrite (order is match priority)', () => {
+    const genericIndex = dashboardRewrites.findIndex((r) => !r.has);
+    assert.ok(genericIndex >= 0, 'generic /dashboard -> /dashboard.html rewrite must exist');
+    assert.strictEqual(
+      genericIndex,
+      dashboardRewrites.length - 1,
+      'the un-conditioned /dashboard rewrite must come last so host rules win'
+    );
+    assert.strictEqual(dashboardRewrites.length, WEB_DASHBOARD_VARIANTS.length + 1);
+  });
+
+  it('vite build emits the variant dashboard files the rewrites point at (web full build only)', () => {
+    assert.match(
+      viteConfigSource,
+      /!isDesktopBuild && activeVariant === 'full' && variantDashboardHtmlPlugin\(\)/,
+      'variantDashboardHtmlPlugin must be registered for web full builds'
+    );
+    const variantHtmlSource = readFileSync(resolve(__dirname, '../src/config/variant-dashboard-html.ts'), 'utf-8');
+    for (const variant of WEB_DASHBOARD_VARIANTS) {
+      assert.ok(
+        variantHtmlSource.includes(`'${variant}'`),
+        `src/config/variant-dashboard-html.ts must cover the '${variant}' variant referenced by vercel.json`
+      );
+    }
+  });
+
+  it('middleware variant host map and the rewrites cover the same subdomains', () => {
+    for (const variant of WEB_DASHBOARD_VARIANTS) {
+      assert.ok(
+        middlewareSource.includes(`'${variant}.worldmonitor.app': '${variant}'`),
+        `middleware VARIANT_HOST_MAP must include ${variant}.worldmonitor.app`
+      );
+    }
+  });
+});
+
+describe('markdown canonical Link headers (#4999)', () => {
+  // The sitemap-listed markdown pages are intentionally raw text/markdown for
+  // agents, so they cannot carry a <link rel="canonical">. RFC 6596 allows the
+  // HTTP Link header form; without it these are the only indexable URLs with
+  // no canonical signal at all.
+  const MD_PAGES = ['/pricing.md', '/support.md', '/ai-search.md'];
+
+  for (const page of MD_PAGES) {
+    it(`${page} declares a self-referencing canonical Link header`, () => {
+      assert.strictEqual(
+        getHeaderValueForSource(page, 'Link'),
+        `<https://www.worldmonitor.app${page}>; rel="canonical"`,
+        `${page} must self-canonicalize on the www host via the Link header`
+      );
+      assert.strictEqual(
+        getHeaderValueForSource(page, 'Content-Type'),
+        'text/markdown; charset=utf-8'
+      );
+    });
+  }
+
+  it('every sitemap-listed .md URL has the canonical Link header rule', () => {
+    const sitemap = readFileSync(resolve(__dirname, '../public/sitemap.xml'), 'utf-8');
+    const mdUrls = [...sitemap.matchAll(/<loc>https:\/\/www\.worldmonitor\.app(\/[^<]+\.md)<\/loc>/g)].map((m) => m[1]);
+    assert.ok(mdUrls.length > 0, 'expected .md entries in sitemap.xml');
+    for (const path of mdUrls) {
+      assert.ok(MD_PAGES.includes(path), `${path} is in sitemap.xml but has no canonical Link header rule — add it to vercel.json and this test`);
+    }
   });
 });

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -16,7 +16,7 @@ const middlewareSource = readFileSync(resolve(__dirname, '../middleware.ts'), 'u
 const dockerfileSource = readFileSync(resolve(__dirname, '../Dockerfile'), 'utf-8');
 const dockerNginxSource = readFileSync(resolve(__dirname, '../docker/nginx.conf'), 'utf-8');
 const frontendDockerfileSource = readFileSync(resolve(__dirname, '../docker/Dockerfile'), 'utf-8');
-const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
+const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
 const GLOBAL_SECURITY_HEADER_SOURCE = '/((?!docs|embed|embed\\.html).*)';
 const APP_ROOT_HOST_PATTERN = '^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$';
 const GLOBAL_CSP_INLINE_SCRIPT_HTML_FILES = [
@@ -1662,8 +1662,11 @@ describe('agent readiness: auth.md walkthrough', () => {
   // (#4952), so they get the same three-way pinning as auth.md:
   // explicit markdown Content-Type + CORS, catch-all exclusion (deleting or
   // renaming the static file must 404, not silently serve the dashboard HTML
-  // misleading-200 the journey runs flagged), and this guard.
-  for (const mdPath of ['/pricing.md', '/support.md', '/agents.md']) {
+  // misleading-200 the journey runs flagged), and this guard. /ai-search.md
+  // joined the set with its canonical Link header (#4999): it is
+  // sitemap-listed, and without the catch-all exclusion the SPA cache-header
+  // catch-all (later in the headers array) overrides its max-age rule.
+  for (const mdPath of ['/pricing.md', '/support.md', '/agents.md', '/ai-search.md']) {
     it(`serves ${mdPath} as markdown and keeps it off the SPA catch-all`, () => {
       assert.equal(getHeaderValueForSource(mdPath, 'Content-Type'), 'text/markdown; charset=utf-8');
       assert.equal(getHeaderValueForSource(mdPath, 'Access-Control-Allow-Origin'), '*');
@@ -2130,19 +2133,52 @@ describe('agent readiness: registry branding + ARD catalog', () => {
 });
 
 describe('variant subdomain dashboard SEO (#4996)', () => {
-  const WEB_DASHBOARD_VARIANTS = ['tech', 'finance', 'commodity', 'happy', 'energy'];
+  // No hardcoded variant list: every set is extracted from its real source
+  // and compared BIDIRECTIONALLY, so adding a variant to any one surface
+  // (middleware host map, generator, vercel.json rewrites) without the
+  // others fails here instead of shipping a subdomain with full-brand meta.
   const dashboardRewrites = vercelConfig.rewrites.filter((r) => r.source === '/dashboard');
 
-  it('rewrites each variant host /dashboard to its generated variant HTML', () => {
-    for (const variant of WEB_DASHBOARD_VARIANTS) {
-      const rule = dashboardRewrites.find((r) =>
-        (r.has ?? []).some((h) => h.type === 'host' && h.value === `${variant}.worldmonitor.app`)
-      );
-      assert.ok(rule, `missing host rewrite for ${variant}.worldmonitor.app /dashboard`);
+  const rewriteVariants = dashboardRewrites
+    .filter((r) => r.has)
+    .map((r) => {
+      const host = (r.has ?? []).find((h) => h.type === 'host')?.value ?? '';
+      return host.replace('.worldmonitor.app', '');
+    })
+    .sort();
+
+  const middlewareVariants = [...middlewareSource.matchAll(/'([a-z]+)\.worldmonitor\.app': '([a-z]+)'/g)]
+    .map((m) => m[2])
+    .sort();
+
+  const variantHtmlSource = readFileSync(resolve(__dirname, '../src/config/variant-dashboard-html.ts'), 'utf-8');
+  const generatorArrayMatch = variantHtmlSource.match(/WEB_DASHBOARD_VARIANTS = \[([^\]]+)\]/);
+  const generatorVariants = (generatorArrayMatch?.[1] ?? '')
+    .split(',')
+    .map((s) => s.trim().replace(/['"]/g, ''))
+    .filter(Boolean)
+    .sort();
+
+  it('extracted all three variant sets (extraction regressions fail loudly)', () => {
+    assert.ok(rewriteVariants.length > 0, 'no host-conditioned /dashboard rewrites found in vercel.json');
+    assert.ok(middlewareVariants.length > 0, 'VARIANT_HOST_MAP extraction from middleware.ts found nothing');
+    assert.ok(generatorVariants.length > 0, 'WEB_DASHBOARD_VARIANTS extraction from variant-dashboard-html.ts found nothing');
+  });
+
+  it('vercel.json rewrites, middleware host map, and the generator cover the SAME variant set (bidirectional)', () => {
+    assert.deepEqual(rewriteVariants, middlewareVariants, 'vercel.json /dashboard host rewrites vs middleware VARIANT_HOST_MAP diverged');
+    assert.deepEqual(rewriteVariants, generatorVariants, 'vercel.json /dashboard host rewrites vs WEB_DASHBOARD_VARIANTS diverged');
+  });
+
+  it('each variant host rewrite targets its generated variant file', () => {
+    for (const rule of dashboardRewrites.filter((r) => r.has)) {
+      const host = (rule.has ?? []).find((h) => h.type === 'host')?.value ?? '';
+      const variant = host.replace('.worldmonitor.app', '');
+      assert.match(host, /^[a-z]+\.worldmonitor\.app$/, `unexpected host condition shape: ${host}`);
       assert.strictEqual(
         rule.destination,
         `/dashboard-${variant}.html`,
-        `${variant} host rewrite must target the build-generated variant file`
+        `${host} rewrite must target the build-generated variant file`
       );
     }
   });
@@ -2155,7 +2191,7 @@ describe('variant subdomain dashboard SEO (#4996)', () => {
       dashboardRewrites.length - 1,
       'the un-conditioned /dashboard rewrite must come last so host rules win'
     );
-    assert.strictEqual(dashboardRewrites.length, WEB_DASHBOARD_VARIANTS.length + 1);
+    assert.strictEqual(dashboardRewrites.length, rewriteVariants.length + 1, 'exactly one un-conditioned /dashboard rewrite expected');
   });
 
   it('vite build emits the variant dashboard files the rewrites point at (web full build only)', () => {
@@ -2164,22 +2200,6 @@ describe('variant subdomain dashboard SEO (#4996)', () => {
       /!isDesktopBuild && activeVariant === 'full' && variantDashboardHtmlPlugin\(\)/,
       'variantDashboardHtmlPlugin must be registered for web full builds'
     );
-    const variantHtmlSource = readFileSync(resolve(__dirname, '../src/config/variant-dashboard-html.ts'), 'utf-8');
-    for (const variant of WEB_DASHBOARD_VARIANTS) {
-      assert.ok(
-        variantHtmlSource.includes(`'${variant}'`),
-        `src/config/variant-dashboard-html.ts must cover the '${variant}' variant referenced by vercel.json`
-      );
-    }
-  });
-
-  it('middleware variant host map and the rewrites cover the same subdomains', () => {
-    for (const variant of WEB_DASHBOARD_VARIANTS) {
-      assert.ok(
-        middlewareSource.includes(`'${variant}.worldmonitor.app': '${variant}'`),
-        `middleware VARIANT_HOST_MAP must include ${variant}.worldmonitor.app`
-      );
-    }
   });
 });
 

--- a/tests/variant-dashboard-html.test.mts
+++ b/tests/variant-dashboard-html.test.mts
@@ -1,0 +1,163 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  WEB_DASHBOARD_VARIANTS,
+  renderVariantDashboardHtml,
+  variantDashboardFileName,
+} from '../src/config/variant-dashboard-html';
+import { VARIANT_META } from '../src/config/variant-meta';
+
+// Mirrors the exact markup shapes of the BUILT dist/dashboard.html (index.html
+// after htmlVariantPlugin with the full meta): trailing ` />` on metas,
+// pretty-printed JSON-LD with the WebApplication block first, hreflang cluster
+// with ?lang= suffixes, and the visually-hidden app-heading <h1>. If the real
+// markup drifts, renderVariantDashboardHtml throws at build time — this
+// fixture only exercises the transform logic.
+const FULL = VARIANT_META.full;
+const fixture = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>${FULL.title}</title>
+    <meta name="title" content="${FULL.title}" />
+    <meta name="description" content="${FULL.description}" />
+    <meta name="keywords" content="${FULL.keywords}" />
+    <link rel="canonical" href="${FULL.url}" />
+    <link rel="alternate" hreflang="x-default" href="${FULL.url}" />
+    <link rel="alternate" hreflang="fr" href="${FULL.url}?lang=fr" />
+    <meta name="application-name" content="World Monitor" />
+    <meta name="subject" content="${FULL.subject}" />
+    <meta name="classification" content="${FULL.classification}" />
+    <meta property="og:url" content="${FULL.url}" />
+    <meta property="og:title" content="${FULL.title}" />
+    <meta property="og:description" content="${FULL.description}" />
+    <meta property="og:image" content="https://www.worldmonitor.app/favico/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:site_name" content="World Monitor" />
+    <meta name="twitter:url" content="${FULL.url}" />
+    <meta name="twitter:title" content="${FULL.title}" />
+    <meta name="twitter:description" content="${FULL.description}" />
+    <meta name="twitter:image" content="https://www.worldmonitor.app/favico/og-image.png" />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "World Monitor",
+      "alternateName": ["WorldMonitor", "World Monitor App", "WM Intelligence"],
+      "url": "${FULL.url}",
+      "screenshot": "https://www.worldmonitor.app/favico/og-image.png",
+      "featureList": [
+        "Real-time news aggregation",
+        "Stock market tracking"
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "World Monitor",
+      "alternateName": "WorldMonitor",
+      "url": "https://www.worldmonitor.app/"
+    }
+    </script>
+  </head>
+  <body>
+    <h1 class="app-heading">World Monitor — Real-Time Global Intelligence Dashboard</h1>
+    <p>Link to <a href="${FULL.url}">the main dashboard</a> stays untouched.</p>
+  </body>
+</html>`;
+
+const escHtml = (s: string) =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+describe('renderVariantDashboardHtml (#4996)', () => {
+  it('self-canonicalizes each variant on its own subdomain', () => {
+    for (const variant of WEB_DASHBOARD_VARIANTS) {
+      const html = renderVariantDashboardHtml(fixture, variant);
+      const meta = VARIANT_META[variant];
+      assert.ok(
+        html.includes(`<link rel="canonical" href="${meta.url}" />`),
+        `${variant}: canonical should be ${meta.url}`,
+      );
+      assert.ok(html.includes(`<meta property="og:url" content="${meta.url}" />`), `${variant}: og:url`);
+      assert.ok(html.includes(`<meta name="twitter:url" content="${meta.url}" />`), `${variant}: twitter:url`);
+      assert.ok(
+        !html.includes(`<link rel="canonical" href="${FULL.url}" />`),
+        `${variant}: must not keep the www canonical`,
+      );
+    }
+  });
+
+  it('rewrites brand meta, hreflang cluster, social images, and h1 for tech', () => {
+    const html = renderVariantDashboardHtml(fixture, 'tech');
+    const tech = VARIANT_META.tech;
+    assert.ok(html.includes(`<title>${escHtml(tech.title)}</title>`), 'title');
+    assert.ok(html.includes(`<meta name="description" content="${escHtml(tech.description)}" />`), 'description');
+    assert.ok(html.includes(`<meta property="og:site_name" content="Tech Monitor" />`), 'og:site_name');
+    assert.ok(html.includes(`<meta name="application-name" content="Tech Monitor" />`), 'application-name');
+    assert.ok(html.includes(`<meta name="subject" content="${escHtml(tech.subject)}" />`), 'subject');
+    assert.ok(
+      html.includes(`<link rel="alternate" hreflang="fr" href="${tech.url}?lang=fr" />`),
+      'hreflang keeps ?lang suffix on the variant host',
+    );
+    assert.ok(
+      html.includes(`<link rel="alternate" hreflang="x-default" href="${tech.url}" />`),
+      'x-default alternate moves to the variant host',
+    );
+    assert.ok(
+      html.includes('content="https://tech.worldmonitor.app/favico/tech/og-image.png"'),
+      'og/twitter image points at the variant OG asset',
+    );
+    assert.ok(html.includes('<meta property="og:image:width" content="1200" />'), 'og:image:width untouched');
+    assert.ok(html.includes(`<h1 class="app-heading">${escHtml(tech.title)}</h1>`), 'h1');
+  });
+
+  it('rewrites the WebApplication JSON-LD block but leaves the Organization block as World Monitor', () => {
+    const html = renderVariantDashboardHtml(fixture, 'finance');
+    const finance = VARIANT_META.finance;
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/g)].map(
+      (m) => JSON.parse(m[1]),
+    );
+    assert.equal(blocks.length, 2, 'both JSON-LD blocks stay parseable');
+    const webApp = blocks.find((b) => b['@type'] === 'WebApplication');
+    const org = blocks.find((b) => b['@type'] === 'Organization');
+    assert.equal(webApp.name, 'Finance Monitor');
+    assert.equal(webApp.url, finance.url);
+    assert.equal(webApp.screenshot, 'https://finance.worldmonitor.app/favico/finance/og-image.png');
+    assert.deepEqual(webApp.featureList, finance.features);
+    assert.equal(org.name, 'World Monitor', 'variant isPartOf World Monitor — org identity stays');
+    assert.equal(org.url, 'https://www.worldmonitor.app/');
+  });
+
+  it('leaves body links to the main dashboard untouched', () => {
+    const html = renderVariantDashboardHtml(fixture, 'energy');
+    assert.ok(html.includes(`<a href="${FULL.url}">the main dashboard</a>`));
+  });
+
+  it('throws loudly when an anchor is missing (markup drift guard)', () => {
+    const withoutCanonical = fixture.replace(/<link rel="canonical"[^>]*>\n/, '');
+    assert.throws(() => renderVariantDashboardHtml(withoutCanonical, 'tech'), /anchor "canonical" matched 0/);
+  });
+
+  it('throws loudly when an anchor is duplicated', () => {
+    const doubled = fixture.replace(
+      `<link rel="canonical" href="${FULL.url}" />`,
+      `<link rel="canonical" href="${FULL.url}" />\n    <link rel="canonical" href="${FULL.url}" />`,
+    );
+    assert.throws(() => renderVariantDashboardHtml(doubled, 'tech'), /anchor "canonical" matched 2/);
+  });
+
+  it('rejects unknown variants and the full variant itself', () => {
+    assert.throws(() => renderVariantDashboardHtml(fixture, 'full'));
+    assert.throws(() => renderVariantDashboardHtml(fixture, 'nope'));
+  });
+
+  it('names output files after the variant', () => {
+    assert.equal(variantDashboardFileName('tech'), 'dashboard-tech.html');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -36,7 +36,7 @@
     { "source": "/dashboard", "has": [{ "type": "host", "value": "happy.worldmonitor.app" }], "destination": "/dashboard-happy.html" },
     { "source": "/dashboard", "has": [{ "type": "host", "value": "energy.worldmonitor.app" }], "destination": "/dashboard-energy.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
-    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
+    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [
     {
@@ -251,7 +251,7 @@
       ]
     },
     {
-      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
+      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,11 @@
     { "source": "/.well-known/mcp", "destination": "/api/mcp" },
     { "source": "/.well-known/mcp.json", "destination": "/api/mcp" },
     { "source": "/embed", "destination": "/embed.html" },
+    { "source": "/dashboard", "has": [{ "type": "host", "value": "tech.worldmonitor.app" }], "destination": "/dashboard-tech.html" },
+    { "source": "/dashboard", "has": [{ "type": "host", "value": "finance.worldmonitor.app" }], "destination": "/dashboard-finance.html" },
+    { "source": "/dashboard", "has": [{ "type": "host", "value": "commodity.worldmonitor.app" }], "destination": "/dashboard-commodity.html" },
+    { "source": "/dashboard", "has": [{ "type": "host", "value": "happy.worldmonitor.app" }], "destination": "/dashboard-happy.html" },
+    { "source": "/dashboard", "has": [{ "type": "host", "value": "energy.worldmonitor.app" }], "destination": "/dashboard-energy.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
     { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
@@ -118,7 +123,8 @@
       "headers": [
         { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
         { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Cache-Control", "value": "public, max-age=3600" }
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/pricing.md>; rel=\"canonical\"" }
       ]
     },
     {
@@ -126,7 +132,17 @@
       "headers": [
         { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
         { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Cache-Control", "value": "public, max-age=3600" }
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/support.md>; rel=\"canonical\"" }
+      ]
+    },
+    {
+      "source": "/ai-search.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/ai-search.md>; rel=\"canonical\"" }
       ]
     },
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,11 @@ import { brotliCompress } from 'zlib';
 import { promisify } from 'util';
 import pkg from './package.json';
 import { VARIANT_META, type VariantMeta } from './src/config/variant-meta';
+import {
+  WEB_DASHBOARD_VARIANTS,
+  renderVariantDashboardHtml,
+  variantDashboardFileName,
+} from './src/config/variant-dashboard-html';
 
 // Env-dependent constants moved inside defineConfig function
 
@@ -295,6 +300,38 @@ function dashboardHtmlOutputPlugin(): Plugin {
         dashboardHtml.source = deferDashboardStylesheetLinks(dashboardHtml.source, bundle);
       }
       bundle['dashboard.html'] = dashboardHtml;
+    },
+  };
+}
+
+// Emit dashboard-<variant>.html siblings of dashboard.html for the variant
+// subdomains (#4996). The web deployment serves the 'full' build to every
+// host, so tech/finance/commodity/happy/energy.worldmonitor.app/dashboard
+// shipped full-brand meta and a cross-host canonical pointing at www —
+// crawlers saw five duplicate pages that all declared themselves NOT to be
+// the sitemap URL they were fetched from. vercel.json host-based rewrites
+// map each variant host's /dashboard to its generated file. Runs in
+// generateBundle AFTER dashboardHtmlOutputPlugin (both enforce: 'post',
+// registered later in the plugins array) so it reads the final renamed +
+// stylesheet-deferred dashboard.html; emitted via emitFile so
+// brotliPrecompressPlugin picks the files up like any other asset.
+function variantDashboardHtmlPlugin(): Plugin {
+  return {
+    name: 'wm-variant-dashboard-html',
+    apply: 'build',
+    enforce: 'post',
+    generateBundle(_options, bundle) {
+      const dashboard = bundle['dashboard.html'];
+      if (!dashboard || dashboard.type !== 'asset' || typeof dashboard.source !== 'string') {
+        throw new Error('[vite] wm-variant-dashboard-html expected dashboard.html asset (must run after wm-dashboard-html-output)');
+      }
+      for (const variant of WEB_DASHBOARD_VARIANTS) {
+        this.emitFile({
+          type: 'asset',
+          fileName: variantDashboardFileName(variant),
+          source: renderVariantDashboardHtml(dashboard.source, variant),
+        });
+      }
     },
   };
 }
@@ -930,6 +967,10 @@ export default defineConfig(({ mode }) => {
       },
       htmlVariantPlugin(activeMeta, activeVariant, isDesktopBuild),
       !isDesktopBuild && dashboardHtmlOutputPlugin(),
+      // Variant subdomain SEO pages only make sense on the web deployment,
+      // which is always the 'full' build (variant selection is runtime by
+      // hostname). Desktop and dedicated VITE_VARIANT builds skip it.
+      !isDesktopBuild && activeVariant === 'full' && variantDashboardHtmlPlugin(),
       polymarketPlugin(),
       rssProxyPlugin(),
       youtubeLivePlugin(),


### PR DESCRIPTION
Closes #4996. Closes #4999.

**Source:** boringmarketing.com AI-visibility audit (44% AI coverage) — the two verified "incorrect/missing canonicals" findings.

## What

### Variant subdomain dashboards (#4996)
The web deployment serves the `full` build to every host, so the five sitemap-listed variant dashboards (`tech|finance|commodity|happy|energy.worldmonitor.app/dashboard`) shipped byte-identical full-brand HTML with a cross-host canonical pointing at `www.worldmonitor.app/dashboard` — the sitemap said "index me", the page said "I'm a duplicate of www". AEO scanners score it as a canonical error; crawlers drop the variant URLs.

- **`src/config/variant-dashboard-html.ts`** (new): derives `dashboard-<variant>.html` from the built `dashboard.html`. Rewrites: title metas, description/keywords/subject/classification, self-referencing canonical, the ~26-entry hreflang cluster (moved to the variant host, `?lang=` preserved), og/twitter cards + per-variant OG image, WebApplication JSON-LD identity (name/url/screenshot/featureList), and the visually-hidden `<h1>`. Organization/WebSite JSON-LD intentionally keep the World Monitor identity (variants are `isPartOf` World Monitor — same modelling as the `middleware.ts` crawler stub). Every replacement carries an occurrence-count assertion so markup drift **fails the build loudly** instead of silently shipping full-brand meta again.
- **`vite.config.ts`**: `wm-variant-dashboard-html` plugin (generateBundle, after `wm-dashboard-html-output`), gated to web `full` builds; emits via `emitFile` so brotli precompression picks the files up. Workbox precache untouched (globPatterns has no html).
- **`vercel.json`**: five host-conditioned `/dashboard` rewrites ahead of the generic SPA rule.

### Sitemap-listed .md pages (#4999)
`pricing.md` / `support.md` / `ai-search.md` are intentionally raw `text/markdown` for agents, so they can't carry `<link rel=canonical>` — they were the only indexable URLs with no canonical signal. Added self-referencing `Link: <…>; rel="canonical"` response headers (RFC 6596 header form), including a previously missing header block for `/ai-search.md`.

## Verification
- `npx tsx --test tests/variant-dashboard-html.test.mts` — 8/8 (incl. drift-guard throw paths, JSON-LD parse round-trip, Organization-block immutability)
- `tests/deploy-config.test.mjs` — 128/128 (new guards: per-variant rewrite presence + ordering, vite plugin registration, middleware host-map parity, sitemap↔Link-header completeness sweep that fails if a future .md is added to the sitemap without a canonical rule)
- Full `npx vite build` run: 5 files emitted + `.br` siblings; verified tech/energy canonical, hreflang `?lang=fr` on tech host, all JSON-LD blocks parse, `dashboard.html` byte-identical behavior otherwise
- `tsc --noEmit` clean; `node scripts/docs-stats.mjs --check` OK; built-output suites (critical-css / eager-chunks / map-renderer-deferral) 171/171

## Notes for review
- The un-conditioned `/dashboard` rewrite stays last; Vercel evaluates rewrites in order and `has.host` rules win for the five subdomains (guarded by test).
- `build:full` (self-host image) also emits the five files — harmless unused assets there.
- Rollback: drop the vercel.json rewrites; the generated files become unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
