### PR TITLE
fix(forecast): reserve run-budget for the full provider chain so market_implications' groq fallback isn't stranded (#4978 follow-up)

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14609,6 +14609,12 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
   const providers = resolveForecastLlmProviders(options);
   const stageBudgetMs = getForecastLlmStageBudgetMs(options);
   const budgetStartedAtMs = Date.now();
+  // Per-provider retry count is overridable per call. Budget-constrained tail
+  // stages (market_implications) pass 0 so a slow primary cannot burn the shared
+  // run budget across 4 attempts and strand the fallback provider (#5003 review).
+  const providerMaxRetries = Number.isFinite(options.maxRetries)
+    ? Math.max(0, Math.floor(options.maxRetries))
+    : FORECAST_LLM_PROVIDER_MAX_RETRIES;
   const requestedOrder = Array.isArray(options.providerOrder) && options.providerOrder.length > 0
     ? options.providerOrder.join(',')
     : providers.map(provider => provider.name).join(',');
@@ -14709,9 +14715,10 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
               // timeout (attemptTimeoutMs < provider.timeout) AND the run budget is
               // now exhausted — i.e. we never gave the provider its full window, so
               // we cannot call this a provider failure. When the call gets the full
-              // provider.timeout (the MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS >= 30s
-              // guard guarantees this for admitted market_implications calls), a
-              // timeout is unambiguously a provider failure -> sawProviderFailure.
+              // provider.timeout (market_implications' admission guard reserves the
+              // whole resolved chain — every runnable provider's timeout + the stage
+              // guard, with maxRetries:0 — so each admitted attempt gets its full
+              // window), a timeout is unambiguously a provider failure -> sawProviderFailure.
               const budgetCappedTimeout = timedOut
                 && attemptTimeoutMs < provider.timeout
                 && getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) <= 0;
@@ -14723,7 +14730,7 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
             }
             throw err;
           }
-        }, FORECAST_LLM_PROVIDER_MAX_RETRIES, retryDelayMs);
+        }, providerMaxRetries, retryDelayMs);
 
         let json;
         try {
@@ -16439,20 +16446,24 @@ const MARKET_IMPLICATIONS_META_TTL = 86400 * 7;
 // fingerprint is not model-sensitive, so retire old-model rows explicitly.
 const MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX = 'forecast:llm-market-implications:v2:';
 
-// Admit the tail stage only when the shared run budget (#4978) still covers the
-// ENTIRE provider chain — the sum of every provider's call timeout PLUS the 5s
-// stage guard that getUsableForecastLlmBudgetMs subtracts. Reserving only the
-// PRIMARY timeout (the original 25_000 + 5_000 = 30_000) was a latent bug: with
-// the default openrouter→groq order, a 25s deepseek-v4-flash timeout drained the
-// budget so the groq FALLBACK was stranded ("groq llm budget exhausted") and a
-// recoverable timeout was misreported as SEED_ERROR (health WARNING). Reserving
-// the full chain (25_000 + 20_000 + 5_000 = 50_000) means an admitted call can
-// exhaust the primary AND still run the fallback; below that we skip and preserve
-// last-good honestly (age-based STALE_SEED still escalates past 2h) rather than
-// attempt a chain we cannot finish. Genuine both-providers-failed still SEED_ERRORs.
-const MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS =
-  FORECAST_LLM_PROVIDERS.reduce((sum, provider) => sum + (provider.timeout || 0), 0)
-  + FORECAST_LLM_STAGE_BUDGET_GUARD_MS;
+// Minimum shared run budget to admit the tail stage (#4978): reserve the RESOLVED,
+// RUNNABLE provider chain for THIS call — every provider in the (possibly env-
+// overridden) order that actually has an API key, ONE attempt each (market_implications
+// forces maxRetries:0), summed with the 5s stage guard that getUsableForecastLlmBudgetMs
+// subtracts. Reserving only the PRIMARY timeout (the original 30_000) was a latent bug:
+// with the default openrouter→groq order a 25s deepseek-v4-flash timeout drained the
+// budget so the groq FALLBACK was stranded and a recoverable timeout was misreported as
+// SEED_ERROR (health WARNING). Reserving the full chain means an admitted call can exhaust
+// the primary AND still run the fallback; below that we skip and preserve last-good (green,
+// age-based STALE_SEED still escalates past 2h) rather than attempt a chain we cannot finish.
+// Provider-order/key aware, so a single-provider override or a missing key reserves only what
+// that chain needs (no over-skip); a chain with NO runnable providers reserves just the guard,
+// so a genuine no-key outage is admitted and surfaces SEED_ERROR instead of hiding as a starve.
+function getMarketImplicationsMinRunBudgetMs(llmOptions = {}) {
+  const runnable = resolveForecastLlmProviders(llmOptions).filter((provider) => process.env[provider.envKey]);
+  const chainMs = runnable.reduce((sum, provider) => sum + (provider.timeout || 0), 0);
+  return chainMs + FORECAST_LLM_STAGE_BUDGET_GUARD_MS;
+}
 
 // Input-hash guard for the market_implications LLM stage (#4894). This was
 // the only forecast stage with no pre-call cache — a 2,500-token completion
@@ -16569,24 +16580,31 @@ async function buildAndSeedMarketImplications(inputs) {
   // stage runs; callForecastLLM would then throw a budget error, return null,
   // and we'd (mis)write a SEED_ERROR for benign, self-healing resource
   // contention. Skip gracefully and preserve last-good instead.
+  // Resolve the call options up front so the admission reservation matches the exact
+  // providers this call will use (env-overridable order, key-filtered).
+  const llmOptions = getForecastLlmCallOptions('market_implications');
+  const minRunBudgetMs = getMarketImplicationsMinRunBudgetMs(llmOptions);
   const runBudgetRemainingMs = getRemainingForecastLlmRunBudgetMs();
-  if (runBudgetRemainingMs < MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS) {
+  if (runBudgetRemainingMs < minRunBudgetMs) {
     const remaining = Math.max(0, Math.round(runBudgetRemainingMs));
-    console.warn(`  [MarketImplications] Skipped: shared LLM run budget exhausted (${remaining}ms left, need ${MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS}ms) — preserving last-good, no SEED_ERROR`);
-    console.log(JSON.stringify({ event: 'llm_market_implications', skipped: 'run_budget_exhausted', remainingMs: remaining }));
+    console.warn(`  [MarketImplications] Skipped: shared LLM run budget too low for the provider chain (${remaining}ms left, need ${minRunBudgetMs}ms) — preserving last-good, no SEED_ERROR`);
+    console.log(JSON.stringify({ event: 'llm_market_implications', skipped: 'run_budget_exhausted', remainingMs: remaining, needMs: minRunBudgetMs }));
     await preserveMarketImplicationsLastGoodOnStarve();
     return;
   }
 
   const userPrompt = `World state as of ${new Date().toISOString()}:\n\n${context}\n\nAllowed tickers: ${[...ALL_ALLOWED_TICKERS].join(', ')}`;
 
-  const llmOptions = getForecastLlmCallOptions('market_implications');
   const result = await callForecastLLM(MARKET_IMPLICATIONS_SYSTEM_PROMPT, userPrompt, {
     ...llmOptions,
     stage: 'market_implications',
     maxTokens: 2500,
     temperature: 0.25,
     returnFailureReason: true,
+    // One attempt per provider: reserving the full retry chain (4 attempts × 2
+    // providers) would exceed the entire run budget, so a slow primary must fall
+    // straight through to the fallback instead of retrying it (#5003 review).
+    maxRetries: 0,
   });
 
   if (!result?.text) {

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -16439,18 +16439,20 @@ const MARKET_IMPLICATIONS_META_TTL = 86400 * 7;
 // fingerprint is not model-sensitive, so retire old-model rows explicitly.
 const MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX = 'forecast:llm-market-implications:v2:';
 
-// A market_implications completion needs ~20s wall-clock (observed 2026-07-06),
-// and the primary provider (openrouter deepseek-v4-flash) has a 25s call timeout.
 // Admit the tail stage only when the shared run budget (#4978) still covers the
-// FULL provider timeout PLUS the 5s stage guard that getUsableForecastLlmBudgetMs
-// subtracts (25_000 + 5_000 = 30_000). Below that, an admitted call is timeout-
-// CAPPED below the provider's own timeout, which is indistinguishable from a
-// genuinely hung provider — so it would either waste a doomed request (needs
-// ~20s, gets <20s) OR misreport a real provider timeout as a benign starve and
-// suppress a legitimate SEED_ERROR. Skipping instead preserves last-good honestly
-// (age-based STALE_SEED still escalates past 2h). Keep >= max(provider.timeout in
-// FORECAST_LLM_PROVIDERS) + FORECAST_LLM_STAGE_BUDGET_GUARD_MS.
-const MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS = 30_000;
+// ENTIRE provider chain — the sum of every provider's call timeout PLUS the 5s
+// stage guard that getUsableForecastLlmBudgetMs subtracts. Reserving only the
+// PRIMARY timeout (the original 25_000 + 5_000 = 30_000) was a latent bug: with
+// the default openrouter→groq order, a 25s deepseek-v4-flash timeout drained the
+// budget so the groq FALLBACK was stranded ("groq llm budget exhausted") and a
+// recoverable timeout was misreported as SEED_ERROR (health WARNING). Reserving
+// the full chain (25_000 + 20_000 + 5_000 = 50_000) means an admitted call can
+// exhaust the primary AND still run the fallback; below that we skip and preserve
+// last-good honestly (age-based STALE_SEED still escalates past 2h) rather than
+// attempt a chain we cannot finish. Genuine both-providers-failed still SEED_ERRORs.
+const MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS =
+  FORECAST_LLM_PROVIDERS.reduce((sum, provider) => sum + (provider.timeout || 0), 0)
+  + FORECAST_LLM_STAGE_BUDGET_GUARD_MS;
 
 // Input-hash guard for the market_implications LLM stage (#4894). This was
 // the only forecast stage with no pre-call cache — a 2,500-token completion

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -151,9 +151,10 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
-  // >= 30_000 so the pre-call guard admits the call; the mock then drains the
-  // deadline mid-flight to prove a real failure is not reclassified as a starve.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 35_000);
+  // >= the full-chain reservation (50_000) so the pre-call guard admits the call;
+  // the mock then drains the deadline mid-flight to prove a real failure is not
+  // reclassified as a starve.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 60_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -172,7 +173,7 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   assert.equal(meta.status, 'error', 'provider failure must not be reclassified as budget starve just because the deadline is now exhausted');
 });
 
-test('pre-call guard skips in the 20-30s band — needs the full provider timeout, not just 20s (#1/#4)', async () => {
+test('pre-call guard skips when the run budget cannot cover the full provider chain (#1/#4)', async () => {
   const store = {};
   __setRedisStoreForTests(store);
   seedLastGood(store);
@@ -180,10 +181,10 @@ test('pre-call guard skips in the 20-30s band — needs the full provider timeou
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
 
-  // 25s run budget: the OLD 20s threshold would (wrongly) admit this and then time
-  // out CAPPED below the 25s provider timeout — indistinguishable from a hung
-  // provider. The fix requires the full provider timeout + 5s stage guard (30s), so
-  // a 25s budget must now SKIP cleanly instead of attempting an ambiguous call.
+  // 25s run budget: well below the full-chain reservation (openrouter 25s + groq
+  // 20s + 5s stage guard = 50s). Admitting it would time out CAPPED below the 25s
+  // provider timeout — indistinguishable from a hung provider — so it must SKIP
+  // cleanly and preserve last-good instead of attempting an ambiguous call.
   __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
 
   let providerCalls = 0;
@@ -194,9 +195,9 @@ test('pre-call guard skips in the 20-30s band — needs the full provider timeou
 
   await buildAndSeedMarketImplications({});
 
-  assert.equal(providerCalls, 0, 'a call with < 30s run budget must be skipped, not attempted with a capped (ambiguous) timeout');
+  assert.equal(providerCalls, 0, 'a call below the full-chain reservation must be skipped, not attempted with a capped (ambiguous) timeout');
   const meta = store['seed-meta:intelligence:market-implications'];
-  assert.equal(meta.status, 'ok', 'skipping in the 20-30s band preserves last-good, no SEED_ERROR');
+  assert.equal(meta.status, 'ok', 'skipping below the full-chain reservation preserves last-good, no SEED_ERROR');
   assert.equal(meta.fetchedAt, 1783340000000, 'fetchedAt untouched on a skip');
 });
 
@@ -205,13 +206,12 @@ test('mid-call budget_exhausted result preserves last-good, no SEED_ERROR (#5 de
   __setRedisStoreForTests(store);
   seedLastGood(store);
 
-  // Admit the call (>= 30s guard), then have callForecastLLM report a run-budget
-  // exhaustion mid-flight. This drives the caller's mid-call preserve branch
-  // (result.failureReason === BUDGET_EXHAUSTED) directly via the call-override seam
-  // — the one branch no organic path reaches now that admitted calls get the full
-  // provider timeout, but which is retained as defense-in-depth for env-overridden
-  // provider chains.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  // Admit the call (>= the 50s full-chain reservation), then have callForecastLLM
+  // report a run-budget exhaustion mid-flight. This drives the caller's mid-call
+  // preserve branch (result.failureReason === BUDGET_EXHAUSTED) directly via the
+  // call-override seam — retained as defense-in-depth for env-overridden provider
+  // chains and mid-flight deadline drains.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 60_000);
   let overrideCalls = 0;
   __setForecastLlmCallOverrideForTests(() => {
     overrideCalls += 1;
@@ -237,7 +237,7 @@ test('mid-call provider_failed result still writes a SEED_ERROR (#5 classificati
   __setRedisStoreForTests(store);
   seedLastGood(store);
 
-  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  __setForecastLlmRunDeadlineForTests(Date.now() + 60_000);
   __setForecastLlmCallOverrideForTests(() => ({ text: '', model: '', provider: '', failureReason: PROVIDER_FAILED }));
   global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
 
@@ -245,4 +245,35 @@ test('mid-call provider_failed result still writes a SEED_ERROR (#5 classificati
 
   const meta = store['seed-meta:intelligence:market-implications'];
   assert.equal(meta.status, 'error', 'a genuine provider failure (even textless) must surface SEED_ERROR, not be preserved as a starve');
+});
+
+test('a budget covering only the primary — not the fallback — skips instead of stranding groq → no SEED_ERROR (#4978 follow-up)', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.GROQ_API_KEY = 'test-key';
+  // DEFAULT chain (openrouter → groq); do NOT pin to a single provider.
+  delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+
+  // 40s budget: enough for the primary openrouter attempt (25s) + guard — the OLD
+  // 30s threshold admitted this — but NOT the full openrouter→groq chain (50s). The
+  // reported bug: admitted, deepseek-v4-flash timed out (~25s), the run budget was
+  // drained, the groq fallback was stranded ("groq llm budget exhausted"), and a
+  // recoverable timeout was misreported as SEED_ERROR (health WARNING). The full-
+  // chain reservation makes this SKIP and preserve last-good (green) instead.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+
+  let providerCalls = 0;
+  __setForecastLlmTransportForTests({
+    fetch: async () => { providerCalls += 1; throw Object.assign(new Error('timeout'), { name: 'TimeoutError' }); },
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(providerCalls, 0, 'a call that cannot finish the openrouter→groq chain must skip before stranding the fallback');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'ok', 'a stranded-fallback budget must preserve last-good, not write SEED_ERROR (the health WARNING this fixes)');
+  assert.equal(meta.fetchedAt, 1783340000000, 'fetchedAt untouched — STALE_SEED still escalates if the starve persists past 2h');
 });

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -25,7 +25,10 @@ import {
 const BUDGET_EXHAUSTED = 'budget_exhausted';
 const PROVIDER_FAILED = 'provider_failed';
 
-const ENV_KEYS = ['OPENROUTER_API_KEY', 'FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER'];
+const ENV_KEYS = [
+  'OPENROUTER_API_KEY', 'GROQ_API_KEY',
+  'FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER', 'FORECAST_LLM_PROVIDER_ORDER',
+];
 const originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
 const realFetch = global.fetch;
 afterEach(() => {
@@ -151,10 +154,11 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
-  // >= the full-chain reservation (50_000) so the pre-call guard admits the call;
-  // the mock then drains the deadline mid-flight to prove a real failure is not
-  // reclassified as a starve.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 60_000);
+  // 40s: the resolved chain here is openrouter-only (pinned below), so the
+  // reservation is just 25s + 5s guard = 30s — a 40s budget admits it (the static
+  // all-provider 50s reservation would have wrongly skipped). The mock then drains
+  // the deadline mid-flight to prove a real failure is not reclassified as a starve.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -177,14 +181,16 @@ test('pre-call guard skips when the run budget cannot cover the full provider ch
   const store = {};
   __setRedisStoreForTests(store);
   seedLastGood(store);
-  // Real provider config so a broken/too-low guard would actually invoke the transport.
+  // Default chain, both providers runnable → reservation is openrouter 25s + groq
+  // 20s + 5s guard = 50s. Real keys so a broken/too-low guard would actually invoke
+  // the transport rather than short-circuit on a missing key.
   process.env.OPENROUTER_API_KEY = 'test-key';
-  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+  process.env.GROQ_API_KEY = 'test-key';
+  delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+  delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
-  // 25s run budget: well below the full-chain reservation (openrouter 25s + groq
-  // 20s + 5s stage guard = 50s). Admitting it would time out CAPPED below the 25s
-  // provider timeout — indistinguishable from a hung provider — so it must SKIP
-  // cleanly and preserve last-good instead of attempting an ambiguous call.
+  // 25s run budget: well below the 50s two-provider reservation, so it must SKIP
+  // cleanly and preserve last-good instead of attempting an ambiguous, doomed call.
   __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
 
   let providerCalls = 0;
@@ -255,6 +261,7 @@ test('a budget covering only the primary — not the fallback — skips instead 
   process.env.GROQ_API_KEY = 'test-key';
   // DEFAULT chain (openrouter → groq); do NOT pin to a single provider.
   delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+  delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
   // 40s budget: enough for the primary openrouter attempt (25s) + guard — the OLD
   // 30s threshold admitted this — but NOT the full openrouter→groq chain (50s). The
@@ -276,4 +283,62 @@ test('a budget covering only the primary — not the fallback — skips instead 
   const meta = store['seed-meta:intelligence:market-implications'];
   assert.equal(meta.status, 'ok', 'a stranded-fallback budget must preserve last-good, not write SEED_ERROR (the health WARNING this fixes)');
   assert.equal(meta.fetchedAt, 1783340000000, 'fetchedAt untouched — STALE_SEED still escalates if the starve persists past 2h');
+});
+
+test('an admitted primary timeout falls through to the fallback in ONE attempt each — not stranded by retries (#5003 review, finding 1)', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.GROQ_API_KEY = 'test-key';
+  delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+  delete process.env.FORECAST_LLM_PROVIDER_ORDER;
+
+  // 60s admits the full two-provider chain (50s). Every attempt times out. PRE-FIX,
+  // openrouter's 3 retries (4 attempts) drained the run budget and groq was NEVER
+  // reached — a recoverable timeout became a SEED_ERROR without trying the fallback.
+  // With maxRetries:0 each provider gets exactly ONE attempt, so groq IS reached.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 60_000);
+
+  const calls = { openrouter: 0, groq: 0 };
+  __setForecastLlmTransportForTests({
+    fetch: async (u) => {
+      const url = String(u);
+      if (url.includes('openrouter')) calls.openrouter += 1;
+      else if (url.includes('groq')) calls.groq += 1;
+      throw Object.assign(new Error('timeout'), { name: 'TimeoutError' });
+    },
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(calls.openrouter, 1, 'primary must be tried exactly ONCE (maxRetries:0) — no 4-attempt retry storm that burns the fallback budget');
+  assert.equal(calls.groq, 1, 'the fallback MUST be reached (it was stranded pre-fix)');
+  const meta = store['seed-meta:intelligence:market-implications'];
+  assert.equal(meta.status, 'error', 'both providers genuinely failed → SEED_ERROR is correct (the fallback ran, it just also failed)');
+});
+
+test('a single-provider override reserves only that provider — admitted where the 2-provider chain would skip (#5003 review, finding 2)', async () => {
+  const store = {};
+  __setRedisStoreForTests(store);
+  seedLastGood(store);
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  process.env.GROQ_API_KEY = 'test-key';
+  // Pin to openrouter only → resolved chain reserves just 25s + 5s = 30s.
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
+
+  // 40s: below the 2-provider 50s reservation (would skip) but above the pinned
+  // single-provider 30s reservation — so this MUST be admitted, not skipped.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+
+  let providerCalls = 0;
+  __setForecastLlmTransportForTests({
+    fetch: async () => { providerCalls += 1; throw Object.assign(new Error('timeout'), { name: 'TimeoutError' }); },
+  });
+  global.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: 1 }), text: async () => '' });
+
+  await buildAndSeedMarketImplications({});
+
+  assert.equal(providerCalls, 1, 'a pinned single-provider chain needs only 30s, so a 40s budget must ADMIT it (and try it once)');
 });


### PR DESCRIPTION
## Problem
`/api/health` intermittently flips to **WARNING** because `marketImplications` writes `SEED_ERROR`. Caught live in a seed-forecasts run log:

```
[LLM:combined]  openrouter success  latencyMs=16069      ← fast
[LLM:scenario]  openrouter success  latencyMs=14200      ← fast
[LLM:market_implications] openrouter invalid response: The operation was aborted due to timeout   ← deepseek-v4-flash timed out (~25s)
[LLM:market_implications] groq llm budget exhausted after 51395ms                                 ← fallback STRANDED
[MarketImplications] LLM returned no response — writing error seed-meta                            ← SEED_ERROR
```

`market_implications` is the **last** forecast LLM stage under the shared 150s run budget, with provider order `openrouter → groq`. #4978's admission guard (`MARKET_IMPLICATIONS_MIN_RUN_BUDGET_MS`) reserved budget for only the **primary** attempt (`max(provider.timeout) + guard = 30s`). So when deepseek-v4-flash times out (~25s), the run budget is drained and the **groq fallback can't run** — a *recoverable* timeout gets misreported as a producer failure (`SEED_ERROR`).

## Fix
Reserve the **entire provider chain** in the admission guard: `sum(provider.timeout) + stage guard` = 25s + 20s + 5s = **50s**, computed from `FORECAST_LLM_PROVIDERS` so it tracks the config.

- An admitted call can now exhaust the primary **and still run the fallback**.
- Below that, it **skips and preserves last-good** (health stays green; age-based `STALE_SEED` still escalates past 2h) rather than attempting a chain it can't finish.
- **Keeps deepseek-v4-flash primary** per the #4944 migration — no model/provider-order change.
- A genuine both-providers-failed still writes `SEED_ERROR` (marketImplications is deliberately a hard health signal).

## Tests
- **New reproduction**: a 40s budget (covers the primary + guard = old 30s threshold, but not the 50s chain) with the default `openrouter→groq` order now **skips → preserve last-good, no SEED_ERROR**. Verified red on the old `30_000` constant (pass 7/fail 1), green on the fix (8/8).
- Existing tests that intended admission were recalibrated from 35–40s to 60s for the new threshold; the "skip band" test reframed to the full-chain reservation. All 8 in `market-implications-budget-starve.test.mjs` pass, plus `market-implications-seed-health` (4) and `-cache-guard` (5).

## Note / follow-up
If the tail stage is *chronically* left < 50s budget, it will preserve-last-good more often and could eventually `STALE_SEED` — that would indicate the 150s forecast run budget is too tight for a 5-stage chain + fallback, worth a separate look (market_implications runs in `afterPublish`, so a dedicated post-publish budget is an option).

https://claude.ai/code/session_01XKZZy7bzUNTZeJDVWgXbjj