### PR TITLE
fix(forecast): use ACLED resolution feeds for hard counts

### DIFF
--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -13,7 +13,7 @@
 // metricKey format: '<feedKey>|<fn>(<field>==<value>)' — a path expression
 // over the shape read from that feed, with REAL substituted values (region,
 // title, ticker) and a unified '==' comparison grammar across every family,
-// e.g. 'conflict:acled:v1:all:0:0|count(country==Mali)' or
+// e.g. 'conflict:acled-resolution:v1:all:0:0|count(country==Mali)' or
 // 'market:commodities-bootstrap:v1|price(symbol==CL=F)'. It documents where in
 // the feed the metric lives and what to match; it is not executable code and
 // is not parsed by this module or any consumer today (Bet 2's resolver
@@ -41,8 +41,8 @@ export const HORIZON_MS = {
   '30d': 30 * DAY_MS,
 };
 
-export const CONFLICT_COUNT_SOURCE_FEED = 'conflict:acled:v1:all:0:0';
-export const UNREST_COUNT_SOURCE_FEED = 'unrest:events:v1';
+export const CONFLICT_COUNT_SOURCE_FEED = 'conflict:acled-resolution:v1:all:0:0';
+export const UNREST_COUNT_SOURCE_FEED = 'unrest:events-resolution:v1';
 export const CYBER_COUNT_SOURCE_FEED = 'cyber:threats-bootstrap:v2';
 
 // Never returns null and never silently coerces an unrecognized horizon to a

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -20,8 +20,16 @@ import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, loadShar
 
 loadEnvFile(import.meta.url);
 
+const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
 const ACLED_CACHE_KEY = 'conflict:acled:v1:all:0:0';
+const ACLED_RESOLUTION_CACHE_KEY = 'conflict:acled-resolution:v1:all:0:0';
 const ACLED_TTL = 900;
+const ACLED_DISPLAY_LOOKBACK_DAYS = 30;
+const ACLED_DISPLAY_LIMIT = 500;
+const ACLED_RESOLUTION_LOOKBACK_DAYS = 60;
+const ACLED_RESOLUTION_PAGE_LIMIT = 5000;
+const ACLED_RESOLUTION_MAX_PAGES = 20;
+const ACLED_PAGE_DELAY_MS = 250;
 const HAPI_CACHE_KEY_PREFIX = 'conflict:humanitarian:v1';
 const HAPI_TTL = 21600;
 const PIZZINT_TTL = 600;
@@ -62,35 +70,44 @@ async function fetchAcledToken() {
   return null;
 }
 
-async function fetchAcledEvents() {
-  const token = await fetchAcledToken();
-  if (!token) {
-    console.log('  ACLED: no credentials configured, skipping');
-    return null;
-  }
+let acledTokenPromise;
+function getAcledTokenOnce() {
+  if (!acledTokenPromise) acledTokenPromise = fetchAcledToken();
+  return acledTokenPromise;
+}
 
-  const now = Date.now();
-  const startDate = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-  const endDate = new Date(now).toISOString().split('T')[0];
+function acledDateRange(now, lookbackDays) {
+  return {
+    startDate: new Date(now - lookbackDays * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+    endDate: new Date(now).toISOString().split('T')[0],
+  };
+}
 
+function buildAcledParams({ startDate, endDate, limit, page }) {
   const params = new URLSearchParams({
     event_type: 'Battles|Explosions/Remote violence|Violence against civilians',
     event_date: `${startDate}|${endDate}`,
     event_date_where: 'BETWEEN',
-    limit: '500',
+    limit: String(limit),
     _format: 'json',
   });
+  if (page) params.set('page', String(page));
+  return params;
+}
 
-  const resp = await fetch(`https://acleddata.com/api/acled/read?${params}`, {
+async function fetchAcledPage(token, params) {
+  const resp = await fetch(`${ACLED_API_URL}?${params}`, {
     headers: { Accept: 'application/json', Authorization: `Bearer ${token}`, 'User-Agent': CHROME_UA },
     signal: AbortSignal.timeout(15_000),
   });
   if (!resp.ok) throw new Error(`ACLED HTTP ${resp.status}`);
   const data = await resp.json();
   if (data.error || data.message) throw new Error(data.error || data.message);
+  return Array.isArray(data.data) ? data.data : [];
+}
 
-  const rawEvents = data.data || [];
-  const events = rawEvents
+function normalizeAcledConflictEvents(rawEvents) {
+  return rawEvents
     .filter(e => {
       const lat = parseFloat(e.latitude || '');
       const lon = parseFloat(e.longitude || '');
@@ -107,9 +124,56 @@ async function fetchAcledEvents() {
       source: e.source || '',
       admin1: e.admin1 || '',
     }));
+}
 
-  console.log(`  ACLED: ${events.length} events (${startDate} to ${endDate})`);
-  return { events, pagination: undefined };
+async function fetchAcledEvents({
+  lookbackDays = ACLED_DISPLAY_LOOKBACK_DAYS,
+  limit = ACLED_DISPLAY_LIMIT,
+  paginated = false,
+  maxPages = 1,
+  label = 'ACLED',
+} = {}) {
+  const token = await getAcledTokenOnce();
+  if (!token) {
+    console.log(`  ${label}: no credentials configured, skipping`);
+    return null;
+  }
+
+  const now = Date.now();
+  const { startDate, endDate } = acledDateRange(now, lookbackDays);
+  const rawEvents = [];
+  const seen = new Set();
+  let pagesFetched = 0;
+  let lastPageCount = 0;
+  const pageLimit = paginated ? Math.max(1, maxPages) : 1;
+
+  for (let page = 1; page <= pageLimit; page += 1) {
+    const params = buildAcledParams({
+      startDate,
+      endDate,
+      limit,
+      page: paginated ? page : undefined,
+    });
+    const pageEvents = await fetchAcledPage(token, params);
+    pagesFetched = page;
+    lastPageCount = pageEvents.length;
+    const before = rawEvents.length;
+    for (const event of pageEvents) {
+      const id = event.event_id_cnty || `${event.event_date}:${event.country}:${event.latitude}:${event.longitude}:${event.notes || event.source || ''}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      rawEvents.push(event);
+    }
+    if (!paginated || pageEvents.length < limit || rawEvents.length === before) break;
+    await sleep(ACLED_PAGE_DELAY_MS);
+  }
+
+  const events = normalizeAcledConflictEvents(rawEvents);
+  const pagination = paginated
+    ? { lookbackDays, limit, pagesFetched, maxPages, truncated: pagesFetched >= maxPages && lastPageCount >= limit }
+    : undefined;
+  console.log(`  ${label}: ${events.length} events (${startDate} to ${endDate}${paginated ? `, ${pagesFetched} page(s)` : ''})`);
+  return { events, pagination };
 }
 
 // ─── Humanitarian Summary (HAPI) ───
@@ -245,19 +309,28 @@ async function fetchGdeltTensions() {
 // ─── Main ───
 
 async function fetchAll() {
-  const [acled, hapi, pizzint, gdelt] = await Promise.allSettled([
-    fetchAcledEvents(),
+  const [acled, acledResolution, hapi, pizzint, gdelt] = await Promise.allSettled([
+    fetchAcledEvents({ label: 'ACLED display' }),
+    fetchAcledEvents({
+      lookbackDays: ACLED_RESOLUTION_LOOKBACK_DAYS,
+      limit: ACLED_RESOLUTION_PAGE_LIMIT,
+      paginated: true,
+      maxPages: ACLED_RESOLUTION_MAX_PAGES,
+      label: 'ACLED resolution',
+    }),
     fetchAllHumanitarianSummaries(),
     fetchPizzintStatus(),
     fetchGdeltTensions(),
   ]);
 
   const ac = acled.status === 'fulfilled' ? acled.value : null;
+  const acResolution = acledResolution.status === 'fulfilled' ? acledResolution.value : null;
   const ha = hapi.status === 'fulfilled' ? hapi.value : null;
   const pi = pizzint.status === 'fulfilled' ? pizzint.value : null;
   const gd = gdelt.status === 'fulfilled' ? gdelt.value : null;
 
   if (acled.status === 'rejected') console.warn(`  ACLED failed: ${acled.reason?.message || acled.reason}`);
+  if (acledResolution.status === 'rejected') console.warn(`  ACLED resolution failed: ${acledResolution.reason?.message || acledResolution.reason}`);
   if (hapi.status === 'rejected') console.warn(`  HAPI failed: ${hapi.reason?.message || hapi.reason}`);
   if (pizzint.status === 'rejected') console.warn(`  PizzINT failed: ${pizzint.reason?.message || pizzint.reason}`);
   if (gdelt.status === 'rejected') console.warn(`  GDELT failed: ${gdelt.reason?.message || gdelt.reason}`);
@@ -266,6 +339,7 @@ async function fetchAll() {
 
   // Write secondary keys BEFORE returning (runSeed calls process.exit after primary write)
   if (ha) { for (const [cc, data] of Object.entries(ha)) await writeExtraKeyWithMeta(`${HAPI_CACHE_KEY_PREFIX}:${cc}`, data, HAPI_TTL, 1); }
+  if (acResolution?.events?.length) await writeExtraKeyWithMeta(ACLED_RESOLUTION_CACHE_KEY, acResolution, ACLED_TTL, acResolution.events.length);
   if (pi) await writeExtraKeyWithMeta('intel:pizzint:v1:base', { pizzint: pi, tensionPairs: [] }, PIZZINT_TTL, pi.locationsMonitored ?? 0);
   if (pi && gd) await writeExtraKeyWithMeta('intel:pizzint:v1:gdelt', { pizzint: pi, tensionPairs: gd }, PIZZINT_TTL, gd.length ?? 0);
 

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -339,7 +339,14 @@ async function fetchAll() {
 
   // Write secondary keys BEFORE returning (runSeed calls process.exit after primary write)
   if (ha) { for (const [cc, data] of Object.entries(ha)) await writeExtraKeyWithMeta(`${HAPI_CACHE_KEY_PREFIX}:${cc}`, data, HAPI_TTL, 1); }
-  if (acResolution?.events?.length) await writeExtraKeyWithMeta(ACLED_RESOLUTION_CACHE_KEY, acResolution, ACLED_TTL, acResolution.events.length);
+  if (acResolution?.events?.length) {
+    await writeExtraKeyWithMeta(
+      ACLED_RESOLUTION_CACHE_KEY,
+      { events: acResolution.events, clusters: [], pagination: acResolution.pagination },
+      ACLED_TTL,
+      acResolution.events.length,
+    );
+  }
   if (pi) await writeExtraKeyWithMeta('intel:pizzint:v1:base', { pizzint: pi, tensionPairs: [] }, PIZZINT_TTL, pi.locationsMonitored ?? 0);
   if (pi && gd) await writeExtraKeyWithMeta('intel:pizzint:v1:gdelt', { pizzint: pi, tensionPairs: gd }, PIZZINT_TTL, gd.length ?? 0);
 

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -123,6 +123,7 @@ export function ingestHistory(existingLedger, historySnapshots, nowMs = Date.now
     }
   }
 
+  migratePendingCountFeedKeys(ledger);
   return sortLedger(ledger);
 }
 

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -16,6 +16,7 @@ import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
 import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
+import { CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
 import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
 
 export const HISTORY_KEY = 'forecast:predictions:history:v1';
@@ -27,6 +28,10 @@ export const RESOLUTION_SOURCE_VERSION = 'forecast-resolution-engine-v1';
 export const RESOLUTION_SCHEMA_VERSION = 1;
 export const MAX_RECENT_SAMPLES = 40;
 const DAY_MS = 24 * 60 * 60 * 1000;
+const STALE_COUNT_FEED_REPLACEMENTS = new Map([
+  ['conflict:acled:v1:all:0:0', CONFLICT_COUNT_SOURCE_FEED],
+  ['unrest:events:v1', UNREST_COUNT_SOURCE_FEED],
+]);
 
 // Retention for the persistent working ledger (#5067). A resolved entry only
 // leaves the hot `forecast:resolutions:v1` value once it is (a) durably archived
@@ -88,6 +93,7 @@ function isPrunableTerminalEntry(entry, minResolvedAt) {
 
 export function ingestHistory(existingLedger, historySnapshots, nowMs = Date.now()) {
   const ledger = cloneJson(normalizeLedger(existingLedger));
+  migratePendingCountFeedKeys(ledger);
   const snapshots = [...(historySnapshots || [])]
     .filter(Boolean)
     .sort((a, b) => Number(a.generatedAt || 0) - Number(b.generatedAt || 0));
@@ -118,6 +124,19 @@ export function ingestHistory(existingLedger, historySnapshots, nowMs = Date.now
   }
 
   return sortLedger(ledger);
+}
+
+function migratePendingCountFeedKeys(ledger) {
+  for (const entry of Object.values(ledger)) {
+    if (entry?.status !== 'pending' || entry.spec?.kind !== 'hard') continue;
+    const replacement = STALE_COUNT_FEED_REPLACEMENTS.get(entry.spec.sourceFeed);
+    if (!replacement) continue;
+    const parsed = parseMetricKey(entry.spec.metricKey);
+    entry.spec.sourceFeed = replacement;
+    if (parsed?.feedKey && STALE_COUNT_FEED_REPLACEMENTS.get(parsed.feedKey) === replacement) {
+      entry.spec.metricKey = `${replacement}|${entry.spec.metricKey.slice(parsed.feedKey.length + 1)}`;
+    }
+  }
 }
 
 export function samplePendingEntries(ledger, feedsByKey, nowMs) {

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -1680,23 +1680,31 @@ function deriveStateDrivenForecasts({
     });
 }
 
+function isAcledUnrestCountEvent(event) {
+  const sourceType = String(event?.sourceType || event?.source_type || '').trim().toUpperCase();
+  if (!sourceType) return false;
+  return sourceType.replace(/^UNREST_SOURCE_TYPE_/, '') === 'ACLED';
+}
+
 function detectPoliticalScenarios(inputs) {
   const predictions = [];
   const scores = extractCiiScores(inputs);
   const anomalies = Array.isArray(inputs.temporalAnomalies) ? inputs.temporalAnomalies : inputs.temporalAnomalies?.anomalies || [];
   const unrestEvents = Array.isArray(inputs.unrestEvents) ? inputs.unrestEvents : inputs.unrestEvents?.events || [];
-  const unrestCounts = new Map();
+  const acledUnrestCounts = new Map();
 
   for (const event of unrestEvents) {
+    // Hard-count unrest specs resolve against the ACLED-only resolution feed.
+    if (!isAcledUnrestCountEvent(event)) continue;
     const country = resolveCountryName(event.country || event.country_name || event.region || event.location || '');
     if (!country) continue;
-    unrestCounts.set(country, (unrestCounts.get(country) || 0) + 1);
+    acledUnrestCounts.set(country, (acledUnrestCounts.get(country) || 0) + 1);
   }
 
   for (const c of scores) {
     if (!c.components) continue;
     const unrestComp = c.components.unrest ?? 0;
-    const unrestCount = unrestCounts.get(c.name) || 0;
+    const unrestCount = acledUnrestCounts.get(c.name) || 0;
     if (unrestComp <= 50 && unrestCount < 3) continue;
     if (c.score >= 80) continue;
 

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, httpsProxyFetchRaw, resolveProxyForConnect, describeErr } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, httpsProxyFetchRaw, resolveProxyForConnect, describeErr, writeExtraKeyWithMeta, sleep } from './_seed-utils.mjs';
 import { getAcledToken } from './shared/acled-oauth.mjs';
 
 loadEnvFile(import.meta.url);
@@ -8,7 +8,14 @@ loadEnvFile(import.meta.url);
 const GDELT_GKG_URL = 'https://api.gdeltproject.org/api/v1/gkg_geojson';
 const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
 const CANONICAL_KEY = 'unrest:events:v1';
+const UNREST_RESOLUTION_CACHE_KEY = 'unrest:events-resolution:v1';
 const CACHE_TTL = 16200; // 4.5h — 6x the 45 min cron interval (was 1.3x)
+const ACLED_DISPLAY_LOOKBACK_DAYS = 30;
+const ACLED_DISPLAY_LIMIT = 500;
+const UNREST_RESOLUTION_LOOKBACK_DAYS = 60;
+const UNREST_RESOLUTION_PAGE_LIMIT = 5000;
+const UNREST_RESOLUTION_MAX_PAGES = 20;
+const ACLED_PAGE_DELAY_MS = 250;
 const MAX_SOURCE_URLS = 5;
 const GDELT_THEME_MIN_DELAY_MS = 5_500;
 const GDELT_THEME_JITTER_MS = 1_000;
@@ -140,25 +147,32 @@ function sortBySeverityAndRecency(events) {
 
 // ---------- ACLED Fetch ----------
 
-async function fetchAcledProtests() {
-  const token = await getAcledToken({ userAgent: CHROME_UA });
-  if (!token) {
-    console.log('  ACLED: no credentials configured, skipping');
-    return [];
-  }
+let acledTokenPromise;
+function getAcledTokenOnce() {
+  if (!acledTokenPromise) acledTokenPromise = getAcledToken({ userAgent: CHROME_UA });
+  return acledTokenPromise;
+}
 
-  const now = Date.now();
-  const startDate = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-  const endDate = new Date(now).toISOString().split('T')[0];
+function acledDateRange(now, lookbackDays) {
+  return {
+    startDate: new Date(now - lookbackDays * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+    endDate: new Date(now).toISOString().split('T')[0],
+  };
+}
 
+function buildAcledProtestParams({ startDate, endDate, limit, page }) {
   const params = new URLSearchParams({
     event_type: 'Protests',
     event_date: `${startDate}|${endDate}`,
     event_date_where: 'BETWEEN',
-    limit: '500',
+    limit: String(limit),
     _format: 'json',
   });
+  if (page) params.set('page', String(page));
+  return params;
+}
 
+async function fetchAcledProtestPage(token, params) {
   const resp = await fetch(`${ACLED_API_URL}?${params}`, {
     headers: {
       Accept: 'application/json',
@@ -171,10 +185,10 @@ async function fetchAcledProtests() {
   if (!resp.ok) throw new Error(`ACLED API error: ${resp.status}`);
   const data = await resp.json();
   if (data.message || data.error) throw new Error(data.message || data.error || 'ACLED API error');
+  return Array.isArray(data.data) ? data.data : [];
+}
 
-  const rawEvents = data.data || [];
-  console.log(`  ACLED: ${rawEvents.length} raw events`);
-
+function normalizeAcledProtestEvents(rawEvents) {
   return rawEvents
     .filter((e) => {
       const lat = parseFloat(e.latitude || '');
@@ -206,6 +220,56 @@ async function fetchAcledProtests() {
         sourceUrls: extractAcledSourceUrls(e),
       };
     });
+}
+
+async function fetchAcledProtests({
+  lookbackDays = ACLED_DISPLAY_LOOKBACK_DAYS,
+  limit = ACLED_DISPLAY_LIMIT,
+  paginated = false,
+  maxPages = 1,
+  label = 'ACLED',
+} = {}) {
+  const token = await getAcledTokenOnce();
+  if (!token) {
+    console.log(`  ${label}: no credentials configured, skipping`);
+    return { events: [], pagination: undefined };
+  }
+
+  const now = Date.now();
+  const { startDate, endDate } = acledDateRange(now, lookbackDays);
+  const rawEvents = [];
+  const seen = new Set();
+  let pagesFetched = 0;
+  let lastPageCount = 0;
+  const pageLimit = paginated ? Math.max(1, maxPages) : 1;
+
+  for (let page = 1; page <= pageLimit; page += 1) {
+    const params = buildAcledProtestParams({
+      startDate,
+      endDate,
+      limit,
+      page: paginated ? page : undefined,
+    });
+    const pageEvents = await fetchAcledProtestPage(token, params);
+    pagesFetched = page;
+    lastPageCount = pageEvents.length;
+    const before = rawEvents.length;
+    for (const event of pageEvents) {
+      const id = event.event_id_cnty || `${event.event_date}:${event.country}:${event.latitude}:${event.longitude}:${event.notes || event.source || ''}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      rawEvents.push(event);
+    }
+    if (!paginated || pageEvents.length < limit || rawEvents.length === before) break;
+    await sleep(ACLED_PAGE_DELAY_MS);
+  }
+
+  const events = normalizeAcledProtestEvents(rawEvents);
+  const pagination = paginated
+    ? { lookbackDays, limit, pagesFetched, maxPages, truncated: pagesFetched >= maxPages && lastPageCount >= limit }
+    : undefined;
+  console.log(`  ${label}: ${events.length} raw events (${startDate} to ${endDate}${paginated ? `, ${pagesFetched} page(s)` : ''})`);
+  return { events, pagination };
 }
 
 // ---------- GDELT Fetch ----------
@@ -372,13 +436,36 @@ export async function fetchGdeltEvents(opts = {}) {
 // ---------- Main Fetch ----------
 
 async function fetchUnrestEvents() {
-  const results = await Promise.allSettled([fetchAcledProtests(), fetchGdeltEvents()]);
+  const results = await Promise.allSettled([
+    fetchAcledProtests({ label: 'ACLED display' }),
+    fetchAcledProtests({
+      lookbackDays: UNREST_RESOLUTION_LOOKBACK_DAYS,
+      limit: UNREST_RESOLUTION_PAGE_LIMIT,
+      paginated: true,
+      maxPages: UNREST_RESOLUTION_MAX_PAGES,
+      label: 'ACLED resolution',
+    }),
+    fetchGdeltEvents(),
+  ]);
 
-  const acledEvents = results[0].status === 'fulfilled' ? results[0].value : [];
-  const gdeltEvents = results[1].status === 'fulfilled' ? results[1].value : [];
+  const acled = results[0].status === 'fulfilled' ? results[0].value : null;
+  const acledResolution = results[1].status === 'fulfilled' ? results[1].value : null;
+  const acledEvents = acled?.events ?? [];
+  const gdeltEvents = results[2].status === 'fulfilled' ? results[2].value : [];
 
   if (results[0].status === 'rejected') console.log(`  ACLED failed: ${describeErr(results[0].reason)}`);
-  if (results[1].status === 'rejected') console.log(`  GDELT failed: ${describeErr(results[1].reason)}`);
+  if (results[1].status === 'rejected') console.log(`  ACLED resolution failed: ${describeErr(results[1].reason)}`);
+  if (results[2].status === 'rejected') console.log(`  GDELT failed: ${describeErr(results[2].reason)}`);
+
+  if (acledResolution?.events?.length) {
+    const sortedResolutionEvents = sortBySeverityAndRecency([...acledResolution.events]);
+    await writeExtraKeyWithMeta(
+      UNREST_RESOLUTION_CACHE_KEY,
+      { events: sortedResolutionEvents, clusters: [], pagination: acledResolution.pagination },
+      CACHE_TTL,
+      sortedResolutionEvents.length,
+    );
+  }
 
   const merged = deduplicateEvents([...acledEvents, ...gdeltEvents]);
   const sorted = sortBySeverityAndRecency(merged);

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+
+function source(path) {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+describe('ACLED resolution-feed seed contract (#5076)', () => {
+  const conflictSeed = source('scripts/seed-conflict-intel.mjs');
+  const unrestSeed = source('scripts/seed-unrest-events.mjs');
+  const resolutionSpec = source('scripts/_forecast-resolution.mjs');
+
+  it('routes conflict hard counts to a long-window resolution key, not the map display key', () => {
+    assert.match(resolutionSpec, /CONFLICT_COUNT_SOURCE_FEED\s*=\s*'conflict:acled-resolution:v1:all:0:0'/);
+    assert.doesNotMatch(resolutionSpec, /CONFLICT_COUNT_SOURCE_FEED\s*=\s*'conflict:acled:v1:all:0:0'/);
+  });
+
+  it('routes unrest hard counts to a long-window resolution key, not the canonical display feed', () => {
+    assert.match(resolutionSpec, /UNREST_COUNT_SOURCE_FEED\s*=\s*'unrest:events-resolution:v1'/);
+    assert.doesNotMatch(resolutionSpec, /UNREST_COUNT_SOURCE_FEED\s*=\s*'unrest:events:v1'/);
+  });
+
+  it('conflict seeder keeps the capped display payload but also publishes a paginated 60d resolution feed', () => {
+    assert.match(conflictSeed, /ACLED_CACHE_KEY\s*=\s*'conflict:acled:v1:all:0:0'/);
+    assert.match(conflictSeed, /ACLED_DISPLAY_LOOKBACK_DAYS\s*=\s*30/);
+    assert.match(conflictSeed, /ACLED_DISPLAY_LIMIT\s*=\s*500/);
+    assert.match(conflictSeed, /ACLED_RESOLUTION_CACHE_KEY\s*=\s*'conflict:acled-resolution:v1:all:0:0'/);
+    assert.match(conflictSeed, /ACLED_RESOLUTION_LOOKBACK_DAYS\s*=\s*60/);
+    assert.match(conflictSeed, /ACLED_RESOLUTION_PAGE_LIMIT\s*=\s*5000/);
+    assert.match(conflictSeed, /ACLED_RESOLUTION_MAX_PAGES\s*=\s*(?:[1-9]\d+)/);
+    assert.match(conflictSeed, /writeExtraKeyWithMeta\(\s*ACLED_RESOLUTION_CACHE_KEY/);
+  });
+
+  it('unrest seeder keeps the canonical display feed but also publishes a paginated 60d ACLED resolution feed', () => {
+    assert.match(unrestSeed, /CANONICAL_KEY\s*=\s*'unrest:events:v1'/);
+    assert.match(unrestSeed, /ACLED_DISPLAY_LOOKBACK_DAYS\s*=\s*30/);
+    assert.match(unrestSeed, /ACLED_DISPLAY_LIMIT\s*=\s*500/);
+    assert.match(unrestSeed, /UNREST_RESOLUTION_CACHE_KEY\s*=\s*'unrest:events-resolution:v1'/);
+    assert.match(unrestSeed, /UNREST_RESOLUTION_LOOKBACK_DAYS\s*=\s*60/);
+    assert.match(unrestSeed, /UNREST_RESOLUTION_PAGE_LIMIT\s*=\s*5000/);
+    assert.match(unrestSeed, /UNREST_RESOLUTION_MAX_PAGES\s*=\s*(?:[1-9]\d+)/);
+    assert.match(unrestSeed, /writeExtraKeyWithMeta\(\s*UNREST_RESOLUTION_CACHE_KEY/);
+  });
+});

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -35,6 +35,7 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
     assert.match(conflictSeed, /ACLED_RESOLUTION_PAGE_LIMIT\s*=\s*5000/);
     assert.match(conflictSeed, /ACLED_RESOLUTION_MAX_PAGES\s*=\s*(?:[1-9]\d+)/);
     assert.match(conflictSeed, /writeExtraKeyWithMeta\(\s*ACLED_RESOLUTION_CACHE_KEY/);
+    assert.match(conflictSeed, /ACLED_RESOLUTION_CACHE_KEY,[\s\S]*clusters:\s*\[\],[\s\S]*acResolution\.pagination/);
   });
 
   it('unrest seeder keeps the canonical display feed but also publishes a paginated 60d ACLED resolution feed', () => {

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -843,7 +843,7 @@ describe('detectPoliticalScenarios', () => {
     assert.equal(result[0].region, 'Israel');
   });
 
-  it('can generate from unrest event counts even when CII unrest is weak', () => {
+  it('can generate from ACLED unrest event counts even when CII unrest is weak', () => {
     const inputs = {
       ciiScores: {
         ciiScores: [{
@@ -854,12 +854,44 @@ describe('detectPoliticalScenarios', () => {
         }],
       },
       temporalAnomalies: { anomalies: [] },
-      unrestEvents: { events: [{ country: 'India' }, { country: 'India' }, { country: 'India' }] },
+      unrestEvents: {
+        events: [
+          { country: 'India', sourceType: 'UNREST_SOURCE_TYPE_ACLED' },
+          { country: 'India', sourceType: 'UNREST_SOURCE_TYPE_ACLED' },
+          { country: 'India', sourceType: 'UNREST_SOURCE_TYPE_ACLED' },
+        ],
+      },
     };
     const result = detectPoliticalScenarios(inputs);
     assert.equal(result.length, 1);
     assert.equal(result[0].domain, 'political');
     assert.equal(result[0].region, 'India');
+  });
+
+  it('does not derive hard-count unrest signals from GDELT-only events', () => {
+    const inputs = {
+      ciiScores: {
+        ciiScores: [{
+          region: 'IN',
+          combinedScore: 62,
+          trend: 'TREND_DIRECTION_STABLE',
+          components: { ciiContribution: 0, geoConvergence: 63 },
+        }],
+      },
+      temporalAnomalies: { anomalies: [] },
+      unrestEvents: {
+        events: [
+          { country: 'India', sourceType: 'UNREST_SOURCE_TYPE_GDELT' },
+          { country: 'India', sourceType: 'UNREST_SOURCE_TYPE_GDELT' },
+          { country: 'India', sourceType: 'UNREST_SOURCE_TYPE_GDELT' },
+        ],
+      },
+    };
+    const result = detectPoliticalScenarios(inputs);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].domain, 'political');
+    assert.equal(result[0].region, 'India');
+    assert.ok(!result[0].signals.some((signal) => signal.type === 'unrest_events'));
   });
 });
 

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -84,6 +84,7 @@ import {
   __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,
 } from '../scripts/seed-forecasts.mjs';
+import { CONFLICT_COUNT_SOURCE_FEED } from '../scripts/_forecast-resolution.mjs';
 
 const originalForecastEnv = {
   FORECAST_LLM_PROVIDER_ORDER: process.env.FORECAST_LLM_PROVIDER_ORDER,
@@ -3073,12 +3074,12 @@ describe('forecast quality gating', () => {
     };
     hard.resolution = {
       kind: 'hard',
-      metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+      metricKey: `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`,
       operator: '>=',
       threshold: 1,
       window: 'within-horizon',
       deadline,
-      sourceFeed: 'conflict:acled:v1:all:0:0',
+      sourceFeed: CONFLICT_COUNT_SOURCE_FEED,
     };
 
     const pool = selectPublishedForecastPool([judged, hard], { targetCount: 1 });

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -157,6 +157,74 @@ describe('resolveHardSpec', () => {
     assert.equal(resolved.evidence.comparison, '2 >= 2');
   });
 
+  it('voids a 30d ACLED display feed whose retained window starts after forecast generation', () => {
+    const generatedAt = START;
+    const deadline = generatedAt + 30 * DAY_MS;
+    const sealAt = deadline + ACLED_SETTLEMENT_LAG_MS;
+    const e = entry({
+      id: 'fc-display-window-pruned',
+      generatedAt,
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:acled:v1:all:0:0',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Mali', occurredAt: generatedAt + 2 * DAY_MS },
+        { country: 'Burkina Faso', occurredAt: deadline },
+      ],
+    };
+
+    const result = resolveHardSpec(e, feed, {}, sealAt);
+
+    assert.equal(result.status, 'resolved');
+    assert.equal(result.outcome, 'VOID');
+    assert.equal(result.evidence.reason, 'count_source_window_not_retained');
+    assert.equal(result.evidence.sourceMinTs, generatedAt + 2 * DAY_MS);
+    assert.equal(result.evidence.partialMetricValue, 1);
+  });
+
+  it('resolves a below-threshold 30d ACLED count when the resolution feed retains pre-generation coverage', () => {
+    const generatedAt = START;
+    const deadline = generatedAt + 30 * DAY_MS;
+    const sealAt = deadline + ACLED_SETTLEMENT_LAG_MS;
+    const e = entry({
+      id: 'fc-resolution-window-retained',
+      generatedAt,
+      deadline,
+      spec: {
+        kind: 'hard',
+        metricKey: 'conflict:acled-resolution:v1:all:0:0|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:acled-resolution:v1:all:0:0',
+      },
+    });
+    const feed = {
+      events: [
+        { country: 'Ghana', occurredAt: generatedAt - DAY_MS },
+        { country: 'Mali', occurredAt: generatedAt + 2 * DAY_MS },
+        { country: 'Burkina Faso', occurredAt: deadline },
+      ],
+    };
+
+    const result = resolveHardSpec(e, feed, {}, sealAt);
+
+    assert.equal(result.status, 'resolved');
+    assert.equal(result.outcome, 'NO');
+    assert.equal(result.evidence.metricValue, 1);
+    assert.equal(result.evidence.sourceCoverage.minTs, generatedAt - DAY_MS);
+  });
+
   it('keeps due count specs pending until the UCDP source has reached the forecast deadline', () => {
     const generatedAt = Date.parse('2026-07-09T00:00:00Z');
     const deadline = Date.parse('2026-08-08T00:00:00Z');

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -234,6 +234,8 @@ describe('buildResolutionSpec — feed mapping per family', () => {
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
+    assert.equal(CONFLICT_COUNT_SOURCE_FEED, 'conflict:acled-resolution:v1:all:0:0');
+    assert.notEqual(spec.sourceFeed, 'conflict:acled:v1:all:0:0');
   });
 
   it('a political unrest-events forecast resolves to the unrest count feed', () => {
@@ -249,6 +251,8 @@ describe('buildResolutionSpec — feed mapping per family', () => {
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
+    assert.equal(UNREST_COUNT_SOURCE_FEED, 'unrest:events-resolution:v1');
+    assert.notEqual(spec.sourceFeed, 'unrest:events:v1');
     assert.equal(spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
   });
 

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -258,6 +258,69 @@ describe('processResolutionCycle', () => {
     assert.equal(receipts.length, 2);
   });
 
+  it('migrates old-key count specs first ingested from history snapshots', () => {
+    const deadline = T0 + DAY_MS;
+    const conflict = forecast({
+      id: 'fc-mali',
+      domain: 'conflict',
+      region: 'Mali',
+      title: 'Conflict events in Mali stay below threshold',
+      deadline,
+      resolution: {
+        kind: 'hard',
+        metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'conflict:acled:v1:all:0:0',
+      },
+    });
+    const unrest = forecast({
+      id: 'fc-venezuela',
+      domain: 'political',
+      region: 'Venezuela',
+      title: 'Protests in Venezuela stay below threshold',
+      deadline,
+      resolution: {
+        kind: 'hard',
+        metricKey: 'unrest:events:v1|count(country==Venezuela)',
+        operator: '>=',
+        threshold: 2,
+        window: 'within-horizon',
+        deadline,
+        sourceFeed: 'unrest:events:v1',
+      },
+    });
+
+    const { ledger, receipts } = processResolutionCycle({}, [snapshot(T0, [conflict, unrest])], {
+      [CONFLICT_COUNT_SOURCE_FEED]: {
+        events: [
+          { country: 'Ghana', occurredAt: T0 - DAY_MS },
+          { country: 'Mali', occurredAt: T0 + 2 * 60 * 60 * 1000 },
+          { country: 'Burkina Faso', occurredAt: deadline },
+        ],
+      },
+      [UNREST_COUNT_SOURCE_FEED]: {
+        events: [
+          { country: 'Colombia', occurredAt: T0 - DAY_MS },
+          { country: 'Venezuela', occurredAt: T0 + 3 * 60 * 60 * 1000 },
+          { country: 'Ecuador', occurredAt: deadline },
+        ],
+      },
+    }, deadline + 3 * DAY_MS);
+
+    assert.equal(ledger[`fc-mali@${deadline}`].spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
+    assert.equal(ledger[`fc-mali@${deadline}`].spec.metricKey, `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`);
+    assert.equal(ledger[`fc-mali@${deadline}`].status, 'resolved');
+    assert.equal(ledger[`fc-mali@${deadline}`].outcome, 'NO');
+    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
+    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
+    assert.equal(ledger[`fc-venezuela@${deadline}`].status, 'resolved');
+    assert.equal(ledger[`fc-venezuela@${deadline}`].outcome, 'NO');
+    assert.equal(receipts.length, 2);
+  });
+
   it('does not resolve stale UCDP count snapshots to NO after the settlement lag', () => {
     const deadline = T0 + 30 * DAY_MS;
     const countForecast = forecast({

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -15,6 +15,7 @@ import {
   pruneArchivedTerminalEntries,
 } from '../scripts/seed-forecast-resolutions.mjs';
 import { computeScorecard } from '../scripts/_forecast-scorecard.mjs';
+import { CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from '../scripts/_forecast-resolution.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const T0 = Date.parse('2026-07-07T00:00:00Z');
@@ -165,6 +166,96 @@ describe('processResolutionCycle', () => {
     assert.equal(row.status, 'pending');
     assert.equal(row.outcome, undefined);
     assert.equal(receipts.length, 0);
+  });
+
+  it('migrates already-open ACLED/unrest count entries from display feeds to resolution feeds', () => {
+    const deadline = T0 + DAY_MS;
+    const oldLedger = {
+      [`fc-mali@${deadline}`]: {
+        id: 'fc-mali',
+        key: `fc-mali@${deadline}`,
+        domain: 'conflict',
+        region: 'Mali',
+        title: 'Conflict events in Mali stay below threshold',
+        timeHorizon: '24h',
+        generationOrigin: 'detector',
+        spec: {
+          kind: 'hard',
+          metricKey: 'conflict:acled:v1:all:0:0|count(country==Mali)',
+          operator: '>=',
+          threshold: 2,
+          window: 'within-horizon',
+          deadline,
+          sourceFeed: 'conflict:acled:v1:all:0:0',
+        },
+        probability: 0.52,
+        firstSeenProbability: 0.52,
+        generatedAt: T0,
+        deadline,
+        firstSeenAt: T0,
+        lastSeenAt: T0,
+        status: 'pending',
+        samples: { count: 0, recent: [] },
+      },
+      [`fc-venezuela@${deadline}`]: {
+        id: 'fc-venezuela',
+        key: `fc-venezuela@${deadline}`,
+        domain: 'political',
+        region: 'Venezuela',
+        title: 'Protests in Venezuela stay below threshold',
+        timeHorizon: '24h',
+        generationOrigin: 'detector',
+        spec: {
+          kind: 'hard',
+          metricKey: 'unrest:events:v1|count(country==Venezuela)',
+          operator: '>=',
+          threshold: 2,
+          window: 'within-horizon',
+          deadline,
+          sourceFeed: 'unrest:events:v1',
+        },
+        probability: 0.55,
+        firstSeenProbability: 0.55,
+        generatedAt: T0,
+        deadline,
+        firstSeenAt: T0,
+        lastSeenAt: T0,
+        status: 'pending',
+        samples: { count: 0, recent: [] },
+      },
+    };
+
+    const { ledger, receipts } = processResolutionCycle(oldLedger, [], {
+      [CONFLICT_COUNT_SOURCE_FEED]: {
+        events: [
+          { country: 'Ghana', occurredAt: T0 - DAY_MS },
+          { country: 'Mali', occurredAt: T0 + 2 * 60 * 60 * 1000 },
+          { country: 'Burkina Faso', occurredAt: deadline },
+        ],
+      },
+      [UNREST_COUNT_SOURCE_FEED]: {
+        events: [
+          { country: 'Colombia', occurredAt: T0 - DAY_MS },
+          { country: 'Venezuela', occurredAt: T0 + 3 * 60 * 60 * 1000 },
+          { country: 'Ecuador', occurredAt: deadline },
+        ],
+      },
+    }, deadline + 3 * DAY_MS);
+
+    const conflictRow = ledger[`fc-mali@${deadline}`];
+    assert.equal(conflictRow.spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
+    assert.equal(conflictRow.spec.metricKey, `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`);
+    assert.equal(conflictRow.status, 'resolved');
+    assert.equal(conflictRow.outcome, 'NO');
+    assert.equal(conflictRow.evidence.metricValue, 1);
+
+    const unrestRow = ledger[`fc-venezuela@${deadline}`];
+    assert.equal(unrestRow.spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
+    assert.equal(unrestRow.spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
+    assert.equal(unrestRow.status, 'resolved');
+    assert.equal(unrestRow.outcome, 'NO');
+    assert.equal(unrestRow.evidence.metricValue, 1);
+    assert.equal(receipts.length, 2);
   });
 
   it('does not resolve stale UCDP count snapshots to NO after the settlement lag', () => {


### PR DESCRIPTION
## Summary

Thirty-day conflict and unrest hard-count forecasts no longer resolve against display feeds that can prune the beginning of the forecast window. The map-facing ACLED and unrest payloads stay capped for UI use, while the seeders now also publish 60-day, paginated resolution feeds for the forecast resolver.

Newly emitted hard specs point at `conflict:acled-resolution:v1:all:0:0` and `unrest:events-resolution:v1`, and the resolution seeder migrates already-open pending ledger entries off the old display keys before reading feeds. That covers both future forecasts and entries already waiting to settle.

Fixes #5076.

## Validation

- `git diff --check`
- `node --check scripts/seed-conflict-intel.mjs`
- `node --check scripts/seed-unrest-events.mjs`
- `node --check scripts/seed-forecast-resolutions.mjs`
- `node --test tests/acled-resolution-feed-seed.test.mjs tests/forecast-resolution.test.mjs tests/forecast-resolution-eval.test.mjs tests/forecast-detectors.test.mjs tests/forecast-resolutions-seeder.test.mjs tests/forecast-history.test.mjs`
- Pre-push hook via `git push -u origin HEAD`: frontend/API/Convex typechecks, CJS syntax, Unicode safety, boundary/safe-HTML/rate-limit/premium-fetch guards, edge bundle check, changed tests, version sync.

## Post-Deploy Monitoring & Validation

- Log searches: `ACLED resolution`, `ACLED resolution failed`, `Extra key conflict:acled-resolution:v1:all:0:0`, `Extra key unrest:events-resolution:v1`, `missing_feed:conflict:acled-resolution`, `missing_feed:unrest:events-resolution`, `count_source_window_not_retained`.
- Watch Redis seed metadata for `seed-meta:conflict:acled-resolution:v1:all:0:0` and `seed-meta:unrest:events-resolution`, plus the daily forecast-resolution seed logs.
- Healthy signals: both resolution keys are written after the conflict/unrest seeders run, pagination reports a 60-day lookback, pending ACLED/unrest count entries read the new keys, and ACLED display-feed window-pruning VOIDs stop appearing for current 30-day hard-count entries.
- Failure signals: resolution-key write warnings, repeated `missing_feed` samples for the new keys, sustained `count_source_window_not_retained` on ACLED/unrest count specs, or no seed-meta refresh inside the expected seeder cadence.
- Validation window: first 24 hours after deploy, owned by the forecast pipeline operator. If the keys do not refresh, rerun the conflict/unrest seeders; if the resolver starts accumulating missing-feed samples, roll back this PR or temporarily restore affected specs to judged resolution.

## Known Residuals

- The new resolution feeds are secondary keys with seed-meta and log visibility, but not dedicated rows in `api/health.js`. That keeps this fix narrow; the post-deploy checks above are the operational backstop.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
