### PR TITLE
fix(railway): prevent skipped seeder deployments

### DIFF
--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
       - name: Require green main for scheduled alerts
         id: gate
         if: github.event_name == 'schedule'

--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -1,0 +1,37 @@
+name: Seed Freshness Monitor
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  statuses: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require green main for scheduled alerts
+        id: gate
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gate_state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
+            --jq '[.statuses[] | select(.context == "gate")] | sort_by(.updated_at) | last | .state // "missing"')
+          echo "gate_state=$gate_state"
+          if [ "$gate_state" = "success" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping seed freshness alert because main gate is $gate_state."
+          fi
+
+      - name: Check seed metadata freshness
+        if: github.event_name == 'workflow_dispatch' || steps.gate.outputs.should_run == 'true'
+        run: node scripts/check-seed-freshness.mjs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -368,6 +368,7 @@ Runs before every `git push`:
 | `feed-validation.yml` | PR (feed changes), daily cron | RSS feed reachability and validation |
 | `mcp-live-smoke.yml` | 6-hourly cron, push to main (smoke paths), manual | Anonymous strict-client walk of the production MCP surface on apex + www (capability walk, auth wall, OAuth endpoint routing — #4937/#4938 regression net) |
 | `security-audit.yml` | PR, push to main, daily cron, manual | Production dependency audits for every tracked `package-lock.json` workspace, failing on unbaselined high/critical advisories |
+| `seed-freshness-monitor.yml` | 15-minute cron, manual | Checks production seed metadata freshness after a green main gate and fails on stale seed sources |
 | `contributor-trust.yml` | PR | Gates untrusted first-time-contributor runs |
 | `deploy-gate.yml` | After Test/Typecheck/Security Audit complete | Aggregates required smoke-gate statuses onto the head SHA for branch protection |
 | `convex-deploy.yml` | Push to main, manual | Deploys Convex backend functions |

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -65,11 +65,12 @@
     "publish-python.yml",
     "publish-ruby.yml",
     "security-audit.yml",
+    "seed-freshness-monitor.yml",
     "test-linux-app.yml",
     "test.yml",
     "typecheck.yml"
   ],
-  "workflowCount": 20,
+  "workflowCount": 21,
   "freshnessSources": 35,
   "freshnessRequiredForRisk": 2,
   "feedDefinitions": 567,

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -24,6 +24,66 @@
 
 ---
 
+## Deployment safety guardrails
+
+### Watch paths are a live contract
+
+Railway stores watch paths in each service's environment configuration, not in
+the repository. The repo-side contract is
+`scripts/audit-railway-watch-paths.mjs`: every WorldMonitor Railway seeder,
+including Dockerfile and repo-root services, must either have no watch filter
+(watch the whole repo) or include both `scripts/**` and `shared/**`. Enumerating
+the current entry file and known helpers is unsafe because the next helper can
+be added without updating the dashboard list.
+
+After linking the CLI to the `world-monitor` production environment, audit the
+live settings with:
+
+```bash
+node scripts/audit-railway-watch-paths.mjs
+```
+
+To reconcile only drifted seeders and verify the read-back:
+
+```bash
+node scripts/audit-railway-watch-paths.mjs --apply
+```
+
+The apply mode changes only `build.watchPatterns`, preserves any existing paths
+outside those broad directories, uses one environment config commit, and waits
+for Railway's eventually consistent config read-back before reporting success.
+Run the audit after adding or replacing a standalone seeder.
+
+### Merged does not mean deployed
+
+`.github/workflows/seed-freshness-monitor.yml` runs every 15 minutes on the
+default branch. It first requires the latest `main` commit's `gate` status to
+be green, then checks public compact health and fails when any seed metadata is
+older than its `maxStaleMin` threshold (`STALE_SEED`). This is the alert for the
+"green main, stale Railway image" gap; the existing compact health monitor
+continues to cover critical `EMPTY`/`EMPTY_DATA` and Redis failures.
+
+Do not use `railway redeploy` to recover a bad or stale source deployment.
+Railway documents redeploy as rebuilding the most recent deployment with the
+same code, so it cannot pick up a newer fixed commit. From a clean checkout
+whose `HEAD` equals current `origin/main`, upload the current source instead:
+
+```bash
+git fetch origin
+git rev-parse HEAD
+git rev-parse origin/main
+railway up --service <service-name> --environment production --detach
+```
+
+Alternatively, Railway's dashboard **Deploy Latest Commit** action deploys the
+latest commit from the service's default GitHub branch. After either recovery
+path, verify the deployment commit SHA and the relevant compact-health problem
+have both advanced. See Railway's official
+[redeploy CLI reference](https://docs.railway.com/cli/redeploy) and
+[deployment actions reference](https://docs.railway.com/deployments/deployment-actions).
+
+---
+
 ## How It Works
 
 Each "bundle" is a single Railway cron service that replaces N individual services. The bundle script spawns each member seed sequentially via `child_process.execFile`, checking Redis `seed-meta:` timestamps to skip seeds that ran recently. Original seed scripts are unchanged.

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -1,0 +1,92 @@
+---
+title: Railway seeder watch paths can skip deployments
+date: 2026-07-13
+category: integration-issues
+module: railway-seeders
+problem_type: integration_issue
+component: development_workflow
+symptoms:
+  - "A seeder helper changed on green main, but Railway kept running an older source deployment"
+  - "Seed metadata became stale even though the repository fix had merged"
+root_cause: config_error
+resolution_type: workflow_improvement
+severity: high
+tags: [railway, seeders, watch-paths, deployment, health-monitoring]
+---
+
+# Railway seeder watch paths can skip deployments
+
+## Problem
+
+Railway watch paths are live service configuration rather than repository
+configuration. A seeder that enumerates its current entry point and helper files
+can therefore miss a newly added transitive dependency: main is green, but the
+service never builds the commit that changed its behavior.
+
+## Symptoms
+
+- The repository contains the fix while the running Railway deployment still
+  points at an older commit.
+- Compact health reports `STALE_SEED` after the affected producer misses enough
+  scheduled runs.
+- A data key may expire before the staleness threshold and surface through the
+  existing `EMPTY` health alert instead.
+
+## What Didn't Work
+
+- Adding only the newly missed helper to the watch list fixes one deployment but
+  leaves the same failure mode for the next helper.
+- `railway redeploy` rebuilds the most recent deployment with the same source;
+  it does not select a newer commit from main.
+- Treating a healthy compact-health response without a `problems` field as
+  malformed creates a false alert. The endpoint intentionally omits that field
+  when there are no problems.
+
+## Solution
+
+Use directory-level watch paths as the repository contract:
+
+```text
+scripts/**
+shared/**
+```
+
+For services rooted at `scripts`, replace non-empty enumerated filters with
+exactly those two patterns. For repo-root and Docker services, preserve required
+paths outside those directories, such as Dockerfiles or server helpers, and add
+the two broad patterns.
+
+The live guard is `scripts/audit-railway-watch-paths.mjs`. Its audit mode reports
+drift; `--apply` sends one minimal environment-config patch and waits for the
+eventually consistent read-back before succeeding. The separate
+`scripts/check-seed-freshness.mjs` probe fails only for `STALE_SEED` problems and
+accepts the healthy compact response shape where `problems` is absent.
+
+## Why This Works
+
+The watch contract now follows dependency boundaries rather than today's import
+list, so a new helper under either shared directory triggers a deployment
+without another dashboard edit. Live introspection covers Nixpacks, repo-root,
+and Dockerfile seed services, while read-back verification prevents a Railway
+CLI no-op from being mistaken for a successful mutation.
+
+The scheduled workflow checks freshness only after the current main commit has
+a successful `gate` status. That separates a code failure from the operational
+case this guard targets: repository checks are green while a Railway producer is
+still stale.
+
+## Prevention
+
+- Run `node scripts/audit-railway-watch-paths.mjs` after adding or replacing a
+  Railway seeder.
+- Keep the healthy compact-response case in monitor tests; absence of
+  `problems` is success when `status` is `HEALTHY`.
+- Recover stale source deployments with a clean current-main `railway up` or
+  Railway's **Deploy Latest Commit** action, then verify both deployment SHA and
+  compact health.
+- Keep operational details in
+  `docs/railway-seed-consolidation-runbook.md` aligned with the executable audit.
+
+## Related Issues
+
+- [Issue #5288](https://github.com/koala73/worldmonitor/issues/5288)

--- a/scripts/audit-railway-watch-paths.mjs
+++ b/scripts/audit-railway-watch-paths.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const REQUIRED_WATCH_PATTERNS = Object.freeze(['scripts/**', 'shared/**']);
+
+const REPOSITORY = 'koala73/worldmonitor';
+const SEED_COMMAND_RE = /^node\s+(?:\.\/)?(?:scripts\/)?(?:seed-[^\s]+|fetch-gpsjam\.mjs)(?:\s|$)/;
+const SEED_DOCKERFILE_RE = /(?:^|\/)Dockerfile\.(?:seed-[^/\s]+|digest-notifications)$/;
+
+function normalizeRootDirectory(value) {
+  return typeof value === 'string' ? value.replace(/^\/+|\/+$/g, '') : '';
+}
+
+function isSeederService(service) {
+  return service?.source?.repo === REPOSITORY
+    && (
+      SEED_COMMAND_RE.test(service?.deploy?.startCommand || '')
+      || SEED_DOCKERFILE_RE.test(service?.build?.dockerfilePath || '')
+    );
+}
+
+export function auditRailwayWatchPaths(config) {
+  const services = config?.services;
+  if (!services || typeof services !== 'object' || Array.isArray(services)) {
+    throw new Error('Railway environment config must contain a services object');
+  }
+
+  return Object.entries(services)
+    .filter(([, service]) => isSeederService(service))
+    .flatMap(([serviceId, service]) => {
+      const watchPatterns = service?.build?.watchPatterns;
+      // Railway omits this field when no filter is configured. Missing and an
+      // explicit [] both mean "watch the whole repository".
+      if (watchPatterns == null) return [];
+      if (!Array.isArray(watchPatterns)) {
+        return [{
+          serviceId,
+          startCommand: service?.deploy?.startCommand || '',
+          missingPatterns: [...REQUIRED_WATCH_PATTERNS],
+          extraPatterns: [],
+        }];
+      }
+
+      // An empty list means Railway watches the whole repository, which is
+      // broader than this contract and therefore cannot miss a helper change.
+      if (watchPatterns.length === 0) return [];
+
+      const missingPatterns = REQUIRED_WATCH_PATTERNS.filter(
+        (pattern) => !watchPatterns.includes(pattern),
+      );
+      const scriptsRoot = normalizeRootDirectory(service?.source?.rootDirectory) === 'scripts';
+      const extraPatterns = scriptsRoot
+        ? watchPatterns.filter((pattern) => !REQUIRED_WATCH_PATTERNS.includes(pattern))
+        : [];
+      const canonicalScriptsRoot = scriptsRoot
+        && watchPatterns.length === REQUIRED_WATCH_PATTERNS.length
+        && missingPatterns.length === 0;
+      if (missingPatterns.length === 0 && (!scriptsRoot || canonicalScriptsRoot)) return [];
+
+      return [{
+        serviceId,
+        startCommand: service?.deploy?.startCommand || service?.build?.dockerfilePath || '',
+        missingPatterns,
+        extraPatterns,
+      }];
+    })
+    .sort((a, b) => a.serviceId.localeCompare(b.serviceId));
+}
+
+export function buildRailwayWatchPathPatch(config) {
+  const services = Object.fromEntries(
+    auditRailwayWatchPaths(config).map(({ serviceId }) => [
+      serviceId,
+      {
+        build: {
+          watchPatterns:
+            normalizeRootDirectory(config.services[serviceId]?.source?.rootDirectory) === 'scripts'
+              ? [...REQUIRED_WATCH_PATTERNS]
+              : [
+                ...(Array.isArray(config.services[serviceId]?.build?.watchPatterns)
+                  ? config.services[serviceId].build.watchPatterns
+                  : []),
+                ...REQUIRED_WATCH_PATTERNS.filter(
+                  (pattern) => !config.services[serviceId]?.build?.watchPatterns?.includes?.(pattern),
+                ),
+              ],
+        },
+      },
+    ]),
+  );
+  return { services };
+}
+
+export function buildRailwayEditArgs(config) {
+  // Calling audit here keeps this helper honest: an empty patch must not be
+  // sent through the mutation path.
+  if (auditRailwayWatchPaths(config).length === 0) return [];
+  return [
+    'environment',
+    'edit',
+    '--message',
+    'ops: enforce broad seeder watch paths (#5288)',
+    '--json',
+  ];
+}
+
+export function serializeRailwayWatchPathPatch(config) {
+  // Railway's JSON stdin parser requires a record terminator before it moves
+  // on to the apply confirmation. Without the newline it exits 0 with a no-op.
+  return `${JSON.stringify(buildRailwayWatchPathPatch(config))}\n`;
+}
+
+function runRailway(args, options = {}) {
+  const result = spawnSync('railway', args, {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `railway ${args.join(' ')} failed (${result.status}): ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout;
+}
+
+function readEnvironmentConfig() {
+  return JSON.parse(runRailway(['environment', 'config', '--json']));
+}
+
+export async function waitForRailwayWatchPathConvergence(
+  readConfig,
+  {
+    attempts = 5,
+    delayMs = 1_000,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  } = {},
+) {
+  let remaining = [];
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    remaining = auditRailwayWatchPaths(readConfig());
+    if (remaining.length === 0 || attempt === attempts) return remaining;
+    await sleep(delayMs);
+  }
+  return remaining;
+}
+
+function printAudit(drift) {
+  if (drift.length === 0) {
+    console.log('Railway watch-path audit passed: every scoped seeder watches scripts/** and shared/** (or the whole repository).');
+    return;
+  }
+
+  console.error(`Railway watch-path audit found ${drift.length} narrow seeder service(s):`);
+  for (const entry of drift) {
+    const details = [
+      entry.missingPatterns.length > 0 ? `missing ${entry.missingPatterns.join(', ')}` : '',
+      entry.extraPatterns.length > 0 ? `replace enumerated ${entry.extraPatterns.join(', ')}` : '',
+    ].filter(Boolean).join('; ');
+    console.error(
+      `- ${entry.serviceId} (${entry.startCommand}): ${details}`,
+    );
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const config = readEnvironmentConfig();
+  const drift = auditRailwayWatchPaths(config);
+  printAudit(drift);
+
+  if (drift.length === 0) return;
+  if (!apply) {
+    process.exitCode = 1;
+    return;
+  }
+
+  runRailway(buildRailwayEditArgs(config), {
+    input: serializeRailwayWatchPathPatch(config),
+  });
+
+  const remaining = await waitForRailwayWatchPathConvergence(readEnvironmentConfig);
+  if (remaining.length > 0) {
+    printAudit(remaining);
+    throw new Error('Railway accepted the patch but watch-path drift remains');
+  }
+  console.log(`Applied and verified broad watch paths for ${drift.length} Railway seeder service(s).`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -41,7 +41,7 @@ async function main() {
   const payload = await response.json();
   const staleSeeds = findStaleSeedProblems(payload);
   if (staleSeeds.length === 0) {
-    console.log(`Seed freshness healthy at ${payload.checkedAt || 'unknown time'}: no STALE_SEED checks.`);
+    console.log(`Seed freshness healthy at ${payload.checkedAt || 'unknown time'}: no STALE_SEED problems.`);
     return;
   }
 

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_HEALTH_URL = 'https://api.worldmonitor.app/api/health?compact=1';
+
+export function validateCompactHealthPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Compact health payload must be an object');
+  }
+  // Compact health omits `problems` entirely when every check is healthy.
+  if (payload.problems == null && payload.status === 'HEALTHY') return payload;
+  if (!payload.problems || typeof payload.problems !== 'object' || Array.isArray(payload.problems)) {
+    throw new Error('Compact health payload must contain a problems object');
+  }
+  return payload;
+}
+
+export function findStaleSeedProblems(payload) {
+  validateCompactHealthPayload(payload);
+  return Object.entries(payload.problems ?? {})
+    .filter(([, problem]) => problem?.status === 'STALE_SEED')
+    .map(([name, problem]) => ({
+      name,
+      seedAgeMin: problem.seedAgeMin,
+      maxStaleMin: problem.maxStaleMin,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function main() {
+  const healthUrl = process.env.HEALTH_URL || DEFAULT_HEALTH_URL;
+  const response = await fetch(healthUrl, {
+    headers: { 'User-Agent': 'worldmonitor-seed-freshness-monitor/1.0' },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Compact health request failed: HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const staleSeeds = findStaleSeedProblems(payload);
+  if (staleSeeds.length === 0) {
+    console.log(`Seed freshness healthy at ${payload.checkedAt || 'unknown time'}: no STALE_SEED checks.`);
+    return;
+  }
+
+  console.error(`Seed freshness alert: ${staleSeeds.length} seed(s) exceeded maxStaleMin.`);
+  for (const seed of staleSeeds) {
+    console.error(`- ${seed.name}: age=${seed.seedAgeMin}m max=${seed.maxStaleMin}m`);
+  }
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  REQUIRED_WATCH_PATTERNS,
+  auditRailwayWatchPaths,
+  buildRailwayEditArgs,
+  buildRailwayWatchPathPatch,
+  serializeRailwayWatchPathPatch,
+  waitForRailwayWatchPathConvergence,
+} from '../scripts/audit-railway-watch-paths.mjs';
+
+function service({
+  rootDirectory = 'scripts',
+  startCommand = 'node seed-example.mjs',
+  watchPatterns = [],
+  repo = 'koala73/worldmonitor',
+  dockerfilePath,
+} = {}) {
+  return {
+    source: { repo, rootDirectory },
+    build: { watchPatterns, dockerfilePath },
+    deploy: { startCommand },
+  };
+}
+
+describe('Railway watch-path audit', () => {
+  it('flags WorldMonitor seeders that enumerate files without both broad paths', () => {
+    const watchesEverythingByOmission = service();
+    delete watchesEverythingByOmission.build.watchPatterns;
+    const config = {
+      services: {
+        narrow: service({
+          watchPatterns: [
+            'scripts/seed-example.mjs',
+            'scripts/_seed-utils.mjs',
+            'shared/**',
+          ],
+        }),
+        broad: service({ watchPatterns: ['scripts/**', 'shared/**'] }),
+        broadWithEnumeration: service({
+          watchPatterns: ['scripts/seed-example.mjs', 'scripts/**', 'shared/**'],
+        }),
+        watchesEverything: service({ watchPatterns: [] }),
+        watchesEverythingByOmission,
+        bundleNarrow: service({
+          startCommand: 'node seed-bundle-example.mjs',
+          watchPatterns: ['scripts/seed-bundle-example.mjs', 'shared/**'],
+        }),
+        rootRepoNarrow: service({
+          rootDirectory: '',
+          startCommand: 'node scripts/seed-digest-notifications.mjs',
+          watchPatterns: ['Dockerfile.digest-notifications', 'shared/**'],
+        }),
+        dockerSeederNarrow: service({
+          rootDirectory: '',
+          startCommand: '',
+          dockerfilePath: 'Dockerfile.seed-bundle-portwatch-port-activity',
+          watchPatterns: ['Dockerfile.seed-bundle-portwatch-port-activity', 'shared/**'],
+        }),
+        worker: service({
+          startCommand: 'node process-simulation-tasks.mjs --once',
+          watchPatterns: ['scripts/process-simulation-tasks.mjs'],
+        }),
+        otherRepo: service({
+          repo: 'example/other',
+          watchPatterns: ['scripts/seed-example.mjs'],
+        }),
+      },
+    };
+
+    assert.deepEqual(
+      auditRailwayWatchPaths(config).map(({ serviceId, missingPatterns, extraPatterns }) => ({
+        serviceId,
+        missingPatterns,
+        extraPatterns,
+      })),
+      [
+        { serviceId: 'broadWithEnumeration', missingPatterns: [], extraPatterns: ['scripts/seed-example.mjs'] },
+        { serviceId: 'bundleNarrow', missingPatterns: ['scripts/**'], extraPatterns: ['scripts/seed-bundle-example.mjs'] },
+        { serviceId: 'dockerSeederNarrow', missingPatterns: ['scripts/**'], extraPatterns: [] },
+        { serviceId: 'narrow', missingPatterns: ['scripts/**'], extraPatterns: ['scripts/seed-example.mjs', 'scripts/_seed-utils.mjs'] },
+        { serviceId: 'rootRepoNarrow', missingPatterns: ['scripts/**'], extraPatterns: [] },
+      ],
+    );
+  });
+
+  it('builds a minimal service-config patch for only the drifted services', () => {
+    const config = {
+      services: {
+        narrow: service({ watchPatterns: ['scripts/seed-example.mjs', 'shared/**'] }),
+        broad: service({ watchPatterns: ['scripts/**', 'shared/**'] }),
+        rootRepo: service({
+          rootDirectory: '',
+          startCommand: 'node scripts/seed-digest-notifications.mjs',
+          watchPatterns: ['Dockerfile.digest-notifications', 'shared/**'],
+        }),
+      },
+    };
+
+    assert.deepEqual(buildRailwayWatchPathPatch(config), {
+      services: {
+        narrow: {
+          build: { watchPatterns: REQUIRED_WATCH_PATTERNS },
+        },
+        rootRepo: {
+          build: {
+            watchPatterns: [
+              'Dockerfile.digest-notifications',
+              'shared/**',
+              'scripts/**',
+            ],
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(buildRailwayEditArgs(config), [
+      'environment',
+      'edit',
+      '--message',
+      'ops: enforce broad seeder watch paths (#5288)',
+      '--json',
+    ]);
+    assert.ok(serializeRailwayWatchPathPatch(config).endsWith('\n'));
+    assert.deepEqual(
+      JSON.parse(serializeRailwayWatchPathPatch(config)),
+      buildRailwayWatchPathPatch(config),
+    );
+  });
+
+  it('allows Railway environment config read-back to converge after a commit', async () => {
+    const narrow = {
+      services: {
+        example: service({ watchPatterns: ['scripts/seed-example.mjs', 'shared/**'] }),
+      },
+    };
+    const broad = {
+      services: {
+        example: service({ watchPatterns: ['scripts/**', 'shared/**'] }),
+      },
+    };
+    const snapshots = [narrow, narrow, broad];
+    let reads = 0;
+    let sleeps = 0;
+
+    const remaining = await waitForRailwayWatchPathConvergence(
+      () => snapshots[Math.min(reads++, snapshots.length - 1)],
+      { attempts: 3, delayMs: 0, sleep: async () => { sleeps += 1; } },
+    );
+
+    assert.deepEqual(remaining, []);
+    assert.equal(reads, 3);
+    assert.equal(sleeps, 2);
+  });
+});

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  findStaleSeedProblems,
+  validateCompactHealthPayload,
+} from '../scripts/check-seed-freshness.mjs';
+
+describe('scheduled seed freshness monitor', () => {
+  it('alerts only when seed metadata has exceeded maxStaleMin', () => {
+    const payload = {
+      status: 'UNHEALTHY',
+      checkedAt: '2026-07-13T17:45:19.746Z',
+      summary: { total: 4, ok: 0, warn: 2, onDemandWarn: 0, staleContent: 0, crit: 2 },
+      problems: {
+        wildfire: { status: 'STALE_SEED', seedAgeMin: 361, maxStaleMin: 360 },
+        frozenFeed: { status: 'STALE_CONTENT', contentAgeMin: 91, maxContentAgeMin: 90 },
+        emptyFeed: { status: 'EMPTY', records: 0, maxStaleMin: 180 },
+        failedFeed: { status: 'SEED_ERROR', records: 1, maxStaleMin: 120 },
+      },
+    };
+
+    assert.deepEqual(findStaleSeedProblems(payload), [
+      {
+        name: 'wildfire',
+        seedAgeMin: 361,
+        maxStaleMin: 360,
+      },
+    ]);
+  });
+
+  it('rejects payloads that cannot prove compact seed freshness', () => {
+    assert.throws(() => validateCompactHealthPayload(null), /object/);
+    assert.deepEqual(findStaleSeedProblems({ status: 'HEALTHY' }), []);
+    assert.throws(() => validateCompactHealthPayload({ status: 'WARNING' }), /problems/);
+    assert.throws(
+      () => validateCompactHealthPayload({ status: 'HEALTHY', problems: [] }),
+      /problems/,
+    );
+  });
+
+  it('runs on a schedule, skips non-green main, and invokes the monitor script', () => {
+    const workflow = readFileSync(
+      new URL('../.github/workflows/seed-freshness-monitor.yml', import.meta.url),
+      'utf8',
+    );
+
+    assert.match(workflow, /schedule:/);
+    assert.match(workflow, /cron:\s*['"]\*\/15 \* \* \* \*['"]/);
+    assert.match(workflow, /context\s*==\s*"gate"/);
+    assert.match(workflow, /gate_state.*success/s);
+    assert.match(workflow, /node scripts\/check-seed-freshness\.mjs/);
+  });
+});

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -48,6 +48,8 @@ describe('scheduled seed freshness monitor', () => {
 
     assert.match(workflow, /schedule:/);
     assert.match(workflow, /cron:\s*['"]\*\/15 \* \* \* \*['"]/);
+    assert.match(workflow, /actions\/setup-node@[a-f0-9]+/);
+    assert.match(workflow, /node-version:\s*['"]24['"]/);
     assert.match(workflow, /context\s*==\s*"gate"/);
     assert.match(workflow, /gate_state.*success/s);
     assert.match(workflow, /node scripts\/check-seed-freshness\.mjs/);


### PR DESCRIPTION
## Summary

Railway seeder changes can no longer be silently skipped because a service enumerated yesterday's dependency files. The live production configuration has been reconciled: `scripts`-root seeders use the two broad directory watches, while repo-root and Docker seeders retain required Docker/server paths and add broad script coverage.

A scheduled monitor now distinguishes the operational gap this incident exposed: the current `main` commit is green, but seed metadata is stale. It consumes the public compact-health contract, including the healthy response shape where `problems` is omitted.

The runbook also makes recovery explicit: `railway redeploy` rebuilds the same source deployment, so a stale image must be replaced with a clean current-main `railway up` or Railway's **Deploy Latest Commit** action.

Fixes #5288

## Validation

- Pre-push gate passed: frontend/API/Convex typechecks, CJS and edge bundle checks, Unicode/boundary/safe-HTML/rate-limit/premium-fetch guards, focused tests, markdown lint, and version sync.
- Focused regression suite: 6 tests passed for live-config classification/patching, eventual-consistency read-back, compact-health contracts, and workflow wiring.
- Live production audit: zero Railway seeder watch-path drift after reconciliation.
- Live public health probe: no `STALE_SEED` checks at validation time.
- `npm run lint` passed with existing repository warnings only; no changed-file diagnostics.
- The broad `npm run test:data` command hit the local `tsx` IPC `EPERM` failure; its `node --import tsx --test` fallback later deadlocked in unrelated tests. The scoped suite and repository pre-push gate completed successfully.

## Post-Deploy Monitoring & Validation

- Logs/searches: watch the **Seed Freshness Monitor** workflow for `Seed freshness alert`; inspect Railway deployment/build logs for the named stale producer; run `node scripts/audit-railway-watch-paths.mjs` from a production-linked CLI.
- Metrics/surfaces: monitor `https://api.worldmonitor.app/api/health?compact=1`, especially `STALE_SEED`, `seedAgeMin`, and `maxStaleMin`; compare the affected Railway deployment SHA with current `main`.
- Healthy signals: the latest `main` `gate` status is `success`, the scheduled workflow is green, the audit reports zero drift, and compact health has no `STALE_SEED` problems.
- Failure/mitigation: any stale-seed workflow failure or new audit drift requires identifying the missed producer and deploying current `main` with `railway up` or **Deploy Latest Commit**. Do not use `railway redeploy` for a stale source snapshot.
- Rollback trigger: if the new workflow produces a verified contract false positive, disable/revert the scheduled monitor while correcting its parser; keep the broad live watch paths because narrowing them restores the original failure mode.
- Validation window/owner: repository maintainer or on-call watches the next 24 hours and the next scheduled run of any affected producer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
