### PR TITLE
fix(auth): suppress dead anonymous session retry storms

### DIFF
--- a/api/_usage-telemetry.js
+++ b/api/_usage-telemetry.js
@@ -13,6 +13,8 @@ const CB_MIN_SAMPLES = 20;
 
 const breakerSamples = [];
 let breakerTripped = false;
+let breakerOpenUntil = 0;
+let breakerProbeInFlight = false;
 
 function capHeader(value) {
   if (value == null) return null;
@@ -52,21 +54,43 @@ function originKind(req) {
   }
 }
 
-function recordDelivery(ok) {
+function recordDelivery(ok, isProbe) {
   const now = Date.now();
+  if (isProbe) {
+    breakerProbeInFlight = false;
+    if (ok) {
+      breakerSamples.length = 0;
+      breakerTripped = false;
+      breakerOpenUntil = 0;
+    } else {
+      breakerOpenUntil = now + CB_WINDOW_MS;
+    }
+    return;
+  }
   while (breakerSamples.length > 0 && now - breakerSamples[0].ts > CB_WINDOW_MS) breakerSamples.shift();
   breakerSamples.push({ ts: now, ok });
   if (breakerSamples.length < CB_MIN_SAMPLES) {
     breakerTripped = false;
+    breakerOpenUntil = 0;
     return;
   }
   breakerTripped = breakerSamples.filter((sample) => !sample.ok).length / breakerSamples.length > CB_TRIP_FAILURE_RATIO;
+  breakerOpenUntil = breakerTripped ? now + CB_WINDOW_MS : 0;
+}
+
+function deliveryMode() {
+  if (!breakerTripped) return 'normal';
+  if (Date.now() < breakerOpenUntil || breakerProbeInFlight) return null;
+  breakerProbeInFlight = true;
+  return 'probe';
 }
 
 async function deliver(event) {
   if (process.env.USAGE_TELEMETRY !== '1') return;
   const token = process.env.AXIOM_API_TOKEN;
-  if (!token || breakerTripped) return;
+  if (!token) return;
+  const mode = deliveryMode();
+  if (!mode) return;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
@@ -80,9 +104,9 @@ async function deliver(event) {
       body: JSON.stringify([event]),
       signal: controller.signal,
     });
-    recordDelivery(response.ok);
+    recordDelivery(response.ok, mode === 'probe');
   } catch {
-    recordDelivery(false);
+    recordDelivery(false, mode === 'probe');
     // Observability must never alter the session-mint response path.
   } finally {
     clearTimeout(timer);
@@ -92,6 +116,8 @@ async function deliver(event) {
 export function __resetWmSessionTelemetryForTests() {
   breakerSamples.length = 0;
   breakerTripped = false;
+  breakerOpenUntil = 0;
+  breakerProbeInFlight = false;
 }
 
 /**

--- a/api/_usage-telemetry.js
+++ b/api/_usage-telemetry.js
@@ -1,0 +1,144 @@
+// Edge-safe wm_api_usage emission for standalone API routes that do not pass
+// through server/gateway.ts. Keep this helper in api/: root-level .js Edge
+// functions cannot import server/_shared modules at runtime.
+
+import { getClientIp, UNKNOWN_CLIENT_IP } from './_client-ip.js';
+
+const AXIOM_INGEST_URL = 'https://api.axiom.co/v1/datasets/wm_api_usage/ingest';
+const MAX_HEADER_FIELD_LEN = 512;
+const TELEMETRY_TIMEOUT_MS = 1_500;
+const CB_WINDOW_MS = 5 * 60 * 1_000;
+const CB_TRIP_FAILURE_RATIO = 0.05;
+const CB_MIN_SAMPLES = 20;
+
+const breakerSamples = [];
+let breakerTripped = false;
+
+function capHeader(value) {
+  if (value == null) return null;
+  return value.length > MAX_HEADER_FIELD_LEN ? value.slice(0, MAX_HEADER_FIELD_LEN) : value;
+}
+
+function sanitizedReferer(req) {
+  const raw = req.headers.get('referer');
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    return capHeader(`${url.origin}${url.pathname}`);
+  } catch {
+    return null;
+  }
+}
+
+function requestBytes(req) {
+  const parsed = Number(req.headers.get('content-length'));
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function responseBytes(res) {
+  const parsed = Number(res.headers.get('content-length'));
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function originKind(req) {
+  const origin = req.headers.get('origin');
+  if (!origin) return null;
+  try {
+    return new URL(origin).host === new URL(req.url).host
+      ? 'browser-same-origin'
+      : 'browser-cross-origin';
+  } catch {
+    return 'browser-cross-origin';
+  }
+}
+
+function recordDelivery(ok) {
+  const now = Date.now();
+  while (breakerSamples.length > 0 && now - breakerSamples[0].ts > CB_WINDOW_MS) breakerSamples.shift();
+  breakerSamples.push({ ts: now, ok });
+  if (breakerSamples.length < CB_MIN_SAMPLES) {
+    breakerTripped = false;
+    return;
+  }
+  breakerTripped = breakerSamples.filter((sample) => !sample.ok).length / breakerSamples.length > CB_TRIP_FAILURE_RATIO;
+}
+
+async function deliver(event) {
+  if (process.env.USAGE_TELEMETRY !== '1') return;
+  const token = process.env.AXIOM_API_TOKEN;
+  if (!token || breakerTripped) return;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+  try {
+    const response = await fetch(AXIOM_INGEST_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify([event]),
+      signal: controller.signal,
+    });
+    recordDelivery(response.ok);
+  } catch {
+    recordDelivery(false);
+    // Observability must never alter the session-mint response path.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function __resetWmSessionTelemetryForTests() {
+  breakerSamples.length = 0;
+  breakerTripped = false;
+}
+
+/**
+ * Queue one terminal mint outcome. The event intentionally contains only
+ * allowlisted request metadata; never add cookies or request/response bodies.
+ */
+export function emitWmSessionUsage(ctx, req, res, startedAt, reason) {
+  if (!ctx?.waitUntil || process.env.USAGE_TELEMETRY !== '1') return;
+  try {
+    const requestId = req.headers.get('x-vercel-id') ?? '';
+    const executionRegion = requestId.includes('::') ? requestId.split('::', 1)[0] : null;
+    ctx.waitUntil(deliver({
+      _time: new Date().toISOString(),
+      event_type: 'request',
+      request_id: requestId,
+      domain: 'auth',
+      route: '/api/wm-session',
+      method: req.method,
+      status: res.status,
+      duration_ms: Math.max(0, Date.now() - startedAt),
+      req_bytes: requestBytes(req),
+      res_bytes: responseBytes(res),
+      customer_id: null,
+      principal_id: null,
+      auth_kind: 'anon',
+      tier: 0,
+      plan_key: null,
+      country: req.headers.get('x-vercel-ip-country') ?? req.headers.get('cf-ipcountry') ?? null,
+      ip_city: req.headers.get('x-vercel-ip-city') ?? null,
+      ip_region: req.headers.get('x-vercel-ip-country-region') ?? null,
+      execution_region: executionRegion,
+      execution_plane: 'vercel-edge',
+      origin_kind: originKind(req),
+      cache_tier: 'no-store',
+      ip: (() => {
+        const ip = getClientIp(req);
+        return ip === UNKNOWN_CLIENT_IP ? null : ip;
+      })(),
+      user_agent: capHeader(req.headers.get('user-agent')),
+      ua_hash: null,
+      referer: sanitizedReferer(req),
+      accept_language: capHeader(req.headers.get('accept-language')),
+      host: capHeader(req.headers.get('host')),
+      sentry_trace_id: req.headers.get('sentry-trace') ?? null,
+      reason,
+    }));
+  } catch {
+    // Request metadata parsing must not alter the mint response path.
+  }
+}

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -7,6 +7,7 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { timingSafeEqualSecret, timingSafeIncludes } from './_crypto.js';
 import { checkRateLimit } from './_rate-limit.js';
 import { issueSessionToken } from './_session.js';
+import { emitWmSessionUsage } from './_usage-telemetry.js';
 
 export const config = { runtime: 'edge' };
 
@@ -98,8 +99,17 @@ async function readBody(req) {
 }
 
 export default async function handler(req, ctx) {
+  const startedAt = Date.now();
+  const respond = (body, status, headers, reason) => {
+    const response = jsonResponse(body, status, headers);
+    emitWmSessionUsage(ctx, req, response, startedAt, reason);
+    return response;
+  };
+
   if (isDisallowedOrigin(req)) {
-    return new Response('Forbidden', { status: 403 });
+    const response = new Response('Forbidden', { status: 403 });
+    emitWmSessionUsage(ctx, req, response, startedAt, 'origin_403');
+    return response;
   }
 
   const cors = getCorsHeaders(req, 'POST, OPTIONS');
@@ -109,7 +119,7 @@ export default async function handler(req, ctx) {
   }
 
   if (req.method !== 'POST') {
-    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+    return respond({ error: 'Method not allowed' }, 405, cors, 'method_not_allowed');
   }
 
   // Rate-limit per IP. Without this, an attacker can farm tokens cheaply.
@@ -122,7 +132,10 @@ export default async function handler(req, ctx) {
     limit: SESSION_RATE_LIMIT_PER_MINUTE,
     window: SESSION_RATE_LIMIT_WINDOW,
   });
-  if (rl) return rl;
+  if (rl) {
+    emitWmSessionUsage(ctx, req, rl, startedAt, rl.status === 429 ? 'rate_limit_429' : 'rate_limit_degraded');
+    return rl;
+  }
 
   let issued;
   try {
@@ -130,7 +143,7 @@ export default async function handler(req, ctx) {
   } catch {
     // WM_SESSION_SECRET missing — fail closed. 503 signals "configure me",
     // not "you're rejected." Operator-visible.
-    return jsonResponse({ error: 'Session service not configured' }, 503, cors);
+    return respond({ error: 'Session service not configured' }, 503, cors, 'auth_unavailable');
   }
 
   const body = await readBody(req);
@@ -141,7 +154,7 @@ export default async function handler(req, ctx) {
     (submittedLegacyKey(body.widgetKey) && !(await isValidWidgetKey(widgetKey))) ||
     (submittedLegacyKey(body.proKey) && !(await isValidProKey(proKey)))
   ) {
-    return jsonResponse({ error: 'Invalid session key' }, 401, cors);
+    return respond({ error: 'Invalid session key' }, 401, cors, 'auth_401');
   }
 
   let headers = appendHeader(cors, 'Set-Cookie', sessionCookie(req, SESSION_COOKIE, issued.token));
@@ -157,5 +170,5 @@ export default async function handler(req, ctx) {
     headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, PRO_KEY_COOKIE, proKey));
   }
 
-  return jsonResponse({ ok: true, exp: issued.exp }, 200, headers);
+  return respond({ ok: true, exp: issued.exp }, 200, headers, 'ok');
 }

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -9,6 +9,7 @@ const originalEnv = { ...process.env };
 const { default: handler } = await import('./wm-session.js');
 const { validateSessionToken } = await import('./_session.js');
 const { __resetRateLimitForTest } = await import('./_rate-limit.js');
+const { __resetWmSessionTelemetryForTests } = await import('./_usage-telemetry.js');
 
 function restoreEnv() {
   for (const key of Object.keys(process.env)) {
@@ -42,18 +43,21 @@ function mockUpstashRateLimit({ remaining = 29, limit = 30 } = {}) {
 beforeEach(() => {
   configureDefaultEnv();
   __resetRateLimitForTest();
+  __resetWmSessionTelemetryForTests();
   mockUpstashRateLimit();
 });
 
 afterEach(() => {
   __resetRateLimitForTest();
+  __resetWmSessionTelemetryForTests();
   globalThis.fetch = originalFetch;
   restoreEnv();
 });
 
-function makeReq(method, { origin } = {}) {
+function makeReq(method, { origin, referer } = {}) {
   const headers = new Headers();
   if (origin) headers.set('origin', origin);
+  if (referer) headers.set('referer', referer);
   return new Request('https://api.worldmonitor.app/api/wm-session', { method, headers });
 }
 
@@ -94,6 +98,18 @@ function finalCookieJar(cookies) {
   return jar;
 }
 
+function makeWaitUntilCtx() {
+  const pending = [];
+  return {
+    ctx: { waitUntil: (promise) => pending.push(promise) },
+    settle: async () => {
+      for (let index = 0; index < pending.length; index += 1) {
+        await Promise.allSettled([pending[index]]);
+      }
+    },
+  };
+}
+
 test('POST from trusted origin sets a valid HttpOnly wms_ session cookie without exposing token JSON', async () => {
   const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
   assert.equal(resp.status, 200);
@@ -106,6 +122,61 @@ test('POST from trusted origin sets a valid HttpOnly wms_ session cookie without
   assert.equal(await validateSessionToken(token), true);
   assert.match(cookies.join('\n'), /wm-session=.*HttpOnly/);
   assert.match(cookies.join('\n'), /wm-session=.*Domain=\.worldmonitor\.app/);
+});
+
+test('POST emits one anonymous mint usage event without exposing cookie material', async () => {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  const events = [];
+  globalThis.fetch = async (input, init) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.includes('fake.upstash.io')) {
+      return new Response(JSON.stringify([{ result: [29, 30] }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('axiom.co')) {
+      events.push(...JSON.parse(init.body));
+      return new Response('{}', { status: 200 });
+    }
+    throw new Error(`unexpected telemetry fetch: ${url}`);
+  };
+  const { ctx, settle } = makeWaitUntilCtx();
+
+  const request = makeReq('POST', {
+    origin: 'https://worldmonitor.app',
+    referer: 'https://worldmonitor.app/reset-password?token=must-not-be-logged#also-not-logged',
+  });
+  request.headers.set('x-forwarded-for', '203.0.113.99, attacker-controlled');
+  const resp = await handler(request, ctx);
+  assert.equal(resp.status, 200);
+  await settle();
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(
+    {
+      event_type: events[0].event_type,
+      route: events[0].route,
+      status: events[0].status,
+      auth_kind: events[0].auth_kind,
+      origin_kind: events[0].origin_kind,
+      ip: events[0].ip,
+      referer: events[0].referer,
+      reason: events[0].reason,
+    },
+    {
+      event_type: 'request',
+      route: '/api/wm-session',
+      status: 200,
+      auth_kind: 'anon',
+      origin_kind: 'browser-cross-origin',
+      ip: null,
+      referer: 'https://worldmonitor.app/reset-password',
+      reason: 'ok',
+    },
+  );
+  assert.equal(JSON.stringify(events[0]).includes('wms_'), false, 'never telemeter the minted session token');
 });
 
 test('localhost session cookie remains host-only for dev', async () => {
@@ -182,6 +253,69 @@ test('POST returns 429 without issuing a token when the wm-session issuance budg
   assert.equal(cookieValue(setCookies(resp), 'wm-session'), '');
   const body = await resp.json();
   assert.equal(body.error, 'Too many requests');
+});
+
+test('failed mint outcomes emit their terminal status', async () => {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  const events = [];
+  globalThis.fetch = async (input, init) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.includes('fake.upstash.io')) {
+      return new Response(JSON.stringify([{ result: [-1, 30] }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('axiom.co')) {
+      events.push(...JSON.parse(init.body));
+      return new Response('{}', { status: 200 });
+    }
+    throw new Error(`unexpected telemetry fetch: ${url}`);
+  };
+  const { ctx, settle } = makeWaitUntilCtx();
+
+  const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }), ctx);
+  assert.equal(resp.status, 429);
+  await settle();
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].status, 429);
+  assert.equal(events[0].reason, 'rate_limit_429');
+});
+
+test('telemetry stops delivery attempts when the Axiom sink is repeatedly unavailable', async () => {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  let axiomAttempts = 0;
+  globalThis.fetch = async (input) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.includes('fake.upstash.io')) {
+      return new Response(JSON.stringify([{ result: [29, 30] }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('axiom.co')) {
+      axiomAttempts += 1;
+      throw new Error('Axiom unavailable');
+    }
+    throw new Error(`unexpected telemetry fetch: ${url}`);
+  };
+
+  for (let index = 0; index < 20; index += 1) {
+    const { ctx, settle } = makeWaitUntilCtx();
+    const response = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }), ctx);
+    assert.equal(response.status, 200);
+    await settle();
+  }
+  assert.equal(axiomAttempts, 20);
+
+  const { ctx, settle } = makeWaitUntilCtx();
+  const response = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }), ctx);
+  assert.equal(response.status, 200);
+  await settle();
+  assert.equal(axiomAttempts, 20, 'open circuit breaker drops later telemetry delivery attempts');
 });
 
 test('no-key session refresh preserves existing HttpOnly key cookies', async () => {

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -318,6 +318,53 @@ test('telemetry stops delivery attempts when the Axiom sink is repeatedly unavai
   assert.equal(axiomAttempts, 20, 'open circuit breaker drops later telemetry delivery attempts');
 });
 
+test('telemetry probes and closes the circuit after the outage window elapses', async () => {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  const originalDateNow = Date.now;
+  let now = 1_000_000;
+  let axiomAttempts = 0;
+  let axiomAvailable = false;
+  Date.now = () => now;
+  globalThis.fetch = async (input) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.includes('fake.upstash.io')) {
+      return new Response(JSON.stringify([{ result: [29, 30] }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('axiom.co')) {
+      axiomAttempts += 1;
+      if (!axiomAvailable) throw new Error('Axiom unavailable');
+      return new Response('{}', { status: 200 });
+    }
+    throw new Error(`unexpected telemetry fetch: ${url}`);
+  };
+
+  try {
+    for (let index = 0; index < 20; index += 1) {
+      const { ctx, settle } = makeWaitUntilCtx();
+      await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }), ctx);
+      await settle();
+    }
+    now += 5 * 60 * 1000 + 1;
+    axiomAvailable = true;
+
+    const recovered = makeWaitUntilCtx();
+    await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }), recovered.ctx);
+    await recovered.settle();
+    assert.equal(axiomAttempts, 21, 'a single half-open delivery probes the recovered sink');
+
+    const resumed = makeWaitUntilCtx();
+    await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }), resumed.ctx);
+    await resumed.settle();
+    assert.equal(axiomAttempts, 22, 'a successful probe closes the circuit for later events');
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test('no-key session refresh preserves existing HttpOnly key cookies', async () => {
   const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
   assert.equal(resp.status, 200);

--- a/src/App.ts
+++ b/src/App.ts
@@ -92,7 +92,7 @@ import {
   waitForBootstrapSlowTier,
   type BootstrapHydrationState,
 } from '@/services/bootstrap';
-import { ensureWmSession, installWmSessionFetchInterceptor } from '@/services/wm-session';
+import { ensureWmSession, installWmSessionFetchInterceptor, WM_SESSION_DEGRADED_EVENT } from '@/services/wm-session';
 import { describeFreshness } from '@/services/persistent-cache';
 import { DesktopUpdater } from '@/app/desktop-updater';
 import { CountryIntelManager } from '@/app/country-intel';
@@ -191,6 +191,11 @@ export class App {
   private followedCountriesCapDropToastTimer: number | null = null;
   private bootstrapHydrationState: BootstrapHydrationState = getBootstrapHydrationState();
   private cachedModeBannerEl: HTMLElement | null = null;
+  private readonly handleWmSessionDegraded = (): void => {
+    if (!this.state.isDestroyed) {
+      showToast('Anonymous data is temporarily unavailable. Check your cookie settings, then reload.');
+    }
+  };
   private readonly handleViewportPrime = (): void => {
     if (this.visiblePanelPrimeRaf !== null) return;
     this.visiblePanelPrimeRaf = window.requestAnimationFrame(() => {
@@ -1354,6 +1359,7 @@ export class App {
     // API key path and doesn't need this; Clerk-authenticated users will pass
     // their JWT in a Bearer header and the interceptor steps aside.
     if (!isDesktopRuntime()) {
+      window.addEventListener(WM_SESSION_DEGRADED_EVENT, this.handleWmSessionDegraded);
       installWmSessionFetchInterceptor();
       await ensureWmSession();
       markLcpDebug('wm:boot:session-ready');
@@ -1816,6 +1822,7 @@ export class App {
     destroyBreakingNewsAlerts();
     this.cachedModeBannerEl?.remove();
     this.cachedModeBannerEl = null;
+    window.removeEventListener(WM_SESSION_DEGRADED_EVENT, this.handleWmSessionDegraded);
     if (this.followedCountriesCapDropToastTimer !== null) {
       window.clearTimeout(this.followedCountriesCapDropToastTimer);
       this.followedCountriesCapDropToastTimer = null;

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -22,6 +22,11 @@ const REFRESH_MARGIN_MS = 5 * 60 * 1000;
 // 12-hour token expires. Long-lived tabs (overnight, multi-day) lose the
 // token without this; the original implementation had no auto-refresh.
 const PERIODIC_REFRESH_MS = 30 * 60 * 1000;
+// A rejected retry means the browser cannot currently deliver the HttpOnly
+// cookie (for example, strict cookie settings). Avoid amplifying that into a
+// request + mint + retry loop for every panel refresh.
+const SESSION_DEAD_COOLDOWN_MS = 15 * 60 * 1000;
+export const WM_SESSION_DEGRADED_EVENT = 'wm-session-degraded';
 
 interface StoredSession {
   exp: number;
@@ -29,9 +34,41 @@ interface StoredSession {
 
 let cached: StoredSession | null = null;
 let inflight: Promise<boolean> | null = null;
+let recoveryInFlight: Promise<Response | null> | null = null;
+let sessionGeneration = 0;
 let interceptorInstalled = false;
 let nativeSessionFetch: typeof fetch | null = null;
-let retryRejectedWarned = false;
+let sessionDeadUntil = 0;
+
+export function isWmSessionDead(): boolean {
+  if (sessionDeadUntil <= Date.now()) {
+    sessionDeadUntil = 0;
+    return false;
+  }
+  return true;
+}
+
+function markWmSessionDead(): void {
+  const alreadyDead = isWmSessionDead();
+  sessionDeadUntil = Date.now() + SESSION_DEAD_COOLDOWN_MS;
+  cached = null;
+  try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+  if (alreadyDead) return;
+  console.warn('[wm-session] refreshed HttpOnly session cookie was still rejected; suppressing anonymous API calls briefly');
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new Event(WM_SESSION_DEGRADED_EVENT));
+  }
+}
+
+function sessionDegradedResponse(): Response {
+  return new Response(JSON.stringify({ error: 'Anonymous session temporarily unavailable' }), {
+    status: 503,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Wm-Session-Degraded': '1',
+    },
+  });
+}
 
 function isFresh(s: StoredSession | null): s is StoredSession {
   return !!s && s.exp - REFRESH_MARGIN_MS > Date.now();
@@ -70,6 +107,7 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
 }
 
 export async function ensureWmSession(): Promise<boolean> {
+  if (isWmSessionDead()) return false;
   if (isFresh(cached)) return true;
   if (inflight) return inflight;
 
@@ -83,6 +121,7 @@ export async function ensureWmSession(): Promise<boolean> {
     const fresh = await fetchNewSession();
     if (fresh) {
       cached = fresh;
+      sessionGeneration += 1;
       saveToStorage(fresh);
       return true;
     }
@@ -102,6 +141,8 @@ export async function establishWmKeySession(keys: { widgetKey?: string; proKey?:
   const fresh = await fetchNewSession(keys);
   if (!fresh) return false;
   cached = fresh;
+  sessionGeneration += 1;
+  sessionDeadUntil = 0;
   saveToStorage(fresh);
   return true;
 }
@@ -123,8 +164,10 @@ function withCredentials(init?: RequestInit): RequestInit {
 export function __resetWmSessionForTests(): void {
   cached = null;
   inflight = null;
+  recoveryInFlight = null;
+  sessionGeneration = 0;
   interceptorInstalled = false;
-  retryRejectedWarned = false;
+  sessionDeadUntil = 0;
 }
 
 // Install a one-shot fetch wrapper that includes HttpOnly session cookies on
@@ -236,7 +279,11 @@ export function installWmSessionFetchInterceptor(): void {
       return original(input, withCredentials(init));
     }
 
+    if (isWmSessionDead()) return sessionDegradedResponse();
+
     await ensureWmSession().catch(() => false);
+
+    if (isWmSessionDead()) return sessionDegradedResponse();
 
     // A Request body is a one-shot stream — clone BEFORE the first send so
     // the refresh-on-401 retry below has an intact body to replay. For
@@ -251,6 +298,7 @@ export function installWmSessionFetchInterceptor(): void {
       return original(src, { ...withCredentials(init), headers: h });
     };
 
+    const requestSessionGeneration = sessionGeneration;
     const resp = await sendWith(headers, input);
 
     // Layer 2 — refresh-on-401. A single transient blip (HMAC-key rotation,
@@ -260,6 +308,13 @@ export function installWmSessionFetchInterceptor(): void {
     // wms_ token is irrelevant there.
     if (resp.status !== 401) return resp;
 
+    // A slower initial request can report the old cookie after another caller
+    // already recovered it. Replay with the newer cookie instead of clearing
+    // that success and spending another mint.
+    if (sessionGeneration !== requestSessionGeneration) {
+      return sendWith(new Headers(headers), requestClone ?? input);
+    }
+
     // Invalidate the cached expiry (and its sessionStorage twin) before
     // re-minting. ensureWmSession() is opportunistic — without invalidation,
     // it would return the same not-yet-clock-expired token that the server
@@ -268,16 +323,33 @@ export function installWmSessionFetchInterceptor(): void {
     cached = null;
     try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
 
-    const fresh = await ensureWmSession().catch(() => false);
-    if (!fresh) return resp;
-
-    const retryHeaders = new Headers(headers);
-    const retryResp = await sendWith(retryHeaders, requestClone ?? input);
-    if (retryResp.status === 401 && !retryRejectedWarned) {
-      retryRejectedWarned = true;
-      console.warn('[wm-session] API request still returned 401 after refreshing HttpOnly session cookie');
+    // One request verifies the reminted cookie. Other simultaneous 401s wait
+    // for that result instead of each multiplying the failed retry.
+    if (!recoveryInFlight) {
+      const recovery = (async (): Promise<Response | null> => {
+        const fresh = await ensureWmSession().catch(() => false);
+        if (!fresh) {
+          markWmSessionDead();
+          return null;
+        }
+        const retryResp = await sendWith(new Headers(headers), requestClone ?? input);
+        if (retryResp.status === 401) {
+          markWmSessionDead();
+          return null;
+        }
+        return retryResp;
+      })();
+      recoveryInFlight = recovery;
+      void recovery.then(
+        () => { if (recoveryInFlight === recovery) recoveryInFlight = null; },
+        () => { if (recoveryInFlight === recovery) recoveryInFlight = null; },
+      );
+      return (await recovery) ?? resp;
     }
-    return retryResp;
+
+    const verified = await recoveryInFlight;
+    if (!verified) return resp;
+    return sendWith(new Headers(headers), requestClone ?? input);
   };
 
   // Layer 1 — periodic refresh. The token is short-lived (12h server-side)

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -366,12 +366,11 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     assert.equal(lastSeenAuth, 'Bearer caller-supplied-jwt', 'caller Authorization must pass through untouched');
   });
 
-  it('returns the second 401 if the retry also fails (no infinite loop)', async () => {
+  it('suppresses later anonymous API calls when a refreshed session is still rejected', async () => {
     // No cached expiry and no stored expiry. Server 401s, the interceptor
     // mints a fresh cookie, replays with credentials, server 401s again.
-    // The second 401 must be returned as-is (no further retry) — the
-    // retryGuard semantics are encoded by `fresh === token`-bail and by the
-    // structural fact that the retry path is never re-entered.
+    // The second 401 must be returned as-is (no further retry); later calls
+    // are suppressed by the dead-session cooldown.
     memoryStorage.clear();
 
     let bootstrapAttempts = 0;
@@ -396,14 +395,95 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
     try {
       const resp = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
-      assert.equal(resp.status, 401, 'returns second 401 instead of looping');
+      assert.equal(resp.status, 401, 'the failed recovery returns the server response');
+
+      const suppressed = await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/list-service-statuses');
+      assert.equal(suppressed.status, 503, 'the dead session suppresses later gated calls during the cooldown');
+      assert.equal(suppressed.headers.get('x-wm-session-degraded'), '1');
     } finally {
       console.warn = originalWarn;
     }
-    assert.equal(bootstrapAttempts, 2, 'exactly one retry — no infinite loop');
-    assert.equal(mintCalls, 2, 'initial preflight mint plus one refresh mint after the first 401');
+    assert.equal(bootstrapAttempts, 2, 'exactly one retry — later calls must not reach the API');
+    assert.equal(mintCalls, 2, 'initial preflight mint plus one recovery mint; no later remints');
     assert.deepEqual(warnings, [
-      '[wm-session] API request still returned 401 after refreshing HttpOnly session cookie',
+      '[wm-session] refreshed HttpOnly session cookie was still rejected; suppressing anonymous API calls briefly',
     ]);
+  });
+
+  it('single-flights concurrent 401 recovery so only one retry verifies the mint', async () => {
+    memoryStorage.clear();
+    let gatedAttempts = 0;
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      gatedAttempts += 1;
+      return Promise.resolve(new Response('still-rejected', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const responses = await Promise.all([
+        wrappedFetch('https://api.worldmonitor.app/api/bootstrap'),
+        wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/list-service-statuses'),
+        wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health'),
+      ]);
+      assert.deepEqual(responses.map((response) => response.status), [401, 401, 401]);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.equal(mintCalls, 2, 'all callers share the initial mint and one recovery mint');
+    assert.equal(gatedAttempts, 4, 'three initial 401s plus one verifier retry, never one retry per caller');
+  });
+
+  it('replays a delayed stale 401 after another caller has refreshed the session', async () => {
+    memoryStorage.clear();
+    let mintCalls = 0;
+    let bootstrapAttempts = 0;
+    let cableAttempts = 0;
+    let releaseDelayed401: (() => void) | null = null;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      if (url.includes('/api/bootstrap')) {
+        bootstrapAttempts += 1;
+        return Promise.resolve(new Response(bootstrapAttempts === 1 ? 'stale' : 'recovered', {
+          status: bootstrapAttempts === 1 ? 401 : 200,
+        }));
+      }
+      cableAttempts += 1;
+      if (cableAttempts === 1) {
+        return new Promise((resolve) => {
+          releaseDelayed401 = () => resolve(new Response('stale', { status: 401 }));
+        });
+      }
+      return Promise.resolve(new Response('recovered', { status: 200 }));
+    };
+
+    const first = wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+    const delayed = wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.ok(releaseDelayed401, 'the second request should already be awaiting its stale response');
+    releaseDelayed401?.();
+
+    const [firstResponse, delayedResponse] = await Promise.all([first, delayed]);
+    assert.equal(firstResponse.status, 200);
+    assert.equal(delayedResponse.status, 200);
+    assert.equal(mintCalls, 2, 'one initial mint plus one recovery mint');
+    assert.equal(bootstrapAttempts, 2, 'the first caller verifies the reminted cookie once');
+    assert.equal(cableAttempts, 2, 'the delayed stale response replays without invalidating the fresh session');
   });
 });


### PR DESCRIPTION
## Summary

Anonymous browsers that cannot return the shared HttpOnly session cookie no longer remint and retry every protected RPC indefinitely. The first unrecoverable retry is surfaced, simultaneous requests share one verification attempt, and later anonymous requests pause locally with reload guidance instead of continuing the 401 flood.

The session-mint route now emits bounded, redacted `wm_api_usage` outcomes, so operators can distinguish successful mints, origin rejection, auth rejection, configuration failure, and rate limiting without logging session cookies or request bodies. Telemetry is time-bounded and opens its circuit after a persistent sink outage, leaving minting unaffected.

Fixes #5207.

## Validation

- Reproduced the production baseline: an unauthenticated `POST /api/news/v1/summarize-article` returns `401`.
- `./node_modules/.bin/tsx --test tests/wm-session-auto-refresh.test.mts` — 10 passed.
- `node --test api/wm-session.test.mjs` — 19 passed.
- `npm run typecheck`, `npm run typecheck:api`, `node --test tests/edge-functions.test.mjs` (228 passed), `node scripts/enforce-sebuf-api-contract.mjs`, and `npm run test:data` passed.

## Post-deploy monitoring

For 24–72 hours after deploy, track the daily `auth_401` count for browser-originated `wm_api_usage` events; it should fall materially from the issue baseline. Also group `/api/wm-session` outcomes by `status` and `reason` to catch unexpected mint failures or rate-limit degradation. A sustained `auth_401` level, new `auth_unavailable` events, or elevated `rate_limit_degraded` outcomes is a rollback trigger.

```apl
['wm_api_usage']
| where route == '/api/wm-session'
| summarize requests=count() by reason, status, bin(_time, 1d)
```

## Residual risk

This intentionally retains the existing shared `.worldmonitor.app` cookie model. Moving to a partitioned/CHIPS cookie could change cross-subdomain behavior, so it needs a dedicated browser compatibility decision and live third-party-cookie validation rather than being bundled into this incident fix.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
