### PR TITLE
fix(sentry): skip client-synthesized session-degraded 503s (#5245)

### DIFF
--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -53,8 +53,21 @@ export function _setTestProviders(
   _testProviders = p;
 }
 
-function reportServerError(res: Response, input: RequestInfo | URL): void {
+// Exported for tests (tests/premium-fetch.test.mts) — the `enqueue` parameter
+// exists only so tests can observe captures without loading the Sentry SDK;
+// production call sites never pass it.
+export function reportServerError(
+  res: Response,
+  input: RequestInfo | URL,
+  enqueue: typeof enqueueSentryCall = enqueueSentryCall,
+): void {
   if (res.status < 500) return;
+  // wm-session's dead-session cooldown synthesizes a local 503 (marked with
+  // X-Wm-Session-Degraded) for every suppressed anonymous call — it never
+  // left the browser, so reporting it here floods one `API 503:` issue per
+  // widget endpoint and drowns the genuine origin-5xx canary (#5245).
+  // markWmSessionDead() captures the episode once instead.
+  if (res.headers.get('X-Wm-Session-Degraded') === '1') return;
   try {
     const href = input instanceof Request ? input.url : String(input);
     const path = new URL(href, globalThis.location?.href ?? 'https://worldmonitor.app').pathname;
@@ -68,7 +81,7 @@ function reportServerError(res: Response, input: RequestInfo | URL): void {
     const level: 'warning' | 'error' = isCloudflareEdgeError ? 'warning' : 'error';
     const tags = { kind: isCloudflareEdgeError ? 'api_cf_5xx' : 'api_5xx' };
     const extra = { path, status: res.status };
-    enqueueSentryCall((s) => s.captureMessage(message, { level, tags, extra }));
+    enqueue((s) => s.captureMessage(message, { level, tags, extra }));
   } catch { /* ignore URL parse errors */ }
 }
 

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -14,6 +14,7 @@
 
 import { getCanonicalApiOrigin, toApiUrl } from './runtime';
 import { PREMIUM_RPC_PATHS } from '@/shared/premium-paths';
+import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 
 const STORAGE_KEY = 'wm-session-exp';
 // Refresh well before expiry so a half-loaded page doesn't fail mid-flight.
@@ -39,6 +40,7 @@ let sessionGeneration = 0;
 let interceptorInstalled = false;
 let nativeSessionFetch: typeof fetch | null = null;
 let sessionDeadUntil = 0;
+let sentryEnqueue: typeof enqueueSentryCall = enqueueSentryCall;
 
 export function isWmSessionDead(): boolean {
   if (sessionDeadUntil <= Date.now()) {
@@ -55,6 +57,13 @@ function markWmSessionDead(): void {
   try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
   if (alreadyDead) return;
   console.warn('[wm-session] refreshed HttpOnly session cookie was still rejected; suppressing anonymous API calls briefly');
+  // One warning per degraded episode — reportServerError (premium-fetch.ts)
+  // deliberately skips the synthetic X-Wm-Session-Degraded 503s, so this is
+  // the only remote signal that anonymous browsing is degraded (#5245).
+  sentryEnqueue((s) => s.captureMessage(
+    'wm-session dead: anonymous API calls suppressed',
+    { level: 'warning', tags: { kind: 'wm_session_dead' } },
+  ));
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
     window.dispatchEvent(new Event(WM_SESSION_DEGRADED_EVENT));
   }
@@ -168,6 +177,13 @@ export function __resetWmSessionForTests(): void {
   sessionGeneration = 0;
   interceptorInstalled = false;
   sessionDeadUntil = 0;
+  sentryEnqueue = enqueueSentryCall;
+}
+
+// Test-only: observe the once-per-episode dead-session Sentry capture without
+// loading the SDK. Reset back to the real enqueue by __resetWmSessionForTests.
+export function __setWmSessionSentryEnqueueForTests(fn: typeof enqueueSentryCall): void {
+  sentryEnqueue = fn;
 }
 
 // Install a one-shot fetch wrapper that includes HttpOnly session cookies on

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -60,10 +60,14 @@ function markWmSessionDead(): void {
   // One warning per degraded episode — reportServerError (premium-fetch.ts)
   // deliberately skips the synthetic X-Wm-Session-Degraded 503s, so this is
   // the only remote signal that anonymous browsing is degraded (#5245).
-  sentryEnqueue((s) => s.captureMessage(
-    'wm-session dead: anonymous API calls suppressed',
-    { level: 'warning', tags: { kind: 'wm_session_dead' } },
-  ));
+  // Guarded: a telemetry throw must never skip the degraded-event dispatch
+  // below, nor turn the interceptor's recovery return into a rejection.
+  try {
+    sentryEnqueue((s) => s.captureMessage(
+      'wm-session dead: anonymous API calls suppressed',
+      { level: 'warning', tags: { kind: 'wm_session_dead' } },
+    ));
+  } catch { /* best-effort telemetry */ }
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
     window.dispatchEvent(new Event(WM_SESSION_DEGRADED_EVENT));
   }

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -14,7 +14,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, it, before, after, mock } from 'node:test';
-import { premiumFetch, _setTestProviders } from '@/services/premium-fetch';
+import { premiumFetch, reportServerError, _setTestProviders } from '@/services/premium-fetch';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -315,5 +315,48 @@ describe('premiumFetch', () => {
     assert.equal(res.status, 200);
     assert.equal(tokenCalls, 2, 'retried once, then gives up — no infinite loop');
     assert.equal(sentHeaders().get('Authorization'), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reportServerError — the Sentry origin-5xx surface.
+// ---------------------------------------------------------------------------
+describe('reportServerError', () => {
+  function makeSpy() {
+    const calls: Array<{ msg: string; ctx: { level: string; tags: Record<string, string> } }> = [];
+    const enqueue = ((fn: (s: unknown) => void) => {
+      fn({ captureMessage: (msg: string, ctx: { level: string; tags: Record<string, string> }) => { calls.push({ msg, ctx }); } });
+    }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+    return { calls, enqueue };
+  }
+
+  it('captures a genuine origin 503 at error level with kind api_5xx', () => {
+    const { calls, enqueue } = makeSpy();
+    reportServerError(new Response('oops', { status: 503 }), PUBLIC_TARGET, enqueue);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].msg, 'API 503: /api/economic/v1/get-fred-series-batch');
+    assert.equal(calls[0].ctx.level, 'error');
+    assert.equal(calls[0].ctx.tags.kind, 'api_5xx');
+  });
+
+  it('keeps Cloudflare edge 52x at warning with kind api_cf_5xx', () => {
+    const { calls, enqueue } = makeSpy();
+    reportServerError(new Response('cf', { status: 521 }), PUBLIC_TARGET, enqueue);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].ctx.level, 'warning');
+    assert.equal(calls[0].ctx.tags.kind, 'api_cf_5xx');
+  });
+
+  it('skips the client-synthesized session-degraded 503 (X-Wm-Session-Degraded)', () => {
+    // wm-session's dead-session cooldown fabricates this Response locally —
+    // it never left the browser, so it must NOT be reported as an origin 5xx
+    // (#5245: 17 per-endpoint `API 503:` issues flooded after #5219 shipped).
+    const { calls, enqueue } = makeSpy();
+    const res = new Response(JSON.stringify({ error: 'Anonymous session temporarily unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', 'X-Wm-Session-Degraded': '1' },
+    });
+    reportServerError(res, PUBLIC_TARGET, enqueue);
+    assert.equal(calls.length, 0, 'synthetic degraded 503 must not be reported as an origin 5xx');
   });
 });

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -410,6 +410,48 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     ]);
   });
 
+  it('captures ONE wm_session_dead Sentry warning per degraded episode, not one per suppressed call', async () => {
+    // reportServerError (premium-fetch.ts) deliberately skips the synthetic
+    // X-Wm-Session-Degraded 503s, so this once-per-episode capture is the
+    // only remote signal that anonymous browsing is degraded (#5245).
+    memoryStorage.clear();
+
+    const captures: Array<{ msg: string; ctx: { level?: string; tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({ captureMessage: (msg: string, ctx: { level?: string; tags?: Record<string, string> }) => { captures.push({ msg, ctx }); } });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('still-rejected', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      // First call trips the failed recovery → markWmSessionDead().
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      // Later calls are suppressed by the cooldown — no additional captures.
+      const s1 = await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      const s2 = await wrappedFetch('https://api.worldmonitor.app/api/supply-chain/v1/get-shipping-stress');
+      assert.equal(s1.status, 503);
+      assert.equal(s2.status, 503);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(captures.length, 1, 'exactly one Sentry capture per dead-session episode');
+    assert.equal(captures[0].msg, 'wm-session dead: anonymous API calls suppressed');
+    assert.equal(captures[0].ctx.level, 'warning');
+    assert.equal(captures[0].ctx.tags?.kind, 'wm_session_dead');
+  });
+
   it('single-flights concurrent 401 recovery so only one retry verifies the mint', async () => {
     memoryStorage.clear();
     let gatedAttempts = 0;

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -452,6 +452,51 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     assert.equal(captures[0].ctx.tags?.kind, 'wm_session_dead');
   });
 
+  it('a throwing Sentry enqueue never skips the degraded-event dispatch nor rejects the recovery return', async () => {
+    // greptile P2 on PR #5247: the capture sits upstream of the
+    // WM_SESSION_DEGRADED_EVENT dispatch AND inside the interceptor's 401
+    // recovery path — an unguarded throw would both hide the UI toast and
+    // turn the wrapped fetch into a rejection instead of returning the 401.
+    memoryStorage.clear();
+    mod.__setWmSessionSentryEnqueueForTests((() => {
+      throw new Error('sdk exploded');
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+
+    // window === globalThis in this harness, and Node's main-thread
+    // globalThis is not an EventTarget — stub dispatchEvent so the module's
+    // `typeof window.dispatchEvent === 'function'` guard takes the dispatch
+    // branch and we can observe it.
+    let degradedEvents = 0;
+    const g = globalThis as unknown as { dispatchEvent?: (ev: Event) => boolean };
+    g.dispatchEvent = (ev: Event) => {
+      if (ev.type === mod.WM_SESSION_DEGRADED_EVENT) degradedEvents += 1;
+      return true;
+    };
+
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('still-rejected', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const resp = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      assert.equal(resp.status, 401, 'recovery must return the server 401, not reject');
+    } finally {
+      console.warn = originalWarn;
+      delete g.dispatchEvent;
+    }
+
+    assert.equal(degradedEvents, 1, 'degraded event must still dispatch when telemetry throws');
+  });
+
   it('single-flights concurrent 401 recovery so only one retry verifies the mint', async () => {
     memoryStorage.clear();
     let gatedAttempts = 0;


### PR DESCRIPTION
## Summary

- Closes #5245. Since #5219, `sessionDegradedResponse()` (`src/services/wm-session.ts`) fabricates a local `503 {"error":"Anonymous session temporarily unavailable"}` for every anonymous API call during the 15-minute dead-session cooldown. `reportServerError` (`src/services/premium-fetch.ts`) reported each one to Sentry as an origin 5xx — flooding 17 per-endpoint `API 503:` issues (~2.6k error events/day from ~120 users; first event 10 minutes after the #5219 merge) and drowning the genuine origin-outage canary. Axiom gateway telemetry shows ~zero real 503s over the same window (3 rows / 14 days).
- `reportServerError` now skips responses carrying the `X-Wm-Session-Degraded: 1` marker (they never left the browser). Genuine origin 5xx and the Cloudflare 52x warning downgrade are unchanged (lock-in tests added).
- `markWmSessionDead()` now captures **one** `wm_session_dead` warning per degraded episode via the existing once-per-episode guard, so the underlying anon-session mint-failure phenomenon (#5207) keeps accurate remote visibility (per-episode user counts, single Sentry issue) instead of ×17 per-endpoint error inflation.

## Test plan

- [x] New failing-first tests: synthetic degraded 503 is NOT reported (`tests/premium-fetch.test.mts`); exactly one `wm_session_dead` capture per episode across multiple suppressed calls (`tests/wm-session-auto-refresh.test.mts`)
- [x] Lock-in tests: genuine 503 stays `error`/`api_5xx`; CF 521 stays `warning`/`api_cf_5xx`
- [x] Full gate: typecheck + typecheck:api, biome, cjs syntax, lint:md, version:check, edge-bundle, edge-functions (228/228), `test:data` split-run (5,612 + 9,576 tests, 0 fail), `VITE_VARIANT=full vite build`

## Post-deploy

The 17 flooded Sentry issues are deliberately left open (chronic #5227 platform-503 trickle shares the titles; resolving would churn false regression emails) — verify the flood drains after this deploys, then consider archive-until-escalating for the chronic ones.

https://claude.ai/code/session_01XVfoi1HBiiFSvFx7rQCjSo