### PR TITLE
fix(seed-economy): bound FRED fetch concurrency under 240s deadline

### DIFF
--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, resolveProxy, resolveProxyForConnect, fredFetchJson, curlFetch, getRedisCredentials } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, resolveProxy, resolveProxyForConnect, fredFetchJson, curlFetch, getRedisCredentials, allSettledWithConcurrency } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
@@ -67,7 +67,15 @@ async function eiaFetchJson(url, label, { timeoutMs = 20_000, attempts = 3 } = {
   throw lastErr;
 }
 
-const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO', 'BAMLH0A0HYM2', 'ICSA', 'MORTGAGE30US', 'BAMLC0A0CM', 'SOFR', 'DGS1MO', 'DGS3MO', 'DGS6MO', 'DGS1', 'DGS2', 'DGS5', 'DGS30', 'T10Y3M', 'STLFSI4'];
+export const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO', 'BAMLH0A0HYM2', 'ICSA', 'MORTGAGE30US', 'BAMLC0A0CM', 'SOFR', 'DGS1MO', 'DGS3MO', 'DGS6MO', 'DGS1', 'DGS2', 'DGS5', 'DGS30', 'T10Y3M', 'STLFSI4'];
+
+// In-flight FRED series. The 24-series loop MUST finish inside runSeed's 240s fetch-phase
+// deadline even when the proxy is fully down: fredFetchJson worst case ≈ 3×20s proxy attempts
+// + 20s direct fallback ≈ 82s/series. Sequential (the old code) = 24×82s ≫ 240s → recurring
+// exit-75 "Deploy Crashed!" alerts (issue #5037). At concurrency 12, ⌈24/12⌉ = 2 waves × 82s
+// ≈ 164s — comfortably under the deadline. In-flight requests peak at 12×2 (obs+meta), well
+// under FRED's 120/min limit. Mirrors the seed-bigmac #4994 bounded-concurrency fix.
+export const FRED_CONCURRENCY = 12;
 
 // ─── Economic Stress Index (computed last from FRED data in fetchAll) ───
 
@@ -298,49 +306,63 @@ async function fetchEnergyCapacity() {
 
 // ─── FRED Series (10 allowed series) ───
 
-async function fetchFredSeries() {
+// Fetch one FRED series (observations + metadata in parallel). Throws on a rejected
+// observations fetch so allSettledWithConcurrency records it as a per-series failure —
+// one flaky series can NOT sink the whole run.
+async function fetchOneFredSeries(seriesId, apiKey, fredFetchFn) {
+  const limit = 120;
+  const obsParams = new URLSearchParams({
+    series_id: seriesId, api_key: apiKey, file_type: 'json', sort_order: 'desc', limit: String(limit),
+  });
+  const metaParams = new URLSearchParams({
+    series_id: seriesId, api_key: apiKey, file_type: 'json',
+  });
+
+  const [obsResp, metaResp] = await Promise.allSettled([
+    fredFetchFn(`https://api.stlouisfed.org/fred/series/observations?${obsParams}`, _proxyAuth),
+    fredFetchFn(`https://api.stlouisfed.org/fred/series?${metaParams}`, _proxyAuth),
+  ]);
+
+  if (obsResp.status === 'rejected') {
+    throw new Error(`fetch failed — ${obsResp.reason?.message || obsResp.reason}`);
+  }
+
+  const obsData = obsResp.value;
+  const observations = (obsData.observations || [])
+    .map((o) => { const v = parseFloat(o.value); return Number.isNaN(v) || o.value === '.' ? null : { date: o.date, value: v }; })
+    .filter(Boolean)
+    .reverse();
+
+  let title = seriesId, units = '', frequency = '';
+  if (metaResp.status === 'fulfilled') {
+    const meta = metaResp.value.seriess?.[0];
+    if (meta) { title = meta.title || seriesId; units = meta.units || ''; frequency = meta.frequency || ''; }
+  }
+
+  return { seriesId, title, units, frequency, observations };
+}
+
+// Fetch all FRED series with BOUNDED CONCURRENCY. The old sequential for…of loop breached
+// runSeed's 240s fetch-phase deadline whenever the proxy was down (24 series × ~82s worst-case
+// fredFetchJson budget) → recurring exit-75 "Deploy Crashed!" alerts (issue #5037). deps are
+// injectable for tests (see tests/seed-economy-fred-concurrency.test.mjs).
+export async function fetchFredSeries({ fredFetchFn = fredFetchJson, concurrency = FRED_CONCURRENCY } = {}) {
   const apiKey = process.env.FRED_API_KEY;
   if (!apiKey) throw new Error('Missing FRED_API_KEY');
 
+  const settled = await allSettledWithConcurrency(
+    FRED_SERIES,
+    concurrency,
+    (seriesId) => fetchOneFredSeries(seriesId, apiKey, fredFetchFn),
+  );
+
   const results = {};
-  for (const seriesId of FRED_SERIES) {
-    try {
-      const limit = 120;
-      const obsParams = new URLSearchParams({
-        series_id: seriesId, api_key: apiKey, file_type: 'json', sort_order: 'desc', limit: String(limit),
-      });
-      const metaParams = new URLSearchParams({
-        series_id: seriesId, api_key: apiKey, file_type: 'json',
-      });
+  settled.forEach((s, i) => {
+    const seriesId = FRED_SERIES[i];
+    if (s.status === 'fulfilled') results[seriesId] = s.value;
+    else console.warn(`  FRED ${seriesId}: ${s.reason?.message || s.reason}`);
+  });
 
-      const [obsResp, metaResp] = await Promise.allSettled([
-        fredFetchJson(`https://api.stlouisfed.org/fred/series/observations?${obsParams}`, _proxyAuth),
-        fredFetchJson(`https://api.stlouisfed.org/fred/series?${metaParams}`, _proxyAuth),
-      ]);
-
-      if (obsResp.status === 'rejected') {
-        console.warn(`  FRED ${seriesId}: fetch failed — ${obsResp.reason?.message || obsResp.reason}`);
-        continue;
-      }
-
-      const obsData = obsResp.value;
-      const observations = (obsData.observations || [])
-        .map((o) => { const v = parseFloat(o.value); return Number.isNaN(v) || o.value === '.' ? null : { date: o.date, value: v }; })
-        .filter(Boolean)
-        .reverse();
-
-      let title = seriesId, units = '', frequency = '';
-      if (metaResp.status === 'fulfilled') {
-        const meta = metaResp.value.seriess?.[0];
-        if (meta) { title = meta.title || seriesId; units = meta.units || ''; frequency = meta.frequency || ''; }
-      }
-
-      results[seriesId] = { seriesId, title, units, frequency, observations };
-      await sleep(200); // be nice to FRED
-    } catch (e) {
-      console.warn(`  FRED ${seriesId}: ${e.message}`);
-    }
-  }
   const fredCount = Object.keys(results).length;
   console.log(`  FRED series: ${fredCount}/${FRED_SERIES.length}`);
   if (fredCount === 0) console.warn('  [WARN] FRED series: 0 fetched — all series failed. Check FRED_API_KEY and PROXY_URL. FRED-dependent panels will go stale.');

--- a/tests/seed-economy-fred-concurrency.test.mjs
+++ b/tests/seed-economy-fred-concurrency.test.mjs
@@ -1,0 +1,111 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchFredSeries, FRED_SERIES, FRED_CONCURRENCY } from '../scripts/seed-economy.mjs';
+
+// Reproduces #5037: fetchFredSeries used to loop FRED_SERIES STRICTLY SEQUENTIALLY under
+// runSeed's 240s fetch-phase deadline. fredFetchJson worst case ≈ 3×20s proxy attempts + 20s
+// direct ≈ 82s/series, so with the proxy down 24 series × 82s ≫ 240s → the seed exited 75 and
+// fired a recurring "Deploy Crashed!" alert ~daily. The fix runs the loop with bounded
+// concurrency (allSettledWithConcurrency, FRED_CONCURRENCY). These tests pin that in.
+
+// The seeder logs one line per series (×24) plus per-failure warnings; silence for the file
+// (matches the bigmac suite — a synchronous warn burst can corrupt node:test's IPC parser).
+const realLog = console.log;
+const realWarn = console.warn;
+before(() => { console.log = () => {}; console.warn = () => {}; });
+after(() => { console.log = realLog; console.warn = realWarn; });
+
+// The production default (FRED_CONCURRENCY in scripts/seed-economy.mjs). Hard-coded on purpose:
+// a regression that drops the default back toward sequential (→ 1) must fail this suite, and an
+// intentional bump must consciously update it here.
+const EXPECTED_DEFAULT_CONCURRENCY = 12;
+
+const PER_CALL_MS = 15;
+
+// fetchFredSeries fetches observations + metadata per series in parallel, so a series that is
+// "in flight" holds 2 fredFetchFn calls at once → peak in-flight = 2 × (series in flight).
+function seriesIdFromUrl(url) {
+  return new URL(url).searchParams.get('series_id');
+}
+function isObservations(url) {
+  return url.includes('/series/observations');
+}
+
+// A fake fredFetchJson: sleeps PER_CALL_MS then returns the right shape for the URL kind.
+function makeFakeFred({ failSeries = new Set() } = {}) {
+  return async (url) => {
+    await new Promise((r) => setTimeout(r, PER_CALL_MS));
+    const seriesId = seriesIdFromUrl(url);
+    if (isObservations(url)) {
+      if (failSeries.has(seriesId)) throw new Error(`simulated FRED failure for ${seriesId}`);
+      return { observations: [{ date: '2026-07-01', value: '1.23' }, { date: '2026-07-08', value: '4.56' }] };
+    }
+    return { seriess: [{ title: `${seriesId} title`, units: 'Percent', frequency: 'Daily' }] };
+  };
+}
+
+// Same as makeFakeFred but records the peak number of simultaneously in-flight calls.
+function makeTrackingFred() {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const fn = async (url) => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    try {
+      await new Promise((r) => setTimeout(r, PER_CALL_MS));
+      const seriesId = seriesIdFromUrl(url);
+      return isObservations(url)
+        ? { observations: [{ date: '2026-07-08', value: '4.56' }] }
+        : { seriess: [{ title: `${seriesId} title`, units: 'Percent', frequency: 'Daily' }] };
+    } finally {
+      inFlight -= 1;
+    }
+  };
+  return { fn, get maxInFlight() { return maxInFlight; } };
+}
+
+describe('seed-economy fetchFredSeries — bounded concurrency (#5037)', () => {
+  before(() => { process.env.FRED_API_KEY = 'test-key'; });
+
+  it('caps in-flight FRED calls at the production default when NO override is passed (pins #5037 fix)', async () => {
+    const tracker = makeTrackingFred();
+    await fetchFredSeries({ fredFetchFn: tracker.fn });
+    // 24 series at concurrency 12 = 2 full waves; each in-flight series holds obs+meta → 12×2.
+    assert.equal(
+      tracker.maxInFlight,
+      EXPECTED_DEFAULT_CONCURRENCY * 2,
+      `default run should hold ${EXPECTED_DEFAULT_CONCURRENCY} series (×2 obs+meta = ${EXPECTED_DEFAULT_CONCURRENCY * 2}) in flight (got ${tracker.maxInFlight}); a value of 2 means the loop regressed to SEQUENTIAL and will breach the 240s deadline`,
+    );
+    assert.equal(FRED_CONCURRENCY, EXPECTED_DEFAULT_CONCURRENCY, 'FRED_CONCURRENCY default changed — update EXPECTED_DEFAULT_CONCURRENCY');
+  });
+
+  it('concurrency: 1 collapses to the SEQUENTIAL shape (peak = 2, obs+meta of one series) — documents the bug', async () => {
+    const tracker = makeTrackingFred();
+    await fetchFredSeries({ fredFetchFn: tracker.fn, concurrency: 1 });
+    assert.equal(tracker.maxInFlight, 2, `sequential run should peak at 2 in-flight (got ${tracker.maxInFlight})`);
+  });
+
+  it('fetches every series when all calls succeed', async () => {
+    const results = await fetchFredSeries({ fredFetchFn: makeFakeFred() });
+    assert.equal(Object.keys(results).length, FRED_SERIES.length);
+    for (const id of FRED_SERIES) {
+      assert.ok(results[id], `missing series ${id}`);
+      assert.equal(results[id].seriesId, id);
+      assert.ok(results[id].observations.length > 0, `no observations for ${id}`);
+    }
+  });
+
+  it('isolates per-series failures — a few flaky series do NOT sink the rest', async () => {
+    const failSeries = new Set([FRED_SERIES[0], FRED_SERIES[5], FRED_SERIES[23]]);
+    const results = await fetchFredSeries({ fredFetchFn: makeFakeFred({ failSeries }) });
+    assert.equal(Object.keys(results).length, FRED_SERIES.length - failSeries.size);
+    for (const id of failSeries) assert.equal(results[id], undefined, `failed series ${id} should be absent`);
+    for (const id of FRED_SERIES) if (!failSeries.has(id)) assert.ok(results[id], `healthy series ${id} should be present`);
+  });
+
+  it('returns an empty object (does not throw) when every series fails', async () => {
+    const results = await fetchFredSeries({ fredFetchFn: makeFakeFred({ failSeries: new Set(FRED_SERIES) }) });
+    assert.deepEqual(results, {});
+  });
+});


### PR DESCRIPTION
## Summary

`seed-economy`'s `fetchFredSeries()` looped **24 FRED series sequentially**. When the FRED proxy is down, each `fredFetchJson` burns ~82s worst-case (3×20s proxy attempts + 20s direct fallback), so `24 × 82s` blew past `runSeed`'s **240s fetch-phase deadline** → graceful **exit 75** and a recurring **~daily "Deploy Crashed!" alert** (~03–04 UTC, the proxy's flaky window). It self-heals on the next cron tick, so a status-only Railway scan never surfaced it — Railway rewrites `CRASHED → REMOVED` on the next success. Same class as the already-fixed #4864 (gdelt/grocery/supply-chain) and #4994 (seed-bigmac).

**Fix** (mirrors #4994): run the loop through the shared `allSettledWithConcurrency` helper at **`FRED_CONCURRENCY = 12`** → `⌈24/12⌉ = 2` waves × ~82s ≈ **164s, comfortably under 240s** even with the proxy fully down. In-flight requests peak at 12×2 (obs+meta), well under FRED's 120/min limit. Per-series failures are isolated so one flaky series can't sink the whole run.

Surfaced by the `diagnose-railway-seeders` recovered-crash sweep (re-pulls recently-`REMOVED` deployment logs), which classified it `GRACEFUL·CHRONIC` from two self-healed crashes ~24h apart.

## Test plan

- [x] New `tests/seed-economy-fred-concurrency.test.mjs` (5 cases): pins default concurrency via **max-in-flight** (a regression to sequential → peak 2 → fails), per-series failure isolation, all-fail → `{}`.
- [x] Verified red→green: forced `FRED_CONCURRENCY=1` → test fails (`got 2, expected 24`); restored → 5/5 pass.
- [x] Existing `economy-eia-spr-seed.test.mjs` green (25/25).
- [x] Full `/newpr` gate: typecheck + typecheck:api, biome lint, `test:data` (13,973), edge bundle + edge tests (218), markdown lint, version:check — all pass.

Closes #5037

https://claude.ai/code/session_01J2kCLQdcKY7Wb5MJaecavw