### PR TITLE
fix(api): strip router-injected ?rpc= so public RPC URLs are CDN-shielded (#5285)

### DIFF
--- a/src/shared/public-rpc-cache.ts
+++ b/src/shared/public-rpc-cache.ts
@@ -9,10 +9,45 @@ const NEWS_LANGUAGES = new Set([
   'sv', 'ru', 'ar', 'fa', 'zh', 'ja', 'ko', 'ro', 'tr', 'th', 'vi', 'hi',
 ]);
 const NEWS_QUERY_KEYS = new Set(['variant', 'lang', 'public']);
-const DISPLACEMENT_PUBLIC_SEARCH = '?flow_limit=50&public=1';
+// Exact raw-query contract (no leading `?`): exactly one public displacement shape,
+// so the CDN key space stays at one entry. Compared against the raw search string —
+// order- and encoding-sensitive by design (see stripRouterInjectedRpcEcho).
+const DISPLACEMENT_PUBLIC_SEARCH = 'flow_limit=50&public=1';
 
 function hasSingleValue(params: URLSearchParams, key: string): boolean {
   return params.getAll(key).length === 1;
+}
+
+/**
+ * Vercel serves these routes through `api/<domain>/v1/[rpc].ts` and its filesystem router
+ * echoes the matched segment back as `?rpc=<lastPathSegment>`. The function therefore
+ * sees a query the caller never sent, which fails the exhaustive shape checks below
+ * and silently 401'd every public RPC in production (#5285). `server/_shared/
+ * mcp-internal-hmac.ts` strips the same echo before signing, for the same reason.
+ *
+ * Returns the RAW search string (no leading `?`) with the echo removed. Raw, not a
+ * re-serialised URLSearchParams, because the displacement contract is an exact-string
+ * compare: re-encoding would normalise `flow_limit=%35%30` into `flow_limit=50` and
+ * silently widen the accepted shape.
+ *
+ * Strips `rpc` ONLY when every value equals the final path segment — i.e. only the
+ * router's own echo. A caller-appended `?rpc=<anything-else>` is left in place and
+ * still fails the shape check, so this is not a bypass vector.
+ */
+function stripRouterInjectedRpcEcho(url: URL): string {
+  const raw = url.search.startsWith('?') ? url.search.slice(1) : url.search;
+  if (!raw) return '';
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1] ?? '';
+  const echo = `rpc=${lastSegment}`;
+
+  const parts = raw.split('&');
+  const rpcParts = parts.filter((part) => part === 'rpc' || part.startsWith('rpc='));
+  if (rpcParts.length === 0) return raw;
+  if (!rpcParts.every((part) => part === echo)) return raw;
+
+  return parts.filter((part) => part !== echo).join('&');
 }
 
 function hasOnlyKeys(params: URLSearchParams, allowed: Set<string>): boolean {
@@ -41,10 +76,14 @@ export function isPublicSharedRpcRequest(urlLike: string | URL, method = 'GET'):
 
   const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
   if (!PUBLIC_SHARED_RPC_PATHS.has(pathname)) return false;
-  if (!hasSingleValue(url.searchParams, 'public') || url.searchParams.get('public') !== '1') return false;
 
-  if (pathname === '/api/news/v1/list-feed-digest') return isNewsDigestShape(url.searchParams);
-  return url.search === DISPLACEMENT_PUBLIC_SEARCH;
+  // Shape-check the caller's query, not the router's echo of the path segment.
+  const search = stripRouterInjectedRpcEcho(url);
+  const params = new URLSearchParams(search);
+  if (!hasSingleValue(params, 'public') || params.get('public') !== '1') return false;
+
+  if (pathname === '/api/news/v1/list-feed-digest') return isNewsDigestShape(params);
+  return search === DISPLACEMENT_PUBLIC_SEARCH;
 }
 
 export function addPublicSharedRpcMarker(urlLike: string | URL): string {

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -161,6 +161,25 @@ describe('gateway CDN origin policy', () => {
     });
   }
 
+  // Vercel's filesystem router serves these through api/**/[rpc].ts and echoes the
+  // matched segment back as ?rpc=<lastPathSegment>. Production therefore sees a query
+  // the hand-built URLs in these tests never had — which silently 401'd every public
+  // RPC (#5285). server/_shared/mcp-internal-hmac.ts strips the same echo for signing.
+  for (const [path, rpc] of [
+    ['/api/news/v1/list-feed-digest?variant=full&lang=en&public=1', 'list-feed-digest'],
+    ['/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1', 'get-displacement-summary'],
+  ] as const) {
+    it(`CDN-shields the public RPC variant when the router echoes ?rpc=: ${path}`, async () => {
+      const handler = createHandler();
+      const res = await handler(new Request(`https://worldmonitor.app${path}&rpc=${rpc}`, {
+        headers: { Origin: 'https://worldmonitor.app' },
+      }));
+
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    });
+  }
+
   it('does not widen the public RPC cache contract to legacy or arbitrary query shapes', async () => {
     const handler = createHandler();
     for (const path of [
@@ -176,6 +195,11 @@ describe('gateway CDN origin policy', () => {
       '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&public=1',
       '/api/displacement/v1/get-displacement-summary?public=1&flow_limit=50',
       '/api/displacement/v1/get-displacement-summary?flow_limit=%35%30&public=1',
+      // A caller-supplied ?rpc= that is NOT the router's echo of the final path
+      // segment must still fail the shape check — stripping is not a bypass vector.
+      '/api/news/v1/list-feed-digest?variant=full&lang=en&public=1&rpc=bogus',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&rpc=bogus',
+      '/api/displacement/v1/get-displacement-summary?flow_limit=50&public=1&rpc=list-feed-digest',
     ]) {
       const res = await handler(new Request(`https://worldmonitor.app${path}`, {
         headers: { Origin: 'https://worldmonitor.app' },


### PR DESCRIPTION
## Summary

Both public RPC URLs shipped by #5263 return **401** in production and are never CDN-cached. Fixes #5285.

```
GET /api/news/v1/list-feed-digest?variant=full&lang=en&public=1         -> 401
GET /api/displacement/v1/get-displacement-summary?flow_limit=50&public=1 -> 401
```

Two consequences, both live right now:
- The ~19 GB/day of Redis egress those routes were meant to shield (#5259) keeps hitting origin.
- The deployed client calls **only** the public URLs, so the news digest falls back to a stale persisted copy and **the displacement panel renders empty**.

## Root cause

Vercel serves these through `api/<domain>/v1/[rpc].ts`, and its filesystem router echoes the matched segment back as `?rpc=<lastPathSegment>`. So the function actually sees:

```
/api/news/v1/list-feed-digest?variant=full&lang=en&public=1&rpc=list-feed-digest
```

`isPublicSharedRpcRequest` validates the query with an **exhaustive allowlist** (news) and an **exact-string compare** (displacement). Neither tolerates `rpc`, so `isPublicNoAuthRpc` stayed false and the gateway fell through to `validateApiKey` → 401.

`/api/bootstrap` (#5250) is unaffected because it is a **static** route. Every pre-existing public RPC matches on `pathname` only — #5263 was the first query-strict check on a dynamic route, and the first to trip on this. `server/_shared/mcp-internal-hmac.ts:455` already strips the same echo before signing ("confirmed live: signing WITH the injected param verifies, without fails" — WORLDMONITOR-R1/T8); this reuses that guard.

## Fix

Strip `rpc` **only** when every value equals the final path segment — the router's own echo. A caller-supplied `?rpc=<anything-else>` is left in place and still fails the shape check, so this is **not a bypass vector**.

The echo is removed from the **raw** query string rather than a re-serialised `URLSearchParams`: re-encoding would normalise `flow_limit=%35%30` into `flow_limit=50` and silently widen the displacement contract, which is deliberately an exact-string match to keep the CDN key space at exactly one entry.

The #5263 blocker stays closed — `year` / `country_limit` / any other `flow_limit` remain rejected, now verified *with* the echo appended.

## Why the tests didn't catch it

The existing suite hand-builds URLs, which never carry the router echo — so the unit tests were green while production was 401ing. Added coverage for the router-echo shape on both routes, plus rejection of a caller-supplied `?rpc=`.

## Validation

- Proof-first: the two new tests **fail** on `main` (reproducing the exact prod 401), pass with the fix.
- `node --test tests/gateway-cdn-origin-policy.test.mts tests/public-rpc-fetch.test.mts` — 22 pass, 0 fail
- `node --test tests/edge-functions.test.mjs` — 228 pass, 0 fail
- `npm run typecheck`, `npm run typecheck:api` — pass
- Direct probe of all 8 prod URL shapes (router echo accepted; `rpc=bogus`, `year=1999`, `flow_limit=7`, `%35%30` all still rejected)
- Pre-push gate passed

## Post-deploy check

Both URLs must return **200** anonymously with `CDN-Cache-Control` and `x-vercel-cache: HIT` on a second request, and the news + displacement panels must hydrate without the breaker fallback.

> Note: this does **not** close #5259. Egress cannot be validated until the wildfire seeder is also restored (#5268 — merged but Railway never rebuilt, so both wildfire keys are still absent); a measurement taken now would be flattered by that outage.