### PR TITLE
perf(dashboard): add mobile tap render-axis tracing

### DIFF
--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -12,7 +12,7 @@
  * Usage:
  *   node scripts/measure-dashboard-render-axis.mjs [url] [--settle 10000] [--json]
  *   node scripts/measure-dashboard-render-axis.mjs [url] --trace-out /tmp/dashboard-trace.json
- *   node scripts/measure-dashboard-render-axis.mjs [url] --interact country --json
+ *   node scripts/measure-dashboard-render-axis.mjs [url] --interact country --cpu-throttle 4 --json
  *   node scripts/measure-dashboard-render-axis.mjs --compare before.json after.json --json
  */
 import { readFile, writeFile } from 'node:fs/promises';
@@ -21,12 +21,16 @@ import { pathToFileURL } from 'node:url';
 const TBT_THRESHOLD_MS = 50;
 const DEFAULT_INTERACTION_VIEWPORT = { width: 390, height: 844 };
 const DEFAULT_POST_INTERACT_MS = 1200;
+const DEFAULT_CPU_THROTTLE_RATE = 1;
 
 const DEFAULT_TRACE_CATEGORIES = [
   'devtools.timeline',
   'disabled-by-default-devtools.timeline',
   'disabled-by-default-devtools.timeline.stack',
   'blink',
+  'disabled-by-default-gpu.debug',
+  'disabled-by-default-gpu.service',
+  'gpu',
   'loading',
   'rail',
   'v8',
@@ -383,6 +387,7 @@ export function buildReport(result) {
     generatedAt: result?.generatedAt,
     viewport: result?.viewport,
     settleMs: result?.settleMs,
+    cpuThrottleRate: Number(result?.cpuThrottleRate) || DEFAULT_CPU_THROTTLE_RATE,
     tracePath: result?.tracePath || null,
     ...summary,
   };
@@ -397,6 +402,10 @@ export function buildReport(result) {
       target: result.interaction,
       timings: summarizeInteractionTimings(result?.eventTimings),
       dominantPhase: dominantRenderPhase(summary.durationMs),
+      traceWindow: {
+        postInteractMs: Number(result.interaction?.postInteractMs) || DEFAULT_POST_INTERACT_MS,
+        dominantPhaseScope: 'full-post-interaction-trace-window',
+      },
       warnings: targetWarnings,
     };
     report.warnings = [...report.warnings, ...targetWarnings];
@@ -417,6 +426,7 @@ export function normalizeReport(input) {
     generatedAt: input?.generatedAt,
     viewport: input?.viewport,
     settleMs: input?.settleMs,
+    cpuThrottleRate: input?.cpuThrottleRate,
     tracePath: input?.tracePath || null,
     traceEvents: events,
     interaction: input?.interaction || null,
@@ -528,6 +538,7 @@ export function parseArgs(argv) {
     compare: null,
     interact: null,
     postInteract: DEFAULT_POST_INTERACT_MS,
+    cpuThrottleRate: DEFAULT_CPU_THROTTLE_RATE,
   };
   let widthExplicit = false;
   let heightExplicit = false;
@@ -558,6 +569,9 @@ export function parseArgs(argv) {
     } else if (value === '--post-interact') {
       const n = Number(rest[++i]);
       if (!Number.isNaN(n)) args.postInteract = n;
+    } else if (value === '--cpu-throttle') {
+      const n = Number(rest[++i]);
+      if (Number.isFinite(n) && n >= 1) args.cpuThrottleRate = n;
     } else if (value === '--compare') {
       const before = rest[++i];
       const after = rest[++i];
@@ -580,6 +594,12 @@ async function startTracing(client) {
     categories: DEFAULT_TRACE_CATEGORIES.join(','),
     transferMode: 'ReturnAsStream',
   });
+}
+
+async function setCpuThrottle(client, rate) {
+  const throttleRate = Number(rate) || DEFAULT_CPU_THROTTLE_RATE;
+  if (throttleRate <= DEFAULT_CPU_THROTTLE_RATE) return;
+  await client.send('Emulation.setCPUThrottlingRate', { rate: throttleRate });
 }
 
 async function readStream(client, stream) {
@@ -772,6 +792,7 @@ async function captureTrace(url, {
   traceOut = '',
   interaction = null,
   postInteractMs = DEFAULT_POST_INTERACT_MS,
+  cpuThrottleRate = DEFAULT_CPU_THROTTLE_RATE,
 } = {}) {
   const { chromium } = await import('@playwright/test');
   const browser = await chromium.launch();
@@ -786,6 +807,7 @@ async function captureTrace(url, {
     const page = await context.newPage();
     if (interaction) await installInteractionTimingObserver(page);
     const client = await context.newCDPSession(page);
+    await setCpuThrottle(client, cpuThrottleRate);
     let eventTimings = [];
     let interactionTarget = null;
 
@@ -816,6 +838,7 @@ async function captureTrace(url, {
       generatedAt: new Date().toISOString(),
       viewport: { width, height },
       settleMs,
+      cpuThrottleRate: Number(cpuThrottleRate) || DEFAULT_CPU_THROTTLE_RATE,
       tracePath: traceOut || null,
       traceEvents: events,
       interaction: interactionTarget,
@@ -853,6 +876,9 @@ function printHuman(report) {
     return;
   }
   const d = report.durationMs;
+  if ((report.cpuThrottleRate || DEFAULT_CPU_THROTTLE_RATE) > DEFAULT_CPU_THROTTLE_RATE) {
+    console.log(`CPU Throttle:     ${report.cpuThrottleRate}x`);
+  }
   console.log(`Style/Layout:     ${d.styleLayout}ms (${report.sharePct.styleLayoutOfAccounted}% of accounted render-axis)`);
   console.log(`Rendering:        ${d.rendering}ms (${report.sharePct.renderingOfAccounted}% of accounted render-axis)`);
   console.log(`Canvas/WebGL:     ${d.canvas}ms (${report.sharePct.canvasOfAccounted}% of accounted render-axis)`);
@@ -862,15 +888,16 @@ function printHuman(report) {
     const { target, timings, dominantPhase } = report.interaction;
     console.log(`Interaction:      ${target.name} (${target.selector})`);
     if (timings.worst) {
+      const selector = timings.worst.selector ? ` on ${timings.worst.selector}` : '';
       console.log(
-        `Event Timing:     ${timings.worst.name} ${timings.worst.durationMs}ms `
+        `Event Timing:     ${timings.worst.name}${selector} ${timings.worst.durationMs}ms `
         + `(input ${timings.worst.inputDelayMs}ms, processing ${timings.worst.processingMs}ms, `
         + `presentation ${timings.worst.presentationDelayMs}ms)`,
       );
     } else {
       console.log('Event Timing:     unavailable (browser did not emit Event Timing entries)');
     }
-    console.log(`Dominant phase:   ${dominantPhase.label} (${dominantPhase.ms}ms)`);
+    console.log(`Dominant phase:   ${dominantPhase.label} (${dominantPhase.ms}ms over ${report.interaction.traceWindow.postInteractMs}ms trace window)`);
     for (const warning of report.interaction.warnings || []) console.log(`  ! ${warning}`);
   }
   console.log(`Forced reflows:   ${report.forcedReflows.eventCount} attributed events, ${report.forcedReflows.totalMs}ms`);
@@ -907,6 +934,7 @@ async function main() {
       traceOut: args.traceOut,
       interaction: args.interact,
       postInteractMs: args.postInteract,
+      cpuThrottleRate: args.cpuThrottleRate,
     }));
   }
   if (args.json) console.log(JSON.stringify(report, null, 2));

--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -12,12 +12,15 @@
  * Usage:
  *   node scripts/measure-dashboard-render-axis.mjs [url] [--settle 10000] [--json]
  *   node scripts/measure-dashboard-render-axis.mjs [url] --trace-out /tmp/dashboard-trace.json
+ *   node scripts/measure-dashboard-render-axis.mjs [url] --interact country --json
  *   node scripts/measure-dashboard-render-axis.mjs --compare before.json after.json --json
  */
 import { readFile, writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 const TBT_THRESHOLD_MS = 50;
+const DEFAULT_INTERACTION_VIEWPORT = { width: 390, height: 844 };
+const DEFAULT_POST_INTERACT_MS = 1200;
 
 const DEFAULT_TRACE_CATEGORIES = [
   'devtools.timeline',
@@ -50,6 +53,15 @@ const RENDERING_NAMES = new Set([
   'Rasterize Paint',
   'UpdateLayer',
   'UpdateLayerTree',
+]);
+
+const CANVAS_NAMES = new Set([
+  'Canvas2DLayerBridge::FlushCanvas',
+  'Canvas2DLayerBridge::FinalizeFrame',
+  'CanvasResourceProvider::FlushCanvas',
+  'CanvasResourceProvider::RasterRecord',
+  'GLES2DecoderImpl::DoCommands',
+  'WebGLRenderingContextBase::commit',
 ]);
 
 const SCRIPT_EVALUATION_NAMES = new Set([
@@ -91,6 +103,33 @@ const FORCED_MARKER_NAMES = new Set([
   'Blink.ForcedStyleAndLayout.UpdateTime',
 ]);
 
+const NAMED_INTERACTION_TARGETS = Object.freeze({
+  country: {
+    name: 'country',
+    label: 'SVG country path',
+    selector: '#mapSvg path.country',
+    action: 'tap',
+  },
+  base: {
+    name: 'base',
+    label: 'SVG base rect',
+    selector: '#mapSvg > g.map-base > rect',
+    action: 'tap',
+  },
+  nav: {
+    name: 'nav',
+    label: 'mobile panel nav chip',
+    selector: '#main > nav.mobile-panel-nav > button, .mobile-panel-nav-chip',
+    action: 'tap',
+  },
+  'nav-chip': {
+    name: 'nav-chip',
+    label: 'mobile panel nav chip',
+    selector: '#main > nav.mobile-panel-nav > button, .mobile-panel-nav-chip',
+    action: 'tap',
+  },
+});
+
 function round(n) {
   return Math.round((Number(n) || 0) * 10) / 10;
 }
@@ -109,14 +148,36 @@ export function classifyRenderAxisEvent(name) {
   const value = String(name || '');
   if (!value || value === 'LayoutShift') return null;
   if (STYLE_LAYOUT_NAMES.has(value)) return 'styleLayout';
+  if (CANVAS_NAMES.has(value)) return 'canvas';
   if (RENDERING_NAMES.has(value)) return 'rendering';
   if (SCRIPT_EVALUATION_NAMES.has(value)) return 'scriptEvaluation';
   if (/layout|style|recalculate/i.test(value) && !/shift/i.test(value)) return 'styleLayout';
+  if (/canvas|webgl|gles2|skia/i.test(value)) return 'canvas';
   if (/paint|composite|raster|layerize|prepaint/i.test(value)) return 'rendering';
   if (/evaluate|functioncall|eventdispatch|timerfire|microtask|compile|execute|v8/i.test(value)) {
     return 'scriptEvaluation';
   }
   return null;
+}
+
+export function resolveInteractionTarget(raw = 'country') {
+  const value = String(raw || 'country').trim() || 'country';
+  const named = NAMED_INTERACTION_TARGETS[value];
+  if (named) return { ...named };
+  if (value.startsWith('selector:')) {
+    return {
+      name: 'custom',
+      label: 'custom selector',
+      selector: value.slice('selector:'.length).trim(),
+      action: 'tap',
+    };
+  }
+  return {
+    name: 'custom',
+    label: 'custom selector',
+    selector: value,
+    action: 'tap',
+  };
 }
 
 function stackFromUnknown(raw) {
@@ -212,6 +273,7 @@ export function summarizeTraceEvents(trace) {
   const duration = {
     styleLayoutMs: 0,
     renderingMs: 0,
+    canvasMs: 0,
     scriptEvaluationMs: 0,
     topLevelTaskMs: 0,
     tbtMs: 0,
@@ -225,6 +287,7 @@ export function summarizeTraceEvents(trace) {
     const group = classifyRenderAxisEvent(event.name);
     if (group === 'styleLayout') duration.styleLayoutMs += ms;
     else if (group === 'rendering') duration.renderingMs += ms;
+    else if (group === 'canvas') duration.canvasMs += ms;
     else if (group === 'scriptEvaluation') duration.scriptEvaluationMs += ms;
 
     if (TOP_LEVEL_TASK_NAMES.has(String(event.name || ''))) {
@@ -243,24 +306,27 @@ export function summarizeTraceEvents(trace) {
   }
 
   const accountedMs = duration.styleLayoutMs + duration.renderingMs + duration.scriptEvaluationMs;
+  const accountedWithCanvasMs = accountedMs + duration.canvasMs;
   const warnings = [];
   if (events.length === 0) warnings.push('No trace events found.');
-  if (events.length > 0 && accountedMs === 0) warnings.push('No render-axis duration events were recognized.');
+  if (events.length > 0 && accountedWithCanvasMs === 0) warnings.push('No render-axis duration events were recognized.');
 
   return {
     eventCount: events.length,
     durationMs: {
       styleLayout: round(duration.styleLayoutMs),
       rendering: round(duration.renderingMs),
+      canvas: round(duration.canvasMs),
       scriptEvaluation: round(duration.scriptEvaluationMs),
       topLevelTasks: round(duration.topLevelTaskMs),
       estimatedTbt: round(duration.tbtMs),
-      accountedRenderAxis: round(accountedMs),
+      accountedRenderAxis: round(accountedWithCanvasMs),
     },
     sharePct: {
-      styleLayoutOfAccounted: accountedMs ? round((duration.styleLayoutMs / accountedMs) * 100) : 0,
-      renderingOfAccounted: accountedMs ? round((duration.renderingMs / accountedMs) * 100) : 0,
-      scriptEvaluationOfAccounted: accountedMs ? round((duration.scriptEvaluationMs / accountedMs) * 100) : 0,
+      styleLayoutOfAccounted: accountedWithCanvasMs ? round((duration.styleLayoutMs / accountedWithCanvasMs) * 100) : 0,
+      renderingOfAccounted: accountedWithCanvasMs ? round((duration.renderingMs / accountedWithCanvasMs) * 100) : 0,
+      canvasOfAccounted: accountedWithCanvasMs ? round((duration.canvasMs / accountedWithCanvasMs) * 100) : 0,
+      scriptEvaluationOfAccounted: accountedWithCanvasMs ? round((duration.scriptEvaluationMs / accountedWithCanvasMs) * 100) : 0,
     },
     forcedReflows: summarizeForcedReflows(events),
     topEvents: summarizeTopEvents(topEvents),
@@ -268,9 +334,50 @@ export function summarizeTraceEvents(trace) {
   };
 }
 
+export function dominantRenderPhase(duration = {}) {
+  const labels = {
+    styleLayout: 'style/layout',
+    rendering: 'paint/composite/raster',
+    canvas: 'canvas/webgl',
+    scriptEvaluation: 'script/evaluation',
+  };
+  const phases = ['styleLayout', 'rendering', 'canvas', 'scriptEvaluation'];
+  const [phase, ms] = phases
+    .map((key) => [key, Number(duration[key]) || 0])
+    .sort((a, b) => b[1] - a[1])[0] || ['none', 0];
+  return { phase, label: labels[phase] || 'none', ms: round(ms) };
+}
+
+export function summarizeInteractionTimings(entries) {
+  const rows = (Array.isArray(entries) ? entries : [])
+    .map((entry) => {
+      const startTime = Number(entry?.startTime) || 0;
+      const duration = Number(entry?.duration) || 0;
+      const processingStart = Number(entry?.processingStart) || startTime;
+      const processingEnd = Number(entry?.processingEnd) || processingStart;
+      return {
+        name: String(entry?.name || 'event'),
+        selector: String(entry?.selector || ''),
+        startTime: round(startTime),
+        durationMs: round(duration),
+        inputDelayMs: round(Math.max(0, processingStart - startTime)),
+        processingMs: round(Math.max(0, processingEnd - processingStart)),
+        presentationDelayMs: round(Math.max(0, startTime + duration - processingEnd)),
+      };
+    })
+    .filter((row) => row.durationMs > 0 || row.processingMs > 0 || row.presentationDelayMs > 0)
+    .sort((a, b) => b.durationMs - a.durationMs || b.presentationDelayMs - a.presentationDelayMs);
+
+  return {
+    eventCount: rows.length,
+    worst: rows[0] || null,
+    events: rows.slice(0, 8),
+  };
+}
+
 export function buildReport(result) {
   const summary = summarizeTraceEvents(result?.traceEvents || []);
-  return {
+  const report = {
     url: result?.url,
     generatedAt: result?.generatedAt,
     viewport: result?.viewport,
@@ -278,6 +385,14 @@ export function buildReport(result) {
     tracePath: result?.tracePath || null,
     ...summary,
   };
+  if (result?.interaction) {
+    report.interaction = {
+      target: result.interaction,
+      timings: summarizeInteractionTimings(result?.eventTimings),
+      dominantPhase: dominantRenderPhase(summary.durationMs),
+    };
+  }
+  return report;
 }
 
 export function normalizeReport(input) {
@@ -396,7 +511,11 @@ export function parseArgs(argv) {
     json: false,
     traceOut: '',
     compare: null,
+    interact: null,
+    postInteract: DEFAULT_POST_INTERACT_MS,
   };
+  let widthExplicit = false;
+  let heightExplicit = false;
   const rest = argv.slice(2);
   for (let i = 0; i < rest.length; i++) {
     const value = rest[i];
@@ -406,11 +525,20 @@ export function parseArgs(argv) {
     } else if (value === '--width') {
       const n = Number(rest[++i]);
       if (!Number.isNaN(n)) args.width = n;
+      widthExplicit = true;
     } else if (value === '--height') {
       const n = Number(rest[++i]);
       if (!Number.isNaN(n)) args.height = n;
+      heightExplicit = true;
     } else if (value === '--trace-out') {
       args.traceOut = rest[++i] || '';
+    } else if (value === '--interact') {
+      const next = rest[i + 1];
+      const target = next && !next.startsWith('--') ? rest[++i] : 'country';
+      args.interact = resolveInteractionTarget(target);
+    } else if (value === '--post-interact') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.postInteract = n;
     } else if (value === '--compare') {
       const before = rest[++i];
       const after = rest[++i];
@@ -421,7 +549,18 @@ export function parseArgs(argv) {
       args.url = value;
     }
   }
+  if (args.interact) {
+    if (!widthExplicit) args.width = DEFAULT_INTERACTION_VIEWPORT.width;
+    if (!heightExplicit) args.height = DEFAULT_INTERACTION_VIEWPORT.height;
+  }
   return args;
+}
+
+async function startTracing(client) {
+  await client.send('Tracing.start', {
+    categories: DEFAULT_TRACE_CATEGORIES.join(','),
+    transferMode: 'ReturnAsStream',
+  });
 }
 
 async function readStream(client, stream) {
@@ -447,23 +586,211 @@ async function stopTracing(client) {
   return traceEvents(parsed);
 }
 
-async function captureTrace(url, { settleMs = 10000, width = 1365, height = 768, traceOut = '' } = {}) {
+async function installInteractionTimingObserver(page) {
+  await page.addInitScript(() => {
+    const selectorFor = (node) => {
+      try {
+        if (!(node instanceof Element)) return '';
+        if (node.id) return `#${CSS.escape(node.id)}`;
+        const className = typeof node.className === 'string'
+          ? node.className
+          : (node.className?.baseVal || '');
+        const firstClass = className.trim().split(/\s+/).filter(Boolean)[0];
+        return `${node.tagName.toLowerCase()}${firstClass ? `.${CSS.escape(firstClass)}` : ''}`;
+      } catch {
+        return '';
+      }
+    };
+    window.__wmInteractionTimings = [];
+    try {
+      new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          window.__wmInteractionTimings.push({
+            name: entry.name,
+            startTime: entry.startTime,
+            duration: entry.duration,
+            processingStart: entry.processingStart,
+            processingEnd: entry.processingEnd,
+            interactionId: entry.interactionId || 0,
+            selector: selectorFor(entry.target),
+          });
+        }
+      }).observe({ type: 'event', buffered: true, durationThreshold: 0 });
+    } catch {
+      /* Event Timing unavailable in this browser — trace phases still work. */
+    }
+  });
+}
+
+async function describeInteractionTarget(page, target) {
+  const first = page.locator(target.selector).first();
+  await first.waitFor({ state: 'visible', timeout: 15000 });
+  await first.scrollIntoViewIfNeeded();
+  const info = await page.evaluate((selector) => {
+    const round1 = (n) => Math.round(Number(n || 0) * 10) / 10;
+    const inViewport = (x, y) => (
+      Number.isFinite(x)
+      && Number.isFinite(y)
+      && x >= 0
+      && y >= 0
+      && x <= window.innerWidth
+      && y <= window.innerHeight
+    );
+    const rectInfo = (el) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        x: round1(rect.x),
+        y: round1(rect.y),
+        width: round1(rect.width),
+        height: round1(rect.height),
+      };
+    };
+    const topMatches = (el, x, y) => {
+      const top = document.elementFromPoint(x, y);
+      if (!top) return false;
+      if (top === el || el.contains(top)) return true;
+      try {
+        return top.closest(selector) === el;
+      } catch {
+        return false;
+      }
+    };
+    const screenPoint = (el, point) => {
+      const ctm = typeof el.getScreenCTM === 'function' ? el.getScreenCTM() : null;
+      if (!ctm) return null;
+      return {
+        x: point.x * ctm.a + point.y * ctm.c + ctm.e,
+        y: point.x * ctm.b + point.y * ctm.d + ctm.f,
+      };
+    };
+    const candidatePoints = (el) => {
+      const points = [];
+      if (typeof el.getTotalLength === 'function' && typeof el.getPointAtLength === 'function') {
+        try {
+          const length = el.getTotalLength();
+          if (Number.isFinite(length) && length > 0) {
+            for (let i = 1; i < 24; i++) {
+              const point = screenPoint(el, el.getPointAtLength((length * i) / 24));
+              if (point) points.push(point);
+            }
+          }
+        } catch {
+          /* Some SVG nodes expose geometry methods but throw for invalid paths. */
+        }
+      }
+      const rect = el.getBoundingClientRect();
+      const visibleLeft = Math.max(0, rect.left);
+      const visibleRight = Math.min(window.innerWidth, rect.right);
+      const visibleTop = Math.max(0, rect.top);
+      const visibleBottom = Math.min(window.innerHeight, rect.bottom);
+      if (visibleRight > visibleLeft && visibleBottom > visibleTop) {
+        for (const xRatio of [0.5, 0.15, 0.3, 0.7, 0.85]) {
+          for (const yRatio of [0.5, 0.15, 0.3, 0.7, 0.85]) {
+            points.push({
+              x: visibleLeft + (visibleRight - visibleLeft) * xRatio,
+              y: visibleTop + (visibleBottom - visibleTop) * yRatio,
+            });
+          }
+        }
+      }
+      return points;
+    };
+    const describe = (el, point, matchedTop) => ({
+      tagName: el.tagName.toLowerCase(),
+      text: (el.textContent || '').trim().slice(0, 80),
+      rect: rectInfo(el),
+      tapPoint: point ? { x: round1(point.x), y: round1(point.y), matchedTop } : null,
+    });
+
+    const candidates = [...document.querySelectorAll(selector)];
+    for (const el of candidates) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) continue;
+      for (const point of candidatePoints(el)) {
+        if (!inViewport(point.x, point.y)) continue;
+        if (topMatches(el, point.x, point.y)) return describe(el, point, true);
+      }
+    }
+
+    const fallback = candidates.find((el) => {
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    });
+    if (!fallback) return null;
+    const rect = fallback.getBoundingClientRect();
+    const point = {
+      x: Math.min(Math.max(rect.left + rect.width / 2, 1), window.innerWidth - 1),
+      y: Math.min(Math.max(rect.top + rect.height / 2, 1), window.innerHeight - 1),
+    };
+    return describe(fallback, point, false);
+  }, target.selector);
+  if (!info?.tapPoint) {
+    throw new Error(`No visible interaction target matched ${target.selector}`);
+  }
+  return info;
+}
+
+async function performInteraction(page, targetInfo) {
+  const point = targetInfo?.tapPoint;
+  if (!point) throw new Error('Interaction target did not include a tap point');
+  await page.touchscreen.tap(point.x, point.y);
+}
+
+async function readInteractionTimings(page) {
+  return page.evaluate(() => window.__wmInteractionTimings || []);
+}
+
+async function resetInteractionTimings(page) {
+  await page.evaluate(() => {
+    window.__wmInteractionTimings = [];
+  });
+}
+
+async function captureTrace(url, {
+  settleMs = 10000,
+  width = 1365,
+  height = 768,
+  traceOut = '',
+  interaction = null,
+  postInteractMs = DEFAULT_POST_INTERACT_MS,
+} = {}) {
   const { chromium } = await import('@playwright/test');
   const browser = await chromium.launch();
   try {
+    const mobileInteraction = Boolean(interaction);
     const context = await browser.newContext({
       viewport: { width, height },
-      deviceScaleFactor: 1,
-      isMobile: false,
+      deviceScaleFactor: mobileInteraction ? 3 : 1,
+      isMobile: mobileInteraction,
+      hasTouch: mobileInteraction,
     });
     const page = await context.newPage();
+    if (interaction) await installInteractionTimingObserver(page);
     const client = await context.newCDPSession(page);
-    await client.send('Tracing.start', {
-      categories: DEFAULT_TRACE_CATEGORIES.join(','),
-      transferMode: 'ReturnAsStream',
-    });
-    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
-    await page.waitForTimeout(settleMs);
+    let eventTimings = [];
+    let interactionTarget = null;
+
+    if (interaction) {
+      await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+      await page.waitForTimeout(settleMs);
+      const targetInfo = await describeInteractionTarget(page, interaction);
+      interactionTarget = {
+        ...interaction,
+        postInteractMs,
+        targetInfo,
+      };
+      await resetInteractionTimings(page);
+      await startTracing(client);
+      await page.evaluate(() => performance.mark?.('wm-interaction-start'));
+      await performInteraction(page, targetInfo);
+      await page.waitForTimeout(postInteractMs);
+      eventTimings = await readInteractionTimings(page);
+    } else {
+      await startTracing(client);
+      await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+      await page.waitForTimeout(settleMs);
+    }
+
     const events = await stopTracing(client);
     const result = {
       url,
@@ -472,6 +799,8 @@ async function captureTrace(url, { settleMs = 10000, width = 1365, height = 768,
       settleMs,
       tracePath: traceOut || null,
       traceEvents: events,
+      interaction: interactionTarget,
+      eventTimings,
     };
     if (traceOut) {
       await writeFile(traceOut, JSON.stringify(result, null, 2));
@@ -506,8 +835,23 @@ function printHuman(report) {
   const d = report.durationMs;
   console.log(`Style/Layout:     ${d.styleLayout}ms (${report.sharePct.styleLayoutOfAccounted}% of accounted render-axis)`);
   console.log(`Rendering:        ${d.rendering}ms (${report.sharePct.renderingOfAccounted}% of accounted render-axis)`);
+  console.log(`Canvas/WebGL:     ${d.canvas}ms (${report.sharePct.canvasOfAccounted}% of accounted render-axis)`);
   console.log(`Script Evaluation:${String(d.scriptEvaluation).padStart(7)}ms (${report.sharePct.scriptEvaluationOfAccounted}% of accounted render-axis)`);
   console.log(`Estimated TBT:    ${d.estimatedTbt}ms`);
+  if (report.interaction) {
+    const { target, timings, dominantPhase } = report.interaction;
+    console.log(`Interaction:      ${target.name} (${target.selector})`);
+    if (timings.worst) {
+      console.log(
+        `Event Timing:     ${timings.worst.name} ${timings.worst.durationMs}ms `
+        + `(input ${timings.worst.inputDelayMs}ms, processing ${timings.worst.processingMs}ms, `
+        + `presentation ${timings.worst.presentationDelayMs}ms)`,
+      );
+    } else {
+      console.log('Event Timing:     unavailable (browser did not emit Event Timing entries)');
+    }
+    console.log(`Dominant phase:   ${dominantPhase.label} (${dominantPhase.ms}ms)`);
+  }
   console.log(`Forced reflows:   ${report.forcedReflows.eventCount} attributed events, ${report.forcedReflows.totalMs}ms`);
   console.log(`  (Blink.ForcedStyleAndLayout markers: ${report.forcedReflows.markerCount ?? 0}, ${report.forcedReflows.markerTotalMs ?? 0}ms — stackless fallback)`);
   if (report.forcedReflows.stacks.length > 0) {
@@ -540,6 +884,8 @@ async function main() {
       width: args.width,
       height: args.height,
       traceOut: args.traceOut,
+      interaction: args.interact,
+      postInteractMs: args.postInteract,
     }));
   }
   if (args.json) console.log(JSON.stringify(report, null, 2));

--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -344,7 +344,8 @@ export function dominantRenderPhase(duration = {}) {
   const phases = ['styleLayout', 'rendering', 'canvas', 'scriptEvaluation'];
   const [phase, ms] = phases
     .map((key) => [key, Number(duration[key]) || 0])
-    .sort((a, b) => b[1] - a[1])[0] || ['none', 0];
+    .sort((a, b) => b[1] - a[1])
+    .find(([, value]) => value > 0) || ['none', 0];
   return { phase, label: labels[phase] || 'none', ms: round(ms) };
 }
 
@@ -386,11 +387,19 @@ export function buildReport(result) {
     ...summary,
   };
   if (result?.interaction) {
+    const targetWarnings = [];
+    if (result.interaction?.targetInfo?.tapPoint?.matchedTop === false) {
+      targetWarnings.push(
+        `Interaction target ${result.interaction.name || 'custom'} used a fallback tap point that did not hit the requested selector.`,
+      );
+    }
     report.interaction = {
       target: result.interaction,
       timings: summarizeInteractionTimings(result?.eventTimings),
       dominantPhase: dominantRenderPhase(summary.durationMs),
+      warnings: targetWarnings,
     };
+    report.warnings = [...report.warnings, ...targetWarnings];
   }
   return report;
 }
@@ -410,6 +419,8 @@ export function normalizeReport(input) {
     settleMs: input?.settleMs,
     tracePath: input?.tracePath || null,
     traceEvents: events,
+    interaction: input?.interaction || null,
+    eventTimings: input?.eventTimings || [],
   });
 }
 
@@ -443,6 +454,8 @@ export function compareReports(before, after) {
   const a = after?.durationMs || {};
   const beforeStyle = Number(b.styleLayout) || 0;
   const afterStyle = Number(a.styleLayout) || 0;
+  const beforeCanvas = Number(b.canvas) || 0;
+  const afterCanvas = Number(a.canvas) || 0;
   const beforeTbt = Number(b.estimatedTbt) || 0;
   const afterTbt = Number(a.estimatedTbt) || 0;
   const beforeForced = compareForcedReflowMetrics(before);
@@ -476,11 +489,13 @@ export function compareReports(before, after) {
     deltaMs: {
       styleLayout: round(afterStyle - beforeStyle),
       rendering: round((Number(a.rendering) || 0) - (Number(b.rendering) || 0)),
+      canvas: round(afterCanvas - beforeCanvas),
       scriptEvaluation: round((Number(a.scriptEvaluation) || 0) - (Number(b.scriptEvaluation) || 0)),
       estimatedTbt: round(afterTbt - beforeTbt),
     },
     deltaPct: {
       styleLayout: beforeStyle ? round(((afterStyle - beforeStyle) / beforeStyle) * 100) : 0,
+      canvas: beforeCanvas ? round(((afterCanvas - beforeCanvas) / beforeCanvas) * 100) : 0,
       estimatedTbt: beforeTbt ? round(((afterTbt - beforeTbt) / beforeTbt) * 100) : 0,
     },
     forcedReflowEvents: {
@@ -524,12 +539,16 @@ export function parseArgs(argv) {
       if (!Number.isNaN(n)) args.settle = n;
     } else if (value === '--width') {
       const n = Number(rest[++i]);
-      if (!Number.isNaN(n)) args.width = n;
-      widthExplicit = true;
+      if (!Number.isNaN(n)) {
+        args.width = n;
+        widthExplicit = true;
+      }
     } else if (value === '--height') {
       const n = Number(rest[++i]);
-      if (!Number.isNaN(n)) args.height = n;
-      heightExplicit = true;
+      if (!Number.isNaN(n)) {
+        args.height = n;
+        heightExplicit = true;
+      }
     } else if (value === '--trace-out') {
       args.traceOut = rest[++i] || '';
     } else if (value === '--interact') {
@@ -820,6 +839,7 @@ function printHuman(report) {
   console.log(`\nDesktop render-axis trace - ${report.url || 'comparison'}\n`);
   if (report.deltaMs) {
     console.log(`Style/Layout delta: ${report.deltaMs.styleLayout}ms (${report.deltaPct.styleLayout}%)`);
+    console.log(`Canvas/WebGL delta: ${report.deltaMs.canvas}ms (${report.deltaPct.canvas}%)`);
     console.log(`Estimated TBT delta: ${report.deltaMs.estimatedTbt}ms (${report.deltaPct.estimatedTbt}%)`);
     console.log(`Forced-reflow events: ${report.forcedReflowEvents.before} -> ${report.forcedReflowEvents.after}`);
     if (report.forcedReflowMs) {
@@ -851,6 +871,7 @@ function printHuman(report) {
       console.log('Event Timing:     unavailable (browser did not emit Event Timing entries)');
     }
     console.log(`Dominant phase:   ${dominantPhase.label} (${dominantPhase.ms}ms)`);
+    for (const warning of report.interaction.warnings || []) console.log(`  ! ${warning}`);
   }
   console.log(`Forced reflows:   ${report.forcedReflows.eventCount} attributed events, ${report.forcedReflows.totalMs}ms`);
   console.log(`  (Blink.ForcedStyleAndLayout markers: ${report.forcedReflows.markerCount ?? 0}, ${report.forcedReflows.markerTotalMs ?? 0}ms — stackless fallback)`);

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -172,7 +172,10 @@ describe('measure-dashboard-render-axis reporting', () => {
       url: 'http://127.0.0.1:4173/dashboard',
       generatedAt: '2026-07-09T00:00:00.000Z',
       viewport: { width: 390, height: 844 },
-      interaction: resolveInteractionTarget('country'),
+      interaction: {
+        ...resolveInteractionTarget('country'),
+        targetInfo: { tapPoint: { x: 120, y: 200, matchedTop: true } },
+      },
       eventTimings: [
         {
           name: 'pointerup',
@@ -194,6 +197,22 @@ describe('measure-dashboard-render-axis reporting', () => {
     assert.equal(report.interaction?.timings.worst?.presentationDelayMs, 520);
     assert.equal(report.interaction?.dominantPhase.phase, 'rendering');
     assert.equal(report.interaction?.dominantPhase.ms, 250);
+    assert.deepEqual(report.interaction?.warnings, []);
+  });
+
+  it('warns when the tap target falls back to a point that did not hit the selector', () => {
+    const report = buildReport({
+      url: 'http://127.0.0.1:4173/dashboard',
+      interaction: {
+        ...resolveInteractionTarget('country'),
+        targetInfo: { tapPoint: { x: 120, y: 200, matchedTop: false } },
+      },
+      eventTimings: [],
+      traceEvents: [{ ph: 'X', name: 'Paint', dur: 250_000 }],
+    });
+
+    assert.match(report.interaction?.warnings[0] || '', /fallback tap point/);
+    assert.match(report.warnings.join('\n'), /did not hit the requested selector/);
   });
 
   it('summarizes event-timing entries into input, processing, and presentation delay', () => {
@@ -220,6 +239,16 @@ describe('measure-dashboard-render-axis reporting', () => {
       label: 'canvas/webgl',
       ms: 45,
     });
+    assert.deepEqual(dominantRenderPhase({
+      styleLayout: 0,
+      rendering: 0,
+      canvas: 0,
+      scriptEvaluation: 0,
+    }), {
+      phase: 'none',
+      label: 'none',
+      ms: 0,
+    });
   });
 
   it('normalizes raw trace files before comparison', () => {
@@ -239,14 +268,45 @@ describe('measure-dashboard-render-axis reporting', () => {
     assert.equal(report.forcedReflows.eventCount, 0);
   });
 
+  it('normalizes raw interaction trace files without dropping timing metadata', () => {
+    const report = normalizeReport({
+      url: 'http://127.0.0.1:4175/dashboard',
+      interaction: {
+        ...resolveInteractionTarget('nav-chip'),
+        targetInfo: { tapPoint: { x: 32, y: 48, matchedTop: true } },
+      },
+      eventTimings: [
+        {
+          name: 'click',
+          startTime: 100,
+          processingStart: 120,
+          processingEnd: 140,
+          duration: 300,
+          selector: '.mobile-panel-nav-chip',
+        },
+      ],
+      traceEvents: [
+        { ph: 'X', name: 'Canvas2DLayerBridge::FlushCanvas', dur: 5000 },
+      ],
+    });
+
+    assert.equal(report.interaction?.target.name, 'nav-chip');
+    assert.equal(report.interaction?.timings.eventCount, 1);
+    assert.equal(report.interaction?.timings.worst?.name, 'click');
+    assert.equal(report.interaction?.timings.worst?.presentationDelayMs, 260);
+    assert.equal(report.interaction?.dominantPhase.phase, 'canvas');
+  });
+
   it('compares before/after reports with absolute and relative deltas', () => {
     const comparison = compareReports(
-      { url: 'before', durationMs: { styleLayout: 100, rendering: 20, scriptEvaluation: 10, estimatedTbt: 50 }, forcedReflows: { eventCount: 4, totalMs: 246, markerCount: 0, markerTotalMs: 0 } },
-      { url: 'after', durationMs: { styleLayout: 60, rendering: 15, scriptEvaluation: 11, estimatedTbt: 35 }, forcedReflows: { eventCount: 1, totalMs: 171, markerCount: 0, markerTotalMs: 0 } },
+      { url: 'before', durationMs: { styleLayout: 100, rendering: 20, canvas: 10, scriptEvaluation: 10, estimatedTbt: 50 }, forcedReflows: { eventCount: 4, totalMs: 246, markerCount: 0, markerTotalMs: 0 } },
+      { url: 'after', durationMs: { styleLayout: 60, rendering: 15, canvas: 25, scriptEvaluation: 11, estimatedTbt: 35 }, forcedReflows: { eventCount: 1, totalMs: 171, markerCount: 0, markerTotalMs: 0 } },
     );
 
     assert.equal(comparison.deltaMs.styleLayout, -40);
     assert.equal(comparison.deltaPct.styleLayout, -40);
+    assert.equal(comparison.deltaMs.canvas, 15);
+    assert.equal(comparison.deltaPct.canvas, 150);
     assert.equal(comparison.deltaMs.estimatedTbt, -15);
     assert.equal(comparison.forcedReflowEvents.delta, -3);
     // The ≤200ms #4487 acceptance target tracks attributed forced-reflow ms.
@@ -365,5 +425,21 @@ describe('measure-dashboard-render-axis parseArgs', () => {
     assert.equal(args.interact?.selector, '#mapOverlays .conflict-click-area');
     assert.equal(args.width, 430);
     assert.equal(args.height, 932);
+  });
+
+  it('falls back to the issue viewport when invalid interaction viewport overrides are ignored', () => {
+    const args = parseArgs([
+      'node',
+      'script',
+      '--width',
+      'notanumber',
+      '--height',
+      'nope',
+      '--interact',
+      'country',
+    ]);
+
+    assert.equal(args.width, 390);
+    assert.equal(args.height, 844);
   });
 });

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -172,8 +172,10 @@ describe('measure-dashboard-render-axis reporting', () => {
       url: 'http://127.0.0.1:4173/dashboard',
       generatedAt: '2026-07-09T00:00:00.000Z',
       viewport: { width: 390, height: 844 },
+      cpuThrottleRate: 4,
       interaction: {
         ...resolveInteractionTarget('country'),
+        postInteractMs: 1500,
         targetInfo: { tapPoint: { x: 120, y: 200, matchedTop: true } },
       },
       eventTimings: [
@@ -194,9 +196,14 @@ describe('measure-dashboard-render-axis reporting', () => {
     });
 
     assert.equal(report.interaction?.target.name, 'country');
+    assert.equal(report.cpuThrottleRate, 4);
     assert.equal(report.interaction?.timings.worst?.presentationDelayMs, 520);
     assert.equal(report.interaction?.dominantPhase.phase, 'rendering');
     assert.equal(report.interaction?.dominantPhase.ms, 250);
+    assert.deepEqual(report.interaction?.traceWindow, {
+      postInteractMs: 1500,
+      dominantPhaseScope: 'full-post-interaction-trace-window',
+    });
     assert.deepEqual(report.interaction?.warnings, []);
   });
 
@@ -271,6 +278,7 @@ describe('measure-dashboard-render-axis reporting', () => {
   it('normalizes raw interaction trace files without dropping timing metadata', () => {
     const report = normalizeReport({
       url: 'http://127.0.0.1:4175/dashboard',
+      cpuThrottleRate: 6,
       interaction: {
         ...resolveInteractionTarget('nav-chip'),
         targetInfo: { tapPoint: { x: 32, y: 48, matchedTop: true } },
@@ -291,6 +299,7 @@ describe('measure-dashboard-render-axis reporting', () => {
     });
 
     assert.equal(report.interaction?.target.name, 'nav-chip');
+    assert.equal(report.cpuThrottleRate, 6);
     assert.equal(report.interaction?.timings.eventCount, 1);
     assert.equal(report.interaction?.timings.worst?.name, 'click');
     assert.equal(report.interaction?.timings.worst?.presentationDelayMs, 260);
@@ -358,6 +367,7 @@ describe('measure-dashboard-render-axis parseArgs', () => {
     assert.equal(args.settle, 10000);
     assert.equal(args.width, 1365);
     assert.equal(args.height, 768);
+    assert.equal(args.cpuThrottleRate, 1);
     assert.equal(args.json, false);
   });
 
@@ -372,6 +382,8 @@ describe('measure-dashboard-render-axis parseArgs', () => {
       '1440',
       '--height',
       '900',
+      '--cpu-throttle',
+      '4',
       '--trace-out',
       '/tmp/trace.json',
       '--json',
@@ -380,6 +392,7 @@ describe('measure-dashboard-render-axis parseArgs', () => {
     assert.equal(args.settle, 250);
     assert.equal(args.width, 1440);
     assert.equal(args.height, 900);
+    assert.equal(args.cpuThrottleRate, 4);
     assert.equal(args.traceOut, '/tmp/trace.json');
     assert.equal(args.json, true);
   });
@@ -435,11 +448,14 @@ describe('measure-dashboard-render-axis parseArgs', () => {
       'notanumber',
       '--height',
       'nope',
+      '--cpu-throttle',
+      'nope',
       '--interact',
       'country',
     ]);
 
     assert.equal(args.width, 390);
     assert.equal(args.height, 844);
+    assert.equal(args.cpuThrottleRate, 1);
   });
 });

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -5,11 +5,14 @@ import {
   buildReport,
   classifyRenderAxisEvent,
   compareReports,
+  dominantRenderPhase,
   extractStackFrames,
   isForcedReflow,
   normalizeReport,
   parseArgs,
+  resolveInteractionTarget,
   summarizeForcedReflows,
+  summarizeInteractionTimings,
   summarizeTraceEvents,
 } from '../scripts/measure-dashboard-render-axis.mjs';
 
@@ -18,6 +21,7 @@ describe('measure-dashboard-render-axis trace parsing', () => {
     assert.equal(classifyRenderAxisEvent('Layout'), 'styleLayout');
     assert.equal(classifyRenderAxisEvent('UpdateLayoutTree'), 'styleLayout');
     assert.equal(classifyRenderAxisEvent('Paint'), 'rendering');
+    assert.equal(classifyRenderAxisEvent('Canvas2DLayerBridge::FlushCanvas'), 'canvas');
     assert.equal(classifyRenderAxisEvent('EvaluateScript'), 'scriptEvaluation');
     assert.equal(classifyRenderAxisEvent('LayoutShift'), null);
   });
@@ -27,19 +31,21 @@ describe('measure-dashboard-render-axis trace parsing', () => {
       traceEvents: [
         { ph: 'X', name: 'Layout', dur: 4000 },
         { ph: 'X', name: 'Paint', dur: 2000 },
+        { ph: 'X', name: 'Canvas2DLayerBridge::FlushCanvas', dur: 1000 },
         { ph: 'X', name: 'EvaluateScript', dur: 6000 },
         { ph: 'X', name: 'RunTask', dur: 90000 },
         { ph: 'I', name: 'Layout', dur: 100000 },
       ],
     });
 
-    assert.equal(summary.eventCount, 5);
+    assert.equal(summary.eventCount, 6);
     assert.equal(summary.durationMs.styleLayout, 4);
     assert.equal(summary.durationMs.rendering, 2);
+    assert.equal(summary.durationMs.canvas, 1);
     assert.equal(summary.durationMs.scriptEvaluation, 6);
     assert.equal(summary.durationMs.topLevelTasks, 90);
     assert.equal(summary.durationMs.estimatedTbt, 40);
-    assert.equal(summary.sharePct.styleLayoutOfAccounted, 33.3);
+    assert.equal(summary.sharePct.styleLayoutOfAccounted, 30.8);
   });
 
   it('extracts and ranks explicitly forced reflow stacks', () => {
@@ -161,6 +167,61 @@ describe('measure-dashboard-render-axis reporting', () => {
     assert.doesNotThrow(() => JSON.parse(JSON.stringify(report)));
   });
 
+  it('builds an interaction report with event timing parts and dominant render phase', () => {
+    const report = buildReport({
+      url: 'http://127.0.0.1:4173/dashboard',
+      generatedAt: '2026-07-09T00:00:00.000Z',
+      viewport: { width: 390, height: 844 },
+      interaction: resolveInteractionTarget('country'),
+      eventTimings: [
+        {
+          name: 'pointerup',
+          startTime: 100,
+          processingStart: 150,
+          processingEnd: 180,
+          duration: 600,
+          selector: '#mapSvg path.country',
+        },
+      ],
+      traceEvents: [
+        { ph: 'X', name: 'Layout', dur: 20_000 },
+        { ph: 'X', name: 'Paint', dur: 250_000 },
+        { ph: 'X', name: 'FunctionCall', dur: 30_000 },
+      ],
+    });
+
+    assert.equal(report.interaction?.target.name, 'country');
+    assert.equal(report.interaction?.timings.worst?.presentationDelayMs, 520);
+    assert.equal(report.interaction?.dominantPhase.phase, 'rendering');
+    assert.equal(report.interaction?.dominantPhase.ms, 250);
+  });
+
+  it('summarizes event-timing entries into input, processing, and presentation delay', () => {
+    const summary = summarizeInteractionTimings([
+      { name: 'pointerdown', startTime: 20, processingStart: 30, processingEnd: 45, duration: 80 },
+      { name: 'click', startTime: 100, processingStart: 140, processingEnd: 160, duration: 240 },
+    ]);
+
+    assert.equal(summary.eventCount, 2);
+    assert.equal(summary.worst?.name, 'click');
+    assert.equal(summary.worst?.inputDelayMs, 40);
+    assert.equal(summary.worst?.processingMs, 20);
+    assert.equal(summary.worst?.presentationDelayMs, 180);
+  });
+
+  it('names the dominant render phase from render-axis durations', () => {
+    assert.deepEqual(dominantRenderPhase({
+      styleLayout: 12,
+      rendering: 4,
+      canvas: 45,
+      scriptEvaluation: 8,
+    }), {
+      phase: 'canvas',
+      label: 'canvas/webgl',
+      ms: 45,
+    });
+  });
+
   it('normalizes raw trace files before comparison', () => {
     const report = normalizeReport({
       url: 'http://127.0.0.1:4175/dashboard',
@@ -267,5 +328,42 @@ describe('measure-dashboard-render-axis parseArgs', () => {
     const args = parseArgs(['node', 'script', '--compare', 'before.json', 'after.json', '--json']);
     assert.deepEqual(args.compare, { before: 'before.json', after: 'after.json' });
     assert.equal(args.json, true);
+  });
+
+  it('accepts named mobile interaction targets and uses the 390x844 issue viewport', () => {
+    const args = parseArgs([
+      'node',
+      'script',
+      'http://localhost:4173/dashboard',
+      '--interact',
+      'country',
+      '--json',
+    ]);
+
+    assert.equal(args.url, 'http://localhost:4173/dashboard');
+    assert.equal(args.interact?.name, 'country');
+    assert.equal(args.interact?.selector, '#mapSvg path.country');
+    assert.equal(args.width, 390);
+    assert.equal(args.height, 844);
+    assert.equal(args.postInteract, 1200);
+    assert.equal(args.json, true);
+  });
+
+  it('accepts custom interaction selectors without losing explicit viewport overrides', () => {
+    const args = parseArgs([
+      'node',
+      'script',
+      '--width',
+      '430',
+      '--height',
+      '932',
+      '--interact',
+      'selector:#mapOverlays .conflict-click-area',
+    ]);
+
+    assert.equal(args.interact?.name, 'custom');
+    assert.equal(args.interact?.selector, '#mapOverlays .conflict-click-area');
+    assert.equal(args.width, 430);
+    assert.equal(args.height, 932);
   });
 });


### PR DESCRIPTION
## Summary

The dashboard render-axis harness can now run a settled mobile tap capture instead of only page-load traces, so the #5080 investigation can isolate whether a bad map or nav interaction is dominated by style/layout, paint/raster, canvas/WebGL, or script. The new `--interact` mode defaults to the issue viewport, records Event Timing input/processing/presentation parts, and includes named targets for country paths, the SVG base rect, and mobile nav chips.

The tap driver also chooses an actual hit-testable point from SVG geometry or the visible portion of large SVG elements, so the diagnostic works on the current layered map DOM instead of timing out on Playwright actionability checks.

Related: #5080

## Validation

- `./node_modules/.bin/tsx --test tests/measure-dashboard-render-axis.test.mts`
- `node --check scripts/measure-dashboard-render-axis.mjs`
- `git diff --check`
- `./node_modules/.bin/biome lint scripts/measure-dashboard-render-axis.mjs tests/measure-dashboard-render-axis.test.mts`
- `npm run typecheck`
- Live local smoke against `http://127.0.0.1:3000/dashboard` for `--interact country`, `--interact base`, and `--interact nav-chip`; the country/base/nav traces completed and reported `paint/composite/raster` as the dominant phase with `RasterTask` leading the render-axis events.
- Push-time pre-push gate passed, including frontend/API/Convex typechecks, boundary/safe-html/rate-limit/premium-fetch guards, changed test file, version sync, and scoped skips for unchanged surfaces.

## Post-Deploy Monitoring & Validation

- Run `node scripts/measure-dashboard-render-axis.mjs https://www.worldmonitor.app/dashboard --interact country --json` and repeat for `base` / `nav-chip` during the next #5080 triage pass.
- Watch `interaction.target.targetInfo.tapPoint.matchedTop`, `interaction.timings.eventCount`, `interaction.timings.worst.presentationDelayMs`, `interaction.dominantPhase`, and `topEvents[0]`.
- Healthy signal: all named targets exit 0 at 390x844, Event Timing rows are tap-window scoped, and the dominant phase/top event names are stable enough to choose the next production fix.
- Failure signal: selector timeout, `matchedTop: false` for a named target, no Event Timing entries, or trace categories collapsing to `No render-axis duration events were recognized.`
- Mitigation trigger: if the diagnostic cannot hit a target after deploy, update the target selector/point picker or revert this harness change; it has no runtime dashboard impact.
- Validation window/owner: next Track M / #5080 performance triage session; owner is the dashboard performance investigator running the trace.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
