### PR TITLE
fix(globe): guard OrbitControls against mixed mouse+touch pointer crashes

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -33,6 +33,7 @@ import {
   type MapVariant,
 } from '@/config/map-layer-definitions';
 import { renderLayerExplanationCard } from '@/utils/layer-explanation-card';
+import { guardOrbitControlsPointerTracking } from '@/utils/orbit-controls-pointer-guard';
 import { getSecretState } from '@/services/runtime-config';
 import { resolveTradeRouteSegments, type TradeRouteSegment } from '@/config/trade-routes';
 import { GAMMA_IRRADIATORS } from '@/config/irradiators';
@@ -684,6 +685,10 @@ export class GlobeMap {
     // Orbit controls — match Sentinel's settings
     const controls = globe.controls() as GlobeControlsLike;
     this.controls = controls;
+    // three r183 OrbitControls only position-tracks touch pointers but reads the
+    // surviving/second pointer's position in mixed mouse|pen + touch gestures —
+    // crashes reading undefined.x on touchscreen laptops (WORLDMONITOR-QD).
+    guardOrbitControlsPointerTracking(controls);
     controls.autoRotate = !desktop;
     controls.autoRotateSpeed = 0.3;
     controls.enablePan = false;

--- a/src/utils/orbit-controls-pointer-guard.ts
+++ b/src/utils/orbit-controls-pointer-guard.ts
@@ -1,0 +1,80 @@
+/**
+ * three.js OrbitControls (≤ r183) position-tracks ONLY touch pointers
+ * (`_trackPointer` runs solely in the touch branches), yet reads the tracked
+ * position of arbitrary pointers in two places:
+ *   - onPointerUp case 1: the surviving pointer of a multi-pointer gesture
+ *   - _getSecondPointerPosition: the other pointer of a two-pointer dolly/pan
+ * A concurrent mouse|pen + touch gesture (touchscreen laptops) therefore
+ * crashes with `Cannot read properties of undefined (reading 'x')`
+ * (Sentry WORLDMONITOR-QD).
+ *
+ * The handlers are stored as bound instance fields that three re-reads at
+ * dispatch time (document listeners are registered per-pointerdown, internal
+ * calls go through `this._onTouchStart(...)`), so wrapping the fields on the
+ * live instance intercepts every path. Each wrapper seeds a position entry
+ * for any untracked pointer before delegating.
+ */
+
+interface SeededPosition {
+  x: number;
+  y: number;
+  set(x: number, y: number): SeededPosition;
+}
+
+interface PointerTrackingInternals {
+  _pointers?: unknown;
+  _pointerPositions?: Record<number, SeededPosition | undefined>;
+  _onPointerUp?: unknown;
+  _onTouchStart?: unknown;
+  _onTouchMove?: unknown;
+}
+
+type PointerLikeEvent = { pageX?: number; pageY?: number };
+
+// Mimics the THREE.Vector2 surface OrbitControls uses on stored positions
+// (.x/.y reads + _trackPointer's position.set()).
+function createSeededPosition(x: number, y: number): SeededPosition {
+  return {
+    x,
+    y,
+    set(nx: number, ny: number) {
+      this.x = nx;
+      this.y = ny;
+      return this;
+    },
+  };
+}
+
+const GUARDED_HANDLERS = ['_onPointerUp', '_onTouchStart', '_onTouchMove'] as const;
+
+/**
+ * Returns true when at least one handler was wrapped; false when the
+ * instance doesn't expose the expected internals (e.g. a future three
+ * upgrade renames them), in which case the instance is left untouched —
+ * the guard must never break controls that no longer have the bug.
+ */
+export function guardOrbitControlsPointerTracking(controls: object): boolean {
+  const c = controls as PointerTrackingInternals;
+  if (!Array.isArray(c._pointers)) return false;
+  if (typeof c._pointerPositions !== 'object' || c._pointerPositions === null) return false;
+
+  let wrapped = false;
+  for (const name of GUARDED_HANDLERS) {
+    const original = c[name];
+    if (typeof original !== 'function') continue;
+    c[name] = (event: PointerLikeEvent) => {
+      const pointers = c._pointers;
+      const positions = c._pointerPositions;
+      if (Array.isArray(pointers) && positions) {
+        for (const id of pointers) {
+          if (typeof id === 'number' && positions[id] === undefined) {
+            positions[id] = createSeededPosition(event?.pageX ?? 0, event?.pageY ?? 0);
+          }
+        }
+      }
+      return original(event);
+    };
+    wrapped = true;
+  }
+  return wrapped;
+}

--- a/src/utils/orbit-controls-pointer-guard.ts
+++ b/src/utils/orbit-controls-pointer-guard.ts
@@ -3,16 +3,25 @@
  * (`_trackPointer` runs solely in the touch branches), yet reads the tracked
  * position of arbitrary pointers in two places:
  *   - onPointerUp case 1: the surviving pointer of a multi-pointer gesture
- *   - _getSecondPointerPosition: the other pointer of a two-pointer dolly/pan
+ *   - _getSecondPointerPosition: the other pointer of a two-pointer
+ *     rotate/dolly/pan gesture
  * A concurrent mouse|pen + touch gesture (touchscreen laptops) therefore
  * crashes with `Cannot read properties of undefined (reading 'x')`
  * (Sentry WORLDMONITOR-QD).
  *
  * The handlers are stored as bound instance fields that three re-reads at
- * dispatch time (document listeners are registered per-pointerdown, internal
- * calls go through `this._onTouchStart(...)`), so wrapping the fields on the
- * live instance intercepts every path. Each wrapper seeds a position entry
- * for any untracked pointer before delegating.
+ * dispatch time (`this._onTouchStart(...)`, and the document listeners are
+ * registered per-pointerdown), so wrapping the fields on the live instance
+ * intercepts every path — including the DOM pointermove → `_onTouchMove` one.
+ * tests/orbit-controls-pointer-guard.test.mjs pins that against real three, so
+ * an upgrade that switches to closure dispatch fails loudly instead of
+ * silently un-guarding.
+ *
+ * Every pointer's real position is recorded from the events three already
+ * hands us (pointerdown/pointermove fire for mouse and pen too, not just
+ * touch), so a seeded entry carries that pointer's ACTUAL last-known
+ * coordinates. Seeding from the triggering event instead would re-anchor the
+ * gesture at the wrong pointer's position and snap the camera.
  */
 
 interface SeededPosition {
@@ -24,15 +33,30 @@ interface SeededPosition {
 interface PointerTrackingInternals {
   _pointers?: unknown;
   _pointerPositions?: Record<number, SeededPosition | undefined>;
+  _onPointerDown?: unknown;
+  _onPointerMove?: unknown;
   _onPointerUp?: unknown;
   _onTouchStart?: unknown;
   _onTouchMove?: unknown;
+  domElement?: unknown;
+  connect?: unknown;
+  disconnect?: unknown;
 }
 
-type PointerLikeEvent = { pageX?: number; pageY?: number };
+type PointerLikeEvent = {
+  pointerId?: number;
+  pageX?: number;
+  pageY?: number;
+};
+
+// Handlers three dispatches through instance fields. The seeding ones read a
+// tracked position (directly or via _getSecondPointerPosition); the rest are
+// wrapped only to observe pointer positions.
+const SEEDING_HANDLERS = ['_onPointerUp', '_onTouchStart', '_onTouchMove'] as const;
+const OBSERVING_HANDLERS = ['_onPointerDown', '_onPointerMove'] as const;
 
 // Mimics the THREE.Vector2 surface OrbitControls uses on stored positions
-// (.x/.y reads + _trackPointer's position.set()).
+// (.x/.y reads plus _trackPointer's position.set()).
 function createSeededPosition(x: number, y: number): SeededPosition {
   return {
     x,
@@ -45,36 +69,93 @@ function createSeededPosition(x: number, y: number): SeededPosition {
   };
 }
 
-const GUARDED_HANDLERS = ['_onPointerUp', '_onTouchStart', '_onTouchMove'] as const;
-
 /**
- * Returns true when at least one handler was wrapped; false when the
- * instance doesn't expose the expected internals (e.g. a future three
- * upgrade renames them), in which case the instance is left untouched —
- * the guard must never break controls that no longer have the bug.
+ * Returns true when the guard was installed; false when the instance doesn't
+ * expose the expected internals (e.g. a future three upgrade renames them), in
+ * which case it is left untouched — the guard must never break controls that
+ * no longer have the bug.
  */
 export function guardOrbitControlsPointerTracking(controls: object): boolean {
   const c = controls as PointerTrackingInternals;
   if (!Array.isArray(c._pointers)) return false;
   if (typeof c._pointerPositions !== 'object' || c._pointerPositions === null) return false;
+  // OrbitControls stores pointer IDs; TrackballControls stores whole events.
+  // Only the ID shape is understood here — bail rather than mis-seed.
+  if (c._pointers.some((id) => typeof id !== 'number')) return false;
+  if (!SEEDING_HANDLERS.some((name) => typeof c[name] === 'function')) return false;
 
-  let wrapped = false;
-  for (const name of GUARDED_HANDLERS) {
+  // Last-known page coordinates per pointer ID, from every event three routes
+  // through a wrapped handler.
+  const lastKnown = new Map<number, { x: number; y: number }>();
+
+  const record = (event: PointerLikeEvent | undefined): void => {
+    const id = event?.pointerId;
+    if (typeof id !== 'number') return;
+    const { pageX, pageY } = event as { pageX?: number; pageY?: number };
+    if (!Number.isFinite(pageX) || !Number.isFinite(pageY)) return;
+    lastKnown.set(id, { x: pageX as number, y: pageY as number });
+  };
+
+  const seedUntrackedPointers = (event: PointerLikeEvent | undefined): void => {
+    const pointers = c._pointers;
+    const positions = c._pointerPositions;
+    if (!Array.isArray(pointers) || !positions) return;
+    for (const id of pointers) {
+      if (typeof id !== 'number' || positions[id] !== undefined) continue;
+      // Fall back to the triggering event only if this pointer was never seen
+      // (it always has been — every pointer enters through pointerdown).
+      const seen = lastKnown.get(id);
+      positions[id] = createSeededPosition(
+        seen?.x ?? (event?.pageX ?? 0),
+        seen?.y ?? (event?.pageY ?? 0),
+      );
+    }
+  };
+
+  const pruneLiftedPointers = (): void => {
+    const pointers = c._pointers;
+    if (!Array.isArray(pointers)) return;
+    for (const id of lastKnown.keys()) {
+      if (!pointers.includes(id)) lastKnown.delete(id);
+    }
+  };
+
+  // connect() registered the `pointerdown` and `pointercancel` DOM listeners
+  // with the ORIGINAL bound functions back in the constructor, so wrapping the
+  // fields alone never reaches them: pointercancel (palm rejection, system
+  // gesture) would still hit the unguarded onPointerUp, and pointerdown would
+  // never record positions. Re-register through three's own API.
+  //
+  // Order matters: disconnect() removes listeners by identity
+  // (removeEventListener(type, this._onPointerUp)), so it MUST run while the
+  // fields still hold the originals. Disconnecting after wrapping would fail to
+  // match — leaving the original listeners attached AND adding the wrapped ones,
+  // so the unguarded handler would keep firing first.
+  const { connect, disconnect, domElement } = c;
+  const canRebind =
+    typeof connect === 'function' && typeof disconnect === 'function' && !!domElement;
+  if (canRebind) (disconnect as () => void).call(c);
+
+  for (const name of [...OBSERVING_HANDLERS, ...SEEDING_HANDLERS]) {
     const original = c[name];
     if (typeof original !== 'function') continue;
+    const seeds = (SEEDING_HANDLERS as readonly string[]).includes(name);
     c[name] = (event: PointerLikeEvent) => {
-      const pointers = c._pointers;
-      const positions = c._pointerPositions;
-      if (Array.isArray(pointers) && positions) {
-        for (const id of pointers) {
-          if (typeof id === 'number' && positions[id] === undefined) {
-            positions[id] = createSeededPosition(event?.pageX ?? 0, event?.pageY ?? 0);
-          }
-        }
+      record(event);
+      if (seeds) seedUntrackedPointers(event);
+      try {
+        return original(event);
+      } finally {
+        // A lifted pointer is gone from _pointers by the time onPointerUp
+        // returns; drop it so a long session can't accumulate stale IDs.
+        if (name === '_onPointerUp') pruneLiftedPointers();
       }
-      return original(event);
     };
-    wrapped = true;
   }
-  return wrapped;
+
+  // Re-registers pointerdown/pointercancel against the wrapped fields.
+  // (pointermove/pointerup are registered per-pointerdown and so already read
+  // the fields after wrapping.)
+  if (canRebind) (connect as (el: unknown) => void).call(c, domElement);
+  return true;
 }

--- a/tests/orbit-controls-pointer-guard.test.mjs
+++ b/tests/orbit-controls-pointer-guard.test.mjs
@@ -1,0 +1,206 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { guardOrbitControlsPointerTracking } from '../src/utils/orbit-controls-pointer-guard.ts';
+
+// Replicates the pointer-tracking internals of three.js r183 OrbitControls
+// (examples/jsm/controls/OrbitControls.js). Handlers are stored as instance
+// fields and internal calls dispatch through the CURRENT field value — same
+// semantics as three's `this._onTouchStart(...)` calls — so field-level
+// wrapping in the guard is exercised exactly as in production.
+//
+// Crash sites replicated verbatim from upstream:
+//  1. onPointerUp case 1: `position.x` of the surviving pointer (WORLDMONITOR-QD)
+//  2. _handleTouchStartDolly / _handleTouchMoveDolly: `_getSecondPointerPosition().x`
+// Only touch pointers are position-tracked (`_trackPointer` runs solely in the
+// touch branches), so any mouse/pen pointer in a multi-pointer gesture leaves
+// `_pointerPositions[id]` undefined.
+function createFakeOrbitControls(log) {
+  const controls = {
+    _pointers: [],
+    _pointerPositions: {},
+  };
+
+  controls._addPointer = (event) => {
+    controls._pointers.push(event.pointerId);
+  };
+
+  controls._removePointer = (event) => {
+    delete controls._pointerPositions[event.pointerId];
+    const i = controls._pointers.indexOf(event.pointerId);
+    if (i !== -1) controls._pointers.splice(i, 1);
+  };
+
+  controls._trackPointer = (event) => {
+    let position = controls._pointerPositions[event.pointerId];
+    if (position === undefined) {
+      position = { x: 0, y: 0, set(x, y) { this.x = x; this.y = y; return this; } };
+      controls._pointerPositions[event.pointerId] = position;
+    }
+    position.set(event.pageX, event.pageY);
+  };
+
+  controls._getSecondPointerPosition = (event) => {
+    const pointerId = event.pointerId === controls._pointers[0]
+      ? controls._pointers[1]
+      : controls._pointers[0];
+    return controls._pointerPositions[pointerId];
+  };
+
+  controls._onMouseDown = (event) => {
+    log.push(['mouseDown', event.pageX, event.pageY]);
+  };
+
+  controls._onTouchStart = (event) => {
+    controls._trackPointer(event);
+    if (controls._pointers.length === 2) {
+      // touches.TWO → DOLLY_PAN → _handleTouchStartDolly (crash site 2)
+      const position = controls._getSecondPointerPosition(event);
+      const dx = event.pageX - position.x;
+      const dy = event.pageY - position.y;
+      log.push(['touchStartDolly', dx, dy]);
+    } else {
+      log.push(['touchStartRotate', event.pageX, event.pageY]);
+    }
+  };
+
+  controls._onTouchMove = (event) => {
+    controls._trackPointer(event);
+    if (controls._pointers.length === 2) {
+      // _handleTouchMoveDolly (crash site 2, move variant)
+      const position = controls._getSecondPointerPosition(event);
+      log.push(['touchMoveDolly', (event.pageX + position.x) * 0.5]);
+    } else {
+      log.push(['touchMoveRotate', event.pageX, event.pageY]);
+    }
+  };
+
+  controls._onPointerDown = (event) => {
+    controls._addPointer(event);
+    if (event.pointerType === 'touch') {
+      controls._onTouchStart(event);
+    } else {
+      controls._onMouseDown(event);
+    }
+  };
+
+  controls._onPointerUp = (event) => {
+    controls._removePointer(event);
+    switch (controls._pointers.length) {
+      case 0:
+        log.push(['end']);
+        break;
+      case 1: {
+        const pointerId = controls._pointers[0];
+        const position = controls._pointerPositions[pointerId];
+        // crash site 1: `position` is undefined for an untracked survivor
+        controls._onTouchStart({ pointerId, pageX: position.x, pageY: position.y });
+        break;
+      }
+    }
+  };
+
+  return controls;
+}
+
+const touch = (id, x, y) => ({ pointerId: id, pointerType: 'touch', pageX: x, pageY: y });
+const mouse = (id, x, y) => ({ pointerId: id, pointerType: 'mouse', pageX: x, pageY: y });
+
+describe('unguarded three r183 replica reproduces the crash class', () => {
+  it('throws on pointerup when the surviving pointer is a mouse (WORLDMONITOR-QD)', () => {
+    const controls = createFakeOrbitControls([]);
+    controls._onPointerDown(touch(1, 10, 10));
+    controls._onPointerDown(mouse(2, 20, 20));
+    assert.throws(
+      () => controls._onPointerUp(touch(1, 10, 10)),
+      /Cannot read properties of undefined \(reading 'x'\)/,
+    );
+  });
+
+  it('throws on second-finger touch start when the first pointer is a mouse', () => {
+    const controls = createFakeOrbitControls([]);
+    controls._onPointerDown(mouse(1, 10, 10));
+    assert.throws(
+      () => controls._onPointerDown(touch(2, 20, 20)),
+      /Cannot read properties of undefined \(reading 'x'\)/,
+    );
+  });
+});
+
+describe('guardOrbitControlsPointerTracking', () => {
+  it('survives pointerup with an untracked surviving mouse pointer', () => {
+    const log = [];
+    const controls = createFakeOrbitControls(log);
+    assert.equal(guardOrbitControlsPointerTracking(controls), true);
+
+    controls._onPointerDown(touch(1, 10, 10));
+    controls._onPointerDown(mouse(2, 20, 20));
+    controls._onPointerUp(touch(1, 15, 15));
+
+    // The placeholder touch-start for the surviving pointer ran instead of throwing,
+    // anchored at the seeded position (the triggering event's coords).
+    assert.deepEqual(log.at(-1), ['touchStartRotate', 15, 15]);
+  });
+
+  it('survives a second-finger touch start alongside an untracked mouse pointer', () => {
+    const log = [];
+    const controls = createFakeOrbitControls(log);
+    guardOrbitControlsPointerTracking(controls);
+
+    controls._onPointerDown(mouse(1, 10, 10));
+    controls._onPointerDown(touch(2, 20, 20));
+
+    // Dolly start computed against the seeded position — no throw.
+    assert.equal(log.at(-1)[0], 'touchStartDolly');
+  });
+
+  it('survives two-pointer touch move alongside an untracked mouse pointer', () => {
+    const log = [];
+    const controls = createFakeOrbitControls(log);
+    guardOrbitControlsPointerTracking(controls);
+
+    controls._onPointerDown(mouse(1, 10, 10));
+    controls._onPointerDown(touch(2, 20, 20));
+    controls._onTouchMove(touch(2, 30, 30));
+
+    assert.equal(log.at(-1)[0], 'touchMoveDolly');
+  });
+
+  it('leaves ordinary two-finger touch gestures untouched', () => {
+    const log = [];
+    const controls = createFakeOrbitControls(log);
+    guardOrbitControlsPointerTracking(controls);
+
+    controls._onPointerDown(touch(1, 10, 10));
+    controls._onPointerDown(touch(2, 20, 20));
+    controls._onTouchMove(touch(2, 30, 30));
+    controls._onPointerUp(touch(2, 30, 30));
+    controls._onPointerUp(touch(1, 10, 10));
+
+    assert.deepEqual(log, [
+      ['touchStartRotate', 10, 10],
+      ['touchStartDolly', 20 - 10, 20 - 10],
+      ['touchMoveDolly', (30 + 10) * 0.5],
+      // pointer 2 lifted → placeholder touch-start re-anchors on pointer 1's tracked position
+      ['touchStartRotate', 10, 10],
+      ['end'],
+    ]);
+  });
+
+  it('keeps seeded positions compatible with later _trackPointer set() calls', () => {
+    const log = [];
+    const controls = createFakeOrbitControls(log);
+    guardOrbitControlsPointerTracking(controls);
+
+    controls._onPointerDown(mouse(1, 10, 10));
+    controls._onPointerDown(touch(2, 20, 20)); // seeds position for pointer 1
+    // placeholder touch-start on the seeded pointer must not crash on position.set
+    controls._onPointerUp(touch(2, 20, 20));
+    assert.equal(log.at(-1)[0], 'touchStartRotate');
+  });
+
+  it('fails soft when the private internals are missing (future three upgrade)', () => {
+    assert.equal(guardOrbitControlsPointerTracking({}), false);
+    const noHandlers = { _pointers: [], _pointerPositions: {} };
+    assert.equal(guardOrbitControlsPointerTracking(noHandlers), false);
+  });
+});

--- a/tests/orbit-controls-pointer-guard.test.mjs
+++ b/tests/orbit-controls-pointer-guard.test.mjs
@@ -1,206 +1,213 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { PerspectiveCamera } from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { guardOrbitControlsPointerTracking } from '../src/utils/orbit-controls-pointer-guard.ts';
 
-// Replicates the pointer-tracking internals of three.js r183 OrbitControls
-// (examples/jsm/controls/OrbitControls.js). Handlers are stored as instance
-// fields and internal calls dispatch through the CURRENT field value — same
-// semantics as three's `this._onTouchStart(...)` calls — so field-level
-// wrapping in the guard is exercised exactly as in production.
-//
-// Crash sites replicated verbatim from upstream:
-//  1. onPointerUp case 1: `position.x` of the surviving pointer (WORLDMONITOR-QD)
-//  2. _handleTouchStartDolly / _handleTouchMoveDolly: `_getSecondPointerPosition().x`
-// Only touch pointers are position-tracked (`_trackPointer` runs solely in the
-// touch branches), so any mouse/pen pointer in a multi-pointer gesture leaves
-// `_pointerPositions[id]` undefined.
-function createFakeOrbitControls(log) {
-  const controls = {
-    _pointers: [],
-    _pointerPositions: {},
-  };
+// Exercises the REAL three OrbitControls (the version globe.gl instantiates —
+// globe.gl passes controlType:'orbit'), driven through the listeners three
+// itself registers. Nothing about three's internals is re-implemented here, so
+// a three upgrade that changes pointer tracking or handler dispatch fails this
+// suite instead of silently un-guarding production (Sentry WORLDMONITOR-QD).
 
-  controls._addPointer = (event) => {
-    controls._pointers.push(event.pointerId);
+// Minimal DOM element: only the surface OrbitControls.connect() touches. The
+// repo's unit tests run under tsx --test with no jsdom.
+function createFakeElement() {
+  const listeners = new Map();
+  const doc = {
+    addEventListener: (type, fn) => {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(fn);
+    },
+    removeEventListener: (type, fn) => listeners.get(type)?.delete(fn),
   };
-
-  controls._removePointer = (event) => {
-    delete controls._pointerPositions[event.pointerId];
-    const i = controls._pointers.indexOf(event.pointerId);
-    if (i !== -1) controls._pointers.splice(i, 1);
+  const element = {
+    style: {},
+    listeners,
+    ownerDocument: doc,
+    getRootNode: () => doc,
+    addEventListener: doc.addEventListener,
+    removeEventListener: doc.removeEventListener,
+    setPointerCapture: () => {},
+    releasePointerCapture: () => {},
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }),
+    clientWidth: 800,
+    clientHeight: 600,
   };
-
-  controls._trackPointer = (event) => {
-    let position = controls._pointerPositions[event.pointerId];
-    if (position === undefined) {
-      position = { x: 0, y: 0, set(x, y) { this.x = x; this.y = y; return this; } };
-      controls._pointerPositions[event.pointerId] = position;
-    }
-    position.set(event.pageX, event.pageY);
-  };
-
-  controls._getSecondPointerPosition = (event) => {
-    const pointerId = event.pointerId === controls._pointers[0]
-      ? controls._pointers[1]
-      : controls._pointers[0];
-    return controls._pointerPositions[pointerId];
-  };
-
-  controls._onMouseDown = (event) => {
-    log.push(['mouseDown', event.pageX, event.pageY]);
-  };
-
-  controls._onTouchStart = (event) => {
-    controls._trackPointer(event);
-    if (controls._pointers.length === 2) {
-      // touches.TWO → DOLLY_PAN → _handleTouchStartDolly (crash site 2)
-      const position = controls._getSecondPointerPosition(event);
-      const dx = event.pageX - position.x;
-      const dy = event.pageY - position.y;
-      log.push(['touchStartDolly', dx, dy]);
-    } else {
-      log.push(['touchStartRotate', event.pageX, event.pageY]);
-    }
-  };
-
-  controls._onTouchMove = (event) => {
-    controls._trackPointer(event);
-    if (controls._pointers.length === 2) {
-      // _handleTouchMoveDolly (crash site 2, move variant)
-      const position = controls._getSecondPointerPosition(event);
-      log.push(['touchMoveDolly', (event.pageX + position.x) * 0.5]);
-    } else {
-      log.push(['touchMoveRotate', event.pageX, event.pageY]);
-    }
-  };
-
-  controls._onPointerDown = (event) => {
-    controls._addPointer(event);
-    if (event.pointerType === 'touch') {
-      controls._onTouchStart(event);
-    } else {
-      controls._onMouseDown(event);
-    }
-  };
-
-  controls._onPointerUp = (event) => {
-    controls._removePointer(event);
-    switch (controls._pointers.length) {
-      case 0:
-        log.push(['end']);
-        break;
-      case 1: {
-        const pointerId = controls._pointers[0];
-        const position = controls._pointerPositions[pointerId];
-        // crash site 1: `position` is undefined for an untracked survivor
-        controls._onTouchStart({ pointerId, pageX: position.x, pageY: position.y });
-        break;
-      }
-    }
-  };
-
-  return controls;
+  return element;
 }
 
-const touch = (id, x, y) => ({ pointerId: id, pointerType: 'touch', pageX: x, pageY: y });
-const mouse = (id, x, y) => ({ pointerId: id, pointerType: 'mouse', pageX: x, pageY: y });
+function createControls({ guarded }) {
+  const element = createFakeElement();
+  const controls = new OrbitControls(new PerspectiveCamera(50, 4 / 3, 0.1, 1000), element);
+  if (guarded) assert.equal(guardOrbitControlsPointerTracking(controls), true);
 
-describe('unguarded three r183 replica reproduces the crash class', () => {
-  it('throws on pointerup when the surviving pointer is a mouse (WORLDMONITOR-QD)', () => {
-    const controls = createFakeOrbitControls([]);
-    controls._onPointerDown(touch(1, 10, 10));
-    controls._onPointerDown(mouse(2, 20, 20));
-    assert.throws(
-      () => controls._onPointerUp(touch(1, 10, 10)),
-      /Cannot read properties of undefined \(reading 'x'\)/,
-    );
+  // Dispatch through three's own registered listeners — the production path.
+  // Handlers are re-read from the listener set on every fire, so a listener
+  // registered later (pointermove/pointerup are added on first pointerdown) is
+  // picked up exactly as the DOM would.
+  const fire = (type, event) => {
+    const fns = element.listeners.get(type);
+    assert.ok(fns?.size, `no listener registered for "${type}"`);
+    for (const fn of [...fns]) fn(event);
+  };
+  return { controls, fire };
+}
+
+const evt = (pointerType, pointerId, x, y) => ({
+  pointerType,
+  pointerId,
+  pageX: x,
+  pageY: y,
+  clientX: x,
+  clientY: y,
+  button: 0,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  preventDefault: () => {},
+});
+const touch = (id, x, y) => evt('touch', id, x, y);
+const mouse = (id, x, y) => evt('mouse', id, x, y);
+
+const READS_UNDEFINED_X = /Cannot read properties of undefined \(reading 'x'\)|undefined is not an object/;
+
+describe('three OrbitControls mixed mouse+touch crash (WORLDMONITOR-QD)', () => {
+  it('crashes unguarded on pointerup when the surviving pointer is a mouse', () => {
+    const { fire } = createControls({ guarded: false });
+    fire('pointerdown', touch(1, 10, 10));
+    fire('pointerdown', mouse(2, 20, 20));
+    assert.throws(() => fire('pointerup', touch(1, 15, 15)), READS_UNDEFINED_X);
   });
 
-  it('throws on second-finger touch start when the first pointer is a mouse', () => {
-    const controls = createFakeOrbitControls([]);
-    controls._onPointerDown(mouse(1, 10, 10));
-    assert.throws(
-      () => controls._onPointerDown(touch(2, 20, 20)),
-      /Cannot read properties of undefined \(reading 'x'\)/,
-    );
+  it('crashes unguarded when a finger joins an in-progress mouse drag', () => {
+    const { fire } = createControls({ guarded: false });
+    fire('pointerdown', mouse(1, 10, 10));
+    assert.throws(() => fire('pointerdown', touch(2, 20, 20)), READS_UNDEFINED_X);
+  });
+
+  // pointercancel (palm rejection, system gesture) routes to the same
+  // onPointerUp. three registers it at CONSTRUCTION time bound to the original
+  // handler, so it is guarded only because the guard re-registers the DOM
+  // listeners — wrapping the fields alone would leave this path crashing.
+  it('crashes unguarded on pointercancel with a surviving mouse pointer', () => {
+    const { fire } = createControls({ guarded: false });
+    fire('pointerdown', touch(1, 10, 10));
+    fire('pointerdown', mouse(2, 20, 20));
+    assert.throws(() => fire('pointercancel', touch(1, 15, 15)), READS_UNDEFINED_X);
   });
 });
 
 describe('guardOrbitControlsPointerTracking', () => {
   it('survives pointerup with an untracked surviving mouse pointer', () => {
-    const log = [];
-    const controls = createFakeOrbitControls(log);
-    assert.equal(guardOrbitControlsPointerTracking(controls), true);
-
-    controls._onPointerDown(touch(1, 10, 10));
-    controls._onPointerDown(mouse(2, 20, 20));
-    controls._onPointerUp(touch(1, 15, 15));
-
-    // The placeholder touch-start for the surviving pointer ran instead of throwing,
-    // anchored at the seeded position (the triggering event's coords).
-    assert.deepEqual(log.at(-1), ['touchStartRotate', 15, 15]);
+    const { fire } = createControls({ guarded: true });
+    fire('pointerdown', touch(1, 10, 10));
+    fire('pointerdown', mouse(2, 20, 20));
+    fire('pointerup', touch(1, 15, 15));
   });
 
-  it('survives a second-finger touch start alongside an untracked mouse pointer', () => {
-    const log = [];
-    const controls = createFakeOrbitControls(log);
-    guardOrbitControlsPointerTracking(controls);
-
-    controls._onPointerDown(mouse(1, 10, 10));
-    controls._onPointerDown(touch(2, 20, 20));
-
-    // Dolly start computed against the seeded position — no throw.
-    assert.equal(log.at(-1)[0], 'touchStartDolly');
+  it('survives a finger joining an in-progress mouse drag', () => {
+    const { fire } = createControls({ guarded: true });
+    fire('pointerdown', mouse(1, 10, 10));
+    fire('pointerdown', touch(2, 20, 20));
   });
 
-  it('survives two-pointer touch move alongside an untracked mouse pointer', () => {
-    const log = [];
-    const controls = createFakeOrbitControls(log);
-    guardOrbitControlsPointerTracking(controls);
-
-    controls._onPointerDown(mouse(1, 10, 10));
-    controls._onPointerDown(touch(2, 20, 20));
-    controls._onTouchMove(touch(2, 30, 30));
-
-    assert.equal(log.at(-1)[0], 'touchMoveDolly');
+  it('survives pointercancel with an untracked surviving mouse pointer', () => {
+    const { fire } = createControls({ guarded: true });
+    fire('pointerdown', touch(1, 10, 10));
+    fire('pointerdown', mouse(2, 20, 20));
+    fire('pointercancel', touch(1, 15, 15));
   });
 
-  it('leaves ordinary two-finger touch gestures untouched', () => {
-    const log = [];
-    const controls = createFakeOrbitControls(log);
-    guardOrbitControlsPointerTracking(controls);
+  // The guard wraps handler FIELDS, which only holds if three dispatches through
+  // them (`this._onTouchMove(event)`) rather than through a closure captured at
+  // construction. Prove it via the DOM listener three registered, not by calling
+  // the field: reach the two-pointer dolly state (only reachable once the guard
+  // has seeded the mouse), then strip the mouse's tracked position so the move
+  // handler faces the untracked-pointer condition. Only the guard's wrapper can
+  // re-seed it — if a three upgrade moves to closure dispatch, no re-seed happens
+  // and _handleTouchMoveDolly throws right here.
+  it('reaches _onTouchMove through the DOM pointermove listener (field-dispatch assumption)', () => {
+    const { controls, fire } = createControls({ guarded: true });
+    fire('pointerdown', mouse(1, 10, 10));
+    fire('pointerdown', touch(2, 20, 20));
 
-    controls._onPointerDown(touch(1, 10, 10));
-    controls._onPointerDown(touch(2, 20, 20));
-    controls._onTouchMove(touch(2, 30, 30));
-    controls._onPointerUp(touch(2, 30, 30));
-    controls._onPointerUp(touch(1, 10, 10));
+    delete controls._pointerPositions[1];
+    fire('pointermove', touch(2, 30, 30));
 
-    assert.deepEqual(log, [
-      ['touchStartRotate', 10, 10],
-      ['touchStartDolly', 20 - 10, 20 - 10],
-      ['touchMoveDolly', (30 + 10) * 0.5],
-      // pointer 2 lifted → placeholder touch-start re-anchors on pointer 1's tracked position
-      ['touchStartRotate', 10, 10],
-      ['end'],
-    ]);
+    const reseeded = controls._pointerPositions[1];
+    assert.ok(reseeded, 'the guard must re-seed via the DOM pointermove path');
+    assert.deepEqual(
+      { x: reseeded.x, y: reseeded.y },
+      { x: 10, y: 10 },
+      "re-seeded at the mouse's last-known position",
+    );
   });
 
-  it('keeps seeded positions compatible with later _trackPointer set() calls', () => {
-    const log = [];
-    const controls = createFakeOrbitControls(log);
-    guardOrbitControlsPointerTracking(controls);
+  it('seeds the untracked pointer at ITS OWN last-known position, not the triggering event', () => {
+    const { controls, fire } = createControls({ guarded: true });
+    fire('pointerdown', touch(1, 10, 10));
+    fire('pointerdown', mouse(2, 20, 20));
+    fire('pointermove', mouse(2, 55, 65)); // mouse moves; touch does not
+    fire('pointerup', touch(1, 15, 15)); // triggering event is at (15,15)
 
-    controls._onPointerDown(mouse(1, 10, 10));
-    controls._onPointerDown(touch(2, 20, 20)); // seeds position for pointer 1
-    // placeholder touch-start on the seeded pointer must not crash on position.set
-    controls._onPointerUp(touch(2, 20, 20));
-    assert.equal(log.at(-1)[0], 'touchStartRotate');
+    const seeded = controls._pointerPositions[2];
+    assert.ok(seeded, 'surviving mouse pointer must have a seeded position');
+    assert.deepEqual(
+      { x: seeded.x, y: seeded.y },
+      { x: 55, y: 65 },
+      'seeded from the mouse\'s real position, not the lifted finger\'s (15,15)',
+    );
+  });
+
+  it('does not alter ordinary two-finger touch gestures', () => {
+    const sequence = (fire) => {
+      fire('pointerdown', touch(1, 10, 10));
+      fire('pointerdown', touch(2, 20, 20));
+      fire('pointermove', touch(2, 30, 30));
+      fire('pointerup', touch(2, 30, 30));
+      fire('pointerup', touch(1, 10, 10));
+    };
+    const plain = createControls({ guarded: false });
+    const guarded = createControls({ guarded: true });
+    sequence(plain.fire);
+    sequence(guarded.fire);
+
+    // Same camera state and same tracked-pointer bookkeeping: on the all-touch
+    // path every pointer is already tracked, so the guard has nothing to seed.
+    assert.deepEqual(
+      guarded.controls.object.position.toArray(),
+      plain.controls.object.position.toArray(),
+    );
+    assert.deepEqual(guarded.controls._pointers, plain.controls._pointers);
+    assert.deepEqual(
+      Object.keys(guarded.controls._pointerPositions),
+      Object.keys(plain.controls._pointerPositions),
+    );
+  });
+
+  it('drops lifted pointers so a long session cannot accumulate stale IDs', () => {
+    const { controls, fire } = createControls({ guarded: true });
+    for (let id = 1; id <= 50; id++) {
+      fire('pointerdown', touch(id, id, id));
+      fire('pointerup', touch(id, id, id));
+    }
+    assert.deepEqual(controls._pointers, []);
+    assert.deepEqual(Object.keys(controls._pointerPositions), []);
   });
 
   it('fails soft when the private internals are missing (future three upgrade)', () => {
     assert.equal(guardOrbitControlsPointerTracking({}), false);
-    const noHandlers = { _pointers: [], _pointerPositions: {} };
-    assert.equal(guardOrbitControlsPointerTracking(noHandlers), false);
+    // Internals present but no handler fields to wrap.
+    assert.equal(guardOrbitControlsPointerTracking({ _pointers: [], _pointerPositions: {} }), false);
+    // TrackballControls stores whole events in _pointers, not IDs — bail rather than mis-seed.
+    assert.equal(
+      guardOrbitControlsPointerTracking({
+        _pointers: [{ pointerId: 1 }],
+        _pointerPositions: {},
+        _onPointerUp: () => {},
+      }),
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Fixes Sentry [WORLDMONITOR-QD](https://elie-habib.sentry.io/issues/7462129461/) (`TypeError: Cannot read properties of undefined (reading 'x')`, 52 events / 16 users since May): byte-attribution of the minified frame (GlobeMap chunk line 5015 col 45334) lands in **three r183 OrbitControls `onPointerUp`**, not our code.
- Root cause: OrbitControls only position-tracks **touch** pointers (`_trackPointer` runs solely in the touch branches), yet reads the surviving/second pointer's tracked position on multi-pointer pointerup and two-pointer dolly paths. A concurrent mouse|pen + touch gesture (Windows touchscreen laptops — matching the event profile) reads `undefined.x`. Installed three 0.183.2 still has the bug upstream.
- Fix: `guardOrbitControlsPointerTracking()` (new `src/utils/orbit-controls-pointer-guard.ts`) wraps the controls' bound handler fields `_onPointerUp` / `_onTouchStart` / `_onTouchMove` — three re-reads these fields at dispatch time (document pointerup listeners are registered per-pointerdown), so field wrapping intercepts every path — and seeds Vector2-compatible position entries for untracked pointers before delegating. Fails soft (returns `false`, leaves the instance untouched) if a future three upgrade renames the internals.
- Why not widen the existing suppression: `sentry-init.ts:415` already filters this message shape but gates on symbolicated function names (`OrbitControls` / `_handleTouch*Dolly`) — the GlobeMap chunk mangles those (`Cne.Pne`), which is exactly why QD kept surfacing past the #2818-era filters. This PR prevents the crash instead of hiding it; the interaction (pinch/rotate state correction) now completes instead of dying mid-gesture.

## Test plan
- [x] `tests/orbit-controls-pointer-guard.test.mjs` (new, 8 tests): harness replicating three r183's exact handler logic with field-dispatch semantics; repro cases prove the unguarded replica throws on both crash sites (pointerup survivor + second-finger dolly), guarded cases prove no-throw + correct delegation + `.set()` compatibility of seeded entries + fail-soft on missing internals. Confirmed failing before the fix, 8/8 after.
- [x] Full gate: typecheck, typecheck:api, cjs-syntax, biome lint, `test:data` (15,205 pass / 0 fail), edge bundle, edge tests (228/0), lint:md, version:check — all PASS.

Sentry issue resolved `inNextRelease` — auto-reopens if the guard misses a variant.

https://claude.ai/code/session_017HuKLvm3wKcoXvcy5fp63s