### PR TITLE
perf(bootstrap): restore CDN cache shield for tier reads (#5249)

### DIFF
--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -173,6 +173,14 @@ function assertSharedCacheHeaders(resp) {
   assert.match(resp.headers.get('cdn-cache-control') || '', /\b(public|s-maxage)\b/i);
 }
 
+function assertPublicCorsHeaders(resp) {
+  // Public seed payload → ACAO:* with no Vary: Origin and no credentials, so the
+  // shared CDN stores one entry per URL and no origin can pin an echoed ACAO.
+  assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+  assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+  assert.equal(resp.headers.get('vary'), null);
+}
+
 function assertNonSharedCacheHeaders(resp) {
   assert.equal(resp.headers.get('cdn-cache-control'), null);
   assert.equal(resp.headers.get('vercel-cdn-cache-control'), null);
@@ -430,6 +438,7 @@ test('anonymous fast-tier bootstrap (no credentials) is CDN-cacheable — restor
     assert.equal(resp.status, 200);
     assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);
     assertSharedCacheHeaders(resp);
+    assertPublicCorsHeaders(resp);
     // fast tier shields at s-maxage=600; browser Cache-Control stays private
     // (max-age only — no public/s-maxage) to avoid CF ACAO mispinning.
     assert.match(resp.headers.get('cdn-cache-control') || '', /s-maxage=600/);
@@ -437,6 +446,21 @@ test('anonymous fast-tier bootstrap (no credentials) is CDN-cacheable — restor
     // Public path short-circuits before any key/entitlement validation.
     assert.equal(calls.some((call) => call.url.endsWith('/api/internal-validate-api-key')), false);
     assert.equal(calls.some((call) => call.url.endsWith('/api/internal-entitlements')), false);
+  });
+});
+
+test('HEAD tier bootstrap is not the public path (no unshielded Redis read)', async () => {
+  // A HEAD read must not qualify for the cacheable public-tier path, or it would
+  // run the full registry Redis pipeline to build a body it cannot return.
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
+    const resp = await handler(
+      new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast', { method: 'HEAD' }),
+    );
+
+    assert.equal(resp.status, 401);
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
+    // Rejected before any Redis GET pipeline runs.
+    assert.equal(calls.some((call) => call.url.startsWith('https://upstash.test')), false);
   });
 });
 

--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -17,7 +17,14 @@ function snapshotEnv(names) {
   };
 }
 
-async function withMockedBootstrapAuth({ entitlement, userKeyResponse = 'valid', rateLimitResults, rateLimitStatus }, fn) {
+async function withMockedBootstrapAuth({
+  entitlement,
+  userKeyResponse = 'valid',
+  rateLimitResults,
+  rateLimitStatus,
+  bootstrapPipelineStatus,
+  bootstrapPipelineBody,
+}, fn) {
   const restoreEnv = snapshotEnv([
     'CONVEX_SITE_URL',
     'CONVEX_SERVER_SHARED_SECRET',
@@ -55,7 +62,19 @@ async function withMockedBootstrapAuth({ entitlement, userKeyResponse = 'valid',
         });
       }
       if (commands[0]?.[0] === 'GET') {
-        return new Response(JSON.stringify([{ result: null }]), {
+        if (bootstrapPipelineBody !== undefined) {
+          return new Response(JSON.stringify(bootstrapPipelineBody), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (bootstrapPipelineStatus) {
+          return new Response(JSON.stringify({ error: 'redis unavailable' }), {
+            status: bootstrapPipelineStatus,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify(commands.map(() => ({ result: null }))), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
@@ -160,6 +179,13 @@ function makeWeatherBootstrapRequest(headers = {}) {
 
 function makeTierBootstrapRequest(tier = 'fast', headers = {}) {
   return new Request(`https://api.worldmonitor.app/api/bootstrap?tier=${tier}`, {
+    method: 'GET',
+    headers,
+  });
+}
+
+function makePublicTierBootstrapRequest(tier = 'fast', headers = {}) {
+  return new Request(`https://api.worldmonitor.app/api/bootstrap?tier=${tier}&public=1`, {
     method: 'GET',
     headers,
   });
@@ -427,13 +453,13 @@ test('anonymous weather-only bootstrap (no key header) keeps the shared public c
   });
 });
 
-test('anonymous fast-tier bootstrap (no credentials) is CDN-cacheable — restores the #5249 shield', async () => {
+test('explicit public fast-tier bootstrap is CDN-cacheable — restores the #5249 shield', async () => {
   // The regression: dashboard boots carry an anonymous wm-session cookie, so
   // successful tier reads returned no-store and every boot re-read the full
   // registry from Upstash. A credential-less tier read serves the shared public
   // seed payload and MUST carry the CDN shared-cache shield.
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
-    const resp = await handler(makeTierBootstrapRequest('fast'));
+    const resp = await handler(makePublicTierBootstrapRequest('fast'));
 
     assert.equal(resp.status, 200);
     assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);
@@ -454,7 +480,7 @@ test('HEAD tier bootstrap is not the public path (no unshielded Redis read)', as
   // run the full registry Redis pipeline to build a body it cannot return.
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
     const resp = await handler(
-      new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast', { method: 'HEAD' }),
+      new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1', { method: 'HEAD' }),
     );
 
     assert.equal(resp.status, 401);
@@ -464,9 +490,9 @@ test('HEAD tier bootstrap is not the public path (no unshielded Redis read)', as
   });
 });
 
-test('anonymous slow-tier bootstrap (no credentials) is CDN-cacheable with the slow TTL', async () => {
+test('explicit public slow-tier bootstrap is CDN-cacheable with the slow TTL', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
-    const resp = await handler(makeTierBootstrapRequest('slow'));
+    const resp = await handler(makePublicTierBootstrapRequest('slow'));
 
     assert.equal(resp.status, 200);
     assertSharedCacheHeaders(resp);
@@ -474,9 +500,69 @@ test('anonymous slow-tier bootstrap (no credentials) is CDN-cacheable with the s
   });
 });
 
-test('session-cookie tier bootstrap stays no-store (cookie disqualifies the public path)', async () => {
-  // A cookie-bearing tier read can carry session scope, so it keeps no-store —
-  // this is exactly why the client now sends tier fetches with credentials:'omit'.
+test('legacy anonymous tier URL remains credentialed and non-cacheable', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(makeTierBootstrapRequest('fast'));
+
+    assert.equal(resp.status, 401);
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
+    assertNonSharedCacheHeaders(resp);
+  });
+});
+
+test('explicit public tier URL keeps public semantics even when credentials are attached', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
+    const resp = await handler(makePublicTierBootstrapRequest('fast', {
+      'X-WorldMonitor-Key': ENTERPRISE_KEY,
+    }));
+
+    assert.equal(resp.status, 200);
+    assertSharedCacheHeaders(resp);
+    assertPublicCorsHeaders(resp);
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-validate-api-key')), false);
+  });
+});
+
+test('public tier Redis outage returns retryable 503 without a CDN cache header', async () => {
+  await withMockedBootstrapAuth({
+    entitlement: activeApiEntitlement(),
+    bootstrapPipelineStatus: 500,
+  }, async () => {
+    const resp = await handler(makePublicTierBootstrapRequest('fast'));
+    const body = await resp.json();
+
+    assert.equal(resp.status, 503);
+    assert.equal(resp.headers.get('retry-after'), '5');
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
+    assert.equal(resp.headers.get('cdn-cache-control'), null);
+    assert.equal(resp.headers.get('vercel-cdn-cache-control'), null);
+    assertPublicCorsHeaders(resp);
+    assert.equal(body.error, 'Bootstrap service temporarily unavailable');
+  });
+});
+
+for (const [label, bootstrapPipelineBody] of [
+  ['truncated response', []],
+  ['per-command error', [{ error: 'upstream command failed' }]],
+]) {
+  test(`public tier Redis ${label} returns retryable 503 without a CDN cache header`, async () => {
+    await withMockedBootstrapAuth({
+      entitlement: activeApiEntitlement(),
+      bootstrapPipelineBody,
+    }, async () => {
+      const resp = await handler(makePublicTierBootstrapRequest('fast'));
+
+      assert.equal(resp.status, 503);
+      assert.equal(resp.headers.get('cache-control'), 'no-store');
+      assert.equal(resp.headers.get('cdn-cache-control'), null);
+      assertPublicCorsHeaders(resp);
+    });
+  });
+}
+
+test('session-cookie legacy tier bootstrap stays no-store', async () => {
+  // The legacy tier URL remains credentialed and cannot share the explicit
+  // public=1 cache entry.
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
     const { token } = await issueSessionToken();
     const resp = await handler(makeTierBootstrapRequest('fast', { Cookie: `wm-session=${token}` }));
@@ -486,7 +572,7 @@ test('session-cookie tier bootstrap stays no-store (cookie disqualifies the publ
   });
 });
 
-test('enterprise-key tier bootstrap stays no-store (key auth is never shared-cacheable)', async () => {
+test('enterprise-key legacy tier bootstrap stays no-store (key auth is never shared-cacheable)', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
     const resp = await handler(makeTierBootstrapRequest('fast', { 'X-WorldMonitor-Key': ENTERPRISE_KEY }));
 
@@ -500,7 +586,7 @@ test('tier bootstrap with extra params is not treated as the public path', async
   // back to key auth (401 here) so we never widen the cacheable key space.
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
     const resp = await handler(
-      new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast&keys=marketQuotes', { method: 'GET' }),
+      new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1&keys=marketQuotes', { method: 'GET' }),
     );
 
     assert.equal(resp.status, 401);
@@ -510,7 +596,7 @@ test('tier bootstrap with extra params is not treated as the public path', async
 
 test('unknown tier value does not qualify for the public path', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
-    const resp = await handler(makeTierBootstrapRequest('bogus'));
+    const resp = await handler(makePublicTierBootstrapRequest('bogus'));
 
     assert.equal(resp.status, 401);
     assert.equal(resp.headers.get('cache-control'), 'no-store');

--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -158,6 +158,21 @@ function makeWeatherBootstrapRequest(headers = {}) {
   });
 }
 
+function makeTierBootstrapRequest(tier = 'fast', headers = {}) {
+  return new Request(`https://api.worldmonitor.app/api/bootstrap?tier=${tier}`, {
+    method: 'GET',
+    headers,
+  });
+}
+
+function assertSharedCacheHeaders(resp) {
+  // Tier responses intentionally avoid public/s-maxage in Cache-Control (CF in
+  // front of api.worldmonitor.app would mispin ACAO) and shield via Vercel's
+  // CDN-Cache-Control instead.
+  assert.ok(resp.headers.get('cdn-cache-control'));
+  assert.match(resp.headers.get('cdn-cache-control') || '', /\b(public|s-maxage)\b/i);
+}
+
 function assertNonSharedCacheHeaders(resp) {
   assert.equal(resp.headers.get('cdn-cache-control'), null);
   assert.equal(resp.headers.get('vercel-cdn-cache-control'), null);
@@ -401,5 +416,79 @@ test('anonymous weather-only bootstrap (no key header) keeps the shared public c
     assert.match(resp.headers.get('cache-control') || '', /\bpublic\b/);
     assert.match(resp.headers.get('cache-control') || '', /s-maxage/);
     assert.ok(resp.headers.get('cdn-cache-control'));
+  });
+});
+
+test('anonymous fast-tier bootstrap (no credentials) is CDN-cacheable — restores the #5249 shield', async () => {
+  // The regression: dashboard boots carry an anonymous wm-session cookie, so
+  // successful tier reads returned no-store and every boot re-read the full
+  // registry from Upstash. A credential-less tier read serves the shared public
+  // seed payload and MUST carry the CDN shared-cache shield.
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
+    const resp = await handler(makeTierBootstrapRequest('fast'));
+
+    assert.equal(resp.status, 200);
+    assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);
+    assertSharedCacheHeaders(resp);
+    // fast tier shields at s-maxage=600; browser Cache-Control stays private
+    // (max-age only — no public/s-maxage) to avoid CF ACAO mispinning.
+    assert.match(resp.headers.get('cdn-cache-control') || '', /s-maxage=600/);
+    assert.doesNotMatch(resp.headers.get('cache-control') || '', /\bpublic\b/);
+    // Public path short-circuits before any key/entitlement validation.
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-validate-api-key')), false);
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-entitlements')), false);
+  });
+});
+
+test('anonymous slow-tier bootstrap (no credentials) is CDN-cacheable with the slow TTL', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(makeTierBootstrapRequest('slow'));
+
+    assert.equal(resp.status, 200);
+    assertSharedCacheHeaders(resp);
+    assert.match(resp.headers.get('cdn-cache-control') || '', /s-maxage=7200/);
+  });
+});
+
+test('session-cookie tier bootstrap stays no-store (cookie disqualifies the public path)', async () => {
+  // A cookie-bearing tier read can carry session scope, so it keeps no-store —
+  // this is exactly why the client now sends tier fetches with credentials:'omit'.
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const { token } = await issueSessionToken();
+    const resp = await handler(makeTierBootstrapRequest('fast', { Cookie: `wm-session=${token}` }));
+
+    assert.equal(resp.status, 200);
+    assertNonSharedCacheHeaders(resp);
+  });
+});
+
+test('enterprise-key tier bootstrap stays no-store (key auth is never shared-cacheable)', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(makeTierBootstrapRequest('fast', { 'X-WorldMonitor-Key': ENTERPRISE_KEY }));
+
+    assert.equal(resp.status, 200);
+    assertNonSharedCacheHeaders(resp);
+  });
+});
+
+test('tier bootstrap with extra params is not treated as the public path', async () => {
+  // Only the two fixed tier shapes qualify; an arbitrary extra param must fall
+  // back to key auth (401 here) so we never widen the cacheable key space.
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(
+      new Request('https://api.worldmonitor.app/api/bootstrap?tier=fast&keys=marketQuotes', { method: 'GET' }),
+    );
+
+    assert.equal(resp.status, 401);
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
+  });
+});
+
+test('unknown tier value does not qualify for the public path', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(makeTierBootstrapRequest('bogus'));
+
+    assert.equal(resp.status, 401);
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
   });
 });

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -1,4 +1,4 @@
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { getCorsHeaders, getPublicCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import {
   USER_API_KEY_GATEWAY_VALIDATION_ERROR,
   getHeaderApiKey,
@@ -249,8 +249,20 @@ const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
 // Scoped to the two fixed tier shapes (not arbitrary ?keys= combinations) so
 // the CDN key space stays tiny and hit rate high; credentialed / API-key /
 // arbitrary-key reads keep the no-store posture below.
+//
+// INVARIANT — do not break: the shared CDN caches these by URL only; it does
+// NOT vary on Cookie, so a cached public-tier entry can be served to a later
+// cookie-bearing request for the same ?tier URL (and vice-versa). That is safe
+// ONLY because the tier payload is byte-identical for every caller. Any future
+// change that makes tier output vary by session/entitlement/user MUST stop
+// classifying these as public (or add a Vary the CDN honors) or it will
+// cross-serve one caller's snapshot to another.
+//
+// GET only: a HEAD here would still run the full registry Redis read to build a
+// body it must not return — the exact unshielded egress this path exists to
+// avoid. HEAD tier reads have no client and fall through to the no-store path.
 export function isPublicTierBootstrapRequest(req) {
-  if (req.method !== 'GET' && req.method !== 'HEAD') return false;
+  if (req.method !== 'GET') return false;
 
   const url = new URL(req.url);
   const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
@@ -444,9 +456,16 @@ function successCacheHeaders(tier, authKind, cors) {
     };
   }
 
+  // Public seed payload with no per-user variation: serve with ACAO:* (no
+  // Vary: Origin, no Access-Control-Allow-Credentials) so the shared CDN stores
+  // ONE entry per URL instead of one per Origin, and no preview/embed origin can
+  // pin an echoed ACAO onto a cached response. Safe because isDisallowedOrigin()
+  // already rejected unauthorized origins at the handler entry (this is exactly
+  // the contract getPublicCorsHeaders documents).
+  const publicCors = getPublicCorsHeaders();
   const cacheControl = (tier && TIER_CACHE[tier]) || 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900';
   return {
-    ...cors,
+    ...publicCors,
     'Cache-Control': cacheControl,
     'CDN-Cache-Control': (tier && TIER_CDN_CACHE[tier]) || TIER_CDN_CACHE.fast,
   };
@@ -487,9 +506,12 @@ export default async function handler(req) {
     // tier reads) may avoid no-store here; every other successful bootstrap
     // response can carry session/key scoped data. no-cache (revalidate) rather
     // than a cacheable posture so a transient empty/error payload is never
-    // pinned in the shared CDN.
-    const cacheControl = isPublicBootstrapKind(auth.kind) ? 'no-cache' : 'no-store';
-    return jsonResponse({ data: {}, missing: names }, 200, { ...cors, 'Cache-Control': cacheControl });
+    // pinned in the shared CDN. Public paths also emit ACAO:* (getPublicCorsHeaders)
+    // to match the success path and avoid per-Origin ACAO pinning.
+    const isPublic = isPublicBootstrapKind(auth.kind);
+    const cacheControl = isPublic ? 'no-cache' : 'no-store';
+    const errorCors = isPublic ? getPublicCorsHeaders() : cors;
+    return jsonResponse({ data: {}, missing: names }, 200, { ...errorCors, 'Cache-Control': cacheControl });
   }
 
   const data = {};

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -240,23 +240,17 @@ export function isPublicWeatherBootstrapRequest(req) {
 
 const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
 
-// A tier bootstrap read (?tier=fast|slow, no other params) returns the shared
+// An explicit public tier bootstrap read (?tier=fast|slow&public=1, no other
+// params) returns the shared
 // production seed payload — identical for every caller (see PR #4499 non-goals:
 // only static transforms like wildfire compaction / enrichmentMeta strip apply,
-// never per-user variance). When such a request carries no credentials it is
-// therefore safe to serve from the shared CDN, restoring the s-maxage shield
-// that #4499 inadvertently removed for cookie-bearing dashboard boots (#5249).
-// Scoped to the two fixed tier shapes (not arbitrary ?keys= combinations) so
-// the CDN key space stays tiny and hit rate high; credentialed / API-key /
-// arbitrary-key reads keep the no-store posture below.
-//
-// INVARIANT — do not break: the shared CDN caches these by URL only; it does
-// NOT vary on Cookie, so a cached public-tier entry can be served to a later
-// cookie-bearing request for the same ?tier URL (and vice-versa). That is safe
-// ONLY because the tier payload is byte-identical for every caller. Any future
-// change that makes tier output vary by session/entitlement/user MUST stop
-// classifying these as public (or add a Vary the CDN honors) or it will
-// cross-serve one caller's snapshot to another.
+// never per-user variance). The explicit marker gives the shared response its
+// own CDN cache key; the legacy ?tier=fast|slow URLs remain credentialed and
+// no-store, so a warmed public response cannot bypass their auth/CORS contract.
+// The public URL is public regardless of request credentials because a CDN hit
+// occurs before handler auth. Callers that need credential processing must use
+// the legacy URL. Scoped to the two fixed public shapes so the CDN key space
+// stays tiny and hit rate high.
 //
 // GET only: a HEAD here would still run the full registry Redis read to build a
 // body it must not return — the exact unshielded egress this path exists to
@@ -269,10 +263,11 @@ export function isPublicTierBootstrapRequest(req) {
   if (pathname !== '/api/bootstrap') return false;
 
   const params = Array.from(url.searchParams.keys());
-  if (params.some((key) => key !== 'tier')) return false;
+  if (params.some((key) => key !== 'tier' && key !== 'public')) return false;
 
   const tierParams = url.searchParams.getAll('tier');
-  if (tierParams.length !== 1) return false;
+  const publicParams = url.searchParams.getAll('public');
+  if (tierParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return false;
 
   return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]);
 }
@@ -334,10 +329,21 @@ async function getCachedJsonBatch(keys) {
   // populate prefixed keys, so prefixing would always miss.
   const pipeline = keys.map((k) => ['GET', k]);
   const data = await redisPipeline(pipeline, 3000);
-  if (!data) return result;
+  if (!Array.isArray(data) || data.length !== keys.length) {
+    throw new Error('Bootstrap Redis pipeline unavailable');
+  }
 
   for (let i = 0; i < keys.length; i++) {
-    const raw = data[i]?.result;
+    const entry = data[i];
+    if (
+      !entry
+      || typeof entry !== 'object'
+      || !('result' in entry)
+      || entry.error != null
+    ) {
+      throw new Error('Bootstrap Redis pipeline command failed');
+    }
+    const raw = entry.result;
     if (raw) {
       try {
         const parsed = JSON.parse(raw);
@@ -364,15 +370,14 @@ function authFailure(body, status, cors, extraHeaders = {}) {
 
 async function validateBootstrapAuth(req, cors) {
   const headerKey = getHeaderApiKey(req);
+  // The explicit public URL must have one response contract for every request:
+  // Vercel may serve it from cache before cookie/header auth reaches this code.
+  if (isPublicTierBootstrapRequest(req)) {
+    return { ok: true, kind: 'public-tier' };
+  }
   if (!headerKey && !hasBootstrapCredentialCookie(req)) {
     if (isPublicWeatherBootstrapRequest(req)) {
       return { ok: true, kind: 'public-weather' };
-    }
-    // Credential-less tier reads serve the same public seed payload and are
-    // CDN-cacheable — restores the shared-cache shield for dashboard boots
-    // (client now sends these with credentials: 'omit'; see #5249).
-    if (isPublicTierBootstrapRequest(req)) {
-      return { ok: true, kind: 'public-tier' };
     }
   }
 
@@ -502,16 +507,22 @@ export default async function handler(req) {
   try {
     cached = await getCachedJsonBatch(keys);
   } catch {
-    // Only the anonymous public bootstrap paths (weather probe + credential-less
-    // tier reads) may avoid no-store here; every other successful bootstrap
-    // response can carry session/key scoped data. no-cache (revalidate) rather
-    // than a cacheable posture so a transient empty/error payload is never
-    // pinned in the shared CDN. Public paths also emit ACAO:* (getPublicCorsHeaders)
-    // to match the success path and avoid per-Origin ACAO pinning.
     const isPublic = isPublicBootstrapKind(auth.kind);
-    const cacheControl = isPublic ? 'no-cache' : 'no-store';
-    const errorCors = isPublic ? getPublicCorsHeaders() : cors;
-    return jsonResponse({ data: {}, missing: names }, 200, { ...errorCors, 'Cache-Control': cacheControl });
+    if (isPublic) {
+      // Infrastructure failure is not an empty registry. Make it retryable and
+      // omit every CDN cache header so the outage response cannot replace a
+      // healthy public snapshot at the shared cache key.
+      return jsonResponse(
+        { error: 'Bootstrap service temporarily unavailable' },
+        503,
+        {
+          ...getPublicCorsHeaders(),
+          'Cache-Control': 'no-store',
+          'Retry-After': '5',
+        },
+      );
+    }
+    return jsonResponse({ data: {}, missing: names }, 200, { ...cors, 'Cache-Control': 'no-store' });
   }
 
   const data = {};

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -238,6 +238,33 @@ export function isPublicWeatherBootstrapRequest(req) {
   return requested.length === 1 && requested[0] === 'weatherAlerts';
 }
 
+const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
+
+// A tier bootstrap read (?tier=fast|slow, no other params) returns the shared
+// production seed payload — identical for every caller (see PR #4499 non-goals:
+// only static transforms like wildfire compaction / enrichmentMeta strip apply,
+// never per-user variance). When such a request carries no credentials it is
+// therefore safe to serve from the shared CDN, restoring the s-maxage shield
+// that #4499 inadvertently removed for cookie-bearing dashboard boots (#5249).
+// Scoped to the two fixed tier shapes (not arbitrary ?keys= combinations) so
+// the CDN key space stays tiny and hit rate high; credentialed / API-key /
+// arbitrary-key reads keep the no-store posture below.
+export function isPublicTierBootstrapRequest(req) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return false;
+
+  const url = new URL(req.url);
+  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
+  if (pathname !== '/api/bootstrap') return false;
+
+  const params = Array.from(url.searchParams.keys());
+  if (params.some((key) => key !== 'tier')) return false;
+
+  const tierParams = url.searchParams.getAll('tier');
+  if (tierParams.length !== 1) return false;
+
+  return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]);
+}
+
 const BOOTSTRAP_CREDENTIAL_COOKIES = new Set(['wm-session', 'wm-pro-key', 'wm-widget-key']);
 
 function hasBootstrapCredentialCookie(req) {
@@ -325,8 +352,16 @@ function authFailure(body, status, cors, extraHeaders = {}) {
 
 async function validateBootstrapAuth(req, cors) {
   const headerKey = getHeaderApiKey(req);
-  if (!headerKey && !hasBootstrapCredentialCookie(req) && isPublicWeatherBootstrapRequest(req)) {
-    return { ok: true, kind: 'public-weather' };
+  if (!headerKey && !hasBootstrapCredentialCookie(req)) {
+    if (isPublicWeatherBootstrapRequest(req)) {
+      return { ok: true, kind: 'public-weather' };
+    }
+    // Credential-less tier reads serve the same public seed payload and are
+    // CDN-cacheable — restores the shared-cache shield for dashboard boots
+    // (client now sends these with credentials: 'omit'; see #5249).
+    if (isPublicTierBootstrapRequest(req)) {
+      return { ok: true, kind: 'public-tier' };
+    }
   }
 
   const apiKeyResult = await validateApiKey(req);
@@ -397,8 +432,12 @@ async function validateBootstrapAuth(req, cors) {
   };
 }
 
+function isPublicBootstrapKind(authKind) {
+  return authKind === 'public-weather' || authKind === 'public-tier';
+}
+
 function successCacheHeaders(tier, authKind, cors) {
-  if (authKind !== 'public-weather') {
+  if (!isPublicBootstrapKind(authKind)) {
     return {
       ...cors,
       'Cache-Control': 'no-store',
@@ -444,9 +483,12 @@ export default async function handler(req) {
   try {
     cached = await getCachedJsonBatch(keys);
   } catch {
-    // Only the anonymous weather bootstrap may avoid no-store here; every
-    // other successful bootstrap response can carry session/key scoped data.
-    const cacheControl = auth.kind === 'public-weather' ? 'no-cache' : 'no-store';
+    // Only the anonymous public bootstrap paths (weather probe + credential-less
+    // tier reads) may avoid no-store here; every other successful bootstrap
+    // response can carry session/key scoped data. no-cache (revalidate) rather
+    // than a cacheable posture so a transient empty/error payload is never
+    // pinned in the shared CDN.
+    const cacheControl = isPublicBootstrapKind(auth.kind) ? 'no-cache' : 'no-store';
     return jsonResponse({ data: {}, missing: names }, 200, { ...cors, 'Cache-Control': cacheControl });
   }
 

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -116,7 +116,13 @@ async function fetchTier(
   let missingKeys: string[] = [];
 
   try {
-    const resp = await fetch(toApiUrl(`/api/bootstrap?tier=${tier}`), { signal });
+    // credentials: 'omit' — the tier payload is the shared public seed bundle
+    // (no per-session/per-user variance), so we deliberately drop the anonymous
+    // wm-session cookie. Without a credential cookie the server serves the
+    // CDN-cacheable public-tier path, restoring the shared-cache shield in
+    // front of Upstash (see #5249); sending the cookie forced no-store and made
+    // every boot re-read the full registry from Redis.
+    const resp = await fetch(toApiUrl(`/api/bootstrap?tier=${tier}`), { signal, credentials: 'omit' });
     if (resp.ok) {
       const payload = (await resp.json()) as {
         data?: Record<string, unknown>;

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -116,13 +116,10 @@ async function fetchTier(
   let missingKeys: string[] = [];
 
   try {
-    // credentials: 'omit' — the tier payload is the shared public seed bundle
-    // (no per-session/per-user variance), so we deliberately drop the anonymous
-    // wm-session cookie. Without a credential cookie the server serves the
-    // CDN-cacheable public-tier path, restoring the shared-cache shield in
-    // front of Upstash (see #5249); sending the cookie forced no-store and made
-    // every boot re-read the full registry from Redis.
-    const resp = await fetch(toApiUrl(`/api/bootstrap?tier=${tier}`), { signal, credentials: 'omit' });
+    // public=1 gives the shared seed bundle a cache key distinct from the legacy
+    // credentialed tier URL. credentials:'omit' also avoids sending cookies to
+    // a route whose contract is explicitly public (see #5249).
+    const resp = await fetch(toApiUrl(`/api/bootstrap?tier=${tier}&public=1`), { signal, credentials: 'omit' });
     if (resp.ok) {
       const payload = (await resp.json()) as {
         data?: Record<string, unknown>;

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -231,6 +231,35 @@ export function isApiCallTarget(url: string, apiOrigin: string): boolean {
   return parsed.origin === apiOrigin && parsed.pathname.startsWith('/api/');
 }
 
+function isCredentiallessPublicTierRequest(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  url: string,
+): boolean {
+  const credentials = init?.credentials ?? (input instanceof Request ? input.credentials : undefined);
+  if (credentials !== 'omit') return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url, typeof location === 'undefined' ? 'http://localhost' : location.href);
+  } catch {
+    return false;
+  }
+
+  const pathname = parsed.pathname.length > 1 ? parsed.pathname.replace(/\/+$/, '') : parsed.pathname;
+  if (pathname !== '/api/bootstrap') return false;
+
+  const params = Array.from(parsed.searchParams.keys());
+  if (params.some((key) => key !== 'tier' && key !== 'public')) return false;
+
+  const tiers = parsed.searchParams.getAll('tier');
+  const publicFlags = parsed.searchParams.getAll('public');
+  return tiers.length === 1
+    && (tiers[0] === 'fast' || tiers[0] === 'slow')
+    && publicFlags.length === 1
+    && publicFlags[0] === '1';
+}
+
 // If a caller already set Authorization / X-WorldMonitor-Key / X-Api-Key, we
 // don't override — Clerk Bearer JWT and explicit user keys still take
 // precedence over the anonymous session token.
@@ -268,6 +297,14 @@ export function installWmSessionFetchInterceptor(): void {
     })();
 
     if (!isApiCallTarget(url, apiOrigin)) return original(input, init);
+
+    // Public tier hydration is intentionally credential-less and does not rely
+    // on the anonymous wm-session cookie. Let this exact request shape reach
+    // the native fetch even while session recovery is cooling down; otherwise
+    // the interceptor's synthetic 503 prevents the public CDN path from
+    // restoring the dashboard. Keep the bypass narrow so arbitrary bootstrap
+    // reads cannot opt out of the normal session machinery.
+    if (isCredentiallessPublicTierRequest(input, init, url)) return original(input, init);
 
     // Premium routes have a dedicated auth-injection layer
     // (`installWebApiRedirect`'s `enrichInitForPremium` adds Clerk Bearer JWT,

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -244,6 +244,8 @@ describe('Frontend hydration (src/services/bootstrap.ts)', () => {
 
   it('fetches tiered bootstrap URLs', () => {
     assert.ok(src.includes('/api/bootstrap?tier='), 'Missing tiered bootstrap fetch URLs');
+    assert.ok(src.includes('&public=1'), 'Tiered bootstrap fetches must use the isolated public cache URL');
+    assert.ok(src.includes("credentials: 'omit'"), 'Public tier fetches must omit credentials');
   });
 
   it('handles fetch failure silently', () => {

--- a/tests/embed-public-data-auth.test.mts
+++ b/tests/embed-public-data-auth.test.mts
@@ -64,7 +64,11 @@ describe('embed public data auth', () => {
     assert.equal(isPublicWeatherBootstrapRequest(publicReq), true);
 
     const publicRes = await bootstrapHandler(publicReq);
-    assert.equal(publicRes.status, 200);
+    // This test intentionally has no Redis credentials. The public route still
+    // bypasses auth, then reports the unavailable cache as a retryable outage
+    // instead of turning it into a cacheable empty success.
+    assert.equal(publicRes.status, 503);
+    assert.equal(publicRes.headers.get('cache-control'), 'no-store');
 
     const rejected = [
       'https://worldmonitor.app/api/bootstrap',

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -410,6 +410,64 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     ]);
   });
 
+  it('forwards only explicit credential-less public tier reads during the dead-session cooldown', async () => {
+    memoryStorage.clear();
+
+    const forwarded: Array<{ url: string; credentials: RequestCredentials | undefined }> = [];
+    currentFetchHandler = (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      const credentials = init?.credentials ?? (input instanceof Request ? input.credentials : undefined);
+      forwarded.push({ url, credentials });
+      if (url.includes('public=1')) return Promise.resolve(new Response('public-tier', { status: 200 }));
+      return Promise.resolve(new Response('still-rejected', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const failed = await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/list-service-statuses');
+      assert.equal(failed.status, 401, 'failed recovery should enter the dead-session cooldown');
+
+      const fast = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1', {
+        credentials: 'omit',
+      });
+      assert.equal(fast.status, 200, 'string input should reach the public tier while the session is dead');
+
+      const slowRequest = new Request('https://api.worldmonitor.app/api/bootstrap?public=1&tier=slow', {
+        credentials: 'omit',
+      });
+      const slow = await wrappedFetch(slowRequest);
+      assert.equal(slow.status, 200, 'Request input should preserve its effective omit credentials');
+
+      const missingPublicFlag = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap?tier=fast', {
+        credentials: 'omit',
+      });
+      assert.equal(missingPublicFlag.status, 503, 'ordinary tier reads must remain session-gated');
+
+      const credentialed = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1', {
+        credentials: 'include',
+      });
+      assert.equal(credentialed.status, 503, 'credentialed tier reads must remain session-gated');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.deepEqual(
+      forwarded.slice(-2),
+      [
+        { url: 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1', credentials: 'omit' },
+        { url: 'https://api.worldmonitor.app/api/bootstrap?public=1&tier=slow', credentials: 'omit' },
+      ],
+      'only the two explicit public tier requests should reach native fetch during cooldown',
+    );
+  });
+
   it('captures ONE wm_session_dead Sentry warning per degraded episode, not one per suppressed call', async () => {
     // reportServerError (premium-fetch.ts) deliberately skips the synthetic
     // X-Wm-Session-Degraded 503s, so this once-per-episode capture is the


### PR DESCRIPTION
## Summary

Fixes #5249 — Upstash Redis read egress ~30× (≈17 GB/day → 300–520 GB/day).

PR #4499 set `Cache-Control: no-store` on every successful `/api/bootstrap` response except the anonymous single-key `weatherAlerts` probe. Because the browser runtime fetches tiers with default `same-origin` credentials and **every visitor carries an anonymous `wm-session` cookie**, `hasBootstrapCredentialCookie()` disqualified ~100% of dashboard boots from the public path. The CDN shield (`CDN-Cache-Control: public, s-maxage=…`) that used to absorb bootstrap traffic was gone, so every boot/refresh pipelined the full seed registry (~5–10 MB) straight out of Upstash.

The tier payload is the shared production seed bundle — **identical for every caller** (per #4499's own non-goals: only static transforms like wildfire compaction + `enrichmentMeta` strip apply, never per-user variance). So a credential-less tier read is safe to serve from the shared CDN, restoring the shield without weakening #4495/#4499's header hardening.

This implements **fix direction 1** from the issue (client + server). Directions 2 (pre-compact heavy seeder keys) and 3 (memoize `/api/health` verdict) remain as follow-ups.

**Server** (`api/bootstrap.js`)
- Add `isPublicTierBootstrapRequest()`: a `GET`/`HEAD` `?tier=fast|slow` with no other params. Scoped to the two fixed tier shapes (not arbitrary `?keys=`) so the CDN key space stays tiny and hit rate high.
- Treat credential-less tier reads as a new `public-tier` auth kind and emit the CDN shield (fast `s-maxage=600`, slow `s-maxage=7200`).
- Credentialed / API-key / arbitrary-key reads and all failures keep `no-store`.

**Client** (`src/services/bootstrap.ts`)
- Send tier fetches with `credentials: 'omit'` so the anonymous `wm-session` cookie is dropped and the request qualifies for the public CDN-cacheable path.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (no new errors introduced in changed files)

Tests: added `public-tier` coverage to `api/bootstrap-auth.test.mjs` — anonymous `fast`/`slow` reads are CDN-cacheable with the correct TTL; `no-store` retained for cookie-bearing, enterprise-key, extra-param, and unknown-tier requests. `bootstrap-auth` (26), sidecar auth/cors (104), and the tsx bootstrap suites (44) all pass.

## Documentation Alignment Checklist

N/A — no documentation claims or Redis key contracts changed; this only adjusts cache-control posture for an existing endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FncwEiWddJ9My2HhQmrbYL)_