### PR TITLE
chore(aeo): brand-named developer-resource discoverability pages

### DIFF
--- a/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
+++ b/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
@@ -144,6 +144,15 @@ Build alerting bots that post to your team channel when:
 - A prediction market probability shifts significantly
 - A cyber threat spike is detected in your region of interest
 
+## Developer Resources
+
+Every developer surface has a dedicated, named page you can jump to directly — the [World Monitor Developer Portal](https://www.worldmonitor.app/developers.md) links them all in one place:
+
+- **[World Monitor MCP Server](https://www.worldmonitor.app/mcp-server.md)** — the recommended agent surface at `https://worldmonitor.app/mcp`, with 39 tools over Streamable HTTP. Connect Claude, Cursor, or any MCP client. See the [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) for auth and the full catalog.
+- **[World Monitor OpenAPI Specification](https://www.worldmonitor.app/openapi.md)** — the OpenAPI 3.1 contract for the REST API ([openapi.yaml](https://worldmonitor.app/openapi.yaml) / [openapi.json](https://worldmonitor.app/openapi.json)), so you can generate a typed client in any language.
+- **[World Monitor SDKs](https://www.worldmonitor.app/sdks.md)** — official zero-dependency client libraries for Python, Ruby, Go, and JavaScript, plus the [`worldmonitor` CLI](https://www.worldmonitor.app/docs/cli).
+- **World Monitor API docs** — the full [developer documentation](https://www.worldmonitor.app/docs/documentation) site, with an [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart) and [agent auth walkthrough](https://worldmonitor.app/auth.md).
+
 ## Self-Hosting
 
 World Monitor is AGPL-3.0. You can self-host the entire platform, including [local AI capabilities that run without cloud dependencies](/blog/posts/ai-powered-intelligence-without-the-cloud/):

--- a/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
+++ b/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
@@ -6,6 +6,7 @@ keywords: "open source intelligence API, OSINT API free, geopolitical data API, 
 audience: "Developers, data engineers, startup builders, academic researchers, open-source contributors"
 heroImage: "/blog/images/blog/build-on-worldmonitor-developer-api-open-source.jpg"
 pubDate: "2026-03-09"
+modifiedDate: "2026-07-07"
 ---
 
 Most intelligence platforms are walled gardens. You pay for access, you use their interface, and if you want to build something custom, you're out of luck. The data is locked behind a UI.

--- a/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
+++ b/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
@@ -146,11 +146,11 @@ Build alerting bots that post to your team channel when:
 
 ## Developer Resources
 
-Every developer surface has a dedicated, named page you can jump to directly — the [World Monitor Developer Portal](https://www.worldmonitor.app/developers.md) links them all in one place:
+Every developer surface has a dedicated, named page you can jump to directly — the [World Monitor Developer Portal](https://worldmonitor.app/developers.md) links them all in one place:
 
-- **[World Monitor MCP Server](https://www.worldmonitor.app/mcp-server.md)** — the recommended agent surface at `https://worldmonitor.app/mcp`, with 39 tools over Streamable HTTP. Connect Claude, Cursor, or any MCP client. See the [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) for auth and the full catalog.
-- **[World Monitor OpenAPI Specification](https://www.worldmonitor.app/openapi.md)** — the OpenAPI 3.1 contract for the REST API ([openapi.yaml](https://worldmonitor.app/openapi.yaml) / [openapi.json](https://worldmonitor.app/openapi.json)), so you can generate a typed client in any language.
-- **[World Monitor SDKs](https://www.worldmonitor.app/sdks.md)** — official zero-dependency client libraries for Python, Ruby, Go, and JavaScript, plus the [`worldmonitor` CLI](https://www.worldmonitor.app/docs/cli).
+- **[World Monitor MCP Server](https://worldmonitor.app/mcp-server.md)** — the recommended agent surface at `https://worldmonitor.app/mcp`, with 39 tools over Streamable HTTP. Connect Claude, Cursor, or any MCP client. See the [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) for auth and the full catalog.
+- **[World Monitor OpenAPI Specification](https://worldmonitor.app/openapi.md)** — the OpenAPI 3.1 contract for the REST API ([openapi.yaml](https://worldmonitor.app/openapi.yaml) / [openapi.json](https://worldmonitor.app/openapi.json)), so you can generate a typed client in any language.
+- **[World Monitor SDKs](https://worldmonitor.app/sdks.md)** — official zero-dependency client libraries for Python, Ruby, Go, and JavaScript, plus the [`worldmonitor` CLI](https://www.worldmonitor.app/docs/cli).
 - **World Monitor API docs** — the full [developer documentation](https://www.worldmonitor.app/docs/documentation) site, with an [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart) and [agent auth walkthrough](https://worldmonitor.app/auth.md).
 
 ## Self-Hosting

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -64,6 +64,26 @@
           "href": "https://worldmonitor.app/agents.md",
           "type": "text/markdown",
           "title": "Agent operations guide (surfaces, auth, crawl policy)"
+        },
+        {
+          "href": "https://worldmonitor.app/developers.md",
+          "type": "text/markdown",
+          "title": "World Monitor Developer Portal — links every developer resource by name"
+        },
+        {
+          "href": "https://worldmonitor.app/mcp-server.md",
+          "type": "text/markdown",
+          "title": "World Monitor MCP Server — endpoint, tools, auth (machine-readable)"
+        },
+        {
+          "href": "https://worldmonitor.app/openapi.md",
+          "type": "text/markdown",
+          "title": "World Monitor OpenAPI Specification — REST API contract (machine-readable)"
+        },
+        {
+          "href": "https://worldmonitor.app/sdks.md",
+          "type": "text/markdown",
+          "title": "World Monitor SDKs — Python, Ruby, Go, JavaScript (machine-readable)"
         }
       ],
       "status": [

--- a/public/agents.md
+++ b/public/agents.md
@@ -14,6 +14,7 @@ World Monitor is a real-time global intelligence dashboard: 500+ news feeds, 56 
 - **CLI:** `npx worldmonitor tools` lists every tool (public, no key) — https://www.npmjs.com/package/worldmonitor
 - **SDKs:** Python `pip install worldmonitor-sdk` · Ruby `gem install worldmonitor` · Go `go get github.com/koala73/worldmonitor/sdk/go` · JavaScript npm `worldmonitor` — guide: https://www.worldmonitor.app/docs/sdks
 - **LLM briefings:** https://worldmonitor.app/llms.txt (overview) · https://worldmonitor.app/llms-full.txt (full reference) · https://worldmonitor.app/api/llms.txt (API section)
+- **Developer portal:** https://worldmonitor.app/developers.md — links every developer resource by name. Named resource pages: [MCP Server](https://worldmonitor.app/mcp-server.md) · [OpenAPI Specification](https://worldmonitor.app/openapi.md) · [SDKs](https://worldmonitor.app/sdks.md)
 
 ## Authentication
 

--- a/public/api/llms.txt
+++ b/public/api/llms.txt
@@ -43,6 +43,13 @@ This is the API-section companion to the site-wide briefing at https://worldmoni
 - Discovery methods (`tools/list`, `prompts/list`, `describe_tool`) are quota-exempt but rate-limited to 60 requests/minute.
 - Data calls consume the plan's daily quota. Free, Pro, API, and Enterprise tier details: https://worldmonitor.app/pricing.md
 
+## Developer Resource Pages
+
+- [World Monitor Developer Portal](https://worldmonitor.app/developers.md): Hub linking every developer resource by name
+- [World Monitor MCP Server](https://worldmonitor.app/mcp-server.md): MCP server endpoint, tools, and auth
+- [World Monitor OpenAPI Specification](https://worldmonitor.app/openapi.md): REST API OpenAPI 3.1 contract (openapi.yaml / openapi.json)
+- [World Monitor SDKs](https://worldmonitor.app/sdks.md): Official Python, Ruby, Go, and JavaScript client libraries
+
 ## Optional
 
 - [Site-wide llms.txt](https://worldmonitor.app/llms.txt): Full platform briefing and agent guidance

--- a/public/developers.md
+++ b/public/developers.md
@@ -1,0 +1,37 @@
+# World Monitor Developer Portal
+
+Last updated: July 7, 2026
+
+The World Monitor Developer Portal is the single entry point for building on World Monitor — the real-time global-intelligence platform that correlates geopolitics, markets, commodities, shipping, aviation, infrastructure, cyber threats, weather, and live news as source-attributed structured JSON. Every developer surface below shares one authentication model and one tool inventory, so you can start with the MCP server and drop down to the REST API or an SDK without relearning anything.
+
+This page names and links every developer resource type. For the machine-readable companion, see [agents.md](https://worldmonitor.app/agents.md) and the [API llms.txt](https://worldmonitor.app/api/llms.txt).
+
+## Developer Resources
+
+- **[World Monitor MCP Server](https://worldmonitor.app/mcp-server.md):** the recommended agent surface — `https://worldmonitor.app/mcp`, Streamable HTTP, 39 tools. Connect Claude, Cursor, and any MCP-compatible client to live intelligence data. Details: [mcp-server.md](https://worldmonitor.app/mcp-server.md) · [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) · Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **[World Monitor OpenAPI Specification](https://worldmonitor.app/openapi.md):** the OpenAPI 3.1 contract for the REST API — [openapi.yaml](https://worldmonitor.app/openapi.yaml) · [openapi.json](https://worldmonitor.app/openapi.json). Details: [openapi.md](https://worldmonitor.app/openapi.md)
+- **World Monitor REST API:** base `https://api.worldmonitor.app` — the same 39 tools and data as the MCP server over plain HTTP. Machine-readable [API catalog (RFC 9727)](https://worldmonitor.app/.well-known/api-catalog) · human docs at [/docs/documentation](https://www.worldmonitor.app/docs/documentation)
+- **[World Monitor SDKs](https://worldmonitor.app/sdks.md):** official zero-dependency client libraries for Python, Ruby, Go, and JavaScript. Details: [sdks.md](https://worldmonitor.app/sdks.md) · [SDK guide](https://www.worldmonitor.app/docs/sdks)
+- **World Monitor CLI:** `npx worldmonitor tools` scripts every tool from a shell — [npm `worldmonitor`](https://www.npmjs.com/package/worldmonitor) · [CLI guide](https://www.worldmonitor.app/docs/cli)
+- **World Monitor Agent Skills:** installable skills for agent frameworks — discovery index at https://worldmonitor.app/.well-known/agent-skills/index.json · `npx skills add koala73/worldmonitor`
+- **World Monitor API documentation:** the full developer documentation site at [/docs](https://www.worldmonitor.app/docs/documentation), including the [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart), [tool reference](https://www.worldmonitor.app/docs/mcp-tools-reference), and [JMESPath projection guide](https://www.worldmonitor.app/docs/mcp-jmespath).
+- **World Monitor authentication:** the agent auth walkthrough at [auth.md](https://worldmonitor.app/auth.md) — API keys (`X-WorldMonitor-Key: wm_<40-hex>`) and OAuth 2.1 (`scope=mcp`) with dynamic client registration.
+
+## Authentication in one line
+
+Discovery endpoints and `tools/list` are public. Data calls need either an API key header `X-WorldMonitor-Key: wm_<40-hex>` (issue one at https://worldmonitor.app/pro) or OAuth 2.1 with scope `mcp`. The full walkthrough — including dynamic client registration and the Pro sign-in flow — lives at [auth.md](https://worldmonitor.app/auth.md).
+
+## Pricing, limits & support
+
+- **Pricing and plan limits:** [pricing.md](https://worldmonitor.app/pricing.md) · live JSON catalog `GET https://www.worldmonitor.app/api/product-catalog`
+- **Rate limits:** 60 requests/minute/key; OAuth Pro contexts get 50 quota-consuming MCP calls/UTC day. Honor `Retry-After` on 429.
+- **Support:** [support.md](https://worldmonitor.app/support.md) — support@worldmonitor.app · Status: https://status.worldmonitor.app
+- **Source (AGPL-3.0):** https://github.com/koala73/worldmonitor · Issues: https://github.com/koala73/worldmonitor/issues
+
+## Important query matches
+
+- World Monitor developer portal
+- World Monitor API for developers
+- Build on World Monitor
+- World Monitor MCP server, OpenAPI, SDK, and CLI
+- How to access World Monitor data programmatically

--- a/public/developers.md
+++ b/public/developers.md
@@ -10,7 +10,7 @@ This page names and links every developer resource type. For the machine-readabl
 
 - **[World Monitor MCP Server](https://worldmonitor.app/mcp-server.md):** the recommended agent surface — `https://worldmonitor.app/mcp`, Streamable HTTP, 39 tools. Connect Claude, Cursor, and any MCP-compatible client to live intelligence data. Details: [mcp-server.md](https://worldmonitor.app/mcp-server.md) · [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) · Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
 - **[World Monitor OpenAPI Specification](https://worldmonitor.app/openapi.md):** the OpenAPI 3.1 contract for the REST API — [openapi.yaml](https://worldmonitor.app/openapi.yaml) · [openapi.json](https://worldmonitor.app/openapi.json). Details: [openapi.md](https://worldmonitor.app/openapi.md)
-- **World Monitor REST API:** base `https://api.worldmonitor.app` — the same 39 tools and data as the MCP server over plain HTTP. Machine-readable [API catalog (RFC 9727)](https://worldmonitor.app/.well-known/api-catalog) · human docs at [/docs/documentation](https://www.worldmonitor.app/docs/documentation)
+- **World Monitor REST API:** base `https://api.worldmonitor.app` — the same tools and data as the MCP server, exposed as granular endpoints over plain HTTP. Machine-readable [API catalog (RFC 9727)](https://worldmonitor.app/.well-known/api-catalog) · human docs at [/docs/documentation](https://www.worldmonitor.app/docs/documentation)
 - **[World Monitor SDKs](https://worldmonitor.app/sdks.md):** official zero-dependency client libraries for Python, Ruby, Go, and JavaScript. Details: [sdks.md](https://worldmonitor.app/sdks.md) · [SDK guide](https://www.worldmonitor.app/docs/sdks)
 - **World Monitor CLI:** `npx worldmonitor tools` scripts every tool from a shell — [npm `worldmonitor`](https://www.npmjs.com/package/worldmonitor) · [CLI guide](https://www.worldmonitor.app/docs/cli)
 - **World Monitor Agent Skills:** installable skills for agent frameworks — discovery index at https://worldmonitor.app/.well-known/agent-skills/index.json · `npx skills add koala73/worldmonitor`
@@ -24,7 +24,7 @@ Discovery endpoints and `tools/list` are public. Data calls need either an API k
 ## Pricing, limits & support
 
 - **Pricing and plan limits:** [pricing.md](https://worldmonitor.app/pricing.md) · live JSON catalog `GET https://www.worldmonitor.app/api/product-catalog`
-- **Rate limits:** 60 requests/minute/key; OAuth Pro contexts get 50 quota-consuming MCP calls/UTC day. Honor `Retry-After` on 429.
+- **Rate limits:** 60 requests/minute (per key, or per user for OAuth); any OAuth-connected context (Pro *or* API tier) also shares one 50 quota-consuming MCP calls/UTC day counter, while `wm_…`-key MCP clients have no daily reservation. Honor `Retry-After` on 429.
 - **Support:** [support.md](https://worldmonitor.app/support.md) — support@worldmonitor.app · Status: https://status.worldmonitor.app
 - **Source (AGPL-3.0):** https://github.com/koala73/worldmonitor · Issues: https://github.com/koala73/worldmonitor/issues
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -46,6 +46,10 @@ Reach for World Monitor when a task needs live, correlated, machine-readable glo
 - [README](https://github.com/koala73/worldmonitor/blob/main/README.md): Full project documentation with architecture details, algorithm descriptions, and data source specifications
 - [Full Documentation](https://github.com/koala73/worldmonitor/blob/main/docs/DOCUMENTATION.md): Detailed feature documentation, data layer reference, panel descriptions, and clustering logic
 - [API llms.txt](https://worldmonitor.app/api/llms.txt): API-section briefing — MCP server, REST API, CLI, auth, and per-task tool routing for the developer surface
+- [World Monitor Developer Portal](https://worldmonitor.app/developers.md): Developer resource hub linking the MCP server, OpenAPI spec, REST API, SDKs, CLI, and agent skills by name
+- [World Monitor MCP Server](https://worldmonitor.app/mcp-server.md): MCP server endpoint, 39 tools, and auth modes
+- [World Monitor OpenAPI Specification](https://worldmonitor.app/openapi.md): REST API OpenAPI 3.1 contract (openapi.yaml / openapi.json)
+- [World Monitor SDKs](https://worldmonitor.app/sdks.md): Official Python, Ruby, Go, and JavaScript client libraries
 
 ## Data Layers — Geopolitical
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -144,8 +144,12 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - [pricing.md](https://worldmonitor.app/pricing.md): Machine-readable pricing, limits and plan features
 - [support.md](https://worldmonitor.app/support.md): Machine-readable support channels and contact routes
 - [ai-search.md](https://worldmonitor.app/ai-search.md): AI-search answer blocks for citation and extraction
+- [World Monitor Developer Portal](https://worldmonitor.app/developers.md): Developer resource hub — links the MCP server, OpenAPI spec, REST API, SDKs, CLI, and agent skills by name
+- [World Monitor MCP Server](https://worldmonitor.app/mcp-server.md): The MCP server surface — endpoint, 39 tools, auth (OAuth + API key), server card
+- [World Monitor OpenAPI Specification](https://worldmonitor.app/openapi.md): The REST API OpenAPI 3.1 contract — openapi.yaml / openapi.json
+- [World Monitor SDKs](https://worldmonitor.app/sdks.md): Official client libraries for Python, Ruby, Go, and JavaScript
 - [worldmonitor CLI](https://www.npmjs.com/package/worldmonitor): Official command-line client — `npx worldmonitor` scripts the MCP tools and REST API from a shell or agent
-- [SDKs](https://www.worldmonitor.app/docs/sdks): Official client libraries — Python (PyPI `worldmonitor-sdk`), Ruby (gem `worldmonitor`), Go (`github.com/koala73/worldmonitor/sdk/go`), JavaScript (npm `worldmonitor`)
+- [SDKs guide](https://www.worldmonitor.app/docs/sdks): Full SDK documentation — Python (PyPI `worldmonitor-sdk`), Ruby (gem `worldmonitor`), Go (`github.com/koala73/worldmonitor/sdk/go`), JavaScript (npm `worldmonitor`)
 
 ## Optional
 

--- a/public/mcp-server.md
+++ b/public/mcp-server.md
@@ -1,0 +1,47 @@
+# World Monitor MCP Server
+
+Last updated: July 7, 2026
+
+The World Monitor MCP Server exposes World Monitor's real-time global-intelligence stack over the [Model Context Protocol](https://modelcontextprotocol.io), so any MCP-compatible client — Claude Desktop, Claude web, Cursor, MCP Inspector, or a custom agent — can pull live conflict, market, aviation, maritime, economic, cyber, and forecasting data directly into a model's context. It is the recommended way for AI agents to consume World Monitor data.
+
+## Endpoint
+
+- **Server URL:** `https://worldmonitor.app/mcp` — Streamable HTTP transport, JSON-RPC 2.0 (JSON responses by default, SSE when the client advertises `text/event-stream`; `initialize` defaults to protocol `2025-03-26`).
+- **Server card:** https://worldmonitor.app/.well-known/mcp/server-card.json
+- **Docs MCP server:** `https://www.worldmonitor.app/docs/mcp` — a second, public (no-auth) MCP server with search-and-retrieval tools over the documentation. Route "how do I…" questions there; route live-data calls to the product server above.
+
+## Tools
+
+The server ships **39 tools** covering world and country briefs, country risk and resilience, conflict events, markets, commodities, energy, maritime and aviation activity, cyber threats, sanctions, natural disasters, health signals, prediction markets, and AI forecasts. Issue `tools/list` for the live inventory, `prompts/list` for pre-built workflow templates, and `resources/list` for read-only resources. `tools/list`, `prompts/list`, and `resources/list` are **public** — no key required. Every tool accepts an optional `jmespath` argument for [server-side projection](https://www.worldmonitor.app/docs/mcp-jmespath), typically an 80–95% response-size cut.
+
+## Authentication
+
+- **`tools/list` and other discovery calls:** anonymous, no key.
+- **`tools/call` and `resources/read` (data):** need either an API key or OAuth.
+  - **API key:** header `X-WorldMonitor-Key: wm_<40-hex>` — issue one at https://worldmonitor.app/pro. Rate limit: 60 requests/minute/key.
+  - **OAuth 2.1 (`scope=mcp`):** Pro and API tiers can both connect via OAuth with no API key. Dynamic Client Registration (RFC 7591) at `https://api.worldmonitor.app/api/oauth/register`; authorization and token endpoints follow OAuth 2.1 with PKCE. Pro OAuth contexts get 50 quota-consuming `tools/call` / `resources/read` calls per UTC day.
+
+Full agent walkthrough: [auth.md](https://worldmonitor.app/auth.md). Authorization-server metadata: https://worldmonitor.app/.well-known/oauth-authorization-server · protected-resource metadata: https://worldmonitor.app/.well-known/oauth-protected-resource
+
+## Connect in one step
+
+```sh
+# Confirm reachability with the public CLI (no key):
+npx worldmonitor tools
+```
+
+Add the server to Claude Desktop / Cursor via their MCP settings using the URL `https://worldmonitor.app/mcp`, or follow the [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart) for a five-minute path to a real tool call.
+
+## Learn more
+
+- [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) — auth modes, plans, OAuth setup, full tool catalog
+- [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart) · [Tool reference](https://www.worldmonitor.app/docs/mcp-tools-reference) · [JMESPath projection](https://www.worldmonitor.app/docs/mcp-jmespath) · [Error catalog](https://www.worldmonitor.app/docs/mcp-error-catalog)
+- [Developer Portal](https://worldmonitor.app/developers.md) · [REST API OpenAPI spec](https://worldmonitor.app/openapi.md) · [SDKs](https://worldmonitor.app/sdks.md) · [agents.md](https://worldmonitor.app/agents.md)
+
+## Important query matches
+
+- World Monitor MCP server
+- World Monitor Model Context Protocol server
+- Connect Claude to World Monitor
+- Real-time geopolitical intelligence MCP server
+- MCP server for markets, conflicts, and global risk data

--- a/public/mcp-server.md
+++ b/public/mcp-server.md
@@ -19,7 +19,7 @@ The server ships **39 tools** covering world and country briefs, country risk an
 - **`tools/list` and other discovery calls:** anonymous, no key.
 - **`tools/call` and `resources/read` (data):** need either an API key or OAuth.
   - **API key:** header `X-WorldMonitor-Key: wm_<40-hex>` — issue one at https://worldmonitor.app/pro. Rate limit: 60 requests/minute/key.
-  - **OAuth 2.1 (`scope=mcp`):** Pro and API tiers can both connect via OAuth with no API key. Dynamic Client Registration (RFC 7591) at `https://api.worldmonitor.app/api/oauth/register`; authorization and token endpoints follow OAuth 2.1 with PKCE. Pro OAuth contexts get 50 quota-consuming `tools/call` / `resources/read` calls per UTC day.
+  - **OAuth 2.1 (`scope=mcp`):** Pro and API tiers can both connect via OAuth with no API key. Dynamic Client Registration (RFC 7591) at `https://worldmonitor.app/oauth/register`; authorization and token endpoints follow OAuth 2.1 with PKCE. Any OAuth-connected context — Pro *or* API tier — shares one 50 quota-consuming `tools/call` / `resources/read` counter per UTC day; API-tier clients that authenticate with a `wm_…` key instead have no daily reservation (only the 60 requests/minute limiter).
 
 Full agent walkthrough: [auth.md](https://worldmonitor.app/auth.md). Authorization-server metadata: https://worldmonitor.app/.well-known/oauth-authorization-server · protected-resource metadata: https://worldmonitor.app/.well-known/oauth-protected-resource
 

--- a/public/openapi.md
+++ b/public/openapi.md
@@ -1,0 +1,46 @@
+# World Monitor OpenAPI Specification
+
+Last updated: July 7, 2026
+
+The World Monitor OpenAPI Specification is the machine-readable contract for the World Monitor REST API — the HTTP surface that exposes the same 39 real-time global-intelligence tools as the [MCP server](https://worldmonitor.app/mcp-server.md), returning source-attributed structured JSON. Point your OpenAPI client, code generator, or agent at the spec to discover every endpoint, parameter, and response shape.
+
+## The spec
+
+- **OpenAPI 3.1 (YAML):** https://worldmonitor.app/openapi.yaml
+- **OpenAPI 3.1 (JSON):** https://worldmonitor.app/openapi.json
+- **REST API base URL:** `https://api.worldmonitor.app`
+- **Media types:** `application/vnd.oai.openapi` (YAML) and `application/json` (JSON), both served with `Access-Control-Allow-Origin: *`.
+
+The spec is generated on every deploy from the canonical proto/service definitions, so it always matches the running gateway — there is no hand-maintained drift.
+
+## Related descriptors
+
+- **Commerce / pricing endpoints** live in a separate spec (kept out of the root bundle for size): https://www.worldmonitor.app/docs/openapi/CommerceService.openapi.yaml
+- **API catalog (RFC 9727):** https://worldmonitor.app/.well-known/api-catalog — a linkset that enumerates the REST API, MCP server, OpenAPI spec, pricing, support, and status surfaces.
+- **Human documentation:** https://www.worldmonitor.app/docs/documentation
+
+## Authentication
+
+Send the header `X-WorldMonitor-Key: wm_<40-hex>` on data calls (issue a key at https://worldmonitor.app/pro); discovery routes are public. Always send a descriptive `User-Agent` — the edge firewall challenges generic library agents (`curl/*`, `python-requests/*`), and a 403 means "retry with a real UA", not "endpoint missing". Rate limit: 60 requests/minute/key; honor `Retry-After` on 429. Full matrix: https://www.worldmonitor.app/docs/usage-auth · walkthrough: [auth.md](https://worldmonitor.app/auth.md)
+
+## Use it
+
+```sh
+# Generate a typed client from the spec:
+npx @openapitools/openapi-generator-cli generate \
+  -i https://worldmonitor.app/openapi.yaml -g python -o ./wm-client
+```
+
+Or skip codegen entirely and use an [official SDK](https://worldmonitor.app/sdks.md) or the [CLI](https://www.worldmonitor.app/docs/cli).
+
+## Learn more
+
+- [Developer Portal](https://worldmonitor.app/developers.md) · [MCP Server](https://worldmonitor.app/mcp-server.md) · [SDKs](https://worldmonitor.app/sdks.md) · [agents.md](https://worldmonitor.app/agents.md) · [API llms.txt](https://worldmonitor.app/api/llms.txt)
+
+## Important query matches
+
+- World Monitor OpenAPI specification
+- World Monitor OpenAPI 3.1 spec
+- World Monitor REST API OpenAPI YAML / JSON
+- Generate a World Monitor API client from OpenAPI
+- Global intelligence REST API spec

--- a/public/openapi.md
+++ b/public/openapi.md
@@ -2,14 +2,14 @@
 
 Last updated: July 7, 2026
 
-The World Monitor OpenAPI Specification is the machine-readable contract for the World Monitor REST API — the HTTP surface that exposes the same 39 real-time global-intelligence tools as the [MCP server](https://worldmonitor.app/mcp-server.md), returning source-attributed structured JSON. Point your OpenAPI client, code generator, or agent at the spec to discover every endpoint, parameter, and response shape.
+The World Monitor OpenAPI Specification is the machine-readable contract for the World Monitor REST API — the HTTP surface that exposes the same real-time global-intelligence tools and data as the [MCP server](https://worldmonitor.app/mcp-server.md) via granular REST endpoints, returning source-attributed structured JSON. Point your OpenAPI client, code generator, or agent at the spec to discover every endpoint, parameter, and response shape.
 
 ## The spec
 
 - **OpenAPI 3.1 (YAML):** https://worldmonitor.app/openapi.yaml
 - **OpenAPI 3.1 (JSON):** https://worldmonitor.app/openapi.json
 - **REST API base URL:** `https://api.worldmonitor.app`
-- **Media types:** `application/vnd.oai.openapi` (YAML) and `application/json` (JSON), both served with `Access-Control-Allow-Origin: *`.
+- **Served Content-Type:** `application/yaml; charset=utf-8` (YAML) and `application/json; charset=utf-8` (JSON), both with `Access-Control-Allow-Origin: *`. The API catalog advertises the OpenAPI descriptor media type `application/vnd.oai.openapi` for the spec.
 
 The spec is generated on every deploy from the canonical proto/service definitions, so it always matches the running gateway — there is no hand-maintained drift.
 

--- a/public/sdks.md
+++ b/public/sdks.md
@@ -1,0 +1,52 @@
+# World Monitor SDKs
+
+Last updated: July 7, 2026
+
+World Monitor ships official client libraries in four language ecosystems so you can script country briefs, risk scores, market data, and every one of the 39 [MCP tools](https://worldmonitor.app/mcp-server.md) without writing an HTTP integration. All of them are **zero-dependency**, MCP-first mirrors of the [`worldmonitor` npm CLI](https://www.worldmonitor.app/docs/cli), with a small REST escape hatch for host-relative and self-hosted use.
+
+## Official SDKs
+
+| Language | Package | Install | Source |
+| --- | --- | --- | --- |
+| Python | [`worldmonitor-sdk` on PyPI](https://pypi.org/project/worldmonitor-sdk/) | `pip install worldmonitor-sdk` | [`sdk/python/`](https://github.com/koala73/worldmonitor/tree/main/sdk/python) |
+| Ruby | [`worldmonitor` on RubyGems](https://rubygems.org/gems/worldmonitor) | `gem install worldmonitor` | [`sdk/ruby/`](https://github.com/koala73/worldmonitor/tree/main/sdk/ruby) |
+| Go | [`github.com/koala73/worldmonitor/sdk/go` on pkg.go.dev](https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go) | `go get github.com/koala73/worldmonitor/sdk/go` | [`sdk/go/`](https://github.com/koala73/worldmonitor/tree/main/sdk/go) |
+| JavaScript / CLI | [`worldmonitor` on npm](https://www.npmjs.com/package/worldmonitor) | `npm install worldmonitor` | [`cli/`](https://github.com/koala73/worldmonitor/tree/main/cli) |
+
+Every package sets its homepage to `worldmonitor.app` — that is how you (or your agent) verify it is the official SDK and not a look-alike.
+
+## Shared design
+
+All four clients expose the same surface with language-native naming:
+
+- **Any MCP tool** via `call_tool` / `CallTool` with named arguments; the result is the unwrapped JSON-RPC `result`.
+- **Curated helpers** for the highest-traffic tools: world brief, country brief/risk, markets, conflicts, cyber, news, disasters, sanctions, forecasts, maritime.
+- **Public listings** — `list_tools`, `list_prompts`, `list_resources` — need no key.
+- **REST escape hatch** — `get("/api/…")` and `health()` against `https://api.worldmonitor.app`.
+- **Configuration** via constructor arguments or the `WORLDMONITOR_API_KEY` (alias `WM_API_KEY`), `WORLDMONITOR_BASE_URL`, and `WORLDMONITOR_MCP_URL` environment variables.
+- Every tool accepts an optional `jmespath` argument for [server-side projection](https://www.worldmonitor.app/docs/mcp-jmespath) — typically an 80–95% response-size cut.
+
+## Quick start (Python)
+
+```python
+from worldmonitor_sdk import Client
+
+client = Client(api_key="wm_...")  # or set WORLDMONITOR_API_KEY
+client.list_tools()                # public — no key needed
+client.country_risk("IR")
+client.call_tool("get_market_data", asset_class="crypto")
+```
+
+Get an API key at https://worldmonitor.app/pro. The full per-language guide — Ruby, Go, and JavaScript examples included — is at https://www.worldmonitor.app/docs/sdks.
+
+## Learn more
+
+- [Developer Portal](https://worldmonitor.app/developers.md) · [MCP Server](https://worldmonitor.app/mcp-server.md) · [OpenAPI Specification](https://worldmonitor.app/openapi.md) · [CLI guide](https://www.worldmonitor.app/docs/cli) · [agents.md](https://worldmonitor.app/agents.md)
+
+## Important query matches
+
+- World Monitor SDK
+- World Monitor Python / Ruby / Go / JavaScript SDK
+- World Monitor client library
+- pip install worldmonitor-sdk
+- Official World Monitor API client libraries

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -200,7 +200,7 @@
   </url>
   <url>
     <loc>https://www.worldmonitor.app/blog/posts/build-on-worldmonitor-developer-api-open-source/</loc>
-    <lastmod>2026-03-09</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -37,6 +37,30 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.worldmonitor.app/developers.md</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.worldmonitor.app/mcp-server.md</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.worldmonitor.app/openapi.md</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.worldmonitor.app/sdks.md</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://www.worldmonitor.app/llms.txt</loc>
     <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2348,12 +2348,13 @@ describe('agent readiness: named developer-resource pages (#4953)', () => {
     // Mirror the #4958 "advertises...on every discovery surface" guard: a page
     // that is supposed to be advertised everywhere silently going unadvertised
     // on one surface was a real drift incident. Check the api-catalog plus every
-    // text discovery surface the PR wires (llms.txt, agents.md, api/llms.txt).
+    // text discovery surface the PR wires (llms.txt, llms-full.txt, agents.md,
+    // api/llms.txt).
     const catalog = JSON.parse(readFileSync(resolve(__dirname, '../public/.well-known/api-catalog'), 'utf-8'));
     const catalogHrefs = catalog.linkset.flatMap((ctx) =>
       Object.values(ctx).flatMap((v) => (Array.isArray(v) ? v.map((e) => e.href) : []))
     );
-    const surfaces = ['llms.txt', 'agents.md', 'api/llms.txt'].map((f) => [
+    const surfaces = ['llms.txt', 'llms-full.txt', 'agents.md', 'api/llms.txt'].map((f) => [
       f,
       readFileSync(resolve(__dirname, `../public/${f}`), 'utf-8'),
     ]);

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2358,12 +2358,26 @@ describe('agent readiness: named developer-resource pages (#4953)', () => {
       f,
       readFileSync(resolve(__dirname, `../public/${f}`), 'utf-8'),
     ]);
+    // The sitemap and the indexed "Build on World Monitor" blog post are the two
+    // web-search discovery surfaces (candidate fixes #1/#3 of the issue) — assert
+    // them directly so a dropped sitemap entry or blog cross-link is caught here,
+    // not only via the reverse #4999 sitemap->MD_PAGES sweep.
+    const sitemap = readFileSync(resolve(__dirname, '../public/sitemap.xml'), 'utf-8');
+    const blogPost = readFileSync(
+      resolve(__dirname, '../blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md'),
+      'utf-8'
+    );
     for (const page of DEV_PAGES) {
       const url = `https://worldmonitor.app${page.path}`;
       assert.ok(catalogHrefs.includes(url), `api-catalog must advertise ${url}`);
       for (const [name, content] of surfaces) {
         assert.ok(content.includes(page.path), `public/${name} must link ${page.path}`);
       }
+      assert.ok(
+        sitemap.includes(`https://www.worldmonitor.app${page.path}`),
+        `sitemap.xml must register ${page.path} on the www host`
+      );
+      assert.ok(blogPost.includes(page.path), `the developer blog post must cross-link ${page.path}`);
     }
   });
 });

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2345,15 +2345,24 @@ describe('agent readiness: named developer-resource pages (#4953)', () => {
   }
 
   it('advertises the developer portal + resource pages across the discovery chain', () => {
+    // Mirror the #4958 "advertises...on every discovery surface" guard: a page
+    // that is supposed to be advertised everywhere silently going unadvertised
+    // on one surface was a real drift incident. Check the api-catalog plus every
+    // text discovery surface the PR wires (llms.txt, agents.md, api/llms.txt).
     const catalog = JSON.parse(readFileSync(resolve(__dirname, '../public/.well-known/api-catalog'), 'utf-8'));
     const catalogHrefs = catalog.linkset.flatMap((ctx) =>
       Object.values(ctx).flatMap((v) => (Array.isArray(v) ? v.map((e) => e.href) : []))
     );
-    const llms = readFileSync(resolve(__dirname, '../public/llms.txt'), 'utf-8');
+    const surfaces = ['llms.txt', 'agents.md', 'api/llms.txt'].map((f) => [
+      f,
+      readFileSync(resolve(__dirname, `../public/${f}`), 'utf-8'),
+    ]);
     for (const page of DEV_PAGES) {
       const url = `https://worldmonitor.app${page.path}`;
       assert.ok(catalogHrefs.includes(url), `api-catalog must advertise ${url}`);
-      assert.ok(llms.includes(page.path), `llms.txt must link ${page.path}`);
+      for (const [name, content] of surfaces) {
+        assert.ok(content.includes(page.path), `public/${name} must link ${page.path}`);
+      }
     }
   });
 });

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -16,7 +16,7 @@ const middlewareSource = readFileSync(resolve(__dirname, '../middleware.ts'), 'u
 const dockerfileSource = readFileSync(resolve(__dirname, '../Dockerfile'), 'utf-8');
 const dockerNginxSource = readFileSync(resolve(__dirname, '../docker/nginx.conf'), 'utf-8');
 const frontendDockerfileSource = readFileSync(resolve(__dirname, '../docker/Dockerfile'), 'utf-8');
-const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
+const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
 const GLOBAL_SECURITY_HEADER_SOURCE = '/((?!docs|embed|embed\\.html).*)';
 const APP_ROOT_HOST_PATTERN = '^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$';
 const GLOBAL_CSP_INLINE_SCRIPT_HTML_FILES = [
@@ -2281,7 +2281,7 @@ describe('markdown canonical Link headers (#4999)', () => {
   // agents, so they cannot carry a <link rel="canonical">. RFC 6596 allows the
   // HTTP Link header form; without it these are the only indexable URLs with
   // no canonical signal at all.
-  const MD_PAGES = ['/pricing.md', '/support.md', '/ai-search.md'];
+  const MD_PAGES = ['/pricing.md', '/support.md', '/ai-search.md', '/developers.md', '/mcp-server.md', '/openapi.md', '/sdks.md'];
 
   for (const page of MD_PAGES) {
     it(`${page} declares a self-referencing canonical Link header`, () => {
@@ -2303,6 +2303,57 @@ describe('markdown canonical Link headers (#4999)', () => {
     assert.ok(mdUrls.length > 0, 'expected .md entries in sitemap.xml');
     for (const path of mdUrls) {
       assert.ok(MD_PAGES.includes(path), `${path} is in sitemap.xml but has no canonical Link header rule — add it to vercel.json and this test`);
+    }
+  });
+});
+
+// #4953 — developer-resource discoverability: an agent web-searching "World
+// Monitor MCP server", "World Monitor OpenAPI", "World Monitor developer
+// portal", or "World Monitor SDK" must land on a crawlable page whose H1 names
+// that resource type. Each named page mirrors the auth.md/ai-search.md serving
+// pattern (static public/*.md, excluded from the SPA catch-all, advertised in
+// the discovery chain).
+describe('agent readiness: named developer-resource pages (#4953)', () => {
+  const DEV_PAGES = [
+    { file: 'developers.md', path: '/developers.md', h1: '# World Monitor Developer Portal' },
+    { file: 'mcp-server.md', path: '/mcp-server.md', h1: '# World Monitor MCP Server' },
+    { file: 'openapi.md', path: '/openapi.md', h1: '# World Monitor OpenAPI Specification' },
+    { file: 'sdks.md', path: '/sdks.md', h1: '# World Monitor SDKs' },
+  ];
+
+  const spaCatchAll = () =>
+    vercelConfig.rewrites.find((r) => r.destination === DASHBOARD_HTML_DESTINATION && r.source.startsWith('/((?!'));
+
+  for (const page of DEV_PAGES) {
+    it(`public/${page.file} opens with the brand-named H1 "${page.h1}"`, () => {
+      const body = readFileSync(resolve(__dirname, `../public/${page.file}`), 'utf-8');
+      assert.ok(body.startsWith(`${page.h1}\n`), `public/${page.file} must open with "${page.h1}"`);
+    });
+
+    it(`${page.path} is excluded from the SPA catch-all (serves the static page, not the app shell)`, () => {
+      const catchAll = spaCatchAll();
+      assert.ok(catchAll, 'expected the SPA catch-all rewrite');
+      assert.ok(
+        !sourceToRegExp(catchAll.source).test(page.path),
+        `${page.path} must be excluded from the SPA catch-all rewrite`
+      );
+      assert.ok(
+        !sourceToRegExp(SPA_HTML_CACHE_SOURCE).test(page.path),
+        `${page.path} must be excluded from the pinned HTML-cache catch-all`
+      );
+    });
+  }
+
+  it('advertises the developer portal + resource pages across the discovery chain', () => {
+    const catalog = JSON.parse(readFileSync(resolve(__dirname, '../public/.well-known/api-catalog'), 'utf-8'));
+    const catalogHrefs = catalog.linkset.flatMap((ctx) =>
+      Object.values(ctx).flatMap((v) => (Array.isArray(v) ? v.map((e) => e.href) : []))
+    );
+    const llms = readFileSync(resolve(__dirname, '../public/llms.txt'), 'utf-8');
+    for (const page of DEV_PAGES) {
+      const url = `https://worldmonitor.app${page.path}`;
+      assert.ok(catalogHrefs.includes(url), `api-catalog must advertise ${url}`);
+      assert.ok(llms.includes(page.path), `llms.txt must link ${page.path}`);
     }
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -38,7 +38,7 @@
     { "source": "/dashboard", "has": [{ "type": "host", "value": "happy.worldmonitor.app" }], "destination": "/dashboard-happy.html" },
     { "source": "/dashboard", "has": [{ "type": "host", "value": "energy.worldmonitor.app" }], "destination": "/dashboard-energy.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
-    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
+    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [
     {
@@ -156,6 +156,42 @@
       ]
     },
     {
+      "source": "/developers.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/developers.md>; rel=\"canonical\"" }
+      ]
+    },
+    {
+      "source": "/mcp-server.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/mcp-server.md>; rel=\"canonical\"" }
+      ]
+    },
+    {
+      "source": "/openapi.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/openapi.md>; rel=\"canonical\"" }
+      ]
+    },
+    {
+      "source": "/sdks.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/sdks.md>; rel=\"canonical\"" }
+      ]
+    },
+    {
       "source": "/agent.txt",
       "headers": [
         { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
@@ -253,7 +289,7 @@
       ]
     },
     {
-      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
+      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]


### PR DESCRIPTION
## Summary

Closes #4953. An agent web-searching *"World Monitor MCP server"*, *"World Monitor OpenAPI"*, *"World Monitor developer portal"*, or *"World Monitor SDK"* previously landed on **no page whose title/H1 names that resource type** — only auth docs and API docs were discoverable by name (orank AEO audit 2026-07-06).

This adds four crawlable, **brand-named** markdown pages on the primary origin, mirroring the proven `auth.md` / `ai-search.md` serving pattern:

| Page | H1 |
|------|----|
| `public/developers.md` | **World Monitor Developer Portal** — hub, links every resource type by name |
| `public/mcp-server.md` | **World Monitor MCP Server** |
| `public/openapi.md` | **World Monitor OpenAPI Specification** |
| `public/sdks.md` | **World Monitor SDKs** |

Covers all three candidate fixes in the issue: (1) a named page per resource type, (2) a `/developers.md` portal hub linking every resource by name, (3) cross-links from the indexed "Build on World Monitor" blog post.

## Wiring (per page, matching the existing `.md`-page convention)

- **vercel.json** — excluded from the SPA catch-all (both the rewrite and cache-header negative-lookahead; the pinned `SPA_HTML_CACHE_SOURCE` test constant kept byte-identical) + a per-page `text/markdown; charset=utf-8` header block with ACAO and a self-referencing canonical `Link`.
- **public/sitemap.xml** — registered on the `www` host.
- **public/.well-known/api-catalog** — advertised in `service-meta` (RFC 9727). Kept out of `item[]` because that array's invariant requires every href to also be a context anchor.
- **Discovery surfaces** — cross-linked from `llms.txt`, `llms-full.txt`, `api/llms.txt`, and `agents.md`.
- **Blog** — a "Developer Resources" section naming each type with links, added to the "Build on World Monitor" post (Vercel rebuilds `public/blog/` on deploy).

## Content provenance

All facts (39 MCP tools, endpoints, OAuth flow, rate limits, SDK package names/install commands, OpenAPI URLs) sourced from the authoritative surfaces — `agents.md`, `docs/mcp-overview.mdx`, `docs/sdks.mdx`, `docs/cli.mdx` — so no numbers/URLs drift from canonical values. A round of code review corrected three subtle accuracy issues: the canonical DCR endpoint (`${origin}/oauth/register`), the 50/day MCP daily reservation being per-OAuth-context (Pro **or** API tier, not Pro-only), and the real served `Content-Type` for `/openapi.yaml` (`application/yaml`, not the api-catalog descriptor type).

## Test plan

- [x] `tests/deploy-config.test.mjs` green (144/144) — extended the `#4999` `MD_PAGES` canonical-Link sweep to the four new pages, plus a new `#4953` block asserting each page's brand-named H1, SPA-catch-all exclusion, and advertisement across **every** discovery surface (mirrors the `#4958` guard).
- [x] Affected + guard test batch green (448/448): `llms-txt-mcp-tools`, `sdk-packages`, `cli-package`, `agent-mode-view`, `agent-skills-index`, `mcp-registry-artifacts`, `web-bot-auth-directory`, `blog-*`, `middleware-bot-gate`, etc.
- [x] `edge-functions` tests 218/218, `typecheck` / `typecheck:api` / `version:check` / Biome / `lint:md` all pass.
- [x] Verified independently that every internal link resolves to a real served surface, and that root `.md` pages are crawlable under robots.txt (`Allow: /`).

Related: #3306 (agent-readiness epic), #4854 (pricing-journey discovery chain), #4952/#4955 (sibling robots/agents.md work).

https://claude.ai/code/session_01PH9gAazPGBcj6gpfXCHRbK