### PR TITLE
perf(cls): pin mobile boot skeleton to the real map footprint (#4580)

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,12 +352,17 @@
       [data-variant="happy"][data-theme="dark"] .skeleton-panel-metric span{color:#B9C4B0}
       [data-variant="happy"][data-theme="dark"] .skeleton-line{background:linear-gradient(90deg,rgba(139,175,122,.05) 25%,rgba(139,175,122,.10) 50%,rgba(139,175,122,.05) 75%);background-size:200% 100%;animation:skel-shimmer 1.5s infinite}
 
-      @media (max-width:767px){
-        .skeleton-header{height:44px;padding:6px 10px;gap:8px}
+      @media (max-width:768px){
+        .skeleton-header{height:40px;padding:6px 10px;gap:8px}
         .skeleton-header-left,.skeleton-header-right{gap:8px;min-width:0}
         .skeleton-kicker,.skeleton-section-note{display:none}
         .skeleton-chip{padding:0 6px;font-size:10px}
-        .skeleton-map{min-height:320px}
+        /* Mirror the real full-viewport mobile map (.map-section @ max-width:768px in
+           main.css): the skeleton previously reserved 50vh (~422px) while the hydrated
+           map is calc(100dvh - 48px) (~796px), shoving #panelsGrid down ~374px on the
+           skeleton->app swap (#4580 item a, largest mobile CLS offender). Keep the
+           100vh fallback first for pre-dvh browsers, same order as the real rule. */
+        .skeleton-map{height:calc(100vh - 48px);height:calc(100dvh - 48px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));min-height:60vh;max-height:100dvh}
         .skeleton-map-content{max-width:calc(100% - 24px);margin:12px;padding:16px}
         .skeleton-map-title{font-size:22px;line-height:1.15}
         .skeleton-map-copy{font-size:13px;line-height:1.42}

--- a/tests/skeleton-app-footprint-parity.test.mjs
+++ b/tests/skeleton-app-footprint-parity.test.mjs
@@ -48,67 +48,119 @@ function ruleBody(source, selectorRe, must) {
   return null;
 }
 
+function mobileBreakpoint() {
+  const bp = utils.match(/MOBILE_BREAKPOINT_PX\s*=\s*(\d+)/);
+  assert.ok(bp, 'Expected MOBILE_BREAKPOINT_PX in src/utils/index.ts');
+  return bp[1];
+}
+
+function matchingBraceIndex(source, openBraceIndex) {
+  let depth = 0;
+  for (let i = openBraceIndex; i < source.length; i += 1) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function maxWidthMediaBlocks(source) {
+  const blocks = [];
+  const re = /@media\s*\(max-width:\s*(\d+)px\)\s*\{/g;
+  for (const m of source.matchAll(re)) {
+    const openBrace = source.indexOf('{', m.index);
+    const closeBrace = matchingBraceIndex(source, openBrace);
+    assert.notEqual(closeBrace, -1, `Expected @media (max-width:${m[1]}px) block to close`);
+    blocks.push({
+      breakpoint: m[1],
+      body: source.slice(openBrace + 1, closeBrace),
+    });
+  }
+  return blocks;
+}
+
+function mediaRule(source, selectorRe, must) {
+  for (const block of maxWidthMediaBlocks(source)) {
+    const body = ruleBody(block.body, selectorRe, must);
+    if (body) return { breakpoint: block.breakpoint, body };
+  }
+  return null;
+}
+
+function mediaRuleAtBreakpoint(source, breakpoint, selectorRe, must) {
+  for (const block of maxWidthMediaBlocks(source)) {
+    if (block.breakpoint !== breakpoint) continue;
+    const body = ruleBody(block.body, selectorRe, must);
+    if (body) return body;
+  }
+  return null;
+}
+
 describe('#4580 boot skeleton <-> app footprint parity', () => {
   it('mobile skeleton map reserves the same height as the real .map-section', () => {
     // Source of truth: the full-viewport mobile map rule in main.css.
-    const realMap = ruleBody(css, '\\.map-section', '100dvh');
+    const realMap = mediaRule(css, '\\.map-section', '100dvh');
     assert.ok(realMap, 'Expected a mobile .map-section rule using 100dvh in main.css');
     // The skeleton mirror (the only .skeleton-map rule carrying 100dvh).
-    const skelMap = ruleBody(html, '\\.skeleton-map', '100dvh');
+    const skelMap = mediaRule(html, '\\.skeleton-map', '100dvh');
     assert.ok(
       skelMap,
       'index.html .skeleton-map must mirror the real mobile map height (calc(100dvh - 48px ...)). ' +
         'It currently does not reserve a 100dvh height — the skeleton->app swap will shove #panelsGrid on mobile.',
     );
 
+    assert.equal(
+      skelMap.breakpoint,
+      realMap.breakpoint,
+      'skeleton .skeleton-map and real .map-section must live under the same mobile breakpoint',
+    );
+
     for (const prop of ['height', 'min-height', 'max-height']) {
       assert.deepEqual(
-        declarations(skelMap, prop),
-        declarations(realMap, prop),
+        declarations(skelMap.body, prop),
+        declarations(realMap.body, prop),
         `skeleton .skeleton-map "${prop}" must match real .map-section "${prop}" (#4580 mobile CLS parity)`,
       );
     }
   });
 
   it('mobile skeleton header height matches the real .header height', () => {
-    // Source of truth is the BASE .header height; no rule under @media (max-width:768px)
-    // overrides .header height today (the mobile blocks only touch its padding), so the
-    // base value is the effective mobile height. If a mobile header-height override is
-    // ever added, tighten this to read the effective mobile value instead.
-    const realHeader = ruleBody(css, '(?:^|\\n)\\.header');
-    assert.ok(realHeader, 'Expected a base .header rule in main.css');
-    // The skeleton-header inside the mobile media block (first rule after the query open).
-    // Whitespace-tolerant so a reformat of the (hand-authored, compact) inline CSS doesn't
-    // spuriously fail — we assert the breakpoint value and the height, not the formatting.
-    const skelHeaderMobile = html.match(/@media \(max-width:\s*768px\)\s*\{\s*\.skeleton-header\{([^}]*)\}/);
+    const breakpoint = mobileBreakpoint();
+    const baseHeader = ruleBody(css, '(?:^|\\n)\\.header');
+    assert.ok(baseHeader, 'Expected a base .header rule in main.css');
+    const mobileHeader = mediaRuleAtBreakpoint(css, breakpoint, '\\.header');
+    const effectiveRealHeader =
+      mobileHeader && declarations(mobileHeader, 'height').length > 0 ? mobileHeader : baseHeader;
+    const skelHeaderMobile = mediaRuleAtBreakpoint(html, breakpoint, '\\.skeleton-header');
     assert.ok(
       skelHeaderMobile,
-      'Expected a .skeleton-header rule inside the @media (max-width:768px) skeleton block',
+      `Expected a .skeleton-header rule inside the @media (max-width:${breakpoint}px) skeleton block`,
     );
     assert.deepEqual(
-      declarations(skelHeaderMobile[1], 'height'),
-      declarations(realHeader, 'height'),
+      declarations(skelHeaderMobile, 'height'),
+      declarations(effectiveRealHeader, 'height'),
       'skeleton mobile header height must match the real .header height (#4580 header parity)',
     );
   });
 
   it('skeleton mobile breakpoint matches the app mobile breakpoint (MOBILE_BREAKPOINT_PX)', () => {
-    const bp = utils.match(/MOBILE_BREAKPOINT_PX\s*=\s*(\d+)/);
-    assert.ok(bp, 'Expected MOBILE_BREAKPOINT_PX in src/utils/index.ts');
-    const breakpoint = bp[1];
+    const breakpoint = mobileBreakpoint();
+    const realMap = mediaRule(css, '\\.map-section', '100dvh');
+    assert.ok(realMap, 'Expected a mobile .map-section rule using 100dvh in main.css');
 
     // main.css switches the map to full-viewport at exactly this breakpoint...
-    assert.match(
-      css,
-      new RegExp(`@media \\(max-width:\\s*${breakpoint}px\\)`),
-      `main.css should gate mobile rules at MOBILE_BREAKPOINT_PX (${breakpoint}px)`,
+    assert.equal(
+      realMap.breakpoint,
+      breakpoint,
+      `main.css .map-section should gate mobile rules at MOBILE_BREAKPOINT_PX (${breakpoint}px)`,
     );
     // ...so the skeleton mobile block must use the SAME breakpoint. A 767/768 seam
     // fully de-syncs the skeleton on iPad portrait (exactly 768px CSS width): the app
     // renders the 100dvh map while the skeleton stays on the desktop 50vh map.
-    assert.match(
-      html,
-      new RegExp(`@media \\(max-width:\\s*${breakpoint}px\\)\\s*\\{\\s*\\.skeleton-header`),
+    assert.ok(
+      mediaRuleAtBreakpoint(html, breakpoint, '\\.skeleton-header'),
       `The skeleton mobile block must gate at MOBILE_BREAKPOINT_PX (${breakpoint}px), not a 1px-off seam`,
     );
   });

--- a/tests/skeleton-app-footprint-parity.test.mjs
+++ b/tests/skeleton-app-footprint-parity.test.mjs
@@ -1,0 +1,115 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// #4580 item (a): the inline boot skeleton in index.html must reserve the same
+// above-the-fold footprint as the first hydrated dashboard frame, or the
+// skeleton->app swap shoves #panelsGrid/#main and generates field CLS. The most
+// severe offender was the mobile map: the real `.map-section` goes full-viewport
+// on mobile (calc(100dvh - 48px), ~796-976px) while the skeleton reserved a flat
+// 50vh (~422-512px) — a 374-464px under-reservation depending on device.
+//
+// The runtime warner (warnOnBootShellFootprintDrift in src/app/panel-layout.ts)
+// catches this at boot, but only in DEV and only when someone is watching the
+// console. This test encodes the same parity contract statically so CI catches
+// drift: it treats main.css `.map-section` as the source of truth and asserts the
+// index.html skeleton mirrors it. If the real mobile map dimensions change, this
+// test fails until the skeleton is updated to match (and vice versa).
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const html = readFileSync(join(root, 'index.html'), 'utf-8');
+const css = readFileSync(join(root, 'src', 'styles', 'main.css'), 'utf-8');
+const utils = readFileSync(join(root, 'src', 'utils', 'index.ts'), 'utf-8');
+
+/** Collapse whitespace and drop `!important` so declarations compare structurally. */
+const norm = (v) => v.replace(/!important/g, '').trim().replace(/\s+/g, ' ');
+
+/**
+ * Every value declared for `prop` inside a rule body, in source order.
+ * The leading boundary (start | `;` | `{` | whitespace) prevents `height`
+ * from also matching inside `min-height` / `max-height`.
+ */
+function declarations(block, prop) {
+  // Terminate with a lookahead (not a consuming match) so the separating `;`
+  // stays available as the leading boundary for the next declaration.
+  const re = new RegExp(`(?:^|[;{\\s])${prop}\\s*:\\s*([^;]+?)\\s*(?=;|$)`, 'g');
+  return [...block.matchAll(re)].map((m) => norm(m[1]));
+}
+
+/** First rule body matching `selectorRe` (optionally required to contain `must`). */
+function ruleBody(source, selectorRe, must) {
+  const re = new RegExp(`${selectorRe}\\s*\\{([^}]*)\\}`, 'g');
+  for (const m of source.matchAll(re)) {
+    if (!must || m[1].includes(must)) return m[1];
+  }
+  return null;
+}
+
+describe('#4580 boot skeleton <-> app footprint parity', () => {
+  it('mobile skeleton map reserves the same height as the real .map-section', () => {
+    // Source of truth: the full-viewport mobile map rule in main.css.
+    const realMap = ruleBody(css, '\\.map-section', '100dvh');
+    assert.ok(realMap, 'Expected a mobile .map-section rule using 100dvh in main.css');
+    // The skeleton mirror (the only .skeleton-map rule carrying 100dvh).
+    const skelMap = ruleBody(html, '\\.skeleton-map', '100dvh');
+    assert.ok(
+      skelMap,
+      'index.html .skeleton-map must mirror the real mobile map height (calc(100dvh - 48px ...)). ' +
+        'It currently does not reserve a 100dvh height — the skeleton->app swap will shove #panelsGrid on mobile.',
+    );
+
+    for (const prop of ['height', 'min-height', 'max-height']) {
+      assert.deepEqual(
+        declarations(skelMap, prop),
+        declarations(realMap, prop),
+        `skeleton .skeleton-map "${prop}" must match real .map-section "${prop}" (#4580 mobile CLS parity)`,
+      );
+    }
+  });
+
+  it('mobile skeleton header height matches the real .header height', () => {
+    // Source of truth is the BASE .header height; no rule under @media (max-width:768px)
+    // overrides .header height today (the mobile blocks only touch its padding), so the
+    // base value is the effective mobile height. If a mobile header-height override is
+    // ever added, tighten this to read the effective mobile value instead.
+    const realHeader = ruleBody(css, '(?:^|\\n)\\.header');
+    assert.ok(realHeader, 'Expected a base .header rule in main.css');
+    // The skeleton-header inside the mobile media block (first rule after the query open).
+    // Whitespace-tolerant so a reformat of the (hand-authored, compact) inline CSS doesn't
+    // spuriously fail — we assert the breakpoint value and the height, not the formatting.
+    const skelHeaderMobile = html.match(/@media \(max-width:\s*768px\)\s*\{\s*\.skeleton-header\{([^}]*)\}/);
+    assert.ok(
+      skelHeaderMobile,
+      'Expected a .skeleton-header rule inside the @media (max-width:768px) skeleton block',
+    );
+    assert.deepEqual(
+      declarations(skelHeaderMobile[1], 'height'),
+      declarations(realHeader, 'height'),
+      'skeleton mobile header height must match the real .header height (#4580 header parity)',
+    );
+  });
+
+  it('skeleton mobile breakpoint matches the app mobile breakpoint (MOBILE_BREAKPOINT_PX)', () => {
+    const bp = utils.match(/MOBILE_BREAKPOINT_PX\s*=\s*(\d+)/);
+    assert.ok(bp, 'Expected MOBILE_BREAKPOINT_PX in src/utils/index.ts');
+    const breakpoint = bp[1];
+
+    // main.css switches the map to full-viewport at exactly this breakpoint...
+    assert.match(
+      css,
+      new RegExp(`@media \\(max-width:\\s*${breakpoint}px\\)`),
+      `main.css should gate mobile rules at MOBILE_BREAKPOINT_PX (${breakpoint}px)`,
+    );
+    // ...so the skeleton mobile block must use the SAME breakpoint. A 767/768 seam
+    // fully de-syncs the skeleton on iPad portrait (exactly 768px CSS width): the app
+    // renders the 100dvh map while the skeleton stays on the desktop 50vh map.
+    assert.match(
+      html,
+      new RegExp(`@media \\(max-width:\\s*${breakpoint}px\\)\\s*\\{\\s*\\.skeleton-header`),
+      `The skeleton mobile block must gate at MOBILE_BREAKPOINT_PX (${breakpoint}px), not a 1px-off seam`,
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Part of #4580 — **item (a): boot skeleton ↔ app footprint parity**.

The dashboard boots an inline HTML **skeleton** (critical CSS in `index.html`) that is atomically swapped for the real app on hydration. Field CLS attribution (DebugBear + Sentry) ranked the boot-skeleton selectors among the largest mobile shifters (`#main div#panelsGrid` p75 **1.039** mobile; `skeleton-map-body` 0.740, `skeleton-map-content` 0.811). This closes the measured skeleton→app mismatch that drives them.

**Root cause (measured in-browser):** the real mobile `.map-section` is a full-viewport map (`calc(100dvh - 48px …)`) but the skeleton `.skeleton-map` had **no mobile override** — it stayed on the desktop `50vh`. So the skeleton reserved far less than the real map, and the whole grid was shoved down on the swap.

| viewport | region | skeleton (before) | real app | gap |
|---|---|---|---|---|
| 500×844 | map | 422px (50vh) | **796px** | **+374px** |
| 768×1024 (iPad portrait) | map | 512px (50vh) | **976px** | **+464px** |
| both | header | 44px | 40px | −4px |

The iPad-portrait gap was compounded by a **1px breakpoint seam**: the skeleton mobile block was `@media (max-width:767px)` while the app's mobile rules use `768px` (`MOBILE_BREAKPOINT_PX`) — so at exactly 768px the app rendered the full-viewport map while the skeleton stayed on the desktop 50vh map.

## Changes

- **`index.html`** — skeleton mobile CSS:
  - `.skeleton-map` now mirrors the real `.map-section` mobile `height`/`min-height`/`max-height` (100vh fallback line + `100dvh`, same order as the real rule).
  - `.skeleton-header` `44px → 40px` (matches the real `.header`).
  - breakpoint `max-width:767px → 768px` (= `MOBILE_BREAKPOINT_PX`).
- **`tests/skeleton-app-footprint-parity.test.mjs`** *(new)* — a CI guard that treats `main.css .map-section` as the source of truth and fails if the skeleton drifts (map height, header height, breakpoint). Complements the existing DEV-only runtime drift warner (`warnOnBootShellFootprintDrift`, `panel-layout.ts`) — that one only fires in DEV when someone watches the console; this one runs in CI.

## Verification

Lab-verified in-browser (chrome-devtools) — after the fix, the skeleton matches the real app within **<1px** on every boot-shell region at both 500px (map 422→796) and 768px (512→976), including the cascaded tabs/main/map y-positions from the header fix.

Aggregate CLS is **field-only** (lab ≈0.001 vs field 0.14), so acceptance is post-deploy, per the issue's loop:
DebugBear `clsSelector` p75 (`#main div#panelsGrid` + skeleton selectors should drop) → Sentry `webvital:cls` bad-event rate per target → CrUX `/dashboard` weekly (%good stops falling).

Desktop parity was already clean at 1280×900 (skeleton 50vh = real 50vh), so this slice targets the mobile gap; desktop remains item (b)/(c) territory.

## Known residual (follow-up, not this PR)

For the **opt-in minority** who collapse the mobile map (`localStorage` map-collapsed), the real first frame is `height:auto` while the skeleton now reserves full-viewport — so that cohort's shift roughly doubles in exchange for eliminating the default-expanded majority's shift. A clean mitigation exists (stamp `html.wm-map-collapsed` from the existing inline boot script, mirroring `wm-pro-banner-reserved`, and add a collapsed skeleton rule); tracking as a follow-up on #4580.

Closes item (a) of #4580 (items (b) async panel-mount displacement and (c) deep-dive containment remain).