### PR TITLE
perf(lcp): paint cached World Brief at panel construction (#4890)

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -71,6 +71,13 @@ export class InsightsPanel extends Panel {
 
     this.fwSelector = new FrameworkSelector({ panelId: 'insights', isPremium: hasPremiumAccess(), panel: this, note: t('components.insights.frameworkNote') });
     this.header.appendChild(this.fwSelector.el);
+
+    // #4890: the World Brief text is the field LCP element in ~1/3 of desktop
+    // views but normally paints only after clusters + hydration + sentiment
+    // complete (p75 ~4.3s). Repeat visitors already have the previous brief in
+    // the persistent cache — paint it with the shell so the LCP text lands in
+    // the first paint window; the first real update pass overwrites it.
+    void this.paintCachedBriefEarly();
   }
 
   public setMilitaryFlights(flights: MilitaryFlight[]): void {
@@ -118,6 +125,25 @@ export class InsightsPanel extends Panel {
     this.cachedBriefSources = sources;
     this.lastBriefUpdate = entry.updatedAt;
     return true;
+  }
+
+  /**
+   * #4890: early-paint the persisted World Brief at construction time so the
+   * LCP text block exists at shell paint instead of after the full insights
+   * pipeline. Generation guards on BOTH sides of the async cache read keep
+   * this from clobbering a real updateInsights() pass that races the
+   * IndexedDB read (updateInsights bumps updateGeneration synchronously on
+   * entry, so a stale early paint can never land on top of real content).
+   */
+  private async paintCachedBriefEarly(): Promise<void> {
+    if (this.updateGeneration > 0) return;
+    await this.loadBriefFromCache();
+    if (this.updateGeneration > 0 || !this.cachedBrief) return;
+    this.setDataBadge('cached');
+    this.setSafeContent(unsafeRawHtml(
+      this.renderWorldBrief(this.cachedBrief, this.cachedBriefSources),
+      'renderWorldBrief escapes the cached summary (#4890 early brief paint)',
+    ));
   }
 
   private extractISQInput(cluster: ClusteredEvent): SignalQualityInput {
@@ -524,6 +550,15 @@ export class InsightsPanel extends Panel {
     const briefHtml = insights.worldBrief
       ? this.renderWorldBrief(insights.worldBrief, worldBriefSources, this.renderBriefExtras(insights))
       : '';
+    if (insights.worldBrief) {
+      // #4890: keep the persistent brief cache warm from the dominant server
+      // path (previously only the client-LLM fallback wrote it, so repeat
+      // visitors had an empty cache and nothing to early-paint at boot).
+      this.cachedBrief = insights.worldBrief;
+      this.cachedBriefSources = worldBriefSources.slice(0, 6);
+      this.lastBriefUpdate = Date.now();
+      void setPersistentCache(InsightsPanel.BRIEF_CACHE_KEY, { summary: insights.worldBrief, sources: this.cachedBriefSources });
+    }
     const focalPointsHtml = this.renderFocalPoints();
     const convergenceHtml = this.renderConvergenceZones();
     const sentimentOverview = this.renderSentimentOverview(sentiments);

--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -47,6 +47,10 @@ export class InsightsPanel extends Panel {
   private updateGeneration = 0;
   private static readonly BRIEF_COOLDOWN_MS = 120000; // 2 min cooldown (API has limits)
   private static readonly BRIEF_CACHE_KEY = 'summary:world-brief';
+  // #4928: the server synthesis cites up to 12 sources — capping the cached
+  // list at the legacy 6 orphans [7]/[8] citations on the early paint (#4890)
+  // and client cooldown renders. Keep read + write on this shared bound.
+  private static readonly BRIEF_CACHE_MAX_SOURCES = 12;
 
   constructor() {
     super({
@@ -116,7 +120,7 @@ export class InsightsPanel extends Panel {
     if (this.cachedBrief) return false;
     const entry = await getPersistentCache<{ summary: string; sources?: BriefSource[] }>(InsightsPanel.BRIEF_CACHE_KEY);
     if (!entry?.data?.summary) return false;
-    const { sources, legacySourceShape } = normalizeCachedBriefSources(entry.data, 6);
+    const { sources, legacySourceShape } = normalizeCachedBriefSources(entry.data, InsightsPanel.BRIEF_CACHE_MAX_SOURCES);
     if (legacySourceShape) {
       void deletePersistentCache(InsightsPanel.BRIEF_CACHE_KEY);
       return false;
@@ -555,7 +559,7 @@ export class InsightsPanel extends Panel {
       // path (previously only the client-LLM fallback wrote it, so repeat
       // visitors had an empty cache and nothing to early-paint at boot).
       this.cachedBrief = insights.worldBrief;
-      this.cachedBriefSources = worldBriefSources.slice(0, 6);
+      this.cachedBriefSources = worldBriefSources;
       this.lastBriefUpdate = Date.now();
       void setPersistentCache(InsightsPanel.BRIEF_CACHE_KEY, { summary: insights.worldBrief, sources: this.cachedBriefSources });
     }

--- a/tests/insights-brief-early-paint.test.mts
+++ b/tests/insights-brief-early-paint.test.mts
@@ -61,5 +61,19 @@ describe('InsightsPanel early cached-brief paint (#4890)', () => {
       /setPersistentCache\(InsightsPanel\.BRIEF_CACHE_KEY, \{ summary: insights\.worldBrief, sources: this\.cachedBriefSources \}\)/,
       'the server path must write the persistent brief cache — before #4890 only the client-LLM fallback wrote it, so repeat visitors on the dominant server path had an empty cache',
     );
+    assert.doesNotMatch(
+      method,
+      /worldBriefSources\.slice\(0,\s*6\)/,
+      '#4928: the server brief cites up to 12 sources — re-capping the persisted list at 6 orphans [7]/[8] citations in the early paint (Greptile P1 on PR #5130)',
+    );
+  });
+
+  it('reads the cached brief with the citation-space bound, not the legacy 6 cap', () => {
+    const method = sliceBetween('private async loadBriefFromCache()', 'private async paintCachedBriefEarly()');
+    assert.match(
+      method,
+      /normalizeCachedBriefSources\(entry\.data, InsightsPanel\.BRIEF_CACHE_MAX_SOURCES\)/,
+      'the cache read must use the shared 12-source citation bound — a literal 6 re-orphans [7]/[8] on the early paint and client cooldown renders',
+    );
   });
 });

--- a/tests/insights-brief-early-paint.test.mts
+++ b/tests/insights-brief-early-paint.test.mts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+// #4890: `#insightsContent .insights-brief-text` is the field LCP element in
+// ~1/3 of desktop views (DebugBear lcpSelector, p75 4344ms) because the World
+// Brief only paints after clusters + hydration + sentiment complete. For
+// repeat visitors the previous brief is already in the persistent cache, so
+// the panel must paint it at construction time (shell paint, ~600ms) and let
+// the first real update pass overwrite it. These are source-pattern guards
+// (InsightsPanel is DOM-heavy; repo convention — see
+// insights-brief-sources-static.test.mts).
+const source = readFileSync(new URL('../src/components/InsightsPanel.ts', import.meta.url), 'utf8');
+
+const sliceBetween = (start: string, end: string): string => {
+  const startIdx = source.indexOf(start);
+  assert.notEqual(startIdx, -1, `slice start not found: ${start}`);
+  const endIdx = source.indexOf(end, startIdx);
+  assert.notEqual(endIdx, -1, `slice end not found: ${end}`);
+  return source.slice(startIdx, endIdx);
+};
+
+describe('InsightsPanel early cached-brief paint (#4890)', () => {
+  it('kicks the early cached-brief paint from the constructor', () => {
+    const ctor = sliceBetween('constructor()', 'public setMilitaryFlights');
+    assert.match(
+      ctor,
+      /void this\.paintCachedBriefEarly\(\);/,
+      'the constructor must start the early cached-brief paint so the LCP text can land with the shell',
+    );
+  });
+
+  it('guards the early paint against racing a real update on both sides of the await', () => {
+    const method = sliceBetween('private async paintCachedBriefEarly()', 'private extractISQInput');
+    assert.match(
+      method,
+      /if \(this\.updateGeneration > 0\) return;[\s\S]*?await this\.loadBriefFromCache\(\)/,
+      'must bail before the cache read when a real update already started',
+    );
+    assert.match(
+      method,
+      /await this\.loadBriefFromCache\(\);[\s\S]*?if \(this\.updateGeneration > 0 \|\| !this\.cachedBrief\) return;/,
+      'must re-check updateGeneration AFTER the async cache read — updateInsights() may have started during the await',
+    );
+    assert.match(
+      method,
+      /this\.setDataBadge\('cached'\);/,
+      'the early paint is stale-by-definition content and must carry the cached badge',
+    );
+    assert.match(
+      method,
+      /this\.renderWorldBrief\(this\.cachedBrief, this\.cachedBriefSources\)/,
+      'the early paint must reuse renderWorldBrief (it escapes the cached summary)',
+    );
+  });
+
+  it('server-insights renders persist the brief so the NEXT boot has something to early-paint', () => {
+    const method = sliceBetween('private renderServerInsights(', 'private renderServerStories(');
+    assert.match(
+      method,
+      /setPersistentCache\(InsightsPanel\.BRIEF_CACHE_KEY, \{ summary: insights\.worldBrief, sources: this\.cachedBriefSources \}\)/,
+      'the server path must write the persistent brief cache — before #4890 only the client-LLM fallback wrote it, so repeat visitors on the dominant server path had an empty cache',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Repeat visitors now get the World Brief text painted at panel construction (shell-paint time) instead of after the full insights pipeline. `#insightsContent .insights-brief-text` is the field LCP element in ~1/3 of desktop views (DebugBear `lcpSelector`, p75 4344ms vs 500–612ms when the shell copy stays LCP) — this moves the re-election of LCP from ~4.3s into the first paint window for anyone with a warm cache.

Two halves:
1. **Early paint**: `InsightsPanel`'s constructor kicks `paintCachedBriefEarly()` — reads the persisted brief, renders it via the existing escaping `renderWorldBrief()` with the `cached` data badge. `updateGeneration` is checked on **both** sides of the async cache read, so a racing real `updateInsights()` pass can neither be clobbered nor painted over (it bumps the generation synchronously on entry).
2. **Cache warmth**: `renderServerInsights()` now persists the brief to `summary:world-brief`. Previously only the client-LLM fallback wrote that key, so the dominant server-insights path left repeat visitors with an **empty cache** — the early paint would have been a no-op for most traffic.

Known tradeoff (accepted): when the first real update lands, its progress bar briefly replaces the cached brief before full content renders — same swap users see today, just with useful text beforehand instead of a skeleton. LCP is already recorded by then.

## Validation

- Red proof: `tests/insights-brief-early-paint.test.mts` (3 source-pattern guards, repo convention for DOM-heavy panels) failed before the implementation, passes after; `insights-brief-sources-static.test.mts` still green.
- `npx tsc --noEmit` clean; `biome check` clean on changed files; `node scripts/enforce-safe-html.mjs` passes (new sink uses the approved `setSafeContent(unsafeRawHtml(...))` pattern; content is escaped inside `renderWorldBrief`).
- `node scripts/docs-stats.mjs --check` OK.

## Post-Deploy Monitoring & Validation

- DebugBear: `GET https://www.debugbear.com/api/v1/project/103025/rumMetrics?from=<ISO>&to=<ISO>&groupBy=lcpSelector&device=desktop` (key in `.env.local`) — healthy signal: the `insights-brief-text` row's p75 falls toward shell-paint time and/or its share collapses (shell copy stays LCP). First-visit views are unaffected by design (empty cache) — expect partial movement, sized by the repeat-visitor share.
- Sentry: `webvital:lcp` faceted by the new `lcp.element` tag (PR #5123), `formFactor:desktop` — bad-event rate for `insights-brief-text` should drop.
- CrUX page-level desktop LCP (currently p75 2997ms / 71% good) over the next 2–4 weekly windows; pass = 75%.
- Failure signal: stale-brief complaints (badge shows `cached` until refresh — intended), or the early paint visibly flashing against the update pass. Revert is a clean 2-hunk rollback.

Related: #4890 (fix slice 1 — repeat visitors; first-visit prioritization via bootstrap hydration remains).

https://claude.ai/code/session_01PgggD2v8bpN5evLAgNCuZ6
