### PR TITLE
fix(security): harden client-ip proof comparison

### DIFF
--- a/api/_client-ip.js
+++ b/api/_client-ip.js
@@ -20,7 +20,7 @@ function constantTimeEqual(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string') return false;
   const len = b.length;
   let diff = a.length ^ b.length;
-  for (let i = 0; i < len; i += 1) diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  for (let i = 0; i < len; i += 1) diff |= (a.charCodeAt(i) || 0) ^ b.charCodeAt(i);
   return diff === 0;
 }
 

--- a/api/_client-ip.js
+++ b/api/_client-ip.js
@@ -12,13 +12,15 @@ export const RATE_LIMIT_DEGRADED_HEADERS = Object.freeze({
 // the request actually transited CF. Keep in sync with server/_shared/client-ip.ts.
 const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
 
-// Constant-time comparison for the edge-proof secret. Synchronous so getClientIp
-// stays sync (it's on the per-request rate-limit hot path with several callers
-// that invoke it without await).
+// Compare the edge-proof secret without an early exit on length mismatch.
+// Synchronous so getClientIp stays sync (it's on the per-request rate-limit hot
+// path with several callers that invoke it without await). Keep in sync with
+// server/_shared/client-ip.ts.
 function constantTimeEqual(a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const len = b.length;
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i += 1) diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
   return diff === 0;
 }
 

--- a/server/_shared/client-ip.ts
+++ b/server/_shared/client-ip.ts
@@ -27,7 +27,7 @@ const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
 function constantTimeEqual(a: string, b: string): boolean {
   const len = b.length;
   let diff = a.length ^ b.length;
-  for (let i = 0; i < len; i += 1) diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  for (let i = 0; i < len; i += 1) diff |= (a.charCodeAt(i) || 0) ^ b.charCodeAt(i);
   return diff === 0;
 }
 

--- a/server/_shared/client-ip.ts
+++ b/server/_shared/client-ip.ts
@@ -21,12 +21,13 @@ export const UNKNOWN_CLIENT_IP = 'unknown';
 // the request actually transited CF. Keep in sync with api/_client-ip.js.
 const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
 
-// Constant-time comparison for the edge-proof secret. Synchronous so getClientIp
-// stays sync (per-request rate-limit hot path, several non-awaiting callers).
+// Compare the edge-proof secret without an early exit on length mismatch.
+// Synchronous so getClientIp stays sync (per-request rate-limit hot path,
+// several non-awaiting callers). Keep in sync with api/_client-ip.js.
 function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  const len = b.length;
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i += 1) diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
   return diff === 0;
 }
 

--- a/tests/client-ip.test.mts
+++ b/tests/client-ip.test.mts
@@ -1,14 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 import { getClientIp as getServerClientIp } from '../server/_shared/client-ip.ts';
 import { getClientIp as getApiClientIp } from '../api/_client-ip.js';
-
-const SOURCE_FILES = [
-  'server/_shared/client-ip.ts',
-  'api/_client-ip.js',
-] as const;
 
 function makeRequest(proof: string): Request {
   return new Request('https://worldmonitor.app/api/test', {
@@ -20,13 +14,49 @@ function makeRequest(proof: string): Request {
   });
 }
 
+function compareWithCharCodeCount(
+  getClientIp: (request: Request) => string,
+  proof: string,
+  secret: string,
+): { ip: string; proofReads: number; secretReads: number } {
+  const request = makeRequest(proof);
+  const originalCharCodeAt = String.prototype.charCodeAt;
+  let proofReads = 0;
+  let secretReads = 0;
+
+  String.prototype.charCodeAt = function (this: string, index: number): number {
+    const value = String(this);
+    if (value === proof) proofReads += 1;
+    if (value === secret) secretReads += 1;
+    return originalCharCodeAt.call(this, index);
+  };
+
+  try {
+    return { ip: getClientIp(request), proofReads, secretReads };
+  } finally {
+    String.prototype.charCodeAt = originalCharCodeAt;
+  }
+}
+
 describe('client-IP edge-proof comparison (#5239)', () => {
-  it('does not retain an unequal-length early return in either sync mirror', () => {
-    for (const file of SOURCE_FILES) {
-      const source = readFileSync(file, 'utf8');
-      assert.doesNotMatch(source, /a\.length !== b\.length\) return false/);
-      assert.match(source, /const len = b\.length;/);
-      assert.match(source, /let diff = a\.length \^ b\.length;/);
+  it('uses the secret length for short and long invalid proofs in both sync mirrors', () => {
+    const secret = 'edge-secret-xyz';
+    const proofs = ['short', 'edge-secret-xyz-with-extra'];
+    const originalSecret = process.env.CF_EDGE_PROOF_SECRET;
+    process.env.CF_EDGE_PROOF_SECRET = secret;
+
+    try {
+      for (const getClientIp of [getServerClientIp, getApiClientIp]) {
+        for (const proof of proofs) {
+          const comparison = compareWithCharCodeCount(getClientIp, proof, secret);
+          assert.equal(comparison.ip, '192.0.2.5');
+          assert.equal(comparison.proofReads, secret.length);
+          assert.equal(comparison.secretReads, secret.length);
+        }
+      }
+    } finally {
+      if (originalSecret == null) delete process.env.CF_EDGE_PROOF_SECRET;
+      else process.env.CF_EDGE_PROOF_SECRET = originalSecret;
     }
   });
 

--- a/tests/client-ip.test.mts
+++ b/tests/client-ip.test.mts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import { getClientIp as getServerClientIp } from '../server/_shared/client-ip.ts';
+import { getClientIp as getApiClientIp } from '../api/_client-ip.js';
+
+const SOURCE_FILES = [
+  'server/_shared/client-ip.ts',
+  'api/_client-ip.js',
+] as const;
+
+function makeRequest(proof: string): Request {
+  return new Request('https://worldmonitor.app/api/test', {
+    headers: {
+      'cf-connecting-ip': '203.0.113.7',
+      'x-real-ip': '192.0.2.5',
+      'x-wm-edge-proof': proof,
+    },
+  });
+}
+
+describe('client-IP edge-proof comparison (#5239)', () => {
+  it('does not retain an unequal-length early return in either sync mirror', () => {
+    for (const file of SOURCE_FILES) {
+      const source = readFileSync(file, 'utf8');
+      assert.doesNotMatch(source, /a\.length !== b\.length\) return false/);
+      assert.match(source, /const len = b\.length;/);
+      assert.match(source, /let diff = a\.length \^ b\.length;/);
+    }
+  });
+
+  it('keeps valid, mismatched-length, and wrong-value proofs semantically identical', () => {
+    const originalSecret = process.env.CF_EDGE_PROOF_SECRET;
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+
+    try {
+      for (const getClientIp of [getServerClientIp, getApiClientIp]) {
+        assert.equal(getClientIp(makeRequest('edge-secret-xyz')), '203.0.113.7');
+        assert.equal(getClientIp(makeRequest('short')), '192.0.2.5');
+        assert.equal(getClientIp(makeRequest('edge-secret-xyz-with-extra')), '192.0.2.5');
+        assert.equal(getClientIp(makeRequest('edge-secret-xyq')), '192.0.2.5');
+      }
+    } finally {
+      if (originalSecret == null) delete process.env.CF_EDGE_PROOF_SECRET;
+      else process.env.CF_EDGE_PROOF_SECRET = originalSecret;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Invalid Cloudflare edge proofs no longer return sooner simply because their length differs from the configured secret. Both runtime copies now take the configured secret-length comparison path, while retaining the existing fail-closed `x-real-ip` fallback for every invalid proof.

Fixes #5239

## Validation

- `npm run typecheck`
- `npm run typecheck:api`
- Focused client-IP and rate-limit tests, the dependency import-graph guard, and the pre-push Edge bundle and changed-test gates
- `npm run test:data`: 15,018 passed; two dashboard critical-CSS assertions require a prebuilt `dist/dashboard.html`. The production build that would produce it was stopped by the repository's Vite local-secret safety guard, so no build artifacts were produced.

## Post-Deploy Monitoring & Validation

- Monitor client-IP attribution and rate-limit identity distribution for unexpected increases in fallback identities after deployment.
- Healthy: valid Cloudflare-transit traffic continues to use `cf-connecting-ip`; invalid or absent proofs follow the existing `x-real-ip` fallback.
- Investigate or roll back if trusted-client attribution or rate-limit bucket distribution changes unexpectedly during the first 24 hours. Owner: on-call API maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
