### PR TITLE
fix(build): co-locate ResilienceWidget into panels-intel chunk (#5203)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1305,6 +1305,17 @@ export default defineConfig(({ mode }) => {
             if (id.endsWith('/src/components/DeckGLMap.ts')) {
               return 'deck-stack';
             }
+            // Co-locate ResilienceWidget with its only runtime importer
+            // (CountryDeepDivePanel, panels-intel). As a standalone chunk its
+            // import() was a second network hop on every deep-dive open, and
+            // filtering middleboxes that stub the *Widget*-named chunk URL with
+            // an empty 200 made the import resolve WITHOUT the export
+            // (Sentry WORLDMONITOR-T6). In-chunk resolution removes that
+            // surface and the waterfall hop; shared deps (resilience-widget-
+            // utils, services/resilience) already live in shared chunks.
+            if (id.endsWith('/src/components/ResilienceWidget.ts')) {
+              return 'panels-intel';
+            }
             if (id.includes('/src/components/') && id.endsWith('.ts')) {
               const panelChunk = panelChunkForComponentId(id);
               if (panelChunk) return panelChunk;


### PR DESCRIPTION
## Summary

- Fixes #5203 / Sentry [WORLDMONITOR-T6](https://elie-habib.sentry.io/issues/7543789061/) — `Error: ResilienceWidget export is unavailable.` (6 events / 3 users since 2026-06-11).
- `ResilienceWidget.ts` misses the `*Panel.ts` manualChunks rule, so it shipped as a standalone 10.5 kB async chunk fetched on every country deep-dive open. Filtering middleboxes that stub the `*Widget*`-named chunk URL with an empty 200 make the `import()` **resolve** with no exports → the guard in `CountryDeepDivePanel.renderResilienceWidgetSlot` throws. Explains per-session determinism (one iOS user failed 4× in 4 min) across unrelated browsers (Firefox/Win, iOS WebView, Safari/Mac).
- Fix: co-locate `ResilienceWidget.ts` into `panels-intel` — the chunk of its only runtime importer, `CountryDeepDivePanel` — mirroring the existing `DeckGLMap.ts` → `deck-stack` precedent. The built import becomes `Promise.resolve().then(() => ns)`: no separate URL to intercept, one fewer waterfall request per deep-dive open.
- Cost: panels-intel 244.28 → 253.12 kB raw (+2.4 kB gzip). Shared deps (`resilience-widget-utils`, `services/resilience`) already live in shared chunks (also consumed by DeckGLMap, data-loader, RouteExplorer) — no eager-bundle regression.

## Test plan

- [x] Before-build reproduces standalone `ResilienceWidget-<hash>.js` chunk; after-build it is gone and the widget code (incl. the export guard) lives inside `panels-intel-<hash>.js`
- [x] Built import verified as in-chunk namespace resolution (no network fetch)
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint`, CJS syntax sweep, `npm run lint:md`, `npm run version:check`
- [x] `npm run test:data` — 14544 pass / 0 fail (incl. `resilience-widget.test.mts`, deep-dive harness tests, built-output critical-css tests against the post-fix build)
- [x] Edge bundle check + `tests/edge-functions.test.mjs`

## Follow-up after merge

Mark WORLDMONITOR-T6 resolved `inNextRelease` in Sentry so any recurrence after the fixed release ships is a genuine regression signal.

https://claude.ai/code/session_01F5kLCnJ342K8F32MLARAfQ
