### PR TITLE
Fix seeder health metadata drift

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -119,9 +119,11 @@ const STANDALONE_KEYS = {
   newsRecallBenchmark: 'news:recall-benchmark:v1',
   serviceStatuses:       'infra:service-statuses:v1',
   macroSignals:          'economic:macro-signals:v1',
+  energyPrices:          'economic:energy:v1:all',
   bisPolicy:             'economic:bis:policy:v1',
   bisExchange:           'economic:bis:eer:v1',
   fxYoy:                 'economic:fx:yoy:v1',
+  sharedFxRates:          'shared:fx-rates:v1',
   bisCredit:             'economic:bis:credit:v1',
   bisDsr:                'economic:bis:dsr:v1',
   bisPropertyResidential: 'economic:bis:property-residential:v1',
@@ -151,6 +153,7 @@ const STANDALONE_KEYS = {
   notamClosures:         'aviation:notam:closures:v2',
   positiveEventsLive:    'positive-events:geo:v1',
   cableHealth:           'cable-health-v1',
+  submarineCables:       'infrastructure:submarine-cables:v1',
   cyberThreatsRpc:       'cyber:threats:v2',
   militaryBases:         'military:bases:active',
   militaryFlights:       'military:flights:v1',
@@ -160,15 +163,21 @@ const STANDALONE_KEYS = {
   // verifies existence + freshness via the matching SEED_META entry. Same
   // shape as militaryFlights above.
   militaryCii:           'intelligence:military-cii:v1',
+  defensePatents:        'patents:defense:latest',
   temporalAnomalies:     'temporal:anomalies:v1',
   displacement:          `displacement:summary:v1:${new Date().getUTCFullYear()}`,
   displacementPrev:      `displacement:summary:v1:${new Date().getUTCFullYear() - 1}`,
+  acledIntel:            'conflict:acled:v1:all:0:0',
   satellites:            'intelligence:satellites:tle:v1',
   portwatch:             'supply_chain:portwatch:v1',
+  portwatchDisruptions:  'portwatch:disruptions:active:v1',
   portwatchPortActivity: 'supply_chain:portwatch-ports:v1:_countries',
   corridorrisk:          'supply_chain:corridorrisk:v1',
   chokepointTransits:    'supply_chain:chokepoint_transits:v1',
   transitSummaries:      'supply_chain:transit-summaries:v1',
+  // Meta-only aggregate: payloads are sharded by country, so use the seed-meta
+  // key as the probe target rather than pretending one country key is global.
+  comtradeBilateralHs4:  'seed-meta:comtrade:bilateral-hs4',
   thermalEscalation:     'thermal:escalation:v1',
   tariffTrendsUs:           'trade:tariffs:v1:840:all:10',
   militaryForecastInputs:   'military:forecast-inputs:stale:v1',
@@ -247,6 +256,7 @@ const STANDALONE_KEYS = {
   webcams:                       'webcam:cameras:active',
   forecastResolutions:           'forecast:resolutions:v1',
   forecastScorecard:             'forecast:scorecard:v1',
+  researchArxivHnTrending:       'research:arxiv:v1:cs.AI::50',
 };
 
 const SEED_META = {
@@ -282,7 +292,9 @@ const SEED_META = {
   // RPC/warm-ping keys — seed-meta written by relay loops or handlers
   // serviceStatuses: moved to ON_DEMAND — RPC-populated, no dedicated seed, goes stale when no users visit
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
-  macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 150 }, // seed-economy cron; primary key energy-prices has same 150min threshold
+  submarineCables:  { key: 'seed-meta:infrastructure:submarine-cables', maxStaleMin: 25200 },
+  macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 150 }, // seed-economy afterPublish-derived stress/macro key
+  energyPrices:     { key: 'seed-meta:economic:energy-prices',    maxStaleMin: 150 }, // seed-economy primary runSeed resource
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   // seed-bis-extended.mjs is a child-process section spawned by
   // scripts/seed-bundle-macro.mjs. The bundle's Railway cron fires more
@@ -318,17 +330,21 @@ const SEED_META = {
   // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL
   // bisExchange + bisCredit: extras written by same BIS script via writeExtraKey, no dedicated seed-meta
   fxYoy:            { key: 'seed-meta:economic:fx-yoy',           maxStaleMin: 1500 }, // daily cron; 25h tolerance + 1h drift
+  sharedFxRates:    { key: 'seed-meta:shared:fx-rates',           maxStaleMin: 3600 }, // daily seed; 60h tolerance covers a missed 25h cache refresh
   gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 1440 }, // Wingbits API (scripts/fetch-gpsjam.mjs); 1440min = 24h tolerance gives operator headroom to handle upstream outages and monthly quota exhaustion (HTTP 402 observed 2026-04-29) without dashboard noise. Seeder catch-block extends TTL on fail without refreshing fetchedAt, so STALE_SEED via age is the only alarm path.
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
   riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30, minRecordCount: 3 }, // CII warm-ping every 8min; recordCount is realtime signal-density coverage for score-relevant conflict (ACLED or UCDP), news, and cyber families, not raw feed availability; quiet-but-fresh feeds may warn COVERAGE_PARTIAL.
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
+  acledIntel:       { key: 'seed-meta:conflict:acled-intel',      maxStaleMin: 38 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,
   militaryCii:      { key: 'seed-meta:intelligence:military-cii',  maxStaleMin: 45 }, // seed-military-cii cron ~10min; 45 = generous grace (relay-dependent; preserve-last-good runs still refresh meta)
+  defensePatents:   { key: 'seed-meta:military:defense-patents',  maxStaleMin: 25200 },
   satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 45 }, // relay loop every 15min; 45 = 3× interval (was 30 = 2×, too tight on relay hiccup)
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },
   techEvents:       { key: 'seed-meta:research:tech-events',       maxStaleMin: 480 },
+  researchArxivHnTrending: { key: 'seed-meta:research:arxiv-hn-trending', maxStaleMin: 150 },
   gdeltIntel:       { key: 'seed-meta:intelligence:gdelt-intel',   maxStaleMin: 720 }, // 6h cron; 12h staleness = 2× cadence = 1 missed tick + cron jitter, alerts at 2 missed ticks. Bumped from 420 (1.16× cadence, virtually zero margin) on 2026-05-12 after the same Railway-deploy-preempted-tick pattern that hit resilienceIntervals on 2026-05-10 (PR #3652): seedAgeMin=467 vs maxStale=420 → ~1min UptimeRobot WARNING flip when a deploy preempted the 15:00 UTC tick. CACHE_TTL is 24h so per-topic merge always has a prior snapshot even at the upper end of the new budget.
   telegramFeed:     { key: 'seed-meta:intelligence:telegram-feed:v1', maxStaleMin: 10 }, // 60s poll interval; 10min grace catches poll failures before they go stale in the panel
   digestNotifications: { key: 'seed-meta:digest:last-run',          maxStaleMin: 90 }, // Railway digest-notifications cron runs every 30min; 90 = 3x cadence and detects a dead cron before daily digests are missed.
@@ -344,6 +360,7 @@ const SEED_META = {
   theaterPosture:   { key: 'seed-meta:theater-posture',         maxStaleMin: 60 },
   correlationCards: { key: 'seed-meta:correlation:cards',       maxStaleMin: 30 }, // 5min cron (seed-bundle-derived-signals); 30min = 6× interval. Was 15 (3× = gold-standard floor) — overnight UptimeRobot flips when bundle jitter spaced two consecutive runs ~9-10min apart, producing 15-19min gaps that tripped STALE_SEED briefly. See WM 2026-05-10 health:failure-log.
   portwatch:           { key: 'seed-meta:supply_chain:portwatch',            maxStaleMin: 720 },
+  portwatchDisruptions: { key: 'seed-meta:portwatch:disruptions',             maxStaleMin: 150 },
   portwatchPortActivity: { key: 'seed-meta:supply_chain:portwatch-ports',   maxStaleMin: 2160, minRecordCount: 174 }, // 12h cron; 36h = 3x interval; #3613 requires full 174-country coverage before OK.
   corridorrisk:        { key: 'seed-meta:supply_chain:corridorrisk',         maxStaleMin: 120 },
   chokepointTransits:  { key: 'seed-meta:supply_chain:chokepoint_transits',  maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
@@ -352,6 +369,7 @@ const SEED_META = {
   securityAdvisories:  { key: 'seed-meta:intelligence:advisories',           maxStaleMin: 120 },
   customsRevenue:      { key: 'seed-meta:trade:customs-revenue',              maxStaleMin: 1440 },
   comtradeFlows:       { key: 'seed-meta:trade:comtrade-flows',               maxStaleMin: 2880 }, // 24h cron; 2880min = 48h = 2x interval
+  comtradeBilateralHs4: { key: 'seed-meta:comtrade:bilateral-hs4',             maxStaleMin: 34560 }, // 24d freshness gate + 25d meta TTL; meta-only aggregate over sharded country keys
   blsSeries:           { key: 'seed-meta:economic:bls-series',                maxStaleMin: 2880 }, // daily seed; 2880min = 48h = 2x interval
   sanctionsPressure:   { key: 'seed-meta:sanctions:pressure',                 maxStaleMin: 720 },
   crossSourceSignals:  { key: 'seed-meta:intelligence:cross-source-signals',  maxStaleMin: 30 }, // 15min cron; 30min = 2x interval

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -46,9 +46,11 @@ const SEED_DOMAINS = {
   'market:etf-flows':         { key: 'seed-meta:market:etf-flows',         intervalMin: 30 },
   'market:gulf-quotes':       { key: 'seed-meta:market:gulf-quotes',       intervalMin: 15 },
   'market:stablecoins':       { key: 'seed-meta:market:stablecoins',       intervalMin: 30 },
+  'shared:fx-rates':          { key: 'seed-meta:shared:fx-rates',          intervalMin: 1800 }, // 60h staleness budget in api/health.js
   // Phase 3 — Hybrid endpoints
   'natural:events':           { key: 'seed-meta:natural:events',           intervalMin: 60 },
   'displacement:summary':     { key: 'seed-meta:displacement:summary',     intervalMin: 360 },
+  'economic:energy-prices':   { key: 'seed-meta:economic:energy-prices',   intervalMin: 75 },
   // Aligned with health.js SEED_META (intervalMin = maxStaleMin / 2)
   'market:stocks':            { key: 'seed-meta:market:stocks',            intervalMin: 15 },
   'market:commodities':       { key: 'seed-meta:market:commodities',       intervalMin: 15 },
@@ -64,16 +66,19 @@ const SEED_DOMAINS = {
   'intelligence:risk-scores': { key: 'seed-meta:intelligence:risk-scores', intervalMin: 15 }, // CII warm-ping every 8min; intervalMin*2 = 30min, aligned with api/health.js riskScores.
   'conflict:iran-events':     { key: 'seed-meta:conflict:iran-events',     intervalMin: 5040 },
   'conflict:ucdp-events':     { key: 'seed-meta:conflict:ucdp-events',     intervalMin: 210 },
+  'conflict:acled-intel':     { key: 'seed-meta:conflict:acled-intel',     intervalMin: 19 },
   'weather:alerts':           { key: 'seed-meta:weather:alerts',           intervalMin: 15 },
   'economic:spending':        { key: 'seed-meta:economic:spending',        intervalMin: 60 },
   'intelligence:gpsjam':      { key: 'seed-meta:intelligence:gpsjam',      intervalMin: 720 }, // 720 × 2 = 1440min (24h) staleness; matches api/health.js gpsjam.maxStaleMin. Widened from 360 (12h) on 2026-04-29 alongside Wingbits API quota incident — see PR #3494 + the seeder graceful-failure path at scripts/fetch-gpsjam.mjs:258-262.
   'intelligence:satellites':  { key: 'seed-meta:intelligence:satellites',  intervalMin: 90 },
   'military:flights':         { key: 'seed-meta:military:flights',         intervalMin: 8 },
+  'military:defense-patents': { key: 'seed-meta:military:defense-patents', intervalMin: 12600 },
   'military-forecast-inputs': { key: 'seed-meta:military-forecast-inputs', intervalMin: 8 },
   'infra:service-statuses':   { key: 'seed-meta:infra:service-statuses',   intervalMin: 60 },
   'supply_chain:shipping':    { key: 'seed-meta:supply_chain:shipping',    intervalMin: 120 },
   'supply_chain:chokepoints': { key: 'seed-meta:supply_chain:chokepoints', intervalMin: 30 },
   'cable-health':             { key: 'seed-meta:cable-health',             intervalMin: 30 },
+  'infrastructure:submarine-cables': { key: 'seed-meta:infrastructure:submarine-cables', intervalMin: 12600 },
   'prediction:markets':       { key: 'seed-meta:prediction:markets',       intervalMin: 8 },
   'aviation:intl':            { key: 'seed-meta:aviation:intl',            intervalMin: 45 }, // intervalMin*2 = 90min staleness. seed-aviation's freshness gate (AVIATIONSTACK_MIN_REFRESH_MIN, default 55) lets fetchedAt age to ~55+cron between paid fetches; 90min matches the aviation:faa sibling + api/health.js intlDelays maxStaleMin:90. Was 15 (30min) and false-WARNed every cycle once the gate landed.
   'theater-posture':          { key: 'seed-meta:theater-posture',          intervalMin: 8 },
@@ -85,12 +90,14 @@ const SEED_DOMAINS = {
   'economic:bis-property-residential': { key: 'seed-meta:economic:bis-property-residential', intervalMin: 720 }, // 12h cron; only written when SPP slice fetched fresh entries
   'economic:bis-property-commercial':  { key: 'seed-meta:economic:bis-property-commercial',  intervalMin: 720 }, // 12h cron; only written when CPP slice fetched fresh entries
   'research:tech-events':    { key: 'seed-meta:research:tech-events',     intervalMin: 240 },
-  'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
+  'research:arxiv-hn-trending': { key: 'seed-meta:research:arxiv-hn-trending', intervalMin: 75 },
+  'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // seed-health alerts at 420min; /api/health uses a wider 720min freshness budget.
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },
   'intelligence:advisories':  { key: 'seed-meta:intelligence:advisories',  intervalMin: 60 },
   'intelligence:social-reddit': { key: 'seed-meta:intelligence:social-reddit', intervalMin: 270 }, // 180min relay loop (3h; dropped from 60min now that ScrapeCreators handles Reddit); intervalMin = maxStaleMin / 2 (540 / 2), matching api/health.js
   'intelligence:wsb-tickers': { key: 'seed-meta:intelligence:wsb-tickers', intervalMin: 270 }, // 180min relay loop (3h); intervalMin = maxStaleMin / 2 (540 / 2), matching api/health.js
   'trade:customs-revenue':    { key: 'seed-meta:trade:customs-revenue',    intervalMin: 720 },
+  'comtrade:bilateral-hs4':   { key: 'seed-meta:comtrade:bilateral-hs4',   intervalMin: 17280 }, // 24d gate in seed-comtrade-bilateral-hs4.mjs
   'thermal:escalation':       { key: 'seed-meta:thermal:escalation',       intervalMin: 180 },
   'radiation:observations':   { key: 'seed-meta:radiation:observations',   intervalMin: 15 },
   'sanctions:pressure':       { key: 'seed-meta:sanctions:pressure',       intervalMin: 360 },
@@ -121,7 +128,8 @@ const SEED_DOMAINS = {
   'economic:bis-lbs':          { key: 'seed-meta:economic:bis-lbs',          intervalMin: 7200 },  // BIS LBS quarterly; intervalMin = health.js maxStaleMin / 2 (14400 / 2)
   'economic:fatf-listing':     { key: 'seed-meta:economic:fatf-listing',     intervalMin: 30240 }, // FATF plenary 3×/year; intervalMin = health.js maxStaleMin / 2 (60480 / 2)
   'product-catalog':          { key: 'seed-meta:product-catalog',          intervalMin: 360 }, // relay loop every 6h; intervalMin = health.js maxStaleMin / 3 (1080 / 3)
-  'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 10080 }, // seed-bundle-portwatch runs this at WEEK cadence; intervalMin*2 = 14d matches api/health.js SEED_META.portwatchChokepointsRef
+  'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 10080 },
+  'portwatch:disruptions':    { key: 'seed-meta:portwatch:disruptions',    intervalMin: 75 }, // active disruptions seed; intervalMin*2 = 150min matches api/health.js
   'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720, minRecordCount: 174 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3); #3613 requires 174-country coverage before OK.
   'energy:chokepoint-flows': { key: 'seed-meta:energy:chokepoint-flows', intervalMin: 360 }, // 6h relay loop; intervalMin = maxStaleMin / 2 (720 / 2)
   'energy:eia-petroleum':   { key: 'seed-meta:energy:eia-petroleum',   intervalMin: 1440 }, // daily bundle cron; intervalMin*3 = health.js maxStaleMin (4320)

--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -4,10 +4,21 @@
 // entry, current feed snapshot, observed samples, and nowMs; output is a
 // deterministic pending/resolved result with evidence.
 
+import { readFileSync } from 'node:fs';
+
 const DAY_MS = 24 * 60 * 60 * 1000;
+export const ACLED_SETTLEMENT_LAG_MS = 2 * DAY_MS;
 export const UCDP_SETTLEMENT_LAG_MS = 14 * DAY_MS;
 
 const SUPPORTED_FUNCTIONS = new Set(['count', 'riskScore', 'present', 'yesPrice', 'hexCount', 'price']);
+const COUNTRY_ALIASES = loadCountryAliases();
+
+export function countSettlementLagMs(feedKey) {
+  const key = String(feedKey || '');
+  if (key.includes('ucdp-events')) return UCDP_SETTLEMENT_LAG_MS;
+  if (key.includes('acled')) return ACLED_SETTLEMENT_LAG_MS;
+  return 0;
+}
 
 export function parseMetricKey(metricKey) {
   if (typeof metricKey !== 'string' || !metricKey) return null;
@@ -43,7 +54,7 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
   }
 
   if (parsed.fn === 'count') {
-    const sealAfter = deadline + UCDP_SETTLEMENT_LAG_MS;
+    const sealAfter = deadline + countSettlementLagMs(parsed.feedKey || spec.sourceFeed);
     if (nowMs < sealAfter) {
       return { status: 'pending', evidence: { reason: 'count_settlement_lag', deadline, sealAfter } };
     }
@@ -219,16 +230,33 @@ function firstFinite(...values) {
   return NaN;
 }
 
+function normalizeComparable(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
 function valueEquals(actual, expected) {
-  return String(actual ?? '').trim().toLowerCase() === String(expected ?? '').trim().toLowerCase();
+  return normalizeComparable(actual) === normalizeComparable(expected);
+}
+
+function countryValueEquals(actual, expected) {
+  const actualAliases = countryAliases(actual);
+  const expectedAliases = countryAliases(expected);
+  for (const alias of actualAliases) {
+    if (expectedAliases.has(alias)) return true;
+  }
+  return false;
+}
+
+function metricValueEquals(actual, expected, field) {
+  return field === 'country' ? countryValueEquals(actual, expected) : valueEquals(actual, expected);
 }
 
 function findMatchingRecord(feedData, field, value) {
   for (const record of iterateRecords(feedData)) {
-    if (record && typeof record === 'object' && valueEquals(record[field], value)) return record;
+    if (record && typeof record === 'object' && metricValueEquals(record[field], value, field)) return record;
     if (record && typeof record === 'object') {
       const aliases = fieldAliases(field);
-      if (aliases.some((alias) => valueEquals(record[alias], value))) return record;
+      if (aliases.some((alias) => metricValueEquals(record[alias], value, field))) return record;
     }
   }
   return null;
@@ -237,16 +265,47 @@ function findMatchingRecord(feedData, field, value) {
 function fieldAliases(field) {
   if (field === 'market') return ['market', 'title', 'question'];
   if (field === 'route') return ['route', 'name', 'label', 'chokepoint'];
-  if (field === 'country') return ['country', 'country_name', 'countryName', 'location'];
+  if (field === 'country') return ['country', 'country_name', 'countryName', 'countryCode', 'iso2', 'location'];
   if (field === 'region') return ['region', 'name', 'label'];
   return [field];
+}
+
+function loadCountryAliases() {
+  const byToken = new Map();
+  try {
+    const raw = JSON.parse(readFileSync(new URL('../shared/country-names.json', import.meta.url), 'utf8'));
+    for (const [name, code] of Object.entries(raw || {})) {
+      const normalizedName = normalizeComparable(name);
+      const normalizedCode = normalizeComparable(code);
+      if (!normalizedName || !normalizedCode) continue;
+      if (!byToken.has(normalizedName)) byToken.set(normalizedName, new Set());
+      if (!byToken.has(normalizedCode)) byToken.set(normalizedCode, new Set());
+      byToken.get(normalizedName).add(normalizedCode);
+      byToken.get(normalizedCode).add(normalizedName);
+    }
+  } catch {
+    // Country aliases are a best-effort bridge for mixed ISO/name feeds.
+  }
+  return byToken;
+}
+
+function countryAliases(value) {
+  const normalized = normalizeComparable(value);
+  const aliases = new Set();
+  if (!normalized) return aliases;
+  aliases.add(normalized);
+  const direct = COUNTRY_ALIASES.get(normalized);
+  if (direct) {
+    for (const alias of direct) aliases.add(alias);
+  }
+  return aliases;
 }
 
 function countMatchingRecords(feedData, field, value, startMs, endMs) {
   let count = 0;
   for (const record of iterateRecords(feedData)) {
     if (!record || typeof record !== 'object') continue;
-    const matches = [field, ...fieldAliases(field)].some((key) => valueEquals(record[key], value));
+    const matches = [field, ...fieldAliases(field)].some((key) => metricValueEquals(record[key], value, field));
     if (!matches) continue;
     const ts = extractRecordTime(record);
     if (Number.isFinite(ts) && ts >= startMs && ts <= endMs) count += 1;
@@ -286,8 +345,12 @@ function extractRecordTime(record) {
     record.ts,
     record.timestamp,
     record.generatedAt,
+    record.firstSeenAt,
+    record.lastSeenAt,
+    record.occurredAt,
     record.dateStart,
     record.date_start && Date.parse(record.date_start),
+    record.event_date && Date.parse(record.event_date),
     record.date && Date.parse(record.date),
     record.eventDate && Date.parse(record.eventDate),
   );

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -805,6 +805,8 @@ export function isTransientProxyError(message) {
   return /HTTP 5\d{2}|522|timeout|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|EPIPE|socket (disconnected|hang up)|TLS connection|tls_get_more_records|packet length too long|SSL routines|secure TLS connection/i.test(message || '');
 }
 
+const FRED_JSON_HEADERS = { Accept: 'application/json', 'User-Agent': CHROME_UA };
+
 // Fetch JSON from a FRED URL, routing through proxy when available.
 // Proxy-first: FRED consistently blocks/throttles Railway datacenter IPs,
 // so try proxy first to avoid 20s timeout on every direct attempt.
@@ -828,14 +830,14 @@ export async function fredFetchJson(url, proxyAuth) {
     }
     console.warn(`  [fredFetch] proxy failed after retries (${lastProxyErr?.message}) — retrying direct`);
     try {
-      const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
+      const r = await fetch(url, { headers: FRED_JSON_HEADERS, signal: AbortSignal.timeout(20_000) });
       if (r.ok) return r.json();
       throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
     } catch (directErr) {
       throw Object.assign(new Error(`direct: ${directErr.message}`), { cause: directErr });
     }
   }
-  const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
+  const r = await fetch(url, { headers: FRED_JSON_HEADERS, signal: AbortSignal.timeout(20_000) });
   if (r.ok) return r.json();
   throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
 }

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -317,6 +317,6 @@ if (process.argv[1]?.endsWith('seed-gdelt-intel.mjs')) {
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);
-    process.exit(0);
+    process.exit(1);
   });
 }

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -113,12 +113,6 @@ export function declareRecords(data) {
   return Array.isArray(data?.quotes) ? data.quotes.length : 0;
 }
 
-let seedData = null;
-
-async function fetchAndStash() {
-  seedData = await fetchMarketQuotes();
-  return seedData;
-}
 
 // #4922d: on non-trading days (weekends + full NYSE holidays) the last
 // published close IS the current truth — skip the upstream fetch entirely and
@@ -136,9 +130,9 @@ async function fetchAndStash() {
 if (!isUsEquityTradingDay()) {
   const lastGood = await readCanonicalEnvelopeMeta(CANONICAL_KEY);
   if (lastGood) {
-    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:quotes', RPC_KEY], CACHE_TTL);
+    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY], CACHE_TTL);
     if (extended) {
-      await writeFreshnessMetadata('market', 'quotes', lastGood.recordCount, lastGood.sourceVersion || 'alphavantage+finnhub+yahoo', CACHE_TTL);
+      await writeFreshnessMetadata('market', 'stocks', lastGood.recordCount, lastGood.sourceVersion || 'alphavantage+finnhub+yahoo', CACHE_TTL);
       console.log(`[seed-market-quotes] US market closed (session=${getUsEquitySession()}) — skipping upstream fetch, extended TTL`);
       process.exit(0);
     }
@@ -148,16 +142,23 @@ if (!isUsEquityTradingDay()) {
   }
 }
 
-runSeed('market', 'quotes', CANONICAL_KEY, fetchAndStash, {
+async function writeRequiredCompanionKeys(data) {
+  if (!data) return;
+  await writeExtraKey(RPC_KEY, data, CACHE_TTL);
+}
+
+runSeed('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'alphavantage+finnhub+yahoo',
   declareRecords,
   schemaVersion: 1,
   maxStaleMin: 30,
-}).then(async (result) => {
-  if (result?.skipped || !seedData) return;
-  await writeExtraKey(RPC_KEY, seedData, CACHE_TTL);
+  afterPublish: async (data) => {
+    // runSeed exits the process on success; required companion writes must be
+    // awaited here so the RPC key is published before the terminal exit.
+    await writeRequiredCompanionKeys(data);
+  },
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/tests/closed-market-equity-maintenance.test.mjs
+++ b/tests/closed-market-equity-maintenance.test.mjs
@@ -7,6 +7,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -17,6 +18,19 @@ const {
 describe('closed-market equity key maintenance', () => {
   it('builds the stock quotes key with sorted symbols', () => {
     assert.equal(marketQuotesKey(['MSFT', 'AAPL', '^GSPC']), 'market:quotes:v1:AAPL,MSFT,^GSPC');
+  });
+
+  it('seed-market-quotes writes the health-watched stock meta before terminal exit', () => {
+    const source = readFileSync(new URL('../scripts/seed-market-quotes.mjs', import.meta.url), 'utf8');
+
+    assert.match(source, /runSeed\('market', 'stocks'/);
+    assert.doesNotMatch(source, /runSeed\('market', 'quotes'/);
+    assert.match(source, /writeFreshnessMetadata\('market', 'stocks'/);
+    assert.doesNotMatch(source, /seed-meta:market:quotes/);
+    const runSeedCall = source.match(/runSeed\('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, \{[\s\S]*?\}\)\.catch/);
+    assert.ok(runSeedCall, 'expected seed-market-quotes to use a catch-terminated runSeed call');
+    assert.match(runSeedCall[0], /afterPublish:\s*async \(data\) => \{[\s\S]*writeRequiredCompanionKeys\(data\)/);
+    assert.doesNotMatch(runSeedCall[0], /\.then\(async/);
   });
 
   it('extends both stock keys and refreshes seed-meta from the last in-process quote count', async () => {

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -2,7 +2,9 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import {
+  ACLED_SETTLEMENT_LAG_MS,
   UCDP_SETTLEMENT_LAG_MS,
+  countSettlementLagMs,
   parseMetricKey,
   resolveHardSpec,
 } from '../scripts/_forecast-resolution-eval.mjs';
@@ -42,9 +44,15 @@ function assertNoNullFields(value, path = 'fixture') {
 }
 
 describe('parseMetricKey', () => {
-  it('parses the six emitted function forms with anchored delimiters', () => {
+  it('parses the emitted function forms with anchored delimiters', () => {
     assert.deepEqual(parseMetricKey('conflict:ucdp-events:v1|count(country==Mali)'), {
       feedKey: 'conflict:ucdp-events:v1',
+      fn: 'count',
+      field: 'country',
+      value: 'Mali',
+    });
+    assert.deepEqual(parseMetricKey('conflict:acled:v1:all:0:0|count(country==Mali)'), {
+      feedKey: 'conflict:acled:v1:all:0:0',
       fn: 'count',
       field: 'country',
       value: 'Mali',
@@ -66,6 +74,15 @@ describe('parseMetricKey', () => {
     for (const bad of ['', 'no-pipe', 'feed|fn(field=value)', 'feed|fn(field==value', 'feed|fn()']) {
       assert.equal(parseMetricKey(bad), null, bad);
     }
+  });
+});
+
+describe('countSettlementLagMs', () => {
+  it('uses the long UCDP lag only for legacy UCDP count feeds', () => {
+    assert.equal(countSettlementLagMs('conflict:ucdp-events:v1'), UCDP_SETTLEMENT_LAG_MS);
+    assert.equal(countSettlementLagMs('conflict:acled:v1:all:0:0'), ACLED_SETTLEMENT_LAG_MS);
+    assert.equal(countSettlementLagMs('unrest:events:v1'), 0);
+    assert.equal(countSettlementLagMs('cyber:threats-bootstrap:v2'), 0);
   });
 });
 
@@ -95,6 +112,71 @@ describe('resolveHardSpec', () => {
     assert.equal(resolved.outcome, 'YES');
     assert.equal(resolved.evidence.metricValue, 2);
     assert.equal(resolved.evidence.comparison, '2 >= 2');
+  });
+
+  it('uses the shorter ACLED lag and event_date for fresh conflict counts', () => {
+    const deadline = START + 3 * DAY_MS;
+    const e = entry({
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:acled:v1:all:0:0',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Mali', event_date: '2026-07-07' },
+        { country: 'Mali', event_date: '2026-07-09' },
+        { country: 'Mali', event_date: '2026-07-11' },
+        { country: 'Burkina Faso', event_date: '2026-07-09' },
+      ],
+    };
+
+    assert.deepEqual(
+      resolveHardSpec(e, feed, {}, deadline + ACLED_SETTLEMENT_LAG_MS - 1),
+      {
+        status: 'pending',
+        evidence: { reason: 'count_settlement_lag', deadline, sealAfter: deadline + ACLED_SETTLEMENT_LAG_MS },
+      },
+    );
+
+    const resolved = resolveHardSpec(e, feed, {}, deadline + ACLED_SETTLEMENT_LAG_MS);
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.outcome, 'YES');
+    assert.equal(resolved.evidence.metricValue, 2);
+    assert.equal(resolved.evidence.comparison, '2 >= 2');
+  });
+
+  it('matches country display names against ISO-2 country fields for cyber counts', () => {
+    const deadline = START + 1_000;
+    const e = entry({
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'cyber:threats-bootstrap:v2|count(country==Estonia)',
+        operator: '>=',
+        threshold: 1,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'cyber:threats-bootstrap:v2',
+      },
+    });
+    const feed = {
+      threats: [
+        { country: 'EE', firstSeenAt: START + 1_000 },
+        { country: 'LV', firstSeenAt: START + 2_000 },
+      ],
+    };
+
+    const resolved = resolveHardSpec(e, feed, {}, deadline);
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.outcome, 'YES');
+    assert.equal(resolved.evidence.metricValue, 1);
   });
 
   it('keeps due count specs pending until the UCDP source has reached the forecast deadline', () => {

--- a/tests/fred-proxy-transient-classify.test.mjs
+++ b/tests/fred-proxy-transient-classify.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isTransientProxyError } from '../scripts/_seed-utils.mjs';
+import { CHROME_UA, fredFetchJson, isTransientProxyError } from '../scripts/_seed-utils.mjs';
 
 // fredFetchJson retries the (IP-rotating) Decodo proxy only when the error is
 // classified transient; otherwise it breaks to a direct FRED fetch, which a
@@ -11,6 +11,42 @@ import { isTransientProxyError } from '../scripts/_seed-utils.mjs';
 // MUST be retried — they did not match the original 5xx/timeout-only regex.
 //
 // Run: node --test tests/fred-proxy-transient-classify.test.mjs
+
+const originalFetch = globalThis.fetch;
+
+test('fredFetchJson direct FRED fallback sends a User-Agent header', async (t) => {
+  t.after(() => { globalThis.fetch = originalFetch; });
+  let seenHeaders = null;
+  globalThis.fetch = async (_url, init = {}) => {
+    seenHeaders = init.headers;
+    return new Response(JSON.stringify({ observations: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  await fredFetchJson('https://api.stlouisfed.org/fred/series/observations?series_id=GDP');
+
+  assert.equal(seenHeaders?.['User-Agent'], CHROME_UA);
+  assert.equal(seenHeaders?.Accept, 'application/json');
+});
+
+test('fredFetchJson proxy fallback direct path sends a User-Agent header', async (t) => {
+  t.after(() => { globalThis.fetch = originalFetch; });
+  let seenHeaders = null;
+  globalThis.fetch = async (_url, init = {}) => {
+    seenHeaders = init.headers;
+    return new Response(JSON.stringify({ observations: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  await fredFetchJson('https://api.stlouisfed.org/fred/series/observations?series_id=GDP', 'invalid-proxy-auth');
+
+  assert.equal(seenHeaders?.['User-Agent'], CHROME_UA);
+  assert.equal(seenHeaders?.Accept, 'application/json');
+});
 
 test('TLS-handshake tear signatures (from the real failing logs) are transient', () => {
   const tlsTears = [

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -16,7 +16,7 @@ import assert from 'node:assert/strict';
 
 import { __testing__ } from '../api/health.js';
 
-const { classifyKey, STATUS_COUNTS, BOOTSTRAP_KEYS, STANDALONE_KEYS } = __testing__;
+const { classifyKey, STATUS_COUNTS, BOOTSTRAP_KEYS, STANDALONE_KEYS, SEED_META } = __testing__;
 
 const NOW = 1_700_000_000_000;
 const ONE_MIN_MS = 60_000;
@@ -189,6 +189,49 @@ test('classifyKey: empty bootstrap key (no cascade) → EMPTY (crit)', () => {
     makeCtx({ metaValues: { 'seed-meta:seismology:earthquakes': seedMeta() } }));
   assert.equal(entry.status, 'EMPTY');
   assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
+const ISSUE_5055_HEALTH_REGISTRATIONS = [
+  ['energyPrices', 'economic:energy:v1:all', 'seed-meta:economic:energy-prices', 150],
+  ['researchArxivHnTrending', 'research:arxiv:v1:cs.AI::50', 'seed-meta:research:arxiv-hn-trending', 150],
+  ['defensePatents', 'patents:defense:latest', 'seed-meta:military:defense-patents', 25200],
+  ['acledIntel', 'conflict:acled:v1:all:0:0', 'seed-meta:conflict:acled-intel', 38],
+  ['portwatchDisruptions', 'portwatch:disruptions:active:v1', 'seed-meta:portwatch:disruptions', 150],
+  ['comtradeBilateralHs4', 'seed-meta:comtrade:bilateral-hs4', 'seed-meta:comtrade:bilateral-hs4', 34560],
+  ['sharedFxRates', 'shared:fx-rates:v1', 'seed-meta:shared:fx-rates', 3600],
+  ['submarineCables', 'infrastructure:submarine-cables:v1', 'seed-meta:infrastructure:submarine-cables', 25200],
+];
+
+test('issue #5055: validated seed-meta writers are registered in /api/health', () => {
+  for (const [name, dataKey, metaKey, maxStaleMin] of ISSUE_5055_HEALTH_REGISTRATIONS) {
+    assert.equal(STANDALONE_KEYS[name], dataKey, `${name} data key`);
+    assert.equal(SEED_META[name]?.key, metaKey, `${name} seed-meta key`);
+    assert.equal(SEED_META[name]?.maxStaleMin, maxStaleMin, `${name} maxStaleMin`);
+  }
+});
+
+test('classifyKey: issue #5055 strict seeds surface missing metadata instead of reporting OK', () => {
+  const entry = classifyKey('energyPrices', STANDALONE_KEYS.energyPrices, { allowOnDemand: true },
+    makeCtx({ strens: { [STANDALONE_KEYS.energyPrices]: 2048 } }));
+
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.equal(entry.records, 1);
+  assert.equal(entry.maxStaleMin, 150);
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: issue #5055 Comtrade bilateral probe is explicitly meta-only', () => {
+  const metaKey = 'seed-meta:comtrade:bilateral-hs4';
+  const entry = classifyKey('comtradeBilateralHs4', STANDALONE_KEYS.comtradeBilateralHs4, { allowOnDemand: true },
+    makeCtx({
+      strens: { [metaKey]: 96 },
+      metaValues: { [metaKey]: seedMeta({ recordCount: 180 }) },
+    }));
+
+  assert.equal(STANDALONE_KEYS.comtradeBilateralHs4, metaKey);
+  assert.equal(entry.status, 'OK');
+  assert.equal(entry.records, 180);
+  assert.equal(entry.maxStaleMin, 34560);
 });
 
 test('classifyKey: empty on-demand standalone key → EMPTY_ON_DEMAND (warn)', () => {

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -146,6 +146,26 @@ const EXCLUDED_FROM_MCP = new Map([
     'deferred: recovery pillar scorer input. Future resilience tool will expose recovery dimensions.'],
 
   // ===========================================================================
+  // #5055 health-only seed probes added to strict /api/health monitoring.
+  // ===========================================================================
+  ['economic:energy:v1:all',
+    'deferred: strict health seed probe added by #5055; future economic-data MCP expansion can expose energy prices directly.'],
+  ['shared:fx-rates:v1',
+    'deferred: strict health seed probe added by #5055; FX rates are shared infrastructure consumed by seeders and future economic MCP expansion.'],
+  ['infrastructure:submarine-cables:v1',
+    'deferred: strict health seed probe added by #5055; future infrastructure MCP expansion can expose the cable inventory directly.'],
+  ['patents:defense:latest',
+    'deferred: strict health seed probe added by #5055; future military or defense-innovation MCP expansion can expose patent summaries.'],
+  ['conflict:acled:v1:all:0:0',
+    'deferred: strict health seed probe added by #5055; ACLED aggregate currently feeds downstream intelligence and forecast inputs.'],
+  ['portwatch:disruptions:active:v1',
+    'deferred: strict health seed probe added by #5055; disruptions are consumed by chokepoint hazard scoring until a PortWatch MCP expansion exists.'],
+  ['seed-meta:comtrade:bilateral-hs4',
+    'operational: meta-only aggregate health probe added by #5055 for sharded comtrade:bilateral-hs4:{iso2}:v1 payloads; no queryable data slice lives at this key.'],
+  ['research:arxiv:v1:cs.AI::50',
+    'deferred: strict health seed probe added by #5055; future research MCP expansion can expose the ArXiv/HN trending feed.'],
+
+  // ===========================================================================
   // Deferred follow-up tools (explicit gaps named in the plan or related domain)
   // ===========================================================================
   ['intelligence:gpsjam:v2',

--- a/tests/resilience-source-failure.test.mts
+++ b/tests/resilience-source-failure.test.mts
@@ -54,10 +54,6 @@ const TRACKED_STANDALONE_META_KEYS_NOT_IN_HEALTH = new Set([
   // does not include a direct SEED_META entry because its data key is
   // parameterized by year.
   'seed-meta:displacement:summary',
-  // api/health.js tracks seed-meta:economic:macro-signals and documents
-  // energy-prices as the primary key with the same 150min threshold, but
-  // it does not classify the energy-prices data key directly.
-  'seed-meta:economic:energy-prices',
   // scripts/seed-supply-chain-trade.mjs writes these via
   // writeExtraKeyWithMeta. They feed scoreTradePolicy directly but are not
   // standalone /api/health probes today.

--- a/tests/seed-gdelt-intel-fetch-budget.test.mjs
+++ b/tests/seed-gdelt-intel-fetch-budget.test.mjs
@@ -16,6 +16,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { fetchAllTopics } from '../scripts/seed-gdelt-intel.mjs';
 
@@ -29,6 +30,15 @@ const cachedSnapshot = () => ({
 });
 
 describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
+  it('fatal runSeed rejection exits nonzero so Railway/bundles see the failure', () => {
+    const source = readFileSync(new URL('../scripts/seed-gdelt-intel.mjs', import.meta.url), 'utf8');
+    const fatalCatch = source.match(/\.catch\(\(err\) => \{[\s\S]*?console\.error\('FATAL:'[\s\S]*?\n  \}\);/);
+
+    assert.ok(fatalCatch, 'seed-gdelt-intel must keep an explicit fatal catch');
+    assert.match(fatalCatch[0], /process\.exit\(1\)/);
+    assert.doesNotMatch(fatalCatch[0], /process\.exit\(0\)/);
+  });
+
   it('budget spent up front → every topic backfilled from cache, returns immediately (no deadline churn)', async () => {
     const started = Date.now();
     const out = await fetchAllTopics({


### PR DESCRIPTION
## Summary
- Align market quote seeding with the health-watched `seed-meta:market:stocks` resource and await the RPC companion key from `afterPublish` before `runSeed` exits.
- Register validated seeder metadata keys in `/api/health` and `/api/seed-health` so missing/stale meta is visible without softening optional/on-demand keys.
- Make GDELT fatal seed failures exit nonzero and ensure FRED direct fallback fetches carry `User-Agent`.
- Document MCP parity exclusions for the new health-only seed probes so the seeded inventory contract remains explicit.

## Intent
Closes #5055. This fixes health/meta correctness drift from the audit sweep: health now watches keys that real seeders write, strict seeded resources surface missing metadata, and fatal seed failures no longer look successful.

## Validation Matrix
| Check | Result |
| --- | --- |
| `./node_modules/.bin/tsx --test tests/closed-market-equity-maintenance.test.mjs tests/fred-proxy-transient-classify.test.mjs tests/seed-gdelt-intel-fetch-budget.test.mjs tests/health-classify.test.mjs tests/resilience-source-failure.test.mts` | PASS, 70 tests |
| `./node_modules/.bin/tsx --test tests/resilience-cache-keys-health-sync.test.mts tests/resilience-dimension-freshness.test.mts tests/portwatch-disruptions-seed.test.mjs tests/comtrade-bilateral-hs4.test.mjs tests/relay-boot-seed-freshness-guard.test.mjs` | PASS, 159 tests |
| `./node_modules/.bin/tsx --test tests/mcp-bootstrap-parity.test.mjs` | PASS, 11 tests |
| `npm run typecheck:api` | PASS |
| `git diff --check` | PASS |

## Review Gates
- Baseline reviewer: PASS, no blocking findings; one stale GDELT seed-health comment was fixed.
- `$code-review-expert`: PASS, no blocking findings after checklist review.
- Outcome reviewer: PASS, acceptance criteria satisfied; residual live Redis/Railway behavior not exercised locally.

## Documentation
No docs changes. The touched health comments were updated where they described monitored keys or freshness budgets, and MCP parity exclusions document why the new strict health probes are not direct MCP tools yet.

## Screenshots / UI Evidence
Not applicable. This is seed, Redis metadata, and health classification behavior only.

## Residual Findings
- No live Redis/Railway seed run was executed in this worktree.
- Market companion ordering is covered by source-level regression tests plus `runSeed` ordering inspection rather than a subprocess integration test.