### PR TITLE
fix(forecast): avoid stale UCDP count resolutions

### DIFF
--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -262,6 +262,10 @@ function partialCountEstablishesOutcome(count, spec) {
   return false;
 }
 
+// Count specs currently resolve only against homogeneous dated snapshots
+// (UCDP GED), where feed-wide min/max dates describe every country series.
+// Do not reuse this coverage gate for heterogeneous feeds unless it is scoped
+// to the metric filter first.
 function summarizeRecordCoverage(feedData) {
   let count = 0;
   let minTs = NaN;

--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -52,8 +52,43 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
     }
     const generatedAt = Number(entry?.generatedAt ?? entry?.firstSeenAt);
     if (!Number.isFinite(generatedAt)) return voidResult('missing_generated_at', entry, spec, parsed, nowMs);
+    const coverage = summarizeRecordCoverage(feedData);
+    if (!coverage.count || !Number.isFinite(coverage.maxTs)) {
+      return {
+        status: 'pending',
+        evidence: {
+          reason: 'count_source_no_dated_records',
+          deadline,
+          metricKey: spec.metricKey,
+          sourceRecordCount: coverage.count,
+        },
+      };
+    }
+    if (coverage.maxTs < deadline) {
+      return {
+        status: 'pending',
+        evidence: {
+          reason: 'count_source_lags_deadline',
+          deadline,
+          metricKey: spec.metricKey,
+          sourceMaxTs: coverage.maxTs,
+          sourceRecordCount: coverage.count,
+        },
+      };
+    }
     const count = countMatchingRecords(feedData, parsed.field, parsed.value, generatedAt, deadline);
-    return compareResult(count, spec, entry, parsed, nowMs, { sampleSpan: summarizeSamples(samples) });
+    if (Number.isFinite(coverage.minTs) && coverage.minTs > generatedAt && !partialCountEstablishesOutcome(count, spec)) {
+      return voidResult('count_source_window_not_retained', entry, spec, parsed, nowMs, {
+        sourceMinTs: coverage.minTs,
+        sourceMaxTs: coverage.maxTs,
+        sourceRecordCount: coverage.count,
+        partialMetricValue: count,
+      });
+    }
+    return compareResult(count, spec, entry, parsed, nowMs, {
+      sampleSpan: summarizeSamples(samples),
+      sourceCoverage: coverage,
+    });
   }
 
   if (spec.window === 'at-deadline' || spec.window === 'at-endDate') {
@@ -130,7 +165,7 @@ function compareResult(value, spec, entry, parsed, nowMs, extraEvidence = {}) {
   };
 }
 
-function voidResult(reason, entry, spec, parsed, nowMs) {
+function voidResult(reason, entry, spec, parsed, nowMs, extraEvidence = {}) {
   return {
     status: 'resolved',
     outcome: 'VOID',
@@ -140,6 +175,7 @@ function voidResult(reason, entry, spec, parsed, nowMs) {
       parsed,
       resolvedAt: nowMs,
       id: entry?.id,
+      ...extraEvidence,
     },
   };
 }
@@ -216,6 +252,29 @@ function countMatchingRecords(feedData, field, value, startMs, endMs) {
     if (Number.isFinite(ts) && ts >= startMs && ts <= endMs) count += 1;
   }
   return count;
+}
+
+function partialCountEstablishesOutcome(count, spec) {
+  const threshold = Number(spec?.threshold);
+  if (!Number.isFinite(count) || !Number.isFinite(threshold)) return false;
+  if (spec?.operator === '>=') return count >= threshold;
+  if (spec?.operator === '<=') return count > threshold;
+  return false;
+}
+
+function summarizeRecordCoverage(feedData) {
+  let count = 0;
+  let minTs = NaN;
+  let maxTs = NaN;
+  for (const record of iterateRecords(feedData)) {
+    if (!record || typeof record !== 'object') continue;
+    const ts = extractRecordTime(record);
+    if (!Number.isFinite(ts)) continue;
+    count += 1;
+    if (!Number.isFinite(minTs) || ts < minTs) minTs = ts;
+    if (!Number.isFinite(maxTs) || ts > maxTs) maxTs = ts;
+  }
+  return { count, minTs, maxTs };
 }
 
 function extractRecordTime(record) {

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -97,6 +97,70 @@ describe('resolveHardSpec', () => {
     assert.equal(resolved.evidence.comparison, '2 >= 2');
   });
 
+  it('keeps due count specs pending until the UCDP source has reached the forecast deadline', () => {
+    const generatedAt = Date.parse('2026-07-09T00:00:00Z');
+    const deadline = Date.parse('2026-08-08T00:00:00Z');
+    const e = entry({
+      id: 'fc-ukraine',
+      generatedAt,
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:ucdp-events:v1|count(country==Ukraine)',
+        operator: '>=',
+        threshold: 66,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:ucdp-events:v1',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Ukraine', dateStart: Date.parse('2025-11-20T00:00:00Z') },
+        { country: 'Ukraine', dateStart: Date.parse('2025-12-18T00:00:00Z') },
+        { country: 'Somalia', dateStart: Date.parse('2025-12-19T00:00:00Z') },
+      ],
+    };
+
+    const result = resolveHardSpec(e, feed, {}, deadline + UCDP_SETTLEMENT_LAG_MS);
+
+    assert.equal(result.status, 'pending');
+    assert.equal(result.evidence.reason, 'count_source_lags_deadline');
+    assert.equal(result.evidence.sourceMaxTs, Date.parse('2025-12-19T00:00:00Z'));
+  });
+
+  it('voids count specs when a capped feed can no longer establish a below-threshold count', () => {
+    const generatedAt = Date.parse('2026-07-01T00:00:00Z');
+    const deadline = Date.parse('2026-07-10T00:00:00Z');
+    const e = entry({
+      id: 'fc-pruned-window',
+      generatedAt,
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:ucdp-events:v1|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:ucdp-events:v1',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Mali', dateStart: Date.parse('2026-07-09T00:00:00Z') },
+        { country: 'Ghana', dateStart: Date.parse('2026-07-11T00:00:00Z') },
+      ],
+    };
+
+    const result = resolveHardSpec(e, feed, {}, deadline + UCDP_SETTLEMENT_LAG_MS);
+
+    assert.equal(result.status, 'resolved');
+    assert.equal(result.outcome, 'VOID');
+    assert.equal(result.evidence.reason, 'count_source_window_not_retained');
+    assert.equal(result.evidence.partialMetricValue, 1);
+  });
+
   it('resolves at-deadline point reads from the first sample at or after deadline', () => {
     const e = entry({
       spec: {

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -161,6 +161,39 @@ describe('resolveHardSpec', () => {
     assert.equal(result.evidence.partialMetricValue, 1);
   });
 
+  it('resolves truncated count specs when the partial count already establishes YES', () => {
+    const generatedAt = Date.parse('2026-07-01T00:00:00Z');
+    const deadline = Date.parse('2026-07-10T00:00:00Z');
+    const e = entry({
+      id: 'fc-pruned-yes',
+      generatedAt,
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:ucdp-events:v1|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:ucdp-events:v1',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Mali', dateStart: Date.parse('2026-07-09T00:00:00Z') },
+        { country: 'Mali', dateStart: Date.parse('2026-07-10T00:00:00Z') },
+        { country: 'Ghana', dateStart: Date.parse('2026-07-11T00:00:00Z') },
+      ],
+    };
+
+    const result = resolveHardSpec(e, feed, {}, deadline + UCDP_SETTLEMENT_LAG_MS);
+
+    assert.equal(result.status, 'resolved');
+    assert.equal(result.outcome, 'YES');
+    assert.equal(result.evidence.metricValue, 2);
+    assert.equal(result.evidence.sourceCoverage.minTs, Date.parse('2026-07-09T00:00:00Z'));
+  });
+
   it('resolves at-deadline point reads from the first sample at or after deadline', () => {
     const e = entry({
       spec: {

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -164,6 +164,43 @@ describe('processResolutionCycle', () => {
     assert.equal(receipts.length, 0);
   });
 
+  it('does not resolve stale UCDP count snapshots to NO after the settlement lag', () => {
+    const deadline = T0 + 30 * DAY_MS;
+    const countForecast = forecast({
+      id: 'fc-ukraine',
+      domain: 'conflict',
+      region: 'Ukraine',
+      timeHorizon: '30d',
+      deadline,
+      resolution: {
+        kind: 'hard',
+        metricKey: 'conflict:ucdp-events:v1|count(country==Ukraine)',
+        operator: '>=',
+        threshold: 66,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:ucdp-events:v1',
+      },
+    });
+
+    const { ledger, receipts, scorecard } = processResolutionCycle({}, [snapshot(T0, [countForecast])], {
+      'conflict:ucdp-events:v1': {
+        events: [
+          { country: 'Ukraine', dateStart: Date.parse('2025-11-20T00:00:00Z') },
+          { country: 'Ukraine', dateStart: Date.parse('2025-12-18T00:00:00Z') },
+        ],
+      },
+    }, deadline + 14 * DAY_MS);
+
+    const row = ledger[`fc-ukraine@${deadline}`];
+    assert.equal(row.status, 'pending');
+    assert.equal(row.outcome, undefined);
+    assert.equal(row.samples.count, 0);
+    assert.equal(receipts.length, 0);
+    assert.equal(scorecard.totals.pending, 1);
+    assert.equal(scorecard.totals.scored, 0);
+  });
+
   it('records feed-read gaps as error samples and computes a scorecard', () => {
     const pending = forecast({ deadline: T0 + 7 * DAY_MS });
     const { ledger, scorecard } = processResolutionCycle({}, [snapshot(T0, [pending])], {}, T0 + DAY_MS);


### PR DESCRIPTION
## Summary

Stale UCDP count feeds can no longer turn conflict forecasts into confident false NO resolutions. Count-family specs now wait until the dated source has reached the forecast deadline, and capped feeds that have already lost the start of the window VOID unsafe below-threshold outcomes instead of entering Brier math.

This preserves the existing point-window behavior for price, yesPrice, hexCount, and riskScore families while making the count resolver prove its source coverage before scoring.

## Validation

- `node --test tests/forecast-resolution-eval.test.mjs tests/forecast-resolutions-seeder.test.mjs`
- `git diff --check`

## Related

Related: #5024

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
