### PR TITLE
fix(edge): allow longer enterprise wm_ keys through bot gate

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -284,11 +284,11 @@ export default function middleware(request: Request) {
   // Authenticated Pro API clients bypass UA filtering. This is a cheap
   // edge heuristic, not auth — real validation (SHA-256 hash vs Convex
   // userApiKeys + entitlement) happens in server/gateway.ts. To keep the
-  // bot-UA shield meaningful, require the exact key shape emitted by
-  // src/services/api-keys.ts:generateKey: `wm_` + 40 lowercase hex chars.
-  // A random scraper would have to guess a specific 43-char format, and
-  // spoofed-but-well-shaped keys still 401 at the gateway.
-  const WM_KEY_SHAPE = /^wm_[a-f0-9]{40}$/;
+  // bot-UA shield meaningful, require the `wm_` prefix plus 40–64 lowercase
+  // hex chars. User keys are 40 hex chars; enterprise keys may be longer.
+  // A random scraper would still have to guess this format, and spoofed-but-
+  // well-shaped keys still 401 at the gateway.
+  const WM_KEY_SHAPE = /^wm_[a-f0-9]{40,64}$/;
   const apiKey =
     request.headers.get('x-worldmonitor-key') ??
     request.headers.get('x-api-key') ??

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -37,15 +37,42 @@ const LEGACY_DATE_ONLY_CAROUSEL_PATH = '/api/brief/carousel/user_abc/2026-04-19/
 const OTHER_API_PATH = '/api/notifications';
 const MALFORMED_CAROUSEL_PATH = '/api/brief/carousel/admin/dashboard';
 
-function call(pathOrUrl: string, ua: string): Response | void {
+function call(pathOrUrl: string, ua: string, headers: Record<string, string> = {}): Response | void {
   const url = pathOrUrl.startsWith('http')
     ? pathOrUrl
     : `https://www.worldmonitor.app${pathOrUrl}`;
   const req = new Request(url, {
-    headers: ua ? { 'user-agent': ua } : {},
+    headers: {
+      ...(ua ? { 'user-agent': ua } : {}),
+      ...headers,
+    },
   });
   return middleware(req) as Response | void;
 }
+
+describe('middleware bot gate / keyed API clients', () => {
+  const KEYED_API_PATH = '/api/forecast/v1/get-forecast-scorecard';
+  const USER_API_KEY = `wm_${'a'.repeat(40)}`;
+  const ENTERPRISE_API_KEY = `wm_${'b'.repeat(48)}`;
+
+  it('passes a 40-hex user API key through when curl would otherwise be blocked', () => {
+    const res = call(KEYED_API_PATH, GENERIC_CURL_UA, { 'x-worldmonitor-key': USER_API_KEY });
+    assert.equal(res, undefined, 'the gateway, not the UA gate, must validate a well-shaped user key');
+  });
+
+  it('passes a 48-hex enterprise API key through when curl would otherwise be blocked', () => {
+    const res = call(KEYED_API_PATH, GENERIC_CURL_UA, { 'x-worldmonitor-key': ENTERPRISE_API_KEY });
+    assert.equal(res, undefined, 'the gateway, not the UA gate, must validate a well-shaped enterprise key');
+  });
+
+  it('still blocks malformed and overlong wm_ keys with a curl UA', () => {
+    for (const apiKey of [`wm_${'c'.repeat(39)}`, `wm_${'d'.repeat(65)}`, 'wm_not-hex']) {
+      const res = call(KEYED_API_PATH, GENERIC_CURL_UA, { 'x-worldmonitor-key': apiKey });
+      assert.ok(res instanceof Response, `${apiKey} must not bypass the UA gate`);
+      assert.equal(res.status, 403);
+    }
+  });
+});
 
 describe('middleware bot gate / carousel allowlist', () => {
   it('passes TelegramBot through on the carousel route (the PR #3196 fix)', () => {


### PR DESCRIPTION
## Summary

Valid enterprise `wm_` keys sent by script clients no longer receive a bot-gate 403 before their credentials are authenticated. The edge heuristic now accepts the established 40–64 hexadecimal `wm_` format; malformed and overlong strings remain gated, and the gateway still decides real key validity.

Fixes #5153.

## Validation

- `node node_modules/tsx/dist/cli.mjs --test tests/middleware-bot-gate.test.mts` — 56/56 middleware-gate assertions pass, including curl with a 48-hex enterprise key and malformed-key negative cases.
- `npm run typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
