### PR TITLE
fix(digest): prefix story-track reads in previews

### DIFF
--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -29,7 +29,6 @@ import {
   STORY_ALIAS_KEY,
   DIGEST_ACCUMULATOR_KEY,
   STORY_TTL,
-  STORY_TRACK_KEY_PREFIX,
   DIGEST_ACCUMULATOR_TTL,
 } from '../../../_shared/cache-keys';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
@@ -968,9 +967,9 @@ async function readStoryTracks(titleHashes: string[]): Promise<Map<string, Story
   if (titleHashes.length === 0) return new Map();
   const fields = ['firstSeen', 'lastSeen', 'mentionCount', 'sourceCount', 'currentScore', 'peakScore'];
   const commands = titleHashes.map(h => [
-    'HMGET', `${STORY_TRACK_KEY_PREFIX}${h}`, ...fields,
+    'HMGET', STORY_TRACK_KEY(h), ...fields,
   ]);
-  const results = await runRedisPipeline(commands, true);
+  const results = await runRedisPipeline(commands);
   const map = new Map<string, StoryTrack>();
   for (let i = 0; i < titleHashes.length; i++) {
     const vals = results[i]?.result as string[] | null;
@@ -1540,6 +1539,7 @@ export const __testing__ = {
   promoteDiplomacySeverity,
   computeEntityCorroborationSignals,
   computeEntityCorroborationCounts,
+  readStoryTracks,
   resolveMaxAgeMs,
   capLlmUpgrade,
   MAX_DESCRIPTION_LEN,

--- a/tests/news-story-track-prefix-parity.test.mts
+++ b/tests/news-story-track-prefix-parity.test.mts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { STORY_TRACK_KEY } from "../server/_shared/cache-keys.ts";
+import { __resetKeyPrefixCacheForTests } from "../server/_shared/redis.ts";
+import { __testing__ } from "../server/worldmonitor/news/v1/list-feed-digest.ts";
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+  __resetKeyPrefixCacheForTests();
+});
+
+describe("news digest story tracking Redis key prefix parity", () => {
+  it("reads story:track rows through the same preview key-prefix normalization as writes", async () => {
+    const hash = "0123456789abcdef0123456789abcdef";
+    const pipelineBodies: unknown[] = [];
+
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_GIT_COMMIT_SHA = "deadbeefcafebabe";
+    __resetKeyPrefixCacheForTests();
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      assert.equal(String(input), "https://redis.example/pipeline");
+      pipelineBodies.push(JSON.parse(String(init?.body ?? "[]")));
+      return new Response(JSON.stringify([
+        { result: ["1000", "2000", "4", "2", "7", "9"] },
+      ]), { status: 200 });
+    }) as typeof fetch;
+
+    const tracks = await __testing__.readStoryTracks([hash]);
+
+    assert.equal(tracks.get(hash)?.mentionCount, 4);
+    assert.deepEqual(pipelineBodies, [[
+      [
+        "HMGET",
+        `preview:deadbeef:${STORY_TRACK_KEY(hash)}`,
+        "firstSeen",
+        "lastSeen",
+        "mentionCount",
+        "sourceCount",
+        "currentScore",
+        "peakScore",
+      ],
+    ]]);
+  });
+});

--- a/tests/story-identity.test.mjs
+++ b/tests/story-identity.test.mjs
@@ -451,7 +451,8 @@ describe('story key TTL ordering (#4924 external review P2)', () => {
       'sources EXPIRE must not sit in the once-per-hash pre-block — EXPIRE on a missing key is a no-op and the later SADD creates a persistent key');
     assert.ok(!onceBlock.includes("['EXPIRE', peakKey"),
       'peak EXPIRE must not sit in the once-per-hash pre-block');
-    const memberBlock = src.slice(src.indexOf("['ZADD', peakKey, 'GT'"), src.indexOf('runRedisPipeline(commands)'));
+    const memberBlockStart = src.indexOf("['ZADD', peakKey, 'GT'");
+    const memberBlock = src.slice(memberBlockStart, src.indexOf('runRedisPipeline(commands)', memberBlockStart));
     assert.ok(memberBlock.includes("['EXPIRE', sourcesKey") && memberBlock.includes("['EXPIRE', peakKey"),
       'both EXPIREs must follow the creating SADD/ZADD in the per-member block');
     assert.match(src, /STORY_ALIAS_KEY\(memberHash\), hash, 'EX', ttl/, 'alias rows persisted with story TTL');


### PR DESCRIPTION
## Summary

Preview digest story tracking now reads the same prefixed Redis keys it writes, so repeated stories keep their mention history instead of resetting to `BREAKING` on preview deployments. The read path now uses the canonical story-track key helper and lets the shared Redis pipeline apply the environment prefix, matching the writer's behavior.

Fixes #4936.

## Validation

- `/home/elie/github/worldmonitor/node_modules/.bin/tsx --test tests/news-story-track-prefix-parity.test.mts` passes.
- `/home/elie/github/worldmonitor/node_modules/.bin/biome lint server/worldmonitor/news/v1/list-feed-digest.ts tests/news-story-track-prefix-parity.test.mts` passes.
- `git diff --check` passes.
- `tsc --noEmit -p tsconfig.api.json` could not complete in this worktree because local dependency bootstrap failed with `ENOSPC`; the focused checks above used the main checkout's matching installed tooling.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
