### PR TITLE
fix(notifications): fail open on dedup SETNX errors

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -30,9 +30,8 @@ const { parseProxyConfig, resolveProxyString } = require('./_proxy-utils.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
 const {
   buildDedupMaterial,
-  buildSetNxErrorTelemetryLine,
   classifySetNxResult,
-  shouldPublishAfterDedupResult,
+  recordDedupOutcome,
 } = require('./shared/notification-dedup.cjs');
 const parseProxyUrl = parseProxyConfig;
 
@@ -390,7 +389,7 @@ function upstashLpush(key, value) {
 
 function upstashSetNx(key, value, ttlSeconds) {
   return new Promise((resolve) => {
-    if (!UPSTASH_ENABLED) return resolve('error');
+    if (!UPSTASH_ENABLED) return resolve('disabled');
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const serialized = typeof value === 'string' ? value : JSON.stringify(value);
     const body = JSON.stringify(['SET', key, serialized, 'NX', 'EX', String(ttlSeconds)]);
@@ -622,21 +621,23 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
     const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
     const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifySimpleHash(dedupMaterial)}`;
     const dedupResult = await upstashSetNx(dedupKey, '1', dedupTtl);
-    if (!shouldPublishAfterDedupResult(dedupResult, severity)) {
-      if (dedupResult !== 'duplicate') {
-        recordNotificationDedupSetNxError({ surface: 'ais-relay', eventType, severity, action: 'fail_closed' });
-        return;
-      }
+    const dedupDecision = recordDedupOutcome(dedupResult, {
+      surface: 'ais-relay',
+      eventType,
+      severity,
+      fallbackKey: dedupKey,
+      fallbackTtlSeconds: dedupTtl,
+      emitTelemetry: recordNotificationDedupSetNxError,
+    });
+    if (!dedupDecision.shouldPublish) {
+      if (!dedupDecision.isDuplicate) return;
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
       return;
     }
-    if (dedupResult === 'error') {
-      recordNotificationDedupSetNxError({ surface: 'ais-relay', eventType, severity, action: 'fail_open' });
-    }
-    const msg = JSON.stringify({ eventType, payload, severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
+    const msg = JSON.stringify({ eventType, payload, severity: dedupDecision.severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
     const ok = await upstashLpush('wm:events:queue', msg);
     if (ok) {
-      console.log(`[Notify] Queued ${severity} event: ${eventType} — ${String(payload.title ?? '').slice(0, 60)}`);
+      console.log(`[Notify] Queued ${dedupDecision.severity} event: ${eventType} — ${String(payload.title ?? '').slice(0, 60)}`);
     } else {
       // Rollback the dedup key so the next poll cycle can retry — avoids silent
       // suppression for the full dedupTtl when a transient LPUSH fails.
@@ -6956,10 +6957,10 @@ function getRelayRollingMetrics() {
   };
 }
 
-function recordNotificationDedupSetNxError({ surface, eventType, severity, action }) {
+function recordNotificationDedupSetNxError({ line, action }) {
   incrementRelayMetric('notificationDedupSetNxErrors');
   incrementRelayMetric(action === 'fail_open' ? 'notificationDedupSetNxFailOpen' : 'notificationDedupSetNxFailClosed');
-  console.warn(buildSetNxErrorTelemetryLine({ surface, eventType, severity, action }));
+  console.warn(line);
 }
 
 // AIS aggregate state for snapshot API (server-side fanout)

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -28,7 +28,12 @@ const v8 = require('v8');
 const { WebSocketServer, WebSocket } = require('ws');
 const { parseProxyConfig, resolveProxyString } = require('./_proxy-utils.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
-const { buildDedupMaterial } = require('./shared/notification-dedup.cjs');
+const {
+  buildDedupMaterial,
+  buildSetNxErrorTelemetryLine,
+  classifySetNxResult,
+  shouldPublishAfterDedupResult,
+} = require('./shared/notification-dedup.cjs');
 const parseProxyUrl = parseProxyConfig;
 
 const httpsKeepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 6, timeout: 60_000 });
@@ -385,7 +390,7 @@ function upstashLpush(key, value) {
 
 function upstashSetNx(key, value, ttlSeconds) {
   return new Promise((resolve) => {
-    if (!UPSTASH_ENABLED) return resolve(null);
+    if (!UPSTASH_ENABLED) return resolve('error');
     const url = new URL('/', UPSTASH_REDIS_REST_URL);
     const serialized = typeof value === 'string' ? value : JSON.stringify(value);
     const body = JSON.stringify(['SET', key, serialized, 'NX', 'EX', String(ttlSeconds)]);
@@ -402,12 +407,12 @@ function upstashSetNx(key, value, ttlSeconds) {
       resp.on('end', () => {
         try {
           const parsed = JSON.parse(data);
-          resolve(parsed?.result === 'OK' ? 'OK' : null);
-        } catch { resolve(null); }
+          resolve(classifySetNxResult(parsed?.result));
+        } catch { resolve('error'); }
       });
     });
-    req.on('error', () => resolve(null));
-    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.on('error', () => resolve('error'));
+    req.on('timeout', () => { req.destroy(); resolve('error'); });
     req.end(body);
   });
 }
@@ -616,10 +621,17 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
     const variantSuffix = variant ? `:${variant}` : '';
     const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
     const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifySimpleHash(dedupMaterial)}`;
-    const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
-    if (!isNew) {
+    const dedupResult = await upstashSetNx(dedupKey, '1', dedupTtl);
+    if (!shouldPublishAfterDedupResult(dedupResult, severity)) {
+      if (dedupResult !== 'duplicate') {
+        recordNotificationDedupSetNxError({ surface: 'ais-relay', eventType, severity, action: 'fail_closed' });
+        return;
+      }
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
       return;
+    }
+    if (dedupResult === 'error') {
+      recordNotificationDedupSetNxError({ surface: 'ais-relay', eventType, severity, action: 'fail_open' });
     }
     const msg = JSON.stringify({ eventType, payload, severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
     const ok = await upstashLpush('wm:events:queue', msg);
@@ -6794,6 +6806,9 @@ const relayMetricsLifetime = {
   openskyMiss: 0,
   openskyUpstreamFetches: 0,
   drops: 0,
+  notificationDedupSetNxErrors: 0,
+  notificationDedupSetNxFailOpen: 0,
+  notificationDedupSetNxFailClosed: 0,
 };
 let relayMetricsQueueMaxLifetime = 0;
 let relayMetricsCurrentSec = 0;
@@ -6811,6 +6826,9 @@ function createRelayMetricsBucket() {
     openskyMiss: 0,
     openskyUpstreamFetches: 0,
     drops: 0,
+    notificationDedupSetNxErrors: 0,
+    notificationDedupSetNxFailOpen: 0,
+    notificationDedupSetNxFailClosed: 0,
     queueMax: 0,
   };
 }
@@ -6886,6 +6904,9 @@ function getRelayRollingMetrics() {
     rollup.openskyMiss += bucket.openskyMiss;
     rollup.openskyUpstreamFetches += bucket.openskyUpstreamFetches;
     rollup.drops += bucket.drops;
+    rollup.notificationDedupSetNxErrors += bucket.notificationDedupSetNxErrors;
+    rollup.notificationDedupSetNxFailOpen += bucket.notificationDedupSetNxFailOpen;
+    rollup.notificationDedupSetNxFailClosed += bucket.notificationDedupSetNxFailClosed;
     if (bucket.queueMax > rollup.queueMax) rollup.queueMax = bucket.queueMax;
   }
 
@@ -6914,6 +6935,11 @@ function getRelayRollingMetrics() {
       dropsPerSec: Number((rollup.drops / METRICS_WINDOW_SECONDS).toFixed(4)),
       upstreamPaused,
     },
+    notifications: {
+      dedupSetNxErrors: rollup.notificationDedupSetNxErrors,
+      dedupSetNxFailOpen: rollup.notificationDedupSetNxFailOpen,
+      dedupSetNxFailClosed: rollup.notificationDedupSetNxFailClosed,
+    },
     lifetime: {
       openskyRequests: relayMetricsLifetime.openskyRequests,
       openskyCacheHit: relayMetricsLifetime.openskyCacheHit,
@@ -6922,9 +6948,18 @@ function getRelayRollingMetrics() {
       openskyMiss: relayMetricsLifetime.openskyMiss,
       openskyUpstreamFetches: relayMetricsLifetime.openskyUpstreamFetches,
       drops: relayMetricsLifetime.drops,
+      notificationDedupSetNxErrors: relayMetricsLifetime.notificationDedupSetNxErrors,
+      notificationDedupSetNxFailOpen: relayMetricsLifetime.notificationDedupSetNxFailOpen,
+      notificationDedupSetNxFailClosed: relayMetricsLifetime.notificationDedupSetNxFailClosed,
       queueMax: relayMetricsQueueMaxLifetime,
     },
   };
+}
+
+function recordNotificationDedupSetNxError({ surface, eventType, severity, action }) {
+  incrementRelayMetric('notificationDedupSetNxErrors');
+  incrementRelayMetric(action === 'fail_open' ? 'notificationDedupSetNxFailOpen' : 'notificationDedupSetNxFailClosed');
+  console.warn(buildSetNxErrorTelemetryLine({ surface, eventType, severity, action }));
 }
 
 // AIS aggregate state for snapshot API (server-side fanout)

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -12,7 +12,12 @@ const {
 const { callLLM } = require('./lib/llm-chain.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
-const { buildDedupMaterial } = require('./shared/notification-dedup.cjs');
+const {
+  buildDedupMaterial,
+  buildSetNxErrorTelemetryLine,
+  classifySetNxResult,
+  shouldPublishAfterDedupResult,
+} = require('./shared/notification-dedup.cjs');
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -67,6 +72,24 @@ async function upstashRest(...args) {
   return json.result;
 }
 
+async function upstashDedupSetNx(key) {
+  try {
+    const res = await fetch(`${UPSTASH_URL}/${['SET', key, '1', 'NX', 'EX', '1800'].map(encodeURIComponent).join('/')}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${UPSTASH_TOKEN}`, 'User-Agent': 'worldmonitor-relay/1.0' },
+    });
+    if (!res.ok) {
+      console.warn(`[relay] Upstash SETNX dedup error ${res.status}`);
+      return 'error';
+    }
+    const json = await res.json();
+    return classifySetNxResult(json.result);
+  } catch (err) {
+    console.warn('[relay] Upstash SETNX dedup request failed:', err?.message || err);
+    return 'error';
+  }
+}
+
 // ── Dedup ─────────────────────────────────────────────────────────────────────
 
 function sha256Hex(str) {
@@ -83,8 +106,7 @@ async function checkDedup(userId, eventType, title, coalesceKey) {
   const keyMaterial = buildDedupMaterial(eventType, title, coalesceKey);
   const hash = sha256Hex(keyMaterial);
   const key = `wm:notif:dedup:${userId}:${hash}`;
-  const result = await upstashRest('SET', key, '1', 'NX', 'EX', '1800');
-  return result === 'OK'; // true = new, false = duplicate
+  return upstashDedupSetNx(key);
 }
 
 // ── Channel deactivation ──────────────────────────────────────────────────────
@@ -1062,15 +1084,29 @@ async function processEvent(event) {
     const coalesceKey = typeof event.payload?.coalesceKey === 'string' ? event.payload.coalesceKey : undefined;
 
     if (quietAction === 'hold') {
-      const isNew = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
-      if (!isNew) { console.log(`[relay] Dedup hit (held) for ${rule.userId}`); continue; }
+      const dedupResult = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
+      if (!shouldPublishAfterDedupResult(dedupResult, eventSeverity)) {
+        if (dedupResult === 'duplicate') console.log(`[relay] Dedup hit (held) for ${rule.userId}`);
+        else console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay-held', eventType: event.eventType, severity: eventSeverity, action: 'fail_closed' }));
+        continue;
+      }
+      if (dedupResult === 'error') {
+        console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay-held', eventType: event.eventType, severity: eventSeverity, action: 'fail_open' }));
+      }
       console.log(`[relay] Quiet hours hold for ${rule.userId} — queuing for batch_on_wake`);
       await holdEvent(rule.userId, rule.variant ?? 'full', JSON.stringify(event));
       continue;
     }
 
-    const isNew = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
-    if (!isNew) { console.log(`[relay] Dedup hit for ${rule.userId}`); continue; }
+    const dedupResult = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
+    if (!shouldPublishAfterDedupResult(dedupResult, eventSeverity)) {
+      if (dedupResult === 'duplicate') console.log(`[relay] Dedup hit for ${rule.userId}`);
+      else console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay', eventType: event.eventType, severity: eventSeverity, action: 'fail_closed' }));
+      continue;
+    }
+    if (dedupResult === 'error') {
+      console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay', eventType: event.eventType, severity: eventSeverity, action: 'fail_open' }));
+    }
 
     let channels = [];
     try {

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -14,9 +14,8 @@ const { fetchUserPreferences, extractUserContext, formatUserProfile } = require(
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
 const {
   buildDedupMaterial,
-  buildSetNxErrorTelemetryLine,
   classifySetNxResult,
-  shouldPublishAfterDedupResult,
+  recordDedupOutcome,
 } = require('./shared/notification-dedup.cjs');
 
 // ── Config ────────────────────────────────────────────────────────────────────
@@ -35,6 +34,7 @@ const RESEND_FROM = process.env.RESEND_FROM_EMAIL ?? 'WorldMonitor <alerts@world
 const QUIET_HOURS_BATCH_ENABLED = process.env.QUIET_HOURS_BATCH_ENABLED !== '0';
 const AI_IMPACT_ENABLED = process.env.AI_IMPACT_ENABLED === '1';
 const AI_IMPACT_CACHE_TTL = 1800; // 30 min, matches dedup window
+const DEDUP_TTL_SECONDS = 1800;
 
 if (!UPSTASH_URL || !UPSTASH_TOKEN) { console.error('[relay] UPSTASH_REDIS_REST_URL/TOKEN not set'); process.exit(1); }
 if (!CONVEX_URL) { console.error('[relay] CONVEX_URL not set'); process.exit(1); }
@@ -74,18 +74,15 @@ async function upstashRest(...args) {
 
 async function upstashDedupSetNx(key) {
   try {
-    const res = await fetch(`${UPSTASH_URL}/${['SET', key, '1', 'NX', 'EX', '1800'].map(encodeURIComponent).join('/')}`, {
+    const res = await fetch(`${UPSTASH_URL}/${['SET', key, '1', 'NX', 'EX', String(DEDUP_TTL_SECONDS)].map(encodeURIComponent).join('/')}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${UPSTASH_TOKEN}`, 'User-Agent': 'worldmonitor-relay/1.0' },
+      signal: AbortSignal.timeout(10000),
     });
-    if (!res.ok) {
-      console.warn(`[relay] Upstash SETNX dedup error ${res.status}`);
-      return 'error';
-    }
+    if (!res.ok) return 'error';
     const json = await res.json();
     return classifySetNxResult(json.result);
   } catch (err) {
-    console.warn('[relay] Upstash SETNX dedup request failed:', err?.message || err);
     return 'error';
   }
 }
@@ -1085,13 +1082,17 @@ async function processEvent(event) {
 
     if (quietAction === 'hold') {
       const dedupResult = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
-      if (!shouldPublishAfterDedupResult(dedupResult, eventSeverity)) {
-        if (dedupResult === 'duplicate') console.log(`[relay] Dedup hit (held) for ${rule.userId}`);
-        else console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay-held', eventType: event.eventType, severity: eventSeverity, action: 'fail_closed' }));
+      const dedupDecision = recordDedupOutcome(dedupResult, {
+        surface: 'notification-relay-held',
+        eventType: event.eventType,
+        severity: eventSeverity,
+        fallbackKey: `held:${rule.userId}:${event.eventType}:${event.payload?.title ?? ''}:${coalesceKey ?? ''}`,
+        fallbackTtlSeconds: DEDUP_TTL_SECONDS,
+        emitTelemetry: ({ line }) => console.warn(line),
+      });
+      if (!dedupDecision.shouldPublish) {
+        if (dedupDecision.isDuplicate) console.log(`[relay] Dedup hit (held) for ${rule.userId}`);
         continue;
-      }
-      if (dedupResult === 'error') {
-        console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay-held', eventType: event.eventType, severity: eventSeverity, action: 'fail_open' }));
       }
       console.log(`[relay] Quiet hours hold for ${rule.userId} — queuing for batch_on_wake`);
       await holdEvent(rule.userId, rule.variant ?? 'full', JSON.stringify(event));
@@ -1099,13 +1100,17 @@ async function processEvent(event) {
     }
 
     const dedupResult = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
-    if (!shouldPublishAfterDedupResult(dedupResult, eventSeverity)) {
-      if (dedupResult === 'duplicate') console.log(`[relay] Dedup hit for ${rule.userId}`);
-      else console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay', eventType: event.eventType, severity: eventSeverity, action: 'fail_closed' }));
+    const dedupDecision = recordDedupOutcome(dedupResult, {
+      surface: 'notification-relay',
+      eventType: event.eventType,
+      severity: eventSeverity,
+      fallbackKey: `realtime:${rule.userId}:${event.eventType}:${event.payload?.title ?? ''}:${coalesceKey ?? ''}`,
+      fallbackTtlSeconds: DEDUP_TTL_SECONDS,
+      emitTelemetry: ({ line }) => console.warn(line),
+    });
+    if (!dedupDecision.shouldPublish) {
+      if (dedupDecision.isDuplicate) console.log(`[relay] Dedup hit for ${rule.userId}`);
       continue;
-    }
-    if (dedupResult === 'error') {
-      console.warn(buildSetNxErrorTelemetryLine({ surface: 'notification-relay', eventType: event.eventType, severity: eventSeverity, action: 'fail_open' }));
     }
 
     let channels = [];
@@ -1229,4 +1234,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { sendTelegram };
+module.exports = { sendTelegram, checkDedup, upstashDedupSetNx };

--- a/scripts/regional-snapshot/alert-emitter.mjs
+++ b/scripts/regional-snapshot/alert-emitter.mjs
@@ -39,6 +39,12 @@
 // touching the network.
 
 import { getRedisCredentials } from '../_seed-utils.mjs';
+import notificationDedup from '../shared/notification-dedup.cjs';
+
+const {
+  classifySetNxResult,
+  recordDedupOutcome,
+} = notificationDedup;
 
 // ── Event type constants ─────────────────────────────────────────────────────
 
@@ -199,18 +205,22 @@ export function buildDedupKey(event) {
 // ── Default Upstash publisher ────────────────────────────────────────────────
 
 async function upstashSetNx(url, token, key, ttlSeconds) {
-  // Path-based REST call: /set/{key}/{value}?NX=true&EX={ttl}
-  const resp = await fetch(
-    `${url}/set/${encodeURIComponent(key)}/1?NX=true&EX=${ttlSeconds}`,
-    {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(5_000),
-    },
-  );
-  if (!resp.ok) return false;
-  const json = await resp.json().catch(() => null);
-  return json?.result === 'OK';
+  try {
+    // Path-based REST call: /set/{key}/{value}?NX=true&EX={ttl}
+    const resp = await fetch(
+      `${url}/set/${encodeURIComponent(key)}/1?NX=true&EX=${ttlSeconds}`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+    if (!resp.ok) return 'error';
+    const json = await resp.json().catch(() => null);
+    return classifySetNxResult(json?.result);
+  } catch {
+    return 'error';
+  }
 }
 
 async function upstashLpush(url, token, key, value) {
@@ -249,7 +259,7 @@ async function upstashDel(url, token, key) {
  * testable without fetch stubs.
  *
  * @typedef {{
- *   setNx: (key: string, ttlSeconds: number) => Promise<boolean>,
+ *   setNx: (key: string, ttlSeconds: number) => Promise<boolean|'new'|'duplicate'|'error'|'disabled'>,
  *   lpush: (key: string, value: string) => Promise<boolean>,
  *   del: (key: string) => Promise<boolean>,
  * }} RedisPublishOps
@@ -262,6 +272,8 @@ async function upstashDel(url, token, key) {
  *
  * Flow:
  *   1. SET NX dedup key (6h TTL). If already set → dedup hit, return false.
+ *      SET NX transport errors fail open for high/critical events through the
+ *      shared notification-dedup policy, with in-process fallback suppression.
  *   2. LPUSH event onto wm:events:queue.
  *   3. If LPUSH fails → DEL the dedup key so the next cron cycle can retry.
  *      Otherwise the alert would be silently suppressed for 6h even though
@@ -279,14 +291,24 @@ export async function publishEventWithOps(event, ops) {
   const outcome = { enqueued: false, dedupHit: false, rolledBack: false };
   try {
     const dedupKey = buildDedupKey(event);
-    const isNew = await ops.setNx(dedupKey, DEDUP_TTL_SECONDS);
-    if (!isNew) {
-      outcome.dedupHit = true;
-      const title = String(event.payload?.title ?? '');
-      console.log(`[alerts] dedup skip: ${event.eventType} — ${title.slice(0, 60)}`);
+    const dedupResult = await ops.setNx(dedupKey, DEDUP_TTL_SECONDS);
+    const dedupDecision = recordDedupOutcome(dedupResult, {
+      surface: 'regional-snapshot',
+      eventType: event.eventType,
+      severity: event.severity,
+      fallbackKey: dedupKey,
+      fallbackTtlSeconds: DEDUP_TTL_SECONDS,
+      emitTelemetry: ({ line }) => console.warn(line),
+    });
+    if (!dedupDecision.shouldPublish) {
+      outcome.dedupHit = dedupDecision.isDuplicate;
+      if (dedupDecision.isDuplicate) {
+        const title = String(event.payload?.title ?? '');
+        console.log(`[alerts] dedup skip: ${event.eventType} — ${title.slice(0, 60)}`);
+      }
       return outcome;
     }
-    const msg = JSON.stringify({ ...event, publishedAt: Date.now() });
+    const msg = JSON.stringify({ ...event, severity: dedupDecision.severity, publishedAt: Date.now() });
     const ok = await ops.lpush('wm:events:queue', msg);
     if (ok) {
       outcome.enqueued = true;

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -43,9 +43,8 @@ import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const {
   buildDedupMaterial,
-  buildSetNxErrorTelemetryLine,
   classifySetNxResult,
-  shouldPublishAfterDedupResult,
+  recordDedupOutcome,
 } = notificationDedup;
 
 loadEnvFile(import.meta.url);
@@ -360,21 +359,23 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
     const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
     const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifyHash(dedupMaterial)}`;
     const dedupResult = await upstashSetNx(dedupKey, '1', dedupTtl);
-    if (!shouldPublishAfterDedupResult(dedupResult, severity)) {
-      if (dedupResult !== 'duplicate') {
-        console.warn(buildSetNxErrorTelemetryLine({ surface: 'seed-aviation', eventType, severity, action: 'fail_closed' }));
-        return;
-      }
+    const dedupDecision = recordDedupOutcome(dedupResult, {
+      surface: 'seed-aviation',
+      eventType,
+      severity,
+      fallbackKey: dedupKey,
+      fallbackTtlSeconds: dedupTtl,
+      emitTelemetry: ({ line }) => console.warn(line),
+    });
+    if (!dedupDecision.shouldPublish) {
+      if (!dedupDecision.isDuplicate) return;
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
       return;
     }
-    if (dedupResult === 'error') {
-      console.warn(buildSetNxErrorTelemetryLine({ surface: 'seed-aviation', eventType, severity, action: 'fail_open' }));
-    }
-    const msg = JSON.stringify({ eventType, payload, severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
+    const msg = JSON.stringify({ eventType, payload, severity: dedupDecision.severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
     const ok = await upstashLpush('wm:events:queue', msg);
     if (ok) {
-      console.log(`[Notify] Queued ${severity} event: ${eventType} — ${String(payload.title ?? '').slice(0, 60)}`);
+      console.log(`[Notify] Queued ${dedupDecision.severity} event: ${eventType} — ${String(payload.title ?? '').slice(0, 60)}`);
     } else {
       console.warn(`[Notify] LPUSH failed for ${eventType} — rolling back dedup key`);
       await upstashDel(dedupKey);

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -41,7 +41,12 @@ import {
 import notificationDedup from './shared/notification-dedup.cjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
-const { buildDedupMaterial } = notificationDedup;
+const {
+  buildDedupMaterial,
+  buildSetNxErrorTelemetryLine,
+  classifySetNxResult,
+  shouldPublishAfterDedupResult,
+} = notificationDedup;
 
 loadEnvFile(import.meta.url);
 
@@ -319,8 +324,8 @@ async function upstashSetNx(key, value, ttlSeconds) {
   try {
     const serialized = typeof value === 'string' ? value : JSON.stringify(value);
     const result = await upstashCommand(['SET', key, serialized, 'NX', 'EX', String(ttlSeconds)]);
-    return result?.result === 'OK' ? 'OK' : null;
-  } catch { return null; }
+    return classifySetNxResult(result?.result);
+  } catch { return 'error'; }
 }
 
 async function upstashLpush(key, value) {
@@ -354,10 +359,17 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
     const variantSuffix = variant ? `:${variant}` : '';
     const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
     const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifyHash(dedupMaterial)}`;
-    const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
-    if (!isNew) {
+    const dedupResult = await upstashSetNx(dedupKey, '1', dedupTtl);
+    if (!shouldPublishAfterDedupResult(dedupResult, severity)) {
+      if (dedupResult !== 'duplicate') {
+        console.warn(buildSetNxErrorTelemetryLine({ surface: 'seed-aviation', eventType, severity, action: 'fail_closed' }));
+        return;
+      }
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
       return;
+    }
+    if (dedupResult === 'error') {
+      console.warn(buildSetNxErrorTelemetryLine({ surface: 'seed-aviation', eventType, severity, action: 'fail_open' }));
     }
     const msg = JSON.stringify({ eventType, payload, severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
     const ok = await upstashLpush('wm:events:queue', msg);

--- a/scripts/shared/notification-dedup.cjs
+++ b/scripts/shared/notification-dedup.cjs
@@ -22,4 +22,41 @@ function buildDedupMaterial(eventType, title, coalesceKey) {
   return coalesceKey ? `coalesce:${coalesceKey}` : `${eventType}:${title ?? ''}`;
 }
 
-module.exports = { buildDedupMaterial };
+function classifySetNxResult(result) {
+  if (result === 'OK') return 'new';
+  if (result === null) return 'duplicate';
+  return 'error';
+}
+
+function isHighPriorityNotificationSeverity(severity) {
+  const normalized = String(severity ?? '').toLowerCase();
+  return normalized === 'critical' || normalized === 'high';
+}
+
+function shouldPublishAfterDedupResult(dedupResult, severity) {
+  if (dedupResult === 'new') return true;
+  if (dedupResult === 'duplicate') return false;
+  if (dedupResult === 'error') return isHighPriorityNotificationSeverity(severity);
+  return false;
+}
+
+function normalizeTelemetryToken(raw) {
+  const value = String(raw ?? 'unknown').trim().toLowerCase();
+  return (value || 'unknown').replace(/[^a-z0-9_.:-]+/g, '_').slice(0, 80);
+}
+
+function buildSetNxErrorTelemetryLine({ surface, eventType, severity, action }) {
+  return `[notifications] wm_notification_dedup_setnx_error ` +
+    `count=1 ` +
+    `surface=${normalizeTelemetryToken(surface)} ` +
+    `event_type=${normalizeTelemetryToken(eventType)} ` +
+    `severity=${normalizeTelemetryToken(severity)} ` +
+    `action=${normalizeTelemetryToken(action)}`;
+}
+
+module.exports = {
+  buildDedupMaterial,
+  classifySetNxResult,
+  shouldPublishAfterDedupResult,
+  buildSetNxErrorTelemetryLine,
+};

--- a/scripts/shared/notification-dedup.cjs
+++ b/scripts/shared/notification-dedup.cjs
@@ -22,17 +22,51 @@ function buildDedupMaterial(eventType, title, coalesceKey) {
   return coalesceKey ? `coalesce:${coalesceKey}` : `${eventType}:${title ?? ''}`;
 }
 
+const failOpenFallbackDedup = new Map();
+const MAX_FAIL_OPEN_FALLBACK_KEYS = 10_000;
+
+/**
+ * Convert an Upstash SET NX REST result into the publisher-facing dedup state.
+ *
+ * @param {unknown} result Upstash command result (`"OK"` for a new key, `null`
+ *   for an existing key); callers may also pass the already-classified
+ *   `"disabled"` token when Redis is deliberately unavailable.
+ * @returns {'new'|'duplicate'|'error'|'disabled'}
+ */
 function classifySetNxResult(result) {
   if (result === 'OK') return 'new';
   if (result === null) return 'duplicate';
+  if (result === 'disabled') return 'disabled';
   return 'error';
 }
 
+/**
+ * Normalize alert severity before dedup policy decisions and telemetry. Missing
+ * severity defaults to `high`, matching notification-relay's historical
+ * fail-open default for alert events.
+ *
+ * @param {unknown} severity
+ * @returns {string}
+ */
+function normalizeNotificationSeverity(severity) {
+  return String(severity ?? 'high').trim().toLowerCase() || 'high';
+}
+
 function isHighPriorityNotificationSeverity(severity) {
-  const normalized = String(severity ?? '').toLowerCase();
+  const normalized = normalizeNotificationSeverity(severity);
   return normalized === 'critical' || normalized === 'high';
 }
 
+/**
+ * Decide whether a publisher should continue after the dedup SET NX result.
+ *
+ * New keys always publish; duplicate keys suppress; disabled Redis suppresses
+ * without telemetry; SET NX errors fail open only for high/critical alerts.
+ *
+ * @param {'new'|'duplicate'|'error'|'disabled'} dedupResult
+ * @param {unknown} severity
+ * @returns {boolean}
+ */
 function shouldPublishAfterDedupResult(dedupResult, severity) {
   if (dedupResult === 'new') return true;
   if (dedupResult === 'duplicate') return false;
@@ -45,18 +79,108 @@ function normalizeTelemetryToken(raw) {
   return (value || 'unknown').replace(/[^a-z0-9_.:-]+/g, '_').slice(0, 80);
 }
 
-function buildSetNxErrorTelemetryLine({ surface, eventType, severity, action }) {
+/**
+ * Build the low-cardinality marker used by logs/Sentry/metrics for SET NX
+ * failures. Do not include user IDs, titles, or dedup keys.
+ *
+ * @param {{surface: unknown, eventType: unknown, severity: unknown, action: unknown, reason?: unknown}} params
+ * @returns {string}
+ */
+function buildSetNxErrorTelemetryLine({ surface, eventType, severity, action, reason = 'setnx_error' }) {
   return `[notifications] wm_notification_dedup_setnx_error ` +
     `count=1 ` +
     `surface=${normalizeTelemetryToken(surface)} ` +
     `event_type=${normalizeTelemetryToken(eventType)} ` +
     `severity=${normalizeTelemetryToken(severity)} ` +
-    `action=${normalizeTelemetryToken(action)}`;
+    `action=${normalizeTelemetryToken(action)} ` +
+    `reason=${normalizeTelemetryToken(reason)}`;
+}
+
+function normalizeDedupResult(result) {
+  if (result === 'new' || result === 'duplicate' || result === 'error' || result === 'disabled') return result;
+  if (result === true) return 'new';
+  if (result === false) return 'duplicate';
+  return classifySetNxResult(result);
+}
+
+function reserveFailOpenFallback(key, ttlSeconds, nowMs) {
+  if (!key || !Number.isFinite(ttlSeconds) || ttlSeconds <= 0) return false;
+  const existing = failOpenFallbackDedup.get(key);
+  if (existing && existing > nowMs) return true;
+
+  failOpenFallbackDedup.set(key, nowMs + ttlSeconds * 1000);
+  for (const [seenKey, expiresAt] of failOpenFallbackDedup) {
+    if (expiresAt <= nowMs || failOpenFallbackDedup.size > MAX_FAIL_OPEN_FALLBACK_KEYS) {
+      failOpenFallbackDedup.delete(seenKey);
+    }
+    if (failOpenFallbackDedup.size <= MAX_FAIL_OPEN_FALLBACK_KEYS) break;
+  }
+  return false;
+}
+
+/**
+ * Centralize the side-effecting SET NX dedup policy for notification publishers.
+ *
+ * During transient SET NX failures, high/critical alerts fail open once per
+ * dedup key and then use a bounded in-process fallback dedup for the same TTL.
+ * This is not a substitute for Redis, but it prevents a hot-loop duplicate
+ * storm while preserving the first critical delivery during a partial outage.
+ *
+ * @param {unknown} dedupResult Raw or classified SET NX result.
+ * @param {{
+ *   surface: unknown,
+ *   eventType: unknown,
+ *   severity?: unknown,
+ *   fallbackKey?: string,
+ *   fallbackTtlSeconds?: number,
+ *   nowMs?: number,
+ *   emitTelemetry?: (event: {line: string, action: string, reason: string, severity: string}) => void,
+ * }} options
+ * @returns {{shouldPublish: boolean, isDuplicate: boolean, dedupResult: string, action: string, severity: string}}
+ */
+function recordDedupOutcome(dedupResult, options) {
+  const result = normalizeDedupResult(dedupResult);
+  const severity = normalizeNotificationSeverity(options?.severity);
+  if (result === 'new') {
+    return { shouldPublish: true, isDuplicate: false, dedupResult: result, action: 'publish', severity };
+  }
+  if (result === 'duplicate') {
+    return { shouldPublish: false, isDuplicate: true, dedupResult: result, action: 'dedup_hit', severity };
+  }
+  if (result === 'disabled') {
+    return { shouldPublish: false, isDuplicate: false, dedupResult: result, action: 'disabled', severity };
+  }
+
+  const highPriority = isHighPriorityNotificationSeverity(severity);
+  let shouldPublish = highPriority;
+  let action = highPriority ? 'fail_open' : 'fail_closed';
+  if (highPriority && reserveFailOpenFallback(
+    options?.fallbackKey,
+    Number(options?.fallbackTtlSeconds),
+    Number(options?.nowMs) || Date.now(),
+  )) {
+    shouldPublish = false;
+    action = 'fallback_suppressed';
+  }
+  const reason = 'setnx_error';
+  const line = buildSetNxErrorTelemetryLine({
+    surface: options?.surface,
+    eventType: options?.eventType,
+    severity,
+    action,
+    reason,
+  });
+  if (typeof options?.emitTelemetry === 'function') {
+    options.emitTelemetry({ line, action, reason, severity });
+  }
+  return { shouldPublish, isDuplicate: action === 'fallback_suppressed', dedupResult: result, action, severity };
 }
 
 module.exports = {
   buildDedupMaterial,
   classifySetNxResult,
+  normalizeNotificationSeverity,
   shouldPublishAfterDedupResult,
   buildSetNxErrorTelemetryLine,
+  recordDedupOutcome,
 };

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -19,6 +19,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import Module from 'node:module';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -27,6 +28,7 @@ const require = createRequire(import.meta.url);
 const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'), 'utf-8');
 const aisRelaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf-8');
 const seedAviationSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'seed-aviation.mjs'), 'utf-8');
+const regionalAlertEmitterSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'regional-snapshot', 'alert-emitter.mjs'), 'utf-8');
 const notificationDedupSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'shared', 'notification-dedup.cjs'), 'utf-8');
 const notificationDedup = require('../scripts/shared/notification-dedup.cjs');
 
@@ -69,6 +71,67 @@ describe('notification-relay checkDedup — Slot B coalesce key', () => {
   });
 });
 
+describe('notification-relay checkDedup — SETNX transport outcomes', () => {
+  function loadRelayForUnitTest() {
+    const relayPath = resolve(__dirname, '..', 'scripts', 'notification-relay.cjs');
+    const previousEnv = {
+      UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+      UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+      CONVEX_URL: process.env.CONVEX_URL,
+      CONVEX_SITE_URL: process.env.CONVEX_SITE_URL,
+      RELAY_SHARED_SECRET: process.env.RELAY_SHARED_SECRET,
+    };
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    process.env.CONVEX_URL = 'https://example.convex.cloud';
+    process.env.CONVEX_SITE_URL = 'https://example.convex.site';
+    process.env.RELAY_SHARED_SECRET = 'secret';
+    delete require.cache[require.resolve(relayPath)];
+
+    const originalLoad = Module._load;
+    Module._load = function patchedLoad(request, parent, ...rest) {
+      if (request === 'resend') return { Resend: class {} };
+      return originalLoad.call(this, request, parent, ...rest);
+    };
+    try {
+      return require(relayPath);
+    } finally {
+      Module._load = originalLoad;
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  }
+
+  it('exports checkDedup and maps SET NX OK/null/non-OK with a timeout-bound fetch', async () => {
+    const relay = loadRelayForUnitTest();
+    assert.equal(typeof relay.checkDedup, 'function');
+
+    const originalFetch = globalThis.fetch;
+    const results = ['OK', null];
+    const seenSignals = [];
+    try {
+      globalThis.fetch = async (_url, init) => {
+        seenSignals.push(init?.signal);
+        const result = results.shift();
+        return { ok: true, json: async () => ({ result }) };
+      };
+      assert.equal(await relay.checkDedup('user1', 'market_alert', 'Oil spike'), 'new');
+      assert.equal(await relay.checkDedup('user1', 'market_alert', 'Oil spike'), 'duplicate');
+
+      globalThis.fetch = async (_url, init) => {
+        seenSignals.push(init?.signal);
+        return { ok: false, status: 503, json: async () => ({}) };
+      };
+      assert.equal(await relay.checkDedup('user1', 'market_alert', 'Oil spike'), 'error');
+      assert.ok(seenSignals.every(signal => signal instanceof AbortSignal));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe('shared notification-dedup helper — buildDedupMaterial', () => {
   it('keys on coalesceKey when set, else falls back to eventType:title', () => {
     assert.match(
@@ -82,17 +145,19 @@ describe('shared notification-dedup helper — buildDedupMaterial', () => {
     assert.equal(typeof notificationDedup.buildDedupMaterial, 'function', 'buildDedupMaterial must be exported');
   });
 
-  it('all three publishers import/require the shared helper (no re-inlined copies)', () => {
+  it('all notification publishers import/require the shared helper (no re-inlined copies)', () => {
     assert.match(relaySrc, /require\('\.\/shared\/notification-dedup\.cjs'\)/, 'notification-relay.cjs must require the shared helper');
     assert.match(aisRelaySrc, /require\('\.\/shared\/notification-dedup\.cjs'\)/, 'ais-relay.cjs must require the shared helper');
     assert.match(seedAviationSrc, /from '\.\/shared\/notification-dedup\.cjs'/, 'seed-aviation.mjs must import the shared helper');
+    assert.match(regionalAlertEmitterSrc, /from '\.\.\/shared\/notification-dedup\.cjs'/, 'regional alert emitter must import the shared helper');
   });
 });
 
 describe('shared notification-dedup helper — SETNX failure policy', () => {
-  it('distinguishes new keys, genuine duplicate hits, and Redis errors', () => {
+  it('distinguishes new keys, genuine duplicate hits, disabled Redis, and Redis errors', () => {
     assert.equal(notificationDedup.classifySetNxResult('OK'), 'new');
     assert.equal(notificationDedup.classifySetNxResult(null), 'duplicate');
+    assert.equal(notificationDedup.classifySetNxResult('disabled'), 'disabled');
     assert.equal(notificationDedup.classifySetNxResult(undefined), 'error');
     assert.equal(notificationDedup.classifySetNxResult('ERR'), 'error');
   });
@@ -100,10 +165,55 @@ describe('shared notification-dedup helper — SETNX failure policy', () => {
   it('fails open only for high-priority notification severities on SETNX errors', () => {
     assert.equal(notificationDedup.shouldPublishAfterDedupResult('new', 'low'), true);
     assert.equal(notificationDedup.shouldPublishAfterDedupResult('duplicate', 'critical'), false);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('disabled', 'critical'), false);
     assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', 'critical'), true);
     assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', 'high'), true);
     assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', 'info'), false);
-    assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', undefined), false);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', undefined), true);
+  });
+
+  it('records the shared SETNX outcome branch and caps repeat fail-open publishes in-process', () => {
+    const emitted = [];
+    const fallbackKey = `unit:${Date.now()}:setnx-error`;
+    const first = notificationDedup.recordDedupOutcome('error', {
+      surface: 'notification-relay',
+      eventType: 'market_alert',
+      severity: 'critical',
+      fallbackKey,
+      fallbackTtlSeconds: 60,
+      nowMs: 1_000,
+      emitTelemetry: event => emitted.push(event),
+    });
+    assert.equal(first.shouldPublish, true);
+    assert.equal(first.isDuplicate, false);
+    assert.equal(first.action, 'fail_open');
+
+    const second = notificationDedup.recordDedupOutcome('error', {
+      surface: 'notification-relay',
+      eventType: 'market_alert',
+      severity: 'critical',
+      fallbackKey,
+      fallbackTtlSeconds: 60,
+      nowMs: 2_000,
+      emitTelemetry: event => emitted.push(event),
+    });
+    assert.equal(second.shouldPublish, false);
+    assert.equal(second.isDuplicate, true);
+    assert.equal(second.action, 'fallback_suppressed');
+    assert.equal(emitted.length, 2);
+  });
+
+  it('keeps low-priority SETNX errors fail-closed through the shared outcome branch', () => {
+    const decision = notificationDedup.recordDedupOutcome('error', {
+      surface: 'notification-relay',
+      eventType: 'market_alert',
+      severity: 'low',
+      fallbackKey: `unit:${Date.now()}:low`,
+      fallbackTtlSeconds: 60,
+      emitTelemetry: () => {},
+    });
+    assert.equal(decision.shouldPublish, false);
+    assert.equal(decision.action, 'fail_closed');
   });
 
   it('emits a stable low-cardinality Sentry/metric marker for SETNX errors', () => {
@@ -115,7 +225,7 @@ describe('shared notification-dedup helper — SETNX failure policy', () => {
     });
     assert.equal(
       line,
-      '[notifications] wm_notification_dedup_setnx_error count=1 surface=notification_relay event_type=market_alert severity=critical action=fail_open',
+      '[notifications] wm_notification_dedup_setnx_error count=1 surface=notification_relay event_type=market_alert severity=critical action=fail_open reason=setnx_error',
     );
     assert.ok(!line.includes('user'), 'telemetry marker must not include user identifiers');
     assert.ok(!line.includes('title'), 'telemetry marker must not include alert titles');
@@ -124,23 +234,28 @@ describe('shared notification-dedup helper — SETNX failure policy', () => {
   it('all notification publishers consume the shared SETNX classification helper', () => {
     assert.match(
       notificationDedupSrc,
-      /module\.exports\s*=\s*\{[\s\S]*classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine[\s\S]*\}/,
-      'shared helper must export the SETNX classifier, publish policy, and telemetry marker',
+      /module\.exports\s*=\s*\{[\s\S]*classifySetNxResult[\s\S]*recordDedupOutcome[\s\S]*\}/,
+      'shared helper must export the SETNX classifier and outcome recorder',
     );
     assert.match(
       relaySrc,
-      /classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine/,
-      'notification-relay.cjs must use the shared SETNX classifier, publish policy, and telemetry marker',
+      /classifySetNxResult[\s\S]*recordDedupOutcome/,
+      'notification-relay.cjs must use the shared SETNX classifier and outcome recorder',
     );
     assert.match(
       aisRelaySrc,
-      /classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine/,
-      'ais-relay.cjs must use the shared SETNX classifier, publish policy, and telemetry marker',
+      /classifySetNxResult[\s\S]*recordDedupOutcome/,
+      'ais-relay.cjs must use the shared SETNX classifier and outcome recorder',
     );
     assert.match(
       seedAviationSrc,
-      /classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine/,
-      'seed-aviation.mjs must use the shared SETNX classifier, publish policy, and telemetry marker',
+      /classifySetNxResult[\s\S]*recordDedupOutcome/,
+      'seed-aviation.mjs must use the shared SETNX classifier and outcome recorder',
+    );
+    assert.match(
+      regionalAlertEmitterSrc,
+      /classifySetNxResult[\s\S]*recordDedupOutcome/,
+      'regional alert emitter must use the shared SETNX classifier and outcome recorder',
     );
   });
 

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -18,14 +18,17 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'), 'utf-8');
 const aisRelaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf-8');
 const seedAviationSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'seed-aviation.mjs'), 'utf-8');
 const notificationDedupSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'shared', 'notification-dedup.cjs'), 'utf-8');
+const notificationDedup = require('../scripts/shared/notification-dedup.cjs');
 
 describe('notification-relay checkDedup — Slot B coalesce key', () => {
   it('checkDedup signature accepts an optional coalesceKey parameter', () => {
@@ -76,17 +79,82 @@ describe('shared notification-dedup helper — buildDedupMaterial', () => {
   });
 
   it('is exported for reuse by all publishers', () => {
-    assert.match(
-      notificationDedupSrc,
-      /module\.exports\s*=\s*\{\s*buildDedupMaterial\s*\}/,
-      'buildDedupMaterial must be exported',
-    );
+    assert.equal(typeof notificationDedup.buildDedupMaterial, 'function', 'buildDedupMaterial must be exported');
   });
 
   it('all three publishers import/require the shared helper (no re-inlined copies)', () => {
     assert.match(relaySrc, /require\('\.\/shared\/notification-dedup\.cjs'\)/, 'notification-relay.cjs must require the shared helper');
     assert.match(aisRelaySrc, /require\('\.\/shared\/notification-dedup\.cjs'\)/, 'ais-relay.cjs must require the shared helper');
     assert.match(seedAviationSrc, /from '\.\/shared\/notification-dedup\.cjs'/, 'seed-aviation.mjs must import the shared helper');
+  });
+});
+
+describe('shared notification-dedup helper — SETNX failure policy', () => {
+  it('distinguishes new keys, genuine duplicate hits, and Redis errors', () => {
+    assert.equal(notificationDedup.classifySetNxResult('OK'), 'new');
+    assert.equal(notificationDedup.classifySetNxResult(null), 'duplicate');
+    assert.equal(notificationDedup.classifySetNxResult(undefined), 'error');
+    assert.equal(notificationDedup.classifySetNxResult('ERR'), 'error');
+  });
+
+  it('fails open only for high-priority notification severities on SETNX errors', () => {
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('new', 'low'), true);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('duplicate', 'critical'), false);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', 'critical'), true);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', 'high'), true);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', 'info'), false);
+    assert.equal(notificationDedup.shouldPublishAfterDedupResult('error', undefined), false);
+  });
+
+  it('emits a stable low-cardinality Sentry/metric marker for SETNX errors', () => {
+    const line = notificationDedup.buildSetNxErrorTelemetryLine({
+      surface: 'Notification Relay',
+      eventType: 'market_alert',
+      severity: 'critical',
+      action: 'fail_open',
+    });
+    assert.equal(
+      line,
+      '[notifications] wm_notification_dedup_setnx_error count=1 surface=notification_relay event_type=market_alert severity=critical action=fail_open',
+    );
+    assert.ok(!line.includes('user'), 'telemetry marker must not include user identifiers');
+    assert.ok(!line.includes('title'), 'telemetry marker must not include alert titles');
+  });
+
+  it('all notification publishers consume the shared SETNX classification helper', () => {
+    assert.match(
+      notificationDedupSrc,
+      /module\.exports\s*=\s*\{[\s\S]*classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine[\s\S]*\}/,
+      'shared helper must export the SETNX classifier, publish policy, and telemetry marker',
+    );
+    assert.match(
+      relaySrc,
+      /classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine/,
+      'notification-relay.cjs must use the shared SETNX classifier, publish policy, and telemetry marker',
+    );
+    assert.match(
+      aisRelaySrc,
+      /classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine/,
+      'ais-relay.cjs must use the shared SETNX classifier, publish policy, and telemetry marker',
+    );
+    assert.match(
+      seedAviationSrc,
+      /classifySetNxResult[\s\S]*shouldPublishAfterDedupResult[\s\S]*buildSetNxErrorTelemetryLine/,
+      'seed-aviation.mjs must use the shared SETNX classifier, publish policy, and telemetry marker',
+    );
+  });
+
+  it('ais-relay exposes SETNX error counters in /metrics rollups', () => {
+    assert.match(
+      aisRelaySrc,
+      /notificationDedupSetNxErrors:\s*0/,
+      'rolling metrics bucket must count notification SETNX errors',
+    );
+    assert.match(
+      aisRelaySrc,
+      /notifications:\s*\{[\s\S]*dedupSetNxErrors[\s\S]*dedupSetNxFailOpen[\s\S]*dedupSetNxFailClosed[\s\S]*\}/,
+      '/metrics output must expose notification SETNX error counters',
+    );
   });
 });
 

--- a/tests/regional-snapshot-alerts.test.mjs
+++ b/tests/regional-snapshot-alerts.test.mjs
@@ -425,10 +425,10 @@ describe('publishEventWithOps — dedup rollback', () => {
     const deletedKeys = [];
     const ops = {
       setNx: async (key, _ttl) => {
-        if (setNxFails) return false;
-        if (dedupKeys[key]) return false;
+        if (setNxFails) return 'error';
+        if (dedupKeys[key]) return 'duplicate';
         dedupKeys[key] = true;
-        return true;
+        return 'new';
       },
       lpush: async (_key, value) => {
         if (lpushFails) return false;
@@ -467,6 +467,33 @@ describe('publishEventWithOps — dedup rollback', () => {
     assert.deepEqual(outcome, { enqueued: false, dedupHit: true, rolledBack: false });
     assert.equal(mem.queue.length, 0);
     assert.equal(mem.deletedKeys.length, 0);
+  });
+
+  it('SETNX error fails open for the first high-priority alert, then fallback-suppresses repeats', async () => {
+    const mem = memoryOps({ setNxFails: true });
+    const event = {
+      ...sampleEvent,
+      payload: { title: `MENA: regime shift SETNX outage ${Date.now()}` },
+    };
+    const first = await publishEventWithOps(event, mem.ops);
+    assert.deepEqual(first, { enqueued: true, dedupHit: false, rolledBack: false });
+    assert.equal(mem.queue.length, 1);
+
+    const second = await publishEventWithOps(event, mem.ops);
+    assert.deepEqual(second, { enqueued: false, dedupHit: true, rolledBack: false });
+    assert.equal(mem.queue.length, 1);
+  });
+
+  it('SETNX error fails closed for low-priority injected test events', async () => {
+    const mem = memoryOps({ setNxFails: true });
+    const lowEvent = {
+      ...sampleEvent,
+      severity: 'low',
+      payload: { title: `MENA: low-priority SETNX outage ${Date.now()}` },
+    };
+    const outcome = await publishEventWithOps(lowEvent, mem.ops);
+    assert.deepEqual(outcome, { enqueued: false, dedupHit: false, rolledBack: false });
+    assert.equal(mem.queue.length, 0);
   });
 
   it('LPUSH failure: dedup key is rolled back via DEL', async () => {


### PR DESCRIPTION
## Summary

Notification publishers no longer treat Redis/Upstash SETNX failures as duplicate hits. A transient dedup-store outage now preserves high and critical alert delivery by failing open, while genuine duplicate hits still suppress repeated notifications.

The affected publisher and relay paths now share one result classifier for `SET ... NX`: `new`, `duplicate`, or `error`. SETNX errors emit a stable low-cardinality marker, `wm_notification_dedup_setnx_error`, with surface, event type, severity, and fail-open/fail-closed action fields so operator log/Sentry pipelines can alert on the condition without leaking user IDs or alert titles. The long-running AIS relay also exposes rolling and lifetime `/metrics` counters for SETNX dedup errors and their fail-open/fail-closed split.

Fixes #4990

## Validation

- `node --test tests/notification-relay-coalesce-key.test.mjs` (27/27)
- `node --check scripts/notification-relay.cjs`
- `node --check scripts/ais-relay.cjs`
- `node --check scripts/seed-aviation.mjs`
- `git diff --check`
- Pre-push hook passed: frontend typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundary lint, safe HTML guard, rate-limit policy guard, premium-fetch guard, edge bundle check, changed test files, version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
