### PR TITLE
docs(solutions): three verified learnings from the seeder/health session

### DIFF
--- a/docs/solutions/integration-issues/merged-is-not-ran-long-cron-seeders.md
+++ b/docs/solutions/integration-issues/merged-is-not-ran-long-cron-seeders.md
@@ -1,0 +1,138 @@
+---
+title: A merged seeder fix is not live until its cron fires — backfill long-cron seeders by hand
+date: 2026-07-14
+category: integration-issues
+module: railway-seeders
+problem_type: integration_issue
+component: development_workflow
+symptoms:
+  - "/api/health reports a domain EMPTY (crit) with records=0 and no seedAgeMin, days after the fix merged"
+  - "The seeder's Railway service shows only SUCCESS builds — no crashes, nothing red"
+  - "A health key goes crit the moment its PR merges, then clears by itself hours or days later"
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+severity: high
+related_components: [background_job, documentation]
+tags: [railway, seeders, cron, health-monitoring, seed-meta, backfill, deployment]
+---
+
+# A merged seeder fix is not live until its cron fires
+
+## Problem
+
+`defensePatents` sat at `EMPTY` (crit) on `/api/health` with `records: 0`, and
+production overall was `DEGRADED` — *after* the USPTO ODP migration (#5284) had
+merged and deployed. The seeder code was correct. It had simply never run.
+
+The same shape appeared twice in one session, so it is a pattern, not an
+incident.
+
+## Symptoms
+
+- `/api/health?compact=1` shows the domain as `EMPTY`, `records: 0`, and **no
+  `seedAgeMin`** — the seed-meta key is absent entirely, not merely stale.
+- The Railway service looks perfectly healthy: no crashes, no red badge.
+- Nothing in the repo is wrong. Reading the seeder source proves nothing.
+
+## What Didn't Work
+
+- **Assuming a regression.** The obvious read of "fix shipped, data still
+  missing" is that the fix is broken. It was not. A read-only probe of the new
+  source path (importing only the pure `scripts/_defense-patents-source.mjs`,
+  never the seeder entry point) returned 90 valid records and passed the
+  seeder's own `validateDefensePatents`. The code was fine the whole time.
+- **Reading Railway's deployment list as a run log.** The service showed a long
+  list of `SUCCESS` deployments. Nearly all of them were `buildOnly: true` —
+  image builds triggered by pushes to `main`, which run *nothing*. In the last
+  100 deployments there was exactly **one** real run against 82 builds. A busy
+  deployment list is not evidence that a cron ever fired.
+
+## Solution
+
+Check the seeder's **cron cadence against the fix's merge time** before
+concluding anything:
+
+```bash
+# The cron schedule lives in Railway service config, not the repo.
+# seed-bundle-static-ref: "0 3 * * 0"  => Sunday 03:00 UTC, WEEKLY.
+railway status --json   # then query the deployment's serviceManifest.deploy.cronSchedule
+```
+
+The timeline that explained everything:
+
+| when | what |
+|------|------|
+| Sun 2026-07-12 03:00 UTC | last cron tick — **before the fix existed** |
+| Mon 2026-07-13 18:07 UTC | #5284 merged and the image rebuilt |
+| Sun 2026-07-19 03:00 UTC | next cron tick — **5 days away** |
+
+The fix was baked into the image and had never executed. The remedy is a manual
+backfill, which also *verifies* the fix in the real seeder path (publish,
+envelope dual-write, Redis verification) rather than only in a probe:
+
+```bash
+cd scripts
+railway run --service <service> --environment production -- node seed-defense-patents.mjs
+# => {"event":"seed_complete","recordCount":90,"state":"OK"}
+#    Verified: data present in Redis   ===  Done  ===
+```
+
+`/api/health` cleared on the next poll.
+
+## Why This Works
+
+A Railway cron seeder has two independent lifecycles that are easy to conflate:
+
+1. **The image** rebuilds on every push to `main` (`buildOnly: true` deployments).
+   This is what makes the service look active.
+2. **The code inside it** only executes when the cron schedule fires.
+
+Merging a fix advances (1) immediately and (2) not at all. For an hourly seeder
+the gap is invisible. For a **weekly** seeder it is up to **7 days** — long
+enough that the fix looks broken.
+
+This is compounded by the fact that a `seed-meta` key does not resurrect itself:
+nothing re-seeds an absent key except a run of the seeder that owns it.
+
+## The general rule
+
+**Merged ≠ deployed ≠ ran.** The only ground truth for seeder data is the
+`seed-meta` key in Redis, not the PR state, not CI, and not the Railway badge.
+
+A corollary worth internalizing: **shipping a health-key registration in the
+same PR as its seeder makes health go crit for exactly one cron period.** The
+health endpoint starts grading a key before the seeder that populates it has
+ever run. Observed twice on the same day:
+
+- `defensePatents` — weekly cron → would have stayed crit for ~5 days.
+- `chinaMacro` / `chinaReleaseCalendar` (#5294) — daily cron (`0 8 * * *`) →
+  crit for ~10 hours, then self-healed with no intervention.
+
+The registration is at `api/health.js:211` (data key) and `api/health.js:403`
+(seed-meta key); the weekly section is `scripts/seed-bundle-static-ref.mjs:6`
+(`intervalMs: WEEK`).
+
+## Prevention
+
+- **Before calling a seeder fix "shipped", check its cron cadence.** If the next
+  tick is far away, run a manual backfill. This is not optional cleanup — it is
+  the step that makes the fix real *and* proves it end-to-end.
+- **When a health key goes crit right after a merge, check the cron before
+  hunting for a regression.** Compare the seeder's last real run to the merge
+  time. `railway status --json` → `serviceManifest.deploy.cronSchedule`.
+- **Do not read `SUCCESS` deployments as runs.** Filter on `meta.buildOnly` —
+  `buildOnly: true` deployments build the image and execute nothing.
+- **Never import a seeder entry point to smoke-test it.** Import the pure source
+  module instead (`scripts/_defense-patents-source.mjs`, not
+  `scripts/seed-defense-patents.mjs`). This particular seeder happens to guard
+  its `runSeed` behind an `isMain` check, but that is not a repo-wide guarantee —
+  an unguarded seeder executes on import and writes production Redis.
+
+## Related
+
+- [Railway seeder watch paths can skip deployments](railway-seeder-watch-paths-can-skip-deployments.md)
+  — the sibling failure where the *image* never rebuilds. This doc is the
+  opposite: the image rebuilt fine and the *code* never ran.
+- PR #5284 (USPTO ODP migration) — the fix that was correct but dormant.
+- PR #5294 — the China coverage PR that registered health keys ahead of the
+  first `seed-bundle-macro` tick.

--- a/docs/solutions/integration-issues/timeout-assumed-a-routing-pin-that-never-existed.md
+++ b/docs/solutions/integration-issues/timeout-assumed-a-routing-pin-that-never-existed.md
@@ -1,0 +1,152 @@
+---
+title: A timeout that assumed a provider-routing pin the seeder never had
+date: 2026-07-14
+category: integration-issues
+module: seed-forecasts
+problem_type: integration_issue
+component: background_job
+symptoms:
+  - "market_implications wrote errorReason 'llm_no_response' on every hourly run"
+  - "/api/health stuck at SEED_ERROR while the panel served frozen last-good cards"
+  - "The LLM provider answers a trivial prompt instantly, so the model looks healthy"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+related_components: [service_object, documentation]
+tags: [llm, openrouter, deepseek, timeouts, provider-routing, seeders, security-policy]
+---
+
+# A timeout that assumed a provider-routing pin the seeder never had
+
+## Problem
+
+`market_implications` wrote `status: 'error' / errorReason: 'llm_no_response'`
+on **every hourly run**. `/api/health` sat at `SEED_ERROR` indefinitely while the
+homepage panel served **frozen last-good cards** — the failure path
+EXPIRE-refreshes the canonical key, so the data never expired, it just never
+updated.
+
+The model was not slow, and the provider was not down.
+
+## Root cause: a policy split across an import boundary
+
+```js
+// scripts/_llm-model-timeouts.mjs — before
+export const DEEPSEEK_V4_FLASH_COMPLETION_TIMEOUT_MS = 15_000;
+// "Keep it above the pinned endpoint's observed p50"   <-- nothing pinned it
+```
+
+The comment names the assumption. **Nothing implemented it.** OpenRouter
+free-routes `deepseek/deepseek-v4-flash` across backends whose latency spans an
+order of magnitude. Measured against production on the real call shape
+(`max_tokens: 2500`, ~2.3k-token prompt):
+
+| backend | latency |
+|---|---|
+| AtlasCloud / Venice | 10–25s |
+| DigitalOcean / GMICloud | 61–73s |
+| NextBit | 110s |
+| one call | >120s, never returned |
+
+**The fastest of 12 unrouted samples was 17.1s — above the 15s clamp.** The
+primary provider could not succeed *even once*: **0/12**. Not flaky. Impossible.
+
+The routing *did* exist — in `server/_shared/llm.ts`. The Railway seeder cannot
+import from `server/` (it packages only `scripts/`), so it inherited the
+**timeout** but not the **routing**. That split is the bug.
+
+The Groq fallback was simultaneously useless: its free tier caps at 100k
+tokens/day and this stage alone needs ~114k (4,749 tokens × 24 hourly runs), so
+it returned `429` in 86ms. Both providers empty → `llm_no_response`, every run.
+
+## Solution (PR #5304, open as of this writing)
+
+Move the routing policy next to the timeout it is inseparable from, in
+`scripts/_llm-model-timeouts.mjs`, and have **both** consumers import it — so a
+consumer cannot pick up one without the other.
+
+```js
+export const OPENROUTER_PROVIDER_ROUTING = {
+  ignore: OPENROUTER_BLOCKED_PROVIDERS,   // China-hosted providers
+  sort: 'throughput',                     // fastest eligible backend
+};
+```
+
+Measured under that routing: **p50 15.3s, p90 22.4s, max 25.0s, 14/14** → a 40s
+completion deadline covers 100%.
+
+## The trap: the security policy and the latency fix pull in opposite directions
+
+WorldMonitor blocks China-hosted inference providers because it is a
+geopolitical product — an adapter could log queries or bias outputs on exactly
+the topics it covers (Taiwan, Xinjiang, the South China Sea).
+
+**Applying `sort: 'throughput'` *without* the blocklist routes those prompts
+straight onto the blocked providers — precisely BECAUSE they are the fastest.**
+The optimization actively selects for the thing the policy forbids. This nearly
+shipped: the first draft added throughput-sorting alone, and its excellent
+latency numbers were partly *achieved by* violating the policy.
+
+They must ship together, and it is now pinned by a test.
+
+Reassuringly, **blocking costs nothing** — the eligible set is *faster*
+(p50 15.3s / max 25.0s) than the unrestricted set (p50 17.5s / max 34.7s). When
+a security control looks like it has a performance price, measure it; the price
+may be imaginary.
+
+> Caveat recorded in-code: `novita` is on the blocklist but is
+> San-Francisco-headquartered, and its GPU hosting is not publicly disclosed.
+> The list is flagged for periodic re-audit. Loosening a security control should
+> be its own reviewed change, never a rider on a latency fix.
+
+## Two regressions the existing tests caught
+
+Both would have shipped without the suite:
+
+- **Raising the shared provider timeout to suit Flash loosened a different
+  model.** `critical_signals` pins `google/gemini-2.5-flash` at 25s on the *same*
+  provider entry. Fixed by giving Flash its own requested window and leaving
+  other models on `provider.timeout`.
+- **Replace-instead-of-min broke a shorter caller.** The shared server client
+  passes 8s for some utility calls and must still get 8s. `Math.min(requested,
+  cap)` had to stay; the long-generation caller opts into a bigger *cap*.
+
+## One test started passing vacuously
+
+Once Groq left the `market_implications` default chain, #4978's
+stranded-fallback test began skipping **for the wrong reason** — it would have
+kept passing while covering nothing. It now pins the two-provider chain
+explicitly, because the fallback machinery must stay correct for any deployment
+that configures one.
+
+**Watch for this whenever you change a default:** a test that exercised a path
+through the default silently stops exercising it, and green tells you nothing.
+
+## Prevention
+
+- **A comment asserting an invariant is not an invariant.** "Keep it above the
+  pinned endpoint's p50" described a pin that did not exist. If a constant
+  depends on a policy, co-locate them so they cannot be adopted separately.
+- **Probe the real call shape, not a toy prompt.** `"say ok"` returned instantly
+  from every backend and proved nothing. The bug only appears at
+  `max_tokens: 2500`.
+- **When two modules must share a policy but cannot share an import, move the
+  policy to the side that both can reach.** `scripts/` is importable by
+  `server/`; the reverse is not true for Railway workers.
+
+## Verified in production
+
+```
+[LLM:market_implications] openrouter success model=deepseek/deepseek-v4-flash
+[MarketImplications] Published 5 cards to intelligence:market-implications:v1 (23404ms)
+```
+
+`/api/health` went `SEED_ERROR` → resolved. **Bonus:** `[LLM:combined]` also
+succeeded, at 20,561ms — it too exceeded the 15s clamp, so that stage had been
+silently degrading to `fallbackNarratives` on every run.
+
+## Related
+
+- [A merged seeder fix is not live until its cron fires](../integration-issues/merged-is-not-ran-long-cron-seeders.md)
+  — same session; the other way a correct fix fails to reach production.
+- PR #5304 — routing/timeout fix (unmerged as of this writing).

--- a/docs/solutions/logic-errors/health-must-not-grade-an-unconfigured-optional-source.md
+++ b/docs/solutions/logic-errors/health-must-not-grade-an-unconfigured-optional-source.md
@@ -1,0 +1,145 @@
+---
+title: Health must not grade a deliberately-unconfigured optional source
+date: 2026-07-14
+category: logic-errors
+module: api-health
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "/api/health reports SEED_ERROR for a source the deployment never supplied a credential for"
+  - "A warn that no operator action can clear except obtaining a third-party API key"
+  - "The producer distinguishes 'unavailable' from 'stale'/'error' but health reports all three identically"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components: [background_job, frontend_stimulus]
+tags: [health-monitoring, seed-meta, classifier, status-codes, optional-sources]
+---
+
+# Health must not grade a deliberately-unconfigured optional source
+
+## Problem
+
+`/api/health` reported `globalTendersSam: SEED_ERROR` on **every run** since the
+Global Tenders feature shipped. The SAM.gov adapter requires `SAM_GOV_API_KEY`,
+which had never been provisioned — so the warn could not be cleared by any
+engineering action, only by obtaining a US government API key.
+
+Health was grading the deployment on a source it had never opted into.
+
+## Symptoms
+
+- A permanent `warn` on `/api/health` that no code change can fix.
+- The seeder's own logs say the source is *unavailable*, not *failing*.
+- The docs explicitly describe the unconfigured state as supported
+  (`docs/global-procurement-intelligence.mdx`), yet health calls it an error.
+
+## Root cause
+
+The producer emits **four** distinct source states — `ok`, `stale`, `error`, and
+`unavailable` — and `unavailable` is written from exactly one place in the repo:
+the adapter's missing-credential branch. But the classifier collapsed every
+non-`ok` state into a single bucket:
+
+```js
+// api/health.js — before
+const sourceDegraded = typeof meta?.sourceState === 'string' && meta.sourceState !== 'ok';
+...
+if (seedError) status = 'SEED_ERROR';   // warn
+```
+
+So *"this deployment never opted into the adapter"* was graded identically to
+*"this adapter was tried and is broken."* Those are different claims and only
+one of them is actionable.
+
+## Solution (PR #5295, merged)
+
+Classify `sourceState: 'unavailable'` as its own status, bucketed `ok` and
+excluded from the compact `problems` map:
+
+```js
+// api/health.js:806 — "never opted in" is not a fault
+const sourceUnavailable = meta?.sourceState === 'unavailable';
+const sourceDegraded = typeof meta?.sourceState === 'string'
+  && meta.sourceState !== 'ok'
+  && !sourceUnavailable;
+...
+if (sourceUnavailable) status = 'NOT_CONFIGURED';
+else if (seedError) status = 'SEED_ERROR';
+```
+
+It is **self-clearing**: once the credential lands, the next seed run writes
+`sourceState: 'ok'` and the key flips to `OK` with no health-config change.
+
+## Two traps that make the naive fix worse
+
+Both are load-bearing, and both are pinned by mutation-tested assertions.
+
+**1. Exempting `unavailable` without a dedicated status turns a warn into a
+`crit`.** Removing it from `sourceDegraded` lets the check fall through to the
+`records === 0` branch and land on `EMPTY_DATA`, which buckets to `crit`. The
+"fix" would have escalated the very thing it was meant to silence.
+
+**2. An unregistered status silently re-becomes the warn.** The summary does:
+
+```js
+const bucket = STATUS_COUNTS[entry.status] ?? 'warn';   // api/health.js
+```
+
+so a new status that is not explicitly registered in `STATUS_COUNTS` defaults
+straight back to `warn`. The exemption only holds because `NOT_CONFIGURED: 'ok'`
+is listed there.
+
+## Sweep every problem surface, not just the one you are looking at
+
+The first commit fixed the compact `problems` map and **missed two identical
+hardcoded filters** feeding the console failure log and the `?history=1`
+incident signature:
+
+```js
+c.status !== 'OK' && c.status !== 'OK_CASCADE' && c.status !== 'EMPTY_ON_DEMAND'
+```
+
+That path runs whenever `overall !== 'HEALTHY'` — precisely the state an
+*unrelated* crit puts the fleet in. Production was `DEGRADED` at the time, so
+operators would still have seen a permanent `NOT_CONFIGURED` problem, and the
+dedupe signature would have been permanently salted with a non-problem.
+
+The fix is a single `STATUS_COUNTS`-derived predicate shared by every surface,
+so a future `ok`-bucket status cannot be honoured on one and ignored on another:
+
+```js
+function isProblemStatus(status) {
+  return STATUS_COUNTS[status] !== 'ok';
+}
+```
+
+**One intentional asymmetry survives:** the failure log additionally suppresses
+`EMPTY_ON_DEMAND` (warn-for-visibility only; it never flips `overall`), while
+the compact map *does* surface it. Verify divergences like this against
+production before "unifying" them — flattening it would have been a regression.
+
+## Prevention
+
+- **When a producer distinguishes states, the consumer must too.** A classifier
+  that reduces N states to a boolean is throwing away the exact signal the
+  producer paid to compute.
+- **Grep for sibling filters before declaring a status change done.** The bug
+  here was not the logic; it was fixing one of three copies. Derive shared
+  predicates from the status table rather than hardcoding status lists.
+- **A permanent warn nobody can clear is a bug, not noise.** It trains operators
+  to ignore the channel, which is how a real failure gets missed.
+
+## Verified
+
+`globalTendersSam` disappeared from `/api/health` problems in production, while
+`globalTendersCanadaBuys` — a genuinely *broken* source in the same bundle —
+kept reporting `SEED_ERROR`. That contrast is the regression guard proving
+itself: the deliberately-unconfigured source went quiet, the actually-broken one
+still shouts.
+
+## Related
+
+- [Reject degraded China macro snapshots at the seed publish boundary](reject-degraded-china-macro-seed-publication.md)
+  — the mirror-image concern at the *publish* boundary rather than the health boundary.
+- PR #5295 — the `NOT_CONFIGURED` status and the shared `isProblemStatus` predicate.


### PR DESCRIPTION
Three verified learnings from the 2026-07-14 seeder/health session, written via `/ce-compound`.

They share one shape, which is the reason they're worth keeping: **the code was right and the data was still dead.** Three of the four problems investigated that day looked like code regressions and none of them were.

## What's here

**`integration-issues/merged-is-not-ran-long-cron-seeders.md`**
A seeder fix isn't live until its cron fires. `defensePatents` (#5284) was correct but **dormant for 5 days** — `seed-bundle-static-ref` runs weekly (`0 3 * * 0`) and the last tick predated the merge. Corollary: **registering a health key in the same PR as its seeder makes health go crit for exactly one cron period** — hours for a daily seeder, up to a week for a weekly one (seen twice that day: `defensePatents`, and `chinaMacro`/`chinaReleaseCalendar` from #5294). Also records why the Railway deployment list misleads: **82 of the last 100 deployments were `buildOnly` image builds that execute nothing.**

**`logic-errors/health-must-not-grade-an-unconfigured-optional-source.md`** (PR #5295, merged)
`sourceState: 'unavailable'` (never opted in) is not `'stale'`/`'error'` (tried and broken). Collapsing them produced a permanent warn that no engineering action could clear. Two traps documented because both make the naive fix *worse*: exempting the state without a dedicated status falls through to `EMPTY_DATA` (**crit**), and `STATUS_COUNTS[s] ?? 'warn'` silently re-adds the warn for an unregistered status. Plus the meta-lesson — **sweep every problem surface**; the first commit fixed one of three identical hardcoded filters.

**`integration-issues/timeout-assumed-a-routing-pin-that-never-existed.md`** (PR #5304, open)
A 15s DeepSeek-Flash timeout assumed an OpenRouter routing pin that existed only in `server/_shared/llm.ts` and never in `scripts/seed-forecasts.mjs` (Railway workers can't import `server/`). The fastest observed completion was **17.1s**, so the primary was **0/12** — mathematically incapable of succeeding. It also records the trap that nearly shipped: **`sort: throughput` WITHOUT the China-hosted-provider blocklist routes geopolitical prompts onto the blocked providers precisely BECAUSE they are the fastest.** The security policy and the latency optimization pull in opposite directions and must ship together. Blocking turned out to be *faster* anyway.

## Validation

All three pass the bundled validators: frontmatter parser-safe, and the mechanical claims check resolves every cited path and link (**0 flags**). Merge state is grounded — #5295 is cited as merged, #5304 explicitly as *unmerged as of this writing*.

## Notes

- Ran `ce-compound` in **Lightweight mode** (session context was long), one run per learning as the skill requires. A later Full run would add cross-referencing and a `CONCEPTS.md` seed.
- `CONCEPTS.md` does not exist at repo root; lightweight defers creation to a Full run.
- **Discoverability gap:** `AGENTS.md` never mentions `docs/solutions/`, so agents won't discover the knowledge store. Not edited here — amending the repo's operating contract deserves its own reviewed change. Happy to open it.

https://claude.ai/code/session_015HXMBUiQa6iRJfjbpLWYxU
