### PR TITLE
fix(payments): pace dunning Resend sends under the 10 req/s limit

### DIFF
--- a/convex/__tests__/dunningEmails.test.ts
+++ b/convex/__tests__/dunningEmails.test.ts
@@ -361,14 +361,15 @@ describe("runDunningScan windows", () => {
     expect(resendSends(fetchMock)).toHaveLength(0);
   });
 
-  test("batch scan staggers sends to stay under Resend's 10 req/s cap (WORLDMONITOR-VH)", async () => {
+  test("batch scan staggers send START times (first pacing layer, WORLDMONITOR-VH)", async () => {
     vi.useFakeTimers();
     process.env.RESEND_API_KEY = "re_test";
-    const fetchMock = mockResend();
     const t = convexTest(schema, modules);
     // 12 distinct subs all past the day-7 window → 12 due sends in one tick.
     // Pre-fix every send was scheduled at runAfter(0), bursting concurrently and
     // tripping Resend's 10 req/s limit (the 11th+ threw a 429 out of sendEmail).
+    // Start-staggering spreads the Dodo portal load and the initial Resend load;
+    // the hard POST-rate guarantee is reserveResendSlot (see the pacing test).
     const anchor = Date.now() - (DUNNING_DAY7_AGE_MS + DAY_MS);
     const N = 12;
     for (let i = 0; i < N; i++) {
@@ -383,8 +384,8 @@ describe("runDunningScan windows", () => {
     const summary = await t.mutation(internal.payments.subscriptionEmails.runDunningScan, {});
     expect(summary.scheduled).toBe(N);
 
-    // Inspect the PENDING scheduled sends (before draining): their scheduledTime
-    // must be staggered by SEND_SPACING_MS, not all identical (the burst bug).
+    // Pending scheduled sends: their scheduledTime must be staggered by
+    // SEND_SPACING_MS, not all identical (the burst bug).
     const scheduledTimes = await t.run(async (ctx) => {
       const jobs = await ctx.db.system.query("_scheduled_functions").collect();
       return jobs
@@ -395,14 +396,35 @@ describe("runDunningScan windows", () => {
     expect(scheduledTimes).toHaveLength(N);
     // All distinct — pre-fix every send fired at the same instant (Set size 1).
     expect(new Set(scheduledTimes).size).toBe(N);
-    // Consecutive sends are exactly SEND_SPACING_MS apart (≤4/s, under 10/s).
+    // Consecutive starts are exactly SEND_SPACING_MS apart (≤4/s, under 10/s).
     for (let i = 1; i < scheduledTimes.length; i++) {
       expect(scheduledTimes[i]! - scheduledTimes[i - 1]!).toBe(SEND_SPACING_MS);
     }
+  });
 
-    // …and they all still deliver once drained.
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
-    expect(resendSends(fetchMock)).toHaveLength(N);
+  test("reserveResendSlot paces actual POSTs >= SEND_SPACING_MS apart, portal-latency-independent (WORLDMONITOR-VH)", async () => {
+    // Staggering only spaces send START times; the real Resend POST happens
+    // after a variable-latency Dodo portal mint, so start-spacing alone can't
+    // bound the POST rate. reserveResendSlot is the hard guarantee: it hands out
+    // the instant each send may POST. Asserting those instants are monotonic and
+    // exactly SEND_SPACING_MS apart proves the POST rate stays <= 1/SEND_SPACING_MS
+    // regardless of portal jitter — no timers/portal mocking needed because the
+    // reserved slot IS the POST schedule.
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const N = 12;
+    const slots: number[] = [];
+    for (let i = 0; i < N; i++) {
+      slots.push(await t.mutation(internal.payments.subscriptionEmails.reserveResendSlot, {}));
+    }
+    for (let i = 1; i < N; i++) {
+      expect(slots[i]! - slots[i - 1]!).toBe(SEND_SPACING_MS);
+    }
+    // Idle reset: once the reserved window fully elapses, the next slot floors at
+    // `now` (no wait toward a stale future cursor), not lastSlot + spacing.
+    vi.advanceTimersByTime(N * SEND_SPACING_MS + 10_000);
+    const afterIdle = await t.mutation(internal.payments.subscriptionEmails.reserveResendSlot, {});
+    expect(afterIdle).toBe(Date.now());
   });
 });
 

--- a/convex/__tests__/dunningEmails.test.ts
+++ b/convex/__tests__/dunningEmails.test.ts
@@ -21,6 +21,7 @@ import {
   DUNNING_DAY7_AGE_MS,
   WINBACK_MIN_AGE_MS,
   WINBACK_MAX_AGE_MS,
+  SEND_SPACING_MS,
 } from "../payments/subscriptionEmails";
 
 const modules = import.meta.glob("../**/*.ts");
@@ -358,6 +359,50 @@ describe("runDunningScan windows", () => {
     const summary = await t.mutation(internal.payments.subscriptionEmails.runDunningScan, {});
     expect(summary.scheduled).toBe(0);
     expect(resendSends(fetchMock)).toHaveLength(0);
+  });
+
+  test("batch scan staggers sends to stay under Resend's 10 req/s cap (WORLDMONITOR-VH)", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = mockResend();
+    const t = convexTest(schema, modules);
+    // 12 distinct subs all past the day-7 window → 12 due sends in one tick.
+    // Pre-fix every send was scheduled at runAfter(0), bursting concurrently and
+    // tripping Resend's 10 req/s limit (the 11th+ threw a 429 out of sendEmail).
+    const anchor = Date.now() - (DUNNING_DAY7_AGE_MS + DAY_MS);
+    const N = 12;
+    for (let i = 0; i < N; i++) {
+      await seedSub(t, {
+        dodoSubscriptionId: `sub_burst_${i}`,
+        userId: `user_burst_${i}`,
+        email: `burst${i}@example.com`,
+        onHoldAt: anchor,
+      });
+    }
+
+    const summary = await t.mutation(internal.payments.subscriptionEmails.runDunningScan, {});
+    expect(summary.scheduled).toBe(N);
+
+    // Inspect the PENDING scheduled sends (before draining): their scheduledTime
+    // must be staggered by SEND_SPACING_MS, not all identical (the burst bug).
+    const scheduledTimes = await t.run(async (ctx) => {
+      const jobs = await ctx.db.system.query("_scheduled_functions").collect();
+      return jobs
+        .filter((j) => j.name.endsWith("sendDunningEmail"))
+        .map((j) => j.scheduledTime)
+        .sort((a, b) => a - b);
+    });
+    expect(scheduledTimes).toHaveLength(N);
+    // All distinct — pre-fix every send fired at the same instant (Set size 1).
+    expect(new Set(scheduledTimes).size).toBe(N);
+    // Consecutive sends are exactly SEND_SPACING_MS apart (≤4/s, under 10/s).
+    for (let i = 1; i < scheduledTimes.length; i++) {
+      expect(scheduledTimes[i]! - scheduledTimes[i - 1]!).toBe(SEND_SPACING_MS);
+    }
+
+    // …and they all still deliver once drained.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(resendSends(fetchMock)).toHaveLength(N);
   });
 });
 

--- a/convex/__tests__/dunningEmails.test.ts
+++ b/convex/__tests__/dunningEmails.test.ts
@@ -22,6 +22,7 @@ import {
   WINBACK_MIN_AGE_MS,
   WINBACK_MAX_AGE_MS,
   SEND_SPACING_MS,
+  resendPacingWaitMs,
 } from "../payments/subscriptionEmails";
 
 const modules = import.meta.glob("../**/*.ts");
@@ -425,6 +426,21 @@ describe("runDunningScan windows", () => {
     vi.advanceTimersByTime(N * SEND_SPACING_MS + 10_000);
     const afterIdle = await t.mutation(internal.payments.subscriptionEmails.reserveResendSlot, {});
     expect(afterIdle).toBe(Date.now());
+  });
+
+  test("resendPacingWaitMs never clamps a large backlog into a burst (WORLDMONITOR-VH re-review P2)", () => {
+    const now = 1_000_000_000_000;
+    expect(resendPacingWaitMs(now, now)).toBe(0);
+    expect(resendPacingWaitMs(now + SEND_SPACING_MS, now)).toBe(SEND_SPACING_MS);
+    // A backlog past ~240 reservations reserves a slot >60s out. A fixed 60s cap
+    // (the earlier bug) would flatten every such tail send to a 60s wait so they
+    // woke together and re-burst; the wait must equal the FULL distance to the
+    // slot. 300 * 250ms = 75s, well past the removed ceiling.
+    const bigBacklogMs = 300 * SEND_SPACING_MS;
+    expect(bigBacklogMs).toBeGreaterThan(60_000);
+    expect(resendPacingWaitMs(now + bigBacklogMs, now)).toBe(bigBacklogMs);
+    // Slot already elapsed (clock moved past it): no negative/oversized wait.
+    expect(resendPacingWaitMs(now - 5_000, now)).toBe(0);
   });
 });
 

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -378,6 +378,15 @@ export const WINBACK_MAX_AGE_MS = 60 * DAY_MS;
 const DASHBOARD_URL = "https://www.worldmonitor.app/dashboard";
 const PRICING_URL = "https://www.worldmonitor.app/pro#pricing";
 
+// Resend caps at 10 requests/second. A scan that schedules every due send at
+// runAfter(0) fires them concurrently, so the 11th+ gets a 429 that throws
+// uncaught out of sendDunningEmail -> Sentry WORLDMONITOR-VH; because the send
+// throws before the ledger write, those rows re-burst on the next daily tick and
+// compound. Stagger sends 250ms apart (<=4/s) to stay well under the cap with
+// headroom for concurrent welcome/admin emails. The cadence is daily and
+// non-urgent, so spreading a batch over a few seconds is inconsequential.
+export const SEND_SPACING_MS = 250;
+
 const dunningStepValidator = v.union(
   v.literal("dunning_day0"),
   v.literal("dunning_day3"),
@@ -758,8 +767,10 @@ export const runDunningScan = internalMutation({
         )
         .first();
       if (existing) continue;
+      // Stagger to stay under Resend's 10 req/s limit (see SEND_SPACING_MS):
+      // `scheduled` is the running index, so sends fire at 0ms, 250ms, 500ms, ...
       await ctx.scheduler.runAfter(
-        0,
+        scheduled * SEND_SPACING_MS,
         internal.payments.subscriptionEmails.sendDunningEmail,
         item,
       );

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -378,14 +378,35 @@ export const WINBACK_MAX_AGE_MS = 60 * DAY_MS;
 const DASHBOARD_URL = "https://www.worldmonitor.app/dashboard";
 const PRICING_URL = "https://www.worldmonitor.app/pro#pricing";
 
-// Resend caps at 10 requests/second. A scan that schedules every due send at
-// runAfter(0) fires them concurrently, so the 11th+ gets a 429 that throws
-// uncaught out of sendDunningEmail -> Sentry WORLDMONITOR-VH; because the send
-// throws before the ledger write, those rows re-burst on the next daily tick and
-// compound. Stagger sends 250ms apart (<=4/s) to stay well under the cap with
-// headroom for concurrent welcome/admin emails. The cadence is daily and
-// non-urgent, so spreading a batch over a few seconds is inconsequential.
+// Resend caps at 10 requests/second. TWO complementary layers keep dunning
+// under it:
+//
+//   1. runDunningScan staggers each send's START by SEND_SPACING_MS (below).
+//      This spreads the upstream Dodo portal-mint load and the initial Resend
+//      load, and keeps reserveResendSlot contention low.
+//   2. The actual Resend POST happens AFTER a variable-latency Dodo portal-mint
+//      (createCustomerPortalUrlForUser), so staggering START times does NOT by
+//      itself bound the POST rate — portal-latency jitter can bunch several
+//      POSTs into the same instant and recreate the burst. So immediately
+//      before the POST, every send reserves a monotonic slot from a shared
+//      token bucket (reserveResendSlot) and waits for it. Slots are handed out
+//      >= SEND_SPACING_MS apart, so actual POSTs stay >= SEND_SPACING_MS apart
+//      regardless of portal latency.
+//
+// Original bug (WORLDMONITOR-VH): sends were scheduled at runAfter(0) and burst
+// concurrently; the 11th+ threw an uncaught 429 out of sendEmail, and since the
+// throw precedes the ledger write those rows re-burst next tick and compounded.
+// The cadence is daily and non-urgent, so spreading a batch over a few seconds
+// (250ms => <=4/s) is inconsequential.
 export const SEND_SPACING_MS = 250;
+
+// Shared-cursor key in the generic `counters` table: the epoch-ms timestamp of
+// the next free Resend send slot for the dunning/winback fleet.
+const RESEND_SLOT_COUNTER = "dunning_resend_next_slot";
+
+// Safety ceiling on how long one send will wait for its slot, so a corrupt or
+// far-future cursor value can never wedge an action indefinitely.
+const MAX_PACING_WAIT_MS = 60_000;
 
 const dunningStepValidator = v.union(
   v.literal("dunning_day0"),
@@ -603,6 +624,33 @@ export function buildDunningEmail(
  * cron) and the subscription may have recovered, been cancelled, or been
  * re-held (new episode) since it was scheduled.
  */
+/**
+ * Token-bucket pacer for Resend POSTs across the whole dunning/winback fleet.
+ *
+ * Returns the epoch-ms instant at which the caller may perform its Resend POST.
+ * sendDunningEmail calls this immediately before the send and waits until the
+ * returned slot, so concurrent sends POST >= SEND_SPACING_MS apart no matter how
+ * their upstream Dodo portal-mint latency varies. Single-row OCC makes
+ * concurrent reservations serialize, so no two callers get overlapping slots.
+ * The cursor floors at `now`, so after any idle gap the next send fires
+ * immediately instead of sleeping toward a stale future slot.
+ */
+export const reserveResendSlot = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<number> => {
+    const row = await ctx.db
+      .query("counters")
+      .withIndex("by_name", (q) => q.eq("name", RESEND_SLOT_COUNTER))
+      .unique();
+    const now = Date.now();
+    const slotAt = Math.max(now, row?.value ?? 0);
+    const nextSlotAt = slotAt + SEND_SPACING_MS;
+    if (row) await ctx.db.patch(row._id, { value: nextSlotAt });
+    else await ctx.db.insert("counters", { name: RESEND_SLOT_COUNTER, value: nextSlotAt });
+    return slotAt;
+  },
+});
+
 export const sendDunningEmail = internalAction({
   args: {
     dodoSubscriptionId: v.string(),
@@ -682,6 +730,18 @@ export const sendDunningEmail = internalAction({
 
     const planName = PLAN_DISPLAY[sub.planKey] ?? sub.planKey;
     const { subject, html } = buildDunningEmail(args.step, planName, ctaUrl);
+    // Pace the actual POST (not just the scheduled start): the portal mint above
+    // has variable latency, so reserve the Resend slot HERE — after the mint —
+    // and wait for it. This bounds the true POST rate to <= 1/SEND_SPACING_MS
+    // even when portal jitter bunches start-staggered sends together, which
+    // start-time staggering alone can't guarantee (review follow-up to
+    // WORLDMONITOR-VH). The wait is capped by MAX_PACING_WAIT_MS.
+    const slotAt = await ctx.runMutation(
+      internal.payments.subscriptionEmails.reserveResendSlot,
+      {},
+    );
+    const waitMs = Math.min(Math.max(0, slotAt - Date.now()), MAX_PACING_WAIT_MS);
+    if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
     await sendEmail(apiKey, sub.email, subject, html, ADMIN_EMAIL);
     // Ledger write AFTER the send: a Resend failure throws above, leaving no
     // row, so the next cron tick retries. The narrow crash window between

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -404,10 +404,6 @@ export const SEND_SPACING_MS = 250;
 // the next free Resend send slot for the dunning/winback fleet.
 const RESEND_SLOT_COUNTER = "dunning_resend_next_slot";
 
-// Safety ceiling on how long one send will wait for its slot, so a corrupt or
-// far-future cursor value can never wedge an action indefinitely.
-const MAX_PACING_WAIT_MS = 60_000;
-
 const dunningStepValidator = v.union(
   v.literal("dunning_day0"),
   v.literal("dunning_day3"),
@@ -651,6 +647,20 @@ export const reserveResendSlot = internalMutation({
   },
 });
 
+/**
+ * The wait (ms) a send owes before its reserved Resend slot. Deliberately
+ * UNCAPPED: a large legitimate backlog reserves proportionally distant slots, so
+ * clamping the wait would let the tail — every reservation past cap/SEND_SPACING_MS
+ * — wake together and re-burst, the exact collapse a fixed ceiling caused
+ * (WORLDMONITOR-VH re-review P2). Safe to leave uncapped because
+ * `counters[RESEND_SLOT_COUNTER]` is single-writer (reserveResendSlot only) and
+ * only ever advances by SEND_SPACING_MS, so it can never be corruptly far in the
+ * future — there is no runaway state to defend against. Exported for testing.
+ */
+export function resendPacingWaitMs(slotAt: number, now: number): number {
+  return Math.max(0, slotAt - now);
+}
+
 export const sendDunningEmail = internalAction({
   args: {
     dodoSubscriptionId: v.string(),
@@ -735,12 +745,13 @@ export const sendDunningEmail = internalAction({
     // and wait for it. This bounds the true POST rate to <= 1/SEND_SPACING_MS
     // even when portal jitter bunches start-staggered sends together, which
     // start-time staggering alone can't guarantee (review follow-up to
-    // WORLDMONITOR-VH). The wait is capped by MAX_PACING_WAIT_MS.
+    // WORLDMONITOR-VH). The wait is intentionally uncapped (see resendPacingWaitMs)
+    // so a large backlog stays serialized instead of collapsing into a burst.
     const slotAt = await ctx.runMutation(
       internal.payments.subscriptionEmails.reserveResendSlot,
       {},
     );
-    const waitMs = Math.min(Math.max(0, slotAt - Date.now()), MAX_PACING_WAIT_MS);
+    const waitMs = resendPacingWaitMs(slotAt, Date.now());
     if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
     await sendEmail(apiKey, sub.email, subject, html, ADMIN_EMAIL);
     // Ledger write AFTER the send: a Resend failure throws above, leaving no


### PR DESCRIPTION
## Summary

Dunning/winback emails no longer burst past Resend's rate limit. When a daily scan had more than ~10 due emails they were all scheduled at once and the overflow tripped Resend's 10 requests/second cap; the excess sends threw an uncaught 429, and because the throw happens *before* the ledger write those customers' emails silently re-queued and re-burst on the next tick, compounding day over day (Sentry WORLDMONITOR-VH). Sends are now paced so every due email goes out under the limit.

## Two pacing layers

The actual Resend POST happens *after* a variable-latency Dodo portal mint (`createCustomerPortalUrlForUser`), so spacing the scheduled *start* times alone can't bound the POST rate — portal-latency jitter could still bunch several POSTs together and recreate the burst. So the fix has two layers:

1. **Staggered starts** — `runDunningScan` schedules each send at `index × SEND_SPACING_MS`, spreading both the Dodo portal load and the initial Resend load (and keeping bucket contention low).
2. **Token bucket at the POST site** — immediately before each Resend POST (after the portal mint), the send reserves a monotonic slot from a shared cursor (`reserveResendSlot`, stored in the generic `counters` table) and waits for it. Slots are handed out ≥ `SEND_SPACING_MS` apart, so actual POSTs stay ≥ `SEND_SPACING_MS` apart **regardless of portal latency**. Single-row OCC serializes concurrent reservations; the cursor floors at `now` so an idle gap never leaves a send waiting toward a stale future slot.

The reserved-slot wait is **uncapped by design**: a large legitimate backlog reserves proportionally distant slots, so clamping the wait (an earlier `MAX_PACING_WAIT_MS = 60s` ceiling) would let every send past ~240 reservations wake together and re-burst. The cursor is single-writer (`reserveResendSlot` only, always advancing by `SEND_SPACING_MS`), so it can never be corruptly far in the future — there is no runaway state a cap needs to guard. A backlog so large that a send's wait exceeds the Convex action limit degrades gracefully (that send fails and retries next tick), never into a burst.

## Validation

Backend change, no visual surface.

- `tsc --noEmit -p tsconfig.api.json` + `audit-convex-string-calls` clean; `biome` clean.
- Full convex suite: **669 tests pass** (43 files).
- Tests: start-stagger (scan schedules 12 due sends at distinct, evenly-spaced times; fails against the old `runAfter(0)`); token-bucket pacing (`reserveResendSlot` hands out monotonic slots exactly `SEND_SPACING_MS` apart + floors at `now` after idle); and no-clamp (`resendPacingWaitMs` returns the full 75s wait for a 300-reservation backlog past the removed 60s ceiling, and floors at 0 for an elapsed slot).

Related: Sentry WORLDMONITOR-VH

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
