### PR TITLE
feat(content): free-vs-paid comparison post + fix never-firing FAQPage JSON-LD (#4998, #5001)

### DIFF
--- a/blog-site/src/content/blog/free-vs-paid-real-time-intelligence-dashboards.md
+++ b/blog-site/src/content/blog/free-vs-paid-real-time-intelligence-dashboards.md
@@ -1,0 +1,122 @@
+---
+title: "Free vs. Paid Real-Time Intelligence Dashboards: What to Compare"
+description: "What free intelligence dashboards actually include, what paid tiers add, and the seven factors buyers should compare — with real 2026 price anchors from $0 to $24,000/year."
+metaTitle: "Free vs Paid Intelligence Dashboards: Buyer's Comparison 2026"
+keywords: "free vs paid intelligence dashboard, real-time intelligence dashboard comparison, free OSINT dashboard, intelligence platform pricing, geopolitical dashboard cost, situational awareness tools comparison, free intelligence tools 2026"
+audience: "Buyers evaluating intelligence tooling, analysts justifying budget, procurement teams, researchers deciding whether to upgrade"
+heroImage: "/blog/og/free-vs-paid-real-time-intelligence-dashboards.png"
+pubDate: "2026-07-07"
+---
+
+Most buyers evaluating real-time intelligence dashboards compare the wrong things. The honest answer to "free versus paid" is that free tiers now cover **awareness** — seeing what is happening in the world right now — remarkably well, while paid tiers sell the **decision layer**: analysis, alert routing, programmatic access, and deployment control. If your job ends at "know what's happening," a good free dashboard is enough. If your job is "decide, notify, and integrate," you are buying one of those three things, and you should price them separately.
+
+This guide breaks down what free tiers actually include in 2026, what paid tiers actually add, and the seven factors that separate a fair price from an expensive logo.
+
+## What does a free real-time intelligence dashboard include?
+
+More than most buyers expect. Using [World Monitor's free tier](https://www.worldmonitor.app/) as a concrete reference point — because its scope is public and it requires no signup — a $0 dashboard today includes:
+
+- **56 map layer types** across conflicts, military activity, natural disasters, cyber incidents, infrastructure, shipping, and markets
+- **500+ curated news feeds** aggregated and deduplicated in real time
+- **Country briefs and instability scores** for situational context worldwide
+- **Maritime chokepoint monitoring** (Hormuz, Suez, Malacca, Bab el-Mandeb) and undersea cable status
+- **Cascade analysis, hotspots, breaking-alert pipeline, and watchlists**
+- Coverage in [21 languages](https://www.worldmonitor.app/blog/posts/worldmonitor-in-21-languages-global-intelligence-for-everyone/)
+
+The catch, and it is a fair one: free-tier refresh cadence is typically **5–15 minutes** rather than seconds, and the workflow layer — analyst chat, scheduled digests, API access, team features — sits behind paid plans.
+
+Free tiers built on open data are not a marketing trick. Much of the underlying signal (ACLED, UCDP, USGS, NASA FIRMS, GDELT) is [free at the source](https://www.worldmonitor.app/blog/posts/free-geopolitical-data-apis-2026/); what a free dashboard adds is aggregation, normalization, and a single view.
+
+## What do paid tiers actually add?
+
+Across the category, paid features cluster into three groups. Price each one separately, because vendors bundle them differently:
+
+**1. The decision layer.** AI analysis grounded in the live data (not a generic chatbot), scenario simulation, route risk, and personal digests delivered on a schedule. This is the layer that turns "something happened" into "here is what it means for your exposure."
+
+**2. Programmatic access.** REST APIs, webhooks, structured JSON, and — increasingly important in 2026 — [MCP servers](https://www.worldmonitor.app/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/) so AI agents (Claude, GPT, custom stacks) can query the same intelligence your analysts see. If your evaluation checklist doesn't include agent access yet, it will next cycle.
+
+**3. Organizational control.** SSO/MFA/RBAC, team workspaces, audit trails, white-labeling, SIEM connectors, and deployment options up to on-premises or air-gapped. This is where enterprise pricing lives, and it is legitimately expensive to deliver.
+
+## What should buyers compare?
+
+Seven factors, in the order they usually decide outcomes:
+
+| Factor | The question to ask | Why it decides |
+|---|---|---|
+| Data breadth | How many domains in one view — conflicts, markets, shipping, cyber, disasters? | Multi-domain correlation is the whole point of a dashboard |
+| Refresh cadence | Minutes or seconds? Is the cadence documented per source? | The gap between free (5–15 min) and paid (near-real-time) tiers |
+| Source transparency | Can you see per-source freshness and provenance? | Aggregated intelligence you can't audit is a liability |
+| Alert routing | Slack, Teams, Discord, Telegram, email, webhook — or in-app only? | Alerts nobody sees are decoration |
+| Programmatic access | REST API quotas, webhook rules, MCP/agent support | Determines whether the tool composes with your stack |
+| AI grounding | Does the AI cite the live data it reasoned over, or hallucinate freely? | Ungrounded AI summaries are worse than none |
+| Deployment control | Cloud-only, or dedicated tenant / on-prem / air-gapped? | Non-negotiable for government, SOC, and regulated buyers |
+
+## How the market prices real-time intelligence in 2026
+
+Realistic anchors across the spectrum:
+
+| Tier | Typical 2026 price | What you get | Examples |
+|---|---|---|---|
+| Free / open source | $0 | Aggregated multi-domain awareness, community support | World Monitor free tier, self-hosted OSINT stacks |
+| Prosumer / analyst | ~$30–80/month | AI analysis, digests, alerting, personal workflows | World Monitor Pro at $39.99/month |
+| API / developer | ~$100–250/month | Programmatic quotas, webhooks, structured data | World Monitor API at $99.99–249.99/month |
+| Enterprise SaaS | Six figures/year | Team seats, SLAs, integrations, support | Dataminr-class licenses |
+| Terminal / platform | $24,000/year per seat and up | Deep proprietary data, execution workflows | Bloomberg Terminal; Palantir deployments start in the millions |
+
+Two things follow from this table. First, the gap between $0 and $24,000 is not 24,000× the intelligence — it is depth in one domain (Bloomberg's tick-level market data) or organizational integration (Palantir), which you should buy only if you specifically need it. We've published a [detailed head-to-head comparison](https://www.worldmonitor.app/blog/posts/worldmonitor-vs-traditional-intelligence-tools/) if that's your decision. Second, the prosumer tier is new: the $40/month analyst desk simply did not exist a few years ago, and it is the right answer for most individual professionals.
+
+## When is free enough?
+
+Free is the correct choice — not a compromise — when:
+
+- You need **situational awareness**, not automated decisions: journalists, researchers, students, and anyone [building a daily briefing habit](https://www.worldmonitor.app/blog/posts/daily-intelligence-briefing-workflow-15-minutes/)
+- A 5–15 minute refresh cadence is acceptable for your decisions
+- You check the dashboard rather than needing it to reach you
+- You want to **validate the data quality before paying** — a vendor whose free tier is a crippled demo is telling you something about their paid tier
+- You have engineering time instead of budget: open-source options can be [self-hosted outright](https://www.worldmonitor.app/blog/posts/self-host-worldmonitor-open-source-osint-dashboard/)
+
+## When is paid worth it?
+
+Upgrade when one of these is concretely true:
+
+- **Missed events cost you money or safety.** Scheduled digests and alert routing to Slack/Teams/Telegram exist so the dashboard reaches you.
+- **You ask analytical questions daily.** An AI analyst grounded in 30+ live data services with citations replaces the hour of tab-hopping, not the dashboard.
+- **You're integrating, not reading.** API quotas (e.g. 1,000 requests/day starter, 10,000/day business tier) and webhook rules are the product; the UI is incidental.
+- **Your agents need the data.** MCP access with a documented tool surface (39 tools in World Monitor's case) lets Claude or GPT query live intelligence under one key.
+- **Compliance is in the room.** SSO, RBAC, audit trails, and air-gapped deployment are enterprise-tier features everywhere; nobody ships them free.
+
+## How World Monitor prices free vs. paid
+
+For a concrete, current example (full details on the [pricing page](https://www.worldmonitor.app/pro#pricing), machine-readable at [pricing.md](https://www.worldmonitor.app/pricing.md)):
+
+| Plan | Price | Built for |
+|---|---|---|
+| Free | $0, no signup | Public situational awareness: 56 map layers, 500+ feeds, country briefs, chokepoints, watchlists |
+| Pro | $39.99/month or $399.99/year | Analysts: WM Analyst chat with citations, Scenario Engine, Route Explorer, AI digest, MCP access with 39 tools |
+| API | $99.99/month or $999/year | Developers: REST access, 1,000 requests/day, 5 webhook rules, OpenAPI docs |
+| API Business | $249.99/month | Teams: 300 requests/minute, 10,000 requests/day, priority support |
+| Enterprise | Custom | Organizations: SSO/MFA/RBAC, team workspaces, white-label, on-prem or air-gapped deployment |
+
+Rate limits are hard limits — exceeding a quota returns HTTP 429 with a `Retry-After` header, never a silent charge. That is the kind of detail worth checking on any vendor's pricing page before you integrate.
+
+## Frequently Asked Questions
+
+**Are free intelligence dashboards actually usable, or just demos?**
+
+The good ones are fully usable for awareness work. World Monitor's free tier ships 56 map layers and 500+ feeds with no signup; the underlying open data (ACLED, UCDP, USGS, NASA FIRMS) is the same signal paid platforms ingest. The honest limitation is refresh cadence (5–15 minutes) and the absence of the workflow layer — alerts, AI analysis, API access.
+
+**What is the single biggest difference between free and paid tiers?**
+
+Delivery. Free tiers require you to look at the dashboard; paid tiers push intelligence to where you work — scheduled digests and alerts into Slack, Teams, Discord, Telegram, email, or webhooks — and expose the data programmatically via API and MCP so your systems and AI agents consume it directly.
+
+**How much should an individual analyst expect to pay in 2026?**
+
+Around $30–80/month for the prosumer tier. World Monitor Pro is $39.99/month ($399.99/year). Compare that against enterprise anchors — Bloomberg Terminal at $24,000/year per seat, Dataminr licenses in six figures — and price the specific capability gap, not the brand.
+
+**Do paid intelligence platforms train AI on my queries?**
+
+Policies vary by vendor and this belongs on your comparison checklist. Look for an explicit content-signal or data-usage policy; World Monitor, for example, declares ai-train=no site-wide and runs BYOK/local AI options so analysis can stay on your keys.
+
+**When does the API tier make more sense than the Pro tier?**
+
+When the consumer is software, not a person. If you are wiring intelligence into your own risk models, ops tooling, or agents, the API tier's quotas (1,000 requests/day starter, 10,000/day business) and webhook rules are what you are actually buying. If a human reads the output, Pro's analyst chat and digests are the better $40.

--- a/blog-site/src/layouts/BlogPost.astro
+++ b/blog-site/src/layouts/BlogPost.astro
@@ -118,7 +118,11 @@ function extractFaqLd(body: string | undefined): object | null {
   const afterFaq = body.slice(faqIdx + '## Frequently Asked Questions'.length);
   const nextHeading = afterFaq.search(/\n##\s/);
   const faqSection = nextHeading === -1 ? afterFaq : afterFaq.slice(0, nextHeading);
-  const qaRegex = /\*\*(.+?)\*\*\n([^\n*]+(?:\n[^\n*#]+)*)/g;
+  // \n+ (not \n): every post writes a blank line between the bolded question
+  // and its answer — with a single \n the regex matched nothing and NO post
+  // ever emitted FAQPage JSON-LD (#5001). Guarded against the real post
+  // corpus by tests/blog-faq-ld.test.mjs.
+  const qaRegex = /\*\*(.+?)\*\*\n+([^\n*]+(?:\n[^\n*#]+)*)/g;
   const items: { "@type": string; name: string; acceptedAnswer: { "@type": string; text: string } }[] = [];
   let match: RegExpExecArray | null;
   while ((match = qaRegex.exec(faqSection)) !== null) {

--- a/blog-site/src/layouts/BlogPost.astro
+++ b/blog-site/src/layouts/BlogPost.astro
@@ -116,7 +116,10 @@ function extractFaqLd(body: string | undefined): object | null {
   const faqIdx = body.indexOf('## Frequently Asked Questions');
   if (faqIdx === -1) return null;
   const afterFaq = body.slice(faqIdx + '## Frequently Asked Questions'.length);
-  const nextHeading = afterFaq.search(/\n##\s/);
+  // The FAQ section ends at the next H2 OR at a horizontal rule — nearly
+  // every post closes its FAQ with `---` followed by a bold takeaway/CTA
+  // paragraph, which must not be extracted as a Question.
+  const nextHeading = afterFaq.search(/\n##\s|\n---\s*\n/);
   const faqSection = nextHeading === -1 ? afterFaq : afterFaq.slice(0, nextHeading);
   // \n+ (not \n): every post writes a blank line between the bolded question
   // and its answer — with a single \n the regex matched nothing and NO post

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -193,6 +193,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://www.worldmonitor.app/blog/posts/free-vs-paid-real-time-intelligence-dashboards/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://www.worldmonitor.app/blog/glossary/</loc>
     <lastmod>2026-07-06</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/blog-faq-ld.test.mjs
+++ b/tests/blog-faq-ld.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LAYOUT_PATH = resolve(__dirname, '../blog-site/src/layouts/BlogPost.astro');
+const BLOG_DIR = resolve(__dirname, '../blog-site/src/content/blog');
+
+// extractFaqLd lives in the .astro frontmatter, which node can't import.
+// Text-extract the function body and evaluate it (established pattern for
+// guarding generators without importing them). If the function is renamed
+// or moved, this fails loudly rather than silently guarding nothing.
+function loadExtractFaqLd() {
+  const source = readFileSync(LAYOUT_PATH, 'utf-8');
+  const match = source.match(/function extractFaqLd\([\s\S]*?\n\}/);
+  assert.ok(match, 'extractFaqLd function not found in BlogPost.astro');
+  // Strip the TS annotations that would break plain-JS evaluation.
+  const js = match[0]
+    .replace('(body: string | undefined): object | null', '(body)')
+    .replace(/const items: \{[\s\S]*?\}\[\] = \[\];/, 'const items = [];')
+    .replace('let match: RegExpExecArray | null;', 'let match;');
+  return new Function(`${js}\nreturn extractFaqLd;`)();
+}
+
+const extractFaqLd = loadExtractFaqLd();
+
+describe('blog FAQPage JSON-LD extraction (#5001)', () => {
+  it('extracts Q&A written in the corpus format (blank line between question and answer)', () => {
+    const body = [
+      '## Frequently Asked Questions',
+      '',
+      '**Is the free tier usable?**',
+      '',
+      'Yes — it ships [56 layers](https://www.worldmonitor.app/) with no signup.',
+      '',
+      '**When is paid worth it?**',
+      '',
+      'When missed events cost you money.',
+      '',
+      '## Next section',
+      'not faq content',
+    ].join('\n');
+    const ld = extractFaqLd(body);
+    assert.ok(ld, 'FAQPage LD must be produced');
+    assert.equal(ld['@type'], 'FAQPage');
+    assert.equal(ld.mainEntity.length, 2);
+    assert.equal(ld.mainEntity[0].name, 'Is the free tier usable?');
+    assert.equal(
+      ld.mainEntity[0].acceptedAnswer.text,
+      'Yes — it ships 56 layers with no signup.',
+      'markdown links must be flattened to text',
+    );
+  });
+
+  it('still extracts the tight format (answer on the very next line)', () => {
+    const body = '## Frequently Asked Questions\n**Q one?**\nAnswer one.\n';
+    const ld = extractFaqLd(body);
+    assert.equal(ld.mainEntity.length, 1);
+  });
+
+  it('returns null when there is no FAQ section', () => {
+    assert.equal(extractFaqLd('## Something else\n\n**bold** text'), null);
+    assert.equal(extractFaqLd(undefined), null);
+  });
+
+  it('every published post with an FAQ section yields at least one Question (corpus sweep)', () => {
+    const posts = readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'));
+    assert.ok(posts.length > 0, 'expected blog posts');
+    let postsWithFaq = 0;
+    for (const file of posts) {
+      const body = readFileSync(join(BLOG_DIR, file), 'utf-8');
+      if (!body.includes('## Frequently Asked Questions')) continue;
+      postsWithFaq += 1;
+      const ld = extractFaqLd(body);
+      assert.ok(
+        ld && ld.mainEntity.length > 0,
+        `${file} has an FAQ section but extractFaqLd produced nothing — the regex regressed against the corpus format`,
+      );
+      for (const item of ld.mainEntity) {
+        assert.ok(item.name.length > 0 && item.acceptedAnswer.text.length > 0, `${file}: empty Q or A extracted`);
+      }
+    }
+    assert.ok(postsWithFaq > 0, 'expected at least one post with an FAQ section — the sweep is guarding nothing');
+  });
+});

--- a/tests/blog-faq-ld.test.mjs
+++ b/tests/blog-faq-ld.test.mjs
@@ -39,13 +39,20 @@ describe('blog FAQPage JSON-LD extraction (#5001)', () => {
       '',
       'When missed events cost you money.',
       '',
-      '## Next section',
-      'not faq content',
+      '---',
+      '',
+      '**Pick your variant and start exploring:**',
+      '',
+      '- [worldmonitor.app](https://worldmonitor.app) for geopolitics',
     ].join('\n');
     const ld = extractFaqLd(body);
     assert.ok(ld, 'FAQPage LD must be produced');
     assert.equal(ld['@type'], 'FAQPage');
-    assert.equal(ld.mainEntity.length, 2);
+    assert.equal(
+      ld.mainEntity.length,
+      2,
+      'the bold CTA after the --- rule must NOT be extracted as a Question (corpus posts end FAQs with --- + CTA)',
+    );
     assert.equal(ld.mainEntity[0].name, 'Is the free tier usable?');
     assert.equal(
       ld.mainEntity[0].acceptedAnswer.text,
@@ -80,6 +87,13 @@ describe('blog FAQPage JSON-LD extraction (#5001)', () => {
       );
       for (const item of ld.mainEntity) {
         assert.ok(item.name.length > 0 && item.acceptedAnswer.text.length > 0, `${file}: empty Q or A extracted`);
+        // Every real FAQ question in the corpus ends with '?'; the bold
+        // takeaway/CTA paragraphs after the closing --- rule do not. If this
+        // fires, the extractor is running past the FAQ terminator again.
+        assert.ok(
+          item.name.endsWith('?'),
+          `${file}: extracted non-question "${item.name.slice(0, 60)}" — FAQ section terminator over-capture`,
+        );
       }
     }
     assert.ok(postsWithFaq > 0, 'expected at least one post with an FAQ section — the sweep is guarding nothing');


### PR DESCRIPTION
Closes #4998. Closes #5001.

**Source:** boringmarketing.com AI-visibility audit — the "Free vs Paid Comparison" citation test was the only query family where worldmonitor.app scored **0/4 AI platforms** (ChatGPT, Perplexity, Claude, Gemini); third-party publishers take those citations instead.

## What

### New comparison post (#4998)
`blog-site/src/content/blog/free-vs-paid-real-time-intelligence-dashboards.md` — built to the audit's format guidance:

- **Answer capsule** in the first paragraph (quotable 3-sentence direct answer: free = awareness, paid = decision layer / programmatic access / org control)
- **Question-headed H2s** matching the tested buyer queries ("What does a free dashboard include?", "What should buyers compare?", "When is paid worth it?")
- **Seven-factor comparison checklist** + 2026 market price-anchor table ($0 → $24k/yr, reusing only anchors already published in the vs-traditional-tools post)
- **Exact WM tier table sourced from `public/pricing.md`** — every number cross-checked (Free $0 / Pro $39.99 / API $99.99 / API Business $249.99), no invented stats
- 5-question FAQ in the FAQPage-extractable format; internal links into the existing content cluster (free-APIs, daily-briefing, self-host, vs-traditional, MCP posts)
- Root `public/sitemap.xml` entry; OG image deploy-generates via the existing satori pipeline

### FAQPage JSON-LD was never firing (#5001)
While wiring the FAQ I found `extractFaqLd` in `BlogPost.astro` requires the answer on the line **immediately** after `**Question**` — but every post in the corpus writes a blank line between them. Result: **no post has ever emitted FAQPage JSON-LD** (verified live: free-geopolitical-data-apis-2026 emits only BlogPosting + BreadcrumbList despite a 6-question FAQ). One-char fix (`\n+`), and a new `tests/blog-faq-ld.test.mjs` that text-extracts the function from the .astro frontmatter and **sweeps every published post** with an FAQ section — format drift now fails the suite instead of silently dropping rich results across ~39 posts.

## Verification
- Full `blog-site` build: post renders at `/posts/free-vs-paid-real-time-intelligence-dashboards/` — self-canonical, 1 H1, visible `<time>` date, 1,617 words, `BlogPosting + BreadcrumbList + FAQPage (5 questions)` all JSON-parse
- Regression check on an existing post's built output: free-geopolitical-data-apis-2026 now emits FAQPage too
- `npx tsx --test tests/blog-faq-ld.test.mjs` — 4/4 (incl. corpus sweep + old tight-format still supported + link-flattening in answers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
