### PR TITLE
perf(mobile): split post-hydration long-task wave

### DIFF
--- a/scripts/generate-product-config.mjs
+++ b/scripts/generate-product-config.mjs
@@ -5,6 +5,7 @@
  * Reads: convex/config/productCatalog.ts
  * Writes:
  *   - src/config/products.generated.ts   (product IDs for dashboard)
+ *   - src/config/product-ids.generated.ts (analytics-safe product ID allowlist)
  *   - pro-test/src/generated/tiers.json  (tier view model for /pro page)
  *   - pro-test/src/locales/*.json       (English pricing feature placeholders)
  *
@@ -66,6 +67,22 @@ export const DEFAULT_UPGRADE_PRODUCT = DODO_PRODUCTS.PRO_MONTHLY;
 const productsPath = join(ROOT, 'src/config/products.generated.ts');
 writeFileSync(productsPath, productsTs);
 console.log(`  ✓ ${productsPath}`);
+
+const productIdsTs = `// AUTO-GENERATED from convex/config/productCatalog.ts
+// Do not edit manually. Run: npx tsx scripts/generate-product-config.mjs
+
+/** Product IDs accepted by client-side analytics without loading checkout config. */
+export const DODO_PRODUCT_IDS: ReadonlySet<string> = new Set([
+${Object.values(PRODUCT_CATALOG)
+  .filter((entry) => entry.dodoProductId)
+  .map((entry) => `  '${entry.dodoProductId}',`)
+  .join('\n')}
+]);
+`;
+
+const productIdsPath = join(ROOT, 'src/config/product-ids.generated.ts');
+writeFileSync(productIdsPath, productIdsTs);
+console.log(`  ✓ ${productIdsPath}`);
 
 // ---------------------------------------------------------------------------
 // 1b. Generate api/_product-fallback-prices.js

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2,6 +2,8 @@ import type { AppContext, AppModule } from '@/app/app-context';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { enqueuePanelCall } from '@/app/pending-panel-data';
 import { markLcpDebug } from '@/utils/lcp-debug';
+import { runHydrationTier, type HydrationTask } from '@/app/hydration-scheduler';
+import { yieldToMain } from '@/utils/after-paint';
 import { getSignalAggregator, type SignalAggregator } from '@/app/lazy-services';
 import { getMilitaryVesselsModule, isVesselRuntimeStoppedError } from '@/services/military-vessels-lazy';
 import type { NewsItem, MapLayers, SocialUnrestEvent, MilitaryFlight } from '@/types';
@@ -239,11 +241,6 @@ export interface DataLoaderCallbacks {
   refreshOpenCountryBrief: () => void;
 }
 
-type HydrationTask = {
-  name: string;
-  task: () => Promise<void>;
-};
-
 type HydrationTier = 1 | 2 | 3 | 4;
 type DailyMarketBriefModule = typeof import('@/services/daily-market-brief');
 type RssModule = Pick<typeof import('@/services/rss'), 'fetchCategoryFeeds' | 'getFeedFailures'>;
@@ -424,27 +421,17 @@ export class DataLoaderManager implements AppModule {
     performance.mark(label);
   }
 
-  private async yieldHydrationFrame(): Promise<void> {
-    if (typeof window === 'undefined') return;
-    await new Promise<void>(resolve => {
-      const idle = window.requestIdleCallback as ((cb: IdleRequestCallback, opts?: IdleRequestOptions) => number) | undefined;
-      if (idle) {
-        idle(() => resolve(), { timeout: 250 });
-        return;
-      }
-      window.setTimeout(resolve, 16);
-    });
-  }
-
   private async runHydrationTasks(tasks: HydrationTask[], forceAll: boolean): Promise<void> {
     const prioritized = tasks
       .map((task, order) => ({ ...task, order, tier: this.getHydrationTier(task.name) }))
       .sort((a, b) => a.tier - b.tier || a.order - b.order);
 
-    const maxConcurrency = forceAll ? 6 : 3;
+    // On the mobile profile, starting several panel loaders in the same task
+    // lets their dynamic-import evaluation and synchronous render work merge
+    // into one long task. Keep desktop concurrency, but give the browser a
+    // scheduling boundary between every mobile panel in a tier. (#5165)
+    const maxConcurrency = this.ctx.isMobile ? 1 : (forceAll ? 6 : 3);
     const failures: Array<{ name: string; reason: unknown }> = [];
-    let cursor = 0;
-
     this.markHydration(`wm:hydration:${forceAll ? 'force' : 'viewport'}:start`);
 
     for (const tier of HYDRATION_TIERS) {
@@ -452,21 +439,14 @@ export class DataLoaderManager implements AppModule {
       if (tierTasks.length === 0) continue;
 
       this.markHydration(`wm:hydration:tier-${tier}:start`);
-      cursor = 0;
-      while (cursor < tierTasks.length) {
-        const batch = tierTasks.slice(cursor, cursor + maxConcurrency);
-        const results = await Promise.allSettled(batch.map(item => item.task()));
-        results.forEach((result, idx) => {
-          if (result.status === 'rejected') {
-            failures.push({ name: batch[idx]?.name ?? 'unknown', reason: result.reason });
-          }
-        });
-
-        cursor += batch.length;
-        if (cursor < tierTasks.length) await this.yieldHydrationFrame();
-      }
+      await runHydrationTier({
+        tasks: tierTasks,
+        maxConcurrency,
+        yieldToMain,
+        onFailure: (name, reason) => failures.push({ name, reason }),
+      });
       this.markHydration(`wm:hydration:tier-${tier}:end`);
-      if (tier < 4 && prioritized.some(task => task.tier > tier)) await this.yieldHydrationFrame();
+      if (tier < 4 && prioritized.some(task => task.tier > tier)) await yieldToMain();
     }
 
     this.markHydration(`wm:hydration:${forceAll ? 'force' : 'viewport'}:end`);

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -605,8 +605,9 @@ export class EventHandlerManager implements AppModule {
         mode: 'modify',
         existingSpec: spec,
         onComplete: (updated) => {
-          saveWidget(updated);
-          (this.ctx.panels[updated.id] as CustomWidgetPanel | undefined)?.updateSpec(updated);
+          void saveWidget(updated).then(() => {
+            (this.ctx.panels[updated.id] as CustomWidgetPanel | undefined)?.updateSpec(updated);
+          }).catch((error) => console.error('[widget-chat] failed to save widget', error));
         },
       })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     }) as EventListener;

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -607,7 +607,10 @@ export class EventHandlerManager implements AppModule {
         onComplete: (updated) => {
           void saveWidget(updated).then(() => {
             (this.ctx.panels[updated.id] as CustomWidgetPanel | undefined)?.updateSpec(updated);
-          }).catch((error) => console.error('[widget-chat] failed to save widget', error));
+          }).catch((error) => {
+            console.error('[widget-chat] failed to save widget', error);
+            showToast(t('widgets.saveFailed'));
+          });
         },
       })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     }) as EventListener;

--- a/src/app/hydration-scheduler.ts
+++ b/src/app/hydration-scheduler.ts
@@ -1,0 +1,38 @@
+export interface HydrationTask {
+  name: string;
+  task: () => Promise<void>;
+}
+
+interface RunHydrationTierOptions {
+  tasks: HydrationTask[];
+  maxConcurrency: number;
+  yieldToMain: () => Promise<void>;
+  onFailure: (name: string, reason: unknown) => void;
+}
+
+/**
+ * Run one priority tier without letting mobile panel loaders merge into the
+ * same main-thread task. The caller controls the concurrency policy so desktop
+ * force-all hydration retains its existing parallelism. (#5165)
+ */
+export async function runHydrationTier({
+  tasks,
+  maxConcurrency,
+  yieldToMain,
+  onFailure,
+}: RunHydrationTierOptions): Promise<void> {
+  let cursor = 0;
+
+  while (cursor < tasks.length) {
+    const batch = tasks.slice(cursor, cursor + maxConcurrency);
+    const results = await Promise.allSettled(batch.map(item => item.task()));
+    results.forEach((result, idx) => {
+      if (result.status === 'rejected') {
+        onFailure(batch[idx]?.name ?? 'unknown', result.reason);
+      }
+    });
+
+    cursor += batch.length;
+    if (cursor < tasks.length) await yieldToMain();
+  }
+}

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -515,7 +515,10 @@ export class PanelLayoutManager implements AppModule {
         tier: 'pro',
         initialMessage: e.detail.initialMessage,
         onComplete: (spec) => {
-          void this.addCustomWidget(spec).catch((error) => console.error('[widget-builder] failed to add widget', error));
+          void this.addCustomWidget(spec).catch((error) => {
+            console.error('[widget-builder] failed to add widget', error);
+            showToast(t('widgets.saveFailed'));
+          });
         },
       })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     }) as EventListener;
@@ -2321,7 +2324,10 @@ export class PanelLayoutManager implements AppModule {
         mode: 'create',
         tier: 'pro',
         onComplete: (spec) => {
-          void this.addCustomWidget(spec).catch((error) => console.error('[widget-builder] failed to add widget', error));
+          void this.addCustomWidget(spec).catch((error) => {
+            console.error('[widget-builder] failed to add widget', error);
+            showToast(t('widgets.saveFailed'));
+          });
         },
       })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     });

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -514,7 +514,9 @@ export class PanelLayoutManager implements AppModule {
         mode: 'create',
         tier: 'pro',
         initialMessage: e.detail.initialMessage,
-        onComplete: (spec) => this.addCustomWidget(spec),
+        onComplete: (spec) => {
+          void this.addCustomWidget(spec).catch((error) => console.error('[widget-builder] failed to add widget', error));
+        },
       })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     }) as EventListener;
     this.ctx.container.addEventListener('wm:open-widget-creator', this.boundWidgetCreatorHandler);
@@ -2318,7 +2320,9 @@ export class PanelLayoutManager implements AppModule {
       void import('@/components/WidgetChatModal').then((m) => m.openWidgetChatModal({
         mode: 'create',
         tier: 'pro',
-        onComplete: (spec) => this.addCustomWidget(spec),
+        onComplete: (spec) => {
+          void this.addCustomWidget(spec).catch((error) => console.error('[widget-builder] failed to add widget', error));
+        },
       })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     });
     panelsGrid.appendChild(proBlock);
@@ -2591,8 +2595,8 @@ export class PanelLayoutManager implements AppModule {
     this.applyPanelSettings();
   }
 
-  addCustomWidget(spec: CustomWidgetSpec): void {
-    saveWidget(spec);
+  async addCustomWidget(spec: CustomWidgetSpec): Promise<void> {
+    await saveWidget(spec);
     this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
     saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
     void this.importPanel(

--- a/src/config/product-ids.generated.ts
+++ b/src/config/product-ids.generated.ts
@@ -1,0 +1,12 @@
+// AUTO-GENERATED from convex/config/productCatalog.ts
+// Do not edit manually. Run: npx tsx scripts/generate-product-config.mjs
+
+/** Product IDs accepted by client-side analytics without loading checkout config. */
+export const DODO_PRODUCT_IDS: ReadonlySet<string> = new Set([
+  'pdt_0Nbtt71uObulf7fGXhQup',
+  'pdt_0NbttMIfjLWC10jHQWYgJ',
+  'pdt_0NbttVmG1SERrxhygbbUq',
+  'pdt_0Nbu2lawHYE3dv2THgSEV',
+  'pdt_0Nbttg7NuOJrhbyBGCius',
+  'pdt_0Nbttnqrfh51cRqhMdVLx',
+]);

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -3108,6 +3108,7 @@
     "serverError": "خطأ الخادم: {{status}}",
     "unknownError": "خطأ غير معروف",
     "generatedWidget": "أداة معاد إنشاؤها: {{title}}",
+    "saveFailed": "تعذر حفظ الأداة. حاول مرة أخرى.",
     "checkingConnection": "التحقق من وصول الأداة…",
     "preflightConnected": "تم الاتصال بوكيل الأداة",
     "preflightInvalidKey": "مفتاح الأداة مرفوض. حدّث wm-widget-key وأعد التحميل.",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -3044,6 +3044,7 @@
     "serverError": "Грешка на сървъра: {{status}}",
     "unknownError": "Неизвестна грешка",
     "generatedWidget": "Генериран уиджет: {{title}}",
+    "saveFailed": "Приспособлението не можа да бъде запазено. Опитайте отново.",
     "checkingConnection": "Проверка на достъп до уиджет…",
     "preflightConnected": "Свързан със агент за уиджети",
     "preflightInvalidKey": "Ключ на уиджет отхвърлен. Актуализирай wm-widget-key и презареди.",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -3076,6 +3076,7 @@
     "serverError": "Chyba serveru: {{status}}",
     "unknownError": "Neznámá chyba",
     "generatedWidget": "Vygenerovaný widget: {{title}}",
+    "saveFailed": "Widget se nepodařilo uložit. Zkuste to prosím znovu.",
     "checkingConnection": "Ověřování přístupu k widgetu…",
     "preflightConnected": "Připojeno k agentovi widgetu",
     "preflightInvalidKey": "Klíč widgetu odmítnut. Aktualizujte wm-widget-key a načtěte znovu.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3044,6 +3044,7 @@
     "serverError": "Serverfehler: {{status}}",
     "unknownError": "Unbekannter Fehler",
     "generatedWidget": "Generiertes Widget: {{title}}",
+    "saveFailed": "Widget konnte nicht gespeichert werden. Bitte versuche es erneut.",
     "checkingConnection": "Prüfe Widget-Zugriff…",
     "preflightConnected": "Mit Widget-Agent verbunden",
     "preflightInvalidKey": "Widget-Schlüssel abgelehnt. Aktualisieren Sie wm-widget-key und laden Sie neu.",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -3044,6 +3044,7 @@
     "serverError": "Σφάλμα διακομιστή: {{status}}",
     "unknownError": "Άγνωστο σφάλμα",
     "generatedWidget": "Δημιουργημένο widget: {{title}}",
+    "saveFailed": "Δεν ήταν δυνατή η αποθήκευση του γραφικού στοιχείου. Δοκιμάστε ξανά.",
     "checkingConnection": "Έλεγχος πρόσβασης widget…",
     "preflightConnected": "Συνδεδεμένο με τον παράγοντα widget",
     "preflightInvalidKey": "Κλειδί widget απορρίφθηκε. Ενημερώστε wm-widget-key και επαναφορτώστε.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,6 +21,7 @@
     "serverError": "Server error: {{status}}",
     "unknownError": "Unknown error",
     "generatedWidget": "Generated widget: {{title}}",
+    "saveFailed": "Widget could not be saved. Please try again.",
     "checkingConnection": "Checking widget access…",
     "preflightConnected": "Connected to the widget agent",
     "preflightInvalidKey": "Widget key rejected. Update wm-widget-key and reload.",

--- a/src/locales/en.shell.json
+++ b/src/locales/en.shell.json
@@ -321,6 +321,7 @@
     "serverError": "Server error: {{status}}",
     "unknownError": "Unknown error",
     "generatedWidget": "Generated widget: {{title}}",
+    "saveFailed": "Widget could not be saved. Please try again.",
     "checkingConnection": "Checking widget access…",
     "preflightConnected": "Connected to the widget agent",
     "preflightInvalidKey": "Widget key rejected. Update wm-widget-key and reload.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3060,6 +3060,7 @@
     "serverError": "Error del servidor: {{status}}",
     "unknownError": "Error desconocido",
     "generatedWidget": "Widget generado: {{title}}",
+    "saveFailed": "No se pudo guardar el widget. Inténtalo de nuevo.",
     "checkingConnection": "Verificando acceso al widget…",
     "preflightConnected": "Conectado al agente de widget",
     "preflightInvalidKey": "Clave de widget rechazada. Actualiza wm-widget-key y recarga.",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -21,6 +21,7 @@
     "serverError": "Server error: {{status}}",
     "unknownError": "Unknown error",
     "generatedWidget": "Generated widget: {{title}}",
+    "saveFailed": "ذخیره ابزارک ممکن نشد. دوباره تلاش کنید.",
     "checkingConnection": "Checking widget access…",
     "preflightConnected": "Connected to the widget agent",
     "preflightInvalidKey": "Widget key rejected. Update wm-widget-key and reload.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3060,6 +3060,7 @@
     "serverError": "Erreur serveur : {{status}}",
     "unknownError": "Erreur inconnue",
     "generatedWidget": "Widget généré : {{title}}",
+    "saveFailed": "Impossible d’enregistrer le widget. Réessayez.",
     "checkingConnection": "Vérification de l'accès au widget...",
     "preflightConnected": "Connecté à l'agent widget",
     "preflightInvalidKey": "Clé widget rejetée. Mettez à jour wm-widget-key et rechargez.",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -21,6 +21,7 @@
     "serverError": "सर्वर त्रुटि: {{status}}",
     "unknownError": "अज्ञात त्रुटि",
     "generatedWidget": "बनाया गया विजेट: {{title}}",
+    "saveFailed": "विजेट सहेजा नहीं जा सका. कृपया पुनः प्रयास करें.",
     "checkingConnection": "विजेट का संबंध जांच रहे हैं…",
     "preflightConnected": "विजेट एजेंट से जुड़ा हुआ है",
     "preflightInvalidKey": "विजेट की अस्वीकृत। wm-widget-key अपडेट करें और पेज रीलोड करें।",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -27,6 +27,7 @@
     "serverError": "Greška servera: {{status}}",
     "unknownError": "Nepoznata greška",
     "generatedWidget": "Generirani widget: {{title}}",
+    "saveFailed": "Widget nije moguće spremiti. Pokušajte ponovno.",
     "checkingConnection": "Provjera pristupa widgetu…",
     "preflightConnected": "Povezano s agentom widgeta",
     "preflightInvalidKey": "Ključ widgeta odbijen. Ažuriraj wm-widget-key i ponovno učitaj.",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -21,6 +21,7 @@
     "serverError": "Szerverhiba: {{status}}",
     "unknownError": "Ismeretlen hiba",
     "generatedWidget": "Generált widget: {{title}}",
+    "saveFailed": "A widgetet nem sikerült menteni. Próbáld újra.",
     "checkingConnection": "Widget hozzáférés ellenőrzése…",
     "preflightConnected": "Csatlakozva a widget ügynökhöz",
     "preflightInvalidKey": "Widget kulcs elutasítva. Frissítse a wm-widget-key kulcsot és töltse újra az oldalt.",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -3060,6 +3060,7 @@
     "serverError": "Errore del server: {{status}}",
     "unknownError": "Errore sconosciuto",
     "generatedWidget": "Widget generato: {{title}}",
+    "saveFailed": "Impossibile salvare il widget. Riprova.",
     "checkingConnection": "Verifica accesso widget…",
     "preflightConnected": "Connesso all'agente widget",
     "preflightInvalidKey": "Chiave widget rifiutata. Aggiorna wm-widget-key e ricarica.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3044,6 +3044,7 @@
     "serverError": "サーバーエラー: {{status}}",
     "unknownError": "不明なエラー",
     "generatedWidget": "生成されたウィジェット: {{title}}",
+    "saveFailed": "ウィジェットを保存できませんでした。もう一度お試しください。",
     "checkingConnection": "ウィジェットアクセスを確認中…",
     "preflightConnected": "ウィジェットエージェントに接続しました",
     "preflightInvalidKey": "ウィジェットキーが拒否されました。wm-widget-keyを更新して再読み込みしてください。",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -3044,6 +3044,7 @@
     "serverError": "서버 오류: {{status}}",
     "unknownError": "알 수 없는 오류",
     "generatedWidget": "생성된 위젯: {{title}}",
+    "saveFailed": "위젯을 저장하지 못했습니다. 다시 시도해 주세요.",
     "checkingConnection": "위젯 액세스 확인 중…",
     "preflightConnected": "위젯 에이전트에 연결됨",
     "preflightInvalidKey": "위젯 키가 거부되었습니다. wm-widget-key를 업데이트하고 다시 로드하세요.",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -3044,6 +3044,7 @@
     "serverError": "Serverfout: {{status}}",
     "unknownError": "Onbekende fout",
     "generatedWidget": "Gegenereerd widget: {{title}}",
+    "saveFailed": "De widget kon niet worden opgeslagen. Probeer het opnieuw.",
     "checkingConnection": "Widget-toegang controleren…",
     "preflightConnected": "Verbonden met de widget-agent",
     "preflightInvalidKey": "Widget-sleutel afgewezen. Werk wm-widget-key bij en herlaad.",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -3076,6 +3076,7 @@
     "serverError": "Błąd serwera: {{status}}",
     "unknownError": "Nieznany błąd",
     "generatedWidget": "Wygenerowany widget: {{title}}",
+    "saveFailed": "Nie udało się zapisać widżetu. Spróbuj ponownie.",
     "checkingConnection": "Sprawdzanie dostępu do widgetu…",
     "preflightConnected": "Połączono z agentem widgetu",
     "preflightInvalidKey": "Klucz widgetu odrzucony. Zaktualizuj wm-widget-key i przeładuj.",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -3060,6 +3060,7 @@
     "serverError": "Erro do servidor: {{status}}",
     "unknownError": "Erro desconhecido",
     "generatedWidget": "Widget gerado: {{title}}",
+    "saveFailed": "Não foi possível guardar o widget. Tente novamente.",
     "checkingConnection": "Verificando acesso ao widget…",
     "preflightConnected": "Conectado ao agente de widget",
     "preflightInvalidKey": "Chave de widget rejeitada. Atualize wm-widget-key e recarregue.",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -3060,6 +3060,7 @@
     "serverError": "Eroare server: {{status}}",
     "unknownError": "Eroare necunoscută",
     "generatedWidget": "Widget generat: {{title}}",
+    "saveFailed": "Widgetul nu a putut fi salvat. Încercați din nou.",
     "checkingConnection": "Se verifică accesul la widget...",
     "preflightConnected": "Conectat la agentul widget",
     "preflightInvalidKey": "Cheia widget respingă. Actualizează wm-widget-key și reîncarcă.",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -3076,6 +3076,7 @@
     "serverError": "Ошибка сервера: {{status}}",
     "unknownError": "Неизвестная ошибка",
     "generatedWidget": "Созданный виджет: {{title}}",
+    "saveFailed": "Не удалось сохранить виджет. Попробуйте ещё раз.",
     "checkingConnection": "Проверка доступа к виджету…",
     "preflightConnected": "Подключено к агенту виджетов",
     "preflightInvalidKey": "Ключ виджета отклонен. Обновите wm-widget-key и перезагрузите.",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -3044,6 +3044,7 @@
     "serverError": "Serverfel: {{status}}",
     "unknownError": "Okänt fel",
     "generatedWidget": "Genererad widget: {{title}}",
+    "saveFailed": "Det gick inte att spara widgeten. Försök igen.",
     "checkingConnection": "Kontrollerar widgetåtkomst…",
     "preflightConnected": "Ansluten till widgetagenten",
     "preflightInvalidKey": "Widgetnyckel avvisad. Uppdatera wm-widget-key och ladda om.",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -3044,6 +3044,7 @@
     "serverError": "ข้อผิดพลาดของเซิร์ฟเวอร์: {{status}}",
     "unknownError": "ข้อผิดพลาดที่ไม่ทราบ",
     "generatedWidget": "วิดเจ็ตที่สร้างขึ้น: {{title}}",
+    "saveFailed": "ไม่สามารถบันทึกวิดเจ็ตได้ โปรดลองอีกครั้ง",
     "checkingConnection": "ตรวจสอบการเข้าถึงวิดเจ็ต…",
     "preflightConnected": "เชื่อมต่อกับเอเจนต์วิดเจ็ต",
     "preflightInvalidKey": "ปฏิเสธคีย์วิดเจ็ต อัปเดต wm-widget-key แล้วโหลดใหม่",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -3044,6 +3044,7 @@
     "serverError": "Sunucu hatası: {{status}}",
     "unknownError": "Bilinmeyen hata",
     "generatedWidget": "Oluşturulan widget: {{title}}",
+    "saveFailed": "Widget kaydedilemedi. Lütfen tekrar deneyin.",
     "checkingConnection": "Widget erişimi kontrol ediliyor…",
     "preflightConnected": "Widget ajanına bağlandı",
     "preflightInvalidKey": "Widget anahtarı reddedildi. wm-widget-key'i güncelleyin ve yeniden yükleyin.",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -3044,6 +3044,7 @@
     "serverError": "Lỗi máy chủ: {{status}}",
     "unknownError": "Lỗi không xác định",
     "generatedWidget": "Tiện ích được tạo: {{title}}",
+    "saveFailed": "Không thể lưu tiện ích. Vui lòng thử lại.",
     "checkingConnection": "Đang kiểm tra quyền truy cập tiện ích…",
     "preflightConnected": "Đã kết nối với đại lý tiện ích",
     "preflightInvalidKey": "Khóa tiện ích bị từ chối. Cập nhật wm-widget-key và tải lại.",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -3044,6 +3044,7 @@
     "serverError": "服务器错误: {{status}}",
     "unknownError": "未知错误",
     "generatedWidget": "生成的小组件: {{title}}",
+    "saveFailed": "无法保存小组件。请重试。",
     "checkingConnection": "检查小组件访问权限中…",
     "preflightConnected": "已连接到小组件代理",
     "preflightInvalidKey": "小组件密钥被拒绝。请更新 wm-widget-key 并重新加载。",

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -9,7 +9,7 @@ import { scheduleAfterFirstPaint } from '@/utils/after-paint';
 import { subscribeAuthState, type AuthSession } from './auth-state';
 import { onSubscriptionChange, type SubscriptionInfo } from './billing';
 import { getClerkUserCreatedAt } from './clerk';
-import { DODO_PRODUCTS } from '@/config/products.generated';
+import { DODO_PRODUCT_IDS } from '@/config/product-ids.generated';
 
 const UMAMI_SCRIPT_SRC = 'https://abacus.worldmonitor.app/script.js';
 const UMAMI_WEBSITE_ID = 'e8800335-c853-46a8-8497-c993ed2f58bc';
@@ -442,9 +442,11 @@ export function trackGateHit(feature: string): void {
  * through URL/sessionStorage, so a crafted value must not inject unbounded
  * cardinality into Umami. Unknown ids collapse to 'unknown'; the checkout
  * flow itself still passes the raw id through (backend validates).
- * Auto-fresh: DODO_PRODUCTS is generated from the catalog.
+ * Auto-fresh: DODO_PRODUCT_IDS is generated from the catalog. Keeping this
+ * small allowlist separate means analytics does not pull the checkout config
+ * into the post-hydration module graph. (#5165)
  */
-const KNOWN_PRODUCT_IDS: ReadonlySet<string> = new Set(Object.values(DODO_PRODUCTS));
+const KNOWN_PRODUCT_IDS = DODO_PRODUCT_IDS;
 
 export function bucketProductIdForAnalytics(productId: string): string {
   return KNOWN_PRODUCT_IDS.has(productId) ? productId : 'unknown';

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -1,6 +1,6 @@
 import type { Feed, NewsItem } from '@/types';
 import { SITE_VARIANT } from '@/config';
-import { chunkArray, fetchWithProxy } from '@/utils';
+import { chunkArray, fetchWithProxy, isMobileDevice } from '@/utils';
 import { classifyByKeyword, classifyWithAI } from './threat-classifier';
 import { inferGeoHubsFromTitle } from './geo-hub-index';
 import { getPersistentCache, setPersistentCache } from './persistent-cache';
@@ -23,7 +23,11 @@ const feedCache = new Map<string, { items: NewsItem[]; timestamp: number }>();
 const CACHE_TTL = 30 * 60 * 1000;
 const enqueueFeedParse = createYieldingWorkQueue(yieldToMain);
 
-function parseFeedXml(text: string): Promise<Document> {
+function parseFeedXml(text: string, isMobile: boolean): Promise<Document> {
+  // Desktop keeps its established concurrent feed path. The queue is only a
+  // mobile guard against several completed requests synchronously parsing XML
+  // in the same post-hydration task. (#5165)
+  if (!isMobile) return Promise.resolve(new DOMParser().parseFromString(text, 'text/xml'));
   return enqueueFeedParse(() => new DOMParser().parseFromString(text, 'text/xml'));
 }
 
@@ -244,12 +248,14 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
     const response = await fetchWithProxy(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const text = await response.text();
-    const doc = await parseFeedXml(text);
+    const isMobile = isMobileDevice();
+    const doc = await parseFeedXml(text, isMobile);
 
     // XML parsing is synchronous. It is serialized behind a yield so several
-    // completed feed requests cannot parse back-to-back in one post-hydration
-    // task; yield again before querying and mapping entries. (#5165)
-    await yieldToMain();
+    // completed mobile feed requests cannot parse back-to-back in one
+    // post-hydration task; yield again before querying and mapping entries.
+    // (#5165)
+    if (isMobile) await yieldToMain();
 
     const parseError = doc.querySelector('parsererror');
     if (parseError) {
@@ -312,7 +318,7 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
       // Each item performs DOM queries, date normalization, classification,
       // and geo inference. Let paint/input run before the next item instead
       // of concatenating all five into the same task on mobile. (#5165)
-      if (index < itemNodes.length - 1) await yieldToMain();
+      if (isMobile && index < itemNodes.length - 1) await yieldToMain();
     }
 
     feedCache.set(feedScope, { items: parsed, timestamp: Date.now() });

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -11,6 +11,8 @@ import { parseFeedDate, effectivePubDateMs } from './feed-date';
 import { canQueueAiClassification, AI_CLASSIFY_MAX_PER_FEED } from './ai-classify-queue';
 import { mlWorker } from './ml-worker';
 import { isHeadlineMemoryEnabled } from './ai-flow-settings';
+import { yieldToMain } from '@/utils/after-paint';
+import { createYieldingWorkQueue } from '@/utils/yielding-work-queue';
 
 const FEED_COOLDOWN_MS = 5 * 60 * 1000;
 const MAX_FAILURES = 2;
@@ -19,6 +21,11 @@ const FEED_SCOPE_SEPARATOR = '::';
 const feedFailures = new Map<string, { count: number; cooldownUntil: number }>();
 const feedCache = new Map<string, { items: NewsItem[]; timestamp: number }>();
 const CACHE_TTL = 30 * 60 * 1000;
+const enqueueFeedParse = createYieldingWorkQueue(yieldToMain);
+
+function parseFeedXml(text: string): Promise<Document> {
+  return enqueueFeedParse(() => new DOMParser().parseFromString(text, 'text/xml'));
+}
 
 function toSerializable(items: NewsItem[]): Array<Omit<NewsItem, 'pubDate'> & { pubDate: string }> {
   return items.map(item => ({ ...item, pubDate: item.pubDate.toISOString() }));
@@ -237,8 +244,12 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
     const response = await fetchWithProxy(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const text = await response.text();
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(text, 'text/xml');
+    const doc = await parseFeedXml(text);
+
+    // XML parsing is synchronous. It is serialized behind a yield so several
+    // completed feed requests cannot parse back-to-back in one post-hydration
+    // task; yield again before querying and mapping entries. (#5165)
+    await yieldToMain();
 
     const parseError = doc.querySelector('parsererror');
     if (parseError) {
@@ -252,52 +263,57 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
     const isAtom = items.length === 0;
     if (isAtom) items = doc.querySelectorAll('entry');
 
-    const parsed = Array.from(items)
-      .slice(0, 5)
-      .map((item) => {
-        const title = item.querySelector('title')?.textContent || '';
-        let link = '';
-        if (isAtom) {
-          const linkEl = item.querySelector('link[href]');
-          link = linkEl?.getAttribute('href') || '';
-        } else {
-          link = item.querySelector('link')?.textContent || '';
-        }
+    const itemNodes = Array.from(items).slice(0, 5);
+    const parsed: Array<NewsItem & { threat: ReturnType<typeof classifyByKeyword> }> = [];
+    for (const [index, item] of itemNodes.entries()) {
+      const title = item.querySelector('title')?.textContent || '';
+      let link = '';
+      if (isAtom) {
+        const linkEl = item.querySelector('link[href]');
+        link = linkEl?.getAttribute('href') || '';
+      } else {
+        link = item.querySelector('link')?.textContent || '';
+      }
 
-        // Dublin Core (<dc:date>) fallback for RSS feeds. ArXiv RSS (already
-        // in the feed registry as "ArXiv AI", "ArXiv ML") ships dc:date with
-        // no <pubDate>; without this fallback every ArXiv item would land
-        // with pubDateMissing=true and get demoted in every freshness ranking.
-        // Prior precedent: PR #3417. querySelector('dc\\:date') escapes the
-        // CSS-selector colon so the XML qname matches; getElementsByTagName
-        // is an alternative that also works under browser DOMParser in XML
-        // mode. textContent reads the element's inner text without namespace
-        // gymnastics.
-        const pubDateStr = isAtom
-          ? (item.querySelector('published')?.textContent || item.querySelector('updated')?.textContent || '')
-          : (item.querySelector('pubDate')?.textContent
-            || item.querySelector('dc\\:date')?.textContent
-            || item.getElementsByTagName('dc:date')[0]?.textContent
-            || '');
-        const { date: pubDate, missing: pubDateMissing } = parseFeedDate(pubDateStr);
-        const threat = classifyByKeyword(title, SITE_VARIANT);
-        const isAlert = threat.level === 'critical' || threat.level === 'high';
-        const geoMatches = inferGeoHubsFromTitle(title);
-        const topGeo = geoMatches[0];
+      // Dublin Core (<dc:date>) fallback for RSS feeds. ArXiv RSS (already
+      // in the feed registry as "ArXiv AI", "ArXiv ML") ships dc:date with
+      // no <pubDate>; without this fallback every ArXiv item would land
+      // with pubDateMissing=true and get demoted in every freshness ranking.
+      // Prior precedent: PR #3417. querySelector('dc\\:date') escapes the
+      // CSS-selector colon so the XML qname matches; getElementsByTagName
+      // is an alternative that also works under browser DOMParser in XML
+      // mode. textContent reads the element's inner text without namespace
+      // gymnastics.
+      const pubDateStr = isAtom
+        ? (item.querySelector('published')?.textContent || item.querySelector('updated')?.textContent || '')
+        : (item.querySelector('pubDate')?.textContent
+          || item.querySelector('dc\\:date')?.textContent
+          || item.getElementsByTagName('dc:date')[0]?.textContent
+          || '');
+      const { date: pubDate, missing: pubDateMissing } = parseFeedDate(pubDateStr);
+      const threat = classifyByKeyword(title, SITE_VARIANT);
+      const isAlert = threat.level === 'critical' || threat.level === 'high';
+      const geoMatches = inferGeoHubsFromTitle(title);
+      const topGeo = geoMatches[0];
 
-        return {
-          source: feed.name,
-          title,
-          link,
-          pubDate,
-          pubDateMissing,
-          isAlert,
-          threat,
-          ...(topGeo && { lat: topGeo.hub.lat, lon: topGeo.hub.lon, locationName: topGeo.hub.name }),
-          lang: feed.lang,
-          ...(SITE_VARIANT === 'happy' && { imageUrl: extractImageUrl(item) }),
-        };
+      parsed.push({
+        source: feed.name,
+        title,
+        link,
+        pubDate,
+        pubDateMissing,
+        isAlert,
+        threat,
+        ...(topGeo && { lat: topGeo.hub.lat, lon: topGeo.hub.lon, locationName: topGeo.hub.name }),
+        lang: feed.lang,
+        ...(SITE_VARIANT === 'happy' && { imageUrl: extractImageUrl(item) }),
       });
+
+      // Each item performs DOM queries, date normalization, classification,
+      // and geo inference. Let paint/input run before the next item instead
+      // of concatenating all five into the same task on mobile. (#5165)
+      if (index < itemNodes.length - 1) await yieldToMain();
+    }
 
     feedCache.set(feedScope, { items: parsed, timestamp: Date.now() });
     void setPersistentCache(getPersistentFeedKey(feedScope), toSerializable(parsed));

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -1,6 +1,5 @@
 import { loadFromStorage, saveToStorage } from '@/utils';
 import { clearPanelColSpanEntry, clearPanelSpanEntry } from '@/utils/panel-storage';
-import { sanitizeWidgetHtml } from '@/utils/widget-sanitizer';
 import { getAuthState } from '@/services/auth-state';
 import { isEntitled } from '@/services/entitlements';
 import {
@@ -14,6 +13,18 @@ const MAX_WIDGETS = 10;
 const MAX_HISTORY = 10;
 const MAX_HTML_CHARS = 50_000;
 const MAX_HTML_CHARS_PRO = 80_000;
+
+type WidgetSanitizer = Pick<typeof import('@/utils/widget-sanitizer'), 'sanitizeWidgetHtml'>;
+
+let widgetSanitizerPromise: Promise<WidgetSanitizer> | null = null;
+
+function getWidgetSanitizer(): Promise<WidgetSanitizer> {
+  widgetSanitizerPromise ??= import('@/utils/widget-sanitizer').catch((error) => {
+    widgetSanitizerPromise = null;
+    throw error;
+  });
+  return widgetSanitizerPromise;
+}
 
 function proHtmlKey(id: string): string {
   return `wm-pro-html-${id}`;
@@ -54,7 +65,7 @@ export function loadWidgets(): CustomWidgetSpec[] {
   return result;
 }
 
-export function saveWidget(spec: CustomWidgetSpec): void {
+export async function saveWidget(spec: CustomWidgetSpec): Promise<void> {
   if (spec.tier === 'pro') {
     const proHtml = spec.html.slice(0, MAX_HTML_CHARS_PRO);
     const meta: CustomWidgetSpec = {
@@ -71,6 +82,7 @@ export function saveWidget(spec: CustomWidgetSpec): void {
       throw new Error('Storage quota exceeded saving PRO widget');
     }
   } else {
+    const { sanitizeWidgetHtml } = await getWidgetSanitizer();
     const trimmed: CustomWidgetSpec = {
       ...spec,
       tier: 'basic',

--- a/src/utils/yielding-work-queue.ts
+++ b/src/utils/yielding-work-queue.ts
@@ -1,0 +1,16 @@
+/**
+ * Serialize work that must remain synchronous internally while yielding before
+ * each item starts. A rejected item never blocks later work.
+ */
+export function createYieldingWorkQueue(yieldToMain: () => Promise<void>) {
+  let tail = Promise.resolve();
+
+  return function enqueue<T>(work: () => T | Promise<T>): Promise<T> {
+    const current = tail.then(async () => {
+      await yieldToMain();
+      return work();
+    });
+    tail = current.then(() => undefined, () => undefined);
+    return current;
+  };
+}

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -30,6 +30,10 @@ const DEFERRED_AGENT_BUS_CHUNKS = ['agent-bus-actions'];
 //   confetti.module — canvas-confetti, loaded on the first milestone celebration
 // Re-adding a static `import` of either would re-eagerise it into main and fail this.
 const DEFERRED_NPM_LIB_CHUNKS = ['satellite.es', 'confetti.module'];
+// Checkout catalog and widget HTML sanitization are needed only after an
+// upgrade/custom-widget action. Keep them out of the dashboard's static graph;
+// otherwise their shared dependencies rejoin the post-hydration long-task wave.
+const DEFERRED_CHECKOUT_CHUNKS = ['products', 'widget-sanitizer'];
 // Enrichment SERVICE tail deferred off the eager boot graph (#4486 — service-graph
 // split, Phase A). Each runs only AFTER first paint — correlation-engine.run() is
 // post-loadAllData fire-and-forget; story-renderer fires on story-modal open — so its
@@ -284,6 +288,13 @@ describe('eager chunk budget: opt-in npm libs stay off the entry', { skip: !exis
   registerDeferredChunkAssertions(DEFERRED_NPM_LIB_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if missing, the lib was inlined into another chunk by a static import`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads on demand`,
+  });
+});
+
+describe('eager chunk budget: checkout-only code stays off the dashboard entry', { skip: !existsSync(dashboardHtml) }, () => {
+  registerDeferredChunkAssertions(DEFERRED_CHECKOUT_CHUNKS, {
+    missingMessage: (chunk) => `${chunk}-*.js chunk should exist — checkout/widget work must remain code-split`,
+    preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads only after checkout or widget interaction`,
   });
 });
 

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -48,7 +48,7 @@ interface AllowEntry {
 const ALLOW_LIST: AllowEntry[] = [
   {
     file: 'src/services/rss.ts',
-    line: 315,
+    line: 337,
     reason: 'mlWorker.vectorStoreIngest stores pubDate as embedding metadata; not used as a freshness comparator.',
   },
   {

--- a/tests/funnel-analytics-policy.test.mjs
+++ b/tests/funnel-analytics-policy.test.mjs
@@ -126,8 +126,8 @@ test('checkout-start product ids are bucketed on both surfaces (round-4 F2)', ()
   const analytics = read('src/services/analytics.ts');
   assert.ok(analytics.includes('bucketProductIdForAnalytics(productId)'),
     'dashboard trackCheckoutStart no longer buckets the (resume-path URL-derived) productId');
-  assert.ok(analytics.includes('Object.values(DODO_PRODUCTS)'),
-    'dashboard product allowlist no longer derives from the generated catalog');
+  assert.ok(analytics.includes("from '@/config/product-ids.generated'") && analytics.includes('DODO_PRODUCT_IDS'),
+    'dashboard product allowlist must keep deriving from the generated catalog');
   const pro = read('pro-test/src/services/checkout.ts');
   const emissions = pro.match(/trackFunnelEvent\(\s*'checkout-start'[\s\S]{0,300}?\}\s*\)/g) ?? [];
   assert.equal(emissions.length, 2, 'expected exactly two /pro checkout-start emissions');

--- a/tests/hydration-scheduler.test.mts
+++ b/tests/hydration-scheduler.test.mts
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runHydrationTier, type HydrationTask } from '@/app/hydration-scheduler';
+
+function createInstrumentedTasks(count: number, state: { active: number; maxActive: number }): HydrationTask[] {
+  return Array.from({ length: count }, (_, index) => ({
+    name: `task-${index}`,
+    task: async () => {
+      state.active += 1;
+      state.maxActive = Math.max(state.maxActive, state.active);
+      await Promise.resolve();
+      state.active -= 1;
+    },
+  }));
+}
+
+test('runs mobile tier work one task at a time and yields between tasks (#5165)', async () => {
+  const state = { active: 0, maxActive: 0 };
+  let yields = 0;
+
+  await runHydrationTier({
+    tasks: createInstrumentedTasks(3, state),
+    maxConcurrency: 1,
+    yieldToMain: async () => { yields += 1; },
+    onFailure: () => assert.fail('all instrumented tasks should succeed'),
+  });
+
+  assert.equal(state.maxActive, 1);
+  assert.equal(yields, 2, 'each remaining task starts after a cooperative yield');
+});
+
+test('preserves desktop normal and force-all tier concurrency', async () => {
+  for (const [maxConcurrency, expectedYields] of [[3, 1], [6, 0]] as const) {
+    const state = { active: 0, maxActive: 0 };
+    let yields = 0;
+    await runHydrationTier({
+      tasks: createInstrumentedTasks(6, state),
+      maxConcurrency,
+      yieldToMain: async () => { yields += 1; },
+      onFailure: () => assert.fail('all instrumented tasks should succeed'),
+    });
+    assert.equal(state.maxActive, maxConcurrency);
+    assert.equal(yields, expectedYields);
+  }
+});
+
+test('reports individual rejected panel loaders and continues the tier', async () => {
+  const failures: Array<{ name: string; reason: unknown }> = [];
+  await runHydrationTier({
+    tasks: [
+      { name: 'fails', task: async () => { throw new Error('nope'); } },
+      { name: 'succeeds', task: async () => {} },
+    ],
+    maxConcurrency: 1,
+    yieldToMain: async () => {},
+    onFailure: (name, reason) => failures.push({ name, reason }),
+  });
+
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0]?.name, 'fails');
+  assert.equal((failures[0]?.reason as Error).message, 'nope');
+});

--- a/tests/product-catalog-freshness.test.mjs
+++ b/tests/product-catalog-freshness.test.mjs
@@ -1,7 +1,7 @@
 /**
  * Product catalog freshness tests.
  *
- * Verifies that generated files (products.generated.ts, tiers.json)
+ * Verifies that generated files (products.generated.ts, product-ids.generated.ts, tiers.json)
  * match the canonical catalog in convex/config/productCatalog.ts.
  * Bidirectional: checks generated→catalog AND catalog→generated.
  */
@@ -27,6 +27,7 @@ const PRODUCT_ID_EXCLUDE_PATTERNS = [
   'api/product-catalog',
   'api/_product-fallback-prices',
   'src/config/products.generated',
+  'src/config/product-ids.generated',
   'pro-test/src/generated/',
   'public/pro/',
   'tests/',
@@ -354,6 +355,7 @@ describe('Product catalog freshness', () => {
   it('generated files and pro locale placeholders are fresh (re-running generator produces same output)', () => {
     // Capture current generated content
     const currentProducts = readFileSync(join(ROOT, 'src/config/products.generated.ts'), 'utf8');
+    const currentProductIds = readFileSync(join(ROOT, 'src/config/product-ids.generated.ts'), 'utf8');
     const currentTiers = readFileSync(join(ROOT, 'pro-test/src/generated/tiers.json'), 'utf8');
     const currentFallback = readFileSync(join(ROOT, 'api/_product-fallback-prices.js'), 'utf8');
     const currentLocales = readProLocaleFiles();
@@ -363,11 +365,13 @@ describe('Product catalog freshness', () => {
 
     // Compare
     const freshProducts = readFileSync(join(ROOT, 'src/config/products.generated.ts'), 'utf8');
+    const freshProductIds = readFileSync(join(ROOT, 'src/config/product-ids.generated.ts'), 'utf8');
     const freshTiers = readFileSync(join(ROOT, 'pro-test/src/generated/tiers.json'), 'utf8');
     const freshFallback = readFileSync(join(ROOT, 'api/_product-fallback-prices.js'), 'utf8');
     const freshLocales = readProLocaleFiles();
 
     assert.equal(currentProducts, freshProducts, 'products.generated.ts is stale — run: npx tsx scripts/generate-product-config.mjs');
+    assert.equal(currentProductIds, freshProductIds, 'product-ids.generated.ts is stale — run: npx tsx scripts/generate-product-config.mjs');
     assert.equal(currentTiers, freshTiers, 'tiers.json is stale — run: npx tsx scripts/generate-product-config.mjs');
 
     assert.equal(currentFallback, freshFallback, '_product-fallback-prices.js is stale — run: npx tsx scripts/generate-product-config.mjs');

--- a/tests/rss-mobile-yielding.test.mts
+++ b/tests/rss-mobile-yielding.test.mts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rssSource = readFileSync(resolve(__dirname, '../src/services/rss.ts'), 'utf8');
+
+describe('RSS mobile yielding', () => {
+  it('keeps desktop feed XML parsing concurrent while queuing mobile parses', () => {
+    assert.match(
+      rssSource,
+      /function parseFeedXml\(text: string, isMobile: boolean\): Promise<Document> \{\s*\/\/ Desktop keeps its established concurrent feed path[\s\S]*?if \(!isMobile\) return Promise\.resolve\(new DOMParser\(\)\.parseFromString\(text, 'text\/xml'\)\);\s*return enqueueFeedParse/s,
+    );
+    assert.match(rssSource, /const isMobile = isMobileDevice\(\);\s*const doc = await parseFeedXml\(text, isMobile\);/s);
+    assert.match(rssSource, /if \(isMobile\) await yieldToMain\(\);/);
+    assert.match(rssSource, /if \(isMobile && index < itemNodes\.length - 1\) await yieldToMain\(\);/);
+  });
+});

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -542,6 +542,22 @@ describe('panel guardrails — cw- prefix handling', () => {
     );
   });
 
+  it('shows an accessible save failure message when widget persistence rejects', () => {
+    assert.match(
+      events,
+      /failed to save widget[\s\S]{0,220}showToast\(t\('widgets\.saveFailed'\)\)/,
+      'Modifying a widget must surface a rejected save to the user',
+    );
+    const createFailureHandlers = layout.match(
+      /failed to add widget[\s\S]{0,220}showToast\(t\('widgets\.saveFailed'\)\)/g,
+    ) ?? [];
+    assert.equal(
+      createFailureHandlers.length,
+      2,
+      'Both widget create entry points must surface a rejected save to the user',
+    );
+  });
+
   it('panel-layout loads widgets when feature is enabled', () => {
     assert.ok(
       layout.includes('hasPremiumAccess') || layout.includes('isProUser'),
@@ -821,6 +837,7 @@ describe('i18n — widgets section completeness', () => {
     'preflightInvalidKey',
     'preflightUnavailable',
     'preflightAiUnavailable',
+    'saveFailed',
     'readyToGenerate',
     'readyToApply',
     'modifyHint',

--- a/tests/widget-store.test.mts
+++ b/tests/widget-store.test.mts
@@ -65,7 +65,7 @@ async function loadWidgetStore(): Promise<WidgetStore> {
         globalThis.__clearedPanelColSpans.push(id);
       }
     `],
-    ['widget-sanitizer-stub', `export function sanitizeWidgetHtml(html) { return String(html); }`],
+    ['widget-sanitizer-stub', `export function sanitizeWidgetHtml(html) { return 'sanitized:' + String(html); }`],
     ['auth-state-stub', `export function getAuthState() { return { user: { role: 'pro' } }; }`],
     ['entitlements-stub', `export function isEntitled() { return true; }`],
     ['browser-key-session-stub', `
@@ -159,12 +159,25 @@ describe('widget-store PRO persistence', () => {
     const storage = installLocalStorage();
     const { saveWidget } = await loadWidgetStore();
 
-    saveWidget(makeProWidget());
+    const save = saveWidget(makeProWidget());
+    assert.ok(save instanceof Promise, 'saving a widget should defer optional sanitizer loading');
+    await save;
 
     const stored = JSON.parse(localStorage.getItem('wm-custom-widgets') ?? '[]') as Array<{ html?: string }>;
     assert.equal(stored.length, 1);
     assert.match(stored[0]?.html ?? '', /reload-marker/);
     assert.equal(storage.has(proHtmlKey('cw-pro-reload')), false);
+  });
+
+  it('loads the sanitizer only when persisting a basic widget', async () => {
+    installLocalStorage();
+    const { saveWidget } = await loadWidgetStore();
+    const basic = makeProWidget({ id: 'cw-basic', tier: 'basic', html: '<div>basic</div>' });
+
+    await saveWidget(basic);
+
+    const stored = JSON.parse(localStorage.getItem('wm-custom-widgets') ?? '[]') as Array<{ html?: string }>;
+    assert.equal(stored[0]?.html, 'sanitized:<div>basic</div>');
   });
 
   it('loadWidgets restores PRO HTML from the canonical entry when the side key is absent', async () => {

--- a/tests/yielding-work-queue.test.mts
+++ b/tests/yielding-work-queue.test.mts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createYieldingWorkQueue } from '@/utils/yielding-work-queue';
+
+test('serializes work behind a cooperative yield', async () => {
+  const starts: string[] = [];
+  let active = 0;
+  let maxActive = 0;
+  let yields = 0;
+  const enqueue = createYieldingWorkQueue(async () => { yields += 1; });
+
+  await Promise.all([
+    enqueue(async () => {
+      starts.push('first');
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+    }),
+    enqueue(async () => {
+      starts.push('second');
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+    }),
+  ]);
+
+  assert.deepEqual(starts, ['first', 'second']);
+  assert.equal(maxActive, 1);
+  assert.equal(yields, 2);
+});
+
+test('continues after a rejected item', async () => {
+  const enqueue = createYieldingWorkQueue(async () => {});
+  await assert.rejects(enqueue(async () => { throw new Error('expected'); }));
+  assert.equal(await enqueue(() => 'next'), 'next');
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1272,6 +1272,16 @@ export default defineConfig(({ mode }) => {
             // Post-paint service tail split (#4487). These files are dynamic-imported
             // from data-loader/country-intel/SignalModal; stable names let the
             // dist guard prove they stay out of main rather than merely grepping src.
+            // Keep the product catalog independent from its shared cache and
+            // entitlement dependencies. Before this split, Rollup named the shared
+            // cache group `products`, making the post-hydration product task parse
+            // unrelated IndexedDB code alongside the tiny checkout catalog. (#5165)
+            if (id.endsWith('/src/config/products.ts') || id.endsWith('/src/config/products.generated.ts')) {
+              return 'products';
+            }
+            if (id.endsWith('/src/services/persistent-cache.ts')) {
+              return 'persistent-cache';
+            }
             if (id.endsWith('/src/services/rss.ts')) {
               return 'rss';
             }


### PR DESCRIPTION
## Summary

Mobile hydration now gives the browser a scheduling boundary between same-tier panel loaders, so dynamic-import evaluation, RSS parsing, and synchronous panel setup do not accumulate into one post-hydration long-task wave.

The checkout allowlist is now independent of the checkout configuration, and basic-widget sanitization loads only when it is actually needed. Those changes keep the products and widget-store work out of the dashboard's eager path without changing Pro-widget persistence.

## Performance validation

| Mobile DebugBear profile | Before | After |
| --- | --- | --- |
| Post-hydration long-task wave | 20 long tasks / 9.5s TBT | Pending a PR-deployment run; the current task's DebugBear MCP connection remains unavailable, so this PR makes no lab-result claim. |

## Validation

- `tsx --test` focused hydration, RSS queue, widget-store, product freshness, analytics-policy, and eager-chunk suites: 52 passed.
- `npm run typecheck` and `vite build` passed.
- Built-dashboard guard confirmed `products` and `widget-sanitizer` are absent from the eager dashboard preload/static-import path.

The deferred-panel second-viewport cycle remains a separate follow-up; this PR keeps newly mounted panels hydrated rather than disabling that behavior.

Related: #5165

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
