### PR TITLE
fix(relay): stop double-TLS wrapping OpenSky proxy fetches (#5074)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -8302,7 +8302,12 @@ function _attemptOpenSkyTokenFetch(clientId, clientSecret) {
     return _openskyProxyConnect('auth.opensky-network.org', 443).then((tlsSocket) => {
       return new Promise((resolve) => {
         const req = https.request({
-          socket: tlsSocket,
+          // tlsSocket is ALREADY a TLS connection to the target — proxyConnectTunnel
+          // does tls.connect() through the CONNECT tunnel. Reuse it via
+          // createConnection (NOT `socket:`): `socket:` makes https.request wrap it
+          // in a SECOND TLS layer → EPROTO "wrong version number" (double-TLS),
+          // which fails every OpenSky auth attempt. Mirrors proxyFetch(). See #5074.
+          createConnection: () => tlsSocket,
           hostname: 'auth.opensky-network.org',
           path: '/auth/realms/opensky-network/protocol/openid-connect/token',
           method: 'POST',
@@ -8434,7 +8439,10 @@ function _openskyRawFetch(url, token) {
     return _openskyProxyConnect(parsed.hostname, 443, 15000).then((tlsSocket) => {
       return new Promise((resolve) => {
         const request = https.get({
-          socket: tlsSocket,
+          // Reuse the already-TLS tunnel socket via createConnection, not `socket:`
+          // — passing an already-TLS socket as `socket:` double-wraps TLS and throws
+          // EPROTO "wrong version number", failing every OpenSky states fetch. See #5074.
+          createConnection: () => tlsSocket,
           hostname: parsed.hostname,
           path: parsed.pathname + parsed.search,
           headers: reqHeaders,

--- a/tests/ais-relay-opensky-proxy-tls.test.mjs
+++ b/tests/ais-relay-opensky-proxy-tls.test.mjs
@@ -1,0 +1,42 @@
+// Regression guard for #5074 — OpenSky OAuth/data fetch through the residential
+// proxy must reuse the tunnel's already-TLS socket via `createConnection`, NOT `socket:`.
+//
+// proxyConnectTunnel() (scripts/_proxy-utils.cjs) returns a socket that is ALREADY
+// tls.connect()-wrapped to the target (opensky) over the CONNECT tunnel. Passing it
+// to https.request/https.get as `socket: tlsSocket` makes the https layer wrap it in
+// a SECOND TLS handshake → the inner encrypted response is read as a TLS handshake
+// record → EPROTO "tls_validate_record_header: wrong version number". The whole
+// OpenSky flight path (auth token + states fetch) then fails every tick (opensky=0).
+//
+// The working sibling proxyFetch() in _proxy-utils.cjs consumes the same tunnel with
+// `createConnection: () => tlsSocket`, which reuses the socket as-is (no double wrap).
+// This test locks the two OpenSky proxy call sites onto that correct pattern.
+//
+// The double-TLS mechanism itself is proven separately (a self-contained repro:
+// https.request({socket: alreadyTlsSocket}) → EPROTO; {createConnection:()=>sock} → 200).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync(new URL('../scripts/ais-relay.cjs', import.meta.url), 'utf8');
+
+test('OpenSky proxy fetches never pass an already-TLS tunnel socket via `socket:` (double-TLS → EPROTO #5074)', () => {
+  const antipattern = SRC.match(/socket:\s*tlsSocket/g) || [];
+  assert.equal(
+    antipattern.length,
+    0,
+    `Found ${antipattern.length} "socket: tlsSocket" occurrence(s). proxyConnectTunnel returns an ` +
+    `already-TLS socket; passing it as \`socket:\` to https.request double-wraps TLS and throws ` +
+    `EPROTO "wrong version number". Use \`createConnection: () => tlsSocket\` instead (see proxyFetch).`,
+  );
+});
+
+test('both OpenSky proxy fetches (token + data) reuse the tunnel socket via createConnection', () => {
+  const good = SRC.match(/createConnection:\s*\(\)\s*=>\s*tlsSocket/g) || [];
+  // One for _attemptOpenSkyTokenFetch (OAuth token), one for _openskyRawFetch (states data).
+  assert.ok(
+    good.length >= 2,
+    `Expected >= 2 "createConnection: () => tlsSocket" call sites (OpenSky token + data fetch); found ${good.length}.`,
+  );
+});


### PR DESCRIPTION
## Root cause
OpenSky auth + states fetch in `scripts/ais-relay.cjs` route through a residential CONNECT proxy (to dodge Railway IP blocks). `proxyConnectTunnel()` (`_proxy-utils.cjs:146`) returns a socket that is **already `tls.connect()`-wrapped to the target** over the tunnel. Both OpenSky call sites fed that socket into `https.request` / `https.get` as **`socket: tlsSocket`** — which makes the https layer initiate a **second** TLS handshake on top of it. The inner (already-encrypted) response is then parsed as a TLS handshake record:

```
[Relay] OpenSky auth attempt 1 failed: EPROTO: write EPROTO ...
  SSL routines:tls_validate_record_header:wrong version number
[Relay] OpenSky auth failed after 3 attempts, cooling down for 60s
... cache: opensky=0 ...
```

So the relay never acquires a token and every OpenSky tick is dead.

The working sibling `proxyFetch()` in the same file consumes the identical tunnel correctly with **`createConnection: () => tlsSocket`** — which reuses the socket as-is, no double wrap.

## Fix
Both OpenSky proxy sites (OAuth token fetch + states data fetch) now use `createConnection: () => tlsSocket` instead of `socket: tlsSocket`. One-mechanism change, matching the proven `proxyFetch` path.

## Reproduction (self-contained, Bug Fix Protocol)
A local HTTPS server + a pre-established `tls.connect` socket (simulating the tunnel's target-TLS socket):
```
https.request({ socket: alreadyTlsSocket })          → EPROTO (SSL routines, bad TLS record)  [BROKEN]
https.request({ createConnection: () => sock })      → 200 OK                                  [FIXED]
```
Same OpenSSL EPROTO family as production (`wrong version number`); the exact sub-message varies by cert/ciphersuite — both are "these bytes aren't a valid TLS record," the double-wrap signature.

## Tests
`tests/ais-relay-opensky-proxy-tls.test.mjs` — a source guard (fails on the current code, green after) that (a) asserts the `socket: tlsSocket` anti-pattern is absent and (b) both OpenSky sites use `createConnection`. `ais-relay.cjs` is a non-exported 11k-line monolith, so the guard + the repro are the durable regression coverage. Existing `ais-relay-rss` suite (7 tests) still passes.

## Post-deploy validation (needs a relay redeploy)
Once merged + deployed, confirm `[Relay] OpenSky token acquired, expires in …` appears and `opensky=N` (N>0) in the monitor line. If a clean `401`/`503` shows up *instead* of EPROTO, that's a separate credential/proxy-health issue — but the TLS blocker is gone.

Fixes #5074.

https://claude.ai/code/session_011u6t4bQjMMNtTAWbfAxoR5