### PR TITLE
ci(consumer-prices): run vitest suite

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -22,7 +22,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          required='["changes","docs-stats","unit","sidecar","convex-tests","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","security-audit"]'
+          required='["changes","docs-stats","unit","consumer-prices","sidecar","convex-tests","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","security-audit"]'
 
           # Poll check-runs for this SHA and find the latest result for each required job.
           # Project to just the three fields the gate logic reads. A SHA can

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       code: ${{ steps.diff.outputs.code }}
       digest: ${{ steps.diff.outputs.digest }}
       validation: ${{ steps.diff.outputs.validation }}
+      consumer_prices: ${{ steps.diff.outputs.consumer_prices }}
     steps:
       - id: diff
         env:
@@ -26,6 +27,7 @@ jobs:
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "digest=true" >> "$GITHUB_OUTPUT"
             echo "validation=true" >> "$GITHUB_OUTPUT"
+            echo "consumer_prices=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
@@ -67,6 +69,14 @@ jobs:
             END { print count + 0 }
           ')
           echo "validation=$( [ "$VALIDATION" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          # Consumer-prices-core has its own lockfile and Vitest suite, so run
+          # it whenever package code, tests, or its CI definition changes.
+          CONSUMER_PRICES=$(echo "$FILES" | awk '
+            /^consumer-prices-core\// { count++ }
+            /^\.github\/workflows\/test\.yml$/ { count++ }
+            END { print count + 0 }
+          ')
+          echo "consumer_prices=$( [ "$CONSUMER_PRICES" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
 
   docs-stats:
     # Always-on: guards the capability counts quoted in README / ARCHITECTURE /
@@ -129,6 +139,21 @@ jobs:
               exit 1
             }
           done
+
+  consumer-prices:
+    needs: changes
+    if: needs.changes.outputs.consumer_prices == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: consumer-prices-core/package-lock.json
+      - run: npm ci --prefix consumer-prices-core
+      - run: npm test --prefix consumer-prices-core
 
   sidecar:
     needs: changes

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -38,6 +38,7 @@ const REQUIRED_TEST_JOBS = [
 ] as const;
 
 const TIMEOUT_CAPPED_TEST_JOBS = [
+  'consumer-prices',
   'sidecar',
   'convex-tests',
   'variant-smoke-full',


### PR DESCRIPTION
## Summary

Consumer-prices regressions now receive a dedicated CI check whenever the package or its test workflow changes. The deploy gate now waits for that check, so a failing package test blocks the same branch-protection path as the rest of the Test workflow.

Fixes #5148.

## Validation

- `consumer-prices-core/node_modules/.bin/tsx --test tests/ci-workflow-coverage.test.mts` (9 passed)
- `npm test --prefix consumer-prices-core` (101 passed)
- Parsed both changed GitHub Actions workflows with `js-yaml` and ran `git diff --check`

## Post-Deploy Monitoring & Validation

No additional production monitoring is required: this is CI-only. On this PR, confirm the `consumer-prices` check runs and succeeds; any red or missing check is the rollback/mitigation trigger. Validation window: this PR CI run. Owner: PR author.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)