### PR TITLE
fix(forecast): fail ACLED seed when primary feed is unavailable

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -352,7 +352,7 @@ async function fetchAll() {
   if (!ac) {
     const reason = acled.status === 'rejected'
       ? (acled.reason?.message || acled.reason)
-      : 'no ACLED display payload returned';
+      : 'ACLED credentials not configured (set ACLED_EMAIL + ACLED_PASSWORD or ACLED_ACCESS_TOKEN)';
     throw new Error(
       `ACLED display fetch failed for ${ACLED_CACHE_KEY}; refusing to let auxiliary conflict/intel feeds mask the primary feed (${reason})`,
     );

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -335,9 +335,8 @@ async function fetchAll() {
   if (pizzint.status === 'rejected') console.warn(`  PizzINT failed: ${pizzint.reason?.message || pizzint.reason}`);
   if (gdelt.status === 'rejected') console.warn(`  GDELT failed: ${gdelt.reason?.message || gdelt.reason}`);
 
-  if (!ac && !ha && !pi) throw new Error('All conflict/intel fetches failed');
-
-  // Write secondary keys BEFORE returning (runSeed calls process.exit after primary write)
+  // Write secondary keys BEFORE returning or failing the primary feed
+  // (runSeed calls process.exit after primary write).
   if (ha) { for (const [cc, data] of Object.entries(ha)) await writeExtraKeyWithMeta(`${HAPI_CACHE_KEY_PREFIX}:${cc}`, data, HAPI_TTL, 1); }
   if (acResolution?.events?.length) {
     await writeExtraKeyWithMeta(
@@ -350,7 +349,16 @@ async function fetchAll() {
   if (pi) await writeExtraKeyWithMeta('intel:pizzint:v1:base', { pizzint: pi, tensionPairs: [] }, PIZZINT_TTL, pi.locationsMonitored ?? 0);
   if (pi && gd) await writeExtraKeyWithMeta('intel:pizzint:v1:gdelt', { pizzint: pi, tensionPairs: gd }, PIZZINT_TTL, gd.length ?? 0);
 
-  return ac || { events: [], pagination: undefined };
+  if (!ac) {
+    const reason = acled.status === 'rejected'
+      ? (acled.reason?.message || acled.reason)
+      : 'no ACLED display payload returned';
+    throw new Error(
+      `ACLED display fetch failed for ${ACLED_CACHE_KEY}; refusing to let auxiliary conflict/intel feeds mask the primary feed (${reason})`,
+    );
+  }
+
+  return ac;
 }
 
 function validate(data) {

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -350,12 +350,15 @@ async function fetchAll() {
   if (pi && gd) await writeExtraKeyWithMeta('intel:pizzint:v1:gdelt', { pizzint: pi, tensionPairs: gd }, PIZZINT_TTL, gd.length ?? 0);
 
   if (!ac) {
+    const missingCredentials = acled.status === 'fulfilled';
     const reason = acled.status === 'rejected'
       ? (acled.reason?.message || acled.reason)
       : 'ACLED credentials not configured (set ACLED_EMAIL + ACLED_PASSWORD or ACLED_ACCESS_TOKEN)';
-    throw new Error(
+    const err = new Error(
       `ACLED display fetch failed for ${ACLED_CACHE_KEY}; refusing to let auxiliary conflict/intel feeds mask the primary feed (${reason})`,
     );
+    if (missingCredentials || acled.reason?.nonRetryable) err.nonRetryable = true;
+    throw err;
   }
 
   return ac;

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -40,6 +40,7 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
 
   it('conflict seeder fails the primary feed when ACLED display data is unavailable', () => {
     assert.match(conflictSeed, /if\s*\(!ac\)\s*\{[\s\S]*throw new Error\([\s\S]*ACLED display fetch failed for \$\{ACLED_CACHE_KEY\}[\s\S]*auxiliary conflict\/intel feeds mask the primary feed/);
+    assert.match(conflictSeed, /ACLED credentials not configured \(set ACLED_EMAIL \+ ACLED_PASSWORD or ACLED_ACCESS_TOKEN\)/);
     assert.doesNotMatch(conflictSeed, /return\s+ac\s*\|\|\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/);
   });
 

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -38,6 +38,11 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
     assert.match(conflictSeed, /ACLED_RESOLUTION_CACHE_KEY,[\s\S]*clusters:\s*\[\],[\s\S]*acResolution\.pagination/);
   });
 
+  it('conflict seeder fails the primary feed when ACLED display data is unavailable', () => {
+    assert.match(conflictSeed, /if\s*\(!ac\)\s*\{[\s\S]*throw new Error\([\s\S]*ACLED display fetch failed for \$\{ACLED_CACHE_KEY\}[\s\S]*auxiliary conflict\/intel feeds mask the primary feed/);
+    assert.doesNotMatch(conflictSeed, /return\s+ac\s*\|\|\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/);
+  });
+
   it('unrest seeder keeps the canonical display feed but also publishes a paginated 60d ACLED resolution feed', () => {
     assert.match(unrestSeed, /CANONICAL_KEY\s*=\s*'unrest:events:v1'/);
     assert.match(unrestSeed, /ACLED_DISPLAY_LOOKBACK_DAYS\s*=\s*30/);

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -39,8 +39,11 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
   });
 
   it('conflict seeder fails the primary feed when ACLED display data is unavailable', () => {
-    assert.match(conflictSeed, /if\s*\(!ac\)\s*\{[\s\S]*throw new Error\([\s\S]*ACLED display fetch failed for \$\{ACLED_CACHE_KEY\}[\s\S]*auxiliary conflict\/intel feeds mask the primary feed/);
+    assert.match(conflictSeed, /if\s*\(!ac\)\s*\{[\s\S]*const err = new Error\([\s\S]*ACLED display fetch failed for \$\{ACLED_CACHE_KEY\}[\s\S]*auxiliary conflict\/intel feeds mask the primary feed/);
     assert.match(conflictSeed, /ACLED credentials not configured \(set ACLED_EMAIL \+ ACLED_PASSWORD or ACLED_ACCESS_TOKEN\)/);
+    assert.match(conflictSeed, /missingCredentials\s*=\s*acled\.status\s*===\s*'fulfilled'/);
+    assert.match(conflictSeed, /if\s*\(\s*missingCredentials\s*\|\|\s*acled\.reason\?\.nonRetryable\s*\)\s*err\.nonRetryable\s*=\s*true/);
+    assert.match(conflictSeed, /throw err/);
     assert.doesNotMatch(conflictSeed, /return\s+ac\s*\|\|\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/);
   });
 


### PR DESCRIPTION
## Summary

The conflict-intel seed now treats the ACLED display feed as the primary contract instead of letting HAPI/PizzINT side feeds turn a missing ACLED payload into a zero-record retry. The side feeds still publish when available, but the ACLED canonical key now takes the seed runner's fetch-failure path so Railway and health both show the outage instead of a green-looking cron tick.

Related: #5099

## Validation

- Live production check on 2026-07-09: `/api/health?compact=1` reports `acledIntel` as `EMPTY`; Railway `seed-conflict-intel` logs show scheduled runs with ACLED credentials missing and contract `RETRY`.
- `node --test tests/acled-resolution-feed-seed.test.mjs tests/health-classify.test.mjs`
- `node --check scripts/seed-conflict-intel.mjs`
- `git diff --check`
- `./node_modules/.bin/biome lint scripts/seed-conflict-intel.mjs tests/acled-resolution-feed-seed.test.mjs`
- Pre-push hook: frontend typecheck, API typecheck, Convex audit, boundary lint, safe-html lint, rate-limit policy lint, premium-fetch lint, edge bundle check, changed tests, proto freshness, and version sync.

## Post-Deploy Monitoring & Validation

- Log queries: in Railway service `seed-conflict-intel`, search for `ACLED display:`, `FETCH FAILED:`, `ACLED display fetch failed for conflict:acled:v1:all:0:0`, and `=== Failed gracefully`.
- Healthy signals: after ACLED credentials are configured, scheduled runs show a non-zero `ACLED display` event count, publish the `conflict:acled:v1:all:0:0` envelope, and `/api/health?compact=1` reports `acledIntel` OK with records above zero and seed age under 38 minutes.
- Failure signals: the cron keeps exiting through fetch-failure, or health remains `EMPTY` / `STALE_SEED` after one 15-minute cycle.
- Mitigation trigger: configure `ACLED_EMAIL` + `ACLED_PASSWORD` or `ACLED_ACCESS_TOKEN` on the Railway `seed-conflict-intel` service, then run/redeploy the service. Roll back this PR only if the service must temporarily keep side-feed-only green status.
- Validation window and owner: watch the first two scheduled runs after deploy and credential update; owner is the operator applying Railway secrets.

## Known Residuals

- Production still needs ACLED credentials configured on the Railway `seed-conflict-intel` service. This PR makes the outage fail loudly but does not set or expose secret values.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex-GPT--5-000000)
