### PR TITLE
test(forecast): lock ACLED health visibility

### DIFF
--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -11,6 +11,10 @@ function source(path) {
   return readFileSync(resolve(root, path), 'utf8');
 }
 
+function assertObjectProperty(sourceText, objectName, propertyPattern) {
+  assert.match(sourceText, new RegExp(`${objectName}:\\s*\\{[^}]*${propertyPattern}`, 's'));
+}
+
 describe('ACLED resolution-feed seed contract (#5076)', () => {
   const conflictSeed = source('scripts/seed-conflict-intel.mjs');
   const unrestSeed = source('scripts/seed-unrest-events.mjs');
@@ -51,8 +55,10 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
 
   it('health surfaces the ACLED display cache and seeder heartbeat (#5099)', () => {
     assert.match(healthApi, /acledIntel:\s*'conflict:acled:v1:all:0:0'/);
-    assert.match(healthApi, /acledIntel:\s*\{\s*key:\s*'seed-meta:conflict:acled-intel',\s*maxStaleMin:\s*38\s*\}/);
-    assert.match(seedHealthApi, /'conflict:acled-intel':\s*\{\s*key:\s*'seed-meta:conflict:acled-intel',\s*intervalMin:\s*19\s*\}/);
+    assertObjectProperty(healthApi, 'acledIntel', "key:\\s*'seed-meta:conflict:acled-intel'");
+    assertObjectProperty(healthApi, 'acledIntel', 'maxStaleMin:\\s*38');
+    assertObjectProperty(seedHealthApi, "'conflict:acled-intel'", "key:\\s*'seed-meta:conflict:acled-intel'");
+    assertObjectProperty(seedHealthApi, "'conflict:acled-intel'", 'intervalMin:\\s*19');
   });
 
   it('unrest seeder keeps the canonical display feed but also publishes a paginated 60d ACLED resolution feed', () => {

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -15,6 +15,8 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
   const conflictSeed = source('scripts/seed-conflict-intel.mjs');
   const unrestSeed = source('scripts/seed-unrest-events.mjs');
   const resolutionSpec = source('scripts/_forecast-resolution.mjs');
+  const healthApi = source('api/health.js');
+  const seedHealthApi = source('api/seed-health.js');
 
   it('routes conflict hard counts to a long-window resolution key, not the map display key', () => {
     assert.match(resolutionSpec, /CONFLICT_COUNT_SOURCE_FEED\s*=\s*'conflict:acled-resolution:v1:all:0:0'/);
@@ -45,6 +47,12 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
     assert.match(conflictSeed, /if\s*\(\s*missingCredentials\s*\|\|\s*acled\.reason\?\.nonRetryable\s*\)\s*err\.nonRetryable\s*=\s*true/);
     assert.match(conflictSeed, /throw err/);
     assert.doesNotMatch(conflictSeed, /return\s+ac\s*\|\|\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/);
+  });
+
+  it('health surfaces the ACLED display cache and seeder heartbeat (#5099)', () => {
+    assert.match(healthApi, /acledIntel:\s*'conflict:acled:v1:all:0:0'/);
+    assert.match(healthApi, /acledIntel:\s*\{\s*key:\s*'seed-meta:conflict:acled-intel',\s*maxStaleMin:\s*38\s*\}/);
+    assert.match(seedHealthApi, /'conflict:acled-intel':\s*\{\s*key:\s*'seed-meta:conflict:acled-intel',\s*intervalMin:\s*19\s*\}/);
   });
 
   it('unrest seeder keeps the canonical display feed but also publishes a paginated 60d ACLED resolution feed', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -220,6 +220,26 @@ test('classifyKey: issue #5055 strict seeds surface missing metadata instead of 
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: issue #5099 ACLED display feed is strict, not on-demand softened', () => {
+  assert.equal(STANDALONE_KEYS.acledIntel, 'conflict:acled:v1:all:0:0');
+  assert.equal(SEED_META.acledIntel?.key, 'seed-meta:conflict:acled-intel');
+  assert.equal(SEED_META.acledIntel?.maxStaleMin, 38);
+
+  const missing = classifyKey('acledIntel', STANDALONE_KEYS.acledIntel, { allowOnDemand: true },
+    makeCtx({}));
+  assert.equal(missing.status, 'EMPTY');
+  assert.equal(missing.records, 0);
+  assert.equal(missing.maxStaleMin, 38);
+  assert.equal(STATUS_COUNTS[missing.status], 'crit');
+
+  const dataWithoutMeta = classifyKey('acledIntel', STANDALONE_KEYS.acledIntel, { allowOnDemand: true },
+    makeCtx({ strens: { [STANDALONE_KEYS.acledIntel]: 2048 } }));
+  assert.equal(dataWithoutMeta.status, 'STALE_SEED');
+  assert.equal(dataWithoutMeta.records, 1);
+  assert.equal(dataWithoutMeta.maxStaleMin, 38);
+  assert.equal(STATUS_COUNTS[dataWithoutMeta.status], 'warn');
+});
+
 test('classifyKey: issue #5055 Comtrade bilateral probe is explicitly meta-only', () => {
   const metaKey = 'seed-meta:comtrade:bilateral-hs4';
   const entry = classifyKey('comtradeBilateralHs4', STANDALONE_KEYS.comtradeBilateralHs4, { allowOnDemand: true },

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -221,10 +221,6 @@ test('classifyKey: issue #5055 strict seeds surface missing metadata instead of 
 });
 
 test('classifyKey: issue #5099 ACLED display feed is strict, not on-demand softened', () => {
-  assert.equal(STANDALONE_KEYS.acledIntel, 'conflict:acled:v1:all:0:0');
-  assert.equal(SEED_META.acledIntel?.key, 'seed-meta:conflict:acled-intel');
-  assert.equal(SEED_META.acledIntel?.maxStaleMin, 38);
-
   const missing = classifyKey('acledIntel', STANDALONE_KEYS.acledIntel, { allowOnDemand: true },
     makeCtx({}));
   assert.equal(missing.status, 'EMPTY');


### PR DESCRIPTION
## Summary
ACLED health visibility is now locked by regression coverage: if the production display cache or `seed-meta:conflict:acled-intel` disappears, the health classifier must surface it as a real outage instead of an on-demand warning.

This is intentionally a narrow guard on top of current `main`: the producer-side fail-closed behavior is already present from the earlier ACLED fix, and this branch makes the issue #5099 health blindspot harder to reintroduce.

## Validation
- `./node_modules/.bin/tsx --test tests/health-classify.test.mjs tests/acled-resolution-feed-seed.test.mjs` passed: 38 tests.
- `npm run typecheck:api` passed.
- `git push` pre-push hook passed frontend/API/Convex typechecks, boundary/safe HTML/rate-limit/premium-fetch guards, edge bundle check, changed tests, and version sync.

## Post-Deploy Monitoring & Validation
- Watch `/api/health?compact=1` and detailed `/api/health` for `acledIntel`.
- Healthy state: `checks.acledIntel.status=OK`, `records > 0`, `seedAgeMin <= 38`, and `seed-meta:conflict:acled-intel` present/fresh.
- Failure signals: `acledIntel=EMPTY`, `STALE_SEED`, or `SEED_ERROR`; missing/stale `seed-meta:conflict:acled-intel`; forecast logs with `ACLED display fetch failed for conflict:acled:v1:all:0:0`.
- Monitor through the first two Railway `seed-conflict-intel` intervals after deploy.
- If health regresses, inspect the Railway `seed-conflict-intel` service, schedule, and ACLED credentials (`ACLED_EMAIL` + `ACLED_PASSWORD` or `ACLED_ACCESS_TOKEN`).

## Related
Related: #5099

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex_GPT--5-000000)
