### PR TITLE
Enforce no-store RPC fallback cache contract

### DIFF
--- a/server/_shared/cache-contract.ts
+++ b/server/_shared/cache-contract.ts
@@ -1,0 +1,63 @@
+export type RpcNoStoreReason =
+  | 'upstream-unavailable'
+  | 'unavailable'
+  | 'data-unavailable'
+  | 'degraded'
+  | 'available-false'
+  | 'error'
+  | 'nonterminal';
+
+interface RpcNoStoreOptions {
+  pathname?: string;
+  includeAvailableFalse?: boolean;
+}
+
+const SCENARIO_STATUS_PATH = '/api/scenario/v1/get-scenario-status';
+const SCENARIO_TERMINAL_STATUSES = new Set(['done', 'failed']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+export function getRpcNoStoreReasonFromPayload(
+  payload: unknown,
+  options: RpcNoStoreOptions = {},
+): RpcNoStoreReason | null {
+  if (!isRecord(payload)) return null;
+
+  if (payload.upstreamUnavailable === true) return 'upstream-unavailable';
+  if (payload.unavailable === true) return 'unavailable';
+  if (payload.dataAvailable === false) return 'data-unavailable';
+  if (payload.degraded === true) return 'degraded';
+  if (options.includeAvailableFalse !== false && payload.available === false) return 'available-false';
+  if (nonEmptyString(payload.error)) return 'error';
+
+  if (options.pathname === SCENARIO_STATUS_PATH && nonEmptyString(payload.status)) {
+    const status = payload.status.trim().toLowerCase();
+    if (!SCENARIO_TERMINAL_STATUSES.has(status)) return 'nonterminal';
+  }
+
+  return null;
+}
+
+export function getRpcNoStoreReasonFromJson(
+  body: string,
+  options: RpcNoStoreOptions = {},
+): RpcNoStoreReason | null {
+  try {
+    return getRpcNoStoreReasonFromPayload(JSON.parse(body), options);
+  } catch {
+    // Keep the previous gateway behavior for non-JSON or malformed bodies
+    // where string markers are still all we can safely inspect.
+    if (body.includes('"upstreamUnavailable":true')) return 'upstream-unavailable';
+    if (body.includes('"unavailable":true')) return 'unavailable';
+    if (body.includes('"dataAvailable":false')) return 'data-unavailable';
+    if (body.includes('"degraded":true')) return 'degraded';
+    if (options.includeAvailableFalse !== false && body.includes('"available":false')) return 'available-false';
+    return null;
+  }
+}

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -1,4 +1,5 @@
 import { unwrapEnvelope } from './seed-envelope';
+import { getRpcNoStoreReasonFromPayload } from './cache-contract';
 import { buildUpstreamEvent, getUsageScope, sendToAxiom } from './usage';
 
 // Default Upstash REST timeouts are tuned for production (Vercel ↔ Upstash
@@ -537,12 +538,18 @@ export async function cachedFetchJson<T extends object>(
   const promise = withFetcherTimeout(fetcher(), key, timeoutMs, 'cachedFetchJson')
     .then(async (result) => {
       if (result != null) {
-        const wrote = await setCachedJson(key, result, ttlSeconds);
-        // Remote Redis write/read failures should not force every caller back
-        // upstream while the isolate is still warm. Sidecar/local mode skips
-        // this bridge because hasRemoteRedisConfig() is false there.
-        if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
-          armLocalPositiveFallback(key, result, ttlSeconds);
+        const noStoreReason = getRpcNoStoreReasonFromPayload(result, { includeAvailableFalse: false });
+        if (noStoreReason) {
+          armLocalNegativeCooldown(key, negativeTtlSeconds);
+          await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
+        } else {
+          const wrote = await setCachedJson(key, result, ttlSeconds);
+          // Remote Redis write/read failures should not force every caller back
+          // upstream while the isolate is still warm. Sidecar/local mode skips
+          // this bridge because hasRemoteRedisConfig() is false there.
+          if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
+            armLocalPositiveFallback(key, result, ttlSeconds);
+          }
         }
       } else {
         armLocalNegativeCooldown(key, negativeTtlSeconds);
@@ -644,12 +651,20 @@ export async function cachedFetchJsonWithMeta<T extends object>(
       // error rates). Use status=0 for the empty branch; cache_status carries
       // the structural detail.
       if (result != null) {
-        upstreamStatus = 200;
-        const wrote = await setCachedJson(key, result, ttlSeconds);
-        // See cachedFetchJson(): this short in-process bridge is only for
-        // remote Redis outages, not local sidecar cache writes.
-        if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
-          armLocalPositiveFallback(key, result, ttlSeconds);
+        const noStoreReason = getRpcNoStoreReasonFromPayload(result, { includeAvailableFalse: false });
+        if (noStoreReason) {
+          upstreamStatus = 0;
+          cacheStatus = 'neg-sentinel';
+          armLocalNegativeCooldown(key, negativeTtlSeconds);
+          await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
+        } else {
+          upstreamStatus = 200;
+          const wrote = await setCachedJson(key, result, ttlSeconds);
+          // See cachedFetchJson(): this short in-process bridge is only for
+          // remote Redis outages, not local sidecar cache writes.
+          if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
+            armLocalPositiveFallback(key, result, ttlSeconds);
+          }
         }
       } else {
         upstreamStatus = 0;

--- a/server/_shared/response-headers.ts
+++ b/server/_shared/response-headers.ts
@@ -21,6 +21,11 @@ export function markNoCacheResponse(req: Request): void {
   setResponseHeader(req, 'X-No-Cache', '1');
 }
 
+export function markNoStoreFallbackResponse<T>(req: Request, payload: T): T {
+  markNoCacheResponse(req);
+  return payload;
+}
+
 export function drainResponseHeaders(req: Request): Record<string, string> | undefined {
   const headers = channel.get(req);
   if (headers) channel.delete(req);

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -21,6 +21,7 @@ import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
 import { drainResponseHeaders, drainSuccessStatusOverride } from './_shared/response-headers';
 import { projectJsonResponse } from './_shared/response-projection';
+import { getRpcNoStoreReasonFromJson } from './_shared/cache-contract';
 import { checkEntitlementDetailed, getRequiredTier, getEntitlements, type CachedEntitlements } from './_shared/entitlement-check';
 import { resolveClerkSession } from './_shared/auth-session';
 import {
@@ -1626,33 +1627,10 @@ export function createDomainGateway(
     if (response.status === 200 && request.method === 'GET' && response.body) {
       const bodyBytes = await response.arrayBuffer();
 
-      // Skip CDN caching for upstream-unavailable / empty responses so CF
-      // doesn't serve stale error data for hours.
-      //
-      // Three field names are in active use across the RPC handlers because the
-      // codebase grew three fallback conventions in parallel:
-      //   - `upstreamUnavailable: true` — used by consumer-prices/intelligence/
-      //     trade handlers that return ad-hoc JSON shapes.
-      //   - `unavailable: true` — proto-typed handlers (every economic RPC
-      //     including get-macro-signals — `bool unavailable = N` in the proto).
-      //   - `dataAvailable: false` — seed-backed handlers that distinguish
-      //     a real empty snapshot from a degraded or missing seed.
-      // The original check only matched the first form, so proto-typed
-      // fallback responses were getting full `medium` cache tier (CF s-maxage
-      // 1200s, browser max-age 1800s). Production incident 2026-05-03: a
-      // 30-min window of auth bug (PR #3541's wm-session interceptor) caused
-      // every macroSignals RPC to return the fallback. Those responses got
-      // cached for 30 min. Even after auth was fixed (PR #3574), browsers
-      // and CF POPs kept serving "Upstream API unavailable" until the cache
-      // TTL expired naturally — 30 min of false-bad UX per affected user.
-      // Detecting all three field names closes that window.
       const bodyStr = new TextDecoder().decode(bodyBytes);
-      const isUpstreamUnavailable =
-        bodyStr.includes('"upstreamUnavailable":true') ||
-        bodyStr.includes('"unavailable":true') ||
-        bodyStr.includes('"dataAvailable":false');
+      const noStoreReason = getRpcNoStoreReasonFromJson(bodyStr, { pathname });
 
-      if (mergedHeaders.get('X-No-Cache') || isUpstreamUnavailable) {
+      if (mergedHeaders.get('X-No-Cache') || noStoreReason) {
         mergedHeaders.set('Cache-Control', 'no-store');
         mergedHeaders.delete('CDN-Cache-Control');
         mergedHeaders.delete('Vercel-CDN-Cache-Control');

--- a/server/worldmonitor/climate/v1/get-co2-monitoring.ts
+++ b/server/worldmonitor/climate/v1/get-co2-monitoring.ts
@@ -7,15 +7,16 @@ import type {
 
 import { CLIMATE_CO2_MONITORING_KEY } from '../../../_shared/cache-keys';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 export const getCo2Monitoring: ClimateServiceHandler['getCo2Monitoring'] = async (
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetCo2MonitoringRequest,
 ): Promise<GetCo2MonitoringResponse> => {
   try {
     const cached = await getCachedJson(CLIMATE_CO2_MONITORING_KEY, true);
-    return (cached as GetCo2MonitoringResponse | null) ?? {};
+    return (cached as GetCo2MonitoringResponse | null) ?? markNoStoreFallbackResponse(ctx.request, {});
   } catch {
-    return {};
+    return markNoStoreFallbackResponse(ctx.request, {});
   }
 };

--- a/server/worldmonitor/climate/v1/get-ocean-ice-data.ts
+++ b/server/worldmonitor/climate/v1/get-ocean-ice-data.ts
@@ -9,6 +9,7 @@ import type {
 
 import { CLIMATE_OCEAN_ICE_KEY } from '../../../_shared/cache-keys';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 type LooseRecord = Record<string, unknown>;
 
@@ -90,13 +91,14 @@ function normalizeOceanIceSeed(value: unknown): GetOceanIceDataResponse {
 }
 
 export const getOceanIceData: ClimateServiceHandler['getOceanIceData'] = async (
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetOceanIceDataRequest,
 ): Promise<GetOceanIceDataResponse> => {
   try {
     const cached = await getCachedJson(CLIMATE_OCEAN_ICE_KEY, true);
-    return normalizeOceanIceSeed(cached);
+    const normalized = normalizeOceanIceSeed(cached);
+    return normalized.data ? normalized : markNoStoreFallbackResponse(ctx.request, normalized);
   } catch {
-    return {};
+    return markNoStoreFallbackResponse(ctx.request, {});
   }
 };

--- a/server/worldmonitor/climate/v1/list-climate-anomalies.ts
+++ b/server/worldmonitor/climate/v1/list-climate-anomalies.ts
@@ -12,15 +12,19 @@ import type {
 
 import { getCachedJson } from '../../../_shared/redis';
 import { CLIMATE_ANOMALIES_KEY } from '../../../_shared/cache-keys';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 export const listClimateAnomalies: ClimateServiceHandler['listClimateAnomalies'] = async (
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListClimateAnomaliesRequest,
 ): Promise<ListClimateAnomaliesResponse> => {
   try {
     const result = await getCachedJson(CLIMATE_ANOMALIES_KEY, true) as ListClimateAnomaliesResponse | null;
-    return { anomalies: result?.anomalies || [], pagination: undefined };
+    if (!result?.anomalies) {
+      return markNoStoreFallbackResponse(ctx.request, { anomalies: [], pagination: undefined });
+    }
+    return { anomalies: result.anomalies, pagination: result.pagination };
   } catch {
-    return { anomalies: [], pagination: undefined };
+    return markNoStoreFallbackResponse(ctx.request, { anomalies: [], pagination: undefined });
   }
 };

--- a/server/worldmonitor/climate/v1/list-climate-disasters.ts
+++ b/server/worldmonitor/climate/v1/list-climate-disasters.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/climate/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'climate:disasters:v1';
 const DEFAULT_LIMIT = 100;
@@ -58,16 +59,22 @@ function normalizeCachedDisaster(row: unknown): ClimateDisaster | null {
 }
 
 export const listClimateDisasters: ClimateServiceHandler['listClimateDisasters'] = async (
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListClimateDisastersRequest,
 ): Promise<ListClimateDisastersResponse> => {
   try {
     const limit = clampInt(req.pageSize, DEFAULT_LIMIT, 1, MAX_LIMIT);
     const offset = parseCursor(req.cursor);
     const result = await getCachedJson(SEED_CACHE_KEY, true) as { disasters?: unknown[] } | null;
-    const allDisasters = Array.isArray(result?.disasters)
-      ? result.disasters.map(normalizeCachedDisaster).filter((row): row is ClimateDisaster => row != null)
-      : [];
+    if (!result || !Array.isArray(result.disasters)) {
+      return markNoStoreFallbackResponse(ctx.request, {
+        disasters: [],
+        pagination: { nextCursor: '', totalCount: 0 },
+      });
+    }
+    const allDisasters = result.disasters
+      .map(normalizeCachedDisaster)
+      .filter((row): row is ClimateDisaster => row != null);
     if (offset >= allDisasters.length) {
       return {
         disasters: [],
@@ -85,9 +92,9 @@ export const listClimateDisasters: ClimateServiceHandler['listClimateDisasters']
       },
     };
   } catch {
-    return {
+    return markNoStoreFallbackResponse(ctx.request, {
       disasters: [],
       pagination: { nextCursor: '', totalCount: 0 },
-    };
+    });
   }
 };

--- a/server/worldmonitor/conflict/v1/list-ucdp-events.ts
+++ b/server/worldmonitor/conflict/v1/list-ucdp-events.ts
@@ -5,6 +5,7 @@ import type {
   UcdpViolenceEvent,
 } from '../../../../src/generated/server/worldmonitor/conflict/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const CACHE_KEY = 'conflict:ucdp-events:v1';
 
@@ -13,16 +14,16 @@ const CACHE_KEY = 'conflict:ucdp-events:v1';
 // Gold standard: Vercel reads, Railway writes.
 
 export async function listUcdpEvents(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListUcdpEventsRequest,
 ): Promise<ListUcdpEventsResponse> {
   try {
     const raw = await getCachedJson(CACHE_KEY, true) as { events?: UcdpViolenceEvent[] } | null;
-    if (!raw?.events?.length) return { events: [], pagination: undefined };
+    if (!raw?.events?.length) return markNoStoreFallbackResponse(ctx.request, { events: [], pagination: undefined });
     let events = raw.events;
     if (req.country) events = events.filter((e) => e.country === req.country);
     return { events, pagination: undefined };
   } catch {
-    return { events: [], pagination: undefined };
+    return markNoStoreFallbackResponse(ctx.request, { events: [], pagination: undefined });
   }
 }

--- a/server/worldmonitor/cyber/v1/list-cyber-threats.ts
+++ b/server/worldmonitor/cyber/v1/list-cyber-threats.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/cyber/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 import {
   DEFAULT_LIMIT,
   MAX_LIMIT,
@@ -45,7 +46,7 @@ function filterSeededThreats(
 }
 
 export async function listCyberThreats(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListCyberThreatsRequest,
 ): Promise<ListCyberThreatsResponse> {
   const empty: ListCyberThreatsResponse = { threats: [], pagination: { nextCursor: '', totalCount: 0 } };
@@ -55,7 +56,9 @@ export async function listCyberThreats(
     const offset = parseCursor(req.cursor);
 
     const seedData = await getCachedJson(SEED_CACHE_KEY, true) as Pick<ListCyberThreatsResponse, 'threats'> | null;
-    if (!seedData?.threats?.length) return empty;
+    if (!seedData || !Array.isArray(seedData.threats)) {
+      return markNoStoreFallbackResponse(ctx.request, empty);
+    }
 
     const allThreats = filterSeededThreats(seedData.threats, req);
     if (offset >= allThreats.length) return empty;
@@ -66,6 +69,6 @@ export async function listCyberThreats(
       pagination: { totalCount: allThreats.length, nextCursor: hasMore ? String(offset + pageSize) : '' },
     };
   } catch {
-    return empty;
+    return markNoStoreFallbackResponse(ctx.request, empty);
   }
 }

--- a/server/worldmonitor/economic/v1/get-bis-credit.ts
+++ b/server/worldmonitor/economic/v1/get-bis-credit.ts
@@ -10,17 +10,18 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:bis:credit:v1';
 
 export async function getBisCredit(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetBisCreditRequest,
 ): Promise<GetBisCreditResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetBisCreditResponse | null;
-    return result || { entries: [] };
+    return result || markNoStoreFallbackResponse(ctx.request, { entries: [] });
   } catch {
-    return { entries: [] };
+    return markNoStoreFallbackResponse(ctx.request, { entries: [] });
   }
 }

--- a/server/worldmonitor/economic/v1/get-bis-exchange-rates.ts
+++ b/server/worldmonitor/economic/v1/get-bis-exchange-rates.ts
@@ -10,17 +10,18 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:bis:eer:v1';
 
 export async function getBisExchangeRates(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetBisExchangeRatesRequest,
 ): Promise<GetBisExchangeRatesResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetBisExchangeRatesResponse | null;
-    return result || { rates: [] };
+    return result || markNoStoreFallbackResponse(ctx.request, { rates: [] });
   } catch {
-    return { rates: [] };
+    return markNoStoreFallbackResponse(ctx.request, { rates: [] });
   }
 }

--- a/server/worldmonitor/economic/v1/get-bis-policy-rates.ts
+++ b/server/worldmonitor/economic/v1/get-bis-policy-rates.ts
@@ -10,17 +10,18 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:bis:policy:v1';
 
 export async function getBisPolicyRates(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetBisPolicyRatesRequest,
 ): Promise<GetBisPolicyRatesResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetBisPolicyRatesResponse | null;
-    return result || { rates: [] };
+    return result || markNoStoreFallbackResponse(ctx.request, { rates: [] });
   } catch {
-    return { rates: [] };
+    return markNoStoreFallbackResponse(ctx.request, { rates: [] });
   }
 }

--- a/server/worldmonitor/economic/v1/get-crude-inventories.ts
+++ b/server/worldmonitor/economic/v1/get-crude-inventories.ts
@@ -10,20 +10,21 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:crude-inventories:v1';
 
 export async function getCrudeInventories(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetCrudeInventoriesRequest,
 ): Promise<GetCrudeInventoriesResponse> {
   try {
     // true = raw key: seed scripts write without Vercel env prefix
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetCrudeInventoriesResponse | null;
-    if (!result?.weeks?.length) return { weeks: [], latestPeriod: '' };
+    if (!result?.weeks?.length) return markNoStoreFallbackResponse(ctx.request, { weeks: [], latestPeriod: '' });
     return result;
   } catch (err) {
     console.error('[getCrudeInventories] Redis read failed:', err);
-    return { weeks: [], latestPeriod: '' };
+    return markNoStoreFallbackResponse(ctx.request, { weeks: [], latestPeriod: '' });
   }
 }

--- a/server/worldmonitor/economic/v1/get-energy-capacity.ts
+++ b/server/worldmonitor/economic/v1/get-energy-capacity.ts
@@ -10,21 +10,22 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:capacity:v1:COL,SUN,WND:20';
 
 export async function getEnergyCapacity(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: GetEnergyCapacityRequest,
 ): Promise<GetEnergyCapacityResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetEnergyCapacityResponse | null;
-    if (!result?.series?.length) return { series: [] };
+    if (!result?.series?.length) return markNoStoreFallbackResponse(ctx.request, { series: [] });
     if (req.energySources.length > 0) {
       return { series: result.series.filter(s => req.energySources.includes(s.energySource)) };
     }
     return result;
   } catch {
-    return { series: [] };
+    return markNoStoreFallbackResponse(ctx.request, { series: [] });
   }
 }

--- a/server/worldmonitor/economic/v1/get-energy-prices.ts
+++ b/server/worldmonitor/economic/v1/get-energy-prices.ts
@@ -10,21 +10,22 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:energy:v1:all';
 
 export async function getEnergyPrices(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: GetEnergyPricesRequest,
 ): Promise<GetEnergyPricesResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetEnergyPricesResponse | null;
-    if (!result?.prices?.length) return { prices: [] };
+    if (!result?.prices?.length) return markNoStoreFallbackResponse(ctx.request, { prices: [] });
     if (req.commodities.length > 0) {
       return { prices: result.prices.filter(p => req.commodities.includes(p.commodity)) };
     }
     return result;
   } catch {
-    return { prices: [] };
+    return markNoStoreFallbackResponse(ctx.request, { prices: [] });
   }
 }

--- a/server/worldmonitor/economic/v1/get-fao-food-price-index.ts
+++ b/server/worldmonitor/economic/v1/get-fao-food-price-index.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:fao-ffpi:v1';
 
@@ -22,14 +23,14 @@ const EMPTY: GetFaoFoodPriceIndexResponse = {
 };
 
 export async function getFaoFoodPriceIndex(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetFaoFoodPriceIndexRequest,
 ): Promise<GetFaoFoodPriceIndexResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetFaoFoodPriceIndexResponse | null;
-    if (!result?.points?.length) return EMPTY;
+    if (!result?.points?.length) return markNoStoreFallbackResponse(ctx.request, EMPTY);
     return result;
   } catch {
-    return EMPTY;
+    return markNoStoreFallbackResponse(ctx.request, EMPTY);
   }
 }

--- a/server/worldmonitor/economic/v1/get-nat-gas-storage.ts
+++ b/server/worldmonitor/economic/v1/get-nat-gas-storage.ts
@@ -10,20 +10,21 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:nat-gas-storage:v1';
 
 export async function getNatGasStorage(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetNatGasStorageRequest,
 ): Promise<GetNatGasStorageResponse> {
   try {
     // true = raw key: seed scripts write without Vercel env prefix
     const result = await getCachedJson(SEED_CACHE_KEY, true) as GetNatGasStorageResponse | null;
-    if (!result?.weeks?.length) return { weeks: [], latestPeriod: '' };
+    if (!result?.weeks?.length) return markNoStoreFallbackResponse(ctx.request, { weeks: [], latestPeriod: '' });
     return result;
   } catch (err) {
     console.error('[getNatGasStorage] Redis read failed:', err);
-    return { weeks: [], latestPeriod: '' };
+    return markNoStoreFallbackResponse(ctx.request, { weeks: [], latestPeriod: '' });
   }
 }

--- a/server/worldmonitor/economic/v1/list-bigmac-prices.ts
+++ b/server/worldmonitor/economic/v1/list-bigmac-prices.ts
@@ -10,20 +10,21 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:bigmac:v1';
 
 export async function listBigMacPrices(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListBigMacPricesRequest,
 ): Promise<ListBigMacPricesResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as ListBigMacPricesResponse | null;
     if (!result?.countries?.length) {
-      return { countries: [], fetchedAt: '', cheapestCountry: '', mostExpensiveCountry: '', wowAvgPct: 0, wowAvailable: false, prevFetchedAt: '' };
+      return markNoStoreFallbackResponse(ctx.request, { countries: [], fetchedAt: '', cheapestCountry: '', mostExpensiveCountry: '', wowAvgPct: 0, wowAvailable: false, prevFetchedAt: '' });
     }
     return result;
   } catch {
-    return { countries: [], fetchedAt: '', cheapestCountry: '', mostExpensiveCountry: '', wowAvgPct: 0, wowAvailable: false, prevFetchedAt: '' };
+    return markNoStoreFallbackResponse(ctx.request, { countries: [], fetchedAt: '', cheapestCountry: '', mostExpensiveCountry: '', wowAvgPct: 0, wowAvailable: false, prevFetchedAt: '' });
   }
 }

--- a/server/worldmonitor/economic/v1/list-fuel-prices.ts
+++ b/server/worldmonitor/economic/v1/list-fuel-prices.ts
@@ -10,20 +10,21 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'economic:fuel-prices:v1';
 
 export async function listFuelPrices(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListFuelPricesRequest,
 ): Promise<ListFuelPricesResponse> {
   try {
     const result = await getCachedJson(SEED_CACHE_KEY, true) as ListFuelPricesResponse | null;
     if (!result?.countries?.length) {
-      return { countries: [], fetchedAt: '', cheapestGasoline: '', cheapestDiesel: '', mostExpensiveGasoline: '', mostExpensiveDiesel: '', wowAvailable: false, prevFetchedAt: '', sourceCount: 0, countryCount: 0 };
+      return markNoStoreFallbackResponse(ctx.request, { countries: [], fetchedAt: '', cheapestGasoline: '', cheapestDiesel: '', mostExpensiveGasoline: '', mostExpensiveDiesel: '', wowAvailable: false, prevFetchedAt: '', sourceCount: 0, countryCount: 0 });
     }
     return result;
   } catch {
-    return { countries: [], fetchedAt: '', cheapestGasoline: '', cheapestDiesel: '', mostExpensiveGasoline: '', mostExpensiveDiesel: '', wowAvailable: false, prevFetchedAt: '', sourceCount: 0, countryCount: 0 };
+    return markNoStoreFallbackResponse(ctx.request, { countries: [], fetchedAt: '', cheapestGasoline: '', cheapestDiesel: '', mostExpensiveGasoline: '', mostExpensiveDiesel: '', wowAvailable: false, prevFetchedAt: '', sourceCount: 0, countryCount: 0 });
   }
 }

--- a/server/worldmonitor/forecast/v1/get-forecast-scorecard.ts
+++ b/server/worldmonitor/forecast/v1/get-forecast-scorecard.ts
@@ -3,6 +3,7 @@ import type {
   GetForecastScorecardResponse,
   ServerContext,
 } from '../../../../src/generated/server/worldmonitor/forecast/v1/service_server';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const REDIS_KEY = 'forecast:scorecard:v1';
 const MAX_STALE_MS = 2160 * 60 * 1000;
@@ -39,12 +40,12 @@ function emptyScorecard(overrides: Partial<GetForecastScorecardResponse> = {}): 
 }
 
 export const getForecastScorecard: ForecastServiceHandler['getForecastScorecard'] = async (
-  _ctx: ServerContext,
+  ctx: ServerContext,
 ): Promise<GetForecastScorecardResponse> => {
   try {
     const envelope = await getScorecardJson();
     const data = envelope.data as Partial<GetForecastScorecardResponse> | null;
-    if (!data) return emptyScorecard();
+    if (!data) return markNoStoreFallbackResponse(ctx.request, emptyScorecard());
     const fetchedAt = Number(envelope.fetchedAt);
     return emptyScorecard({
       ...data,

--- a/server/worldmonitor/forecast/v1/get-forecasts.ts
+++ b/server/worldmonitor/forecast/v1/get-forecasts.ts
@@ -7,18 +7,19 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/forecast/v1/service_server';
 import filterParamContracts from '../../../../shared/openapi-filter-param-contracts.json';
 import { getRawJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const REDIS_KEY = 'forecast:predictions:v2';
 const FORECAST_DOMAINS = new Set(filterParamContracts.forecastDomains);
 
 export const getForecasts: ForecastServiceHandler['getForecasts'] = async (
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: GetForecastsRequest,
 ): Promise<GetForecastsResponse> => {
   try {
     const data = await getRawJson(REDIS_KEY) as { predictions: Forecast[]; generatedAt: number } | null;
     if (!data?.predictions) {
-      return { forecasts: [], generatedAt: 0, degraded: false, stale: false, error: '' };
+      return markNoStoreFallbackResponse(ctx.request, { forecasts: [], generatedAt: 0, degraded: false, stale: false, error: '' });
     }
 
     let forecasts = data.predictions;

--- a/server/worldmonitor/market/v1/list-ai-tokens.ts
+++ b/server/worldmonitor/market/v1/list-ai-tokens.ts
@@ -9,18 +9,19 @@ import type {
   CryptoQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'market:ai-tokens:v1';
 
 type TokenSeedEntry = { name: string; symbol: string; price: number; change24h: number; change7d: number };
 
 export async function listAiTokens(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListAiTokensRequest,
 ): Promise<ListAiTokensResponse> {
   try {
     const seedData = await getCachedJson(SEED_CACHE_KEY, true) as { tokens: TokenSeedEntry[] } | null;
-    if (!seedData?.tokens?.length) return { tokens: [] };
+    if (!seedData?.tokens?.length) return markNoStoreFallbackResponse(ctx.request, { tokens: [] });
     const tokens: CryptoQuote[] = seedData.tokens.map(t => ({
       name: t.name,
       symbol: t.symbol,
@@ -31,6 +32,6 @@ export async function listAiTokens(
     }));
     return { tokens };
   } catch {
-    return { tokens: [] };
+    return markNoStoreFallbackResponse(ctx.request, { tokens: [] });
   }
 }

--- a/server/worldmonitor/market/v1/list-defi-tokens.ts
+++ b/server/worldmonitor/market/v1/list-defi-tokens.ts
@@ -9,18 +9,19 @@ import type {
   CryptoQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'market:defi-tokens:v1';
 
 type TokenSeedEntry = { name: string; symbol: string; price: number; change24h: number; change7d: number };
 
 export async function listDefiTokens(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListDefiTokensRequest,
 ): Promise<ListDefiTokensResponse> {
   try {
     const seedData = await getCachedJson(SEED_CACHE_KEY, true) as { tokens: TokenSeedEntry[] } | null;
-    if (!seedData?.tokens?.length) return { tokens: [] };
+    if (!seedData?.tokens?.length) return markNoStoreFallbackResponse(ctx.request, { tokens: [] });
     const tokens: CryptoQuote[] = seedData.tokens.map(t => ({
       name: t.name,
       symbol: t.symbol,
@@ -31,6 +32,6 @@ export async function listDefiTokens(
     }));
     return { tokens };
   } catch {
-    return { tokens: [] };
+    return markNoStoreFallbackResponse(ctx.request, { tokens: [] });
   }
 }

--- a/server/worldmonitor/market/v1/list-other-tokens.ts
+++ b/server/worldmonitor/market/v1/list-other-tokens.ts
@@ -9,18 +9,19 @@ import type {
   CryptoQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_CACHE_KEY = 'market:other-tokens:v1';
 
 type TokenSeedEntry = { name: string; symbol: string; price: number; change24h: number; change7d: number };
 
 export async function listOtherTokens(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListOtherTokensRequest,
 ): Promise<ListOtherTokensResponse> {
   try {
     const seedData = await getCachedJson(SEED_CACHE_KEY, true) as { tokens: TokenSeedEntry[] } | null;
-    if (!seedData?.tokens?.length) return { tokens: [] };
+    if (!seedData?.tokens?.length) return markNoStoreFallbackResponse(ctx.request, { tokens: [] });
     const tokens: CryptoQuote[] = seedData.tokens.map(t => ({
       name: t.name,
       symbol: t.symbol,
@@ -31,6 +32,6 @@ export async function listOtherTokens(
     }));
     return { tokens };
   } catch {
-    return { tokens: [] };
+    return markNoStoreFallbackResponse(ctx.request, { tokens: [] });
   }
 }

--- a/server/worldmonitor/military/v1/get-theater-posture.ts
+++ b/server/worldmonitor/military/v1/get-theater-posture.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const CACHE_KEY = 'theater-posture:sebuf:v1';
 const STALE_CACHE_KEY = 'theater_posture:sebuf:stale:v1';
@@ -16,7 +17,7 @@ const BACKUP_CACHE_KEY = 'theater-posture:sebuf:backup:v1';
 // Gold standard: Vercel reads, Railway writes.
 
 export async function getTheaterPosture(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: GetTheaterPostureRequest,
 ): Promise<GetTheaterPostureResponse> {
   try {
@@ -34,5 +35,5 @@ export async function getTheaterPosture(
     if (backup?.theaters?.length) return backup;
   } catch { /* empty */ }
 
-  return { theaters: [] };
+  return markNoStoreFallbackResponse(ctx.request, { theaters: [] });
 }

--- a/server/worldmonitor/military/v1/list-defense-patents.ts
+++ b/server/worldmonitor/military/v1/list-defense-patents.ts
@@ -5,19 +5,20 @@ import type {
   DefensePatentFiling,
 } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_KEY = 'patents:defense:latest';
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
 export async function listDefensePatents(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListDefensePatentsRequest,
 ): Promise<ListDefensePatentsResponse> {
   try {
     const result = await getCachedJson(SEED_KEY, true) as { patents?: DefensePatentFiling[]; fetchedAt?: string } | null;
-    if (!result?.patents?.length) {
-      return { patents: [], total: 0, fetchedAt: '' };
+    if (!result || !Array.isArray(result.patents)) {
+      return markNoStoreFallbackResponse(ctx.request, { patents: [], total: 0, fetchedAt: '' });
     }
 
     const total = result.patents.length;
@@ -37,6 +38,6 @@ export async function listDefensePatents(
 
     return { patents, total, fetchedAt: result.fetchedAt ?? '' };
   } catch {
-    return { patents: [], total: 0, fetchedAt: '' };
+    return markNoStoreFallbackResponse(ctx.request, { patents: [], total: 0, fetchedAt: '' });
   }
 }

--- a/server/worldmonitor/research/v1/list-arxiv-papers.ts
+++ b/server/worldmonitor/research/v1/list-arxiv-papers.ts
@@ -11,11 +11,12 @@ import type {
 
 import { clampInt } from '../../../_shared/constants';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_KEY_PREFIX = 'research:arxiv:v1';
 
 export async function listArxivPapers(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListArxivPapersRequest,
 ): Promise<ListArxivPapersResponse> {
   try {
@@ -23,9 +24,9 @@ export async function listArxivPapers(
     const pageSize = clampInt(req.pageSize, 50, 1, 100);
     const seedKey = `${SEED_KEY_PREFIX}:${category}::50`;
     const result = await getCachedJson(seedKey, true) as ListArxivPapersResponse | null;
-    if (!result?.papers?.length) return { papers: [], pagination: undefined };
+    if (!result?.papers?.length) return markNoStoreFallbackResponse(ctx.request, { papers: [], pagination: undefined });
     return { papers: result.papers.slice(0, pageSize), pagination: undefined };
   } catch {
-    return { papers: [], pagination: undefined };
+    return markNoStoreFallbackResponse(ctx.request, { papers: [], pagination: undefined });
   }
 }

--- a/server/worldmonitor/research/v1/list-hackernews-items.ts
+++ b/server/worldmonitor/research/v1/list-hackernews-items.ts
@@ -12,12 +12,13 @@ import type {
 import filterParamContracts from '../../../../shared/openapi-filter-param-contracts.json';
 import { clampInt } from '../../../_shared/constants';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_KEY_PREFIX = 'research:hackernews:v1';
 const ALLOWED_HN_FEEDS = new Set(filterParamContracts.researchHackerNewsFeedTypes);
 
 export async function listHackernewsItems(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListHackernewsItemsRequest,
 ): Promise<ListHackernewsItemsResponse> {
   try {
@@ -25,9 +26,9 @@ export async function listHackernewsItems(
     const pageSize = clampInt(req.pageSize, 30, 1, 100);
     const seedKey = `${SEED_KEY_PREFIX}:${feedType}:30`;
     const result = await getCachedJson(seedKey, true) as ListHackernewsItemsResponse | null;
-    if (!result?.items?.length) return { items: [], pagination: undefined };
+    if (!result?.items?.length) return markNoStoreFallbackResponse(ctx.request, { items: [], pagination: undefined });
     return { items: result.items.slice(0, pageSize), pagination: undefined };
   } catch {
-    return { items: [], pagination: undefined };
+    return markNoStoreFallbackResponse(ctx.request, { items: [], pagination: undefined });
   }
 }

--- a/server/worldmonitor/research/v1/list-trending-repos.ts
+++ b/server/worldmonitor/research/v1/list-trending-repos.ts
@@ -11,11 +11,12 @@ import type {
 
 import { clampInt } from '../../../_shared/constants';
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoStoreFallbackResponse } from '../../../_shared/response-headers';
 
 const SEED_KEY_PREFIX = 'research:trending:v1';
 
 export async function listTrendingRepos(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: ListTrendingReposRequest,
 ): Promise<ListTrendingReposResponse> {
   try {
@@ -24,9 +25,9 @@ export async function listTrendingRepos(
     const pageSize = clampInt(req.pageSize, 50, 1, 100);
     const seedKey = `${SEED_KEY_PREFIX}:${language}:${period}:50`;
     const result = await getCachedJson(seedKey, true) as ListTrendingReposResponse | null;
-    if (!result?.repos?.length) return { repos: [], pagination: undefined };
+    if (!result?.repos?.length) return markNoStoreFallbackResponse(ctx.request, { repos: [], pagination: undefined });
     return { repos: result.repos.slice(0, pageSize), pagination: undefined };
   } catch {
-    return { repos: [], pagination: undefined };
+    return markNoStoreFallbackResponse(ctx.request, { repos: [], pagination: undefined });
   }
 }

--- a/tests/gateway-rpc-no-store-contract.test.mts
+++ b/tests/gateway-rpc-no-store-contract.test.mts
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+import { createDomainGateway } from '../server/gateway.ts';
+import { getEnergyPrices } from '../server/worldmonitor/economic/v1/get-energy-prices.ts';
+import type { RouteDescriptor } from '../server/router.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const TEST_KEY = 'cache-contract-test-key';
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+function setGatewayAuthEnv() {
+  process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+}
+
+function request(pathAndQuery: string): Request {
+  setGatewayAuthEnv();
+  const separator = pathAndQuery.includes('?') ? '&' : '?';
+  return new Request('https://worldmonitor.app' + pathAndQuery + separator + '_debug=1', {
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      'X-WorldMonitor-Key': TEST_KEY,
+    },
+  });
+}
+
+function jsonRoute(path: string, payload: unknown): RouteDescriptor {
+  return {
+    method: 'GET',
+    path,
+    handler: async () => new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  };
+}
+
+function assertNoStore(res: Response): void {
+  assert.equal(res.headers.get('Cache-Control'), 'no-store');
+  assert.equal(res.headers.get('X-Cache-Tier'), 'no-store');
+  assert.equal(res.headers.get('CDN-Cache-Control'), null);
+  assert.equal(res.headers.get('Vercel-CDN-Cache-Control'), null);
+}
+
+function assertCacheable(res: Response): void {
+  assert.notEqual(res.headers.get('Cache-Control'), 'no-store');
+  assert.match(res.headers.get('Cache-Control') ?? '', /max-age=/);
+  assert.notEqual(res.headers.get('X-Cache-Tier'), 'no-store');
+}
+
+describe('gateway RPC no-store contract', () => {
+  it('forces no-store for degraded, unavailable, nonterminal, and error-shaped 200 payloads', async () => {
+    const handler = createDomainGateway([
+      jsonRoute('/api/scenario/v1/get-scenario-status', { status: 'pending', error: '' }),
+      jsonRoute('/api/intelligence/v1/get-risk-scores', { ciiScores: [], strategicRisks: [], degraded: true, stale: true }),
+      jsonRoute('/api/forecast/v1/get-forecasts', { forecasts: [], generatedAt: 0, degraded: true, stale: false, error: 'forecast_backend_unavailable' }),
+      jsonRoute('/api/market/v1/analyze-stock', { available: false, symbol: 'XYZ', error: '' }),
+      jsonRoute('/api/climate/v1/list-climate-anomalies', { anomalies: [], dataAvailable: false }),
+    ]);
+
+    for (const path of [
+      '/api/scenario/v1/get-scenario-status?jobId=scenario:1712345678901:abcdefgh',
+      '/api/intelligence/v1/get-risk-scores',
+      '/api/forecast/v1/get-forecasts',
+      '/api/market/v1/analyze-stock?symbol=XYZ',
+      '/api/climate/v1/list-climate-anomalies',
+    ]) {
+      const res = await handler(request(path));
+      assert.equal(res.status, 200, path);
+      assertNoStore(res);
+    }
+  });
+
+  it('keeps semantically healthy empty results cacheable', async () => {
+    const handler = createDomainGateway([
+      jsonRoute('/api/forecast/v1/get-forecasts', {
+        forecasts: [],
+        generatedAt: 123,
+        degraded: false,
+        stale: false,
+        error: '',
+      }),
+    ]);
+
+    const res = await handler(request('/api/forecast/v1/get-forecasts?domain=nonexistent'));
+
+    assert.equal(res.status, 200);
+    assertCacheable(res);
+  });
+
+  it('lets a bare energy seed miss opt into no-store through the handler side channel', async () => {
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/economic/v1/get-energy-prices',
+        handler: async (req) => {
+          const result = await getEnergyPrices({
+            request: req,
+            pathParams: {},
+            headers: Object.fromEntries(req.headers.entries()),
+          }, { commodities: [] });
+          return new Response(JSON.stringify(result), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    ]);
+
+    const res = await handler(request('/api/economic/v1/get-energy-prices'));
+    const body = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(body, { prices: [] });
+    assertNoStore(res);
+  });
+});
+
+const PROTECTED_HIGH_TIER_EMPTY_HANDLERS = [
+  'server/worldmonitor/economic/v1/get-energy-prices.ts',
+  'server/worldmonitor/economic/v1/get-energy-capacity.ts',
+  'server/worldmonitor/economic/v1/get-crude-inventories.ts',
+  'server/worldmonitor/economic/v1/get-nat-gas-storage.ts',
+  'server/worldmonitor/economic/v1/list-fuel-prices.ts',
+  'server/worldmonitor/economic/v1/list-bigmac-prices.ts',
+  'server/worldmonitor/economic/v1/get-fao-food-price-index.ts',
+  'server/worldmonitor/economic/v1/get-bis-policy-rates.ts',
+  'server/worldmonitor/economic/v1/get-bis-exchange-rates.ts',
+  'server/worldmonitor/economic/v1/get-bis-credit.ts',
+  'server/worldmonitor/climate/v1/get-co2-monitoring.ts',
+  'server/worldmonitor/climate/v1/get-ocean-ice-data.ts',
+  'server/worldmonitor/climate/v1/list-climate-anomalies.ts',
+  'server/worldmonitor/climate/v1/list-climate-disasters.ts',
+  'server/worldmonitor/conflict/v1/list-ucdp-events.ts',
+  'server/worldmonitor/cyber/v1/list-cyber-threats.ts',
+  'server/worldmonitor/forecast/v1/get-forecasts.ts',
+  'server/worldmonitor/forecast/v1/get-forecast-scorecard.ts',
+  'server/worldmonitor/market/v1/list-defi-tokens.ts',
+  'server/worldmonitor/market/v1/list-ai-tokens.ts',
+  'server/worldmonitor/market/v1/list-other-tokens.ts',
+  'server/worldmonitor/research/v1/list-arxiv-papers.ts',
+  'server/worldmonitor/research/v1/list-hackernews-items.ts',
+  'server/worldmonitor/research/v1/list-trending-repos.ts',
+  'server/worldmonitor/military/v1/get-theater-posture.ts',
+  'server/worldmonitor/military/v1/list-defense-patents.ts',
+] as const;
+
+const HEALTHY_EMPTY_ALLOWLIST = new Set([
+  "server/worldmonitor/forecast/v1/get-forecasts.ts::{ forecasts: [], generatedAt: data.generatedAt || 0, degraded: false, stale: false, error: '' }",
+  "server/worldmonitor/forecast/v1/get-forecast-scorecard.ts::{ schemaVersion: 1, generatedAt: 0, rollingWindowDays: 180, methodology: '', totals: { entries: 0, resolved: 0, pending: 0, pendingJudge: 0, scored: 0, void: 0, voidRate: 0, publicationCoverage: 0, }, byDomain: [], byGenerationOrigin: [], calibration: [], degraded: false, stale: false, error: '', ...overrides, }",
+  "server/worldmonitor/climate/v1/list-climate-disasters.ts::{ disasters: [], pagination: { nextCursor: '', totalCount: allDisasters.length }, }",
+]);
+
+function propName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return null;
+}
+
+function boolLiteral(node: ts.Expression): boolean | null {
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
+  return null;
+}
+
+function objectHasEmptyArrayPayload(node: ts.ObjectLiteralExpression): boolean {
+  return node.properties.some((prop) => {
+    if (!ts.isPropertyAssignment(prop)) return false;
+    return ts.isArrayLiteralExpression(prop.initializer) && prop.initializer.elements.length === 0;
+  });
+}
+
+function objectHasNoStoreMarker(node: ts.ObjectLiteralExpression): boolean {
+  return node.properties.some((prop) => {
+    if (!ts.isPropertyAssignment(prop)) return false;
+    const name = propName(prop.name);
+    if (name === 'upstreamUnavailable' || name === 'unavailable' || name === 'degraded') {
+      return boolLiteral(prop.initializer) === true;
+    }
+    if (name === 'dataAvailable' || name === 'available') {
+      return boolLiteral(prop.initializer) === false;
+    }
+    return false;
+  });
+}
+
+function unwrapNoStoreCall(expr: ts.Expression): boolean {
+  return ts.isCallExpression(expr)
+    && ts.isIdentifier(expr.expression)
+    && expr.expression.text === 'markNoStoreFallbackResponse';
+}
+
+describe('high-tier bare-empty source guard', () => {
+  it('requires protected high-tier empty seed-miss returns to carry no-store metadata', () => {
+    const failures: string[] = [];
+
+    for (const relative of PROTECTED_HIGH_TIER_EMPTY_HANDLERS) {
+      const absolute = resolve(root, relative);
+      const source = readFileSync(absolute, 'utf8');
+      const sourceFile = ts.createSourceFile(absolute, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+
+      function visit(node: ts.Node): void {
+        if (ts.isReturnStatement(node) && node.expression) {
+          const expr = node.expression;
+          if (unwrapNoStoreCall(expr)) return;
+          if (ts.isObjectLiteralExpression(expr) && objectHasEmptyArrayPayload(expr) && !objectHasNoStoreMarker(expr)) {
+            const snippet = expr.getText(sourceFile).replace(/\s+/g, ' ').trim();
+            const key = relative + '::' + snippet;
+            if (!HEALTHY_EMPTY_ALLOWLIST.has(key)) failures.push(key);
+          }
+        }
+        ts.forEachChild(node, visit);
+      }
+
+      visit(sourceFile);
+    }
+
+    assert.deepEqual(failures, []);
+  });
+});

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -135,6 +135,42 @@ describe('redis caching behavior', { concurrency: 1 }, () => {
     }
   });
 
+  it('does not positive-cache no-store fallback payloads', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    const setValues = [];
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (isSetRequest(url, init)) {
+        const parsed = parseSetRequest(url, init);
+        setValues.push(parsed);
+        return jsonResponse({ result: 'OK' });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const fallback = { items: [], degraded: true, error: 'upstream_unavailable' };
+      const result = await redis.cachedFetchJson('meta:test:no-store', 60, async () => fallback);
+
+      assert.deepEqual(result, fallback);
+      assert.equal(setValues.length, 1);
+      assert.equal(JSON.parse(setValues[0].value), '__WM_NEG__');
+      assert.equal(setValues[0].ttlSeconds, 120);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   it('parses pipeline results and skips malformed entries', async () => {
     const redis = await importRedisFresh();
     const restoreEnv = withEnv({
@@ -919,6 +955,7 @@ describe('theater posture caching behavior', { concurrency: 1 }, () => {
       './_shared': resolve(root, 'server/worldmonitor/military/v1/_shared.ts'),
       '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
       '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
+      '../../../_shared/response-headers': resolve(root, 'server/_shared/response-headers.ts'),
     });
   }
 
@@ -957,7 +994,7 @@ describe('theater posture caching behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      const result = await module.getTheaterPosture({}, {});
+      const result = await module.getTheaterPosture({ request: new Request('https://worldmonitor.app/api/military/v1/get-theater-posture') }, {});
       assert.equal(openskyFetchCount, 0, 'must not call upstream APIs (Redis-read-only)');
       assert.deepEqual(result, liveData, 'should return live Redis data');
     } finally {
@@ -1004,7 +1041,7 @@ describe('theater posture caching behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      const result = await module.getTheaterPosture({}, {});
+      const result = await module.getTheaterPosture({ request: new Request('https://worldmonitor.app/api/military/v1/get-theater-posture') }, {});
       assert.deepEqual(result, staleData, 'should return stale cache when upstreams fail');
     } finally {
       cleanup();
@@ -1041,7 +1078,7 @@ describe('theater posture caching behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      const result = await module.getTheaterPosture({}, {});
+      const result = await module.getTheaterPosture({ request: new Request('https://worldmonitor.app/api/military/v1/get-theater-posture') }, {});
       assert.deepEqual(result, { theaters: [] }, 'should return empty when all tiers exhausted');
     } finally {
       cleanup();
@@ -1072,7 +1109,7 @@ describe('theater posture caching behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      await module.getTheaterPosture({}, {});
+      await module.getTheaterPosture({ request: new Request('https://worldmonitor.app/api/military/v1/get-theater-posture') }, {});
       assert.equal(cacheWrites.length, 0, 'handler must not write to Redis (read-only)');
     } finally {
       cleanup();


### PR DESCRIPTION
## Summary

- Adds a shared RPC cache-contract helper for `unavailable`, `upstreamUnavailable`, `dataAvailable:false`, `degraded`, `available:false`, non-empty `error`, and nonterminal scenario status payloads.
- Applies the helper in the gateway so transient/degraded 200 responses get `Cache-Control: no-store` and no CDN cache headers.
- Prevents Redis positive-cache writes for fallback-shaped payloads, while preserving normal cacheability for semantically healthy empty results.
- Marks high-tier seeded bare-empty seed misses through the existing response-header side channel and adds a source-walk guard for future drift.

Fixes #5053

## Intent

The issue is harmful cache-contract drift: transient seed misses, degraded fallbacks, and pending poll responses can look like valid 200 JSON and then get pinned by Redis, CDN, or browser caches. This PR centralizes that policy instead of adding one-off per-route header edits, and keeps valid filtered empties cacheable.

## Validation Matrix

| Check | Result |
| --- | --- |
| `./node_modules/.bin/tsx --test tests/gateway-rpc-no-store-contract.test.mts` | Pass: 4 tests |
| `./node_modules/.bin/tsx --test tests/redis-caching.test.mjs` | Pass: 34 tests |
| `./node_modules/.bin/tsx --test tests/empty-200-degradation-handlers.test.mts` | Pass: 7 tests |
| `./node_modules/.bin/tsx --test tests/forecast-get-forecasts.test.mts` | Pass: 6 tests |
| `./node_modules/.bin/tsx --test tests/forecast-get-scorecard.test.mts` | Pass: 3 tests |
| `./node_modules/.bin/tsx --test tests/scenario-handler.test.mjs` | Pass: 18 tests |
| `./node_modules/.bin/tsx --test tests/route-cache-tier.test.mjs` | Pass: 5 tests |
| `./node_modules/.bin/tsx --test tests/gateway-cdn-origin-policy.test.mts` | Pass: 12 tests |
| `npm run typecheck:api` | Pass |
| `git diff --check` / `git diff --cached --check` | Pass |

## Review Gates

- Baseline review: pass; scoped diff reviewed against issue acceptance criteria.
- `$code-review-expert`: pass; SOLID/security/code-quality checklist review found no remaining blocking findings.
- Outcome review: pass; representative gateway headers, Redis write behavior, seed-miss side channel, nonterminal scenario response, degraded risk/forecast cases, and healthy-empty cacheability are covered.
- Fixed during review: updated the redis-caching theater-posture fixture to rewrite the new response-headers import and pass a realistic request context for direct handler calls.

## Documentation

No docs changes. This is an internal API cache-contract fix covered by focused tests.

## Screenshots/UI Evidence

Not applicable; API/server cache behavior only.

## Residual Findings

- Full repository test suite was not run; focused cache/API suites and `typecheck:api` passed.
- `npm run worktree:bootstrap:test-only` completed, but no local env source was found for this worktree; credentialed/live checks were not attempted.
- Dependency audit findings reported by npm/GitHub are pre-existing and unrelated to this patch.
