### PR TITLE
feat(docs): add About, Privacy, and Terms trust pages

### DIFF
--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -1,0 +1,37 @@
+---
+title: "About World Monitor"
+description: "What World Monitor is, who builds it, and the mission behind a free real-time global intelligence dashboard fusing 500+ feeds, conflict tracking, markets, and AI analysis into one live map."
+---
+
+World Monitor is a free, real-time global intelligence dashboard. It fuses 500+ live data feeds — conflict events, market data, shipping chokepoints, satellite passes, cyber signals, natural disasters, and more — into a single live map of the world, with AI analysis layered on top.
+
+The basic dashboard is open to everyone with no signup required.
+
+## Mission
+
+Situational awareness of the world should not be locked behind a terminal that costs thousands of dollars a month. World Monitor's goal is to make credible, real-time global intelligence — the kind normally reserved for governments, funds, and newsrooms — accessible to anyone with a browser.
+
+## What it does
+
+- **Live global map** — conflicts, hotspots, sanctions, weather, outages, and natural events, updated continuously.
+- **Signal intelligence** — 500+ sources normalized into one feed, from open-source conflict datasets to market and maritime data.
+- **AI analysis** — automated briefings, country risk, and forecasts generated on top of the underlying signals.
+- **Developer surfaces** — a public REST API, an [MCP server](https://worldmonitor.app/mcp), SDKs, and a desktop app, so agents and applications can consume the same intelligence programmatically.
+
+## Who builds it
+
+World Monitor is built by [Elie Habib](https://x.com/eliehabib), co-founder and former CTO of the music-streaming platform Anghami. The project and its origins were covered by [WIRED](https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map).
+
+The platform source is open under AGPL-3.0-only — see the [License](/license) and [Trademark Policy](/trademark-policy).
+
+## Explore
+
+- [Dashboard](https://www.worldmonitor.app) — the live map
+- [Pro](https://www.worldmonitor.app/pro) — deeper signal, more AI briefings, a research assistant
+- [Documentation](https://www.worldmonitor.app/docs) — API, MCP, and platform guides
+- [GitHub](https://github.com/koala73/worldmonitor) — source and issues
+- [Blog](https://www.worldmonitor.app/blog) — analysis and product updates
+
+## Contact
+
+General questions and support: [support@worldmonitor.app](mailto:support@worldmonitor.app). Enterprise and partnerships: [enterprise@worldmonitor.app](mailto:enterprise@worldmonitor.app). See [Support & Contact](/support) for all channels.

--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -1,28 +1,46 @@
 ---
 title: "About World Monitor"
-description: "What World Monitor is, who builds it, and the mission behind a free real-time global intelligence dashboard fusing 500+ feeds, conflict tracking, markets, and AI analysis into one live map."
+description: "The story behind World Monitor — a free, open-source real-time global intelligence dashboard built by Anghami co-founder and CEO Elie Habib that grew from a weekend project into a platform used by millions across 170+ countries."
 ---
 
-World Monitor is a free, real-time global intelligence dashboard. It fuses 500+ live data feeds — conflict events, market data, shipping chokepoints, satellite passes, cyber signals, natural disasters, and more — into a single live map of the world, with AI analysis layered on top.
+World Monitor is a free, real-time global intelligence dashboard. It fuses 500+ live data feeds — conflict events, military flights, ship movements, satellite fire detections, market data, shipping chokepoints, internet outages, cyber signals, and natural disasters — into a single live map of the world, with AI analysis layered on top. The core dashboard is open to everyone, with no signup.
 
-The basic dashboard is open to everyone with no signup required.
+## Origin
+
+{/* REVIEW: traction figures below are sourced from press coverage (Jan–2026 onward) and the live GitHub count at time of writing. Refresh to current numbers before or after merge if you want them exact. */}
+
+World Monitor began in January 2026 as a weekend project. Elie Habib — co-founder and CEO of the music-streaming platform Anghami — built the first version in a matter of days to see whether a day's worth of chaotic geopolitical news could be made legible on one map. He posted it once and moved on.
+
+It didn't stay quiet. As global events escalated through 2026, the dashboard reached hundreds of thousands of users in its first week and has since grown to millions of people across more than 170 countries — most of them well outside the usual intelligence-tooling audience. It is now one of the most-starred open-source OSINT projects on GitHub, with 60,000+ stars.
+
+## What makes it different
+
+World Monitor has no newsroom and no human editors. Instead it leans on method:
+
+- **Convergence over noise.** Signals are cross-checked against multiple independent sources before anything surfaces as an alert, so a single unverified report doesn't become a headline.
+- **A tiered source hierarchy.** Wire services and official channels (Reuters, AP, the Pentagon, the UN) rank above major broadcasters (BBC, Al Jazeera), which rank above specialist open-source outlets (Bellingcat) — with provenance kept visible.
+- **Breadth in one place.** ADS-B aircraft transponders, AIS maritime positions, ACLED and UCDP conflict datasets, NASA fire detections, GPS-jamming and outage data, prediction markets, and commodity prices all sit on the same globe.
+- **A Country Instability Index.** Every country is scored 0–100 from baseline risk, unrest, security events, and information velocity, adjusted in real time.
+- **AI on top, not instead.** Automated briefings, country risk, and forecasts are generated from the underlying signals — not from a chatbot's imagination.
+
+Specialized variants point the same engine at a theme: [Tech](https://tech.worldmonitor.app), [Finance](https://finance.worldmonitor.app), [Commodity](https://commodity.worldmonitor.app), [Energy](https://energy.worldmonitor.app), and [Happy](https://happy.worldmonitor.app) (positive news only).
 
 ## Mission
 
-Situational awareness of the world should not be locked behind a terminal that costs thousands of dollars a month. World Monitor's goal is to make credible, real-time global intelligence — the kind normally reserved for governments, funds, and newsrooms — accessible to anyone with a browser.
-
-## What it does
-
-- **Live global map** — conflicts, hotspots, sanctions, weather, outages, and natural events, updated continuously.
-- **Signal intelligence** — 500+ sources normalized into one feed, from open-source conflict datasets to market and maritime data.
-- **AI analysis** — automated briefings, country risk, and forecasts generated on top of the underlying signals.
-- **Developer surfaces** — a public REST API, an [MCP server](https://worldmonitor.app/mcp), SDKs, and a desktop app, so agents and applications can consume the same intelligence programmatically.
+Situational awareness of the world shouldn't require a five-figure terminal. World Monitor's goal is to make credible, real-time global intelligence — the kind normally reserved for governments, funds, and newsrooms — accessible to anyone with a browser.
 
 ## Who builds it
 
-World Monitor is built by [Elie Habib](https://x.com/eliehabib), co-founder and former CTO of the music-streaming platform Anghami. The project and its origins were covered by [WIRED](https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map).
+World Monitor is built by [Elie Habib](https://x.com/eliehabib), co-founder and CEO of Anghami — the first Arab technology company to list on NASDAQ. His work on World Monitor and its origins were covered by [WIRED](https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map).
 
-The platform source is open under AGPL-3.0-only — see the [License](/license) and [Trademark Policy](/trademark-policy).
+The platform is open source under AGPL-3.0-only — see the [License](/license) and [Trademark Policy](/trademark-policy).
+
+## In the press
+
+- [WIRED — The music-streaming CEO who built a global war map](https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map)
+- [Entrepreneur Middle East — How Elie Habib built World Monitor to track global events in real time](https://mena.entrepreneur.com/business-news/how-elie-habib-built-world-monitor-to-track-global-events-in-real-time)
+- [Silicon Canals — Anghami CEO's side project now has 2 million users](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/)
+- [L'Orient Today — How the Anghami CEO's side project became a go-to for geopolitics research](https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research.html)
 
 ## Explore
 

--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -31,13 +31,15 @@ Situational awareness of the world shouldn't require a five-figure terminal. Wor
 
 ## Who builds it
 
-World Monitor is built by [Elie Habib](https://x.com/eliehabib), co-founder and CEO of Anghami — the first Arab technology company to list on NASDAQ. His work on World Monitor and its origins were covered by [WIRED](https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map).
+World Monitor is built by [Elie Habib](https://x.com/eliehabib), co-founder and CEO of Anghami — the first Arab technology company to list on NASDAQ. His work on World Monitor and its origins were covered by [WIRED](https://www.wired.com/story/world-monitor-elie-habib/).
 
 The platform is open source under AGPL-3.0-only — see the [License](/license) and [Trademark Policy](/trademark-policy).
 
 ## In the press
 
-- [WIRED — The music-streaming CEO who built a global war map](https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map)
+- [WIRED — How a music-streaming CEO built an open-source global threat map in his spare time](https://www.wired.com/story/world-monitor-elie-habib/)
+- [The Economic Times — God's view: the rise of AI war dashboards](https://m.economictimes.com/tech/artificial-intelligence/gods-view-the-rise-of-ai-war-dashboards/articleshow/129553559.cms)
+- [Arabian Business — Anghami co-founder's AI tool tracking global crises draws millions of users](https://www.arabianbusiness.com/business/technology/exclusive-anghami-co-founders-ai-tool-tracking-global-crises-draws-millions-of-users)
 - [Entrepreneur Middle East — How Elie Habib built World Monitor to track global events in real time](https://mena.entrepreneur.com/business-news/how-elie-habib-built-world-monitor-to-track-global-events-in-real-time)
 - [Silicon Canals — Anghami CEO's side project now has 2 million users](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/)
 - [L'Orient Today — How the Anghami CEO's side project became a go-to for geopolitics research](https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research.html)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -229,10 +229,18 @@
             ]
           },
           {
+            "group": "Company",
+            "pages": [
+              "about"
+            ]
+          },
+          {
             "group": "Legal",
             "pages": [
               "license",
-              "trademark-policy"
+              "trademark-policy",
+              "privacy",
+              "terms"
             ]
           }
         ]

--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -1,0 +1,87 @@
+---
+title: "Privacy Policy"
+description: "How World Monitor handles personal data — what we collect, the subprocessors we use, AI query processing, cookies, retention, and your access and deletion rights under GDPR and CCPA."
+---
+
+{/* REVIEW BEFORE MERGE — confirm/replace: (1) the operating legal entity and its jurisdiction (currently written generically as "World Monitor"); (2) the effective date below; (3) whether a dedicated privacy@ inbox should replace support@; (4) that the subprocessor list matches production. This draft is factual from the current stack but is NOT legal advice and should get a legal review. */}
+
+_Last updated: 10 July 2026_
+
+This Privacy Policy explains how World Monitor ("World Monitor", "we", "us") handles information when you use the World Monitor dashboard, website, API, MCP server, and apps (the "Service").
+
+This page is written in plain language and is not legal advice.
+
+## The short version
+
+- The basic dashboard works **without an account and without signup**.
+- We do not sell your personal data.
+- We use a small set of established subprocessors for authentication, payments, hosting, error monitoring, and AI analysis — listed in full below.
+- You can request access to, export of, or deletion of your account data at any time.
+
+## Information we collect
+
+**Account information.** If you create an account or upgrade to Pro, our authentication providers (Clerk and WorkOS) process your email address, name, and login credentials. We store account identifiers and your plan/entitlement state in our database (Convex).
+
+**Payment information.** Subscriptions are processed by Dodo Payments, which acts as the merchant of record. Your full card details are entered with and held by the payment processor — **World Monitor never receives or stores your full card number.** We receive limited billing metadata (such as plan, status, country, and the last four digits) needed to manage your subscription.
+
+**Usage and diagnostics.** To keep the Service reliable we collect:
+
+- **Error and crash diagnostics** via Sentry (e.g. error messages, stack traces, browser and device type).
+- **Aggregate, privacy-oriented analytics** via Vercel Web Analytics and Cloudflare — used to understand traffic patterns. These are designed to avoid cross-site tracking, and where configured are cookieless.
+- **Server and request logs** via Axiom and our hosting/CDN providers (Vercel, Cloudflare), including IP address, user agent, and request metadata, retained for security and debugging.
+
+**Content you submit to AI features.** When you use AI briefings, analysis, forecasts, or the research assistant, the text of your query and the relevant context are sent to our AI providers (Anthropic and, via OpenRouter, other model providers) to generate a response. Do not submit sensitive personal data into AI prompts.
+
+**Preferences and alerts.** Settings such as saved locations, alert rules, and layer preferences are stored in your browser (local storage) and, for signed-in users, in our database (Convex).
+
+## Cookies and local storage
+
+- **Essential** — authentication sessions (Clerk/WorkOS) and security use cookies or equivalent storage that are required for signed-in features to work.
+- **Preferences** — dashboard settings are stored locally in your browser.
+- **Analytics** — our analytics are designed to be privacy-friendly and, where configured, do not use tracking cookies.
+
+## Subprocessors
+
+We share personal data only with service providers that process it on our behalf to run the Service:
+
+| Provider | Purpose |
+|----------|---------|
+| Clerk | Authentication and account management |
+| WorkOS | Authentication, OAuth, and enterprise/agent sign-in |
+| Convex | Application database (accounts, entitlements, alerts, preferences) |
+| Dodo Payments | Payment processing and subscription billing (merchant of record) |
+| Sentry | Error and crash monitoring |
+| Vercel | Application hosting and web analytics |
+| Cloudflare | Content delivery, edge security, and web analytics |
+| Axiom | Application logging and observability |
+| Anthropic | AI model provider for analysis and briefings |
+| OpenRouter | AI model routing for analysis and forecasts |
+| Resend | Transactional email delivery |
+
+## How we use information
+
+We use the information above to operate and secure the Service, authenticate users, process subscriptions, generate AI analysis you request, communicate with you about your account, and improve reliability and performance. We rely on legitimate interests, contract performance, and — where applicable — your consent as the legal bases for this processing.
+
+## Data retention
+
+We keep account and subscription data for as long as your account is active and as needed to meet legal, tax, and security obligations. Diagnostic and log data is retained on a rolling basis for a limited period. When you delete your account, we delete or anonymize associated personal data, except where we must retain it by law.
+
+## Your rights
+
+Depending on where you live (including under the EU/UK GDPR and the California CCPA/CPRA), you may have the right to access, correct, export, or delete your personal data, and to object to or restrict certain processing. To exercise any of these rights, contact us at [support@worldmonitor.app](mailto:support@worldmonitor.app). You also have the right to complain to your local data protection authority.
+
+## International transfers
+
+Our subprocessors may process data in countries other than yours, including the United States. Where required, transfers are covered by appropriate safeguards such as standard contractual clauses.
+
+## Children
+
+The Service is not directed to children and is not intended for use by anyone under the age required by their local law to consent to data processing. We do not knowingly collect personal data from children.
+
+## Changes
+
+We may update this policy as the Service evolves. Material changes will be reflected here with a new "Last updated" date.
+
+## Contact
+
+Questions about this policy or your data: [support@worldmonitor.app](mailto:support@worldmonitor.app).

--- a/docs/terms.mdx
+++ b/docs/terms.mdx
@@ -1,0 +1,82 @@
+---
+title: "Terms of Service"
+description: "The terms governing use of World Monitor — acceptable use, the intelligence-data disclaimer, API and MCP usage, subscriptions and billing, intellectual property, and limitation of liability."
+---
+
+{/* REVIEW BEFORE MERGE — confirm/replace: (1) the operating legal entity and the governing-law jurisdiction (written generically below); (2) the effective date; (3) refund/cancellation terms match Dodo Payments and your actual policy; (4) that the disclaimer and liability wording is acceptable to you / your counsel. This draft is factual but is NOT legal advice and should get a legal review. */}
+
+_Last updated: 10 July 2026_
+
+These Terms of Service ("Terms") govern your use of the World Monitor dashboard, website, API, MCP server, SDKs, and apps (the "Service"), operated by World Monitor ("we", "us"). By using the Service, you agree to these Terms. If you do not agree, do not use the Service.
+
+This page is written in plain language and is not legal advice.
+
+## The Service
+
+World Monitor aggregates and presents real-time global intelligence from many third-party and open sources, with automated and AI-generated analysis layered on top. The basic dashboard is available without an account. Additional features are available on paid Pro plans.
+
+We may change, suspend, or discontinue any part of the Service at any time.
+
+## Accounts
+
+Some features require an account, provided through our authentication providers. You are responsible for keeping your credentials and any API keys secure and for all activity under your account. Notify us promptly of any unauthorized use.
+
+## Acceptable use
+
+You agree not to:
+
+- use the Service unlawfully, or to harm, harass, surveil, or endanger any person;
+- exceed published rate limits, or circumvent quotas, authentication, or access controls;
+- scrape, resell, or redistribute the data or Service except as expressly permitted by the API terms and the source licenses;
+- disrupt, overload, or attempt to gain unauthorized access to the Service or its infrastructure;
+- misrepresent affiliation with or endorsement by World Monitor (see the [Trademark Policy](/trademark-policy)).
+
+## Intelligence disclaimer
+
+**Read this carefully.** World Monitor aggregates data from third-party and open sources and generates automated and AI analysis. This information:
+
+- is provided **"as is" and "as available"**, without warranty of accuracy, completeness, timeliness, or fitness for any purpose;
+- may be delayed, incomplete, wrong, or misattributed, and may reflect the errors of its underlying sources;
+- is **not** professional advice — not financial, investment, legal, security, medical, or safety advice.
+
+**Do not rely on the Service for decisions where errors could cause loss or harm** — including trading, travel, security, or life-safety decisions — without independently verifying the information. AI-generated briefings and forecasts are probabilistic and can be confidently wrong. You are solely responsible for how you use the information.
+
+## API, MCP, and programmatic access
+
+Programmatic use through the REST API and MCP server is subject to these Terms, the [API documentation](https://www.worldmonitor.app/docs), and any plan-specific rate limits and quotas. Keep your API keys confidential; you are responsible for usage attributed to your keys. We may throttle, suspend, or revoke access for abuse or to protect the Service.
+
+## Subscriptions and billing
+
+Paid plans are sold and processed by Dodo Payments, which acts as the merchant of record. By subscribing you also agree to the payment processor's terms. Subscriptions renew automatically until cancelled. You can cancel at any time, effective at the end of the current billing period. Except where required by law, payments are non-refundable. Prices and plan features may change with notice for future billing periods.
+
+## Intellectual property
+
+The World Monitor platform source code is licensed under AGPL-3.0-only, with certain client packages under MIT — see the [License](/license). The World Monitor name, logo, and branding are **not** covered by the code license; see the [Trademark Policy](/trademark-policy). Underlying data belongs to its respective sources and is subject to their licenses and terms.
+
+## Third-party sources and links
+
+The Service incorporates data and links from third parties. We do not control and are not responsible for third-party sources, their accuracy, or their availability, and inclusion does not imply endorsement.
+
+## Disclaimer of warranties
+
+The Service is provided "as is" and "as available" without warranties of any kind, whether express or implied, including merchantability, fitness for a particular purpose, non-infringement, and uninterrupted or error-free operation, to the maximum extent permitted by law.
+
+## Limitation of liability
+
+To the maximum extent permitted by law, World Monitor and its operator will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss of profits, data, or goodwill, arising from your use of or inability to use the Service — even if advised of the possibility. Our total liability for any claim relating to the Service will not exceed the amount you paid us for the Service in the twelve months before the claim, or USD 100 if you paid nothing.
+
+## Indemnification
+
+You agree to indemnify and hold harmless World Monitor and its operator from claims and expenses arising out of your misuse of the Service or violation of these Terms.
+
+## Changes to these Terms
+
+We may update these Terms as the Service evolves. Material changes will be reflected here with a new "Last updated" date. Continued use after changes take effect constitutes acceptance.
+
+## Governing law
+
+These Terms are governed by the laws of the jurisdiction in which the operator is established, without regard to conflict-of-laws principles. {/* REVIEW: replace with the specific governing-law jurisdiction and venue. */}
+
+## Contact
+
+Questions about these Terms: [support@worldmonitor.app](mailto:support@worldmonitor.app).

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,13 @@
     { "source": "/reference", "destination": "/reference/changelog/", "permanent": false },
     { "source": "/contact", "destination": "/docs/support", "permanent": false },
     { "source": "/support", "destination": "/docs/support", "permanent": false },
-    { "source": "/help", "destination": "/docs/support", "permanent": false }
+    { "source": "/help", "destination": "/docs/support", "permanent": false },
+    { "source": "/about", "destination": "/docs/about", "permanent": false },
+    { "source": "/privacy", "destination": "/docs/privacy", "permanent": false },
+    { "source": "/privacy-policy", "destination": "/docs/privacy", "permanent": false },
+    { "source": "/terms", "destination": "/docs/terms", "permanent": false },
+    { "source": "/terms-of-service", "destination": "/docs/terms", "permanent": false },
+    { "source": "/tos", "destination": "/docs/terms", "permanent": false }
   ],
   "rewrites": [
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,8 @@
     { "source": "/privacy-policy", "destination": "/docs/privacy", "permanent": false },
     { "source": "/terms", "destination": "/docs/terms", "permanent": false },
     { "source": "/terms-of-service", "destination": "/docs/terms", "permanent": false },
-    { "source": "/tos", "destination": "/docs/terms", "permanent": false }
+    { "source": "/tos", "destination": "/docs/terms", "permanent": false },
+    { "source": "/legal", "destination": "/docs/terms", "permanent": false }
   ],
   "rewrites": [
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },


### PR DESCRIPTION
## Why

orank's agent-readiness scan flagged **`~ Trust anchor pages — only Contact verified; missing About, Privacy`**. Investigation found `/about`, `/privacy`, `/terms` (and `/privacy-policy`, `/legal`, `/tos`) all returned the **SPA shell** — the `vercel.json` catch-all rewrites anything not excluded to `/dashboard.html`, so to a non-JS agent these paths *are* the homepage. And **no privacy/terms/about content existed anywhere** — repo, live site, or `/docs` (all 404).

For a product processing user data via **Clerk, WorkOS, Convex, Dodo Payments, and Sentry**, a missing privacy policy is a **compliance gap** (GDPR/CCPA, payment-processor + app-store requirements), not just an AEO one.

## What

Three real trust pages built as Mintlify docs, **mirroring the existing `/contact` → `/docs/support` pattern** — real HTML for humans/crawlers, markdown content-negotiation for agents:

- `docs/about.mdx` — what World Monitor is, mission, who builds it, links
- `docs/privacy.mdx` — data handling, **subprocessor table drawn from the actual stack** (Clerk, WorkOS, Convex, Dodo, Sentry, Vercel, Cloudflare, Axiom, Anthropic, OpenRouter, Resend), cookies, GDPR/CCPA rights
- `docs/terms.mdx` — acceptable use, **intelligence disclaimer** (data "as is", not financial/safety advice, don't rely on it for trading/life-safety), Dodo merchant-of-record billing, liability limits

Wiring:
- `docs/docs.json` — new **"Company"** nav group (about) + **privacy/terms** added to the existing **"Legal"** group
- `vercel.json` — clean-URL redirects `/about`, `/privacy`, `/privacy-policy`, `/terms`, `/terms-of-service`, `/tos` → `/docs/*` (redirects run **before** the SPA rewrite, so they resolve to real HTML)

## ⚠️ Review before merge (drafted factual from the stack, NOT legal advice)

Flagged inline via non-rendering `{/* ... */}` MDX comments:
- [ ] **Operating legal entity** — written generically as "World Monitor"; is there an LLC/Ltd or is it an individual?
- [ ] **Governing-law jurisdiction + venue** — Terms uses a generic placeholder
- [ ] **Effective date** — set to *10 July 2026*
- [ ] **Refund/cancellation terms** — confirm they match the Dodo setup
- [ ] **Privacy contact** — using `support@`; consider a dedicated `privacy@`
- [ ] **Subprocessor accuracy** — confirm the table matches production (e.g., WorkOS live vs Clerk-only)

Recommend a legal pass on the liability/disclaimer wording.

## Notes

- `/docs/about|privacy|terms` resolve once Mintlify rebuilds from `docs/*.mdx` on merge (same eventual-consistency as any docs page add).
- No test pins the redirect set or docs nav; `docs.json`/`vercel.json` validated as JSON. Prepush gate green.
- Not included: homepage (`welcome.html`) footer links — it has no footer and adding one is invasive; the nav groups + redirects make the pages reachable (as Contact is, without a homepage link).

Separate from #5174 (dead-QID removal).

https://claude.ai/code/session_01J4WNHvxXL79zEjgUuHQ9ci