### PR TITLE
fix(seed): don't crash seed-conflict-intel when ACLED creds are absent

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -350,14 +350,22 @@ async function fetchAll() {
   if (pi && gd) await writeExtraKeyWithMeta('intel:pizzint:v1:gdelt', { pizzint: pi, tensionPairs: gd }, PIZZINT_TTL, gd.length ?? 0);
 
   if (!ac) {
+    // ACLED credentials are optional. When NONE are configured (fetchAcledEvents
+    // returned null → fulfilled), the seed runs in its long-standing auxiliary-only
+    // mode (#1651/#2288): the auxiliary conflict/intel feeds above are already
+    // published, so return an empty ACLED payload and exit 0 rather than crashing
+    // every cron tick. We only refuse to let auxiliary feeds mask the PRIMARY feed
+    // when ACLED credentials ARE present but the display fetch failed (#5106).
     const missingCredentials = acled.status === 'fulfilled';
-    const reason = acled.status === 'rejected'
-      ? (acled.reason?.message || acled.reason)
-      : 'ACLED credentials not configured (set ACLED_EMAIL + ACLED_PASSWORD or ACLED_ACCESS_TOKEN)';
+    if (missingCredentials) {
+      console.log('  ACLED: no credentials configured — publishing auxiliary feeds only, primary feed left empty');
+      return { events: [], pagination: undefined };
+    }
+    const reason = acled.reason?.message || acled.reason;
     const err = new Error(
       `ACLED display fetch failed for ${ACLED_CACHE_KEY}; refusing to let auxiliary conflict/intel feeds mask the primary feed (${reason})`,
     );
-    if (missingCredentials || acled.reason?.nonRetryable) err.nonRetryable = true;
+    if (acled.reason?.nonRetryable) err.nonRetryable = true;
     throw err;
   }
 

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -38,13 +38,23 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
     assert.match(conflictSeed, /ACLED_RESOLUTION_CACHE_KEY,[\s\S]*clusters:\s*\[\],[\s\S]*acResolution\.pagination/);
   });
 
-  it('conflict seeder fails the primary feed when ACLED display data is unavailable', () => {
-    assert.match(conflictSeed, /if\s*\(!ac\)\s*\{[\s\S]*const err = new Error\([\s\S]*ACLED display fetch failed for \$\{ACLED_CACHE_KEY\}[\s\S]*auxiliary conflict\/intel feeds mask the primary feed/);
-    assert.match(conflictSeed, /ACLED credentials not configured \(set ACLED_EMAIL \+ ACLED_PASSWORD or ACLED_ACCESS_TOKEN\)/);
+  it('conflict seeder skips ACLED gracefully when no credentials are configured (auxiliary-only mode, #1651/#2288)', () => {
+    // Regression guard for #5106: a *missing* ACLED credential must NOT crash the
+    // seed every cron tick. When creds are absent the seed runs in its long-standing
+    // auxiliary-only mode — publish an empty ACLED payload and exit 0 rather than throw.
     assert.match(conflictSeed, /missingCredentials\s*=\s*acled\.status\s*===\s*'fulfilled'/);
-    assert.match(conflictSeed, /if\s*\(\s*missingCredentials\s*\|\|\s*acled\.reason\?\.nonRetryable\s*\)\s*err\.nonRetryable\s*=\s*true/);
+    assert.match(
+      conflictSeed,
+      /if\s*\(\s*missingCredentials\s*\)\s*\{[\s\S]*?return\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/,
+    );
+  });
+
+  it('conflict seeder still fails when a CONFIGURED ACLED primary feed is unavailable (no silent masking, #5106)', () => {
+    // #5106's genuine value is preserved: when creds ARE present but the display
+    // fetch fails, refuse to let auxiliary feeds silently mask the broken primary feed.
+    assert.match(conflictSeed, /const err = new Error\([\s\S]*ACLED display fetch failed for \$\{ACLED_CACHE_KEY\}[\s\S]*auxiliary conflict\/intel feeds mask the primary feed/);
+    assert.match(conflictSeed, /if\s*\(\s*acled\.reason\?\.nonRetryable\s*\)\s*err\.nonRetryable\s*=\s*true/);
     assert.match(conflictSeed, /throw err/);
-    assert.doesNotMatch(conflictSeed, /return\s+ac\s*\|\|\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/);
   });
 
   it('unrest seeder keeps the canonical display feed but also publishes a paginated 60d ACLED resolution feed', () => {


### PR DESCRIPTION
## Problem — chronic graceful crash, surfaced by `/diagnose-railway-seeders`

`seed-conflict-intel` was classified **GRACEFUL·CHRONIC**: it crashed gracefully (exit 75, one "Deploy Crashed!" alert each) on every ~30-min cron tick — 3 crashes in the hour before diagnosis (15:02 / 15:30 / 16:00 UTC). Same evidence each run:

```
FETCH FAILED: ACLED display fetch failed for conflict:acled:v1:all:0:0;
refusing to let auxiliary conflict/intel feeds mask the primary feed
(ACLED credentials not configured …)
=== Failed gracefully ===
```

### Root cause
- The seed reads `ACLED_EMAIL`/`ACLED_PASSWORD` or `ACLED_ACCESS_TOKEN` (`scripts/seed-conflict-intel.mjs:40-61`). **No valid ACLED credential exists in production** — the Railway service has only `VITE_ACLED_ACCESS_TOKEN` set to an *empty string* (and the seed doesn't read that `VITE_`-prefixed name).
- Running without ACLED has been the intended, supported mode since **#1651** ("allow conflict-intel seed to succeed without ACLED keys") and **#2288** ("graceful ACLED skip"); auxiliary feeds (PizzINT/GDELT/HAPI) carry it and `acledIntel` has always been empty.
- **#5106** (merged the same day) changed `return ac || {events:[]}` into a hard, non-retryable `throw` for *any* missing `ac` — treating "ACLED absent" (intended) the same as "primary feed broken" (alarming). A seed that had run fine for months began crashing every tick. Only alert-fatigue + wasted compute resulted; no data was lost (auxiliary keys still written).

## Fix
Distinguish the two cases in `fetchAll()`:
- **ACLED creds absent** (`fetchAcledEvents` → `null` → settled `fulfilled`): log + return an empty ACLED payload and exit 0, restoring the pre-#5106 auxiliary-only behavior.
- **ACLED creds present but display fetch failed** (settled `rejected`): keep #5106's genuine value — refuse to let auxiliary feeds silently mask a broken primary feed; `throw` (retryable unless the source marked it non-retryable).

This stops the crash immediately without needing ACLED credentials. (Provisioning a real ACLED token to actually populate the empty `acledIntel` feed is a separate, deferred ops task.)

## Tests
`tests/acled-resolution-feed-seed.test.mjs` — the #5106 contract block is replaced with two guards (one per branch). Both **fail against the pre-fix code** and pass after. Full file + `tests/forecast-resolution-eval.test.mjs`: 30 pass / 0 fail. `node --check` + `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0199ZmFiQztqqHdAdptCq5K8