### PR TITLE
fix(health): no-store on the compact status response so uptime monitors never read a stale verdict

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1077,9 +1077,12 @@ export default async function handler(req, ctx) {
     const { 'CF-Cache-Status': _bypassMarker, ...base } = headers;
     responseHeaders = {
       ...base,
-      // public (keyless, shared-cacheable in principle) but no-store so no CDN
-      // or browser ever serves a stale health verdict to a monitor.
-      'Cache-Control': 'public, no-store, max-age=0',
+      // no-store so no CDN or browser ever serves a stale health verdict to a
+      // monitor. Deliberately NOT `public` — `public, no-store` is a
+      // self-contradictory signal (RFC 9111 §5.2.2.5: no-store wins, but a
+      // non-compliant proxy could read `public` as permission to cache — the
+      // exact bug class this closes).
+      'Cache-Control': 'no-store, max-age=0',
       'CDN-Cache-Control': 'no-store',
     };
   }

--- a/api/health.js
+++ b/api/health.js
@@ -1062,20 +1062,25 @@ export default async function handler(req, ctx) {
     if (Object.keys(problems).length > 0) body.problems = problems;
   }
 
-  // Compact is the public keyless form polled by every dashboard tab (#4907):
-  // a short shared cache collapses per-tab polling onto ~one 196-key Redis
-  // pipeline per cache window per edge region. Browsers stay revalidate-always
-  // so a recovering tab sees fresh state within one poll. Everything else —
-  // the key-gated detailed response, the 401, the REDIS_DOWN 503 — keeps the
-  // no-store defaults from `headers` (caching a 401 would pin an auth failure;
-  // caching a 503 would mask recovery from HTTP monitors).
+  // Compact is the public keyless form polled by external uptime MONITORS, so it
+  // must NEVER be edge-cached: the prior `s-maxage=60` (#4907, to collapse
+  // dashboard-tab polling) let a shared CDN entry pin a stale WARNING that kept
+  // UptimeRobot reading "down" long AFTER the seed recovered (2026-07-07 — the
+  // literal `?cb=*cachebuster*` was a constant, so it never busted the entry).
+  // no-store guarantees a monitor sees live recovery on its very next poll. The
+  // origin cost is one 196-key Redis pipeline per request — cheap — so losing
+  // the per-tab poll-collapse is a non-issue. All other responses already carry
+  // the no-store defaults from `headers` (a cached 401 pins an auth failure; a
+  // cached 503 masks REDIS_DOWN recovery).
   let responseHeaders = headers;
   if (compact) {
-    const { 'CF-Cache-Status': _bypassMarker, ...cacheable } = headers;
+    const { 'CF-Cache-Status': _bypassMarker, ...base } = headers;
     responseHeaders = {
-      ...cacheable,
-      'Cache-Control': 'public, max-age=0, must-revalidate',
-      'CDN-Cache-Control': 'public, s-maxage=60',
+      ...base,
+      // public (keyless, shared-cacheable in principle) but no-store so no CDN
+      // or browser ever serves a stale health verdict to a monitor.
+      'Cache-Control': 'public, no-store, max-age=0',
+      'CDN-Cache-Control': 'no-store',
     };
   }
 

--- a/tests/health-compact-cdn-cache.test.mjs
+++ b/tests/health-compact-cdn-cache.test.mjs
@@ -1,13 +1,13 @@
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-// Compact /api/health is the public keyless form polled by every dashboard
-// tab. #4907 makes its 200s CDN-cacheable (short s-maxage) so per-tab polling
-// collapses onto ~one origin Redis pipeline per cache window per edge region.
-// Everything else must STAY no-store: caching the key-gated detailed response
-// could leak an operator view across the shared cache, caching a 401 would
-// pin an auth failure, and caching the REDIS_DOWN 503 would mask recovery
-// from HTTP monitors.
+// Compact /api/health is the public keyless form polled by external uptime
+// MONITORS, so its 200 must be no-store: a shared CDN entry (the prior #4907
+// s-maxage=60) pinned a stale WARNING and kept UptimeRobot "down" long after
+// the seed recovered (2026-07-07). Every response here stays no-store: caching
+// the key-gated detailed response could leak an operator view across the shared
+// cache, caching a 401 would pin an auth failure, and caching the REDIS_DOWN
+// 503 would mask recovery from HTTP monitors.
 //
 // Run: node --test tests/health-compact-cdn-cache.test.mjs
 
@@ -34,16 +34,17 @@ function mockRedisPipeline() {
   };
 }
 
-test('compact 200 is CDN-cacheable with a short shared TTL', async () => {
+test('compact 200 is never edge-cached (monitors must see live recovery)', async () => {
   mockRedisPipeline();
   const res = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
   assert.equal(res.status, 200);
-  assert.equal(res.headers.get('CDN-Cache-Control'), 'public, s-maxage=60');
+  // A shared CDN entry (prior s-maxage=60) pinned a stale WARNING and kept
+  // uptime monitors "down" after the seed recovered (2026-07-07). no-store
+  // guarantees a monitor reads live status on its next poll.
+  assert.equal(res.headers.get('CDN-Cache-Control'), 'no-store');
   const cacheControl = res.headers.get('Cache-Control');
-  assert.match(cacheControl, /public/, 'shared caches must be allowed to store the compact form');
-  assert.doesNotMatch(cacheControl, /no-store/);
-  assert.match(cacheControl, /max-age=0/, 'browsers must revalidate so a tab sees recovery within one poll');
-  assert.equal(res.headers.get('CF-Cache-Status'), null, 'no hardcoded BYPASS marker on the cacheable response');
+  assert.match(cacheControl, /no-store/, 'compact health must not be stored by any cache');
+  assert.equal(res.headers.get('CF-Cache-Status'), null, 'no hardcoded BYPASS marker');
 });
 
 test('detailed (key-authenticated) 200 stays no-store', async () => {


### PR DESCRIPTION
## Problem

The public compact `GET /api/health?compact=1` — the form external uptime monitors poll — was edge-cacheable via `CDN-Cache-Control: public, s-maxage=60` (#4907, to collapse per-dashboard-tab polling). A shared CDN entry pinned a stale `WARNING` and kept **UptimeRobot reading "down" long after the underlying seed recovered** (2026-07-07: portwatch reached 174 → origin `HEALTHY`, but the monitor kept seeing a cached `WARNING`).

The monitor's `?cb=*cachebuster*` didn't help because it's a **literal constant** — every poll hits the same cacheable URL, so it never busts anything.

## Fix

Switch the compact 200 to **`no-store`** (both `Cache-Control` and `CDN-Cache-Control`), so no CDN or browser ever serves a stale health verdict — a monitor sees live recovery on its very next poll.

- Origin cost: one ~196-key Redis pipeline per request (cheap). Losing the per-tab poll-collapse (#4907) is a non-issue for a monitoring endpoint; if load ever matters, a small `s-maxage` can be re-added.
- Non-compact responses (key-gated detailed 200, 401, `REDIS_DOWN` 503) were already `no-store` and are unchanged.

## Test plan

- `tests/health-compact-cdn-cache.test.mjs` updated: compact 200 now asserts `CDN-Cache-Control: no-store` and `Cache-Control` contains `no-store`. 4/4 pass.
- Regression-checked: `health-content-age` (18), `health-redis-down-status` (8) green; gateway CDN-policy test unaffected (that governs RPC paths, not `/api/health`).

Note: I also purged the existing CF cache for the health URLs so the current staleness clears immediately; this PR prevents it from recurring.

Independent of other open PRs (branched off current `main`).

https://claude.ai/code/session_019uhnqAKEHTws3QMaUvq58N