### PR TITLE
fix(dashboard): reduce mobile map tap presentation work

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -4191,6 +4191,7 @@ export class MapComponent {
     if (!topLeft || !bottomRight) {
       this.state.zoom = 4;
       this.setCenter(midLat, midLon);
+      this.resumeMobileLabelVisibility();
       return;
     }
     const pxWidth = Math.abs(bottomRight[0] - topLeft[0]);
@@ -4200,6 +4201,7 @@ export class MapComponent {
     const zoomY = pxHeight > 0 ? (height * padFactor) / pxHeight : 4;
     this.state.zoom = Math.max(1, Math.min(8, Math.min(zoomX, zoomY)));
     this.setCenter(midLat, midLon);
+    this.resumeMobileLabelVisibility();
   }
 
   public getState(): MapState {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -887,16 +887,6 @@ export class MapComponent {
       );
     };
 
-    // Resume mobile label-overlap measurement on the first direct map interaction.
-    // Mobile-only: on desktop the flag is always armed, so this would only ever
-    // early-return inside resumeMobileLabelVisibility().
-    if (this.isMobile) {
-      this.container.addEventListener('pointerdown', (e) => {
-        if (shouldIgnoreInteractionStart(e.target)) return;
-        this.resumeMobileLabelVisibility();
-      }, { signal });
-    }
-
     // Wheel zoom with smooth delta
     this.container.addEventListener(
       'wheel',
@@ -967,9 +957,10 @@ export class MapComponent {
     const touchHistory: Array<{ x: number; y: number; t: number }> = [];
     let inertiaRaf = 0;
 
+    // Keep tap starts out of the label-collision pass; arm it only once the
+    // gesture actually moves/zooms the viewport.
     this.container.addEventListener('touchstart', (e) => {
       if (shouldIgnoreInteractionStart(e.target)) return;
-      this.resumeMobileLabelVisibility();
       cancelAnimationFrame(inertiaRaf);
       const touch1 = e.touches[0];
       const touch2 = e.touches[1];
@@ -1019,6 +1010,7 @@ export class MapComponent {
         this.state.pan.y += (center.y - lastTouchCenter.y) * panSpeed;
         lastTouchCenter = center;
 
+        this.resumeMobileLabelVisibility();
         this.applyTransform();
       } else if (e.touches.length === 1 && isDragging && touch1) {
         if (!touchDragActive) {
@@ -1026,6 +1018,7 @@ export class MapComponent {
           const dy0 = touch1.clientY - touchStartPos.y;
           if (Math.hypot(dx0, dy0) < TOUCH_DRAG_THRESHOLD) return;
           touchDragActive = true;
+          this.resumeMobileLabelVisibility();
         }
 
         e.preventDefault();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13281,7 +13281,7 @@ a.prediction-link:hover {
 
   .nat-event-marker,
   .conflict-click-area {
-    transition: none;
+    transition: opacity 0.2s ease;
   }
 
   .nat-event-marker:hover {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4938,6 +4938,7 @@ body.playback-mode .status-dot {
   position: relative;
   overflow: hidden;
   background: var(--map-bg);
+  contain: layout paint;
   /* Let the map library handle all touch gestures (pinch-zoom, pan)
      instead of the browser intercepting them on mobile/Android */
   touch-action: none;
@@ -5000,6 +5001,7 @@ body.playback-mode .status-dot {
   width: 100%;
   height: 100%;
   pointer-events: none;
+  contain: layout paint;
 }
 
 #mapOverlays>* {
@@ -13275,6 +13277,15 @@ a.prediction-link:hover {
   .conflict-click-area {
     min-width: 44px;
     min-height: 44px;
+  }
+
+  .nat-event-marker,
+  .conflict-click-area {
+    transition: none;
+  }
+
+  .nat-event-marker:hover {
+    transform: translate(-50%, -50%) scale(var(--marker-scale, 1));
   }
 
   /* Ensure hotspot container is large enough for touch */

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const mapSrc = readFileSync(resolve(root, 'src/components/Map.ts'), 'utf-8');
+const cssSrc = readFileSync(resolve(root, 'src/styles/main.css'), 'utf-8');
 
 function sliceBetween(start, end) {
   const startIdx = mapSrc.indexOf(start);
@@ -62,7 +63,7 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
     assert.match(block, /: this\.iranEvents;/, 'desktop path must keep the full Iran event list');
   });
 
-  it('keeps label overlap measurement disabled on mobile until the first direct map interaction', () => {
+  it('keeps label overlap measurement disabled on mobile until movement or zoom needs it', () => {
     assert.match(mapSrc, /private mobileLabelVisibilityArmed = false/);
     assert.match(mapSrc, /this\.mobileLabelVisibilityArmed = !this\.isMobile/);
     assert.match(
@@ -80,21 +81,60 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
     assert.ok(emitIdx > zoomVisibilityIdx, 'state emission should still run after the label guard');
   });
 
-  it('resumes mobile label measurement once from valid pointer or touch starts', () => {
-    assert.match(
+  it('keeps mobile label measurement out of the tap-start window and resumes it on real movement', () => {
+    assert.doesNotMatch(
       mapSrc,
-      /addEventListener\('pointerdown', \(e\) => \{\s*if \(shouldIgnoreInteractionStart\(e\.target\)\) return;\s*this\.resumeMobileLabelVisibility\(\);\s*\}, \{ signal \}\)/,
-      'pointerdown should resume label visibility only for direct map interactions',
+      /this\.container\.addEventListener\('pointerdown'[\s\S]*?resumeMobileLabelVisibility\(\)/,
+      'pointerdown is part of the tap INP window and must not arm label measurement',
+    );
+    const touchStartBlock = sliceBetween("this.container.addEventListener('touchstart', (e) => {", "this.container.addEventListener('touchmove'");
+    assert.doesNotMatch(
+      touchStartBlock,
+      /resumeMobileLabelVisibility\(\)/,
+      'touchstart is part of the tap INP window and must not arm label measurement',
+    );
+    const touchMoveBlock = sliceBetween("this.container.addEventListener('touchmove', (e) => {", "this.container.addEventListener('touchend'");
+    assert.match(
+      touchMoveBlock,
+      /if \(e\.touches\.length === 2[\s\S]*?this\.resumeMobileLabelVisibility\(\);[\s\S]*?this\.applyTransform\(\);/,
+      'pinch movement should arm label measurement before the transform pass that needs it',
     );
     assert.match(
-      mapSrc,
-      /addEventListener\('touchstart', \(e\) => \{\s*if \(shouldIgnoreInteractionStart\(e\.target\)\) return;\s*this\.resumeMobileLabelVisibility\(\);/,
-      'touchstart should resume label visibility only for direct map interactions',
+      touchMoveBlock,
+      /touchDragActive = true;[\s\S]*?this\.resumeMobileLabelVisibility\(\);[\s\S]*?this\.applyTransform\(\);/,
+      'single-finger panning should arm label measurement only after the drag threshold is crossed',
     );
     assert.match(
       mapSrc,
       /private resumeMobileLabelVisibility\(\): void \{\s*if \(!this\.isMobile \|\| this\.mobileLabelVisibilityArmed\) return;\s*this\.mobileLabelVisibilityArmed = true;\s*this\.updateLabelVisibility\(this\.state\.zoom\);\s*\}/,
-      'resume should be mobile-only, idempotent, and run one immediate label pass',
+      'resume should remain mobile-only, idempotent, and run one label pass when movement/zoom arms it',
+    );
+  });
+
+  it('isolates mobile tap paint and disables marker hover transitions in the touch map', () => {
+    assert.match(
+      cssSrc,
+      /\.map-container\s*\{[\s\S]*?contain:\s*layout paint;/,
+      'the map container should contain map-triggered layout and paint work',
+    );
+    assert.match(
+      cssSrc,
+      /#mapOverlays\s*\{[\s\S]*?contain:\s*layout paint;/,
+      'the overlay layer should isolate marker paint from the rest of the page',
+    );
+    const mobileTouchBlock = cssSrc.slice(
+      cssSrc.indexOf('Mobile Touch Optimization'),
+      cssSrc.indexOf('/* Extra small screens */'),
+    );
+    assert.match(
+      mobileTouchBlock,
+      /\.nat-event-marker,\s*\.conflict-click-area\s*\{[\s\S]*?transition:\s*none;/,
+      'mobile marker tap targets should not run hover/opacity transitions during touch interactions',
+    );
+    assert.match(
+      mobileTouchBlock,
+      /\.nat-event-marker:hover\s*\{[\s\S]*?transform:\s*translate\(-50%, -50%\) scale\(var\(--marker-scale, 1\)\);/,
+      'mobile natural-event hover should preserve the current transform instead of scaling on tap',
     );
   });
 });

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -109,6 +109,12 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
       /private resumeMobileLabelVisibility\(\): void \{\s*if \(!this\.isMobile \|\| this\.mobileLabelVisibilityArmed\) return;\s*this\.mobileLabelVisibilityArmed = true;\s*this\.updateLabelVisibility\(this\.state\.zoom\);\s*\}/,
       'resume should remain mobile-only, idempotent, and run one label pass when movement/zoom arms it',
     );
+    const fitCountryBlock = sliceBetween('public fitCountry(code: string): void {', 'public getState(): MapState {');
+    assert.equal(
+      fitCountryBlock.match(/this\.setCenter\(midLat, midLon\);\s*this\.resumeMobileLabelVisibility\(\);/g)?.length,
+      2,
+      'fitCountry should re-arm mobile label measurement after both country-fit center paths',
+    );
   });
 
   it('isolates mobile tap paint and removes marker transform transitions in the touch map', () => {

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -111,7 +111,7 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
     );
   });
 
-  it('isolates mobile tap paint and disables marker hover transitions in the touch map', () => {
+  it('isolates mobile tap paint and removes marker transform transitions in the touch map', () => {
     assert.match(
       cssSrc,
       /\.map-container\s*\{[\s\S]*?contain:\s*layout paint;/,
@@ -128,8 +128,15 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
     );
     assert.match(
       mobileTouchBlock,
-      /\.nat-event-marker,\s*\.conflict-click-area\s*\{[\s\S]*?transition:\s*none;/,
-      'mobile marker tap targets should not run hover/opacity transitions during touch interactions',
+      /\.nat-event-marker,\s*\.conflict-click-area\s*\{[\s\S]*?transition:\s*opacity 0\.2s ease;/,
+      'mobile marker tap targets should keep opacity fades while avoiding transform transitions',
+    );
+    const mobileMarkerTransitionBlock =
+      mobileTouchBlock.match(/\.nat-event-marker,\s*\.conflict-click-area\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    assert.doesNotMatch(
+      mobileMarkerTransitionBlock,
+      /transform/,
+      'mobile marker tap target transitions must not include transform',
     );
     assert.match(
       mobileTouchBlock,


### PR DESCRIPTION
## Summary
Mobile map taps now keep avoidable presentation work out of the tap-start window. The SVG map no longer arms hidden-label collision measurement on `pointerdown`/`touchstart`; it still re-arms that pass when the user actually pans, pinches, or uses zoom controls, so movement readability behavior remains intact.

The phone map overlay also gets a tighter paint boundary and touch layouts no longer run natural-event/conflict marker hover transitions on tap. This covers the highest-confidence map-tap slice from the #5080 brief; nav-chip and deeper density/commit work remain follow-up surfaces in that issue.

## Measurement context
| Surface | Build | 4x CPU trace result | Notes |
|---|---|---|---|
| Country tap landing through conflict overlay | production before patch | style/layout 845.1ms, rendering 794.5ms, worst presentation delay 61.3ms | Confirmed presentation-side work in the tap window before changing code. |
| Natural-event marker tap | production before patch | style/layout 1157.6ms, rendering 1177.8ms, worst presentation delay 62.1ms | Worst issue-table class; localhost lacked live natural-event data for a patched same-selector trace. |
| Country/overlay tap | patched localhost | style/layout 642.9ms, rendering 777.2ms, worst presentation delay 49.6ms | Confirms patched dashboard renders and the tap path remains functional under the tracer. |
| Conflict overlay tap | patched localhost | noisy run: background map render overlapped the post-interaction window | Not treated as a clean before/after delta; kept as a functional tracer smoke only. |

Related: #5080

## Validation
- `./node_modules/.bin/tsx --test tests/map-mobile-feature-caps.test.mjs tests/map-deferred-overlays.test.mts tests/marker-pulse-settle.test.mjs tests/map-container-size-cache.test.mjs tests/country-deep-dive-yield.test.mts`
- `npm run typecheck`
- `./node_modules/.bin/biome check src/components/Map.ts tests/map-mobile-feature-caps.test.mjs src/styles/main.css`
- `npm run build:full`
- Local mobile render smoke at `http://127.0.0.1:3000/dashboard`: SVG map rendered with overlays after the containment change; local-origin CORS/API noise was present as expected for production API calls.
- `git push` pre-push hook passed: frontend/API typechecks, Convex, CJS, Unicode, boundaries, safe HTML, rate-limit policies, premium-fetch parity, edge bundle/tests, changed tests, and version sync.

## Post-Deploy Monitoring & Validation
- Watch DebugBear RUM for `/dashboard` INP by selector: `https://www.debugbear.com/api/v1/project/103025/rumMetrics?from=<ISO>&to=<ISO>&groupBy=inpSelector&device=mobile` using header `x-api-key: $DEBUGBEAR_API_KEY` (key already in `.env.local`; base URL is `www.debugbear.com/api/v1`, not `api.debugbear.com`).
- Watch Sentry mobile INP events faceted by presentation delay and selector, especially `#mapWrapper svg#mapSvg`, `#mapOverlays div.nat-event-marker`, `#mapOverlays div.conflict-click-area`, and `nav button.mobile-panel-nav-chip`.
- Watch CrUX PHONE `/dashboard` INP p75 and good-rate after the field window rolls forward.
- Expected healthy signal: map-selector p75 starts moving toward the <500ms milestone, and Sentry's presentation-dominant share falls for the map/overlay selectors.
- Failure signal: map-selector p75 regresses, the same selectors remain flat after rollout, or mobile map pan/pinch readability regresses. Mitigation is to revert this PR and continue #5080 with the density/commit-coalescing levers.
- Validation window: first 24-48h in DebugBear/Sentry for directional signal; CrUX after the normal field-data delay. Owner: dashboard performance follow-up for #5080.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

