### PR TITLE
perf(onboarding): defer mission-preset auto-open to idle after paint

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -91,6 +91,7 @@ import { t } from '@/services/i18n';
 import { TvModeController } from '@/services/tv-mode';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { scheduleAfterFirstPaint } from '@/utils/after-paint';
 import { escapeHtml } from '@/utils/sanitize';
 import { buildEmbedIframeSnippet, buildEmbedMapUrl, type EmbedVariant } from '@/embed/embed-url';
 import { createSettingsButton } from '@/components/settings-button';
@@ -795,10 +796,16 @@ export class EventHandlerManager implements AppModule {
       !loadStoredMissionPreset() &&
       !isMissionPresetPromptDismissed();
     if (shouldPrompt) {
-      window.setTimeout(() => {
+      // Defer the onboarding auto-open to browser idle after first paint so it
+      // never competes with load or first-interaction work — it was a fixed
+      // 700ms timeout that also forced a layout read (getBoundingClientRect +
+      // offsetHeight) on the post-load path. Re-check state at fire time since
+      // the idle wait can outlast the old fixed delay.
+      scheduleAfterFirstPaint(() => {
         if (this.ctx.isDestroyed) return;
+        if (loadStoredMissionPreset() || isMissionPresetPromptDismissed()) return;
         this.openMissionPresetPopover(document.getElementById('missionPresetBtn'), false);
-      }, 700);
+      });
     }
   }
 


### PR DESCRIPTION
Defers the mission-preset onboarding popover's auto-open off the load path.

## What & why
On desktop with no chosen preset, the mission-preset popover auto-opened via a fixed `window.setTimeout(…, 700)` and positioned itself with a **forced layout read** (`getBoundingClientRect()` + `offsetHeight`, `event-handlers.ts`). That lands ~700ms post-load — squarely in the window we're optimizing for **input delay (#5042)** and **forced reflow (#5029)**.

This routes the auto-open through `scheduleAfterFirstPaint` (`requestIdleCallback` after first paint, 3s timeout fallback) so it yields to load and first-interaction work rather than competing with it. It also **re-checks** `loadStoredMissionPreset()`/`isMissionPresetPromptDismissed()` at fire time, since idle can outlast the old fixed 700ms (avoids opening the popover after the user already picked/dismissed during the wait).

No network request is involved — opening the popover builds cards from an in-memory constant — so this saves **main-thread time**, not a request. The onboarding nudge itself is unchanged; only its timing moves to idle.

## Verification
- `npm run typecheck`: clean. `biome`: clean.
- Behavior preserved: same `shouldPrompt` gate; `scheduleAfterFirstPaint` fires within 3s via the rIC timeout even if the browser never idles.

No auto-merge — left for manual review.

https://claude.ai/code/session_01Gc3t8s5cdgecwXGxzdq5Xn