### PR TITLE
fix(forecast): give DeepSeek-Flash the routing its timeout always assumed

### DIFF
--- a/scripts/_llm-model-timeouts.d.mts
+++ b/scripts/_llm-model-timeouts.d.mts
@@ -1,7 +1,18 @@
-// Declaration file for the dependency-free timeout policy shared by the
-// Railway forecast workers and bundled server code.
+// Declaration file for the dependency-free timeout + OpenRouter routing policy
+// shared by the Railway forecast workers and bundled server code.
 export const DEEPSEEK_V4_FLASH_MODEL_PREFIX: string;
 export const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS: number;
+export const DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS: number;
+
+export const OPENROUTER_BLOCKED_PROVIDERS: readonly string[];
+export const OPENROUTER_PROVIDER_ROUTING: {
+  readonly ignore: readonly string[];
+  readonly sort: 'throughput';
+};
 
 export function isDeepseekV4FlashModel(model: string): boolean;
-export function getLlmAttemptTimeoutMs(model: string, requestedTimeoutMs: number): number;
+export function getLlmAttemptTimeoutMs(
+  model: string,
+  requestedTimeoutMs: number,
+  capMs?: number,
+): number;

--- a/scripts/_llm-model-timeouts.mjs
+++ b/scripts/_llm-model-timeouts.mjs
@@ -1,18 +1,75 @@
-// Shared model-specific LLM timeout policy. This module lives in scripts/
-// because Railway forecast workers package only that directory; server code
-// can import it and Vercel's build inlines the dependency.
+// Shared model-specific LLM timeout + OpenRouter routing policy. This module lives
+// in scripts/ because Railway forecast workers package only that directory; server
+// code can import it and Vercel's build inlines the dependency.
+//
+// Timeout and routing live TOGETHER on purpose: the Flash completion timeout is only
+// meaningful under throughput-sorted routing. seed-forecasts previously had the
+// timeout but NOT the routing (the routing existed only in server/_shared/llm.ts),
+// so OpenRouter free-routed its calls to backends 4-7x slower than the timeout
+// allowed and every market_implications run failed. Keeping both here means a
+// consumer cannot pick up one without the other.
 export const DEEPSEEK_V4_FLASH_MODEL_PREFIX = 'deepseek/deepseek-v4-flash';
 
+// OpenRouter provider routing. WorldMonitor is a geopolitical product, so inference
+// must never physically run on a China-hosted provider — one could log queries or
+// bias outputs on the exact topics we cover (Taiwan, Xinjiang, the South China Sea,
+// etc.). We BLOCK the known China-based providers and let OpenRouter serve the model
+// (DeepSeek weights are fine; hosting is the concern) from the fastest of the rest.
+//   - `ignore`: blocklist. These MUST be OpenRouter's lowercase provider SLUGS (from
+//     GET /api/v1/providers), NOT display names — OpenRouter silently drops
+//     unrecognized entries, so a display name like "DeepSeek" matches nothing and the
+//     block is a no-op (caught in #4993 review). Verified against /providers
+//     2026-07-07. RE-AUDIT periodically — a new China-based entrant would otherwise
+//     be eligible, and an entry here may be MIS-classified (novita is
+//     San-Francisco-headquartered; its GPU hosting is not publicly disclosed).
+//   - `sort: throughput`: also steers off OpenRouter's cheapest-but-slowest default
+//     to the fastest eligible provider.
+// Blocking costs nothing: measured on the market_implications call shape, the
+// eligible set (Venice/AtlasCloud) is FASTER than the unrestricted set —
+// p50 15.3s / p90 22.4s / max 25.0s vs p50 17.5s / p90 26.4s / max 34.7s.
+export const OPENROUTER_BLOCKED_PROVIDERS = [
+  'baidu', 'alibaba', 'deepseek', 'siliconflow', 'streamlake', 'novita',
+];
+
+export const OPENROUTER_PROVIDER_ROUTING = {
+  ignore: OPENROUTER_BLOCKED_PROVIDERS,
+  sort: 'throughput',
+};
+
 // This is a non-streaming completion deadline, not a first-token deadline.
-// Keep it above the pinned endpoint's observed p50 while cutting off the 25s stall tail.
+//
+// DEFAULT (15s): short utility completions — the shared server LLM client (brief,
+// classification, etc.). Calibrated for those payloads; do not raise it to suit a
+// long-generation caller, pass a bigger cap instead.
 export const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
+
+// LONG (40s): large generations, e.g. forecast stages at max_tokens 2500, which emit
+// ~1.2-1.9k completion tokens. Measured against production under the routing above:
+// p50 15.3s, p90 22.4s, max 25.0s across 14 samples => 40s covers 100% with margin.
+// The old behaviour clamped these to 15s — BELOW the fastest observed completion —
+// so the primary provider could never succeed and every run wrote a SEED_ERROR.
+export const DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS = 40_000;
 
 export function isDeepseekV4FlashModel(model) {
   return model.startsWith(DEEPSEEK_V4_FLASH_MODEL_PREFIX);
 }
 
-export function getLlmAttemptTimeoutMs(model, requestedTimeoutMs) {
+// Stays a MIN: a caller asking for LESS than the cap must still get less (the shared
+// client passes 8s for some utility calls and must not be silently loosened to 15s).
+//
+// capMs lets a long-generation caller (forecast stages, max_tokens 2500) opt into a
+// bigger ceiling without raising it for every short utility call. The caller is then
+// responsible for also requesting a timeout >= capMs — a provider entry's `timeout`
+// is shared across whatever model a stage overrides onto it (the forecast openrouter
+// entry also serves google/gemini-2.5-flash for critical_signals), so raising THAT to
+// suit Flash would silently loosen Gemini too. See resolveForecastLlmProviders, which
+// passes a Flash-specific requested timeout and leaves other models on 25s.
+export function getLlmAttemptTimeoutMs(
+  model,
+  requestedTimeoutMs,
+  capMs = DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS,
+) {
   return isDeepseekV4FlashModel(model)
-    ? Math.min(requestedTimeoutMs, DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS)
+    ? Math.min(requestedTimeoutMs, capMs)
     : requestedTimeoutMs;
 }

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14715,7 +14715,7 @@ const FORECAST_FLASH_REQUESTED_TIMEOUT_MS = 45_000;
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
 // 3 retries (=4 attempts/provider): during an OpenRouter slowdown 2 retries all timed
 // out and market_implications wrote an error seed-meta. Bounded by the per-stage /
-// per-run LLM budgets below, so extra attempts can't blow the 180s seed lock.
+// per-run LLM budgets below, so extra attempts can't blow the 240s seed lock.
 const FORECAST_LLM_PROVIDER_MAX_RETRIES = 3;
 const FORECAST_LLM_RETRY_BASE_MS = 1_000;
 const FORECAST_LLM_RETRY_AFTER_MAX_MS = 10_000;
@@ -14726,8 +14726,8 @@ const FORECAST_LLM_STAGE_BUDGET_GUARD_MS = 5_000;
 // call, but a run makes ~10 LLM calls (scenario/combined/critique/impact +
 // market-implications in afterPublish) — all under the same 240s lock with no
 // lock renewal. Without a run-level cap, several degraded stages still serialize
-// past 180s and the lock expires mid-run, letting the next cron tick start a
-// duplicate. 150s leaves ~30s for input reads, publish, and cleanup.
+// past 240s and the lock expires mid-run, letting the next cron tick start a
+// duplicate. 200s leaves 40s for input reads, publish, and cleanup.
 // The seed lock bounds the WHOLE run (fetch + publish + afterPublish tail).
 // FORECAST_LLM_RUN_BUDGET_MS must stay strictly below it with cleanup headroom;
 // tests/forecast-llm-flash-routing-and-timeout pins that invariant.
@@ -17353,7 +17353,7 @@ if (_isDirectRun) {
         await clearForecastRefreshRequestIfUnchanged(triggerContext.triggerRequest);
       }
 
-      // market_implications is the last remaining LLM stage and shares the 150s
+      // market_implications is the last remaining LLM stage and shares the 200s
       // run budget (#4978). Run it BEFORE the best-effort telemetry below
       // (history + deep-forecast snapshots, ~20s R2 trace export) so their
       // wall-clock can't push the tail stage past the run deadline and starve

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14812,8 +14812,10 @@ function getForecastLlmCallOptions(stage = 'default') {
         openrouter: process.env.FORECAST_LLM_CRITICAL_MODEL_OPENROUTER || 'google/gemini-2.5-flash',
       },
       // Legacy request-body parity: the pinned models predate the
-      // reasoning-off extraBody on the table's openrouter entry.
-      extraBodyOverrides: { openrouter: null },
+      // reasoning-off extraBody on the table's openrouter entry. Keep that
+      // omission, but never drop the mandatory provider-routing policy: a
+      // Groq fallback still sends this probability-bearing prompt to OpenRouter.
+      extraBodyOverrides: { openrouter: { provider: OPENROUTER_PROVIDER_ROUTING } },
     };
   }
 

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11,7 +11,12 @@ import { attachResolutionSpecs } from './_forecast-resolution.mjs';
 import { assessFunnelDiversity } from './_forecast-funnel.mjs';
 import { resolveR2StorageConfig, putR2JsonObject, getR2JsonObject } from './_r2-storage.mjs';
 import { extractFirstJsonObject, extractFirstJsonArray, cleanJsonText } from './_llm-json.mjs';
-import { getLlmAttemptTimeoutMs, isDeepseekV4FlashModel } from './_llm-model-timeouts.mjs';
+import {
+  getLlmAttemptTimeoutMs,
+  isDeepseekV4FlashModel,
+  OPENROUTER_PROVIDER_ROUTING,
+  DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS,
+} from './_llm-model-timeouts.mjs';
 import { loadTickerSet } from './_ticker-validation.mjs';
 import { computeEmaWindows, computeRisk24h } from './_ema-threat-engine.mjs';
 import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.mjs';
@@ -14682,9 +14687,31 @@ function selectForecastsForEnrichment(predictions, options = {}) {
 // llama-3.3-70b-versatile is the free-tier/outage fallback. Per-stage
 // FORECAST_LLM_*_PROVIDER_ORDER env still overrides.
 const FORECAST_LLM_PROVIDERS = [
-  { name: 'openrouter', envKey: 'OPENROUTER_API_KEY', apiUrl: 'https://openrouter.ai/api/v1/chat/completions', model: 'deepseek/deepseek-v4-flash', timeout: 25_000, extraBody: { reasoning: { enabled: false } } },
+  // `provider.sort: 'throughput'` makes OpenRouter dispatch to its fastest backend
+  // instead of free-routing. Without it the SAME model lands on backends spanning
+  // an order of magnitude (17s .. 110s), and no completion timeout is reliable —
+  // this is the routing that DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS has always
+  // assumed but never had. Fallbacks stay enabled, so a fast backend going down
+  // degrades latency rather than hard-failing the call.
+  // This 25s timeout governs NON-Flash models only (critical_signals overrides this
+  // same entry onto google/gemini-2.5-flash and must keep its 25s window). Flash uses
+  // its own completion deadline via getLlmAttemptTimeoutMs — see _llm-model-timeouts.
+  { name: 'openrouter', envKey: 'OPENROUTER_API_KEY', apiUrl: 'https://openrouter.ai/api/v1/chat/completions', model: 'deepseek/deepseek-v4-flash', timeout: 25_000, extraBody: { reasoning: { enabled: false }, provider: OPENROUTER_PROVIDER_ROUTING } },
   { name: 'groq', envKey: 'GROQ_API_KEY', apiUrl: 'https://api.groq.com/openai/v1/chat/completions', model: 'llama-3.3-70b-versatile', timeout: 20_000 },
 ];
+
+// market_implications does NOT fall back to groq. Groq's free tier caps at 100k
+// tokens/day and this stage alone needs ~114k (4,749 tokens x 24 hourly runs), so
+// the fallback 429s for most of the day. Reserving 20s of run budget for a provider
+// that returns 429 in 86ms only raises the admission bar and starves the stage.
+// OpenRouter is the primary and, with throughput routing, succeeds 100% of measured
+// runs. Still overridable via FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER.
+const MARKET_IMPLICATIONS_DEFAULT_PROVIDER_ORDER = ['openrouter'];
+
+// Requested window for DeepSeek-Flash in forecast stages. Kept above the Flash
+// completion cap so the cap (not this) is the binding constraint; the provider
+// entry's own 25s stays reserved for the non-Flash models stages pin onto it.
+const FORECAST_FLASH_REQUESTED_TIMEOUT_MS = 45_000;
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
 // 3 retries (=4 attempts/provider): during an OpenRouter slowdown 2 retries all timed
 // out and market_implications wrote an error seed-meta. Bounded by the per-stage /
@@ -14692,16 +14719,20 @@ const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider 
 const FORECAST_LLM_PROVIDER_MAX_RETRIES = 3;
 const FORECAST_LLM_RETRY_BASE_MS = 1_000;
 const FORECAST_LLM_RETRY_AFTER_MAX_MS = 10_000;
-// The forecast seed lock is 180s; leave headroom for non-LLM work and cleanup.
+// The forecast seed lock is 240s; leave headroom for non-LLM work and cleanup.
 const FORECAST_LLM_STAGE_BUDGET_MS = 120_000;
 const FORECAST_LLM_STAGE_BUDGET_GUARD_MS = 5_000;
 // Cumulative LLM ceiling for one seed run. The per-stage budget bounds a single
 // call, but a run makes ~10 LLM calls (scenario/combined/critique/impact +
-// market-implications in afterPublish) — all under the same 180s lock with no
+// market-implications in afterPublish) — all under the same 240s lock with no
 // lock renewal. Without a run-level cap, several degraded stages still serialize
 // past 180s and the lock expires mid-run, letting the next cron tick start a
 // duplicate. 150s leaves ~30s for input reads, publish, and cleanup.
-const FORECAST_LLM_RUN_BUDGET_MS = 150_000;
+// The seed lock bounds the WHOLE run (fetch + publish + afterPublish tail).
+// FORECAST_LLM_RUN_BUDGET_MS must stay strictly below it with cleanup headroom;
+// tests/forecast-llm-flash-routing-and-timeout pins that invariant.
+const FORECAST_SEED_LOCK_TTL_MS = 240_000;
+const FORECAST_LLM_RUN_BUDGET_MS = 200_000;
 // Anchored at the start of the direct seed run; null in tests and the deep-forecast
 // worker (separate entry/lock) so only the per-stage budget applies there.
 let forecastLlmRunDeadlineMs = null;
@@ -14743,8 +14774,12 @@ function getForecastLlmCallOptions(stage = 'default') {
       ? (criticalProviderOrder || globalProviderOrder || defaultProviderOrder)
       : stage === 'impact_expansion'
         ? (impactProviderOrder || globalProviderOrder || defaultProviderOrder)
+      // Deliberately does NOT fall through to globalProviderOrder: that env is set
+      // to `openrouter,groq` in production, which would re-add the groq fallback
+      // this stage must not depend on (see MARKET_IMPLICATIONS_DEFAULT_PROVIDER_ORDER).
+      // Its own stage env still overrides.
       : stage === 'market_implications'
-        ? (marketImplicationsProviderOrder || globalProviderOrder || defaultProviderOrder)
+        ? (marketImplicationsProviderOrder || MARKET_IMPLICATIONS_DEFAULT_PROVIDER_ORDER)
       : (globalProviderOrder || defaultProviderOrder);
 
   const openrouterModel = stage === 'combined'
@@ -14807,7 +14842,16 @@ function resolveForecastLlmProviders(options = {}) {
       model,
       // #5246: cut off Flash's 25s stall tail while preserving enough room for
       // the pinned endpoint's observed median completion. Other models are unchanged.
-      timeout: getLlmAttemptTimeoutMs(model, provider.timeout),
+      // Flash is a LONG generation here (max_tokens 2500 => ~1.2-1.9k completion
+      // tokens, p90 22.4s) and needs its own requested window: the entry's 25s is
+      // calibrated for the NON-Flash models stages override onto it (Gemini), so
+      // reusing it would re-clamp Flash to 25s. getLlmAttemptTimeoutMs still MINs
+      // this against the Flash cap, and leaves non-Flash models on provider.timeout.
+      timeout: getLlmAttemptTimeoutMs(
+        model,
+        isDeepseekV4FlashModel(model) ? FORECAST_FLASH_REQUESTED_TIMEOUT_MS : provider.timeout,
+        DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS,
+      ),
       failFastOnTimeout,
       // `null` explicitly clears the table entry's extraBody (R13 pin);
       // undefined leaves it untouched.
@@ -15093,7 +15137,7 @@ function getForecastLlmStageBudgetMs(options = {}) {
 function getRemainingForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
   const stageRemaining = budgetStartedAtMs + stageBudgetMs - Date.now();
   // The run deadline (when set) caps cumulative LLM time across all stages so
-  // the seed can't outlive its 180s lock; whichever budget is tighter wins.
+  // the seed can't outlive its 240s lock; whichever budget is tighter wins.
   // Single source of truth for run-remaining lives in getRemainingForecastLlmRunBudgetMs.
   const runRemaining = getRemainingForecastLlmRunBudgetMs();
   return Math.max(0, Math.min(stageRemaining, runRemaining));
@@ -15107,7 +15151,7 @@ function getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
 // tests and the deep-forecast worker, which have only the per-stage budget).
 // market_implications runs LAST in afterPublish, so this is the budget that
 // starves it when upstream stages are slow (e.g. repeated provider stalls drain
-// the shared 150s run budget before the tail stage runs). #4978.
+// the shared 200s run budget before the tail stage runs). #4978.
 function getRemainingForecastLlmRunBudgetMs() {
   return forecastLlmRunDeadlineMs == null ? Infinity : forecastLlmRunDeadlineMs - Date.now();
 }
@@ -17100,7 +17144,7 @@ async function writeMarketImplicationsFailureMeta(reason) {
 }
 
 // A budget-starve is NOT a producer failure — it's resource contention from
-// slow upstream stages consuming the shared 150s run budget before this tail
+// slow upstream stages consuming the shared 200s run budget before this tail
 // stage runs (#4978). Unlike writeMarketImplicationsFailureMeta, this preserves
 // last-good seed-meta without advancing fetchedAt: existing OK meta is TTL-
 // refreshed, and stale error meta is replaced only when the canonical payload
@@ -17162,7 +17206,7 @@ async function buildAndSeedMarketImplications(inputs) {
   } catch { /* guard is best-effort — fall through to live generation */ }
 
   // Tail-stage budget guard (#4978): market_implications is the LAST forecast
-  // LLM stage under the shared 150s run budget. When upstream stages are slow
+  // LLM stage under the shared 200s run budget. When upstream stages are slow
   // (e.g. repeated provider stalls) they drain that budget before this
   // stage runs; callForecastLLM would then throw a budget error, return null,
   // and we'd (mis)write a SEED_ERROR for benign, self-healing resource
@@ -17282,7 +17326,9 @@ if (_isDirectRun) {
   console.log(`  [Trigger] source=${triggerContext.triggerSource}${triggerContext.triggerRequest?.requester ? ` requester=${triggerContext.triggerRequest.requester}` : ''}`);
 
   // Bound cumulative LLM time across every stage of this run (fetchForecasts +
-  // afterPublish market-implications) so the seed can't outlive its 180s lock.
+  // afterPublish market-implications) so the seed can't outlive its 240s lock.
+  // 200s run budget < 240s lock: upstream would have to burn >155s to starve the
+  // ~45s market_implications tail, which throughput-routed stages (p90 26s) cannot.
   beginForecastLlmRunBudget();
 
   await runSeed('forecast', 'predictions', CANONICAL_KEY, async () => {
@@ -17293,7 +17339,7 @@ if (_isDirectRun) {
     };
   }, {
     ttlSeconds: TTL_SECONDS,
-    lockTtlMs: 180_000,
+    lockTtlMs: FORECAST_SEED_LOCK_TTL_MS,
     validateFn: (data) => Array.isArray(data?.predictions) && data.predictions.length > 0,
     declareRecords,
     sourceVersion: 'detectors+llm-pipeline',
@@ -18853,6 +18899,9 @@ export {
   selectForecastsForEnrichment,
   parseForecastProviderOrder,
   getForecastLlmCallOptions,
+  getMarketImplicationsMinRunBudgetMs,
+  FORECAST_LLM_RUN_BUDGET_MS,
+  FORECAST_SEED_LOCK_TTL_MS,
   resolveForecastLlmProviders,
   resolveScenarioLlmResult,
   buildFallbackScenario,

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -2,7 +2,10 @@ import { CHROME_UA } from './constants';
 import { isProviderAvailable } from './llm-health';
 import { sanitizeForPrompt } from './llm-sanitize.js';
 import { buildLlmCallEvent, deliverUsageEvents, type LlmCallEvent } from './usage';
-import { getLlmAttemptTimeoutMs } from '../../scripts/_llm-model-timeouts.mjs';
+import {
+  getLlmAttemptTimeoutMs,
+  OPENROUTER_PROVIDER_ROUTING,
+} from '../../scripts/_llm-model-timeouts.mjs';
 
 export { getLlmAttemptTimeoutMs } from '../../scripts/_llm-model-timeouts.mjs';
 
@@ -45,28 +48,12 @@ function isLocalDeployment(): boolean {
   return mode.includes('sidecar') || mode.includes('docker');
 }
 
-// OpenRouter provider routing. WorldMonitor is a geopolitical product, so
-// inference must never physically run on a China-hosted provider — one could
-// log queries or bias outputs on the exact topics we cover (Taiwan, Xinjiang,
-// the South China Sea, etc.). We BLOCK the known China-based providers and let
-// OpenRouter serve the model (DeepSeek weights are fine; hosting is the
-// concern) from the fastest of the rest.
-//   - `ignore`: blocklist. These MUST be OpenRouter's lowercase provider
-//     SLUGS (from GET /api/v1/providers), NOT display names — OpenRouter
-//     silently drops unrecognized entries, so a display name like "DeepSeek"
-//     matches nothing and the block is a no-op (caught in #4993 review).
-//     Verified against /providers 2026-07-07. RE-AUDIT periodically — a new
-//     China-based entrant would otherwise be eligible.
-//   - `sort: throughput`: also steers off OpenRouter's cheapest-but-slowest
-//     default (DeepInfra ~17 tok/s) to the fastest eligible provider, which is
-//     the brief-latency win we were chasing (#4983 follow-up).
-const OPENROUTER_BLOCKED_PROVIDERS = [
-  'baidu', 'alibaba', 'deepseek', 'siliconflow', 'streamlake', 'novita',
-];
-const OPENROUTER_PROVIDER_ROUTING = {
-  ignore: OPENROUTER_BLOCKED_PROVIDERS,
-  sort: 'throughput',
-} as const;
+// OpenRouter provider routing now lives in scripts/_llm-model-timeouts.mjs, next to
+// the Flash completion timeout it is inseparable from. It used to be defined HERE
+// only, which meant the Railway forecast seeder (which cannot import server/) had the
+// timeout but NOT the routing: OpenRouter free-routed its calls to backends 4-7x
+// slower than the timeout allowed, and every market_implications run failed. One
+// source of truth so a consumer cannot pick up the timeout without the routing.
 
 export function getProviderCredentials(
   provider: string,

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -85,6 +85,7 @@ import {
   __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,
 } from '../scripts/seed-forecasts.mjs';
+import { OPENROUTER_PROVIDER_ROUTING } from '../scripts/_llm-model-timeouts.mjs';
 import { CONFLICT_COUNT_SOURCE_FEED } from '../scripts/_forecast-resolution.mjs';
 
 const originalForecastEnv = {
@@ -1662,7 +1663,11 @@ describe('forecast llm overrides', () => {
     assert.equal(providers[1]?.name, 'openrouter');
     assert.equal(providers[1]?.model, 'google/gemini-2.5-flash');
     assert.equal(providers[1]?.timeout, 25_000, 'the DeepSeek stall cutoff must not change the pinned Gemini fallback');
-    assert.equal(providers[1]?.extraBody, undefined, 'pinned openrouter entry must keep the legacy request body (no reasoning field)');
+    assert.deepEqual(
+      providers[1]?.extraBody,
+      { provider: OPENROUTER_PROVIDER_ROUTING },
+      'pinned OpenRouter fallback keeps the mandatory provider policy without adding a reasoning override',
+    );
   });
 
   it('lets ONLY the stage-scoped env override unpin critical_signals', () => {
@@ -1709,7 +1714,7 @@ describe('forecast llm overrides', () => {
 
     assert.equal(providers[0]?.model, 'llama-3.1-8b-instant');
     assert.equal(providers[1]?.model, 'google/gemini-2.5-flash');
-    assert.equal(providers[1]?.extraBody, undefined);
+    assert.deepEqual(providers[1]?.extraBody, { provider: OPENROUTER_PROVIDER_ROUTING });
 
     // The stage-scoped model env DOES reach the pinned fallback slot.
     process.env.FORECAST_LLM_CRITICAL_MODEL_OPENROUTER = 'google/gemini-2.5-pro';

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -1631,7 +1631,14 @@ describe('forecast llm overrides', () => {
     assert.deepEqual(options.providerOrder, ['openrouter', 'groq']);
     assert.equal(providers[0]?.name, 'openrouter');
     assert.equal(providers[0]?.model, 'deepseek/deepseek-v4-flash');
-    assert.equal(providers[0]?.timeout, 15_000, 'stalled DeepSeek Flash calls must fall through before the 25s clamp');
+    // Was 15_000: a 'stall cutoff' that treated the SYMPTOM of unrouted OpenRouter
+    // requests landing on slow backends. The cause is now fixed at the source (the
+    // openrouter entry carries OPENROUTER_PROVIDER_ROUTING, so calls go to the
+    // fastest non-China-hosted backend). Under that routing Flash completes at p90
+    // 22.4s, so a 15s cutoff did not prevent stalls — it GUARANTEED failure, and
+    // every market_implications run wrote a SEED_ERROR. Flash now gets a completion
+    // deadline that covers its measured distribution.
+    assert.equal(providers[0]?.timeout, 40_000, 'Flash gets its measured completion deadline under pinned routing');
     assert.equal(providers[1]?.name, 'groq');
     assert.equal(providers[1]?.model, 'llama-3.3-70b-versatile');
     assert.equal(providers[1]?.timeout, 20_000, 'the fallback keeps its provider-specific window');
@@ -1731,7 +1738,7 @@ describe('forecast llm overrides', () => {
     assert.deepEqual(scenarioOptions.providerOrder, ['openrouter', 'groq']);
     assert.equal(scenarioProviders[0]?.name, 'openrouter');
     assert.equal(scenarioProviders[0]?.model, 'deepseek/deepseek-v4-flash');
-    assert.equal(scenarioProviders[0]?.timeout, 15_000);
+    assert.equal(scenarioProviders[0]?.timeout, 40_000, 'Flash completion deadline (see above); non-Flash overrides keep 25s');
     assert.equal(scenarioProviders[1]?.model, 'llama-3.3-70b-versatile');
   });
 

--- a/tests/forecast-llm-flash-routing-and-timeout.test.mjs
+++ b/tests/forecast-llm-flash-routing-and-timeout.test.mjs
@@ -1,0 +1,190 @@
+// DeepSeek-Flash routing + completion-timeout policy.
+//
+// Bug (found 2026-07-14 by probing production): market_implications wrote
+// `status:'error' / errorReason:'llm_no_response'` on EVERY hourly run, so
+// /api/health sat at SEED_ERROR indefinitely and the homepage panel served
+// frozen last-good cards.
+//
+// Root cause was NOT a slow model — it was a timeout that assumed a pinning
+// which was never implemented:
+//
+//   _llm-model-timeouts.mjs: DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS = 15_000
+//   "Keep it above the pinned endpoint's observed p50"   <-- nothing pinned it
+//
+// OpenRouter free-routes `deepseek/deepseek-v4-flash` across backends whose
+// latency spans an order of magnitude. Measured against production, 12 samples
+// of the real market_implications call shape (max_tokens 2500, ~2.3k-token
+// prompt):
+//
+//   Novita / StreamLake / AtlasCloud : 17-28s   (fast)
+//   DigitalOcean / GMICloud          : 61-73s
+//   NextBit                          : 110s
+//   one call                         : >120s, never returned
+//
+// The FASTEST of those 12 was 17.1s — above the 15s clamp. So the primary
+// provider could not succeed even once: 0/12 at 15s. The groq fallback was
+// simultaneously 429-ing (free-tier 100k tokens/day, exhausted), hence
+// llm_no_response every run.
+//
+// Fix, measured over 20 samples with `provider: { sort: 'throughput' }`:
+//   timeout 15s -> 25%   timeout 25s -> 85%   timeout 40s -> 100%
+//
+// These tests pin BOTH halves. Either alone is insufficient: routing without a
+// workable timeout still guillotines the p90 (26.4s), and a longer timeout
+// without routing still lands on NextBit (110s).
+import test, { afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS,
+  OPENROUTER_BLOCKED_PROVIDERS,
+} from '../scripts/_llm-model-timeouts.mjs';
+import {
+  getForecastLlmCallOptions,
+  resolveForecastLlmProviders,
+  getMarketImplicationsMinRunBudgetMs,
+  FORECAST_LLM_RUN_BUDGET_MS,
+  FORECAST_SEED_LOCK_TTL_MS,
+} from '../scripts/seed-forecasts.mjs';
+
+// Observed completion latencies (ms) under the COMPLIANT routing — China-hosted
+// providers BLOCKED and throughput-sorted — 14 samples against production.
+// Landed on Venice + AtlasCloud only. Blocking costs nothing: this set is FASTER
+// than the unrestricted one (which reached p50 17.5s / max 34.7s only by routing to
+// novita/streamlake, i.e. by violating the policy).
+const MEASURED_THROUGHPUT_ROUTED_MS = [
+  16252, 17263, 15944, 10085, 15851, 14360, 22448,
+  14739, 14439, 25037, 15281, 14529, 12883, 16408,
+];
+
+function coverage(timeoutMs) {
+  const ok = MEASURED_THROUGHPUT_ROUTED_MS.filter((ms) => ms <= timeoutMs).length;
+  return ok / MEASURED_THROUGHPUT_ROUTED_MS.length;
+}
+
+// getMarketImplicationsMinRunBudgetMs key-filters the chain on process.env, and
+// the stage/global provider-order envs steer resolution — so both must be
+// controlled here, or the reservation silently computes against an empty chain.
+const ENV_KEYS = [
+  'OPENROUTER_API_KEY',
+  'GROQ_API_KEY',
+  'FORECAST_LLM_PROVIDER_ORDER',
+  'FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER',
+];
+let savedEnv = {};
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+  process.env.GROQ_API_KEY = 'test-groq-key';
+  // Production sets this to `openrouter,groq`. market_implications must NOT
+  // inherit it — that is the precedence this fix deliberately breaks.
+  process.env.FORECAST_LLM_PROVIDER_ORDER = 'openrouter,groq';
+  delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+test('the Flash completion timeout clears the measured p90 (the 15s clamp made the primary impossible)', () => {
+  // The old 15s clamp sat BELOW the fastest observed completion for this call
+  // shape, so no amount of retrying could ever succeed.
+  assert.ok(
+    DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS > Math.min(...MEASURED_THROUGHPUT_ROUTED_MS),
+    'timeout must exceed the FASTEST observed completion, or the primary can never succeed',
+  );
+  // The user's bar: succeed 90%+ of the time.
+  assert.ok(
+    coverage(DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS) >= 0.9,
+    `timeout ${DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS}ms only covers `
+      + `${(coverage(DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS) * 100).toFixed(0)}% of measured runs; need >=90%`,
+  );
+});
+
+test('the provider-level timeout does not re-clamp Flash below its completion budget', () => {
+  // getLlmAttemptTimeoutMs takes min(providerTimeout, flashCap). A provider
+  // timeout below the cap silently reinstates the bug, which is exactly what
+  // the old 25s provider timeout did to a 40s cap.
+  const [openrouter] = resolveForecastLlmProviders(getForecastLlmCallOptions('market_implications'));
+  assert.equal(openrouter.name, 'openrouter');
+  assert.equal(
+    openrouter.timeout,
+    DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS,
+    'the effective attempt timeout must equal the Flash cap, not a lower provider timeout',
+  );
+  assert.ok(coverage(openrouter.timeout) >= 0.9);
+});
+
+test('Flash is pinned to fast backends — the timeout policy assumes routing that must actually exist', () => {
+  const [openrouter] = resolveForecastLlmProviders(getForecastLlmCallOptions('market_implications'));
+  // Without this, OpenRouter free-routes to NextBit (110s) / DigitalOcean (73s)
+  // and NO timeout under ~120s is reliable.
+  assert.equal(
+    openrouter.extraBody?.provider?.sort,
+    'throughput',
+    'openrouter must request throughput-sorted routing so the latency tail is bounded',
+  );
+  // The seeder MUST carry the same China-hosted-provider blocklist as the server
+  // client. Throughput-sorting WITHOUT it routes WorldMonitor's geopolitical
+  // prompts straight onto the blocked providers, because they are the fastest —
+  // the policy and the speed fix pull in opposite directions, so they must ship
+  // together. This is the regression that nearly shipped.
+  assert.deepEqual(
+    openrouter.extraBody?.provider?.ignore,
+    OPENROUTER_BLOCKED_PROVIDERS,
+    'seeder routing must apply the shared China-hosted provider blocklist',
+  );
+  // The reasoning:false pin must survive the change (Flash emits reasoning
+  // tokens otherwise, inflating latency and cost for no benefit).
+  assert.equal(openrouter.extraBody?.reasoning?.enabled, false);
+});
+
+test('market_implications does not depend on groq', () => {
+  // Groq free tier caps at 100k tokens/day; this stage alone needs ~114k/day
+  // (4,749 tokens x 24 hourly runs), so the fallback 429s for most of the day.
+  // It is not a dependable fallback and reserving budget for it only raises the
+  // admission bar (=> more starvation) for a provider that returns 429 in 86ms.
+  const providers = resolveForecastLlmProviders(getForecastLlmCallOptions('market_implications'));
+  assert.deepEqual(providers.map((p) => p.name), ['openrouter']);
+});
+
+test('the market_implications admission reservation covers exactly its own chain', () => {
+  // market_implications runs LAST (afterPublish) on the SAME run budget as every
+  // upstream stage, and afterPublish is INSIDE the seed lock — so the tail cannot
+  // simply be handed its own budget without risking a lock overrun.
+  //
+  // Dropping groq is what keeps this affordable: the reservation is the sum of the
+  // resolved chain's timeouts + guard. Keeping groq would reserve 40+20+5 = 65s of
+  // run budget for a provider that 429s in 86ms, raising the admission bar (=> MORE
+  // starvation) to buy nothing.
+  const reservation = getMarketImplicationsMinRunBudgetMs(getForecastLlmCallOptions('market_implications'));
+  assert.equal(reservation, DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS + 5_000, 'openrouter attempt + guard only');
+});
+
+test('the run budget leaves the tail its reservation, and still fits inside the seed lock', () => {
+  // Two invariants that must move together. Raising the Flash timeout makes upstream
+  // stages actually COMPLETE (~20s) instead of dying at 15s, so they consume more of
+  // the shared run budget — the tail needs headroom, but the whole run must still
+  // finish inside the lock or a slow run gets its lock stolen mid-write.
+  const reservation = getMarketImplicationsMinRunBudgetMs(getForecastLlmCallOptions('market_implications'));
+
+  // Upstream would have to burn (200s - 45s) = 155s to starve the tail. Throughput-
+  // routed stages are p90 26s / capped at 40s, so this cannot happen in practice.
+  assert.ok(
+    FORECAST_LLM_RUN_BUDGET_MS - reservation >= 150_000,
+    'run budget must leave upstream ample room while still preserving the tail reservation',
+  );
+  // The run budget must stay strictly under the lock, with cleanup headroom.
+  assert.ok(
+    FORECAST_LLM_RUN_BUDGET_MS < FORECAST_SEED_LOCK_TTL_MS,
+    'LLM run budget must not be able to outlive the seed lock',
+  );
+  assert.ok(
+    FORECAST_SEED_LOCK_TTL_MS - FORECAST_LLM_RUN_BUDGET_MS >= 30_000,
+    'leave >=30s of lock headroom for non-LLM work, publish and cleanup',
+  );
+});

--- a/tests/forecast-llm-flash-routing-and-timeout.test.mjs
+++ b/tests/forecast-llm-flash-routing-and-timeout.test.mjs
@@ -8,7 +8,7 @@
 // Root cause was NOT a slow model — it was a timeout that assumed a pinning
 // which was never implemented:
 //
-//   _llm-model-timeouts.mjs: DEEPSEEK_V4_FLASH_LONG_COMPLETION_TIMEOUT_MS = 15_000
+//   _llm-model-timeouts.mjs: DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000
 //   "Keep it above the pinned endpoint's observed p50"   <-- nothing pinned it
 //
 // OpenRouter free-routes `deepseek/deepseek-v4-flash` across backends whose

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -1,7 +1,7 @@
 // market_implications budget-starve handling (#4978).
 //
 // market_implications is the LAST forecast LLM stage (afterPublish) and shares
-// the single 150s run budget with every upstream stage. When upstream stages
+// the single 200s run budget with every upstream stage. When upstream stages
 // are slow (e.g. repeated LLM provider stalls, #4944) they drain that budget
 // before this stage runs; callForecastLLM then throws a budget error and
 // returns null. The bug: the caller treated that starve identically to a real
@@ -65,7 +65,7 @@ test('run-budget starve preserves last-good and does NOT write a SEED_ERROR', as
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
 
-  // Shared 150s run budget already blown before this tail stage runs.
+  // Shared 200s run budget already blown before this tail stage runs.
   __setForecastLlmRunDeadlineForTests(Date.now() - 1000);
 
   let llmCalls = 0;

--- a/tests/market-implications-budget-starve.test.mjs
+++ b/tests/market-implications-budget-starve.test.mjs
@@ -159,7 +159,10 @@ test('a genuine provider failure that drains the run deadline still writes a SEE
   // all-provider 40s reservation would also admit, but the test still proves the
   // resolved provider chain drives admission). The mock then drains
   // the deadline mid-flight to prove a real failure is not reclassified as a starve.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 40_000);
+  // 50s > the openrouter-only reservation (40s Flash + 5s guard = 45s), so the call
+  // is ADMITTED. (Was 40s against a 15s-Flash chain; the Flash completion deadline is
+  // now 40s — see _llm-model-timeouts.)
+  __setForecastLlmRunDeadlineForTests(Date.now() + 50_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -260,8 +263,12 @@ test('a budget covering only the primary — not the fallback — skips instead 
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.GROQ_API_KEY = 'test-key';
-  // DEFAULT chain (openrouter → groq); do NOT pin to a single provider.
-  delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+  // The 2-provider chain is no longer the market_implications DEFAULT (it is now
+  // openrouter-only — groq's free tier 429s for most of the day). Pin it explicitly:
+  // the stranded-fallback logic still exists and must stay correct for any deployment
+  // that configures a fallback. Without this the test would skip for the WRONG reason
+  // and silently stop covering #4978.
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter,groq';
   delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
   // 30s budget: enough for the primary openrouter attempt (15s) + guard, but NOT
@@ -269,7 +276,9 @@ test('a budget covering only the primary — not the fallback — skips instead 
   // admitting only the primary can strand Groq ("groq llm budget exhausted")
   // after a timeout and misreport a recoverable timeout as SEED_ERROR. The full-
   // chain reservation makes this SKIP and preserve last-good (green) instead.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 30_000);
+  // 50s covers the primary (40s Flash + 5s guard = 45s) but NOT the full
+  // openrouter→groq chain (40 + 20 + 5 = 65s) => must SKIP rather than strand groq.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 50_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -291,14 +300,20 @@ test('an admitted primary timeout falls through to the fallback in ONE attempt e
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.GROQ_API_KEY = 'test-key';
-  delete process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER;
+  // Pin the 2-provider chain explicitly: it is no longer the market_implications
+  // default, but the one-attempt-per-provider machinery must stay correct for any
+  // deployment that configures a fallback. Deleting the env here would leave an
+  // openrouter-only chain and the test could never reach groq — it would assert
+  // nothing about the #5003 regression.
+  process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter,groq';
   delete process.env.FORECAST_LLM_PROVIDER_ORDER;
 
-  // 60s admits the full two-provider chain (40s). Every attempt times out. PRE-FIX,
-  // openrouter's 3 retries (4 attempts) drained the run budget and groq was NEVER
-  // reached — a recoverable timeout became a SEED_ERROR without trying the fallback.
-  // With maxRetries:0 each provider gets exactly ONE attempt, so groq IS reached.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 60_000);
+  // 70s admits the full two-provider chain (40s Flash + 20s groq + 5s guard = 65s).
+  // Every attempt times out. PRE-FIX, openrouter's 3 retries (4 attempts) drained the
+  // run budget and groq was NEVER reached — a recoverable timeout became a SEED_ERROR
+  // without trying the fallback. With maxRetries:0 each provider gets exactly ONE
+  // attempt, so groq IS reached.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 70_000);
 
   const calls = { openrouter: 0, groq: 0 };
   __setForecastLlmTransportForTests({
@@ -325,12 +340,12 @@ test('a single-provider override reserves only that provider — admitted where 
   seedLastGood(store);
   process.env.OPENROUTER_API_KEY = 'test-key';
   process.env.GROQ_API_KEY = 'test-key';
-  // Pin to openrouter only → resolved chain reserves just 15s + 5s = 20s.
+  // Pin to openrouter only → resolved chain reserves just 40s Flash + 5s guard = 45s.
   process.env.FORECAST_LLM_MARKET_IMPLICATIONS_PROVIDER_ORDER = 'openrouter';
 
-  // 25s: below the 2-provider 40s reservation (would skip) but above the pinned
-  // single-provider 20s reservation — so this MUST be admitted, not skipped.
-  __setForecastLlmRunDeadlineForTests(Date.now() + 25_000);
+  // 50s: below the 2-provider 65s reservation (would skip) but above the pinned
+  // single-provider 45s reservation — so this MUST be admitted, not skipped.
+  __setForecastLlmRunDeadlineForTests(Date.now() + 50_000);
 
   let providerCalls = 0;
   __setForecastLlmTransportForTests({
@@ -340,5 +355,5 @@ test('a single-provider override reserves only that provider — admitted where 
 
   await buildAndSeedMarketImplications({});
 
-  assert.equal(providerCalls, 1, 'a pinned single-provider chain needs only 20s, so a 25s budget must ADMIT it (and try it once)');
+  assert.equal(providerCalls, 1, 'a pinned single-provider chain needs only 45s, so a 50s budget must ADMIT it (and try it once)');
 });


### PR DESCRIPTION
## Problem

`market_implications` wrote `status:'error' / errorReason:'llm_no_response'` on **every hourly run**. `/api/health` sat at `SEED_ERROR` indefinitely, and the homepage panel served **frozen last-good cards** — the failure path EXPIRE-refreshes the canonical key, so the data never expired, it just never updated.

## Root cause — a timeout that assumed a pinning that was never implemented

```js
// scripts/_llm-model-timeouts.mjs
DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000
// "Keep it above the pinned endpoint's observed p50"   <-- nothing pinned it
```

OpenRouter free-routes `deepseek-v4-flash` across backends spanning an order of magnitude. Measured against production on the real call shape (`max_tokens: 2500`):

| backend | latency |
|---|---|
| AtlasCloud / Venice | 10–25s |
| DigitalOcean / GMICloud | 61–73s |
| NextBit | 110s |
| one call | >120s, never returned |

**The fastest of 12 unrouted samples was 17.1s — above the 15s clamp.** The primary could not succeed *even once*: **0/12**. Meanwhile the groq fallback was 429-ing: free tier caps at 100k tokens/day and this stage alone needs ~114k (4,749 tokens × 24 hourly runs). Both providers empty → `llm_no_response`, every run.

**The routing already existed — in `server/_shared/llm.ts`.** The Railway seeder cannot import from `server/`, so it inherited the timeout but *not* the routing. **That split is the bug.** The policy now lives in `scripts/_llm-model-timeouts.mjs`, imported by both, so a consumer cannot take one without the other.

## Changes

- **Shared routing, including the China-hosted-provider blocklist.** Applying `sort: throughput` *without* the blocklist would route WorldMonitor's geopolitical prompts onto the blocked providers precisely **because they are the fastest** — the policy and the latency fix pull in opposite directions, so they must ship together. Pinned by a test. Blocking costs nothing: the eligible set is *faster* (p50 **15.3s** / p90 22.4s / max 25.0s, 14/14) than unrestricted (p50 17.5s / max 34.7s).
- **Flash gets its own completion deadline (40s → 100% of routed samples) and its own requested window.** Raising the shared provider timeout instead would have loosened `google/gemini-2.5-flash`, which `critical_signals` deliberately pins at 25s — caught by the existing test suite.
- **`market_implications` no longer depends on groq** (openrouter-only). This *lowers* its admission reservation versus reserving 20s for a provider that 429s in 86ms, so it starves **less**, not more.
- **Run budget 150s → 200s, seed lock 180s → 240s.** Upstream stages now actually *complete* (~20s) instead of dying at 15s, so the tail needs headroom. `afterPublish` runs inside the lock, so `runBudget < lockTtl` is an invariant — now pinned by a test.

## Verification

**End-to-end in production**, not just unit tests:

```
[LLM:market_implications] openrouter success model=deepseek/deepseek-v4-flash
[MarketImplications] Published 5 cards to intelligence:market-implications:v1 (23404ms)
{"event":"seed_complete","recordCount":14,"state":"OK"}
```

`/api/health` went `SEED_ERROR` → resolved (warns 3 → 2).

**Bonus fix, confirmed by the same run:** `[LLM:combined]` succeeded at **20,561ms** — it too exceeded the 15s clamp, so it had been silently degrading to `fallbackNarratives` on every run. It now produces real narratives.

- **2,305 tests pass** across every forecast/LLM/brief/news suite.
- **Mutation-tested, all three halves independently red**: restore the 15s clamp → red; drop the China blocklist → red; re-add groq to the default → red.
- Two existing tests caught real regressions in my first attempt (the Gemini 25s pin; a shared-llm caller that requests 8s and must still get 8s) — both fixed rather than papered over.
- One test would have started passing **vacuously** (#4978's stranded-fallback case skips for the wrong reason once groq leaves the default) — it now pins the 2-provider chain explicitly so the fallback machinery stays covered.
- `tsc`, `tsc -p tsconfig.api.json`, Biome clean (3 Biome infos are pre-existing — verified identical without this change).

## Note on the blocklist

`novita` is on the blocklist but is **San-Francisco-headquartered**; its GPU hosting is not publicly disclosed. I did **not** change the blocklist here — loosening a security control shouldn't ride along with a latency fix, and it buys nothing (the compliant set is already faster). Flagged in-code for re-audit.

https://claude.ai/code/session_015HXMBUiQa6iRJfjbpLWYxU
