### PR TITLE
feat(forecast): fast-resolving commodity price bets — Gate-1 accelerator (#5233)

### DIFF
--- a/scripts/_bet-templates-commodities.mjs
+++ b/scripts/_bet-templates-commodities.mjs
@@ -44,8 +44,11 @@ function buildCommodityTemplate({ symbol, subject, unit }) {
       // Prices are strictly positive; a 0/negative quote is a broken feed. Skip
       // it (a zero baseline would mint a guaranteed-YES bet).
       if (!q || !Number.isFinite(price) || price <= 0) return null;
-      const changePct = Number(q.change); // daily % change (may be absent)
-      return { subject, symbol, value: price, changePct: Number.isFinite(changePct) ? changePct : 0, unit };
+      // daily % change — null when absent (Yahoo omits `change` on non-trading
+      // sessions). Kept as a sentinel so the spec builder can skip a bet whose
+      // direction is undetermined rather than silently defaulting it to "up".
+      const changePct = Number(q.change);
+      return { subject, symbol, value: price, changePct: Number.isFinite(changePct) ? changePct : null, unit };
     },
 
     horizonPolicy({ nowMs }) {
@@ -56,7 +59,11 @@ function buildCommodityTemplate({ symbol, subject, unit }) {
       const { value, changePct } = metric;
       const magnitude = Math.abs(value) * MOVE_FRACTION;
       if (!(magnitude > 0)) return null;
-      const wantUp = changePct >= 0; // continuation of the latest daily move
+      // Direction = continuation of the latest daily move. Undetermined
+      // (absent or exactly-flat change) → emit no bet, so a missing-data day
+      // never skews the shadow pool bullish.
+      if (changePct == null || changePct === 0) return null;
+      const wantUp = changePct > 0;
       const threshold = round(wantUp ? value + magnitude : value - magnitude);
       return {
         kind: 'hard',

--- a/scripts/_bet-templates-commodities.mjs
+++ b/scripts/_bet-templates-commodities.mjs
@@ -1,0 +1,111 @@
+// Commodity price bet templates (Phase 1 pilot, fast-resolving lane / #5233).
+//
+// Source feed: market:commodities-bootstrap:v1, live shape (post-unwrap)
+//   { quotes: [ { symbol, name, price, change /* daily % */, ... } ] }
+// Unlike the weekly EIA feed, commodity prices update daily, so these bets use a
+// SHORT (~4-day) horizon and resolve within the week — the fast Gate-1 evidence
+// lane. The metricKey reads back through the resolver's existing `price()` fn as
+// `market:commodities-bootstrap:v1|price(symbol==<SYMBOL>)`.
+//
+// Pure: templates are declarative; generateBets drives them with an injected
+// (unwrapped) feed snapshot + nowMs.
+
+export const COMMODITY_FEED = 'market:commodities-bootstrap:v1';
+const DAY_MS = 24 * 60 * 60 * 1000;
+// ~4 calendar days: lands the deadline within the week for near-real-time price
+// resolution (markets settle daily), the fast Gate-1 signal.
+const COMMODITY_HORIZON_MS = 4 * DAY_MS;
+// Threshold move over the horizon — a plausible ~4-day commodity swing. The bet
+// asks whether the latest daily direction continues by at least this much.
+const MOVE_FRACTION = 0.025;
+
+const COMMODITIES = [
+  { symbol: 'CL=F', subject: 'the WTI crude oil price', unit: 'USD/bbl' },
+  { symbol: 'BZ=F', subject: 'the Brent crude oil price', unit: 'USD/bbl' },
+  { symbol: 'NG=F', subject: 'the US natural gas price', unit: 'USD/MMBtu' },
+  { symbol: 'GC=F', subject: 'the gold price', unit: 'USD/oz' },
+];
+
+function findQuote(feed, symbol) {
+  const quotes = Array.isArray(feed?.quotes) ? feed.quotes : Array.isArray(feed) ? feed : null;
+  if (!quotes) return null;
+  return quotes.find((q) => q && q.symbol === symbol) || null;
+}
+
+function buildCommodityTemplate({ symbol, subject, unit }) {
+  return {
+    id: `commodity:${symbol}`,
+    feedKey: COMMODITY_FEED,
+    domain: 'market',
+
+    extractMetric(feed) {
+      const q = findQuote(feed, symbol);
+      const price = Number(q?.price);
+      // Prices are strictly positive; a 0/negative quote is a broken feed. Skip
+      // it (a zero baseline would mint a guaranteed-YES bet).
+      if (!q || !Number.isFinite(price) || price <= 0) return null;
+      const changePct = Number(q.change); // daily % change (may be absent)
+      return { subject, symbol, value: price, changePct: Number.isFinite(changePct) ? changePct : 0, unit };
+    },
+
+    horizonPolicy({ nowMs }) {
+      return nowMs + COMMODITY_HORIZON_MS;
+    },
+
+    buildResolutionSpec({ metric, deadlineMs }) {
+      const { value, changePct } = metric;
+      const magnitude = Math.abs(value) * MOVE_FRACTION;
+      if (!(magnitude > 0)) return null;
+      const wantUp = changePct >= 0; // continuation of the latest daily move
+      const threshold = round(wantUp ? value + magnitude : value - magnitude);
+      return {
+        kind: 'hard',
+        metricKey: `${COMMODITY_FEED}|price(symbol==${symbol})`,
+        operator: 'crosses',
+        threshold,
+        baselineValue: round(value),
+        window: 'at-deadline',
+        deadline: deadlineMs,
+        sourceFeed: COMMODITY_FEED,
+        question: buildQuestion(metric, wantUp, threshold, deadlineMs),
+      };
+    },
+
+    buildQuestion({ metric, spec }) {
+      return spec.question;
+    },
+
+    buildTitle({ metric, spec }) {
+      const dir = spec.threshold >= spec.baselineValue ? 'rise' : 'fall';
+      return `${capitalize(metric.subject)}: ${dir} to ${spec.threshold} ${metric.unit}?`;
+    },
+
+    userValueScore() {
+      return symbol === 'CL=F' || symbol === 'BZ=F' ? 0.7 : 0.6;
+    },
+  };
+}
+
+function buildQuestion(metric, wantUp, threshold, deadlineMs) {
+  const dir = wantUp ? 'rise to at least' : 'fall to at most';
+  return `Will ${metric.subject} ${dir} ${threshold} ${metric.unit} by ${isoDate(deadlineMs)}?`;
+}
+
+export const COMMODITY_BET_TEMPLATES = COMMODITIES.map(buildCommodityTemplate);
+
+function isoDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function capitalize(text) {
+  const s = String(text || '');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Prices read at 2 decimals so the question is clean (69.62, not 69.62475).
+// The spec threshold and the displayed threshold are the same value, so
+// resolution stays exact against what the question states.
+function round(value) {
+  if (!Number.isFinite(value)) return value;
+  return Math.round(value * 100) / 100;
+}

--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -61,12 +61,15 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
     return { status: 'pending', evidence: { reason: 'deadline_not_reached', deadline } };
   }
 
-  // Settlement gate for scalar `value` reads (energy/economic bet engine). Like
-  // count(), a premature read scores a false NO: period feeds (e.g. EIA's weekly
-  // release, dated by `asOf`) may still hold the PRIOR period's value when the
-  // resolver ticks on the deadline. Only resolve once the feed carries a reading
-  // dated on/after the deadline day; pend until then, VOID if it never settles.
-  if (parsed.fn === 'value') {
+  // Settlement gate for scalar `value`/`price` reads (energy/economic/commodity
+  // bet engine). Like count(), a premature or STALE read scores a false YES/NO:
+  // a period feed (EIA weekly, dated by `asOf`) may still hold the prior period's
+  // value, and a live feed kept warm through a fetch failure (commodities, whose
+  // shaper stamps each quote with the envelope `_seed.fetchedAt` as `asOf`) may
+  // hold a quote dated days before the deadline. Only resolve once the matched
+  // record is dated on/after the deadline day; pend until then, VOID if it never
+  // settles. Records with no timestamp fall through (cannot gate).
+  if (parsed.fn === 'value' || parsed.fn === 'price') {
     const settle = valueSettlementResult(parsed, feedData, deadline, nowMs, entry, spec);
     if (settle) return settle;
   }

--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -61,15 +61,18 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
     return { status: 'pending', evidence: { reason: 'deadline_not_reached', deadline } };
   }
 
-  // Settlement gate for scalar `value`/`price` reads (energy/economic/commodity
-  // bet engine). Like count(), a premature or STALE read scores a false YES/NO:
-  // a period feed (EIA weekly, dated by `asOf`) may still hold the prior period's
-  // value, and a live feed kept warm through a fetch failure (commodities, whose
-  // shaper stamps each quote with the envelope `_seed.fetchedAt` as `asOf`) may
-  // hold a quote dated days before the deadline. Only resolve once the matched
-  // record is dated on/after the deadline day; pend until then, VOID if it never
-  // settles. Records with no timestamp fall through (cannot gate).
-  if (parsed.fn === 'value' || parsed.fn === 'price') {
+  // Settlement gate for scalar `value`/`price` reads at a POINT window
+  // (at-deadline). Like count(), a premature or STALE read scores a false
+  // YES/NO: a period feed (EIA weekly, dated by `asOf`) may still hold the prior
+  // period's value, and a live feed kept warm through a fetch failure
+  // (commodities, whose shaper stamps each quote with the envelope
+  // `_seed.fetchedAt` as `asOf`) may hold a quote dated days before the
+  // deadline. Only resolve once the matched record is dated on/after the
+  // deadline day; pend until then, VOID if it never settles. Records with no
+  // timestamp fall through (cannot gate). within-horizon is exempt — it resolves
+  // from the asOf-stamped sample timeline, not the current feed record.
+  const isPointWindow = spec.window === 'at-deadline' || spec.window === 'at-endDate';
+  if (isPointWindow && (parsed.fn === 'value' || parsed.fn === 'price')) {
     const settle = valueSettlementResult(parsed, feedData, deadline, nowMs, entry, spec);
     if (settle) return settle;
   }
@@ -177,8 +180,19 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
 // a pending result while within the grace window, or VOID once grace elapses.
 function valueSettlementResult(parsed, feedData, deadline, nowMs, entry, spec) {
   const record = findMatchingRecord(feedData, parsed.field, parsed.value);
-  const asOf = parseAsOfMs(record?.asOf ?? record?.date);
-  if (!Number.isFinite(asOf)) return null; // no timestamp → cannot gate
+  if (!record) {
+    // Whole-feed-down is handled by the window path (source_feed_unavailable);
+    // here the feed is PRESENT but the matched record is absent — a partial
+    // refresh that dropped this symbol. Pend through the grace so a transient
+    // gap doesn't immediately VOID; VOID only if it never returns (#5243 P2).
+    if (feedData == null) return null;
+    if (nowMs < deadline + VALUE_SETTLEMENT_MAX_LAG_MS) {
+      return { status: 'pending', evidence: { reason: 'value_source_record_missing', deadline } };
+    }
+    return voidResult('value_source_never_settled', entry, spec, parsed, nowMs);
+  }
+  const asOf = parseAsOfMs(record.asOf ?? record.date);
+  if (!Number.isFinite(asOf)) return null; // record present but no timestamp → cannot gate
   const deadlineDay = Math.floor(deadline / DAY_MS) * DAY_MS;
   if (asOf >= deadlineDay) return null; // feed has caught up to the deadline period
   if (nowMs < deadline + VALUE_SETTLEMENT_MAX_LAG_MS) {
@@ -194,12 +208,8 @@ function parseAsOfMs(value) {
   return Number.isFinite(parsed) ? parsed : NaN;
 }
 
-export function extractMetricValue(parsed, feedData) {
-  const record = findMatchingRecord(feedData, parsed.field, parsed.value);
-  if (parsed.fn === 'present') return record ? 1 : 0;
-  if (!record) return NaN;
-
-  switch (parsed.fn) {
+function valueFromRecord(fn, record) {
+  switch (fn) {
     case 'riskScore':
       return firstFinite(record.riskScore, record.risk_score, record.score, record.risk);
     case 'yesPrice':
@@ -216,6 +226,26 @@ export function extractMetricValue(parsed, feedData) {
     default:
       return NaN;
   }
+}
+
+export function extractMetricValue(parsed, feedData) {
+  const record = findMatchingRecord(feedData, parsed.field, parsed.value);
+  if (parsed.fn === 'present') return record ? 1 : 0;
+  if (!record) return NaN;
+  return valueFromRecord(parsed.fn, record);
+}
+
+// Value AND the source observation time (`asOf`) of the matched record. Callers
+// that STORE a sample must stamp it with this asOf, not the cycle time — a stale
+// kept-warm reading carries a pre-deadline asOf, so stamping it with the cycle
+// time would let a settlement-gated resolution later prefer that stale sample
+// over the fresh feed (#5243 P1). asOf is null when the record has no timestamp.
+export function extractMetricObservation(parsed, feedData) {
+  const record = findMatchingRecord(feedData, parsed.field, parsed.value);
+  if (!record) return { value: NaN, asOf: null };
+  const asOf = parseAsOfMs(record.asOf ?? record.date);
+  const value = parsed.fn === 'present' ? 1 : valueFromRecord(parsed.fn, record);
+  return { value, asOf: Number.isFinite(asOf) ? asOf : null };
 }
 
 function compareResult(value, spec, entry, parsed, nowMs, extraEvidence = {}) {

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -139,12 +139,17 @@ async function main() {
       await redisPipeline(['LTRIM', BETS_HISTORY_KEY, 0, BETS_MAX_RUNS - 1]);
       await redisPipeline(['EXPIRE', BETS_HISTORY_KEY, BETS_TTL_SECONDS]);
       await redisPipeline(['SET', BETS_SERIES_KEY, JSON.stringify(nextSeries), 'EX', SERIES_TTL_SECONDS]);
-      console.log(`  [bets] published ${count} shadow energy bet(s) -> ${BETS_HISTORY_KEY}`);
+      const byDomain = snapshot.predictions.reduce((acc, b) => {
+        acc[b.domain] = (acc[b.domain] || 0) + 1;
+        return acc;
+      }, {});
+      const breakdown = Object.entries(byDomain).map(([d, n]) => `${d}:${n}`).join(', ');
+      console.log(`  [bets] published ${count} shadow bet(s) [${breakdown}] -> ${BETS_HISTORY_KEY}`);
       for (const bet of snapshot.predictions) {
         console.log(`    - ${bet.question} (p=${bet.probability})`);
       }
     } else {
-      console.warn('  [bets] no energy bets generated (feeds absent/unusable); nothing appended');
+      console.warn('  [bets] no bets generated (feeds absent/unusable); nothing appended');
     }
     await writeFreshnessMetadata('forecast', 'bets', count, 'bet-engine:v1', BETS_TTL_SECONDS);
   } catch (err) {

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -17,6 +17,7 @@ import {
 } from './_seed-utils.mjs';
 import { generateBets } from './_bet-templates.mjs';
 import { ENERGY_BET_TEMPLATES, EIA_PETROLEUM_FEED } from './_bet-templates-energy.mjs';
+import { COMMODITY_BET_TEMPLATES, COMMODITY_FEED } from './_bet-templates-commodities.mjs';
 import { baseRateProbability } from './_bet-baserate.mjs';
 import { parseMetricKey } from './_forecast-resolution-eval.mjs';
 import { BETS_HISTORY_KEY } from './_forecast-bets-keys.mjs';
@@ -39,7 +40,11 @@ const BETS_TTL_SECONDS = 45 * 24 * 60 * 60;
 const SERIES_TTL_SECONDS = 400 * 24 * 60 * 60;
 const SERIES_CAP = 104; // ~2 years of weekly EIA releases
 const EIA_METRICS = ['inventory', 'production', 'wti', 'brent'];
-const ENERGY_FEEDS = [EIA_PETROLEUM_FEED];
+// All template families + the feeds they read. Energy (EIA, weekly) has an
+// accumulator-backed base rate; commodities (daily prices) are the fast-
+// resolving lane and use the thin-history prior until their own series accrues.
+const ALL_BET_TEMPLATES = [...ENERGY_BET_TEMPLATES, ...COMMODITY_BET_TEMPLATES];
+const BET_FEEDS = [EIA_PETROLEUM_FEED, COMMODITY_FEED];
 
 function unwrapFeeds(feedsByKey) {
   const unwrapped = {};
@@ -79,9 +84,12 @@ export function computeNextSeries(feedsByKey, priorSeries = {}, cap = SERIES_CAP
 export function buildBetsSnapshot(feedsByKey, nowMs, priorSeries = {}) {
   const unwrapped = unwrapFeeds(feedsByKey);
   const series = computeNextSeries(unwrapped, priorSeries);
-  const bets = generateBets(ENERGY_BET_TEMPLATES, unwrapped, nowMs);
+  const bets = generateBets(ALL_BET_TEMPLATES, unwrapped, nowMs);
   for (const bet of bets) {
     const parsed = parseMetricKey(bet.resolution?.metricKey);
+    // Base rate is computed over the accumulated series keyed by the metric
+    // subject (EIA metric name). Commodity symbols have no accumulator yet, so
+    // their series is empty → baseRateProbability returns the honest prior.
     const values = (series[parsed?.value] || []).map((p) => Number(p.v)).filter(Number.isFinite);
     const { probability } = baseRateProbability(values, bet.resolution);
     bet.probability = probability;
@@ -109,7 +117,7 @@ async function readRedisJson(key) {
 
 async function main() {
   const feedsByKey = {};
-  for (const key of ENERGY_FEEDS) {
+  for (const key of BET_FEEDS) {
     try {
       feedsByKey[key] = await readRedisJson(key);
     } catch (err) {

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -46,6 +46,28 @@ const EIA_METRICS = ['inventory', 'production', 'wti', 'brent'];
 const ALL_BET_TEMPLATES = [...ENERGY_BET_TEMPLATES, ...COMMODITY_BET_TEMPLATES];
 const BET_FEEDS = [EIA_PETROLEUM_FEED, COMMODITY_FEED];
 
+// Per-feed generation freshness contract. A live-price feed (commodities) kept
+// warm through a multi-day outage (extendExistingTtl preserves the old
+// _seed.fetchedAt) must NOT mint a "newly dated" bet from a stale price (#5243
+// P2). 5 days tolerates any weekend/holiday gap but rejects a real outage.
+// Period feeds (EIA weekly) are naturally days old → not listed (no cap).
+const FEED_MAX_GENERATION_AGE_MS = { [COMMODITY_FEED]: 5 * 24 * 60 * 60 * 1000 };
+
+// Drop feeds whose envelope predates their freshness contract, so their
+// templates receive no data and generate no bet. Pure (no I/O / console).
+function filterFreshFeeds(feedsByKey, nowMs) {
+  const out = {};
+  for (const [key, value] of Object.entries(feedsByKey || {})) {
+    const maxAge = FEED_MAX_GENERATION_AGE_MS[key];
+    if (maxAge != null) {
+      const fetchedAt = Number(value?._seed?.fetchedAt);
+      if (Number.isFinite(fetchedAt) && nowMs - fetchedAt > maxAge) continue; // stale → drop
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
 function unwrapFeeds(feedsByKey) {
   const unwrapped = {};
   for (const [key, value] of Object.entries(feedsByKey || {})) {
@@ -82,8 +104,9 @@ export function computeNextSeries(feedsByKey, priorSeries = {}, cap = SERIES_CAP
 // accumulated observation series (thin history honestly falls back to a
 // directional prior inside baseRateProbability). Exported for tests (no I/O).
 export function buildBetsSnapshot(feedsByKey, nowMs, priorSeries = {}) {
-  const unwrapped = unwrapFeeds(feedsByKey);
-  const series = computeNextSeries(unwrapped, priorSeries);
+  const fresh = filterFreshFeeds(feedsByKey, nowMs);
+  const unwrapped = unwrapFeeds(fresh);
+  const series = computeNextSeries(fresh, priorSeries);
   const bets = generateBets(ALL_BET_TEMPLATES, unwrapped, nowMs);
   for (const bet of bets) {
     const parsed = parseMetricKey(bet.resolution?.metricKey);

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -1089,8 +1089,15 @@ export function shapeResolutionFeed(key, data) {
     // descends into ARRAY children, so the doubly-nested quotes array is
     // invisible as-is — expose it directly so `price(symbol==<SYM>)` resolves.
     // (Also unblocks the pre-existing market commodity-price forecast path.)
+    // Quotes carry no per-symbol timestamp; stamp each with the envelope's
+    // `_seed.fetchedAt` as `asOf` so the settlement gate can refuse to resolve a
+    // stale kept-warm quote (extendExistingTtl preserves the old fetchedAt) as
+    // if it were the deadline-time price.
+    const fetchedAt = Number(data?._seed?.fetchedAt);
     const d = data?.data ?? data;
-    if (Array.isArray(d?.quotes)) return d.quotes;
+    if (Array.isArray(d?.quotes)) {
+      return d.quotes.map((q) => (q && typeof q === 'object' && Number.isFinite(fetchedAt) ? { ...q, asOf: fetchedAt } : q));
+    }
     return d;
   }
   return data;

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -1084,6 +1084,15 @@ export function shapeResolutionFeed(key, data) {
     }
     return records;
   }
+  if (key === 'market:commodities-bootstrap:v1') {
+    // Enveloped as {_seed, data:{quotes:[...]}}. The eval's iterateRecords only
+    // descends into ARRAY children, so the doubly-nested quotes array is
+    // invisible as-is — expose it directly so `price(symbol==<SYM>)` resolves.
+    // (Also unblocks the pre-existing market commodity-price forecast path.)
+    const d = data?.data ?? data;
+    if (Array.isArray(d?.quotes)) return d.quotes;
+    return d;
+  }
   return data;
 }
 

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -17,7 +17,7 @@
 import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveR2StorageConfig, putR2JsonObject } from './_r2-storage.mjs';
-import { parseMetricKey, resolveHardSpec, extractMetricValue } from './_forecast-resolution-eval.mjs';
+import { parseMetricKey, resolveHardSpec, extractMetricValue, extractMetricObservation } from './_forecast-resolution-eval.mjs';
 import { CONFLICT_COUNT_FEED_AVAILABLE, UNREST_COUNT_FEED_AVAILABLE, CONFLICT_COUNT_SOURCE_FEED, UNREST_COUNT_SOURCE_FEED } from './_forecast-resolution.mjs';
 import { computeScorecard, DEFAULT_ROLLING_WINDOW_DAYS } from './_forecast-scorecard.mjs';
 import { BETS_HISTORY_KEY } from './_forecast-bets-keys.mjs';
@@ -879,9 +879,15 @@ export function samplePendingEntries(ledger, feedsByKey, nowMs) {
       entry.samples = appendSample(entry.samples, { ts: nowMs, error: `missing_feed:${entry.spec.sourceFeed || parsed.feedKey}` });
       continue;
     }
-    const value = extractMetricValue(parsed, feedData);
+    const { value, asOf } = extractMetricObservation(parsed, feedData);
+    // Stamp the sample with the source observation time (asOf) when the feed
+    // provides one, NOT the cycle time — otherwise a stale kept-warm reading
+    // gets a post-deadline ts and is later preferred over the fresh quote,
+    // defeating the settlement gate (#5243 P1). Feeds with no per-record
+    // timestamp (riskScore/hexCount/yesPrice) keep the cycle time.
+    const sampleTs = Number.isFinite(asOf) ? asOf : nowMs;
     entry.samples = Number.isFinite(value)
-      ? appendSample(entry.samples, { ts: nowMs, value })
+      ? appendSample(entry.samples, { ts: sampleTs, value })
       : appendSample(entry.samples, { ts: nowMs, error: 'metric_not_found' });
   }
 }

--- a/tests/bet-templates-commodities.test.mjs
+++ b/tests/bet-templates-commodities.test.mjs
@@ -66,6 +66,19 @@ describe('commodity bet templates (fast-resolving lane)', () => {
     const missing = generateBets(COMMODITY_BET_TEMPLATES, { [COMMODITY_FEED]: { quotes: [] } }, NOW);
     assert.equal(missing.length, 0);
   });
+
+  it('skips a bet when the daily direction is undetermined (absent or flat change)', () => {
+    // absent `change` (non-trading session) — direction unknown → no bet
+    const absent = generateBets(COMMODITY_BET_TEMPLATES, {
+      [COMMODITY_FEED]: { quotes: [{ symbol: 'CL=F', price: 71.41 }] },
+    }, NOW);
+    assert.equal(absent.length, 0);
+    // exactly-flat change → no directional signal → no bet (no bullish default)
+    const flat = generateBets(COMMODITY_BET_TEMPLATES, {
+      [COMMODITY_FEED]: { quotes: [{ symbol: 'CL=F', price: 71.41, change: 0 }] },
+    }, NOW);
+    assert.equal(flat.length, 0);
+  });
 });
 
 describe('shapeResolutionFeed exposes the nested commodities quotes array', () => {

--- a/tests/bet-templates-commodities.test.mjs
+++ b/tests/bet-templates-commodities.test.mjs
@@ -82,38 +82,62 @@ describe('commodity bet templates (fast-resolving lane)', () => {
 });
 
 describe('shapeResolutionFeed exposes the nested commodities quotes array', () => {
-  it('unwraps {_seed,data:{quotes}} to the quotes array so price() resolves', () => {
-    const shaped = shapeResolutionFeed(COMMODITY_FEED, { _seed: {}, data: commoditiesFixture() });
+  it('unwraps {_seed,data:{quotes}} to the quotes array and stamps asOf', () => {
+    const fetchedAt = Date.parse('2026-07-16T06:00:00Z');
+    const shaped = shapeResolutionFeed(COMMODITY_FEED, { _seed: { fetchedAt }, data: commoditiesFixture() });
     assert.ok(Array.isArray(shaped));
-    assert.equal(shaped.find((q) => q.symbol === 'CL=F').price, 71.41);
+    const cl = shaped.find((q) => q.symbol === 'CL=F');
+    assert.equal(cl.price, 71.41);
+    assert.equal(cl.asOf, fetchedAt); // envelope fetchedAt carried onto each quote
   });
 });
 
-describe('commodity bets resolve end-to-end (no settlement gate — live price)', () => {
+// Fresh quote dated on/after the deadline; deadline is 2026-07-16.
+function shapedFeed(price, fetchedAtIso) {
+  return shapeResolutionFeed(COMMODITY_FEED, {
+    _seed: { fetchedAt: Date.parse(fetchedAtIso) },
+    data: { quotes: [{ symbol: 'CL=F', price, change: -0.5 }] },
+  });
+}
+
+describe('commodity bets resolve end-to-end (settlement-gated on quote freshness)', () => {
   function wtiBet() {
     const bets = generateBets(COMMODITY_BET_TEMPLATES, { [COMMODITY_FEED]: commoditiesFixture() }, NOW);
     const bet = bets.find((b) => b.resolution.metricKey.includes('symbol==CL=F'));
     return { spec: bet.resolution, generationOrigin: bet.generationOrigin, generatedAt: NOW };
   }
 
-  it('resolves YES when the price falls past the threshold at the deadline', () => {
-    const feed = shapeResolutionFeed(COMMODITY_FEED, { data: { quotes: [{ symbol: 'CL=F', price: 69.0, change: 0 }] } });
-    const res = resolveHardSpec(wtiBet(), feed, [], DEADLINE + DAY_MS);
+  it('resolves YES when a fresh quote falls past the threshold', () => {
+    const res = resolveHardSpec(wtiBet(), shapedFeed(69.0, '2026-07-16T06:00:00Z'), [], DEADLINE + DAY_MS);
     assert.equal(res.status, 'resolved');
-    assert.equal(res.outcome, 'YES'); // 69.0 <= 69.62475 (falling bet)
+    assert.equal(res.outcome, 'YES'); // 69.0 <= 69.62 (falling bet), fresh quote
   });
 
-  it('resolves NO when the price stays above the threshold', () => {
-    const feed = shapeResolutionFeed(COMMODITY_FEED, { data: { quotes: [{ symbol: 'CL=F', price: 70.5, change: 0 }] } });
-    const res = resolveHardSpec(wtiBet(), feed, [], DEADLINE + DAY_MS);
+  it('resolves NO when a fresh quote stays above the threshold', () => {
+    const res = resolveHardSpec(wtiBet(), shapedFeed(70.5, '2026-07-16T06:00:00Z'), [], DEADLINE + DAY_MS);
     assert.equal(res.status, 'resolved');
     assert.equal(res.outcome, 'NO');
   });
 
   it('pends before the deadline', () => {
-    const feed = shapeResolutionFeed(COMMODITY_FEED, { data: commoditiesFixture() });
+    const feed = shapeResolutionFeed(COMMODITY_FEED, { _seed: { fetchedAt: NOW }, data: commoditiesFixture() });
     const res = resolveHardSpec(wtiBet(), feed, [], NOW + DAY_MS);
     assert.equal(res.status, 'pending');
+  });
+
+  it('does NOT resolve a stale kept-warm quote as a deadline price (P2 regression)', () => {
+    // Quote fetched two days BEFORE the deadline (fetch-failure keep-warm) —
+    // must pend, not record a false YES against a pre-deadline price.
+    const stale = shapedFeed(69.0, '2026-07-14T06:00:00Z'); // 2 days pre-deadline
+    const res = resolveHardSpec(wtiBet(), stale, [], DEADLINE + DAY_MS);
+    assert.equal(res.status, 'pending');
+    assert.equal(res.evidence.reason, 'value_source_not_settled');
+  });
+
+  it('VOIDs a quote that never freshens past the settlement grace', () => {
+    const stale = shapedFeed(69.0, '2026-07-14T06:00:00Z');
+    const res = resolveHardSpec(wtiBet(), stale, [], DEADLINE + 11 * DAY_MS);
+    assert.equal(res.outcome, 'VOID');
   });
 });
 

--- a/tests/bet-templates-commodities.test.mjs
+++ b/tests/bet-templates-commodities.test.mjs
@@ -1,0 +1,120 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { generateBets } from '../scripts/_bet-templates.mjs';
+import { COMMODITY_BET_TEMPLATES, COMMODITY_FEED } from '../scripts/_bet-templates-commodities.mjs';
+import { parseMetricKey, resolveHardSpec } from '../scripts/_forecast-resolution-eval.mjs';
+import { RESOLUTION_FEED_KEYS } from '../scripts/_forecast-resolution.mjs';
+import { shapeResolutionFeed } from '../scripts/seed-forecast-resolutions.mjs';
+import { buildBetsSnapshot } from '../scripts/seed-forecast-bets.mjs';
+import { EIA_PETROLEUM_FEED } from '../scripts/_bet-templates-energy.mjs';
+
+const NOW = Date.parse('2026-07-12T00:00:00Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEADLINE = NOW + 4 * DAY_MS; // 2026-07-16
+
+// Unwrapped shape (the seeder unwraps {_seed,data} before templates see it).
+function commoditiesFixture(overrides = {}) {
+  return {
+    quotes: [
+      { symbol: 'CL=F', name: 'Crude Oil WTI', price: 71.41, change: -0.93 }, // falling
+      { symbol: 'BZ=F', name: 'Brent Crude', price: 76.01, change: 0.5 },     // rising
+      { symbol: 'NG=F', name: 'Natural Gas', price: 2.94, change: -2.39 },
+      { symbol: 'GC=F', name: 'Gold', price: 4113.7, change: -0.65 },
+      ...(overrides.extraQuotes || []),
+    ],
+  };
+}
+
+describe('commodity bet templates (fast-resolving lane)', () => {
+  it('generates one crisp, resolver-valid bet per commodity', () => {
+    const bets = generateBets(COMMODITY_BET_TEMPLATES, { [COMMODITY_FEED]: commoditiesFixture() }, NOW);
+    assert.equal(bets.length, 4);
+    for (const bet of bets) {
+      assert.equal(bet.domain, 'market');
+      assert.equal(bet.generationOrigin, 'bet_engine');
+      assert.equal(bet.resolution.sourceFeed, COMMODITY_FEED);
+      assert.equal(bet.resolution.window, 'at-deadline');
+      assert.equal(bet.resolution.deadline, DEADLINE);
+      const parsed = parseMetricKey(bet.resolution.metricKey);
+      assert.ok(parsed, `did not parse: ${bet.resolution.metricKey}`);
+      assert.equal(parsed.fn, 'price');
+      assert.equal(parsed.field, 'symbol');
+      assert.ok(RESOLUTION_FEED_KEYS.has(bet.resolution.sourceFeed));
+    }
+  });
+
+  it('frames direction from the latest daily change', () => {
+    const bets = generateBets(COMMODITY_BET_TEMPLATES, { [COMMODITY_FEED]: commoditiesFixture() }, NOW);
+    const wti = bets.find((b) => b.resolution.metricKey.includes('symbol==CL=F'));
+    // change -0.93 → falling → threshold below baseline 71.41 by 2.5% (2-dp)
+    assert.equal(wti.resolution.baselineValue, 71.41);
+    assert.equal(wti.resolution.threshold, 69.62); // 71.41 - 1.78525 → 69.62
+    assert.match(wti.question, /WTI crude oil price fall to at most 69\.62 USD\/bbl by 2026-07-16/);
+
+    const brent = bets.find((b) => b.resolution.metricKey.includes('symbol==BZ=F'));
+    // change +0.5 → rising → threshold above baseline
+    assert.ok(brent.resolution.threshold > brent.resolution.baselineValue);
+    assert.match(brent.question, /Brent crude oil price rise to at least/);
+  });
+
+  it('emits no bet for a zero/negative quote or an absent symbol', () => {
+    const bad = generateBets(COMMODITY_BET_TEMPLATES, {
+      [COMMODITY_FEED]: { quotes: [{ symbol: 'CL=F', price: 0, change: 0 }] },
+    }, NOW);
+    assert.equal(bad.length, 0);
+    const missing = generateBets(COMMODITY_BET_TEMPLATES, { [COMMODITY_FEED]: { quotes: [] } }, NOW);
+    assert.equal(missing.length, 0);
+  });
+});
+
+describe('shapeResolutionFeed exposes the nested commodities quotes array', () => {
+  it('unwraps {_seed,data:{quotes}} to the quotes array so price() resolves', () => {
+    const shaped = shapeResolutionFeed(COMMODITY_FEED, { _seed: {}, data: commoditiesFixture() });
+    assert.ok(Array.isArray(shaped));
+    assert.equal(shaped.find((q) => q.symbol === 'CL=F').price, 71.41);
+  });
+});
+
+describe('commodity bets resolve end-to-end (no settlement gate — live price)', () => {
+  function wtiBet() {
+    const bets = generateBets(COMMODITY_BET_TEMPLATES, { [COMMODITY_FEED]: commoditiesFixture() }, NOW);
+    const bet = bets.find((b) => b.resolution.metricKey.includes('symbol==CL=F'));
+    return { spec: bet.resolution, generationOrigin: bet.generationOrigin, generatedAt: NOW };
+  }
+
+  it('resolves YES when the price falls past the threshold at the deadline', () => {
+    const feed = shapeResolutionFeed(COMMODITY_FEED, { data: { quotes: [{ symbol: 'CL=F', price: 69.0, change: 0 }] } });
+    const res = resolveHardSpec(wtiBet(), feed, [], DEADLINE + DAY_MS);
+    assert.equal(res.status, 'resolved');
+    assert.equal(res.outcome, 'YES'); // 69.0 <= 69.62475 (falling bet)
+  });
+
+  it('resolves NO when the price stays above the threshold', () => {
+    const feed = shapeResolutionFeed(COMMODITY_FEED, { data: { quotes: [{ symbol: 'CL=F', price: 70.5, change: 0 }] } });
+    const res = resolveHardSpec(wtiBet(), feed, [], DEADLINE + DAY_MS);
+    assert.equal(res.status, 'resolved');
+    assert.equal(res.outcome, 'NO');
+  });
+
+  it('pends before the deadline', () => {
+    const feed = shapeResolutionFeed(COMMODITY_FEED, { data: commoditiesFixture() });
+    const res = resolveHardSpec(wtiBet(), feed, [], NOW + DAY_MS);
+    assert.equal(res.status, 'pending');
+  });
+});
+
+describe('seeder emits both energy and commodity bets', () => {
+  it('combines families; commodity bets use the honest thin-history prior', () => {
+    const snap = buildBetsSnapshot({
+      [COMMODITY_FEED]: { _seed: {}, data: commoditiesFixture() },
+    }, NOW, {});
+    // 4 commodity bets (no energy feed provided here)
+    assert.equal(snap.predictions.length, 4);
+    for (const bet of snap.predictions) {
+      assert.equal(bet.domain, 'market');
+      assert.equal(bet.probability, 0.4); // commodity series empty → prior
+    }
+    assert.ok(snap.predictions.some((b) => b.resolution.metricKey.includes('symbol==CL=F')));
+  });
+});

--- a/tests/bet-templates-commodities.test.mjs
+++ b/tests/bet-templates-commodities.test.mjs
@@ -5,7 +5,7 @@ import { generateBets } from '../scripts/_bet-templates.mjs';
 import { COMMODITY_BET_TEMPLATES, COMMODITY_FEED } from '../scripts/_bet-templates-commodities.mjs';
 import { parseMetricKey, resolveHardSpec } from '../scripts/_forecast-resolution-eval.mjs';
 import { RESOLUTION_FEED_KEYS } from '../scripts/_forecast-resolution.mjs';
-import { shapeResolutionFeed } from '../scripts/seed-forecast-resolutions.mjs';
+import { shapeResolutionFeed, ingestHistory, samplePendingEntries, resolveDueEntries } from '../scripts/seed-forecast-resolutions.mjs';
 import { buildBetsSnapshot } from '../scripts/seed-forecast-bets.mjs';
 import { EIA_PETROLEUM_FEED } from '../scripts/_bet-templates-energy.mjs';
 
@@ -144,7 +144,7 @@ describe('commodity bets resolve end-to-end (settlement-gated on quote freshness
 describe('seeder emits both energy and commodity bets', () => {
   it('combines families; commodity bets use the honest thin-history prior', () => {
     const snap = buildBetsSnapshot({
-      [COMMODITY_FEED]: { _seed: {}, data: commoditiesFixture() },
+      [COMMODITY_FEED]: { _seed: { fetchedAt: NOW }, data: commoditiesFixture() },
     }, NOW, {});
     // 4 commodity bets (no energy feed provided here)
     assert.equal(snap.predictions.length, 4);
@@ -153,5 +153,62 @@ describe('seeder emits both energy and commodity bets', () => {
       assert.equal(bet.probability, 0.4); // commodity series empty → prior
     }
     assert.ok(snap.predictions.some((b) => b.resolution.metricKey.includes('symbol==CL=F')));
+  });
+
+  it('does NOT generate a commodity bet from a stale kept-warm envelope (P2 #3)', () => {
+    const stale = { [COMMODITY_FEED]: { _seed: { fetchedAt: NOW - 6 * DAY_MS }, data: commoditiesFixture() } };
+    assert.equal(buildBetsSnapshot(stale, NOW, {}).predictions.length, 0); // 6d > 5d cap → dropped
+    const fresh = { [COMMODITY_FEED]: { _seed: { fetchedAt: NOW - DAY_MS }, data: commoditiesFixture() } };
+    assert.equal(buildBetsSnapshot(fresh, NOW, {}).predictions.length, 4);
+  });
+});
+
+describe('commodity resolution hardening (review fixes)', () => {
+  function wtiEntryInLedger() {
+    const snap = buildBetsSnapshot({ [COMMODITY_FEED]: { _seed: { fetchedAt: NOW }, data: commoditiesFixture() } }, NOW, {});
+    const ledger = ingestHistory({}, [snap], NOW);
+    const key = Object.keys(ledger).find((k) => ledger[k].spec?.metricKey?.includes('symbol==CL=F'));
+    return { ledger, key, deadline: ledger[key].deadline };
+  }
+
+  it('never prefers a stale post-deadline sample over the later fresh quote (P1 two-cycle)', () => {
+    const { ledger, key, deadline } = wtiEntryInLedger();
+    // Cycle 1: post-deadline but the feed still holds a STALE quote (asOf 2 days
+    // pre-deadline) whose price 69.0 would score YES.
+    const cycle1 = deadline + DAY_MS;
+    const staleFeed = { [COMMODITY_FEED]: shapeResolutionFeed(COMMODITY_FEED, {
+      _seed: { fetchedAt: deadline - 2 * DAY_MS },
+      data: { quotes: [{ symbol: 'CL=F', price: 69.0, change: -0.5 }] },
+    }) };
+    samplePendingEntries(ledger, staleFeed, cycle1);
+    resolveDueEntries(ledger, staleFeed, cycle1);
+    assert.equal(ledger[key].status, 'pending'); // gate held the stale cycle
+
+    // Cycle 2: the feed freshens (asOf post-deadline) to 70.5, which scores NO.
+    const cycle2 = deadline + 2 * DAY_MS;
+    const freshFeed = { [COMMODITY_FEED]: shapeResolutionFeed(COMMODITY_FEED, {
+      _seed: { fetchedAt: cycle2 },
+      data: { quotes: [{ symbol: 'CL=F', price: 70.5, change: -0.5 }] },
+    }) };
+    samplePendingEntries(ledger, freshFeed, cycle2);
+    resolveDueEntries(ledger, freshFeed, cycle2);
+    assert.equal(ledger[key].status, 'resolved');
+    // Must reflect the FRESH 70.5 (NO), not the stored stale 69.0 (YES).
+    assert.equal(ledger[key].outcome, 'NO');
+  });
+
+  it('pends (not VOIDs) when a partial refresh drops the symbol, VOIDs after grace (P2 #2)', () => {
+    const { ledger, key, deadline } = wtiEntryInLedger();
+    const entry = { spec: ledger[key].spec, generatedAt: NOW };
+    // Feed present + fresh, but CL=F is absent (partial refresh dropped it).
+    const partial = shapeResolutionFeed(COMMODITY_FEED, {
+      _seed: { fetchedAt: deadline + DAY_MS },
+      data: { quotes: [{ symbol: 'BZ=F', price: 76 }] },
+    });
+    const pend = resolveHardSpec(entry, partial, [], deadline + DAY_MS);
+    assert.equal(pend.status, 'pending');
+    assert.equal(pend.evidence.reason, 'value_source_record_missing');
+    const voided = resolveHardSpec(entry, partial, [], deadline + 11 * DAY_MS);
+    assert.equal(voided.outcome, 'VOID');
   });
 });


### PR DESCRIPTION
## Why

The energy pilot's EIA bets resolve **weekly** (deadline 2026-07-19), so `bet_engine` scorecard evidence was a week out. This adds a **fast lane** on the daily-updating commodities feed — bets resolve within the week (~4-day horizon → **2026-07-16**) — so Gate-1 evidence lands sooner, and it proves the engine generalizes to a second feed with a different metric fn.

## What

- **`_bet-templates-commodities.mjs`** — bets over `market:commodities-bootstrap:v1` for WTI (`CL=F`), Brent (`BZ=F`), nat-gas (`NG=F`), gold (`GC=F`). Directional (from the daily `change`), 2.5% threshold, 2-decimal prices, resolvable via the resolver's existing `price(symbol==X)` fn.
- **`shapeResolutionFeed`** — the commodities feed is `{_seed, data:{quotes:[...]}}`, and the eval's `iterateRecords` only descends into *array* children, so the doubly-nested `quotes` were unreadable. Now exposed as the array. **This also unblocks the pre-existing market commodity-price forecast path** (it had the same read problem).
- **`seed-forecast-bets.mjs`** — reads both feeds, emits both families. Commodity bets use the honest thin-history prior (`0.4`) until their own series accrues (Phase 2's ensemble replaces the probability regardless).

## Evidence

- **8 new tests** (templates, the shaper unwrap, and end-to-end YES/NO/pending through the real resolver). 870/870 forecast+bet suites green; api tsc exit 0.
- **Live prod preview** — 8 bets total (4 energy @07-19, 4 commodity @07-16), all crisp + resolvable:
  - Will the WTI crude oil price fall to at most 69.62 USD/bbl by 2026-07-16?
  - Will the US natural gas price fall to at most 2.87 USD/MMBtu by 2026-07-16?
  - Will the gold price fall to at most 4010.86 USD/oz by 2026-07-16?

## Scope

Shadow lane only (invisible to users; held out of the skill Brier). Short-horizon price bets are ~coin-flip on direction by design — Gate 1 tests *resolves + crisp + not-silly*, not skill; calibration is Phase 2. A per-symbol commodity base-rate accumulator is a fast-follow (they're at the prior until then).

Refs #5233, #4930

https://claude.ai/code/session_01StNurp4TGC3JLHbTtKJhbp