### PR TITLE
fix(security): consolidate runtime hardening residuals

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,7 @@ World Monitor is a client-side intelligence dashboard that aggregates publicly a
 - No API keys should ever be committed to the repository
 - Environment variables (`.env.local`) are gitignored
 - The RSS proxy uses domain allowlisting to prevent SSRF. Both the Vercel Edge proxy and the Railway relay re-check the RSS allowlist on every redirect hop.
+- The Pro-gated MCP proxy accepts only HTTPS targets, resolves and rejects private/reserved A and AAAA answers immediately before each outbound request, and strips cloud-metadata headers. Vercel Edge `fetch` cannot pin its socket to the vetted address, so a narrow resolve-versus-connect DNS-rebinding window remains an accepted residual; closing it requires a Node-runtime/socket-pinning design (tracked in issue #5061).
 
 ### Edge Functions & Sebuf Handlers
 

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -187,7 +187,7 @@ async function assertServerUrlSafe(url) {
 // resolve. This re-resolve-and-recheck immediately before every outbound
 // dispatch NARROWS that DNS-rebinding window but does not close it. The
 // residual rebind window is an ACCEPTED limitation of the Edge runtime (no
-// socket-level pin available) — documented, not fixed here (P1, issue #4674).
+// socket-level pin available) — documented, not fixed here (P2, issue #5061).
 async function revalidateBeforeFetch(url) {
   await assertServerUrlSafe(url);
 }
@@ -222,7 +222,8 @@ async function validateServerUrl(raw) {
 // even if a DNS rebind slipped a fetch onto 169.254.169.254 the credential-less
 // request is refused by the metadata service. Matched case-insensitively. (The
 // full socket-pin fix that closes resolve!=connect is a Node-runtime follow-up;
-// this Edge mitigation kills the demonstrated PoC without a runtime switch.)
+// this Edge mitigation kills the demonstrated PoC without a runtime switch;
+// the accepted residual and migration trade-off are tracked in issue #5061.)
 const DENIED_FORWARD_HEADERS = new Set([
   'metadata-flavor',
   'metadata',
@@ -248,7 +249,7 @@ function buildHeaders(customHeaders) {
         // them as forbidden header names and silently drops them, so they never
         // reach the upstream. (The Node-runtime socket-pin follow-up uses raw
         // `http.request`, which does NOT auto-drop them, so that PR must add an
-        // explicit hop-by-hop filter — see #4674.)
+        // explicit hop-by-hop filter — see #5061.)
         if (safeKey && !DENIED_FORWARD_HEADERS.has(safeKey.toLowerCase())) {
           h[safeKey] = safeVal;
         }

--- a/scripts/lib/notification-webhook-ssrf.cjs
+++ b/scripts/lib/notification-webhook-ssrf.cjs
@@ -217,8 +217,12 @@ async function assertNotificationWebhookDeliveryUrlSafe(rawUrl, resolveHostname 
 }
 
 function responseFromNode(statusCode, statusMessage, headers, body) {
-  return new Response(new Uint8Array(body), {
-    status: statusCode || 502,
+  const status = statusCode || 502;
+  const responseBody = status === 204 || status === 205 || status === 304
+    ? null
+    : new Uint8Array(body);
+  return new Response(responseBody, {
+    status,
     statusText: statusMessage,
     headers,
   });
@@ -294,4 +298,5 @@ module.exports = {
   blockedNotificationWebhookUrlReason,
   isBlockedResolvedAddress,
   postJsonWithPinnedAddress,
+  responseFromNode,
 };

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -1,12 +1,10 @@
 'use strict';
 
 const { createHash } = require('node:crypto');
-const dns = require('node:dns').promises;
 const { Resend } = require('resend');
 const { decrypt } = require('./lib/crypto.cjs');
 const {
   assertNotificationWebhookDeliveryUrlSafe,
-  isBlockedResolvedAddress,
   postJsonWithPinnedAddress,
 } = require('./lib/notification-webhook-ssrf.cjs');
 const { callLLM } = require('./lib/llm-chain.cjs');
@@ -194,12 +192,6 @@ async function isUserPro(userId) {
     try { await upstashRest('SET', cacheKey, '0', 'EX', String(ENTITLEMENT_FAILCLOSED_CACHE_TTL)); } catch { /* cache write best-effort */ }
     return false;
   }
-}
-
-// ── Private IP guard ─────────────────────────────────────────────────────────
-
-function isPrivateIP(ip) {
-  return isBlockedResolvedAddress(ip);
 }
 
 // ── Quiet hours ───────────────────────────────────────────────────────────────
@@ -416,24 +408,26 @@ async function sendSlack(userId, webhookEnvelope, text) {
     console.warn(`[relay] Slack URL invalid for ${userId}`);
     return false;
   }
-  // SSRF prevention: resolve hostname and check for private IPs
+  let safeUrl;
+  let resolvedAddresses;
   try {
-    const hostname = new URL(webhookUrl).hostname;
-    const addresses = await dns.resolve4(hostname);
-    if (addresses.some(isPrivateIP)) {
-      console.warn(`[relay] Slack URL resolves to private IP for ${userId}`);
-      return false;
-    }
-  } catch {
-    console.warn(`[relay] Slack DNS resolution failed for ${userId}`);
+    ({ url: safeUrl, resolvedAddresses } = await assertNotificationWebhookDeliveryUrlSafe(webhookUrl));
+  } catch (err) {
+    console.warn(`[relay] Slack URL rejected for ${userId}:`, err.message);
     return false;
   }
-  const res = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
-    body: JSON.stringify({ text, unfurl_links: false }),
-    signal: AbortSignal.timeout(10000),
-  });
+  let res;
+  try {
+    res = await postJsonWithPinnedAddress(
+      safeUrl,
+      JSON.stringify({ text, unfurl_links: false }),
+      { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
+      resolvedAddresses,
+    );
+  } catch (err) {
+    console.warn(`[relay] Slack send error for ${userId}:`, err.message);
+    return false;
+  }
   if (res.status === 404 || res.status === 410) {
     console.warn(`[relay] Slack webhook gone for ${userId} — deactivating`);
     await deactivateChannel(userId, 'slack');
@@ -461,27 +455,29 @@ async function sendDiscord(userId, webhookEnvelope, text, retryCount = 0) {
     console.warn(`[relay] Discord URL invalid for ${userId}`);
     return false;
   }
-  // SSRF prevention: resolve hostname and check for private IPs
+  let safeUrl;
+  let resolvedAddresses;
   try {
-    const hostname = new URL(webhookUrl).hostname;
-    const addresses = await dns.resolve4(hostname);
-    if (addresses.some(isPrivateIP)) {
-      console.warn(`[relay] Discord URL resolves to private IP for ${userId}`);
-      return false;
-    }
-  } catch {
-    console.warn(`[relay] Discord DNS resolution failed for ${userId}`);
+    ({ url: safeUrl, resolvedAddresses } = await assertNotificationWebhookDeliveryUrlSafe(webhookUrl));
+  } catch (err) {
+    console.warn(`[relay] Discord URL rejected for ${userId}:`, err.message);
     return false;
   }
   const content = text.length > DISCORD_MAX_CONTENT
     ? text.slice(0, DISCORD_MAX_CONTENT - 1) + '…'
     : text;
-  const res = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
-    body: JSON.stringify({ content }),
-    signal: AbortSignal.timeout(10000),
-  });
+  let res;
+  try {
+    res = await postJsonWithPinnedAddress(
+      safeUrl,
+      JSON.stringify({ content }),
+      { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
+      resolvedAddresses,
+    );
+  } catch (err) {
+    console.warn(`[relay] Discord send error for ${userId}:`, err.message);
+    return false;
+  }
   if (res.status === 404 || res.status === 410) {
     console.warn(`[relay] Discord webhook gone for ${userId} — deactivating`);
     await deactivateChannel(userId, 'discord');

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -12,7 +12,6 @@
  *   7. Updates digest:last-sent:v1:${userId}:${variant}
  */
 import { createRequire } from 'node:module';
-import dns from 'node:dns/promises';
 import {
   escapeHtml,
   escapeTelegramHtml,
@@ -32,7 +31,6 @@ const WATCHLIST_STOCKS_DATA = require('../shared/stocks.json');
 const { decrypt } = require('./lib/crypto.cjs');
 const {
   assertNotificationWebhookDeliveryUrlSafe,
-  isBlockedResolvedAddress,
   postJsonWithPinnedAddress,
 } = require('./lib/notification-webhook-ssrf.cjs');
 const { callLLM } = require('./lib/llm-chain.cjs');
@@ -1307,10 +1305,6 @@ async function deactivateChannel(userId, channelType) {
   }
 }
 
-function isPrivateIP(ip) {
-  return isBlockedResolvedAddress(ip);
-}
-
 // ── Send functions ────────────────────────────────────────────────────────────
 
 const TELEGRAM_MAX_LEN = 4096;
@@ -1449,18 +1443,21 @@ async function sendSlack(userId, webhookEnvelope, text) {
     console.warn(`[digest] Slack decrypt failed for ${userId}:`, err.message); return false;
   }
   if (!SLACK_RE.test(webhookUrl)) { console.warn(`[digest] Slack URL invalid for ${userId}`); return false; }
+  let safeUrl;
+  let resolvedAddresses;
   try {
-    const hostname = new URL(webhookUrl).hostname;
-    const addrs = await dns.resolve4(hostname).catch(() => []);
-    if (addrs.some(isPrivateIP)) { console.warn(`[digest] Slack SSRF blocked for ${userId}`); return false; }
-  } catch { return false; }
+    ({ url: safeUrl, resolvedAddresses } = await assertNotificationWebhookDeliveryUrlSafe(webhookUrl));
+  } catch (err) {
+    console.warn(`[digest] Slack URL rejected for ${userId}:`, err.message);
+    return false;
+  }
   try {
-    const res = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
-      body: JSON.stringify({ text, unfurl_links: false }),
-      signal: AbortSignal.timeout(10000),
-    });
+    const res = await postJsonWithPinnedAddress(
+      safeUrl,
+      JSON.stringify({ text, unfurl_links: false }),
+      { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
+      resolvedAddresses,
+    );
     if (res.status === 404 || res.status === 410) {
       console.warn(`[digest] Slack webhook gone for ${userId}, deactivating`);
       await deactivateChannel(userId, 'slack');
@@ -1483,19 +1480,22 @@ async function sendDiscord(userId, webhookEnvelope, text) {
     console.warn(`[digest] Discord decrypt failed for ${userId}:`, err.message); return false;
   }
   if (!DISCORD_RE.test(webhookUrl)) { console.warn(`[digest] Discord URL invalid for ${userId}`); return false; }
+  let safeUrl;
+  let resolvedAddresses;
   try {
-    const hostname = new URL(webhookUrl).hostname;
-    const addrs = await dns.resolve4(hostname).catch(() => []);
-    if (addrs.some(isPrivateIP)) { console.warn(`[digest] Discord SSRF blocked for ${userId}`); return false; }
-  } catch { return false; }
+    ({ url: safeUrl, resolvedAddresses } = await assertNotificationWebhookDeliveryUrlSafe(webhookUrl));
+  } catch (err) {
+    console.warn(`[digest] Discord URL rejected for ${userId}:`, err.message);
+    return false;
+  }
   const content = text.length > 2000 ? text.slice(0, 1999) + '\u2026' : text;
   try {
-    const res = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
-      body: JSON.stringify({ content }),
-      signal: AbortSignal.timeout(10000),
-    });
+    const res = await postJsonWithPinnedAddress(
+      safeUrl,
+      JSON.stringify({ content }),
+      { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
+      resolvedAddresses,
+    );
     if (res.status === 404 || res.status === 410) {
       console.warn(`[digest] Discord webhook gone for ${userId}, deactivating`);
       await deactivateChannel(userId, 'discord');

--- a/src-tauri/open-url-safety.test.mjs
+++ b/src-tauri/open-url-safety.test.mjs
@@ -33,3 +33,27 @@ test("open_in_shell opens URLs/paths via the opener crate (ShellExecuteW on Wind
       "on Windows (no shell interpretation of the URL).",
   );
 });
+
+test("every renderer-callable UX and log command requires a trusted window", () => {
+  const commands = [
+    "list_supported_secret_keys",
+    "open_logs_folder",
+    "open_sidecar_log_file",
+    "open_settings_window_command",
+    "close_settings_window",
+    "close_live_channels_window",
+  ];
+
+  for (const command of commands) {
+    const start = mainRs.indexOf(`fn ${command}(`);
+    assert.ok(start >= 0, `${command} must remain registered in main.rs`);
+    const nextCommand = mainRs.indexOf("#[tauri::command]", start);
+    const body = mainRs.slice(start, nextCommand >= 0 ? nextCommand : undefined);
+    assert.match(body, /webview: Webview/, `${command} must receive Tauri's calling webview`);
+    assert.match(
+      body,
+      /require_trusted_window\(webview\.label\(\)\)\?/,
+      `${command} must reject calls from untrusted windows`,
+    );
+  }
+});

--- a/src-tauri/open-url-safety.test.mjs
+++ b/src-tauri/open-url-safety.test.mjs
@@ -48,7 +48,8 @@ test("every renderer-callable UX and log command requires a trusted window", () 
     const start = mainRs.indexOf(`fn ${command}(`);
     assert.ok(start >= 0, `${command} must remain registered in main.rs`);
     const nextCommand = mainRs.indexOf("#[tauri::command]", start);
-    const body = mainRs.slice(start, nextCommand >= 0 ? nextCommand : undefined);
+    assert.ok(nextCommand >= 0, `${command} must have an explicit command boundary`);
+    const body = mainRs.slice(start, nextCommand);
     assert.match(body, /webview: Webview/, `${command} must receive Tauri's calling webview`);
     assert.match(
       body,

--- a/src-tauri/src/cache_bounds.rs
+++ b/src-tauri/src/cache_bounds.rs
@@ -1,0 +1,59 @@
+/// Renderer IPC cache keys are identifiers, not data storage. Keep them small
+/// enough to avoid pathological object-map and serialized-file overhead.
+pub(crate) const MAX_CACHE_KEY_BYTES: usize = 1024;
+
+/// A single cached dataset may be large (the desktop cache commonly exceeds
+/// 10 MiB in aggregate), but no one renderer call may add an unbounded value.
+pub(crate) const MAX_CACHE_VALUE_BYTES: usize = 5 * 1024 * 1024;
+
+pub(crate) fn validate_cache_write_sizes(key: &str, value: &str) -> Result<(), String> {
+    let key_bytes = key.len();
+    if key_bytes > MAX_CACHE_KEY_BYTES {
+        return Err(format!(
+            "cache key exceeds {MAX_CACHE_KEY_BYTES} byte limit ({key_bytes} bytes)"
+        ));
+    }
+
+    let value_bytes = value.len();
+    if value_bytes > MAX_CACHE_VALUE_BYTES {
+        return Err(format!(
+            "cache payload exceeds {MAX_CACHE_VALUE_BYTES} byte limit ({value_bytes} bytes)"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_cache_keys_and_values_at_the_explicit_limits() {
+        assert!(validate_cache_write_sizes(
+            &"k".repeat(MAX_CACHE_KEY_BYTES),
+            &"v".repeat(MAX_CACHE_VALUE_BYTES),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_cache_keys_over_the_limit() {
+        let error = validate_cache_write_sizes(
+            &"k".repeat(MAX_CACHE_KEY_BYTES + 1),
+            "{}",
+        )
+        .expect_err("oversized keys must be rejected");
+        assert!(error.contains("cache key exceeds"));
+    }
+
+    #[test]
+    fn rejects_cache_values_over_the_limit() {
+        let error = validate_cache_write_sizes(
+            "news:latest",
+            &"v".repeat(MAX_CACHE_VALUE_BYTES + 1),
+        )
+        .expect_err("oversized values must be rejected");
+        assert!(error.contains("cache payload exceeds"));
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod cache_bounds;
+
 use std::collections::HashMap;
 use std::env;
 use std::fs::{self, File, OpenOptions};
@@ -17,6 +19,8 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Manager, RunEvent, Webview, WebviewUrl, WebviewWindowBuilder, WindowEvent};
+
+use cache_bounds::validate_cache_write_sizes;
 
 const DEFAULT_LOCAL_API_PORT: u16 = 46123;
 const KEYRING_SERVICE: &str = "world-monitor";
@@ -274,11 +278,12 @@ fn get_local_api_port(webview: Webview, state: tauri::State<'_, LocalApiState>) 
 }
 
 #[tauri::command]
-fn list_supported_secret_keys() -> Vec<String> {
-    SUPPORTED_SECRET_KEYS
+fn list_supported_secret_keys(webview: Webview) -> Result<Vec<String>, String> {
+    require_trusted_window(webview.label())?;
+    Ok(SUPPORTED_SECRET_KEYS
         .iter()
         .map(|key| (*key).to_string())
-        .collect()
+        .collect())
 }
 
 #[tauri::command]
@@ -463,6 +468,7 @@ fn delete_cache_entries_by_prefix(webview: Webview, app: AppHandle, cache: tauri
 #[tauri::command]
 fn write_cache_entry(webview: Webview, app: AppHandle, cache: tauri::State<'_, PersistentCache>, key: String, value: String) -> Result<(), String> {
     require_trusted_window(webview.label())?;
+    validate_cache_write_sizes(&key, &value)?;
     let parsed_value: Value = serde_json::from_str(&value)
         .map_err(|e| format!("Invalid cache payload JSON: {e}"))?;
     {
@@ -573,22 +579,26 @@ fn open_sidecar_log_impl(app: &AppHandle) -> Result<PathBuf, String> {
 }
 
 #[tauri::command]
-fn open_logs_folder(app: AppHandle) -> Result<String, String> {
+fn open_logs_folder(webview: Webview, app: AppHandle) -> Result<String, String> {
+    require_trusted_window(webview.label())?;
     open_logs_folder_impl(&app).map(|path| path.display().to_string())
 }
 
 #[tauri::command]
-fn open_sidecar_log_file(app: AppHandle) -> Result<String, String> {
+fn open_sidecar_log_file(webview: Webview, app: AppHandle) -> Result<String, String> {
+    require_trusted_window(webview.label())?;
     open_sidecar_log_impl(&app).map(|path| path.display().to_string())
 }
 
 #[tauri::command]
-async fn open_settings_window_command(app: AppHandle) -> Result<(), String> {
+async fn open_settings_window_command(webview: Webview, app: AppHandle) -> Result<(), String> {
+    require_trusted_window(webview.label())?;
     open_settings_window(&app)
 }
 
 #[tauri::command]
-fn close_settings_window(app: AppHandle) -> Result<(), String> {
+fn close_settings_window(webview: Webview, app: AppHandle) -> Result<(), String> {
+    require_trusted_window(webview.label())?;
     if let Some(window) = app.get_webview_window("settings") {
         window
             .close()
@@ -621,7 +631,8 @@ async fn open_live_channels_window_command(
 }
 
 #[tauri::command]
-fn close_live_channels_window(app: AppHandle) -> Result<(), String> {
+fn close_live_channels_window(webview: Webview, app: AppHandle) -> Result<(), String> {
+    require_trusted_window(webview.label())?;
     if let Some(window) = app.get_webview_window("live-channels") {
         window
             .close()

--- a/tests/notification-webhook-ssrf.test.mts
+++ b/tests/notification-webhook-ssrf.test.mts
@@ -17,6 +17,12 @@ const scriptSsrf = require('../scripts/lib/notification-webhook-ssrf.cjs') as {
   ) => Promise<{ url: URL; resolvedAddresses: string[] }>;
   blockedNotificationWebhookUrlReason: (rawUrl: string) => string | null;
   isBlockedResolvedAddress: (address: string) => boolean;
+  responseFromNode: (
+    statusCode: number,
+    statusMessage: string,
+    headers: Record<string, string>,
+    body: Uint8Array,
+  ) => Response;
 };
 
 const blockedUrls = [
@@ -176,11 +182,48 @@ describe('notification webhook SSRF guard', () => {
     }
   });
 
+  test('Slack and Discord senders validate DNS and pin delivery to the vetted address', () => {
+    for (const relPath of ['scripts/notification-relay.cjs', 'scripts/seed-digest-notifications.mjs']) {
+      const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
+      const slackStart = source.indexOf('async function sendSlack');
+      const discordStart = source.indexOf('async function sendDiscord', slackStart);
+      const emailStart = source.indexOf('async function sendEmail', discordStart);
+
+      assert.ok(slackStart >= 0 && discordStart > slackStart && emailStart > discordStart, `${relPath} delivery functions must stay discoverable`);
+
+      const slackSource = source.slice(slackStart, discordStart);
+      const discordSource = source.slice(discordStart, emailStart);
+      for (const [channel, functionSource] of [['Slack', slackSource], ['Discord', discordSource]] as const) {
+        assert.match(
+          functionSource,
+          /assertNotificationWebhookDeliveryUrlSafe\(webhookUrl\)/,
+          `${relPath} ${channel} delivery must validate the final DNS answer`,
+        );
+        assert.match(
+          functionSource,
+          /postJsonWithPinnedAddress\(/,
+          `${relPath} ${channel} delivery must pin the connection to a vetted address`,
+        );
+        assert.doesNotMatch(
+          functionSource,
+          /fetch\(webhookUrl/,
+          `${relPath} ${channel} delivery must not re-resolve through ordinary fetch`,
+        );
+      }
+    }
+  });
+
   test('pinned delivery helper keeps hard timeout and response body caps', () => {
     const source = readFileSync(resolve(process.cwd(), 'scripts/lib/notification-webhook-ssrf.cjs'), 'utf8');
     assert.match(source, /MAX_WEBHOOK_RESPONSE_BYTES/);
     assert.match(source, /totalBytes > MAX_WEBHOOK_RESPONSE_BYTES/);
     assert.match(source, /hardDeadline = setTimeout/);
     assert.match(source, /clearTimeout\(hardDeadline\)/);
+  });
+
+  test('pinned delivery helper preserves null-body HTTP statuses', async () => {
+    const response = scriptSsrf.responseFromNode(204, 'No Content', {}, new Uint8Array());
+    assert.equal(response.status, 204);
+    assert.equal(await response.text(), '');
   });
 });

--- a/tests/notification-webhook-ssrf.test.mts
+++ b/tests/notification-webhook-ssrf.test.mts
@@ -221,9 +221,11 @@ describe('notification webhook SSRF guard', () => {
     assert.match(source, /clearTimeout\(hardDeadline\)/);
   });
 
-  test('pinned delivery helper preserves null-body HTTP statuses', async () => {
-    const response = scriptSsrf.responseFromNode(204, 'No Content', {}, new Uint8Array());
-    assert.equal(response.status, 204);
-    assert.equal(await response.text(), '');
+  test('pinned delivery helper preserves every null-body HTTP status', async () => {
+    for (const status of [204, 205, 304]) {
+      const response = scriptSsrf.responseFromNode(status, 'No Content', {}, new Uint8Array());
+      assert.equal(response.status, status);
+      assert.equal(await response.text(), '');
+    }
   });
 });


### PR DESCRIPTION
## Summary

Notification delivery no longer validates one DNS answer and then reconnects by hostname. Slack and Discord realtime/digest sends now connect to the vetted address, closing that resolve-versus-connect SSRF gap while preserving retries, webhook deactivation, response limits, and normal `204 No Content` success responses.

Desktop renderer IPC now rejects oversized persistent-cache writes and applies the existing trusted-window boundary to the remaining UX and log commands. The MCP Edge mitigation and its accepted socket-pinning limitation are also documented explicitly so the residual is intentional rather than implicit.

Fixes #5061.

## Validation

- Pre-push gate passed: frontend/API/Convex typechecks, CJS syntax, architectural and security policy lints, edge bundling, 9 changed notification tests, 228 edge tests, markdown lint, and version sync.
- Focused notification SSRF suite: 9 passed, including pinned Slack/Discord delivery and null-body HTTP status handling.
- Desktop command contract suite: 3 passed; standalone Rust cache-bound tests: 3 passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `npm run test:sidecar` passed earlier in the worktree: 209 tests.
- The broad `test:data` command could not start under the sandbox's `tsx` IPC restrictions; its direct Node fallback was interrupted after unrelated test processes stalled, with no assertion failure observed. Change-scoped and pre-push suites above are green.

Review found one regression before shipping: constructing a Fetch `Response` with a body for Discord's normal 204 response. The helper now preserves null-body status semantics and has a regression test; the final review has no remaining actionable findings.

## Post-Deploy Monitoring & Validation

- Watch relay/digest logs for `Slack URL rejected`, `Discord URL rejected`, `send error`, unexpected webhook deactivations, or delivery timeouts.
- Watch desktop error reporting for cache-size rejection spikes, persistent-cache fallback warnings, and `Command not allowed from window` errors.
- Healthy signal: Slack/Discord delivery success remains stable with no increase in channel deactivation, timeout, or desktop cache-fallback rates.
- Failure signal: a delivery-success drop, renewed 204 response-construction errors, or widespread trusted-window/cache-limit failures. Roll back this PR if those appear.
- Validation window: first 24 hours after deploy; owner: WorldMonitor maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
