### PR TITLE
fix(a11y): restore Intel Feed tag contrast

### DIFF
--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -713,7 +713,7 @@ export class NewsPanel extends Panel {
     const threatVarMap: Record<string, string> = { critical: '--threat-critical', high: '--threat-high', medium: '--threat-medium', low: '--threat-low', info: '--threat-info' };
     const catColor = cluster.threat ? getCSSColor(threatVarMap[cluster.threat.level] || '--text-dim') : '';
     const categoryBadge = catLabel
-      ? `<span class="category-tag" style="color:${catColor};border-color:${catColor}40;background:${catColor}20">${catLabel}</span>`
+      ? `<span class="category-tag" style="--category-color:${catColor};--category-background:${catColor}20">${catLabel}</span>`
       : '';
 
     // Numeric risk score badge (0-100): from external getter or fallback to threat-level derivation

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4304,11 +4304,14 @@ body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
 }
 
 .category-tag {
+  color: var(--text);
   font-size: 8px;
   padding: 1px 5px;
   border-radius: 3px;
   font-weight: 600;
   border: 1px solid;
+  border-color: var(--category-color);
+  background: var(--category-background);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }

--- a/tests/intel-feed-category-tag-contrast.test.mts
+++ b/tests/intel-feed-category-tag-contrast.test.mts
@@ -51,6 +51,12 @@ function contrastRatio(a: string | [number, number, number], b: string | [number
   return (lighter! + 0.05) / (darker! + 0.05);
 }
 
+function requiredHexColor(vars: Record<string, string>, name: string, theme: string): string {
+  const value = vars[name];
+  assert.ok(value, `${theme} must define ${name} as a hex color for contrast verification`);
+  return value;
+}
+
 describe('Intel Feed category-tag contrast (#5166)', () => {
   it('uses primary text for the generated label while retaining the threat color as the tag treatment', () => {
     assert.match(
@@ -69,7 +75,7 @@ describe('Intel Feed category-tag contrast (#5166)', () => {
     const rootBlocks = [...mainCss.matchAll(/:root\s*\{/g)].map(match => cssBlock(mainCss.slice(match.index), ':root'));
     const base = cssVars(rootBlocks[0]!, rootBlocks[1]!);
     const light = { ...base, ...cssVars(cssBlock(mainCss, '[data-theme="light"]')) };
-    const happyLight = cssVars(cssBlock(happyCss, ':root[data-variant="happy"],'));
+    const happyLight = cssVars(cssBlock(happyCss, ':root[data-variant="happy"]'));
     const happyDark = cssVars(cssBlock(happyCss, ':root[data-variant="happy"][data-theme="dark"]'));
     const themes = [
       ['dark', base],
@@ -81,7 +87,14 @@ describe('Intel Feed category-tag contrast (#5166)', () => {
 
     for (const [name, vars] of themes) {
       for (const threatVar of threatVars) {
-        const ratio = contrastRatio(vars['--text']!, composite(vars[threatVar]!, vars['--surface']!, 0x20 / 0xff));
+        const ratio = contrastRatio(
+          requiredHexColor(vars, '--text', name),
+          composite(
+            requiredHexColor(vars, threatVar, name),
+            requiredHexColor(vars, '--surface', name),
+            0x20 / 0xff,
+          ),
+        );
         assert.ok(ratio >= 4.5, `${name} ${threatVar} category tag is ${ratio.toFixed(2)}:1 (needs 4.5:1)`);
       }
     }

--- a/tests/intel-feed-category-tag-contrast.test.mts
+++ b/tests/intel-feed-category-tag-contrast.test.mts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const newsPanelSource = readFileSync(resolve(root, 'src/components/NewsPanel.ts'), 'utf8');
+const mainCss = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8');
+const happyCss = readFileSync(resolve(root, 'src/styles/happy-theme.css'), 'utf8');
+
+function cssBlock(source: string, selector: string): string {
+  const start = source.indexOf(selector);
+  assert.notEqual(start, -1, `missing ${selector} selector`);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}' && --depth === 0) return source.slice(open + 1, i);
+  }
+  throw new Error(`unterminated ${selector} block`);
+}
+
+function cssVars(...blocks: string[]): Record<string, string> {
+  return Object.assign({}, ...blocks.map(block => Object.fromEntries(
+    [...block.matchAll(/(--[\w-]+):\s*(#[0-9a-fA-F]{3,6})\b/g)].map(([, name, value]) => [name!, value!]),
+  )));
+}
+
+function rgb(hex: string): [number, number, number] {
+  const expanded = hex.length === 4 ? `#${[...hex.slice(1)].map(char => char + char).join('')}` : hex;
+  return [1, 3, 5].map(offset => Number.parseInt(expanded.slice(offset, offset + 2), 16)) as [number, number, number];
+}
+
+function composite(foreground: string, background: string, alpha: number): [number, number, number] {
+  const fg = rgb(foreground);
+  const bg = rgb(background);
+  return fg.map((channel, index) => channel * alpha + bg[index]! * (1 - alpha)) as [number, number, number];
+}
+
+function luminance(color: string | [number, number, number]): number {
+  const channels = (typeof color === 'string' ? rgb(color) : color).map(channel => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+}
+
+function contrastRatio(a: string | [number, number, number], b: string | [number, number, number]): number {
+  const [lighter, darker] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (lighter! + 0.05) / (darker! + 0.05);
+}
+
+describe('Intel Feed category-tag contrast (#5166)', () => {
+  it('uses primary text for the generated label while retaining the threat color as the tag treatment', () => {
+    assert.match(
+      newsPanelSource,
+      /style="--category-color:\$\{catColor\};--category-background:\$\{catColor\}20"/,
+      'the generated tag keeps its threat-specific border and tint',
+    );
+    assert.doesNotMatch(newsPanelSource, /style="color:\$\{catColor\}/, 'the tint must not become the small label foreground');
+    const categoryTagCss = cssBlock(mainCss, '.category-tag');
+    assert.match(categoryTagCss, /color:\s*var\(--text\)/, 'small tag labels use the theme primary text color');
+    assert.match(categoryTagCss, /border-color:\s*var\(--category-color\)/, 'the border carries the category color');
+    assert.match(categoryTagCss, /background:\s*var\(--category-background\)/, 'the tint carries the category color');
+  });
+
+  it('keeps every category threat color AA-safe on each panel surface', () => {
+    const rootBlocks = [...mainCss.matchAll(/:root\s*\{/g)].map(match => cssBlock(mainCss.slice(match.index), ':root'));
+    const base = cssVars(rootBlocks[0]!, rootBlocks[1]!);
+    const light = { ...base, ...cssVars(cssBlock(mainCss, '[data-theme="light"]')) };
+    const happyLight = cssVars(cssBlock(happyCss, ':root[data-variant="happy"],'));
+    const happyDark = cssVars(cssBlock(happyCss, ':root[data-variant="happy"][data-theme="dark"]'));
+    const themes = [
+      ['dark', base],
+      ['light', light],
+      ['happy light', happyLight],
+      ['happy dark', happyDark],
+    ] as const;
+    const threatVars = ['--threat-critical', '--threat-high', '--threat-medium', '--threat-low', '--threat-info'];
+
+    for (const [name, vars] of themes) {
+      for (const threatVar of threatVars) {
+        const ratio = contrastRatio(vars['--text']!, composite(vars[threatVar]!, vars['--surface']!, 0x20 / 0xff));
+        assert.ok(ratio >= 4.5, `${name} ${threatVar} category tag is ${ratio.toFixed(2)}:1 (needs 4.5:1)`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Intel Feed category labels previously used the threat color as 8 px foreground text on the same color's translucent tint. The `CONFLICT` label could therefore render at 4.34:1.

The label now uses the active theme's primary text color while preserving the threat signal in its border and background tint.

Fixes #5166

## Validation

- Added a focused regression that exercises the generated tag path and calculates contrast for every threat color on the actual panel surface in standard dark/light and Happy dark/light themes.
- Confirmed the regression fails before the implementation change and passes after it.
- `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/intel-feed-category-tag-contrast.test.mts`
- `npm run typecheck`
- `./node_modules/.bin/biome lint src/components/NewsPanel.ts src/styles/main.css tests/intel-feed-category-tag-contrast.test.mts`
- `npm run lint` completed; it reports existing repository-wide warnings in unrelated files, while the changed files are clean.

## Post-Deploy Monitoring & Validation

- Owner: PR author / release reviewer.
- Within the first production deployment, rerun the UK desktop DebugBear or Lighthouse accessibility audit for `div#intelContent > div.item > div.item-source > span.category-tag`.
- Healthy signal: no `category-tag` color-contrast failure; `CONFLICT` is at least 4.5:1 at its rendered 8 px size.
- Failure signal and mitigation: any recurring tag contrast finding blocks issue closure; revert this commit or adjust the affected theme surface/token, then rerun the focused regression and audit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
