### PR TITLE
fix(observability): filter Floot automation + DebugBear-wrapped fetch Sentry noise

### DIFF
--- a/src/bootstrap/debugbear-rum.ts
+++ b/src/bootstrap/debugbear-rum.ts
@@ -1,5 +1,6 @@
 export const DEBUGBEAR_RUM_SCRIPT_SRC = 'https://cdn.debugbear.com/lpMwA9KpC6pf.js';
 export const DEBUGBEAR_RUM_SAMPLE_RATE = 100;
+const DEBUGBEAR_RUM_SCRIPT_PATHNAME = new URL(DEBUGBEAR_RUM_SCRIPT_SRC).pathname;
 const DEBUGBEAR_RUM_HOSTS = new Set([
   'worldmonitor.app',
   'www.worldmonitor.app',
@@ -22,6 +23,11 @@ let debugBearRumStarted = false;
 
 export function shouldEnableDebugBearRum(hostname: string): boolean {
   return DEBUGBEAR_RUM_HOSTS.has(hostname.toLowerCase());
+}
+
+/** Identifies a Sentry frame emitted by the configured DebugBear collector. */
+export function isDebugBearRumScriptFrame(filename: string): boolean {
+  return filename.endsWith(DEBUGBEAR_RUM_SCRIPT_PATHNAME) || /debugbear/i.test(filename);
 }
 
 function loadDebugBearRumScript(): void {

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -6,7 +6,7 @@
  * entry chunk. Keep pre-init queuing in `sentry-defer.ts`; keep SDK setup here.
  */
 
-import { DEBUGBEAR_RUM_SCRIPT_SRC } from './debugbear-rum';
+import { isDebugBearRumScriptFrame } from './debugbear-rum';
 
 type SentryNs = typeof import('@sentry/browser');
 
@@ -42,20 +42,6 @@ const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set([
   // surface). WORLDMONITOR-RP.
   'data.debugbear.com',
 ]);
-
-// Frame-filename matcher for the DebugBear RUM collector script. Sentry attributes
-// the collector's window.fetch-monkeypatch frames to the script basename (e.g.
-// `/lpMwA9KpC6pf.js`). Derived from DEBUGBEAR_RUM_SCRIPT_SRC — the single source of
-// truth in debugbear-rum.ts — so a CDN/script-id rotation updates the beforeSend
-// bare-`Failed to fetch` gate in lockstep instead of silently failing open
-// (Greptile P2, #5143). Falls back to a host-only `debugbear` match if the URL ever
-// lacks a basename, so the matcher can never degrade into matching every frame.
-const DEBUGBEAR_RUM_COLLECTOR_FRAME = (() => {
-  const basename = DEBUGBEAR_RUM_SCRIPT_SRC.split('/').pop();
-  if (!basename) return /debugbear/i;
-  const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(?:^|/)${escaped}$|debugbear`, 'i');
-})();
 
 function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
@@ -553,7 +539,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // Bare `Failed to fetch` surfacing through the DebugBear RUM collector's
       // window.fetch monkeypatch. DebugBear (src/bootstrap/debugbear-rum.ts →
       // cdn.debugbear.com/<id>.js; Sentry attributes its frames to the script
-      // basename, e.g. `/lpMwA9KpC6pf.js`) wraps window.fetch to time it, so a
+      // configured script path) wraps window.fetch to time it, so a
       // transient network blip on ANY app fetch rejects and its wrapper
       // re-surfaces the rejection as an unhandled rejection, injecting its own
       // frames. Without DebugBear the identical failure is zero-frame and already
@@ -562,16 +548,18 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // (Vite code-split chunk names, e.g. panel-storage/widget-store, which do
       // not themselves fetch — grep-verified), NOT real callers. Suppress only
       // when a DebugBear collector frame is present AND every non-infra frame is
-      // either that collector or a bare `window.fetch`/`fetch` trampoline, so a
-      // genuine uncaught first-party fetch rejection (which carries a real
-      // function name) still surfaces. Mirrors the SG extension-wrapper gate
-      // above; the collector frame is matched via DEBUGBEAR_RUM_COLLECTOR_FRAME,
-      // derived from DEBUGBEAR_RUM_SCRIPT_SRC. WORLDMONITOR-VC (93ev/69u, 2026-07-04+).
+      // either that collector or the observed caller-free `window.fetch`/`fetch`
+      // trampolines from panel-storage/widget-store. Other first-party fetch
+      // wrappers (notably runtime.ts) must surface. Mirrors the SG
+      // extension-wrapper gate above; collector identity comes from
+      // DEBUGBEAR_RUM_SCRIPT_SRC via the shared predicate.
+      // WORLDMONITOR-VC (93ev/69u, 2026-07-04+).
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
-          && frames.some(f => DEBUGBEAR_RUM_COLLECTOR_FRAME.test(f.filename ?? ''))
+          && frames.some(f => isDebugBearRumScriptFrame(f.filename ?? ''))
           && nonInfraFrames.every(f =>
-            DEBUGBEAR_RUM_COLLECTOR_FRAME.test(f.filename ?? '')
-            || /^(?:window\.)?fetch$/.test(f.function ?? ''))) {
+            isDebugBearRumScriptFrame(f.filename ?? '')
+            || (/\/assets\/(?:panel-storage|widget-store)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? '')
+              && /^(?:window\.)?fetch$/.test(f.function ?? '')))) {
         return null;
       }
       // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -6,6 +6,8 @@
  * entry chunk. Keep pre-init queuing in `sentry-defer.ts`; keep SDK setup here.
  */
 
+import { DEBUGBEAR_RUM_SCRIPT_SRC } from './debugbear-rum';
+
 type SentryNs = typeof import('@sentry/browser');
 
 // Known third-party hosts fetched by MapLibre (tiles, styles, glyphs, sprites).
@@ -40,6 +42,20 @@ const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set([
   // surface). WORLDMONITOR-RP.
   'data.debugbear.com',
 ]);
+
+// Frame-filename matcher for the DebugBear RUM collector script. Sentry attributes
+// the collector's window.fetch-monkeypatch frames to the script basename (e.g.
+// `/lpMwA9KpC6pf.js`). Derived from DEBUGBEAR_RUM_SCRIPT_SRC — the single source of
+// truth in debugbear-rum.ts — so a CDN/script-id rotation updates the beforeSend
+// bare-`Failed to fetch` gate in lockstep instead of silently failing open
+// (Greptile P2, #5143). Falls back to a host-only `debugbear` match if the URL ever
+// lacks a basename, so the matcher can never degrade into matching every frame.
+const DEBUGBEAR_RUM_COLLECTOR_FRAME = (() => {
+  const basename = DEBUGBEAR_RUM_SCRIPT_SRC.split('/').pop();
+  if (!basename) return /debugbear/i;
+  const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|/)${escaped}$|debugbear`, 'i');
+})();
 
 function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
@@ -549,13 +565,12 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // either that collector or a bare `window.fetch`/`fetch` trampoline, so a
       // genuine uncaught first-party fetch rejection (which carries a real
       // function name) still surfaces. Mirrors the SG extension-wrapper gate
-      // above; the `<id>.js` basename tracks DEBUGBEAR_RUM_SCRIPT_SRC.
-      // WORLDMONITOR-VC (93ev/69u, 2026-07-04+).
+      // above; the collector frame is matched via DEBUGBEAR_RUM_COLLECTOR_FRAME,
+      // derived from DEBUGBEAR_RUM_SCRIPT_SRC. WORLDMONITOR-VC (93ev/69u, 2026-07-04+).
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
-          && frames.some(f => /(?:^|\/)lpMwA9KpC6pf\.js$/.test(f.filename ?? '') || /debugbear/i.test(f.filename ?? ''))
+          && frames.some(f => DEBUGBEAR_RUM_COLLECTOR_FRAME.test(f.filename ?? ''))
           && nonInfraFrames.every(f =>
-            /(?:^|\/)lpMwA9KpC6pf\.js$/.test(f.filename ?? '')
-            || /debugbear/i.test(f.filename ?? '')
+            DEBUGBEAR_RUM_COLLECTOR_FRAME.test(f.filename ?? '')
             || /^(?:window\.)?fetch$/.test(f.function ?? ''))) {
         return null;
       }

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -442,6 +442,29 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       if (excType === 'TypeError' && frames.some(f => /sortedTrackListForMenu/.test(f.function ?? ''))) return null;
       // Suppress TypeErrors from anonymous/injected scripts (no real source files or only inline page URL)
       if ((excType === 'TypeError' || /^TypeError:/.test(msg)) && frames.length > 0 && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
+      // Suppress errors thrown by an injected browser-automation harness driving
+      // the page (e.g. Floot's agent). Its selector-resolution helpers throw
+      // `Element not found: <sel>`, `No element found: <sel>`, and
+      // `$pressKey(...) was called with no selector` from an injected
+      // `<anonymous>` script (helperGetStyle et al.), and reference Floot's own
+      // `data-floot-id` attribute. These are generic `Error` (not TypeError, so
+      // the anonymous-script gate above misses them) whose only frames are
+      // `<anonymous>` → hasFirstParty=false. Our bundle never emits these
+      // phrasings (grep-verified across src/ + api/). Gated on !hasFirstParty so
+      // a same-worded first-party error would still surface. The `... found:`
+      // matches REQUIRE the trailing colon+selector, leaving the colon-less
+      // ambiguous `Element not found` (handled by the !hasFirstParty ambiguous
+      // gate below, which additionally demands a confirmed third-party stack)
+      // untouched. WORLDMONITOR-VR/VV/VW/VX/VY/VS/VT/VZ (2026-07-09 Floot agent).
+      // NB: the `called with no selector` regex deliberately omits the leading
+      // "was " — the beforeSend unit-test harness strips TypeScript `as <T>`
+      // assertions with a crude `/as\s+\w+/` that also mangles the English
+      // "was called". Matching from "called" keeps the test's eval'd copy intact.
+      if (!hasFirstParty && (
+        /^(?:Element not found|No element found):/.test(msg)
+        || /\bcalled with no selector\b/.test(msg)
+        || /data-floot-id/.test(msg)
+      )) return null;
       // Suppress parentNode.insertBefore from injected/inline scripts (iOS WKWebView, Apple Mail)
       // Also covers [native code] frames (no filename) produced by WKWebView's forEach wrapper
       if (/parentNode\.insertBefore/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || f.filename === '[native code]' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
@@ -509,6 +532,31 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // surfaces as `Object.apply`, not `window.fetch`.
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
           && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:(?:window|Object)\.)?(?:fetch|apply)$/i.test(f.function ?? ''))) {
+        return null;
+      }
+      // Bare `Failed to fetch` surfacing through the DebugBear RUM collector's
+      // window.fetch monkeypatch. DebugBear (src/bootstrap/debugbear-rum.ts →
+      // cdn.debugbear.com/<id>.js; Sentry attributes its frames to the script
+      // basename, e.g. `/lpMwA9KpC6pf.js`) wraps window.fetch to time it, so a
+      // transient network blip on ANY app fetch rejects and its wrapper
+      // re-surfaces the rejection as an unhandled rejection, injecting its own
+      // frames. Without DebugBear the identical failure is zero-frame and already
+      // suppressed above — the collector's frames are the ONLY reason it reaches
+      // here. The `/assets/*.js` frames it carries are `window.fetch` TRAMPOLINES
+      // (Vite code-split chunk names, e.g. panel-storage/widget-store, which do
+      // not themselves fetch — grep-verified), NOT real callers. Suppress only
+      // when a DebugBear collector frame is present AND every non-infra frame is
+      // either that collector or a bare `window.fetch`/`fetch` trampoline, so a
+      // genuine uncaught first-party fetch rejection (which carries a real
+      // function name) still surfaces. Mirrors the SG extension-wrapper gate
+      // above; the `<id>.js` basename tracks DEBUGBEAR_RUM_SCRIPT_SRC.
+      // WORLDMONITOR-VC (93ev/69u, 2026-07-04+).
+      if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
+          && frames.some(f => /(?:^|\/)lpMwA9KpC6pf\.js$/.test(f.filename ?? '') || /debugbear/i.test(f.filename ?? ''))
+          && nonInfraFrames.every(f =>
+            /(?:^|\/)lpMwA9KpC6pf\.js$/.test(f.filename ?? '')
+            || /debugbear/i.test(f.filename ?? '')
+            || /^(?:window\.)?fetch$/.test(f.function ?? ''))) {
         return null;
       }
       // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1031,3 +1031,114 @@ describe('ignoreErrors — mainWorldSdk extension global (WORLDMONITOR-TG)', () 
       'pattern must not swallow a longer identifier with the same prefix');
   });
 });
+
+// ─── WORLDMONITOR-VR/VV/VW/VX/VY/VS/VT/VZ: injected browser-automation harness ─
+//
+// An external browser-automation agent (Floot) drove the dashboard on 2026-07-09.
+// Its injected selector-resolution helpers (helperGetStyle et al., <anonymous>
+// script) throw generic `Error`s our bundle never emits: `Element not found:
+// <sel>`, `No element found: <sel>`, `$pressKey(...) was called with no
+// selector`, and references to its own `data-floot-id` attribute. Generic Error
+// type (so the anonymous-script TypeError gate misses them) + <anonymous>-only
+// frames (→ !hasFirstParty). Gated on !hasFirstParty; the `... found:` matches
+// require the trailing colon so the colon-less ambiguous `Element not found`
+// (which needs a confirmed third-party stack) is untouched.
+describe('injected browser-automation harness errors (Floot)', () => {
+  const automationMsgs = [
+    'Element not found: [data-floot-id="307"]',
+    'Element not found: header',
+    'Element not found: null',
+    'Element not found: .bg-orange-500\\/20',
+    'No element found: button, hasText="×", within="[data-floot-id=\\"12\\"]"',
+    'No element found: #intel-feed',
+    '$pressKey("Escape") was called with no selector but no element is focused',
+  ];
+
+  for (const msg of automationMsgs) {
+    it(`suppresses "${msg.slice(0, 40)}..." from an <anonymous> injected script`, () => {
+      // Real shape: generic Error, helperGetStyle in an <anonymous> eval frame.
+      const event = makeEvent(msg, 'Error', [
+        { filename: '<anonymous>', lineno: 91, function: null },
+        { filename: '<anonymous>', lineno: 5, function: 'helperGetStyle' },
+      ]);
+      assert.equal(beforeSend(event), null, `Floot automation error should be suppressed: ${msg}`);
+    });
+
+    it(`suppresses "${msg.slice(0, 40)}..." with an empty stack too`, () => {
+      assert.equal(beforeSend(makeEvent(msg, 'Error', [])), null);
+    });
+  }
+
+  it('does NOT suppress the colon-less ambiguous "Element not found" with empty stack', () => {
+    // Preserves the existing ambiguous-error contract: a bare "Element not found"
+    // (no selector) could be our own code and must surface with an unknown origin.
+    assert.ok(beforeSend(makeEvent('Element not found', 'Error', [])) !== null,
+      'bare colon-less "Element not found" must still surface');
+  });
+
+  it('does NOT suppress a first-party error that happens to say "Element not found: X"', () => {
+    // Defense-in-depth: a genuine first-party frame means our code threw it —
+    // must surface even with the automation-shaped message.
+    const event = makeEvent('Element not found: #someLegitSelector', 'Error', [
+      firstPartyFrame('src/components/SomePanel.ts', 'requireEl'),
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party "Element not found: X" must reach Sentry');
+  });
+});
+
+// ─── WORLDMONITOR-VC: bare "Failed to fetch" through DebugBear's fetch wrapper ─
+//
+// DebugBear's RUM collector (cdn.debugbear.com/<id>.js → frame `/lpMwA9KpC6pf.js`)
+// monkeypatches window.fetch to time it. A transient network blip on any app
+// fetch rejects and its wrapper re-surfaces the rejection as an unhandled
+// rejection, injecting its own frames. The only "first-party" frames it carries
+// are `window.fetch` trampolines on Vite chunk names (panel-storage/widget-store
+// — neither module actually fetches). Without DebugBear the identical failure is
+// zero-frame and already suppressed. Suppress only when a DebugBear frame is
+// present AND every non-infra frame is that collector or a bare window.fetch
+// trampoline, so a genuine uncaught first-party fetch rejection still surfaces.
+describe('bare "Failed to fetch" via DebugBear RUM fetch wrapper (WORLDMONITOR-VC)', () => {
+  // Verbatim production stack from WORLDMONITOR-VC.
+  const vcStack = [
+    { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 8, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 'e' },
+    { filename: '/assets/widget-store-BQi6MP9w.js', lineno: 38, function: 'window.fetch' },
+    { filename: '/assets/panel-storage-DSqo8-tt.js', lineno: 2, function: 'window.fetch' },
+  ];
+
+  it('suppresses the exact VC stack (DebugBear wrapper + window.fetch trampolines)', () => {
+    assert.equal(beforeSend(makeEvent('Failed to fetch', 'TypeError', vcStack)), null,
+      'DebugBear-wrapped transient fetch failure should be suppressed');
+  });
+
+  it('suppresses the type-prefixed value variant', () => {
+    assert.equal(beforeSend(makeEvent('TypeError: Failed to fetch', 'TypeError', vcStack)), null);
+  });
+
+  it('does NOT suppress when a genuine first-party fetch caller frame is present', () => {
+    // A real uncaught first-party fetch rejection carries a real function name
+    // (not a bare window.fetch trampoline) — must surface even with DebugBear on
+    // the stack.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 'e' },
+      { filename: '/assets/panels-DzUv7BBV.js', lineno: 100, function: 'loadCountryGeometry' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'genuine first-party fetch rejection must reach Sentry');
+  });
+
+  it('does NOT suppress a plain first-party "Failed to fetch" with no DebugBear frame', () => {
+    // Regression guard for the existing contract: without DebugBear, a first-party
+    // window.fetch failure still surfaces (it is not this gate's business).
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'non-DebugBear first-party fetch failure must surface');
+  });
+
+  it('does NOT suppress a non-"Failed to fetch" error that merely has a DebugBear frame', () => {
+    const event = makeEvent('Something else entirely', 'TypeError', vcStack);
+    assert.ok(beforeSend(event) !== null, 'gate is scoped to the bare Failed-to-fetch message');
+  });
+});

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isDebugBearRumScriptFrame } from '../src/bootstrap/debugbear-rum.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -37,23 +38,12 @@ const fnBody = mainSrc.slice(bsStart + 'beforeSend(event) '.length, bsEnd)
 const tpMatch = mainSrc.match(/const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set\(\[[^\]]*\]\);/);
 assert.ok(tpMatch, 'THIRD_PARTY_FETCH_HOST_ALLOWLIST must be defined in src/bootstrap/sentry-init.ts');
 
-// beforeSend's DebugBear gate references DEBUGBEAR_RUM_COLLECTOR_FRAME, which
-// sentry-init.ts derives at module scope from DEBUGBEAR_RUM_SCRIPT_SRC (the source
-// of truth in debugbear-rum.ts). Rebuild the identical matcher here from that same
-// constant — reading it from debugbear-rum.ts rather than hardcoding the script id
-// — so the eval'd beforeSend has it and the test tracks a script-id rotation too.
-const debugbearSrc = readFileSync(resolve(__dirname, '../src/bootstrap/debugbear-rum.ts'), 'utf-8');
-const dbUrlMatch = debugbearSrc.match(/DEBUGBEAR_RUM_SCRIPT_SRC\s*=\s*['"]([^'"]+)['"]/);
-assert.ok(dbUrlMatch, 'DEBUGBEAR_RUM_SCRIPT_SRC must be defined in src/bootstrap/debugbear-rum.ts');
-const dbBasename = dbUrlMatch[1].split('/').pop();
-const dbCollectorFrame = dbBasename
-  ? new RegExp(`(?:^|/)${dbBasename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$|debugbear`, 'i')
-  : /debugbear/i;
-const dbFrameInject = `const DEBUGBEAR_RUM_COLLECTOR_FRAME = ${dbCollectorFrame.toString()};`;
-
 // Build a callable version. Input: a Sentry-shaped event object. Returns event or null.
 // eslint-disable-next-line no-new-func
-const beforeSend = new Function('event', `${tpMatch[0]}\n${dbFrameInject}\n${fnBody}`);
+const rawBeforeSend = new Function('event', 'isDebugBearRumScriptFrame', `${tpMatch[0]}\n${fnBody}`);
+function beforeSend(event) {
+  return rawBeforeSend(event, isDebugBearRumScriptFrame);
+}
 
 // Extract the `ignoreErrors` array literal so tests can assert which messages
 // Sentry's built-in (pre-beforeSend) filter drops. The array body contains
@@ -1066,6 +1056,7 @@ describe('injected browser-automation harness errors (Floot)', () => {
     'No element found: button, hasText="×", within="[data-floot-id=\\"12\\"]"',
     'No element found: #intel-feed',
     '$pressKey("Escape") was called with no selector but no element is focused',
+    'Floot helper failed near [data-floot-id="307"]',
   ];
 
   for (const msg of automationMsgs) {
@@ -1131,6 +1122,38 @@ describe('bare "Failed to fetch" via DebugBear RUM fetch wrapper (WORLDMONITOR-V
     assert.equal(beforeSend(makeEvent('TypeError: Failed to fetch', 'TypeError', vcStack)), null);
   });
 
+  it('derives collector-frame identity from the DebugBear loader module', () => {
+    assert.match(mainSrc, /import \{ isDebugBearRumScriptFrame \} from '\.\/debugbear-rum';/,
+      'beforeSend must use the collector identity exported by the loader module');
+    const debugBearGate = mainSrc.slice(mainSrc.indexOf('// Bare `Failed to fetch` surfacing through the DebugBear'));
+    assert.match(debugBearGate, /isDebugBearRumScriptFrame\(f\.filename \?\? ''\)/,
+      'the DebugBear gate must call the shared collector-frame predicate');
+  });
+
+  it('suppresses a generic DebugBear collector with a bare fetch trampoline', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: 'https://cdn.debugbear.com/rotated-collector.js', lineno: 1, function: 'e' },
+      { filename: '/assets/widget-store-BQi6MP9w.js', lineno: 38, function: 'fetch' },
+    ]);
+    assert.equal(beforeSend(event), null, 'generic DebugBear collector and bare fetch trampoline should be suppressed');
+  });
+
+  it('does NOT suppress a DebugBear stack with a non-trampoline fetchContent frame', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 'e' },
+      { filename: '/assets/widget-store-BQi6MP9w.js', lineno: 38, function: 'fetchContent' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'a named first-party caller must still reach Sentry');
+  });
+
+  it('does NOT suppress a DebugBear stack with the runtime fetch wrapper', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 'e' },
+      { filename: '/assets/runtime-BQi6MP9w.js', lineno: 38, function: 'window.fetch' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'runtime fetch wrapper failures must still reach Sentry');
+  });
+
   it('does NOT suppress when a genuine first-party fetch caller frame is present', () => {
     // A real uncaught first-party fetch rejection carries a real function name
     // (not a bare window.fetch trampoline) — must surface even with DebugBear on
@@ -1149,6 +1172,14 @@ describe('bare "Failed to fetch" via DebugBear RUM fetch wrapper (WORLDMONITOR-V
       { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
     ]);
     assert.ok(beforeSend(event) !== null, 'non-DebugBear first-party fetch failure must surface');
+  });
+
+  it('does NOT suppress an observed trampoline without a DebugBear collector', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/widget-store-BQi6MP9w.js', lineno: 38, function: 'fetch' },
+    ]);
+    assert.ok(beforeSend(event) !== null,
+      'the allowed trampoline alone must not suppress a first-party fetch failure');
   });
 
   it('does NOT suppress a non-"Failed to fetch" error that merely has a DebugBear frame', () => {

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -37,9 +37,23 @@ const fnBody = mainSrc.slice(bsStart + 'beforeSend(event) '.length, bsEnd)
 const tpMatch = mainSrc.match(/const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set\(\[[^\]]*\]\);/);
 assert.ok(tpMatch, 'THIRD_PARTY_FETCH_HOST_ALLOWLIST must be defined in src/bootstrap/sentry-init.ts');
 
+// beforeSend's DebugBear gate references DEBUGBEAR_RUM_COLLECTOR_FRAME, which
+// sentry-init.ts derives at module scope from DEBUGBEAR_RUM_SCRIPT_SRC (the source
+// of truth in debugbear-rum.ts). Rebuild the identical matcher here from that same
+// constant — reading it from debugbear-rum.ts rather than hardcoding the script id
+// — so the eval'd beforeSend has it and the test tracks a script-id rotation too.
+const debugbearSrc = readFileSync(resolve(__dirname, '../src/bootstrap/debugbear-rum.ts'), 'utf-8');
+const dbUrlMatch = debugbearSrc.match(/DEBUGBEAR_RUM_SCRIPT_SRC\s*=\s*['"]([^'"]+)['"]/);
+assert.ok(dbUrlMatch, 'DEBUGBEAR_RUM_SCRIPT_SRC must be defined in src/bootstrap/debugbear-rum.ts');
+const dbBasename = dbUrlMatch[1].split('/').pop();
+const dbCollectorFrame = dbBasename
+  ? new RegExp(`(?:^|/)${dbBasename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$|debugbear`, 'i')
+  : /debugbear/i;
+const dbFrameInject = `const DEBUGBEAR_RUM_COLLECTOR_FRAME = ${dbCollectorFrame.toString()};`;
+
 // Build a callable version. Input: a Sentry-shaped event object. Returns event or null.
 // eslint-disable-next-line no-new-func
-const beforeSend = new Function('event', `${tpMatch[0]}\n${fnBody}`);
+const beforeSend = new Function('event', `${tpMatch[0]}\n${dbFrameInject}\n${fnBody}`);
 
 // Extract the `ignoreErrors` array literal so tests can assert which messages
 // Sentry's built-in (pre-beforeSend) filter drops. The array body contains


### PR DESCRIPTION
## Context

From the 2026-07-09/10 Sentry event-volume review (asked: *"too many errors than usual?"*). Bottom line: **no error regression** — `level:error` is flat (07-10 ≈ 11, baseline 13–40/day). The one 07-09 bump (105) was mostly benign, and two of its contributors are pure noise that inflate the perceived error count. This filters both. Neither is a real bug.

## Changes (both in `beforeSend`)

### 1. Injected browser-automation harness (Floot) — WORLDMONITOR-VR/VV/VW/VX/VY/VS/VT/VZ
An external automation agent drove the dashboard on 07-09. Its selector helpers throw generic `Error`s our bundle never emits (grep-verified across `src/` + `api/`):
- `Element not found: <sel>` / `No element found: <sel>`
- `$pressKey(...) was called with no selector`
- `data-floot-id` references

Generic `Error` type (so the existing anonymous-script **TypeError** gate missed them) with `<anonymous>`-only frames. New gate is `!hasFirstParty`-scoped and **colon-anchored**, so the ambiguous colon-less `Element not found` still requires a confirmed third-party stack (existing contract preserved).

### 2. Bare `Failed to fetch` via DebugBear's fetch wrapper — WORLDMONITOR-VC (93 ev / 69 users)
DebugBear's RUM collector (`cdn.debugbear.com/<id>.js` → frame `/lpMwA9KpC6pf.js`) monkeypatches `window.fetch`. A transient network blip on **any** app fetch re-surfaces as an unhandled rejection carrying the collector's frames + `window.fetch` **trampolines** on Vite chunk names (`panel-storage`/`widget-store` — neither module actually fetches; the chunk names are code-split artifacts, not the source). Without DebugBear the identical failure is zero-frame and already suppressed — the collector's frames are the *only* reason it reaches Sentry.

New gate mirrors the existing SG extension-wrapper gate: suppress only when a DebugBear frame is present **AND** every non-infra frame is that collector or a bare `window.fetch`/`fetch` trampoline — so a genuine uncaught first-party fetch rejection (which carries a real function name) still surfaces.

## Safety
Both gates preserve first-party signal by construction (`!hasFirstParty` / real-function-name checks). No `ignoreErrors` entries added — nothing here is message-only suppression.

## Tests
`tests/sentry-beforesend.test.mjs` +111 lines, **198/198 pass**. Includes the verbatim production stacks and the surface-not-suppress safety cases (first-party `Element not found: X`, genuine first-party fetch caller with DebugBear on the stack, non-DebugBear `Failed to fetch`). `tsc --noEmit` clean.

https://claude.ai/code/session_01KShEjhgAgzKUXqbuXcYNsP