### PR TITLE
fix(sentry): suppress Firefox host-suffixed NetworkError for DebugBear RUM beacon

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -30,6 +30,15 @@ const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set([
   // ignoreError. NOT our `api.worldmonitor.app`, which stays off the list so
   // genuine API regressions still surface (WORLDMONITOR-SA/SB).
   'clerk.worldmonitor.app',
+  // DebugBear RUM beacon collector. We embed the DebugBear RUM script
+  // (`src/bootstrap/debugbear-rum.ts` → cdn.debugbear.com) whose collector
+  // POSTs field metrics to `data.debugbear.com`; a leaked
+  // `NetworkError ... (data.debugbear.com)` / `Failed to fetch (data.debugbear.com)`
+  // is a dropped monitoring beacon (adblock / network blip) — invisible to the
+  // user and unactionable, same disposition as the Clerk-SDK-internal fetch
+  // above. NOT `api.worldmonitor.app` (stays off so real API regressions
+  // surface). WORLDMONITOR-RP.
+  'data.debugbear.com',
 ]);
 
 function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
@@ -336,11 +345,14 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // so a self-hosted R2 PMTiles / first-party basemap regression isn't silently dropped just
       // because its stack happens to be all-vendor frames (WORLDMONITOR-NE/NF follow-up).
       const excType = event.exception?.values?.[0]?.type ?? '';
-      // `TypeError: Failed to fetch (<host>)` shape — emitted by maplibre's AJAX
-      // wrapper AND by first-party fetch callers that surface a host-suffixed
-      // network error. The host allowlist below is the load-bearing safety;
-      // this match is just the shape detector.
-      const isHostScopedFetchFailure = excType === 'TypeError' && /^Failed to fetch \([^)]+\)$/.test(msg);
+      // Host-suffixed fetch-failure shapes — Chrome/Edge `Failed to fetch (<host>)`
+      // (maplibre's AJAX wrapper AND first-party fetch callers) and Firefox
+      // `NetworkError when attempting to fetch resource. (<host>)` (the
+      // engine-equivalent phrasing, e.g. an embedded SDK's beacon fetch —
+      // WORLDMONITOR-RP). Both route through the host allowlist below, which is
+      // the load-bearing safety; this match is just the shape detector.
+      const isHostScopedFetchFailure = excType === 'TypeError'
+        && /^(?:Failed to fetch|NetworkError when attempting to fetch resource\.) \([^)]+\)$/.test(msg);
       if (!isHostScopedFetchFailure
           && (excType === 'TypeError' || excType === 'RangeError' || /^(?:TypeError|RangeError):/.test(msg))
           && frames.length > 0) {
@@ -359,7 +371,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // real basemap / API regression is never silently dropped
       // (WORLDMONITOR-NE/NF, WORLDMONITOR-QG).
       if (isHostScopedFetchFailure) {
-        const hostMatch = msg.match(/^Failed to fetch \(([^)]+)\)$/);
+        const hostMatch = msg.match(/^(?:Failed to fetch|NetworkError when attempting to fetch resource\.) \(([^)]+)\)$/);
         const host = hostMatch?.[1];
         if (host && THIRD_PARTY_FETCH_HOST_ALLOWLIST.has(host)) return null;
       }

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -630,6 +630,39 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'First-party + extension Failed-to-fetch must reach Sentry');
   });
 
+  it('suppresses Firefox "NetworkError ... (data.debugbear.com)" — embedded RUM beacon, zero frames (WORLDMONITOR-RP)', () => {
+    // Firefox's host-suffixed phrasing for a failed fetch. The DebugBear RUM
+    // script (src/bootstrap/debugbear-rum.ts) POSTs field metrics to
+    // data.debugbear.com; a dropped beacon surfaces via onunhandledrejection
+    // with no captured frames. Routed through the same host allowlist as the
+    // Chrome `Failed to fetch (<host>)` shape, so an allowlisted host is
+    // suppressed regardless of stack.
+    const event = makeEvent('NetworkError when attempting to fetch resource. (data.debugbear.com)', 'TypeError', []);
+    assert.equal(beforeSend(event), null, 'DebugBear RUM beacon network failure should be suppressed');
+  });
+
+  it('suppresses Firefox "NetworkError ... (data.debugbear.com)" even with the DebugBear RUM script frame', () => {
+    // The DebugBear collector monkeypatches window.fetch, so the leaked
+    // rejection can carry its own CDN script frame. That chunk is not
+    // first-party (not under /assets/, not .ts), so the host allowlist — not
+    // hasFirstParty — must decide.
+    const event = makeEvent('NetworkError when attempting to fetch resource. (data.debugbear.com)', 'TypeError', [
+      { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 'window.fetch' },
+    ]);
+    assert.equal(beforeSend(event), null, 'DebugBear-framed beacon failure should be suppressed');
+  });
+
+  it('does NOT suppress Firefox "NetworkError ... (<host>)" for a NON-allowlisted first-party host', () => {
+    // Safety mirror of the Chrome `Failed to fetch (api.worldmonitor.app)`
+    // guard: the Firefox host-suffixed shape must still surface for our own
+    // API so a real outage isn't silenced just because Firefox phrases the
+    // network error differently.
+    const event = makeEvent('NetworkError when attempting to fetch resource. (api.worldmonitor.app)', 'TypeError', [
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'Non-allowlisted host Firefox NetworkError must reach Sentry');
+  });
+
   it('suppresses iOS Safari WKWebView "Cannot inject key into script value" regardless of first-party frame', () => {
     // The native throw always lands in a first-party caller; the existing
     // !hasFirstParty gate missed it. `UnknownError` type name is WebKit-only


### PR DESCRIPTION
## Summary

Dropped DebugBear RUM beacons stopped leaking into Sentry as unactionable error noise. `data.debugbear.com` is the collector for the DebugBear RUM script we embed ourselves (`src/bootstrap/debugbear-rum.ts`), so a failed beacon (adblock, network blip) is invisible to the user — but Firefox phrases the failure as `NetworkError when attempting to fetch resource. (<host>)`, and that host-suffixed shape matched neither the Chrome `Failed to fetch (<host>)` allowlist block nor the bare-`NetworkError` gate in `beforeSend`. It leaked through at error level (Sentry WORLDMONITOR-RP).

The host-scoped fetch-failure shape detector (`isHostScopedFetchFailure`) and its host extractor now recognize both engine phrasings and route them through the same third-party host allowlist, and `data.debugbear.com` joins that allowlist (same disposition as the existing Clerk-SDK-internal entry). Non-allowlisted hosts — `api.worldmonitor.app`, the self-hosted PMTiles bucket — are still **not** in the set, so a genuine first-party API or basemap regression continues to surface even when Firefox is the reporter.

Related: Sentry WORLDMONITOR-RP (resolved inNextRelease).

## Validation

- `npx tsc --noEmit` — clean.
- `node --test tests/sentry-beforesend.test.mjs` — 177/177 pass, including 3 new lock-in cases: the DebugBear beacon is suppressed both with zero frames and with the RUM script frame, and a non-allowlisted host (`api.worldmonitor.app`) with the same Firefox shape is **not** suppressed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 4.8](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
