### PR TITLE
fix(pipeline): harden AIS relay Upstash detection, mask Redis creds, add EVALSHA-free rate-limit fallback

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -174,6 +174,7 @@ node scripts/seed-military-flights.mjs
 > **`redis-rest` command allowlist**: the bundled proxy (`docker/redis-rest-proxy.mjs`) only
 > forwards a fixed allowlist of Redis commands and rejects `EVAL`/`EVALSHA`/`SCRIPT` (no Lua
 > scripting). Two consequences for a self-hosted stack:
+>
 > - `@upstash/ratelimit`'s Lua-based sliding-window limiter (`server/_shared/rate-limit.ts`,
 >   `api/_rate-limit.js`) can't run against it. Both automatically detect the rejection once and
 >   fall back to a non-Lua fixed-window limiter (`INCR` + `EXPIRE NX`) for the rest of the
@@ -181,7 +182,7 @@ node scripts/seed-military-flights.mjs
 > - `scripts/ais-relay.cjs`'s own in-container seed loops (`UPSTASH_ENABLED`) also require
 >   `UPSTASH_REDIS_REST_URL` to start with `https://` by default, which the plain-HTTP proxy
 >   never satisfies. Set `UPSTASH_ALLOW_INSECURE_HTTP=true` on the `ais-relay` service (already
->   wired for `redis-rest` in `docker-compose.override.yml`) to opt into using the proxy from
+>   wired for `redis-rest` in `docker-compose.yml`) to opt into using the proxy from
 >   inside the relay container.
 
 ## 🔨 Building from Source

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -171,6 +171,19 @@ node scripts/seed-military-flights.mjs
 | `worldmonitor-redis-rest` | Upstash-compatible REST proxy | 8079 |
 | `worldmonitor-ais-relay` | Live vessel tracking WebSocket | 3004 (internal) |
 
+> **`redis-rest` command allowlist**: the bundled proxy (`docker/redis-rest-proxy.mjs`) only
+> forwards a fixed allowlist of Redis commands and rejects `EVAL`/`EVALSHA`/`SCRIPT` (no Lua
+> scripting). Two consequences for a self-hosted stack:
+> - `@upstash/ratelimit`'s Lua-based sliding-window limiter (`server/_shared/rate-limit.ts`,
+>   `api/_rate-limit.js`) can't run against it. Both automatically detect the rejection once and
+>   fall back to a non-Lua fixed-window limiter (`INCR` + `EXPIRE NX`) for the rest of the
+>   process — rate limiting still enforces, just with fixed- instead of sliding-window semantics.
+> - `scripts/ais-relay.cjs`'s own in-container seed loops (`UPSTASH_ENABLED`) also require
+>   `UPSTASH_REDIS_REST_URL` to start with `https://` by default, which the plain-HTTP proxy
+>   never satisfies. Set `UPSTASH_ALLOW_INSECURE_HTTP=true` on the `ais-relay` service (already
+>   wired for `redis-rest` in `docker-compose.override.yml`) to opt into using the proxy from
+>   inside the relay container.
+
 ## 🔨 Building from Source
 
 ```bash

--- a/api/_rate-limit-fallback.js
+++ b/api/_rate-limit-fallback.js
@@ -1,0 +1,80 @@
+import { redisPipeline } from './_upstash-json.js';
+
+const FALLBACK_REDIS_TIMEOUT_MS = 1_000;
+
+let luaUnsupported = false;
+
+// Duration parsing mirrors @upstash/ratelimit's internal (unexported) `ms()`
+// helper. Needed only so the non-Lua fallback can pass a plain-seconds EXPIRE.
+export function durationToSeconds(window) {
+  const match = /^(\d+)\s?(ms|s|m|h|d)$/.exec(window);
+  if (!match) throw new Error(`Unable to parse rate-limit window: ${window}`);
+  const value = Number(match[1]);
+  const unit = match[2] ?? 's';
+  const unitSeconds = { ms: 0.001, s: 1, m: 60, h: 3600, d: 86_400 };
+  return Math.max(1, Math.ceil(value * (unitSeconds[unit] ?? 1)));
+}
+
+function commandError(entry, command) {
+  if (!entry?.error) return null;
+  return new Error(`rate-limit fallback: ${command} failed: ${entry.error}`);
+}
+
+// Non-Lua fixed-window fallback: INCR + EXPIRE-NX + TTL over the plain REST
+// pipeline endpoint (no EVAL/EVALSHA/SCRIPT). EXPIRE's NX flag requires Redis
+// 7+; if a self-hosted Redis 6 endpoint returns a per-command error or leaves
+// the key without a TTL, degrade instead of creating a permanent counter.
+async function fixedWindowLimit(key, limit, windowSeconds) {
+  const result = await redisPipeline([
+    ['INCR', key],
+    ['EXPIRE', key, String(windowSeconds), 'NX'],
+    ['TTL', key],
+  ], FALLBACK_REDIS_TIMEOUT_MS);
+  if (!result) throw new Error('rate-limit fallback: Redis pipeline unavailable');
+
+  const incrError = commandError(result[0], 'INCR');
+  if (incrError) throw incrError;
+  const expireError = commandError(result[1], 'EXPIRE');
+  if (expireError) throw expireError;
+  const ttlError = commandError(result[2], 'TTL');
+  if (ttlError) throw ttlError;
+
+  const count = Number(result[0]?.result ?? 0);
+  if (!Number.isFinite(count) || count < 1) {
+    throw new Error(`rate-limit fallback: invalid Redis counter (${String(result[0]?.result)})`);
+  }
+
+  const ttlRaw = Number(result[2]?.result ?? -1);
+  if (!Number.isFinite(ttlRaw) || ttlRaw < 0) {
+    throw new Error(`rate-limit fallback: Redis key has no expiry (ttl=${String(result[2]?.result ?? 'missing')})`);
+  }
+
+  return { success: count <= limit, limit, reset: Date.now() + ttlRaw * 1000 };
+}
+
+// Drop-in replacement for `ratelimit.limit(identifier)` that transparently
+// falls back to fixedWindowLimit the moment EVAL/EVALSHA is detected as
+// unsupported. Any OTHER Lua-path error is rethrown unchanged so existing
+// per-caller fail-open/failClosed + Sentry handling is untouched.
+export async function limitWithFallback(rl, identifier, fallbackKey, limit, windowSeconds) {
+  if (!luaUnsupported) {
+    try {
+      return await rl.limit(identifier);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/Command not allowed: (EVAL|EVALSHA|SCRIPT)\b/i.test(msg)) throw err;
+      luaUnsupported = true;
+      console.warn('[rate-limit] EVAL/EVALSHA rejected by this Redis endpoint — switching to the non-Lua fixed-window fallback for the rest of this process');
+    }
+  }
+
+  try {
+    return await fixedWindowLimit(fallbackKey, limit, windowSeconds);
+  } catch (err) {
+    throw new Error('rate-limit fallback: Redis unavailable', { cause: err });
+  }
+}
+
+export function resetRateLimitFallbackForTest() {
+  luaUnsupported = false;
+}

--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -2,7 +2,11 @@ import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
-import { redisPipeline } from './_upstash-json.js';
+import {
+  durationToSeconds,
+  limitWithFallback,
+  resetRateLimitFallbackForTest,
+} from './_rate-limit-fallback.js';
 import {
   RATE_LIMIT_DEGRADED_HEADERS,
   getClientIp,
@@ -24,78 +28,6 @@ const REDIS_TEST_RETRY_OPTS = process.env.NODE_TEST_CONTEXT ? { retry: false } :
 const DEFAULT_RATE_LIMIT_SCOPE = 'global';
 const DEFAULT_RATE_LIMIT = 600;
 const DEFAULT_RATE_LIMIT_WINDOW = '60 s';
-
-// Duration parsing — same regex as @upstash/ratelimit's internal (unexported)
-// `ms()` helper. Mirrored verbatim in server/_shared/rate-limit.ts.
-function durationToSeconds(window) {
-  const match = /^(\d+)\s?(ms|s|m|h|d)$/.exec(window);
-  if (!match) throw new Error(`Unable to parse rate-limit window: ${window}`);
-  const value = Number(match[1]);
-  const unit = match[2] ?? 's';
-  const unitSeconds = { ms: 0.001, s: 1, m: 60, h: 3600, d: 86_400 };
-  return Math.max(1, Math.ceil(value * (unitSeconds[unit] ?? 1)));
-}
-
-// The self-hosted redis-rest proxy (docker/redis-rest-proxy.mjs) blocks
-// EVAL/EVALSHA/SCRIPT via its command allowlist. @upstash/ratelimit's
-// sliding-window limiter is a Lua script run via EVALSHA (falling back to
-// EVAL on NOSCRIPT) — against that proxy every `.limit()` call throws an
-// UpstashError wrapping the proxy's `Command not allowed: EVALSHA` (or
-// `EVAL`/`SCRIPT`) body. Detect that once per process and switch to the
-// non-Lua fallback below — retrying the Lua path on every request would
-// just double every rate-limit check's latency forever. Mirrored verbatim
-// in server/_shared/rate-limit.ts.
-let luaUnsupported = false;
-
-const FALLBACK_REDIS_TIMEOUT_MS = 1_000;
-
-// Non-Lua fixed-window fallback: INCR + EXPIRE-NX + TTL over the plain REST
-// pipeline endpoint (no EVAL/EVALSHA/SCRIPT). Mirrors the pattern already
-// proven in production by
-// api/_user-api-key.js::checkBootstrapUserApiKeyRateLimit — EXPIRE's NX flag
-// (Redis 7+) means whichever concurrent caller's INCR happens to be first
-// also wins the one-time TTL set; every other command in the window no-ops
-// on EXPIRE, so there's no double-set race and no crash-between-INCR-and-
-// EXPIRE gap to reason about. Returns null when Redis itself is
-// unreachable — callers treat that identically to a Lua-path outage
-// (existing fail-open / failClosed handling below).
-async function fixedWindowLimit(key, limit, windowSeconds) {
-  const result = await redisPipeline([
-    ['INCR', key],
-    ['EXPIRE', key, String(windowSeconds), 'NX'],
-    ['TTL', key],
-  ], FALLBACK_REDIS_TIMEOUT_MS);
-  if (!result) return null;
-
-  const count = Number(result[0]?.result ?? 0);
-  if (!Number.isFinite(count) || count < 1) return null;
-
-  const ttlRaw = Number(result[2]?.result ?? -1);
-  const ttlSeconds = Number.isFinite(ttlRaw) && ttlRaw >= 0 ? ttlRaw : windowSeconds;
-
-  return { success: count <= limit, limit, reset: Date.now() + ttlSeconds * 1000 };
-}
-
-// Drop-in replacement for `ratelimit.limit(identifier)` that transparently
-// falls back to fixedWindowLimit the moment EVAL/EVALSHA is detected as
-// unsupported. Any OTHER error (genuine Redis outage/timeout) is rethrown
-// unchanged so the existing per-caller fail-open/failClosed + Sentry
-// reporting below is untouched.
-async function limitWithFallback(rl, identifier, fallbackKey, limit, windowSeconds) {
-  if (!luaUnsupported) {
-    try {
-      return await rl.limit(identifier);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!/Command not allowed: (EVAL|EVALSHA|SCRIPT)\b/i.test(msg)) throw err;
-      luaUnsupported = true;
-      console.warn('[rate-limit] EVAL/EVALSHA rejected by this Redis endpoint — switching to the non-Lua fixed-window fallback for the rest of this process');
-    }
-  }
-  const fallback = await fixedWindowLimit(fallbackKey, limit, windowSeconds);
-  if (!fallback) throw new Error('rate-limit fallback: Redis unreachable');
-  return fallback;
-}
 
 let ratelimits = new Map();
 
@@ -140,7 +72,7 @@ function getRatelimit(policy) {
 // Mirrored verbatim in server/_shared/rate-limit.ts.
 function rateLimitErrorLevel(stage, msg) {
   if (stage.includes('missing-config')) return 'error';
-  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|socket hang up/i.test(msg)) {
+  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|socket hang up|Redis unavailable|Redis unreachable/i.test(msg)) {
     return 'warning';
   }
   return 'error';
@@ -224,5 +156,5 @@ export async function checkRateLimit(request, corsHeaders, opts = {}) {
 
 export function __resetRateLimitForTest() {
   ratelimits = new Map();
-  luaUnsupported = false;
+  resetRateLimitFallbackForTest();
 }

--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -2,6 +2,7 @@ import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
+import { redisPipeline } from './_upstash-json.js';
 import {
   RATE_LIMIT_DEGRADED_HEADERS,
   getClientIp,
@@ -23,6 +24,78 @@ const REDIS_TEST_RETRY_OPTS = process.env.NODE_TEST_CONTEXT ? { retry: false } :
 const DEFAULT_RATE_LIMIT_SCOPE = 'global';
 const DEFAULT_RATE_LIMIT = 600;
 const DEFAULT_RATE_LIMIT_WINDOW = '60 s';
+
+// Duration parsing — same regex as @upstash/ratelimit's internal (unexported)
+// `ms()` helper. Mirrored verbatim in server/_shared/rate-limit.ts.
+function durationToSeconds(window) {
+  const match = /^(\d+)\s?(ms|s|m|h|d)$/.exec(window);
+  if (!match) throw new Error(`Unable to parse rate-limit window: ${window}`);
+  const value = Number(match[1]);
+  const unit = match[2] ?? 's';
+  const unitSeconds = { ms: 0.001, s: 1, m: 60, h: 3600, d: 86_400 };
+  return Math.max(1, Math.ceil(value * (unitSeconds[unit] ?? 1)));
+}
+
+// The self-hosted redis-rest proxy (docker/redis-rest-proxy.mjs) blocks
+// EVAL/EVALSHA/SCRIPT via its command allowlist. @upstash/ratelimit's
+// sliding-window limiter is a Lua script run via EVALSHA (falling back to
+// EVAL on NOSCRIPT) — against that proxy every `.limit()` call throws an
+// UpstashError wrapping the proxy's `Command not allowed: EVALSHA` (or
+// `EVAL`/`SCRIPT`) body. Detect that once per process and switch to the
+// non-Lua fallback below — retrying the Lua path on every request would
+// just double every rate-limit check's latency forever. Mirrored verbatim
+// in server/_shared/rate-limit.ts.
+let luaUnsupported = false;
+
+const FALLBACK_REDIS_TIMEOUT_MS = 1_000;
+
+// Non-Lua fixed-window fallback: INCR + EXPIRE-NX + TTL over the plain REST
+// pipeline endpoint (no EVAL/EVALSHA/SCRIPT). Mirrors the pattern already
+// proven in production by
+// api/_user-api-key.js::checkBootstrapUserApiKeyRateLimit — EXPIRE's NX flag
+// (Redis 7+) means whichever concurrent caller's INCR happens to be first
+// also wins the one-time TTL set; every other command in the window no-ops
+// on EXPIRE, so there's no double-set race and no crash-between-INCR-and-
+// EXPIRE gap to reason about. Returns null when Redis itself is
+// unreachable — callers treat that identically to a Lua-path outage
+// (existing fail-open / failClosed handling below).
+async function fixedWindowLimit(key, limit, windowSeconds) {
+  const result = await redisPipeline([
+    ['INCR', key],
+    ['EXPIRE', key, String(windowSeconds), 'NX'],
+    ['TTL', key],
+  ], FALLBACK_REDIS_TIMEOUT_MS);
+  if (!result) return null;
+
+  const count = Number(result[0]?.result ?? 0);
+  if (!Number.isFinite(count) || count < 1) return null;
+
+  const ttlRaw = Number(result[2]?.result ?? -1);
+  const ttlSeconds = Number.isFinite(ttlRaw) && ttlRaw >= 0 ? ttlRaw : windowSeconds;
+
+  return { success: count <= limit, limit, reset: Date.now() + ttlSeconds * 1000 };
+}
+
+// Drop-in replacement for `ratelimit.limit(identifier)` that transparently
+// falls back to fixedWindowLimit the moment EVAL/EVALSHA is detected as
+// unsupported. Any OTHER error (genuine Redis outage/timeout) is rethrown
+// unchanged so the existing per-caller fail-open/failClosed + Sentry
+// reporting below is untouched.
+async function limitWithFallback(rl, identifier, fallbackKey, limit, windowSeconds) {
+  if (!luaUnsupported) {
+    try {
+      return await rl.limit(identifier);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/Command not allowed: (EVAL|EVALSHA|SCRIPT)\b/i.test(msg)) throw err;
+      luaUnsupported = true;
+      console.warn('[rate-limit] EVAL/EVALSHA rejected by this Redis endpoint — switching to the non-Lua fixed-window fallback for the rest of this process');
+    }
+  }
+  const fallback = await fixedWindowLimit(fallbackKey, limit, windowSeconds);
+  if (!fallback) throw new Error('rate-limit fallback: Redis unreachable');
+  return fallback;
+}
 
 let ratelimits = new Map();
 
@@ -122,7 +195,14 @@ export async function checkRateLimit(request, corsHeaders, opts = {}) {
 
   const ip = getClientIp(request);
   try {
-    const { success, limit, reset } = await rl.limit(ip);
+    const fallbackPrefix = policy.scope === DEFAULT_RATE_LIMIT_SCOPE ? 'rl:fw' : `rl:${policy.scope}:fw`;
+    const { success, limit, reset } = await limitWithFallback(
+      rl,
+      ip,
+      `${fallbackPrefix}:${ip}`,
+      policy.limit,
+      durationToSeconds(policy.window),
+    );
 
     if (!success) {
       return jsonResponse({ error: 'Too many requests' }, 429, {
@@ -144,4 +224,5 @@ export async function checkRateLimit(request, corsHeaders, opts = {}) {
 
 export function __resetRateLimitForTest() {
   ratelimits = new Map();
+  luaUnsupported = false;
 }

--- a/api/_rate-limit.test.mjs
+++ b/api/_rate-limit.test.mjs
@@ -222,3 +222,96 @@ describe('api/_rate-limit constants parity', () => {
     assert.equal(RATE_LIMIT_DEGRADED_HEADERS['Retry-After'], '5');
   });
 });
+
+describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors tests/rate-limit.test.mts #7c)', () => {
+  // The api/ mirror was only covered by the constants-parity block above —
+  // if this file's limitWithFallback drifts from server/_shared/rate-limit.ts
+  // or mishandles the redis-rest proxy's "Command not allowed: EVALSHA"
+  // response, API routes could keep failing while the tested server helper
+  // stays green. Exercise the mirror's own fallback path end to end.
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  });
+
+  // Faithful in-memory INCR + EXPIRE-NX + TTL, gated by the same command
+  // allowlist docker/redis-rest-proxy.mjs enforces — mirrors the handler in
+  // tests/rate-limit.test.mts so both surfaces are proven against identical
+  // proxy behaviour.
+  const ALLOWED_COMMANDS = new Set(['INCR', 'EXPIRE', 'TTL']);
+
+  function makeProxyPipelineHandler() {
+    const store = new Map();
+    return (commands) =>
+      commands.map((cmd) => {
+        const op = String(cmd[0]).toUpperCase();
+        if (!ALLOWED_COMMANDS.has(op)) return { error: `Command not allowed: ${op}` };
+        const key = String(cmd[1]);
+        const entry = store.get(key) ?? { count: 0, hasTtl: false };
+        if (op === 'INCR') {
+          entry.count += 1;
+          store.set(key, entry);
+          return { result: entry.count };
+        }
+        if (op === 'EXPIRE') {
+          const applied = !entry.hasTtl;
+          if (applied) entry.hasTtl = true;
+          store.set(key, entry);
+          return { result: applied ? 1 : 0 };
+        }
+        return { result: entry.hasTtl ? 60 : -1 }; // TTL
+      });
+  }
+
+  it('detects "Command not allowed: EVALSHA", falls back to INCR+EXPIRE without retrying Lua, and enforces 429s', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    let luaAttempts = 0;
+    let fetchCalls = 0;
+    globalThis.fetch = async (_url, init) => {
+      fetchCalls++;
+      const commands = JSON.parse(String(init?.body));
+      if (commands.some((c) => /^(EVAL|EVALSHA|SCRIPT)$/i.test(String(c[0])))) luaAttempts++;
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    };
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'cf-connecting-ip': '203.0.113.9' });
+
+    const first = await mod.checkRateLimit(req, {});
+    assert.equal(first, null, 'first request is under the global limit');
+    assert.equal(luaAttempts, 1, 'exactly one Lua attempt before the unsupported-command detection latches');
+    assert.equal(fetchCalls, 2, 'the failed Lua attempt plus its immediate fallback pipeline call');
+
+    const second = await mod.checkRateLimit(req, {});
+    assert.equal(second, null, 'second request is still under the limit');
+    assert.equal(luaAttempts, 1, 'Lua must not be retried once EVALSHA is known unsupported');
+    assert.equal(fetchCalls, 3, 'no further Lua attempts — only the fallback pipeline call');
+
+    // Drive the same identifier past the global fixed-window limit purely
+    // through the fallback path until checkRateLimit enforces a 429. Bound
+    // generously above the known GLOBAL_RATE_LIMIT (600) so a source change
+    // to the limit can't turn this into an infinite loop.
+    let res = null;
+    let iterations = 0;
+    while (!res && iterations < 1000) {
+      res = await mod.checkRateLimit(req, {});
+      iterations++;
+    }
+
+    assert.ok(res, 'expected checkRateLimit to eventually return a 429 Response');
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+    assert.ok(res.headers.get('Retry-After'), 'expected a Retry-After header on the 429');
+    assert.equal(luaAttempts, 1, 'Lua must stay latched off while the fallback enforces the window');
+
+    // A different identifier gets its own independent fixed window.
+    const otherReq = makeRequest({ 'cf-connecting-ip': '203.0.113.10' });
+    const other = await mod.checkRateLimit(otherReq, {});
+    assert.equal(other, null, 'a different identifier has its own fixed-window counter');
+  });
+});

--- a/api/_rate-limit.test.mjs
+++ b/api/_rate-limit.test.mjs
@@ -280,7 +280,7 @@ describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors t
     };
 
     const mod = await importFreshRateLimitModule();
-    const req = makeRequest({ 'cf-connecting-ip': '203.0.113.9' });
+    const req = makeRequest({ 'x-real-ip': '203.0.113.9' });
 
     const first = await mod.checkRateLimit(req, {});
     assert.equal(first, null, 'first request is under the global limit');
@@ -310,7 +310,7 @@ describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors t
     assert.equal(luaAttempts, 1, 'Lua must stay latched off while the fallback enforces the window');
 
     // A different identifier gets its own independent fixed window.
-    const otherReq = makeRequest({ 'cf-connecting-ip': '203.0.113.10' });
+    const otherReq = makeRequest({ 'x-real-ip': '203.0.113.10' });
     const other = await mod.checkRateLimit(otherReq, {});
     assert.equal(other, null, 'a different identifier has its own fixed-window counter');
   });

--- a/api/_rate-limit.test.mjs
+++ b/api/_rate-limit.test.mjs
@@ -236,6 +236,7 @@ describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors t
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    __resetRateLimitForTest();
     restoreEnv();
   });
 
@@ -245,7 +246,7 @@ describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors t
   // proxy behaviour.
   const ALLOWED_COMMANDS = new Set(['INCR', 'EXPIRE', 'TTL']);
 
-  function makeProxyPipelineHandler() {
+  function makeProxyPipelineHandler({ expireNxUnsupported = false } = {}) {
     const store = new Map();
     return (commands) =>
       commands.map((cmd) => {
@@ -259,6 +260,9 @@ describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors t
           return { result: entry.count };
         }
         if (op === 'EXPIRE') {
+          if (expireNxUnsupported && String(cmd[3]).toUpperCase() === 'NX') {
+            return { error: 'ERR syntax error' };
+          }
           const applied = !entry.hasTtl;
           if (applied) entry.hasTtl = true;
           store.set(key, entry);
@@ -267,6 +271,33 @@ describe('api/_rate-limit checkRateLimit EVALSHA-unsupported fallback (mirrors t
         return { result: entry.hasTtl ? 60 : -1 }; // TTL
       });
   }
+
+  it('degrades instead of creating a permanent counter when EXPIRE NX is unsupported', async () => {
+    const pipelineHandler = makeProxyPipelineHandler({ expireNxUnsupported: true });
+    globalThis.fetch = async (_url, init) => {
+      const commands = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    };
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.12' });
+
+    const failOpen = await mod.checkRateLimit(
+      req,
+      {},
+      { scope: 'redis6-fallback', limit: 1, window: '60 s' },
+    );
+    assert.equal(failOpen, null, 'default API rate limit should fail open when fallback cannot set a TTL');
+
+    const failClosed = await mod.checkRateLimit(
+      req,
+      {},
+      { scope: 'redis6-fallback', limit: 1, window: '60 s', failClosed: true },
+    );
+    assert.ok(failClosed, 'failClosed API callers should receive a degraded response when fallback cannot set a TTL');
+    assert.equal(failClosed.status, 503);
+    assert.equal(failClosed.headers.get('X-RateLimit-Mode'), 'degraded');
+  });
 
   it('detects "Command not allowed: EVALSHA", falls back to INCR+EXPIRE without retrying Lua, and enforces 429s', async () => {
     const pipelineHandler = makeProxyPipelineHandler();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,13 @@ services:
     container_name: worldmonitor-ais-relay
     environment:
       AISSTREAM_API_KEY: "${AISSTREAM_API_KEY:-}"
+      UPSTASH_REDIS_REST_URL: "http://redis-rest:80"
+      UPSTASH_REDIS_REST_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
+      UPSTASH_ALLOW_INSECURE_HTTP: "true"
       PORT: "3004"
+    depends_on:
+      redis-rest:
+        condition: service_started
     restart: unless-stopped
 
   redis:

--- a/docker/redis-rest-proxy.mjs
+++ b/docker/redis-rest-proxy.mjs
@@ -23,10 +23,24 @@ const REDIS_URL = process.env.SRH_CONNECTION_STRING || process.env.REDIS_URL || 
 const TOKEN = process.env.SRH_TOKEN || '';
 const PORT = parseInt(process.env.PORT || '80', 10);
 
+// Redact userinfo before a connection string ever reaches stdout — REDIS_URL
+// carries the Redis password (SRH_CONNECTION_STRING: redis://:<password>@host:port)
+// and docker logs are readable by anyone with docker/compose access.
+function maskRedisUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.password) parsed.password = '***';
+    if (parsed.username) parsed.username = '***';
+    return parsed.toString();
+  } catch {
+    return '<unparsable redis URL>';
+  }
+}
+
 const client = createClient({ url: REDIS_URL });
 client.on('error', (err) => console.error('Redis error:', err.message));
 await client.connect();
-console.log(`Connected to Redis at ${REDIS_URL}`);
+console.log(`Connected to Redis at ${maskRedisUrl(REDIS_URL)}`);
 
 function checkAuth(req) {
   if (!TOKEN) return true;

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:feeds:ci": "node scripts/validate-rss-feeds.mjs --ci",
-    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs src-tauri/open-url-safety.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/_sentry-common.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
+    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs src-tauri/open-url-safety.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/_rate-limit.test.mjs api/_sentry-common.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual": "npm run test:e2e:visual:full && npm run test:e2e:visual:tech",

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -205,7 +205,7 @@ const UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || '';
 // transiting the public internet in cleartext) doesn't apply there. This
 // gate stayed https-only after the local proxy shipped, so every seed loop
 // in this file silently no-ops against http://redis-rest:80 (see
-// docker-compose.override.yml's UPSTASH_* comment + 4+ days of
+// SELF_HOSTING.md's redis-rest command allowlist note + 4+ days of
 // "[TransitSummary]"/"[CorridorRisk]"/etc. never firing).
 // UPSTASH_ALLOW_INSECURE_HTTP is an explicit, off-by-default opt-in (never
 // inferred from hostname/URL shape) so a genuine Upstash misconfiguration in

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -198,20 +198,38 @@ if (RELAY_SHARED_SECRET && ALLOW_UNAUTHENTICATED_RELAY) {
 // ─────────────────────────────────────────────────────────────
 const UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL || '';
 const UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || '';
+// Self-hosted deployments front Redis with a plain-http REST proxy
+// (docker/redis-rest-proxy.mjs) reachable only inside the compose network —
+// there's no TLS to terminate and no public exposure, so the https-only
+// requirement below (which exists to stop a *real* Upstash bearer token from
+// transiting the public internet in cleartext) doesn't apply there. This
+// gate stayed https-only after the local proxy shipped, so every seed loop
+// in this file silently no-ops against http://redis-rest:80 (see
+// docker-compose.override.yml's UPSTASH_* comment + 4+ days of
+// "[TransitSummary]"/"[CorridorRisk]"/etc. never firing).
+// UPSTASH_ALLOW_INSECURE_HTTP is an explicit, off-by-default opt-in (never
+// inferred from hostname/URL shape) so a genuine Upstash misconfiguration in
+// production can't silently downgrade to plaintext.
+const UPSTASH_ALLOW_INSECURE_HTTP = process.env.UPSTASH_ALLOW_INSECURE_HTTP === 'true';
 const UPSTASH_ENABLED = !!(
   UPSTASH_REDIS_REST_URL &&
   UPSTASH_REDIS_REST_TOKEN &&
-  UPSTASH_REDIS_REST_URL.startsWith('https://')
+  (UPSTASH_REDIS_REST_URL.startsWith('https://') ||
+    (UPSTASH_ALLOW_INSECURE_HTTP && UPSTASH_REDIS_REST_URL.startsWith('http://')))
 );
+// Node's https module can't speak to a plain-http endpoint — resolve the
+// matching client once at startup instead of hardcoding https.request at
+// each upstash* call site below.
+const UPSTASH_HTTP_MODULE = UPSTASH_REDIS_REST_URL.startsWith('http://') ? http : https;
 const RELAY_ENV_PREFIX = process.env.RELAY_ENV ? `${process.env.RELAY_ENV}:` : '';
 const OREF_REDIS_KEY = `${RELAY_ENV_PREFIX}relay:oref:history:v1`;
 const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
 
-if (UPSTASH_REDIS_REST_URL && !UPSTASH_REDIS_REST_URL.startsWith('https://')) {
-  console.warn('[Relay] UPSTASH_REDIS_REST_URL must start with https:// — Redis disabled');
+if (UPSTASH_REDIS_REST_URL && !UPSTASH_REDIS_REST_URL.startsWith('https://') && !UPSTASH_ALLOW_INSECURE_HTTP) {
+  console.warn('[Relay] UPSTASH_REDIS_REST_URL must start with https:// — Redis disabled (set UPSTASH_ALLOW_INSECURE_HTTP=true for a trusted internal http proxy)');
 }
 if (UPSTASH_ENABLED) {
-  console.log(`[Relay] Upstash Redis enabled (key: ${OREF_REDIS_KEY})`);
+  console.log(`[Relay] Upstash Redis enabled (key: ${OREF_REDIS_KEY}${UPSTASH_REDIS_REST_URL.startsWith('http://') ? ', insecure-http opt-in' : ''})`);
 }
 
 function upstashGet(key, onFailure) {
@@ -230,7 +248,7 @@ function upstashGet(key, onFailure) {
       resolve(null);
     };
     const url = new URL(`/get/${encodeURIComponent(key)}`, UPSTASH_REDIS_REST_URL);
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'GET',
       headers: { Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}` },
       timeout: 5000,
@@ -268,7 +286,7 @@ function upstashSet(key, value, ttlSeconds) {
     if (!UPSTASH_ENABLED) return resolve(false);
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const body = JSON.stringify(['SET', key, JSON.stringify(value), 'EX', String(ttlSeconds)]);
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
@@ -296,7 +314,7 @@ function upstashExpire(key, ttlSeconds) {
     if (!UPSTASH_ENABLED) return resolve(false);
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const body = JSON.stringify(['EXPIRE', key, String(ttlSeconds)]);
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
@@ -324,7 +342,7 @@ function upstashMGet(keys) {
     if (!UPSTASH_ENABLED || keys.length === 0) return resolve([]);
     const url = new URL('/pipeline', UPSTASH_REDIS_REST_URL);
     const body = JSON.stringify(keys.map((k) => ['GET', k]));
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
@@ -360,7 +378,7 @@ function upstashLpush(key, value) {
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const serialized = typeof value === 'string' ? value : JSON.stringify(value);
     const body = JSON.stringify(['LPUSH', key, serialized]);
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
@@ -389,7 +407,7 @@ function upstashSetNx(key, value, ttlSeconds) {
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const serialized = typeof value === 'string' ? value : JSON.stringify(value);
     const body = JSON.stringify(['SET', key, serialized, 'NX', 'EX', String(ttlSeconds)]);
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
@@ -498,7 +516,7 @@ function upstashDel(key) {
     if (!UPSTASH_ENABLED) return resolve(false);
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const body = JSON.stringify(['DEL', key]);
-    const req = https.request(url, {
+    const req = UPSTASH_HTTP_MODULE.request(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
@@ -555,8 +573,8 @@ function envelopeWrite(key, data, ttlSeconds, meta) {
 // passes legacy shapes through unchanged. MUST be used for any seeded canonical
 // key — reading raw via upstashGet() on an enveloped key iterates {_seed, data}
 // as payload keys and silently corrupts downstream consumers.
-async function envelopeRead(key) {
-  const raw = await upstashGet(key);
+async function envelopeRead(key, onFailure) {
+  const raw = await upstashGet(key, onFailure);
   if (raw && typeof raw === 'object' && !Array.isArray(raw) && '_seed' in raw && 'data' in raw) {
     return raw.data;
   }
@@ -7719,8 +7737,17 @@ function detectTrafficAnomalyRelay(history, threatLevel) {
 }
 
 async function seedTransitSummaries() {
-  const pw = await envelopeRead(PORTWATCH_REDIS_KEY);
-  if (!pw || typeof pw !== 'object' || Object.keys(pw).length === 0) return;
+  let pwFailureReason = null;
+  const pw = await envelopeRead(PORTWATCH_REDIS_KEY, (reason) => { pwFailureReason = reason; });
+  if (!pw || typeof pw !== 'object' || Object.keys(pw).length === 0) {
+    const reason = !UPSTASH_ENABLED
+      ? 'Upstash Redis disabled — see [Relay] startup warning (UPSTASH_REDIS_REST_URL/UPSTASH_ALLOW_INSECURE_HTTP)'
+      : pwFailureReason
+        ? `read failed: ${pwFailureReason}`
+        : 'key empty or absent — upstream seeder has not written it yet';
+    console.warn(`[TransitSummary] Skipped — ${PORTWATCH_REDIS_KEY} unavailable (${reason})`);
+    return;
+  }
 
   if (!latestCorridorRiskData) {
     const persisted = await envelopeRead(CORRIDOR_RISK_REDIS_KEY);

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -2,6 +2,8 @@ import { Ratelimit, type Duration } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../api/_sentry-edge.js';
+// @ts-expect-error — JS module, no declaration file
+import { redisPipeline } from '../../api/_upstash-json.js';
 
 // @upstash/redis defaults to 5 retries with exponential backoff (~4.3s total)
 // before surfacing an unreachable-Redis error. The node test runner sets
@@ -13,7 +15,87 @@ import { captureSilentError } from '../../api/_sentry-edge.js';
 // MCP limiter to unblock the suite (PR #3963).
 const REDIS_TEST_RETRY_OPTS: { retry?: false } = process.env.NODE_TEST_CONTEXT ? { retry: false } : {};
 
+// Duration parsing mirrors @upstash/ratelimit's internal (unexported) `ms()`
+// helper — needed only so the non-Lua fallback below can pass a plain-seconds
+// EXPIRE argument. Not worth a dependency: same regex, ~10 lines.
+function durationToSeconds(window: Duration): number {
+  const match = /^(\d+)\s?(ms|s|m|h|d)$/.exec(window);
+  if (!match) throw new Error(`Unable to parse rate-limit window: ${window}`);
+  const value = Number(match[1]);
+  const unit = match[2] ?? 's';
+  const unitSeconds: Record<string, number> = { ms: 0.001, s: 1, m: 60, h: 3600, d: 86_400 };
+  return Math.max(1, Math.ceil(value * (unitSeconds[unit] ?? 1)));
+}
+
+// The self-hosted redis-rest proxy (docker/redis-rest-proxy.mjs) blocks
+// EVAL/EVALSHA/SCRIPT via its command allowlist. @upstash/ratelimit's
+// sliding-window limiter is a Lua script run via EVALSHA (falling back to
+// EVAL on NOSCRIPT) — against that proxy every `.limit()` call throws an
+// UpstashError wrapping the proxy's `Command not allowed: EVALSHA` (or
+// `EVAL`/`SCRIPT`) body. Detect that once per process and switch every
+// limiter below to the non-Lua fallback — retrying the Lua path on each
+// request would just double every rate-limit check's latency forever.
+let luaUnsupported = false;
+
+const FALLBACK_REDIS_TIMEOUT_MS = 1_000;
+
+interface LimitResult {
+  success: boolean;
+  limit: number;
+  reset: number;
+}
+
+// Non-Lua fixed-window fallback: INCR + EXPIRE-NX + TTL over the plain REST
+// pipeline endpoint (no EVAL/EVALSHA/SCRIPT). Mirrors the pattern already
+// proven in production by api/_user-api-key.js::checkBootstrapUserApiKeyRateLimit
+// — EXPIRE's NX flag (Redis 7+) means whichever concurrent caller's INCR
+// happens to be first also wins the one-time TTL set; every other command in
+// the window no-ops on EXPIRE, so there's no double-set race and no
+// crash-between-INCR-and-EXPIRE gap to reason about. Returns null when Redis
+// itself is unreachable — callers treat that identically to a Lua-path
+// outage (existing fail-open / failClosed handling below).
+async function fixedWindowLimit(key: string, limit: number, windowSeconds: number): Promise<LimitResult | null> {
+  const result = await redisPipeline([
+    ['INCR', key],
+    ['EXPIRE', key, String(windowSeconds), 'NX'],
+    ['TTL', key],
+  ], FALLBACK_REDIS_TIMEOUT_MS);
+  if (!result) return null;
+
+  const count = Number(result[0]?.result ?? 0);
+  if (!Number.isFinite(count) || count < 1) return null;
+
+  const ttlRaw = Number(result[2]?.result ?? -1);
+  const ttlSeconds = Number.isFinite(ttlRaw) && ttlRaw >= 0 ? ttlRaw : windowSeconds;
+
+  return { success: count <= limit, limit, reset: Date.now() + ttlSeconds * 1000 };
+}
+
+// Drop-in replacement for `ratelimit.limit(identifier)` that transparently
+// falls back to fixedWindowLimit the moment EVAL/EVALSHA is detected as
+// unsupported. Any OTHER error (genuine Redis outage/timeout) is rethrown
+// unchanged so the existing per-caller fail-open/failClosed + Sentry
+// reporting below is untouched.
+async function limitWithFallback(rl: Ratelimit, identifier: string, fallbackKey: string, limit: number, windowSeconds: number): Promise<LimitResult> {
+  if (!luaUnsupported) {
+    try {
+      return await rl.limit(identifier);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/Command not allowed: (EVAL|EVALSHA|SCRIPT)\b/i.test(msg)) throw err;
+      luaUnsupported = true;
+      console.warn('[rate-limit] EVAL/EVALSHA rejected by this Redis endpoint — switching to the non-Lua fixed-window fallback for the rest of this process');
+    }
+  }
+  const fallback = await fixedWindowLimit(fallbackKey, limit, windowSeconds);
+  if (!fallback) throw new Error('rate-limit fallback: Redis unreachable');
+  return fallback;
+}
+
 let ratelimit: Ratelimit | null = null;
+const GLOBAL_RATE_LIMIT = 600;
+const GLOBAL_RATE_WINDOW: Duration = '60 s';
+const GLOBAL_RATE_WINDOW_SECONDS = durationToSeconds(GLOBAL_RATE_WINDOW);
 
 function getRatelimit(): Ratelimit | null {
   if (ratelimit) return ratelimit;
@@ -23,7 +105,7 @@ function getRatelimit(): Ratelimit | null {
 
   ratelimit = new Ratelimit({
     redis: new Redis({ url, token, ...REDIS_TEST_RETRY_OPTS }),
-    limiter: Ratelimit.slidingWindow(600, '60 s'),
+    limiter: Ratelimit.slidingWindow(GLOBAL_RATE_LIMIT, GLOBAL_RATE_WINDOW),
     prefix: 'rl',
     analytics: false,
   });
@@ -179,7 +261,7 @@ export async function checkRateLimit(request: Request, corsHeaders: Record<strin
   const ip = getClientIp(request);
 
   try {
-    const { success, limit, reset } = await rl.limit(ip);
+    const { success, limit, reset } = await limitWithFallback(rl, ip, `rl:fw:${ip}`, GLOBAL_RATE_LIMIT, GLOBAL_RATE_WINDOW_SECONDS);
 
     if (!success) {
       return tooManyRequestsResponse(limit, reset, corsHeaders);
@@ -400,9 +482,14 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
   }
 
   const ip = getClientIp(request);
+  const policy = ENDPOINT_RATE_POLICIES[pathname];
+  // hasEndpointRatePolicy(pathname) above already guarantees this — the
+  // extra check exists only to satisfy noUncheckedIndexedAccess, since TS
+  // can't carry that narrowing across a second independent index lookup.
+  if (!policy) return null;
 
   try {
-    const { success, limit, reset } = await rl.limit(`${pathname}:${ip}`);
+    const { success, limit, reset } = await limitWithFallback(rl, `${pathname}:${ip}`, `rl:ep:fw:${pathname}:${ip}`, policy.limit, durationToSeconds(policy.window));
 
     if (!success) {
       return tooManyRequestsResponse(limit, reset, corsHeaders);
@@ -478,7 +565,7 @@ export async function checkScopedRateLimit(scope: string, limit: number, window:
     return { allowed: true, limit, reset: 0, degraded: true };
   }
   try {
-    const result = await rl.limit(`${scope}:${identifier}`);
+    const result = await limitWithFallback(rl, `${scope}:${identifier}`, `rl:scope:fw:${scope}:${identifier}`, limit, durationToSeconds(window));
     return {
       allowed: result.success,
       limit: result.limit,

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -3,7 +3,7 @@ import { Redis } from '@upstash/redis';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../api/_sentry-edge.js';
 // @ts-expect-error — JS module, no declaration file
-import { redisPipeline } from '../../api/_upstash-json.js';
+import { durationToSeconds, limitWithFallback, resetRateLimitFallbackForTest } from '../../api/_rate-limit-fallback.js';
 
 // @upstash/redis defaults to 5 retries with exponential backoff (~4.3s total)
 // before surfacing an unreachable-Redis error. The node test runner sets
@@ -14,83 +14,6 @@ import { redisPipeline } from '../../api/_upstash-json.js';
 // resilient default untouched. Mirrors the retry:false already shipped on the
 // MCP limiter to unblock the suite (PR #3963).
 const REDIS_TEST_RETRY_OPTS: { retry?: false } = process.env.NODE_TEST_CONTEXT ? { retry: false } : {};
-
-// Duration parsing mirrors @upstash/ratelimit's internal (unexported) `ms()`
-// helper — needed only so the non-Lua fallback below can pass a plain-seconds
-// EXPIRE argument. Not worth a dependency: same regex, ~10 lines.
-function durationToSeconds(window: Duration): number {
-  const match = /^(\d+)\s?(ms|s|m|h|d)$/.exec(window);
-  if (!match) throw new Error(`Unable to parse rate-limit window: ${window}`);
-  const value = Number(match[1]);
-  const unit = match[2] ?? 's';
-  const unitSeconds: Record<string, number> = { ms: 0.001, s: 1, m: 60, h: 3600, d: 86_400 };
-  return Math.max(1, Math.ceil(value * (unitSeconds[unit] ?? 1)));
-}
-
-// The self-hosted redis-rest proxy (docker/redis-rest-proxy.mjs) blocks
-// EVAL/EVALSHA/SCRIPT via its command allowlist. @upstash/ratelimit's
-// sliding-window limiter is a Lua script run via EVALSHA (falling back to
-// EVAL on NOSCRIPT) — against that proxy every `.limit()` call throws an
-// UpstashError wrapping the proxy's `Command not allowed: EVALSHA` (or
-// `EVAL`/`SCRIPT`) body. Detect that once per process and switch every
-// limiter below to the non-Lua fallback — retrying the Lua path on each
-// request would just double every rate-limit check's latency forever.
-let luaUnsupported = false;
-
-const FALLBACK_REDIS_TIMEOUT_MS = 1_000;
-
-interface LimitResult {
-  success: boolean;
-  limit: number;
-  reset: number;
-}
-
-// Non-Lua fixed-window fallback: INCR + EXPIRE-NX + TTL over the plain REST
-// pipeline endpoint (no EVAL/EVALSHA/SCRIPT). Mirrors the pattern already
-// proven in production by api/_user-api-key.js::checkBootstrapUserApiKeyRateLimit
-// — EXPIRE's NX flag (Redis 7+) means whichever concurrent caller's INCR
-// happens to be first also wins the one-time TTL set; every other command in
-// the window no-ops on EXPIRE, so there's no double-set race and no
-// crash-between-INCR-and-EXPIRE gap to reason about. Returns null when Redis
-// itself is unreachable — callers treat that identically to a Lua-path
-// outage (existing fail-open / failClosed handling below).
-async function fixedWindowLimit(key: string, limit: number, windowSeconds: number): Promise<LimitResult | null> {
-  const result = await redisPipeline([
-    ['INCR', key],
-    ['EXPIRE', key, String(windowSeconds), 'NX'],
-    ['TTL', key],
-  ], FALLBACK_REDIS_TIMEOUT_MS);
-  if (!result) return null;
-
-  const count = Number(result[0]?.result ?? 0);
-  if (!Number.isFinite(count) || count < 1) return null;
-
-  const ttlRaw = Number(result[2]?.result ?? -1);
-  const ttlSeconds = Number.isFinite(ttlRaw) && ttlRaw >= 0 ? ttlRaw : windowSeconds;
-
-  return { success: count <= limit, limit, reset: Date.now() + ttlSeconds * 1000 };
-}
-
-// Drop-in replacement for `ratelimit.limit(identifier)` that transparently
-// falls back to fixedWindowLimit the moment EVAL/EVALSHA is detected as
-// unsupported. Any OTHER error (genuine Redis outage/timeout) is rethrown
-// unchanged so the existing per-caller fail-open/failClosed + Sentry
-// reporting below is untouched.
-async function limitWithFallback(rl: Ratelimit, identifier: string, fallbackKey: string, limit: number, windowSeconds: number): Promise<LimitResult> {
-  if (!luaUnsupported) {
-    try {
-      return await rl.limit(identifier);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!/Command not allowed: (EVAL|EVALSHA|SCRIPT)\b/i.test(msg)) throw err;
-      luaUnsupported = true;
-      console.warn('[rate-limit] EVAL/EVALSHA rejected by this Redis endpoint — switching to the non-Lua fixed-window fallback for the rest of this process');
-    }
-  }
-  const fallback = await fixedWindowLimit(fallbackKey, limit, windowSeconds);
-  if (!fallback) throw new Error('rate-limit fallback: Redis unreachable');
-  return fallback;
-}
 
 let ratelimit: Ratelimit | null = null;
 const GLOBAL_RATE_LIMIT = 600;
@@ -135,7 +58,7 @@ export const UNKNOWN_CLIENT_IP = 'unknown';
 // Mirrored verbatim in api/_rate-limit.js.
 function rateLimitErrorLevel(stage: string, msg: string): 'warning' | 'error' {
   if (stage.includes('missing-config')) return 'error';
-  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|socket hang up/i.test(msg)) {
+  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|socket hang up|Redis unavailable|Redis unreachable/i.test(msg)) {
     return 'warning';
   }
   return 'error';
@@ -576,4 +499,12 @@ export async function checkScopedRateLimit(scope: string, limit: number, window:
     logRateLimitDegraded(`checkScopedRateLimit:${scope}`, err);
     return { allowed: true, limit, reset: 0, degraded: true };
   }
+}
+
+export function __resetRateLimitForTest(): void {
+  ratelimit = null;
+  endpointLimiters.clear();
+  scopedLimiters.clear();
+  scopedMissingConfigStages.clear();
+  resetRateLimitFallbackForTest();
 }

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -22,6 +22,14 @@ async function read(rel: string): Promise<string> {
   return readFile(new URL(rel, REPO_ROOT), 'utf8');
 }
 
+function serviceBlock(compose: string, serviceName: string): string {
+  const match = compose.match(
+    new RegExp(`^  ${serviceName}:\\n([\\s\\S]*?)(?=^  [a-zA-Z0-9_-]+:\\n|^volumes:)`, 'm'),
+  );
+  assert.ok(match, `docker-compose.yml must define ${serviceName} service`);
+  return match[1];
+}
+
 // Allow a documentation note that EXPLAINS the historical default while
 // scanning for live shipped defaults. The note has the literal in prose
 // (e.g. "shipped `wm-local-token` as a default") rather than as a YAML
@@ -88,6 +96,32 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
     assert.ok(
       /--requirepass\s+"\$\{REDIS_PASSWORD/.test(compose),
       'docker-compose.yml redis service must pass --requirepass using REDIS_PASSWORD',
+    );
+  });
+
+  it('docker-compose.yml wires redis-rest into the ais-relay seed loops', async () => {
+    const compose = await read('docker-compose.yml');
+    const relay = serviceBlock(compose, 'ais-relay');
+
+    assert.match(
+      relay,
+      /UPSTASH_REDIS_REST_URL:\s*"http:\/\/redis-rest:80"/,
+      'ais-relay must point UPSTASH_REDIS_REST_URL at the in-network redis-rest proxy',
+    );
+    assert.match(
+      relay,
+      /UPSTASH_REDIS_REST_TOKEN:\s*"\$\{REDIS_TOKEN:\?/,
+      'ais-relay must pass the fail-closed REDIS_TOKEN to redis-rest',
+    );
+    assert.match(
+      relay,
+      /UPSTASH_ALLOW_INSECURE_HTTP:\s*"true"/,
+      'ais-relay must explicitly opt into the plain-http redis-rest proxy inside the compose network',
+    );
+    assert.match(
+      relay,
+      /depends_on:\s*\n\s+redis-rest:\s*\n\s+condition:\s*service_started/,
+      'ais-relay must wait for redis-rest so Redis-backed seed loops can start in the bundled stack',
     );
   });
 

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -16,6 +16,7 @@ import {
   GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES,
   RATE_LIMIT_DEGRADED_HEADERS,
   UNKNOWN_CLIENT_IP,
+  __resetRateLimitForTest,
   checkEndpointRateLimit,
   checkRateLimit,
   checkScopedRateLimit,
@@ -477,6 +478,7 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    __resetRateLimitForTest();
     restoreEnv();
   });
 
@@ -489,7 +491,7 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
   // `UpstashError: "Command failed: Command not allowed: EVALSHA"`.
   const ALLOWED_COMMANDS = new Set(['INCR', 'EXPIRE', 'TTL']);
 
-  function makeProxyPipelineHandler() {
+  function makeProxyPipelineHandler({ expireNxUnsupported = false } = {}) {
     const store = new Map<string, { count: number; hasTtl: boolean }>();
     return (commands: unknown[][]) =>
       commands.map((cmd) => {
@@ -503,6 +505,9 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
           return { result: entry.count };
         }
         if (op === 'EXPIRE') {
+          if (expireNxUnsupported && String(cmd[3]).toUpperCase() === 'NX') {
+            return { error: 'ERR syntax error' };
+          }
           const applied = !entry.hasTtl;
           if (applied) entry.hasTtl = true;
           store.set(key, entry);
@@ -511,6 +516,81 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
         return { result: entry.hasTtl ? 60 : -1 }; // TTL
       });
   }
+
+  it('canonical checkRateLimit enforces the non-Lua fallback window directly', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    let luaAttempts = 0;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      if (commands.some((c) => /^(EVAL|EVALSHA|SCRIPT)$/i.test(String(c[0])))) luaAttempts++;
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.9' });
+
+    let res: Response | null = null;
+    let iterations = 0;
+    while (!res && iterations < 1000) {
+      res = await mod.checkRateLimit(req, {});
+      iterations++;
+    }
+
+    assert.ok(res, 'expected checkRateLimit to eventually return a 429 Response');
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get('X-RateLimit-Limit'), '600');
+    assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+    assert.equal(luaAttempts, 1, 'Lua must latch off after the first unsupported-command response');
+  });
+
+  it('checkEndpointRateLimit enforces the endpoint policy through the non-Lua fallback', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    let luaAttempts = 0;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      if (commands.some((c) => /^(EVAL|EVALSHA|SCRIPT)$/i.test(String(c[0])))) luaAttempts++;
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.10' });
+    const pathname = '/api/leads/v1/submit-contact';
+
+    assert.equal(await mod.checkEndpointRateLimit(req, pathname, {}), null);
+    assert.equal(await mod.checkEndpointRateLimit(req, pathname, {}), null);
+    assert.equal(await mod.checkEndpointRateLimit(req, pathname, {}), null);
+    const blocked = await mod.checkEndpointRateLimit(req, pathname, {});
+
+    assert.ok(blocked, 'expected endpoint policy to return a 429 on the fourth request');
+    assert.equal(blocked.status, 429);
+    assert.equal(blocked.headers.get('X-RateLimit-Limit'), '3');
+    assert.equal(blocked.headers.get('X-RateLimit-Remaining'), '0');
+    assert.equal(luaAttempts, 1, 'endpoint fallback must not retry Lua after it is known unsupported');
+  });
+
+  it('degrades instead of creating a permanent counter when EXPIRE NX is unsupported', async () => {
+    const pipelineHandler = makeProxyPipelineHandler({ expireNxUnsupported: true });
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.11' });
+    const pathname = '/api/leads/v1/submit-contact';
+
+    const failOpen = await mod.checkEndpointRateLimit(req, pathname, {}, { failClosed: false });
+    assert.equal(failOpen, null, 'opted-out endpoint callers should fail open when fallback cannot set a TTL');
+
+    const failClosed = await mod.checkEndpointRateLimit(req, pathname, {});
+    assert.ok(failClosed, 'default endpoint policy should fail closed when fallback cannot set a TTL');
+    assert.equal(failClosed.status, 503);
+    assert.equal(failClosed.headers.get('X-RateLimit-Mode'), 'degraded');
+
+    const scoped = await mod.checkScopedRateLimit('redis6-fallback', 1, '60 s', 'caller');
+    assert.equal(scoped.allowed, true);
+    assert.equal(scoped.degraded, true, 'scoped fallback reports degradation instead of returning a permanent 429');
+  });
 
   it('detects "Command not allowed: EVALSHA" and falls back to INCR+EXPIRE, then enforces the window on subsequent calls without retrying Lua', async () => {
     const pipelineHandler = makeProxyPipelineHandler();

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -468,3 +468,84 @@ describe('rate-limit constants', () => {
     assert.equal(UNKNOWN_CLIENT_IP, 'unknown');
   });
 });
+
+describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blocks Lua)', () => {
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  });
+
+  // Faithful in-memory INCR + EXPIRE-NX + TTL, gated by the same command
+  // allowlist docker/redis-rest-proxy.mjs enforces. @upstash/redis
+  // auto-pipelines every command (including a bare `.evalsha()`) through
+  // POST /pipeline, so the real proxy's per-command `{error}` entries — not
+  // an HTTP-level rejection — are what @upstash/ratelimit actually sees.
+  // Confirmed against the live SDK (v1.37.0): a blocked command surfaces as
+  // `UpstashError: "Command failed: Command not allowed: EVALSHA"`.
+  const ALLOWED_COMMANDS = new Set(['INCR', 'EXPIRE', 'TTL']);
+
+  function makeProxyPipelineHandler() {
+    const store = new Map<string, { count: number; hasTtl: boolean }>();
+    return (commands: unknown[][]) =>
+      commands.map((cmd) => {
+        const op = String(cmd[0]).toUpperCase();
+        if (!ALLOWED_COMMANDS.has(op)) return { error: `Command not allowed: ${op}` };
+        const key = String(cmd[1]);
+        const entry = store.get(key) ?? { count: 0, hasTtl: false };
+        if (op === 'INCR') {
+          entry.count += 1;
+          store.set(key, entry);
+          return { result: entry.count };
+        }
+        if (op === 'EXPIRE') {
+          const applied = !entry.hasTtl;
+          if (applied) entry.hasTtl = true;
+          store.set(key, entry);
+          return { result: applied ? 1 : 0 };
+        }
+        return { result: entry.hasTtl ? 60 : -1 }; // TTL
+      });
+  }
+
+  it('detects "Command not allowed: EVALSHA" and falls back to INCR+EXPIRE, then enforces the window on subsequent calls without retrying Lua', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    let luaAttempts = 0;
+    let fetchCalls = 0;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      fetchCalls++;
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      if (commands.some((c) => /^(EVAL|EVALSHA|SCRIPT)$/i.test(String(c[0])))) luaAttempts++;
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+
+    const first = await mod.checkScopedRateLimit('fallback-scope', 2, '60 s', 'caller-1');
+    assert.equal(first.allowed, true, 'first request is under the limit of 2');
+    assert.equal(first.degraded, false, 'a working fallback is not a degraded/outage state');
+    assert.equal(luaAttempts, 1, 'exactly one Lua attempt before the unsupported-command detection latches');
+    assert.equal(fetchCalls, 2, 'the failed Lua attempt plus its immediate fallback pipeline call');
+
+    const second = await mod.checkScopedRateLimit('fallback-scope', 2, '60 s', 'caller-1');
+    assert.equal(second.allowed, true, 'second request is still under the limit of 2');
+
+    const third = await mod.checkScopedRateLimit('fallback-scope', 2, '60 s', 'caller-1');
+    assert.equal(third.allowed, false, 'third request exceeds the limit of 2 and must be blocked');
+    assert.equal(third.degraded, false, 'enforcement, not an outage — degraded must stay false');
+
+    // The cached "unsupported" detection must not retry Lua on every call —
+    // still exactly 1 attempt after 3 limiter checks, with the other 3 calls
+    // going straight to the non-Lua fallback (4 total: 1 Lua + 3 fallback).
+    assert.equal(luaAttempts, 1, 'Lua must not be retried once EVALSHA is known unsupported');
+    assert.equal(fetchCalls, 4, '1 failed Lua attempt + 3 fallback pipeline calls');
+
+    // A different identifier gets its own independent window.
+    const otherCaller = await mod.checkScopedRateLimit('fallback-scope', 2, '60 s', 'caller-2');
+    assert.equal(otherCaller.allowed, true, 'a different identifier has its own fixed-window counter');
+  });
+});

--- a/tests/redis-rest-proxy-url-masking.test.mjs
+++ b/tests/redis-rest-proxy-url-masking.test.mjs
@@ -1,0 +1,55 @@
+// docker/redis-rest-proxy.mjs connects to Redis (and calls server.listen) as a
+// top-level side effect on import, so it can't be required directly in a unit
+// test — same constraint as scripts/ais-relay.cjs (see
+// relay-boot-seed-freshness-guard.test.mjs). Extract maskRedisUrl's real
+// source via regex and eval it standalone instead.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const proxySrc = readFileSync(resolve(here, '../docker/redis-rest-proxy.mjs'), 'utf8');
+
+const helperSrc = proxySrc.match(/function maskRedisUrl\([\s\S]*?\n\}/)?.[0];
+
+function buildMaskRedisUrl() {
+  // eslint-disable-next-line no-new-func
+  return new Function(`${helperSrc}\nreturn maskRedisUrl;`)();
+}
+
+describe('maskRedisUrl (redis-rest-proxy)', () => {
+  it('is defined in redis-rest-proxy.mjs', () => {
+    assert.ok(helperSrc, 'maskRedisUrl not found in docker/redis-rest-proxy.mjs');
+  });
+
+  it('redacts the password from a SRH_CONNECTION_STRING-shaped URL', () => {
+    const maskRedisUrl = buildMaskRedisUrl();
+    const masked = maskRedisUrl('redis://:deadbeef00112233445566778899aabbccddeeff00112233445566778899aa@redis:6379');
+    assert.equal(masked, 'redis://:***@redis:6379');
+    assert.doesNotMatch(masked, /deadbeef00112233445566778899aabbccddeeff00112233445566778899aa/);
+  });
+
+  it('redacts a username when present too', () => {
+    const maskRedisUrl = buildMaskRedisUrl();
+    assert.equal(maskRedisUrl('redis://user:pass@host:6379/0'), 'redis://***:***@host:6379/0');
+  });
+
+  it('passes through a URL with no credentials unchanged', () => {
+    const maskRedisUrl = buildMaskRedisUrl();
+    assert.equal(maskRedisUrl('redis://redis:6379'), 'redis://redis:6379');
+  });
+
+  it('fails safe (never throws, never returns the raw input) on an unparsable value', () => {
+    const maskRedisUrl = buildMaskRedisUrl();
+    assert.equal(maskRedisUrl('not a url'), '<unparsable redis URL>');
+  });
+
+  it('is called at the actual "Connected to Redis at" log site (regression guard)', () => {
+    // The whole point of this fix: REDIS_URL itself must never reach a
+    // console call unmasked again.
+    assert.match(proxySrc, /console\.log\(`Connected to Redis at \$\{maskRedisUrl\(REDIS_URL\)\}`\)/);
+    assert.doesNotMatch(proxySrc, /console\.(log|error|warn|info)\([^)]*\$\{REDIS_URL\}/);
+  });
+});

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -121,7 +121,10 @@ describe('seedTransitSummaries (relay)', () => {
   });
 
   it('PortWatch data is read via envelopeRead (unwraps {_seed, data} contract-mode shape)', () => {
-    assert.match(relaySrc, /const pw = await envelopeRead\(PORTWATCH_REDIS_KEY\)/);
+    // envelopeRead takes an optional onFailure reason callback (added so the
+    // empty-read early return can log WHY, not just THAT, portwatch was
+    // empty) — match the call regardless of that second argument.
+    assert.match(relaySrc, /const pw = await envelopeRead\(PORTWATCH_REDIS_KEY[,)]/);
     assert.doesNotMatch(relaySrc, /const pw = await upstashGet\(PORTWATCH_REDIS_KEY\)/);
   });
 
@@ -136,6 +139,22 @@ describe('seedTransitSummaries (relay)', () => {
 
   it('has TTL >= 6x seed interval (survives multiple missed pings)', () => {
     assert.match(relaySrc, /TRANSIT_SUMMARY_TTL\s*=\s*[3-9]\d{3}/);
+  });
+
+  it('empty-portwatch early return is non-silent (logs key + reason, not a bare `return;`)', () => {
+    // Regression guard for the 2026-07 incident: this early return fired on
+    // every 10-min tick for 4d20h with zero log output (UPSTASH_ENABLED was
+    // false in-container), so the dead scheduler was invisible until a live
+    // audit caught it via the never-populated Redis key. A bare early
+    // `return;` here must never come back.
+    const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
+    assert.doesNotMatch(fnBody, /length === 0\) return;/);
+    assert.match(fnBody, /console\.warn\(`\[TransitSummary\] Skipped — \$\{PORTWATCH_REDIS_KEY\}/);
+    // The logged reason must distinguish "Upstash disabled" from "read
+    // failed" from "key genuinely empty" — three different root causes that
+    // all look identical from the caller's perspective otherwise.
+    assert.match(fnBody, /!UPSTASH_ENABLED/);
+    assert.match(fnBody, /pwFailureReason/);
   });
 });
 
@@ -554,7 +573,7 @@ describe('handler transit data strategy', () => {
 describe('seedTransitSummaries Redis reads', () => {
   it('always reads PortWatch fresh from Redis (no in-memory cache guard)', () => {
     assert.doesNotMatch(relaySrc, /if\s*\(\s*!latestPortwatchData\s*\)/);
-    assert.match(relaySrc, /envelopeRead\(PORTWATCH_REDIS_KEY\)/);
+    assert.match(relaySrc, /envelopeRead\(PORTWATCH_REDIS_KEY[,)]/);
   });
 
   it('reads CorridorRisk from Redis when latestCorridorRiskData is null', () => {
@@ -590,16 +609,16 @@ describe('seedTransitSummaries Redis reads', () => {
 
   it('PortWatch Redis read is the first statement (before early return)', () => {
     const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
-    const readPos = fnBody.indexOf('envelopeRead(PORTWATCH_REDIS_KEY)');
+    const readPos = fnBody.indexOf('envelopeRead(PORTWATCH_REDIS_KEY');
     const earlyReturnPos = fnBody.indexOf('if (!pw ||');
-    assert.ok(readPos > 0, 'envelopeRead(PORTWATCH_REDIS_KEY) not found in function body');
+    assert.ok(readPos > 0, 'envelopeRead(PORTWATCH_REDIS_KEY not found in function body');
     assert.ok(earlyReturnPos > 0, 'pw early return not found');
     assert.ok(readPos < earlyReturnPos, 'Redis read must come before the early return');
   });
 
   it('PortWatch data is assigned directly from Redis (no stale in-memory cache)', () => {
     const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
-    assert.match(fnBody, /const pw = await envelopeRead\(PORTWATCH_REDIS_KEY\)/);
+    assert.match(fnBody, /const pw = await envelopeRead\(PORTWATCH_REDIS_KEY[,)]/);
   });
 
   it('assigns hydrated data back to latestCorridorRiskData', () => {

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -669,3 +669,114 @@ describe('envelopeRead helper', () => {
     assert.deepEqual(await read('array:key'), [1, 2, 3]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Upstash Redis client selection — runtime behavior for the insecure-http
+// opt-in (regression guard for the incident where the https-only gate
+// silently no-oped every seed loop against http://redis-rest:80 for 4+ days).
+// UPSTASH_ALLOW_INSECURE_HTTP + UPSTASH_HTTP_MODULE decide both whether
+// Redis writes are enabled at all and which Node client (http vs https)
+// upstashGet/Set/etc. use. The source-scan tests above only assert the
+// scheduler shape; these actually eval the init block + upstashGet in a
+// sandbox with mocked http/https clients (no network, no real Upstash) so a
+// future edit that regresses the opt-in gate fails a test, not silence.
+// ---------------------------------------------------------------------------
+describe('Upstash Redis client selection (insecure-http opt-in)', () => {
+  // The relay can't be require()'d directly in a test — it process.exit(1)s
+  // without AISSTREAM_API_KEY and otherwise boots a live server on import.
+  // Slice the init block (UPSTASH_REDIS_REST_URL ... end of upstashGet)
+  // straight out of the relay source and eval it in a sandbox instead.
+  const initStart = relaySrc.indexOf("const UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL || '';");
+  const initEnd = relaySrc.indexOf('function upstashSet(key, value, ttlSeconds) {');
+  assert.ok(initStart > 0 && initEnd > initStart, 'Upstash init block (through upstashGet) not found');
+  const initAndGetSrc = relaySrc.slice(initStart, initEnd);
+
+  function makeMockClient(name) {
+    return {
+      name,
+      requestCalls: [],
+      request(url, opts) {
+        this.requestCalls.push({ url, opts });
+        // No response callback is ever invoked — these tests only assert
+        // which client received the call, so the resulting (intentionally
+        // never-settling) promise must not be awaited.
+        return { on() {}, end() {} };
+      },
+    };
+  }
+
+  function buildUpstashInit(env, httpClient, httpsClient) {
+    // eslint-disable-next-line no-new-func
+    const fn = new Function(
+      'process', 'http', 'https',
+      `${initAndGetSrc}\nreturn { UPSTASH_ALLOW_INSECURE_HTTP, UPSTASH_ENABLED, UPSTASH_HTTP_MODULE, upstashGet };`,
+    );
+    return fn({ env }, httpClient, httpsClient);
+  }
+
+  it('https:// URL enables Upstash and routes upstashGet through the https client', () => {
+    const httpClient = makeMockClient('http');
+    const httpsClient = makeMockClient('https');
+    const { UPSTASH_ENABLED, UPSTASH_HTTP_MODULE, upstashGet } = buildUpstashInit(
+      { UPSTASH_REDIS_REST_URL: 'https://real-upstash.io', UPSTASH_REDIS_REST_TOKEN: 'tok' },
+      httpClient, httpsClient,
+    );
+    assert.equal(UPSTASH_ENABLED, true);
+    assert.equal(UPSTASH_HTTP_MODULE, httpsClient);
+    upstashGet('some:key');
+    assert.equal(httpsClient.requestCalls.length, 1);
+    assert.equal(httpClient.requestCalls.length, 0);
+  });
+
+  it('http:// URL WITHOUT UPSTASH_ALLOW_INSECURE_HTTP disables Upstash entirely (never calls Redis) — the regressed state that silently disabled every seed loop for 4+ days', async () => {
+    const httpClient = makeMockClient('http');
+    const httpsClient = makeMockClient('https');
+    const { UPSTASH_ALLOW_INSECURE_HTTP, UPSTASH_ENABLED, upstashGet } = buildUpstashInit(
+      { UPSTASH_REDIS_REST_URL: 'http://redis-rest:80', UPSTASH_REDIS_REST_TOKEN: 'tok' },
+      httpClient, httpsClient,
+    );
+    assert.equal(UPSTASH_ALLOW_INSECURE_HTTP, false);
+    assert.equal(UPSTASH_ENABLED, false);
+    // Resolves null synchronously via the !UPSTASH_ENABLED guard — safe to
+    // await, and proves no request is ever attempted on either client.
+    assert.equal(await upstashGet('some:key'), null);
+    assert.equal(httpClient.requestCalls.length, 0);
+    assert.equal(httpsClient.requestCalls.length, 0);
+  });
+
+  it('http:// URL WITH UPSTASH_ALLOW_INSECURE_HTTP=true enables Upstash and routes upstashGet through the http client (the scheduler fix)', () => {
+    const httpClient = makeMockClient('http');
+    const httpsClient = makeMockClient('https');
+    const { UPSTASH_ALLOW_INSECURE_HTTP, UPSTASH_ENABLED, UPSTASH_HTTP_MODULE, upstashGet } = buildUpstashInit(
+      { UPSTASH_REDIS_REST_URL: 'http://redis-rest:80', UPSTASH_REDIS_REST_TOKEN: 'tok', UPSTASH_ALLOW_INSECURE_HTTP: 'true' },
+      httpClient, httpsClient,
+    );
+    assert.equal(UPSTASH_ALLOW_INSECURE_HTTP, true);
+    assert.equal(UPSTASH_ENABLED, true);
+    assert.equal(UPSTASH_HTTP_MODULE, httpClient);
+    upstashGet('some:key');
+    assert.equal(httpClient.requestCalls.length, 1);
+    assert.equal(httpsClient.requestCalls.length, 0);
+  });
+
+  it('UPSTASH_ALLOW_INSECURE_HTTP is a strict "true" match — "TRUE"/"1" do not opt in', () => {
+    const httpClient = makeMockClient('http');
+    const httpsClient = makeMockClient('https');
+    const { UPSTASH_ALLOW_INSECURE_HTTP, UPSTASH_ENABLED } = buildUpstashInit(
+      { UPSTASH_REDIS_REST_URL: 'http://redis-rest:80', UPSTASH_REDIS_REST_TOKEN: 'tok', UPSTASH_ALLOW_INSECURE_HTTP: 'TRUE' },
+      httpClient, httpsClient,
+    );
+    assert.equal(UPSTASH_ALLOW_INSECURE_HTTP, false);
+    assert.equal(UPSTASH_ENABLED, false);
+  });
+
+  it('missing UPSTASH_REDIS_REST_TOKEN disables Upstash even over https', () => {
+    const httpClient = makeMockClient('http');
+    const httpsClient = makeMockClient('https');
+    const { UPSTASH_ENABLED } = buildUpstashInit(
+      { UPSTASH_REDIS_REST_URL: 'https://real-upstash.io' },
+      httpClient, httpsClient,
+    );
+    assert.equal(UPSTASH_ENABLED, false);
+  });
+});

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -278,6 +278,42 @@ describe('seedTransitSummaries (relay)', () => {
     assert.equal(metaWrites.length, 0, 'no seed-meta write should occur when portwatch is empty');
     assert.equal(warnings.length, 1, 'the skip must log, not fail silently');
     assert.match(warnings[0], /\[TransitSummary\] Skipped — supply_chain:portwatch:v1 unavailable/);
+    assert.match(warnings[0], /key empty or absent — upstream seeder has not written it yet/);
+  });
+
+  it('disabled Upstash skip reason is exercised behaviorally', async () => {
+    const warnings = [];
+    const seed = buildSeedTransitSummaries({
+      envelopeRead: async () => null,
+      envelopeWrite: async () => { throw new Error('must not write when portwatch is unavailable'); },
+      upstashSet: async () => { throw new Error('must not write seed-meta when portwatch is unavailable'); },
+      upstashEnabled: false,
+      warn: msg => warnings.push(msg),
+    });
+
+    await seed();
+
+    assert.equal(warnings.length, 1, 'the skip must log even when Redis is disabled');
+    assert.match(warnings[0], /Upstash Redis disabled/);
+    assert.match(warnings[0], /UPSTASH_REDIS_REST_URL\/UPSTASH_ALLOW_INSECURE_HTTP/);
+  });
+
+  it('portwatch read-failure skip reason is exercised behaviorally', async () => {
+    const warnings = [];
+    const seed = buildSeedTransitSummaries({
+      envelopeRead: async (_key, onFailure) => {
+        onFailure('HTTP 500 from redis-rest');
+        return null;
+      },
+      envelopeWrite: async () => { throw new Error('must not write when portwatch read failed'); },
+      upstashSet: async () => { throw new Error('must not write seed-meta when portwatch read failed'); },
+      warn: msg => warnings.push(msg),
+    });
+
+    await seed();
+
+    assert.equal(warnings.length, 1, 'the skip must log the read failure reason');
+    assert.match(warnings[0], /read failed: HTTP 500 from redis-rest/);
   });
 });
 

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -156,6 +156,129 @@ describe('seedTransitSummaries (relay)', () => {
     assert.match(fnBody, /!UPSTASH_ENABLED/);
     assert.match(fnBody, /pwFailureReason/);
   });
+
+  // ---------------------------------------------------------------------------
+  // Behavioral seeding — runs the real seedTransitSummaries body (extracted
+  // from source, not reimplemented) in a sandbox with mocked
+  // envelopeRead/envelopeWrite/upstashSet. No network, no real Upstash. The
+  // regex assertions above only prove the source SHAPE is wired correctly —
+  // they still pass even if the scheduler silently never populates Redis
+  // (the exact 2026-07 incident class). These tests actually invoke the
+  // function and assert on the writes it produces.
+  // ---------------------------------------------------------------------------
+
+  function extractConstLine(name) {
+    const m = relaySrc.match(new RegExp(`const ${name} = [^;]+;`));
+    assert.ok(m, `${name} definition not found in relaySrc`);
+    return m[0];
+  }
+
+  function extractObjectConst(name) {
+    const m = relaySrc.match(new RegExp(`const ${name} = \\{[\\s\\S]*?\\n\\};`));
+    assert.ok(m, `${name} definition not found in relaySrc`);
+    return m[0];
+  }
+
+  const seedFnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1];
+  assert.ok(seedFnBody, 'seedTransitSummaries body not found');
+  const anomalyFnBody = relaySrc.match(/function detectTrafficAnomalyRelay\(history, threatLevel\)\s*\{([\s\S]*?)\n\}/)?.[1];
+  assert.ok(anomalyFnBody, 'detectTrafficAnomalyRelay body not found');
+
+  // Assembled in dependency order from real extracted source snippets, not
+  // hand-copied literals — a future rename/edit in ais-relay.cjs breaks this
+  // extraction (loud) instead of silently testing stale duplicated code.
+  const seedHarnessSrc = [
+    extractConstLine('PORTWATCH_REDIS_KEY'),
+    extractConstLine('CORRIDOR_RISK_REDIS_KEY'),
+    extractConstLine('TRANSIT_SUMMARY_REDIS_KEY'),
+    extractConstLine('TRANSIT_SUMMARY_HISTORY_KEY_PREFIX'),
+    extractConstLine('TRANSIT_SUMMARY_TTL'),
+    extractConstLine('TRANSIT_WINDOW_MS'),
+    extractObjectConst('CHOKEPOINT_THREAT_LEVELS'),
+    extractObjectConst('RELAY_NAME_TO_ID'),
+    'let latestCorridorRiskData = null;',
+    `function detectTrafficAnomalyRelay(history, threatLevel) {${anomalyFnBody}\n}`,
+    `async function seedTransitSummaries() {${seedFnBody}\n}`,
+    'return seedTransitSummaries;',
+  ].join('\n');
+
+  // Fresh sandbox per call — `latestCorridorRiskData` resets like a cold
+  // relay restart instead of leaking state between tests.
+  function buildSeedTransitSummaries({ envelopeRead, envelopeWrite, upstashSet, upstashEnabled = true, warn = () => {}, log = () => {} }) {
+    // eslint-disable-next-line no-new-func
+    const factory = new Function(
+      'envelopeRead', 'envelopeWrite', 'upstashSet', 'console', 'UPSTASH_ENABLED', 'chokepointCrossings',
+      seedHarnessSrc,
+    );
+    return factory(envelopeRead, envelopeWrite, upstashSet, { warn, log }, upstashEnabled, new Map());
+  }
+
+  const ALL_CANONICAL_IDS = [
+    'suez', 'malacca_strait', 'hormuz_strait', 'bab_el_mandeb', 'panama',
+    'taiwan_strait', 'cape_of_good_hope', 'gibraltar', 'bosphorus',
+    'korea_strait', 'dover_strait', 'kerch_strait', 'lombok_strait',
+  ];
+
+  it('populated portwatch actually produces the compact summary key, all 13 per-id history keys, and a seed-meta write', async () => {
+    const fakePortwatch = {
+      suez: { history: makeDays(40, 120, 0), wowChangePct: 4.2 },
+      hormuz_strait: { history: makeDays(3, 10, 0), wowChangePct: -1 },
+    };
+    const writes = [];
+    const metaWrites = [];
+    const seed = buildSeedTransitSummaries({
+      envelopeRead: async key => (key === 'supply_chain:portwatch:v1' ? fakePortwatch : null),
+      envelopeWrite: async (key, data, ttlSeconds, meta) => { writes.push({ key, data, ttlSeconds, meta }); return true; },
+      upstashSet: async (key, data, ttlSeconds) => { metaWrites.push({ key, data, ttlSeconds }); },
+    });
+
+    await seed();
+
+    const summaryWrites = writes.filter(w => w.key === 'supply_chain:transit-summaries:v1');
+    assert.equal(summaryWrites.length, 1, 'expected exactly one write to the compact summary key');
+    const { summaries } = summaryWrites[0].data;
+    assert.deepEqual(Object.keys(summaries).sort(), [...ALL_CANONICAL_IDS].sort());
+    assert.equal(summaries.suez.dataAvailable, true);
+    assert.equal(summaries.hormuz_strait.dataAvailable, true);
+    // Chokepoint missing from this cycle's portwatch payload still publishes
+    // a zero-state row instead of vanishing (partial-coverage regression).
+    assert.equal(summaries.panama.dataAvailable, false);
+    assert.equal(summaries.panama.todayTotal, 0);
+    assert.equal(summaryWrites[0].meta.recordCount, 2, 'recordCount must reflect pwCovered, not the always-13 shape');
+    assert.equal(summaryWrites[0].ttlSeconds, 3600);
+
+    const historyWrites = writes.filter(w => w.key.startsWith('supply_chain:transit-summaries:history:v1:'));
+    assert.equal(historyWrites.length, 13, 'one history write per canonical chokepoint, covered or not');
+    const suezHistory = historyWrites.find(w => w.key === 'supply_chain:transit-summaries:history:v1:suez');
+    assert.deepEqual(suezHistory.data.history, fakePortwatch.suez.history);
+    assert.equal(suezHistory.data.chokepointId, 'suez');
+    const panamaHistory = historyWrites.find(w => w.key === 'supply_chain:transit-summaries:history:v1:panama');
+    assert.deepEqual(panamaHistory.data.history, []);
+
+    assert.equal(metaWrites.length, 1, 'seed-meta must actually be written so health checks see it');
+    assert.equal(metaWrites[0].key, 'seed-meta:supply_chain:transit-summaries');
+    assert.equal(metaWrites[0].data.recordCount, 2);
+    assert.equal(metaWrites[0].ttlSeconds, 604800);
+  });
+
+  it('empty portwatch writes NOTHING to Redis — the exact "scheduler wired but keys never populate" failure class this suite must catch', async () => {
+    const writes = [];
+    const metaWrites = [];
+    const warnings = [];
+    const seed = buildSeedTransitSummaries({
+      envelopeRead: async () => null,
+      envelopeWrite: async (key, data, ttlSeconds, meta) => { writes.push({ key, data, ttlSeconds, meta }); return true; },
+      upstashSet: async (key, data, ttlSeconds) => { metaWrites.push({ key, data, ttlSeconds }); },
+      warn: msg => warnings.push(msg),
+    });
+
+    await seed();
+
+    assert.equal(writes.length, 0, 'no Redis writes should occur when portwatch is empty');
+    assert.equal(metaWrites.length, 0, 'no seed-meta write should occur when portwatch is empty');
+    assert.equal(warnings.length, 1, 'the skip must log, not fail silently');
+    assert.match(warnings[0], /\[TransitSummary\] Skipped — supply_chain:portwatch:v1 unavailable/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three independent production fixes, all currently running on the live stack:

1. **Transit-summary scheduler root cause + non-silent early return** (`scripts/ais-relay.cjs`) — `UPSTASH_ENABLED` required `UPSTASH_REDIS_REST_URL` to start with `https://`, but the self-hosted `redis-rest` proxy is plain `http://redis-rest:80` inside the compose network. `UPSTASH_ENABLED` has therefore been `false` in-container since that proxy shipped, so `seedTransitSummaries` silently returned on every 10-minute tick and `supply_chain:chokepoints:v4` never populated (confirmed live: 4d20h uptime with zero `[TransitSummary]`/`[CorridorRisk]` success logs). Adds an explicit, off-by-default `UPSTASH_ALLOW_INSECURE_HTTP` opt-in (mirrors the existing `I_UNDERSTAND_THIS_DISABLES_AUTH` pattern) plus a protocol-aware `UPSTASH_HTTP_MODULE` so the upstash helpers pick `http` vs `https` to match the configured URL. The empty-portwatch early return now logs the key and a specific reason (Upstash disabled / Redis read failure / key genuinely absent) instead of a bare `return;` — the exact silent-failure class that let this run undetected. No behavior change for the default (unset) case.
2. **Redis credential masking in `redis-rest-proxy` logs** (`docker/redis-rest-proxy.mjs`) — the startup log printed `Connected to Redis at ${REDIS_URL}`, where the URL carries the Redis password in cleartext, landing in docker logs readable by anyone with docker/compose access. Adds `maskRedisUrl()` (WHATWG `URL` parser) to redact any username/password before logging. Audited the file for other `REDIS_URL`/`SRH_CONNECTION_STRING` log sites — this was the only one.
3. **EVALSHA-free rate-limit fallback with cached detection** (`server/_shared/rate-limit.ts`, `api/_rate-limit.js`) — the self-hosted `redis-rest` proxy blocks `EVAL`/`EVALSHA`/`SCRIPT` via its command allowlist, so `@upstash/ratelimit`'s Lua-based sliding-window limiter was throwing on every call against that proxy and silently fail-open/fail-closed degrading instead of actually rate-limiting. Adds `limitWithFallback()`: a non-Lua INCR + EXPIRE-NX + TTL fixed-window limiter over the plain REST pipeline endpoint (mirrors the pattern already proven by `api/_user-api-key.js`), transparently retried the moment the proxy's "Command not allowed: EVAL/EVALSHA/SCRIPT" error is detected, then latched via a module-level flag so Lua is never retried again for the life of the process. Any other error (genuine Redis outage/timeout) is rethrown unchanged, preserving existing fail-open/failClosed/Sentry handling at each call site.

## Verification

- `npm run typecheck` (`tsc --noEmit`) — clean.
- Targeted suites for these changes, all passing: `tests/transit-summaries.test.mjs`, `tests/redis-rest-proxy-url-masking.test.mjs` (new), `tests/rate-limit.test.mts`, and `api/_rate-limit.test.mjs` (new, now wired into `npm run test:sidecar` — it existed but was never referenced by any npm script and silently never ran in CI). Full `test:sidecar` run: 171/171 passing.
- Live-verified against the real `redis-rest` proxy in the running compose stack: with `UPSTASH_ALLOW_INSECURE_HTTP` set, `UPSTASH_ENABLED` flips `true` and `envelopeRead(portwatch:v1)` correctly reads and unwraps all 13 canonical chokepoints; the rate-limit fallback was exercised against the proxy's actual EVALSHA rejection and correctly enforces 429s via INCR+EXPIRE.
- No API keys or secrets committed; this PR removes one (Redis password in logs).

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: AIS relay scheduler (`scripts/ais-relay.cjs`), self-hosted Redis REST proxy (`docker/redis-rest-proxy.mjs`)

## Checklist

- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] No API keys or secrets committed
- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A, no new feeds
</content>
