### PR TITLE
fix(forecast): reclassify conflict/ucdp_zone count specs to judged (#5136)

### DIFF
--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -180,6 +180,18 @@ export const MARKET_PRICE_MOVE_RATIO = 1.1;
 // counted over NEW events dated within [emission, deadline]. Like
 // MARKET_PRICE_MOVE_RATIO, this is a named Bet-2 tuning knob.
 export const CONFLICT_ESCALATION_RATIO = 1.5;
+
+// The conflict/ucdp_zone hard-count families resolve against
+// CONFLICT_COUNT_SOURCE_FEED (conflict:acled-resolution:v1), which only
+// populates with ACLED credentials. Without them the feed is empty and every
+// conflict count spec is unresolvable — it sits pending/VOID forever (#5136).
+// Until a populated near-real-time event-count feed exists, route these
+// families to judged resolution (#5087) instead of emitting a dead hard spec.
+// Article volume (GDELT, #5099/#5134) is NOT a substitute: its scale is
+// article count, not event count, so the horizon-scaled thresholds below would
+// mis-resolve. Flip to true — and confirm the feed is actually seeded — to
+// re-enable hard-count resolution; the threshold logic below is preserved.
+export const CONFLICT_COUNT_FEED_AVAILABLE = false;
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 // FAMILY_FEED / FAMILY_WINDOW map each hard family to its default sourceFeed
@@ -368,10 +380,16 @@ function resolveHardFamily(pred) {
 // extraction — pulls the first numeric token out of the matching signal's
 // `value` string (the seeder already renders these as human-readable
 // "N units" strings, e.g. "14 UCDP conflict events").
-function deriveHardMetrics(pred, family, inputs) {
+function deriveHardMetrics(pred, family, inputs, options = {}) {
   switch (family) {
     case 'conflict':
     case 'ucdp_zone': {
+      // #5136: the conflict count feed (conflict:acled-resolution:v1) is empty
+      // without ACLED credentials, so a hard spec here is unresolvable. Return
+      // null → buildHardSpec falls back to buildJudgedSpec (LLM judge, #5087).
+      // The `conflictCountFeedAvailable` override lets callers (and the tests
+      // that lock the preserved #5010 threshold logic) force the hard path.
+      if (!(options.conflictCountFeedAvailable ?? CONFLICT_COUNT_FEED_AVAILABLE)) return null;
       // Count threshold comes ONLY from an actual event-count signal
       // (ucdp / conflict_events). A 'cii' value is a 0-100 composite INDEX,
       // not an event count — using it would emit a semantically wrong
@@ -515,6 +533,12 @@ function buildQuestion(pred) {
   const region = pred.region || 'unspecified region';
   const domain = pred.domain || 'unspecified domain';
   const horizon = pred.timeHorizon || 'unspecified horizon';
+  // Conflict forecasts are now judged (#5136). A sharper, escalation-framed
+  // question resolves more reliably against the news archive than the generic
+  // "resolve YES" phrasing.
+  if (domain === 'conflict') {
+    return `Within the ${horizon} horizon, did ${region} experience a materially escalated level of armed conflict versus its recent baseline, consistent with "${title}"?`;
+  }
   return `Will "${title}" (${domain}, ${region}) resolve YES within its ${horizon} horizon?`;
 }
 
@@ -532,8 +556,8 @@ function buildJudgedSpec(pred, generatedAt) {
   };
 }
 
-function buildHardSpec(pred, inputs, family, generatedAt) {
-  const metrics = deriveHardMetrics(pred, family, inputs);
+function buildHardSpec(pred, inputs, family, generatedAt, options = {}) {
+  const metrics = deriveHardMetrics(pred, family, inputs, options);
   if (!metrics || !Number.isFinite(metrics.threshold)) {
     // Threshold fallback (R3/plan step 3): a hard family that cannot derive
     // a finite threshold emits a judged spec rather than an unresolvable
@@ -590,7 +614,7 @@ function buildHardSpec(pred, inputs, family, generatedAt) {
 //  6. Otherwise (no-signal-match/unrecognized domain) -> judged.
 // deriveDeadline is the only call that can throw (an unrecognized horizon);
 // buildResolutionSpec itself never throws.
-export function buildResolutionSpec(pred, inputs, generatedAt) {
+export function buildResolutionSpec(pred, inputs, generatedAt, options = {}) {
   if (pred.generationOrigin === 'state_derived') {
     return buildJudgedSpec(pred, generatedAt);
   }
@@ -600,7 +624,7 @@ export function buildResolutionSpec(pred, inputs, generatedAt) {
     (s) => SIGNAL_TO_HARD_FAMILY[s.type] === 'prediction_market',
   );
   if (hasPredictionMarketSignal) {
-    return buildHardSpec(pred, inputs, 'prediction_market', generatedAt);
+    return buildHardSpec(pred, inputs, 'prediction_market', generatedAt, options);
   }
 
   if (JUDGED_DOMAINS.has(pred.domain)) {
@@ -612,15 +636,15 @@ export function buildResolutionSpec(pred, inputs, generatedAt) {
     return buildJudgedSpec(pred, generatedAt);
   }
 
-  return buildHardSpec(pred, inputs, family, generatedAt);
+  return buildHardSpec(pred, inputs, family, generatedAt, options);
 }
 
 // The seam pass (D1): sets pred.resolution on every prediction in place and
 // returns the (same) array for chaining, mirroring the existing
 // calibrateWithMarkets / computeProjections enrichment-pass convention.
-export function attachResolutionSpecs(predictions, inputs, generatedAt) {
+export function attachResolutionSpecs(predictions, inputs, generatedAt, options = {}) {
   for (const pred of predictions) {
-    pred.resolution = buildResolutionSpec(pred, inputs, generatedAt);
+    pred.resolution = buildResolutionSpec(pred, inputs, generatedAt, options);
   }
   return predictions;
 }

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -18,7 +18,7 @@ import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
 import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
-import { CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
+import { CONFLICT_COUNT_FEED_AVAILABLE, CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
 import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
 import { callForecastLLM } from './seed-forecasts.mjs';
 
@@ -763,13 +763,45 @@ function migratePendingCountFeedKeys(ledger) {
   for (const entry of Object.values(ledger)) {
     if (entry?.status !== 'pending' || entry.spec?.kind !== 'hard') continue;
     const replacement = STALE_COUNT_FEED_REPLACEMENTS.get(entry.spec.sourceFeed);
-    if (!replacement) continue;
-    const parsed = parseMetricKey(entry.spec.metricKey);
-    entry.spec.sourceFeed = replacement;
-    if (parsed?.feedKey && STALE_COUNT_FEED_REPLACEMENTS.get(parsed.feedKey) === replacement) {
-      entry.spec.metricKey = `${replacement}|${entry.spec.metricKey.slice(parsed.feedKey.length + 1)}`;
+    if (replacement) {
+      const parsed = parseMetricKey(entry.spec.metricKey);
+      entry.spec.sourceFeed = replacement;
+      if (parsed?.feedKey && STALE_COUNT_FEED_REPLACEMENTS.get(parsed.feedKey) === replacement) {
+        entry.spec.metricKey = `${replacement}|${entry.spec.metricKey.slice(parsed.feedKey.length + 1)}`;
+      }
     }
+    migratePendingConflictCountEntryToJudged(entry);
   }
+}
+
+function migratePendingConflictCountEntryToJudged(entry) {
+  if (CONFLICT_COUNT_FEED_AVAILABLE) return;
+  if (entry?.status !== 'pending' || entry.spec?.kind !== 'hard') return;
+  if (entry.spec.sourceFeed !== CONFLICT_COUNT_SOURCE_FEED) return;
+  const parsed = parseMetricKey(entry.spec.metricKey);
+  if (parsed?.fn !== 'count') return;
+
+  const deadline = toFiniteNumber(entry.deadline ?? entry.spec.deadline);
+  entry.spec = {
+    kind: 'judged',
+    metricKey: null,
+    operator: null,
+    threshold: null,
+    baselineValue: null,
+    window: null,
+    deadline: deadline ?? entry.spec.deadline,
+    sourceFeed: null,
+    question: buildConflictJudgedQuestionForEntry(entry),
+  };
+  entry.status = 'pending-judge';
+  entry.samples = { count: 0, recent: [] };
+}
+
+function buildConflictJudgedQuestionForEntry(entry) {
+  const title = entry.title || '(untitled forecast)';
+  const region = entry.region || 'unspecified region';
+  const horizon = entry.timeHorizon || 'unspecified horizon';
+  return `Within the ${horizon} horizon, did ${region} experience a materially escalated level of armed conflict versus its recent baseline, consistent with "${title}"?`;
 }
 
 export function samplePendingEntries(ledger, feedsByKey, nowMs) {

--- a/tests/forecast-history.test.mjs
+++ b/tests/forecast-history.test.mjs
@@ -349,7 +349,8 @@ describe('forecast resolution spec round-trip (U3)', () => {
   it('a hard spec survives buildHistoryForecastEntry -> JSON -> parse with camelCase fields intact', () => {
     const pred = makeHardConflictPred();
     pred.projections = { h24: 0.6, d7: 0.64, d30: 0.7 };
-    attachResolutionSpecs([pred], {}, HARD_CONFLICT_GENERATED_AT);
+    // conflict is judged by default (#5136); force the hard path to exercise hard-spec history round-trip.
+    attachResolutionSpecs([pred], {}, HARD_CONFLICT_GENERATED_AT, { conflictCountFeedAvailable: true });
     assert.equal(pred.resolution.kind, 'hard');
 
     const entry = JSON.parse(JSON.stringify(buildHistoryForecastEntry(pred)));
@@ -403,7 +404,8 @@ describe('forecast resolution spec round-trip (U3)', () => {
 
   it('canonical payload emits a camelCase resolution object for a spec\'d forecast, omits it otherwise', () => {
     const spec = makeHardConflictPred();
-    attachResolutionSpecs([spec], {}, HARD_CONFLICT_GENERATED_AT);
+    // conflict is judged by default (#5136); force the hard path for the camelCase resolution round-trip.
+    attachResolutionSpecs([spec], {}, HARD_CONFLICT_GENERATED_AT, { conflictCountFeedAvailable: true });
     const payload = buildPublishedForecastPayload(spec);
     assert.equal(payload.resolution.kind, 'hard');
     assert.equal(payload.resolution.metricKey, spec.resolution.metricKey);
@@ -480,7 +482,8 @@ describe('forecast resolution seam coverage (U3, R2/D1)', () => {
     };
 
     const batch = [conflictPred, commodityPred, politicalPred, stateDerivedPred];
-    attachResolutionSpecs(batch, inputs, HARD_CONFLICT_GENERATED_AT);
+    // conflict is judged by default (#5136); force its hard path so this mixed batch still exercises hard+judged.
+    attachResolutionSpecs(batch, inputs, HARD_CONFLICT_GENERATED_AT, { conflictCountFeedAvailable: true });
 
     // 100% coverage (R2): every forecast carries a non-null spec.
     assert.equal(batch.every((p) => p.resolution != null), true);

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -116,22 +116,44 @@ describe('horizon drift guard', () => {
   });
 });
 
-describe('buildResolutionSpec — happy path (conflict)', () => {
-  it('a conflict forecast yields a hard spec with camelCase keys, a real sourceFeed, finite threshold', () => {
+describe('buildResolutionSpec — conflict is judged (#5136)', () => {
+  it('a conflict forecast with a ucdp signal yields a JUDGED spec (was hard) — the conflict count feed needs ACLED creds it lacks', () => {
     const forecast = pred({
       domain: 'conflict',
+      region: 'Sudan',
       signals: [{ type: 'ucdp', value: '14 UCDP conflict events', weight: 0.5 }],
     });
     const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    assert.equal(spec.kind, 'judged');
+    // judged specs carry a question + derived deadline, and NO hard-metric fields
+    assert.equal(spec.metricKey, null);
+    assert.equal(spec.sourceFeed, null);
+    assert.equal(spec.operator, null);
+    assert.equal(spec.threshold, null);
+    assert.ok(Number.isFinite(spec.deadline), 'judged spec still carries a derived deadline');
+    assert.ok(typeof spec.question === 'string' && spec.question.length > 0);
+  });
+
+  it('conflict judged specs use an escalation-framed, region-anchored question', () => {
+    const spec = buildResolutionSpec(
+      pred({ domain: 'conflict', region: 'Sudan', timeHorizon: '30d', signals: [{ type: 'ucdp', value: '9 UCDP conflict events', weight: 0.5 }] }),
+      {},
+      GENERATED_AT,
+    );
+    assert.match(spec.question, /Sudan/);
+    assert.match(spec.question, /escalat/i);
+    assert.match(spec.question, /30d/);
+  });
+
+  it('the reclassification is scoped — unrest (political domain) still emits a hard spec', () => {
+    const spec = buildResolutionSpec(
+      pred({ domain: 'political', region: 'Kenya', timeHorizon: '7d', signals: [{ type: 'unrest_events', value: '20 unrest events', weight: 0.5 }] }),
+      {},
+      GENERATED_AT,
+    );
     assert.equal(spec.kind, 'hard');
     assert.ok(RESOLUTION_FEED_KEYS.has(spec.sourceFeed));
-    assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     assert.ok(Number.isFinite(spec.threshold));
-    assert.ok(['>=', '<=', 'crosses'].includes(spec.operator));
-    assert.ok(Object.hasOwn(spec, 'metricKey'));
-    assert.ok(Object.hasOwn(spec, 'sourceFeed'));
-    assert.equal(spec.metric_key, undefined);
-    assert.equal(spec.source_feed, undefined);
   });
 });
 
@@ -226,12 +248,14 @@ describe('buildResolutionSpec — feed mapping per family', () => {
     assert.equal(spec.sourceFeed, 'intelligence:gpsjam:v2');
   });
 
-  it('a UCDP-zone forecast resolves to the fresh ACLED count feed', () => {
+  it('a UCDP-zone forecast resolves to the fresh ACLED count feed (when the feed is available)', () => {
     const forecast = pred({
       domain: 'conflict',
       signals: [{ type: 'ucdp', value: '25 UCDP conflict events', weight: 0.5 }],
     });
-    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    // conflict/ucdp_zone are judged by default (#5136); force the hard path to
+    // assert the feed mapping still points at the ACLED-resolution feed.
+    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT, { conflictCountFeedAvailable: true });
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     assert.equal(CONFLICT_COUNT_SOURCE_FEED, 'conflict:acled-resolution:v1:all:0:0');
@@ -478,7 +502,8 @@ describe('deadline is always present', () => {
     });
     const judgedForecast = pred({ domain: 'political', signals: [] });
 
-    const hardSpec = buildResolutionSpec(hardForecast, {}, GENERATED_AT);
+    // conflict is judged by default (#5136); force the hard path to exercise the deadline invariant on a hard spec.
+    const hardSpec = buildResolutionSpec(hardForecast, {}, GENERATED_AT, { conflictCountFeedAvailable: true });
     const judgedSpec = buildResolutionSpec(judgedForecast, {}, GENERATED_AT);
 
     assert.equal(hardSpec.kind, 'hard');
@@ -527,7 +552,9 @@ describe('R4 — sourceFeed membership over every hard fixture', () => {
     for (const forecast of fixtures) {
       // COMMODITY_INPUTS supplies the commodities feed the market fixture
       // needs; a harmless superset for the other families (they don't read it).
-      const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT);
+      // conflict is judged by default (#5136) — force the hard path so the
+      // conflict fixture still exercises the sourceFeed-membership invariant.
+      const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT, { conflictCountFeedAvailable: true });
       assert.equal(spec.kind, 'hard', `expected fixture ${forecast.id} to resolve hard`);
       assert.ok(
         RESOLUTION_FEED_KEYS.has(spec.sourceFeed),
@@ -682,7 +709,9 @@ describe('FIX 1 — domain constrains the hard family (DOMAIN_TO_HARD_FAMILIES)'
         { type: 'conflict_events', value: '3 cross-border events', weight: 0.35 },
       ],
     });
-    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    // conflict is judged by default (#5136); force the hard path to lock the
+    // preserved #5010 horizon-commensurable threshold derivation.
+    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT, { conflictCountFeedAvailable: true });
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     // #5010 horizon-commensurable threshold: the 365d-trailing tally (3) is
@@ -703,7 +732,8 @@ describe('FIX 2 — metricKey embeds real values with unified "==" grammar', () 
       region: 'Pakistan',
       signals: [{ type: 'ucdp', value: '175 UCDP conflict events', weight: 0.5 }],
     });
-    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    // conflict is judged by default (#5136); force the hard path to lock the metricKey grammar.
+    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT, { conflictCountFeedAvailable: true });
     assert.equal(spec.metricKey, `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Pakistan)`);
     assert.ok(!spec.metricKey.includes('<region>'));
   });
@@ -822,7 +852,7 @@ describe('#5010 amendment — resolvable windows + horizon-commensurable count',
     const conflict = buildResolutionSpec(pred({
       domain: 'conflict', region: 'Mali',
       signals: [{ type: 'conflict_events', value: '12 cross-border events', weight: 0.4 }],
-    }), {}, GENERATED_AT);
+    }), {}, GENERATED_AT, { conflictCountFeedAvailable: true }); // judged by default (#5136); force hard to assert the window
     assert.equal(conflict.window, 'within-horizon');
 
     const infra = buildResolutionSpec(pred({
@@ -839,10 +869,11 @@ describe('#5010 amendment — resolvable windows + horizon-commensurable count',
   });
 
   it('the conflict count threshold scales with the horizon (24h vs 30d from the same tally)', () => {
+    // conflict is judged by default (#5136); force the hard path to lock the preserved #5010 horizon scaling.
     const mk = (horizon) => buildResolutionSpec(pred({
       domain: 'conflict', region: 'Pakistan', timeHorizon: horizon,
       signals: [{ type: 'ucdp', value: '175 UCDP conflict events', weight: 0.5 }],
-    }), {}, GENERATED_AT);
+    }), {}, GENERATED_AT, { conflictCountFeedAvailable: true });
     const day = mk('24h');
     const month = mk('30d');
     // 175 events/365d: 24h → max(1, round(175 × 1/365 × 1.5)) = 1;

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -190,7 +190,7 @@ describe('processResolutionCycle', () => {
     assert.equal(receipts.length, 0);
   });
 
-  it('migrates already-open ACLED/unrest count entries from display feeds to resolution feeds', () => {
+  it('migrates already-open display count entries while moving ACLED conflict rows to judged', () => {
     const deadline = T0 + DAY_MS;
     const oldLedger = {
       [`fc-mali@${deadline}`]: {
@@ -265,11 +265,13 @@ describe('processResolutionCycle', () => {
     }, deadline + 3 * DAY_MS);
 
     const conflictRow = ledger[`fc-mali@${deadline}`];
-    assert.equal(conflictRow.spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
-    assert.equal(conflictRow.spec.metricKey, `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`);
-    assert.equal(conflictRow.status, 'resolved');
-    assert.equal(conflictRow.outcome, 'NO');
-    assert.equal(conflictRow.evidence.metricValue, 1);
+    assert.equal(conflictRow.status, 'pending-judge');
+    assert.equal(conflictRow.spec.kind, 'judged');
+    assert.equal(conflictRow.spec.sourceFeed, null);
+    assert.equal(conflictRow.spec.metricKey, null);
+    assert.equal(conflictRow.spec.deadline, deadline);
+    assert.match(conflictRow.spec.question, /Mali/);
+    assert.equal(conflictRow.outcome, undefined);
 
     const unrestRow = ledger[`fc-venezuela@${deadline}`];
     assert.equal(unrestRow.spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
@@ -277,7 +279,7 @@ describe('processResolutionCycle', () => {
     assert.equal(unrestRow.status, 'resolved');
     assert.equal(unrestRow.outcome, 'NO');
     assert.equal(unrestRow.evidence.metricValue, 1);
-    assert.equal(receipts.length, 2);
+    assert.equal(receipts.length, 1);
   });
 
   it('migrates old-key count specs first ingested from history snapshots', () => {
@@ -332,15 +334,100 @@ describe('processResolutionCycle', () => {
       },
     }, deadline + 3 * DAY_MS);
 
-    assert.equal(ledger[`fc-mali@${deadline}`].spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
-    assert.equal(ledger[`fc-mali@${deadline}`].spec.metricKey, `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`);
-    assert.equal(ledger[`fc-mali@${deadline}`].status, 'resolved');
-    assert.equal(ledger[`fc-mali@${deadline}`].outcome, 'NO');
+    assert.equal(ledger[`fc-mali@${deadline}`].status, 'pending-judge');
+    assert.equal(ledger[`fc-mali@${deadline}`].spec.kind, 'judged');
+    assert.equal(ledger[`fc-mali@${deadline}`].spec.sourceFeed, null);
+    assert.equal(ledger[`fc-mali@${deadline}`].spec.metricKey, null);
+    assert.match(ledger[`fc-mali@${deadline}`].spec.question, /Mali/);
     assert.equal(ledger[`fc-venezuela@${deadline}`].spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
     assert.equal(ledger[`fc-venezuela@${deadline}`].spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
     assert.equal(ledger[`fc-venezuela@${deadline}`].status, 'resolved');
     assert.equal(ledger[`fc-venezuela@${deadline}`].outcome, 'NO');
-    assert.equal(receipts.length, 2);
+    assert.equal(receipts.length, 1);
+  });
+
+  it('migrates persisted pending ACLED conflict rows to judged without rewriting resolved rows', () => {
+    const deadline = T0 + DAY_MS;
+    const oldLedger = {
+      [`fc-mali@${deadline}`]: {
+        id: 'fc-mali',
+        key: `fc-mali@${deadline}`,
+        domain: 'conflict',
+        region: 'Mali',
+        title: 'Conflict events in Mali rise above trend',
+        timeHorizon: '24h',
+        generationOrigin: 'detector',
+        spec: {
+          kind: 'hard',
+          metricKey: `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`,
+          operator: '>=',
+          threshold: 2,
+          window: 'within-horizon',
+          deadline,
+          sourceFeed: CONFLICT_COUNT_SOURCE_FEED,
+        },
+        probability: 0.52,
+        firstSeenProbability: 0.52,
+        generatedAt: T0,
+        deadline,
+        firstSeenAt: T0,
+        lastSeenAt: T0,
+        status: 'pending',
+        samples: { count: 1, recent: [{ ts: deadline + DAY_MS, error: `missing_feed:${CONFLICT_COUNT_SOURCE_FEED}` }] },
+      },
+      [`fc-resolved@${deadline}`]: {
+        id: 'fc-resolved',
+        key: `fc-resolved@${deadline}`,
+        domain: 'conflict',
+        region: 'Mali',
+        title: 'Already resolved conflict row',
+        timeHorizon: '24h',
+        generationOrigin: 'detector',
+        spec: {
+          kind: 'hard',
+          metricKey: `${CONFLICT_COUNT_SOURCE_FEED}|count(country==Mali)`,
+          operator: '>=',
+          threshold: 1,
+          window: 'within-horizon',
+          deadline,
+          sourceFeed: CONFLICT_COUNT_SOURCE_FEED,
+        },
+        probability: 0.7,
+        firstSeenProbability: 0.7,
+        generatedAt: T0,
+        deadline,
+        firstSeenAt: T0,
+        lastSeenAt: deadline,
+        status: 'resolved',
+        outcome: 'YES',
+        resolvedAt: deadline + DAY_MS,
+        sealedAt: deadline + DAY_MS,
+        evidence: { metricValue: 2 },
+        samples: { count: 0, recent: [] },
+      },
+    };
+
+    const { ledger, receipts } = processResolutionCycle(oldLedger, [], {
+      [CONFLICT_COUNT_SOURCE_FEED]: { events: [{ country: 'Mali', occurredAt: T0 + 1 }] },
+    }, deadline + 3 * DAY_MS);
+
+    const migrated = ledger[`fc-mali@${deadline}`];
+    assert.equal(migrated.status, 'pending-judge');
+    assert.equal(migrated.spec.kind, 'judged');
+    assert.equal(migrated.spec.sourceFeed, null);
+    assert.equal(migrated.spec.metricKey, null);
+    assert.equal(migrated.spec.operator, null);
+    assert.equal(migrated.spec.threshold, null);
+    assert.equal(migrated.spec.deadline, deadline);
+    assert.match(migrated.spec.question, /Mali/);
+    assert.deepEqual(migrated.samples, { count: 0, recent: [] });
+
+    const resolved = ledger[`fc-resolved@${deadline}`];
+    assert.equal(resolved.status, 'resolved');
+    assert.equal(resolved.spec.kind, 'hard');
+    assert.equal(resolved.spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
+    assert.equal(resolved.outcome, 'YES');
+    assert.equal(receipts.length, 0);
   });
 
   it('does not resolve stale UCDP count snapshots to NO after the settlement lag', () => {


### PR DESCRIPTION
## Summary

Implements the #5136 recommendation: **reclassify conflict / ucdp_zone count specs to `judged`**, since their hard-count feed (`conflict:acled-resolution:v1`) is empty without ACLED credentials — every conflict count spec was otherwise unresolvable (pending/VOID forever). Judged resolution is live (#5087).

## Why judged (not GDELT-count or UCDP)
- The count thresholds are derived from an **event tally** × `CONFLICT_ESCALATION_RATIO` (e.g. "≥66 events in-horizon"). GDELT article **volume** is a different scale (one event → dozens of articles), so `count(articles) >= 66` would false-YES constantly.
- UCDP's ~months lag → perpetual `count_source_lags_deadline` (why #5072 moved off it).
- Judged resolves "did conflict escalate in X by the deadline" from the WM news archive with dual-model + citations, and works today. A resolvable judged spec beats an unresolvable hard one.

## What changed (`scripts/_forecast-resolution.mjs`)
- `deriveHardMetrics`: conflict/ucdp_zone `return null` when the count feed is unavailable → `buildHardSpec` falls back to `buildJudgedSpec`. Gated by `CONFLICT_COUNT_FEED_AVAILABLE` (default `false`); the horizon-commensurable threshold logic (#5010) is **preserved**, not deleted — flip the flag to re-enable once a populated event-count feed exists.
- `buildQuestion`: family-aware, escalation-framed question for conflict forecasts.
- Threaded an optional `conflictCountFeedAvailable` override through `buildResolutionSpec` / `attachResolutionSpecs` (a real config with a production default, and the seam that lets the preserved-hard-logic tests force the hard path — same pattern as `_gdelt-fetch.mjs`'s seams).

## Tests
- New: conflict now emits `judged` with an escalation/region-anchored question; scoped-regression that **unrest still emits hard** (change is conflict/ucdp_zone-only).
- Existing conflict-hard tests (feed mapping, #5010 threshold scaling, metricKey grammar, R4 fixture, history round-trip) now pass `{ conflictCountFeedAvailable: true }` — so they keep validating the preserved logic.
- **405 forecast tests green** (`forecast-resolution` 58, `forecast-history`, `forecast-detectors`, `forecast-resolution-eval`, `forecast-resolutions-seeder`, `forecast-scorecard`, + `.mts` scorecard/get-forecasts).

## Follow-ups (not in this PR)
- **#5091**: reframe the coverage KPI to *resolvable* coverage — this lowers nominal hard-ratio but raises real resolvable coverage.
- **Judge budget**: conflict is high-volume; watch `pendingJudge` on the scorecard-watch and bump `FORECAST_RESOLUTION_JUDGE_MAX_PER_RUN` if the backlog grows.
- **Deploy verify**: `get-forecasts` shows conflict specs as `judged`; scorecard shows them moving `pending-judge → resolved`.

Related: #5136, #5097, #5087, #5091.

https://claude.ai/code/session_01StNurp4TGC3JLHbTtKJhbp
