### PR TITLE
fix(conflict): restore keyless GDELT fallback

### DIFF
--- a/scripts/_conflict-gdelt-bulk.mjs
+++ b/scripts/_conflict-gdelt-bulk.mjs
@@ -163,12 +163,15 @@ export function mapGdeltExportToConflictEvents(csv) {
   return events;
 }
 
-async function fetchBoundedBuffer(fetchImpl, url, maxBytes, extraHeaders = {}) {
+async function fetchBoundedBuffer(fetchImpl, url, maxBytes, expectedStatus, extraHeaders = {}) {
   const response = await fetchImpl(url, {
     headers: { Accept: '*/*', 'User-Agent': USER_AGENT, ...extraHeaders },
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) throw new Error(`GDELT bulk HTTP ${response.status} for ${url}`);
+  if (expectedStatus && response.status !== expectedStatus) {
+    throw new Error(`GDELT bulk expected HTTP ${expectedStatus}, got ${response.status} for ${url}`);
+  }
   const declaredLength = Number(response.headers.get('content-length'));
   if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
     throw new Error(`GDELT bulk response exceeds ${maxBytes} bytes`);
@@ -191,6 +194,7 @@ export async function fetchGdeltBulkConflictEvents({ fetchImpl = globalThis.fetc
     fetchImpl,
     GDELT_MASTER_FILELIST_URL,
     MASTER_TAIL_BYTES,
+    206,
     { Range: `bytes=-${MASTER_TAIL_BYTES}` },
   );
   const descriptors = parseGdeltRecentExports(manifestBytes.toString('utf8'));

--- a/scripts/_conflict-gdelt-bulk.mjs
+++ b/scripts/_conflict-gdelt-bulk.mjs
@@ -17,6 +17,7 @@ const MASTER_TAIL_BYTES = 16_384;
 const RECENT_EXPORT_COUNT = 8;
 const EXPORT_FETCH_CONCURRENCY = 4;
 const REQUEST_TIMEOUT_MS = 20_000;
+export const GDELT_ROLLING_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const GDELT_BULK_WORST_NETWORK_MS = REQUEST_TIMEOUT_MS
   * (1 + Math.ceil(RECENT_EXPORT_COUNT / EXPORT_FETCH_CONCURRENCY));
 const USER_AGENT = 'WorldMonitor/1.0 (+https://www.worldmonitor.app)';
@@ -133,6 +134,15 @@ function sourceDomain(sourceUrl) {
   }
 }
 
+export function gdeltTimestampToMs(value) {
+  const digits = String(value || '').replace(/[^0-9]/g, '');
+  if (digits.length < 14) return Number.NaN;
+  return Date.parse(
+    `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
+      + `T${digits.slice(8, 10)}:${digits.slice(10, 12)}:${digits.slice(12, 14)}Z`,
+  );
+}
+
 export function mapGdeltExportToConflictEvents(csv) {
   const events = [];
   const seen = new Set();
@@ -146,7 +156,8 @@ export function mapGdeltExportToConflictEvents(csv) {
     const country = GDELT_COUNTRY_NAMES[iso2];
     const id = fields[0];
     const eventDate = gdeltSeenDateToIso(fields[59]);
-    if (!id || seen.has(id) || !country || !eventDate) continue;
+    const gdeltAddedAt = gdeltTimestampToMs(fields[59]);
+    if (!id || seen.has(id) || !country || !eventDate || !Number.isFinite(gdeltAddedAt)) continue;
     seen.add(id);
 
     const url = fields[60] || '';
@@ -155,12 +166,69 @@ export function mapGdeltExportToConflictEvents(csv) {
       eventType: `GDELT ${fields[26] || fields[28] || 'material conflict'}`,
       country,
       event_date: eventDate,
-      occurredAt: Date.parse(eventDate) || 0,
+      occurredAt: gdeltAddedAt,
+      gdeltAddedAt,
       source: sourceDomain(url),
       url,
     });
   }
   return events;
+}
+
+function eventAddedAt(event, fallbackTimestamp) {
+  const exact = Number(event?.gdeltAddedAt);
+  if (Number.isFinite(exact) && exact > 0) return exact;
+  return gdeltTimestampToMs(fallbackTimestamp);
+}
+
+export function mergeGdeltBulkRollingWindow(bulk, previousSnapshot, nowMs = Date.now()) {
+  const cutoff = nowMs - GDELT_ROLLING_WINDOW_MS;
+  const previousIsBulk = previousSnapshot?.source === 'gdelt-bulk'
+    && Array.isArray(previousSnapshot.events);
+  const previousExportTimestamp = previousSnapshot?.pagination?.exportTimestamp;
+  const currentExportTimestamp = bulk?.exportTimestamp;
+  const byId = new Map();
+
+  const addEvents = (events, fallbackTimestamp) => {
+    for (const event of Array.isArray(events) ? events : []) {
+      const addedAt = eventAddedAt(event, fallbackTimestamp);
+      if (!event?.id || !Number.isFinite(addedAt) || addedAt < cutoff) continue;
+      byId.set(event.id, { ...event, occurredAt: addedAt, gdeltAddedAt: addedAt });
+    }
+  };
+
+  if (previousIsBulk) addEvents(previousSnapshot.events, previousExportTimestamp);
+  // Current exports win on duplicate IDs, though GDELT event IDs are normally
+  // first-seen-only and therefore unique across 15-minute export files.
+  addEvents(bulk?.events, currentExportTimestamp);
+
+  const currentCoverageStart = gdeltTimestampToMs(
+    bulk?.oldestExportTimestamp || currentExportTimestamp,
+  );
+  const previousCoverageStart = previousIsBulk
+    ? Number(previousSnapshot.pagination?.rollingWindowStartedAt)
+    : Number.NaN;
+  const legacyPreviousCoverageStart = previousIsBulk
+    ? gdeltTimestampToMs(previousExportTimestamp) - (RECENT_EXPORT_COUNT * 15 * 60 * 1000)
+    : Number.NaN;
+  const coverageCandidates = [
+    currentCoverageStart,
+    previousCoverageStart,
+    legacyPreviousCoverageStart,
+  ].filter(value => Number.isFinite(value) && value > 0);
+  const earliestCoverage = coverageCandidates.length
+    ? Math.min(...coverageCandidates)
+    : nowMs;
+  const rollingWindowStartedAt = Math.max(cutoff, earliestCoverage);
+
+  return {
+    events: [...byId.values()].sort((a, b) => b.gdeltAddedAt - a.gdeltAddedAt),
+    rollingWindowStartedAt,
+    rollingWindowComplete: rollingWindowStartedAt <= cutoff,
+    retainedPreviousEvents: previousIsBulk
+      ? [...byId.values()].filter(event => event.gdeltAddedAt < currentCoverageStart).length
+      : 0,
+  };
 }
 
 async function fetchBoundedBuffer(fetchImpl, url, maxBytes, expectedStatus, extraHeaders = {}) {
@@ -231,6 +299,10 @@ export async function fetchGdeltBulkConflictEvents({ fetchImpl = globalThis.fetc
   }
   return {
     events,
+    oldestExportTimestamp: successful
+      .map(result => result.value.exportTimestamp)
+      .sort()
+      .at(0),
     exportTimestamp: successful
       .map(result => result.value.exportTimestamp)
       .sort()

--- a/scripts/_conflict-gdelt-bulk.mjs
+++ b/scripts/_conflict-gdelt-bulk.mjs
@@ -12,6 +12,7 @@ const GDELT_STORAGE_ORIGIN = 'https://storage.googleapis.com/data.gdeltproject.o
 export const GDELT_MASTER_FILELIST_URL = `${GDELT_STORAGE_ORIGIN}/gdeltv2/masterfilelist.txt`;
 export const GDELT_MAX_EXPORT_ZIP_BYTES = 5_000_000;
 export const GDELT_MAX_EXPORT_CSV_BYTES = 30_000_000;
+export const GDELT_ROLLING_WINDOW_MAX_EVENTS = 5_000;
 
 const MASTER_TAIL_BYTES = 16_384;
 const RECENT_EXPORT_COUNT = 8;
@@ -220,13 +221,16 @@ export function mergeGdeltBulkRollingWindow(bulk, previousSnapshot, nowMs = Date
     ? Math.min(...coverageCandidates)
     : nowMs;
   const rollingWindowStartedAt = Math.max(cutoff, earliestCoverage);
+  const events = [...byId.values()]
+    .sort((a, b) => b.gdeltAddedAt - a.gdeltAddedAt)
+    .slice(0, GDELT_ROLLING_WINDOW_MAX_EVENTS);
 
   return {
-    events: [...byId.values()].sort((a, b) => b.gdeltAddedAt - a.gdeltAddedAt),
+    events,
     rollingWindowStartedAt,
     rollingWindowComplete: rollingWindowStartedAt <= cutoff,
     retainedPreviousEvents: previousIsBulk
-      ? [...byId.values()].filter(event => event.gdeltAddedAt < currentCoverageStart).length
+      ? events.filter(event => event.gdeltAddedAt < currentCoverageStart).length
       : 0,
   };
 }

--- a/scripts/_conflict-gdelt-bulk.mjs
+++ b/scripts/_conflict-gdelt-bulk.mjs
@@ -1,0 +1,237 @@
+// Resilient GDELT conflict-event fallback using the official 15-minute bulk
+// event export. The DOC API is aggressively per-IP throttled; the bulk stream
+// is a single global stream and therefore remains usable when country-by-country
+// DOC queries all return 429.
+
+import { createHash } from 'node:crypto';
+import { inflateRawSync } from 'node:zlib';
+import { GDELT_COUNTRY_NAMES, gdeltSeenDateToIso } from './_conflict-gdelt.mjs';
+import { allSettledWithConcurrency } from './_seed-utils.mjs';
+
+const GDELT_STORAGE_ORIGIN = 'https://storage.googleapis.com/data.gdeltproject.org';
+export const GDELT_MASTER_FILELIST_URL = `${GDELT_STORAGE_ORIGIN}/gdeltv2/masterfilelist.txt`;
+export const GDELT_MAX_EXPORT_ZIP_BYTES = 5_000_000;
+export const GDELT_MAX_EXPORT_CSV_BYTES = 30_000_000;
+
+const MASTER_TAIL_BYTES = 16_384;
+const RECENT_EXPORT_COUNT = 8;
+const EXPORT_FETCH_CONCURRENCY = 4;
+const REQUEST_TIMEOUT_MS = 20_000;
+export const GDELT_BULK_WORST_NETWORK_MS = REQUEST_TIMEOUT_MS
+  * (1 + Math.ceil(RECENT_EXPORT_COUNT / EXPORT_FETCH_CONCURRENCY));
+const USER_AGENT = 'WorldMonitor/1.0 (+https://www.worldmonitor.app)';
+const MATERIAL_VIOLENCE_ROOT_CODES = new Set(['18', '19', '20']);
+
+// GDELT ActionGeo_CountryCode uses FIPS 10-4 rather than ISO-2.
+// Palestine can appear as either Gaza (GZ) or West Bank (WE).
+export const GDELT_FIPS_TO_ISO2 = Object.freeze({
+  AF: 'AF', SY: 'SY', UP: 'UA', SU: 'SD', OD: 'SS', SO: 'SO', CG: 'CD',
+  BM: 'MM', YM: 'YE', ET: 'ET', IZ: 'IQ', GZ: 'PS', WE: 'PS', LY: 'LY',
+  ML: 'ML', UV: 'BF', NG: 'NE', NI: 'NG', CM: 'CM', MZ: 'MZ', HA: 'HT',
+});
+
+function boundedPositiveInteger(value, label, max) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > max) {
+    throw new Error(`invalid GDELT ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function parseExportDescriptorLine(exportLine) {
+  const [sizeRaw, md5Raw, urlRaw, ...extra] = exportLine.split(/\s+/);
+  if (!sizeRaw || !md5Raw || !urlRaw || extra.length) {
+    throw new Error('malformed GDELT event export manifest line');
+  }
+  const size = boundedPositiveInteger(sizeRaw, 'event export size', GDELT_MAX_EXPORT_ZIP_BYTES);
+  const md5 = md5Raw.toLowerCase();
+  if (!/^[a-f0-9]{32}$/.test(md5)) throw new Error('invalid GDELT event export checksum');
+
+  const url = new URL(urlRaw);
+  if (!['http:', 'https:'].includes(url.protocol) || url.hostname !== 'data.gdeltproject.org' || url.port) {
+    throw new Error(`untrusted GDELT event export URL: ${urlRaw}`);
+  }
+  const match = url.pathname.match(/^\/gdeltv2\/(\d{14})\.export\.CSV\.zip$/);
+  if (!match || url.search || url.hash) throw new Error(`invalid GDELT event export path: ${urlRaw}`);
+
+  return {
+    size,
+    md5,
+    url: `${GDELT_STORAGE_ORIGIN}${url.pathname}`,
+    exportTimestamp: match[1],
+  };
+}
+
+export function parseGdeltRecentExports(manifest, limit = RECENT_EXPORT_COUNT) {
+  const descriptors = [];
+  for (const line of String(manifest || '').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!/\.export\.CSV\.zip$/i.test(trimmed)) continue;
+    try {
+      descriptors.push(parseExportDescriptorLine(trimmed));
+    } catch (error) {
+      // A suffix range can begin mid-line. Ignore that incomplete fragment,
+      // but fail closed for any full-looking descriptor that violates the
+      // checksum/size/URL allowlist.
+      if (!/^\d+\s+[a-f0-9]{32}\s+/i.test(trimmed)) continue;
+      throw error;
+    }
+  }
+  if (!descriptors.length) throw new Error('GDELT master manifest tail has no valid event exports');
+  return descriptors
+    .sort((a, b) => a.exportTimestamp.localeCompare(b.exportTimestamp))
+    .slice(-Math.max(1, limit));
+}
+
+export function extractGdeltExportCsv(zipBytes) {
+  const zip = Buffer.isBuffer(zipBytes) ? zipBytes : Buffer.from(zipBytes || []);
+  if (zip.length < 30 || zip.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error('invalid GDELT event export ZIP header');
+  }
+  const flags = zip.readUInt16LE(6);
+  if (flags & 0x1) throw new Error('encrypted GDELT event export ZIP is unsupported');
+  if (flags & 0x8) throw new Error('streaming GDELT event export ZIP is unsupported');
+
+  const method = zip.readUInt16LE(8);
+  const compressedSize = boundedPositiveInteger(
+    zip.readUInt32LE(18),
+    'ZIP compressed size',
+    GDELT_MAX_EXPORT_ZIP_BYTES,
+  );
+  const uncompressedSize = boundedPositiveInteger(
+    zip.readUInt32LE(22),
+    'ZIP uncompressed size',
+    GDELT_MAX_EXPORT_CSV_BYTES,
+  );
+  const filenameLength = zip.readUInt16LE(26);
+  const extraLength = zip.readUInt16LE(28);
+  const dataStart = 30 + filenameLength + extraLength;
+  const dataEnd = dataStart + compressedSize;
+  if (dataStart > zip.length || dataEnd > zip.length) throw new Error('truncated GDELT event export ZIP');
+
+  const filename = zip.subarray(30, 30 + filenameLength).toString('utf8');
+  if (!/^\d{14}\.export\.CSV$/.test(filename)) {
+    throw new Error(`unexpected GDELT event export filename: ${filename}`);
+  }
+
+  const compressed = zip.subarray(dataStart, dataEnd);
+  const csv = method === 8
+    ? inflateRawSync(compressed, { maxOutputLength: GDELT_MAX_EXPORT_CSV_BYTES })
+    : (method === 0 ? Buffer.from(compressed) : null);
+  if (!csv) throw new Error(`unsupported GDELT event export ZIP compression method: ${method}`);
+  if (csv.length !== uncompressedSize) {
+    throw new Error(`GDELT event export size mismatch: expected ${uncompressedSize}, got ${csv.length}`);
+  }
+  return csv.toString('utf8');
+}
+
+function sourceDomain(sourceUrl) {
+  try {
+    return new URL(sourceUrl).hostname;
+  } catch {
+    return '';
+  }
+}
+
+export function mapGdeltExportToConflictEvents(csv) {
+  const events = [];
+  const seen = new Set();
+  for (const line of String(csv || '').split(/\r?\n/)) {
+    if (!line) continue;
+    const fields = line.split('\t');
+    if (fields.length < 61 || fields[25] !== '1' || fields[29] !== '4') continue;
+    if (!MATERIAL_VIOLENCE_ROOT_CODES.has(fields[28])) continue;
+
+    const iso2 = GDELT_FIPS_TO_ISO2[fields[53]];
+    const country = GDELT_COUNTRY_NAMES[iso2];
+    const id = fields[0];
+    const eventDate = gdeltSeenDateToIso(fields[59]);
+    if (!id || seen.has(id) || !country || !eventDate) continue;
+    seen.add(id);
+
+    const url = fields[60] || '';
+    events.push({
+      id: `gdelt-event-${id}`,
+      eventType: `GDELT ${fields[26] || fields[28] || 'material conflict'}`,
+      country,
+      event_date: eventDate,
+      occurredAt: Date.parse(eventDate) || 0,
+      source: sourceDomain(url),
+      url,
+    });
+  }
+  return events;
+}
+
+async function fetchBoundedBuffer(fetchImpl, url, maxBytes, extraHeaders = {}) {
+  const response = await fetchImpl(url, {
+    headers: { Accept: '*/*', 'User-Agent': USER_AGENT, ...extraHeaders },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`GDELT bulk HTTP ${response.status} for ${url}`);
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new Error(`GDELT bulk response exceeds ${maxBytes} bytes`);
+  }
+  if (!response.body) throw new Error(`GDELT bulk response has no body for ${url}`);
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of response.body) {
+    total += chunk.byteLength;
+    if (total > maxBytes) {
+      throw new Error(`GDELT bulk response exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks, total);
+}
+
+export async function fetchGdeltBulkConflictEvents({ fetchImpl = globalThis.fetch } = {}) {
+  const manifestBytes = await fetchBoundedBuffer(
+    fetchImpl,
+    GDELT_MASTER_FILELIST_URL,
+    MASTER_TAIL_BYTES,
+    { Range: `bytes=-${MASTER_TAIL_BYTES}` },
+  );
+  const descriptors = parseGdeltRecentExports(manifestBytes.toString('utf8'));
+  const results = await allSettledWithConcurrency(
+    descriptors,
+    EXPORT_FETCH_CONCURRENCY,
+    async (descriptor) => {
+      const zipBytes = await fetchBoundedBuffer(fetchImpl, descriptor.url, GDELT_MAX_EXPORT_ZIP_BYTES);
+      if (zipBytes.length !== descriptor.size) {
+        throw new Error(`download size mismatch: expected ${descriptor.size}, got ${zipBytes.length}`);
+      }
+      const actualMd5 = createHash('md5').update(zipBytes).digest('hex');
+      if (actualMd5 !== descriptor.md5) throw new Error('checksum mismatch');
+      return {
+        events: mapGdeltExportToConflictEvents(extractGdeltExportCsv(zipBytes)),
+        exportTimestamp: descriptor.exportTimestamp,
+      };
+    },
+  );
+
+  const successful = results.filter(result => result.status === 'fulfilled');
+  if (!successful.length) {
+    const sample = results.slice(0, 3).map(result => result.reason?.message || result.reason).join(', ');
+    throw new Error(`all recent GDELT event exports failed${sample ? `: ${sample}` : ''}`);
+  }
+  const events = [];
+  const seen = new Set();
+  for (const result of successful) {
+    for (const event of result.value.events) {
+      if (seen.has(event.id)) continue;
+      seen.add(event.id);
+      events.push(event);
+    }
+  }
+  return {
+    events,
+    exportTimestamp: successful
+      .map(result => result.value.exportTimestamp)
+      .sort()
+      .at(-1),
+    exportsRequested: descriptors.length,
+    exportsSucceeded: successful.length,
+  };
+}

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1175,9 +1175,11 @@ export async function fetchYahooFxRates(fxSymbols, fallbacks) {
 /**
  * Read the current canonical snapshot from Redis before a seed run overwrites it.
  * Used by seed scripts that compute WoW deltas (bigmac, grocery-basket).
- * Returns null on any error — scripts must handle first-run (no prev data).
+ * Returns null on any error by default — scripts must handle first-run (no prev
+ * data). Pass strict:true when overwriting without the prior snapshot would lose
+ * accumulated state; missing keys still return null, while read failures throw.
  */
-export async function readSeedSnapshot(canonicalKey) {
+export async function readSeedSnapshot(canonicalKey, { strict = false } = {}) {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
@@ -1186,14 +1188,18 @@ export async function readSeedSnapshot(canonicalKey) {
       headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(5_000),
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      if (strict) throw new Error(`Redis snapshot read failed: HTTP ${resp.status}`);
+      return null;
+    }
     const { result } = await resp.json();
     if (!result) return null;
     // Envelope-aware: WoW/prev baselines (bigmac, grocery-basket, fear-greed)
     // must see bare legacy-shape data whether the last write was pre- or post-
     // contract-migration. unwrapEnvelope is a no-op on legacy values.
     return unwrapEnvelope(JSON.parse(result)).data;
-  } catch {
+  } catch (error) {
+    if (strict) throw error;
     return null;
   }
 }

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -19,6 +19,7 @@
 import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, loadSharedConfig } from './_seed-utils.mjs';
 import { fetchGdeltJson } from './_gdelt-fetch.mjs';
 import { buildGdeltConflictUrl, mapGdeltArticlesToEvents, GDELT_COUNTRY_NAMES } from './_conflict-gdelt.mjs';
+import { fetchGdeltBulkConflictEvents } from './_conflict-gdelt-bulk.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -48,10 +49,11 @@ export const GDELT_MIN_SUCCESSFUL_COUNTRIES = Math.ceil(CONFLICT_COUNTRIES.lengt
 // in-flight batch may still drain past the cutoff: ≤~100s at the knobs below
 // (15s concurrent direct legs + 4 × 20s SERIALIZED sync proxy curls — curlFetch is
 // execFileSync, so "concurrent" proxy attempts block the event loop one at a time;
-// 92s observed live 2026-07-10). Worst single fetchAll attempt ≈
-// max(HAPI 306s, 120s + 100s) + extra-key writes ≈ ~350s, inside both the 360s
-// lock below and the 480s fetch deadline (lockTtl + margin). Without this cap a
+// 92s observed live 2026-07-10). Worst single fetchAll attempt before the bulk
+// fallback ≈ max(HAPI 306s, 120s + 100s). Without this cap a
 // GDELT brownout ran 5 batches ≈ 375s+ → deadline breach → exit 75 every tick.
+// The bulk fallback runs after those parallel feeds settle, so its 60s bound
+// and 30s publish slack are additive: max(306s, 220s) + 60s + 30s = 396s.
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
 // maxRetries: 0 — a second direct attempt would honor GDELT's Retry-After header
 // (≤60s sleep, _gdelt-fetch.mjs MAX_RETRY_AFTER_MS), blowing any per-batch bound;
@@ -61,10 +63,10 @@ export const GDELT_SWEEP_BUDGET_MS = 120_000;
 export const GDELT_COUNTRY_FETCH_OPTS = Object.freeze({ maxRetries: 0, proxyMaxAttempts: 1 });
 // Lock must outlive the worst legitimate run (runSeed's documented invariant —
 // _seed-utils.mjs: "a healthy seeder is designed never to outlive its own lock");
-// it also sets the fetch deadline (lockTtlMs + 120s margin = 480s). The default
+// it also sets the fetch deadline (lockTtlMs + 120s margin = 540s). The default
 // 120s lock was ALREADY shorter than this seeder's worst case. Cron cadence is
-// 30min, so a hard-crashed run's dangling lock costs at most 6 of those minutes.
-export const ACLED_INTEL_LOCK_TTL_MS = 360_000;
+// 30min, so a hard-crashed run's dangling lock costs at most 7 of those minutes.
+export const ACLED_INTEL_LOCK_TTL_MS = 420_000;
 
 const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
 
@@ -209,14 +211,11 @@ async function fetchAcledEvents({
 
 // ─── GDELT conflict-events fallback (used when ACLED has no credentials) ───
 // ACLED requires a registered account. When its credentials are absent, keep a
-// near-real-time conflict signal by proxying GDELT DOC 2.0 coverage volume: per
-// priority country, count recent conflict-tagged articles and emit them as synthetic
-// events in the SAME {country, event_date} shape the EMA engine reads
-// (_ema-threat-engine.mjs). Article volume is a coarser proxy than ACLED event counts,
-// but it is keyless, near-real-time, and directionally valid for the per-country
-// escalation EMA. URL/query + article→event mapping live in the import-safe,
-// unit-tested _conflict-gdelt.mjs; this fn owns the throttle-aware fetch via
-// fetchGdeltJson's proxy path (GDELT is per-IP 429-throttled).
+// near-real-time conflict signal from GDELT. The DOC 2.0 path counts recent
+// conflict-tagged articles per priority country and emits synthetic events in the
+// SAME {country, event_date} shape the EMA engine reads (_ema-threat-engine.mjs).
+// When DOC coverage is throttled or yields no events, the official 15-minute bulk
+// event export supplies material-conflict records instead.
 export async function fetchGdeltCountryEvents(cc) {
   if (!GDELT_COUNTRY_NAMES[cc]) {
     return { country: cc, ok: false, events: [], error: 'unknown country code' };
@@ -234,6 +233,7 @@ export async function fetchGdeltCountryEvents(cc) {
 
 export async function fetchGdeltConflictEvents({
   fetchCountryEvents = fetchGdeltCountryEvents,
+  fetchBulkEvents = fetchGdeltBulkConflictEvents,
   pace = sleep,
   now = Date.now,
   deadlineAt,
@@ -269,12 +269,34 @@ export async function fetchGdeltConflictEvents({
     }
     if (i + CONCURRENCY < CONFLICT_COUNTRIES.length) await pace(500); // inter-batch only; no trailing wait
   }
-  if (successfulCountries < GDELT_MIN_SUCCESSFUL_COUNTRIES) {
+  if (successfulCountries < GDELT_MIN_SUCCESSFUL_COUNTRIES || events.length === 0) {
     const sample = failedCountries.slice(0, 6).map(({ country, error }) => `${country}:${error}`).join(', ');
-    throw new Error(
-      `GDELT conflict-events coverage below floor: ${successfulCountries}/${CONFLICT_COUNTRIES.length} countries succeeded ` +
-      `(min ${GDELT_MIN_SUCCESSFUL_COUNTRIES})${sample ? `; failures: ${sample}` : ''}`,
-    );
+    const docFailure = successfulCountries < GDELT_MIN_SUCCESSFUL_COUNTRIES
+      ? `GDELT conflict-events coverage below floor: ${successfulCountries}/${CONFLICT_COUNTRIES.length} countries succeeded ` +
+        `(min ${GDELT_MIN_SUCCESSFUL_COUNTRIES})${sample ? `; failures: ${sample}` : ''}`
+      : `GDELT conflict-events returned zero events across ${successfulCountries}/${CONFLICT_COUNTRIES.length} successful countries`;
+    console.warn(`  ${docFailure}; trying official bulk event export`);
+    try {
+      const bulk = await fetchBulkEvents();
+      if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
+      console.log(`  GDELT bulk conflict-events fallback: ${bulk.events.length} events from export ${bulk.exportTimestamp}`);
+      return {
+        events: bulk.events,
+        pagination: {
+          countriesTotal: CONFLICT_COUNTRIES.length,
+          countriesSucceeded: CONFLICT_COUNTRIES.length,
+          countriesFailed: 0,
+          minSuccessfulCountries: GDELT_MIN_SUCCESSFUL_COUNTRIES,
+          exportTimestamp: bulk.exportTimestamp,
+          exportsRequested: bulk.exportsRequested,
+          exportsSucceeded: bulk.exportsSucceeded,
+          countriesWithEvents: new Set(bulk.events.map(event => event.country)).size,
+        },
+        source: 'gdelt-bulk',
+      };
+    } catch (bulkError) {
+      throw new Error(`${docFailure}; bulk fallback failed: ${bulkError?.message || bulkError}`);
+    }
   }
   console.log(`  GDELT conflict-events (ACLED fallback): ${events.length} events across ${successfulCountries}/${CONFLICT_COUNTRIES.length} successful country fetches`);
   return {

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -16,10 +16,10 @@
  * - searchGdeltDocuments: per-query GDELT search
  */
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, loadSharedConfig } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, loadSharedConfig, readSeedSnapshot } from './_seed-utils.mjs';
 import { fetchGdeltJson } from './_gdelt-fetch.mjs';
 import { buildGdeltConflictUrl, mapGdeltArticlesToEvents, GDELT_COUNTRY_NAMES } from './_conflict-gdelt.mjs';
-import { fetchGdeltBulkConflictEvents } from './_conflict-gdelt-bulk.mjs';
+import { fetchGdeltBulkConflictEvents, GDELT_ROLLING_WINDOW_MS, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -237,6 +237,7 @@ export async function fetchGdeltConflictEvents({
   pace = sleep,
   now = Date.now,
   deadlineAt,
+  loadPreviousSnapshot = () => readSeedSnapshot(ACLED_CACHE_KEY, { strict: true }),
 } = {}) {
   const events = [];
   const failedCountries = [];
@@ -279,9 +280,15 @@ export async function fetchGdeltConflictEvents({
     try {
       const bulk = await fetchBulkEvents();
       if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
-      console.log(`  GDELT bulk conflict-events fallback: ${bulk.events.length} events from export ${bulk.exportTimestamp}`);
+      const previousSnapshot = await loadPreviousSnapshot();
+      const rolling = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now());
+      if (!rolling.events.length) throw new Error('rolling bulk window contained no priority-country material-conflict events');
+      console.log(
+        `  GDELT bulk conflict-events fallback: ${rolling.events.length} events through export ${bulk.exportTimestamp}`
+        + ` (${rolling.retainedPreviousEvents} retained from prior runs)`,
+      );
       return {
-        events: bulk.events,
+        events: rolling.events,
         pagination: {
           countriesTotal: CONFLICT_COUNTRIES.length,
           countriesSucceeded: successfulCountries,
@@ -290,7 +297,11 @@ export async function fetchGdeltConflictEvents({
           exportTimestamp: bulk.exportTimestamp,
           exportsRequested: bulk.exportsRequested,
           exportsSucceeded: bulk.exportsSucceeded,
-          countriesWithEvents: new Set(bulk.events.map(event => event.country)).size,
+          countriesWithEvents: new Set(rolling.events.map(event => event.country)).size,
+          rollingWindowHours: GDELT_ROLLING_WINDOW_MS / (60 * 60 * 1000),
+          rollingWindowStartedAt: rolling.rollingWindowStartedAt,
+          rollingWindowComplete: rolling.rollingWindowComplete,
+          retainedPreviousEvents: rolling.retainedPreviousEvents,
         },
         source: 'gdelt-bulk',
       };

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -284,8 +284,8 @@ export async function fetchGdeltConflictEvents({
         events: bulk.events,
         pagination: {
           countriesTotal: CONFLICT_COUNTRIES.length,
-          countriesSucceeded: CONFLICT_COUNTRIES.length,
-          countriesFailed: 0,
+          countriesSucceeded: successfulCountries,
+          countriesFailed: failedCountries.length,
           minSuccessfulCountries: GDELT_MIN_SUCCESSFUL_COUNTRIES,
           exportTimestamp: bulk.exportTimestamp,
           exportsRequested: bulk.exportsRequested,

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -280,7 +280,15 @@ export async function fetchGdeltConflictEvents({
     try {
       const bulk = await fetchBulkEvents();
       if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
-      const previousSnapshot = await loadPreviousSnapshot();
+      let previousSnapshot = null;
+      try {
+        previousSnapshot = await loadPreviousSnapshot();
+      } catch (snapshotError) {
+        console.warn(
+          '  GDELT bulk previous snapshot unavailable; publishing current exports only:'
+          + ` ${snapshotError?.message || snapshotError}`,
+        );
+      }
       const rolling = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now());
       if (!rolling.events.length) throw new Error('rolling bulk window contained no priority-country material-conflict events');
       console.log(

--- a/tests/conflict-gdelt-bulk.test.mjs
+++ b/tests/conflict-gdelt-bulk.test.mjs
@@ -6,6 +6,7 @@ import {
   extractGdeltExportCsv,
   fetchGdeltBulkConflictEvents,
   GDELT_ROLLING_WINDOW_MS,
+  GDELT_ROLLING_WINDOW_MAX_EVENTS,
   mapGdeltExportToConflictEvents,
   mergeGdeltBulkRollingWindow,
   parseGdeltRecentExports,
@@ -206,6 +207,26 @@ test('mergeGdeltBulkRollingWindow reaches a bounded complete window and never mi
     pagination: undefined,
   }, now);
   assert.deepEqual(sourceIsolated.events.map(item => item.id), ['current-bulk']);
+});
+
+test('mergeGdeltBulkRollingWindow caps the newest events to protect the publish budget', () => {
+  const now = Date.parse('2026-07-14T18:00:00Z');
+  const events = Array.from({ length: GDELT_ROLLING_WINDOW_MAX_EVENTS + 2 }, (_, index) => ({
+    id: `event-${index}`,
+    country: 'Sudan',
+    event_date: '2026-07-14',
+    gdeltAddedAt: now - index,
+  }));
+
+  const result = mergeGdeltBulkRollingWindow({
+    events,
+    oldestExportTimestamp: '20260714160000',
+    exportTimestamp: '20260714170000',
+  }, null, now);
+
+  assert.equal(result.events.length, GDELT_ROLLING_WINDOW_MAX_EVENTS);
+  assert.equal(result.events[0].id, 'event-0');
+  assert.equal(result.events.at(-1).id, `event-${GDELT_ROLLING_WINDOW_MAX_EVENTS - 1}`);
 });
 
 test('extractGdeltExportCsv reads the bounded single-file ZIP payload', () => {

--- a/tests/conflict-gdelt-bulk.test.mjs
+++ b/tests/conflict-gdelt-bulk.test.mjs
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto';
+import { deflateRawSync } from 'node:zlib';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractGdeltExportCsv,
+  fetchGdeltBulkConflictEvents,
+  mapGdeltExportToConflictEvents,
+  parseGdeltRecentExports,
+} from '../scripts/_conflict-gdelt-bulk.mjs';
+
+function gdeltRow({
+  id = '1',
+  isRoot = '1',
+  eventCode = '190',
+  eventRootCode = '19',
+  quadClass = '4',
+  countryCode = 'SU',
+  dateAdded = '20260713110000',
+  url = 'https://example.com/conflict',
+} = {}) {
+  const fields = Array(61).fill('');
+  fields[0] = id;
+  fields[25] = isRoot;
+  fields[26] = eventCode;
+  fields[28] = eventRootCode;
+  fields[29] = quadClass;
+  fields[53] = countryCode;
+  fields[59] = dateAdded;
+  fields[60] = url;
+  return fields.join('\t');
+}
+
+function makeStoredZip(filename, text) {
+  const name = Buffer.from(filename);
+  const body = Buffer.from(text);
+  const zip = Buffer.alloc(30 + name.length + body.length);
+  zip.writeUInt32LE(0x04034b50, 0);
+  zip.writeUInt16LE(20, 4);
+  zip.writeUInt16LE(0, 6);
+  zip.writeUInt16LE(0, 8);
+  zip.writeUInt32LE(body.length, 18);
+  zip.writeUInt32LE(body.length, 22);
+  zip.writeUInt16LE(name.length, 26);
+  zip.writeUInt16LE(0, 28);
+  name.copy(zip, 30);
+  body.copy(zip, 30 + name.length);
+  return zip;
+}
+
+function makeDeflatedZip(filename, text) {
+  const name = Buffer.from(filename);
+  const plain = Buffer.from(text);
+  const body = deflateRawSync(plain);
+  const zip = Buffer.alloc(30 + name.length + body.length);
+  zip.writeUInt32LE(0x04034b50, 0);
+  zip.writeUInt16LE(20, 4);
+  zip.writeUInt16LE(0, 6);
+  zip.writeUInt16LE(8, 8);
+  zip.writeUInt32LE(body.length, 18);
+  zip.writeUInt32LE(plain.length, 22);
+  zip.writeUInt16LE(name.length, 26);
+  zip.writeUInt16LE(0, 28);
+  name.copy(zip, 30);
+  body.copy(zip, 30 + name.length);
+  return zip;
+}
+
+test('parseGdeltRecentExports validates descriptors and rewrites downloads to the TLS storage origin', () => {
+  const [descriptor] = parseGdeltRecentExports(
+    '123 0123456789abcdef0123456789abcdef http://data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip\n' +
+    '456 fedcba9876543210fedcba9876543210 http://data.gdeltproject.org/gdeltv2/20260713110000.gkg.csv.zip\n', 1,
+  );
+  assert.deepEqual(descriptor, {
+    size: 123,
+    md5: '0123456789abcdef0123456789abcdef',
+    url: 'https://storage.googleapis.com/data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip',
+    exportTimestamp: '20260713110000',
+  });
+});
+
+test('parseGdeltRecentExports rejects untrusted export URLs', () => {
+  assert.throws(
+    () => parseGdeltRecentExports(
+      '123 0123456789abcdef0123456789abcdef http://evil.example/gdeltv2/20260713110000.export.CSV.zip',
+    ),
+    /untrusted GDELT event export URL/,
+  );
+});
+
+test('parseGdeltRecentExports keeps the newest bounded set from a range tail', () => {
+  const timestamps = [
+    '20260713090000', '20260713091500', '20260713093000', '20260713094500',
+    '20260713100000', '20260713101500', '20260713103000', '20260713104500',
+    '20260713110000', '20260713111500',
+  ];
+  const lines = timestamps.map((timestamp) => {
+    return `123 0123456789abcdef0123456789abcdef http://data.gdeltproject.org/gdeltv2/${timestamp}.export.CSV.zip`;
+  });
+  const descriptors = parseGdeltRecentExports(`truncated-prefix\n${lines.join('\n')}`, 3);
+  assert.deepEqual(
+    descriptors.map(descriptor => descriptor.exportTimestamp),
+    ['20260713104500', '20260713110000', '20260713111500'],
+  );
+});
+
+test('mapGdeltExportToConflictEvents maps strong material conflict and filters noise', () => {
+  const csv = [
+    gdeltRow({ id: '1', countryCode: 'SU' }),
+    gdeltRow({ id: '2', countryCode: 'UP', eventRootCode: '18', eventCode: '183' }),
+    gdeltRow({ id: '3', countryCode: 'NI', eventRootCode: '17', eventCode: '173' }),
+    gdeltRow({ id: '4', countryCode: 'US' }),
+    gdeltRow({ id: '5', countryCode: 'ML', isRoot: '0' }),
+    gdeltRow({ id: '1', countryCode: 'SU' }),
+  ].join('\n');
+
+  const events = mapGdeltExportToConflictEvents(csv);
+  assert.equal(events.length, 2);
+  assert.deepEqual(events.map(event => event.country), ['Sudan', 'Ukraine']);
+  assert.equal(events[0].event_date, '2026-07-13');
+  assert.equal(events[0].source, 'example.com');
+  assert.equal(events[0].id, 'gdelt-event-1');
+});
+
+test('extractGdeltExportCsv reads the bounded single-file ZIP payload', () => {
+  const csv = gdeltRow();
+  const zip = makeStoredZip('20260713110000.export.CSV', csv);
+  assert.equal(extractGdeltExportCsv(zip), csv);
+});
+
+test('extractGdeltExportCsv inflates the compression method used by live exports', () => {
+  const csv = gdeltRow();
+  const zip = makeDeflatedZip('20260713110000.export.CSV', csv);
+  assert.equal(extractGdeltExportCsv(zip), csv);
+});
+
+test('fetchGdeltBulkConflictEvents verifies the manifest and returns mapped events', async () => {
+  const csv = gdeltRow();
+  const zip = makeStoredZip('20260713110000.export.CSV', csv);
+  const md5 = createHash('md5').update(zip).digest('hex');
+  const manifest = `${zip.length} ${md5} http://data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip\n`;
+  const requests = [];
+  const responses = [
+    new Response(manifest, { headers: { 'content-length': String(Buffer.byteLength(manifest)) } }),
+    new Response(zip, { headers: { 'content-length': String(zip.length) } }),
+  ];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    return responses.shift();
+  };
+
+  const result = await fetchGdeltBulkConflictEvents({ fetchImpl });
+  assert.equal(result.exportTimestamp, '20260713110000');
+  assert.equal(result.events.length, 1);
+  assert.equal(result.events[0].country, 'Sudan');
+  assert.equal(result.exportsRequested, 1);
+  assert.equal(result.exportsSucceeded, 1);
+  assert.equal(requests.length, 2);
+  assert.ok(requests.every(request => request.options.headers['User-Agent']));
+  assert.equal(requests[0].options.headers.Range, 'bytes=-16384');
+});
+
+test('fetchGdeltBulkConflictEvents fails closed on checksum mismatch', async () => {
+  const csv = gdeltRow();
+  const zip = makeStoredZip('20260713110000.export.CSV', csv);
+  const manifest = `${zip.length} 00000000000000000000000000000000 http://data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip\n`;
+  const responses = [new Response(manifest), new Response(zip)];
+
+  await assert.rejects(
+    fetchGdeltBulkConflictEvents({ fetchImpl: async () => responses.shift() }),
+    /all recent GDELT event exports failed: checksum mismatch/,
+  );
+});
+
+test('fetchGdeltBulkConflictEvents reports the newest successful export when a later export fails', async () => {
+  const csv = gdeltRow();
+  const zip = makeStoredZip('20260713110000.export.CSV', csv);
+  const md5 = createHash('md5').update(zip).digest('hex');
+  const manifest = [
+    `${zip.length} ${md5} http://data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip`,
+    `${zip.length} 00000000000000000000000000000000 http://data.gdeltproject.org/gdeltv2/20260713111500.export.CSV.zip`,
+  ].join('\n');
+  const fetchImpl = async (url) => String(url).endsWith('masterfilelist.txt')
+    ? new Response(manifest)
+    : new Response(zip);
+
+  const result = await fetchGdeltBulkConflictEvents({ fetchImpl });
+  assert.equal(result.exportTimestamp, '20260713110000');
+  assert.equal(result.exportsRequested, 2);
+  assert.equal(result.exportsSucceeded, 1);
+  assert.equal(result.events.length, 1);
+});
+
+test('fetchGdeltBulkConflictEvents bounds streamed responses without content-length', async () => {
+  const oversizedManifest = 'x'.repeat(16_385);
+  await assert.rejects(
+    fetchGdeltBulkConflictEvents({ fetchImpl: async () => new Response(oversizedManifest) }),
+    /GDELT bulk response exceeds 16384 bytes/,
+  );
+});

--- a/tests/conflict-gdelt-bulk.test.mjs
+++ b/tests/conflict-gdelt-bulk.test.mjs
@@ -5,7 +5,9 @@ import assert from 'node:assert/strict';
 import {
   extractGdeltExportCsv,
   fetchGdeltBulkConflictEvents,
+  GDELT_ROLLING_WINDOW_MS,
   mapGdeltExportToConflictEvents,
+  mergeGdeltBulkRollingWindow,
   parseGdeltRecentExports,
 } from '../scripts/_conflict-gdelt-bulk.mjs';
 
@@ -118,8 +120,92 @@ test('mapGdeltExportToConflictEvents maps strong material conflict and filters n
   assert.equal(events.length, 2);
   assert.deepEqual(events.map(event => event.country), ['Sudan', 'Ukraine']);
   assert.equal(events[0].event_date, '2026-07-13');
+  assert.equal(events[0].gdeltAddedAt, Date.parse('2026-07-13T11:00:00Z'));
+  assert.equal(events[0].occurredAt, Date.parse('2026-07-13T11:00:00Z'));
   assert.equal(events[0].source, 'example.com');
   assert.equal(events[0].id, 'gdelt-event-1');
+});
+
+test('mergeGdeltBulkRollingWindow retains the prior 24h, prunes stale events, and prefers current duplicates', () => {
+  const now = Date.parse('2026-07-13T18:00:00Z');
+  const event = (id, hoursAgo, url = `https://example.com/${id}`) => {
+    const gdeltAddedAt = now - hoursAgo * 60 * 60 * 1000;
+    return {
+      id,
+      country: 'Sudan',
+      event_date: new Date(gdeltAddedAt).toISOString().slice(0, 10),
+      occurredAt: gdeltAddedAt,
+      gdeltAddedAt,
+      url,
+    };
+  };
+  const previousSnapshot = {
+    source: 'gdelt-bulk',
+    events: [
+      event('prior-12h', 12),
+      event('stale-25h', 25),
+      event('duplicate', 1.5, 'https://example.com/old'),
+    ],
+    pagination: {
+      exportTimestamp: '20260713163000',
+      rollingWindowStartedAt: now - 14 * 60 * 60 * 1000,
+    },
+  };
+  const bulk = {
+    events: [event('current-1h', 1), event('duplicate', 1, 'https://example.com/new')],
+    oldestExportTimestamp: '20260713160000',
+    exportTimestamp: '20260713170000',
+  };
+
+  const result = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now);
+
+  assert.deepEqual(result.events.map(item => item.id), ['duplicate', 'current-1h', 'prior-12h']);
+  assert.equal(result.events.find(item => item.id === 'duplicate').url, 'https://example.com/new');
+  assert.equal(result.events.some(item => item.id === 'stale-25h'), false);
+  assert.equal(result.rollingWindowStartedAt, now - 14 * 60 * 60 * 1000);
+  assert.equal(result.rollingWindowComplete, false);
+  assert.equal(result.retainedPreviousEvents, 1);
+});
+
+test('mergeGdeltBulkRollingWindow reaches a bounded complete window and never mixes prior ACLED data', () => {
+  const now = Date.parse('2026-07-14T18:00:00Z');
+  const cutoff = now - GDELT_ROLLING_WINDOW_MS;
+  const previousEvent = {
+    id: 'prior-bulk',
+    country: 'Sudan',
+    event_date: '2026-07-14',
+    gdeltAddedAt: now - 12 * 60 * 60 * 1000,
+  };
+  const currentEvent = {
+    id: 'current-bulk',
+    country: 'Sudan',
+    event_date: '2026-07-14',
+    gdeltAddedAt: now - 60 * 60 * 1000,
+  };
+  const bulk = {
+    events: [currentEvent],
+    oldestExportTimestamp: '20260714160000',
+    exportTimestamp: '20260714170000',
+  };
+
+  const complete = mergeGdeltBulkRollingWindow(bulk, {
+    source: 'gdelt-bulk',
+    events: [previousEvent],
+    pagination: {
+      exportTimestamp: '20260714153000',
+      rollingWindowStartedAt: cutoff - 60 * 60 * 1000,
+    },
+  }, now);
+  assert.equal(complete.rollingWindowStartedAt, cutoff);
+  assert.equal(complete.rollingWindowComplete, true);
+  assert.deepEqual(complete.events.map(item => item.id), ['current-bulk', 'prior-bulk']);
+
+  const sourceIsolated = mergeGdeltBulkRollingWindow(bulk, {
+    source: 'acled',
+    events: [{ id: 'acled-event', country: 'Sudan', event_date: '2026-07-14' }],
+    pagination: undefined,
+  }, now);
+  assert.deepEqual(sourceIsolated.events.map(item => item.id), ['current-bulk']);
 });
 
 test('extractGdeltExportCsv reads the bounded single-file ZIP payload', () => {

--- a/tests/conflict-gdelt-bulk.test.mjs
+++ b/tests/conflict-gdelt-bulk.test.mjs
@@ -141,7 +141,7 @@ test('fetchGdeltBulkConflictEvents verifies the manifest and returns mapped even
   const manifest = `${zip.length} ${md5} http://data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip\n`;
   const requests = [];
   const responses = [
-    new Response(manifest, { headers: { 'content-length': String(Buffer.byteLength(manifest)) } }),
+    new Response(manifest, { status: 206, headers: { 'content-length': String(Buffer.byteLength(manifest)) } }),
     new Response(zip, { headers: { 'content-length': String(zip.length) } }),
   ];
   const fetchImpl = async (url, options) => {
@@ -164,7 +164,7 @@ test('fetchGdeltBulkConflictEvents fails closed on checksum mismatch', async () 
   const csv = gdeltRow();
   const zip = makeStoredZip('20260713110000.export.CSV', csv);
   const manifest = `${zip.length} 00000000000000000000000000000000 http://data.gdeltproject.org/gdeltv2/20260713110000.export.CSV.zip\n`;
-  const responses = [new Response(manifest), new Response(zip)];
+  const responses = [new Response(manifest, { status: 206 }), new Response(zip)];
 
   await assert.rejects(
     fetchGdeltBulkConflictEvents({ fetchImpl: async () => responses.shift() }),
@@ -181,7 +181,7 @@ test('fetchGdeltBulkConflictEvents reports the newest successful export when a l
     `${zip.length} 00000000000000000000000000000000 http://data.gdeltproject.org/gdeltv2/20260713111500.export.CSV.zip`,
   ].join('\n');
   const fetchImpl = async (url) => String(url).endsWith('masterfilelist.txt')
-    ? new Response(manifest)
+    ? new Response(manifest, { status: 206 })
     : new Response(zip);
 
   const result = await fetchGdeltBulkConflictEvents({ fetchImpl });
@@ -194,7 +194,14 @@ test('fetchGdeltBulkConflictEvents reports the newest successful export when a l
 test('fetchGdeltBulkConflictEvents bounds streamed responses without content-length', async () => {
   const oversizedManifest = 'x'.repeat(16_385);
   await assert.rejects(
-    fetchGdeltBulkConflictEvents({ fetchImpl: async () => new Response(oversizedManifest) }),
+    fetchGdeltBulkConflictEvents({ fetchImpl: async () => new Response(oversizedManifest, { status: 206 }) }),
     /GDELT bulk response exceeds 16384 bytes/,
+  );
+});
+
+test('fetchGdeltBulkConflictEvents rejects a manifest response that ignores the suffix range', async () => {
+  await assert.rejects(
+    fetchGdeltBulkConflictEvents({ fetchImpl: async () => new Response('full manifest') }),
+    /expected HTTP 206, got 200/,
   );
 });

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -145,12 +145,38 @@ test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk
   assert.equal(result.events.length, 1);
   assert.equal(result.events[0].country, 'Sudan');
   assert.equal(result.pagination.countriesTotal, Object.keys(GDELT_COUNTRY_NAMES).length);
-  assert.equal(result.pagination.countriesSucceeded, Object.keys(GDELT_COUNTRY_NAMES).length);
-  assert.equal(result.pagination.countriesFailed, 0);
+  assert.equal(result.pagination.countriesSucceeded, 0);
+  assert.equal(result.pagination.countriesFailed, Object.keys(GDELT_COUNTRY_NAMES).length);
   assert.equal(result.pagination.exportTimestamp, '20260713110000');
   assert.equal(result.pagination.exportsRequested, 8);
   assert.equal(result.pagination.exportsSucceeded, 8);
   assert.equal(result.pagination.countriesWithEvents, 1);
+});
+
+test('fetchGdeltConflictEvents preserves partial DOC coverage telemetry after bulk recovery', async () => {
+  let calls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    fetchCountryEvents: async (cc) => {
+      calls += 1;
+      return calls <= GDELT_MIN_SUCCESSFUL_COUNTRIES
+        ? { country: cc, ok: true, events: [] }
+        : { country: cc, ok: false, events: [], error: 'HTTP 429' };
+    },
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'gdelt-event-partial-doc', country: 'Sudan' }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+  });
+
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.equal(result.pagination.countriesSucceeded, GDELT_MIN_SUCCESSFUL_COUNTRIES);
+  assert.equal(
+    result.pagination.countriesFailed,
+    Object.keys(GDELT_COUNTRY_NAMES).length - GDELT_MIN_SUCCESSFUL_COUNTRIES,
+  );
 });
 
 // #5140: the sweep's worst case (20 countries × direct+proxy retries ÷ 4

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -86,6 +86,7 @@ test('fetchGdeltConflictEvents fails closed when too many country fetches fail',
   await assert.rejects(
     fetchGdeltConflictEvents({
       pace: async () => {},
+      fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
         if (calls < GDELT_MIN_SUCCESSFUL_COUNTRIES) {
@@ -98,15 +99,58 @@ test('fetchGdeltConflictEvents fails closed when too many country fetches fail',
   );
 });
 
-test('fetchGdeltConflictEvents treats successful zero-article countries as coverage', async () => {
+test('fetchGdeltConflictEvents falls through to bulk when the DOC sweep succeeds but yields zero events', async () => {
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
     fetchCountryEvents: async (cc) => ({ country: cc, ok: true, events: [] }),
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'gdelt-event-empty-doc', country: 'Sudan' }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
   });
 
-  assert.equal(result.events.length, 0);
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.equal(result.events.length, 1);
   assert.equal(result.pagination.countriesSucceeded, 20);
   assert.equal(result.pagination.countriesFailed, 0);
+});
+
+test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk event feed', async () => {
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    fetchCountryEvents: async (cc) => ({
+      country: cc,
+      ok: false,
+      events: [],
+      error: 'HTTP 429',
+    }),
+    fetchBulkEvents: async () => ({
+      events: [{
+        id: 'gdelt-event-1',
+        country: 'Sudan',
+        event_date: '2026-07-13',
+        occurredAt: Date.parse('2026-07-13'),
+        source: 'example.com',
+        url: 'https://example.com/conflict',
+      }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+  });
+
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.equal(result.events.length, 1);
+  assert.equal(result.events[0].country, 'Sudan');
+  assert.equal(result.pagination.countriesTotal, Object.keys(GDELT_COUNTRY_NAMES).length);
+  assert.equal(result.pagination.countriesSucceeded, Object.keys(GDELT_COUNTRY_NAMES).length);
+  assert.equal(result.pagination.countriesFailed, 0);
+  assert.equal(result.pagination.exportTimestamp, '20260713110000');
+  assert.equal(result.pagination.exportsRequested, 8);
+  assert.equal(result.pagination.exportsSucceeded, 8);
+  assert.equal(result.pagination.countriesWithEvents, 1);
 });
 
 // #5140: the sweep's worst case (20 countries × direct+proxy retries ÷ 4
@@ -123,6 +167,7 @@ test('fetchGdeltConflictEvents stops launching batches once the launch cutoff pa
       pace: async () => {},
       now: () => fakeTime,
       deadlineAt: 75_000,
+      fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
         // Each batch of 4 consumes 40s of fake wall clock — a degraded-GDELT batch.
@@ -146,6 +191,7 @@ test('fetchGdeltConflictEvents launches nothing when the phase cutoff already pa
     fetchGdeltConflictEvents({
       pace: async () => {},
       deadlineAt: Date.now() - 1,
+      fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
         return { country: cc, ok: true, events: [] };
@@ -161,6 +207,7 @@ test('fetchGdeltConflictEvents stops sweeping once the coverage floor is unreach
   await assert.rejects(
     fetchGdeltConflictEvents({
       pace: async () => {},
+      fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
         return { country: cc, ok: false, events: [], error: 'proxy unavailable' };
@@ -182,6 +229,7 @@ test('early-stop reason names BOTH conditions when budget and floor trip togethe
       pace: async () => {},
       now: () => fakeTime,
       deadlineAt: 115_000,
+      fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
         fakeTime += 10_000;

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -102,6 +102,7 @@ test('fetchGdeltConflictEvents fails closed when too many country fetches fail',
 test('fetchGdeltConflictEvents falls through to bulk when the DOC sweep succeeds but yields zero events', async () => {
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
+    loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async (cc) => ({ country: cc, ok: true, events: [] }),
     fetchBulkEvents: async () => ({
       events: [{ id: 'gdelt-event-empty-doc', country: 'Sudan' }],
@@ -120,6 +121,7 @@ test('fetchGdeltConflictEvents falls through to bulk when the DOC sweep succeeds
 test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk event feed', async () => {
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
+    loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async (cc) => ({
       country: cc,
       ok: false,
@@ -153,10 +155,53 @@ test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk
   assert.equal(result.pagination.countriesWithEvents, 1);
 });
 
+test('fetchGdeltConflictEvents carries prior bulk events through the EMA 24h window', async () => {
+  const now = Date.parse('2026-07-13T18:00:00Z');
+  const makeEvent = (id, hoursAgo) => {
+    const gdeltAddedAt = now - hoursAgo * 60 * 60 * 1000;
+    return {
+      id,
+      country: 'Sudan',
+      event_date: new Date(gdeltAddedAt).toISOString().slice(0, 10),
+      occurredAt: gdeltAddedAt,
+      gdeltAddedAt,
+      source: 'example.com',
+      url: `https://example.com/${id}`,
+    };
+  };
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => now,
+    fetchCountryEvents: async (cc) => ({ country: cc, ok: false, events: [], error: 'HTTP 429' }),
+    fetchBulkEvents: async () => ({
+      events: [makeEvent('current-1h', 1)],
+      oldestExportTimestamp: '20260713160000',
+      exportTimestamp: '20260713170000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+    loadPreviousSnapshot: async () => ({
+      source: 'gdelt-bulk',
+      events: [makeEvent('prior-12h', 12), makeEvent('stale-25h', 25)],
+      pagination: {
+        exportTimestamp: '20260713153000',
+        rollingWindowStartedAt: now - 14 * 60 * 60 * 1000,
+      },
+    }),
+  });
+
+  assert.deepEqual(result.events.map(event => event.id), ['current-1h', 'prior-12h']);
+  assert.equal(result.pagination.rollingWindowHours, 24);
+  assert.equal(result.pagination.retainedPreviousEvents, 1);
+  const windows = computeEmaWindows(new Map(), result.events, [], now);
+  assert.equal(windows.get('sudan').window.at(-1), 2);
+});
+
 test('fetchGdeltConflictEvents preserves partial DOC coverage telemetry after bulk recovery', async () => {
   let calls = 0;
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
+    loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async (cc) => {
       calls += 1;
       return calls <= GDELT_MIN_SUCCESSFUL_COUNTRIES

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -197,6 +197,36 @@ test('fetchGdeltConflictEvents carries prior bulk events through the EMA 24h win
   assert.equal(windows.get('sudan').window.at(-1), 2);
 });
 
+test('fetchGdeltConflictEvents publishes fresh bulk events when the previous snapshot read fails', async () => {
+  const now = Date.parse('2026-07-13T18:00:00Z');
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => now,
+    fetchCountryEvents: async (cc) => ({ country: cc, ok: false, events: [], error: 'HTTP 429' }),
+    fetchBulkEvents: async () => ({
+      events: [{
+        id: 'fresh-after-redis-blip',
+        country: 'Sudan',
+        event_date: '2026-07-13',
+        occurredAt: now - 60 * 60 * 1000,
+        gdeltAddedAt: now - 60 * 60 * 1000,
+      }],
+      oldestExportTimestamp: '20260713160000',
+      exportTimestamp: '20260713170000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+    loadPreviousSnapshot: async () => {
+      throw new Error('Redis snapshot read failed: HTTP 503');
+    },
+  });
+
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.deepEqual(result.events.map(event => event.id), ['fresh-after-redis-blip']);
+  assert.equal(result.pagination.retainedPreviousEvents, 0);
+  assert.equal(result.pagination.rollingWindowComplete, false);
+});
+
 test('fetchGdeltConflictEvents preserves partial DOC coverage telemetry after bulk recovery', async () => {
   let calls = 0;
   const result = await fetchGdeltConflictEvents({

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -66,6 +66,7 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
       GDELT_COUNTRY_FETCH_OPTS,
       ACLED_INTEL_LOCK_TTL_MS,
     } = await import('../scripts/seed-conflict-intel.mjs');
+    const { GDELT_BULK_WORST_NETWORK_MS } = await import('../scripts/_conflict-gdelt-bulk.mjs');
 
     // maxRetries MUST stay 0: a second direct attempt honors GDELT's Retry-After
     // header (≤60s sleep, MAX_RETRY_AFTER_MS in _gdelt-fetch.mjs), voiding any
@@ -90,6 +91,7 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
     const HAPI_WORST_MS = 20 * (15_000 + 300);
     const EXTRA_KEY_WRITE_SLACK_MS = 30_000;
     const worstFetchAttempt = Math.max(HAPI_WORST_MS, GDELT_SWEEP_BUDGET_MS + worstBatch)
+      + GDELT_BULK_WORST_NETWORK_MS
       + EXTRA_KEY_WRITE_SLACK_MS;
 
     // runSeed invariant: a healthy seeder never outlives its own lock…

--- a/tests/seed-utils-envelope-reads.test.mjs
+++ b/tests/seed-utils-envelope-reads.test.mjs
@@ -51,6 +51,14 @@ test('readSeedSnapshot: null Upstash result returns null', async () => {
   assert.equal(await readSeedSnapshot('missing:key:v1'), null);
 });
 
+test('readSeedSnapshot: strict mode distinguishes an upstream read failure from a missing key', async () => {
+  globalThis.fetch = async () => ({ ok: false, status: 503 });
+  await assert.rejects(
+    readSeedSnapshot('conflict:acled:v1:all:0:0', { strict: true }),
+    /Redis snapshot read failed: HTTP 503/,
+  );
+});
+
 test('verifySeedKey: envelope-wrapped value returns inner data only', async () => {
   mockFetch({
     _seed: { fetchedAt: 1, recordCount: 1, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },


### PR DESCRIPTION
## Summary

Without ACLED credentials, conflict seeding no longer collapses when GDELT DOC queries are throttled or return a misleading all-empty result. The seeder now falls back to GDELT's recent 15-minute event exports and produces the same priority-country conflict shape consumed by the escalation EMA.

The fallback range-reads the current manifest, downloads only the eight newest exports through the TLS storage origin, and bounds every network and decompression step. Manifest URLs, byte sizes, checksums, ZIP metadata, GDELT event classes, and priority-country mappings are validated before publication; if both DOC and bulk paths fail, the existing last-good preservation/retry contract remains fail-closed. The seeder lock was also resized and regression-pinned to cover the bulk leg after the parallel auxiliary feeds settle.

Related: #5256

## Validation

- Live GDELT probe: export `20260713113000`, 8/8 exports succeeded, 94 material-conflict records across 9 priority countries.
- `npm run build:full` completed successfully.
- Final focused suite: 64/64 passed, including DOC throttling, empty-DOC recovery, manifest trust, checksum, compression, streamed-size, partial-export, and runtime-budget cases.
- Canonical data suite: 15,098 passed and 6 skipped; its two built-output prerequisite failures passed 9/9 after the required full build.
- Pre-push gate passed typechecks, boundary/safe-HTML/rate-limit/premium-fetch checks, edge bundling, changed tests, version sync, and repository safety guards.

## Post-deploy monitoring

- Confirm the first no-ACLED seed logs `GDELT bulk conflict-events fallback` with a non-zero record count.
- Verify `acled-intel` seed metadata stays current and non-zero for two 30-minute intervals.
- Alert on `bulk fallback failed` or `RETRY FAILED`; if repeated, inspect storage-origin reachability and manifest/schema drift before rerunning the seeder.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
