### PR TITLE
perf(observability): sample field web-vital telemetry to cut Sentry volume ~80%

### DIFF
--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -15,7 +15,12 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { getWebVitalsFormFactor, roundMs } from '@/bootstrap/web-vitals-utils';
+import {
+  getWebVitalsFormFactor,
+  roundMs,
+  shouldSampleWebVital,
+  WEB_VITAL_SAMPLE_RATE,
+} from '@/bootstrap/web-vitals-utils';
 
 /** Structural subset of web-vitals' CLS attribution (kept local to avoid the dep). */
 export interface ClsAttributionLike {
@@ -76,10 +81,14 @@ export function reportClsMetric(
   metric: ClsMetricLike,
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
   env: ClsReportEnv = collectClsReportEnv(),
+  keep: () => boolean = shouldSampleWebVital,
 ): void {
   // Volume trim: skip 'good' (<0.1) CLS and report needs-improvement / poor /
   // unknown only, so field attribution stays focused on actionable shifts.
   if (metric.rating === 'good') return;
+  // Uniform sample of the surviving bad tail to cut Sentry volume ~80% without
+  // biasing the rating/formFactor/shift-target distributions.
+  if (!keep()) return;
   const a = metric.attribution ?? {};
   const formFactor = getWebVitalsFormFactor();
   enqueue((s) => {
@@ -88,6 +97,7 @@ export function reportClsMetric(
       tags: {
         webvital: 'cls',
         formFactor,
+        sampleRate: String(WEB_VITAL_SAMPLE_RATE),
         'cls.rating': metric.rating ?? 'unknown',
       },
       extra: {

--- a/src/bootstrap/inp-report.ts
+++ b/src/bootstrap/inp-report.ts
@@ -18,7 +18,12 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { getWebVitalsFormFactor, roundMs } from '@/bootstrap/web-vitals-utils';
+import {
+  getWebVitalsFormFactor,
+  roundMs,
+  shouldSampleWebVital,
+  WEB_VITAL_SAMPLE_RATE,
+} from '@/bootstrap/web-vitals-utils';
 
 /** Structural subset of web-vitals' INP attribution (kept local to avoid the dep). */
 export interface InpAttributionLike {
@@ -44,11 +49,15 @@ export interface InpMetricLike {
 export function reportInpMetric(
   metric: InpMetricLike,
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
+  keep: () => boolean = shouldSampleWebVital,
 ): void {
   // Volume trim (#4565): skip 'good' (<200ms) INP — ~70% of field events, low
   // diagnostic value. Report needs-improvement / poor / unknown only, so the
   // actionable worst-case signal still lands while Sentry event volume drops ~70%.
   if (metric.rating === 'good') return;
+  // Uniform sample of the surviving bad tail (~50% poor here) to cut Sentry
+  // volume ~80% without biasing the rating/formFactor/target distributions.
+  if (!keep()) return;
   const a = metric.attribution ?? {};
   const formFactor = getWebVitalsFormFactor();
   enqueue((s) => {
@@ -57,6 +66,7 @@ export function reportInpMetric(
       tags: {
         webvital: 'inp',
         formFactor,
+        sampleRate: String(WEB_VITAL_SAMPLE_RATE),
         'inp.rating': metric.rating ?? 'unknown',
         'inp.interactionType': a.interactionType ?? 'unknown',
       },

--- a/src/bootstrap/lcp-report.ts
+++ b/src/bootstrap/lcp-report.ts
@@ -17,7 +17,13 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { getWebVitalsFormFactor, roundMs, sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
+import {
+  getWebVitalsFormFactor,
+  roundMs,
+  sanitizeWebVitalUrl,
+  shouldSampleWebVital,
+  WEB_VITAL_SAMPLE_RATE,
+} from '@/bootstrap/web-vitals-utils';
 
 const MAX_LCP_ELEMENT_TAG_LENGTH = 200;
 
@@ -50,11 +56,15 @@ function normalizeLcpElementTag(target: string | undefined): string {
 export function reportLcpMetric(
   metric: LcpMetricLike,
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
+  keep: () => boolean = shouldSampleWebVital,
 ): void {
   // Volume trim (#4565): skip 'good' (<=2500ms) LCP. Report
   // needs-improvement / poor / unknown only, so Sentry volume stays focused on
   // the bad tail while success is measured by bad-event rate per surface.
   if (metric.rating === 'good') return;
+  // Uniform sample of the surviving bad tail to cut Sentry volume ~80% without
+  // biasing the rating/formFactor/element-target distributions.
+  if (!keep()) return;
   const a = metric.attribution ?? {};
   const formFactor = getWebVitalsFormFactor();
   const elementTag = normalizeLcpElementTag(a.target);
@@ -64,6 +74,7 @@ export function reportLcpMetric(
       tags: {
         webvital: 'lcp',
         formFactor,
+        sampleRate: String(WEB_VITAL_SAMPLE_RATE),
         'lcp.rating': metric.rating ?? 'unknown',
         'lcp.element': elementTag,
       },

--- a/src/bootstrap/web-vitals-utils.ts
+++ b/src/bootstrap/web-vitals-utils.ts
@@ -1,6 +1,36 @@
 export const roundMs = (n: number | undefined): number | undefined =>
   typeof n === 'number' && Number.isFinite(n) ? Math.round(n) : undefined;
 
+/**
+ * Fraction of (already good-trimmed) field Web-Vital events forwarded to Sentry.
+ *
+ * The good-trim (#4565) drops the `good` bucket, but the surviving
+ * needs-improvement/poor tail still runs ~12k events/day — ~92% of ALL Sentry
+ * volume — which is pure telemetry, not errors. This uniformly samples that tail
+ * to cut that volume ~80%. Uniform (not rating-aware) sampling is deliberate: it
+ * leaves the rating split, formFactor split, attribution-target distribution, and
+ * p75 unbiased — only the sample size shrinks. Captured events carry a
+ * `sampleRate` tag so absolute field volume is reconstructable (× 1/sampleRate).
+ * At current traffic 20% still yields ~2.4k events/day — ample for weekly
+ * page-level CrUX cross-checks and per-target histograms.
+ */
+export const WEB_VITAL_SAMPLE_RATE = 0.2;
+
+/**
+ * Uniform sampling gate for field Web-Vital reporting; returns true when the
+ * event should be forwarded. `rate` in [0,1]; `rng` is injectable for tests.
+ * `rate >= 1` (or NaN) always keeps — a misconfigured rate over-reports rather
+ * than silently losing data; `rate <= 0` always drops.
+ */
+export function shouldSampleWebVital(
+  rate: number = WEB_VITAL_SAMPLE_RATE,
+  rng: () => number = Math.random,
+): boolean {
+  if (!(rate < 1)) return true;
+  if (rate <= 0) return false;
+  return rng() < rate;
+}
+
 export type WebVitalsFormFactor = 'mobile' | 'desktop';
 
 function mediaQueryMatches(query: string): boolean {

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -16,7 +16,8 @@ function capture(metric: ClsMetricLike, env?: ClsReportEnv): { msg: string; ctx:
   const fakeEnqueue = ((fn: (s: any) => void) => {
     fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportClsMetric(metric, fakeEnqueue, env);
+  // Force-keep the sampling gate so distribution-shaping assertions are stable.
+  reportClsMetric(metric, fakeEnqueue, env, () => true);
   assert.ok(out, 'reportClsMetric must call enqueue exactly once');
   return out!;
 }
@@ -69,8 +70,23 @@ test('reportClsMetric still reports unknown/undefined-rated CLS conservatively',
     calls += 1;
     fn({ captureMessage: () => {} });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportClsMetric({ value: 0.17 }, fakeEnqueue);
+  reportClsMetric({ value: 0.17 }, fakeEnqueue, undefined, () => true);
   assert.equal(calls, 1, 'unknown/undefined rating still reports; do not drop unknowns');
+});
+
+test('reportClsMetric drops when the sample gate rejects (volume trim)', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportClsMetric({ value: 0.24, rating: 'poor' }, fakeEnqueue, undefined, () => false);
+  assert.equal(calls, 0, 'sampled-out CLS is not enqueued even when rating is poor');
+});
+
+test('reportClsMetric tags the configured sampleRate for reweighting', () => {
+  const { ctx } = capture({ value: 0.2, rating: 'poor' });
+  assert.equal(ctx.tags.sampleRate, '0.2', 'sampleRate tag lets analysis rescale to true field volume');
 });
 
 test('reportClsMetric includes the shift-class environment fields (#4580)', () => {
@@ -97,7 +113,7 @@ test('reportClsMetric captures formFactor before deferred Sentry drain', () => {
     queued = fn;
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
   const out = withWindow(webVitalsTestWindow(900), () => {
-    reportClsMetric({ value: 0.22, rating: 'poor' }, fakeEnqueue);
+    reportClsMetric({ value: 0.22, rating: 'poor' }, fakeEnqueue, undefined, () => true);
     return { ctx: undefined as any };
   });
 

--- a/tests/inp-report.test.mts
+++ b/tests/inp-report.test.mts
@@ -10,7 +10,8 @@ function capture(metric: InpMetricLike): { msg: string; ctx: any } {
   const fakeEnqueue = ((fn: (s: any) => void) => {
     fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportInpMetric(metric, fakeEnqueue);
+  // Force-keep the sampling gate so distribution-shaping assertions are stable.
+  reportInpMetric(metric, fakeEnqueue, () => true);
   assert.ok(out, 'reportInpMetric must call enqueue exactly once');
   return out!;
 }
@@ -54,7 +55,7 @@ test('reportInpMetric routes through the injected enqueue exactly once (R2 deleg
     calls += 1;
     fn({ captureMessage: () => {} });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportInpMetric({ value: 100 }, fakeEnqueue);
+  reportInpMetric({ value: 100 }, fakeEnqueue, () => true);
   assert.equal(calls, 1, 'delegates to enqueueSentryCall (which buffers until Sentry init)');
 });
 
@@ -64,7 +65,7 @@ test('reportInpMetric captures formFactor before deferred Sentry drain', () => {
     queued = fn;
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
   const out = withWindow(webVitalsTestWindow(900), () => {
-    reportInpMetric({ value: 350, rating: 'needs-improvement' }, fakeEnqueue);
+    reportInpMetric({ value: 350, rating: 'needs-improvement' }, fakeEnqueue, () => true);
     return { ctx: undefined as any };
   });
 
@@ -97,6 +98,22 @@ test('reportInpMetric still reports unknown/undefined-rated INP (conservative) (
     calls += 1;
     fn({ captureMessage: () => {} });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportInpMetric({ value: 250 }, fakeEnqueue); // no rating field
+  reportInpMetric({ value: 250 }, fakeEnqueue, () => true); // no rating field
   assert.equal(calls, 1, 'unknown/undefined rating still reports — do not drop unknowns');
+});
+
+test('reportInpMetric drops when the sample gate rejects (volume trim)', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  // poor-rated (would normally report) but the sample gate says drop.
+  reportInpMetric({ value: 900, rating: 'poor', attribution: { interactionTarget: 'x' } }, fakeEnqueue, () => false);
+  assert.equal(calls, 0, 'sampled-out INP is not enqueued even when rating is poor');
+});
+
+test('reportInpMetric tags the configured sampleRate for reweighting', () => {
+  const { ctx } = capture({ value: 350, rating: 'needs-improvement' });
+  assert.equal(ctx.tags.sampleRate, '0.2', 'sampleRate tag lets analysis rescale to true field volume');
 });

--- a/tests/lcp-report.test.mts
+++ b/tests/lcp-report.test.mts
@@ -8,7 +8,8 @@ function capture(metric: LcpMetricLike): { msg: string; ctx: any } {
   const fakeEnqueue = ((fn: (s: any) => void) => {
     fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportLcpMetric(metric, fakeEnqueue);
+  // Force-keep the sampling gate so distribution-shaping assertions are stable.
+  reportLcpMetric(metric, fakeEnqueue, () => true);
   assert.ok(out, 'reportLcpMetric must call enqueue exactly once');
   return out!;
 }
@@ -57,7 +58,7 @@ test('reportLcpMetric captures formFactor before deferred Sentry drain', () => {
     queued = fn;
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
   const out = withWindow(webVitalsTestWindow(900), () => {
-    reportLcpMetric({ value: 3200, rating: 'needs-improvement' }, fakeEnqueue);
+    reportLcpMetric({ value: 3200, rating: 'needs-improvement' }, fakeEnqueue, () => true);
     return { ctx: undefined as any };
   });
 
@@ -74,7 +75,7 @@ test('reportLcpMetric still reports unknown/undefined-rated LCP conservatively',
     calls += 1;
     fn({ captureMessage: () => {} });
   }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
-  reportLcpMetric({ value: 2600 }, fakeEnqueue);
+  reportLcpMetric({ value: 2600 }, fakeEnqueue, () => true);
   assert.equal(calls, 1, 'unknown/undefined rating still reports; do not drop unknowns');
 });
 
@@ -87,6 +88,21 @@ test('reportLcpMetric bounds the LCP element tag value', () => {
   });
   assert.equal(ctx.tags['lcp.element'].length, 200);
   assert.equal(ctx.extra.elementTarget, target);
+});
+
+test('reportLcpMetric drops when the sample gate rejects (volume trim)', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportLcpMetric({ value: 4100, rating: 'poor' }, fakeEnqueue, () => false);
+  assert.equal(calls, 0, 'sampled-out LCP is not enqueued even when rating is poor');
+});
+
+test('reportLcpMetric tags the configured sampleRate for reweighting', () => {
+  const { ctx } = capture({ value: 3200, rating: 'needs-improvement' });
+  assert.equal(ctx.tags.sampleRate, '0.2', 'sampleRate tag lets analysis rescale to true field volume');
 });
 
 test('reportLcpMetric tolerates missing attribution', () => {

--- a/tests/web-vitals-utils.test.mts
+++ b/tests/web-vitals-utils.test.mts
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { getWebVitalsFormFactor, sanitizeWebVitalUrl } from '@/bootstrap/web-vitals-utils';
+import {
+  getWebVitalsFormFactor,
+  sanitizeWebVitalUrl,
+  shouldSampleWebVital,
+  WEB_VITAL_SAMPLE_RATE,
+} from '@/bootstrap/web-vitals-utils';
 import { withWindow } from './web-vitals-report-test-helpers.mts';
 
 test('getWebVitalsFormFactor defaults to desktop outside the browser', () => {
@@ -27,6 +32,37 @@ test('getWebVitalsFormFactor tags wide fine-pointer surfaces as desktop', () => 
   }, () => getWebVitalsFormFactor());
 
   assert.equal(formFactor, 'desktop');
+});
+
+test('WEB_VITAL_SAMPLE_RATE keeps ~20% of the bad tail', () => {
+  assert.equal(WEB_VITAL_SAMPLE_RATE, 0.2);
+});
+
+test('shouldSampleWebVital keeps when rng falls under the rate, drops otherwise', () => {
+  assert.equal(shouldSampleWebVital(0.2, () => 0.1), true, 'rng 0.1 < 0.2 → keep');
+  assert.equal(shouldSampleWebVital(0.2, () => 0.19), true, 'just under the rate → keep');
+  assert.equal(shouldSampleWebVital(0.2, () => 0.2), false, 'at the rate → drop (strict <)');
+  assert.equal(shouldSampleWebVital(0.2, () => 0.5), false, 'rng 0.5 ≥ 0.2 → drop');
+});
+
+test('shouldSampleWebVital keeps everything at rate >= 1 and drops everything at rate <= 0', () => {
+  assert.equal(shouldSampleWebVital(1, () => 0.99), true, 'rate 1 keeps all');
+  assert.equal(shouldSampleWebVital(1.5, () => 0.99), true, 'rate > 1 keeps all');
+  assert.equal(shouldSampleWebVital(0, () => 0), false, 'rate 0 drops all');
+  assert.equal(shouldSampleWebVital(-0.3, () => 0), false, 'negative rate drops all');
+});
+
+test('shouldSampleWebVital over-reports rather than losing data on a NaN rate', () => {
+  assert.equal(shouldSampleWebVital(Number.NaN, () => 0.99), true, 'misconfigured NaN rate keeps all');
+});
+
+test('shouldSampleWebVital defaults to the configured rate and Math.random', () => {
+  // Deterministic bounds check across many draws: keep-rate should land near 0.2.
+  let kept = 0;
+  const N = 4000;
+  for (let i = 0; i < N; i += 1) if (shouldSampleWebVital()) kept += 1;
+  const ratio = kept / N;
+  assert.ok(ratio > 0.12 && ratio < 0.28, `default keep-rate ~0.2, got ${ratio}`);
 });
 
 test('sanitizeWebVitalUrl redacts query strings and caps malformed URLs', () => {


### PR DESCRIPTION
## What

Sample field web-vital telemetry (INP/CLS/LCP) to cut Sentry event volume ~80%.

## Why

Triage of "we're getting too many errors than usual" found the perception was **not** errors:

| Level | events/day (07-09) | note |
|-------|-------------------|------|
| error | ~40 | low & flat — no regression |
| warning | ~400–950 | CSP flood 06-28→07-04 (~60k/day peak) already filtered |
| **info (web-vitals)** | **~12,000** | **~92% of ALL Sentry volume** — pure telemetry |

The web-vital reporters (`captureMessage`, #4537/#4580/#5079) dominate the account. The good-trim (#4565) already drops the `good` bucket, but the surviving needs-improvement/poor tail is what's flooding Sentry.

## How

Shared uniform sampler `shouldSampleWebVital` (default **keep 20%**), applied after the good-trim in all three reporters.

- **Uniform, not rating-aware — on purpose.** `poor` is 37–55% of events (measured), so keeping it whole can't reach an 80% cut, and sampling ratings at different rates would distort the bad-event-rate ratios the attribution work depends on. Uniform sampling leaves the rating split, formFactor split, attribution-target distribution, and **p75 unbiased** — only N shrinks.
- **Still enough signal:** 20% → ~2.4k events/day, ample for weekly page-level CrUX cross-checks and per-target histograms.
- **Reconstructable:** each kept event carries a `sampleRate: "0.2"` tag, so absolute field volume is recoverable (× 1/sampleRate).
- The gate is an **injectable predicate** (mirrors the existing `enqueue` DI) so unit tests stay deterministic.

## Impact

~12k web-vital events/day → ~2.4k/day. Total Sentry volume ~13k/day → ~3k/day (~77% cut), all telemetry, zero error-signal lost.

## Tests

`npx tsc --noEmit` clean; 35/35 unit tests pass across the 4 affected files. New coverage: drop-when-rejected, `sampleRate` tag, and sampler boundaries (rng threshold, rate ≥1 / ≤0 / NaN, plus a 4000-draw statistical check of the real `Math.random` default path).

https://claude.ai/code/session_01KShEjhgAgzKUXqbuXcYNsP
