### PR TITLE
fix(forecast): horizon-commensurable count + point-read supply/gps windows (#5010)

### DIFF
--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -175,15 +175,25 @@ const FAMILY_FEED = {
   // whichever MARKET_INPUT_KEYS-backed calibration source is available.
 };
 
+// #5010: supply_chain (chokepoints:v4 riskScore) and gps (gpsjam:v2 hexCount) read
+// CURRENT-snapshot feeds with no per-record timeline, so a `sustained-48h` window
+// is unestablishable and forced a permanent VOID in the Bet-2 resolver. They now
+// emit an `at-deadline` point-read window the resolver can actually establish.
 const FAMILY_WINDOW = {
   conflict: 'within-horizon',
   ucdp_zone: 'within-horizon',
-  supply_chain: 'sustained-48h',
+  supply_chain: 'at-deadline',
   infrastructure: 'within-horizon',
   prediction_market: 'at-endDate',
-  gps: 'sustained-48h',
+  gps: 'at-deadline',
   market: 'within-horizon',
 };
+
+// #5010: the UCDP count threshold is prorated from the seeder's trailing window
+// (seed-ucdp-events.mjs TRAILING_WINDOW_MS = 365d) down to the forecast horizon,
+// so a within-horizon count is compared like-for-like instead of an annual tally
+// against a ~30d window (the Bet-2 F2/Q1 systematic-NO bias).
+const UCDP_TRAILING_WINDOW_DAYS = 365;
 
 // ── Commodity label -> future ticker (market family) ────────────────────
 //
@@ -345,10 +355,18 @@ function deriveHardMetrics(pred, family, inputs) {
       // forecast with only cii signals has no clean count metric -> judged.
       const count = firstFiniteSignalCount(pred, new Set(['ucdp', 'conflict_events']));
       if (!Number.isFinite(count)) return null;
+      // #5010: horizon-commensurable threshold. `count` is the detector's tally
+      // over the 365d trailing window; the resolver checks a within-horizon count,
+      // so prorate to the horizon (the expected event count if the trailing-year
+      // rate persists). Unknown horizon → null (deriveDeadline would throw anyway).
+      const horizonMs = HORIZON_MS[pred.timeHorizon];
+      if (!Number.isFinite(horizonMs)) return null;
+      const horizonDays = horizonMs / DAY_MS;
+      const proratedThreshold = Math.max(1, Math.round((count * horizonDays) / UCDP_TRAILING_WINDOW_DAYS));
       return {
         metricKey: `conflict:ucdp-events:v1|count(country==${pred.region})`,
         operator: '>=',
-        threshold: Math.max(1, Math.round(count)),
+        threshold: proratedThreshold,
         window: FAMILY_WINDOW[family],
       };
     }

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -642,8 +642,9 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     const forecast = pred({
       domain: 'conflict',
       region: 'Sudan',
+      timeHorizon: '30d',
       // cii emitted first (would shadow the count if it were accepted) — the
-      // threshold must come from the conflict_events count (3), not 71.
+      // threshold must come from the conflict_events count, not the cii 71.
       signals: [
         { type: 'cii', value: 'Sudan CII 71', weight: 0.4 },
         { type: 'conflict_events', value: '3 cross-border events', weight: 0.35 },
@@ -652,7 +653,60 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, 'conflict:ucdp-events:v1');
-    assert.equal(spec.threshold, 3);
+    // #5010: threshold is now horizon-prorated (was the raw 3). round(3*30/365)=0 → floor 1.
+    assert.equal(spec.threshold, 1);
+  });
+});
+
+describe('#5010 — resolution-spec emission amendment (horizon-commensurable count, resolvable supply/gps windows)', () => {
+  it('count threshold is prorated to the horizon, not the raw 365d tally', () => {
+    // count=365 (one/day over the trailing year) → expected 30 over a 30d horizon
+    const c30 = buildResolutionSpec(pred({
+      domain: 'conflict', region: 'Sudan', timeHorizon: '30d',
+      signals: [{ type: 'conflict_events', value: '365 events', weight: 0.35 }],
+    }), {}, GENERATED_AT);
+    assert.equal(c30.kind, 'hard');
+    assert.equal(c30.threshold, 30);
+    // same count, 7d horizon → expected 7
+    const c7 = buildResolutionSpec(pred({
+      domain: 'conflict', region: 'Sudan', timeHorizon: '7d',
+      signals: [{ type: 'conflict_events', value: '365 events', weight: 0.35 }],
+    }), {}, GENERATED_AT);
+    assert.equal(c7.threshold, 7);
+    // low count floors at 1 (round(10*30/365)=0 → 1)
+    const cLow = buildResolutionSpec(pred({
+      domain: 'conflict', region: 'Mali', timeHorizon: '30d',
+      signals: [{ type: 'ucdp', value: '10 UCDP events', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    assert.equal(cLow.threshold, 1);
+  });
+
+  it('supply_chain and gps windows are a point read (at-deadline), not sustained-48h', () => {
+    const sc = buildResolutionSpec(pred({
+      domain: 'supply_chain', region: 'Strait of Hormuz', timeHorizon: '7d',
+      signals: [{ type: 'chokepoint', value: 'disruption', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    assert.equal(sc.window, 'at-deadline');
+    assert.notEqual(sc.window, 'sustained-48h');
+
+    const gps = buildResolutionSpec(pred({
+      domain: 'supply_chain', region: 'Black Sea', timeHorizon: '7d',
+      signals: [{ type: 'gps_jamming', value: '12 jamming hexes', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    assert.equal(gps.window, 'at-deadline');
+  });
+
+  it('within-horizon families are unchanged (infra/market stay within-horizon; conflict stays within-horizon)', () => {
+    const infra = buildResolutionSpec(pred({
+      domain: 'infrastructure', region: 'Cuba', timeHorizon: '24h',
+      signals: [{ type: 'outage', value: '3 outages', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    assert.equal(infra.window, 'within-horizon');
+    const conflict = buildResolutionSpec(pred({
+      domain: 'conflict', region: 'Sudan', timeHorizon: '30d',
+      signals: [{ type: 'conflict_events', value: '40 events', weight: 0.35 }],
+    }), {}, GENERATED_AT);
+    assert.equal(conflict.window, 'within-horizon');
   });
 });
 


### PR DESCRIPTION
## What

Resolution-spec **emission** amendment (Bet-1 follow-up) so the Bet-2 resolver (#5007) can faithfully score the specs. The Bet-2 planning review found the shipped spec shapes make only **~1 currently-published forecast resolvable**; this fixes the two emission flaws while the clock is one day old (→ ~90% of hard specs resolvable). Emission-only — no proto/schema change, no publish-selection change.

| Flaw (shipped) | Fix |
|---|---|
| `count` threshold = detector's **365-day** tally (`TRAILING_WINDOW_MS`), but resolver checks a within-horizon count → systematic **NO bias** | **Horizon-prorate**: `threshold = max(1, round(count × horizonDays / 365))` — the expected event count if the trailing-year rate persists, resolvable over `[generatedAt, deadline]` |
| `supply_chain`/`gps` window = `sustained-48h` over **current-snapshot** feeds (chokepoints riskScore, gpsjam hexCount) → permanent **VOID** | Window → `at-deadline` point read the resolver can establish |
| `prediction_market` `at-endDate`, `market`/`infra` `within-horizon` | unchanged (already resolvable) |

## Why now

Resets a **one-day-old** resolution-spec clock (new shapes supersede old — intended). Every day this waits, more unresolvable specs accumulate and the reset gets more expensive. Blocks #5007.

## Tests

Bug-fix protocol — updated the stale raw-count threshold assertion + 3 new `#5010` tests (RED-first): count prorated per horizon (365-count → 30 @30d, 7 @7d, floors at 1), supply/gps windows = `at-deadline` not `sustained-48h`, within-horizon families unchanged.

- `tests/forecast-resolution.test.mjs`: 54/54
- forecast-detectors 229, forecast-trace-export 310, forecast-history 15, forecast-integrity-provenance 6 — all green
- `evaluate-forecast-benchmark`: 6/6

(Note: `forecast-get-forecasts.test.mts` fails locally under plain `node --test` on a pre-existing bare-JSON-import gotcha — unrelated to this diff, passes in CI.)

Carries the Bet-1 guardrails (no `null` fields introduced; grammar still parses values with spaces/`?`/`)`). Part of #4930; follows #4976/PR #5004.

https://claude.ai/code/session_01XhvRdRjkLqtkRBZi9ZYAu2