### PR TITLE
fix(seeders): don't crash a bundle when a member fails gracefully (#5077)

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -235,7 +235,7 @@ export async function runBundle(label, sections, opts = {}) {
   const budgetLabel = Number.isFinite(maxBundleMs) ? `, budget ${Math.round(maxBundleMs / 1000)}s` : '';
   console.log(`[Bundle:${label}] Starting (${sections.length} sections${budgetLabel})`);
 
-  let ran = 0, skipped = 0, deferred = 0, failed = 0;
+  let ran = 0, skipped = 0, deferred = 0, failed = 0, gracefulFailed = 0;
 
   for (const section of sections) {
     const scriptPath = join(__dirname, section.script);
@@ -293,11 +293,23 @@ export async function runBundle(label, sections, opts = {}) {
       // signal-escalation ordering.
       const status = result.status || 'FAILED';
       console.error(`[Bundle:${label}] section=${section.label} status=${status} elapsed=${result.elapsed}s reason=${(result.reason || 'unknown').replace(/\s+/g, ' ')}`);
-      failed++;
+      // A GRACEFUL_FAIL (child exit 75) extended the last-good TTL and lost no
+      // data — a transient upstream blip (e.g. a rate-limited source). Counting
+      // it as a hard failure would crash the whole bundle (exit 1 → Railway
+      // "Deploy Crashed!") over a benign per-member skip. Track it separately so
+      // only HARD failures gate the exit code; the skip stays fully logged above.
+      if (status === 'GRACEFUL_FAIL') gracefulFailed++;
+      else failed++;
     }
   }
 
   const totalSec = ((Date.now() - t0) / 1000).toFixed(1);
-  console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred} failed:${failed}`);
+  console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred} failed:${failed} graceful:${gracefulFailed}`);
+  // Graceful-only run (transient skips, no hard failures): exit 0 so Railway
+  // does not paint CRASHED and fire a spurious alert. Real staleness is caught
+  // independently by the /api/health freshness monitor keyed on seed-meta TTL.
+  if (failed === 0 && gracefulFailed > 0) {
+    console.log(`[Bundle:${label}] ${gracefulFailed} graceful fetch skip(s), no hard failures — no data lost, exiting 0 (not a crash)`);
+  }
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -147,7 +147,7 @@ test('non-zero exit without timeout reports exit code', async () => {
   }
 });
 
-test('graceful fetch failure exit reports a distinct non-OK bundle status', async () => {
+test('graceful-only fetch failure exits 0 (no data lost) but still logs the skip', async () => {
   const cleanup = writeFixture(
     '_bundle-fixture-graceful-fail.mjs',
     `console.error('FETCH FAILED: upstream unavailable');\nconsole.log('=== Failed gracefully (42ms) ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
@@ -157,14 +157,67 @@ test('graceful fetch failure exit reports a distinct non-OK bundle status', asyn
       { label: 'GRACEFUL', script: '_bundle-fixture-graceful-fail.mjs', intervalMs: 1, timeoutMs: 5000 },
     ]);
     const combined = stdout + stderr;
-    assert.equal(code, 1, 'graceful fetch failure must make the bundle non-zero');
+    // A child exit 75 is a *graceful* fetch failure: the last-good TTL is
+    // extended and no data is lost. It must NOT crash the whole bundle — one
+    // flaky member (e.g. a rate-limited source returning 429) otherwise fires a
+    // spurious Railway "Deploy Crashed!" alert for a benign skip. Only HARD
+    // failures (real errors / timeouts / non-75 exits) make the bundle exit 1.
+    assert.equal(code, 0, 'graceful-only fetch failure must exit 0 (benign skip, no data lost)');
+    // The skip stays fully observable — the per-section GRACEFUL_FAIL line and a
+    // bundle-level explanation are emitted, so it is silenced but never silent.
     assert.match(combined, /\[GRACEFUL\] FETCH FAILED: upstream unavailable/);
     assert.match(combined, new RegExp(`Failed after .*s: graceful fetch failure \\(exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE}\\)`));
     assert.match(combined, new RegExp(`\\[Bundle:test\\] section=GRACEFUL status=GRACEFUL_FAIL .*reason=graceful fetch failure \\(exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE}\\)`));
-    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:1/);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:0 graceful:1/);
+    assert.match(stdout, /\[Bundle:test\] 1 graceful fetch skip\(s\), no hard failures — no data lost, exiting 0/);
     assert.doesNotMatch(combined, /\[Bundle:test\] section=GRACEFUL status=OK/);
   } finally {
     cleanup();
+  }
+});
+
+test('a hard failure alongside a graceful skip still exits 1 (graceful never masks a real crash)', async () => {
+  const cleanupG = writeFixture(
+    '_bundle-fixture-graceful-mixed.mjs',
+    `console.log('=== Failed gracefully ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
+  );
+  const cleanupH = writeFixture(
+    '_bundle-fixture-hard-mixed.mjs',
+    `console.error('boom');\nprocess.exit(2);\n`,
+  );
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'GRACE', script: '_bundle-fixture-graceful-mixed.mjs', intervalMs: 1, timeoutMs: 5000 },
+      { label: 'HARD', script: '_bundle-fixture-hard-mixed.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 1, 'a hard failure must still crash the bundle even when another member skipped gracefully');
+    assert.match(stdout, /\[Bundle:test\] Finished .* failed:1 graceful:1/);
+    assert.doesNotMatch(stdout, /no data lost, exiting 0/);
+  } finally {
+    cleanupG();
+    cleanupH();
+  }
+});
+
+test('a graceful skip alongside a successful member exits 0', async () => {
+  const cleanupG = writeFixture(
+    '_bundle-fixture-graceful-ok.mjs',
+    `console.log('=== Failed gracefully ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
+  );
+  const cleanupOk = writeFixture(
+    '_bundle-fixture-ok-mem.mjs',
+    `console.log('did work');\n`,
+  );
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'OKMEM', script: '_bundle-fixture-ok-mem.mjs', intervalMs: 1, timeoutMs: 5000 },
+      { label: 'GRACE', script: '_bundle-fixture-graceful-ok.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 0, 'graceful skip must not crash a bundle that otherwise did work');
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:1 skipped:0 deferred:0 failed:0 graceful:1/);
+  } finally {
+    cleanupG();
+    cleanupOk();
   }
 });
 


### PR DESCRIPTION
## Problem
`scripts/_bundle-runner.mjs` (shared by **all 16 `seed-bundle-*` cron services**) counted a member's **graceful** fetch failure — child exit `75`, last-good TTL extended, **no data lost** — in the same `failed` counter as a hard crash, then `process.exit(failed > 0 ? 1 : 0)`. So one transient per-member blip crashed the whole bundle → Railway **"Deploy Crashed!"** email + wasted compute.

**Observed (2026-07-09):** `seed-bundle-market-backup` deploy `24b0b8b1` (04:26 UTC) — Hyperliquid-Flow hit a transient 429 while the other 7 members were fresh/skipped:
```
[Bundle:market-backup] section=Hyperliquid-Flow status=GRACEFUL_FAIL reason=graceful fetch failure (exit 75)
[Bundle:market-backup] Finished in 8.0s, ran:0 skipped:7 deferred:0 failed:1
```
→ exit 1 → crash email, for a benign skip that lost nothing.

## Fix (policy: silence benign — exit 0)
Track graceful failures in a separate counter; only **hard** failures gate the exit code:
- hard failure (real error / timeout / non-75 exit) → **exit 1** (a real crash — still alerts)
- graceful-only, no hard failures → **exit 0** (Railway SUCCESS, no email)

The skip is never silent — it still logs `status=GRACEFUL_FAIL` plus a bundle-level `N graceful fetch skip(s) … no data lost, exiting 0 (not a crash)` line, and the summary gains a `graceful:N` field.

**Safety net:** real staleness is still caught independently by the `/api/health` freshness monitor keyed on seed-meta TTL — the exit code only answers "does a human need to act right now," and a transient 429 doesn't.

## Tests (failing-first, per Bug Fix Protocol)
`tests/bundle-runner.test.mjs`:
- graceful-only → exit 0 (was 1) — still logs the skip
- graceful + successful member → exit 0
- graceful + **hard** failure → exit 1 (graceful never masks a real crash)

Confirmed red against the old code, green after. Sibling bundle suites (resilience-recovery / validation / empty-data-is-failure / sigterm-cleanup: 31 tests) still pass.

Fixes #5077.

https://claude.ai/code/session_011u6t4bQjMMNtTAWbfAxoR5