### PR TITLE
perf(map): cut INP input-delay — guard rebuild loops, throttle hover query, yield-schedule heavy commit (#5042)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -75,6 +75,7 @@ import { getCachedFuelShortageRegistry } from '@/shared/fuel-shortage-registry-s
 import { tokenizeForMatch, matchKeyword, matchesAnyKeyword, findMatchingKeywords } from '@/utils/keyword-match';
 import { t } from '@/services/i18n';
 import { debounce, rafSchedule, getCurrentTheme } from '@/utils/index';
+import { isInputPending, scheduleYield } from '@/utils/after-paint';
 import { showLayerWarning } from '@/utils/layer-warning';
 import { localizeMapLabels } from '@/utils/map-locale';
 import { getCachedMilitaryBases, preloadMilitaryBases } from '@/services/military-base-config';
@@ -737,7 +738,9 @@ export class DeckGLMap {
    * lands off the measured frame. The gate skips the defer when data is unchanged.
    */
   private readonly heavyGate = new DeferredHeavyCommit<unknown>({
-    schedule: (fn) => { const id = setTimeout(fn, 0); return () => clearTimeout(id); },
+    // Yield the deferred heavy-layer flush off the interaction frame via
+    // scheduler.yield (ahead of clamped timers, behind queued input) — #5042 U4.
+    schedule: (fn) => scheduleYield(fn),
     isAlive: () => !this.renderPaused && !this.webglLost && !!this.maplibreMap,
     onCommit: () => this.updateLayers(true),
   });
@@ -4279,7 +4282,10 @@ export class DeckGLMap {
         return;
       }
       this.pulseTime = now;
-      this.rafUpdateLayers();
+      // Steady-state pulse rebuild: skip when input is queued (#5042 U2). The
+      // terminal settle branch above is never guarded — it must commit the
+      // static end state. pulseTime still advances so no visual state is lost.
+      if (!isInputPending()) this.rafUpdateLayers();
     }, PULSE_UPDATE_INTERVAL_MS);
   }
 
@@ -6300,7 +6306,10 @@ export class DeckGLMap {
       this.tradeAnimationTime = (this.tradeAnimationTime + delta * TRADE_ANIMATION_SPEED) % TRADE_ANIMATION_CYCLE;
       this.tradeAnimationFrame = requestAnimationFrame(animate);
       this.tradeAnimationFrameCount++;
-      if (this.tradeAnimationFrameCount % 2 === 0) this.render();
+      // Skip this decorative rebuild when input is queued so the pending
+      // interaction handler runs sooner (#5042 U2). Frame-predictive and
+      // discrete-only; graceful no-op where isInputPending is unsupported.
+      if (this.tradeAnimationFrameCount % 2 === 0 && !isInputPending()) this.render();
     };
     this.tradeAnimationFrame = requestAnimationFrame(animate);
   }
@@ -7475,11 +7484,15 @@ export class DeckGLMap {
       map.setFilter('country-hover-border', noMatch);
     };
 
-    map.on('mousemove', (e) => {
+    // rAF-throttle the per-mousemove feature query (#5042 U3). The canvas is the
+    // dominant input-delay surface and queryRenderedFeatures is synchronous, so
+    // coalesce to at most one query per frame; the latest pointer position wins.
+    let pendingHoverPoint: maplibregl.Point | null = null;
+    const runHoverQuery = (point: maplibregl.Point) => {
       if (!this.onCountryClick) return;
       try {
         if (!map.getLayer('country-interactive')) return;
-        const features = map.queryRenderedFeatures(e.point, { layers: ['country-interactive'] });
+        const features = map.queryRenderedFeatures(point, { layers: ['country-interactive'] });
         const props = features?.[0]?.properties;
         const iso2 = props?.['ISO3166-1-Alpha-2'] as string | undefined;
         const name = props?.['name'] as string | undefined;
@@ -7497,9 +7510,22 @@ export class DeckGLMap {
           clearHover();
         }
       } catch { /* style not done loading during theme switch */ }
+    };
+    const throttledHoverQuery = rafSchedule(() => {
+      if (pendingHoverPoint) runHoverQuery(pendingHoverPoint);
+    });
+    this.hoverQueryThrottle = throttledHoverQuery;
+
+    map.on('mousemove', (e) => {
+      pendingHoverPoint = e.point;
+      throttledHoverQuery();
     });
 
     map.on('mouseout', () => {
+      // Cancel a queued query so a deferred rAF cannot re-highlight a country the
+      // pointer has already left (R8); clearHover stays immediate.
+      pendingHoverPoint = null;
+      throttledHoverQuery.cancel();
       if (hoveredIso2) {
         hoveredIso2 = null;
         try { clearHover(); } catch { /* style not done loading */ }
@@ -7508,6 +7534,7 @@ export class DeckGLMap {
   }
 
   private countryPulseRaf: number | null = null;
+  private hoverQueryThrottle: ((() => void) & { cancel(): void }) | null = null;
 
   private getHighlightRestOpacity(): { fill: number; border: number } {
     const theme = isLightMapTheme(getMapTheme(getMapProvider())) ? 'light' : 'dark';
@@ -7697,6 +7724,7 @@ export class DeckGLMap {
     this.debouncedFetchBases.cancel();
     this.debouncedFetchAircraft.cancel();
     this.rafUpdateLayers.cancel();
+    this.hoverQueryThrottle?.cancel();
     this.heavyGate.cancel();
 
     if (this.renderRafId !== null) {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -7530,6 +7530,10 @@ export class DeckGLMap {
     this.hoverQueryThrottle = hoverQueryThrottle;
 
     map.on('mousemove', (e) => {
+      if (!this.onCountryClick) {
+        hoverQueryThrottle.cancel();
+        return;
+      }
       hoverQueryThrottle.queue(e.point);
     });
 

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -78,6 +78,13 @@ import { debounce, rafSchedule, getCurrentTheme } from '@/utils/index';
 import { isInputPending, scheduleYield } from '@/utils/after-paint';
 import { showLayerWarning } from '@/utils/layer-warning';
 import { localizeMapLabels } from '@/utils/map-locale';
+import {
+  createCountryHoverQueryController,
+  resolveCountryForPointerInteraction,
+  shouldRenderTradeAnimationFrame,
+  shouldRunInputSensitiveMapWork,
+  type CountryHoverQueryController,
+} from './map/input-delay-interactions';
 import { getCachedMilitaryBases, preloadMilitaryBases } from '@/services/military-base-config';
 import {
   INTEL_HOTSPOTS,
@@ -703,13 +710,18 @@ export class DeckGLMap {
     const y = e.clientY - rect.top;
     const lngLat = this.maplibreMap.unproject([x, y]);
     if (!Number.isFinite(lngLat.lng)) return;
+    const country = resolveCountryForPointerInteraction(
+      { code: this.hoveredCountryIso2, name: this.hoveredCountryName },
+      this.hoverQueryThrottle?.isPending() ?? false,
+      () => this.resolveCountryFromCoordinate(lngLat.lng, lngLat.lat),
+    );
     this.onMapContextMenu({
       lat: lngLat.lat,
       lon: lngLat.lng,
       screenX: e.clientX,
       screenY: e.clientY,
-      countryCode: this.hoveredCountryIso2 ?? undefined,
-      countryName: this.hoveredCountryName ?? undefined,
+      countryCode: country?.code,
+      countryName: country?.name,
     });
   };
   private onLayerChange?: (layer: keyof MapLayers, enabled: boolean, source: 'user' | 'programmatic') => void;
@@ -4285,7 +4297,7 @@ export class DeckGLMap {
       // Steady-state pulse rebuild: skip when input is queued (#5042 U2). The
       // terminal settle branch above is never guarded — it must commit the
       // static end state. pulseTime still advances so no visual state is lost.
-      if (!isInputPending()) this.rafUpdateLayers();
+      if (shouldRunInputSensitiveMapWork(isInputPending)) this.rafUpdateLayers();
     }, PULSE_UPDATE_INTERVAL_MS);
   }
 
@@ -4960,11 +4972,12 @@ export class DeckGLMap {
         let country: { code: string; name: string } | null = null;
         if (isChoropleth && info.object?.properties) {
           country = { code: info.object.properties['ISO3166-1-Alpha-2'] as string, name: info.object.properties.name as string };
-        } else if (this.hoveredCountryIso2 && this.hoveredCountryName) {
-          // Use pre-resolved hover state for instant response
-          country = { code: this.hoveredCountryIso2, name: this.hoveredCountryName };
         } else {
-          country = this.resolveCountryFromCoordinate(lon, lat);
+          country = resolveCountryForPointerInteraction(
+            { code: this.hoveredCountryIso2, name: this.hoveredCountryName },
+            this.hoverQueryThrottle?.isPending() ?? false,
+            () => this.resolveCountryFromCoordinate(lon, lat),
+          );
         }
         // Only fire if we have a country — ocean/no-country clicks are silently ignored
         if (country?.code && country?.name) {
@@ -6309,7 +6322,7 @@ export class DeckGLMap {
       // Skip this decorative rebuild when input is queued so the pending
       // interaction handler runs sooner (#5042 U2). Frame-predictive and
       // discrete-only; graceful no-op where isInputPending is unsupported.
-      if (this.tradeAnimationFrameCount % 2 === 0 && !isInputPending()) this.render();
+      if (shouldRenderTradeAnimationFrame(this.tradeAnimationFrameCount, isInputPending)) this.render();
     };
     this.tradeAnimationFrame = requestAnimationFrame(animate);
   }
@@ -7487,7 +7500,6 @@ export class DeckGLMap {
     // rAF-throttle the per-mousemove feature query (#5042 U3). The canvas is the
     // dominant input-delay surface and queryRenderedFeatures is synchronous, so
     // coalesce to at most one query per frame; the latest pointer position wins.
-    let pendingHoverPoint: maplibregl.Point | null = null;
     const runHoverQuery = (point: maplibregl.Point) => {
       if (!this.onCountryClick) return;
       try {
@@ -7511,21 +7523,20 @@ export class DeckGLMap {
         }
       } catch { /* style not done loading during theme switch */ }
     };
-    const throttledHoverQuery = rafSchedule(() => {
-      if (pendingHoverPoint) runHoverQuery(pendingHoverPoint);
-    });
-    this.hoverQueryThrottle = throttledHoverQuery;
+    const hoverQueryThrottle = createCountryHoverQueryController<maplibregl.Point>(
+      rafSchedule,
+      runHoverQuery,
+    );
+    this.hoverQueryThrottle = hoverQueryThrottle;
 
     map.on('mousemove', (e) => {
-      pendingHoverPoint = e.point;
-      throttledHoverQuery();
+      hoverQueryThrottle.queue(e.point);
     });
 
     map.on('mouseout', () => {
       // Cancel a queued query so a deferred rAF cannot re-highlight a country the
       // pointer has already left (R8); clearHover stays immediate.
-      pendingHoverPoint = null;
-      throttledHoverQuery.cancel();
+      hoverQueryThrottle.cancel();
       if (hoveredIso2) {
         hoveredIso2 = null;
         try { clearHover(); } catch { /* style not done loading */ }
@@ -7534,7 +7545,7 @@ export class DeckGLMap {
   }
 
   private countryPulseRaf: number | null = null;
-  private hoverQueryThrottle: ((() => void) & { cancel(): void }) | null = null;
+  private hoverQueryThrottle: CountryHoverQueryController<maplibregl.Point> | null = null;
 
   private getHighlightRestOpacity(): { fill: number; border: number } {
     const theme = isLightMapTheme(getMapTheme(getMapProvider())) ? 'light' : 'dark';

--- a/src/components/map/input-delay-interactions.ts
+++ b/src/components/map/input-delay-interactions.ts
@@ -1,0 +1,66 @@
+export interface CountryIdentity {
+  code: string;
+  name: string;
+}
+
+export interface CountryHoverCache {
+  code: string | null;
+  name: string | null;
+}
+
+export type CancelableFrameTask = (() => void) & { cancel(): void };
+
+export interface CountryHoverQueryController<TPoint> {
+  queue(point: TPoint): void;
+  cancel(): void;
+  isPending(): boolean;
+}
+
+export function shouldRunInputSensitiveMapWork(isInputPending: () => boolean): boolean {
+  return !isInputPending();
+}
+
+export function shouldRenderTradeAnimationFrame(frameCount: number, isInputPending: () => boolean): boolean {
+  return frameCount % 2 === 0 && shouldRunInputSensitiveMapWork(isInputPending);
+}
+
+export function resolveCountryForPointerInteraction(
+  hover: CountryHoverCache,
+  hoverQueryPending: boolean,
+  resolveFromCoordinate: () => CountryIdentity | null,
+): CountryIdentity | null {
+  if (!hoverQueryPending && hover.code && hover.name) {
+    return { code: hover.code, name: hover.name };
+  }
+  return resolveFromCoordinate();
+}
+
+export function createCountryHoverQueryController<TPoint>(
+  scheduleFrame: (run: () => void) => CancelableFrameTask,
+  runQuery: (point: TPoint) => void,
+): CountryHoverQueryController<TPoint> {
+  let pendingPoint: TPoint | null = null;
+  let pending = false;
+  const frameTask = scheduleFrame(() => {
+    const point = pendingPoint;
+    pendingPoint = null;
+    pending = false;
+    if (point !== null) runQuery(point);
+  });
+
+  return {
+    queue(point: TPoint): void {
+      pendingPoint = point;
+      pending = true;
+      frameTask();
+    },
+    cancel(): void {
+      pendingPoint = null;
+      pending = false;
+      frameTask.cancel();
+    },
+    isPending(): boolean {
+      return pending;
+    },
+  };
+}

--- a/src/utils/after-paint.ts
+++ b/src/utils/after-paint.ts
@@ -57,3 +57,27 @@ export function yieldToMain(): Promise<void> {
   }
   return new Promise((resolve) => { setTimeout(resolve, 0); });
 }
+
+/**
+ * Whether the browser currently has queued input (a click/keypress) waiting to
+ * be dispatched. Recurring, animation-driven work on the input path calls this
+ * and skips its tick when input is pending, so the interaction handler can run
+ * sooner (#5042).
+ *
+ * Feature-detected: `navigator.scheduling.isInputPending` is Chromium-only,
+ * which matches INP being a Chromium-measured metric. Returns `false` wherever
+ * the API is absent (Firefox/Safari/node), so callers degrade to today's
+ * behavior with no functional change.
+ *
+ * Called with no arguments, so it reports DISCRETE input (clicks/keys) only —
+ * `includeContinuous` defaults to `false`. That is the correct scope for the
+ * click/keypress control targets; passing `{ includeContinuous: true }` would
+ * also report pointermove/wheel/drag and stall callers during any hover/pan.
+ */
+export function isInputPending(): boolean {
+  const scheduling = (globalThis as unknown as {
+    navigator?: { scheduling?: { isInputPending?: () => boolean } };
+  }).navigator?.scheduling;
+  if (typeof scheduling?.isInputPending !== 'function') return false;
+  return scheduling.isInputPending();
+}

--- a/src/utils/after-paint.ts
+++ b/src/utils/after-paint.ts
@@ -94,6 +94,16 @@ export function isInputPending(): boolean {
  */
 export function scheduleYield(run: () => void): () => void {
   let aborted = false;
-  void yieldToMain().then(() => { if (!aborted) run(); });
+  void yieldToMain().then(() => {
+    if (aborted) return;
+    try {
+      run();
+    } catch (err) {
+      // Surface a throw from the deferred flush on the global error channel
+      // (window.onerror -> Sentry) exactly as the replaced setTimeout(fn, 0)
+      // did, rather than leaving it as a floating promise rejection.
+      setTimeout(() => { throw err; });
+    }
+  });
   return () => { aborted = true; };
 }

--- a/src/utils/after-paint.ts
+++ b/src/utils/after-paint.ts
@@ -81,3 +81,19 @@ export function isInputPending(): boolean {
   if (typeof scheduling?.isInputPending !== 'function') return false;
   return scheduling.isInputPending();
 }
+
+/**
+ * Adapt `yieldToMain()` to a fire-once scheduler with a cancel handle:
+ * `scheduleYield(run)` runs `run` after the yield resolves and returns a cancel
+ * that prevents it. `DeferredHeavyCommit` (#4558) depends on this shape to
+ * coalesce a burst of stages into one flush and to drop the flush on teardown;
+ * the `yieldToMain` promise can't be cleared, so an abort flag preserves those
+ * semantics. Prefer this over `setTimeout(0)`: `scheduler.yield()` resumes ahead
+ * of clamped timer work (but still behind queued input), lowering commit latency
+ * without newly blocking the input path (#5042 U4).
+ */
+export function scheduleYield(run: () => void): () => void {
+  let aborted = false;
+  void yieldToMain().then(() => { if (!aborted) run(); });
+  return () => { aborted = true; };
+}

--- a/tests/after-paint-input-pending.test.mts
+++ b/tests/after-paint-input-pending.test.mts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isInputPending } from '@/utils/after-paint';
+
+type Scheduling = { isInputPending?: (...args: unknown[]) => boolean };
+
+/**
+ * Swap `globalThis.navigator` around a call. Node 22+ ships a real `navigator`
+ * global (configurable), so save/restore its property descriptor rather than a
+ * plain assignment — an ESM (strict-mode) assignment to a getter-only global
+ * would throw.
+ */
+function withNavigator<T>(value: { scheduling?: Scheduling } | undefined, run: () => T): T {
+  const desc = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  if (value === undefined) {
+    delete (globalThis as { navigator?: unknown }).navigator;
+  } else {
+    Object.defineProperty(globalThis, 'navigator', { value, configurable: true, writable: true });
+  }
+  try {
+    return run();
+  } finally {
+    if (desc) Object.defineProperty(globalThis, 'navigator', desc);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+  }
+}
+
+test('isInputPending returns true when the API reports pending input (#5042)', () => {
+  const val = withNavigator({ scheduling: { isInputPending: () => true } }, () => isInputPending());
+  assert.equal(val, true);
+});
+
+test('isInputPending returns false when the API reports no pending input', () => {
+  const val = withNavigator({ scheduling: { isInputPending: () => false } }, () => isInputPending());
+  assert.equal(val, false);
+});
+
+test('isInputPending returns false when navigator.scheduling lacks isInputPending (graceful, R6)', () => {
+  const val = withNavigator({ scheduling: {} }, () => isInputPending());
+  assert.equal(val, false);
+});
+
+test('isInputPending returns false when navigator.scheduling is absent (R6)', () => {
+  const val = withNavigator({}, () => isInputPending());
+  assert.equal(val, false);
+});
+
+test('isInputPending returns false when navigator is absent (node/SSR, R6)', () => {
+  const val = withNavigator(undefined, () => isInputPending());
+  assert.equal(val, false);
+});
+
+test('isInputPending calls the API with no arguments (discrete-only scope)', () => {
+  let receivedArgs: unknown[] | null = null;
+  withNavigator(
+    { scheduling: { isInputPending: (...args: unknown[]) => { receivedArgs = args; return false; } } },
+    () => isInputPending(),
+  );
+  assert.deepEqual(receivedArgs, [], 'no-arg call keeps includeContinuous at its false default');
+});

--- a/tests/after-paint-yield.test.mts
+++ b/tests/after-paint-yield.test.mts
@@ -74,3 +74,31 @@ test('scheduleYield cancel before resolution prevents the callback (coalesce/tea
   });
   assert.equal(ran, 0, 'a pre-resolution cancel drops the flush');
 });
+
+test('scheduleYield rethrows deferred callback errors on the timer channel (#5042 U4)', async () => {
+  const sentinel = new Error('deferred flush failed');
+  let timerHandler: (() => void) | null = null;
+  const originalSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = ((handler: Parameters<typeof globalThis.setTimeout>[0]) => {
+    assert.equal(typeof handler, 'function', 'scheduleYield should surface errors with a function timer');
+    timerHandler = handler as () => void;
+    return 0 as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+
+  try {
+    await withScheduler({ yield: () => Promise.resolve() }, async () => {
+      scheduleYield(() => { throw sentinel; });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.ok(timerHandler, 'failed deferred flush should be rethrown via setTimeout');
+    assert.throws(
+      () => { timerHandler?.(); },
+      (err) => err === sentinel,
+    );
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});

--- a/tests/after-paint-yield.test.mts
+++ b/tests/after-paint-yield.test.mts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { yieldToMain } from '@/utils/after-paint';
+import { yieldToMain, scheduleYield } from '@/utils/after-paint';
 
 type SchedulerHost = { scheduler?: { yield?: () => Promise<void> } };
 
@@ -50,4 +50,27 @@ test('yieldToMain returns a Promise in both paths (signature preserved)', () => 
   assert.ok(withYield instanceof Promise);
   assert.ok(withoutYield instanceof Promise);
   return Promise.all([withYield, withoutYield]);
+});
+
+test('scheduleYield runs the callback after the yield resolves (#5042 U4)', async () => {
+  let ran = 0;
+  await withScheduler({ yield: () => Promise.resolve() }, async () => {
+    scheduleYield(() => { ran += 1; });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  assert.equal(ran, 1, 'callback fires once after the yield');
+});
+
+test('scheduleYield cancel before resolution prevents the callback (coalesce/teardown, U4)', async () => {
+  let ran = 0;
+  await withScheduler({ yield: () => Promise.resolve() }, async () => {
+    const cancel = scheduleYield(() => { ran += 1; });
+    cancel();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  assert.equal(ran, 0, 'a pre-resolution cancel drops the flush');
 });

--- a/tests/map-input-delay-interactions.test.mts
+++ b/tests/map-input-delay-interactions.test.mts
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createCountryHoverQueryController,
+  resolveCountryForPointerInteraction,
+  shouldRenderTradeAnimationFrame,
+  shouldRunInputSensitiveMapWork,
+  type CancelableFrameTask,
+} from '@/components/map/input-delay-interactions';
+
+function createManualFrameScheduler(): {
+  scheduleFrame: (run: () => void) => CancelableFrameTask;
+  flush: () => void;
+  hasQueuedFrame: () => boolean;
+} {
+  let queued: (() => void) | null = null;
+  return {
+    scheduleFrame(run: () => void): CancelableFrameTask {
+      const task = (() => { queued = run; }) as CancelableFrameTask;
+      task.cancel = () => { queued = null; };
+      return task;
+    },
+    flush(): void {
+      const run = queued;
+      queued = null;
+      run?.();
+    },
+    hasQueuedFrame(): boolean {
+      return queued !== null;
+    },
+  };
+}
+
+test('shouldRunInputSensitiveMapWork skips work only while input is pending (#5042 U2)', () => {
+  assert.equal(shouldRunInputSensitiveMapWork(() => false), true);
+  assert.equal(shouldRunInputSensitiveMapWork(() => true), false);
+});
+
+test('shouldRenderTradeAnimationFrame keeps the every-other-frame gate and input skip (#5042 U2)', () => {
+  assert.equal(shouldRenderTradeAnimationFrame(1, () => false), false, 'odd frames stay skipped');
+  assert.equal(shouldRenderTradeAnimationFrame(2, () => false), true, 'even frames render without input pressure');
+  assert.equal(shouldRenderTradeAnimationFrame(2, () => true), false, 'even frames skip while input is pending');
+});
+
+test('country hover query controller coalesces mouse moves so the latest point wins (#5042 U3)', () => {
+  const frames = createManualFrameScheduler();
+  const queried: number[] = [];
+  const controller = createCountryHoverQueryController<number>(frames.scheduleFrame, (point) => {
+    queried.push(point);
+  });
+
+  controller.queue(1);
+  controller.queue(2);
+
+  assert.equal(controller.isPending(), true);
+  assert.equal(frames.hasQueuedFrame(), true);
+  frames.flush();
+  assert.deepEqual(queried, [2], 'only the latest queued point is queried');
+  assert.equal(controller.isPending(), false);
+});
+
+test('country hover query controller cancels queued work on mouseout/destroy (#5042 U3)', () => {
+  const frames = createManualFrameScheduler();
+  const queried: string[] = [];
+  const controller = createCountryHoverQueryController<string>(frames.scheduleFrame, (point) => {
+    queried.push(point);
+  });
+
+  controller.queue('inside-country');
+  controller.cancel();
+
+  assert.equal(controller.isPending(), false);
+  assert.equal(frames.hasQueuedFrame(), false);
+  frames.flush();
+  assert.deepEqual(queried, [], 'cancelled hover query must not re-highlight after pointer exit');
+});
+
+test('pointer country resolution uses cached hover only when no hover query is pending', () => {
+  let fallbackCalls = 0;
+  const fallback = () => {
+    fallbackCalls += 1;
+    return { code: 'CA', name: 'Canada' };
+  };
+
+  assert.deepEqual(
+    resolveCountryForPointerInteraction({ code: 'US', name: 'United States' }, false, fallback),
+    { code: 'US', name: 'United States' },
+  );
+  assert.equal(fallbackCalls, 0, 'fresh hover cache should avoid sync coordinate lookup');
+
+  assert.deepEqual(
+    resolveCountryForPointerInteraction({ code: 'US', name: 'United States' }, true, fallback),
+    { code: 'CA', name: 'Canada' },
+  );
+  assert.equal(fallbackCalls, 1, 'pending hover cache is stale and must fall back to the click coordinate');
+});


### PR DESCRIPTION
Closes #5042 (input-delay axis). Plan: `docs/plans/2026-07-08-001-perf-map-input-delay-inp-plan.md`.

## What & why

Cuts the main-thread work that's already running **when** a pointer/keypress lands on a map control, so the interaction's handler can start sooner — the **input-delay** axis of INP (31% of field bad-INP, previously unowned).

Before writing code, a fresh Sentry `onINP` pull (800 events) validated where to aim:
- Input-delay-dominant interactions are **99% `loadState=complete`** (post-load steady-state, not hydration congestion).
- The dominant surface is the **map/canvas**: `canvas.maplibregl-canvas` + unselectable `unknown` + scene-canvas ≈ **47%** of input-delay-dominant events.
- The time-range buttons (the issue's headline "~1985ms" target) were a minor 4 events — so the synchronous `rebuildProtestSupercluster()` is **not** the dominant source and stays deferred.

That makes **U3 the highest-yield lever** and confirms the surgical bundle targets the right surface.

## Changes

- **U1** — `isInputPending()` helper in `src/utils/after-paint.ts`. Feature-detected (Chromium-only, graceful `false` elsewhere — matches INP being a Chromium metric). No-arg call = **discrete input only** (`includeContinuous` defaults false), the correct scope for click/keypress targets.
- **U2** — guard the two recurring full-rebuild loops (trade-route animation, news pulse) on `!isInputPending()` so a queued interaction isn't serially delayed behind a `buildLayers` rebuild. The terminal pulse-settle render is never guarded; animation state still advances, so no visual state is lost. Frame-predictive (curbs sustained/repeated interactions; can't interrupt an in-flight build).
- **U3** — rAF-throttle the per-`mousemove` `queryRenderedFeatures` country-hover query on the canvas (one query per frame max). Cancels the pending query on `mouseout` **and** teardown so a deferred rAF can't re-highlight a country the pointer already left.
- **U4** — route the `DeferredHeavyCommit` flush through a `yieldToMain`-backed adapter (`scheduler.yield`, ahead of clamped timers) instead of `setTimeout(0)`, matching the module's own doc. Adapter preserves the gate's coalesce/teardown-cancel contract via an abort flag.

## Verification

- `npm run test:data` (relevant): **20/20** — new `isInputPending` + `scheduleYield` coverage and the `DeferredHeavyCommit` regression suite unchanged.
- `npm run typecheck`: clean. `biome` on changed files: clean.
- Browser smoke (local dev): map renders, all controls present, **zero runtime errors** from the changed code across synthetic hover events. Country-hover *highlight* couldn't be positively exercised locally (country boundaries need live data), and the hover change is a pure refactor of the existing query logic.
- **Field verification is a post-deploy follow-up, not a merge gate** (per the plan's acceptance): a fresh `onINP` pull should show the input-delay share drop and the map/canvas targets leave the poor bucket.

## Review notes

- Reviewed by a 4-persona doc-review pass; findings folded in (notably the `isInputPending()` discrete-only correction and a hover re-highlight-after-`mouseout` race, both fixed here).
- No auto-merge — left for manual review.

https://claude.ai/code/session_01Gc3t8s5cdgecwXGxzdq5Xn