### PR TITLE
chore(perf): remove stale protomaps.github.io dns-prefetch (#5016)

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,7 +377,6 @@
 
     <!-- Preconnect: map tiles + assets -->
     <link rel="preconnect" href="https://maps.worldmonitor.app" crossorigin>
-    <link rel="dns-prefetch" href="https://protomaps.github.io">
 
     <!-- Variant/locale fonts are narrowed and loaded after the dashboard paints. -->
   </head>


### PR DESCRIPTION
Closes #5016.

## What

Remove the stale `<link rel="dns-prefetch" href="https://protomaps.github.io">` from `index.html` (was line 380).

## Why

DebugBear's daily analysis of prod `/dashboard` reported `hints.errors = 1` on **11 consecutive runs (2026-06-30 → 2026-07-07)**: *"Resource hint `https://protomaps.github.io` (dns-prefetch) — the connection was not used."* The only network consumer is `buildPMTilesStyle()` in `src/config/basemap-styles.ts:47-48` (PMTiles glyphs + sprites), which runs lazily behind the DeckGLMap dynamic import — glyph/sprite fetches only fire ~16s+ into the load when maplibre actually renders labels/icons. A `t=0` dns-prefetch buys nothing over resolving DNS at request time that late.

## Safety

- Only reference removed is the hint itself. `basemap-styles.ts` keeps the absolute `https://protomaps.github.io/...` glyph + sprite URLs, so map rendering is unchanged — verified `grep` still finds both.
- The `protomaps.github.io` entry in `src/bootstrap/sentry-init.ts` is an allowlist string, not a fetch — untouched.
- No variant HTML carries this hint (it existed only in `index.html`), and `variant-meta-index-html-drift` only guards meta tags, not resource hints.

## Verification

- `tests/secondary-startup`, `tests/variant-meta-index-html-drift`, `tests/variant-inline-bootstrap`, `tests/deploy-config` — **161/161 pass**.
- Acceptance (`hints.errors → 0`) resolves on the next daily DebugBear run post-deploy.

https://claude.ai/code/session_01BfmsXVjM2mdDAxpUTpkXoW
