### PR TITLE
perf(map): skip zoom-hidden SVG marker DOM

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -134,6 +134,8 @@ export class MapComponent {
       natural: { minZoom: 1, showLabels: 2 },
     };
 
+  private static readonly SVG_MARKER_DOM_ZOOM_LAYERS = new Set<keyof MapLayers>(['bases', 'nuclear']);
+
   private container: HTMLElement;
   private svg: d3.Selection<SVGSVGElement, unknown, null, undefined>;
   private wrapper: HTMLElement;
@@ -1298,7 +1300,7 @@ export class MapComponent {
         // sub-50ms tasks (#4442), so the overlay build is neither blocking nor one long task.
         scheduleAfterFirstPaint(() => { void this.renderInitialDynamicPass(); });
       }
-      this.applyTransform();
+      this.applyTransform(false);
       return;
     }
 
@@ -1320,7 +1322,7 @@ export class MapComponent {
       }
     }
 
-    this.applyTransform();
+    this.applyTransform(false);
   }
 
   // Builds the dynamic overlay layers (cables/pipelines/conflicts/AIS/cluster/overlays).
@@ -1366,7 +1368,7 @@ export class MapComponent {
     if (width === 0 || height === 0) return; // next real render handles it
     this.initialDynamicRendered = true;
     await this.renderDynamicLayers(width, height, true);
-    if (!this.destroyed) this.applyTransform();
+    if (!this.destroyed) this.applyTransform(false);
   }
 
   private renderGrid(
@@ -1653,6 +1655,13 @@ export class MapComponent {
     return clusters;
   }
 
+  private isLayerZoomVisible(layer: keyof MapLayers): boolean {
+    if (!this.state.layers[layer]) return false;
+    const thresholds = MapComponent.LAYER_ZOOM_THRESHOLDS[layer];
+    if (!thresholds) return true;
+    return Boolean(this.layerZoomOverrides[layer]) || this.state.zoom >= thresholds.minZoom;
+  }
+
   private renderOverlays(projection: d3.GeoProjection): void {
     setTrustedHtml(this.overlays, trustedHtml('', "legacy direct innerHTML migration"));
     this.labelVisibilityScheduled = false;
@@ -1677,7 +1686,7 @@ export class MapComponent {
     }
 
     // Nuclear facilities (always HTML - shapes convey status)
-    if (this.state.layers.nuclear) {
+    if (this.state.layers.nuclear && this.isLayerZoomVisible('nuclear')) {
       NUCLEAR_FACILITIES.forEach((facility) => {
         const pos = projection([facility.lon, facility.lat]);
         if (!pos) return;
@@ -1833,7 +1842,7 @@ export class MapComponent {
     }
 
     // Military bases (always HTML - nation colors matter)
-    if (this.state.layers.bases) {
+    if (this.state.layers.bases && this.isLayerZoomVisible('bases')) {
       this.getMilitaryBasesForRender().forEach((base) => {
         const pos = projection([base.lon, base.lat]);
         if (!pos) return;
@@ -3991,7 +4000,7 @@ export class MapComponent {
     this.state.pan.y = Math.max(-maxPanY, Math.min(maxPanY, this.state.pan.y));
   }
 
-  private applyTransform(): void {
+  private applyTransform(rebuildOnZoomVisibilityChange = true): void {
     const { width, height } = this.getKnownContainerSize();
     this.clampPan(width, height);
     const zoom = this.state.zoom;
@@ -4016,8 +4025,9 @@ export class MapComponent {
 
     // Smart label hiding based on zoom level and overlap
     if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);
-    this.updateZoomLayerVisibility();
+    const zoomVisibilityChanged = this.updateZoomLayerVisibility();
     this.emitStateChange();
+    if (rebuildOnZoomVisibilityChange && zoomVisibilityChanged) this.scheduleRender();
   }
 
   private shouldUpdateLabelVisibility(): boolean {
@@ -4030,8 +4040,9 @@ export class MapComponent {
     this.updateLabelVisibility(this.state.zoom);
   }
 
-  private updateZoomLayerVisibility(): void {
+  private updateZoomLayerVisibility(): boolean {
     const zoom = this.state.zoom;
+    let visibilityChanged = false;
     (Object.keys(MapComponent.LAYER_ZOOM_THRESHOLDS) as (keyof MapLayers)[]).forEach((layer) => {
       const thresholds = MapComponent.LAYER_ZOOM_THRESHOLDS[layer];
       if (!thresholds) return;
@@ -4043,6 +4054,10 @@ export class MapComponent {
       const labelsVisible = enabled && zoom >= labelZoom;
       const hiddenAttr = `data-layer-hidden-${layer}`;
       const labelsHiddenAttr = `data-labels-hidden-${layer}`;
+      const wasVisible = !this.wrapper.hasAttribute(hiddenAttr);
+
+      const affectsSvgMarkerDom = MapComponent.SVG_MARKER_DOM_ZOOM_LAYERS.has(layer);
+      if (affectsSvgMarkerDom && wasVisible !== isVisible) visibilityChanged = true;
 
       if (isVisible) {
         this.wrapper.removeAttribute(hiddenAttr);
@@ -4060,6 +4075,7 @@ export class MapComponent {
       const autoHidden = enabled && !override && zoom < thresholds.minZoom;
       btn?.classList.toggle('auto-hidden', autoHidden);
     });
+    return visibilityChanged;
   }
 
   private emitStateChange(): void {

--- a/tests/map-deferred-overlays.test.mts
+++ b/tests/map-deferred-overlays.test.mts
@@ -163,7 +163,7 @@ describe('mobile SVG map: defer + chunk dynamic overlays off first paint (#4429/
       "ResizeObserver should refresh cached dimensions before scheduling render",
     );
 
-    const transformStart = mapSrc.indexOf("private applyTransform(): void");
+    const transformStart = mapSrc.indexOf("private applyTransform(rebuildOnZoomVisibilityChange = true): void");
     const transformEnd = mapSrc.indexOf("  private updateLabelVisibility", transformStart);
     assert.ok(transformStart > 0 && transformEnd > transformStart, "applyTransform block should be present");
     const transformBlock = mapSrc.slice(transformStart, transformEnd);

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -71,7 +71,7 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
       'desktop should keep label measurement enabled while mobile waits for the resume trigger',
     );
 
-    const applyBlock = sliceBetween('private applyTransform(): void {', 'private shouldUpdateLabelVisibility(): boolean');
+    const applyBlock = sliceBetween('private applyTransform(rebuildOnZoomVisibilityChange = true): void {', 'private shouldUpdateLabelVisibility(): boolean');
     const guardIdx = applyBlock.indexOf('if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);');
     const zoomVisibilityIdx = applyBlock.indexOf('this.updateZoomLayerVisibility();');
     const emitIdx = applyBlock.indexOf('this.emitStateChange();');

--- a/tests/map-svg-zoom-layer-dom.test.mjs
+++ b/tests/map-svg-zoom-layer-dom.test.mjs
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const mapPath = resolve(root, 'src/components/Map.ts');
+const mapSrc = readFileSync(mapPath, 'utf-8');
+const sourceFile = ts.createSourceFile(mapPath, mapSrc, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+
+function findClassMethod(className, methodName) {
+  let result = null;
+
+  function visit(node) {
+    if (result) return;
+    if (ts.isClassDeclaration(node) && node.name?.text === className) {
+      for (const member of node.members) {
+        if (ts.isMethodDeclaration(member) && member.name.getText(sourceFile) === methodName) {
+          result = member;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  assert.ok(result, `missing ${className}.${methodName}`);
+  return result;
+}
+
+function ifConditionText(node) {
+  return ts.isIfStatement(node) ? node.expression.getText(sourceFile) : '';
+}
+
+function hasZoomGate(node, layer) {
+  const condition = ifConditionText(node);
+  return condition.includes(`this.state.layers.${layer}`)
+    && condition.includes(`this.isLayerZoomVisible('${layer}')`);
+}
+
+function classNameAssignments(method, markerClass) {
+  const matches = [];
+
+  function visit(node, ancestors) {
+    if (
+      ts.isBinaryExpression(node)
+      && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+      && node.left.getText(sourceFile).endsWith('.className')
+      && node.right.getText(sourceFile).includes(markerClass)
+    ) {
+      matches.push({ node, ancestors: [...ancestors] });
+    }
+
+    ts.forEachChild(node, (child) => visit(child, [...ancestors, node]));
+  }
+
+  visit(method, []);
+  return matches;
+}
+
+describe('SVG map zoom-hidden layer DOM allocation', () => {
+  it('routes zoom threshold checks through an override-aware helper', () => {
+    const helper = findClassMethod('MapComponent', 'isLayerZoomVisible');
+    const body = helper.getText(sourceFile);
+
+    assert.ok(body.includes('if (!this.state.layers[layer]) return false;'));
+    assert.match(body, /MapComponent\.LAYER_ZOOM_THRESHOLDS\[layer\]/);
+    assert.match(body, /this\.layerZoomOverrides\[layer\]/);
+    assert.match(body, /this\.state\.zoom >= thresholds\.minZoom/);
+  });
+
+  it('schedules one overlay rebuild when zoom interactions cross layer visibility thresholds', () => {
+    const applyTransform = findClassMethod('MapComponent', 'applyTransform');
+    const applyBody = applyTransform.getText(sourceFile);
+    const updateZoomLayerVisibility = findClassMethod('MapComponent', 'updateZoomLayerVisibility');
+    const updateBody = updateZoomLayerVisibility.getText(sourceFile);
+
+    assert.match(applyBody, /rebuildOnZoomVisibilityChange = true/);
+    assert.match(applyBody, /const zoomVisibilityChanged = this\.updateZoomLayerVisibility\(\)/);
+    assert.match(
+      applyBody,
+      /if \(rebuildOnZoomVisibilityChange && zoomVisibilityChanged\) this\.scheduleRender\(\)/,
+    );
+    assert.ok(mapSrc.includes("SVG_MARKER_DOM_ZOOM_LAYERS = new Set<keyof MapLayers>(['bases', 'nuclear'])"));
+    assert.match(updateBody, /let visibilityChanged = false/);
+    assert.match(updateBody, /const wasVisible = !this\.wrapper\.hasAttribute\(hiddenAttr\)/);
+    assert.match(updateBody, /const affectsSvgMarkerDom = MapComponent\.SVG_MARKER_DOM_ZOOM_LAYERS\.has\(layer\)/);
+    assert.match(updateBody, /if \(affectsSvgMarkerDom && wasVisible !== isVisible\) visibilityChanged = true/);
+    assert.match(updateBody, /return visibilityChanged/);
+  });
+
+  it('does not schedule another rebuild from render-time transform syncs', () => {
+    const renderWithSize = findClassMethod('MapComponent', 'renderWithSize');
+    const renderCalls = renderWithSize.getText(sourceFile).match(/this\.applyTransform\(false\)/g) ?? [];
+    const initialDynamicPass = findClassMethod('MapComponent', 'renderInitialDynamicPass');
+
+    assert.equal(renderCalls.length, 2, 'renderWithSize should opt out for both render-time transform syncs');
+    assert.match(initialDynamicPass.getText(sourceFile), /this\.applyTransform\(false\)/);
+  });
+
+  for (const { layer, markerClass } of [
+    { layer: 'nuclear', markerClass: 'nuclear-marker' },
+    { layer: 'bases', markerClass: 'base-marker' },
+  ]) {
+    it(`does not create ${markerClass} nodes while ${layer} is zoom-hidden`, () => {
+      const renderOverlays = findClassMethod('MapComponent', 'renderOverlays');
+      const assignments = classNameAssignments(renderOverlays, markerClass);
+
+      assert.equal(assignments.length, 1, `expected one ${markerClass} assignment`);
+      const guarded = assignments[0].ancestors.some((ancestor) => hasZoomGate(ancestor, layer));
+
+      assert.equal(
+        guarded,
+        true,
+        `${markerClass} DOM allocation must sit inside the ${layer} zoom visibility gate`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Stop the SVG fallback map from allocating `nuclear-marker`, `base-marker`, and `base-label` DOM while those layers are hidden by the existing zoom thresholds.
- Add an override-aware `isLayerZoomVisible()` helper so render-time marker allocation follows the same threshold policy as the visibility toggles.
- Rebuild the SVG overlays once when zoom interactions cross a layer visibility threshold, so skipped markers appear/disappear without waiting for an unrelated render.

Related: #5029

## Intent

Issue #5029 points to DOM node count, especially high-count map marker layers, as the current driver of `/dashboard` forced-reflow time. This is a narrow fallback-renderer reduction: at global zoom levels where bases and nuclear sites are already hidden, the SVG fallback now skips creating those marker nodes at all instead of creating them and hiding them afterward. It preserves existing thresholds and `layerZoomOverrides`, and avoids triggering a render loop during render-time transform syncs.

## Validation Matrix

- PASS `./node_modules/.bin/tsx --test tests/map-deferred-overlays.test.mts tests/map-svg-zoom-layer-dom.test.mjs tests/map-mobile-feature-caps.test.mjs tests/map-layer-executable.test.mts`
- PASS `./node_modules/.bin/tsx --test tests/measure-dashboard-render-axis.test.mts tests/measure-desktop-mainthread.test.mts tests/measure-composited-layers.test.mts`
- PASS `npm run typecheck`
- PASS `npm run lint` (`biome` reported existing repo-wide warnings outside this diff; `lint:safe-html` passed)
- PASS `git diff --check`
- DIAGNOSED `npm run test:data` after the CI unit failure: the PR-related map guard now passes; remaining local full-suite failures require a prebuilt `dist/dashboard.html` for `tests/dashboard-critical-css.test.mjs`

## Review Gates

- PASS self-review for the changed SVG fallback render path, zoom threshold helper, and zoom-triggered overlay rebuild.
- PASS independent code review after the zoom-threshold rebuild fix; no remaining actionable findings.
- PASS addressed Greptile observations: `isLayerZoomVisible()` now fails closed for disabled layers, and zoom-crossing overlay rebuilds are limited to SVG marker DOM layers.

## Documentation

Not required. This is an internal runtime/performance behavior change with focused regression coverage.

## Screenshots / UI Evidence

Not included. The visible map policy is unchanged: hidden-at-zoom marker layers remain hidden until their existing thresholds, and this change only avoids allocating their fallback DOM before then.

## Post-Deploy Monitoring & Validation

- Watch DebugBear `/dashboard` DOM Nodes, forced reflow time/count, and `cpu.styleLayout` against the #5029 baseline.
- Re-run `scripts/measure-dashboard-render-axis.mjs` on production and compare fallback marker owner counts for `.nuclear-marker`, `.base-marker`, and `.base-label`.
- Watch Sentry for `MapComponent`, `renderOverlays`, `isLayerZoomVisible`, `scheduleRender`, map interaction errors, and render-loop symptoms.
- Healthy result: lower global-dashboard fallback marker DOM, lower or stable forced-reflow time, and no missing marker reports after zooming past thresholds.
- Rollback signal: bases/nuclear markers fail to appear after zooming in, map interaction errors rise, or layout/reflow timing regresses.

## Residual Findings

No actionable residual findings. The remaining risk is that the added coverage is structural/AST-focused rather than browser-level SVG fallback interaction coverage.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
