### PR TITLE
fix(welcome): drop dead Wikidata QID from homepage sameAs

### DIFF
--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -173,7 +173,7 @@
       "operatingSystem": "Web, Windows, macOS, Linux, Android TV",
       "url": "https://worldmonitor.app",
       "description": "Free real-time global intelligence dashboard. 500+ news feeds, conflict tracking, market data, shipping chokepoints, satellite passes and cyber signals fused into one live map of the world, with AI analysis layered on top.",
-      "sameAs": ["https://www.wikidata.org/wiki/Q140439514", "https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
+      "sameAs": ["https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
       "author": {
         "@type": "Person",
         "name": "Elie Habib",

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -173,7 +173,7 @@
       "operatingSystem": "Web, Windows, macOS, Linux, Android TV",
       "url": "https://worldmonitor.app",
       "description": "Free real-time global intelligence dashboard. 500+ news feeds, conflict tracking, market data, shipping chokepoints, satellite passes and cyber signals fused into one live map of the world, with AI analysis layered on top.",
-      "sameAs": ["https://www.wikidata.org/wiki/Q140439514", "https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
+      "sameAs": ["https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
       "author": {
         "@type": "Person",
         "name": "Elie Habib",


### PR DESCRIPTION
## What

The welcome page (served at `/` via the `vercel.json` host rewrite → `/pro/welcome.html`) advertised a `SoftwareApplication` JSON-LD `sameAs` pointing at `https://www.wikidata.org/wiki/Q140439514` — a **non-existent Wikidata entity**:
- `wbgetentities` → `{"id":"Q140439514","missing":""}`
- `Special:EntityData/Q140439514.json` → **404**
- deletion log: speedy-deleted **2026-07-05** under [WD:N](https://www.wikidata.org/wiki/Wikidata:Notability) (bare label, sole self-creator, no refs)

## Why it matters

A `sameAs` to a deleted entity is a broken trust signal — the Knowledge Graph and AI crawlers dereference `sameAs` and hard-fail on it. It also produced a contradictory result in an ora.ai scan (Discovery agent dereferenced it → "no Wikidata entity"; the sameAs check only pattern-matched the URL's presence → false pass).

## Change

Removed the dead QID from `pro-test/welcome.html` (source) and `public/pro/welcome.html` (the build-injected artifact that ships). Kept the live `github` + `npm` links. The real **person** entity `Q121365724` (Elie Habib) is untouched.

## Follow-up (not in this PR)

- Recreate the WorldMonitor **app** entity on Wikidata with references → new QID → rewire `sameAs`.
- The WIRED-citation swap (wired.me → global wired.com edition) is tracked in a **separate PR**, not this one.

https://claude.ai/code/session_01J4WNHvxXL79zEjgUuHQ9ci