### PR TITLE
fix(checkout): quiet active subscription blocks

### DIFF
--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -27,6 +27,7 @@ const CONVEX_SITE_URL =
   (process.env.CONVEX_URL ?? '').replace('.convex.cloud', '.convex.site');
 const RELAY_SHARED_SECRET = process.env.RELAY_SHARED_SECRET ?? '';
 const ACTIVE_SUBSCRIPTION_EXISTS = 'ACTIVE_SUBSCRIPTION_EXISTS';
+const CHECKOUT_RELAY_USER_AGENT = 'worldmonitor-checkout-edge/1.0';
 
 type CreateCheckoutDeps = {
   validateBearerToken: typeof validateBearerToken;
@@ -161,6 +162,7 @@ export default async function handler(
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${RELAY_SHARED_SECRET}`,
+        'User-Agent': CHECKOUT_RELAY_USER_AGENT,
       },
       body: JSON.stringify({
         userId: session.userId,

--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -26,6 +26,34 @@ const CONVEX_SITE_URL =
   process.env.CONVEX_SITE_URL ??
   (process.env.CONVEX_URL ?? '').replace('.convex.cloud', '.convex.site');
 const RELAY_SHARED_SECRET = process.env.RELAY_SHARED_SECRET ?? '';
+const ACTIVE_SUBSCRIPTION_EXISTS = 'ACTIVE_SUBSCRIPTION_EXISTS';
+
+type CreateCheckoutDeps = {
+  validateBearerToken: typeof validateBearerToken;
+  fetch: typeof fetch;
+};
+
+type RelayErrorBody = {
+  error?: unknown;
+  message?: unknown;
+  subscription?: unknown;
+  pendingPayment?: unknown;
+};
+
+function createDefaultCreateCheckoutDeps(): CreateCheckoutDeps {
+  return {
+    validateBearerToken,
+    fetch: (...args) => globalThis.fetch(...args),
+  };
+}
+
+let createCheckoutDeps: CreateCheckoutDeps = createDefaultCreateCheckoutDeps();
+
+export function __setCreateCheckoutDepsForTests(overrides: Partial<CreateCheckoutDeps> | null): void {
+  createCheckoutDeps = overrides
+    ? { ...createDefaultCreateCheckoutDeps(), ...overrides }
+    : createDefaultCreateCheckoutDeps();
+}
 
 function json(body: unknown, status: number, cors: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {
@@ -36,6 +64,20 @@ function json(body: unknown, status: number, cors: Record<string, string>): Resp
       ...cors,
     },
   });
+}
+
+function checkoutBlockedBody(data: RelayErrorBody): {
+  error: string;
+  message: string;
+  subscription: unknown;
+  pendingPayment: unknown;
+} {
+  return {
+    error: typeof data?.error === 'string' ? data.error : 'CHECKOUT_BLOCKED',
+    message: typeof data?.message === 'string' ? data.message : 'This checkout could not be started.',
+    subscription: data?.subscription,
+    pendingPayment: data?.pendingPayment,
+  };
 }
 
 export default async function handler(
@@ -64,7 +106,7 @@ export default async function handler(
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
   if (!token) return json({ error: 'Unauthorized' }, 401, cors);
 
-  const session = await validateBearerToken(token);
+  const session = await createCheckoutDeps.validateBearerToken(token);
   if (!session.valid || !session.userId) {
     return json({ error: 'Unauthorized' }, 401, cors);
   }
@@ -114,7 +156,7 @@ export default async function handler(
 
   // Relay to Convex
   try {
-    const resp = await fetch(`${CONVEX_SITE_URL}/relay/create-checkout`, {
+    const resp = await createCheckoutDeps.fetch(`${CONVEX_SITE_URL}/relay/create-checkout`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -135,7 +177,6 @@ export default async function handler(
 
     const data = await resp.json();
     if (!resp.ok) {
-      console.error('[create-checkout] Relay error:', resp.status, data);
       if (resp.status === 409) {
         // Two distinct blocks share 409; the client discriminates on `error`
         // (ACTIVE_SUBSCRIPTION_EXISTS vs PAYMENT_IN_PROGRESS, #4438). Forward
@@ -144,13 +185,14 @@ export default async function handler(
         // to ACTIVE_SUBSCRIPTION_EXISTS would silently misroute a PAYMENT_IN_PROGRESS
         // (or any future) block to the wrong dialog — so fall back to a generic
         // code that the client classifies as a neutral block, not a duplicate sub.
-        return completeStandaloneIdempotency(idempotency, json({
-          error: data?.error ?? 'CHECKOUT_BLOCKED',
-          message: data?.message ?? 'This checkout could not be started.',
-          subscription: data?.subscription,
-          pendingPayment: data?.pendingPayment,
-        }, 409, cors));
+        const blockedBody = checkoutBlockedBody(data as RelayErrorBody);
+        if (blockedBody.error === ACTIVE_SUBSCRIPTION_EXISTS) {
+          return completeStandaloneIdempotency(idempotency, json(blockedBody, 409, cors));
+        }
+        console.error('[create-checkout] Relay error:', resp.status, data);
+        return completeStandaloneIdempotency(idempotency, json(blockedBody, 409, cors));
       }
+      console.error('[create-checkout] Relay error:', resp.status, data);
       return completeStandaloneIdempotency(idempotency, json({ error: data?.error || 'Checkout creation failed' }, 502, cors));
     }
 

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -986,12 +986,16 @@ export async function startCheckout(
  * Capture them at `info` so the funnel is still observable without
  * triggering alerts. Everything else stays at `error`.
  */
-type SentryLevel = 'error' | 'info';
+export type SentryLevel = 'error' | 'info';
 const INFO_LEVEL_CODES: ReadonlySet<CheckoutErrorCode> = new Set([
   'unauthorized',
   'session_expired',
   'duplicate_subscription',
 ]);
+
+export function checkoutErrorTelemetryLevel(error: Pick<CheckoutError, 'code'>): SentryLevel {
+  return INFO_LEVEL_CODES.has(error.code) ? 'info' : 'error';
+}
 
 function reportCheckoutError(
   error: CheckoutError,
@@ -999,7 +1003,7 @@ function reportCheckoutError(
   caught?: unknown,
   upstream?: UpstreamSnapshot,
 ): void {
-  const level: SentryLevel = INFO_LEVEL_CODES.has(error.code) ? 'info' : 'error';
+  const level = checkoutErrorTelemetryLevel(error);
   const payload = {
     level,
     tags: {

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -981,8 +981,8 @@ export async function startCheckout(
  *
  * Unauthorized / session_expired are *expected* user states (nobody
  * signed in yet, Clerk session aged out) rather than engineering
- * failures. They fire on every free-tier pricing click, so reporting
- * them at `error` level would drown Sentry in non-actionable noise.
+ * failures. duplicate_subscription is also expected when an existing
+ * Pro user clicks checkout again and should route to billing instead.
  * Capture them at `info` so the funnel is still observable without
  * triggering alerts. Everything else stays at `error`.
  */
@@ -990,6 +990,7 @@ type SentryLevel = 'error' | 'info';
 const INFO_LEVEL_CODES: ReadonlySet<CheckoutErrorCode> = new Set([
   'unauthorized',
   'session_expired',
+  'duplicate_subscription',
 ]);
 
 function reportCheckoutError(

--- a/tests/checkout-report-error.test.mts
+++ b/tests/checkout-report-error.test.mts
@@ -92,6 +92,10 @@ describe('reportCheckoutError call sites in src/services/checkout.ts', () => {
     );
   });
 
+  it('keeps duplicate-subscription checkout attempts at info level', () => {
+    assert.match(src, /INFO_LEVEL_CODES[\s\S]*'duplicate_subscription'/);
+  });
+
   it('no-user is the only call site marked for skip', () => {
     for (const action of knownActions) {
       const expected = action === 'no-user';

--- a/tests/checkout-report-error.test.mts
+++ b/tests/checkout-report-error.test.mts
@@ -20,6 +20,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { shouldSkipSentryForAction, SENTRY_SKIP_ACTIONS } from '../src/services/checkout-sentry-policy.ts';
+import { checkoutErrorTelemetryLevel } from '../src/services/checkout.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -93,7 +94,9 @@ describe('reportCheckoutError call sites in src/services/checkout.ts', () => {
   });
 
   it('keeps duplicate-subscription checkout attempts at info level', () => {
-    assert.match(src, /INFO_LEVEL_CODES[\s\S]*'duplicate_subscription'/);
+    assert.equal(checkoutErrorTelemetryLevel({ code: 'duplicate_subscription' }), 'info');
+    assert.equal(checkoutErrorTelemetryLevel({ code: 'payment_in_progress' }), 'error');
+    assert.equal(checkoutErrorTelemetryLevel({ code: 'service_unavailable' }), 'error');
   });
 
   it('no-user is the only call site marked for skip', () => {

--- a/tests/create-checkout-active-subscription.test.mts
+++ b/tests/create-checkout-active-subscription.test.mts
@@ -71,5 +71,41 @@ describe('/api/create-checkout ACTIVE_SUBSCRIPTION_EXISTS relay handling', () =>
     });
     assert.equal(consoleError.mock.calls.length, 0);
     assert.equal(relayFetch.mock.calls.length, 1);
+    const relayInit = relayFetch.mock.calls[0].arguments[1] as RequestInit;
+    assert.equal((relayInit.headers as Record<string, string>)['User-Agent'], 'worldmonitor-checkout-edge/1.0');
+  });
+
+  it('continues logging and forwarding non-active 409 checkout blocks', async () => {
+    const mod = await importFreshCreateCheckout();
+    const consoleError = mock.method(console, 'error', () => {});
+    const relayFetch = mock.fn(async () =>
+      Response.json(
+        {
+          error: 'PAYMENT_IN_PROGRESS',
+          message: 'A Pro Monthly payment is already in progress',
+          pendingPayment: { planKey: 'pro_monthly' },
+        },
+        { status: 409 },
+      ),
+    );
+
+    mod.__setCreateCheckoutDepsForTests({
+      validateBearerToken: async () => ({
+        valid: true,
+        userId: 'user_pending_payment',
+      }),
+      fetch: relayFetch,
+    });
+
+    const res = await mod.default(makeCheckoutRequest());
+
+    assert.equal(res.status, 409);
+    assert.deepEqual(await res.json(), {
+      error: 'PAYMENT_IN_PROGRESS',
+      message: 'A Pro Monthly payment is already in progress',
+      pendingPayment: { planKey: 'pro_monthly' },
+    });
+    assert.equal(consoleError.mock.calls.length, 1);
+    assert.equal(String(consoleError.mock.calls[0].arguments[0]), '[create-checkout] Relay error:');
   });
 });

--- a/tests/create-checkout-active-subscription.test.mts
+++ b/tests/create-checkout-active-subscription.test.mts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+const originalEnv = { ...process.env };
+
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+async function importFreshCreateCheckout() {
+  process.env.CONVEX_SITE_URL = 'https://convex.test';
+  process.env.RELAY_SHARED_SECRET = 'relay-secret';
+  return import(`../api/create-checkout.ts?test=${Date.now()}-${Math.random()}`);
+}
+
+function makeCheckoutRequest(): Request {
+  return new Request('https://worldmonitor.app/api/create-checkout', {
+    method: 'POST',
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      Authorization: 'Bearer clerk-token',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      productId: 'pdt_pro_monthly',
+      returnUrl: 'https://worldmonitor.app/?wm_checkout=return',
+    }),
+  });
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  restoreEnv();
+});
+
+describe('/api/create-checkout ACTIVE_SUBSCRIPTION_EXISTS relay handling', () => {
+  it('forwards the typed duplicate-subscription response without logging a production error', async () => {
+    const mod = await importFreshCreateCheckout();
+    const consoleError = mock.method(console, 'error', () => {});
+    const relayFetch = mock.fn(async () =>
+      Response.json(
+        {
+          error: 'ACTIVE_SUBSCRIPTION_EXISTS',
+          message: 'Active Pro Monthly subscription already exists',
+          subscription: { planKey: 'pro_monthly' },
+        },
+        { status: 409 },
+      ),
+    );
+
+    mod.__setCreateCheckoutDepsForTests({
+      validateBearerToken: async () => ({
+        valid: true,
+        userId: 'user_existing_pro',
+        email: 'pro@example.com',
+        name: 'Existing Pro',
+      }),
+      fetch: relayFetch,
+    });
+
+    const res = await mod.default(makeCheckoutRequest());
+
+    assert.equal(res.status, 409);
+    assert.deepEqual(await res.json(), {
+      error: 'ACTIVE_SUBSCRIPTION_EXISTS',
+      message: 'Active Pro Monthly subscription already exists',
+      subscription: { planKey: 'pro_monthly' },
+    });
+    assert.equal(consoleError.mock.calls.length, 0);
+    assert.equal(relayFetch.mock.calls.length, 1);
+  });
+});

--- a/tests/create-checkout-active-subscription.test.mts
+++ b/tests/create-checkout-active-subscription.test.mts
@@ -108,4 +108,40 @@ describe('/api/create-checkout ACTIVE_SUBSCRIPTION_EXISTS relay handling', () =>
     assert.equal(consoleError.mock.calls.length, 1);
     assert.equal(String(consoleError.mock.calls[0].arguments[0]), '[create-checkout] Relay error:');
   });
+
+  it('continues logging non-409 relay failures before returning the fallback envelope', async () => {
+    const mod = await importFreshCreateCheckout();
+    const consoleError = mock.method(console, 'error', () => {});
+    const relayFetch = mock.fn(async () =>
+      Response.json(
+        {
+          error: 'UPSTREAM_CHECKOUT_FAILURE',
+          message: 'Dodo checkout temporarily failed',
+        },
+        { status: 500 },
+      ),
+    );
+
+    mod.__setCreateCheckoutDepsForTests({
+      validateBearerToken: async () => ({
+        valid: true,
+        userId: 'user_retryable_failure',
+      }),
+      fetch: relayFetch,
+    });
+
+    const res = await mod.default(makeCheckoutRequest());
+
+    assert.equal(res.status, 502);
+    assert.deepEqual(await res.json(), {
+      error: 'UPSTREAM_CHECKOUT_FAILURE',
+    });
+    assert.equal(consoleError.mock.calls.length, 1);
+    assert.equal(String(consoleError.mock.calls[0].arguments[0]), '[create-checkout] Relay error:');
+    assert.equal(consoleError.mock.calls[0].arguments[1], 500);
+    assert.deepEqual(consoleError.mock.calls[0].arguments[2], {
+      error: 'UPSTREAM_CHECKOUT_FAILURE',
+      message: 'Dodo checkout temporarily failed',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Existing Pro users who click checkout again now take the expected duplicate-subscription path without creating production-error noise. `/api/create-checkout` still returns the typed `ACTIVE_SUBSCRIPTION_EXISTS` 409 body that the dashboard uses to show the duplicate-subscription billing dialog, but the edge gateway no longer logs that expected relay block as an error.

The browser checkout reporter also treats `duplicate_subscription` as info-level telemetry, matching the expected-user-state handling already used for auth/session checkout states.

## Validation
- `./node_modules/.bin/tsx --test tests/create-checkout-active-subscription.test.mts`
- `./node_modules/.bin/tsx --test tests/checkout-error-classification.test.mts`
- `./node_modules/.bin/tsx --test tests/checkout-report-error.test.mts`
- `npm run typecheck:api`
- `npm run typecheck`
- `git diff --check`

## Post-Deploy Monitoring & Validation
- Watch Vercel/function logs for `[create-checkout] Relay error` and confirm `ACTIVE_SUBSCRIPTION_EXISTS` checkout attempts no longer appear there.
- Watch Sentry events tagged `component=dodo-checkout` and `code=duplicate_subscription`; healthy signal is info-level observability without error alerts for existing Pro users.
- Failure signal: duplicate-subscription attempts still arrive as error-level checkout events or lose the billing-dialog response body. Roll back this PR if the typed 409 contract regresses.
- Validation window: first 24 hours after deploy; owner: whoever is monitoring checkout production health for the release.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
