### PR TITLE
fix(dashboard): stabilize CLS-prone deep-dive motion

### DIFF
--- a/e2e/country-deep-dive-visibility.spec.ts
+++ b/e2e/country-deep-dive-visibility.spec.ts
@@ -3,8 +3,8 @@ import { expect, test, type Page } from '@playwright/test';
 // Regression guard for the country deep-dive panel visibility contract.
 //
 // PR #4346 added an inline critical-CSS rule in index.html to keep the CLOSED
-// panel off-canvas before the bundled CSS loads. The rule was UNLAYERED and
-// UNCONDITIONAL:
+// panel off-canvas before the bundled CSS loads. The original rule was
+// UNLAYERED and UNCONDITIONAL:
 //
 //     #country-deep-dive-panel.country-deep-dive{ right:-460px; visibility:hidden }
 //
@@ -18,7 +18,9 @@ import { expect, test, type Page } from '@playwright/test';
 // inline rule won the cascade even after open() added `.active` / `.maximized`
 // and set aria-hidden="false" — the panel could never slide on-screen. The fix
 // scopes the inline rule to the closed state ([aria-hidden="true"]) so it stops
-// matching once the panel opens.
+// matching once the panel opens. Issue #4580 later found that animating `right`
+// itself can show up as CLS on the panel; the contract is now "right stays
+// settled at 0, transform moves the panel off/on canvas."
 //
 // This spec loads the real dashboard (inline critical CSS + the layered bundle)
 // and applies the exact class + aria-hidden mutations CountryDeepDivePanel
@@ -33,7 +35,7 @@ import { expect, test, type Page } from '@playwright/test';
 
 const PANEL = '#country-deep-dive-panel';
 
-type Geometry = { right: string; visibility: string };
+type Geometry = { right: string; transform: string; visibility: string };
 
 // Mirrors the DOM mutations in CountryDeepDivePanel.open()/hide():
 // classList.add('active'[, 'maximized']) + setAttribute('aria-hidden', ...).
@@ -43,14 +45,14 @@ const applyPanelState = (page: Page, classes: string[], ariaHidden: boolean): Pr
     if (!el) throw new Error('#country-deep-dive-panel not found');
     // Disable the 0.28s slide so getComputedStyle returns the settled target,
     // not an interpolated frame. This is an inline style and only affects
-    // `transition` — `right`/`visibility` still resolve through the real cascade.
+    // `transition` — `right`/`transform`/`visibility` still resolve through the real cascade.
     el.style.transition = 'none';
     el.classList.remove('active', 'maximized');
     for (const cls of classes) el.classList.add(cls);
     el.setAttribute('aria-hidden', ariaHidden ? 'true' : 'false');
     void el.offsetWidth; // force a style/layout flush before measuring
     const style = getComputedStyle(el);
-    return { right: style.right, visibility: style.visibility };
+    return { right: style.right, transform: style.transform, visibility: style.visibility };
   }, { classes, ariaHidden });
 
 const bootDashboard = async (page: Page): Promise<void> => {
@@ -70,8 +72,8 @@ test.describe('country deep-dive panel visibility contract', () => {
   test('stays off-canvas and hidden while closed (aria-hidden="true")', async ({ page }) => {
     const closed = await applyPanelState(page, [], true);
     expect(closed.visibility).toBe('hidden');
-    // 430px panel parked at right:-460px (or -100vw on mobile) — i.e. off-canvas.
-    expect(Number.parseFloat(closed.right)).toBeLessThan(0);
+    expect(closed.right).toBe('0px');
+    expect(closed.transform).not.toBe('none');
   });
 
   test('slides on-screen and becomes visible when opened (.active)', async ({ page }) => {
@@ -80,11 +82,13 @@ test.describe('country deep-dive panel visibility contract', () => {
     // right:-460px / visibility:hidden over the layered .country-deep-dive.active.
     expect(open.visibility).toBe('visible');
     expect(open.right).toBe('0px');
+    expect(open.transform).toBe('none');
   });
 
   test('is visible and full-bleed when opened maximized (.active.maximized)', async ({ page }) => {
     const maximized = await applyPanelState(page, ['active', 'maximized'], false);
     expect(maximized.visibility).toBe('visible');
     expect(maximized.right).toBe('0px'); // from inset: 0
+    expect(maximized.transform).toBe('none');
   });
 });

--- a/index.html
+++ b/index.html
@@ -211,8 +211,8 @@
       .pro-banner-slot{flex:0 0 auto;min-height:0;box-sizing:border-box}
       html.wm-pro-banner-reserved .pro-banner-slot{min-height:var(--wm-pro-banner-slot-height)}
       .pro-banner-slot .pro-banner{box-sizing:border-box;min-height:var(--wm-pro-banner-slot-height);width:100%}
-      #country-deep-dive-panel.country-deep-dive[aria-hidden="true"]{position:fixed;top:0;right:-460px;width:430px;height:100vh;visibility:hidden;z-index:5000;box-sizing:border-box}
-      @media (max-width:767px){#country-deep-dive-panel.country-deep-dive[aria-hidden="true"]{right:-100vw;width:100vw}}
+      #country-deep-dive-panel.country-deep-dive[aria-hidden="true"]{position:fixed;top:0;right:0;width:430px;height:100vh;visibility:hidden;z-index:5000;box-sizing:border-box;transform:translateX(calc(100% + 30px));contain:layout paint}
+      @media (max-width:767px){#country-deep-dive-panel.country-deep-dive[aria-hidden="true"]{width:100vw;transform:translateX(100%)}}
       [data-theme="light"].wm-pro-banner-reserved #app::before{background:#fff;border-bottom-color:#d4d4d4}
       [data-variant="happy"].wm-pro-banner-reserved #app::before{background:#fff;border-bottom-color:#DDD9CF}
       [data-variant="happy"][data-theme="dark"].wm-pro-banner-reserved #app::before{background:#222E3E;border-bottom-color:#344050}

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -200,6 +200,83 @@ function warnOnDeferredFootprintDrift(key: string, placeholder: HTMLElement, rea
   }
 }
 
+type BootShellFootprintKey = 'header' | 'tabs' | 'main' | 'map' | 'grid';
+
+type BootShellFootprintBox = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+type BootShellFootprintSnapshot = Partial<Record<BootShellFootprintKey, BootShellFootprintBox>>;
+
+const BOOT_SHELL_FOOTPRINT_TARGETS: ReadonlyArray<{
+  key: BootShellFootprintKey;
+  shellSelector: string;
+  appSelector: string;
+}> = [
+  { key: 'header', shellSelector: '.skeleton-header', appSelector: '.header' },
+  { key: 'tabs', shellSelector: '.skeleton-tabs', appSelector: '#panelTabsMount' },
+  { key: 'main', shellSelector: '.skeleton-main', appSelector: '#main' },
+  { key: 'map', shellSelector: '.skeleton-map', appSelector: '#mapSection' },
+  { key: 'grid', shellSelector: '.skeleton-grid', appSelector: '#panelsGrid' },
+];
+
+function readFootprintBox(root: ParentNode, selector: string): BootShellFootprintBox | null {
+  const el = root.querySelector<Element>(selector);
+  if (!el) return null;
+  const rect = el.getBoundingClientRect();
+  return {
+    height: rect.height,
+    width: rect.width,
+    x: rect.x,
+    y: rect.y,
+  };
+}
+
+function captureBootShellFootprint(root: ParentNode): BootShellFootprintSnapshot | null {
+  if (!root.querySelector('.skeleton-shell')) return null;
+  const snapshot: BootShellFootprintSnapshot = {};
+  for (const target of BOOT_SHELL_FOOTPRINT_TARGETS) {
+    const box = readFootprintBox(root, target.shellSelector);
+    if (box) snapshot[target.key] = box;
+  }
+  return Object.keys(snapshot).length > 0 ? snapshot : null;
+}
+
+function formatFootprintDelta(before: BootShellFootprintBox, after: BootShellFootprintBox): string {
+  const delta = (field: keyof BootShellFootprintBox) => Math.round((after[field] - before[field]) * 10) / 10;
+  return `dx=${delta('x')}, dy=${delta('y')}, dw=${delta('width')}, dh=${delta('height')}`;
+}
+
+function warnOnBootShellFootprintDrift(snapshot: BootShellFootprintSnapshot): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const drifts: string[] = [];
+      for (const target of BOOT_SHELL_FOOTPRINT_TARGETS) {
+        const before = snapshot[target.key];
+        const after = readFootprintBox(document, target.appSelector);
+        if (!before || !after) continue;
+        const maxDelta = Math.max(
+          Math.abs(after.x - before.x),
+          Math.abs(after.y - before.y),
+          Math.abs(after.width - before.width),
+          Math.abs(after.height - before.height),
+        );
+        if (maxDelta > 2) {
+          drifts.push(`${target.key} ${formatFootprintDelta(before, after)}`);
+        }
+      }
+      if (drifts.length === 0) return;
+      console.warn(
+        '[PanelLayoutManager] Boot shell footprint drift during skeleton->app swap: ' +
+          `${drifts.join('; ')}. Keep index.html skeleton dimensions in parity with the first hydrated dashboard frame.`,
+      );
+    });
+  });
+}
+
 export interface PanelLayoutManagerCallbacks {
   openCountryStory: (code: string, name: string) => void;
   openCountryBrief: (code: string) => void;
@@ -596,6 +673,7 @@ export class PanelLayoutManager implements AppModule {
 
   async renderLayout(): Promise<void> {
     const isGlobeMode = getStoredMapModePreference() === 'globe';
+    const bootShellFootprint = import.meta.env.DEV ? captureBootShellFootprint(this.ctx.container) : null;
 
     markLcpDebug('wm:layout:render-start');
     document.documentElement.classList.add('wm-layout-hydrated');
@@ -864,6 +942,7 @@ export class PanelLayoutManager implements AppModule {
     await this.createPanels();
 
     this.initPanelTabs();
+    if (import.meta.env.DEV && bootShellFootprint) warnOnBootShellFootprintDrift(bootShellFootprint);
 
     if (this.ctx.isMobile) {
       this.setupMobileMapToggle();

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -135,7 +135,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  contain: layout paint;
 }
 
 .country-deep-dive .panel-close {
@@ -156,7 +155,6 @@
   height: 100%;
   overflow-y: auto;
   padding: 12px;
-  contain: layout paint;
 }
 
 .cdp-shell {

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1,24 +1,27 @@
 .country-deep-dive {
   position: fixed;
   top: 0;
-  right: -460px;
+  right: 0;
   width: 430px;
   height: 100vh;
   z-index: 5000;
   border-left: 1px solid var(--border);
   background: var(--panel-bg);
   box-shadow: -8px 0 32px color-mix(in srgb, var(--overlay-heavy) 65%, transparent);
-  transition: right 0.28s ease;
+  transform: translateX(calc(100% + 30px));
+  transition: transform 0.28s ease;
+  will-change: transform;
+  contain: layout paint;
 }
 
 .country-deep-dive[aria-hidden="true"] {
-  transition: right 0.28s ease, visibility 0s linear 0.28s;
+  transition: transform 0.28s ease, visibility 0s linear 0.28s;
   visibility: hidden;
 }
 
 .country-deep-dive.active {
-  right: 0;
-  transition: right 0.28s ease;
+  transform: none;
+  transition: transform 0.28s ease;
   visibility: visible;
 }
 
@@ -28,6 +31,7 @@
   width: 100%;
   height: 100%;
   right: 0;
+  transform: none;
   z-index: 10000;
   border-left: none;
   background: color-mix(in srgb, var(--bg) 85%, transparent);
@@ -131,6 +135,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  contain: layout paint;
 }
 
 .country-deep-dive .panel-close {
@@ -151,6 +156,7 @@
   height: 100%;
   overflow-y: auto;
   padding: 12px;
+  contain: layout paint;
 }
 
 .cdp-shell {
@@ -250,12 +256,14 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
+  contain: layout paint;
 }
 
 .cdp-summary-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
+  contain: layout paint;
 }
 
 .cdp-score-top {
@@ -1190,7 +1198,7 @@
 @media (max-width: 767px) {
   .country-deep-dive {
     width: 100vw;
-    right: -100vw;
+    transform: translateX(100%);
   }
 
   .country-deep-dive.maximized .panel-content {

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -699,6 +699,33 @@ describe('panel-config guardrails', () => {
     );
   });
 
+  it('warns in dev when the boot skeleton footprint drifts from the hydrated app shell', () => {
+    const renderLayout = panelLayoutSrc.match(/async\s+renderLayout\(\):\s+Promise<void>\s+\{[\s\S]*?\n {2}\}/);
+    assert.ok(renderLayout, 'renderLayout method not found');
+    assert.match(
+      renderLayout[0],
+      /const\s+bootShellFootprint\s*=\s*import\.meta\.env\.DEV\s*\?\s*captureBootShellFootprint\(this\.ctx\.container\)\s*:\s*null;/,
+      'renderLayout must snapshot the pre-hydration skeleton footprint in dev builds',
+    );
+    assert.match(
+      renderLayout[0],
+      /if\s*\(import\.meta\.env\.DEV\s*&&\s*bootShellFootprint\)\s*warnOnBootShellFootprintDrift\(bootShellFootprint\);/,
+      'renderLayout must surface skeleton->app footprint drift after initial panels/tabs mount',
+    );
+    assert.match(
+      panelLayoutSrc,
+      /function warnOnBootShellFootprintDrift\(/,
+      'warnOnBootShellFootprintDrift helper must exist',
+    );
+    for (const selector of ['.skeleton-header', '.skeleton-tabs', '.skeleton-main', '.skeleton-map', '.skeleton-grid']) {
+      assert.match(
+        panelLayoutSrc,
+        new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        `boot shell footprint guard must include ${selector}`,
+      );
+    }
+  });
+
   it('keeps brace depth balanced across regex literals inside super() bodies', () => {
     // Regression: a regex literal containing braces or quotes must not desync
     // findMatchingBrace/superObjectBodies (which would silently drop or


### PR DESCRIPTION
## Summary

The country deep-dive drawer now moves on a compositor transform while its layout position stays parked at `right: 0`, so opening or populating the panel no longer gives CLS attribution a moving layout edge to record. The boot dashboard also gets a dev-only footprint warning when the initial skeleton and first hydrated shell disagree across the header, tabs, main, map, or panel grid, making the remaining above-the-fold parity work easier to catch before deploy.

This intentionally covers the deep-dive containment path and skeleton parity guardrails; the broader desktop top-of-page displacement investigation still needs live post-deploy telemetry.

## Validation

| Check | Result |
|---|---|
| Red proof | Updated `e2e/country-deep-dive-visibility.spec.ts` failed against the old `right:-460px` contract before the CSS change |
| `node --test tests/panel-config-guardrails.test.mjs` | Pass |
| `npx playwright test e2e/country-deep-dive-visibility.spec.ts` | Pass |
| `npx playwright test e2e/dashboard-cls.spec.ts` | Pass |
| `npm run typecheck` | Pass |
| `npm run lint` | Pass; repo still emits existing unrelated Biome warnings, safe-html passed |
| Pre-push hook | Pass: typecheck, API typecheck, changed tests, edge tests, boundary/safe-html/rate-limit/premium-fetch checks, version sync |

## Post-Deploy Monitoring & Validation

Watch DebugBear RUM grouped by CLS selector on desktop and mobile for `#country-deep-dive-panel`, `.cdp-grid`, `#main`, and `#panelsGrid`. In Sentry `webvital:cls`, filter early page shifts (`scrollY <= 10` when present) and compare `largestShiftTarget` / selector tags for the same targets plus the skeleton selectors.

Healthy outcome: deep-dive panel/grid selectors disappear from the bad tail and dashboard p75 trends back toward <= 0.10, especially desktop. Failure mode: deep-dive selectors remain around the reported 0.25-0.57 range or `#main/#panelsGrid` worsens, in which case continue the top-of-page displacement audit from the new dev drift warnings and consider rolling back only the drawer CSS if it introduces a visual regression.

## Related

Related: #4580

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
