### PR TITLE
perf(dashboard/INP): route flashLocation through the base-map geometry cache (#5049)

### DIFF
--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -298,6 +298,31 @@ export function normalizeReport(input) {
   });
 }
 
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(Object(value), key);
+}
+
+function legacySummaryForcedReflows(report) {
+  const forced = report?.forcedReflows;
+  return Boolean(
+    report?.durationMs
+      && forced
+      && !hasOwn(forced, 'markerTotalMs')
+      && !hasOwn(forced, 'markerCount'),
+  );
+}
+
+function compareForcedReflowMetrics(report) {
+  const forced = report?.forcedReflows || {};
+  const legacySummary = legacySummaryForcedReflows(report);
+  const totalMs = Number(forced.totalMs) || 0;
+  return {
+    attributedMs: legacySummary ? 0 : totalMs,
+    markerMs: legacySummary ? totalMs : Number(forced.markerTotalMs) || 0,
+    legacySummary,
+  };
+}
+
 export function compareReports(before, after) {
   const b = before?.durationMs || {};
   const a = after?.durationMs || {};
@@ -305,16 +330,25 @@ export function compareReports(before, after) {
   const afterStyle = Number(a.styleLayout) || 0;
   const beforeTbt = Number(b.estimatedTbt) || 0;
   const afterTbt = Number(a.estimatedTbt) || 0;
-  const beforeAttribMs = Number(before?.forcedReflows?.totalMs) || 0;
-  const afterAttribMs = Number(after?.forcedReflows?.totalMs) || 0;
-  const beforeMarkerMs = Number(before?.forcedReflows?.markerTotalMs) || 0;
-  const afterMarkerMs = Number(after?.forcedReflows?.markerTotalMs) || 0;
+  const beforeForced = compareForcedReflowMetrics(before);
+  const afterForced = compareForcedReflowMetrics(after);
+  const beforeAttribMs = beforeForced.attributedMs;
+  const afterAttribMs = afterForced.attributedMs;
+  const beforeMarkerMs = beforeForced.markerMs;
+  const afterMarkerMs = afterForced.markerMs;
   // A side with forced style+layout marker time but ZERO attributed stacks was
   // captured without the timeline.stack category — its attributed forcedReflowMs
   // is ~0 and would pass the <=200ms gate trivially while the real forced cost
   // (markers) is unmeasured. Carry the marker aggregate + a warning into the
   // compare so the gate view cannot go falsely green on a stackless capture.
   const warnings = [];
+  if (beforeForced.legacySummary || afterForced.legacySummary) {
+    warnings.push(
+      'Legacy stored forcedReflows.totalMs lacks marker fields; treating it as '
+      + 'Blink.ForcedStyleAndLayout marker fallback. Re-run the capture or keep '
+      + 'raw traceEvents before gating on attributed forcedReflowMs.',
+    );
+  }
   if ((beforeMarkerMs > 0 && beforeAttribMs === 0) || (afterMarkerMs > 0 && afterAttribMs === 0)) {
     warnings.push(
       'Attributed forced-reflow ms is 0 on a side with non-zero Blink.ForcedStyleAndLayout markers — '

--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -69,6 +69,28 @@ const TOP_LEVEL_TASK_NAMES = new Set([
   'ThreadControllerImpl::RunTask',
 ]);
 
+// A JS-forced synchronous style/layout is recorded under one of these event
+// names AND carries the forcing JS stack (from the timeline.stack category).
+// Scheduled (end-of-frame) layouts run inside the rendering lifecycle with no
+// script on the stack, so they carry no stackTrace — that presence/absence is
+// exactly how DevTools separates a "Forced reflow" from an ordinary layout.
+const FORCED_LAYOUT_NAMES = new Set([
+  'Layout',
+  'UpdateLayoutTree',
+  'RecalculateStyles',
+  'Blink.UpdateLayout',
+]);
+
+// Blink.ForcedStyleAndLayout(.UpdateTime) reports the aggregate forced
+// style+layout TIME but carries no JS stack, so it cannot be attributed to a
+// call site. It is tracked separately as an always-available fallback signal
+// for traces captured without the disabled-by-default-devtools.timeline.stack
+// category (e.g. some minified prod captures).
+const FORCED_MARKER_NAMES = new Set([
+  'Blink.ForcedStyleAndLayout',
+  'Blink.ForcedStyleAndLayout.UpdateTime',
+]);
+
 function round(n) {
   return Math.round((Number(n) || 0) * 10) / 10;
 }
@@ -125,21 +147,33 @@ export function extractStackFrames(event) {
   );
 }
 
-function looksForcedReflow(event) {
-  const name = String(event?.name || '');
-  if (/forced.*(layout|reflow)|layout.*forced|reflow/i.test(name)) return true;
+export function isForcedReflow(event) {
   const data = event?.args?.data || event?.args?.beginData || {};
+  // Explicitly annotated (synthetic fixtures / traces that flag the event).
   if (data.forcedReflow || data.forcedLayout || data.isForced) return true;
-  return false;
+  // Real captures: a style/layout event is JS-forced iff it carries a stack.
+  if (!FORCED_LAYOUT_NAMES.has(String(event?.name || ''))) return false;
+  return extractStackFrames(event).length > 0;
 }
 
 export function summarizeForcedReflows(events, limit = 10) {
   const stacks = new Map();
   let eventCount = 0;
   let totalMs = 0;
+  let markerCount = 0;
+  let markerTotalMs = 0;
 
   for (const event of Array.isArray(events) ? events : []) {
-    if (event?.ph !== 'X' || !looksForcedReflow(event)) continue;
+    if (event?.ph !== 'X') continue;
+    // Aggregate the stackless browser markers separately — they carry the total
+    // forced style+layout time but no call site, so they must not pollute the
+    // attributed-stack ranking.
+    if (FORCED_MARKER_NAMES.has(String(event.name || ''))) {
+      markerCount += 1;
+      markerTotalMs += durationMs(event);
+      continue;
+    }
+    if (!isForcedReflow(event)) continue;
     const ms = durationMs(event);
     const frames = extractStackFrames(event);
     const key = frames.slice(0, 4).join(' <- ') || String(event.name || 'unknown');
@@ -156,6 +190,8 @@ export function summarizeForcedReflows(events, limit = 10) {
   return {
     eventCount,
     totalMs: round(totalMs),
+    markerCount,
+    markerTotalMs: round(markerTotalMs),
     stacks: [...stacks.values()]
       .map((row) => ({ ...row, totalMs: round(row.totalMs), maxMs: round(row.maxMs) }))
       .sort((a, b) => b.totalMs - a.totalMs || b.count - a.count)
@@ -281,6 +317,11 @@ export function compareReports(before, after) {
       after: Number(after?.forcedReflows?.eventCount) || 0,
       delta: (Number(after?.forcedReflows?.eventCount) || 0) - (Number(before?.forcedReflows?.eventCount) || 0),
     },
+    forcedReflowMs: {
+      before: Number(before?.forcedReflows?.totalMs) || 0,
+      after: Number(after?.forcedReflows?.totalMs) || 0,
+      delta: round((Number(after?.forcedReflows?.totalMs) || 0) - (Number(before?.forcedReflows?.totalMs) || 0)),
+    },
   };
 }
 
@@ -390,6 +431,9 @@ function printHuman(report) {
     console.log(`Style/Layout delta: ${report.deltaMs.styleLayout}ms (${report.deltaPct.styleLayout}%)`);
     console.log(`Estimated TBT delta: ${report.deltaMs.estimatedTbt}ms (${report.deltaPct.estimatedTbt}%)`);
     console.log(`Forced-reflow events: ${report.forcedReflowEvents.before} -> ${report.forcedReflowEvents.after}`);
+    if (report.forcedReflowMs) {
+      console.log(`Attributed forced-reflow ms: ${report.forcedReflowMs.before} -> ${report.forcedReflowMs.after} (${report.forcedReflowMs.delta}ms)`);
+    }
     console.log('');
     return;
   }
@@ -398,12 +442,16 @@ function printHuman(report) {
   console.log(`Rendering:        ${d.rendering}ms (${report.sharePct.renderingOfAccounted}% of accounted render-axis)`);
   console.log(`Script Evaluation:${String(d.scriptEvaluation).padStart(7)}ms (${report.sharePct.scriptEvaluationOfAccounted}% of accounted render-axis)`);
   console.log(`Estimated TBT:    ${d.estimatedTbt}ms`);
-  console.log(`Forced reflows:   ${report.forcedReflows.eventCount} events, ${report.forcedReflows.totalMs}ms`);
+  console.log(`Forced reflows:   ${report.forcedReflows.eventCount} attributed events, ${report.forcedReflows.totalMs}ms`);
+  console.log(`  (Blink.ForcedStyleAndLayout markers: ${report.forcedReflows.markerCount ?? 0}, ${report.forcedReflows.markerTotalMs ?? 0}ms — stackless fallback)`);
   if (report.forcedReflows.stacks.length > 0) {
     console.log('\nTop forced-reflow stacks:');
     for (const stack of report.forcedReflows.stacks) {
       console.log(`  ${stack.totalMs}ms across ${stack.count}x - ${stack.topFrame}`);
     }
+  } else if (report.forcedReflows.markerCount) {
+    console.log('\nNo JS-attributed forced reflows (capture lacks the timeline.stack category);');
+    console.log('only the stackless Blink.ForcedStyleAndLayout aggregate above is available.');
   }
   if (report.warnings.length > 0) {
     console.log('\nWarnings:');

--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -281,14 +281,20 @@ export function buildReport(result) {
 }
 
 export function normalizeReport(input) {
-  if (input?.durationMs) return input;
+  const events = traceEvents(input);
+  // A stored summary (has durationMs, no raw traceEvents) is returned as-is.
+  // But whenever traceEvents are present, recompute with the CURRENT detector
+  // rather than trusting a stored forcedReflows summary — a summary written by
+  // an older tool version carries the marker-based totalMs, which would make a
+  // --compare mix two different quantities under the same field name.
+  if (input?.durationMs && !events.length) return input;
   return buildReport({
     url: input?.url,
     generatedAt: input?.generatedAt,
     viewport: input?.viewport,
     settleMs: input?.settleMs,
     tracePath: input?.tracePath || null,
-    traceEvents: traceEvents(input),
+    traceEvents: events,
   });
 }
 
@@ -299,6 +305,22 @@ export function compareReports(before, after) {
   const afterStyle = Number(a.styleLayout) || 0;
   const beforeTbt = Number(b.estimatedTbt) || 0;
   const afterTbt = Number(a.estimatedTbt) || 0;
+  const beforeAttribMs = Number(before?.forcedReflows?.totalMs) || 0;
+  const afterAttribMs = Number(after?.forcedReflows?.totalMs) || 0;
+  const beforeMarkerMs = Number(before?.forcedReflows?.markerTotalMs) || 0;
+  const afterMarkerMs = Number(after?.forcedReflows?.markerTotalMs) || 0;
+  // A side with forced style+layout marker time but ZERO attributed stacks was
+  // captured without the timeline.stack category — its attributed forcedReflowMs
+  // is ~0 and would pass the <=200ms gate trivially while the real forced cost
+  // (markers) is unmeasured. Carry the marker aggregate + a warning into the
+  // compare so the gate view cannot go falsely green on a stackless capture.
+  const warnings = [];
+  if ((beforeMarkerMs > 0 && beforeAttribMs === 0) || (afterMarkerMs > 0 && afterAttribMs === 0)) {
+    warnings.push(
+      'Attributed forced-reflow ms is 0 on a side with non-zero Blink.ForcedStyleAndLayout markers — '
+      + 'that capture lacks JS stacks; gate on forcedStyleLayoutMarkerMs, not forcedReflowMs.',
+    );
+  }
   return {
     before: before?.url || null,
     after: after?.url || null,
@@ -318,10 +340,16 @@ export function compareReports(before, after) {
       delta: (Number(after?.forcedReflows?.eventCount) || 0) - (Number(before?.forcedReflows?.eventCount) || 0),
     },
     forcedReflowMs: {
-      before: Number(before?.forcedReflows?.totalMs) || 0,
-      after: Number(after?.forcedReflows?.totalMs) || 0,
-      delta: round((Number(after?.forcedReflows?.totalMs) || 0) - (Number(before?.forcedReflows?.totalMs) || 0)),
+      before: round(beforeAttribMs),
+      after: round(afterAttribMs),
+      delta: round(afterAttribMs - beforeAttribMs),
     },
+    forcedStyleLayoutMarkerMs: {
+      before: round(beforeMarkerMs),
+      after: round(afterMarkerMs),
+      delta: round(afterMarkerMs - beforeMarkerMs),
+    },
+    warnings,
   };
 }
 
@@ -434,6 +462,10 @@ function printHuman(report) {
     if (report.forcedReflowMs) {
       console.log(`Attributed forced-reflow ms: ${report.forcedReflowMs.before} -> ${report.forcedReflowMs.after} (${report.forcedReflowMs.delta}ms)`);
     }
+    if (report.forcedStyleLayoutMarkerMs) {
+      console.log(`Blink.ForcedStyleAndLayout marker ms: ${report.forcedStyleLayoutMarkerMs.before} -> ${report.forcedStyleLayoutMarkerMs.after} (${report.forcedStyleLayoutMarkerMs.delta}ms — stackless fallback)`);
+    }
+    for (const w of report.warnings || []) console.log(`  ! ${w}`);
     console.log('');
     return;
   }

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -3644,7 +3644,16 @@ export class MapComponent {
   }
 
   public flashLocation(lat: number, lon: number, durationMs = 2000): void {
-    const { width, height } = this.readContainerSize();
+    // flashMapForNews() calls this once per streamed news item, so on boot it
+    // fires hundreds of times against a container whose size is not changing.
+    // A live clientWidth/clientHeight read here forced a synchronous layout of
+    // the whole base-map SVG on every call (~75ms across the boot in the
+    // authenticated DebugBear trace — the dominant Map forced-reflow, #5049 /
+    // tail of #5017/#5022). Route through the ResizeObserver-maintained cache
+    // instead; it falls back to a live read only while the cache is empty
+    // (first paint). This is the draw/render path, not a one-shot viewport
+    // command, so the cache is the correct source (#5022).
+    const { width, height } = this.getKnownContainerSize();
     if (!width || !height) return;
 
     const projection = this.getProjection(width, height);

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -3644,12 +3644,13 @@ export class MapComponent {
   }
 
   public flashLocation(lat: number, lon: number, durationMs = 2000): void {
-    // flashMapForNews() calls this once per streamed news item, so on boot it
-    // fires hundreds of times against a container whose size is not changing.
-    // A live clientWidth/clientHeight read here forced a synchronous layout of
-    // the whole base-map SVG on every call (~75ms across the boot in the
-    // authenticated DebugBear trace — the dominant Map forced-reflow, #5049 /
-    // tail of #5017/#5022). Route through the ResizeObserver-maintained cache
+    // flashMapForNews() flashes the map once per matching news item, firing in
+    // bursts across load passes (hundreds of calls shortly after load) against a
+    // container whose size is not changing. A live clientWidth/clientHeight read
+    // here forced a synchronous layout of the whole base-map SVG on every call
+    // (~75ms across the load in the authenticated DebugBear trace — the dominant
+    // Map forced-reflow, #5049 / tail of #5017/#5022). Route through the
+    // ResizeObserver-maintained cache
     // instead; it falls back to a live read only while the cache is empty
     // (first paint). This is the draw/render path, not a one-shot viewport
     // command, so the cache is the correct source (#5022).

--- a/tests/map-container-size-cache.test.mjs
+++ b/tests/map-container-size-cache.test.mjs
@@ -94,3 +94,29 @@ describe('Map one-shot viewport commands read current size (#5022 review)', () =
     assert.match(mapSrc, /if \(width === 0 \|\| height === 0\)/, 'renderWithSize must skip when the container has no dimensions');
   });
 });
+
+// #5049: the residual Map base-map forced reflow (246ms / 55% of the 450ms
+// authenticated DebugBear /dashboard total) was dominated by flashLocation().
+// flashMapForNews() calls it once per streamed news item, so on boot it fires
+// hundreds of times; each live readContainerSize() forced a synchronous layout
+// of the whole base-map SVG (~75ms across the load in the symbolicated trace).
+// flashLocation is the draw/render path (a transient marker on a container whose
+// size is not changing), NOT a one-shot viewport command, so per #5022 it must
+// read the ResizeObserver-maintained cache via getKnownContainerSize().
+describe('Map flashLocation reads the cached container size (#5049 forced-reflow guard)', () => {
+  const flash = mapSrc.match(/public flashLocation\([\s\S]*?\n {2}\}/);
+
+  it('flashLocation() reads via getKnownContainerSize(), not a live readContainerSize()', () => {
+    assert.ok(flash, 'could not locate flashLocation() body');
+    assert.match(
+      flash[0],
+      /getKnownContainerSize\(\)/,
+      'flashLocation() must read the cached container size — it is called once per news item on the draw path',
+    );
+    assert.doesNotMatch(
+      flash[0],
+      /readContainerSize\(\)/,
+      'flashLocation() must not read live per call (reintroduces the #5049 base-map forced reflow)',
+    );
+  });
+});

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -180,8 +180,8 @@ describe('measure-dashboard-render-axis reporting', () => {
 
   it('compares before/after reports with absolute and relative deltas', () => {
     const comparison = compareReports(
-      { url: 'before', durationMs: { styleLayout: 100, rendering: 20, scriptEvaluation: 10, estimatedTbt: 50 }, forcedReflows: { eventCount: 4, totalMs: 246 } },
-      { url: 'after', durationMs: { styleLayout: 60, rendering: 15, scriptEvaluation: 11, estimatedTbt: 35 }, forcedReflows: { eventCount: 1, totalMs: 171 } },
+      { url: 'before', durationMs: { styleLayout: 100, rendering: 20, scriptEvaluation: 10, estimatedTbt: 50 }, forcedReflows: { eventCount: 4, totalMs: 246, markerCount: 0, markerTotalMs: 0 } },
+      { url: 'after', durationMs: { styleLayout: 60, rendering: 15, scriptEvaluation: 11, estimatedTbt: 35 }, forcedReflows: { eventCount: 1, totalMs: 171, markerCount: 0, markerTotalMs: 0 } },
     );
 
     assert.equal(comparison.deltaMs.styleLayout, -40);
@@ -193,6 +193,22 @@ describe('measure-dashboard-render-axis reporting', () => {
     assert.equal(comparison.forcedReflowMs.after, 171);
     assert.equal(comparison.forcedReflowMs.delta, -75);
     assert.deepEqual(comparison.warnings, []);
+  });
+
+  it('treats legacy summary-only forcedReflows.totalMs as marker fallback', () => {
+    // Older stored summaries had durationMs but no raw traceEvents/marker fields,
+    // and their forcedReflows.totalMs came from Blink.ForcedStyleAndLayout markers.
+    // Do not compare that old stackless marker total as attributed forced-reflow ms.
+    const comparison = compareReports(
+      { url: 'before', durationMs: { styleLayout: 100 }, forcedReflows: { eventCount: 4, totalMs: 460 } },
+      { url: 'after', durationMs: { styleLayout: 90 }, forcedReflows: { eventCount: 1, totalMs: 171, markerCount: 0, markerTotalMs: 0 } },
+    );
+
+    assert.equal(comparison.forcedReflowMs.before, 0);
+    assert.equal(comparison.forcedReflowMs.after, 171);
+    assert.equal(comparison.forcedStyleLayoutMarkerMs.before, 460);
+    assert.equal(comparison.forcedStyleLayoutMarkerMs.after, 0);
+    assert.match(comparison.warnings.join('\\n'), /Legacy stored forcedReflows.totalMs/);
   });
 
   it('carries the marker fallback and warns when a compare side has stackless captures', () => {

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -6,6 +6,7 @@ import {
   classifyRenderAxisEvent,
   compareReports,
   extractStackFrames,
+  isForcedReflow,
   normalizeReport,
   parseArgs,
   summarizeForcedReflows,
@@ -66,25 +67,64 @@ describe('measure-dashboard-render-axis trace parsing', () => {
     assert.equal(forced.stacks[0].totalMs, 8);
   });
 
-  it('does not count ordinary style/layout events solely because they have JS stacks', () => {
+  it('attributes real-capture forced reflows: Layout/UpdateLayoutTree events that carry a JS stack', () => {
+    // Real Chrome traces (disabled-by-default-devtools.timeline.stack category)
+    // do NOT flag forced reflows; instead a JS-forced synchronous layout is a
+    // Layout/UpdateLayoutTree event that CARRIES the forcing stack. This mirrors
+    // the #5049 /dashboard capture where flashLocation()'s readContainerSize()
+    // forced hundreds of base-map layouts.
     const forced = summarizeForcedReflows([
       {
         ph: 'X',
         name: 'Layout',
         dur: 8000,
-        args: { beginData: { stackTrace: [{ functionName: 'renderMap', url: 'src/components/Map.ts', lineNumber: 100 }] } },
+        args: { beginData: { stackTrace: [
+          { functionName: 'readContainerSize', url: 'https://x/assets/Map.js', lineNumber: 62, columnNumber: 5478 },
+          { functionName: 'flashLocation', url: 'https://x/assets/Map.js', lineNumber: 67 },
+        ] } },
       },
       {
         ph: 'X',
         name: 'UpdateLayoutTree',
         dur: 2000,
-        args: { data: { stackTrace: [{ functionName: 'hydratePanel', url: 'src/app/panel-layout.ts', lineNumber: 50 }] } },
+        args: { data: { stackTrace: [{ functionName: 'measureLabelVisibility', url: 'https://x/assets/Map.js', lineNumber: 67 }] } },
       },
+    ]);
+
+    assert.equal(forced.eventCount, 2);
+    assert.equal(forced.totalMs, 10);
+    assert.match(forced.stacks[0].topFrame, /readContainerSize/);
+    assert.equal(forced.stacks[0].totalMs, 8);
+    assert.equal(isForcedReflow({ name: 'Layout', args: { beginData: { stackTrace: [{ functionName: 'readContainerSize' }] } } }), true);
+  });
+
+  it('excludes scheduled (end-of-frame) style/layout events that carry no JS stack', () => {
+    const forced = summarizeForcedReflows([
+      { ph: 'X', name: 'Layout', dur: 8000 },
+      { ph: 'X', name: 'UpdateLayoutTree', dur: 2000, args: { beginData: {} } },
     ]);
 
     assert.equal(forced.eventCount, 0);
     assert.equal(forced.totalMs, 0);
     assert.deepEqual(forced.stacks, []);
+    assert.equal(isForcedReflow({ name: 'Layout', dur: 8000 }), false);
+  });
+
+  it('aggregates stackless Blink.ForcedStyleAndLayout markers separately as a fallback signal', () => {
+    // These markers report the aggregate forced style+layout TIME but carry no
+    // call site, so they must not pollute the attributed-stack ranking — they
+    // are reported as markerCount/markerTotalMs for captures without the stack
+    // category (the old detector wrongly bucketed all of these as one reflow).
+    const forced = summarizeForcedReflows([
+      { ph: 'X', name: 'Blink.ForcedStyleAndLayout.UpdateTime', dur: 4000 },
+      { ph: 'X', name: 'Blink.ForcedStyleAndLayout.UpdateTime', dur: 2000 },
+      { ph: 'X', name: 'Blink.ForcedStyleAndLayout', dur: 1000 },
+    ]);
+
+    assert.equal(forced.eventCount, 0);
+    assert.deepEqual(forced.stacks, []);
+    assert.equal(forced.markerCount, 3);
+    assert.equal(forced.markerTotalMs, 7);
   });
 
   it('handles missing trace data with warnings instead of throwing', () => {
@@ -133,14 +173,18 @@ describe('measure-dashboard-render-axis reporting', () => {
 
   it('compares before/after reports with absolute and relative deltas', () => {
     const comparison = compareReports(
-      { url: 'before', durationMs: { styleLayout: 100, rendering: 20, scriptEvaluation: 10, estimatedTbt: 50 }, forcedReflows: { eventCount: 4 } },
-      { url: 'after', durationMs: { styleLayout: 60, rendering: 15, scriptEvaluation: 11, estimatedTbt: 35 }, forcedReflows: { eventCount: 1 } },
+      { url: 'before', durationMs: { styleLayout: 100, rendering: 20, scriptEvaluation: 10, estimatedTbt: 50 }, forcedReflows: { eventCount: 4, totalMs: 246 } },
+      { url: 'after', durationMs: { styleLayout: 60, rendering: 15, scriptEvaluation: 11, estimatedTbt: 35 }, forcedReflows: { eventCount: 1, totalMs: 171 } },
     );
 
     assert.equal(comparison.deltaMs.styleLayout, -40);
     assert.equal(comparison.deltaPct.styleLayout, -40);
     assert.equal(comparison.deltaMs.estimatedTbt, -15);
     assert.equal(comparison.forcedReflowEvents.delta, -3);
+    // The ≤200ms #4487 acceptance target tracks attributed forced-reflow ms.
+    assert.equal(comparison.forcedReflowMs.before, 246);
+    assert.equal(comparison.forcedReflowMs.after, 171);
+    assert.equal(comparison.forcedReflowMs.delta, -75);
   });
 });
 

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -95,7 +95,10 @@ describe('measure-dashboard-render-axis trace parsing', () => {
     assert.equal(forced.totalMs, 10);
     assert.match(forced.stacks[0].topFrame, /readContainerSize/);
     assert.equal(forced.stacks[0].totalMs, 8);
+    // Every name in FORCED_LAYOUT_NAMES is a forced reflow when it carries a stack.
     assert.equal(isForcedReflow({ name: 'Layout', args: { beginData: { stackTrace: [{ functionName: 'readContainerSize' }] } } }), true);
+    assert.equal(isForcedReflow({ name: 'RecalculateStyles', args: { beginData: { stackTrace: [{ functionName: 'f' }] } } }), true);
+    assert.equal(isForcedReflow({ name: 'Blink.UpdateLayout', args: { data: { stackTrace: [{ functionName: 'g' }] } } }), true);
   });
 
   it('excludes scheduled (end-of-frame) style/layout events that carry no JS stack', () => {
@@ -108,6 +111,10 @@ describe('measure-dashboard-render-axis trace parsing', () => {
     assert.equal(forced.totalMs, 0);
     assert.deepEqual(forced.stacks, []);
     assert.equal(isForcedReflow({ name: 'Layout', dur: 8000 }), false);
+    // An explicitly annotated event is forced regardless of name/stack (all
+    // three synonyms), for synthetic fixtures and traces that flag the event.
+    assert.equal(isForcedReflow({ name: 'X', args: { data: { isForced: true } } }), true);
+    assert.equal(isForcedReflow({ name: 'X', args: { beginData: { forcedLayout: true } } }), true);
   });
 
   it('aggregates stackless Blink.ForcedStyleAndLayout markers separately as a fallback signal', () => {
@@ -185,6 +192,25 @@ describe('measure-dashboard-render-axis reporting', () => {
     assert.equal(comparison.forcedReflowMs.before, 246);
     assert.equal(comparison.forcedReflowMs.after, 171);
     assert.equal(comparison.forcedReflowMs.delta, -75);
+    assert.deepEqual(comparison.warnings, []);
+  });
+
+  it('carries the marker fallback and warns when a compare side has stackless captures', () => {
+    // Both sides captured without the timeline.stack category: attributed
+    // totalMs is 0 (no JS stacks) but the real forced style+layout cost lives in
+    // the markers. The compare must surface the markers and warn, so the gate
+    // view cannot go falsely green on forcedReflowMs 0 -> 0.
+    const comparison = compareReports(
+      { url: 'before', durationMs: { styleLayout: 100 }, forcedReflows: { eventCount: 0, totalMs: 0, markerTotalMs: 460 } },
+      { url: 'after', durationMs: { styleLayout: 90 }, forcedReflows: { eventCount: 0, totalMs: 0, markerTotalMs: 300 } },
+    );
+
+    assert.equal(comparison.forcedReflowMs.delta, 0);
+    assert.equal(comparison.forcedStyleLayoutMarkerMs.before, 460);
+    assert.equal(comparison.forcedStyleLayoutMarkerMs.after, 300);
+    assert.equal(comparison.forcedStyleLayoutMarkerMs.delta, -160);
+    assert.equal(comparison.warnings.length, 1);
+    assert.match(comparison.warnings[0], /lacks JS stacks/);
   });
 });
 


### PR DESCRIPTION
## What & why

Closes the actionable part of #5049 — trim the residual Map base-map forced reflow on `/dashboard`.

**Symbolication first (the issue's mandated step).** I captured a prod `/dashboard` trace and fixed the repo's own measure tool to attribute forced reflows to their JS stacks (see below), which pinpointed the owner unambiguously:

| Forced-reflow source (attributed) | Cost |
|---|---|
| `readContainerSize` ← **`flashLocation`** ← `flashMapForNews` | **74.8 ms / 330 events (~70% of all forced reflow)** |
| `readContainerSize` ← `scheduleRender` (resize-safe, kept) | 44.3 ms / 33 |
| `measureLabelVisibility` (batched label rects) | 27.1 ms / 10 |
| non-Map (user-location, Panel, main) | ~20 ms |

`flashMapForNews()` flashes the map once per matching news item, firing in bursts across load passes — hundreds of `flashLocation()` calls against a container whose size is not changing. Each did a live `clientWidth`/`clientHeight` read, forcing a synchronous layout of the whole base-map SVG.

## The fix

`Map.ts` `flashLocation()` now reads the ResizeObserver-maintained cache (`getKnownContainerSize()`) instead of live `readContainerSize()` — the exact tail of #5017/#5022's container read-trim, on the draw path. It falls back to a live read only while the cache is empty (first paint), and keeps the `if (!width || !height) return` guard.

`scheduleRender()` is deliberately **left** on the live read: the ResizeObserver bails during an active resize (`if (this.isResizing) return`), so `scheduleRender` is the post-resize re-measure primitive and must read current size. Only `flashLocation` was the app-fixable stray read.

Scope is narrowly the SVG renderer (`Map.ts`, the DebugBear surface). `DeckGLMap`/`GlobeMap` `flashLocation` use viewport/globe projection, not container reads — unaffected.

## Measurement instrument fix

The issue notes `scripts/measure-dashboard-render-axis.mjs` "resolves stacks only to `Blink.ForcedStyleAndLayout.UpdateTime`". Root cause: it name-matched those stackless timing markers. It now attributes forced reflows to `Layout`/`UpdateLayoutTree`/`RecalculateStyles` events that carry a JS `beginData.stackTrace`, keeps the stackless markers as a separate `markerCount`/`markerTotalMs` fallback, and adds a `forcedReflowMs` before/after delta. A code-review follow-up also makes `--compare` carry the marker fallback + warn when a side is a stackless capture, so the gate view can't go falsely green.

## Tests

- Source-pattern guard (`map-container-size-cache.test.mjs`, #5049) locks `flashLocation` to the cache; existing #5017/#5022 invariants intact.
- Tool tests updated to the real-capture detection with fixtures for stack'd attribution, scheduled (no-stack) exclusion, the stackless-marker fallback, and the stackless-compare warning.
- `npx tsc --noEmit` clean; 23 targeted tests pass.

## Acceptance

DebugBear `/dashboard` forced-reflow ≤ 200 ms (#4487) is validated by the daily authenticated DebugBear run, per the #5029 method — I can't run the authenticated arbiter locally. The prod trace + guard test establish the mechanism (74.8 ms of `flashLocation` forced layout removed).

## Considered, deferred (not this PR)

- `measureLabelVisibility` (27 ms, batched) and the browser layout-of-large-SVG floor are the next-tier residual.
- `flashMapForNews` DOM churn is unthrottled but bounded by a per-key 10-min cooldown — a separate follow-up if it ever shows in the field.

https://claude.ai/code/session_0179sxdDgMqxuC18PY8eZJSR