### PR TITLE
fix(lcp): tag field LCP element selector

### DIFF
--- a/src/bootstrap/lcp-report.ts
+++ b/src/bootstrap/lcp-report.ts
@@ -19,6 +19,8 @@
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 import { getWebVitalsFormFactor, roundMs, sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
 
+const MAX_LCP_ELEMENT_TAG_LENGTH = 200;
+
 /** Structural subset of web-vitals' LCP attribution (kept local to avoid the dep). */
 export interface LcpAttributionLike {
   target?: string;
@@ -36,6 +38,11 @@ export interface LcpMetricLike {
   attribution?: LcpAttributionLike;
 }
 
+function normalizeLcpElementTag(target: string | undefined): string {
+  const normalized = (target ?? '').replace(/\s+/g, ' ').trim();
+  return normalized ? normalized.slice(0, MAX_LCP_ELEMENT_TAG_LENGTH) : 'unknown';
+}
+
 /**
  * Report one field LCP measurement to Sentry. `enqueue` is injectable for tests;
  * in production it defaults to the deferred-Sentry queue.
@@ -50,6 +57,7 @@ export function reportLcpMetric(
   if (metric.rating === 'good') return;
   const a = metric.attribution ?? {};
   const formFactor = getWebVitalsFormFactor();
+  const elementTag = normalizeLcpElementTag(a.target);
   enqueue((s) => {
     s.captureMessage('web-vital: LCP', {
       level: 'info',
@@ -57,6 +65,7 @@ export function reportLcpMetric(
         webvital: 'lcp',
         formFactor,
         'lcp.rating': metric.rating ?? 'unknown',
+        'lcp.element': elementTag,
       },
       extra: {
         value: Math.round(metric.value),

--- a/tests/lcp-report.test.mts
+++ b/tests/lcp-report.test.mts
@@ -30,6 +30,7 @@ test('reportLcpMetric reports LCP value, target, phase sub-parts, and form facto
   assert.equal(msg, 'web-vital: LCP');
   assert.equal(ctx.tags.webvital, 'lcp');
   assert.equal(ctx.tags['lcp.rating'], 'needs-improvement');
+  assert.equal(ctx.tags['lcp.element'], 'main.hero>h1');
   assert.equal(ctx.tags.formFactor, 'desktop');
   assert.equal(ctx.extra.value, 3876, 'LCP value rounded');
   assert.equal(ctx.extra.elementTarget, 'main.hero>h1');
@@ -77,9 +78,21 @@ test('reportLcpMetric still reports unknown/undefined-rated LCP conservatively',
   assert.equal(calls, 1, 'unknown/undefined rating still reports; do not drop unknowns');
 });
 
+test('reportLcpMetric bounds the LCP element tag value', () => {
+  const target = `section.${'x'.repeat(240)}`;
+  const { ctx } = capture({
+    value: 4100,
+    rating: 'poor',
+    attribution: { target },
+  });
+  assert.equal(ctx.tags['lcp.element'].length, 200);
+  assert.equal(ctx.extra.elementTarget, target);
+});
+
 test('reportLcpMetric tolerates missing attribution', () => {
   const { ctx } = capture({ value: 4100, rating: 'poor' });
   assert.equal(ctx.tags['lcp.rating'], 'poor');
+  assert.equal(ctx.tags['lcp.element'], 'unknown');
   assert.equal(ctx.extra.value, 4100);
   assert.equal(ctx.extra.elementTarget, 'unknown');
   assert.equal(ctx.extra.timeToFirstByte, undefined);


### PR DESCRIPTION
## Summary

Bad-tail LCP Sentry events now carry the LCP selector as a queryable `lcp.element` tag, so field data can be faceted by the element that overtakes the early shell paint. The existing detailed `extra.elementTarget` payload stays intact; only the tag value is whitespace-normalized and capped at 200 chars, matching Sentry's tag value limit. Missing attribution still reports as `unknown`.

This is the instrumentation slice for #4890, not the LCP fix itself. DebugBear already identifies the element-level LCP candidate; this adds the Sentry facet needed to pair that selector with the field LCP phase splits, so follow-up work can tell whether candidates like `#insightsContent .insights-brief-text` are delayed by render time or resource discovery/download. The Intel Brief early-paint work remains open.

Related: #4890

## Validation

- Proof-first: `./node_modules/.bin/tsx --test tests/lcp-report.test.mts` failed before the implementation because `ctx.tags['lcp.element']` was undefined, then passed after the fix.
- `./node_modules/.bin/tsx --test tests/lcp-report.test.mts`
- `./node_modules/.bin/tsx --test tests/lcp-attribution.test.mts`
- `node --test tests/lcp-attribution-contract.test.mjs`
- `npm run typecheck`
- `git diff --check`
- Push-time pre-push hook: frontend/API/Convex typechecks, CJS syntax, Unicode, architectural boundaries, safe HTML, Sentry coverage, rate-limit policy, premium-fetch parity, edge bundle, changed tests, edge tests, and version sync.
- `ce-code-review` lite pass: correctness and project-standards reviewers reported no findings.

## Post-Deploy Monitoring & Validation

- Watch Sentry events where `message:"web-vital: LCP"` and `tags.webvital:lcp`; facet by `tags["lcp.element"]`, especially for `formFactor:desktop`, then compare the existing LCP subparts (`timeToFirstByte`, `resourceLoadDelay`, `resourceLoadDuration`, `elementRenderDelay`).
- Healthy signal: bad-tail LCP events include a non-`unknown` `lcp.element` selector, with candidate selectors such as `#insightsContent .insights-brief-text` visible when they are the field LCP element and phase splits available on the same event.
- Failure signal: `lcp.element` is absent, `unknown` dominates events with attribution available, or Sentry rejects/drops LCP events because of tag shape/cardinality.
- Rollback trigger: revert this PR if LCP event ingestion or Sentry tag indexing regresses after deploy.
- Validation window and owner: first 24-48 hours after Vercel deploy; WorldMonitor maintainer/on-call.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
