### PR TITLE
fix(seeders): extract dependency-free client-ip.ts so usage.ts stops pulling @upstash into seeder containers (#5231)

### DIFF
--- a/api/_client-ip.js
+++ b/api/_client-ip.js
@@ -9,7 +9,7 @@ export const RATE_LIMIT_DEGRADED_HEADERS = Object.freeze({
 });
 
 // Header a Cloudflare Transform Rule injects on every proxied request to prove
-// the request actually transited CF. Keep in sync with server/_shared/rate-limit.ts.
+// the request actually transited CF. Keep in sync with server/_shared/client-ip.ts.
 const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
 
 // Constant-time comparison for the edge-proof secret. Synchronous so getClientIp

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test:e2e:variant-smoke": "npm run test:e2e:variant-smoke:full && npm run test:e2e:variant-smoke:tech && npm run test:e2e:variant-smoke:finance && npm run test:e2e:variant-smoke:commodity && npm run test:e2e:variant-smoke:energy && npm run test:e2e:variant-smoke:happy",
     "test:e2e": "npm run test:e2e:runtime && npm run test:e2e:full && npm run test:e2e:tech && npm run test:e2e:finance && npm run test:e2e:energy",
     "test:data": "tsx --test --test-concurrency=16 tests/*.test.mjs tests/*.test.mts cli/test/*.test.mjs api/security/report.test.mjs",
-    "test:resilience-validation-smoke": "tsx --test tests/resilience-validation-artifacts-schema.test.mts tests/benchmark-resilience-external.test.mjs tests/backtest-resilience-outcomes.test.mjs tests/resilience-sensitivity-v2.test.mts tests/seed-bundle-resilience-validation.test.mjs",
+    "test:resilience-validation-smoke": "tsx --test tests/resilience-validation-artifacts-schema.test.mts tests/benchmark-resilience-external.test.mjs tests/backtest-resilience-outcomes.test.mjs tests/resilience-sensitivity-v2.test.mts tests/seed-bundle-resilience-validation.test.mjs tests/resilience-validation-import-graph.test.mjs",
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:feeds:ci": "node scripts/validate-rss-feeds.mjs --ci",

--- a/server/_shared/client-ip.ts
+++ b/server/_shared/client-ip.ts
@@ -1,8 +1,8 @@
 // Trusted client-IP derivation, extracted from rate-limit.ts (#5231).
 //
 // This module MUST stay free of npm imports (node: builtins and repo-relative
-// imports only). It sits in the static import closure of server/_shared/usage.ts
-// -> redis.ts, which Railway seeders load through the tsx loader in containers
+// imports only). It sits in the static import closure of server/_shared/redis.ts
+// -> usage.ts, which Railway seeders load through the tsx loader in containers
 // that install no npm packages beyond tsx itself. A bare npm specifier
 // reachable from here crashes those crons with ERR_MODULE_NOT_FOUND at module
 // resolution time — that is how #5229 took down seed-bundle-resilience-

--- a/server/_shared/client-ip.ts
+++ b/server/_shared/client-ip.ts
@@ -1,0 +1,59 @@
+// Trusted client-IP derivation, extracted from rate-limit.ts (#5231).
+//
+// This module MUST stay free of npm imports (node: builtins and repo-relative
+// imports only). It sits in the static import closure of server/_shared/usage.ts
+// -> redis.ts, which Railway seeders load through the tsx loader in containers
+// that install no npm packages beyond tsx itself. A bare npm specifier
+// reachable from here crashes those crons with ERR_MODULE_NOT_FOUND at module
+// resolution time — that is how #5229 took down seed-bundle-resilience-
+// validation by importing this logic's previous home (rate-limit.ts, which
+// pulls @upstash/ratelimit). tests/resilience-validation-import-graph.test.mjs
+// enforces the invariant.
+
+// Sentinel returned when no trusted client-IP header is present. Routed
+// through the Upstash limiter as a single shared bucket so the entire
+// "no trusted identity" population is naturally rate-limited together —
+// an attacker who strips cf-connecting-ip / x-real-ip can no longer rotate
+// identities by toggling x-forwarded-for. See getClientIp / #3531.
+export const UNKNOWN_CLIENT_IP = 'unknown';
+
+// Header a Cloudflare Transform Rule injects on every proxied request to prove
+// the request actually transited CF. Keep in sync with api/_client-ip.js.
+const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
+
+// Constant-time comparison for the edge-proof secret. Synchronous so getClientIp
+// stays sync (per-request rate-limit hot path, several non-awaiting callers).
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+// True only when the request proves it transited Cloudflare. If
+// CF_EDGE_PROOF_SECRET is unset, do not trust cf-connecting-ip; fall back to
+// x-real-ip/UNKNOWN so a missing deployment secret cannot silently reopen
+// GHSA-c267.
+export function hasCloudflareTransitProof(request: Request): boolean {
+  const secret = (process.env.CF_EDGE_PROOF_SECRET ?? '').trim();
+  if (!secret) return false;
+  return constantTimeEqual((request.headers.get(CF_EDGE_PROOF_HEADER) ?? '').trim(), secret);
+}
+
+export function getClientIp(request: Request): string {
+  // cf-connecting-ip is only unforgeable for traffic that actually transited
+  // Cloudflare (x-real-ip is then the CF edge IP, shared across users). On a
+  // direct-to-origin hit (bypassing CF) cf-connecting-ip is fully client-
+  // controlled, so a caller sending a fresh value per request rotates the
+  // per-IP window and neutralises the limit (GHSA-c267). Trust it only with
+  // proof of CF transit. Otherwise fall back to x-real-ip (the real peer IP)
+  // then the UNKNOWN_CLIENT_IP sentinel — the spoofable cf-connecting-ip and
+  // the client-settable x-forwarded-for (#3531) are deliberately NOT fallbacks.
+  //
+  // Trim each header value before falling through — a whitespace-only
+  // cf-connecting-ip would otherwise short-circuit past x-real-ip.
+  const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
+  const xr = (request.headers.get('x-real-ip') ?? '').trim();
+  if (cf && hasCloudflareTransitProof(request)) return cf;
+  return xr || UNKNOWN_CLIENT_IP;
+}

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -9,8 +9,9 @@ import { durationToSeconds, limitWithFallback, resetRateLimitFallbackForTest } f
 // Client-IP derivation lives in the dependency-free client-ip.ts (#5231) so
 // seeder-reachable modules (usage.ts) can use it without pulling this file's
 // @upstash imports into Railway containers. Re-exported here because this was
-// the helpers' original home and callers (gateway, leads, turnstile, tests)
-// import them alongside the limiters.
+// the helpers' original home and existing callers import them from this
+// module (getClientIp: api/ask.ts, api/a2a.ts, api/mcp-proxy.ts;
+// UNKNOWN_CLIENT_IP: turnstile.ts; plus the rate-limit test suites).
 export { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './client-ip';
 
 // @upstash/redis defaults to 5 retries with exponential backoff (~4.3s total)

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -1,9 +1,17 @@
 import { Ratelimit, type Duration } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+import { getClientIp } from './client-ip';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../api/_sentry-edge.js';
 // @ts-expect-error — JS module, no declaration file
 import { durationToSeconds, limitWithFallback, resetRateLimitFallbackForTest } from '../../api/_rate-limit-fallback.js';
+
+// Client-IP derivation lives in the dependency-free client-ip.ts (#5231) so
+// seeder-reachable modules (usage.ts) can use it without pulling this file's
+// @upstash imports into Railway containers. Re-exported here because this was
+// the helpers' original home and callers (gateway, leads, turnstile, tests)
+// import them alongside the limiters.
+export { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './client-ip';
 
 // @upstash/redis defaults to 5 retries with exponential backoff (~4.3s total)
 // before surfacing an unreachable-Redis error. The node test runner sets
@@ -34,13 +42,6 @@ function getRatelimit(): Ratelimit | null {
   });
   return ratelimit;
 }
-
-// Sentinel returned when no trusted client-IP header is present. Routed
-// through the Upstash limiter as a single shared bucket so the entire
-// "no trusted identity" population is naturally rate-limited together —
-// an attacker who strips cf-connecting-ip / x-real-ip can no longer rotate
-// identities by toggling x-forwarded-for. See getClientIp / #3531.
-export const UNKNOWN_CLIENT_IP = 'unknown';
 
 // Structured one-line log so api/server log aggregation can grep for the
 // "rate-limit available" gap independently of Sentry. Keep the prefix
@@ -92,47 +93,6 @@ export const RATE_LIMIT_DEGRADED_HEADERS = {
   // rather than treating the 503 as a hard outage.
   'Retry-After': '5',
 } as const;
-
-// Header a Cloudflare Transform Rule injects on every proxied request to prove
-// the request actually transited CF. Keep in sync with api/_client-ip.js.
-const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
-
-// Constant-time comparison for the edge-proof secret. Synchronous so getClientIp
-// stays sync (per-request rate-limit hot path, several non-awaiting callers).
-function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  return diff === 0;
-}
-
-// True only when the request proves it transited Cloudflare. If
-// CF_EDGE_PROOF_SECRET is unset, do not trust cf-connecting-ip; fall back to
-// x-real-ip/UNKNOWN so a missing deployment secret cannot silently reopen
-// GHSA-c267.
-export function hasCloudflareTransitProof(request: Request): boolean {
-  const secret = (process.env.CF_EDGE_PROOF_SECRET ?? '').trim();
-  if (!secret) return false;
-  return constantTimeEqual((request.headers.get(CF_EDGE_PROOF_HEADER) ?? '').trim(), secret);
-}
-
-export function getClientIp(request: Request): string {
-  // cf-connecting-ip is only unforgeable for traffic that actually transited
-  // Cloudflare (x-real-ip is then the CF edge IP, shared across users). On a
-  // direct-to-origin hit (bypassing CF) cf-connecting-ip is fully client-
-  // controlled, so a caller sending a fresh value per request rotates the
-  // per-IP window and neutralises the limit (GHSA-c267). Trust it only with
-  // proof of CF transit. Otherwise fall back to x-real-ip (the real peer IP)
-  // then the UNKNOWN_CLIENT_IP sentinel — the spoofable cf-connecting-ip and
-  // the client-settable x-forwarded-for (#3531) are deliberately NOT fallbacks.
-  //
-  // Trim each header value before falling through — a whitespace-only
-  // cf-connecting-ip would otherwise short-circuit past x-real-ip.
-  const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
-  const xr = (request.headers.get('x-real-ip') ?? '').trim();
-  if (cf && hasCloudflareTransitProof(request)) return cf;
-  return xr || UNKNOWN_CLIENT_IP;
-}
 
 function tooManyRequestsResponse(limit: number, reset: number, corsHeaders: Record<string, string>, windowSeconds: number): Response {
   // `reset` is a Unix epoch in MILLISECONDS (Upstash). IETF RateLimit fields

--- a/server/_shared/turnstile.ts
+++ b/server/_shared/turnstile.ts
@@ -1,4 +1,7 @@
-import { UNKNOWN_CLIENT_IP } from './rate-limit';
+// client-ip (NOT rate-limit): the constant's home is dependency-free; going
+// through rate-limit's re-export would needlessly weight this module's import
+// graph with @upstash packages (#5231's exact failure shape).
+import { UNKNOWN_CLIENT_IP } from './client-ip';
 
 const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 

--- a/server/_shared/turnstile.ts
+++ b/server/_shared/turnstile.ts
@@ -8,7 +8,10 @@ export function getClientIp(request: Request): string {
   // some non-CF deploys set it directly. x-forwarded-for is client-settable
   // and MUST NOT be used as a rate-limit / abuse-defence identifier (#3531).
   // Trim each value so a whitespace-only header doesn't short-circuit past
-  // the next fallback. Mirrors getClientIp in server/_shared/rate-limit.ts.
+  // the next fallback. Named after getClientIp in server/_shared/client-ip.ts
+  // but deliberately WITHOUT its CF transit-proof gate — this value feeds the
+  // Turnstile siteverify remoteip hint. Hardening the rate-limit call sites
+  // that also consume it is tracked in #5235.
   const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
   const xr = (request.headers.get('x-real-ip') ?? '').trim();
   return cf || xr || UNKNOWN_CLIENT_IP;

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -14,7 +14,10 @@
  */
 
 import type { AuthKind } from './usage-identity';
-import { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './rate-limit';
+// client-ip (NOT rate-limit): this module is in the Railway seeders' static
+// import closure via redis.ts, and rate-limit.ts pulls @upstash/* packages
+// that seeder containers do not install (#5231).
+import { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './client-ip';
 
 const AXIOM_DATASET = 'wm_api_usage';
 // US region endpoint. EU workspaces would use api.eu.axiom.co.

--- a/tests/_lib/import-graph-walk.mjs
+++ b/tests/_lib/import-graph-walk.mjs
@@ -1,9 +1,9 @@
 // Shared static import-graph machinery for the Dockerfile/container guard
 // tests (#5231 review follow-up). Single home for the comment-stripping
-// tokenizer, edge extraction, resolution, and BFS walks that were previously
-// hand-copied across three guards:
+// tokenizer, edge extraction, resolution, Dockerfile COPY parsing, and BFS
+// walks that were previously hand-copied across three guards:
 //   - tests/resilience-validation-import-graph.test.mjs (walkContainerGraph)
-//   - tests/dockerfile-relay-imports.test.mjs (collectRelativeImports/resolveImport)
+//   - tests/dockerfile-relay-imports.test.mjs (collectRelativeImports/resolveNodeRelative)
 //   - tests/dockerfile-digest-notifications-imports.test.mjs (same scanner, copied)
 // A fix to an extraction edge case lands here once and covers all three.
 //
@@ -14,27 +14,50 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { isBuiltin } from 'node:module';
 import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 
+// Keywords after which a `/` in code position starts a REGEX LITERAL, not
+// division (`return /x/.test(s)`, `typeof /x/`, `case /x/:` ...).
+const REGEX_PRECEDING_KEYWORDS = /(?:^|[^$\w.])(?:return|typeof|case|delete|void|in|of|new|instanceof|yield|await|do|else)\s*$/;
+
 // Structure-preserving comment strip. A state machine, not regexes: naive
 // regex stripping misreads `/*` inside comment text or strings (a comment
 // mentioning `@upstash/*` swallowed everything to the next `*/`, silently
 // deleting real imports from extraction) and misreads `//` inside string
-// literals. Comments are removed exactly; string/template contents and line
-// structure are preserved. Known limit: a bare `//` inside a regex literal's
-// character class would be misread — no such shape exists in the walked
-// graphs, and the guards' deep-node canaries backstop it.
+// literals. Comments are removed exactly; string/template/regex-literal
+// contents and line structure are preserved.
+//
+// Regex literals get their own state: `/[/*]/` or `/a\/\*b/` would otherwise
+// flip the tokenizer into block-comment state and swallow everything to the
+// next `*/` or EOF — and a swallowed BARE import produces no visited node and
+// no violation, so the deep-node canaries could NOT backstop that case (they
+// only see dropped relative edges). Regex-vs-division at a `/` is decided by
+// expression position: the last significant char (or a preceding keyword like
+// `return`) says whether a regex can start there. Known residual limit: an
+// exotic ASI shape could still misclassify division as a regex start — the
+// self-test fixtures pin the realistic cases (char-class slashes, division,
+// URLs in strings).
 export function stripComments(src) {
   let out = '';
-  let state = 'code'; // code | line | block | squote | dquote | template
+  let state = 'code'; // code | line | block | squote | dquote | template | regex
+  let inClass = false; // inside [...] while state === 'regex'
+  let lastSig = ''; // last non-whitespace char emitted in code state
   let i = 0;
+
+  const regexCanStart = () =>
+    lastSig === '' ||
+    '([{,;=:?!&|^~%*+-<>'.includes(lastSig) ||
+    (lastSig === '/' ? false : /[$\w]/.test(lastSig) && REGEX_PRECEDING_KEYWORDS.test(out));
+
   while (i < src.length) {
     const c = src[i];
     const n = src[i + 1];
     if (state === 'code') {
       if (c === '/' && n === '/') { state = 'line'; i += 2; continue; }
       if (c === '/' && n === '*') { state = 'block'; i += 2; continue; }
+      if (c === '/' && regexCanStart()) { state = 'regex'; inClass = false; out += c; i += 1; continue; }
       if (c === "'") state = 'squote';
       else if (c === '"') state = 'dquote';
       else if (c === '`') state = 'template';
+      if (!/\s/.test(c)) lastSig = c;
       out += c; i += 1; continue;
     }
     if (state === 'line') {
@@ -46,10 +69,19 @@ export function stripComments(src) {
       if (c === '\n') out += c;
       i += 1; continue;
     }
+    if (state === 'regex') {
+      if (c === '\\') { out += c + (n ?? ''); i += 2; continue; }
+      if (c === '[') inClass = true;
+      else if (c === ']') inClass = false;
+      else if (c === '/' && !inClass) { state = 'code'; lastSig = '/'; out += c; i += 1; continue; }
+      else if (c === '\n') { state = 'code'; } // regex literals cannot span lines; bail defensively
+      out += c; i += 1; continue;
+    }
     // Inside a string or template literal: pass through, honor escapes.
     if (c === '\\') { out += c + (n ?? ''); i += 2; continue; }
     if ((state === 'squote' && c === "'") || (state === 'dquote' && c === '"') || (state === 'template' && c === '`')) {
       state = 'code';
+      lastSig = c; // a closing quote is a value terminator: `/` after it is division
     }
     out += c; i += 1;
   }
@@ -98,9 +130,11 @@ export function extractEdges(src) {
   for (const m of src.matchAll(/\brequire\(\s*['"]([^'"]+)['"]\s*\)/g)) {
     requireSpecs.push(m[1]);
   }
-  // createRequire(import.meta.url)('...') — immediately-invoked form; the
-  // plain require regex cannot see it (no lowercase `require(` substring)
-  for (const m of src.matchAll(/\bcreateRequire\([^)]*\)\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+  // createRequire(...)('...') — immediately-invoked form; the plain require
+  // regex cannot see it (no lowercase `require(` substring). The argument may
+  // itself contain one level of call parens — the common
+  // createRequire(fileURLToPath(import.meta.url))('./x') idiom.
+  for (const m of src.matchAll(/\bcreateRequire\((?:[^()]|\([^()]*\))*\)\(\s*['"]([^'"]+)['"]\s*\)/g)) {
     requireSpecs.push(m[1]);
   }
   return { staticSpecs, dynamicSpecs, requireSpecs };
@@ -108,6 +142,63 @@ export function extractEdges(src) {
 
 export function isBare(spec) {
   return !spec.startsWith('.') && !spec.startsWith('/');
+}
+
+// --- Dockerfile COPY parsing -------------------------------------------------
+
+// Parse every `COPY [--flags] <src> [<src> ...] <dest>` line into file-level
+// and directory-level (recursive) coverage. A trailing slash on a source
+// means recursive directory coverage; the trailing slash is stripped from
+// the returned directory names. `--from=`/`--chown=` style flags are skipped.
+// Line continuations are NOT supported — none of the guarded Dockerfiles use
+// them, and an unparsed line surfaces via the callers' loud sanity asserts.
+// Single home for the three container guards' COPY knowledge (#5236 review).
+export function parseDockerfileCopy(src) {
+  const files = new Set();
+  const directories = new Set();
+  for (const m of src.matchAll(/^COPY\s+([^\n]+)$/gm)) {
+    const tokens = m[1].trim().split(/\s+/).filter((t) => !t.startsWith('--'));
+    if (tokens.length < 2) continue; // need at least <src> <dest>
+    for (const arg of tokens.slice(0, -1)) {
+      if (arg.endsWith('/')) directories.add(arg.replace(/\/+$/, ''));
+      else files.add(arg);
+    }
+  }
+  return { files, directories };
+}
+
+// --- Resolution ---------------------------------------------------------------
+
+// Source extensions plain node can load when written explicitly. The runtime-
+// loadable set additionally includes .json (via import attributes / require).
+export const NODE_SOURCE_EXTS = ['.mjs', '.cjs', '.js'];
+const PLAIN_NODE_LOADABLE_EXTS = new Set([...NODE_SOURCE_EXTS, '.json']);
+// tsx's extension-guessing order for extensionless specifiers, plus the
+// directory-index candidates it probes.
+const TSX_EXT_CANDIDATES = ['.ts', '.mts', '.js', '.mjs', '.cjs'];
+const TSX_INDEX_CANDIDATES = ['index.ts', 'index.js', 'index.mjs'];
+
+// Node-style resolution against an explicit extension candidate list (COPY-
+// closure guard style: literal hit or listed extension appended). Skips
+// directory hits — a bare directory match is never what plain node loads.
+export function resolveNodeRelative(fromFile, relImport, exts = NODE_SOURCE_EXTS) {
+  const abs = resolve(dirname(fromFile), relImport);
+  if (existsSync(abs) && !statSync(abs).isDirectory()) return abs;
+  for (const ext of exts) {
+    if (existsSync(abs + ext)) return abs + ext;
+  }
+  return null;
+}
+
+// tsx-style resolution: extension guessing (including TypeScript), directory
+// index probing, and the TS idiom where an explicit .js/.mjs specifier maps
+// to a .ts/.mts source.
+export function resolveTsxRelative(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [base, ...TSX_EXT_CANDIDATES.map((ext) => base + ext), ...TSX_INDEX_CANDIDATES.map((ix) => join(base, ix))];
+  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
+  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
+  return candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? null;
 }
 
 // Relative specifiers a file mentions via static import / export-from /
@@ -124,44 +215,7 @@ export function collectRelativeImports(filePath) {
   return imports;
 }
 
-// Resolve a relative specifier against an extension candidate list (COPY-
-// closure guard style). Skips directory hits — a bare directory match is
-// never what plain node loads.
-export function resolveImport(fromFile, relImport, exts = ['.mjs', '.cjs', '.js']) {
-  const abs = resolve(dirname(fromFile), relImport);
-  if (existsSync(abs) && !statSync(abs).isDirectory()) return abs;
-  for (const ext of exts) {
-    if (existsSync(abs + ext)) return abs + ext;
-  }
-  return null;
-}
-
-// Resolve a relative specifier the way node+tsx would inside a container.
-export function resolveRelative(fromFile, spec) {
-  const base = resolve(dirname(fromFile), spec);
-  const candidates = [
-    base,
-    `${base}.ts`,
-    `${base}.mts`,
-    `${base}.js`,
-    `${base}.mjs`,
-    `${base}.cjs`,
-    join(base, 'index.ts'),
-    join(base, 'index.js'),
-    join(base, 'index.mjs'),
-  ];
-  // TS-style: an explicit .js specifier may map to a .ts source.
-  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
-  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
-  return candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? null;
-}
-
-// Extensions plain node (no tsx loader) can load as an explicit specifier.
-// .ts/.mts are deliberately excluded even though node:24 type-strips
-// erasable syntax natively — non-erasable syntax still crashes, so the
-// guard fails loud (a false red a dev can fix by writing the runtime
-// extension) instead of green-while-red.
-const PLAIN_NODE_EXTS = new Set(['.mjs', '.cjs', '.js', '.json']);
+// --- Container-contract walk ---------------------------------------------------
 
 // Walk the container-reachable graph from `rootFiles` under `contract`:
 //   contract.repoRoot        — absolute path imports may not escape reporting-wise
@@ -191,7 +245,7 @@ export function walkContainerGraph(rootFiles, contract) {
   const inside = (dirs, p) => dirs.some((d) => p.startsWith(d + sep));
 
   const followRelative = (file, spec) => {
-    const resolved = resolveRelative(file, spec);
+    const resolved = resolveTsxRelative(file, spec);
     if (!resolved) {
       unresolved.push(`'${spec}' imported from\n    ${chainOf(file)}`);
       return;
@@ -202,7 +256,7 @@ export function walkContainerGraph(rootFiles, contract) {
       // TypeScript would work under tsx elsewhere in the repo yet crash
       // this container at import time.
       const literal = resolve(dirname(file), spec);
-      if (resolved !== literal || !PLAIN_NODE_EXTS.has(extname(resolved))) {
+      if (resolved !== literal || !PLAIN_NODE_LOADABLE_EXTS.has(extname(resolved))) {
         violations.push(
           `'${spec}' resolves only under a tsx loader (extension guessing / TypeScript -> ${relative(contract.repoRoot, resolved)}), but this container runs plain node via\n    ${chainOf(file)}`,
         );
@@ -250,7 +304,7 @@ export function walkContainerGraph(rootFiles, contract) {
     }
     for (const spec of dynamicSpecs) {
       if (isBare(spec)) continue; // lazy; cannot classify statically
-      const resolved = resolveRelative(file, spec);
+      const resolved = resolveTsxRelative(file, spec);
       if (resolved && inside(contract.dynamicRootDirs, resolved)) {
         if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
         queue.push(resolved);

--- a/tests/_lib/import-graph-walk.mjs
+++ b/tests/_lib/import-graph-walk.mjs
@@ -1,0 +1,262 @@
+// Shared static import-graph machinery for the Dockerfile/container guard
+// tests (#5231 review follow-up). Single home for the comment-stripping
+// tokenizer, edge extraction, resolution, and BFS walks that were previously
+// hand-copied across three guards:
+//   - tests/resilience-validation-import-graph.test.mjs (walkContainerGraph)
+//   - tests/dockerfile-relay-imports.test.mjs (collectRelativeImports/resolveImport)
+//   - tests/dockerfile-digest-notifications-imports.test.mjs (same scanner, copied)
+// A fix to an extraction edge case lands here once and covers all three.
+//
+// This module is test infrastructure only — it lives under tests/ and is
+// never COPY'd into any container image.
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isBuiltin } from 'node:module';
+import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+
+// Structure-preserving comment strip. A state machine, not regexes: naive
+// regex stripping misreads `/*` inside comment text or strings (a comment
+// mentioning `@upstash/*` swallowed everything to the next `*/`, silently
+// deleting real imports from extraction) and misreads `//` inside string
+// literals. Comments are removed exactly; string/template contents and line
+// structure are preserved. Known limit: a bare `//` inside a regex literal's
+// character class would be misread — no such shape exists in the walked
+// graphs, and the guards' deep-node canaries backstop it.
+export function stripComments(src) {
+  let out = '';
+  let state = 'code'; // code | line | block | squote | dquote | template
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const n = src[i + 1];
+    if (state === 'code') {
+      if (c === '/' && n === '/') { state = 'line'; i += 2; continue; }
+      if (c === '/' && n === '*') { state = 'block'; i += 2; continue; }
+      if (c === "'") state = 'squote';
+      else if (c === '"') state = 'dquote';
+      else if (c === '`') state = 'template';
+      out += c; i += 1; continue;
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; out += c; }
+      i += 1; continue;
+    }
+    if (state === 'block') {
+      if (c === '*' && n === '/') { state = 'code'; i += 2; continue; }
+      if (c === '\n') out += c;
+      i += 1; continue;
+    }
+    // Inside a string or template literal: pass through, honor escapes.
+    if (c === '\\') { out += c + (n ?? ''); i += 2; continue; }
+    if ((state === 'squote' && c === "'") || (state === 'dquote' && c === '"') || (state === 'template' && c === '`')) {
+      state = 'code';
+    }
+    out += c; i += 1;
+  }
+  return out;
+}
+
+// True when a named-import/export clause consists ONLY of `type` bindings
+// (`{ type Foo, type Bar }`). tsx/esbuild erase those at runtime, so the
+// specifier is not a runtime edge. A mixed clause (`{ type Foo, real }`) or
+// any default/namespace binding keeps the edge.
+function isAllTypeNamedClause(clause) {
+  const inner = clause.trim();
+  if (!inner.startsWith('{') || !inner.endsWith('}')) return false;
+  const bindings = inner.slice(1, -1).split(',').map((b) => b.trim()).filter(Boolean);
+  return bindings.length > 0 && bindings.every((b) => /^type\s/.test(b));
+}
+
+// Extract import edges from one source file (comments already stripped).
+export function extractEdges(src) {
+  const staticSpecs = [];
+  const dynamicSpecs = [];
+  const requireSpecs = [];
+
+  // import ... from '...' (multi-line safe; skips `import type` and clauses
+  // whose named bindings are all inline `type` modifiers — tsx erases both)
+  for (const m of src.matchAll(/^[ \t]*import\s+(?!type\s)([^'";]*?)\bfrom\s*['"]([^'"]+)['"]/gms)) {
+    if (isAllTypeNamedClause(m[1])) continue;
+    staticSpecs.push(m[2]);
+  }
+  // side-effect: import '...'
+  for (const m of src.matchAll(/^[ \t]*import\s*['"]([^'"]+)['"]/gm)) {
+    staticSpecs.push(m[1]);
+  }
+  // export { ... } from '...' / export * from '...' (skips `export type` and
+  // all-inline-type clauses)
+  for (const m of src.matchAll(/^[ \t]*export\s+(?!type\b)(\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gms)) {
+    if (m[1].startsWith('{') && isAllTypeNamedClause(m[1])) continue;
+    staticSpecs.push(m[2]);
+  }
+  // dynamic import('...') literals
+  for (const m of src.matchAll(/\bimport\(\s*['"]([^'"]+)['"]/g)) {
+    dynamicSpecs.push(m[1]);
+  }
+  // require('...') literals (plain require in .cjs, or a createRequire-bound
+  // local named require)
+  for (const m of src.matchAll(/\brequire\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+    requireSpecs.push(m[1]);
+  }
+  // createRequire(import.meta.url)('...') — immediately-invoked form; the
+  // plain require regex cannot see it (no lowercase `require(` substring)
+  for (const m of src.matchAll(/\bcreateRequire\([^)]*\)\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+    requireSpecs.push(m[1]);
+  }
+  return { staticSpecs, dynamicSpecs, requireSpecs };
+}
+
+export function isBare(spec) {
+  return !spec.startsWith('.') && !spec.startsWith('/');
+}
+
+// Relative specifiers a file mentions via static import / export-from /
+// require / createRequire (dynamic import() literals are deliberately NOT
+// included — the COPY-closure guards never followed those). Used by the
+// relay and digest-notifications Dockerfile guards.
+export function collectRelativeImports(filePath) {
+  const src = stripComments(readFileSync(filePath, 'utf-8'));
+  const { staticSpecs, requireSpecs } = extractEdges(src);
+  const imports = new Set();
+  for (const spec of [...staticSpecs, ...requireSpecs]) {
+    if (spec.startsWith('.')) imports.add(spec);
+  }
+  return imports;
+}
+
+// Resolve a relative specifier against an extension candidate list (COPY-
+// closure guard style). Skips directory hits — a bare directory match is
+// never what plain node loads.
+export function resolveImport(fromFile, relImport, exts = ['.mjs', '.cjs', '.js']) {
+  const abs = resolve(dirname(fromFile), relImport);
+  if (existsSync(abs) && !statSync(abs).isDirectory()) return abs;
+  for (const ext of exts) {
+    if (existsSync(abs + ext)) return abs + ext;
+  }
+  return null;
+}
+
+// Resolve a relative specifier the way node+tsx would inside a container.
+export function resolveRelative(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.mts`,
+    `${base}.js`,
+    `${base}.mjs`,
+    `${base}.cjs`,
+    join(base, 'index.ts'),
+    join(base, 'index.js'),
+    join(base, 'index.mjs'),
+  ];
+  // TS-style: an explicit .js specifier may map to a .ts source.
+  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
+  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
+  return candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? null;
+}
+
+// Extensions plain node (no tsx loader) can load as an explicit specifier.
+// .ts/.mts are deliberately excluded even though node:24 type-strips
+// erasable syntax natively — non-erasable syntax still crashes, so the
+// guard fails loud (a false red a dev can fix by writing the runtime
+// extension) instead of green-while-red.
+const PLAIN_NODE_EXTS = new Set(['.mjs', '.cjs', '.js', '.json']);
+
+// Walk the container-reachable graph from `rootFiles` under `contract`:
+//   contract.repoRoot        — absolute path imports may not escape reporting-wise
+//   contract.copyRootDirs    — absolute dirs the image COPYs (containment set)
+//   contract.dynamicRootDirs — absolute dirs dynamic import() literals are
+//                              followed into (executed-unconditionally set)
+//   contract.installedPackages — bare-specifier budget beyond node builtins
+//   contract.hasTsx          — false = the container runs plain node: no
+//                              extension guessing, no index resolution, no
+//                              TypeScript. Omitted/true = tsx-shaped resolution.
+// Returns violations/unresolved (each with the import chain from a root) and
+// the visited set for reachability assertions.
+export function walkContainerGraph(rootFiles, contract) {
+  const parent = new Map();
+  const visited = new Set();
+  const queue = [...rootFiles];
+  const violations = [];
+  const unresolved = [];
+  const hasTsx = contract.hasTsx !== false;
+
+  const chainOf = (file) => {
+    const chain = [];
+    for (let f = file; f; f = parent.get(f)) chain.unshift(relative(contract.repoRoot, f));
+    return chain.join('\n    -> ');
+  };
+
+  const inside = (dirs, p) => dirs.some((d) => p.startsWith(d + sep));
+
+  const followRelative = (file, spec) => {
+    const resolved = resolveRelative(file, spec);
+    if (!resolved) {
+      unresolved.push(`'${spec}' imported from\n    ${chainOf(file)}`);
+      return;
+    }
+    if (!hasTsx) {
+      // Plain node resolves ONLY the literal specifier, and only for
+      // extensions it can load. An edge that needed extension guessing or
+      // TypeScript would work under tsx elsewhere in the repo yet crash
+      // this container at import time.
+      const literal = resolve(dirname(file), spec);
+      if (resolved !== literal || !PLAIN_NODE_EXTS.has(extname(resolved))) {
+        violations.push(
+          `'${spec}' resolves only under a tsx loader (extension guessing / TypeScript -> ${relative(contract.repoRoot, resolved)}), but this container runs plain node via\n    ${chainOf(file)}`,
+        );
+        return;
+      }
+    }
+    if (!inside(contract.copyRootDirs, resolved)) {
+      violations.push(
+        `'${spec}' resolves in the repo but OUTSIDE the container COPY set (${relative(contract.repoRoot, resolved)}) via\n    ${chainOf(file)}`,
+      );
+      return;
+    }
+    if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
+    queue.push(resolved);
+  };
+
+  const checkBare = (file, spec, how) => {
+    const pkg = spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/');
+    if (!isBuiltin(spec) && !contract.installedPackages.has(pkg)) {
+      violations.push(`'${spec}' ${how} via\n    ${chainOf(file)}`);
+    }
+  };
+
+  while (queue.length > 0) {
+    const file = queue.shift();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    if (extname(file) === '.json') continue; // data, no imports
+
+    const src = stripComments(readFileSync(file, 'utf-8'));
+    const { staticSpecs, dynamicSpecs, requireSpecs } = extractEdges(src);
+
+    for (const spec of staticSpecs) {
+      if (isBare(spec)) checkBare(file, spec, 'statically imported');
+      else followRelative(file, spec);
+    }
+    for (const spec of requireSpecs) {
+      // A top-level require in a walked file loads eagerly at startup (e.g.
+      // _seed-utils.mjs createRequire()s _proxy-utils.cjs at module scope),
+      // so bare requires get the same budget check as static imports. The
+      // walked graph is require-clean today; if a genuinely-lazy bare
+      // require ever appears, exempt that one site explicitly.
+      if (isBare(spec)) checkBare(file, spec, 'require()d');
+      else followRelative(file, spec);
+    }
+    for (const spec of dynamicSpecs) {
+      if (isBare(spec)) continue; // lazy; cannot classify statically
+      const resolved = resolveRelative(file, spec);
+      if (resolved && inside(contract.dynamicRootDirs, resolved)) {
+        if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return { violations, unresolved, visited };
+}

--- a/tests/dockerfile-digest-notifications-imports.test.mjs
+++ b/tests/dockerfile-digest-notifications-imports.test.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 // Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
 // one home for the machinery this guard previously copied from the relay
 // test; see tests/_lib/import-graph-walk.mjs (#5231 review follow-up).
-import { collectRelativeImports, resolveImport } from './_lib/import-graph-walk.mjs';
+import { collectRelativeImports, parseDockerfileCopy, resolveNodeRelative } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -53,27 +53,13 @@ const TRACKED_PREFIXES = ['scripts/', 'shared/', 'server/_shared/', 'api/'];
  * @returns {{ files: Set<string>, directories: Set<string> }}
  */
 function readCoverage(dockerfilePath) {
-  const src = readFileSync(dockerfilePath, 'utf-8');
-  const files = new Set();
-  const directories = new Set();
-
-  // Split each COPY line, take all source args (everything but the
-  // trailing destination), and bucket into file/directory coverage.
-  const lineRe = /^COPY\s+(.+?)\s+\.\/[^\n]*$/gm;
-  for (const m of src.matchAll(lineRe)) {
-    const args = m[1].split(/\s+/);
-    for (const arg of args) {
-      // Skip non-tracked prefixes (e.g. package.json, node_modules
-      // would never appear here but defensive).
-      if (!TRACKED_PREFIXES.some((p) => arg.startsWith(p))) continue;
-      if (arg.endsWith('/')) {
-        directories.add(arg.replace(/\/$/, ''));
-      } else {
-        files.add(arg);
-      }
-    }
-  }
-  return { files, directories };
+  // The COPY grammar itself is parsed by the shared tests/_lib parser so all
+  // three container guards read Dockerfiles identically; this guard then
+  // scopes coverage to its tracked prefixes (e.g. package.json COPYs are
+  // runtime-resolved, not import-graph coverage).
+  const parsed = parseDockerfileCopy(readFileSync(dockerfilePath, 'utf-8'));
+  const tracked = (set) => new Set([...set].filter((p) => TRACKED_PREFIXES.some((prefix) => p.startsWith(prefix))));
+  return { files: tracked(parsed.files), directories: tracked(parsed.directories) };
 }
 
 /**
@@ -162,7 +148,7 @@ describe('Dockerfile.digest-notifications — transitive-import closure', () => 
       visited.add(file);
       if (!existsSync(file)) continue;
       for (const rel of collectRelativeImports(file)) {
-        const resolved = resolveImport(file, rel, DIGEST_RESOLVE_EXTS);
+        const resolved = resolveNodeRelative(file, rel, DIGEST_RESOLVE_EXTS);
         if (!resolved) continue;
         const relToRoot = resolved.startsWith(root + '/')
           ? resolved.slice(root.length + 1)

--- a/tests/dockerfile-digest-notifications-imports.test.mjs
+++ b/tests/dockerfile-digest-notifications-imports.test.mjs
@@ -22,9 +22,13 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+// Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
+// one home for the machinery this guard previously copied from the relay
+// test; see tests/_lib/import-graph-walk.mjs (#5231 review follow-up).
+import { collectRelativeImports, resolveImport } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -85,31 +89,9 @@ function isCovered(coverage, relPath) {
   return false;
 }
 
-/**
- * Collect relative imports from a JS/TS source file. Same scanner the
- * relay test uses (covers ESM import/export-from + CJS require + CJS
- * createRequire).
- */
-function collectRelativeImports(filePath) {
-  const src = readFileSync(filePath, 'utf-8');
-  const imports = new Set();
-  const esmRe = /(?:^|\s|;)(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(esmRe)) imports.add(m[1]);
-  const cjsRe = /(?:^|[^a-zA-Z0-9_$])require\s*\(\s*['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(cjsRe)) imports.add(m[1]);
-  const createRequireRe = /createRequire\s*\([^)]*\)\s*\(\s*['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(createRequireRe)) imports.add(m[1]);
-  return imports;
-}
-
-function resolveImport(fromFile, relImport) {
-  const abs = resolve(dirname(fromFile), relImport);
-  if (existsSync(abs) && !statSync(abs).isDirectory()) return abs;
-  for (const ext of ['.mjs', '.cjs', '.js', '.ts']) {
-    if (existsSync(abs + ext)) return abs + ext;
-  }
-  return null;
-}
+// Extension candidates for this image: the digest cron's graph spans .ts
+// modules under server/_shared/, unlike the relay's .mjs/.cjs-only graph.
+const DIGEST_RESOLVE_EXTS = ['.mjs', '.cjs', '.js', '.ts'];
 
 describe('Dockerfile.digest-notifications — transitive-import closure', () => {
   const dockerfile = resolve(root, 'Dockerfile.digest-notifications');
@@ -180,7 +162,7 @@ describe('Dockerfile.digest-notifications — transitive-import closure', () => 
       visited.add(file);
       if (!existsSync(file)) continue;
       for (const rel of collectRelativeImports(file)) {
-        const resolved = resolveImport(file, rel);
+        const resolved = resolveImport(file, rel, DIGEST_RESOLVE_EXTS);
         if (!resolved) continue;
         const relToRoot = resolved.startsWith(root + '/')
           ? resolved.slice(root.length + 1)

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -17,18 +17,17 @@ import { fileURLToPath } from 'node:url';
 // Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
 // one home for the machinery this guard previously hand-rolled; see
 // tests/_lib/import-graph-walk.mjs (#5231 review follow-up).
-import { collectRelativeImports, resolveImport } from './_lib/import-graph-walk.mjs';
+import { collectRelativeImports, parseDockerfileCopy, resolveNodeRelative } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
+// This guard tracks file-level `COPY scripts/foo.mjs ...` lines only; the
+// COPY grammar itself is parsed by the shared tests/_lib parser so all three
+// container guards read Dockerfiles identically.
 function readCopyList(dockerfilePath) {
-  const src = readFileSync(dockerfilePath, 'utf-8');
-  const copied = new Set();
-  // Matches: COPY scripts/foo.mjs ./scripts/foo.mjs
-  const re = /^COPY\s+(scripts\/[^\s]+\.(mjs|cjs))\s+/gm;
-  for (const m of src.matchAll(re)) copied.add(m[1]);
-  return copied;
+  const { files } = parseDockerfileCopy(readFileSync(dockerfilePath, 'utf-8'));
+  return new Set([...files].filter((f) => /^scripts\/.+\.(mjs|cjs)$/.test(f)));
 }
 
 describe('Dockerfile.relay — transitive-import closure', () => {
@@ -69,7 +68,7 @@ describe('Dockerfile.relay — transitive-import closure', () => {
       visited.add(file);
       if (!existsSync(file)) continue;
       for (const rel of collectRelativeImports(file)) {
-        const resolved = resolveImport(file, rel);
+        const resolved = resolveNodeRelative(file, rel);
         if (!resolved) continue;
         const relToRoot = resolved.startsWith(root + '/') ? resolved.slice(root.length + 1) : null;
         if (!relToRoot || !relToRoot.startsWith('scripts/')) continue;

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -12,8 +12,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
-import { dirname, resolve, basename } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+// Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
+// one home for the machinery this guard previously hand-rolled; see
+// tests/_lib/import-graph-walk.mjs (#5231 review follow-up).
+import { collectRelativeImports, resolveImport } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -25,32 +29,6 @@ function readCopyList(dockerfilePath) {
   const re = /^COPY\s+(scripts\/[^\s]+\.(mjs|cjs))\s+/gm;
   for (const m of src.matchAll(re)) copied.add(m[1]);
   return copied;
-}
-
-function collectRelativeImports(filePath) {
-  const src = readFileSync(filePath, 'utf-8');
-  const imports = new Set();
-  // ESM: import ... from './x.mjs'   |  export ... from './x.mjs'
-  const esmRe = /(?:^|\s|;)(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(esmRe)) imports.add(m[1]);
-  // CJS direct: require('./x.cjs')
-  const cjsRe = /(?:^|[^a-zA-Z0-9_$])require\s*\(\s*['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(cjsRe)) imports.add(m[1]);
-  // CJS chained: createRequire(import.meta.url)('./x.cjs')
-  //  — the final `('./x')` argument is applied to createRequire's return,
-  //    not to a `require(` token, so the cjsRe above misses it.
-  const createRequireRe = /createRequire\s*\([^)]*\)\s*\(\s*['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(createRequireRe)) imports.add(m[1]);
-  return imports;
-}
-
-function resolveImport(fromFile, relImport) {
-  const abs = resolve(dirname(fromFile), relImport);
-  if (existsSync(abs)) return abs;
-  for (const ext of ['.mjs', '.cjs', '.js']) {
-    if (existsSync(abs + ext)) return abs + ext;
-  }
-  return null;
 }
 
 describe('Dockerfile.relay — transitive-import closure', () => {

--- a/tests/resilience-validation-import-graph.test.mjs
+++ b/tests/resilience-validation-import-graph.test.mjs
@@ -1,77 +1,141 @@
-// #5231 — static guard for the seed-bundle-resilience-validation container's
-// dependency contract.
+// #5231 — static dependency-contract guard for the zero/single-npm-install
+// Docker seed-bundle containers.
 //
-// Dockerfile.seed-bundle-resilience-validation installs EXACTLY ONE npm
-// package: tsx (as the ESM loader — never imported by code). Everything the
-// bundle's member scripts reach — scripts/ helpers, and the ../server/*.ts
-// modules they dynamic-import through the tsx loader — must therefore resolve
-// using node: builtins and repo files only. ESM resolves a module's full
-// static import closure eagerly, so ONE bare npm specifier anywhere in that
+// These containers install (at most) the tsx loader — no scripts/package.json,
+// no root node_modules. Everything their entry script reaches — the bundle
+// runner, member scripts, scripts/ helpers, and (for resilience-validation)
+// the ../server/*.ts modules loaded through tsx — must resolve using node:
+// builtins and files the Dockerfile actually COPYs. ESM resolves a module's
+// full static import closure eagerly, so ONE bad edge anywhere in that
 // closure crashes the cron with ERR_MODULE_NOT_FOUND even if the importing
 // code path never runs.
 //
-// That is exactly how #5229 broke this bundle: server/_shared/usage.ts (deep
-// in the closure via redis.ts) gained a static import of ./rate-limit, whose
-// own static imports pull @upstash/ratelimit — declared only in the ROOT
-// package.json, absent from the container. The seeder never calls the rate
-// limiter; it crashed anyway, at resolution time.
+// That is exactly how #5229 broke seed-bundle-resilience-validation:
+// server/_shared/usage.ts (deep in the closure via redis.ts) gained a static
+// import of ./rate-limit, whose own static imports pull @upstash/ratelimit —
+// declared only in the ROOT package.json, absent from the container. The
+// seeder never calls the rate limiter; it crashed anyway, at resolution time.
+//
+// The guard enforces three container invariants, per container, with the
+// COPY roots and installed-package set DERIVED from each Dockerfile (so the
+// test cannot drift from the image contract):
+//   1. every relative import in the reachable graph resolves on disk;
+//   2. every resolved file lives inside the container's COPY roots (a module
+//      that resolves in the repo but is never COPY'd — e.g. api/ — is the
+//      same production crash);
+//   3. every bare specifier (static import OR require) is a node builtin or
+//      an installed package.
 //
 // Scope notes (kept deliberately aligned with the crash mechanics):
-//  - Static `import`/`export ... from` edges are followed and enforced.
 //  - `import type` / `export type` edges are skipped (tsx erases them).
-//  - Dynamic import() literals are followed only when they resolve into
-//    server/ — the bundle members execute those unconditionally (loading the
-//    scorers IS their job). Other dynamic imports and require() calls of bare
-//    specifiers are conditional/lazy and cannot be classified statically, so
-//    they are not enforced here.
-//  - Relative require() literals in .cjs/.mjs helpers are followed so their
-//    static closures stay covered (e.g. _seed-utils.mjs eagerly
-//    createRequire()s _proxy-utils.cjs).
+//  - Comments are stripped (structure-preserving tokenizer) before edge
+//    extraction, so commented-out imports and JSDoc `@typedef {import(...)}`
+//    text are not edges, while string/template contents are preserved.
+//  - Dynamic import() literals are followed only when they resolve into a
+//    container's dynamic-follow roots (server/ for resilience-validation —
+//    the members execute those unconditionally; loading the scorers IS their
+//    job). Unresolvable or computed dynamic imports are out of scope.
+//  - createRequire(...)('<spec>') chains are treated as require edges —
+//    _seed-utils.mjs eagerly createRequire()s _proxy-utils.cjs at module top
+//    level, so that CJS closure loads at seeder startup.
+//
+// The final describe block is a self-test: it builds a synthetic module tree
+// in a tmpdir with one planted violation of each class and asserts the
+// walker still catches them — so a regex/walker regression fails loudly
+// instead of silently blinding the guard.
 
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, statSync } from 'node:fs';
-import { dirname, join, resolve, relative, extname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { isBuiltin } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
-const scriptsDir = join(root, 'scripts');
-const serverDir = join(root, 'server');
 
-// Bare npm specifiers installed in the container image. Keep in lockstep with
-// the `npm install` line in Dockerfile.seed-bundle-resilience-validation.
-// tsx is intentionally NOT listed: it is the loader, and code importing tsx
-// directly would be a smell this guard should surface.
-const CONTAINER_INSTALLED_PACKAGES = new Set([]);
+// --- Dockerfile contract derivation ----------------------------------------
 
-function isFile(p) {
-  return existsSync(p) && statSync(p).isFile();
+// Directory-level COPY sources (`COPY <dir>/ ./<dir>/`) define where imports
+// may resolve; the `npm install` RUN line defines the bare-specifier budget.
+// Deriving both here means adding a package to the image or a new COPY root
+// updates the guard automatically — and removing one makes the guard fail
+// loudly instead of silently passing on a contract the image no longer meets.
+function parseDockerfileContract(dockerfileName) {
+  const src = readFileSync(join(root, dockerfileName), 'utf-8');
+
+  const copyRoots = [];
+  for (const m of src.matchAll(/^COPY\s+([A-Za-z0-9._-]+)\/\s+\.\//gm)) {
+    copyRoots.push(m[1]);
+  }
+
+  const installedPackages = new Set();
+  const installLines = [...src.matchAll(/^RUN\s+npm\s+install\b[^\n]*/gm)];
+  for (const [line] of installLines) {
+    for (const m of line.matchAll(/\s((?:@[a-z0-9._-]+\/)?[a-z0-9._-]+)@[\d^~]/g)) {
+      installedPackages.add(m[1]);
+    }
+  }
+  if (installLines.length > 0) {
+    assert.ok(
+      installedPackages.size > 0,
+      `${dockerfileName} has an npm install line but no parseable package@version tokens — update the parser with the Dockerfile refactor`,
+    );
+  }
+  // tsx is the ESM loader, wired via NODE_OPTIONS — code importing tsx
+  // directly would be a smell this guard should surface, so it does not
+  // count toward the bare-specifier budget.
+  installedPackages.delete('tsx');
+
+  return { copyRoots, installedPackages };
 }
 
-// Resolve a relative specifier the way node+tsx would inside the container.
-function resolveRelative(fromFile, spec) {
-  const base = resolve(dirname(fromFile), spec);
-  const candidates = [
-    base,
-    `${base}.ts`,
-    `${base}.mts`,
-    `${base}.js`,
-    `${base}.mjs`,
-    `${base}.cjs`,
-    join(base, 'index.ts'),
-    join(base, 'index.js'),
-    join(base, 'index.mjs'),
-  ];
-  // TS-style: an explicit .js specifier may map to a .ts source.
-  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
-  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
-  return candidates.find(isFile) ?? null;
+// --- Source preparation and edge extraction ---------------------------------
+
+// Structure-preserving comment strip. A state machine, not regexes: naive
+// regex stripping misreads `/*` inside comment text or strings (a comment
+// mentioning `@upstash/*` swallowed everything to the next `*/`, silently
+// deleting real imports from extraction) and misreads `//` inside string
+// literals. Comments are removed exactly; string/template contents and line
+// structure are preserved. Known limit: a bare `//` inside a regex literal's
+// character class would be misread — no such shape exists in the walked
+// graphs, and the deep-node canaries below backstop it.
+function stripComments(src) {
+  let out = '';
+  let state = 'code'; // code | line | block | squote | dquote | template
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const n = src[i + 1];
+    if (state === 'code') {
+      if (c === '/' && n === '/') { state = 'line'; i += 2; continue; }
+      if (c === '/' && n === '*') { state = 'block'; i += 2; continue; }
+      if (c === "'") state = 'squote';
+      else if (c === '"') state = 'dquote';
+      else if (c === '`') state = 'template';
+      out += c; i += 1; continue;
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; out += c; }
+      i += 1; continue;
+    }
+    if (state === 'block') {
+      if (c === '*' && n === '/') { state = 'code'; i += 2; continue; }
+      if (c === '\n') out += c;
+      i += 1; continue;
+    }
+    // Inside a string or template literal: pass through, honor escapes.
+    if (c === '\\') { out += c + (n ?? ''); i += 2; continue; }
+    if ((state === 'squote' && c === "'") || (state === 'dquote' && c === '"') || (state === 'template' && c === '`')) {
+      state = 'code';
+    }
+    out += c; i += 1;
+  }
+  return out;
 }
 
-// Extract import edges from one source file. Anchored to line starts so
-// commented-out imports don't count.
+// Extract import edges from one source file (comments already stripped).
 function extractEdges(src) {
   const staticSpecs = [];
   const dynamicSpecs = [];
@@ -93,8 +157,14 @@ function extractEdges(src) {
   for (const m of src.matchAll(/\bimport\(\s*['"]([^'"]+)['"]/g)) {
     dynamicSpecs.push(m[1]);
   }
-  // require('...') literals (createRequire in .mjs, plain require in .cjs)
+  // require('...') literals (plain require in .cjs, or a createRequire-bound
+  // local named require)
   for (const m of src.matchAll(/\brequire\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+    requireSpecs.push(m[1]);
+  }
+  // createRequire(import.meta.url)('...') — immediately-invoked form; the
+  // plain require regex cannot see it (no lowercase `require(` substring)
+  for (const m of src.matchAll(/\bcreateRequire\([^)]*\)\(\s*['"]([^'"]+)['"]\s*\)/g)) {
     requireSpecs.push(m[1]);
   }
   return { staticSpecs, dynamicSpecs, requireSpecs };
@@ -104,20 +174,72 @@ function isBare(spec) {
   return !spec.startsWith('.') && !spec.startsWith('/');
 }
 
-// Walk the container-reachable graph from the bundle's member scripts.
-// Returns bare-specifier violations and unresolvable relative imports, each
-// with the import chain from a member script for debuggability.
-function walkContainerGraph(memberFiles) {
-  const parent = new Map(); // file -> importing file
+// Resolve a relative specifier the way node+tsx would inside the container.
+function resolveRelative(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.mts`,
+    `${base}.js`,
+    `${base}.mjs`,
+    `${base}.cjs`,
+    join(base, 'index.ts'),
+    join(base, 'index.js'),
+    join(base, 'index.mjs'),
+  ];
+  // TS-style: an explicit .js specifier may map to a .ts source.
+  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
+  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
+  return candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? null;
+}
+
+// --- The walk ----------------------------------------------------------------
+
+// Walk the container-reachable graph from `rootFiles` under `contract`:
+//   contract.repoRoot        — absolute path imports may not escape reporting-wise
+//   contract.copyRootDirs    — absolute dirs the image COPYs (containment set)
+//   contract.dynamicRootDirs — absolute dirs dynamic import() literals are
+//                              followed into (executed-unconditionally set)
+//   contract.installedPackages — bare-specifier budget beyond node builtins
+// Returns violations/unresolved (each with the import chain from a root) and
+// the visited set for reachability assertions.
+function walkContainerGraph(rootFiles, contract) {
+  const parent = new Map();
   const visited = new Set();
-  const queue = [...memberFiles];
+  const queue = [...rootFiles];
   const violations = [];
   const unresolved = [];
 
   const chainOf = (file) => {
     const chain = [];
-    for (let f = file; f; f = parent.get(f)) chain.unshift(relative(root, f));
+    for (let f = file; f; f = parent.get(f)) chain.unshift(relative(contract.repoRoot, f));
     return chain.join('\n    -> ');
+  };
+
+  const inside = (dirs, p) => dirs.some((d) => p.startsWith(d + sep));
+
+  const followRelative = (file, spec) => {
+    const resolved = resolveRelative(file, spec);
+    if (!resolved) {
+      unresolved.push(`'${spec}' imported from\n    ${chainOf(file)}`);
+      return;
+    }
+    if (!inside(contract.copyRootDirs, resolved)) {
+      violations.push(
+        `'${spec}' resolves in the repo but OUTSIDE the container COPY set (${relative(contract.repoRoot, resolved)}) via\n    ${chainOf(file)}`,
+      );
+      return;
+    }
+    if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
+    queue.push(resolved);
+  };
+
+  const checkBare = (file, spec, how) => {
+    const pkg = spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/');
+    if (!isBuiltin(spec) && !contract.installedPackages.has(pkg)) {
+      violations.push(`'${spec}' ${how} via\n    ${chainOf(file)}`);
+    }
   };
 
   while (queue.length > 0) {
@@ -126,83 +248,238 @@ function walkContainerGraph(memberFiles) {
     visited.add(file);
     if (extname(file) === '.json') continue; // data, no imports
 
-    const src = readFileSync(file, 'utf-8');
+    const src = stripComments(readFileSync(file, 'utf-8'));
     const { staticSpecs, dynamicSpecs, requireSpecs } = extractEdges(src);
 
-    const followRelative = (spec) => {
-      const resolved = resolveRelative(file, spec);
-      if (!resolved) {
-        unresolved.push(`'${spec}' imported from\n    ${chainOf(file)}`);
-        return;
-      }
-      if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
-      queue.push(resolved);
-    };
-
     for (const spec of staticSpecs) {
-      if (isBare(spec)) {
-        if (!isBuiltin(spec) && !CONTAINER_INSTALLED_PACKAGES.has(spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/'))) {
-          violations.push(`'${spec}' statically imported via\n    ${chainOf(file)}`);
-        }
-        continue;
-      }
-      followRelative(spec);
+      if (isBare(spec)) checkBare(file, spec, 'statically imported');
+      else followRelative(file, spec);
     }
-
+    for (const spec of requireSpecs) {
+      // A top-level require in a walked file loads eagerly at startup (e.g.
+      // _seed-utils.mjs createRequire()s _proxy-utils.cjs at module scope),
+      // so bare requires get the same budget check as static imports. The
+      // walked graph is require-clean today; if a genuinely-lazy bare
+      // require ever appears, exempt that one site explicitly.
+      if (isBare(spec)) checkBare(file, spec, 'require()d');
+      else followRelative(file, spec);
+    }
     for (const spec of dynamicSpecs) {
       if (isBare(spec)) continue; // lazy; cannot classify statically
       const resolved = resolveRelative(file, spec);
-      // Follow only dynamic imports into server/ — the members execute those
-      // unconditionally (that is the bundle's purpose).
-      if (resolved && resolved.startsWith(serverDir)) {
+      if (resolved && inside(contract.dynamicRootDirs, resolved)) {
         if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
         queue.push(resolved);
       }
     }
-
-    for (const spec of requireSpecs) {
-      if (isBare(spec)) continue; // lazy/conditional; cannot classify statically
-      followRelative(spec);
-    }
   }
 
-  return { violations, unresolved, visitedCount: visited.size };
+  return { violations, unresolved, visited };
 }
 
-describe('seed-bundle-resilience-validation container import graph (#5231)', () => {
-  const bundleSrc = readFileSync(join(scriptsDir, 'seed-bundle-resilience-validation.mjs'), 'utf-8');
+// --- Container contracts under guard ----------------------------------------
+
+// minVisited is a tight sanity floor against a silently-shrunken walk (a
+// dropped edge class shrinks the graph without producing violations or
+// unresolved entries); deepNodes pin the load-bearing modules explicitly.
+// Current actual counts (2026-07-12): resilience-validation 35, portwatch 9.
+const CONTAINERS = [
+  {
+    name: 'seed-bundle-resilience-validation',
+    dockerfile: 'Dockerfile.seed-bundle-resilience-validation',
+    bundleScript: 'seed-bundle-resilience-validation.mjs',
+    minMembers: 3,
+    mustIncludeMember: 'validate-resilience-sensitivity.mjs',
+    dynamicRoots: ['server'],
+    minVisited: 32,
+    deepNodes: [
+      'scripts/_bundle-runner.mjs',
+      'scripts/_proxy-utils.cjs',
+      'server/_shared/redis.ts',
+      'server/_shared/usage.ts',
+      'server/_shared/client-ip.ts',
+    ],
+  },
+  {
+    name: 'seed-bundle-portwatch-port-activity',
+    dockerfile: 'Dockerfile.seed-bundle-portwatch-port-activity',
+    bundleScript: 'seed-bundle-portwatch-port-activity.mjs',
+    minMembers: 1,
+    mustIncludeMember: 'seed-portwatch-port-activity.mjs',
+    dynamicRoots: [],
+    minVisited: 8,
+    deepNodes: ['scripts/_bundle-runner.mjs', 'scripts/_proxy-utils.cjs'],
+  },
+];
+
+const scriptsDir = join(root, 'scripts');
+
+function buildContract(container) {
+  const { copyRoots, installedPackages } = parseDockerfileContract(container.dockerfile);
+  assert.ok(
+    copyRoots.includes('scripts'),
+    `${container.dockerfile}: no 'COPY scripts/ ...' line parsed — Dockerfile format changed; update parseDockerfileContract`,
+  );
+  return {
+    repoRoot: root,
+    copyRootDirs: copyRoots.map((d) => join(root, d)),
+    dynamicRootDirs: container.dynamicRoots.map((d) => join(root, d)),
+    installedPackages,
+  };
+}
+
+function walkRootsFor(container) {
+  const bundleSrc = readFileSync(join(scriptsDir, container.bundleScript), 'utf-8');
   const members = [...bundleSrc.matchAll(/script:\s*'([^']+)'/g)].map((m) => m[1]);
+  assert.ok(
+    members.length >= container.minMembers,
+    `${container.bundleScript}: expected >=${container.minMembers} member scripts, found ${members.length} — bundle definition or the member regex drifted`,
+  );
+  assert.ok(
+    members.includes(container.mustIncludeMember),
+    `${container.bundleScript}: expected member ${container.mustIncludeMember} missing — bundle definition or the member regex drifted`,
+  );
+  // The entry script's own closure (-> _bundle-runner.mjs) resolves FIRST in
+  // the container (it is the CMD), before any member spawns — walk it too.
+  const roots = [join(scriptsDir, container.bundleScript), ...members.map((m) => join(scriptsDir, m))];
+  for (const r of roots) {
+    assert.ok(existsSync(r), `walk root missing on disk: ${relative(root, r)}`);
+  }
+  return roots;
+}
 
-  it('discovers the bundle member scripts', () => {
-    assert.ok(members.length >= 3, `expected >=3 member scripts, found ${members.length}`);
+for (const container of CONTAINERS) {
+  describe(`${container.name} container import graph (#5231)`, () => {
+    const contract = buildContract(container);
+    const { violations, unresolved, visited } = walkContainerGraph(walkRootsFor(container), contract);
+
+    it('every relative import resolves on disk', () => {
+      assert.deepEqual(
+        unresolved,
+        [],
+        `unresolvable relative import(s) — these crash the cron with ERR_MODULE_NOT_FOUND:\n\n  ${unresolved.join('\n\n  ')}`,
+      );
+    });
+
+    it('reaches no bare specifier or COPY-set escape the container cannot resolve', () => {
+      assert.deepEqual(
+        violations,
+        [],
+        `import(s) reachable from ${container.name} that its container cannot resolve ` +
+          `(${container.dockerfile} defines the COPY roots and the installed-package budget). ESM resolves ` +
+          `these eagerly, so the cron crashes with ERR_MODULE_NOT_FOUND even if the importing code never ` +
+          `runs. Break the import chain (extract a dependency-free module) or change the container image:\n\n  ${violations.join('\n\n  ')}`,
+      );
+    });
+
+    it('walk reaches the load-bearing deep nodes (walker-regression canary)', () => {
+      for (const node of container.deepNodes) {
+        assert.ok(
+          visited.has(join(root, node)),
+          `${node} not visited — an edge class was silently dropped from the walk (visited ${visited.size} files)`,
+        );
+      }
+      assert.ok(
+        visited.size >= container.minVisited,
+        `graph walk shrank — visited only ${visited.size} modules (floor ${container.minVisited}); ` +
+          `if files were legitimately removed, update minVisited alongside the change`,
+      );
+    });
+  });
+}
+
+// --- Guard self-test: the walker must still catch each violation class ------
+
+describe('import-graph guard self-test (synthetic fixtures)', () => {
+  let fixRoot;
+  let result;
+
+  before(() => {
+    fixRoot = mkdtempSync(join(tmpdir(), 'wm-import-graph-guard-'));
+    const write = (rel, content) => {
+      const p = join(fixRoot, rel);
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, content);
+    };
+
+    write(
+      'scripts/entry.mjs',
+      [
+        "import './helper.mjs';",
+        "import 'node:fs';",
+        "// import './commented-out.mjs'",
+        "import { createRequire } from 'node:module';",
+        "const load = createRequire(import.meta.url)('./util.cjs');",
+        "const scorer = import('../srv/scorer.ts');",
+        '',
+      ].join('\n'),
+    );
+    write(
+      'scripts/helper.mjs',
+      [
+        'import {',
+        '  aThing,',
+        '  bThing,',
+        "} from './deep/multi.mjs';",
+        "import type { Phantom } from 'phantom-types-pkg';",
+        "import '@evil/bare-pkg';",
+        '',
+      ].join('\n'),
+    );
+    write('scripts/deep/multi.mjs', "import { esc } from '../../api/outside.js';\nexport const aThing = 1;\nexport const bThing = 2;\n");
+    write('scripts/util.cjs', "const p = require('node:path');\nconst bad = require('bad-npm-cjs');\nmodule.exports = { p, bad };\n");
+    write('srv/scorer.ts', "import gone from './gone';\nexport default gone;\n");
+    write('api/outside.js', 'export const esc = true;\n');
+
+    result = walkContainerGraph([join(fixRoot, 'scripts/entry.mjs')], {
+      repoRoot: fixRoot,
+      copyRootDirs: [join(fixRoot, 'scripts'), join(fixRoot, 'srv')],
+      dynamicRootDirs: [join(fixRoot, 'srv')],
+      installedPackages: new Set(),
+    });
+  });
+
+  after(() => {
+    rmSync(fixRoot, { recursive: true, force: true });
+  });
+
+  it('flags a bare npm static import (the #5229 class)', () => {
     assert.ok(
-      members.includes('validate-resilience-sensitivity.mjs'),
-      'Sensitivity-Suite member missing — the bundle definition or this regex drifted',
-    );
-    for (const member of members) {
-      assert.ok(isFile(join(scriptsDir, member)), `member script missing on disk: scripts/${member}`);
-    }
-  });
-
-  it('every relative import in the container-reachable graph resolves on disk', () => {
-    const { unresolved } = walkContainerGraph(members.map((m) => join(scriptsDir, m)));
-    assert.deepEqual(
-      unresolved,
-      [],
-      `unresolvable relative import(s) — these crash the cron with ERR_MODULE_NOT_FOUND:\n\n  ${unresolved.join('\n\n  ')}`,
+      result.violations.some((v) => v.includes("'@evil/bare-pkg' statically imported")),
+      `missing bare-import violation; got:\n${result.violations.join('\n')}`,
     );
   });
 
-  it('reaches no bare npm specifier absent from the container (node builtins only)', () => {
-    const { violations, visitedCount } = walkContainerGraph(members.map((m) => join(scriptsDir, m)));
-    assert.ok(visitedCount > 10, `graph walk looks broken — only ${visitedCount} modules visited`);
-    assert.deepEqual(
-      violations,
-      [],
-      `bare npm import(s) reachable from the resilience-validation container, which installs ONLY the tsx loader ` +
-        `(Dockerfile.seed-bundle-resilience-validation). ESM resolves these eagerly, so the cron crashes with ` +
-        `ERR_MODULE_NOT_FOUND even if the importing code never runs. Break the import chain (extract a ` +
-        `dependency-free module) or add the package to the container image:\n\n  ${violations.join('\n\n  ')}`,
+  it('flags a bare require() in an eagerly-loaded CJS closure', () => {
+    assert.ok(
+      result.violations.some((v) => v.includes("'bad-npm-cjs' require()d")),
+      `missing bare-require violation (createRequire edge not followed?); got:\n${result.violations.join('\n')}`,
+    );
+  });
+
+  it('flags a relative import that resolves outside the COPY roots', () => {
+    assert.ok(
+      result.violations.some((v) => v.includes('OUTSIDE the container COPY set') && v.includes('api')),
+      `missing COPY-set containment violation; got:\n${result.violations.join('\n')}`,
+    );
+  });
+
+  it('reports an unresolvable relative import (through the dynamic-follow root)', () => {
+    assert.ok(
+      result.unresolved.some((u) => u.includes("'./gone'")),
+      `missing unresolved entry (dynamic follow into srv/ broken?); got:\n${result.unresolved.join('\n')}`,
+    );
+  });
+
+  it('follows multi-line imports and skips comments and type-only imports', () => {
+    assert.ok(result.visited.has(join(fixRoot, 'scripts/deep/multi.mjs')), 'multi-line import edge not followed');
+    assert.ok(
+      !result.violations.some((v) => v.includes('phantom-types-pkg')),
+      'import type must not count as an edge',
+    );
+    assert.ok(
+      ![...result.visited].some((f) => f.includes('commented-out')),
+      'commented-out import must not be walked',
     );
   });
 });

--- a/tests/resilience-validation-import-graph.test.mjs
+++ b/tests/resilience-validation-import-graph.test.mjs
@@ -61,7 +61,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { walkContainerGraph } from './_lib/import-graph-walk.mjs';
+import { parseDockerfileCopy, walkContainerGraph } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -77,10 +77,11 @@ const root = resolve(__dirname, '..');
 // updates the guard automatically — and a drift makes the guard fail loudly
 // instead of silently passing on a contract the image no longer meets.
 function parseDockerfileContractSrc(src, label) {
-  const copyRoots = [];
-  for (const m of src.matchAll(/^COPY\s+([A-Za-z0-9._-]+)\/\s+\.\//gm)) {
-    copyRoots.push(m[1]);
-  }
+  // Directory-level COPY sources define the containment roots; file-level
+  // COPYs (tsconfigs) are not importable modules and are ignored here. The
+  // COPY grammar itself is parsed by the shared tests/_lib parser so all
+  // three container guards read Dockerfiles identically.
+  const copyRoots = [...parseDockerfileCopy(src).directories];
 
   const installedPackages = new Set();
   const installLines = [...src.matchAll(/^RUN\s+npm\s+install\b[^\n]*/gm)];
@@ -150,7 +151,9 @@ const CONTAINERS = [
     mustIncludeMember: 'seed-portwatch-port-activity.mjs',
     dynamicRoots: [],
     expectsTsx: false,
-    minVisited: 8,
+    // Margin of 0 over the actual count: this small graph has only 2 deep-node
+    // canaries, so a single silently-dropped node must already trip the floor.
+    minVisited: 9,
     deepNodes: ['scripts/_bundle-runner.mjs', 'scripts/_proxy-utils.cjs'],
   },
 ];
@@ -325,6 +328,8 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
       'scripts/entry.mjs',
       [
         "import './helper.mjs';",
+        "import './regex-hazards.mjs';",
+        "import './nested-cr.mjs';",
         "import 'node:fs';",
         "import 'ok-npm-pkg';",
         "// import './commented-out.mjs'",
@@ -352,6 +357,38 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
     write('scripts/util.cjs', "const p = require('node:path');\nconst bad = require('bad-npm-cjs');\nconst ok = require('@scope/ok-pkg/sub');\nmodule.exports = { p, bad, ok };\n");
     write('srv/scorer.ts', "import gone from './gone';\nexport default gone;\n");
     write('api/outside.js', 'export const esc = true;\n');
+    // Tokenizer hazards: a regex literal containing /* (or //) must not flip
+    // the stripper into comment state and swallow the edges after it — a
+    // swallowed BARE edge raises no violation and no canary, so only this
+    // fixture proves the case. Division and URL strings pin the flip side
+    // (a `/` in value position must NOT start a regex literal).
+    write(
+      'scripts/regex-hazards.mjs',
+      [
+        "import './entry-was-not-swallowed.mjs';",
+        'const classSlashStar = /[/*]/;',
+        'const escapedSlashes = /a\\/\\*b/;',
+        'const division = 4 / 2 + 8 / 4;',
+        "const url = 'https://example.com/x?a=1'; // trailing comment",
+        "import 'bare-after-regex-pkg';",
+        "import './after-regex.mjs';",
+        '',
+      ].join('\n'),
+    );
+    write('scripts/entry-was-not-swallowed.mjs', 'export const alive = 1;\n');
+    write('scripts/after-regex.mjs', 'export const reached = 1;\n');
+    // The common nested-parens createRequire idiom — the extraction regex must
+    // cross the inner call's parens to find the specifier.
+    write(
+      'scripts/nested-cr.mjs',
+      [
+        "import { createRequire } from 'node:module';",
+        "import { fileURLToPath } from 'node:url';",
+        "const load = createRequire(fileURLToPath(import.meta.url))('./nested-target.cjs');",
+        '',
+      ].join('\n'),
+    );
+    write('scripts/nested-target.cjs', "const bad = require('bad-nested-cjs-pkg');\nmodule.exports = { bad };\n");
 
     result = walkContainerGraph([join(fixRoot, 'scripts/entry.mjs')], {
       repoRoot: fixRoot,
@@ -425,6 +462,35 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
     assert.ok(
       ![...result.visited].some((f) => f.includes('commented-out')),
       'commented-out import must not be walked',
+    );
+  });
+
+  it('regex literals containing /* do not swallow the edges after them', () => {
+    // The dangerous variant: /[/*]/ used to flip the tokenizer into
+    // block-comment state and eat to EOF — dropping BOTH a bare edge (no
+    // violation, no canary) and a relative edge. Prove both survive.
+    assert.ok(
+      result.violations.some((v) => v.includes("'bare-after-regex-pkg' statically imported")),
+      `bare import after a /[/*]/ regex literal was swallowed:\n${result.violations.join('\n')}`,
+    );
+    assert.ok(
+      result.visited.has(join(fixRoot, 'scripts/after-regex.mjs')),
+      'relative import after a /[/*]/ regex literal was swallowed',
+    );
+    assert.ok(
+      result.visited.has(join(fixRoot, 'scripts/entry-was-not-swallowed.mjs')),
+      'edge BEFORE the regex hazards must be unaffected',
+    );
+  });
+
+  it('follows the nested-parens createRequire(fileURLToPath(...))(...) idiom', () => {
+    assert.ok(
+      result.visited.has(join(fixRoot, 'scripts/nested-target.cjs')),
+      'createRequire with a nested call argument was not followed',
+    );
+    assert.ok(
+      result.violations.some((v) => v.includes("'bad-nested-cjs-pkg' require()d")),
+      `bare require inside the nested-createRequire target was not enforced:\n${result.violations.join('\n')}`,
     );
   });
 });

--- a/tests/resilience-validation-import-graph.test.mjs
+++ b/tests/resilience-validation-import-graph.test.mjs
@@ -1,0 +1,208 @@
+// #5231 — static guard for the seed-bundle-resilience-validation container's
+// dependency contract.
+//
+// Dockerfile.seed-bundle-resilience-validation installs EXACTLY ONE npm
+// package: tsx (as the ESM loader — never imported by code). Everything the
+// bundle's member scripts reach — scripts/ helpers, and the ../server/*.ts
+// modules they dynamic-import through the tsx loader — must therefore resolve
+// using node: builtins and repo files only. ESM resolves a module's full
+// static import closure eagerly, so ONE bare npm specifier anywhere in that
+// closure crashes the cron with ERR_MODULE_NOT_FOUND even if the importing
+// code path never runs.
+//
+// That is exactly how #5229 broke this bundle: server/_shared/usage.ts (deep
+// in the closure via redis.ts) gained a static import of ./rate-limit, whose
+// own static imports pull @upstash/ratelimit — declared only in the ROOT
+// package.json, absent from the container. The seeder never calls the rate
+// limiter; it crashed anyway, at resolution time.
+//
+// Scope notes (kept deliberately aligned with the crash mechanics):
+//  - Static `import`/`export ... from` edges are followed and enforced.
+//  - `import type` / `export type` edges are skipped (tsx erases them).
+//  - Dynamic import() literals are followed only when they resolve into
+//    server/ — the bundle members execute those unconditionally (loading the
+//    scorers IS their job). Other dynamic imports and require() calls of bare
+//    specifiers are conditional/lazy and cannot be classified statically, so
+//    they are not enforced here.
+//  - Relative require() literals in .cjs/.mjs helpers are followed so their
+//    static closures stay covered (e.g. _seed-utils.mjs eagerly
+//    createRequire()s _proxy-utils.cjs).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { dirname, join, resolve, relative, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isBuiltin } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const scriptsDir = join(root, 'scripts');
+const serverDir = join(root, 'server');
+
+// Bare npm specifiers installed in the container image. Keep in lockstep with
+// the `npm install` line in Dockerfile.seed-bundle-resilience-validation.
+// tsx is intentionally NOT listed: it is the loader, and code importing tsx
+// directly would be a smell this guard should surface.
+const CONTAINER_INSTALLED_PACKAGES = new Set([]);
+
+function isFile(p) {
+  return existsSync(p) && statSync(p).isFile();
+}
+
+// Resolve a relative specifier the way node+tsx would inside the container.
+function resolveRelative(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.mts`,
+    `${base}.js`,
+    `${base}.mjs`,
+    `${base}.cjs`,
+    join(base, 'index.ts'),
+    join(base, 'index.js'),
+    join(base, 'index.mjs'),
+  ];
+  // TS-style: an explicit .js specifier may map to a .ts source.
+  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
+  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
+  return candidates.find(isFile) ?? null;
+}
+
+// Extract import edges from one source file. Anchored to line starts so
+// commented-out imports don't count.
+function extractEdges(src) {
+  const staticSpecs = [];
+  const dynamicSpecs = [];
+  const requireSpecs = [];
+
+  // import ... from '...' (multi-line safe; skips `import type`)
+  for (const m of src.matchAll(/^[ \t]*import\s+(?!type\s)[^'";]*?\bfrom\s*['"]([^'"]+)['"]/gms)) {
+    staticSpecs.push(m[1]);
+  }
+  // side-effect: import '...'
+  for (const m of src.matchAll(/^[ \t]*import\s*['"]([^'"]+)['"]/gm)) {
+    staticSpecs.push(m[1]);
+  }
+  // export { ... } from '...' / export * from '...' (skips `export type`)
+  for (const m of src.matchAll(/^[ \t]*export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gms)) {
+    staticSpecs.push(m[1]);
+  }
+  // dynamic import('...') literals
+  for (const m of src.matchAll(/\bimport\(\s*['"]([^'"]+)['"]/g)) {
+    dynamicSpecs.push(m[1]);
+  }
+  // require('...') literals (createRequire in .mjs, plain require in .cjs)
+  for (const m of src.matchAll(/\brequire\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+    requireSpecs.push(m[1]);
+  }
+  return { staticSpecs, dynamicSpecs, requireSpecs };
+}
+
+function isBare(spec) {
+  return !spec.startsWith('.') && !spec.startsWith('/');
+}
+
+// Walk the container-reachable graph from the bundle's member scripts.
+// Returns bare-specifier violations and unresolvable relative imports, each
+// with the import chain from a member script for debuggability.
+function walkContainerGraph(memberFiles) {
+  const parent = new Map(); // file -> importing file
+  const visited = new Set();
+  const queue = [...memberFiles];
+  const violations = [];
+  const unresolved = [];
+
+  const chainOf = (file) => {
+    const chain = [];
+    for (let f = file; f; f = parent.get(f)) chain.unshift(relative(root, f));
+    return chain.join('\n    -> ');
+  };
+
+  while (queue.length > 0) {
+    const file = queue.shift();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    if (extname(file) === '.json') continue; // data, no imports
+
+    const src = readFileSync(file, 'utf-8');
+    const { staticSpecs, dynamicSpecs, requireSpecs } = extractEdges(src);
+
+    const followRelative = (spec) => {
+      const resolved = resolveRelative(file, spec);
+      if (!resolved) {
+        unresolved.push(`'${spec}' imported from\n    ${chainOf(file)}`);
+        return;
+      }
+      if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
+      queue.push(resolved);
+    };
+
+    for (const spec of staticSpecs) {
+      if (isBare(spec)) {
+        if (!isBuiltin(spec) && !CONTAINER_INSTALLED_PACKAGES.has(spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/'))) {
+          violations.push(`'${spec}' statically imported via\n    ${chainOf(file)}`);
+        }
+        continue;
+      }
+      followRelative(spec);
+    }
+
+    for (const spec of dynamicSpecs) {
+      if (isBare(spec)) continue; // lazy; cannot classify statically
+      const resolved = resolveRelative(file, spec);
+      // Follow only dynamic imports into server/ — the members execute those
+      // unconditionally (that is the bundle's purpose).
+      if (resolved && resolved.startsWith(serverDir)) {
+        if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
+        queue.push(resolved);
+      }
+    }
+
+    for (const spec of requireSpecs) {
+      if (isBare(spec)) continue; // lazy/conditional; cannot classify statically
+      followRelative(spec);
+    }
+  }
+
+  return { violations, unresolved, visitedCount: visited.size };
+}
+
+describe('seed-bundle-resilience-validation container import graph (#5231)', () => {
+  const bundleSrc = readFileSync(join(scriptsDir, 'seed-bundle-resilience-validation.mjs'), 'utf-8');
+  const members = [...bundleSrc.matchAll(/script:\s*'([^']+)'/g)].map((m) => m[1]);
+
+  it('discovers the bundle member scripts', () => {
+    assert.ok(members.length >= 3, `expected >=3 member scripts, found ${members.length}`);
+    assert.ok(
+      members.includes('validate-resilience-sensitivity.mjs'),
+      'Sensitivity-Suite member missing — the bundle definition or this regex drifted',
+    );
+    for (const member of members) {
+      assert.ok(isFile(join(scriptsDir, member)), `member script missing on disk: scripts/${member}`);
+    }
+  });
+
+  it('every relative import in the container-reachable graph resolves on disk', () => {
+    const { unresolved } = walkContainerGraph(members.map((m) => join(scriptsDir, m)));
+    assert.deepEqual(
+      unresolved,
+      [],
+      `unresolvable relative import(s) — these crash the cron with ERR_MODULE_NOT_FOUND:\n\n  ${unresolved.join('\n\n  ')}`,
+    );
+  });
+
+  it('reaches no bare npm specifier absent from the container (node builtins only)', () => {
+    const { violations, visitedCount } = walkContainerGraph(members.map((m) => join(scriptsDir, m)));
+    assert.ok(visitedCount > 10, `graph walk looks broken — only ${visitedCount} modules visited`);
+    assert.deepEqual(
+      violations,
+      [],
+      `bare npm import(s) reachable from the resilience-validation container, which installs ONLY the tsx loader ` +
+        `(Dockerfile.seed-bundle-resilience-validation). ESM resolves these eagerly, so the cron crashes with ` +
+        `ERR_MODULE_NOT_FOUND even if the importing code never runs. Break the import chain (extract a ` +
+        `dependency-free module) or add the package to the container image:\n\n  ${violations.join('\n\n  ')}`,
+    );
+  });
+});

--- a/tests/resilience-validation-import-graph.test.mjs
+++ b/tests/resilience-validation-import-graph.test.mjs
@@ -16,18 +16,27 @@
 // declared only in the ROOT package.json, absent from the container. The
 // seeder never calls the rate limiter; it crashed anyway, at resolution time.
 //
-// The guard enforces three container invariants, per container, with the
-// COPY roots and installed-package set DERIVED from each Dockerfile (so the
-// test cannot drift from the image contract):
-//   1. every relative import in the reachable graph resolves on disk;
+// The guard enforces four container invariants, per container, with the
+// COPY roots, installed-package set, tsx-loader presence, and CMD entry all
+// DERIVED from each Dockerfile (so the test cannot drift from the image
+// contract — including the entry point it walks and the resolution model
+// it simulates):
+//   1. every relative import in the reachable graph resolves on disk —
+//      under the container's OWN resolution model (a no-tsx container gets
+//      plain-node rules: no extension guessing, no TypeScript);
 //   2. every resolved file lives inside the container's COPY roots (a module
 //      that resolves in the repo but is never COPY'd — e.g. api/ — is the
 //      same production crash);
 //   3. every bare specifier (static import OR require) is a node builtin or
-//      an installed package.
+//      an installed package;
+//   4. the Dockerfile CMD entry equals the bundle script this guard walks —
+//      an entry swap that left the old file on disk would otherwise keep the
+//      guard green while the deployed cron loads an unwalked graph.
 //
 // Scope notes (kept deliberately aligned with the crash mechanics):
-//  - `import type` / `export type` edges are skipped (tsx erases them).
+//  - `import type` / `export type` edges are skipped, including the inline
+//    all-type form `import { type X } from '...'` (tsx erases both). A mixed
+//    clause (`{ type X, real }`) is still a runtime edge.
 //  - Comments are stripped (structure-preserving tokenizer) before edge
 //    extraction, so commented-out imports and JSDoc `@typedef {import(...)}`
 //    text are not edges, while string/template contents are preserved.
@@ -39,32 +48,35 @@
 //    _seed-utils.mjs eagerly createRequire()s _proxy-utils.cjs at module top
 //    level, so that CJS closure loads at seeder startup.
 //
-// The final describe block is a self-test: it builds a synthetic module tree
-// in a tmpdir with one planted violation of each class and asserts the
-// walker still catches them — so a regex/walker regression fails loudly
-// instead of silently blinding the guard.
+// The shared tokenizer/extraction/walk machinery lives in
+// tests/_lib/import-graph-walk.mjs (also consumed by the relay and
+// digest-notifications Dockerfile guards). The self-test describe blocks
+// below exercise that shared machinery with one planted violation of each
+// class — so a regex/walker regression fails loudly instead of silently
+// blinding all three guards.
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { isBuiltin } from 'node:module';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { walkContainerGraph } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
 // --- Dockerfile contract derivation ----------------------------------------
 
-// Directory-level COPY sources (`COPY <dir>/ ./<dir>/`) define where imports
-// may resolve; the `npm install` RUN line defines the bare-specifier budget.
-// Deriving both here means adding a package to the image or a new COPY root
-// updates the guard automatically — and removing one makes the guard fail
-// loudly instead of silently passing on a contract the image no longer meets.
-function parseDockerfileContract(dockerfileName) {
-  const src = readFileSync(join(root, dockerfileName), 'utf-8');
-
+// The Dockerfile is the single source of truth for the container contract:
+// directory-level COPY sources (`COPY <dir>/ ./<dir>/`) define where imports
+// may resolve; the `npm install` RUN line defines the bare-specifier budget;
+// the tsx loader's presence (install line or NODE_OPTIONS --import) defines
+// the resolution model; and the CMD line defines the entry whose graph the
+// container actually loads. Deriving all four here means an image change
+// updates the guard automatically — and a drift makes the guard fail loudly
+// instead of silently passing on a contract the image no longer meets.
+function parseDockerfileContractSrc(src, label) {
   const copyRoots = [];
   for (const m of src.matchAll(/^COPY\s+([A-Za-z0-9._-]+)\/\s+\.\//gm)) {
     copyRoots.push(m[1]);
@@ -73,208 +85,37 @@ function parseDockerfileContract(dockerfileName) {
   const installedPackages = new Set();
   const installLines = [...src.matchAll(/^RUN\s+npm\s+install\b[^\n]*/gm)];
   for (const [line] of installLines) {
-    for (const m of line.matchAll(/\s((?:@[a-z0-9._-]+\/)?[a-z0-9._-]+)@[\d^~]/g)) {
+    // pkg@1.2.3 / pkg@^1.2 / pkg@~1.2 / @scope/pkg@... / pkg@latest / pkg@next
+    for (const m of line.matchAll(/\s((?:@[a-z0-9._-]+\/)?[a-z0-9._-]+)@(?=[\d^~]|latest\b|next\b)/g)) {
       installedPackages.add(m[1]);
     }
   }
   if (installLines.length > 0) {
     assert.ok(
       installedPackages.size > 0,
-      `${dockerfileName} has an npm install line but no parseable package@version tokens — update the parser with the Dockerfile refactor`,
+      `${label} has an npm install line but no parseable package@version tokens — update the parser with the Dockerfile refactor`,
     );
   }
+
+  // tsx presence decides the resolution model the container runs under —
+  // either an installed tsx package or a NODE_OPTIONS --import of its loader.
+  const hasTsx = installedPackages.has('tsx') || /^ENV\s+NODE_OPTIONS="[^"]*tsx[^"]*"/m.test(src);
   // tsx is the ESM loader, wired via NODE_OPTIONS — code importing tsx
   // directly would be a smell this guard should surface, so it does not
   // count toward the bare-specifier budget.
   installedPackages.delete('tsx');
 
-  return { copyRoots, installedPackages };
+  // CMD ["node", "scripts/<entry>"] — the entry decides which graph the
+  // container loads first; buildContract asserts it matches the walked
+  // bundle script.
+  const cmd = src.match(/^CMD\s+\[\s*"node"\s*,\s*"([^"]+)"\s*\]/m);
+  const entryScript = cmd ? cmd[1] : null;
+
+  return { copyRoots, installedPackages, hasTsx, entryScript };
 }
 
-// --- Source preparation and edge extraction ---------------------------------
-
-// Structure-preserving comment strip. A state machine, not regexes: naive
-// regex stripping misreads `/*` inside comment text or strings (a comment
-// mentioning `@upstash/*` swallowed everything to the next `*/`, silently
-// deleting real imports from extraction) and misreads `//` inside string
-// literals. Comments are removed exactly; string/template contents and line
-// structure are preserved. Known limit: a bare `//` inside a regex literal's
-// character class would be misread — no such shape exists in the walked
-// graphs, and the deep-node canaries below backstop it.
-function stripComments(src) {
-  let out = '';
-  let state = 'code'; // code | line | block | squote | dquote | template
-  let i = 0;
-  while (i < src.length) {
-    const c = src[i];
-    const n = src[i + 1];
-    if (state === 'code') {
-      if (c === '/' && n === '/') { state = 'line'; i += 2; continue; }
-      if (c === '/' && n === '*') { state = 'block'; i += 2; continue; }
-      if (c === "'") state = 'squote';
-      else if (c === '"') state = 'dquote';
-      else if (c === '`') state = 'template';
-      out += c; i += 1; continue;
-    }
-    if (state === 'line') {
-      if (c === '\n') { state = 'code'; out += c; }
-      i += 1; continue;
-    }
-    if (state === 'block') {
-      if (c === '*' && n === '/') { state = 'code'; i += 2; continue; }
-      if (c === '\n') out += c;
-      i += 1; continue;
-    }
-    // Inside a string or template literal: pass through, honor escapes.
-    if (c === '\\') { out += c + (n ?? ''); i += 2; continue; }
-    if ((state === 'squote' && c === "'") || (state === 'dquote' && c === '"') || (state === 'template' && c === '`')) {
-      state = 'code';
-    }
-    out += c; i += 1;
-  }
-  return out;
-}
-
-// Extract import edges from one source file (comments already stripped).
-function extractEdges(src) {
-  const staticSpecs = [];
-  const dynamicSpecs = [];
-  const requireSpecs = [];
-
-  // import ... from '...' (multi-line safe; skips `import type`)
-  for (const m of src.matchAll(/^[ \t]*import\s+(?!type\s)[^'";]*?\bfrom\s*['"]([^'"]+)['"]/gms)) {
-    staticSpecs.push(m[1]);
-  }
-  // side-effect: import '...'
-  for (const m of src.matchAll(/^[ \t]*import\s*['"]([^'"]+)['"]/gm)) {
-    staticSpecs.push(m[1]);
-  }
-  // export { ... } from '...' / export * from '...' (skips `export type`)
-  for (const m of src.matchAll(/^[ \t]*export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gms)) {
-    staticSpecs.push(m[1]);
-  }
-  // dynamic import('...') literals
-  for (const m of src.matchAll(/\bimport\(\s*['"]([^'"]+)['"]/g)) {
-    dynamicSpecs.push(m[1]);
-  }
-  // require('...') literals (plain require in .cjs, or a createRequire-bound
-  // local named require)
-  for (const m of src.matchAll(/\brequire\(\s*['"]([^'"]+)['"]\s*\)/g)) {
-    requireSpecs.push(m[1]);
-  }
-  // createRequire(import.meta.url)('...') — immediately-invoked form; the
-  // plain require regex cannot see it (no lowercase `require(` substring)
-  for (const m of src.matchAll(/\bcreateRequire\([^)]*\)\(\s*['"]([^'"]+)['"]\s*\)/g)) {
-    requireSpecs.push(m[1]);
-  }
-  return { staticSpecs, dynamicSpecs, requireSpecs };
-}
-
-function isBare(spec) {
-  return !spec.startsWith('.') && !spec.startsWith('/');
-}
-
-// Resolve a relative specifier the way node+tsx would inside the container.
-function resolveRelative(fromFile, spec) {
-  const base = resolve(dirname(fromFile), spec);
-  const candidates = [
-    base,
-    `${base}.ts`,
-    `${base}.mts`,
-    `${base}.js`,
-    `${base}.mjs`,
-    `${base}.cjs`,
-    join(base, 'index.ts'),
-    join(base, 'index.js'),
-    join(base, 'index.mjs'),
-  ];
-  // TS-style: an explicit .js specifier may map to a .ts source.
-  if (spec.endsWith('.js')) candidates.push(base.replace(/\.js$/, '.ts'));
-  if (spec.endsWith('.mjs')) candidates.push(base.replace(/\.mjs$/, '.mts'));
-  return candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? null;
-}
-
-// --- The walk ----------------------------------------------------------------
-
-// Walk the container-reachable graph from `rootFiles` under `contract`:
-//   contract.repoRoot        — absolute path imports may not escape reporting-wise
-//   contract.copyRootDirs    — absolute dirs the image COPYs (containment set)
-//   contract.dynamicRootDirs — absolute dirs dynamic import() literals are
-//                              followed into (executed-unconditionally set)
-//   contract.installedPackages — bare-specifier budget beyond node builtins
-// Returns violations/unresolved (each with the import chain from a root) and
-// the visited set for reachability assertions.
-function walkContainerGraph(rootFiles, contract) {
-  const parent = new Map();
-  const visited = new Set();
-  const queue = [...rootFiles];
-  const violations = [];
-  const unresolved = [];
-
-  const chainOf = (file) => {
-    const chain = [];
-    for (let f = file; f; f = parent.get(f)) chain.unshift(relative(contract.repoRoot, f));
-    return chain.join('\n    -> ');
-  };
-
-  const inside = (dirs, p) => dirs.some((d) => p.startsWith(d + sep));
-
-  const followRelative = (file, spec) => {
-    const resolved = resolveRelative(file, spec);
-    if (!resolved) {
-      unresolved.push(`'${spec}' imported from\n    ${chainOf(file)}`);
-      return;
-    }
-    if (!inside(contract.copyRootDirs, resolved)) {
-      violations.push(
-        `'${spec}' resolves in the repo but OUTSIDE the container COPY set (${relative(contract.repoRoot, resolved)}) via\n    ${chainOf(file)}`,
-      );
-      return;
-    }
-    if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
-    queue.push(resolved);
-  };
-
-  const checkBare = (file, spec, how) => {
-    const pkg = spec.split('/').slice(0, spec.startsWith('@') ? 2 : 1).join('/');
-    if (!isBuiltin(spec) && !contract.installedPackages.has(pkg)) {
-      violations.push(`'${spec}' ${how} via\n    ${chainOf(file)}`);
-    }
-  };
-
-  while (queue.length > 0) {
-    const file = queue.shift();
-    if (visited.has(file)) continue;
-    visited.add(file);
-    if (extname(file) === '.json') continue; // data, no imports
-
-    const src = stripComments(readFileSync(file, 'utf-8'));
-    const { staticSpecs, dynamicSpecs, requireSpecs } = extractEdges(src);
-
-    for (const spec of staticSpecs) {
-      if (isBare(spec)) checkBare(file, spec, 'statically imported');
-      else followRelative(file, spec);
-    }
-    for (const spec of requireSpecs) {
-      // A top-level require in a walked file loads eagerly at startup (e.g.
-      // _seed-utils.mjs createRequire()s _proxy-utils.cjs at module scope),
-      // so bare requires get the same budget check as static imports. The
-      // walked graph is require-clean today; if a genuinely-lazy bare
-      // require ever appears, exempt that one site explicitly.
-      if (isBare(spec)) checkBare(file, spec, 'require()d');
-      else followRelative(file, spec);
-    }
-    for (const spec of dynamicSpecs) {
-      if (isBare(spec)) continue; // lazy; cannot classify statically
-      const resolved = resolveRelative(file, spec);
-      if (resolved && inside(contract.dynamicRootDirs, resolved)) {
-        if (!visited.has(resolved) && !parent.has(resolved)) parent.set(resolved, file);
-        queue.push(resolved);
-      }
-    }
-  }
-
-  return { violations, unresolved, visited };
+function parseDockerfileContract(dockerfileName) {
+  return parseDockerfileContractSrc(readFileSync(join(root, dockerfileName), 'utf-8'), dockerfileName);
 }
 
 // --- Container contracts under guard ----------------------------------------
@@ -291,6 +132,7 @@ const CONTAINERS = [
     minMembers: 3,
     mustIncludeMember: 'validate-resilience-sensitivity.mjs',
     dynamicRoots: ['server'],
+    expectsTsx: true,
     minVisited: 32,
     deepNodes: [
       'scripts/_bundle-runner.mjs',
@@ -307,6 +149,7 @@ const CONTAINERS = [
     minMembers: 1,
     mustIncludeMember: 'seed-portwatch-port-activity.mjs',
     dynamicRoots: [],
+    expectsTsx: false,
     minVisited: 8,
     deepNodes: ['scripts/_bundle-runner.mjs', 'scripts/_proxy-utils.cjs'],
   },
@@ -315,22 +158,48 @@ const CONTAINERS = [
 const scriptsDir = join(root, 'scripts');
 
 function buildContract(container) {
-  const { copyRoots, installedPackages } = parseDockerfileContract(container.dockerfile);
+  const { copyRoots, installedPackages, hasTsx, entryScript } = parseDockerfileContract(container.dockerfile);
   assert.ok(
     copyRoots.includes('scripts'),
-    `${container.dockerfile}: no 'COPY scripts/ ...' line parsed — Dockerfile format changed; update parseDockerfileContract`,
+    `${container.dockerfile}: no 'COPY scripts/ ...' line parsed — Dockerfile format changed; update parseDockerfileContractSrc`,
+  );
+  // The CMD entry decides what the deployed container actually loads. If it
+  // ever diverges from the bundle script this guard walks, the guard would
+  // stay green (the stale file still exists on disk) while the cron loads a
+  // completely unwalked graph — so the divergence itself must fail loudly.
+  assert.ok(
+    entryScript,
+    `${container.dockerfile}: no parseable CMD ["node", "<script>"] line — Dockerfile format changed; update parseDockerfileContractSrc`,
+  );
+  assert.equal(
+    entryScript,
+    `scripts/${container.bundleScript}`,
+    `${container.dockerfile} CMD entry (${entryScript}) != the guard's walk root (scripts/${container.bundleScript}) — ` +
+      `update bundleScript alongside the CMD change so the guard walks what the container runs`,
+  );
+  // The resolution model must match the runtime: a no-tsx container cannot
+  // load .ts or extensionless specifiers that tsx would resolve.
+  assert.equal(
+    hasTsx,
+    container.expectsTsx,
+    `${container.dockerfile}: tsx-loader detection (${hasTsx}) != expected (${container.expectsTsx}) — ` +
+      `if the image's loader setup changed, update expectsTsx so the guard simulates the right resolution model`,
   );
   return {
     repoRoot: root,
     copyRootDirs: copyRoots.map((d) => join(root, d)),
     dynamicRootDirs: container.dynamicRoots.map((d) => join(root, d)),
     installedPackages,
+    hasTsx,
   };
 }
 
 function walkRootsFor(container) {
   const bundleSrc = readFileSync(join(scriptsDir, container.bundleScript), 'utf-8');
-  const members = [...bundleSrc.matchAll(/script:\s*'([^']+)'/g)].map((m) => m[1]);
+  // Quote-agnostic: a member added with double quotes or a template literal
+  // must not silently escape the walk (minMembers is only a floor, so an
+  // unmatched ADDED member would otherwise pass the count assertion unwalked).
+  const members = [...bundleSrc.matchAll(/script:\s*(["'`])([^"'`]+)\1/g)].map((m) => m[2]);
   assert.ok(
     members.length >= container.minMembers,
     `${container.bundleScript}: expected >=${container.minMembers} member scripts, found ${members.length} — bundle definition or the member regex drifted`,
@@ -366,7 +235,7 @@ for (const container of CONTAINERS) {
         violations,
         [],
         `import(s) reachable from ${container.name} that its container cannot resolve ` +
-          `(${container.dockerfile} defines the COPY roots and the installed-package budget). ESM resolves ` +
+          `(${container.dockerfile} defines the COPY roots, the installed-package budget, and the loader). ESM resolves ` +
           `these eagerly, so the cron crashes with ERR_MODULE_NOT_FOUND even if the importing code never ` +
           `runs. Break the import chain (extract a dependency-free module) or change the container image:\n\n  ${violations.join('\n\n  ')}`,
       );
@@ -388,6 +257,56 @@ for (const container of CONTAINERS) {
   });
 }
 
+// --- Dockerfile contract parser self-test (synthetic Dockerfile text) --------
+
+describe('parseDockerfileContractSrc self-test (synthetic Dockerfiles)', () => {
+  const SYNTH_TSX_INSTALL = [
+    'FROM node:24-alpine@sha256:abc',
+    'WORKDIR /app',
+    'RUN npm install --prefix /app --no-save @org/pkg@1.2.3 lodash@^4.17.0 semver@~7.5.0 leftpad@latest tsx@4.21.0',
+    'COPY scripts/ ./scripts/',
+    'COPY shared/ ./shared/',
+    'COPY tsconfig.json ./',
+    'ENV NODE_OPTIONS="--max-old-space-size=1024"',
+    'CMD ["node", "scripts/my-entry.mjs"]',
+  ].join('\n');
+
+  it('extracts a populated installed-package budget (scoped, caret, tilde, latest; tsx excluded)', () => {
+    const { installedPackages } = parseDockerfileContractSrc(SYNTH_TSX_INSTALL, 'synthetic');
+    assert.deepEqual(
+      [...installedPackages].sort(),
+      ['@org/pkg', 'leftpad', 'lodash', 'semver'],
+      'install-line extraction must handle scoped packages, range prefixes, and dist-tags on one RUN line',
+    );
+  });
+
+  it('derives COPY roots, CMD entry, and tsx presence from an install line', () => {
+    const { copyRoots, entryScript, hasTsx } = parseDockerfileContractSrc(SYNTH_TSX_INSTALL, 'synthetic');
+    assert.deepEqual(copyRoots, ['scripts', 'shared'], 'dir-level COPY roots only (file COPYs excluded)');
+    assert.equal(entryScript, 'scripts/my-entry.mjs');
+    assert.equal(hasTsx, true, 'tsx@ on the install line must mark the container tsx-shaped');
+  });
+
+  it('detects tsx via NODE_OPTIONS --import when nothing is npm-installed', () => {
+    const viaNodeOptions = parseDockerfileContractSrc(
+      'ENV NODE_OPTIONS="--max-old-space-size=8192 --import=file:///app/node_modules/tsx/dist/loader.mjs"\nCOPY scripts/ ./scripts/\nCMD ["node", "scripts/e.mjs"]',
+      'synthetic',
+    );
+    assert.equal(viaNodeOptions.hasTsx, true);
+    const plain = parseDockerfileContractSrc(
+      'ENV NODE_OPTIONS="--max-old-space-size=1024 --dns-result-order=ipv4first"\nCOPY scripts/ ./scripts/\nCMD ["node", "scripts/e.mjs"]',
+      'synthetic',
+    );
+    assert.equal(plain.hasTsx, false, 'no install line and no tsx in NODE_OPTIONS = plain node');
+    assert.equal(plain.entryScript, 'scripts/e.mjs');
+  });
+
+  it('reports a missing/unparseable CMD as null so buildContract fails loudly', () => {
+    const { entryScript } = parseDockerfileContractSrc('COPY scripts/ ./scripts/\n', 'synthetic');
+    assert.equal(entryScript, null);
+  });
+});
+
 // --- Guard self-test: the walker must still catch each violation class ------
 
 describe('import-graph guard self-test (synthetic fixtures)', () => {
@@ -407,6 +326,7 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
       [
         "import './helper.mjs';",
         "import 'node:fs';",
+        "import 'ok-npm-pkg';",
         "// import './commented-out.mjs'",
         "import { createRequire } from 'node:module';",
         "const load = createRequire(import.meta.url)('./util.cjs');",
@@ -422,12 +342,14 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
         '  bThing,',
         "} from './deep/multi.mjs';",
         "import type { Phantom } from 'phantom-types-pkg';",
+        "import { type PhantomInline } from 'phantom-inline-pkg';",
+        "import { type MixedT, mixedReal } from 'mixed-type-pkg';",
         "import '@evil/bare-pkg';",
         '',
       ].join('\n'),
     );
     write('scripts/deep/multi.mjs', "import { esc } from '../../api/outside.js';\nexport const aThing = 1;\nexport const bThing = 2;\n");
-    write('scripts/util.cjs', "const p = require('node:path');\nconst bad = require('bad-npm-cjs');\nmodule.exports = { p, bad };\n");
+    write('scripts/util.cjs', "const p = require('node:path');\nconst bad = require('bad-npm-cjs');\nconst ok = require('@scope/ok-pkg/sub');\nmodule.exports = { p, bad, ok };\n");
     write('srv/scorer.ts', "import gone from './gone';\nexport default gone;\n");
     write('api/outside.js', 'export const esc = true;\n');
 
@@ -435,7 +357,8 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
       repoRoot: fixRoot,
       copyRootDirs: [join(fixRoot, 'scripts'), join(fixRoot, 'srv')],
       dynamicRootDirs: [join(fixRoot, 'srv')],
-      installedPackages: new Set(),
+      installedPackages: new Set(['ok-npm-pkg', '@scope/ok-pkg']),
+      hasTsx: true,
     });
   });
 
@@ -457,6 +380,20 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
     );
   });
 
+  it('allows installed packages through the budget (import AND scoped subpath require)', () => {
+    // The allow-path: a package the Dockerfile installs must NOT be flagged.
+    // Guards the extraction-to-budget wiring that the always-empty production
+    // set never exercises (both real containers install only tsx today).
+    assert.ok(
+      !result.violations.some((v) => v.includes('ok-npm-pkg')),
+      `installed package 'ok-npm-pkg' wrongly flagged:\n${result.violations.join('\n')}`,
+    );
+    assert.ok(
+      !result.violations.some((v) => v.includes('@scope/ok-pkg')),
+      `installed scoped package '@scope/ok-pkg' (required via subpath) wrongly flagged:\n${result.violations.join('\n')}`,
+    );
+  });
+
   it('flags a relative import that resolves outside the COPY roots', () => {
     assert.ok(
       result.violations.some((v) => v.includes('OUTSIDE the container COPY set') && v.includes('api')),
@@ -471,15 +408,83 @@ describe('import-graph guard self-test (synthetic fixtures)', () => {
     );
   });
 
-  it('follows multi-line imports and skips comments and type-only imports', () => {
+  it('follows multi-line imports and skips comments and type-only imports (leading and inline)', () => {
     assert.ok(result.visited.has(join(fixRoot, 'scripts/deep/multi.mjs')), 'multi-line import edge not followed');
     assert.ok(
       !result.violations.some((v) => v.includes('phantom-types-pkg')),
       'import type must not count as an edge',
     );
     assert.ok(
+      !result.violations.some((v) => v.includes('phantom-inline-pkg')),
+      'inline all-type clause (import { type X }) must not count as an edge — tsx erases it',
+    );
+    assert.ok(
+      result.violations.some((v) => v.includes("'mixed-type-pkg' statically imported")),
+      `a mixed clause (import { type T, real }) IS a runtime edge and must be flagged; got:\n${result.violations.join('\n')}`,
+    );
+    assert.ok(
       ![...result.visited].some((f) => f.includes('commented-out')),
       'commented-out import must not be walked',
     );
+  });
+});
+
+// --- Plain-node (no-tsx) resolution self-test --------------------------------
+
+describe('plain-node container resolution self-test (hasTsx: false)', () => {
+  let fixRoot;
+  let plain;
+  let withTsx;
+
+  before(() => {
+    fixRoot = mkdtempSync(join(tmpdir(), 'wm-import-graph-plainnode-'));
+    const write = (rel, content) => {
+      const p = join(fixRoot, rel);
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, content);
+    };
+
+    write(
+      'scripts/entry.mjs',
+      ["import './plain-ok.mjs';", "import './no-ext';", "import './typed.ts';", ''].join('\n'),
+    );
+    write('scripts/plain-ok.mjs', 'export const ok = 1;\n');
+    write('scripts/no-ext.mjs', 'export const x = 1;\n'); // exists only WITH extension
+    write('scripts/typed.ts', 'export const t = 1;\n');
+
+    const contract = (hasTsx) => ({
+      repoRoot: fixRoot,
+      copyRootDirs: [join(fixRoot, 'scripts')],
+      dynamicRootDirs: [],
+      installedPackages: new Set(),
+      hasTsx,
+    });
+    plain = walkContainerGraph([join(fixRoot, 'scripts/entry.mjs')], contract(false));
+    withTsx = walkContainerGraph([join(fixRoot, 'scripts/entry.mjs')], contract(true));
+  });
+
+  after(() => {
+    rmSync(fixRoot, { recursive: true, force: true });
+  });
+
+  it('flags extensionless and .ts edges a plain-node container cannot load', () => {
+    // The green-while-red hole this closes: these edges work under tsx in
+    // every other repo context (and in the resilience-validation container),
+    // so only a per-container resolution model catches them before the
+    // portwatch cron crashes at import time.
+    assert.ok(
+      plain.violations.some((v) => v.includes("'./no-ext'") && v.includes('plain node')),
+      `missing plain-node violation for extensionless specifier; got:\n${plain.violations.join('\n')}`,
+    );
+    assert.ok(
+      plain.violations.some((v) => v.includes("'./typed.ts'") && v.includes('plain node')),
+      `missing plain-node violation for .ts specifier; got:\n${plain.violations.join('\n')}`,
+    );
+  });
+
+  it('still walks literal loadable specifiers, and the same edges pass under tsx', () => {
+    assert.ok(plain.visited.has(join(fixRoot, 'scripts/plain-ok.mjs')), 'literal .mjs edge must still be walked');
+    assert.deepEqual(withTsx.violations, [], 'the identical graph must be violation-free under a tsx-shaped contract');
+    assert.deepEqual(plain.unresolved, [], 'plain-node misfits are violations (with chains), not unresolved entries');
   });
 });


### PR DESCRIPTION
Fixes #5231.

## What

`seed-bundle-resilience-validation` went red last night: its Sensitivity-Suite member crashed with `Cannot find module '@upstash/ratelimit'`. PR #5229 added `server/_shared/usage.ts -> ./rate-limit`, and `rate-limit.ts` top-level-imports `@upstash/ratelimit` + `@upstash/redis` — packages that exist only in the root `package.json`. `usage.ts` sits under `redis.ts` in the static ESM closure the seeder loads through the tsx loader, and that container installs **no npm packages beyond tsx** (`Dockerfile.seed-bundle-resilience-validation`), so module resolution failed eagerly — the seeder never even calls the rate limiter.

## How

- **`server/_shared/client-ip.ts` (new):** `getClientIp`, `hasCloudflareTransitProof`, `UNKNOWN_CLIENT_IP` moved verbatim from `rate-limit.ts` (incl. private `constantTimeEqual` + `CF_EDGE_PROOF_HEADER`). Dependency-free by contract — header comment documents why.
- **`server/_shared/rate-limit.ts`:** imports `getClientIp` from the new module and re-exports all three symbols, so its ~8 existing importers (gateway, leads, turnstile, api/*) and test mocks are untouched.
- **`server/_shared/usage.ts`:** imports from `./client-ip` instead of `./rate-limit`, with a comment stating the constraint.
- **`tests/resilience-validation-import-graph.test.mjs` (new guard):** statically walks the container-reachable import graph from the bundle's member scripts (regex text extraction — no module execution) and asserts every bare specifier is a node builtin, plus that every relative import resolves on disk. Wired into `test:resilience-validation-smoke`. This locks the whole class: the next server-side npm dep that creeps under `redis.ts`/`usage.ts` fails CI instead of crashing the cron.

## Bug Fix Protocol

Guard test written first and observed **red** on the pre-fix tree — it reported exactly the production chain:

```
'@upstash/ratelimit' statically imported via
    scripts/validate-resilience-sensitivity.mjs
    -> server/worldmonitor/resilience/v1/_dimension-scorers.ts
    -> server/_shared/redis.ts
    -> server/_shared/usage.ts
    -> server/_shared/rate-limit.ts
```

Green after the extraction (plus `@upstash/redis`, same chain — both cleared by the one edge removal).

## Testing

- New guard: 3/3 (red -> green witnessed)
- `test:resilience-validation-smoke`: 129 pass (now includes the guard)
- vitest `gateway-api-rate-limit` + `gateway-summarize-article-security` + `usage-identity`: 35 pass (spread-actual `vi.mock('../_shared/rate-limit')` patterns keep working via the re-export)
- tsx: `usage-telemetry-emission`, `api-key-rate-limit`, `cors-fail-closed`, `rate-limit`, `turnstile`, `gateway-required-bbox`, `resilience-ranking`: 155 pass
- `typecheck:api` clean; runtime smoke-load of `_dimension-scorers.ts` + `rate-limit.ts` via tsx confirms wiring and re-exports
- Security semantics preserved byte-for-byte: GHSA-c267 cf-connecting-ip transit-proof gating, #3531 x-forwarded-for exclusion, constant-time secret compare

## Post-Deploy Monitoring & Validation

- **Primary signal:** Railway `seed-bundle-resilience-validation` — next weekly cron tick must exit 0 (green badge, no "Deploy Crashed!" email). Members are weekly-interval; to validate immediately after deploy, trigger a manual run or check `railway logs <deployment-id> -d` for `=== Done ===` with `failed:0`.
- **Log query:** Railway logs for `Cannot find module` / `ERR_MODULE_NOT_FOUND` across seeder services (should be zero occurrences).
- **Healthy signal:** `node ~/.claude/skills/diagnose-railway-seeders/diagnose-railway-seeders.mjs seed-bundle-resilience-validation` reports HEALTHY; `/api/health?compact=1` stays at 0 stale content.
- **Failure signal / rollback:** if the bundle crashes again with a module-resolution error, the guard missed an import shape — re-run the guard test locally against the deployed SHA; revert is a clean single-commit revert (pure refactor + additive test).
- **Validation window / owner:** through the next two weekly ticks; owner: elie.

## Code review (multi-agent, pre-push)

Reviewed by 8 personas (correctness, security, adversarial, testing, maintainability, project-standards, agent-native, learnings) plus an **independent cross-model adversarial pass via Codex** and per-finding validators. All 8 validated findings were applied in `fix(review)`:

- Guard hardening: entry-closure walk, COPY-set containment, createRequire edges, bare-require budget, Dockerfile-derived contract, tokenizer comment-stripping, deep-node canaries + calibrated floors, synthetic-fixture self-test, and parametrization over **both** zero-install bundle containers (resilience-validation + portwatch-port-activity).
- Security verified the extraction byte-identical (fail-closed secret gate, transit-proof gating, no x-forwarded-for, no desync surface, no secret exposure); stale sync-pointer comments corrected.
- 1 finding rejected in validation (bare-require scenario as filed was subsumed by the createRequire fix; enforcement implemented anyway as free hardening, proven by the self-test).

## Known residuals (accepted, recorded)

- Lazy/dynamic bare npm specifiers remain out of the guard's scope by design (documented in the test header) — an unconditionally-executed lazy bare import would still crash at call time.
- `isBuiltin` evaluates with the test-runner's node; the container pins node:24-alpine (low-likelihood skew).
- Bundle-member discovery matches single-quoted `script: '...'` only; mitigated by the min-members + named-member assertions (fails loud, not silent).
- Pre-existing: `turnstile.ts` ships a transit-proof-less `getClientIp` consumed by lead-endpoint scoped rate limits — tracked in #5235 (bounded by HMAC gating + hardened outer gateway budgets).

---
https://claude.ai/code/session_01CbyWHXafMRMXNfGak9rcg5
