### PR TITLE
fix(seo): advertise Chinese docs sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -61,3 +61,5 @@ Disallow: /
 
 Sitemap: https://www.worldmonitor.app/sitemap.xml
 Sitemap: https://www.worldmonitor.app/blog/sitemap-index.xml
+# Mintlify owns the documentation index, including /docs/zh/ translations.
+Sitemap: https://www.worldmonitor.app/docs/sitemap.xml

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -274,9 +274,10 @@ describe('crawlable content corpus deployment contracts', () => {
     }
   });
 
-  it('keeps robots.txt advertising both the root sitemap and the generated blog sitemap', () => {
+  it('keeps robots.txt advertising root, blog, and Mintlify docs sitemaps', () => {
     assert.match(robotsSource, /^Sitemap: https:\/\/www\.worldmonitor\.app\/sitemap\.xml$/m);
     assert.match(robotsSource, /^Sitemap: https:\/\/www\.worldmonitor\.app\/blog\/sitemap-index\.xml$/m);
+    assert.match(robotsSource, /^Sitemap: https:\/\/www\.worldmonitor\.app\/docs\/sitemap\.xml$/m);
   });
 
   it('keeps a generated-content marker in the root sitemap', () => {


### PR DESCRIPTION
## Summary

Crawlers can now discover the localized documentation through Mintlify's maintained sitemap instead of relying only on internal navigation. A deployment-contract test keeps that crawl-discovery link from regressing.

Mintlify's sitemap already lists the English and `/docs/zh/` pages. Its live pages self-canonicalize, but Mintlify currently emits no reciprocal `hreflang` or `x-default` annotations; this PR deliberately does not misrepresent that upstream limitation as solved.

## Validation

- `git push` pre-push gate: passed typechecks, deployment configuration tests, boundary/security checks, and edge bundle validation.
- Verified the live `https://www.worldmonitor.app/docs/sitemap.xml` returns 200 and contains English plus Chinese documentation paths.
- `node --test tests/docs-i18n-parity.test.mjs` (225 passing checks).

## Post-Deploy Monitoring & Validation

- Fetch `/robots.txt` and confirm it advertises the root, blog, and `/docs/sitemap.xml` indexes.
- Fetch `/docs/sitemap.xml` and confirm representative English and `/docs/zh/` entries return 200.
- No additional runtime monitoring is required: this is a static crawler-discovery declaration. Roll back by reverting this commit if the external sitemap becomes unavailable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)