### PR TITLE
fix(forecast): reclassify unrest count specs to judged (#5091)

### DIFF
--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -192,6 +192,14 @@ export const CONFLICT_ESCALATION_RATIO = 1.5;
 // mis-resolve. Flip to true — and confirm the feed is actually seeded — to
 // re-enable hard-count resolution; the threshold logic below is preserved.
 export const CONFLICT_COUNT_FEED_AVAILABLE = false;
+
+// UNREST_COUNT_SOURCE_FEED (unrest:events-resolution:v1) has the identical
+// problem (#5091): seed-unrest-events only writes it from an ACLED resolution
+// fetch (seed-unrest-events.mjs), which is empty without ACLED credentials, so
+// unrest count specs are unresolvable. Same treatment as conflict — route to
+// judged until a populated event-count feed exists. Flip to true once the feed
+// is actually seeded; the threshold logic below is preserved.
+export const UNREST_COUNT_FEED_AVAILABLE = false;
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 // FAMILY_FEED / FAMILY_WINDOW map each hard family to its default sourceFeed
@@ -416,6 +424,11 @@ function deriveHardMetrics(pred, family, inputs, options = {}) {
       };
     }
     case 'unrest': {
+      // #5091: unrest:events-resolution:v1 is empty without ACLED credentials
+      // (same root cause as conflict, #5136) → route to judged. The
+      // `unrestCountFeedAvailable` override forces the hard path for the tests
+      // that lock the preserved threshold logic.
+      if (!(options.unrestCountFeedAvailable ?? UNREST_COUNT_FEED_AVAILABLE)) return null;
       const tally = firstFiniteSignalCount(pred, new Set(['unrest_events']));
       if (!Number.isFinite(tally)) return null;
       const horizonMs = HORIZON_MS[pred.timeHorizon];
@@ -533,11 +546,14 @@ function buildQuestion(pred) {
   const region = pred.region || 'unspecified region';
   const domain = pred.domain || 'unspecified domain';
   const horizon = pred.timeHorizon || 'unspecified horizon';
-  // Conflict forecasts are now judged (#5136). A sharper, escalation-framed
-  // question resolves more reliably against the news archive than the generic
-  // "resolve YES" phrasing.
+  // Conflict (#5136) and unrest/political (#5091) forecasts are now judged. A
+  // sharper, escalation-framed question resolves more reliably against the news
+  // archive than the generic "resolve YES" phrasing.
   if (domain === 'conflict') {
     return `Within the ${horizon} horizon, did ${region} experience a materially escalated level of armed conflict versus its recent baseline, consistent with "${title}"?`;
+  }
+  if (domain === 'political') {
+    return `Within the ${horizon} horizon, did ${region} experience a materially elevated level of civil unrest or political instability versus its recent baseline, consistent with "${title}"?`;
   }
   return `Will "${title}" (${domain}, ${region}) resolve YES within its ${horizon} horizon?`;
 }

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -18,7 +18,7 @@ import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
 import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
-import { CONFLICT_COUNT_FEED_AVAILABLE, CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
+import { CONFLICT_COUNT_FEED_AVAILABLE, UNREST_COUNT_FEED_AVAILABLE, CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
 import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
 import { callForecastLLM } from './seed-forecasts.mjs';
 
@@ -770,14 +770,26 @@ function migratePendingCountFeedKeys(ledger) {
         entry.spec.metricKey = `${replacement}|${entry.spec.metricKey.slice(parsed.feedKey.length + 1)}`;
       }
     }
-    migratePendingConflictCountEntryToJudged(entry);
+    migratePendingCountEntryToJudged(entry);
   }
 }
 
-function migratePendingConflictCountEntryToJudged(entry) {
-  if (CONFLICT_COUNT_FEED_AVAILABLE) return;
+// Families whose count-resolution feed is unavailable (empty without ACLED
+// credentials) — existing pending hard-count ledger entries are reclassified to
+// judged so they resolve via the LLM judge instead of pending/VOID forever.
+// Mirrors the generator-side flag gates in _forecast-resolution.mjs.
+// #5136 (conflict), #5091 (unrest).
+const UNAVAILABLE_COUNT_FEED_MIGRATIONS = [
+  { feed: CONFLICT_COUNT_SOURCE_FEED, available: () => CONFLICT_COUNT_FEED_AVAILABLE, buildQuestion: buildConflictJudgedQuestionForEntry },
+  { feed: UNREST_COUNT_SOURCE_FEED, available: () => UNREST_COUNT_FEED_AVAILABLE, buildQuestion: buildUnrestJudgedQuestionForEntry },
+];
+
+function migratePendingCountEntryToJudged(entry) {
   if (entry?.status !== 'pending' || entry.spec?.kind !== 'hard') return;
-  if (entry.spec.sourceFeed !== CONFLICT_COUNT_SOURCE_FEED) return;
+  const migration = UNAVAILABLE_COUNT_FEED_MIGRATIONS.find(
+    (m) => m.feed === entry.spec.sourceFeed && !m.available(),
+  );
+  if (!migration) return;
   const parsed = parseMetricKey(entry.spec.metricKey);
   if (parsed?.fn !== 'count') return;
 
@@ -791,7 +803,7 @@ function migratePendingConflictCountEntryToJudged(entry) {
     window: null,
     deadline: deadline ?? entry.spec.deadline,
     sourceFeed: null,
-    question: buildConflictJudgedQuestionForEntry(entry),
+    question: migration.buildQuestion(entry),
   };
   entry.status = 'pending-judge';
   entry.samples = { count: 0, recent: [] };
@@ -802,6 +814,13 @@ function buildConflictJudgedQuestionForEntry(entry) {
   const region = entry.region || 'unspecified region';
   const horizon = entry.timeHorizon || 'unspecified horizon';
   return `Within the ${horizon} horizon, did ${region} experience a materially escalated level of armed conflict versus its recent baseline, consistent with "${title}"?`;
+}
+
+function buildUnrestJudgedQuestionForEntry(entry) {
+  const title = entry.title || '(untitled forecast)';
+  const region = entry.region || 'unspecified region';
+  const horizon = entry.timeHorizon || 'unspecified horizon';
+  return `Within the ${horizon} horizon, did ${region} experience a materially elevated level of civil unrest or political instability versus its recent baseline, consistent with "${title}"?`;
 }
 
 export function samplePendingEntries(ledger, feedsByKey, nowMs) {

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -906,6 +906,20 @@ describe('#5010 amendment — resolvable windows + horizon-commensurable count',
     assert.notEqual(month.threshold, 175);
     assert.equal(CONFLICT_ESCALATION_RATIO, 1.5);
   });
+
+  it('the unrest count threshold scales with the horizon when the feed is available', () => {
+    const mk = (horizon) => buildResolutionSpec(pred({
+      domain: 'political', region: 'Venezuela', timeHorizon: horizon,
+      signals: [{ type: 'unrest_events', value: '20 unrest events', weight: 0.5 }],
+    }), {}, GENERATED_AT, { unrestCountFeedAvailable: true });
+    const day = mk('24h');
+    const month = mk('30d');
+    // 20 events/30d: 24h -> max(1, round(20 x 1/30 x 0.75)) = 1;
+    // 30d -> max(1, round(20 x 30/30 x 0.75)) = 15. Never the raw tally.
+    assert.equal(day.threshold, 1);
+    assert.equal(month.threshold, 15);
+    assert.notEqual(month.threshold, 20);
+  });
 });
 
 describe('FIX 6 — prediction_market baseline is percent-anchored', () => {

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -145,9 +145,20 @@ describe('buildResolutionSpec — conflict is judged (#5136)', () => {
     assert.match(spec.question, /30d/);
   });
 
-  it('the reclassification is scoped — unrest (political domain) still emits a hard spec', () => {
+  it('unrest is also judged by default (#5091 — same empty-feed root cause as conflict)', () => {
     const spec = buildResolutionSpec(
       pred({ domain: 'political', region: 'Kenya', timeHorizon: '7d', signals: [{ type: 'unrest_events', value: '20 unrest events', weight: 0.5 }] }),
+      {},
+      GENERATED_AT,
+    );
+    assert.equal(spec.kind, 'judged');
+    assert.match(spec.question, /Kenya/);
+    assert.match(spec.question, /unrest|instability/i);
+  });
+
+  it('the reclassification is scoped — cyber (populated feed) still emits a hard spec', () => {
+    const spec = buildResolutionSpec(
+      pred({ domain: 'cyber', region: 'Estonia', timeHorizon: '7d', signals: [{ type: 'cyber', value: '10 threats (malware)', weight: 0.5 }] }),
       {},
       GENERATED_AT,
     );
@@ -262,7 +273,7 @@ describe('buildResolutionSpec — feed mapping per family', () => {
     assert.notEqual(spec.sourceFeed, 'conflict:acled:v1:all:0:0');
   });
 
-  it('a political unrest-events forecast resolves to the unrest count feed', () => {
+  it('a political unrest-events forecast resolves to the unrest count feed (when the feed is available)', () => {
     const forecast = pred({
       domain: 'political',
       region: 'Venezuela',
@@ -272,7 +283,8 @@ describe('buildResolutionSpec — feed mapping per family', () => {
         { type: 'unrest_events', value: '4 unrest events in Venezuela', weight: 0.3 },
       ],
     });
-    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT);
+    // unrest is judged by default (#5091); force the hard path to assert the feed mapping.
+    const spec = buildResolutionSpec(forecast, {}, GENERATED_AT, { unrestCountFeedAvailable: true });
     assert.equal(spec.kind, 'hard');
     assert.equal(spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
     assert.equal(UNREST_COUNT_SOURCE_FEED, 'unrest:events-resolution:v1');
@@ -552,9 +564,9 @@ describe('R4 — sourceFeed membership over every hard fixture', () => {
     for (const forecast of fixtures) {
       // COMMODITY_INPUTS supplies the commodities feed the market fixture
       // needs; a harmless superset for the other families (they don't read it).
-      // conflict is judged by default (#5136) — force the hard path so the
-      // conflict fixture still exercises the sourceFeed-membership invariant.
-      const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT, { conflictCountFeedAvailable: true });
+      // conflict (#5136) and unrest (#5091) are judged by default — force both
+      // hard so their fixtures still exercise the sourceFeed-membership invariant.
+      const spec = buildResolutionSpec(forecast, COMMODITY_INPUTS, GENERATED_AT, { conflictCountFeedAvailable: true, unrestCountFeedAvailable: true });
       assert.equal(spec.kind, 'hard', `expected fixture ${forecast.id} to resolve hard`);
       assert.ok(
         RESOLUTION_FEED_KEYS.has(spec.sourceFeed),

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -154,6 +154,17 @@ describe('buildResolutionSpec — conflict is judged (#5136)', () => {
     assert.equal(spec.kind, 'judged');
     assert.match(spec.question, /Kenya/);
     assert.match(spec.question, /unrest|instability/i);
+    assert.match(spec.question, /7d/); // horizon embedded in the question template
+  });
+
+  it('unrest with the feed forced available but no finite count signal still falls back to judged (tally-null guard)', () => {
+    const spec = buildResolutionSpec(
+      pred({ domain: 'political', region: 'Kenya', timeHorizon: '7d', signals: [{ type: 'unrest_events', value: 'unrest reported (no count)', weight: 0.5 }] }),
+      {},
+      GENERATED_AT,
+      { unrestCountFeedAvailable: true },
+    );
+    assert.equal(spec.kind, 'judged');
   });
 
   it('the reclassification is scoped — cyber (populated feed) still emits a hard spec', () => {

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -190,7 +190,7 @@ describe('processResolutionCycle', () => {
     assert.equal(receipts.length, 0);
   });
 
-  it('migrates already-open display count entries while moving ACLED conflict rows to judged', () => {
+  it('migrates already-open display count entries — conflict AND unrest rows move to judged (#5091)', () => {
     const deadline = T0 + DAY_MS;
     const oldLedger = {
       [`fc-mali@${deadline}`]: {
@@ -273,13 +273,18 @@ describe('processResolutionCycle', () => {
     assert.match(conflictRow.spec.question, /Mali/);
     assert.equal(conflictRow.outcome, undefined);
 
+    // unrest's resolution feed is empty without ACLED creds (#5091), so the
+    // display-key entry is remapped and then migrated to judged too — even when
+    // this test supplies fake feed data, migration is gated on the flag, not the data.
     const unrestRow = ledger[`fc-venezuela@${deadline}`];
-    assert.equal(unrestRow.spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
-    assert.equal(unrestRow.spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
-    assert.equal(unrestRow.status, 'resolved');
-    assert.equal(unrestRow.outcome, 'NO');
-    assert.equal(unrestRow.evidence.metricValue, 1);
-    assert.equal(receipts.length, 1);
+    assert.equal(unrestRow.status, 'pending-judge');
+    assert.equal(unrestRow.spec.kind, 'judged');
+    assert.equal(unrestRow.spec.sourceFeed, null);
+    assert.equal(unrestRow.spec.metricKey, null);
+    assert.match(unrestRow.spec.question, /Venezuela/);
+    assert.match(unrestRow.spec.question, /unrest|instability/i);
+    assert.equal(unrestRow.outcome, undefined);
+    assert.equal(receipts.length, 0);
   });
 
   it('migrates old-key count specs first ingested from history snapshots', () => {
@@ -339,11 +344,13 @@ describe('processResolutionCycle', () => {
     assert.equal(ledger[`fc-mali@${deadline}`].spec.sourceFeed, null);
     assert.equal(ledger[`fc-mali@${deadline}`].spec.metricKey, null);
     assert.match(ledger[`fc-mali@${deadline}`].spec.question, /Mali/);
-    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.sourceFeed, UNREST_COUNT_SOURCE_FEED);
-    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.metricKey, `${UNREST_COUNT_SOURCE_FEED}|count(country==Venezuela)`);
-    assert.equal(ledger[`fc-venezuela@${deadline}`].status, 'resolved');
-    assert.equal(ledger[`fc-venezuela@${deadline}`].outcome, 'NO');
-    assert.equal(receipts.length, 1);
+    // unrest migrates to judged too (#5091), regardless of any supplied feed data.
+    assert.equal(ledger[`fc-venezuela@${deadline}`].status, 'pending-judge');
+    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.kind, 'judged');
+    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.sourceFeed, null);
+    assert.equal(ledger[`fc-venezuela@${deadline}`].spec.metricKey, null);
+    assert.match(ledger[`fc-venezuela@${deadline}`].spec.question, /Venezuela/);
+    assert.equal(receipts.length, 0);
   });
 
   it('migrates persisted pending ACLED conflict rows to judged without rewriting resolved rows', () => {
@@ -428,6 +435,48 @@ describe('processResolutionCycle', () => {
     assert.equal(resolved.spec.sourceFeed, CONFLICT_COUNT_SOURCE_FEED);
     assert.equal(resolved.outcome, 'YES');
     assert.equal(receipts.length, 0);
+  });
+
+  it('migrates persisted pending unrest count rows to judged too (#5091 — empty unrest:events-resolution feed)', () => {
+    const deadline = T0 + DAY_MS;
+    const oldLedger = {
+      [`fc-unrest@${deadline}`]: {
+        id: 'fc-unrest',
+        key: `fc-unrest@${deadline}`,
+        domain: 'political',
+        region: 'Kenya',
+        title: 'Civil unrest in Kenya escalates',
+        timeHorizon: '7d',
+        generationOrigin: 'detector',
+        spec: {
+          kind: 'hard',
+          metricKey: `${UNREST_COUNT_SOURCE_FEED}|count(country==Kenya)`,
+          operator: '>=',
+          threshold: 3,
+          window: 'within-horizon',
+          deadline,
+          sourceFeed: UNREST_COUNT_SOURCE_FEED,
+        },
+        probability: 0.5,
+        firstSeenProbability: 0.5,
+        generatedAt: T0,
+        deadline,
+        firstSeenAt: T0,
+        lastSeenAt: T0,
+        status: 'pending',
+        samples: { count: 0, recent: [] },
+      },
+    };
+
+    const { ledger } = processResolutionCycle(oldLedger, [], {}, deadline + 3 * DAY_MS);
+    const migrated = ledger[`fc-unrest@${deadline}`];
+    assert.equal(migrated.status, 'pending-judge');
+    assert.equal(migrated.spec.kind, 'judged');
+    assert.equal(migrated.spec.sourceFeed, null);
+    assert.equal(migrated.spec.metricKey, null);
+    assert.equal(migrated.spec.deadline, deadline);
+    assert.match(migrated.spec.question, /Kenya/);
+    assert.match(migrated.spec.question, /unrest|instability/i);
   });
 
   it('does not resolve stale UCDP count snapshots to NO after the settlement lag', () => {


### PR DESCRIPTION
## Summary

The **twin of #5136/#5138**, folded into #5091. Unrest hard-count specs resolve against `unrest:events-resolution:v1`, which is **empty in prod** — `seed-unrest-events.mjs:460` only writes it from an **ACLED** resolution fetch (`if (acledResolution?.events?.length)`), and we have no ACLED credentials. So unrest counts were unresolvable (pending/VOID forever) while *inflating the nominal hard-ratio* — exactly the "hard % hides unresolvable specs" problem #5091 documents.

## What changed (`scripts/_forecast-resolution.mjs`)
- `deriveHardMetrics`: the `unrest` family `return null`s when the count feed is unavailable → `buildJudgedSpec` (LLM judge, live via #5087). Gated by a new `UNREST_COUNT_FEED_AVAILABLE` flag (default `false`) + an `unrestCountFeedAvailable` override; the horizon-scaled threshold logic is **preserved** for re-enable once a populated feed exists.
- `buildQuestion`: family-aware, instability-framed question for the `political` (unrest) domain, mirroring the conflict question.
- **Not** GDELT-for-count: article volume ≠ event count, so the thresholds would mis-resolve (same reason rejected for conflict).

## Tests
- Unrest now emits `judged` by default with an instability/region-anchored question.
- The `#5138` scoped-regression exemplar switched from unrest → **cyber** (a genuinely populated feed) so it still proves the change is scoped.
- The unrest feed-mapping + R4 fixtures force the feed-available path (preserves the threshold coverage).
- **404 forecast `.mjs` tests + 9 `.mts` green.**

## Note on impact (see #5091)
This lowers the *nominal* hard-ratio further (unrest leaves the hard column) but raises *resolvable* coverage — which is why #5091's KPI was reframed to "≥80% **resolvable** (populated-hard OR judged)." The open verification remains: confirm the judged resolver actually resolves these (not perpetual-pending on its 48h archive window, per the #5087 review) once #5138 + this deploy.

Related: #5091, #5136, #5138, #5087, #4930.

https://claude.ai/code/session_01StNurp4TGC3JLHbTtKJhbp
