### PR TITLE
docs(legal): set UAE governing law, clarify refunds, ground operator in Dubai

### DIFF
--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -3,11 +3,11 @@ title: "Privacy Policy"
 description: "How World Monitor handles personal data — what we collect, the subprocessors we use, AI query processing, cookies, retention, and your access and deletion rights under GDPR and CCPA."
 ---
 
-{/* REVIEW BEFORE MERGE — confirm/replace: (1) the operating legal entity and its jurisdiction (currently written generically as "World Monitor"); (2) the effective date below; (3) whether a dedicated privacy@ inbox should replace support@; (4) that the subprocessor list matches production. This draft is factual from the current stack but is NOT legal advice and should get a legal review. */}
+{/* REVIEW — operator based in Dubai, UAE. Still optional: (1) name the specific registered legal entity if one exists; (2) the effective date; (3) a dedicated privacy@ inbox vs support@; (4) confirm the subprocessor list matches production. NOT legal advice — a legal review is still recommended. */}
 
 _Last updated: 10 July 2026_
 
-This Privacy Policy explains how World Monitor ("World Monitor", "we", "us") handles information when you use the World Monitor dashboard, website, API, MCP server, and apps (the "Service").
+This Privacy Policy explains how World Monitor, based in Dubai, United Arab Emirates ("World Monitor", "we", "us"), handles information when you use the World Monitor dashboard, website, API, MCP server, and apps (the "Service").
 
 This page is written in plain language and is not legal advice.
 

--- a/docs/privacy.mdx
+++ b/docs/privacy.mdx
@@ -3,7 +3,7 @@ title: "Privacy Policy"
 description: "How World Monitor handles personal data — what we collect, the subprocessors we use, AI query processing, cookies, retention, and your access and deletion rights under GDPR and CCPA."
 ---
 
-{/* REVIEW — operator based in Dubai, UAE. Still optional: (1) name the specific registered legal entity if one exists; (2) the effective date; (3) a dedicated privacy@ inbox vs support@; (4) confirm the subprocessor list matches production. NOT legal advice — a legal review is still recommended. */}
+{/* REVIEW — operator based in Dubai, UAE; effective date 10 July 2026. Still optional: (1) name the specific registered legal entity if one exists; (2) a dedicated privacy@ inbox vs support@; (3) confirm the subprocessor list matches production. NOT legal advice — a legal review is still recommended. */}
 
 _Last updated: 10 July 2026_
 

--- a/docs/terms.mdx
+++ b/docs/terms.mdx
@@ -3,7 +3,7 @@ title: "Terms of Service"
 description: "The terms governing use of World Monitor — acceptable use, the intelligence-data disclaimer, API and MCP usage, subscriptions and billing, intellectual property, and limitation of liability."
 ---
 
-{/* REVIEW — governing law set to the UAE (Dubai venue); refunds deferred to Dodo Payments + consumer law (no separate policy configured in Dodo). Still optional: (1) name the specific registered legal entity if one exists (currently "World Monitor, based in Dubai, UAE"); (2) the effective date. NOT legal advice — a legal review is still recommended. */}
+{/* REVIEW — governing law set to the UAE (Dubai venue, with a mandatory-consumer-law carve-out); refunds deferred to Dodo Payments + consumer law (no separate policy configured in Dodo); effective date 10 July 2026. Still optional: name the specific registered legal entity if one exists (currently "World Monitor, based in Dubai, UAE"). NOT legal advice — a legal review is still recommended. */}
 
 _Last updated: 10 July 2026_
 
@@ -75,7 +75,7 @@ We may update these Terms as the Service evolves. Material changes will be refle
 
 ## Governing law
 
-These Terms are governed by the laws of the United Arab Emirates, without regard to conflict-of-laws principles. You submit to the exclusive jurisdiction of the competent courts of Dubai, United Arab Emirates for any dispute arising out of or relating to these Terms or the Service.
+These Terms are governed by the laws of the United Arab Emirates, without regard to conflict-of-laws principles, and the courts of Dubai, United Arab Emirates will have jurisdiction over any dispute arising out of or relating to these Terms or the Service. Nothing in this section removes any protection you have under the mandatory consumer-protection laws of your country of residence, including any right you may have to bring proceedings in your local courts.
 
 ## Contact
 

--- a/docs/terms.mdx
+++ b/docs/terms.mdx
@@ -3,11 +3,11 @@ title: "Terms of Service"
 description: "The terms governing use of World Monitor — acceptable use, the intelligence-data disclaimer, API and MCP usage, subscriptions and billing, intellectual property, and limitation of liability."
 ---
 
-{/* REVIEW BEFORE MERGE — confirm/replace: (1) the operating legal entity and the governing-law jurisdiction (written generically below); (2) the effective date; (3) refund/cancellation terms match Dodo Payments and your actual policy; (4) that the disclaimer and liability wording is acceptable to you / your counsel. This draft is factual but is NOT legal advice and should get a legal review. */}
+{/* REVIEW — governing law set to the UAE (Dubai venue); refunds deferred to Dodo Payments + consumer law (no separate policy configured in Dodo). Still optional: (1) name the specific registered legal entity if one exists (currently "World Monitor, based in Dubai, UAE"); (2) the effective date. NOT legal advice — a legal review is still recommended. */}
 
 _Last updated: 10 July 2026_
 
-These Terms of Service ("Terms") govern your use of the World Monitor dashboard, website, API, MCP server, SDKs, and apps (the "Service"), operated by World Monitor ("we", "us"). By using the Service, you agree to these Terms. If you do not agree, do not use the Service.
+These Terms of Service ("Terms") govern your use of the World Monitor dashboard, website, API, MCP server, SDKs, and apps (the "Service"), operated by World Monitor, based in Dubai, United Arab Emirates ("we", "us"). By using the Service, you agree to these Terms. If you do not agree, do not use the Service.
 
 This page is written in plain language and is not legal advice.
 
@@ -47,7 +47,7 @@ Programmatic use through the REST API and MCP server is subject to these Terms, 
 
 ## Subscriptions and billing
 
-Paid plans are sold and processed by Dodo Payments, which acts as the merchant of record. By subscribing you also agree to the payment processor's terms. Subscriptions renew automatically until cancelled. You can cancel at any time, effective at the end of the current billing period. Except where required by law, payments are non-refundable. Prices and plan features may change with notice for future billing periods.
+Paid plans are sold and processed by Dodo Payments, which acts as the merchant of record; payments and any refunds are handled by Dodo Payments, and by subscribing you also agree to its terms. Subscriptions renew automatically until you cancel. You can cancel at any time — cancellation stops future renewals and takes effect at the end of the current billing period. We do not provide refunds for partial billing periods except where required by applicable consumer-protection law. Prices and plan features may change with notice for future billing periods.
 
 ## Intellectual property
 
@@ -75,7 +75,7 @@ We may update these Terms as the Service evolves. Material changes will be refle
 
 ## Governing law
 
-These Terms are governed by the laws of the jurisdiction in which the operator is established, without regard to conflict-of-laws principles. {/* REVIEW: replace with the specific governing-law jurisdiction and venue. */}
+These Terms are governed by the laws of the United Arab Emirates, without regard to conflict-of-laws principles. You submit to the exclusive jurisdiction of the competent courts of Dubai, United Arab Emirates for any dispute arising out of or relating to these Terms or the Service.
 
 ## Contact
 


### PR DESCRIPTION
Fills the legal placeholders flagged in #5177 (now merged), per confirmation from Elie.

## Changes

**Terms**
- **Governing law** → United Arab Emirates, with exclusive jurisdiction of the competent courts of **Dubai** (was a generic "jurisdiction where the operator is established" placeholder).
- **Refunds** → no separate refund policy is configured in Dodo, so this defers refunds to **Dodo Payments (merchant of record) + applicable consumer-protection law** and drops the flat "non-refundable" wording. Cancellation stops future renewals, effective at the end of the billing period.
- Operator grounded as **"World Monitor, based in Dubai, United Arab Emirates."**

**Privacy**
- Operator grounded the same way (consistent with the Organization schema's `Dubai, AE` address).

## Still open (optional, flagged inline)
- A specific **registered legal entity** name, if one exists (e.g. a FZ-LLC) — currently just "World Monitor, based in Dubai, UAE".
- The **effective date** (10 July 2026).

Not legal advice — a legal review is still recommended. Docs-only; no code/CSP/pro-build impact.

https://claude.ai/code/session_01J4WNHvxXL79zEjgUuHQ9ci