### PR TITLE
fix(seeders): give the ACLED conflict key a TTL that outlives its staleness gate

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -26,7 +26,19 @@ loadEnvFile(import.meta.url);
 const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
 const ACLED_CACHE_KEY = 'conflict:acled:v1:all:0:0';
 const ACLED_RESOLUTION_CACHE_KEY = 'conflict:acled-resolution:v1:all:0:0';
-const ACLED_TTL = 900;
+// Data TTL for the conflict-events key. MUST outlive health's staleness threshold
+// for acledIntel (maxStaleMin 38 in api/health.js), or the key expires BEFORE
+// STALE_SEED can fire and a merely-late seeder reports as an EMPTY crit — while
+// consumers of the forecast EMA input get nothing at all.
+//
+// Was 900s (15 min) against a */15 cron: a TTL exactly equal to the refresh
+// interval, i.e. ZERO headroom. Railway SKIPS a tick whenever the previous run is
+// still in flight (11 skipped ticks in one 12h window), so one skip dropped the
+// data. Observed live: last good run 23 min old, key already gone, health crit.
+// 2700s = 45 min = 3x the interval, matching the convention in
+// seed-defense-patents.mjs (21d TTL for a weekly seed). Pinned by
+// tests/seed-ttl-outlives-health-staleness.
+export const ACLED_TTL = 2700;
 const ACLED_DISPLAY_LOOKBACK_DAYS = 30;
 const ACLED_DISPLAY_LIMIT = 500;
 const ACLED_RESOLUTION_LOOKBACK_DAYS = 60;

--- a/tests/seed-ttl-outlives-health-staleness.test.mjs
+++ b/tests/seed-ttl-outlives-health-staleness.test.mjs
@@ -1,0 +1,53 @@
+// A seeded key's data TTL must OUTLIVE the health staleness threshold for that key.
+//
+// Bug (found 2026-07-14 in production): seed-conflict-intel runs on `*/15 * * * *`
+// and wrote `conflict:acled:v1:all:0:0` with ACLED_TTL = 900s — a 15-minute TTL on a
+// 15-minute refresh interval. Zero headroom: ONE late, slow, or Railway-SKIPPED tick
+// and the key expires before the next write lands. Observed live: last successful run
+// 23 min ago (recordCount 67, status ok), data key already gone (EXISTS 0, TTL -2),
+// /api/health = EMPTY (crit) — and consumers of the forecast EMA input got nothing.
+//
+// The incoherence this pins: health's maxStaleMin for acledIntel is 38 minutes, but
+// the data evaporated at 15. The key disappeared BEFORE the staleness warning could
+// fire, so a mild "the seeder is running late" condition reported as a CRIT (EMPTY)
+// instead of escalating gracefully through STALE_SEED (warn).
+//
+// The invariant: TTL > maxStaleMin. Then the escalation is ordered and truthful —
+// seeder late  -> STALE_SEED (warn, data still served)
+// seeder dead  -> EMPTY (crit, data genuinely gone)
+//
+// This is NOT the SAM/NOT_CONFIGURED case. That key has no keyless path and correctly
+// reports `unavailable`. This one is populated by a credential-free source
+// (sourceVersion "acled-hapi-pizzint", 67 records), so an EMPTY here is a real outage
+// and must stay a crit — it just must not fire spuriously.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ACLED_TTL } from '../scripts/seed-conflict-intel.mjs';
+import { __testing__ } from '../api/health.js';
+
+test('the ACLED conflict key outlives its own health staleness threshold', () => {
+  const { SEED_META } = __testing__;
+  const maxStaleSeconds = SEED_META.acledIntel.maxStaleMin * 60;
+
+  assert.ok(
+    ACLED_TTL > maxStaleSeconds,
+    `ACLED_TTL (${ACLED_TTL}s) must exceed health maxStaleMin `
+      + `(${SEED_META.acledIntel.maxStaleMin}min = ${maxStaleSeconds}s), or the data key expires `
+      + 'before STALE_SEED can fire and a late seeder reports as an EMPTY crit',
+  );
+});
+
+test('the ACLED key survives more than one missed cron tick', () => {
+  // seed-conflict-intel cron is */15. Railway SKIPS a tick whenever the previous run
+  // is still in flight (11 SKIPPED ticks observed in a 12h window), so the EFFECTIVE
+  // cadence is routinely longer than 15 minutes. A TTL equal to the interval cannot
+  // survive that; the repo convention elsewhere is ~3x the interval (see
+  // seed-defense-patents.mjs: `CACHE_TTL = 1_814_400; // 21 days (3x weekly interval)`).
+  const CRON_INTERVAL_SECONDS = 15 * 60;
+  assert.ok(
+    ACLED_TTL >= 2 * CRON_INTERVAL_SECONDS,
+    `ACLED_TTL (${ACLED_TTL}s) must cover at least 2 refresh intervals `
+      + `(${2 * CRON_INTERVAL_SECONDS}s) so a single skipped tick cannot drop the data`,
+  );
+});


### PR DESCRIPTION
## Problem

`/api/health` reported `acledIntel: EMPTY` (**crit**) — while the seeder was working perfectly.

```
seed-meta : {"recordCount":67,"sourceVersion":"acled-hapi-pizzint"}  status ok, 23 min ago
data key  : EXISTS 0   TTL -2 (gone)   STRLEN 0
```

The seeder had **succeeded**, producing 67 conflict events from the **credential-free** hapi/pizzint path — and its data had already evaporated.

## Root cause: a TTL with zero headroom

```
cron:      */15 * * * *   → every 15 minutes
ACLED_TTL: 900s           → 15 minutes
```

**The data TTL was exactly equal to the refresh interval.** One late, slow, or Railway-SKIPPED tick and the key expires before the next write lands. Not hypothetical: Railway skips a tick whenever the previous run is still in flight — **11 skipped ticks in a single 12-hour window**.

And the escalation was incoherent: health's `maxStaleMin` for `acledIntel` is **38 minutes**, but the data died at **15**. The key vanished *before* the staleness warning could fire, so a merely-late seeder reported as a **CRIT** (`EMPTY`) instead of escalating gracefully through `STALE_SEED` (warn). Meanwhile consumers of the forecast EMA input got **nothing** — this isn't a monitoring artifact, the conflict data genuinely disappeared for part of every cycle.

## Not the SAM/NOT_CONFIGURED case

Worth stating explicitly, because the surface looks similar to #5295 and the *opposite* fix would be actively harmful here.

`globalTendersSam` has **no keyless path** — it correctly reports `unavailable`, and #5295 rightly stopped grading it. `acledIntel` **is** populated without credentials (67 events via hapi/pizzint). An `EMPTY` here is a **real outage** and must stay a crit. It just must not fire spuriously.

(Separately: the seeder reads `ACLED_ACCESS_TOKEN`, and only `VITE_ACLED_ACCESS_TOKEN` is set on the service — so there really are no ACLED creds. That's fine; the keyless path is what feeds this key. Flagging it only so nobody assumes the token is wired up.)

## Fix

**`ACLED_TTL` 900 → 2700** (45 min = 3× the interval), matching the repo convention in `seed-defense-patents.mjs` (`CACHE_TTL = 1_814_400; // 21 days (3x weekly interval)`).

The invariant, now pinned by tests:

> **A seeded key's data TTL must OUTLIVE the health staleness threshold for that key.**

so the escalation is ordered and truthful:

```
seeder late  ->  STALE_SEED (warn, data still served)
seeder dead  ->  EMPTY      (crit, data genuinely gone)
```

## Verification

- Failing invariant reproduced, then **mutation-tested**: restoring `ACLED_TTL = 900` turns both assertions red.
- **203 tests pass** across the conflict/acled/gdelt/health suites. `tsc` and Biome clean.
- **Verified in production:** after seeding with the new TTL the key holds **11,672 bytes with TTL 2680s**, and `/api/health` went `DEGRADED (crit=1)` → **`WARNING (crit=0)`**.

Found while investigating a (separate, self-healed) CanadaBuys blip.

https://claude.ai/code/session_015HXMBUiQa6iRJfjbpLWYxU
