### PR TITLE
Fix SPA lifecycle recovery

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1784,6 +1784,7 @@ export class App {
     this.unsubAiFlow?.();
     this.unsubFreeTier?.();
     this.unsubEntitlementPremiumLoaders?.();
+    mlWorker.terminate();
     this.state.findingsBadge?.destroy();
     this.state.findingsBadge = null;
     this.state.breakingBanner?.destroy();

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -376,6 +376,16 @@ export class DataLoaderManager implements AppModule {
     enqueuePanelCall(key, method, args);
   }
 
+  private panelHasRetainedData(key: string): boolean {
+    const panel = this.ctx.panels[key] as { hasData?: () => boolean } | undefined;
+    return typeof panel?.hasData === 'function' && panel.hasData();
+  }
+
+  private showColdLoadError(key: string): void {
+    if (this.panelHasRetainedData(key)) return;
+    this.callPanel(key, 'showError');
+  }
+
   private boundMarketWatchlistHandler: (() => void) | null = null;
   private satellitePropagationCleanup: (() => void) | null = null;
   private dailyBriefGeneration = 0;
@@ -848,6 +858,7 @@ export class DataLoaderManager implements AppModule {
           const givingResult = await fetchGivingSummary();
           if (!givingResult.ok) {
             dataFreshness.recordError('giving', 'Giving data unavailable (retaining prior state)');
+            this.showColdLoadError('giving');
             return;
           }
           const data = givingResult.data;
@@ -2634,6 +2645,7 @@ export class DataLoaderManager implements AppModule {
           // listUcdpEvents is a pure Redis-read (gold standard). Retrying returns
           // the same empty result until the Railway seed refreshes the key.
           dataFreshness.recordError('ucdp_events', 'UCDP events unavailable (retaining prior event state)');
+          this.showColdLoadError('ucdp-events');
           return;
         }
         const acledEvents = protestEvents.map(e => ({
@@ -2656,6 +2668,7 @@ export class DataLoaderManager implements AppModule {
         const unhcrResult = await fetchUnhcrPopulation();
         if (!unhcrResult.ok) {
           dataFreshness.recordError('unhcr', 'UNHCR displacement unavailable (retaining prior displacement state)');
+          this.showColdLoadError('displacement');
           return;
         }
         const data = unhcrResult.data;
@@ -2677,6 +2690,7 @@ export class DataLoaderManager implements AppModule {
         const climateResult = await fetchClimateAnomalies();
         if (!climateResult.ok) {
           dataFreshness.recordError('climate', 'Climate anomalies unavailable (retaining prior climate state)');
+          this.showColdLoadError('climate');
           return;
         }
         const anomalies = climateResult.anomalies;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2680,7 +2680,7 @@ export class DataLoaderManager implements AppModule {
         if (data.countries.length > 0) dataFreshness.recordUpdate('unhcr', data.countries.length);
       } catch (error) {
         console.error('[Intelligence] UNHCR displacement fetch failed:', error);
-        this.callPanel('displacement', 'showError');
+        this.showColdLoadError('displacement');
         dataFreshness.recordError('unhcr', String(error));
       }
     })());
@@ -2702,7 +2702,7 @@ export class DataLoaderManager implements AppModule {
         if (anomalies.length > 0) dataFreshness.recordUpdate('climate', anomalies.length);
       } catch (error) {
         console.error('[Intelligence] Climate anomalies fetch failed:', error);
-        this.callPanel('climate', 'showError');
+        this.showColdLoadError('climate');
         dataFreshness.recordError('climate', String(error));
       }
     })());

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -435,6 +435,13 @@ export class PanelLayoutManager implements AppModule {
     this.proBlockUnsubscribe = null;
     this.proBlockEntitlementUnsubscribe?.();
     this.proBlockEntitlementUnsubscribe = null;
+
+    const destroyedTargets = new Set<{ destroy?: () => void }>();
+    const destroyOnce = (target: { destroy?: () => void } | null | undefined): void => {
+      if (!target || destroyedTargets.has(target)) return;
+      destroyedTargets.add(target);
+      target.destroy?.();
+    };
     if (this.boundWidgetCreatorHandler) {
       this.ctx.container.removeEventListener('wm:open-widget-creator', this.boundWidgetCreatorHandler);
       this.boundWidgetCreatorHandler = null;
@@ -465,20 +472,35 @@ export class PanelLayoutManager implements AppModule {
     this.panelTabBar?.destroy();
     this.panelTabBar = null;
     // Clean up happy variant panels
-    this.ctx.tvMode?.destroy();
+    destroyOnce(this.ctx.tvMode);
     this.ctx.tvMode = null;
-    this.ctx.countersPanel?.destroy();
-    this.ctx.progressPanel?.destroy();
-    this.ctx.breakthroughsPanel?.destroy();
-    this.ctx.heroPanel?.destroy();
-    this.ctx.digestPanel?.destroy();
-    this.ctx.speciesPanel?.destroy();
-    this.ctx.renewablePanel?.destroy();
+    destroyOnce(this.ctx.countersPanel);
+    this.ctx.countersPanel = null;
+    destroyOnce(this.ctx.progressPanel);
+    this.ctx.progressPanel = null;
+    destroyOnce(this.ctx.breakthroughsPanel);
+    this.ctx.breakthroughsPanel = null;
+    destroyOnce(this.ctx.heroPanel);
+    this.ctx.heroPanel = null;
+    destroyOnce(this.ctx.digestPanel);
+    this.ctx.digestPanel = null;
+    destroyOnce(this.ctx.speciesPanel);
+    this.ctx.speciesPanel = null;
+    destroyOnce(this.ctx.renewablePanel);
+    this.ctx.renewablePanel = null;
 
     // Clean up aviation components
-    this.aviationCommandBar?.destroy();
+    destroyOnce(this.aviationCommandBar);
     this.aviationCommandBar = null;
-    this.ctx.panels['airline-intel']?.destroy();
+
+    // Destroy every registered panel exactly once, including lazy-created
+    // and self-fetching panels that own subscriptions, intervals, or aborts.
+    for (const panel of Object.values(this.ctx.panels)) {
+      destroyOnce(panel);
+    }
+    for (const key of Object.keys(this.ctx.panels)) {
+      delete this.ctx.panels[key];
+    }
 
     // Clean up billing subscription watch + entitlement subscription
     destroySubscriptionWatch();

--- a/src/components/ClimateAnomalyPanel.ts
+++ b/src/components/ClimateAnomalyPanel.ts
@@ -5,6 +5,7 @@ import { t } from '@/services/i18n';
 
 export class ClimateAnomalyPanel extends Panel {
   private anomalies: ClimateAnomaly[] = [];
+  private hasLoadedAnomalies = false;
   private onZoneClick?: (lat: number, lon: number) => void;
 
   constructor() {
@@ -24,8 +25,13 @@ export class ClimateAnomalyPanel extends Panel {
 
   public setAnomalies(anomalies: ClimateAnomaly[]): void {
     this.anomalies = anomalies;
+    this.hasLoadedAnomalies = true;
     this.setCount(anomalies.length);
     this.renderContent();
+  }
+
+  public hasData(): boolean {
+    return this.hasLoadedAnomalies;
   }
 
   private renderContent(): void {

--- a/src/components/DisplacementPanel.ts
+++ b/src/components/DisplacementPanel.ts
@@ -88,6 +88,10 @@ export class DisplacementPanel extends Panel {
     this.renderContent();
   }
 
+  public hasData(): boolean {
+    return this.data !== null;
+  }
+
   private renderContent(): void {
     if (!this.data) return;
 

--- a/src/components/GivingPanel.ts
+++ b/src/components/GivingPanel.ts
@@ -29,6 +29,10 @@ export class GivingPanel extends Panel {
     this.renderContent();
   }
 
+  public hasData(): boolean {
+    return this.data !== null;
+  }
+
   private renderContent(): void {
     if (!this.data) return;
 

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -4,6 +4,7 @@ import { premiumFetch } from '@/services/premium-fetch';
 import { IS_EMBEDDED_PREVIEW } from '@/utils/embedded-preview';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { subscribeAuthState } from '@/services/auth-state';
+import { onEntitlementChange } from '@/services/entitlements';
 
 import type { RegionalSnapshot, RegimeTransition, RegionalBrief } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren, setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -69,6 +70,7 @@ export class RegionalIntelligenceBoard extends Panel {
    * previous "Panel has no destroy hook" comment was wrong.
    */
   private authUnsubscribe: (() => void) | null = null;
+  private entitlementUnsubscribe: (() => void) | null = null;
 
   constructor() {
     super({
@@ -109,20 +111,8 @@ export class RegionalIntelligenceBoard extends Panel {
     // session hasn't resolved at panel-construction time would see
     // renderEmpty() and then stay empty forever even after sign-in, because
     // nothing else triggers loadCurrent for the current region.
-    this.authUnsubscribe = subscribeAuthState(() => {
-      const hasPremium = hasPremiumAccess();
-      if (hasPremium && !this.lastHadPremium) {
-        this.lastHadPremium = true;
-        void this.loadCurrent();
-      } else if (!hasPremium && this.lastHadPremium) {
-        // Entitlement was revoked (sign-out, subscription ended) — blank
-        // the panel so stale data doesn't linger for a user who can no
-        // longer see it. Panel locking separately re-applies via
-        // panel-layout's auth subscription.
-        this.lastHadPremium = false;
-        this.renderEmpty();
-      }
-    });
+    this.authUnsubscribe = subscribeAuthState(() => this.handlePremiumAccessChange());
+    this.entitlementUnsubscribe = onEntitlementChange(() => this.handlePremiumAccessChange());
   }
 
   /** Public API for tests and agent tools: force-load a region directly. */
@@ -135,6 +125,8 @@ export class RegionalIntelligenceBoard extends Panel {
   override destroy(): void {
     this.authUnsubscribe?.();
     this.authUnsubscribe = null;
+    this.entitlementUnsubscribe?.();
+    this.entitlementUnsubscribe = null;
     // Invalidate any in-flight loadCurrent: the existing sequence guard
     // (see `isLatestSequence` checks) drops responses whose sequence no
     // longer matches `latestSequence`. Bumping it here ensures a pending
@@ -142,6 +134,21 @@ export class RegionalIntelligenceBoard extends Panel {
     // render into a detached DOM tree.
     this.latestSequence += 1;
     super.destroy();
+  }
+
+  private handlePremiumAccessChange(): void {
+    const hasPremium = hasPremiumAccess();
+    if (hasPremium && !this.lastHadPremium) {
+      this.lastHadPremium = true;
+      void this.loadCurrent();
+    } else if (!hasPremium && this.lastHadPremium) {
+      // Entitlement was revoked (sign-out, subscription ended) — blank
+      // the panel so stale data doesn't linger for a user who can no
+      // longer see it. Panel locking separately re-applies via
+      // panel-layout's auth subscription.
+      this.lastHadPremium = false;
+      this.renderEmpty();
+    }
   }
 
   private async loadCurrent(): Promise<void> {

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -147,6 +147,7 @@ export class RegionalIntelligenceBoard extends Panel {
       // longer see it. Panel locking separately re-applies via
       // panel-layout's auth subscription.
       this.lastHadPremium = false;
+      this.latestSequence += 1;
       this.renderEmpty();
     }
   }

--- a/src/components/UcdpEventsPanel.ts
+++ b/src/components/UcdpEventsPanel.ts
@@ -5,6 +5,7 @@ import { t } from '@/services/i18n';
 
 export class UcdpEventsPanel extends Panel {
   private events: UcdpGeoEvent[] = [];
+  private hasLoadedEvents = false;
   private activeTab: UcdpEventType = 'state-based';
   private onEventClick?: (lat: number, lon: number) => void;
 
@@ -41,8 +42,13 @@ export class UcdpEventsPanel extends Panel {
 
   public setEvents(events: UcdpGeoEvent[]): void {
     this.events = events;
+    this.hasLoadedEvents = true;
     this.setCount(events.length);
     this.renderContent();
+  }
+
+  public hasData(): boolean {
+    return this.hasLoadedEvents;
   }
 
   public getEvents(): UcdpGeoEvent[] {

--- a/tests/app-destroy-lifecycle.test.mjs
+++ b/tests/app-destroy-lifecycle.test.mjs
@@ -101,6 +101,7 @@ describe('App.destroy lifecycle cleanup contract', () => {
       'this.state.map?.destroy()',
       'disconnectAisStream()',
       'this.webMcpController?.abort()',
+      'mlWorker.terminate()',
     ]) {
       assert.ok(body.includes(expected), `App.destroy() must keep ${expected}`);
     }

--- a/tests/regional-intelligence-board.test.mts
+++ b/tests/regional-intelligence-board.test.mts
@@ -709,6 +709,27 @@ describe('loadCurrent race simulation', () => {
     await loadCurrent('mena', Promise.resolve('snap'));
     assert.deepEqual(state.rendered, ['mena:snap']);
   });
+
+  it('drops an in-flight response after premium revocation invalidates the sequence', async () => {
+    const state = { latestSequence: 0, rendered: [] as string[] };
+    let resolveSnapshot: (value: string) => void;
+    const snapshot = new Promise<string>((resolve) => { resolveSnapshot = resolve; });
+
+    async function loadCurrent(promise: Promise<string>) {
+      state.latestSequence += 1;
+      const mySeq = state.latestSequence;
+      const result = await promise;
+      if (!isLatestSequence(mySeq, state.latestSequence)) return;
+      state.rendered.push(result);
+    }
+
+    const load = loadCurrent(snapshot);
+    state.latestSequence += 1;
+    resolveSnapshot!('premium-snapshot');
+    await load;
+
+    assert.deepEqual(state.rendered, []);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/spa-lifecycle-recovery.test.mts
+++ b/tests/spa-lifecycle-recovery.test.mts
@@ -149,6 +149,20 @@ describe('SPA lifecycle recovery contracts', () => {
       [],
       'all validated cold soft-fail loaders must call showColdLoadError',
     );
+
+    const directShowErrorPanels = new Set(
+      propertyCalls(file, 'callPanel')
+        .filter(call =>
+          ts.isStringLiteralLike(call.arguments[0]!) &&
+          ts.isStringLiteralLike(call.arguments[1]!) &&
+          call.arguments[1].text === 'showError')
+        .map(call => (call.arguments[0] as ts.StringLiteralLike).text),
+    );
+    assert.deepEqual(
+      requiredColdFailPanels.filter(panel => directShowErrorPanels.has(panel)),
+      [],
+      'validated cold-failure panels must route every showError path through showColdLoadError',
+    );
   });
 
   it('cold-failure panels expose loaded-data state to preserve warm retained views', () => {
@@ -202,6 +216,11 @@ describe('SPA lifecycle recovery contracts', () => {
     assert.ok(
       propertyCalls(handler, 'loadCurrent').length >= 1,
       'false-to-true premium transition must reload the current regional snapshot',
+    );
+    assert.match(
+      handler.getText(file),
+      /this\.latestSequence\s*\+=\s*1[\s\S]*this\.renderEmpty\(\)/,
+      'true-to-false premium transition must invalidate in-flight loads before blanking the panel',
     );
   });
 

--- a/tests/spa-lifecycle-recovery.test.mts
+++ b/tests/spa-lifecycle-recovery.test.mts
@@ -1,0 +1,210 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ts from 'typescript';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+
+function read(rel: string): string {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+function sourceFile(rel: string): ts.SourceFile {
+  return ts.createSourceFile(
+    resolve(REPO_ROOT, rel),
+    read(rel),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function visit(node: ts.Node, cb: (child: ts.Node) => void): void {
+  node.forEachChild(child => {
+    cb(child);
+    visit(child, cb);
+  });
+}
+
+function findClassMember<T extends ts.ClassElement>(
+  file: ts.SourceFile,
+  className: string,
+  predicate: (member: ts.ClassElement) => member is T,
+  label: string,
+): T {
+  let match: T | undefined;
+  visit(file, node => {
+    if (!ts.isClassDeclaration(node) || node.name?.text !== className) return;
+    for (const member of node.members) {
+      if (predicate(member)) match = member;
+    }
+  });
+  assert.ok(match, `could not find ${className}.${label}`);
+  return match;
+}
+
+function findMethod(file: ts.SourceFile, className: string, methodName: string): ts.MethodDeclaration {
+  return findClassMember(
+    file,
+    className,
+    (member): member is ts.MethodDeclaration => (
+      ts.isMethodDeclaration(member) &&
+      ts.isIdentifier(member.name) &&
+      member.name.text === methodName
+    ),
+    methodName,
+  );
+}
+
+function findConstructor(file: ts.SourceFile, className: string): ts.ConstructorDeclaration {
+  return findClassMember(
+    file,
+    className,
+    (member): member is ts.ConstructorDeclaration => ts.isConstructorDeclaration(member),
+    'constructor',
+  );
+}
+
+function propertyCalls(node: ts.Node, propertyName: string): ts.CallExpression[] {
+  const calls: ts.CallExpression[] = [];
+  visit(node, child => {
+    if (
+      ts.isCallExpression(child) &&
+      ts.isPropertyAccessExpression(child.expression) &&
+      child.expression.name.text === propertyName
+    ) {
+      calls.push(child);
+    }
+  });
+  return calls;
+}
+
+function identifierCalls(node: ts.Node, identifierName: string): ts.CallExpression[] {
+  const calls: ts.CallExpression[] = [];
+  visit(node, child => {
+    if (ts.isCallExpression(child) && ts.isIdentifier(child.expression) && child.expression.text === identifierName) {
+      calls.push(child);
+    }
+  });
+  return calls;
+}
+
+function firstStringArg(call: ts.CallExpression): string | null {
+  const arg = call.arguments[0];
+  return arg && ts.isStringLiteralLike(arg) ? arg.text : null;
+}
+
+function hasReturnGuard(method: ts.MethodDeclaration, guardedCall: string): boolean {
+  let found = false;
+  visit(method, child => {
+    if (!ts.isIfStatement(child)) return;
+    const expr = child.expression;
+    if (
+      ts.isCallExpression(expr) &&
+      ts.isPropertyAccessExpression(expr.expression) &&
+      expr.expression.name.text === guardedCall &&
+      ts.isReturnStatement(child.thenStatement)
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+describe('SPA lifecycle recovery contracts', () => {
+  it('cold soft-fail loaders show an error only when no retained panel data exists', () => {
+    const file = sourceFile('src/app/data-loader.ts');
+    const helper = findMethod(file, 'DataLoaderManager', 'showColdLoadError');
+
+    assert.ok(
+      hasReturnGuard(helper, 'panelHasRetainedData'),
+      'showColdLoadError must retain warm panel data instead of replacing it with an error state',
+    );
+
+    const showErrorCalls = propertyCalls(helper, 'callPanel');
+    assert.ok(
+      showErrorCalls.some(call =>
+        call.arguments[0]?.getText(file) === 'key' &&
+        ts.isStringLiteralLike(call.arguments[1]!) &&
+        call.arguments[1].text === 'showError'),
+      'showColdLoadError must route cold failures through Panel.showError',
+    );
+
+    const coldFailPanels = new Set(
+      propertyCalls(file, 'showColdLoadError')
+        .map(firstStringArg)
+        .filter((value): value is string => value !== null),
+    );
+    const requiredColdFailPanels = ['climate', 'displacement', 'giving', 'ucdp-events'];
+    const missing = requiredColdFailPanels.filter(panel => !coldFailPanels.has(panel));
+    assert.deepEqual(
+      missing,
+      [],
+      'all validated cold soft-fail loaders must call showColdLoadError',
+    );
+  });
+
+  it('cold-failure panels expose loaded-data state to preserve warm retained views', () => {
+    for (const [rel, className] of [
+      ['src/components/GivingPanel.ts', 'GivingPanel'],
+      ['src/components/UcdpEventsPanel.ts', 'UcdpEventsPanel'],
+      ['src/components/DisplacementPanel.ts', 'DisplacementPanel'],
+      ['src/components/ClimateAnomalyPanel.ts', 'ClimateAnomalyPanel'],
+    ] as const) {
+      const file = sourceFile(rel);
+      assert.ok(findMethod(file, className, 'hasData'), `${className} must expose hasData()`);
+    }
+  });
+
+  it('PanelLayoutManager.destroy destroys every registered panel once and clears the registry', () => {
+    const file = sourceFile('src/app/panel-layout.ts');
+    const destroy = findMethod(file, 'PanelLayoutManager', 'destroy');
+    const body = destroy.getText(file);
+
+    assert.match(body, /destroyOnce/, 'destroy() must use a shared exactly-once helper');
+    assert.match(
+      body,
+      /Object\.values\(this\.ctx\.panels\)[\s\S]*destroyOnce\(panel\)/,
+      'destroy() must iterate every registered panel and pass each through destroyOnce',
+    );
+    assert.match(
+      body,
+      /Object\.keys\(this\.ctx\.panels\)[\s\S]*delete this\.ctx\.panels\[key\]/,
+      'destroy() must clear ctx.panels after teardown so repeat destroys do not hit stale panels',
+    );
+    assert.doesNotMatch(
+      body,
+      /this\.ctx\.panels\[['"]airline-intel['"]\]\?\.destroy\(/,
+      'destroy() must not special-case only airline-intel from the registered panel catalog',
+    );
+  });
+
+  it('RegionalIntelligenceBoard reloads on entitlement unlock and unsubscribes on destroy', () => {
+    const file = sourceFile('src/components/RegionalIntelligenceBoard.ts');
+    const src = file.getFullText();
+    const ctor = findConstructor(file, 'RegionalIntelligenceBoard');
+    const destroy = findMethod(file, 'RegionalIntelligenceBoard', 'destroy');
+    const handler = findMethod(file, 'RegionalIntelligenceBoard', 'handlePremiumAccessChange');
+
+    assert.match(src, /import \{ onEntitlementChange \} from '@\/services\/entitlements';/);
+    assert.ok(
+      identifierCalls(ctor, 'onEntitlementChange').length >= 1,
+      'constructor must subscribe to entitlement changes, not only auth state',
+    );
+    assert.match(destroy.getText(file), /this\.entitlementUnsubscribe\?\.\(\)/);
+    assert.ok(
+      propertyCalls(handler, 'loadCurrent').length >= 1,
+      'false-to-true premium transition must reload the current regional snapshot',
+    );
+  });
+
+  it('App.destroy terminates the ML worker it may have initialized', () => {
+    const file = sourceFile('src/App.ts');
+    const destroy = findMethod(file, 'App', 'destroy');
+    assert.ok(
+      propertyCalls(destroy, 'terminate').some(call => call.expression.getText(file) === 'mlWorker.terminate'),
+      'App.destroy must terminate mlWorker so same-document reinit does not leak worker resources',
+    );
+  });
+});

--- a/tests/spa-lifecycle-recovery.test.mts
+++ b/tests/spa-lifecycle-recovery.test.mts
@@ -100,11 +100,17 @@ function hasReturnGuard(method: ts.MethodDeclaration, guardedCall: string): bool
   visit(method, child => {
     if (!ts.isIfStatement(child)) return;
     const expr = child.expression;
+    const thenStatement = child.thenStatement;
+    const returns =
+      ts.isReturnStatement(thenStatement) ||
+      (ts.isBlock(thenStatement) &&
+        thenStatement.statements.length === 1 &&
+        ts.isReturnStatement(thenStatement.statements[0]!));
     if (
       ts.isCallExpression(expr) &&
       ts.isPropertyAccessExpression(expr.expression) &&
       expr.expression.name.text === guardedCall &&
-      ts.isReturnStatement(child.thenStatement)
+      returns
     ) {
       found = true;
     }


### PR DESCRIPTION
## Summary

- Show the existing panel error state on cold soft-fail results for Giving, UCDP events, displacement, and climate while preserving warm retained data.
- Make `PanelLayoutManager.destroy()` destroy every registered panel exactly once and clear the panel registry after teardown.
- Re-fire Regional Intelligence on entitlement unlocks, not only auth-state changes, and terminate the ML worker from `App.destroy()`.
- Add focused SPA lifecycle regression coverage for the issue contract.

## Intent

Fix #5058 by tightening SPA ownership boundaries:

- loaders own cold-failure UI recovery,
- panels expose whether they have retained data,
- layout owns registered panel teardown,
- Regional Intelligence listens to both auth and entitlement transitions,
- App owns long-lived worker teardown.

Non-goals: no new user-visible copy, no new backend/API behavior, no visual layout changes.

## Validation Matrix

| Check | Reason | Result |
| --- | --- | --- |
| `./node_modules/.bin/tsx --test tests/spa-lifecycle-recovery.test.mts tests/app-destroy-lifecycle.test.mjs tests/premium-loaders-fan-out-coverage.test.mts tests/regional-intelligence-board.test.mts` | Focused lifecycle, premium fan-out, Regional Intelligence regressions | Pass: 70 tests |
| `./node_modules/.bin/tsx --test tests/spa-lifecycle-recovery.test.mts` | Rerun after test assertion refinement | Pass: 5 tests |
| `npm run typecheck` | Frontend TypeScript validation | Pass |
| `npm run build` | Production bundle validation | Pass; required installing `blog-site` dependencies after test-only bootstrap skipped postinstall; existing chunk warnings only |
| `npm run lint` | Repo lint plus safe-html guard | Pass exit 0; existing warnings outside this diff; safe-html passed |
| `git diff --check` / `git diff --cached --check` | Whitespace/conflict-marker sanity | Pass |

## Review Gates

- Baseline Reviewer: pass, scoped diff matches issue contract.
- Code Review Expert: pass, no P0/P1/P2/P3 findings after SOLID, reliability, security, and test-quality review.
- Outcome Reviewer: pass, acceptance criteria are covered by code and focused tests.

## Documentation

Not applicable. This is SPA lifecycle/error-state recovery with no public API or docs-surface change.

## Screenshots / UI Evidence

Not applicable. The change uses the existing `Panel.showError()` UI and lifecycle cleanup paths; focused tests cover the behavior. No visual copy or layout changed.

## Residual Findings

None.

Closes #5058.
