### PR TITLE
fix(intelligence): cap deduct-situation LLM budget under edge ceiling

### DIFF
--- a/server/worldmonitor/intelligence/v1/deduct-situation.ts
+++ b/server/worldmonitor/intelligence/v1/deduct-situation.ts
@@ -77,7 +77,19 @@ function buildPredictionContext(query: string, bootstrap: PredictionBootstrap): 
   return `## Prediction Market Odds (crowd-calibrated)\n${lines.join('\n')}`;
 }
 
-const DEDUCT_TIMEOUT_MS = 120_000;
+// This route runs on the Vercel Edge gateway (api/intelligence/v1/[rpc].ts →
+// runtime: 'edge'), which enforces a 25s initial-response ceiling — same
+// constraint list-feed-digest budgets under. The LLM reasoning budget must
+// fail closed to the graceful `provider: 'error'` degradation below BEFORE
+// the platform kills the invocation: the previous 120s budget was
+// unreachable (7d of Axiom route telemetry shows no success past 23.6s),
+// so every slower run surfaced as a client 504 with the LLM spend wasted
+// and nothing cached (WORLDMONITOR-VP, #5147). 22s keeps the budget above
+// the observed reasoning p95 (~17.5s) while leaving a 3s guard band for
+// pre-LLM context assembly and response serialization.
+const VERCEL_INITIAL_RESPONSE_LIMIT_MS = 25_000;
+const RESPONSE_GUARD_BAND_MS = 3_000;
+const DEDUCT_TIMEOUT_MS = VERCEL_INITIAL_RESPONSE_LIMIT_MS - RESPONSE_GUARD_BAND_MS;
 const DEDUCT_CACHE_TTL = 3600;
 
 export async function deductSituation(

--- a/tests/deduct-situation-edge-budget.test.mjs
+++ b/tests/deduct-situation-edge-budget.test.mjs
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// deduct-situation runs on the Vercel Edge gateway
+// (api/intelligence/v1/[rpc].ts → runtime: 'edge'), which enforces a 25s
+// initial-response ceiling. The LLM reasoning budget must fail closed to the
+// handler's graceful `provider: 'error'` degradation BEFORE the platform
+// kills the invocation — a budget above the ceiling is unreachable: 7d of
+// Axiom route telemetry (2026-07) shows no successful response past 23.6s,
+// while slower runs surface as client 504s with the LLM spend wasted and
+// nothing cached (WORLDMONITOR-VP, #5147).
+//
+// Source-text extraction (same pattern as csp-filter.test.mjs) so the test
+// doesn't drag the handler's redis/llm import graph into the runner.
+const src = readFileSync(
+  resolve(__dirname, '../server/worldmonitor/intelligence/v1/deduct-situation.ts'),
+  'utf-8',
+);
+
+function constVal(name, known = {}) {
+  const m = src.match(new RegExp(`const ${name} = ([^;]+);`));
+  assert.ok(m, `const ${name} must exist in deduct-situation.ts`);
+  let expr = m[1].split('//')[0].trim();
+  for (const [k, v] of Object.entries(known)) {
+    expr = expr.replaceAll(k, String(v));
+  }
+  // eslint-disable-next-line no-new-func
+  return new Function(`"use strict"; return (${expr});`)();
+}
+
+describe('deduct-situation edge response budget (WORLDMONITOR-VP / #5147)', () => {
+  it('names the Vercel edge initial-response ceiling at 25s', () => {
+    assert.equal(constVal('VERCEL_INITIAL_RESPONSE_LIMIT_MS'), 25_000);
+  });
+
+  it('LLM budget fits under the edge ceiling with at least a 2s guard band', () => {
+    const limit = constVal('VERCEL_INITIAL_RESPONSE_LIMIT_MS');
+    const budget = constVal('DEDUCT_TIMEOUT_MS', {
+      VERCEL_INITIAL_RESPONSE_LIMIT_MS: limit,
+      RESPONSE_GUARD_BAND_MS: constVal('RESPONSE_GUARD_BAND_MS'),
+    });
+    assert.ok(
+      budget <= limit - 2_000,
+      `DEDUCT_TIMEOUT_MS (${budget}ms) must leave ≥2s of guard band under the ${limit}ms edge ceiling`,
+    );
+  });
+
+  it('LLM budget stays above the observed reasoning p95 (~17.5s) so real runs are not starved', () => {
+    const budget = constVal('DEDUCT_TIMEOUT_MS', {
+      VERCEL_INITIAL_RESPONSE_LIMIT_MS: constVal('VERCEL_INITIAL_RESPONSE_LIMIT_MS'),
+      RESPONSE_GUARD_BAND_MS: constVal('RESPONSE_GUARD_BAND_MS'),
+    });
+    assert.ok(budget >= 20_000, `DEDUCT_TIMEOUT_MS (${budget}ms) must stay ≥20s (LLM stage p95 ≈ 17.5s)`);
+  });
+
+  it('cache safety net still sits above the LLM budget so the LLM bound wins (#3539)', () => {
+    // The inflight-wrapper bound must exceed the LLM's own bound; the exact
+    // +5s relationship is asserted as source text so a refactor that inverts
+    // the ordering fails loudly.
+    assert.match(src, /timeoutMs: DEDUCT_TIMEOUT_MS \+ 5_000/);
+  });
+});


### PR DESCRIPTION
## Summary
- `deduct-situation` runs on the Vercel Edge gateway (`api/intelligence/v1/[rpc].ts`, `runtime: 'edge'`), which enforces a **25s initial-response ceiling** — but its LLM reasoning budget was `DEDUCT_TIMEOUT_MS = 120_000`, unreachable by ~95s. Every reasoning run slower than the ceiling burned the LLM spend, cached nothing, and surfaced to the client as a platform 504 (Sentry WORLDMONITOR-VP, #5147) instead of the handler's own graceful `provider: 'error'` degradation.
- **Evidence (Axiom `wm_api_usage`, 7d):** 91 successful responses, p50 5.5s / p95 16.6s / **max 23.6s** — nothing ever succeeds past ~25s. Zero 504 rows, because platform-killed invocations never emit telemetry. LLM stage p95 ≈ 17.5s, max 23.5s.
- **Fix:** derive the budget from the ceiling — `25_000 − 3_000` guard band = **22s**, still above the LLM p95. Slow runs now fail closed *inside* the window to the existing 200 `provider:'error'` path the client already handles, and remain retryable. Same pattern `list-feed-digest.ts` already uses (`VERCEL_INITIAL_RESPONSE_LIMIT_MS`).
- New config-invariant test (`tests/deduct-situation-edge-budget.test.mjs`, source-text extraction like `csp-filter.test.mjs`) pins: ceiling named at 25s, budget ≤ ceiling − 2s, budget ≥ 20s floor (don't starve real reasoning runs), and the #3539 cache-safety-net ordering.

## Test plan
- [x] TDD: 3 of the 4 new assertions failed against the old 120s constant, all pass after the fix (4/4)
- [x] Sibling deduction tests: 22/22 (`deduction-prompt`, `deduction-probability`, `deduction-sanitize-yield`)
- [x] `tsc --noEmit` + `typecheck:api`: clean (fresh worktree off current `origin/main`, f5b23f7)
- [x] Sentry WORLDMONITOR-VP marked resolved-in-next-release — auto-reopens if 504s continue after deploy
- [x] Root-cause evidence and correction posted on #5147

Refs #5147

https://claude.ai/code/session_01Bi8WV1hyEw7qKKnbyuqxXF