### PR TITLE
fix(sentry): suppress h5player userscript frame-src CSP noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -209,6 +209,12 @@ function shouldSuppressCspViolation(
       // accounts.google.com / support.google.com SURFACED: a future first-party
       // Google sign-in embed regression must not be masked.
       if (frameHost.endsWith('.clients6.google.com')) return true;
+      // Tampermonkey "h5player" video-enhancement userscript (large Chinese
+      // install base) frames its own vendor host into every page with a
+      // <video> element. We never reference anzz.site; exact parsed-hostname
+      // match like the vendor rules above so lookalikes still surface
+      // (WORLDMONITOR-HT long tail — 5.8k events / 1.2k users since March).
+      if (frameHost === 'h5player.anzz.site') return true;
     } catch { /* scheme-only values fall through */ }
   }
   // Browser extensions or injected scripts. `ms-browser-extension://` is Edge's

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -406,9 +406,16 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(suppress('enforce', 'frame-src', 'https://toolytics.pa.clients6.google.com', '', false, FIRST_PARTY_CONVEX));
     });
 
+    it('suppresses frame-src for h5player userscript vendor frame (WORLDMONITOR-HT)', () => {
+      // Tampermonkey "h5player" video-enhancement userscript frames its own
+      // vendor host into every page. Origin-only blockedURI, exact host.
+      assert.ok(suppress('enforce', 'frame-src', 'https://h5player.anzz.site', '', false, FIRST_PARTY_CONVEX));
+    });
+
     it('does NOT suppress frame-src for lookalike filter-vendor hosts', () => {
       assert.ok(!suppress('enforce', 'frame-src', 'https://netstar-inc.com.evil.com', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'frame-src', 'https://clients6.google.com.evil.com', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'https://h5player.anzz.site.evil.com', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress frame-src for arbitrary third-party hosts (rotating extension long tail stays surfaced)', () => {


### PR DESCRIPTION
## Summary
- Adds an exact-host `frame-src` suppression for `h5player.anzz.site` to `shouldSuppressCspViolation` in `src/main.ts`. The Tampermonkey "h5player" video-enhancement userscript frames its own vendor host into every page containing a `<video>` element — 5,881 Sentry events / 1,235 users since March (WORLDMONITOR-HT long tail). We never reference anzz.site anywhere; the CSP block is the userscript's own frame failing regardless of our code.
- Same vendor-frame class and pattern as the existing zscloud / netstar / techloq / trendmicro rules: parsed-hostname exact match, so lookalike hosts (e.g. `h5player.anzz.site.evil.com`) still surface to Sentry.
- Sentry issue WORLDMONITOR-HT marked resolved-in-next-release; it auto-reopens if events persist after this ships.

## Test plan
- [x] TDD: new test failed before the fix, passes after (`tests/csp-filter.test.mjs` — 98/98)
- [x] Lookalike negative case added (`h5player.anzz.site.evil.com` must NOT be suppressed)
- [x] Full gate: typecheck, typecheck:api, cjs-syntax, biome lint, test:data (15,082 tests, 0 fail), edge-bundle, edge-functions (228), lint:md, version:check — all pass

https://claude.ai/code/session_01Bi8WV1hyEw7qKKnbyuqxXF