### PR TITLE
feat(mcp-apps): expand interactive widget fleet 5 → 10 (#4956)

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -220,6 +220,41 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/ui/news-intelligence-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/news-intelligence.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/conflict-events-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/conflict-events.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/natural-disasters-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/natural-disasters.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/prediction-markets-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/prediction-markets.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/ui/forecasts-app.ts",
+      "category": "external-protocol",
+      "reason": "MCP Apps (io.modelcontextprotocol/ui) self-contained HTML app shell served verbatim as the ui://worldmonitor/forecasts.html resource. Exports an HTML string constant (no HTTP handler); the postMessage bridge protocol is dictated by the MCP Apps spec. Same external-protocol constraint as the ui/registry.ts it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp-proxy.ts",
       "category": "external-protocol",
       "reason": "Proxy for the MCP transport — same shape constraint as api/mcp.ts. Renamed .js → .ts in PR #3768 to unlock the isCallerPremium import from server/.",

--- a/api/mcp/constants.ts
+++ b/api/mcp/constants.ts
@@ -280,9 +280,22 @@ export const SERVER_NAME = 'worldmonitor';
 //   - Purely additive on the wire: `_meta` appears on the four newly-linked
 //     tools; every ui:// read is anonymously servable. No input/output schema
 //     change to any tool, no envelope-shape change, no auth change.
+// Bumped 1.14.0 → 1.15.0 (2026-07-10) reflecting:
+//   - MCP Apps interactive-dashboard fleet expansion 5 → 10: five new ui://
+//     app-shell resources joining the existing fleet —
+//       * ui://worldmonitor/news-intelligence.html  (get_news_intelligence)
+//       * ui://worldmonitor/conflict-events.html     (get_conflict_events)
+//       * ui://worldmonitor/natural-disasters.html   (get_natural_disasters)
+//       * ui://worldmonitor/prediction-markets.html  (get_prediction_markets)
+//       * ui://worldmonitor/forecasts.html           (get_forecast_predictions)
+//     Each renders through the shared shell (api/mcp/ui/shell.ts) and links from
+//     its backing cache tool via `_meta.ui.resourceUri`. Purely additive: `_meta`
+//     appears on five newly-linked tools; every ui:// read stays anonymously
+//     servable, quota-exempt, and data-free. No input/output schema, envelope,
+//     or auth change.
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-export const SERVER_VERSION = '1.14.0';
+export const SERVER_VERSION = '1.15.0';
 
 // MCP logging capability — valid severity levels per the 2025-03-26 spec
 // (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -23,7 +23,15 @@ import {
   selectDatasets,
 } from '../filters';
 import type { ToolDef } from '../types';
-import { CHOKEPOINT_MONITOR_UI_URI, MARKET_RADAR_UI_URI } from '../ui/registry';
+import {
+  CHOKEPOINT_MONITOR_UI_URI,
+  CONFLICT_EVENTS_UI_URI,
+  FORECASTS_UI_URI,
+  MARKET_RADAR_UI_URI,
+  NATURAL_DISASTERS_UI_URI,
+  NEWS_INTELLIGENCE_UI_URI,
+  PREDICTION_MARKETS_UI_URI,
+} from '../ui/registry';
 
 // Iran-events domain sunset (war ended 2026-07). Default OFF: drop the dormant
 // conflict:iran-events:v1 key from the get_conflict_events cache set so the MCP
@@ -171,6 +179,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   },
   {
     name: 'get_conflict_events',
+    _uiResourceUri: CONFLICT_EVENTS_UI_URI,
     _outputBudgetBytes: 131072,
     description: 'Active armed conflict events (UCDP, Iran), unrest events with geo-coordinates, and country risk scores. Covers ongoing conflicts, protests, and instability indices worldwide.',
     inputSchema: {
@@ -320,6 +329,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   },
   {
     name: 'get_news_intelligence',
+    _uiResourceUri: NEWS_INTELLIGENCE_UI_URI,
     _outputBudgetBytes: 131072,
     description: 'AI-classified geopolitical threat news summaries, GDELT intelligence signals, cross-source signals, and security advisories from WorldMonitor\'s intelligence layer.',
     inputSchema: {
@@ -397,6 +407,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   },
   {
     name: 'get_natural_disasters',
+    _uiResourceUri: NATURAL_DISASTERS_UI_URI,
     _outputBudgetBytes: 131072,
     description: 'Recent earthquakes (USGS), active wildfires (NASA FIRMS), and natural hazard events. Includes magnitude, location, and threat severity.',
     inputSchema: {
@@ -863,6 +874,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   },
   {
     name: 'get_prediction_markets',
+    _uiResourceUri: PREDICTION_MARKETS_UI_URI,
     _outputBudgetBytes: 131072,
     description: 'Active Polymarket event contracts with current probabilities. Covers geopolitical, economic, and election prediction markets.',
     inputSchema: {
@@ -1755,6 +1767,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   },
   {
     name: 'get_forecast_predictions',
+    _uiResourceUri: FORECASTS_UI_URI,
     _outputBudgetBytes: 131072,
     description: 'AI-generated geopolitical and economic forecasts from WorldMonitor\'s predictive models. Covers upcoming risk events and probability assessments.',
     inputSchema: {

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -352,8 +352,13 @@ export const CACHE_TOOLS: ToolDef[] = [
         type: ['object', 'null'],
         properties: {
           topStories: { type: 'array', items: { type: 'object', properties: {
-            title: { type: 'string' }, category: { type: 'string' }, countryCode: { type: 'string' },
-            isAlert: { type: 'boolean' }, summary: { type: 'string' },
+            primaryTitle: { type: 'string' }, primarySource: { type: 'string' }, primaryLink: { type: 'string' },
+            pubDate: { type: 'string' }, sourceCount: { type: 'number' }, importanceScore: { type: 'number' },
+            velocity: { type: 'object', properties: {
+              level: { type: 'string' }, sourcesPerHour: { type: 'number' },
+            } },
+            category: { type: 'string' }, threatLevel: { type: 'string' },
+            countryCode: { type: ['string', 'null'] }, isAlert: { type: 'boolean' },
           } } },
         },
       },
@@ -429,8 +434,13 @@ export const CACHE_TOOLS: ToolDef[] = [
         type: ['object', 'null'],
         properties: {
           earthquakes: { type: 'array', items: { type: 'object', properties: {
-            magnitude: { type: 'number' }, place: { type: 'string' }, time: { type: ['number', 'string'] },
-            latitude: { type: 'number' }, longitude: { type: 'number' }, depth: { type: 'number' },
+            id: { type: 'string' }, place: { type: 'string' }, magnitude: { type: 'number' },
+            depthKm: { type: 'number' }, occurredAt: { type: 'number' }, sourceUrl: { type: 'string' },
+            location: { type: 'object', properties: {
+              latitude: { type: 'number' }, longitude: { type: 'number' },
+            } },
+            nearTestSite: { type: 'boolean' }, testSiteName: { type: 'string' },
+            concernScore: { type: 'number' }, concernLevel: { type: 'string' },
           } } },
         },
       },
@@ -438,8 +448,17 @@ export const CACHE_TOOLS: ToolDef[] = [
         type: ['object', 'null'],
         properties: {
           fireDetections: { type: 'array', items: { type: 'object', properties: {
-            latitude: { type: 'number' }, longitude: { type: 'number' },
-            brightness: { type: 'number' }, confidence: { type: ['number', 'string'] },
+            id: { type: 'string' },
+            location: { type: 'object', properties: {
+              latitude: { type: 'number' }, longitude: { type: 'number' },
+            } },
+            brightness: { type: 'number' }, frp: { type: 'number' },
+            confidence: { type: 'string', enum: [
+              'FIRE_CONFIDENCE_HIGH', 'FIRE_CONFIDENCE_NOMINAL',
+              'FIRE_CONFIDENCE_LOW', 'FIRE_CONFIDENCE_UNSPECIFIED',
+            ] },
+            satellite: { type: 'string' }, detectedAt: { type: 'number' }, region: { type: 'string' },
+            dayNight: { type: 'string' }, possibleExplosion: { type: 'boolean' },
           } } },
         },
       },
@@ -895,9 +914,21 @@ export const CACHE_TOOLS: ToolDef[] = [
       'markets-bootstrap': {
         type: ['object', 'null'],
         properties: {
-          geopolitical: { type: 'array', items: { type: 'object', properties: { title: { type: 'string' }, source: { type: 'string' }, probability: { type: 'number' } } } },
-          tech:         { type: 'array', items: { type: 'object', properties: { title: { type: 'string' }, source: { type: 'string' }, probability: { type: 'number' } } } },
-          finance:      { type: 'array', items: { type: 'object', properties: { title: { type: 'string' }, source: { type: 'string' }, probability: { type: 'number' } } } },
+          geopolitical: { type: 'array', items: { type: 'object', properties: {
+            title: { type: 'string' }, yesPrice: { type: 'number', minimum: 0, maximum: 100 },
+            source: { type: 'string' }, volume: { type: 'number' }, url: { type: 'string' },
+            endDate: { type: 'string' }, regions: { type: 'array', items: { type: 'string' } },
+          } } },
+          tech: { type: 'array', items: { type: 'object', properties: {
+            title: { type: 'string' }, yesPrice: { type: 'number', minimum: 0, maximum: 100 },
+            source: { type: 'string' }, volume: { type: 'number' }, url: { type: 'string' },
+            endDate: { type: 'string' }, regions: { type: 'array', items: { type: 'string' } },
+          } } },
+          finance: { type: 'array', items: { type: 'object', properties: {
+            title: { type: 'string' }, yesPrice: { type: 'number', minimum: 0, maximum: 100 },
+            source: { type: 'string' }, volume: { type: 'number' }, url: { type: 'string' },
+            endDate: { type: 'string' }, regions: { type: 'array', items: { type: 'string' } },
+          } } },
         },
       },
     }),

--- a/api/mcp/ui/conflict-events-app.ts
+++ b/api/mcp/ui/conflict-events-app.ts
@@ -1,0 +1,91 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_conflict_events` tool: an active armed-
+// conflict / unrest event list rendering the UCDP events (belligerents, violence
+// type, country, fatalities, date). Built on the shared shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       "ucdp-events": { events: [{ sideA, sideB, violenceType, country,
+//                                   deathsBest, dateStart, location{latitude,longitude} }] },
+//       "iran-events": { events: [...] },   // sunset, usually absent
+//       events: { ... } } }                 // unrest bundle
+// Any label may be absent (country / min_fatalities filters narrow the bundle).
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .evt { display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+    padding: 9px 0; border-bottom: 1px solid var(--border); }
+  .evt:last-child { border-bottom: none; }
+  .evt-main { min-width: 0; }
+  .evt-sides { font-size: 13px; font-weight: 600; color: var(--fg); }
+  .evt-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
+  .evt-deaths { font-variant-numeric: tabular-nums; font-size: 12px; font-weight: 600; white-space: nowrap; }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">Conflict Events</div>
+    <div class="badge">WorldMonitor Conflict</div>
+  </div>
+  <div class="empty" id="empty">Waiting for conflict data…</div>
+  <div id="card" style="display:none">
+    <div id="list"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var uc = d["ucdp-events"] && typeof d["ucdp-events"] === "object" ? d["ucdp-events"] : null;
+    var evs = uc && Array.isArray(uc.events) ? uc.events : [];
+    var host = q("list");
+    host.textContent = "";
+    for (var i = 0; i < evs.length && i < 14; i++) {
+      var ev = evs[i];
+      if (!ev || typeof ev !== "object") continue;
+      var row = el("div", "evt");
+      var main = el("div", "evt-main");
+      var a = collapseWs(ev.sideA);
+      var b = collapseWs(ev.sideB);
+      var sides = a && b ? a + " vs " + b : (a || b || collapseWs(ev.violenceType) || "Event");
+      main.appendChild(el("div", "evt-sides", sides));
+      var metaParts = [];
+      var ct = collapseWs(ev.country);
+      if (ct) metaParts.push(ct);
+      var vt = collapseWs(ev.violenceType);
+      if (vt && a && b) metaParts.push(vt);
+      var dv = ev.dateStart;
+      var dt = dv != null ? new Date(typeof dv === "number" ? dv : String(dv)) : null;
+      if (dt && !isNaN(dt.getTime())) metaParts.push(dt.toISOString().slice(0, 10));
+      main.appendChild(el("div", "evt-meta", metaParts.join(" · ")));
+      row.appendChild(main);
+      var deaths = num(ev.deathsBest);
+      if (deaths != null) {
+        var badge = el("span", "evt-deaths", deaths.toLocaleString() + (deaths === 1 ? " death" : " deaths"));
+        var col = deaths >= 100 ? cssVar("--severe") : (deaths >= 10 ? cssVar("--high") : (deaths >= 1 ? cssVar("--moderate") : cssVar("--muted")));
+        badge.style.color = col || "";
+        row.appendChild(badge);
+      }
+      host.appendChild(row);
+    }
+    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No conflict events available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const CONFLICT_EVENTS_APP_HTML = buildAppHtml({
+  title: 'Conflict Events — WorldMonitor',
+  appName: 'worldmonitor-conflict-events',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/conflict-events-app.ts
+++ b/api/mcp/ui/conflict-events-app.ts
@@ -1,15 +1,19 @@
 // MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
 // interactive app shell for the `get_conflict_events` tool: an active armed-
-// conflict / unrest event list rendering the UCDP events (belligerents, violence
-// type, country, fatalities, date). Built on the shared shell foundation.
+// conflict event list rendering the UCDP events (belligerents, violence type,
+// country, fatalities, date). Built on the shared shell foundation.
 //
-// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope).
+// The tool serves the raw UCDP cache value under label `ucdp-events`; each event
+// carries `violenceType` as a UCDP_VIOLENCE_TYPE_* enum constant (see
+// scripts/seed-ucdp-events.mjs), mapped here to a human label:
 //   { cached_at, stale, data: {
 //       "ucdp-events": { events: [{ sideA, sideB, violenceType, country,
-//                                   deathsBest, dateStart, location{latitude,longitude} }] },
-//       "iran-events": { events: [...] },   // sunset, usually absent
-//       events: { ... } } }                 // unrest bundle
-// Any label may be absent (country / min_fatalities filters narrow the bundle).
+//                                   deathsBest, dateStart }] },
+//       events: {...}, scores: {...} } }  // unrest + CII buckets (not rendered here)
+// The tool also returns unrest `events` and CII `scores` buckets in its text
+// response; this widget focuses on the UCDP armed-conflict feed. Any label may
+// be absent (country / min_fatalities filters narrow the bundle).
 //
 // textContent-only rendering; renderBody stays backtick/`${`/regex-free.
 
@@ -45,6 +49,11 @@ const RENDER = `
 
     var uc = d["ucdp-events"] && typeof d["ucdp-events"] === "object" ? d["ucdp-events"] : null;
     var evs = uc && Array.isArray(uc.events) ? uc.events : [];
+    var vtMap = {
+      UCDP_VIOLENCE_TYPE_STATE_BASED: "State-based",
+      UCDP_VIOLENCE_TYPE_NON_STATE: "Non-state",
+      UCDP_VIOLENCE_TYPE_ONE_SIDED: "One-sided"
+    };
     var host = q("list");
     host.textContent = "";
     for (var i = 0; i < evs.length && i < 14; i++) {
@@ -54,12 +63,12 @@ const RENDER = `
       var main = el("div", "evt-main");
       var a = collapseWs(ev.sideA);
       var b = collapseWs(ev.sideB);
-      var sides = a && b ? a + " vs " + b : (a || b || collapseWs(ev.violenceType) || "Event");
+      var vt = vtMap[collapseWs(ev.violenceType)] || "";
+      var sides = a && b ? a + " vs " + b : (a || b || vt || "Event");
       main.appendChild(el("div", "evt-sides", sides));
       var metaParts = [];
       var ct = collapseWs(ev.country);
       if (ct) metaParts.push(ct);
-      var vt = collapseWs(ev.violenceType);
       if (vt && a && b) metaParts.push(vt);
       var dv = ev.dateStart;
       var dt = dv != null ? new Date(typeof dv === "number" ? dv : String(dv)) : null;
@@ -69,8 +78,8 @@ const RENDER = `
       var deaths = num(ev.deathsBest);
       if (deaths != null) {
         var badge = el("span", "evt-deaths", deaths.toLocaleString() + (deaths === 1 ? " death" : " deaths"));
-        var col = deaths >= 100 ? cssVar("--severe") : (deaths >= 10 ? cssVar("--high") : (deaths >= 1 ? cssVar("--moderate") : cssVar("--muted")));
-        badge.style.color = col || "";
+        var dcol = deaths >= 100 ? cssVar("--severe") : (deaths >= 10 ? cssVar("--high") : (deaths >= 1 ? cssVar("--moderate") : cssVar("--muted")));
+        badge.style.color = dcol || "";
         row.appendChild(badge);
       }
       host.appendChild(row);

--- a/api/mcp/ui/conflict-events-app.ts
+++ b/api/mcp/ui/conflict-events-app.ts
@@ -48,7 +48,8 @@ const RENDER = `
     q("card").style.display = "block";
 
     var uc = d["ucdp-events"] && typeof d["ucdp-events"] === "object" ? d["ucdp-events"] : null;
-    var evs = uc && Array.isArray(uc.events) ? uc.events : [];
+    var eventState = listState(uc && uc.events);
+    var evs = eventState.items;
     var vtMap = {
       UCDP_VIOLENCE_TYPE_STATE_BASED: "State-based",
       UCDP_VIOLENCE_TYPE_NON_STATE: "Non-state",
@@ -84,7 +85,11 @@ const RENDER = `
       }
       host.appendChild(row);
     }
-    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No conflict events available."));
+    if (!host.childNodes.length) {
+      host.appendChild(el("div", "empty", eventState.available
+        ? "No conflict events available."
+        : "Conflict event data is temporarily unavailable."));
+    }
 
     q("foot").textContent = data.cached_at
       ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")

--- a/api/mcp/ui/forecasts-app.ts
+++ b/api/mcp/ui/forecasts-app.ts
@@ -3,13 +3,16 @@
 // AI-generated geopolitical/economic forecasts as probability cards (title,
 // domain + region, probability bar). Built on the shared shell foundation.
 //
-// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope).
+// The tool serves the raw `forecast:predictions:v2` cache value under label
+// `predictions`; items carry `probability` as a 0-1 fraction (see
+// src/components/ForecastPanel.ts):
 //   { cached_at, stale, data: {
 //       predictions: { predictions: [{ title, domain, region, probability }] } } }
-// probability is nullable (render "—" and hide the bar when absent) and a 0-1
-// fraction (tolerated as 0-100 defensively). This widget renders forecast titles
-// and probabilities ONLY — no calibration / Brier / scorecard claims (that is the
-// get_forecast_scorecard tool's domain, guarded elsewhere).
+// probability is nullable (render "—" and hide the bar when absent). This widget
+// renders forecast titles and probabilities ONLY — no calibration / Brier /
+// scorecard claims (that is the get_forecast_scorecard tool's domain, guarded
+// elsewhere).
 //
 // textContent-only rendering; renderBody stays backtick/`${`/regex-free.
 
@@ -24,8 +27,6 @@ const STYLES = `
   .fc-meta { margin-top: 3px; display: flex; gap: 6px; flex-wrap: wrap; }
   .chip { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
     border: 1px solid var(--border); border-radius: 999px; padding: 1px 7px; }
-  .pbar { height: 6px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 6px; }
-  .pbar > span { display: block; height: 100%; width: 0%; background: var(--accent); }
 `;
 
 const BODY = `
@@ -66,13 +67,8 @@ const RENDER = `
       var reg = collapseWs(p.region);
       if (reg) meta.appendChild(el("span", "chip", reg));
       if (meta.childNodes.length) fc.appendChild(meta);
-      if (pct != null) {
-        var bar = el("div", "pbar");
-        var fill = el("span");
-        fill.style.width = clampPct(pct) + "%";
-        bar.appendChild(fill);
-        fc.appendChild(bar);
-      }
+      var bar = probabilityBar(pct);
+      if (bar) fc.appendChild(bar);
       host.appendChild(fc);
     }
     if (!host.childNodes.length) host.appendChild(el("div", "empty", "No forecasts available."));

--- a/api/mcp/ui/forecasts-app.ts
+++ b/api/mcp/ui/forecasts-app.ts
@@ -48,7 +48,7 @@ const RENDER = `
     q("card").style.display = "block";
 
     var node = d.predictions && typeof d.predictions === "object" ? d.predictions : null;
-    var preds = node && Array.isArray(node.predictions) ? node.predictions : [];
+    var preds = listState(node && node.predictions).items;
     var host = q("list");
     host.textContent = "";
     for (var i = 0; i < preds.length && i < 12; i++) {

--- a/api/mcp/ui/forecasts-app.ts
+++ b/api/mcp/ui/forecasts-app.ts
@@ -1,0 +1,91 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_forecast_predictions` tool: WorldMonitor's
+// AI-generated geopolitical/economic forecasts as probability cards (title,
+// domain + region, probability bar). Built on the shared shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       predictions: { predictions: [{ title, domain, region, probability }] } } }
+// probability is nullable (render "—" and hide the bar when absent) and a 0-1
+// fraction (tolerated as 0-100 defensively). This widget renders forecast titles
+// and probabilities ONLY — no calibration / Brier / scorecard claims (that is the
+// get_forecast_scorecard tool's domain, guarded elsewhere).
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .fc { padding: 8px 0; border-bottom: 1px solid var(--border); }
+  .fc:last-child { border-bottom: none; }
+  .fc-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .fc-title { font-size: 13px; color: var(--fg); min-width: 0; }
+  .fc-prob { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 13px; white-space: nowrap; }
+  .fc-meta { margin-top: 3px; display: flex; gap: 6px; flex-wrap: wrap; }
+  .chip { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+    border: 1px solid var(--border); border-radius: 999px; padding: 1px 7px; }
+  .pbar { height: 6px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 6px; }
+  .pbar > span { display: block; height: 100%; width: 0%; background: var(--accent); }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">Forecasts</div>
+    <div class="badge">WorldMonitor Forecasts</div>
+  </div>
+  <div class="empty" id="empty">Waiting for forecasts…</div>
+  <div id="card" style="display:none">
+    <div id="list"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var node = d.predictions && typeof d.predictions === "object" ? d.predictions : null;
+    var preds = node && Array.isArray(node.predictions) ? node.predictions : [];
+    var host = q("list");
+    host.textContent = "";
+    for (var i = 0; i < preds.length && i < 12; i++) {
+      var p = preds[i];
+      if (!p || typeof p !== "object") continue;
+      var fc = el("div", "fc");
+      var head = el("div", "fc-head");
+      head.appendChild(el("span", "fc-title", collapseWs(p.title) || "Forecast"));
+      var pr = num(p.probability);
+      var pct = pr == null ? null : (pr <= 1 ? pr * 100 : pr);
+      head.appendChild(el("span", "fc-prob", pct == null ? "—" : Math.round(pct) + "%"));
+      fc.appendChild(head);
+      var meta = el("div", "fc-meta");
+      var dom = collapseWs(p.domain);
+      if (dom) meta.appendChild(el("span", "chip", dom));
+      var reg = collapseWs(p.region);
+      if (reg) meta.appendChild(el("span", "chip", reg));
+      if (meta.childNodes.length) fc.appendChild(meta);
+      if (pct != null) {
+        var bar = el("div", "pbar");
+        var fill = el("span");
+        fill.style.width = clampPct(pct) + "%";
+        bar.appendChild(fill);
+        fc.appendChild(bar);
+      }
+      host.appendChild(fc);
+    }
+    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No forecasts available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const FORECASTS_APP_HTML = buildAppHtml({
+  title: 'Forecasts — WorldMonitor',
+  appName: 'worldmonitor-forecasts',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/natural-disasters-app.ts
+++ b/api/mcp/ui/natural-disasters-app.ts
@@ -1,0 +1,105 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_natural_disasters` tool: a hazard board
+// grouping recent earthquakes (USGS) and active wildfires (NASA FIRMS). Built on
+// the shared shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       earthquakes: { earthquakes: [{ magnitude, place, time, latitude, longitude, depth }] },
+//       fires: { fireDetections: [{ latitude, longitude, brightness, confidence }] } } }
+// Any dataset may be absent (dataset / min_magnitude / active_only filters narrow it).
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .dgroup { margin-top: 14px; }
+  .dgroup:first-child { margin-top: 4px; }
+  .sec-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin-bottom: 6px; }
+  .drow { display: flex; align-items: baseline; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--border); }
+  .drow:last-child { border-bottom: none; }
+  .mag { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 13px; min-width: 42px; }
+  .dplace { flex: 1; font-size: 13px; color: var(--fg); min-width: 0; }
+  .dtime { font-size: 11px; color: var(--muted); white-space: nowrap; }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">Natural Disasters</div>
+    <div class="badge">WorldMonitor Hazards</div>
+  </div>
+  <div class="empty" id="empty">Waiting for hazard data…</div>
+  <div id="card" style="display:none">
+    <div id="groups"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var host = q("groups");
+    host.textContent = "";
+
+    var quakeNode = d.earthquakes && typeof d.earthquakes === "object" ? d.earthquakes : null;
+    var quakes = quakeNode && Array.isArray(quakeNode.earthquakes) ? quakeNode.earthquakes : [];
+    if (quakes.length) {
+      var sec = el("div", "dgroup");
+      sec.appendChild(el("div", "sec-label", "Earthquakes"));
+      for (var i = 0; i < quakes.length && i < 8; i++) {
+        var eq = quakes[i];
+        if (!eq || typeof eq !== "object") continue;
+        var row = el("div", "drow");
+        var m = num(eq.magnitude);
+        var mag = el("span", "mag", m == null ? "—" : "M" + m.toFixed(1));
+        var col = m == null ? cssVar("--muted") : (m >= 6 ? cssVar("--severe") : (m >= 5 ? cssVar("--high") : (m >= 4 ? cssVar("--moderate") : cssVar("--low"))));
+        mag.style.color = col || "";
+        row.appendChild(mag);
+        row.appendChild(el("span", "dplace", collapseWs(eq.place) || "Unknown location"));
+        var tv = eq.time;
+        var dt = tv != null ? new Date(typeof tv === "number" ? tv : String(tv)) : null;
+        row.appendChild(el("span", "dtime", dt && !isNaN(dt.getTime()) ? dt.toISOString().slice(0, 10) : ""));
+        sec.appendChild(row);
+      }
+      host.appendChild(sec);
+    }
+
+    var fireNode = d.fires && typeof d.fires === "object" ? d.fires : null;
+    var fires = fireNode && Array.isArray(fireNode.fireDetections) ? fireNode.fireDetections : [];
+    if (fires.length) {
+      var fsec = el("div", "dgroup");
+      fsec.appendChild(el("div", "sec-label", "Active Wildfires (" + fires.length + ")"));
+      for (var k = 0; k < fires.length && k < 6; k++) {
+        var fr = fires[k];
+        if (!fr || typeof fr !== "object") continue;
+        var frow = el("div", "drow");
+        var conf = collapseWs(fr.confidence);
+        frow.appendChild(el("span", "mag", conf ? conf : "fire"));
+        var lat = num(fr.latitude);
+        var lng = num(fr.longitude);
+        frow.appendChild(el("span", "dplace", lat != null && lng != null ? lat.toFixed(2) + ", " + lng.toFixed(2) : "detection"));
+        var bright = num(fr.brightness);
+        frow.appendChild(el("span", "dtime", bright != null ? "brightness " + Math.round(bright) : ""));
+        fsec.appendChild(frow);
+      }
+      host.appendChild(fsec);
+    }
+
+    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No natural-hazard events available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const NATURAL_DISASTERS_APP_HTML = buildAppHtml({
+  title: 'Natural Disasters — WorldMonitor',
+  appName: 'worldmonitor-natural-disasters',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/natural-disasters-app.ts
+++ b/api/mcp/ui/natural-disasters-app.ts
@@ -52,7 +52,8 @@ const RENDER = `
     host.textContent = "";
 
     var quakeNode = d.earthquakes && typeof d.earthquakes === "object" ? d.earthquakes : null;
-    var quakes = quakeNode && Array.isArray(quakeNode.earthquakes) ? quakeNode.earthquakes : [];
+    var quakeState = listState(quakeNode && quakeNode.earthquakes);
+    var quakes = quakeState.items;
     if (quakes.length) {
       var sec = el("div", "dgroup");
       sec.appendChild(el("div", "sec-label", "Earthquakes"));
@@ -72,10 +73,16 @@ const RENDER = `
         sec.appendChild(row);
       }
       host.appendChild(sec);
+    } else if (!quakeState.available) {
+      var quakeMissing = el("div", "dgroup");
+      quakeMissing.appendChild(el("div", "sec-label", "Earthquakes"));
+      quakeMissing.appendChild(el("div", "empty", "Earthquake data is temporarily unavailable."));
+      host.appendChild(quakeMissing);
     }
 
     var fireNode = d.fires && typeof d.fires === "object" ? d.fires : null;
-    var fires = fireNode && Array.isArray(fireNode.fireDetections) ? fireNode.fireDetections : [];
+    var fireState = listState(fireNode && fireNode.fireDetections);
+    var fires = fireState.items;
     if (fires.length) {
       var fsec = el("div", "dgroup");
       var fireShown = Math.min(fires.length, 6);
@@ -104,6 +111,11 @@ const RENDER = `
         fsec.appendChild(frow);
       }
       host.appendChild(fsec);
+    } else if (!fireState.available) {
+      var fireMissing = el("div", "dgroup");
+      fireMissing.appendChild(el("div", "sec-label", "Active Wildfires"));
+      fireMissing.appendChild(el("div", "empty", "Wildfire data is temporarily unavailable."));
+      host.appendChild(fireMissing);
     }
 
     if (!host.childNodes.length) host.appendChild(el("div", "empty", "No natural-hazard events available."));

--- a/api/mcp/ui/natural-disasters-app.ts
+++ b/api/mcp/ui/natural-disasters-app.ts
@@ -3,11 +3,17 @@
 // grouping recent earthquakes (USGS) and active wildfires (NASA FIRMS). Built on
 // the shared shell foundation.
 //
-// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope).
+// The tool serves the raw seed cache values under labels `earthquakes` / `fires`
+// (see scripts/seed-earthquakes.mjs, scripts/seed-fire-detections.mjs):
 //   { cached_at, stale, data: {
-//       earthquakes: { earthquakes: [{ magnitude, place, time, latitude, longitude, depth }] },
-//       fires: { fireDetections: [{ latitude, longitude, brightness, confidence }] } } }
-// Any dataset may be absent (dataset / min_magnitude / active_only filters narrow it).
+//       earthquakes: { earthquakes: [{ place, magnitude, occurredAt (epoch-ms),
+//                                      location:{latitude,longitude} }] },
+//       fires: { fireDetections: [{ location:{latitude,longitude}, brightness,
+//                                   confidence: "FIRE_CONFIDENCE_*", region }] } } }
+// Timestamp is `occurredAt` (not `time`); fire lat/lng are nested under
+// `location`; fire `confidence` is a FIRE_CONFIDENCE_* enum constant. Any dataset
+// may be absent (dataset / min_magnitude / active_only filters narrow it).
 //
 // textContent-only rendering; renderBody stays backtick/`${`/regex-free.
 
@@ -19,7 +25,7 @@ const STYLES = `
   .sec-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin-bottom: 6px; }
   .drow { display: flex; align-items: baseline; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--border); }
   .drow:last-child { border-bottom: none; }
-  .mag { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 13px; min-width: 42px; }
+  .mag { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 13px; min-width: 52px; }
   .dplace { flex: 1; font-size: 13px; color: var(--fg); min-width: 0; }
   .dtime { font-size: 11px; color: var(--muted); white-space: nowrap; }
 `;
@@ -60,7 +66,7 @@ const RENDER = `
         mag.style.color = col || "";
         row.appendChild(mag);
         row.appendChild(el("span", "dplace", collapseWs(eq.place) || "Unknown location"));
-        var tv = eq.time;
+        var tv = eq.occurredAt;
         var dt = tv != null ? new Date(typeof tv === "number" ? tv : String(tv)) : null;
         row.appendChild(el("span", "dtime", dt && !isNaN(dt.getTime()) ? dt.toISOString().slice(0, 10) : ""));
         sec.appendChild(row);
@@ -73,15 +79,22 @@ const RENDER = `
     if (fires.length) {
       var fsec = el("div", "dgroup");
       fsec.appendChild(el("div", "sec-label", "Active Wildfires (" + fires.length + ")"));
+      var confMap = {
+        FIRE_CONFIDENCE_HIGH: "High",
+        FIRE_CONFIDENCE_NOMINAL: "Nominal",
+        FIRE_CONFIDENCE_LOW: "Low"
+      };
       for (var k = 0; k < fires.length && k < 6; k++) {
         var fr = fires[k];
         if (!fr || typeof fr !== "object") continue;
         var frow = el("div", "drow");
-        var conf = collapseWs(fr.confidence);
-        frow.appendChild(el("span", "mag", conf ? conf : "fire"));
-        var lat = num(fr.latitude);
-        var lng = num(fr.longitude);
-        frow.appendChild(el("span", "dplace", lat != null && lng != null ? lat.toFixed(2) + ", " + lng.toFixed(2) : "detection"));
+        var confLabel = confMap[collapseWs(fr.confidence)] || "";
+        frow.appendChild(el("span", "mag", confLabel || "Fire"));
+        var loc = fr.location && typeof fr.location === "object" ? fr.location : null;
+        var lat = loc ? num(loc.latitude) : null;
+        var lng = loc ? num(loc.longitude) : null;
+        var place = collapseWs(fr.region) || (lat != null && lng != null ? lat.toFixed(2) + ", " + lng.toFixed(2) : "detection");
+        frow.appendChild(el("span", "dplace", place));
         var bright = num(fr.brightness);
         frow.appendChild(el("span", "dtime", bright != null ? "brightness " + Math.round(bright) : ""));
         fsec.appendChild(frow);

--- a/api/mcp/ui/natural-disasters-app.ts
+++ b/api/mcp/ui/natural-disasters-app.ts
@@ -78,13 +78,17 @@ const RENDER = `
     var fires = fireNode && Array.isArray(fireNode.fireDetections) ? fireNode.fireDetections : [];
     if (fires.length) {
       var fsec = el("div", "dgroup");
-      fsec.appendChild(el("div", "sec-label", "Active Wildfires (" + fires.length + ")"));
+      var fireShown = Math.min(fires.length, 6);
+      var fireLabel = fires.length > fireShown
+        ? "Active Wildfires (" + fireShown + " of " + fires.length + ")"
+        : "Active Wildfires (" + fires.length + ")";
+      fsec.appendChild(el("div", "sec-label", fireLabel));
       var confMap = {
         FIRE_CONFIDENCE_HIGH: "High",
         FIRE_CONFIDENCE_NOMINAL: "Nominal",
         FIRE_CONFIDENCE_LOW: "Low"
       };
-      for (var k = 0; k < fires.length && k < 6; k++) {
+      for (var k = 0; k < fireShown; k++) {
         var fr = fires[k];
         if (!fr || typeof fr !== "object") continue;
         var frow = el("div", "drow");

--- a/api/mcp/ui/news-intelligence-app.ts
+++ b/api/mcp/ui/news-intelligence-app.ts
@@ -49,7 +49,8 @@ const RENDER = `
     q("card").style.display = "block";
 
     var ins = d.insights && typeof d.insights === "object" ? d.insights : null;
-    var stories = ins && Array.isArray(ins.topStories) ? ins.topStories : [];
+    var storyState = listState(ins && ins.topStories);
+    var stories = storyState.items;
     var host = q("list");
     host.textContent = "";
     for (var i = 0; i < stories.length && i < 12; i++) {
@@ -68,7 +69,11 @@ const RENDER = `
       if (src) row.appendChild(el("div", "story-src", src));
       host.appendChild(row);
     }
-    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No news stories available."));
+    if (!host.childNodes.length) {
+      host.appendChild(el("div", "empty", storyState.available
+        ? "No news stories available."
+        : "News intelligence is temporarily unavailable."));
+    }
 
     q("foot").textContent = data.cached_at
       ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")

--- a/api/mcp/ui/news-intelligence-app.ts
+++ b/api/mcp/ui/news-intelligence-app.ts
@@ -1,0 +1,80 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_news_intelligence` tool: a compact news
+// radar rendering AI-classified top stories (title, category, alert flag,
+// country, summary) from WorldMonitor's intelligence layer. Built on the shared
+// shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       insights: { topStories: [{ title, category, countryCode, isAlert, summary }] },
+//       "gdelt-intel": { topics: [...] }, "cross-source-signals": { signals: [...] } } }
+// Any label may be absent (topic/category/country filters narrow the bundle).
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .story { padding: 10px 0; border-bottom: 1px solid var(--border); }
+  .story:last-child { border-bottom: none; }
+  .story-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+  .story-title { font-size: 14px; font-weight: 600; color: var(--fg); }
+  .chip { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+    border: 1px solid var(--border); border-radius: 999px; padding: 1px 7px; }
+  .chip.alert { color: #fff; background: var(--severe); border-color: var(--severe); font-weight: 600; }
+  .story-country { font-size: 11px; color: var(--muted); }
+  .story-sum { margin-top: 4px; font-size: 13px; color: var(--muted); line-height: 1.5; }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">News Intelligence</div>
+    <div class="badge">WorldMonitor Intelligence</div>
+  </div>
+  <div class="empty" id="empty">Waiting for news intelligence…</div>
+  <div id="card" style="display:none">
+    <div id="list"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var ins = d.insights && typeof d.insights === "object" ? d.insights : null;
+    var stories = ins && Array.isArray(ins.topStories) ? ins.topStories : [];
+    var host = q("list");
+    host.textContent = "";
+    for (var i = 0; i < stories.length && i < 12; i++) {
+      var s = stories[i];
+      if (!s || typeof s !== "object") continue;
+      var row = el("div", "story");
+      var head = el("div", "story-head");
+      head.appendChild(el("span", "story-title", collapseWs(s.title) || "Untitled"));
+      var cat = collapseWs(s.category);
+      if (cat) head.appendChild(el("span", "chip", cat));
+      if (s.isAlert === true) head.appendChild(el("span", "chip alert", "Alert"));
+      var cn = countryName(s.countryCode);
+      if (cn) head.appendChild(el("span", "story-country", cn));
+      row.appendChild(head);
+      var sum = collapseWs(s.summary);
+      if (sum) row.appendChild(el("div", "story-sum", sum));
+      host.appendChild(row);
+    }
+    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No news stories available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const NEWS_INTELLIGENCE_APP_HTML = buildAppHtml({
+  title: 'News Intelligence — WorldMonitor',
+  appName: 'worldmonitor-news-intelligence',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/news-intelligence-app.ts
+++ b/api/mcp/ui/news-intelligence-app.ts
@@ -1,13 +1,17 @@
 // MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
 // interactive app shell for the `get_news_intelligence` tool: a compact news
-// radar rendering AI-classified top stories (title, category, alert flag,
-// country, summary) from WorldMonitor's intelligence layer. Built on the shared
+// radar rendering AI-classified top stories (headline, category, alert flag,
+// country, source) from WorldMonitor's intelligence layer. Built on the shared
 // shell foundation.
 //
-// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope).
+// The tool serves the raw `news:insights:v1` cache value under label `insights`;
+// its topStories items are ServerInsightStory (see src/services/insights-loader.ts),
+// which use camelCase `primaryTitle` / `primarySource` (NOT `title`/`summary`):
 //   { cached_at, stale, data: {
-//       insights: { topStories: [{ title, category, countryCode, isAlert, summary }] },
-//       "gdelt-intel": { topics: [...] }, "cross-source-signals": { signals: [...] } } }
+//       insights: { topStories: [{ primaryTitle, primarySource, category,
+//                                  threatLevel, isAlert, countryCode }] },
+//       "gdelt-intel": {...}, "cross-source-signals": {...} } }
 // Any label may be absent (topic/category/country filters narrow the bundle).
 //
 // textContent-only rendering; renderBody stays backtick/`${`/regex-free.
@@ -23,7 +27,7 @@ const STYLES = `
     border: 1px solid var(--border); border-radius: 999px; padding: 1px 7px; }
   .chip.alert { color: #fff; background: var(--severe); border-color: var(--severe); font-weight: 600; }
   .story-country { font-size: 11px; color: var(--muted); }
-  .story-sum { margin-top: 4px; font-size: 13px; color: var(--muted); line-height: 1.5; }
+  .story-src { margin-top: 4px; font-size: 12px; color: var(--muted); }
 `;
 
 const BODY = `
@@ -53,15 +57,15 @@ const RENDER = `
       if (!s || typeof s !== "object") continue;
       var row = el("div", "story");
       var head = el("div", "story-head");
-      head.appendChild(el("span", "story-title", collapseWs(s.title) || "Untitled"));
+      head.appendChild(el("span", "story-title", collapseWs(s.primaryTitle) || "Untitled story"));
       var cat = collapseWs(s.category);
       if (cat) head.appendChild(el("span", "chip", cat));
       if (s.isAlert === true) head.appendChild(el("span", "chip alert", "Alert"));
       var cn = countryName(s.countryCode);
       if (cn) head.appendChild(el("span", "story-country", cn));
       row.appendChild(head);
-      var sum = collapseWs(s.summary);
-      if (sum) row.appendChild(el("div", "story-sum", sum));
+      var src = collapseWs(s.primarySource);
+      if (src) row.appendChild(el("div", "story-src", src));
       host.appendChild(row);
     }
     if (!host.childNodes.length) host.appendChild(el("div", "empty", "No news stories available."));

--- a/api/mcp/ui/prediction-markets-app.ts
+++ b/api/mcp/ui/prediction-markets-app.ts
@@ -1,0 +1,102 @@
+// MCP Apps (extension `io.modelcontextprotocol/ui`, spec 2026-01-26) — the
+// interactive app shell for the `get_prediction_markets` tool: active event-
+// contract odds grouped by category (geopolitical / tech / finance), each with a
+// probability bar. Built on the shared shell foundation.
+//
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+//   { cached_at, stale, data: {
+//       "markets-bootstrap": {
+//         geopolitical: [{ title, source, probability }],
+//         tech:         [{ title, source, probability }],
+//         finance:      [{ title, source, probability }] } } }
+// A bucket may be empty (category / query / source filters narrow the bundle).
+// probability is a 0-1 fraction (tolerated as 0-100 defensively). Odds are shown
+// as a percentage only — never dollar volume/liquidity.
+//
+// textContent-only rendering; renderBody stays backtick/`${`/regex-free.
+
+import { buildAppHtml } from './shell';
+
+const STYLES = `
+  .mgroup { margin-top: 14px; }
+  .mgroup:first-child { margin-top: 4px; }
+  .sec-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin-bottom: 6px; }
+  .mkt { padding: 7px 0; border-bottom: 1px solid var(--border); }
+  .mkt:last-child { border-bottom: none; }
+  .mkt-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .mkt-title { font-size: 13px; color: var(--fg); min-width: 0; }
+  .mkt-prob { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 13px; white-space: nowrap; }
+  .mkt-src { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); margin-top: 2px; }
+  .pbar { height: 6px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 5px; }
+  .pbar > span { display: block; height: 100%; width: 0%; background: var(--accent); }
+`;
+
+const BODY = `
+  <div class="head">
+    <div class="title">Prediction Markets</div>
+    <div class="badge">WorldMonitor Markets</div>
+  </div>
+  <div class="empty" id="empty">Waiting for market odds…</div>
+  <div id="card" style="display:none">
+    <div id="groups"></div>
+    <div class="foot" id="foot"></div>
+  </div>
+`;
+
+const RENDER = `
+    if (!data || typeof data !== "object") return;
+    var d = data.data && typeof data.data === "object" ? data.data : data;
+    q("empty").style.display = "none";
+    q("card").style.display = "block";
+
+    var mb = d["markets-bootstrap"] && typeof d["markets-bootstrap"] === "object" ? d["markets-bootstrap"] : null;
+    var buckets = [
+      { key: "geopolitical", label: "Geopolitical" },
+      { key: "tech", label: "Tech" },
+      { key: "finance", label: "Finance" }
+    ];
+    var host = q("groups");
+    host.textContent = "";
+    for (var g = 0; g < buckets.length; g++) {
+      var cfg = buckets[g];
+      var list = mb && Array.isArray(mb[cfg.key]) ? mb[cfg.key] : null;
+      if (!list || !list.length) continue;
+      var sec = el("div", "mgroup");
+      sec.appendChild(el("div", "sec-label", cfg.label));
+      for (var i = 0; i < list.length && i < 6; i++) {
+        var m = list[i];
+        if (!m || typeof m !== "object") continue;
+        var mkt = el("div", "mkt");
+        var head = el("div", "mkt-head");
+        head.appendChild(el("span", "mkt-title", collapseWs(m.title) || "Market"));
+        var p = num(m.probability);
+        var pct = p == null ? null : (p <= 1 ? p * 100 : p);
+        head.appendChild(el("span", "mkt-prob", pct == null ? "—" : Math.round(pct) + "%"));
+        mkt.appendChild(head);
+        if (pct != null) {
+          var bar = el("div", "pbar");
+          var fill = el("span");
+          fill.style.width = clampPct(pct) + "%";
+          bar.appendChild(fill);
+          mkt.appendChild(bar);
+        }
+        var src = collapseWs(m.source);
+        if (src) mkt.appendChild(el("div", "mkt-src", src));
+        sec.appendChild(mkt);
+      }
+      host.appendChild(sec);
+    }
+    if (!host.childNodes.length) host.appendChild(el("div", "empty", "No prediction markets available."));
+
+    q("foot").textContent = data.cached_at
+      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
+      : "";
+`;
+
+export const PREDICTION_MARKETS_APP_HTML = buildAppHtml({
+  title: 'Prediction Markets — WorldMonitor',
+  appName: 'worldmonitor-prediction-markets',
+  styles: STYLES,
+  body: BODY,
+  renderBody: RENDER,
+});

--- a/api/mcp/ui/prediction-markets-app.ts
+++ b/api/mcp/ui/prediction-markets-app.ts
@@ -3,15 +3,17 @@
 // contract odds grouped by category (geopolitical / tech / finance), each with a
 // probability bar. Built on the shared shell foundation.
 //
-// Tool result shape (cache tool — content[0].text JSON, freshness envelope):
+// Tool result shape (cache tool — content[0].text JSON, freshness envelope).
+// The tool serves the raw `prediction:markets-bootstrap:v1` cache value under
+// label `markets-bootstrap`; bucket items carry `yesPrice` (a 0-100 percentage,
+// see src/components/PredictionPanel.ts) — NOT `probability`:
 //   { cached_at, stale, data: {
 //       "markets-bootstrap": {
-//         geopolitical: [{ title, source, probability }],
-//         tech:         [{ title, source, probability }],
-//         finance:      [{ title, source, probability }] } } }
+//         geopolitical: [{ title, source, yesPrice }],
+//         tech:         [{ title, source, yesPrice }],
+//         finance:      [{ title, source, yesPrice }] } } }
 // A bucket may be empty (category / query / source filters narrow the bundle).
-// probability is a 0-1 fraction (tolerated as 0-100 defensively). Odds are shown
-// as a percentage only — never dollar volume/liquidity.
+// Odds are shown as a percentage only — never dollar volume/liquidity.
 //
 // textContent-only rendering; renderBody stays backtick/`${`/regex-free.
 
@@ -27,8 +29,6 @@ const STYLES = `
   .mkt-title { font-size: 13px; color: var(--fg); min-width: 0; }
   .mkt-prob { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 13px; white-space: nowrap; }
   .mkt-src { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); margin-top: 2px; }
-  .pbar { height: 6px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 5px; }
-  .pbar > span { display: block; height: 100%; width: 0%; background: var(--accent); }
 `;
 
 const BODY = `
@@ -69,17 +69,12 @@ const RENDER = `
         var mkt = el("div", "mkt");
         var head = el("div", "mkt-head");
         head.appendChild(el("span", "mkt-title", collapseWs(m.title) || "Market"));
-        var p = num(m.probability);
+        var p = num(m.yesPrice);
         var pct = p == null ? null : (p <= 1 ? p * 100 : p);
         head.appendChild(el("span", "mkt-prob", pct == null ? "—" : Math.round(pct) + "%"));
         mkt.appendChild(head);
-        if (pct != null) {
-          var bar = el("div", "pbar");
-          var fill = el("span");
-          fill.style.width = clampPct(pct) + "%";
-          bar.appendChild(fill);
-          mkt.appendChild(bar);
-        }
+        var bar = probabilityBar(pct);
+        if (bar) mkt.appendChild(bar);
         var src = collapseWs(m.source);
         if (src) mkt.appendChild(el("div", "mkt-src", src));
         sec.appendChild(mkt);

--- a/api/mcp/ui/prediction-markets-app.ts
+++ b/api/mcp/ui/prediction-markets-app.ts
@@ -59,7 +59,7 @@ const RENDER = `
     host.textContent = "";
     for (var g = 0; g < buckets.length; g++) {
       var cfg = buckets[g];
-      var list = mb && Array.isArray(mb[cfg.key]) ? mb[cfg.key] : null;
+      var list = listState(mb && mb[cfg.key]).items;
       if (!list || !list.length) continue;
       var sec = el("div", "mgroup");
       sec.appendChild(el("div", "sec-label", cfg.label));

--- a/api/mcp/ui/prediction-markets-app.ts
+++ b/api/mcp/ui/prediction-markets-app.ts
@@ -70,7 +70,7 @@ const RENDER = `
         var head = el("div", "mkt-head");
         head.appendChild(el("span", "mkt-title", collapseWs(m.title) || "Market"));
         var p = num(m.yesPrice);
-        var pct = p == null ? null : (p <= 1 ? p * 100 : p);
+        var pct = p == null ? null : p; // yesPrice is already a 0-100 percentage — no scaling
         head.appendChild(el("span", "mkt-prob", pct == null ? "—" : Math.round(pct) + "%"));
         mkt.appendChild(head);
         var bar = probabilityBar(pct);

--- a/api/mcp/ui/registry.ts
+++ b/api/mcp/ui/registry.ts
@@ -25,6 +25,11 @@ import { COUNTRY_RISK_APP_HTML } from './country-risk-app';
 import { MARKET_RADAR_APP_HTML } from './market-radar-app';
 import { buildUiMeta, UI_RESOURCE_MIME_TYPE as SHELL_UI_MIME_TYPE, type UiResourceMeta } from './shell';
 import { WORLD_BRIEF_APP_HTML } from './world-brief-app';
+import { NEWS_INTELLIGENCE_APP_HTML } from './news-intelligence-app';
+import { CONFLICT_EVENTS_APP_HTML } from './conflict-events-app';
+import { NATURAL_DISASTERS_APP_HTML } from './natural-disasters-app';
+import { PREDICTION_MARKETS_APP_HTML } from './prediction-markets-app';
+import { FORECASTS_APP_HTML } from './forecasts-app';
 
 // Re-exported from the shared shell so the mimeType has a single source of
 // truth across the fleet (the first widget defined it here in v1.11.0).
@@ -38,6 +43,11 @@ export const WORLD_BRIEF_UI_URI = 'ui://worldmonitor/world-brief.html';
 export const COUNTRY_BRIEF_UI_URI = 'ui://worldmonitor/country-brief.html';
 export const MARKET_RADAR_UI_URI = 'ui://worldmonitor/market-radar.html';
 export const CHOKEPOINT_MONITOR_UI_URI = 'ui://worldmonitor/chokepoint-monitor.html';
+export const NEWS_INTELLIGENCE_UI_URI = 'ui://worldmonitor/news-intelligence.html';
+export const CONFLICT_EVENTS_UI_URI = 'ui://worldmonitor/conflict-events.html';
+export const NATURAL_DISASTERS_UI_URI = 'ui://worldmonitor/natural-disasters.html';
+export const PREDICTION_MARKETS_UI_URI = 'ui://worldmonitor/prediction-markets.html';
+export const FORECASTS_UI_URI = 'ui://worldmonitor/forecasts.html';
 
 // Per-resource `_meta.ui` (ext-apps `UIResourceMeta`) is built by the shared
 // `buildUiMeta()` in ./shell — SINGLE source of truth for the fleet's CSP /
@@ -106,6 +116,51 @@ export const UI_RESOURCE_REGISTRY: UiResourceDef[] = [
     mimeType: UI_RESOURCE_MIME_TYPE,
     _meta: buildUiMeta(),
     html: CHOKEPOINT_MONITOR_APP_HTML,
+  },
+  {
+    uri: NEWS_INTELLIGENCE_UI_URI,
+    name: 'News Intelligence (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_news_intelligence: renders AI-classified top stories (title, category, alert flag, country, summary) from WorldMonitor\'s intelligence layer. Linked from the get_news_intelligence tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: NEWS_INTELLIGENCE_APP_HTML,
+  },
+  {
+    uri: CONFLICT_EVENTS_UI_URI,
+    name: 'Conflict Events (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_conflict_events: renders active armed-conflict and unrest events (belligerents, violence type, country, fatalities, date) from the UCDP feed. Linked from the get_conflict_events tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: CONFLICT_EVENTS_APP_HTML,
+  },
+  {
+    uri: NATURAL_DISASTERS_UI_URI,
+    name: 'Natural Disasters (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_natural_disasters: groups recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS). Linked from the get_natural_disasters tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: NATURAL_DISASTERS_APP_HTML,
+  },
+  {
+    uri: PREDICTION_MARKETS_UI_URI,
+    name: 'Prediction Markets (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_prediction_markets: renders active event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. Linked from the get_prediction_markets tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: PREDICTION_MARKETS_APP_HTML,
+  },
+  {
+    uri: FORECASTS_UI_URI,
+    name: 'Forecasts (interactive)',
+    description:
+      'Interactive in-conversation app shell for get_forecast_predictions: renders WorldMonitor\'s AI-generated geopolitical and economic forecasts as probability cards (title, domain, region). Linked from the get_forecast_predictions tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+    mimeType: UI_RESOURCE_MIME_TYPE,
+    _meta: buildUiMeta(),
+    html: FORECASTS_APP_HTML,
   },
 ];
 

--- a/api/mcp/ui/registry.ts
+++ b/api/mcp/ui/registry.ts
@@ -130,7 +130,7 @@ export const UI_RESOURCE_REGISTRY: UiResourceDef[] = [
     uri: CONFLICT_EVENTS_UI_URI,
     name: 'Conflict Events (interactive)',
     description:
-      'Interactive in-conversation app shell for get_conflict_events: renders active armed-conflict and unrest events (belligerents, violence type, country, fatalities, date) from the UCDP feed. Linked from the get_conflict_events tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+      'Interactive in-conversation app shell for get_conflict_events: renders active armed-conflict events (belligerents, violence type, country, fatalities, date) from the UCDP feed. Linked from the get_conflict_events tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
     mimeType: UI_RESOURCE_MIME_TYPE,
     _meta: buildUiMeta(),
     html: CONFLICT_EVENTS_APP_HTML,

--- a/api/mcp/ui/registry.ts
+++ b/api/mcp/ui/registry.ts
@@ -121,7 +121,7 @@ export const UI_RESOURCE_REGISTRY: UiResourceDef[] = [
     uri: NEWS_INTELLIGENCE_UI_URI,
     name: 'News Intelligence (interactive)',
     description:
-      'Interactive in-conversation app shell for get_news_intelligence: renders AI-classified top stories (title, category, alert flag, country, summary) from WorldMonitor\'s intelligence layer. Linked from the get_news_intelligence tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
+      'Interactive in-conversation app shell for get_news_intelligence: renders AI-classified top stories (title, category, alert flag, country, source) from WorldMonitor\'s intelligence layer. Linked from the get_news_intelligence tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.',
     mimeType: UI_RESOURCE_MIME_TYPE,
     _meta: buildUiMeta(),
     html: NEWS_INTELLIGENCE_APP_HTML,

--- a/api/mcp/ui/shell.ts
+++ b/api/mcp/ui/shell.ts
@@ -118,7 +118,7 @@ const SHARED_STYLE_TOKENS = `
 `;
 
 // The shared bridge + helper library. Injected once per shell. It exposes a
-// small helper set (q/num/clampPct/pctText/setText/el/cssVar) in closure scope
+// small helper set (q/num/listState/clampPct/pctText/setText/el/cssVar) in closure scope
 // that a widget's `renderBody` uses, then calls the widget-defined
 // `renderData(data)` on every tool-result. NOTE: no `${` / backtick here.
 const SHARED_BRIDGE_HEAD = `
@@ -135,7 +135,22 @@ const SHARED_BRIDGE_HEAD = `
 
   // ---- shared render helpers (widget renderBody uses these) ----
   function q(id) { return document.getElementById(id); }
-  function num(v) { var n = typeof v === "number" ? v : Number(v); return isFinite(n) ? n : null; }
+  function num(v) {
+    if (v == null) return null;
+    var n = typeof v === "number" ? v : Number(v);
+    return isFinite(n) ? n : null;
+  }
+  // Normalise both full array fields and summary:true fields shaped as
+  // { count, sample }. The available flag remains false for absent/null/malformed
+  // fields so widgets can distinguish a partial cache miss from a real empty
+  // array (including { count: 0, sample: [] }).
+  function listState(v) {
+    if (Array.isArray(v)) return { available: true, items: v };
+    if (v && typeof v === "object" && Array.isArray(v.sample)) {
+      return { available: true, items: v.sample };
+    }
+    return { available: false, items: [] };
+  }
   function clampPct(n) { return Math.max(0, Math.min(100, n)); }
   function setText(id, text) { var e = q(id); if (e) e.textContent = text == null ? "—" : String(text); }
   function el(tag, cls, text) {
@@ -325,7 +340,7 @@ export interface AppShellSpec {
   // empty-state + card elements.
   body: string;
   // JS body of `function renderData(data) { ... }`. Runs inside the shared
-  // bridge closure with access to q/num/setText/el/cssVar/pctText/clampPct/
+  // bridge closure with access to q/num/listState/setText/el/cssVar/pctText/clampPct/
   // levelFor/collapseWs/paragraphs/httpUrl/countryName/probabilityBar. MUST
   // avoid backticks and `${`.
   renderBody: string;

--- a/api/mcp/ui/shell.ts
+++ b/api/mcp/ui/shell.ts
@@ -113,6 +113,8 @@ const SHARED_STYLE_TOKENS = `
   .empty { color: var(--muted); padding: 8px 0; }
   .foot { margin-top: 14px; font-size: 11px; color: var(--muted); }
   a { color: var(--accent); text-decoration: none; }
+  .pbar { height: 6px; border-radius: 999px; background: var(--border); overflow: hidden; margin-top: 5px; }
+  .pbar > span { display: block; height: 100%; width: 0%; background: var(--accent); }
 `;
 
 // The shared bridge + helper library. Injected once per shell. It exposes a
@@ -141,6 +143,17 @@ const SHARED_BRIDGE_HEAD = `
     if (cls) e.className = cls;
     if (text != null) e.textContent = String(text);
     return e;
+  }
+  // Shared 0-100 probability bar: a .pbar node with a filled span, or null when
+  // pct is not a finite number. Callers pass an already-0-100 value and append
+  // the returned node under a market / forecast row.
+  function probabilityBar(pct) {
+    if (typeof pct !== "number" || !isFinite(pct)) return null;
+    var bar = el("div", "pbar");
+    var fill = el("span");
+    fill.style.width = clampPct(pct) + "%";
+    bar.appendChild(fill);
+    return bar;
   }
   function cssVar(name) {
     return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -313,7 +326,8 @@ export interface AppShellSpec {
   body: string;
   // JS body of `function renderData(data) { ... }`. Runs inside the shared
   // bridge closure with access to q/num/setText/el/cssVar/pctText/clampPct/
-  // levelFor. MUST avoid backticks and `${`.
+  // levelFor/collapseWs/paragraphs/httpUrl/countryName/probabilityBar. MUST
+  // avoid backticks and `${`.
   renderBody: string;
 }
 

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -129,7 +129,7 @@
         "uriConst": "NEWS_INTELLIGENCE_UI_URI",
         "uri": "ui://worldmonitor/news-intelligence.html",
         "name": "News Intelligence (interactive)",
-        "description": "Interactive in-conversation app shell for get_news_intelligence: renders AI-classified top stories (title, category, alert flag, country, summary) from WorldMonitor's intelligence layer. Linked from the get_news_intelligence tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "description": "Interactive in-conversation app shell for get_news_intelligence: renders AI-classified top stories (title, category, alert flag, country, source) from WorldMonitor's intelligence layer. Linked from the get_news_intelligence tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
         "tool": "get_news_intelligence"
       },
       {

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -124,6 +124,41 @@
         "name": "Chokepoint Monitor (interactive)",
         "description": "Interactive in-conversation app shell for get_chokepoint_status: renders per-chokepoint rolling transit summaries (today's transit count, week-over-week change, tanker split) with a risk-level badge. Linked from the get_chokepoint_status tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
         "tool": "get_chokepoint_status"
+      },
+      {
+        "uriConst": "NEWS_INTELLIGENCE_UI_URI",
+        "uri": "ui://worldmonitor/news-intelligence.html",
+        "name": "News Intelligence (interactive)",
+        "description": "Interactive in-conversation app shell for get_news_intelligence: renders AI-classified top stories (title, category, alert flag, country, summary) from WorldMonitor's intelligence layer. Linked from the get_news_intelligence tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_news_intelligence"
+      },
+      {
+        "uriConst": "CONFLICT_EVENTS_UI_URI",
+        "uri": "ui://worldmonitor/conflict-events.html",
+        "name": "Conflict Events (interactive)",
+        "description": "Interactive in-conversation app shell for get_conflict_events: renders active armed-conflict events (belligerents, violence type, country, fatalities, date) from the UCDP feed. Linked from the get_conflict_events tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_conflict_events"
+      },
+      {
+        "uriConst": "NATURAL_DISASTERS_UI_URI",
+        "uri": "ui://worldmonitor/natural-disasters.html",
+        "name": "Natural Disasters (interactive)",
+        "description": "Interactive in-conversation app shell for get_natural_disasters: groups recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS). Linked from the get_natural_disasters tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_natural_disasters"
+      },
+      {
+        "uriConst": "PREDICTION_MARKETS_UI_URI",
+        "uri": "ui://worldmonitor/prediction-markets.html",
+        "name": "Prediction Markets (interactive)",
+        "description": "Interactive in-conversation app shell for get_prediction_markets: renders active event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. Linked from the get_prediction_markets tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_prediction_markets"
+      },
+      {
+        "uriConst": "FORECASTS_UI_URI",
+        "uri": "ui://worldmonitor/forecasts.html",
+        "name": "Forecasts (interactive)",
+        "description": "Interactive in-conversation app shell for get_forecast_predictions: renders WorldMonitor's AI-generated geopolitical and economic forecasts as probability cards (title, domain, region). Linked from the get_forecast_predictions tool via _meta.ui.resourceUri; an MCP-Apps host renders it inline and streams the tool result in via postMessage. Static, data-free template — public and quota-exempt.",
+        "tool": "get_forecast_predictions"
       }
     ],
     "uiResources": [
@@ -131,14 +166,24 @@
       "ui://worldmonitor/world-brief.html",
       "ui://worldmonitor/country-brief.html",
       "ui://worldmonitor/market-radar.html",
-      "ui://worldmonitor/chokepoint-monitor.html"
+      "ui://worldmonitor/chokepoint-monitor.html",
+      "ui://worldmonitor/news-intelligence.html",
+      "ui://worldmonitor/conflict-events.html",
+      "ui://worldmonitor/natural-disasters.html",
+      "ui://worldmonitor/prediction-markets.html",
+      "ui://worldmonitor/forecasts.html"
     ],
     "linkedTools": [
       "get_country_risk",
       "get_world_brief",
       "get_country_brief",
       "get_market_data",
-      "get_chokepoint_status"
+      "get_chokepoint_status",
+      "get_news_intelligence",
+      "get_conflict_events",
+      "get_natural_disasters",
+      "get_prediction_markets",
+      "get_forecast_predictions"
     ],
     "toolLinks": [
       {
@@ -160,22 +205,52 @@
       {
         "tool": "get_chokepoint_status",
         "uri": "ui://worldmonitor/chokepoint-monitor.html"
+      },
+      {
+        "tool": "get_news_intelligence",
+        "uri": "ui://worldmonitor/news-intelligence.html"
+      },
+      {
+        "tool": "get_conflict_events",
+        "uri": "ui://worldmonitor/conflict-events.html"
+      },
+      {
+        "tool": "get_natural_disasters",
+        "uri": "ui://worldmonitor/natural-disasters.html"
+      },
+      {
+        "tool": "get_prediction_markets",
+        "uri": "ui://worldmonitor/prediction-markets.html"
+      },
+      {
+        "tool": "get_forecast_predictions",
+        "uri": "ui://worldmonitor/forecasts.html"
       }
     ]
   },
-  "mcpAppCount": 5,
+  "mcpAppCount": 10,
   "mcpAppUiResources": [
     "ui://worldmonitor/country-risk.html",
     "ui://worldmonitor/world-brief.html",
     "ui://worldmonitor/country-brief.html",
     "ui://worldmonitor/market-radar.html",
-    "ui://worldmonitor/chokepoint-monitor.html"
+    "ui://worldmonitor/chokepoint-monitor.html",
+    "ui://worldmonitor/news-intelligence.html",
+    "ui://worldmonitor/conflict-events.html",
+    "ui://worldmonitor/natural-disasters.html",
+    "ui://worldmonitor/prediction-markets.html",
+    "ui://worldmonitor/forecasts.html"
   ],
   "mcpAppLinkedTools": [
     "get_country_risk",
     "get_world_brief",
     "get_country_brief",
     "get_market_data",
-    "get_chokepoint_status"
+    "get_chokepoint_status",
+    "get_news_intelligence",
+    "get_conflict_events",
+    "get_natural_disasters",
+    "get_prediction_markets",
+    "get_forecast_predictions"
   ]
 }

--- a/docs/mcp-apps.mdx
+++ b/docs/mcp-apps.mdx
@@ -3,7 +3,7 @@ title: "MCP Apps"
 description: "Complete contract for WorldMonitor's MCP Apps interactive ui:// resources, tool links, host flow, security posture, and drift checks."
 ---
 
-WorldMonitor supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) through the `io.modelcontextprotocol/ui` extension. The current fleet ships 5 MCP Apps: self-contained `ui://` HTML resources that an MCP Apps host can render inline after a linked tool call.
+WorldMonitor supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) through the `io.modelcontextprotocol/ui` extension. The current fleet ships 10 MCP Apps: self-contained `ui://` HTML resources that an MCP Apps host can render inline after a linked tool call.
 
 This page is the source-of-truth guide for the interactive surface. Use it with the [MCP Server overview](/mcp-overview) for auth, quota, transport, and general JSON-RPC behavior.
 
@@ -36,6 +36,11 @@ Three discovery signals must stay aligned:
 | `ui://worldmonitor/country-brief.html` | `get_country_brief` | Country Brief (interactive) | Per-country intelligence brief, analytical framework lens, and grounding sources. |
 | `ui://worldmonitor/market-radar.html` | `get_market_data` | Market Radar (interactive) | Fear & Greed composite plus equity, commodity, crypto, Gulf, and sector quote tables with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Chokepoint Monitor (interactive) | Per-chokepoint transit summaries, week-over-week change, tanker split, and risk-level badge. |
+| `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | News Intelligence (interactive) | AI-classified top stories with category, alert flag, country, and summary. |
+| `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Conflict Events (interactive) | Active armed-conflict/unrest events (belligerents, violence type, country, fatalities, date) from UCDP. |
+| `ui://worldmonitor/natural-disasters.html` | `get_natural_disasters` | Natural Disasters (interactive) | Recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS), grouped. |
+| `ui://worldmonitor/prediction-markets.html` | `get_prediction_markets` | Prediction Markets (interactive) | Event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. |
+| `ui://worldmonitor/forecasts.html` | `get_forecast_predictions` | Forecasts (interactive) | AI-generated geopolitical and economic forecasts as probability cards (title, domain, region). |
 
 ## Runtime Flow
 

--- a/docs/mcp-apps.mdx
+++ b/docs/mcp-apps.mdx
@@ -37,7 +37,7 @@ Three discovery signals must stay aligned:
 | `ui://worldmonitor/market-radar.html` | `get_market_data` | Market Radar (interactive) | Fear & Greed composite plus equity, commodity, crypto, Gulf, and sector quote tables with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Chokepoint Monitor (interactive) | Per-chokepoint transit summaries, week-over-week change, tanker split, and risk-level badge. |
 | `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | News Intelligence (interactive) | AI-classified top stories with category, alert flag, country, and summary. |
-| `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Conflict Events (interactive) | Active armed-conflict/unrest events (belligerents, violence type, country, fatalities, date) from UCDP. |
+| `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Conflict Events (interactive) | Active armed-conflict events (belligerents, violence type, country, fatalities, date) from UCDP. |
 | `ui://worldmonitor/natural-disasters.html` | `get_natural_disasters` | Natural Disasters (interactive) | Recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS), grouped. |
 | `ui://worldmonitor/prediction-markets.html` | `get_prediction_markets` | Prediction Markets (interactive) | Event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. |
 | `ui://worldmonitor/forecasts.html` | `get_forecast_predictions` | Forecasts (interactive) | AI-generated geopolitical and economic forecasts as probability cards (title, domain, region). |

--- a/docs/mcp-apps.mdx
+++ b/docs/mcp-apps.mdx
@@ -36,7 +36,7 @@ Three discovery signals must stay aligned:
 | `ui://worldmonitor/country-brief.html` | `get_country_brief` | Country Brief (interactive) | Per-country intelligence brief, analytical framework lens, and grounding sources. |
 | `ui://worldmonitor/market-radar.html` | `get_market_data` | Market Radar (interactive) | Fear & Greed composite plus equity, commodity, crypto, Gulf, and sector quote tables with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Chokepoint Monitor (interactive) | Per-chokepoint transit summaries, week-over-week change, tanker split, and risk-level badge. |
-| `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | News Intelligence (interactive) | AI-classified top stories with category, alert flag, country, and summary. |
+| `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | News Intelligence (interactive) | AI-classified top stories with category, alert flag, country, and source. |
 | `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Conflict Events (interactive) | Active armed-conflict events (belligerents, violence type, country, fatalities, date) from UCDP. |
 | `ui://worldmonitor/natural-disasters.html` | `get_natural_disasters` | Natural Disasters (interactive) | Recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS), grouped. |
 | `ui://worldmonitor/prediction-markets.html` | `get_prediction_markets` | Prediction Markets (interactive) | Event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. |

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -412,7 +412,7 @@ The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/b
 | `ui://worldmonitor/market-radar.html` | `get_market_data` | The Fear & Greed composite plus per-asset-class quote tables (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Per-chokepoint rolling transit summaries (today's count, week-over-week change, tanker split) with a risk-level badge. |
 | `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | AI-classified top stories with category, alert flag, country, and summary. |
-| `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Active armed-conflict and unrest events (belligerents, violence type, country, fatalities, date) from the UCDP feed. |
+| `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Active armed-conflict events (belligerents, violence type, country, fatalities, date) from the UCDP feed. |
 | `ui://worldmonitor/natural-disasters.html` | `get_natural_disasters` | Recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS), grouped. |
 | `ui://worldmonitor/prediction-markets.html` | `get_prediction_markets` | Active event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. |
 | `ui://worldmonitor/forecasts.html` | `get_forecast_predictions` | AI-generated geopolitical and economic forecasts as probability cards (title, domain, region). |

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -411,7 +411,7 @@ The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/b
 | `ui://worldmonitor/country-brief.html` | `get_country_brief` | The AI-synthesised per-country brief as paragraphs, with the analytical framework lens and grounding sources. |
 | `ui://worldmonitor/market-radar.html` | `get_market_data` | The Fear & Greed composite plus per-asset-class quote tables (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Per-chokepoint rolling transit summaries (today's count, week-over-week change, tanker split) with a risk-level badge. |
-| `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | AI-classified top stories with category, alert flag, country, and summary. |
+| `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | AI-classified top stories with category, alert flag, country, and source. |
 | `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Active armed-conflict events (belligerents, violence type, country, fatalities, date) from the UCDP feed. |
 | `ui://worldmonitor/natural-disasters.html` | `get_natural_disasters` | Recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS), grouped. |
 | `ui://worldmonitor/prediction-markets.html` | `get_prediction_markets` | Active event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. |

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -28,7 +28,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
 | `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
-Server identifier: `worldmonitor` v1.14.0.
+Server identifier: `worldmonitor` v1.15.0.
 
 Registry listings: the server is published in the [official MCP registry](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) as `app.worldmonitor/mcp` — a domain-verified namespace, so clients that resolve servers through the registry get the same endpoint and metadata as the server card above — and listed on [Smithery](https://smithery.ai/servers/worldmonitor/wm-mcp) and [mcp.so](https://mcp.so/server/world-monitor).
 
@@ -411,6 +411,11 @@ The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/b
 | `ui://worldmonitor/country-brief.html` | `get_country_brief` | The AI-synthesised per-country brief as paragraphs, with the analytical framework lens and grounding sources. |
 | `ui://worldmonitor/market-radar.html` | `get_market_data` | The Fear & Greed composite plus per-asset-class quote tables (equities, commodities, crypto, Gulf, sectors) with signed, colour-coded change. |
 | `ui://worldmonitor/chokepoint-monitor.html` | `get_chokepoint_status` | Per-chokepoint rolling transit summaries (today's count, week-over-week change, tanker split) with a risk-level badge. |
+| `ui://worldmonitor/news-intelligence.html` | `get_news_intelligence` | AI-classified top stories with category, alert flag, country, and summary. |
+| `ui://worldmonitor/conflict-events.html` | `get_conflict_events` | Active armed-conflict and unrest events (belligerents, violence type, country, fatalities, date) from the UCDP feed. |
+| `ui://worldmonitor/natural-disasters.html` | `get_natural_disasters` | Recent earthquakes (USGS magnitude, place, time) and active wildfires (NASA FIRMS), grouped. |
+| `ui://worldmonitor/prediction-markets.html` | `get_prediction_markets` | Active event-contract odds grouped by category (geopolitical, tech, finance) with a probability bar per market. |
+| `ui://worldmonitor/forecasts.html` | `get_forecast_predictions` | AI-generated geopolitical and economic forecasts as probability cards (title, domain, region). |
 
 All UI resources share `mimeType: text/html;profile=mcp-app`.
 

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -257,9 +257,14 @@
         "ui://worldmonitor/world-brief.html",
         "ui://worldmonitor/country-brief.html",
         "ui://worldmonitor/market-radar.html",
-        "ui://worldmonitor/chokepoint-monitor.html"
+        "ui://worldmonitor/chokepoint-monitor.html",
+        "ui://worldmonitor/news-intelligence.html",
+        "ui://worldmonitor/conflict-events.html",
+        "ui://worldmonitor/natural-disasters.html",
+        "ui://worldmonitor/prediction-markets.html",
+        "ui://worldmonitor/forecasts.html"
       ],
-      "note": "MCP Apps support: tools with an interactive surface carry `_meta.ui.resourceUri` (get_country_risk → country-risk.html, get_world_brief → world-brief.html, get_country_brief → country-brief.html, get_market_data → market-radar.html, get_chokepoint_status → chokepoint-monitor.html). Issue `resources/list` to enumerate ui:// app shells and `resources/read` to fetch them — ui:// reads are public + quota-exempt (static, data-free templates); live data reaches the shell via host postMessage after a normal tools/call."
+      "note": "MCP Apps support: tools with an interactive surface carry `_meta.ui.resourceUri` (get_country_risk → country-risk.html, get_world_brief → world-brief.html, get_country_brief → country-brief.html, get_market_data → market-radar.html, get_chokepoint_status → chokepoint-monitor.html, get_news_intelligence → news-intelligence.html, get_conflict_events → conflict-events.html, get_natural_disasters → natural-disasters.html, get_prediction_markets → prediction-markets.html, get_forecast_predictions → forecasts.html). Issue `resources/list` to enumerate ui:// app shells and `resources/read` to fetch them — ui:// reads are public + quota-exempt (static, data-free templates); live data reaches the shell via host postMessage after a normal tools/call."
     }
   },
   "features": {

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -3,12 +3,12 @@
   "kind": "product",
   "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
   "icon": "https://www.worldmonitor.app/favico/apple-touch-icon.png",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "url": "https://worldmonitor.app/mcp",
   "serverUrl": "https://worldmonitor.app/mcp",
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"

--- a/public/mcp-server.md
+++ b/public/mcp-server.md
@@ -16,13 +16,18 @@ The server ships **40 tools** covering world and country briefs, country risk an
 
 ## MCP Apps
 
-World Monitor supports MCP Apps (`io.modelcontextprotocol/ui`) with five interactive `ui://` app shells. The linked tools are `get_country_risk`, `get_world_brief`, `get_country_brief`, `get_market_data`, and `get_chokepoint_status`; their UI resources are:
+World Monitor supports MCP Apps (`io.modelcontextprotocol/ui`) with ten interactive `ui://` app shells. The linked tools are `get_country_risk`, `get_world_brief`, `get_country_brief`, `get_market_data`, `get_chokepoint_status`, `get_news_intelligence`, `get_conflict_events`, `get_natural_disasters`, `get_prediction_markets`, and `get_forecast_predictions`; their UI resources are:
 
 - `ui://worldmonitor/country-risk.html`
 - `ui://worldmonitor/world-brief.html`
 - `ui://worldmonitor/country-brief.html`
 - `ui://worldmonitor/market-radar.html`
 - `ui://worldmonitor/chokepoint-monitor.html`
+- `ui://worldmonitor/news-intelligence.html`
+- `ui://worldmonitor/conflict-events.html`
+- `ui://worldmonitor/natural-disasters.html`
+- `ui://worldmonitor/prediction-markets.html`
+- `ui://worldmonitor/forecasts.html`
 
 Hosts discover the links through `_meta.ui.resourceUri` in `tools/list`, enumerate the shells through `resources/list`, and fetch each template with `resources/read`. `ui://` reads are public and quota-exempt because they return static, data-free HTML; live data still arrives through a normal authenticated `tools/call`. Full contract: [MCP Apps](https://www.worldmonitor.app/docs/mcp-apps).
 

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/koala73/worldmonitor",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.15.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,12 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.14.0"', async () => {
+    it('serverInfo.version === "1.15.0"', async () => {
       // Tracks current SERVER_VERSION. Each minor bump needs to update
       // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.14.0');
+      assert.equal(body.result?.serverInfo?.version, '1.15.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -326,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (currently 1.14.0)', () => {
+    it('server-card.json version matches SERVER_VERSION (currently 1.15.0)', () => {
       // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.14.0');
+      assert.equal(card.serverInfo.version, '1.15.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 

--- a/tests/mcp-output-schema-coverage.test.mjs
+++ b/tests/mcp-output-schema-coverage.test.mjs
@@ -102,6 +102,52 @@ describe('api/mcp.ts — per-tool outputSchema coverage (v1.7.0)', () => {
     });
   }
 
+  it('interactive cache-tool schemas declare the authoritative fields consumed by their apps', () => {
+    const dataProperties = (toolName) => {
+      const tool = mod.__testing__.TOOL_REGISTRY.find(t => t.name === toolName);
+      assert.ok(tool, `tool ${toolName} not found in registry`);
+      return tool.outputSchema.properties.data.properties;
+    };
+
+    const newsStory = dataProperties('get_news_intelligence').insights.properties.topStories.items.properties;
+    assert.ok(newsStory.primaryTitle, 'news schema must declare primaryTitle');
+    assert.ok(newsStory.primarySource, 'news schema must declare primarySource');
+    assert.ok(newsStory.threatLevel, 'news schema must declare threatLevel');
+    assert.deepEqual(newsStory.countryCode.type, ['string', 'null']);
+    assert.equal(newsStory.title, undefined, 'news schema must not advertise the drifted title field');
+    assert.equal(newsStory.summary, undefined, 'news schema must not advertise the drifted summary field');
+
+    const disasters = dataProperties('get_natural_disasters');
+    const earthquake = disasters.earthquakes.properties.earthquakes.items.properties;
+    assert.ok(earthquake.occurredAt, 'earthquake schema must declare occurredAt');
+    assert.ok(earthquake.depthKm, 'earthquake schema must declare depthKm');
+    assert.ok(earthquake.location.properties.latitude, 'earthquake latitude must be nested under location');
+    assert.equal(earthquake.time, undefined, 'earthquake schema must not advertise the drifted time field');
+    assert.equal(earthquake.latitude, undefined, 'earthquake schema must not advertise a flat latitude');
+
+    const fire = disasters.fires.properties.fireDetections.items.properties;
+    assert.ok(fire.location.properties.longitude, 'fire longitude must be nested under location');
+    assert.ok(fire.region, 'fire schema must declare region');
+    assert.deepEqual(fire.confidence.enum, [
+      'FIRE_CONFIDENCE_HIGH',
+      'FIRE_CONFIDENCE_NOMINAL',
+      'FIRE_CONFIDENCE_LOW',
+      'FIRE_CONFIDENCE_UNSPECIFIED',
+    ]);
+    assert.equal(fire.latitude, undefined, 'fire schema must not advertise a flat latitude');
+
+    const markets = dataProperties('get_prediction_markets')['markets-bootstrap'].properties;
+    for (const bucket of ['geopolitical', 'tech', 'finance']) {
+      const market = markets[bucket].items.properties;
+      assert.deepEqual(
+        { type: market.yesPrice.type, minimum: market.yesPrice.minimum, maximum: market.yesPrice.maximum },
+        { type: 'number', minimum: 0, maximum: 100 },
+        `${bucket} must declare yesPrice on its authoritative 0-100 scale`,
+      );
+      assert.equal(market.probability, undefined, `${bucket} must not advertise the drifted probability field`);
+    }
+  });
+
   // --------------------------------------------------------------------
   // Test 3 — outputSchema is emitted on the wire for every tool in tools/list
   // --------------------------------------------------------------------

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -252,6 +252,11 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       'ui://worldmonitor/country-brief.html',
       'ui://worldmonitor/market-radar.html',
       'ui://worldmonitor/chokepoint-monitor.html',
+      'ui://worldmonitor/news-intelligence.html',
+      'ui://worldmonitor/conflict-events.html',
+      'ui://worldmonitor/natural-disasters.html',
+      'ui://worldmonitor/prediction-markets.html',
+      'ui://worldmonitor/forecasts.html',
     ], 'resources/list = concrete DATA freshness probe then the ui:// app-shell fleet, in registry order');
     for (const r of body.result.resources) {
       assert.equal(typeof r.uri, 'string', `resource ${r.uri}: uri must be a string`);
@@ -469,6 +474,11 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       'ui://worldmonitor/country-brief.html',
       'ui://worldmonitor/market-radar.html',
       'ui://worldmonitor/chokepoint-monitor.html',
+      'ui://worldmonitor/news-intelligence.html',
+      'ui://worldmonitor/conflict-events.html',
+      'ui://worldmonitor/natural-disasters.html',
+      'ui://worldmonitor/prediction-markets.html',
+      'ui://worldmonitor/forecasts.html',
     ];
     for (const uri of shellWidgets) {
       const res = await handler(envKeyReq(readBody(uri)));

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -23,6 +23,7 @@ import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import vm from 'node:vm';
 
 import {
   BASE_URL,
@@ -62,6 +63,118 @@ function anonReq(body, headers = {}) {
 // resources/read JSON-RPC body factory.
 function readBody(uri, id = 100) {
   return { jsonrpc: '2.0', id, method: 'resources/read', params: { uri } };
+}
+
+// Execute a served MCP App shell without pulling a browser-DOM dependency into
+// the Edge/API test surface. The widgets only need a deliberately small DOM:
+// id lookup, textContent, appendChild, style, theme attributes, and height
+// reporting. Keeping innerHTML as a throwing setter turns the harness into an
+// executable injection guard rather than another source-regex assertion.
+function mountWidgetHtml(html) {
+  class TestElement {
+    constructor(tagName, id = '') {
+      this.tagName = String(tagName).toUpperCase();
+      this.id = id;
+      this.className = '';
+      this.childNodes = [];
+      this.style = {};
+      this.attributes = {};
+      this._text = '';
+    }
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    }
+    set textContent(value) {
+      this._text = value == null ? '' : String(value);
+      this.childNodes = [];
+    }
+    get textContent() {
+      return this._text + this.childNodes.map((child) => child.textContent).join('');
+    }
+    set innerHTML(_value) {
+      throw new Error('widget renderers must not write innerHTML');
+    }
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+    }
+    getBoundingClientRect() {
+      return { height: 240 };
+    }
+  }
+
+  const byId = new Map();
+  for (const match of html.matchAll(/<([a-z][a-z0-9-]*)\b[^>]*\bid="([^"]+)"[^>]*>/gi)) {
+    byId.set(match[2], new TestElement(match[1], match[2]));
+  }
+  const created = [];
+  const documentElement = new TestElement('html');
+  const document = {
+    documentElement,
+    getElementById: (id) => byId.get(id) ?? null,
+    createElement: (tag) => {
+      const node = new TestElement(tag);
+      created.push(node);
+      return node;
+    },
+  };
+  const listeners = new Map();
+  const posted = [];
+  const parent = { postMessage: (message) => posted.push(message) };
+  const window = {
+    parent,
+    addEventListener: (type, listener) => listeners.set(type, listener),
+    matchMedia: () => ({ matches: false }),
+  };
+  const context = {
+    window,
+    document,
+    URL,
+    Intl,
+    Date,
+    Math,
+    Number,
+    String,
+    Object,
+    Array,
+    JSON,
+    isFinite,
+    isNaN,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  };
+  const script = html.match(/<script>([\s\S]*)<\/script>/i)?.[1];
+  assert.ok(script, 'served widget HTML must contain an executable script');
+  vm.runInNewContext(script, context, { timeout: 1_000 });
+  assert.equal(typeof listeners.get('message'), 'function', 'widget must register its host message listener');
+
+  return {
+    posted,
+    sendToolResult(structuredContent) {
+      listeners.get('message')({
+        source: parent,
+        data: {
+          jsonrpc: '2.0',
+          method: 'ui/notifications/tool-result',
+          params: { result: { structuredContent } },
+        },
+      });
+    },
+    text(id) {
+      return byId.get(id)?.textContent ?? '';
+    },
+    nodes(id) {
+      const root = byId.get(id);
+      const result = [];
+      const visit = (node) => {
+        if (!node) return;
+        result.push(node);
+        node.childNodes.forEach(visit);
+      };
+      visit(root);
+      return result;
+    },
+    created,
+  };
 }
 
 // Mock fetch covering every read path the four resources can touch:
@@ -491,6 +604,216 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       // blank/empty-success dashboard renders before the error is caught.
       assert.match(html, /softError\(data\)[\s\S]*renderData\(data\)/,
         `${uri}: safeRender must check softError(data) before calling renderData(data)`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Execute the five expansion widgets against real host tool-result messages.
+  // Static shell checks cannot catch field-name drift or the dispatcher's
+  // `summary:true` array shape ({ count, sample }), because both failures still
+  // leave perfectly valid-looking HTML and bridge source behind.
+  // -------------------------------------------------------------------------
+  it('EXPANSION WIDGETS: execute authoritative payloads and summary samples for all five renderers', async () => {
+    const cases = [
+      {
+        uri: 'ui://worldmonitor/news-intelligence.html',
+        hostId: 'list',
+        raw: { data: { insights: { topStories: [{
+          primaryTitle: 'Port disruption expands', primarySource: 'WorldMonitor Wire',
+          category: 'security', threatLevel: 'high', isAlert: true, countryCode: 'DE',
+        }] } } },
+        summary: { data: { insights: { topStories: { count: 1, sample: [{
+          primaryTitle: 'Summary news headline', primarySource: 'Summary Wire', category: 'politics',
+        }] } } } },
+        rawTokens: [/Port disruption expands/, /WorldMonitor Wire/, /Alert/, /Germany/],
+        summaryTokens: [/Summary news headline/, /Summary Wire/],
+      },
+      {
+        uri: 'ui://worldmonitor/conflict-events.html',
+        hostId: 'list',
+        raw: { data: { 'ucdp-events': { events: [{
+          sideA: 'Government forces', sideB: 'Armed group', country: 'Sudan',
+          violenceType: 'UCDP_VIOLENCE_TYPE_STATE_BASED', dateStart: '2026-07-01', deathsBest: 12,
+        }] } } },
+        summary: { data: { 'ucdp-events': { events: { count: 1, sample: [{
+          sideA: 'Summary side A', sideB: 'Summary side B', country: 'Lebanon', deathsBest: 3,
+        }] } } } },
+        rawTokens: [/Government forces vs Armed group/, /Sudan/, /State-based/, /12 deaths/],
+        summaryTokens: [/Summary side A vs Summary side B/, /Lebanon/, /3 deaths/],
+      },
+      {
+        uri: 'ui://worldmonitor/natural-disasters.html',
+        hostId: 'groups',
+        raw: { data: {
+          earthquakes: { earthquakes: [{ magnitude: 5.4, place: 'Aegean Sea', occurredAt: '2026-07-02T00:00:00Z' }] },
+          fires: { fireDetections: [{
+            confidence: 'FIRE_CONFIDENCE_HIGH', region: 'Attica', brightness: 337,
+            location: { latitude: 37.98, longitude: 23.72 },
+          }] },
+        } },
+        summary: { data: {
+          earthquakes: { earthquakes: { count: 1, sample: [{ magnitude: 4.8, place: 'Summary quake', occurredAt: 1_784_000_000_000 }] } },
+          fires: { fireDetections: { count: 1, sample: [{
+            confidence: 'FIRE_CONFIDENCE_NOMINAL', region: 'Summary fire', brightness: 301,
+            location: { latitude: 1, longitude: 2 },
+          }] } },
+        } },
+        rawTokens: [/Earthquakes/, /M5\.4/, /Aegean Sea/, /Active Wildfires \(1\)/, /High/, /Attica/, /brightness 337/],
+        summaryTokens: [/M4\.8/, /Summary quake/, /Nominal/, /Summary fire/, /brightness 301/],
+      },
+      {
+        uri: 'ui://worldmonitor/prediction-markets.html',
+        hostId: 'groups',
+        raw: { data: { 'markets-bootstrap': {
+          geopolitical: [{ title: 'Ceasefire by September?', yesPrice: 73, source: 'Polymarket' }],
+          tech: [], finance: [],
+        } } },
+        summary: { data: { 'markets-bootstrap': {
+          geopolitical: { count: 1, sample: [{ title: 'Summary market?', yesPrice: 61, source: 'Kalshi' }] },
+          tech: { count: 0, sample: [] }, finance: { count: 0, sample: [] },
+        } } },
+        rawTokens: [/Ceasefire by September\?/, /73%/, /Polymarket/],
+        summaryTokens: [/Summary market\?/, /61%/, /Kalshi/],
+      },
+      {
+        uri: 'ui://worldmonitor/forecasts.html',
+        hostId: 'list',
+        raw: { data: { predictions: { predictions: [{
+          title: 'Oil remains above $70', probability: 0.42, domain: 'energy', region: 'Global',
+        }] } } },
+        summary: { data: { predictions: { predictions: { count: 1, sample: [{
+          title: 'Summary forecast', probability: 67, domain: 'economy', region: 'MENA',
+        }] } } } },
+        rawTokens: [/Oil remains above \$70/, /42%/, /energy/, /Global/],
+        summaryTokens: [/Summary forecast/, /67%/, /economy/, /MENA/],
+      },
+    ];
+
+    for (const entry of cases) {
+      const res = await handler(envKeyReq(readBody(entry.uri)));
+      const html = (await res.json()).result.contents[0].text;
+      const rawView = mountWidgetHtml(html);
+      rawView.sendToolResult(entry.raw);
+      const rawText = rawView.text(entry.hostId);
+      for (const token of entry.rawTokens) assert.match(rawText, token, `${entry.uri}: authoritative payload token ${token}`);
+
+      const summaryView = mountWidgetHtml(html);
+      summaryView.sendToolResult(entry.summary);
+      const summaryText = summaryView.text(entry.hostId);
+      for (const token of entry.summaryTokens) assert.match(summaryText, token, `${entry.uri}: summary sample token ${token}`);
+    }
+  });
+
+  it('EXPANSION WIDGETS: probability nulls remain unknown and visual ranges clamp safely', async () => {
+    const payloads = [
+      {
+        uri: 'ui://worldmonitor/prediction-markets.html', hostId: 'groups',
+        payload: { data: { 'markets-bootstrap': { geopolitical: [
+          { title: 'Unknown market', yesPrice: null },
+          { title: 'Low outlier', yesPrice: -5 },
+          { title: 'High outlier', yesPrice: 130 },
+        ] } } },
+      },
+      {
+        uri: 'ui://worldmonitor/forecasts.html', hostId: 'list',
+        payload: { data: { predictions: { predictions: [
+          { title: 'Unknown forecast', probability: null },
+          { title: 'Fraction forecast', probability: 0.25 },
+          { title: 'High forecast', probability: 140 },
+        ] } } },
+      },
+    ];
+    for (const entry of payloads) {
+      const res = await handler(envKeyReq(readBody(entry.uri)));
+      const view = mountWidgetHtml((await res.json()).result.contents[0].text);
+      view.sendToolResult(entry.payload);
+      const text = view.text(entry.hostId);
+      assert.match(text, /Unknown (market|forecast)—/, `${entry.uri}: null probability must render as unknown`);
+      assert.doesNotMatch(text, /Unknown (market|forecast)0%/, `${entry.uri}: null must not coerce to a definite zero`);
+      const widths = view.nodes(entry.hostId)
+        .filter((node) => node.tagName === 'SPAN' && typeof node.style.width === 'string')
+        .map((node) => node.style.width);
+      assert.ok(widths.includes('100%'), `${entry.uri}: probability bars must clamp values above 100`);
+      if (entry.uri.includes('prediction-markets')) assert.ok(widths.includes('0%'), `${entry.uri}: probability bars must clamp negative values to zero`);
+      else assert.ok(widths.includes('25%'), `${entry.uri}: fractional forecast probability must scale to 0-100`);
+    }
+  });
+
+  it('EXPANSION WIDGETS: hostile tool text stays literal textContent in all five renderers', async () => {
+    const hostile = '<img src=x onerror="globalThis.pwned=true">';
+    const cases = [
+      {
+        uri: 'ui://worldmonitor/news-intelligence.html', hostId: 'list',
+        payload: { data: { insights: { topStories: [{ primaryTitle: hostile, primarySource: hostile }] } } },
+      },
+      {
+        uri: 'ui://worldmonitor/conflict-events.html', hostId: 'list',
+        payload: { data: { 'ucdp-events': { events: [{ sideA: hostile, sideB: 'Other side' }] } } },
+      },
+      {
+        uri: 'ui://worldmonitor/natural-disasters.html', hostId: 'groups',
+        payload: { data: {
+          earthquakes: { earthquakes: [{ place: hostile, magnitude: 4, occurredAt: 0 }] },
+          fires: { fireDetections: [] },
+        } },
+      },
+      {
+        uri: 'ui://worldmonitor/prediction-markets.html', hostId: 'groups',
+        payload: { data: { 'markets-bootstrap': { geopolitical: [{ title: hostile, yesPrice: 50 }] } } },
+      },
+      {
+        uri: 'ui://worldmonitor/forecasts.html', hostId: 'list',
+        payload: { data: { predictions: { predictions: [{ title: hostile, probability: 0.5 }] } } },
+      },
+    ];
+
+    for (const entry of cases) {
+      const res = await handler(envKeyReq(readBody(entry.uri)));
+      const view = mountWidgetHtml((await res.json()).result.contents[0].text);
+      view.sendToolResult(entry.payload);
+      assert.match(view.text(entry.hostId), /<img src=x onerror="globalThis\.pwned=true">/,
+        `${entry.uri}: hostile markup must remain visible literal text`);
+      assert.equal(view.created.some((node) => node.tagName === 'IMG' || node.tagName === 'SCRIPT'), false,
+        `${entry.uri}: tool payload must not manufacture executable DOM nodes`);
+    }
+  });
+
+  it('MULTI-CACHE WIDGETS: missing labels show unavailable while present empty lists show genuine empty copy', async () => {
+    const cases = [
+      {
+        uri: 'ui://worldmonitor/news-intelligence.html', hostId: 'list',
+        missing: { data: { 'gdelt-intel': {} } },
+        empty: { data: { insights: { topStories: [] } } },
+        emptyCopy: /No news stories available\./,
+      },
+      {
+        uri: 'ui://worldmonitor/conflict-events.html', hostId: 'list',
+        missing: { data: { acled: {} } },
+        empty: { data: { 'ucdp-events': { events: [] } } },
+        emptyCopy: /No conflict events available\./,
+      },
+      {
+        uri: 'ui://worldmonitor/natural-disasters.html', hostId: 'groups',
+        missing: { data: { fires: { fireDetections: [] } } },
+        empty: { data: { earthquakes: { earthquakes: [] }, fires: { fireDetections: [] } } },
+        emptyCopy: /No natural-hazard events available\./,
+      },
+    ];
+
+    for (const entry of cases) {
+      const res = await handler(envKeyReq(readBody(entry.uri)));
+      const html = (await res.json()).result.contents[0].text;
+      const missingView = mountWidgetHtml(html);
+      missingView.sendToolResult(entry.missing);
+      const missingText = missingView.text(entry.hostId);
+      assert.match(missingText, /unavailable/i, `${entry.uri}: a missing cache label must be visibly unavailable`);
+      assert.doesNotMatch(missingText, entry.emptyCopy, `${entry.uri}: a cache miss must not masquerade as genuine empty data`);
+
+      const emptyView = mountWidgetHtml(html);
+      emptyView.sendToolResult(entry.empty);
+      const emptyText = emptyView.text(entry.hostId);
+      assert.match(emptyText, entry.emptyCopy, `${entry.uri}: a present empty list must retain genuine-empty copy`);
+      assert.doesNotMatch(emptyText, /unavailable/i, `${entry.uri}: genuine empty data must not be called unavailable`);
     }
   });
 

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -405,14 +405,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
     // ============================================================
     // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
     // ============================================================
-    it('serverInfo.version === "1.14.0"', async () => {
+    it('serverInfo.version === "1.15.0"', async () => {
       const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
       }));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.14.0');
+      assert.equal(body.result?.serverInfo?.version, '1.15.0');
     });
 
     it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
@@ -429,9 +429,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.14.0) AND tools[] length matches (40)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.15.0) AND tools[] length matches (40)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.14.0');
+      assert.equal(card.serverInfo.version, '1.15.0');
       // orank (ora.ai) agent-readiness scanner reads the card's `tools` as an
       // ARRAY (tools[]) for pre-connection preview — not the old {count,categories}
       // object. Keep it an array; the count now derives from the length.


### PR DESCRIPTION
## What

Expands the MCP Apps interactive `ui://` widget fleet **5 → 10** by adding five net-new data-card widgets, each built on the shared `buildAppHtml` shell and linked to its backing MCP tool:

| Widget | Backing tool | Renders |
|---|---|---|
| News Intelligence | `get_news_intelligence` | AI-classified top stories (headline, category, alert, country, source) |
| Conflict Events | `get_conflict_events` | UCDP armed-conflict events (belligerents, violence type, country, fatalities, date) |
| Natural Disasters | `get_natural_disasters` | USGS earthquakes + NASA FIRMS wildfires |
| Prediction Markets | `get_prediction_markets` | Event-contract odds by category with a probability bar |
| Forecasts | `get_forecast_predictions` | WorldMonitor probabilistic forecasts as probability cards |

Plus the docs, `server-card.json`, and version parity that reflect the larger fleet (MCP server bumped **1.14.0 → 1.15.0** across `SERVER_VERSION`, server-card, `server.json`, and version-pinned tests).

This is the first, self-contained PR toward #4956 (an app listed in the ChatGPT Apps marketplace). It deliberately does **not** add the OpenAI Apps-SDK `skybridge` markers, ChatGPT auth-linking, the homepage listing reference, or the review-gated submission — those are tracked in the follow-on #5198. A richer widget fleet is independently valuable for any MCP Apps host (ChatGPT, Claude, others).

Closes #4956 is **not** claimed — this is the widget/docs slice; #4956 stays open for the listing work (#5198).

## How it was built + reviewed

- Product definition resolved via a `/grill-me` session (artifact = Apps-SDK app on the existing `/mcp` server; hero surface incl. News, flagged critical). Plan: `docs/plans/2026-07-10-001-feat-mcp-apps-widgets-expansion-plan.md`.
- **Independent multi-model code review** (correctness + security + standards) caught that the initial widgets rendered fields from the *drifted* `outputSchema` docs rather than the real cached shape, plus two missing CI gates. All fixed in the third commit and re-verified — field names checked against the authoritative seed scripts + frontend consumers:
  - news `primaryTitle`/`primarySource` (not `title`/`summary`); prediction `yesPrice` (0-100, not `probability`); earthquake `occurredAt` (not `time`); fire `location.{lat,lng}` nested + `region`; `FIRE_CONFIDENCE_*` / `UCDP_VIOLENCE_TYPE_*` enums mapped to human labels
  - added `api/api-route-exceptions.json` entries for the 5 new files (`lint:api-contract`) and regenerated `docs/generated/stats.json` (`docs-stats`)
  - extracted a shared `probabilityBar()` helper into `shell.ts`
- Security review: clean — widgets are `textContent`-only, bounded loops, no untrusted `href`/`innerHTML`; they inherit the shell's `event.source` gate and 4-category CSP.

## Verification

- `tests/mcp-resources.test.mjs` (FLEET quality gate over all 10 shells + exact `deepEqual` fleet list + soft-error) and the version/parity/tools suites — green.
- `tsc --noEmit -p tsconfig.api.json`, biome, `docs:check`, `lint:api-contract`, `docs-stats` — all green.

No auto-merge — manual review requested.

https://claude.ai/code/session_018vcgXnLF66YmWSCJS2hco4