### PR TITLE
Fix forecast hard resolution coverage

### DIFF
--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -4,10 +4,21 @@
 // entry, current feed snapshot, observed samples, and nowMs; output is a
 // deterministic pending/resolved result with evidence.
 
+import { readFileSync } from 'node:fs';
+
 const DAY_MS = 24 * 60 * 60 * 1000;
+export const ACLED_SETTLEMENT_LAG_MS = 2 * DAY_MS;
 export const UCDP_SETTLEMENT_LAG_MS = 14 * DAY_MS;
 
 const SUPPORTED_FUNCTIONS = new Set(['count', 'riskScore', 'present', 'yesPrice', 'hexCount', 'price']);
+const COUNTRY_ALIASES = loadCountryAliases();
+
+export function countSettlementLagMs(feedKey) {
+  const key = String(feedKey || '');
+  if (key.includes('ucdp-events')) return UCDP_SETTLEMENT_LAG_MS;
+  if (key.includes('acled')) return ACLED_SETTLEMENT_LAG_MS;
+  return 0;
+}
 
 export function parseMetricKey(metricKey) {
   if (typeof metricKey !== 'string' || !metricKey) return null;
@@ -43,7 +54,7 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
   }
 
   if (parsed.fn === 'count') {
-    const sealAfter = deadline + UCDP_SETTLEMENT_LAG_MS;
+    const sealAfter = deadline + countSettlementLagMs(parsed.feedKey || spec.sourceFeed);
     if (nowMs < sealAfter) {
       return { status: 'pending', evidence: { reason: 'count_settlement_lag', deadline, sealAfter } };
     }
@@ -183,16 +194,33 @@ function firstFinite(...values) {
   return NaN;
 }
 
+function normalizeComparable(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
 function valueEquals(actual, expected) {
-  return String(actual ?? '').trim().toLowerCase() === String(expected ?? '').trim().toLowerCase();
+  return normalizeComparable(actual) === normalizeComparable(expected);
+}
+
+function countryValueEquals(actual, expected) {
+  const actualAliases = countryAliases(actual);
+  const expectedAliases = countryAliases(expected);
+  for (const alias of actualAliases) {
+    if (expectedAliases.has(alias)) return true;
+  }
+  return false;
+}
+
+function metricValueEquals(actual, expected, field) {
+  return field === 'country' ? countryValueEquals(actual, expected) : valueEquals(actual, expected);
 }
 
 function findMatchingRecord(feedData, field, value) {
   for (const record of iterateRecords(feedData)) {
-    if (record && typeof record === 'object' && valueEquals(record[field], value)) return record;
+    if (record && typeof record === 'object' && metricValueEquals(record[field], value, field)) return record;
     if (record && typeof record === 'object') {
       const aliases = fieldAliases(field);
-      if (aliases.some((alias) => valueEquals(record[alias], value))) return record;
+      if (aliases.some((alias) => metricValueEquals(record[alias], value, field))) return record;
     }
   }
   return null;
@@ -201,16 +229,47 @@ function findMatchingRecord(feedData, field, value) {
 function fieldAliases(field) {
   if (field === 'market') return ['market', 'title', 'question'];
   if (field === 'route') return ['route', 'name', 'label', 'chokepoint'];
-  if (field === 'country') return ['country', 'country_name', 'countryName', 'location'];
+  if (field === 'country') return ['country', 'country_name', 'countryName', 'countryCode', 'iso2', 'location'];
   if (field === 'region') return ['region', 'name', 'label'];
   return [field];
+}
+
+function loadCountryAliases() {
+  const byToken = new Map();
+  try {
+    const raw = JSON.parse(readFileSync(new URL('../shared/country-names.json', import.meta.url), 'utf8'));
+    for (const [name, code] of Object.entries(raw || {})) {
+      const normalizedName = normalizeComparable(name);
+      const normalizedCode = normalizeComparable(code);
+      if (!normalizedName || !normalizedCode) continue;
+      if (!byToken.has(normalizedName)) byToken.set(normalizedName, new Set());
+      if (!byToken.has(normalizedCode)) byToken.set(normalizedCode, new Set());
+      byToken.get(normalizedName).add(normalizedCode);
+      byToken.get(normalizedCode).add(normalizedName);
+    }
+  } catch {
+    // Country aliases are a best-effort bridge for mixed ISO/name feeds.
+  }
+  return byToken;
+}
+
+function countryAliases(value) {
+  const normalized = normalizeComparable(value);
+  const aliases = new Set();
+  if (!normalized) return aliases;
+  aliases.add(normalized);
+  const direct = COUNTRY_ALIASES.get(normalized);
+  if (direct) {
+    for (const alias of direct) aliases.add(alias);
+  }
+  return aliases;
 }
 
 function countMatchingRecords(feedData, field, value, startMs, endMs) {
   let count = 0;
   for (const record of iterateRecords(feedData)) {
     if (!record || typeof record !== 'object') continue;
-    const matches = [field, ...fieldAliases(field)].some((key) => valueEquals(record[key], value));
+    const matches = [field, ...fieldAliases(field)].some((key) => metricValueEquals(record[key], value, field));
     if (!matches) continue;
     const ts = extractRecordTime(record);
     if (Number.isFinite(ts) && ts >= startMs && ts <= endMs) count += 1;
@@ -223,8 +282,12 @@ function extractRecordTime(record) {
     record.ts,
     record.timestamp,
     record.generatedAt,
+    record.firstSeenAt,
+    record.lastSeenAt,
+    record.occurredAt,
     record.dateStart,
     record.date_start && Date.parse(record.date_start),
+    record.event_date && Date.parse(record.event_date),
     record.date && Date.parse(record.date),
     record.eventDate && Date.parse(record.eventDate),
   );

--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -13,7 +13,7 @@
 // metricKey format: '<feedKey>|<fn>(<field>==<value>)' — a path expression
 // over the shape read from that feed, with REAL substituted values (region,
 // title, ticker) and a unified '==' comparison grammar across every family,
-// e.g. 'conflict:ucdp-events:v1|count(country==Mali)' or
+// e.g. 'conflict:acled:v1:all:0:0|count(country==Mali)' or
 // 'market:commodities-bootstrap:v1|price(symbol==CL=F)'. It documents where in
 // the feed the metric lives and what to match; it is not executable code and
 // is not parsed by this module or any consumer today (Bet 2's resolver
@@ -41,6 +41,10 @@ export const HORIZON_MS = {
   '30d': 30 * DAY_MS,
 };
 
+export const CONFLICT_COUNT_SOURCE_FEED = 'conflict:acled:v1:all:0:0';
+export const UNREST_COUNT_SOURCE_FEED = 'unrest:events:v1';
+export const CYBER_COUNT_SOURCE_FEED = 'cyber:threats-bootstrap:v2';
+
 // Never returns null and never silently coerces an unrecognized horizon to a
 // nearby one — a silent '7d' fallback would score a 14d forecast a full week
 // early and corrupt the track record this bet exists to make trustworthy.
@@ -61,10 +65,13 @@ export function deriveDeadline(generatedAt, timeHorizon) {
 // keys (not path expressions) — `metricKey` embeds the extraction path on
 // top of one of these. The market entries are copied (string literals, not
 // imported — seed-forecasts.mjs has top-level side effects) from
-// MARKET_INPUT_KEYS (scripts/seed-forecasts.mjs :215) plus the market
-// feed keys already read into `readInputKeys()` (:708-717).
+// MARKET_INPUT_KEYS; the other entries are the non-market feeds hard specs
+// can actually emit and the resolver seeder can read by sourceFeed.
 export const RESOLUTION_FEED_KEYS = new Set([
   'conflict:ucdp-events:v1',
+  CONFLICT_COUNT_SOURCE_FEED,
+  UNREST_COUNT_SOURCE_FEED,
+  CYBER_COUNT_SOURCE_FEED,
   'supply_chain:chokepoints:v4',
   'infra:outages:v1',
   'prediction:markets-bootstrap:v1',
@@ -114,6 +121,9 @@ export const SIGNAL_TO_HARD_FAMILY = {
   commodity: 'market',
   prediction_market: 'prediction_market',
   ucdp: 'ucdp_zone',
+  unrest: 'unrest',
+  unrest_events: 'unrest',
+  cyber: 'cyber',
   gps_jamming: 'gps',
   outage: 'infrastructure',
   conflict_events: 'conflict',
@@ -123,22 +133,19 @@ export const SIGNAL_TO_HARD_FAMILY = {
 };
 
 // Domains whose forecasts are ALWAYS judged (R3), regardless of what signals
-// they carry. Domain is the claim's SUBJECT; signals are only evidence. A
-// political-domain forecast can carry a 'cii' signal (which
-// SIGNAL_TO_HARD_FAMILY maps to the conflict family) — but resolving that
-// political claim against a conflict event-count metric would mis-resolve the
-// political claim. Military posture-transition and cyber-volume thresholds
-// also need dedicated metric design (deferred, D3). This gate is checked
-// AFTER the state_derived origin check and the prediction_market exemption,
-// and BEFORE the general SIGNAL_TO_HARD_FAMILY lookup, so domain wins over any
-// incidental hard-mapped evidence signal — EXCEPT a prediction_market signal,
-// whose forecast's claim *is* the market question (see buildResolutionSpec).
-export const JUDGED_DOMAINS = new Set(['political', 'military', 'cyber']);
+// they carry. Domain is the claim's SUBJECT; signals are only evidence.
+// Political unrest and cyber concentration now have country/date feeds with a
+// direct count metric, but military still lacks a stable theater id on the
+// forecast object. Keep military judged until the detector carries that id.
+// This gate is checked AFTER the state_derived origin check and the
+// prediction_market exemption, and BEFORE the general SIGNAL_TO_HARD_FAMILY
+// lookup.
+export const JUDGED_DOMAINS = new Set(['military']);
 
 // Which hard families a forecast's DOMAIN permits (R3, by-domain constraint).
 // Domain is the claim's SUBJECT; signals are only evidence. A market-domain
 // forecast carrying a 'cii' signal (evidence of instability driving a
-// commodity move) must NOT resolve as a conflict spec scored against UCDP
+// commodity move) must NOT resolve as a conflict spec scored against conflict
 // event counts — 'conflict' is simply not an allowed family for domain
 // 'market'. When resolving the family from signals, any family not listed for
 // pred.domain is skipped; a domain absent from this table (after the
@@ -154,6 +161,8 @@ export const DOMAIN_TO_HARD_FAMILIES = {
   market: ['market', 'prediction_market'],
   supply_chain: ['supply_chain', 'gps'],
   infrastructure: ['infrastructure'],
+  political: ['unrest'],
+  cyber: ['cyber'],
 };
 
 // The commodity price-MOVE threshold ratio (market family): threshold =
@@ -178,8 +187,10 @@ const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 // resolved per-forecast (commodities feed for a commodity signal, or the
 // calibration fallback feed).
 const FAMILY_FEED = {
-  conflict: 'conflict:ucdp-events:v1',
-  ucdp_zone: 'conflict:ucdp-events:v1',
+  conflict: CONFLICT_COUNT_SOURCE_FEED,
+  ucdp_zone: CONFLICT_COUNT_SOURCE_FEED,
+  unrest: UNREST_COUNT_SOURCE_FEED,
+  cyber: CYBER_COUNT_SOURCE_FEED,
   supply_chain: 'supply_chain:chokepoints:v4',
   infrastructure: 'infra:outages:v1',
   prediction_market: 'prediction:markets-bootstrap:v1',
@@ -200,6 +211,8 @@ const FAMILY_FEED = {
 const FAMILY_WINDOW = {
   conflict: 'within-horizon',
   ucdp_zone: 'within-horizon',
+  unrest: 'within-horizon',
+  cyber: 'within-horizon',
   supply_chain: 'at-deadline',
   infrastructure: 'within-horizon',
   prediction_market: 'at-endDate',
@@ -377,7 +390,36 @@ function deriveHardMetrics(pred, family, inputs) {
       if (!Number.isFinite(horizonMs)) return null; // deriveDeadline throws for the judged path too
       const threshold = Math.max(1, Math.round(tally * (horizonMs / YEAR_MS) * CONFLICT_ESCALATION_RATIO));
       return {
-        metricKey: `conflict:ucdp-events:v1|count(country==${pred.region})`,
+        metricKey: `${CONFLICT_COUNT_SOURCE_FEED}|count(country==${pred.region})`,
+        sourceFeed: CONFLICT_COUNT_SOURCE_FEED,
+        operator: '>=',
+        threshold,
+        window: FAMILY_WINDOW[family],
+      };
+    }
+    case 'unrest': {
+      const tally = firstFiniteSignalCount(pred, new Set(['unrest_events']));
+      if (!Number.isFinite(tally)) return null;
+      const horizonMs = HORIZON_MS[pred.timeHorizon];
+      if (!Number.isFinite(horizonMs)) return null;
+      const threshold = Math.max(1, Math.round(tally * (horizonMs / (30 * DAY_MS)) * 0.75));
+      return {
+        metricKey: `${UNREST_COUNT_SOURCE_FEED}|count(country==${pred.region})`,
+        sourceFeed: UNREST_COUNT_SOURCE_FEED,
+        operator: '>=',
+        threshold,
+        window: FAMILY_WINDOW[family],
+      };
+    }
+    case 'cyber': {
+      const tally = firstFiniteSignalCount(pred, new Set(['cyber']));
+      if (!Number.isFinite(tally)) return null;
+      const horizonMs = HORIZON_MS[pred.timeHorizon];
+      if (!Number.isFinite(horizonMs)) return null;
+      const threshold = Math.max(1, Math.round(tally * (horizonMs / (14 * DAY_MS)) * 0.75));
+      return {
+        metricKey: `${CYBER_COUNT_SOURCE_FEED}|count(country==${pred.region})`,
+        sourceFeed: CYBER_COUNT_SOURCE_FEED,
         operator: '>=',
         threshold,
         window: FAMILY_WINDOW[family],
@@ -537,10 +579,8 @@ function buildHardSpec(pred, inputs, family, generatedAt) {
 //     claim's ground truth regardless of the domain the detector assigned
 //     (which can be political/conflict/market). This is unlike a 'cii' signal
 //     on a political claim (evidence, not the claim) — hence the exemption.
-//  3. JUDGED_DOMAINS (political/military/cyber) -> ALWAYS judged. Domain is
-//     the claim's subject; a political forecast carrying a hard-mapped
-//     evidence signal (e.g. 'cii' -> conflict) must not be resolved against a
-//     conflict metric (R3, by-domain assignment).
+//  3. JUDGED_DOMAINS (currently military) -> ALWAYS judged until the detector
+//     carries the stable metric identity needed for a hard feed lookup.
 //  4. Other hard families resolved from pred.signals[].type via
 //     SIGNAL_TO_HARD_FAMILY (with the market-domain chokepoint/ais_gap
 //     exclusion + a calibration.marketPrice fallback for market-domain

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -86,6 +86,7 @@ const SIM_TASK_COMPLETE_STATUS_COMPLETED = 'COMPLETED';
 const SIM_TASK_COMPLETE_STATUS_MISSING_WORKER = 'MISSING_WORKER';
 const SIMULATION_POLL_INTERVAL_MS = 30 * 1000;
 const PUBLISH_MIN_PROBABILITY = 0;
+const RESOLVABLE_HARD_SELECTION_LIFT = 0.25;
 const PANEL_MIN_PROBABILITY = 0.1;
 const CANONICAL_PAYLOAD_SOFT_LIMIT_BYTES = 4 * 1024 * 1024;
 const ENRICHMENT_COMBINED_MAX = 5;
@@ -13621,6 +13622,7 @@ function computePublishSelectionScore(pred, memoryIndex = null) {
   const defensePenalty = topBucketId === 'defense' && pred.marketSelectionContext?.topChannel !== 'defense_repricing'
     ? 0.018
     : 0;
+  const resolvabilityLift = pred?.resolution?.kind === 'hard' ? RESOLVABLE_HARD_SELECTION_LIFT : 0;
   pred.publishSelectionMemory = memoryHint ? {
     matchedBy: memoryHint.matchedBy,
     situationId: memoryHint.memory?.situationId || '',
@@ -13649,7 +13651,8 @@ function computePublishSelectionScore(pred, memoryIndex = null) {
     enrichedLift +
     memoryLift +
     marketTransmissionLift +
-    criticalLift -
+    criticalLift +
+    resolvabilityLift -
     marketPenalty +
     coreBucketLift -
     defensePenalty

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -86,7 +86,13 @@ const SIM_TASK_COMPLETE_STATUS_COMPLETED = 'COMPLETED';
 const SIM_TASK_COMPLETE_STATUS_MISSING_WORKER = 'MISSING_WORKER';
 const SIMULATION_POLL_INTERVAL_MS = 30 * 1000;
 const PUBLISH_MIN_PROBABILITY = 0;
-const RESOLVABLE_HARD_SELECTION_LIFT = 0.25;
+// Publish-selection lift for hard-resolvable forecasts (helps the canonical set
+// meet the >=80% resolvability KPI). Kept below the primary quality signals it
+// sits beside in computePublishSelectionScore -- priority (x0.55), readiness
+// (x0.2), probability (x0.15) and the memory lift (<=~0.17) -- so it strongly
+// favours measurable forecasts without flatly overriding a large quality gap.
+// A former flat 0.25 dominated every other term. Tune upward if the KPI is missed.
+const RESOLVABLE_HARD_SELECTION_LIFT = 0.12;
 const PANEL_MIN_PROBABILITY = 0.1;
 const CANONICAL_PAYLOAD_SOFT_LIMIT_BYTES = 4 * 1024 * 1024;
 const ENRICHMENT_COMBINED_MAX = 5;

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -3050,6 +3050,43 @@ describe('forecast quality gating', () => {
     assert.ok((pool[0].publishSelectionMarket?.confirmationScore || 0) > 0.7);
   });
 
+  it('boosts hard-resolvable forecasts during publish selection', () => {
+    const judged = makePrediction('political', 'France', 'Political pressure: France', 0.82, 0.58, '14d', [
+      { type: 'news_corroboration', value: 'France coalition pressure persists', weight: 0.35 },
+    ]);
+    const hard = makePrediction('conflict', 'Mali', 'Escalation risk: Mali', 0.5, 0.58, '14d', [
+      { type: 'conflict_events', value: '4 cross-border events in Mali', weight: 0.35 },
+    ]);
+
+    buildForecastCases([judged, hard]);
+    for (const pred of [judged, hard]) {
+      pred.traceMeta = { narrativeSource: 'fallback' };
+      pred.readiness = { overall: 0.6 };
+      pred.analysisPriority = 0.12;
+    }
+
+    const deadline = Date.parse('2026-08-01T00:00:00Z');
+    judged.resolution = {
+      kind: 'judged',
+      deadline,
+      question: 'Will French political pressure materially escalate?',
+    };
+    hard.resolution = {
+      kind: 'hard',
+      metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+      operator: '>=',
+      threshold: 1,
+      window: 'within-horizon',
+      deadline,
+      sourceFeed: 'conflict:acled:v1:all:0:0',
+    };
+
+    const pool = selectPublishedForecastPool([judged, hard], { targetCount: 1 });
+    assert.equal(pool.length, 1);
+    assert.equal(pool[0].id, hard.id);
+    assert.ok(hard.publishSelectionScore > judged.publishSelectionScore);
+  });
+
   it('keeps strategic supply-chain forecasts alive alongside same-state market repricing and reports survival telemetry', () => {
     const market = makePrediction('market', 'Strait of Hormuz', 'Energy repricing risk: Strait of Hormuz', 0.66, 0.61, '30d', [
       { type: 'energy_supply_shock', value: 'Energy repricing persists around Hormuz shipping stress.', weight: 0.36 },

--- a/tests/forecast-history.test.mjs
+++ b/tests/forecast-history.test.mjs
@@ -9,7 +9,10 @@ import {
   buildPublishedForecastPayload,
 } from '../scripts/seed-forecasts.mjs';
 
-import { attachResolutionSpecs } from '../scripts/_forecast-resolution.mjs';
+import {
+  CONFLICT_COUNT_SOURCE_FEED,
+  attachResolutionSpecs,
+} from '../scripts/_forecast-resolution.mjs';
 
 import {
   selectBenchmarkCandidates,
@@ -331,8 +334,8 @@ describe('forecast benchmark promotion', () => {
 // the makePrediction default, and the camelCase resolution + projections
 // blocks in both the canonical payload and the 45-day history entry.
 
-// A conflict forecast reaching the hard path needs a ucdp/cii signal with a
-// finite count; a commodity market forecast needs an inputs feed with the
+// A conflict forecast reaching the hard path needs a count-bearing signal;
+// a commodity market forecast needs an inputs feed with the
 // mapped future ticker priced. Kept minimal + console-quiet.
 const HARD_CONFLICT_GENERATED_AT = 1_700_000_000_000;
 
@@ -354,7 +357,7 @@ describe('forecast resolution spec round-trip (U3)', () => {
     assert.equal(entry.resolution.metricKey, pred.resolution.metricKey);
     assert.equal(entry.resolution.operator, '>=');
     assert.ok(Number.isFinite(entry.resolution.threshold));
-    assert.equal(entry.resolution.sourceFeed, 'conflict:ucdp-events:v1');
+    assert.equal(entry.resolution.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     assert.equal(entry.resolution.deadline, HARD_CONFLICT_GENERATED_AT + 7 * 24 * 60 * 60 * 1000);
     // camelCase only — no snake_case leaked through the boundary (D6).
     assert.ok(!('metric_key' in entry.resolution));

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -117,7 +117,7 @@ describe('resolveHardSpec', () => {
     assert.equal(resolved.evidence.comparison, '2 >= 2');
   });
 
-  it('uses the shorter ACLED lag and event_date for fresh conflict counts', () => {
+  it('uses the shorter ACLED lag for fresh conflict counts', () => {
     const deadline = START + 3 * DAY_MS;
     const e = entry({
       deadline,
@@ -133,9 +133,11 @@ describe('resolveHardSpec', () => {
     });
     const feed = {
       events: [
-        { country: 'Mali', event_date: '2026-07-07' },
-        { country: 'Mali', event_date: '2026-07-09' },
-        { country: 'Mali', event_date: '2026-07-11' },
+        // Production ACLED shape from seed-conflict-intel.mjs: numeric occurredAt.
+        { country: 'Mali', occurredAt: START },
+        { country: 'Mali', occurredAt: START + 2 * DAY_MS },
+        { country: 'Mali', occurredAt: START + 4 * DAY_MS },
+        // Raw ACLED date string still resolves via the event_date fallback.
         { country: 'Burkina Faso', event_date: '2026-07-09' },
       ],
     };

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -2,7 +2,9 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import {
+  ACLED_SETTLEMENT_LAG_MS,
   UCDP_SETTLEMENT_LAG_MS,
+  countSettlementLagMs,
   parseMetricKey,
   resolveHardSpec,
 } from '../scripts/_forecast-resolution-eval.mjs';
@@ -42,9 +44,15 @@ function assertNoNullFields(value, path = 'fixture') {
 }
 
 describe('parseMetricKey', () => {
-  it('parses the six emitted function forms with anchored delimiters', () => {
+  it('parses the emitted function forms with anchored delimiters', () => {
     assert.deepEqual(parseMetricKey('conflict:ucdp-events:v1|count(country==Mali)'), {
       feedKey: 'conflict:ucdp-events:v1',
+      fn: 'count',
+      field: 'country',
+      value: 'Mali',
+    });
+    assert.deepEqual(parseMetricKey('conflict:acled:v1:all:0:0|count(country==Mali)'), {
+      feedKey: 'conflict:acled:v1:all:0:0',
       fn: 'count',
       field: 'country',
       value: 'Mali',
@@ -66,6 +74,15 @@ describe('parseMetricKey', () => {
     for (const bad of ['', 'no-pipe', 'feed|fn(field=value)', 'feed|fn(field==value', 'feed|fn()']) {
       assert.equal(parseMetricKey(bad), null, bad);
     }
+  });
+});
+
+describe('countSettlementLagMs', () => {
+  it('uses the long UCDP lag only for legacy UCDP count feeds', () => {
+    assert.equal(countSettlementLagMs('conflict:ucdp-events:v1'), UCDP_SETTLEMENT_LAG_MS);
+    assert.equal(countSettlementLagMs('conflict:acled:v1:all:0:0'), ACLED_SETTLEMENT_LAG_MS);
+    assert.equal(countSettlementLagMs('unrest:events:v1'), 0);
+    assert.equal(countSettlementLagMs('cyber:threats-bootstrap:v2'), 0);
   });
 });
 
@@ -95,6 +112,71 @@ describe('resolveHardSpec', () => {
     assert.equal(resolved.outcome, 'YES');
     assert.equal(resolved.evidence.metricValue, 2);
     assert.equal(resolved.evidence.comparison, '2 >= 2');
+  });
+
+  it('uses the shorter ACLED lag and event_date for fresh conflict counts', () => {
+    const deadline = START + 3 * DAY_MS;
+    const e = entry({
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:acled:v1:all:0:0',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Mali', event_date: '2026-07-07' },
+        { country: 'Mali', event_date: '2026-07-09' },
+        { country: 'Mali', event_date: '2026-07-11' },
+        { country: 'Burkina Faso', event_date: '2026-07-09' },
+      ],
+    };
+
+    assert.deepEqual(
+      resolveHardSpec(e, feed, {}, deadline + ACLED_SETTLEMENT_LAG_MS - 1),
+      {
+        status: 'pending',
+        evidence: { reason: 'count_settlement_lag', deadline, sealAfter: deadline + ACLED_SETTLEMENT_LAG_MS },
+      },
+    );
+
+    const resolved = resolveHardSpec(e, feed, {}, deadline + ACLED_SETTLEMENT_LAG_MS);
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.outcome, 'YES');
+    assert.equal(resolved.evidence.metricValue, 2);
+    assert.equal(resolved.evidence.comparison, '2 >= 2');
+  });
+
+  it('matches country display names against ISO-2 country fields for cyber counts', () => {
+    const deadline = START + DAY_MS;
+    const e = entry({
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'cyber:threats-bootstrap:v2|count(country==Estonia)',
+        operator: '>=',
+        threshold: 1,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'cyber:threats-bootstrap:v2',
+      },
+    });
+    const feed = {
+      threats: [
+        { country: 'EE', firstSeenAt: START + 1_000 },
+        { country: 'LV', firstSeenAt: START + 2_000 },
+      ],
+    };
+
+    const resolved = resolveHardSpec(e, feed, {}, deadline);
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.outcome, 'YES');
+    assert.equal(resolved.evidence.metricValue, 1);
   });
 
   it('resolves at-deadline point reads from the first sample at or after deadline', () => {

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -6,6 +6,9 @@ import { fileURLToPath } from 'node:url';
 
 import {
   HORIZON_MS,
+  CONFLICT_COUNT_SOURCE_FEED,
+  UNREST_COUNT_SOURCE_FEED,
+  CYBER_COUNT_SOURCE_FEED,
   RESOLUTION_FEED_KEYS,
   SIGNAL_TO_HARD_FAMILY,
   JUDGED_DOMAINS,
@@ -122,7 +125,7 @@ describe('buildResolutionSpec — happy path (conflict)', () => {
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
     assert.ok(RESOLUTION_FEED_KEYS.has(spec.sourceFeed));
-    assert.equal(spec.sourceFeed, 'conflict:ucdp-events:v1');
+    assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     assert.ok(Number.isFinite(spec.threshold));
     assert.ok(['>=', '<=', 'crosses'].includes(spec.operator));
     assert.ok(Object.hasOwn(spec, 'metricKey'));
@@ -223,14 +226,43 @@ describe('buildResolutionSpec — feed mapping per family', () => {
     assert.equal(spec.sourceFeed, 'intelligence:gpsjam:v2');
   });
 
-  it('a UCDP-zone forecast resolves to conflict:ucdp-events:v1', () => {
+  it('a UCDP-zone forecast resolves to the fresh ACLED count feed', () => {
     const forecast = pred({
       domain: 'conflict',
       signals: [{ type: 'ucdp', value: '25 UCDP conflict events', weight: 0.5 }],
     });
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
-    assert.equal(spec.sourceFeed, 'conflict:ucdp-events:v1');
+    assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
+  });
+
+  it('a political unrest-events forecast resolves to the unrest count feed', () => {
+    const forecast = pred({
+      domain: 'political',
+      region: 'Venezuela',
+      title: 'Political instability: Venezuela',
+      signals: [
+        { type: 'unrest', value: 'Venezuela unrest component: 62', weight: 0.4 },
+        { type: 'unrest_events', value: '4 unrest events in Venezuela', weight: 0.3 },
+      ],
+    });
+    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    assert.equal(spec.kind, 'hard');
+    assert.equal(spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
+    assert.equal(spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
+  });
+
+  it('a cyber volume forecast resolves to the cyber threat count feed', () => {
+    const forecast = pred({
+      domain: 'cyber',
+      region: 'Estonia',
+      title: 'Cyber disruption risk: Estonia',
+      signals: [{ type: 'cyber', value: '10 threats (malware)', weight: 0.5 }],
+    });
+    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    assert.equal(spec.kind, 'hard');
+    assert.equal(spec.sourceFeed, CYBER_COUNT_SOURCE_FEED);
+    assert.equal(spec.metricKey, `${CYBER_COUNT_SOURCE_FEED}|count(country==Estonia)`);
   });
 
   it('an infrastructure forecast resolves to infra:outages:v1', () => {
@@ -373,18 +405,13 @@ describe('buildResolutionSpec — threshold fallback', () => {
   });
 });
 
-describe('buildResolutionSpec — judged families', () => {
-  it('a political forecast yields judged with a non-empty question and no threshold', () => {
+describe('buildResolutionSpec — domain-specific hard and judged families', () => {
+  it('a political forecast with no unrest event count yields judged with a non-empty question and no threshold', () => {
     const forecast = pred({
       domain: 'political',
       region: 'Venezuela',
       title: 'Political instability: Venezuela',
-      // Real detectPoliticalScenarios signal vocabulary (unrest/unrest_events/anomaly) —
-      // none of these are hard-family-mapped, unlike 'cii' (which maps to conflict).
-      signals: [
-        { type: 'unrest', value: 'Venezuela unrest component: 62', weight: 0.4 },
-        { type: 'unrest_events', value: '4 unrest events in Venezuela', weight: 0.3 },
-      ],
+      signals: [{ type: 'unrest', value: 'Venezuela unrest component: elevated', weight: 0.4 }],
     });
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'judged');
@@ -398,23 +425,17 @@ describe('buildResolutionSpec — judged families', () => {
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'judged');
   });
-
-  it('a cyber forecast yields judged', () => {
-    const forecast = pred({ domain: 'cyber', signals: [{ type: 'cyber', value: '10 threats (malware)', weight: 0.5 }] });
-    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
-    assert.equal(spec.kind, 'judged');
-  });
 });
 
-describe('buildResolutionSpec — JUDGED_DOMAINS gate wins over hard-mapped signals (R3 by-domain)', () => {
-  it('JUDGED_DOMAINS is the documented political/military/cyber set', () => {
-    assert.deepEqual([...JUDGED_DOMAINS].sort(), ['cyber', 'military', 'political']);
+describe('buildResolutionSpec — domain constraints win over hard-mapped signals (R3 by-domain)', () => {
+  it('JUDGED_DOMAINS only retains domains without a stable hard metric identity', () => {
+    assert.deepEqual([...JUDGED_DOMAINS].sort(), ['military']);
   });
 
   it('a political-domain forecast carrying a cii signal yields judged, never a hard conflict spec', () => {
-    // 'cii' maps to the conflict hard family in SIGNAL_TO_HARD_FAMILY — without
-    // the domain gate this political claim would be resolved against a conflict
-    // event-count metric (the exact latent coupling the gate closes).
+    // 'cii' maps to the conflict hard family in SIGNAL_TO_HARD_FAMILY, but
+    // political claims only permit the unrest hard family. This must not
+    // resolve against a conflict event-count metric.
     const forecast = pred({
       domain: 'political',
       region: 'Venezuela',
@@ -480,6 +501,8 @@ describe('deadline is always present', () => {
 describe('R4 — sourceFeed membership over every hard fixture', () => {
   const fixtures = [
     pred({ id: 'conflict', domain: 'conflict', signals: [{ type: 'ucdp', value: '14 UCDP conflict events', weight: 0.5 }] }),
+    pred({ id: 'political', domain: 'political', region: 'Venezuela', signals: [{ type: 'unrest_events', value: '4 unrest events', weight: 0.3 }] }),
+    pred({ id: 'cyber', domain: 'cyber', region: 'Estonia', signals: [{ type: 'cyber', value: '10 threats', weight: 0.5 }] }),
     pred({ id: 'supply_chain', domain: 'supply_chain', timeHorizon: '7d', signals: [{ type: 'chokepoint', value: 'disruption', weight: 0.5 }] }),
     pred({ id: 'gps', domain: 'supply_chain', timeHorizon: '7d', signals: [{ type: 'gps_jamming', value: '5 jamming hexes', weight: 0.5 }] }),
     pred({ id: 'infra', domain: 'infrastructure', timeHorizon: '24h', signals: [{ type: 'outage', value: '2 outages', weight: 0.5 }] }),
@@ -565,6 +588,9 @@ describe('edge cases', () => {
     assert.equal(SIGNAL_TO_HARD_FAMILY.commodity, 'market');
     assert.equal(SIGNAL_TO_HARD_FAMILY.prediction_market, 'prediction_market');
     assert.equal(SIGNAL_TO_HARD_FAMILY.ucdp, 'ucdp_zone');
+    assert.equal(SIGNAL_TO_HARD_FAMILY.unrest, 'unrest');
+    assert.equal(SIGNAL_TO_HARD_FAMILY.unrest_events, 'unrest');
+    assert.equal(SIGNAL_TO_HARD_FAMILY.cyber, 'cyber');
     assert.equal(SIGNAL_TO_HARD_FAMILY.gps_jamming, 'gps');
     assert.equal(SIGNAL_TO_HARD_FAMILY.outage, 'infrastructure');
     assert.equal(SIGNAL_TO_HARD_FAMILY.conflict_events, 'conflict');
@@ -579,6 +605,8 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
       market: ['market', 'prediction_market'],
       supply_chain: ['supply_chain', 'gps'],
       infrastructure: ['infrastructure'],
+      political: ['unrest'],
+      cyber: ['cyber'],
     });
   });
 
@@ -587,7 +615,7 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     // :1152-1157): domain 'market', signals [cii, commodity]. 'cii' maps to
     // the conflict family, but conflict is not allowed for domain 'market' —
     // so the claim must resolve via 'commodity' (market family), never against
-    // UCDP event counts on conflict:ucdp-events:v1.
+    // event counts on the conflict count feed.
     const forecast = pred({
       domain: 'market',
       region: 'Middle East',
@@ -599,10 +627,10 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     });
     const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT);
     // Never a conflict-feed hard spec.
-    assert.notEqual(spec.sourceFeed, 'conflict:ucdp-events:v1');
+    assert.notEqual(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     if (spec.kind === 'hard') {
       assert.equal(spec.sourceFeed, 'market:commodities-bootstrap:v1');
-      assert.ok(!spec.metricKey.includes('conflict:ucdp-events'));
+      assert.ok(!spec.metricKey.includes(CONFLICT_COUNT_SOURCE_FEED));
     } else {
       assert.equal(spec.kind, 'judged');
     }
@@ -621,7 +649,7 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT);
     assert.equal(spec.kind, 'judged');
     assert.equal(spec.sourceFeed, null);
-    assert.notEqual(spec.sourceFeed, 'conflict:ucdp-events:v1');
+    assert.notEqual(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
   });
 
   // FIX A: 'cii' is a 0-100 composite index, NOT an event count, so it no
@@ -652,7 +680,7 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
     });
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
-    assert.equal(spec.sourceFeed, 'conflict:ucdp-events:v1');
+    assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     // #5010 horizon-commensurable threshold: the 365d-trailing tally (3) is
     // scaled to the 30d horizon and escalated —
     // max(1, round(3 × 30d/365d × CONFLICT_ESCALATION_RATIO)) = 1.
@@ -672,7 +700,7 @@ describe('FIX 2 — metricKey embeds real values with unified "==" grammar', () 
       signals: [{ type: 'ucdp', value: '175 UCDP conflict events', weight: 0.5 }],
     });
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
-    assert.equal(spec.metricKey, 'conflict:ucdp-events:v1|count(country==Pakistan)');
+    assert.equal(spec.metricKey, `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Pakistan)`);
     assert.ok(!spec.metricKey.includes('<region>'));
   });
 


### PR DESCRIPTION
## Summary
- route conflict/UCDP hard count specs to fresh ACLED data instead of the lagged UCDP feed
- add hard resolvability for political unrest-event and cyber-volume forecasts, including ISO/name country matching for cyber feeds
- boost hard-resolvable forecasts during publication selection to help the canonical set meet the >=80% resolvability KPI

Fixes #5066

## Tests
- node --test tests/forecast-resolution.test.mjs tests/forecast-resolution-eval.test.mjs tests/forecast-resolutions-seeder.test.mjs tests/forecast-history.test.mjs tests/forecast-detectors.test.mjs
- node --test tests/forecast-resolution.test.mjs tests/forecast-resolution-eval.test.mjs tests/forecast-detectors.test.mjs
- npm run typecheck:api
- git diff --check