### PR TITLE
fix(forecast): restore FRED macro signals

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -9672,7 +9672,8 @@ function extractFredSeriesMap(payload) {
 }
 
 function extractFredObservations(series) {
-  return Array.isArray(series?.observations) ? series.observations : [];
+  const observations = series?.series?.observations ?? series?.observations;
+  return Array.isArray(observations) ? observations : [];
 }
 
 function getFredLatestObservation(series) {

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -656,6 +656,31 @@ describe('market transmission macro state', () => {
     assert.ok((marketConsequences?.blockedCount || 0) >= 1);
   });
 
+  it('continues accepting legacy flat FRED observations for macro signals', () => {
+    const worldState = buildForecastRunWorldState({
+      predictions: [],
+      inputs: {
+        fredSeries: {
+          VIXCLS: {
+            seriesId: 'VIXCLS',
+            title: 'VIXCLS',
+            observations: [
+              { date: '2026-02-01', value: 17.9 },
+              { date: '2026-03-01', value: 24.2 },
+            ],
+          },
+        },
+      },
+    });
+
+    const vixSignal = (worldState.worldSignals?.signals || []).find((item) => (
+      item.type === 'volatility_shock' &&
+      item.sourceType === 'fred' &&
+      item.sourceKey === 'VIXCLS'
+    ));
+    assert.ok(vixSignal);
+  });
+
   it('promotes direct core-bucket market consequences when critical signals are strong even if macro coverage is incomplete', () => {
     const consequences = buildSimulationMarketConsequences({
       situationSimulations: [

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -534,9 +534,11 @@ describe('forecast trace artifact builder', () => {
 describe('market transmission macro state', () => {
   it('uses live-shaped macro and market payloads to form energy-aware world signals and keep market consequences selective', () => {
     const fredSeries = (seriesId, observations) => ({
-      seriesId,
-      title: seriesId,
-      observations: observations.map(([date, value]) => ({ date, value })),
+      series: {
+        seriesId,
+        title: seriesId,
+        observations: observations.map(([date, value]) => ({ date, value })),
+      },
     });
 
     const conflict = makePrediction('conflict', 'Middle East', 'Hormuz escalation risk', 0.73, 0.64, '7d', [


### PR DESCRIPTION
## Summary

FRED macro and rates signals now read the production Redis shape instead of silently disappearing. Forecast generation still accepts the older flat `{ observations }` fixture shape, but it also unwraps the live `{ series: { observations } }` payload that `seed-economy` writes, restoring the VIX, yield-curve, policy-rate, inflation, labor, liquidity, oil, and GDP inputs that feed market world signals.

The regression fixture now uses the canonical wrapped FRED payload and proves `buildForecastRunWorldState` emits FRED-backed macro signals such as `volatility_shock`, `yield_curve_stress`, `inflation_impulse`, and `oil_macro_shock`.

Fixes #5098.
Related: #5097, #4930

## Validation

- Red proof before the fix: `node --test tests/forecast-trace-export.test.mjs` failed because `signalTypes` no longer contained `volatility_shock` when the fixture used `{ series: { observations } }`.
- Green after the fix: `node --test tests/forecast-trace-export.test.mjs` passed, 319 tests.
- `node --check scripts/seed-forecasts.mjs`
- `git diff --check`
- Pre-push hook passed after installing this fresh worktree's dependencies: frontend typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, architectural boundary check, safe HTML sink check, rate-limit policy coverage, premium-fetch parity, edge bundle check, changed test file run, and version sync.

Code review: manual fallback used. `ce-code-review` could not be dispatched because this Codex session exposes subagents only for explicit user-requested delegation; the tiny two-file diff was reviewed directly for the FRED wrapper compatibility and legacy flat-shape preservation.

## Post-Deploy Monitoring & Validation

- Window: first forecast seeder run after deploy, plus the following scheduled run.
- Owner: forecast/on-call operator.
- Log queries: search forecast seeder logs for `volatility_shock`, `yield_curve_stress`, `inflation_impulse`, `oil_macro_shock`, and `fred`.
- Redis/runtime checks: inspect the next `forecast:trace:*` or world-state debug artifact for FRED-backed `worldSignals.signals[].source === "fred"` with non-empty entries.
- Expected healthy signal: macro/rates world-signal counts are nonzero when VIX, T10Y2Y, CPI, DCOILWTICO, or related FRED values cross thresholds; market buckets such as `rates_inflation`, `fx_stress`, and `energy` show macro confirmation when those signals are present.
- Failure signal: FRED Redis keys remain fresh but forecast world signals contain zero `source: "fred"` entries, or market macro confirmation drops to zero despite threshold-crossing FRED observations.
- Rollback trigger: if the helper causes malformed FRED payloads to throw or suppress non-FRED forecast generation, revert this PR and rerun the focused trace test with the observed payload shape.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
