### PR TITLE
fix(matcher): don't treat missing category as an exact category match

### DIFF
--- a/consumer-prices-core/src/matchers/canonical.ts
+++ b/consumer-prices-core/src/matchers/canonical.ts
@@ -35,7 +35,13 @@ export function scoreMatch(raw: RawProduct, canonical: CanonicalProduct): MatchR
 
   const rawCategory = (raw.categoryText ?? '').toLowerCase();
   const canonCategory = canonical.category.toLowerCase();
-  const categoryExact = rawCategory.includes(canonCategory) || canonCategory.includes(rawCategory);
+  // Guard against empty strings: `x.includes('')` is always true, so without
+  // this a product with no categoryText would count as an exact category match
+  // against every canonical product and wrongly earn the +20 bonus.
+  const categoryExact =
+    rawCategory.length > 0 &&
+    canonCategory.length > 0 &&
+    (rawCategory.includes(canonCategory) || canonCategory.includes(rawCategory));
   if (categoryExact) score += 20;
 
   const overlap = tokenOverlap(raw.rawTitle, canonical.canonicalName);

--- a/consumer-prices-core/tests/unit/matcher.test.ts
+++ b/consumer-prices-core/tests/unit/matcher.test.ts
@@ -57,6 +57,16 @@ describe('scoreMatch', () => {
     );
     expect(emptyCategory.evidence.categoryExact).toBe(false);
   });
+
+  it('does not treat an empty canonical category as an exact category match', () => {
+    // The symmetric case: a canonical product with an empty category must not
+    // match every categorized raw product via `rawCategory.includes('')`.
+    const emptyCanonical = scoreMatch(
+      { rawTitle: 'Sunflower Oil 2L', rawBrand: 'Generic', rawSizeText: '2L', categoryText: 'oil' },
+      { ...baseCanonical, category: '' },
+    );
+    expect(emptyCanonical.evidence.categoryExact).toBe(false);
+  });
 });
 
 describe('bestMatch', () => {

--- a/consumer-prices-core/tests/unit/matcher.test.ts
+++ b/consumer-prices-core/tests/unit/matcher.test.ts
@@ -41,6 +41,22 @@ describe('scoreMatch', () => {
     );
     expect(result.status).toBe('reject');
   });
+
+  it('does not treat a missing category as an exact category match', () => {
+    // A raw product with no categoryText must not earn the +20 category bonus.
+    // Previously `canonCategory.includes('')` was always true.
+    const nullCategory = scoreMatch(
+      { rawTitle: 'Sunflower Oil 2L', rawBrand: 'Generic', rawSizeText: '2L', categoryText: null },
+      baseCanonical,
+    );
+    expect(nullCategory.evidence.categoryExact).toBe(false);
+
+    const emptyCategory = scoreMatch(
+      { rawTitle: 'Sunflower Oil 2L', rawBrand: 'Generic', rawSizeText: '2L', categoryText: '' },
+      baseCanonical,
+    );
+    expect(emptyCategory.evidence.categoryExact).toBe(false);
+  });
 });
 
 describe('bestMatch', () => {

--- a/consumer-prices-core/vitest.config.ts
+++ b/consumer-prices-core/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', 'src/adapters/search.smoke.ts'],
   },
 });


### PR DESCRIPTION
## Problem

In `consumer-prices-core/src/matchers/canonical.ts`, `scoreMatch()` computes the category-match evidence as:

```ts
const rawCategory = (raw.categoryText ?? '').toLowerCase();
const canonCategory = canonical.category.toLowerCase();
const categoryExact = rawCategory.includes(canonCategory) || canonCategory.includes(rawCategory);
if (categoryExact) score += 20;
```

`categoryText` is explicitly nullable (`categoryText?: string | null`), and `raw.categoryText ?? ''` deliberately maps a missing category to `''`. But `anyString.includes('')` is **always `true`**, so when a raw product has no category, `canonCategory.includes('')` short-circuits `categoryExact` to `true`.

Result: a product with **no category information** is scored as an *exact category match against every canonical product* and earns the full `+20` bonus. That inflates `score` and can push a match up the `reject → review → auto` ladder (thresholds 70 / 85), and in `bestMatch()` it biases ranking toward candidates it shouldn't match on category at all.

## Fix

Guard both sides against empty strings before the `includes` test:

```ts
const categoryExact =
  rawCategory.length > 0 &&
  canonCategory.length > 0 &&
  (rawCategory.includes(canonCategory) || canonCategory.includes(rawCategory));
```

## Also: the matcher test suite never ran

While adding a regression test I noticed `vitest.config.ts` only included `src/**/*.test.ts`, so the entire `tests/unit/` directory — `matcher`, `size`, `title`, `pinning`, `search-extract-size` — was **never executed** by `npm test`. This is why the bug wasn't caught. I widened the include glob to also cover `tests/**/*.test.ts`.

```ts
include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
```

## Verification

Regression test added to `tests/unit/matcher.test.ts` asserting a `null`/`''` category does not report `categoryExact`.

- **Before the fix** (pristine `canonical.ts`): the new test fails — `categoryExact` is `true` for a no-category product.
- **After the fix:** it passes.
- Full suite with the widened include glob: **100 tests passing** across 10 files (the 5 previously-dormant `tests/unit` files + the existing `src` suite), no regressions.

```
$ npx vitest run
 Test Files  10 passed (10)
      Tests  100 passed (100)
```

Note: `scoreMatch`/`bestMatch` are currently exercised only by this unit suite (not yet wired into a live scrape/aggregate path), so this is a correctness fix to the matcher module and its test coverage rather than a change to live output.
