### PR TITLE
Harden Convex entitlement lifecycle races

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -85,6 +85,7 @@ async function seedAnonClaimState(
       planKey: PlanKey;
       validUntil: number;
     };
+    includeAnonEntitlement?: boolean;
   } = {},
 ) {
   const anonId = opts.anonId ?? ANON_USER_ID;
@@ -102,13 +103,15 @@ async function seedAnonClaimState(
       rawPayload: { metadata: { wm_anon_claim: "v2" } },
       updatedAt: NOW,
     });
-    await ctx.db.insert("entitlements", {
-      userId: anonId,
-      planKey,
-      features: getFeaturesForPlan(planKey),
-      validUntil: opts.validUntil ?? NOW + 30 * DAY_MS,
-      updatedAt: NOW,
-    });
+    if (opts.includeAnonEntitlement !== false) {
+      await ctx.db.insert("entitlements", {
+        userId: anonId,
+        planKey,
+        features: getFeaturesForPlan(planKey),
+        validUntil: opts.validUntil ?? NOW + 30 * DAY_MS,
+        updatedAt: NOW,
+      });
+    }
     await ctx.db.insert("customers", {
       userId: anonId,
       dodoCustomerId: "cus_anon_claim_001",
@@ -253,6 +256,19 @@ describe("claimSubscription anonymous ownership proof", () => {
         validUntil: NOW + 10 * DAY_MS,
       },
     });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: CLAIMANT_A.subject,
+        dodoSubscriptionId: "sub_real_api_business",
+        dodoProductId: PRODUCT_CATALOG.api_business.dodoProductId!,
+        planKey: "api_business",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 10 * DAY_MS,
+        rawPayload: {},
+        updatedAt: NOW - DAY_MS,
+      });
+    });
     const claimToken = await signAnonClaimToken(ANON_USER_ID);
 
     await t.withIdentity(CLAIMANT_A).mutation(api.payments.billing.claimSubscription, {
@@ -288,6 +304,56 @@ describe("claimSubscription anonymous ownership proof", () => {
     const urls = fetchMock.mock.calls.map((call) => String(call[0]));
     expect(urls.some((url) => url.includes("/del/") && url.includes(encodeURIComponent(ANON_USER_ID)))).toBe(true);
     expect(urls.some((url) => url.includes("/set/") && url.includes(encodeURIComponent(CLAIMANT_A.subject)))).toBe(true);
+  });
+
+  test("recomputes and syncs real entitlement when the anon entitlement row is missing", async () => {
+    vi.useFakeTimers();
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "redis-token";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("OK", { status: 200 }),
+    );
+    const t = convexTest(schema, modules);
+    await seedAnonClaimState(t, {
+      planKey: "api_starter",
+      includeAnonEntitlement: false,
+    });
+    const claimToken = await signAnonClaimToken(ANON_USER_ID);
+
+    const result = await t.withIdentity(CLAIMANT_A).mutation(api.payments.billing.claimSubscription, {
+      anonId: ANON_USER_ID,
+      claimToken,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(result).toEqual({
+      claimed: { subscriptions: 1, entitlements: 0, customers: 1, payments: 1 },
+    });
+    const rows = await t.run(async (ctx) => {
+      const [sub, entitlement, oldEntitlement] = await Promise.all([
+        ctx.db.query("subscriptions").withIndex("by_userId", (q) => q.eq("userId", CLAIMANT_A.subject)).first(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", CLAIMANT_A.subject)).first(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", ANON_USER_ID)).first(),
+      ]);
+      return { sub, entitlement, oldEntitlement };
+    });
+    expect(rows.sub?.userId).toBe(CLAIMANT_A.subject);
+    expect(rows.entitlement?.planKey).toBe("api_starter");
+    expect(rows.entitlement?.features.tier).toBe(getFeaturesForPlan("api_starter").tier);
+    expect(rows.oldEntitlement).toBeNull();
+
+    const urls = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(urls.some((url) => url.includes("/del/") && url.includes(encodeURIComponent(ANON_USER_ID)))).toBe(true);
+    const realUserSetUrl = urls.find((url) =>
+      url.includes("/set/") && url.includes(encodeURIComponent(CLAIMANT_A.subject)),
+    );
+    if (!realUserSetUrl) throw new Error("missing real-user Redis SET");
+    const setPathParts = new URL(realUserSetUrl).pathname.split("/");
+    const cachedEntitlement = JSON.parse(decodeURIComponent(setPathParts[3] ?? "{}"));
+    expect(cachedEntitlement.planKey).toBe("api_starter");
+    expect(cachedEntitlement.validUntil).toBe(NOW + 30 * DAY_MS);
+    expect(cachedEntitlement.features.tier).toBe(getFeaturesForPlan("api_starter").tier);
   });
 
   test("returns a quiet zero claim for bare UUIDs with no payment rows", async () => {

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -80,10 +80,12 @@ async function seedAnonClaimState(
     anonId?: string;
     planKey?: PlanKey;
     validUntil?: number;
+    compUntil?: number;
     existingRealEntitlement?: {
       userId: string;
       planKey: PlanKey;
       validUntil: number;
+      compUntil?: number;
     };
     includeAnonEntitlement?: boolean;
   } = {},
@@ -109,6 +111,7 @@ async function seedAnonClaimState(
         planKey,
         features: getFeaturesForPlan(planKey),
         validUntil: opts.validUntil ?? NOW + 30 * DAY_MS,
+        ...(opts.compUntil !== undefined ? { compUntil: opts.compUntil } : {}),
         updatedAt: NOW,
       });
     }
@@ -139,6 +142,9 @@ async function seedAnonClaimState(
         planKey: opts.existingRealEntitlement.planKey,
         features: getFeaturesForPlan(opts.existingRealEntitlement.planKey),
         validUntil: opts.existingRealEntitlement.validUntil,
+        ...(opts.existingRealEntitlement.compUntil !== undefined
+          ? { compUntil: opts.existingRealEntitlement.compUntil }
+          : {}),
         updatedAt: NOW - DAY_MS,
       });
     }
@@ -281,6 +287,50 @@ describe("claimSubscription anonymous ownership proof", () => {
     );
     expect(entitlement?.planKey).toBe("api_business");
     expect(entitlement?.features.tier).toBe(getFeaturesForPlan("api_business").tier);
+  });
+
+  test("does not let a lower-tier anon comp floor suppress a higher real subscription on claim", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const t = convexTest(schema, modules);
+    const anonCompUntil = NOW + 90 * DAY_MS;
+    const realPaidUntil = NOW + 30 * DAY_MS;
+    await seedAnonClaimState(t, {
+      planKey: "api_starter",
+      validUntil: anonCompUntil,
+      compUntil: anonCompUntil,
+      existingRealEntitlement: {
+        userId: CLAIMANT_A.subject,
+        planKey: "pro_monthly",
+        validUntil: realPaidUntil,
+      },
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: CLAIMANT_A.subject,
+        dodoSubscriptionId: "sub_real_api_business",
+        dodoProductId: PRODUCT_CATALOG.api_business.dodoProductId!,
+        planKey: "api_business",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: realPaidUntil,
+        rawPayload: {},
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+    const claimToken = await signAnonClaimToken(ANON_USER_ID);
+
+    await t.withIdentity(CLAIMANT_A).mutation(api.payments.billing.claimSubscription, {
+      anonId: ANON_USER_ID,
+      claimToken,
+    });
+
+    const entitlement = await t.run(async (ctx) =>
+      ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", CLAIMANT_A.subject)).first(),
+    );
+    expect(entitlement?.planKey).toBe("api_business");
+    expect(entitlement?.features.tier).toBe(getFeaturesForPlan("api_business").tier);
+    expect(entitlement?.validUntil).toBe(realPaidUntil);
+    expect(entitlement?.compUntil).toBeUndefined();
   });
 
   test("schedules anon cache delete and real-user cache sync after a proven claim", async () => {

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -1,5 +1,7 @@
 import { convexTest } from "convex-test";
-import { expect, test, describe } from "vitest";
+import { afterEach, expect, test, describe } from "vitest";
+import { getFeaturesForPlan } from "../lib/entitlements";
+import { signUserId } from "../lib/identitySigning";
 import schema from "../schema";
 import { internal } from "../_generated/api";
 
@@ -62,6 +64,11 @@ function makePaymentPayload(
 }
 
 const BASE_TIMESTAMP = new Date("2026-03-21T10:00:00Z").getTime();
+const SIGNING_SECRET = "test-dodo-identity-signing-secret";
+
+afterEach(() => {
+  delete process.env.DODO_IDENTITY_SIGNING_SECRET;
+});
 
 // ---------------------------------------------------------------------------
 // Helper: seed a productPlans mapping
@@ -464,6 +471,241 @@ describe("webhook processWebhookEvent", () => {
     });
     expect(paymentEvents).toHaveLength(1);
     expect(paymentEvents[0].status).toBe("failed");
+  });
+
+  // #5056 — entitlement lifecycle integrity across claim, active webhook, and dispute races.
+  test("subscription.active keeps claimed real owner when stale signed anon metadata arrives", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const t = convexTest(schema, modules);
+    const realUserId = "user_claimed_subscription";
+    const anonId = "22222222-2222-4222-8222-222222222222";
+    const customerId = "cust_claimed_001";
+    const subscriptionId = "sub_claimed_001";
+    const anonSig = await signUserId(anonId);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: realUserId,
+        dodoSubscriptionId: subscriptionId,
+        dodoProductId: "pdt_test_pro",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: BASE_TIMESTAMP - 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP,
+        dodoCustomerId: customerId,
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: realUserId,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_claimed_stale_anon",
+      eventType: "subscription.active",
+      rawPayload: makeSubscriptionPayload({
+        subscription_id: subscriptionId,
+        customer: {
+          customer_id: customerId,
+          email: "claimed@example.com",
+          name: "Claimed User",
+        },
+        metadata: { wm_user_id: anonId, wm_user_id_sig: anonSig },
+        next_billing_date: "2026-05-21T00:00:00Z",
+      }),
+      timestamp: BASE_TIMESTAMP + 1000,
+    });
+
+    const rows = await t.run(async (ctx) => {
+      const [sub, customer, realEntitlement, anonEntitlement] = await Promise.all([
+        ctx.db.query("subscriptions").withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", subscriptionId)).unique(),
+        ctx.db.query("customers").withIndex("by_dodoCustomerId", (q) => q.eq("dodoCustomerId", customerId)).first(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", realUserId)).first(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", anonId)).first(),
+      ]);
+      return { sub, customer, realEntitlement, anonEntitlement };
+    });
+    expect(rows.sub?.userId).toBe(realUserId);
+    expect(rows.customer?.userId).toBe(realUserId);
+    expect(rows.realEntitlement?.planKey).toBe("pro_monthly");
+    expect(rows.realEntitlement?.validUntil).toBe(new Date("2026-05-21T00:00:00Z").getTime());
+    expect(rows.anonEntitlement).toBeNull();
+  });
+
+  test("subscription.active uses signed real metadata for a new sub even when the Dodo customer row exists", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const t = convexTest(schema, modules);
+    const previousUserId = "user_existing_customer";
+    const newUserId = "user_new_signed_checkout";
+    const customerId = "cust_shared_real";
+    const subscriptionId = "sub_new_signed_real";
+    const userSig = await signUserId(newUserId);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: previousUserId,
+        dodoCustomerId: customerId,
+        email: "shared@example.com",
+        normalizedEmail: "shared@example.com",
+        createdAt: BASE_TIMESTAMP - 1000,
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_new_signed_real_shared_customer",
+      eventType: "subscription.active",
+      rawPayload: makeSubscriptionPayload({
+        subscription_id: subscriptionId,
+        customer: { customer_id: customerId, email: "shared@example.com", name: "Shared Customer" },
+        metadata: { wm_user_id: newUserId, wm_user_id_sig: userSig },
+      }),
+      timestamp: BASE_TIMESTAMP + 1000,
+    });
+
+    const rows = await t.run(async (ctx) => {
+      const [sub, entitlement] = await Promise.all([
+        ctx.db.query("subscriptions").withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", subscriptionId)).unique(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", newUserId)).first(),
+      ]);
+      return { sub, entitlement };
+    });
+    expect(rows.sub?.userId).toBe(newUserId);
+    expect(rows.entitlement?.planKey).toBe("pro_monthly");
+  });
+
+  test("dispute.lost expires only the disputed subscription when another active subscription covers the user", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "user_dispute_multi";
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId,
+        dodoCustomerId: "cust_dispute_multi",
+        email: "multi@example.com",
+        normalizedEmail: "multi@example.com",
+        createdAt: BASE_TIMESTAMP - 1000,
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId,
+        dodoSubscriptionId: "sub_disputed_multi",
+        dodoProductId: "pdt_test_pro",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: BASE_TIMESTAMP - 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP + 30 * 86400000,
+        dodoCustomerId: "cust_dispute_multi",
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId,
+        dodoSubscriptionId: "sub_cover_multi",
+        dodoProductId: "pdt_test_api",
+        planKey: "api_starter",
+        status: "active",
+        currentPeriodStart: BASE_TIMESTAMP - 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP + 45 * 86400000,
+        dodoCustomerId: "cust_dispute_multi",
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: BASE_TIMESTAMP + 30 * 86400000,
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_dispute_multi",
+      eventType: "dispute.lost",
+      rawPayload: makePaymentPayload("payment.succeeded", {
+        payment_id: "pay_dispute_multi",
+        subscription_id: "sub_disputed_multi",
+        customer: { customer_id: "cust_dispute_multi", email: "multi@example.com" },
+        metadata: { wm_user_id: userId },
+      }),
+      timestamp: BASE_TIMESTAMP + 1000,
+    });
+
+    const rows = await t.run(async (ctx) => {
+      const [disputed, cover, entitlement, paymentEvent] = await Promise.all([
+        ctx.db.query("subscriptions").withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", "sub_disputed_multi")).unique(),
+        ctx.db.query("subscriptions").withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", "sub_cover_multi")).unique(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", userId)).first(),
+        ctx.db.query("paymentEvents").withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_dispute_multi")).first(),
+      ]);
+      return { disputed, cover, entitlement, paymentEvent };
+    });
+    expect(rows.disputed?.status).toBe("expired");
+    expect(rows.cover?.status).toBe("active");
+    expect(rows.entitlement?.planKey).toBe("api_starter");
+    expect(rows.entitlement?.validUntil).toBe(BASE_TIMESTAMP + 45 * 86400000);
+    expect(rows.entitlement?.features.tier).toBe(getFeaturesForPlan("api_starter").tier);
+    expect(rows.paymentEvent?.status).toBe("dispute_lost");
+  });
+
+  test("dispute.lost preserves a future complimentary entitlement floor", async () => {
+    const t = convexTest(schema, modules);
+    const userId = "user_dispute_comp";
+    const compUntil = BASE_TIMESTAMP + 60 * 86400000;
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId,
+        dodoSubscriptionId: "sub_dispute_comp",
+        dodoProductId: "pdt_test_pro",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: BASE_TIMESTAMP - 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP + 30 * 86400000,
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: compUntil,
+        compUntil,
+        updatedAt: BASE_TIMESTAMP - 1000,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_dispute_comp",
+      eventType: "dispute.lost",
+      rawPayload: makePaymentPayload("payment.succeeded", {
+        payment_id: "pay_dispute_comp",
+        subscription_id: "sub_dispute_comp",
+        customer: { customer_id: "cust_dispute_comp", email: "comp@example.com" },
+        metadata: { wm_user_id: userId },
+      }),
+      timestamp: BASE_TIMESTAMP + 1000,
+    });
+
+    const rows = await t.run(async (ctx) => {
+      const [sub, entitlement] = await Promise.all([
+        ctx.db.query("subscriptions").withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", "sub_dispute_comp")).unique(),
+        ctx.db.query("entitlements").withIndex("by_userId", (q) => q.eq("userId", userId)).first(),
+      ]);
+      return { sub, entitlement };
+    });
+    expect(rows.sub?.status).toBe("expired");
+    expect(rows.entitlement?.planKey).toBe("pro_monthly");
+    expect(rows.entitlement?.validUntil).toBe(compUntil);
+    expect(rows.entitlement?.compUntil).toBe(compUntil);
   });
 
   // #4436 — Dodo delivers the 3DS/SCA-pending state as a `payment.processing`

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -2583,44 +2583,34 @@ export const claimSubscription = mutation({
       await ctx.db.patch(sub._id, { userId: realUserId });
     }
 
-    // Reassign entitlements — compare by tier first, then validUntil
-    // Use .first() instead of .unique() to avoid throwing on duplicate rows
-    let winningPlanKey: string | null = null;
-    let winningFeatures: ReturnType<typeof getFeaturesForPlan> | null = null;
-    let winningValidUntil: number | null = null;
+    // Move entitlement rows first, then let the shared recompute path derive
+    // the final paid/free state from the post-claim subscriptions. If the
+    // anonymous row carried a future complimentary floor, preserve that floor
+    // on the real user before recompute so support credits survive the claim.
+    const recomputeTimestamp = Date.now();
     if (anonEntitlement) {
       const existingEntitlement = await ctx.db
         .query("entitlements")
         .withIndex("by_userId", (q) => q.eq("userId", realUserId))
         .first();
       if (existingEntitlement) {
-        // Compare by tier first, break ties with validUntil
-        const anonTier = anonEntitlement.features?.tier ?? 0;
-        const existingTier = existingEntitlement.features?.tier ?? 0;
-        const anonWins =
-          anonTier > existingTier ||
-          (anonTier === existingTier && anonEntitlement.validUntil > existingEntitlement.validUntil);
-        if (anonWins) {
-          winningPlanKey = anonEntitlement.planKey;
-          winningFeatures = anonEntitlement.features;
-          winningValidUntil = anonEntitlement.validUntil;
+        const anonCompUntil = anonEntitlement.compUntil ?? 0;
+        const existingCompUntil = existingEntitlement.compUntil ?? 0;
+        if (anonCompUntil > existingCompUntil && anonCompUntil > recomputeTimestamp) {
           await ctx.db.patch(existingEntitlement._id, {
             planKey: anonEntitlement.planKey,
             features: anonEntitlement.features,
-            validUntil: anonEntitlement.validUntil,
-            updatedAt: Date.now(),
+            validUntil: Math.max(existingEntitlement.validUntil, anonEntitlement.validUntil),
+            compUntil: anonCompUntil,
+            updatedAt: recomputeTimestamp,
           });
-        } else {
-          winningPlanKey = existingEntitlement.planKey;
-          winningFeatures = existingEntitlement.features;
-          winningValidUntil = existingEntitlement.validUntil;
         }
         await ctx.db.delete(anonEntitlement._id);
       } else {
-        winningPlanKey = anonEntitlement.planKey;
-        winningFeatures = anonEntitlement.features;
-        winningValidUntil = anonEntitlement.validUntil;
-        await ctx.db.patch(anonEntitlement._id, { userId: realUserId });
+        await ctx.db.patch(anonEntitlement._id, {
+          userId: realUserId,
+          updatedAt: recomputeTimestamp,
+        });
       }
     }
 
@@ -2635,26 +2625,30 @@ export const claimSubscription = mutation({
       await ctx.db.patch(payment._id, { userId: realUserId });
     }
 
+    await recomputeEntitlementFromAllSubs(ctx, realUserId, recomputeTimestamp);
+    const recomputedEntitlement = await ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", realUserId))
+      .first();
+
     // ACCEPTED BOUND: cache sync runs after mutation commits. Stale cache
     // survives up to ENTITLEMENT_CACHE_TTL_SECONDS (900s) if scheduler fails.
-    // Sync Redis cache: clear stale anon entry + write real user's entitlement
+    // Clear stale anon cache and sync the final recomputed real-user state.
     if (process.env.UPSTASH_REDIS_REST_URL) {
-      // Delete the anon ID's stale Redis cache entry
       await ctx.scheduler.runAfter(
         0,
         internal.payments.cacheActions.deleteEntitlementCache,
         { userId: args.anonId },
       );
-      // Sync the real user's entitlement to Redis
-      if (winningPlanKey && winningFeatures && winningValidUntil) {
+      if (recomputedEntitlement) {
         await ctx.scheduler.runAfter(
           0,
           internal.payments.cacheActions.syncEntitlementCache,
           {
             userId: realUserId,
-            planKey: winningPlanKey,
-            features: winningFeatures,
-            validUntil: winningValidUntil,
+            planKey: recomputedEntitlement.planKey,
+            features: recomputedEntitlement.features,
+            validUntil: recomputedEntitlement.validUntil,
           },
         );
       }

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -18,7 +18,7 @@ import type { Id } from "../_generated/dataModel";
 import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
-import { PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
+import { PLAN_PRECEDENCE, PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
 import {
   isNewerEvent,
   recomputeEntitlementFromAllSubs,
@@ -57,6 +57,17 @@ function getDodoClient(
     ...(isLive ? {} : { environment: "test_mode" as const }),
     ...options,
   });
+}
+
+function compareEntitlementPlans(
+  a: { planKey: string; validUntil: number },
+  b: { planKey: string; validUntil: number },
+): number {
+  const tierDelta = getFeaturesForPlan(a.planKey).tier - getFeaturesForPlan(b.planKey).tier;
+  if (tierDelta !== 0) return tierDelta;
+  const rankDelta = (PLAN_PRECEDENCE[a.planKey] ?? 0) - (PLAN_PRECEDENCE[b.planKey] ?? 0);
+  if (rankDelta !== 0) return rankDelta;
+  return a.validUntil - b.validUntil;
 }
 
 // Max Dodo lookups attempted per action INVOCATION (each retrieve is a paid
@@ -2585,8 +2596,8 @@ export const claimSubscription = mutation({
 
     // Move entitlement rows first, then let the shared recompute path derive
     // the final paid/free state from the post-claim subscriptions. If the
-    // anonymous row carried a future complimentary floor, preserve that floor
-    // on the real user before recompute so support credits survive the claim.
+    // anonymous row carried a future complimentary floor, transfer it only
+    // when it does not undercut stronger current real-user coverage.
     const recomputeTimestamp = Date.now();
     if (anonEntitlement) {
       const existingEntitlement = await ctx.db
@@ -2597,13 +2608,53 @@ export const claimSubscription = mutation({
         const anonCompUntil = anonEntitlement.compUntil ?? 0;
         const existingCompUntil = existingEntitlement.compUntil ?? 0;
         if (anonCompUntil > existingCompUntil && anonCompUntil > recomputeTimestamp) {
-          await ctx.db.patch(existingEntitlement._id, {
-            planKey: anonEntitlement.planKey,
-            features: anonEntitlement.features,
-            validUntil: Math.max(existingEntitlement.validUntil, anonEntitlement.validUntil),
-            compUntil: anonCompUntil,
-            updatedAt: recomputeTimestamp,
-          });
+          const realSubscriptions = await ctx.db
+            .query("subscriptions")
+            .withIndex("by_userId", (q) => q.eq("userId", realUserId))
+            .collect();
+          let bestCoveringSubscription: (typeof realSubscriptions)[number] | null = null;
+          for (const candidate of realSubscriptions) {
+            const covers =
+              candidate.status === "active" ||
+              candidate.status === "on_hold" ||
+              (candidate.status === "cancelled" && candidate.currentPeriodEnd > recomputeTimestamp);
+            if (!covers) continue;
+            if (
+              bestCoveringSubscription === null ||
+              compareEntitlementPlans(
+                { planKey: candidate.planKey, validUntil: candidate.currentPeriodEnd },
+                {
+                  planKey: bestCoveringSubscription.planKey,
+                  validUntil: bestCoveringSubscription.currentPeriodEnd,
+                },
+              ) > 0
+            ) {
+              bestCoveringSubscription = candidate;
+            }
+          }
+          const strongestCurrentCoverage = bestCoveringSubscription
+            ? {
+                planKey: bestCoveringSubscription.planKey,
+                validUntil: bestCoveringSubscription.currentPeriodEnd,
+              }
+            : existingEntitlement.validUntil > recomputeTimestamp
+              ? { planKey: existingEntitlement.planKey, validUntil: existingEntitlement.validUntil }
+              : null;
+          const anonCompOutranksCurrentCoverage =
+            strongestCurrentCoverage === null ||
+            compareEntitlementPlans(
+              { planKey: anonEntitlement.planKey, validUntil: anonEntitlement.validUntil },
+              strongestCurrentCoverage,
+            ) >= 0;
+          if (anonCompOutranksCurrentCoverage) {
+            await ctx.db.patch(existingEntitlement._id, {
+              planKey: anonEntitlement.planKey,
+              features: anonEntitlement.features,
+              validUntil: Math.max(existingEntitlement.validUntil, anonEntitlement.validUntil),
+              compUntil: anonCompUntil,
+              updatedAt: recomputeTimestamp,
+            });
+          }
         }
         await ctx.db.delete(anonEntitlement._id);
       } else {

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -10,7 +10,7 @@ import { MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { PLAN_PRECEDENCE, LEGACY_PRODUCT_ALIASES } from "../config/productCatalog";
-import { verifyUserId } from "../lib/identitySigning";
+import { ANON_ID_V4_REGEX, verifyUserId } from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -516,6 +516,20 @@ function mergeDodoCustomerId(
   return existing.dodoCustomerId;
 }
 
+function preferExistingCustomerOwner(
+  existingCustomerUserId: string | undefined,
+  resolvedUserId: string,
+): string {
+  if (
+    existingCustomerUserId !== undefined &&
+    ANON_ID_V4_REGEX.test(resolvedUserId) &&
+    !ANON_ID_V4_REGEX.test(existingCustomerUserId)
+  ) {
+    return existingCustomerUserId;
+  }
+  return resolvedUserId;
+}
+
 /**
  * Handles `subscription.active` -- a new subscription has been activated.
  *
@@ -527,11 +541,6 @@ export async function handleSubscriptionActive(
   eventTimestamp: number,
 ): Promise<void> {
   const planKey = await resolvePlanKey(ctx, data.product_id);
-  const userId = await resolveUserId(
-    ctx,
-    data.customer?.customer_id ?? "",
-    data.metadata,
-  );
 
   const currentPeriodStart = toEpochMs(data.previous_billing_date, "previous_billing_date", eventTimestamp);
   const currentPeriodEnd = toEpochMs(data.next_billing_date, "next_billing_date", eventTimestamp);
@@ -553,6 +562,19 @@ export async function handleSubscriptionActive(
     typeof data.customer?.customer_id === "string" && data.customer.customer_id.length > 0
       ? data.customer.customer_id
       : undefined;
+  const existingCustomer = incomingDodoCustomerId
+    ? await ctx.db
+        .query("customers")
+        .withIndex("by_dodoCustomerId", (q) =>
+          q.eq("dodoCustomerId", incomingDodoCustomerId),
+        )
+        .first()
+    : null;
+  const resolvedUserId = existing?.userId
+    ?? await resolveUserId(ctx, incomingDodoCustomerId ?? "", data.metadata);
+  const userId = existing
+    ? resolvedUserId
+    : preferExistingCustomerOwner(existingCustomer?.userId, resolvedUserId);
 
   if (existing) {
     if (!isNewerEvent(existing.updatedAt, eventTimestamp)) return;
@@ -633,18 +655,10 @@ export async function handleSubscriptionActive(
   await recomputeEntitlementFromAllSubs(ctx, userId, eventTimestamp);
 
   // Upsert customer record so portal session creation can find dodoCustomerId
-  const dodoCustomerId = data.customer?.customer_id;
   const email = data.customer?.email ?? "";
   const normalizedEmail = email.trim().toLowerCase();
 
-  if (dodoCustomerId) {
-    const existingCustomer = await ctx.db
-      .query("customers")
-      .withIndex("by_dodoCustomerId", (q) =>
-        q.eq("dodoCustomerId", dodoCustomerId),
-      )
-      .first();
-
+  if (incomingDodoCustomerId) {
     if (existingCustomer) {
       await ctx.db.patch(existingCustomer._id, {
         userId,
@@ -655,7 +669,7 @@ export async function handleSubscriptionActive(
     } else {
       await ctx.db.insert("customers", {
         userId,
-        dodoCustomerId,
+        dodoCustomerId: incomingDodoCustomerId,
         email,
         normalizedEmail,
         createdAt: eventTimestamp,
@@ -1166,11 +1180,20 @@ export async function handleDisputeEvent(
   eventType: string,
   eventTimestamp: number,
 ): Promise<void> {
-  const userId = await resolveUserId(
-    ctx,
-    data.customer?.customer_id ?? "",
-    data.metadata,
-  );
+  const existingSubscription = data.subscription_id
+    ? await ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", data.subscription_id ?? ""),
+        )
+        .unique()
+    : null;
+  const userId = existingSubscription?.userId
+    ?? await resolveUserId(
+      ctx,
+      data.customer?.customer_id ?? "",
+      data.metadata,
+    );
 
   const disputeStatusMap: Record<string, "dispute_opened" | "dispute_won" | "dispute_lost" | "dispute_closed"> = {
     "dispute.opened": "dispute_opened",
@@ -1198,34 +1221,17 @@ export async function handleDisputeEvent(
 
   if (eventType === "dispute.lost") {
     console.warn(
-      `[subscriptionHelpers] Dispute LOST for user ${userId}, payment ${data.payment_id} — revoking entitlement`,
+      `[subscriptionHelpers] Dispute LOST for user ${userId}, payment ${data.payment_id} — recomputing entitlement`,
     );
-    // Chargeback = no longer entitled. Downgrade to free immediately.
-    // Use eventTimestamp (not Date.now()) to preserve isNewerEvent out-of-order protection.
-    const existing = await ctx.db
-      .query("entitlements")
-      .withIndex("by_userId", (q) => q.eq("userId", userId))
-      .first();
-    if (existing) {
-      const freeFeatures = getFeaturesForPlan("free");
-      await ctx.db.patch(existing._id, {
-        planKey: "free",
-        features: freeFeatures,
-        validUntil: eventTimestamp,
+
+    if (existingSubscription && isNewerEvent(existingSubscription.updatedAt, eventTimestamp)) {
+      await ctx.db.patch(existingSubscription._id, {
+        status: "expired",
+        rawPayload: data,
         updatedAt: eventTimestamp,
       });
-      if (process.env.UPSTASH_REDIS_REST_URL) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.payments.cacheActions.syncEntitlementCache,
-          {
-            userId,
-            planKey: "free",
-            features: freeFeatures,
-            validUntil: eventTimestamp,
-          },
-        );
-      }
     }
+
+    await recomputeEntitlementFromAllSubs(ctx, userId, eventTimestamp);
   }
 }

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -562,6 +562,9 @@ export async function handleSubscriptionActive(
     typeof data.customer?.customer_id === "string" && data.customer.customer_id.length > 0
       ? data.customer.customer_id
       : undefined;
+
+  if (existing && !isNewerEvent(existing.updatedAt, eventTimestamp)) return;
+
   const existingCustomer = incomingDodoCustomerId
     ? await ctx.db
         .query("customers")
@@ -570,14 +573,14 @@ export async function handleSubscriptionActive(
         )
         .first()
     : null;
-  const resolvedUserId = existing?.userId
-    ?? await resolveUserId(ctx, incomingDodoCustomerId ?? "", data.metadata);
+  const resolvedUserId = existing
+    ? existing.userId
+    : await resolveUserId(ctx, incomingDodoCustomerId ?? "", data.metadata);
   const userId = existing
-    ? resolvedUserId
+    ? existing.userId
     : preferExistingCustomerOwner(existingCustomer?.userId, resolvedUserId);
 
   if (existing) {
-    if (!isNewerEvent(existing.updatedAt, eventTimestamp)) return;
     await ctx.db.patch(existing._id, {
       userId,
       status: "active",


### PR DESCRIPTION
## Summary
- Hardened `subscription.active` ownership resolution so existing claimed subscriptions keep their stored real-user owner even when later active webhooks carry stale anonymous checkout metadata.
- Routed dispute/lost revocation through `recomputeEntitlementFromAllSubs` after expiring only the disputed subscription, preserving other active subscriptions and active compensation floors.
- Refactored anonymous subscription claim to finish through the shared recompute path, sync the real-user cache even when the anon entitlement row is missing, and avoid lower-tier anon comp floors suppressing stronger current real-user coverage.

## Intent
Fixes #5056. This is a P1 payment/authorization integrity fix for Convex entitlement lifecycle races across claims, active webhooks, disputes, cancellations, and compensation floors.

## Validation Matrix
| Check | Result |
| --- | --- |
| `npm run test:convex -- convex/__tests__/billing.test.ts convex/__tests__/webhook.test.ts convex/__tests__/comp-entitlement.test.ts` | Passed, 3 files / 136 tests |
| `./node_modules/.bin/tsc --noEmit -p convex/tsconfig.json` | Passed |
| `git diff --check` | Passed |
| `npm run lint` | Passed; reported existing warnings outside the Convex diff |

## Review Gates
- Baseline self-review: passed after tightening customer-owner and comp-floor coverage behavior.
- `$code-review-expert`: passed before publication; rerun locally after Greptile follow-up with no remaining blocking findings.
- Outcome reviewer: passed before publication.
- Greptile: initial P1/P2 findings were addressed in follow-up commit `a298b664d`; awaiting the post-push review/check refresh on the latest head.

## Documentation
No docs changes. This is internal Convex payment lifecycle behavior covered by focused regression tests.

## Screenshots/UI Evidence
Not applicable; no UI changes.

## Residual Findings
None known locally. Post-follow-up CI and Greptile refresh are being monitored on the latest pushed head.
