### PR TITLE
perf(bootstrap): serve thermal escalation as a dashboard-sized view, not the full watch (#5300)

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -67,7 +67,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   oceanIce: 'climate:ocean-ice:v1',
   climateNews:      'climate:news-intelligence:v1',
   radiationWatch: 'radiation:observations:v1',
-  thermalEscalation: 'thermal:escalation:v1',
+  thermalEscalation: 'thermal:escalation-bootstrap:v1',
   crossSourceSignals: 'intelligence:cross-source-signals:v1',
   wildfires:        'wildfire:fires-bootstrap:v1',
   cyberThreats:     'cyber:threats-bootstrap:v2',

--- a/api/health.js
+++ b/api/health.js
@@ -224,6 +224,7 @@ const STANDALONE_KEYS = {
   // key as the probe target rather than pretending one country key is global.
   comtradeBilateralHs4:  'seed-meta:comtrade:bilateral-hs4',
   thermalEscalation:     'thermal:escalation:v1',
+  thermalEscalationBootstrap: 'thermal:escalation-bootstrap:v1',
   tariffTrendsUs:           'trade:tariffs:v1:840:all:10',
   militaryForecastInputs:   'military:forecast-inputs:stale:v1',
   gscpi:                    'economic:fred:v1:GSCPI:0',
@@ -453,6 +454,7 @@ const SEED_META = {
   fuelPrices:          { key: 'seed-meta:economic:fuel-prices',               maxStaleMin: 10080 }, // weekly seed; 10080 = 7 days
   faoFoodPriceIndex:   { key: 'seed-meta:economic:fao-ffpi',                  maxStaleMin: 86400 }, // monthly seed; 86400 = 60 days (2x interval)
   thermalEscalation:   { key: 'seed-meta:thermal:escalation',                 maxStaleMin: 360 }, // cron every 2h; 360 = 3x interval (was 240 = 2x)
+  thermalEscalationBootstrap: { key: 'seed-meta:thermal:escalation-bootstrap', maxStaleMin: 360 }, // Same cron as above. Monitored separately because the bootstrap tier now hydrates from the compact projection, and a transform/write failure there must not hide behind a healthy canonical key (#5300).
   nationalDebt:        { key: 'seed-meta:economic:national-debt',              maxStaleMin: 86400 }, // monthly seed (seed-bundle-macro intervalMs: 30 * DAY); 60d = 2x interval absorbs one missed run. Prior 10080 (7d) was narrower than the cron interval so every cron past day 7 alarmed STALE_SEED.
   tariffTrendsUs:      { key: 'seed-meta:trade:tariffs:v1:840:all:10',        maxStaleMin: 540 }, // co-pinned to TARIFF_TTL (8h=480min) + 60min grace. Prior 900 (15h) created an 8h-15h silent window where data had expired but seed-meta was still considered fresh, masking real outages as status=EMPTY (not STALE_SEED). See scripts/seed-supply-chain-trade.mjs TARIFF_TTL.
   // publish.ts runs once daily (02:30 UTC); seed-meta TTL=52h — maxStaleMin must cover the full 24h cycle
@@ -695,6 +697,7 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'cableHealth', // `cables: {}` = no active subsea cable disruptions per NGA NAVAREA warnings — all cables implicitly healthy. Also covers NGA-upstream-down windows where get-cable-health writes back the fallback response (empty cables); without this, those would alarm EMPTY_DATA.
   'forecastBets', // #5233 shadow bet-engine stream; absent before the cron ships it and empty on weeks the energy feed yields no bet — tolerate as STALE_SEED (warn), not EMPTY (crit).
   'forecastFunnel', // #5233 funnel guardrail is a new afterPublish side-write; before the first seed-forecasts run ships it the key is absent — tolerate as STALE_SEED (warn), not EMPTY (crit). A COLLAPSED funnel still surfaces via seed-meta status:'error' → SEED_ERROR, which classifyKey checks before this branch.
+  'thermalEscalationBootstrap', // Compact dashboard projection is absent until the first thermal seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
   'wildfiresBootstrap', // Compact dashboard side-write is absent until the first fire seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
 ]);
 

--- a/scripts/_thermal-dashboard.mjs
+++ b/scripts/_thermal-dashboard.mjs
@@ -1,0 +1,42 @@
+/**
+ * Dashboard-sized projection of the thermal-escalation watch (#5300).
+ *
+ * The canonical `thermal:escalation:v1` payload carries every cluster the
+ * detector produced (~117, and every one of them rides in the bootstrap slow
+ * tier that EVERY client downloads on EVERY boot). The dashboard renders 12:
+ * `fetchThermalEscalations(maxItems = 12)` slices the array and recomputes its
+ * summary from that slice, so clusters past the cap are downloaded and thrown
+ * away — ~2.9 GB/day of Redis egress for bytes no UI ever shows.
+ *
+ * `computeThermalEscalationWatch` already ranks clusters (strategic relevance →
+ * severity → total FRP → observation count), so the client's `slice(0, 12)` is a
+ * top-12-by-rank. Capping the published array to the same ranked prefix is
+ * therefore byte-for-byte behaviour-preserving for every current consumer.
+ *
+ * The cap sits above the client's render limit so a caller may raise `maxItems`
+ * a little without silently losing clusters; `thermal-dashboard-cap.test.mjs`
+ * pins the client default below it so the two can never drift into silent
+ * truncation.
+ *
+ * `summary` is deliberately left as computed over the FULL cluster set: it
+ * describes the world, not the page, and the hydrated client recomputes its own
+ * summary from the slice anyway. `totalClusters` records the pre-cap count so no
+ * consumer mistakes a capped array for the whole picture.
+ *
+ * NOTE: this file must not import anything outside `scripts/` — Railway builds
+ * the seeders from a scripts-only Nixpacks root, and a `../api/` import crashes
+ * the container at startup (#5268).
+ */
+
+export const THERMAL_DASHBOARD_CLUSTER_LIMIT = 24;
+
+export function compactThermalDashboardPayload(value, limit = THERMAL_DASHBOARD_CLUSTER_LIMIT) {
+  if (!value || typeof value !== 'object' || !Array.isArray(value.clusters)) return value;
+  if (value.clusters.length <= limit) return value;
+
+  return {
+    ...value,
+    clusters: value.clusters.slice(0, limit),
+    totalClusters: value.clusters.length,
+  };
+}

--- a/scripts/seed-thermal-escalation.mjs
+++ b/scripts/seed-thermal-escalation.mjs
@@ -2,10 +2,16 @@
 
 import { loadEnvFile, runSeed, verifySeedKey, writeExtraKeyWithMeta } from './_seed-utils.mjs';
 import { computeThermalEscalationWatch, emptyThermalEscalationWatch } from './lib/thermal-escalation.mjs';
+import { compactThermalDashboardPayload } from './_thermal-dashboard.mjs';
 
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'thermal:escalation:v1';
+// Dashboard-sized projection of the canonical watch. The bootstrap slow tier
+// hydrates from THIS key so every client stops downloading ~117 clusters to
+// render 12 (#5300). The canonical key above is untouched and still serves the
+// RPC and analytical consumers.
+const BOOTSTRAP_KEY = 'thermal:escalation-bootstrap:v1';
 const HISTORY_KEY = 'thermal:escalation:history:v1';
 const CACHE_TTL = 6 * 60 * 60; // 6h — cron runs every 2h; 3x interval so one missed run does not expire the key (was 3h = 1.5x, too tight)
 const SOURCE_VERSION = 'thermal-escalation-v1';
@@ -57,6 +63,12 @@ async function main() {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 360,
+    extraKeys: [{
+      key: BOOTSTRAP_KEY,
+      transform: compactThermalDashboardPayload,
+      declareRecords,
+      metaKey: 'seed-meta:thermal:escalation-bootstrap',
+    }],
     afterPublish: async () => {
       await writeExtraKeyWithMeta(
         HISTORY_KEY,

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -187,7 +187,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   oceanIce:         'climate:ocean-ice:v1',
   climateNews:      'climate:news-intelligence:v1',
   radiationWatch:  'radiation:observations:v1',
-  thermalEscalation: 'thermal:escalation:v1',
+  thermalEscalation: 'thermal:escalation-bootstrap:v1',
   crossSourceSignals: 'intelligence:cross-source-signals:v1',
   wildfires:        'wildfire:fires-bootstrap:v1',
   marketQuotes:     'market:stocks-bootstrap:v1',

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -98,6 +98,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'cascade-mirror: RPC variant of cyber:threats-bootstrap:v2 (covered by get_cyber_threats). Same seed-meta key (seed-meta:cyber:threats).'],
   ['wildfire:fires-bootstrap:v1',
     'cascade-mirror: pre-compacted dashboard/RPC variant of wildfire:fires:v1 (covered by get_natural_events). It preserves the same top-500 response while avoiding canonical-payload Redis egress.'],
+  ['thermal:escalation-bootstrap:v1',
+    'cascade-mirror: pre-compacted dashboard view of thermal:escalation:v1 (the canonical key remains the tool/RPC source). Capped to the top-24 ranked clusters the dashboard renders — agents should read the canonical key, which carries the full cluster set (#5300).'],
   ['aviation:delays:intl:v3',
     'cascade-mirror: international delays sibling of aviation:delays-bootstrap:v2 (covered by get_aviation_status) — deferred to a future expanded aviation tool that exposes the intl variant directly.'],
   ['aviation:notam:closures:v2',

--- a/tests/thermal-dashboard-cap.test.mjs
+++ b/tests/thermal-dashboard-cap.test.mjs
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  THERMAL_DASHBOARD_CLUSTER_LIMIT,
+  compactThermalDashboardPayload,
+} from '../scripts/_thermal-dashboard.mjs';
+import { __testing__ as healthTesting } from '../api/health.js';
+
+const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+function makeWatch(clusterCount) {
+  return {
+    fetchedAt: '2026-07-14T00:00:00.000Z',
+    observationWindowHours: 24,
+    sourceVersion: 'thermal-escalation-v1',
+    clusters: Array.from({ length: clusterCount }, (_, i) => ({ id: `c${i}`, totalFrp: 1000 - i })),
+    summary: { clusterCount },
+  };
+}
+
+test('caps the published cluster array while preserving rank order', () => {
+  const compact = compactThermalDashboardPayload(makeWatch(117));
+
+  assert.equal(compact.clusters.length, THERMAL_DASHBOARD_CLUSTER_LIMIT);
+  // computeThermalEscalationWatch ranks clusters before publish and the client
+  // takes slice(0, maxItems), so the cap must be the ranked PREFIX — otherwise
+  // the dashboard would silently render a different top-12 than it does today.
+  assert.deepEqual(compact.clusters.map(c => c.id), makeWatch(117).clusters.slice(0, THERMAL_DASHBOARD_CLUSTER_LIMIT).map(c => c.id));
+});
+
+test('records the pre-cap total so a capped array is never mistaken for the whole picture', () => {
+  const compact = compactThermalDashboardPayload(makeWatch(117));
+  assert.equal(compact.totalClusters, 117);
+  // summary describes the world, not the page — the hydrated client recomputes
+  // its own summary from the slice it renders.
+  assert.equal(compact.summary.clusterCount, 117);
+});
+
+test('passes through payloads at or under the cap untouched', () => {
+  const small = makeWatch(5);
+  const compact = compactThermalDashboardPayload(small);
+  assert.deepEqual(compact, small);
+  assert.equal(compact.totalClusters, undefined, 'no cap applied ⇒ no totalClusters marker');
+});
+
+test('tolerates malformed payloads rather than publishing garbage', () => {
+  for (const bad of [null, undefined, 'nope', 42, {}, { clusters: 'not-an-array' }]) {
+    assert.equal(compactThermalDashboardPayload(bad), bad);
+  }
+});
+
+// The drift guard. The seeder publishes THERMAL_DASHBOARD_CLUSTER_LIMIT clusters;
+// the client slices to its own maxItems default. If someone raises the client
+// default above the cap, the dashboard silently renders fewer clusters than it
+// asked for — a truncation with no error anywhere. Pin the relationship.
+test('client render limit stays within the published cap', () => {
+  const src = readFileSync(join(root, 'src', 'services', 'thermal-escalation.ts'), 'utf-8');
+  const m = src.match(/fetchThermalEscalations\(maxItems\s*=\s*(\d+)\)/);
+  assert.ok(m, 'could not find the client maxItems default — update this guard if the signature changed');
+
+  const clientDefault = Number(m[1]);
+  assert.ok(
+    clientDefault <= THERMAL_DASHBOARD_CLUSTER_LIMIT,
+    `client renders ${clientDefault} clusters but the seeder only publishes ${THERMAL_DASHBOARD_CLUSTER_LIMIT} — raise THERMAL_DASHBOARD_CLUSTER_LIMIT or the dashboard silently truncates`,
+  );
+});
+
+test('health monitors the compact key the bootstrap tier actually serves', () => {
+  const { STANDALONE_KEYS, SEED_META } = healthTesting;
+
+  // health sweeps BOOTSTRAP_KEYS ∪ STANDALONE_KEYS identically; thermal has
+  // always lived in the latter. What matters is that the key the dashboard now
+  // hydrates from is monitored on its own, so a transform/write failure can't
+  // hide behind a healthy canonical key.
+  assert.equal(STANDALONE_KEYS.thermalEscalationBootstrap, 'thermal:escalation-bootstrap:v1');
+  assert.equal(SEED_META.thermalEscalationBootstrap.key, 'seed-meta:thermal:escalation-bootstrap');
+  // The canonical key stays monitored too: it still feeds the RPC.
+  assert.equal(STANDALONE_KEYS.thermalEscalation, 'thermal:escalation:v1');
+});
+
+test('a not-yet-published compact key warns, it does not CRIT', () => {
+  // Deploy-ordering: the web change lands before the seeder's next tick, so the
+  // key is legitimately absent for one cron interval. EMPTY scores as crit and
+  // would flip /api/health to DEGRADED on a false alarm — the trap #5263 hit on
+  // its second round. Warn instead; seed-meta staleness still catches a writer
+  // that actually stops.
+  const { classifyKey, STANDALONE_KEYS } = healthTesting;
+  const NOW = 1_700_000_000_000;
+  const verdict = classifyKey(
+    'thermalEscalationBootstrap',
+    STANDALONE_KEYS.thermalEscalationBootstrap,
+    { allowOnDemand: false },
+    {
+      keyStrens: new Map([[STANDALONE_KEYS.thermalEscalationBootstrap, 0]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map(),
+      keyMetaErrors: new Map(),
+      now: NOW,
+    },
+  );
+  assert.equal(verdict.status, 'STALE_SEED');
+});
+
+test('bootstrap hydrates thermalEscalation from the compact key', () => {
+  const src = readFileSync(join(root, 'api', 'bootstrap.js'), 'utf-8');
+  assert.match(src, /thermalEscalation:\s*'thermal:escalation-bootstrap:v1'/);
+  const cacheKeys = readFileSync(join(root, 'server', '_shared', 'cache-keys.ts'), 'utf-8');
+  assert.match(cacheKeys, /thermalEscalation:\s*'thermal:escalation-bootstrap:v1'/);
+});


### PR DESCRIPTION
Second slice of #5300. **Cache what we show.**

## The finding

The bootstrap slow tier is downloaded by **every client on every boot**, so what rides in it should be what the UI renders.

`thermal:escalation:v1` ships **~117 ranked clusters**. The dashboard renders **12** — `fetchThermalEscalations(maxItems = 12)` slices the array *and recomputes its summary from that slice*, so every cluster past the cap is downloaded and thrown away.

At peak that is **467 KB per origin miss for a payload the UI never shows: ~2.9 GB/day** of Redis egress. (The MONITOR tap confirms thermal is read at exactly the slow-tier origin rate — 21 per 300 s — i.e. **only** by bootstrap.)

## What changes

Publish `thermal:escalation-bootstrap:v1` — the same watch, capped to the top **24** clusters — and hydrate the tier from it.

`computeThermalEscalationWatch` already ranks clusters (strategic relevance → severity → total FRP → observation count), so the client's `slice(0, 12)` is a **top-12-by-rank**, and the capped array is the identical ranked prefix. **Behaviour is preserved exactly**; only the bytes the client was already discarding are gone.

The canonical key is untouched and still serves the RPC and analytical consumers. Same shape as the wildfire compaction in #5263: **canonical = source, `*-bootstrap` = the view the dashboard renders.**

| | before | after |
|---|---|---|
| `thermalEscalation` bootstrap payload | 467 KB (117 clusters) | **~50–100 KB (24 clusters)** |
| | | **~2.3–2.7 GB/day** |

## Guards — each one earned from a prior incident in this epic

- **The compactor lives in `scripts/` and imports nothing outside it.** A `../api/` import escapes Railway's scripts-only Nixpacks root and crashes the seeder at startup — that is #5268, which took the wildfire feed down for ~6 hours. The no-escape-import guard added by #5270 now covers this entry point too (verified: 145 pass).
- **Health monitors `thermal:escalation-bootstrap:v1` and its seed-meta separately**, so a transform/write failure cannot hide behind a healthy canonical key. Without this the savings could silently evaporate — the client would just fall back to the RPC and nothing would alarm.
- **The compact key is in `EMPTY_DATA_OK_KEYS`.** It is legitimately absent for one cron interval after deploy, and `EMPTY` scores as **crit**, which would flip `/api/health` to DEGRADED on a false alarm — exactly the trap #5263 hit on its second review round. Warn instead; seed-meta staleness still catches a writer that actually stops.
- **A drift guard pins the client's `maxItems` default at or below the published cap**, so raising one without the other can never silently truncate the dashboard.

## Validation

- `node --test tests/thermal-dashboard-cap.test.mjs` — **8 pass** (rank-prefix preservation, pre-cap `totalClusters`, under-cap passthrough, malformed-input tolerance, drift guard, health registration, cold-start warn-not-crit)
- `node --test tests/bootstrap.test.mjs api/bootstrap-auth.test.mjs tests/wildfire-bootstrap-health.test.mjs` — **72 pass, 0 fail**
- `node --test tests/scripts-railway-nixpacks-no-escape-import.test.mts` — **145 pass**, incl. `seed-thermal-escalation.mjs`
- `npm run typecheck`, `npm run typecheck:api` — pass
- Pre-push gate — pass

## Post-deploy

1. Confirm the seeder has published `thermal:escalation-bootstrap:v1` (≤ 24 clusters, healthy envelope) **before** relying on the web change — until then bootstrap reports it missing and the client falls back to the RPC, which is graceful but uncached.
2. In a peak-hour MONITOR tap, `thermal:escalation:v1` should drop out of the bootstrap origin reads and the compact key should take its place at ~1/5 the bytes.

Stacks cleanly with #5302 (cyberThreats → on-demand). Together: **~2.15 + ~2.5 ≈ 4.7 GB/day.**