### PR TITLE
perf(map): gate overlay counter-scale var writes on real zoom change (#5080 slice 2)

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -221,6 +221,10 @@ export class MapComponent {
   private labelVisibilityScheduled = false;
   private pendingLabelVisibilityZoom = 1;
   private lastContainerSize = { width: 0, height: 0 };
+  // #5080 slice 2: last zoom (4dp) whose overlay counter-scale CSS vars were
+  // written — lets applyTransform() skip same-value setProperty calls that
+  // would restyle every marker on every render pass.
+  private lastOverlayVarZoom = '';
   // Desktop measures label overlap from the start; mobile defers until the first
   // interaction. The effective value is set in the constructor (= !this.isMobile);
   // false here documents the mobile-off default.
@@ -4032,11 +4036,22 @@ export class MapComponent {
     // Set CSS variable for counter-scaling labels/markers
     // Labels: max 1.5x scale, so counter-scale = min(1.5, zoom) / zoom
     // Markers: fixed size, so counter-scale = 1 / zoom
-    const labelScale = Math.min(1.5, zoom) / zoom;
-    const markerScale = 1 / zoom;
-    this.wrapper.style.setProperty('--label-scale', String(labelScale));
-    this.wrapper.style.setProperty('--marker-scale', String(markerScale));
-    this.wrapper.style.setProperty('--zoom', String(zoom));
+    // #5080 slice 2: write the vars ONLY when zoom actually changed.
+    // applyTransform() also runs on every render/data pass at unchanged zoom,
+    // and each setProperty — even with an identical value — invalidates every
+    // var() consumer: invalidation tracking measured thousands of per-marker
+    // style recalcs in a single tap window (earthquake-marker 4356,
+    // hotspot-marker 1694, conflict-zone 1210) — the dominant mobile tap
+    // presentation cost.
+    const overlayVarZoom = zoom.toFixed(4);
+    if (this.lastOverlayVarZoom !== overlayVarZoom) {
+      this.lastOverlayVarZoom = overlayVarZoom;
+      const labelScale = Math.min(1.5, zoom) / zoom;
+      const markerScale = 1 / zoom;
+      this.wrapper.style.setProperty('--label-scale', String(labelScale));
+      this.wrapper.style.setProperty('--marker-scale', String(markerScale));
+      this.wrapper.style.setProperty('--zoom', String(zoom));
+    }
 
     // Smart label hiding based on zoom level and overlap
     if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);

--- a/tests/map-overlay-var-write-gate.test.mjs
+++ b/tests/map-overlay-var-write-gate.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// #5080 slice 2: applyTransform() runs on every render/data pass, and an
+// unconditional setProperty('--marker-scale', ...) — even with an identical
+// value — invalidates every var() consumer (~68 rules across all overlay
+// markers). Chrome invalidation tracking measured 7,654 per-marker style
+// recalcs in ONE 1.5s tap window (earthquake-marker 4356, hotspot 1694,
+// conflict-zone 1210); gating the writes on a real zoom change cut that to
+// 88 (-98.9%) and tap-scoped style/layout from 437ms to 267ms at 5x CPU.
+// Map tests assert on source text by repo convention (no live map mount).
+const mapSrc = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), '..', 'src/components/Map.ts'),
+  'utf-8',
+);
+
+describe('map overlay counter-scale var write gate (#5080 slice 2)', () => {
+  it('declares the last-written zoom cache field', () => {
+    assert.match(mapSrc, /private lastOverlayVarZoom = '';/);
+  });
+
+  it('gates the three overlay var writes on a real zoom change', () => {
+    assert.match(
+      mapSrc,
+      /const overlayVarZoom = zoom\.toFixed\(4\);\s*if \(this\.lastOverlayVarZoom !== overlayVarZoom\) \{\s*this\.lastOverlayVarZoom = overlayVarZoom;[\s\S]{0,400}?setProperty\('--label-scale'[\s\S]{0,200}?setProperty\('--marker-scale'[\s\S]{0,200}?setProperty\('--zoom'/,
+      'the counter-scale vars must be written only when zoom (4dp) changed — a same-value write restyles every marker on every render pass',
+    );
+    assert.doesNotMatch(
+      mapSrc.replace(/const overlayVarZoom[\s\S]{0,700}?setProperty\('--zoom'[^;]*;\s*\}/, ''),
+      /setProperty\('--marker-scale'/,
+      'no other call site may write --marker-scale outside the zoom-change gate',
+    );
+  });
+});

--- a/tests/map-overlay-var-write-gate.test.mjs
+++ b/tests/map-overlay-var-write-gate.test.mjs
@@ -28,10 +28,16 @@ describe('map overlay counter-scale var write gate (#5080 slice 2)', () => {
       /const overlayVarZoom = zoom\.toFixed\(4\);\s*if \(this\.lastOverlayVarZoom !== overlayVarZoom\) \{\s*this\.lastOverlayVarZoom = overlayVarZoom;[\s\S]{0,400}?setProperty\('--label-scale'[\s\S]{0,200}?setProperty\('--marker-scale'[\s\S]{0,200}?setProperty\('--zoom'/,
       'the counter-scale vars must be written only when zoom (4dp) changed — a same-value write restyles every marker on every render pass',
     );
-    assert.doesNotMatch(
-      mapSrc.replace(/const overlayVarZoom[\s\S]{0,700}?setProperty\('--zoom'[^;]*;\s*\}/, ''),
-      /setProperty\('--marker-scale'/,
-      'no other call site may write --marker-scale outside the zoom-change gate',
+    const outsideGate = mapSrc.replace(
+      /const overlayVarZoom[\s\S]{0,700}?setProperty\('--zoom'[^;]*;\s*\}/,
+      '',
     );
+    for (const varName of ['--label-scale', '--marker-scale', '--zoom']) {
+      assert.doesNotMatch(
+        outsideGate,
+        new RegExp(`setProperty\\('${varName}'`),
+        `no other call site may write ${varName} outside the zoom-change gate — an ungated write restyles every var() consumer on every render pass`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

Slice 2 of #5080 (mobile map-tap INP). The 07-10 diagnosis showed map taps are style-invalidation-bound; adding Chrome's `invalidationTracking` trace category **named the mechanism** and overturned the containment hypothesis: `applyTransform()` runs on every render/data pass (not just zoom changes), and its unconditional `setProperty('--marker-scale'/'--label-scale'/'--zoom')` calls — even with identical values — invalidate every `var()` consumer (~68 rules spanning all overlay markers). One prod tap window (5× CPU) recorded **7,654 per-marker StyleRecalc invalidations**: `earthquake-marker` 4,356, `hotspot-marker` 1,694, `conflict-zone` 1,210.

Fix: write the three counter-scale vars only when zoom (4dp) actually changed. Zoom gestures/animations still write per frame (values change every frame), so counter-scaling behavior is pixel-identical; render/data passes at rest stop restyling the marker fleet.

## Validation (probe = red/green proof)

| A/B (tap `country` @5× CPU, invalidationTracking) | baseline (prod) | patched (local build) |
|---|---|---|
| StyleRecalc invalidations in tap window | **7,654** | **88** (−98.9%; residue = the popup's own recalcs) |
| tap-scoped style/layout | 436.6ms | 266.9ms |
| tap-scoped rendering | 112.7ms | 36.4ms |
| worst Event Timing | 216ms | 160ms |

- `npx tsc --noEmit` clean; biome clean; map guard suite 20/20 (incl. new `tests/map-overlay-var-write-gate.test.mjs` pinning the gate + forbidding ungated `--marker-scale` writes).
- Full `vite build` + preview smoke (map renders, popup opens, zoom gestures re-scale markers).

## Post-Deploy Monitoring & Validation

- DebugBear `rumMetrics?groupBy=inpSelector&device=mobile&urlPath=/dashboard`: `svg#mapSvg` (48h baseline 528), overlays (conflict 208, hotspot 184) and the **unattributed bucket (n=729, p75 960 — the current worst)** should step down toward the <500ms milestone.
- Sentry `webvital:inp` + `formFactor:mobile`: bad-event rate on map selectors.
- Failure signal: markers mis-scaled after zoom (would mean a zoom path bypassing `applyTransform` — none found), or no field movement in 48h → next lever is the marker-fleet density budget (slice 3).

Related: #5080 (slice 2 of Track M).

https://claude.ai/code/session_01PgggD2v8bpN5evLAgNCuZ6
