### PR TITLE
fix(forecast): resolve judged forecast outcomes

### DIFF
--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -36,8 +36,11 @@ export const JUDGED_ARCHIVE_LOOKBACK_PAD_MS = 6 * 60 * 60 * 1000;
 export const DEFAULT_JUDGED_ARCHIVE_ITEMS = 16;
 export const DEFAULT_JUDGED_MAX_PER_RUN = 12;
 export const DEFAULT_JUDGED_RUN_BUDGET_MS = 110_000;
+export const DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT = 3_000;
 const DEFAULT_MIN_JUDGED_STAGE_BUDGET_MS = 5_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_JUDGED_MAX_PENDING_ATTEMPTS = 14;
+export const DEFAULT_JUDGED_MAX_PENDING_AGE_MS = 14 * DAY_MS;
 const JUDGED_TOKEN_STOPWORDS = new Set([
   'about', 'above', 'after', 'again', 'against', 'before', 'being', 'below',
   'between', 'could', 'deadline', 'during', 'forecast', 'from', 'have',
@@ -106,10 +109,14 @@ export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, op
   const minJudgeStageBudgetMs = Number.isFinite(options.minJudgeStageBudgetMs)
     ? Math.max(0, Math.floor(options.minJudgeStageBudgetMs))
     : Math.min(DEFAULT_MIN_JUDGED_STAGE_BUDGET_MS, judgeStageBudgetMs);
+  const retryPolicy = resolveJudgedRetryPolicy(options);
   let attempted = 0;
 
-  for (const [key, entry] of Object.entries(ledger)) {
-    if (entry?.status !== 'pending-judge') continue;
+  const pendingRows = Object.entries(ledger)
+    .filter(([, entry]) => entry?.status === 'pending-judge')
+    .sort((left, right) => comparePendingJudgedEntries(left, right, nowMs));
+
+  for (const [key, entry] of pendingRows) {
     if (attempted >= maxEntries) break;
     let entryOptions = options;
     if (Number.isFinite(deadlineMs)) {
@@ -121,17 +128,14 @@ export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, op
       };
     }
 
-    const result = await resolveJudgedEntry(entry, newsArchive, nowMs, entryOptions);
+    let result = await resolveJudgedEntry(entry, newsArchive, nowMs, entryOptions);
     if (result.status === 'skip') continue;
     attempted += 1;
 
     if (result.status === 'pending') {
-      entry.judgeLastAttempt = {
-        at: nowMs,
-        reason: result.reason || 'judge_pending',
-        detail: result.detail || '',
-      };
-      continue;
+      recordJudgedPendingAttempt(entry, result, nowMs);
+      result = maybeExpireJudgedEntry(entry, nowMs, retryPolicy);
+      if (!result) continue;
     }
 
     entry.status = 'resolved';
@@ -143,6 +147,76 @@ export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, op
   }
 
   return receipts;
+}
+
+function comparePendingJudgedEntries([keyA, entryA], [keyB, entryB], nowMs) {
+  const dueA = judgedEntryIsDue(entryA, nowMs);
+  const dueB = judgedEntryIsDue(entryB, nowMs);
+  if (dueA !== dueB) return dueA ? -1 : 1;
+
+  const attemptA = toFiniteNumber(entryA?.judgeLastAttempt?.at);
+  const attemptB = toFiniteNumber(entryB?.judgeLastAttempt?.at);
+  const orderA = Number.isFinite(attemptA) ? attemptA : -Infinity;
+  const orderB = Number.isFinite(attemptB) ? attemptB : -Infinity;
+  if (orderA !== orderB) return orderA - orderB;
+
+  const deadlineA = toFiniteNumber(entryA?.deadline ?? entryA?.spec?.deadline);
+  const deadlineB = toFiniteNumber(entryB?.deadline ?? entryB?.spec?.deadline);
+  const deadlineOrderA = Number.isFinite(deadlineA) ? deadlineA : Infinity;
+  const deadlineOrderB = Number.isFinite(deadlineB) ? deadlineB : Infinity;
+  if (deadlineOrderA !== deadlineOrderB) return deadlineOrderA - deadlineOrderB;
+
+  return keyA.localeCompare(keyB);
+}
+
+function judgedEntryIsDue(entry, nowMs) {
+  const deadline = toFiniteNumber(entry?.deadline ?? entry?.spec?.deadline);
+  return !Number.isFinite(deadline) || nowMs >= deadline;
+}
+
+function recordJudgedPendingAttempt(entry, result, nowMs) {
+  entry.judgeAttempts = toNonNegativeInteger(entry.judgeAttempts) + 1;
+  entry.judgeLastAttempt = {
+    at: nowMs,
+    reason: result.reason || 'judge_pending',
+    detail: result.detail || '',
+  };
+}
+
+function resolveJudgedRetryPolicy(options = {}) {
+  return {
+    maxAttempts: Number.isFinite(options.maxJudgedPendingAttempts)
+      ? Math.max(1, Math.floor(options.maxJudgedPendingAttempts))
+      : envPositiveInt('FORECAST_RESOLUTION_JUDGE_MAX_PENDING_ATTEMPTS', DEFAULT_JUDGED_MAX_PENDING_ATTEMPTS),
+    maxAgeMs: Number.isFinite(options.maxJudgedPendingAgeMs)
+      ? Math.max(0, Math.floor(options.maxJudgedPendingAgeMs))
+      : envPositiveInt('FORECAST_RESOLUTION_JUDGE_MAX_PENDING_AGE_MS', DEFAULT_JUDGED_MAX_PENDING_AGE_MS),
+  };
+}
+
+function maybeExpireJudgedEntry(entry, nowMs, retryPolicy) {
+  const attempts = toNonNegativeInteger(entry?.judgeAttempts);
+  if (attempts < retryPolicy.maxAttempts) return null;
+  const deadline = toFiniteNumber(entry?.deadline ?? entry?.spec?.deadline);
+  const ageMs = Number.isFinite(deadline) ? nowMs - deadline : retryPolicy.maxAgeMs;
+  if (ageMs < retryPolicy.maxAgeMs) return null;
+
+  const result = resolvedJudgedResult('VOID', 'judge_retry_exhausted', entry, [], [], nowMs);
+  result.evidence = pruneUndefined({
+    ...result.evidence,
+    attempts,
+    maxAttempts: retryPolicy.maxAttempts,
+    deadlineAgeMs: Number.isFinite(ageMs) ? Math.max(0, ageMs) : undefined,
+    maxAgeMs: retryPolicy.maxAgeMs,
+    lastAttemptReason: entry?.judgeLastAttempt?.reason,
+    lastAttemptDetail: entry?.judgeLastAttempt?.detail,
+  });
+  return result;
+}
+
+function toNonNegativeInteger(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : 0;
 }
 
 export async function resolveJudgedEntry(entry, newsArchive, nowMs, options = {}) {
@@ -915,7 +989,7 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   const coverageStartMs = Math.max(windowStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
   const maxHashes = Number.isFinite(options.maxHashes)
     ? Math.max(1, Math.floor(options.maxHashes))
-    : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', 300);
+    : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT);
   const base = {
     requestedStartMs: windowStartMs,
     requestedEndMs: nowMs,
@@ -943,6 +1017,9 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
 
   const selectedHashes = hashes.slice(0, maxHashes);
   const truncated = hashes.length >= maxHashes;
+  if (truncated) {
+    console.warn(`  [forecast-resolutions] judged archive hash cap reached (${selectedHashes.length}/${maxHashes}) for ${new Date(coverageStartMs).toISOString()}..${new Date(nowMs).toISOString()}; increase FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT or page the archive scan`);
+  }
   const pipelineResp = await fetch(`${url}/pipeline`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -12,11 +12,12 @@
 //   - Start command: node scripts/seed-forecast-resolutions.mjs
 //   - Cron: daily
 
-import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
+import { CHROME_UA, getRedisCredentials, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
 import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
 import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
+import { callForecastLLM } from './seed-forecasts.mjs';
 
 export const HISTORY_KEY = 'forecast:predictions:history:v1';
 export const RESOLUTIONS_KEY = 'forecast:resolutions:v1';
@@ -26,7 +27,20 @@ export const SCORECARD_TTL_SECONDS = 7 * 24 * 60 * 60;
 export const RESOLUTION_SOURCE_VERSION = 'forecast-resolution-engine-v1';
 export const RESOLUTION_SCHEMA_VERSION = 1;
 export const MAX_RECENT_SAMPLES = 40;
+export const JUDGED_ARCHIVE_KEY = 'digest:accumulator:v1:full:en';
+export const JUDGED_ARCHIVE_RETENTION_MS = 48 * 60 * 60 * 1000;
+export const JUDGED_ARCHIVE_LOOKBACK_PAD_MS = 6 * 60 * 60 * 1000;
+export const DEFAULT_JUDGED_ARCHIVE_ITEMS = 16;
+export const DEFAULT_JUDGED_MAX_PER_RUN = 12;
+export const DEFAULT_JUDGED_RUN_BUDGET_MS = 110_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
+const JUDGED_TOKEN_STOPWORDS = new Set([
+  'about', 'above', 'after', 'again', 'against', 'before', 'being', 'below',
+  'between', 'could', 'deadline', 'during', 'forecast', 'from', 'have',
+  'into', 'more', 'over', 'than', 'that', 'their', 'there', 'these',
+  'this', 'through', 'under', 'until', 'what', 'when', 'where', 'which',
+  'while', 'will', 'with', 'within', 'would',
+]);
 
 // Retention for the persistent working ledger (#5067). A resolved entry only
 // leaves the hot `forecast:resolutions:v1` value once it is (a) durably archived
@@ -60,6 +74,526 @@ export function processResolutionCycle(existingLedger, historySnapshots, feedsBy
   const ledger = pruneArchivedTerminalEntries(ingested, nowMs);
   const scorecard = computeScorecard(ledger, nowMs);
   return { ledger, receipts, scorecard };
+}
+
+export async function processResolutionCycleWithJudges(existingLedger, historySnapshots, feedsByKey, newsArchive, nowMs, options = {}) {
+  const ingested = ingestHistory(existingLedger, historySnapshots, nowMs);
+  samplePendingEntries(ingested, feedsByKey, nowMs);
+  const receipts = resolveDueEntries(ingested, feedsByKey, nowMs);
+  receipts.push(...await resolvePendingJudgedEntries(ingested, newsArchive, nowMs, options));
+  const ledger = pruneArchivedTerminalEntries(ingested, nowMs);
+  const scorecard = computeScorecard(ledger, nowMs);
+  return { ledger, receipts, scorecard };
+}
+
+export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, options = {}) {
+  const receipts = [];
+  const maxEntries = Number.isFinite(options.maxJudgedEntries)
+    ? Math.max(0, Math.floor(options.maxJudgedEntries))
+    : Infinity;
+  const deadlineMs = Number.isFinite(options.deadlineMs) ? options.deadlineMs : Infinity;
+  let attempted = 0;
+
+  for (const [key, entry] of Object.entries(ledger)) {
+    if (entry?.status !== 'pending-judge') continue;
+    if (attempted >= maxEntries) break;
+    if (Date.now() + 1_000 > deadlineMs) break;
+
+    const result = await resolveJudgedEntry(entry, newsArchive, nowMs, options);
+    if (result.status === 'skip') continue;
+    attempted += 1;
+
+    if (result.status === 'pending') {
+      entry.judgeLastAttempt = {
+        at: nowMs,
+        reason: result.reason || 'judge_pending',
+        detail: result.detail || '',
+      };
+      continue;
+    }
+
+    entry.status = 'resolved';
+    entry.outcome = result.outcome;
+    entry.resolvedAt = nowMs;
+    entry.sealedAt = nowMs;
+    entry.evidence = result.evidence;
+    receipts.push({ key, entry: cloneJson(entry), resolvedAt: nowMs });
+  }
+
+  return receipts;
+}
+
+export async function resolveJudgedEntry(entry, newsArchive, nowMs, options = {}) {
+  const spec = entry?.spec || entry?.resolution;
+  if (!spec || spec.kind !== 'judged') return { status: 'skip' };
+
+  const deadline = Number(spec.deadline ?? entry.deadline);
+  if (!Number.isFinite(deadline)) {
+    return resolvedJudgedResult('VOID', 'missing_deadline', entry, [], [], nowMs);
+  }
+  if (nowMs < deadline) return { status: 'skip' };
+
+  const archiveInput = normalizeJudgedArchiveInput(newsArchive);
+  if (!archiveInput.available) {
+    return { status: 'pending', reason: 'archive_unavailable' };
+  }
+
+  const archiveItems = selectJudgedArchiveItems(entry, archiveInput.items, {
+    maxItems: options.maxArchiveItems ?? DEFAULT_JUDGED_ARCHIVE_ITEMS,
+  });
+  if (!archiveItems.length) {
+    if (!archiveCoversEntryWindow(entry, archiveInput, nowMs)) {
+      return { status: 'pending', reason: 'archive_unavailable', detail: 'archive_window_incomplete' };
+    }
+    return resolvedJudgedResult('VOID', 'no_archive_evidence', entry, [], [], nowMs);
+  }
+
+  const judgeModels = Array.isArray(options.judgeModels) && options.judgeModels.length >= 2
+    ? options.judgeModels.slice(0, 2)
+    : createLiveJudgeModels(options);
+  if (judgeModels.length < 2) {
+    return { status: 'pending', reason: 'judge_unavailable', detail: 'fewer_than_two_models' };
+  }
+
+  const settled = await Promise.allSettled(judgeModels.map((judge) => judge(entry, archiveItems, nowMs)));
+  const judgments = [];
+  for (const result of settled) {
+    if (result.status !== 'fulfilled') {
+      return { status: 'pending', reason: 'judge_unavailable', detail: result.reason?.message || String(result.reason || '') };
+    }
+    const normalized = normalizeJudgment(result.value, archiveItems);
+    if (!normalized) return { status: 'pending', reason: 'judge_unavailable', detail: 'invalid_judge_response' };
+    judgments.push(normalized);
+  }
+
+  const nonVoidOutcomes = judgments.map((judgment) => judgment.outcome).filter((outcome) => outcome !== 'VOID');
+  if (nonVoidOutcomes.length === judgments.length && new Set(nonVoidOutcomes).size === 1) {
+    return resolvedJudgedResult(nonVoidOutcomes[0], 'dual_model_agreement', entry, judgments, archiveItems, nowMs);
+  }
+  if (judgments.every((judgment) => judgment.outcome === 'VOID')) {
+    return resolvedJudgedResult('VOID', 'all_judges_void', entry, judgments, archiveItems, nowMs);
+  }
+  return resolvedJudgedResult('VOID', 'judge_disagreement', entry, judgments, archiveItems, nowMs);
+}
+
+export function selectJudgedArchiveItems(entry, archiveItems, options = {}) {
+  const maxItems = Number.isFinite(options.maxItems) ? Math.max(1, Math.floor(options.maxItems)) : DEFAULT_JUDGED_ARCHIVE_ITEMS;
+  const tokenPatterns = judgedQueryTokens(entry).map(buildTokenPattern);
+  return normalizeJudgedArchiveItems(archiveItems)
+    .map((item, index) => ({
+      ...item,
+      id: item.id || `N${index + 1}`,
+      relevance: scoreArchiveItem(item, tokenPatterns),
+    }))
+    .filter((item) => item.relevance > 0)
+    .sort((a, b) => b.relevance - a.relevance || Number(b.publishedAt || 0) - Number(a.publishedAt || 0))
+    .slice(0, maxItems)
+    .map((item, index) => pruneUndefined({
+      id: item.id || `N${index + 1}`,
+      title: item.title,
+      description: item.description,
+      url: item.url,
+      source: item.source,
+      publishedAt: item.publishedAt,
+      severity: item.severity,
+      relevance: item.relevance,
+    }));
+}
+
+function normalizeJudgedArchiveInput(newsArchive) {
+  if (Array.isArray(newsArchive)) {
+    return { items: normalizeJudgedArchiveItems(newsArchive), available: true };
+  }
+  if (!newsArchive || typeof newsArchive !== 'object') {
+    return { items: [], available: false };
+  }
+  if (newsArchive.available === false) {
+    return { items: [], available: false };
+  }
+  const items = newsArchive.items
+    ?? newsArchive.stories
+    ?? newsArchive.topStories
+    ?? newsArchive.articles
+    ?? newsArchive.data
+    ?? [];
+  return {
+    items: normalizeJudgedArchiveItems(items),
+    available: true,
+    truncated: Boolean(newsArchive.truncated || newsArchive.partial || newsArchive.coverageComplete === false),
+    coverageStartMs: toFiniteMs(newsArchive.coverageStartMs ?? newsArchive.windowStartMs ?? newsArchive.fromMs),
+    coverageEndMs: toFiniteMs(newsArchive.coverageEndMs ?? newsArchive.windowEndMs ?? newsArchive.toMs),
+  };
+}
+
+function normalizeJudgedArchiveItems(value) {
+  const rows = unwrapArchiveRows(value);
+  return rows
+    .map((row, index) => normalizeJudgedArchiveItem(row, index))
+    .filter(Boolean);
+}
+
+function unwrapArchiveRows(value) {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== 'object') return [];
+  return unwrapArchiveRows(
+    value.items
+      ?? value.stories
+      ?? value.topStories
+      ?? value.articles
+      ?? value.data
+      ?? [],
+  );
+}
+
+function normalizeJudgedArchiveItem(row, index) {
+  if (!row || typeof row !== 'object') return null;
+  const title = cleanString(row.title ?? row.headline ?? row.name);
+  const description = truncateText(cleanString(row.description ?? row.summary ?? row.text ?? row.body), 700);
+  if (!title && !description) return null;
+  return pruneUndefined({
+    id: cleanString(row.id ?? row.hash ?? row.titleHash ?? row.key) || `N${index + 1}`,
+    hash: cleanString(row.hash ?? row.titleHash),
+    title,
+    description,
+    url: cleanString(row.url ?? row.link ?? row.sourceUrl),
+    source: cleanString(row.source ?? row.publisher ?? row.feedName ?? row.domain),
+    publishedAt: toFiniteMs(row.publishedAt ?? row.pubDate ?? row.lastSeen ?? row.lastSeenAt ?? row.firstSeen),
+    severity: cleanString(row.severity),
+    currentScore: toFiniteNumber(row.currentScore ?? row.score),
+  });
+}
+
+function judgedQueryTokens(entry) {
+  const spec = entry?.spec || entry?.resolution || {};
+  const text = [
+    entry?.title,
+    entry?.domain,
+    entry?.region,
+    spec.question,
+  ].filter(Boolean).join(' ');
+  const rawTokens = text.toLowerCase().match(/[a-z0-9][a-z0-9-]{2,}/g) || [];
+  return [...new Set(rawTokens
+    .map((token) => token.replace(/^-+|-+$/g, ''))
+    .filter((token) => token.length >= 4)
+    .filter((token) => !JUDGED_TOKEN_STOPWORDS.has(token)))];
+}
+
+function scoreArchiveItem(item, tokenPatterns) {
+  if (!tokenPatterns.length) return 0;
+  const title = `${item.title || ''}`.toLowerCase();
+  const description = `${item.description || ''}`.toLowerCase();
+  const source = `${item.source || ''}`.toLowerCase();
+  let score = 0;
+  for (const pattern of tokenPatterns) {
+    if (textHasToken(title, pattern)) score += 3;
+    if (textHasToken(description, pattern)) score += 1;
+    if (textHasToken(source, pattern)) score += 0.25;
+  }
+  return score;
+}
+
+function archiveCoversEntryWindow(entry, archiveInput, nowMs) {
+  if (archiveInput.truncated) return false;
+  const coverageStartMs = Number(archiveInput.coverageStartMs);
+  const coverageEndMs = Number(archiveInput.coverageEndMs);
+  if (!Number.isFinite(coverageStartMs) && !Number.isFinite(coverageEndMs)) return true;
+  const { startMs, endMs } = judgedArchiveWindowForEntry(entry, nowMs);
+  return (!Number.isFinite(coverageStartMs) || coverageStartMs <= startMs)
+    && (!Number.isFinite(coverageEndMs) || coverageEndMs >= endMs);
+}
+
+function judgedArchiveWindowForEntry(entry, nowMs) {
+  const deadline = Number(entry?.deadline ?? entry?.spec?.deadline);
+  const candidates = [entry?.generatedAt, entry?.firstSeenAt, deadline, nowMs]
+    .map(Number)
+    .filter(Number.isFinite);
+  const anchor = candidates.length ? Math.min(...candidates) : nowMs;
+  return {
+    startMs: Math.max(0, anchor - JUDGED_ARCHIVE_LOOKBACK_PAD_MS),
+    endMs: nowMs,
+  };
+}
+
+function buildTokenPattern(token) {
+  return new RegExp(`(^|[^a-z0-9])${escapeRegExp(token)}([^a-z0-9]|$)`, 'i');
+}
+
+function textHasToken(text, pattern) {
+  return pattern.test(text);
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function createLiveJudgeModels(options = {}) {
+  const stageBudgetMs = envPositiveInt('FORECAST_RESOLUTION_JUDGE_STAGE_BUDGET_MS', 35_000);
+  const common = {
+    temperature: 0.1,
+    maxTokens: envPositiveInt('FORECAST_RESOLUTION_JUDGE_MAX_TOKENS', 700),
+    maxRetries: 0,
+    returnFailureReason: true,
+    stageBudgetMs: options.judgeStageBudgetMs ?? stageBudgetMs,
+  };
+  return [
+    (entry, archiveItems, nowMs) => callLiveJudgedModel(entry, archiveItems, nowMs, {
+      ...common,
+      stage: 'forecast_resolution_judge_openrouter',
+      providerOrder: ['openrouter'],
+      modelOverrides: {
+        openrouter: process.env.FORECAST_RESOLUTION_JUDGE_MODEL_OPENROUTER
+          || process.env.FORECAST_LLM_MODEL_OPENROUTER
+          || 'deepseek/deepseek-v4-flash',
+      },
+    }),
+    (entry, archiveItems, nowMs) => callLiveJudgedModel(entry, archiveItems, nowMs, {
+      ...common,
+      stage: 'forecast_resolution_judge_groq',
+      providerOrder: ['groq'],
+      modelOverrides: {
+        groq: process.env.FORECAST_RESOLUTION_JUDGE_MODEL_GROQ || 'llama-3.3-70b-versatile',
+      },
+    }),
+  ];
+}
+
+async function callLiveJudgedModel(entry, archiveItems, nowMs, options) {
+  const { systemPrompt, userPrompt } = buildJudgedResolutionPrompt(entry, archiveItems, nowMs);
+  const result = await callForecastLLM(systemPrompt, userPrompt, options);
+  if (!result?.text) return null;
+  return {
+    text: result.text,
+    provider: result.provider,
+    model: result.model,
+  };
+}
+
+function buildJudgedResolutionPrompt(entry, archiveItems, nowMs) {
+  const spec = entry?.spec || entry?.resolution || {};
+  const systemPrompt = [
+    'You resolve forecasts using only the provided news archive.',
+    'Return JSON only: {"outcome":"YES|NO|VOID","citations":[{"id":"N1","quote":"short evidence"}],"rationale":"short reason"}.',
+    'YES means the archive proves the forecast happened by the deadline.',
+    'NO means the archive proves it did not happen by the deadline.',
+    'VOID means the archive is insufficient, ambiguous, contradictory, or unrelated.',
+    'YES and NO require at least one valid citation id and quote/excerpt copied from that archive item. Never use outside knowledge.',
+  ].join('\n');
+  const archiveText = archiveItems.map((item) => [
+    `[${item.id}] ${new Date(item.publishedAt || nowMs).toISOString()}`,
+    item.source ? `source=${item.source}` : '',
+    item.title || '',
+    item.url ? `url=${item.url}` : '',
+    item.description ? `summary=${truncateText(item.description, 420)}` : '',
+  ].filter(Boolean).join(' | ')).join('\n');
+  const userPrompt = [
+    `Forecast: ${entry?.title || entry?.id || 'untitled forecast'}`,
+    `Domain: ${entry?.domain || 'unknown'}`,
+    `Region: ${entry?.region || 'global'}`,
+    `Question: ${spec.question || entry?.title || ''}`,
+    `Deadline: ${Number.isFinite(Number(spec.deadline ?? entry?.deadline)) ? new Date(Number(spec.deadline ?? entry?.deadline)).toISOString() : 'unknown'}`,
+    '',
+    'News archive:',
+    archiveText,
+  ].join('\n');
+  return { systemPrompt, userPrompt };
+}
+
+function normalizeJudgment(value, archiveItems) {
+  const raw = parseJudgmentPayload(value);
+  if (!raw || typeof raw !== 'object') return null;
+  const outcome = cleanString(raw.outcome ?? raw.result ?? raw.resolution).toUpperCase();
+  if (!['YES', 'NO', 'VOID'].includes(outcome)) return null;
+  const rawCitations = raw.citations ?? raw.evidence ?? raw.sources ?? [];
+  const citationRows = normalizeCitationRows(rawCitations);
+  const citations = normalizeJudgmentCitations(citationRows, archiveItems);
+  const base = pruneUndefined({
+    provider: cleanString(raw.provider),
+    model: cleanString(raw.model),
+    outcome,
+    citations,
+    rationale: truncateText(cleanString(raw.rationale ?? raw.reason ?? raw.explanation), 420),
+    reason: cleanString(raw.reasonCode ?? raw.reason),
+  });
+  if ((outcome === 'YES' || outcome === 'NO') && citations.length === 0) {
+    return { ...base, outcome: 'VOID', reason: citationRows.length ? 'invalid_citations' : 'missing_citations' };
+  }
+  return base;
+}
+
+function parseJudgmentPayload(value) {
+  if (!value) return null;
+  if (typeof value === 'object' && !value.text) return value;
+  const text = typeof value === 'string' ? value : value.text;
+  if (typeof text !== 'string' || !text.trim()) return null;
+  const parsed = parseJsonObject(text);
+  if (!parsed) return null;
+  if (typeof value === 'object') {
+    return {
+      ...parsed,
+      provider: parsed.provider ?? value.provider,
+      model: parsed.model ?? value.model,
+    };
+  }
+  return parsed;
+}
+
+function parseJsonObject(text) {
+  const trimmed = text.trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '')
+    .trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {}
+  try {
+    return JSON.parse(cleanJudgmentJson(trimmed));
+  } catch {}
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+  try {
+    return JSON.parse(trimmed.slice(start, end + 1));
+  } catch {}
+  try {
+    return JSON.parse(cleanJudgmentJson(trimmed.slice(start, end + 1)));
+  } catch {
+    return null;
+  }
+}
+
+function cleanJudgmentJson(text) {
+  return text.replace(/,(\s*[}\]])/g, '$1');
+}
+
+function normalizeCitationRows(rawCitations) {
+  return Array.isArray(rawCitations) ? rawCitations : [rawCitations].filter(Boolean);
+}
+
+function normalizeJudgmentCitations(citationRows, archiveItems) {
+  const byId = new Map(archiveItems.map((item) => [item.id, item]));
+  const citations = [];
+  const seen = new Set();
+  for (const citation of citationRows) {
+    const rawId = typeof citation === 'object'
+      ? citation.id ?? citation.sourceId ?? citation.articleId ?? citation.citationId ?? citation.n
+      : citation;
+    const id = normalizeCitationId(rawId);
+    const item = byId.get(id);
+    if (!item || seen.has(id)) continue;
+    const quote = truncateText(cleanString(citation?.quote ?? citation?.excerpt), 240);
+    if (!quote || !citationQuoteMatchesItem(quote, item)) continue;
+    seen.add(id);
+    citations.push(pruneUndefined({
+      id,
+      title: item.title,
+      url: item.url,
+      publishedAt: item.publishedAt,
+      quote,
+    }));
+  }
+  return citations;
+}
+
+function citationQuoteMatchesItem(quote, item) {
+  const quoteText = normalizeCitationText(quote);
+  const itemText = normalizeCitationText([item.title, item.description].filter(Boolean).join(' '));
+  if (!quoteText || !itemText) return false;
+  if (itemText.includes(quoteText)) return true;
+  const quoteTokens = quoteText.match(/[a-z0-9]{4,}/g) || [];
+  if (quoteTokens.length < 3) return false;
+  const matched = quoteTokens.filter((token) => itemText.includes(token)).length;
+  return matched / quoteTokens.length >= 0.8;
+}
+
+function normalizeCitationText(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function normalizeCitationId(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return `N${Math.floor(value)}`;
+  const text = cleanString(value);
+  if (/^\d+$/.test(text)) return `N${text}`;
+  const match = text.match(/^N?\s*(\d+)$/i);
+  if (match) return `N${match[1]}`;
+  return text;
+}
+
+function resolvedJudgedResult(outcome, reason, entry, judgments, archiveItems, nowMs) {
+  const spec = entry?.spec || entry?.resolution || {};
+  return {
+    status: 'resolved',
+    outcome,
+    evidence: pruneUndefined({
+      kind: 'judged',
+      reason,
+      resolvedAt: nowMs,
+      question: spec.question,
+      deadline: Number.isFinite(Number(spec.deadline ?? entry?.deadline)) ? Number(spec.deadline ?? entry?.deadline) : undefined,
+      judgedBy: judgments.map((judgment) => pruneUndefined({
+        provider: judgment.provider,
+        model: judgment.model,
+        outcome: judgment.outcome,
+        reason: judgment.reason,
+      })),
+      judgments: judgments.map((judgment) => pruneUndefined({
+        provider: judgment.provider,
+        model: judgment.model,
+        outcome: judgment.outcome,
+        reason: judgment.reason,
+        rationale: judgment.rationale,
+        citations: judgment.citations,
+      })),
+      citations: mergeJudgmentCitations(judgments),
+      archive: archiveItems.map((item) => pruneUndefined({
+        id: item.id,
+        title: item.title,
+        url: item.url,
+        source: item.source,
+        publishedAt: item.publishedAt,
+      })),
+    }),
+  };
+}
+
+function mergeJudgmentCitations(judgments) {
+  const merged = [];
+  const seen = new Set();
+  for (const judgment of judgments) {
+    for (const citation of judgment.citations || []) {
+      if (seen.has(citation.id)) continue;
+      seen.add(citation.id);
+      merged.push(citation);
+    }
+  }
+  return merged;
+}
+
+function cleanString(value) {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+function truncateText(value, maxLength) {
+  const text = cleanString(value);
+  if (!text || text.length <= maxLength) return text;
+  return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}...`;
+}
+
+function toFiniteMs(value) {
+  if (value == null || value === '') return undefined;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric > 0 && numeric < 1_000_000_000_000 ? numeric * 1000 : numeric;
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toFiniteNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function envPositiveInt(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
 }
 
 // Terminal entries whose receipt is safely in R2 and that have aged past the
@@ -317,6 +851,100 @@ async function readResolutionFeeds(ledger) {
   return Object.fromEntries(pairs);
 }
 
+async function readJudgedNewsArchiveForLedger(ledger, nowMs, options = {}) {
+  const dueEntries = Object.values(normalizeLedger(ledger))
+    .filter((entry) => entry?.status === 'pending-judge')
+    .filter((entry) => Number(entry.deadline ?? entry.spec?.deadline) <= nowMs);
+  if (!dueEntries.length) return { items: [], available: false };
+
+  const windowStartMs = Math.min(...dueEntries.map((entry) => judgedArchiveWindowForEntry(entry, nowMs).startMs));
+  try {
+    return await readDigestAccumulatorArchive(windowStartMs, nowMs, options);
+  } catch (err) {
+    console.warn(`  [forecast-resolutions] judged archive unavailable: ${err?.message || err}`);
+    return { items: [], available: false };
+  }
+}
+
+export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options = {}) {
+  const { url, token } = getRedisCredentials();
+  const coverageStartMs = Math.max(windowStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
+  const base = {
+    requestedStartMs: windowStartMs,
+    requestedEndMs: nowMs,
+    coverageStartMs,
+    coverageEndMs: nowMs,
+  };
+  const zsetResp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+    body: JSON.stringify(['ZRANGEBYSCORE', JUDGED_ARCHIVE_KEY, String(windowStartMs), String(nowMs)]),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!zsetResp.ok) throw new Error(`Redis ZRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} failed: HTTP ${zsetResp.status}`);
+  const zsetPayload = await zsetResp.json();
+  const hashes = Array.isArray(zsetPayload.result) ? zsetPayload.result.filter(Boolean) : [];
+  if (!hashes.length) return { ...base, items: [], available: true };
+
+  const maxHashes = Number.isFinite(options.maxHashes)
+    ? Math.max(1, Math.floor(options.maxHashes))
+    : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', 300);
+  const selectedHashes = hashes.slice(-maxHashes);
+  const truncated = selectedHashes.length < hashes.length;
+  const pipelineResp = await fetch(`${url}/pipeline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+    body: JSON.stringify(selectedHashes.map((hash) => ['HGETALL', `story:track:v1:${hash}`])),
+    signal: AbortSignal.timeout(options.archiveTimeoutMs ?? 15_000),
+  });
+  if (!pipelineResp.ok) throw new Error(`Redis story-track pipeline failed: HTTP ${pipelineResp.status}`);
+  const pipelinePayload = await pipelineResp.json();
+  if (!Array.isArray(pipelinePayload) || pipelinePayload.length !== selectedHashes.length) {
+    throw new Error(`Redis story-track pipeline returned ${Array.isArray(pipelinePayload) ? pipelinePayload.length : 'non-array'} of ${selectedHashes.length}`);
+  }
+  const rows = pipelinePayload;
+  const items = [];
+  for (let index = 0; index < selectedHashes.length; index += 1) {
+    if (rows[index]?.error) {
+      throw new Error(`Redis story-track pipeline row ${index} failed: ${rows[index].error}`);
+    }
+    const raw = rows[index]?.result;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      throw new Error(`Redis story-track pipeline row ${index} returned invalid HGETALL result`);
+    }
+    const track = flatArrayToObject(raw);
+    items.push(pruneUndefined({
+      id: `N${items.length + 1}`,
+      hash: selectedHashes[index],
+      title: track.title,
+      description: track.description,
+      url: track.link || track.url,
+      source: track.source || track.publisher || track.domain,
+      publishedAt: toFiniteMs(track.publishedAt ?? track.lastSeen ?? track.firstSeen),
+      severity: track.severity,
+      currentScore: toFiniteNumber(track.currentScore ?? track.score),
+    }));
+  }
+  return { ...base, items: normalizeJudgedArchiveItems(items), available: true, truncated };
+}
+
+function flatArrayToObject(flat) {
+  const obj = {};
+  for (let i = 0; i + 1 < flat.length; i += 2) {
+    obj[flat[i]] = flat[i + 1];
+  }
+  return obj;
+}
+
+function buildLiveJudgedOptions(nowMs = Date.now()) {
+  return {
+    maxJudgedEntries: envPositiveInt('FORECAST_RESOLUTION_JUDGE_MAX_PER_RUN', DEFAULT_JUDGED_MAX_PER_RUN),
+    maxArchiveItems: envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_ITEMS', DEFAULT_JUDGED_ARCHIVE_ITEMS),
+    judgeStageBudgetMs: envPositiveInt('FORECAST_RESOLUTION_JUDGE_STAGE_BUDGET_MS', 35_000),
+    deadlineMs: nowMs + envPositiveInt('FORECAST_RESOLUTION_JUDGE_RUN_BUDGET_MS', DEFAULT_JUDGED_RUN_BUDGET_MS),
+  };
+}
+
 async function buildLedgerForRun() {
   const nowMs = Date.now();
   const [existingLedger, history] = await Promise.all([
@@ -325,7 +953,9 @@ async function buildLedgerForRun() {
   ]);
   const preLedger = ingestHistory(existingLedger || {}, history, nowMs);
   const feeds = await readResolutionFeeds(preLedger);
-  const result = processResolutionCycle(preLedger, [], feeds, nowMs);
+  const judgedOptions = buildLiveJudgedOptions(nowMs);
+  const judgedArchive = await readJudgedNewsArchiveForLedger(preLedger, nowMs, judgedOptions);
+  const result = await processResolutionCycleWithJudges(preLedger, [], feeds, judgedArchive, nowMs, judgedOptions);
   const receiptsForArchive = collectUnarchivedReceipts(result.ledger);
   const archivedReceipts = await appendR2Receipts(receiptsForArchive);
   markReceiptsArchived(result.ledger, archivedReceipts, Date.now());
@@ -397,7 +1027,8 @@ if (DIRECT_RUN && process.argv.includes('--dry-run')) {
     schemaVersion: RESOLUTION_SCHEMA_VERSION,
     zeroIsValid: true,
     maxStaleMin: 2160,
-    fetchPhaseTimeoutMs: 90_000,
+    lockTtlMs: 180_000,
+    fetchPhaseTimeoutMs: 150_000,
     extraKeys: [{
       key: SCORECARD_KEY,
       ttl: SCORECARD_TTL_SECONDS,

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -2,9 +2,11 @@
 
 // Daily forecast resolution seeder for Bet 2 (#5007).
 //
-// The exported helpers are pure/testable; the direct-run block is the Railway
-// worker shell that reads the forecast history intake, persists the working
-// ledger, writes the scorecard, and appends terminal receipts to R2.
+// Pure exported helpers cover ledger ingest, hard resolution, scorecards, and
+// pruning. Exported live-I/O helpers take options/test doubles so tests can use
+// them without invoking Redis or LLM providers. The direct-run block is the
+// Railway worker shell that reads the forecast history intake, persists the
+// working ledger, writes the scorecard, and appends terminal receipts to R2.
 //
 // Railway service config (set up manually via Railway dashboard or
 // `railway service`):
@@ -12,7 +14,7 @@
 //   - Start command: node scripts/seed-forecast-resolutions.mjs
 //   - Cron: daily
 
-import { CHROME_UA, getRedisCredentials, loadEnvFile, runSeed } from './_seed-utils.mjs';
+import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
 import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
@@ -33,6 +35,7 @@ export const JUDGED_ARCHIVE_LOOKBACK_PAD_MS = 6 * 60 * 60 * 1000;
 export const DEFAULT_JUDGED_ARCHIVE_ITEMS = 16;
 export const DEFAULT_JUDGED_MAX_PER_RUN = 12;
 export const DEFAULT_JUDGED_RUN_BUDGET_MS = 110_000;
+const DEFAULT_MIN_JUDGED_STAGE_BUDGET_MS = 5_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const JUDGED_TOKEN_STOPWORDS = new Set([
   'about', 'above', 'after', 'again', 'against', 'before', 'being', 'below',
@@ -92,14 +95,28 @@ export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, op
     ? Math.max(0, Math.floor(options.maxJudgedEntries))
     : Infinity;
   const deadlineMs = Number.isFinite(options.deadlineMs) ? options.deadlineMs : Infinity;
+  const judgeStageBudgetMs = Number.isFinite(options.judgeStageBudgetMs)
+    ? Math.max(0, Math.floor(options.judgeStageBudgetMs))
+    : envPositiveInt('FORECAST_RESOLUTION_JUDGE_STAGE_BUDGET_MS', 35_000);
+  const minJudgeStageBudgetMs = Number.isFinite(options.minJudgeStageBudgetMs)
+    ? Math.max(0, Math.floor(options.minJudgeStageBudgetMs))
+    : Math.min(DEFAULT_MIN_JUDGED_STAGE_BUDGET_MS, judgeStageBudgetMs);
   let attempted = 0;
 
   for (const [key, entry] of Object.entries(ledger)) {
     if (entry?.status !== 'pending-judge') continue;
     if (attempted >= maxEntries) break;
-    if (Date.now() + 1_000 > deadlineMs) break;
+    let entryOptions = options;
+    if (Number.isFinite(deadlineMs)) {
+      const remainingBudgetMs = deadlineMs - Date.now() - 1_000;
+      if (remainingBudgetMs < minJudgeStageBudgetMs) break;
+      entryOptions = {
+        ...options,
+        judgeStageBudgetMs: Math.min(judgeStageBudgetMs, remainingBudgetMs),
+      };
+    }
 
-    const result = await resolveJudgedEntry(entry, newsArchive, nowMs, options);
+    const result = await resolveJudgedEntry(entry, newsArchive, nowMs, entryOptions);
     if (result.status === 'skip') continue;
     attempted += 1;
 
@@ -141,14 +158,18 @@ export async function resolveJudgedEntry(entry, newsArchive, nowMs, options = {}
   const archiveItems = selectJudgedArchiveItems(entry, archiveInput.items, {
     maxItems: options.maxArchiveItems ?? DEFAULT_JUDGED_ARCHIVE_ITEMS,
   });
+  const archiveComplete = archiveCoversEntryWindow(entry, archiveInput, nowMs);
   if (!archiveItems.length) {
-    if (!archiveCoversEntryWindow(entry, archiveInput, nowMs)) {
+    if (!archiveComplete) {
       return { status: 'pending', reason: 'archive_unavailable', detail: 'archive_window_incomplete' };
     }
     return resolvedJudgedResult('VOID', 'no_archive_evidence', entry, [], [], nowMs);
   }
 
-  const judgeModels = Array.isArray(options.judgeModels) && options.judgeModels.length >= 2
+  if (Array.isArray(options.judgeModels) && options.judgeModels.length < 2) {
+    return { status: 'pending', reason: 'judge_unavailable', detail: 'fewer_than_two_models' };
+  }
+  const judgeModels = Array.isArray(options.judgeModels)
     ? options.judgeModels.slice(0, 2)
     : createLiveJudgeModels(options);
   if (judgeModels.length < 2) {
@@ -169,6 +190,9 @@ export async function resolveJudgedEntry(entry, newsArchive, nowMs, options = {}
   const nonVoidOutcomes = judgments.map((judgment) => judgment.outcome).filter((outcome) => outcome !== 'VOID');
   if (nonVoidOutcomes.length === judgments.length && new Set(nonVoidOutcomes).size === 1) {
     return resolvedJudgedResult(nonVoidOutcomes[0], 'dual_model_agreement', entry, judgments, archiveItems, nowMs);
+  }
+  if (!archiveComplete) {
+    return { status: 'pending', reason: 'archive_unavailable', detail: 'archive_window_incomplete' };
   }
   if (judgments.every((judgment) => judgment.outcome === 'VOID')) {
     return resolvedJudgedResult('VOID', 'all_judges_void', entry, judgments, archiveItems, nowMs);
@@ -867,8 +891,11 @@ async function readJudgedNewsArchiveForLedger(ledger, nowMs, options = {}) {
 }
 
 export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options = {}) {
-  const { url, token } = getRedisCredentials();
+  const { url, token } = getArchiveRedisCredentials(options);
   const coverageStartMs = Math.max(windowStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
+  const maxHashes = Number.isFinite(options.maxHashes)
+    ? Math.max(1, Math.floor(options.maxHashes))
+    : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', 300);
   const base = {
     requestedStartMs: windowStartMs,
     requestedEndMs: nowMs,
@@ -878,19 +905,24 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   const zsetResp = await fetch(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify(['ZRANGEBYSCORE', JUDGED_ARCHIVE_KEY, String(windowStartMs), String(nowMs)]),
+    body: JSON.stringify([
+      'ZREVRANGEBYSCORE',
+      JUDGED_ARCHIVE_KEY,
+      String(nowMs),
+      String(coverageStartMs),
+      'LIMIT',
+      '0',
+      String(maxHashes),
+    ]),
     signal: AbortSignal.timeout(10_000),
   });
-  if (!zsetResp.ok) throw new Error(`Redis ZRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} failed: HTTP ${zsetResp.status}`);
+  if (!zsetResp.ok) throw new Error(`Redis ZREVRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} failed: HTTP ${zsetResp.status}`);
   const zsetPayload = await zsetResp.json();
   const hashes = Array.isArray(zsetPayload.result) ? zsetPayload.result.filter(Boolean) : [];
   if (!hashes.length) return { ...base, items: [], available: true };
 
-  const maxHashes = Number.isFinite(options.maxHashes)
-    ? Math.max(1, Math.floor(options.maxHashes))
-    : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', 300);
-  const selectedHashes = hashes.slice(-maxHashes);
-  const truncated = selectedHashes.length < hashes.length;
+  const selectedHashes = hashes.slice(0, maxHashes);
+  const truncated = hashes.length >= maxHashes;
   const pipelineResp = await fetch(`${url}/pipeline`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
@@ -904,15 +936,21 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   }
   const rows = pipelinePayload;
   const items = [];
+  let missingRows = 0;
   for (let index = 0; index < selectedHashes.length; index += 1) {
     if (rows[index]?.error) {
       throw new Error(`Redis story-track pipeline row ${index} failed: ${rows[index].error}`);
     }
     const raw = rows[index]?.result;
-    if (!Array.isArray(raw) || raw.length === 0) {
+    const flat = normalizeRedisHashResult(raw);
+    if (!flat) {
       throw new Error(`Redis story-track pipeline row ${index} returned invalid HGETALL result`);
     }
-    const track = flatArrayToObject(raw);
+    if (flat.length === 0) {
+      missingRows += 1;
+      continue;
+    }
+    const track = flatArrayToObject(flat);
     items.push(pruneUndefined({
       id: `N${items.length + 1}`,
       hash: selectedHashes[index],
@@ -925,7 +963,21 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
       currentScore: toFiniteNumber(track.currentScore ?? track.score),
     }));
   }
-  return { ...base, items: normalizeJudgedArchiveItems(items), available: true, truncated };
+  return { ...base, items: normalizeJudgedArchiveItems(items), available: true, truncated: truncated || missingRows > 0, missingRows };
+}
+
+function getArchiveRedisCredentials(options = {}) {
+  const env = options.env || process.env;
+  const url = options.redisUrl || env.UPSTASH_REDIS_REST_URL;
+  const token = options.redisToken || env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) throw new Error('Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN');
+  return { url, token };
+}
+
+function normalizeRedisHashResult(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (raw && typeof raw === 'object') return Object.entries(raw).flat();
+  return null;
 }
 
 function flatArrayToObject(flat) {
@@ -974,10 +1026,20 @@ async function dryRun() {
   ]);
   const preLedger = ingestHistory(existingLedger || {}, history, nowMs);
   const feeds = await readResolutionFeeds(preLedger);
-  const result = processResolutionCycle(preLedger, [], feeds, nowMs);
+  const judgedOptions = buildLiveJudgedOptions(nowMs);
+  const judgedArchive = await readJudgedNewsArchiveForLedger(preLedger, nowMs, judgedOptions);
+  const dryRunJudgeModels = [
+    async () => null,
+    async () => null,
+  ];
+  const result = await processResolutionCycleWithJudges(preLedger, [], feeds, judgedArchive, nowMs, {
+    ...judgedOptions,
+    judgeModels: dryRunJudgeModels,
+  });
   const entries = Object.values(result.ledger);
   const summary = {
     dryRun: true,
+    judgedMode: 'no-llm',
     historySnapshots: history.length,
     ledgerEntries: entries.length,
     pending: entries.filter((entry) => entry.status === 'pending').length,

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from 'node:fs';
 import { afterEach, describe, it } from 'node:test';
 
 import {
+  DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT,
+  DEFAULT_JUDGED_MAX_PENDING_AGE_MS,
+  DEFAULT_JUDGED_MAX_PENDING_ATTEMPTS,
   JUDGED_ARCHIVE_KEY,
   JUDGED_ARCHIVE_RETENTION_MS,
   RESOLUTIONS_KEY,
@@ -667,6 +670,56 @@ describe('processResolutionCycleWithJudges', () => {
     assert.equal(judgeCalls, 2);
   });
 
+  it('rotates judged backlog by oldest attempt instead of fixed key order', async () => {
+    const deadline = T0 + DAY_MS;
+    const { ledger } = processResolutionCycle({}, [snapshot(T0, [
+      judgedForecast({ id: 'a-recent' }),
+      judgedForecast({ id: 'b-old' }),
+    ])], {}, T0);
+    ledger[`a-recent@${deadline}`].judgeAttempts = 3;
+    ledger[`a-recent@${deadline}`].judgeLastAttempt = { at: T0 + 12 * 60 * 60 * 1000, reason: 'archive_unavailable' };
+    ledger[`b-old@${deadline}`].judgeAttempts = 3;
+    ledger[`b-old@${deadline}`].judgeLastAttempt = { at: T0 + 60 * 60 * 1000, reason: 'archive_unavailable' };
+
+    const result = await processResolutionCycleWithJudges(ledger, [], {}, archive, T0 + DAY_MS + 2, {
+      maxJudgedEntries: 1,
+      maxJudgedPendingAttempts: 99,
+      judgeModels: [
+        async () => ({ outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }] }),
+        async () => ({ outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }] }),
+      ],
+    });
+
+    assert.equal(result.ledger[`a-recent@${deadline}`].status, 'pending-judge');
+    assert.equal(result.ledger[`b-old@${deadline}`].status, 'resolved');
+    assert.equal(result.receipts[0].key, `b-old@${deadline}`);
+  });
+
+  it('voids old judged entries after retry attempts are exhausted', async () => {
+    const deadline = T0 + DAY_MS;
+    const { ledger } = processResolutionCycle({}, [snapshot(T0, [judgedForecast({ id: 'stuck-judge' })])], {}, T0);
+    const key = `stuck-judge@${deadline}`;
+    ledger[key].judgeAttempts = 1;
+    ledger[key].judgeLastAttempt = { at: deadline + 1, reason: 'archive_unavailable' };
+
+    const result = await processResolutionCycleWithJudges(ledger, [], {}, { available: false }, deadline + 2 * DAY_MS, {
+      maxJudgedPendingAttempts: 2,
+      maxJudgedPendingAgeMs: DAY_MS,
+    });
+
+    const row = result.ledger[key];
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'VOID');
+    assert.equal(row.judgeAttempts, 2);
+    assert.equal(row.evidence.reason, 'judge_retry_exhausted');
+    assert.equal(row.evidence.attempts, 2);
+    assert.equal(row.evidence.maxAttempts, 2);
+    assert.equal(row.evidence.maxAgeMs, DAY_MS);
+    assert.equal(row.evidence.lastAttemptReason, 'archive_unavailable');
+    assert.equal(result.receipts.length, 1);
+    assert.equal(result.scorecard.totals.void, 1);
+  });
+
   it('does not start judge calls when the remaining run budget is below the admission floor', async () => {
     const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
       deadlineMs: Date.now() + 2_000,
@@ -686,6 +739,9 @@ describe('processResolutionCycleWithJudges', () => {
   it('marks capped archive reads as truncated instead of complete', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
     globalThis.fetch = async (url, init) => {
       if (String(url).endsWith('/pipeline')) {
         const commands = JSON.parse(init.body);
@@ -702,9 +758,14 @@ describe('processResolutionCycleWithJudges', () => {
       };
     };
 
-    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS, { maxHashes: 1 });
-    assert.equal(archive.truncated, true);
-    assert.equal(archive.items.length, 1);
+    try {
+      const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS, { maxHashes: 1 });
+      assert.equal(archive.truncated, true);
+      assert.equal(archive.items.length, 1);
+      assert.ok(warnings.some((line) => line.includes('judged archive hash cap reached')));
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });
 
@@ -727,11 +788,34 @@ describe('readDigestAccumulatorArchive', () => {
     }
   });
 
+  it('uses a production-sized default archive hash limit', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    let zsetCommand;
+    globalThis.fetch = async (_url, init) => {
+      zsetCommand = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => ({ result: [] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
+
+    assert.ok(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT >= 2_500);
+    assert.equal(zsetCommand.at(-1), String(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT));
+    assert.equal(archive.truncated, undefined);
+    assert.equal(archive.items.length, 0);
+  });
+
   it('bounds the Redis archive query to the retention floor and hash limit', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
     let zsetCommand;
     let pipelineCommands;
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
     const nowMs = T0 + 5 * DAY_MS;
     globalThis.fetch = async (url, init) => {
       if (String(url).endsWith('/pipeline')) {
@@ -750,24 +834,29 @@ describe('readDigestAccumulatorArchive', () => {
       };
     };
 
-    const archive = await readDigestAccumulatorArchive(T0 - 30 * DAY_MS, nowMs, { maxHashes: 2 });
+    try {
+      const archive = await readDigestAccumulatorArchive(T0 - 30 * DAY_MS, nowMs, { maxHashes: 2 });
 
-    assert.deepEqual(zsetCommand, [
-      'ZREVRANGEBYSCORE',
-      JUDGED_ARCHIVE_KEY,
-      String(nowMs),
-      String(nowMs - JUDGED_ARCHIVE_RETENTION_MS),
-      'LIMIT',
-      '0',
-      '2',
-    ]);
-    assert.deepEqual(pipelineCommands.map(([, key]) => key), [
-      'story:track:v1:new-hash',
-      'story:track:v1:old-hash',
-    ]);
-    assert.equal(archive.coverageStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
-    assert.equal(archive.items.length, 2);
-    assert.equal(archive.truncated, true);
+      assert.deepEqual(zsetCommand, [
+        'ZREVRANGEBYSCORE',
+        JUDGED_ARCHIVE_KEY,
+        String(nowMs),
+        String(nowMs - JUDGED_ARCHIVE_RETENTION_MS),
+        'LIMIT',
+        '0',
+        '2',
+      ]);
+      assert.deepEqual(pipelineCommands.map(([, key]) => key), [
+        'story:track:v1:new-hash',
+        'story:track:v1:old-hash',
+      ]);
+      assert.equal(archive.coverageStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
+      assert.equal(archive.items.length, 2);
+      assert.equal(archive.truncated, true);
+      assert.ok(warnings.some((line) => line.includes('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT')));
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   it('normalizes object-shaped HGETALL rows', async () => {
@@ -909,6 +998,8 @@ describe('appendSample and seed contract', () => {
     assert.equal(RESOLUTIONS_KEY, 'forecast:resolutions:v1');
     assert.equal(SCORECARD_KEY, 'forecast:scorecard:v1');
     assert.equal(SCORECARD_META_KEY, 'seed-meta:forecast:scorecard');
+    assert.equal(DEFAULT_JUDGED_MAX_PENDING_ATTEMPTS, 14);
+    assert.equal(DEFAULT_JUDGED_MAX_PENDING_AGE_MS, 14 * DAY_MS);
     assert.equal(declareRecords({ a: {}, b: {} }), 2);
   });
 

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -1,7 +1,10 @@
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 import { afterEach, describe, it } from 'node:test';
 
 import {
+  JUDGED_ARCHIVE_KEY,
+  JUDGED_ARCHIVE_RETENTION_MS,
   RESOLUTIONS_KEY,
   SCORECARD_META_KEY,
   SCORECARD_KEY,
@@ -20,6 +23,7 @@ import { computeScorecard } from '../scripts/_forecast-scorecard.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const T0 = Date.parse('2026-07-07T00:00:00Z');
+const SEEDER_SOURCE = readFileSync(new URL('../scripts/seed-forecast-resolutions.mjs', import.meta.url), 'utf8');
 const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_REDIS_ENV = {
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
@@ -400,6 +404,27 @@ describe('processResolutionCycleWithJudges', () => {
     assert.equal(result.receipts.length, 0);
   });
 
+  it('keeps weak judge outcomes pending when matching evidence comes from an incomplete archive', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, {
+      available: true,
+      coverageStartMs: T0 + DAY_MS,
+      coverageEndMs: T0 + DAY_MS + 2,
+      items: archive,
+    }, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash', outcome: 'VOID', citations: [], rationale: 'Archive is insufficient.' }),
+        async () => ({ provider: 'groq', model: 'llama-3.3-70b-versatile', outcome: 'VOID', citations: [], rationale: 'Not enough coverage.' }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.outcome, undefined);
+    assert.equal(row.judgeLastAttempt.reason, 'archive_unavailable');
+    assert.equal(row.judgeLastAttempt.detail, 'archive_window_incomplete');
+    assert.equal(result.receipts.length, 0);
+  });
+
   it('resolves YES/NO judge agreement to VOID when citations lack matching excerpts', async () => {
     const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
       judgeModels: [
@@ -432,6 +457,78 @@ describe('processResolutionCycleWithJudges', () => {
     assert.equal(result.receipts.length, 0);
   });
 
+  it('does not fall back to live judges when an injected judge list is incomplete', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash', outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The article says it passed.' }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.outcome, undefined);
+    assert.equal(row.judgeLastAttempt.reason, 'judge_unavailable');
+    assert.equal(row.judgeLastAttempt.detail, 'fewer_than_two_models');
+    assert.equal(result.receipts.length, 0);
+  });
+
+  it('keeps the entry pending when a judge returns unparseable text', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash', outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The article says it passed.' }),
+        async () => ({ provider: 'groq', model: 'llama-3.3-70b-versatile', text: 'not-json' }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.judgeLastAttempt.reason, 'judge_unavailable');
+    assert.equal(row.judgeLastAttempt.detail, 'invalid_judge_response');
+    assert.equal(result.receipts.length, 0);
+  });
+
+  it('caps judged attempts per run', async () => {
+    let judgeCalls = 0;
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [
+      judgedForecast({ id: 'fc-judge-1' }),
+      judgedForecast({ id: 'fc-judge-2' }),
+    ])], {}, archive, T0 + DAY_MS + 2, {
+      maxJudgedEntries: 1,
+      judgeModels: [
+        async () => {
+          judgeCalls += 1;
+          return { outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }] };
+        },
+        async () => {
+          judgeCalls += 1;
+          return { outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }] };
+        },
+      ],
+    });
+
+    const rows = Object.values(result.ledger);
+    assert.equal(rows.filter((row) => row.status === 'resolved').length, 1);
+    assert.equal(rows.filter((row) => row.status === 'pending-judge').length, 1);
+    assert.equal(result.receipts.length, 1);
+    assert.equal(judgeCalls, 2);
+  });
+
+  it('does not start judge calls when the remaining run budget is below the admission floor', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      deadlineMs: Date.now() + 2_000,
+      minJudgeStageBudgetMs: 5_000,
+      judgeModels: [
+        async () => { throw new Error('judge should not start when the run budget is exhausted'); },
+        async () => { throw new Error('judge should not start when the run budget is exhausted'); },
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.judgeLastAttempt, undefined);
+    assert.equal(result.receipts.length, 0);
+  });
+
   it('marks capped archive reads as truncated instead of complete', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
@@ -458,6 +555,163 @@ describe('processResolutionCycleWithJudges', () => {
 });
 
 describe('readDigestAccumulatorArchive', () => {
+  it('rejects missing Redis credentials without exiting the process', async () => {
+    const originalExit = process.exit;
+    let exitCalled = false;
+    process.exit = (() => {
+      exitCalled = true;
+      throw new Error('process.exit should not be called');
+    });
+    try {
+      await assert.rejects(
+        readDigestAccumulatorArchive(T0, T0 + DAY_MS, { env: {} }),
+        /Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN/,
+      );
+      assert.equal(exitCalled, false);
+    } finally {
+      process.exit = originalExit;
+    }
+  });
+
+  it('bounds the Redis archive query to the retention floor and hash limit', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    let zsetCommand;
+    let pipelineCommands;
+    const nowMs = T0 + 5 * DAY_MS;
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/pipeline')) {
+        pipelineCommands = JSON.parse(init.body);
+        return {
+          ok: true,
+          json: async () => pipelineCommands.map(([, key]) => ({
+            result: ['title', `Story ${key}`, 'description', 'Policy change context', 'publishedAt', String(T0 + 1)],
+          })),
+        };
+      }
+      zsetCommand = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => ({ result: ['new-hash', 'old-hash', 'extra-hash'] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0 - 30 * DAY_MS, nowMs, { maxHashes: 2 });
+
+    assert.deepEqual(zsetCommand, [
+      'ZREVRANGEBYSCORE',
+      JUDGED_ARCHIVE_KEY,
+      String(nowMs),
+      String(nowMs - JUDGED_ARCHIVE_RETENTION_MS),
+      'LIMIT',
+      '0',
+      '2',
+    ]);
+    assert.deepEqual(pipelineCommands.map(([, key]) => key), [
+      'story:track:v1:new-hash',
+      'story:track:v1:old-hash',
+    ]);
+    assert.equal(archive.coverageStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
+    assert.equal(archive.items.length, 2);
+    assert.equal(archive.truncated, true);
+  });
+
+  it('normalizes object-shaped HGETALL rows', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/pipeline')) {
+        return {
+          ok: true,
+          json: async () => [{
+            result: {
+              title: 'Policy change passes',
+              description: 'The bill passed.',
+              publishedAt: String(T0 + 1),
+            },
+          }],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['hash-1'] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS, { maxHashes: 2 });
+
+    assert.equal(archive.items.length, 1);
+    assert.equal(archive.items[0].hash, 'hash-1');
+    assert.equal(archive.items[0].title, 'Policy change passes');
+  });
+
+  it('skips missing story-track rows but marks the archive incomplete', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/pipeline')) {
+        return {
+          ok: true,
+          json: async () => [
+            { result: [] },
+            { result: ['title', 'Policy change passes', 'description', 'The bill passed.', 'publishedAt', String(T0 + 1)] },
+          ],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['missing-hash', 'hash-2'] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
+
+    assert.equal(archive.items.length, 1);
+    assert.equal(archive.truncated, true);
+    assert.equal(archive.missingRows, 1);
+    assert.equal(archive.items[0].hash, 'hash-2');
+  });
+
+  it('does not seal no-evidence judged forecasts when every archive row is missing', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/pipeline')) {
+        return {
+          ok: true,
+          json: async () => [{ result: [] }],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['missing-hash'] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [forecast({
+      id: 'judge-missing-archive-row',
+      domain: 'political',
+      region: 'Freedonia',
+      title: 'Policy change passes',
+      resolution: {
+        kind: 'judged',
+        deadline: T0 + 1,
+        question: 'Will the emergency policy change pass before the deadline?',
+      },
+    })])], {}, archive, T0 + DAY_MS, {
+      judgeModels: [
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+      ],
+    });
+
+    const row = result.ledger[`judge-missing-archive-row@${T0 + 1}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.judgeLastAttempt.reason, 'archive_unavailable');
+    assert.equal(result.receipts.length, 0);
+  });
+
   it('fails closed when a same-length Redis pipeline response has an invalid story row', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
@@ -502,6 +756,19 @@ describe('appendSample and seed contract', () => {
     assert.equal(SCORECARD_KEY, 'forecast:scorecard:v1');
     assert.equal(SCORECARD_META_KEY, 'seed-meta:forecast:scorecard');
     assert.equal(declareRecords({ a: {}, b: {} }), 2);
+  });
+
+  it('keeps dry-run on the judged path without live LLM calls', () => {
+    const dryRunStart = SEEDER_SOURCE.indexOf('async function dryRun()');
+    const dryRunEnd = SEEDER_SOURCE.indexOf('export async function appendR2Receipts');
+    const dryRunSource = SEEDER_SOURCE.slice(dryRunStart, dryRunEnd);
+
+    assert.ok(dryRunStart > -1);
+    assert.ok(dryRunEnd > dryRunStart);
+    assert.match(dryRunSource, /processResolutionCycleWithJudges/);
+    assert.match(dryRunSource, /judgedMode:\s*'no-llm'/);
+    assert.match(dryRunSource, /judgeModels:\s*dryRunJudgeModels/);
+    assert.doesNotMatch(dryRunSource, /processResolutionCycle\(/);
   });
 
   it('keeps terminal receipts retryable until R2 archival is marked successful', () => {
@@ -612,7 +879,7 @@ describe('pruneArchivedTerminalEntries', () => {
       },
       // pending forever → kept (still needs resolution)
       'pending@1': { key: 'pending@1', id: 'pending', status: 'pending' },
-      // judged spec awaiting a judge resolver that has not shipped → kept
+      // judged spec awaiting resolution → kept
       'judge@1': { key: 'judge@1', id: 'judge', status: 'pending-judge' },
       // resolved+archived but missing resolvedAt → kept (cannot age-check safely)
       'no-resolvedat@1': {

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 
 import {
   RESOLUTIONS_KEY,
@@ -12,12 +12,27 @@ import {
   declareRecords,
   markReceiptsArchived,
   processResolutionCycle,
+  processResolutionCycleWithJudges,
   pruneArchivedTerminalEntries,
+  readDigestAccumulatorArchive,
 } from '../scripts/seed-forecast-resolutions.mjs';
 import { computeScorecard } from '../scripts/_forecast-scorecard.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const T0 = Date.parse('2026-07-07T00:00:00Z');
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_REDIS_ENV = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_URL === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_URL;
+  if (ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_TOKEN === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_TOKEN;
+});
 
 function forecast(overrides = {}) {
   const generatedAt = overrides.generatedAt ?? T0;
@@ -243,6 +258,229 @@ describe('processResolutionCycle', () => {
     assert.equal(row.samples.recent.at(-1).ts, T0 + DAY_MS + 10);
     assert.equal(row.evidence.metricValue, 98);
     assert.equal(receipts.length, 1);
+  });
+});
+
+describe('processResolutionCycleWithJudges', () => {
+  const archive = [
+    {
+      id: 'N1',
+      title: 'Parliament approves the emergency policy change',
+      description: 'The bill passed before the forecast deadline after the coalition vote.',
+      url: 'https://news.example/policy-change',
+      publishedAt: T0 + DAY_MS + 1,
+    },
+  ];
+
+  function judgedForecast(overrides = {}) {
+    return forecast({
+      id: 'fc-judge',
+      domain: 'political',
+      region: 'Freedonia',
+      title: 'Policy change passes',
+      probability: 0.7,
+      resolution: {
+        kind: 'judged',
+        deadline: T0 + DAY_MS,
+        question: 'Will the emergency policy change pass before the deadline?',
+      },
+      ...overrides,
+    });
+  }
+
+  it('resolves a due judged entry when both models agree and cite archive evidence', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({
+          provider: 'openrouter',
+          model: 'deepseek/deepseek-v4-flash',
+          text: JSON.stringify({ outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The cited article confirms passage.' }),
+        }),
+        async () => ({ provider: 'groq', model: 'llama-3.3-70b-versatile', outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The policy passed before the deadline.' }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'YES');
+    assert.equal(row.evidence.reason, 'dual_model_agreement');
+    assert.deepEqual(row.evidence.citations.map((citation) => citation.id), ['N1']);
+    assert.equal(result.receipts.length, 1);
+    assert.equal(result.scorecard.totals.scored, 1);
+  });
+
+  it('resolves to VOID when the two judges disagree', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash', outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The article says it passed.' }),
+        async () => ({ provider: 'groq', model: 'llama-3.3-70b-versatile', outcome: 'NO', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The article does not establish passage.' }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'VOID');
+    assert.equal(row.evidence.reason, 'judge_disagreement');
+    assert.equal(result.scorecard.totals.void, 1);
+    assert.equal(result.scorecard.totals.scored, 0);
+  });
+
+  it('resolves to VOID without calling judges when the archive has no relevant evidence', async () => {
+    const unrelatedArchive = [{
+      id: 'N9',
+      title: 'Central bank holds rates unchanged',
+      description: 'Officials said inflation remained steady.',
+      url: 'https://news.example/rates',
+      publishedAt: T0 + DAY_MS + 1,
+    }];
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, unrelatedArchive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'VOID');
+    assert.equal(row.evidence.reason, 'no_archive_evidence');
+    assert.equal(result.scorecard.totals.void, 1);
+  });
+
+  it('keeps no-evidence entries pending when the archive does not cover the entry window', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, {
+      available: true,
+      coverageStartMs: T0 + DAY_MS,
+      coverageEndMs: T0 + DAY_MS + 2,
+      items: [{
+        id: 'N1',
+        title: 'Central bank holds rates unchanged',
+        description: 'Officials said inflation remained steady.',
+        url: 'https://news.example/rates',
+        publishedAt: T0 + DAY_MS + 1,
+      }],
+    }, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.outcome, undefined);
+    assert.equal(row.judgeLastAttempt.reason, 'archive_unavailable');
+    assert.equal(result.receipts.length, 0);
+  });
+
+  it('keeps no-evidence entries pending when the archive read was truncated', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, {
+      available: true,
+      truncated: true,
+      coverageStartMs: T0 - 6 * 60 * 60 * 1000,
+      coverageEndMs: T0 + DAY_MS + 2,
+      items: [{
+        id: 'N1',
+        title: 'Central bank holds rates unchanged',
+        description: 'Officials said inflation remained steady.',
+        url: 'https://news.example/rates',
+        publishedAt: T0 + DAY_MS + 1,
+      }],
+    }, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.outcome, undefined);
+    assert.equal(row.judgeLastAttempt.reason, 'archive_unavailable');
+    assert.equal(result.receipts.length, 0);
+  });
+
+  it('resolves YES/NO judge agreement to VOID when citations lack matching excerpts', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash', outcome: 'YES', citations: [{ id: 'N1' }], rationale: 'The article says it passed.' }),
+        async () => ({ provider: 'groq', model: 'llama-3.3-70b-versatile', outcome: 'YES', citations: [{ id: 'N1', quote: 'A fabricated sentence that is not in the archive' }], rationale: 'The policy passed before the deadline.' }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'VOID');
+    assert.equal(row.evidence.reason, 'all_judges_void');
+    assert.deepEqual(row.evidence.judgments.map((judgment) => judgment.reason), ['invalid_citations', 'invalid_citations']);
+    assert.equal(result.scorecard.totals.void, 1);
+    assert.equal(result.scorecard.totals.scored, 0);
+  });
+
+  it('keeps the entry pending when a judge call is unavailable or malformed', async () => {
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, archive, T0 + DAY_MS + 2, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', model: 'deepseek/deepseek-v4-flash', outcome: 'YES', citations: [{ id: 'N1', quote: 'The bill passed before the forecast deadline' }], rationale: 'The article says it passed.' }),
+        async () => null,
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.outcome, undefined);
+    assert.equal(row.judgeLastAttempt.reason, 'judge_unavailable');
+    assert.equal(result.receipts.length, 0);
+  });
+
+  it('marks capped archive reads as truncated instead of complete', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/pipeline')) {
+        const commands = JSON.parse(init.body);
+        return {
+          ok: true,
+          json: async () => commands.map(([, key]) => ({
+            result: ['title', `Story ${key}`, 'description', 'Policy change context', 'publishedAt', String(T0 + 1)],
+          })),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['old-hash', 'new-hash'] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS, { maxHashes: 1 });
+    assert.equal(archive.truncated, true);
+    assert.equal(archive.items.length, 1);
+  });
+});
+
+describe('readDigestAccumulatorArchive', () => {
+  it('fails closed when a same-length Redis pipeline response has an invalid story row', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/pipeline')) {
+        return {
+          ok: true,
+          json: async () => [
+            { result: ['title', 'Policy change passes', 'description', 'The bill passed.', 'publishedAt', String(T0 + 1)] },
+            { error: 'ERR transient HGETALL failure' },
+          ],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['hash-1', 'hash-2'] }),
+      };
+    };
+
+    await assert.rejects(
+      readDigestAccumulatorArchive(T0, T0 + DAY_MS),
+      /story-track pipeline row 1 failed/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Forecast resolution now handles due judged forecasts instead of leaving them permanently in `pending-judge`. The resolver uses two LLM judges over digest-archive evidence, seals YES/NO only when both models agree with grounded citations, and writes the result through the existing ledger, receipt, and scorecard flow.

The failure modes are deliberately conservative: model disagreement becomes VOID, missing/malformed judge output stays pending for retry, complete archive reads with no relevant evidence become VOID, and incomplete or truncated archive reads stay pending instead of creating permanent false VOID receipts.

Related: #5007

## Validation

- `node --test tests/forecast-resolutions-seeder.test.mjs tests/forecast-scorecard.test.mjs tests/forecast-resolution-eval.test.mjs tests/scripts-railway-nixpacks-no-escape-import.test.mts`
- Pre-push hook passed: frontend typecheck, API typecheck, Convex check, CJS syntax, Unicode safety, boundary lint, safe HTML guard, Sentry coverage gate, rate-limit policy lint, premium-fetch parity, edge bundle check, changed resolver tests, and version sync.

## Post-Deploy Monitoring & Validation

- Watch Railway logs for `forecast-resolutions`, `[LLM:forecast_resolution_judge_openrouter]`, `[LLM:forecast_resolution_judge_groq]`, `judged archive unavailable`, `Terminal receipts resolved this cycle`, and `R2 receipts archived`.
- Check `/api/health` and `seed-meta:forecast:scorecard` for fresh successful runs; inspect `forecast:scorecard:v1` for judged entries moving from pending to scored or VOID without a sudden VOID-rate spike.
- Sample new R2 `forecast-resolutions` receipts and confirm judged evidence includes `dual_model_agreement`, `judge_disagreement`, `all_judges_void`, or `no_archive_evidence` with citations only when excerpts match the archive item.
- Healthy signal: due judged forecasts resolve gradually, `judge_unavailable`/`archive_unavailable` attempts are transient, and LLM telemetry shows successful calls from both judge providers.
- Failure signal: repeated `archive_unavailable`, same provider failing every run, zero judged receipts after due forecasts exist, or a sharp increase in `no_archive_evidence`/VOID rate. Roll back by reverting this PR and redeploying the previous Railway worker image.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
