### PR TITLE
fix(cls): create #mapSection already collapsed for the collapsed-map cohort (#5159)

### DIFF
--- a/e2e/collapsed-map-first-paint.spec.ts
+++ b/e2e/collapsed-map-first-paint.spec.ts
@@ -1,0 +1,67 @@
+import { devices, expect, test } from '@playwright/test';
+
+// #5159 / PR #5205 review P2: the source-pattern guard in
+// tests/skeleton-app-footprint-parity.test.mjs proves the creation template
+// SEEDS .collapsed, but only a behavioral check proves the section is never
+// OBSERVABLE expanded. Pre-fix, #mapSection painted expanded (~796px) for
+// ~150ms (9+ frames) before setupMobileMapToggle collapsed it, shoving
+// #panelsGrid up 698px (CLS 0.617, 3/3 repro). This spec samples every rAF
+// frame from document start: for the seeded collapsed cohort, NO frame may
+// show an attached #mapSection without .collapsed.
+//
+// NOTE (PR #5205 review P1 follow-up): the blocked-storage variant of this
+// contract (boot must complete with throwing localStorage) is NOT testable
+// yet — an unrelated module-level bare localStorage access crashes boot
+// before the shell installs (pre-existing; tracked separately). Add that
+// scenario here once boot is storage-block resilient.
+
+const { defaultBrowserType, ...mobileDevice } = devices['iPhone 14 Pro Max'];
+void defaultBrowserType;
+
+declare global {
+  interface Window {
+    __wmMapFrames?: Array<{ t: number; collapsed: boolean; className: string }>;
+  }
+}
+
+test.describe('collapsed-map cohort first paint (#5159)', () => {
+  test.use({ ...mobileDevice });
+
+  test('#mapSection is never observable without .collapsed when the pref is set', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('mobile-map-collapsed', 'true');
+      } catch {
+        /* storage unavailable — the seeded-cohort contract is then vacuous */
+      }
+      window.__wmMapFrames = [];
+      const sample = (): void => {
+        const sec = document.getElementById('mapSection');
+        if (sec) {
+          const frames = window.__wmMapFrames;
+          const collapsed = sec.classList.contains('collapsed');
+          const last = frames[frames.length - 1];
+          if (!last || last.collapsed !== collapsed) {
+            frames.push({ t: Math.round(performance.now()), collapsed, className: sec.className.slice(0, 80) });
+          }
+        }
+        requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+    });
+
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#mapSection', { timeout: 45_000 });
+    // Let several render passes land (deferred panels, map hydration) so a
+    // late uncollapse would be caught too.
+    await page.waitForTimeout(4_000);
+
+    const frames = await page.evaluate(() => window.__wmMapFrames ?? []);
+    expect(frames.length, 'the rAF sampler must have observed #mapSection').toBeGreaterThan(0);
+    const uncollapsed = frames.filter((f) => !f.collapsed);
+    expect(
+      uncollapsed,
+      `#mapSection was observable WITHOUT .collapsed for the seeded cohort (pre-#5205 bug: expanded-then-snap, CLS 0.617): ${JSON.stringify(uncollapsed)}`,
+    ).toEqual([]);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -370,6 +370,13 @@
            Hide the loading card too: otherwise its intrinsic height still shifts panels. */
         html.wm-map-collapsed .skeleton-map-bar{height:47px}
         html.wm-map-collapsed .skeleton-map-body{display:none}
+        /* #5159 NOTE: do NOT try to pre-paint-collapse the REAL .map-section from
+           here. main.css sets its expanded height with !important inside a cascade
+           layer, and for !important declarations LAYERED beats UNLAYERED — the
+           inverse of the normal-declaration rule this critical CSS relies on. The
+           real section is instead CREATED with .collapsed already present
+           (panel-layout.ts renderLayout template), so the runtime rule applies from
+           its first frame. */
         .skeleton-map-content{max-width:calc(100% - 24px);margin:12px;padding:16px}
         .skeleton-map-title{font-size:22px;line-height:1.15}
         .skeleton-map-copy{font-size:13px;line-height:1.42}

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -21,7 +21,7 @@ import type { TheaterPostureSummary } from '@/services/military-surge';
 import type { NewsPanel } from '@/components/NewsPanel';
 import type { AviationCommandBar } from '@/components/AviationCommandBar';
 import { MobilePanelNav } from '@/components/MobilePanelNav';
-import { debounce, saveToStorage } from '@/utils';
+import { debounce, loadFromStorage, saveToStorage } from '@/utils';
 import { escapeHtml } from '@/utils/sanitize';
 import {
   FEEDS,
@@ -671,6 +671,15 @@ export class PanelLayoutManager implements AppModule {
     }
   }
 
+  /** #5159/#5205 review: storage access can throw (blocked cookies, sandboxed
+   *  iframe) and this runs BEFORE the shell installs — an uncaught throw would
+   *  strand users on the boot skeleton. loadFromStorage is try/catch-guarded;
+   *  default is expanded. Wire format stays 'true'/'false' (JSON booleans),
+   *  identical to the previous String(isCollapsed) writes. */
+  private static isMobileMapCollapsedPreferred(): boolean {
+    return loadFromStorage<boolean>('mobile-map-collapsed', false) === true;
+  }
+
   async renderLayout(): Promise<void> {
     const isGlobeMode = getStoredMapModePreference() === 'globe';
     // #5159: the collapsed-map cohort's #mapSection must be CREATED with
@@ -681,7 +690,7 @@ export class PanelLayoutManager implements AppModule {
     // Seeding the class here makes the runtime collapsed rule apply from the
     // section's first frame instead of ~150ms later via setupMobileMapToggle
     // (which shoved #panelsGrid up 698px, field CLS ~0.62 for this cohort).
-    const mapStartsCollapsed = this.ctx.isMobile && localStorage.getItem('mobile-map-collapsed') === 'true';
+    const mapStartsCollapsed = this.ctx.isMobile && PanelLayoutManager.isMobileMapCollapsedPreferred();
     const bootShellFootprint = import.meta.env.DEV ? captureBootShellFootprint(this.ctx.container) : null;
 
     markLcpDebug('wm:layout:render-start');
@@ -1173,8 +1182,7 @@ export class PanelLayoutManager implements AppModule {
     const headerLeft = mapSection?.querySelector('.panel-header-left');
     if (!mapSection || !headerLeft) return;
 
-    const stored = localStorage.getItem('mobile-map-collapsed');
-    const collapsed = stored === 'true';
+    const collapsed = PanelLayoutManager.isMobileMapCollapsedPreferred();
     if (collapsed) mapSection.classList.add('collapsed');
 
     const btn = document.createElement('button');
@@ -1186,7 +1194,7 @@ export class PanelLayoutManager implements AppModule {
     btn.addEventListener('click', () => {
       const isCollapsed = mapSection.classList.toggle('collapsed');
       this.updateMobileMapCollapseBtn(isCollapsed);
-      localStorage.setItem('mobile-map-collapsed', String(isCollapsed));
+      saveToStorage('mobile-map-collapsed', isCollapsed);
       if (!isCollapsed) window.dispatchEvent(new Event('resize'));
     });
   }
@@ -1201,7 +1209,7 @@ export class PanelLayoutManager implements AppModule {
     if (mapSection.classList.contains('hidden')) return;
     if (mapSection.classList.contains('collapsed')) {
       mapSection.classList.remove('collapsed');
-      localStorage.setItem('mobile-map-collapsed', 'false');
+      saveToStorage('mobile-map-collapsed', false);
       this.updateMobileMapCollapseBtn(false);
       window.dispatchEvent(new Event('resize'));
     }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -673,6 +673,15 @@ export class PanelLayoutManager implements AppModule {
 
   async renderLayout(): Promise<void> {
     const isGlobeMode = getStoredMapModePreference() === 'globe';
+    // #5159: the collapsed-map cohort's #mapSection must be CREATED with
+    // .collapsed — main.css sets the expanded mobile height with !important
+    // inside a cascade layer, and layered !important beats any unlayered
+    // pre-paint override (inverse of the normal-declaration rule), so the
+    // html.wm-map-collapsed critical CSS can only cover the boot SKELETON.
+    // Seeding the class here makes the runtime collapsed rule apply from the
+    // section's first frame instead of ~150ms later via setupMobileMapToggle
+    // (which shoved #panelsGrid up 698px, field CLS ~0.62 for this cohort).
+    const mapStartsCollapsed = this.ctx.isMobile && localStorage.getItem('mobile-map-collapsed') === 'true';
     const bootShellFootprint = import.meta.env.DEV ? captureBootShellFootprint(this.ctx.container) : null;
 
     markLcpDebug('wm:layout:render-start');
@@ -869,7 +878,7 @@ export class PanelLayoutManager implements AppModule {
       </div>
       <div class="dashboard-tabs-mount" id="panelTabsMount"></div>
       <main id="main" tabindex="-1" class="main-content${this.ctx.isDesktopApp ? ' desktop-grid' : ''}">
-        <div class="map-section" id="mapSection">
+        <div class="map-section${mapStartsCollapsed ? ' collapsed' : ''}" id="mapSection">
           <div class="panel-header">
             <div class="panel-header-left">
               <span class="panel-title">${SITE_VARIANT === 'tech' ? t('panels.techMap') : SITE_VARIANT === 'happy' ? 'Good News Map' : t('panels.map')}</span>

--- a/tests/skeleton-app-footprint-parity.test.mjs
+++ b/tests/skeleton-app-footprint-parity.test.mjs
@@ -257,4 +257,33 @@ describe('#4580 boot skeleton <-> app footprint parity', () => {
       `The skeleton mobile block must gate at MOBILE_BREAKPOINT_PX (${breakpoint}px), not a 1px-off seam`,
     );
   });
+
+  it('collapsed cohort: #mapSection is CREATED with .collapsed when the pref is set (#5159)', () => {
+    // The pre-paint html.wm-map-collapsed critical CSS can only cover the boot
+    // SKELETON: main.css sets the expanded mobile .map-section height with
+    // !important inside a cascade layer, and for !important declarations
+    // LAYERED beats UNLAYERED — the inverse of the normal-declaration rule the
+    // critical CSS relies on. So the REAL section must be born collapsed: the
+    // renderLayout template seeds .collapsed from the same localStorage key the
+    // toggle persists. Without this, #mapSection paints expanded (~796px) and
+    // snaps up 698px when setupMobileMapToggle runs (~150ms later; CLS 0.617,
+    // reproduced 3/3 for the mobile-map-collapsed cohort).
+    assert.match(
+      panelLayout,
+      /const mapStartsCollapsed = this\.ctx\.isMobile && localStorage\.getItem\('mobile-map-collapsed'\) === 'true';/,
+      'renderLayout must read the collapse pref before building the shell template',
+    );
+    assert.match(
+      panelLayout,
+      /<div class="map-section\$\{mapStartsCollapsed \? ' collapsed' : ''\}" id="mapSection">/,
+      '#mapSection must be created with .collapsed for the collapsed cohort — adding it later shifts #panelsGrid',
+    );
+    // The critical CSS must keep the do-not-retry note so nobody re-attempts an
+    // unlayered !important pre-paint override of the layered expanded height.
+    assert.match(
+      html,
+      /do NOT try to pre-paint-collapse the REAL \.map-section/,
+      'index.html must document why the real section is not styled from critical CSS (#5159 layered-!important inversion)',
+    );
+  });
 });

--- a/tests/skeleton-app-footprint-parity.test.mjs
+++ b/tests/skeleton-app-footprint-parity.test.mjs
@@ -270,8 +270,22 @@ describe('#4580 boot skeleton <-> app footprint parity', () => {
     // reproduced 3/3 for the mobile-map-collapsed cohort).
     assert.match(
       panelLayout,
-      /const mapStartsCollapsed = this\.ctx\.isMobile && localStorage\.getItem\('mobile-map-collapsed'\) === 'true';/,
-      'renderLayout must read the collapse pref before building the shell template',
+      /const mapStartsCollapsed = this\.ctx\.isMobile && PanelLayoutManager\.isMobileMapCollapsedPreferred\(\);/,
+      'renderLayout must read the collapse pref (via the guarded helper) before building the shell template',
+    );
+    // #5205 review P1: this read runs BEFORE the shell installs — a bare
+    // localStorage access throws under blocked storage (SecurityError) and
+    // would strand users on the boot skeleton. The helper must route through
+    // the try/catch-guarded loadFromStorage with an expanded default.
+    assert.match(
+      panelLayout,
+      /private static isMobileMapCollapsedPreferred\(\): boolean \{\s*return loadFromStorage<boolean>\('mobile-map-collapsed', false\) === true;/,
+      'the collapse-pref read must use guarded loadFromStorage, defaulting to expanded',
+    );
+    assert.doesNotMatch(
+      panelLayout,
+      /localStorage\.getItem\('mobile-map-collapsed'\)/,
+      'no bare localStorage read of the collapse pref may remain (boot-critical path)',
     );
     assert.match(
       panelLayout,


### PR DESCRIPTION
## Summary

Completes #5159 (reopened): the collapsed-map cohort (`mobile-map-collapsed=true`, ~5% of mobile views) had a deterministic CLS 0.617 — the real `#mapSection` painted expanded (~796px) and snapped up 698px when `setupMobileMapToggle` added `.collapsed` ~150ms after first paint.

**Why the obvious fix doesn't work (and is now documented in-place):** #5161's pre-paint `html.wm-map-collapsed` stamp can only style the boot *skeleton*. main.css sets the expanded mobile height with `!important` inside a cascade layer, and for `!important` declarations **layered beats unlayered** — the exact inverse of the normal-declaration rule that makes the unlayered critical CSS win everywhere else (#4346). An unlayered pre-paint override was tried and measurably did nothing (probe: identical 0.617 CLS). `index.html` now carries a do-not-retry note.

**The fix:** `renderLayout` seeds `.collapsed` into the `#mapSection` creation template from the same localStorage key, so the runtime collapsed rule (layered, high specificity) applies from the section's first frame. `setupMobileMapToggle`'s later `classList.add('collapsed')` becomes a no-op; its `wm-map-collapsed` removal is unchanged.

## Validation (probe = red/green)

| 390×844, 4× CPU, Slow-4G, seeded pref | before | after |
|---|---|---|
| CLS (3/3 runs, deterministic) | **0.617** | **0.047** |
| largest shift | 0.617 (grid up 698px) | none >0.05 |
| `#panelsGrid` first paint | 912 → 214 snap | 165 (collapsed from frame 1) |

- Guards: `skeleton-app-footprint-parity` extended (creation-time seeding + the critical-CSS note pinned); 37/37 across the skeleton/critical-css/bootstrap/panel-config suites; `tsc` + biome clean; full `vite build`.
- Residual (optional polish, not this PR): a 49px skeleton↔collapsed-header parity gap remains (165→214, CLS 0.047 — well under the 0.1 threshold).

## Post-Deploy Monitoring & Validation

- DebugBear `rumMetrics?groupBy=clsSelector&device=mobile&urlPath=/dashboard`: the bimodal `#main div#panelsGrid` tail (p75 0.972, n≈154/day) should collapse within 24–48h; headline mobile CLS (0.015) should hold or improve.
- Failure signal: collapsed-cohort users seeing an expanded-then-collapse flash (would mean a path rendering `#mapSection` outside `renderLayout` — none found), or the tail persisting → the cohort hypothesis was wrong and the per-view `clsStartTime` cut runs again.

Closes #5159. Part of #4580 item (a).

https://claude.ai/code/session_01PgggD2v8bpN5evLAgNCuZ6
