### PR TITLE
fix(security): harden Turnstile client IP identity

### DIFF
--- a/server/_shared/turnstile.ts
+++ b/server/_shared/turnstile.ts
@@ -1,24 +1,10 @@
-// client-ip (NOT rate-limit): the constant's home is dependency-free; going
-// through rate-limit's re-export would needlessly weight this module's import
-// graph with @upstash packages (#5231's exact failure shape).
-import { UNKNOWN_CLIENT_IP } from './client-ip';
+// Keep this module's public helper surface for its lead-handler consumers, but
+// use the dependency-free canonical client-IP implementation. This preserves
+// Cloudflare transit-proof validation for the scoped rate-limit identity
+// instead of maintaining a divergent local copy (#5235, GHSA-c267).
+export { getClientIp } from './client-ip';
 
 const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
-
-export function getClientIp(request: Request): string {
-  // cf-connecting-ip is the trusted client IP set by Cloudflare; x-real-ip
-  // is the CF edge IP (shared across users) — kept as a secondary because
-  // some non-CF deploys set it directly. x-forwarded-for is client-settable
-  // and MUST NOT be used as a rate-limit / abuse-defence identifier (#3531).
-  // Trim each value so a whitespace-only header doesn't short-circuit past
-  // the next fallback. Named after getClientIp in server/_shared/client-ip.ts
-  // but deliberately WITHOUT its CF transit-proof gate — this value feeds the
-  // Turnstile siteverify remoteip hint. Hardening the rate-limit call sites
-  // that also consume it is tracked in #5235.
-  const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
-  const xr = (request.headers.get('x-real-ip') ?? '').trim();
-  return cf || xr || UNKNOWN_CLIENT_IP;
-}
 
 export type TurnstileMissingSecretPolicy = 'allow' | 'allow-in-development' | 'deny';
 

--- a/tests/turnstile.test.mjs
+++ b/tests/turnstile.test.mjs
@@ -20,12 +20,26 @@ test.afterEach(() => {
   restoreEnv();
 });
 
-test('getClientIp prefers cf-connecting-ip, then x-real-ip', () => {
+test('getClientIp ignores an unproven cf-connecting-ip and falls back to x-real-ip (#5235)', () => {
+  process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
   const request = new Request('https://worldmonitor.app/api/test', {
     headers: {
       'x-forwarded-for': '198.51.100.8, 203.0.113.10',
       'cf-connecting-ip': '203.0.113.7',
       'x-real-ip': '192.0.2.5',
+    },
+  });
+
+  assert.equal(getClientIp(request), '192.0.2.5');
+});
+
+test('getClientIp trusts cf-connecting-ip when Cloudflare transit is proven (#5235)', () => {
+  process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+  const request = new Request('https://worldmonitor.app/api/test', {
+    headers: {
+      'cf-connecting-ip': '203.0.113.7',
+      'x-real-ip': '192.0.2.5',
+      'x-wm-edge-proof': 'edge-secret-xyz',
     },
   });
 

--- a/tests/turnstile.test.mjs
+++ b/tests/turnstile.test.mjs
@@ -33,6 +33,18 @@ test('getClientIp ignores an unproven cf-connecting-ip and falls back to x-real-
   assert.equal(getClientIp(request), '192.0.2.5');
 });
 
+test('getClientIp ignores cf-connecting-ip when the Cloudflare proof secret is unset (#5235)', () => {
+  delete process.env.CF_EDGE_PROOF_SECRET;
+  const request = new Request('https://worldmonitor.app/api/test', {
+    headers: {
+      'cf-connecting-ip': '203.0.113.7',
+      'x-real-ip': '192.0.2.5',
+    },
+  });
+
+  assert.equal(getClientIp(request), '192.0.2.5');
+});
+
 test('getClientIp trusts cf-connecting-ip when Cloudflare transit is proven (#5235)', () => {
   process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
   const request = new Request('https://worldmonitor.app/api/test', {


### PR DESCRIPTION
## Summary

Direct-to-origin lead requests can no longer rotate their scoped rate-limit identity by forging `cf-connecting-ip`. The Turnstile helper now exposes the canonical transit-proof-aware client-IP derivation while keeping its existing handler import surface intact.

Fixes #5235.

## Validation

- Added a regression test showing an unproven `cf-connecting-ip` falls back to `x-real-ip`.
- Confirmed a valid Cloudflare transit proof still preserves the client IP.
- Ran focused Turnstile and rate-limit tests, API typechecking, targeted lint, and the full pre-push server gate.

## Post-Deploy Monitoring & Validation

- Owner/window: WorldMonitor on-call, for the first 24 hours after deploy.
- Watch rate-limit and lead-handler logs for `checkScopedRateLimit`, `register-interest`, and `contact` failures; healthy behavior is normal accepted lead traffic with the existing 429 budgets still enforced.
- Investigate a material increase in legitimate lead 429s, Turnstile 403s, or rate-limit degraded 503s; roll back this commit if the increase is correlated with the deploy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT-5-000000)
