### PR TITLE
fix(wildfire): package compactor with Railway seeder

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -10,8 +10,9 @@
 > registry before merging. Both `tests/scripts-railway-nixpacks-no-escape-import.test.mts`
 > and `tests/dockerfile-digest-notifications-imports.test.mjs` derive their entry
 > lists from the registry, and `tests/railway-services-registry-coverage.test.mts`
-> fails if a `Dockerfile.*` CMD or a runbook "Start command:" entry references a
-> script the registry doesn't know about.
+> fails if a `Dockerfile.*` CMD, runbook "Start command:" entry, or standalone
+> service row references a script the registry doesn't know about. The
+> scripts-root guard also conservatively scans unregistered legacy seeders.
 
 ---
 
@@ -442,9 +443,9 @@ entries.
 > runs as its own Railway nixpacks cron service (root directory `.`, start
 > command `node scripts/<file>`, watch paths `scripts/**`, `shared/**`). They
 > are intentionally **not** part of the 100-service inventory count above and
-> are not in `scripts/railway-services.json` (the registry only covers bundles,
-> Dockerfile services, and long-running workers — standalone crons live here in
-> the runbook, like the 43 above).
+> are registered in `scripts/railway-services.json` with deploy mode
+> `nixpacks-root-repo`, so scripts-root packaging checks do not misclassify
+> their valid imports outside `scripts/`.
 >
 > **Cadence below is inferred from each seed's cache TTL** as a documentation
 > aid; confirm the live cron schedule and Service ID against the Railway

--- a/scripts/_wildfire-dashboard.mjs
+++ b/scripts/_wildfire-dashboard.mjs
@@ -1,0 +1,38 @@
+export const WILDFIRE_DASHBOARD_DETECTION_LIMIT = 500;
+
+function numeric(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function confidenceRank(confidence) {
+  switch (confidence) {
+    case 'FIRE_CONFIDENCE_HIGH': return 3;
+    case 'FIRE_CONFIDENCE_NOMINAL': return 2;
+    case 'FIRE_CONFIDENCE_LOW': return 1;
+    default: return 0;
+  }
+}
+
+function compareFireDetectionsForDashboard(a, b) {
+  return Number(Boolean(b?.possibleExplosion)) - Number(Boolean(a?.possibleExplosion))
+    || confidenceRank(b?.confidence) - confidenceRank(a?.confidence)
+    || numeric(b?.brightness) - numeric(a?.brightness)
+    || numeric(b?.frp) - numeric(a?.frp)
+    || numeric(b?.detectedAt) - numeric(a?.detectedAt);
+}
+
+export function limitFireDetectionsForDashboard(detections, limit = WILDFIRE_DASHBOARD_DETECTION_LIMIT) {
+  if (detections.length <= limit) return detections;
+  return [...detections].sort(compareFireDetectionsForDashboard).slice(0, limit);
+}
+
+export function compactWildfireDashboardPayload(value, limit = WILDFIRE_DASHBOARD_DETECTION_LIMIT) {
+  if (!value || typeof value !== 'object' || !Array.isArray(value.fireDetections)) return value;
+  if (value.fireDetections.length <= limit) return value;
+  return {
+    ...value,
+    fireDetections: limitFireDetectionsForDashboard(value.fireDetections, limit),
+    pagination: { nextCursor: '', totalCount: value.fireDetections.length },
+  };
+}

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -28,6 +28,66 @@
     "documentedAt": "Dockerfile.seed-bundle-resilience-validation"
   },
   {
+    "entry": "scripts/seed-aaii-sentiment.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-aaii-sentiment",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-market-quotes.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-market-quotes",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-commodity-quotes.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-commodity-quotes",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-crypto-sectors.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-crypto-sectors",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-market-breadth.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-market-breadth",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-weather-alerts.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-weather-alerts",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-fx-yoy.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-fx-yoy",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-comtrade-bilateral-hs4.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-comtrade-bilateral-hs4",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-hs2-chokepoint-exposure.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-hs2-chokepoint-exposure",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
+    "entry": "scripts/seed-service-statuses.mjs",
+    "deployMode": "nixpacks-root-repo",
+    "service": "seed-service-statuses",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
+  },
+  {
     "entry": "scripts/seed-forecasts.mjs",
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-forecasts",

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, CHROME_UA, sleep } from './_seed-utils.mjs';
-import { compactWildfireDashboardPayload } from '../api/_wildfire-dashboard.js';
+import { compactWildfireDashboardPayload } from './_wildfire-dashboard.mjs';
 
 loadEnvFile(import.meta.url);
 

--- a/tests/_lib/import-graph-walk.mjs
+++ b/tests/_lib/import-graph-walk.mjs
@@ -107,17 +107,17 @@ export function extractEdges(src) {
 
   // import ... from '...' (multi-line safe; skips `import type` and clauses
   // whose named bindings are all inline `type` modifiers — tsx erases both)
-  for (const m of src.matchAll(/^[ \t]*import\s+(?!type\s)([^'";]*?)\bfrom\s*['"]([^'"]+)['"]/gms)) {
+  for (const m of src.matchAll(/(?:^|;)[ \t]*import\s+(?!type\s)([^'";]*?)\bfrom\s*['"]([^'"]+)['"]/gms)) {
     if (isAllTypeNamedClause(m[1])) continue;
     staticSpecs.push(m[2]);
   }
   // side-effect: import '...'
-  for (const m of src.matchAll(/^[ \t]*import\s*['"]([^'"]+)['"]/gm)) {
+  for (const m of src.matchAll(/(?:^|;)[ \t]*import\s*['"]([^'"]+)['"]/gm)) {
     staticSpecs.push(m[1]);
   }
   // export { ... } from '...' / export * from '...' (skips `export type` and
   // all-inline-type clauses)
-  for (const m of src.matchAll(/^[ \t]*export\s+(?!type\b)(\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gms)) {
+  for (const m of src.matchAll(/(?:^|;)[ \t]*export\s+(?!type\b)(\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*['"]([^'"]+)['"]/gms)) {
     if (m[1].startsWith('{') && isAllTypeNamedClause(m[1])) continue;
     staticSpecs.push(m[2]);
   }
@@ -210,6 +210,20 @@ export function collectRelativeImports(filePath) {
   const { staticSpecs, requireSpecs } = extractEdges(src);
   const imports = new Set();
   for (const spec of [...staticSpecs, ...requireSpecs]) {
+    if (spec.startsWith('.')) imports.add(spec);
+  }
+  return imports;
+}
+
+// Scripts-only packaging guards must cover every literal runtime edge. Unlike
+// Dockerfile COPY-closure callers, they cannot safely ignore dynamic imports:
+// a conditional import that escapes scripts/ still crashes when that branch
+// executes in Railway's /app scripts root.
+export function collectRelativeRuntimeImports(filePath) {
+  const src = stripComments(readFileSync(filePath, 'utf-8'));
+  const { staticSpecs, dynamicSpecs, requireSpecs } = extractEdges(src);
+  const imports = new Set();
+  for (const spec of [...staticSpecs, ...dynamicSpecs, ...requireSpecs]) {
     if (spec.startsWith('.')) imports.add(spec);
   }
   return imports;

--- a/tests/railway-services-registry-coverage.test.mts
+++ b/tests/railway-services-registry-coverage.test.mts
@@ -1,8 +1,9 @@
 /**
  * Coverage guardrail for scripts/railway-services.json — the single source
  * of truth for every script that runs as a Railway service. This test fails
- * if a deployment artifact in the repo (Dockerfile.* CMD line or runbook
- * "Start command:" entry) references a script not present in the registry.
+ * if a deployment artifact in the repo (Dockerfile.* CMD line, runbook
+ * "Start command:" entry, or standalone-service row) references a script not
+ * present in the registry.
  *
  * Two BFS-style tests derive their entry lists from the registry:
  *   - tests/scripts-railway-nixpacks-no-escape-import.test.mts (nixpacks)
@@ -30,7 +31,7 @@ const repoRoot = resolve(__dirname, '..');
 
 interface RailwayServiceEntry {
   entry: string;
-  deployMode: 'nixpacks-root-scripts' | 'dockerfile';
+  deployMode: 'nixpacks-root-scripts' | 'nixpacks-root-repo' | 'dockerfile';
   dockerfile?: string;
   service: string;
   documentedAt: string;
@@ -54,6 +55,10 @@ const DOCKERFILE_CMD_RE = /^\s*CMD\s+\[\s*"node"\s*,\s*"(scripts\/[^"]+)"\s*\]/m
 // (table-cell shape — multiple spaces, backtick quoting around the command).
 // Also tolerates `node` paths without backticks in case the runbook drifts.
 const RUNBOOK_START_RE = /\|\s*\*\*Start command\*\*\s*\|\s*`?node\s+(scripts\/\S+?\.(?:mjs|cjs|js))`?\s*\|/g;
+
+// Match standalone-service rows like:
+//   | seed-fake | `node scripts/seed-fake.mjs` | hourly | Domain |
+const RUNBOOK_SERVICE_ROW_RE = /^\|\s*seed-[a-z0-9-]+\s*\|\s*`node\s+(scripts\/[^`]+\.(?:mjs|cjs|js))`\s*\|/gm;
 
 // Match script headers that document a manually provisioned Railway service:
 //   - Service name: seed-bundle-foo
@@ -92,7 +97,7 @@ describe('Railway service registry coverage', () => {
     }
   });
 
-  it('every runbook "Start command" references a registered script', () => {
+  it('every runbook Railway command references a registered script', () => {
     const runbookPath = resolve(repoRoot, 'docs/railway-seed-consolidation-runbook.md');
     const src = readFileSync(runbookPath, 'utf8');
 
@@ -102,10 +107,14 @@ describe('Railway service registry coverage', () => {
     while ((m = RUNBOOK_START_RE.exec(src)) !== null) {
       referenced.add(m[1]!);
     }
+    RUNBOOK_SERVICE_ROW_RE.lastIndex = 0;
+    while ((m = RUNBOOK_SERVICE_ROW_RE.exec(src)) !== null) {
+      referenced.add(m[1]!);
+    }
     assert.ok(
       referenced.size > 0,
       `Runbook regex matched zero entries — runbook format may have drifted. ` +
-        `Update RUNBOOK_START_RE.`,
+        `Update RUNBOOK_START_RE or RUNBOOK_SERVICE_ROW_RE.`,
     );
 
     const missing: string[] = [];
@@ -120,7 +129,7 @@ describe('Railway service registry coverage', () => {
         `Runbook entries drift from scripts/railway-services.json:\n` +
           missing.map((s) => `  - ${s}`).join('\n') +
           `\n\nAdd the missing entry to the registry (deployMode: ` +
-          `"nixpacks-root-scripts") or update the runbook.`,
+          `"nixpacks-root-scripts" or "nixpacks-root-repo") or update the runbook.`,
       );
     }
   });
@@ -176,6 +185,14 @@ describe('Railway service registry coverage', () => {
     RUNBOOK_START_RE.lastIndex = 0;
     const m = RUNBOOK_START_RE.exec(sample);
     assert.ok(m, 'RUNBOOK_START_RE failed to match canonical Start command shape');
+    assert.equal(m![1], 'scripts/seed-fake.mjs');
+  });
+
+  it('RUNBOOK_SERVICE_ROW_RE matches the documented standalone-service shape', () => {
+    const sample = '| seed-fake | `node scripts/seed-fake.mjs` | hourly | Fake data |\n';
+    RUNBOOK_SERVICE_ROW_RE.lastIndex = 0;
+    const m = RUNBOOK_SERVICE_ROW_RE.exec(sample);
+    assert.ok(m, 'RUNBOOK_SERVICE_ROW_RE failed to match canonical standalone-service shape');
     assert.equal(m![1], 'scripts/seed-fake.mjs');
   });
 

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -30,19 +30,24 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { collectRelativeImports, stripComments } from './_lib/import-graph-walk.mjs';
+import {
+  collectRelativeRuntimeImports,
+  extractEdges,
+  parseDockerfileCopy,
+  stripComments,
+} from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const scriptsDir = resolve(repoRoot, 'scripts');
 
-// Registry-derived entry points cover bundles and workers. Standalone cron
-// seeders historically live outside that registry, so conservatively include
-// every seed-* script unless its registry entry names a Dockerfile whose COPY
-// closure is checked separately.
+// Registry-derived entry points cover bundles and workers. Conservatively scan
+// unregistered seed-* scripts as scripts-root services too, but exclude entries
+// the registry explicitly classifies as repo-root or Dockerfile deployments,
+// plus exact child scripts COPY'd into a registered Dockerfile image.
 interface RailwayServiceEntry {
   entry: string;
-  deployMode: 'nixpacks-root-scripts' | 'dockerfile';
+  deployMode: 'nixpacks-root-scripts' | 'nixpacks-root-repo' | 'dockerfile';
   dockerfile?: string;
   service: string;
   documentedAt: string;
@@ -55,15 +60,28 @@ const registry = JSON.parse(
 const REGISTERED_NIXPACKS_ENTRY_POINTS = registry
   .filter((r) => r.deployMode === 'nixpacks-root-scripts')
   .map((r) => r.entry);
-const DOCKERFILE_ENTRY_FILES = new Set(
+const NON_SCRIPTS_ROOT_ENTRY_FILES = new Set(
   registry
-    .filter((r) => r.deployMode === 'dockerfile')
+    .filter((r) => r.deployMode !== 'nixpacks-root-scripts')
     .map((r) => resolve(repoRoot, r.entry)),
+);
+const DOCKERFILE_COPIED_SCRIPT_FILES = new Set(
+  registry
+    .filter((r) => r.deployMode === 'dockerfile' && r.dockerfile)
+    .flatMap((r) => {
+      const dockerfile = readFileSync(resolve(repoRoot, r.dockerfile!), 'utf8');
+      return [...parseDockerfileCopy(dockerfile).files]
+        .filter((file) => file.startsWith('scripts/'))
+        .map((file) => resolve(repoRoot, file));
+    }),
 );
 const STANDALONE_SEED_ENTRY_POINTS = readdirSync(scriptsDir)
   .filter((file) => /^seed-.*\.(?:mjs|cjs|js)$/.test(file))
   .map((file) => `scripts/${file}`)
-  .filter((entry) => !DOCKERFILE_ENTRY_FILES.has(resolve(repoRoot, entry)));
+  .filter((entry) => {
+    const absEntry = resolve(repoRoot, entry);
+    return !NON_SCRIPTS_ROOT_ENTRY_FILES.has(absEntry) && !DOCKERFILE_COPIED_SCRIPT_FILES.has(absEntry);
+  });
 const ENTRY_POINTS = [...new Set([...REGISTERED_NIXPACKS_ENTRY_POINTS, ...STANDALONE_SEED_ENTRY_POINTS])];
 const BUNDLE_ENTRY_FILES = new Set(
   REGISTERED_NIXPACKS_ENTRY_POINTS.map((entry) => resolve(repoRoot, entry)),
@@ -98,6 +116,29 @@ function escapesScriptsDir(absResolved: string): boolean {
 }
 
 describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
+  it('classifies scripts-root, repo-root, and Dockerfile child seeders correctly', () => {
+    assert.ok(ENTRY_POINTS.includes('scripts/seed-fire-detections.mjs'));
+    assert.ok(!ENTRY_POINTS.includes('scripts/seed-market-quotes.mjs'));
+    assert.ok(!ENTRY_POINTS.includes('scripts/seed-chokepoint-flows.mjs'));
+  });
+
+  it('scanner recognizes every supported literal runtime import form', () => {
+    const edges = extractEdges([
+      "const ready = true; import value from './same-line.mjs';",
+      "import './side-effect.mjs';",
+      "export { value } from './exported.mjs';",
+      "await import('./dynamic.mjs');",
+      "const required = require('./required.cjs');",
+    ].join('\n'));
+
+    assert.deepEqual(
+      new Set(edges.staticSpecs),
+      new Set(['./same-line.mjs', './side-effect.mjs', './exported.mjs']),
+    );
+    assert.deepEqual(new Set(edges.dynamicSpecs), new Set(['./dynamic.mjs']));
+    assert.deepEqual(new Set(edges.requireSpecs), new Set(['./required.cjs']));
+  });
+
   for (const entry of ENTRY_POINTS) {
     it(`entry ${entry} and its transitive scripts/ deps never import outside scripts/`, () => {
       const visited = new Set<string>();
@@ -111,7 +152,7 @@ describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
 
         let imports: Set<string>;
         try {
-          imports = collectRelativeImports(file);
+          imports = collectRelativeRuntimeImports(file);
         } catch (err) {
           assert.fail(`Could not read ${file}: ${(err as Error).message}`);
         }
@@ -151,7 +192,7 @@ describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
       if (violations.length > 0) {
         const lines = violations.map(
           (v) =>
-            `  ${v.from}\n    imports '${v.spec}'\n    → ${v.resolved} (escapes scripts/)`,
+            `  ${v.from}\n    imports '${v.spec}'\n    -> ${v.resolved} (escapes scripts/)`,
         );
         assert.fail(
           `Found ${violations.length} import(s) that escape scripts/ in the ` +

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -6,14 +6,15 @@
  * `/server/_shared/X.mjs` at runtime — a path that doesn't exist — and
  * crashes the worker on startup with `ERR_MODULE_NOT_FOUND`.
  *
- * Three Railway services are affected:
+ * The original #3811 regression covered three registered Railway services:
  *   - seed-forecasts        — node scripts/seed-forecasts.mjs
  *   - simulation-worker     — node scripts/process-simulation-tasks.mjs
  *   - deep-forecast-worker  — node scripts/process-deep-forecast-tasks.mjs
  *
- * (See docs/railway-seed-consolidation-runbook.md for the service list and
- * Dockerfile.digest-notifications header for the cherry-pick alternative
- * we explicitly do NOT use for these three.)
+ * This guard now also covers standalone `seed-*` cron entry points that use
+ * the same root-scripts packaging contract. (See
+ * docs/railway-seed-consolidation-runbook.md for the service list and
+ * Dockerfile.digest-notifications for the cherry-pick alternative.)
  *
  * Approach: BFS from each entry script, follow relative imports and
  * _bundle-runner section script references, assert no resolved path escapes
@@ -25,20 +26,20 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { collectRelativeImports, stripComments } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const scriptsDir = resolve(repoRoot, 'scripts');
 
-// Entry points derived from scripts/railway-services.json, the single
-// source of truth for every script that runs as a Railway service. New
-// services are added by editing the registry, NOT this array. The
-// companion test tests/railway-services-registry-coverage.test.mts fails
-// if any Dockerfile.* or runbook entry references a script that isn't
-// in the registry — that's how drift is caught.
+// Registry-derived entry points cover bundles and workers. Standalone cron
+// seeders historically live outside that registry, so conservatively include
+// every seed-* script unless its registry entry names a Dockerfile whose COPY
+// closure is checked separately.
 interface RailwayServiceEntry {
   entry: string;
   deployMode: 'nixpacks-root-scripts' | 'dockerfile';
@@ -51,40 +52,24 @@ const registry = JSON.parse(
   readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
 ) as RailwayServiceEntry[];
 
-const ENTRY_POINTS = registry
+const REGISTERED_NIXPACKS_ENTRY_POINTS = registry
   .filter((r) => r.deployMode === 'nixpacks-root-scripts')
   .map((r) => r.entry);
-const BUNDLE_ENTRY_FILES = new Set(ENTRY_POINTS.map((entry) => resolve(repoRoot, entry)));
+const DOCKERFILE_ENTRY_FILES = new Set(
+  registry
+    .filter((r) => r.deployMode === 'dockerfile')
+    .map((r) => resolve(repoRoot, r.entry)),
+);
+const STANDALONE_SEED_ENTRY_POINTS = readdirSync(scriptsDir)
+  .filter((file) => /^seed-.*\.(?:mjs|cjs|js)$/.test(file))
+  .map((file) => `scripts/${file}`)
+  .filter((entry) => !DOCKERFILE_ENTRY_FILES.has(resolve(repoRoot, entry)));
+const ENTRY_POINTS = [...new Set([...REGISTERED_NIXPACKS_ENTRY_POINTS, ...STANDALONE_SEED_ENTRY_POINTS])];
+const BUNDLE_ENTRY_FILES = new Set(
+  REGISTERED_NIXPACKS_ENTRY_POINTS.map((entry) => resolve(repoRoot, entry)),
+);
 
-const IMPORT_RE = /(?:^|[\s;])(?:import\b[\s\S]*?\bfrom|import|export\b[\s\S]*?\bfrom)\s+['"]([^'"]+)['"]/gm;
 const BUNDLE_SECTION_SCRIPT_RE = /\bscript\s*:\s*['"]([^'"]+\.(?:mjs|cjs|js))['"]/gm;
-
-function isRelative(spec: string): boolean {
-  return spec.startsWith('./') || spec.startsWith('../');
-}
-
-function collectRelativeImports(filePath: string): string[] {
-  const src = readFileSync(filePath, 'utf8');
-  const out: string[] = [];
-  let m: RegExpExecArray | null;
-  IMPORT_RE.lastIndex = 0;
-  while ((m = IMPORT_RE.exec(src)) !== null) {
-    const spec = m[1]!;
-    if (isRelative(spec)) out.push(spec);
-  }
-  return out;
-}
-
-// Conservative JS comment stripper (same pattern as
-// tests/news-feed-key-parity.test.mts): drop block comments, then line
-// comments anchored at a line start or after whitespace so in-string `//`
-// (e.g. `https://`) survives. Keeps a `script:` literal in a block, trailing,
-// or full-line comment from registering as a real child seeder.
-function stripComments(src: string): string {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|\s)\/\/[^\n]*/g, '$1');
-}
 
 function collectBundleSectionScripts(filePath: string): string[] {
   // Strip comments first so the gate and the extraction agree on the same
@@ -124,7 +109,7 @@ describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
         if (visited.has(file)) continue;
         visited.add(file);
 
-        let imports: string[];
+        let imports: Set<string>;
         try {
           imports = collectRelativeImports(file);
         } catch (err) {

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -132,6 +132,15 @@ describe('wildfire dashboard payload cap', () => {
     assert.doesNotMatch(bootstrap, /wildfires:\s*'wildfire:fires:v1'/);
   });
 
+  it('packages the shared compactor with the seeder and keeps the Edge mirror in sync', () => {
+    const seeder = readFileSync(new URL('../scripts/seed-fire-detections.mjs', import.meta.url), 'utf8');
+    const scriptsHelper = readFileSync(new URL('../scripts/_wildfire-dashboard.mjs', import.meta.url), 'utf8');
+    const edgeHelper = readFileSync(new URL('../api/_wildfire-dashboard.js', import.meta.url), 'utf8');
+
+    assert.match(seeder, /from '\.\/_wildfire-dashboard\.mjs'/);
+    assert.equal(edgeHelper, scriptsHelper, 'Edge helper mirror must match the scripts-packaged source');
+  });
+
   it('caps response detections without mutating the seed array and keeps highest-signal detections', () => {
     const lowSignal = Array.from({ length: WILDFIRE_DASHBOARD_DETECTION_LIMIT + 25 }, (_, index) =>
       fireDetection(index, {


### PR DESCRIPTION
## Summary

The wildfire seeder can start again in Railway's scripts-only Nixpacks root instead of crashing while resolving a helper from the undeployed `api/` tree. The seeder and Edge endpoint retain identical compaction behavior through an enforced byte-parity contract.

The packaging regression guard now discovers every standalone `seed-*` entry point and walks both ESM and CommonJS relative dependencies, so this class of root-directory escape fails before deployment.

Fixes #5268.

## Validation

- Proof-first regression reproduced the exact `../api/_wildfire-dashboard.js` escape before the fix.
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint` (passes with existing unrelated warnings)
- 435 focused packaging, bootstrap, Edge, registry, and wildfire tests passed.
- The repository pre-push gate passed, including typechecks, boundary checks, Edge bundling, and all changed tests.

## Deployment monitoring

- Watch the `seed-fire-detections` Railway logs for `ERR_MODULE_NOT_FOUND`, `FATAL`, and non-zero exits through the first two 10-minute cron ticks.
- Healthy: the job exits 0, writes wildfire seed metadata, and the wildfire health entry reports records greater than zero without a stale-seed verdict.
- Failure: any module-resolution crash or zero/stale wildfire records after the validation window. Roll back to the last green deployment and revert this commit while inspecting the deployed scripts closure.
- Owner/window: repository maintainer or on-call through the first two scheduled runs, approximately 30 minutes after deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
