### PR TITLE
fix(health): measure list-typed data keys with LLEN, not STRLEN

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -690,6 +690,24 @@ function strlenIsData(strlen) {
   return strlen > 0 && strlen !== NEG_SENTINEL.length;
 }
 
+// Data keys whose Redis value is a LIST rather than a string. STRLEN against a
+// list returns WRONGTYPE, which lands in keyErrors and pins the key at
+// REDIS_PARTIAL forever even though its seeder is healthy — measure these with
+// LLEN instead. Presence is then simply `len > 0`: the NEG_SENTINEL
+// byte-length rule above is a STRING concept, and applying it to a list would
+// declare a 10-ELEMENT history empty.
+const LIST_DATA_KEYS = new Set([
+  STANDALONE_KEYS.forecastBets, // LPUSH/LTRIM — scripts/seed-forecast-bets.mjs
+]);
+
+function dataLenCommand(redisKey) {
+  return [LIST_DATA_KEYS.has(redisKey) ? 'LLEN' : 'STRLEN', redisKey];
+}
+
+function keyHasData(redisKey, len) {
+  return LIST_DATA_KEYS.has(redisKey) ? len > 0 : strlenIsData(len);
+}
+
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
     return { seedAge: null, seedStale: null, seedError: false, metaReadFailed: false, metaCount: null, contentAge: null };
@@ -753,7 +771,7 @@ function isCascadeCovered(name, hasData, keyStrens, keyErrors) {
     const sibKey = STANDALONE_KEYS[sibling] ?? BOOTSTRAP_KEYS[sibling];
     if (!sibKey) continue;
     if (keyErrors.get(sibKey)) continue;
-    if (strlenIsData(keyStrens.get(sibKey) ?? 0)) return true;
+    if (keyHasData(sibKey, keyStrens.get(sibKey) ?? 0)) return true;
   }
   return false;
 }
@@ -776,7 +794,7 @@ function classifyKey(name, redisKey, opts, ctx) {
   }
 
   const strlen = keyStrens.get(redisKey) ?? 0;
-  const hasData = strlenIsData(strlen);
+  const hasData = keyHasData(redisKey, strlen);
   const { seedAge, seedStale, seedError, metaCount, contentAge } = meta;
 
   // When the data key is gone the meta count is meaningless; force records=0
@@ -941,11 +959,12 @@ export default async function handler(req, ctx) {
 
   // STRLEN for data keys avoids loading large blobs into memory (OOM prevention).
   // NEG_SENTINEL ('__WM_NEG__') is 10 bytes — strlenIsData() rejects exactly
-  // that length while accepting any other non-zero strlen as data.
+  // that length while accepting any other non-zero strlen as data. List-typed
+  // keys (LIST_DATA_KEYS) take LLEN instead; STRLEN would WRONGTYPE on them.
   let results;
   try {
     const commands = [
-      ...allDataKeys.map(k => ['STRLEN', k]),
+      ...allDataKeys.map(dataLenCommand),
       ...allMetaKeys.map(k => ['GET', k]),
       ...activationEntries.map(([, marker]) => ['EXISTS', marker]),
     ];
@@ -1149,6 +1168,10 @@ export const __testing__ = {
   classifyKey,
   ACTIVATION_MARKERS,
   STATUS_COUNTS,
+  // List-typed data keys + the command builder that measures them with LLEN
+  // instead of STRLEN (tests/health-list-data-keys.test.mjs).
+  LIST_DATA_KEYS,
+  dataLenCommand,
   // U7 (Tier 3 parity test): exposed for tests/mcp-bootstrap-parity.test.mjs
   // to walk the canonical seeded-data inventory. Both consts are unexported
   // at module scope by design — this is the test-only escape hatch.

--- a/tests/health-list-data-keys.test.mjs
+++ b/tests/health-list-data-keys.test.mjs
@@ -1,0 +1,110 @@
+// Health data keys that are Redis LISTS, not strings (#5233 regression).
+//
+// /api/health measures every registered data key with STRLEN. STRLEN against a
+// LIST returns a WRONGTYPE error, which the handler records in keyErrors and
+// classifyKey turns into REDIS_PARTIAL (records: null) — permanently, for a
+// seeder that is perfectly healthy. `forecast:bets:history:v1` is written with
+// LPUSH/LTRIM (scripts/seed-forecast-bets.mjs) and shipped into STANDALONE_KEYS
+// with #5233, so prod has reported forecastBets: REDIS_PARTIAL ever since.
+//
+// Two halves must hold, and this file pins both:
+//   1. the pipeline must issue LLEN (not STRLEN) for list-typed keys, and
+//   2. presence for a list must be `len > 0` — the NEG_SENTINEL byte-length
+//      rule in strlenIsData() is a STRING concept, so a 10-ELEMENT list must
+//      not be mistaken for the 10-BYTE '__WM_NEG__' sentinel.
+//
+// node:test to match the repo's data-test runner (tsx --test tests/*.test.mjs).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ } from '../api/health.js';
+
+const { classifyKey, LIST_DATA_KEYS, dataLenCommand, STANDALONE_KEYS, SEED_META } = __testing__;
+
+const NOW = 1_700_000_000_000;
+const ONE_MIN_MS = 60_000;
+const BETS_KEY = STANDALONE_KEYS.forecastBets;
+
+function makeCtx({ strens = {}, errors = {}, metaValues = {}, metaErrors = {} } = {}) {
+  return {
+    keyStrens: new Map(Object.entries(strens)),
+    keyErrors: new Map(Object.entries(errors)),
+    keyMetaValues: new Map(Object.entries(metaValues).map(([k, v]) => [k, typeof v === 'string' ? v : JSON.stringify(v)])),
+    keyMetaErrors: new Map(Object.entries(metaErrors)),
+    now: NOW,
+  };
+}
+
+const freshBetsMeta = (over = {}) => ({
+  [SEED_META.forecastBets.key]: JSON.stringify({ fetchedAt: NOW - ONE_MIN_MS, recordCount: 4, ...over }),
+});
+
+// ── the registry itself ─────────────────────────────────────────────────────
+
+test('forecast:bets:history:v1 is registered as a LIST key', () => {
+  assert.ok(LIST_DATA_KEYS.has(BETS_KEY), `${BETS_KEY} must be in LIST_DATA_KEYS — it is written with LPUSH/LTRIM`);
+});
+
+// ── half 1: the pipeline command ────────────────────────────────────────────
+
+test('dataLenCommand issues LLEN for list keys and STRLEN for string keys', () => {
+  assert.deepEqual(dataLenCommand(BETS_KEY), ['LLEN', BETS_KEY]);
+  // A representative string key must be untouched.
+  const stringKey = STANDALONE_KEYS.defensePatents;
+  assert.deepEqual(dataLenCommand(stringKey), ['STRLEN', stringKey]);
+});
+
+// ── half 2: presence semantics ──────────────────────────────────────────────
+
+test('a populated bets list with fresh seed-meta classifies OK (not REDIS_PARTIAL)', () => {
+  const entry = classifyKey('forecastBets', BETS_KEY, {}, makeCtx({
+    strens: { [BETS_KEY]: 1 },          // LLEN = 1 snapshot
+    metaValues: freshBetsMeta(),        // seeder healthy, recordCount 4
+  }));
+  assert.equal(entry.status, 'OK');
+  assert.equal(entry.records, 4);
+});
+
+test('a 10-ELEMENT list is data, not the 10-BYTE NEG_SENTINEL', () => {
+  // The trap: strlenIsData() rejects exactly 10 bytes as '__WM_NEG__'. Reusing
+  // it for LLEN would silently declare a 10-entry history EMPTY (crit).
+  const entry = classifyKey('forecastBets', BETS_KEY, {}, makeCtx({
+    strens: { [BETS_KEY]: 10 },
+    metaValues: freshBetsMeta({ recordCount: 7 }),
+  }));
+  assert.equal(entry.status, 'OK');
+  assert.equal(entry.records, 7);
+});
+
+test('an empty bets list (LLEN 0) still reports absent', () => {
+  const entry = classifyKey('forecastBets', BETS_KEY, {}, makeCtx({
+    strens: { [BETS_KEY]: 0 },
+    metaValues: freshBetsMeta(),
+  }));
+  // forecastBets is in EMPTY_DATA_OK_KEYS (#5233: tolerated as STALE_SEED/OK
+  // while fresh), so assert only that it is NOT scored as present-with-records.
+  assert.notEqual(entry.status, 'OK_LIST_PRESENT');
+  assert.equal(entry.records, 0);
+});
+
+// ── regressions the fix must not break ──────────────────────────────────────
+
+test('a REAL per-command Redis error on the list key still surfaces REDIS_PARTIAL', () => {
+  const entry = classifyKey('forecastBets', BETS_KEY, {}, makeCtx({
+    errors: { [BETS_KEY]: 'ERR something broke' },
+    metaValues: freshBetsMeta(),
+  }));
+  assert.equal(entry.status, 'REDIS_PARTIAL');
+  assert.equal(entry.records, null);
+});
+
+test('string keys keep NEG_SENTINEL semantics: strlen 10 is NOT data', () => {
+  const key = STANDALONE_KEYS.defensePatents;
+  const entry = classifyKey('defensePatents', key, {}, makeCtx({
+    strens: { [key]: 10 },  // exactly '__WM_NEG__'
+    metaValues: { [SEED_META.defensePatents.key]: JSON.stringify({ fetchedAt: NOW - ONE_MIN_MS, recordCount: 3 }) },
+  }));
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(entry.records, 0);
+});


### PR DESCRIPTION
## The bug

`/api/health` measures every registered data key with `STRLEN`. But `forecast:bets:history:v1` is a Redis **list** — `seed-forecast-bets.mjs:161-163` writes it with `LPUSH`/`LTRIM`. `STRLEN` against a list returns `WRONGTYPE`, the pipeline records that as a per-command error, and `classifyKey` turns it into `REDIS_PARTIAL` (`records: null`) — permanently, for a seeder that is perfectly healthy.

Prod has reported `forecastBets: REDIS_PARTIAL` ever since #5233 registered the key, and it is one of the two warns currently holding `/api/health` at `DEGRADED`.

## Verified against prod Redis

```
STRLEN forecast:bets:history:v1 -> WRONGTYPE Operation against a key holding the wrong kind of value
                                -> {"status":"REDIS_PARTIAL","records":null}
LLEN   forecast:bets:history:v1 -> 1
                                -> {"status":"OK","records":4,"seedAgeMin":691}
```

The seeder was never broken: `seed-meta:forecast:bets` is fresh with `recordCount: 4`.

## The fix

`LIST_DATA_KEYS` names the list-typed keys, `dataLenCommand()` issues `LLEN` for them and `STRLEN` for everything else, and `keyHasData()` gates presence on `len > 0` for lists.

That last part is load-bearing. `strlenIsData()` rejects exactly 10 bytes as the `__WM_NEG__` sentinel — a **string** concept. Reusing it for `LLEN` would silently classify a 10-**element** history as `EMPTY` (crit). The test pins that case explicitly.

A `TYPE` sweep of all 218 registered data keys against prod Redis confirms `forecastBets` is the only non-string key today, so the blast radius is exactly one key.

## Tests

`tests/health-list-data-keys.test.mjs` — written first, confirmed failing against unfixed code (`dataLenCommand is not a function`; the 10-element list scored `records: 0` instead of `7`). Covers both halves of the bug plus the regressions:

- `LLEN` is issued for list keys, `STRLEN` for string keys
- a populated bets list with fresh seed-meta classifies `OK`, not `REDIS_PARTIAL`
- a 10-**element** list is data, not the 10-**byte** sentinel
- a *real* per-command Redis error still surfaces `REDIS_PARTIAL`
- string keys keep `NEG_SENTINEL` semantics (strlen 10 is not data)

172 tests pass across every file that touches health internals (`health-classify`, `health-content-age`, `health-redis-down-status`, `forecast-health-registration`, `health-compact-cdn-cache`, `bootstrap`, `mcp-bootstrap-parity`, `resilience-scores-seed`, `temporal-anomalies-cache`). `biome lint` and `typecheck:api` clean.

## Not in scope

Found while triaging the same `DEGRADED` response — filing separately:
- **`acledIntel` (crit)** — `seed-conflict-intel` has no ACLED credentials (`VITE_ACLED_ACCESS_TOKEN` is set but empty; the seeder reads `ACLED_EMAIL`/`ACLED_PASSWORD` or `ACLED_ACCESS_TOKEN`), and its GDELT fallback is dead upstream. It publishes nothing, exits 0, and its keys have expired. Needs credentials, not code.
- **`defensePatents` (crit)** — the seeder targets `search.patentsview.org`, which is now **NXDOMAIN**; PatentsView has migrated to USPTO's Open Data Portal (needs an API key + a rewrite). The cron is already disabled; health still scores the key as crit.

https://claude.ai/code/session_014xoeVpgK3YJtUcr4t5VzF4