### PR TITLE
fix(convex): guard JSON object request bodies

### DIFF
--- a/convex/__tests__/followed-countries-relay.test.ts
+++ b/convex/__tests__/followed-countries-relay.test.ts
@@ -173,7 +173,7 @@ describe("/relay/followed-countries HTTP action", () => {
     expect(body.error).toBe("userId required");
   });
 
-  test("invalid JSON body → 400 INVALID_BODY", async () => {
+  test("invalid JSON body → 400 INVALID_JSON", async () => {
     const t = convexTest(schema, modules);
 
     const res = await t.fetch("/relay/followed-countries", {
@@ -187,8 +187,27 @@ describe("/relay/followed-countries HTTP action", () => {
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("INVALID_BODY");
+    expect(body.error).toBe("INVALID_JSON");
   });
+
+  test.each([null, [], "not-an-object", 42, true])(
+    "non-object JSON body (%j) → 400 INVALID_JSON",
+    async (payload) => {
+      const t = convexTest(schema, modules);
+      const res = await t.fetch("/relay/followed-countries", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${RELAY_SECRET}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("INVALID_JSON");
+    },
+  );
 
   test("returns countries sorted by addedAt ascending (matches listFollowed convention)", async () => {
     const t = convexTest(schema, modules);

--- a/convex/__tests__/http.test.ts
+++ b/convex/__tests__/http.test.ts
@@ -57,6 +57,24 @@ describe("/api/user-prefs Convex HTTP action", () => {
     expectExposedRateLimitHeaders(res.headers);
   });
 
+  test.each([null, [], "not-an-object", 42, true])(
+    "rejects non-object JSON body (%j) with 400 INVALID_JSON",
+    async (payload) => {
+      const t = convexTest(schema, modules);
+      const res = await t.withIdentity(USER).fetch("/api/user-prefs", {
+        method: "POST",
+        headers: {
+          Origin: "https://worldmonitor.app",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "INVALID_JSON" });
+    },
+  );
+
   test("maps mutation RATE_LIMITED errors to 429 with retry guidance", async () => {
     vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
     const t = convexTest(schema, modules);

--- a/convex/__tests__/internal-entitlements.test.ts
+++ b/convex/__tests__/internal-entitlements.test.ts
@@ -154,4 +154,20 @@ describe("/api/internal-entitlements HTTP action", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("INVALID_JSON");
   });
+
+  test.each([null, [], "not-an-object", 42, true])(
+    "non-object JSON body (%j) → 400 INVALID_JSON",
+    async (payload) => {
+      const t = convexTest(schema, modules);
+      const res = await t.fetch("/api/internal-entitlements", {
+        method: "POST",
+        headers: validHeaders(),
+        body: JSON.stringify(payload),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("INVALID_JSON");
+    },
+  );
 });

--- a/convex/__tests__/relay-json-object-guard.test.ts
+++ b/convex/__tests__/relay-json-object-guard.test.ts
@@ -1,0 +1,48 @@
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import schema from "../schema";
+
+const modules = import.meta.glob("../**/*.ts");
+const RELAY_SECRET = "test-relay-secret-json-object-guard";
+
+const routes = [
+  "/relay/deactivate",
+  "/relay/channels",
+  "/relay/notification-channels",
+  "/relay/user-preferences",
+  "/relay/followed-countries",
+  "/relay/entitlement",
+  "/relay/register-referral-code",
+  "/relay/create-checkout",
+  "/relay/customer-portal",
+  "/relay/bulk-suppress-emails",
+];
+
+describe("relay JSON object body guard", () => {
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.RELAY_SHARED_SECRET;
+    process.env.RELAY_SHARED_SECRET = RELAY_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.RELAY_SHARED_SECRET;
+    else process.env.RELAY_SHARED_SECRET = originalSecret;
+  });
+
+  test.each(routes)("%s rejects a JSON null body with 400 INVALID_JSON", async (path) => {
+    const t = convexTest(schema, modules);
+    const res = await t.fetch(path, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RELAY_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: "null",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "INVALID_JSON" });
+  });
+});

--- a/convex/__tests__/telegramWebhook.test.ts
+++ b/convex/__tests__/telegramWebhook.test.ts
@@ -143,4 +143,25 @@ describe("HTTP route /api/telegram-pair-callback (security #3767)", () => {
     expect(res.status).toBe(200);
     expect(await tokenUsed(t)).toBe(true); // handler ran and claimed the token
   });
+
+  test.each([null, [], "not-an-object", 42, true])(
+    "matching secret with non-object JSON (%j) → 200 without consuming token",
+    async (payload) => {
+      process.env.TELEGRAM_WEBHOOK_SECRET = VALID_SECRET;
+      const t = convexTest(schema, modules);
+      await seedPairingToken(t);
+
+      const res = await t.fetch("/api/telegram-pair-callback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Telegram-Bot-Api-Secret-Token": VALID_SECRET,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await tokenUsed(t)).toBe(false);
+    },
+  );
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -61,6 +61,18 @@ async function timingSafeEqualStrings(a: string, b: string): Promise<boolean> {
   return diff === 0;
 }
 
+/** Parse a request body only when JSON produced an object (never null or an array). */
+async function parseJsonObjectBody<T extends object>(request: Request): Promise<T | null> {
+  try {
+    const body: unknown = await request.json();
+    return body !== null && typeof body === "object" && !Array.isArray(body)
+      ? body as T
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Extract a stable error `code` from a thrown ConvexError.
  *
@@ -128,10 +140,8 @@ http.route({
       });
     }
 
-    let body: { userId?: unknown };
-    try {
-      body = await request.json() as { userId?: unknown };
-    } catch {
+    const body = await parseJsonObjectBody<{ userId?: unknown }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -184,15 +194,13 @@ http.route({
       });
     }
 
-    let body: {
+    const body = await parseJsonObjectBody<{
       variant?: string;
       data?: unknown;
       expectedSyncVersion?: number;
       schemaVersion?: number;
-    };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers,
@@ -312,16 +320,14 @@ http.route({
       return new Response("OK", { status: 200 });
     }
 
-    let update: {
+    const update = await parseJsonObjectBody<{
       message?: {
         chat?: { type?: string; id?: number };
         text?: string;
         date?: number;
       };
-    };
-    try {
-      update = await request.json() as typeof update;
-    } catch {
+    }>(request);
+    if (!update) {
       return new Response("OK", { status: 200 });
     }
 
@@ -379,10 +385,8 @@ http.route({
       });
     }
 
-    let body: { userId?: string; channelType?: string };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    const body = await parseJsonObjectBody<{ userId?: string; channelType?: string }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -425,10 +429,8 @@ http.route({
       });
     }
 
-    let body: { userId?: string };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    const body = await parseJsonObjectBody<{ userId?: string }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -468,7 +470,7 @@ http.route({
       });
     }
 
-    let body: {
+    const body = await parseJsonObjectBody<{
       action?: string;
       userId?: string;
       channelType?: string;
@@ -501,10 +503,8 @@ http.route({
       aiDigestEnabled?: boolean;
       countries?: string[];
       tickers?: string[];
-    };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -834,11 +834,9 @@ http.route({
         headers: { "Content-Type": "application/json" },
       });
     }
-    let body: { userId?: string; variant?: string };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
-      return new Response(JSON.stringify({ error: "INVALID_BODY" }), {
+    const body = await parseJsonObjectBody<{ userId?: string; variant?: string }>(request);
+    if (!body) {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -877,11 +875,9 @@ http.route({
         headers: { "Content-Type": "application/json" },
       });
     }
-    let body: { userId?: unknown };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
-      return new Response(JSON.stringify({ error: "INVALID_BODY" }), {
+    const body = await parseJsonObjectBody<{ userId?: unknown }>(request);
+    if (!body) {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -922,11 +918,9 @@ http.route({
         headers: { "Content-Type": "application/json" },
       });
     }
-    let body: { userId?: string };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
-      return new Response(JSON.stringify({ error: "INVALID_BODY" }), {
+    const body = await parseJsonObjectBody<{ userId?: string }>(request);
+    if (!body) {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -971,11 +965,9 @@ http.route({
         headers: { "Content-Type": "application/json" },
       });
     }
-    let body: { userId?: string; code?: string };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
-      return new Response(JSON.stringify({ error: "INVALID_BODY" }), {
+    const body = await parseJsonObjectBody<{ userId?: string; code?: string }>(request);
+    if (!body) {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -1018,10 +1010,8 @@ http.route({
       });
     }
 
-    let body: { keyHash?: unknown };
-    try {
-      body = await request.json() as { keyHash?: unknown };
-    } catch {
+    const body = await parseJsonObjectBody<{ keyHash?: unknown }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1072,10 +1062,8 @@ http.route({
       });
     }
 
-    let body: { keyHash?: unknown };
-    try {
-      body = await request.json() as { keyHash?: unknown };
-    } catch {
+    const body = await parseJsonObjectBody<{ keyHash?: unknown }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1120,10 +1108,12 @@ http.route({
       });
     }
 
-    let body: { userId?: unknown; clientId?: unknown; name?: unknown };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    const body = await parseJsonObjectBody<{
+      userId?: unknown;
+      clientId?: unknown;
+      name?: unknown;
+    }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1182,10 +1172,8 @@ http.route({
       });
     }
 
-    let body: { tokenId?: unknown };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    const body = await parseJsonObjectBody<{ tokenId?: unknown }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1255,10 +1243,8 @@ http.route({
       });
     }
 
-    let body: { userId?: unknown; tokenId?: unknown };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    const body = await parseJsonObjectBody<{ userId?: unknown; tokenId?: unknown }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1343,7 +1329,7 @@ http.route({
       });
     }
 
-    let body: {
+    const body = await parseJsonObjectBody<{
       userId?: string;
       email?: string;
       name?: string;
@@ -1352,10 +1338,8 @@ http.route({
       discountCode?: string;
       referralCode?: string;
       bypassPendingGuard?: boolean;
-    };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1437,10 +1421,8 @@ http.route({
       });
     }
 
-    let body: { userId?: string };
-    try {
-      body = await request.json() as typeof body;
-    } catch {
+    const body = await parseJsonObjectBody<{ userId?: string }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1500,16 +1482,14 @@ http.route({
       });
     }
 
-    let body: {
+    const body = await parseJsonObjectBody<{
       emails: Array<{
         email: string;
         reason: "bounce" | "complaint" | "manual";
         source?: string;
       }>;
-    };
-    try {
-      body = (await request.json()) as typeof body;
-    } catch {
+    }>(request);
+    if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },

--- a/tests/convex-http-json-object-guard.test.mjs
+++ b/tests/convex-http-json-object-guard.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, '..', 'convex', 'http.ts'), 'utf8');
+
+const guardedPaths = [
+  '/api/internal-entitlements',
+  '/api/user-prefs',
+  '/api/telegram-pair-callback',
+  '/relay/deactivate',
+  '/relay/channels',
+  '/relay/notification-channels',
+  '/relay/user-preferences',
+  '/relay/followed-countries',
+  '/relay/entitlement',
+  '/relay/register-referral-code',
+  '/api/internal-validate-api-key',
+  '/api/internal-get-key-owner',
+  '/api/internal-issue-pro-mcp-token',
+  '/api/internal-validate-pro-mcp-token',
+  '/api/internal-revoke-pro-mcp-token',
+  '/relay/create-checkout',
+  '/relay/customer-portal',
+  '/relay/bulk-suppress-emails',
+];
+
+describe('convex/http JSON object body guard', () => {
+  it('uses the shared parser for every authenticated JSON POST route', () => {
+    assert.match(source, /async function parseJsonObjectBody/);
+    assert.equal(
+      (source.match(/await request\.json\(\)/g) ?? []).length,
+      1,
+      'only the shared parser may parse JSON directly',
+    );
+
+    for (const path of guardedPaths) {
+      const routeStart = source.indexOf(`path: "${path}",\n  method: "POST"`);
+      assert.notEqual(routeStart, -1, `missing ${path} route`);
+      const nextRoute = source.indexOf('http.route({', routeStart + 1);
+      const route = source.slice(routeStart, nextRoute === -1 ? undefined : nextRoute);
+      assert.match(route, /parseJsonObjectBody[\s\S]*?\(request\)/, `${path} bypasses object guard`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Authenticated Convex HTTP handlers now reject JSON nulls, arrays, and primitives before field access, returning deterministic 400 errors instead of unhandled failures. Telegram's webhook retains its deliberate 200 OK retry-suppression response for malformed input.

Fixes #5150.

## Validation

- Focused Convex regressions: 55 passing tests across entitlement, user preferences, relay, and Telegram routes
- JSON route-inventory guard passed
- npm run typecheck:api and npm run typecheck passed
- npm run lint completed; existing unrelated Biome diagnostics remain warnings

## Post-Deploy Monitoring & Validation

- Monitor Convex HTTP route 5xx rates and Telegram webhook retries for 24 hours after deploy.
- Healthy signal: malformed authenticated payloads produce expected 400s (or Telegram 200) with no route 5xx increase.
- Investigate or rollback if internal or relay routes show unexpected 4xx spikes from valid clients, or Telegram retries increase. Owner: WorldMonitor maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)