### PR TITLE
fix(seed): time-box seed-conflict-intel GDELT fallback sweep to fit the fetch deadline (#5140)

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -41,6 +41,13 @@ const CONFLICT_COUNTRIES = [
   'IQ', 'PS', 'LY', 'ML', 'BF', 'NE', 'NG', 'CM', 'MZ', 'HT',
 ];
 export const GDELT_MIN_SUCCESSFUL_COUNTRIES = Math.ceil(CONFLICT_COUNTRIES.length * 0.8);
+// #5140: wall-clock budget for the whole GDELT fallback sweep. The sweep's worst
+// case must fit runSeed's 240s fetch deadline AFTER the aux Promise.allSettled
+// (~≤60s) and with one in-flight batch allowed to drain past the budget check
+// (~92s OBSERVED for a full-timeout batch at the fetch knobs below — retry math
+// says 75s, curl/DNS overheads add ~17s): 60s + 75s + 95s = 230s ≤ 240s. Without
+// this cap a GDELT brownout ran 5 batches ≈ 375s → deadline breach → exit 75 every tick.
+export const GDELT_SWEEP_BUDGET_MS = 75_000;
 
 const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
 
@@ -211,13 +218,27 @@ export async function fetchGdeltCountryEvents(cc) {
 export async function fetchGdeltConflictEvents({
   fetchCountryEvents = fetchGdeltCountryEvents,
   pace = sleep,
+  now = Date.now,
 } = {}) {
   const events = [];
   const failedCountries = [];
   let successfulCountries = 0;
   const CONCURRENCY = 4; // bound the run window (20 countries × proxy retries)
+  const budgetSpentAt = now() + GDELT_SWEEP_BUDGET_MS;
   for (let i = 0; i < CONFLICT_COUNTRIES.length; i += CONCURRENCY) {
-    const batch = CONFLICT_COUNTRIES.slice(i, i + CONCURRENCY);
+    // #5140: stop LAUNCHING batches once the budget is spent or the floor can no
+    // longer be reached — either way the caller degrades to aux-only and exits 0,
+    // instead of grinding retries into the fetch-phase deadline (exit 75).
+    const remaining = CONFLICT_COUNTRIES.slice(i);
+    const overBudget = now() >= budgetSpentAt;
+    const floorUnreachable = successfulCountries + remaining.length < GDELT_MIN_SUCCESSFUL_COUNTRIES;
+    if (overBudget || floorUnreachable) {
+      const why = overBudget ? 'sweep budget exhausted' : 'coverage floor unreachable';
+      for (const cc of remaining) failedCountries.push({ country: cc, error: why });
+      console.warn(`  [GDELT] conflict sweep stopped early (${why}) with ${i}/${CONFLICT_COUNTRIES.length} countries attempted`);
+      break;
+    }
+    const batch = remaining.slice(0, CONCURRENCY);
     const results = await Promise.all(batch.map(cc => fetchCountryEvents(cc)));
     for (const result of results) {
       if (result?.ok) {

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -41,13 +41,30 @@ const CONFLICT_COUNTRIES = [
   'IQ', 'PS', 'LY', 'ML', 'BF', 'NE', 'NG', 'CM', 'MZ', 'HT',
 ];
 export const GDELT_MIN_SUCCESSFUL_COUNTRIES = Math.ceil(CONFLICT_COUNTRIES.length * 0.8);
-// #5140: wall-clock budget for the whole GDELT fallback sweep. The sweep's worst
-// case must fit runSeed's 240s fetch deadline AFTER the aux Promise.allSettled
-// (~≤60s) and with one in-flight batch allowed to drain past the budget check
-// (~92s OBSERVED for a full-timeout batch at the fetch knobs below — retry math
-// says 75s, curl/DNS overheads add ~17s): 60s + 75s + 95s = 230s ≤ 240s. Without
-// this cap a GDELT brownout ran 5 batches ≈ 375s → deadline breach → exit 75 every tick.
-export const GDELT_SWEEP_BUDGET_MS = 75_000;
+// #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
+// fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
+// an absolute deadline down, so slow aux feeds — HAPI is sequential, ~306s worst —
+// automatically shrink the sweep window instead of stacking on top of it). One
+// in-flight batch may still drain past the cutoff: ≤~100s at the knobs below
+// (15s concurrent direct legs + 4 × 20s SERIALIZED sync proxy curls — curlFetch is
+// execFileSync, so "concurrent" proxy attempts block the event loop one at a time;
+// 92s observed live 2026-07-10). Worst single fetchAll attempt ≈
+// max(HAPI 306s, 120s + 100s) + extra-key writes ≈ ~350s, inside both the 360s
+// lock below and the 480s fetch deadline (lockTtl + margin). Without this cap a
+// GDELT brownout ran 5 batches ≈ 375s+ → deadline breach → exit 75 every tick.
+export const GDELT_SWEEP_BUDGET_MS = 120_000;
+// maxRetries: 0 — a second direct attempt would honor GDELT's Retry-After header
+// (≤60s sleep, _gdelt-fetch.mjs MAX_RETRY_AFTER_MS), blowing any per-batch bound;
+// the proxy leg (IP-rotating) is the designed 429 answer, not a same-IP retry.
+// proxyMaxAttempts: 1 — proxy curls are synchronous (execFileSync, ≤20s each) and
+// serialize across the whole batch: each extra attempt adds 4 × 20s of worst case.
+export const GDELT_COUNTRY_FETCH_OPTS = Object.freeze({ maxRetries: 0, proxyMaxAttempts: 1 });
+// Lock must outlive the worst legitimate run (runSeed's documented invariant —
+// _seed-utils.mjs: "a healthy seeder is designed never to outlive its own lock");
+// it also sets the fetch deadline (lockTtlMs + 120s margin = 480s). The default
+// 120s lock was ALREADY shorter than this seeder's worst case. Cron cadence is
+// 30min, so a hard-crashed run's dangling lock costs at most 6 of those minutes.
+export const ACLED_INTEL_LOCK_TTL_MS = 360_000;
 
 const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
 
@@ -207,7 +224,7 @@ export async function fetchGdeltCountryEvents(cc) {
   let data;
   try {
     // Runs 20× per cycle — keep each call cheap so the whole sweep fits the run window.
-    data = await fetchGdeltJson(buildGdeltConflictUrl(cc), { label: `conflict:${cc}`, maxRetries: 1, proxyMaxAttempts: 2 });
+    data = await fetchGdeltJson(buildGdeltConflictUrl(cc), { label: `conflict:${cc}`, ...GDELT_COUNTRY_FETCH_OPTS });
   } catch (e) {
     console.warn(`  GDELT ${cc}: ${e.message}`);
     return { country: cc, ok: false, events: [], error: e.message || String(e) };
@@ -219,21 +236,23 @@ export async function fetchGdeltConflictEvents({
   fetchCountryEvents = fetchGdeltCountryEvents,
   pace = sleep,
   now = Date.now,
+  deadlineAt,
 } = {}) {
   const events = [];
   const failedCountries = [];
   let successfulCountries = 0;
   const CONCURRENCY = 4; // bound the run window (20 countries × proxy retries)
-  const budgetSpentAt = now() + GDELT_SWEEP_BUDGET_MS;
+  const launchCutoffAt = deadlineAt ?? now() + GDELT_SWEEP_BUDGET_MS;
   for (let i = 0; i < CONFLICT_COUNTRIES.length; i += CONCURRENCY) {
-    // #5140: stop LAUNCHING batches once the budget is spent or the floor can no
-    // longer be reached — either way the caller degrades to aux-only and exits 0,
+    // #5140: stop LAUNCHING batches once the phase cutoff passes or the floor can
+    // no longer be reached — either way the caller degrades to aux-only and exits 0,
     // instead of grinding retries into the fetch-phase deadline (exit 75).
     const remaining = CONFLICT_COUNTRIES.slice(i);
-    const overBudget = now() >= budgetSpentAt;
+    const overBudget = now() >= launchCutoffAt;
     const floorUnreachable = successfulCountries + remaining.length < GDELT_MIN_SUCCESSFUL_COUNTRIES;
     if (overBudget || floorUnreachable) {
-      const why = overBudget ? 'sweep budget exhausted' : 'coverage floor unreachable';
+      const why = [overBudget && 'sweep budget exhausted', floorUnreachable && 'coverage floor unreachable']
+        .filter(Boolean).join(' + ');
       for (const cc of remaining) failedCountries.push({ country: cc, error: why });
       console.warn(`  [GDELT] conflict sweep stopped early (${why}) with ${i}/${CONFLICT_COUNTRIES.length} countries attempted`);
       break;
@@ -403,6 +422,11 @@ async function fetchGdeltTensions() {
 // ─── Main ───
 
 async function fetchAll() {
+  // #5140: anchor the GDELT-fallback sweep cutoff at the START of the fetch phase,
+  // not at sweep entry — the aux feeds below (HAPI is sequential, ~306s worst) and
+  // the sweep share runSeed's single fetch deadline, so time the aux stage burns
+  // must come out of the sweep's window, not be added to it.
+  const sweepDeadlineAt = Date.now() + GDELT_SWEEP_BUDGET_MS;
   const [acled, acledResolution, hapi, pizzint, gdelt] = await Promise.allSettled([
     fetchAcledEvents({ label: 'ACLED display' }),
     fetchAcledEvents({
@@ -457,7 +481,7 @@ async function fetchAll() {
       // on the no-creds path: a credentialed-but-failed fetch still throws below, and a
       // credentialed-but-empty ACLED result is trusted (returns `ac`) rather than
       // overwritten by GDELT volume.
-      const gdeltEvents = await fetchGdeltConflictEvents().catch((e) => {
+      const gdeltEvents = await fetchGdeltConflictEvents({ deadlineAt: sweepDeadlineAt }).catch((e) => {
         console.warn(`  GDELT conflict-events fallback failed: ${e.message}`);
         return null;
       });
@@ -487,6 +511,7 @@ export function declareRecords(data) {
 if (process.argv[1]?.endsWith('seed-conflict-intel.mjs')) {
   runSeed('conflict', 'acled-intel', ACLED_CACHE_KEY, fetchAll, {
     validateFn: validate,
+    lockTtlMs: ACLED_INTEL_LOCK_TTL_MS,
     ttlSeconds: ACLED_TTL,
     sourceVersion: 'acled-hapi-pizzint',
     declareRecords,

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -10,7 +10,6 @@ import { computeEmaWindows } from '../scripts/_ema-threat-engine.mjs';
 import {
   fetchGdeltConflictEvents,
   GDELT_MIN_SUCCESSFUL_COUNTRIES,
-  GDELT_SWEEP_BUDGET_MS,
 } from '../scripts/seed-conflict-intel.mjs';
 
 test('gdeltSeenDateToIso parses GDELT seendate formats to YYYY-MM-DD', () => {
@@ -110,18 +109,20 @@ test('fetchGdeltConflictEvents treats successful zero-article countries as cover
   assert.equal(result.pagination.countriesFailed, 0);
 });
 
-// #5140: the sweep's worst case (20 countries × ~75s of direct+proxy retries ÷ 4
-// concurrency ≈ 375s) exceeded runSeed's 240s fetch deadline, so a GDELT brownout
+// #5140: the sweep's worst case (20 countries × direct+proxy retries ÷ 4
+// concurrency ≈ 375s+) exceeded runSeed's fetch deadline, so a GDELT brownout
 // crashed the seeder (exit 75) instead of reaching the caught coverage-floor →
-// aux-only → exit 0 path. The sweep must stop launching batches once its wall-clock
-// budget is spent, regardless of per-country outcome.
-test('fetchGdeltConflictEvents stops launching batches once the sweep budget is spent (#5140)', async () => {
+// aux-only → exit 0 path. The sweep must stop launching batches once its
+// launch cutoff passes, regardless of per-country outcome. (The deadline
+// arithmetic itself is pinned in seed-fetch-deadline-budget-invariants.test.mjs.)
+test('fetchGdeltConflictEvents stops launching batches once the launch cutoff passes (#5140)', async () => {
   let calls = 0;
   let fakeTime = 0;
   await assert.rejects(
     fetchGdeltConflictEvents({
       pace: async () => {},
       now: () => fakeTime,
+      deadlineAt: 75_000,
       fetchCountryEvents: async (cc) => {
         calls += 1;
         // Each batch of 4 consumes 40s of fake wall clock — a degraded-GDELT batch.
@@ -131,9 +132,28 @@ test('fetchGdeltConflictEvents stops launching batches once the sweep budget is 
     }),
     /coverage below floor.*sweep budget exhausted/s,
   );
-  // Budget 75s: batch 1 ends at 40s (< 75s → batch 2 launches), batch 2 ends at
-  // 80s (≥ 75s → stop). Only 8 of 20 countries may be attempted.
+  // Cutoff at 75s: batch 1 ends at 40s (< 75s → batch 2 launches), batch 2 ends
+  // at 80s (≥ 75s → stop). Only 8 of 20 countries may be attempted.
   assert.equal(calls, 8);
+});
+
+test('fetchGdeltConflictEvents launches nothing when the phase cutoff already passed at entry (#5140)', async () => {
+  // fetchAll anchors deadlineAt at fetch-phase START; if slow aux feeds (HAPI is
+  // sequential, ~306s worst) consume the window first, the sweep must not add a
+  // single batch on top — it degrades instantly to the caught floor throw.
+  let calls = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      deadlineAt: Date.now() - 1,
+      fetchCountryEvents: async (cc) => {
+        calls += 1;
+        return { country: cc, ok: true, events: [] };
+      },
+    }),
+    /coverage below floor: 0\/20/,
+  );
+  assert.equal(calls, 0);
 });
 
 test('fetchGdeltConflictEvents stops sweeping once the coverage floor is unreachable (#5140)', async () => {
@@ -152,17 +172,32 @@ test('fetchGdeltConflictEvents stops sweeping once the coverage floor is unreach
   assert.equal(calls, 8);
 });
 
-test('GDELT sweep budget + one in-flight batch fits the 240s fetch deadline with aux headroom (#5140)', () => {
-  // Per-country worst case at the seed's knobs (maxRetries:1, proxyMaxAttempts:2,
-  // 15s timeouts, 10s direct backoff, 5s proxy backoff) is 75s by retry math, but
-  // a full-timeout batch measured ~92s live (curl/DNS overheads) — use 95s. A batch
-  // launched at the budget edge may still run that long past it, and the aux
-  // allSettled that precedes the sweep needs headroom inside the same fetch phase.
-  const WORST_IN_FLIGHT_BATCH_MS = 95_000;
-  const AUX_ALLSETTLED_HEADROOM_MS = 60_000;
-  const FETCH_DEADLINE_MS = 240_000;
+test('early-stop reason names BOTH conditions when budget and floor trip together (#5140)', async (t) => {
+  const warns = [];
+  t.mock.method(console, 'warn', (...args) => { warns.push(args.join(' ')); });
+  let calls = 0;
+  let fakeTime = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      now: () => fakeTime,
+      deadlineAt: 115_000,
+      fetchCountryEvents: async (cc) => {
+        calls += 1;
+        fakeTime += 10_000;
+        // Batch 1 succeeds; later batches fail → the floor drifts out of reach
+        // while the clock runs out, so both stop conditions hold at once.
+        return calls <= 4
+          ? { country: cc, ok: true, events: [] }
+          : { country: cc, ok: false, events: [], error: 'down' };
+      },
+    }),
+    /coverage below floor/,
+  );
+  // Before batch 4: clock 120s ≥ 115s cutoff AND 4 successes + 8 remaining < 16.
+  assert.equal(calls, 12);
   assert.ok(
-    GDELT_SWEEP_BUDGET_MS + WORST_IN_FLIGHT_BATCH_MS + AUX_ALLSETTLED_HEADROOM_MS <= FETCH_DEADLINE_MS,
-    `sweep budget ${GDELT_SWEEP_BUDGET_MS}ms leaves no headroom under the ${FETCH_DEADLINE_MS}ms fetch deadline`,
+    warns.some((w) => w.includes('sweep budget exhausted + coverage floor unreachable')),
+    `expected combined stop reason in warns: ${warns.join(' | ')}`,
   );
 });

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -10,6 +10,7 @@ import { computeEmaWindows } from '../scripts/_ema-threat-engine.mjs';
 import {
   fetchGdeltConflictEvents,
   GDELT_MIN_SUCCESSFUL_COUNTRIES,
+  GDELT_SWEEP_BUDGET_MS,
 } from '../scripts/seed-conflict-intel.mjs';
 
 test('gdeltSeenDateToIso parses GDELT seendate formats to YYYY-MM-DD', () => {
@@ -107,4 +108,61 @@ test('fetchGdeltConflictEvents treats successful zero-article countries as cover
   assert.equal(result.events.length, 0);
   assert.equal(result.pagination.countriesSucceeded, 20);
   assert.equal(result.pagination.countriesFailed, 0);
+});
+
+// #5140: the sweep's worst case (20 countries × ~75s of direct+proxy retries ÷ 4
+// concurrency ≈ 375s) exceeded runSeed's 240s fetch deadline, so a GDELT brownout
+// crashed the seeder (exit 75) instead of reaching the caught coverage-floor →
+// aux-only → exit 0 path. The sweep must stop launching batches once its wall-clock
+// budget is spent, regardless of per-country outcome.
+test('fetchGdeltConflictEvents stops launching batches once the sweep budget is spent (#5140)', async () => {
+  let calls = 0;
+  let fakeTime = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      now: () => fakeTime,
+      fetchCountryEvents: async (cc) => {
+        calls += 1;
+        // Each batch of 4 consumes 40s of fake wall clock — a degraded-GDELT batch.
+        fakeTime += 40_000 / 4;
+        return { country: cc, ok: true, events: [] };
+      },
+    }),
+    /coverage below floor.*sweep budget exhausted/s,
+  );
+  // Budget 75s: batch 1 ends at 40s (< 75s → batch 2 launches), batch 2 ends at
+  // 80s (≥ 75s → stop). Only 8 of 20 countries may be attempted.
+  assert.equal(calls, 8);
+});
+
+test('fetchGdeltConflictEvents stops sweeping once the coverage floor is unreachable (#5140)', async () => {
+  let calls = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      fetchCountryEvents: async (cc) => {
+        calls += 1;
+        return { country: cc, ok: false, events: [], error: 'proxy unavailable' };
+      },
+    }),
+    /coverage below floor/,
+  );
+  // After 2 all-failed batches: 0 successes + 12 remaining < 16 floor → no third batch.
+  assert.equal(calls, 8);
+});
+
+test('GDELT sweep budget + one in-flight batch fits the 240s fetch deadline with aux headroom (#5140)', () => {
+  // Per-country worst case at the seed's knobs (maxRetries:1, proxyMaxAttempts:2,
+  // 15s timeouts, 10s direct backoff, 5s proxy backoff) is 75s by retry math, but
+  // a full-timeout batch measured ~92s live (curl/DNS overheads) — use 95s. A batch
+  // launched at the budget edge may still run that long past it, and the aux
+  // allSettled that precedes the sweep needs headroom inside the same fetch phase.
+  const WORST_IN_FLIGHT_BATCH_MS = 95_000;
+  const AUX_ALLSETTLED_HEADROOM_MS = 60_000;
+  const FETCH_DEADLINE_MS = 240_000;
+  assert.ok(
+    GDELT_SWEEP_BUDGET_MS + WORST_IN_FLIGHT_BATCH_MS + AUX_ALLSETTLED_HEADROOM_MS <= FETCH_DEADLINE_MS,
+    `sweep budget ${GDELT_SWEEP_BUDGET_MS}ms leaves no headroom under the ${FETCH_DEADLINE_MS}ms fetch deadline`,
+  );
 });

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -57,4 +57,50 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
     assert.ok(lock, 'supply-chain runSeed must set lockTtlMs (WTO reporter scan far exceeds the 240s default)');
     assert.ok(deadlineFromLock(lock) >= 600_000, `deadline ${deadlineFromLock(lock)}ms must clear the ~10min WTO design budget`);
   });
+
+  it('conflict-intel: GDELT fallback sweep worst case fits its lock and deadline (issue #5140)', async () => {
+    // seed-conflict-intel is import-safe (runSeed is argv-guarded), so unlike the
+    // seeders above we assert against its real exported constants, not source text.
+    const {
+      GDELT_SWEEP_BUDGET_MS,
+      GDELT_COUNTRY_FETCH_OPTS,
+      ACLED_INTEL_LOCK_TTL_MS,
+    } = await import('../scripts/seed-conflict-intel.mjs');
+
+    // maxRetries MUST stay 0: a second direct attempt honors GDELT's Retry-After
+    // header (≤60s sleep, MAX_RETRY_AFTER_MS in _gdelt-fetch.mjs), voiding any
+    // per-batch bound computed below.
+    assert.equal(GDELT_COUNTRY_FETCH_OPTS.maxRetries, 0,
+      'direct retries reintroduce the ≤60s Retry-After sleep into the batch bound');
+
+    // Worst in-flight batch: 4 concurrent direct legs (15s AbortSignal timeout,
+    // _gdelt-fetch.mjs default) + CONCURRENCY × proxyMaxAttempts SERIALIZED sync
+    // proxy curls (curlFetch is execFileSync with a 20s ceiling — proxy attempts
+    // block the event loop one at a time, so they sum across the whole batch).
+    const DIRECT_LEG_MS = 15_000;
+    const PROXY_CURL_CEILING_MS = 20_000;
+    const SWEEP_CONCURRENCY = 4;
+    const worstBatch = DIRECT_LEG_MS
+      + SWEEP_CONCURRENCY * GDELT_COUNTRY_FETCH_OPTS.proxyMaxAttempts * PROXY_CURL_CEILING_MS;
+
+    // HAPI aux worst: 20 sequential countries × (15s timeout + 300ms pace). It
+    // precedes the sweep inside the same fetch phase, and the sweep cutoff is
+    // anchored at phase START — so the two occupy the same window (max), they
+    // do not stack (sum).
+    const HAPI_WORST_MS = 20 * (15_000 + 300);
+    const EXTRA_KEY_WRITE_SLACK_MS = 30_000;
+    const worstFetchAttempt = Math.max(HAPI_WORST_MS, GDELT_SWEEP_BUDGET_MS + worstBatch)
+      + EXTRA_KEY_WRITE_SLACK_MS;
+
+    // runSeed invariant: a healthy seeder never outlives its own lock…
+    assert.ok(worstFetchAttempt <= ACLED_INTEL_LOCK_TTL_MS,
+      `worst fetch attempt ${worstFetchAttempt}ms must fit the ${ACLED_INTEL_LOCK_TTL_MS}ms lock`);
+    // …and the lock-derived deadline (lock + 120s margin) then clears it a fortiori.
+    assert.ok(worstFetchAttempt <= deadlineFromLock(ACLED_INTEL_LOCK_TTL_MS),
+      `worst fetch attempt ${worstFetchAttempt}ms must fit the ${deadlineFromLock(ACLED_INTEL_LOCK_TTL_MS)}ms fetch deadline`);
+    // The runSeed call must actually wire the exported lock value.
+    const src = read('seed-conflict-intel.mjs');
+    assert.ok(/lockTtlMs:\s*ACLED_INTEL_LOCK_TTL_MS/.test(src),
+      'runSeed must pass lockTtlMs: ACLED_INTEL_LOCK_TTL_MS');
+  });
 });


### PR DESCRIPTION
Fixes #5140.

## Problem

Since #5134 deployed (2026-07-09 19:25 UTC), `seed-conflict-intel` crashed on ~6 of 7 cron ticks. The GDELT fallback sweeps 20 countries at concurrency 4; a full-brownout sweep (~375s+) breaches runSeed's fetch deadline → `FETCH FAILED` → exit 75 → Railway "Crashed" every ~30 min. GDELT is currently rejecting Railway egress (resets/429s) and killing Decodo TLS handshakes (`SSL_ERROR_SYSCALL`). The existing caught coverage-floor → aux-only → exit 0 path was unreachable in time.

## Fix (commit 1 + adversarial-review hardening in commit 2)

**Sweep guards** — checked before each batch launch, both landing in the caught floor throw → aux-only publish → exit 0:

1. **Phase-anchored launch cutoff** (`GDELT_SWEEP_BUDGET_MS = 120s`): `fetchAll` anchors the clock at fetch-phase START and passes an absolute `deadlineAt` down, so slow aux feeds (HAPI is sequential, ~306s worst) shrink the sweep window instead of stacking on top of it.
2. **Floor-unreachable breaker**: stop when `successes + remaining < 16` — a total brownout stops after 2 batches. When both trip together the stop reason names both (Greptile).

**Worst-case bounds made real** (adversarial review found the original arithmetic broken by four confirmed mechanisms):

3. `maxRetries: 1 → 0` — a second direct attempt honors GDELT's `Retry-After` (≤60s sleep, `MAX_RETRY_AFTER_MS`), voiding any batch bound; the IP-rotating proxy is the designed 429 answer.
4. `proxyMaxAttempts: 2 → 1` — `curlFetch` is `execFileSync` (sync, ≤20s): proxy attempts SERIALIZE across the batch, so each attempt adds 4×20s of worst case. Worst batch is now 15s + 4×20s ≈ 95s (92s observed live).
5. `lockTtlMs: 120s → 360s` (per the #4864 precedent, same failure class): worst single fetch attempt ≈ max(HAPI 306s, cutoff 120s + batch 95s) + writes ≈ 336s fits the lock — restoring runSeed's documented "a healthy seeder never outlives its own lock" invariant (a ~230s run against a 120s lock violated it) — and the deadline becomes lockTtl + 120s margin = **480s**, replacing a 10s knife-edge with real margin. Cron is 30min, so a dangling lock costs ≤6 of those minutes.

**Known residual (accepted):** runSeed wraps `fetchAll` in `withRetry(3)` inside ONE shared deadline (fleet-wide, pre-existing), so a transient mid-fetch rejection (e.g. Redis hiccup during extra-key writes) that forces a second full attempt can still overrun in a pathological double-brownout — that yields a one-off graceful exit 75 (self-heals), not the chronic per-tick crash this PR eliminates.

## Verification

- **Failing tests first**: behavior tests failed on the unfixed logic (20 launches vs 8), pass after. `tests/conflict-gdelt.test.mjs`: cutoff stop, zero-launch when aux ate the phase, floor breaker, combined stop reason — 14/14.
- **Deadline contract** moved to `tests/seed-fetch-deadline-budget-invariants.test.mjs` (the #4864 home for this class), deriving from the seeder's exported constants (`GDELT_SWEEP_BUDGET_MS`, `GDELT_COUNTRY_FETCH_OPTS`, `ACLED_INTEL_LOCK_TTL_MS`) instead of literal-vs-literal, and pinning `maxRetries === 0` + the lock-invariant inequality + that `runSeed` actually wires the lock const.
- **Live probes during the actual brownout** (read-only): commit-1 knobs rejected in 92s (budget path); commit-2 knobs rejected in **76s** (floor-unreachable after 2 batches) → aux-only exit 0. Before the fix: 244s+ crash.
- Sibling suites green (`acled-resolution-feed-seed` 7/7, `forecast-resolution-eval` 24/24, invariants 4/4). Biome clean.

## Notes

- Stops the crash storm; cannot populate `acledIntel` during a brownout — the durable fix remains provisioning real `ACLED_*` creds (#5140 closing note).
- Post-merge: verify the next tick logs `Done` or the early-stop marker instead of `FETCH FAILED` (service redeploy lagged ~1h on #5126 — `railway up` unblocks).

https://claude.ai/code/session_01LnV7XZ3FuoxC8MuD3gA2UU
