### PR TITLE
fix(forecast): harden simulation outcome writes

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -76,7 +76,14 @@ const SIMULATION_DECORATIONS_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48h — skip a
 const SIMULATION_ROUND1_MAX_TOKENS = 2200;
 const SIMULATION_ROUND2_MAX_TOKENS = 2500;
 const SIMULATION_LOCK_TTL_SECONDS = 20 * 60;
-const SIMULATION_LOCK_MAX_TTL_MULTIPLIER = 6;
+const SIMULATION_LOCK_MAX_TTL_MULTIPLIER = 3;
+const REDIS_WRITE_IF_NEWER_SKIPPED_PREFIX = 'SKIPPED:';
+const SIM_LOCK_STATUS_DELETED = 'DELETED';
+const SIM_LOCK_STATUS_EXTENDED = 'EXTENDED';
+const SIM_LOCK_STATUS_EXPIRED = 'EXPIRED';
+const SIM_LOCK_STATUS_OWNED_BY_OTHER = 'OWNED_BY_OTHER';
+const SIM_TASK_COMPLETE_STATUS_COMPLETED = 'COMPLETED';
+const SIM_TASK_COMPLETE_STATUS_MISSING_WORKER = 'MISSING_WORKER';
 const SIMULATION_POLL_INTERVAL_MS = 30 * 1000;
 const PUBLISH_MIN_PROBABILITY = 0;
 const PANEL_MIN_PROBABILITY = 0.1;
@@ -97,6 +104,22 @@ const MIN_TARGET_PUBLISHED_FORECASTS = 10;
 const MAX_TARGET_PUBLISHED_FORECASTS = 14;
 const MAX_PRESELECTED_FORECASTS_PER_FAMILY = 3;
 const MAX_PRESELECTED_FORECASTS_PER_SITUATION = 2;
+
+function isRedisWriteSkippedStatus(status) {
+  return typeof status === 'string' && status.startsWith(REDIS_WRITE_IF_NEWER_SKIPPED_PREFIX);
+}
+
+function redisWriteSkippedGeneratedAt(status) {
+  return String(status || '').slice(REDIS_WRITE_IF_NEWER_SKIPPED_PREFIX.length);
+}
+
+function createSimulationWorkerId() {
+  const randomSuffix = typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : crypto.randomBytes(16).toString('hex');
+  return `sim-worker-${process.pid}-${Date.now()}-${randomSuffix}`;
+}
+
 // stateKind values that legitimately drive maritime energy/freight supply_chain forecasts.
 // Defined at module scope — not per-call — to avoid re-allocating the Set on every invocation.
 const MARITIME_BUCKET_STATE_KINDS = new Set([
@@ -17203,8 +17226,8 @@ async function writeSimulationDecorations(mergeResult, snapshot) {
       generatedAt: runGeneratedAt,
       byForecastId,
     }, SIMULATION_DECORATIONS_TTL_SECONDS);
-    if (sideKeyStatus.startsWith('SKIPPED:')) {
-      console.log(`  [SimulationDecorations] Skipping side key write — existing is from a newer run (existing=${sideKeyStatus.slice(8)}, this_run=${runGeneratedAt})`);
+    if (isRedisWriteSkippedStatus(sideKeyStatus)) {
+      console.log(`  [SimulationDecorations] Skipping side key write — existing is from a newer run (existing=${redisWriteSkippedGeneratedAt(sideKeyStatus)}, this_run=${runGeneratedAt})`);
       return;
     }
     await redisSet(url, token, SIMULATION_DECORATIONS_META_KEY, {
@@ -17221,16 +17244,16 @@ async function writeSimulationDecorations(mergeResult, snapshot) {
   }
 }
 
-// Lua script for atomic write-if-newer of the simulation decoration side key.
-// Prevents a late older worker from overwriting a newer run's decorations.
+// Lua script for atomic write-if-newer of Redis JSON payloads with generatedAt.
+// Prevents a late older worker from overwriting a newer run's pointers/decorations.
 //
-// KEYS[1]  = SIMULATION_DECORATIONS_KEY (forecast:sim-decorations:v1)
-// ARGV[1]  = runGeneratedAt of this run (decimal string; '0' = unconditional write)
+// KEYS[1]  = Redis key
+// ARGV[1]  = payload.generatedAt of this run (decimal string; '0' = unconditional write)
 // ARGV[2]  = new payload JSON string
 // ARGV[3]  = TTL in seconds
 //
 // Returns: 'WRITTEN' | 'SKIPPED:<existingGeneratedAt>'
-const _SIM_SIDE_WRITE_LUA = `
+const _REDIS_WRITE_IF_NEWER_LUA = `
 local raw = redis.call('GET', KEYS[1])
 if raw then
   local ok, existing = pcall(cjson.decode, raw)
@@ -17245,14 +17268,46 @@ return 'WRITTEN'
 `.trim();
 
 /**
- * Atomically write the simulation decoration side key only if this run is newer
- * than any existing value. Prevents a late older worker from poisoning the side key
- * with stale byForecastId data.
+ * Atomically write a generatedAt-bearing Redis payload only if this run is not
+ * older than the value already stored at the key.
  *
  * Production path: single Redis EVAL (atomic read-compare-write).
  * Test path (_testRedisStore set): equivalent JavaScript logic.
  *
  * Returns: 'WRITTEN' | 'SKIPPED:<existingGeneratedAt>'
+ *
+ * @param {string} url
+ * @param {string} token
+ * @param {string} key
+ * @param {{ generatedAt?: number }} payload
+ * @param {number} ttlSeconds
+ * @returns {Promise<string>}
+ */
+async function redisAtomicWriteIfNewer(url, token, key, payload, ttlSeconds) {
+  // ── Test path ────────────────────────────────────────────────────────────────
+  if (_testRedisStore) {
+    const existing = _testRedisStore[key] ?? null;
+    const existingTs = typeof existing?.generatedAt === 'number' ? existing.generatedAt : 0;
+    const runTs = typeof payload.generatedAt === 'number' ? payload.generatedAt : 0;
+    if (runTs > 0 && existingTs > runTs) return `${REDIS_WRITE_IF_NEWER_SKIPPED_PREFIX}${existingTs}`;
+    _testRedisStore[key] = JSON.parse(JSON.stringify(payload));
+    return 'WRITTEN';
+  }
+  // ── Production path: Lua EVAL ────────────────────────────────────────────────
+  const result = await redisCommand(url, token, [
+    'EVAL', _REDIS_WRITE_IF_NEWER_LUA, '1',
+    key,
+    String(typeof payload.generatedAt === 'number' ? payload.generatedAt : 0),
+    JSON.stringify(payload),
+    String(ttlSeconds),
+  ]);
+  return result?.result ?? 'WRITTEN';
+}
+
+/**
+ * Atomically write the simulation decoration side key only if this run is newer
+ * than any existing value. Prevents a late older worker from poisoning the side key
+ * with stale byForecastId data.
  *
  * @param {string} url
  * @param {string} token
@@ -17262,49 +17317,8 @@ return 'WRITTEN'
  * @returns {Promise<string>}
  */
 async function redisAtomicWriteSimDecorations(url, token, key, payload, ttlSeconds) {
-  // ── Test path ────────────────────────────────────────────────────────────────
-  if (_testRedisStore) {
-    const existing = _testRedisStore[key] ?? null;
-    const existingTs = typeof existing?.generatedAt === 'number' ? existing.generatedAt : 0;
-    const runTs = typeof payload.generatedAt === 'number' ? payload.generatedAt : 0;
-    if (runTs > 0 && existingTs > runTs) return `SKIPPED:${existingTs}`;
-    _testRedisStore[key] = JSON.parse(JSON.stringify(payload));
-    return 'WRITTEN';
-  }
-  // ── Production path: Lua EVAL ────────────────────────────────────────────────
-  const result = await redisCommand(url, token, [
-    'EVAL', _SIM_SIDE_WRITE_LUA, '1',
-    key,
-    String(typeof payload.generatedAt === 'number' ? payload.generatedAt : 0),
-    JSON.stringify(payload),
-    String(ttlSeconds),
-  ]);
-  return result?.result ?? 'WRITTEN';
+  return redisAtomicWriteIfNewer(url, token, key, payload, ttlSeconds);
 }
-
-// Lua script for atomic write-if-newer of simulation outcome pointers.
-// Prevents a late older simulation worker from regressing :latest or a by-run
-// pointer after a newer payload has already landed.
-//
-// KEYS[1] = outcome pointer key
-// ARGV[1] = payload.generatedAt
-// ARGV[2] = payload JSON
-// ARGV[3] = TTL seconds
-//
-// Returns: 'WRITTEN' | 'SKIPPED:<existingGeneratedAt>'
-const _SIM_OUTCOME_POINTER_WRITE_LUA = `
-local raw = redis.call('GET', KEYS[1])
-if raw then
-  local ok, existing = pcall(cjson.decode, raw)
-  local existingTs = ok and tonumber(existing.generatedAt) or 0
-  local runTs = tonumber(ARGV[1]) or 0
-  if runTs > 0 and existingTs > runTs then
-    return 'SKIPPED:' .. tostring(existingTs)
-  end
-end
-redis.call('SET', KEYS[1], ARGV[2], 'EX', tonumber(ARGV[3]))
-return 'WRITTEN'
-`.trim();
 
 /**
  * Atomically write a simulation outcome pointer only if the incoming run is
@@ -17318,37 +17332,83 @@ return 'WRITTEN'
  * @returns {Promise<string>}
  */
 async function redisAtomicWriteSimulationOutcomePointer(url, token, key, payload, ttlSeconds) {
-  if (_testRedisStore) {
-    const existing = _testRedisStore[key] ?? null;
-    const existingTs = typeof existing?.generatedAt === 'number' ? existing.generatedAt : 0;
-    const runTs = typeof payload.generatedAt === 'number' ? payload.generatedAt : 0;
-    if (runTs > 0 && existingTs > runTs) return `SKIPPED:${existingTs}`;
-    _testRedisStore[key] = JSON.parse(JSON.stringify(payload));
-    return 'WRITTEN';
-  }
-  const result = await redisCommand(url, token, [
-    'EVAL', _SIM_OUTCOME_POINTER_WRITE_LUA, '1',
-    key,
-    String(typeof payload.generatedAt === 'number' ? payload.generatedAt : 0),
-    JSON.stringify(payload),
-    String(ttlSeconds),
-  ]);
-  return result?.result ?? 'WRITTEN';
+  return redisAtomicWriteIfNewer(url, token, key, payload, ttlSeconds);
 }
 
 const _SIM_LOCK_RELEASE_LUA = `
-if redis.call('GET', KEYS[1]) == ARGV[1] then
-  return redis.call('DEL', KEYS[1])
-end
-return 0
+local owner = redis.call('GET', KEYS[1])
+if not owner then return 'EXPIRED' end
+if owner ~= ARGV[1] then return 'OWNED_BY_OTHER' end
+redis.call('DEL', KEYS[1])
+return 'DELETED'
+`.trim();
+
+const _SIM_TASK_COMPLETE_LUA = `
+local owner = redis.call('GET', KEYS[3])
+if not owner then return 'EXPIRED' end
+if owner ~= ARGV[1] then return 'OWNED_BY_OTHER' end
+redis.call('ZREM', KEYS[1], ARGV[2])
+redis.call('DEL', KEYS[2])
+redis.call('DEL', KEYS[3])
+return 'COMPLETED'
 `.trim();
 
 const _SIM_LOCK_EXPIRE_LUA = `
-if redis.call('GET', KEYS[1]) == ARGV[1] then
-  return redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
-end
-return 0
+local owner = redis.call('GET', KEYS[1])
+if not owner then return 'EXPIRED' end
+if owner ~= ARGV[1] then return 'OWNED_BY_OTHER' end
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+return 'EXTENDED'
 `.trim();
+
+function removeRunIdFromTestQueue(runId) {
+  if (!_testRedisStore || !Array.isArray(_testRedisStore[SIMULATION_TASK_QUEUE_KEY])) return;
+  _testRedisStore[SIMULATION_TASK_QUEUE_KEY] = _testRedisStore[SIMULATION_TASK_QUEUE_KEY].filter((entry) => entry !== runId);
+}
+
+function simulationLockStatusFromTestStore(lockKey, workerId, successStatus) {
+  if (!workerId) return SIM_TASK_COMPLETE_STATUS_MISSING_WORKER;
+  const owner = _testRedisStore?.[lockKey];
+  if (!owner) return SIM_LOCK_STATUS_EXPIRED;
+  if (owner !== workerId) return SIM_LOCK_STATUS_OWNED_BY_OTHER;
+  return successStatus;
+}
+
+async function redisCompleteSimulationTaskIfOwned(url, token, runId, workerId) {
+  if (!workerId) return SIM_TASK_COMPLETE_STATUS_MISSING_WORKER;
+  const taskKey = buildSimulationTaskKey(runId);
+  const lockKey = buildSimulationLockKey(runId);
+  if (_testRedisStore) {
+    const status = simulationLockStatusFromTestStore(lockKey, workerId, SIM_TASK_COMPLETE_STATUS_COMPLETED);
+    if (status !== SIM_TASK_COMPLETE_STATUS_COMPLETED) return status;
+    removeRunIdFromTestQueue(runId);
+    delete _testRedisStore[taskKey];
+    delete _testRedisStore[lockKey];
+    return SIM_TASK_COMPLETE_STATUS_COMPLETED;
+  }
+  const result = await redisCommand(url, token, [
+    'EVAL', _SIM_TASK_COMPLETE_LUA, '3',
+    SIMULATION_TASK_QUEUE_KEY,
+    taskKey,
+    lockKey,
+    workerId,
+    runId,
+  ]);
+  return String(result?.result || SIM_TASK_COMPLETE_STATUS_COMPLETED);
+}
+
+function logSimulationTaskCleanupStatus(runId, workerId, status) {
+  if (status === SIM_TASK_COMPLETE_STATUS_COMPLETED) return;
+  if (status === SIM_LOCK_STATUS_EXPIRED) {
+    console.warn(`  [Simulation] Did not complete ${runId}; lock expired before cleanup (${workerId})`);
+  } else if (status === SIM_LOCK_STATUS_OWNED_BY_OTHER) {
+    console.warn(`  [Simulation] Did not complete ${runId}; lock owned by another worker (${workerId})`);
+  } else if (status === SIM_TASK_COMPLETE_STATUS_MISSING_WORKER) {
+    console.warn(`  [Simulation] Did not complete ${runId}; missing worker id`);
+  } else {
+    console.warn(`  [Simulation] Did not complete ${runId}; unexpected cleanup status ${status}`);
+  }
+}
 
 /**
  * Compute the simulation task lock TTL from the amount of theater work queued
@@ -17374,21 +17434,22 @@ function computeSimulationLockTtlSeconds(theaterCount) {
  * @param {string} token
  * @param {string} lockKey
  * @param {string} workerId
- * @returns {Promise<boolean>}
+ * @returns {Promise<string>}
  */
 async function redisCompareAndDeleteSimulationLock(url, token, lockKey, workerId) {
-  if (!workerId) return false;
+  if (!workerId) return SIM_TASK_COMPLETE_STATUS_MISSING_WORKER;
   if (_testRedisStore) {
-    if (_testRedisStore[lockKey] !== workerId) return false;
+    const status = simulationLockStatusFromTestStore(lockKey, workerId, SIM_LOCK_STATUS_DELETED);
+    if (status !== SIM_LOCK_STATUS_DELETED) return status;
     delete _testRedisStore[lockKey];
-    return true;
+    return SIM_LOCK_STATUS_DELETED;
   }
   const result = await redisCommand(url, token, [
     'EVAL', _SIM_LOCK_RELEASE_LUA, '1',
     lockKey,
     workerId,
   ]);
-  return Number(result?.result || 0) > 0;
+  return String(result?.result || SIM_LOCK_STATUS_EXPIRED);
 }
 
 /**
@@ -17399,14 +17460,13 @@ async function redisCompareAndDeleteSimulationLock(url, token, lockKey, workerId
  * @param {string} lockKey
  * @param {string} workerId
  * @param {number} ttlSeconds
- * @returns {Promise<boolean>}
+ * @returns {Promise<string>}
  */
 async function redisCompareAndExpireSimulationLock(url, token, lockKey, workerId, ttlSeconds) {
-  if (!workerId) return false;
+  if (!workerId) return SIM_TASK_COMPLETE_STATUS_MISSING_WORKER;
   const ttl = Number.isFinite(ttlSeconds) ? Math.max(1, Math.floor(ttlSeconds)) : SIMULATION_LOCK_TTL_SECONDS;
   if (_testRedisStore) {
-    if (_testRedisStore[lockKey] !== workerId) return false;
-    return true;
+    return simulationLockStatusFromTestStore(lockKey, workerId, SIM_LOCK_STATUS_EXTENDED);
   }
   const result = await redisCommand(url, token, [
     'EVAL', _SIM_LOCK_EXPIRE_LUA, '1',
@@ -17414,7 +17474,7 @@ async function redisCompareAndExpireSimulationLock(url, token, lockKey, workerId
     workerId,
     String(ttl),
   ]);
-  return Number(result?.result || 0) > 0;
+  return String(result?.result || SIM_LOCK_STATUS_EXPIRED);
 }
 
 // Lua script for atomic compare-and-swap patch of the canonical forecast key.
@@ -17565,8 +17625,8 @@ async function patchPublishedForecastsWithSimDecorations(byForecastId, runGenera
     const status = await redisAtomicPatchSimDecorations(url, token, CANONICAL_KEY, byForecastId, runGeneratedAt, TTL_SECONDS);
     if (status.startsWith('PATCHED:')) {
       console.log(`  [SimulationDecorations] Patched ${status.slice(8)} forecasts in ${CANONICAL_KEY} (atomic)`);
-    } else if (status.startsWith('SKIPPED:')) {
-      console.log(`  [SimulationDecorations] Skipping patch — canonical key is from a newer run (published=${status.slice(8)}, sim_run=${runGeneratedAt})`);
+    } else if (isRedisWriteSkippedStatus(status)) {
+      console.log(`  [SimulationDecorations] Skipping patch — canonical key is from a newer run (published=${redisWriteSkippedGeneratedAt(status)}, sim_run=${runGeneratedAt})`);
     } else if (status === 'MISSING') {
       console.warn('  [SimulationDecorations] Cannot patch canonical key — predictions missing or not an array');
     }
@@ -17804,8 +17864,8 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
     outcomePayload,
     TRACE_REDIS_TTL_SECONDS,
   );
-  if (latestStatus.startsWith('SKIPPED:')) {
-    console.log(`  [Simulation] Skipping stale :latest outcome pointer for ${runId} — existing=${latestStatus.slice(8)} this_run=${outcomePayload.generatedAt}`);
+  if (isRedisWriteSkippedStatus(latestStatus)) {
+    console.log(`  [Simulation] Skipping stale :latest outcome pointer for ${runId} — existing=${redisWriteSkippedGeneratedAt(latestStatus)} this_run=${outcomePayload.generatedAt}`);
   }
 
   // Secondary :by-run write — D9. Failure must NOT block the worker
@@ -17821,8 +17881,8 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
       outcomePayload,
       SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS,
     );
-    if (byRunStatus.startsWith('SKIPPED:')) {
-      console.log(`  [Simulation] Skipping stale by-run outcome pointer for ${runId} — existing=${byRunStatus.slice(8)} this_run=${outcomePayload.generatedAt}`);
+    if (isRedisWriteSkippedStatus(byRunStatus)) {
+      console.log(`  [Simulation] Skipping stale by-run outcome pointer for ${runId} — existing=${redisWriteSkippedGeneratedAt(byRunStatus)} this_run=${outcomePayload.generatedAt}`);
     }
   } catch (err) {
     console.warn(`  [Simulation] by-run SET failed for ${runId}: ${err.message}`);
@@ -17925,18 +17985,15 @@ async function claimSimulationTask(runId, workerId) {
 }
 
 async function completeSimulationTask(runId, workerId = '') {
-  if (!runId) return;
+  if (!runId) return '';
   const { url, token } = getRedisCredentials();
-  await redisCommand(url, token, ['ZREM', SIMULATION_TASK_QUEUE_KEY, runId]);
-  await redisDel(url, token, buildSimulationTaskKey(runId));
-  const released = await redisCompareAndDeleteSimulationLock(url, token, buildSimulationLockKey(runId), workerId);
-  if (!released && workerId) {
-    console.warn(`  [Simulation] Did not release lock for ${runId}; worker no longer owns it (${workerId})`);
-  }
+  const status = await redisCompleteSimulationTaskIfOwned(url, token, runId, workerId);
+  logSimulationTaskCleanupStatus(runId, workerId, status);
+  return status;
 }
 
 async function extendSimulationTaskLockForTheaters(runId, workerId, theaterCount) {
-  if (!runId || !workerId) return false;
+  if (!runId || !workerId) return SIM_TASK_COMPLETE_STATUS_MISSING_WORKER;
   const ttlSeconds = computeSimulationLockTtlSeconds(theaterCount);
   const { url, token } = getRedisCredentials();
   return redisCompareAndExpireSimulationLock(url, token, buildSimulationLockKey(runId), workerId, ttlSeconds);
@@ -17968,7 +18025,7 @@ function sanitizeKeyActorRoles(rawRoles, allowedRoles) {
 }
 
 async function processNextSimulationTask(options = {}) {
-  const workerId = options.workerId || `sim-worker-${process.pid}-${Date.now()}`;
+  const workerId = options.workerId || createSimulationWorkerId();
   const queuedRunIds = options.runId ? [options.runId] : await listQueuedSimulationTasks(10);
   console.log(`  [Simulation] Queue check: ${queuedRunIds.length} task(s) in ${SIMULATION_TASK_QUEUE_KEY}`);
 
@@ -18032,10 +18089,12 @@ async function processNextSimulationTask(options = {}) {
 
       const eligibleTheaters = (pkgData.selectedTheaters || []).filter(isSimulationEligible);
       console.log(`  [Simulation] ${runId}: ${eligibleTheaters.length}/${pkgData.selectedTheaters.length} theaters eligible`);
-      const lockExtended = await extendSimulationTaskLockForTheaters(runId, workerId, eligibleTheaters.length);
-      if (!lockExtended) {
-        console.warn(`  [Simulation] ${runId}: lock ownership lost before theater simulation; leaving task for current owner`);
-        return { status: 'skipped', reason: 'lock_ownership_lost', runId };
+      const lockStatus = await extendSimulationTaskLockForTheaters(runId, workerId, eligibleTheaters.length);
+      if (lockStatus !== SIM_LOCK_STATUS_EXTENDED) {
+        const reason = lockStatus === SIM_LOCK_STATUS_EXPIRED ? 'lock_expired' : 'lock_ownership_lost';
+        const detail = lockStatus === SIM_LOCK_STATUS_EXPIRED ? 'lock expired' : 'lock ownership lost';
+        console.warn(`  [Simulation] ${runId}: ${detail} before theater simulation; leaving task for reclaim`);
+        return { status: 'skipped', reason, runId };
       }
 
       const theaterResults = [];
@@ -18300,12 +18359,14 @@ export {
   buildSimulationOutcomeKey,
   writeSimulationOutcome,
   computeSimulationLockTtlSeconds,
+  createSimulationWorkerId,
   buildSimulationRound1SystemPrompt,
   buildSimulationRound2SystemPrompt,
   tryParseSimulationRoundPayload,
   extractSimulationRoundPayload,
   runTheaterSimulation,
   enqueueSimulationTask,
+  completeSimulationTask,
   processNextSimulationTask,
   runSimulationWorker,
   fetchSimulationOutcomeForMerge,
@@ -18318,6 +18379,7 @@ export {
   redisAtomicWriteSimulationOutcomePointer,
   redisCompareAndDeleteSimulationLock,
   redisCompareAndExpireSimulationLock,
+  redisCompleteSimulationTaskIfOwned,
   SIMULATION_DECORATIONS_KEY,
   SIMULATION_DECORATIONS_MAX_AGE_MS,
   computeSimulationAdjustment,

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -76,6 +76,7 @@ const SIMULATION_DECORATIONS_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48h — skip a
 const SIMULATION_ROUND1_MAX_TOKENS = 2200;
 const SIMULATION_ROUND2_MAX_TOKENS = 2500;
 const SIMULATION_LOCK_TTL_SECONDS = 20 * 60;
+const SIMULATION_LOCK_MAX_TTL_MULTIPLIER = 6;
 const SIMULATION_POLL_INTERVAL_MS = 30 * 1000;
 const PUBLISH_MIN_PROBABILITY = 0;
 const PANEL_MIN_PROBABILITY = 0.1;
@@ -17281,6 +17282,141 @@ async function redisAtomicWriteSimDecorations(url, token, key, payload, ttlSecon
   return result?.result ?? 'WRITTEN';
 }
 
+// Lua script for atomic write-if-newer of simulation outcome pointers.
+// Prevents a late older simulation worker from regressing :latest or a by-run
+// pointer after a newer payload has already landed.
+//
+// KEYS[1] = outcome pointer key
+// ARGV[1] = payload.generatedAt
+// ARGV[2] = payload JSON
+// ARGV[3] = TTL seconds
+//
+// Returns: 'WRITTEN' | 'SKIPPED:<existingGeneratedAt>'
+const _SIM_OUTCOME_POINTER_WRITE_LUA = `
+local raw = redis.call('GET', KEYS[1])
+if raw then
+  local ok, existing = pcall(cjson.decode, raw)
+  local existingTs = ok and tonumber(existing.generatedAt) or 0
+  local runTs = tonumber(ARGV[1]) or 0
+  if runTs > 0 and existingTs > runTs then
+    return 'SKIPPED:' .. tostring(existingTs)
+  end
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', tonumber(ARGV[3]))
+return 'WRITTEN'
+`.trim();
+
+/**
+ * Atomically write a simulation outcome pointer only if the incoming run is
+ * not older than the pointer already stored at the key.
+ *
+ * @param {string} url
+ * @param {string} token
+ * @param {string} key
+ * @param {{ generatedAt?: number }} payload
+ * @param {number} ttlSeconds
+ * @returns {Promise<string>}
+ */
+async function redisAtomicWriteSimulationOutcomePointer(url, token, key, payload, ttlSeconds) {
+  if (_testRedisStore) {
+    const existing = _testRedisStore[key] ?? null;
+    const existingTs = typeof existing?.generatedAt === 'number' ? existing.generatedAt : 0;
+    const runTs = typeof payload.generatedAt === 'number' ? payload.generatedAt : 0;
+    if (runTs > 0 && existingTs > runTs) return `SKIPPED:${existingTs}`;
+    _testRedisStore[key] = JSON.parse(JSON.stringify(payload));
+    return 'WRITTEN';
+  }
+  const result = await redisCommand(url, token, [
+    'EVAL', _SIM_OUTCOME_POINTER_WRITE_LUA, '1',
+    key,
+    String(typeof payload.generatedAt === 'number' ? payload.generatedAt : 0),
+    JSON.stringify(payload),
+    String(ttlSeconds),
+  ]);
+  return result?.result ?? 'WRITTEN';
+}
+
+const _SIM_LOCK_RELEASE_LUA = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+`.trim();
+
+const _SIM_LOCK_EXPIRE_LUA = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+end
+return 0
+`.trim();
+
+/**
+ * Compute the simulation task lock TTL from the amount of theater work queued
+ * for this run. One theater keeps the historical 20-minute floor; multiple
+ * theaters scale linearly, bounded defensively in case a malformed package
+ * bypasses the normal selected-theater cap.
+ *
+ * @param {number} theaterCount
+ * @returns {number}
+ */
+function computeSimulationLockTtlSeconds(theaterCount) {
+  const count = Number.isFinite(theaterCount) ? Math.max(1, Math.floor(theaterCount)) : 1;
+  const multiplier = Math.min(SIMULATION_LOCK_MAX_TTL_MULTIPLIER, count);
+  return SIMULATION_LOCK_TTL_SECONDS * multiplier;
+}
+
+/**
+ * Release a simulation worker lock only when it is still owned by the worker
+ * doing cleanup. This prevents an expired slow worker from deleting a
+ * successor's lock after the successor has already claimed the same task.
+ *
+ * @param {string} url
+ * @param {string} token
+ * @param {string} lockKey
+ * @param {string} workerId
+ * @returns {Promise<boolean>}
+ */
+async function redisCompareAndDeleteSimulationLock(url, token, lockKey, workerId) {
+  if (!workerId) return false;
+  if (_testRedisStore) {
+    if (_testRedisStore[lockKey] !== workerId) return false;
+    delete _testRedisStore[lockKey];
+    return true;
+  }
+  const result = await redisCommand(url, token, [
+    'EVAL', _SIM_LOCK_RELEASE_LUA, '1',
+    lockKey,
+    workerId,
+  ]);
+  return Number(result?.result || 0) > 0;
+}
+
+/**
+ * Extend a simulation worker lock only if the caller still owns it.
+ *
+ * @param {string} url
+ * @param {string} token
+ * @param {string} lockKey
+ * @param {string} workerId
+ * @param {number} ttlSeconds
+ * @returns {Promise<boolean>}
+ */
+async function redisCompareAndExpireSimulationLock(url, token, lockKey, workerId, ttlSeconds) {
+  if (!workerId) return false;
+  const ttl = Number.isFinite(ttlSeconds) ? Math.max(1, Math.floor(ttlSeconds)) : SIMULATION_LOCK_TTL_SECONDS;
+  if (_testRedisStore) {
+    if (_testRedisStore[lockKey] !== workerId) return false;
+    return true;
+  }
+  const result = await redisCommand(url, token, [
+    'EVAL', _SIM_LOCK_EXPIRE_LUA, '1',
+    lockKey,
+    workerId,
+    String(ttl),
+  ]);
+  return Number(result?.result || 0) > 0;
+}
+
 // Lua script for atomic compare-and-swap patch of the canonical forecast key.
 // Executed via EVAL so the read-guard-modify-write is a single Redis operation with no TOCTOU gap.
 //
@@ -17626,7 +17762,12 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
     schema_version: SIMULATION_OUTCOME_SCHEMA_VERSION,
   });
   const { url, token } = getRedisCredentials();
-  const uiTheaters = (outcome.theaterResults || []).map((tr) => ({
+  const theaterResults = Array.isArray(outcome.theaterResults) ? outcome.theaterResults : [];
+  const emptyCandidateStateIdCount = theaterResults.filter((tr) => !String(tr?.candidateStateId || '').trim()).length;
+  if (emptyCandidateStateIdCount > 0) {
+    console.warn(`  [Simulation] Outcome ${runId} has ${emptyCandidateStateIdCount}/${theaterResults.length} theaterResults with empty candidateStateId`);
+  }
+  const uiTheaters = theaterResults.map((tr) => ({
     theaterId: tr.theaterId,
     theaterLabel: tr.theaterLabel || tr.theaterId,
     stateKind: tr.stateKind || '',
@@ -17649,20 +17790,23 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
     runId,
     outcomeKey,
     schemaVersion: SIMULATION_OUTCOME_SCHEMA_VERSION,
-    theaterCount: (outcome.theaterResults || []).length,
+    theaterCount: theaterResults.length,
+    emptyCandidateStateIdCount,
     generatedAt: generatedAt || Date.now(),
     uiTheaters,
   };
-  const outcomePayloadString = JSON.stringify(outcomePayload);
   // Canonical :latest write — D10. Awaited; throws propagate to the worker's
   // try/catch and surface as `status: 'failed'`.
-  await redisCommand(url, token, [
-    'SET',
+  const latestStatus = await redisAtomicWriteSimulationOutcomePointer(
+    url,
+    token,
     SIMULATION_OUTCOME_LATEST_KEY,
-    outcomePayloadString,
-    'EX',
-    String(TRACE_REDIS_TTL_SECONDS),
-  ]);
+    outcomePayload,
+    TRACE_REDIS_TTL_SECONDS,
+  );
+  if (latestStatus.startsWith('SKIPPED:')) {
+    console.log(`  [Simulation] Skipping stale :latest outcome pointer for ${runId} — existing=${latestStatus.slice(8)} this_run=${outcomePayload.generatedAt}`);
+  }
 
   // Secondary :by-run write — D9. Failure must NOT block the worker
   // (R7: auto-trigger / worker liveness unchanged). On failure, log +
@@ -17670,9 +17814,16 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
   // from "by-run write failed" via the get-simulation-outcome `note` text.
   const byRunKey = `${SIMULATION_OUTCOME_BY_RUN_KEY_PREFIX}:${runId}`;
   try {
-    await redisCommand(url, token, [
-      'SET', byRunKey, outcomePayloadString, 'EX', String(SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS),
-    ]);
+    const byRunStatus = await redisAtomicWriteSimulationOutcomePointer(
+      url,
+      token,
+      byRunKey,
+      outcomePayload,
+      SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS,
+    );
+    if (byRunStatus.startsWith('SKIPPED:')) {
+      console.log(`  [Simulation] Skipping stale by-run outcome pointer for ${runId} — existing=${byRunStatus.slice(8)} this_run=${outcomePayload.generatedAt}`);
+    }
   } catch (err) {
     console.warn(`  [Simulation] by-run SET failed for ${runId}: ${err.message}`);
     // Best-effort tombstone with NX — if the primary by-run SET actually
@@ -17767,18 +17918,28 @@ async function claimSimulationTask(runId, workerId) {
   if (claim?.result !== 'OK') return null;
   const taskRaw = await redisGet(url, token, buildSimulationTaskKey(runId));
   if (!taskRaw?.runId) {
-    await redisDel(url, token, lockKey);
+    await redisCompareAndDeleteSimulationLock(url, token, lockKey, workerId);
     return null;
   }
   return taskRaw;
 }
 
-async function completeSimulationTask(runId) {
+async function completeSimulationTask(runId, workerId = '') {
   if (!runId) return;
   const { url, token } = getRedisCredentials();
   await redisCommand(url, token, ['ZREM', SIMULATION_TASK_QUEUE_KEY, runId]);
   await redisDel(url, token, buildSimulationTaskKey(runId));
-  await redisDel(url, token, buildSimulationLockKey(runId));
+  const released = await redisCompareAndDeleteSimulationLock(url, token, buildSimulationLockKey(runId), workerId);
+  if (!released && workerId) {
+    console.warn(`  [Simulation] Did not release lock for ${runId}; worker no longer owns it (${workerId})`);
+  }
+}
+
+async function extendSimulationTaskLockForTheaters(runId, workerId, theaterCount) {
+  if (!runId || !workerId) return false;
+  const ttlSeconds = computeSimulationLockTtlSeconds(theaterCount);
+  const { url, token } = getRedisCredentials();
+  return redisCompareAndExpireSimulationLock(url, token, buildSimulationLockKey(runId), workerId, ttlSeconds);
 }
 
 async function listQueuedSimulationTasks(limit = 10) {
@@ -17826,7 +17987,7 @@ async function processNextSimulationTask(options = {}) {
       const existing = await redisGet(url, token, SIMULATION_OUTCOME_LATEST_KEY);
       if (existing?.runId === runId) {
         console.log(`  [Simulation] Skipping ${runId} — outcome already written`);
-        await completeSimulationTask(runId);
+        await completeSimulationTask(runId, workerId);
         return { status: 'skipped', reason: 'already_processed', runId };
       }
 
@@ -17834,7 +17995,7 @@ async function processNextSimulationTask(options = {}) {
       const pkgPointer = await redisGet(url, token, SIMULATION_PACKAGE_LATEST_KEY);
       if (!pkgPointer?.pkgKey) {
         console.warn(`  [Simulation] No package pointer for ${runId}`);
-        await completeSimulationTask(runId);
+        await completeSimulationTask(runId, workerId);
         return { status: 'failed', reason: 'no_package_pointer', runId };
       }
       if (pkgPointer.runId && pkgPointer.runId !== runId) {
@@ -17859,18 +18020,23 @@ async function processNextSimulationTask(options = {}) {
 
       const storageConfig = resolveR2StorageConfig();
       if (!storageConfig) {
-        await completeSimulationTask(runId);
+        await completeSimulationTask(runId, workerId);
         return { status: 'failed', reason: 'no_storage_config', runId };
       }
 
       const pkgData = await getR2JsonObject(storageConfig, pkgPointer.pkgKey);
       if (!pkgData?.selectedTheaters) {
-        await completeSimulationTask(runId);
+        await completeSimulationTask(runId, workerId);
         return { status: 'failed', reason: 'package_read_failed', runId };
       }
 
       const eligibleTheaters = (pkgData.selectedTheaters || []).filter(isSimulationEligible);
       console.log(`  [Simulation] ${runId}: ${eligibleTheaters.length}/${pkgData.selectedTheaters.length} theaters eligible`);
+      const lockExtended = await extendSimulationTaskLockForTheaters(runId, workerId, eligibleTheaters.length);
+      if (!lockExtended) {
+        console.warn(`  [Simulation] ${runId}: lock ownership lost before theater simulation; leaving task for current owner`);
+        return { status: 'skipped', reason: 'lock_ownership_lost', runId };
+      }
 
       const theaterResults = [];
       const failedTheaters = [];
@@ -17937,7 +18103,7 @@ async function processNextSimulationTask(options = {}) {
       };
 
       const writeResult = await writeSimulationOutcome(pkgData, outcome, { storageConfig });
-      await completeSimulationTask(runId);
+      await completeSimulationTask(runId, workerId);
       console.log(`  [Simulation] Completed ${runId}: ${theaterResults.length} theaters → ${writeResult?.outcomeKey}`);
       // Awaited (not fire-and-forget): re-score must complete before process.exit() so that
       // writeSimulationDecorations + patchPublishedForecastsWithSimDecorations update the
@@ -17949,7 +18115,7 @@ async function processNextSimulationTask(options = {}) {
       return { status: 'completed', runId, theaterCount: theaterResults.length, outcomeKey: writeResult?.outcomeKey };
     } catch (err) {
       console.warn(`  [Simulation] Task failed for ${runId}: ${err.message}`);
-      await completeSimulationTask(runId);
+      await completeSimulationTask(runId, workerId);
       return { status: 'failed', reason: err.message, runId };
     }
   }
@@ -18133,6 +18299,7 @@ export {
   SIMULATION_OUTCOME_SCHEMA_VERSION,
   buildSimulationOutcomeKey,
   writeSimulationOutcome,
+  computeSimulationLockTtlSeconds,
   buildSimulationRound1SystemPrompt,
   buildSimulationRound2SystemPrompt,
   tryParseSimulationRoundPayload,
@@ -18148,6 +18315,9 @@ export {
   patchPublishedForecastsWithSimDecorations,
   redisAtomicPatchSimDecorations,
   redisAtomicWriteSimDecorations,
+  redisAtomicWriteSimulationOutcomePointer,
+  redisCompareAndDeleteSimulationLock,
+  redisCompareAndExpireSimulationLock,
   SIMULATION_DECORATIONS_KEY,
   SIMULATION_DECORATIONS_MAX_AGE_MS,
   computeSimulationAdjustment,

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -64,6 +64,7 @@ import {
   buildSimulationOutcomeKey,
   writeSimulationOutcome,
   computeSimulationLockTtlSeconds,
+  createSimulationWorkerId,
   buildSimulationRound1SystemPrompt,
   buildSimulationRound2SystemPrompt,
   extractSimulationRoundPayload,
@@ -78,6 +79,8 @@ import {
   redisAtomicWriteSimulationOutcomePointer,
   redisCompareAndDeleteSimulationLock,
   redisCompareAndExpireSimulationLock,
+  redisCompleteSimulationTaskIfOwned,
+  completeSimulationTask,
   SIMULATION_DECORATIONS_KEY,
   SIMULATION_DECORATIONS_MAX_AGE_MS,
   CANONICAL_KEY,
@@ -6417,6 +6420,14 @@ describe('simulation runner — writeSimulationOutcome', () => {
       assert.ok(skipped.startsWith('SKIPPED:'), `expected SKIPPED, got ${skipped}`);
       assert.equal(store[key].runId, 'run-newer');
 
+      const equal = await redisAtomicWriteSimulationOutcomePointer('http://test', 'test', key, {
+        runId: 'run-equal-rerun',
+        generatedAt: newerTs,
+        outcomeKey: 'equal-rerun.json',
+      }, 86400);
+      assert.equal(equal, 'WRITTEN');
+      assert.equal(store[key].runId, 'run-equal-rerun', 'equal generatedAt re-runs must overwrite per D6');
+
       const written = await redisAtomicWriteSimulationOutcomePointer('http://test', 'test', key, {
         runId: 'run-newer-2',
         generatedAt: newerTs + 1,
@@ -6435,12 +6446,15 @@ describe('simulation runner — writeSimulationOutcome', () => {
     __setRedisStoreForTests(store);
     try {
       const stale = await redisCompareAndDeleteSimulationLock('http://test', 'test', lockKey, 'worker-a');
-      assert.equal(stale, false);
+      assert.equal(stale, 'OWNED_BY_OTHER');
       assert.equal(store[lockKey], 'worker-b', 'successor lock must survive stale worker cleanup');
 
       const current = await redisCompareAndDeleteSimulationLock('http://test', 'test', lockKey, 'worker-b');
-      assert.equal(current, true);
+      assert.equal(current, 'DELETED');
       assert.equal(store[lockKey], undefined);
+
+      const expired = await redisCompareAndDeleteSimulationLock('http://test', 'test', lockKey, 'worker-b');
+      assert.equal(expired, 'EXPIRED');
     } finally {
       __setRedisStoreForTests(null);
     }
@@ -6450,6 +6464,8 @@ describe('simulation runner — writeSimulationOutcome', () => {
     assert.equal(computeSimulationLockTtlSeconds(0), 20 * 60);
     assert.equal(computeSimulationLockTtlSeconds(1), 20 * 60);
     assert.equal(computeSimulationLockTtlSeconds(3), 60 * 60);
+    assert.equal(computeSimulationLockTtlSeconds(4), 60 * 60, 'current selected-theater cap bounds crash recovery at 3x');
+    assert.equal(computeSimulationLockTtlSeconds(99), 60 * 60);
   });
 
   it('redisCompareAndExpireSimulationLock extends only the current worker-owned lock', async () => {
@@ -6457,19 +6473,82 @@ describe('simulation runner — writeSimulationOutcome', () => {
     const calls = [];
     globalThis.fetch = async (url, init = {}) => {
       calls.push({ url: String(url), command: JSON.parse(String(init.body || '[]')) });
-      return new Response(JSON.stringify({ result: calls.length === 1 ? 0 : 1 }), { status: 200 });
+      const result = calls.length === 1 ? 'OWNED_BY_OTHER' : 'EXTENDED';
+      return new Response(JSON.stringify({ result }), { status: 200 });
     };
     try {
       const stale = await redisCompareAndExpireSimulationLock('http://test', 'test', 'forecast:simulation-lock:v1:test-run', 'worker-a', 3600);
       const current = await redisCompareAndExpireSimulationLock('http://test', 'test', 'forecast:simulation-lock:v1:test-run', 'worker-b', 3600);
-      assert.equal(stale, false);
-      assert.equal(current, true);
+      assert.equal(stale, 'OWNED_BY_OTHER');
+      assert.equal(current, 'EXTENDED');
       assert.equal(calls.length, 2);
       assert.equal(calls[1].command[0], 'EVAL');
       assert.equal(calls[1].command.at(-1), '3600');
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it('completeSimulationTask leaves queue and task state when another worker owns the lock', async () => {
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args.join(' '));
+    const runId = '1783471835470-cleanup';
+    const taskKey = `forecast:simulation-task:v1:${runId}`;
+    const lockKey = `forecast:simulation-lock:v1:${runId}`;
+    const queueKey = 'forecast:simulation-task-queue:v1';
+    const store = {
+      [taskKey]: { runId },
+      [lockKey]: 'worker-b',
+      [queueKey]: [runId],
+    };
+    __setRedisStoreForTests(store);
+    try {
+      const stale = await completeSimulationTask(runId, 'worker-a');
+      assert.equal(stale, 'OWNED_BY_OTHER');
+      assert.deepEqual(store[taskKey], { runId }, 'task payload must survive stale cleanup');
+      assert.equal(store[lockKey], 'worker-b', 'successor lock must survive stale cleanup');
+      assert.deepEqual(store[queueKey], [runId], 'queue member must survive stale cleanup');
+      assert.ok(
+        warnings.some((line) => line.includes('lock owned by another worker')),
+        `expected ownership warning, got ${warnings.join('\n')}`,
+      );
+
+      const current = await completeSimulationTask(runId, 'worker-b');
+      assert.equal(current, 'COMPLETED');
+      assert.equal(store[taskKey], undefined);
+      assert.equal(store[lockKey], undefined);
+      assert.deepEqual(store[queueKey], []);
+    } finally {
+      console.warn = originalWarn;
+      __setRedisStoreForTests(null);
+    }
+  });
+
+  it('redisCompleteSimulationTaskIfOwned reports expired locks without deleting task state', async () => {
+    const runId = '1783471835470-expired';
+    const taskKey = `forecast:simulation-task:v1:${runId}`;
+    const queueKey = 'forecast:simulation-task-queue:v1';
+    const store = {
+      [taskKey]: { runId },
+      [queueKey]: [runId],
+    };
+    __setRedisStoreForTests(store);
+    try {
+      const status = await redisCompleteSimulationTaskIfOwned('http://test', 'test', runId, 'worker-a');
+      assert.equal(status, 'EXPIRED');
+      assert.deepEqual(store[taskKey], { runId });
+      assert.deepEqual(store[queueKey], [runId]);
+    } finally {
+      __setRedisStoreForTests(null);
+    }
+  });
+
+  it('createSimulationWorkerId includes a random suffix for same-process workers', () => {
+    const first = createSimulationWorkerId();
+    const second = createSimulationWorkerId();
+    assert.match(first, /^sim-worker-\d+-\d+-[a-f0-9-]+$/);
+    assert.notEqual(first, second);
   });
 
   it('writeSimulationOutcome emits an empty-candidateStateId counter for outcome telemetry', async () => {

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -63,6 +63,7 @@ import {
   SIMULATION_OUTCOME_SCHEMA_VERSION,
   buildSimulationOutcomeKey,
   writeSimulationOutcome,
+  computeSimulationLockTtlSeconds,
   buildSimulationRound1SystemPrompt,
   buildSimulationRound2SystemPrompt,
   extractSimulationRoundPayload,
@@ -74,6 +75,9 @@ import {
   patchPublishedForecastsWithSimDecorations,
   redisAtomicPatchSimDecorations,
   redisAtomicWriteSimDecorations,
+  redisAtomicWriteSimulationOutcomePointer,
+  redisCompareAndDeleteSimulationLock,
+  redisCompareAndExpireSimulationLock,
   SIMULATION_DECORATIONS_KEY,
   SIMULATION_DECORATIONS_MAX_AGE_MS,
   CANONICAL_KEY,
@@ -6341,6 +6345,181 @@ describe('simulation runner — outcome key builder', () => {
 });
 
 describe('simulation runner — writeSimulationOutcome', () => {
+  it('skips stale :latest outcome writes when a newer run pointer already exists', async () => {
+    const originalFetch = globalThis.fetch;
+    const newerTs = Date.now();
+    const olderTs = newerTs - 60_000;
+    const store = {
+      [SIMULATION_OUTCOME_LATEST_KEY]: {
+        runId: `${newerTs}-newer`,
+        generatedAt: newerTs,
+        outcomeKey: 'seed-data/forecast-traces/newer/simulation-outcome.json',
+        schemaVersion: SIMULATION_OUTCOME_SCHEMA_VERSION,
+        theaterCount: 1,
+        uiTheaters: [],
+      },
+    };
+    __setRedisStoreForTests(store);
+    globalThis.fetch = async (url, init = {}) => {
+      const target = String(url);
+      if (target.includes('/r2/buckets/')) {
+        return new Response('{}', { status: 200 });
+      }
+      if (target === 'http://test') {
+        const command = JSON.parse(String(init.body || '[]'));
+        if (command[0] === 'SET') {
+          store[command[1]] = JSON.parse(command[2]);
+          return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ result: 1 }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch ${target}`);
+    };
+    try {
+      const olderRunId = `${olderTs}-older`;
+      const result = await writeSimulationOutcome(
+        { runId: olderRunId, generatedAt: olderTs },
+        { theaterResults: [], failedTheaters: [], generatedAt: olderTs },
+        {
+          storageConfig: {
+            mode: 'api',
+            apiBaseUrl: 'https://api.cloudflare.test/client/v4',
+            accountId: 'acct',
+            bucket: 'trace-bucket',
+            apiToken: 'token',
+            basePrefix: 'seed-data/forecast-traces',
+          },
+        },
+      );
+      assert.ok(result?.outcomeKey, 'older outcome still writes its R2 object');
+      assert.equal(store[SIMULATION_OUTCOME_LATEST_KEY].runId, `${newerTs}-newer`, 'newer :latest pointer must win');
+      assert.equal(store[SIMULATION_OUTCOME_LATEST_KEY].generatedAt, newerTs, 'newer :latest generatedAt preserved');
+    } finally {
+      globalThis.fetch = originalFetch;
+      __setRedisStoreForTests(null);
+    }
+  });
+
+  it('redisAtomicWriteSimulationOutcomePointer writes only when generatedAt is not older', async () => {
+    const newerTs = Date.now();
+    const olderTs = newerTs - 30_000;
+    const key = 'forecast:simulation-outcome:by-run:test-run';
+    const store = {
+      [key]: { runId: 'run-newer', generatedAt: newerTs, outcomeKey: 'newer.json' },
+    };
+    __setRedisStoreForTests(store);
+    try {
+      const skipped = await redisAtomicWriteSimulationOutcomePointer('http://test', 'test', key, {
+        runId: 'run-older',
+        generatedAt: olderTs,
+        outcomeKey: 'older.json',
+      }, 86400);
+      assert.ok(skipped.startsWith('SKIPPED:'), `expected SKIPPED, got ${skipped}`);
+      assert.equal(store[key].runId, 'run-newer');
+
+      const written = await redisAtomicWriteSimulationOutcomePointer('http://test', 'test', key, {
+        runId: 'run-newer-2',
+        generatedAt: newerTs + 1,
+        outcomeKey: 'newer-2.json',
+      }, 86400);
+      assert.equal(written, 'WRITTEN');
+      assert.equal(store[key].runId, 'run-newer-2');
+    } finally {
+      __setRedisStoreForTests(null);
+    }
+  });
+
+  it('redisCompareAndDeleteSimulationLock deletes only the current worker-owned lock', async () => {
+    const lockKey = 'forecast:simulation-lock:v1:test-run';
+    const store = { [lockKey]: 'worker-b' };
+    __setRedisStoreForTests(store);
+    try {
+      const stale = await redisCompareAndDeleteSimulationLock('http://test', 'test', lockKey, 'worker-a');
+      assert.equal(stale, false);
+      assert.equal(store[lockKey], 'worker-b', 'successor lock must survive stale worker cleanup');
+
+      const current = await redisCompareAndDeleteSimulationLock('http://test', 'test', lockKey, 'worker-b');
+      assert.equal(current, true);
+      assert.equal(store[lockKey], undefined);
+    } finally {
+      __setRedisStoreForTests(null);
+    }
+  });
+
+  it('computeSimulationLockTtlSeconds scales with theater count and preserves the base TTL floor', () => {
+    assert.equal(computeSimulationLockTtlSeconds(0), 20 * 60);
+    assert.equal(computeSimulationLockTtlSeconds(1), 20 * 60);
+    assert.equal(computeSimulationLockTtlSeconds(3), 60 * 60);
+  });
+
+  it('redisCompareAndExpireSimulationLock extends only the current worker-owned lock', async () => {
+    const originalFetch = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), command: JSON.parse(String(init.body || '[]')) });
+      return new Response(JSON.stringify({ result: calls.length === 1 ? 0 : 1 }), { status: 200 });
+    };
+    try {
+      const stale = await redisCompareAndExpireSimulationLock('http://test', 'test', 'forecast:simulation-lock:v1:test-run', 'worker-a', 3600);
+      const current = await redisCompareAndExpireSimulationLock('http://test', 'test', 'forecast:simulation-lock:v1:test-run', 'worker-b', 3600);
+      assert.equal(stale, false);
+      assert.equal(current, true);
+      assert.equal(calls.length, 2);
+      assert.equal(calls[1].command[0], 'EVAL');
+      assert.equal(calls[1].command.at(-1), '3600');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('writeSimulationOutcome emits an empty-candidateStateId counter for outcome telemetry', async () => {
+    const originalWarn = console.warn;
+    const originalFetch = globalThis.fetch;
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args.join(' '));
+    globalThis.fetch = async (url) => {
+      const target = String(url);
+      if (target.includes('/r2/buckets/')) {
+        return new Response('{}', { status: 200 });
+      }
+      throw new Error(`unexpected fetch ${target}`);
+    };
+    const store = {};
+    __setRedisStoreForTests(store);
+    try {
+      await writeSimulationOutcome(
+        { runId: '1783471835470-emptyid', generatedAt: 1783471835470 },
+        {
+          theaterResults: [
+            { theaterId: 'theater-empty', candidateStateId: '', topPaths: [] },
+            { theaterId: 'theater-ok', candidateStateId: 'state-ok', topPaths: [] },
+          ],
+          failedTheaters: [],
+          generatedAt: 1783471835470,
+        },
+        {
+          storageConfig: {
+            mode: 'api',
+            apiBaseUrl: 'https://api.cloudflare.test/client/v4',
+            accountId: 'acct',
+            bucket: 'trace-bucket',
+            apiToken: 'token',
+            basePrefix: 'seed-data/forecast-traces',
+          },
+        },
+      );
+      assert.equal(store[SIMULATION_OUTCOME_LATEST_KEY].emptyCandidateStateIdCount, 1);
+      assert.ok(
+        warnings.some((line) => line.includes('empty candidateStateId') && line.includes('1/2')),
+        `expected empty candidateStateId warning, got ${warnings.join('\n')}`,
+      );
+    } finally {
+      console.warn = originalWarn;
+      globalThis.fetch = originalFetch;
+      __setRedisStoreForTests(null);
+    }
+  });
+
   it('returns null when R2 storage is not configured', async () => {
     const outcome = { theaterResults: [], failedTheaters: [], runId: 'run-001', generatedAt: Date.now() };
     const result = await writeSimulationOutcome(minimalPkg, outcome, { storageConfig: null });

--- a/tests/simulation-outcome-by-run-write.test.mjs
+++ b/tests/simulation-outcome-by-run-write.test.mjs
@@ -92,4 +92,32 @@ describe('writeSimulationOutcome by-run write structural lock (#3734 U5)', () =>
       'writeSimulationOutcome must return { outcomeKey } at the end of its body',
     );
   });
+
+  it('keeps generatedAt CAS centralized for decorations and outcome pointers', () => {
+    assert.equal(
+      (src.match(/const _REDIS_WRITE_IF_NEWER_LUA =/g) || []).length,
+      1,
+      'generatedAt write-if-newer Lua must have one shared implementation',
+    );
+    assert.ok(
+      /async function redisAtomicWriteSimDecorations[\s\S]*?return redisAtomicWriteIfNewer\(/.test(src),
+      'simulation decorations helper must delegate to the shared generatedAt CAS helper',
+    );
+    assert.ok(
+      /async function redisAtomicWriteSimulationOutcomePointer[\s\S]*?return redisAtomicWriteIfNewer\(/.test(src),
+      'simulation outcome pointer helper must delegate to the shared generatedAt CAS helper',
+    );
+  });
+
+  it('extends the simulation task lock before the theater loop and returns explicit lost-lock reasons', () => {
+    const extensionIdx = src.indexOf('extendSimulationTaskLockForTheaters(runId, workerId, eligibleTheaters.length)');
+    const loopIdx = src.indexOf('for (const theater of eligibleTheaters)');
+    assert.ok(extensionIdx >= 0, 'worker must extend the simulation task lock after theater eligibility is known');
+    assert.ok(loopIdx >= 0, 'worker theater loop not found');
+    assert.ok(extensionIdx < loopIdx, 'worker must check lock ownership before starting theater simulation work');
+    assert.ok(
+      /lockStatus !== SIM_LOCK_STATUS_EXTENDED[\s\S]*?reason = lockStatus === SIM_LOCK_STATUS_EXPIRED \? 'lock_expired' : 'lock_ownership_lost'/.test(src),
+      'worker must early-return with distinct expired-vs-owned-by-other lock reasons',
+    );
+  });
 });

--- a/tests/simulation-outcome-by-run-write.test.mjs
+++ b/tests/simulation-outcome-by-run-write.test.mjs
@@ -25,32 +25,32 @@ const root = resolve(__dirname, '..');
 describe('writeSimulationOutcome by-run write structural lock (#3734 U5)', () => {
   const src = readFileSync(resolve(root, 'scripts/seed-forecasts.mjs'), 'utf-8');
 
-  it('writes :latest first (canonical, D10) with the existing TRACE TTL', () => {
-    // The :latest SET must remain awaited (no swallow) so the worker's try/catch
-    // surfaces transport errors as `status: 'failed'`. Locking the EX flag against
-    // TRACE_REDIS_TTL_SECONDS prevents an accidental TTL bump from changing the
-    // observable :latest semantics.
+  it('writes :latest through generatedAt CAS with the existing TRACE TTL', () => {
+    // The :latest write must remain awaited (no swallow) so the worker's try/catch
+    // surfaces transport errors as `status: 'failed'`. It must also use the
+    // generatedAt CAS helper so a late older worker cannot regress the pointer.
     assert.ok(
-      /await redisCommand\([\s\S]*?SIMULATION_OUTCOME_LATEST_KEY[\s\S]*?TRACE_REDIS_TTL_SECONDS/.test(src),
-      'writeSimulationOutcome must await SET on SIMULATION_OUTCOME_LATEST_KEY with TRACE_REDIS_TTL_SECONDS',
+      /await redisAtomicWriteSimulationOutcomePointer\([\s\S]*?SIMULATION_OUTCOME_LATEST_KEY[\s\S]*?TRACE_REDIS_TTL_SECONDS/.test(src),
+      'writeSimulationOutcome must await CAS on SIMULATION_OUTCOME_LATEST_KEY with TRACE_REDIS_TTL_SECONDS',
     );
   });
 
-  it('writes :by-run with the 24h TTL constant + no NX flag (D6)', () => {
-    // SET <byRunKey> <payload> EX SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS.
-    // No NX flag — re-runs (manual --run-id=X) must overwrite cleanly per D6.
-    // The shim's TTL constant is the single source of truth (24h * 3600 = 86400).
+  it('writes :by-run through generatedAt CAS with the 24h TTL constant (D6)', () => {
+    // CAS <byRunKey> <payload> EX SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS.
+    // Equal/newer re-runs (manual --run-id=X) still overwrite cleanly per D6;
+    // older out-of-order workers are skipped by generatedAt.
     assert.ok(
-      /SET[\s\S]{0,40}byRunKey[\s\S]{0,80}EX[\s\S]{0,40}SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS/.test(src),
-      'by-run SET must use SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS from the shim',
+      /redisAtomicWriteSimulationOutcomePointer\([\s\S]*?byRunKey[\s\S]*?SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS/.test(src),
+      'by-run CAS must use SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS from the shim',
     );
-    // No NX flag in the by-run path. The line is short — easiest assertion is
-    // that the by-run SET region doesn't contain 'NX' before the closing `]`.
-    const byRunMatch = src.match(/'SET', byRunKey, outcomePayloadString[^\]]+\]/);
-    assert.ok(byRunMatch, 'by-run SET region not found');
+    // No NX flag in the primary by-run path. The helper call is short enough
+    // to assert its argument region; the tombstone fallback is still allowed
+    // to use NX below.
+    const byRunMatch = src.match(/redisAtomicWriteSimulationOutcomePointer\([\s\S]*?byRunKey[\s\S]*?SIMULATION_OUTCOME_BY_RUN_TTL_SECONDS[\s\S]*?\);/);
+    assert.ok(byRunMatch, 'by-run CAS region not found');
     assert.ok(
       !byRunMatch[0].includes("'NX'"),
-      'by-run SET must NOT use NX flag (D6: re-runs overwrite cleanly)',
+      'primary by-run CAS must NOT use NX flag (D6: equal/newer re-runs overwrite cleanly)',
     );
   });
 
@@ -86,7 +86,7 @@ describe('writeSimulationOutcome by-run write structural lock (#3734 U5)', () =>
     // Slice a generous window from the function start and look for the
     // single occurrence of "return { outcomeKey }". The function ends with
     // exactly that statement.
-    const body = src.slice(startIdx, startIdx + 4000);
+    const body = src.slice(startIdx, startIdx + 7000);
     assert.ok(
       /return\s+\{\s*outcomeKey\s*\}/.test(body),
       'writeSimulationOutcome must return { outcomeKey } at the end of its body',


### PR DESCRIPTION
## Summary

Simulation workers now fail closed on out-of-order completion: stale workers cannot regress outcome pointers, cannot delete successor locks, and get an owner-checked TTL extension sized to eligible theater work before LLM simulation begins.

Simulation outcome pointers also expose `emptyCandidateStateIdCount` and warn when theater results lack candidate state IDs, making merge-suppression cases observable instead of silent.

## Validation

- `node --test tests/forecast-trace-export.test.mjs` passed: 316/316
- `node --test tests/simulation-outcome-by-run-write.test.mjs` passed: 4/4
- Pre-push hook passed: dependency bootstrap, `npm run typecheck`, `npm run typecheck:api`, Convex type check, CJS syntax, Unicode safety, boundary/safe-html/Sentry/rate-limit/premium-fetch/edge bundle checks, changed test files (`320/320`), and version sync

## Related

Related: #4933

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
