### PR TITLE
fix(seeders): stop seed-conflict-intel crash-looping when it has no usable source (#5256)

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -759,6 +759,13 @@ export function resolveProxyForConnect() {
 // NOTE: requires curl binary — available in Dockerfile.relay (apk add curl) and Railway.
 // Prefer httpsProxyFetchJson (pure Node.js) when possible; use curlFetch when curl-specific
 // features are needed (e.g. --compressed, -L redirect following with proxy).
+// Scrub `scheme://user:pass@host` credentials out of anything we surface. Proxy auth
+// strings are the only place seeders carry inline credentials, and they end up embedded
+// in curl argv — see the execFileSync catch below.
+export function redactProxyCredentials(text) {
+  return String(text ?? '').replace(/(\w+:\/\/)[^/\s:@]+:[^/\s@]+@/g, '$1***:***@');
+}
+
 export function curlFetch(url, proxyAuth, headers = {}) {
   const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
   if (proxyAuth) {
@@ -768,7 +775,22 @@ export function curlFetch(url, proxyAuth, headers = {}) {
   for (const [k, v] of Object.entries(headers)) args.push('-H', `${k}: ${v}`);
   args.push('-w', '\n%{http_code}');
   args.push(url);
-  const raw = execFileSync('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
+  let raw;
+  try {
+    raw = execFileSync('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
+  } catch (err) {
+    // SECURITY: when curl itself exits non-zero (SSL_ERROR_SYSCALL, "CONNECT tunnel
+    // failed", DNS), execFileSync builds an Error whose message is the ENTIRE argv —
+    // including `-x http://user:pass@proxy-host`. Seeders log that message, so the proxy
+    // credentials were being written verbatim into Railway logs on every curl-level
+    // failure (observed continuously during the 2026-07-13 GDELT 429 storm). Re-throw
+    // with curl's own stderr, which names the failure without echoing the command.
+    const stderr = redactProxyCredentials(err?.stderr || '').trim().split('\n').filter(Boolean).pop();
+    throw Object.assign(
+      new Error(`curl failed: ${stderr || redactProxyCredentials(err?.message) || 'unknown error'}`),
+      { curlFailed: true },
+    );
+  }
   const nl = raw.lastIndexOf('\n');
   const status = parseInt(raw.slice(nl + 1).trim(), 10);
   if (status < 200 || status >= 300) throw Object.assign(new Error(`HTTP ${status}`), { status });
@@ -1527,6 +1549,23 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
       const preserved = await extendExistingTtl(keys, ttlSeconds || 600);
       if (!preserved) {
+        // #5256: exiting 1 here assumes a LATER TICK CAN RESTORE THE DATA. When the seeder
+        // reports it had no usable source at all (primary unconfigured AND every fallback
+        // down), no tick ever can — seed-conflict-intel crash-looped every ~15min forever,
+        // firing "Deploy Crashed!" each time while /api/health already reported the domain
+        // EMPTY/crit. The crash added nothing over health; it only trained us to ignore the
+        // crash channel. Stay green, publish NOTHING (an empty envelope would overwrite
+        // last-good the moment the source blips), and leave the data alarm to /api/health.
+        //
+        // This is deliberately NOT `zeroIsValid`: a seeder must opt in per-run, on the exact
+        // code path where it knows it has no source. A zero-yield run that does not declare
+        // sourceUnavailable is still a dead feed and still exits 1 — #5258 stands.
+        if (data?.sourceUnavailable) {
+          console.warn(`  NO SOURCE: declareRecords returned 0 and no usable upstream was available — published nothing, last-good left untouched. /api/health reports ${domain}:${resource} EMPTY.`);
+          console.log(`\n=== Done (${Math.round(durationMs)}ms, NO SOURCE) ===`);
+          await releaseLock(`${domain}:${resource}`, runId);
+          await exitAfterTelemetryFlush(0);
+        }
         console.error(`  FAILURE: declareRecords returned 0 and last-good preservation failed — one or more keys are missing or could not be extended`);
         console.log(`\n=== Done (${Math.round(durationMs)}ms, RETRY FAILED) ===`);
         await releaseLock(`${domain}:${resource}`, runId);

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -755,18 +755,21 @@ export function resolveProxyForConnect() {
   return resolveProxyStringConnect();
 }
 
-// curl-based fetch; throws on non-2xx. Returns response body as string.
-// NOTE: requires curl binary — available in Dockerfile.relay (apk add curl) and Railway.
-// Prefer httpsProxyFetchJson (pure Node.js) when possible; use curlFetch when curl-specific
-// features are needed (e.g. --compressed, -L redirect following with proxy).
 // Scrub `scheme://user:pass@host` credentials out of anything we surface. Proxy auth
 // strings are the only place seeders carry inline credentials, and they end up embedded
-// in curl argv — see the execFileSync catch below.
+// in curl argv — see the execFileSync catch in curlFetch below.
 export function redactProxyCredentials(text) {
   return String(text ?? '').replace(/(\w+:\/\/)[^/\s:@]+:[^/\s@]+@/g, '$1***:***@');
 }
 
-export function curlFetch(url, proxyAuth, headers = {}) {
+// curl-based fetch; throws on non-2xx. Returns response body as string.
+// NOTE: requires curl binary — available in Dockerfile.relay (apk add curl) and Railway.
+// Prefer httpsProxyFetchJson (pure Node.js) when possible; use curlFetch when curl-specific
+// features are needed (e.g. --compressed, -L redirect following with proxy).
+//
+// `exec` is an injection seam for tests ONLY — the credential scrubbing below lives in a
+// catch around execFileSync, and there is no other way to drive that branch deterministically.
+export function curlFetch(url, proxyAuth, headers = {}, { exec = execFileSync } = {}) {
   const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
   if (proxyAuth) {
     const proxyUrl = /^https?:\/\//i.test(proxyAuth) ? proxyAuth : `http://${proxyAuth}`;
@@ -777,7 +780,7 @@ export function curlFetch(url, proxyAuth, headers = {}) {
   args.push(url);
   let raw;
   try {
-    raw = execFileSync('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
+    raw = exec('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
   } catch (err) {
     // SECURITY: when curl itself exits non-zero (SSL_ERROR_SYSCALL, "CONNECT tunnel
     // failed", DNS), execFileSync builds an Error whose message is the ENTIRE argv —
@@ -785,6 +788,14 @@ export function curlFetch(url, proxyAuth, headers = {}) {
     // credentials were being written verbatim into Railway logs on every curl-level
     // failure (observed continuously during the 2026-07-13 GDELT 429 storm). Re-throw
     // with curl's own stderr, which names the failure without echoing the command.
+    //
+    // Dropping `.status` is load-bearing, not incidental: execFileSync sets it to curl's
+    // EXIT CODE (35, 56, 7…). _gdelt-fetch.mjs discriminates "upstream returned non-2xx"
+    // from "network/curl failure" purely on `typeof status === 'number'`, so leaking the
+    // exit code through made it read curl exit 35 as an HTTP status, find it absent from
+    // RETRYABLE_STATUSES, and refuse to retry the proxy — defeating the Decodo per-attempt
+    // IP rotation on exactly the TLS tears it exists to survive. Only a genuine HTTP
+    // status may carry `.status`.
     const stderr = redactProxyCredentials(err?.stderr || '').trim().split('\n').filter(Boolean).pop();
     throw Object.assign(
       new Error(`curl failed: ${stderr || redactProxyCredentials(err?.message) || 'unknown error'}`),

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1548,24 +1548,37 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
       if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
       const preserved = await extendExistingTtl(keys, ttlSeconds || 600);
+
+      // #5256: the RETRY-FAILED exit below assumes A LATER TICK CAN RESTORE THE DATA. When
+      // the seeder reports it had no usable source at all (primary unconfigured AND every
+      // fallback down), no tick ever can — seed-conflict-intel crash-looped every ~15min
+      // forever, firing "Deploy Crashed!" each time while /api/health already reported the
+      // domain EMPTY/crit. The crash added nothing over health; it only trained us to ignore
+      // the crash channel. Stay green, publish NOTHING (an empty envelope would overwrite
+      // last-good the moment the source blips), and leave the data alarm to /api/health.
+      //
+      // This is deliberately NOT `zeroIsValid`: a seeder must opt in per-run, on the exact
+      // code path where it knows it has no source. A zero-yield run that does not declare
+      // sourceUnavailable is still a dead feed and still exits 1 — #5258 stands.
+      //
+      // Checked BEFORE `preserved`, not inside `!preserved`: the outcome is exit 0 either
+      // way, but an operator must see the REAL reason on every tick. Falling through to the
+      // generic "TTL extended, bundle will retry next cycle" message while last-good is
+      // still alive would hide the no-source condition for however many cycles the keys
+      // survive, and only surface it once they expire.
+      if (data?.sourceUnavailable) {
+        console.warn(
+          `  NO SOURCE: declareRecords returned 0 and no usable upstream was available — published nothing, `
+          + (preserved
+            ? `last-good TTL extended (data still served, but it is no longer being refreshed).`
+            : `and last-good has already expired — /api/health reports ${domain}:${resource} EMPTY.`),
+        );
+        console.log(`\n=== Done (${Math.round(durationMs)}ms, NO SOURCE) ===`);
+        await releaseLock(`${domain}:${resource}`, runId);
+        await exitAfterTelemetryFlush(0);
+      }
+
       if (!preserved) {
-        // #5256: exiting 1 here assumes a LATER TICK CAN RESTORE THE DATA. When the seeder
-        // reports it had no usable source at all (primary unconfigured AND every fallback
-        // down), no tick ever can — seed-conflict-intel crash-looped every ~15min forever,
-        // firing "Deploy Crashed!" each time while /api/health already reported the domain
-        // EMPTY/crit. The crash added nothing over health; it only trained us to ignore the
-        // crash channel. Stay green, publish NOTHING (an empty envelope would overwrite
-        // last-good the moment the source blips), and leave the data alarm to /api/health.
-        //
-        // This is deliberately NOT `zeroIsValid`: a seeder must opt in per-run, on the exact
-        // code path where it knows it has no source. A zero-yield run that does not declare
-        // sourceUnavailable is still a dead feed and still exits 1 — #5258 stands.
-        if (data?.sourceUnavailable) {
-          console.warn(`  NO SOURCE: declareRecords returned 0 and no usable upstream was available — published nothing, last-good left untouched. /api/health reports ${domain}:${resource} EMPTY.`);
-          console.log(`\n=== Done (${Math.round(durationMs)}ms, NO SOURCE) ===`);
-          await releaseLock(`${domain}:${resource}`, runId);
-          await exitAfterTelemetryFlush(0);
-        }
         console.error(`  FAILURE: declareRecords returned 0 and last-good preservation failed — one or more keys are missing or could not be extended`);
         console.log(`\n=== Done (${Math.round(durationMs)}ms, RETRY FAILED) ===`);
         await releaseLock(`${domain}:${resource}`, runId);

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1540,9 +1540,12 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     }
 
     // Contract RETRY on empty (no zeroIsValid) — skip publish and preserve the
-    // last-good keys. Exit 0 only when Redis confirms every key was actually
-    // extended; otherwise the data is already gone (or preservation could not
-    // be verified), so a green process would hide a live outage indefinitely.
+    // last-good keys. Exit 0 when Redis confirms every key was actually extended;
+    // otherwise the data is already gone (or preservation could not be verified), so a
+    // green process would hide a live outage indefinitely — EXCEPT when the seeder
+    // declared `sourceUnavailable`, which also exits 0 (see #5256 below: with no source
+    // configured, no retry can ever restore the data, so exiting 1 crash-loops forever
+    // and /api/health already carries the alarm).
     if (contractState === 'RETRY') {
       const durationMs = Date.now() - startMs;
       const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -37,11 +37,14 @@ const HAPI_CACHE_KEY_PREFIX = 'conflict:humanitarian:v1';
 const HAPI_TTL = 21600;
 const PIZZINT_TTL = 600;
 
-const CONFLICT_COUNTRIES = [
+export const CONFLICT_COUNTRIES = [
   'AF', 'SY', 'UA', 'SD', 'SS', 'SO', 'CD', 'MM', 'YE', 'ET',
   'IQ', 'PS', 'LY', 'ML', 'BF', 'NE', 'NG', 'CM', 'MZ', 'HT',
 ];
 export const GDELT_MIN_SUCCESSFUL_COUNTRIES = Math.ceil(CONFLICT_COUNTRIES.length * 0.8);
+// A throttled failure, as it reaches us: fetchGdeltCountryEvents flattens the direct and
+// proxy attempts into one message, e.g. "...(last direct: HTTP 429) (last proxy: HTTP 429)".
+const RATE_LIMIT_ERROR = /\b429\b|rate.?limit|too many requests/i;
 // #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
 // fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
 // an absolute deadline down, so slow aux feeds — HAPI is sequential, ~306s worst —
@@ -268,6 +271,19 @@ export async function fetchGdeltConflictEvents({
         failedCountries.push({ country: result?.country || 'unknown', error: result?.error || 'unknown failure' });
       }
     }
+    // #5256: back off out of a rate-limit storm instead of grinding into it. On
+    // 2026-07-13 GDELT 429'd every country, direct AND through the proxy — reproducible
+    // off-Railway, so it is a GLOBAL throttle, not our egress. Once a whole batch comes
+    // back throttled with zero successes anywhere, the remaining batches cannot succeed
+    // either; they just burn the run window and deepen the limit we are already hitting.
+    // (The floor check above would stop us eventually, but only after ~2× the requests.)
+    const rateLimited = results.every(r => !r?.ok && RATE_LIMIT_ERROR.test(String(r?.error ?? '')));
+    if (rateLimited && successfulCountries === 0) {
+      const why = 'GDELT rate-limit storm (batch fully throttled, 0 successes)';
+      for (const cc of remaining.slice(CONCURRENCY)) failedCountries.push({ country: cc, error: why });
+      console.warn(`  [GDELT] conflict sweep backed off (${why}) after ${i + batch.length}/${CONFLICT_COUNTRIES.length} countries`);
+      break;
+    }
     if (i + CONCURRENCY < CONFLICT_COUNTRIES.length) await pace(500); // inter-batch only; no trailing wait
   }
   if (successfulCountries < GDELT_MIN_SUCCESSFUL_COUNTRIES || events.length === 0) {
@@ -462,7 +478,10 @@ async function fetchGdeltTensions() {
 
 // ─── Main ───
 
-async function fetchAll() {
+// runSeed invokes this as `fetchFn()` with no arguments, so the injected dep is for tests
+// only — the GDELT fallback reaches its proxy through a `curl` child process, which no
+// global-fetch stub can intercept, so it must be injectable to keep tests hermetic.
+export async function fetchAll({ fetchGdeltFallback = fetchGdeltConflictEvents } = {}) {
   // #5140: anchor the GDELT-fallback sweep cutoff at the START of the fetch phase,
   // not at sweep entry — the aux feeds below (HAPI is sequential, ~306s worst) and
   // the sweep share runSeed's single fetch deadline, so time the aux stage burns
@@ -522,13 +541,24 @@ async function fetchAll() {
       // on the no-creds path: a credentialed-but-failed fetch still throws below, and a
       // credentialed-but-empty ACLED result is trusted (returns `ac`) rather than
       // overwritten by GDELT volume.
-      const gdeltEvents = await fetchGdeltConflictEvents({ deadlineAt: sweepDeadlineAt }).catch((e) => {
+      const gdeltEvents = await fetchGdeltFallback({ deadlineAt: sweepDeadlineAt }).catch((e) => {
         console.warn(`  GDELT conflict-events fallback failed: ${e.message}`);
         return null;
       });
       if (gdeltEvents?.events?.length) return gdeltEvents;
-      console.log('  ACLED: no credentials + GDELT fallback empty — publishing auxiliary feeds only, primary feed left empty');
-      return { events: [], pagination: undefined };
+      // #5256: we have NO usable primary source this tick — ACLED is unconfigured and the
+      // only fallback errored (fetchGdeltConflictEvents throws on floor-miss/zero/bulk
+      // failure; it never resolves to a legitimate empty). Say so explicitly.
+      //
+      // Returning a bare `{ events: [] }` here laundered an upstream OUTAGE into a
+      // "0 records" result, which runSeed reads as contract RETRY -> and once the
+      // last-good keys had expired, #5258's guard exited 1. With no source configured no
+      // retry can ever fix that, so it crash-looped every tick forever while /api/health
+      // already reported acledIntel EMPTY. sourceUnavailable tells runSeed to publish
+      // nothing (an empty envelope would wipe last-good the moment GDELT merely blips)
+      // and exit 0, leaving the data alarm to health where it belongs.
+      console.warn('  ACLED: no credentials + GDELT fallback unavailable — no usable conflict source; publishing auxiliary feeds only, primary feed left untouched (health reports acledIntel EMPTY)');
+      return { events: [], pagination: undefined, sourceUnavailable: true };
     }
     const reason = acled.reason?.message || acled.reason;
     const err = new Error(

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -277,8 +277,14 @@ export async function fetchGdeltConflictEvents({
     // back throttled with zero successes anywhere, the remaining batches cannot succeed
     // either; they just burn the run window and deepen the limit we are already hitting.
     // (The floor check above would stop us eventually, but only after ~2× the requests.)
-    const rateLimited = results.every(r => !r?.ok && RATE_LIMIT_ERROR.test(String(r?.error ?? '')));
-    if (rateLimited && successfulCountries === 0) {
+    // A throttled batch rarely comes back UNIFORMLY 429: under load GDELT also times out and
+    // tears TLS mid-handshake, so a real storm looks like 3×429 + 1×SSL. Requiring every
+    // result to be a 429 would miss that and grind on for another batch. Trigger on the
+    // honest signal instead — the whole batch failed, nothing has succeeded anywhere, and at
+    // least one failure is an explicit rate-limit.
+    const batchAllFailed = results.every(r => !r?.ok);
+    const anyRateLimited = results.some(r => RATE_LIMIT_ERROR.test(String(r?.error ?? '')));
+    if (batchAllFailed && anyRateLimited && successfulCountries === 0) {
       const why = 'GDELT rate-limit storm (batch fully throttled, 0 successes)';
       for (const cc of remaining.slice(CONCURRENCY)) failedCountries.push({ country: cc, error: why });
       console.warn(`  [GDELT] conflict sweep backed off (${why}) after ${i + batch.length}/${CONFLICT_COUNTRIES.length} countries`);

--- a/tests/acled-resolution-feed-seed.test.mjs
+++ b/tests/acled-resolution-feed-seed.test.mjs
@@ -48,10 +48,18 @@ describe('ACLED resolution-feed seed contract (#5076)', () => {
     // Regression guard for #5106: a *missing* ACLED credential must NOT crash the
     // seed every cron tick. When creds are absent the seed runs in its long-standing
     // auxiliary-only mode — publish an empty ACLED payload and exit 0 rather than throw.
+    //
+    // #5256: returning a BARE `{ events: [], pagination: undefined }` was not enough to
+    // deliver the exit 0 this guard promises. It laundered an upstream outage into a
+    // "0 records" result, which runSeed reads as contract RETRY — and once the last-good
+    // keys expired, #5258's guard exited 1 and the seeder crash-looped forever. The
+    // payload must carry `sourceUnavailable: true` so runSeed skips the publish (an empty
+    // envelope would overwrite last-good) and exits 0. Keep the flag in the pattern:
+    // dropping it silently reinstates the crash loop.
     assert.match(conflictSeed, /missingCredentials\s*=\s*acled\.status\s*===\s*'fulfilled'/);
     assert.match(
       conflictSeed,
-      /if\s*\(\s*missingCredentials\s*\)\s*\{[\s\S]*?return\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined\s*\}/,
+      /if\s*\(\s*missingCredentials\s*\)\s*\{[\s\S]*?return\s*\{\s*events:\s*\[\],\s*pagination:\s*undefined,\s*sourceUnavailable:\s*true\s*\}/,
     );
   });
 

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -115,6 +115,36 @@ test('sourceUnavailable never publishes an empty envelope over last-good', async
   );
 });
 
+test('sourceUnavailable while last-good is STILL ALIVE: exits 0 and still says NO SOURCE', async () => {
+  // PR#5290 review (Greptile P2): the outcome is exit 0 whether or not last-good survived,
+  // but the REASON must be visible on every tick. Falling through to the generic
+  // "TTL extended, bundle will retry next cycle" message would hide the no-source condition
+  // for however many cycles the keys survive — an operator would only learn the feed had no
+  // source once it had already gone EMPTY.
+  expireResult = 1; // every key still present — TTL extension succeeds
+
+  const lines = [];
+  const [origLog, origWarn] = [console.log, console.warn];
+  console.log = (...a) => lines.push(a.join(' '));
+  console.warn = (...a) => lines.push(a.join(' '));
+  let exitCode;
+  try {
+    exitCode = await runSeedReturning({ events: [], sourceUnavailable: true }, 'no-source-alive');
+  } finally {
+    console.log = origLog;
+    console.warn = origWarn;
+  }
+  const out = lines.join('\n');
+
+  assert.equal(exitCode, 0);
+  assert.match(out, /NO SOURCE/, 'the no-source reason must be logged even while last-good is alive');
+  assert.match(out, /=== Done \(\d+ms, NO SOURCE\) ===/, 'terminal marker must name the real outcome');
+  assert.doesNotMatch(
+    out, /bundle will retry next cycle/,
+    'the generic RETRY message implies a source may come back — misleading when there is none',
+  );
+});
+
 // ─── #5258 must NOT be weakened ───
 
 test('plain zero-yield with expired last-good STILL exits 1 (#5258 intact)', async () => {
@@ -203,5 +233,61 @@ test('GDELT 429 storm: sweep aborts after the first all-throttled batch', async 
   assert.ok(
     attempted.length <= 4,
     `must stop after the first all-429 batch, not grind the limiter: attempted ${attempted.length}/${CONFLICT_COUNTRIES.length}`,
+  );
+});
+
+test('GDELT storm: aborts on a MIXED throttled batch (429 + SSL tear), not just a uniform one', async () => {
+  // PR#5290 review (Greptile P2): a real storm is rarely uniformly 429 — under load GDELT
+  // also times out and tears TLS. Requiring EVERY result to be a 429 missed that and ground
+  // on for a second batch. The signal is: whole batch failed, nothing succeeded anywhere,
+  // and at least one failure is an explicit rate-limit.
+  const attempted = [];
+  const errors = [
+    'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)',
+    'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)',
+    'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)',
+    'curl failed: curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL', // no 429 in this one
+  ];
+  const result = await fetchGdeltConflictEvents({
+    fetchCountryEvents: async (cc) => {
+      const error = errors[attempted.length % errors.length];
+      attempted.push(cc);
+      return { country: cc, ok: false, events: [], error };
+    },
+    fetchBulkEvents: async () => { throw new Error('bulk export also throttled'); },
+    pace: async () => {},
+    now: () => 0,
+    deadlineAt: 10_000_000,
+    loadPreviousSnapshot: async () => null,
+  }).catch((e) => e);
+
+  assert.ok(result instanceof Error);
+  assert.ok(
+    attempted.length <= 4,
+    `a mixed 429/SSL storm must abort on the first batch too: attempted ${attempted.length}/${CONFLICT_COUNTRIES.length}`,
+  );
+});
+
+test('GDELT storm abort does NOT fire when a country in the batch succeeds', async () => {
+  // The abort must never cut short a sweep that is actually working. One success in the
+  // batch means we are not being uniformly throttled — keep going.
+  const attempted = [];
+  await fetchGdeltConflictEvents({
+    fetchCountryEvents: async (cc) => {
+      attempted.push(cc);
+      // First country of every batch succeeds; the rest are throttled.
+      if (attempted.length % 4 === 1) return { country: cc, ok: true, events: [{ country: cc, event_date: '2026-07-13' }] };
+      return { country: cc, ok: false, events: [], error: 'HTTP 429' };
+    },
+    fetchBulkEvents: async () => { throw new Error('bulk unused'); },
+    pace: async () => {},
+    now: () => 0,
+    deadlineAt: 10_000_000,
+    loadPreviousSnapshot: async () => null,
+  }).catch(() => {});
+
+  assert.ok(
+    attempted.length > 4,
+    'a batch containing a success must not trip the storm abort',
   );
 });

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -24,7 +24,7 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { runSeed, redactProxyCredentials } from '../scripts/_seed-utils.mjs';
+import { runSeed, redactProxyCredentials, curlFetch } from '../scripts/_seed-utils.mjs';
 import { fetchAll, fetchGdeltConflictEvents, CONFLICT_COUNTRIES } from '../scripts/seed-conflict-intel.mjs';
 
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -213,6 +213,77 @@ test('redactProxyCredentials leaves credential-free text untouched', () => {
   assert.equal(redactProxyCredentials(clean), clean);
 });
 
+// The helper tests above are NOT enough: the scrubbing that actually protects us lives in a
+// catch inside curlFetch. PR#5290 review caught that reverting that catch to a bare
+// `throw err` left the whole suite green — the security fix was guarded by nothing. These
+// drive the real branch through curlFetch's `exec` seam.
+
+const PROXY_AUTH = 'spp5user:s3cr3tPassw0rd@us.decodo.com:10001';
+
+// Exactly what Node builds when the curl BINARY exits non-zero: the entire argv in .message,
+// curl's diagnostic in .stderr, and .status set to curl's EXIT CODE (not an HTTP status).
+function execFileSyncFailure({ stderr }) {
+  return () => {
+    throw Object.assign(
+      new Error(
+        'Command failed: curl -sS --compressed --max-time 15 -L '
+        + `-x http://${PROXY_AUTH} -H Accept: application/json `
+        + 'https://api.gdeltproject.org/api/v2/doc/doc?query=x',
+      ),
+      { status: 35, stderr, stdout: '' },
+    );
+  };
+}
+
+function curlFetchExpectingThrow(exec) {
+  try {
+    curlFetch('https://api.gdeltproject.org/api/v2/doc/doc?query=x', PROXY_AUTH, {}, { exec });
+  } catch (err) {
+    return err;
+  }
+  throw new Error('curlFetch should have thrown');
+}
+
+test('curlFetch: a curl-level failure never leaks proxy credentials into the error', () => {
+  const err = curlFetchExpectingThrow(execFileSyncFailure({
+    stderr: 'curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to api.gdeltproject.org:443\n',
+  }));
+
+  assert.equal(err.message.includes('s3cr3tPassw0rd'), false, 'password must never reach the logs');
+  assert.equal(err.message.includes('spp5user'), false, 'username must never reach the logs');
+  assert.match(err.message, /^curl failed: /);
+  assert.equal(err.curlFailed, true);
+  assert.match(err.message, /SSL_ERROR_SYSCALL/, "curl's own diagnostic is kept — it is the useful part");
+});
+
+test('curlFetch: credentials are scrubbed even when curl produced no stderr (message fallback)', () => {
+  // The fallback path interpolates err.message — the argv-bearing string itself. If it is
+  // not redacted on the way through, this is where the credentials escape.
+  const err = curlFetchExpectingThrow(execFileSyncFailure({ stderr: '' }));
+
+  assert.equal(err.message.includes('s3cr3tPassw0rd'), false);
+  assert.equal(err.message.includes('spp5user'), false);
+  assert.match(err.message, /\*\*\*:\*\*\*@us\.decodo\.com/, 'redacted, but the proxy host is still named');
+});
+
+test('curlFetch: a curl-level failure must NOT carry .status (it is an exit code, not HTTP)', () => {
+  // _gdelt-fetch.mjs discriminates "upstream returned non-2xx" from "network/curl failure"
+  // purely on `typeof status === 'number'`. execFileSync sets .status to curl's EXIT code
+  // (35 here), so leaking it through made the retry logic read exit-35 as an HTTP status,
+  // miss RETRYABLE_STATUSES, and refuse to retry the proxy — killing the Decodo IP rotation
+  // on exactly the TLS tears it exists to survive.
+  const err = curlFetchExpectingThrow(execFileSyncFailure({ stderr: 'curl: (35) SSL_ERROR_SYSCALL\n' }));
+  assert.equal(err.status, undefined, 'curl exit code must not masquerade as an HTTP status');
+});
+
+test('curlFetch: a genuine non-2xx HTTP response still carries .status (contract intact)', () => {
+  // The other half of the discriminator: when curl SUCCEEDS but the upstream returns 429,
+  // .status must still be set, or the retry logic loses the HTTP case entirely.
+  const err = curlFetchExpectingThrow(() => 'rate limited\n429');
+  assert.equal(err.status, 429);
+  assert.equal(err.curlFailed, undefined, 'an HTTP error is not a curl-level failure');
+});
+
 // ─── GDELT 429-storm: back off instead of hammering ───
 
 test('GDELT 429 storm: sweep aborts after the first all-throttled batch', async () => {
@@ -265,6 +336,33 @@ test('GDELT storm: aborts on a MIXED throttled batch (429 + SSL tear), not just 
   assert.ok(
     attempted.length <= 4,
     `a mixed 429/SSL storm must abort on the first batch too: attempted ${attempted.length}/${CONFLICT_COUNTRIES.length}`,
+  );
+});
+
+test('GDELT storm abort does NOT fire on an all-failed batch with NO rate-limit (SSL/timeout only)', async () => {
+  // PR#5290 review: without this, deleting `anyRateLimited` from the abort condition still
+  // passed every test. It is the clause that distinguishes "we are being throttled — backing
+  // off helps" from "transient per-country network failures — backing off just gives up
+  // early". A pure SSL/timeout wipeout must keep sweeping and let floorUnreachable decide.
+  const attempted = [];
+  await fetchGdeltConflictEvents({
+    fetchCountryEvents: async (cc) => {
+      attempted.push(cc);
+      return {
+        country: cc, ok: false, events: [],
+        error: 'curl failed: curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL', // no 429 anywhere
+      };
+    },
+    fetchBulkEvents: async () => { throw new Error('bulk unused'); },
+    pace: async () => {},
+    now: () => 0,
+    deadlineAt: 10_000_000,
+    loadPreviousSnapshot: async () => null,
+  }).catch(() => {});
+
+  assert.ok(
+    attempted.length > 4,
+    `a non-throttled wipeout must not be mislabelled a rate-limit storm and cut short: attempted ${attempted.length}`,
   );
 });
 

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -1,0 +1,207 @@
+// Regression tests for #5256: seed-conflict-intel crash-looped forever when it had
+// NO usable conflict source.
+//
+// The chain (verified in prod 2026-07-13, deployment 31cefd91): ACLED has no
+// credentials configured -> the seeder takes its long-standing auxiliary-only path
+// (#1651/#2288, whose own comment says it exists to "exit 0 rather than crashing every
+// cron tick") -> GDELT, the only fallback, is 429ing GLOBALLY (reproduced off-Railway)
+// so it yields nothing -> declareRecords returns 0 -> contract RETRY -> the last-good
+// keys expired long ago so extendExistingTtl no-ops -> #5258's guard exits 1.
+//
+// That guard is right in general (a zero-yield run whose last-good is gone IS a dead
+// feed), but it assumes a later tick can restore data. With no source configured, no
+// tick ever can: it crash-looped every ~15min forever, firing "Deploy Crashed!" each
+// time while /api/health ALREADY reported acledIntel EMPTY/crit. The crash added no
+// information over the health check — only alert fatigue.
+//
+// Fix: a seeder may declare `sourceUnavailable` on its payload. runSeed then publishes
+// NOTHING (an empty envelope would overwrite last-good the moment the source blips) and
+// exits 0. The data alarm stays where it belongs — /api/health.
+//
+// These tests lock BOTH directions: the new exit-0 escape AND that a plain zero-yield
+// run (no sourceUnavailable) still exits 1, so #5258 is not weakened.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runSeed, redactProxyCredentials } from '../scripts/_seed-utils.mjs';
+import { fetchAll, fetchGdeltConflictEvents, CONFLICT_COUNTRIES } from '../scripts/seed-conflict-intel.mjs';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_EXIT = process.exit;
+const ORIGINAL_ENV = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  ACLED_EMAIL: process.env.ACLED_EMAIL,
+  ACLED_PASSWORD: process.env.ACLED_PASSWORD,
+  ACLED_ACCESS_TOKEN: process.env.ACLED_ACCESS_TOKEN,
+};
+
+let recordedCalls;
+let expireResult;
+
+beforeEach(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+  recordedCalls = [];
+  expireResult = 0; // every key already expired — the prod state that triggered exit 1
+
+  globalThis.fetch = async (url, opts = {}) => {
+    const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
+    recordedCalls.push({ url: String(url), method: opts?.method || 'GET', body });
+    if (Array.isArray(body) && Array.isArray(body[0])) {
+      return new Response(JSON.stringify(body.map(() => ({ result: expireResult }))), { status: 200 });
+    }
+    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+  };
+
+  process.exit = (code) => {
+    const e = new Error(`__test_exit__:${code}`);
+    e.exitCode = code;
+    throw e;
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  process.exit = ORIGINAL_EXIT;
+  for (const [k, v] of Object.entries(ORIGINAL_ENV)) {
+    if (v == null) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+async function runWithExitTrap(fn) {
+  try {
+    await fn();
+    return null;
+  } catch (err) {
+    if (!String(err.message).startsWith('__test_exit__:')) throw err;
+    return err.exitCode;
+  }
+}
+
+// Did runSeed write the canonical payload key? (An empty publish would clobber last-good.)
+function publishedCanonicalKey(key) {
+  return recordedCalls.some(c =>
+    Array.isArray(c.body) && c.body[0] === 'SET' && c.body[1] === key);
+}
+
+function runSeedReturning(payload, resource) {
+  return runWithExitTrap(() =>
+    runSeed('test', resource, `test:${resource}:v1`, async () => payload, {
+      validateFn: (d) => Array.isArray(d?.events),
+      ttlSeconds: 3600,
+      sourceVersion: 'test-v1',
+      schemaVersion: 1,
+      maxStaleMin: 120,
+      declareRecords: (d) => d.events.length,
+    }),
+  );
+}
+
+// ─── the fix ───
+
+test('sourceUnavailable + expired last-good: exits 0 instead of crash-looping', async () => {
+  const exitCode = await runSeedReturning({ events: [], sourceUnavailable: true }, 'no-source');
+  assert.equal(exitCode, 0, 'a seeder with no usable source must not crash — /api/health carries the EMPTY alarm');
+});
+
+test('sourceUnavailable never publishes an empty envelope over last-good', async () => {
+  await runSeedReturning({ events: [], sourceUnavailable: true }, 'no-source-nopublish');
+  assert.equal(
+    publishedCanonicalKey('test:no-source-nopublish:v1'), false,
+    'publishing events:[] would wipe real data the next time the source merely blips',
+  );
+});
+
+// ─── #5258 must NOT be weakened ───
+
+test('plain zero-yield with expired last-good STILL exits 1 (#5258 intact)', async () => {
+  const exitCode = await runSeedReturning({ events: [] }, 'dead-feed');
+  assert.equal(exitCode, 1, 'a zero-yield run that did NOT declare sourceUnavailable is still a dead feed');
+});
+
+// ─── seeder wiring: the no-creds + GDELT-down path must declare sourceUnavailable ───
+
+test('fetchAll: no ACLED creds + GDELT fallback down -> declares sourceUnavailable', async () => {
+  delete process.env.ACLED_EMAIL;
+  delete process.env.ACLED_PASSWORD;
+  delete process.env.ACLED_ACCESS_TOKEN;
+
+  // Aux feeds (HAPI/PizzINT) 429 like prod; the GDELT fallback is injected because its
+  // proxy path shells out to curl and would otherwise escape the stub and hit the network.
+  globalThis.fetch = async () => new Response('rate limited', { status: 429 });
+
+  const data = await fetchAll({
+    fetchGdeltFallback: async () => { throw new Error('GDELT coverage below floor: 0/20; bulk fallback failed: HTTP 429'); },
+  });
+  assert.equal(Array.isArray(data.events), true);
+  assert.equal(data.events.length, 0);
+  assert.equal(
+    data.sourceUnavailable, true,
+    'an errored fallback is NOT a legitimate zero — it must be flagged so runSeed skips publish and exits 0',
+  );
+});
+
+test('fetchAll: no ACLED creds but GDELT fallback WORKS -> not sourceUnavailable', async () => {
+  delete process.env.ACLED_EMAIL;
+  delete process.env.ACLED_PASSWORD;
+  delete process.env.ACLED_ACCESS_TOKEN;
+  globalThis.fetch = async () => new Response('rate limited', { status: 429 });
+
+  const data = await fetchAll({
+    fetchGdeltFallback: async () => ({ events: [{ country: 'UA', event_date: '2026-07-13' }], source: 'gdelt' }),
+  });
+  assert.equal(data.events.length, 1);
+  assert.notEqual(
+    data.sourceUnavailable, true,
+    'a working fallback must publish normally — the exit-0 escape must not swallow real data',
+  );
+});
+
+// ─── SECURITY: proxy credentials must never reach the logs ───
+
+test('redactProxyCredentials scrubs inline proxy user:pass from surfaced errors', () => {
+  // The exact shape Node's execFileSync produced on a curl-level failure: the whole argv,
+  // proxy credentials included. This was written to Railway logs on every GDELT proxy
+  // failure during the 2026-07-13 429 storm.
+  const leaked = 'Command failed: curl -sS --compressed --max-time 15 -L '
+    + '-x http://spp5user:s3cr3tPassw0rd@us.decodo.com:10001 '
+    + '-H Accept: application/json https://api.gdeltproject.org/api/v2/doc/doc?query=x';
+
+  const safe = redactProxyCredentials(leaked);
+
+  assert.equal(safe.includes('s3cr3tPassw0rd'), false, 'password must not survive redaction');
+  assert.equal(safe.includes('spp5user'), false, 'username must not survive redaction');
+  assert.match(safe, /http:\/\/\*\*\*:\*\*\*@us\.decodo\.com:10001/, 'host:port kept — it is the useful diagnostic');
+  assert.match(safe, /api\.gdeltproject\.org/, 'target URL must survive — it is not a secret');
+});
+
+test('redactProxyCredentials leaves credential-free text untouched', () => {
+  const clean = 'curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to api.gdeltproject.org:443';
+  assert.equal(redactProxyCredentials(clean), clean);
+});
+
+// ─── GDELT 429-storm: back off instead of hammering ───
+
+test('GDELT 429 storm: sweep aborts after the first all-throttled batch', async () => {
+  const attempted = [];
+  const result = await fetchGdeltConflictEvents({
+    fetchCountryEvents: async (cc) => {
+      attempted.push(cc);
+      return { country: cc, ok: false, events: [], error: 'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)' };
+    },
+    fetchBulkEvents: async () => { throw new Error('bulk export also throttled'); },
+    pace: async () => {},
+    now: () => 0,
+    deadlineAt: 10_000_000,
+    loadPreviousSnapshot: async () => null,
+  }).catch((e) => e);
+
+  assert.ok(result instanceof Error, 'a fully throttled sweep still fails (no data)');
+  assert.ok(
+    attempted.length <= 4,
+    `must stop after the first all-429 batch, not grind the limiter: attempted ${attempted.length}/${CONFLICT_COUNTRIES.length}`,
+  );
+});


### PR DESCRIPTION
Fixes the crash loop in #5256. `seed-conflict-intel` has been exiting 1 on **every** cron tick.

## Why it crashes

1. `ACLED display: no credentials configured, skipping` — the **primary** source is off. (`VITE_ACLED_ACCESS_TOKEN` exists on the Railway service but its value is **empty**, and the seeder reads `ACLED_ACCESS_TOKEN` / `ACLED_EMAIL`+`ACLED_PASSWORD` anyway, so it would never see it.)
2. The seeder therefore takes its long-standing **auxiliary-only** path (#1651/#2288) — whose own comment says it exists to *"return an empty ACLED payload and **exit 0 rather than crashing every cron tick**"*.
3. GDELT, the only fallback, is **429ing globally**: `0/20 countries succeeded (min 16)`, direct *and* through the proxy, with the bulk export throttled behind it. I reproduced the 429 off-Railway, so this is an upstream throttle, **not our egress**.
4. So it returns 0 records → `runSeed` reads contract `RETRY` → the last-good keys expired long ago → **#5258's guard exits 1**.

Prod evidence: deployment `31cefd91`, ending `=== Done (132541ms, RETRY FAILED) ===`.

## Why that's a bug

#5258's guard is right in general — a zero-yield run whose last-good is gone **is** a dead feed. But it assumes **a later tick can restore the data**. With no source configured, no tick ever can. It crash-looped every ~15 min **forever**, firing "Deploy Crashed!" each time, while `/api/health` **already** reported `acledIntel: EMPTY` as a crit. The crash carried no information the health check didn't — only alert fatigue on the channel we need to stay trustworthy.

## The fix

A seeder may declare **`sourceUnavailable`** on its payload when it had no usable upstream at all. `runSeed` then:

- publishes **nothing** — an empty envelope would overwrite last-good the moment the source merely blips, and
- **exits 0**, leaving the data alarm to `/api/health`, where it belongs.

This is deliberately **not** `zeroIsValid`. It is opted into **per-run, on the exact code path that knows it has no source**. A zero-yield run that does *not* declare it is still a dead feed and **still exits 1** — #5258 stands, and its regression test (`contract RETRY hard-fails when expired keys make last-good preservation impossible`) still passes.

## Also in this PR

**GDELT 429 backoff.** Once a whole batch comes back throttled with zero successes anywhere, stop sweeping — the remaining batches cannot succeed, they just burn the run window and deepen the limit we're already hitting. Cuts a storm run from 8 country fetches to 4. (The existing coverage-floor check stopped it eventually, but only after ~2x the requests.)

**🔒 SECURITY — proxy credentials were leaking into Railway logs.** When **curl itself** exits non-zero (`SSL_ERROR_SYSCALL`, `CONNECT tunnel failed`), `execFileSync` builds an Error whose message is the **entire argv** — including `-x http://user:pass@proxy-host`. Seeders log that message, so the Decodo proxy credentials were written **verbatim** into Railway logs on every curl-level failure — continuously, throughout the current 429 storm. `curlFetch` is the single choke point for the GDELT, Open-Meteo and Yahoo proxy paths, so redacting there fixes all of them.

> **⚠️ The leaked credentials are in the existing Railway log history and should be rotated.**

## Tests

New `tests/seed-conflict-intel-no-source-exit0.test.mjs` (8 tests) locks **both** directions — the exit-0 escape *and* that #5258 is not weakened:

- `sourceUnavailable` + expired last-good → **exits 0**, and **never publishes** an empty envelope
- plain zero-yield (no flag) + expired last-good → **still exits 1** (#5258 intact)
- `fetchAll`: no creds + fallback down → declares `sourceUnavailable`; fallback **working** → does *not* (the escape can't swallow real data)
- GDELT 429 storm → sweep aborts after the first all-throttled batch
- `redactProxyCredentials` scrubs `user:pass@`, keeps host/port and target URL

`tests/acled-resolution-feed-seed.test.mjs` — the source-guard for the auxiliary-only path — now requires the `sourceUnavailable` flag, since that's what finally delivers the exit 0 its comment always promised. Dropping the flag silently reinstates the crash loop.

65/65 related tests pass; lint + typecheck clean.

## What this does NOT fix

Conflict data stays **EMPTY** until a source works: ACLED needs a credential, and GDELT's 429 is a global upstream outage. This PR stops the crash loop and keeps the alarm on `/api/health` — it does not conjure data. #5256 stays open for the source.

https://claude.ai/code/session_017awYYqfZ2Vrsjbb8FdfUYz