### PR TITLE
perf(health): serve ?compact=1 from a compact verdict snapshot (#5300)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -25,6 +25,22 @@ const HEALTH_VERDICT_SNAPSHOT_KEY = healthVerdictRedisKey(
   process.env.VERCEL_ENV,
   process.env.VERCEL_GIT_COMMIT_SHA,
 );
+// The memoized verdict is stored TWICE, and the difference is the whole point.
+// The full snapshot carries the entire `checks` map (~228 entries, ~20 KB). The
+// compact snapshot carries what `?compact=1` actually returns — status, summary,
+// checkedAt and the handful of problem entries — about 1 KB.
+//
+// `?compact=1` is the browser poll: every client hits it every 5 minutes (~115k
+// times/day). Before this split each of those reads pulled the full 20 KB blob out
+// of Redis to render ~1 KB of it, which is ~2.2 GB/day of egress for bytes the
+// caller throws away (#5300). One sweep writes both keys, so they can never
+// disagree.
+const HEALTH_VERDICT_COMPACT_SNAPSHOT_BASE_KEY = 'health:verdict:compact:v1';
+const HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY = healthVerdictRedisKey(
+  HEALTH_VERDICT_COMPACT_SNAPSHOT_BASE_KEY,
+  process.env.VERCEL_ENV,
+  process.env.VERCEL_GIT_COMMIT_SHA,
+);
 const HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS = 60;
 // Edge runtime mirror of scripts/china-coverage-manifest.mjs. Edge functions
 // cannot import scripts/; tests enforce key and status-projection parity.
@@ -1068,13 +1084,15 @@ function composeChinaCoverageStatus(entry, raw, readError = false) {
   return { ...entry, ...projected, seedStatus };
 }
 
-function parseHealthVerdictSnapshot(raw, now) {
+function parseHealthVerdictSnapshot(raw, now, { requireChecks = true } = {}) {
   if (typeof raw !== 'string') return null;
   const snapshot = parseRedisValue(raw);
   if (!snapshot || typeof snapshot !== 'object') return null;
   if (typeof snapshot.status !== 'string' || typeof snapshot.checkedAt !== 'string') return null;
   if (!snapshot.summary || typeof snapshot.summary !== 'object') return null;
-  if (!snapshot.checks || typeof snapshot.checks !== 'object') return null;
+  // The compact snapshot deliberately has no `checks` map — that omission IS the
+  // 20 KB saving. Only the full snapshot must carry one.
+  if (requireChecks && (!snapshot.checks || typeof snapshot.checks !== 'object')) return null;
 
   const checkedAtMs = Date.parse(snapshot.checkedAt);
   const ageMs = now - checkedAtMs;
@@ -1134,12 +1152,25 @@ function healthResponseBody(snapshot, compact) {
     return body;
   }
 
-  const problems = {};
-  for (const [name, check] of Object.entries(snapshot.checks)) {
-    if (isProblemStatus(check.status)) problems[name] = check;
-  }
+  // Two shapes reach here. A freshly-swept verdict (and the full cached snapshot)
+  // carries `checks`, so derive `problems` from it. The compact snapshot key stores
+  // `problems` already computed — that is why a browser poll reads ~1 KB instead of
+  // the full 20 KB check map. Passing a compact snapshot back through here is a
+  // no-op, which is what makes buildCompactVerdictSnapshot() below safe.
+  const problems = snapshot.checks
+    ? Object.fromEntries(Object.entries(snapshot.checks).filter(([, check]) => isProblemStatus(check.status)))
+    : (snapshot.problems ?? {});
   if (Object.keys(problems).length > 0) body.problems = problems;
   return body;
+}
+
+/**
+ * The compact snapshot stored in Redis is byte-for-byte the body a `?compact=1`
+ * request returns. Deriving it from the same function that renders the response
+ * means the cached form can never drift from the live form.
+ */
+function buildCompactVerdictSnapshot(snapshot) {
+  return healthResponseBody(snapshot, true);
 }
 
 function healthResponse(snapshot, compact, headers) {
@@ -1251,10 +1282,14 @@ export default async function handler(req, ctx) {
   let ownsSnapshotRefreshLock = false;
   try {
     if (!getRedisCredentials()) throw new Error('Redis not configured');
-    const snapshotResult = await redisPipeline([['GET', HEALTH_VERDICT_SNAPSHOT_KEY]], 4_000);
+    // Read the snapshot this request will actually render. `?compact=1` — the
+    // browser poll, ~115k/day — reads the ~1 KB compact key instead of dragging the
+    // full ~20 KB check map out of Redis to show a tenth of it (#5300).
+    const snapshotKey = compact ? HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY : HEALTH_VERDICT_SNAPSHOT_KEY;
+    const snapshotResult = await redisPipeline([['GET', snapshotKey]], 4_000);
     if (!snapshotResult) throw new Error('Redis request failed');
     if (snapshotResult[0]?.error) throw new Error('Redis snapshot read failed');
-    const cachedSnapshot = parseHealthVerdictSnapshot(snapshotResult[0]?.result, Date.now());
+    const cachedSnapshot = parseHealthVerdictSnapshot(snapshotResult[0]?.result, Date.now(), { requireChecks: !compact });
     if (cachedSnapshot) return healthResponse(cachedSnapshot, compact, headers);
 
     refreshLockToken = `${now}:${crypto.randomUUID()}`;
@@ -1287,9 +1322,9 @@ export default async function handler(req, ctx) {
         const remainingMs = waitDeadline - Date.now();
         if (remainingMs < HEALTH_VERDICT_MIN_REDIS_TIMEOUT_MS) break;
         const redisTimeoutMs = Math.min(4_000, remainingMs);
-        const refreshedResult = await redisPipeline([['GET', HEALTH_VERDICT_SNAPSHOT_KEY]], redisTimeoutMs);
+        const refreshedResult = await redisPipeline([['GET', snapshotKey]], redisTimeoutMs);
         if (!refreshedResult || refreshedResult[0]?.error) throw new Error('Redis snapshot wait failed');
-        const refreshedSnapshot = parseHealthVerdictSnapshot(refreshedResult[0]?.result, Date.now());
+        const refreshedSnapshot = parseHealthVerdictSnapshot(refreshedResult[0]?.result, Date.now(), { requireChecks: !compact });
         if (refreshedSnapshot) return healthResponse(refreshedSnapshot, compact, headers);
 
         lockResult = await redisPipeline([[
@@ -1489,6 +1524,8 @@ export default async function handler(req, ctx) {
   // Await the write so the next request cannot race an unstarted background
   // SET and repeat the full sweep. A write failure does not invalidate the
   // live verdict just computed; the next request will retry by sweeping.
+  // Both snapshots are written by the SAME sweep, in one pipeline, so the compact
+  // form can never disagree with the full one or outlive it.
   const snapshotWriteResult = await redisPipeline([
     [
       'SET',
@@ -1497,8 +1534,17 @@ export default async function handler(req, ctx) {
       'EX',
       String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS),
     ],
+    [
+      'SET',
+      HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY,
+      JSON.stringify(buildCompactVerdictSnapshot(verdictSnapshot)),
+      'EX',
+      String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS),
+    ],
   ], 4_000).catch(() => null);
-  const snapshotWriteFailed = !snapshotWriteResult || snapshotWriteResult[0]?.error;
+  const snapshotWriteFailed = !snapshotWriteResult
+    || snapshotWriteResult.length !== 2
+    || snapshotWriteResult.some((entry) => entry?.error);
   if (ownsSnapshotRefreshLock) await releaseHealthVerdictRefreshLock(refreshLockToken);
   // A failed cache write does not invalidate the live verdict. Releasing only
   // this request's token lets the next caller retry immediately without ever
@@ -1533,6 +1579,8 @@ export const __testing__ = {
   LIST_DATA_KEYS,
   dataLenCommand,
   HEALTH_VERDICT_SNAPSHOT_KEY,
+  HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY,
+  buildCompactVerdictSnapshot,
   HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
   HEALTH_VERDICT_REFRESH_LOCK_KEY,
   HEALTH_VERDICT_REFRESH_WAIT_MS,

--- a/tests/health-verdict-compact-snapshot.test.mjs
+++ b/tests/health-verdict-compact-snapshot.test.mjs
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ } from '../api/health.js';
+
+const {
+  HEALTH_VERDICT_SNAPSHOT_KEY,
+  HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY,
+  buildCompactVerdictSnapshot,
+  healthResponseBody,
+  parseHealthVerdictSnapshot,
+} = __testing__;
+
+const CHECKED_AT = '2026-07-14T00:00:00.000Z';
+
+/** A verdict shaped like production: a few hundred checks, a handful of problems. */
+function fullVerdict(checkCount = 228, problemCount = 5) {
+  const checks = {};
+  for (let i = 0; i < checkCount - problemCount; i++) {
+    checks[`ok_key_${i}`] = { status: 'OK', records: 1234, seedAgeMin: 3 };
+  }
+  for (let i = 0; i < problemCount; i++) {
+    checks[`bad_key_${i}`] = { status: 'STALE_SEED', records: 0, seedAgeMin: 900 };
+  }
+  return {
+    status: 'WARNING',
+    summary: { total: checkCount, ok: checkCount - problemCount, warn: problemCount, crit: 0 },
+    checkedAt: CHECKED_AT,
+    checks,
+  };
+}
+
+test('the two snapshot keys are distinct', () => {
+  assert.notEqual(HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY, HEALTH_VERDICT_SNAPSHOT_KEY);
+  assert.match(HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY, /health:verdict:compact:v1$/);
+});
+
+// THE POINT OF THE CHANGE. ?compact=1 is the browser poll — every client, every 5
+// minutes, ~115k/day. It used to drag the full ~20 KB check map out of Redis to
+// render ~1 KB of it: ~2.2 GB/day of egress for bytes the caller discards (#5300).
+test('the compact snapshot is a fraction of the full one', () => {
+  const full = fullVerdict();
+  const compact = buildCompactVerdictSnapshot(full);
+
+  const fullBytes = JSON.stringify(full).length;
+  const compactBytes = JSON.stringify(compact).length;
+
+  assert.ok(
+    compactBytes < fullBytes / 10,
+    `compact snapshot must be an order of magnitude smaller (full ${fullBytes} B, compact ${compactBytes} B)`,
+  );
+  assert.equal(compact.checks, undefined, 'the compact snapshot must not carry the check map — that omission IS the saving');
+});
+
+test('the stored compact snapshot is exactly the body a compact request returns', () => {
+  const full = fullVerdict();
+  // Derived from the same renderer, so the cached form cannot drift from the live
+  // form — and re-rendering a compact snapshot is a no-op.
+  assert.deepEqual(buildCompactVerdictSnapshot(full), healthResponseBody(full, true));
+  assert.deepEqual(healthResponseBody(buildCompactVerdictSnapshot(full), true), healthResponseBody(full, true));
+});
+
+test('a compact response reports the same verdict and problems as the full one', () => {
+  const full = fullVerdict();
+  const fromFull = healthResponseBody(full, true);
+  const fromCompact = healthResponseBody(buildCompactVerdictSnapshot(full), true);
+
+  assert.equal(fromCompact.status, full.status);
+  assert.deepEqual(fromCompact.summary, full.summary);
+  assert.equal(fromCompact.checkedAt, full.checkedAt);
+  assert.deepEqual(Object.keys(fromCompact.problems ?? {}).sort(), Object.keys(fromFull.problems ?? {}).sort());
+  // Every problem is carried in full — operators still see records/seedAgeMin.
+  for (const [name, check] of Object.entries(fromFull.problems ?? {})) {
+    assert.deepEqual(fromCompact.problems[name], check);
+  }
+});
+
+test('an all-healthy verdict omits `problems` entirely', () => {
+  const healthy = { status: 'HEALTHY', summary: { total: 2, ok: 2 }, checkedAt: CHECKED_AT, checks: { a: { status: 'OK' }, b: { status: 'OK_CASCADE' } } };
+  const compact = buildCompactVerdictSnapshot(healthy);
+  assert.equal(compact.problems, undefined);
+  assert.equal(healthResponseBody(compact, true).problems, undefined);
+});
+
+// The parse contract. The full snapshot MUST carry `checks` — a truncated write
+// would otherwise be served as a valid verdict. The compact one must not.
+test('parse requires `checks` on the full snapshot but not the compact one', () => {
+  const now = Date.parse(CHECKED_AT) + 1_000;
+  const full = fullVerdict();
+  const compact = buildCompactVerdictSnapshot(full);
+
+  assert.ok(parseHealthVerdictSnapshot(JSON.stringify(full), now));
+  assert.ok(parseHealthVerdictSnapshot(JSON.stringify(compact), now, { requireChecks: false }));
+
+  // A compact snapshot must NOT satisfy a full (operator) read.
+  assert.equal(parseHealthVerdictSnapshot(JSON.stringify(compact), now), null);
+  // Junk is still rejected on both paths.
+  for (const bad of ['', 'not-json', JSON.stringify({ status: 'OK' })]) {
+    assert.equal(parseHealthVerdictSnapshot(bad, now, { requireChecks: false }), null);
+  }
+});
+
+test('a stale snapshot is rejected regardless of shape', () => {
+  const full = fullVerdict();
+  const compact = buildCompactVerdictSnapshot(full);
+  const wayLater = Date.parse(CHECKED_AT) + 10 * 60 * 1000; // past the 60s TTL
+
+  assert.equal(parseHealthVerdictSnapshot(JSON.stringify(full), wayLater), null);
+  assert.equal(parseHealthVerdictSnapshot(JSON.stringify(compact), wayLater, { requireChecks: false }), null);
+});

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -9,6 +9,8 @@ const { default: handler, __testing__ } = await import('../api/health.js');
 
 const {
   HEALTH_VERDICT_SNAPSHOT_KEY: HEALTH_SNAPSHOT_KEY,
+  HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY: HEALTH_COMPACT_SNAPSHOT_KEY,
+  buildCompactVerdictSnapshot,
   HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
   HEALTH_VERDICT_REFRESH_LOCK_KEY: HEALTH_REFRESH_LOCK_KEY,
   HEALTH_VERDICT_REFRESH_WAIT_MS,
@@ -51,8 +53,10 @@ test('scopes health verdict Redis keys to non-production deployments', () => {
   );
 });
 
-test('reuses one Redis verdict snapshot across compact and detailed callers', async () => {
-  let storedSnapshot = null;
+test('one sweep serves both callers, each from its own snapshot', async () => {
+  // #5300: one sweep writes TWO snapshots — the full check map (operator reads) and
+  // the compact body (?compact=1, the browser poll). Mock both.
+  const snapshotStore = { [HEALTH_SNAPSHOT_KEY]: null, [HEALTH_COMPACT_SNAPSHOT_KEY]: null };
   const pipelineCalls = [];
 
   globalThis.fetch = async (_url, init) => {
@@ -60,8 +64,8 @@ test('reuses one Redis verdict snapshot across compact and detailed callers', as
     pipelineCalls.push(commands);
 
     const results = commands.map(([op, key, value]) => {
-      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) {
-        return { result: storedSnapshot };
+      if (op === 'GET' && key in snapshotStore) {
+        return { result: snapshotStore[key] };
       }
       if (op === 'STRLEN') return { result: 100 };
       if (op === 'LLEN') return { result: 1 };
@@ -69,8 +73,8 @@ test('reuses one Redis verdict snapshot across compact and detailed callers', as
         return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
       }
       if (op === 'EXISTS') return { result: 0 };
-      if (op === 'SET' && key === HEALTH_SNAPSHOT_KEY) {
-        storedSnapshot = value;
+      if (op === 'SET' && key in snapshotStore) {
+        snapshotStore[key] = value;
         return { result: 'OK' };
       }
       return { result: 'OK' };
@@ -95,16 +99,33 @@ test('reuses one Redis verdict snapshot across compact and detailed callers', as
     commands.some(([op]) => op === 'STRLEN' || op === 'LLEN'));
   assert.equal(sweepCalls.length, 1, 'two callers inside the TTL must share one full health sweep');
 
-  const snapshotReads = pipelineCalls.filter((commands) =>
-    commands.length === 1
-      && commands[0][0] === 'GET'
-      && commands[0][1] === HEALTH_SNAPSHOT_KEY);
-  assert.equal(snapshotReads.length, 2, 'each response should need only one small snapshot GET');
+  // Each caller reads ONLY the snapshot it will render. The browser poll
+  // (?compact=1) must not drag the full ~20 KB check map out of Redis to show a
+  // tenth of it — that was ~2.2 GB/day of wasted egress (#5300).
+  const readsOf = (key) => pipelineCalls.filter((commands) =>
+    commands.length === 1 && commands[0][0] === 'GET' && commands[0][1] === key);
+  assert.equal(readsOf(HEALTH_COMPACT_SNAPSHOT_KEY).length, 1, 'the compact caller reads the compact snapshot');
+  assert.equal(readsOf(HEALTH_SNAPSHOT_KEY).length, 1, 'the detailed caller reads the full snapshot');
 
-  const snapshotWrites = pipelineCalls.flat().filter((command) =>
-    command[0] === 'SET' && command[1] === HEALTH_SNAPSHOT_KEY);
-  assert.equal(snapshotWrites.length, 1);
-  assert.deepEqual(snapshotWrites[0].slice(3), ['EX', String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS)]);
+  // ...and ONE sweep persists both, in a single pipeline, so they cannot disagree.
+  const writesOf = (key) => pipelineCalls.flat().filter((command) => command[0] === 'SET' && command[1] === key);
+  assert.equal(writesOf(HEALTH_SNAPSHOT_KEY).length, 1);
+  assert.equal(writesOf(HEALTH_COMPACT_SNAPSHOT_KEY).length, 1);
+  for (const key of [HEALTH_SNAPSHOT_KEY, HEALTH_COMPACT_SNAPSHOT_KEY]) {
+    assert.deepEqual(writesOf(key)[0].slice(3), ['EX', String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS)]);
+  }
+  const persistPipeline = pipelineCalls.find((commands) =>
+    commands.some(([op, key]) => op === 'SET' && key === HEALTH_SNAPSHOT_KEY));
+  assert.ok(
+    persistPipeline.some(([op, key]) => op === 'SET' && key === HEALTH_COMPACT_SNAPSHOT_KEY),
+    'both snapshots must be written by the same sweep, in one pipeline',
+  );
+
+  // The stored compact snapshot is a fraction of the full one — the whole point.
+  const storedFull = writesOf(HEALTH_SNAPSHOT_KEY)[0][2];
+  const storedCompact = writesOf(HEALTH_COMPACT_SNAPSHOT_KEY)[0][2];
+  assert.ok(storedCompact.length < storedFull.length, 'the compact snapshot must be smaller than the full one');
+  assert.equal(JSON.parse(storedCompact).checks, undefined, 'the compact snapshot must not carry the check map');
 
   assert.equal(compactResponse.headers.get('Cache-Control'), 'no-store, max-age=0');
   assert.equal(detailedResponse.headers.get('Cache-Control'), 'private, no-store, max-age=0');
@@ -138,7 +159,9 @@ test('rejects malformed or older-than-TTL snapshots', () => {
 });
 
 test('coalesces concurrent cache misses into one full sweep', async () => {
-  let storedSnapshot = null;
+  // #5300: one sweep writes TWO snapshots — the full check map (operator reads) and
+  // the compact body (?compact=1, the browser poll). Mock both.
+  const snapshotStore = { [HEALTH_SNAPSHOT_KEY]: null, [HEALTH_COMPACT_SNAPSHOT_KEY]: null };
   let refreshLocked = false;
   const pipelineCalls = [];
 
@@ -153,7 +176,7 @@ test('coalesces concurrent cache misses into one full sweep', async () => {
     }
 
     const results = commands.map(([op, key, value]) => {
-      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) return { result: storedSnapshot };
+      if (op === 'GET' && key in snapshotStore) return { result: snapshotStore[key] };
       if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) {
         if (refreshLocked) return { result: null };
         refreshLocked = true;
@@ -165,8 +188,8 @@ test('coalesces concurrent cache misses into one full sweep', async () => {
         return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
       }
       if (op === 'EXISTS') return { result: 0 };
-      if (op === 'SET' && key === HEALTH_SNAPSHOT_KEY) {
-        storedSnapshot = value;
+      if (op === 'SET' && key in snapshotStore) {
+        snapshotStore[key] = value;
         return { result: 'OK' };
       }
       return { result: 'OK' };
@@ -198,10 +221,15 @@ test('projects only failing checks from a cached compact snapshot', async () => 
       delayed: { status: 'STALE_SEED', seedAgeMin: 30 },
     },
   };
+  // The problems are now projected ONCE, at sweep time, into the compact snapshot —
+  // so the browser poll reads ~1 KB instead of the full check map (#5300). A compact
+  // caller must therefore read the compact key, and must never touch the full one.
+  const compactSnapshot = buildCompactVerdictSnapshot(snapshot);
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
-    assert.deepEqual(commands, [['GET', HEALTH_SNAPSHOT_KEY]]);
-    return new Response(JSON.stringify([{ result: JSON.stringify(snapshot) }]), { status: 200 });
+    assert.deepEqual(commands, [['GET', HEALTH_COMPACT_SNAPSHOT_KEY]],
+      'a ?compact=1 caller must read the compact snapshot, never the full check map');
+    return new Response(JSON.stringify([{ result: JSON.stringify(compactSnapshot) }]), { status: 200 });
   };
 
   const response = await handler(new Request('https://api.worldmonitor.app/api/health?compact=1'));
@@ -211,6 +239,9 @@ test('projects only failing checks from a cached compact snapshot', async () => 
   assert.deepEqual(body.problems, { delayed: snapshot.checks.delayed });
   assert.ok(!Object.hasOwn(body, 'checks'));
   assert.equal(body.checkedAt, snapshot.checkedAt);
+  // The stored form carries only the problems, not all three checks.
+  assert.equal(compactSnapshot.checks, undefined);
+  assert.deepEqual(Object.keys(compactSnapshot.problems), ['delayed']);
 });
 
 test('takes over refresh after the prior lock owner disappears', async () => {
@@ -287,7 +318,7 @@ test('does not start a doomed Redis request at the contention deadline', async (
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
     if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
-    if (commands.length === 1 && commands[0][0] === 'GET' && commands[0][1] === HEALTH_SNAPSHOT_KEY) {
+    if (commands.length === 1 && commands[0][0] === 'GET' && (commands[0][1] === HEALTH_SNAPSHOT_KEY || commands[0][1] === HEALTH_COMPACT_SNAPSHOT_KEY)) {
       snapshotReads++;
       if (snapshotReads > 1) {
         return new Response(null, { status: 504 });
@@ -315,15 +346,29 @@ test('does not start a doomed Redis request at the contention deadline', async (
 });
 
 test('releases its refresh lock when snapshot persistence fails', async () => {
-  let storedSnapshot = null;
+  // #5300: one sweep writes TWO snapshots — the full check map (operator reads) and
+  // the compact body (?compact=1, the browser poll). Mock both.
+  const snapshotStore = { [HEALTH_SNAPSHOT_KEY]: null, [HEALTH_COMPACT_SNAPSHOT_KEY]: null };
   let refreshLockToken = null;
   let snapshotWriteAttempts = 0;
   let sweepCount = 0;
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
     if (commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) sweepCount++;
+
+    // A sweep persists BOTH snapshots in one pipeline (#5300), so a failed
+    // persistence attempt fails the pair. Failing only one would leave a usable
+    // compact snapshot behind, and the next caller would rightly serve it instead
+    // of re-sweeping — which is not the path this test is probing.
+    const isSnapshotPersist = commands.some(([op, key]) => op === 'SET' && key === HEALTH_SNAPSHOT_KEY);
+    let failThisWriteAttempt = false;
+    if (isSnapshotPersist) {
+      snapshotWriteAttempts++;
+      failThisWriteAttempt = snapshotWriteAttempts === 1;
+    }
+
     const results = commands.map(([op, key, value]) => {
-      if (op === 'GET' && key === HEALTH_SNAPSHOT_KEY) return { result: storedSnapshot };
+      if (op === 'GET' && key in snapshotStore) return { result: snapshotStore[key] };
       if (op === 'SET' && key === HEALTH_REFRESH_LOCK_KEY) {
         if (refreshLockToken) return { result: null };
         refreshLockToken = value;
@@ -333,10 +378,9 @@ test('releases its refresh lock when snapshot persistence fails', async () => {
         if (commands[0][4] === refreshLockToken) refreshLockToken = null;
         return { result: 1 };
       }
-      if (op === 'SET' && key === HEALTH_SNAPSHOT_KEY) {
-        snapshotWriteAttempts++;
-        if (snapshotWriteAttempts === 1) return { error: 'transient write failure' };
-        storedSnapshot = value;
+      if (op === 'SET' && key in snapshotStore) {
+        if (failThisWriteAttempt) return { error: 'transient write failure' };
+        snapshotStore[key] = value;
         return { result: 'OK' };
       }
       if (op === 'STRLEN') return { result: 100 };


### PR DESCRIPTION
Fourth slice of #5300 — and a regression **#5262 introduced**, which I should have measured at the time.

## The finding

#5262 memoized the `/api/health` verdict and cut the ~390-command sweep from 1.24/s to 0.02/s — **79% off total Redis commands**. Unambiguously worth it. But it traded some of that back in *bandwidth*, and nobody measured that side:

The snapshot stores the **entire check map** (~228 entries, **~20 KB**), and every caller reads it. But `?compact=1` **is the browser poll** — every client, every 5 minutes, **~115k/day** — and it renders only `status`, `summary`, `checkedAt` and the handful of problem entries. About **1 KB**.

Measured against production:

```
full snapshot   : 20,117 B  (228 checks)
compact snapshot:  1,077 B  (5 problems)   -> 5.4%
```

So every browser poll dragged 20 KB out of Redis to display 5% of it: **~2.19 GB/day of egress for bytes the caller throws away.**

## What changes

The sweep now persists **two** snapshots in **one pipeline** — the full check map for the key-gated operator view, and the compact body for `?compact=1`. Each caller reads only the one it will render.

The compact snapshot is produced by `healthResponseBody(snapshot, true)` — **the very function that renders the compact response** — so the cached form cannot drift from the live form, and re-rendering a compact snapshot is a no-op. `parseHealthVerdictSnapshot` gains a `requireChecks` flag: the full snapshot **must** carry a check map (a truncated write must never be served as a valid verdict); the compact one **must not** (that omission *is* the saving).

## Everything #5262 established still holds

I re-verified each property rather than assuming:
- every request still issues a real Redis command → a genuine outage still returns `REDIS_DOWN`/503
- the operator key-gate still precedes the snapshot read
- one sweep still serves a cold burst (lock-coalesced)
- both keys are written by the same sweep, so they can never disagree or outlive each other

## I updated #5262's tests rather than working around them

Its test was literally named **"reuses ONE Redis verdict snapshot across compact and detailed callers"** — asserting exactly the behaviour this change splits. Making it pass by patching a mock would have been dishonest, so it now asserts the *better* invariant: **one sweep, two snapshots, each caller reading only its own, written together in one pipeline** — plus that the stored compact form carries no check map.

The persistence-failure mock now fails the **pair**: failing only one SET would leave a usable compact snapshot behind, and the next caller would rightly serve it instead of re-sweeping — which is not the path that test probes. That's a real behavioural nuance the split introduces, and it's now pinned.

## Validation

- `tests/health-verdict-compact-snapshot.test.mjs` (new) — **7 pass**: size floor, no check map in the compact form, cached form == rendered body, identical verdict/problems from either shape, `problems` omitted when healthy, the `requireChecks` contract, TTL rejection on both shapes
- `tests/health-verdict-snapshot.test.mjs` (#5262's suite, updated) — **10 pass**
- All health-touching suites — **142 pass, 0 fail**
- `tests/edge-functions.test.mjs` — **228 pass**
- `npm run typecheck`, `npm run typecheck:api` — pass
- Pre-push gate — pass

## Post-deploy

`GET /api/health?compact=1` must return the same verdict as today, and a MONITOR tap should show the poll reading `health:verdict:compact:v1` (~1 KB) instead of `health:verdict:v1` (~20 KB).

## Epic running total

| PR | saving |
|---|---|
| #5302 cyberThreats → on-demand | ~2.15 GB/day |
| #5303 thermal → dashboard view | ~2.5 GB/day |
| #5305 ucdp → projection | ~3.8 GB/day |
| **this** | **~2.2 GB/day** |
| | **≈ 10.7 GB/day** |