### PR TITLE
chore(perf-tooling): harden render-axis interaction traces

### DIFF
--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -13,6 +13,7 @@
  *   node scripts/measure-dashboard-render-axis.mjs [url] [--settle 10000] [--json]
  *   node scripts/measure-dashboard-render-axis.mjs [url] --trace-out /tmp/dashboard-trace.json
  *   node scripts/measure-dashboard-render-axis.mjs [url] --interact country --cpu-throttle 4 --json
+ *   (use --cpu-throttle 4-6 to approximate mid-tier mobile CPU in local traces)
  *   node scripts/measure-dashboard-render-axis.mjs --compare before.json after.json --json
  */
 import { readFile, writeFile } from 'node:fs/promises';
@@ -22,19 +23,22 @@ const TBT_THRESHOLD_MS = 50;
 const DEFAULT_INTERACTION_VIEWPORT = { width: 390, height: 844 };
 const DEFAULT_POST_INTERACT_MS = 1200;
 const DEFAULT_CPU_THROTTLE_RATE = 1;
+const INTERACTION_TRACE_MARK = 'wm-interaction-start';
 
-const DEFAULT_TRACE_CATEGORIES = [
+export const DEFAULT_TRACE_CATEGORIES = Object.freeze([
   'devtools.timeline',
   'disabled-by-default-devtools.timeline',
+  'disabled-by-default-devtools.timeline.frame',
   'disabled-by-default-devtools.timeline.stack',
   'blink',
+  'blink.user_timing',
   'disabled-by-default-gpu.debug',
   'disabled-by-default-gpu.service',
   'gpu',
   'loading',
   'rail',
   'v8',
-];
+]);
 
 const STYLE_LAYOUT_NAMES = new Set([
   'InvalidateLayout',
@@ -338,6 +342,45 @@ export function summarizeTraceEvents(trace) {
   };
 }
 
+function summarizePhaseDurationsInWindow(trace, traceStartUs, traceEndUs) {
+  const duration = {
+    styleLayout: 0,
+    rendering: 0,
+    canvas: 0,
+    scriptEvaluation: 0,
+  };
+  const startUs = Number(traceStartUs);
+  const endUs = Number(traceEndUs);
+  if (!Number.isFinite(startUs) || !Number.isFinite(endUs) || endUs <= startUs) {
+    return {
+      styleLayout: 0,
+      rendering: 0,
+      canvas: 0,
+      scriptEvaluation: 0,
+    };
+  }
+
+  for (const event of traceEvents(trace)) {
+    if (event?.ph !== 'X') continue;
+    const group = classifyRenderAxisEvent(event.name);
+    if (!group || !hasOwn(duration, group)) continue;
+    const eventStartUs = Number(event.ts);
+    const eventDurationUs = Number(event.dur) || 0;
+    if (!Number.isFinite(eventStartUs) || eventDurationUs <= 0) continue;
+    const eventEndUs = eventStartUs + eventDurationUs;
+    const overlapUs = Math.min(endUs, eventEndUs) - Math.max(startUs, eventStartUs);
+    if (overlapUs <= 0) continue;
+    duration[group] += overlapUs / 1000;
+  }
+
+  return {
+    styleLayout: round(duration.styleLayout),
+    rendering: round(duration.rendering),
+    canvas: round(duration.canvas),
+    scriptEvaluation: round(duration.scriptEvaluation),
+  };
+}
+
 export function dominantRenderPhase(duration = {}) {
   const labels = {
     styleLayout: 'style/layout',
@@ -380,6 +423,60 @@ export function summarizeInteractionTimings(entries) {
   };
 }
 
+function traceMarkerNames(event) {
+  return [
+    event?.name,
+    event?.args?.data?.name,
+    event?.args?.name,
+  ]
+    .map((value) => String(value || ''))
+    .filter(Boolean);
+}
+
+function findTraceMarkerTimeUs(trace, markerName = INTERACTION_TRACE_MARK) {
+  for (const event of traceEvents(trace)) {
+    if (!traceMarkerNames(event).includes(markerName)) continue;
+    const ts = Number(event.ts);
+    if (Number.isFinite(ts)) return ts;
+  }
+  return null;
+}
+
+function resolveInteractionTimeAnchor(trace, anchor) {
+  const performanceTimeMs = Number(anchor?.performanceTimeMs);
+  const markerName = String(anchor?.markName || INTERACTION_TRACE_MARK);
+  let traceTimeUs = Number(anchor?.traceTimeUs);
+  if (!Number.isFinite(traceTimeUs)) {
+    const markerTraceTimeUs = findTraceMarkerTimeUs(trace, markerName);
+    traceTimeUs = markerTraceTimeUs == null ? NaN : Number(markerTraceTimeUs);
+  }
+  if (!Number.isFinite(performanceTimeMs) || !Number.isFinite(traceTimeUs)) return null;
+  return { performanceTimeMs, traceTimeUs };
+}
+
+export function summarizeInteractionEventWindow(trace, worstTiming, anchor) {
+  const resolvedAnchor = resolveInteractionTimeAnchor(trace, anchor);
+  const startTime = Number(worstTiming?.startTime);
+  const duration = Number(worstTiming?.durationMs ?? worstTiming?.duration);
+  if (!resolvedAnchor || !Number.isFinite(startTime) || !Number.isFinite(duration) || duration <= 0) {
+    return null;
+  }
+
+  const traceStartUs = Math.round(
+    resolvedAnchor.traceTimeUs + ((startTime - resolvedAnchor.performanceTimeMs) * 1000),
+  );
+  const traceEndUs = Math.round(traceStartUs + (duration * 1000));
+  const durationMsByPhase = summarizePhaseDurationsInWindow(trace, traceStartUs, traceEndUs);
+  return {
+    startTime: round(startTime),
+    durationMs: round(duration),
+    traceStartUs,
+    traceEndUs,
+    dominantPhase: dominantRenderPhase(durationMsByPhase),
+    durationMsByPhase,
+  };
+}
+
 export function buildReport(result) {
   const summary = summarizeTraceEvents(result?.traceEvents || []);
   const report = {
@@ -392,23 +489,33 @@ export function buildReport(result) {
     ...summary,
   };
   if (result?.interaction) {
-    const targetWarnings = [];
+    const interactionWarnings = [];
     if (result.interaction?.targetInfo?.tapPoint?.matchedTop === false) {
-      targetWarnings.push(
+      interactionWarnings.push(
         `Interaction target ${result.interaction.name || 'custom'} used a fallback tap point that did not hit the requested selector.`,
+      );
+    }
+    const timings = summarizeInteractionTimings(result?.eventTimings);
+    const eventWindow = timings.worst
+      ? summarizeInteractionEventWindow(result?.traceEvents || [], timings.worst, result?.interactionTimeAnchor)
+      : null;
+    if (timings.worst && !eventWindow) {
+      interactionWarnings.push(
+        'Unable to scope dominant phase to the worst Event Timing row because the interaction trace clock anchor is unavailable. Re-run with a trace captured by this tool version.',
       );
     }
     report.interaction = {
       target: result.interaction,
-      timings: summarizeInteractionTimings(result?.eventTimings),
+      timings,
       dominantPhase: dominantRenderPhase(summary.durationMs),
+      eventWindow,
       traceWindow: {
         postInteractMs: Number(result.interaction?.postInteractMs) || DEFAULT_POST_INTERACT_MS,
         dominantPhaseScope: 'full-post-interaction-trace-window',
       },
-      warnings: targetWarnings,
+      warnings: interactionWarnings,
     };
-    report.warnings = [...report.warnings, ...targetWarnings];
+    report.warnings = [...report.warnings, ...interactionWarnings];
   }
   return report;
 }
@@ -431,6 +538,7 @@ export function normalizeReport(input) {
     traceEvents: events,
     interaction: input?.interaction || null,
     eventTimings: input?.eventTimings || [],
+    interactionTimeAnchor: input?.interactionTimeAnchor || null,
   });
 }
 
@@ -596,7 +704,7 @@ async function startTracing(client) {
   });
 }
 
-async function setCpuThrottle(client, rate) {
+export async function setCpuThrottle(client, rate) {
   const throttleRate = Number(rate) || DEFAULT_CPU_THROTTLE_RATE;
   if (throttleRate <= DEFAULT_CPU_THROTTLE_RATE) return;
   await client.send('Emulation.setCPUThrottlingRate', { rate: throttleRate });
@@ -810,6 +918,7 @@ async function captureTrace(url, {
     await setCpuThrottle(client, cpuThrottleRate);
     let eventTimings = [];
     let interactionTarget = null;
+    let interactionTimeAnchor = null;
 
     if (interaction) {
       await page.goto(url, { waitUntil: 'load', timeout: 60000 });
@@ -822,10 +931,18 @@ async function captureTrace(url, {
       };
       await resetInteractionTimings(page);
       await startTracing(client);
-      await page.evaluate(() => performance.mark?.('wm-interaction-start'));
+      const performanceTimeMs = await page.evaluate((markName) => {
+        const now = performance.now();
+        performance.mark?.(markName);
+        return now;
+      }, INTERACTION_TRACE_MARK);
       await performInteraction(page, targetInfo);
       await page.waitForTimeout(postInteractMs);
       eventTimings = await readInteractionTimings(page);
+      interactionTimeAnchor = {
+        performanceTimeMs,
+        markName: INTERACTION_TRACE_MARK,
+      };
     } else {
       await startTracing(client);
       await page.goto(url, { waitUntil: 'load', timeout: 60000 });
@@ -843,6 +960,12 @@ async function captureTrace(url, {
       traceEvents: events,
       interaction: interactionTarget,
       eventTimings,
+      interactionTimeAnchor: interactionTimeAnchor
+        ? {
+          ...interactionTimeAnchor,
+          traceTimeUs: findTraceMarkerTimeUs(events, INTERACTION_TRACE_MARK),
+        }
+        : null,
     };
     if (traceOut) {
       await writeFile(traceOut, JSON.stringify(result, null, 2));
@@ -885,7 +1008,7 @@ function printHuman(report) {
   console.log(`Script Evaluation:${String(d.scriptEvaluation).padStart(7)}ms (${report.sharePct.scriptEvaluationOfAccounted}% of accounted render-axis)`);
   console.log(`Estimated TBT:    ${d.estimatedTbt}ms`);
   if (report.interaction) {
-    const { target, timings, dominantPhase } = report.interaction;
+    const { target, timings, dominantPhase, eventWindow } = report.interaction;
     console.log(`Interaction:      ${target.name} (${target.selector})`);
     if (timings.worst) {
       const selector = timings.worst.selector ? ` on ${timings.worst.selector}` : '';
@@ -897,7 +1020,10 @@ function printHuman(report) {
     } else {
       console.log('Event Timing:     unavailable (browser did not emit Event Timing entries)');
     }
-    console.log(`Dominant phase:   ${dominantPhase.label} (${dominantPhase.ms}ms over ${report.interaction.traceWindow.postInteractMs}ms trace window)`);
+    console.log(`Dominant phase:   ${dominantPhase.label} (${dominantPhase.ms}ms over whole ${report.interaction.traceWindow.postInteractMs}ms post-interaction trace window)`);
+    if (eventWindow?.dominantPhase) {
+      console.log(`Worst-event phase: ${eventWindow.dominantPhase.label} (${eventWindow.dominantPhase.ms}ms over ${eventWindow.durationMs}ms Event Timing window)`);
+    }
     for (const warning of report.interaction.warnings || []) console.log(`  ! ${warning}`);
   }
   console.log(`Forced reflows:   ${report.forcedReflows.eventCount} attributed events, ${report.forcedReflows.totalMs}ms`);

--- a/scripts/measure-dashboard-render-axis.mjs
+++ b/scripts/measure-dashboard-render-axis.mjs
@@ -445,7 +445,8 @@ function findTraceMarkerTimeUs(trace, markerName = INTERACTION_TRACE_MARK) {
 function resolveInteractionTimeAnchor(trace, anchor) {
   const performanceTimeMs = Number(anchor?.performanceTimeMs);
   const markerName = String(anchor?.markName || INTERACTION_TRACE_MARK);
-  let traceTimeUs = Number(anchor?.traceTimeUs);
+  const rawTraceTimeUs = anchor?.traceTimeUs;
+  let traceTimeUs = rawTraceTimeUs == null ? NaN : Number(rawTraceTimeUs);
   if (!Number.isFinite(traceTimeUs)) {
     const markerTraceTimeUs = findTraceMarkerTimeUs(trace, markerName);
     traceTimeUs = markerTraceTimeUs == null ? NaN : Number(markerTraceTimeUs);
@@ -950,6 +951,7 @@ async function captureTrace(url, {
     }
 
     const events = await stopTracing(client);
+    const interactionTraceTimeUs = findTraceMarkerTimeUs(events, INTERACTION_TRACE_MARK);
     const result = {
       url,
       generatedAt: new Date().toISOString(),
@@ -963,7 +965,7 @@ async function captureTrace(url, {
       interactionTimeAnchor: interactionTimeAnchor
         ? {
           ...interactionTimeAnchor,
-          traceTimeUs: findTraceMarkerTimeUs(events, INTERACTION_TRACE_MARK),
+          ...(interactionTraceTimeUs == null ? {} : { traceTimeUs: interactionTraceTimeUs }),
         }
         : null,
     };

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -286,6 +286,23 @@ describe('measure-dashboard-render-axis reporting', () => {
     assert.match(report.warnings.join('\n'), /Unable to scope dominant phase/);
   });
 
+  it('warns when a captured interaction anchor serialized a null trace timestamp', () => {
+    const report = buildReport({
+      interaction: {
+        ...resolveInteractionTarget('country'),
+        targetInfo: { tapPoint: { x: 120, y: 200, matchedTop: true } },
+      },
+      interactionTimeAnchor: { performanceTimeMs: 400, traceTimeUs: null },
+      eventTimings: [
+        { name: 'pointerup', startTime: 450, processingStart: 450, processingEnd: 500, duration: 180 },
+      ],
+      traceEvents: [{ ph: 'X', name: 'Paint', ts: 10_140_000, dur: 20_000 }],
+    });
+
+    assert.equal(report.interaction?.eventWindow, null);
+    assert.match(report.interaction?.warnings.join('\n') || '', /Unable to scope dominant phase/);
+  });
+
   it('warns when the tap target falls back to a point that did not hit the selector', () => {
     const report = buildReport({
       url: 'http://127.0.0.1:4173/dashboard',

--- a/tests/measure-dashboard-render-axis.test.mts
+++ b/tests/measure-dashboard-render-axis.test.mts
@@ -5,12 +5,14 @@ import {
   buildReport,
   classifyRenderAxisEvent,
   compareReports,
+  DEFAULT_TRACE_CATEGORIES,
   dominantRenderPhase,
   extractStackFrames,
   isForcedReflow,
   normalizeReport,
   parseArgs,
   resolveInteractionTarget,
+  setCpuThrottle,
   summarizeForcedReflows,
   summarizeInteractionTimings,
   summarizeTraceEvents,
@@ -22,8 +24,16 @@ describe('measure-dashboard-render-axis trace parsing', () => {
     assert.equal(classifyRenderAxisEvent('UpdateLayoutTree'), 'styleLayout');
     assert.equal(classifyRenderAxisEvent('Paint'), 'rendering');
     assert.equal(classifyRenderAxisEvent('Canvas2DLayerBridge::FlushCanvas'), 'canvas');
+    assert.equal(classifyRenderAxisEvent('GLES2DecoderImpl::DoCommands'), 'canvas');
     assert.equal(classifyRenderAxisEvent('EvaluateScript'), 'scriptEvaluation');
     assert.equal(classifyRenderAxisEvent('LayoutShift'), null);
+  });
+
+  it('captures GPU and frame categories needed for WebGL render-axis attribution', () => {
+    assert.ok(DEFAULT_TRACE_CATEGORIES.includes('gpu'));
+    assert.ok(DEFAULT_TRACE_CATEGORIES.includes('disabled-by-default-gpu.service'));
+    assert.ok(DEFAULT_TRACE_CATEGORIES.includes('disabled-by-default-devtools.timeline.frame'));
+    assert.ok(DEFAULT_TRACE_CATEGORIES.includes('blink.user_timing'));
   });
 
   it('summarizes style/layout, rendering, script, and estimated TBT durations', () => {
@@ -189,10 +199,13 @@ describe('measure-dashboard-render-axis reporting', () => {
         },
       ],
       traceEvents: [
-        { ph: 'X', name: 'Layout', dur: 20_000 },
-        { ph: 'X', name: 'Paint', dur: 250_000 },
-        { ph: 'X', name: 'FunctionCall', dur: 30_000 },
+        { ph: 'I', name: 'UserTiming', ts: 1_000_000, args: { data: { name: 'wm-interaction-start' } } },
+        { ph: 'X', name: 'Layout', ts: 1_020_000, dur: 20_000 },
+        { ph: 'X', name: 'Paint', ts: 1_100_000, dur: 250_000 },
+        { ph: 'X', name: 'FunctionCall', ts: 1_500_000, dur: 30_000 },
+        { ph: 'X', name: 'GLES2DecoderImpl::DoCommands', ts: 1_650_000, dur: 25_000 },
       ],
+      interactionTimeAnchor: { performanceTimeMs: 100 },
     });
 
     assert.equal(report.interaction?.target.name, 'country');
@@ -204,7 +217,73 @@ describe('measure-dashboard-render-axis reporting', () => {
       postInteractMs: 1500,
       dominantPhaseScope: 'full-post-interaction-trace-window',
     });
+    assert.deepEqual(report.interaction?.eventWindow, {
+      startTime: 100,
+      durationMs: 600,
+      traceStartUs: 1_000_000,
+      traceEndUs: 1_600_000,
+      dominantPhase: {
+        phase: 'rendering',
+        label: 'paint/composite/raster',
+        ms: 250,
+      },
+      durationMsByPhase: {
+        styleLayout: 20,
+        rendering: 250,
+        canvas: 0,
+        scriptEvaluation: 30,
+      },
+    });
     assert.deepEqual(report.interaction?.warnings, []);
+  });
+
+  it('scopes the interaction dominant phase to the worst Event Timing window when clocks are anchored', () => {
+    const report = buildReport({
+      interaction: {
+        ...resolveInteractionTarget('country'),
+        postInteractMs: 1200,
+        targetInfo: { tapPoint: { x: 120, y: 200, matchedTop: true } },
+      },
+      interactionTimeAnchor: { performanceTimeMs: 400, traceTimeUs: 10_000_000 },
+      eventTimings: [
+        {
+          name: 'pointerup',
+          startTime: 450,
+          processingStart: 450,
+          processingEnd: 500,
+          duration: 180,
+        },
+      ],
+      traceEvents: [
+        // Whole post-tap window is canvas-dominant...
+        { ph: 'X', name: 'GLES2DecoderImpl::DoCommands', ts: 10_180_000, dur: 500_000 },
+        // ...but the worst event itself is style/layout-dominant.
+        { ph: 'X', name: 'Layout', ts: 10_050_000, dur: 90_000 },
+        { ph: 'X', name: 'Paint', ts: 10_140_000, dur: 20_000 },
+      ],
+    });
+
+    assert.equal(report.interaction?.dominantPhase.phase, 'canvas');
+    assert.equal(report.interaction?.eventWindow?.dominantPhase.phase, 'styleLayout');
+    assert.equal(report.interaction?.eventWindow?.durationMsByPhase.styleLayout, 90);
+    assert.equal(report.interaction?.eventWindow?.durationMsByPhase.canvas, 50);
+  });
+
+  it('warns when an interaction trace cannot anchor Event Timing to trace timestamps', () => {
+    const report = buildReport({
+      interaction: {
+        ...resolveInteractionTarget('country'),
+        targetInfo: { tapPoint: { x: 120, y: 200, matchedTop: true } },
+      },
+      eventTimings: [
+        { name: 'pointerup', startTime: 450, processingStart: 450, processingEnd: 500, duration: 180 },
+      ],
+      traceEvents: [{ ph: 'X', name: 'Paint', ts: 10_140_000, dur: 20_000 }],
+    });
+
+    assert.equal(report.interaction?.eventWindow, null);
+    assert.match(report.interaction?.warnings.join('\n') || '', /Unable to scope dominant phase/);
+    assert.match(report.warnings.join('\n'), /Unable to scope dominant phase/);
   });
 
   it('warns when the tap target falls back to a point that did not hit the selector', () => {
@@ -457,5 +536,21 @@ describe('measure-dashboard-render-axis parseArgs', () => {
     assert.equal(args.width, 390);
     assert.equal(args.height, 844);
     assert.equal(args.cpuThrottleRate, 1);
+  });
+
+  it('applies the CPU throttle rate through CDP only when requested', async () => {
+    const calls: Array<{ method: string; payload: unknown }> = [];
+    const client = {
+      async send(method: string, payload: unknown) {
+        calls.push({ method, payload });
+      },
+    };
+
+    await setCpuThrottle(client, 1);
+    await setCpuThrottle(client, 4);
+
+    assert.deepEqual(calls, [
+      { method: 'Emulation.setCPUThrottlingRate', payload: { rate: 4 } },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Render-axis interaction captures now produce trustworthy attribution on slower local traces: CPU throttling is documented and covered, GPU/WebGL trace categories are part of the default capture contract, and interaction reports separate the whole post-tap dominant phase from the phase inside the worst Event Timing row.

That keeps background render work from being mistaken for the tap's own bottleneck while preserving a warning path for older traces that lack the interaction trace-clock anchor.

## Related

Fixes #5114.

## Validation

- `./node_modules/.bin/tsx --test tests/measure-dashboard-render-axis.test.mts`
- `node --check scripts/measure-dashboard-render-axis.mjs`
- `./node_modules/.bin/biome lint scripts/measure-dashboard-render-axis.mjs tests/measure-dashboard-render-axis.test.mts`
- Push preflight passed, including frontend/API typechecks, architectural boundary checks, safe HTML, rate-limit and premium-fetch guards, changed render-axis tests, and version sync.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this only changes local perf tooling and its pure summarizer tests, with no runtime dashboard code path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
