### PR TITLE
fix(telemetry): attribute usage to verified clients

### DIFF
--- a/api/_client-ip.js
+++ b/api/_client-ip.js
@@ -26,7 +26,7 @@ function constantTimeEqual(a, b) {
 // CF_EDGE_PROOF_SECRET is unset, do not trust cf-connecting-ip; fall back to
 // x-real-ip/UNKNOWN so a missing deployment secret cannot silently reopen
 // GHSA-c267.
-function cfTransitProven(request) {
+export function hasCloudflareTransitProof(request) {
   const secret = (process.env.CF_EDGE_PROOF_SECRET ?? '').trim();
   if (!secret) return false;
   return constantTimeEqual((request.headers.get(CF_EDGE_PROOF_HEADER) ?? '').trim(), secret);
@@ -43,6 +43,6 @@ export function getClientIp(request) {
   // real peer IP) then the shared UNKNOWN bucket; the spoofable cf-connecting-ip
   // and the client-settable x-forwarded-for (#3531) are deliberately NOT
   // fallbacks here.
-  if (cf && cfTransitProven(request)) return cf;
+  if (cf && hasCloudflareTransitProof(request)) return cf;
   return xr || UNKNOWN_CLIENT_IP;
 }

--- a/api/_usage-telemetry.js
+++ b/api/_usage-telemetry.js
@@ -2,7 +2,7 @@
 // through server/gateway.ts. Keep this helper in api/: root-level .js Edge
 // functions cannot import server/_shared modules at runtime.
 
-import { getClientIp, UNKNOWN_CLIENT_IP } from './_client-ip.js';
+import { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './_client-ip.js';
 
 const AXIOM_INGEST_URL = 'https://api.axiom.co/v1/datasets/wm_api_usage/ingest';
 const MAX_HEADER_FIELD_LEN = 512;
@@ -52,6 +52,17 @@ function originKind(req) {
   } catch {
     return 'browser-cross-origin';
   }
+}
+
+function deriveCountry(req) {
+  // cf-ipcountry is client geography only on requests proved to have
+  // transited Cloudflare; otherwise it is forgeable and Vercel's peer-country
+  // metadata remains the safe fallback.
+  if (hasCloudflareTransitProof(req)) {
+    const country = req.headers.get('cf-ipcountry');
+    return (country && country !== 'T1' ? country : null) ?? req.headers.get('x-vercel-ip-country') ?? null;
+  }
+  return req.headers.get('x-vercel-ip-country') ?? null;
 }
 
 function recordDelivery(ok, isProbe) {
@@ -145,7 +156,7 @@ export function emitWmSessionUsage(ctx, req, res, startedAt, reason) {
       auth_kind: 'anon',
       tier: 0,
       plan_key: null,
-      country: req.headers.get('x-vercel-ip-country') ?? req.headers.get('cf-ipcountry') ?? null,
+      country: deriveCountry(req),
       ip_city: req.headers.get('x-vercel-ip-city') ?? null,
       ip_region: req.headers.get('x-vercel-ip-country-region') ?? null,
       execution_region: executionRegion,

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -179,6 +179,66 @@ test('POST emits one anonymous mint usage event without exposing cookie material
   assert.equal(JSON.stringify(events[0]).includes('wms_'), false, 'never telemeter the minted session token');
 });
 
+test('session usage telemetry records verified Cloudflare client attribution and rejects forged headers', async () => {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+  process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+  const events = [];
+  globalThis.fetch = async (input, init) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.includes('fake.upstash.io')) {
+      return new Response(JSON.stringify([{ result: [29, 30] }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('axiom.co')) {
+      events.push(...JSON.parse(init.body));
+      return new Response('{}', { status: 200 });
+    }
+    throw new Error(`unexpected telemetry fetch: ${url}`);
+  };
+
+  const verified = makeReq('POST', { origin: 'https://worldmonitor.app' });
+  verified.headers.set('cf-connecting-ip', '203.0.113.7');
+  verified.headers.set('cf-ipcountry', 'FR');
+  verified.headers.set('x-real-ip', '192.0.2.5');
+  verified.headers.set('x-vercel-ip-country', 'ZA');
+  verified.headers.set('x-wm-edge-proof', 'edge-secret-xyz');
+  const verifiedCtx = makeWaitUntilCtx();
+  assert.equal((await handler(verified, verifiedCtx.ctx)).status, 200);
+  await verifiedCtx.settle();
+
+  const forged = makeReq('POST', { origin: 'https://worldmonitor.app' });
+  forged.headers.set('cf-connecting-ip', '203.0.113.7');
+  forged.headers.set('cf-ipcountry', 'FR');
+  forged.headers.set('x-real-ip', '192.0.2.5');
+  forged.headers.set('x-vercel-ip-country', 'ZA');
+  const forgedCtx = makeWaitUntilCtx();
+  assert.equal((await handler(forged, forgedCtx.ctx)).status, 200);
+  await forgedCtx.settle();
+
+  const tor = makeReq('POST', { origin: 'https://worldmonitor.app' });
+  tor.headers.set('cf-connecting-ip', '203.0.113.7');
+  tor.headers.set('cf-ipcountry', 'T1');
+  tor.headers.set('x-real-ip', '192.0.2.5');
+  tor.headers.set('x-vercel-ip-country', 'ZA');
+  tor.headers.set('x-wm-edge-proof', 'edge-secret-xyz');
+  const torCtx = makeWaitUntilCtx();
+  assert.equal((await handler(tor, torCtx.ctx)).status, 200);
+  await torCtx.settle();
+
+  assert.equal(events.length, 3);
+  assert.deepEqual(
+    events.map(({ ip, country }) => ({ ip, country })),
+    [
+      { ip: '203.0.113.7', country: 'FR' },
+      { ip: '192.0.2.5', country: 'ZA' },
+      { ip: '203.0.113.7', country: 'ZA' },
+    ],
+  );
+});
+
 test('localhost session cookie remains host-only for dev', async () => {
   const resp = await handler(makeLocalReq('POST', { origin: 'http://localhost:5173' }));
   assert.equal(resp.status, 200);

--- a/docs/architecture/usage-telemetry.md
+++ b/docs/architecture/usage-telemetry.md
@@ -37,7 +37,10 @@ Two event types in dataset `wm_api_usage`:
 | `auth_kind`        | `clerk_jwt` \| `user_api_key` \| `enterprise_api_key` \| `widget_key` \| `anon` | |
 | `tier`             | `0` free / `1` pro / `2` api / `3` enterprise | `0` if unknown                          |
 | `cache_tier`       | `fast` \| `medium` \| `slow` \| `slow-browser` \| `static` \| `daily` \| `no-store` | only on 200/304 |
-| `country`, `execution_region` | `"US"`, `"iad1"`               | Vercel-provided                              |
+| `ip`                 | `"203.0.113.7"`                         | Cloudflare client IP only when the edge-proof header is valid; otherwise Vercel's peer IP |
+| `country`            | `"US"`                                  | Cloudflare client country only when edge transit is proven; otherwise Vercel connection country |
+| `ip_city`, `ip_region` | `"Johannesburg"`, `"WC"`            | Vercel connection/edge geography, not verified client location |
+| `execution_region`   | `"iad1"`                                | Vercel execution region                      |
 | `execution_plane`  | `"vercel-edge"`                           |                                              |
 | `origin_kind`      | `api-key` \| `oauth` \| `browser-same-origin` \| `browser-cross-origin` \| `null` | derived from headers by `deriveOriginKind()` — `mcp` and `internal-cron` exist in the `OriginKind` type for upstream/future use but are not currently emitted on the request path |
 | `ua_hash`          | SHA-256 of the UA                         | hashed so PII doesn't land in Axiom          |

--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -28,11 +28,15 @@ vi.mock("../_shared/api-key-rate-limit", () => ({
 
 // --- Stub the per-IP layer: spy whether checkRateLimit runs ------------------
 const checkRateLimit = vi.fn().mockResolvedValue(null);
-vi.mock("../_shared/rate-limit", () => ({
-  checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
-  checkEndpointRateLimit: vi.fn().mockResolvedValue(null),
-  hasEndpointRatePolicy: () => false,
-}));
+vi.mock("../_shared/rate-limit", async (importActual) => {
+  const actual = await importActual<typeof import("../_shared/rate-limit")>();
+  return {
+    ...actual,
+    checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+    checkEndpointRateLimit: vi.fn().mockResolvedValue(null),
+    hasEndpointRatePolicy: () => false,
+  };
+});
 
 // --- Stub entitlement resolution: a Starter user, non-tier-gated route -------
 const STARTER = {

--- a/server/__tests__/gateway-idempotency.test.ts
+++ b/server/__tests__/gateway-idempotency.test.ts
@@ -21,11 +21,15 @@ vi.mock('../_shared/redis', async (importActual) => {
 // Per-IP / per-endpoint rate limits are irrelevant here — pass them through.
 const checkRateLimit = vi.fn();
 const checkEndpointRateLimit = vi.fn();
-vi.mock('../_shared/rate-limit', () => ({
-  checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
-  checkEndpointRateLimit: (...a: unknown[]) => checkEndpointRateLimit(...a),
-  hasEndpointRatePolicy: () => false,
-}));
+vi.mock('../_shared/rate-limit', async (importActual) => {
+  const actual = await importActual<typeof import('../_shared/rate-limit')>();
+  return {
+    ...actual,
+    checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+    checkEndpointRateLimit: (...a: unknown[]) => checkEndpointRateLimit(...a),
+    hasEndpointRatePolicy: () => false,
+  };
+});
 
 import { createDomainGateway } from '../gateway';
 import { IDEMPOTENCY_HEADER, IDEMPOTENT_REPLAYED_HEADER } from '../_shared/idempotency';

--- a/server/__tests__/gateway-status-override.test.ts
+++ b/server/__tests__/gateway-status-override.test.ts
@@ -21,11 +21,15 @@ vi.mock('../_shared/redis', async (importActual) => {
 
 const checkRateLimit = vi.fn();
 const checkEndpointRateLimit = vi.fn();
-vi.mock('../_shared/rate-limit', () => ({
-  checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
-  checkEndpointRateLimit: (...a: unknown[]) => checkEndpointRateLimit(...a),
-  hasEndpointRatePolicy: () => false,
-}));
+vi.mock('../_shared/rate-limit', async (importActual) => {
+  const actual = await importActual<typeof import('../_shared/rate-limit')>();
+  return {
+    ...actual,
+    checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+    checkEndpointRateLimit: (...a: unknown[]) => checkEndpointRateLimit(...a),
+    hasEndpointRatePolicy: () => false,
+  };
+});
 
 import { createDomainGateway } from '../gateway';
 import { setResponseHeader, setSuccessStatusOverride } from '../_shared/response-headers';

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -36,11 +36,15 @@ vi.mock("../_shared/api-key-rate-limit", () => ({
 
 // --- Stub the per-IP layer: spy whether checkRateLimit runs. -----------------
 const checkRateLimit = vi.fn().mockResolvedValue(null);
-vi.mock("../_shared/rate-limit", () => ({
-  checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
-  checkEndpointRateLimit: vi.fn().mockResolvedValue(null),
-  hasEndpointRatePolicy: () => false,
-}));
+vi.mock("../_shared/rate-limit", async (importActual) => {
+  const actual = await importActual<typeof import("../_shared/rate-limit")>();
+  return {
+    ...actual,
+    checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+    checkEndpointRateLimit: vi.fn().mockResolvedValue(null),
+    hasEndpointRatePolicy: () => false,
+  };
+});
 
 // --- Stub entitlement resolution. getEntitlements returns whatever the
 //     current test sets. getRequiredTier defaults to null so most routes stay

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -110,7 +110,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 // CF_EDGE_PROOF_SECRET is unset, do not trust cf-connecting-ip; fall back to
 // x-real-ip/UNKNOWN so a missing deployment secret cannot silently reopen
 // GHSA-c267.
-function cfTransitProven(request: Request): boolean {
+export function hasCloudflareTransitProof(request: Request): boolean {
   const secret = (process.env.CF_EDGE_PROOF_SECRET ?? '').trim();
   if (!secret) return false;
   return constantTimeEqual((request.headers.get(CF_EDGE_PROOF_HEADER) ?? '').trim(), secret);
@@ -130,7 +130,7 @@ export function getClientIp(request: Request): string {
   // cf-connecting-ip would otherwise short-circuit past x-real-ip.
   const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
   const xr = (request.headers.get('x-real-ip') ?? '').trim();
-  if (cf && cfTransitProven(request)) return cf;
+  if (cf && hasCloudflareTransitProof(request)) return cf;
   return xr || UNKNOWN_CLIENT_IP;
 }
 

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AuthKind } from './usage-identity';
+import { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './rate-limit';
 
 const AXIOM_DATASET = 'wm_api_usage';
 // US region endpoint. EU workspaces would use api.eu.axiom.co.
@@ -333,11 +334,14 @@ export function deriveExecutionRegion(req: Request): string | null {
 }
 
 export function deriveCountry(req: Request): string | null {
-  return (
-    req.headers.get('x-vercel-ip-country') ??
-    req.headers.get('cf-ipcountry') ??
-    null
-  );
+  // Cloudflare's client-country header is trustworthy only when the transform
+  // rule proves the request transited Cloudflare. Without that proof it is
+  // caller-controlled, so retain Vercel's connection-country fallback.
+  if (hasCloudflareTransitProof(req)) {
+    const country = req.headers.get('cf-ipcountry');
+    return (country && country !== 'T1' ? country : null) ?? req.headers.get('x-vercel-ip-country') ?? null;
+  }
+  return req.headers.get('x-vercel-ip-country') ?? null;
 }
 
 export function deriveIpCity(req: Request): string | null {
@@ -355,24 +359,12 @@ export function deriveIpRegion(req: Request): string | null {
   return req.headers.get('x-vercel-ip-country-region') ?? null;
 }
 
-// Client IP. Order matches Vercel's documented precedence; cf-connecting-ip is
-// only present when the request transited Cloudflare. x-forwarded-for is the
-// last-resort hop list — we take the *rightmost* entry, since Vercel/proxies
-// append the real socket IP on the right while clients can inject arbitrary
-// values on the left. On Vercel this branch should be unreachable; the safer
-// choice matters in local dev or non-Vercel deploys.
+// Reuse the same Cloudflare-proof gate as rate limiting: the client IP is only
+// trusted when the Transform Rule proves CF transit. Never use x-forwarded-for
+// for telemetry, as direct callers can forge it.
 export function deriveIp(req: Request): string | null {
-  const real = req.headers.get('x-real-ip');
-  if (real) return real;
-  const cf = req.headers.get('cf-connecting-ip');
-  if (cf) return cf;
-  const xff = req.headers.get('x-forwarded-for');
-  if (xff) {
-    const parts = xff.split(',');
-    const last = parts[parts.length - 1]?.trim();
-    if (last) return last;
-  }
-  return null;
+  const ip = getClientIp(req);
+  return ip === UNKNOWN_CLIENT_IP ? null : ip;
 }
 
 export function deriveUserAgent(req: Request): string | null {

--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -20,6 +20,7 @@ import { afterEach, before, after, describe, it } from 'node:test';
 import { generateKeyPair, exportJWK, SignJWT } from 'jose';
 
 import { createDomainGateway, type GatewayCtx } from '../server/gateway.ts';
+import { deriveCountry } from '../server/_shared/usage.ts';
 import { issueSessionToken } from '../api/_session.js';
 import { createRedisFetch } from './helpers/fake-upstash-redis.mts';
 
@@ -38,6 +39,8 @@ interface CapturedEvent {
   auth_kind: string;
   tier: number;
   plan_key: string | null;
+  country: string | null;
+  ip: string | null;
   reason: string;
 }
 
@@ -108,6 +111,7 @@ const ORIGINAL_CONVEX_SITE_URL = process.env.CONVEX_SITE_URL;
 const ORIGINAL_CONVEX_SHARED_SECRET = process.env.CONVEX_SERVER_SHARED_SECRET;
 const ORIGINAL_REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
 const ORIGINAL_REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+const ORIGINAL_CF_EDGE_PROOF_SECRET = process.env.CF_EDGE_PROOF_SECRET;
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
@@ -125,6 +129,8 @@ afterEach(() => {
   else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_REDIS_URL;
   if (ORIGINAL_REDIS_TOKEN == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
   else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_REDIS_TOKEN;
+  if (ORIGINAL_CF_EDGE_PROOF_SECRET == null) delete process.env.CF_EDGE_PROOF_SECRET;
+  else process.env.CF_EDGE_PROOF_SECRET = ORIGINAL_CF_EDGE_PROOF_SECRET;
 });
 
 describe('gateway telemetry payload — domain extraction', () => {
@@ -262,6 +268,103 @@ describe('gateway telemetry payload — domain extraction', () => {
     assert.equal(ev.status, 400);
     assert.equal(ev.reason, 'malformed_request');
     assert.equal(ev.domain, 'market');
+  });
+});
+
+describe('gateway telemetry payload — trusted client attribution (#5228)', () => {
+  it('records Cloudflare client IP and country only when the edge proof is valid', async () => {
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH);
+
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/list-market-quotes',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+    const recorder = makeRecordingCtx();
+    const response = await handler(
+      new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-WorldMonitor-Key': SESSION_TOKEN,
+          'cf-connecting-ip': '203.0.113.7',
+          'cf-ipcountry': 'FR',
+          'x-real-ip': '192.0.2.5',
+          'x-vercel-ip-country': 'ZA',
+          'x-wm-edge-proof': 'edge-secret-xyz',
+        },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(response.status, 200);
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0]!.ip, '203.0.113.7');
+    assert.equal(spy.events[0]!.country, 'FR');
+  });
+
+  it('rejects forged Cloudflare client attribution without the edge proof', async () => {
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH);
+
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/list-market-quotes',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+    const recorder = makeRecordingCtx();
+    const response = await handler(
+      new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-WorldMonitor-Key': SESSION_TOKEN,
+          'cf-connecting-ip': '203.0.113.7',
+          'cf-ipcountry': 'FR',
+          'x-real-ip': '192.0.2.5',
+          'x-vercel-ip-country': 'ZA',
+        },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(response.status, 200);
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0]!.ip, '192.0.2.5');
+    assert.equal(spy.events[0]!.country, 'ZA');
+  });
+
+  it('never falls back to an unproven Cloudflare country header', () => {
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+    const request = new Request('https://worldmonitor.app/api/market/v1/list-market-quotes', {
+      headers: { 'cf-ipcountry': 'FR' },
+    });
+
+    assert.equal(deriveCountry(request), null);
+  });
+
+  it('falls back from Cloudflare’s T1 pseudo-country to Vercel geography', () => {
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+    const request = new Request('https://worldmonitor.app/api/market/v1/list-market-quotes', {
+      headers: {
+        'cf-ipcountry': 'T1',
+        'x-vercel-ip-country': 'ZA',
+        'x-wm-edge-proof': 'edge-secret-xyz',
+      },
+    });
+
+    assert.equal(deriveCountry(request), 'ZA');
   });
 });
 


### PR DESCRIPTION
## Summary

Usage telemetry now records a Cloudflare-provided client IP and country only when the request carries the verified edge-proof header. Direct-origin requests cannot forge either field: they retain Vercel peer metadata (or no country when it is unavailable).

The existing Cloudflare edge city and region fields remain explicitly documented as edge geography, so they cannot be mistaken for client location. `T1` is treated as a pseudo-country and falls back to Vercel geography.

Fixes #5228

## Validation

- `npm run test:data`
- `npm run typecheck:all`
- `npm run lint:md`
- Pre-push API/server gates, edge bundle checks, and changed telemetry tests

## Post-Deploy Monitoring & Validation

- **Owner / window:** platform on-call, inspect the first 24 hours after deployment.
- **Axiom query:** `['wm_api_usage'] | where event_type == 'request' and _time > ago(24h) | summarize requests=count(), distinct_ips=dcount(ip), distinct_countries=dcount(country) by execution_region, country | order by requests desc`
- **Healthy signal:** the `cpt1`/Johannesburg edge block gains a varied client-IP and country distribution rather than concentrating on `ZA`; `execution_region` remains available for PoP analysis.
- **Important interpretation:** `ip_city` and `ip_region` remain Vercel edge geography and should not be used as client-location metrics.
- **Failure / mitigation:** if verified traffic stays concentrated on the edge IP/country, or client attribution becomes unexpectedly null, verify the Cloudflare Transform Rule and `CF_EDGE_PROOF_SECRET`; roll back this commit if the deployment configuration cannot be restored promptly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
