### PR TITLE
feat(mcp-apps): interactive dashboard fleet — 4 new ui:// widgets (#4959)

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -185,6 +185,41 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/ui/shell.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) shared app-shell builder — factors the DOCTYPE / 4-category CSP / dark-mode tokens / postMessage bridge every ui:// widget inlines. Exports HTML/meta builder functions (no HTTP handler); the bridge protocol + view CSP shape are dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/world-brief-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/world-brief.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/country-brief-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/country-brief.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/market-radar-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/market-radar.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/chokepoint-monitor-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/chokepoint-monitor.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp-proxy.ts",
       "category": "external-protocol",
       "reason": "Proxy for the MCP transport — same shape constraint as api/mcp.ts. Renamed .js → .ts in PR #3768 to unlock the isCallerPremium import from server/.",

--- a/api/mcp/constants.ts
+++ b/api/mcp/constants.ts
@@ -263,9 +263,26 @@ export const SERVER_NAME = 'worldmonitor';
 //     envelope, or auth change. Mirrored into
 //     public/.well-known/mcp/server-card.json::capabilities.extensions so the
 //     static card and the live wire stay in parity.
+// Bumped 1.13.0 → 1.14.0 (2026-07-08) reflecting:
+//   - MCP Apps interactive-dashboard fleet: four new ui:// app-shell resources
+//     joining the v1.11.0 country-risk widget —
+//       * ui://worldmonitor/world-brief.html      (get_world_brief)
+//       * ui://worldmonitor/country-brief.html    (get_country_brief)
+//       * ui://worldmonitor/market-radar.html      (get_market_data)
+//       * ui://worldmonitor/chokepoint-monitor.html (get_chokepoint_status)
+//     Each is linked from its backing tool via `_meta.ui.resourceUri` (+ the
+//     deprecated flat `ui/resourceUri` alias) and registered in
+//     api/mcp/ui/registry.ts. A shared shell (api/mcp/ui/shell.ts) factors the
+//     DOCTYPE / 4-category CSP / dark-mode tokens / postMessage bridge so the
+//     fleet can't drift on the orank quality/CSP signals. resources/read of a
+//     ui:// URI stays public + quota-exempt (static, data-free template); DATA
+//     reads (worldmonitor://…) stay gated + Pro-quota-symmetric.
+//   - Purely additive on the wire: `_meta` appears on the four newly-linked
+//     tools; every ui:// read is anonymously servable. No input/output schema
+//     change to any tool, no envelope-shape change, no auth change.
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-export const SERVER_VERSION = '1.13.0';
+export const SERVER_VERSION = '1.14.0';
 
 // MCP logging capability — valid severity levels per the 2025-03-26 spec
 // (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -23,6 +23,7 @@ import {
   selectDatasets,
 } from '../filters';
 import type { ToolDef } from '../types';
+import { CHOKEPOINT_MONITOR_UI_URI, MARKET_RADAR_UI_URI } from '../ui/registry';
 
 // Iran-events domain sunset (war ended 2026-07). Default OFF: drop the dormant
 // conflict:iran-events:v1 key from the get_conflict_events cache set so the MCP
@@ -138,6 +139,9 @@ export const CACHE_TOOLS: ToolDef[] = [
       }
       return data;
     },
+    // MCP Apps (`io.modelcontextprotocol/ui`): links the tool to its interactive
+    // ui:// app shell. Single source of truth — registered in ../ui/registry.ts.
+    _uiResourceUri: MARKET_RADAR_UI_URI,
     _cacheKeys: [
       'market:stocks-bootstrap:v1',
       'market:commodities-bootstrap:v1',
@@ -1600,6 +1604,9 @@ export const CACHE_TOOLS: ToolDef[] = [
     // EXCLUDED on purpose: supply_chain:corridorrisk:v1 is an intermediate
     // key whose data flows through supply_chain:transit-summaries:v1
     // (api/health.js:461). U7 will add corridorrisk to EXCLUDED_FROM_MCP.
+    // MCP Apps (`io.modelcontextprotocol/ui`): links the tool to its interactive
+    // ui:// app shell. Single source of truth — registered in ../ui/registry.ts.
+    _uiResourceUri: CHOKEPOINT_MONITOR_UI_URI,
     _cacheKeys: [
       'supply_chain:transit-summaries:v1',          // STANDALONE_KEYS::transitSummaries
       'supply_chain:chokepoint_transits:v1',        // STANDALONE_KEYS::chokepointTransits

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -7,7 +7,7 @@ import { buildAuthHeaders } from '../auth';
 import { SUPPORTED_CONSUMER_PRICES_COUNTRIES } from '../constants';
 import { evaluateFreshness } from '../freshness';
 import type { FreshnessCheck, ToolDef } from '../types';
-import { COUNTRY_RISK_UI_URI } from '../ui/registry';
+import { COUNTRY_BRIEF_UI_URI, COUNTRY_RISK_UI_URI, WORLD_BRIEF_UI_URI } from '../ui/registry';
 import { buildPublicTool, TOOL_REGISTRY } from './index';
 
 type McpBriefSource = {
@@ -139,6 +139,10 @@ export const RPC_TOOLS: ToolDef[] = [
       },
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    // MCP Apps (`io.modelcontextprotocol/ui`): links the tool to its interactive
+    // ui:// app shell (rendered inline by an MCP-Apps host). Single source of
+    // truth — the ui:// resource is registered in ../ui/registry.ts.
+    _uiResourceUri: WORLD_BRIEF_UI_URI,
     _execute: async (params, base, context) => {
       const UA = 'worldmonitor-mcp-edge/1.0';
       // Step 1: fetch current geopolitical headlines (budget: 6 s, leaves ~24 s for LLM).
@@ -232,6 +236,9 @@ export const RPC_TOOLS: ToolDef[] = [
       },
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    // MCP Apps (`io.modelcontextprotocol/ui`): links the tool to its interactive
+    // ui:// app shell. Single source of truth — registered in ../ui/registry.ts.
+    _uiResourceUri: COUNTRY_BRIEF_UI_URI,
     _execute: async (params, base, context) => {
       const UA = 'worldmonitor-mcp-edge/1.0';
       const countryCode = String(params.country_code ?? '').toUpperCase().slice(0, 2);

--- a/api/mcp/ui/chokepoint-monitor-app.ts
+++ b/api/mcp/ui/chokepoint-monitor-app.ts
@@ -1,0 +1,118 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_chokepoint_status` tool: a maritime
+// chokepoint monitor rendering per-chokepoint rolling transit summaries
+// (today's transit count, week-over-week change, tanker split) with a
+// risk-level badge. Built on the shared shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       "transit-summaries": { summaries: {
+//         <chokepoint>: { todayTotal, todayTanker, todayCargo, wowChangePct,
+//                         riskLevel, riskSummary, dataAvailable } },
+//         fetchedAt } } }
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .crow { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }
+  .crow:first-child { border-top: none; }
+  .crow-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .cname { font-size: 15px; font-weight: 600; }
+  .risk { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;
+    padding: 1px 8px; border-radius: 999px; border: 1px solid var(--border); }
+  .cstats { display: flex; gap: 18px; margin-top: 6px; flex-wrap: wrap; }
+  .cstat { display: flex; flex-direction: column; }
+  .cstat .k { font-size: 11px; color: var(--muted); }
+  .cstat .v { font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .csum { margin-top: 6px; font-size: 12px; color: var(--muted); }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">Chokepoint Monitor</div>
+    <div class="badge">WorldMonitor Maritime</div>
+  </div>
+  <div class="empty" id="empty">Waiting for chokepoint data…</div>
+  <div id="card" style="display:none">
+    <div id="rows"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    function prettyName(key) {
+      var s = String(key == null ? "" : key).split("_").join(" ").trim();
+      if (!s) return "—";
+      return s.charAt(0).toUpperCase() + s.slice(1);
+    }
+    function riskColor(r) {
+      if (r === "critical" || r === "severe") return cssVar("--severe");
+      if (r === "high" || r === "elevated") return cssVar("--high");
+      if (r === "moderate" || r === "warning") return cssVar("--moderate");
+      return cssVar("--low");
+    }
+    function stat(k, v) {
+      var wrap = el("div", "cstat");
+      wrap.appendChild(el("span", "k", k));
+      wrap.appendChild(el("span", "v", v));
+      return wrap;
+    }
+
+    var ts = d["transit-summaries"];
+    var summaries = ts && typeof ts === "object" ? ts.summaries : null;
+    var host = q("rows");
+    host.textContent = "";
+    var count = 0;
+    if (summaries && typeof summaries === "object") {
+      var keys = Object.keys(summaries);
+      for (var i = 0; i < keys.length && count < 20; i++) {
+        var s = summaries[keys[i]];
+        if (!s || typeof s !== "object" || s.dataAvailable === false) continue;
+        var row = el("div", "crow");
+        var head = el("div", "crow-head");
+        head.appendChild(el("span", "cname", prettyName(keys[i])));
+        var risk = collapseWs(s.riskLevel).toLowerCase() || "normal";
+        var badge = el("span", "risk", risk);
+        var rc = riskColor(risk);
+        badge.style.color = rc;
+        badge.style.borderColor = rc;
+        head.appendChild(badge);
+        row.appendChild(head);
+
+        var stats = el("div", "cstats");
+        var total = num(s.todayTotal);
+        stats.appendChild(stat("Transits today", total == null ? "—" : String(Math.round(total))));
+        var wow = num(s.wowChangePct);
+        var wowCell = stat("Week over week", pctText(wow));
+        if (wow != null) wowCell.lastChild.style.color = wow >= 0 ? cssVar("--up") : cssVar("--down");
+        stats.appendChild(wowCell);
+        var tanker = num(s.todayTanker);
+        if (tanker != null) stats.appendChild(stat("Tanker", String(Math.round(tanker))));
+        row.appendChild(stats);
+
+        if (s.riskSummary) row.appendChild(el("div", "csum", collapseWs(s.riskSummary)));
+        host.appendChild(row);
+        count++;
+      }
+    }
+    if (!count) host.appendChild(el("div", "empty", "No chokepoint transit data available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const CHOKEPOINT_MONITOR_APP_HTML = buildAppHtml({
+  title: 'Chokepoint Monitor — WorldMonitor',
+  appName: 'worldmonitor-chokepoint-monitor',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/chokepoint-monitor-app.ts
+++ b/api/mcp/ui/chokepoint-monitor-app.ts
@@ -58,10 +58,12 @@ const RENDER = `
       if (r === "moderate" || r === "warning") return cssVar("--moderate");
       return cssVar("--low");
     }
-    function stat(k, v) {
+    function stat(k, v, color) {
       var wrap = el("div", "cstat");
       wrap.appendChild(el("span", "k", k));
-      wrap.appendChild(el("span", "v", v));
+      var val = el("span", "v", v);
+      if (color) val.style.color = color;
+      wrap.appendChild(val);
       return wrap;
     }
 
@@ -90,9 +92,8 @@ const RENDER = `
         var total = num(s.todayTotal);
         stats.appendChild(stat("Transits today", total == null ? "—" : String(Math.round(total))));
         var wow = num(s.wowChangePct);
-        var wowCell = stat("Week over week", pctText(wow));
-        if (wow != null) wowCell.lastChild.style.color = wow >= 0 ? cssVar("--up") : cssVar("--down");
-        stats.appendChild(wowCell);
+        var wowColor = wow == null ? null : (wow >= 0 ? cssVar("--up") : cssVar("--down"));
+        stats.appendChild(stat("Week over week", pctText(wow), wowColor));
         var tanker = num(s.todayTanker);
         if (tanker != null) stats.appendChild(stat("Tanker", String(Math.round(tanker))));
         row.appendChild(stats);

--- a/api/mcp/ui/country-brief-app.ts
+++ b/api/mcp/ui/country-brief-app.ts
@@ -1,0 +1,108 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_country_brief` tool: the per-country
+// deep-dive companion to the country-risk widget. Renders the LLM-synthesised
+// country intelligence brief as paragraphs, the analytical framework lens (when
+// supplied), and the grounding sources. Built on the shared shell foundation.
+//
+// Tool result shape (RPC tool — content[0].text JSON):
+//   { country_code, brief: string, framework, provider, model, generatedAt,
+//     sources: [{ title, url, source, publishedAt }] }
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .lens { display: inline-block; margin: 4px 0 0; font-size: 11px; color: var(--muted); }
+  .lens b { color: var(--fg); font-weight: 600; }
+  .brief { margin: 14px 0 4px; }
+  .brief .para { margin: 0 0 10px; font-size: 14px; line-height: 1.6; }
+  .section { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border); }
+  .sec-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin-bottom: 8px; }
+  .src-row { display: flex; flex-direction: column; gap: 1px; padding: 6px 0; border-bottom: 1px solid var(--border); }
+  .src-row:last-child { border-bottom: none; }
+  .src-name { font-size: 11px; color: var(--accent); font-weight: 600; }
+  .src-title { font-size: 12px; color: var(--fg); }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title" id="title">Country Brief</div>
+    <div class="badge">WorldMonitor Intelligence</div>
+  </div>
+  <div class="lens" id="lens" style="display:none"></div>
+  <div class="empty" id="empty">Waiting for country-brief data…</div>
+  <div id="card" style="display:none">
+    <div class="brief" id="brief"></div>
+    <div class="section" id="src-sec" style="display:none">
+      <div class="sec-label">Sources</div>
+      <div class="sources" id="sources"></div>
+    </div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var name = countryName(data.country_code);
+    setText("title", name ? name + " Brief" : "Country Brief");
+
+    var fw = collapseWs(data.framework);
+    if (fw) {
+      var lens = q("lens");
+      lens.textContent = "";
+      lens.appendChild(el("span", null, "Lens: "));
+      lens.appendChild(el("b", null, fw));
+      lens.style.display = "block";
+    } else {
+      q("lens").style.display = "none";
+    }
+
+    var brief = typeof data.brief === "string" ? data.brief
+      : (typeof data.summary === "string" ? data.summary : "");
+    var briefEl = q("brief");
+    briefEl.textContent = "";
+    var paras = paragraphs(brief);
+    for (var i = 0; i < paras.length; i++) briefEl.appendChild(el("p", "para", paras[i]));
+    if (!briefEl.childNodes.length) briefEl.appendChild(el("div", "empty", "No brief text available."));
+
+    var srcs = Array.isArray(data.sources) ? data.sources : [];
+    var srcHost = q("sources");
+    srcHost.textContent = "";
+    for (var k = 0; k < srcs.length && srcHost.childNodes.length < 8; k++) {
+      var s = srcs[k];
+      if (!s || typeof s !== "object") continue;
+      var row = el("div", "src-row");
+      row.appendChild(el("span", "src-name", collapseWs(s.source) || "source"));
+      var url = httpUrl(s.url);
+      if (s.title) {
+        var titleText = collapseWs(s.title);
+        if (url) {
+          var a = el("a", "src-title", titleText);
+          a.href = url;
+          a.target = "_blank";
+          a.rel = "noopener noreferrer";
+          row.appendChild(a);
+        } else {
+          row.appendChild(el("span", "src-title", titleText));
+        }
+      }
+      srcHost.appendChild(row);
+    }
+    q("src-sec").style.display = srcHost.childNodes.length ? "block" : "none";
+
+    var prov = [data.provider, data.model].filter(Boolean).map(collapseWs).filter(Boolean).join(" · ");
+    var gen = data.generatedAt != null ? "Generated " + collapseWs(data.generatedAt) : "";
+    q("foot").textContent = [prov, gen].filter(Boolean).join(" · ");
+`;
+
+export const COUNTRY_BRIEF_APP_HTML = buildAppHtml({
+  title: 'Country Brief — WorldMonitor',
+  appName: 'worldmonitor-country-brief',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/country-brief-app.ts
+++ b/api/mcp/ui/country-brief-app.ts
@@ -4,9 +4,13 @@
 // country intelligence brief as paragraphs, the analytical framework lens (when
 // supplied), and the grounding sources. Built on the shared shell foundation.
 //
-// Tool result shape (RPC tool — content[0].text JSON):
-//   { country_code, brief: string, framework, provider, model, generatedAt,
-//     sources: [{ title, url, source, publishedAt }] }
+// Tool result shape (RPC tool — content[0].text JSON). The backing
+// get-country-intel-brief handler emits CAMELCASE identity fields
+// (`countryCode` + a resolved `countryName`), NOT `country_code`:
+//   { countryCode, countryName, brief: string, framework, provider, model,
+//     generatedAt, sources: [{ title, url, source, publishedAt }] }
+// The title read below prefers `countryName`, then resolves `countryCode`
+// via Intl, and still tolerates a legacy `country_code` for safety.
 //
 // textContent-only rendering; renderBody stays backtick/`${`/regex-free.
 
@@ -47,7 +51,7 @@ const RENDER = `
     q("empty").style.display = "none";
     q("card").style.display = "block";
 
-    var name = countryName(data.country_code);
+    var name = collapseWs(data.countryName) || countryName(data.countryCode || data.country_code);
     setText("title", name ? name + " Brief" : "Country Brief");
 
     var fw = collapseWs(data.framework);

--- a/api/mcp/ui/market-radar-app.ts
+++ b/api/mcp/ui/market-radar-app.ts
@@ -1,0 +1,127 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_market_data` tool: a compact market radar
+// rendering the Fear & Greed composite plus per-asset-class quote tables
+// (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded
+// change. Built on the shared shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       "stocks-bootstrap": { quotes: [{ symbol, price, changePercent }] },
+//       "commodities-bootstrap": { quotes: [...] }, "crypto": { quotes: [...] },
+//       "gulf-quotes": { quotes: [...] },
+//       "sectors": { sectors: [{ symbol, name, changePercent }] },
+//       "fear-greed": { composite: { score, label, previous } } } }
+// Any label may be absent (asset_class / symbols filters narrow the bundle).
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .fg { display: none; align-items: center; gap: 12px; margin: 14px 0 4px; }
+  .fg-score { font-size: 34px; font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; }
+  .fg-meta { flex: 1; }
+  .fg-cap { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+  .fg-label { font-size: 13px; font-weight: 600; }
+  .fg-track { height: 8px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 6px; }
+  .fg-track > span { display: block; height: 100%; width: 0%; transition: width .3s ease; }
+  .mgroup { margin-top: 16px; }
+  .sec-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin-bottom: 6px; }
+  .qtbl { display: grid; grid-template-columns: 1fr auto auto; gap: 4px 14px; align-items: baseline; }
+  .qsym { font-weight: 600; font-size: 13px; }
+  .qprice { font-variant-numeric: tabular-nums; color: var(--muted); text-align: right; }
+  .qchg { font-variant-numeric: tabular-nums; text-align: right; min-width: 68px; }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">Market Radar</div>
+    <div class="badge">WorldMonitor Markets</div>
+  </div>
+  <div class="empty" id="empty">Waiting for market data…</div>
+  <div id="card" style="display:none">
+    <div class="fg" id="fg">
+      <div class="fg-score" id="fg-score">—</div>
+      <div class="fg-meta">
+        <div class="fg-cap">Fear &amp; Greed</div>
+        <div class="fg-label" id="fg-label">—</div>
+        <div class="fg-track"><span id="fg-bar"></span></div>
+      </div>
+    </div>
+    <div id="groups"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var fg = d["fear-greed"];
+    var comp = fg && typeof fg === "object" ? fg.composite : null;
+    var score = null, label = "";
+    if (comp && typeof comp === "object") { score = num(comp.score); label = collapseWs(comp.label); }
+    else if (typeof comp === "number") { score = num(comp); }
+    if (score != null) {
+      q("fg").style.display = "flex";
+      setText("fg-score", String(Math.round(score)));
+      setText("fg-label", label || "");
+      var col = score >= 55 ? cssVar("--up") : (score <= 45 ? cssVar("--down") : cssVar("--moderate"));
+      var fgBar = q("fg-bar");
+      fgBar.style.width = clampPct(score) + "%";
+      fgBar.style.background = col || "var(--accent)";
+      q("fg-score").style.color = col || "";
+    } else {
+      q("fg").style.display = "none";
+    }
+
+    var groups = [
+      { key: "stocks-bootstrap", list: "quotes", label: "Equities" },
+      { key: "commodities-bootstrap", list: "quotes", label: "Commodities" },
+      { key: "crypto", list: "quotes", label: "Crypto" },
+      { key: "gulf-quotes", list: "quotes", label: "Gulf" },
+      { key: "sectors", list: "sectors", label: "Sectors" }
+    ];
+    var host = q("groups");
+    host.textContent = "";
+    var rendered = 0;
+    for (var g = 0; g < groups.length; g++) {
+      var cfg = groups[g];
+      var node = d[cfg.key];
+      var items = node && typeof node === "object" ? node[cfg.list] : null;
+      if (!Array.isArray(items) || !items.length) continue;
+      var sec = el("div", "mgroup");
+      sec.appendChild(el("div", "sec-label", cfg.label));
+      var tbl = el("div", "qtbl");
+      for (var i = 0; i < items.length && i < 8; i++) {
+        var it = items[i];
+        if (!it || typeof it !== "object") continue;
+        tbl.appendChild(el("span", "qsym", collapseWs(it.symbol || it.name || it.ticker) || "—"));
+        var price = num(it.price);
+        tbl.appendChild(el("span", "qprice",
+          price == null ? "—" : price.toLocaleString(undefined, { maximumFractionDigits: 2 })));
+        var chg = num(it.changePercent);
+        var cell = el("span", "qchg", pctText(chg));
+        if (chg != null) cell.style.color = chg >= 0 ? cssVar("--up") : cssVar("--down");
+        tbl.appendChild(cell);
+      }
+      sec.appendChild(tbl);
+      host.appendChild(sec);
+      rendered++;
+    }
+    if (!rendered) host.appendChild(el("div", "empty", "No market data available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const MARKET_RADAR_APP_HTML = buildAppHtml({
+  title: 'Market Radar — WorldMonitor',
+  appName: 'worldmonitor-market-radar',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/registry.ts
+++ b/api/mcp/ui/registry.ts
@@ -19,49 +19,37 @@
 // OpenAI Apps SDK's marker).
 
 import { rpcError, rpcOk } from '../rpc';
+import { CHOKEPOINT_MONITOR_APP_HTML } from './chokepoint-monitor-app';
+import { COUNTRY_BRIEF_APP_HTML } from './country-brief-app';
 import { COUNTRY_RISK_APP_HTML } from './country-risk-app';
+import { MARKET_RADAR_APP_HTML } from './market-radar-app';
+import { buildUiMeta, UI_RESOURCE_MIME_TYPE as SHELL_UI_MIME_TYPE, type UiResourceMeta } from './shell';
+import { WORLD_BRIEF_APP_HTML } from './world-brief-app';
 
-export const UI_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
+// Re-exported from the shared shell so the mimeType has a single source of
+// truth across the fleet (the first widget defined it here in v1.11.0).
+export const UI_RESOURCE_MIME_TYPE = SHELL_UI_MIME_TYPE;
 
-// Canonical ui:// URI for the country-risk app shell. Imported by the
-// get_country_risk tool def as its single-source-of-truth `_uiResourceUri`,
-// so the tool linkage and the registered resource can never drift.
+// Canonical ui:// URIs for each app shell. Each is imported by its backing tool
+// def as the single-source-of-truth `_uiResourceUri`, so the tool linkage and
+// the registered resource can never drift.
 export const COUNTRY_RISK_UI_URI = 'ui://worldmonitor/country-risk.html';
+export const WORLD_BRIEF_UI_URI = 'ui://worldmonitor/world-brief.html';
+export const COUNTRY_BRIEF_UI_URI = 'ui://worldmonitor/country-brief.html';
+export const MARKET_RADAR_UI_URI = 'ui://worldmonitor/market-radar.html';
+export const CHOKEPOINT_MONITOR_UI_URI = 'ui://worldmonitor/chokepoint-monitor.html';
 
-// Per-resource `_meta.ui` (ext-apps `UIResourceMeta`). The `csp` block is the
-// spec-native complement to the HTML `<meta http-equiv>` CSP: it declares which
-// external origins the view needs so the HOST can enforce an iframe CSP. It is
-// kept CONSISTENT with the HTML meta: `connectDomains` mirrors the meta's
-// `connect-src` (the MCP server origin — the app's data ultimately originates
-// there); `resourceDomains` / `frameDomains` / `baseUriDomains` stay empty (the
-// secure default) because the app loads no external assets, embeds no frames,
-// and needs no external base URI (postMessage only, inline CSS/JS). `prefersBorder`
-// asks the host to frame the card. Surfaced on BOTH resources/list and the
-// resources/read response so a host learns the policy at discovery time.
-export interface UiResourceMeta {
-  ui: {
-    csp: {
-      connectDomains: string[];
-      resourceDomains: string[];
-      frameDomains: string[];
-      baseUriDomains: string[];
-    };
-    prefersBorder: boolean;
-  };
-}
-
-const COUNTRY_RISK_UI_META: UiResourceMeta = {
-  ui: {
-    csp: {
-      // Mirrors the HTML meta CSP's connect-src (the MCP server origin).
-      connectDomains: ['https://worldmonitor.app', 'https://www.worldmonitor.app'],
-      resourceDomains: [],
-      frameDomains: [],
-      baseUriDomains: [],
-    },
-    prefersBorder: true,
-  },
-};
+// Per-resource `_meta.ui` (ext-apps `UIResourceMeta`) is built by the shared
+// `buildUiMeta()` in ./shell — SINGLE source of truth for the fleet's CSP /
+// render policy. The `csp` block is the spec-native complement to the HTML
+// `<meta http-equiv>` CSP: `connectDomains` mirrors the meta's `connect-src`
+// (the MCP server origin); `resourceDomains` / `frameDomains` / `baseUriDomains`
+// stay empty (the secure default) because the apps load no external assets,
+// embed no frames, and need no external base URI (postMessage + inline CSS/JS
+// only). `prefersBorder` asks the host to frame the card. A fresh object is
+// minted per entry so a mutating consumer can't poison siblings. Surfaced on
+// BOTH resources/list and the resources/read response.
+export type { UiResourceMeta };
 
 interface UiResourceDef {
   uri: string;
@@ -80,8 +68,44 @@ export const UI_RESOURCE_REGISTRY: UiResourceDef[] = [
     description:
       'Interactive in-conversation app shell for get_country_risk: renders the Composite Instability Index (CII 0-100), the unrest/conflict/security/news component breakdown, travel-advisory level, and sanctions exposure. Linked from the get_country_risk tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
     mimeType: UI_RESOURCE_MIME_TYPE,
-    _meta: COUNTRY_RISK_UI_META,
+    _meta: buildUiMeta(),
     html: COUNTRY_RISK_APP_HTML,
+  },
+  {
+    uri: WORLD_BRIEF_UI_URI,
+    name: 'World Brief (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_world_brief: renders the AI-summarised global intelligence brief as readable paragraphs, the grounding headlines, and the source feed articles. Linked from the get_world_brief tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: WORLD_BRIEF_APP_HTML,
+  },
+  {
+    uri: COUNTRY_BRIEF_UI_URI,
+    name: 'Country Brief (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_country_brief: renders the AI-synthesised per-country intelligence brief as paragraphs, the analytical framework lens, and the grounding sources. Linked from the get_country_brief tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: COUNTRY_BRIEF_APP_HTML,
+  },
+  {
+    uri: MARKET_RADAR_UI_URI,
+    name: 'Market Radar (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_market_data: renders the Fear & Greed composite plus per-asset-class quote tables (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded change. Linked from the get_market_data tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: MARKET_RADAR_APP_HTML,
+  },
+  {
+    uri: CHOKEPOINT_MONITOR_UI_URI,
+    name: 'Chokepoint Monitor (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_chokepoint_status: renders per-chokepoint rolling transit summaries (today\'s transit count, week-over-week change, tanker split) with a risk-level badge. Linked from the get_chokepoint_status tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: CHOKEPOINT_MONITOR_APP_HTML,
   },
 ];
 

--- a/api/mcp/ui/shell.ts
+++ b/api/mcp/ui/shell.ts
@@ -213,7 +213,39 @@ const SHARED_BRIDGE_HEAD = `
     }
   }
 
+  // Soft-error envelopes are SUCCESSFUL tools/call results (HTTP 200, valid
+  // JSON) that carry an error sentinel instead of renderable data — the
+  // dispatcher returns { _budget_exceeded, ... } when the tool output exceeds
+  // its byte budget, and a bad jmespath projection returns { _jmespath_error,
+  // ... }. A few tools also surface user-input faults as a result-level
+  // { error: "..." } string. Rendering any of these through renderData() shows
+  // a blank / empty-success dashboard, so detect them and surface a visible
+  // message instead. Returns the message string, or null when data is genuinely
+  // renderable.
+  function softError(data) {
+    if (!data || typeof data !== "object") return null;
+    if (data._budget_exceeded === true) {
+      return "This response is too large to display here. Narrow the request (fewer items, or a jmespath projection) and try again.";
+    }
+    if (data._jmespath_error) {
+      return "The response projection could not be applied, so there is nothing to render. Remove the jmespath argument and retry.";
+    }
+    if (typeof data.error === "string" && data.error) return data.error;
+    return null;
+  }
+  // Every fleet widget owns an #empty placeholder and an #card body; on a soft
+  // error we reuse #empty as the error slot (hide the card) so the message is
+  // visible regardless of which widget is mounted.
+  function showError(msg) {
+    var card = q("card");
+    if (card) card.style.display = "none";
+    var empty = q("empty");
+    if (empty) { empty.textContent = msg; empty.style.display = "block"; }
+  }
+
   function safeRender(data) {
+    var errMsg = softError(data);
+    if (errMsg) { showError(errMsg); reportSize(); return; }
     try { renderData(data); } catch (e) { /* never break the host on a bad payload */ }
     reportSize();
   }

--- a/api/mcp/ui/shell.ts
+++ b/api/mcp/ui/shell.ts
@@ -251,7 +251,13 @@ const SHARED_BRIDGE_HEAD = `
   }
 `;
 
-const SHARED_BRIDGE_TAIL = `
+// The bridge tail interpolates the per-widget appInfo.name directly (no
+// placeholder sentinel), so a widget whose renderBody happens to contain the
+// old `__APP_NAME__` token can't leak it into the served HTML. `appName` is
+// JSON.stringified at the call site — it becomes a string literal in the
+// emitted JS.
+function renderBridgeTail(appName: string): string {
+  return `
   window.addEventListener("message", function (event) {
     if (event.source !== parentWin) return;
     var msg = event.data;
@@ -288,12 +294,13 @@ const SHARED_BRIDGE_TAIL = `
     method: "ui/initialize",
     params: {
       protocolVersion: "${UI_PROTOCOL_VERSION}",
-      appInfo: { name: __APP_NAME__, version: "1.0.0" },
+      appInfo: { name: ${JSON.stringify(appName)}, version: "1.0.0" },
       appCapabilities: {}
     }
   });
 })();
 `;
+}
 
 export interface AppShellSpec {
   // Page <title> and the app-shell identity reported in ui/initialize.appInfo.name.
@@ -317,7 +324,7 @@ export function buildAppHtml(spec: AppShellSpec): string {
   const bridge =
     SHARED_BRIDGE_HEAD +
     '\n  function renderData(data) {\n' + spec.renderBody + '\n  }\n' +
-    SHARED_BRIDGE_TAIL.replace('__APP_NAME__', JSON.stringify(spec.appName));
+    renderBridgeTail(spec.appName);
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/api/mcp/ui/shell.ts
+++ b/api/mcp/ui/shell.ts
@@ -1,0 +1,311 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// SHARED app-shell foundation for the WorldMonitor interactive-dashboard fleet.
+//
+// The first shipped widget (get_country_risk, v1.11.0) inlined its whole HTML —
+// DOCTYPE, CSP, dark-mode CSS vars, and the ~150-line postMessage bridge — in
+// api/mcp/ui/country-risk-app.ts. That file stays as the reference widget; this
+// module factors the parts that MUST be identical across every widget (the
+// bridge protocol, the 4-category CSP, uppercase DOCTYPE + color-scheme meta,
+// the dark-mode theme handling, and the size-reporting handshake) into one
+// `buildAppHtml` builder so the fleet can't drift on the orank quality/CSP
+// signals a scanner reads statically off each served shell.
+//
+// Bridge protocol (raw JSON-RPC 2.0 over `window.postMessage(msg, "*")`, no
+// envelope), per the extension — identical to the country-risk reference:
+//   View → Host  request : `ui/initialize` {appInfo, appCapabilities, protocolVersion}
+//   Host → View  result  : {hostCapabilities, hostInfo, hostContext}
+//   View → Host  notify  : `ui/notifications/initialized`
+//   Host → View  notify  : `ui/notifications/tool-input`  {arguments}
+//   Host → View  notify  : `ui/notifications/tool-result` (a CallToolResult)
+//   View → Host  notify  : `ui/notifications/size-changed` {height}
+//
+// Incoming messages are gated on `event.source === window.parent` — the sandbox
+// origin is opaque ("null"), so a source-identity check is the available trust
+// boundary. Rendering ALWAYS uses `textContent` / numeric coercion (never
+// innerHTML), so a hostile tool payload cannot inject markup.
+//
+// Authoring constraint: each widget's `styles`, `body`, and `renderBody` are
+// interpolated into the outer template below. The SHARED bridge carries no
+// `${` sequences; per-widget `renderBody` strings must likewise avoid backticks
+// and `${` so the outer TS template literal stays un-escaped.
+
+export const UI_PROTOCOL_VERSION = '2026-01-26';
+
+// The MCP-Apps UI resource mimeType is EXACTLY `text/html;profile=mcp-app` (the
+// extension's content profile) — NOT `text/html+skybridge` (OpenAI Apps SDK).
+export const UI_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
+
+// The MCP server origin(s) the views connect back to. Mirrored into BOTH the
+// HTML `<meta http-equiv>` CSP connect-src and the spec-native
+// `_meta.ui.csp.connectDomains` so a host learns the identical policy two ways.
+export const UI_CONNECT_DOMAINS = ['https://worldmonitor.app', 'https://www.worldmonitor.app'] as const;
+
+// The agent hosts allowed to embed a shell (advisory in a <meta> CSP — browsers
+// honor frame-ancestors only via HTTP header — but the static scanner reads it
+// here, and it documents intent).
+const UI_FRAME_ANCESTORS = ['https://chatgpt.com', 'https://claude.ai', 'https://claude.com'] as const;
+
+// Per-resource `_meta.ui` (ext-apps `UIResourceMeta`). `connectDomains` mirrors
+// the HTML meta's connect-src (the MCP server origin — the app's data ultimately
+// originates there); the other allowlists stay empty (the secure default) because
+// every widget loads no external assets, embeds no frames, and needs no external
+// base URI (postMessage + inline CSS/JS only). `prefersBorder` asks the host to
+// frame the card.
+export interface UiResourceMeta {
+  ui: {
+    csp: {
+      connectDomains: string[];
+      resourceDomains: string[];
+      frameDomains: string[];
+      baseUriDomains: string[];
+    };
+    prefersBorder: boolean;
+  };
+}
+
+// SINGLE source of truth for every widget's `_meta.ui` — shared so the fleet's
+// CSP policy can't drift entry-to-entry. Returns a fresh object per call so a
+// mutating consumer can't poison siblings.
+export function buildUiMeta(): UiResourceMeta {
+  return {
+    ui: {
+      csp: {
+        connectDomains: [...UI_CONNECT_DOMAINS],
+        resourceDomains: [],
+        frameDomains: [],
+        baseUriDomains: [],
+      },
+      prefersBorder: true,
+    },
+  };
+}
+
+// The 4-category CSP shared by every shell. default-src 'none' earns full orank
+// credit over a permissive default; script/style-src 'unsafe-inline' keeps the
+// inline bridge + styles working; connect-src pins the MCP origin; frame-ancestors
+// allowlists the embedding agent hosts; form-action + base-uri are locked.
+const SHARED_CSP =
+  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; " +
+  "img-src 'self' data:; connect-src 'self' " + UI_CONNECT_DOMAINS.join(' ') + '; ' +
+  'frame-ancestors ' + UI_FRAME_ANCESTORS.join(' ') + "; form-action 'none'; base-uri 'none'";
+
+// The shared dark-mode design tokens every widget inherits. A widget's own
+// `styles` block is appended AFTER these, so it can add component styles and
+// override any token.
+const SHARED_STYLE_TOKENS = `
+  :root {
+    --bg: #ffffff; --fg: #0f172a; --muted: #64748b; --card: #f8fafc;
+    --border: #e2e8f0; --accent: #2563eb;
+    --low: #16a34a; --moderate: #ca8a04; --high: #ea580c; --severe: #dc2626;
+    --up: #16a34a; --down: #dc2626;
+  }
+  [data-theme="dark"] {
+    --bg: #0b1220; --fg: #e5e7eb; --muted: #94a3b8; --card: #131c2e;
+    --border: #1e293b; --accent: #60a5fa;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+  .wrap { padding: 16px; max-width: 560px; }
+  .head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+  .title { font-size: 20px; font-weight: 650; letter-spacing: 0.2px; }
+  .badge { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+  .empty { color: var(--muted); padding: 8px 0; }
+  .foot { margin-top: 14px; font-size: 11px; color: var(--muted); }
+  a { color: var(--accent); text-decoration: none; }
+`;
+
+// The shared bridge + helper library. Injected once per shell. It exposes a
+// small helper set (q/num/clampPct/pctText/setText/el/cssVar) in closure scope
+// that a widget's `renderBody` uses, then calls the widget-defined
+// `renderData(data)` on every tool-result. NOTE: no `${` / backtick here.
+const SHARED_BRIDGE_HEAD = `
+(function () {
+  "use strict";
+  var parentWin = window.parent;
+
+  function post(msg) {
+    try { parentWin.postMessage(msg, "*"); } catch (e) { /* host gone */ }
+  }
+  function notify(method, params) {
+    post({ jsonrpc: "2.0", method: method, params: params || {} });
+  }
+
+  // ---- shared render helpers (widget renderBody uses these) ----
+  function q(id) { return document.getElementById(id); }
+  function num(v) { var n = typeof v === "number" ? v : Number(v); return isFinite(n) ? n : null; }
+  function clampPct(n) { return Math.max(0, Math.min(100, n)); }
+  function setText(id, text) { var e = q(id); if (e) e.textContent = text == null ? "—" : String(text); }
+  function el(tag, cls, text) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = String(text);
+    return e;
+  }
+  function cssVar(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+  function pctText(v) {
+    var n = num(v);
+    if (n == null) return "—";
+    return (n > 0 ? "+" : "") + n.toFixed(2) + "%";
+  }
+  function levelFor(score) {
+    if (typeof score !== "number" || isNaN(score)) return { label: "Unknown", varName: "--muted" };
+    if (score >= 75) return { label: "Severe", varName: "--severe" };
+    if (score >= 50) return { label: "High", varName: "--high" };
+    if (score >= 25) return { label: "Moderate", varName: "--moderate" };
+    return { label: "Low", varName: "--low" };
+  }
+  // Text helpers centralised here so widget renderBody stays regex/escape-free.
+  function collapseWs(s) { return String(s == null ? "" : s).replace(/\\s+/g, " ").trim(); }
+  function paragraphs(s) {
+    return String(s == null ? "" : s)
+      .split(/\\n\\s*\\n/)
+      .map(function (p) { return collapseWs(p); })
+      .filter(Boolean);
+  }
+  function httpUrl(u) {
+    if (typeof u !== "string") return "";
+    try {
+      var parsed = new URL(u.trim());
+      return (parsed.protocol === "http:" || parsed.protocol === "https:") ? parsed.href : "";
+    } catch (e) { return ""; }
+  }
+  function countryName(code) {
+    var c = String(code == null ? "" : code).toUpperCase().slice(0, 2);
+    if (!c) return "";
+    try {
+      var n = new Intl.DisplayNames(["en"], { type: "region" }).of(c);
+      return n || c;
+    } catch (e) { return c; }
+  }
+
+  function reportSize() {
+    var root = q("root");
+    if (!root) return;
+    var h = Math.ceil(root.getBoundingClientRect().height) + 8;
+    notify("ui/notifications/size-changed", { height: h });
+  }
+
+  function extractToolData(result) {
+    if (!result || typeof result !== "object") return null;
+    if (result.structuredContent && typeof result.structuredContent === "object") {
+      return result.structuredContent;
+    }
+    if (Array.isArray(result.content)) {
+      for (var i = 0; i < result.content.length; i++) {
+        var c = result.content[i];
+        if (c && c.type === "text" && typeof c.text === "string") {
+          try { return JSON.parse(c.text); } catch (e) { /* not JSON */ }
+        }
+      }
+    }
+    return null;
+  }
+
+  function applyTheme(hostContext) {
+    var theme = hostContext && hostContext.theme;
+    if (theme === "dark" || theme === "light") {
+      document.documentElement.setAttribute("data-theme", theme);
+    } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      document.documentElement.setAttribute("data-theme", "dark");
+    }
+  }
+
+  function safeRender(data) {
+    try { renderData(data); } catch (e) { /* never break the host on a bad payload */ }
+    reportSize();
+  }
+`;
+
+const SHARED_BRIDGE_TAIL = `
+  window.addEventListener("message", function (event) {
+    if (event.source !== parentWin) return;
+    var msg = event.data;
+    if (!msg || typeof msg !== "object" || msg.jsonrpc !== "2.0") return;
+
+    if (msg.id === 1 && msg.result) {
+      applyTheme(msg.result.hostContext);
+      notify("ui/notifications/initialized", {});
+      reportSize();
+      return;
+    }
+
+    switch (msg.method) {
+      case "ui/notifications/tool-result": {
+        var data = extractToolData(msg.params && msg.params.result ? msg.params.result : msg.params);
+        if (data) safeRender(data);
+        break;
+      }
+      case "ui/notifications/tool-input":
+        break;
+      case "ui/notifications/host-context-changed":
+        applyTheme(msg.params && msg.params.hostContext ? msg.params.hostContext : msg.params);
+        break;
+      default:
+        break;
+    }
+  });
+
+  applyTheme(null);
+
+  post({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "ui/initialize",
+    params: {
+      protocolVersion: "${UI_PROTOCOL_VERSION}",
+      appInfo: { name: __APP_NAME__, version: "1.0.0" },
+      appCapabilities: {}
+    }
+  });
+})();
+`;
+
+export interface AppShellSpec {
+  // Page <title> and the app-shell identity reported in ui/initialize.appInfo.name.
+  title: string;
+  appName: string;
+  // Component CSS appended after the shared design tokens.
+  styles: string;
+  // Body markup placed inside <div class="wrap" id="root">. Owns its own
+  // empty-state + card elements.
+  body: string;
+  // JS body of `function renderData(data) { ... }`. Runs inside the shared
+  // bridge closure with access to q/num/setText/el/cssVar/pctText/clampPct/
+  // levelFor. MUST avoid backticks and `${`.
+  renderBody: string;
+}
+
+// Assemble a complete, self-contained MCP-Apps shell. Every widget goes through
+// here so DOCTYPE, color-scheme, CSP, theme handling, and the bridge stay
+// byte-consistent across the fleet.
+export function buildAppHtml(spec: AppShellSpec): string {
+  const bridge =
+    SHARED_BRIDGE_HEAD +
+    '\n  function renderData(data) {\n' + spec.renderBody + '\n  }\n' +
+    SHARED_BRIDGE_TAIL.replace('__APP_NAME__', JSON.stringify(spec.appName));
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- MCP Apps view quality: uppercase DOCTYPE + color-scheme so the host renders
+     light/dark correctly (orank mcp-apps-ui-quality + mcp-view-domain checks). -->
+<meta name="color-scheme" content="light dark">
+<!-- MCP Apps view CSP (orank mcp-view-csp): all 4 required directive categories
+     scoped. Shared across the widget fleet via api/mcp/ui/shell.ts. -->
+<meta http-equiv="Content-Security-Policy" content="${SHARED_CSP}">
+<title>${spec.title}</title>
+<style>${SHARED_STYLE_TOKENS}${spec.styles}</style>
+</head>
+<body>
+<div class="wrap" id="root">
+${spec.body}
+</div>
+<script>${bridge}</script>
+</body>
+</html>`;
+}

--- a/api/mcp/ui/world-brief-app.ts
+++ b/api/mcp/ui/world-brief-app.ts
@@ -1,0 +1,114 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_world_brief` tool: the flagship reader of
+// the fleet. Renders the LLM-summarised geopolitical brief as paragraphs, the
+// grounding headlines, and the source feed articles. Built on the shared
+// api/mcp/ui/shell.ts foundation (DOCTYPE / CSP / dark-mode / bridge), so the
+// only per-widget code is the layout + render mapping below.
+//
+// Tool result shape (RPC tool — content[0].text JSON):
+//   { brief|summary: string, headlines: string[],
+//     sources: [{ title, url, source, publishedAt }], provider, model, generatedAt }
+//
+// Rendering uses textContent / element construction only (never innerHTML), so
+// a hostile brief/headline/source payload cannot inject markup. renderBody must
+// avoid backticks and `${` (it is interpolated into shell.ts's outer literal),
+// and stays regex/escape-free by delegating text handling to the shared helpers
+// (paragraphs / collapseWs / httpUrl).
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .brief { margin: 14px 0 4px; }
+  .brief .para { margin: 0 0 10px; font-size: 14px; line-height: 1.6; }
+  .section { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border); }
+  .sec-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin-bottom: 8px; }
+  ul.headlines { margin: 0; padding-left: 18px; }
+  ul.headlines li { margin: 4px 0; font-size: 13px; }
+  .src-row { display: flex; flex-direction: column; gap: 1px; padding: 6px 0; border-bottom: 1px solid var(--border); }
+  .src-row:last-child { border-bottom: none; }
+  .src-name { font-size: 11px; color: var(--accent); font-weight: 600; }
+  .src-title { font-size: 12px; color: var(--fg); }
+  .src-date { font-size: 11px; color: var(--muted); }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title" id="title">World Brief</div>
+    <div class="badge">WorldMonitor Intelligence</div>
+  </div>
+  <div class="empty" id="empty">Waiting for world-brief data…</div>
+  <div id="card" style="display:none">
+    <div class="brief" id="brief"></div>
+    <div class="section" id="hl-sec" style="display:none">
+      <div class="sec-label">Grounding headlines</div>
+      <ul class="headlines" id="headlines"></ul>
+    </div>
+    <div class="section" id="src-sec" style="display:none">
+      <div class="sec-label">Sources</div>
+      <div class="sources" id="sources"></div>
+    </div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var brief = typeof data.brief === "string" && data.brief ? data.brief
+      : (typeof data.summary === "string" ? data.summary : "");
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var briefEl = q("brief");
+    briefEl.textContent = "";
+    var paras = paragraphs(brief);
+    for (var i = 0; i < paras.length; i++) briefEl.appendChild(el("p", "para", paras[i]));
+    if (!briefEl.childNodes.length) briefEl.appendChild(el("div", "empty", "No brief text available."));
+
+    var hls = Array.isArray(data.headlines) ? data.headlines : [];
+    var hlHost = q("headlines");
+    hlHost.textContent = "";
+    for (var j = 0; j < hls.length && hlHost.childNodes.length < 12; j++) {
+      var h = hls[j];
+      if (typeof h !== "string" || !h) continue;
+      hlHost.appendChild(el("li", null, collapseWs(h)));
+    }
+    q("hl-sec").style.display = hlHost.childNodes.length ? "block" : "none";
+
+    var srcs = Array.isArray(data.sources) ? data.sources : [];
+    var srcHost = q("sources");
+    srcHost.textContent = "";
+    for (var k = 0; k < srcs.length && srcHost.childNodes.length < 8; k++) {
+      var s = srcs[k];
+      if (!s || typeof s !== "object") continue;
+      var row = el("div", "src-row");
+      row.appendChild(el("span", "src-name", collapseWs(s.source) || "source"));
+      var url = httpUrl(s.url);
+      if (s.title) {
+        var titleText = collapseWs(s.title);
+        if (url) {
+          var a = el("a", "src-title", titleText);
+          a.href = url;
+          a.target = "_blank";
+          a.rel = "noopener noreferrer";
+          row.appendChild(a);
+        } else {
+          row.appendChild(el("span", "src-title", titleText));
+        }
+      }
+      if (s.publishedAt) row.appendChild(el("span", "src-date", collapseWs(s.publishedAt)));
+      srcHost.appendChild(row);
+    }
+    q("src-sec").style.display = srcHost.childNodes.length ? "block" : "none";
+
+    var prov = [data.provider, data.model].filter(Boolean).map(collapseWs).filter(Boolean).join(" · ");
+    var gen = data.generatedAt != null ? "Generated " + collapseWs(data.generatedAt) : "";
+    q("foot").textContent = [prov, gen].filter(Boolean).join(" · ");
+`;
+
+export const WORLD_BRIEF_APP_HTML = buildAppHtml({
+  title: 'World Brief — WorldMonitor',
+  appName: 'worldmonitor-world-brief',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -193,6 +193,7 @@
               "cli",
               "sdks",
               "mcp-overview",
+              "mcp-apps",
               "mcp-tools-reference",
               "mcp-jmespath",
               "mcp-error-catalog",

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -84,5 +84,98 @@
   },
   "leaderNames": 16,
   "populationPriorityCountries": 20,
-  "sebufVersion": "v0.11.1"
+  "sebufVersion": "v0.11.1",
+  "mcpToolCount": 40,
+  "mcpApps": {
+    "specVersion": "2026-01-26",
+    "mimeType": "text/html;profile=mcp-app",
+    "apps": [
+      {
+        "uriConst": "COUNTRY_RISK_UI_URI",
+        "uri": "ui://worldmonitor/country-risk.html",
+        "name": "Country Risk (interactive)",
+        "description": "Interactive in-conversation app shell for get_country_risk: renders the Composite Instability Index (CII 0-100), the unrest/conflict/security/news component breakdown, travel-advisory level, and sanctions exposure. Linked from the get_country_risk tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_country_risk"
+      },
+      {
+        "uriConst": "WORLD_BRIEF_UI_URI",
+        "uri": "ui://worldmonitor/world-brief.html",
+        "name": "World Brief (interactive)",
+        "description": "Interactive in-conversation app shell for get_world_brief: renders the AI-summarised global intelligence brief as readable paragraphs, the grounding headlines, and the source feed articles. Linked from the get_world_brief tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_world_brief"
+      },
+      {
+        "uriConst": "COUNTRY_BRIEF_UI_URI",
+        "uri": "ui://worldmonitor/country-brief.html",
+        "name": "Country Brief (interactive)",
+        "description": "Interactive in-conversation app shell for get_country_brief: renders the AI-synthesised per-country intelligence brief as paragraphs, the analytical framework lens, and the grounding sources. Linked from the get_country_brief tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_country_brief"
+      },
+      {
+        "uriConst": "MARKET_RADAR_UI_URI",
+        "uri": "ui://worldmonitor/market-radar.html",
+        "name": "Market Radar (interactive)",
+        "description": "Interactive in-conversation app shell for get_market_data: renders the Fear & Greed composite plus per-asset-class quote tables (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded change. Linked from the get_market_data tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_market_data"
+      },
+      {
+        "uriConst": "CHOKEPOINT_MONITOR_UI_URI",
+        "uri": "ui://worldmonitor/chokepoint-monitor.html",
+        "name": "Chokepoint Monitor (interactive)",
+        "description": "Interactive in-conversation app shell for get_chokepoint_status: renders per-chokepoint rolling transit summaries (today's transit count, week-over-week change, tanker split) with a risk-level badge. Linked from the get_chokepoint_status tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_chokepoint_status"
+      }
+    ],
+    "uiResources": [
+      "ui://worldmonitor/country-risk.html",
+      "ui://worldmonitor/world-brief.html",
+      "ui://worldmonitor/country-brief.html",
+      "ui://worldmonitor/market-radar.html",
+      "ui://worldmonitor/chokepoint-monitor.html"
+    ],
+    "linkedTools": [
+      "get_country_risk",
+      "get_world_brief",
+      "get_country_brief",
+      "get_market_data",
+      "get_chokepoint_status"
+    ],
+    "toolLinks": [
+      {
+        "tool": "get_country_risk",
+        "uri": "ui://worldmonitor/country-risk.html"
+      },
+      {
+        "tool": "get_world_brief",
+        "uri": "ui://worldmonitor/world-brief.html"
+      },
+      {
+        "tool": "get_country_brief",
+        "uri": "ui://worldmonitor/country-brief.html"
+      },
+      {
+        "tool": "get_market_data",
+        "uri": "ui://worldmonitor/market-radar.html"
+      },
+      {
+        "tool": "get_chokepoint_status",
+        "uri": "ui://worldmonitor/chokepoint-monitor.html"
+      }
+    ]
+  },
+  "mcpAppCount": 5,
+  "mcpAppUiResources": [
+    "ui://worldmonitor/country-risk.html",
+    "ui://worldmonitor/world-brief.html",
+    "ui://worldmonitor/country-brief.html",
+    "ui://worldmonitor/market-radar.html",
+    "ui://worldmonitor/chokepoint-monitor.html"
+  ],
+  "mcpAppLinkedTools": [
+    "get_country_risk",
+    "get_world_brief",
+    "get_country_brief",
+    "get_market_data",
+    "get_chokepoint_status"
+  ]
 }

--- a/docs/mcp-apps.mdx
+++ b/docs/mcp-apps.mdx
@@ -1,0 +1,113 @@
+---
+title: "MCP Apps"
+description: "Complete contract for WorldMonitor's MCP Apps interactive ui:// resources, tool links, host flow, security posture, and drift checks."
+---
+
+WorldMonitor supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) through the `io.modelcontextprotocol/ui` extension. The current fleet ships 5 MCP Apps: self-contained `ui://` HTML resources that an MCP Apps host can render inline after a linked tool call.
+
+This page is the source-of-truth guide for the interactive surface. Use it with the [MCP Server overview](/mcp-overview) for auth, quota, transport, and general JSON-RPC behavior.
+
+## Contract
+
+| Field | Value |
+|---|---|
+| Extension | `io.modelcontextprotocol/ui` |
+| Spec version | `2026-01-26` |
+| UI resource MIME type | `text/html;profile=mcp-app` |
+| Transport endpoint | `https://worldmonitor.app/mcp` |
+| UI resource scheme | `ui://worldmonitor/...` |
+| Data path | normal gated `tools/call`, then host `postMessage` into the iframe |
+| Template path | `resources/read` of `ui://...`, public and quota-exempt |
+
+Three discovery signals must stay aligned:
+
+| Signal | Where it appears | Purpose |
+|---|---|---|
+| `initialize.result.capabilities.extensions["io.modelcontextprotocol/ui"]` | `initialize` response | Negotiates MCP Apps support with the host. |
+| `_meta.ui.resourceUri` and `_meta["ui/resourceUri"]` | `tools/list` / `describe_tool` entries for linked tools | Tells the host which app shell should render a tool result. |
+| `ui://...` resources with `_meta.ui.csp` | `resources/list` and `resources/read` | Lets the host discover and fetch the static HTML template plus view policy. |
+
+## Fleet
+
+| UI resource URI | Linked tool | App | Renders |
+|---|---|---|---|
+| `ui://worldmonitor/country-risk.html` | `get_country_risk` | Country Risk (interactive) | Composite Instability Index score, component breakdown, travel advisory, and sanctions exposure. |
+| `ui://worldmonitor/world-brief.html` | `get_world_brief` | World Brief (interactive) | AI-summarised global brief, grounding headlines, and source feed articles. |
+| `ui://worldmonitor/country-brief.html` | `get_country_brief` | Country Brief (interactive) | Per-country intelligence brief, analytical framework lens, and grounding sources. |
+| `ui://worldmonitor/market-radar.html` | `get_market_data` | Market Radar (interactive) | Fear & Greed composite plus equity, commodity, crypto, Gulf, sector, and ETF-flow quote tables. |
+| `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Chokepoint Monitor (interactive) | Per-chokepoint transit summaries, week-over-week change, tanker split, and risk-level badge. |
+
+## Runtime Flow
+
+1. The host calls `initialize` on `https://worldmonitor.app/mcp`.
+2. WorldMonitor returns the normal MCP capabilities plus `capabilities.extensions["io.modelcontextprotocol/ui"]`.
+3. The host calls `tools/list`. UI-linked tools carry `_meta.ui.resourceUri` and the deprecated flat `_meta["ui/resourceUri"]` alias.
+4. The host calls `resources/list` and sees the `ui://` app resources. Each UI entry includes `mimeType: text/html;profile=mcp-app` and `_meta.ui.csp`.
+5. The host calls `resources/read` for the chosen `ui://` URI. This read is public and quota-exempt because it returns only a static, data-free template.
+6. The host performs the normal authenticated `tools/call` for the linked tool. This is the only step that fetches live data and consumes any applicable quota.
+7. The host embeds the returned HTML in a sandboxed iframe and exchanges MCP Apps messages:
+
+```text
+View -> Host: ui/initialize
+Host -> View: initialize result with hostContext
+View -> Host: ui/notifications/initialized
+Host -> View: ui/notifications/tool-result
+View -> Host: ui/notifications/size-changed
+```
+
+The view never fetches live WorldMonitor data itself. Live data always reaches the app through the host after a normal tool call.
+
+## Resource Reads And Quota
+
+`resources/list` exposes concrete public resources, including all `ui://` templates. `resources/templates/list` exposes parameterised data resources.
+
+| Read kind | Example | Auth | Pro daily quota | Why |
+|---|---|---|---|---|
+| UI template | `resources/read` `ui://worldmonitor/market-radar.html` | No | No | Static HTML shell, no data and no upstream fetch. |
+| Public metadata | `resources/read` `worldmonitor://seed-meta/freshness` | No | No | Metadata-only health/freshness probe. |
+| Data template instantiation | `resources/read` `worldmonitor://countries/de/risk` | Yes | Yes | Routes through the same dispatcher as the equivalent `tools/call`. |
+| Tool data | `tools/call` `get_market_data` | Yes | Yes for OAuth/Pro contexts | Fetches live or cached data. |
+
+All methods still count toward the 60/minute per-key, per-user, or anonymous-IP rate limiter.
+
+## View Security
+
+The app shells are deliberately static and narrow:
+
+- They are self-contained HTML: no external scripts, styles, images, iframes, fonts, or network fetches.
+- Rendering uses DOM construction and `textContent`, never `innerHTML`.
+- Links are admitted only through `http:` or `https:` URL parsing and are rendered with `rel="noopener noreferrer"`.
+- The shared shell reports size after initialization and after every render so hosts can resize the iframe.
+- Soft-error envelopes (`_budget_exceeded`, `_jmespath_error`, and top-level string `error`) render as visible error messages instead of blank success states.
+- The HTML includes a meta CSP with `default-src 'none'`, scoped inline script/style allowances, locked `form-action` and `base-uri`, and a connect-src mirror of the `_meta.ui.csp.connectDomains` policy.
+
+Important limitation: `frame-ancestors` inside a meta CSP is advisory only. Browsers enforce `frame-ancestors` only from an HTTP `Content-Security-Policy` response header. The meta directive remains in the shell for static scanners and intent documentation; do not treat it as browser-level clickjacking protection.
+
+## Adding A New MCP App
+
+1. Add the self-contained app shell under `api/mcp/ui/*-app.ts`.
+2. Reuse `buildAppHtml()` from `api/mcp/ui/shell.ts` unless there is a protocol reason not to.
+3. Add a canonical `*_UI_URI` constant and registry entry in `api/mcp/ui/registry.ts`.
+4. Set `_uiResourceUri` on exactly one backing tool in `api/mcp/registry/rpc-tools.ts` or `api/mcp/registry/cache-tools.ts`.
+5. Update `docs/mcp-apps.mdx`, the short [MCP overview](/mcp-overview#mcp-apps-interactive-ui), and `public/.well-known/mcp/server-card.json`.
+6. Run `npm run docs:stats` to refresh `docs/generated/stats.json`.
+7. Run `npm run docs:check` and the focused MCP resource/tool tests.
+
+The docs-stat gate derives the app inventory from `api/mcp/ui/registry.ts` and the tool registries. It fails when:
+
+- `docs/mcp-apps.mdx`, `docs/mcp-overview.mdx`, or `public/mcp-server.md` omits a linked tool or `ui://` URI.
+- `public/.well-known/mcp/server-card.json.metadata.mcpApps` drifts from the code-derived app list, spec version, or MIME type.
+- `docs/docs.json` drops this page from navigation.
+- The documented MCP tool count drifts from the server-card tool inventory.
+
+## Source Files
+
+| Source | Owns |
+|---|---|
+| `api/mcp/ui/shell.ts` | Shared HTML builder, protocol bridge, MIME type, spec version, CSP, theme, soft-error handling. |
+| `api/mcp/ui/registry.ts` | Canonical `ui://` resource inventory and `resources/read` response builder. |
+| `api/mcp/registry/rpc-tools.ts` | UI links for RPC-backed tools such as `get_world_brief`, `get_country_brief`, and `get_country_risk`. |
+| `api/mcp/registry/cache-tools.ts` | UI links for cache-backed tools such as `get_market_data` and `get_chokepoint_status`. |
+| `api/mcp/handler.ts` | Public `ui://` read promotion, `resources/list`, `resources/read`, and `initialize` capability advertisement. |
+| `public/.well-known/mcp/server-card.json` | Static pre-connection discovery metadata for scanners and agents. |
+| `scripts/docs-stats.mjs` | Drift guard for docs, server-card metadata, navigation, and app inventory. |

--- a/docs/mcp-apps.mdx
+++ b/docs/mcp-apps.mdx
@@ -34,7 +34,7 @@ Three discovery signals must stay aligned:
 | `ui://worldmonitor/country-risk.html` | `get_country_risk` | Country Risk (interactive) | Composite Instability Index score, component breakdown, travel advisory, and sanctions exposure. |
 | `ui://worldmonitor/world-brief.html` | `get_world_brief` | World Brief (interactive) | AI-summarised global brief, grounding headlines, and source feed articles. |
 | `ui://worldmonitor/country-brief.html` | `get_country_brief` | Country Brief (interactive) | Per-country intelligence brief, analytical framework lens, and grounding sources. |
-| `ui://worldmonitor/market-radar.html` | `get_market_data` | Market Radar (interactive) | Fear & Greed composite plus equity, commodity, crypto, Gulf, sector, and ETF-flow quote tables. |
+| `ui://worldmonitor/market-radar.html` | `get_market_data` | Market Radar (interactive) | Fear & Greed composite plus equity, commodity, crypto, Gulf, and sector quote tables with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Chokepoint Monitor (interactive) | Per-chokepoint transit summaries, week-over-week change, tanker split, and risk-level badge. |
 
 ## Runtime Flow

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -401,6 +401,8 @@ All UI resources share `mimeType: text/html;profile=mcp-app`.
 
 `resources/read` on a `ui://` URI returns the self-contained HTML view. Unlike the data resources, a `ui://` read is **public and quota-exempt** — the template carries no data and spends no upstream call, so a host can preload it (and an agent-readiness scanner can fetch it) without credentials and without touching the Pro daily cap. The view is fully self-contained (no external assets) and communicates with the host over the standard MCP Apps `postMessage` bridge (`ui/initialize` → `ui/notifications/tool-result` → `ui/notifications/size-changed`).
 
+For the full MCP Apps contract — host flow, security posture, per-widget inventory, source files, and docs-stat drift checks — see [MCP Apps](/mcp-apps).
+
 ## JSON-RPC example
 
 Server-side with a direct API key — send it as `X-WorldMonitor-Key`, **not** as a bearer token.

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -28,7 +28,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
 | `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
-Server identifier: `worldmonitor` v1.13.0.
+Server identifier: `worldmonitor` v1.14.0.
 
 Registry listings: the server is published in the [official MCP registry](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) as `app.worldmonitor/mcp` — a domain-verified namespace, so clients that resolve servers through the registry get the same endpoint and metadata as the server card above — and listed on [Smithery](https://smithery.ai/servers/worldmonitor/wm-mcp) and [mcp.so](https://mcp.so/server/world-monitor).
 
@@ -386,12 +386,18 @@ Resources come in two tiers. **Concrete resources** are surfaced by `resources/l
 The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) (extension `io.modelcontextprotocol/ui`, spec `2026-01-26`) — interactive views a host renders in a sandboxed iframe when a linked tool is called. Three wire signals drive it:
 
 - **`initialize`** declares support in the handshake. The response's `capabilities.extensions` names the extension: `{"io.modelcontextprotocol/ui": {}}`. This is the negotiation signal a host (or agent-readiness scanner) reads to classify the endpoint as an MCP-App surface — the `tools/list` and `resources/list` entries below are the content it then renders.
-- **`tools/list`** advertises the linkage on the tool. `get_country_risk` carries `_meta.ui.resourceUri` (and the deprecated flat `ui/resourceUri` alias) pointing at its UI resource.
-- **`resources/list`** surfaces the UI resource itself, alongside the concrete data resource (the parameterised data templates live in `resources/templates/list`):
+- **`tools/list`** advertises the linkage on the tool. Each UI-linked tool carries `_meta.ui.resourceUri` (and the deprecated flat `ui/resourceUri` alias) pointing at its UI resource.
+- **`resources/list`** surfaces the UI resources themselves, alongside the concrete data resource (the parameterised data templates live in `resources/templates/list`):
 
-| UI resource URI | mimeType | Renders |
-|-----------------|----------|---------|
-| `ui://worldmonitor/country-risk.html` | `text/html;profile=mcp-app` | The `get_country_risk` result as an interactive card: CII score, unrest/conflict/security/news component breakdown, travel-advisory level, and OFAC sanctions exposure. |
+| UI resource URI | Linked tool | Renders |
+|-----------------|-------------|---------|
+| `ui://worldmonitor/country-risk.html` | `get_country_risk` | CII score, unrest/conflict/security/news component breakdown, travel-advisory level, and OFAC sanctions exposure. |
+| `ui://worldmonitor/world-brief.html` | `get_world_brief` | The AI-summarised global intelligence brief as readable paragraphs, plus grounding headlines and source articles. |
+| `ui://worldmonitor/country-brief.html` | `get_country_brief` | The AI-synthesised per-country brief as paragraphs, with the analytical framework lens and grounding sources. |
+| `ui://worldmonitor/market-radar.html` | `get_market_data` | The Fear & Greed composite plus per-asset-class quote tables (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded change. |
+| `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Per-chokepoint rolling transit summaries (today's count, week-over-week change, tanker split) with a risk-level badge. |
+
+All UI resources share `mimeType: text/html;profile=mcp-app`.
 
 `resources/read` on a `ui://` URI returns the self-contained HTML view. Unlike the data resources, a `ui://` read is **public and quota-exempt** — the template carries no data and spends no upstream call, so a host can preload it (and an agent-readiness scanner can fetch it) without credentials and without touching the Pro daily cap. The view is fully self-contained (no external assets) and communicates with the host over the standard MCP Apps `postMessage` bridge (`ui/initialize` → `ui/notifications/tool-result` → `ui/notifications/size-changed`).
 

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -3,7 +3,7 @@ title: "MCP Quickstart"
 description: "Connect Claude Desktop to WorldMonitor and make your first real intelligence call in five minutes."
 ---
 
-WorldMonitor exposes 39 live tools — markets, conflict events, maritime chokepoints, aviation, climate, AI briefs — over the [Model Context Protocol](https://modelcontextprotocol.io). This page is the shortest path from zero to a useful response inside Claude. Everything else in the [MCP Server reference](/mcp-overview) is optional reading once this works.
+WorldMonitor exposes 40 live tools — markets, conflict events, maritime chokepoints, aviation, climate, AI briefs — over the [Model Context Protocol](https://modelcontextprotocol.io). This page is the shortest path from zero to a useful response inside Claude. Everything else in the [MCP Server reference](/mcp-overview) is optional reading once this works.
 
 ## 1. Pick a tier and grab credentials
 
@@ -127,7 +127,7 @@ Full per-tool parameters, freshness budgets, and `curl` examples are in the [MCP
 The MCP handshake is invisible from the chat side, but here's the sequence so you know where to look if something breaks:
 
 1. Claude Desktop reads `claude_desktop_config.json`, sees the WorldMonitor server, and on first use POSTs `initialize` to `https://worldmonitor.app/mcp`. The server responds with its capabilities, the negotiated protocol version (default `2025-06-18`, matching the static server card; clients pinned to `2025-03-26` still get `2025-03-26`), and a session-level `instructions` string that tells the model about the universal `jmespath` argument. Clients that advertise `text/event-stream` may receive this response as SSE with a resumable `Mcp-Session-Id` / `Last-Event-ID` cursor; clients that do not advertise SSE receive JSON. See [protocol negotiation](/mcp-overview#protocol-negotiation) and [Streamable HTTP responses](/mcp-overview#streamable-http-responses) for the rollout details.
-2. Claude Desktop calls `tools/list` and receives 39 compressed tool descriptions (`≤120` bytes per tool). The compressed form keeps `tools/list` cheap; `describe_tool` returns the full definition on demand.
+2. Claude Desktop calls `tools/list` and receives 40 compressed tool descriptions (`≤120` bytes per tool). The compressed form keeps `tools/list` cheap; `describe_tool` returns the full definition on demand.
 3. When you ask a question that needs live data, Claude picks a tool, calls `tools/call`, and inlines the response into its reply. Cache tools return in under a second; LLM-backed tools (`get_world_brief`, `analyze_situation`, etc.) take 1–4 s.
 
 ## Server-side curl

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -3,12 +3,12 @@
   "kind": "product",
   "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
   "icon": "https://www.worldmonitor.app/favico/apple-touch-icon.png",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "url": "https://worldmonitor.app/mcp",
   "serverUrl": "https://worldmonitor.app/mcp",
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
@@ -252,8 +252,14 @@
       "extension": "io.modelcontextprotocol/ui",
       "specVersion": "2026-01-26",
       "uiResourceMimeType": "text/html;profile=mcp-app",
-      "uiResources": ["ui://worldmonitor/country-risk.html"],
-      "note": "MCP Apps support: tools with an interactive surface carry `_meta.ui.resourceUri` (get_country_risk → ui://worldmonitor/country-risk.html). Issue `resources/list` to enumerate ui:// app shells and `resources/read` to fetch them — ui:// reads are public + quota-exempt (static, data-free templates); live data reaches the shell via host postMessage after a normal tools/call."
+      "uiResources": [
+        "ui://worldmonitor/country-risk.html",
+        "ui://worldmonitor/world-brief.html",
+        "ui://worldmonitor/country-brief.html",
+        "ui://worldmonitor/market-radar.html",
+        "ui://worldmonitor/chokepoint-monitor.html"
+      ],
+      "note": "MCP Apps support: tools with an interactive surface carry `_meta.ui.resourceUri` (get_country_risk → country-risk.html, get_world_brief → world-brief.html, get_country_brief → country-brief.html, get_market_data → market-radar.html, get_chokepoint_status → chokepoint-monitor.html). Issue `resources/list` to enumerate ui:// app shells and `resources/read` to fetch them — ui:// reads are public + quota-exempt (static, data-free templates); live data reaches the shell via host postMessage after a normal tools/call."
     }
   },
   "features": {

--- a/public/mcp-server.md
+++ b/public/mcp-server.md
@@ -12,7 +12,19 @@ The World Monitor MCP Server exposes World Monitor's real-time global-intelligen
 
 ## Tools
 
-The server ships **39 tools** covering world and country briefs, country risk and resilience, conflict events, markets, commodities, energy, maritime and aviation activity, cyber threats, sanctions, natural disasters, health signals, prediction markets, and AI forecasts. Issue `tools/list` for the live inventory, `prompts/list` for pre-built workflow templates, and `resources/list` for read-only resources. `tools/list`, `prompts/list`, and `resources/list` are **public** — no key required. Every tool accepts an optional `jmespath` argument for [server-side projection](https://www.worldmonitor.app/docs/mcp-jmespath), typically an 80–95% response-size cut.
+The server ships **40 tools** covering world and country briefs, country risk and resilience, conflict events, markets, commodities, energy, maritime and aviation activity, cyber threats, sanctions, natural disasters, health signals, prediction markets, and AI forecasts. Issue `tools/list` for the live inventory, `prompts/list` for pre-built workflow templates, and `resources/list` for read-only resources. `tools/list`, `prompts/list`, and `resources/list` are **public** — no key required. Every tool accepts an optional `jmespath` argument for [server-side projection](https://www.worldmonitor.app/docs/mcp-jmespath), typically an 80–95% response-size cut.
+
+## MCP Apps
+
+World Monitor supports MCP Apps (`io.modelcontextprotocol/ui`) with five interactive `ui://` app shells. The linked tools are `get_country_risk`, `get_world_brief`, `get_country_brief`, `get_market_data`, and `get_chokepoint_status`; their UI resources are:
+
+- `ui://worldmonitor/country-risk.html`
+- `ui://worldmonitor/world-brief.html`
+- `ui://worldmonitor/country-brief.html`
+- `ui://worldmonitor/market-radar.html`
+- `ui://worldmonitor/chokepoint-monitor.html`
+
+Hosts discover the links through `_meta.ui.resourceUri` in `tools/list`, enumerate the shells through `resources/list`, and fetch each template with `resources/read`. `ui://` reads are public and quota-exempt because they return static, data-free HTML; live data still arrives through a normal authenticated `tools/call`. Full contract: [MCP Apps](https://www.worldmonitor.app/docs/mcp-apps).
 
 ## Authentication
 
@@ -35,6 +47,7 @@ Add the server to Claude Desktop / Cursor via their MCP settings using the URL `
 ## Learn more
 
 - [MCP Overview](https://www.worldmonitor.app/docs/mcp-overview) — auth modes, plans, OAuth setup, full tool catalog
+- [MCP Apps](https://www.worldmonitor.app/docs/mcp-apps) — interactive `ui://` resources, host flow, view security, and drift checks
 - [MCP Quickstart](https://www.worldmonitor.app/docs/mcp-quickstart) · [Tool reference](https://www.worldmonitor.app/docs/mcp-tools-reference) · [JMESPath projection](https://www.worldmonitor.app/docs/mcp-jmespath) · [Error catalog](https://www.worldmonitor.app/docs/mcp-error-catalog)
 - [Developer Portal](https://worldmonitor.app/developers.md) · [REST API OpenAPI spec](https://worldmonitor.app/openapi.md) · [SDKs](https://worldmonitor.app/sdks.md) · [agents.md](https://worldmonitor.app/agents.md)
 

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -25,6 +25,7 @@ const dirsIn = (p) =>
 const filesIn = (p) =>
   readdirSync(join(ROOT, p), { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name);
 const entriesIn = (p) => readdirSync(join(ROOT, p), { withFileTypes: true }).map((e) => e.name);
+const parseJson = (p) => JSON.parse(read(p));
 
 function sorted(items) {
   return [...items].sort();
@@ -45,6 +46,97 @@ function describeSetDelta(found, expected) {
     missing.length ? `missing: ${missing.join(', ')}` : '',
     extra.length ? `extra: ${extra.join(', ')}` : '',
   ].filter(Boolean).join('; ');
+}
+
+function extractSingleQuotedValue(text, name) {
+  const match = text.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*'([^']+)'`));
+  if (!match) throw new Error(`docs-stats: could not find ${name}`);
+  return match[1];
+}
+
+function findTopLevelObjectBlocks(source) {
+  const starts = [...source.matchAll(/^  \{$/gm)].map((m) => m.index);
+  return starts.map((start) => {
+    const close = source.slice(start).search(/^  \},?$/m);
+    if (close === -1) return source.slice(start);
+    return source.slice(start, start + close);
+  });
+}
+
+function parseMcpAppsInventory({
+  uiRegistrySource = read('api/mcp/ui/registry.ts'),
+  shellSource = read('api/mcp/ui/shell.ts'),
+  rpcToolsSource = read('api/mcp/registry/rpc-tools.ts'),
+  cacheToolsSource = read('api/mcp/registry/cache-tools.ts'),
+} = {}) {
+  const uiConstToUri = new Map(
+    [...uiRegistrySource.matchAll(/^export\s+const\s+(\w+_UI_URI)\s*=\s*'([^']+)';/gm)]
+      .map((m) => [m[1], m[2]]),
+  );
+  if (uiConstToUri.size === 0) {
+    throw new Error('docs-stats: could not parse MCP Apps ui:// URI constants');
+  }
+
+  const registryBlockMatch = uiRegistrySource.match(/export const UI_RESOURCE_REGISTRY:[\s\S]*?=\s*\[([\s\S]*?)\n\];/);
+  if (!registryBlockMatch) {
+    throw new Error('docs-stats: could not parse UI_RESOURCE_REGISTRY');
+  }
+  const registryEntries = [...registryBlockMatch[1].matchAll(
+    /uri:\s*(\w+_UI_URI),\s*\n\s*name:\s*'((?:\\'|[^'])*)',\s*\n\s*description:\s*\n\s*'((?:\\'|[^'])*)',/g,
+  )].map((m) => ({
+    uriConst: m[1],
+    uri: uiConstToUri.get(m[1]) ?? m[1],
+    name: m[2].replace(/\\'/g, "'"),
+    description: m[3].replace(/\\'/g, "'"),
+  }));
+  const registryConsts = registryEntries.map((entry) => entry.uriConst);
+  const uiConsts = [...uiConstToUri.keys()];
+  if (!sameStringSet(registryConsts, uiConsts)) {
+    throw new Error(
+      `docs-stats: UI_RESOURCE_REGISTRY entries do not match ui:// constants (${describeSetDelta(registryConsts, uiConsts)})`,
+    );
+  }
+
+  const toolLinks = [];
+  for (const source of [rpcToolsSource, cacheToolsSource]) {
+    for (const block of findTopLevelObjectBlocks(source)) {
+      const name = block.match(/^\s+name:\s*'([^']+)'/m)?.[1];
+      const uriConst = block.match(/^\s+_uiResourceUri:\s*(\w+_UI_URI),/m)?.[1];
+      if (name && uriConst) {
+        const uri = uiConstToUri.get(uriConst);
+        if (!uri) throw new Error(`docs-stats: tool ${name} links unknown MCP App URI constant ${uriConst}`);
+        toolLinks.push({ tool: name, uriConst, uri });
+      }
+    }
+  }
+  for (const [label, values] of [
+    ['tool', toolLinks.map((entry) => entry.tool)],
+    ['ui resource', toolLinks.map((entry) => entry.uri)],
+  ]) {
+    const duplicates = values.filter((value, index) => values.indexOf(value) !== index);
+    if (duplicates.length) {
+      throw new Error(`docs-stats: duplicate MCP Apps ${label} links: ${sorted([...new Set(duplicates)]).join(', ')}`);
+    }
+  }
+
+  const toolByUri = new Map(toolLinks.map((entry) => [entry.uri, entry.tool]));
+  const apps = registryEntries.map((entry) => ({
+    ...entry,
+    tool: toolByUri.get(entry.uri) ?? null,
+  }));
+  const unlinked = apps.filter((entry) => !entry.tool).map((entry) => entry.uri);
+  if (unlinked.length) {
+    throw new Error(`docs-stats: MCP Apps resources missing linked tools: ${unlinked.join(', ')}`);
+  }
+
+  return {
+    specVersion: extractSingleQuotedValue(shellSource, 'UI_PROTOCOL_VERSION'),
+    mimeType: extractSingleQuotedValue(shellSource, 'UI_RESOURCE_MIME_TYPE'),
+    apps,
+    uiResources: apps.map((entry) => entry.uri),
+    linkedTools: apps.map((entry) => entry.tool),
+    toolLinks: apps.map((entry) => ({ tool: entry.tool, uri: entry.uri })),
+  };
 }
 
 function parseJsonLdBlocks(html) {
@@ -160,6 +252,8 @@ function walk(rel, out = []) {
 
 function computeStats() {
   const makefile = read('Makefile');
+  const serverCard = parseJson('public/.well-known/mcp/server-card.json');
+  const mcpApps = parseMcpAppsInventory();
 
   // ---- Map layers (src/config/map-layer-definitions.ts) ----
   const mld = read('src/config/map-layer-definitions.ts');
@@ -292,6 +386,11 @@ function computeStats() {
     leaderNames,
     populationPriorityCountries,
     sebufVersion: makefileVar(makefile, 'SEBUF_VERSION'),
+    mcpToolCount: Array.isArray(serverCard.tools) ? serverCard.tools.length : 0,
+    mcpApps,
+    mcpAppCount: mcpApps.apps.length,
+    mcpAppUiResources: mcpApps.uiResources,
+    mcpAppLinkedTools: mcpApps.linkedTools,
   };
 }
 
@@ -351,6 +450,12 @@ function claims(s) {
     { file: 'docs/agent-discovery.mdx', re: /all (\d+)\s+services/, value: s.protoServices },
     { file: 'docs/api-reference.mdx', re: /all (\d+)\s+generated services/, value: s.protoServices },
 
+    { file: 'docs/mcp-overview.mdx', re: /same (\d+)\s+tools/, value: s.mcpToolCount },
+    { file: 'docs/mcp-apps.mdx', re: /current fleet ships (\d+)\s+MCP Apps/, value: s.mcpAppCount },
+    { file: 'docs/mcp-quickstart.mdx', re: /WorldMonitor exposes (\d+)\s+live tools/, value: s.mcpToolCount },
+    { file: 'docs/mcp-quickstart.mdx', re: /receives (\d+)\s+compressed tool descriptions/, value: s.mcpToolCount },
+    { file: 'public/mcp-server.md', re: /server ships \*\*(\d+)\s+tools\*\*/, value: s.mcpToolCount },
+
     { file: 'docs/data-sources.mdx', re: /monitors (\d+)\s+data sources/, value: s.freshnessSources },
     { file: 'docs/data-sources.mdx', re: /across (\d+)\s+monitored airports/, value: s.airportCount },
     { file: 'docs/data-sources.mdx', re: /^(\d+)\s+airports across 5 regions/m, value: s.airportCount },
@@ -392,6 +497,81 @@ function claims(s) {
   ];
 }
 
+function findDocsJsonPages(node, out = []) {
+  if (typeof node === 'string') {
+    out.push(node);
+    return out;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) findDocsJsonPages(item, out);
+    return out;
+  }
+  if (!node || typeof node !== 'object') return out;
+  for (const value of Object.values(node)) findDocsJsonPages(value, out);
+  return out;
+}
+
+function validateMcpAppsDocs(stats) {
+  const failures = [];
+  const docsPage = read('docs/mcp-apps.mdx');
+  const overview = read('docs/mcp-overview.mdx');
+  const publicMcp = read('public/mcp-server.md');
+  const docsJson = parseJson('docs/docs.json');
+  const serverCard = parseJson('public/.well-known/mcp/server-card.json');
+
+  if (!findDocsJsonPages(docsJson).includes('mcp-apps')) {
+    failures.push('docs/docs.json: MCP Apps page `mcp-apps` is not in navigation');
+  }
+
+  const cardApps = serverCard.metadata?.mcpApps;
+  if (!cardApps || cardApps.supported !== true) {
+    failures.push('public/.well-known/mcp/server-card.json: metadata.mcpApps.supported must be true');
+  } else {
+    if (cardApps.extension !== 'io.modelcontextprotocol/ui') {
+      failures.push(`public/.well-known/mcp/server-card.json: metadata.mcpApps.extension is ${cardApps.extension}`);
+    }
+    if (cardApps.specVersion !== stats.mcpApps.specVersion) {
+      failures.push(
+        `public/.well-known/mcp/server-card.json: metadata.mcpApps.specVersion is ${cardApps.specVersion}, code says ${stats.mcpApps.specVersion}`,
+      );
+    }
+    if (cardApps.uiResourceMimeType !== stats.mcpApps.mimeType) {
+      failures.push(
+        `public/.well-known/mcp/server-card.json: metadata.mcpApps.uiResourceMimeType is ${cardApps.uiResourceMimeType}, code says ${stats.mcpApps.mimeType}`,
+      );
+    }
+    if (!sameStringSet(cardApps.uiResources ?? [], stats.mcpAppUiResources)) {
+      failures.push(
+        `public/.well-known/mcp/server-card.json: metadata.mcpApps.uiResources drift (${describeSetDelta(cardApps.uiResources ?? [], stats.mcpAppUiResources)})`,
+      );
+    }
+  }
+
+  for (const { tool, uri } of stats.mcpApps.toolLinks) {
+    for (const [file, text] of [
+      ['docs/mcp-apps.mdx', docsPage],
+      ['docs/mcp-overview.mdx', overview],
+      ['public/mcp-server.md', publicMcp],
+    ]) {
+      if (!text.includes(uri)) failures.push(`${file}: missing MCP Apps ui resource ${uri}`);
+      if (!text.includes(tool)) failures.push(`${file}: missing MCP Apps linked tool ${tool}`);
+    }
+  }
+
+  for (const app of stats.mcpApps.apps) {
+    if (!docsPage.includes(app.name)) failures.push(`docs/mcp-apps.mdx: missing MCP Apps display name ${app.name}`);
+  }
+
+  if (!docsPage.includes(stats.mcpApps.specVersion)) {
+    failures.push(`docs/mcp-apps.mdx: missing MCP Apps spec version ${stats.mcpApps.specVersion}`);
+  }
+  if (!docsPage.includes(stats.mcpApps.mimeType)) {
+    failures.push(`docs/mcp-apps.mdx: missing MCP Apps mime type ${stats.mcpApps.mimeType}`);
+  }
+
+  return failures;
+}
+
 function main() {
   const check = process.argv.includes('--check');
   const stats = computeStats();
@@ -416,6 +596,7 @@ function main() {
 
   failures.push(...validateIndexLanguageMetadata(stats));
   failures.push(...validateSupportedLanguagesRegistry(stats));
+  failures.push(...validateMcpAppsDocs(stats));
 
   for (const c of claims(stats)) {
     let text;
@@ -460,6 +641,8 @@ export {
   parseJsonLdBlocks,
   sameStringSet,
   describeSetDelta,
+  parseMcpAppsInventory,
+  validateMcpAppsDocs,
 };
 
 // Run only when executed directly (node scripts/docs-stats.mjs [--check]).

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/koala73/worldmonitor",
     "source": "github"
   },
-  "version": "1.13.0",
+  "version": "1.14.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,12 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.13.0"', async () => {
+    it('serverInfo.version === "1.14.0"', async () => {
       // Tracks current SERVER_VERSION. Each minor bump needs to update
       // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.13.0');
+      assert.equal(body.result?.serverInfo?.version, '1.14.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -326,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (currently 1.13.0)', () => {
+    it('server-card.json version matches SERVER_VERSION (currently 1.14.0)', () => {
       // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.13.0');
+      assert.equal(card.serverInfo.version, '1.14.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -447,6 +447,50 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     }
   });
 
+  // -------------------------------------------------------------------------
+  // Soft-error envelopes must surface a VISIBLE message, not a blank/empty-
+  // success dashboard. A successful tools/call can carry an error sentinel
+  // instead of data — { _budget_exceeded, ... } when the tool output exceeds
+  // its byte budget, or { _jmespath_error, ... } on a bad projection. The
+  // shared shell's safeRender detects these before renderData and routes them
+  // to showError (hides #card, fills #empty). Guarded on the served HTML so a
+  // future shell edit can't silently drop the branch.
+  // -------------------------------------------------------------------------
+  it('FLEET: shared-shell widgets surface soft-error envelopes (_budget_exceeded / _jmespath_error) instead of rendering blank success', async () => {
+    const shellWidgets = [
+      'ui://worldmonitor/world-brief.html',
+      'ui://worldmonitor/country-brief.html',
+      'ui://worldmonitor/market-radar.html',
+      'ui://worldmonitor/chokepoint-monitor.html',
+    ];
+    for (const uri of shellWidgets) {
+      const res = await handler(envKeyReq(readBody(uri)));
+      const html = (await res.json()).result.contents[0].text;
+      assert.match(html, /function softError/, `${uri}: must define a softError() detector`);
+      assert.match(html, /_budget_exceeded/, `${uri}: must detect the _budget_exceeded soft-error envelope`);
+      assert.match(html, /_jmespath_error/, `${uri}: must detect the _jmespath_error soft-error envelope`);
+      assert.match(html, /function showError/, `${uri}: must route soft errors to a visible showError() path`);
+      // The detector MUST run before renderData in safeRender — otherwise a
+      // blank/empty-success dashboard renders before the error is caught.
+      assert.match(html, /softError\(data\)[\s\S]*renderData\(data\)/,
+        `${uri}: safeRender must check softError(data) before calling renderData(data)`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // The country-brief widget must title from the fields get_country_brief
+  // actually returns. The backing get-country-intel-brief handler emits
+  // CAMELCASE identity (`countryCode` + resolved `countryName`), NOT the
+  // snake_case `country_code` the MCP outputSchema documents — so a widget that
+  // reads only `country_code` leaves the title stuck at generic "Country Brief".
+  // -------------------------------------------------------------------------
+  it('country-brief widget resolves its title from the camelCase countryName / countryCode fields the tool returns', async () => {
+    const res = await handler(envKeyReq(readBody('ui://worldmonitor/country-brief.html')));
+    const html = (await res.json()).result.contents[0].text;
+    assert.match(html, /data\.countryName/, 'must prefer the resolved countryName field');
+    assert.match(html, /data\.countryCode/, 'must resolve the camelCase countryCode field');
+  });
+
   it('resources/templates/list returns the three data-bearing URI templates', async () => {
     const res = await handler(envKeyReq({ jsonrpc: '2.0', id: 3, method: 'resources/templates/list', params: {} }));
     assert.equal(res.status, 200);

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -424,8 +424,15 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       const csp = cspMatch[1];
       assert.match(csp, /default-src\s+'none'/, `${uri}: default-src must be 'none'`);
       assert.match(csp, /connect-src[^;]*worldmonitor\.app/, `${uri}: connect-src must include the MCP origin`);
-      assert.match(csp, /frame-ancestors[^;]*https:\/\/chatgpt\.com/, `${uri}: frame-ancestors must include chatgpt.com`);
-      assert.match(csp, /frame-ancestors[^;]*https:\/\/claude\.ai/, `${uri}: frame-ancestors must include claude.ai`);
+      // frame-ancestors in a <meta> CSP is ADVISORY — browsers enforce it only
+      // via an HTTP response header, and a ui:// shell is delivered as a
+      // JSON-RPC string the host injects into its own sandboxed iframe (no HTTP
+      // document, so no header to carry it). We assert its presence as a
+      // declarative host/scanner signal of intended embedders, NOT as
+      // browser-enforced clickjacking protection (the real embedding boundary
+      // is the host sandbox + the bridge's event.source === parent check).
+      assert.match(csp, /frame-ancestors[^;]*https:\/\/chatgpt\.com/, `${uri}: must declare chatgpt.com in frame-ancestors (advisory embedder signal)`);
+      assert.match(csp, /frame-ancestors[^;]*https:\/\/claude\.ai/, `${uri}: must declare claude.ai in frame-ancestors (advisory embedder signal)`);
       assert.match(csp, /form-action\s+'none'/, `${uri}: form-action must be scoped`);
       assert.match(csp, /base-uri\s+'none'/, `${uri}: base-uri must be scoped`);
       assert.match(csp, /(img|script|style)-src/, `${uri}: img/script/style-src must be present`);

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -248,7 +248,11 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     assert.deepEqual(actualUris, [
       'worldmonitor://seed-meta/freshness',
       'ui://worldmonitor/country-risk.html',
-    ], 'resources/list = concrete DATA freshness probe then ui:// shell, in order');
+      'ui://worldmonitor/world-brief.html',
+      'ui://worldmonitor/country-brief.html',
+      'ui://worldmonitor/market-radar.html',
+      'ui://worldmonitor/chokepoint-monitor.html',
+    ], 'resources/list = concrete DATA freshness probe then the ui:// app-shell fleet, in registry order');
     for (const r of body.result.resources) {
       assert.equal(typeof r.uri, 'string', `resource ${r.uri}: uri must be a string`);
       assert.ok(r.uri.length > 0, `resource ${r.uri}: uri must be non-empty`);
@@ -386,6 +390,60 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     for (const uri of listedUiUris) {
       assert.ok(linkedByTools.has(uri),
         `ui:// resource "${uri}" is advertised but no tool references it via _uiResourceUri`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // MCP Apps fleet-wide quality — the orank view-quality / view-csp signals
+  // asserted for country-risk above must hold for EVERY widget in the fleet,
+  // so a future app shell (or a shared-shell edit) can't silently regress the
+  // CSP / dark-mode / bridge contract. Generalises the single-widget check to
+  // the whole ui:// registry read back off the wire.
+  // -------------------------------------------------------------------------
+  it('FLEET: every ui:// shell carries the orank quality signals (DOCTYPE, color-scheme, 4-category CSP, bridge, no secrets)', async () => {
+    const listRes = await handler(envKeyReq({ jsonrpc: '2.0', id: 11, method: 'resources/list', params: {} }));
+    const listBody = await listRes.json();
+    const uiUris = listBody.result.resources.map((r) => r.uri).filter((u) => u.startsWith('ui://'));
+    assert.ok(uiUris.length >= 5, `expected the interactive-dashboard fleet (>=5 widgets), got ${uiUris.length}`);
+
+    for (const uri of uiUris) {
+      const res = await handler(envKeyReq(readBody(uri)));
+      const c = (await res.json()).result.contents[0];
+      const html = c.text;
+
+      // ui-quality + view-domain.
+      assert.match(html, /^<!DOCTYPE html>/, `${uri}: must open with an uppercase <!DOCTYPE html>`);
+      assert.match(html, /<meta\s+name="color-scheme"\s+content="light dark">/, `${uri}: must declare color-scheme`);
+      assert.doesNotMatch(html, /wm_[a-f0-9]{40}|X-WorldMonitor-Key|Bearer\s+[A-Za-z0-9]/, `${uri}: must not hardcode secrets`);
+      // The TS template interpolation must be fully resolved — no leaked `${` markers.
+      assert.doesNotMatch(html, /\$\{/, `${uri}: unresolved template placeholder leaked into served HTML`);
+
+      // view-csp: all four required directive categories, scoped (not `*`).
+      const cspMatch = html.match(/<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)">/);
+      assert.ok(cspMatch, `${uri}: must carry a <meta http-equiv CSP> tag`);
+      const csp = cspMatch[1];
+      assert.match(csp, /default-src\s+'none'/, `${uri}: default-src must be 'none'`);
+      assert.match(csp, /connect-src[^;]*worldmonitor\.app/, `${uri}: connect-src must include the MCP origin`);
+      assert.match(csp, /frame-ancestors[^;]*https:\/\/chatgpt\.com/, `${uri}: frame-ancestors must include chatgpt.com`);
+      assert.match(csp, /frame-ancestors[^;]*https:\/\/claude\.ai/, `${uri}: frame-ancestors must include claude.ai`);
+      assert.match(csp, /form-action\s+'none'/, `${uri}: form-action must be scoped`);
+      assert.match(csp, /base-uri\s+'none'/, `${uri}: base-uri must be scoped`);
+      assert.match(csp, /(img|script|style)-src/, `${uri}: img/script/style-src must be present`);
+      assert.doesNotMatch(csp, /default-src\s+\*/, `${uri}: must not use a permissive default-src *`);
+
+      // MCP Apps postMessage bridge handshake must be implemented.
+      assert.match(html, /ui\/initialize/, `${uri}: must implement the ui/initialize handshake`);
+      assert.match(html, /ui\/notifications\/tool-result/, `${uri}: must consume tool-result notifications`);
+      assert.match(html, /ui\/notifications\/size-changed/, `${uri}: must report size to the host`);
+
+      // Spec _meta.ui.csp must mirror the HTML connect-src and keep the other
+      // allowlists empty (the fleet's shared secure default).
+      assert.deepEqual(c._meta?.ui?.csp?.connectDomains,
+        ['https://worldmonitor.app', 'https://www.worldmonitor.app'],
+        `${uri}: _meta.ui.csp.connectDomains must mirror the HTML connect-src`);
+      assert.deepEqual(c._meta?.ui?.csp?.resourceDomains, [], `${uri}: resourceDomains must be empty`);
+      assert.deepEqual(c._meta?.ui?.csp?.frameDomains, [], `${uri}: frameDomains must be empty`);
+      assert.deepEqual(c._meta?.ui?.csp?.baseUriDomains, [], `${uri}: baseUriDomains must be empty`);
     }
   });
 

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -140,8 +140,11 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
 
     it('compressDescriptions=true returns { name, description, inputSchema, outputSchema, annotations } with no other top-level keys', async () => {
       const tools = await getRegistry();
-      const t = tools.find(t => t.name === 'get_market_data');
-      assert.ok(t, 'get_market_data must be registered');
+      // get_cyber_threats is a cache tool WITHOUT a ui:// surface, so it carries
+      // no `_meta` — the clean 5-key public shape. (get_market_data now links a
+      // Market Radar ui:// app shell and legitimately carries `_meta`.)
+      const t = tools.find(t => t.name === 'get_cyber_threats');
+      assert.ok(t, 'get_cyber_threats must be registered');
       assert.deepEqual(Object.keys(t).sort(), ['annotations', 'description', 'inputSchema', 'name', 'outputSchema']);
     });
 
@@ -286,10 +289,10 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'the deprecated flat ui/resourceUri alias must mirror the nested form');
     });
 
-    it('a tool WITHOUT a UI surface (get_market_data) omits _meta entirely (no empty object on the wire)', async () => {
+    it('a tool WITHOUT a UI surface (get_cyber_threats) omits _meta entirely (no empty object on the wire)', async () => {
       const tools = await getRegistry();
-      const t = tools.find(t => t.name === 'get_market_data');
-      assert.ok(t, 'get_market_data must be registered');
+      const t = tools.find(t => t.name === 'get_cyber_threats');
+      assert.ok(t, 'get_cyber_threats must be registered');
       assert.ok(!('_meta' in t), 'non-UI tools must not carry a _meta key at all');
     });
 
@@ -402,14 +405,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
     // ============================================================
     // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
     // ============================================================
-    it('serverInfo.version === "1.13.0"', async () => {
+    it('serverInfo.version === "1.14.0"', async () => {
       const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
       }));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.13.0');
+      assert.equal(body.result?.serverInfo?.version, '1.14.0');
     });
 
     it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
@@ -426,9 +429,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.13.0) AND tools[] length matches (40)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.14.0) AND tools[] length matches (40)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.13.0');
+      assert.equal(card.serverInfo.version, '1.14.0');
       // orank (ora.ai) agent-readiness scanner reads the card's `tools` as an
       // ARRAY (tools[]) for pre-connection preview — not the old {count,categories}
       // object. Keep it an array; the count now derives from the length.


### PR DESCRIPTION
Closes #4959.

## Summary

Grows the MCP Apps surface from the single `get_country_risk` widget to a **five-widget interactive-dashboard fleet**, closing the deepest Telnyx-parity gap identified in the report (in-conversation dashboards).

Four new `ui://` app-shell resources, each linked from its backing tool via `_meta.ui.resourceUri` (+ the deprecated flat `ui/resourceUri` alias) and registered in `api/mcp/ui/registry.ts`:

| UI resource | Backing tool | Renders |
|---|---|---|
| `ui://worldmonitor/world-brief.html` | `get_world_brief` | AI-summarised global brief as paragraphs + grounding headlines + sources |
| `ui://worldmonitor/country-brief.html` | `get_country_brief` | Per-country brief + analytical framework lens + sources |
| `ui://worldmonitor/market-radar.html` | `get_market_data` | Fear & Greed composite + per-asset-class quote tables (equities/commodities/crypto/Gulf/sectors), signed & colour-coded change |
| `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Per-chokepoint transit summaries (today's count, WoW change, tanker split) + risk-level badge |

A shared shell (`api/mcp/ui/shell.ts`) factors the parts that must stay identical across the fleet — uppercase DOCTYPE, `color-scheme` meta, the 4-category view CSP, dark-mode design tokens, and the `postMessage` bridge (`ui/initialize` → `tool-result` → `size-changed`) — so a new widget can't drift on the orank quality/CSP signals. Each widget supplies only its layout + render mapping; rendering is `textContent`-only (never `innerHTML`) and shells are fully self-contained (no external assets). The shipped country-risk widget is unchanged and now sources its `_meta` from the shared `buildUiMeta()`.

`resources/read` of every `ui://` URI stays **public + quota-exempt** (static, data-free templates); DATA reads stay gated + Pro-quota-symmetric. Purely additive on the wire: `_meta` appears only on the four newly-linked tools — no input/output schema, envelope, or auth change to any tool.

Also bumps `SERVER_VERSION` 1.13.0 → 1.14.0 (constants, server-card, `server.json`), documents the fleet in the server-card `mcpApps` block and `docs/mcp-overview`, and adds a fleet-wide test asserting every `ui://` shell carries the DOCTYPE / color-scheme / 4-category CSP / bridge / `_meta.ui.csp` contract.

## Type of change

- [x] New feature

## Affected areas

- [x] AI Insights / World Brief
- [x] Market Radar / Crypto
- [x] API endpoints (`/api/*`) — MCP server (`api/mcp/*`)
- [x] Other: MCP Apps (`io.modelcontextprotocol/ui`) interactive `ui://` resources

## Checklist

- [x] No API keys or secrets committed (fleet-wide test asserts no hardcoded credentials in any shell)
- [x] TypeScript compiles without errors (`tsc --noEmit` clean)
- [x] Full MCP + edge-functions test suite green (807 tests); `biome lint` clean; `enforce-sebuf-api-contract` clean
- [x] All 4 widgets rendered end-to-end in real Chromium with simulated host `postMessage` (no page errors, correct data/theme/formatting)

## Documentation Alignment Checklist

- [x] Generated docs updated where applicable — `docs/mcp-overview` UI-resource table + server-card `mcpApps` block list the full fleet; `SERVER_VERSION`/`server.json` bumped in lockstep (parity tests enforce)
- [ ] N/A — no methodology / CII / CRI / Redis-key contract change; this PR only adds static, data-free HTML app shells over existing tool results

## Screenshots

Rendered from each shell driven with a simulated host `tool-result` (light theme):

- **World Brief** — `World Brief · Escalation in the Red Sea continued. Markets steadied after the Fed held rates. · GROUNDING HEADLINES: Red Sea shipping disrupted; Fed holds rates steady · SOURCES: Reuters — Reuters wrap`
- **Country Brief** — `Germany Brief · Lens: PMESII-PT · Germany faces industrial headwinds. Coalition tensions persist. · SOURCES: DW — DW analysis`
- **Market Radar** — `Market Radar · 72 FEAR & GREED Greed · EQUITIES AAPL 212.34 +1.23%  MSFT 401.1 -0.45% · CRYPTO BTC-USD 98,765.4 +2.10%`
- **Chokepoint Monitor** — `Chokepoint Monitor · Suez ELEVATED — Transits today 42, WoW -8.50%, Tanker 12 · Hormuz strait NORMAL — Transits today 88, WoW +2.00%, Tanker 40`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqf2CzuQFKjUNa4U6r3Zqb)_