### PR TITLE
perf(bootstrap): serve UCDP as a dashboard projection, not 2,000 raw events (#5300)

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -90,7 +90,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   stablecoinMarkets: 'market:stablecoins:v1',
   unrestEvents: 'unrest:events:v1',
   iranEvents: 'conflict:iran-events:v1',
-  ucdpEvents: 'conflict:ucdp-events:v1',
+  ucdpEvents: 'conflict:ucdp-events-bootstrap:v1',
   temporalAnomalies: 'temporal:anomalies:v1',
   weatherAlerts:     'weather:alerts:v1',
   spending:          'economic:spending:v1',

--- a/api/health.js
+++ b/api/health.js
@@ -98,6 +98,7 @@ const BOOTSTRAP_KEYS = {
   unrestEvents:      'unrest:events:v1',
   iranEvents:        'conflict:iran-events:v1',
   ucdpEvents:        'conflict:ucdp-events:v1',
+  ucdpEventsBootstrap: 'conflict:ucdp-events-bootstrap:v1',
   weatherAlerts:     'weather:alerts:v1',
   spending:          'economic:spending:v1',
   techEvents:        'research:tech-events-bootstrap:v1',
@@ -415,6 +416,7 @@ const SEED_META = {
   riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30, minRecordCount: 3 }, // CII warm-ping every 8min; recordCount is realtime signal-density coverage for score-relevant conflict (ACLED or UCDP), news, and cyber families, not raw feed availability; quiet-but-fresh feeds may warn COVERAGE_PARTIAL.
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
+  ucdpEventsBootstrap: { key: 'seed-meta:conflict:ucdp-events-bootstrap', maxStaleMin: 420 }, // Same cron. Monitored separately because the bootstrap tier now hydrates from the compact projection, and a transform/write failure there must not hide behind a healthy canonical key (#5300).
   acledIntel:       { key: 'seed-meta:conflict:acled-intel',      maxStaleMin: 38 }, // conflict:acled:v1:all:0:0, now ACLED-or-GDELT fallback for the forecast EMA input (#5099).
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,
   militaryCii:      { key: 'seed-meta:intelligence:military-cii',  maxStaleMin: 45 }, // seed-military-cii cron ~10min; 45 = generous grace (relay-dependent; preserve-last-good runs still refresh meta)
@@ -715,6 +717,7 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'forecastBets', // #5233 shadow bet-engine stream; absent before the cron ships it and empty on weeks the energy feed yields no bet — tolerate as STALE_SEED (warn), not EMPTY (crit).
   'forecastFunnel', // #5233 funnel guardrail is a new afterPublish side-write; before the first seed-forecasts run ships it the key is absent — tolerate as STALE_SEED (warn), not EMPTY (crit). A COLLAPSED funnel still surfaces via seed-meta status:'error' → SEED_ERROR, which classifyKey checks before this branch.
   'thermalEscalationBootstrap', // Compact dashboard projection is absent until the first thermal seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
+  'ucdpEventsBootstrap', // Compact dashboard projection is absent until the first ucdp seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
   'wildfiresBootstrap', // Compact dashboard side-write is absent until the first fire seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
 ]);
 

--- a/scripts/_ucdp-dashboard.mjs
+++ b/scripts/_ucdp-dashboard.mjs
@@ -136,6 +136,22 @@ export function selectUcdpPanelRows(events, rowsPerTab = UCDP_PANEL_ROWS_PER_TAB
   return kept;
 }
 
+/**
+ * Compact attributes needed to replay the existing client-side ACLED de-duplication
+ * against the full UCDP set. The panel only renders 150 rows, but its tab totals
+ * are calculated after that dynamic de-duplication; carrying this small numeric
+ * index keeps the precomputed totals faithful without restoring every raw field.
+ */
+export function buildUcdpDedupeIndex(events) {
+  return events.map((event) => [
+    UCDP_VIOLENCE_TYPES.indexOf(event.violenceType),
+    Number(event.dateStart),
+    Number(event.location?.latitude),
+    Number(event.location?.longitude),
+    Number(event.deathsBest) || 0,
+  ]);
+}
+
 export function compactUcdpDashboardPayload(payload, nowMs = Date.now(), rowsPerTab = UCDP_PANEL_ROWS_PER_TAB) {
   if (!payload || typeof payload !== 'object' || !Array.isArray(payload.events)) return payload;
 
@@ -147,6 +163,7 @@ export function compactUcdpDashboardPayload(payload, nowMs = Date.now(), rowsPer
     // array cannot change what the user sees.
     classifications: classifyUcdpEvents(events, nowMs),
     aggregates: summarizeUcdpEvents(events),
+    dedupeIndex: buildUcdpDedupeIndex(events),
     totalEvents: events.length,
   };
 }

--- a/scripts/_ucdp-dashboard.mjs
+++ b/scripts/_ucdp-dashboard.mjs
@@ -1,0 +1,152 @@
+/**
+ * Dashboard-sized projection of the UCDP conflict-event feed (#5300).
+ *
+ * `conflict:ucdp-events:v1` carries 2,000 events (662 KB) and rides in the
+ * bootstrap slow tier that EVERY client downloads on EVERY boot. Nothing renders
+ * 2,000 events. Three consumers read it, and each wants something small:
+ *
+ *   1. CII  — `deriveUcdpClassifications` folds all 2,000 events into a per-country
+ *             conflict status. 42 countries. Derived, not displayed.
+ *   2. panel — `UcdpEventsPanel` renders `filtered.slice(0, 50)` per violence-type
+ *             tab (150 rows max), but computes its tab counts and total-deaths
+ *             figures over the FULL set. So a naive truncation would silently
+ *             corrupt the numbers on screen — the counts must be precomputed.
+ *   3. map   — draws every event, but the `ucdpEvents` layer is OFF by default in
+ *             all 12 variant configs. Clients that switch it on re-fetch the full
+ *             set from the RPC; they do not need it in everyone's boot payload.
+ *
+ * So the projection ships: the rows we render + the aggregates we compute +
+ * the classifications we derive. ~662 KB -> ~55 KB, with every number on screen
+ * identical to today.
+ *
+ * ── The duplication, and why it is guarded ──────────────────────────────────
+ * `classifyUcdpEvents` below is a byte-for-byte mirror of `deriveUcdpClassifications`
+ * in src/services/conflict/index.ts. It CANNOT import it: Railway builds the
+ * seeders from a scripts-only Nixpacks root, and a `../src/` import crashes the
+ * container at startup (#5268 took the wildfire feed down for ~6h exactly this
+ * way). Duplicated scoring logic is how silent data drift happens, so
+ * `tests/ucdp-dashboard-projection.test.mts` runs BOTH implementations over the
+ * same fixture and asserts identical output. Change one without the other and CI
+ * fails.
+ */
+
+export const UCDP_PANEL_ROWS_PER_TAB = 50;
+
+export const UCDP_VIOLENCE_TYPES = [
+  'UCDP_VIOLENCE_TYPE_STATE_BASED',
+  'UCDP_VIOLENCE_TYPE_NON_STATE',
+  'UCDP_VIOLENCE_TYPE_ONE_SIDED',
+];
+
+const TWO_YEARS_MS = 2 * 365 * 24 * 60 * 60 * 1000;
+
+function isRecentUcdpClassificationDate(dateStart, now, windowMs) {
+  const eventMs = Number(dateStart);
+  return Number.isFinite(eventMs)
+    && Number.isFinite(now)
+    && eventMs <= now
+    && now - eventMs < windowMs;
+}
+
+/**
+ * MIRROR of deriveUcdpClassifications (src/services/conflict/index.ts).
+ * Pinned by tests/ucdp-dashboard-projection.test.mts — do not edit one alone.
+ */
+export function classifyUcdpEvents(events, nowMs = Date.now()) {
+  const byCountry = new Map();
+  for (const e of events) {
+    const country = e.country;
+    if (!byCountry.has(country)) byCountry.set(country, []);
+    byCountry.get(country).push(e);
+  }
+
+  const result = {};
+
+  for (const [country, countryEvents] of byCountry) {
+    const recentEvents = countryEvents.filter(e => isRecentUcdpClassificationDate(e.dateStart, nowMs, TWO_YEARS_MS));
+    const totalDeaths = recentEvents.reduce((sum, e) => sum + e.deathsBest, 0);
+    const eventCount = recentEvents.length;
+
+    let intensity;
+    if (totalDeaths > 1000 || eventCount > 100) {
+      intensity = 'war';
+    } else if (eventCount > 10) {
+      intensity = 'minor';
+    } else {
+      intensity = 'none';
+    }
+
+    let maxDeathEvent;
+    for (const e of recentEvents) {
+      if (!maxDeathEvent || e.deathsBest > maxDeathEvent.deathsBest) maxDeathEvent = e;
+    }
+
+    const mostRecentEvent = recentEvents.reduce(
+      (latest, e) => (!latest || e.dateStart > latest.dateStart) ? e : latest,
+      undefined,
+    );
+    const year = mostRecentEvent ? new Date(mostRecentEvent.dateStart).getFullYear() : new Date(nowMs).getFullYear();
+
+    result[country] = {
+      location: country,
+      intensity,
+      year,
+      sideA: maxDeathEvent?.sideA,
+      sideB: maxDeathEvent?.sideB,
+    };
+  }
+
+  return result;
+}
+
+/**
+ * The panel's tab counts and total-deaths figures are computed over every event,
+ * not the 50 it shows. Precompute them so the capped array cannot change a number
+ * on screen.
+ */
+export function summarizeUcdpEvents(events) {
+  const byType = {};
+  for (const type of UCDP_VIOLENCE_TYPES) {
+    byType[type] = { count: 0, totalDeaths: 0 };
+  }
+  for (const e of events) {
+    const bucket = byType[e.violenceType];
+    if (!bucket) continue; // unknown/unspecified violence type — not a panel tab
+    bucket.count += 1;
+    bucket.totalDeaths += Number(e.deathsBest) || 0;
+  }
+  return byType;
+}
+
+/**
+ * Keep the newest `rowsPerTab` events of each violence type. `mapped` is already
+ * sorted newest-first by the seeder, and the panel renders in that same order, so
+ * this is the exact prefix the UI would have displayed.
+ */
+export function selectUcdpPanelRows(events, rowsPerTab = UCDP_PANEL_ROWS_PER_TAB) {
+  const kept = [];
+  const takenPerType = {};
+  for (const e of events) {
+    const type = e.violenceType;
+    const taken = takenPerType[type] ?? 0;
+    if (taken >= rowsPerTab) continue;
+    takenPerType[type] = taken + 1;
+    kept.push(e);
+  }
+  return kept;
+}
+
+export function compactUcdpDashboardPayload(payload, nowMs = Date.now(), rowsPerTab = UCDP_PANEL_ROWS_PER_TAB) {
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.events)) return payload;
+
+  const events = payload.events;
+  return {
+    ...payload,
+    events: selectUcdpPanelRows(events, rowsPerTab),
+    // Everything the UI derives from the full set, precomputed so the capped
+    // array cannot change what the user sees.
+    classifications: classifyUcdpEvents(events, nowMs),
+    aggregates: summarizeUcdpEvents(events),
+    totalEvents: events.length,
+  };
+}

--- a/scripts/seed-ucdp-events.mjs
+++ b/scripts/seed-ucdp-events.mjs
@@ -263,12 +263,13 @@ async function main() {
     if (!compactResp.ok) throw new Error(`HTTP ${compactResp.status}`);
 
     const compactMeta = JSON.stringify({ fetchedAt: Date.now(), recordCount: compact.events.length });
-    await fetch(redisUrl, {
+    const compactMetaResp = await fetch(redisUrl, {
       method: 'POST',
       headers: { Authorization: `Bearer ${redisToken}`, 'Content-Type': 'application/json' },
       body: JSON.stringify(['SET', BOOTSTRAP_META_KEY, compactMeta, 'EX', 604800]),
       signal: AbortSignal.timeout(5_000),
     });
+    if (!compactMetaResp.ok) throw new Error(`seed-meta HTTP ${compactMetaResp.status}`);
     console.log(`  Wrote ${BOOTSTRAP_KEY}: ${compact.events.length} rows, ${Object.keys(compact.classifications).length} classifications (from ${compact.totalEvents} events)`);
   } catch (e) {
     console.error(`  Compact projection write failed: ${e.message} — canonical key is published, dashboard will fall back to the RPC`);

--- a/scripts/seed-ucdp-events.mjs
+++ b/scripts/seed-ucdp-events.mjs
@@ -4,10 +4,17 @@ import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+import { compactUcdpDashboardPayload } from './_ucdp-dashboard.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const REDIS_KEY = 'conflict:ucdp-events:v1';
+// Dashboard-sized projection. The bootstrap slow tier hydrates from THIS key so
+// every client stops downloading 2,000 events (662 KB) to render 150 rows and a
+// handful of derived numbers (#5300). The canonical key above is untouched and
+// still serves the RPC, MCP and the map layer.
+const BOOTSTRAP_KEY = 'conflict:ucdp-events-bootstrap:v1';
+const BOOTSTRAP_META_KEY = 'seed-meta:conflict:ucdp-events-bootstrap';
 const UCDP_PAGE_SIZE = 1000;
 const MAX_PAGES = 6;
 const MAX_EVENTS = 2000; // Redis payload guard; widening needs live UCDP volume + Upstash payload validation.
@@ -239,6 +246,33 @@ async function main() {
 
   const result = await resp.json();
   console.log('  Redis SET result:', result);
+
+  // Compact dashboard projection (#5300): rows the panel renders + aggregates and
+  // classifications it derives from the full set. Best-effort — a failure here
+  // must not fail the canonical publish; bootstrap falls back to reporting the key
+  // missing and the client re-fetches from the RPC.
+  try {
+    const compact = compactUcdpDashboardPayload(payload);
+    const compactBody = JSON.stringify(['SET', BOOTSTRAP_KEY, JSON.stringify(compact), 'EX', 86400]);
+    const compactResp = await fetch(redisUrl, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${redisToken}`, 'Content-Type': 'application/json' },
+      body: compactBody,
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!compactResp.ok) throw new Error(`HTTP ${compactResp.status}`);
+
+    const compactMeta = JSON.stringify({ fetchedAt: Date.now(), recordCount: compact.events.length });
+    await fetch(redisUrl, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${redisToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(['SET', BOOTSTRAP_META_KEY, compactMeta, 'EX', 604800]),
+      signal: AbortSignal.timeout(5_000),
+    });
+    console.log(`  Wrote ${BOOTSTRAP_KEY}: ${compact.events.length} rows, ${Object.keys(compact.classifications).length} classifications (from ${compact.totalEvents} events)`);
+  } catch (e) {
+    console.error(`  Compact projection write failed: ${e.message} — canonical key is published, dashboard will fall back to the RPC`);
+  }
 
   // Write seed-meta for health endpoint freshness tracking
   const metaKey = 'seed-meta:conflict:ucdp-events';

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -208,7 +208,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   stablecoinMarkets: 'market:stablecoins:v1',
   unrestEvents:     'unrest:events:v1',
   iranEvents:       'conflict:iran-events:v1',
-  ucdpEvents:       'conflict:ucdp-events:v1',
+  ucdpEvents:       'conflict:ucdp-events-bootstrap:v1',
   temporalAnomalies: 'temporal:anomalies:v1',
   weatherAlerts:    'weather:alerts:v1',
   spending:         'economic:spending:v1',

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -89,7 +89,7 @@ import { fetchSatelliteTLEs, initSatRecs, propagatePositions, startPropagationLo
 import type { SatRecEntry } from '@/services/satellites';
 import { dataFreshness, type DataSourceId } from '@/services/data-freshness';
 import type { CorrelationSignal } from '@/services/correlation';
-import { fetchConflictEvents, fetchUcdpClassifications, fetchHapiSummary, fetchUcdpEvents, deduplicateAgainstAcled, fetchIranEvents } from '@/services/conflict';
+import { fetchConflictEvents, fetchUcdpClassifications, fetchHapiSummary, fetchUcdpEvents, deduplicateAgainstAcled, deduplicateUcdpProjectionAggregates, fetchIranEvents } from '@/services/conflict';
 import { fetchUnhcrPopulation } from '@/services/displacement';
 import { fetchClimateAnomalies } from '@/services/climate';
 import { fetchSecurityAdvisories } from '@/services/security-advisories';
@@ -2642,9 +2642,12 @@ export class DataLoaderManager implements AppModule {
           latitude: e.lat, longitude: e.lon, event_date: e.time.toISOString(), fatalities: e.fatalities ?? 0,
         }));
         const events = deduplicateAgainstAcled(result.data, acledEvents);
+        const aggregates = !wantsFullUcdpSet && hydratedUcdp?.aggregates && hydratedUcdp.dedupeIndex
+          ? deduplicateUcdpProjectionAggregates(hydratedUcdp.aggregates, hydratedUcdp.dedupeIndex, acledEvents)
+          : undefined;
         (this.ctx.panels['ucdp-events'] as UcdpEventsPanel)?.setEvents(
           events,
-          wantsFullUcdpSet ? undefined : hydratedUcdp?.aggregates,
+          aggregates,
         );
         if (this.ctx.mapLayers.ucdpEvents) {
           this.ctx.map?.setUcdpEvents(events);

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2538,7 +2538,7 @@ export class DataLoaderManager implements AppModule {
       }
     })());
 
-    const hydratedUcdp = getHydratedData('ucdpEvents') as import('@/generated/client/worldmonitor/conflict/v1/service_client').ListUcdpEventsResponse | undefined;
+    const hydratedUcdp = getHydratedData('ucdpEvents') as import('@/services/conflict').HydratedUcdpPayload | undefined;
 
     tasks.push((async () => {
       try {
@@ -2624,7 +2624,13 @@ export class DataLoaderManager implements AppModule {
     tasks.push((async () => {
       try {
         const protestEvents = await protestsTask;
-        const result = await fetchUcdpEvents(hydratedUcdp);
+        // The bootstrap payload is a dashboard projection (#5300) — 150 rows, not
+        // 2,000. The panel is fine with that (it renders 50/tab and takes its
+        // counts from the precomputed aggregates), but the map draws every event.
+        // When its layer is on, skip hydration so fetchUcdpEvents goes to the RPC
+        // and returns the full set.
+        const wantsFullUcdpSet = this.ctx.mapLayers.ucdpEvents;
+        const result = await fetchUcdpEvents(wantsFullUcdpSet ? undefined : hydratedUcdp);
         if (!result.success) {
           // listUcdpEvents is a pure Redis-read (gold standard). Retrying returns
           // the same empty result until the Railway seed refreshes the key.
@@ -2636,7 +2642,10 @@ export class DataLoaderManager implements AppModule {
           latitude: e.lat, longitude: e.lon, event_date: e.time.toISOString(), fatalities: e.fatalities ?? 0,
         }));
         const events = deduplicateAgainstAcled(result.data, acledEvents);
-        (this.ctx.panels['ucdp-events'] as UcdpEventsPanel)?.setEvents(events);
+        (this.ctx.panels['ucdp-events'] as UcdpEventsPanel)?.setEvents(
+          events,
+          wantsFullUcdpSet ? undefined : hydratedUcdp?.aggregates,
+        );
         if (this.ctx.mapLayers.ucdpEvents) {
           this.ctx.map?.setUcdpEvents(events);
         }

--- a/src/components/UcdpEventsPanel.ts
+++ b/src/components/UcdpEventsPanel.ts
@@ -2,9 +2,24 @@ import { Panel } from './Panel';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import type { UcdpGeoEvent, UcdpEventType } from '@/types';
 import { t } from '@/services/i18n';
+import type { UcdpTabAggregate } from '@/services/conflict';
+
+// The panel's tabs are the three UCDP violence types. The projection keys its
+// aggregates by the proto enum, so map between them in exactly one place.
+const UCDP_EVENT_TYPES: UcdpEventType[] = ['state-based', 'non-state', 'one-sided'];
+const PROTO_VIOLENCE_TYPE: Record<UcdpEventType, string> = {
+  'state-based': 'UCDP_VIOLENCE_TYPE_STATE_BASED',
+  'non-state': 'UCDP_VIOLENCE_TYPE_NON_STATE',
+  'one-sided': 'UCDP_VIOLENCE_TYPE_ONE_SIDED',
+};
+
+function totalFromAggregates(aggregates: Record<string, UcdpTabAggregate>): number {
+  return UCDP_EVENT_TYPES.reduce((sum, type) => sum + (aggregates[PROTO_VIOLENCE_TYPE[type]]?.count ?? 0), 0);
+}
 
 export class UcdpEventsPanel extends Panel {
   private events: UcdpGeoEvent[] = [];
+  private aggregates?: Record<string, UcdpTabAggregate>;
   private hasLoadedEvents = false;
   private activeTab: UcdpEventType = 'state-based';
   private onEventClick?: (lat: number, lon: number) => void;
@@ -40,10 +55,18 @@ export class UcdpEventsPanel extends Panel {
     this.onEventClick = handler;
   }
 
-  public setEvents(events: UcdpGeoEvent[]): void {
+  /**
+   * `aggregates` carries per-tab counts and death totals computed over the FULL
+   * event set. The bootstrap payload is a projection (#5300) — `events` holds only
+   * the rows this panel renders — so deriving those numbers from `events` would
+   * silently under-report them. When the caller has the full set (the RPC path, or
+   * the map layer being on) it passes no aggregates and we compute as before.
+   */
+  public setEvents(events: UcdpGeoEvent[], aggregates?: Record<string, UcdpTabAggregate>): void {
     this.events = events;
+    this.aggregates = aggregates;
     this.hasLoadedEvents = true;
-    this.setCount(events.length);
+    this.setCount(aggregates ? totalFromAggregates(aggregates) : events.length);
     this.renderContent();
   }
 
@@ -68,11 +91,19 @@ export class UcdpEventsPanel extends Panel {
       'non-state': 0,
       'one-sided': 0,
     };
-    for (const event of this.events) {
-      tabCounts[event.type_of_violence] += 1;
+    if (this.aggregates) {
+      for (const type of UCDP_EVENT_TYPES) {
+        tabCounts[type] = this.aggregates[PROTO_VIOLENCE_TYPE[type]]?.count ?? 0;
+      }
+    } else {
+      for (const event of this.events) {
+        tabCounts[event.type_of_violence] += 1;
+      }
     }
 
-    const totalDeaths = filtered.reduce((sum, e) => sum + e.deaths_best, 0);
+    const totalDeaths = this.aggregates
+      ? (this.aggregates[PROTO_VIOLENCE_TYPE[this.activeTab]]?.totalDeaths ?? 0)
+      : filtered.reduce((sum, e) => sum + e.deaths_best, 0);
 
     const tabsHtml = tabs.map(t =>
       `<button class="panel-tab ${t.key === this.activeTab ? 'active' : ''}" data-tab="${t.key}">${t.label} <span class="ucdp-tab-count">${tabCounts[t.key]}</span></button>`

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -54,18 +54,7 @@ export interface ConflictData {
   count: number;
 }
 
-export type ConflictIntensity = 'none' | 'minor' | 'war';
 
-export interface UcdpConflictStatus {
-  location: string;
-  intensity: ConflictIntensity;
-  conflictId?: number;
-  conflictName?: string;
-  year: number;
-  typeOfConflict?: number;
-  sideA?: string;
-  sideB?: string;
-}
 
 export interface HapiConflictSummary {
   iso2: string;
@@ -155,69 +144,26 @@ function toHapiSummary(proto: ProtoHumanSummary): HapiConflictSummary {
   };
 }
 
-// ---- UCDP classification derivation heuristic ----
+/**
+ * The bootstrap-hydrated UCDP payload. It is a dashboard PROJECTION of
+ * conflict:ucdp-events:v1 (#5300): `events` is capped to the rows the panel
+ * renders, and the numbers the UI derives from the full 2,000-event set —
+ * per-country classifications and per-tab aggregates — arrive precomputed.
+ * The RPC still returns the full, unprojected response.
+ */
+export interface UcdpTabAggregate { count: number; totalDeaths: number }
+export type HydratedUcdpPayload = ListUcdpEventsResponse & {
+  classifications?: Record<string, UcdpConflictStatus>;
+  aggregates?: Record<string, UcdpTabAggregate>;
+  totalEvents?: number;
+};
 
-function isRecentUcdpClassificationDate(dateStart: unknown, now: number, windowMs: number): boolean {
-  const eventMs = Number(dateStart);
-  return Number.isFinite(eventMs)
-    && Number.isFinite(now)
-    && eventMs <= now
-    && now - eventMs < windowMs;
-}
-
-function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string, UcdpConflictStatus> {
-  const byCountry = new Map<string, ProtoUcdpEvent[]>();
-  for (const e of events) {
-    const country = e.country;
-    if (!byCountry.has(country)) byCountry.set(country, []);
-    byCountry.get(country)!.push(e);
-  }
-
-  const now = Date.now();
-  const twoYearsMs = 2 * 365 * 24 * 60 * 60 * 1000;
-  const result = new Map<string, UcdpConflictStatus>();
-
-  for (const [country, countryEvents] of byCountry) {
-    // Filter to trailing 2-year window
-    const recentEvents = countryEvents.filter(e => isRecentUcdpClassificationDate(e.dateStart, now, twoYearsMs));
-    const totalDeaths = recentEvents.reduce((sum, e) => sum + e.deathsBest, 0);
-    const eventCount = recentEvents.length;
-
-    let intensity: ConflictIntensity;
-    if (totalDeaths > 1000 || eventCount > 100) {
-      intensity = 'war';
-    } else if (eventCount > 10) {
-      intensity = 'minor';
-    } else {
-      intensity = 'none';
-    }
-
-    // Find the highest-death event for sideA/sideB
-    let maxDeathEvent: ProtoUcdpEvent | undefined;
-    for (const e of recentEvents) {
-      if (!maxDeathEvent || e.deathsBest > maxDeathEvent.deathsBest) {
-        maxDeathEvent = e;
-      }
-    }
-
-    // Most recent event year
-    const mostRecentEvent = recentEvents.reduce<ProtoUcdpEvent | undefined>(
-      (latest, e) => (!latest || e.dateStart > latest.dateStart) ? e : latest,
-      undefined,
-    );
-    const year = mostRecentEvent ? new Date(mostRecentEvent.dateStart).getFullYear() : new Date().getFullYear();
-
-    result.set(country, {
-      location: country,
-      intensity,
-      year,
-      sideA: maxDeathEvent?.sideA,
-      sideB: maxDeathEvent?.sideB,
-    });
-  }
-
-  return result;
-}
+// UCDP classification derivation lives in ./ucdp-classify (leaf module, no
+// runtime imports) so the seeder's parity test can load it without Vite.
+import { deriveUcdpClassifications } from './ucdp-classify';
+import type { UcdpConflictStatus } from './ucdp-classify';
+export { deriveUcdpClassifications } from './ucdp-classify';
+export type { ConflictIntensity, UcdpConflictStatus } from './ucdp-classify';
 
 // ---- Haversine helper (ported exactly from legacy ucdp-events.ts) ----
 
@@ -275,7 +221,14 @@ export async function fetchConflictEvents(): Promise<ConflictData> {
   };
 }
 
-export async function fetchUcdpClassifications(hydrated?: ListUcdpEventsResponse): Promise<Map<string, UcdpConflictStatus>> {
+export async function fetchUcdpClassifications(hydrated?: HydratedUcdpPayload): Promise<Map<string, UcdpConflictStatus>> {
+  // The bootstrap payload is a dashboard projection (#5300): it carries only the
+  // 150 rows the panel renders, so deriving classifications from its `events`
+  // would score CII against a truncated set. The seeder precomputes them over all
+  // 2,000 events instead — use those when present.
+  if (hydrated?.classifications) {
+    return new Map(Object.entries(hydrated.classifications));
+  }
   if (hydrated?.events?.length) return deriveUcdpClassifications(hydrated.events);
 
   const resp = await ucdpBreaker.execute(async () => {
@@ -337,7 +290,7 @@ interface UcdpEventsResponse {
   cached_at: string;
 }
 
-export async function fetchUcdpEvents(hydrated?: ListUcdpEventsResponse): Promise<UcdpEventsResponse> {
+export async function fetchUcdpEvents(hydrated?: HydratedUcdpPayload): Promise<UcdpEventsResponse> {
   if (hydrated?.events?.length) {
     const events = hydrated.events.map(toUcdpGeoEvent);
     return { success: true, count: events.length, data: events, cached_at: '' };

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -5,6 +5,10 @@ import { createCircuitBreaker } from '@/utils';
 import { getHydratedData } from '@/services/bootstrap';
 import { toApiUrl } from '@/services/runtime';
 import { ConflictServiceClient } from '@/services/generated-rpc-clients';
+import { isDuplicatedByAcled } from './ucdp-dedupe';
+import type { AcledDedupEvent, UcdpDedupeIndexEntry, UcdpTabAggregate } from './ucdp-dedupe';
+export { deduplicateUcdpProjectionAggregates } from './ucdp-dedupe';
+export type { UcdpDedupeIndexEntry, UcdpTabAggregate } from './ucdp-dedupe';
 
 // ---- Client + Circuit Breakers (per-RPC; HAPI uses per-country map) ----
 
@@ -151,10 +155,10 @@ function toHapiSummary(proto: ProtoHumanSummary): HapiConflictSummary {
  * per-country classifications and per-tab aggregates — arrive precomputed.
  * The RPC still returns the full, unprojected response.
  */
-export interface UcdpTabAggregate { count: number; totalDeaths: number }
 export type HydratedUcdpPayload = ListUcdpEventsResponse & {
   classifications?: Record<string, UcdpConflictStatus>;
   aggregates?: Record<string, UcdpTabAggregate>;
+  dedupeIndex?: UcdpDedupeIndexEntry[];
   totalEvents?: number;
 };
 
@@ -165,26 +169,9 @@ import type { UcdpConflictStatus } from './ucdp-classify';
 export { deriveUcdpClassifications } from './ucdp-classify';
 export type { ConflictIntensity, UcdpConflictStatus } from './ucdp-classify';
 
-// ---- Haversine helper (ported exactly from legacy ucdp-events.ts) ----
-
-function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lon2 - lon1) * Math.PI) / 180;
-  const a = Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) *
-    Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
 // ---- AcledEvent interface for deduplication (ported from legacy) ----
 
-interface AcledEvent {
-  latitude: string | number;
-  longitude: string | number;
-  event_date: string;
-  fatalities: string | number;
-}
+type AcledEvent = AcledDedupEvent;
 
 // ---- Empty fallbacks ----
 
@@ -310,38 +297,14 @@ export async function fetchUcdpEvents(hydrated?: HydratedUcdpPayload): Promise<U
   };
 }
 
-export function deduplicateAgainstAcled(
-  ucdpEvents: UcdpGeoEvent[],
-  acledEvents: AcledEvent[],
-): UcdpGeoEvent[] {
+export function deduplicateAgainstAcled(ucdpEvents: UcdpGeoEvent[], acledEvents: AcledEvent[]): UcdpGeoEvent[] {
   if (!acledEvents.length) return ucdpEvents;
-
-  return ucdpEvents.filter(ucdp => {
-    const uLat = ucdp.latitude;
-    const uLon = ucdp.longitude;
-    const uDate = new Date(ucdp.date_start).getTime();
-    const uDeaths = ucdp.deaths_best;
-
-    for (const acled of acledEvents) {
-      const aLat = Number(acled.latitude);
-      const aLon = Number(acled.longitude);
-      const aDate = new Date(acled.event_date).getTime();
-      const aDeaths = Number(acled.fatalities) || 0;
-
-      const dayDiff = Math.abs(uDate - aDate) / (1000 * 60 * 60 * 24);
-      if (dayDiff > 7) continue;
-
-      const dist = haversineKm(uLat, uLon, aLat, aLon);
-      if (dist > 50) continue;
-
-      if (uDeaths === 0 && aDeaths === 0) return false;
-      if (uDeaths > 0 && aDeaths > 0) {
-        const ratio = uDeaths / aDeaths;
-        if (ratio >= 0.5 && ratio <= 2.0) return false;
-      }
-    }
-    return true;
-  });
+  return ucdpEvents.filter((ucdp) => !isDuplicatedByAcled({
+    latitude: ucdp.latitude,
+    longitude: ucdp.longitude,
+    dateMs: new Date(ucdp.date_start).getTime(),
+    deathsBest: ucdp.deaths_best,
+  }, acledEvents));
 }
 
 const CONFLICT_HISTORY_RADIUS_DEG = 3;

--- a/src/services/conflict/ucdp-classify.ts
+++ b/src/services/conflict/ucdp-classify.ts
@@ -1,0 +1,82 @@
+import type { UcdpViolenceEvent as ProtoUcdpEvent } from '@/generated/client/worldmonitor/conflict/v1/service_client';
+
+export type ConflictIntensity = 'none' | 'minor' | 'war';
+
+export interface UcdpConflictStatus {
+  location: string;
+  intensity: ConflictIntensity;
+  year: number;
+  sideA?: string;
+  sideB?: string;
+}
+
+// Leaf module by design: it imports nothing at runtime, so tests can load it
+// without Vite's import.meta.env. scripts/_ucdp-dashboard.mjs mirrors
+// deriveUcdpClassifications (it cannot import from src/ — Railway builds seeders
+// from a scripts-only Nixpacks root, #5268) and
+// tests/ucdp-dashboard-projection.test.mts pins the two implementations equal.
+
+function isRecentUcdpClassificationDate(dateStart: unknown, now: number, windowMs: number): boolean {
+  const eventMs = Number(dateStart);
+  return Number.isFinite(eventMs)
+    && Number.isFinite(now)
+    && eventMs <= now
+    && now - eventMs < windowMs;
+}
+
+// Exported for tests/ucdp-dashboard-projection.test.mts: scripts/_ucdp-dashboard.mjs
+// carries a mirror of this function (it cannot import from src/ — Railway builds
+// seeders from a scripts-only root, #5268), and the parity test pins them equal.
+export function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string, UcdpConflictStatus> {
+  const byCountry = new Map<string, ProtoUcdpEvent[]>();
+  for (const e of events) {
+    const country = e.country;
+    if (!byCountry.has(country)) byCountry.set(country, []);
+    byCountry.get(country)!.push(e);
+  }
+
+  const now = Date.now();
+  const twoYearsMs = 2 * 365 * 24 * 60 * 60 * 1000;
+  const result = new Map<string, UcdpConflictStatus>();
+
+  for (const [country, countryEvents] of byCountry) {
+    // Filter to trailing 2-year window
+    const recentEvents = countryEvents.filter(e => isRecentUcdpClassificationDate(e.dateStart, now, twoYearsMs));
+    const totalDeaths = recentEvents.reduce((sum, e) => sum + e.deathsBest, 0);
+    const eventCount = recentEvents.length;
+
+    let intensity: ConflictIntensity;
+    if (totalDeaths > 1000 || eventCount > 100) {
+      intensity = 'war';
+    } else if (eventCount > 10) {
+      intensity = 'minor';
+    } else {
+      intensity = 'none';
+    }
+
+    // Find the highest-death event for sideA/sideB
+    let maxDeathEvent: ProtoUcdpEvent | undefined;
+    for (const e of recentEvents) {
+      if (!maxDeathEvent || e.deathsBest > maxDeathEvent.deathsBest) {
+        maxDeathEvent = e;
+      }
+    }
+
+    // Most recent event year
+    const mostRecentEvent = recentEvents.reduce<ProtoUcdpEvent | undefined>(
+      (latest, e) => (!latest || e.dateStart > latest.dateStart) ? e : latest,
+      undefined,
+    );
+    const year = mostRecentEvent ? new Date(mostRecentEvent.dateStart).getFullYear() : new Date().getFullYear();
+
+    result.set(country, {
+      location: country,
+      intensity,
+      year,
+      sideA: maxDeathEvent?.sideA,
+      sideB: maxDeathEvent?.sideB,
+    });
+  }
+
+  return result;
+}

--- a/src/services/conflict/ucdp-classify.ts
+++ b/src/services/conflict/ucdp-classify.ts
@@ -27,7 +27,7 @@ function isRecentUcdpClassificationDate(dateStart: unknown, now: number, windowM
 // Exported for tests/ucdp-dashboard-projection.test.mts: scripts/_ucdp-dashboard.mjs
 // carries a mirror of this function (it cannot import from src/ — Railway builds
 // seeders from a scripts-only root, #5268), and the parity test pins them equal.
-export function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string, UcdpConflictStatus> {
+export function deriveUcdpClassifications(events: ProtoUcdpEvent[], now = Date.now()): Map<string, UcdpConflictStatus> {
   const byCountry = new Map<string, ProtoUcdpEvent[]>();
   for (const e of events) {
     const country = e.country;
@@ -35,7 +35,6 @@ export function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string,
     byCountry.get(country)!.push(e);
   }
 
-  const now = Date.now();
   const twoYearsMs = 2 * 365 * 24 * 60 * 60 * 1000;
   const result = new Map<string, UcdpConflictStatus>();
 
@@ -67,7 +66,7 @@ export function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string,
       (latest, e) => (!latest || e.dateStart > latest.dateStart) ? e : latest,
       undefined,
     );
-    const year = mostRecentEvent ? new Date(mostRecentEvent.dateStart).getFullYear() : new Date().getFullYear();
+    const year = mostRecentEvent ? new Date(mostRecentEvent.dateStart).getFullYear() : new Date(now).getFullYear();
 
     result.set(country, {
       location: country,

--- a/src/services/conflict/ucdp-dedupe.ts
+++ b/src/services/conflict/ucdp-dedupe.ts
@@ -1,0 +1,79 @@
+export interface UcdpTabAggregate { count: number; totalDeaths: number }
+export type UcdpDedupeIndexEntry = [number, number, number, number, number];
+
+export interface AcledDedupEvent {
+  latitude: string | number;
+  longitude: string | number;
+  event_date: string;
+  fatalities: string | number;
+}
+
+export interface UcdpDedupCandidate {
+  latitude: number;
+  longitude: number;
+  dateMs: number;
+  deathsBest: number;
+}
+
+const UCDP_PROTO_VIOLENCE_TYPES = [
+  'UCDP_VIOLENCE_TYPE_STATE_BASED',
+  'UCDP_VIOLENCE_TYPE_NON_STATE',
+  'UCDP_VIOLENCE_TYPE_ONE_SIDED',
+] as const;
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) *
+    Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function isDuplicatedByAcled(ucdp: UcdpDedupCandidate, acledEvents: AcledDedupEvent[]): boolean {
+  for (const acled of acledEvents) {
+    const aLat = Number(acled.latitude);
+    const aLon = Number(acled.longitude);
+    const aDate = new Date(acled.event_date).getTime();
+    const aDeaths = Number(acled.fatalities) || 0;
+
+    const dayDiff = Math.abs(ucdp.dateMs - aDate) / (1000 * 60 * 60 * 24);
+    if (dayDiff > 7) continue;
+
+    const dist = haversineKm(ucdp.latitude, ucdp.longitude, aLat, aLon);
+    if (dist > 50) continue;
+
+    if (ucdp.deathsBest === 0 && aDeaths === 0) return true;
+    if (ucdp.deathsBest > 0 && aDeaths > 0) {
+      const ratio = ucdp.deathsBest / aDeaths;
+      if (ratio >= 0.5 && ratio <= 2.0) return true;
+    }
+  }
+  return false;
+}
+
+/** Reconcile full-set projection totals with the existing dynamic ACLED de-duplication. */
+export function deduplicateUcdpProjectionAggregates(
+  aggregates: Record<string, UcdpTabAggregate>,
+  dedupeIndex: UcdpDedupeIndexEntry[],
+  acledEvents: AcledDedupEvent[],
+): Record<string, UcdpTabAggregate> {
+  if (!acledEvents.length) return aggregates;
+
+  const reconciled = Object.fromEntries(
+    Object.entries(aggregates).map(([type, aggregate]) => [type, { ...aggregate }]),
+  ) as Record<string, UcdpTabAggregate>;
+
+  for (const entry of dedupeIndex) {
+    const [typeIndex, dateMs, latitude, longitude, deathsBest] = entry;
+    const type = UCDP_PROTO_VIOLENCE_TYPES[typeIndex];
+    const aggregate = type && reconciled[type];
+    if (!aggregate || !isDuplicatedByAcled({ latitude, longitude, dateMs, deathsBest }, acledEvents)) continue;
+
+    aggregate.count = Math.max(0, aggregate.count - 1);
+    aggregate.totalDeaths = Math.max(0, aggregate.totalDeaths - deathsBest);
+  }
+
+  return reconciled;
+}

--- a/tests/conflict-ucdp-date-window.test.mts
+++ b/tests/conflict-ucdp-date-window.test.mts
@@ -13,6 +13,10 @@ import { transformSync } from 'esbuild';
 
 const root = resolve(import.meta.dirname, '..');
 const conflictServiceSource = readFileSync(resolve(root, 'src/services/conflict/index.ts'), 'utf8');
+// index.ts delegates the UCDP classifier to a leaf module with no runtime imports
+// (#5300), so the seeder's drift-parity test can load it without Vite. This harness
+// evaluates index.ts as ONE self-contained module, so inline the leaf back in.
+const ucdpClassifySource = readFileSync(resolve(root, 'src/services/conflict/ucdp-classify.ts'), 'utf8');
 
 let moduleCounter = 0;
 
@@ -79,6 +83,16 @@ type ListIranEventsResponse = any;`,
     'const toApiUrl = (path: string) => path;',
     'runtime',
   );
+  const inlinedClassifier = ucdpClassifySource
+    .replace(/^import type .*$/m, '')   // type-only import — nothing to resolve
+    .replace(/^export /gm, '');          // the harness re-exports the deriver below
+  patched = replaceRequired(
+    patched,
+    /import \{ deriveUcdpClassifications \} from '\.\/ucdp-classify';\nimport type \{ UcdpConflictStatus \} from '\.\/ucdp-classify';\nexport \{ deriveUcdpClassifications \} from '\.\/ucdp-classify';\nexport type \{ ConflictIntensity, UcdpConflictStatus \} from '\.\/ucdp-classify';/,
+    inlinedClassifier,
+    'ucdp-classify leaf',
+  );
+
   patched = `${patched}\nexport { deriveUcdpClassifications };\n`;
 
   const transformed = transformSync(patched, {

--- a/tests/conflict-ucdp-date-window.test.mts
+++ b/tests/conflict-ucdp-date-window.test.mts
@@ -17,6 +17,50 @@ const conflictServiceSource = readFileSync(resolve(root, 'src/services/conflict/
 // (#5300), so the seeder's drift-parity test can load it without Vite. This harness
 // evaluates index.ts as ONE self-contained module, so inline the leaf back in.
 const ucdpClassifySource = readFileSync(resolve(root, 'src/services/conflict/ucdp-classify.ts'), 'utf8');
+// The aggregate reconciler is also a dependency-free leaf. Keep this harness
+// self-contained for the same reason as the classifier above.
+const ucdpDedupeHarness = `
+const UCDP_PROTO_VIOLENCE_TYPES = [
+  'UCDP_VIOLENCE_TYPE_STATE_BASED',
+  'UCDP_VIOLENCE_TYPE_NON_STATE',
+  'UCDP_VIOLENCE_TYPE_ONE_SIDED',
+];
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a = Math.sin(dLat / 2) ** 2 + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+function isDuplicatedByAcled(ucdp, acledEvents) {
+  for (const acled of acledEvents) {
+    const aLat = Number(acled.latitude);
+    const aLon = Number(acled.longitude);
+    const aDate = new Date(acled.event_date).getTime();
+    const aDeaths = Number(acled.fatalities) || 0;
+    if (Math.abs(ucdp.dateMs - aDate) / (1000 * 60 * 60 * 24) > 7) continue;
+    if (haversineKm(ucdp.latitude, ucdp.longitude, aLat, aLon) > 50) continue;
+    if (ucdp.deathsBest === 0 && aDeaths === 0) return true;
+    if (ucdp.deathsBest > 0 && aDeaths > 0) {
+      const ratio = ucdp.deathsBest / aDeaths;
+      if (ratio >= 0.5 && ratio <= 2.0) return true;
+    }
+  }
+  return false;
+}
+function deduplicateUcdpProjectionAggregates(aggregates, dedupeIndex, acledEvents) {
+  if (!acledEvents.length) return aggregates;
+  const reconciled = Object.fromEntries(Object.entries(aggregates).map(([type, aggregate]) => [type, { ...aggregate }]));
+  for (const [typeIndex, dateMs, latitude, longitude, deathsBest] of dedupeIndex) {
+    const aggregate = reconciled[UCDP_PROTO_VIOLENCE_TYPES[typeIndex]];
+    if (aggregate && isDuplicatedByAcled({ latitude, longitude, dateMs, deathsBest }, acledEvents)) {
+      aggregate.count = Math.max(0, aggregate.count - 1);
+      aggregate.totalDeaths = Math.max(0, aggregate.totalDeaths - deathsBest);
+    }
+  }
+  return reconciled;
+}
+`;
 
 let moduleCounter = 0;
 
@@ -82,6 +126,12 @@ type ListIranEventsResponse = any;`,
     "import { toApiUrl } from '@/services/runtime';",
     'const toApiUrl = (path: string) => path;',
     'runtime',
+  );
+  patched = replaceRequired(
+    patched,
+    /import \{ isDuplicatedByAcled \} from '\.\/ucdp-dedupe';\nimport type \{ AcledDedupEvent, UcdpDedupeIndexEntry, UcdpTabAggregate \} from '\.\/ucdp-dedupe';\nexport \{ deduplicateUcdpProjectionAggregates \} from '\.\/ucdp-dedupe';\nexport type \{ UcdpDedupeIndexEntry, UcdpTabAggregate \} from '\.\/ucdp-dedupe';/,
+    ucdpDedupeHarness,
+    'ucdp-dedupe leaf',
   );
   const inlinedClassifier = ucdpClassifySource
     .replace(/^import type .*$/m, '')   // type-only import — nothing to resolve

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -98,6 +98,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'cascade-mirror: RPC variant of aviation:delays-bootstrap:v2 (covered by get_aviation_status). Same seed-meta key (seed-meta:aviation:faa).'],
   ['cyber:threats:v2',
     'cascade-mirror: RPC variant of cyber:threats-bootstrap:v2 (covered by get_cyber_threats). Same seed-meta key (seed-meta:cyber:threats).'],
+  ['conflict:ucdp-events-bootstrap:v1',
+    'cascade-mirror: pre-compacted dashboard view of conflict:ucdp-events:v1 (covered by get_conflict_events). Carries the 150 rows the panel renders plus precomputed classifications/aggregates; agents must read the canonical key, which carries all 2,000 events (#5300).'],
   ['wildfire:fires-bootstrap:v1',
     'cascade-mirror: pre-compacted dashboard/RPC variant of wildfire:fires:v1 (covered by get_natural_events). It preserves the same top-500 response while avoiding canonical-payload Redis egress.'],
   ['thermal:escalation-bootstrap:v1',

--- a/tests/ucdp-dashboard-projection.test.mts
+++ b/tests/ucdp-dashboard-projection.test.mts
@@ -4,11 +4,13 @@ import assert from 'node:assert/strict';
 import {
   UCDP_PANEL_ROWS_PER_TAB,
   classifyUcdpEvents,
+  buildUcdpDedupeIndex,
   summarizeUcdpEvents,
   selectUcdpPanelRows,
   compactUcdpDashboardPayload,
 } from '../scripts/_ucdp-dashboard.mjs';
 import { deriveUcdpClassifications } from '../src/services/conflict/ucdp-classify.ts';
+import { deduplicateUcdpProjectionAggregates, isDuplicatedByAcled } from '../src/services/conflict/ucdp-dedupe.ts';
 
 const NOW = Date.parse('2026-07-14T00:00:00.000Z');
 const DAY = 24 * 60 * 60 * 1000;
@@ -134,6 +136,7 @@ test('projection shrinks the payload while preserving every displayed number', (
 
   assert.ok(compact.events.length < events.length, 'events must be capped');
   assert.equal(compact.totalEvents, events.length, 'pre-cap total must be recorded');
+  assert.equal(compact.dedupeIndex.length, events.length, 'dedupe index must cover the full pre-cap set');
   assert.deepEqual(compact.aggregates, summarizeUcdpEvents(events));
   assert.deepEqual(compact.classifications, classifyUcdpEvents(events, NOW));
   // Passthrough metadata is preserved.
@@ -143,6 +146,30 @@ test('projection shrinks the payload while preserving every displayed number', (
   const before = JSON.stringify(full).length;
   const after = JSON.stringify(compact).length;
   assert.ok(after < before / 2, `projection should at least halve the payload (was ${before}, now ${after})`);
+});
+
+test('reconciles projection totals after ACLED de-duplication', () => {
+  const events = fixture();
+  const compact = compactUcdpDashboardPayload({ events }, NOW);
+  const acledEvents = [{ latitude: 1, longitude: 2, event_date: new Date(NOW - DAY).toISOString(), fatalities: 1 }];
+  const expectedAggregates = summarizeUcdpEvents(events
+    .filter((event) => [
+      'UCDP_VIOLENCE_TYPE_STATE_BASED',
+      'UCDP_VIOLENCE_TYPE_NON_STATE',
+      'UCDP_VIOLENCE_TYPE_ONE_SIDED',
+    ].includes(event.violenceType))
+    .filter((event) => !isDuplicatedByAcled({
+      latitude: event.location.latitude,
+      longitude: event.location.longitude,
+      dateMs: event.dateStart,
+      deathsBest: event.deathsBest,
+    }, acledEvents)));
+
+  assert.deepEqual(
+    deduplicateUcdpProjectionAggregates(compact.aggregates, compact.dedupeIndex, acledEvents),
+    expectedAggregates,
+  );
+  assert.deepEqual(compact.dedupeIndex, buildUcdpDedupeIndex(events));
 });
 
 test('tolerates malformed payloads rather than publishing garbage', () => {

--- a/tests/ucdp-dashboard-projection.test.mts
+++ b/tests/ucdp-dashboard-projection.test.mts
@@ -67,7 +67,7 @@ test('seeder classifier is identical to the client classifier (drift guard)', ()
   const events = fixture();
 
   const fromSeeder = classifyUcdpEvents(events, NOW);
-  const fromClient = deriveUcdpClassifications(events as never);
+  const fromClient = deriveUcdpClassifications(events as never, NOW);
 
   assert.deepEqual(
     Object.keys(fromSeeder).sort(),

--- a/tests/ucdp-dashboard-projection.test.mts
+++ b/tests/ucdp-dashboard-projection.test.mts
@@ -1,0 +1,152 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  UCDP_PANEL_ROWS_PER_TAB,
+  classifyUcdpEvents,
+  summarizeUcdpEvents,
+  selectUcdpPanelRows,
+  compactUcdpDashboardPayload,
+} from '../scripts/_ucdp-dashboard.mjs';
+import { deriveUcdpClassifications } from '../src/services/conflict/ucdp-classify.ts';
+
+const NOW = Date.parse('2026-07-14T00:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+/** Deterministic fixture spanning every branch of the classifier. */
+function fixture(): any[] {
+  const events: any[] = [];
+  const push = (country: string, type: string, deaths: number, ageDays: number, sideA: string, sideB: string, i: number) => {
+    events.push({
+      id: `${country}-${i}`,
+      country,
+      violenceType: type,
+      deathsBest: deaths,
+      deathsLow: deaths,
+      deathsHigh: deaths,
+      dateStart: NOW - ageDays * DAY,
+      dateEnd: NOW - ageDays * DAY,
+      sideA, sideB,
+      location: { latitude: 1, longitude: 2 },
+      sourceOriginal: 'x'.repeat(40),
+    });
+  };
+
+  // 'war' via the deaths threshold (>1000)
+  for (let i = 0; i < 5; i++) push('Warland', 'UCDP_VIOLENCE_TYPE_STATE_BASED', 400, 10 + i, 'GovA', 'RebelA', i);
+  // 'war' via the event-count threshold (>100)
+  for (let i = 0; i < 120; i++) push('Countryland', 'UCDP_VIOLENCE_TYPE_NON_STATE', 1, 5 + (i % 30), 'MilA', 'MilB', i);
+  // 'minor' (>10 events, under both war thresholds)
+  for (let i = 0; i < 15; i++) push('Minorland', 'UCDP_VIOLENCE_TYPE_ONE_SIDED', 2, 20 + i, 'GovC', 'CivC', i);
+  // 'none' (few events)
+  for (let i = 0; i < 3; i++) push('Quietland', 'UCDP_VIOLENCE_TYPE_STATE_BASED', 1, 30 + i, 'GovD', 'RebelD', i);
+  // outside the trailing 2-year window — must be excluded from classification
+  for (let i = 0; i < 50; i++) push('Staleland', 'UCDP_VIOLENCE_TYPE_STATE_BASED', 999, 900 + i, 'GovE', 'RebelE', i);
+  // an unspecified violence type — not a panel tab, must not break the summary
+  push('Oddland', 'UCDP_VIOLENCE_TYPE_UNSPECIFIED', 7, 3, 'GovF', 'RebelF', 0);
+
+  // Bulk, in production proportions (~1,266 state-based / 505 non-state / 229
+  // one-sided out of 2,000). Without this the fixture is smaller than the 50-row
+  // cap and the size assertion below would prove nothing.
+  for (let i = 0; i < 1200; i++) push('Bulkland', 'UCDP_VIOLENCE_TYPE_STATE_BASED', 1, 1 + (i % 300), 'GovX', 'RebelX', i);
+  for (let i = 0; i < 380; i++) push('Bulkstan', 'UCDP_VIOLENCE_TYPE_NON_STATE', 1, 1 + (i % 300), 'MilX', 'MilY', i);
+  for (let i = 0; i < 210; i++) push('Bulkovia', 'UCDP_VIOLENCE_TYPE_ONE_SIDED', 1, 1 + (i % 300), 'GovZ', 'CivZ', i);
+
+  events.sort((a, b) => b.dateStart - a.dateStart); // seeder publishes newest-first
+  return events;
+}
+
+// ── THE DRIFT GUARD ─────────────────────────────────────────────────────────
+// scripts/_ucdp-dashboard.mjs mirrors deriveUcdpClassifications because it cannot
+// import it: Railway builds seeders from a scripts-only Nixpacks root and a
+// `../src/` import crashes the container at startup (#5268). Duplicated scoring
+// logic is how silent data drift happens — CII intensity would quietly diverge
+// from what the client would have computed, and nothing would alarm. Run both
+// over the same events and demand identical output.
+test('seeder classifier is identical to the client classifier (drift guard)', () => {
+  const events = fixture();
+
+  const fromSeeder = classifyUcdpEvents(events, NOW);
+  const fromClient = deriveUcdpClassifications(events as never);
+
+  assert.deepEqual(
+    Object.keys(fromSeeder).sort(),
+    [...fromClient.keys()].sort(),
+    'seeder and client disagree on which countries are classified',
+  );
+
+  for (const [country, clientStatus] of fromClient) {
+    assert.deepEqual(
+      fromSeeder[country],
+      { ...clientStatus },
+      `classification drift for ${country} — scripts/_ucdp-dashboard.mjs and src/services/conflict/index.ts must stay in lockstep`,
+    );
+  }
+});
+
+test('classifier honours the trailing-2-year window', () => {
+  const c = classifyUcdpEvents(fixture(), NOW);
+  // Staleland's 50 high-death events are all >2y old ⇒ nothing recent ⇒ 'none'.
+  assert.equal(c.Staleland.intensity, 'none');
+  assert.equal(c.Warland.intensity, 'war');      // 5 × 400 = 2000 deaths > 1000
+  assert.equal(c.Countryland.intensity, 'war');  // 120 events > 100
+  assert.equal(c.Minorland.intensity, 'minor');  // 15 events > 10
+  assert.equal(c.Quietland.intensity, 'none');   // 3 events
+});
+
+// ── THE PANEL CONTRACT ──────────────────────────────────────────────────────
+// UcdpEventsPanel renders filtered.slice(0, 50) per violence tab, but computes its
+// tab counts and total-deaths figures over the FULL event set. Capping the array
+// without precomputing those aggregates would silently change numbers on screen.
+test('aggregates are computed over every event, not the capped rows', () => {
+  const events = fixture();
+  const agg = summarizeUcdpEvents(events);
+
+  for (const type of ['UCDP_VIOLENCE_TYPE_STATE_BASED', 'UCDP_VIOLENCE_TYPE_NON_STATE', 'UCDP_VIOLENCE_TYPE_ONE_SIDED']) {
+    const all = events.filter(e => e.violenceType === type);
+    assert.equal(agg[type].count, all.length, `${type} count must match the full set`);
+    assert.equal(agg[type].totalDeaths, all.reduce((s, e) => s + e.deathsBest, 0), `${type} deaths must match the full set`);
+  }
+  // The panel has no tab for UNSPECIFIED; it must not appear or throw.
+  assert.equal(agg.UCDP_VIOLENCE_TYPE_UNSPECIFIED, undefined);
+});
+
+test('keeps the newest N rows PER violence type, in publish order', () => {
+  const events = fixture();
+  const rows = selectUcdpPanelRows(events, UCDP_PANEL_ROWS_PER_TAB);
+
+  for (const type of ['UCDP_VIOLENCE_TYPE_STATE_BASED', 'UCDP_VIOLENCE_TYPE_NON_STATE', 'UCDP_VIOLENCE_TYPE_ONE_SIDED']) {
+    const keptOfType = rows.filter(e => e.violenceType === type);
+    const allOfType = events.filter(e => e.violenceType === type);
+    const expected = Math.min(allOfType.length, UCDP_PANEL_ROWS_PER_TAB);
+
+    assert.equal(keptOfType.length, expected, `${type}: expected ${expected} rows`);
+    // The panel filters by tab then slices — so the kept rows must be the exact
+    // prefix it would have displayed from the full array.
+    assert.deepEqual(keptOfType.map(e => e.id), allOfType.slice(0, expected).map(e => e.id));
+  }
+});
+
+test('projection shrinks the payload while preserving every displayed number', () => {
+  const events = fixture();
+  const full = { events, fetchedAt: NOW, version: '25.1', totalRaw: 9999, filteredCount: events.length };
+  const compact = compactUcdpDashboardPayload(full, NOW);
+
+  assert.ok(compact.events.length < events.length, 'events must be capped');
+  assert.equal(compact.totalEvents, events.length, 'pre-cap total must be recorded');
+  assert.deepEqual(compact.aggregates, summarizeUcdpEvents(events));
+  assert.deepEqual(compact.classifications, classifyUcdpEvents(events, NOW));
+  // Passthrough metadata is preserved.
+  assert.equal(compact.version, '25.1');
+  assert.equal(compact.fetchedAt, NOW);
+
+  const before = JSON.stringify(full).length;
+  const after = JSON.stringify(compact).length;
+  assert.ok(after < before / 2, `projection should at least halve the payload (was ${before}, now ${after})`);
+});
+
+test('tolerates malformed payloads rather than publishing garbage', () => {
+  for (const bad of [null, undefined, 'nope', 42, {}, { events: 'not-an-array' }]) {
+    assert.equal(compactUcdpDashboardPayload(bad as never, NOW), bad);
+  }
+});


### PR DESCRIPTION
Third slice of #5300, and the last big one. **662 KB → 54 KB (8%), ~3.8 GB/day** — measured against the live payload.

## Why this one is a *projection*, not a truncation

`conflict:ucdp-events:v1` carries **2,000 events (662 KB)** in the slow tier every client downloads on every boot. Nothing renders 2,000 events. Three consumers read it, and each wants something small — but they want *different* small things:

| consumer | actually needs | default |
|---|---|---|
| **CII** (`ingestUcdpForCII`) | per-country conflict status folded from **all 2,000** events — **42 rows**, derived, never displayed | always on |
| **`ucdp-events` panel** | `filtered.slice(0, 50)` per violence tab (**150 rows**) — but its tab counts and total-deaths figures are computed over the **FULL set** | on (viewport-gated) |
| **map layer** | every event | **OFF in all 12 variant configs** |

So a naive cap would have **silently corrupted the numbers on screen** and **scored CII against a truncated set** — a data-quality regression with no error anywhere. That is what makes this a projection.

## What ships

`conflict:ucdp-events-bootstrap:v1` = the 150 rows the panel renders **+ the classifications and per-tab aggregates it derives from the full set**.

```
events   : 2000 -> 150
countries classified: 42
payload  : 662 KB -> 54 KB  (8%)
```

**Every displayed number is identical to today.** Clients that switch the map layer on skip hydration and take the full set from the RPC, so markers are unchanged too. The canonical key is untouched and still serves the RPC, MCP and analytics.

## The drift guard is the important part

The classifier is **duplicated** in `scripts/_ucdp-dashboard.mjs` because it *cannot* import from `src/`: Railway builds seeders from a scripts-only Nixpacks root, and a `../src/` import crashes the container at startup — **#5268 took the wildfire feed down for ~6 hours exactly this way, today.**

Duplicated scoring logic is how silent data drift happens: CII intensity would quietly diverge from what the client computes and nothing would alarm. So `tests/ucdp-dashboard-projection.test.mts` runs **both implementations over the same fixture and demands identical output**. Change one without the other and CI fails.

To make that testable, `deriveUcdpClassifications` moved to a leaf module with **no runtime imports** — the client service transitively pulls in `import.meta.env`, which doesn't exist under `tsx --test`.

## Guards this epic has already paid for

- **Health monitors the projection separately** — a transform/write failure must not hide behind a healthy canonical key (otherwise the savings evaporate silently while the client falls back to the RPC).
- **`EMPTY_DATA_OK`** — the key is legitimately absent for one cron interval after deploy, and `EMPTY` scores as **crit**, which would fire a false DEGRADED. Exactly the trap #5263 hit on review round two.
- **MCP parity exclusion** — documented, pointing agents at the canonical key so nobody wires a tool to the 150-row view.
- **No-escape-import guard** covers `seed-ucdp-events.mjs`.

## Validation

- `tests/ucdp-dashboard-projection.test.mts` — **6 pass**: the drift guard, the 2-year classification window, aggregates-over-full-set, exact per-tab row prefix, projection shape, malformed-input tolerance
- `tests/scripts-railway-nixpacks-no-escape-import.test.mts` — **145 pass**, incl. `seed-ucdp-events.mjs`
- `tests/bootstrap.test.mjs` + `tests/mcp-bootstrap-parity.test.mjs` — **50 pass**
- `npm run typecheck`, `npm run typecheck:api` — pass
- Pre-push gate — pass

## Post-deploy

1. Confirm the seeder published `conflict:ucdp-events-bootstrap:v1` (150 rows, 42 classifications) before relying on it — until then bootstrap reports it missing and the client falls back to the RPC (graceful, but uncached).
2. Spot-check the UCDP panel: tab counts and total-deaths must match production today, and the map (layer on) must still draw all events.

## Epic running total

| PR | saving |
|---|---|
| #5302 cyberThreats → on-demand | ~2.15 GB/day |
| #5303 thermal → dashboard view | ~2.5 GB/day |
| **this** | **~3.8 GB/day** |
| | **≈ 8.5 GB/day** |