### PR TITLE
fix(rate-limit): isolate paid summarize callers

### DIFF
--- a/server/__tests__/gateway-summarize-article-security.test.ts
+++ b/server/__tests__/gateway-summarize-article-security.test.ts
@@ -297,6 +297,16 @@ describe("summarize-article gateway spend controls", () => {
       SUMMARIZE_PATH,
       expect.any(Object),
     );
+    expect(checkFailClosedScopedIpRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      "summarize-article:principal-attribution",
+      600,
+      "60 s",
+      expect.any(Object),
+    );
+    expect(checkFailClosedScopedIpRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+      getEntitlements.mock.invocationCallOrder[0]!,
+    );
     expect(calls.summarize).toBe(0);
   });
 
@@ -317,6 +327,16 @@ describe("summarize-article gateway spend controls", () => {
       expect.any(Request),
       SUMMARIZE_PATH,
       expect.any(Object),
+    );
+    expect(checkFailClosedScopedIpRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      "summarize-article:principal-attribution",
+      600,
+      "60 s",
+      expect.any(Object),
+    );
+    expect(checkFailClosedScopedIpRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+      getEntitlements.mock.invocationCallOrder[0]!,
     );
     expect(calls.summarize).toBe(0);
   });
@@ -343,6 +363,16 @@ describe("summarize-article gateway spend controls", () => {
       expect.any(Request),
       SUMMARIZE_PATH,
       expect.any(Object),
+    );
+    expect(checkFailClosedScopedIpRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      "summarize-article:principal-attribution",
+      600,
+      "60 s",
+      expect.any(Object),
+    );
+    expect(checkFailClosedScopedIpRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+      getEntitlements.mock.invocationCallOrder[0]!,
     );
   });
 

--- a/server/__tests__/gateway-summarize-article-security.test.ts
+++ b/server/__tests__/gateway-summarize-article-security.test.ts
@@ -4,12 +4,14 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const checkEndpointRateLimit = vi.fn().mockResolvedValue(null);
 const checkRateLimit = vi.fn().mockResolvedValue(null);
+const checkFailClosedScopedIpRateLimit = vi.fn().mockResolvedValue(null);
 vi.mock("../_shared/rate-limit", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../_shared/rate-limit")>();
   return {
     ...actual,
     checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
     checkEndpointRateLimit: (...a: unknown[]) => checkEndpointRateLimit(...a),
+    checkFailClosedScopedIpRateLimit: (...a: unknown[]) => checkFailClosedScopedIpRateLimit(...a),
   };
 });
 
@@ -33,6 +35,11 @@ const validateApiKey = vi.fn();
 vi.mock("../../api/_api-key.js", () => ({
   USER_API_KEY_GATEWAY_VALIDATION_ERROR: "User API key requires gateway validation",
   validateApiKey: (...a: unknown[]) => validateApiKey(...a),
+}));
+
+const validateUserApiKey = vi.fn();
+vi.mock("../_shared/user-api-key", () => ({
+  validateUserApiKey: (...a: unknown[]) => validateUserApiKey(...a),
 }));
 
 const reserveDirectLlmQuota = vi.fn();
@@ -93,6 +100,7 @@ function makeGateway(handlerCalls: { summarize: number; cache: number }) {
 beforeEach(() => {
   checkEndpointRateLimit.mockReset().mockResolvedValue(null);
   checkRateLimit.mockReset().mockResolvedValue(null);
+  checkFailClosedScopedIpRateLimit.mockReset().mockResolvedValue(null);
   checkEntitlementDetailed.mockReset().mockResolvedValue({ response: null, entitlements: null });
   getEntitlements.mockReset().mockResolvedValue(null);
   resolveClerkSession.mockReset().mockResolvedValue(null);
@@ -101,6 +109,7 @@ beforeEach(() => {
     required: true,
     error: "API key required",
   });
+  validateUserApiKey.mockReset().mockResolvedValue(null);
   reserveDirectLlmQuota.mockReset().mockResolvedValue({
     ok: true,
     newCount: 1,
@@ -166,8 +175,13 @@ describe("summarize-article gateway spend controls", () => {
     );
   });
 
-  test("Pro bearer sessions pass entitlement and endpoint rate-limit before the summarize handler runs", async () => {
+  test("active Pro bearer sessions use a principal-scoped endpoint rate-limit bucket", async () => {
     resolveClerkSession.mockResolvedValue({ userId: "pro_user", orgId: null, role: "pro" });
+    getEntitlements.mockResolvedValue({
+      planKey: "pro_monthly",
+      features: { tier: 1 },
+      validUntil: Date.now() + 86_400_000,
+    });
     validateApiKey.mockResolvedValue({ valid: true, required: false, kind: "session" });
     const calls = { summarize: 0, cache: 0 };
 
@@ -182,11 +196,154 @@ describe("summarize-article gateway spend controls", () => {
       expect.any(Request),
       SUMMARIZE_PATH,
       expect.any(Object),
+      { principalUserId: "pro_user" },
+    );
+    expect(checkFailClosedScopedIpRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      "summarize-article:principal-attribution",
+      600,
+      "60 s",
+      expect.any(Object),
     );
     expect(reserveDirectLlmQuota).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "pro_user" }),
     );
     expect(calls.summarize).toBe(1);
+  });
+
+  test("pre-attribution IP guard rejects before entitlement lookup or handler execution", async () => {
+    resolveClerkSession.mockResolvedValue({ userId: "pro_user", orgId: null, role: "pro" });
+    validateApiKey.mockResolvedValue({ valid: true, required: false, kind: "session" });
+    checkFailClosedScopedIpRateLimit.mockResolvedValue(json({ error: "Too many requests" }, 429));
+    const calls = { summarize: 0, cache: 0 };
+
+    const res = await makeGateway(calls)(
+      makeRequest(SUMMARIZE_PATH, { Authorization: "Bearer pro-session" }),
+      { waitUntil: () => {} },
+    );
+
+    expect(res.status).toBe(429);
+    expect(getEntitlements).not.toHaveBeenCalled();
+    expect(checkEndpointRateLimit).not.toHaveBeenCalled();
+    expect(calls.summarize).toBe(0);
+  });
+
+  test("pre-attribution IP guard fails closed on degradation before entitlement lookup", async () => {
+    resolveClerkSession.mockResolvedValue({ userId: "pro_user", orgId: null, role: "pro" });
+    validateApiKey.mockResolvedValue({ valid: true, required: false, kind: "session" });
+    checkFailClosedScopedIpRateLimit.mockResolvedValue(new Response(
+      JSON.stringify({ error: "Rate-limit service temporarily unavailable" }),
+      { status: 503, headers: { "X-RateLimit-Mode": "degraded" } },
+    ));
+    const calls = { summarize: 0, cache: 0 };
+
+    const res = await makeGateway(calls)(
+      makeRequest(SUMMARIZE_PATH, { Authorization: "Bearer pro-session" }),
+      { waitUntil: () => {} },
+    );
+
+    expect(res.status).toBe(503);
+    expect(getEntitlements).not.toHaveBeenCalled();
+    expect(checkEndpointRateLimit).not.toHaveBeenCalled();
+    expect(calls.summarize).toBe(0);
+  });
+
+  test("active user API keys reuse the resolved entitlement and use the principal bucket", async () => {
+    const activeEntitlement = {
+      planKey: "api_starter",
+      features: { tier: 1, apiAccess: true, apiRateLimit: 60 },
+      validUntil: Date.now() + 86_400_000,
+    };
+    validateUserApiKey.mockResolvedValue({ userId: "api_user", keyId: "key_1", name: "test" });
+    getEntitlements.mockResolvedValue(activeEntitlement);
+    const calls = { summarize: 0, cache: 0 };
+
+    const res = await makeGateway(calls)(
+      makeRequest(SUMMARIZE_PATH, { "X-Api-Key": "wm_active_user_key" }),
+      { waitUntil: () => {} },
+    );
+
+    expect(res.status).toBe(200);
+    expect(getEntitlements).toHaveBeenCalledTimes(1);
+    expect(getEntitlements).toHaveBeenCalledWith("api_user");
+    expect(checkEndpointRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      SUMMARIZE_PATH,
+      expect.any(Object),
+      { principalUserId: "api_user" },
+    );
+    expect(calls.summarize).toBe(1);
+  });
+
+  test("expired tier-1 bearer sessions retain the per-IP endpoint bucket", async () => {
+    resolveClerkSession.mockResolvedValue({ userId: "expired_user", orgId: null, role: "pro" });
+    getEntitlements.mockResolvedValue({
+      planKey: "pro_monthly",
+      features: { tier: 1 },
+      validUntil: Date.now() - 1,
+    });
+    validateApiKey.mockResolvedValue({ valid: true, required: false, kind: "session" });
+    checkEndpointRateLimit.mockResolvedValue(json({ error: "Too many requests" }, 429));
+    const calls = { summarize: 0, cache: 0 };
+
+    const res = await makeGateway(calls)(
+      makeRequest(SUMMARIZE_PATH, { Authorization: "Bearer expired-session" }),
+      { waitUntil: () => {} },
+    );
+
+    expect(res.status).toBe(429);
+    expect(checkEndpointRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      SUMMARIZE_PATH,
+      expect.any(Object),
+    );
+    expect(calls.summarize).toBe(0);
+  });
+
+  test("unresolved Pro bearer sessions retain the per-IP endpoint bucket", async () => {
+    resolveClerkSession.mockResolvedValue({ userId: "unresolved_user", orgId: null, role: "pro" });
+    getEntitlements.mockResolvedValue(null);
+    validateApiKey.mockResolvedValue({ valid: true, required: false, kind: "session" });
+    checkEndpointRateLimit.mockResolvedValue(json({ error: "Too many requests" }, 429));
+    const calls = { summarize: 0, cache: 0 };
+
+    const res = await makeGateway(calls)(
+      makeRequest(SUMMARIZE_PATH, { Authorization: "Bearer unresolved-session" }),
+      { waitUntil: () => {} },
+    );
+
+    expect(res.status).toBe(429);
+    expect(checkEndpointRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      SUMMARIZE_PATH,
+      expect.any(Object),
+    );
+    expect(calls.summarize).toBe(0);
+  });
+
+  test("signed-in free sessions remain on the shared per-IP endpoint bucket", async () => {
+    resolveClerkSession.mockResolvedValue({ userId: "free_user", orgId: null, role: "free" });
+    getEntitlements.mockResolvedValue({
+      planKey: "free",
+      features: { tier: 0 },
+      validUntil: Date.now() + 86_400_000,
+    });
+    validateApiKey.mockResolvedValue({ valid: true, required: false, kind: "session" });
+    checkEndpointRateLimit.mockResolvedValue(json({ error: "Too many requests" }, 429));
+    const calls = { summarize: 0, cache: 0 };
+
+    const res = await makeGateway(calls)(
+      makeRequest(SUMMARIZE_PATH, { Authorization: "Bearer free-session" }),
+      { waitUntil: () => {} },
+    );
+
+    expect(res.status).toBe(429);
+    expect(calls.summarize).toBe(0);
+    expect(checkEndpointRateLimit).toHaveBeenCalledWith(
+      expect.any(Request),
+      SUMMARIZE_PATH,
+      expect.any(Object),
+    );
   });
 
   test("translate mode remains public and quota-exempt", async () => {

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -185,6 +185,16 @@ export interface RateLimitOptions {
   failClosed?: boolean;
 }
 
+export interface EndpointRateLimitOptions extends RateLimitOptions {
+  /**
+   * Optional trusted server-derived user ID for endpoint policies that should
+   * isolate authenticated principals sharing one public IP. Callers must never
+   * pass a raw client-controlled header here. The limiter owns the namespace
+   * prefix so user IDs cannot collide with anonymous IP buckets.
+   */
+  principalUserId?: string;
+}
+
 export async function checkRateLimit(request: Request, corsHeaders: Record<string, string>, opts: RateLimitOptions = {}): Promise<Response | null> {
   const rl = getRatelimit();
   if (!rl) {
@@ -405,7 +415,7 @@ export function hasEndpointRatePolicy(pathname: string): boolean {
   return pathname in ENDPOINT_RATE_POLICIES;
 }
 
-export async function checkEndpointRateLimit(request: Request, pathname: string, corsHeaders: Record<string, string>, opts: RateLimitOptions = {}): Promise<Response | null> {
+export async function checkEndpointRateLimit(request: Request, pathname: string, corsHeaders: Record<string, string>, opts: EndpointRateLimitOptions = {}): Promise<Response | null> {
   if (!hasEndpointRatePolicy(pathname)) return null;
 
   const rl = getEndpointRatelimit(pathname);
@@ -418,7 +428,9 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
     return null;
   }
 
-  const ip = getClientIp(request);
+  const identifier = opts.principalUserId
+    ? `user:${opts.principalUserId}`
+    : getClientIp(request);
   const policy = ENDPOINT_RATE_POLICIES[pathname];
   // hasEndpointRatePolicy(pathname) above already guarantees this — the
   // extra check exists only to satisfy noUncheckedIndexedAccess, since TS
@@ -426,7 +438,7 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
   if (!policy) return null;
 
   try {
-    const { success, limit, reset } = await limitWithFallback(rl, `${pathname}:${ip}`, `rl:ep:fw:${pathname}:${ip}`, policy.limit, durationToSeconds(policy.window));
+    const { success, limit, reset } = await limitWithFallback(rl, `${pathname}:${identifier}`, `rl:ep:fw:${pathname}:${identifier}`, policy.limit, durationToSeconds(policy.window));
 
     if (!success) {
       return tooManyRequestsResponse(limit, reset, corsHeaders, durationToSeconds(policy.window));
@@ -513,6 +525,27 @@ export async function checkScopedRateLimit(scope: string, limit: number, window:
     logRateLimitDegraded(`checkScopedRateLimit:${scope}`, err);
     return { allowed: true, limit, reset: 0, degraded: true };
   }
+}
+
+/**
+ * Applies a distinct, fail-closed per-IP scoped guard and converts its result
+ * into the gateway's standard 429/503 response contract. Use this ahead of
+ * expensive identity-attribution lookups that cannot yet use the endpoint's
+ * final principal-scoped bucket.
+ */
+export async function checkFailClosedScopedIpRateLimit(
+  request: Request,
+  scope: string,
+  limit: number,
+  window: Duration,
+  corsHeaders: Record<string, string>,
+): Promise<Response | null> {
+  const result = await checkScopedRateLimit(scope, limit, window, getClientIp(request));
+  if (result.degraded) return rateLimitDegradedResponse(corsHeaders);
+  if (!result.allowed) {
+    return tooManyRequestsResponse(result.limit, result.reset, corsHeaders, durationToSeconds(window));
+  }
+  return null;
 }
 
 export function __resetRateLimitForTest(): void {

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -430,7 +430,7 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
 
   const identifier = opts.principalUserId
     ? `user:${opts.principalUserId}`
-    : getClientIp(request);
+    : `ip:${getClientIp(request)}`;
   const policy = ENDPOINT_RATE_POLICIES[pathname];
   // hasEndpointRatePolicy(pathname) above already guarantees this — the
   // extra check exists only to satisfy noUncheckedIndexedAccess, since TS

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1293,6 +1293,10 @@ export function createDomainGateway(
       // bucket. Keep the exact same fail-closed endpoint policy, but isolate
       // confirmed active paid principals. Signed-in free, anonymous, expired,
       // and unresolvable callers deliberately retain the per-IP bucket.
+      // requiresDirectLlmQuota intentionally limits this exception to
+      // spend-bearing summarize requests: translate/malformed requests do not
+      // spend direct LLM quota and keep ordinary per-IP behavior, while cache
+      // lookup is handled by its distinct route.
       if (
         pathname === '/api/news/v1/summarize-article' &&
         requiresDirectLlmQuota &&

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -18,7 +18,12 @@ import { timingSafeEqualSecret } from '../api/_crypto.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../api/_sentry-edge.js';
 import { mapErrorToResponse } from './error-mapper';
-import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
+import {
+  checkRateLimit,
+  checkEndpointRateLimit,
+  checkFailClosedScopedIpRateLimit,
+  hasEndpointRatePolicy,
+} from './_shared/rate-limit';
 import { drainResponseHeaders, drainSuccessStatusOverride } from './_shared/response-headers';
 import { projectJsonResponse } from './_shared/response-projection';
 import { getRpcNoStoreReasonFromJson } from './_shared/cache-contract';
@@ -1067,6 +1072,7 @@ export function createDomainGateway(
     const requiresDirectLlmQuota = !internalMcpVerified && await shouldReserveGatewayDirectLlmQuota(request, pathname);
     const isTierGated = !internalMcpVerified && !isPublicNoAuthRpc && !seedRefreshVerified && !relayWarmPingVerified && getRequiredTier(pathname) !== null;
     const needsLegacyProBearerGate = !internalMcpVerified && !isPublicNoAuthRpc && PREMIUM_RPC_PATHS.has(pathname) && !isTierGated;
+    let endpointRateLimitPrincipalUserId: string | undefined;
 
     // Session resolution — extract userId from bearer token (Clerk JWT) if present.
     // Only runs for tier-gated or direct-LLM endpoints to avoid JWKS lookup on every request.
@@ -1281,6 +1287,49 @@ export function createDomainGateway(
           ? markAuthErrorNoStore(entitlementResponse)
           : entitlementResponse;
       }
+
+      // #5206: summarize refreshes from multiple active Pro users can share a
+      // NAT/public IP and collectively exhaust the endpoint's 30/min abuse
+      // bucket. Keep the exact same fail-closed endpoint policy, but isolate
+      // confirmed active paid principals. Signed-in free, anonymous, expired,
+      // and unresolvable callers deliberately retain the per-IP bucket.
+      if (
+        pathname === '/api/news/v1/summarize-article' &&
+        requiresDirectLlmQuota &&
+        sessionUserId
+      ) {
+        // This guard runs before the entitlement lookup needed to choose the
+        // final endpoint bucket. Its distinct 600/min IP namespace matches the
+        // repo-wide global ceiling (20x the endpoint's 30/min spend cap): enough
+        // NAT headroom for legitimate Pro refreshes, while bounding per-IP
+        // entitlement-I/O amplification and failing closed when Redis degrades.
+        const attributionGuardResponse = await checkFailClosedScopedIpRateLimit(
+          request,
+          'summarize-article:principal-attribution',
+          600,
+          '60 s',
+          corsHeaders,
+        );
+        if (attributionGuardResponse) {
+          const reason =
+            attributionGuardResponse.status === 503 &&
+            attributionGuardResponse.headers.get('X-RateLimit-Mode') === 'degraded'
+              ? 'rate_limit_degraded'
+              : 'rate_limit_429';
+          emitRequest(attributionGuardResponse.status, reason, null);
+          return attributionGuardResponse;
+        }
+
+        const ent = entitlementCheck.entitlements ?? (
+          userKeyEntitlement !== undefined
+            ? userKeyEntitlement
+            : await getEntitlements(sessionUserId)
+        );
+        recordUsageEntitlement(ent);
+        if (ent && ent.features.tier >= 1 && ent.validUntil >= Date.now()) {
+          endpointRateLimitPrincipalUserId = sessionUserId;
+        }
+      }
     }
 
     // Route matching — if POST doesn't match, convert to GET for stale clients
@@ -1392,7 +1441,11 @@ export function createDomainGateway(
     // limiter here would create misleading double-counting and could 429
     // legitimate Pro tool fetches that pass the upstream cap.
     if (!internalMcpVerified) {
-      const endpointRlResponse = await checkEndpointRateLimit(request, pathname, corsHeaders);
+      const endpointRlResponse = endpointRateLimitPrincipalUserId
+        ? await checkEndpointRateLimit(request, pathname, corsHeaders, {
+            principalUserId: endpointRateLimitPrincipalUserId,
+          })
+        : await checkEndpointRateLimit(request, pathname, corsHeaders);
       if (endpointRlResponse) {
         const reason =
           endpointRlResponse.status === 503 &&

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -22,7 +22,9 @@ import { premiumFetch } from '@/services/premium-fetch';
 import {
   canAttemptServerSummarization,
   configureSummarizeGate,
+  parseSummarizeRetryAfterMs,
   suppressServerSummarization,
+  suppressServerSummarizationFor,
 } from '@/services/summarize-gate';
 import { hasPremiumAccess } from '@/services/panel-gating';
 
@@ -53,7 +55,20 @@ export interface SummarizeOptions {
 
 const newsClient = new NewsServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
 const premiumNewsClient = new NewsServiceClient(getRpcBaseUrl(), {
-  fetch: (input, init) => premiumFetch(input, { ...init, forcePremium: true }),
+  fetch: async (input, init) => {
+    const response = await premiumFetch(input, { ...init, forcePremium: true });
+    if (response.status === 429) {
+      const retryAfterMs = parseSummarizeRetryAfterMs(response.headers.get('Retry-After'));
+      if (retryAfterMs === null) {
+        // The server normally supplies Retry-After. A malformed/missing value
+        // must still stop this provider chain from multiplying the same 429.
+        suppressServerSummarization();
+      } else {
+        suppressServerSummarizationFor(retryAfterMs);
+      }
+    }
+    return response;
+  },
 });
 
 // #4913: summarize-article LLM spend is premium-gated server-side (#4687).

--- a/src/services/summarize-gate.ts
+++ b/src/services/summarize-gate.ts
@@ -36,6 +36,8 @@
  */
 
 export const SUMMARIZE_SUPPRESS_MS = 15 * 60 * 1000;
+export const SUMMARIZE_RETRY_AFTER_MIN_MS = 1_000;
+export const SUMMARIZE_RETRY_AFTER_MAX_MS = 24 * 60 * 60 * 1000;
 
 type EntitlementProbe = () => boolean;
 
@@ -61,9 +63,56 @@ export function canAttemptServerSummarization(now: number = Date.now()): boolean
   }
 }
 
+/**
+ * Parse an HTTP Retry-After value into a bounded delay.
+ *
+ * Both RFC delta-seconds and HTTP-date forms are accepted. The header is
+ * untrusted input, so malformed, negative, non-finite, or already-expired
+ * values are rejected and excessively large hints are capped at one day.
+ */
+export function parseSummarizeRetryAfterMs(
+  value: string | null,
+  now: number = Date.now(),
+): number | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  let delayMs: number;
+  if (/^\d+$/.test(trimmed)) {
+    delayMs = Number(trimmed) * 1_000;
+  } else {
+    const retryAt = Date.parse(trimmed);
+    if (!Number.isFinite(retryAt)) return null;
+    delayMs = retryAt - now;
+  }
+
+  if (!Number.isFinite(delayMs) || delayMs < 0) return null;
+  return Math.min(
+    Math.max(delayMs, SUMMARIZE_RETRY_AFTER_MIN_MS),
+    SUMMARIZE_RETRY_AFTER_MAX_MS,
+  );
+}
+
+/**
+ * Suppress server attempts for a bounded delay without shortening an active
+ * suppression window. Used for server-directed 429 cooldowns.
+ */
+export function suppressServerSummarizationFor(
+  delayMs: number,
+  now: number = Date.now(),
+): void {
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return;
+  const boundedDelayMs = Math.min(
+    Math.max(delayMs, SUMMARIZE_RETRY_AFTER_MIN_MS),
+    SUMMARIZE_RETRY_AFTER_MAX_MS,
+  );
+  suppressedUntil = Math.max(suppressedUntil, now + boundedDelayMs);
+}
+
 /** Suppress all attempts for SUMMARIZE_SUPPRESS_MS (called on a server 403). */
 export function suppressServerSummarization(now: number = Date.now()): void {
-  suppressedUntil = now + SUMMARIZE_SUPPRESS_MS;
+  suppressServerSummarizationFor(SUMMARIZE_SUPPRESS_MS, now);
 }
 
 export function __resetSummarizeGateForTests(): void {

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -18,6 +18,7 @@ import {
   UNKNOWN_CLIENT_IP,
   __resetRateLimitForTest,
   checkEndpointRateLimit,
+  checkFailClosedScopedIpRateLimit,
   checkRateLimit,
   checkScopedRateLimit,
   getClientIp,
@@ -374,6 +375,20 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.equal(result.allowed, true, 'preserve availability-first default');
     assert.equal(result.degraded, true, 'flag the degraded path so callers can escalate');
   });
+
+  it('checkFailClosedScopedIpRateLimit converts scoped degradation to the standard 503 contract', async () => {
+    const res = await checkFailClosedScopedIpRateLimit(
+      makeRequest({ 'x-real-ip': '203.0.113.14' }),
+      'pre-attribution-test',
+      600,
+      '60 s',
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+    );
+
+    assert.equal(res?.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+  });
 });
 
 describe('rate-limit fail-closed call-site policy (#3531)', () => {
@@ -568,6 +583,38 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
     assert.equal(luaAttempts, 1, 'endpoint fallback must not retry Lua after it is known unsupported');
   });
 
+  it('checkEndpointRateLimit isolates trusted principals sharing one IP while preserving the IP default', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.12' });
+    const pathname = '/api/news/v1/summarize-article';
+
+    for (let i = 0; i < 30; i++) {
+      assert.equal(
+        await mod.checkEndpointRateLimit(req, pathname, {}, { principalUserId: 'pro-a' }),
+        null,
+      );
+    }
+    const blocked = await mod.checkEndpointRateLimit(req, pathname, {}, { principalUserId: 'pro-a' });
+    assert.equal(blocked?.status, 429, 'one Pro principal must still be capped at 30/min');
+
+    assert.equal(
+      await mod.checkEndpointRateLimit(req, pathname, {}, { principalUserId: 'pro-b' }),
+      null,
+      'a second Pro principal behind the same IP must receive an independent bucket',
+    );
+    assert.equal(
+      await mod.checkEndpointRateLimit(req, pathname, {}),
+      null,
+      'callers without a trusted principal must continue using the original IP bucket',
+    );
+  });
+
   it('degrades instead of creating a permanent counter when EXPIRE NX is unsupported', async () => {
     const pipelineHandler = makeProxyPipelineHandler({ expireNxUnsupported: true });
     globalThis.fetch = (async (_url: string, init?: RequestInit) => {
@@ -627,5 +674,30 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
     // A different identifier gets its own independent window.
     const otherCaller = await mod.checkScopedRateLimit('fallback-scope', 2, '60 s', 'caller-2');
     assert.equal(otherCaller.allowed, true, 'a different identifier has its own fixed-window counter');
+  });
+
+  it('checkFailClosedScopedIpRateLimit converts an enforced scoped limit to a standard 429', async () => {
+    const pipelineHandler = makeProxyPipelineHandler();
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const commands = JSON.parse(String(init?.body)) as unknown[][];
+      return new Response(JSON.stringify(pipelineHandler(commands)), { status: 200 });
+    }) as typeof fetch;
+
+    const mod = await importFreshRateLimitModule();
+    const req = makeRequest({ 'x-real-ip': '203.0.113.15' });
+
+    assert.equal(
+      await mod.checkFailClosedScopedIpRateLimit(req, 'pre-attribution-fallback', 1, '60 s', {}),
+      null,
+    );
+    const blocked = await mod.checkFailClosedScopedIpRateLimit(
+      req,
+      'pre-attribution-fallback',
+      1,
+      '60 s',
+      {},
+    );
+    assert.equal(blocked?.status, 429);
+    assert.equal(blocked.headers.get('X-RateLimit-Limit'), '1');
   });
 });

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -604,6 +604,16 @@ describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blo
     assert.equal(blocked?.status, 429, 'one Pro principal must still be capped at 30/min');
 
     assert.equal(
+      await mod.checkEndpointRateLimit(
+        makeRequest({ 'x-real-ip': 'user:pro-a' }),
+        pathname,
+        {},
+      ),
+      null,
+      'an IP-shaped caller value must not collide with the user namespace',
+    );
+
+    assert.equal(
       await mod.checkEndpointRateLimit(req, pathname, {}, { principalUserId: 'pro-b' }),
       null,
       'a second Pro principal behind the same IP must receive an independent bucket',

--- a/tests/summarize-entitlement-gate.test.mts
+++ b/tests/summarize-entitlement-gate.test.mts
@@ -22,7 +22,11 @@ import { fileURLToPath } from 'node:url';
 import {
   canAttemptServerSummarization,
   configureSummarizeGate,
+  parseSummarizeRetryAfterMs,
   suppressServerSummarization,
+  suppressServerSummarizationFor,
+  SUMMARIZE_RETRY_AFTER_MAX_MS,
+  SUMMARIZE_RETRY_AFTER_MIN_MS,
   SUMMARIZE_SUPPRESS_MS,
   __resetSummarizeGateForTests,
 } from '../src/services/summarize-gate.ts';
@@ -77,6 +81,52 @@ describe('summarize-gate — entitlement probe + timed suppression', () => {
     assert.ok(SUMMARIZE_SUPPRESS_MS >= 5 * 60_000, `window too short: ${SUMMARIZE_SUPPRESS_MS}`);
   });
 
+  it('parses Retry-After delta-seconds and HTTP dates deterministically', () => {
+    const t0 = Date.parse('2026-07-11T12:00:00.000Z');
+    assert.equal(parseSummarizeRetryAfterMs('90', t0), 90_000);
+    assert.equal(
+      parseSummarizeRetryAfterMs('Sat, 11 Jul 2026 12:02:00 GMT', t0),
+      120_000,
+    );
+  });
+
+  it('rejects malformed/expired Retry-After values and clamps untrusted extremes', () => {
+    const t0 = Date.parse('2026-07-11T12:00:00.000Z');
+    for (const value of [null, '', '-1', '1.5', 'not-a-date']) {
+      assert.equal(parseSummarizeRetryAfterMs(value, t0), null, String(value));
+    }
+    assert.equal(parseSummarizeRetryAfterMs('0', t0), SUMMARIZE_RETRY_AFTER_MIN_MS);
+    assert.equal(
+      parseSummarizeRetryAfterMs('999999999999999999999999', t0),
+      SUMMARIZE_RETRY_AFTER_MAX_MS,
+    );
+    assert.equal(
+      parseSummarizeRetryAfterMs('Sat, 11 Jul 2026 11:59:59 GMT', t0),
+      null,
+    );
+  });
+
+  it('never shortens an existing server-directed suppression window', () => {
+    configureSummarizeGate(() => true);
+    const t0 = 1_000_000;
+    suppressServerSummarizationFor(60_000, t0);
+    suppressServerSummarizationFor(5_000, t0 + 1_000);
+
+    assert.equal(canAttemptServerSummarization(t0 + 59_999), false);
+    assert.equal(canAttemptServerSummarization(t0 + 60_000), true);
+  });
+
+  it('bounds direct suppression inputs as defense in depth', () => {
+    configureSummarizeGate(() => true);
+    const t0 = 1_000_000;
+    suppressServerSummarizationFor(1, t0);
+    assert.equal(canAttemptServerSummarization(t0 + SUMMARIZE_RETRY_AFTER_MIN_MS - 1), false);
+    assert.equal(canAttemptServerSummarization(t0 + SUMMARIZE_RETRY_AFTER_MIN_MS), true);
+
+    suppressServerSummarizationFor(Number.POSITIVE_INFINITY, t0);
+    assert.equal(canAttemptServerSummarization(t0 + SUMMARIZE_RETRY_AFTER_MIN_MS), true);
+  });
+
   it('keeps state separate from classify-gate — a summarize 403 must not silence classification', async () => {
     const classifyGate = await import('../src/services/classify-gate.ts');
     classifyGate.__resetClassifyGateForTests();
@@ -111,6 +161,29 @@ describe('summarization.ts wiring (source-grep — module not loadable under nod
     assert.ok(
       branch.indexOf('suppressServerSummarization()') > -1,
       '403 branch must call suppressServerSummarization()',
+    );
+  });
+
+  it('a premium 429 consumes Retry-After at the fetch boundary before provider fan-out continues', () => {
+    const clientInit = src.slice(
+      src.indexOf('const premiumNewsClient'),
+      src.indexOf('// #4913'),
+    );
+    assert.match(clientInit, /response\.status === 429/, 'premium fetch boundary must inspect 429 responses');
+    assert.match(
+      clientInit,
+      /parseSummarizeRetryAfterMs\(response\.headers\.get\('Retry-After'\)\)/,
+      '429 path must parse the server Retry-After header',
+    );
+    assert.match(
+      clientInit,
+      /suppressServerSummarizationFor\(retryAfterMs\)/,
+      'valid Retry-After must suppress future premium dispatches',
+    );
+    assert.match(
+      clientInit,
+      /retryAfterMs === null[\s\S]*suppressServerSummarization\(\)/,
+      'malformed/missing Retry-After must still stop the current provider fan-out',
     );
   });
 


### PR DESCRIPTION
## Summary

Paid article-summary refreshes behind a shared NAT no longer consume one collective 30/min endpoint bucket. The three principals cited in the incident were confirmed as active paid subscribers; confirmed active paid callers now receive independent, trusted user-scoped buckets, while anonymous, free, expired, and unresolved callers retain the existing per-IP cap and the per-user daily LLM quota is unchanged.

Principal attribution happens behind a distinct fail-closed 600/min per-IP guard. That preserves NAT headroom while preventing authenticated callers from turning the entitlement lookup needed for attribution into an unbounded Redis/Convex amplification path. User API-key requests reuse their already-resolved entitlement instead of performing a second lookup.

The client now consumes `Retry-After` on summarize 429s at the premium fetch boundary, immediately stopping the remaining provider fan-out and sending later refreshes to the browser fallback for the bounded cooldown. This preserves the intentional 50/day direct-LLM cost ceiling without allowing daily-cap rejections to become a repeated 429 flood.

Fixes #5206.

## Validation

- Proof-first gateway regression failed before the implementation and passed after paid-principal attribution was added.
- Focused gateway suites: 17/17 passed.
- Retry-After and summarize-gate suite: 19/19 passed, including malformed/extreme header handling and non-shortening cooldown behavior.
- Rate-limit suite: 34/34 passed, including principal isolation, per-IP fallback, non-Lua Redis fallback, and scoped 429/503 contracts.
- Full data suite: 14,617 passed, 6 skipped, 0 failed.
- `npm run typecheck:all`, `npm run lint`, pre-push checks, and `npm run build:full` passed. Lint retained the repository's existing 31 warnings and 10 informational diagnostics.

## Post-Deploy Monitoring & Validation

For 24-72 hours after deployment, the platform owner should compare authenticated `/api/news/v1/summarize-article` usage by status, auth kind, and user principal in Axiom, with the issue's pre-deploy window as baseline.

- Success: paid-caller 429 share stays below 2%; anonymous/free request volume and 429 behavior remain stable; OpenRouter/Groq spend remains near the roughly $10/day baseline; no sustained `rate_limit_degraded`/503 increase appears.
- Watch latency as well as status mix because principal attribution adds one scoped Redis decision and may require an entitlement lookup on cache misses.
- Endpoint identifiers are rekeyed from `${pathname}:${ip}` to `${pathname}:ip:${ip}` for every endpoint policy, so deploy resets in-flight endpoint windows once; those windows are at most 60 seconds.
- Roll back this commit if paid 429s remain above 2%, anonymous/free 200 volume or provider spend rises materially, or the new scoped guard causes sustained degraded 503s. Reverting restores the prior shared-IP endpoint attribution without changing the daily quota contract.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
