### PR TITLE
fix(forecast): resolve judged entries from deadline evidence

### DIFF
--- a/scripts/lib/story-track-batch-reader.mjs
+++ b/scripts/lib/story-track-batch-reader.mjs
@@ -61,9 +61,11 @@ export async function readStoryTracksChunked(
     }
     const failedAt = Math.floor(i / batchSize);
     const got = Array.isArray(partial) ? partial.length : 'non-array';
-    const skippedTick = context === 'digest' ? 'this digest tick' : 'this tick';
+    const failureConsequence = context === 'digest'
+      ? 'skips this digest tick'
+      : 'treats the archive read as failed';
     log(
-      `[${context}] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — aborting and returning null so caller skips ${skippedTick}`,
+      `[${context}] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — aborting and returning null so caller ${failureConsequence}`,
     );
     return null;
   }

--- a/scripts/lib/story-track-batch-reader.mjs
+++ b/scripts/lib/story-track-batch-reader.mjs
@@ -47,7 +47,7 @@ export const STORY_TRACK_HGETALL_BATCH = 500;
 export async function readStoryTracksChunked(
   hashes,
   pipelineFn,
-  { batchSize = STORY_TRACK_HGETALL_BATCH, log = console.warn } = {},
+  { batchSize = STORY_TRACK_HGETALL_BATCH, log = console.warn, context = 'digest' } = {},
 ) {
   const out = [];
   for (let i = 0; i < hashes.length; i += batchSize) {
@@ -61,8 +61,9 @@ export async function readStoryTracksChunked(
     }
     const failedAt = Math.floor(i / batchSize);
     const got = Array.isArray(partial) ? partial.length : 'non-array';
+    const skippedTick = context === 'digest' ? 'this digest tick' : 'this tick';
     log(
-      `[digest] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — aborting and returning null so caller skips this digest tick`,
+      `[${context}] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — aborting and returning null so caller skips ${skippedTick}`,
     );
     return null;
   }

--- a/scripts/lib/story-track-batch-reader.mjs
+++ b/scripts/lib/story-track-batch-reader.mjs
@@ -1,6 +1,7 @@
 /**
  * Chunked HGETALL reader for story:track:v1:<hash> rows used by
- * scripts/seed-digest-notifications.mjs::buildDigest.
+ * scripts/seed-digest-notifications.mjs::buildDigest and
+ * scripts/seed-forecast-resolutions.mjs::readDigestAccumulatorArchive.
  *
  * Extracted so the index-alignment-on-partial-failure contract can be
  * unit-tested without dragging the cron's top-level side effects
@@ -36,10 +37,12 @@
  *   next tick. Worse: dropped stories would be silent — no operator
  *   signal that the digest was incomplete.
  *
- *   So we return `null` on any chunk failure. Callers MUST treat
- *   null as "skip this digest tick — Upstash partial outage" rather
- *   than as empty-but-successful. Stops iterating so an outage
- *   doesn't burn the full pipeline budget on N × per-chunk timeouts.
+ *   So we return `null` on any chunk failure. Callers MUST treat null
+ *   as an incomplete read rather than empty-but-successful: digest
+ *   skips the tick, while forecast resolution fails the archive read
+ *   closed so judged entries remain pending. Stops iterating so an
+ *   outage doesn't burn the full pipeline budget on N × per-chunk
+ *   timeouts.
  */
 
 export const STORY_TRACK_HGETALL_BATCH = 500;

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -343,6 +343,8 @@ function normalizeJudgedArchiveInput(newsArchive) {
   return markNormalizedJudgedArchiveInput({
     items: normalizeJudgedArchiveItems(items),
     available: true,
+    // Hash-cap `truncated` means bounded recency sampling, not a failed window read.
+    // Reserve incompleteness for explicit/missing coverage signals that must fail closed.
     incomplete: Boolean(newsArchive.incomplete || newsArchive.partial || newsArchive.coverageComplete === false),
     coverageStartMs: toFiniteMs(newsArchive.coverageStartMs ?? newsArchive.windowStartMs ?? newsArchive.fromMs),
     coverageEndMs: toFiniteMs(newsArchive.coverageEndMs ?? newsArchive.windowEndMs ?? newsArchive.toMs),
@@ -442,9 +444,17 @@ export function judgedArchiveWindowForEntry(entry, nowMs) {
 }
 
 function resolveJudgedEvidenceLookbackMs() {
-  return envPositiveInt(
+  const configuredLookbackMs = envPositiveInt(
     'FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS',
     JUDGED_EVIDENCE_LOOKBACK_MS,
+  );
+  return Math.min(configuredLookbackMs, resolveJudgedEvidenceMaxLookbackMs());
+}
+
+function resolveJudgedEvidenceMaxLookbackMs() {
+  return envPositiveInt(
+    'FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS',
+    JUDGED_EVIDENCE_MAX_LOOKBACK_MS,
   );
 }
 
@@ -1070,10 +1080,7 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   const { url, token } = getArchiveRedisCredentials(options);
   const configuredMaxLookbackMs = Number.isFinite(options.maxLookbackMs)
     ? Math.max(1, Math.floor(options.maxLookbackMs))
-    : envPositiveInt(
-      'FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS',
-      JUDGED_EVIDENCE_MAX_LOOKBACK_MS,
-    );
+    : resolveJudgedEvidenceMaxLookbackMs();
   const coverageStartMs = Math.max(windowStartMs, nowMs - configuredMaxLookbackMs);
   const maxHashes = Number.isFinite(options.maxHashes)
     ? Math.max(1, Math.floor(options.maxHashes))

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -1081,14 +1081,14 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   const configuredMaxLookbackMs = Number.isFinite(options.maxLookbackMs)
     ? Math.max(1, Math.floor(options.maxLookbackMs))
     : resolveJudgedEvidenceMaxLookbackMs();
-  const coverageStartMs = Math.max(windowStartMs, nowMs - configuredMaxLookbackMs);
+  const requestedCoverageStartMs = Math.max(windowStartMs, nowMs - configuredMaxLookbackMs);
   const maxHashes = Number.isFinite(options.maxHashes)
     ? Math.max(1, Math.floor(options.maxHashes))
     : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT);
   const base = {
     requestedStartMs: windowStartMs,
     requestedEndMs: nowMs,
-    coverageStartMs,
+    coverageStartMs: requestedCoverageStartMs,
     coverageEndMs: nowMs,
   };
   const zsetResp = await fetch(url, {
@@ -1098,22 +1098,47 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
       'ZREVRANGEBYSCORE',
       JUDGED_ARCHIVE_KEY,
       String(nowMs),
-      String(coverageStartMs),
+      String(requestedCoverageStartMs),
+      'WITHSCORES',
       'LIMIT',
       '0',
-      String(maxHashes),
+      String(maxHashes + 1),
     ]),
     signal: AbortSignal.timeout(10_000),
   });
   if (!zsetResp.ok) throw new Error(`Redis ZREVRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} failed: HTTP ${zsetResp.status}`);
   const zsetPayload = await zsetResp.json();
-  const hashes = Array.isArray(zsetPayload.result) ? zsetPayload.result.filter(Boolean) : [];
-  if (!hashes.length) return { ...base, items: [], available: true };
+  if (!Array.isArray(zsetPayload?.result)) {
+    throw new Error(`Redis ZREVRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} returned non-array WITHSCORES data`);
+  }
+  const zsetRows = zsetPayload.result;
+  if (zsetRows.length % 2 !== 0) {
+    throw new Error(`Redis ZREVRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} returned malformed WITHSCORES data`);
+  }
+  const hashRows = [];
+  for (let index = 0; index < zsetRows.length; index += 2) {
+    const hash = zsetRows[index];
+    const score = Number(zsetRows[index + 1]);
+    if (!hash || !Number.isFinite(score)) {
+      throw new Error(`Redis ZREVRANGEBYSCORE ${JUDGED_ARCHIVE_KEY} returned malformed member/score pair at index ${index / 2}`);
+    }
+    hashRows.push({ hash, score });
+  }
+  if (!hashRows.length) return { ...base, items: [], available: true };
 
-  const selectedHashes = hashes.slice(0, maxHashes);
-  const truncated = hashes.length >= maxHashes;
+  const selectedHashRows = hashRows.slice(0, maxHashes);
+  const selectedHashes = selectedHashRows.map(({ hash }) => hash);
+  const truncated = hashRows.length > maxHashes;
+  const oldestRetainedScore = selectedHashRows.at(-1)?.score;
+  const firstDroppedScore = hashRows[maxHashes]?.score;
+  const retainedCoverageStartMs = firstDroppedScore === oldestRetainedScore
+    ? oldestRetainedScore + 1
+    : oldestRetainedScore;
+  const coverageStartMs = truncated
+    ? Math.max(requestedCoverageStartMs, retainedCoverageStartMs)
+    : requestedCoverageStartMs;
   if (truncated) {
-    console.warn(`  [forecast-resolutions] judged archive hash cap reached (${selectedHashes.length}/${maxHashes}) for ${new Date(coverageStartMs).toISOString()}..${new Date(nowMs).toISOString()}; increase FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT or page the archive scan`);
+    console.warn(`  [forecast-resolutions] judged archive hash cap reached (${selectedHashes.length}/${maxHashes}) for ${new Date(requestedCoverageStartMs).toISOString()}..${new Date(nowMs).toISOString()}; retained coverage begins ${new Date(coverageStartMs).toISOString()}; increase FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT or page the archive scan`);
   }
   const archiveTimeoutMs = Number.isFinite(options.archiveTimeoutMs)
     ? Math.max(1, Math.floor(options.archiveTimeoutMs))
@@ -1132,18 +1157,15 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
       signal: AbortSignal.timeout(remainingMs),
     });
     if (!pipelineResp.ok) throw new Error(`Redis story-track pipeline failed: HTTP ${pipelineResp.status}`);
-    const pipelinePayload = await pipelineResp.json();
-    if (!Array.isArray(pipelinePayload) || pipelinePayload.length !== commands.length) {
-      throw new Error(`Redis story-track pipeline returned ${Array.isArray(pipelinePayload) ? pipelinePayload.length : 'non-array'} of ${commands.length}`);
-    }
-    return pipelinePayload;
+    return pipelineResp.json();
   }, { batchSize: storyTrackBatchSize, context: 'forecast-resolutions' });
   if (!rows) throw new Error('Redis story-track pipeline returned incomplete archive data');
   const items = [];
   let missingRows = 0;
   for (let index = 0; index < selectedHashes.length; index += 1) {
     if (rows[index]?.error) {
-      throw new Error(`Redis story-track pipeline row ${index} failed: ${rows[index].error}`);
+      missingRows += 1;
+      continue;
     }
     const raw = rows[index]?.result;
     const flat = normalizeRedisHashResult(raw);
@@ -1169,6 +1191,7 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   }
   return {
     ...base,
+    coverageStartMs,
     items: normalizeJudgedArchiveItems(items),
     available: true,
     ...(truncated ? { truncated: true } : {}),

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -21,6 +21,7 @@ import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast
 import { CONFLICT_COUNT_FEED_AVAILABLE, UNREST_COUNT_FEED_AVAILABLE, CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
 import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
 import { callForecastLLM } from './seed-forecasts.mjs';
+import { readStoryTracksChunked, STORY_TRACK_HGETALL_BATCH } from './lib/story-track-batch-reader.mjs';
 
 export const HISTORY_KEY = 'forecast:predictions:history:v1';
 export const RESOLUTIONS_KEY = 'forecast:resolutions:v1';
@@ -31,14 +32,15 @@ export const RESOLUTION_SOURCE_VERSION = 'forecast-resolution-engine-v1';
 export const RESOLUTION_SCHEMA_VERSION = 1;
 export const MAX_RECENT_SAMPLES = 40;
 export const JUDGED_ARCHIVE_KEY = 'digest:accumulator:v1:full:en';
-export const JUDGED_ARCHIVE_RETENTION_MS = 48 * 60 * 60 * 1000;
-export const JUDGED_ARCHIVE_LOOKBACK_PAD_MS = 6 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const JUDGED_EVIDENCE_LOOKBACK_MS = 7 * DAY_MS;
+export const JUDGED_EVIDENCE_MAX_LOOKBACK_MS = 14 * DAY_MS;
 export const DEFAULT_JUDGED_ARCHIVE_ITEMS = 16;
 export const DEFAULT_JUDGED_MAX_PER_RUN = 12;
 export const DEFAULT_JUDGED_RUN_BUDGET_MS = 110_000;
-export const DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT = 3_000;
+export const DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT = 15_000;
+export const DEFAULT_JUDGED_ARCHIVE_TIMEOUT_MS = 25_000;
 const DEFAULT_MIN_JUDGED_STAGE_BUDGET_MS = 5_000;
-const DAY_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_JUDGED_MAX_PENDING_ATTEMPTS = 14;
 export const DEFAULT_JUDGED_MAX_PENDING_AGE_MS = 14 * DAY_MS;
 const JUDGED_TOKEN_STOPWORDS = new Set([
@@ -48,6 +50,7 @@ const JUDGED_TOKEN_STOPWORDS = new Set([
   'this', 'through', 'under', 'until', 'what', 'when', 'where', 'which',
   'while', 'will', 'with', 'within', 'would',
 ]);
+const NORMALIZED_JUDGED_ARCHIVE_INPUT = Symbol('normalizedJudgedArchiveInput');
 const STALE_COUNT_FEED_REPLACEMENTS = new Map([
   ['conflict:acled:v1:all:0:0', CONFLICT_COUNT_SOURCE_FEED],
   ['unrest:events:v1', UNREST_COUNT_SOURCE_FEED],
@@ -115,6 +118,8 @@ export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, op
   const pendingRows = Object.entries(ledger)
     .filter(([, entry]) => entry?.status === 'pending-judge')
     .sort((left, right) => comparePendingJudgedEntries(left, right, nowMs));
+  if (!pendingRows.length) return receipts;
+  const normalizedNewsArchive = normalizeJudgedArchiveInput(newsArchive);
 
   for (const [key, entry] of pendingRows) {
     if (attempted >= maxEntries) break;
@@ -128,7 +133,7 @@ export async function resolvePendingJudgedEntries(ledger, newsArchive, nowMs, op
       };
     }
 
-    let result = await resolveJudgedEntry(entry, newsArchive, nowMs, entryOptions);
+    let result = await resolveJudgedEntry(entry, normalizedNewsArchive, nowMs, entryOptions);
     if (result.status === 'skip') continue;
     attempted += 1;
 
@@ -234,8 +239,9 @@ export async function resolveJudgedEntry(entry, newsArchive, nowMs, options = {}
     return { status: 'pending', reason: 'archive_unavailable' };
   }
 
-  const archiveItems = selectJudgedArchiveItems(entry, archiveInput.items, {
+  const archiveItems = selectNormalizedJudgedArchiveItems(entry, archiveInput.items, {
     maxItems: options.maxArchiveItems ?? DEFAULT_JUDGED_ARCHIVE_ITEMS,
+    nowMs,
   });
   const archiveComplete = archiveCoversEntryWindow(entry, archiveInput, nowMs);
   if (!archiveItems.length) {
@@ -280,9 +286,23 @@ export async function resolveJudgedEntry(entry, newsArchive, nowMs, options = {}
 }
 
 export function selectJudgedArchiveItems(entry, archiveItems, options = {}) {
+  return selectNormalizedJudgedArchiveItems(entry, normalizeJudgedArchiveItems(archiveItems), options);
+}
+
+function selectNormalizedJudgedArchiveItems(entry, archiveItems, options = {}) {
   const maxItems = Number.isFinite(options.maxItems) ? Math.max(1, Math.floor(options.maxItems)) : DEFAULT_JUDGED_ARCHIVE_ITEMS;
   const tokenPatterns = judgedQueryTokens(entry).map(buildTokenPattern);
-  return normalizeJudgedArchiveItems(archiveItems)
+  const evidenceWindow = Number.isFinite(options.nowMs)
+    ? judgedArchiveWindowForEntry(entry, options.nowMs)
+    : null;
+  return archiveItems
+    .filter((item) => {
+      if (!evidenceWindow) return true;
+      const publishedAt = Number(item.publishedAt);
+      return Number.isFinite(publishedAt)
+        && publishedAt >= evidenceWindow.startMs
+        && publishedAt <= evidenceWindow.endMs;
+    })
     .map((item, index) => ({
       ...item,
       id: item.id || `N${index + 1}`,
@@ -304,14 +324,15 @@ export function selectJudgedArchiveItems(entry, archiveItems, options = {}) {
 }
 
 function normalizeJudgedArchiveInput(newsArchive) {
+  if (newsArchive?.[NORMALIZED_JUDGED_ARCHIVE_INPUT]) return newsArchive;
   if (Array.isArray(newsArchive)) {
-    return { items: normalizeJudgedArchiveItems(newsArchive), available: true };
+    return markNormalizedJudgedArchiveInput({ items: normalizeJudgedArchiveItems(newsArchive), available: true });
   }
   if (!newsArchive || typeof newsArchive !== 'object') {
-    return { items: [], available: false };
+    return markNormalizedJudgedArchiveInput({ items: [], available: false });
   }
   if (newsArchive.available === false) {
-    return { items: [], available: false };
+    return markNormalizedJudgedArchiveInput({ items: [], available: false });
   }
   const items = newsArchive.items
     ?? newsArchive.stories
@@ -319,13 +340,18 @@ function normalizeJudgedArchiveInput(newsArchive) {
     ?? newsArchive.articles
     ?? newsArchive.data
     ?? [];
-  return {
+  return markNormalizedJudgedArchiveInput({
     items: normalizeJudgedArchiveItems(items),
     available: true,
-    truncated: Boolean(newsArchive.truncated || newsArchive.partial || newsArchive.coverageComplete === false),
+    incomplete: Boolean(newsArchive.incomplete || newsArchive.partial || newsArchive.coverageComplete === false),
     coverageStartMs: toFiniteMs(newsArchive.coverageStartMs ?? newsArchive.windowStartMs ?? newsArchive.fromMs),
     coverageEndMs: toFiniteMs(newsArchive.coverageEndMs ?? newsArchive.windowEndMs ?? newsArchive.toMs),
-  };
+  });
+}
+
+function markNormalizedJudgedArchiveInput(archiveInput) {
+  Object.defineProperty(archiveInput, NORMALIZED_JUDGED_ARCHIVE_INPUT, { value: true });
+  return archiveInput;
 }
 
 function normalizeJudgedArchiveItems(value) {
@@ -396,7 +422,7 @@ function scoreArchiveItem(item, tokenPatterns) {
 }
 
 function archiveCoversEntryWindow(entry, archiveInput, nowMs) {
-  if (archiveInput.truncated) return false;
+  if (archiveInput.incomplete) return false;
   const coverageStartMs = Number(archiveInput.coverageStartMs);
   const coverageEndMs = Number(archiveInput.coverageEndMs);
   if (!Number.isFinite(coverageStartMs) && !Number.isFinite(coverageEndMs)) return true;
@@ -405,16 +431,21 @@ function archiveCoversEntryWindow(entry, archiveInput, nowMs) {
     && (!Number.isFinite(coverageEndMs) || coverageEndMs >= endMs);
 }
 
-function judgedArchiveWindowForEntry(entry, nowMs) {
+export function judgedArchiveWindowForEntry(entry, nowMs) {
   const deadline = Number(entry?.deadline ?? entry?.spec?.deadline);
-  const candidates = [entry?.generatedAt, entry?.firstSeenAt, deadline, nowMs]
-    .map(Number)
-    .filter(Number.isFinite);
-  const anchor = candidates.length ? Math.min(...candidates) : nowMs;
+  const anchor = Number.isFinite(deadline) ? deadline : nowMs;
+  const evidenceLookbackMs = resolveJudgedEvidenceLookbackMs();
   return {
-    startMs: Math.max(0, anchor - JUDGED_ARCHIVE_LOOKBACK_PAD_MS),
+    startMs: Math.max(0, anchor - evidenceLookbackMs),
     endMs: nowMs,
   };
+}
+
+function resolveJudgedEvidenceLookbackMs() {
+  return envPositiveInt(
+    'FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS',
+    JUDGED_EVIDENCE_LOOKBACK_MS,
+  );
 }
 
 function buildTokenPattern(token) {
@@ -1037,7 +1068,13 @@ async function readJudgedNewsArchiveForLedger(ledger, nowMs, options = {}) {
 
 export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options = {}) {
   const { url, token } = getArchiveRedisCredentials(options);
-  const coverageStartMs = Math.max(windowStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
+  const configuredMaxLookbackMs = Number.isFinite(options.maxLookbackMs)
+    ? Math.max(1, Math.floor(options.maxLookbackMs))
+    : envPositiveInt(
+      'FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS',
+      JUDGED_EVIDENCE_MAX_LOOKBACK_MS,
+    );
+  const coverageStartMs = Math.max(windowStartMs, nowMs - configuredMaxLookbackMs);
   const maxHashes = Number.isFinite(options.maxHashes)
     ? Math.max(1, Math.floor(options.maxHashes))
     : envPositiveInt('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT', DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT);
@@ -1071,18 +1108,30 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
   if (truncated) {
     console.warn(`  [forecast-resolutions] judged archive hash cap reached (${selectedHashes.length}/${maxHashes}) for ${new Date(coverageStartMs).toISOString()}..${new Date(nowMs).toISOString()}; increase FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT or page the archive scan`);
   }
-  const pipelineResp = await fetch(`${url}/pipeline`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify(selectedHashes.map((hash) => ['HGETALL', `story:track:v1:${hash}`])),
-    signal: AbortSignal.timeout(options.archiveTimeoutMs ?? 15_000),
-  });
-  if (!pipelineResp.ok) throw new Error(`Redis story-track pipeline failed: HTTP ${pipelineResp.status}`);
-  const pipelinePayload = await pipelineResp.json();
-  if (!Array.isArray(pipelinePayload) || pipelinePayload.length !== selectedHashes.length) {
-    throw new Error(`Redis story-track pipeline returned ${Array.isArray(pipelinePayload) ? pipelinePayload.length : 'non-array'} of ${selectedHashes.length}`);
-  }
-  const rows = pipelinePayload;
+  const archiveTimeoutMs = Number.isFinite(options.archiveTimeoutMs)
+    ? Math.max(1, Math.floor(options.archiveTimeoutMs))
+    : DEFAULT_JUDGED_ARCHIVE_TIMEOUT_MS;
+  const archiveDeadlineMs = Date.now() + archiveTimeoutMs;
+  const storyTrackBatchSize = Number.isFinite(options.storyTrackBatchSize)
+    ? Math.max(1, Math.floor(options.storyTrackBatchSize))
+    : STORY_TRACK_HGETALL_BATCH;
+  const rows = await readStoryTracksChunked(selectedHashes, async (commands) => {
+    const remainingMs = archiveDeadlineMs - Date.now();
+    if (remainingMs <= 0) throw new Error(`Redis story-track pipeline exceeded ${archiveTimeoutMs}ms archive budget`);
+    const pipelineResp = await fetch(`${url}/pipeline`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+      body: JSON.stringify(commands),
+      signal: AbortSignal.timeout(remainingMs),
+    });
+    if (!pipelineResp.ok) throw new Error(`Redis story-track pipeline failed: HTTP ${pipelineResp.status}`);
+    const pipelinePayload = await pipelineResp.json();
+    if (!Array.isArray(pipelinePayload) || pipelinePayload.length !== commands.length) {
+      throw new Error(`Redis story-track pipeline returned ${Array.isArray(pipelinePayload) ? pipelinePayload.length : 'non-array'} of ${commands.length}`);
+    }
+    return pipelinePayload;
+  }, { batchSize: storyTrackBatchSize, context: 'forecast-resolutions' });
+  if (!rows) throw new Error('Redis story-track pipeline returned incomplete archive data');
   const items = [];
   let missingRows = 0;
   for (let index = 0; index < selectedHashes.length; index += 1) {
@@ -1111,7 +1160,14 @@ export async function readDigestAccumulatorArchive(windowStartMs, nowMs, options
       currentScore: toFiniteNumber(track.currentScore ?? track.score),
     }));
   }
-  return { ...base, items: normalizeJudgedArchiveItems(items), available: true, truncated: truncated || missingRows > 0, missingRows };
+  return {
+    ...base,
+    items: normalizeJudgedArchiveItems(items),
+    available: true,
+    ...(truncated ? { truncated: true } : {}),
+    incomplete: missingRows > 0,
+    missingRows,
+  };
 }
 
 function getArchiveRedisCredentials(options = {}) {

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -789,6 +789,61 @@ describe('processResolutionCycleWithJudges', () => {
     assert.deepEqual(selected.map((item) => item.id), ['N-current']);
   });
 
+  it('filters one normalized archive independently for judged entries with different deadlines', async () => {
+    const earlyDeadline = T0 + 10 * DAY_MS;
+    const lateDeadline = T0 + 20 * DAY_MS;
+    const nowMs = lateDeadline + 1;
+    const forecasts = [
+      judgedForecast({
+        id: 'judge-early-window',
+        resolution: {
+          kind: 'judged',
+          deadline: earlyDeadline,
+          question: 'Will the emergency policy change pass before the deadline?',
+        },
+      }),
+      judgedForecast({
+        id: 'judge-late-window',
+        resolution: {
+          kind: 'judged',
+          deadline: lateDeadline,
+          question: 'Will the emergency policy change pass before the deadline?',
+        },
+      }),
+    ];
+    const sharedArchive = {
+      available: true,
+      coverageStartMs: earlyDeadline - JUDGED_EVIDENCE_LOOKBACK_MS,
+      coverageEndMs: nowMs,
+      items: [{
+        id: 'N-early',
+        title: 'Emergency policy change passes early vote',
+        description: 'The policy passed in the early session.',
+        publishedAt: earlyDeadline - DAY_MS,
+      }, {
+        id: 'N-late',
+        title: 'Emergency policy change passes final vote',
+        description: 'The policy passed in the later session.',
+        publishedAt: lateDeadline - DAY_MS,
+      }],
+    };
+    const evidenceByEntry = new Map();
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, forecasts)], {}, sharedArchive, nowMs, {
+      judgeModels: [
+        async (entry, items) => {
+          evidenceByEntry.set(entry.id, items.map((item) => item.id));
+          return { provider: 'openrouter', outcome: 'YES', citations: [{ id: items[0].id, quote: items[0].description }] };
+        },
+        async (_entry, items) => ({ provider: 'groq', outcome: 'YES', citations: [{ id: items[0].id, quote: items[0].description }] }),
+      ],
+    });
+
+    assert.deepEqual(evidenceByEntry.get('judge-early-window'), ['N-late', 'N-early']);
+    assert.deepEqual(evidenceByEntry.get('judge-late-window'), ['N-late']);
+    assert.equal(result.ledger[`judge-early-window@${earlyDeadline}`].status, 'resolved');
+    assert.equal(result.ledger[`judge-late-window@${lateDeadline}`].status, 'resolved');
+  });
+
   it('keeps weak judge outcomes pending when matching evidence comes from an incomplete archive', async () => {
     const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, {
       available: true,
@@ -982,7 +1037,7 @@ describe('processResolutionCycleWithJudges', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['old-hash', 'new-hash'] }),
+        json: async () => ({ result: ['new-hash', String(T0 + 2), 'old-hash', String(T0 + 1)] }),
       };
     };
 
@@ -1032,9 +1087,23 @@ describe('readDigestAccumulatorArchive', () => {
 
     assert.ok(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT >= 15_000);
     assert.ok(DEFAULT_JUDGED_ARCHIVE_TIMEOUT_MS >= 20_000);
-    assert.equal(zsetCommand.at(-1), String(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT));
+    assert.equal(zsetCommand.at(-1), String(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT + 1));
     assert.equal(archive.truncated, undefined);
     assert.equal(archive.items.length, 0);
+  });
+
+  it('fails closed when the scored archive response is structurally invalid', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ result: { hash: 'not-a-scored-array' } }),
+    });
+
+    await assert.rejects(
+      readDigestAccumulatorArchive(T0, T0 + DAY_MS),
+      /returned non-array WITHSCORES data/,
+    );
   });
 
   it('bounds the Redis archive query to the 14-day evidence floor and hash limit', async () => {
@@ -1059,7 +1128,11 @@ describe('readDigestAccumulatorArchive', () => {
       zsetCommand = JSON.parse(init.body);
       return {
         ok: true,
-        json: async () => ({ result: ['new-hash', 'old-hash', 'extra-hash'] }),
+        json: async () => ({ result: [
+          'new-hash', String(nowMs - 1),
+          'old-hash', String(nowMs - 2),
+          'extra-hash', String(nowMs - 3),
+        ] }),
       };
     };
 
@@ -1071,15 +1144,17 @@ describe('readDigestAccumulatorArchive', () => {
         JUDGED_ARCHIVE_KEY,
         String(nowMs),
         String(nowMs - JUDGED_EVIDENCE_MAX_LOOKBACK_MS),
+        'WITHSCORES',
         'LIMIT',
         '0',
-        '2',
+        '3',
       ]);
       assert.deepEqual(pipelineCommands.map(([, key]) => key), [
         'story:track:v1:new-hash',
         'story:track:v1:old-hash',
       ]);
-      assert.equal(archive.coverageStartMs, nowMs - JUDGED_EVIDENCE_MAX_LOOKBACK_MS);
+      assert.equal(archive.requestedStartMs, T0 - 30 * DAY_MS);
+      assert.equal(archive.coverageStartMs, nowMs - 2);
       assert.equal(archive.items.length, 2);
       assert.equal(archive.truncated, true);
       assert.ok(warnings.some((line) => line.includes('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT')));
@@ -1159,6 +1234,60 @@ describe('readDigestAccumulatorArchive', () => {
     assert.equal(result.receipts.length, 1);
   });
 
+  it('keeps a due judged entry pending when a capped read starts after its required window', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const deadline = T0 + 10 * DAY_MS;
+    const nowMs = deadline + DAY_MS;
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/pipeline')) {
+        return {
+          ok: true,
+          json: async () => [{
+            result: ['title', 'Unrelated market update', 'description', 'Markets were steady.', 'publishedAt', String(deadline + 1)],
+          }],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: [
+          'retained-hash', String(deadline + 1),
+          'dropped-hash', String(deadline + 1),
+        ] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(
+      deadline - JUDGED_EVIDENCE_LOOKBACK_MS,
+      nowMs,
+      { maxHashes: 1 },
+    );
+    assert.equal(archive.truncated, true);
+    assert.equal(archive.coverageStartMs, deadline + 2, 'equal-score cap ties must not over-claim the boundary');
+
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [forecast({
+      id: 'judge-truncated-window',
+      domain: 'political',
+      region: 'Freedonia',
+      title: 'Policy change passes',
+      resolution: {
+        kind: 'judged',
+        deadline,
+        question: 'Will the emergency policy change pass before the deadline?',
+      },
+    })])], {}, archive, nowMs, {
+      judgeModels: [
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+      ],
+    });
+
+    const row = result.ledger[`judge-truncated-window@${deadline}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.judgeLastAttempt.detail, 'archive_window_incomplete');
+    assert.equal(result.receipts.length, 0);
+  });
+
   it('chunks story-track reads while preserving hash-to-row alignment', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
@@ -1176,7 +1305,11 @@ describe('readDigestAccumulatorArchive', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['hash-1', 'hash-2', 'hash-3'] }),
+        json: async () => ({ result: [
+          'hash-1', String(T0 + 3),
+          'hash-2', String(T0 + 2),
+          'hash-3', String(T0 + 1),
+        ] }),
       };
     };
 
@@ -1213,7 +1346,11 @@ describe('readDigestAccumulatorArchive', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['hash-1', 'hash-2', 'hash-3'] }),
+        json: async () => ({ result: [
+          'hash-1', String(T0 + 3),
+          'hash-2', String(T0 + 2),
+          'hash-3', String(T0 + 1),
+        ] }),
       };
     };
 
@@ -1249,7 +1386,7 @@ describe('readDigestAccumulatorArchive', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['hash-1'] }),
+        json: async () => ({ result: ['hash-1', String(T0 + 1)] }),
       };
     };
 
@@ -1275,7 +1412,7 @@ describe('readDigestAccumulatorArchive', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['missing-hash', 'hash-2'] }),
+        json: async () => ({ result: ['missing-hash', String(T0 + 2), 'hash-2', String(T0 + 1)] }),
       };
     };
 
@@ -1300,7 +1437,7 @@ describe('readDigestAccumulatorArchive', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['missing-hash'] }),
+        json: async () => ({ result: ['missing-hash', String(T0 + 1)] }),
       };
     };
 
@@ -1328,7 +1465,7 @@ describe('readDigestAccumulatorArchive', () => {
     assert.equal(result.receipts.length, 0);
   });
 
-  it('fails closed when a same-length Redis pipeline response has an invalid story row', async () => {
+  it('keeps good evidence while marking an errored Redis story row incomplete', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
     globalThis.fetch = async (url) => {
@@ -1343,14 +1480,48 @@ describe('readDigestAccumulatorArchive', () => {
       }
       return {
         ok: true,
-        json: async () => ({ result: ['hash-1', 'hash-2'] }),
+        json: async () => ({ result: ['hash-1', String(T0 + 2), 'hash-2', String(T0 + 1)] }),
       };
     };
 
-    await assert.rejects(
-      readDigestAccumulatorArchive(T0, T0 + DAY_MS),
-      /story-track pipeline row 1 failed/,
-    );
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
+
+    assert.equal(archive.items.length, 1);
+    assert.equal(archive.items[0].hash, 'hash-1');
+    assert.equal(archive.incomplete, true);
+    assert.equal(archive.missingRows, 1);
+  });
+
+  it('logs caller context and fails closed when a story-track response is short', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/pipeline')) {
+        return {
+          ok: true,
+          json: async () => [{ result: ['title', 'Only one row'] }],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['hash-1', String(T0 + 2), 'hash-2', String(T0 + 1)] }),
+      };
+    };
+
+    try {
+      await assert.rejects(
+        readDigestAccumulatorArchive(T0, T0 + DAY_MS),
+        /story-track pipeline returned incomplete archive data/,
+      );
+      assert.ok(warnings.some((line) => line.includes('[forecast-resolutions] readStoryTracksChunked')));
+      assert.ok(warnings.some((line) => line.includes('returned 1 of 2 expected')));
+      assert.ok(warnings.some((line) => line.includes('treats the archive read as failed')));
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });
 

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -1109,7 +1109,7 @@ describe('readDigestAccumulatorArchive', () => {
     assert.equal(archive.coverageStartMs, nowMs - 3 * DAY_MS);
   });
 
-  it('keeps the configured maximum lookback as a hard read ceiling', async () => {
+  it('clamps the evidence window to the configured maximum lookback', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
     delete process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS;
@@ -1130,6 +1130,11 @@ describe('readDigestAccumulatorArchive', () => {
     assert.equal(archive.coverageStartMs, nowMs - DAY_MS);
 
     const deadline = nowMs;
+    assert.deepEqual(judgedArchiveWindowForEntry({ spec: { kind: 'judged', deadline } }, nowMs), {
+      startMs: deadline - DAY_MS,
+      endMs: nowMs,
+    });
+
     const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [forecast({
       id: 'judge-max-lookback',
       domain: 'political',
@@ -1148,9 +1153,10 @@ describe('readDigestAccumulatorArchive', () => {
     });
 
     const row = result.ledger[`judge-max-lookback@${deadline}`];
-    assert.equal(row.status, 'pending-judge');
-    assert.equal(row.judgeLastAttempt.detail, 'archive_window_incomplete');
-    assert.equal(result.receipts.length, 0);
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'VOID');
+    assert.equal(row.evidence.reason, 'no_archive_evidence');
+    assert.equal(result.receipts.length, 1);
   });
 
   it('chunks story-track reads while preserving hash-to-row alignment', async () => {

--- a/tests/forecast-resolutions-seeder.test.mjs
+++ b/tests/forecast-resolutions-seeder.test.mjs
@@ -4,10 +4,12 @@ import { afterEach, describe, it } from 'node:test';
 
 import {
   DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT,
+  DEFAULT_JUDGED_ARCHIVE_TIMEOUT_MS,
   DEFAULT_JUDGED_MAX_PENDING_AGE_MS,
   DEFAULT_JUDGED_MAX_PENDING_ATTEMPTS,
   JUDGED_ARCHIVE_KEY,
-  JUDGED_ARCHIVE_RETENTION_MS,
+  JUDGED_EVIDENCE_LOOKBACK_MS,
+  JUDGED_EVIDENCE_MAX_LOOKBACK_MS,
   RESOLUTIONS_KEY,
   SCORECARD_META_KEY,
   SCORECARD_KEY,
@@ -21,6 +23,8 @@ import {
   processResolutionCycleWithJudges,
   pruneArchivedTerminalEntries,
   readDigestAccumulatorArchive,
+  judgedArchiveWindowForEntry,
+  selectJudgedArchiveItems,
 } from '../scripts/seed-forecast-resolutions.mjs';
 import { computeScorecard } from '../scripts/_forecast-scorecard.mjs';
 import { CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from '../scripts/_forecast-resolution.mjs';
@@ -32,6 +36,8 @@ const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_REDIS_ENV = {
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS: process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS,
+  FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS: process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS,
 };
 
 afterEach(() => {
@@ -40,6 +46,10 @@ afterEach(() => {
   else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_URL;
   if (ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_TOKEN === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
   else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_REDIS_ENV.UPSTASH_REDIS_REST_TOKEN;
+  if (ORIGINAL_REDIS_ENV.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS === undefined) delete process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS;
+  else process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS = ORIGINAL_REDIS_ENV.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS;
+  if (ORIGINAL_REDIS_ENV.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS === undefined) delete process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS;
+  else process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS = ORIGINAL_REDIS_ENV.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS;
 });
 
 function forecast(overrides = {}) {
@@ -670,31 +680,113 @@ describe('processResolutionCycleWithJudges', () => {
     assert.equal(result.receipts.length, 0);
   });
 
-  it('keeps no-evidence entries pending when the archive read was truncated', async () => {
-    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, {
+  it('seals a long-horizon disagreement when a truncated archive covers the deadline window', async () => {
+    const deadline = T0 + 30 * DAY_MS;
+    const nowMs = deadline + 60 * 60 * 1000;
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast({
+      resolution: {
+        kind: 'judged',
+        deadline,
+        question: 'Will the emergency policy change pass before the deadline?',
+      },
+    })])], {}, {
       available: true,
       truncated: true,
-      coverageStartMs: T0 - 6 * 60 * 60 * 1000,
-      coverageEndMs: T0 + DAY_MS + 2,
+      coverageStartMs: deadline - JUDGED_EVIDENCE_LOOKBACK_MS,
+      coverageEndMs: nowMs,
       items: [{
         id: 'N1',
-        title: 'Central bank holds rates unchanged',
-        description: 'Officials said inflation remained steady.',
-        url: 'https://news.example/rates',
-        publishedAt: T0 + DAY_MS + 1,
+        title: 'Parliament votes on the emergency policy change',
+        description: 'The coalition held its final vote before the forecast deadline.',
+        url: 'https://news.example/policy-change',
+        publishedAt: deadline - 1,
       }],
-    }, T0 + DAY_MS + 2, {
+    }, nowMs, {
+      judgeModels: [
+        async () => ({ provider: 'openrouter', outcome: 'YES', citations: [{ id: 'N1', quote: 'The coalition held its final vote before the forecast deadline' }] }),
+        async () => ({ provider: 'groq', outcome: 'NO', citations: [{ id: 'N1', quote: 'The coalition held its final vote before the forecast deadline' }] }),
+      ],
+    });
+
+    const row = result.ledger[`fc-judge@${deadline}`];
+    assert.equal(row.status, 'resolved');
+    assert.equal(row.outcome, 'VOID');
+    assert.equal(row.evidence.reason, 'judge_disagreement');
+    assert.equal(result.receipts.length, 1);
+  });
+
+  it('anchors the evidence window on the deadline instead of forecast generation', () => {
+    const deadline = T0 + 30 * DAY_MS;
+    const nowMs = deadline + 60 * 60 * 1000;
+
+    assert.deepEqual(judgedArchiveWindowForEntry({
+      generatedAt: T0,
+      firstSeenAt: T0,
+      spec: { kind: 'judged', deadline },
+    }, nowMs), {
+      startMs: deadline - JUDGED_EVIDENCE_LOOKBACK_MS,
+      endMs: nowMs,
+    });
+  });
+
+  it('honors the configured deadline evidence lookback', () => {
+    const deadline = T0 + 30 * DAY_MS;
+    const nowMs = deadline + 60 * 60 * 1000;
+    process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS = String(2 * DAY_MS);
+
+    assert.deepEqual(judgedArchiveWindowForEntry({ spec: { kind: 'judged', deadline } }, nowMs), {
+      startMs: deadline - 2 * DAY_MS,
+      endMs: nowMs,
+    });
+  });
+
+  it('keeps a covered no-evidence entry pending when the archive is explicitly incomplete', async () => {
+    const deadline = T0 + DAY_MS;
+    const nowMs = deadline + 2;
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [judgedForecast()])], {}, {
+      available: true,
+      coverageComplete: false,
+      coverageStartMs: deadline - JUDGED_EVIDENCE_LOOKBACK_MS,
+      coverageEndMs: nowMs,
+      items: [],
+    }, nowMs, {
       judgeModels: [
         async () => { throw new Error('judge should not be called without relevant archive evidence'); },
         async () => { throw new Error('judge should not be called without relevant archive evidence'); },
       ],
     });
 
-    const row = result.ledger[`fc-judge@${T0 + DAY_MS}`];
+    const row = result.ledger[`fc-judge@${deadline}`];
     assert.equal(row.status, 'pending-judge');
-    assert.equal(row.outcome, undefined);
     assert.equal(row.judgeLastAttempt.reason, 'archive_unavailable');
+    assert.equal(row.judgeLastAttempt.detail, 'archive_window_incomplete');
     assert.equal(result.receipts.length, 0);
+  });
+
+  it('filters shared archive evidence to each entry deadline window', () => {
+    const deadline = T0 + 30 * DAY_MS;
+    const nowMs = deadline + 60 * 60 * 1000;
+    const entry = judgedForecast({
+      resolution: {
+        kind: 'judged',
+        deadline,
+        question: 'Will the emergency policy change pass before the deadline?',
+      },
+    });
+
+    const selected = selectJudgedArchiveItems(entry, [{
+      id: 'N-old',
+      title: 'Emergency policy change passes',
+      description: 'The coalition passed the policy in an earlier session.',
+      publishedAt: deadline - 8 * DAY_MS,
+    }, {
+      id: 'N-current',
+      title: 'Emergency policy change passes',
+      description: 'The coalition passed the policy before the deadline.',
+      publishedAt: deadline - DAY_MS,
+    }], { nowMs });
+
+    assert.deepEqual(selected.map((item) => item.id), ['N-current']);
   });
 
   it('keeps weak judge outcomes pending when matching evidence comes from an incomplete archive', async () => {
@@ -938,13 +1030,14 @@ describe('readDigestAccumulatorArchive', () => {
 
     const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
 
-    assert.ok(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT >= 2_500);
+    assert.ok(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT >= 15_000);
+    assert.ok(DEFAULT_JUDGED_ARCHIVE_TIMEOUT_MS >= 20_000);
     assert.equal(zsetCommand.at(-1), String(DEFAULT_JUDGED_ARCHIVE_HASH_LIMIT));
     assert.equal(archive.truncated, undefined);
     assert.equal(archive.items.length, 0);
   });
 
-  it('bounds the Redis archive query to the retention floor and hash limit', async () => {
+  it('bounds the Redis archive query to the 14-day evidence floor and hash limit', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
     let zsetCommand;
@@ -977,7 +1070,7 @@ describe('readDigestAccumulatorArchive', () => {
         'ZREVRANGEBYSCORE',
         JUDGED_ARCHIVE_KEY,
         String(nowMs),
-        String(nowMs - JUDGED_ARCHIVE_RETENTION_MS),
+        String(nowMs - JUDGED_EVIDENCE_MAX_LOOKBACK_MS),
         'LIMIT',
         '0',
         '2',
@@ -986,12 +1079,149 @@ describe('readDigestAccumulatorArchive', () => {
         'story:track:v1:new-hash',
         'story:track:v1:old-hash',
       ]);
-      assert.equal(archive.coverageStartMs, nowMs - JUDGED_ARCHIVE_RETENTION_MS);
+      assert.equal(archive.coverageStartMs, nowMs - JUDGED_EVIDENCE_MAX_LOOKBACK_MS);
       assert.equal(archive.items.length, 2);
       assert.equal(archive.truncated, true);
       assert.ok(warnings.some((line) => line.includes('FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT')));
     } finally {
       console.warn = originalWarn;
+    }
+  });
+
+  it('honors the configured maximum archive lookback', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS = String(2 * DAY_MS);
+    process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS = String(3 * DAY_MS);
+    const nowMs = T0 + 5 * DAY_MS;
+    let zsetCommand;
+    globalThis.fetch = async (_url, init) => {
+      zsetCommand = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => ({ result: [] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0 - 30 * DAY_MS, nowMs);
+
+    assert.equal(zsetCommand[3], String(nowMs - 3 * DAY_MS));
+    assert.equal(archive.coverageStartMs, nowMs - 3 * DAY_MS);
+  });
+
+  it('keeps the configured maximum lookback as a hard read ceiling', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    delete process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS;
+    process.env.FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS = String(DAY_MS);
+    const nowMs = T0 + 5 * DAY_MS;
+    let zsetCommand;
+    globalThis.fetch = async (_url, init) => {
+      zsetCommand = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => ({ result: [] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0 - 30 * DAY_MS, nowMs);
+
+    assert.equal(zsetCommand[3], String(nowMs - DAY_MS));
+    assert.equal(archive.coverageStartMs, nowMs - DAY_MS);
+
+    const deadline = nowMs;
+    const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [forecast({
+      id: 'judge-max-lookback',
+      domain: 'political',
+      region: 'Freedonia',
+      title: 'Policy change passes',
+      resolution: {
+        kind: 'judged',
+        deadline,
+        question: 'Will the emergency policy change pass before the deadline?',
+      },
+    })])], {}, archive, nowMs, {
+      judgeModels: [
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+        async () => { throw new Error('judge should not be called without relevant archive evidence'); },
+      ],
+    });
+
+    const row = result.ledger[`judge-max-lookback@${deadline}`];
+    assert.equal(row.status, 'pending-judge');
+    assert.equal(row.judgeLastAttempt.detail, 'archive_window_incomplete');
+    assert.equal(result.receipts.length, 0);
+  });
+
+  it('chunks story-track reads while preserving hash-to-row alignment', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const pipelineBatches = [];
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/pipeline')) {
+        const commands = JSON.parse(init.body);
+        pipelineBatches.push(commands);
+        return {
+          ok: true,
+          json: async () => commands.map(([, key]) => ({
+            result: ['title', `Story ${key}`, 'description', 'Policy change context', 'publishedAt', String(T0 + 1)],
+          })),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['hash-1', 'hash-2', 'hash-3'] }),
+      };
+    };
+
+    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS, {
+      maxHashes: 4,
+      storyTrackBatchSize: 2,
+    });
+
+    assert.deepEqual(pipelineBatches.map((batch) => batch.map(([, key]) => key)), [
+      ['story:track:v1:hash-1', 'story:track:v1:hash-2'],
+      ['story:track:v1:hash-3'],
+    ]);
+    assert.deepEqual(archive.items.map((item) => item.hash), ['hash-1', 'hash-2', 'hash-3']);
+  });
+
+  it('fails closed when the shared archive budget expires between chunks', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const originalDateNow = Date.now;
+    const clock = [1_000, 1_000, 1_002];
+    let clockIndex = 0;
+    let pipelineCalls = 0;
+    Date.now = () => clock[Math.min(clockIndex++, clock.length - 1)];
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/pipeline')) {
+        pipelineCalls += 1;
+        const commands = JSON.parse(init.body);
+        return {
+          ok: true,
+          json: async () => commands.map(() => ({
+            result: ['title', 'Story', 'description', 'Policy context', 'publishedAt', String(T0 + 1)],
+          })),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: ['hash-1', 'hash-2', 'hash-3'] }),
+      };
+    };
+
+    try {
+      await assert.rejects(
+        readDigestAccumulatorArchive(T0, T0 + DAY_MS, {
+          archiveTimeoutMs: 1,
+          storyTrackBatchSize: 2,
+        }),
+        /exceeded 1ms archive budget/,
+      );
+      assert.equal(pipelineCalls, 1);
+    } finally {
+      Date.now = originalDateNow;
     }
   });
 
@@ -1046,7 +1276,8 @@ describe('readDigestAccumulatorArchive', () => {
     const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
 
     assert.equal(archive.items.length, 1);
-    assert.equal(archive.truncated, true);
+    assert.equal(archive.truncated, undefined);
+    assert.equal(archive.incomplete, true);
     assert.equal(archive.missingRows, 1);
     assert.equal(archive.items[0].hash, 'hash-2');
   });
@@ -1067,7 +1298,7 @@ describe('readDigestAccumulatorArchive', () => {
       };
     };
 
-    const archive = await readDigestAccumulatorArchive(T0, T0 + DAY_MS);
+    const archive = await readDigestAccumulatorArchive(T0 - JUDGED_EVIDENCE_LOOKBACK_MS, T0 + DAY_MS);
     const result = await processResolutionCycleWithJudges({}, [snapshot(T0, [forecast({
       id: 'judge-missing-archive-row',
       domain: 'political',


### PR DESCRIPTION
## Summary

Long-horizon judged forecasts can now resolve from evidence around their deadline instead of remaining pending until the retry safety net forces a VOID. The resolver uses a configurable seven-day deadline window, reads up to a hard configurable 14-day Redis ceiling, and filters the shared archive back to each forecast's own window before judging.

Hash-cap truncation is now treated as bounded recency sampling, so a covered window can honestly terminate on agreement, disagreement, or no evidence. Genuine incompleteness remains fail-closed: unavailable archives, explicit incomplete coverage, missing Redis rows, invalid pipeline rows, and exhausted read budgets keep entries pending.

The larger 15,000-hash read is split into 500-command pipelines under a shared 25-second budget. The new knobs are:

- `FORECAST_RESOLUTION_JUDGE_EVIDENCE_LOOKBACK_MS` (default 7 days)
- `FORECAST_RESOLUTION_JUDGE_EVIDENCE_MAX_LOOKBACK_MS` (default 14 days, enforced as a hard ceiling)
- `FORECAST_RESOLUTION_JUDGE_ARCHIVE_HASH_LIMIT` (default 15,000)

## Validation

- `npm run test:data`: 14,552 passed, 6 skipped, 0 failed
- Focused resolver and batch-reader suites: 62 passed, 0 failed
- `npm run typecheck:all`: passed
- `npm run lint`: passed; only existing repository warnings/info were reported
- `VITE_VARIANT=full vite build`: passed, including dashboard critical-CSS checks
- Pre-push gate: passed typechecks, boundaries, safe HTML, rate-limit policy, premium-fetch parity, edge bundle checks, changed tests, and version sync
- Multi-persona code review and follow-up: all actionable findings applied; no residual findings

## Post-deploy monitoring and validation

Owner: forecast service on-call / repository maintainer. Observe the first manual seed-service deployment through the first judged deadlines around 2026-07-14.

Healthy signals:

- `forecast:scorecard:v1.pendingJudge` falls as due judged entries terminate, while `scored` and `void` rise.
- Scorecard-watch M2 fires on the first judged resolution.
- Resolver runs remain within `FORECAST_RESOLUTION_JUDGE_RUN_BUDGET_MS` without repeated `judged archive unavailable` or archive-budget errors.
- Covered disagreements and no-evidence cases terminate directly rather than accumulating `judge_retry_exhausted` outcomes.

Failure signals and response:

- If judged `voidRate` rises above roughly 40%, preserve the receipts and investigate judge agreement/evidence quality before considering a tiebreaker follow-up.
- If archive timeouts or run-budget exhaustion repeat, reduce the evidence pool or tune the bounded timeout/hash limit, then redeploy.
- Roll back this commit's service deployment if pending judged entries or forced-VOID behavior regress.

The `seed-forecast-resolutions` service still requires a manual Railway deployment after merge because its automatic deploy is blocked by the existing `checkSuites` skip. Use the established `serviceInstanceDeployV2` followed by `deploymentInstanceExecutionCreate` flow documented in #5062; this PR does not deploy or merge the service.

Fixes #5183

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
