### PR TITLE
perf(mobile): profile panel work and trim font precache

### DIFF
--- a/scripts/measure-mobile-mainthread.mjs
+++ b/scripts/measure-mobile-mainthread.mjs
@@ -71,6 +71,21 @@ export function rankLongTasks(entries) {
     .sort((a, b) => b.tbtMs - a.tbtMs || b.totalMs - a.totalMs);
 }
 
+function summarizeLongTaskWindows(entries) {
+  return (Array.isArray(entries) ? entries : [])
+    .filter((entry) => (Number(entry?.duration) || 0) > TBT_THRESHOLD_MS)
+    .map((entry) => {
+      const startTime = Number(entry?.startTime) || 0;
+      const duration = Number(entry?.duration) || 0;
+      return {
+        source: longTaskSource(entry),
+        startTime: round(startTime),
+        duration: round(duration),
+        endTime: round(startTime + duration),
+      };
+    });
+}
+
 /** Headline long-task summary: counts, total ms, TBT ms, and the per-source ranking. */
 export function summarizeLongTasks(entries) {
   const list = Array.isArray(entries) ? entries : [];
@@ -83,6 +98,7 @@ export function summarizeLongTasks(entries) {
     totalMs: round(totalMs),
     tbtMs: round(tbtMs),
     ranked: rankLongTasks(list),
+    windows: summarizeLongTaskWindows(list),
   };
 }
 
@@ -96,6 +112,14 @@ function summarizeLcpResources(resources) {
     count: Number(resource?.count) || 0,
     encodedBodySize: round(resource?.encodedBodySize),
     transferSize: round(resource?.transferSize),
+  }));
+}
+
+function summarizeLcpMarks(marks) {
+  return (Array.isArray(marks) ? marks : []).map((mark) => ({
+    name: String(mark?.name || ''),
+    startTime: round(mark?.startTime),
+    ...(mark?.detail ? { detail: mark.detail } : {}),
   }));
 }
 
@@ -114,6 +138,7 @@ export function summarizeLcpDebug(snapshot) {
     } : null,
     context: snapshot?.context ?? latest?.context ?? null,
     entryCount: entries.length,
+    marks: summarizeLcpMarks(snapshot?.marks),
     resources: summarizeLcpResources(latest?.resources ?? snapshot?.resources),
   };
 }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1543,6 +1543,8 @@ export class PanelLayoutManager implements AppModule {
     const grid = this.getPanelMountGrid(key);
     if (!grid && !deferred.placeholder?.parentNode) return false;
 
+    markLcpDebug('wm:panel:deferred-mount-start', { panel: key });
+
     deferred.observer?.disconnect();
     deferred.observer = null;
     if (deferred.retryTimer !== null) {
@@ -1555,16 +1557,19 @@ export class PanelLayoutManager implements AppModule {
       if (current !== deferred || deferred.mounted) return;
       deferred.loading = null;
       if (!panel || this.ctx.isDestroyed) {
+        markLcpDebug('wm:panel:deferred-mount-unavailable', { panel: key });
         this.scheduleDeferredPanelRetry(key, deferred);
         return;
       }
       const placeholder = deferred.placeholder;
-      if (this.mountPanelElement(targetGrid, key, panel, placeholder)) {
+      const mounted = this.mountPanelElement(targetGrid, key, panel, placeholder);
+      if (mounted) {
         this.afterPanelMounted(key, panel);
       }
       deferred.mounted = true;
       deferred.placeholder = null;
       this.deferredPanelMounts.delete(key);
+      markLcpDebug('wm:panel:deferred-mount-ready', { mounted, panel: key });
     };
 
     if (deferred.panel) {

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -439,6 +439,7 @@ describe('deploy/cache configuration guardrails', () => {
     assertGlobIgnore('pro/**');
     assertGlobIgnore('favico/**');
     assertGlobIgnore('textures/**');
+    assertGlobIgnore('**/*.woff2');
     // #4891: blog OG covers exist only in prod builds (blog generated at
     // deploy), so a local dist/sw.js never exposes the regression — guard the
     // config directly. Without this ignore, every first dashboard visit

--- a/tests/lcp-attribution-contract.test.mjs
+++ b/tests/lcp-attribution-contract.test.mjs
@@ -57,6 +57,13 @@ describe('LCP attribution debug contract', () => {
     assert.ok(layoutSrc.includes("markLcpDebug('wm:layout:shell-replaced'"));
     assert.ok(layoutSrc.includes("markLcpDebug('wm:map:container-construct'"));
     assert.ok(layoutSrc.includes("markLcpDebug('wm:map:container-ready'"));
+    for (const mark of [
+      'wm:panel:deferred-mount-start',
+      'wm:panel:deferred-mount-ready',
+      'wm:panel:deferred-mount-unavailable',
+    ]) {
+      assert.ok(layoutSrc.includes(`markLcpDebug('${mark}'`), `missing deferred panel trace mark ${mark}`);
+    }
 
     for (const mark of [
       'wm:map:shell-shown',

--- a/tests/measure-mobile-mainthread.test.mts
+++ b/tests/measure-mobile-mainthread.test.mts
@@ -54,6 +54,7 @@ describe('measure-mobile-mainthread attribution', () => {
       totalMs: 0,
       tbtMs: 0,
       ranked: [],
+      windows: [],
     });
     assert.equal(rankLongTasks([]).length, 0);
     assert.equal(rankLongTasks(undefined).length, 0);
@@ -75,6 +76,7 @@ describe('measure-mobile-mainthread attribution', () => {
         startTime: 987.65,
         url: '',
       }],
+      marks: [{ detail: { panel: 'markets' }, name: 'wm:panel:deferred-mount-start', startTime: 1337.4 }],
       resources: [],
     });
     assert.equal(summary.entryCount, 1);
@@ -83,6 +85,7 @@ describe('measure-mobile-mainthread attribution', () => {
     assert.equal(summary.resources[0].category, 'map-topology');
     assert.equal(summary.resources[0].transferSize, 1200.6);
     assert.equal(summary.context?.variant, 'tech');
+    assert.deepEqual(summary.marks, [{ detail: { panel: 'markets' }, name: 'wm:panel:deferred-mount-start', startTime: 1337.4 }]);
   });
 
   it('summarizes missing LCP debug data without throwing', () => {
@@ -90,6 +93,12 @@ describe('measure-mobile-mainthread attribution', () => {
     assert.equal(summary.candidate, null);
     assert.equal(summary.entryCount, 0);
     assert.deepEqual(summary.resources, []);
+    assert.deepEqual(summary.marks, []);
+  });
+
+  it('keeps long-task timing windows for correlation with debug marks', () => {
+    const summary = summarizeLongTasks([{ duration: 80, name: 'self', startTime: 120 }]);
+    assert.deepEqual(summary.windows, [{ duration: 80, endTime: 200, source: 'self', startTime: 120 }]);
   });
 
   it('attributeDomNodes computes share percentages and sorts by node count desc', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1016,6 +1016,9 @@ export default defineConfig(({ mode }) => {
             '**/onnx*.wasm',
             '**/locale-*.js',
             '**/clerk-*.js',
+            // Fonts are fetched only when their stylesheet applies. Precache
+            // would pull every local weight into the first mobile visit.
+            '**/*.woff2',
             // Keep off-page/static-heavy public assets out of the dashboard's
             // first-visit precache. The small root favicons above remain
             // explicit includeAssets entries.


### PR DESCRIPTION
## Summary

The late mobile task wave can now be correlated with deferred-panel lifecycle timing before changing its scheduling. The profiler reports every task above the 50 ms long-task threshold with an exact time window, alongside opt-in panel mount start, completion, and attach-result marks.

The service worker also stops forcing every local `woff2` font weight into the first dashboard visit. Fonts remain available on demand when their stylesheet applies.

| Service-worker precache | Before | After |
| --- | ---: | ---: |
| Entries | 251 | 225 |
| Size | 10,762.11 KiB | 10,476.45 KiB |

Normal visitors do not receive native User Timing marks or recorder writes; the profiler enables the existing debug recorder through local storage.

## Validation

- `./node_modules/.bin/tsx --test tests/measure-mobile-mainthread.test.mts tests/lcp-debug-gating.test.mts tests/lcp-attribution-contract.test.mjs` (30 passing)
- `npm run typecheck`
- `npm run build`
- Full repository pre-push gate, including frontend/API checks and changed test suites

The emitted `sw.js` and Workbox manifest contain no `.woff2` precache entries.

The local 4x trace confirmed that marks and task windows are recorded, but its CORS-constrained initial state did not auto-mount deferred panels. It is not evidence that the production task wave is fixed.

## Post-deploy monitoring and validation

Run the same iPhone 14 Pro Max / 4x CPU profile with a 35-second settle window against the deployed dashboard. Compare each `wm:panel:deferred-mount-*` interval with `tasks.windows` and the trace around 19–31.5 seconds.

Proceed to a scheduling change only when a late task overlaps a concrete panel lifecycle interval. If the marks are absent or do not overlap the wave, keep scheduling unchanged and continue attribution; this slice is inert outside opt-in debug runs.

Related: #5165

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
