### PR TITLE
perf(cls): take cached-mode banner out of flow to stop column shove (#4580)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -359,6 +359,8 @@ export class App {
     if (bannerMessage) {
       if (!this.cachedModeBannerEl) {
         this.cachedModeBannerEl = document.createElement('div');
+        // CSS disables pointer events on this status-only container. Keep its descendants
+        // non-interactive unless the banner interaction model is updated with it.
         this.cachedModeBannerEl.className = 'cached-mode-banner';
         this.cachedModeBannerEl.setAttribute('role', 'status');
         this.cachedModeBannerEl.setAttribute('aria-live', 'polite');

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -857,8 +857,9 @@ canvas,
    .header and toggled during boot on slow connections (cached -> live), shoving the
    whole column ~83px and generating field CLS (#4580: #panelsGrid/#main top offenders).
    Bottom-fixed matches the .toast-notification convention; the panel nav is top-sticky
-   so there is no persistent bottom bar to collide with. z-index sits below modals but
-   above the bottom search FAB (z 500) / footer, so `pointer-events: none` is required:
+   so there is no persistent bottom bar to collide with. z-index sits above the bottom
+   search FAB (z 500) / footer but below search overlays (z 2000), so
+   `pointer-events: none` is required:
    the banner is purely informational (role=status, no interactive children), so it must
    not trap taps meant for the FAB / open search sheet / footer links it overlaps. */
 .cached-mode-banner {
@@ -866,7 +867,7 @@ canvas,
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 9000;
+  z-index: 900;
   pointer-events: none;
   display: flex;
   align-items: center;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -852,20 +852,44 @@ canvas,
   animation: none;
 }
 
+/* Out of flow (fixed, bottom) so inserting/removing the connectivity banner never
+   reflows the #tabs/#main/#panelsGrid column. In-flow it was inserted afterend of
+   .header and toggled during boot on slow connections (cached -> live), shoving the
+   whole column ~83px and generating field CLS (#4580: #panelsGrid/#main top offenders).
+   Bottom-fixed matches the .toast-notification convention; the panel nav is top-sticky
+   so there is no persistent bottom bar to collide with. z-index sits below modals but
+   above the bottom search FAB (z 500) / footer, so `pointer-events: none` is required:
+   the banner is purely informational (role=status, no interactive children), so it must
+   not trap taps meant for the FAB / open search sheet / footer links it overlaps. */
 .cached-mode-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9000;
+  pointer-events: none;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 10px;
   padding: 9px 16px;
-  border-bottom: 1px solid rgba(217, 119, 6, 0.32);
-  background: linear-gradient(180deg, rgba(217, 119, 6, 0.14), rgba(217, 119, 6, 0.08));
+  padding-bottom: calc(9px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid rgba(217, 119, 6, 0.32);
+  background: linear-gradient(0deg, rgba(217, 119, 6, 0.14), rgba(217, 119, 6, 0.08));
   color: var(--text);
 }
 
 .cached-mode-banner--unavailable {
-  border-bottom-color: rgba(239, 68, 68, 0.32);
-  background: linear-gradient(180deg, rgba(239, 68, 68, 0.14), rgba(239, 68, 68, 0.08));
+  border-top-color: rgba(239, 68, 68, 0.32);
+  background: linear-gradient(0deg, rgba(239, 68, 68, 0.14), rgba(239, 68, 68, 0.08));
+}
+
+/* Clear the bottom-right search FAB (56px @ right:16px, mobile only) so the
+   fixed banner's wrapped text never sits under it. */
+@media (max-width: 768px) {
+  .cached-mode-banner {
+    padding-right: 84px;
+  }
 }
 
 .cached-mode-banner__badge {

--- a/tests/cached-mode-banner-out-of-flow.test.mjs
+++ b/tests/cached-mode-banner-out-of-flow.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// #4580 item (b): the connectivity "cached mode" banner (App.ts, inserted afterend of
+// .header) is toggled during boot on slow connections (cached -> live). When it was
+// in normal flow (display:flex, no position) that insert/remove reflowed the entire
+// #panelTabsMount / #main / #panelsGrid column by ~83px, generating field CLS
+// (#panelsGrid and #main were the top field offenders). Verified in-browser: an in-flow
+// banner shifts #main.y +83px; a position:fixed banner shifts it 0px.
+//
+// This guard keeps the banner OUT OF FLOW so its toggling can never reflow the column
+// again. CLS itself is field-only (not unit-testable), but "the banner is fixed-position"
+// is a checkable structural contract.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const css = readFileSync(join(root, 'src', 'styles', 'main.css'), 'utf-8');
+const appTs = readFileSync(join(root, 'src', 'App.ts'), 'utf-8');
+
+/**
+ * First rule body for `selectorRe`. The `\s*\{` anchor means `.cached-mode-banner`
+ * matches only the base rule, not `.cached-mode-banner--unavailable` /
+ * `.cached-mode-banner__badge` (those have `--`/`__` before the brace).
+ */
+function ruleBody(source, selectorRe) {
+  const re = new RegExp(`${selectorRe}\\s*\\{([^}]*)\\}`);
+  const m = source.match(re);
+  return m ? m[1] : null;
+}
+
+describe('#4580 cached-mode banner stays out of flow', () => {
+  it('the App still renders a .cached-mode-banner (guard is not dead)', () => {
+    // If the banner element is ever renamed/removed, this test would silently pass on a
+    // stale selector — anchor it to the source that creates the element.
+    assert.match(
+      appTs,
+      /className = 'cached-mode-banner'/,
+      'App.ts should still create the .cached-mode-banner element (update this guard if renamed)',
+    );
+  });
+
+  it('.cached-mode-banner is position:fixed so toggling it never reflows the column', () => {
+    const body = ruleBody(css, '\\.cached-mode-banner');
+    assert.ok(body, 'Expected a base .cached-mode-banner rule in main.css');
+    assert.match(
+      body,
+      /position:\s*fixed/,
+      'The cached-mode banner must be position:fixed (out of flow). In normal flow its ' +
+        'insert/remove during boot reflows #panelsGrid/#main ~83px and regresses field CLS (#4580).',
+    );
+    // A fixed element must be pinned, or it collapses to its static position and still
+    // participates visually where it was inserted. Require an explicit anchor edge.
+    assert.match(
+      body,
+      /(?:^|[;{\s])(?:top|bottom)\s*:/,
+      'A fixed .cached-mode-banner needs a top/bottom anchor so it pins to the viewport edge',
+    );
+  });
+});

--- a/tests/cached-mode-banner-out-of-flow.test.mjs
+++ b/tests/cached-mode-banner-out-of-flow.test.mjs
@@ -48,7 +48,7 @@ describe('#4580 cached-mode banner stays out of flow', () => {
     // stale selector — anchor it to the source that creates the element.
     assert.match(
       appTs,
-      /className = 'cached-mode-banner'/,
+      /['"`]cached-mode-banner['"`]/,
       'App.ts should still create the .cached-mode-banner element (update this guard if renamed)',
     );
   });

--- a/tests/cached-mode-banner-out-of-flow.test.mjs
+++ b/tests/cached-mode-banner-out-of-flow.test.mjs
@@ -31,6 +31,17 @@ function ruleBody(source, selectorRe) {
   return m ? m[1] : null;
 }
 
+function declarationValue(body, property) {
+  const re = new RegExp(`(?:^|[;\\s])${property}\\s*:\\s*([^;]+)`);
+  const m = body.match(re);
+  return m ? m[1].trim() : null;
+}
+
+function numericDeclaration(body, property) {
+  const value = declarationValue(body, property);
+  return value === null ? Number.NaN : Number.parseInt(value, 10);
+}
+
 describe('#4580 cached-mode banner stays out of flow', () => {
   it('the App still renders a .cached-mode-banner (guard is not dead)', () => {
     // If the banner element is ever renamed/removed, this test would silently pass on a
@@ -51,12 +62,35 @@ describe('#4580 cached-mode banner stays out of flow', () => {
       'The cached-mode banner must be position:fixed (out of flow). In normal flow its ' +
         'insert/remove during boot reflows #panelsGrid/#main ~83px and regresses field CLS (#4580).',
     );
-    // A fixed element must be pinned, or it collapses to its static position and still
-    // participates visually where it was inserted. Require an explicit anchor edge.
-    assert.match(
-      body,
-      /(?:^|[;{\s])(?:top|bottom)\s*:/,
-      'A fixed .cached-mode-banner needs a top/bottom anchor so it pins to the viewport edge',
+    // A fixed element must be pinned to the intended viewport edge, or it can drift
+    // back toward its static insertion point while still passing a generic top/bottom
+    // presence check.
+    assert.equal(
+      declarationValue(body, 'bottom'),
+      '0',
+      'A fixed .cached-mode-banner must stay pinned to the bottom viewport edge',
+    );
+    assert.equal(declarationValue(body, 'left'), '0', 'The fixed banner must span from the left edge');
+    assert.equal(declarationValue(body, 'right'), '0', 'The fixed banner must span to the right edge');
+  });
+
+  it('.cached-mode-banner is layered above the mobile FAB but below search overlays', () => {
+    const bannerBody = ruleBody(css, '\\.cached-mode-banner');
+    const searchOverlayBody = ruleBody(css, '\\.search-overlay');
+    assert.ok(bannerBody, 'Expected a base .cached-mode-banner rule in main.css');
+    assert.ok(searchOverlayBody, 'Expected a base .search-overlay rule in main.css');
+
+    const bannerZ = numericDeclaration(bannerBody, 'z-index');
+    const searchOverlayZ = numericDeclaration(searchOverlayBody, 'z-index');
+    assert.ok(Number.isFinite(bannerZ), 'Expected .cached-mode-banner to set a numeric z-index');
+    assert.ok(Number.isFinite(searchOverlayZ), 'Expected .search-overlay to set a numeric z-index');
+    assert.ok(
+      bannerZ > 500,
+      'The cached-mode banner must remain above the bottom-right search FAB (z-index 500)',
+    );
+    assert.ok(
+      bannerZ < searchOverlayZ,
+      'The cached-mode banner must stay below search overlays so it does not cover the search sheet/modal',
     );
   });
 });


### PR DESCRIPTION
## What & why — a re-diagnosis of #4580 item (b)

This PR was scoped as item (b) **"async panel-mount displacement"** — but proof-first investigation shows that mechanism **does not reproduce**, and the real reproduced cause of the `#panelsGrid`/`#main` field shifts is an **unreserved above-grid element**: the connectivity **cached-mode banner**.

### Evidence (proof-first, in-browser)
- **Code map**: the issue's named culprit `applySavedPanelOrder()` is **not on the boot path** (only user tab actions); immediate-mount panels' shells already absorb in-grid shifts.
- **Throttled repros (Slow-4G + 4× CPU)**: desktop CLS 0.091, mobile 0.159 — with **zero** in-grid `[data-panel]` shifts on either platform. Every shift attributed to `#main` being shoved by something above it.
- **DOM timeline**: the shifter is `div.cached-mode-banner` (83px), inserted in normal flow via `header.insertAdjacentElement('afterend', …)` (`App.ts:374`) and `.remove()`d when live data returns (`App.ts:388`). On slow connections (the exact bad-CLS cohort) it toggles during boot, shoving the whole `#panelTabsMount`/`#main`/`#panelsGrid` column.
- **Controlled A/B**: an in-flow banner shifts `#main.y` **+83px**; a `position:fixed` banner shifts it **0px**.

## The fix (`src/styles/main.css`)
- `.cached-mode-banner` → `position: fixed; bottom: 0; z-index: 9000` — out of flow, so insert/remove **cannot reflow** the column (structurally zero-CLS in all cases).
- `pointer-events: none` — the banner is purely informational (`role=status`, no controls), so it must not trap taps for the bottom search FAB (z-index 500) / footer it overlays (addresses review finding).
- Mobile `padding-right` clears the bottom-right search FAB; `env(safe-area-inset-bottom)` padding.
- Flips `border-bottom`→`border-top` for the new bottom placement.
- **`tests/cached-mode-banner-out-of-flow.test.mjs`** — guards the banner stays `position:fixed` (regression fence), and that `App.ts` still creates the element.

Screenshotted mobile (390) + desktop (1280): banner renders as a readable bottom bar; a11y unchanged.

## Verification
Zero-CLS proven in-browser (A/B above). Aggregate CLS is **field-only** (lab ≈0), so acceptance is post-deploy via the #4580 loop: DebugBear `clsSelector` p75 → Sentry `webvital:cls` bad-event rate → CrUX `/dashboard` weekly.

## Deliberately out of scope (follow-up)
- **Desktop `header-right` / `#panelTabsMount` shifts** (0.064 / 0.027) — a smaller, **intermittent** above-grid mechanism that did not reliably reproduce (one clean boot showed header/tabs/main all stable). Not fixed here to avoid a speculative change; noted on #4580 for a future slice.
- **Genuine panel-mount displacement** — the shell-less immediate-mount panels (`mountLazyPanel`, no placeholder) remain a theoretical gap that did not surface in lab; tracked on #4580.

Part of #4580 (item (b), re-diagnosed). Item (a) skeleton parity is #5133.