### PR TITLE
Harden watchlist notification follow-ups

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -39,6 +39,9 @@ COPY scripts/shared/notification-dedup.cjs ./scripts/shared/notification-dedup.c
 # market-hours.cjs gates the equity portion of the relay market seed loop on
 # the US-equity session (#4922d). Missing it = ERR_MODULE_NOT_FOUND at startup.
 COPY scripts/shared/market-hours.cjs ./scripts/shared/market-hours.cjs
+# closed-market-equity-maintenance.cjs keeps the closed-market TTL refresh
+# logic importable/testable for ais-relay.cjs. Missing it = startup crash.
+COPY scripts/shared/closed-market-equity-maintenance.cjs ./scripts/shared/closed-market-equity-maintenance.cjs
 COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
 # _seed-envelope-source.mjs and _seed-contract.mjs are transitively imported
 # by _seed-utils.mjs (lines 9-10) and by seed-chokepoint-flows.mjs /

--- a/api/notify.ts
+++ b/api/notify.ts
@@ -22,7 +22,11 @@ import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
 const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
-const INTERNAL_EVENT_TYPES = new Set(['flush_quiet_held', 'channel_welcome']);
+const INTERNAL_EVENT_TYPES = new Set(['flush_quiet_held', 'channel_welcome', 'watchlist_story_alert']);
+
+export function isInternalNotifyEventType(eventType: string): boolean {
+  return INTERNAL_EVENT_TYPES.has(eventType);
+}
 
 export default async function handler(req: Request): Promise<Response> {
   if (isDisallowedOrigin(req)) {
@@ -71,8 +75,10 @@ export default async function handler(req: Request): Promise<Response> {
   // Reject internal relay control events. These are dispatched by Railway
   // cron scripts (seed-digest-notifications, quiet-hours) and must never be
   // user-submittable. flush_quiet_held would let a Pro user force-drain their
-  // held queue on demand, bypassing batch_on_wake behaviour.
-  if (INTERNAL_EVENT_TYPES.has(body.eventType)) {
+  // held queue on demand, bypassing batch_on_wake behaviour. watchlist_story_alert
+  // is produced by the digest scanner after ticker extraction, importance gating,
+  // and scan dedup; user-submitted copies would bypass that pipeline.
+  if (isInternalNotifyEventType(body.eventType)) {
     return jsonResponse({ error: 'Reserved event type' }, 403, cors);
   }
 

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -33,6 +33,7 @@ const {
   classifySetNxResult,
   recordDedupOutcome,
 } = require('./shared/notification-dedup.cjs');
+const { maintainClosedMarketEquityKeys: maintainClosedMarketEquityKeysWithDeps } = require('./shared/closed-market-equity-maintenance.cjs');
 const { getUsEquitySession, isUsEquityTradingDay } = require('./shared/market-hours.cjs');
 const parseProxyUrl = parseProxyConfig;
 
@@ -2153,19 +2154,15 @@ let _equityGateLoggedClosed = false;
 // preserved; false means the keys are missing/expired and the caller must
 // fall back to a real fetch to repopulate.
 async function maintainClosedMarketEquityKeys() {
-  const redisKey = `market:quotes:v1:${[...MARKET_SYMBOLS].sort().join(',')}`;
-  const ok1 = await upstashExpire(redisKey, MARKET_SEED_TTL);
-  const ok2 = await upstashExpire('market:stocks-bootstrap:v1', MARKET_SEED_TTL);
-  if (!ok1 || !ok2) return false;
-  let count = _lastEquityQuoteCount;
-  if (!count) {
-    const meta = await upstashGet('seed-meta:market:stocks');
-    count = (meta && typeof meta.recordCount === 'number') ? meta.recordCount : 0;
-  }
-  if (count > 0) {
-    await upstashSet('seed-meta:market:stocks', { fetchedAt: Date.now(), recordCount: count }, 604800);
-  }
-  return true;
+  return maintainClosedMarketEquityKeysWithDeps({
+    marketSymbols: MARKET_SYMBOLS,
+    marketSeedTtl: MARKET_SEED_TTL,
+    lastEquityQuoteCount: _lastEquityQuoteCount,
+    upstashExpire,
+    upstashGet,
+    upstashSet,
+    nowMs: () => Date.now(),
+  });
 }
 
 async function seedMarketQuotes() {

--- a/scripts/lib/watchlist-story-scan.mjs
+++ b/scripts/lib/watchlist-story-scan.mjs
@@ -111,19 +111,26 @@ export async function scanAndEnqueueWatchlistStoryEvents(nowMs, {
     }
     if (candidates.length === 0) return { hashes: hashes.length, candidates: 0, events: 0, enqueued: 0, scoreMin };
 
-    const events = buildWatchlistStoryEvents(candidates, tickerDictionary, scoreMin);
+    const eventEntries = [];
+    for (const candidate of candidates) {
+      for (const event of buildWatchlistStoryEvents([candidate], tickerDictionary, scoreMin)) {
+        eventEntries.push({ event, sourceKey: `story:sources:v1:${candidate.hash}` });
+      }
+    }
 
-    if (events.length > 0) {
+    if (eventEntries.length > 0) {
       try {
         const srcResults = await upstashPipeline(
-          events.map((event) => ['SMEMBERS', `story:sources:v1:${String(event.payload.coalesceKey).slice('watchlist:'.length)}`]),
+          eventEntries.map(({ sourceKey }) => ['SMEMBERS', sourceKey]),
         );
-        for (let i = 0; i < events.length; i++) {
+        for (let i = 0; i < eventEntries.length; i++) {
           const arr = srcResults[i]?.result;
-          if (Array.isArray(arr) && typeof arr[0] === 'string') events[i].payload.source = arr[0];
+          if (Array.isArray(arr) && typeof arr[0] === 'string') eventEntries[i].event.payload.source = arr[0];
         }
       } catch { /* best-effort */ }
     }
+
+    const events = eventEntries.map(({ event }) => event);
     const publish = publishNotificationEvent ??
       ((event) => publishWatchlistNotificationEvent(event, { upstashRest, logger }));
     let enqueued = 0;

--- a/scripts/lib/watchlist-story-scan.mjs
+++ b/scripts/lib/watchlist-story-scan.mjs
@@ -1,0 +1,143 @@
+import { createHash } from 'node:crypto';
+
+import { buildDedupMaterial } from '../shared/notification-dedup.cjs';
+import { buildWatchlistStoryEvents, resolveWatchlistScoreMin, WATCHLIST_STORY_EVENT_TYPE } from './watchlist-story-events.mjs';
+
+export const WATCHLIST_SCAN_DEDUP_TTL_SECONDS = 24 * 60 * 60;
+const WATCHLIST_SCAN_WINDOW_MS = 24 * 60 * 60 * 1000;
+const WATCHLIST_SCAN_ACCUMULATORS = [
+  'digest:accumulator:v1:full:en',
+  'digest:accumulator:v1:finance:en',
+];
+
+function flatArrayToObject(flat) {
+  const obj = Object.create(null);
+  if (!Array.isArray(flat)) return obj;
+  for (let i = 0; i + 1 < flat.length; i += 2) {
+    obj[flat[i]] = flat[i + 1];
+  }
+  return obj;
+}
+
+export async function publishWatchlistNotificationEvent(
+  { eventType, payload, severity, dedupTtl = WATCHLIST_SCAN_DEDUP_TTL_SECONDS },
+  { upstashRest, nowMs = () => Date.now(), logger = console } = {},
+) {
+  if (typeof upstashRest !== 'function') throw new Error('upstashRest dependency is required');
+  const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
+  const dedupHash = createHash('sha256').update(dedupMaterial).digest('hex').slice(0, 16);
+  const dedupKey = `wm:notif:scan-dedup:${eventType}:${dedupHash}`;
+  const isNew = (await upstashRest('SET', dedupKey, '1', 'NX', 'EX', String(dedupTtl))) === 'OK';
+  if (!isNew) return false;
+  const msg = JSON.stringify({ eventType, payload, severity, publishedAt: nowMs() });
+  let pushed;
+  try {
+    pushed = await upstashRest('LPUSH', 'wm:events:queue', msg);
+  } catch (err) {
+    logger.warn?.(`[digest] watchlist LPUSH failed for ${eventType} - rolling back dedup key: ${err?.message ?? err}`);
+    try { await upstashRest('DEL', dedupKey); } catch {}
+    return false;
+  }
+  if (typeof pushed !== 'number') {
+    logger.warn?.(`[digest] watchlist LPUSH failed for ${eventType} - rolling back dedup key`);
+    try { await upstashRest('DEL', dedupKey); } catch {}
+    return false;
+  }
+  logger.log?.(
+    `[digest] watchlist queued ${severity} ${eventType}: ` +
+      `${String(payload?.title ?? '').slice(0, 60)} tickers=${(payload?.tickers ?? []).join(',')}`,
+  );
+  return true;
+}
+
+export async function scanAndEnqueueWatchlistStoryEvents(nowMs, {
+  env = process.env,
+  upstashRest,
+  upstashPipeline,
+  readStoryTracksChunked,
+  tickerDictionary,
+  publishNotificationEvent,
+  logger = console,
+  accumulators = WATCHLIST_SCAN_ACCUMULATORS,
+  scanWindowMs = WATCHLIST_SCAN_WINDOW_MS,
+} = {}) {
+  try {
+    if (typeof upstashRest !== 'function') throw new Error('upstashRest dependency is required');
+    if (typeof upstashPipeline !== 'function') throw new Error('upstashPipeline dependency is required');
+    if (typeof readStoryTracksChunked !== 'function') throw new Error('readStoryTracksChunked dependency is required');
+
+    const scoreMin = resolveWatchlistScoreMin(env);
+    const windowStart = String(nowMs - scanWindowMs);
+    const seenHashes = new Set();
+    const hashes = [];
+    const memberLists = await Promise.all(
+      accumulators.map((accKey) =>
+        upstashRest('ZRANGEBYSCORE', accKey, windowStart, String(nowMs)),
+      ),
+    );
+    for (const members of memberLists) {
+      if (!Array.isArray(members)) continue;
+      for (const h of members) {
+        if (typeof h === 'string' && h.length > 0 && !seenHashes.has(h)) {
+          seenHashes.add(h);
+          hashes.push(h);
+        }
+      }
+    }
+    if (hashes.length === 0) return { hashes: 0, candidates: 0, events: 0, enqueued: 0, scoreMin };
+
+    const trackResults = await readStoryTracksChunked(hashes, upstashPipeline);
+    if (trackResults === null) {
+      logger.warn?.('[digest] watchlist scan: story-track read failed - skipping this tick');
+      return { hashes: hashes.length, candidates: 0, events: 0, enqueued: 0, scoreMin, skipped: 'track_read_failed' };
+    }
+
+    const candidates = [];
+    for (let i = 0; i < hashes.length; i++) {
+      const raw = trackResults[i]?.result;
+      if (!Array.isArray(raw) || raw.length === 0) continue;
+      const track = flatArrayToObject(raw);
+      if (!track.title) continue;
+      const currentScore = parseInt(track.currentScore ?? '0', 10);
+      if (!Number.isFinite(currentScore) || currentScore < scoreMin) continue;
+      candidates.push({
+        hash: hashes[i],
+        title: track.title,
+        description: typeof track.description === 'string' ? track.description : '',
+        link: track.link ?? '',
+        source: '',
+        currentScore,
+      });
+    }
+    if (candidates.length === 0) return { hashes: hashes.length, candidates: 0, events: 0, enqueued: 0, scoreMin };
+
+    const events = buildWatchlistStoryEvents(candidates, tickerDictionary, scoreMin);
+
+    if (events.length > 0) {
+      try {
+        const srcResults = await upstashPipeline(
+          events.map((event) => ['SMEMBERS', `story:sources:v1:${String(event.payload.coalesceKey).slice('watchlist:'.length)}`]),
+        );
+        for (let i = 0; i < events.length; i++) {
+          const arr = srcResults[i]?.result;
+          if (Array.isArray(arr) && typeof arr[0] === 'string') events[i].payload.source = arr[0];
+        }
+      } catch { /* best-effort */ }
+    }
+    const publish = publishNotificationEvent ??
+      ((event) => publishWatchlistNotificationEvent(event, { upstashRest, logger }));
+    let enqueued = 0;
+    for (const ev of events) {
+      if (await publish(ev)) enqueued++;
+    }
+    logger.log?.(
+      `[digest] watchlist scan: hashes=${hashes.length} candidates=${candidates.length} ` +
+        `events=${events.length} enqueued=${enqueued} score_min=${scoreMin} ` +
+        `event_type=${WATCHLIST_STORY_EVENT_TYPE}`,
+    );
+    return { hashes: hashes.length, candidates: candidates.length, events: events.length, enqueued, scoreMin };
+  } catch (err) {
+    logger.warn?.(`[digest] watchlist scan failed (non-fatal): ${err?.message ?? err}`);
+    return { hashes: 0, candidates: 0, events: 0, enqueued: 0, error: err?.message ?? String(err) };
+  }
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -12,7 +12,6 @@
  *   7. Updates digest:last-sent:v1:${userId}:${variant}
  */
 import { createRequire } from 'node:module';
-import { createHash } from 'node:crypto';
 import dns from 'node:dns/promises';
 import {
   escapeHtml,
@@ -30,7 +29,6 @@ const DIGEST_DIPLOMACY_DATA = require('../shared/diplomacy-keywords.json');
 // uses for diplomacy-keywords.json (avoids the two-sided `with {type:
 // 'json'}` bundler/node trap — see vercel-edge-gotchas).
 const WATCHLIST_STOCKS_DATA = require('../shared/stocks.json');
-const { buildDedupMaterial } = require('./shared/notification-dedup.cjs');
 const { decrypt } = require('./lib/crypto.cjs');
 const {
   assertNotificationWebhookDeliveryUrlSafe,
@@ -98,11 +96,7 @@ import { readCooldownConfig } from './lib/digest-cooldown-config.mjs';
 import { evaluateCooldown } from './lib/digest-cooldown-decision.mjs';
 import { emitCooldownShadowLog } from './lib/digest-cooldown-shadow-log.mjs';
 import { buildTickerDictionary } from '../shared/ticker-extract.js';
-import {
-  buildWatchlistStoryEvents,
-  resolveWatchlistScoreMin,
-  WATCHLIST_STORY_EVENT_TYPE,
-} from './lib/watchlist-story-events.mjs';
+import { scanAndEnqueueWatchlistStoryEvents as scanWatchlistStoryEvents } from './lib/watchlist-story-scan.mjs';
 
 const EPHEMERAL_LIVE_LOG_TITLE_SAMPLE_LIMIT = 5;
 const EPHEMERAL_LIVE_LOG_TITLE_MAX_CHARS = 160;
@@ -589,42 +583,6 @@ function matchesSensitivity(ruleSensitivity, severity) {
 // (ais-relay publishNotificationEvent parity).
 
 const WATCHLIST_TICKER_DICTIONARY = buildTickerDictionary(WATCHLIST_STOCKS_DATA?.symbols ?? []);
-const WATCHLIST_SCAN_DEDUP_TTL_SECONDS = 24 * 60 * 60;
-const WATCHLIST_SCAN_WINDOW_MS = DIGEST_LOOKBACK_MS; // same 24h window the digest reads
-// Ticker-bearing stories live in the general pool AND the finance pool;
-// scan both (hash-deduped) so finance-only feeds still alert. Events carry
-// no `variant`, so the relay fans them out across variants.
-const WATCHLIST_SCAN_ACCUMULATORS = [
-  'digest:accumulator:v1:full:en',
-  'digest:accumulator:v1:finance:en',
-];
-
-/**
- * Publisher: SET NX scan-dedup → LPUSH wm:events:queue → DEL rollback on
- * LPUSH failure. Mirrors ais-relay.cjs publishNotificationEvent over this
- * file's upstashRest helper. Returns true when the event was enqueued.
- */
-async function publishNotificationEvent({ eventType, payload, severity, dedupTtl = WATCHLIST_SCAN_DEDUP_TTL_SECONDS }) {
-  const dedupMaterial = buildDedupMaterial(eventType, payload?.title, payload?.coalesceKey);
-  const dedupHash = createHash('sha256').update(dedupMaterial).digest('hex').slice(0, 16);
-  const dedupKey = `wm:notif:scan-dedup:${eventType}:${dedupHash}`;
-  const isNew = (await upstashRest('SET', dedupKey, '1', 'NX', 'EX', String(dedupTtl))) === 'OK';
-  if (!isNew) return false;
-  const msg = JSON.stringify({ eventType, payload, severity, publishedAt: Date.now() });
-  const pushed = await upstashRest('LPUSH', 'wm:events:queue', msg);
-  if (typeof pushed !== 'number') {
-    // Roll back the dedup key so the next cron tick can retry — otherwise a
-    // transient LPUSH failure silently suppresses the alert for the full TTL.
-    console.warn(`[digest] watchlist LPUSH failed for ${eventType} — rolling back dedup key`);
-    await upstashRest('DEL', dedupKey);
-    return false;
-  }
-  console.log(
-    `[digest] watchlist queued ${severity} ${eventType}: ` +
-      `${String(payload?.title ?? '').slice(0, 60)} tickers=${(payload?.tickers ?? []).join(',')}`,
-  );
-  return true;
-}
 
 /**
  * One watchlist scan per cron tick. Best-effort and self-contained: any
@@ -633,80 +591,15 @@ async function publishNotificationEvent({ eventType, payload, severity, dedupTtl
  * of main(), before the digest-rules fetch).
  */
 async function scanAndEnqueueWatchlistStoryEvents(nowMs) {
-  try {
-    const scoreMin = resolveWatchlistScoreMin(process.env);
-    const windowStart = String(nowMs - WATCHLIST_SCAN_WINDOW_MS);
-    const seenHashes = new Set();
-    const hashes = [];
-    // Read the accumulators concurrently — they are independent ZRANGEBYSCOREs;
-    // one round-trip instead of one-per-accumulator each cron tick.
-    const memberLists = await Promise.all(
-      WATCHLIST_SCAN_ACCUMULATORS.map((accKey) =>
-        upstashRest('ZRANGEBYSCORE', accKey, windowStart, String(nowMs)),
-      ),
-    );
-    for (const members of memberLists) {
-      if (!Array.isArray(members)) continue;
-      for (const h of members) {
-        if (typeof h === 'string' && h.length > 0 && !seenHashes.has(h)) {
-          seenHashes.add(h);
-          hashes.push(h);
-        }
-      }
-    }
-    if (hashes.length === 0) return;
-
-    const trackResults = await readStoryTracksChunked(hashes, upstashPipeline);
-    if (trackResults === null) {
-      console.warn('[digest] watchlist scan: story-track read failed — skipping this tick');
-      return;
-    }
-
-    const candidates = [];
-    for (let i = 0; i < hashes.length; i++) {
-      const raw = trackResults[i]?.result;
-      if (!Array.isArray(raw) || raw.length === 0) continue;
-      const track = flatArrayToObject(raw);
-      if (!track.title) continue;
-      const currentScore = parseInt(track.currentScore ?? '0', 10);
-      if (!Number.isFinite(currentScore) || currentScore < scoreMin) continue;
-      candidates.push({
-        hash: hashes[i],
-        title: track.title,
-        description: typeof track.description === 'string' ? track.description : '',
-        link: track.link ?? '',
-        source: '',
-        currentScore,
-      });
-    }
-    if (candidates.length === 0) return;
-
-    // Hydrate the primary source for the bounded above-threshold set only
-    // (one SMEMBERS per candidate). Best-effort: a failed pipeline leaves
-    // source='' — the relay renders "Source:" only when non-empty.
-    try {
-      const srcResults = await upstashPipeline(
-        candidates.map((c) => ['SMEMBERS', `story:sources:v1:${c.hash}`]),
-      );
-      for (let i = 0; i < candidates.length; i++) {
-        const arr = srcResults[i]?.result;
-        if (Array.isArray(arr) && typeof arr[0] === 'string') candidates[i].source = arr[0];
-      }
-    } catch { /* best-effort */ }
-
-    const events = buildWatchlistStoryEvents(candidates, WATCHLIST_TICKER_DICTIONARY, scoreMin);
-    let enqueued = 0;
-    for (const ev of events) {
-      if (await publishNotificationEvent(ev)) enqueued++;
-    }
-    console.log(
-      `[digest] watchlist scan: hashes=${hashes.length} candidates=${candidates.length} ` +
-        `events=${events.length} enqueued=${enqueued} score_min=${scoreMin} ` +
-        `event_type=${WATCHLIST_STORY_EVENT_TYPE}`,
-    );
-  } catch (err) {
-    console.warn(`[digest] watchlist scan failed (non-fatal): ${err?.message ?? err}`);
-  }
+  return scanWatchlistStoryEvents(nowMs, {
+    env: process.env,
+    upstashRest,
+    upstashPipeline,
+    readStoryTracksChunked,
+    tickerDictionary: WATCHLIST_TICKER_DICTIONARY,
+    logger: console,
+    scanWindowMs: DIGEST_LOOKBACK_MS,
+  });
 }
 
 const DIGEST_DIPLOMACY_KEYWORDS = DIGEST_DIPLOMACY_DATA.diplomacyKeywords;

--- a/scripts/shared/closed-market-equity-maintenance.cjs
+++ b/scripts/shared/closed-market-equity-maintenance.cjs
@@ -1,0 +1,43 @@
+function marketQuotesKey(marketSymbols) {
+  return `market:quotes:v1:${[...marketSymbols].sort().join(',')}`;
+}
+
+async function maintainClosedMarketEquityKeys({
+  marketSymbols,
+  marketSeedTtl,
+  lastEquityQuoteCount = 0,
+  upstashExpire,
+  upstashGet,
+  upstashSet,
+  nowMs = () => Date.now(),
+  metaTtlSeconds = 604800,
+}) {
+  if (!marketSymbols || typeof marketSymbols[Symbol.iterator] !== 'function') {
+    throw new Error('marketSymbols iterable is required');
+  }
+  if (typeof upstashExpire !== 'function') throw new Error('upstashExpire dependency is required');
+  if (typeof upstashGet !== 'function') throw new Error('upstashGet dependency is required');
+  if (typeof upstashSet !== 'function') throw new Error('upstashSet dependency is required');
+
+  const redisKey = marketQuotesKey(marketSymbols);
+  const [ok1, ok2] = await Promise.all([
+    upstashExpire(redisKey, marketSeedTtl),
+    upstashExpire('market:stocks-bootstrap:v1', marketSeedTtl),
+  ]);
+  if (!ok1 || !ok2) return false;
+
+  let count = lastEquityQuoteCount;
+  if (!count) {
+    const meta = await upstashGet('seed-meta:market:stocks');
+    count = (meta && typeof meta.recordCount === 'number') ? meta.recordCount : 0;
+  }
+  if (count > 0) {
+    await upstashSet('seed-meta:market:stocks', { fetchedAt: nowMs(), recordCount: count }, metaTtlSeconds);
+  }
+  return true;
+}
+
+module.exports = {
+  marketQuotesKey,
+  maintainClosedMarketEquityKeys,
+};

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -1415,7 +1415,7 @@ export async function analyzeStock(
   // v3 rows carry old-model output and must age out at cutover.
   const cacheKey = `market:analyze-stock:v4:${symbol}:${includeNews ? 'news' : 'no-news'}${nameSuffix}`;
 
-  const cached = await cachedFetchJson<AnalyzeStockResponse>(cacheKey, CACHE_TTL_SECONDS, async () => {
+  const fetchFreshAnalysis = async (): Promise<AnalyzeStockResponse | null> => {
     const [history, analystData] = await Promise.all([
       fetchYahooHistory(symbol),
       fetchYahooAnalystData(symbol),
@@ -1457,13 +1457,17 @@ export async function analyzeStock(
     });
     await storeStockAnalysisSnapshot(response, includeNews);
     return response;
-  }, undefined, {
-    // Worst-case fetcher budget: 2× UPSTREAM_TIMEOUT_MS sequenced (10s+10s for
-    // history/analyst then headlines/dividend) + 20s LLM overlay + small
-    // overhead. 60s safely sits above this so the cache safety net (#3539)
-    // doesn't pre-empt the caller's own per-stage timeouts.
-    timeoutMs: 60_000,
-  });
+  };
+
+  const cached = options.now
+    ? await fetchFreshAnalysis()
+    : await cachedFetchJson<AnalyzeStockResponse>(cacheKey, CACHE_TTL_SECONDS, fetchFreshAnalysis, undefined, {
+        // Worst-case fetcher budget: 2× UPSTREAM_TIMEOUT_MS sequenced (10s+10s for
+        // history/analyst then headlines/dividend) + 20s LLM overlay + small
+        // overhead. 60s safely sits above this so the cache safety net (#3539)
+        // doesn't pre-empt the caller's own per-stage timeouts.
+        timeoutMs: 60_000,
+      });
 
   if (cached) return cached;
 

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -1394,9 +1394,14 @@ function buildEmptyAnalysisResponse(symbol: string, name: string, includeNews: b
   };
 }
 
+export type AnalyzeStockOptions = {
+  now?: Date;
+};
+
 export async function analyzeStock(
   _ctx: ServerContext,
   req: AnalyzeStockRequest,
+  options: AnalyzeStockOptions = {},
 ): Promise<AnalyzeStockResponse> {
   const symbol = sanitizeSymbol(req.symbol || '');
   if (!symbol) {
@@ -1424,7 +1429,7 @@ export async function analyzeStock(
     // regular session the current price is already live, and while closed
     // there is no extended tape.
     const marketSession = usEquityHoursApply(symbol, history.currency || 'USD')
-      ? getUsEquitySessionAt()
+      ? getUsEquitySessionAt(options.now)
       : '';
     const [headlines, dividend, extendedQuote] = await Promise.all([
       includeNews ? searchRecentStockHeadlines(symbol, name, NEWS_LIMIT).then((r) => r.headlines) : Promise.resolve([]),

--- a/src/services/notification-channels.ts
+++ b/src/services/notification-channels.ts
@@ -200,8 +200,10 @@ function normalizeWatchlistTickers(input: readonly string[] | undefined): string
   return cleaned.slice(0, WATCHLIST_TICKERS_MAX);
 }
 
-function tickerListsEqual(a: readonly string[], b: readonly string[]): boolean {
-  return a.length === b.length && a.every((ticker, index) => ticker === b[index]);
+function tickerSetsEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const bSet = new Set(b);
+  return a.every((ticker) => bSet.has(ticker));
 }
 
 export type WatchlistTickerSyncPayload = Pick<AlertRule, 'variant' | 'enabled' | 'eventTypes' | 'sensitivity' | 'channels'> & {
@@ -211,7 +213,7 @@ export type WatchlistTickerSyncPayload = Pick<AlertRule, 'variant' | 'enabled' |
 export function buildWatchlistTickerSyncPayload(rule: AlertRule | undefined, symbols: string[]): WatchlistTickerSyncPayload | null {
   if (!rule?.enabled || !rule.eventTypes?.includes('watchlist_story_alert')) return null;
   const tickers = normalizeWatchlistTickers(symbols);
-  if (tickerListsEqual(normalizeWatchlistTickers(rule.tickers), tickers)) return null;
+  if (tickerSetsEqual(normalizeWatchlistTickers(rule.tickers), tickers)) return null;
   return {
     variant: rule.variant,
     enabled: rule.enabled,

--- a/src/services/notification-channels.ts
+++ b/src/services/notification-channels.ts
@@ -183,19 +183,51 @@ export async function setDigestSettings(settings: {
  * PRO tier + signed-in state before invoking, so free/anon watchlist edits
  * never generate 4xx traffic against the PRO-gated endpoint.
  */
-export async function syncWatchlistTickersToAlertRule(symbols: string[]): Promise<void> {
-  const data = await getChannelsData();
-  const rule = data.alertRules?.[0];
-  if (!rule?.enabled || !rule.eventTypes?.includes('watchlist_story_alert')) return;
-  await saveAlertRules({
+const WATCHLIST_TICKERS_MAX = 50;
+const WATCHLIST_TICKER_RE = /^[A-Z][A-Z0-9&-]{0,11}(\.[A-Z]{1,3})?$/;
+
+function normalizeWatchlistTickers(input: readonly string[] | undefined): string[] {
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of input ?? []) {
+    if (typeof raw !== 'string') continue;
+    const upper = raw.trim().toUpperCase();
+    if (!WATCHLIST_TICKER_RE.test(upper)) continue;
+    if (seen.has(upper)) continue;
+    seen.add(upper);
+    cleaned.push(upper);
+  }
+  return cleaned.slice(0, WATCHLIST_TICKERS_MAX);
+}
+
+function tickerListsEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((ticker, index) => ticker === b[index]);
+}
+
+export type WatchlistTickerSyncPayload = Pick<AlertRule, 'variant' | 'enabled' | 'eventTypes' | 'sensitivity' | 'channels'> & {
+  tickers: string[];
+};
+
+export function buildWatchlistTickerSyncPayload(rule: AlertRule | undefined, symbols: string[]): WatchlistTickerSyncPayload | null {
+  if (!rule?.enabled || !rule.eventTypes?.includes('watchlist_story_alert')) return null;
+  const tickers = normalizeWatchlistTickers(symbols);
+  if (tickerListsEqual(normalizeWatchlistTickers(rule.tickers), tickers)) return null;
+  return {
     variant: rule.variant,
     enabled: rule.enabled,
     eventTypes: rule.eventTypes,
     sensitivity: rule.sensitivity,
     channels: rule.channels,
     // countries / aiDigestEnabled omitted on purpose — preserve-on-omit.
-    tickers: symbols,
-  });
+    tickers,
+  };
+}
+
+export async function syncWatchlistTickersToAlertRule(symbols: string[]): Promise<void> {
+  const data = await getChannelsData();
+  const payload = buildWatchlistTickerSyncPayload(data.alertRules?.[0], symbols);
+  if (!payload) return;
+  await saveAlertRules(payload);
 }
 
 /**

--- a/tests/closed-market-equity-maintenance.test.mjs
+++ b/tests/closed-market-equity-maintenance.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Behavioral coverage for the AIS relay closed-market equity TTL refresher.
+ *
+ * Run: node --test tests/closed-market-equity-maintenance.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  marketQuotesKey,
+  maintainClosedMarketEquityKeys,
+} = require('../scripts/shared/closed-market-equity-maintenance.cjs');
+
+describe('closed-market equity key maintenance', () => {
+  it('builds the stock quotes key with sorted symbols', () => {
+    assert.equal(marketQuotesKey(['MSFT', 'AAPL', '^GSPC']), 'market:quotes:v1:AAPL,MSFT,^GSPC');
+  });
+
+  it('extends both stock keys and refreshes seed-meta from the last in-process quote count', async () => {
+    const expires = [];
+    const writes = [];
+
+    const ok = await maintainClosedMarketEquityKeys({
+      marketSymbols: ['MSFT', 'AAPL'],
+      marketSeedTtl: 7200,
+      lastEquityQuoteCount: 2,
+      upstashExpire: async (key, ttl) => { expires.push([key, ttl]); return true; },
+      upstashGet: async () => { throw new Error('should not read meta when last count is present'); },
+      upstashSet: async (key, value, ttl) => { writes.push([key, value, ttl]); return true; },
+      nowMs: () => 123456,
+    });
+
+    assert.equal(ok, true);
+    assert.deepEqual(expires, [
+      ['market:quotes:v1:AAPL,MSFT', 7200],
+      ['market:stocks-bootstrap:v1', 7200],
+    ]);
+    assert.deepEqual(writes, [
+      ['seed-meta:market:stocks', { fetchedAt: 123456, recordCount: 2 }, 604800],
+    ]);
+  });
+
+  it('falls back to the prior seed-meta record count when the process has not seeded yet', async () => {
+    const writes = [];
+
+    const ok = await maintainClosedMarketEquityKeys({
+      marketSymbols: ['AAPL'],
+      marketSeedTtl: 7200,
+      lastEquityQuoteCount: 0,
+      upstashExpire: async () => true,
+      upstashGet: async (key) => {
+        assert.equal(key, 'seed-meta:market:stocks');
+        return { fetchedAt: 111, recordCount: 17 };
+      },
+      upstashSet: async (key, value, ttl) => { writes.push([key, value, ttl]); return true; },
+      nowMs: () => 222,
+    });
+
+    assert.equal(ok, true);
+    assert.deepEqual(writes, [
+      ['seed-meta:market:stocks', { fetchedAt: 222, recordCount: 17 }, 604800],
+    ]);
+  });
+
+  it('returns false and skips seed-meta writes when either last-good key is missing', async () => {
+    const writes = [];
+
+    const ok = await maintainClosedMarketEquityKeys({
+      marketSymbols: ['AAPL'],
+      marketSeedTtl: 7200,
+      lastEquityQuoteCount: 5,
+      upstashExpire: async (key) => key !== 'market:stocks-bootstrap:v1',
+      upstashGet: async () => ({ recordCount: 5 }),
+      upstashSet: async (...args) => { writes.push(args); return true; },
+    });
+
+    assert.equal(ok, false);
+    assert.deepEqual(writes, []);
+  });
+});

--- a/tests/market-hours.test.mjs
+++ b/tests/market-hours.test.mjs
@@ -124,6 +124,7 @@ describe('closed-market seeding gates (source-textual, #4922d)', () => {
 
   it('Dockerfile.relay COPYs the new shared helper (scripts/shared/ is copied per-file)', () => {
     const src = readSrc('Dockerfile.relay');
+    assert.match(src, /COPY scripts\/shared\/closed-market-equity-maintenance\.cjs \.\/scripts\/shared\/closed-market-equity-maintenance\.cjs/);
     assert.match(src, /COPY scripts\/shared\/market-hours\.cjs \.\/scripts\/shared\/market-hours\.cjs/);
   });
 });

--- a/tests/notification-channels-watchlist-sync.test.mts
+++ b/tests/notification-channels-watchlist-sync.test.mts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildWatchlistTickerSyncPayload,
+  type AlertRule,
+} from '../src/services/notification-channels.ts';
+
+const baseRule: AlertRule = {
+  variant: 'finance',
+  enabled: true,
+  eventTypes: ['watchlist_story_alert'],
+  sensitivity: 'high',
+  channels: ['email'],
+  quietHoursEnabled: true,
+  aiDigestEnabled: true,
+  countries: ['US'],
+  tickers: ['OLD'],
+};
+
+describe('buildWatchlistTickerSyncPayload', () => {
+  it('returns null when the rule is missing, disabled, or not opted into watchlist stories', () => {
+    assert.equal(buildWatchlistTickerSyncPayload(undefined, ['AAPL']), null);
+    assert.equal(buildWatchlistTickerSyncPayload({ ...baseRule, enabled: false }, ['AAPL']), null);
+    assert.equal(buildWatchlistTickerSyncPayload({ ...baseRule, eventTypes: ['rss_alert'] }, ['AAPL']), null);
+  });
+
+  it('builds the preserve-on-omit alert-rule payload with the normalized ticker scope', () => {
+    const payload = buildWatchlistTickerSyncPayload(baseRule, [' aapl ', 'MSFT', 'MSFT', '^GSPC']);
+
+    assert.deepEqual(payload, {
+      variant: 'finance',
+      enabled: true,
+      eventTypes: ['watchlist_story_alert'],
+      sensitivity: 'high',
+      channels: ['email'],
+      tickers: ['AAPL', 'MSFT'],
+    });
+    assert.equal(Object.hasOwn(payload!, 'countries'), false);
+    assert.equal(Object.hasOwn(payload!, 'aiDigestEnabled'), false);
+  });
+
+  it('returns null when the normalized ticker scope is already current', () => {
+    assert.equal(
+      buildWatchlistTickerSyncPayload({ ...baseRule, tickers: ['aapl', 'MSFT'] }, [' AAPL ', 'MSFT', 'MSFT', '^GSPC']),
+      null,
+    );
+  });
+});

--- a/tests/notification-channels-watchlist-sync.test.mts
+++ b/tests/notification-channels-watchlist-sync.test.mts
@@ -46,4 +46,11 @@ describe('buildWatchlistTickerSyncPayload', () => {
       null,
     );
   });
+
+  it('returns null for reorder-only ticker scope changes', () => {
+    assert.equal(
+      buildWatchlistTickerSyncPayload({ ...baseRule, tickers: ['MSFT', 'aapl'] }, [' AAPL ', 'MSFT', 'MSFT', '^GSPC']),
+      null,
+    );
+  });
 });

--- a/tests/notify-internal-events.test.mts
+++ b/tests/notify-internal-events.test.mts
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isInternalNotifyEventType } from '../api/notify.ts';
+
+describe('/api/notify reserved event types', () => {
+  it('reserves relay-control and digest-produced watchlist event types', () => {
+    assert.equal(isInternalNotifyEventType('flush_quiet_held'), true);
+    assert.equal(isInternalNotifyEventType('channel_welcome'), true);
+    assert.equal(isInternalNotifyEventType('watchlist_story_alert'), true);
+  });
+
+  it('does not reserve ordinary user-publishable event types', () => {
+    assert.equal(isInternalNotifyEventType('rss_alert'), false);
+    assert.equal(isInternalNotifyEventType('market_alert'), false);
+  });
+});

--- a/tests/stock-market-session.test.mts
+++ b/tests/stock-market-session.test.mts
@@ -77,6 +77,63 @@ function mockFetchJson(payload: unknown, capture?: { url?: string }) {
   }) as typeof fetch;
 }
 
+function yahooHistoryPayload() {
+  const timestamps = Array.from({ length: 80 }, (_, i) => 1_700_000_000 + i * 86_400);
+  const closes = timestamps.map((_, i) => 100 + i * 0.4);
+  return {
+    chart: {
+      result: [
+        {
+          meta: { currency: 'USD' },
+          timestamp: timestamps,
+          indicators: {
+            quote: [
+              {
+                open: closes.map((close) => close - 0.2),
+                high: closes.map((close) => close + 1),
+                low: closes.map((close) => close - 1),
+                close: closes,
+                volume: closes.map(() => 1_000_000),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function installAnalyzeStockFetchMock() {
+  const urls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    urls.push(url);
+    if (url.includes('range=6mo&interval=1d')) {
+      return new Response(JSON.stringify(yahooHistoryPayload()), { status: 200 });
+    }
+    if (url.includes('modules=recommendationTrend,financialData,upgradeDowngradeHistory')) {
+      return new Response(JSON.stringify({ quoteSummary: { result: [{}] } }), { status: 200 });
+    }
+    if (url.includes('range=5y&interval=1mo')) {
+      return new Response(JSON.stringify({ chart: { result: [{ meta: { currency: 'USD' }, events: { dividends: {} } }] } }), { status: 200 });
+    }
+    if (url.includes('modules=summaryDetail')) {
+      return new Response(JSON.stringify({ quoteSummary: { result: [{ summaryDetail: {} }] } }), { status: 200 });
+    }
+    if (url.includes('range=1d&interval=5m')) {
+      return new Response(JSON.stringify(extendedChartPayload({
+        regularStart: 100_000,
+        regularEnd: 123_400,
+        timestamps: [95_000, 96_000, 100_000],
+        closes: [9, 9.45, 10],
+        regularMarketPrice: 9,
+      })), { status: 200 });
+    }
+    throw new Error('unexpected fetch ' + url);
+  }) as typeof fetch;
+  return urls;
+}
+
 describe('usEquityHoursApply (#4922d)', () => {
   it('applies to US listings (USD, no exchange suffix) including indices and ADRs', () => {
     assert.equal(usEquityHoursApply('AAPL', 'USD'), true);
@@ -224,6 +281,47 @@ describe('AnalyzeStockResponse marketSession / extended fields (#4922d)', () => 
     const invalid = await analyzeStock({} as never, { symbol: '', name: '', includeNews: false });
     assert.equal(invalid.available, false);
     assert.equal(invalid.marketSession, '');
+  });
+
+  it('success path uses the injected analysis clock to fetch and attach pre-market extended fields', async () => {
+    const previousRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const previousRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const previousOpenRouterKey = process.env.OPENROUTER_API_KEY;
+    const previousLlmApiUrl = process.env.LLM_API_URL;
+    const previousLlmApiKey = process.env.LLM_API_KEY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+    try {
+      const urls = installAnalyzeStockFetchMock();
+      const response = await analyzeStock(
+        {} as never,
+        { symbol: 'AAPL', name: 'Apple', includeNews: false },
+        { now: new Date('2026-07-08T11:00:00Z') },
+      );
+
+      assert.equal(response.available, true);
+      assert.equal(response.marketSession, 'pre');
+      assert.equal(response.extendedPrice, 9.45);
+      assert.equal(response.extendedChangePercent, 5);
+      assert.ok(
+        urls.some((url) => url.includes('range=1d&interval=5m&includePrePost=true')),
+        'pre-market analysis must request the extended-hours Yahoo chart',
+      );
+    } finally {
+      if (previousRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = previousRedisUrl;
+      if (previousRedisToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = previousRedisToken;
+      if (previousOpenRouterKey === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = previousOpenRouterKey;
+      if (previousLlmApiUrl === undefined) delete process.env.LLM_API_URL;
+      else process.env.LLM_API_URL = previousLlmApiUrl;
+      if (previousLlmApiKey === undefined) delete process.env.LLM_API_KEY;
+      else process.env.LLM_API_KEY = previousLlmApiKey;
+    }
   });
 });
 

--- a/tests/stock-market-session.test.mts
+++ b/tests/stock-market-session.test.mts
@@ -103,11 +103,13 @@ function yahooHistoryPayload() {
   };
 }
 
-function installAnalyzeStockFetchMock() {
+function installAnalyzeStockFetchMock(handleUrl?: (url: string) => Response | undefined) {
   const urls: string[] = [];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     urls.push(url);
+    const handled = handleUrl?.(url);
+    if (handled) return handled;
     if (url.includes('range=6mo&interval=1d')) {
       return new Response(JSON.stringify(yahooHistoryPayload()), { status: 200 });
     }
@@ -309,6 +311,58 @@ describe('AnalyzeStockResponse marketSession / extended fields (#4922d)', () => 
       assert.ok(
         urls.some((url) => url.includes('range=1d&interval=5m&includePrePost=true')),
         'pre-market analysis must request the extended-hours Yahoo chart',
+      );
+    } finally {
+      if (previousRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = previousRedisUrl;
+      if (previousRedisToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = previousRedisToken;
+      if (previousOpenRouterKey === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = previousOpenRouterKey;
+      if (previousLlmApiUrl === undefined) delete process.env.LLM_API_URL;
+      else process.env.LLM_API_URL = previousLlmApiUrl;
+      if (previousLlmApiKey === undefined) delete process.env.LLM_API_KEY;
+      else process.env.LLM_API_KEY = previousLlmApiKey;
+    }
+  });
+
+  it('bypasses a warm shared cache when the analysis clock is injected', async () => {
+    const previousRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const previousRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const previousOpenRouterKey = process.env.OPENROUTER_API_KEY;
+    const previousLlmApiUrl = process.env.LLM_API_URL;
+    const previousLlmApiKey = process.env.LLM_API_KEY;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+    try {
+      const staleCachedResponse = buildAnalysisResponse({ ...baseParams, marketSession: 'regular' });
+      const urls = installAnalyzeStockFetchMock((url) => {
+        if (url.startsWith('https://redis.example') && url.includes('market%3Aanalyze-stock')) {
+          return new Response(JSON.stringify({ result: JSON.stringify(staleCachedResponse) }), { status: 200 });
+        }
+        if (url.startsWith('https://redis.example')) {
+          return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+        }
+        return undefined;
+      });
+
+      const response = await analyzeStock(
+        {} as never,
+        { symbol: 'AAPL', name: 'Apple', includeNews: false },
+        { now: new Date('2026-07-08T11:00:00Z') },
+      );
+
+      assert.equal(response.available, true);
+      assert.equal(response.marketSession, 'pre');
+      assert.equal(response.extendedPrice, 9.45);
+      assert.equal(response.extendedChangePercent, 5);
+      assert.equal(
+        urls.some((url) => url.startsWith('https://redis.example') && url.includes('market%3Aanalyze-stock')),
+        false,
+        'injected analysis clocks must not read session-agnostic analyze-stock cache entries',
       );
     } finally {
       if (previousRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;

--- a/tests/watchlist-story-events.test.mjs
+++ b/tests/watchlist-story-events.test.mjs
@@ -4,10 +4,10 @@
  * Two surfaces:
  *  1. Unit tests for the pure builder in scripts/lib/watchlist-story-events.mjs
  *     (extraction + threshold + event-shape decisions).
- *  2. Source-grep contract on scripts/seed-digest-notifications.mjs — the cron
- *     is a runtime side-effect module (top-level main() + process.exit guards),
- *     so its wiring is locked via source text, same pattern as
- *     tests/notification-relay-country-filter.test.mjs.
+ *  2. Source-grep contract on scripts/seed-digest-notifications.mjs and
+ *     scripts/lib/watchlist-story-scan.mjs — the cron is a runtime
+ *     side-effect module, so only the wrapper wiring stays in the cron body
+ *     while the Redis orchestration lives in an importable helper.
  *
  * Run: node --test tests/watchlist-story-events.test.mjs
  */
@@ -29,6 +29,10 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const digestSrc = readFileSync(
   resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'),
+  'utf-8',
+);
+const scanSrc = readFileSync(
+  resolve(__dirname, '..', 'scripts', 'lib', 'watchlist-story-scan.mjs'),
   'utf-8',
 );
 const relaySrc = readFileSync(
@@ -153,11 +157,11 @@ describe('resolveWatchlistScoreMin — env threshold', () => {
 });
 
 describe('seed-digest-notifications.mjs — enqueue wiring (source-grep contract)', () => {
-  it('imports the pure builder + threshold resolver and the shared ticker dictionary', () => {
+  it('wires the importable scan helper and the shared ticker dictionary', () => {
     assert.match(
       digestSrc,
-      /from '\.\/lib\/watchlist-story-events\.mjs'/,
-      'cron must import the watchlist-story-events lib',
+      /from '\.\/lib\/watchlist-story-scan\.mjs'/,
+      'cron must delegate Redis orchestration to the watchlist-story-scan helper',
     );
     assert.match(
       digestSrc,
@@ -177,22 +181,22 @@ describe('seed-digest-notifications.mjs — enqueue wiring (source-grep contract
 
   it('publishes via the SET-NX scan-dedup → LPUSH wm:events:queue → DEL-rollback pattern', () => {
     assert.match(
-      digestSrc,
+      scanSrc,
       /wm:notif:scan-dedup:/,
       'publisher must dedup on the shared scan-dedup keyspace',
     );
     assert.match(
-      digestSrc,
+      scanSrc,
       /buildDedupMaterial\(/,
       'publisher dedup material must come from the shared notification-dedup helper',
     );
     assert.match(
-      digestSrc,
+      scanSrc,
       /'LPUSH',\s*'wm:events:queue'/,
       'events must be LPUSHed onto the queue the notification relay consumes',
     );
     assert.match(
-      digestSrc,
+      scanSrc,
       /rolling back dedup key/i,
       'LPUSH failure must roll back the dedup key (ais-relay publishNotificationEvent parity)',
     );
@@ -213,6 +217,6 @@ describe('seed-digest-notifications.mjs — enqueue wiring (source-grep contract
   });
 
   it('threshold comes from WATCHLIST_STORY_SCORE_MIN via resolveWatchlistScoreMin', () => {
-    assert.match(digestSrc, /resolveWatchlistScoreMin\(process\.env\)/);
+    assert.match(scanSrc, /resolveWatchlistScoreMin\(env\)/);
   });
 });

--- a/tests/watchlist-story-events.test.mjs
+++ b/tests/watchlist-story-events.test.mjs
@@ -219,4 +219,9 @@ describe('seed-digest-notifications.mjs — enqueue wiring (source-grep contract
   it('threshold comes from WATCHLIST_STORY_SCORE_MIN via resolveWatchlistScoreMin', () => {
     assert.match(scanSrc, /resolveWatchlistScoreMin\(env\)/);
   });
+
+  it('hydrates sources using the candidate hash rather than parsing coalesceKey', () => {
+    assert.ok(scanSrc.includes('sourceKey: `story:sources:v1:${candidate.hash}`'));
+    assert.doesNotMatch(scanSrc, /coalesceKey\)\.slice\('watchlist:'/);
+  });
 });

--- a/tests/watchlist-story-scan.test.mjs
+++ b/tests/watchlist-story-scan.test.mjs
@@ -1,0 +1,191 @@
+/**
+ * Behavioral coverage for the watchlist story alert scan/publish orchestration.
+ *
+ * Run: node --test tests/watchlist-story-scan.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildTickerDictionary } from '../shared/ticker-extract.js';
+import {
+  publishWatchlistNotificationEvent,
+  scanAndEnqueueWatchlistStoryEvents,
+  WATCHLIST_SCAN_DEDUP_TTL_SECONDS,
+} from '../scripts/lib/watchlist-story-scan.mjs';
+
+const silentLogger = { log() {}, warn() {} };
+
+const event = {
+  eventType: 'watchlist_story_alert',
+  severity: 'high',
+  payload: {
+    title: 'Microsoft faces new antitrust probe',
+    link: 'https://example.test/msft',
+    source: 'Example Wire',
+    tickers: ['MSFT'],
+    importanceScore: 74,
+    coalesceKey: 'watchlist:h1',
+  },
+};
+
+function flatTrack(overrides) {
+  return Object.entries({
+    title: 'Microsoft faces new antitrust probe',
+    description: '',
+    link: 'https://example.test/msft',
+    currentScore: '74',
+    ...overrides,
+  }).flat();
+}
+
+describe('publishWatchlistNotificationEvent', () => {
+  it('runs SET NX before LPUSH and stamps the queued event', async () => {
+    const calls = [];
+    const upstashRest = async (...args) => {
+      calls.push(args);
+      if (args[0] === 'SET') return 'OK';
+      if (args[0] === 'LPUSH') return 1;
+      throw new Error(`unexpected command ${args[0]}`);
+    };
+
+    assert.equal(
+      await publishWatchlistNotificationEvent(event, { upstashRest, nowMs: () => 1234, logger: silentLogger }),
+      true,
+    );
+
+    assert.equal(calls[0][0], 'SET');
+    assert.match(calls[0][1], /^wm:notif:scan-dedup:watchlist_story_alert:/);
+    assert.deepEqual(calls[0].slice(2), ['1', 'NX', 'EX', String(WATCHLIST_SCAN_DEDUP_TTL_SECONDS)]);
+    assert.equal(calls[1][0], 'LPUSH');
+    assert.equal(calls[1][1], 'wm:events:queue');
+    assert.deepEqual(JSON.parse(calls[1][2]), { ...event, publishedAt: 1234 });
+  });
+
+  it('treats a non-new SET NX result as a duplicate and does not LPUSH', async () => {
+    const calls = [];
+    const upstashRest = async (...args) => {
+      calls.push(args);
+      return null;
+    };
+
+    assert.equal(await publishWatchlistNotificationEvent(event, { upstashRest, logger: silentLogger }), false);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], 'SET');
+  });
+
+  it('rolls back the dedup key when LPUSH returns a non-numeric result', async () => {
+    const calls = [];
+    const upstashRest = async (...args) => {
+      calls.push(args);
+      if (args[0] === 'SET') return 'OK';
+      if (args[0] === 'LPUSH') return 'ERR';
+      if (args[0] === 'DEL') return 1;
+      throw new Error(`unexpected command ${args[0]}`);
+    };
+
+    assert.equal(await publishWatchlistNotificationEvent(event, { upstashRest, logger: silentLogger }), false);
+    assert.deepEqual(calls.map((call) => call[0]), ['SET', 'LPUSH', 'DEL']);
+    assert.equal(calls[2][1], calls[0][1], 'rollback must delete the SET NX dedup key');
+  });
+
+  it('rolls back the dedup key when LPUSH throws', async () => {
+    const calls = [];
+    const upstashRest = async (...args) => {
+      calls.push(args);
+      if (args[0] === 'SET') return 'OK';
+      if (args[0] === 'LPUSH') throw new Error('timeout');
+      if (args[0] === 'DEL') return 1;
+      throw new Error(`unexpected command ${args[0]}`);
+    };
+
+    assert.equal(await publishWatchlistNotificationEvent(event, { upstashRest, logger: silentLogger }), false);
+    assert.deepEqual(calls.map((call) => call[0]), ['SET', 'LPUSH', 'DEL']);
+    assert.equal(calls[2][1], calls[0][1], 'rollback must delete the SET NX dedup key');
+  });
+});
+
+describe('scanAndEnqueueWatchlistStoryEvents', () => {
+  const dictionary = buildTickerDictionary([
+    { symbol: 'MSFT', name: 'Microsoft' },
+    { symbol: 'LLY', name: 'Eli Lilly' },
+  ]);
+
+  it('dedupes accumulator hashes, reads tracks, hydrates sources, gates by score, then publishes', async () => {
+    const order = [];
+    const queued = [];
+    const pipelineCalls = [];
+    const trackReads = [];
+
+    const upstashRest = async (...args) => {
+      order.push(args[0]);
+      if (args[0] === 'ZRANGEBYSCORE') {
+        return args[1].includes(':full:') ? ['h1', 'low'] : ['h1', 'h2'];
+      }
+      if (args[0] === 'SET') return 'OK';
+      if (args[0] === 'LPUSH') {
+        queued.push(JSON.parse(args[2]));
+        return 1;
+      }
+      throw new Error(`unexpected command ${args[0]}`);
+    };
+    const upstashPipeline = async (commands) => {
+      order.push('SMEMBERS');
+      pipelineCalls.push(commands);
+      return commands.map((cmd) => ({ result: [cmd[1].endsWith(':h1') ? 'Reuters' : 'Other Wire'] }));
+    };
+    const readStoryTracksChunked = async (hashes, pipeline) => {
+      order.push('track-read');
+      trackReads.push({ hashes, samePipeline: pipeline === upstashPipeline });
+      return hashes.map((hash) => {
+        if (hash === 'h1') return { result: flatTrack({ title: 'Microsoft antitrust probe', currentScore: '74' }) };
+        if (hash === 'low') return { result: flatTrack({ title: 'Microsoft shares slip', currentScore: '68' }) };
+        return { result: flatTrack({ title: 'Earthquake strikes region', currentScore: '95' }) };
+      });
+    };
+
+    const result = await scanAndEnqueueWatchlistStoryEvents(10_000, {
+      env: { WATCHLIST_STORY_SCORE_MIN: '69' },
+      upstashRest,
+      upstashPipeline,
+      readStoryTracksChunked,
+      tickerDictionary: dictionary,
+      logger: silentLogger,
+    });
+
+    assert.deepEqual(result, { hashes: 3, candidates: 2, events: 1, enqueued: 1, scoreMin: 69 });
+    assert.deepEqual(order, ['ZRANGEBYSCORE', 'ZRANGEBYSCORE', 'track-read', 'SMEMBERS', 'SET', 'LPUSH']);
+    assert.deepEqual(trackReads, [{ hashes: ['h1', 'low', 'h2'], samePipeline: true }]);
+    assert.deepEqual(pipelineCalls, [[['SMEMBERS', 'story:sources:v1:h1']]]);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].eventType, 'watchlist_story_alert');
+    assert.deepEqual(queued[0].payload.tickers, ['MSFT']);
+    assert.equal(queued[0].payload.source, 'Reuters');
+  });
+
+  it('does not publish when the importance threshold filters out ticker matches', async () => {
+    const commands = [];
+    const upstashRest = async (...args) => {
+      commands.push(args[0]);
+      if (args[0] === 'ZRANGEBYSCORE') return ['h1'];
+      throw new Error(`unexpected command ${args[0]}`);
+    };
+    const upstashPipeline = async () => {
+      commands.push('SMEMBERS');
+      return [{ result: ['Reuters'] }];
+    };
+    const readStoryTracksChunked = async () => [{ result: flatTrack({ currentScore: '74' }) }];
+
+    const result = await scanAndEnqueueWatchlistStoryEvents(10_000, {
+      env: { WATCHLIST_STORY_SCORE_MIN: '80' },
+      upstashRest,
+      upstashPipeline,
+      readStoryTracksChunked,
+      tickerDictionary: dictionary,
+      logger: silentLogger,
+    });
+
+    assert.deepEqual(result, { hashes: 1, candidates: 0, events: 0, enqueued: 0, scoreMin: 80 });
+    assert.deepEqual(commands, ['ZRANGEBYSCORE', 'ZRANGEBYSCORE']);
+  });
+});


### PR DESCRIPTION
## Summary

Watchlist story alerts now have tested, importable scanner behavior instead of relying on source-grep coverage inside the digest cron. The scanner preserves the digest lookback window, de-dupes accumulator hashes, hydrates sources only for emitted watchlist events, and rolls back scan de-dupe keys whether queue writes return a bad result or throw.

The remaining review follow-ups are covered across the notification boundary, market seeding, and stock-analysis session path: user-submitted `watchlist_story_alert` events are rejected at `/api/notify`, watchlist ticker sync normalizes and skips no-op saves, closed-market equity TTL maintenance is testable and copied into the relay image, and `analyzeStock` can be tested against an injected pre-market clock.

Fixes #5030.

## Intent

This closes the behavioral-test and hardening gaps left by the #4922 review without changing the public notification contract. The scanner and relay helpers now expose narrow dependency-injected seams for regression coverage while the production cron/relay paths keep their existing ordering and fail-soft behavior.

## Validation Matrix

| Check | Result |
| --- | --- |
| `node --test tests/watchlist-story-scan.test.mjs tests/closed-market-equity-maintenance.test.mjs tests/watchlist-story-events.test.mjs` | Pass, 27 tests |
| `./node_modules/.bin/tsx --test tests/notification-channels-watchlist-sync.test.mts tests/notify-internal-events.test.mts tests/stock-market-session.test.mts` | Pass, 18 tests |
| `node --test tests/notification-relay-payload-audit.test.mjs tests/notification-relay-coalesce-key.test.mjs tests/notification-relay-ticker-filter.test.mjs tests/notifications-settings-ui-invariants.test.mjs tests/dockerfile-relay-imports.test.mjs` | Pass, 78 tests |
| `./node_modules/.bin/tsx --test tests/market-hours.test.mjs` | Pass, 34 tests |
| `npm run typecheck:api` | Pass |
| `npm run typecheck` | Pass |
| `git diff --check` and `git diff --cached --check` | Pass |

Environment note: `npm run worktree:bootstrap` failed during `npm ci` with ENOSPC in this worktree. The final validation used a temporary `node_modules` symlink to another local WorldMonitor checkout after confirming `package.json` and `package-lock.json` matched exactly; the symlink was removed before staging and after push.

## Review Gates

- Read-only reuse, quality, efficiency, and correctness/security review passes ran before commit.
- Fixed the correctness P2 where a thrown Redis `LPUSH` could leave the scan de-dupe key stuck for 24 hours.
- Fixed safe review nits: event-type constant reuse, internal helper exports, redundant digest publisher wrapper, digest lookback wiring, no-op ticker sync saves, source hydration after event filtering, and parallel closed-market `EXPIRE` calls.
- Kept watchlist event publishing serial because queue order can be observable; this PR avoids changing that behavior.

## Documentation

No docs page changed. The new behavioral tests document the scanner, reserved notify event, watchlist ticker sync, closed-market maintenance, relay Docker copy closure, and pre-market analysis success path.

## Screenshots / UI Evidence

Not applicable. This is backend/script/client-service hardening with no visual UI change.

## Residual Findings

- Agent-native MCP ticker exposure and MCP alert-rule management remain product-scope decisions rather than narrow bug fixes in this PR.
- OpenAPI nested `maxItems` detail remains low-priority contract polish per the issue context.
- The analyze-stock cache-key bump remains intentionally untouched; this PR adds the clock seam and success-path regression coverage without changing cache identity.

## Post-Deploy Monitoring & Validation

- Watch digest cron logs for `watchlist scan` and `watchlist queued` counts, plus absence of repeated `watchlist LPUSH failed` rollback warnings.
- Watch `/api/notify` 403 `Reserved event type` rates for `watchlist_story_alert` to spot attempted client-side self-injection.
- Confirm the relay image starts without `ERR_MODULE_NOT_FOUND` for `closed-market-equity-maintenance.cjs`.
- During a closed-market window, monitor `seed-meta:market:stocks` freshness and stock bootstrap TTL preservation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
