### PR TITLE
fix(brief): reject truncated why-matters prose

### DIFF
--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -262,6 +262,10 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
       // WHY_MATTERS_* constants above. Decoupled from LLM_REASONING_MODEL.
       providerOrder: WHY_MATTERS_PROVIDER_ORDER,
       modelOverrides: WHY_MATTERS_MODEL_OVERRIDES,
+      // A provider's explicit token-limit signal is deterministic, so retry
+      // the next provider in-request. The parser remains post-call because
+      // parse rejection is ambiguous and should not trigger duplicate spend.
+      retryOnLengthLimit: true,
       // Note: no `validate` option. The post-call parseWhyMattersV2
       // check below handles rejection. Using validate inside
       // callLlm would walk the provider chain on parse-reject,
@@ -311,6 +315,9 @@ async function runGeminiPath(story: StoryPayload): Promise<string | null> {
       // WHY_MATTERS_* constants above. Decoupled from LLM_REASONING_MODEL.
       providerOrder: WHY_MATTERS_PROVIDER_ORDER,
       modelOverrides: WHY_MATTERS_MODEL_OVERRIDES,
+      // Match the analyst path: retry only deterministic token-limit signals,
+      // while leaving prose-shape validation outside the provider loop.
+      retryOnLengthLimit: true,
       // Note: no `validate` option. The post-call parseWhyMatters check
       // below handles rejection by returning null. Using validate inside
       // callLlm would walk the provider chain on parse-reject,

--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -54,6 +54,7 @@ import { captureSilentError } from '../_sentry-edge.js';
 import {
   buildWhyMattersUserPrompt,
   hashBriefStory,
+  hasTerminalPunctuation,
   parseWhyMatters,
   parseWhyMattersV2,
 } from '../../shared/brief-llm-core.js';
@@ -229,6 +230,12 @@ function validateStoryBody(raw: unknown): ValidationOk | ValidationErr {
 
 // ── LLM paths ─────────────────────────────────────────────────────────
 
+function rejectLengthLimitedCompletion(path: 'analyst' | 'gemini', finishReason: string | null): boolean {
+  if (finishReason !== 'length') return false;
+  console.warn(`[brief-why-matters] ${path} completion_reject reason=length`);
+  return true;
+}
+
 async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise<string | null> {
   try {
     const context = await assembleBriefStoryContext({ iso2, category: story.category });
@@ -261,6 +268,7 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
       // causing duplicate openrouter billings (see todo 245).
     });
     if (!result) return null;
+    if (rejectLengthLimitedCompletion('analyst', result.finishReason)) return null;
     // v2 parser accepts multi-sentence output + rejects preamble /
     // leaked section labels and private forecast percentages. Keep public
     // story grounding separate so sourced figures remain publishable.
@@ -310,6 +318,7 @@ async function runGeminiPath(story: StoryPayload): Promise<string | null> {
       // configured in prod. See todo 245.
     });
     if (!result) return null;
+    if (rejectLengthLimitedCompletion('gemini', result.finishReason)) return null;
     return parseWhyMatters(result.content);
   } catch (err) {
     console.warn(`[brief-why-matters] gemini path failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -330,6 +339,7 @@ function isEnvelope(v: unknown): v is WhyMattersEnvelope {
   const e = v as Record<string, unknown>;
   return (
     typeof e.whyMatters === 'string' &&
+    hasTerminalPunctuation(e.whyMatters) &&
     (e.producedBy === 'analyst' || e.producedBy === 'gemini') &&
     typeof e.at === 'string'
   );
@@ -408,6 +418,12 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
 
   // Cache identity.
   const hash = await hashBriefStory(story);
+  // v10 (2026-07-10): responses now preserve the provider finish reason and
+  // reject `length` completions before parsing. v9 rows were written without
+  // that authoritative signal and may contain abbreviation-ending clips that
+  // look sentence-complete to punctuation heuristics, so they must not survive
+  // the deploy.
+  //
   // v9 (2026-07-10): bumped from v8 alongside the analyst output-policy
   // rollout. v8 rows may use the retired formulaic voice, the longer
   // 40–70-word / 2–3-sentence length, or expose raw forecast probabilities,
@@ -431,7 +447,7 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
   //
   // v6 history (kept for reference): category-gated context + prompt-level
   // RELEVANCE RULE (2026-04-22) — those changes remain in v8.
-  const cacheKey = `brief:llm:whymatters:v9:${hash}`;
+  const cacheKey = `brief:llm:whymatters:v10:${hash}`;
   // Shadow v6→v7 for the same reason: a pre-policy v6 record would mix
   // retired and current analyst outputs in the seven-day evaluation cohort.
   const shadowKey = `brief:llm:whymatters:shadow:v7:${hash}`;

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -15,7 +15,7 @@
 //     through to the original stub — the brief must always ship.
 //
 // Cache semantics:
-//   - brief:llm:whymatters:v5:{storyHash} — 24h, shared across users
+//   - brief:llm:whymatters:v6:{storyHash} — 24h, shared across users
 //     for the same story. v4 bumped from v3 alongside the F6
 //     date-grounding line: every v3 row was produced from a prompt
 //     with no notion of "today" and may state a fabricated year, so
@@ -41,6 +41,7 @@ import {
   briefDateLine,
   buildWhyMattersUserPrompt,
   hashBriefStory,
+  hasTerminalPunctuation,
   parseWhyMatters,
   checkLeadGrounding,
   leadGroundsAgainstStory,
@@ -110,16 +111,24 @@ const BRIEF_LLM_SKIP_PROVIDERS = ['ollama', 'groq'];
 // (`api/internal/brief-why-matters.ts`) can import them without pulling in
 // `node:crypto`. See the `shared/` → `scripts/shared/` mirror convention.
 
+function normalizeAnalystWhyMatters(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  if (normalized.length < 30 || normalized.length > 500) return null;
+  if (/^story flagged by your sensitivity/i.test(normalized)) return null;
+  return hasTerminalPunctuation(normalized) ? normalized : null;
+}
+
 /**
  * Resolve a `whyMatters` sentence for one story.
  *
  * Four-layer graceful degradation:
  *   1. `deps.callAnalystWhyMatters(story)` — the analyst-context edge
- *      endpoint (brief:llm:whymatters:v9 cache lives there). Preferred.
- *   2. Direct read of the endpoint's v9 envelope cache (#4914) — the
+ *      endpoint (brief:llm:whymatters:v10 cache lives there). Preferred.
+ *   2. Direct read of the endpoint's v10 envelope cache (#4914) — the
  *      endpoint CALL can fail while its cached envelope is still valid;
  *      reusing it avoids a paid duplicate generation.
- *   3. Legacy direct-Gemini chain: cacheGet (v5) → callLLM → cacheSet.
+ *   3. Legacy direct-Gemini chain: cacheGet (v6) → callLLM → cacheSet.
  *      Runs whenever the analyst call is missing, returns null, or throws.
  *   4. Caller (enrichBriefEnvelopeWithLLM) uses the baseline stub if
  *      this function returns null.
@@ -138,20 +147,18 @@ export async function generateWhyMatters(story, deps) {
   // Priority path: analyst endpoint. It owns its own cache and has
   // ALREADY validated the output via parseWhyMatters (gemini path) or
   // parseWhyMattersV2 (analyst path, multi-sentence). We must NOT
-  // re-parse here with the single-sentence v1 parser — that silently
-  // truncates v2's 2–3-sentence output to the first sentence. Trust
-  // the wire shape; only reject an obviously-bad payload (empty, stub
-  // echo, or length outside the legal bounds for either parser).
+  // re-parse here with the narrower v1 parser — v2 intentionally permits
+  // longer multi-sentence output. Trust the wire shape; only reject an
+  // obviously-bad payload (empty, stub
+  // echo, incomplete sentence, or length outside either parser's bounds).
   if (typeof deps.callAnalystWhyMatters === 'function') {
     try {
       const analystOut = await deps.callAnalystWhyMatters(story);
+      const normalized = normalizeAnalystWhyMatters(analystOut);
+      if (normalized) return normalized;
       if (typeof analystOut === 'string') {
-        const trimmed = analystOut.trim();
-        const lenOk = trimmed.length >= 30 && trimmed.length <= 500;
-        const notStub = !/^story flagged by your sensitivity/i.test(trimmed);
-        if (lenOk && notStub) return trimmed;
         console.warn(
-          `[brief-llm] callAnalystWhyMatters → fallback: endpoint returned out-of-bounds or stub (len=${trimmed.length})`,
+          `[brief-llm] callAnalystWhyMatters → fallback: endpoint returned out-of-bounds, stub, or incomplete prose (len=${analystOut.trim().length})`,
         );
       } else {
         console.warn('[brief-llm] callAnalystWhyMatters → fallback: null/empty response');
@@ -165,24 +172,18 @@ export async function generateWhyMatters(story, deps) {
 
   // #4914: before paying a direct-Gemini generation, check the analyst
   // endpoint's OWN cache namespace. api/internal/brief-why-matters.ts
-  // stores its envelope at brief:llm:whymatters:v9:{hash} under the same
+  // stores its envelope at brief:llm:whymatters:v10:{hash} under the same
   // hashBriefStory identity — when the endpoint CALL failed transiently
   // (or no endpoint is configured), the story may already have a paid,
   // validated envelope sitting in Redis. Read-only: this fallback's own
-  // single-sentence output stays in the legacy v5 namespace below, so the
+  // fallback output stays in the legacy v6 namespace below, so the
   // two prompt contracts never cross-contaminate in the write direction.
   const storyHash = await hashBriefStory(story);
   try {
-    const v9 = await deps.cacheGet(`brief:llm:whymatters:v9:${storyHash}`);
-    if (v9 && typeof v9 === 'object' && typeof v9.whyMatters === 'string') {
-      const v9Trimmed = v9.whyMatters.trim();
-      // Same acceptance bounds as the live-endpoint path above.
-      if (
-        v9Trimmed.length >= 30 && v9Trimmed.length <= 500
-        && !/^story flagged by your sensitivity/i.test(v9Trimmed)
-      ) {
-        return v9Trimmed;
-      }
+    const v10 = await deps.cacheGet(`brief:llm:whymatters:v10:${storyHash}`);
+    if (v10 && typeof v10 === 'object') {
+      const normalized = normalizeAnalystWhyMatters(v10.whyMatters);
+      if (normalized) return normalized;
     }
   } catch { /* treat as miss */ }
 
@@ -201,10 +202,16 @@ export async function generateWhyMatters(story, deps) {
   // persisted on story:track:v1), post-PR carries the per-story
   // Title-Cased EventCategory value. Every v4 cache row is now stale.
   // Bump invalidates them cleanly.
-  const key = `brief:llm:whymatters:v5:${storyHash}`;
+  //
+  // v5→v6: 2026-07-10 issue #5168. v5 rows were written before the Railway
+  // provider chain rejected finish_reason=length, so an abbreviation-ending
+  // token clip could be cached as an apparently complete sentence. The old
+  // rows carry no completion metadata and cannot be distinguished safely.
+  const key = `brief:llm:whymatters:v6:${storyHash}`;
   try {
     const hit = await deps.cacheGet(key);
-    if (typeof hit === 'string' && hit.length > 0) return hit;
+    const parsedHit = parseWhyMatters(hit);
+    if (parsedHit) return parsedHit;
   } catch { /* cache miss is fine */ }
   // Sanitize story fields before interpolating into the prompt. The analyst
   // endpoint already does this; without it the Railway fallback path was an

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -38,6 +38,10 @@ import { createHash } from 'node:crypto';
 
 import {
   WHY_MATTERS_SYSTEM,
+  WHY_MATTERS_V1_MAX_CHARS,
+  WHY_MATTERS_V1_MIN_CHARS,
+  WHY_MATTERS_V2_MAX_CHARS,
+  WHY_MATTERS_V2_MIN_CHARS,
   briefDateLine,
   buildWhyMattersUserPrompt,
   hashBriefStory,
@@ -114,7 +118,9 @@ const BRIEF_LLM_SKIP_PROVIDERS = ['ollama', 'groq'];
 function normalizeAnalystWhyMatters(value) {
   if (typeof value !== 'string') return null;
   const normalized = value.trim();
-  if (normalized.length < 30 || normalized.length > 500) return null;
+  const minChars = Math.min(WHY_MATTERS_V1_MIN_CHARS, WHY_MATTERS_V2_MIN_CHARS);
+  const maxChars = Math.max(WHY_MATTERS_V1_MAX_CHARS, WHY_MATTERS_V2_MAX_CHARS);
+  if (normalized.length < minChars || normalized.length > maxChars) return null;
   if (/^story flagged by your sensitivity/i.test(normalized)) return null;
   return hasTerminalPunctuation(normalized) ? normalized : null;
 }

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -161,7 +161,10 @@ export async function generateWhyMatters(story, deps) {
           `[brief-llm] callAnalystWhyMatters → fallback: endpoint returned out-of-bounds, stub, or incomplete prose (len=${analystOut.trim().length})`,
         );
       } else {
-        console.warn('[brief-llm] callAnalystWhyMatters → fallback: null/empty response');
+        const responseType = analystOut === null ? 'null' : typeof analystOut;
+        console.warn(
+          `[brief-llm] callAnalystWhyMatters → fallback: endpoint returned no usable string (type=${responseType})`,
+        );
       }
     } catch (err) {
       console.warn(

--- a/scripts/lib/llm-chain.cjs
+++ b/scripts/lib/llm-chain.cjs
@@ -132,6 +132,12 @@ async function callLLM(systemPrompt, userPrompt, opts = {}) {
         continue;
       }
 
+      if (json.choices?.[0]?.finish_reason === 'length') {
+        console.warn(`[llm-chain] ${provider.name}: length-limited response, trying next provider`);
+        record(false, { ...usage, reason: 'length' });
+        continue;
+      }
+
       const text = stripReasoningPreamble(rawText);
       console.log(`[llm-chain] ${provider.name} OK (${text.length} chars)`);
       record(true, usage);

--- a/scripts/lib/llm-chain.cjs
+++ b/scripts/lib/llm-chain.cjs
@@ -125,16 +125,16 @@ async function callLLM(systemPrompt, userPrompt, opts = {}) {
         tokensPrompt: json.usage?.prompt_tokens ?? 0,
         tokensCompletion: json.usage?.completion_tokens ?? 0,
       };
+      if (json.choices?.[0]?.finish_reason === 'length') {
+        console.warn(`[llm-chain] ${provider.name}: length-limited response, trying next provider`);
+        record(false, { ...usage, reason: 'length' });
+        continue;
+      }
+
       const rawText = json.choices?.[0]?.message?.content?.trim();
       if (!rawText) {
         console.warn(`[llm-chain] ${provider.name}: empty response`);
         record(false, { ...usage, reason: 'empty' });
-        continue;
-      }
-
-      if (json.choices?.[0]?.finish_reason === 'length') {
-        console.warn(`[llm-chain] ${provider.name}: length-limited response, trying next provider`);
-        record(false, { ...usage, reason: 'length' });
         continue;
       }
 

--- a/scripts/shared/brief-llm-core.d.ts
+++ b/scripts/shared/brief-llm-core.d.ts
@@ -18,6 +18,10 @@ export interface BriefStoryPromptInput {
 }
 
 export const WHY_MATTERS_SYSTEM: string;
+export const WHY_MATTERS_V1_MIN_CHARS: number;
+export const WHY_MATTERS_V1_MAX_CHARS: number;
+export const WHY_MATTERS_V2_MIN_CHARS: number;
+export const WHY_MATTERS_V2_MAX_CHARS: number;
 
 export function briefDateLine(todayIso?: string): string;
 

--- a/scripts/shared/brief-llm-core.d.ts
+++ b/scripts/shared/brief-llm-core.d.ts
@@ -31,6 +31,8 @@ export function buildWhyMattersUserPrompt(
 
 export function parseWhyMatters(text: unknown): string | null;
 
+export function hasTerminalPunctuation(text: unknown): boolean;
+
 export function hashBriefStory(story: BriefStoryHashInput): Promise<string>;
 
 // ── v2 (analyst path only) ────────────────────────────────────────────────

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -25,6 +25,11 @@ export const WHY_MATTERS_SYSTEM =
   '("This matters because…"), no questions, no calls to action, no markdown, ' +
   'no quotes. One sentence only.';
 
+export const WHY_MATTERS_V1_MIN_CHARS = 30;
+export const WHY_MATTERS_V1_MAX_CHARS = 400;
+export const WHY_MATTERS_V2_MIN_CHARS = 100;
+export const WHY_MATTERS_V2_MAX_CHARS = 500;
+
 /**
  * Date-grounding line appended to every brief LLM system prompt.
  *
@@ -90,7 +95,9 @@ export function buildWhyMattersUserPrompt(story, todayIso) {
 export function hasTerminalPunctuation(text) {
   if (typeof text !== 'string') return false;
   const s = text.trim();
-  return /[.!?](?:["'\u2019\u201D]+)?$/.test(s);
+  const prose = s.replace(/["'\u2019\u201D]+$/, '');
+  if (/(?:\.\.\.|\u2026)$/.test(prose)) return false;
+  return /[.!?]$/.test(prose);
 }
 
 /**
@@ -110,7 +117,7 @@ export function parseWhyMatters(text) {
   // (`U.S. Navy` vs `U.S. Markets rallied`). The prompt owns sentence count;
   // provider finish_reason plus this punctuation gate own completeness.
   if (!hasTerminalPunctuation(s)) return null;
-  if (s.length < 30 || s.length > 400) return null;
+  if (s.length < WHY_MATTERS_V1_MIN_CHARS || s.length > WHY_MATTERS_V1_MAX_CHARS) return null;
   if (/^story flagged by your sensitivity/i.test(s)) return null;
   return s;
 }
@@ -241,7 +248,7 @@ export function parseWhyMattersV2(text, provenance) {
   if (!s) return null;
   // Drop surrounding quotes if the model insisted.
   s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
-  if (s.length < 100 || s.length > 500) return null;
+  if (s.length < WHY_MATTERS_V2_MIN_CHARS || s.length > WHY_MATTERS_V2_MAX_CHARS) return null;
   if (!hasTerminalPunctuation(s)) return null;
   // Reject the stub echo (same as v1).
   if (/^story flagged by your sensitivity/i.test(s)) return null;

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -80,7 +80,21 @@ export function buildWhyMattersUserPrompt(story, todayIso) {
 }
 
 /**
- * Parse + validate the LLM response into a single editorial sentence.
+ * Whether a whyMatters candidate ends as a complete sentence. Accept closing
+ * quote marks after terminal punctuation so cached and wire-format values are
+ * safe to validate before parser-specific normalization.
+ *
+ * @param {unknown} text
+ * @returns {boolean}
+ */
+export function hasTerminalPunctuation(text) {
+  if (typeof text !== 'string') return false;
+  const s = text.trim();
+  return /[.!?](?:["'\u2019\u201D]+)?$/.test(s);
+}
+
+/**
+ * Parse + validate the LLM response into complete editorial prose.
  * Returns null when the output is obviously wrong (empty, boilerplate
  * preamble that survived stripReasoningPreamble, too short / too long).
  *
@@ -92,11 +106,13 @@ export function parseWhyMatters(text) {
   let s = text.trim();
   if (!s) return null;
   s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
-  const match = s.match(/^[^.!?]+[.!?]/);
-  const sentence = match ? match[0].trim() : s;
-  if (sentence.length < 30 || sentence.length > 400) return null;
-  if (/^story flagged by your sensitivity/i.test(sentence)) return null;
-  return sentence;
+  // Dotted abbreviations make sentence splitting intrinsically ambiguous
+  // (`U.S. Navy` vs `U.S. Markets rallied`). The prompt owns sentence count;
+  // provider finish_reason plus this punctuation gate own completeness.
+  if (!hasTerminalPunctuation(s)) return null;
+  if (s.length < 30 || s.length > 400) return null;
+  if (/^story flagged by your sensitivity/i.test(s)) return null;
+  return s;
 }
 
 /**
@@ -226,6 +242,7 @@ export function parseWhyMattersV2(text, provenance) {
   // Drop surrounding quotes if the model insisted.
   s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
   if (s.length < 100 || s.length > 500) return null;
+  if (!hasTerminalPunctuation(s)) return null;
   // Reject the stub echo (same as v1).
   if (/^story flagged by your sensitivity/i.test(s)) return null;
   // Reject common preamble the system prompt explicitly banned.

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -223,6 +223,12 @@ export interface LlmCallOptions {
   stage?: string;
   /** Let reasoning-capable OpenRouter models reason. Set by the reasoning profile; utility calls stay reasoning-off. */
   enableReasoning?: boolean;
+  /**
+   * Treat provider-reported token-limit completions as failed attempts and
+   * continue the configured provider chain. Defaults off so existing callers
+   * retain the historic first-non-empty-completion behavior.
+   */
+  retryOnLengthLimit?: boolean;
 }
 
 export interface LlmCallResult {
@@ -232,6 +238,44 @@ export interface LlmCallResult {
   tokens: number;
   /** Provider-reported completion status; null when the provider omits it. */
   finishReason: string | null;
+}
+
+const TOKEN_LIMIT_FINISH_REASONS = new Set([
+  'length',
+  'max_tokens',
+  'max_output_tokens',
+]);
+
+const KNOWN_NON_LIMIT_FINISH_REASONS = new Set([
+  'stop',
+  'end_turn',
+  'tool_calls',
+  'function_call',
+  'content_filter',
+  'safety',
+  'recitation',
+  'blocklist',
+  'prohibited_content',
+  'spii',
+  'malformed_function_call',
+  'image_safety',
+]);
+
+function normalizeFinishReason(finishReason: string | null): string | null {
+  if (typeof finishReason !== 'string') return null;
+  const normalized = finishReason.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  return normalized || null;
+}
+
+function isLengthLimitedCompletion(
+  finishReason: string | null,
+  completionTokens: number,
+  maxTokens: number,
+): boolean {
+  const normalized = normalizeFinishReason(finishReason);
+  if (normalized && TOKEN_LIMIT_FINISH_REASONS.has(normalized)) return true;
+  if (completionTokens < maxTokens) return false;
+  return normalized === null || !KNOWN_NON_LIMIT_FINISH_REASONS.has(normalized);
 }
 
 function resolveProviderChain(opts: {
@@ -292,7 +336,7 @@ export const callLlmReasoning = (opts: Omit<LlmCallOptions, 'providerOrder' | 'm
 
 // enableReasoning is omitted too: the reasoning stream hardcodes it on —
 // exposing the knob on the stream type would be a silent no-op for callers.
-export type LlmStreamOptions = Omit<LlmCallOptions, 'stripThinkingTags' | 'validate' | 'providerOrder' | 'modelOverrides' | 'provider' | 'enableReasoning'> & {
+export type LlmStreamOptions = Omit<LlmCallOptions, 'stripThinkingTags' | 'validate' | 'providerOrder' | 'modelOverrides' | 'provider' | 'enableReasoning' | 'retryOnLengthLimit'> & {
   /** When fired, aborts the active provider fetch and stops the stream. */
   signal?: AbortSignal;
 };
@@ -500,6 +544,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
     validate,
     systemAppend,
     enableReasoning = false,
+    retryOnLengthLimit = false,
   } = opts;
 
   let messages = rawMessages;
@@ -593,17 +638,27 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
           tokensCompletion: data.usage?.completion_tokens ?? 0,
         };
 
+        const tokens = data.usage?.total_tokens ?? 0;
+        const finishReason = typeof data.choices?.[0]?.finish_reason === 'string'
+          ? data.choices[0].finish_reason
+          : null;
+        if (retryOnLengthLimit && isLengthLimitedCompletion(
+          finishReason,
+          tokensExtra.tokensCompletion,
+          maxTokens,
+        )) {
+          console.warn(`[llm:${providerName}] Token-limited completion, trying next`);
+          record(false, { ...tokensExtra, reason: 'length' });
+          if (forcedProvider) return null;
+          continue;
+        }
+
         let content = data.choices?.[0]?.message?.content?.trim() || '';
         if (!content) {
           record(false, { ...tokensExtra, reason: 'empty' });
           if (forcedProvider) return null;
           continue;
         }
-
-        const tokens = data.usage?.total_tokens ?? 0;
-        const finishReason = typeof data.choices?.[0]?.finish_reason === 'string'
-          ? data.choices[0].finish_reason
-          : null;
 
         if (shouldStrip) {
           content = stripThinkingTags(content);

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -230,6 +230,8 @@ export interface LlmCallResult {
   model: string;
   provider: string;
   tokens: number;
+  /** Provider-reported completion status; null when the provider omits it. */
+  finishReason: string | null;
 }
 
 function resolveProviderChain(opts: {
@@ -582,7 +584,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
         }
 
         const data = (await resp.json()) as {
-          choices?: Array<{ message?: { content?: string } }>;
+          choices?: Array<{ message?: { content?: string }; finish_reason?: string | null }>;
           usage?: { total_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
         };
         const tokensExtra = {
@@ -599,6 +601,9 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
         }
 
         const tokens = data.usage?.total_tokens ?? 0;
+        const finishReason = typeof data.choices?.[0]?.finish_reason === 'string'
+          ? data.choices[0].finish_reason
+          : null;
 
         if (shouldStrip) {
           content = stripThinkingTags(content);
@@ -620,7 +625,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
         }
 
         record(true, tokensExtra);
-        return { content, model: creds.model, provider: providerName, tokens };
+        return { content, model: creds.model, provider: providerName, tokens, finishReason };
       } catch (err) {
         const name = (err as Error).name;
         console.warn(`[llm:${providerName}] ${(err as Error).message}`);

--- a/shared/brief-llm-core.d.ts
+++ b/shared/brief-llm-core.d.ts
@@ -18,6 +18,10 @@ export interface BriefStoryPromptInput {
 }
 
 export const WHY_MATTERS_SYSTEM: string;
+export const WHY_MATTERS_V1_MIN_CHARS: number;
+export const WHY_MATTERS_V1_MAX_CHARS: number;
+export const WHY_MATTERS_V2_MIN_CHARS: number;
+export const WHY_MATTERS_V2_MAX_CHARS: number;
 
 export function briefDateLine(todayIso?: string): string;
 

--- a/shared/brief-llm-core.d.ts
+++ b/shared/brief-llm-core.d.ts
@@ -31,6 +31,8 @@ export function buildWhyMattersUserPrompt(
 
 export function parseWhyMatters(text: unknown): string | null;
 
+export function hasTerminalPunctuation(text: unknown): boolean;
+
 export function hashBriefStory(story: BriefStoryHashInput): Promise<string>;
 
 // ── v2 (analyst path only) ────────────────────────────────────────────────

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -25,6 +25,11 @@ export const WHY_MATTERS_SYSTEM =
   '("This matters because…"), no questions, no calls to action, no markdown, ' +
   'no quotes. One sentence only.';
 
+export const WHY_MATTERS_V1_MIN_CHARS = 30;
+export const WHY_MATTERS_V1_MAX_CHARS = 400;
+export const WHY_MATTERS_V2_MIN_CHARS = 100;
+export const WHY_MATTERS_V2_MAX_CHARS = 500;
+
 /**
  * Date-grounding line appended to every brief LLM system prompt.
  *
@@ -90,7 +95,9 @@ export function buildWhyMattersUserPrompt(story, todayIso) {
 export function hasTerminalPunctuation(text) {
   if (typeof text !== 'string') return false;
   const s = text.trim();
-  return /[.!?](?:["'\u2019\u201D]+)?$/.test(s);
+  const prose = s.replace(/["'\u2019\u201D]+$/, '');
+  if (/(?:\.\.\.|\u2026)$/.test(prose)) return false;
+  return /[.!?]$/.test(prose);
 }
 
 /**
@@ -110,7 +117,7 @@ export function parseWhyMatters(text) {
   // (`U.S. Navy` vs `U.S. Markets rallied`). The prompt owns sentence count;
   // provider finish_reason plus this punctuation gate own completeness.
   if (!hasTerminalPunctuation(s)) return null;
-  if (s.length < 30 || s.length > 400) return null;
+  if (s.length < WHY_MATTERS_V1_MIN_CHARS || s.length > WHY_MATTERS_V1_MAX_CHARS) return null;
   if (/^story flagged by your sensitivity/i.test(s)) return null;
   return s;
 }
@@ -241,7 +248,7 @@ export function parseWhyMattersV2(text, provenance) {
   if (!s) return null;
   // Drop surrounding quotes if the model insisted.
   s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
-  if (s.length < 100 || s.length > 500) return null;
+  if (s.length < WHY_MATTERS_V2_MIN_CHARS || s.length > WHY_MATTERS_V2_MAX_CHARS) return null;
   if (!hasTerminalPunctuation(s)) return null;
   // Reject the stub echo (same as v1).
   if (/^story flagged by your sensitivity/i.test(s)) return null;

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -80,7 +80,21 @@ export function buildWhyMattersUserPrompt(story, todayIso) {
 }
 
 /**
- * Parse + validate the LLM response into a single editorial sentence.
+ * Whether a whyMatters candidate ends as a complete sentence. Accept closing
+ * quote marks after terminal punctuation so cached and wire-format values are
+ * safe to validate before parser-specific normalization.
+ *
+ * @param {unknown} text
+ * @returns {boolean}
+ */
+export function hasTerminalPunctuation(text) {
+  if (typeof text !== 'string') return false;
+  const s = text.trim();
+  return /[.!?](?:["'\u2019\u201D]+)?$/.test(s);
+}
+
+/**
+ * Parse + validate the LLM response into complete editorial prose.
  * Returns null when the output is obviously wrong (empty, boilerplate
  * preamble that survived stripReasoningPreamble, too short / too long).
  *
@@ -92,11 +106,13 @@ export function parseWhyMatters(text) {
   let s = text.trim();
   if (!s) return null;
   s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
-  const match = s.match(/^[^.!?]+[.!?]/);
-  const sentence = match ? match[0].trim() : s;
-  if (sentence.length < 30 || sentence.length > 400) return null;
-  if (/^story flagged by your sensitivity/i.test(sentence)) return null;
-  return sentence;
+  // Dotted abbreviations make sentence splitting intrinsically ambiguous
+  // (`U.S. Navy` vs `U.S. Markets rallied`). The prompt owns sentence count;
+  // provider finish_reason plus this punctuation gate own completeness.
+  if (!hasTerminalPunctuation(s)) return null;
+  if (s.length < 30 || s.length > 400) return null;
+  if (/^story flagged by your sensitivity/i.test(s)) return null;
+  return s;
 }
 
 /**
@@ -226,6 +242,7 @@ export function parseWhyMattersV2(text, provenance) {
   // Drop surrounding quotes if the model insisted.
   s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
   if (s.length < 100 || s.length > 500) return null;
+  if (!hasTerminalPunctuation(s)) return null;
   // Reject the stub echo (same as v1).
   if (/^story flagged by your sensitivity/i.test(s)) return null;
   // Reject common preamble the system prompt explicitly banned.

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -20,6 +20,7 @@ import {
   WHY_MATTERS_SYSTEM,
   briefDateLine,
   buildWhyMattersUserPrompt,
+  hasTerminalPunctuation,
   hashBriefStory,
   parseWhyMatters,
 } from '../shared/brief-llm-core.js';
@@ -46,6 +47,20 @@ const FIXTURE = {
   category: 'Geopolitical Risk',
   country: 'IR',
 };
+
+describe('hasTerminalPunctuation — shared wire/cache completion gate', () => {
+  it('accepts sentence punctuation with optional closing quotes', () => {
+    assert.equal(hasTerminalPunctuation('Complete sentence.'), true);
+    assert.equal(hasTerminalPunctuation('Complete question?\u201D'), true);
+    assert.equal(hasTerminalPunctuation('Complete exclamation!"'), true);
+  });
+
+  it('rejects fragments even when they end in a closing quote', () => {
+    assert.equal(hasTerminalPunctuation('With the ceasefire collapsed, the'), false);
+    assert.equal(hasTerminalPunctuation('With the ceasefire collapsed, the\u201D'), false);
+    assert.equal(hasTerminalPunctuation(null), false);
+  });
+});
 
 describe('hashBriefStory — Web Crypto parity with legacy node:crypto', () => {
   it('returns the exact hash the pre-extract implementation emitted', async () => {
@@ -178,10 +193,10 @@ describe('parseWhyMatters — pure sentence validator', () => {
     assert.equal(parseWhyMatters('x'.repeat(401)), null);
   });
 
-  it('strips smart-quotes and takes the first sentence', () => {
-    const input = '"Closure would spike oil markets and force a naval response." Secondary clause.';
+  it('strips surrounding quotes while preserving complete prose', () => {
+    const input = '"Closure would spike oil markets and force a naval response. Secondary clause."';
     const out = parseWhyMatters(input);
-    assert.equal(out, 'Closure would spike oil markets and force a naval response.');
+    assert.equal(out, 'Closure would spike oil markets and force a naval response. Secondary clause.');
   });
 
   it('rejects the stub echo', () => {
@@ -192,6 +207,26 @@ describe('parseWhyMatters — pure sentence validator', () => {
   it('preserves a valid one-sentence output verbatim', () => {
     const s = 'Closure of the Strait of Hormuz would spike global oil prices and force a US naval response.';
     assert.equal(parseWhyMatters(s), s);
+  });
+
+  it('does not split a valid sentence inside a dotted abbreviation', () => {
+    const s = 'The ruling would reshape alliance planning as U.S. officials prepare for the 2027 vote.';
+    assert.equal(parseWhyMatters(s), s);
+    const capitalized = 'The ruling could alter European coordination with the U.S. Navy as regional tensions rise.';
+    assert.equal(parseWhyMatters(capitalized), capitalized);
+    const hyphenated = 'The sanctions would constrain trade while forcing the U.S.-led coalition to respond.';
+    assert.equal(parseWhyMatters(hyphenated), hyphenated);
+  });
+
+  it('preserves complete multi-sentence output instead of guessing after an abbreviation', () => {
+    const input = 'The decision would immediately change policy across the U.S. Markets repriced risk across Europe.';
+    assert.equal(parseWhyMatters(input), input);
+  });
+
+  it('rejects a max-token clip with no terminal punctuation', () => {
+    const clipped =
+      'Marine Le Pen\u2019s conviction on appeal leaves her legally eligible for the 2027 presidential election, creating a high-stakes';
+    assert.equal(parseWhyMatters(clipped), null);
   });
 });
 
@@ -255,6 +290,14 @@ describe('parseWhyMattersV2 — multi-sentence, analyst-path only', () => {
       },
       privateForecasts: 'WorldMonitor political-instability forecast: 84% probability.',
     }), sourced);
+  });
+
+  it('rejects a clipped final sentence even when an earlier sentence is complete', async () => {
+    const { parseWhyMattersV2 } = await import('../shared/brief-llm-core.js');
+    const clipped =
+      'Marine Le Pen\u2019s conviction on appeal leaves her legally eligible for the 2027 presidential election. ' +
+      'The ruling reshapes the campaign while leaving debate over democratic norms and';
+    assert.equal(parseWhyMattersV2(clipped), null);
   });
 
   it('rejects <100 chars (too terse for the analyst contract)', async () => {

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -18,6 +18,10 @@ import { createHash } from 'node:crypto';
 
 import {
   WHY_MATTERS_SYSTEM,
+  WHY_MATTERS_V1_MAX_CHARS,
+  WHY_MATTERS_V1_MIN_CHARS,
+  WHY_MATTERS_V2_MAX_CHARS,
+  WHY_MATTERS_V2_MIN_CHARS,
   briefDateLine,
   buildWhyMattersUserPrompt,
   hasTerminalPunctuation,
@@ -59,6 +63,34 @@ describe('hasTerminalPunctuation — shared wire/cache completion gate', () => {
     assert.equal(hasTerminalPunctuation('With the ceasefire collapsed, the'), false);
     assert.equal(hasTerminalPunctuation('With the ceasefire collapsed, the\u201D'), false);
     assert.equal(hasTerminalPunctuation(null), false);
+  });
+
+  it('rejects ASCII and Unicode ellipses with optional closing quotes', () => {
+    assert.equal(hasTerminalPunctuation('The negotiations remain unresolved...'), false);
+    assert.equal(hasTerminalPunctuation('The negotiations remain unresolved...\u201D'), false);
+    assert.equal(hasTerminalPunctuation('The negotiations remain unresolved\u2026'), false);
+    assert.equal(hasTerminalPunctuation('The negotiations remain unresolved\u2026"'), false);
+  });
+});
+
+describe('whyMatters character bounds — shared parser contracts', () => {
+  it('wires the exported v1 bounds into parseWhyMatters', () => {
+    assert.equal(WHY_MATTERS_V1_MIN_CHARS, 30);
+    assert.equal(WHY_MATTERS_V1_MAX_CHARS, 400);
+    assert.equal(parseWhyMatters(`${'x'.repeat(WHY_MATTERS_V1_MIN_CHARS - 1)}.`)?.length, WHY_MATTERS_V1_MIN_CHARS);
+    assert.equal(parseWhyMatters(`${'x'.repeat(WHY_MATTERS_V1_MIN_CHARS - 2)}.`), null);
+    assert.equal(parseWhyMatters(`${'x'.repeat(WHY_MATTERS_V1_MAX_CHARS - 1)}.`)?.length, WHY_MATTERS_V1_MAX_CHARS);
+    assert.equal(parseWhyMatters(`${'x'.repeat(WHY_MATTERS_V1_MAX_CHARS)}.`), null);
+  });
+
+  it('wires the exported v2 bounds into parseWhyMattersV2', async () => {
+    const { parseWhyMattersV2 } = await import('../shared/brief-llm-core.js');
+    assert.equal(WHY_MATTERS_V2_MIN_CHARS, 100);
+    assert.equal(WHY_MATTERS_V2_MAX_CHARS, 500);
+    assert.equal(parseWhyMattersV2(`${'x'.repeat(WHY_MATTERS_V2_MIN_CHARS - 1)}.`)?.length, WHY_MATTERS_V2_MIN_CHARS);
+    assert.equal(parseWhyMattersV2(`${'x'.repeat(WHY_MATTERS_V2_MIN_CHARS - 2)}.`), null);
+    assert.equal(parseWhyMattersV2(`${'x'.repeat(WHY_MATTERS_V2_MAX_CHARS - 1)}.`)?.length, WHY_MATTERS_V2_MAX_CHARS);
+    assert.equal(parseWhyMattersV2(`${'x'.repeat(WHY_MATTERS_V2_MAX_CHARS)}.`), null);
   });
 });
 

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -31,7 +31,11 @@ import {
 } from '../scripts/lib/brief-llm.mjs';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { composeBriefFromDigestStories, digestStoryToSynthesisShape } from '../scripts/lib/brief-compose.mjs';
-import { briefDateLine } from '../shared/brief-llm-core.js';
+import {
+  WHY_MATTERS_V1_MIN_CHARS,
+  WHY_MATTERS_V2_MAX_CHARS,
+  briefDateLine,
+} from '../shared/brief-llm-core.js';
 
 const MAX_TOKEN_CLIP =
   'Marine Le Pen\u2019s conviction on appeal leaves her legally eligible for the 2027 presidential election, creating a high-stakes';
@@ -177,6 +181,23 @@ describe('parseWhyMatters', () => {
 // ── generateWhyMatters ─────────────────────────────────────────────────────
 
 describe('generateWhyMatters', () => {
+  it('accepts analyst endpoint prose across the derived v1/v2 union bounds', async () => {
+    for (const prose of [
+      `${'x'.repeat(WHY_MATTERS_V1_MIN_CHARS - 1)}.`,
+      `${'x'.repeat(WHY_MATTERS_V2_MAX_CHARS - 1)}.`,
+    ]) {
+      const cache = makeCache();
+      const llm = makeLLM(() => { throw new Error('analyst output must short-circuit the fallback'); });
+      const out = await generateWhyMatters(story(), {
+        ...cache,
+        callLLM: llm.callLLM,
+        callAnalystWhyMatters: async () => prose,
+      });
+      assert.equal(out, prose);
+      assert.equal(llm.calls.length, 0);
+    }
+  });
+
   it('returns the cached value without calling the LLM when cache hits', async () => {
     const cache = makeCache();
     const llm = makeLLM(() => 'should not be called');
@@ -223,6 +244,47 @@ describe('generateWhyMatters', () => {
     const llm = makeLLM('too short');
     const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
     assert.equal(out, null);
+  });
+
+  it('revalidates the current v6 cache row and replaces rejected prose', async () => {
+    const cache = makeCache();
+    const hash = await hashBriefStory(story());
+    const key = `brief:llm:whymatters:v6:${hash}`;
+    cache.store.set(key, MAX_TOKEN_CLIP);
+    const fresh = 'Closure of the Strait of Hormuz would spike oil prices globally.';
+    const llm = makeLLM(fresh);
+
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+
+    assert.equal(out, fresh);
+    assert.equal(llm.calls.length, 1, 'invalid current-v6 prose must not short-circuit regeneration');
+    assert.equal(cache.store.get(key), fresh, 'fresh prose must replace the rejected v6 row');
+  });
+
+  it('returns null and writes no cache for complete-looking v1 prose without terminal punctuation', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(
+      'This development would reshape regional deterrence and force allies to reconsider their security guarantees',
+    );
+
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+
+    assert.equal(out, null, 'the caller must degrade to the baseline stub');
+    assert.equal(llm.calls.length, 1);
+    assert.equal(cache.store.size, 0, 'incomplete v1 prose must not be cached');
+  });
+
+  it('returns null and writes no cache for an over-400-character v1 output', async () => {
+    const cache = makeCache();
+    const overlong = `${'Regional pressure would force allies to reconsider their security posture. '.repeat(7)}Markets would react.`;
+    assert.ok(overlong.length > 400, 'fixture must exercise the v1 upper bound');
+    const llm = makeLLM(overlong);
+
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+
+    assert.equal(out, null, 'the caller must degrade to the baseline stub');
+    assert.equal(llm.calls.length, 1);
+    assert.equal(cache.store.size, 0, 'overlong v1 prose must not be cached');
   });
 
   it('ignores a clipped legacy v5 cache row and regenerates it under v6', async () => {

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -33,6 +33,11 @@ import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { composeBriefFromDigestStories, digestStoryToSynthesisShape } from '../scripts/lib/brief-compose.mjs';
 import { briefDateLine } from '../shared/brief-llm-core.js';
 
+const MAX_TOKEN_CLIP =
+  'Marine Le Pen\u2019s conviction on appeal leaves her legally eligible for the 2027 presidential election, creating a high-stakes';
+const ABBREVIATION_LENGTH_CLIP =
+  'The ruling would reshape alliance planning across Europe and force renewed debate among officials in the U.S.';
+
 // ── Fixtures ───────────────────────────────────────────────────────────────
 
 // IMPORTANT: the default `headline` here is load-bearing for many
@@ -138,10 +143,10 @@ describe('parseWhyMatters', () => {
     assert.equal(parseWhyMatters(long), null);
   });
 
-  it('takes the first sentence only when the model returns multiple', () => {
+  it('preserves fully completed multi-sentence output instead of truncating it', () => {
     const text = 'Closure would spike oil markets and force a naval response. A second sentence here.';
     const out = parseWhyMatters(text);
-    assert.equal(out, 'Closure would spike oil markets and force a naval response.');
+    assert.equal(out, text);
   });
 
   it('strips surrounding quotes (smart and straight)', () => {
@@ -157,6 +162,15 @@ describe('parseWhyMatters', () => {
     const out = parseWhyMatters('Closure of the Strait of Hormuz would spike global oil prices and force a US naval response.');
     assert.match(out, /^Closure of the Strait/);
     assert.ok(out.endsWith('.'));
+  });
+
+  it('rejects a max-token clip with no terminal punctuation', () => {
+    assert.equal(parseWhyMatters(MAX_TOKEN_CLIP), null);
+  });
+
+  it('keeps a stop-finished sentence intact across a dotted abbreviation', () => {
+    const complete = 'The ruling would reshape alliance planning as U.S. officials prepare for the 2027 vote.';
+    assert.equal(parseWhyMatters(complete), complete);
   });
 });
 
@@ -178,8 +192,8 @@ describe('generateWhyMatters', () => {
     const real = makeLLM('Closure would freeze a fifth of seaborne crude within days.');
     const first = await generateWhyMatters(story(), { ...cache, callLLM: real.callLLM });
     assert.ok(first);
-    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v5:'));
-    assert.ok(cachedKey, 'expected a whymatters cache entry under the v4 key (bumped 2026-05-14 for the F6 date-grounding line)');
+    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v6:'));
+    assert.ok(cachedKey, 'expected a whymatters cache entry under the v6 completion-safe namespace');
 
     // Second call: responder throws — cache must prevent the call
     llm.calls.length = 0;
@@ -209,6 +223,60 @@ describe('generateWhyMatters', () => {
     const llm = makeLLM('too short');
     const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
     assert.equal(out, null);
+  });
+
+  it('ignores a clipped legacy v5 cache row and regenerates it under v6', async () => {
+    const cache = makeCache();
+    const hash = await hashBriefStory(story());
+    cache.store.set(
+      `brief:llm:whymatters:v5:${hash}`,
+      MAX_TOKEN_CLIP,
+    );
+    const fresh = 'Closure of the Strait of Hormuz would spike oil prices globally.';
+    const llm = makeLLM(fresh);
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, fresh);
+    assert.equal(llm.calls.length, 1, 'clipped v5 cache row must not short-circuit regeneration');
+    assert.equal(
+      [...cache.store.keys()].some((key) => key.startsWith('brief:llm:whymatters:v6:')),
+      true,
+    );
+  });
+
+  it('ignores a legacy v5 abbreviation-ending clip that the old parser accepted', async () => {
+    const cache = makeCache();
+    const hash = await hashBriefStory(story());
+    cache.store.set(`brief:llm:whymatters:v5:${hash}`, ABBREVIATION_LENGTH_CLIP);
+    const fresh = 'Closure of the Strait of Hormuz would spike oil prices globally.';
+    const llm = makeLLM(fresh);
+
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+
+    assert.equal(out, fresh);
+    assert.equal(llm.calls.length, 1, 'pre-signal v5 rows must be dark after the v6 bump');
+  });
+
+  it('keeps and caches stop-finished Railway prose across a dotted abbreviation', async () => {
+    const cache = makeCache();
+    const complete = 'The sanctions would constrain trade while forcing the U.S.-led coalition to respond.';
+    const llm = makeLLM(complete);
+
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+
+    assert.equal(out, complete);
+    const v6Value = [...cache.store.entries()].find(([key]) => key.startsWith('brief:llm:whymatters:v6:'))?.[1];
+    assert.equal(v6Value, complete);
+  });
+
+  it('returns null instead of stale prose when clipped legacy regeneration fails', async () => {
+    const cache = makeCache();
+    const hash = await hashBriefStory(story());
+    cache.store.set(`brief:llm:whymatters:v5:${hash}`, MAX_TOKEN_CLIP);
+    const llm = makeLLM(null);
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+
+    assert.equal(out, null);
+    assert.equal(llm.calls.length, 1, 'clipped v5 cache row must attempt regeneration');
   });
 
   it('pins the provider chain to openrouter (skipProviders=ollama,groq)', async () => {
@@ -1750,102 +1818,115 @@ describe('generateStoryDescription — sanitisation + prefix bump (U5)', () => {
   });
 });
 
-// ── generateWhyMatters — v9 endpoint-cache cross-read (#4914) ──────────────
+// ── generateWhyMatters — v10 endpoint-cache cross-read (#4914) ─────────────
 //
 // The analyst endpoint (api/internal/brief-why-matters.ts) caches its
-// envelope at brief:llm:whymatters:v9:{hashBriefStory} — the SAME story
-// identity as the cron's legacy v5 namespace. When the endpoint CALL fails
+// envelope at brief:llm:whymatters:v10:{hashBriefStory} — the SAME story
+// identity as the cron's legacy v6 namespace. When the endpoint CALL fails
 // transiently, the envelope may still be sitting in Redis; the fallback
 // must read it before paying a direct-Gemini generation.
 
-describe('generateWhyMatters — v9 endpoint-cache cross-read (#4914)', () => {
-  const V9_PROSE = 'Closure of the Strait of Hormuz would freeze a fifth of seaborne crude and force allied navies to respond.';
+describe('generateWhyMatters — v10 endpoint-cache cross-read (#4914)', () => {
+  const V10_PROSE = 'Closure of the Strait of Hormuz would freeze a fifth of seaborne crude and force allied navies to respond.';
 
-  it('pins the endpoint cache to v9 and its shadow cohort to v7', async () => {
+  it('pins the endpoint cache to v10 and its shadow cohort to v7', async () => {
     const { readFile } = await import('node:fs/promises');
     const src = await readFile(new URL('../api/internal/brief-why-matters.ts', import.meta.url), 'utf8');
-    assert.match(src, /const cacheKey = `brief:llm:whymatters:v9:\$\{hash\}`;/);
+    assert.match(src, /const cacheKey = `brief:llm:whymatters:v10:\$\{hash\}`;/);
     assert.match(src, /const shadowKey = `brief:llm:whymatters:shadow:v7:\$\{hash\}`;/);
-    assert.doesNotMatch(src, /const cacheKey = `brief:llm:whymatters:v8:/);
+    assert.doesNotMatch(src, /const cacheKey = `brief:llm:whymatters:v9:/);
     assert.doesNotMatch(src, /const shadowKey = `brief:llm:whymatters:shadow:v6:/);
   });
 
-  async function seedV9(cache, s, envelopeOverrides = {}) {
+  async function seedV10(cache, s, envelopeOverrides = {}) {
     const hash = await hashBriefStory(s);
-    cache.store.set(`brief:llm:whymatters:v9:${hash}`, {
-      whyMatters: V9_PROSE,
+    cache.store.set(`brief:llm:whymatters:v10:${hash}`, {
+      whyMatters: V10_PROSE,
       producedBy: 'analyst',
       ...envelopeOverrides,
     });
     return hash;
   }
 
-  it('reuses the v9 envelope when the analyst endpoint call fails — no paid LLM call', async () => {
+  it('reuses the v10 envelope when the analyst endpoint call fails — no paid LLM call', async () => {
     const cache = makeCache();
     const s = story();
-    await seedV9(cache, s);
-    const llm = makeLLM(() => { throw new Error('must not pay direct-Gemini when v9 is warm'); });
+    await seedV10(cache, s);
+    const llm = makeLLM(() => { throw new Error('must not pay direct-Gemini when v10 is warm'); });
     const out = await generateWhyMatters(s, {
       ...cache,
       callLLM: llm.callLLM,
       callAnalystWhyMatters: async () => { throw new Error('endpoint down'); },
     });
-    assert.equal(out, V9_PROSE);
-    assert.equal(llm.calls.length, 0, 'v9 hit must short-circuit the legacy chain');
+    assert.equal(out, V10_PROSE);
+    assert.equal(llm.calls.length, 0, 'v10 hit must short-circuit the legacy chain');
   });
 
-  it('reuses the v9 envelope when no analyst endpoint is configured at all', async () => {
+  it('reuses the v10 envelope when no analyst endpoint is configured at all', async () => {
     const cache = makeCache();
     const s = story();
-    await seedV9(cache, s);
+    await seedV10(cache, s);
     const llm = makeLLM(() => { throw new Error('must not pay'); });
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
-    assert.equal(out, V9_PROSE);
+    assert.equal(out, V10_PROSE);
     assert.equal(llm.calls.length, 0);
   });
 
-  it('ignores a pre-policy v8 envelope and falls through to the legacy chain', async () => {
+  it('ignores a pre-completion-signal v9 envelope and falls through to the legacy chain', async () => {
     const cache = makeCache();
     const s = story();
     const hash = await hashBriefStory(s);
-    cache.store.set(`brief:llm:whymatters:v8:${hash}`, {
-      whyMatters: 'WorldMonitor forecasts an 84% probability of disruption, which must not survive the output-policy rollout.',
+    cache.store.set(`brief:llm:whymatters:v9:${hash}`, {
+      whyMatters: 'The response looks complete because the clipped fragment happens to end with an abbreviation such as the U.S.',
       producedBy: 'analyst',
     });
     const fresh = 'Closure of the Strait of Hormuz would spike oil prices globally.';
     const llm = makeLLM(fresh);
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
     assert.equal(out, fresh);
-    assert.equal(llm.calls.length, 1, 'v8 must not short-circuit the post-policy generation chain');
+    assert.equal(llm.calls.length, 1, 'v9 must not short-circuit the completion-signal generation chain');
   });
 
-  it('malformed v9 envelope falls through to the legacy chain', async () => {
+  it('malformed v10 envelope falls through to the legacy chain', async () => {
     const cache = makeCache();
     const s = story();
     const hash = await hashBriefStory(s);
-    cache.store.set(`brief:llm:whymatters:v9:${hash}`, { whyMatters: 'too short' });
+    cache.store.set(`brief:llm:whymatters:v10:${hash}`, { whyMatters: 'too short' });
     const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
     assert.equal(out, 'Closure of the Strait of Hormuz would spike oil prices globally.');
-    assert.equal(llm.calls.length, 1, 'invalid v9 payload must not be served — legacy chain pays once');
+    assert.equal(llm.calls.length, 1, 'invalid v10 payload must not be served — legacy chain pays once');
   });
 
-  it('v9 sensitivity-stub prose is rejected, not served', async () => {
+  it('v10 sensitivity-stub prose is rejected, not served', async () => {
     const cache = makeCache();
     const s = story();
-    await seedV9(cache, s, { whyMatters: 'Story flagged by your sensitivity settings. Open for context and details.' });
+    await seedV10(cache, s, { whyMatters: 'Story flagged by your sensitivity settings. Open for context and details.' });
     const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
     const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
     assert.equal(out, 'Closure of the Strait of Hormuz would spike oil prices globally.');
     assert.equal(llm.calls.length, 1);
   });
 
-  it('v9 read is read-only — the legacy path must not copy into or overwrite the v9 namespace', async () => {
+  it('v10 max-token clips are rejected, not served', async () => {
+    const cache = makeCache();
+    const s = story();
+    await seedV10(cache, s, {
+      whyMatters: MAX_TOKEN_CLIP,
+    });
+    const fresh = 'Closure of the Strait of Hormuz would spike oil prices globally.';
+    const llm = makeLLM(fresh);
+    const out = await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, fresh);
+    assert.equal(llm.calls.length, 1);
+  });
+
+  it('v10 read is read-only — the legacy path must not copy into or overwrite the v10 namespace', async () => {
     const cache = makeCache();
     const s = story();
     const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
     await generateWhyMatters(s, { ...cache, callLLM: llm.callLLM });
-    const v9Keys = [...cache.store.keys()].filter((k) => k.startsWith('brief:llm:whymatters:v9:'));
-    assert.equal(v9Keys.length, 0, 'legacy single-sentence output must stay in the v5 namespace');
+    const v10Keys = [...cache.store.keys()].filter((k) => k.startsWith('brief:llm:whymatters:v10:'));
+    assert.equal(v10Keys.length, 0, 'legacy fallback output must stay in the v6 namespace');
   });
 });

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -42,7 +42,12 @@ const HANDLER_ENV_KEYS = [
   'LLM_API_KEY',
 ];
 
-async function invokeHandlerWithCachedEnvelope(envelope, providerCompletion = null, primary = 'gemini') {
+async function invokeHandlerWithCachedEnvelope(
+  envelope,
+  providerCompletion = null,
+  primary = 'gemini',
+  fallbackProviderCompletion = null,
+) {
   const previousEnv = Object.fromEntries(HANDLER_ENV_KEYS.map((key) => [key, process.env[key]]));
   const originalFetch = globalThis.fetch;
   const fetchCalls = [];
@@ -55,6 +60,7 @@ async function invokeHandlerWithCachedEnvelope(envelope, providerCompletion = nu
     delete process.env[key];
   }
   if (providerCompletion) process.env.OPENROUTER_API_KEY = 'or-test-key';
+  if (fallbackProviderCompletion) process.env.GROQ_API_KEY = 'groq-test-key';
   globalThis.fetch = async (input, init) => {
     const url = String(input);
     const method = init?.method || 'GET';
@@ -71,6 +77,12 @@ async function invokeHandlerWithCachedEnvelope(envelope, providerCompletion = nu
     if (method === 'GET') return new Response('', { status: 200 });
     if (url === 'https://openrouter.ai/api/v1/chat/completions' && providerCompletion) {
       return new Response(JSON.stringify(providerCompletion), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url === 'https://api.groq.com/openai/v1/chat/completions' && fallbackProviderCompletion) {
+      return new Response(JSON.stringify(fallbackProviderCompletion), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -291,6 +303,46 @@ describe('brief-why-matters Edge cache acceptance', () => {
       false,
       'an analyst length-limited response must never be cached',
     );
+  });
+
+  it('walks the configured provider chain after a length-limited completion on both paths', async () => {
+    const fallback =
+      'The ruling changes alliance planning across Europe while forcing policymakers to reassess regional commitments. ' +
+      'That shift could alter near-term diplomatic and defense priorities.';
+    const clippedCompletion = {
+      choices: [{
+        message: { content: ABBREVIATION_LENGTH_CLIP },
+        finish_reason: 'length',
+      }],
+      usage: { total_tokens: 120, completion_tokens: 80 },
+    };
+    const fallbackCompletion = {
+      choices: [{ message: { content: fallback }, finish_reason: 'stop' }],
+      usage: { total_tokens: 75, completion_tokens: 35 },
+    };
+
+    for (const primary of ['gemini', 'analyst']) {
+      const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope(
+        null,
+        clippedCompletion,
+        primary,
+        fallbackCompletion,
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(body.whyMatters, fallback);
+      assert.equal(body.producedBy, primary);
+      assert.deepEqual(
+        fetchCalls
+          .filter(({ url, method }) => method === 'POST' && url.includes('/chat/completions'))
+          .map(({ url }) => url),
+        [
+          'https://openrouter.ai/api/v1/chat/completions',
+          'https://api.groq.com/openai/v1/chat/completions',
+        ],
+        `${primary} must retry the fallback provider in-request`,
+      );
+    }
   });
 });
 

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -22,6 +22,83 @@ import {
   WHY_MATTERS_SYSTEM,
 } from '../shared/brief-llm-core.js';
 
+const ANALYST_MAX_TOKEN_CLIP =
+  'Marine Le Pen\u2019s conviction on appeal leaves her legally eligible for the 2027 presidential election. ' +
+  'The ruling reshapes the campaign while leaving debate over democratic norms and';
+const ABBREVIATION_LENGTH_CLIP =
+  'The ruling would reshape alliance planning across Europe and force renewed debate among officials in the U.S.';
+
+const HANDLER_ENV_KEYS = [
+  'RELAY_SHARED_SECRET',
+  'UPSTASH_REDIS_REST_URL',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'BRIEF_WHY_MATTERS_PRIMARY',
+  'BRIEF_WHY_MATTERS_SHADOW',
+  'OLLAMA_API_URL',
+  'OLLAMA_API_KEY',
+  'GROQ_API_KEY',
+  'OPENROUTER_API_KEY',
+  'LLM_API_URL',
+  'LLM_API_KEY',
+];
+
+async function invokeHandlerWithCachedEnvelope(envelope, providerCompletion = null, primary = 'gemini') {
+  const previousEnv = Object.fromEntries(HANDLER_ENV_KEYS.map((key) => [key, process.env[key]]));
+  const originalFetch = globalThis.fetch;
+  const fetchCalls = [];
+  process.env.RELAY_SHARED_SECRET = 'test-relay-secret';
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-redis-token';
+  process.env.BRIEF_WHY_MATTERS_PRIMARY = primary;
+  process.env.BRIEF_WHY_MATTERS_SHADOW = '0';
+  for (const key of ['OLLAMA_API_URL', 'OLLAMA_API_KEY', 'GROQ_API_KEY', 'OPENROUTER_API_KEY', 'LLM_API_URL', 'LLM_API_KEY']) {
+    delete process.env[key];
+  }
+  if (providerCompletion) process.env.OPENROUTER_API_KEY = 'or-test-key';
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    const method = init?.method || 'GET';
+    fetchCalls.push({ url, method });
+    if (url.startsWith('https://redis.example.test')) {
+      const result = url.endsWith('/pipeline')
+        ? []
+        : envelope === null ? null : JSON.stringify(envelope);
+      return new Response(JSON.stringify({ result }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (method === 'GET') return new Response('', { status: 200 });
+    if (url === 'https://openrouter.ai/api/v1/chat/completions' && providerCompletion) {
+      return new Response(JSON.stringify(providerCompletion), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch ${method} ${url}`);
+  };
+
+  try {
+    const { default: handler } = await import('../api/internal/brief-why-matters.ts');
+    const request = new Request('https://worldmonitor.test/api/internal/brief-why-matters', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-relay-secret',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ story: story() }),
+    });
+    const response = await handler(request);
+    return { response, body: await response.json(), fetchCalls };
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
 // ── Story fixture matching the cron's actual payload shape
 // (shared/brief-filter.js:134-135). ────────────────────────────────────
 
@@ -128,6 +205,95 @@ describe('cache key identity', () => {
   });
 });
 
+describe('brief-why-matters Edge cache acceptance', () => {
+  it('serves a complete v10 envelope as a cache hit', async () => {
+    const whyMatters = 'The ruling keeps the 2027 race open while reshaping coalition strategy.';
+    const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope({
+      whyMatters,
+      producedBy: 'analyst',
+      at: '2026-07-10T00:00:00.000Z',
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(body.whyMatters, whyMatters);
+    assert.equal(body.source, 'cache');
+    assert.equal(body.producedBy, 'analyst');
+    assert.equal(fetchCalls.length, 1, 'a valid cache hit must not call an LLM provider');
+  });
+
+  it('treats a clipped v10 envelope as a miss when regeneration fails', async () => {
+    const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope({
+      whyMatters: ANALYST_MAX_TOKEN_CLIP,
+      producedBy: 'analyst',
+      at: '2026-07-10T00:00:00.000Z',
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(body.whyMatters, null);
+    assert.equal(body.source, 'gemini');
+    assert.equal(body.producedBy, null);
+    assert.equal(fetchCalls.length, 1, 'a failed regeneration must not serve or rewrite clipped prose');
+  });
+
+  it('rejects a length-limited provider response even when it ends in an abbreviation', async () => {
+    const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope(null, {
+      choices: [{
+        message: { content: ABBREVIATION_LENGTH_CLIP },
+        finish_reason: 'length',
+      }],
+      usage: { total_tokens: 120, completion_tokens: 80 },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(body.whyMatters, null);
+    assert.equal(body.source, 'gemini');
+    assert.equal(body.producedBy, null);
+    assert.equal(
+      fetchCalls.some(({ url }) => url.endsWith('/pipeline')),
+      false,
+      'a length-limited response must never be cached',
+    );
+  });
+
+  it('accepts and caches a stop-finished response containing a dotted abbreviation', async () => {
+    const complete = 'The ruling could alter European coordination with the U.S. Navy as regional tensions rise.';
+    const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope(null, {
+      choices: [{ message: { content: complete }, finish_reason: 'stop' }],
+      usage: { total_tokens: 80, completion_tokens: 30 },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(body.whyMatters, complete);
+    assert.equal(body.source, 'gemini');
+    assert.equal(body.producedBy, 'gemini');
+    assert.equal(
+      fetchCalls.some(({ url }) => url.endsWith('/pipeline')),
+      true,
+      'a stop-finished complete response should populate v10',
+    );
+  });
+
+  it('applies the same length-completion rejection to the analyst path', async () => {
+    const { response, body, fetchCalls } = await invokeHandlerWithCachedEnvelope(null, {
+      choices: [{
+        message: { content: ABBREVIATION_LENGTH_CLIP },
+        finish_reason: 'length',
+      }],
+      usage: { total_tokens: 120, completion_tokens: 80 },
+    }, 'analyst');
+
+    assert.equal(response.status, 200);
+    assert.equal(body.whyMatters, null);
+    assert.equal(body.source, 'analyst');
+    assert.equal(body.producedBy, null);
+    assert.equal(
+      fetchCalls.some(({ url }) => url.endsWith('/pipeline')),
+      false,
+      'an analyst length-limited response must never be cached',
+    );
+  });
+});
+
 // ── parseWhyMattersV2 — analyst-path output validator ───────────────────
 //
 // This is the only output-validation gate between the analyst LLM and
@@ -163,13 +329,17 @@ describe('parseWhyMattersV2 — analyst output validator', () => {
     assert.equal(parseWhyMattersV2('Short sentence under 100 chars.'), null);
     assert.equal(parseWhyMattersV2('x'.repeat(99)), null);
     // Boundary: exactly 100 passes.
-    assert.equal(typeof parseWhyMattersV2('x'.repeat(100)), 'string');
+    assert.equal(typeof parseWhyMattersV2(`${'x'.repeat(99)}.`), 'string');
   });
 
   it('rejects output over the 500-char cap (prevents runaway essays)', () => {
     assert.equal(parseWhyMattersV2('x'.repeat(501)), null);
     // Boundary: exactly 500 passes.
-    assert.equal(typeof parseWhyMattersV2('x'.repeat(500)), 'string');
+    assert.equal(typeof parseWhyMattersV2(`${'x'.repeat(499)}.`), 'string');
+  });
+
+  it('rejects the captured max-token clips from both model eras', () => {
+    assert.equal(parseWhyMattersV2(ANALYST_MAX_TOKEN_CLIP), null);
   });
 
   it('rejects banned preamble phrases (v2-specific)', () => {
@@ -343,11 +513,25 @@ describe('generateWhyMatters — analyst priority', () => {
     assert.equal(callLlmInvoked, true, 'out-of-bounds analyst output must trigger fallback');
   });
 
+  it('falls through when the analyst endpoint returns a max-token clip', async () => {
+    let callLlmInvoked = false;
+    const out = await generateWhyMatters(story(), {
+      callAnalystWhyMatters: async () => ANALYST_MAX_TOKEN_CLIP,
+      callLLM: async () => {
+        callLlmInvoked = true;
+        return VALID;
+      },
+      cacheGet: async () => null,
+      cacheSet: async () => {},
+    });
+    assert.equal(out, VALID);
+    assert.equal(callLlmInvoked, true, 'clipped endpoint output must trigger fallback');
+  });
+
   it('preserves multi-sentence v2 analyst output verbatim (P1 regression guard)', async () => {
     // The endpoint now returns 1–2 sentences validated by parseWhyMattersV2.
-    // The cron MUST NOT reparse with the v1 single-sentence parser, which
-    // would silently truncate the 2nd + 3rd sentences. Caught in PR #3269
-    // review; fixed by trusting the endpoint's own validation and only
+    // The cron MUST NOT reparse with the narrower v1 bounds. Caught in PR
+    // #3269 review; fixed by trusting the endpoint's own validation and only
     // rejecting obvious garbage (length / stub echo) here.
     const multi =
       "Iran's closure of the Strait of Hormuz on April 21 halts roughly 20% of global seaborne oil. " +

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -498,6 +498,35 @@ describe('generateWhyMatters — analyst priority', () => {
     assert.equal(callLlmInvoked, true, 'legacy callLLM must fire after analyst miss');
   });
 
+  it('logs an accurate runtime type when analyst returns a non-string value', async () => {
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args.join(' '));
+
+    try {
+      for (const [analystOut, expectedType] of [
+        [null, 'null'],
+        [{ whyMatters: VALID }, 'object'],
+      ]) {
+        warnings.length = 0;
+        const out = await generateWhyMatters(story(), {
+          callAnalystWhyMatters: async () => analystOut,
+          callLLM: async () => VALID,
+          cacheGet: async () => null,
+          cacheSet: async () => {},
+        });
+
+        assert.equal(out, VALID);
+        assert.ok(
+          warnings.some((line) => line.includes(`endpoint returned no usable string (type=${expectedType})`)),
+          `expected a ${expectedType} runtime type tag; got ${JSON.stringify(warnings)}`,
+        );
+      }
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('falls through when analyst returns out-of-bounds output (too short)', async () => {
     let callLlmInvoked = false;
     const out = await generateWhyMatters(story(), {

--- a/tests/llm-usage-telemetry.test.mts
+++ b/tests/llm-usage-telemetry.test.mts
@@ -30,6 +30,7 @@ interface CapturedIngest {
 
 function installFetchMock(opts: {
   openrouterStatus?: number;
+  openrouterFinishReason?: string;
   captured: CapturedIngest;
 }) {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -54,7 +55,10 @@ function installFetchMock(opts: {
         return new Response('openrouter down', { status: opts.openrouterStatus });
       }
       return new Response(JSON.stringify({
-        choices: [{ message: { content: 'openrouter answer' } }],
+        choices: [{
+          message: { content: 'openrouter answer' },
+          ...(opts.openrouterFinishReason ? { finish_reason: opts.openrouterFinishReason } : {}),
+        }],
         model: 'deepseek/deepseek-v4-flash',
         usage: { prompt_tokens: 130, completion_tokens: 55, total_tokens: 185 },
       }), { status: 200 });
@@ -124,6 +128,28 @@ describe('llm usage telemetry', () => {
     assert.equal(ok.ok, true);
     assert.equal(ok.fallback_index, 1);
     assert.equal(ok.tokens_total, 160);
+  });
+
+  it('records an opted-in length rejection before the fallback success', async () => {
+    baseEnv();
+    const captured: CapturedIngest = { events: [] };
+    installFetchMock({ openrouterFinishReason: 'length', captured });
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'user prompt' }],
+      stage: 'brief-why-matters-test',
+      retryOnLengthLimit: true,
+    });
+
+    assert.equal(result?.content, 'groq answer');
+    assert.equal(captured.events.length, 2);
+    const [lengthReject, fallbackSuccess] = captured.events;
+    assert.equal(lengthReject.provider, 'openrouter');
+    assert.equal(lengthReject.ok, false);
+    assert.equal(lengthReject.reason, 'length');
+    assert.equal(lengthReject.tokens_completion, 55);
+    assert.equal(fallbackSuccess.provider, 'groq');
+    assert.equal(fallbackSuccess.ok, true);
   });
 
   it('emits nothing when USAGE_TELEMETRY is off', async () => {

--- a/tests/seeder-llm-telemetry.test.mjs
+++ b/tests/seeder-llm-telemetry.test.mjs
@@ -35,8 +35,12 @@ function baseEnv() {
   delete process.env.OLLAMA_API_URL;
 }
 
-function llmJson(content, usage = { total_tokens: 30, prompt_tokens: 20, completion_tokens: 10 }) {
-  return { choices: [{ message: { content } }], usage };
+function llmJson(
+  content,
+  usage = { total_tokens: 30, prompt_tokens: 20, completion_tokens: 10 },
+  finishReason = 'stop',
+) {
+  return { choices: [{ message: { content }, finish_reason: finishReason }], usage };
 }
 
 test('llm-telemetry: buildLlmCallEvent mirrors the LlmCallEvent field shape', () => {
@@ -87,6 +91,42 @@ test('llm-chain: fallback emits one event per attempt with the caller stage', as
   assert.equal(ok.fallback_index, 1);
   assert.equal(ok.tokens_total, 30);
   assert.ok(fail.prompt_chars > 0);
+});
+
+test('llm-chain: rejects length-limited prose and falls through to the next provider', async () => {
+  baseEnv();
+  const captured = [];
+  global.fetch = async (url, init = {}) => {
+    const raw = String(url);
+    if (raw.includes('api.axiom.co')) {
+      captured.push(...JSON.parse(String(init.body || '[]')));
+      return { ok: true, json: async () => ({}) };
+    }
+    if (raw.includes('api.groq.com')) {
+      return {
+        ok: true,
+        json: async () => llmJson(
+          'The response looks complete because it ends with the abbreviation U.S.',
+          undefined,
+          'length',
+        ),
+      };
+    }
+    if (raw.includes('openrouter.ai')) {
+      return { ok: true, json: async () => llmJson('Complete fallback prose.') };
+    }
+    throw new Error(`unexpected fetch: ${raw}`);
+  };
+
+  const text = await callLLM('system', 'user prompt', { stage: 'brief-whymatters-cron' });
+
+  assert.equal(text, 'Complete fallback prose.');
+  assert.equal(captured.length, 2);
+  assert.equal(captured[0].provider, 'groq');
+  assert.equal(captured[0].ok, false);
+  assert.equal(captured[0].reason, 'length');
+  assert.equal(captured[1].provider, 'openrouter');
+  assert.equal(captured[1].ok, true);
 });
 
 test('llm-chain: emits nothing when USAGE_TELEMETRY is off', async () => {

--- a/tests/seeder-llm-telemetry.test.mjs
+++ b/tests/seeder-llm-telemetry.test.mjs
@@ -129,6 +129,35 @@ test('llm-chain: rejects length-limited prose and falls through to the next prov
   assert.equal(captured[1].ok, true);
 });
 
+test('llm-chain: records empty length-limited responses as length before falling back', async () => {
+  baseEnv();
+  const captured = [];
+  global.fetch = async (url, init = {}) => {
+    const raw = String(url);
+    if (raw.includes('api.axiom.co')) {
+      captured.push(...JSON.parse(String(init.body || '[]')));
+      return { ok: true, json: async () => ({}) };
+    }
+    if (raw.includes('api.groq.com')) {
+      return { ok: true, json: async () => llmJson('', undefined, 'length') };
+    }
+    if (raw.includes('openrouter.ai')) {
+      return { ok: true, json: async () => llmJson('Complete fallback prose.') };
+    }
+    throw new Error(`unexpected fetch: ${raw}`);
+  };
+
+  const text = await callLLM('system', 'user prompt', { stage: 'brief-whymatters-cron' });
+
+  assert.equal(text, 'Complete fallback prose.');
+  assert.equal(captured.length, 2);
+  assert.equal(captured[0].provider, 'groq');
+  assert.equal(captured[0].ok, false);
+  assert.equal(captured[0].reason, 'length');
+  assert.equal(captured[1].provider, 'openrouter');
+  assert.equal(captured[1].ok, true);
+});
+
 test('llm-chain: emits nothing when USAGE_TELEMETRY is off', async () => {
   baseEnv();
   delete process.env.USAGE_TELEMETRY;

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -111,11 +111,38 @@ describe('callLlm', () => {
     assert.ok(result);
     assert.equal(result.provider, 'openrouter');
     assert.equal(result.model, 'deepseek/deepseek-v4-flash');
+    assert.equal(result.finishReason, null, 'providers that omit finish_reason normalize to null');
     assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
       'https://openrouter.ai/api/v1/chat/completions',
     ]);
     // Utility calls must not pay reasoning tokens on hybrid-reasoning models.
     assert.deepEqual(postBodies[0]?.reasoning, { enabled: false });
+  });
+
+  it('preserves the provider finish reason on non-streaming completions', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      return new Response(JSON.stringify({
+        choices: [{
+          message: { content: 'The response reached its configured token limit.' },
+          finish_reason: 'length',
+        }],
+        usage: { total_tokens: 12 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Return a bounded response.' }],
+    });
+
+    assert.ok(result);
+    assert.equal(result.finishReason, 'length');
   });
 
   it('omits the reasoning-off body when the reasoning profile opts in', async () => {

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -145,6 +145,83 @@ describe('callLlm', () => {
     assert.equal(result.finishReason, 'length');
   });
 
+  it('retries the provider chain on token-limited completions only when opted in', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postUrls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      postUrls.push(url);
+      if (url.includes('openrouter.ai')) {
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: 'Clipped before completing the thought' }, finish_reason: 'length' }],
+          usage: { total_tokens: 80, completion_tokens: 40 },
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'Complete fallback response.' }, finish_reason: 'stop' }],
+        usage: { total_tokens: 35, completion_tokens: 12 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Return a bounded response.' }],
+      maxTokens: 40,
+      providerOrder: ['openrouter', 'groq'],
+      retryOnLengthLimit: true,
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'groq');
+    assert.equal(result.content, 'Complete fallback response.');
+    assert.deepEqual(postUrls, [
+      'https://openrouter.ai/api/v1/chat/completions',
+      'https://api.groq.com/openai/v1/chat/completions',
+    ]);
+  });
+
+  it('rejects token-limit aliases and missing or unknown reasons at the requested ceiling', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const cases: Array<{ finishReason?: string | null; completionTokens: number }> = [
+      { finishReason: 'max_tokens', completionTokens: 10 },
+      { finishReason: 'MAX_TOKENS', completionTokens: 10 },
+      { finishReason: 'max_output_tokens', completionTokens: 10 },
+      { finishReason: null, completionTokens: 20 },
+      { finishReason: 'provider_specific_limit', completionTokens: 20 },
+    ];
+
+    for (const { finishReason, completionTokens } of cases) {
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+        return new Response(JSON.stringify({
+          choices: [{
+            message: { content: 'Potentially clipped response.' },
+            ...(finishReason === undefined ? {} : { finish_reason: finishReason }),
+          }],
+          usage: { total_tokens: 30, completion_tokens: completionTokens },
+        }), { status: 200 });
+      }) as typeof fetch;
+
+      const result = await callLlm({
+        messages: [{ role: 'user', content: 'Return a bounded response.' }],
+        provider: 'openrouter',
+        maxTokens: 20,
+        retryOnLengthLimit: true,
+      });
+      assert.equal(result, null, `must reject finish_reason=${String(finishReason)} at ${completionTokens} tokens`);
+    }
+  });
+
   it('omits the reasoning-off body when the reasoning profile opts in', async () => {
     process.env.OPENROUTER_API_KEY = 'or-test-key';
     delete process.env.GROQ_API_KEY;


### PR DESCRIPTION
## Summary

Why Matters cards could expose visibly cut-off model output, including dotted abbreviations being cached as fragments such as `... U.`. Completed prose is now preserved intact, while provider-reported token-limit completions and punctuation-incomplete responses are rejected before they can reach the wire or cache.

Both the Vercel analyst/fallback endpoint and the Railway fallback chain enforce the same completion boundary. The endpoint cache moves to v10 and the Railway cache to v6 so pre-fix rows without completion metadata cannot survive deployment.

Fixes #5168

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [x] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Railway digest enrichment fallback

## Validation

- Red-first regressions reproduced no-punctuation clips, `finish_reason: length` clips ending in `U.S.`, and the prior `U.` abbreviation truncation.
- Focused parser, actual Edge-handler, cache, Railway fallback, and provider-contract suite: 268 passed.
- Full data/integration suite: 14,572 tests; 14,566 passed, 6 skipped, 0 failed.
- `npm run typecheck:all`, `npm run lint`, mirror parity, and `git diff --check` passed.
- The pre-push gate also passed API/frontend/Convex typechecks, Edge bundling, boundary and policy guards, changed tests, and version sync.

## Post-deploy monitoring & validation

Monitor for 24 hours, covering the full Railway v6 cache TTL, with the WorldMonitor maintainers as owner.

- Query Vercel logs for `[brief-why-matters] * completion_reject reason=length` and compare with total brief enrichment requests.
- Query Railway/Axiom `llm_call` events for `stage=brief-whymatters-cron reason=length`; confirm fallback providers or baseline stubs absorb rejected completions.
- Healthy: rejections are occasional, v10/v6 caches warm normally, and no new clipped Why Matters text is reported.
- Failure signal: sustained rejection or null-output growth, repeated provider exhaustion, or any new malformed cached prose.
- Rollback: disable Railway brief LLM enrichment for safe baseline stubs, then revert the behavior in a hotfix while retaining fresh cache namespaces so ambiguous v9/v5 rows stay dark.

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant (requires deployment)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (not applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims.

## Screenshots

Not applicable; this is an API and background-enrichment correctness fix.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)
