### PR TITLE
fix(seeders): fail retry when last-good keys are gone

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1511,12 +1511,21 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       }
     }
 
-    // Contract RETRY on empty (no zeroIsValid) — skip publish, extend TTL, exit 0.
+    // Contract RETRY on empty (no zeroIsValid) — skip publish and preserve the
+    // last-good keys. Exit 0 only when Redis confirms every key was actually
+    // extended; otherwise the data is already gone (or preservation could not
+    // be verified), so a green process would hide a live outage indefinitely.
     if (contractState === 'RETRY') {
       const durationMs = Date.now() - startMs;
       const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
       if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
-      await extendExistingTtl(keys, ttlSeconds || 600);
+      const preserved = await extendExistingTtl(keys, ttlSeconds || 600);
+      if (!preserved) {
+        console.error(`  FAILURE: declareRecords returned 0 and last-good preservation failed — one or more keys are missing or could not be extended`);
+        console.log(`\n=== Done (${Math.round(durationMs)}ms, RETRY FAILED) ===`);
+        await releaseLock(`${domain}:${resource}`, runId);
+        await exitAfterTelemetryFlush(1);
+      }
       console.log(`  RETRY: declareRecords returned 0 (zeroIsValid=false) — envelope unchanged, TTL extended, bundle will retry next cycle`);
       console.log(`\n=== Done (${Math.round(durationMs)}ms, RETRY) ===`);
       await releaseLock(`${domain}:${resource}`, runId);

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -144,6 +144,11 @@ test('contract RETRY remains graceful when every last-good key is preserved', as
 
   assert.equal(exitCode, 0,
     'zero-yield RETRY may remain exit 0 when every last-good key was actually preserved');
+  assert.deepEqual(
+    new Set(expireKeys()),
+    new Set(['test:retry-preserved:v1', 'seed-meta:test:retry-preserved']),
+    'RETRY must attempt to preserve both keys before treating the zero-yield run as graceful',
+  );
 });
 
 test('validation failure with emptyDataIsFailure:true does NOT refresh seed-meta', async () => {

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -18,18 +18,20 @@ const ORIGINAL_ENV = {
 };
 
 let recordedCalls;
+let expireResult;
 
 beforeEach(() => {
   process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
   recordedCalls = [];
+  expireResult = 0;
 
   globalThis.fetch = async (url, opts = {}) => {
     const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
     recordedCalls.push({ url: String(url), method: opts?.method || 'GET', body });
     // Lock acquire: SET NX returns OK. Pipeline (EXPIRE) returns array. Default: OK.
     if (Array.isArray(body) && Array.isArray(body[0])) {
-      return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+      return new Response(JSON.stringify(body.map(() => ({ result: expireResult }))), { status: 200 });
     }
     return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
   };
@@ -79,6 +81,19 @@ function expireKeys() {
     .map(cmd => cmd[1]);
 }
 
+function runEmptyContractRetry(resource) {
+  return runWithExitTrap(() =>
+    runSeed('test', resource, `test:${resource}:v1`, async () => ({ items: [] }), {
+      validateFn: (d) => Array.isArray(d?.items),
+      ttlSeconds: 3600,
+      sourceVersion: 'test-v1',
+      schemaVersion: 1,
+      maxStaleMin: 120,
+      declareRecords: (d) => d.items.length,
+    }),
+  );
+}
+
 test('fetch failure extends existing TTL and exits with graceful-failure code', async () => {
   const exitCode = await runWithExitTrap(() =>
     runSeed('test', 'fetch-fail', 'test:fetch-fail:v1', async () => {
@@ -106,6 +121,29 @@ test('fetch failure extends existing TTL and exits with graceful-failure code', 
     countMetaSets('fetch-fail'), 0,
     'fetch failure must not write fresh seed-meta while reporting graceful failure',
   );
+});
+
+test('contract RETRY hard-fails when expired keys make last-good preservation impossible', async () => {
+  expireResult = 0;
+  const exitCode = await runEmptyContractRetry('retry-missing');
+
+  assert.equal(exitCode, 1,
+    'zero-yield RETRY must be a hard failure when EXPIRE confirms the last-good keys are gone');
+  assert.deepEqual(
+    new Set(expireKeys()),
+    new Set(['test:retry-missing:v1', 'seed-meta:test:retry-missing']),
+    'RETRY must attempt to preserve both canonical and seed-meta keys before deciding its exit state',
+  );
+  assert.equal(countMetaSets('retry-missing'), 0,
+    'a failed RETRY must not write fresh seed-meta and mask the outage');
+});
+
+test('contract RETRY remains graceful when every last-good key is preserved', async () => {
+  expireResult = 1;
+  const exitCode = await runEmptyContractRetry('retry-preserved');
+
+  assert.equal(exitCode, 0,
+    'zero-yield RETRY may remain exit 0 when every last-good key was actually preserved');
 });
 
 test('validation failure with emptyDataIsFailure:true does NOT refresh seed-meta', async () => {


### PR DESCRIPTION
## Summary

Contract seeders can no longer report a successful retry after their last-good Redis keys have already expired. A zero-yield run now stays graceful only when Redis confirms every canonical, metadata, and registered extra key was preserved; otherwise it exits as a hard failure so Railway and bundle health expose the outage.

This hardens the false-green failure class behind the `acledIntel` incident. Restoring the ACLED feed itself still requires provisioning `ACLED_EMAIL` and `ACLED_PASSWORD` on `seed-conflict-intel`; this code change intentionally does not fabricate or relocate credentials.

## Validation

- Proof-first regression: the missing-key RETRY case initially exited `0`; it now exits `1`, while the all-keys-preserved control remains `0`.
- 32 focused seeder and GDELT contract tests pass.
- `npm run typecheck`, `npm run typecheck:api`, changed-file Biome lint, and `npm run build:full` pass.
- `npm run test:data`: 15,050 passed and 6 skipped; its only two initial failures required built `dist/dashboard.html`. After the full build, all 9 dashboard critical-CSS assertions pass.
- The pre-push gate passed typechecks, boundaries, safe-HTML, policy checks, edge bundling, version sync, and the changed test file.

## Post-Deploy Monitoring & Validation

- Search Railway logs for `RETRY FAILED`, `last-good preservation failed`, and bundle section status `FAILED` for `seed-conflict-intel`.
- Watch `/api/health` field `acledIntel`; healthy recovery is `records > 0` with a current `seed-meta:conflict:acled-intel` heartbeat.
- Failure signal: `acledIntel` remains `EMPTY` after ACLED credentials are provisioned and one 30-minute seed interval completes, or the seeder continues to hard-fail for two consecutive intervals.
- Mitigation: verify the ACLED credential pair, run the seeder manually to repopulate expired keys, and inspect upstream OAuth/API errors. Reverting this guard is not a data-recovery action because it would only restore the false-green exit.
- Validation window: two seed intervals (60 minutes) after deployment and credential provisioning. Owner: Railway/on-call operator for the conflict seeder.

Related: #5256

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)