### PR TITLE
test(news): stabilize completeness selection attribution fixture

### DIFF
--- a/tests/completeness-measurement.test.mjs
+++ b/tests/completeness-measurement.test.mjs
@@ -299,9 +299,10 @@ describe('feed-health streak continuity (#4927 external review)', () => {
 
 describe('selection attribution: same-source overflow (#4927 re-review)', () => {
   it('REGRESSION: candidates past maxCount are cap-attributed when their source already hit the cap', () => {
+    const pubDate = '2026-01-01T00:00:00.000Z';
     const mk = (title, source) => ({
       primaryTitle: title, primarySource: source, primaryLink: `https://x/${title}`,
-      pubDate: new Date().toISOString(), sources: [source, 'Wire'], isAlert: true, tier: 1,
+      pubDate, sources: [source, 'Wire'], isAlert: true, tier: 1,
     });
     // 3 selected from SameSource (hits MAX_PER_SOURCE), then 2 distinct fill
     // maxCount=5; then: 1 more SameSource (cap drop even though selection is


### PR DESCRIPTION
## Summary

The completeness attribution regression now exercises the source-cap path deterministically instead of depending on millisecond-level fixture timing.

`selectTopStories()` legitimately recency-sorts same-score candidates before attribution. The old fixture gave every candidate a fresh timestamp, so CI could reorder `s4` ahead of the first three `SameSource` stories and count the later candidates as overflow. The fixture now pins a single publication time for every candidate, preserving the intended equal-score/input-order contract while leaving production selection behavior unchanged.

## Validation

- `TMPDIR=/private/tmp VITE_VARIANT=full ./node_modules/.bin/vite build`
- `TMPDIR=/private/tmp npx tsx --test tests/completeness-measurement.test.mjs`
- `TMPDIR=/private/tmp npm run test:data` (14,225 tests, 0 failed, 6 skipped)
- `git push -u origin HEAD` pre-push hook: typecheck, API typecheck, Convex typecheck, architectural boundaries, safe HTML sink guard, rate-limit policy coverage, premium-fetch parity, edge bundle check, changed test file, and version sync

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
