### PR TITLE
perf(map): route boot-path container geometry through the resize cache (#5017)

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1191,7 +1191,12 @@ export class MapComponent {
     }
     this.lastRenderTime = now;
 
-    const { width, height } = this.readContainerSize();
+    // Use the ResizeObserver-maintained cache instead of a live clientWidth/
+    // clientHeight read: render() fires repeatedly as data streams in on boot,
+    // and each live read interleaved with the prior tick's SVG writes forces a
+    // synchronous layout (the #5017 boot reflow). getKnownContainerSize() falls
+    // back to a live read only when the cache is still empty (first paint).
+    const { width, height } = this.getKnownContainerSize();
     this.renderWithSize(width, height);
   }
 
@@ -2403,8 +2408,7 @@ export class MapComponent {
 
     // Tech Events / Conferences (📅 icons) - with clustering
     if (this.state.layers.techEvents && this.techEvents.length > 0) {
-      const mapWidth = this.container.clientWidth;
-      const mapHeight = this.container.clientHeight;
+      const { width: mapWidth, height: mapHeight } = this.getKnownContainerSize();
 
       // Map events to have lon property for clustering, filter visible
       const visibleEvents = this.techEvents
@@ -3627,8 +3631,7 @@ export class MapComponent {
   }
 
   public flashLocation(lat: number, lon: number, durationMs = 2000): void {
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     if (!width || !height) return;
 
     const projection = this.getProjection(width, height);
@@ -3792,8 +3795,7 @@ export class MapComponent {
     const hotspot = this.hotspots.find(h => h.id === id);
     if (!hotspot) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([hotspot.lon, hotspot.lat]);
     if (!pos) return;
@@ -3814,8 +3816,7 @@ export class MapComponent {
     const conflict = CONFLICT_ZONES.find(c => c.id === id);
     if (!conflict) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection(conflict.center as [number, number]);
     if (!pos) return;
@@ -3842,8 +3843,7 @@ export class MapComponent {
       return;
     }
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([base.lon, base.lat]);
     if (!pos) return;
@@ -3860,8 +3860,7 @@ export class MapComponent {
     const pipeline = PIPELINES.find(p => p.id === id);
     if (!pipeline || pipeline.points.length === 0) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const midPoint = pipeline.points[Math.floor(pipeline.points.length / 2)] as [number, number];
     const pos = projection(midPoint);
@@ -3879,8 +3878,7 @@ export class MapComponent {
     const cable = UNDERSEA_CABLES.find(c => c.id === id);
     if (!cable || cable.points.length === 0) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const midPoint = cable.points[Math.floor(cable.points.length / 2)] as [number, number];
     const pos = projection(midPoint);
@@ -3898,8 +3896,7 @@ export class MapComponent {
     const dc = AI_DATA_CENTERS.find(d => d.id === id);
     if (!dc) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([dc.lon, dc.lat]);
     if (!pos) return;
@@ -3916,8 +3913,7 @@ export class MapComponent {
     const facility = NUCLEAR_FACILITIES.find(n => n.id === id);
     if (!facility) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([facility.lon, facility.lat]);
     if (!pos) return;
@@ -3934,8 +3930,7 @@ export class MapComponent {
     const irradiator = GAMMA_IRRADIATORS.find(i => i.id === id);
     if (!irradiator) return;
 
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([irradiator.lon, irradiator.lat]);
     if (!pos) return;
@@ -4153,8 +4148,7 @@ export class MapComponent {
     const [minLon, minLat, maxLon, maxLat] = bbox;
     const midLon = (minLon + maxLon) / 2;
     const midLat = (minLat + maxLat) / 2;
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const topLeft = projection([minLon, maxLat]);
     const bottomRight = projection([maxLon, minLat]);
@@ -4177,8 +4171,7 @@ export class MapComponent {
   }
 
   public getCenter(): { lat: number; lon: number } | null {
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     if (!projection.invert) return null;
     const zoom = this.state.zoom;
@@ -4225,8 +4218,7 @@ export class MapComponent {
 
   public setCenter(lat: number, lon: number): void {
     console.log('[Map] setCenter called:', { lat, lon });
-    const width = this.container.clientWidth;
-    const height = this.container.clientHeight;
+    const { width, height } = this.getKnownContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([lon, lat]);
     console.log('[Map] projected pos:', pos, 'container:', { width, height }, 'zoom:', this.state.zoom);

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -321,12 +321,16 @@ export class MapComponent {
       if (this.isResizing) return;
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
-        if (width > 0 && height > 0 && (width !== lastWidth || height !== lastHeight)) {
-          lastWidth = width;
-          lastHeight = height;
-          this.rememberContainerSize({ width, height });
-          this.scheduleRender();
-        }
+        if (width === lastWidth && height === lastHeight) continue;
+        lastWidth = width;
+        lastHeight = height;
+        // Record zero-size (hidden) transitions too, not just visible sizes.
+        // getKnownContainerSize() falls back to a live read whenever the cache
+        // is zero, so recording the hide keeps render()'s zero-size skip intact
+        // and lets a reveal center off current dimensions instead of the last
+        // visible ones (#5022 review). Only a visible size is worth rendering.
+        this.rememberContainerSize({ width, height });
+        if (width > 0 && height > 0) this.scheduleRender();
       }
     });
     this.resizeObserver.observe(this.container);
@@ -3631,7 +3635,7 @@ export class MapComponent {
   }
 
   public flashLocation(lat: number, lon: number, durationMs = 2000): void {
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     if (!width || !height) return;
 
     const projection = this.getProjection(width, height);
@@ -3795,7 +3799,7 @@ export class MapComponent {
     const hotspot = this.hotspots.find(h => h.id === id);
     if (!hotspot) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([hotspot.lon, hotspot.lat]);
     if (!pos) return;
@@ -3816,7 +3820,7 @@ export class MapComponent {
     const conflict = CONFLICT_ZONES.find(c => c.id === id);
     if (!conflict) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection(conflict.center as [number, number]);
     if (!pos) return;
@@ -3843,7 +3847,7 @@ export class MapComponent {
       return;
     }
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([base.lon, base.lat]);
     if (!pos) return;
@@ -3860,7 +3864,7 @@ export class MapComponent {
     const pipeline = PIPELINES.find(p => p.id === id);
     if (!pipeline || pipeline.points.length === 0) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const midPoint = pipeline.points[Math.floor(pipeline.points.length / 2)] as [number, number];
     const pos = projection(midPoint);
@@ -3878,7 +3882,7 @@ export class MapComponent {
     const cable = UNDERSEA_CABLES.find(c => c.id === id);
     if (!cable || cable.points.length === 0) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const midPoint = cable.points[Math.floor(cable.points.length / 2)] as [number, number];
     const pos = projection(midPoint);
@@ -3896,7 +3900,7 @@ export class MapComponent {
     const dc = AI_DATA_CENTERS.find(d => d.id === id);
     if (!dc) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([dc.lon, dc.lat]);
     if (!pos) return;
@@ -3913,7 +3917,7 @@ export class MapComponent {
     const facility = NUCLEAR_FACILITIES.find(n => n.id === id);
     if (!facility) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([facility.lon, facility.lat]);
     if (!pos) return;
@@ -3930,7 +3934,7 @@ export class MapComponent {
     const irradiator = GAMMA_IRRADIATORS.find(i => i.id === id);
     if (!irradiator) return;
 
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([irradiator.lon, irradiator.lat]);
     if (!pos) return;
@@ -4148,7 +4152,7 @@ export class MapComponent {
     const [minLon, minLat, maxLon, maxLat] = bbox;
     const midLon = (minLon + maxLon) / 2;
     const midLat = (minLat + maxLat) / 2;
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const topLeft = projection([minLon, maxLat]);
     const bottomRight = projection([maxLon, minLat]);
@@ -4171,7 +4175,7 @@ export class MapComponent {
   }
 
   public getCenter(): { lat: number; lon: number } | null {
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     if (!projection.invert) return null;
     const zoom = this.state.zoom;
@@ -4218,7 +4222,7 @@ export class MapComponent {
 
   public setCenter(lat: number, lon: number): void {
     console.log('[Map] setCenter called:', { lat, lon });
-    const { width, height } = this.getKnownContainerSize();
+    const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     const pos = projection([lon, lat]);
     console.log('[Map] projected pos:', pos, 'container:', { width, height }, 'zoom:', this.state.zoom);

--- a/tests/map-container-size-cache.test.mjs
+++ b/tests/map-container-size-cache.test.mjs
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const mapSrc = readFileSync(resolve(__dirname, '..', 'src', 'components', 'Map.ts'), 'utf8');
+
+// #5017: the /dashboard "Avoid forced reflows" audit attributed 516ms (65% of
+// the 797ms total) to Map-*.js. The cause was repeated LIVE reads of the
+// container geometry (this.container.clientWidth / clientHeight) on the
+// render/draw path — each read interleaved with the prior render tick's SVG
+// writes forces a synchronous layout. The container size only changes on
+// resize, which the ResizeObserver already tracks into lastContainerSize, so
+// the boot/draw path must read the cached size via getKnownContainerSize()
+// instead of hitting the DOM live.
+describe('Map container-size cache (#5017 forced-reflow guard)', () => {
+  it('render() reads the cached container size, not a live DOM read', () => {
+    const render = mapSrc.match(/public render\(\): void \{[\s\S]*?\n {2}\}/);
+    assert.ok(render, 'could not locate render() body');
+    assert.match(
+      render[0],
+      /getKnownContainerSize\(\)/,
+      'render() must read via getKnownContainerSize() (ResizeObserver-maintained cache), not a live clientWidth/clientHeight',
+    );
+    assert.doesNotMatch(
+      render[0],
+      /this\.container\.client(Width|Height)/,
+      'render() must not read this.container.clientWidth/clientHeight directly',
+    );
+  });
+
+  it('keeps direct container clientWidth/clientHeight reads confined to the two intended sites', () => {
+    // Direct live reads are allowed ONLY in:
+    //   1. readContainerSize() — the primitive that refreshes the cache.
+    //   2. the pointer/click handler — needs live geometry paired with a live
+    //      getBoundingClientRect() for scroll-accurate cursor→map mapping.
+    // Any NEW direct read on the render/draw path reintroduces the #5017 reflow.
+    const widthReads = (mapSrc.match(/this\.container\.clientWidth/g) || []).length;
+    const heightReads = (mapSrc.match(/this\.container\.clientHeight/g) || []).length;
+    assert.equal(
+      widthReads,
+      2,
+      `expected exactly 2 direct this.container.clientWidth reads (readContainerSize + pointer handler); found ${widthReads}. New draw-path reads must use getKnownContainerSize().`,
+    );
+    assert.equal(
+      heightReads,
+      2,
+      `expected exactly 2 direct this.container.clientHeight reads (readContainerSize + pointer handler); found ${heightReads}.`,
+    );
+  });
+
+  it('still exposes the cache accessor and its resize-driven refresh', () => {
+    assert.match(mapSrc, /private getKnownContainerSize\(\)/, 'getKnownContainerSize() accessor must exist');
+    assert.match(mapSrc, /rememberContainerSize\(\{ width, height \}\)/, 'ResizeObserver must refresh the cache via rememberContainerSize()');
+  });
+});

--- a/tests/map-container-size-cache.test.mjs
+++ b/tests/map-container-size-cache.test.mjs
@@ -56,3 +56,41 @@ describe('Map container-size cache (#5017 forced-reflow guard)', () => {
     assert.match(mapSrc, /rememberContainerSize\(\{ width, height \}\)/, 'ResizeObserver must refresh the cache via rememberContainerSize()');
   });
 });
+
+// #5022 review: cached geometry is only safe on the render/draw hot path. One-shot
+// viewport commands can run right after revealMobileMap() expands the map — before
+// the ResizeObserver refreshes the cache — so they must read the CURRENT size or
+// they center off stale dimensions. readContainerSize() reads live AND refreshes
+// the cache, keeping the subsequent cached applyTransform() read consistent.
+describe('Map one-shot viewport commands read current size (#5022 review)', () => {
+  function methodSlice(name) {
+    const start = mapSrc.search(new RegExp(String.raw`\n  (?:public|private) ${name}\(`));
+    assert.ok(start >= 0, `could not locate ${name}()`);
+    const rest = mapSrc.slice(start + 1);
+    const next = rest.slice(1).search(/\n {2}(?:public|private|protected) \w+\(/);
+    return next >= 0 ? rest.slice(0, next + 1) : rest;
+  }
+
+  for (const name of ['setCenter', 'fitCountry', 'getCenter']) {
+    it(`${name}() reads live via readContainerSize(), not the stale cache`, () => {
+      const body = methodSlice(name);
+      assert.match(body, /readContainerSize\(\)/, `${name}() must read the current size (correct after reveal/resize)`);
+      assert.doesNotMatch(body, /getKnownContainerSize\(\)/, `${name}() must not read the cached size — it can run before the ResizeObserver refresh`);
+    });
+  }
+
+  it('ResizeObserver records zero-size (hidden) transitions, gating only the render on visibility', () => {
+    const ro = mapSrc.slice(mapSrc.indexOf('private setupResizeObserver('));
+    const body = ro.slice(0, ro.slice(1).search(/\n {2}(?:public|private) \w+\(/) + 1);
+    // scheduleRender is gated on a visible size...
+    assert.match(body, /if \(width > 0 && height > 0\) this\.scheduleRender\(\)/, 'scheduleRender must fire only for a visible size');
+    // ...but the cache update must run for ANY change (including -> 0), so the
+    // old combined visible-only guard must be gone.
+    assert.doesNotMatch(body, /width > 0 && height > 0 && \(width !== lastWidth/, 'must not gate the cache update behind the visible-size check (hidden state must be recorded so render() skips)');
+    assert.match(body, /rememberContainerSize\(\{ width, height \}\)/, 'must record every observed size (including zero) into the cache');
+  });
+
+  it('render paths keep the zero-size skip so a hidden map does not render off stale dimensions', () => {
+    assert.match(mapSrc, /if \(width === 0 \|\| height === 0\)/, 'renderWithSize must skip when the container has no dimensions');
+  });
+});


### PR DESCRIPTION
Addresses the dominant lever in #5017 (forced reflows on `/dashboard` load).

## Attribution (from the DebugBear forced-reflow stacks)

| Chunk | Sites | Total | Source |
|---|---|---|---|
| **Map-*.js** | 3 (462+39+15) | **516ms (65%)** | `src/components/Map.ts` |
| [unattributed] | 1 | 179ms | browser-internal (no JS frame) |
| panel-storage-*.js | 1 | 52ms | |
| main-*.js | 4 | 34ms | App boot |
| Panel-*.js | 1 | 12ms | (line 1085 is a *deliberate* `offsetWidth` animation-restart, not a bug) |
| user-location-*.js | 1 | 4ms | |

This PR fixes the **516ms Map bucket** — 65% of the 797ms total.

## Root cause

`src/components/Map.ts` read the container geometry **live** on the render/draw path — `render()` plus ~13 projection/draw helpers each did `this.container.clientWidth` / `clientHeight`. `render()` fires repeatedly as data streams in on boot, and each live read interleaved with the previous tick's SVG writes forces a synchronous layout (the classic layout-thrash).

The container size only changes on resize, which the existing **`ResizeObserver` already tracks** into `lastContainerSize`. The reflow-free accessor `getKnownContainerSize()` was already present — the render/draw path just wasn't using it.

## Change

Route `render()` and the projection/draw helpers through `getKnownContainerSize()` (cached; falls back to a live read only when the cache is still empty at first paint). Two direct reads are intentionally kept:
- `readContainerSize()` — the cache-refresh primitive.
- the pointer/click handler — needs live geometry paired with a live `getBoundingClientRect()` for scroll-accurate cursor→map mapping.

Net −8 lines. Behavior-preserving: identical values, cache kept fresh by the `ResizeObserver` (which also reschedules `render()` on resize).

## Verification

- `npx tsc --noEmit` clean.
- 26 map tests pass — 23 existing (`marker-pulse-settle`, `map-renderer-deferral`, `measure-dashboard-render-axis`) + **3 new static guard tests** (`tests/map-container-size-cache.test.mjs`) that lock the render path onto the cache and cap direct reads at the two allowed sites, so a new draw-path live read can't silently reintroduce the reflow.
- Cross-checked with the repo's own `scripts/measure-dashboard-render-axis.mjs` (Playwright/CDP trace): anonymous prod load shows 840 forced-reflow events / 271.8ms today.

## Scope / residual

I deliberately scoped this to the high-confidence dominant bucket. The secondary chunks (panel-storage 52ms, main 34ms, Panel 12ms, user-location 4ms) and the [unattributed] 179ms are lower-confidence (interaction-time reads, browser-internal, or deliberate). Left as **not `Closes`** so the next daily DebugBear run can measure this drop and I can attribute any residual before the ≤200ms target is called green.

https://claude.ai/code/session_01BfmsXVjM2mdDAxpUTpkXoW
