### PR TITLE
fix(forecast): guard market calibration anchors

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -148,6 +148,11 @@ const CYBER_PROB_VOLUME_WEIGHT = 0.5;       // weight of volume in probability f
 const CYBER_PROB_TYPE_WEIGHT = 0.15;        // weight of type diversity in probability formula
 const CONFLICT_BASE_DETECTOR_PROB_MAX = 0.90;
 const UCDP_CONFLICT_ZONE_PROB_MAX = 0.85;
+const MARKET_DETECTOR_PROB_MAX = 0.85;
+const SUPPLY_CHAIN_DETECTOR_PROB_MAX = 0.85;
+const POLITICAL_DETECTOR_PROB_MAX = 0.80;
+const MILITARY_DETECTOR_PROB_MAX = 0.90;
+const INFRASTRUCTURE_DETECTOR_PROB_MAX = 0.85;
 const VELOCITY_SPIKE_PROBABILITY_LIFT = 0.08;
 const VELOCITY_SPIKE_PROBABILITY_MAX = 0.99;
 const DEFENSE_DIRECT_CONFIRMATION_PRESSURE_LIFT = 0.12;
@@ -1141,7 +1146,7 @@ function detectMarketScenarios(inputs) {
     affectedRegions.add(region);
 
     const riskNorm = normalize(cp.riskScore || (risk === 'critical' ? 85 : 70), 40, 100);
-    const prob = Math.min(0.85, riskNorm * commodity.sensitivity);
+    const prob = Math.min(MARKET_DETECTOR_PROB_MAX, riskNorm * commodity.sensitivity);
 
     predictions.push(makePrediction(
       'market', region,
@@ -1236,7 +1241,7 @@ function detectSupplyChainScenarios(inputs) {
     }
 
     const riskNorm = normalize(cp.riskScore || 70, 40, 100);
-    const prob = Math.min(0.85, riskNorm * 0.7 + (aisGaps.length > 0 ? 0.1 : 0) + (nearbyJam.length > 0 ? 0.05 : 0));
+    const prob = Math.min(SUPPLY_CHAIN_DETECTOR_PROB_MAX, riskNorm * 0.7 + (aisGaps.length > 0 ? 0.1 : 0) + (nearbyJam.length > 0 ? 0.05 : 0));
     const confidence = Math.max(0.3, normalize(sourceCount, 0, 4));
 
     predictions.push(makePrediction(
@@ -1732,7 +1737,7 @@ function detectPoliticalScenarios(inputs) {
     const unrestNorm = normalize(Math.max(unrestComp, unrestCount * 10), 30, 100);
     const anomalyBoost = protestAnomalies.length > 0 ? 0.1 : 0;
     const eventBoost = unrestCount >= 5 ? 0.08 : unrestCount >= 3 ? 0.04 : 0;
-    const prob = Math.min(0.8, unrestNorm * 0.6 + anomalyBoost + eventBoost);
+    const prob = Math.min(POLITICAL_DETECTOR_PROB_MAX, unrestNorm * 0.6 + anomalyBoost + eventBoost);
     const confidence = Math.max(0.3, normalize(sourceCount, 0, 4));
 
     predictions.push(makePrediction(
@@ -1859,7 +1864,7 @@ function detectMilitaryScenarios(inputs) {
     const strikeBoost = (t?.activeOperations?.includes?.('strike_capable') || highestSurge?.strikeCapable) ? 0.06 : 0;
     const persistenceBoost = persistent ? 0.08 : 0;
     const genericPenalty = highestSurge?.surgeType === 'air_activity' && !persistent ? 0.12 : 0;
-    const prob = Math.min(0.9, Math.max(0.05, baseLine + flightBoost + postureBoost + supportBoost + strikeBoost + persistenceBoost + actorScore - genericPenalty));
+    const prob = Math.min(MILITARY_DETECTOR_PROB_MAX, Math.max(0.05, baseLine + flightBoost + postureBoost + supportBoost + strikeBoost + persistenceBoost + actorScore - genericPenalty));
     const confidence = Math.max(0.3, normalize(sourceCount, 0, 4));
     const title = highestSurge
       ? buildMilitaryForecastTitle(theaterId, theaterLabel, highestSurge)
@@ -1921,7 +1926,7 @@ function detectInfraScenarios(inputs) {
     const cyberBoost = relatedCyber.length > 0 ? 0.15 : 0;
     const jamBoost = nearbyJam.length > 0 ? 0.05 : 0;
     const baseLine = severity === 'total' ? 0.55 : 0.4;
-    const prob = Math.min(0.85, baseLine + cyberBoost + jamBoost);
+    const prob = Math.min(INFRASTRUCTURE_DETECTOR_PROB_MAX, baseLine + cyberBoost + jamBoost);
     const confidence = Math.max(0.3, normalize(sourceCount, 0, 4));
 
     predictions.push(makePrediction(
@@ -2067,34 +2072,53 @@ const DOMAIN_HINTS = {
 };
 
 const MARKET_CALIBRATION_WEIGHT = 0.4;
+// Detector generation can ingest thinner market rows, but calibration only
+// moves canonical probabilities from high-liquidity anchors.
 const MARKET_CALIBRATION_MIN_VOLUME = 5_000;
 const MARKET_CALIBRATION_DOMAIN_CAPS = {
   conflict: CONFLICT_BASE_DETECTOR_PROB_MAX,
-  market: 0.85,
-  supply_chain: 0.85,
-  political: 0.95,
-  military: 0.95,
+  market: MARKET_DETECTOR_PROB_MAX,
+  supply_chain: SUPPLY_CHAIN_DETECTOR_PROB_MAX,
+  political: POLITICAL_DETECTOR_PROB_MAX,
+  military: MILITARY_DETECTOR_PROB_MAX,
   cyber: CYBER_PROB_MAX,
-  infrastructure: 0.95,
+  infrastructure: INFRASTRUCTURE_DETECTOR_PROB_MAX,
 };
 const MARKET_DE_ESCALATION_OUTCOME_TERMS = [
   'ceasefire', 'truce', 'peace', 'peaceful', 'agreement', 'diplomatic solution',
-  'withdrawal', 'de-escalat', 'deescalat', 'reopen', 'reopened', 'restored',
-  'stabiliz', 'normaliz', 'resolution', 'resolved',
+  'withdrawal', 'reopen', 'reopened', 'restored', 'resolution', 'resolved',
 ];
 const MARKET_ADVERSE_OUTCOME_TERMS = [
-  'attack', 'strike', 'war', 'conflict', 'escalat', 'offensive', 'unrest',
+  'attack', 'strike', 'war', 'conflict', 'offensive', 'unrest',
   'instability', 'crisis', 'disruption', 'shock', 'stress', 'collapse',
-  'fail', 'breach', 'violate', 'reject', 'resume', 'renewed',
+  'renewed',
 ];
-const MARKET_STEM_OUTCOME_TERMS = new Set([
-  'de-escalat', 'deescalat', 'stabiliz', 'normaliz', 'escalat',
-]);
+const MARKET_DE_ESCALATION_OUTCOME_PATTERNS = [
+  /(?:^|[^a-z0-9])de-?escalat(?:e|es|ed|ing|ion|ory)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])stabili[sz](?:e|es|ed|ing|ation|ations)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])normali[sz](?:e|es|ed|ing|ation|ations)?(?:[^a-z0-9]|$)/,
+];
+const MARKET_ADVERSE_OUTCOME_PATTERNS = [
+  /(?:^|[^a-z0-9-])escalat(?:e|es|ed|ing|ion|ory)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])destabili[sz](?:e|es|ed|ing|ation|ations)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])fail(?:s|ed|ing|ure|ures)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])breach(?:es|ed|ing)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])violat(?:e|es|ed|ing|ion|ions)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])reject(?:s|ed|ing|ion|ions)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])resum(?:e|es|ed|ing|ption|ptions)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])renew(?:s|ed|ing|al|als)?(?:[^a-z0-9]|$)/,
+  /(?:^|[^a-z0-9])collaps(?:e|es|ed|ing)?(?:[^a-z0-9]|$)/,
+];
 const MARKET_DE_ESCALATION_ANCHOR_PATTERN = String.raw`(?:ceasefire|truce|peace(?: agreement| deal)?|agreement)`;
-const MARKET_DE_ESCALATION_FAILURE_PATTERN = String.raw`(?:fail(?:s|ed|ure)?|collapse(?:s|d)?|break(?:s|ing)? down|breakdown|breach(?:es|ed)?|violat(?:e|es|ed|ion)|reject(?:s|ed)?|expire(?:s|d)?|end(?:s|ed)?)`;
+const MARKET_DE_ESCALATION_FAILURE_PATTERN = String.raw`(?:fail(?:s|ed|ing|ure|ures)?|collaps(?:e|es|ed|ing)?|break(?:s|ing)? down|breakdown|breach(?:es|ed|ing)?|violat(?:e|es|ed|ing|ion|ions)?|reject(?:s|ed|ing|ion|ions)?|expire(?:s|d|ing)?|ends?\b(?!\s+of\b))`;
 const MARKET_FAILED_DE_ESCALATION_PATTERNS = [
   new RegExp(String.raw`\b${MARKET_DE_ESCALATION_ANCHOR_PATTERN}\b.{0,40}\b${MARKET_DE_ESCALATION_FAILURE_PATTERN}\b`),
   new RegExp(String.raw`\b${MARKET_DE_ESCALATION_FAILURE_PATTERN}\b.{0,40}\b${MARKET_DE_ESCALATION_ANCHOR_PATTERN}\b`),
+];
+const MARKET_ADVERSE_CONDITION_PATTERN = String.raw`(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)`;
+const MARKET_ADVERSE_CONDITION_END_PATTERNS = [
+  new RegExp(String.raw`\b${MARKET_ADVERSE_CONDITION_PATTERN}\b.{0,40}\bend(?:s|ed|ing)?\b(?!\s+of\b)`),
+  new RegExp(String.raw`\bend(?:s|ed|ing)?\b(?:\s+of)?.{0,40}\b${MARKET_ADVERSE_CONDITION_PATTERN}\b`),
 ];
 
 const DOMAIN_ACTOR_BLUEPRINTS = {
@@ -2295,26 +2319,31 @@ function computeMarketMatchScore(pred, marketTitle, regionTerms, options = {}) {
   };
 }
 
-function textHasAnyOutcomeTerm(text, terms) {
+function textMatchesAnyPattern(text, patterns) {
+  const lower = String(text || '').toLowerCase();
+  return patterns.some((pattern) => pattern.test(lower));
+}
+
+function textHasAnyOutcomeTerm(text, terms, patterns = []) {
   const lower = String(text || '').toLowerCase();
   return terms.some((term) => {
     const lowerTerm = String(term || '').toLowerCase().trim();
     if (!lowerTerm) return false;
-    if (MARKET_STEM_OUTCOME_TERMS.has(lowerTerm)) return lower.includes(lowerTerm);
     return textIncludesTerm(lower, lowerTerm);
-  });
+  }) || textMatchesAnyPattern(lower, patterns);
 }
 
 function marketTitleHasFailedDeEscalationOutcome(marketTitle) {
   const lower = String(marketTitle || '').toLowerCase();
-  if (!textHasAnyOutcomeTerm(lower, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
+  if (!textHasAnyOutcomeTerm(lower, MARKET_DE_ESCALATION_OUTCOME_TERMS, MARKET_DE_ESCALATION_OUTCOME_PATTERNS)) return false;
   return MARKET_FAILED_DE_ESCALATION_PATTERNS.some((pattern) => pattern.test(lower));
 }
 
 function classifyMarketYesOutcome(marketTitle) {
   if (marketTitleHasFailedDeEscalationOutcome(marketTitle)) return 'adverse';
-  if (textHasAnyOutcomeTerm(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return 'deescalatory';
-  if (textHasAnyOutcomeTerm(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS)) return 'adverse';
+  if (textMatchesAnyPattern(marketTitle, MARKET_ADVERSE_CONDITION_END_PATTERNS)) return 'deescalatory';
+  if (textHasAnyOutcomeTerm(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS, MARKET_DE_ESCALATION_OUTCOME_PATTERNS)) return 'deescalatory';
+  if (textHasAnyOutcomeTerm(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS, MARKET_ADVERSE_OUTCOME_PATTERNS)) return 'adverse';
   return 'unknown';
 }
 
@@ -2323,8 +2352,8 @@ function predictionYesOutcomeLooksDeEscalatory(pred) {
     .map((signal) => `${signal?.type || ''} ${signal?.value || ''}`)
     .join(' ');
   const text = `${pred.title || ''} ${pred.scenario || ''} ${signalText}`;
-  if (!textHasAnyOutcomeTerm(text, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
-  return !textHasAnyOutcomeTerm(text, MARKET_ADVERSE_OUTCOME_TERMS);
+  if (!textHasAnyOutcomeTerm(text, MARKET_DE_ESCALATION_OUTCOME_TERMS, MARKET_DE_ESCALATION_OUTCOME_PATTERNS)) return false;
+  return !textHasAnyOutcomeTerm(text, MARKET_ADVERSE_OUTCOME_TERMS, MARKET_ADVERSE_OUTCOME_PATTERNS);
 }
 
 function marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, marketTitle) {
@@ -2507,6 +2536,15 @@ function computeProjections(predictions) {
 
 function calibrateWithMarkets(predictions, markets) {
   if (!markets?.geopolitical) return;
+  const stats = {
+    applied: 0,
+    noPrice: 0,
+    lowVolume: 0,
+    direction: 0,
+    region: 0,
+    semantic: 0,
+    capNoop: 0,
+  };
   for (const pred of predictions) {
     const keywords = REGION_KEYWORDS[pred.region] || [];
     const regionTerms = [...new Set([...getSearchTermsForRegion(pred.region), pred.region])];
@@ -2522,16 +2560,32 @@ function calibrateWithMarkets(predictions, markets) {
         return { market: m, sameMacroRegion, ...match };
       })
       .filter(item => {
-        if (!Number.isFinite(item.market.yesPrice)) return false; // a price-less anchor would blend toward a fabricated 50%
-        if (getMarketCalibrationVolume(item.market) < MARKET_CALIBRATION_MIN_VOLUME) return false;
-        if (!marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, item.market.title)) return false;
-        if (item.tagMismatch && item.regionHits === 0) return false;
+        if (!Number.isFinite(item.market.yesPrice)) {
+          stats.noPrice++;
+          return false; // a price-less anchor would blend toward a fabricated 50%
+        }
+        if (getMarketCalibrationVolume(item.market) < MARKET_CALIBRATION_MIN_VOLUME) {
+          stats.lowVolume++;
+          return false;
+        }
+        if (!marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, item.market.title)) {
+          stats.direction++;
+          return false;
+        }
+        if (item.tagMismatch && item.regionHits === 0) {
+          stats.region++;
+          return false;
+        }
         const hasSpecificRegionSignal = item.regionHits > 0 || item.tagOverlap;
         const hasSemanticOverlap = item.titleHits > 0 || item.domainHits > 0;
         if (pred.domain === 'market') {
-          return hasSpecificRegionSignal && item.titleHits > 0 && (item.domainHits > 0 || item.score >= 7);
+          const keep = hasSpecificRegionSignal && item.titleHits > 0 && (item.domainHits > 0 || item.score >= 7);
+          if (!keep) stats.semantic++;
+          return keep;
         }
-        return hasSpecificRegionSignal && (hasSemanticOverlap || item.score >= 6);
+        const keep = hasSpecificRegionSignal && (hasSemanticOverlap || item.score >= 6);
+        if (!keep) stats.semantic++;
+        return keep;
       })
       .sort((a, b) => {
         if (b.score !== a.score) return b.score - a.score;
@@ -2541,16 +2595,27 @@ function calibrateWithMarkets(predictions, markets) {
     const match = best?.market || null;
     if (match) {
       const marketProb = match.yesPrice / 100;
+      const originalProbability = pred.probability;
+      const blendedProbability = +((MARKET_CALIBRATION_WEIGHT * marketProb)
+        + ((1 - MARKET_CALIBRATION_WEIGHT) * originalProbability)).toFixed(3);
+      const cappedProbability = capMarketCalibrationProbability(pred.domain, blendedProbability);
+      if (cappedProbability === originalProbability) {
+        stats.capNoop++;
+        continue;
+      }
       pred.calibration = {
         marketTitle: match.title,
         marketPrice: +marketProb.toFixed(3),
-        drift: +(pred.probability - marketProb).toFixed(3),
+        drift: +(originalProbability - marketProb).toFixed(3),
         source: match.source || 'polymarket',
       };
-      const blendedProbability = +((MARKET_CALIBRATION_WEIGHT * marketProb)
-        + ((1 - MARKET_CALIBRATION_WEIGHT) * pred.probability)).toFixed(3);
-      pred.probability = capMarketCalibrationProbability(pred.domain, blendedProbability);
+      pred.probability = cappedProbability;
+      stats.applied++;
     }
+  }
+  const dropped = stats.noPrice + stats.lowVolume + stats.direction + stats.region + stats.semantic + stats.capNoop;
+  if (stats.applied > 0 || dropped > 0) {
+    console.log(`  [calibrateWithMarkets] applied=${stats.applied} dropped=${dropped} no_price=${stats.noPrice} low_volume=${stats.lowVolume} direction=${stats.direction} region=${stats.region} semantic=${stats.semantic} cap_noop=${stats.capNoop}`);
   }
 }
 

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2087,6 +2087,15 @@ const MARKET_ADVERSE_OUTCOME_TERMS = [
   'instability', 'crisis', 'disruption', 'shock', 'stress', 'collapse',
   'fail', 'breach', 'violate', 'reject', 'resume', 'renewed',
 ];
+const MARKET_STEM_OUTCOME_TERMS = new Set([
+  'de-escalat', 'deescalat', 'stabiliz', 'normaliz', 'escalat',
+]);
+const MARKET_DE_ESCALATION_ANCHOR_PATTERN = String.raw`(?:ceasefire|truce|peace(?: agreement| deal)?|agreement)`;
+const MARKET_DE_ESCALATION_FAILURE_PATTERN = String.raw`(?:fail(?:s|ed|ure)?|collapse(?:s|d)?|break(?:s|ing)? down|breakdown|breach(?:es|ed)?|violat(?:e|es|ed|ion)|reject(?:s|ed)?|expire(?:s|d)?|end(?:s|ed)?)`;
+const MARKET_FAILED_DE_ESCALATION_PATTERNS = [
+  new RegExp(String.raw`\b${MARKET_DE_ESCALATION_ANCHOR_PATTERN}\b.{0,40}\b${MARKET_DE_ESCALATION_FAILURE_PATTERN}\b`),
+  new RegExp(String.raw`\b${MARKET_DE_ESCALATION_FAILURE_PATTERN}\b.{0,40}\b${MARKET_DE_ESCALATION_ANCHOR_PATTERN}\b`),
+];
 
 const DOMAIN_ACTOR_BLUEPRINTS = {
   conflict: [
@@ -2286,19 +2295,27 @@ function computeMarketMatchScore(pred, marketTitle, regionTerms, options = {}) {
   };
 }
 
-function textHasAnyStem(text, terms) {
+function textHasAnyOutcomeTerm(text, terms) {
   const lower = String(text || '').toLowerCase();
-  return terms.some((term) => lower.includes(term));
+  return terms.some((term) => {
+    const lowerTerm = String(term || '').toLowerCase().trim();
+    if (!lowerTerm) return false;
+    if (MARKET_STEM_OUTCOME_TERMS.has(lowerTerm)) return lower.includes(lowerTerm);
+    return textIncludesTerm(lower, lowerTerm);
+  });
 }
 
-function marketYesOutcomeLooksDeEscalatory(marketTitle) {
-  if (!textHasAnyStem(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
-  return !textHasAnyStem(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS);
+function marketTitleHasFailedDeEscalationOutcome(marketTitle) {
+  const lower = String(marketTitle || '').toLowerCase();
+  if (!textHasAnyOutcomeTerm(lower, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
+  return MARKET_FAILED_DE_ESCALATION_PATTERNS.some((pattern) => pattern.test(lower));
 }
 
-function marketYesOutcomeLooksAdverse(marketTitle) {
-  if (!textHasAnyStem(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS)) return false;
-  return !textHasAnyStem(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS);
+function classifyMarketYesOutcome(marketTitle) {
+  if (marketTitleHasFailedDeEscalationOutcome(marketTitle)) return 'adverse';
+  if (textHasAnyOutcomeTerm(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return 'deescalatory';
+  if (textHasAnyOutcomeTerm(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS)) return 'adverse';
+  return 'unknown';
 }
 
 function predictionYesOutcomeLooksDeEscalatory(pred) {
@@ -2306,13 +2323,14 @@ function predictionYesOutcomeLooksDeEscalatory(pred) {
     .map((signal) => `${signal?.type || ''} ${signal?.value || ''}`)
     .join(' ');
   const text = `${pred.title || ''} ${pred.scenario || ''} ${signalText}`;
-  if (!textHasAnyStem(text, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
-  return !textHasAnyStem(text, MARKET_ADVERSE_OUTCOME_TERMS);
+  if (!textHasAnyOutcomeTerm(text, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
+  return !textHasAnyOutcomeTerm(text, MARKET_ADVERSE_OUTCOME_TERMS);
 }
 
 function marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, marketTitle) {
-  if (marketYesOutcomeLooksDeEscalatory(marketTitle)) return predictionDeEscalatoryOutcome;
-  if (marketYesOutcomeLooksAdverse(marketTitle)) return !predictionDeEscalatoryOutcome;
+  const marketOutcome = classifyMarketYesOutcome(marketTitle);
+  if (marketOutcome === 'deescalatory') return predictionDeEscalatoryOutcome;
+  if (marketOutcome === 'adverse') return !predictionDeEscalatoryOutcome;
   return true;
 }
 

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2066,6 +2066,25 @@ const DOMAIN_HINTS = {
   infrastructure: ['outage', 'blackout', 'power', 'grid', 'pipeline', 'cyber', 'telecom', 'internet'],
 };
 
+const MARKET_CALIBRATION_WEIGHT = 0.4;
+const MARKET_CALIBRATION_MIN_VOLUME = 5_000;
+const MARKET_CALIBRATION_DOMAIN_CAPS = {
+  conflict: CONFLICT_BASE_DETECTOR_PROB_MAX,
+  market: 0.85,
+  supply_chain: 0.85,
+  cyber: CYBER_PROB_MAX,
+};
+const MARKET_DE_ESCALATION_OUTCOME_TERMS = [
+  'ceasefire', 'truce', 'peace', 'peaceful', 'agreement', 'diplomatic solution',
+  'withdrawal', 'de-escalat', 'deescalat', 'reopen', 'reopened', 'restored',
+  'stabiliz', 'normaliz', 'resolution', 'resolved',
+];
+const MARKET_ADVERSE_OUTCOME_TERMS = [
+  'attack', 'strike', 'war', 'conflict', 'escalat', 'offensive', 'unrest',
+  'instability', 'crisis', 'disruption', 'shock', 'stress', 'collapse',
+  'fail', 'breach', 'violate', 'reject', 'resume', 'renewed',
+];
+
 const DOMAIN_ACTOR_BLUEPRINTS = {
   conflict: [
     { key: 'state_command', name: 'Regional command authority', category: 'state', influenceScore: 0.88 },
@@ -2264,6 +2283,40 @@ function computeMarketMatchScore(pred, marketTitle, regionTerms, options = {}) {
   };
 }
 
+function textHasAnyStem(text, terms) {
+  const lower = String(text || '').toLowerCase();
+  return terms.some((term) => lower.includes(term));
+}
+
+function marketYesOutcomeLooksDeEscalatory(marketTitle) {
+  if (!textHasAnyStem(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
+  return !textHasAnyStem(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS);
+}
+
+function predictionYesOutcomeLooksDeEscalatory(pred) {
+  const signalText = (pred.signals || [])
+    .map((signal) => `${signal?.type || ''} ${signal?.value || ''}`)
+    .join(' ');
+  const text = `${pred.title || ''} ${pred.scenario || ''} ${signalText}`;
+  if (!textHasAnyStem(text, MARKET_DE_ESCALATION_OUTCOME_TERMS)) return false;
+  return !textHasAnyStem(text, MARKET_ADVERSE_OUTCOME_TERMS);
+}
+
+function marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, marketTitle) {
+  if (!marketYesOutcomeLooksDeEscalatory(marketTitle)) return true;
+  return predictionDeEscalatoryOutcome;
+}
+
+function getMarketCalibrationVolume(market) {
+  const volume = Number(market?.volume ?? 0);
+  return Number.isFinite(volume) ? volume : 0;
+}
+
+function capMarketCalibrationProbability(domain, probability) {
+  const cap = MARKET_CALIBRATION_DOMAIN_CAPS[domain] ?? 1;
+  return +Math.max(0, Math.min(cap, probability)).toFixed(3);
+}
+
 function detectFromPredictionMarkets(inputs) {
   const predictions = [];
   const markets = inputs.predictionMarkets?.geopolitical || [];
@@ -2432,6 +2485,7 @@ function calibrateWithMarkets(predictions, markets) {
     const regionTerms = [...new Set([...getSearchTermsForRegion(pred.region), pred.region])];
     const expectedTags = buildExpectedRegionTags(regionTerms, pred.region);
     const titleTokens = extractMeaningfulTokens(pred.title, regionTerms);
+    const predictionDeEscalatoryOutcome = predictionYesOutcomeLooksDeEscalatory(pred);
     if (keywords.length === 0 && regionTerms.length === 0) continue;
     const candidates = markets.geopolitical
       .map(m => {
@@ -2442,6 +2496,8 @@ function calibrateWithMarkets(predictions, markets) {
       })
       .filter(item => {
         if (!Number.isFinite(item.market.yesPrice)) return false; // a price-less anchor would blend toward a fabricated 50%
+        if (getMarketCalibrationVolume(item.market) < MARKET_CALIBRATION_MIN_VOLUME) return false;
+        if (!marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, item.market.title)) return false;
         if (item.tagMismatch && item.regionHits === 0) return false;
         const hasSpecificRegionSignal = item.regionHits > 0 || item.tagOverlap;
         const hasSemanticOverlap = item.titleHits > 0 || item.domainHits > 0;
@@ -2452,7 +2508,7 @@ function calibrateWithMarkets(predictions, markets) {
       })
       .sort((a, b) => {
         if (b.score !== a.score) return b.score - a.score;
-        return (b.market.volume || 0) - (a.market.volume || 0);
+        return getMarketCalibrationVolume(b.market) - getMarketCalibrationVolume(a.market);
       });
     const best = candidates[0];
     const match = best?.market || null;
@@ -2464,7 +2520,9 @@ function calibrateWithMarkets(predictions, markets) {
         drift: +(pred.probability - marketProb).toFixed(3),
         source: match.source || 'polymarket',
       };
-      pred.probability = +(0.4 * marketProb + 0.6 * pred.probability).toFixed(3);
+      const blendedProbability = +((MARKET_CALIBRATION_WEIGHT * marketProb)
+        + ((1 - MARKET_CALIBRATION_WEIGHT) * pred.probability)).toFixed(3);
+      pred.probability = capMarketCalibrationProbability(pred.domain, blendedProbability);
     }
   }
 }

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2072,7 +2072,10 @@ const MARKET_CALIBRATION_DOMAIN_CAPS = {
   conflict: CONFLICT_BASE_DETECTOR_PROB_MAX,
   market: 0.85,
   supply_chain: 0.85,
+  political: 0.95,
+  military: 0.95,
   cyber: CYBER_PROB_MAX,
+  infrastructure: 0.95,
 };
 const MARKET_DE_ESCALATION_OUTCOME_TERMS = [
   'ceasefire', 'truce', 'peace', 'peaceful', 'agreement', 'diplomatic solution',
@@ -2293,6 +2296,11 @@ function marketYesOutcomeLooksDeEscalatory(marketTitle) {
   return !textHasAnyStem(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS);
 }
 
+function marketYesOutcomeLooksAdverse(marketTitle) {
+  if (!textHasAnyStem(marketTitle, MARKET_ADVERSE_OUTCOME_TERMS)) return false;
+  return !textHasAnyStem(marketTitle, MARKET_DE_ESCALATION_OUTCOME_TERMS);
+}
+
 function predictionYesOutcomeLooksDeEscalatory(pred) {
   const signalText = (pred.signals || [])
     .map((signal) => `${signal?.type || ''} ${signal?.value || ''}`)
@@ -2303,8 +2311,9 @@ function predictionYesOutcomeLooksDeEscalatory(pred) {
 }
 
 function marketOutcomeAlignsPrediction(predictionDeEscalatoryOutcome, marketTitle) {
-  if (!marketYesOutcomeLooksDeEscalatory(marketTitle)) return true;
-  return predictionDeEscalatoryOutcome;
+  if (marketYesOutcomeLooksDeEscalatory(marketTitle)) return predictionDeEscalatoryOutcome;
+  if (marketYesOutcomeLooksAdverse(marketTitle)) return !predictionDeEscalatoryOutcome;
+  return true;
 }
 
 function getMarketCalibrationVolume(market) {

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -251,7 +251,7 @@ describe('calibrateWithMarkets', () => {
     );
     const originalProb = pred.probability;
     const markets = {
-      geopolitical: [{ title: 'Will EU inflation drop?', yesPrice: 50 }],
+      geopolitical: [{ title: 'Will EU inflation drop?', yesPrice: 50, volume: 50000 }],
     };
     calibrateWithMarkets([pred], markets);
     assert.equal(pred.probability, originalProb);
@@ -282,6 +282,18 @@ describe('calibrateWithMarkets', () => {
     assert.equal(pred.probability, 0.45);
   });
 
+  it('does not calibrate de-escalation risk from an adverse YES market', () => {
+    const pred = makePrediction(
+      'conflict', 'Sudan', 'Ceasefire holds in Sudan',
+      0.6, 0.5, '7d', [{ type: 'ceasefire', value: 'ceasefire holds', weight: 0.4 }],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Sudan conflict escalate by Q3?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.6);
+  });
+
   it('does not calibrate from a low-liquidity market', () => {
     const pred = makePrediction(
       'conflict', 'Middle East', 'Escalation risk: Iran',
@@ -304,6 +316,18 @@ describe('calibrateWithMarkets', () => {
     });
     assert.ok(pred.calibration !== null);
     assert.equal(pred.probability, 0.9);
+  });
+
+  it('applies explicit post-blend caps to non-conflict domains', () => {
+    const pred = makePrediction(
+      'political', 'Iran', 'Political instability: Iran',
+      0.94, 0.6, '7d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Iran political unrest escalate in 2026?', yesPrice: 99, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null);
+    assert.equal(pred.probability, 0.95);
   });
 
   it('null markets handled gracefully', () => {

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -282,6 +282,18 @@ describe('calibrateWithMarkets', () => {
     assert.equal(pred.probability, 0.45);
   });
 
+  it('does not classify a temporal "end of" phrase as a failed ceasefire', () => {
+    const pred = makePrediction(
+      'conflict', 'Sudan', 'Escalation risk: Sudan',
+      0.45, 0.6, '30d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will there be a ceasefire in Sudan by the end of 2026?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.45);
+  });
+
   it('does not calibrate de-escalation risk from an adverse YES market', () => {
     const pred = makePrediction(
       'conflict', 'Sudan', 'Ceasefire holds in Sudan',
@@ -292,6 +304,60 @@ describe('calibrateWithMarkets', () => {
     });
     assert.equal(pred.calibration, null);
     assert.equal(pred.probability, 0.6);
+  });
+
+  it('calibrates an aligned de-escalation forecast with a de-escalation market', () => {
+    const pred = makePrediction(
+      'conflict', 'Sudan', 'Sudan de-escalation ceasefire forecast',
+      0.55, 0.5, '7d', [{ type: 'de-escalation', value: 'Sudan de-escalate ceasefire diplomacy', weight: 0.4 }],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Sudan de-escalate into a ceasefire by 2026?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null);
+    assert.equal(pred.probability, +(0.4 * 0.8 + 0.6 * 0.55).toFixed(3));
+  });
+
+  it('does not treat destabilize as a stabilizing outcome stem', () => {
+    const pred = makePrediction(
+      'conflict', 'Sudan', 'Escalation risk: Sudan',
+      0.45, 0.6, '30d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Sudan destabilize further amid conflict?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null);
+    assert.equal(pred.probability, +(0.4 * 0.8 + 0.6 * 0.45).toFixed(3));
+  });
+
+  it('does not calibrate de-escalation forecasts from adverse conjugations', () => {
+    for (const title of [
+      'Will Iran rejected nuclear deal terms by 2026?',
+      'Will Iran nuclear deal violation occur by 2026?',
+      'Will Iran nuclear deal breaches resume by 2026?',
+    ]) {
+      const pred = makePrediction(
+        'conflict', 'Iran', 'Nuclear deal restored: Iran',
+        0.55, 0.5, '7d', [{ type: 'agreement', value: 'nuclear deal restored', weight: 0.4 }],
+      );
+      calibrateWithMarkets([pred], {
+        geopolitical: [{ title, yesPrice: 85, source: 'polymarket', volume: 50000 }],
+      });
+      assert.equal(pred.calibration, null, title);
+      assert.equal(pred.probability, 0.55, title);
+    }
+  });
+
+  it('treats an adverse condition ending as a de-escalatory YES outcome', () => {
+    const pred = makePrediction(
+      'conflict', 'Sudan', 'Escalation risk: Sudan',
+      0.3, 0.6, '30d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will the Sudan war end in 2026?', yesPrice: 70, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.3);
   });
 
   it('does not calibrate from a low-liquidity market', () => {
@@ -309,25 +375,37 @@ describe('calibrateWithMarkets', () => {
   it('re-applies the domain cap after market calibration', () => {
     const pred = makePrediction(
       'conflict', 'Middle East', 'Escalation risk: Iran',
+      0.85, 0.6, '7d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', yesPrice: 99, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null);
+    assert.equal(pred.probability, 0.9);
+  });
+
+  it('does not record calibration metadata when a cap makes the blend a no-op', () => {
+    const pred = makePrediction(
+      'conflict', 'Middle East', 'Escalation risk: Iran',
       0.9, 0.6, '7d', [],
     );
     calibrateWithMarkets([pred], {
       geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', yesPrice: 96, source: 'polymarket', volume: 50000 }],
     });
-    assert.ok(pred.calibration !== null);
+    assert.equal(pred.calibration, null);
     assert.equal(pred.probability, 0.9);
   });
 
   it('applies explicit post-blend caps to non-conflict domains', () => {
     const pred = makePrediction(
       'political', 'Iran', 'Political instability: Iran',
-      0.94, 0.6, '7d', [],
+      0.78, 0.6, '7d', [],
     );
     calibrateWithMarkets([pred], {
       geopolitical: [{ title: 'Will Iran political unrest escalate in 2026?', yesPrice: 99, source: 'polymarket', volume: 50000 }],
     });
     assert.ok(pred.calibration !== null);
-    assert.equal(pred.probability, 0.95);
+    assert.equal(pred.probability, 0.8);
   });
 
   it('null markets handled gracefully', () => {
@@ -560,6 +638,7 @@ describe('word-boundary term matching: no substring false positives (#4933)', ()
   it('calibrateWithMarkets: plural domain hint still calibrates (elections vs election)', () => {
     const pred = makePrediction('political', 'Nigeria', 'Political instability: Nigeria', 0.7, 0.6, '30d', []);
     calibrateWithMarkets([pred], {
+      // Keep this title adverse-aligned; a peaceful-election market is now rejected by the direction guard.
       geopolitical: [{ title: 'Will Nigeria elections trigger unrest in 2026?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
     });
     assert.ok(pred.calibration !== null);

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -235,7 +235,7 @@ describe('calibrateWithMarkets', () => {
     );
     pred.region = 'Middle East';
     const markets = {
-      geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', yesPrice: 30, source: 'polymarket' }],
+      geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', yesPrice: 30, source: 'polymarket', volume: 50000 }],
     };
     calibrateWithMarkets([pred], markets);
     const expected = +(0.4 * 0.3 + 0.6 * 0.7).toFixed(3);
@@ -264,10 +264,46 @@ describe('calibrateWithMarkets', () => {
       0.7, 0.6, '7d', [],
     );
     const markets = {
-      geopolitical: [{ title: 'Iran MENA conflict?', yesPrice: 40 }],
+      geopolitical: [{ title: 'Iran MENA conflict?', yesPrice: 40, volume: 50000 }],
     };
     calibrateWithMarkets([pred], markets);
     assert.equal(pred.calibration.drift, +(0.7 - 0.4).toFixed(3));
+  });
+
+  it('does not calibrate escalation risk from a de-escalation YES market', () => {
+    const pred = makePrediction(
+      'conflict', 'Sudan', 'Escalation risk: Sudan',
+      0.45, 0.6, '30d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Sudan reach a ceasefire by Q3?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.45);
+  });
+
+  it('does not calibrate from a low-liquidity market', () => {
+    const pred = makePrediction(
+      'conflict', 'Middle East', 'Escalation risk: Iran',
+      0.5, 0.6, '7d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', yesPrice: 95, source: 'polymarket', volume: 20 }],
+    });
+    assert.equal(pred.calibration, null);
+    assert.equal(pred.probability, 0.5);
+  });
+
+  it('re-applies the domain cap after market calibration', () => {
+    const pred = makePrediction(
+      'conflict', 'Middle East', 'Escalation risk: Iran',
+      0.9, 0.6, '7d', [],
+    );
+    calibrateWithMarkets([pred], {
+      geopolitical: [{ title: 'Will Iran conflict escalate in MENA?', yesPrice: 96, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null);
+    assert.equal(pred.probability, 0.9);
   });
 
   it('null markets handled gracefully', () => {
@@ -500,7 +536,7 @@ describe('word-boundary term matching: no substring false positives (#4933)', ()
   it('calibrateWithMarkets: plural domain hint still calibrates (elections vs election)', () => {
     const pred = makePrediction('political', 'Nigeria', 'Political instability: Nigeria', 0.7, 0.6, '30d', []);
     calibrateWithMarkets([pred], {
-      geopolitical: [{ title: 'Will Nigeria hold peaceful elections in 2026?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
+      geopolitical: [{ title: 'Will Nigeria elections trigger unrest in 2026?', yesPrice: 80, source: 'polymarket', volume: 50000 }],
     });
     assert.ok(pred.calibration !== null);
     assert.equal(pred.probability, +(0.4 * 0.8 + 0.6 * 0.7).toFixed(3));

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -276,7 +276,7 @@ describe('calibrateWithMarkets', () => {
       0.45, 0.6, '30d', [],
     );
     calibrateWithMarkets([pred], {
-      geopolitical: [{ title: 'Will Sudan reach a ceasefire by Q3?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
+      geopolitical: [{ title: 'Will the Sudan conflict reach a ceasefire by Q3?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
     });
     assert.equal(pred.calibration, null);
     assert.equal(pred.probability, 0.45);
@@ -288,7 +288,7 @@ describe('calibrateWithMarkets', () => {
       0.6, 0.5, '7d', [{ type: 'ceasefire', value: 'ceasefire holds', weight: 0.4 }],
     );
     calibrateWithMarkets([pred], {
-      geopolitical: [{ title: 'Will Sudan conflict escalate by Q3?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
+      geopolitical: [{ title: 'Will the Sudan ceasefire fail by Q3?', yesPrice: 85, source: 'polymarket', volume: 50000 }],
     });
     assert.equal(pred.calibration, null);
     assert.equal(pred.probability, 0.6);


### PR DESCRIPTION
## Summary

Market calibration no longer lets a de-escalation YES market, a tiny-liquidity market, or an over-cap market blend corrupt forecast probabilities. Calibration now requires the market outcome to point in the same direction as the forecast, ignores low-volume anchors, and reapplies the detector domain cap after blending.

This keeps prediction-market evidence useful for aligned markets while preventing ceasefire-style markets from raising escalation forecasts or thin markets from moving the canonical forecast set.

Fixes #5100

## Validation

- `node --test tests/forecast-detectors.test.mjs`
- `node --check scripts/seed-forecasts.mjs`
- `git diff --check`
- Pre-push gate: `npm run typecheck`, `npm run typecheck:api`, Convex type check, CJS syntax check, Unicode safety, `npm run lint:boundaries`, `npm run lint:safe-html`, `npm run lint:rate-limit-policies`, `npm run lint:premium-fetch`, edge bundle check, changed test files, proto freshness, and version sync

## Post-Deploy Monitoring & Validation

- Log queries/search terms: `calibrateWithMarkets`, `prediction_market`, `marketTitle`, `marketPrice`, `forecast:predictions:v2`, and any seed logs around market calibration for conflict forecasts.
- Metrics or dashboards to watch: forecast seed success rate, canonical forecast write freshness, forecast probability distribution by domain, and forecast scorecard/Brier movement for conflict forecasts linked to prediction markets.
- Expected healthy signals: no market-calibrated conflict forecast exceeds its detector cap; high-liquidity aligned escalation markets can still calibrate; ceasefire/de-escalation YES markets do not appear as calibration evidence for escalation forecasts.
- Failure signals and rollback trigger: sudden drop to zero market calibration across aligned high-volume markets, renewed forecasts above domain caps after calibration, or seed failures in `seed-forecasts`; rollback this PR and rerun the forecast seed if observed.
- Validation window and owner: first 24 hours after deploy, forecast/seed owner.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
