### PR TITLE
perf(llm): cut DeepSeek Flash stall tail

### DIFF
--- a/scripts/_llm-model-timeouts.d.mts
+++ b/scripts/_llm-model-timeouts.d.mts
@@ -1,0 +1,7 @@
+// Declaration file for the dependency-free timeout policy shared by the
+// Railway forecast workers and bundled server code.
+export const DEEPSEEK_V4_FLASH_MODEL_PREFIX: string;
+export const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS: number;
+
+export function isDeepseekV4FlashModel(model: string): boolean;
+export function getLlmAttemptTimeoutMs(model: string, requestedTimeoutMs: number): number;

--- a/scripts/_llm-model-timeouts.mjs
+++ b/scripts/_llm-model-timeouts.mjs
@@ -1,0 +1,18 @@
+// Shared model-specific LLM timeout policy. This module lives in scripts/
+// because Railway forecast workers package only that directory; server code
+// can import it and Vercel's build inlines the dependency.
+export const DEEPSEEK_V4_FLASH_MODEL_PREFIX = 'deepseek/deepseek-v4-flash';
+
+// This is a non-streaming completion deadline, not a first-token deadline.
+// Keep it above the pinned endpoint's observed p50 while cutting off the 25s stall tail.
+export const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
+
+export function isDeepseekV4FlashModel(model) {
+  return model.startsWith(DEEPSEEK_V4_FLASH_MODEL_PREFIX);
+}
+
+export function getLlmAttemptTimeoutMs(model, requestedTimeoutMs) {
+  return isDeepseekV4FlashModel(model)
+    ? Math.min(requestedTimeoutMs, DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS)
+    : requestedTimeoutMs;
+}

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11,6 +11,7 @@ import { attachResolutionSpecs } from './_forecast-resolution.mjs';
 import { assessFunnelDiversity } from './_forecast-funnel.mjs';
 import { resolveR2StorageConfig, putR2JsonObject, getR2JsonObject } from './_r2-storage.mjs';
 import { extractFirstJsonObject, extractFirstJsonArray, cleanJsonText } from './_llm-json.mjs';
+import { getLlmAttemptTimeoutMs, isDeepseekV4FlashModel } from './_llm-model-timeouts.mjs';
 import { loadTickerSet } from './_ticker-validation.mjs';
 import { computeEmaWindows, computeRisk24h } from './_ema-threat-engine.mjs';
 import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.mjs';
@@ -14684,10 +14685,6 @@ const FORECAST_LLM_PROVIDERS = [
   { name: 'openrouter', envKey: 'OPENROUTER_API_KEY', apiUrl: 'https://openrouter.ai/api/v1/chat/completions', model: 'deepseek/deepseek-v4-flash', timeout: 25_000, extraBody: { reasoning: { enabled: false } } },
   { name: 'groq', envKey: 'GROQ_API_KEY', apiUrl: 'https://api.groq.com/openai/v1/chat/completions', model: 'llama-3.3-70b-versatile', timeout: 20_000 },
 ];
-const DEEPSEEK_V4_FLASH_MODEL_PREFIX = 'deepseek/deepseek-v4-flash';
-// This is a non-streaming completion deadline, not a first-token deadline.
-// Keep it above the pinned endpoint's observed p50 while cutting off the 25s stall tail.
-const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
 // 3 retries (=4 attempts/provider): during an OpenRouter slowdown 2 retries all timed
 // out and market_implications wrote an error seed-meta. Bounded by the per-stage /
@@ -14804,15 +14801,13 @@ function resolveForecastLlmProviders(options = {}) {
     if (!provider) continue;
     seen.add(providerName);
     const model = options.modelOverrides?.[provider.name] || provider.model;
-    const failFastOnTimeout = model.startsWith(DEEPSEEK_V4_FLASH_MODEL_PREFIX);
+    const failFastOnTimeout = isDeepseekV4FlashModel(model);
     providers.push({
       ...provider,
       model,
       // #5246: cut off Flash's 25s stall tail while preserving enough room for
       // the pinned endpoint's observed median completion. Other models are unchanged.
-      timeout: failFastOnTimeout
-        ? Math.min(provider.timeout, DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS)
-        : provider.timeout,
+      timeout: getLlmAttemptTimeoutMs(model, provider.timeout),
       failFastOnTimeout,
       // `null` explicitly clears the table entry's extraBody (R13 pin);
       // undefined leaves it untouched.

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14684,6 +14684,10 @@ const FORECAST_LLM_PROVIDERS = [
   { name: 'openrouter', envKey: 'OPENROUTER_API_KEY', apiUrl: 'https://openrouter.ai/api/v1/chat/completions', model: 'deepseek/deepseek-v4-flash', timeout: 25_000, extraBody: { reasoning: { enabled: false } } },
   { name: 'groq', envKey: 'GROQ_API_KEY', apiUrl: 'https://api.groq.com/openai/v1/chat/completions', model: 'llama-3.3-70b-versatile', timeout: 20_000 },
 ];
+const DEEPSEEK_V4_FLASH_MODEL_PREFIX = 'deepseek/deepseek-v4-flash';
+// This is a non-streaming completion deadline, not a first-token deadline.
+// Keep it above the pinned endpoint's observed p50 while cutting off the 25s stall tail.
+const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
 // 3 retries (=4 attempts/provider): during an OpenRouter slowdown 2 retries all timed
 // out and market_implications wrote an error seed-meta. Bounded by the per-stage /
@@ -14799,9 +14803,17 @@ function resolveForecastLlmProviders(options = {}) {
     const provider = FORECAST_LLM_PROVIDERS.find(item => item.name === providerName);
     if (!provider) continue;
     seen.add(providerName);
+    const model = options.modelOverrides?.[provider.name] || provider.model;
+    const failFastOnTimeout = model.startsWith(DEEPSEEK_V4_FLASH_MODEL_PREFIX);
     providers.push({
       ...provider,
-      model: options.modelOverrides?.[provider.name] || provider.model,
+      model,
+      // #5246: cut off Flash's 25s stall tail while preserving enough room for
+      // the pinned endpoint's observed median completion. Other models are unchanged.
+      timeout: failFastOnTimeout
+        ? Math.min(provider.timeout, DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS)
+        : provider.timeout,
+      failFastOnTimeout,
       // `null` explicitly clears the table entry's extraBody (R13 pin);
       // undefined leaves it untouched.
       extraBody: options.extraBodyOverrides?.[provider.name] !== undefined
@@ -15099,8 +15111,8 @@ function getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
 // Remaining RUN-level LLM budget in ms (Infinity when no run deadline is set —
 // tests and the deep-forecast worker, which have only the per-stage budget).
 // market_implications runs LAST in afterPublish, so this is the budget that
-// starves it when upstream stages are slow (e.g. deepseek-v4-flash 30s
-// timeouts drain the shared 150s run budget before the tail stage runs). #4978.
+// starves it when upstream stages are slow (e.g. repeated provider stalls drain
+// the shared 150s run budget before the tail stage runs). #4978.
 function getRemainingForecastLlmRunBudgetMs() {
   return forecastLlmRunDeadlineMs == null ? Infinity : forecastLlmRunDeadlineMs - Date.now();
 }
@@ -15266,6 +15278,12 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
               err.__llmAttemptRecorded = true;
               const name = err?.name;
               const timedOut = name === 'TimeoutError' || name === 'AbortError';
+              // A Flash timeout represents the observed provider stall mode,
+              // not a transient response worth replaying four times. Move on
+              // to the fallback provider after the first full 15s window.
+              if (timedOut && provider.failFastOnTimeout && attemptTimeoutMs >= provider.timeout) {
+                err.nonRetryable = true;
+              }
               // Attribute a timeout to the run budget (not the provider) ONLY when
               // this attempt's timeout was itself CAPPED below the provider's own
               // timeout (attemptTimeoutMs < provider.timeout) AND the run budget is
@@ -17025,7 +17043,7 @@ const MARKET_IMPLICATIONS_STAGE_CACHE_PREFIX = 'forecast:llm-market-implications
 // overridden) order that actually has an API key, ONE attempt each (market_implications
 // forces maxRetries:0), summed with the 5s stage guard that getUsableForecastLlmBudgetMs
 // subtracts. Reserving only the PRIMARY timeout (the original 30_000) was a latent bug:
-// with the default openrouter→groq order a 25s deepseek-v4-flash timeout drained the
+// with the default openrouter→groq order a DeepSeek Flash timeout drained the
 // budget so the groq FALLBACK was stranded and a recoverable timeout was misreported as
 // SEED_ERROR (health WARNING). Reserving the full chain means an admitted call can exhaust
 // the primary AND still run the fallback; below that we skip and preserve last-good (green,
@@ -17150,7 +17168,7 @@ async function buildAndSeedMarketImplications(inputs) {
 
   // Tail-stage budget guard (#4978): market_implications is the LAST forecast
   // LLM stage under the shared 150s run budget. When upstream stages are slow
-  // (e.g. deepseek-v4-flash 30s timeouts) they drain that budget before this
+  // (e.g. repeated provider stalls) they drain that budget before this
   // stage runs; callForecastLLM would then throw a budget error, return null,
   // and we'd (mis)write a SEED_ERROR for benign, self-healing resource
   // contention. Skip gracefully and preserve last-good instead.

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -204,6 +204,16 @@ export function stripThinkingTags(text: string): string {
 // it is skipped in cloud where OLLAMA_API_URL is unset.
 const PROVIDER_CHAIN = ['ollama', 'openrouter', 'groq', 'generic'] as const;
 const PROVIDER_SET = new Set<string>(PROVIDER_CHAIN);
+const DEEPSEEK_V4_FLASH_MODEL_PREFIX = 'deepseek/deepseek-v4-flash';
+// This is a non-streaming completion deadline, not a first-token deadline.
+// Keep it above the pinned endpoint's observed p50 while cutting off the 25s stall tail.
+const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
+
+export function getLlmAttemptTimeoutMs(model: string, requestedTimeoutMs: number): number {
+  return model.startsWith(DEEPSEEK_V4_FLASH_MODEL_PREFIX)
+    ? Math.min(requestedTimeoutMs, DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS)
+    : requestedTimeoutMs;
+}
 
 export interface LlmCallOptions {
   messages: Array<{ role: string; content: string }>;
@@ -613,7 +623,10 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
             temperature,
             max_tokens: maxTokens,
           }),
-          signal: AbortSignal.timeout(timeoutMs),
+          // #5246: DeepSeek V4 Flash is bimodal — healthy calls finish near 2s,
+          // while stalled calls hang to the old 25s clamp. Cut only this model's
+          // dead tail so the existing provider chain can reach its fallback.
+          signal: AbortSignal.timeout(getLlmAttemptTimeoutMs(creds.model, timeoutMs)),
         });
 
         if (!resp.ok) {

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -2,6 +2,9 @@ import { CHROME_UA } from './constants';
 import { isProviderAvailable } from './llm-health';
 import { sanitizeForPrompt } from './llm-sanitize.js';
 import { buildLlmCallEvent, deliverUsageEvents, type LlmCallEvent } from './usage';
+import { getLlmAttemptTimeoutMs } from '../../scripts/_llm-model-timeouts.mjs';
+
+export { getLlmAttemptTimeoutMs } from '../../scripts/_llm-model-timeouts.mjs';
 
 function promptChars(messages: Array<{ role: string; content: string }>): number {
   return messages.reduce((sum, m) => sum + (m.content?.length ?? 0), 0);
@@ -204,16 +207,6 @@ export function stripThinkingTags(text: string): string {
 // it is skipped in cloud where OLLAMA_API_URL is unset.
 const PROVIDER_CHAIN = ['ollama', 'openrouter', 'groq', 'generic'] as const;
 const PROVIDER_SET = new Set<string>(PROVIDER_CHAIN);
-const DEEPSEEK_V4_FLASH_MODEL_PREFIX = 'deepseek/deepseek-v4-flash';
-// This is a non-streaming completion deadline, not a first-token deadline.
-// Keep it above the pinned endpoint's observed p50 while cutting off the 25s stall tail.
-const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
-
-export function getLlmAttemptTimeoutMs(model: string, requestedTimeoutMs: number): number {
-  return model.startsWith(DEEPSEEK_V4_FLASH_MODEL_PREFIX)
-    ? Math.min(requestedTimeoutMs, DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS)
-    : requestedTimeoutMs;
-}
 
 export interface LlmCallOptions {
   messages: Array<{ role: string; content: string }>;

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -1631,8 +1631,10 @@ describe('forecast llm overrides', () => {
     assert.deepEqual(options.providerOrder, ['openrouter', 'groq']);
     assert.equal(providers[0]?.name, 'openrouter');
     assert.equal(providers[0]?.model, 'deepseek/deepseek-v4-flash');
+    assert.equal(providers[0]?.timeout, 15_000, 'stalled DeepSeek Flash calls must fall through before the 25s clamp');
     assert.equal(providers[1]?.name, 'groq');
     assert.equal(providers[1]?.model, 'llama-3.3-70b-versatile');
+    assert.equal(providers[1]?.timeout, 20_000, 'the fallback keeps its provider-specific window');
   });
 
   it('pins critical_signals to the pre-#4944 chain (probability-coupled stage)', () => {
@@ -1652,6 +1654,7 @@ describe('forecast llm overrides', () => {
     assert.equal(providers[0]?.model, 'llama-3.1-8b-instant');
     assert.equal(providers[1]?.name, 'openrouter');
     assert.equal(providers[1]?.model, 'google/gemini-2.5-flash');
+    assert.equal(providers[1]?.timeout, 25_000, 'the DeepSeek stall cutoff must not change the pinned Gemini fallback');
     assert.equal(providers[1]?.extraBody, undefined, 'pinned openrouter entry must keep the legacy request body (no reasoning field)');
   });
 
@@ -1723,10 +1726,12 @@ describe('forecast llm overrides', () => {
     assert.equal(combinedProviders.length, 1);
     assert.equal(combinedProviders[0]?.name, 'openrouter');
     assert.equal(combinedProviders[0]?.model, 'google/gemini-2.5-pro');
+    assert.equal(combinedProviders[0]?.timeout, 25_000, 'model overrides outside DeepSeek Flash keep the original timeout');
 
     assert.deepEqual(scenarioOptions.providerOrder, ['openrouter', 'groq']);
     assert.equal(scenarioProviders[0]?.name, 'openrouter');
     assert.equal(scenarioProviders[0]?.model, 'deepseek/deepseek-v4-flash');
+    assert.equal(scenarioProviders[0]?.timeout, 15_000);
     assert.equal(scenarioProviders[1]?.model, 'llama-3.3-70b-versatile');
   });
 
@@ -1741,6 +1746,38 @@ describe('forecast llm overrides', () => {
     assert.equal(providers.length, 1);
     assert.equal(providers[0]?.name, 'openrouter');
     assert.equal(providers[0]?.model, 'google/gemini-2.5-flash-lite-preview');
+  });
+
+  it('falls through immediately after a DeepSeek Flash stall instead of retrying the hung provider', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const calls = [];
+
+    __setForecastLlmTransportForTests({
+      fetch: async (url) => {
+        calls.push(String(url));
+        if (String(url).includes('openrouter.ai')) {
+          const error = new Error('The operation was aborted due to timeout');
+          error.name = 'TimeoutError';
+          throw error;
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({
+            model: 'llama-3.3-70b-versatile',
+            choices: [{ message: { content: 'Groq fallback returned a complete narrative.' } }],
+          }),
+        };
+      },
+    });
+
+    const result = await __callForecastLlmForTests('system', 'user', { stage: 'scenario', retryDelayMs: 0 });
+
+    assert.equal(result?.provider, 'groq');
+    assert.equal(calls.filter((url) => url.includes('openrouter.ai')).length, 1);
+    assert.equal(calls.filter((url) => url.includes('api.groq.com')).length, 1);
   });
 
   it('retries a 429 Retry-After response on the same provider and returns groq', async () => {

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -2,7 +2,7 @@
 //
 // market_implications is the LAST forecast LLM stage (afterPublish) and shares
 // the single 150s run budget with every upstream stage. When upstream stages
-// are slow (e.g. deepseek-v4-flash 30s timeouts, #4944) they drain that budget
+// are slow (e.g. repeated LLM provider stalls, #4944) they drain that budget
 // before this stage runs; callForecastLLM then throws a budget error and
 // returns null. The bug: the caller treated that starve identically to a real
 // LLM failure and wrote a `status:'error'` seed-meta, so /api/health flipped to
@@ -155,8 +155,9 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
   // 40s: the resolved chain here is openrouter-only (pinned below), so the
-  // reservation is just 25s + 5s guard = 30s — a 40s budget admits it (the static
-  // all-provider 50s reservation would have wrongly skipped). The mock then drains
+  // reservation is just 15s + 5s guard = 20s — a 40s budget admits it (the static
+  // all-provider 40s reservation would also admit, but the test still proves the
+  // resolved provider chain drives admission). The mock then drains
   // the deadline mid-flight to prove a real failure is not reclassified as a starve.
   __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
 
@@ -181,15 +182,15 @@ test('pre-call guard skips when the run budget cannot cover the full provider ch
   const store = {};
   __setRedisStoreForTests(store);
   seedLastGood(store);
-  // Default chain, both providers runnable → reservation is openrouter 25s + groq
-  // 20s + 5s guard = 50s. Real keys so a broken/too-low guard would actually invoke
+  // Default chain, both providers runnable → reservation is openrouter 15s + groq
+  // 20s + 5s guard = 40s. Real keys so a broken/too-low guard would actually invoke
   // the transport rather than short-circuit on a missing key.
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.GROQ_API_KEY = 'test-key';
   delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
   delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
-  // 25s run budget: well below the 50s two-provider reservation, so it must SKIP
+  // 25s run budget: below the 40s two-provider reservation, so it must SKIP
   // cleanly and preserve last-good instead of attempting an ambiguous, doomed call.
   __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
 
@@ -212,7 +213,7 @@ test('mid-call budget_exhausted result preserves last-good, no SEED_ERROR (#5 de
   __setRedisStoreForTests(store);
   seedLastGood(store);
 
-  // Admit the call (>= the 50s full-chain reservation), then have callForecastLLM
+  // Admit the call (>= the 40s full-chain reservation), then have callForecastLLM
   // report a run-budget exhaustion mid-flight. This drives the caller's mid-call
   // preserve branch (result.failureReason === BUDGET_EXHAUSTED) directly via the
   // call-override seam — retained as defense-in-depth for env-overridden provider
@@ -263,13 +264,12 @@ test('a budget covering only the primary — not the fallback — skips instead 
   delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
   delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
-  // 40s budget: enough for the primary openrouter attempt (25s) + guard — the OLD
-  // 30s threshold admitted this — but NOT the full openrouter→groq chain (50s). The
-  // reported bug: admitted, deepseek-v4-flash timed out (~25s), the run budget was
-  // drained, the groq fallback was stranded ("groq llm budget exhausted"), and a
-  // recoverable timeout was misreported as SEED_ERROR (health WARNING). The full-
+  // 30s budget: enough for the primary openrouter attempt (15s) + guard, but NOT
+  // the full openrouter→groq chain (40s). The reported bug class is unchanged:
+  // admitting only the primary can strand Groq ("groq llm budget exhausted")
+  // after a timeout and misreport a recoverable timeout as SEED_ERROR. The full-
   // chain reservation makes this SKIP and preserve last-good (green) instead.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  __setForecastLlmRunDeadlineForTests(Date.now() + 30_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -294,7 +294,7 @@ test('an admitted primary timeout falls through to the fallback in ONE attempt e
   delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
   delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
-  // 60s admits the full two-provider chain (50s). Every attempt times out. PRE-FIX,
+  // 60s admits the full two-provider chain (40s). Every attempt times out. PRE-FIX,
   // openrouter's 3 retries (4 attempts) drained the run budget and groq was NEVER
   // reached — a recoverable timeout became a SEED_ERROR without trying the fallback.
   // With maxRetries:0 each provider gets exactly ONE attempt, so groq IS reached.
@@ -325,12 +325,12 @@ test('a single-provider override reserves only that provider — admitted where 
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.GROQ_API_KEY = 'test-key';
-  // Pin to openrouter only → resolved chain reserves just 25s + 5s = 30s.
+  // Pin to openrouter only → resolved chain reserves just 15s + 5s = 20s.
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
 
-  // 40s: below the 2-provider 50s reservation (would skip) but above the pinned
-  // single-provider 30s reservation — so this MUST be admitted, not skipped.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  // 25s: below the 2-provider 40s reservation (would skip) but above the pinned
+  // single-provider 20s reservation — so this MUST be admitted, not skipped.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -340,5 +340,5 @@ test('a single-provider override reserves only that provider — admitted where 
 
   await buildAndSeedMarketImplications({});
 
-  assert.equal(providerCalls, 1, 'a pinned single-provider chain needs only 30s, so a 40s budget must ADMIT it (and try it once)');
+  assert.equal(providerCalls, 1, 'a pinned single-provider chain needs only 20s, so a 25s budget must ADMIT it (and try it once)');
 });

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
-import { callLlm, callLlmReasoning } from '../server/_shared/llm.ts';
+import { callLlm, callLlmReasoning, getLlmAttemptTimeoutMs } from '../server/_shared/llm.ts';
 
 const originalFetch = globalThis.fetch;
+const originalAbortSignalTimeout = AbortSignal.timeout;
 const originalGroqApiKey = process.env.GROQ_API_KEY;
 const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 const originalOllamaApiUrl = process.env.OLLAMA_API_URL;
@@ -14,6 +15,7 @@ const originalLlmReasoningModel = process.env.LLM_REASONING_MODEL;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  AbortSignal.timeout = originalAbortSignalTimeout;
 
   if (originalLlmReasoningProvider === undefined) delete process.env.LLM_REASONING_PROVIDER;
   else process.env.LLM_REASONING_PROVIDER = originalLlmReasoningProvider;
@@ -38,6 +40,42 @@ afterEach(() => {
 });
 
 describe('callLlm', () => {
+  it('fails stalled DeepSeek V4 Flash calls over to the next provider after 15s', () => {
+    assert.equal(getLlmAttemptTimeoutMs('deepseek/deepseek-v4-flash', 25_000), 15_000);
+    assert.equal(getLlmAttemptTimeoutMs('deepseek/deepseek-v4-flash', 8_000), 8_000);
+    assert.equal(getLlmAttemptTimeoutMs('deepseek/deepseek-v4-pro', 25_000), 25_000);
+    assert.equal(getLlmAttemptTimeoutMs('google/gemini-2.5-flash', 25_000), 25_000);
+  });
+
+  it('wires the DeepSeek Flash deadline into the shared chat-completion request', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const timeoutBySignal = new Map<AbortSignal, number>();
+    const postTimeouts: number[] = [];
+    AbortSignal.timeout = ((delay: number) => {
+      const signal = new AbortController().signal;
+      timeoutBySignal.set(signal, delay);
+      return signal;
+    }) as typeof AbortSignal.timeout;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      postTimeouts.push(timeoutBySignal.get(init?.signal as AbortSignal) ?? -1);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'bounded response' } }],
+        usage: { total_tokens: 5 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({ messages: [{ role: 'user', content: 'x' }] });
+
+    assert.equal(result?.provider, 'openrouter');
+    assert.deepEqual(postTimeouts, [15_000]);
+  });
+
   it('excludes China-hosted providers and sorts by throughput on every OpenRouter call', async () => {
     process.env.OPENROUTER_API_KEY = 'or-test-key';
     delete process.env.GROQ_API_KEY;


### PR DESCRIPTION
## Summary

DeepSeek V4 Flash stalls now leave OpenRouter after a 15-second completion deadline instead of consuming the full 25-second clamp, allowing forecast enrichment to reach Groq while useful run budget remains. The cutoff is model-specific, preserves shorter caller deadlines, and stays above the pinned endpoint's observed 12.3-second median; other OpenRouter models keep their existing windows.

| Stall behavior | Before | After |
|---|---:|---:|
| DeepSeek Flash completion deadline | 25s | 15s |
| Forecast attempts before provider fallback on timeout | up to 4 | 1 |

This is deliberately a completion deadline rather than a first-token deadline because the current non-streaming transports do not expose first-token timing.

Fixes #5246.

## Validation

- Pre-push gate passed: frontend/API/Convex typechecks, boundary and safety checks, edge bundle validation, server tests, changed-file tests, version sync, and related guards.
- Focused timeout, fallback, telemetry, and run-budget coverage passed: 15 shared-transport assertions plus 271 forecast assertions.
- Tests prove the shared request receives the 15-second abort signal, a stalled forecast call reaches Groq after one OpenRouter attempt, non-DeepSeek models retain their original deadlines, and market-implications admission reserves the shortened provider chain correctly.

## Post-Deploy Monitoring & Validation

For 24-48 hours after deployment, inspect `wm_api_usage` for `deepseek/deepseek-v4-flash` across `scenario`, `combined`, `impact_expansion`, `market_implications`, and `prompt_critique`.

- Expected: the >=24.5s timeout cluster approaches zero, forecast-stage wall time and run-budget starvation fall, and timed-out OpenRouter calls are followed by Groq at the next `fallback_index`.
- Failure signals: successful DeepSeek completions materially decline, `ok=false` grows, Groq volume/cost spikes, or market implications produce more budget-starved/SEED_ERROR outcomes.
- Rollback: revert this PR to restore the 25-second completion window and normal retry policy.
- Owner: forecast pipeline operator/on-call.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
