### PR TITLE
fix(natural): correct HKO health and cyclone wind fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,8 @@ Heavy checks (`test:data`, typechecks, edge-bundle) must run **sequentially** in
 ## Shipping Velocity (Agent Workflow)
 
 - **Before starting work on an issue:** check for parallel/duplicate work first — `gh pr list --search "<issue#>"` AND `git worktree list` (background codex/claude sessions ship PRs under the same account).
-- **After pushing a PR:** don't sleep-poll CI. Enable auto-merge (`gh pr merge <n> --auto --squash` — repo has auto-merge enabled) and/or start `gh pr checks <n> --watch` as a background task; act only when it exits.
+- **Merge authority is explicit and non-delegable:** never merge a PR, enable auto-merge, queue a merge, or run any equivalent GitHub merge action unless the user has explicitly requested that specific action in the current conversation. A request to implement, ship, push, create a PR, or monitor CI does **not** authorize merging. Wait for clear approval and report the ready state instead.
+- **After pushing a PR:** do not sleep-poll CI. Start `gh pr checks <n> --watch` as a background task, or report the current check state; never turn on auto-merge without the explicit approval above.
 - **docs/plans/ is gitignored** — plan documents are local working state and do not travel between worktrees or ship in PRs.
 - **PR-review verification:** never assert a finding is fixed/stale from memory — re-fetch the PR head SHA and diff the cited lines first.
 

--- a/api/health.js
+++ b/api/health.js
@@ -152,6 +152,7 @@ const BOOTSTRAP_KEYS = {
 
 const STANDALONE_KEYS = {
   chinaCoverage:      CHINA_COVERAGE_SUMMARY_KEY,
+  hkoWarnings:        'weather:hko-warnings:v1',
   // #4920 completeness measurement (daily GH Actions publishers) — ops
   // keys: health-monitored but NOT bootstrap-hydrated into page loads.
   newsFeedHealth:    'news:feed-health:v1',
@@ -335,7 +336,7 @@ const SEED_META = {
   gulfQuotes:       { key: 'seed-meta:market:gulf-quotes',      maxStaleMin: 30 },
   stablecoinMarkets:{ key: 'seed-meta:market:stablecoins',      maxStaleMin: 60 },
   naturalEvents:    { key: 'seed-meta:natural:events',          maxStaleMin: 540 }, // 3h Railway climate bundle; 3x cadence preserves a full missed run.
-  hkoWarnings:      { key: 'seed-meta:weather:hko-warnings',    maxStaleMin: 540 }, // written by the natural-event seed's successful HKO extra-key publish.
+  hkoWarnings:      { key: 'seed-meta:weather:hko-warnings',    maxStaleMin: 540 }, // successful HKO responses publish a snapshot even when no tropical-cyclone warning is active.
   flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 90 }, // CACHE_TTL=7200s; matches notamClosures from same cron
   notamClosures:    { key: 'seed-meta:aviation:notam',          maxStaleMin: 240 }, // 2h interval; 240min = 2x interval
   predictionMarkets: { key: 'seed-meta:prediction:markets',     maxStaleMin: 90 },

--- a/scripts/natural/western-pacific-cyclones.mjs
+++ b/scripts/natural/western-pacific-cyclones.mjs
@@ -30,6 +30,8 @@ const PROXIMITY_MATCH_MAX_DISTANCE_KM = 90;
 const PROXIMITY_MATCH_MAX_AGE_MS = 3 * 60 * 60 * 1000;
 
 function asFiniteNumber(value) {
+  if ((typeof value !== 'number' && typeof value !== 'string')
+    || (typeof value === 'string' && value.trim() === '')) return null;
   const number = Number(value);
   return Number.isFinite(number) ? number : null;
 }
@@ -149,7 +151,9 @@ function canonicalIdFor(observations) {
 
 function toCanonicalCyclone(observations, confidence) {
   const active = observations.filter((observation) => observation.status !== 'cancelled');
-  const primary = [...(active.length > 0 ? active : observations)].sort(observationOrder)[0];
+  const ranked = [...(active.length > 0 ? active : observations)].sort(observationOrder);
+  const primary = ranked[0];
+  const windObservation = ranked.find((observation) => observation.windKt != null) || primary;
   const allAliases = [...new Set(observations.flatMap((observation) => observation.aliases))].sort();
   return {
     id: `cyclone:${canonicalIdFor(observations)}`,
@@ -162,8 +166,8 @@ function toCanonicalCyclone(observations, confidence) {
     lat: primary.lat,
     lon: primary.lon,
     observedAt: primary.observedAt,
-    windKt: primary.windKt,
-    windAveragingPeriodMinutes: primary.windAveragingPeriodMinutes,
+    windKt: windObservation.windKt,
+    windAveragingPeriodMinutes: windObservation.windAveragingPeriodMinutes,
     pressureMb: primary.pressureMb,
     classification: primary.classification,
     sourceName: primary.sourceName,

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -210,6 +210,22 @@ test('issue #5055: validated seed-meta writers are registered in /api/health', (
   }
 });
 
+test('HKO warning snapshots are classified through their matching seed-meta key', () => {
+  assert.equal(STANDALONE_KEYS.hkoWarnings, 'weather:hko-warnings:v1');
+  assert.deepEqual(SEED_META.hkoWarnings, {
+    key: 'seed-meta:weather:hko-warnings',
+    maxStaleMin: 540,
+  });
+
+  const entry = classifyKey('hkoWarnings', STANDALONE_KEYS.hkoWarnings, { allowOnDemand: true },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.hkoWarnings]: 1024 },
+      metaValues: { 'seed-meta:weather:hko-warnings': seedMeta({ recordCount: 1 }) },
+    }));
+
+  assert.equal(entry.status, 'OK');
+});
+
 test('classifyKey: issue #5055 strict seeds surface missing metadata instead of reporting OK', () => {
   const entry = classifyKey('energyPrices', STANDALONE_KEYS.energyPrices, { allowOnDemand: true },
     makeCtx({ strens: { [STANDALONE_KEYS.energyPrices]: 2048 } }));

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -70,6 +70,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'intermediate: seed-to-seed pipeline key, only populated after seed-military-flights runs (matches api/health.js:463 ON_DEMAND_KEYS rationale).'],
   ['intelligence:military-cii:v1',
     'intermediate: per-country military-presence aggregate (own/foreign flights+vessels, AIS disruption buckets) read by server/worldmonitor/intelligence/v1/get-risk-scores.ts to feed the CII Security component; surfaces transitively via the country-risk score returned by get_country_risk. Not a queryable MCP slice on its own.'],
+  ['weather:hko-warnings:v1',
+    'intermediate: dedicated HKO warning snapshot is independently health-monitored, while its warning events are merged into natural:events:v1 and exposed by get_natural_disasters. The raw side snapshot has no separate MCP schema or filter surface.'],
 
   // ===========================================================================
   // Cascade-mirror fallbacks (live/stale/backup of a sibling already exposed)

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -16,6 +16,7 @@ const ORIGINAL_ENV = {
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
 };
+const ORIGINAL_SIGTERM_LISTENERS = new Set(process.rawListeners('SIGTERM'));
 
 let recordedCalls;
 let expireResult;
@@ -52,6 +53,9 @@ afterEach(() => {
   else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.UPSTASH_REDIS_REST_URL;
   if (ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
   else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN;
+  for (const listener of process.rawListeners('SIGTERM')) {
+    if (!ORIGINAL_SIGTERM_LISTENERS.has(listener)) process.removeListener('SIGTERM', listener);
+  }
 });
 
 function countMetaSets(resourceSuffix) {
@@ -60,6 +64,14 @@ function countMetaSets(resourceSuffix) {
     && c.body[0] === 'SET'
     && typeof c.body[1] === 'string'
     && c.body[1] === `seed-meta:test:${resourceSuffix}`,
+  ).length;
+}
+
+function countSetsFor(key) {
+  return recordedCalls.filter(c =>
+    Array.isArray(c.body)
+    && c.body[0] === 'SET'
+    && c.body[1] === key,
   ).length;
 }
 
@@ -179,6 +191,64 @@ test('validation failure WITHOUT emptyDataIsFailure DOES refresh seed-meta (quie
     countMetaSets('empty-legacy') >= 1,
     'legacy behavior for quiet-period feeds (news, events) must still write ' +
     'seed-meta count=0 so health does not false-positive STALE_SEED',
+  );
+});
+
+test('contract extra keys publish their explicit seed-meta after a successful write', async () => {
+  const exitCode = await runWithExitTrap(() => runSeed('test', 'extra-meta-success', 'test:extra-meta-success:v1', async () => ({
+    events: [{ id: 'canonical' }],
+    warnings: [{ id: 'warning' }],
+  }), {
+    validateFn: (data) => Array.isArray(data?.events),
+    ttlSeconds: 3600,
+    sourceVersion: 'test-v1',
+    schemaVersion: 1,
+    maxStaleMin: 120,
+    declareRecords: (data) => data.events.length,
+    extraKeys: [{
+      key: 'test:extra-meta-success:warnings',
+      transform: (data) => data.warnings,
+      declareRecords: (warnings) => warnings.length,
+      metaKey: 'seed-meta:test:extra-meta-success:warnings',
+      metaCritical: true,
+      skipWhenEmpty: true,
+    }],
+  }));
+
+  assert.equal(exitCode, 0);
+  assert.equal(
+    countSetsFor('seed-meta:test:extra-meta-success:warnings'),
+    1,
+    'a published extra key must refresh its explicit seed-meta key',
+  );
+});
+
+test('skipWhenEmpty preserves the last-good extra key without refreshing its seed-meta', async () => {
+  const exitCode = await runWithExitTrap(() => runSeed('test', 'extra-meta-empty', 'test:extra-meta-empty:v1', async () => ({
+    events: [{ id: 'canonical' }],
+    warnings: [],
+  }), {
+    validateFn: (data) => Array.isArray(data?.events),
+    ttlSeconds: 3600,
+    sourceVersion: 'test-v1',
+    schemaVersion: 1,
+    maxStaleMin: 120,
+    declareRecords: (data) => data.events.length,
+    extraKeys: [{
+      key: 'test:extra-meta-empty:warnings',
+      transform: (data) => data.warnings,
+      declareRecords: (warnings) => warnings.length,
+      metaKey: 'seed-meta:test:extra-meta-empty:warnings',
+      metaCritical: true,
+      skipWhenEmpty: true,
+    }],
+  }));
+
+  assert.equal(exitCode, 0);
+  assert.equal(
+    countSetsFor('seed-meta:test:extra-meta-empty:warnings'),
+    0,
+    'an empty transformed extra key must not refresh freshness metadata',
   );
 });
 

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -250,6 +250,15 @@ test('skipWhenEmpty preserves the last-good extra key without refreshing its see
     0,
     'an empty transformed extra key must not refresh freshness metadata',
   );
+  assert.equal(
+    countSetsFor('test:extra-meta-empty:warnings'),
+    0,
+    'an empty transformed extra key must not overwrite the last-good payload',
+  );
+  assert.ok(
+    expireKeys().includes('test:extra-meta-empty:warnings'),
+    'the skipped extra key must have its TTL extended to preserve last-good data',
+  );
 });
 
 // PR #3582: When validateFn rejects a transient blip but canonical key still

--- a/tests/western-pacific-cyclones.test.mjs
+++ b/tests/western-pacific-cyclones.test.mjs
@@ -74,6 +74,32 @@ describe('western Pacific cyclone identity', () => {
   it('rejects missing or non-numeric coordinates instead of coercing them to zero', () => {
     assert.deepEqual(canonicalizeWesternPacificCyclones([storm({ lat: null })]), []);
     assert.deepEqual(canonicalizeWesternPacificCyclones([storm({ lon: false })]), []);
+    assert.deepEqual(canonicalizeWesternPacificCyclones([storm({ lat: '' })]), []);
+    assert.deepEqual(canonicalizeWesternPacificCyclones([storm({ lon: '  ' })]), []);
+  });
+
+  it('keeps wind null without crashing when no observation reports wind', () => {
+    const [cyclone] = canonicalizeWesternPacificCyclones([
+      storm({ windKt: null, windAveragingPeriodMinutes: null }),
+    ]);
+
+    assert.equal(cyclone.windKt, null);
+    assert.equal(cyclone.windAveragingPeriodMinutes, undefined);
+  });
+
+  it('never takes wind from a cancelled observation while an active one exists', () => {
+    const [cyclone] = canonicalizeWesternPacificCyclones([
+      storm({ windKt: null, windAveragingPeriodMinutes: null }),
+      storm({
+        agency: 'JTWC', agencyId: '05W', aliases: ['Nari'], lat: 19.9, lon: 128.5,
+        windKt: 65, windAveragingPeriodMinutes: 1, sourceName: 'JTWC',
+        sourceUrl: 'https://www.metoc.navy.mil/', status: 'cancelled',
+      }),
+    ]);
+
+    assert.equal(cyclone.sourceName, 'JMA');
+    assert.equal(cyclone.windKt, null, 'a cancelled advisory must not supply the canonical wind');
+    assert.equal(cyclone.windAveragingPeriodMinutes, undefined);
   });
 
   it('does not merge concurrent nearby storms with distinct aliases', () => {

--- a/tests/western-pacific-cyclones.test.mjs
+++ b/tests/western-pacific-cyclones.test.mjs
@@ -56,6 +56,26 @@ describe('western Pacific cyclone identity', () => {
     );
   });
 
+  it('uses the first reported wind and its matching averaging period when the primary agency omits wind', () => {
+    const [cyclone] = canonicalizeWesternPacificCyclones([
+      storm({ windKt: null, windAveragingPeriodMinutes: 10 }),
+      storm({
+        agency: 'JTWC', agencyId: '05W', aliases: ['Nari'], lat: 19.9, lon: 128.5,
+        windKt: 65, windAveragingPeriodMinutes: 1, sourceName: 'JTWC',
+        sourceUrl: 'https://www.metoc.navy.mil/',
+      }),
+    ]);
+
+    assert.equal(cyclone.sourceName, 'JMA', 'the higher-priority agency remains the canonical source');
+    assert.equal(cyclone.windKt, 65);
+    assert.equal(cyclone.windAveragingPeriodMinutes, 1);
+  });
+
+  it('rejects missing or non-numeric coordinates instead of coercing them to zero', () => {
+    assert.deepEqual(canonicalizeWesternPacificCyclones([storm({ lat: null })]), []);
+    assert.deepEqual(canonicalizeWesternPacificCyclones([storm({ lon: false })]), []);
+  });
+
   it('does not merge concurrent nearby storms with distinct aliases', () => {
     const cyclones = canonicalizeWesternPacificCyclones([
       storm({ agencyId: '2605', aliases: ['Nari'], stormName: 'Nari' }),


### PR DESCRIPTION
## Summary

- Register the successful HKO warning snapshot in global health classification.
- Preserve the first reported wind and its matching averaging period when the primary agency omits wind.
- Reject missing or non-numeric cyclone coordinates instead of coercing them to zero.
- Add Redis-mocked extra-key metadata and skip-empty regression coverage.
- Record the explicit no-merge-without-current-user-approval rule in AGENTS.md.

## Review disposition

- Addresses findings 2 and 3 from PR #5296.
- Finding 1 does not reproduce: runSeed already writes extraKeys metaKey metadata after a successful extra-key publish and does not refresh it on skipWhenEmpty; tests now lock both paths.
- Finding 4 remains accurate because the metadata publish path exists.

## Validation

- npm run typecheck:api
- Focused cyclone, health, China coverage, and seed metadata tests
- Full pre-push gate