### PR TITLE
fix(seo): restore WIRED/2M+ meta description — sync VARIANT_META.full with index.html + drift guard (#5005)

### DIFF
--- a/src/config/variant-meta.ts
+++ b/src/config/variant-meta.ts
@@ -14,13 +14,13 @@ export interface VariantMeta {
 export const VARIANT_META: { full: VariantMeta; [k: string]: VariantMeta } = {
   full: {
     title: 'World Monitor - Real-Time Global Intelligence Dashboard',
-    description: 'Real-time global intelligence dashboard with live news, markets, military tracking, infrastructure monitoring, and geopolitical data. OSINT in one view.',
-    keywords: 'global intelligence, geopolitical dashboard, world news, market data, military bases, nuclear facilities, undersea cables, conflict zones, real-time monitoring, situation awareness, OSINT, flight tracking, AIS ships, earthquake monitor, protest tracker, power outages, oil prices, government spending, polymarket predictions',
+    description: 'Real-time global intelligence platform. Featured in WIRED. Used by 2M+ people across 190 countries. Conflicts, markets, military, OSINT in one view.',
+    keywords: 'AI intelligence, AI-powered dashboard, global intelligence, geopolitical dashboard, world news, market data, military bases, nuclear facilities, undersea cables, conflict zones, real-time monitoring, situation awareness, OSINT, flight tracking, AIS ships, earthquake monitor, protest tracker, power outages, oil prices, government spending, polymarket predictions',
     url: 'https://www.worldmonitor.app/dashboard',
     siteName: 'World Monitor',
     shortName: 'World Monitor',
-    subject: 'Real-Time Global Intelligence and Situation Awareness',
-    classification: 'Intelligence Dashboard, OSINT Tool, News Aggregator',
+    subject: 'AI-Powered Global Intelligence and Situation Awareness',
+    classification: 'AI Intelligence Dashboard, OSINT Tool, News Aggregator',
     categories: ['news', 'productivity'],
     features: [
       'Real-time news aggregation',

--- a/tests/variant-meta-index-html-drift.test.mts
+++ b/tests/variant-meta-index-html-drift.test.mts
@@ -1,0 +1,46 @@
+// Drift guard for #5005: htmlVariantPlugin (vite.config.ts) unconditionally
+// replaces index.html's meta tags with VARIANT_META.full at build time, so any
+// hand-tuned copy in index.html that isn't mirrored in variant-meta.ts silently
+// never ships (the WIRED/2M+ description drifted this way for months).
+// This test extracts each replaced tag from index.html using the same anchors
+// the plugin uses and asserts it equals VARIANT_META.full — the full-variant
+// build must be a no-op. Editing either side alone fails here.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { VARIANT_META } from '../src/config/variant-meta';
+
+const indexHtml = readFileSync(fileURLToPath(new URL('../index.html', import.meta.url)), 'utf8');
+const full = VARIANT_META.full;
+
+function extract(label: string, pattern: RegExp): string {
+  const m = indexHtml.match(pattern);
+  assert.ok(m, `index.html anchor not found for ${label} (pattern: ${pattern}) — if the markup changed, htmlVariantPlugin's matching replace in vite.config.ts is now dead too`);
+  return m[1];
+}
+
+// Each case mirrors one .replace() in htmlVariantPlugin (vite.config.ts ~211-225).
+const cases: Array<{ label: string; pattern: RegExp; expected: string }> = [
+  { label: '<title>', pattern: /<title>(.*?)<\/title>/, expected: full.title },
+  { label: 'meta name="title"', pattern: /<meta name="title" content="(.*?)" \/>/, expected: full.title },
+  { label: 'meta name="description"', pattern: /<meta name="description" content="(.*?)" \/>/, expected: full.description },
+  { label: 'meta name="keywords"', pattern: /<meta name="keywords" content="(.*?)" \/>/, expected: full.keywords },
+  { label: 'link rel="canonical"', pattern: /<link rel="canonical" href="(.*?)" \/>/, expected: full.url },
+  { label: 'meta name="application-name"', pattern: /<meta name="application-name" content="(.*?)" \/>/, expected: full.siteName },
+  { label: 'og:url', pattern: /<meta property="og:url" content="(.*?)" \/>/, expected: full.url },
+  { label: 'og:title', pattern: /<meta property="og:title" content="(.*?)" \/>/, expected: full.title },
+  { label: 'og:description', pattern: /<meta property="og:description" content="(.*?)" \/>/, expected: full.description },
+  { label: 'og:site_name', pattern: /<meta property="og:site_name" content="(.*?)" \/>/, expected: full.siteName },
+  { label: 'meta name="subject"', pattern: /<meta name="subject" content="(.*?)" \/>/, expected: full.subject },
+  { label: 'meta name="classification"', pattern: /<meta name="classification" content="(.*?)" \/>/, expected: full.classification },
+  { label: 'twitter:url', pattern: /<meta name="twitter:url" content="(.*?)" \/>/, expected: full.url },
+  { label: 'twitter:title', pattern: /<meta name="twitter:title" content="(.*?)" \/>/, expected: full.title },
+  { label: 'twitter:description', pattern: /<meta name="twitter:description" content="(.*?)" \/>/, expected: full.description },
+];
+
+for (const { label, pattern, expected } of cases) {
+  test(`index.html ${label} matches VARIANT_META.full (build replacement is a no-op)`, () => {
+    assert.equal(extract(label, pattern), expected);
+  });
+}


### PR DESCRIPTION
Fixes #5005

## Problem

`htmlVariantPlugin` (vite.config.ts) unconditionally regex-replaces index.html's `description`, `og:description`, `twitter:description`, `subject`, `classification`, and `keywords` with `VARIANT_META.full` at build time. The hand-tuned social-proof copy written in #2537 —

> Real-time global intelligence platform. **Featured in WIRED. Used by 2M+ people across 190 countries.** Conflicts, markets, military, OSINT in one view.

— never shipped: `src/config/variant-meta.ts` was never updated, so the build overwrote it with the older "Real-time global intelligence dashboard with live news, markets…" copy (verified live on https://www.worldmonitor.app/dashboard 2026-07-07). `resetMetaTags()` in `src/services/meta-tags.ts` re-applies `variantMeta.description` client-side, so the stale copy won at runtime too.

## Fix

- Sync `VARIANT_META.full` → index.html's hand-tuned values: `description` (WIRED/2M+), `keywords` (restores the "AI intelligence, AI-powered dashboard" prefix), `subject` ("AI-Powered…"), `classification` ("AI Intelligence Dashboard…"). The full-variant build replacement is now a no-op, and both the built HTML and the runtime `resetMetaTags()` path serve the intended copy.
- **Drift guard**: `tests/variant-meta-index-html-drift.test.mts` mirrors each `htmlVariantPlugin` anchor (15 assertions), extracts the tag from index.html, and asserts equality with `VARIANT_META.full`. Editing either side alone fails CI; it also fails loudly if an anchor stops matching (which would make the plugin's replace silently dead).

## Verification

- New guard: 15/15 pass on this branch; **6 fail when run against the pre-fix `variant-meta.ts`** (description ×3, keywords, subject, classification) — proves it catches the original bug.
- No collision with #5000: `renderVariantDashboardHtml` uses content-agnostic `[^"]*` anchors and doesn't touch `variant-meta.ts`.

## Out of scope (tracked in #5005)

The JSON-LD anchors in `htmlVariantPlugin` (vite.config.ts ~226–229) are dead — `alternateName` is now an array and the hardcoded old description string no longer exists in index.html's JSON-LD. Harmless for the full web build; variant *desktop* builds ship full-brand JSON-LD name/description. Separate small fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
