### PR TITLE
fix(docker): keyless healthcheck + wire UCDP_ACCESS_TOKEN into ais-relay env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,6 @@ EXPOSE 8080
 
 # Healthcheck via nginx
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD wget -qO- http://localhost:8080/api/health || exit 1
+  CMD wget -qO- http://localhost:8080/api/health?compact=1 || exit 1
 
 CMD ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       UPSTASH_REDIS_REST_URL: "http://redis-rest:80"
       UPSTASH_REDIS_REST_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
       UPSTASH_ALLOW_INSECURE_HTTP: "true"
+      UCDP_ACCESS_TOKEN: "${UCDP_ACCESS_TOKEN:-}"
       PORT: "3004"
     depends_on:
       redis-rest:


### PR DESCRIPTION
## Summary

Two small self-hosted-stack fixes discovered live while operating the worldmonitor
docker-compose stack after the latest `main` merge:

1. **`fix(docker): use keyless /api/health?compact=1 in the image HEALTHCHECK`** —
   `api/health.js` now gates the verbose default response behind `validateApiKey`;
   only `?compact=1` stays keyless. The Dockerfile's `HEALTHCHECK` still curled the
   bare `/api/health` path, so every self-hosted container built after that upstream
   change reported `unhealthy` (401 on every 30s probe) even though nginx and the API
   process were both up and serving traffic fine. Points the probe at the same
   compact/keyless endpoint `docker-compose.override.yml`'s local healthcheck already
   uses. Verified live: container flips healthy within one `start_period` after
   rebuild.

2. **`fix(pipeline): wire UCDP_ACCESS_TOKEN into ais-relay compose env`** —
   `scripts/ais-relay.cjs`'s UCDP seed loop (`UCDP_ACCESS_TOKEN`) was never templated
   into the `ais-relay` service's environment block, so the token env var was always
   empty in the self-hosted stack. Live-verified after wiring it:
   `[UCDP] Seed loop starting (interval 360min, token: yes)`.

Both are minimal, targeted diffs (2 lines total) fixing real live-observed breakage
in the self-hosted docker-compose deployment; no application/runtime code changed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: self-hosted `docker-compose` stack (Dockerfile HEALTHCHECK, `ais-relay` env)

## Checklist

- [x] Tested on self-hosted docker-compose deployment (live-verified both fixes)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`) — N/A, no TS changed

## Documentation Alignment Checklist

N/A — this PR does not touch methodology, API/MCP contracts, generated docs,
examples, Redis keys, CII, CRI, news, digest, or briefing.

## Screenshots

N/A — infra-only change (Dockerfile HEALTHCHECK command, compose env var).
