### PR TITLE
perf(health): memoize Redis verdict sweep

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -15,7 +15,16 @@ export const config = { runtime: 'edge' };
 // HTTP responses stay `no-store`, but the expensive Redis-wide verdict is
 // shared briefly at the origin. At the measured browser poll rate this turns
 // ~390 Redis commands per request into one GET, plus one sweep per minute.
-const HEALTH_VERDICT_SNAPSHOT_KEY = 'health:verdict:v1';
+const HEALTH_VERDICT_SNAPSHOT_BASE_KEY = 'health:verdict:v1';
+function healthVerdictRedisKey(baseKey, vercelEnv, commitSha) {
+  if (!vercelEnv || vercelEnv === 'production') return baseKey;
+  return `${vercelEnv}:${commitSha?.slice(0, 8) || 'dev'}:${baseKey}`;
+}
+const HEALTH_VERDICT_SNAPSHOT_KEY = healthVerdictRedisKey(
+  HEALTH_VERDICT_SNAPSHOT_BASE_KEY,
+  process.env.VERCEL_ENV,
+  process.env.VERCEL_GIT_COMMIT_SHA,
+);
 const HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS = 60;
 const HEALTH_VERDICT_SNAPSHOT_TTL_MS = HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS * 1_000;
 const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-lock`;
@@ -23,7 +32,7 @@ const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-
 // and 4s snapshot write. Keep the lease comfortably above that worst case.
 const HEALTH_VERDICT_REFRESH_LOCK_TTL_SECONDS = 30;
 const HEALTH_VERDICT_REFRESH_WAIT_ATTEMPTS = 45;
-const HEALTH_VERDICT_REFRESH_WAIT_MS = 10_000;
+const HEALTH_VERDICT_REFRESH_WAIT_MS = 3_000;
 // Avoid starting a Redis HTTP request that cannot realistically complete
 // inside the remaining contention budget. The direct-sweep fallback below is
 // preferable to turning a deadline-boundary timeout into false REDIS_DOWN.
@@ -1326,6 +1335,8 @@ export const __testing__ = {
   HEALTH_VERDICT_SNAPSHOT_KEY,
   HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
   HEALTH_VERDICT_REFRESH_LOCK_KEY,
+  HEALTH_VERDICT_REFRESH_WAIT_MS,
+  healthVerdictRedisKey,
   parseHealthVerdictSnapshot,
   // U7 (Tier 3 parity test): exposed for tests/mcp-bootstrap-parity.test.mjs
   // to walk the canonical seeded-data inventory. Both consts are unexported

--- a/api/health.js
+++ b/api/health.js
@@ -24,6 +24,10 @@ const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-
 const HEALTH_VERDICT_REFRESH_LOCK_TTL_SECONDS = 30;
 const HEALTH_VERDICT_REFRESH_WAIT_ATTEMPTS = 45;
 const HEALTH_VERDICT_REFRESH_WAIT_MS = 10_000;
+// Avoid starting a Redis HTTP request that cannot realistically complete
+// inside the remaining contention budget. The direct-sweep fallback below is
+// preferable to turning a deadline-boundary timeout into false REDIS_DOWN.
+const HEALTH_VERDICT_MIN_REDIS_TIMEOUT_MS = 100;
 const HEALTH_VERDICT_RELEASE_LOCK_SCRIPT = [
   "if redis.call('get', KEYS[1]) == ARGV[1] then",
   "  return redis.call('del', KEYS[1])",
@@ -1074,7 +1078,7 @@ export default async function handler(req, ctx) {
         const sleepMs = Math.min(backoffMs + jitterMs, Math.max(0, waitDeadline - Date.now()));
         await new Promise((resolve) => setTimeout(resolve, sleepMs));
         const remainingMs = waitDeadline - Date.now();
-        if (remainingMs <= 0) break;
+        if (remainingMs < HEALTH_VERDICT_MIN_REDIS_TIMEOUT_MS) break;
         const redisTimeoutMs = Math.min(4_000, remainingMs);
         const refreshedResult = await redisPipeline([['GET', HEALTH_VERDICT_SNAPSHOT_KEY]], redisTimeoutMs);
         if (!refreshedResult || refreshedResult[0]?.error) throw new Error('Redis snapshot wait failed');
@@ -1220,7 +1224,7 @@ export default async function handler(req, ctx) {
       .map(([k, c]) => `${k}:${c.status}`)
       .sort();
     console.log('[health] %s problems=[%s]', overall, problemKeys.join(', '));
-    const snapshot = {
+    const failureLogEntry = {
       at: new Date(now).toISOString(),
       status: overall,
       critCount,
@@ -1236,11 +1240,11 @@ export default async function handler(req, ctx) {
     const prevSigResult = await redisPipeline([['GET', 'health:failure-log-sig']], 4_000).catch(() => null);
     const prevSig = prevSigResult?.[0]?.result ?? '';
     const persistCmds = [
-      ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
+      ['SET', 'health:last-failure', JSON.stringify(failureLogEntry), 'EX', 86400],
     ];
     if (sig !== prevSig) {
       persistCmds.push(
-        ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
+        ['LPUSH', 'health:failure-log', JSON.stringify(failureLogEntry)],
         ['LTRIM', 'health:failure-log', 0, 49],
         ['EXPIRE', 'health:failure-log', 86400 * 7],
         ['SET', 'health:failure-log-sig', sig, 'EX', 86400],
@@ -1256,7 +1260,7 @@ export default async function handler(req, ctx) {
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(clear);
   }
 
-  const snapshot = {
+  const verdictSnapshot = {
     status: overall,
     summary: {
       total: totalChecks,
@@ -1282,7 +1286,7 @@ export default async function handler(req, ctx) {
     [
       'SET',
       HEALTH_VERDICT_SNAPSHOT_KEY,
-      JSON.stringify(snapshot),
+      JSON.stringify(verdictSnapshot),
       'EX',
       String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS),
     ],
@@ -1303,7 +1307,7 @@ export default async function handler(req, ctx) {
   // only the verdict payload is reused, for at most 60 seconds. All other
   // responses already carry the no-store defaults from `headers` (a cached
   // 401 pins an auth failure; a cached 503 masks REDIS_DOWN recovery).
-  return healthResponse(snapshot, compact, headers);
+  return healthResponse(verdictSnapshot, compact, headers);
 }
 
 // Test-only exports. Not part of the public edge handler surface — Vercel's

--- a/api/health.js
+++ b/api/health.js
@@ -12,6 +12,25 @@ import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.js';
 
 export const config = { runtime: 'edge' };
 
+// HTTP responses stay `no-store`, but the expensive Redis-wide verdict is
+// shared briefly at the origin. At the measured browser poll rate this turns
+// ~390 Redis commands per request into one GET, plus one sweep per minute.
+const HEALTH_VERDICT_SNAPSHOT_KEY = 'health:verdict:v1';
+const HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS = 60;
+const HEALTH_VERDICT_SNAPSHOT_TTL_MS = HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS * 1_000;
+const HEALTH_VERDICT_REFRESH_LOCK_KEY = `${HEALTH_VERDICT_SNAPSHOT_KEY}:refresh-lock`;
+// The sweep can consume its full 8s timeout, followed by a 4s failure-log read
+// and 4s snapshot write. Keep the lease comfortably above that worst case.
+const HEALTH_VERDICT_REFRESH_LOCK_TTL_SECONDS = 30;
+const HEALTH_VERDICT_REFRESH_WAIT_ATTEMPTS = 45;
+const HEALTH_VERDICT_REFRESH_WAIT_MS = 10_000;
+const HEALTH_VERDICT_RELEASE_LOCK_SCRIPT = [
+  "if redis.call('get', KEYS[1]) == ARGV[1] then",
+  "  return redis.call('del', KEYS[1])",
+  'end',
+  'return 0',
+].join('\n');
+
 // Iran-events domain sunset (war ended 2026-07). Default OFF everywhere; set
 // IRAN_EVENTS_ENABLED=true to restore the whole domain. Mirrors the backend
 // *_ENABLED env idiom (server/worldmonitor/resilience/v1/_shared.ts).
@@ -865,6 +884,70 @@ const STATUS_COUNTS = {
   EMPTY_DATA: 'crit',
 };
 
+function parseHealthVerdictSnapshot(raw, now) {
+  if (typeof raw !== 'string') return null;
+  const snapshot = parseRedisValue(raw);
+  if (!snapshot || typeof snapshot !== 'object') return null;
+  if (typeof snapshot.status !== 'string' || typeof snapshot.checkedAt !== 'string') return null;
+  if (!snapshot.summary || typeof snapshot.summary !== 'object') return null;
+  if (!snapshot.checks || typeof snapshot.checks !== 'object') return null;
+
+  const checkedAtMs = Date.parse(snapshot.checkedAt);
+  const ageMs = now - checkedAtMs;
+  // Redis expiry is the primary bound; this is a defensive guard against a
+  // malformed/manual snapshot write or a future TTL regression.
+  if (!Number.isFinite(checkedAtMs) || ageMs < 0 || ageMs > HEALTH_VERDICT_SNAPSHOT_TTL_MS) return null;
+  return snapshot;
+}
+
+async function releaseHealthVerdictRefreshLock(lockToken) {
+  if (!lockToken) return;
+  await redisPipeline([[
+    'EVAL',
+    HEALTH_VERDICT_RELEASE_LOCK_SCRIPT,
+    '1',
+    HEALTH_VERDICT_REFRESH_LOCK_KEY,
+    lockToken,
+  ]], 4_000).catch(() => null);
+}
+
+function healthResponseBody(snapshot, compact) {
+  const body = {
+    status: snapshot.status,
+    summary: snapshot.summary,
+    checkedAt: snapshot.checkedAt,
+  };
+
+  if (!compact) {
+    body.checks = snapshot.checks;
+    return body;
+  }
+
+  const problems = {};
+  for (const [name, check] of Object.entries(snapshot.checks)) {
+    if (check.status !== 'OK' && check.status !== 'OK_CASCADE') problems[name] = check;
+  }
+  if (Object.keys(problems).length > 0) body.problems = problems;
+  return body;
+}
+
+function healthResponse(snapshot, compact, headers) {
+  let responseHeaders = headers;
+  if (compact) {
+    const { 'CF-Cache-Status': _bypassMarker, ...base } = headers;
+    responseHeaders = {
+      ...base,
+      'Cache-Control': 'no-store, max-age=0',
+      'CDN-Cache-Control': 'no-store',
+    };
+  }
+
+  return new Response(JSON.stringify(healthResponseBody(snapshot, compact), null, compact ? 0 : 2), {
+    status: 200,
+    headers: responseHeaders,
+  });
+}
+
 export default async function handler(req, ctx) {
   if (isDisallowedOrigin(req)) {
     return new Response('Forbidden', { status: 403 });
@@ -950,6 +1033,80 @@ export default async function handler(req, ctx) {
 
   const now = Date.now();
 
+  // A snapshot hit is one Redis command instead of the ~390-command registry
+  // sweep below. A failed snapshot read is a real Redis outage, not a cache
+  // miss: returning 503 preserves UptimeRobot's hard-down signal.
+  let refreshLockToken = null;
+  let ownsSnapshotRefreshLock = false;
+  try {
+    if (!getRedisCredentials()) throw new Error('Redis not configured');
+    const snapshotResult = await redisPipeline([['GET', HEALTH_VERDICT_SNAPSHOT_KEY]], 4_000);
+    if (!snapshotResult) throw new Error('Redis request failed');
+    if (snapshotResult[0]?.error) throw new Error('Redis snapshot read failed');
+    const cachedSnapshot = parseHealthVerdictSnapshot(snapshotResult[0]?.result, Date.now());
+    if (cachedSnapshot) return healthResponse(cachedSnapshot, compact, headers);
+
+    refreshLockToken = `${now}:${crypto.randomUUID()}`;
+    let lockResult = await redisPipeline([[
+      'SET',
+      HEALTH_VERDICT_REFRESH_LOCK_KEY,
+      refreshLockToken,
+      'EX',
+      String(HEALTH_VERDICT_REFRESH_LOCK_TTL_SECONDS),
+      'NX',
+    ]], 4_000);
+    if (!lockResult || lockResult[0]?.error) throw new Error('Redis snapshot lock failed');
+    ownsSnapshotRefreshLock = lockResult[0]?.result === 'OK';
+
+    if (!ownsSnapshotRefreshLock) {
+      // Another edge invocation is already refreshing. Wait briefly for its
+      // snapshot instead of multiplying the ~390-command sweep during a cold
+      // burst. If the holder dies, retry SET NX until its lease expires; only
+      // a lock owner may proceed to the sweep.
+      const waitDeadline = Date.now() + HEALTH_VERDICT_REFRESH_WAIT_MS;
+      for (
+        let attempt = 0;
+        attempt < HEALTH_VERDICT_REFRESH_WAIT_ATTEMPTS && Date.now() < waitDeadline;
+        attempt++
+      ) {
+        const backoffMs = Math.min(100 * (2 ** attempt), 1_000);
+        const jitterMs = Math.floor(Math.random() * 50);
+        const sleepMs = Math.min(backoffMs + jitterMs, Math.max(0, waitDeadline - Date.now()));
+        await new Promise((resolve) => setTimeout(resolve, sleepMs));
+        const remainingMs = waitDeadline - Date.now();
+        if (remainingMs <= 0) break;
+        const redisTimeoutMs = Math.min(4_000, remainingMs);
+        const refreshedResult = await redisPipeline([['GET', HEALTH_VERDICT_SNAPSHOT_KEY]], redisTimeoutMs);
+        if (!refreshedResult || refreshedResult[0]?.error) throw new Error('Redis snapshot wait failed');
+        const refreshedSnapshot = parseHealthVerdictSnapshot(refreshedResult[0]?.result, Date.now());
+        if (refreshedSnapshot) return healthResponse(refreshedSnapshot, compact, headers);
+
+        lockResult = await redisPipeline([[
+          'SET',
+          HEALTH_VERDICT_REFRESH_LOCK_KEY,
+          refreshLockToken,
+          'EX',
+          String(HEALTH_VERDICT_REFRESH_LOCK_TTL_SECONDS),
+          'NX',
+        ]], redisTimeoutMs);
+        if (!lockResult || lockResult[0]?.error) throw new Error('Redis snapshot lock retry failed');
+        ownsSnapshotRefreshLock = lockResult[0]?.result === 'OK';
+        if (ownsSnapshotRefreshLock) break;
+      }
+      // Redis stayed reachable but another refresher held the lock through our
+      // request budget. Fall back to one direct sweep rather than mislabeling
+      // healthy Redis as REDIS_DOWN. This path is bounded and should be rare;
+      // the normal cold-burst path still permits only the elected owner.
+    }
+  } catch (err) {
+    if (ownsSnapshotRefreshLock) await releaseHealthVerdictRefreshLock(refreshLockToken);
+    return jsonResponse({
+      status: 'REDIS_DOWN',
+      error: err.message,
+      checkedAt: new Date(now).toISOString(),
+    }, 503, headers);
+  }
+
   const allDataKeys = [
     ...Object.values(BOOTSTRAP_KEYS),
     ...Object.values(STANDALONE_KEYS),
@@ -972,6 +1129,7 @@ export default async function handler(req, ctx) {
     results = await redisPipeline(commands, 8_000);
     if (!results) throw new Error('Redis request failed');
   } catch (err) {
+    if (ownsSnapshotRefreshLock) await releaseHealthVerdictRefreshLock(refreshLockToken);
     // REDIS_DOWN is the one hard-down state that returns 503: with Redis
     // unreachable the endpoint can assess nothing, so a plain HTTP-status
     // monitor (UptimeRobot, k8s probe, LB) must see a failure. DEGRADED/
@@ -1050,8 +1208,6 @@ export default async function handler(req, ctx) {
   else if (critCount / totalChecks <= 0.03) overall = 'DEGRADED';
   else overall = 'UNHEALTHY';
 
-  const httpStatus = 200;
-
   if (overall !== 'HEALTHY') {
     // problemKeys includes seedAgeMin for the snapshot (useful for post-mortem),
     // but the dedupe signature uses only key:status (no age) so a long STALE_SEED
@@ -1100,7 +1256,7 @@ export default async function handler(req, ctx) {
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(clear);
   }
 
-  const body = {
+  const snapshot = {
     status: overall,
     summary: {
       total: totalChecks,
@@ -1116,47 +1272,38 @@ export default async function handler(req, ctx) {
       crit: critCount,
     },
     checkedAt: new Date(now).toISOString(),
+    checks,
   };
 
-  if (!compact) {
-    body.checks = checks;
-  } else {
-    const problems = {};
-    for (const [name, check] of Object.entries(checks)) {
-      if (check.status !== 'OK' && check.status !== 'OK_CASCADE') problems[name] = check;
-    }
-    if (Object.keys(problems).length > 0) body.problems = problems;
-  }
+  // Await the write so the next request cannot race an unstarted background
+  // SET and repeat the full sweep. A write failure does not invalidate the
+  // live verdict just computed; the next request will retry by sweeping.
+  const snapshotWriteResult = await redisPipeline([
+    [
+      'SET',
+      HEALTH_VERDICT_SNAPSHOT_KEY,
+      JSON.stringify(snapshot),
+      'EX',
+      String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS),
+    ],
+  ], 4_000).catch(() => null);
+  const snapshotWriteFailed = !snapshotWriteResult || snapshotWriteResult[0]?.error;
+  if (ownsSnapshotRefreshLock) await releaseHealthVerdictRefreshLock(refreshLockToken);
+  // A failed cache write does not invalidate the live verdict. Releasing only
+  // this request's token lets the next caller retry immediately without ever
+  // deleting a successor's lock after a slow sweep outlives its lease.
+  if (snapshotWriteFailed) console.warn('[health] verdict snapshot write failed');
 
   // Compact is the public keyless form polled by external uptime MONITORS, so it
   // must NEVER be edge-cached: the prior `s-maxage=60` (#4907, to collapse
   // dashboard-tab polling) let a shared CDN entry pin a stale WARNING that kept
   // UptimeRobot reading "down" long AFTER the seed recovered (2026-07-07 — the
   // literal `?cb=*cachebuster*` was a constant, so it never busted the entry).
-  // no-store guarantees a monitor sees live recovery on its very next poll. The
-  // origin cost is one 196-key Redis pipeline per request — cheap — so losing
-  // the per-tab poll-collapse is a non-issue. All other responses already carry
-  // the no-store defaults from `headers` (a cached 401 pins an auth failure; a
-  // cached 503 masks REDIS_DOWN recovery).
-  let responseHeaders = headers;
-  if (compact) {
-    const { 'CF-Cache-Status': _bypassMarker, ...base } = headers;
-    responseHeaders = {
-      ...base,
-      // no-store so no CDN or browser ever serves a stale health verdict to a
-      // monitor. Deliberately NOT `public` — `public, no-store` is a
-      // self-contradictory signal (RFC 9111 §5.2.2.5: no-store wins, but a
-      // non-compliant proxy could read `public` as permission to cache — the
-      // exact bug class this closes).
-      'Cache-Control': 'no-store, max-age=0',
-      'CDN-Cache-Control': 'no-store',
-    };
-  }
-
-  return new Response(JSON.stringify(body, null, compact ? 0 : 2), {
-    status: httpStatus,
-    headers: responseHeaders,
-  });
+  // no-store guarantees that Redis reachability is checked on every request;
+  // only the verdict payload is reused, for at most 60 seconds. All other
+  // responses already carry the no-store defaults from `headers` (a cached
+  // 401 pins an auth failure; a cached 503 masks REDIS_DOWN recovery).
+  return healthResponse(snapshot, compact, headers);
 }
 
 // Test-only exports. Not part of the public edge handler surface — Vercel's
@@ -1172,6 +1319,10 @@ export const __testing__ = {
   // instead of STRLEN (tests/health-list-data-keys.test.mjs).
   LIST_DATA_KEYS,
   dataLenCommand,
+  HEALTH_VERDICT_SNAPSHOT_KEY,
+  HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
+  HEALTH_VERDICT_REFRESH_LOCK_KEY,
+  parseHealthVerdictSnapshot,
   // U7 (Tier 3 parity test): exposed for tests/mcp-bootstrap-parity.test.mjs
   // to walk the canonical seeded-data inventory. Both consts are unexported
   // at module scope by design — this is the test-only escape hatch.

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -254,6 +254,46 @@ test('does not report REDIS_DOWN when a healthy Redis lock stays contended', asy
   assert.equal(sweepCount, 1, 'bounded contention fallback performs one direct sweep');
 });
 
+test('does not start a doomed Redis request at the contention deadline', async () => {
+  let fakeNow = realDateNow();
+  let snapshotReads = 0;
+  let sweepCount = 0;
+  Date.now = () => fakeNow;
+  globalThis.setTimeout = (resolve) => {
+    fakeNow += 9_999;
+    resolve();
+    return 0;
+  };
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
+    if (commands.length === 1 && commands[0][0] === 'GET' && commands[0][1] === HEALTH_SNAPSHOT_KEY) {
+      snapshotReads++;
+      if (snapshotReads > 1) {
+        return new Response(null, { status: 504 });
+      }
+      return new Response(JSON.stringify([{ result: null }]), { status: 200 });
+    }
+    const results = commands.map(([op, key]) => {
+      if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) return { result: null };
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      if (op === 'EXISTS') return { result: 0 };
+      return { result: 'OK' };
+    });
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.notEqual(body.status, 'REDIS_DOWN');
+  assert.equal(snapshotReads, 1, 'near-deadline contention must skip a doomed Redis HTTP request');
+  assert.equal(sweepCount, 1, 'near-deadline contention falls back to one direct sweep');
+});
+
 test('releases its refresh lock when snapshot persistence fails', async () => {
   let storedSnapshot = null;
   let refreshLockToken = null;

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -11,6 +11,7 @@ const {
   HEALTH_VERDICT_SNAPSHOT_KEY: HEALTH_SNAPSHOT_KEY,
   HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
   HEALTH_VERDICT_REFRESH_LOCK_KEY: HEALTH_REFRESH_LOCK_KEY,
+  HEALTH_VERDICT_REFRESH_WAIT_MS,
 } = __testing__;
 const realFetch = globalThis.fetch;
 const realSetTimeout = globalThis.setTimeout;
@@ -30,6 +31,25 @@ function healthySnapshot(checkedAt = new Date().toISOString()) {
     checks: { example: { status: 'OK', records: 1 } },
   };
 }
+
+test('scopes health verdict Redis keys to non-production deployments', () => {
+  const baseKey = 'health:verdict:v1';
+  const lockBaseKey = `${baseKey}:refresh-lock`;
+
+  assert.equal(__testing__.healthVerdictRedisKey(baseKey, undefined, undefined), baseKey);
+  assert.equal(
+    __testing__.healthVerdictRedisKey(baseKey, 'production', '1234567890abcdef'),
+    baseKey,
+  );
+  assert.equal(
+    __testing__.healthVerdictRedisKey(baseKey, 'preview', '1234567890abcdef'),
+    'preview:12345678:health:verdict:v1',
+  );
+  assert.equal(
+    __testing__.healthVerdictRedisKey(lockBaseKey, 'preview', undefined),
+    'preview:dev:health:verdict:v1:refresh-lock',
+  );
+});
 
 test('reuses one Redis verdict snapshot across compact and detailed callers', async () => {
   let storedSnapshot = null;
@@ -260,7 +280,7 @@ test('does not start a doomed Redis request at the contention deadline', async (
   let sweepCount = 0;
   Date.now = () => fakeNow;
   globalThis.setTimeout = (resolve) => {
-    fakeNow += 9_999;
+    fakeNow += HEALTH_VERDICT_REFRESH_WAIT_MS - 1;
     resolve();
     return 0;
   };

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -1,0 +1,328 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://mock-upstash.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
+process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
+
+const { default: handler, __testing__ } = await import('../api/health.js');
+
+const {
+  HEALTH_VERDICT_SNAPSHOT_KEY: HEALTH_SNAPSHOT_KEY,
+  HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
+  HEALTH_VERDICT_REFRESH_LOCK_KEY: HEALTH_REFRESH_LOCK_KEY,
+} = __testing__;
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+const realDateNow = Date.now;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+  Date.now = realDateNow;
+});
+
+function healthySnapshot(checkedAt = new Date().toISOString()) {
+  return {
+    status: 'HEALTHY',
+    summary: { total: 1, ok: 1, warn: 0, onDemandWarn: 0, staleContent: 0, crit: 0 },
+    checkedAt,
+    checks: { example: { status: 'OK', records: 1 } },
+  };
+}
+
+test('reuses one Redis verdict snapshot across compact and detailed callers', async () => {
+  let storedSnapshot = null;
+  const pipelineCalls = [];
+
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    pipelineCalls.push(commands);
+
+    const results = commands.map(([op, key, value]) => {
+      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) {
+        return { result: storedSnapshot };
+      }
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') {
+        return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      }
+      if (op === 'EXISTS') return { result: 0 };
+      if (op === 'SET' && key === HEALTH_SNAPSHOT_KEY) {
+        storedSnapshot = value;
+        return { result: 'OK' };
+      }
+      return { result: 'OK' };
+    });
+
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const compactResponse = await handler(
+    new Request('https://api.worldmonitor.app/api/health?compact=1'),
+  );
+  const compactBody = await compactResponse.json();
+
+  const detailedResponse = await handler(
+    new Request('https://api.worldmonitor.app/api/health', {
+      headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
+    }),
+  );
+  const detailedBody = await detailedResponse.json();
+
+  const sweepCalls = pipelineCalls.filter((commands) =>
+    commands.some(([op]) => op === 'STRLEN' || op === 'LLEN'));
+  assert.equal(sweepCalls.length, 1, 'two callers inside the TTL must share one full health sweep');
+
+  const snapshotReads = pipelineCalls.filter((commands) =>
+    commands.length === 1
+      && commands[0][0] === 'GET'
+      && commands[0][1] === HEALTH_SNAPSHOT_KEY);
+  assert.equal(snapshotReads.length, 2, 'each response should need only one small snapshot GET');
+
+  const snapshotWrites = pipelineCalls.flat().filter((command) =>
+    command[0] === 'SET' && command[1] === HEALTH_SNAPSHOT_KEY);
+  assert.equal(snapshotWrites.length, 1);
+  assert.deepEqual(snapshotWrites[0].slice(3), ['EX', String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS)]);
+
+  assert.equal(compactResponse.headers.get('Cache-Control'), 'no-store, max-age=0');
+  assert.equal(detailedResponse.headers.get('Cache-Control'), 'private, no-store, max-age=0');
+  assert.equal(compactBody.checkedAt, detailedBody.checkedAt, 'snapshot hit must expose the original check time');
+  assert.ok(!Object.hasOwn(compactBody, 'checks'), 'public compact shape stays compact');
+  assert.ok(Object.hasOwn(detailedBody, 'checks'), 'authenticated detailed shape is derived from the same snapshot');
+});
+
+test('rejects malformed or older-than-TTL snapshots', () => {
+  const now = Date.now();
+  const validShape = {
+    status: 'HEALTHY',
+    summary: { total: 1, ok: 1, warn: 0, onDemandWarn: 0, staleContent: 0, crit: 0 },
+    checkedAt: new Date(now - 30_000).toISOString(),
+    checks: { example: { status: 'OK', records: 1 } },
+  };
+
+  assert.deepEqual(
+    __testing__.parseHealthVerdictSnapshot(JSON.stringify(validShape), now),
+    validShape,
+  );
+  assert.equal(
+    __testing__.parseHealthVerdictSnapshot(JSON.stringify({
+      ...validShape,
+      checkedAt: new Date(now - (HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS * 1_000 + 1)).toISOString(),
+    }), now),
+    null,
+    'a lingering Redis key must not extend verdict staleness past the configured TTL',
+  );
+  assert.equal(__testing__.parseHealthVerdictSnapshot('{not-json', now), null);
+});
+
+test('coalesces concurrent cache misses into one full sweep', async () => {
+  let storedSnapshot = null;
+  let refreshLocked = false;
+  const pipelineCalls = [];
+
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    pipelineCalls.push(commands);
+
+    if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) {
+      // Longer than the old fixed 2s waiter window: followers must still wait
+      // for the lock owner rather than falling through to a duplicate sweep.
+      await new Promise((resolve) => setTimeout(resolve, 2_100));
+    }
+
+    const results = commands.map(([op, key, value]) => {
+      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) return { result: storedSnapshot };
+      if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) {
+        if (refreshLocked) return { result: null };
+        refreshLocked = true;
+        return { result: 'OK' };
+      }
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') {
+        return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      }
+      if (op === 'EXISTS') return { result: 0 };
+      if (op === 'SET' && key === HEALTH_SNAPSHOT_KEY) {
+        storedSnapshot = value;
+        return { result: 'OK' };
+      }
+      return { result: 'OK' };
+    });
+
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const [first, second] = await Promise.all([
+    handler(new Request('https://api.worldmonitor.app/api/health?compact=1')),
+    handler(new Request('https://api.worldmonitor.app/api/health?compact=1')),
+  ]);
+  const [firstBody, secondBody] = await Promise.all([first.json(), second.json()]);
+
+  const sweepCalls = pipelineCalls.filter((commands) =>
+    commands.some(([op]) => op === 'STRLEN' || op === 'LLEN'));
+  assert.equal(sweepCalls.length, 1, 'a cold burst must elect one snapshot refresher');
+  assert.equal(firstBody.checkedAt, secondBody.checkedAt);
+});
+
+test('projects only failing checks from a cached compact snapshot', async () => {
+  const snapshot = {
+    ...healthySnapshot(),
+    status: 'WARNING',
+    summary: { total: 3, ok: 2, warn: 1, onDemandWarn: 0, staleContent: 0, crit: 0 },
+    checks: {
+      healthy: { status: 'OK', records: 1 },
+      cascade: { status: 'OK_CASCADE', records: 1 },
+      delayed: { status: 'STALE_SEED', seedAgeMin: 30 },
+    },
+  };
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    assert.deepEqual(commands, [['GET', HEALTH_SNAPSHOT_KEY]]);
+    return new Response(JSON.stringify([{ result: JSON.stringify(snapshot) }]), { status: 200 });
+  };
+
+  const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body.problems, { delayed: snapshot.checks.delayed });
+  assert.ok(!Object.hasOwn(body, 'checks'));
+  assert.equal(body.checkedAt, snapshot.checkedAt);
+});
+
+test('takes over refresh after the prior lock owner disappears', async () => {
+  let lockAttempts = 0;
+  let sweepCount = 0;
+  globalThis.setTimeout = (resolve) => {
+    resolve();
+    return 0;
+  };
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
+    const results = commands.map(([op, key]) => {
+      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) return { result: null };
+      if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) {
+        lockAttempts++;
+        return { result: lockAttempts === 1 ? null : 'OK' };
+      }
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      if (op === 'EXISTS') return { result: 0 };
+      return { result: 'OK' };
+    });
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+
+  assert.equal(response.status, 200);
+  assert.equal(lockAttempts, 2);
+  assert.equal(sweepCount, 1);
+});
+
+test('does not report REDIS_DOWN when a healthy Redis lock stays contended', async () => {
+  let sweepCount = 0;
+  globalThis.setTimeout = (resolve) => {
+    resolve();
+    return 0;
+  };
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
+    const results = commands.map(([op, key]) => {
+      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) return { result: null };
+      if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) return { result: null };
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      if (op === 'EXISTS') return { result: 0 };
+      return { result: 'OK' };
+    });
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.notEqual(body.status, 'REDIS_DOWN');
+  assert.equal(sweepCount, 1, 'bounded contention fallback performs one direct sweep');
+});
+
+test('releases its refresh lock when snapshot persistence fails', async () => {
+  let storedSnapshot = null;
+  let refreshLockToken = null;
+  let snapshotWriteAttempts = 0;
+  let sweepCount = 0;
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
+    const results = commands.map(([op, key, value]) => {
+      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) return { result: storedSnapshot };
+      if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) {
+        if (refreshLockToken) return { result: null };
+        refreshLockToken = value;
+        return { result: 'OK' };
+      }
+      if (op === 'EVAL') {
+        if (commands[0][4] === refreshLockToken) refreshLockToken = null;
+        return { result: 1 };
+      }
+      if (op === 'SET' && key === HEALTH_SNAPSHOT_KEY) {
+        snapshotWriteAttempts++;
+        if (snapshotWriteAttempts === 1) return { error: 'transient write failure' };
+        storedSnapshot = value;
+        return { result: 'OK' };
+      }
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      if (op === 'EXISTS') return { result: 0 };
+      return { result: 'OK' };
+    });
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const first = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  const second = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+
+  assert.equal(first.status, 200, 'a live verdict remains usable when only memoization fails');
+  assert.equal(second.status, 200);
+  assert.equal(snapshotWriteAttempts, 2, 'the next request retries immediately after lock release');
+  assert.equal(sweepCount, 2);
+});
+
+test('validates snapshot age after the Redis read completes', async () => {
+  let fakeNow = realDateNow();
+  const almostExpired = healthySnapshot(new Date(fakeNow - 59_000).toISOString());
+  let sweepCount = 0;
+  Date.now = () => fakeNow;
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    if (commands.length === 1 && commands[0][0] === 'GET' && commands[0][1] === HEALTH_SNAPSHOT_KEY) {
+      fakeNow += 2_000;
+      return new Response(JSON.stringify([{ result: JSON.stringify(almostExpired) }]), { status: 200 });
+    }
+    if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
+    const results = commands.map(([op]) => {
+      if (op === 'STRLEN') return { result: 100 };
+      if (op === 'LLEN') return { result: 1 };
+      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+      if (op === 'EXISTS') return { result: 0 };
+      return { result: 'OK' };
+    });
+    return new Response(JSON.stringify(results), { status: 200 });
+  };
+
+  const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(sweepCount, 1, 'a snapshot that expires in flight must be recomputed');
+  assert.notEqual(body.checkedAt, almostExpired.checkedAt);
+});


### PR DESCRIPTION
## Summary

`/api/health` now reuses a Redis-backed verdict for at most 60 seconds instead of sweeping every monitored key on every browser poll. Each request still reads Redis directly, so HTTP responses remain `no-store` and a real Redis outage still returns `REDIS_DOWN` with HTTP 503.

A short owner-token lock coalesces cold misses across edge isolates. Lock handoff, bounded contention fallback, owner-safe release, failed snapshot persistence, and in-flight TTL expiry are covered so the optimization does not trade command volume for false outage alerts or stuck probes.

| Metric | Before | Projected after |
|---|---:|---:|
| Full registry sweeps | ~1.21/sec | <=1/minute |
| Redis commands per warm request | ~390 | 1 snapshot GET |
| Health-attributable Redis commands/day | ~36M | <0.7M |

The projected reduction is greater than 98% at the issue's measured poll rate; production monitoring below will verify the real result after deployment.

Fixes #5261.

## Validation

- Proof-first regression: two callers initially triggered two full sweeps; the implementation reduces them to one shared sweep.
- `node --test tests/health-*.test.mjs api/health-cors.test.mjs` - 82 passed.
- `npm run typecheck` and `npm run typecheck:api` - passed.
- `node --test tests/edge-functions.test.mjs` - 228 passed.
- Diff-scoped Biome lint - clean; repository lint exits successfully with existing unrelated warnings.
- Full pre-push gate - passed, including edge bundling, architectural boundaries, API/frontend/Convex typechecks, changed tests, and version synchronization.

## Post-Deploy Monitoring & Validation

- Window: observe production for 30-60 minutes after the Vercel deployment; owner is the deploying maintainer/on-call.
- Command load: use the Redis MONITOR/tap recipe from #5259 and count `STRLEN`/`LLEN` sweeps against a canonical key such as `market:sectors:v2`. Expect sweep frequency to fall from ~1.21/sec to <=0.017/sec and health-attributable commands to drop by at least 95%.
- Freshness and caching: poll `/api/health?compact=1` repeatedly. `Cache-Control` must stay `no-store, max-age=0`; `checkedAt` should be reused only inside the 60-second verdict window, then advance.
- Availability: watch UptimeRobot for new flapping or false 503s. A genuine Redis read failure must still produce HTTP 503 with `status: REDIS_DOWN`; lock contention must not.
- Failure trigger: rollback if sweeps remain above 0.06/sec, `checkedAt` is served more than 60 seconds stale, or probes start flapping/misclassifying Redis. Reverting the PR is sufficient; the snapshot expires within 60 seconds and refresh locks within 30 seconds.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
