### PR TITLE
fix(api): cool down Finnhub symbol-search 429s

### DIFF
--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -74,6 +74,7 @@ interface FinnhubRateLimitCooldown {
   reason: 'finnhub_rate_limit';
   finnhubStatus: 429;
   retryAfterSeconds: number;
+  expiresAt: number;
 }
 
 function normalizeRetryAfterSeconds(value: number): number {
@@ -106,8 +107,17 @@ function isFinnhubRateLimitCooldown(value: unknown): value is FinnhubRateLimitCo
     maybe.finnhubStatus === 429 &&
     typeof maybe.retryAfterSeconds === 'number' &&
     Number.isFinite(maybe.retryAfterSeconds) &&
-    maybe.retryAfterSeconds > 0
+    maybe.retryAfterSeconds > 0 &&
+    typeof maybe.expiresAt === 'number' &&
+    Number.isFinite(maybe.expiresAt) &&
+    maybe.expiresAt > 0
   );
+}
+
+function getFinnhubCooldownRetryAfterSeconds(cooldown: FinnhubRateLimitCooldown): number | null {
+  const remainingSeconds = (cooldown.expiresAt - Date.now()) / 1000;
+  if (!Number.isFinite(remainingSeconds) || remainingSeconds <= 0) return null;
+  return normalizeRetryAfterSeconds(remainingSeconds);
 }
 
 function symbolSearchUnavailableResponse(
@@ -201,7 +211,10 @@ export default async function handler(
   try {
     const cooldown = await readRawJsonFromUpstash(FINNHUB_429_COOLDOWN_KEY);
     if (isFinnhubRateLimitCooldown(cooldown)) {
-      return symbolSearchUnavailableResponse(cors, cooldown.retryAfterSeconds);
+      const retryAfterSeconds = getFinnhubCooldownRetryAfterSeconds(cooldown);
+      if (retryAfterSeconds) {
+        return symbolSearchUnavailableResponse(cors, retryAfterSeconds);
+      }
     }
   } catch {
     // Cache infrastructure is best-effort; fall through to the real upstream.
@@ -267,7 +280,12 @@ export default async function handler(
           reason: 'finnhub_rate_limit',
           finnhubStatus: 429,
           retryAfterSeconds,
+          expiresAt: Date.now() + retryAfterSeconds * 1000,
         };
+        // The Redis write is async and distributed, so a sudden burst of cold
+        // requests can still produce multiple first-429 captures before the
+        // cooldown key propagates. Once present, it suppresses sequential
+        // duplicate Finnhub calls and Sentry captures for the remaining window.
         const writePromise = setCachedData(FINNHUB_429_COOLDOWN_KEY, cooldown, retryAfterSeconds).catch(() => false);
         if (ctx) ctx.waitUntil(writePromise);
         else void writePromise;

--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -51,6 +51,9 @@ const UPSTREAM_TIMEOUT_MS = 8_000;
 // can't repeatedly hammer Finnhub.
 const CACHE_KEY_PREFIX = 'symsearch:v1:';
 const CACHE_TTL_SECONDS = 600;
+const FINNHUB_429_COOLDOWN_KEY = 'symsearch-cooldown:v1:finnhub-429';
+const FINNHUB_429_DEFAULT_RETRY_AFTER_SECONDS = 60;
+const FINNHUB_429_MAX_RETRY_AFTER_SECONDS = 120;
 // Honest UA identifying ourselves to Finnhub. The AGENTS.md Critical
 // Conventions section requires UA on server-side fetches; matches the
 // `worldmonitor-edge/1.0` convention used by api/notify.ts and
@@ -65,6 +68,57 @@ const FETCH_USER_AGENT = 'worldmonitor-edge/1.0';
 const ALLOWED_TYPES = new Set([
   'Common Stock', 'ADR', 'GDR', 'ETP', 'ETF', 'REIT', 'Unit', 'Equity', '',
 ]);
+
+interface FinnhubRateLimitCooldown {
+  error: 'SYMBOL_SEARCH_UNAVAILABLE';
+  reason: 'finnhub_rate_limit';
+  finnhubStatus: 429;
+  retryAfterSeconds: number;
+}
+
+function normalizeRetryAfterSeconds(value: number): number {
+  return Math.max(1, Math.min(FINNHUB_429_MAX_RETRY_AFTER_SECONDS, Math.ceil(value)));
+}
+
+function parseRetryAfterSeconds(value: string | null): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric)) return normalizeRetryAfterSeconds(numeric);
+
+  const timestamp = Date.parse(trimmed);
+  if (Number.isFinite(timestamp)) return normalizeRetryAfterSeconds((timestamp - Date.now()) / 1000);
+
+  return null;
+}
+
+function getFinnhub429RetryAfterSeconds(resp: Response): number {
+  return parseRetryAfterSeconds(resp.headers.get('Retry-After')) ?? FINNHUB_429_DEFAULT_RETRY_AFTER_SECONDS;
+}
+
+function isFinnhubRateLimitCooldown(value: unknown): value is FinnhubRateLimitCooldown {
+  if (!value || typeof value !== 'object') return false;
+  const maybe = value as Partial<FinnhubRateLimitCooldown>;
+  return (
+    maybe.error === 'SYMBOL_SEARCH_UNAVAILABLE' &&
+    maybe.reason === 'finnhub_rate_limit' &&
+    maybe.finnhubStatus === 429 &&
+    typeof maybe.retryAfterSeconds === 'number' &&
+    Number.isFinite(maybe.retryAfterSeconds) &&
+    maybe.retryAfterSeconds > 0
+  );
+}
+
+function symbolSearchUnavailableResponse(
+  cors: Record<string, string>,
+  retryAfterSeconds?: number,
+): Response {
+  const headers = retryAfterSeconds
+    ? { ...cors, 'Retry-After': String(normalizeRetryAfterSeconds(retryAfterSeconds)) }
+    : cors;
+  return jsonResponse({ error: 'SYMBOL_SEARCH_UNAVAILABLE' }, 503, headers);
+}
 
 /**
  * Map + filter raw Finnhub results to our shape. Exported for unit tests —
@@ -140,6 +194,19 @@ export default async function handler(
     // Treat Upstash unavailability as a cache miss; do not 5xx the user.
   }
 
+  // Finnhub's 429 quota is per shared API key. Once one real upstream 429 has
+  // been observed and captured, cold searches briefly fail fast instead of
+  // multiplying both user-facing latency and the upstream quota outage. Cached
+  // successful query results above still serve during this cooldown.
+  try {
+    const cooldown = await readRawJsonFromUpstash(FINNHUB_429_COOLDOWN_KEY);
+    if (isFinnhubRateLimitCooldown(cooldown)) {
+      return symbolSearchUnavailableResponse(cors, cooldown.retryAfterSeconds);
+    }
+  } catch {
+    // Cache infrastructure is best-effort; fall through to the real upstream.
+  }
+
   try {
     const url = `https://finnhub.io/api/v1/search?q=${encodeURIComponent(q)}&token=${encodeURIComponent(apiKey)}`;
     const resp = await fetch(url, {
@@ -174,6 +241,7 @@ export default async function handler(
       // 429 from Finnhub = quota exhausted; surface as 503 so the client
       // backs off rather than treating it as a permanent failure.
       const status = resp.status === 429 ? 503 : 502;
+      const retryAfterSeconds = resp.status === 429 ? getFinnhub429RetryAfterSeconds(resp) : undefined;
       console.warn(`[symbol-search] Finnhub HTTP ${resp.status} for q="${q}"`);
       // Upstream gateway transients (502/503/504) are Finnhub-side infra blips —
       // not our bug, not our quota, not our auth. Like the 422 skip above, the
@@ -188,10 +256,22 @@ export default async function handler(
       if (!isUpstreamGatewayTransient) {
         captureSilentError(new Error(`Finnhub search HTTP ${resp.status}`), {
           tags: { route: 'api/symbol-search', step: 'finnhub_fetch' },
-          extra: { q, finnhubStatus: resp.status },
+          extra: { q, finnhubStatus: resp.status, ...(retryAfterSeconds ? { retryAfterSeconds } : {}) },
           level: 'warning',
           ctx,
         });
+      }
+      if (resp.status === 429 && retryAfterSeconds) {
+        const cooldown: FinnhubRateLimitCooldown = {
+          error: 'SYMBOL_SEARCH_UNAVAILABLE',
+          reason: 'finnhub_rate_limit',
+          finnhubStatus: 429,
+          retryAfterSeconds,
+        };
+        const writePromise = setCachedData(FINNHUB_429_COOLDOWN_KEY, cooldown, retryAfterSeconds).catch(() => false);
+        if (ctx) ctx.waitUntil(writePromise);
+        else void writePromise;
+        return symbolSearchUnavailableResponse(cors, retryAfterSeconds);
       }
       return jsonResponse({ error: 'SYMBOL_SEARCH_UNAVAILABLE' }, status, cors);
     }

--- a/tests/symbol-search.test.mts
+++ b/tests/symbol-search.test.mts
@@ -123,6 +123,81 @@ describe('symbol-search handler', () => {
     assert.equal(res.status, 503);
   });
 
+  it('writes a short shared cooldown when Finnhub returns 429', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-tok';
+
+    let finnhubCalls = 0;
+    let cooldownSetBody: string | null = null;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith('https://upstash.test/get/symsearch')) {
+        return new Response(JSON.stringify({ result: null }), { status: 200 });
+      }
+      if (url === 'https://upstash.test/pipeline' && typeof init?.body === 'string' && init.body.includes('symsearch-cooldown:v1:finnhub-429')) {
+        cooldownSetBody = init.body;
+        return new Response(JSON.stringify([{ result: 'OK' }]), { status: 200 });
+      }
+      if (url.includes('finnhub.io')) {
+        finnhubCalls++;
+        return new Response('rate limited', { status: 429, headers: { 'Retry-After': '17' } });
+      }
+      if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const writePromises: Array<Promise<unknown>> = [];
+    const res = await handler(makeReq('nvidia'), { waitUntil: (p) => writePromises.push(p) });
+    await Promise.all(writePromises);
+
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('Retry-After'), '17');
+    assert.equal(finnhubCalls, 1, 'first real 429 must still hit Finnhub once');
+    assert.match(cooldownSetBody ?? '', /"SET","symsearch-cooldown:v1:finnhub-429"/);
+    assert.match(cooldownSetBody ?? '', /"EX","17"/);
+  });
+
+  it('honors a cached Finnhub 429 cooldown without calling Finnhub again', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-tok';
+
+    let finnhubCalls = 0;
+    const cooldown = {
+      error: 'SYMBOL_SEARCH_UNAVAILABLE',
+      reason: 'finnhub_rate_limit',
+      finnhubStatus: 429,
+      retryAfterSeconds: 42,
+    };
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith('https://upstash.test/get/')) {
+        const key = decodeURIComponent(url.slice('https://upstash.test/get/'.length));
+        if (key === 'symsearch-cooldown:v1:finnhub-429') {
+          return new Response(JSON.stringify({ result: JSON.stringify(cooldown) }), { status: 200 });
+        }
+        if (key === 'symsearch:v1:nvidia') {
+          return new Response(JSON.stringify({ result: null }), { status: 200 });
+        }
+      }
+      if (url.includes('finnhub.io')) {
+        finnhubCalls++;
+        return new Response('should not be called', { status: 500 });
+      }
+      if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const res = await handler(makeReq('nvidia'));
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('Retry-After'), '42');
+    assert.deepEqual(await res.json(), { error: 'SYMBOL_SEARCH_UNAVAILABLE' });
+    assert.equal(finnhubCalls, 0, 'cooldown hit must not spend more Finnhub quota');
+  });
+
   it('returns 500 when the upstream fetch throws', async () => {
     process.env.FINNHUB_API_KEY = 'test-key';
     globalThis.fetch = (async () => { throw new Error('network down'); }) as typeof fetch;
@@ -195,7 +270,8 @@ describe('symbol-search handler', () => {
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.startsWith('https://upstash.test/get/symsearch')) {
-        getKey = decodeURIComponent(url.slice('https://upstash.test/get/'.length));
+        const key = decodeURIComponent(url.slice('https://upstash.test/get/'.length));
+        if (key !== 'symsearch-cooldown:v1:finnhub-429') getKey = key;
         return new Response(JSON.stringify({ result: null }), { status: 200 }); // miss
       }
       // setCachedData posts a SET-bearing pipeline; identify it by body

--- a/tests/symbol-search.test.mts
+++ b/tests/symbol-search.test.mts
@@ -4,6 +4,7 @@ import { afterEach, describe, it } from 'node:test';
 import handler, { mapFinnhubResults } from '../api/symbol-search.ts';
 
 const originalFetch = globalThis.fetch;
+const originalDateNow = Date.now;
 
 // validateApiKey() rejects credential-less requests (production browsers send
 // an anonymous session token via the wm-session fetch wrapper). The enterprise
@@ -14,6 +15,7 @@ process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  Date.now = originalDateNow;
   delete process.env.FINNHUB_API_KEY;
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -157,12 +159,19 @@ describe('symbol-search handler', () => {
     assert.equal(finnhubCalls, 1, 'first real 429 must still hit Finnhub once');
     assert.match(cooldownSetBody ?? '', /"SET","symsearch-cooldown:v1:finnhub-429"/);
     assert.match(cooldownSetBody ?? '', /"EX","17"/);
+    const commands = JSON.parse(cooldownSetBody ?? '[]') as string[][];
+    const cooldownValue = JSON.parse(commands[0]?.[2] ?? '{}') as { retryAfterSeconds?: number; expiresAt?: number };
+    assert.equal(cooldownValue.retryAfterSeconds, 17);
+    assert.equal(typeof cooldownValue.expiresAt, 'number');
   });
 
-  it('honors a cached Finnhub 429 cooldown without calling Finnhub again', async () => {
+  it('honors a cached Finnhub 429 cooldown with remaining Retry-After seconds', async () => {
     process.env.FINNHUB_API_KEY = 'test-key';
     process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-tok';
+
+    const now = 1_700_000_000_000;
+    Date.now = () => now;
 
     let finnhubCalls = 0;
     const cooldown = {
@@ -170,6 +179,7 @@ describe('symbol-search handler', () => {
       reason: 'finnhub_rate_limit',
       finnhubStatus: 429,
       retryAfterSeconds: 42,
+      expiresAt: now + 12_100,
     };
 
     globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -193,7 +203,7 @@ describe('symbol-search handler', () => {
 
     const res = await handler(makeReq('nvidia'));
     assert.equal(res.status, 503);
-    assert.equal(res.headers.get('Retry-After'), '42');
+    assert.equal(res.headers.get('Retry-After'), '13');
     assert.deepEqual(await res.json(), { error: 'SYMBOL_SEARCH_UNAVAILABLE' });
     assert.equal(finnhubCalls, 0, 'cooldown hit must not spend more Finnhub quota');
   });


### PR DESCRIPTION
## Summary

When Finnhub exhausts the shared symbol-search quota, cold watchlist searches now fail fast during a short shared cooldown instead of repeatedly hitting Finnhub and producing duplicate warning captures. The first real 429 still returns an explicit `503` with `Retry-After` and reaches Sentry, while cached successful query results continue to serve before the cooldown check.

## Related

Related: WORLDMONITOR-RE

## Validation

- `./node_modules/.bin/tsx --test tests/symbol-search.test.mts tests/symbol-search-sentry-capture.test.mts`
- `npm run typecheck:api`
- Pre-push hook: `npm run typecheck`, `npm run typecheck:api`, Convex typecheck, CJS syntax check, Unicode safety, boundary/safe-html/Sentry/rate-limit/premium-fetch lints, edge bundle check, changed tests, edge function tests, and version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
