### PR TITLE
perf(search): defer mobile sheet population past first paint

### DIFF
--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -270,6 +270,15 @@ export class SearchModal {
    * chips can create several nodes plus event listeners, which otherwise makes
    * the first sheet presentation compete with the FAB interaction (#5158).
    */
+  private scheduleMobileReveal(overlay: HTMLElement): void {
+    requestAnimationFrame(() => {
+      // The sheet can close or be replaced before its queued reveal runs. Do
+      // not let stale work reopen an outgoing or removed overlay.
+      if (this.overlay !== overlay || this.closeTimeoutId !== null) return;
+      overlay.classList.add('open');
+    });
+  }
+
   private scheduleMobileInitialPopulation(): void {
     const generation = ++this.mobileInitialPopulationGeneration;
     // The first frame reveals the sheet; the second runs after that paint. Do
@@ -292,7 +301,7 @@ export class SearchModal {
     this.overlay.setAttribute('aria-modal', 'true');
 
     if (this.isMobile) {
-      this.overlay.className = 'search-overlay search-mobile search-mobile-prerender';
+      this.overlay.className = 'search-overlay search-mobile';
       setTrustedHtml(this.overlay, trustedHtml(`
         <div class="search-sheet">
           <div class="search-sheet-handle"></div>
@@ -315,10 +324,7 @@ export class SearchModal {
       this.chipsContainer = this.overlay.querySelector('.search-sheet-chips');
 
       this.container.appendChild(this.overlay);
-      requestAnimationFrame(() => {
-        this.overlay?.classList.remove('search-mobile-prerender');
-        this.overlay?.classList.add('open');
-      });
+      this.scheduleMobileReveal(this.overlay);
 
       const sheet = this.overlay.querySelector('.search-sheet') as HTMLElement | null;
       if (sheet && window.visualViewport) {

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -292,7 +292,7 @@ export class SearchModal {
     this.overlay.setAttribute('aria-modal', 'true');
 
     if (this.isMobile) {
-      this.overlay.className = 'search-overlay search-mobile';
+      this.overlay.className = 'search-overlay search-mobile search-mobile-prerender';
       setTrustedHtml(this.overlay, trustedHtml(`
         <div class="search-sheet">
           <div class="search-sheet-handle"></div>
@@ -315,7 +315,10 @@ export class SearchModal {
       this.chipsContainer = this.overlay.querySelector('.search-sheet-chips');
 
       this.container.appendChild(this.overlay);
-      requestAnimationFrame(() => this.overlay?.classList.add('open'));
+      requestAnimationFrame(() => {
+        this.overlay?.classList.remove('search-mobile-prerender');
+        this.overlay?.classList.add('open');
+      });
 
       const sheet = this.overlay.querySelector('.search-sheet') as HTMLElement | null;
       if (sheet && window.visualViewport) {
@@ -393,6 +396,9 @@ export class SearchModal {
   }
 
   private handleSearch(): void {
+    // A programmatic refresh can render while the mobile sheet's initial
+    // population is still deferred. Its results now own the list.
+    if (this.isMobile) this.mobileInitialPopulationGeneration += 1;
     const rawInput = this.input?.value.toLowerCase() || '';
     const query = rawInput.trim();
     // Record what we actually searched so flushPendingSearch can detect stale results.

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -99,6 +99,9 @@ export class SearchModal {
   private resultsList: HTMLElement | null = null;
   private chipsContainer: HTMLElement | null = null;
   private closeTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  // Invalidates deferred mobile list population when the sheet closes before
+  // its first paint (or is immediately reopened).
+  private mobileInitialPopulationGeneration = 0;
   // Debounce the per-keystroke search so fast typing runs the command match +
   // sort once after settle, not on every input event — cuts INP processing
   // time (#4537). Programmatic handleSearch() calls (filters, category select)
@@ -218,13 +221,17 @@ export class SearchModal {
     this.createModal();
     this.input?.focus();
     this.showingAllCommands = false;
-    this.showRecentOrEmpty();
-    if (this.isMobile) this.renderChips();
+    if (this.isMobile) {
+      this.scheduleMobileInitialPopulation();
+    } else {
+      this.showRecentOrEmpty();
+    }
   }
 
   public close(): void {
     // Drop any pending debounced search so it can't fire against a torn-down modal.
     this.debouncedSearch.cancel();
+    this.mobileInitialPopulationGeneration += 1;
     if (this.viewportHandler && window.visualViewport) {
       window.visualViewport.removeEventListener('resize', this.viewportHandler);
       this.viewportHandler = null;
@@ -256,6 +263,27 @@ export class SearchModal {
 
   public isOpen(): boolean {
     return this.overlay !== null;
+  }
+
+  /**
+   * Keep the tap frame limited to the sheet shell. The results list and command
+   * chips can create several nodes plus event listeners, which otherwise makes
+   * the first sheet presentation compete with the FAB interaction (#5158).
+   */
+  private scheduleMobileInitialPopulation(): void {
+    const generation = ++this.mobileInitialPopulationGeneration;
+    // The first frame reveals the sheet; the second runs after that paint. Do
+    // not use the startup after-paint scheduler here: it can wait for load and
+    // idle time even though this is an already-interactive control.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        // A close/reopen or an immediate keystroke owns the content now; never
+        // overwrite its current results with the initial empty/recent state.
+        if (generation !== this.mobileInitialPopulationGeneration || !this.overlay || this.input?.value) return;
+        this.showRecentOrEmpty();
+        this.renderChips();
+      });
+    });
   }
 
   private createModal(): void {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11292,6 +11292,12 @@ a.prediction-link:hover {
   transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* The appended shell starts hidden, so skip its paint work until the reveal
+   frame adds .open. The transform animation remains the visible transition. */
+.search-overlay.search-mobile:not(.open) .search-sheet {
+  content-visibility: hidden;
+}
+
 .search-overlay.search-mobile.open .search-sheet {
   transform: translateY(0);
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11293,8 +11293,9 @@ a.prediction-link:hover {
 }
 
 /* The appended shell starts hidden, so skip its paint work until the reveal
-   frame adds .open. The transform animation remains the visible transition. */
-.search-overlay.search-mobile:not(.open) .search-sheet {
+   frame clears the pre-render marker. Closing removes .open but preserves the
+   sheet long enough for its slide-out transform to finish. */
+.search-overlay.search-mobile.search-mobile-prerender .search-sheet {
   content-visibility: hidden;
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11292,13 +11292,6 @@ a.prediction-link:hover {
   transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* The appended shell starts hidden, so skip its paint work until the reveal
-   frame clears the pre-render marker. Closing removes .open but preserves the
-   sheet long enough for its slide-out transform to finish. */
-.search-overlay.search-mobile.search-mobile-prerender .search-sheet {
-  content-visibility: hidden;
-}
-
 .search-overlay.search-mobile.open .search-sheet {
   transform: translateY(0);
 }

--- a/tests/search-mobile-first-paint.test.mts
+++ b/tests/search-mobile-first-paint.test.mts
@@ -7,6 +7,7 @@ import ts from 'typescript';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const modalSrc = readFileSync(resolve(root, 'src/components/SearchModal.ts'), 'utf8');
+const stylesSrc = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8');
 
 function extractMethod(signature: string): string {
   const start = modalSrc.indexOf(signature);
@@ -69,6 +70,7 @@ const harnessSource = `
     ${extractMethod('public open(): void {')}
     ${extractMethod('public close(): void {')}
     ${extractMethod('public refreshSearch(): void {')}
+    ${extractMethod('private scheduleMobileReveal(overlay: HTMLElement): void {')}
     ${extractMethod('private scheduleMobileInitialPopulation(): void {')}
     ${extractMethod('private handleSearch(): void {')}
   }
@@ -167,4 +169,36 @@ test('a direct refresh before the inner reveal frame owns mobile search results 
     assert.equal(modal.recentOrEmptyCalls, 1, 'stale initial population must not overwrite refreshed results');
     assert.equal(modal.chipRenderCalls, 1);
   });
+});
+
+test('a close before the queued reveal frame cannot reopen the outgoing mobile sheet (#5158)', () => {
+  withAnimationFrames((frames) => {
+    const modal = new Harness() as unknown as SearchModalHarness & {
+      overlay: HTMLElement | null;
+      scheduleMobileReveal(overlay: HTMLElement): void;
+    };
+    const classOperations: string[] = [];
+    const overlay = {
+      classList: {
+        add: (name: string) => classOperations.push(`add:${name}`),
+        remove: (name: string) => classOperations.push(`remove:${name}`),
+      },
+      remove() {},
+    } as unknown as HTMLElement;
+    modal.overlay = overlay;
+
+    modal.scheduleMobileReveal(overlay);
+    modal.close();
+    runNextFrame(frames);
+
+    assert.deepEqual(classOperations, ['remove:open']);
+    modal.open(); // Clears close's removal timer before this test returns.
+  });
+});
+
+test('mobile search CSS never hides the sheet or input with content-visibility (#5158)', () => {
+  assert.doesNotMatch(
+    stylesSrc,
+    /\.search-overlay\.search-mobile[^{}]*(?:\.search-sheet|\.search-input)[^{}]*\{[^}]*content-visibility\s*:\s*hidden/i,
+  );
 });

--- a/tests/search-mobile-first-paint.test.mts
+++ b/tests/search-mobile-first-paint.test.mts
@@ -3,23 +3,148 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const modalSrc = readFileSync(resolve(root, 'src/components/SearchModal.ts'), 'utf8');
-const stylesSrc = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8');
 
-test('mobile search mounts the sheet shell before deferred result and chip population (#5158)', () => {
-  assert.doesNotMatch(modalSrc, /scheduleAfterFirstPaint/,
-    'opening search must not wait for the dashboard load/idle scheduler');
-  assert.match(modalSrc, /if \(this\.isMobile\) \{\s*this\.scheduleMobileInitialPopulation\(\);\s*\} else \{\s*this\.showRecentOrEmpty\(\);\s*\}/,
-    'open() must leave mobile result/chip construction out of the tap task');
-  assert.match(modalSrc, /private scheduleMobileInitialPopulation\(\): void \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?this\.showRecentOrEmpty\(\);[\s\S]*?this\.renderChips\(\);/,
-    'the initial mobile lists should populate after the sheet reveal frame, without waiting for page load');
-  assert.match(modalSrc, /mobileInitialPopulationGeneration \+= 1;/,
-    'closing the sheet must invalidate deferred work from a prior open');
+function extractMethod(signature: string): string {
+  const start = modalSrc.indexOf(signature);
+  assert.ok(start >= 0, `SearchModal must contain ${signature}`);
+  const braceStart = modalSrc.indexOf('{', start);
+  let depth = 0;
+  for (let i = braceStart; i < modalSrc.length; i++) {
+    if (modalSrc[i] === '{') depth++;
+    if (modalSrc[i] === '}' && --depth === 0) {
+      return modalSrc.slice(start, i + 1).replace(/^(public|private)\s+/, '');
+    }
+  }
+  throw new Error(`Could not find the end of ${signature}`);
+}
+
+// SearchModal cannot be imported under node:test because its alias graph reads
+// Vite-only globals. Compile its actual lifecycle methods into a minimal DOM
+// harness instead, so this covers observable scheduling and cancellation rather
+// than the formatting of its source.
+const harnessSource = `
+  class SearchModalHarness {
+    constructor() {
+      this.closeTimeoutId = null;
+      this.mobileInitialPopulationGeneration = 0;
+      this.debouncedSearch = { cancel() {} };
+      this.viewportHandler = null;
+      this.sources = [];
+      this.overlay = null;
+      this.input = null;
+      this.resultsList = null;
+      this.chipsContainer = null;
+      this.results = [];
+      this.commandResults = [];
+      this.selectedIndex = 0;
+      this.currentFlightCallsign = null;
+      this.flightSearchFired = false;
+      this.showingAllCommands = false;
+      this.isMobile = true;
+      this.createModalCalls = 0;
+      this.focusCalls = 0;
+      this.recentOrEmptyCalls = 0;
+      this.chipRenderCalls = 0;
+    }
+
+    createModal() {
+      this.createModalCalls++;
+      this.overlay = {
+        classList: { remove() {} },
+        remove() {},
+      };
+      this.input = { value: '', focus: () => { this.focusCalls++; } };
+      this.resultsList = {};
+      this.chipsContainer = {};
+    }
+
+    showRecentOrEmpty() { this.recentOrEmptyCalls++; }
+    renderChips() { this.chipRenderCalls++; }
+
+    ${extractMethod('public open(): void {')}
+    ${extractMethod('public close(): void {')}
+    ${extractMethod('private scheduleMobileInitialPopulation(): void {')}
+  }
+
+  return SearchModalHarness;
+`;
+const harnessJs = ts.transpileModule(harnessSource, {
+  compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.None },
+}).outputText;
+interface SearchModalHarness {
+  open(): void;
+  close(): void;
+  input: { value: string };
+  createModalCalls: number;
+  focusCalls: number;
+  recentOrEmptyCalls: number;
+  chipRenderCalls: number;
+}
+const Harness = new Function('isMobileDevice', harnessJs)(() => true) as new () => SearchModalHarness;
+
+function withAnimationFrames(run: (frames: FrameRequestCallback[]) => void): void {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'requestAnimationFrame');
+  const frames: FrameRequestCallback[] = [];
+  Object.defineProperty(globalThis, 'requestAnimationFrame', {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+  });
+  try {
+    run(frames);
+  } finally {
+    if (original) Object.defineProperty(globalThis, 'requestAnimationFrame', original);
+    else delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+  }
+}
+
+function runNextFrame(frames: FrameRequestCallback[]): void {
+  const frame = frames.shift();
+  assert.ok(frame, 'expected a scheduled animation frame');
+  frame(0);
+}
+
+test('mobile search renders only its shell in the tap task, then populates after the reveal frame (#5158)', () => {
+  withAnimationFrames((frames) => {
+    const modal = new Harness();
+    modal.open();
+
+    assert.equal(modal.createModalCalls, 1);
+    assert.equal(modal.focusCalls, 1);
+    assert.equal(modal.recentOrEmptyCalls, 0);
+    assert.equal(modal.chipRenderCalls, 0);
+
+    runNextFrame(frames);
+    assert.equal(modal.recentOrEmptyCalls, 0, 'the reveal frame must stay free of list work');
+    runNextFrame(frames);
+    assert.equal(modal.recentOrEmptyCalls, 1);
+    assert.equal(modal.chipRenderCalls, 1);
+  });
 });
 
-test('mobile search keeps the closed sheet out of rendering until its reveal frame (#5158)', () => {
-  assert.match(stylesSrc, /\.search-overlay\.search-mobile:not\(\.open\) \.search-sheet \{[\s\S]*?content-visibility:\s*hidden;/,
-    'the hidden sheet should not participate in paint work before its reveal');
+test('a typed query or a reopened sheet invalidates stale initial mobile population (#5158)', () => {
+  withAnimationFrames((frames) => {
+    const modal = new Harness();
+    modal.open();
+    runNextFrame(frames);
+    modal.input.value = 'iran';
+    runNextFrame(frames);
+    assert.equal(modal.recentOrEmptyCalls, 0, 'initial empty state must not overwrite an early query');
+    assert.equal(modal.chipRenderCalls, 0);
+
+    modal.close();
+    modal.open();
+    modal.close();
+    modal.open();
+
+    while (frames.length > 0) runNextFrame(frames);
+    assert.equal(modal.recentOrEmptyCalls, 1, 'only the reopened sheet may populate');
+    assert.equal(modal.chipRenderCalls, 1);
+  });
 });

--- a/tests/search-mobile-first-paint.test.mts
+++ b/tests/search-mobile-first-paint.test.mts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const modalSrc = readFileSync(resolve(root, 'src/components/SearchModal.ts'), 'utf8');
+const stylesSrc = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8');
+
+test('mobile search mounts the sheet shell before deferred result and chip population (#5158)', () => {
+  assert.doesNotMatch(modalSrc, /scheduleAfterFirstPaint/,
+    'opening search must not wait for the dashboard load/idle scheduler');
+  assert.match(modalSrc, /if \(this\.isMobile\) \{\s*this\.scheduleMobileInitialPopulation\(\);\s*\} else \{\s*this\.showRecentOrEmpty\(\);\s*\}/,
+    'open() must leave mobile result/chip construction out of the tap task');
+  assert.match(modalSrc, /private scheduleMobileInitialPopulation\(\): void \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?this\.showRecentOrEmpty\(\);[\s\S]*?this\.renderChips\(\);/,
+    'the initial mobile lists should populate after the sheet reveal frame, without waiting for page load');
+  assert.match(modalSrc, /mobileInitialPopulationGeneration \+= 1;/,
+    'closing the sheet must invalidate deferred work from a prior open');
+});
+
+test('mobile search keeps the closed sheet out of rendering until its reveal frame (#5158)', () => {
+  assert.match(stylesSrc, /\.search-overlay\.search-mobile:not\(\.open\) \.search-sheet \{[\s\S]*?content-visibility:\s*hidden;/,
+    'the hidden sheet should not participate in paint work before its reveal');
+});

--- a/tests/search-mobile-first-paint.test.mts
+++ b/tests/search-mobile-first-paint.test.mts
@@ -44,6 +44,7 @@ const harnessSource = `
       this.currentFlightCallsign = null;
       this.flightSearchFired = false;
       this.showingAllCommands = false;
+      this.lastSearchedQuery = '';
       this.isMobile = true;
       this.createModalCalls = 0;
       this.focusCalls = 0;
@@ -67,7 +68,9 @@ const harnessSource = `
 
     ${extractMethod('public open(): void {')}
     ${extractMethod('public close(): void {')}
+    ${extractMethod('public refreshSearch(): void {')}
     ${extractMethod('private scheduleMobileInitialPopulation(): void {')}
+    ${extractMethod('private handleSearch(): void {')}
   }
 
   return SearchModalHarness;
@@ -78,6 +81,7 @@ const harnessJs = ts.transpileModule(harnessSource, {
 interface SearchModalHarness {
   open(): void;
   close(): void;
+  refreshSearch(): void;
   input: { value: string };
   createModalCalls: number;
   focusCalls: number;
@@ -145,6 +149,22 @@ test('a typed query or a reopened sheet invalidates stale initial mobile populat
 
     while (frames.length > 0) runNextFrame(frames);
     assert.equal(modal.recentOrEmptyCalls, 1, 'only the reopened sheet may populate');
+    assert.equal(modal.chipRenderCalls, 1);
+  });
+});
+
+test('a direct refresh before the inner reveal frame owns mobile search results (#5158)', () => {
+  withAnimationFrames((frames) => {
+    const modal = new Harness();
+    modal.open();
+    runNextFrame(frames);
+
+    modal.refreshSearch();
+    assert.equal(modal.recentOrEmptyCalls, 1, 'the direct refresh renders immediately');
+    assert.equal(modal.chipRenderCalls, 1);
+
+    runNextFrame(frames);
+    assert.equal(modal.recentOrEmptyCalls, 1, 'stale initial population must not overwrite refreshed results');
     assert.equal(modal.chipRenderCalls, 1);
   });
 });


### PR DESCRIPTION
## Summary

On mobile, opening search no longer makes the FAB tap compete with initial results and command-chip construction. The sheet starts its reveal immediately; non-critical initial content arrives after that frame, while an early query or a close/reopen invalidates stale deferred work.

| 390x844 interaction trace, 5x CPU throttle | Worst event | Presentation |
| --- | ---: | ---: |
| Production baseline (`www.worldmonitor.app`) | 192 ms | 108.4 ms |
| Local patched dashboard | 72 ms | 45.2 ms |

The traces are from different environments, so the local result demonstrates a regression improvement rather than the production p75 acceptance result.

## Validation

- Behavioral lifecycle coverage exercises shell-first rendering, post-reveal population, early typing, and close/reopen cancellation.
- `./node_modules/.bin/tsx --test tests/search-mobile-first-paint.test.mts tests/search-debounce.test.mts` (9 passing)
- `npm run typecheck` and the repository pre-push gate passed.

## Post-deploy check

Confirm DebugBear mobile p75 for `#searchMobileFab` and the search-sheet header stays below 500 ms after sufficient traffic. The production baseline contained six interactions, so this PR intentionally does not claim the rollout-only acceptance result.

Related: #5158

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
