### PR TITLE
feat(api): IETF RateLimit headers + verifiable signed webhook sample (orank Usability)

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -37,6 +37,16 @@ const EXPOSED_HEADERS = [
   'Retry-After',
   'Idempotency-Key',
   'Idempotent-Replayed',
+  // IETF RateLimit fields (draft-ietf-httpapi-ratelimit-headers): RateLimit-Policy
+  // + RateLimit-Limit are advertised on every API response (vercel.json); the
+  // combined RateLimit member and RateLimit-Remaining/Reset appear on a 429.
+  // Exposed so browser-context agents can read them cross-origin and self-throttle.
+  'RateLimit',
+  'RateLimit-Policy',
+  'RateLimit-Limit',
+  'RateLimit-Remaining',
+  'RateLimit-Reset',
+  // Legacy X-RateLimit-* retained for back-compat with existing consumers.
   'X-RateLimit-Limit',
   'X-RateLimit-Remaining',
   'X-RateLimit-Reset',

--- a/api/_cors.test.mjs
+++ b/api/_cors.test.mjs
@@ -55,6 +55,14 @@ test('CORS allow headers include MCP transport headers', () => {
     assert.match(exposed, /\bMcp-Session-Id\b/);
     assert.match(exposed, /\bWWW-Authenticate\b/);
     assert.match(exposed, /\bRetry-After\b/);
+    // IETF RateLimit fields so browser-context agents can self-throttle cross-origin.
+    assert.match(exposed, /\bRateLimit-Policy\b/);
+    assert.match(exposed, /\bRateLimit-Limit\b/);
+    assert.match(exposed, /\bRateLimit-Remaining\b/);
+    assert.match(exposed, /\bRateLimit-Reset\b/);
+    // Bare combined member: match RateLimit NOT preceded by "-" (so it doesn't
+    // just re-match the RateLimit-* fields above) and followed by a delimiter.
+    assert.match(exposed, /(^|[\s,])RateLimit(,|$)/);
     assert.match(exposed, /\bX-RateLimit-Limit\b/);
     assert.match(exposed, /\bX-RateLimit-Remaining\b/);
     assert.match(exposed, /\bX-RateLimit-Reset\b/);

--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -137,11 +137,26 @@ export async function checkRateLimit(request, corsHeaders, opts = {}) {
     );
 
     if (!success) {
+      // `reset` is a Unix epoch in MILLISECONDS (Upstash convention). The IETF
+      // RateLimit fields carry a delta-seconds reset (`t` / RateLimit-Reset),
+      // NOT an epoch, so derive the remaining-seconds view for them and for
+      // Retry-After. The legacy X-RateLimit-Reset stays epoch-ms unchanged.
+      const resetSeconds = Math.max(0, Math.ceil((reset - Date.now()) / 1000));
+      const windowSeconds = durationToSeconds(policy.window);
       return jsonResponse({ error: 'Too many requests' }, 429, {
+        // IETF RateLimit fields (draft-ietf-httpapi-ratelimit-headers). The
+        // combined RateLimit member references the "default" policy advertised
+        // on every API response via vercel.json so an agent can self-throttle.
+        'RateLimit-Policy': `"default";q=${limit};w=${windowSeconds}`,
+        'RateLimit-Limit': String(limit),
+        'RateLimit-Remaining': '0',
+        'RateLimit-Reset': String(resetSeconds),
+        RateLimit: `"default";r=0;t=${resetSeconds}`,
+        // Legacy X-RateLimit-* retained for back-compat (Reset is epoch-ms).
         'X-RateLimit-Limit': String(limit),
         'X-RateLimit-Remaining': '0',
         'X-RateLimit-Reset': String(reset),
-        'Retry-After': String(Math.ceil((reset - Date.now()) / 1000)),
+        'Retry-After': String(resetSeconds),
         ...corsHeaders,
       });
     }

--- a/api/_rate-limit.test.mjs
+++ b/api/_rate-limit.test.mjs
@@ -209,6 +209,14 @@ describe('api/_rate-limit checkRateLimit fail-open / fail-closed (#3531 M9)', ()
     assert.equal(res.status, 429);
     assert.equal(res.headers.get('X-RateLimit-Limit'), '30');
     assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+    // IETF RateLimit fields alongside the legacy set (draft-ietf-httpapi-ratelimit-headers).
+    assert.equal(res.headers.get('RateLimit-Policy'), '"default";q=30;w=60');
+    assert.equal(res.headers.get('RateLimit-Limit'), '30');
+    assert.equal(res.headers.get('RateLimit-Remaining'), '0');
+    // Combined RateLimit member references the "default" policy with a delta-seconds reset.
+    assert.match(res.headers.get('RateLimit') ?? '', /^"default";r=0;t=\d+$/);
+    // Retry-After is delta-seconds (not the epoch-ms carried by X-RateLimit-Reset).
+    assert.match(res.headers.get('Retry-After') ?? '', /^\d+$/);
     assert.equal(
       res.headers.get('Access-Control-Allow-Origin'),
       'https://worldmonitor.app',

--- a/docs/api-shipping-v2.mdx
+++ b/docs/api-shipping-v2.mdx
@@ -189,3 +189,12 @@ function verifyWorldMonitorWebhook(rawBody, header, secret) {
 ```
 
 The signature contract is also published machine-readably as the `chokepoint.disruption` entry under `webhooks` in the [OpenAPI spec](https://worldmonitor.app/openapi.json).
+
+#### Test your verification against a signed sample
+
+A ready-to-verify sample delivery is published at [`/.well-known/webhook-sample.json`](https://www.worldmonitor.app/.well-known/webhook-sample.json). It carries a fixed sample `secret`, the exact raw `body` string, and the resulting `signature`. Recompute `sha256=` + `hex(HMAC_SHA256(key=secret, message=body))` over the exact bytes of `body` and confirm it equals `signature` — if it matches, your verification will accept real deliveries. (The sample `secret` is a fixture; each live subscription gets its own `secret` from RegisterWebhook.)
+
+```js
+const s = await (await fetch('https://www.worldmonitor.app/.well-known/webhook-sample.json')).json();
+verifyWorldMonitorWebhook(s.body, s.signature, s.secret); // → true
+```

--- a/docs/api/worldmonitor.openapi.yaml
+++ b/docs/api/worldmonitor.openapi.yaml
@@ -21284,6 +21284,11 @@ webhooks:
                 `secret` string verbatim as the HMAC key — do not hex-decode it.
                 Reject the delivery if the signatures differ.
 
+                A verifiable signed sample (fixed secret + exact raw body +
+                resulting signature) is published at
+                https://www.worldmonitor.app/.well-known/webhook-sample.json so you
+                can confirm your HMAC verification end-to-end before registering.
+
                 Respond with any 2xx to acknowledge receipt; a non-2xx response or a
                 timeout marks the delivery failed. `X-WM-Delivery-Id` uniquely
                 identifies each delivery for idempotent processing.

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -69,22 +69,41 @@ These mostly use the default public API limit. Cache headers vary by endpoint:
 - `GET /api/health` — `private, no-store, max-age=0` plus `CDN-Cache-Control: no-store`.
 - `GET /api/version` — `public, s-maxage=300, stale-while-revalidate=60, stale-if-error=3600`.
 
+## Rate limit response headers (self-throttle before a 429)
+
+Every `/api/*` response — success or error — advertises the [IETF `RateLimit` header fields](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/) so an agent can pace itself **before** it trips a 429:
+
+```
+RateLimit-Policy: "default";q=600;w=60
+RateLimit-Limit: 600
+```
+
+- `RateLimit-Policy` — the applicable quota (`q`) over a window of `w` seconds for the default sliding window. Stricter per-endpoint, per-plan, and OAuth limits (see the tables above) apply on those routes.
+- `RateLimit-Limit` — the same quota as a bare integer, for parsers that predate the structured-field draft.
+
+These are static advertisements, so they add no latency on the hot path. The legacy `X-RateLimit-*` names are also emitted for back-compat.
+
 ## Response when limited
 
-HTTP 429 with the standard rate-limit headers so you can self-throttle:
+An HTTP 429 additionally carries the live per-window counters (remaining is `0`; the reset and `Retry-After` are **delta-seconds**) plus the combined `RateLimit` member:
 
 ```
 HTTP/1.1 429 Too Many Requests
+RateLimit-Policy: "default";q=<limit>;w=<window>
+RateLimit-Limit: <limit>
+RateLimit-Remaining: 0
+RateLimit-Reset: <seconds until reset>
+RateLimit: "default";r=0;t=<seconds until reset>
+Retry-After: <seconds>
 X-RateLimit-Limit: <limit>
 X-RateLimit-Remaining: 0
 X-RateLimit-Reset: <reset, ms since epoch>
-Retry-After: <seconds>
 Content-Type: application/json
 
 { "error": "Too many requests" }
 ```
 
-For a daily-ceiling 429 the `Retry-After` counts down to the next 00:00 UTC.
+Note the IETF `RateLimit-Reset` (and the `t` value in the combined `RateLimit` member) is **seconds remaining**, whereas the legacy `X-RateLimit-Reset` is an absolute epoch in **milliseconds**. For a daily-ceiling 429 the `Retry-After` counts down to the next 00:00 UTC.
 
 ## Retry guidance
 

--- a/public/.well-known/webhook-sample.json
+++ b/public/.well-known/webhook-sample.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Verifiable sample of a signed WorldMonitor webhook delivery. Use it to confirm your HMAC-SHA256 verification is correct BEFORE you register a live webhook: recompute the signature over the exact bytes of `body` and check it equals `signature`. The `secret` here is a fixed sample — a real subscription `secret` is returned once by POST /api/v2/shipping/webhooks (RegisterWebhook) and is never published.",
+  "description": "Signed webhook delivery verification fixture (HMAC-SHA256, X-WM-Signature).",
+  "documentation": "https://www.worldmonitor.app/docs/api-shipping-v2",
+  "event": "chokepoint.disruption",
+  "algorithm": "HMAC-SHA256",
+  "signatureHeader": "X-WM-Signature",
+  "signatureFormat": "sha256=<lowercase-hex>",
+  "eventHeader": "X-WM-Event",
+  "deliveryIdHeader": "X-WM-Delivery-Id",
+  "verify": "Compute 'sha256=' + hex(HMAC_SHA256(key=secret, message=body)) over the EXACT bytes of the `body` string below — do NOT re-parse or re-serialize the JSON, and use `secret` verbatim as the key (do not hex-decode it). The result must equal `signature`. Reject any live delivery whose recomputed signature does not match its X-WM-Signature header, compared in constant time.",
+  "secret": "41d3788561e87f16bf7868467b2f2bd4b222455c938926211415043db4e90536",
+  "body": "{\"subscriberId\":\"wh_1a2b3c4d5e6f7a8b9c0d1e2f\",\"chokepointId\":\"suez\",\"score\":72,\"alertThreshold\":50,\"triggeredAt\":\"2026-07-04T12:34:56Z\",\"reason\":\"Disruption score 72 crossed alert threshold 50\",\"details\":{\"trend\":\"rising\"}}",
+  "signature": "sha256=b5b49ba6f739c7f31f05d3391a9d71d50af754efdab7edbcb8df75c89efbc079",
+  "headers": {
+    "Content-Type": "application/json",
+    "X-WM-Signature": "sha256=b5b49ba6f739c7f31f05d3391a9d71d50af754efdab7edbcb8df75c89efbc079",
+    "X-WM-Event": "chokepoint.disruption",
+    "X-WM-Delivery-Id": "whd_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+  }
+}

--- a/scripts/openapi-inject-webhooks.mjs
+++ b/scripts/openapi-inject-webhooks.mjs
@@ -80,6 +80,11 @@ const WEBHOOKS_BLOCK = `webhooks:
                 \`secret\` string verbatim as the HMAC key — do not hex-decode it.
                 Reject the delivery if the signatures differ.
 
+                A verifiable signed sample (fixed secret + exact raw body +
+                resulting signature) is published at
+                https://www.worldmonitor.app/.well-known/webhook-sample.json so you
+                can confirm your HMAC verification end-to-end before registering.
+
                 Respond with any 2xx to acknowledge receipt; a non-2xx response or a
                 timeout marks the delivery failed. \`${DELIVERY_ID_HEADER}\` uniquely
                 identifies each delivery for idempotent processing.

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -207,19 +207,38 @@ export async function reserveDailyMeter(opts: {
 }
 
 /**
- * Standard rate-limit response headers. Mirrors api/_rate-limit.js:110-116 so
- * customers get a uniform self-throttle contract across the per-IP and
- * per-account limiters. The gateway merges these with corsHeaders.
+ * Standard rate-limit response headers for a 429. Emits the IETF RateLimit
+ * fields (draft-ietf-httpapi-ratelimit-headers) — RateLimit-Policy advertises
+ * the quota/window, the combined RateLimit member carries live remaining +
+ * delta-seconds reset — alongside the legacy X-RateLimit-* set for back-compat,
+ * so customers get a uniform self-throttle contract across the per-IP and
+ * per-account limiters. Mirrors api/_rate-limit.js. The gateway merges these
+ * with corsHeaders.
+ *
+ * `resetMs` is a Unix epoch in MILLISECONDS; the IETF reset (`t` /
+ * RateLimit-Reset) is delta-SECONDS, so it is derived here. `windowSec` is the
+ * policy window in seconds (defaults to the 60 s burst window).
  */
 export function rateLimitHeaders(opts: {
   limit: number;
   remaining: number;
   resetMs: number;
   retryAfterSec: number;
+  windowSec?: number;
 }): Record<string, string> {
+  const remaining = Math.max(0, opts.remaining);
+  const resetSeconds = Math.max(0, Math.ceil((opts.resetMs - Date.now()) / 1000));
+  const windowSec = opts.windowSec ?? 60;
   return {
+    // IETF RateLimit fields.
+    'RateLimit-Policy': `"default";q=${opts.limit};w=${windowSec}`,
+    'RateLimit-Limit': String(opts.limit),
+    'RateLimit-Remaining': String(remaining),
+    'RateLimit-Reset': String(resetSeconds),
+    RateLimit: `"default";r=${remaining};t=${resetSeconds}`,
+    // Legacy X-RateLimit-* retained for back-compat (Reset is epoch-ms).
     'X-RateLimit-Limit': String(opts.limit),
-    'X-RateLimit-Remaining': String(Math.max(0, opts.remaining)),
+    'X-RateLimit-Remaining': String(remaining),
     'X-RateLimit-Reset': String(opts.resetMs),
     'Retry-After': String(Math.max(1, opts.retryAfterSec)),
   };

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -134,15 +134,29 @@ export function getClientIp(request: Request): string {
   return xr || UNKNOWN_CLIENT_IP;
 }
 
-function tooManyRequestsResponse(limit: number, reset: number, corsHeaders: Record<string, string>): Response {
+function tooManyRequestsResponse(limit: number, reset: number, corsHeaders: Record<string, string>, windowSeconds: number): Response {
+  // `reset` is a Unix epoch in MILLISECONDS (Upstash). IETF RateLimit fields
+  // carry a delta-seconds reset (`t` / RateLimit-Reset), NOT an epoch — derive
+  // it here. Legacy X-RateLimit-Reset stays epoch-ms for back-compat.
+  const resetSeconds = Math.max(0, Math.ceil((reset - Date.now()) / 1000));
   return new Response(JSON.stringify({ error: 'Too many requests' }), {
     status: 429,
     headers: {
       'Content-Type': 'application/json',
+      // IETF RateLimit fields (draft-ietf-httpapi-ratelimit-headers). The
+      // combined RateLimit member references the "default" policy advertised on
+      // every API response via vercel.json so agents can self-throttle. Mirrors
+      // api/_rate-limit.js.
+      'RateLimit-Policy': `"default";q=${limit};w=${windowSeconds}`,
+      'RateLimit-Limit': String(limit),
+      'RateLimit-Remaining': '0',
+      'RateLimit-Reset': String(resetSeconds),
+      RateLimit: `"default";r=0;t=${resetSeconds}`,
+      // Legacy X-RateLimit-* retained for back-compat (Reset is epoch-ms).
       'X-RateLimit-Limit': String(limit),
       'X-RateLimit-Remaining': '0',
       'X-RateLimit-Reset': String(reset),
-      'Retry-After': String(Math.ceil((reset - Date.now()) / 1000)),
+      'Retry-After': String(resetSeconds),
       ...corsHeaders,
     },
   });
@@ -187,7 +201,7 @@ export async function checkRateLimit(request: Request, corsHeaders: Record<strin
     const { success, limit, reset } = await limitWithFallback(rl, ip, `rl:fw:${ip}`, GLOBAL_RATE_LIMIT, GLOBAL_RATE_WINDOW_SECONDS);
 
     if (!success) {
-      return tooManyRequestsResponse(limit, reset, corsHeaders);
+      return tooManyRequestsResponse(limit, reset, corsHeaders, GLOBAL_RATE_WINDOW_SECONDS);
     }
 
     return null;
@@ -415,7 +429,7 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
     const { success, limit, reset } = await limitWithFallback(rl, `${pathname}:${ip}`, `rl:ep:fw:${pathname}:${ip}`, policy.limit, durationToSeconds(policy.window));
 
     if (!success) {
-      return tooManyRequestsResponse(limit, reset, corsHeaders);
+      return tooManyRequestsResponse(limit, reset, corsHeaders, durationToSeconds(policy.window));
     }
 
     return null;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1470,7 +1470,7 @@ export function createDomainGateway(
                 headers: {
                   'Content-Type': 'application/json',
                   'Cache-Control': 'no-store',
-                  ...rateLimitHeaders({ limit: burst.limit, remaining: 0, resetMs: burst.reset, retryAfterSec }),
+                  ...rateLimitHeaders({ limit: burst.limit, remaining: 0, resetMs: burst.reset, retryAfterSec, windowSec: 60 }),
                   ...corsHeaders,
                 },
               });
@@ -1497,6 +1497,8 @@ export function createDomainGateway(
                       remaining: 0,
                       resetMs: Date.now() + meter.retryAfterSec * 1000,
                       retryAfterSec: meter.retryAfterSec,
+                      // Daily ceiling window (24 h) for the advertised policy.
+                      windowSec: 86_400,
                     }),
                     ...corsHeaders,
                   },

--- a/tests/api-key-rate-limit.test.mts
+++ b/tests/api-key-rate-limit.test.mts
@@ -157,6 +157,24 @@ describe('#3199 U3 — burst limiter fail-open + headers', () => {
     assert.equal(h['Retry-After'], '42');
   });
 
+  it('rateLimitHeaders emits IETF RateLimit fields with a delta-seconds reset', () => {
+    const now = Date.now();
+    const h = rateLimitHeaders({ limit: 60, remaining: 7, resetMs: now + 30_000, retryAfterSec: 30, windowSec: 60 });
+    // RateLimit-Policy advertises the quota + window (structured-field syntax).
+    assert.equal(h['RateLimit-Policy'], '"default";q=60;w=60');
+    assert.equal(h['RateLimit-Limit'], '60');
+    assert.equal(h['RateLimit-Remaining'], '7');
+    // IETF reset is DELTA-seconds (~30), not the epoch-ms carried by X-RateLimit-Reset.
+    const resetSec = Number(h['RateLimit-Reset']);
+    assert.ok(resetSec >= 29 && resetSec <= 31, `RateLimit-Reset should be ~30s, got ${resetSec}`);
+    assert.equal(h.RateLimit, `"default";r=7;t=${resetSec}`);
+  });
+
+  it('rateLimitHeaders defaults the advertised window to 60s', () => {
+    const h = rateLimitHeaders({ limit: 600, remaining: 0, resetMs: Date.now() + 1000, retryAfterSec: 1 });
+    assert.equal(h['RateLimit-Policy'], '"default";q=600;w=60');
+  });
+
   it('Retry-After floors at 1 second', () => {
     assert.equal(rateLimitHeaders({ limit: 60, remaining: 0, resetMs: 0, retryAfterSec: 0 })['Retry-After'], '1');
   });

--- a/tests/openapi-webhooks-contract.test.mjs
+++ b/tests/openapi-webhooks-contract.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { createHmac } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -121,5 +122,41 @@ describe('OpenAPI webhooks contract', () => {
   it('webhooks live at the top level, not under paths (no phantom REST op)', () => {
     assert.ok(!('/webhooks/chokepoint.disruption' in (bundle.paths ?? {})));
     assert.equal(Object.keys(bundle.webhooks).length, 1);
+  });
+});
+
+// The published, verifiable sample delivery (public/.well-known/webhook-sample.json)
+// lets an agent confirm its HMAC verification end-to-end BEFORE registering a live
+// webhook (orank Usability — "webhook signature verification"). This guards it
+// against drift: the committed signature MUST be the genuine HMAC of the committed
+// body+secret, and the scheme must match the documented + worker contract.
+describe('webhook verification fixture (/.well-known/webhook-sample.json)', () => {
+  const fixture = JSON.parse(
+    readFileSync(resolve(root, 'public/.well-known/webhook-sample.json'), 'utf8'),
+  );
+
+  it('the committed signature is the genuine HMAC-SHA256 of body keyed by secret', () => {
+    const expected = 'sha256=' + createHmac('sha256', fixture.secret).update(fixture.body).digest('hex');
+    assert.equal(fixture.signature, expected, 'fixture signature is stale — recompute it from body+secret');
+  });
+
+  it('the sample matches the documented signing scheme', () => {
+    assert.equal(fixture.algorithm, 'HMAC-SHA256');
+    assert.equal(fixture.signatureHeader, SIGNATURE_HEADER);
+    assert.equal(fixture.event, WEBHOOK_EVENT);
+    // Same shape the OpenAPI signature-header schema constrains (^sha256=[0-9a-f]{64}$).
+    assert.match(fixture.signature, /^sha256=[0-9a-f]{64}$/);
+    // Sample secret uses the real registration format (raw 64-char lowercase hex).
+    assert.match(fixture.secret, /^[0-9a-f]{64}$/);
+  });
+
+  it('the signature does NOT match if the body is tampered (guards the recipe)', () => {
+    const tampered = fixture.body.replace('"score":72', '"score":99');
+    const forged = 'sha256=' + createHmac('sha256', fixture.secret).update(tampered).digest('hex');
+    assert.notEqual(fixture.signature, forged, 'a mutated body must not verify against the sample signature');
+  });
+
+  it('the echoed X-WM-Signature header equals the top-level signature', () => {
+    assert.equal(fixture.headers?.['X-WM-Signature'], fixture.signature);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -265,6 +265,13 @@
       ]
     },
     {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "RateLimit-Policy", "value": "\"default\";q=600;w=60" },
+        { "key": "RateLimit-Limit", "value": "600" }
+      ]
+    },
+    {
       "source": "/",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" },


### PR DESCRIPTION
## What & why

Closes two of the three **orank Usability** warnings (score was 95/100 A+; each warning is −1). The third — the Mintlify-hosted **docs MCP** at `/docs/mcp` — is deliberately left as-is: it already returns structured errors, just in MCP's `result.isError` tool-error form rather than the top-level JSON-RPC `error` object orank's parser wants, and we don't control Mintlify's wire format (a normalizing proxy would risk a working prod surface for 1 point).

### 1. `rate-limit-headers` (was 1/2) — emit IETF `RateLimit` fields

orank's finding: *"REST rate-limit headers documented in OpenAPI spec, but not observed on a live response."* The root cause was pure observability — live responses carried **no** actual rate-limit values (only the CORS `expose-headers` list *named* them), and they used legacy `X-RateLimit-*`, not the IETF field names. orank can't trigger a 429, so a 429-only header is invisible to it.

- **`vercel.json`** — a new `/api/(.*)` rule advertises the default policy on **every** API response: `RateLimit-Policy: "default";q=600;w=60` + `RateLimit-Limit: 600`. Static, no Redis on the hot path. This lands on exactly the surfaces orank probes: the JSON 404 catch-all (`api/[...notfound].ts`), `/api/health`, `/api/product-catalog`, and 401s. (Verified mechanism: the live 404 already carries `x-content-type-options: nosniff` from the existing broad headers rule, proving vercel.json rules stamp onto `/api/*` function responses.)
- **Live 429 builders** (`api/_rate-limit.js`, `server/_shared/rate-limit.ts` `tooManyRequestsResponse`, `server/_shared/api-key-rate-limit.ts` `rateLimitHeaders`) now emit the full IETF set — `RateLimit-Policy/Limit/Remaining/Reset` + the combined `RateLimit` member — with a **delta-seconds** reset (not the epoch-ms of `X-RateLimit-Reset`). Legacy `X-RateLimit-*` retained for back-compat.
- **`api/_cors.js`** exposes the new fields cross-origin; **`docs/usage-rate-limits.mdx`** documents the always-on advertisement + the enriched 429.

### 2. `webhook-signing` (was 1/2) — a verifiable signed sample

Signing is already implemented + documented (HMAC-SHA256, `X-WM-Signature: sha256=<hex>`, full recipe in the OpenAPI `webhooks` block), but the delivery is outbound-only, so a consumer can't confirm its verification end-to-end before registering.

- **`public/.well-known/webhook-sample.json`** — a fixed sample secret + the exact raw `body` string + the **genuine** signature. An agent recomputes `sha256=hex(HMAC_SHA256(secret, body))` over the exact bytes and confirms it equals `signature`. Served static (`.well-known` is excluded from the SPA rewrite and not bot-gated).
- Referenced from **`docs/api-shipping-v2.mdx`** and the **OpenAPI webhooks block** (`scripts/openapi-inject-webhooks.mjs`; bundle regenerated).
- **`tests/openapi-webhooks-contract.test.mjs`** recomputes the HMAC so the committed signature can never drift, plus a tamper-detection assertion.

## Verification

All touched suites green: rate-limit, CORS, api-key-rate-limit, gateway (vitest ×3), deploy-config, both OpenAPI contract suites (incl. 4 new fixture-drift tests), plan-limit docs, `.well-known` enumeration. `typecheck:api` exit 0, biome lint clean. The generated-bundle diff is exactly the 5 intended lines (no per-operation churn).

## Follow-up

After merge + deploy, rescan: `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}`. Expected movement 95 → 96–97 (gap 3 should land cleanly; gap 2's sample is genuinely useful but orank's exact rubric for the 2nd point is opaque).

https://claude.ai/code/session_01H9i6GwdiHcyhSFkFjP4jEg
