### PR TITLE
fix(brief): vary analyst why-matters prose

### DIFF
--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -261,8 +261,17 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
     });
     if (!result) return null;
     // v2 parser accepts multi-sentence output + rejects preamble /
-    // leaked section labels. Analyst path ONLY — gemini path stays on v1.
-    return parseWhyMattersV2(result.content);
+    // leaked section labels and private forecast percentages. Keep public
+    // story grounding separate so sourced figures remain publishable.
+    // Analyst path ONLY — gemini path stays on v1.
+    return parseWhyMattersV2(result.content, {
+      publicStory: {
+        headline: story.headline,
+        description: story.description,
+        source: story.source,
+      },
+      privateForecasts: context.forecasts,
+    });
   } catch (err) {
     console.warn(`[brief-why-matters] analyst path failed: ${err instanceof Error ? err.message : String(err)}`);
     // Nested helper called outside the request's `ctx.waitUntil` chain
@@ -398,6 +407,11 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
 
   // Cache identity.
   const hash = await hashBriefStory(story);
+  // v9 (2026-07-10): bumped from v8 alongside the analyst output-policy
+  // rollout. v8 rows may use the retired formulaic voice or expose raw
+  // forecast probabilities, and cache hits bypass parseWhyMattersV2, so
+  // they must not survive the deploy.
+  //
   // v8 (2026-05-14): bumped from v7 alongside the F6 date-grounding
   // line appended to both whyMatters system prompts (analyst v2 and
   // the gemini fallback). Every v7 row was produced from a prompt
@@ -415,10 +429,10 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
   //
   // v6 history (kept for reference): category-gated context + prompt-level
   // RELEVANCE RULE (2026-04-22) — those changes remain in v8.
-  const cacheKey = `brief:llm:whymatters:v8:${hash}`;
-  // Shadow v5→v6 for the same reason — a mid-rollout shadow record
-  // comparing v7 pre-date-grounding vs gemini is not useful once v8 is live.
-  const shadowKey = `brief:llm:whymatters:shadow:v6:${hash}`;
+  const cacheKey = `brief:llm:whymatters:v9:${hash}`;
+  // Shadow v6→v7 for the same reason: a pre-policy v6 record would mix
+  // retired and current analyst outputs in the seven-day evaluation cohort.
+  const shadowKey = `brief:llm:whymatters:shadow:v7:${hash}`;
 
   // Cache read. Any infrastructure failure → treat as miss (logged).
   let cached: WhyMattersEnvelope | null = null;

--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -116,7 +116,7 @@ function readConfig(env: Record<string, string | undefined> = process.env as Rec
 const WHY_MATTERS_TTL_SEC = 6 * 60 * 60; // 6h
 const SHADOW_TTL_SEC = 7 * 24 * 60 * 60; // 7d
 
-// whyMatters is a 2–3 sentence editorial blurb — the fast utility model, not
+// whyMatters is a 1–2 sentence editorial blurb — the fast utility model, not
 // the reasoning tier. Pinning it here DECOUPLES the stage from
 // LLM_REASONING_MODEL: the U3 flip to deepseek-v4-pro dragged this stage onto
 // a 6–10s reasoning model (#4983); flash serves it at ~1.6–2.4s. openrouter
@@ -244,8 +244,9 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
         { role: 'system', content: system },
         { role: 'user', content: user },
       ],
-      // v2 prompt is 2–3 sentences / 40–70 words — roughly 3× v1's
-      // single-sentence output, so bump maxTokens proportionally.
+      // v2 prompt is 1–2 sentences / 25–40 words. maxTokens stays generous
+      // (well above the ~60 tokens a 40-word blurb needs) as deliberate
+      // headroom so a completion is never clipped mid-sentence (#5168).
       maxTokens: 260,
       temperature: 0.4,
       timeoutMs: 15_000,
@@ -408,9 +409,10 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
   // Cache identity.
   const hash = await hashBriefStory(story);
   // v9 (2026-07-10): bumped from v8 alongside the analyst output-policy
-  // rollout. v8 rows may use the retired formulaic voice or expose raw
-  // forecast probabilities, and cache hits bypass parseWhyMattersV2, so
-  // they must not survive the deploy.
+  // rollout. v8 rows may use the retired formulaic voice, the longer
+  // 40–70-word / 2–3-sentence length, or expose raw forecast probabilities,
+  // and cache hits bypass parseWhyMattersV2, so they must not survive the
+  // deploy.
   //
   // v8 (2026-05-14): bumped from v7 alongside the F6 date-grounding
   // line appended to both whyMatters system prompts (analyst v2 and

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -115,8 +115,8 @@ const BRIEF_LLM_SKIP_PROVIDERS = ['ollama', 'groq'];
  *
  * Four-layer graceful degradation:
  *   1. `deps.callAnalystWhyMatters(story)` — the analyst-context edge
- *      endpoint (brief:llm:whymatters:v8 cache lives there). Preferred.
- *   2. Direct read of the endpoint's v8 envelope cache (#4914) — the
+ *      endpoint (brief:llm:whymatters:v9 cache lives there). Preferred.
+ *   2. Direct read of the endpoint's v9 envelope cache (#4914) — the
  *      endpoint CALL can fail while its cached envelope is still valid;
  *      reusing it avoids a paid duplicate generation.
  *   3. Legacy direct-Gemini chain: cacheGet (v5) → callLLM → cacheSet.
@@ -165,7 +165,7 @@ export async function generateWhyMatters(story, deps) {
 
   // #4914: before paying a direct-Gemini generation, check the analyst
   // endpoint's OWN cache namespace. api/internal/brief-why-matters.ts
-  // stores its envelope at brief:llm:whymatters:v8:{hash} under the same
+  // stores its envelope at brief:llm:whymatters:v9:{hash} under the same
   // hashBriefStory identity — when the endpoint CALL failed transiently
   // (or no endpoint is configured), the story may already have a paid,
   // validated envelope sitting in Redis. Read-only: this fallback's own
@@ -173,15 +173,15 @@ export async function generateWhyMatters(story, deps) {
   // two prompt contracts never cross-contaminate in the write direction.
   const storyHash = await hashBriefStory(story);
   try {
-    const v8 = await deps.cacheGet(`brief:llm:whymatters:v8:${storyHash}`);
-    if (v8 && typeof v8 === 'object' && typeof v8.whyMatters === 'string') {
-      const v8Trimmed = v8.whyMatters.trim();
+    const v9 = await deps.cacheGet(`brief:llm:whymatters:v9:${storyHash}`);
+    if (v9 && typeof v9 === 'object' && typeof v9.whyMatters === 'string') {
+      const v9Trimmed = v9.whyMatters.trim();
       // Same acceptance bounds as the live-endpoint path above.
       if (
-        v8Trimmed.length >= 30 && v8Trimmed.length <= 500
-        && !/^story flagged by your sensitivity/i.test(v8Trimmed)
+        v9Trimmed.length >= 30 && v9Trimmed.length <= 500
+        && !/^story flagged by your sensitivity/i.test(v9Trimmed)
       ) {
-        return v8Trimmed;
+        return v9Trimmed;
       }
     }
   } catch { /* treat as miss */ }

--- a/scripts/shared/brief-llm-core.d.ts
+++ b/scripts/shared/brief-llm-core.d.ts
@@ -35,7 +35,14 @@ export function hashBriefStory(story: BriefStoryHashInput): Promise<string>;
 
 // ── v2 (analyst path only) ────────────────────────────────────────────────
 export const WHY_MATTERS_ANALYST_SYSTEM_V2: string;
-export function parseWhyMattersV2(text: unknown): string | null;
+export interface WhyMattersV2Provenance {
+  publicStory?: Pick<BriefStoryHashInput, 'headline' | 'description' | 'source'>;
+  privateForecasts?: string;
+}
+export function parseWhyMattersV2(
+  text: unknown,
+  provenance?: WhyMattersV2Provenance,
+): string | null;
 
 // ── Hallucination validator (PR-2 of brief-content-quality regressions) ──
 export function extractProperNounSequences(text: string): string[][];

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -161,26 +161,30 @@ export async function hashBriefStory(story) {
 // single-sentence abstraction-speak ("destabilize / systemic / sovereign
 // risk repricing") with no named actors, metrics, or dates. Root cause:
 // the 18–30 word cap compressed the context's specifics out of the LLM's
-// response. v2 loosens to 40–70 words across 2–3 sentences and REQUIRES
-// the LLM to ground at least one specific reference from the story or
-// materially relevant live context.
+// response. v2 first loosened to 40–70 words / 2–3 sentences; 2026-07-10
+// retightens to 25–40 words / 1–2 sentences after the field read found the
+// looser cap produced padded, formulaic prose — "much longer to say almost
+// the same" as the concise stable path. Still REQUIRES the LLM to ground at
+// least one specific reference from the story or materially relevant live
+// context.
 
 /**
- * System prompt for the analyst-path v2 (2–3 sentences, ~40–70 words,
- * grounded in a specific named actor / metric / date / place. It uses
+ * System prompt for the analyst-path v2 (1–2 sentences, ~25–40 words,
+ * grounded in a specific named actor / metric / date / place). It uses
  * varied plain prose rather than a fixed analytic sequence, with no
  * section labels in the output.
  */
 export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   'You are the lead analyst at WorldMonitor Brief, a geopolitical intelligence magazine. ' +
-  'Using the story as the primary source and the optional Live WorldMonitor Context only when it is materially connected, write 2–3 sentences (40–70 words total) ' +
+  'Using the story as the primary source and the optional Live WorldMonitor Context only when it is materially connected, write 1–2 sentences (25–40 words total) ' +
   'on why the story matters.\n\n' +
   'VOICE:\n' +
+  '- Be concise: high signal density, every word earns its place. Do not pad to fill the range or restate the headline.\n' +
   '- Vary sentence structure and emphasis across stories; choose the natural angle for this story rather than following a fixed sequence.\n' +
   '- Do not default to a second sentence beginning "This…" or a "Watch for…" closing construction.\n' +
   '- Ground the prose in a SPECIFIC named actor, metric, date, or place relevant to this story.\n\n' +
   'HARD CONSTRAINTS:\n' +
-  '- Total length 40–70 words across 2–3 sentences.\n' +
+  '- Total length 25–40 words across 1–2 sentences.\n' +
   '- MUST reference at least ONE specific: named person / country / organization / ' +
   'number / percentage / date / city.\n' +
   '- No preamble ("This matters because…", "The importance of…").\n' +
@@ -201,7 +205,7 @@ export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
 
 /**
  * Parse + validate the analyst-path v2 LLM response. Accepts
- * multi-sentence output (2–3 sentences), 100–500 chars. Otherwise
+ * short multi-sentence output (1–2 sentences), 100–500 chars. Otherwise
  * same rejection semantics as v1 (stub echo, empty) plus explicit
  * rejection of preamble boilerplate and leaked section labels.
  *

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -209,9 +209,13 @@ export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
  * fall through to the next layer.
  *
  * @param {unknown} text
+ * @param {{
+ *   publicStory?: { headline?: string, description?: string, source?: string },
+ *   privateForecasts?: string,
+ * }} [provenance]
  * @returns {string | null}
  */
-export function parseWhyMattersV2(text) {
+export function parseWhyMattersV2(text, provenance) {
   if (typeof text !== 'string') return null;
   let s = text.trim();
   if (!s) return null;
@@ -227,16 +231,32 @@ export function parseWhyMattersV2(text) {
   // Reject markdown / section-label leakage (we told it to use plain prose).
   if (/^(#|-|\*|\d+\.\s)/.test(s)) return null;
   if (/^(situation|analysis|watch)\s*[:\-–—]/i.test(s)) return null;
-  // The prompt makes forecast figures private reasoning input, but models can
-  // still disobey. Reject only percentages framed as forecasts/probabilities;
-  // ordinary sourced figures such as "20% of seaborne oil" remain valid.
-  const percentage = '\\b\\d{1,3}\\s?(?:%|percent\\b)';
-  const forecastTerm = '\\b(?:forecast|predict(?:ion|s|ed)?|probability|likelihood|chance|odds|likely)\\b';
-  const forecastPercentage = new RegExp(
-    `${forecastTerm}.{0,32}${percentage}|${percentage}.{0,32}${forecastTerm}`,
-    'i',
-  );
-  if (forecastPercentage.test(s)) return null;
+  // Forecast context is private reasoning input. Compare normalized percentage
+  // values instead of nearby wording so paraphrases, distance, and newlines do
+  // not bypass the guard. A value present in the public story remains valid
+  // even when the private forecast block happens to contain the same number.
+  const percentageValues = (value) => {
+    if (typeof value !== 'string' || value.length === 0) return new Set();
+    const values = new Set();
+    const percentage = /(?:^|[^\d.])(\d{1,3}(?:\.\d+)?)\s*(?:%|per\s*cent\b)/gi;
+    for (const match of value.matchAll(percentage)) {
+      const number = Number(match[1]);
+      if (Number.isFinite(number)) values.add(String(number));
+    }
+    return values;
+  };
+  const privateValues = percentageValues(provenance?.privateForecasts);
+  if (privateValues.size > 0) {
+    const publicStory = provenance?.publicStory;
+    const publicText = [publicStory?.headline, publicStory?.description, publicStory?.source]
+      .filter((value) => typeof value === 'string')
+      .join('\n');
+    const publicValues = percentageValues(publicText);
+    const outputValues = percentageValues(s);
+    for (const value of outputValues) {
+      if (privateValues.has(value) && !publicValues.has(value)) return null;
+    }
+  }
   return s;
 }
 

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -162,25 +162,23 @@ export async function hashBriefStory(story) {
 // risk repricing") with no named actors, metrics, or dates. Root cause:
 // the 18–30 word cap compressed the context's specifics out of the LLM's
 // response. v2 loosens to 40–70 words across 2–3 sentences and REQUIRES
-// the LLM to ground at least one specific reference from the live context.
+// the LLM to ground at least one specific reference from the story or
+// materially relevant live context.
 
 /**
  * System prompt for the analyst-path v2 (2–3 sentences, ~40–70 words,
- * grounded in a specific named actor / metric / date / place drawn
- * from the live context). Shape nudged toward the WMAnalyst chat voice
- * (SITUATION → ANALYSIS → optional WATCH) but rendered as plain prose,
- * no section labels in the output.
+ * grounded in a specific named actor / metric / date / place. It uses
+ * varied plain prose rather than a fixed analytic sequence, with no
+ * section labels in the output.
  */
 export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   'You are the lead analyst at WorldMonitor Brief, a geopolitical intelligence magazine. ' +
-  'Using the Live WorldMonitor Context AND the story, write 2–3 sentences (40–70 words total) ' +
+  'Using the story as the primary source and the optional Live WorldMonitor Context only when it is materially connected, write 2–3 sentences (40–70 words total) ' +
   'on why the story matters.\n\n' +
-  'STRUCTURE:\n' +
-  '1. SITUATION — what is happening right now, grounded in a SPECIFIC named actor, ' +
-  'metric, date, or place relevant to this story.\n' +
-  '2. ANALYSIS — the structural consequence (why this forces a repricing, shifts ' +
-  'the balance, triggers a cascade).\n' +
-  '3. (Optional) WATCH — the threshold or indicator to track, if clear from the context.\n\n' +
+  'VOICE:\n' +
+  '- Vary sentence structure and emphasis across stories; choose the natural angle for this story rather than following a fixed sequence.\n' +
+  '- Do not default to a second sentence beginning "This…" or a "Watch for…" closing construction.\n' +
+  '- Ground the prose in a SPECIFIC named actor, metric, date, or place relevant to this story.\n\n' +
   'HARD CONSTRAINTS:\n' +
   '- Total length 40–70 words across 2–3 sentences.\n' +
   '- MUST reference at least ONE specific: named person / country / organization / ' +
@@ -190,11 +188,12 @@ export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   '- Editorial, impersonal, serious. No calls to action, no questions, no quotes.\n\n' +
   'RELEVANCE RULE (critical, read carefully):\n' +
   '- The context block may contain facts from world-brief, country-brief, risk scores, ' +
-  'forecasts, macro signals, and market data. These are BACKGROUND — only cite what is ' +
-  "directly relevant to this story's category and country.\n" +
+  'forecasts, macro signals, and market data. These are optional BACKGROUND, not a ' +
+  "mandatory narrative — most stories should not mention the global context. Only cite what is directly relevant to this story's category and country.\n" +
   '- If NO context fact clearly fits, ground instead in a named actor, place, date, ' +
   'or figure drawn from the headline or description. That is a VALID grounding — do ' +
   'NOT invent a market reading, VIX value, or forecast probability to satisfy the rule.\n' +
+  '- Treat internal forecast figures as private reasoning input. Do not quote raw forecast probabilities or present a WorldMonitor forecast as a user-facing fact.\n' +
   '- NEVER drag an off-topic market metric, FX reading, or probability into a ' +
   'humanitarian, aviation, diplomacy, or cyber story. A story about a refugee flow ' +
   'does not need a VIX number; a story about a drone incursion does not need an FX ' +
@@ -228,6 +227,16 @@ export function parseWhyMattersV2(text) {
   // Reject markdown / section-label leakage (we told it to use plain prose).
   if (/^(#|-|\*|\d+\.\s)/.test(s)) return null;
   if (/^(situation|analysis|watch)\s*[:\-–—]/i.test(s)) return null;
+  // The prompt makes forecast figures private reasoning input, but models can
+  // still disobey. Reject only percentages framed as forecasts/probabilities;
+  // ordinary sourced figures such as "20% of seaborne oil" remain valid.
+  const percentage = '\\b\\d{1,3}\\s?(?:%|percent\\b)';
+  const forecastTerm = '\\b(?:forecast|predict(?:ion|s|ed)?|probability|likelihood|chance|odds|likely)\\b';
+  const forecastPercentage = new RegExp(
+    `${forecastTerm}.{0,32}${percentage}|${percentage}.{0,32}${forecastTerm}`,
+    'i',
+  );
+  if (forecastPercentage.test(s)) return null;
   return s;
 }
 
@@ -972,4 +981,3 @@ export function verifyCitationIndexes(text, sourceCount) {
   });
   return { text: cleaned, stripped };
 }
-

--- a/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
+++ b/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
@@ -107,14 +107,6 @@ const CATEGORY_SECTION_POLICY: Array<{ match: RegExp; sections: SectionKey[]; la
     match: /\b(energy|commodit|market|financ|trade|oil|gas|fuel)/i,
     sections: ['worldBrief', 'countryBrief', 'forecasts', 'macroSignals', 'marketData'],
   },
-  // Humanitarian / civil / social / rights — NO market, NO forecasts.
-  // This is the #1 source of the "77% FX stress dragged into a Rwanda
-  // story" pattern from the 2026-04-22 shadow review.
-  {
-    label: 'humanitarian',
-    match: /\b(humanitarian|refuge|civil|social|rights|genocid|aid\b|migrat)/i,
-    sections: ['worldBrief', 'countryBrief', 'riskScores'],
-  },
   // Justice, history, and human-interest stories are usually local to the
   // reported event. Do not feed them the global narrative or forecasts: a
   // country-specific fact can still help, but a live conflict storyline
@@ -123,6 +115,16 @@ const CATEGORY_SECTION_POLICY: Array<{ match: RegExp; sections: SectionKey[]; la
     label: 'local',
     match: /\b(justice|court|legal|law\b|crime|criminal|history|historical|heritage|culture|human.?interest|obituar|celebrity|entertainment)/i,
     sections: ['countryBrief', 'riskScores'],
+  },
+  // Humanitarian / civil / social / rights — NO market, NO forecasts.
+  // This is the #1 source of the "77% FX stress dragged into a Rwanda
+  // story" pattern from the 2026-04-22 shadow review. Keep this after the
+  // local rule so a combined label such as "Civil Rights Court Ruling"
+  // receives the narrower court-story context.
+  {
+    label: 'humanitarian',
+    match: /\b(humanitarian|refuge|civil|social|rights|genocid|aid\b|migrat)/i,
+    sections: ['worldBrief', 'countryBrief', 'riskScores'],
   },
   // Geopolitical risk / conflict / military / security — risk + forecasts
   // but not market data (the LLM would otherwise tack on a VIX reading to

--- a/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
+++ b/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
@@ -115,6 +115,15 @@ const CATEGORY_SECTION_POLICY: Array<{ match: RegExp; sections: SectionKey[]; la
     match: /\b(humanitarian|refuge|civil|social|rights|genocid|aid\b|migrat)/i,
     sections: ['worldBrief', 'countryBrief', 'riskScores'],
   },
+  // Justice, history, and human-interest stories are usually local to the
+  // reported event. Do not feed them the global narrative or forecasts: a
+  // country-specific fact can still help, but a live conflict storyline
+  // should not be shoehorned into a court ruling or historical commemoration.
+  {
+    label: 'local',
+    match: /\b(justice|court|legal|law\b|crime|criminal|history|historical|heritage|culture|human.?interest|obituar|celebrity|entertainment)/i,
+    sections: ['countryBrief', 'riskScores'],
+  },
   // Geopolitical risk / conflict / military / security — risk + forecasts
   // but not market data (the LLM would otherwise tack on a VIX reading to
   // every conflict story).
@@ -239,7 +248,7 @@ export function buildAnalystWhyMattersPrompt(
 
   const parts: string[] = [];
   if (contextBlock) {
-    parts.push('# Live WorldMonitor Context', contextBlock);
+    parts.push('# Optional Live WorldMonitor Context', contextBlock);
   }
   parts.push('# Story', storyLines);
   // Prompt footer restates the grounding requirement inline (models
@@ -260,11 +269,13 @@ export function buildAnalystWhyMattersPrompt(
   // grounding target when no context fact is a clean fit.
   parts.push(
     `Write 2–3 sentences (40–70 words) on why this ${safe.category || 'story'} matters, grounded in at ` +
-      "least ONE specific reference. Prefer a fact drawn from the context block above WHEN it clearly " +
-      "relates to this story's category and country. If no context fact is a clean fit, ground " +
+      "least ONE specific reference. Reference the global context only when materially connected to this " +
+      "story's category and country; most stories should not mention the global context. If no context fact is a clean fit, ground " +
       'instead in a named actor, place, date, or figure from the headline or description. ' +
       'DO NOT force an off-topic market metric, VIX value, FX reading, or forecast probability ' +
-      "into a story where it does not belong. Plain prose, no section labels in the output:",
+      'into a story where it does not belong. Treat forecasts as private reasoning input: do not quote raw ' +
+      'forecast probabilities or present them as user-facing facts. Vary sentence structure; avoid a stock ' +
+      '"This…" second-sentence opener or "Watch for…" closer. Plain prose, no section labels in the output:',
   );
 
   // F6: append the current date so the analyst does not fabricate

--- a/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
+++ b/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
@@ -67,10 +67,12 @@ const CONTEXT_BUDGET_CHARS = 1700;
 // stories don't see domestic risk scores; etc. The model physically cannot
 // cite what it wasn't given.
 //
-// Matching is case-insensitive substring on the story's category slug
-// (shared/brief-filter.js:134 — category is free-form like "Humanitarian
-// Crisis", "Geopolitical Risk", "Energy"). First match wins. Unknown →
-// DEFAULT_SECTIONS (all six — same as pre-gating behavior).
+// Category matching is case-insensitive because the production brief
+// envelope carries Title-Cased canonical EventCategory values. A narrow
+// story-text override below handles local stories whose canonical category
+// is necessarily broader (for example a historical genocide retrospective
+// classified as Conflict). First match wins. Unknown → DEFAULT_SECTIONS
+// (all six — same as pre-gating behavior).
 type SectionKey = Exclude<keyof BriefStoryContext, 'degraded'>;
 
 // Per-section caps so no single heavy bundle (e.g. long worldBrief)
@@ -94,6 +96,31 @@ const DEFAULT_SECTIONS: SectionKey[] = [
   'marketData',
 ];
 
+const LOCAL_SECTIONS: SectionKey[] = ['countryBrief', 'riskScores'];
+
+// The production classifier deliberately emits a small canonical category
+// enum, so justice/history/human-interest are often represented as General,
+// Crime, or even Conflict when a phrase such as "genocide" or "mass casualty"
+// wins keyword classification. Use grounded story text to recover that local
+// scope without weakening genuine active-conflict routing.
+const LOCAL_HISTORY_OR_HUMAN_INTEREST_RE =
+  /\b(?:historical memory|anniversar(?:y|ies)|commemorat(?:e|es|ed|ing|ion|ions)|memorials?|retrospective|survivors?\s+of\s+(?:the\s+)?(?:19|20)\d{2}|human[\s-]?interest|obituar(?:y|ies)|celebrit(?:y|ies)|entertainment)\b/i;
+const LOCAL_JUSTICE_RE =
+  /\b(?:court|judge|judicial|plaintiffs?|defendants?|lawsuits?|rulings?|sentenc(?:e|es|ed|ing)|convict(?:ed|ion|ions)?|extradit(?:e|es|ed|ing|ion|ions)|guilty pleas?|pleads? guilty|prosecut(?:e|es|ed|ing|ion|ions|or|ors)|indict(?:ed|ment|ments)?|trials?|appeals?|reparations?)\b/i;
+const ACTIVE_GEOPOLITICAL_RE =
+  /\b(?:airstrikes?|missiles?|troops?|military|war|armed conflict|ceasefires?|invasion|bombing|drone strikes?|nuclear|hostages?|genocides?|ethnic cleansing|terror(?:ism|ists?| attacks?)?)\b/i;
+
+function storyUsesLocalContext(story: StoryForPrompt): boolean {
+  // Only repair the broad classifier buckets that swallowed the reported
+  // local stories. Specific categories (Energy, Economic, Diplomatic, etc.)
+  // already carry stronger editorial intent and must keep their own policy
+  // even when a headline happens to mention a court or ruling.
+  if (!/^(?:conflict|general)$/i.test(story.category)) return false;
+  const text = `${story.headline} ${story.description ?? ''}`;
+  if (LOCAL_HISTORY_OR_HUMAN_INTEREST_RE.test(text)) return true;
+  return LOCAL_JUSTICE_RE.test(text) && !ACTIVE_GEOPOLITICAL_RE.test(text);
+}
+
 // NOTE on regex shape: patterns use a LEADING `\b` (start-of-word
 // anchor) but NO TRAILING `\b`, so they match stems. "Diplomac" must
 // match "Diplomacy" and "Diplomatic"; "migrat" must match "migration"
@@ -114,7 +141,7 @@ const CATEGORY_SECTION_POLICY: Array<{ match: RegExp; sections: SectionKey[]; la
   {
     label: 'local',
     match: /\b(justice|court|legal|law\b|crime|criminal|history|historical|heritage|culture|human.?interest|obituar|celebrity|entertainment)/i,
-    sections: ['countryBrief', 'riskScores'],
+    sections: LOCAL_SECTIONS,
   },
   // Humanitarian / civil / social / rights — NO market, NO forecasts.
   // This is the #1 source of the "77% FX stress dragged into a Rwanda
@@ -165,8 +192,8 @@ const CATEGORY_SECTION_POLICY: Array<{ match: RegExp; sections: SectionKey[]; la
  * story category. Exported for testability — the category → sections
  * map is the main lever for tuning analyst output relevance.
  *
- * @param category — the story's category slug (free-form, from the cron
- *   payload). `""` or unknown categories fall back to DEFAULT_SECTIONS.
+ * @param category — the story's category from the cron payload. `""` or
+ *   unknown categories fall back to DEFAULT_SECTIONS.
  */
 export function sectionsForCategory(category: string): {
   sections: SectionKey[];
@@ -235,7 +262,9 @@ export function buildAnalystWhyMattersPrompt(
   todayIso?: string,
 ): { system: string; user: string; policyLabel: string } {
   const safe = sanitizeStoryFields(story);
-  const { sections: allowedSections, policyLabel } = sectionsForCategory(safe.category);
+  const { sections: allowedSections, policyLabel } = storyUsesLocalContext(safe)
+    ? { sections: LOCAL_SECTIONS, policyLabel: 'local' }
+    : sectionsForCategory(safe.category);
   const contextBlock = buildContextBlock(context, allowedSections);
 
   const storyLineList = [

--- a/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
+++ b/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
@@ -299,13 +299,13 @@ export function buildAnalystWhyMattersPrompt(
   // and that a named actor from the headline / description is a valid
   // grounding target when no context fact is a clean fit.
   parts.push(
-    `Write 2–3 sentences (40–70 words) on why this ${safe.category || 'story'} matters, grounded in at ` +
+    `Write 1–2 sentences (25–40 words) on why this ${safe.category || 'story'} matters, grounded in at ` +
       "least ONE specific reference. Reference the global context only when materially connected to this " +
       "story's category and country; most stories should not mention the global context. If no context fact is a clean fit, ground " +
       'instead in a named actor, place, date, or figure from the headline or description. ' +
       'DO NOT force an off-topic market metric, VIX value, FX reading, or forecast probability ' +
       'into a story where it does not belong. Treat forecasts as private reasoning input: do not quote raw ' +
-      'forecast probabilities or present them as user-facing facts. Vary sentence structure; avoid a stock ' +
+      'forecast probabilities or present them as user-facing facts. Be concise and vary sentence structure; avoid a stock ' +
       '"This…" second-sentence opener or "Watch for…" closer. Plain prose, no section labels in the output:',
   );
 

--- a/shared/brief-llm-core.d.ts
+++ b/shared/brief-llm-core.d.ts
@@ -35,7 +35,14 @@ export function hashBriefStory(story: BriefStoryHashInput): Promise<string>;
 
 // ── v2 (analyst path only) ────────────────────────────────────────────────
 export const WHY_MATTERS_ANALYST_SYSTEM_V2: string;
-export function parseWhyMattersV2(text: unknown): string | null;
+export interface WhyMattersV2Provenance {
+  publicStory?: Pick<BriefStoryHashInput, 'headline' | 'description' | 'source'>;
+  privateForecasts?: string;
+}
+export function parseWhyMattersV2(
+  text: unknown,
+  provenance?: WhyMattersV2Provenance,
+): string | null;
 
 // ── Hallucination validator (PR-2 of brief-content-quality regressions) ──
 export function extractProperNounSequences(text: string): string[][];

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -55,7 +55,6 @@ export function briefDateLine(todayIso) {
   );
 }
 
-
 /**
  * @param {{
  *   headline: string;
@@ -163,14 +162,14 @@ export async function hashBriefStory(story) {
 // risk repricing") with no named actors, metrics, or dates. Root cause:
 // the 18–30 word cap compressed the context's specifics out of the LLM's
 // response. v2 loosens to 40–70 words across 2–3 sentences and REQUIRES
-// the LLM to ground at least one specific reference from the live context.
+// the LLM to ground at least one specific reference from the story or
+// materially relevant live context.
 
 /**
  * System prompt for the analyst-path v2 (2–3 sentences, ~40–70 words,
- * grounded in a specific named actor / metric / date / place drawn
- * from the live context). Shape nudged toward the WMAnalyst chat voice
- * (SITUATION → ANALYSIS → optional WATCH) but rendered as plain prose,
- * no section labels in the output.
+ * grounded in a specific named actor / metric / date / place. It uses
+ * varied plain prose rather than a fixed analytic sequence, with no
+ * section labels in the output.
  */
 export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   'You are the lead analyst at WorldMonitor Brief, a geopolitical intelligence magazine. ' +
@@ -228,6 +227,16 @@ export function parseWhyMattersV2(text) {
   // Reject markdown / section-label leakage (we told it to use plain prose).
   if (/^(#|-|\*|\d+\.\s)/.test(s)) return null;
   if (/^(situation|analysis|watch)\s*[:\-–—]/i.test(s)) return null;
+  // The prompt makes forecast figures private reasoning input, but models can
+  // still disobey. Reject only percentages framed as forecasts/probabilities;
+  // ordinary sourced figures such as "20% of seaborne oil" remain valid.
+  const percentage = '\\b\\d{1,3}\\s?(?:%|percent\\b)';
+  const forecastTerm = '\\b(?:forecast|predict(?:ion|s|ed)?|probability|likelihood|chance|odds|likely)\\b';
+  const forecastPercentage = new RegExp(
+    `${forecastTerm}.{0,32}${percentage}|${percentage}.{0,32}${forecastTerm}`,
+    'i',
+  );
+  if (forecastPercentage.test(s)) return null;
   return s;
 }
 

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -161,26 +161,30 @@ export async function hashBriefStory(story) {
 // single-sentence abstraction-speak ("destabilize / systemic / sovereign
 // risk repricing") with no named actors, metrics, or dates. Root cause:
 // the 18–30 word cap compressed the context's specifics out of the LLM's
-// response. v2 loosens to 40–70 words across 2–3 sentences and REQUIRES
-// the LLM to ground at least one specific reference from the story or
-// materially relevant live context.
+// response. v2 first loosened to 40–70 words / 2–3 sentences; 2026-07-10
+// retightens to 25–40 words / 1–2 sentences after the field read found the
+// looser cap produced padded, formulaic prose — "much longer to say almost
+// the same" as the concise stable path. Still REQUIRES the LLM to ground at
+// least one specific reference from the story or materially relevant live
+// context.
 
 /**
- * System prompt for the analyst-path v2 (2–3 sentences, ~40–70 words,
- * grounded in a specific named actor / metric / date / place. It uses
+ * System prompt for the analyst-path v2 (1–2 sentences, ~25–40 words,
+ * grounded in a specific named actor / metric / date / place). It uses
  * varied plain prose rather than a fixed analytic sequence, with no
  * section labels in the output.
  */
 export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   'You are the lead analyst at WorldMonitor Brief, a geopolitical intelligence magazine. ' +
-  'Using the story as the primary source and the optional Live WorldMonitor Context only when it is materially connected, write 2–3 sentences (40–70 words total) ' +
+  'Using the story as the primary source and the optional Live WorldMonitor Context only when it is materially connected, write 1–2 sentences (25–40 words total) ' +
   'on why the story matters.\n\n' +
   'VOICE:\n' +
+  '- Be concise: high signal density, every word earns its place. Do not pad to fill the range or restate the headline.\n' +
   '- Vary sentence structure and emphasis across stories; choose the natural angle for this story rather than following a fixed sequence.\n' +
   '- Do not default to a second sentence beginning "This…" or a "Watch for…" closing construction.\n' +
   '- Ground the prose in a SPECIFIC named actor, metric, date, or place relevant to this story.\n\n' +
   'HARD CONSTRAINTS:\n' +
-  '- Total length 40–70 words across 2–3 sentences.\n' +
+  '- Total length 25–40 words across 1–2 sentences.\n' +
   '- MUST reference at least ONE specific: named person / country / organization / ' +
   'number / percentage / date / city.\n' +
   '- No preamble ("This matters because…", "The importance of…").\n' +
@@ -201,7 +205,7 @@ export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
 
 /**
  * Parse + validate the analyst-path v2 LLM response. Accepts
- * multi-sentence output (2–3 sentences), 100–500 chars. Otherwise
+ * short multi-sentence output (1–2 sentences), 100–500 chars. Otherwise
  * same rejection semantics as v1 (stub echo, empty) plus explicit
  * rejection of preamble boilerplate and leaked section labels.
  *

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -209,9 +209,13 @@ export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
  * fall through to the next layer.
  *
  * @param {unknown} text
+ * @param {{
+ *   publicStory?: { headline?: string, description?: string, source?: string },
+ *   privateForecasts?: string,
+ * }} [provenance]
  * @returns {string | null}
  */
-export function parseWhyMattersV2(text) {
+export function parseWhyMattersV2(text, provenance) {
   if (typeof text !== 'string') return null;
   let s = text.trim();
   if (!s) return null;
@@ -227,16 +231,32 @@ export function parseWhyMattersV2(text) {
   // Reject markdown / section-label leakage (we told it to use plain prose).
   if (/^(#|-|\*|\d+\.\s)/.test(s)) return null;
   if (/^(situation|analysis|watch)\s*[:\-–—]/i.test(s)) return null;
-  // The prompt makes forecast figures private reasoning input, but models can
-  // still disobey. Reject only percentages framed as forecasts/probabilities;
-  // ordinary sourced figures such as "20% of seaborne oil" remain valid.
-  const percentage = '\\b\\d{1,3}\\s?(?:%|percent\\b)';
-  const forecastTerm = '\\b(?:forecast|predict(?:ion|s|ed)?|probability|likelihood|chance|odds|likely)\\b';
-  const forecastPercentage = new RegExp(
-    `${forecastTerm}.{0,32}${percentage}|${percentage}.{0,32}${forecastTerm}`,
-    'i',
-  );
-  if (forecastPercentage.test(s)) return null;
+  // Forecast context is private reasoning input. Compare normalized percentage
+  // values instead of nearby wording so paraphrases, distance, and newlines do
+  // not bypass the guard. A value present in the public story remains valid
+  // even when the private forecast block happens to contain the same number.
+  const percentageValues = (value) => {
+    if (typeof value !== 'string' || value.length === 0) return new Set();
+    const values = new Set();
+    const percentage = /(?:^|[^\d.])(\d{1,3}(?:\.\d+)?)\s*(?:%|per\s*cent\b)/gi;
+    for (const match of value.matchAll(percentage)) {
+      const number = Number(match[1]);
+      if (Number.isFinite(number)) values.add(String(number));
+    }
+    return values;
+  };
+  const privateValues = percentageValues(provenance?.privateForecasts);
+  if (privateValues.size > 0) {
+    const publicStory = provenance?.publicStory;
+    const publicText = [publicStory?.headline, publicStory?.description, publicStory?.source]
+      .filter((value) => typeof value === 'string')
+      .join('\n');
+    const publicValues = percentageValues(publicText);
+    const outputValues = percentageValues(s);
+    for (const value of outputValues) {
+      if (privateValues.has(value) && !publicValues.has(value)) return null;
+    }
+  }
   return s;
 }
 

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -55,6 +55,7 @@ export function briefDateLine(todayIso) {
   );
 }
 
+
 /**
  * @param {{
  *   headline: string;
@@ -173,14 +174,12 @@ export async function hashBriefStory(story) {
  */
 export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   'You are the lead analyst at WorldMonitor Brief, a geopolitical intelligence magazine. ' +
-  'Using the Live WorldMonitor Context AND the story, write 2–3 sentences (40–70 words total) ' +
+  'Using the story as the primary source and the optional Live WorldMonitor Context only when it is materially connected, write 2–3 sentences (40–70 words total) ' +
   'on why the story matters.\n\n' +
-  'STRUCTURE:\n' +
-  '1. SITUATION — what is happening right now, grounded in a SPECIFIC named actor, ' +
-  'metric, date, or place relevant to this story.\n' +
-  '2. ANALYSIS — the structural consequence (why this forces a repricing, shifts ' +
-  'the balance, triggers a cascade).\n' +
-  '3. (Optional) WATCH — the threshold or indicator to track, if clear from the context.\n\n' +
+  'VOICE:\n' +
+  '- Vary sentence structure and emphasis across stories; choose the natural angle for this story rather than following a fixed sequence.\n' +
+  '- Do not default to a second sentence beginning "This…" or a "Watch for…" closing construction.\n' +
+  '- Ground the prose in a SPECIFIC named actor, metric, date, or place relevant to this story.\n\n' +
   'HARD CONSTRAINTS:\n' +
   '- Total length 40–70 words across 2–3 sentences.\n' +
   '- MUST reference at least ONE specific: named person / country / organization / ' +
@@ -190,11 +189,12 @@ export const WHY_MATTERS_ANALYST_SYSTEM_V2 =
   '- Editorial, impersonal, serious. No calls to action, no questions, no quotes.\n\n' +
   'RELEVANCE RULE (critical, read carefully):\n' +
   '- The context block may contain facts from world-brief, country-brief, risk scores, ' +
-  'forecasts, macro signals, and market data. These are BACKGROUND — only cite what is ' +
-  "directly relevant to this story's category and country.\n" +
+  'forecasts, macro signals, and market data. These are optional BACKGROUND, not a ' +
+  "mandatory narrative — most stories should not mention the global context. Only cite what is directly relevant to this story's category and country.\n" +
   '- If NO context fact clearly fits, ground instead in a named actor, place, date, ' +
   'or figure drawn from the headline or description. That is a VALID grounding — do ' +
   'NOT invent a market reading, VIX value, or forecast probability to satisfy the rule.\n' +
+  '- Treat internal forecast figures as private reasoning input. Do not quote raw forecast probabilities or present a WorldMonitor forecast as a user-facing fact.\n' +
   '- NEVER drag an off-topic market metric, FX reading, or probability into a ' +
   'humanitarian, aviation, diplomacy, or cyber story. A story about a refugee flow ' +
   'does not need a VIX number; a story about a drone incursion does not need an FX ' +
@@ -972,4 +972,3 @@ export function verifyCitationIndexes(text, sourceCount) {
   });
   return { text: cleaned, stripped };
 }
-

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -211,6 +211,52 @@ describe('parseWhyMattersV2 — multi-sentence, analyst-path only', () => {
     assert.equal(parseWhyMattersV2(good), good);
   });
 
+  it('rejects private forecast percentages regardless of wording, distance, or newlines', async () => {
+    const { parseWhyMattersV2 } = await import('../shared/brief-llm-core.js');
+    const privateForecasts = 'WorldMonitor disruption model: Strait closure remains 84% likely.';
+    const evasive =
+      'WorldMonitor sees shipping pressure rising through the Gulf as insurers reassess the route. ' +
+      'After several unrelated clauses and a line break, the internal outlook puts disruption risk at\n84 percent.';
+    assert.equal(parseWhyMattersV2(evasive, {
+      publicStory: {
+        headline: 'Insurers reassess Gulf shipping routes',
+        description: 'Carriers are reviewing transit plans after new regional threats.',
+        source: 'Reuters',
+      },
+      privateForecasts,
+    }), null);
+  });
+
+  it('accepts sourced public forecast percentages even when private context has the same value', async () => {
+    const { parseWhyMattersV2 } = await import('../shared/brief-llm-core.js');
+    const sourced =
+      'NOAA forecasts an 80% chance of above-normal Atlantic hurricane activity this season, according to its public outlook. ' +
+      'Ports and carriers are bringing contingency planning forward before peak storm months.';
+    assert.equal(parseWhyMattersV2(sourced, {
+      publicStory: {
+        headline: 'NOAA forecasts 80% chance of above-normal Atlantic hurricane season',
+        description: 'The public NOAA outlook assigns an 80 percent chance to above-normal activity.',
+        source: 'Reuters',
+      },
+      privateForecasts: 'WorldMonitor storm disruption forecast: 80.0% probability.',
+    }), sourced);
+  });
+
+  it('accepts output percentages that do not match private forecast context', async () => {
+    const { parseWhyMattersV2 } = await import('../shared/brief-llm-core.js');
+    const sourced =
+      'Reuters reports that the central bank forecasts inflation at 4% next year after the latest policy review. ' +
+      'The revised path gives officials more room to hold rates steady while monitoring wage growth.';
+    assert.equal(parseWhyMattersV2(sourced, {
+      publicStory: {
+        headline: 'Central bank forecasts inflation at 4%',
+        description: 'Reuters reports a revised public inflation projection.',
+        source: 'Reuters',
+      },
+      privateForecasts: 'WorldMonitor political-instability forecast: 84% probability.',
+    }), sourced);
+  });
+
   it('rejects <100 chars (too terse for the analyst contract)', async () => {
     const { parseWhyMattersV2 } = await import('../shared/brief-llm-core.js');
     assert.equal(parseWhyMattersV2('Short.'), null);

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -1750,78 +1750,102 @@ describe('generateStoryDescription — sanitisation + prefix bump (U5)', () => {
   });
 });
 
-// ── generateWhyMatters — v8 endpoint-cache cross-read (#4914) ──────────────
+// ── generateWhyMatters — v9 endpoint-cache cross-read (#4914) ──────────────
 //
 // The analyst endpoint (api/internal/brief-why-matters.ts) caches its
-// envelope at brief:llm:whymatters:v8:{hashBriefStory} — the SAME story
+// envelope at brief:llm:whymatters:v9:{hashBriefStory} — the SAME story
 // identity as the cron's legacy v5 namespace. When the endpoint CALL fails
 // transiently, the envelope may still be sitting in Redis; the fallback
 // must read it before paying a direct-Gemini generation.
 
-describe('generateWhyMatters — v8 endpoint-cache cross-read (#4914)', () => {
-  const V8_PROSE = 'Closure of the Strait of Hormuz would freeze a fifth of seaborne crude and force allied navies to respond.';
+describe('generateWhyMatters — v9 endpoint-cache cross-read (#4914)', () => {
+  const V9_PROSE = 'Closure of the Strait of Hormuz would freeze a fifth of seaborne crude and force allied navies to respond.';
 
-  async function seedV8(cache, s, envelopeOverrides = {}) {
+  it('pins the endpoint cache to v9 and its shadow cohort to v7', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(new URL('../api/internal/brief-why-matters.ts', import.meta.url), 'utf8');
+    assert.match(src, /const cacheKey = `brief:llm:whymatters:v9:\$\{hash\}`;/);
+    assert.match(src, /const shadowKey = `brief:llm:whymatters:shadow:v7:\$\{hash\}`;/);
+    assert.doesNotMatch(src, /const cacheKey = `brief:llm:whymatters:v8:/);
+    assert.doesNotMatch(src, /const shadowKey = `brief:llm:whymatters:shadow:v6:/);
+  });
+
+  async function seedV9(cache, s, envelopeOverrides = {}) {
     const hash = await hashBriefStory(s);
-    cache.store.set(`brief:llm:whymatters:v8:${hash}`, {
-      whyMatters: V8_PROSE,
+    cache.store.set(`brief:llm:whymatters:v9:${hash}`, {
+      whyMatters: V9_PROSE,
       producedBy: 'analyst',
       ...envelopeOverrides,
     });
     return hash;
   }
 
-  it('reuses the v8 envelope when the analyst endpoint call fails — no paid LLM call', async () => {
+  it('reuses the v9 envelope when the analyst endpoint call fails — no paid LLM call', async () => {
     const cache = makeCache();
     const s = story();
-    await seedV8(cache, s);
-    const llm = makeLLM(() => { throw new Error('must not pay direct-Gemini when v8 is warm'); });
+    await seedV9(cache, s);
+    const llm = makeLLM(() => { throw new Error('must not pay direct-Gemini when v9 is warm'); });
     const out = await generateWhyMatters(s, {
       ...cache,
       callLLM: llm.callLLM,
       callAnalystWhyMatters: async () => { throw new Error('endpoint down'); },
     });
-    assert.equal(out, V8_PROSE);
-    assert.equal(llm.calls.length, 0, 'v8 hit must short-circuit the legacy chain');
+    assert.equal(out, V9_PROSE);
+    assert.equal(llm.calls.length, 0, 'v9 hit must short-circuit the legacy chain');
   });
 
-  it('reuses the v8 envelope when no analyst endpoint is configured at all', async () => {
+  it('reuses the v9 envelope when no analyst endpoint is configured at all', async () => {
     const cache = makeCache();
     const s = story();
-    await seedV8(cache, s);
+    await seedV9(cache, s);
     const llm = makeLLM(() => { throw new Error('must not pay'); });
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
-    assert.equal(out, V8_PROSE);
+    assert.equal(out, V9_PROSE);
     assert.equal(llm.calls.length, 0);
   });
 
-  it('malformed v8 envelope falls through to the legacy chain', async () => {
+  it('ignores a pre-policy v8 envelope and falls through to the legacy chain', async () => {
     const cache = makeCache();
     const s = story();
     const hash = await hashBriefStory(s);
-    cache.store.set(`brief:llm:whymatters:v8:${hash}`, { whyMatters: 'too short' });
+    cache.store.set(`brief:llm:whymatters:v8:${hash}`, {
+      whyMatters: 'WorldMonitor forecasts an 84% probability of disruption, which must not survive the output-policy rollout.',
+      producedBy: 'analyst',
+    });
+    const fresh = 'Closure of the Strait of Hormuz would spike oil prices globally.';
+    const llm = makeLLM(fresh);
+    const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, fresh);
+    assert.equal(llm.calls.length, 1, 'v8 must not short-circuit the post-policy generation chain');
+  });
+
+  it('malformed v9 envelope falls through to the legacy chain', async () => {
+    const cache = makeCache();
+    const s = story();
+    const hash = await hashBriefStory(s);
+    cache.store.set(`brief:llm:whymatters:v9:${hash}`, { whyMatters: 'too short' });
     const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
     assert.equal(out, 'Closure of the Strait of Hormuz would spike oil prices globally.');
-    assert.equal(llm.calls.length, 1, 'invalid v8 payload must not be served — legacy chain pays once');
+    assert.equal(llm.calls.length, 1, 'invalid v9 payload must not be served — legacy chain pays once');
   });
 
-  it('v8 sensitivity-stub prose is rejected, not served', async () => {
+  it('v9 sensitivity-stub prose is rejected, not served', async () => {
     const cache = makeCache();
     const s = story();
-    await seedV8(cache, s, { whyMatters: 'Story flagged by your sensitivity settings. Open for context and details.' });
+    await seedV9(cache, s, { whyMatters: 'Story flagged by your sensitivity settings. Open for context and details.' });
     const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
     assert.equal(out, 'Closure of the Strait of Hormuz would spike oil prices globally.');
     assert.equal(llm.calls.length, 1);
   });
 
-  it('v8 read is read-only — the legacy path must not copy into or overwrite the v8 namespace', async () => {
+  it('v9 read is read-only — the legacy path must not copy into or overwrite the v9 namespace', async () => {
     const cache = makeCache();
     const s = story();
     const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
     await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
-    const v8Keys = [...cache.store.keys()].filter((k) => k.startsWith('brief:llm:whymatters:v8:'));
-    assert.equal(v8Keys.length, 0, 'legacy single-sentence output must stay in the v5 namespace');
+    const v9Keys = [...cache.store.keys()].filter((k) => k.startsWith('brief:llm:whymatters:v9:'));
+    assert.equal(v9Keys.length, 0, 'legacy single-sentence output must stay in the v5 namespace');
   });
 });

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -492,7 +492,7 @@ describe('buildAnalystWhyMattersPrompt — shape and budget', () => {
     assert.ok(typeof builder === 'function');
   });
 
-  it('uses the analyst v2 system prompt (multi-sentence, grounded) + date-grounding line', async () => {
+  it('uses the analyst v2 system prompt (multi-sentence, grounded, varied) + date-grounding line', async () => {
     const { WHY_MATTERS_ANALYST_SYSTEM_V2, briefDateLine } = await import('../shared/brief-llm-core.js');
     const { system } = builder(
       story(),
@@ -513,6 +513,9 @@ describe('buildAnalystWhyMattersPrompt — shape and budget', () => {
     assert.match(system, /40–70 words/);
     assert.match(system, /named person \/ country \/ organization \/ number \/ percentage \/ date \/ city/);
     assert.match(system, /^Today is 2026-05-14\./m);
+    assert.match(system, /vary sentence structure/i);
+    assert.doesNotMatch(system, /STRUCTURE:/);
+    assert.doesNotMatch(system, /SITUATION —/);
   });
 
   it('includes story fields with the multi-sentence footer', () => {
@@ -795,6 +798,36 @@ describe('sectionsForCategory — structural relevance gating', () => {
     assert.match(user, /DO NOT force/i, 'guardrail phrase "DO NOT force" must be in footer');
     assert.match(user, /off-topic market metric|VIX|forecast probability/i);
     assert.match(user, /named actor, place, date, or figure/);
+    assert.match(user, /only when materially connected/i);
+    assert.match(user, /most stories should not mention the global context/i);
+    assert.match(user, /do not quote raw forecast probabilities/i);
+  });
+
+  it('buildAnalystWhyMattersPrompt — justice/history/human-interest stories do not receive global narrative or forecasts', () => {
+    for (const category of ['Justice', 'Historical Commemoration', 'Human Interest']) {
+      const { user, policyLabel } = builder(
+        {
+          headline: 'Court releases reparations funds to a civil-rights plaintiff',
+          source: 'AP',
+          threatLevel: 'medium',
+          category,
+          country: 'US',
+        },
+        {
+          worldBrief: 'US-Iran ceasefire talks remain fragile around the Strait of Hormuz.',
+          countryBrief: 'The plaintiff won a civil case after a federal ruling.',
+          riskScores: 'Domestic stability risk is moderate.',
+          forecasts: 'WorldMonitor forecast: Hormuz traffic disruption remains 84% likely.',
+          marketData: 'Oil trades at $87.',
+          macroSignals: 'FX stress remains elevated.',
+          degraded: false,
+        },
+      );
+      assert.equal(policyLabel, 'local', `${category} should match the local policy`);
+      assert.doesNotMatch(user, /US-Iran ceasefire/);
+      assert.doesNotMatch(user, /84% likely/);
+      assert.match(user, /plaintiff won a civil case/);
+    }
   });
 });
 

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -815,30 +815,32 @@ describe('sectionsForCategory — structural relevance gating', () => {
     assert.match(user, /do not quote raw forecast probabilities/i);
   });
 
-  it('buildAnalystWhyMattersPrompt — justice/history/human-interest stories do not receive global narrative or forecasts', () => {
+  it('buildAnalystWhyMattersPrompt — justice/history/human-interest stories do not receive global narrative or forecasts', async (t) => {
     for (const category of ['Justice', 'Historical Commemoration', 'Human Interest', 'Civil Rights Court Ruling']) {
-      const { user, policyLabel } = builder(
-        {
-          headline: 'Court releases reparations funds to a civil-rights plaintiff',
-          source: 'AP',
-          threatLevel: 'medium',
-          category,
-          country: 'US',
-        },
-        {
-          worldBrief: 'US-Iran ceasefire talks remain fragile around the Strait of Hormuz.',
-          countryBrief: 'The plaintiff won a civil case after a federal ruling.',
-          riskScores: 'Domestic stability risk is moderate.',
-          forecasts: 'WorldMonitor forecast: Hormuz traffic disruption remains 84% likely.',
-          marketData: 'Oil trades at $87.',
-          macroSignals: 'FX stress remains elevated.',
-          degraded: false,
-        },
-      );
-      assert.equal(policyLabel, 'local', `${category} should match the local policy`);
-      assert.doesNotMatch(user, /US-Iran ceasefire/);
-      assert.doesNotMatch(user, /84% likely/);
-      assert.match(user, /plaintiff won a civil case/);
+      await t.test(category, () => {
+        const { user, policyLabel } = builder(
+          {
+            headline: 'Court releases reparations funds to a civil-rights plaintiff',
+            source: 'AP',
+            threatLevel: 'medium',
+            category,
+            country: 'US',
+          },
+          {
+            worldBrief: 'US-Iran ceasefire talks remain fragile around the Strait of Hormuz.',
+            countryBrief: 'The plaintiff won a civil case after a federal ruling.',
+            riskScores: 'Domestic stability risk is moderate.',
+            forecasts: 'WorldMonitor forecast: Hormuz traffic disruption remains 84% likely.',
+            marketData: 'Oil trades at $87.',
+            macroSignals: 'FX stress remains elevated.',
+            degraded: false,
+          },
+        );
+        assert.equal(policyLabel, 'local', `${category} should match the local policy`);
+        assert.doesNotMatch(user, /US-Iran ceasefire/);
+        assert.doesNotMatch(user, /84% likely/);
+        assert.match(user, /plaintiff won a civil case/);
+      });
     }
   });
 });

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -192,6 +192,18 @@ describe('parseWhyMattersV2 — analyst output validator', () => {
     }
   });
 
+  it('rejects raw forecast-probability disclosures but preserves ordinary sourced percentages', () => {
+    const forecastLeak =
+      "WorldMonitor's internal forecast assigns an 84% probability to a Strait of Hormuz disruption, which would intensify regional shipping risk. " +
+      'That projection is not a reader-facing fact and must fall through to the next generation layer.';
+    const likelyLeak =
+      'A disruption is 84% likely according to the forecast, creating an immediate risk of higher insurance costs across Gulf shipping routes. ' +
+      'The analyst should not present that internal probability as a published fact.';
+    assert.equal(parseWhyMattersV2(forecastLeak), null);
+    assert.equal(parseWhyMattersV2(likelyLeak), null);
+    assert.equal(parseWhyMattersV2(VALID_MULTI), VALID_MULTI, 'ordinary story percentages must remain valid');
+  });
+
   it('rejects markdown leakage (bullets, headers, numbered lists)', () => {
     for (const md of [
       '# The closure of the Strait of Hormuz is the single most material geopolitical event of the quarter for sovereign credit.',
@@ -804,7 +816,7 @@ describe('sectionsForCategory — structural relevance gating', () => {
   });
 
   it('buildAnalystWhyMattersPrompt — justice/history/human-interest stories do not receive global narrative or forecasts', () => {
-    for (const category of ['Justice', 'Historical Commemoration', 'Human Interest']) {
+    for (const category of ['Justice', 'Historical Commemoration', 'Human Interest', 'Civil Rights Court Ruling']) {
       const { user, policyLabel } = builder(
         {
           headline: 'Court releases reparations funds to a civil-rights plaintiff',

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -199,8 +199,16 @@ describe('parseWhyMattersV2 — analyst output validator', () => {
     const likelyLeak =
       'A disruption is 84% likely according to the forecast, creating an immediate risk of higher insurance costs across Gulf shipping routes. ' +
       'The analyst should not present that internal probability as a published fact.';
-    assert.equal(parseWhyMattersV2(forecastLeak), null);
-    assert.equal(parseWhyMattersV2(likelyLeak), null);
+    const provenance = {
+      publicStory: {
+        headline: 'Insurers reassess Gulf shipping routes',
+        description: 'Carriers are reviewing transit plans after new regional threats.',
+        source: 'Reuters',
+      },
+      privateForecasts: 'WorldMonitor disruption model: Strait closure remains 84% likely.',
+    };
+    assert.equal(parseWhyMattersV2(forecastLeak, provenance), null);
+    assert.equal(parseWhyMattersV2(likelyLeak, provenance), null);
     assert.equal(parseWhyMattersV2(VALID_MULTI), VALID_MULTI, 'ordinary story percentages must remain valid');
   });
 
@@ -815,20 +823,48 @@ describe('sectionsForCategory — structural relevance gating', () => {
     assert.match(user, /do not quote raw forecast probabilities/i);
   });
 
-  it('buildAnalystWhyMattersPrompt — justice/history/human-interest stories do not receive global narrative or forecasts', async (t) => {
-    for (const category of ['Justice', 'Historical Commemoration', 'Human Interest', 'Civil Rights Court Ruling']) {
-      await t.test(category, () => {
+  it('buildAnalystWhyMattersPrompt — production-shaped local stories do not receive global narrative or forecasts', async (t) => {
+    const stories = [
+      {
+        name: 'Srebrenica historical memory',
+        headline: 'Three survivors of the 1995 Srebrenica genocide preserve the memory of those killed',
+        description: 'Their testimony keeps historical memory alive three decades after the massacre.',
+        threatLevel: 'critical',
+        category: 'Conflict',
+        country: 'BA',
+      },
+      {
+        name: 'mass-casualty smuggling prosecution',
+        headline: 'Two Guatemalan nationals extradited to the U.S. admit roles in a 2021 mass casualty smuggling event',
+        description: 'The defendants entered guilty pleas in federal court.',
+        threatLevel: 'critical',
+        category: 'Conflict',
+        country: 'US',
+      },
+      {
+        name: 'civil-rights court ruling',
+        headline: 'Federal judge orders release of $5.8 million to E. Jean Carroll',
+        description: 'The plaintiff won access to funds after a federal civil-rights ruling.',
+        threatLevel: 'medium',
+        category: 'General',
+        country: 'US',
+      },
+    ];
+
+    for (const story of stories) {
+      await t.test(story.name, () => {
         const { user, policyLabel } = builder(
           {
-            headline: 'Court releases reparations funds to a civil-rights plaintiff',
+            headline: story.headline,
+            description: story.description,
             source: 'AP',
-            threatLevel: 'medium',
-            category,
-            country: 'US',
+            threatLevel: story.threatLevel,
+            category: story.category,
+            country: story.country,
           },
           {
             worldBrief: 'US-Iran ceasefire talks remain fragile around the Strait of Hormuz.',
-            countryBrief: 'The plaintiff won a civil case after a federal ruling.',
+            countryBrief: 'Local institutions are handling the reported event.',
             riskScores: 'Domestic stability risk is moderate.',
             forecasts: 'WorldMonitor forecast: Hormuz traffic disruption remains 84% likely.',
             marketData: 'Oil trades at $87.',
@@ -836,12 +872,64 @@ describe('sectionsForCategory — structural relevance gating', () => {
             degraded: false,
           },
         );
-        assert.equal(policyLabel, 'local', `${category} should match the local policy`);
+        assert.equal(policyLabel, 'local', `${story.name} should match the local policy`);
         assert.doesNotMatch(user, /US-Iran ceasefire/);
         assert.doesNotMatch(user, /84% likely/);
-        assert.match(user, /plaintiff won a civil case/);
+        assert.match(user, /Local institutions are handling/);
       });
     }
+  });
+
+  it('buildAnalystWhyMattersPrompt — genuine geopolitical Conflict story retains global narrative and forecasts', () => {
+    const { user, policyLabel } = builder(
+      {
+        headline: 'Mass casualty missile strikes escalate active conflict across the Gulf',
+        description: 'Military forces exchanged strikes overnight as regional tensions rose.',
+        source: 'Reuters',
+        threatLevel: 'critical',
+        category: 'Conflict',
+        country: 'IR',
+      },
+      {
+        worldBrief: 'US-Iran ceasefire talks remain fragile around the Strait of Hormuz.',
+        countryBrief: 'Iranian forces remain on high alert.',
+        riskScores: 'Regional stability risk is severe.',
+        forecasts: 'WorldMonitor forecast: Hormuz traffic disruption remains elevated.',
+        marketData: 'Oil trades at $87.',
+        macroSignals: 'FX stress remains elevated.',
+        degraded: false,
+      },
+    );
+
+    assert.equal(policyLabel, 'geopolitical');
+    assert.match(user, /US-Iran ceasefire/);
+    assert.match(user, /Hormuz traffic disruption remains elevated/);
+  });
+
+  it('buildAnalystWhyMattersPrompt — specific market category outranks a court keyword', () => {
+    const { user, policyLabel } = builder(
+      {
+        headline: 'Court blocks major oil pipeline permit',
+        description: 'The ruling delays a planned expansion of regional crude capacity.',
+        source: 'Reuters',
+        threatLevel: 'medium',
+        category: 'Energy',
+        country: 'US',
+      },
+      {
+        worldBrief: 'Global energy supply remains tight.',
+        countryBrief: 'The permit dispute is proceeding through federal court.',
+        riskScores: 'Domestic stability risk is low.',
+        forecasts: 'Pipeline capacity is expected to remain constrained.',
+        marketData: 'Oil trades at $87.',
+        macroSignals: 'Refining margins remain elevated.',
+        degraded: false,
+      },
+    );
+
+    assert.equal(policyLabel, 'market');
+    assert.match(user, /Pipeline capacity is expected to remain constrained/);
+    assert.match(user, /Oil trades at \$87/);
   });
 });
 

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -141,12 +141,15 @@ describe('parseWhyMattersV2 — analyst output validator', () => {
     "Iran's closure of the Strait of Hormuz on April 21 halts roughly 20% of global seaborne oil. " +
     'The disruption forces an immediate repricing of sovereign risk across Gulf energy exporters.';
 
-  it('accepts a valid 2-sentence, ~40–70 word output', () => {
+  it('accepts a valid 1–2 sentence output', () => {
     const out = parseWhyMattersV2(VALID_MULTI);
     assert.equal(out, VALID_MULTI);
   });
 
-  it('accepts a valid 3-sentence output with optional WATCH arc', () => {
+  it('parser tolerates a longer 3-sentence output (lenient by design; the prompt asks for 1–2)', () => {
+    // The parser only gates 100–500 chars + shape, not sentence count, so an
+    // occasional over-length generation is passed through rather than nuked
+    // to the stub. Conciseness is enforced by the prompt contract, not here.
     const three =
       "Iran's closure of the Strait of Hormuz on April 21 halts roughly 20% of global seaborne oil. " +
       'The disruption forces an immediate repricing of sovereign risk across Gulf energy exporters. ' +
@@ -341,7 +344,7 @@ describe('generateWhyMatters — analyst priority', () => {
   });
 
   it('preserves multi-sentence v2 analyst output verbatim (P1 regression guard)', async () => {
-    // The endpoint now returns 2–3 sentences validated by parseWhyMattersV2.
+    // The endpoint now returns 1–2 sentences validated by parseWhyMattersV2.
     // The cron MUST NOT reparse with the v1 single-sentence parser, which
     // would silently truncate the 2nd + 3rd sentences. Caught in PR #3269
     // review; fixed by trusting the endpoint's own validation and only
@@ -529,8 +532,12 @@ describe('buildAnalystWhyMattersPrompt — shape and budget', () => {
     );
     // F6: system prompt is the static v2 const + an injected date line.
     assert.equal(system, `${WHY_MATTERS_ANALYST_SYSTEM_V2}\n${briefDateLine('2026-05-14')}`);
-    // Contract must still mention the 40–70 word target + grounding rule.
-    assert.match(system, /40–70 words/);
+    // Contract must mention the tightened 25–40 word target + concision +
+    // grounding rule.
+    assert.match(system, /25–40 words/);
+    assert.match(system, /1–2 sentences/);
+    assert.match(system, /be concise/i);
+    assert.doesNotMatch(system, /40–70 words/);
     assert.match(system, /named person \/ country \/ organization \/ number \/ percentage \/ date \/ city/);
     assert.match(system, /^Today is 2026-05-14\./m);
     assert.match(system, /vary sentence structure/i);
@@ -553,7 +560,7 @@ describe('buildAnalystWhyMattersPrompt — shape and budget', () => {
     assert.match(user, /Severity: critical/);
     assert.match(user, /Category: Geopolitical Risk/);
     assert.match(user, /Country: IR/);
-    assert.match(user, /Write 2–3 sentences \(40–70 words\)/);
+    assert.match(user, /Write 1–2 sentences \(25–40 words\)/);
     assert.match(user, /grounded in at least ONE specific/);
   });
 


### PR DESCRIPTION
## Summary

Why-matters copy no longer forces every story through the same analytic cadence or treats the global conflict narrative as mandatory. Local justice, history, and human-interest stories now receive only local context, while internal forecast probabilities remain reasoning input rather than unattributed reader-facing claims.

Fixes #5169
Fixes #5170
Fixes #5171

## Validation

- `tests/brief-why-matters-analyst.test.mjs` — 65 passing tests, including independent justice/history/human-interest context gates.
- `npm run test:data`
- `npm run typecheck:all`
- `npm run lint` (repository-wide pre-existing warnings only; changed files clean under scoped Biome lint)

## Post-Deploy Monitoring & Validation

- Logs: search `brief-why-matters` for `policy=local` on justice/history/human-interest stories and unexpected analyst-path failures.
- Healthy signal: sampled fresh briefs use varied sentence shapes; unrelated local stories do not mention global Iran/Hormuz context or raw forecast percentages.
- Failure trigger / rollback: repeated forced-context or forecast-figure leakage in a fresh sample -> set `BRIEF_WHY_MATTERS_PRIMARY=gemini` while revising the prompt.
- Window and owner: sample the next daily brief cycle; owner Elie.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
