### PR TITLE
fix(forecast): detector calibration — state-derived cap, UCDP gate, p…

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -157,6 +157,12 @@ const CYBER_PROB_VOLUME_WEIGHT = 0.5;       // weight of volume in probability f
 const CYBER_PROB_TYPE_WEIGHT = 0.15;        // weight of type diversity in probability formula
 const CONFLICT_BASE_DETECTOR_PROB_MAX = 0.90;
 const UCDP_CONFLICT_ZONE_PROB_MAX = 0.85;
+const UCDP_CONFLICT_ZONE_COUNT_GATE = 10; // matches the `count < 10` skip below
+// Probability at the gate itself, so a zone that just qualifies isn't reported as ~0%.
+// 0.3 matches the baseline confidence floor used throughout this file (see the
+// repeated `Math.max(0.3, normalize(...))` confidence pattern).
+const UCDP_CONFLICT_ZONE_PROB_FLOOR = 0.3;
+const STATE_DERIVED_MARKET_SUPPLY_PROB_MAX = 0.85; // same domain ceiling detectMarketScenarios/detectSupplyChainScenarios enforce
 const VELOCITY_SPIKE_PROBABILITY_LIFT = 0.08;
 const VELOCITY_SPIKE_PROBABILITY_MAX = 0.99;
 const DEFENSE_DIRECT_CONFIRMATION_PRESSURE_LIFT = 0.12;
@@ -1472,10 +1478,13 @@ function computeStateDerivedBucketCandidate(domain, stateUnit, bucket, marketCon
 function buildStateDerivedForecast(stateUnit, domain, bucket, candidate, marketContext) {
   const bucketContext = marketContext?.bucketContexts?.[bucket.id] || null;
   const title = buildStateDerivedForecastTitle(domain, stateUnit, bucket.id, bucket.label);
-  const probability = clampUnitInterval(
-    (candidate.score * 0.56) +
-    (Number(bucket.pressureScore || 0) * 0.24) +
-    (Number(stateUnit?.avgProbability || 0) * 0.18),
+  const probability = Math.min(
+    STATE_DERIVED_MARKET_SUPPLY_PROB_MAX,
+    clampUnitInterval(
+      (candidate.score * 0.56) +
+      (Number(bucket.pressureScore || 0) * 0.24) +
+      (Number(stateUnit?.avgProbability || 0) * 0.18),
+    ),
   );
   const confidence = clampUnitInterval(
     (candidate.score * 0.34) +
@@ -1957,10 +1966,16 @@ function detectUcdpConflictZones(inputs, emaRiskScores) {
   }
 
   for (const [country, count] of Object.entries(byCountry)) {
-    if (count < 10) continue;
+    if (count < UCDP_CONFLICT_ZONE_COUNT_GATE) continue;
 
     const signals = [{ type: 'ucdp', value: `${count} UCDP conflict events`, weight: 0.5 }];
-    let prob = Math.min(UCDP_CONFLICT_ZONE_PROB_MAX, normalize(count, 5, 100) * 0.7);
+    // Normalize from the gate itself (not below it) and scale into
+    // [floor, cap] so a country that just qualifies isn't reported as ~0%.
+    let prob = Math.min(
+      UCDP_CONFLICT_ZONE_PROB_MAX,
+      UCDP_CONFLICT_ZONE_PROB_FLOOR
+        + normalize(count, UCDP_CONFLICT_ZONE_COUNT_GATE, 100) * (UCDP_CONFLICT_ZONE_PROB_MAX - UCDP_CONFLICT_ZONE_PROB_FLOOR),
+    );
 
     const emaRisk = emaRiskScores?.get(country?.toLowerCase?.() ?? '');
     if (emaRisk?.velocitySpike) {
@@ -2423,9 +2438,12 @@ const PROJECTION_PROBABILITY_CAP = 0.95;
 function computeProjections(predictions) {
   for (const pred of predictions) {
     const curve = PROJECTION_CURVES[pred.domain] || { h24: 1, d7: 1, d30: 1 };
-    const anchor = pred.timeHorizon === '24h' ? 'h24' : pred.timeHorizon === '30d' ? 'd30' : 'd7';
-    const anchorMult = curve[anchor] || 1;
-    const base = anchorMult > 0 ? pred.probability / anchorMult : pred.probability;
+    // Anchor to the curve's own peak horizon, not the horizon the forecast
+    // happened to be emitted at — those can differ (e.g. UCDP emits
+    // 'conflict' at 30d while conflict's peak is d7), which previously
+    // de-anchored `base` and inflated other horizons past their curves.
+    const peakMult = Math.max(curve.h24, curve.d7, curve.d30) || 1;
+    const base = pred.probability / peakMult;
     pred.projections = {
       h24: Math.round(Math.min(PROJECTION_PROBABILITY_CAP, Math.max(PROJECTION_PROBABILITY_FLOOR, base * curve.h24)) * 1000) / 1000,
       d7:  Math.round(Math.min(PROJECTION_PROBABILITY_CAP, Math.max(PROJECTION_PROBABILITY_FLOOR, base * curve.d7)) * 1000) / 1000,

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -2340,11 +2340,14 @@ describe('validateScenarios', () => {
 // ── Phase 3 Tests ──────────────────────────────────────────
 
 describe('computeProjections', () => {
-  it('anchors projection to timeHorizon', () => {
+  it('anchors projection to the curve peak, which for conflict is d7', () => {
     const p = makePrediction('conflict', 'Iran', 'test', 0.5, 0.5, '7d', []);
     computeProjections([p]);
     assert.ok(p.projections);
-    // probability should equal the d7 projection (anchored to 7d)
+    // conflict's curve peaks at d7 (multiplier 1.0), so the d7 projection
+    // equals the raw probability here. This is a property of conflict's
+    // curve shape, not of the '7d' timeHorizon passed above — see the
+    // '#5103' test below for a domain/horizon combo where they diverge.
     assert.equal(p.projections.d7, p.probability);
   });
 
@@ -2375,6 +2378,22 @@ describe('computeProjections', () => {
     assert.equal(p.projections.h24, 0.5);
     assert.equal(p.projections.d7, 0.5);
     assert.equal(p.projections.d30, 0.5);
+  });
+
+  it('anchors to the curve peak, not the emit horizon, when they differ (#5103)', () => {
+    // conflict's peak horizon is d7 (multiplier 1.0), but UCDP emits conflict
+    // forecasts at '30d' (multiplier 0.78) — the emit horizon must not be
+    // used as the anchor or every other horizon gets inflated.
+    const p = makePrediction('conflict', 'Syria', 'test', 0.6, 0.5, '30d', []);
+    computeProjections([p]);
+    const peakMult = Math.max(PROJECTION_CURVES.conflict.h24, PROJECTION_CURVES.conflict.d7, PROJECTION_CURVES.conflict.d30);
+    const base = 0.6 / peakMult;
+    assert.equal(p.projections.h24, Math.round(base * PROJECTION_CURVES.conflict.h24 * 1000) / 1000);
+    assert.equal(p.projections.d7, Math.round(base * PROJECTION_CURVES.conflict.d7 * 1000) / 1000);
+    assert.equal(p.projections.d30, Math.round(base * PROJECTION_CURVES.conflict.d30 * 1000) / 1000);
+    // Previously (anchored to the emit horizon d30=0.78) h24 came out to
+    // 0.6/0.78*0.91 ≈ 0.7 — well above the correct, non-inflated value.
+    assert.ok(p.projections.h24 < 0.6, `h24 should not be inflated above the base probability, got ${p.projections.h24}`);
   });
 });
 
@@ -2544,6 +2563,22 @@ describe('detectUcdpConflictZones', () => {
 
   it('handles empty input', () => {
     assert.equal(detectUcdpConflictZones({}).length, 0);
+  });
+
+  it('reports a meaningful probability right at the gate, not ~3.7% (#5103)', () => {
+    const events = Array.from({ length: 10 }, () => ({ country: 'Syria' }));
+    const result = detectUcdpConflictZones({ ucdpEvents: { events } });
+    assert.equal(result.length, 1);
+    // count === gate, so normalize(count, gate, 100) is exactly 0 and the
+    // result is exactly the floor — pin the precise value, not just a bound.
+    assert.equal(result[0].probability, 0.3);
+  });
+
+  it('probability rises monotonically with event count and stays capped at 0.85', () => {
+    const low = detectUcdpConflictZones({ ucdpEvents: { events: Array.from({ length: 10 }, () => ({ country: 'Syria' })) } });
+    const high = detectUcdpConflictZones({ ucdpEvents: { events: Array.from({ length: 80 }, () => ({ country: 'Syria' })) } });
+    assert.ok(high[0].probability > low[0].probability);
+    assert.ok(high[0].probability <= 0.85);
   });
 });
 
@@ -4017,5 +4052,22 @@ describe('stable forecast ids: semantic slots, not volatile titles (#4933)', () 
     assert.equal(forecastIdFromKey('military', 'theater:iran-theater'), forecastIdFromKey('military', 'theater:iran-theater'));
     assert.notEqual(forecastIdFromKey('military', 'theater:iran-theater'), forecastIdFromKey('conflict', 'theater:iran-theater'));
     assert.match(forecastIdFromKey('military', 'theater:iran-theater'), /^fc-military-[0-9a-f]{8}$/);
+  });
+
+  it('state-derived forecast probability respects the same 0.85 cap as the legacy market/supply detectors (#5103)', () => {
+    const stateUnit = {
+      id: 'state-max', label: 'Maximal pressure cluster', stateKind: 'market_stress',
+      dominantRegion: 'Middle East', regions: ['Middle East'],
+      avgProbability: 1, avgConfidence: 1,
+      situationCount: 2, forecastCount: 3,
+    };
+    const bucket = { id: 'energy', label: 'Energy', pressureScore: 1, confidence: 1 };
+    const candidate = { score: 1, criticalLift: 1, primarySignalType: 'energy_supply_shock', primaryChannel: 'energy' };
+    // score*0.56 + pressureScore*0.24 + avgProbability*0.18 = 0.98 uncapped,
+    // so the cap must be what brings this down to exactly 0.85.
+    const market = buildStateDerivedForecast(stateUnit, 'market', bucket, candidate, null);
+    const supplyChain = buildStateDerivedForecast(stateUnit, 'supply_chain', bucket, candidate, null);
+    assert.equal(market.probability, 0.85);
+    assert.equal(supplyChain.probability, 0.85);
   });
 });


### PR DESCRIPTION
…rojection anchoring (#5103)

buildStateDerivedForecast could exceed the 0.85 market/supply_chain cap enforced elsewhere; detectUcdpConflictZones under-forecast right at its count gate (~3.7% at count=10); computeProjections anchored to a forecast's emit horizon instead of its curve's peak horizon, inflating other horizons (e.g. h24) past their intended curves.

## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

<!-- Required for documentation-alignment PRs that touch methodology, API/MCP contracts, generated docs, examples, Redis keys, CII, CRI, news, digest, or briefing. Mark N/A only when this PR does not publish or change documentation claims. -->

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
