### PR TITLE
test(forecast): tighten simulation selection assertions

### DIFF
--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -5758,7 +5758,7 @@ describe('simulation package export', () => {
     }));
     const pkg = buildSimulationPackageFromDeepSnapshot(makeSnapshot(candidates));
     assert.ok(pkg);
-    assert.ok(pkg.selectedTheaters.length <= 3);
+    assert.equal(pkg.selectedTheaters.length, 3, 'selection must apply the hard cap at exactly three theaters');
   });
 
   it('selection preserves the top three ranked candidates even when they share a geo group', () => {
@@ -5831,7 +5831,7 @@ describe('simulation package export', () => {
     assert.ok(routeKeys.includes('Strait of Malacca'), 'Malacca must be selected');
   });
 
-  it('same geo-group candidates are retained when they rank inside the theater cap', () => {
+  it('rank-capped selection retains multiple high-ranked candidates from one region', () => {
     const redsea = makeCandidate({
       candidateStateId: 'state-redsea',
       candidateStateLabel: 'Red Sea blockade',


### PR DESCRIPTION
## Summary

This tightens the follow-up tests around the theater simulation hard cap after PR #5108. The hard-cap regression now asserts the exact selected-theater count, and the shared-region selection case uses a rank-capped description instead of implying the old geo-dedup rule still exists.

## Validation

- `node --test tests/forecast-trace-export.test.mjs` — 331 tests passed.
- Pre-push hook passed: frontend typecheck, API typecheck, CJS syntax, Unicode safety, boundary lint, safe HTML guard, rate-limit policy lint, premium-fetch lint, edge bundle check, changed test file run, version sync.
- Code review: skipped (mechanical test-only cleanup).
- Greptile: reviewed the PR #5108 summary/comments; the applicable test-quality comments are handled here.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a test-only cleanup with no production/runtime behavior change; CI passing is the expected healthy signal. Failure signal is a regression in the forecast trace-export test or type/lint gates, with rollback by reverting this assertion/name cleanup.

## Related

Related: #5102, #5108

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
