### PR TITLE
fix(rum): wire lcp web-vitals reporting

### DIFF
--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -5,6 +5,9 @@
  * into a Sentry event and routes it through `enqueueSentryCall` so it survives
  * Sentry's deferred (~10s idle) init. Reporting the largest shift target/value
  * lets field data name the real shifting element before we ship a layout fix.
+ * Good-rated events are trimmed (#4565), so captured-event p75 is conditioned
+ * on the bad tail. Verify fixes with bad-event rate per formFactor plus
+ * weekly page-level CrUX queryHistoryRecord, not p75 of captured Sentry events.
  *
  * The `onCLS` registration that calls this lives behind the `web-vitals`
  * dependency (see `registerClsReporting` doc at the bottom). This module keeps
@@ -12,7 +15,7 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { roundMs } from '@/bootstrap/web-vitals-utils';
+import { getWebVitalsFormFactor, roundMs } from '@/bootstrap/web-vitals-utils';
 
 /** Structural subset of web-vitals' CLS attribution (kept local to avoid the dep). */
 export interface ClsAttributionLike {
@@ -83,6 +86,7 @@ export function reportClsMetric(
       level: 'info',
       tags: {
         webvital: 'cls',
+        formFactor: getWebVitalsFormFactor(),
         'cls.rating': metric.rating ?? 'unknown',
       },
       extra: {

--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -81,12 +81,13 @@ export function reportClsMetric(
   // unknown only, so field attribution stays focused on actionable shifts.
   if (metric.rating === 'good') return;
   const a = metric.attribution ?? {};
+  const formFactor = getWebVitalsFormFactor();
   enqueue((s) => {
     s.captureMessage('web-vital: CLS', {
       level: 'info',
       tags: {
         webvital: 'cls',
-        formFactor: getWebVitalsFormFactor(),
+        formFactor,
         'cls.rating': metric.rating ?? 'unknown',
       },
       extra: {

--- a/src/bootstrap/inp-report.ts
+++ b/src/bootstrap/inp-report.ts
@@ -8,6 +8,9 @@
  * occurs. Reporting interaction target + the three INP sub-parts lets us see
  * which real interaction is slow and whether the cost is input delay,
  * processing, or presentation — the data that drives fix prioritization.
+ * Good-rated events are trimmed (#4565), so captured-event p75 is conditioned
+ * on the bad tail. Verify fixes with bad-event rate per formFactor plus
+ * weekly page-level CrUX queryHistoryRecord, not p75 of captured Sentry events.
  *
  * The `onINP` registration that calls this lives behind the `web-vitals`
  * dependency (see `registerInpReporting` doc at the bottom). This module keeps
@@ -15,7 +18,7 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { roundMs } from '@/bootstrap/web-vitals-utils';
+import { getWebVitalsFormFactor, roundMs } from '@/bootstrap/web-vitals-utils';
 
 /** Structural subset of web-vitals' INP attribution (kept local to avoid the dep). */
 export interface InpAttributionLike {
@@ -52,6 +55,7 @@ export function reportInpMetric(
       level: 'info',
       tags: {
         webvital: 'inp',
+        formFactor: getWebVitalsFormFactor(),
         'inp.rating': metric.rating ?? 'unknown',
         'inp.interactionType': a.interactionType ?? 'unknown',
       },

--- a/src/bootstrap/inp-report.ts
+++ b/src/bootstrap/inp-report.ts
@@ -50,12 +50,13 @@ export function reportInpMetric(
   // actionable worst-case signal still lands while Sentry event volume drops ~70%.
   if (metric.rating === 'good') return;
   const a = metric.attribution ?? {};
+  const formFactor = getWebVitalsFormFactor();
   enqueue((s) => {
     s.captureMessage('web-vital: INP', {
       level: 'info',
       tags: {
         webvital: 'inp',
-        formFactor: getWebVitalsFormFactor(),
+        formFactor,
         'inp.rating': metric.rating ?? 'unknown',
         'inp.interactionType': a.interactionType ?? 'unknown',
       },

--- a/src/bootstrap/lcp-attribution.ts
+++ b/src/bootstrap/lcp-attribution.ts
@@ -1,4 +1,5 @@
 import { markLcpDebug, type LcpMarkSnapshot } from '@/utils/lcp-debug';
+import { sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
 
 type LcpElementSnapshot = {
   className: string;
@@ -144,18 +145,6 @@ function isLcpTextCaptureEnabled(): boolean {
   return isFlagEnabled(DEBUG_TEXT_QUERY_PARAM, DEBUG_TEXT_STORAGE_KEYS);
 }
 
-function sanitizeResourceUrl(raw: string | undefined): string {
-  if (!raw) return '';
-  try {
-    const url = new URL(raw, typeof window !== 'undefined' ? window.location.href : 'https://worldmonitor.app/');
-    const query = url.search ? '?[redacted]' : '';
-    return `${url.origin}${url.pathname}${query}`;
-  } catch {
-    const [withoutQuery = raw] = raw.split('?');
-    return withoutQuery.slice(0, 200);
-  }
-}
-
 function getClassName(element: Element): string {
   const className = element.className;
   if (typeof className === 'string') return className;
@@ -259,7 +248,7 @@ function summarizeCriticalResources(upToStartTime = Number.POSITIVE_INFINITY): L
       group.largest = {
         duration: Math.round(resource.duration),
         initiatorType: resource.initiatorType,
-        name: sanitizeResourceUrl(resource.name),
+        name: sanitizeWebVitalUrl(resource.name),
         startTime: Math.round(resource.startTime),
         transferSize,
       };
@@ -322,7 +311,7 @@ function recordLcpEntry(entry: LcpPerformanceEntry): void {
     resources: summarizeCriticalResources(entry.startTime),
     size: Math.round(entry.size ?? 0),
     startTime: Math.round(entry.startTime),
-    url: sanitizeResourceUrl(entry.url),
+    url: sanitizeWebVitalUrl(entry.url),
   }, MAX_ENTRIES);
 }
 
@@ -359,6 +348,6 @@ export const __testing__ = {
   isLcpDebugEnabled,
   isLcpTextCaptureEnabled,
   isTruthyDebugFlag,
-  sanitizeResourceUrl,
+  sanitizeResourceUrl: sanitizeWebVitalUrl,
   snapshotContext,
 };

--- a/src/bootstrap/lcp-report.ts
+++ b/src/bootstrap/lcp-report.ts
@@ -1,0 +1,87 @@
+/**
+ * Field LCP attribution reporting (#5079).
+ *
+ * `reportLcpMetric` shapes one web-vitals LCP measurement (attribution build)
+ * into a Sentry event and routes it through `enqueueSentryCall` so it survives
+ * Sentry's deferred (~10s idle) init. Reporting the LCP element selector plus
+ * the four LCP phase sub-parts lets field data show whether last-mile latency
+ * is server response, resource discovery, resource download, or render delay.
+ *
+ * Good-rated events are trimmed (#4565), so captured-event p75 is conditioned
+ * on the bad tail. Verify fixes with bad-event rate per formFactor plus weekly
+ * page-level CrUX queryHistoryRecord, not p75 of captured Sentry events.
+ *
+ * The `onLCP` registration that calls this lives behind the `web-vitals`
+ * dependency (see `registerLcpReporting` doc at the bottom). This module keeps
+ * the reportable logic free of that import so it builds and is unit-tested
+ * without the package present.
+ */
+import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
+import { getWebVitalsFormFactor, roundMs, sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
+
+/** Structural subset of web-vitals' LCP attribution (kept local to avoid the dep). */
+export interface LcpAttributionLike {
+  target?: string;
+  url?: string;
+  timeToFirstByte?: number;
+  resourceLoadDelay?: number;
+  resourceLoadDuration?: number;
+  elementRenderDelay?: number;
+}
+
+/** Structural subset of web-vitals' LCPMetricWithAttribution. */
+export interface LcpMetricLike {
+  value: number;
+  rating?: 'good' | 'needs-improvement' | 'poor';
+  attribution?: LcpAttributionLike;
+}
+
+/**
+ * Report one field LCP measurement to Sentry. `enqueue` is injectable for tests;
+ * in production it defaults to the deferred-Sentry queue.
+ */
+export function reportLcpMetric(
+  metric: LcpMetricLike,
+  enqueue: typeof enqueueSentryCall = enqueueSentryCall,
+): void {
+  // Volume trim (#4565): skip 'good' (<=2500ms) LCP. Report
+  // needs-improvement / poor / unknown only, so Sentry volume stays focused on
+  // the bad tail while success is measured by bad-event rate per surface.
+  if (metric.rating === 'good') return;
+  const a = metric.attribution ?? {};
+  enqueue((s) => {
+    s.captureMessage('web-vital: LCP', {
+      level: 'info',
+      tags: {
+        webvital: 'lcp',
+        formFactor: getWebVitalsFormFactor(),
+        'lcp.rating': metric.rating ?? 'unknown',
+      },
+      extra: {
+        value: Math.round(metric.value),
+        elementTarget: a.target ?? 'unknown',
+        url: sanitizeWebVitalUrl(a.url) || undefined,
+        timeToFirstByte: roundMs(a.timeToFirstByte),
+        resourceLoadDelay: roundMs(a.resourceLoadDelay),
+        resourceLoadDuration: roundMs(a.resourceLoadDuration),
+        elementRenderDelay: roundMs(a.elementRenderDelay),
+      },
+    });
+  });
+}
+
+/**
+ * Register the field LCP listener. Browser-only. Uses a dynamic import so
+ * `web-vitals` code-splits into its own chunk and so this module stays
+ * node-loadable for unit tests. Uses web-vitals' default lifecycle cadence:
+ * buffered LCP entries are reported when the value is ready, and bfcache restores
+ * get their own metric instance.
+ */
+export function registerLcpReporting(): void {
+  if (typeof window === 'undefined') return;
+  void import('web-vitals/attribution')
+    .then(({ onLCP }) => {
+      onLCP((metric) => reportLcpMetric(metric as unknown as LcpMetricLike));
+    })
+    .catch(() => { /* web-vitals chunk failed to load (adblock/CDN) - non-fatal */ });
+}

--- a/src/bootstrap/lcp-report.ts
+++ b/src/bootstrap/lcp-report.ts
@@ -49,12 +49,13 @@ export function reportLcpMetric(
   // the bad tail while success is measured by bad-event rate per surface.
   if (metric.rating === 'good') return;
   const a = metric.attribution ?? {};
+  const formFactor = getWebVitalsFormFactor();
   enqueue((s) => {
     s.captureMessage('web-vital: LCP', {
       level: 'info',
       tags: {
         webvital: 'lcp',
-        formFactor: getWebVitalsFormFactor(),
+        formFactor,
         'lcp.rating': metric.rating ?? 'unknown',
       },
       extra: {

--- a/src/bootstrap/web-vitals-utils.ts
+++ b/src/bootstrap/web-vitals-utils.ts
@@ -1,2 +1,42 @@
 export const roundMs = (n: number | undefined): number | undefined =>
   typeof n === 'number' && Number.isFinite(n) ? Math.round(n) : undefined;
+
+export type WebVitalsFormFactor = 'mobile' | 'desktop';
+
+function mediaQueryMatches(query: string): boolean {
+  return typeof window.matchMedia === 'function' && window.matchMedia(query).matches;
+}
+
+/**
+ * Low-cardinality surface tag for field Web Vitals.
+ *
+ * This intentionally folds tablet/touch and <=1024px responsive layouts into
+ * `mobile`, leaving only `mobile|desktop` as Sentry facets.
+ */
+export function getWebVitalsFormFactor(): WebVitalsFormFactor {
+  if (typeof window === 'undefined') return 'desktop';
+  const navigatorWithUaData = window.navigator as Navigator & {
+    userAgentData?: { mobile?: boolean };
+  };
+  if (navigatorWithUaData.userAgentData?.mobile === true) return 'mobile';
+  if (
+    mediaQueryMatches('(pointer: coarse)')
+    || mediaQueryMatches('(hover: none)')
+    || mediaQueryMatches('(max-width: 1024px)')
+  ) {
+    return 'mobile';
+  }
+  return window.innerWidth > 0 && window.innerWidth <= 1024 ? 'mobile' : 'desktop';
+}
+
+export function sanitizeWebVitalUrl(raw: string | undefined): string {
+  if (!raw) return '';
+  try {
+    const url = new URL(raw, typeof window !== 'undefined' ? window.location.href : 'https://worldmonitor.app/');
+    const query = url.search ? '?[redacted]' : '';
+    return `${url.origin}${url.pathname}${query}`;
+  } catch {
+    const [withoutQuery = raw] = raw.split('?');
+    return withoutQuery.slice(0, 200);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { markLcpDebug } from '@/utils/lcp-debug';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
 import { registerClsReporting } from '@/bootstrap/cls-report';
 import { registerInpReporting } from '@/bootstrap/inp-report';
+import { registerLcpReporting } from '@/bootstrap/lcp-report';
 import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
 import { App } from './App';
 import { installUtmInterceptor } from './utils/utm';
@@ -48,6 +49,10 @@ registerInpReporting();
 // Report field CLS attribution to Sentry so field-only layout shifts can name
 // their largest shifting element before we scope the layout fix (#4580).
 registerClsReporting();
+
+// Report field LCP attribution to Sentry so the last-mile render-delay work can
+// see the real LCP element plus TTFB / load-delay / load-time / render-delay parts (#5079).
+registerLcpReporting();
 
 // Suppress NotAllowedError from YouTube IFrame API's internal play() — browser autoplay policy,
 // not actionable. The YT IFrame API doesn't expose the play() promise so it leaks as unhandled.

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -44,6 +44,7 @@ test('reportClsMetric reports CLS attribution for needs-improvement field shifts
   assert.equal(msg, 'web-vital: CLS');
   assert.equal(ctx.tags.webvital, 'cls');
   assert.equal(ctx.tags['cls.rating'], 'needs-improvement');
+  assert.equal(ctx.tags.formFactor, 'desktop');
   assert.equal(ctx.extra.value, 0.15321, 'CLS value keeps fractional precision');
   assert.equal(ctx.extra.largestShiftTarget, 'div.payment-failure-banner');
   assert.equal(ctx.extra.largestShiftValue, 0.1287);

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -7,6 +7,7 @@ import {
   type ClsMetricLike,
   type ClsReportEnv,
 } from '@/bootstrap/cls-report';
+import { webVitalsTestWindow, withWindow } from './web-vitals-report-test-helpers.mts';
 
 // Capture what reportClsMetric would send, by injecting a fake enqueue that
 // immediately invokes the closure with a fake Sentry namespace.
@@ -88,6 +89,23 @@ test('reportClsMetric includes the shift-class environment fields (#4580)', () =
   assert.equal(ctx.extra.visibilityState, 'visible');
   assert.equal(ctx.extra.scrollY, 0);
   assert.equal(ctx.extra.viewport, '1440x900');
+});
+
+test('reportClsMetric captures formFactor before deferred Sentry drain', () => {
+  let queued: ((s: any) => void) | undefined;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    queued = fn;
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  const out = withWindow(webVitalsTestWindow(900), () => {
+    reportClsMetric({ value: 0.22, rating: 'poor' }, fakeEnqueue);
+    return { ctx: undefined as any };
+  });
+
+  withWindow(webVitalsTestWindow(1440), () => {
+    queued?.({ captureMessage: (_msg: string, ctx: unknown) => { out.ctx = ctx; } });
+  });
+
+  assert.equal(out.ctx.tags.formFactor, 'mobile');
 });
 
 test('collectClsReportEnv is safe (empty) in non-browser contexts', () => {

--- a/tests/inp-report.test.mts
+++ b/tests/inp-report.test.mts
@@ -36,6 +36,7 @@ test('reportInpMetric reports value + all three sub-parts + interaction target (
   assert.equal(ctx.tags['inp.rating'], 'needs-improvement');
   assert.equal(ctx.tags['inp.interactionType'], 'pointer');
   assert.equal(ctx.tags.webvital, 'inp');
+  assert.equal(ctx.tags.formFactor, 'desktop');
 });
 
 test('reportInpMetric tolerates missing attribution (R1)', () => {

--- a/tests/inp-report.test.mts
+++ b/tests/inp-report.test.mts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { reportInpMetric, type InpMetricLike } from '@/bootstrap/inp-report';
+import { webVitalsTestWindow, withWindow } from './web-vitals-report-test-helpers.mts';
 
 // Capture what reportInpMetric would send, by injecting a fake enqueue that
 // immediately invokes the closure with a fake Sentry namespace.
@@ -55,6 +56,23 @@ test('reportInpMetric routes through the injected enqueue exactly once (R2 deleg
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
   reportInpMetric({ value: 100 }, fakeEnqueue);
   assert.equal(calls, 1, 'delegates to enqueueSentryCall (which buffers until Sentry init)');
+});
+
+test('reportInpMetric captures formFactor before deferred Sentry drain', () => {
+  let queued: ((s: any) => void) | undefined;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    queued = fn;
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  const out = withWindow(webVitalsTestWindow(900), () => {
+    reportInpMetric({ value: 350, rating: 'needs-improvement' }, fakeEnqueue);
+    return { ctx: undefined as any };
+  });
+
+  withWindow(webVitalsTestWindow(1440), () => {
+    queued?.({ captureMessage: (_msg: string, ctx: unknown) => { out.ctx = ctx; } });
+  });
+
+  assert.equal(out.ctx.tags.formFactor, 'mobile');
 });
 
 test('reportInpMetric drops good-rated INP without enqueuing (#4565)', () => {

--- a/tests/lcp-attribution-contract.test.mjs
+++ b/tests/lcp-attribution-contract.test.mjs
@@ -17,6 +17,18 @@ describe('LCP attribution debug contract', () => {
     assert.ok(installIndex < appIndex, 'LCP attribution debug must install before App construction');
   });
 
+  it('registers LCP RUM reporting before App construction', () => {
+    const src = readSrc('src/main.ts');
+    const importIndex = src.indexOf("import { registerLcpReporting } from '@/bootstrap/lcp-report';");
+    const registerIndex = src.indexOf('registerLcpReporting();');
+    const appIndex = src.indexOf('new App(');
+
+    assert.ok(importIndex >= 0, 'main.ts must import registerLcpReporting');
+    assert.ok(registerIndex >= 0, 'main.ts must register LCP RUM reporting');
+    assert.ok(appIndex >= 0, 'main.ts must construct App');
+    assert.ok(registerIndex < appIndex, 'LCP RUM reporting must register before App construction');
+  });
+
   it('marks the boot gates that can delay final LCP', () => {
     const appSrc = readSrc('src/App.ts');
     for (const mark of [

--- a/tests/lcp-report.test.mts
+++ b/tests/lcp-report.test.mts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { reportLcpMetric, type LcpMetricLike } from '@/bootstrap/lcp-report';
+import { webVitalsTestWindow, withWindow } from './web-vitals-report-test-helpers.mts';
 
 function capture(metric: LcpMetricLike): { msg: string; ctx: any } {
   let out: { msg: string; ctx: any } | null = null;
@@ -47,6 +48,23 @@ test('reportLcpMetric drops good-rated LCP without enqueuing (#4565)', () => {
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
   reportLcpMetric({ value: 1900, rating: 'good', attribution: { target: 'h1' } }, fakeEnqueue);
   assert.equal(calls, 0, 'good-rated (<=2500ms) LCP is not reported');
+});
+
+test('reportLcpMetric captures formFactor before deferred Sentry drain', () => {
+  let queued: ((s: any) => void) | undefined;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    queued = fn;
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  const out = withWindow(webVitalsTestWindow(900), () => {
+    reportLcpMetric({ value: 3200, rating: 'needs-improvement' }, fakeEnqueue);
+    return { ctx: undefined as any };
+  });
+
+  withWindow(webVitalsTestWindow(1440), () => {
+    queued?.({ captureMessage: (_msg: string, ctx: unknown) => { out.ctx = ctx; } });
+  });
+
+  assert.equal(out.ctx.tags.formFactor, 'mobile');
 });
 
 test('reportLcpMetric still reports unknown/undefined-rated LCP conservatively', () => {

--- a/tests/lcp-report.test.mts
+++ b/tests/lcp-report.test.mts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { reportLcpMetric, type LcpMetricLike } from '@/bootstrap/lcp-report';
+
+function capture(metric: LcpMetricLike): { msg: string; ctx: any } {
+  let out: { msg: string; ctx: any } | null = null;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportLcpMetric(metric, fakeEnqueue);
+  assert.ok(out, 'reportLcpMetric must call enqueue exactly once');
+  return out!;
+}
+
+test('reportLcpMetric reports LCP value, target, phase sub-parts, and form factor', () => {
+  const { msg, ctx } = capture({
+    value: 3875.6,
+    rating: 'needs-improvement',
+    attribution: {
+      target: 'main.hero>h1',
+      url: 'https://worldmonitor.app/assets/hero.webp?token=secret',
+      timeToFirstByte: 421.3,
+      resourceLoadDelay: 83.6,
+      resourceLoadDuration: 1170.8,
+      elementRenderDelay: 2200.2,
+    },
+  });
+
+  assert.equal(msg, 'web-vital: LCP');
+  assert.equal(ctx.tags.webvital, 'lcp');
+  assert.equal(ctx.tags['lcp.rating'], 'needs-improvement');
+  assert.equal(ctx.tags.formFactor, 'desktop');
+  assert.equal(ctx.extra.value, 3876, 'LCP value rounded');
+  assert.equal(ctx.extra.elementTarget, 'main.hero>h1');
+  assert.equal(ctx.extra.url, 'https://worldmonitor.app/assets/hero.webp?[redacted]');
+  assert.equal(ctx.extra.timeToFirstByte, 421);
+  assert.equal(ctx.extra.resourceLoadDelay, 84);
+  assert.equal(ctx.extra.resourceLoadDuration, 1171);
+  assert.equal(ctx.extra.elementRenderDelay, 2200);
+});
+
+test('reportLcpMetric drops good-rated LCP without enqueuing (#4565)', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportLcpMetric({ value: 1900, rating: 'good', attribution: { target: 'h1' } }, fakeEnqueue);
+  assert.equal(calls, 0, 'good-rated (<=2500ms) LCP is not reported');
+});
+
+test('reportLcpMetric still reports unknown/undefined-rated LCP conservatively', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportLcpMetric({ value: 2600 }, fakeEnqueue);
+  assert.equal(calls, 1, 'unknown/undefined rating still reports; do not drop unknowns');
+});
+
+test('reportLcpMetric tolerates missing attribution', () => {
+  const { ctx } = capture({ value: 4100, rating: 'poor' });
+  assert.equal(ctx.tags['lcp.rating'], 'poor');
+  assert.equal(ctx.extra.value, 4100);
+  assert.equal(ctx.extra.elementTarget, 'unknown');
+  assert.equal(ctx.extra.timeToFirstByte, undefined);
+});

--- a/tests/web-vitals-report-test-helpers.mts
+++ b/tests/web-vitals-report-test-helpers.mts
@@ -1,0 +1,20 @@
+export function withWindow<T>(value: unknown, fn: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'window', { configurable: true, value });
+  try {
+    return fn();
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, 'window', descriptor);
+    else delete (globalThis as typeof globalThis & { window?: unknown }).window;
+  }
+}
+
+export function webVitalsTestWindow(innerWidth: number): unknown {
+  return {
+    innerWidth,
+    matchMedia: (query: string) => ({
+      matches: query === '(max-width: 1024px)' ? innerWidth <= 1024 : false,
+    }),
+    navigator: { userAgentData: { mobile: false } },
+  };
+}

--- a/tests/web-vitals-utils.test.mts
+++ b/tests/web-vitals-utils.test.mts
@@ -1,17 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { getWebVitalsFormFactor, sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
-
-function withWindow<T>(value: unknown, fn: () => T): T {
-  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
-  Object.defineProperty(globalThis, 'window', { configurable: true, value });
-  try {
-    return fn();
-  } finally {
-    if (descriptor) Object.defineProperty(globalThis, 'window', descriptor);
-    else delete (globalThis as typeof globalThis & { window?: unknown }).window;
-  }
-}
+import { withWindow } from './web-vitals-report-test-helpers.mts';
 
 test('getWebVitalsFormFactor defaults to desktop outside the browser', () => {
   assert.equal(getWebVitalsFormFactor(), 'desktop');

--- a/tests/web-vitals-utils.test.mts
+++ b/tests/web-vitals-utils.test.mts
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getWebVitalsFormFactor, sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
+
+function withWindow<T>(value: unknown, fn: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'window', { configurable: true, value });
+  try {
+    return fn();
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, 'window', descriptor);
+    else delete (globalThis as typeof globalThis & { window?: unknown }).window;
+  }
+}
+
+test('getWebVitalsFormFactor defaults to desktop outside the browser', () => {
+  assert.equal(getWebVitalsFormFactor(), 'desktop');
+});
+
+test('getWebVitalsFormFactor tags coarse pointer and tablet-width surfaces as mobile', () => {
+  const formFactor = withWindow({
+    innerWidth: 900,
+    matchMedia: (query: string) => ({
+      matches: query === '(pointer: coarse)' || query === '(hover: none)' || query === '(max-width: 1024px)',
+    }),
+    navigator: { userAgentData: { mobile: false } },
+  }, () => getWebVitalsFormFactor());
+
+  assert.equal(formFactor, 'mobile');
+});
+
+test('getWebVitalsFormFactor tags wide fine-pointer surfaces as desktop', () => {
+  const formFactor = withWindow({
+    innerWidth: 1440,
+    matchMedia: () => ({ matches: false }),
+    navigator: { userAgentData: { mobile: false } },
+  }, () => getWebVitalsFormFactor());
+
+  assert.equal(formFactor, 'desktop');
+});
+
+test('sanitizeWebVitalUrl redacts query strings and caps malformed URLs', () => {
+  assert.equal(
+    sanitizeWebVitalUrl('https://api.worldmonitor.app/api/bootstrap?tier=fast&wms=secret#frag'),
+    'https://api.worldmonitor.app/api/bootstrap?[redacted]',
+  );
+  assert.equal(sanitizeWebVitalUrl('https://worldmonitor.app/assets/main.js'), 'https://worldmonitor.app/assets/main.js');
+  assert.equal(sanitizeWebVitalUrl(`http://[bad?${'x'.repeat(220)}`), 'http://[bad');
+});


### PR DESCRIPTION
## Summary
Field Web Vitals reporting now emits first-class mobile/desktop facets and includes LCP attribution in Sentry. INP and CLS events carry a low-cardinality `formFactor` tag, and LCP now reports the target selector, sanitized resource URL, and TTFB/load-delay/load-duration/render-delay parts through the deferred Sentry queue.

The reporter comments also spell out the #4565 volume-trim caveat: because good events are dropped, captured-event p75 is a bad-tail diagnostic, not the success metric. Post-fix verification should use bad-event rate by surface plus weekly page-level CrUX `queryHistoryRecord`.

Related: #5079

## Validation
- Added/updated focused reporter and contract tests for INP/CLS `formFactor`, LCP reporting, URL redaction, and `main.ts` registration.
- `./node_modules/.bin/tsx --test tests/inp-report.test.mts tests/cls-report.test.mts tests/lcp-report.test.mts tests/web-vitals-utils.test.mts tests/lcp-attribution.test.mts tests/lcp-attribution-contract.test.mjs`
- `npm run typecheck`
- `npm run lint` (exit 0; existing unrelated Biome warnings reported; safe-html passed)
- Pre-push hook passed: frontend/API/Convex typechecks, CJS syntax, Unicode, boundaries, safe-html, Sentry coverage, rate-limit policies, premium-fetch, edge bundle check, changed tests, edge tests, and version sync.

## Post-Deploy Monitoring & Validation
- Sentry queries: `event.type:default webvital:inp formFactor:mobile`, `event.type:default webvital:cls formFactor:desktop`, `event.type:default webvital:lcp`, and `event.type:default webvital:lcp formFactor:mobile`.
- Watch tag values for `formFactor` and `webvital`; expected healthy signal is `mobile|desktop` only for `formFactor` and `inp|cls|lcp` for `webvital` after deploy traffic.
- For LCP bad-tail events, confirm extras include `elementTarget`, `timeToFirstByte`, `resourceLoadDelay`, `resourceLoadDuration`, and `elementRenderDelay`; URLs should be query-redacted.
- Success metric: track bad-event rate by surface over the first 24-48h after deployment, then compare weekly page-level CrUX `queryHistoryRecord`; do not use captured-event p75 as the fix-success metric.
- Failure/rollback trigger: no `webvital:lcp` events after normal dashboard traffic, unexpected high-cardinality `formFactor` values, or raw query strings appearing in LCP URL extras. Mitigate by reverting this PR or disabling the reporter registration while preserving INP/CLS paths.
- Owner: WorldMonitor performance/RUM owner for #4487 / #5079.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex_GPT--5-000000)