### PR TITLE
perf(edge): cache apex→www 301 + point published human links at www (#5081)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![skills.sh](https://skills.sh/b/koala73/worldmonitor)](https://skills.sh/koala73/worldmonitor)
 
 <p align="center">
-  <a href="https://worldmonitor.app"><img src="https://img.shields.io/badge/Web_App-worldmonitor.app-blue?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Web App"></a>&nbsp;
+  <a href="https://www.worldmonitor.app"><img src="https://img.shields.io/badge/Web_App-worldmonitor.app-blue?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Web App"></a>&nbsp;
   <a href="https://tech.worldmonitor.app"><img src="https://img.shields.io/badge/Tech_Variant-tech.worldmonitor.app-0891b2?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Tech Variant"></a>&nbsp;
   <a href="https://finance.worldmonitor.app"><img src="https://img.shields.io/badge/Finance_Variant-finance.worldmonitor.app-059669?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Finance Variant"></a>&nbsp;
   <a href="https://commodity.worldmonitor.app"><img src="https://img.shields.io/badge/Commodity_Variant-commodity.worldmonitor.app-b45309?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Commodity Variant"></a>&nbsp;
@@ -30,10 +30,10 @@
 </p>
 
 <p align="center">
-  <a href="https://worldmonitor.app/api/download?platform=windows-exe"><img src="https://img.shields.io/badge/Download-Windows_(.exe)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows"></a>&nbsp;
-  <a href="https://worldmonitor.app/api/download?platform=macos-arm64"><img src="https://img.shields.io/badge/Download-macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS ARM"></a>&nbsp;
-  <a href="https://worldmonitor.app/api/download?platform=macos-x64"><img src="https://img.shields.io/badge/Download-macOS_Intel-555555?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Intel"></a>&nbsp;
-  <a href="https://worldmonitor.app/api/download?platform=linux-appimage"><img src="https://img.shields.io/badge/Download-Linux_(.AppImage)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux"></a>
+  <a href="https://www.worldmonitor.app/api/download?platform=windows-exe"><img src="https://img.shields.io/badge/Download-Windows_(.exe)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows"></a>&nbsp;
+  <a href="https://www.worldmonitor.app/api/download?platform=macos-arm64"><img src="https://img.shields.io/badge/Download-macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS ARM"></a>&nbsp;
+  <a href="https://www.worldmonitor.app/api/download?platform=macos-x64"><img src="https://img.shields.io/badge/Download-macOS_Intel-555555?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Intel"></a>&nbsp;
+  <a href="https://www.worldmonitor.app/api/download?platform=linux-appimage"><img src="https://img.shields.io/badge/Download-Linux_(.AppImage)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux"></a>
 </p>
 
 <p align="center">
@@ -133,7 +133,7 @@ World Monitor is built for agents and scripts as well as browsers:
 
 - **SDKs** — official zero-dependency client libraries mirroring the CLI: Python [`worldmonitor-sdk`](https://pypi.org/project/worldmonitor-sdk/) (source in [`sdk/python/`](sdk/python/)), Ruby [`worldmonitor`](https://rubygems.org/gems/worldmonitor) ([`sdk/ruby/`](sdk/ruby/)), Go [`github.com/koala73/worldmonitor/sdk/go`](https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go) ([`sdk/go/`](sdk/go/)). Guide: [worldmonitor.app/docs/sdks](https://www.worldmonitor.app/docs/sdks).
 
-Agent discovery files: [`llms.txt`](https://worldmonitor.app/llms.txt) · [agent-skills manifest](https://worldmonitor.app/.well-known/agent-skills/index.json) · [api-catalog](https://worldmonitor.app/.well-known/api-catalog). Get an API key at [worldmonitor.app/pro](https://worldmonitor.app/pro).
+Agent discovery files: [`llms.txt`](https://worldmonitor.app/llms.txt) · [agent-skills manifest](https://worldmonitor.app/.well-known/agent-skills/index.json) · [api-catalog](https://worldmonitor.app/.well-known/api-catalog). Get an API key at [worldmonitor.app/pro](https://www.worldmonitor.app/pro).
 
 ---
 
@@ -199,7 +199,7 @@ See our [Security Policy](./SECURITY.md) for responsible disclosure guidelines.
 ---
 
 <p align="center">
-  <a href="https://worldmonitor.app">worldmonitor.app</a> &nbsp;·&nbsp;
+  <a href="https://www.worldmonitor.app">worldmonitor.app</a> &nbsp;·&nbsp;
   <a href="https://www.worldmonitor.app/docs/documentation">docs.worldmonitor.app</a> &nbsp;·&nbsp;
   <a href="https://finance.worldmonitor.app">finance.worldmonitor.app</a> &nbsp;·&nbsp;
   <a href="https://commodity.worldmonitor.app">commodity.worldmonitor.app</a>

--- a/blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md
+++ b/blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md
@@ -153,4 +153,4 @@ For most intelligence tasks, local models like Llama 3.1 70B produce comparable 
 
 ---
 
-**Run intelligence analysis on your own terms at [worldmonitor.app](https://worldmonitor.app). Install Ollama for fully private AI. No login, no tracking, no compromise.**
+**Run intelligence analysis on your own terms at [worldmonitor.app](https://www.worldmonitor.app). Install Ollama for fully private AI. No login, no tracking, no compromise.**

--- a/blog-site/src/content/blog/command-palette-search-everything-instantly.md
+++ b/blog-site/src/content/blog/command-palette-search-everything-instantly.md
@@ -148,4 +148,4 @@ The palette is context-aware: it ranks results based on your currently active pa
 
 ---
 
-**Try it now: open [worldmonitor.app](https://worldmonitor.app) and press Cmd+K. Your intelligence is one search away.**
+**Try it now: open [worldmonitor.app](https://www.worldmonitor.app) and press Cmd+K. Your intelligence is one search away.**

--- a/blog-site/src/content/blog/country-instability-index-methodology-explained.md
+++ b/blog-site/src/content/blog/country-instability-index-methodology-explained.md
@@ -92,7 +92,7 @@ The decomposition is the analysis. The number is just the index into it.
 
 ## Using the CII
 
-- **Dashboard:** the CII panel at [worldmonitor.app](https://worldmonitor.app) shows all 31 countries with scores, bands, and 24-hour deltas; any country's brief decomposes its score.
+- **Dashboard:** the CII panel at [worldmonitor.app](https://www.worldmonitor.app) shows all 31 countries with scores, bands, and 24-hour deltas; any country's brief decomposes its score.
 - **API:** `get-country-risk` returns the score and component breakdown as JSON for [your own models](/blog/posts/build-on-worldmonitor-developer-api-open-source/).
 - **AI agents:** the `get_country_risk` tool on the [MCP server](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/) gives Claude and other assistants the same data, so "why did Egypt's risk score move?" becomes a question your agent can actually answer.
 
@@ -112,4 +112,4 @@ Annual indices measure structural conditions with a 12-month cadence; the CII me
 
 ---
 
-**See every score, band, and delta live at [worldmonitor.app](https://worldmonitor.app). When a number surprises you, click into the country brief and take the score apart. That is what it is for.**
+**See every score, band, and delta live at [worldmonitor.app](https://www.worldmonitor.app). When a number surprises you, click into the country brief and take the score apart. That is what it is for.**

--- a/blog-site/src/content/blog/country-risk-monitoring-workflow-for-analysts.md
+++ b/blog-site/src/content/blog/country-risk-monitoring-workflow-for-analysts.md
@@ -91,4 +91,4 @@ Yes. Every score shown in the dashboard is available through the [REST API](/blo
 
 ---
 
-**Open [worldmonitor.app](https://worldmonitor.app), press Cmd+K, and type the name of the country that worries you most. The baseline takes thirty seconds; the workflow takes a habit.**
+**Open [worldmonitor.app](https://www.worldmonitor.app), press Cmd+K, and type the name of the country that worries you most. The baseline takes thirty seconds; the workflow takes a habit.**

--- a/blog-site/src/content/blog/cyber-threat-intelligence-for-security-teams.md
+++ b/blog-site/src/content/blog/cyber-threat-intelligence-for-security-teams.md
@@ -170,4 +170,4 @@ World Monitor provides geographic and geopolitical threat context rather than or
 
 ---
 
-**Add geopolitical context to your threat intelligence at [worldmonitor.app](https://worldmonitor.app). Free, open source, and integrated with the intelligence data that matters.**
+**Add geopolitical context to your threat intelligence at [worldmonitor.app](https://www.worldmonitor.app). Free, open source, and integrated with the intelligence data that matters.**

--- a/blog-site/src/content/blog/daily-intelligence-briefing-workflow-15-minutes.md
+++ b/blog-site/src/content/blog/daily-intelligence-briefing-workflow-15-minutes.md
@@ -85,4 +85,4 @@ Yes. Pro digest settings push scheduled briefs to your channel of choice, and an
 
 ---
 
-**Run the sequence tomorrow at [worldmonitor.app](https://worldmonitor.app): world brief, deltas, watchlist, region, forward look, capture. By Friday it is a habit; by next month it is an edge.**
+**Run the sequence tomorrow at [worldmonitor.app](https://www.worldmonitor.app): world brief, deltas, watchlist, region, forward look, capture. By Friday it is a habit; by next month it is an edge.**

--- a/blog-site/src/content/blog/five-dashboards-one-platform-worldmonitor-variants.md
+++ b/blog-site/src/content/blog/five-dashboards-one-platform-worldmonitor-variants.md
@@ -201,7 +201,7 @@ No. All five variants are completely free with no time limits, feature gates, or
 
 **Pick your variant and start exploring:**
 
-- [worldmonitor.app](https://worldmonitor.app) for geopolitics
+- [worldmonitor.app](https://www.worldmonitor.app) for geopolitics
 - [tech.worldmonitor.app](https://tech.worldmonitor.app) for technology
 - [finance.worldmonitor.app](https://finance.worldmonitor.app) for markets
 - [commodity.worldmonitor.app](https://commodity.worldmonitor.app) for commodities

--- a/blog-site/src/content/blog/live-webcams-from-geopolitical-hotspots.md
+++ b/blog-site/src/content/blog/live-webcams-from-geopolitical-hotspots.md
@@ -145,4 +145,4 @@ Yes. The Tauri desktop app includes staggered iframe loading and a custom sideca
 
 ---
 
-**See the world in real time at [worldmonitor.app](https://worldmonitor.app). 31 live webcams, 30+ news streams, zero login required.**
+**See the world in real time at [worldmonitor.app](https://www.worldmonitor.app). 31 live webcams, 30+ news streams, zero login required.**

--- a/blog-site/src/content/blog/natural-disaster-monitoring-earthquakes-fires-volcanoes.md
+++ b/blog-site/src/content/blog/natural-disaster-monitoring-earthquakes-fires-volcanoes.md
@@ -178,4 +178,4 @@ Yes. Use Custom Keyword Monitors for terms like "earthquake," "wildfire," or "fl
 
 ---
 
-**Monitor natural disasters in context at [worldmonitor.app](https://worldmonitor.app). USGS, NASA, and AI analysis, all in one free dashboard.**
+**Monitor natural disasters in context at [worldmonitor.app](https://www.worldmonitor.app). USGS, NASA, and AI analysis, all in one free dashboard.**

--- a/blog-site/src/content/blog/osint-for-everyone-open-source-intelligence-democratized.md
+++ b/blog-site/src/content/blog/osint-for-everyone-open-source-intelligence-democratized.md
@@ -140,4 +140,4 @@ World Monitor consolidates 435+ feeds, live tracking, AI analysis, and 45 data l
 
 ---
 
-**Start your OSINT workflow at [worldmonitor.app](https://worldmonitor.app). Free, open source, and no login required.**
+**Start your OSINT workflow at [worldmonitor.app](https://www.worldmonitor.app). Free, open source, and no login required.**

--- a/blog-site/src/content/blog/prediction-markets-ai-forecasting-geopolitics.md
+++ b/blog-site/src/content/blog/prediction-markets-ai-forecasting-geopolitics.md
@@ -168,4 +168,4 @@ The AI synthesizes CII scores, news velocity, military signals, Telegram OSINT, 
 
 ---
 
-**See what's coming at [worldmonitor.app](https://worldmonitor.app). Prediction markets, AI forecasting, and 45 intelligence layers, all free.**
+**See what's coming at [worldmonitor.app](https://www.worldmonitor.app). Prediction markets, AI forecasting, and 45 intelligence layers, all free.**

--- a/blog-site/src/content/blog/satellite-imagery-orbital-surveillance.md
+++ b/blog-site/src/content/blog/satellite-imagery-orbital-surveillance.md
@@ -119,4 +119,4 @@ Yes. Use the time-range query feature to pull imagery from different dates. This
 
 ---
 
-**Explore satellite imagery at [worldmonitor.app](https://worldmonitor.app). Toggle the orbital surveillance layer and see the world from above.**
+**Explore satellite imagery at [worldmonitor.app](https://www.worldmonitor.app). Toggle the orbital surveillance layer and see the world from above.**

--- a/blog-site/src/content/blog/track-global-conflicts-in-real-time.md
+++ b/blog-site/src/content/blog/track-global-conflicts-in-real-time.md
@@ -166,4 +166,4 @@ The CII scores each country from 0 to 100 using four weighted components: baseli
 
 ---
 
-**Monitor developing situations at [worldmonitor.app](https://worldmonitor.app). Real-time geopolitical intelligence, free and open source.**
+**Monitor developing situations at [worldmonitor.app](https://www.worldmonitor.app). Real-time geopolitical intelligence, free and open source.**

--- a/blog-site/src/content/blog/tracking-global-trade-routes-chokepoints-freight-costs.md
+++ b/blog-site/src/content/blog/tracking-global-trade-routes-chokepoints-freight-costs.md
@@ -11,7 +11,7 @@ modifiedDate: "2026-06-13"
 
 > **Key Takeaways:** Strait of Hormuz traffic down 94.4%. World Monitor tracks 8 corridors, 9 freight indices, WTO trade policy, and critical mineral concentration across one free dashboard. Data updates in real time.
 
-The Strait of Hormuz carries 20% of the world's oil. Right now, [World Monitor's](https://worldmonitor.app) live chokepoint tracker shows traffic has dropped 94.4% week-over-week. Tanker transits have collapsed from 60+ daily to single digits. The disruption score is 99%.
+The Strait of Hormuz carries 20% of the world's oil. Right now, [World Monitor's](https://www.worldmonitor.app) live chokepoint tracker shows traffic has dropped 94.4% week-over-week. Tanker transits have collapsed from 60+ daily to single digits. The disruption score is 99%.
 
 This is not a hypothetical scenario for a risk assessment deck. This is happening right now, and World Monitor is tracking it live.
 
@@ -152,4 +152,4 @@ The eight most strategically important chokepoints are: Strait of Hormuz (oil/LN
 
 ---
 
-**Open the Supply Chain panel at [worldmonitor.app](https://worldmonitor.app) and click "Chokepoints" for live corridor disruption scores, or "Shipping Rates" to see real-time freight indices. Free for everyone.**
+**Open the Supply Chain panel at [worldmonitor.app](https://www.worldmonitor.app) and click "Chokepoints" for live corridor disruption scores, or "Shipping Rates" to see real-time freight indices. Free for everyone.**

--- a/blog-site/src/content/blog/verify-breaking-news-osint-workflow-journalists.md
+++ b/blog-site/src/content/blog/verify-breaking-news-osint-workflow-journalists.md
@@ -73,4 +73,4 @@ Physical signals appear within minutes (AIS behavior, airspace changes, connecti
 
 ---
 
-**Bookmark [worldmonitor.app](https://worldmonitor.app) next to your CMS. The next time a claim breaks, run the ten minutes before the call. Your editor gets "three independent signals corroborate" instead of "Twitter says."**
+**Bookmark [worldmonitor.app](https://www.worldmonitor.app) next to your CMS. The next time a claim breaks, run the ten minutes before the call. Your editor gets "three independent signals corroborate" instead of "Twitter says."**

--- a/blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md
+++ b/blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md
@@ -110,4 +110,4 @@ World Monitor covers geopolitics, markets, military tracking, and infrastructure
 
 ---
 
-**Try World Monitor now at [worldmonitor.app](https://worldmonitor.app). No signup required.**
+**Try World Monitor now at [worldmonitor.app](https://www.worldmonitor.app). No signup required.**

--- a/blog-site/src/content/blog/worldmonitor-in-21-languages-global-intelligence-for-everyone.md
+++ b/blog-site/src/content/blog/worldmonitor-in-21-languages-global-intelligence-for-everyone.md
@@ -165,4 +165,4 @@ Yes. World Monitor is open source and uses JSON-based translation files. Bilingu
 
 ---
 
-**Use World Monitor in your language at [worldmonitor.app](https://worldmonitor.app). 21 languages, full RTL support, locale-specific feeds. Free for everyone, everywhere.**
+**Use World Monitor in your language at [worldmonitor.app](https://www.worldmonitor.app). 21 languages, full RTL support, locale-specific feeds. Free for everyone, everywhere.**

--- a/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
+++ b/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
@@ -187,4 +187,4 @@ It means seeing how a conflict zone overlaps with an undersea cable, how a naval
 
 ---
 
-**Compare for yourself at [worldmonitor.app](https://worldmonitor.app). Free, open source, and ready in seconds.**
+**Compare for yourself at [worldmonitor.app](https://www.worldmonitor.app). Free, open source, and ready in seconds.**

--- a/blog-site/src/layouts/BlogPost.astro
+++ b/blog-site/src/layouts/BlogPost.astro
@@ -204,7 +204,7 @@ const faqLd = extractFaqLd(rawBody);
     <div class="cta-banner">
       <h3>See the World in Real Time</h3>
       <p>Markets, geopolitics, conflicts, infrastructure. One dashboard. No login required.</p>
-      <a href="https://worldmonitor.app" class="btn" target="_blank" rel="noopener noreferrer">Open Dashboard</a>
+      <a href="https://www.worldmonitor.app" class="btn" target="_blank" rel="noopener noreferrer">Open Dashboard</a>
     </div>
     <div class="author-bio">
       <img src={avatarSrc} alt={authorName} width="48" height="48" class="author-avatar" loading="lazy" onerror="this.src='/favico/apple-touch-icon.png'" />

--- a/blog-site/src/pages/index.astro
+++ b/blog-site/src/pages/index.astro
@@ -23,7 +23,7 @@ const jsonLd = {
   "publisher": {
     "@type": "Organization",
     "name": "World Monitor",
-    "url": "https://worldmonitor.app",
+    "url": "https://www.worldmonitor.app",
     "logo": {
       "@type": "ImageObject",
       "url": "https://www.worldmonitor.app/favico/apple-touch-icon.png"


### PR DESCRIPTION
Closes #5081.

The apex `worldmonitor.app` → `www` 301 (a Cloudflare Dynamic Redirect) carried **no `Cache-Control`**, so PSI charged ~780ms for it on `/dashboard` mobile — the single largest lab opportunity in the keyed run — and every apex entrant (social, README, docs) re-paid the redirect on every visit.

## Fix #1 — edge Cache-Control (already applied live via Cloudflare API)

Added a zone `http_response_headers_transform` rule that stamps `Cache-Control: public, max-age=3600` on the apex 301s so browsers cache the redirect and repeat apex visits skip the network hop.

**Scope (adversarially verified via `curl`):** the rule matches only `http.host == "worldmonitor.app" AND http.response.code == 301`, and mirrors the redirect rule's agent-surface exemptions. Confirmed untouched:

| Surface | Result |
|---|---|
| apex `/`, `/dashboard`, `/pro` | `301` **+ `public, max-age=3600`** ✅ |
| apex `/mcp` (exempt) | `200 no-store` — unchanged ✅ |
| apex `/robots.txt`, `/security.txt`, `/.well-known/*` | own headers, unchanged ✅ |
| apex `/oauth/*` one-time 302s | excluded by both path and `code==301` ✅ |
| `www` (canonical app) | `private, no-cache` — unchanged ✅ |

Not in this repo (documented in `ARCHITECTURE.md:72` as dashboard-managed). **Rollback:** delete zone response-header ruleset `8d384c81f1994b2993f4ef26bfbeaf6a`.

## Fix #2 — repoint our own published *human* page links at www (this diff)

So first-time visitors from our links skip the hop entirely, and the origin stops fragmenting in CrUX/analytics:

- **README** — web-app badge, desktop download badges, `/pro` link, footer
- **blog-site** — Organization JSON-LD `url`, "Open Dashboard" CTA, and 19 post CTAs

**Preserved as apex by design** (canonical machine-entry surfaces, machine-fetched — not a human PSI source; `/mcp`+`/.well-known`+`/oauth` are also redirect-exempt): `/mcp`, `/openapi.*`, `/llms.txt`, `/.well-known/*`, the `/*.md` agent corpus, and the "start from `https://worldmonitor.app/`" agent-bootstrap prose.

## Verification

- `curl` matrix above (edge scope).
- `npx tsx --test tests/blog-faq-ld.test.mjs` → 4/4 pass, incl. the corpus sweep over real posts. No source code or tests changed; pure link-href swaps.

https://claude.ai/code/session_018KhvfygHmccvcvT7Kusa91
