### PR TITLE
fix(feeds): bypass Nature redirect loop

### DIFF
--- a/scripts/validate-rss-feeds.mjs
+++ b/scripts/validate-rss-feeds.mjs
@@ -168,8 +168,8 @@ async function fetchFeed(url) {
     // full FETCH_TIMEOUT so "Timeout (15s)" in the report means a real
     // 15s on a single network call, not 17s+ aggregated across a chain.
     let currentUrl = assertCiAllowed(url).href;
-    const MAX_HOPS = 3;
-    for (let hop = 0; hop < MAX_HOPS; hop++) {
+    const MAX_REDIRECTS = 3;
+    for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
       let resp;
@@ -185,6 +185,7 @@ async function fetchFeed(url) {
       if (resp.status >= 300 && resp.status < 400) {
         const loc = resp.headers.get('location');
         if (!loc) throw new Error(`HTTP ${resp.status} without Location header`);
+        if (redirectCount === MAX_REDIRECTS) throw new Error(CONFIG_DRIFT_REASONS.TOO_MANY_REDIRECTS);
         const nextUrl = new URL(loc, currentUrl);
         assertCiAllowed(nextUrl.href);
         currentUrl = nextUrl.href;

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -467,7 +467,7 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
     ],
     science: [
       { name: 'ScienceDaily', url: 'https://www.sciencedaily.com/rss/all.xml' },
-      { name: 'Nature News', url: 'https://www.nature.com/nature.rss?error=cookies_not_supported' },
+      { name: 'Nature News', url: 'https://www.nature.com/nature.rss' },
       { name: 'Singularity Hub', url: 'https://singularityhub.com/feed/' },
       { name: 'Human Progress', url: 'https://humanprogress.org/feed/' },
     ],

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -467,7 +467,7 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
     ],
     science: [
       { name: 'ScienceDaily', url: 'https://www.sciencedaily.com/rss/all.xml' },
-      { name: 'Nature News', url: 'https://feeds.nature.com/nature/rss/current' },
+      { name: 'Nature News', url: 'https://www.nature.com/nature.rss?error=cookies_not_supported' },
       { name: 'Singularity Hub', url: 'https://singularityhub.com/feed/' },
       { name: 'Human Progress', url: 'https://humanprogress.org/feed/' },
     ],

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -816,7 +816,7 @@ const HAPPY_FEEDS: Record<string, Feed[]> = {
   science: [
     { name: 'GNN Science', url: rss('https://www.goodnewsnetwork.org/category/news/science/feed/') },
     { name: 'ScienceDaily', url: rss('https://www.sciencedaily.com/rss/all.xml') },
-    { name: 'Nature News', url: rss('https://www.nature.com/nature.rss?error=cookies_not_supported') },
+    { name: 'Nature News', url: rss('https://www.nature.com/nature.rss') },
     { name: 'Live Science', url: rss('https://www.livescience.com/feeds.xml') },
     { name: 'New Scientist', url: rss('https://www.newscientist.com/feed/home/') },
     { name: 'Singularity Hub', url: rss('https://singularityhub.com/feed/') },

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -816,7 +816,7 @@ const HAPPY_FEEDS: Record<string, Feed[]> = {
   science: [
     { name: 'GNN Science', url: rss('https://www.goodnewsnetwork.org/category/news/science/feed/') },
     { name: 'ScienceDaily', url: rss('https://www.sciencedaily.com/rss/all.xml') },
-    { name: 'Nature News', url: rss('https://feeds.nature.com/nature/rss/current') },
+    { name: 'Nature News', url: rss('https://www.nature.com/nature.rss?error=cookies_not_supported') },
     { name: 'Live Science', url: rss('https://www.livescience.com/feeds.xml') },
     { name: 'New Scientist', url: rss('https://www.newscientist.com/feed/home/') },
     { name: 'Singularity Hub', url: rss('https://singularityhub.com/feed/') },

--- a/tests/completeness-measurement.test.mjs
+++ b/tests/completeness-measurement.test.mjs
@@ -151,6 +151,18 @@ describe('server catalog extraction (#4920a)', () => {
     const feeds = extractServerFeeds();
     assert.ok(feeds.some((f) => f.name === "Tom's Hardware"), 'double-quoted names must not be skipped');
   });
+
+  it('uses the direct Nature RSS endpoint in both feed catalogs', () => {
+    const directNatureUrl = 'https://www.nature.com/nature.rss?error=cookies_not_supported';
+    const natureFeed = extractServerFeeds().find((feed) => feed.name === 'Nature News');
+    assert.equal(natureFeed?.url, directNatureUrl, 'server digest must avoid Nature\'s redirect-heavy legacy URL');
+
+    const clientFeeds = readSrc('src/config/feeds.ts');
+    assert.ok(
+      clientFeeds.includes(`{ name: 'Nature News', url: rss('${directNatureUrl}') }`),
+      'client catalog must use the same direct Nature RSS endpoint',
+    );
+  });
 });
 
 describe('coverage-ledger and provenance wiring (source-textual)', () => {

--- a/tests/completeness-measurement.test.mjs
+++ b/tests/completeness-measurement.test.mjs
@@ -152,15 +152,23 @@ describe('server catalog extraction (#4920a)', () => {
     assert.ok(feeds.some((f) => f.name === "Tom's Hardware"), 'double-quoted names must not be skipped');
   });
 
-  it('uses the direct Nature RSS endpoint in both feed catalogs', () => {
-    const directNatureUrl = 'https://www.nature.com/nature.rss?error=cookies_not_supported';
+  it('uses Nature\'s canonical RSS endpoint with the runtime redirect budget', () => {
+    const canonicalNatureUrl = 'https://www.nature.com/nature.rss';
     const natureFeed = extractServerFeeds().find((feed) => feed.name === 'Nature News');
-    assert.equal(natureFeed?.url, directNatureUrl, 'server digest must avoid Nature\'s redirect-heavy legacy URL');
+    assert.equal(natureFeed?.url, canonicalNatureUrl, 'server digest must use Nature\'s canonical RSS URL');
 
     const clientFeeds = readSrc('src/config/feeds.ts');
     assert.ok(
-      clientFeeds.includes(`{ name: 'Nature News', url: rss('${directNatureUrl}') }`),
-      'client catalog must use the same direct Nature RSS endpoint',
+      clientFeeds.includes(`{ name: 'Nature News', url: rss('${canonicalNatureUrl}') }`),
+      'client catalog must use the same canonical Nature RSS endpoint',
+    );
+
+    const validator = readSrc('scripts/validate-rss-feeds.mjs');
+    assert.match(validator, /const MAX_REDIRECTS = 3;/);
+    assert.match(
+      validator,
+      /for \(let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount\+\+\)/,
+      'CI validator must allow the same three redirects as the runtime RSS proxy',
     );
   });
 });

--- a/tests/news-feed-digest-rss-sniff.test.mts
+++ b/tests/news-feed-digest-rss-sniff.test.mts
@@ -30,8 +30,8 @@ describe('looksLikeRssXml: reject non-RSS bodies before they poison the cache', 
   });
 
   it('REGRESSION: accepts RSS 1.0 / RDF feeds (Nature News, Asahi, Slashdot)', () => {
-    // Real Nature News body shape — this feed is in the registry at
-    // server/worldmonitor/news/v1/_feeds.ts:418 (`feeds.nature.com/nature/rss/current`).
+    // Real Nature News body shape — the registry uses Nature's direct RSS endpoint,
+    // while the document retains the publisher's legacy rdf:about identifier.
     // Pre-fix-fix the sniff rejected this entire feed as non-RSS, even
     // though parseRssXml handles its <item> blocks correctly.
     const body = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

Feed validation no longer hard-fails on Nature's canonical RSS feed. The validator previously counted three fetch attempts while the runtime proxy allowed three redirects; it now mirrors the runtime budget, and both client and server catalogs use Nature's canonical `www.nature.com/nature.rss` URL instead of an internal error fallback.

Related: #5281, [failed Feed Validation run](https://github.com/koala73/worldmonitor/actions/runs/29270839283/job/86887828926)

## Validation

- `npm run test:feeds:ci` — 683 live feeds validated with exit code 0 against the canonical Nature URL; only third-party soft warnings remained.
- Feed completeness, RSS parsing, RSS-proxy redirect, key parity, methodology, and China feed parity suites passed.
- Repository pre-push gate — frontend/API/Convex typechecks, boundaries, Edge bundles and tests, changed tests, and version checks passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
