### PR TITLE
fix(forecast): resolution-spec emission amendment — horizon-commensurable count + resolvable supply/gps windows (#5010)

### DIFF
--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -19,7 +19,9 @@
 // is not parsed by this module or any consumer today (Bet 2's resolver
 // interprets it). The grammar is frozen into 45-day history, so it must be
 // consistent — no literal '<region>'/'<title>' placeholders, no '=' vs '=='
-// drift between families.
+// drift between families. count() means NEW events dated within the spec's
+// 'within-horizon' window ([emission, deadline]), with a horizon-scoped
+// threshold (#5010) — never the feed's full 365-day trailing tally.
 
 // ── Horizon -> deadline math (R5) ───────────────────────────────────────
 //
@@ -156,9 +158,20 @@ export const DOMAIN_TO_HARD_FAMILIES = {
 
 // The commodity price-MOVE threshold ratio (market family): threshold =
 // emission baseline × this. A 10% move is the "material price impact" bar.
-// The only tunable in the module — named + exported so it is discoverable and
-// a future per-commodity volatility model has one obvious knob to replace.
+// Named + exported so it is discoverable and a future per-commodity
+// volatility model has one obvious knob to replace.
 export const MARKET_PRICE_MOVE_RATIO = 1.1;
+
+// The conflict escalation ratio (conflict/ucdp_zone count threshold, #5010):
+// the horizon-scoped confirming count is the country's base event rate
+// projected over the forecast horizon, escalated by this factor — "events
+// materially above trend". The emission-time signal tally is a 365-day
+// trailing count (seed-ucdp-events.mjs TRAILING_WINDOW_MS), so
+//   threshold = max(1, round(tally365 × horizonMs/365d × this))
+// counted over NEW events dated within [emission, deadline]. Like
+// MARKET_PRICE_MOVE_RATIO, this is a named Bet-2 tuning knob.
+export const CONFLICT_ESCALATION_RATIO = 1.5;
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 // FAMILY_FEED / FAMILY_WINDOW map each hard family to its default sourceFeed
 // + resolution window. The market family has no single fixed feed — it is
@@ -175,13 +188,22 @@ const FAMILY_FEED = {
   // whichever MARKET_INPUT_KEYS-backed calibration source is available.
 };
 
+// Window vocabulary (#5010 amendment): every value must be establishable by
+// the Bet-2 resolver from the feed it names. 'within-horizon' = the condition
+// is checked over [emission, deadline] (dated-record feeds) or as a deadline
+// point read (snapshot feeds); 'at-deadline' = a point read of the current-
+// snapshot feed at the first resolver tick at/after the deadline;
+// 'at-endDate' = the prediction market's own settlement. The previous
+// sustained-window value for supply_chain/gps was removed (#5010) — a
+// sustained condition is unestablishable from current-snapshot feeds without
+// resolver-side sampling and forced permanent VOID.
 const FAMILY_WINDOW = {
   conflict: 'within-horizon',
   ucdp_zone: 'within-horizon',
-  supply_chain: 'sustained-48h',
+  supply_chain: 'at-deadline',
   infrastructure: 'within-horizon',
   prediction_market: 'at-endDate',
-  gps: 'sustained-48h',
+  gps: 'at-deadline',
   market: 'within-horizon',
 };
 
@@ -343,12 +365,21 @@ function deriveHardMetrics(pred, family, inputs) {
       // `count(country==X) >= <ciiScore>` ground truth, and since detectors
       // emit the cii signal first it would shadow a real count. A conflict
       // forecast with only cii signals has no clean count metric -> judged.
-      const count = firstFiniteSignalCount(pred, new Set(['ucdp', 'conflict_events']));
-      if (!Number.isFinite(count)) return null;
+      const tally = firstFiniteSignalCount(pred, new Set(['ucdp', 'conflict_events']));
+      if (!Number.isFinite(tally)) return null;
+      // Horizon-commensurable threshold (#5010): the signal tally is a
+      // 365-day trailing count, but the forecast is a ~horizon claim — a raw
+      // tally threshold would systematically resolve NO over the horizon
+      // window (biased Brier). Scale the base rate to the horizon and apply
+      // the escalation bar; count() means NEW events dated within
+      // [emission, deadline] (the 'within-horizon' window).
+      const horizonMs = HORIZON_MS[pred.timeHorizon];
+      if (!Number.isFinite(horizonMs)) return null; // deriveDeadline throws for the judged path too
+      const threshold = Math.max(1, Math.round(tally * (horizonMs / YEAR_MS) * CONFLICT_ESCALATION_RATIO));
       return {
         metricKey: `conflict:ucdp-events:v1|count(country==${pred.region})`,
         operator: '>=',
-        threshold: Math.max(1, Math.round(count)),
+        threshold,
         window: FAMILY_WINDOW[family],
       };
     }

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -12,6 +12,7 @@ import {
   DOMAIN_TO_HARD_FAMILIES,
   COMMODITY_LABEL_TO_SYMBOL,
   MARKET_PRICE_MOVE_RATIO,
+  CONFLICT_ESCALATION_RATIO,
   deriveDeadline,
   buildResolutionSpec,
   attachResolutionSpecs,
@@ -638,12 +639,12 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     assert.equal(spec.sourceFeed, null);
   });
 
-  it('a conflict forecast with cii + conflict_events takes the threshold from the COUNT signal, not the cii score', () => {
+  it('a conflict forecast with cii + conflict_events derives a horizon-scoped threshold from the COUNT signal', () => {
     const forecast = pred({
       domain: 'conflict',
       region: 'Sudan',
       // cii emitted first (would shadow the count if it were accepted) — the
-      // threshold must come from the conflict_events count (3), not 71.
+      // count base must come from the conflict_events tally (3), not 71.
       signals: [
         { type: 'cii', value: 'Sudan CII 71', weight: 0.4 },
         { type: 'conflict_events', value: '3 cross-border events', weight: 0.35 },
@@ -652,7 +653,14 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, 'conflict:ucdp-events:v1');
-    assert.equal(spec.threshold, 3);
+    // #5010 horizon-commensurable threshold: the 365d-trailing tally (3) is
+    // scaled to the 30d horizon and escalated —
+    // max(1, round(3 × 30d/365d × CONFLICT_ESCALATION_RATIO)) = 1.
+    // Three wrong answers excluded: 71 (the cii index), 3 (the raw 365d
+    // tally — would systematically resolve NO over a 30d window), and 0
+    // (the floor guarantees a confirmable bar).
+    assert.equal(spec.threshold, Math.max(1, Math.round(3 * (HORIZON_MS['30d'] / (365 * 24 * 60 * 60 * 1000)) * CONFLICT_ESCALATION_RATIO)));
+    assert.equal(spec.threshold, 1);
   });
 });
 
@@ -747,6 +755,48 @@ describe('FIX 4 — MARKET_PRICE_MOVE_RATIO is the named threshold knob', () => 
     const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT);
     assert.equal(spec.baselineValue, 68.92);
     assert.equal(spec.threshold, +(68.92 * MARKET_PRICE_MOVE_RATIO).toFixed(2));
+  });
+});
+
+describe('#5010 amendment — resolvable windows + horizon-commensurable count', () => {
+  it('supply_chain and gps specs emit window at-deadline — sustained-48h is gone', () => {
+    const supply = buildResolutionSpec(pred({
+      domain: 'supply_chain', region: 'Strait of Hormuz',
+      signals: [{ type: 'chokepoint', value: 'Strait of Hormuz disruption detected', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    assert.equal(supply.kind, 'hard');
+    assert.equal(supply.window, 'at-deadline');
+
+    const gps = buildResolutionSpec(pred({
+      domain: 'supply_chain', region: 'Black Sea',
+      signals: [{ type: 'gps_jamming', value: '41 jamming hexes in Black Sea', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    assert.equal(gps.kind, 'hard');
+    assert.equal(gps.window, 'at-deadline');
+  });
+
+  it('no emitted hard spec carries a sustained-48h window (unestablishable from snapshot feeds)', () => {
+    // The module source must not emit the token at all — a resolver cannot
+    // establish a sustained condition from current-snapshot feeds without
+    // sampling, so the old value forced permanent VOID.
+    const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../scripts/_forecast-resolution.mjs'), 'utf8');
+    const emitted = src.match(/'(sustained-[^']+)'/g) || [];
+    assert.deepEqual(emitted, [], `sustained windows must not be emitted, found ${emitted}`);
+  });
+
+  it('the conflict count threshold scales with the horizon (24h vs 30d from the same tally)', () => {
+    const mk = (horizon) => buildResolutionSpec(pred({
+      domain: 'conflict', region: 'Pakistan', timeHorizon: horizon,
+      signals: [{ type: 'ucdp', value: '175 UCDP conflict events', weight: 0.5 }],
+    }), {}, GENERATED_AT);
+    const day = mk('24h');
+    const month = mk('30d');
+    // 175 events/365d: 24h → max(1, round(175 × 1/365 × 1.5)) = 1;
+    // 30d → max(1, round(175 × 30/365 × 1.5)) = 22. Never the raw tally.
+    assert.equal(day.threshold, 1);
+    assert.equal(month.threshold, 22);
+    assert.notEqual(month.threshold, 175);
+    assert.equal(CONFLICT_ESCALATION_RATIO, 1.5);
   });
 });
 

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -784,6 +784,28 @@ describe('#5010 amendment — resolvable windows + horizon-commensurable count',
     assert.deepEqual(emitted, [], `sustained windows must not be emitted, found ${emitted}`);
   });
 
+  it('within-horizon and at-endDate families are unchanged (only supply/gps windows moved)', () => {
+    // Cherry-picked from the racing PR #5011 — the amendment must not drift
+    // the families the issue confirmed fine.
+    const conflict = buildResolutionSpec(pred({
+      domain: 'conflict', region: 'Mali',
+      signals: [{ type: 'conflict_events', value: '12 cross-border events', weight: 0.4 }],
+    }), {}, GENERATED_AT);
+    assert.equal(conflict.window, 'within-horizon');
+
+    const infra = buildResolutionSpec(pred({
+      domain: 'infrastructure', region: 'Cuba',
+      signals: [{ type: 'outage', value: 'Cuba major outage', weight: 0.4 }],
+    }), {}, GENERATED_AT);
+    assert.equal(infra.window, 'within-horizon');
+
+    const market = buildResolutionSpec(pred({
+      domain: 'market', region: 'Middle East', title: 'Oil price impact',
+      signals: [{ type: 'commodity', value: 'Oil sensitivity: 0.8', weight: 0.3 }],
+    }), COMMODITY_INPUTS, GENERATED_AT);
+    assert.equal(market.window, 'within-horizon');
+  });
+
   it('the conflict count threshold scales with the horizon (24h vs 30d from the same tally)', () => {
     const mk = (horizon) => buildResolutionSpec(pred({
       domain: 'conflict', region: 'Pakistan', timeHorizon: horizon,


### PR DESCRIPTION
Closes #5010 (Bet-1 follow-up; unblocks #5007). Epic #4930.

**Why now:** the Bet-2 planning review found the frozen spec shapes left only ~1 currently-published forecast resolvable. Amending emission one day into the resolution-spec clock resets a near-empty record; every day of delay makes the reset more expensive.

## Changes (emission only — `scripts/_forecast-resolution.mjs`)

1. **conflict/ucdp `count` thresholds are horizon-commensurable.** The signal tally is a 365-day trailing count (`TRAILING_WINDOW_MS`, seed-ucdp-events.mjs), so a raw threshold systematically resolves NO over a ~30d horizon — a *biased* Brier. Now: `threshold = max(1, round(tally × horizonMs/365d × CONFLICT_ESCALATION_RATIO))` (named, exported knob, like `MARKET_PRICE_MOVE_RATIO`), counted over **new events dated within [emission, deadline]** — the `count()` semantics are documented in the grammar header.
2. **supply_chain/gps windows: `at-deadline` point reads** instead of a sustained-48h condition that is unestablishable from current-snapshot feeds (forced permanent VOID).
3. Left as shipped (confirmed fine): `prediction_market: at-endDate`, `market`/`infrastructure`: `within-horizon`.

Guardrails carried: omission semantics preserved (no new fields, no nulls), grammar unchanged and still parseable (spaces/`?`/`)` values), signal-vocab + horizon drift guards intact.

## Verification

- Tests **54/54** (+3 amendment tests: at-deadline windows for both families; a source-scan asserting no sustained window token is emitted; horizon-scaling of the same tally across 24h vs 30d). Benchmark **6/6**; history 15/15 and trace-export 310/310 untouched-green; biome clean.
- **Live DoD spot-check** (fresh detector batch, 49 hard specs): **100% shape-resolvable** (target ~90%), window distribution `within-horizon: 41, at-deadline: 7, at-endDate: 1`, zero sustained; conflict thresholds horizon-scoped on real data (7d: 15/1/5 instead of raw 365d tallies).
- **D2 no-selection-change gate re-passed**: real selection path with/without the enrichment pass → identical published id set and order.

Per the issue: this intentionally supersedes the ~1 day of old-shape specs in history — the clock resets to today with resolvable shapes.