### PR TITLE
perf(forecast): prune archived terminal entries from the resolution ledger (#5067)

### DIFF
--- a/scripts/_forecast-scorecard.mjs
+++ b/scripts/_forecast-scorecard.mjs
@@ -3,7 +3,7 @@
 // Input is the Redis working ledger (object or array). Output is a compact,
 // JSON-serializable scorecard. No wall-clock reads: nowMs is injected.
 
-const DEFAULT_ROLLING_WINDOW_DAYS = 180;
+export const DEFAULT_ROLLING_WINDOW_DAYS = 180;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const EPSILON = 1e-6;
 

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -71,7 +71,7 @@ export function pruneArchivedTerminalEntries(ledger, nowMs, options = {}) {
   const retentionDays = options.retentionWindowDays ?? LEDGER_RETENTION_WINDOW_DAYS;
   const minResolvedAt = nowMs - retentionDays * DAY_MS;
   const kept = {};
-  for (const [key, entry] of Object.entries(ledger || {})) {
+  for (const [key, entry] of Object.entries(normalizeLedger(ledger))) {
     if (isPrunableTerminalEntry(entry, minResolvedAt)) continue;
     kept[key] = entry;
   }
@@ -326,10 +326,12 @@ async function buildLedgerForRun() {
   const preLedger = ingestHistory(existingLedger || {}, history, nowMs);
   const feeds = await readResolutionFeeds(preLedger);
   const result = processResolutionCycle(preLedger, [], feeds, nowMs);
-  const archivedReceipts = await appendR2Receipts(collectUnarchivedReceipts(result.ledger));
+  const receiptsForArchive = collectUnarchivedReceipts(result.ledger);
+  const archivedReceipts = await appendR2Receipts(receiptsForArchive);
   markReceiptsArchived(result.ledger, archivedReceipts, Date.now());
   console.log(`  Resolution ledger entries: ${Object.keys(result.ledger).length}`);
-  console.log(`  New terminal receipts: ${result.receipts.length}`);
+  console.log(`  Terminal receipts resolved this cycle: ${result.receipts.length}`);
+  console.log(`  Terminal receipts queued for R2: ${receiptsForArchive.length}`);
   console.log(`  R2 receipts archived: ${archivedReceipts.length}`);
   return result.ledger;
 }

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -16,7 +16,7 @@ import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
 import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
-import { computeScorecard } from './_forecast-scorecard.mjs';
+import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
 
 export const HISTORY_KEY = 'forecast:predictions:history:v1';
 export const RESOLUTIONS_KEY = 'forecast:resolutions:v1';
@@ -26,6 +26,17 @@ export const SCORECARD_TTL_SECONDS = 7 * 24 * 60 * 60;
 export const RESOLUTION_SOURCE_VERSION = 'forecast-resolution-engine-v1';
 export const RESOLUTION_SCHEMA_VERSION = 1;
 export const MAX_RECENT_SAMPLES = 40;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Retention for the persistent working ledger (#5067). A resolved entry only
+// leaves the hot `forecast:resolutions:v1` value once it is (a) durably archived
+// to R2 as a receipt AND (b) older than this window — by which point it no longer
+// contributes to the rolling scorecard math, so pruning it is scorecard-neutral.
+// Aligned to the scorecard's rolling window so the two never diverge: any pruned
+// entry is exactly one the scorecard already excludes. The window (180d) dwarfs
+// the forecast-history intake reach (LRANGE 200 at hourly cadence ~8.3 days), so
+// a pruned window can never be re-ingested from a stale snapshot.
+export const LEDGER_RETENTION_WINDOW_DAYS = DEFAULT_ROLLING_WINDOW_DAYS;
 
 const DIRECT_RUN = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
 if (DIRECT_RUN) loadEnvFile(import.meta.url);
@@ -39,11 +50,40 @@ export function declareScorecardRecords(scorecard) {
 }
 
 export function processResolutionCycle(existingLedger, historySnapshots, feedsByKey, nowMs) {
-  const ledger = ingestHistory(existingLedger, historySnapshots, nowMs);
-  samplePendingEntries(ledger, feedsByKey, nowMs);
-  const receipts = resolveDueEntries(ledger, feedsByKey, nowMs);
+  const ingested = ingestHistory(existingLedger, historySnapshots, nowMs);
+  samplePendingEntries(ingested, feedsByKey, nowMs);
+  const receipts = resolveDueEntries(ingested, feedsByKey, nowMs);
+  // Drop terminal entries that are already receipted to R2 and outside the
+  // rolling scorecard window, keeping the persistent ledger bounded (#5067). Runs after
+  // resolveDueEntries so entries resolved this cycle (resolvedAt === nowMs, not
+  // yet archived) are always retained and still emit a receipt above.
+  const ledger = pruneArchivedTerminalEntries(ingested, nowMs);
   const scorecard = computeScorecard(ledger, nowMs);
   return { ledger, receipts, scorecard };
+}
+
+// Terminal entries whose receipt is safely in R2 and that have aged past the
+// retention window are removed from the hot working ledger; everything else
+// (pending, pending-judge, within-window resolved, un-archived resolved, or
+// resolved-without-a-timestamp) is retained. Pure: returns a new object and
+// never mutates the input.
+export function pruneArchivedTerminalEntries(ledger, nowMs, options = {}) {
+  const retentionDays = options.retentionWindowDays ?? LEDGER_RETENTION_WINDOW_DAYS;
+  const minResolvedAt = nowMs - retentionDays * DAY_MS;
+  const kept = {};
+  for (const [key, entry] of Object.entries(ledger || {})) {
+    if (isPrunableTerminalEntry(entry, minResolvedAt)) continue;
+    kept[key] = entry;
+  }
+  return kept;
+}
+
+function isPrunableTerminalEntry(entry, minResolvedAt) {
+  if (!entry || entry.status !== 'resolved') return false;
+  if (!entry.receiptArchivedAt) return false;
+  const resolvedAt = Number(entry.resolvedAt);
+  if (!Number.isFinite(resolvedAt)) return false;
+  return resolvedAt < minResolvedAt;
 }
 
 export function ingestHistory(existingLedger, historySnapshots, nowMs = Date.now()) {

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -50,6 +50,11 @@ const HISTORY_KEY = 'forecast:predictions:history:v1';
 const TTL_SECONDS = 21600; // 6h — 6x the 1h cron interval (was 1.75x; hourly miss → 15 min panel gap)
 const HISTORY_MAX_RUNS = 200;
 const HISTORY_MAX_FORECASTS = 25;
+// This list is the resolver's intake window (LRANGE 200 at hourly cadence ~8.3d,
+// hard-capped at 45d by the TTL below). seed-forecast-resolutions.mjs relies on
+// that reach staying well under LEDGER_RETENTION_WINDOW_DAYS (180d) so pruned
+// terminal windows can never be re-ingested — keep this cadence×count and TTL
+// far below that retention window if you change either.
 const HISTORY_TTL_SECONDS = 45 * 24 * 60 * 60;
 const TRACE_LATEST_KEY = 'forecast:trace:latest:v1';
 const TRACE_RUNS_KEY = 'forecast:trace:runs:v1';

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -405,6 +405,29 @@ describe('pruneArchivedTerminalEntries', () => {
     assert.ok(ledger['old-archived@1'], 'input must be left intact for the caller');
   });
 
+  it('normalizes array and seed-envelope ledger inputs before pruning', () => {
+    const ledger = ledgerFixture();
+    const arrayPruned = pruneArchivedTerminalEntries(Object.values(ledger), NOW);
+    assert.equal(arrayPruned['old-archived@1'], undefined);
+    assert.ok(arrayPruned['recent-archived@1'], 'array input keeps in-window archived rows');
+    assert.ok(arrayPruned['old-unarchived@1'], 'array input keeps unarchived retry rows');
+
+    const envelopedPruned = pruneArchivedTerminalEntries({
+      _seed: {
+        fetchedAt: NOW,
+        recordCount: Object.keys(ledger).length,
+        sourceVersion: 'test',
+        schemaVersion: 1,
+        state: 'OK',
+      },
+      data: Object.values(ledger),
+    }, NOW);
+    assert.equal(envelopedPruned['old-archived@1'], undefined);
+    assert.equal(envelopedPruned.data, undefined, 'envelope wrapper must not leak into the pruned ledger');
+    assert.ok(envelopedPruned['recent-archived@1'], 'enveloped input keeps in-window archived rows');
+    assert.ok(envelopedPruned['old-unarchived@1'], 'enveloped input keeps unarchived retry rows');
+  });
+
   it('honors a custom retention window', () => {
     const ledger = ledgerFixture();
     // With a 5-day window, the 10-day-old archived entry is also out of window.

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -5,13 +5,16 @@ import {
   RESOLUTIONS_KEY,
   SCORECARD_META_KEY,
   SCORECARD_KEY,
+  LEDGER_RETENTION_WINDOW_DAYS,
   appendSample,
   appendR2Receipts,
   collectUnarchivedReceipts,
   declareRecords,
   markReceiptsArchived,
   processResolutionCycle,
+  pruneArchivedTerminalEntries,
 } from '../scripts/seed-forecast-resolutions.mjs';
+import { computeScorecard } from '../scripts/_forecast-scorecard.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const T0 = Date.parse('2026-07-07T00:00:00Z');
@@ -294,6 +297,14 @@ describe('appendSample and seed contract', () => {
     assert.deepEqual(collectUnarchivedReceipts(ledger), []);
   });
 
+  it('exposes a retention window comfortably larger than the ~8.3d history intake reach', () => {
+    // The forecast-history intake is LRANGE 200 at hourly cadence (~8.3 days).
+    // Retention must be far larger so a pruned window can never be re-ingested
+    // from a stale snapshot still sitting in the intake read.
+    assert.equal(LEDGER_RETENTION_WINDOW_DAYS, 180);
+    assert.ok(LEDGER_RETENTION_WINDOW_DAYS > 30, 'retention must dwarf the intake window');
+  });
+
   it('keeps R2 receipt archival best-effort so one object failure stays retryable', async () => {
     const warnings = [];
     const originalWarn = console.warn;
@@ -322,5 +333,128 @@ describe('appendSample and seed contract', () => {
     } finally {
       console.warn = originalWarn;
     }
+  });
+});
+
+describe('pruneArchivedTerminalEntries', () => {
+  const RETENTION_MS = LEDGER_RETENTION_WINDOW_DAYS * DAY_MS;
+  const NOW = Date.parse('2027-07-07T00:00:00Z');
+
+  function ledgerFixture() {
+    return {
+      // resolved, archived, and older than the retention window → prunable
+      'old-archived@1': {
+        key: 'old-archived@1',
+        id: 'old-archived',
+        status: 'resolved',
+        outcome: 'YES',
+        probability: 0.7,
+        resolvedAt: NOW - RETENTION_MS - DAY_MS,
+        receiptArchivedAt: NOW - RETENTION_MS,
+        receiptArchiveKey: 'receipts/old-archived.json',
+      },
+      // resolved and archived but still inside the rolling window → kept (still scored)
+      'recent-archived@1': {
+        key: 'recent-archived@1',
+        id: 'recent-archived',
+        status: 'resolved',
+        outcome: 'NO',
+        probability: 0.3,
+        resolvedAt: NOW - 10 * DAY_MS,
+        receiptArchivedAt: NOW - 9 * DAY_MS,
+      },
+      // resolved and old but NOT archived to R2 yet → kept (receipt not durably stored)
+      'old-unarchived@1': {
+        key: 'old-unarchived@1',
+        id: 'old-unarchived',
+        status: 'resolved',
+        outcome: 'YES',
+        probability: 0.9,
+        resolvedAt: NOW - RETENTION_MS - DAY_MS,
+      },
+      // pending forever → kept (still needs resolution)
+      'pending@1': { key: 'pending@1', id: 'pending', status: 'pending' },
+      // judged spec awaiting a judge resolver that has not shipped → kept
+      'judge@1': { key: 'judge@1', id: 'judge', status: 'pending-judge' },
+      // resolved+archived but missing resolvedAt → kept (cannot age-check safely)
+      'no-resolvedat@1': {
+        key: 'no-resolvedat@1',
+        id: 'no-resolvedat',
+        status: 'resolved',
+        outcome: 'YES',
+        receiptArchivedAt: NOW - RETENTION_MS,
+      },
+    };
+  }
+
+  it('drops only resolved+archived entries older than the retention window', () => {
+    const pruned = pruneArchivedTerminalEntries(ledgerFixture(), NOW);
+    assert.deepEqual(Object.keys(pruned).sort(), [
+      'judge@1',
+      'no-resolvedat@1',
+      'old-unarchived@1',
+      'pending@1',
+      'recent-archived@1',
+    ]);
+    assert.equal(pruned['old-archived@1'], undefined);
+  });
+
+  it('never mutates the input ledger', () => {
+    const ledger = ledgerFixture();
+    pruneArchivedTerminalEntries(ledger, NOW);
+    assert.ok(ledger['old-archived@1'], 'input must be left intact for the caller');
+  });
+
+  it('honors a custom retention window', () => {
+    const ledger = ledgerFixture();
+    // With a 5-day window, the 10-day-old archived entry is also out of window.
+    const pruned = pruneArchivedTerminalEntries(ledger, NOW, { retentionWindowDays: 5 });
+    assert.equal(pruned['recent-archived@1'], undefined);
+    assert.equal(pruned['old-archived@1'], undefined);
+    assert.ok(pruned['old-unarchived@1'], 'unarchived stays even when out of window');
+  });
+
+  it('does not change the scorecard it is aligned with', () => {
+    const ledger = ledgerFixture();
+    const before = computeScorecard(ledger, NOW);
+    const after = computeScorecard(pruneArchivedTerminalEntries(ledger, NOW), NOW);
+    assert.deepEqual(after, before, 'pruned entries were already outside the rolling scorecard window');
+  });
+});
+
+describe('processResolutionCycle retention', () => {
+  it('prunes prior-cycle archived terminal entries once they age out of the window', () => {
+    const RETENTION_MS = LEDGER_RETENTION_WINDOW_DAYS * DAY_MS;
+    const now = T0 + 2 * RETENTION_MS;
+    const existingLedger = {
+      'stale-archived@1': {
+        key: 'stale-archived@1',
+        id: 'stale-archived',
+        status: 'resolved',
+        outcome: 'YES',
+        probability: 0.55,
+        resolvedAt: T0,
+        receiptArchivedAt: T0 + DAY_MS,
+        receiptArchiveKey: 'receipts/stale-archived.json',
+      },
+    };
+    const fresh = forecast({ generatedAt: now, deadline: now + DAY_MS });
+
+    const { ledger } = processResolutionCycle(existingLedger, [snapshot(now, [fresh])], {
+      'supply_chain:chokepoints:v4': { chokepoints: [{ route: 'Strait of Hormuz', riskScore: 5 }] },
+    }, now);
+
+    assert.equal(ledger['stale-archived@1'], undefined, 'aged-out archived receipt is pruned from the hot ledger');
+    assert.ok(ledger[`fc-hormuz@${now + DAY_MS}`], 'freshly ingested window survives');
+  });
+
+  it('retains a terminal entry that resolved this cycle (not yet archived)', () => {
+    const hard = forecast({ deadline: T0 + DAY_MS });
+    const { ledger, receipts } = processResolutionCycle({}, [snapshot(T0, [hard])], {
+      'supply_chain:chokepoints:v4': { chokepoints: [{ route: 'Strait of Hormuz', riskScore: 61 }] },
+    }, T0 + DAY_MS);
+
+    assert.equal(ledger[`fc-hormuz@${T0 + DAY_MS}`].status, 'resolved');
+    assert.equal(receipts.length, 1, 'the receipt is still emitted for R2 archival');
   });
 });


### PR DESCRIPTION
## Summary

Closes #5067. The persistent working ledger `forecast:resolutions:v1` had **no retention** — every resolved `id@deadline` window was kept forever, and the whole value is read, deep-`cloneJson`'d, and rewritten on every daily run. Both the Redis value and the O(n) clone grow unbounded over months.

This adds the deferred **filtered-ledger retention**: a resolved entry leaves the hot ledger once it is safely archived to R2 **and** aged past the rolling scorecard window. Full history is preserved in the R2 receipt archive.

## What changed

- **`pruneArchivedTerminalEntries(ledger, nowMs, options)`** (`scripts/seed-forecast-resolutions.mjs`) — pure, non-mutating. Prunes an entry only when **all** hold:
  - `status === 'resolved'` (terminal),
  - `receiptArchivedAt` is set (durably receipted to R2), and
  - `resolvedAt < nowMs - 180d`.
  
  So `pending`, `pending-judge`, within-window resolved, un-archived resolved (still retrying R2), and resolved-without-a-timestamp entries are **always retained**.
- Wired into `processResolutionCycle` after `resolveDueEntries` (so an entry resolved *this* cycle — `resolvedAt === nowMs`, not yet archived — is always kept and still emits its receipt) and before `computeScorecard`.
- `LEDGER_RETENTION_WINDOW_DAYS` is aliased to the scorecard's `DEFAULT_ROLLING_WINDOW_DAYS` (now exported from `_forecast-scorecard.mjs`) so the two windows **never diverge**.
- Documented the intake-vs-retention coupling at the producer's `HISTORY_MAX_RUNS`/`HISTORY_TTL_SECONDS` in `scripts/seed-forecasts.mjs`.

## Why it's safe

- **Scorecard-neutral.** The scorecard already excludes resolved entries with `resolvedAt < nowMs - 180d`. Pruned entries are exactly that set, so `computeScorecard(prune(ledger)) === computeScorecard(ledger)` — asserted by a test.
- **No resurrection.** A prunable entry's forecast window is 180d+ old. The resolver's intake is `LRANGE 200` at hourly cadence (~8.3d, hard-capped at 45d by TTL) — far short of 180d — so a pruned window can never be re-ingested from a stale snapshot.
- **Receipt retry preserved.** Pruning requires `receiptArchivedAt`; `collectUnarchivedReceipts` selects the disjoint set. An entry whose R2 archival is broken is never pruned (we don't drop data we haven't durably persisted).
- Existing "idempotent rerun byte-identical" invariant still holds (those fixtures are never archived → prune is a no-op).

## Scope boundaries (deliberate follow-ups)

- **Pending-judge accumulation** — judged specs never terminate until a judge resolver ships (deferred in #5007); they are *not* pruned here (that would discard forecasts resolvable later). Tracked under #5066/#5007.
- **Raw resolution-ledger MCP tool** — the issue's "here too" item; a separate user-facing surface, out of scope for this retention fix.

## Validation

- `node --test tests/forecast-resolutions-seeder.test.mjs` (18/18, incl. 8 new: prune predicate matrix, no-mutation, custom window, scorecard-invariance, prior-cycle prune, this-cycle retention, retention-window guard)
- `node --test tests/forecast-scorecard.test.mjs tests/forecast-resolution-eval.test.mjs tests/forecast-health-registration.test.mjs` (23/23)
- `biome lint` + unicode safety on all touched files; pre-push gate (version sync) passed.

Related: #5024, #5007, #4930, #5066.