### PR TITLE
fix(frontend): harden dashboard lazy loading and metadata

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -225,7 +225,9 @@ interface LazyPanelRegistration {
   loading: Promise<Panel | null> | null;
 }
 
-type PanelConstructor<T extends Panel> = new (...args: unknown[]) => T;
+type AnyPanelConstructor = new (...args: any[]) => Panel;
+type PanelExport<M, K extends keyof M> = M[K] extends AnyPanelConstructor ? M[K] : never;
+type ImportedPanel<M, K extends keyof M> = InstanceType<PanelExport<M, K>>;
 
 type HydrationSchedulePhase = 'visible' | 'near';
 
@@ -1211,11 +1213,18 @@ export class PanelLayoutManager implements AppModule {
       this.mountLazyPanel('live-news', grid);
       return;
     }
-    import('@/components/LiveNewsPanel').then((m) => {
+    void this.importPanel(
+      'live-news',
+      () => import('@/components/LiveNewsPanel'),
+      'LiveNewsPanel',
+      (LiveNewsPanel, module) => {
+        const liveNewsModule = module as typeof import('@/components/LiveNewsPanel');
+        if (liveNewsModule.getDefaultLiveChannels().length === 0 && liveNewsModule.loadChannelsFromStorage().length === 0) return null;
+        return new LiveNewsPanel();
+      },
+    ).then((panel) => {
       if (this.ctx.isDestroyed) return;
-      if (this.ctx.panels['live-news']) return;
-      if (m.getDefaultLiveChannels().length === 0 && m.loadChannelsFromStorage().length === 0) return;
-      const panel = new m.LiveNewsPanel();
+      if (this.ctx.panels['live-news'] || !panel) return;
       this.ctx.panels['live-news'] = panel;
       const el = panel.getElement();
       this.makeDraggable(el, 'live-news');
@@ -1226,8 +1235,6 @@ export class PanelLayoutManager implements AppModule {
       }
       this.applyPanelSettings();
       this.afterPanelMounted('live-news', panel);
-    }).catch((err) => {
-      console.error('[panel] failed to lazy-load "live-news"', err);
     });
   }
 
@@ -1250,24 +1257,22 @@ export class PanelLayoutManager implements AppModule {
     categoryKey = panelKey,
   ): void {
     if (!this.shouldCreatePanel(panelKey)) return;
-    this.lazyPanel(panelKey, () =>
-      import('@/components/NewsPanel').then((m) => {
-        const panel = new m.NewsPanel(panelKey, label, tooltip);
-        this.attachRelatedAssetHandlers(panel);
-        panel.setRiskScoreGetter(PanelLayoutManager.computeEventRisk);
-        this.ctx.newsPanels[categoryKey] = panel;
-        const existingItems = this.ctx.newsByCategory[categoryKey];
-        if (existingItems?.length) {
-          const filteredItems = this.filterItemsByTimeRange(existingItems);
-          if (filteredItems.length === 0) {
-            panel.renderFilteredEmpty(`No items in ${this.getTimeRangeLabel()}`);
-          } else {
-            panel.renderNews(filteredItems);
-          }
+    this.lazyImportedPanel(panelKey, () => import('@/components/NewsPanel'), 'NewsPanel', (NewsPanel) => {
+      const panel = new NewsPanel(panelKey, label, tooltip);
+      this.attachRelatedAssetHandlers(panel);
+      panel.setRiskScoreGetter(PanelLayoutManager.computeEventRisk);
+      this.ctx.newsPanels[categoryKey] = panel;
+      const existingItems = this.ctx.newsByCategory[categoryKey];
+      if (existingItems?.length) {
+        const filteredItems = this.filterItemsByTimeRange(existingItems);
+        if (filteredItems.length === 0) {
+          panel.renderFilteredEmpty(`No items in ${this.getTimeRangeLabel()}`);
+        } else {
+          panel.renderNews(filteredItems);
         }
-        return panel;
-      }),
-    );
+      }
+      return panel;
+    });
   }
 
   // 0-100 event risk score: 0.40×severity + 0.30×geoConvergence + 0.30×CII
@@ -1553,33 +1558,33 @@ export class PanelLayoutManager implements AppModule {
     this.createNewsPanel('tech', 'panels.tech');
     this.createNewsPanel('finance', 'panels.finance');
 
-    this.lazyPanel('heatmap', () => import('@/components/MarketPanel').then(m => new m.HeatmapPanel()));
-    this.lazyPanel('markets', () => import('@/components/MarketPanel').then(m => new m.MarketPanel()));
-    this.lazyPanel('stock-analysis', () => import('@/components/StockAnalysisPanel').then(m => new m.StockAnalysisPanel()));
-    this.lazyPanel('stock-backtest', () => import('@/components/StockBacktestPanel').then(m => new m.StockBacktestPanel()));
+    this.lazyDefaultPanel('heatmap', () => import('@/components/MarketPanel'), 'HeatmapPanel');
+    this.lazyDefaultPanel('markets', () => import('@/components/MarketPanel'), 'MarketPanel');
+    this.lazyDefaultPanel('stock-analysis', () => import('@/components/StockAnalysisPanel'), 'StockAnalysisPanel');
+    this.lazyDefaultPanel('stock-backtest', () => import('@/components/StockBacktestPanel'), 'StockBacktestPanel');
     // Web premium gating for stock-analysis and stock-backtest is handled
     // reactively by updatePanelGating() via auth state subscription.
 
-    this.lazyPanel('monitors', () => import('@/components/MonitorPanel').then(m => {
-      const monitorPanel = new m.MonitorPanel(this.ctx.monitors);
+    this.lazyImportedPanel('monitors', () => import('@/components/MonitorPanel'), 'MonitorPanel', (MonitorPanel) => {
+      const monitorPanel = new MonitorPanel(this.ctx.monitors);
       monitorPanel.onChanged((monitors) => {
         this.ctx.monitors = monitors;
         saveToStorage(STORAGE_KEYS.monitors, monitors);
         this.callbacks.updateMonitorResults();
       });
       return monitorPanel;
-    }));
+    });
 
     // Latest Brief — reads /api/latest-brief and opens the hosted
     // magazine on click. Self-fetching (no data-loader integration);
     // PRO gating handled by the base Panel class via premium: 'locked'.
-    this.lazyPanel('latest-brief', () => import('@/components/LatestBriefPanel').then(m => new m.LatestBriefPanel()));
+    this.lazyDefaultPanel('latest-brief', () => import('@/components/LatestBriefPanel'), 'LatestBriefPanel');
 
-    this.lazyPanel('commodities', () => import('@/components/MarketPanel').then(m => new m.CommoditiesPanel()));
-    this.lazyPanel('energy-complex', () => import('@/components/EnergyComplexPanel').then(m => new m.EnergyComplexPanel()));
-    this.lazyPanel('oil-inventories', () => import('@/components/OilInventoriesPanel').then(m => new m.OilInventoriesPanel()));
-    this.lazyPanel('energy-crisis', () => import('@/components/EnergyCrisisPanel').then(m => new m.EnergyCrisisPanel()));
-    this.lazyPanel('chokepoint-strip', () => import('@/components/ChokepointStripPanel').then(m => new m.ChokepointStripPanel()));
+    this.lazyDefaultPanel('commodities', () => import('@/components/MarketPanel'), 'CommoditiesPanel');
+    this.lazyDefaultPanel('energy-complex', () => import('@/components/EnergyComplexPanel'), 'EnergyComplexPanel');
+    this.lazyDefaultPanel('oil-inventories', () => import('@/components/OilInventoriesPanel'), 'OilInventoriesPanel');
+    this.lazyDefaultPanel('energy-crisis', () => import('@/components/EnergyCrisisPanel'), 'EnergyCrisisPanel');
+    this.lazyDefaultPanel('chokepoint-strip', () => import('@/components/ChokepointStripPanel'), 'ChokepointStripPanel');
     this.lazyPanel('pipeline-status', () =>
       this.importPanel('pipeline-status', () => import('@/components/PipelineStatusPanel'), 'PipelineStatusPanel', (PipelineStatusPanel) => new PipelineStatusPanel()),
     );
@@ -1595,16 +1600,16 @@ export class PanelLayoutManager implements AppModule {
     this.lazyPanel('energy-risk-overview', () =>
       this.importPanel('energy-risk-overview', () => import('@/components/EnergyRiskOverviewPanel'), 'EnergyRiskOverviewPanel', (EnergyRiskOverviewPanel) => new EnergyRiskOverviewPanel()),
     );
-    this.lazyPanel('polymarket', () => import('@/components/PredictionPanel').then(m => new m.PredictionPanel()));
+    this.lazyDefaultPanel('polymarket', () => import('@/components/PredictionPanel'), 'PredictionPanel');
 
     this.createNewsPanel('gov', 'panels.gov');
     this.createNewsPanel('intel', 'panels.intel');
 
-    this.lazyPanel('crypto', () => import('@/components/MarketPanel').then(m => new m.CryptoPanel()));
-    this.lazyPanel('crypto-heatmap', () => import('@/components/MarketPanel').then(m => new m.CryptoHeatmapPanel()));
-    this.lazyPanel('defi-tokens', () => import('@/components/MarketPanel').then(m => new m.DefiTokensPanel()));
-    this.lazyPanel('ai-tokens', () => import('@/components/MarketPanel').then(m => new m.AiTokensPanel()));
-    this.lazyPanel('other-tokens', () => import('@/components/MarketPanel').then(m => new m.OtherTokensPanel()));
+    this.lazyDefaultPanel('crypto', () => import('@/components/MarketPanel'), 'CryptoPanel');
+    this.lazyDefaultPanel('crypto-heatmap', () => import('@/components/MarketPanel'), 'CryptoHeatmapPanel');
+    this.lazyDefaultPanel('defi-tokens', () => import('@/components/MarketPanel'), 'DefiTokensPanel');
+    this.lazyDefaultPanel('ai-tokens', () => import('@/components/MarketPanel'), 'AiTokensPanel');
+    this.lazyDefaultPanel('other-tokens', () => import('@/components/MarketPanel'), 'OtherTokensPanel');
     this.createNewsPanel('middleeast', 'panels.middleeast');
     this.createNewsPanel('layoffs', 'panels.layoffs');
     this.createNewsPanel('ai', 'panels.ai');
@@ -1623,13 +1628,13 @@ export class PanelLayoutManager implements AppModule {
     this.createNewsPanel('github', 'panels.github');
     this.createNewsPanel('ipo', 'panels.ipo');
     this.createNewsPanel('thinktanks', 'panels.thinktanks');
-    this.lazyPanel('economic', () => import('@/components/EconomicPanel').then(m => new m.EconomicPanel()));
-    this.lazyPanel('consumer-prices', () => import('@/components/ConsumerPricesPanel').then(m => new m.ConsumerPricesPanel()));
+    this.lazyDefaultPanel('economic', () => import('@/components/EconomicPanel'), 'EconomicPanel');
+    this.lazyDefaultPanel('consumer-prices', () => import('@/components/ConsumerPricesPanel'), 'ConsumerPricesPanel');
 
-    this.lazyPanel('trade-policy', () => import('@/components/TradePolicyPanel').then(m => new m.TradePolicyPanel()));
-    this.lazyPanel('sanctions-pressure', () => import('@/components/SanctionsPressurePanel').then(m => new m.SanctionsPressurePanel()));
-    this.lazyPanel('supply-chain', () => import('@/components/SupplyChainPanel').then(m => {
-      const supplyChainPanel = new m.SupplyChainPanel();
+    this.lazyDefaultPanel('trade-policy', () => import('@/components/TradePolicyPanel'), 'TradePolicyPanel');
+    this.lazyDefaultPanel('sanctions-pressure', () => import('@/components/SanctionsPressurePanel'), 'SanctionsPressurePanel');
+    this.lazyImportedPanel('supply-chain', () => import('@/components/SupplyChainPanel'), 'SupplyChainPanel', (SupplyChainPanel) => {
+      const supplyChainPanel = new SupplyChainPanel();
       supplyChainPanel.setOnScenarioActivate((id, result) => {
         this.ctx.map?.activateScenario(id, result);
       });
@@ -1638,7 +1643,7 @@ export class PanelLayoutManager implements AppModule {
       });
       this.ctx.map?.setSupplyChainPanel(supplyChainPanel);
       return supplyChainPanel;
-    }));
+    });
 
     this.createNewsPanel('africa', 'panels.africa');
     this.createNewsPanel('latam', 'panels.latam');
@@ -1675,7 +1680,7 @@ export class PanelLayoutManager implements AppModule {
       this.createNewsPanelWithLabel(panelKey, label, tooltip, key);
     }
 
-    this.lazyPanel('gdelt-intel', () => import('@/components/GdeltIntelPanel').then(m => new m.GdeltIntelPanel()));
+    this.lazyDefaultPanel('gdelt-intel', () => import('@/components/GdeltIntelPanel'), 'GdeltIntelPanel');
 
     this.lazyPanel('deduction', () =>
       this.importPanel(
@@ -1694,8 +1699,8 @@ export class PanelLayoutManager implements AppModule {
       ),
     );
 
-    this.lazyPanel('cii', () => import('@/components/CIIPanel').then(m => {
-      const ciiPanel = new m.CIIPanel();
+    this.lazyImportedPanel('cii', () => import('@/components/CIIPanel'), 'CIIPanel', (CIIPanel) => {
+      const ciiPanel = new CIIPanel();
       ciiPanel.setShareStoryHandler((code, name) => {
         this.callbacks.openCountryStory(code, name);
       });
@@ -1703,179 +1708,173 @@ export class PanelLayoutManager implements AppModule {
         this.callbacks.openCountryBrief(code);
       });
       return ciiPanel;
-    }));
+    });
 
-    this.lazyPanel('cascade', () => import('@/components/CascadePanel').then(m => new m.CascadePanel()));
-    this.lazyPanel('satellite-fires', () => import('@/components/SatelliteFiresPanel').then(m => new m.SatelliteFiresPanel()));
+    this.lazyDefaultPanel('cascade', () => import('@/components/CascadePanel'), 'CascadePanel');
+    this.lazyDefaultPanel('satellite-fires', () => import('@/components/SatelliteFiresPanel'), 'SatelliteFiresPanel');
 
-    this.lazyPanel('defense-patents', () => import('@/components/DefensePatentsPanel').then(m => new m.DefensePatentsPanel()));
+    this.lazyDefaultPanel('defense-patents', () => import('@/components/DefensePatentsPanel'), 'DefensePatentsPanel');
 
     // Correlation engine panels
-    this.lazyPanel('military-correlation', () => import('@/components/MilitaryCorrelationPanel').then(m => {
-      const p = new m.MilitaryCorrelationPanel();
+    this.lazyImportedPanel('military-correlation', () => import('@/components/MilitaryCorrelationPanel'), 'MilitaryCorrelationPanel', (MilitaryCorrelationPanel) => {
+      const p = new MilitaryCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 6); });
       return p;
-    }));
-    this.lazyPanel('escalation-correlation', () => import('@/components/EscalationCorrelationPanel').then(m => {
-      const p = new m.EscalationCorrelationPanel();
+    });
+    this.lazyImportedPanel('escalation-correlation', () => import('@/components/EscalationCorrelationPanel'), 'EscalationCorrelationPanel', (EscalationCorrelationPanel) => {
+      const p = new EscalationCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 4); });
       return p;
-    }));
-    this.lazyPanel('economic-correlation', () => import('@/components/EconomicCorrelationPanel').then(m => {
-      const p = new m.EconomicCorrelationPanel();
+    });
+    this.lazyImportedPanel('economic-correlation', () => import('@/components/EconomicCorrelationPanel'), 'EconomicCorrelationPanel', (EconomicCorrelationPanel) => {
+      const p = new EconomicCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 4); });
       return p;
-    }));
-    this.lazyPanel('disaster-correlation', () => import('@/components/DisasterCorrelationPanel').then(m => {
-      const p = new m.DisasterCorrelationPanel();
+    });
+    this.lazyImportedPanel('disaster-correlation', () => import('@/components/DisasterCorrelationPanel'), 'DisasterCorrelationPanel', (DisasterCorrelationPanel) => {
+      const p = new DisasterCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 5); });
       return p;
-    }));
+    });
 
-    this.lazyPanel('strategic-risk', () => import('@/components/StrategicRiskPanel').then(m => {
-      const strategicRiskPanel = new m.StrategicRiskPanel();
+    this.lazyImportedPanel('strategic-risk', () => import('@/components/StrategicRiskPanel'), 'StrategicRiskPanel', (StrategicRiskPanel) => {
+      const strategicRiskPanel = new StrategicRiskPanel();
       strategicRiskPanel.setLocationClickHandler((lat, lon) => {
         this.ctx.map?.setCenter(lat, lon, 4);
       });
       return strategicRiskPanel;
-    }));
+    });
 
-    this.lazyPanel('strategic-posture', () => import('@/components/StrategicPosturePanel').then(m => {
-      const strategicPosturePanel = new m.StrategicPosturePanel(() => this.ctx.allNews);
+    this.lazyImportedPanel('strategic-posture', () => import('@/components/StrategicPosturePanel'), 'StrategicPosturePanel', (StrategicPosturePanel) => {
+      const strategicPosturePanel = new StrategicPosturePanel(() => this.ctx.allNews);
       strategicPosturePanel.setLocationClickHandler((lat, lon) => {
         this.ctx.map?.setCenter(lat, lon, 4);
       });
       return strategicPosturePanel;
-    }));
+    });
 
-    this.lazyPanel('ucdp-events', () => import('@/components/UcdpEventsPanel').then(m => {
-      const ucdpEventsPanel = new m.UcdpEventsPanel();
+    this.lazyImportedPanel('ucdp-events', () => import('@/components/UcdpEventsPanel'), 'UcdpEventsPanel', (UcdpEventsPanel) => {
+      const ucdpEventsPanel = new UcdpEventsPanel();
       ucdpEventsPanel.setEventClickHandler((lat, lon) => {
         this.ctx.map?.setCenter(lat, lon, 5);
       });
       return ucdpEventsPanel;
-    }));
+    });
 
-    this.lazyPanel('disease-outbreaks', () => import('@/components/DiseaseOutbreaksPanel').then(m => new m.DiseaseOutbreaksPanel()));
-    this.lazyPanel('social-velocity', () => import('@/components/SocialVelocityPanel').then(m => new m.SocialVelocityPanel()));
-    this.lazyPanel('wsb-ticker-scanner', () => import('@/components/WsbTickerScannerPanel').then(m => new m.WsbTickerScannerPanel()));
+    this.lazyDefaultPanel('disease-outbreaks', () => import('@/components/DiseaseOutbreaksPanel'), 'DiseaseOutbreaksPanel');
+    this.lazyDefaultPanel('social-velocity', () => import('@/components/SocialVelocityPanel'), 'SocialVelocityPanel');
+    this.lazyDefaultPanel('wsb-ticker-scanner', () => import('@/components/WsbTickerScannerPanel'), 'WsbTickerScannerPanel');
 
-    this.lazyPanel('displacement', () =>
-      import('@/components/DisplacementPanel').then(m => {
-        const p = new m.DisplacementPanel();
-        p.setCountryClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
-        return p;
-      }),
-    );
+    this.lazyImportedPanel('displacement', () => import('@/components/DisplacementPanel'), 'DisplacementPanel', (DisplacementPanel) => {
+      const p = new DisplacementPanel();
+      p.setCountryClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
+      return p;
+    });
 
-    this.lazyPanel('climate', () =>
-      import('@/components/ClimateAnomalyPanel').then(m => {
-        const p = new m.ClimateAnomalyPanel();
-        p.setZoneClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
-        return p;
-      }),
-    );
+    this.lazyImportedPanel('climate', () => import('@/components/ClimateAnomalyPanel'), 'ClimateAnomalyPanel', (ClimateAnomalyPanel) => {
+      const p = new ClimateAnomalyPanel();
+      p.setZoneClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
+      return p;
+    });
 
-    this.lazyPanel('population-exposure', () =>
-      import('@/components/PopulationExposurePanel').then(m => new m.PopulationExposurePanel()),
-    );
+    this.lazyDefaultPanel('population-exposure', () => import('@/components/PopulationExposurePanel'), 'PopulationExposurePanel');
 
-    this.lazyPanel('security-advisories', () =>
-      import('@/components/SecurityAdvisoriesPanel').then(m => {
-        const p = new m.SecurityAdvisoriesPanel();
-        p.setRefreshHandler(() => { void this.callbacks.loadSecurityAdvisories?.(); });
-        return p;
-      }),
-    );
+    this.lazyImportedPanel('security-advisories', () => import('@/components/SecurityAdvisoriesPanel'), 'SecurityAdvisoriesPanel', (SecurityAdvisoriesPanel) => {
+      const p = new SecurityAdvisoriesPanel();
+      p.setRefreshHandler(() => { void this.callbacks.loadSecurityAdvisories?.(); });
+      return p;
+    });
 
-    this.lazyPanel('radiation-watch', () =>
-      import('@/components/RadiationWatchPanel').then(m => {
-        const p = new m.RadiationWatchPanel();
-        p.setLocationClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
-        return p;
-      }),
-    );
+    this.lazyImportedPanel('radiation-watch', () => import('@/components/RadiationWatchPanel'), 'RadiationWatchPanel', (RadiationWatchPanel) => {
+      const p = new RadiationWatchPanel();
+      p.setLocationClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
+      return p;
+    });
 
-    this.lazyPanel('thermal-escalation', () =>
-      import('@/components/ThermalEscalationPanel').then(m => {
-        const p = new m.ThermalEscalationPanel();
-        p.setLocationClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
-        return p;
-      }),
-    );
+    this.lazyImportedPanel('thermal-escalation', () => import('@/components/ThermalEscalationPanel'), 'ThermalEscalationPanel', (ThermalEscalationPanel) => {
+      const p = new ThermalEscalationPanel();
+      p.setLocationClickHandler((lat: number, lon: number) => { this.ctx.map?.setCenter(lat, lon, 4); });
+      return p;
+    });
 
     const _lockPanels = this.ctx.isDesktopApp && !hasPremiumAccess();
 
-    this.lazyPanel('daily-market-brief', () =>
-      import('@/components/DailyMarketBriefPanel').then(m => new m.DailyMarketBriefPanel()),
-    );
+    this.lazyDefaultPanel('daily-market-brief', () => import('@/components/DailyMarketBriefPanel'), 'DailyMarketBriefPanel');
 
-    this.lazyPanel('market-implications', () =>
-      import('@/components/MarketImplicationsPanel').then(m => new m.MarketImplicationsPanel()),
-    );
+    this.lazyDefaultPanel('market-implications', () => import('@/components/MarketImplicationsPanel'), 'MarketImplicationsPanel');
     // Gating for daily-market-brief, market-implications, and chat-analyst is handled
     // reactively by updatePanelGating() via auth state subscription (all in WEB_PREMIUM_PANELS).
 
-    this.lazyPanel('chat-analyst', () =>
+    this.lazyImportedPanel('chat-analyst', () => import('@/components/ChatAnalystPanel'), 'ChatAnalystPanel', (ChatAnalystPanel) => {
       // agent-bus-applier (and its zod-backed shared/agent-bus-actions schemas, ~69KB)
       // is only reachable through this lazy panel's action handler. Start loading it
       // here so it stays off the eager main entry, but do not make plain chat depend
       // on the optional dashboard-control chunk being available.
-      import('@/components/ChatAnalystPanel').then(m => {
-        const panel = new m.ChatAnalystPanel();
-        void import('@/app/agent-bus-applier')
-          .then(({ applyAgentBusAction }) => {
-            panel.setDashboardActionHandler((action) => applyAgentBusAction(this.ctx, action, {
-              getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),
-              isPanelAllowed: (panelId, config) => isPanelEntitled(panelId, config, hasPremiumAccess(getAuthState())),
-              hasPremiumAccess: () => hasPremiumAccess(getAuthState()),
-              applyLayerChange: this.callbacks.applyMapLayerChange,
-            }));
-          })
-          .catch((err) => {
-            console.error('[panel] failed to lazy-load "chat-analyst" dashboard action handler', err);
-          });
-        return panel;
-      }),
-    );
+      const panel = new ChatAnalystPanel();
+      void import('@/app/agent-bus-applier')
+        .then(({ applyAgentBusAction }) => {
+          panel.setDashboardActionHandler((action) => applyAgentBusAction(this.ctx, action, {
+            getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),
+            isPanelAllowed: (panelId, config) => isPanelEntitled(panelId, config, hasPremiumAccess(getAuthState())),
+            hasPremiumAccess: () => hasPremiumAccess(getAuthState()),
+            applyLayerChange: this.callbacks.applyMapLayerChange,
+          }));
+        })
+        .catch((err) => {
+          console.error('[panel] failed to lazy-load "chat-analyst" dashboard action handler', err);
+        });
+      return panel;
+    });
 
-    this.lazyPanel('forecast', () =>
-      import('@/components/ForecastPanel').then(m => new m.ForecastPanel()),
+    this.lazyDefaultPanel(
+      'forecast',
+      () => import('@/components/ForecastPanel'),
+      'ForecastPanel',
       undefined,
       _lockPanels ? ['AI-powered geopolitical forecasts', 'Cross-domain cascade predictions', 'Prediction market calibration'] : undefined,
     );
 
-    this.lazyPanel('oref-sirens', () =>
-      import('@/components/OrefSirensPanel').then(m => new m.OrefSirensPanel()),
+    this.lazyDefaultPanel(
+      'oref-sirens',
+      () => import('@/components/OrefSirensPanel'),
+      'OrefSirensPanel',
       undefined,
       _lockPanels ? [t('premium.features.orefSirens1'), t('premium.features.orefSirens2')] : undefined,
     );
 
-    this.lazyPanel('telegram-intel', () =>
-      import('@/components/TelegramIntelPanel').then(m => new m.TelegramIntelPanel()),
+    this.lazyDefaultPanel(
+      'telegram-intel',
+      () => import('@/components/TelegramIntelPanel'),
+      'TelegramIntelPanel',
       undefined,
       _lockPanels ? [t('premium.features.telegramIntel1'), t('premium.features.telegramIntel2')] : undefined,
     );
 
-    this.lazyPanel('gcc-investments', () =>
-      import('@/components/InvestmentsPanel').then(async (m) => {
-        const { focusInvestmentOnMap } = await import('@/services/investments-focus');
-        return new m.InvestmentsPanel((inv) => {
-          focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
+    this.lazyImportedPanel('gcc-investments', () => import('@/components/InvestmentsPanel'), 'InvestmentsPanel', (InvestmentsPanel) =>
+      new InvestmentsPanel((inv) => {
+        void import('@/services/investments-focus')
+          .then(({ focusInvestmentOnMap }) => {
+            focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
+          })
+          .catch((err) => {
+            console.error('[panel] failed to lazy-load "gcc-investments" map focus helper', err);
+          });
+      }),
+    );
+
+    this.lazyDefaultPanel('world-clock', () => import('@/components/WorldClockPanel'), 'WorldClockPanel');
+
+    this.lazyImportedPanel('airline-intel', () => import('@/components/AirlineIntelPanel'), 'AirlineIntelPanel', (AirlineIntelPanel) => {
+      const panel = new AirlineIntelPanel();
+      void import('@/components/AviationCommandBar')
+        .then(({ AviationCommandBar }) => {
+          if (!this.ctx.isDestroyed) this.aviationCommandBar = new AviationCommandBar();
+        })
+        .catch((err) => {
+          console.error('[panel] failed to lazy-load "airline-intel" command bar', err);
         });
-      }),
-    );
-
-    this.lazyPanel('world-clock', () => import('@/components/WorldClockPanel').then(m => new m.WorldClockPanel()));
-
-    this.lazyPanel('airline-intel', () =>
-      import('@/components/AirlineIntelPanel').then(async (m) => {
-        const { AviationCommandBar } = await import('@/components/AviationCommandBar');
-        const panel = new m.AirlineIntelPanel();
-        this.aviationCommandBar = new AviationCommandBar();
-        return panel;
-      }),
-    );
+      return panel;
+    });
 
     this.lazyPanel('gulf-economies', () =>
       this.importPanel('gulf-economies', () => import('@/components/GulfEconomiesPanel'), 'GulfEconomiesPanel', (GulfEconomiesPanel) => new GulfEconomiesPanel()),
@@ -1896,15 +1895,14 @@ export class PanelLayoutManager implements AppModule {
       this.importPanel('climate-news', () => import('@/components/ClimateNewsPanel'), 'ClimateNewsPanel', (ClimateNewsPanel) => new ClimateNewsPanel()),
     );
 
-    this.lazyPanel('live-news', () =>
-      import('@/components/LiveNewsPanel').then((m) => {
-        if (m.getDefaultLiveChannels().length === 0 && m.loadChannelsFromStorage().length === 0) return null;
-        return new m.LiveNewsPanel();
-      }),
-    );
+    this.lazyImportedPanel('live-news', () => import('@/components/LiveNewsPanel'), 'LiveNewsPanel', (LiveNewsPanel, module) => {
+      const liveNewsModule = module as typeof import('@/components/LiveNewsPanel');
+      if (liveNewsModule.getDefaultLiveChannels().length === 0 && liveNewsModule.loadChannelsFromStorage().length === 0) return null;
+      return new LiveNewsPanel();
+    });
 
-    this.lazyPanel('live-webcams', () => import('@/components/LiveWebcamsPanel').then(m => new m.LiveWebcamsPanel()));
-    this.lazyPanel('windy-webcams', () => import('@/components/PinnedWebcamsPanel').then(m => new m.PinnedWebcamsPanel()));
+    this.lazyDefaultPanel('live-webcams', () => import('@/components/LiveWebcamsPanel'), 'LiveWebcamsPanel');
+    this.lazyDefaultPanel('windy-webcams', () => import('@/components/PinnedWebcamsPanel'), 'PinnedWebcamsPanel');
 
     this.lazyPanel('events', () =>
       this.importPanel(
@@ -1914,163 +1912,133 @@ export class PanelLayoutManager implements AppModule {
         (TechEventsPanel) => new TechEventsPanel('events', () => this.ctx.allNews),
       ),
     );
-    this.lazyPanel('internet-disruptions', () => import('@/components/InternetDisruptionsPanel').then(m => new m.InternetDisruptionsPanel()));
-    this.lazyPanel('service-status', () => import('@/components/ServiceStatusPanel').then(m => new m.ServiceStatusPanel()));
+    this.lazyDefaultPanel('internet-disruptions', () => import('@/components/InternetDisruptionsPanel'), 'InternetDisruptionsPanel');
+    this.lazyDefaultPanel('service-status', () => import('@/components/ServiceStatusPanel'), 'ServiceStatusPanel');
 
-    this.lazyPanel('tech-readiness', () =>
-      import('@/components/TechReadinessPanel').then(m => {
-        const p = new m.TechReadinessPanel();
-        // Only auto-refresh on variants whose bootstrap seeds techReadiness
-        // (full + tech). On commodity/finance/energy the seed key is empty
-        // and the 5s fetch at services/economic/index.ts:694 just times out.
-        // The panel is still created so users who opt-in via settings can
-        // trigger a manual refresh from its UI.
-        if (isPanelInVariantDefaults('tech-readiness')) {
-          void p.refresh();
-        }
-        return p;
-      }),
-    );
-
-    this.lazyPanel('national-debt', () =>
-      import('@/components/NationalDebtPanel').then(m => {
-        const p = new m.NationalDebtPanel();
+    this.lazyImportedPanel('tech-readiness', () => import('@/components/TechReadinessPanel'), 'TechReadinessPanel', (TechReadinessPanel) => {
+      const p = new TechReadinessPanel();
+      // Only auto-refresh on variants whose bootstrap seeds techReadiness
+      // (full + tech). On commodity/finance/energy the seed key is empty
+      // and the 5s fetch at services/economic/index.ts:694 just times out.
+      // The panel is still created so users who opt-in via settings can
+      // trigger a manual refresh from its UI.
+      if (isPanelInVariantDefaults('tech-readiness')) {
         void p.refresh();
-        return p;
-      }),
-    );
+      }
+      return p;
+    });
 
-    this.lazyPanel('cross-source-signals', () =>
-      import('@/components/CrossSourceSignalsPanel').then(m => new m.CrossSourceSignalsPanel()),
-    );
+    this.lazyImportedPanel('national-debt', () => import('@/components/NationalDebtPanel'), 'NationalDebtPanel', (NationalDebtPanel) => {
+      const p = new NationalDebtPanel();
+      void p.refresh();
+      return p;
+    });
 
-    this.lazyPanel('geo-hubs', () =>
-      import('@/components/GeoHubsPanel').then(m => {
-        const p = new m.GeoHubsPanel();
-        p.setOnHubClick((hub) => { this.ctx.map?.setCenter(hub.lat, hub.lon, 4); });
-        return p;
-      }),
-    );
+    this.lazyDefaultPanel('cross-source-signals', () => import('@/components/CrossSourceSignalsPanel'), 'CrossSourceSignalsPanel');
 
-    this.lazyPanel('tech-hubs', () =>
-      import('@/components/TechHubsPanel').then(m => {
-        const p = new m.TechHubsPanel();
-        p.setOnHubClick((hub) => { this.ctx.map?.setCenter(hub.lat, hub.lon, 4); });
-        return p;
-      }),
-    );
+    this.lazyImportedPanel('geo-hubs', () => import('@/components/GeoHubsPanel'), 'GeoHubsPanel', (GeoHubsPanel) => {
+      const p = new GeoHubsPanel();
+      p.setOnHubClick((hub) => { this.ctx.map?.setCenter(hub.lat, hub.lon, 4); });
+      return p;
+    });
 
-    this.lazyPanel('ai-regulation', () =>
-      import('@/components/RegulationPanel').then(m => new m.RegulationPanel('ai-regulation')),
-    );
+    this.lazyImportedPanel('tech-hubs', () => import('@/components/TechHubsPanel'), 'TechHubsPanel', (TechHubsPanel) => {
+      const p = new TechHubsPanel();
+      p.setOnHubClick((hub) => { this.ctx.map?.setCenter(hub.lat, hub.lon, 4); });
+      return p;
+    });
+
+    this.lazyImportedPanel('ai-regulation', () => import('@/components/RegulationPanel'), 'RegulationPanel', (RegulationPanel) => new RegulationPanel('ai-regulation'));
 
     this.lazyPanel('macro-signals', () =>
       this.importPanel('macro-signals', () => import('@/components/MacroSignalsPanel'), 'MacroSignalsPanel', (MacroSignalsPanel) => new MacroSignalsPanel()),
     );
-    this.lazyPanel('fear-greed', () => import('@/components/FearGreedPanel').then(m => new m.FearGreedPanel()));
-    this.lazyPanel('aaii-sentiment', () => import('@/components/AAIISentimentPanel').then(m => new m.AAIISentimentPanel()));
-    this.lazyPanel('market-breadth', () => import('@/components/MarketBreadthPanel').then(m => new m.MarketBreadthPanel()));
-    this.lazyPanel('macro-tiles', () => import('@/components/MacroTilesPanel').then(m => new m.MacroTilesPanel()));
-    this.lazyPanel('fsi', () => import('@/components/FSIPanel').then(m => new m.FSIPanel()));
-    this.lazyPanel('yield-curve', () => import('@/components/YieldCurvePanel').then(m => new m.YieldCurvePanel()));
-    this.lazyPanel('earnings-calendar', () => import('@/components/EarningsCalendarPanel').then(m => new m.EarningsCalendarPanel()));
-    this.lazyPanel('economic-calendar', () => import('@/components/EconomicCalendarPanel').then(m => new m.EconomicCalendarPanel()));
-    this.lazyPanel('cot-positioning', () => import('@/components/CotPositioningPanel').then(m => new m.CotPositioningPanel()));
-    this.lazyPanel('liquidity-shifts', () => import('@/components/LiquidityShiftsPanel').then(m => new m.LiquidityShiftsPanel()));
-    this.lazyPanel('positioning-247', () => import('@/components/PositioningPanel').then(m => new m.PositioningPanel()));
-    this.lazyPanel('gold-intelligence', () => import('@/components/GoldIntelligencePanel').then(m => new m.GoldIntelligencePanel()));
-    this.lazyPanel('hormuz-tracker', () => import('@/components/HormuzPanel').then(m => new m.HormuzPanel()));
-    this.lazyPanel('etf-flows', () => import('@/components/ETFFlowsPanel').then(m => new m.ETFFlowsPanel()));
-    this.lazyPanel('stablecoins', () => import('@/components/StablecoinPanel').then(m => new m.StablecoinPanel()));
+    this.lazyDefaultPanel('fear-greed', () => import('@/components/FearGreedPanel'), 'FearGreedPanel');
+    this.lazyDefaultPanel('aaii-sentiment', () => import('@/components/AAIISentimentPanel'), 'AAIISentimentPanel');
+    this.lazyDefaultPanel('market-breadth', () => import('@/components/MarketBreadthPanel'), 'MarketBreadthPanel');
+    this.lazyDefaultPanel('macro-tiles', () => import('@/components/MacroTilesPanel'), 'MacroTilesPanel');
+    this.lazyDefaultPanel('fsi', () => import('@/components/FSIPanel'), 'FSIPanel');
+    this.lazyDefaultPanel('yield-curve', () => import('@/components/YieldCurvePanel'), 'YieldCurvePanel');
+    this.lazyDefaultPanel('earnings-calendar', () => import('@/components/EarningsCalendarPanel'), 'EarningsCalendarPanel');
+    this.lazyDefaultPanel('economic-calendar', () => import('@/components/EconomicCalendarPanel'), 'EconomicCalendarPanel');
+    this.lazyDefaultPanel('cot-positioning', () => import('@/components/CotPositioningPanel'), 'CotPositioningPanel');
+    this.lazyDefaultPanel('liquidity-shifts', () => import('@/components/LiquidityShiftsPanel'), 'LiquidityShiftsPanel');
+    this.lazyDefaultPanel('positioning-247', () => import('@/components/PositioningPanel'), 'PositioningPanel');
+    this.lazyDefaultPanel('gold-intelligence', () => import('@/components/GoldIntelligencePanel'), 'GoldIntelligencePanel');
+    this.lazyDefaultPanel('hormuz-tracker', () => import('@/components/HormuzPanel'), 'HormuzPanel');
+    this.lazyDefaultPanel('etf-flows', () => import('@/components/ETFFlowsPanel'), 'ETFFlowsPanel');
+    this.lazyDefaultPanel('stablecoins', () => import('@/components/StablecoinPanel'), 'StablecoinPanel');
 
     if (this.ctx.isDesktopApp) {
-      this.lazyPanel('runtime-config', () => import('@/components/RuntimeConfigPanel').then(m => new m.RuntimeConfigPanel({ mode: 'alert' })));
+      this.lazyImportedPanel('runtime-config', () => import('@/components/RuntimeConfigPanel'), 'RuntimeConfigPanel', (RuntimeConfigPanel) => new RuntimeConfigPanel({ mode: 'alert' }));
     }
 
-    this.lazyPanel('insights', () => import('@/components/InsightsPanel').then(m => new m.InsightsPanel()));
+    this.lazyDefaultPanel('insights', () => import('@/components/InsightsPanel'), 'InsightsPanel');
     if (isPanelInVariantDefaults('threat-timeline')) {
-      this.lazyPanel('threat-timeline', () => import('@/components/ThreatTimelinePanel').then(m => new m.ThreatTimelinePanel()));
+      this.lazyDefaultPanel('threat-timeline', () => import('@/components/ThreatTimelinePanel'), 'ThreatTimelinePanel');
     }
 
     // Global Giving panel (all variants)
-    this.lazyPanel('giving', () =>
-      import('@/components/GivingPanel').then(m => new m.GivingPanel()),
-    );
+    this.lazyDefaultPanel('giving', () => import('@/components/GivingPanel'), 'GivingPanel');
 
     // Happy variant panels (lazy-loaded — only relevant for happy variant)
     if (SITE_VARIANT === 'happy') {
-      this.lazyPanel('positive-feed', () =>
-        import('@/components/PositiveNewsFeedPanel').then(m => {
-          const p = new m.PositiveNewsFeedPanel();
-          this.ctx.positivePanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('positive-feed', () => import('@/components/PositiveNewsFeedPanel'), 'PositiveNewsFeedPanel', (PositiveNewsFeedPanel) => {
+        const p = new PositiveNewsFeedPanel();
+        this.ctx.positivePanel = p;
+        return p;
+      });
 
-      this.lazyPanel('counters', () =>
-        import('@/components/CountersPanel').then(m => {
-          const p = new m.CountersPanel();
-          p.startTicking();
-          this.ctx.countersPanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('counters', () => import('@/components/CountersPanel'), 'CountersPanel', (CountersPanel) => {
+        const p = new CountersPanel();
+        p.startTicking();
+        this.ctx.countersPanel = p;
+        return p;
+      });
 
-      this.lazyPanel('progress', () =>
-        import('@/components/ProgressChartsPanel').then(m => {
-          const p = new m.ProgressChartsPanel();
-          this.ctx.progressPanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('progress', () => import('@/components/ProgressChartsPanel'), 'ProgressChartsPanel', (ProgressChartsPanel) => {
+        const p = new ProgressChartsPanel();
+        this.ctx.progressPanel = p;
+        return p;
+      });
 
-      this.lazyPanel('breakthroughs', () =>
-        import('@/components/BreakthroughsTickerPanel').then(m => {
-          const p = new m.BreakthroughsTickerPanel();
-          this.ctx.breakthroughsPanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('breakthroughs', () => import('@/components/BreakthroughsTickerPanel'), 'BreakthroughsTickerPanel', (BreakthroughsTickerPanel) => {
+        const p = new BreakthroughsTickerPanel();
+        this.ctx.breakthroughsPanel = p;
+        return p;
+      });
 
-      this.lazyPanel('spotlight', () =>
-        import('@/components/HeroSpotlightPanel').then(m => {
-          const p = new m.HeroSpotlightPanel();
-          p.onLocationRequest = (lat: number, lon: number) => {
-            this.ctx.map?.setCenter(lat, lon, 4);
-            this.ctx.map?.flashLocation(lat, lon, 3000);
-          };
-          this.ctx.heroPanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('spotlight', () => import('@/components/HeroSpotlightPanel'), 'HeroSpotlightPanel', (HeroSpotlightPanel) => {
+        const p = new HeroSpotlightPanel();
+        p.onLocationRequest = (lat: number, lon: number) => {
+          this.ctx.map?.setCenter(lat, lon, 4);
+          this.ctx.map?.flashLocation(lat, lon, 3000);
+        };
+        this.ctx.heroPanel = p;
+        return p;
+      });
 
-      this.lazyPanel('digest', () =>
-        import('@/components/GoodThingsDigestPanel').then(m => {
-          const p = new m.GoodThingsDigestPanel();
-          this.ctx.digestPanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('digest', () => import('@/components/GoodThingsDigestPanel'), 'GoodThingsDigestPanel', (GoodThingsDigestPanel) => {
+        const p = new GoodThingsDigestPanel();
+        this.ctx.digestPanel = p;
+        return p;
+      });
 
-      this.lazyPanel('species', () =>
-        import('@/components/SpeciesComebackPanel').then(m => {
-          const p = new m.SpeciesComebackPanel();
-          this.ctx.speciesPanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('species', () => import('@/components/SpeciesComebackPanel'), 'SpeciesComebackPanel', (SpeciesComebackPanel) => {
+        const p = new SpeciesComebackPanel();
+        this.ctx.speciesPanel = p;
+        return p;
+      });
 
     }
 
     // Renewable Energy is shared by happy and energy variants.
     if (this.shouldCreatePanel('renewable')) {
-      this.lazyPanel('renewable', () =>
-        import('@/components/RenewableEnergyPanel').then(m => {
-          const p = new m.RenewableEnergyPanel();
-          this.ctx.renewablePanel = p;
-          return p;
-        }),
-      );
+      this.lazyImportedPanel('renewable', () => import('@/components/RenewableEnergyPanel'), 'RenewableEnergyPanel', (RenewableEnergyPanel) => {
+        const p = new RenewableEnergyPanel();
+        this.ctx.renewablePanel = p;
+        return p;
+      });
     }
 
     // Always load custom widgets — Pro gating is handled reactively by auth state.
@@ -2804,23 +2772,49 @@ export class PanelLayoutManager implements AppModule {
     }
   }
 
-  private importPanel<T extends Panel, K extends string>(
+  private importPanel<M extends object, K extends keyof M & string>(
     key: string,
-    importer: () => Promise<Record<K, unknown>>,
+    importer: () => Promise<M>,
     exportName: K,
-    createPanel: (PanelClass: PanelConstructor<T>) => T,
-  ): Promise<T | null> {
+    createPanel: (PanelClass: PanelExport<M, K>, module: M) => ImportedPanel<M, K> | null,
+  ): Promise<ImportedPanel<M, K> | null> {
     return importer().then((module) => {
       const PanelClass = module[exportName];
       if (typeof PanelClass !== 'function') {
         console.error(`[panel] ${exportName} export unavailable for "${key}"`);
         return null;
       }
-      return createPanel(PanelClass as PanelConstructor<T>);
+      return createPanel(PanelClass as PanelExport<M, K>, module);
     }, (err) => {
       console.error(`[panel] failed to lazy-load "${key}"`, err);
       return null;
     });
+  }
+
+  private lazyImportedPanel<M extends object, K extends keyof M & string>(
+    key: string,
+    importer: () => Promise<M>,
+    exportName: K,
+    createPanel: (PanelClass: PanelExport<M, K>, module: M) => ImportedPanel<M, K> | null,
+    setup?: (panel: ImportedPanel<M, K>) => void,
+    lockedFeatures?: string[],
+  ): void {
+    this.lazyPanel(
+      key,
+      () => this.importPanel(key, importer, exportName, createPanel),
+      setup,
+      lockedFeatures,
+    );
+  }
+
+  private lazyDefaultPanel<M extends object, K extends keyof M & string>(
+    key: string,
+    importer: () => Promise<M>,
+    exportName: K,
+    setup?: (panel: ImportedPanel<M, K>) => void,
+    lockedFeatures?: string[],
+  ): void {
+    this.lazyImportedPanel(key, importer, exportName, (PanelClass) => new PanelClass() as ImportedPanel<M, K>, setup, lockedFeatures);
   }
 
   private lazyPanel<T extends Panel>(

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1235,6 +1235,8 @@ export class PanelLayoutManager implements AppModule {
       }
       this.applyPanelSettings();
       this.afterPanelMounted('live-news', panel);
+    }).catch((err) => {
+      console.error('[panel] failed to lazy-load "live-news"', err);
     });
   }
 
@@ -1850,17 +1852,14 @@ export class PanelLayoutManager implements AppModule {
       _lockPanels ? [t('premium.features.telegramIntel1'), t('premium.features.telegramIntel2')] : undefined,
     );
 
-    this.lazyImportedPanel('gcc-investments', () => import('@/components/InvestmentsPanel'), 'InvestmentsPanel', (InvestmentsPanel) =>
-      new InvestmentsPanel((inv) => {
-        void import('@/services/investments-focus')
-          .then(({ focusInvestmentOnMap }) => {
-            focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
-          })
-          .catch((err) => {
-            console.error('[panel] failed to lazy-load "gcc-investments" map focus helper', err);
-          });
-      }),
-    );
+    this.lazyPanel('gcc-investments', async () => {
+      const { focusInvestmentOnMap } = await import('@/services/investments-focus');
+      return this.importPanel('gcc-investments', () => import('@/components/InvestmentsPanel'), 'InvestmentsPanel', (InvestmentsPanel) =>
+        new InvestmentsPanel((inv) => {
+          focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
+        }),
+      );
+    });
 
     this.lazyDefaultPanel('world-clock', () => import('@/components/WorldClockPanel'), 'WorldClockPanel');
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -442,7 +442,15 @@ export class PanelLayoutManager implements AppModule {
     const destroyOnce = (target: { destroy?: () => void } | null | undefined): void => {
       if (!target || destroyedTargets.has(target)) return;
       destroyedTargets.add(target);
-      target.destroy?.();
+      // Isolate each destroy(): teardown runs over every registered panel, so a
+      // single panel throwing must not abort the remaining panel/subscription/
+      // overlay cleanup below (nor the rest of App.destroy(), which iterates
+      // modules without its own try/catch).
+      try {
+        target.destroy?.();
+      } catch (err) {
+        console.error('[panel] destroy() threw during teardown', err);
+      }
     };
     if (this.boundWidgetCreatorHandler) {
       this.ctx.container.removeEventListener('wm:open-widget-creator', this.boundWidgetCreatorHandler);
@@ -488,6 +496,8 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.digestPanel = null;
     destroyOnce(this.ctx.speciesPanel);
     this.ctx.speciesPanel = null;
+    destroyOnce(this.ctx.positivePanel);
+    this.ctx.positivePanel = null;
     destroyOnce(this.ctx.renewablePanel);
     this.ctx.renewablePanel = null;
 
@@ -502,6 +512,11 @@ export class PanelLayoutManager implements AppModule {
     }
     for (const key of Object.keys(this.ctx.panels)) {
       delete this.ctx.panels[key];
+    }
+    // News panels are the same instances just destroyed above; drop the
+    // secondary index so it never hands out a torn-down panel post-destroy.
+    for (const key of Object.keys(this.ctx.newsPanels)) {
+      delete this.ctx.newsPanels[key];
     }
 
     // Clean up billing subscription watch + entitlement subscription

--- a/src/bootstrap/debugbear-rum.ts
+++ b/src/bootstrap/debugbear-rum.ts
@@ -1,0 +1,61 @@
+const DEBUGBEAR_RUM_SCRIPT_SRC = 'https://cdn.debugbear.com/lpMwA9KpC6pf.js';
+const DEBUGBEAR_RUM_SAMPLE_RATE = 100;
+const DEBUGBEAR_RUM_HOSTS = new Set([
+  'worldmonitor.app',
+  'www.worldmonitor.app',
+  'tech.worldmonitor.app',
+  'finance.worldmonitor.app',
+  'commodity.worldmonitor.app',
+  'happy.worldmonitor.app',
+  'energy.worldmonitor.app',
+]);
+
+type DebugBearRumEvent = ['presampling', number] | ['error' | 'unhandledrejection', Event];
+
+declare global {
+  interface Window {
+    dbbRum?: DebugBearRumEvent[];
+  }
+}
+
+let debugBearRumStarted = false;
+
+export function shouldEnableDebugBearRum(hostname: string): boolean {
+  return DEBUGBEAR_RUM_HOSTS.has(hostname.toLowerCase());
+}
+
+function loadDebugBearRumScript(): void {
+  if (typeof document === 'undefined') return;
+  if (document.querySelector<HTMLScriptElement>(`script[src="${DEBUGBEAR_RUM_SCRIPT_SRC}"]`)) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = DEBUGBEAR_RUM_SCRIPT_SRC;
+  if ('fetchPriority' in script) {
+    script.fetchPriority = 'low';
+  }
+  document.head.appendChild(script);
+}
+
+export function initDebugBearRum(): void {
+  if (debugBearRumStarted || typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (!shouldEnableDebugBearRum(window.location.hostname)) return;
+  if (Math.random() * 100 >= DEBUGBEAR_RUM_SAMPLE_RATE) return;
+
+  debugBearRumStarted = true;
+  const queue = window.dbbRum ?? [];
+  window.dbbRum = queue;
+  queue.push(['presampling', DEBUGBEAR_RUM_SAMPLE_RATE]);
+
+  for (const type of ['error', 'unhandledrejection'] as const) {
+    window.addEventListener(type, (event) => {
+      queue.push([type, event]);
+    });
+  }
+
+  loadDebugBearRumScript();
+}
+
+export function resetDebugBearRumForTesting(): void {
+  debugBearRumStarted = false;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import './styles/base-layer.css';
-import './styles/happy-theme.css';
 import './bootstrap/zod-csp';
+import { SITE_VARIANT } from '@/config/variant';
 import { installLcpAttributionDebug } from '@/bootstrap/lcp-attribution';
 import { markLcpDebug } from '@/utils/lcp-debug';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
@@ -9,6 +9,10 @@ import { registerInpReporting } from '@/bootstrap/inp-report';
 import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
 import { App } from './App';
 import { installUtmInterceptor } from './utils/utm';
+
+if (SITE_VARIANT === 'happy') {
+  void import('./styles/happy-theme.css');
+}
 
 // Activate the deferred dashboard app stylesheet. The build
 // (deferDashboardStylesheetLinks in vite.config.ts) emits the large dashboard
@@ -356,7 +360,6 @@ import { loadDesktopSecrets } from '@/services/runtime-config';
 import { applyStoredTheme } from '@/utils/theme-manager';
 import { applyFont } from '@/services/font-settings';
 import { initAnalytics } from '@/services/analytics';
-import { SITE_VARIANT } from '@/config/variant';
 import { clearChunkReloadGuard, installChunkReloadGuard } from '@/bootstrap/chunk-reload';
 import { installStaleBundleCheck } from '@/bootstrap/stale-bundle-check';
 import { installSwUpdateHandler } from '@/bootstrap/sw-update';

--- a/src/main.ts
+++ b/src/main.ts
@@ -363,15 +363,18 @@ import { applyStoredTheme } from '@/utils/theme-manager';
 import { applyFont } from '@/services/font-settings';
 import { initAnalytics } from '@/services/analytics';
 import { clearChunkReloadGuard, installChunkReloadGuard } from '@/bootstrap/chunk-reload';
+import { initDebugBearRum } from '@/bootstrap/debugbear-rum';
 import { installStaleBundleCheck } from '@/bootstrap/stale-bundle-check';
 import { installSwUpdateHandler } from '@/bootstrap/sw-update';
 
 // Auto-reload on stale chunk 404s after deployment (Vite fires this for modulepreload failures).
 const chunkReloadStorageKey = installChunkReloadGuard(__APP_VERSION__);
 
-// Analytics are secondary startup work: schedule loaders after first paint.
+// Product analytics are secondary startup work; RUM starts once the trusted
+// dashboard entry executes so it can observe page-load vitals.
 void initAnalytics();
 initVercelAnalytics();
+initDebugBearRum();
 
 // Initialize dynamic meta tags for sharing
 initMetaTags();

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import { App } from './App';
 import { installUtmInterceptor } from './utils/utm';
 
 if (SITE_VARIANT === 'happy') {
+  // Keeps happy-theme.css off other variants' eager CSS graph. On happy, the
+  // stylesheet applies asynchronously, so a brief base-theme flash is possible.
   void import('./styles/happy-theme.css');
 }
 

--- a/src/services/meta-tags.ts
+++ b/src/services/meta-tags.ts
@@ -99,7 +99,7 @@ function setMetaTag(property: string, content: string): void {
   if (existing) existing.remove();
 
   const meta = document.createElement('meta');
-  if (property.startsWith('og:') || property.startsWith('twitter:')) {
+  if (property.startsWith('og:')) {
     meta.setAttribute('property', property);
   } else {
     meta.setAttribute('name', property);

--- a/tests/dashboard-critical-css.test.mjs
+++ b/tests/dashboard-critical-css.test.mjs
@@ -253,6 +253,22 @@ describe('dashboard critical CSS graph', () => {
     );
   });
 
+  it('keeps happy variant theme CSS off the default dashboard static graph', () => {
+    const dashboardGraph = collectStaticGraph('src/main.ts');
+
+    assert.equal(
+      dashboardGraph.has('src/styles/happy-theme.css'),
+      false,
+      'Non-happy dashboard variants must not eagerly import happy-theme.css through src/main.ts.',
+    );
+
+    assert.equal(
+      dynamicModuleSpecifiers('src/main.ts').includes('./styles/happy-theme.css'),
+      true,
+      'The happy variant should still be able to load happy-theme.css through an explicit dynamic import.',
+    );
+  });
+
   it('keeps dashboard preferences content on dashboard-owned button styles', () => {
     const preferencesContent = src('src/services/preferences-content.ts');
     const mainCss = src('src/styles/main.css');

--- a/tests/debugbear-rum.test.mts
+++ b/tests/debugbear-rum.test.mts
@@ -1,0 +1,126 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  initDebugBearRum,
+  resetDebugBearRumForTesting,
+  shouldEnableDebugBearRum,
+} from '../src/bootstrap/debugbear-rum.ts';
+
+interface FakeDebugBearScript {
+  async: boolean;
+  src: string;
+  fetchPriority?: string;
+}
+
+function installDebugBearHarness(hostname: string, existingScript: FakeDebugBearScript | null = null): {
+  appendedScripts: FakeDebugBearScript[];
+  listeners: Map<string, (event: Event) => void>;
+  win: Window & { dbbRum?: unknown[] };
+  restore: () => void;
+} {
+  const appendedScripts: FakeDebugBearScript[] = [];
+  const listeners = new Map<string, (event: Event) => void>();
+  const win = {
+    location: { hostname },
+    addEventListener: (type: string, cb: (event: Event) => void) => {
+      listeners.set(type, cb);
+    },
+  } as Window & { dbbRum?: unknown[] };
+  const doc = {
+    querySelector: () => existingScript,
+    createElement: (tag: string) => {
+      assert.equal(tag, 'script');
+      return { async: false, src: '', fetchPriority: 'auto' } satisfies FakeDebugBearScript;
+    },
+    head: {
+      appendChild: (script: FakeDebugBearScript) => {
+        appendedScripts.push(script);
+        return script;
+      },
+    },
+  };
+
+  const saved: Record<string, PropertyDescriptor | undefined> = {
+    window: Object.getOwnPropertyDescriptor(globalThis, 'window'),
+    document: Object.getOwnPropertyDescriptor(globalThis, 'document'),
+  };
+  Object.defineProperty(globalThis, 'window', { configurable: true, value: win });
+  Object.defineProperty(globalThis, 'document', { configurable: true, value: doc });
+
+  return {
+    appendedScripts,
+    listeners,
+    win,
+    restore: () => {
+      for (const [key, desc] of Object.entries(saved)) {
+        if (desc) Object.defineProperty(globalThis, key, desc);
+        else delete (globalThis as Record<string, unknown>)[key];
+      }
+      resetDebugBearRumForTesting();
+    },
+  };
+}
+
+describe('DebugBear RUM loader', () => {
+  it('enables only first-party production dashboard hosts', () => {
+    assert.equal(shouldEnableDebugBearRum('www.worldmonitor.app'), true);
+    assert.equal(shouldEnableDebugBearRum('happy.worldmonitor.app'), true);
+    assert.equal(shouldEnableDebugBearRum('localhost'), false);
+    assert.equal(shouldEnableDebugBearRum('worldmonitor-git-codex-preview-eliewm.vercel.app'), false);
+    assert.equal(shouldEnableDebugBearRum('evilworldmonitor.app'), false);
+  });
+
+  it('installs DebugBear RUM with presampling and pre-script error buffering', () => {
+    const h = installDebugBearHarness('www.worldmonitor.app');
+    try {
+      initDebugBearRum();
+
+      assert.equal(h.appendedScripts.length, 1);
+      assert.equal(h.appendedScripts[0]!.async, true);
+      assert.equal(h.appendedScripts[0]!.src, 'https://cdn.debugbear.com/lpMwA9KpC6pf.js');
+      assert.equal(h.appendedScripts[0]!.fetchPriority, 'low');
+      assert.deepEqual(h.win.dbbRum?.[0], ['presampling', 100]);
+      assert.ok(h.listeners.has('error'), 'window error listener missing');
+      assert.ok(h.listeners.has('unhandledrejection'), 'window unhandledrejection listener missing');
+
+      const errorEvent = { type: 'error' } as Event;
+      const rejectionEvent = { type: 'unhandledrejection' } as Event;
+      h.listeners.get('error')!(errorEvent);
+      h.listeners.get('unhandledrejection')!(rejectionEvent);
+      assert.deepEqual(h.win.dbbRum, [
+        ['presampling', 100],
+        ['error', errorEvent],
+        ['unhandledrejection', rejectionEvent],
+      ]);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('does not load on local/dev hosts', () => {
+    const h = installDebugBearHarness('localhost');
+    try {
+      initDebugBearRum();
+
+      assert.equal(h.appendedScripts.length, 0);
+      assert.equal(h.win.dbbRum, undefined);
+      assert.equal(h.listeners.size, 0);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('does not append a duplicate script when one already exists', () => {
+    const existing = { async: true, src: 'https://cdn.debugbear.com/lpMwA9KpC6pf.js' };
+    const h = installDebugBearHarness('worldmonitor.app', existing);
+    try {
+      initDebugBearRum();
+
+      assert.equal(h.appendedScripts.length, 0);
+      assert.deepEqual(h.win.dbbRum?.[0], ['presampling', 100]);
+    } finally {
+      h.restore();
+    }
+  });
+});

--- a/tests/energy-variant-renewable-guard.test.mts
+++ b/tests/energy-variant-renewable-guard.test.mts
@@ -27,7 +27,7 @@ describe('energy variant renewable wiring', () => {
     const layout = src('src/app/panel-layout.ts');
     assert.match(
       layout,
-      /Renewable Energy is shared by happy and energy variants\.[\s\S]*?shouldCreatePanel\('renewable'\)[\s\S]*?this\.lazyPanel\('renewable'/,
+      /Renewable Energy is shared by happy and energy variants\.[\s\S]*?shouldCreatePanel\('renewable'\)[\s\S]*?this\.lazy(?:Imported)?Panel\('renewable'/,
       'panel-layout.ts must mount RenewableEnergyPanel via shouldCreatePanel() so energy can instantiate it',
     );
   });

--- a/tests/live-news-panel-guard.test.mts
+++ b/tests/live-news-panel-guard.test.mts
@@ -75,7 +75,7 @@ describe('LiveNewsPanel instantiation guard', () => {
 
   it('panel-layout.ts live-news guard checks getDefaultLiveChannels()', () => {
     const layout = src('src/app/panel-layout.ts');
-    const guardBlock = layout.match(/this\.lazyPanel\('live-news'[\s\S]*?getDefaultLiveChannels\(\)\.length === 0[\s\S]*?return null;/s);
+    const guardBlock = layout.match(/this\.lazy(?:Imported)?Panel\('live-news'[\s\S]*?getDefaultLiveChannels\(\)\.length === 0[\s\S]*?return null;/s);
     assert.ok(
       guardBlock,
       "panel-layout.ts must guard 'live-news' with getDefaultLiveChannels().length > 0",
@@ -84,7 +84,7 @@ describe('LiveNewsPanel instantiation guard', () => {
 
   it('panel-layout.ts live-news guard also checks loadChannelsFromStorage()', () => {
     const layout = src('src/app/panel-layout.ts');
-    const guardBlock = layout.match(/this\.lazyPanel\('live-news'[\s\S]*?loadChannelsFromStorage\(\)\.length === 0[\s\S]*?return null;/s);
+    const guardBlock = layout.match(/this\.lazy(?:Imported)?Panel\('live-news'[\s\S]*?loadChannelsFromStorage\(\)\.length === 0[\s\S]*?return null;/s);
     assert.ok(
       guardBlock,
       "panel-layout.ts must also check loadChannelsFromStorage().length > 0 so users with saved channels can use the panel on happy variant",

--- a/tests/meta-tags.test.mts
+++ b/tests/meta-tags.test.mts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { after, beforeEach, describe, it } from 'node:test';
+
+const metaTags = await import('../src/services/meta-tags.ts');
+
+class FakeElement {
+  readonly attributes = new Map<string, string>();
+
+  constructor(
+    private readonly documentRef: FakeDocument,
+    readonly tagName: string,
+  ) {}
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name.toLowerCase(), value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name.toLowerCase()) ?? null;
+  }
+
+  remove(): void {
+    this.documentRef.removeElement(this);
+  }
+}
+
+class FakeDocument {
+  title = '';
+  readonly elements: FakeElement[] = [];
+  readonly head = {
+    appendChild: (el: FakeElement) => {
+      this.elements.push(el);
+      return el;
+    },
+  };
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(this, tagName.toLowerCase());
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (selector === 'link[rel="canonical"]') {
+      return this.elements.find((el) =>
+        el.tagName === 'link' && el.getAttribute('rel') === 'canonical'
+      ) ?? null;
+    }
+
+    const metaSelectors = [...selector.matchAll(/meta\[(property|name)="([^"]+)"\]/g)];
+    for (const [, attr, value] of metaSelectors) {
+      const found = this.elements.find((el) =>
+        el.tagName === 'meta' && el.getAttribute(attr!) === value
+      );
+      if (found) return found;
+    }
+
+    return null;
+  }
+
+  removeElement(el: FakeElement): void {
+    const index = this.elements.indexOf(el);
+    if (index >= 0) this.elements.splice(index, 1);
+  }
+}
+
+class FakeStorage {
+  private readonly store = new Map<string, string>();
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+function installDom(): FakeDocument {
+  const fakeDocument = new FakeDocument();
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: fakeDocument,
+  });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: new FakeStorage(),
+  });
+  return fakeDocument;
+}
+
+after(() => {
+  delete (globalThis as { document?: unknown }).document;
+  delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+});
+
+describe('story meta tags', () => {
+  let fakeDocument: FakeDocument;
+
+  beforeEach(() => {
+    fakeDocument = installDom();
+  });
+
+  it('emits OpenGraph tags with property and Twitter tags with name', () => {
+    metaTags.updateMetaTagsForStory({
+      countryCode: 'UA',
+      countryName: 'Ukraine',
+      type: 'dailybrief',
+    });
+
+    assert.ok(
+      fakeDocument.querySelector('meta[property="og:title"]'),
+      'OpenGraph title must use property="og:title".',
+    );
+    assert.equal(
+      fakeDocument.querySelector('meta[name="og:title"]'),
+      null,
+      'OpenGraph tags must not be emitted with name attributes.',
+    );
+    assert.ok(
+      fakeDocument.querySelector('meta[name="twitter:title"]'),
+      'Twitter card title must use name="twitter:title".',
+    );
+    assert.equal(
+      fakeDocument.querySelector('meta[property="twitter:title"]'),
+      null,
+      'Twitter card tags must not be emitted with property attributes.',
+    );
+  });
+});

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -177,17 +177,25 @@ function assertSharedImportPanelGuard(source: string) {
   );
 }
 
+function assertNoDirectComponentConstructors(source: string) {
+  assert.doesNotMatch(
+    source,
+    /import\(['"]@\/components\/[^'"]+['"]\)\.then\(\s*(?:async\s*)?\(?\s*([A-Za-z_$][\w$]*)\s*\)?\s*=>[\s\S]{0,700}\bnew\s+\1\.[A-Za-z0-9_]+/m,
+    'Lazy component constructors must route through importPanel() instead of direct import(...).then(m => new m.Panel()) registrations.',
+  );
+}
+
 function assertChatAnalystLoadsWithoutAgentBusApplier(source: string) {
-  const registrationStart = source.indexOf("this.lazyPanel('chat-analyst'");
+  const registrationStart = source.indexOf("this.lazyImportedPanel('chat-analyst'");
   assert.notEqual(registrationStart, -1, 'chat-analyst lazy panel registration not found');
-  const registrationEnd = source.indexOf("this.lazyPanel('forecast'", registrationStart);
+  const registrationEnd = source.indexOf("this.lazyDefaultPanel(\n      'forecast'", registrationStart);
   assert.ok(registrationEnd > registrationStart, 'chat-analyst lazy panel registration boundary not found');
   const registration = source.slice(registrationStart, registrationEnd);
 
   assert.match(
     registration,
-    /import\('@\/components\/ChatAnalystPanel'\)\.then\(m => \{/,
-    'chat-analyst panel component should load independently',
+    /this\.lazyImportedPanel\('chat-analyst',\s*\(\) => import\('@\/components\/ChatAnalystPanel'\),\s*'ChatAnalystPanel'/,
+    'chat-analyst panel component should load through the guarded helper',
   );
   assert.doesNotMatch(
     registration,
@@ -196,7 +204,7 @@ function assertChatAnalystLoadsWithoutAgentBusApplier(source: string) {
   );
   assert.match(
     registration,
-    /const panel = new m\.ChatAnalystPanel\(\);[\s\S]*?void import\('@\/app\/agent-bus-applier'\)/,
+    /const panel = new ChatAnalystPanel\(\);[\s\S]*?void import\('@\/app\/agent-bus-applier'\)/,
     'chat-analyst should create the panel before loading the optional dashboard action handler',
   );
   assert.match(
@@ -236,6 +244,11 @@ describe('panel-layout lazy dynamic-import guard (WORLDMONITOR-R4)', () => {
     const source = await readFile(filePath, 'utf8');
     assertSharedImportPanelGuard(source);
     assertLazyLoaderHandlesFailedImports(source);
+  });
+
+  it('all lazy component constructors route through the shared guarded helper', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertNoDirectComponentConstructors(source);
   });
 
   it('split-risk panels are demand-loaded through the guarded helper', async () => {

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -248,6 +248,21 @@ function assertGccInvestmentsFocusHelperIsLoadedOnce(source: string) {
   );
 }
 
+function assertDestroyOnceIsolatesPanelThrows(source: string) {
+  const start = source.indexOf('const destroyOnce =');
+  assert.notEqual(start, -1, 'destroyOnce helper not found');
+  // Bound the helper body at its arrow closing so the assertion can't match a
+  // try/catch that belongs to some later statement in destroy().
+  const end = source.indexOf('\n    };', start);
+  assert.ok(end > start, 'destroyOnce helper body boundary not found');
+  const body = source.slice(start, end);
+  assert.match(
+    body,
+    /try \{\s*target\.destroy\?\.\(\);\s*\} catch/,
+    'destroyOnce must wrap target.destroy?.() in try/catch so one panel throwing cannot abort the rest of teardown (App.destroy() iterates modules without its own try/catch).',
+  );
+}
+
 const SPLIT_RISK_PANEL_IMPORTS: Array<[string, string, string]> = [
   ['pipeline-status', '@/components/PipelineStatusPanel', 'PipelineStatusPanel'],
   ['storage-facility-map', '@/components/StorageFacilityMapPanel', 'StorageFacilityMapPanel'],
@@ -301,6 +316,11 @@ describe('panel-layout lazy dynamic-import guard (WORLDMONITOR-R4)', () => {
   it('GCC investments map focus helper is loaded once during panel load', async () => {
     const source = await readFile(filePath, 'utf8');
     assertGccInvestmentsFocusHelperIsLoadedOnce(source);
+  });
+
+  it('destroy() isolates a single panel destroy() throw from the rest of teardown', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertDestroyOnceIsolatesPanelThrows(source);
   });
 
   it('token-aware brace walker skips strings/templates/comments', () => {

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -219,6 +219,35 @@ function assertChatAnalystLoadsWithoutAgentBusApplier(source: string) {
   );
 }
 
+function assertLiveNewsDirectMountCatchesCallbackErrors(source: string) {
+  const start = source.indexOf('mountLiveNewsIfReady(): void');
+  const end = source.indexOf('\n  private shouldCreatePanel', start);
+  assert.ok(start >= 0 && end > start, 'mountLiveNewsIfReady block not found');
+  const block = source.slice(start, end);
+  assert.match(
+    block,
+    /void this\.importPanel\([\s\S]*?\)\.then\(\(panel\) => \{[\s\S]*?this\.afterPanelMounted\('live-news', panel\);[\s\S]*?\}\)\.catch\(\(err\) => \{[\s\S]*?failed to lazy-load "live-news"/,
+    'direct live-news mount path must catch callback errors as well as import failures',
+  );
+}
+
+function assertGccInvestmentsFocusHelperIsLoadedOnce(source: string) {
+  const start = source.indexOf("this.lazyPanel('gcc-investments'");
+  const end = source.indexOf("this.lazyDefaultPanel('world-clock'", start);
+  assert.ok(start >= 0 && end > start, 'gcc-investments lazy panel registration not found');
+  const registration = source.slice(start, end);
+  assert.match(
+    registration,
+    /const \{ focusInvestmentOnMap \} = await import\('@\/services\/investments-focus'\);[\s\S]*?this\.importPanel\('gcc-investments'/,
+    'gcc-investments should load the map focus helper once during panel load before constructing the click handler',
+  );
+  assert.doesNotMatch(
+    registration,
+    /new InvestmentsPanel\(\(inv\) => \{[\s\S]*?import\('@\/services\/investments-focus'\)/,
+    'gcc-investments click handler must not import investments-focus on every click',
+  );
+}
+
 const SPLIT_RISK_PANEL_IMPORTS: Array<[string, string, string]> = [
   ['pipeline-status', '@/components/PipelineStatusPanel', 'PipelineStatusPanel'],
   ['storage-facility-map', '@/components/StorageFacilityMapPanel', 'StorageFacilityMapPanel'],
@@ -262,6 +291,16 @@ describe('panel-layout lazy dynamic-import guard (WORLDMONITOR-R4)', () => {
   it('chat analyst mounts even if the dashboard action handler chunk fails', async () => {
     const source = await readFile(filePath, 'utf8');
     assertChatAnalystLoadsWithoutAgentBusApplier(source);
+  });
+
+  it('direct live-news mid-session mount path catches callback errors', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertLiveNewsDirectMountCatchesCallbackErrors(source);
+  });
+
+  it('GCC investments map focus helper is loaded once during panel load', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertGccInvestmentsFocusHelperIsLoadedOnce(source);
   });
 
   it('token-aware brace walker skips strings/templates/comments', () => {

--- a/tests/secondary-startup.test.mts
+++ b/tests/secondary-startup.test.mts
@@ -26,6 +26,11 @@ describe('secondary dashboard startup', () => {
       'Umami must be injected by the deferred dashboard loader, not index.html',
     );
     assert.equal(
+      /<script\b[^>]+src=["']https:\/\/cdn\.debugbear\.com\/lpMwA9KpC6pf\.js["']/i.test(activeMarkup),
+      false,
+      'DebugBear RUM must be injected by the dashboard loader, not index.html',
+    );
+    assert.equal(
       /<link\b[^>]+rel=["']preconnect["'][^>]+href=["']https:\/\/o4509927897890816\.ingest\.us\.sentry\.io["']/i.test(activeMarkup),
       false,
       'Sentry ingest preconnect must not compete with initial dashboard paint',
@@ -51,6 +56,7 @@ describe('secondary dashboard startup', () => {
     const scriptSrc = dashboardCsp.match(/script-src\s+([^;]+)/)?.[1] ?? '';
     assert.match(scriptSrc, /'strict-dynamic'/);
     assert.doesNotMatch(scriptSrc, /https:\/\/abacus\.worldmonitor\.app/);
+    assert.doesNotMatch(scriptSrc, /https:\/\/cdn\.debugbear\.com/);
     assert.doesNotMatch(scriptSrc, /https:\/\/static\.cloudflareinsights\.com/);
     assert.doesNotMatch(dashboardCsp, /style-src[^;]*https:\/\/fonts\.googleapis\.com/);
     assert.match(dashboardCsp, /font-src[^;]*'self'/);

--- a/tests/tech-readiness-variant-gate.test.mts
+++ b/tests/tech-readiness-variant-gate.test.mts
@@ -60,13 +60,13 @@ describe('tech-readiness variant gate', () => {
     );
   });
 
-  it("panel-layout.ts: lazyPanel('tech-readiness') factory only calls p.refresh() under the variant gate", () => {
+  it("panel-layout.ts: tech-readiness lazy factory only calls p.refresh() under the variant gate", () => {
     const lines = readFile('src/app/panel-layout.ts');
-    // Find the lazyPanel registration for tech-readiness.
-    const lazyIdx = lines.findIndex(l => /lazyPanel\(\s*['"]tech-readiness['"]/.test(stripComments(l)));
-    assert.ok(lazyIdx !== -1, "expected lazyPanel('tech-readiness', ...) in panel-layout.ts");
+    // Find the lazy panel registration for tech-readiness.
+    const lazyIdx = lines.findIndex(l => /lazy(?:Imported)?Panel\(\s*['"]tech-readiness['"]/.test(stripComments(l)));
+    assert.ok(lazyIdx !== -1, "expected tech-readiness lazy panel registration in panel-layout.ts");
 
-    // Collect the factory body — walk forward until the call closes at column 0 with `);`.
+    // Collect the factory body - walk forward until the call closes at column 0 with `);`.
     const body: { lineNo: number; text: string }[] = [];
     let depth = 0;
     let started = false;
@@ -79,7 +79,7 @@ describe('tech-readiness variant gate', () => {
       }
       if (started && depth === 0) break;
     }
-    assert.ok(body.length > 1, 'expected to walk the lazyPanel factory body');
+    assert.ok(body.length > 1, 'expected to walk the lazy panel factory body');
 
     // Every line that calls `p.refresh()` must be preceded (within the body) by
     // a conditional that names isPanelInVariantDefaults('tech-readiness').
@@ -93,7 +93,7 @@ describe('tech-readiness variant gate', () => {
     assert.match(
       bodyText,
       /if\s*\(\s*isPanelInVariantDefaults\(\s*['"]tech-readiness['"]\s*\)\s*\)\s*\{[^}]*\bp\.refresh\(\s*\)/s,
-      "panel-layout.ts lazyPanel('tech-readiness', ...) factory must wrap p.refresh() in " +
+      "panel-layout.ts tech-readiness lazy factory must wrap p.refresh() in " +
       "`if (isPanelInVariantDefaults('tech-readiness')) { ... }`. Without the gate, " +
       'the factory fires the 5s /api/bootstrap?keys=techReadiness fetch on every variant ' +
       "regardless of whether the seed key exists.",

--- a/tests/threat-timeline-panel.test.mts
+++ b/tests/threat-timeline-panel.test.mts
@@ -458,7 +458,7 @@ describe('ThreatTimelinePanel registration', () => {
 
     assert.match(panelsSrc, /'threat-timeline':\s*\{\s*name:\s*'Threat Timeline'/);
     assert.match(panelsSrc, /intelligence:\s*\{[\s\S]*panelKeys:\s*\[[^\]]*'threat-timeline'/);
-    assert.match(layoutSrc, /isPanelInVariantDefaults\('threat-timeline'\)[\s\S]*lazyPanel\('threat-timeline',\s*\(\)\s*=>\s*import\('@\/components\/ThreatTimelinePanel'\)\.then\(m\s*=>\s*new m\.ThreatTimelinePanel\(\)\)\)/);
+    assert.match(layoutSrc, /isPanelInVariantDefaults\('threat-timeline'\)[\s\S]*lazyDefaultPanel\('threat-timeline',\s*\(\)\s*=>\s*import\('@\/components\/ThreatTimelinePanel'\),\s*'ThreatTimelinePanel'\)/);
     assert.match(dataLoaderSrc, /isPanelInVariantDefaults\('threat-timeline'\)[\s\S]*panels\['threat-timeline'\]\s+as ThreatTimelinePanel/);
     assert.match(commandsSrc, /id:\s*'panel:threat-timeline'[\s\S]*keywords:\s*\[[^\]]*'threat trend'/);
   });


### PR DESCRIPTION
## Summary
Non-happy dashboards no longer pull the happy theme into the eager CSS graph, so the default dashboard avoids loading variant-only styling before the happy variant needs it.

Dashboard panel registrations now route component dynamic imports through the shared guarded loader, keeping chunk-load failures isolated while preserving each panel's setup hooks. Story sharing metadata now emits OpenGraph tags with `property` and Twitter card tags with `name`, matching crawler expectations.

## Validation
- Red proof: the new CSS graph, Twitter metadata, and direct lazy-constructor guard assertions failed before the fix.
- `./node_modules/.bin/tsx --test --test-name-pattern "happy variant theme CSS|emits OpenGraph|all lazy component|shared importPanel|split-risk|chat analyst" tests/dashboard-critical-css.test.mjs tests/panel-layout-dynamic-import-guard.test.mts tests/meta-tags.test.mts`
- `./node_modules/.bin/tsx --test tests/dashboard-critical-css.test.mjs`
- `./node_modules/.bin/tsx --test tests/panel-layout-dynamic-import-guard.test.mts tests/meta-tags.test.mts`
- `npm run typecheck`
- `npm run lint` (passes; existing repo-wide Biome warnings still print)
- `env VITE_VARIANT=full ./node_modules/.bin/vite build`
- Pre-push hook passed frontend/API typechecks, boundary/safe-html/rate-limit/premium-fetch checks, changed tests, edge tests, and version sync.

## Post-Deploy Monitoring & Validation
- Watch the Vercel deployment and browser error telemetry for `[panel] failed to lazy-load` spikes or unexpected panel mount failures for the first 24 hours.
- Spot-check `/dashboard`, `/dashboard-tech`, `/dashboard-finance`, and `/dashboard-happy`; non-happy dashboard HTML should not link the happy theme, while the happy variant should still render its theme.
- Verify a sample story share card still exposes Twitter metadata with `name="twitter:*"` and OpenGraph metadata with `property="og:*"`.
- Revert if non-happy pages lose base styling, the happy variant misses its theme, or panel chunk failures become user-visible.

Fixes #5060.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
