### PR TITLE
fix(seeders): absorb a transient tender-source blip instead of raising a health warn

### DIFF
--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { XMLParser } from 'fast-xml-parser';
 import Papa from 'papaparse';
 
-import { loadEnvFile, CHROME_UA, readCanonicalValue, runSeed, writeExtraKey } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, readCanonicalValue, runSeed, withRetry, writeExtraKey } from './_seed-utils.mjs';
 import {
   GLOBAL_TENDER_KEY,
   isOpenOpportunity,
@@ -23,15 +23,37 @@ const MAX_PER_SOURCE = 100;
 const GETS_FEED_URL = 'https://www.gets.govt.nz/ExternalRSSFeed.htm';
 const CANADA_BUYS_OPEN_CSV_URL = 'https://canadabuys.canada.ca/opendata/pub/openTenderNotice-ouvertAvisAppelOffres.csv';
 
+// Every tender source funnels through here, so this is the one place a transient
+// upstream blip can be absorbed. Without it a single failed fetch failed the whole
+// source and raised a health warn that self-healed on the next tick — noise the
+// operator cannot act on.
+//
+// The retry budget is BOUNDED by the bundle section, not chosen for its own sake:
+// Global-Tenders has timeoutMs 180_000 and CanadaBuys uses a 60s per-attempt
+// timeout, so maxRetries 2 would cost 60+1+60+2+60 = 183s and BREACH the section.
+// Callers with a long per-attempt timeout must lower maxRetries accordingly.
+// Sources run in parallel, so the section pays the slowest source, not the sum.
 async function fetchResponse(url, options = {}) {
-  const { timeoutMs = 20_000, ...fetchOptions } = options;
-  const response = await fetch(url, {
-    ...fetchOptions,
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA, ...(fetchOptions.headers || {}) },
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  return response;
+  const { timeoutMs = 20_000, maxRetries = 2, ...fetchOptions } = options;
+  return withRetry(async () => {
+    const response = await fetch(url, {
+      ...fetchOptions,
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA, ...(fetchOptions.headers || {}) },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      const err = new Error(`HTTP ${response.status}`);
+      // A 4xx will not fix itself — retrying only burns the section budget before
+      // failing anyway. 429 is the exception: it is explicitly "try again later".
+      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+        err.nonRetryable = true;
+      }
+      const retryAfter = Number(response.headers?.get?.('retry-after'));
+      if (Number.isFinite(retryAfter) && retryAfter > 0) err.retryAfterMs = retryAfter * 1000;
+      throw err;
+    }
+    return response;
+  }, maxRetries, 1000);
 }
 
 async function fetchJson(url, options = {}) {
@@ -113,6 +135,9 @@ export async function fetchContractsFinder({ now = Date.now(), fetchJsonFn = fet
 export async function fetchCanadaBuys({ now = Date.now(), fetchTextFn = fetchText } = {}) {
   const csv = await fetchTextFn(CANADA_BUYS_OPEN_CSV_URL, {
     timeoutMs: 60_000,
+    // 6 MB CSV on a 60s attempt timeout: one retry (60+1+60 = 121s) fits inside the
+    // 180s Global-Tenders section budget; two (183s) would breach it.
+    maxRetries: 1,
     headers: { Accept: 'text/csv, application/octet-stream;q=0.9, */*;q=0.1' },
   });
   const parsed = Papa.parse(csv, {

--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { XMLParser } from 'fast-xml-parser';
 import Papa from 'papaparse';
 
-import { loadEnvFile, CHROME_UA, readCanonicalValue, runSeed, withRetry, writeExtraKey } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, httpRetryError, readCanonicalValue, runSeed, withRetry, writeExtraKey } from './_seed-utils.mjs';
 import {
   GLOBAL_TENDER_KEY,
   isOpenOpportunity,
@@ -42,15 +42,9 @@ async function fetchResponse(url, options = {}) {
       signal: AbortSignal.timeout(timeoutMs),
     });
     if (!response.ok) {
-      const err = new Error(`HTTP ${response.status}`);
-      // A 4xx will not fix itself — retrying only burns the section budget before
-      // failing anyway. 429 is the exception: it is explicitly "try again later".
-      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-        err.nonRetryable = true;
-      }
-      const retryAfter = Number(response.headers?.get?.('retry-after'));
-      if (Number.isFinite(retryAfter) && retryAfter > 0) err.retryAfterMs = retryAfter * 1000;
-      throw err;
+      // Reuse the repository retry contract: 408 and 429 remain retryable, permanent
+      // 4xx responses fail fast, and Retry-After is capped before it reaches withRetry.
+      throw httpRetryError(response);
     }
     return response;
   }, maxRetries, 1000);

--- a/tests/global-tenders-transient-retry.test.mjs
+++ b/tests/global-tenders-transient-retry.test.mjs
@@ -39,7 +39,7 @@ function stubFetch(responses) {
     return {
       ok: next.status >= 200 && next.status < 300,
       status: next.status,
-      headers: { get: () => null },
+      headers: { get: (name) => next.headers?.[name.toLowerCase()] ?? null },
       text: async () => next.body ?? '',
       json: async () => ({}),
     };
@@ -73,6 +73,18 @@ test('a permanent 4xx is NOT retried — it would only burn the section timeout'
       /HTTP 404/,
     );
     assert.equal(calls.length, 1, 'a permanent 4xx must fail fast, not retry');
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test('HTTP 408 is retried because it is a transient upstream timeout', async () => {
+  const calls = stubFetch([{ status: 408, body: '' }, { status: 200, body: CSV }]);
+  try {
+    const { records, status } = await fetchCanadaBuys({ now: Date.parse('2026-07-14T00:00:00Z') });
+    assert.equal(calls.length, 2, '408 must get the configured retry rather than fail as a permanent 4xx');
+    assert.equal(status.state, 'ok');
+    assert.equal(records.length, 1);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/tests/global-tenders-transient-retry.test.mjs
+++ b/tests/global-tenders-transient-retry.test.mjs
@@ -1,0 +1,79 @@
+// Global-tender source adapters must survive a single transient upstream blip.
+//
+// Bug (found 2026-07-14 in production): /api/health reported
+// globalTendersCanadaBuys: SEED_ERROR. The CanadaBuys upstream was perfectly
+// healthy — probed 6/6 x HTTP 200, 6.0 MB, 2.1-4.3s against a 60s timeout — so a
+// single transient failure on one hourly tick had failed the whole source and
+// raised a health warn, then self-healed on the next tick.
+//
+// None of the six adapters had ANY retry: `fetchResponse` did one fetch and threw.
+// One blip => source fails => health warn. That is noise the operator cannot act on
+// and it trains them to ignore the channel.
+//
+// Bounded on purpose: the Global-Tenders bundle section has timeoutMs 180_000
+// (scripts/seed-bundle-relay-backup.mjs) and CanadaBuys uses a 60s per-attempt
+// timeout, so an unbounded retry chain would BREACH the section budget:
+//   maxRetries 2 => 60 + 1 + 60 + 2 + 60 = 183s  > 180s  (breach)
+//   maxRetries 1 => 60 + 1 + 60           = 121s  < 180s  (safe)
+// Sources run in parallel (Promise.allSettled), so the section cost is the slowest
+// source, not the sum.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchCanadaBuys } from '../scripts/seed-global-tenders.mjs';
+
+const CSV = [
+  '"title-titre-eng","referenceNumber-numeroReference","noticeURL-URLavis-eng",'
+    + '"publicationDate-datePublication","tenderClosingDate-appelOffresDateCloture",'
+    + '"tenderStatus-appelOffresStatut-eng"',
+  '"Radar maintenance","REF-1","https://canadabuys.canada.ca/n/1","2026-07-01","2099-01-01","Open"',
+].join('\n');
+
+function stubFetch(responses) {
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    const next = responses[calls.length - 1];
+    if (!next) throw new Error('unexpected extra fetch');
+    if (next.throw) throw Object.assign(new Error(next.throw), { name: 'TimeoutError' });
+    return {
+      ok: next.status >= 200 && next.status < 300,
+      status: next.status,
+      headers: { get: () => null },
+      text: async () => next.body ?? '',
+      json: async () => ({}),
+    };
+  };
+  return calls;
+}
+
+const realFetch = globalThis.fetch;
+
+test('a transient CanadaBuys failure is retried, not surfaced as a source error', async () => {
+  // First attempt dies the way a real blip dies (connection reset / timeout),
+  // second attempt returns the documented CSV.
+  const calls = stubFetch([{ throw: 'socket hang up' }, { status: 200, body: CSV }]);
+  try {
+    const { records, status } = await fetchCanadaBuys({ now: Date.parse('2026-07-14T00:00:00Z') });
+    assert.equal(calls.length, 2, 'the transient failure must be retried');
+    assert.equal(status.state, 'ok', 'a blip that succeeds on retry is not a source error');
+    assert.equal(records.length, 1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test('a permanent 4xx is NOT retried — it would only burn the section timeout', async () => {
+  // A 404/403 will not fix itself. withRetry honours `nonRetryable`, and retrying
+  // here would waste the bundle's 180s budget for a guaranteed failure.
+  const calls = stubFetch([{ status: 404, body: '' }]);
+  try {
+    await assert.rejects(
+      () => fetchCanadaBuys({ now: Date.parse('2026-07-14T00:00:00Z') }),
+      /HTTP 404/,
+    );
+    assert.equal(calls.length, 1, 'a permanent 4xx must fail fast, not retry');
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});


### PR DESCRIPTION
## Problem

`/api/health` reported `globalTendersCanadaBuys: SEED_ERROR` — but the upstream was **perfectly healthy**. I probed it six times:

```
#1 200  6,010,064 bytes  2.25s     #4 200  6,010,064 bytes  4.26s
#2 200  6,010,064 bytes  2.15s     #5 200  6,010,064 bytes  2.26s
#3 200  6,010,064 bytes  2.60s     #6 200  6,010,064 bytes  2.13s
```

6/6, 2–4s against a **60s** timeout. So a single transient failure on one hourly tick failed the whole source, raised a warn, and self-healed on the next tick.

**None of the six tender adapters had any retry.** `fetchResponse` did one fetch and threw. One blip → source fails → a health warn the operator cannot act on. That is precisely the noise that trains people to ignore the channel.

## Fix

`fetchResponse` is the single choke point for **all six** sources (SAM, TED, Contracts Finder, CanadaBuys, GETS, World Bank), so the retry goes there — every source is hardened, not just the one that happened to blip today.

**The retry budget is bounded by the bundle section, not picked for its own sake.** Global-Tenders has `timeoutMs: 180_000` and CanadaBuys uses a 60s per-attempt timeout:

```
maxRetries 2  =>  60 + 1 + 60 + 2 + 60 = 183s   >  180s   ← would BREACH the section
maxRetries 1  =>  60 + 1 + 60          = 121s   <  180s   ← safe
```

So CanadaBuys passes `maxRetries: 1` explicitly, while the other five keep the 20s default timeout and can afford the default 2. Sources run in parallel (`Promise.allSettled`), so the section pays the **slowest** source, not the sum.

A **4xx is tagged `nonRetryable`** (429 excepted — that one explicitly means *try again later*): retrying a 404/403 cannot succeed and would burn the section budget before failing anyway. Upstream `Retry-After` hints are honoured.

## Verification

- Failing test written first and confirmed red (transient failure not retried).
- **Mutation-tested, both halves independently**: remove the retry → transient test red; remove the `nonRetryable` guard → permanent-failure test red.
- 38 tender/procurement tests pass. `tsc` and Biome clean.

Found while investigating the CanadaBuys warn; the same investigation surfaced a separate live crit, fixed in #5309.

https://claude.ai/code/session_015HXMBUiQa6iRJfjbpLWYxU
