### PR TITLE
fix(session): classify dead recovery telemetry

### DIFF
--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -29,6 +29,8 @@ const PERIODIC_REFRESH_MS = 30 * 60 * 1000;
 const SESSION_DEAD_COOLDOWN_MS = 15 * 60 * 1000;
 export const WM_SESSION_DEGRADED_EVENT = 'wm-session-degraded';
 
+type WmSessionDeadReason = 'mint_failed' | 'retry_401';
+
 interface StoredSession {
   exp: number;
 }
@@ -50,7 +52,7 @@ export function isWmSessionDead(): boolean {
   return true;
 }
 
-function markWmSessionDead(): void {
+function markWmSessionDead(reason: WmSessionDeadReason): void {
   const alreadyDead = isWmSessionDead();
   sessionDeadUntil = Date.now() + SESSION_DEAD_COOLDOWN_MS;
   cached = null;
@@ -65,7 +67,7 @@ function markWmSessionDead(): void {
   try {
     sentryEnqueue((s) => s.captureMessage(
       'wm-session dead: anonymous API calls suppressed',
-      { level: 'warning', tags: { kind: 'wm_session_dead' } },
+      { level: 'warning', tags: { kind: 'wm_session_dead', reason } },
     ));
   } catch { /* best-effort telemetry */ }
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
@@ -349,12 +351,12 @@ export function installWmSessionFetchInterceptor(): void {
       const recovery = (async (): Promise<Response | null> => {
         const fresh = await ensureWmSession().catch(() => false);
         if (!fresh) {
-          markWmSessionDead();
+          markWmSessionDead('mint_failed');
           return null;
         }
         const retryResp = await sendWith(new Headers(headers), requestClone ?? input);
         if (retryResp.status === 401) {
-          markWmSessionDead();
+          markWmSessionDead('retry_401');
           return null;
         }
         return retryResp;

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -450,6 +450,40 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     assert.equal(captures[0].msg, 'wm-session dead: anonymous API calls suppressed');
     assert.equal(captures[0].ctx.level, 'warning');
     assert.equal(captures[0].ctx.tags?.kind, 'wm_session_dead');
+    assert.equal(captures[0].ctx.tags?.reason, 'retry_401');
+  });
+
+  it('tags wm_session_dead as mint_failed when recovery cannot mint a session', async () => {
+    memoryStorage.clear();
+
+    const captures: Array<{ msg: string; ctx: { level?: string; tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({ captureMessage: (msg: string, ctx: { level?: string; tags?: Record<string, string> }) => { captures.push({ msg, ctx }); } });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response('mint unavailable', { status: 503 }));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const resp = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      assert.equal(resp.status, 401, 'failed recovery returns the original server response');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(mintCalls, 2, 'initial preflight and recovery mint both fail');
+    assert.equal(captures.length, 1, 'the failed mint starts one degraded episode');
+    assert.equal(captures[0].ctx.tags?.kind, 'wm_session_dead');
+    assert.equal(captures[0].ctx.tags?.reason, 'mint_failed');
   });
 
   it('a throwing Sentry enqueue never skips the degraded-event dispatch nor rejects the recovery return', async () => {


### PR DESCRIPTION
## Summary

Dead anonymous-session episodes can now be separated into failed mint attempts and fresh-cookie retries that still receive `401`. This turns the existing `wm_session_dead` counter into evidence for deciding whether the blackout population is primarily cookieless clients or server-side verification lag, while preserving the existing once-per-episode emission and 15-minute suppression behavior.

## Validation

- Added focused coverage for both `mint_failed` and `retry_401`, including the existing one-event-per-episode guarantee.
- Passed the 13-test session recovery suite and frontend TypeScript check.
- Passed the repository pre-push gate, including frontend/API/Convex typechecks, architecture and policy checks, the focused session suite, and 228 Edge Function tests.

## Post-Deploy Monitoring & Validation

- Search Sentry issue `WORLDMONITOR-WG` for `kind:wm_session_dead` and group by `reason`.
- Compare hourly `retry_401` volume with Upstash saturation/bandwidth windows and the bootstrap CDN-shield rollout from PR #5250; compare `mint_failed` with `/api/wm-session` non-200 outcomes.
- Healthy: every new event has exactly one of the two reason values, total episode volume remains continuous with the pre-deploy baseline, and no auth/session error metric regresses.
- Failure/rollback trigger: missing or unexpected reason values, a discontinuity in total `wm_session_dead` volume, or any concurrent increase in client session failures. Revert commit `9617968a5` if the telemetry change is implicated; session behavior itself is otherwise unchanged.
- Validation window: first 24 hours for tag integrity, then 72 hours for correlation. Owner: WorldMonitor maintainer/on-call.

Related: #5251

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
