### PR TITLE
Stop aviation failure payloads from poisoning caches

### DIFF
--- a/server/worldmonitor/aviation/v1/get-carrier-ops.ts
+++ b/server/worldmonitor/aviation/v1/get-carrier-ops.ts
@@ -5,6 +5,7 @@ import type {
     CarrierOpsSummary,
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
+import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { parseStringArray, DEFAULT_WATCHED_AIRPORTS } from './_shared';
 import { listAirportFlights } from './list-airport-flights';
 
@@ -19,14 +20,17 @@ export async function getCarrierOps(
     const minFlights = req.minFlights ?? 3;
     const cacheKey = `aviation:carrier-ops:${airports.sort().join(',')}:v1`;
     const now = Date.now();
+    let unavailableSource = 'unavailable';
 
     try {
-        const result = await cachedFetchJson<{ carriers: CarrierOpsSummary[] }>(
+        const result = await cachedFetchJson<{ carriers: CarrierOpsSummary[]; source: 'aviationstack' }>(
             cacheKey, CACHE_TTL, async () => {
                 // Fetch flights for each airport
                 type FI = import('../../../../src/generated/server/worldmonitor/aviation/v1/service_server').FlightInstance;
                 const allFlights: FI[] = [];
                 const flightAirportMap = new Map<FI, string>();
+                const childUnavailableSources = new Set<string>();
+                let successfulChildren = 0;
 
                 const flightPromises = airports.map(airport =>
                     listAirportFlights(ctx, {
@@ -36,18 +40,34 @@ export async function getCarrierOps(
                     }).then(resp => ({
                         airport,
                         flights: resp.flights,
+                        source: resp.source,
                     })),
                 );
 
                 const flightResults = await Promise.allSettled(flightPromises);
 
-                for (const result of flightResults) {
-                    if (result.status !== 'fulfilled') continue;
-                    const { airport, flights } = result.value;
+                for (const child of flightResults) {
+                    if (child.status !== 'fulfilled') {
+                        childUnavailableSources.add('error');
+                        continue;
+                    }
+                    const { airport, flights, source } = child.value;
+                    if (source !== 'aviationstack') {
+                        childUnavailableSources.add(source || 'unavailable');
+                        continue;
+                    }
+                    successfulChildren++;
                     for (const f of flights) {
                         allFlights.push(f);
                         flightAirportMap.set(f, airport);
                     }
+                }
+
+                if (childUnavailableSources.size > 0) {
+                    unavailableSource = successfulChildren > 0
+                        ? 'partial'
+                        : [...childUnavailableSources][0] ?? 'unavailable';
+                    return null;
                 }
 
                 // Group by carrier.iataCode + airport
@@ -89,17 +109,27 @@ export async function getCarrierOps(
                 // Sort by worst cancellation rate then delay pct
                 carriers.sort((a, b) => b.cancellationRate - a.cancellationRate || b.delayPct - a.delayPct);
 
-                return { carriers };
+                return { carriers, source: 'aviationstack' };
             }
         );
 
+        if (!result) {
+            markNoCacheResponse(ctx.request);
+            return {
+                carriers: [],
+                source: unavailableSource,
+                updatedAt: now,
+            };
+        }
+
         return {
-            carriers: (result?.carriers ?? []).filter(c => c.totalFlights >= minFlights),
-            source: 'aviationstack',
+            carriers: result.carriers.filter(c => c.totalFlights >= minFlights),
+            source: result.source,
             updatedAt: now,
         };
     } catch (err) {
         console.warn(`[Aviation] GetCarrierOps failed: ${err instanceof Error ? err.message : err}`);
+        markNoCacheResponse(ctx.request);
         return { carriers: [], source: 'error', updatedAt: now };
     }
 }

--- a/server/worldmonitor/aviation/v1/get-flight-status.ts
+++ b/server/worldmonitor/aviation/v1/get-flight-status.ts
@@ -5,6 +5,7 @@ import type {
     FlightInstance,
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
+import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
 
@@ -52,7 +53,7 @@ function normalizeFlight(f: AVSFlight, now: number): FlightInstance {
 }
 
 export async function getFlightStatus(
-    _ctx: ServerContext,
+    ctx: ServerContext,
     req: GetFlightStatusRequest,
 ): Promise<GetFlightStatusResponse> {
     // Normalize: strip leading zeros from numeric suffix (EK03 → EK3, BA002 → BA2)
@@ -64,21 +65,27 @@ export async function getFlightStatus(
     const now = Date.now();
 
     if (!flightNumber || flightNumber.length > 10) {
+        markNoCacheResponse(ctx.request);
         return { flights: [], source: 'error', cacheHit: false };
     }
 
+    let unavailableSource = 'unavailable';
+
     try {
-        const result = await cachedFetchJson<{ flights: FlightInstance[]; source: string }>(
+        const result = await cachedFetchJson<{ flights: FlightInstance[]; source: 'aviationstack' }>(
             cacheKey, CACHE_TTL, async () => {
                 const relayBase = getRelayBaseUrl();
                 if (!relayBase) {
-                    return { flights: [], source: 'no-relay' };
+                    unavailableSource = 'no-relay';
+                    return null;
                 }
 
-                // Monthly quota guard — once the request-time budget is spent,
-                // serve empty (cached briefly) rather than calling upstream.
+                // Monthly quota guard: once the request-time budget is spent,
+                // negative-cache the unavailable state rather than storing an
+                // empty positive flight-status result.
                 if (!(await reserveAviationStackCalls(1, 'request'))) {
-                    return { flights: [], source: 'budget' };
+                    unavailableSource = 'budget';
+                    return null;
                 }
 
                 const params = new URLSearchParams({
@@ -101,18 +108,29 @@ export async function getFlightStatus(
                     return { flights, source: 'aviationstack' };
                 } catch (err) {
                     console.warn(`[Aviation] Flight status relay fetch failed for ${flightNumber}: ${err instanceof Error ? err.message : err}`);
-                    return { flights: [], source: 'error' };
+                    unavailableSource = 'error';
+                    return null;
                 }
             }
         );
 
+        if (!result) {
+            markNoCacheResponse(ctx.request);
+            return {
+                flights: [],
+                source: unavailableSource,
+                cacheHit: false,
+            };
+        }
+
         return {
-            flights: result?.flights ?? [],
-            source: result?.source ?? 'unknown',
+            flights: result.flights,
+            source: result.source,
             cacheHit: false,
         };
     } catch (err) {
         console.warn(`[Aviation] GetFlightStatus failed for ${flightNumber}: ${err instanceof Error ? err.message : err}`);
+        markNoCacheResponse(ctx.request);
         return { flights: [], source: 'error', cacheHit: false };
     }
 }

--- a/server/worldmonitor/aviation/v1/list-airport-flights.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-flights.ts
@@ -8,6 +8,7 @@ import type {
     AirportRef,
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
+import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
 
@@ -98,12 +99,12 @@ function normalizeFlights(flights: AVSFlight[], now: number): FlightInstance[] {
 
 // Response-level source values (ListAirportFlightsResponse.source):
 //   'aviationstack' — live data from AviationStack via relay
-//   'none'          — relay not configured; flights = []
-//   'error'         — relay fetch failed; flights = []
+//   'none'          — relay not configured; flights = [] (no-store, negative cached)
+//   'error'         — relay fetch failed; flights = [] (no-store, negative cached)
 //   'invalid'       — malformed airport code; rejected before any paid call
-//   'budget'        — monthly AviationStack budget reached; serving empty
+//   'budget'        — monthly AviationStack budget reached; serving empty (no-store, negative cached)
 export async function listAirportFlights(
-    _ctx: ServerContext,
+    ctx: ServerContext,
     req: ListAirportFlightsRequest,
 ): Promise<ListAirportFlightsResponse> {
     const airport = req.airport?.toUpperCase() || 'IST';
@@ -120,19 +121,22 @@ export async function listAirportFlights(
     // Cache key is limit-independent (see UPSTREAM_PAGE) — one upstream call
     // serves every limit for this airport+direction.
     const cacheKey = `aviation:flights:${airport}:${direction}:v2:${aviationStackBudgetMonth()}`;
+    let unavailableSource = 'unavailable';
 
     try {
-        const result = await cachedFetchJson<{ flights: FlightInstance[]; source: string }>(
+        const result = await cachedFetchJson<{ flights: FlightInstance[]; source: 'aviationstack' }>(
             cacheKey, CACHE_TTL, async () => {
                 const relayBase = getRelayBaseUrl();
                 if (!relayBase) {
-                    return { flights: [], source: 'none' };
+                    unavailableSource = 'none';
+                    return null;
                 }
 
-                // Monthly quota guard — serve empty (cached briefly) instead of
-                // calling upstream once the request-time budget is exhausted.
+                // Monthly quota guard: negative-cache the unavailable state
+                // instead of positive-caching an empty flight board.
                 if (!(await reserveAviationStackCalls(1, 'request'))) {
-                    return { flights: [], source: 'budget' };
+                    unavailableSource = 'budget';
+                    return null;
                 }
 
                 const paramKey = direction === 'FLIGHT_DIRECTION_ARRIVAL' ? 'arr_iata' : 'dep_iata';
@@ -154,20 +158,32 @@ export async function listAirportFlights(
                     return { flights, source: 'aviationstack' };
                 } catch (err) {
                     console.warn(`[Aviation] Flights relay fetch failed for ${airport}: ${err instanceof Error ? err.message : err}`);
-                    return { flights: [], source: 'error' };
+                    unavailableSource = 'error';
+                    return null;
                 }
             }
         );
 
-        const flights = result?.flights ?? [];
+        if (!result) {
+            markNoCacheResponse(ctx.request);
+            return {
+                flights: [],
+                totalAvailable: 0,
+                source: unavailableSource,
+                updatedAt: now,
+            };
+        }
+
+        const flights = result.flights;
         return {
             flights: flights.slice(0, limit),
             totalAvailable: flights.length,
-            source: result?.source ?? 'unknown',
+            source: result.source,
             updatedAt: now,
         };
     } catch (err) {
         console.warn(`[Aviation] ListAirportFlights error: ${err instanceof Error ? err.message : err}`);
+        markNoCacheResponse(ctx.request);
         return { flights: [], totalAvailable: 0, source: 'error', updatedAt: now };
     }
 }

--- a/tests/aviation-budget-cap.test.mjs
+++ b/tests/aviation-budget-cap.test.mjs
@@ -131,12 +131,12 @@ describe('aviation budget: call sites are wired to the cap', () => {
     assert.match(src, /flights\.slice\(0, limit\)/);
   });
 
-  it('get-flight-status reserves budget before the upstream call and caches relay errors', () => {
+  it('get-flight-status reserves budget before the upstream call and negative-caches relay errors', () => {
     const src = read('server/worldmonitor/aviation/v1/get-flight-status.ts');
     assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
     assert.match(src, /aviation:status:\$\{flightNumber\}:\$\{date\}:\$\{origin\}:v1:\$\{aviationStackBudgetMonth\(\)\}/);
     assert.match(src, /Flight status relay fetch failed/);
-    assert.match(src, /return \{ flights: \[\], source: 'error' \}/);
+    assert.match(src, /unavailableSource = 'error';\n\s+return null;/);
   });
 
   it('seeder reserves its batch against the same shared counter + key', () => {

--- a/tests/aviation-cache-poison.test.mts
+++ b/tests/aviation-cache-poison.test.mts
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { createDomainGateway, serverOptions } from '../server/gateway.ts';
+import { drainResponseHeaders } from '../server/_shared/response-headers.ts';
+import { createAviationServiceRoutes } from '../src/generated/server/worldmonitor/aviation/v1/service_server.ts';
+import { aviationHandler } from '../server/worldmonitor/aviation/v1/handler.ts';
+import { listAirportFlights } from '../server/worldmonitor/aviation/v1/list-airport-flights.ts';
+import { getFlightStatus } from '../server/worldmonitor/aviation/v1/get-flight-status.ts';
+import { getCarrierOps } from '../server/worldmonitor/aviation/v1/get-carrier-ops.ts';
+
+const ENV_KEYS = [
+  'AVIATIONSTACK_MONTHLY_BUDGET',
+  'AVIATIONSTACK_REQUEST_BUDGET',
+  'LOCAL_API_MODE',
+  'RELAY_AUTH_HEADER',
+  'RELAY_SHARED_SECRET',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'UPSTASH_REDIS_REST_URL',
+  'WORLDMONITOR_VALID_KEYS',
+  'WS_RELAY_URL',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const originalFetch = globalThis.fetch;
+
+type RelayMode = 'ok-empty' | 'http-503' | ((url: string) => Response);
+
+type FetchMockOptions = {
+  relay?: RelayMode;
+  denyBudget?: boolean;
+};
+
+type RedisSetCommand = ['SET', string, string, 'EX', string];
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+});
+
+function installFetchMock(options: FetchMockOptions = {}) {
+  const calls = {
+    relayUrls: [] as string[],
+    redisSets: [] as RedisSetCommand[],
+    pipelines: [] as unknown[][][],
+  };
+  let budgetCounter = 0;
+
+  mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url.startsWith('https://redis.test/get/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+
+    if (url === 'https://redis.test/pipeline') {
+      const commands = JSON.parse(String(init?.body ?? '[]')) as unknown[][];
+      calls.pipelines.push(commands);
+      const results = commands.map((command) => {
+        const [verb, , count] = command;
+        if (verb === 'INCRBY') {
+          budgetCounter += Number(count);
+          return { result: budgetCounter };
+        }
+        if (verb === 'DECRBY') {
+          budgetCounter -= Number(count);
+          return { result: budgetCounter };
+        }
+        return { result: 1 };
+      });
+      return new Response(JSON.stringify(results), { status: 200 });
+    }
+
+    if (url === 'https://redis.test/') {
+      const command = JSON.parse(String(init?.body ?? '[]')) as RedisSetCommand;
+      calls.redisSets.push(command);
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    }
+
+    if (url.startsWith('https://relay.test/aviationstack')) {
+      calls.relayUrls.push(url);
+      if (typeof options.relay === 'function') return options.relay(url);
+      if (options.relay === 'ok-empty') {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: { message: 'relay unavailable' } }), { status: 503 });
+    }
+
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+
+  if (options.denyBudget) {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '1';
+    process.env.AVIATIONSTACK_REQUEST_BUDGET = '0';
+  } else {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '0';
+  }
+
+  return calls;
+}
+
+function requestFor(path: string): Request {
+  return new Request(`https://worldmonitor.app${path}`);
+}
+
+function ctxFor(request: Request) {
+  return { request, pathParams: {}, headers: {} };
+}
+
+function redisPayloads(calls: ReturnType<typeof installFetchMock>): unknown[] {
+  return calls.redisSets.map(([, , payload]) => JSON.parse(payload));
+}
+
+function assertOnlyNegativeSentinels(calls: ReturnType<typeof installFetchMock>) {
+  const payloads = redisPayloads(calls);
+  assert.ok(payloads.length > 0, 'expected at least one Redis SET');
+  assert.deepEqual([...new Set(payloads)], ['__WM_NEG__']);
+}
+
+function assertNoCacheSideChannel(request: Request) {
+  assert.equal(drainResponseHeaders(request)?.['X-No-Cache'], '1');
+}
+
+describe('aviation cache poison prevention', () => {
+  it('negative-caches missing relay config instead of positive-caching an empty airport board', async () => {
+    const calls = installFetchMock();
+    const request = requestFor('/api/aviation/v1/list-airport-flights?airport=AAA');
+
+    const response = await listAirportFlights(ctxFor(request), {
+      airport: 'AAA',
+      direction: 'FLIGHT_DIRECTION_DEPARTURE',
+      limit: 30,
+    });
+
+    assert.deepEqual(response.flights, []);
+    assert.equal(response.totalAvailable, 0);
+    assert.equal(response.source, 'none');
+    assertOnlyNegativeSentinels(calls);
+    assertNoCacheSideChannel(request);
+  });
+
+  it('negative-caches request budget exhaustion without calling the relay', async () => {
+    process.env.WS_RELAY_URL = 'https://relay.test';
+    const calls = installFetchMock({ denyBudget: true });
+    const request = requestFor('/api/aviation/v1/list-airport-flights?airport=BBB');
+
+    const response = await listAirportFlights(ctxFor(request), {
+      airport: 'BBB',
+      direction: 'FLIGHT_DIRECTION_DEPARTURE',
+      limit: 30,
+    });
+
+    assert.equal(response.source, 'budget');
+    assert.deepEqual(response.flights, []);
+    assert.equal(calls.relayUrls.length, 0, 'budget denial must not call AviationStack relay');
+    assert.ok(calls.pipelines.some((commands) => commands.some(([verb]) => verb === 'DECRBY')), 'denied reservation should be refunded');
+    assertOnlyNegativeSentinels(calls);
+    assertNoCacheSideChannel(request);
+  });
+
+  it('negative-caches relay failures for flight-status lookups', async () => {
+    process.env.WS_RELAY_URL = 'https://relay.test';
+    const calls = installFetchMock({ relay: 'http-503' });
+    const request = requestFor('/api/aviation/v1/get-flight-status?flight_number=TK1952&date=2026-07-09');
+
+    const response = await getFlightStatus(ctxFor(request), {
+      flightNumber: 'TK1952',
+      date: '2026-07-09',
+      origin: '',
+    });
+
+    assert.equal(response.source, 'error');
+    assert.deepEqual(response.flights, []);
+    assert.equal(calls.relayUrls.length, 1);
+    assertOnlyNegativeSentinels(calls);
+    assertNoCacheSideChannel(request);
+  });
+
+  it('keeps a healthy AviationStack zero-row response positive-cacheable', async () => {
+    process.env.WS_RELAY_URL = 'https://relay.test';
+    const calls = installFetchMock({ relay: 'ok-empty' });
+    const request = requestFor('/api/aviation/v1/list-airport-flights?airport=CCC');
+
+    const response = await listAirportFlights(ctxFor(request), {
+      airport: 'CCC',
+      direction: 'FLIGHT_DIRECTION_DEPARTURE',
+      limit: 30,
+    });
+
+    assert.equal(response.source, 'aviationstack');
+    assert.deepEqual(response.flights, []);
+    assert.equal(response.totalAvailable, 0);
+    assert.equal(calls.relayUrls.length, 1);
+    assert.deepEqual(redisPayloads(calls), [{ flights: [], source: 'aviationstack' }]);
+    assert.equal(drainResponseHeaders(request), undefined, 'healthy empty data must not request no-store');
+  });
+
+  it('propagates all-child unavailable state from carrier ops instead of claiming aviationstack success', async () => {
+    const calls = installFetchMock();
+    const request = requestFor('/api/aviation/v1/get-carrier-ops?airports=DDD&airports=EEE');
+
+    const response = await getCarrierOps(ctxFor(request), {
+      airports: ['DDD', 'EEE'],
+      minFlights: 0,
+    });
+
+    assert.deepEqual(response.carriers, []);
+    assert.equal(response.source, 'none');
+    assertOnlyNegativeSentinels(calls);
+    assertNoCacheSideChannel(request);
+  });
+
+  it('marks carrier ops partial when one child airport fails and another is healthy empty data', async () => {
+    process.env.WS_RELAY_URL = 'https://relay.test';
+    const calls = installFetchMock({
+      relay: (url) => url.includes('dep_iata=GGG')
+        ? new Response(JSON.stringify({ data: [] }), { status: 200 })
+        : new Response(JSON.stringify({ error: { message: 'relay unavailable' } }), { status: 503 }),
+    });
+    const request = requestFor('/api/aviation/v1/get-carrier-ops?airports=GGG&airports=HHH');
+
+    const response = await getCarrierOps(ctxFor(request), {
+      airports: ['GGG', 'HHH'],
+      minFlights: 0,
+    });
+
+    assert.deepEqual(response.carriers, []);
+    assert.equal(response.source, 'partial');
+    const payloads = redisPayloads(calls);
+    assert.ok(payloads.some((payload) => payload === '__WM_NEG__'), 'partial aggregate should negative-cache its unavailable result');
+    assert.ok(payloads.some((payload) => typeof payload === 'object' && payload !== null && (payload as { source?: string }).source === 'aviationstack'), 'healthy empty child remains positive-cacheable');
+    assertNoCacheSideChannel(request);
+  });
+
+  it('forces airport-flight unavailable HTTP responses to no-store at the gateway', async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+    const calls = installFetchMock();
+    const gateway = createDomainGateway(createAviationServiceRoutes(aviationHandler, serverOptions));
+
+    const response = await gateway(new Request(
+      'https://worldmonitor.app/api/aviation/v1/list-airport-flights?airport=FFF&limit=30&_debug=1',
+      { headers: { 'X-WorldMonitor-Key': 'test-key' } },
+    ));
+    const body = await response.json() as { source?: string; flights?: unknown[] };
+
+    assert.equal(response.status, 200);
+    assert.equal(body.source, 'none');
+    assert.deepEqual(body.flights, []);
+    assert.equal(response.headers.get('Cache-Control'), 'no-store');
+    assert.equal(response.headers.get('X-Cache-Tier'), 'no-store');
+    assert.equal(response.headers.get('CDN-Cache-Control'), null);
+    assertOnlyNegativeSentinels(calls);
+  });
+});


### PR DESCRIPTION
## Summary

- Stops aviation request-time failure states from being positive-cached as empty successful data.
- Marks unavailable airport-flight, flight-status, and carrier-ops responses as no-store through the existing gateway side-channel.
- Preserves legitimate healthy zero-row AviationStack responses as cacheable `source: aviationstack` results.
- Adds focused regressions for missing relay config, budget exhaustion, relay failure, healthy empty data, carrier aggregate degradation, and gateway no-store headers.

Fixes #5054.

## Intent

The intent is to keep transient aviation config/budget/relay failures from becoming Redis or HTTP-cache truth. Non-goals: no proto/schema expansion, no route tier reshuffle, and no UI/client behavior changes.

## Validation Matrix

| Check | Reason | Expected signal | Status |
| --- | --- | --- | --- |
| `./node_modules/.bin/tsx --test tests/aviation-cache-poison.test.mts tests/aviation-budget-cap.test.mjs` | Focused issue regressions plus existing AviationStack budget wiring | Missing relay/budget/relay failures write negative sentinel; healthy zero rows positive-cache; carrier degradation propagates; gateway emits no-store | Pass, 28 tests |
| `npm run typecheck:api` | Server/API TypeScript and API audit after handler changes | tsc succeeds and Convex string-call audit passes | Pass |
| `git diff --check` | Whitespace/conflict hygiene | No whitespace errors | Pass |

## Review Gates

- Baseline reviewer: pass. Reviewed cache semantics, no-store behavior, child aggregate behavior, and legitimate empty-data path.
- Code Review Expert: pass. Checked SOLID/architecture, security/reliability, code quality, and removal candidates; no blocking findings.
- Outcome reviewer: pass. Current diff satisfies the live issue acceptance criteria and validation evidence covers the requested failure modes.
- Greptile: pass, with one P2 observability residual recorded below.

## Documentation

Not applicable. This is an internal cache/error-semantics fix with no public API schema or user-facing copy change.

## Screenshots / UI Evidence

Not applicable. No UI surface changed.

## Residual Findings

- Greptile P2 (observability): Redis NEG_SENTINEL hits report `source: 'unavailable'` instead of the original `none`/`budget`/`error` reason because the fetcher does not run on sentinel hits. Cache correctness and no-store behavior are unaffected; preserving exact failure reasons across isolates would require extending the shared negative-cache sentinel contract, so this is deferred outside the cache-poison fix.
