### PR TITLE
perf(bootstrap): make cyberThreats an on-demand key instead of slow-tier freight (#5300 Phase 1)

### DIFF
--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -602,3 +602,57 @@ test('unknown tier value does not qualify for the public path', async () => {
     assert.equal(resp.headers.get('cache-control'), 'no-store');
   });
 });
+
+// ── On-demand keys: the per-key public URL (#5300) ──────────────────────────
+// `cyberThreats` no longer rides in the slow tier — its layer is off by default
+// in every variant, so the tier was shipping 364 KB to every visitor that no
+// default visitor ever read. It now has its own CDN-shielded per-key URL,
+// fetched only by the clients that actually turn the layer on.
+
+function makePublicOnDemandRequest(keys = 'cyberThreats', headers = {}) {
+  return new Request(`https://api.worldmonitor.app/api/bootstrap?keys=${keys}&public=1`, {
+    method: 'GET',
+    headers,
+  });
+}
+
+test('public on-demand key URL is CDN-shielded and anonymous', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(makePublicOnDemandRequest('cyberThreats'));
+
+    assert.equal(resp.status, 200);
+    assertSharedCacheHeaders(resp);
+    assertPublicCorsHeaders(resp);
+  });
+});
+
+test('public on-demand URL keeps ONE contract even when credentials are attached', async () => {
+  // A CDN hit precedes handler auth, so the response must not vary by caller —
+  // same invariant the tier URLs carry (#5250).
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const resp = await handler(makePublicOnDemandRequest('cyberThreats', { Cookie: 'wm-session=whatever' }));
+
+    assert.equal(resp.status, 200);
+    assertSharedCacheHeaders(resp);
+  });
+});
+
+test('public on-demand URL does not widen into a CDN-amplification vector', async () => {
+  // Every shape below must fall through to the credentialed, no-store path. A
+  // multi-key or unlisted-key public URL would make the CDN key space
+  // combinatorial, and each distinct miss re-reads the registry from Redis —
+  // the exact amplification the public URLs exist to prevent (#5259).
+  await withMockedBootstrapAuth({ entitlement: null }, async () => {
+    for (const keys of [
+      'cyberThreats,marketQuotes',   // multi-key
+      'marketQuotes',                // a real key, but not on-demand
+      'wildfires',                   // slow-tier key, not on-demand
+      'notARealKey',                 // unknown
+      '',                            // empty
+    ]) {
+      const resp = await handler(makePublicOnDemandRequest(keys));
+      assert.equal(resp.status, 401, `keys=${keys} must not qualify for the public path`);
+      assert.equal(resp.headers.get('cache-control'), 'no-store', `keys=${keys} must stay no-store`);
+    }
+  });
+});

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -152,7 +152,7 @@ const SLOW_KEYS = new Set([
   'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'chinaMacro', 'chinaReleaseCalendar', 'minerals', 'giving',
   'sectors', 'etfFlows', 'wildfires', 'climateAnomalies', 'climateDisasters', 'co2Monitoring', 'oceanIce', 'climateNews',
   'radiationWatch', 'thermalEscalation', 'crossSourceSignals',
-  'cyberThreats', 'techReadiness', 'progressData', 'renewableEnergy',
+  'techReadiness', 'progressData', 'renewableEnergy',
   'naturalEvents',
   'cryptoQuotes', 'cryptoSectors', 'defiTokens', 'aiTokens', 'otherTokens',
   'gulfQuotes', 'stablecoinMarkets', 'unrestEvents', 'ucdpEvents',
@@ -203,6 +203,21 @@ const FAST_KEYS = new Set([
   'marketQuotes', 'commodityQuotes', 'positiveGeoEvents', 'riskScores', 'flightDelays','insights', 'predictions',
   'iranEvents', 'temporalAnomalies', 'weatherAlerts', 'spending', 'theaterPosture', 'gdeltIntel',
   'correlationCards', 'forecasts', 'shippingRates', 'shippingStress', 'socialVelocity', 'wsbTickers',
+]);
+
+// ON-DEMAND: registered bootstrap keys that ride in NEITHER tier. Every client
+// downloads both tiers on every boot, so a key belongs in a tier only if the
+// median client actually reads it. These are fetched individually — and only by
+// the clients that need them — via `?keys=<name>&public=1` (#5300).
+//
+// `cyberThreats` (364 KB): `loadCyberThreats` is double-gated on the
+// VITE_ENABLE_CYBER_LAYER build flag AND `mapLayers.cyberThreats`
+// (src/app/data-loader.ts), and that layer is OFF by default in all 12 variant
+// configs (src/config/panels.ts). So the slow tier was shipping 364 KB to every
+// visitor that no default visitor ever read — ~2.15 GB/day of Redis egress for
+// bytes nobody consumed.
+const ON_DEMAND_KEYS = new Set([
+  'cyberThreats',
 ]);
 
 // Iran-events sunset: strip the domain from the bootstrap payload + fast tier
@@ -275,6 +290,38 @@ export function isPublicTierBootstrapRequest(req) {
   return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]);
 }
 
+// The on-demand counterpart to the tier URL above: `?keys=<name>&public=1` for a
+// SINGLE on-demand key. Same reasoning — the payload is the shared production
+// seed value, identical for every caller — so it gets its own CDN entry and the
+// same public contract regardless of attached credentials (a cache hit precedes
+// handler auth).
+//
+// Restricted to ONE key drawn from ON_DEMAND_KEYS, deliberately: an arbitrary
+// `?keys=a,b,c` would make the CDN key space combinatorial, and every distinct
+// combination is a cache MISS that re-reads the registry from Redis — the exact
+// amplification #5259/#5287 exist to prevent. One key per URL keeps the space at
+// |ON_DEMAND_KEYS| entries, each independently cached and each fetched only by
+// the clients that actually render it.
+//
+// The legacy multi-key `?keys=a,b` URL keeps working and stays credentialed +
+// no-store, so nothing that relies on it changes.
+export function isPublicOnDemandBootstrapRequest(req) {
+  if (req.method !== 'GET') return false;
+
+  const url = new URL(req.url);
+  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
+  if (pathname !== '/api/bootstrap') return false;
+
+  const params = Array.from(url.searchParams.keys());
+  if (params.some((key) => key !== 'keys' && key !== 'public')) return false;
+
+  const keyParams = url.searchParams.getAll('keys');
+  const publicParams = url.searchParams.getAll('public');
+  if (keyParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return false;
+
+  return ON_DEMAND_KEYS.has(keyParams[0]);
+}
+
 const BOOTSTRAP_CREDENTIAL_COOKIES = new Set(['wm-session', 'wm-pro-key', 'wm-widget-key']);
 
 function hasBootstrapCredentialCookie(req) {
@@ -345,6 +392,9 @@ async function validateBootstrapAuth(req, cors) {
   // Vercel may serve it from cache before cookie/header auth reaches this code.
   if (isPublicTierBootstrapRequest(req)) {
     return { ok: true, kind: 'public-tier' };
+  }
+  if (isPublicOnDemandBootstrapRequest(req)) {
+    return { ok: true, kind: 'public-on-demand' };
   }
   if (!headerKey && !hasBootstrapCredentialCookie(req)) {
     if (isPublicWeatherBootstrapRequest(req)) {
@@ -421,7 +471,7 @@ async function validateBootstrapAuth(req, cors) {
 }
 
 function isPublicBootstrapKind(authKind) {
-  return authKind === 'public-weather' || authKind === 'public-tier';
+  return authKind === 'public-weather' || authKind === 'public-tier' || authKind === 'public-on-demand';
 }
 
 function successCacheHeaders(tier, authKind, cors) {
@@ -517,5 +567,9 @@ export default async function handler(req) {
   // The browser runtime sends API requests with credentials so session and
   // entitlement cookies can ride along. Credentialed requests cannot consume
   // ACAO: * responses, even for public bootstrap data.
-  return jsonResponse({ data, missing }, 200, successCacheHeaders(tier, auth.kind, cors));
+  // On-demand keys carry slow-tier seed data, so they get the slow-tier CDN
+  // profile (s-maxage=7200) rather than the 600s default that a tier-less
+  // `?keys=` request would otherwise fall back to.
+  const cacheTier = tier ?? (auth.kind === 'public-on-demand' ? 'slow' : null);
+  return jsonResponse({ data, missing }, 200, successCacheHeaders(cacheTier, auth.kind, cors));
 }

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -271,7 +271,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
 export const PORTWATCH_PORT_ACTIVITY_KEY_PREFIX = 'supply_chain:portwatch-ports:v1:';
 export const PORTWATCH_PORT_ACTIVITY_COUNTRIES_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 
-export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast'> = {
+export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast' | 'on-demand'> = {
   bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow',
   bisDsr: 'slow', bisPropertyResidential: 'slow', bisPropertyCommercial: 'slow',
   imfMacro: 'slow', imfGrowth: 'slow', imfLabor: 'slow', imfExternal: 'slow',
@@ -279,7 +279,7 @@ export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast'> = {
   minerals: 'slow', giving: 'slow', sectors: 'slow',
   progressData: 'slow', renewableEnergy: 'slow',
   etfFlows: 'slow', shippingRates: 'fast', wildfires: 'slow',
-  climateAnomalies: 'slow', climateDisasters: 'slow', co2Monitoring: 'slow', oceanIce: 'slow', climateNews: 'slow', sanctionsPressure: 'slow', radiationWatch: 'slow', thermalEscalation: 'slow', crossSourceSignals: 'slow', cyberThreats: 'slow', techReadiness: 'slow',
+  climateAnomalies: 'slow', climateDisasters: 'slow', co2Monitoring: 'slow', oceanIce: 'slow', climateNews: 'slow', sanctionsPressure: 'slow', radiationWatch: 'slow', thermalEscalation: 'slow', crossSourceSignals: 'slow', cyberThreats: 'on-demand', techReadiness: 'slow',
   theaterPosture: 'fast', naturalEvents: 'slow',
   cryptoQuotes: 'slow', gulfQuotes: 'slow', stablecoinMarkets: 'slow',
   unrestEvents: 'slow', ucdpEvents: 'slow', techEvents: 'slow',

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -39,6 +39,51 @@ export function getHydratedData(key: string): unknown | undefined {
   return val;
 }
 
+// In-flight coalescing for on-demand keys: a panel and a map layer can both ask
+// for the same key in the same tick, and we want one request, not two.
+const onDemandInflight = new Map<string, Promise<unknown | undefined>>();
+
+/**
+ * Hydration for keys that ride in NEITHER bootstrap tier (#5300).
+ *
+ * Returns the tier-hydrated value if one is present (so a key promoted back into
+ * a tier keeps working unchanged), otherwise fetches it through its own
+ * CDN-shielded public URL — `?keys=<name>&public=1`, one key per URL, one CDN
+ * entry per key.
+ *
+ * This must NOT fall back to the domain RPC: the RPC reads the same Redis key
+ * with no CDN in front of it, so routing misses there would relocate the egress
+ * rather than remove it — the trap that made #5263's RPC work a no-op until
+ * #5287. Callers keep their existing RPC fallback for the failure case; this
+ * simply gives them a cached path to try first.
+ */
+export async function ensureHydrated(key: string): Promise<unknown | undefined> {
+  const hydrated = getHydratedData(key);
+  if (hydrated !== undefined) return hydrated;
+
+  const existing = onDemandInflight.get(key);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const resp = await fetch(
+        toApiUrl(`/api/bootstrap?keys=${encodeURIComponent(key)}&public=1`),
+        { credentials: 'omit', signal: AbortSignal.timeout(10_000) },
+      );
+      if (!resp.ok) return undefined;
+      const payload = (await resp.json()) as { data?: Record<string, unknown> };
+      return payload.data?.[key];
+    } catch {
+      return undefined;
+    } finally {
+      onDemandInflight.delete(key);
+    }
+  })();
+
+  onDemandInflight.set(key, promise);
+  return promise;
+}
+
 export function markBootstrapAsLive(): void {
   if (lastHydrationState.source === 'cached' || lastHydrationState.source === 'mixed') {
     const now = Date.now();

--- a/src/services/cyber/index.ts
+++ b/src/services/cyber/index.ts
@@ -8,7 +8,7 @@ import type {
   CyberThreatIndicatorType,
 } from '@/types';
 import { createCircuitBreaker } from '@/utils';
-import { getHydratedData } from '@/services/bootstrap';
+import { ensureHydrated } from '@/services/bootstrap';
 import { CyberServiceClient } from '@/services/generated-rpc-clients';
 
 // ---- Client + Circuit Breaker ----
@@ -81,7 +81,13 @@ function clampInt(rawValue: number | undefined, fallback: number, min: number, m
 }
 
 export async function fetchCyberThreats(options: { limit?: number; days?: number } = {}): Promise<CyberThreat[]> {
-  const hydrated = getHydratedData('cyberThreats') as { threats?: ProtoCyberThreat[] } | undefined;
+  // `cyberThreats` is an on-demand bootstrap key (#5300): it no longer rides in
+  // the slow tier, because loadCyberThreats is gated on the cyber layer being ON
+  // and that layer is off by default in every variant — so the tier was shipping
+  // 364 KB to every visitor for data the default visitor never read. Callers that
+  // reach here have already passed that gate, so fetch it now, through its own
+  // CDN-shielded per-key URL. Falls through to the RPC below if that fetch fails.
+  const hydrated = (await ensureHydrated('cyberThreats')) as { threats?: ProtoCyberThreat[] } | undefined;
   if (hydrated?.threats?.length) return hydrated.threats.map(toCyberThreat);
 
   const limit = clampInt(options.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -376,9 +376,14 @@ describe('Bootstrap key hydration coverage', () => {
     ]);
     for (const key of keys) {
       if (PENDING_CONSUMERS.has(key)) continue;
+      // Two valid consumer forms. `getHydratedData(k)` reads a key delivered by a
+      // tier bundle. `ensureHydrated(k)` (#5300) reads a key that rides in no
+      // tier: it returns the tier value if one is present and otherwise fetches
+      // the key through its own CDN-shielded `?keys=<k>&public=1` URL. Both prove
+      // the key is actually consumed — which is what this guard is for.
       assert.ok(
-        allSrc.includes(`getHydratedData('${key}')`),
-        `Bootstrap key '${key}' has no getHydratedData('${key}') consumer in src/ — data is fetched but never used`,
+        allSrc.includes(`getHydratedData('${key}')`) || allSrc.includes(`ensureHydrated('${key}')`),
+        `Bootstrap key '${key}' has no getHydratedData('${key}') or ensureHydrated('${key}') consumer in src/ — data is fetched but never used`,
       );
     }
   });
@@ -415,27 +420,35 @@ describe('Bootstrap tier definitions', () => {
     const block = src.match(/BOOTSTRAP_TIERS[^{]*\{([^}]+)\}/);
     if (!block) return {};
     const result = {};
-    for (const m of block[1].matchAll(/(\w+):\s+'(slow|fast)'/g)) {
+    for (const m of block[1].matchAll(/(\w+):\s+'(slow|fast|on-demand)'/g)) {
       result[m[1]] = m[2];
     }
     return result;
   }
 
-  it('SLOW_KEYS + FAST_KEYS cover all BOOTSTRAP_CACHE_KEYS with no overlap', () => {
+  // Every registered key must be classified exactly once: it rides in the fast
+  // tier, the slow tier, or neither (ON_DEMAND_KEYS — fetched per-key, only by
+  // the clients that render it; #5300). "Neither" is now a deliberate state, not
+  // an omission, so it needs a home in the invariant rather than a hole in it.
+  it('SLOW_KEYS + FAST_KEYS + ON_DEMAND_KEYS cover all BOOTSTRAP_CACHE_KEYS with no overlap', () => {
     const slow = extractSetKeys(bootstrapSrc, 'SLOW_KEYS');
     const fast = extractSetKeys(bootstrapSrc, 'FAST_KEYS');
+    const onDemand = extractSetKeys(bootstrapSrc, 'ON_DEMAND_KEYS');
     const all = extractBootstrapKeys(bootstrapSrc);
 
-    const union = new Set([...slow, ...fast]);
-    assert.deepEqual([...union].sort(), [...all].sort(), 'SLOW_KEYS ∪ FAST_KEYS must equal BOOTSTRAP_CACHE_KEYS');
+    const union = new Set([...slow, ...fast, ...onDemand]);
+    assert.deepEqual([...union].sort(), [...all].sort(), 'SLOW ∪ FAST ∪ ON_DEMAND must equal BOOTSTRAP_CACHE_KEYS');
 
-    const intersection = [...slow].filter(k => fast.has(k));
-    assert.equal(intersection.length, 0, `Overlap between tiers: ${intersection.join(', ')}`);
+    for (const [a, b, label] of [[slow, fast, 'slow/fast'], [slow, onDemand, 'slow/on-demand'], [fast, onDemand, 'fast/on-demand']]) {
+      const overlap = [...a].filter(k => b.has(k));
+      assert.equal(overlap.length, 0, `Overlap between ${label}: ${overlap.join(', ')}`);
+    }
   });
 
-  it('tier sets in bootstrap.js match BOOTSTRAP_TIERS in cache-keys.ts', () => {
+  it('key sets in bootstrap.js match BOOTSTRAP_TIERS in cache-keys.ts', () => {
     const slow = extractSetKeys(bootstrapSrc, 'SLOW_KEYS');
     const fast = extractSetKeys(bootstrapSrc, 'FAST_KEYS');
+    const onDemand = extractSetKeys(bootstrapSrc, 'ON_DEMAND_KEYS');
     const tiers = extractTierKeys(cacheKeysSrc);
 
     for (const k of slow) {
@@ -444,9 +457,21 @@ describe('Bootstrap tier definitions', () => {
     for (const k of fast) {
       assert.equal(tiers[k], 'fast', `FAST_KEYS has '${k}' but BOOTSTRAP_TIERS says '${tiers[k]}'`);
     }
+    for (const k of onDemand) {
+      assert.equal(tiers[k], 'on-demand', `ON_DEMAND_KEYS has '${k}' but BOOTSTRAP_TIERS says '${tiers[k]}'`);
+    }
     const tierKeys = new Set(Object.keys(tiers));
-    const setKeys = new Set([...slow, ...fast]);
-    assert.deepEqual([...tierKeys].sort(), [...setKeys].sort(), 'BOOTSTRAP_TIERS keys must match SLOW_KEYS ∪ FAST_KEYS');
+    const setKeys = new Set([...slow, ...fast, ...onDemand]);
+    assert.deepEqual([...tierKeys].sort(), [...setKeys].sort(), 'BOOTSTRAP_TIERS keys must match SLOW ∪ FAST ∪ ON_DEMAND');
+  });
+
+  it('on-demand keys are NOT served by the tier bundles every client downloads', () => {
+    const slow = extractSetKeys(bootstrapSrc, 'SLOW_KEYS');
+    const fast = extractSetKeys(bootstrapSrc, 'FAST_KEYS');
+    const onDemand = extractSetKeys(bootstrapSrc, 'ON_DEMAND_KEYS');
+
+    assert.ok(onDemand.has('cyberThreats'), 'cyberThreats must stay on-demand: its layer is off by default in every variant');
+    assert.ok(!slow.has('cyberThreats') && !fast.has('cyberThreats'), 'cyberThreats must not ride in a tier');
   });
 });
 


### PR DESCRIPTION
First slice of #5300. Establishes the **on-demand key** seam the rest of the epic needs, and pays for itself immediately.

## The finding

Every client downloads both bootstrap tiers on every boot, so a key belongs in a tier only if the median client actually reads it. **`cyberThreats` did not.**

`loadCyberThreats` is **double-gated** — on the `VITE_ENABLE_CYBER_LAYER` build flag **and** on `mapLayers.cyberThreats` (`src/app/data-loader.ts:881`) — and that layer is **OFF by default in all 12 variant configs** (`src/config/panels.ts`).

So the slow tier shipped `cyber:threats-bootstrap:v2` (**364 KB**) to every visitor, and the default visitor never read a byte of it: **~2.15 GB/day of Redis egress for data nobody consumed.**

## What changes

**`ON_DEMAND_KEYS` becomes a first-class third category.** A key now rides in the fast tier, the slow tier, or *neither* — and "neither" is a deliberate, tested state rather than a hole in the invariant. On-demand keys are fetched individually, and only by clients that render them, via `?keys=<name>&public=1`.

**The per-key public URL is restricted to ONE key drawn from `ON_DEMAND_KEYS`.** An arbitrary `?keys=a,b,c` would make the CDN key space combinatorial, and every distinct combination is a miss that re-reads the registry from Redis — precisely the amplification #5259 exists to prevent. One key per URL keeps the space at `|ON_DEMAND_KEYS|` entries, each independently cached. The legacy multi-key `?keys=` URL is untouched: still credentialed, still `no-store`.

**`ensureHydrated()`** returns the tier value when present (so promoting a key back into a tier needs no consumer change) and otherwise fetches the per-key public URL. It deliberately does **not** fall back to the domain RPC — the RPC reads the same Redis key with *no CDN in front of it*, so routing misses there would **relocate** the egress rather than remove it. That is the exact trap that made #5263's RPC work a no-op until #5287. Callers keep their existing RPC fallback for the failure case.

## Impact

| | before | after |
|---|---|---|
| slow-tier payload | 3.20 MB / origin miss | **2.84 MB** |
| `cyber:threats-bootstrap:v2` bootstrap reads | 6,048/day × 364 KB | **0 for default users** |
| | | **~2.15 GB/day** |

No product change: a user who turns the cyber layer on still gets cyber data — now fetched at the moment they ask for it, from a CDN-shielded URL.

## Validation

- `node --test tests/bootstrap.test.mjs api/bootstrap-auth.test.mjs` — **75 pass, 0 fail**
- `node --test tests/edge-functions.test.mjs` — **228 pass, 0 fail**
- `npm run typecheck`, `npm run typecheck:api` — pass
- Pre-push gate — pass

New tests:
- tier invariant now covers **SLOW ∪ FAST ∪ ON_DEMAND** with pairwise no-overlap, and pins that `cyberThreats` rides in no tier
- hydration-coverage guard accepts `ensureHydrated()` as a consumer form (it caught the change correctly on the first run — the guard works)
- the public per-key URL is pinned **against widening**: multi-key, non-on-demand key, unknown key, and empty all fall through to credentialed `no-store`
- public URL keeps one contract even when credentials are attached (a CDN hit precedes handler auth — same invariant as #5250)

## Post-deploy check

`/api/bootstrap?keys=cyberThreats&public=1` → 200 with `CDN-Cache-Control` and `x-vercel-cache: HIT` on a second request; `?keys=cyberThreats,marketQuotes&public=1` → 401. Then confirm `cyber:threats-bootstrap:v2` disappears from the slow-tier origin reads in a MONITOR tap.

## Corrections to #5300 (found while implementing — the issue is now updated)

- **The cyber "duplicate key" item does not save egress.** `cyber:threats:v2` and `cyber:threats-bootstrap:v2` are byte-identical, but collapsing them leaves the same reads × the same size. Dedup saves *storage*, not bandwidth. The real lever for cyber was this one.
- **`ucdpEvents` cannot simply be demoted.** It feeds `ingestUcdpForCII` → `countryDataMap` → `getCountryData()`, which the country deep-dive renders. Its task is viewport-gated on a set that includes `cii`, so most clients do load it — demotion would relocate the read, not remove it. Its lever is **seeder-side compaction** (2,000 raw events → precomputed classifications + top-N), not demotion.
- **`thermalEscalation` is the next easy win**: the key ships **117 clusters** and the client renders **12** (`fetchThermalEscalations(maxItems = 12)`), with no CII coupling. Pure seeder-side compaction, ~2.9 GB/day at peak.