### PR TITLE
perf(redis): shield residual dashboard read egress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 161
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 161 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (197 service modules and domain directories)
+│   ├── services/           # Business logic (198 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/api/_wildfire-dashboard.d.ts
+++ b/api/_wildfire-dashboard.d.ts
@@ -1,0 +1,5 @@
+export const WILDFIRE_DASHBOARD_DETECTION_LIMIT: number;
+
+export function limitFireDetectionsForDashboard<T>(detections: T[], limit?: number): T[];
+
+export function compactWildfireDashboardPayload<T>(value: T, limit?: number): T;

--- a/api/_wildfire-dashboard.js
+++ b/api/_wildfire-dashboard.js
@@ -1,0 +1,38 @@
+export const WILDFIRE_DASHBOARD_DETECTION_LIMIT = 500;
+
+function numeric(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function confidenceRank(confidence) {
+  switch (confidence) {
+    case 'FIRE_CONFIDENCE_HIGH': return 3;
+    case 'FIRE_CONFIDENCE_NOMINAL': return 2;
+    case 'FIRE_CONFIDENCE_LOW': return 1;
+    default: return 0;
+  }
+}
+
+function compareFireDetectionsForDashboard(a, b) {
+  return Number(Boolean(b?.possibleExplosion)) - Number(Boolean(a?.possibleExplosion))
+    || confidenceRank(b?.confidence) - confidenceRank(a?.confidence)
+    || numeric(b?.brightness) - numeric(a?.brightness)
+    || numeric(b?.frp) - numeric(a?.frp)
+    || numeric(b?.detectedAt) - numeric(a?.detectedAt);
+}
+
+export function limitFireDetectionsForDashboard(detections, limit = WILDFIRE_DASHBOARD_DETECTION_LIMIT) {
+  if (detections.length <= limit) return detections;
+  return [...detections].sort(compareFireDetectionsForDashboard).slice(0, limit);
+}
+
+export function compactWildfireDashboardPayload(value, limit = WILDFIRE_DASHBOARD_DETECTION_LIMIT) {
+  if (!value || typeof value !== 'object' || !Array.isArray(value.fireDetections)) return value;
+  if (value.fireDetections.length <= limit) return value;
+  return {
+    ...value,
+    fireDetections: limitFireDetectionsForDashboard(value.fireDetections, limit),
+    pagination: { nextCursor: '', totalCount: value.fireDetections.length },
+  };
+}

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -15,6 +15,7 @@ import {
 import { redisPipeline } from './_upstash-json.js';
 import { unwrapEnvelope } from './_seed-envelope.js';
 import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.js';
+import { compactWildfireDashboardPayload } from './_wildfire-dashboard.js';
 
 export const config = { runtime: 'edge' };
 
@@ -66,7 +67,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   radiationWatch: 'radiation:observations:v1',
   thermalEscalation: 'thermal:escalation:v1',
   crossSourceSignals: 'intelligence:cross-source-signals:v1',
-  wildfires:        'wildfire:fires:v1',
+  wildfires:        'wildfire:fires-bootstrap:v1',
   cyberThreats:     'cyber:threats-bootstrap:v2',
   techReadiness:    'economic:worldbank-techreadiness:v1',
   progressData:     'economic:worldbank-progress:v1',
@@ -286,39 +287,7 @@ function hasBootstrapCredentialCookie(req) {
 }
 
 const NEG_SENTINEL = '__WM_NEG__';
-const WILDFIRE_DASHBOARD_DETECTION_LIMIT = 500;
-
-function numeric(value) {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function confidenceRank(confidence) {
-  switch (confidence) {
-    case 'FIRE_CONFIDENCE_HIGH': return 3;
-    case 'FIRE_CONFIDENCE_NOMINAL': return 2;
-    case 'FIRE_CONFIDENCE_LOW': return 1;
-    default: return 0;
-  }
-}
-
-function compareFireDetectionsForDashboard(a, b) {
-  return Number(Boolean(b?.possibleExplosion)) - Number(Boolean(a?.possibleExplosion))
-    || confidenceRank(b?.confidence) - confidenceRank(a?.confidence)
-    || numeric(b?.brightness) - numeric(a?.brightness)
-    || numeric(b?.frp) - numeric(a?.frp)
-    || numeric(b?.detectedAt) - numeric(a?.detectedAt);
-}
-
-export function compactWildfireBootstrapPayload(value, limit = WILDFIRE_DASHBOARD_DETECTION_LIMIT) {
-  if (!value || typeof value !== 'object' || !Array.isArray(value.fireDetections)) return value;
-  if (value.fireDetections.length <= limit) return value;
-  return {
-    ...value,
-    fireDetections: [...value.fireDetections].sort(compareFireDetectionsForDashboard).slice(0, limit),
-    pagination: { nextCursor: '', totalCount: value.fireDetections.length },
-  };
-}
+export const compactWildfireBootstrapPayload = compactWildfireDashboardPayload;
 
 async function getCachedJsonBatch(keys) {
   const result = new Map();

--- a/api/health.js
+++ b/api/health.js
@@ -28,6 +28,7 @@ const BOOTSTRAP_KEYS = {
   co2Monitoring:     'climate:co2-monitoring:v1',
   oceanIce:          'climate:ocean-ice:v1',
   wildfires:         'wildfire:fires:v1',
+  wildfiresBootstrap: 'wildfire:fires-bootstrap:v1',
   marketQuotes:      'market:stocks-bootstrap:v1',
   commodityQuotes:   'market:commodities-bootstrap:v1',
   cyberThreats:      'cyber:threats-bootstrap:v2',
@@ -273,6 +274,7 @@ const STANDALONE_KEYS = {
 const SEED_META = {
   earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
   wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 360 }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate
+  wildfiresBootstrap: { key: 'seed-meta:wildfire:fires-bootstrap', maxStaleMin: 360 }, // Compact CDN payload is a distinct publish target; monitor it so canonical fallback cannot hide transform/write failures.
   outages:          { key: 'seed-meta:infra:outages',           maxStaleMin: 30 },
   climateAnomalies: { key: 'seed-meta:climate:anomalies',       maxStaleMin: 540 }, // bundled into seed-bundle-climate (cron `0 */3 * * *`, every 3h); 540 = 3× cron cadence per project convention. Prior 240 (1.33× cron) flipped to silent-EMPTY between minute 180 (TTL_DATA expiry) and 240 (alarm trigger) on every routine cron-jitter cycle — see scripts/seed-climate-anomalies.mjs CACHE_TTL comment.
   climateDisasters: { key: 'seed-meta:climate:disasters',       maxStaleMin: 720 }, // runs every 6h; 720min = 2x interval

--- a/api/health.js
+++ b/api/health.js
@@ -634,6 +634,7 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'cableHealth', // `cables: {}` = no active subsea cable disruptions per NGA NAVAREA warnings — all cables implicitly healthy. Also covers NGA-upstream-down windows where get-cable-health writes back the fallback response (empty cables); without this, those would alarm EMPTY_DATA.
   'forecastBets', // #5233 shadow bet-engine stream; absent before the cron ships it and empty on weeks the energy feed yields no bet — tolerate as STALE_SEED (warn), not EMPTY (crit).
   'forecastFunnel', // #5233 funnel guardrail is a new afterPublish side-write; before the first seed-forecasts run ships it the key is absent — tolerate as STALE_SEED (warn), not EMPTY (crit). A COLLAPSED funnel still surfaces via seed-meta status:'error' → SEED_ERROR, which classifyKey checks before this branch.
+  'wildfiresBootstrap', // Compact dashboard side-write is absent until the first fire seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
 ]);
 
 // Keys where a present payload with meta recordCount=0 is valid, but the data

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 161,
-  "serviceTopLevelEntries": 197,
+  "serviceTopLevelEntries": 198,
   "apiEndpointEntries": 88,
   "panelClasses": 104,
   "protoFiles": 279,

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, CHROME_UA, sleep } from './_seed-utils.mjs';
+import { compactWildfireDashboardPayload } from '../api/_wildfire-dashboard.js';
 
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'wildfire:fires:v1';
+const BOOTSTRAP_KEY = 'wildfire:fires-bootstrap:v1';
 const FIRMS_SOURCES = ['VIIRS_SNPP_NRT', 'VIIRS_NOAA20_NRT', 'VIIRS_NOAA21_NRT'];
 
 const MONITORED_REGIONS = {
@@ -134,6 +136,11 @@ async function main() {
     ttlSeconds: 7200,
     lockTtlMs: 2_400_000, // 40 min — 27 slots × ~72s worst case (30s timeout + 6s backoff + 30s retry + 6s pace) ≈ 32.4 min; pad headroom. Next cron tick sees lock held and safely skips.
     sourceVersion: FIRMS_SOURCES.join('+'),
+    extraKeys: [{
+      key: BOOTSTRAP_KEY,
+      transform: compactWildfireDashboardPayload,
+      declareRecords,
+    }],
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 360,

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -140,6 +140,7 @@ async function main() {
       key: BOOTSTRAP_KEY,
       transform: compactWildfireDashboardPayload,
       declareRecords,
+      metaKey: 'seed-meta:wildfire:fires-bootstrap',
     }],
     declareRecords,
     schemaVersion: 1,

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -184,7 +184,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   radiationWatch:  'radiation:observations:v1',
   thermalEscalation: 'thermal:escalation:v1',
   crossSourceSignals: 'intelligence:cross-source-signals:v1',
-  wildfires:        'wildfire:fires:v1',
+  wildfires:        'wildfire:fires-bootstrap:v1',
   marketQuotes:     'market:stocks-bootstrap:v1',
   commodityQuotes:  'market:commodities-bootstrap:v1',
   cyberThreats:     'cyber:threats-bootstrap:v2',

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -11,6 +11,7 @@
 
 import { createRouter, type RouteDescriptor } from './router';
 import { getCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
+import { isPublicSharedRpcRequest } from '../src/shared/public-rpc-cache';
 // @ts-expect-error — JS module, no declaration file
 import { USER_API_KEY_GATEWAY_VALIDATION_ERROR, validateApiKey } from '../api/_api-key.js';
 // @ts-expect-error — JS module, no declaration file
@@ -1066,7 +1067,14 @@ export function createDomainGateway(
     // entirely: we already resolved the userId via HMAC verify and confirmed
     // tier ≥ 1 + mcpAccess === true. Re-running the JWT path on a request
     // that has no Authorization header would just no-op anyway.
-    const isPublicNoAuthRpc = PUBLIC_NO_AUTH_RPC_PATHS.has(pathname);
+    // Two high-volume, caller-invariant dashboard reads expose an exact
+    // `public=1` URL shape. The marker creates a CDN key separate from the
+    // legacy credentialed URL, which remains session/key gated and no-store.
+    // Classification ignores attached credentials because a Vercel cache hit
+    // happens before this function sees them; the public URL must therefore
+    // have one response contract for every caller.
+    const isPublicNoAuthRpc = PUBLIC_NO_AUTH_RPC_PATHS.has(pathname)
+      || isPublicSharedRpcRequest(request.url, request.method);
     const seedRefreshVerified = await isResilienceRankingSeedRefreshRequest(request, pathname);
     const relayWarmPingVerified = await isRelayWarmPingRequest(request, pathname);
     const requiresDirectLlmQuota = !internalMcpVerified && await shouldReserveGatewayDirectLlmQuota(request, pathname);

--- a/server/worldmonitor/wildfire/v1/list-fire-detections.ts
+++ b/server/worldmonitor/wildfire/v1/list-fire-detections.ts
@@ -11,45 +11,14 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/wildfire/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { limitFireDetectionsForDashboard } from '../../../../api/_wildfire-dashboard.js';
+export { WILDFIRE_DASHBOARD_DETECTION_LIMIT, limitFireDetectionsForDashboard } from '../../../../api/_wildfire-dashboard.js';
 
 const SEED_CACHE_KEY = 'wildfire:fires:v1';
 const SEED_META_KEY = 'seed-meta:wildfire:fires';
-export const WILDFIRE_DASHBOARD_DETECTION_LIMIT = 500;
 
 interface SeedMeta {
   fetchedAt?: number;
-}
-
-type FireDetection = ListFireDetectionsResponse['fireDetections'][number];
-
-function numeric(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function confidenceRank(confidence: FireDetection['confidence']): number {
-  switch (confidence) {
-    case 'FIRE_CONFIDENCE_HIGH': return 3;
-    case 'FIRE_CONFIDENCE_NOMINAL': return 2;
-    case 'FIRE_CONFIDENCE_LOW': return 1;
-    default: return 0;
-  }
-}
-
-function compareFireDetectionsForDashboard(a: FireDetection, b: FireDetection): number {
-  return Number(Boolean(b.possibleExplosion)) - Number(Boolean(a.possibleExplosion))
-    || confidenceRank(b.confidence) - confidenceRank(a.confidence)
-    || numeric(b.brightness) - numeric(a.brightness)
-    || numeric(b.frp) - numeric(a.frp)
-    || numeric(b.detectedAt) - numeric(a.detectedAt);
-}
-
-export function limitFireDetectionsForDashboard(
-  detections: FireDetection[],
-  limit = WILDFIRE_DASHBOARD_DETECTION_LIMIT,
-): FireDetection[] {
-  if (detections.length <= limit) return detections;
-  return [...detections].sort(compareFireDetectionsForDashboard).slice(0, limit);
 }
 
 export const listFireDetections: WildfireServiceHandler['listFireDetections'] = async (

--- a/server/worldmonitor/wildfire/v1/list-fire-detections.ts
+++ b/server/worldmonitor/wildfire/v1/list-fire-detections.ts
@@ -14,8 +14,10 @@ import { getCachedJson } from '../../../_shared/redis';
 import { limitFireDetectionsForDashboard } from '../../../../api/_wildfire-dashboard.js';
 export { WILDFIRE_DASHBOARD_DETECTION_LIMIT, limitFireDetectionsForDashboard } from '../../../../api/_wildfire-dashboard.js';
 
-const SEED_CACHE_KEY = 'wildfire:fires:v1';
-const SEED_META_KEY = 'seed-meta:wildfire:fires';
+const COMPACT_SEED_CACHE_KEY = 'wildfire:fires-bootstrap:v1';
+const COMPACT_SEED_META_KEY = 'seed-meta:wildfire:fires-bootstrap';
+const CANONICAL_SEED_CACHE_KEY = 'wildfire:fires:v1';
+const CANONICAL_SEED_META_KEY = 'seed-meta:wildfire:fires';
 
 interface SeedMeta {
   fetchedAt?: number;
@@ -26,10 +28,20 @@ export const listFireDetections: WildfireServiceHandler['listFireDetections'] = 
   _req: ListFireDetectionsRequest,
 ): Promise<ListFireDetectionsResponse> => {
   try {
-    const [result, meta] = await Promise.all([
-      getCachedJson(SEED_CACHE_KEY, true) as Promise<Partial<ListFireDetectionsResponse> | null>,
-      getCachedJson(SEED_META_KEY, true) as Promise<SeedMeta | null>,
+    let [result, meta] = await Promise.all([
+      getCachedJson(COMPACT_SEED_CACHE_KEY, true) as Promise<Partial<ListFireDetectionsResponse> | null>,
+      getCachedJson(COMPACT_SEED_META_KEY, true) as Promise<SeedMeta | null>,
     ]);
+
+    // Keep deploy ordering safe: the RPC can serve the canonical seed until the
+    // compact extra-key writer has published its first payload.
+    if (!result) {
+      [result, meta] = await Promise.all([
+        getCachedJson(CANONICAL_SEED_CACHE_KEY, true) as Promise<Partial<ListFireDetectionsResponse> | null>,
+        getCachedJson(CANONICAL_SEED_META_KEY, true) as Promise<SeedMeta | null>,
+      ]);
+    }
+
     if (!result) return { fireDetections: [], pagination: undefined, fetchedAt: 0, dataAvailable: false };
     const rawDetections = result.fireDetections ?? [];
     const fireDetections = limitFireDetectionsForDashboard(rawDetections);

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -107,6 +107,7 @@ import { isDesktopRuntime, toApiUrl } from '@/services/runtime';
 import { getAiFlowSettings } from '@/services/ai-flow-settings';
 import { t, getCurrentLanguage } from '@/services/i18n';
 import { getHydratedData } from '@/services/bootstrap';
+import { publicRpcFetch } from '@/services/public-rpc-fetch';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import type { GetSectorSummaryResponse, ListMarketQuotesResponse, ListCommodityQuotesResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
 import type {
@@ -618,9 +619,9 @@ export class DataLoaderManager implements AppModule {
 
     try {
       markLcpDebug('wm:data:feed-digest-start');
-      const resp = await fetch(
+      const resp = await publicRpcFetch(
         toApiUrl(`/api/news/v1/list-feed-digest?variant=${SITE_VARIANT}&lang=${getCurrentLanguage()}`),
-        { cache: 'no-cache', signal: AbortSignal.timeout(this.digestRequestTimeoutMs) },
+        { signal: AbortSignal.timeout(this.digestRequestTimeoutMs) },
       );
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const data = await resp.json() as ListFeedDigestResponse;

--- a/src/services/displacement/index.ts
+++ b/src/services/displacement/index.ts
@@ -2,6 +2,7 @@ import { getRpcBaseUrl } from '@/services/rpc-client';
 import type { GetDisplacementSummaryResponse as ProtoResponse, CountryDisplacement as ProtoCountry, DisplacementFlow as ProtoFlow } from '@/generated/client/worldmonitor/displacement/v1/service_client';
 import { createCircuitBreaker, getCSSColor } from '@/utils';
 import { DisplacementServiceClient } from '@/services/generated-rpc-clients';
+import { publicRpcFetch } from '@/services/public-rpc-fetch';
 
 // ─── Consumer-friendly types (matching legacy shape exactly) ───
 
@@ -112,7 +113,7 @@ function toDisplayFlow(proto: ProtoFlow): DisplacementFlow {
 
 // ─── Client + circuit breaker ───
 
-const client = new DisplacementServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const client = new DisplacementServiceClient(getRpcBaseUrl(), { fetch: publicRpcFetch });
 
 const breaker = createCircuitBreaker<UnhcrSummary>({
   name: 'UNHCR Displacement',

--- a/src/services/displacement/index.ts
+++ b/src/services/displacement/index.ts
@@ -113,7 +113,14 @@ function toDisplayFlow(proto: ProtoFlow): DisplacementFlow {
 
 // ─── Client + circuit breaker ───
 
-const client = new DisplacementServiceClient(getRpcBaseUrl(), { fetch: publicRpcFetch });
+async function fetchPublicDisplacementSummary(): Promise<ProtoResponse> {
+  return new DisplacementServiceClient(getRpcBaseUrl(), { fetch: publicRpcFetch })
+    .getDisplacementSummary({
+      year: 0,          // 0 = handler uses year fallback
+      countryLimit: 0,  // 0 = all countries
+      flowLimit: 50,    // top 50 flows (matching legacy)
+    });
+}
 
 const breaker = createCircuitBreaker<UnhcrSummary>({
   name: 'UNHCR Displacement',
@@ -125,11 +132,7 @@ const breaker = createCircuitBreaker<UnhcrSummary>({
 
 export async function fetchUnhcrPopulation(): Promise<UnhcrFetchResult> {
   const data = await breaker.execute(async () => {
-    const response = await client.getDisplacementSummary({
-      year: 0,          // 0 = handler uses year fallback
-      countryLimit: 0,  // 0 = all countries
-      flowLimit: 50,    // top 50 flows (matching legacy)
-    });
+    const response = await fetchPublicDisplacementSummary();
     return toDisplaySummary(response);
   }, emptyResult, { shouldCache: (r) => r.countries.length > 0 });
 

--- a/src/services/public-rpc-fetch.ts
+++ b/src/services/public-rpc-fetch.ts
@@ -1,0 +1,26 @@
+import { addPublicSharedRpcMarker } from '@/shared/public-rpc-cache';
+
+const CREDENTIAL_HEADERS = ['Authorization', 'X-WorldMonitor-Key', 'X-Api-Key', 'Cookie'];
+
+/**
+ * Fetch one of the explicitly caller-invariant dashboard RPCs through its
+ * isolated public CDN cache key. The legacy URL remains session/key gated.
+ */
+export const publicRpcFetch: typeof fetch = async (input, init) => {
+  const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+  if (method.toUpperCase() !== 'GET') {
+    throw new Error('public RPC fetch only supports GET');
+  }
+
+  const rawUrl = input instanceof Request ? input.url : String(input);
+  const url = addPublicSharedRpcMarker(rawUrl);
+  const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+  for (const name of CREDENTIAL_HEADERS) headers.delete(name);
+
+  return globalThis.fetch(url, {
+    ...init,
+    method: 'GET',
+    headers,
+    credentials: 'omit',
+  });
+};

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -14,6 +14,7 @@
 
 import { getCanonicalApiOrigin, toApiUrl } from './runtime';
 import { PREMIUM_RPC_PATHS } from '@/shared/premium-paths';
+import { isPublicSharedRpcRequest } from '@/shared/public-rpc-cache';
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 
 const STORAGE_KEY = 'wm-session-exp';
@@ -233,7 +234,7 @@ export function isApiCallTarget(url: string, apiOrigin: string): boolean {
   return parsed.origin === apiOrigin && parsed.pathname.startsWith('/api/');
 }
 
-function isCredentiallessPublicTierRequest(
+function isCredentiallessPublicDataRequest(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
   url: string,
@@ -249,7 +250,9 @@ function isCredentiallessPublicTierRequest(
   }
 
   const pathname = parsed.pathname.length > 1 ? parsed.pathname.replace(/\/+$/, '') : parsed.pathname;
-  if (pathname !== '/api/bootstrap') return false;
+  const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+  if (isPublicSharedRpcRequest(parsed, method)) return true;
+  if (pathname !== '/api/bootstrap' || method.toUpperCase() !== 'GET') return false;
 
   const params = Array.from(parsed.searchParams.keys());
   if (params.some((key) => key !== 'tier' && key !== 'public')) return false;
@@ -306,7 +309,7 @@ export function installWmSessionFetchInterceptor(): void {
     // the interceptor's synthetic 503 prevents the public CDN path from
     // restoring the dashboard. Keep the bypass narrow so arbitrary bootstrap
     // reads cannot opt out of the normal session machinery.
-    if (isCredentiallessPublicTierRequest(input, init, url)) return original(input, init);
+    if (isCredentiallessPublicDataRequest(input, init, url)) return original(input, init);
 
     // Premium routes have a dedicated auth-injection layer
     // (`installWebApiRedirect`'s `enrichInitForPremium` adds Clerk Bearer JWT,

--- a/src/shared/public-rpc-cache.ts
+++ b/src/shared/public-rpc-cache.ts
@@ -1,0 +1,84 @@
+const PUBLIC_SHARED_RPC_PATHS = new Set([
+  '/api/news/v1/list-feed-digest',
+  '/api/displacement/v1/get-displacement-summary',
+]);
+
+const NEWS_VARIANTS = new Set(['full', 'tech', 'finance', 'happy', 'commodity', 'energy']);
+const NEWS_LANGUAGES = new Set([
+  'en', 'bg', 'cs', 'fr', 'de', 'el', 'es', 'hr', 'hu', 'it', 'pl', 'pt', 'nl',
+  'sv', 'ru', 'ar', 'fa', 'zh', 'ja', 'ko', 'ro', 'tr', 'th', 'vi', 'hi',
+]);
+const NEWS_QUERY_KEYS = new Set(['variant', 'lang', 'public']);
+const DISPLACEMENT_QUERY_KEYS = new Set(['year', 'country_limit', 'flow_limit', 'public']);
+const DISPLACEMENT_INTEGER_KEYS = ['year', 'country_limit', 'flow_limit'] as const;
+
+function hasSingleValue(params: URLSearchParams, key: string): boolean {
+  return params.getAll(key).length === 1;
+}
+
+function isBoundedInteger(value: string | null, min: number, max: number): boolean {
+  if (value === null || !/^\d+$/.test(value)) return false;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max;
+}
+
+function hasOnlyKeys(params: URLSearchParams, allowed: Set<string>): boolean {
+  return Array.from(params.keys()).every((key) => allowed.has(key));
+}
+
+function isNewsDigestShape(params: URLSearchParams): boolean {
+  return hasOnlyKeys(params, NEWS_QUERY_KEYS)
+    && hasSingleValue(params, 'variant')
+    && hasSingleValue(params, 'lang')
+    && NEWS_VARIANTS.has(params.get('variant') ?? '')
+    && NEWS_LANGUAGES.has(params.get('lang') ?? '');
+}
+
+function isDisplacementShape(params: URLSearchParams): boolean {
+  if (!hasOnlyKeys(params, DISPLACEMENT_QUERY_KEYS)) return false;
+
+  for (const key of DISPLACEMENT_INTEGER_KEYS) {
+    if (params.has(key) && !hasSingleValue(params, key)) return false;
+  }
+  if (params.has('year') && !isBoundedInteger(params.get('year'), 1950, 2100)) return false;
+  if (params.has('country_limit') && !isBoundedInteger(params.get('country_limit'), 1, 500)) return false;
+  if (params.has('flow_limit') && !isBoundedInteger(params.get('flow_limit'), 1, 500)) return false;
+  return true;
+}
+
+export function isPublicSharedRpcRequest(urlLike: string | URL, method = 'GET'): boolean {
+  if (method.toUpperCase() !== 'GET') return false;
+
+  let url: URL;
+  try {
+    url = urlLike instanceof URL
+      ? urlLike
+      : new URL(urlLike, 'https://worldmonitor.invalid');
+  } catch {
+    return false;
+  }
+
+  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
+  if (!PUBLIC_SHARED_RPC_PATHS.has(pathname)) return false;
+  if (!hasSingleValue(url.searchParams, 'public') || url.searchParams.get('public') !== '1') return false;
+
+  if (pathname === '/api/news/v1/list-feed-digest') return isNewsDigestShape(url.searchParams);
+  return isDisplacementShape(url.searchParams);
+}
+
+export function addPublicSharedRpcMarker(urlLike: string | URL): string {
+  const original = String(urlLike);
+  const relative = original.startsWith('/');
+  const base = typeof location === 'undefined' ? 'https://worldmonitor.invalid' : location.href;
+  const url = new URL(original, base);
+
+  if (!PUBLIC_SHARED_RPC_PATHS.has(url.pathname)) {
+    throw new Error(`not an allowlisted public RPC: ${url.pathname}`);
+  }
+  url.searchParams.set('public', '1');
+  if (!isPublicSharedRpcRequest(url)) {
+    throw new Error(`not an allowlisted public RPC shape: ${url.pathname}${url.search}`);
+  }
+
+  return relative ? `${url.pathname}${url.search}${url.hash}` : url.toString();
+}

--- a/src/shared/public-rpc-cache.ts
+++ b/src/shared/public-rpc-cache.ts
@@ -9,17 +9,10 @@ const NEWS_LANGUAGES = new Set([
   'sv', 'ru', 'ar', 'fa', 'zh', 'ja', 'ko', 'ro', 'tr', 'th', 'vi', 'hi',
 ]);
 const NEWS_QUERY_KEYS = new Set(['variant', 'lang', 'public']);
-const DISPLACEMENT_QUERY_KEYS = new Set(['year', 'country_limit', 'flow_limit', 'public']);
-const DISPLACEMENT_INTEGER_KEYS = ['year', 'country_limit', 'flow_limit'] as const;
+const DISPLACEMENT_PUBLIC_SEARCH = '?flow_limit=50&public=1';
 
 function hasSingleValue(params: URLSearchParams, key: string): boolean {
   return params.getAll(key).length === 1;
-}
-
-function isBoundedInteger(value: string | null, min: number, max: number): boolean {
-  if (value === null || !/^\d+$/.test(value)) return false;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max;
 }
 
 function hasOnlyKeys(params: URLSearchParams, allowed: Set<string>): boolean {
@@ -32,18 +25,6 @@ function isNewsDigestShape(params: URLSearchParams): boolean {
     && hasSingleValue(params, 'lang')
     && NEWS_VARIANTS.has(params.get('variant') ?? '')
     && NEWS_LANGUAGES.has(params.get('lang') ?? '');
-}
-
-function isDisplacementShape(params: URLSearchParams): boolean {
-  if (!hasOnlyKeys(params, DISPLACEMENT_QUERY_KEYS)) return false;
-
-  for (const key of DISPLACEMENT_INTEGER_KEYS) {
-    if (params.has(key) && !hasSingleValue(params, key)) return false;
-  }
-  if (params.has('year') && !isBoundedInteger(params.get('year'), 1950, 2100)) return false;
-  if (params.has('country_limit') && !isBoundedInteger(params.get('country_limit'), 1, 500)) return false;
-  if (params.has('flow_limit') && !isBoundedInteger(params.get('flow_limit'), 1, 500)) return false;
-  return true;
 }
 
 export function isPublicSharedRpcRequest(urlLike: string | URL, method = 'GET'): boolean {
@@ -63,7 +44,7 @@ export function isPublicSharedRpcRequest(urlLike: string | URL, method = 'GET'):
   if (!hasSingleValue(url.searchParams, 'public') || url.searchParams.get('public') !== '1') return false;
 
   if (pathname === '/api/news/v1/list-feed-digest') return isNewsDigestShape(url.searchParams);
-  return isDisplacementShape(url.searchParams);
+  return url.search === DISPLACEMENT_PUBLIC_SEARCH;
 }
 
 export function addPublicSharedRpcMarker(urlLike: string | URL): string {

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -166,7 +166,16 @@ describe('gateway CDN origin policy', () => {
     for (const path of [
       '/api/news/v1/list-feed-digest?variant=full&lang=en',
       '/api/news/v1/list-feed-digest?variant=full&lang=en&public=1&jmespath=categories',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=49&public=1',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=500&public=1',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&year=2026',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&country_limit=50',
+      '/api/displacement/v1/get-displacement-summary?public=1',
       '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&unexpected=1',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&flow_limit=50&public=1',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&public=1',
+      '/api/displacement/v1/get-displacement-summary?public=1&flow_limit=50',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=%35%30&public=1',
     ]) {
       const res = await handler(new Request(`https://worldmonitor.app${path}`, {
         headers: { Origin: 'https://worldmonitor.app' },

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -42,6 +42,16 @@ function createHandler(options: { handlerCdnCacheHeader?: string; publicRouteBod
     },
     {
       method: 'GET',
+      path: '/api/news/v1/list-feed-digest',
+      handler: async () => new Response(JSON.stringify({ categories: {}, feedStatuses: {}, generatedAt: '2026-07-13T00:00:00.000Z' }), { status: 200 }),
+    },
+    {
+      method: 'GET',
+      path: '/api/displacement/v1/get-displacement-summary',
+      handler: async () => new Response(JSON.stringify({ summary: { countries: [], topFlows: [] }, fetchedAt: 1, dataAvailable: true }), { status: 200 }),
+    },
+    {
+      method: 'GET',
       path: '/api/market/v1/analyze-stock',
       handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
     },
@@ -121,6 +131,49 @@ describe('gateway CDN origin policy', () => {
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
     assert.equal(res.headers.get('Vary'), 'Origin');
     assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  for (const path of [
+    '/api/news/v1/list-feed-digest?variant=full&lang=en&public=1',
+    '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1',
+  ]) {
+    it(`CDN-shields the exact caller-invariant public RPC variant: ${path}`, async () => {
+      const handler = createHandler();
+      const res = await handler(new Request(`https://worldmonitor.app${path}`, {
+        headers: { Origin: 'https://worldmonitor.app' },
+      }));
+
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    });
+
+    it(`keeps the public RPC response invariant when credentials are attached: ${path}`, async () => {
+      const handler = createHandler();
+      const res = await handler(new Request(`https://worldmonitor.app${path}`, {
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-WorldMonitor-Key': sessionToken,
+        },
+      }));
+
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    });
+  }
+
+  it('does not widen the public RPC cache contract to legacy or arbitrary query shapes', async () => {
+    const handler = createHandler();
+    for (const path of [
+      '/api/news/v1/list-feed-digest?variant=full&lang=en',
+      '/api/news/v1/list-feed-digest?variant=full&lang=en&public=1&jmespath=categories',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&unexpected=1',
+    ]) {
+      const res = await handler(new Request(`https://worldmonitor.app${path}`, {
+        headers: { Origin: 'https://worldmonitor.app' },
+      }));
+      assert.equal(res.status, 401, path);
+      assertNoSharedCacheHeaders(res);
+    }
   });
 
   it('skips CDN caching for degraded dataAvailable=false 200 responses', async () => {

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -82,6 +82,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'cascade-mirror: RPC variant of aviation:delays-bootstrap:v2 (covered by get_aviation_status). Same seed-meta key (seed-meta:aviation:faa).'],
   ['cyber:threats:v2',
     'cascade-mirror: RPC variant of cyber:threats-bootstrap:v2 (covered by get_cyber_threats). Same seed-meta key (seed-meta:cyber:threats).'],
+  ['wildfire:fires-bootstrap:v1',
+    'cascade-mirror: pre-compacted dashboard/RPC variant of wildfire:fires:v1 (covered by get_natural_events). It preserves the same top-500 response while avoiding canonical-payload Redis egress.'],
   ['aviation:delays:intl:v3',
     'cascade-mirror: international delays sibling of aviation:delays-bootstrap:v2 (covered by get_aviation_status) — deferred to a future expanded aviation tool that exposes the intl variant directly.'],
   ['aviation:notam:closures:v2',

--- a/tests/public-rpc-fetch.test.mts
+++ b/tests/public-rpc-fetch.test.mts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { publicRpcFetch } from '../src/services/public-rpc-fetch.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('publicRpcFetch', () => {
+  it('adds the isolated public cache marker and strips credential-bearing request state', async () => {
+    let capturedUrl = '';
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = (async (input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    await publicRpcFetch('https://api.worldmonitor.app/api/news/v1/list-feed-digest?variant=full&lang=en', {
+      credentials: 'include',
+      headers: {
+        Authorization: 'Bearer secret',
+        'X-WorldMonitor-Key': 'wm_secret',
+        'X-Api-Key': 'legacy-secret',
+        Accept: 'application/json',
+      },
+    });
+
+    const url = new URL(capturedUrl);
+    assert.equal(url.searchParams.get('public'), '1');
+    assert.equal(capturedInit?.credentials, 'omit');
+    const headers = new Headers(capturedInit?.headers);
+    assert.equal(headers.get('Authorization'), null);
+    assert.equal(headers.get('X-WorldMonitor-Key'), null);
+    assert.equal(headers.get('X-Api-Key'), null);
+    assert.equal(headers.get('Accept'), 'application/json');
+  });
+
+  it('rejects routes outside the narrow shared-RPC allowlist before fetching', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    await assert.rejects(
+      publicRpcFetch('https://api.worldmonitor.app/api/intelligence/v1/get-risk-scores'),
+      /not an allowlisted public RPC/,
+    );
+    assert.equal(calls, 0);
+  });
+});

--- a/tests/public-rpc-fetch.test.mts
+++ b/tests/public-rpc-fetch.test.mts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
 
 import { publicRpcFetch } from '../src/services/public-rpc-fetch.ts';
 
@@ -10,6 +11,14 @@ afterEach(() => {
 });
 
 describe('publicRpcFetch', () => {
+  it('keeps the allowlist-only transport scoped to the displacement summary call', () => {
+    const source = readFileSync(new URL('../src/services/displacement/index.ts', import.meta.url), 'utf8');
+
+    assert.doesNotMatch(source, /const client = new DisplacementServiceClient[^;]+publicRpcFetch/);
+    assert.match(source, /async function fetchPublicDisplacementSummary/);
+    assert.match(source, /new DisplacementServiceClient[^;]+publicRpcFetch/);
+  });
+
   it('adds the isolated public cache marker and strips credential-bearing request state', async () => {
     let capturedUrl = '';
     let capturedInit: RequestInit | undefined;

--- a/tests/wildfire-bootstrap-health.test.mjs
+++ b/tests/wildfire-bootstrap-health.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ } from '../api/health.js';
+
+const { BOOTSTRAP_KEYS, SEED_META, classifyKey } = __testing__;
+const NOW = 1_700_000_000_000;
+
+function makeCtx({ compactBytes = 0, canonicalBytes = 0, meta } = {}) {
+  return {
+    keyStrens: new Map([
+      [BOOTSTRAP_KEYS.wildfiresBootstrap, compactBytes],
+      [BOOTSTRAP_KEYS.wildfires, canonicalBytes],
+    ]),
+    keyErrors: new Map(),
+    keyMetaValues: new Map(meta ? [[SEED_META.wildfiresBootstrap.key, JSON.stringify(meta)]] : []),
+    keyMetaErrors: new Map(),
+    now: NOW,
+  };
+}
+
+test('health monitors the compact wildfire publish independently of canonical fallback', () => {
+  assert.equal(BOOTSTRAP_KEYS.wildfiresBootstrap, 'wildfire:fires-bootstrap:v1');
+  assert.deepEqual(SEED_META.wildfiresBootstrap, {
+    key: 'seed-meta:wildfire:fires-bootstrap',
+    maxStaleMin: 360,
+  });
+
+  const freshMeta = { fetchedAt: NOW - 60_000, recordCount: 500 };
+  const healthy = classifyKey(
+    'wildfiresBootstrap',
+    BOOTSTRAP_KEYS.wildfiresBootstrap,
+    { allowOnDemand: false },
+    makeCtx({ compactBytes: 64_000, canonicalBytes: 1_360_000, meta: freshMeta }),
+  );
+  assert.equal(healthy.status, 'OK');
+
+  const missingCompact = classifyKey(
+    'wildfiresBootstrap',
+    BOOTSTRAP_KEYS.wildfiresBootstrap,
+    { allowOnDemand: false },
+    makeCtx({ canonicalBytes: 1_360_000, meta: freshMeta }),
+  );
+  assert.equal(missingCompact.status, 'EMPTY');
+});

--- a/tests/wildfire-bootstrap-health.test.mjs
+++ b/tests/wildfire-bootstrap-health.test.mjs
@@ -35,11 +35,19 @@ test('health monitors the compact wildfire publish independently of canonical fa
   );
   assert.equal(healthy.status, 'OK');
 
-  const missingCompact = classifyKey(
+  const missingBeforeFirstSeed = classifyKey(
     'wildfiresBootstrap',
     BOOTSTRAP_KEYS.wildfiresBootstrap,
     { allowOnDemand: false },
-    makeCtx({ canonicalBytes: 1_360_000, meta: freshMeta }),
+    makeCtx({ canonicalBytes: 1_360_000 }),
   );
-  assert.equal(missingCompact.status, 'EMPTY');
+  assert.equal(missingBeforeFirstSeed.status, 'STALE_SEED');
+
+  const missingCanonical = classifyKey(
+    'wildfires',
+    BOOTSTRAP_KEYS.wildfires,
+    { allowOnDemand: false },
+    makeCtx(),
+  );
+  assert.equal(missingCanonical.status, 'EMPTY');
 });

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -37,6 +37,7 @@ describe('wildfire dashboard payload cap', () => {
 
     assert.match(seeder, /wildfire:fires-bootstrap:v1/);
     assert.match(seeder, /extraKeys\s*:/);
+    assert.match(seeder, /metaKey:\s*'seed-meta:wildfire:fires-bootstrap'/);
     assert.match(bootstrap, /wildfires:\s*'wildfire:fires-bootstrap:v1'/);
     assert.doesNotMatch(bootstrap, /wildfires:\s*'wildfire:fires:v1'/);
   });

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
 import { gzipSync } from 'node:zlib';
 
 import { compactWildfireBootstrapPayload } from '../api/bootstrap.js';
@@ -30,6 +31,16 @@ function fireDetection(index: number, overrides: Partial<FireDetection> = {}): F
 }
 
 describe('wildfire dashboard payload cap', () => {
+  it('publishes and hydrates a dedicated pre-compacted bootstrap key', () => {
+    const seeder = readFileSync(new URL('../scripts/seed-fire-detections.mjs', import.meta.url), 'utf8');
+    const bootstrap = readFileSync(new URL('../api/bootstrap.js', import.meta.url), 'utf8');
+
+    assert.match(seeder, /wildfire:fires-bootstrap:v1/);
+    assert.match(seeder, /extraKeys\s*:/);
+    assert.match(bootstrap, /wildfires:\s*'wildfire:fires-bootstrap:v1'/);
+    assert.doesNotMatch(bootstrap, /wildfires:\s*'wildfire:fires:v1'/);
+  });
+
   it('caps response detections without mutating the seed array and keeps highest-signal detections', () => {
     const lowSignal = Array.from({ length: WILDFIRE_DASHBOARD_DETECTION_LIMIT + 25 }, (_, index) =>
       fireDetection(index, {

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -6,6 +6,7 @@ import { gzipSync } from 'node:zlib';
 import { compactWildfireBootstrapPayload } from '../api/bootstrap.js';
 import {
   WILDFIRE_DASHBOARD_DETECTION_LIMIT,
+  listFireDetections,
   limitFireDetectionsForDashboard,
 } from '../server/worldmonitor/wildfire/v1/list-fire-detections.ts';
 import { resolveFireDetectionTotalCount } from '../src/services/wildfires/payload.ts';
@@ -31,6 +32,95 @@ function fireDetection(index: number, overrides: Partial<FireDetection> = {}): F
 }
 
 describe('wildfire dashboard payload cap', () => {
+  it('serves the compact RPC payload without reading the canonical seed', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const requestedKeys: string[] = [];
+    const compactPayload = {
+      fireDetections: [fireDetection(1)],
+      pagination: { nextCursor: '', totalCount: 1_234 },
+      dataAvailable: true,
+    };
+
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = async (input) => {
+      const key = decodeURIComponent(new URL(String(input)).pathname.replace('/get/', ''));
+      requestedKeys.push(key);
+      const value = key === 'wildfire:fires-bootstrap:v1'
+        ? compactPayload
+        : key === 'seed-meta:wildfire:fires-bootstrap'
+          ? { fetchedAt: 1_783_500_000_000 }
+          : null;
+      return Response.json({ result: value == null ? null : JSON.stringify(value) });
+    };
+
+    try {
+      const response = await listFireDetections({} as never, {});
+
+      assert.deepEqual(response, {
+        ...compactPayload,
+        fetchedAt: 1_783_500_000_000,
+      });
+      assert.deepEqual(requestedKeys, [
+        'wildfire:fires-bootstrap:v1',
+        'seed-meta:wildfire:fires-bootstrap',
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    }
+  });
+
+  it('falls back to the canonical payload and metadata when the compact seed is missing', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const requestedKeys: string[] = [];
+    const canonicalDetections = Array.from(
+      { length: WILDFIRE_DASHBOARD_DETECTION_LIMIT + 7 },
+      (_, index) => fireDetection(index),
+    );
+
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = async (input) => {
+      const key = decodeURIComponent(new URL(String(input)).pathname.replace('/get/', ''));
+      requestedKeys.push(key);
+      const value = key === 'wildfire:fires:v1'
+        ? { fireDetections: canonicalDetections, dataAvailable: true }
+        : key === 'seed-meta:wildfire:fires'
+          ? { fetchedAt: 1_783_600_000_000 }
+          : null;
+      return Response.json({ result: value == null ? null : JSON.stringify(value) });
+    };
+
+    try {
+      const response = await listFireDetections({} as never, {});
+
+      assert.equal(response.fireDetections.length, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
+      assert.deepEqual(response.pagination, { nextCursor: '', totalCount: canonicalDetections.length });
+      assert.equal(response.fetchedAt, 1_783_600_000_000);
+      assert.equal(response.dataAvailable, true);
+      assert.deepEqual(requestedKeys, [
+        'wildfire:fires-bootstrap:v1',
+        'seed-meta:wildfire:fires-bootstrap',
+        'wildfire:fires:v1',
+        'seed-meta:wildfire:fires',
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    }
+  });
+
   it('publishes and hydrates a dedicated pre-compacted bootstrap key', () => {
     const seeder = readFileSync(new URL('../scripts/seed-fire-detections.mjs', import.meta.url), 'utf8');
     const bootstrap = readFileSync(new URL('../api/bootstrap.js', import.meta.url), 'utf8');

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -445,6 +445,16 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
       const slow = await wrappedFetch(slowRequest);
       assert.equal(slow.status, 200, 'Request input should preserve its effective omit credentials');
 
+      const digest = await wrappedFetch('https://api.worldmonitor.app/api/news/v1/list-feed-digest?variant=full&lang=en&public=1', {
+        credentials: 'omit',
+      });
+      assert.equal(digest.status, 200, 'public digest should bypass dead-session suppression');
+
+      const displacement = await wrappedFetch('https://api.worldmonitor.app/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1', {
+        credentials: 'omit',
+      });
+      assert.equal(displacement.status, 200, 'public displacement should bypass dead-session suppression');
+
       const missingPublicFlag = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap?tier=fast', {
         credentials: 'omit',
       });
@@ -459,12 +469,14 @@ describe('wm-session refresh-on-401 (Layer 2)', () => {
     }
 
     assert.deepEqual(
-      forwarded.slice(-2),
+      forwarded.slice(-4),
       [
         { url: 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1', credentials: 'omit' },
         { url: 'https://api.worldmonitor.app/api/bootstrap?public=1&tier=slow', credentials: 'omit' },
+        { url: 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?variant=full&lang=en&public=1', credentials: 'omit' },
+        { url: 'https://api.worldmonitor.app/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1', credentials: 'omit' },
       ],
-      'only the two explicit public tier requests should reach native fetch during cooldown',
+      'only exact credential-less public data requests should reach native fetch during cooldown',
     );
   });
 


### PR DESCRIPTION
## Summary

Dashboard refreshes can now reuse shared CDN responses for the news digest and displacement summary through explicit caller-invariant `public=1` URLs. Their legacy URLs remain credential-gated and non-shared, including when callers attach credentials to the public URL.

Wildfire bootstrap hydration now reads a seed-time compact payload instead of paying Redis egress for the full canonical detection set and trimming it after the read. The canonical wildfire key remains intact for RPC and analytical consumers.

| Signal | Before | This PR / validation |
| --- | --- | --- |
| Redis GET egress | ~64 GB/day rate | <=17 GB/day target requires post-deploy measurement |
| Wildfire bootstrap | Full 79 KB-1.36 MB canonical read | Dedicated payload capped at 500 highest-signal detections |
| News + displacement refreshes | Repeated origin reads | Explicit CDN cache keys; deployed MISS -> HIT proof pending |

Related: #5259

## Test plan

- `npm run build:full`
- `npm run test:data` - 15,225 passed, 0 failed, 6 skipped
- `npm run typecheck`
- `npm run typecheck:api`
- `node --test tests/edge-functions.test.mjs` - 228 passed
- 123 focused bootstrap, gateway, public-RPC, wildfire, and session tests
- Pre-push gate passed, including boundary, safe-HTML, rate-limit, premium-fetch, edge-bundle, handler, changed-test, and version checks

## Post-Deploy Monitoring & Validation

1. Before the web rollout depends on it, confirm the Railway seeder has populated `wildfire:fires-bootstrap:v1` with a healthy envelope and no more than 500 detections.
2. During a representative peak window, probe each public URL twice from an allowed origin and confirm `x-vercel-cache` transitions from `MISS` to `HIT` while `CDN-Cache-Control` remains present:
   - `/api/news/v1/list-feed-digest?variant=full&lang=en&public=1`
   - `/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1`
3. Confirm anonymous legacy URLs remain rejected and credentialed legacy URLs remain non-shared. Also confirm credentials attached to the explicit public URLs do not change their response or cache posture.
4. Run a 300-second Upstash `MONITOR` sample at peak, normalize health-sweep and `EVALSHA` noise, and verify bootstrap no longer reads `wildfire:fires:v1` while the two RPC origin-read counts collapse behind CDN hits.
5. Measure a full UTC day. Keep #5259 open unless sustained Redis GET egress is <=17 GB/day; if it remains above budget, use the measured long tail to select the next smaller-bundle or longer-safe-TTL lever.

Rollback by reverting this commit. If deployment ordering is the only failure, hold the web rollout until the compact wildfire key exists rather than restoring the oversized bootstrap read.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
