### PR TITLE
perf(forecasts): serve the dashboard the forecast LIST, not the dossiers (#5300)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 162 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 163 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
 
 ## Repository Map
 
@@ -13,7 +13,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 162
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
-│   ├── components/         # 162 top-level TypeScript component files
+│   ├── components/         # 163 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (199 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Variants share all code but differ in default panels, map layers, and RSS feeds.
 
 | Directory | Purpose |
 |---|---|
-| `src/components/` | UI components — 162 top-level TypeScript component files |
+| `src/components/` | UI components — 163 top-level TypeScript component files |
 | `src/services/` | Data fetching modules — sebuf client wrappers, AI, signal analysis |
 | `src/config/` | Static data and variant configs (feeds, geo, military, pipelines, ports) |
 | `src/generated/` | Auto-generated sebuf client + server stubs (**do not edit by hand**) |

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -97,7 +97,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   techEvents:        'research:tech-events-bootstrap:v1',
   gdeltIntel:        'intelligence:gdelt-intel:v1',
   correlationCards:   'correlation:cards-bootstrap:v1',
-  forecasts:         'forecast:predictions:v2',
+  forecasts:         'forecast:predictions-bootstrap:v1',
   securityAdvisories: 'intelligence:advisories-bootstrap:v1',
   customsRevenue:    'trade:customs-revenue:v1',
   sanctionsPressure: 'sanctions:pressure:v1',

--- a/api/health.js
+++ b/api/health.js
@@ -105,6 +105,7 @@ const BOOTSTRAP_KEYS = {
   gdeltIntel:        'intelligence:gdelt-intel:v1',
   correlationCards:   'correlation:cards-bootstrap:v1',
   forecasts:         'forecast:predictions:v2',
+  forecastsBootstrap: 'forecast:predictions-bootstrap:v1',
   securityAdvisories: 'intelligence:advisories-bootstrap:v1',
   customsRevenue:    'trade:customs-revenue:v1',
   comtradeFlows:     'comtrade:flows:v1',
@@ -438,6 +439,7 @@ const SEED_META = {
   telegramFeed:     { key: 'seed-meta:intelligence:telegram-feed:v1', maxStaleMin: 10 }, // 60s poll interval; 10min grace catches poll failures before they go stale in the panel
   digestNotifications: { key: 'seed-meta:digest:last-run',          maxStaleMin: 90 }, // Railway digest-notifications cron runs every 30min; 90 = 3x cadence and detects a dead cron before daily digests are missed.
   forecasts:        { key: 'seed-meta:forecast:predictions',       maxStaleMin: 90 },
+  forecastsBootstrap: { key: 'seed-meta:forecast:predictions-bootstrap', maxStaleMin: 90 }, // Same cron. Monitored separately: the fast tier now hydrates from the dashboard list, and a transform/write failure there must not hide behind a healthy canonical key (#5300).
   forecastResolutions: { key: 'seed-meta:forecast:resolutions',     maxStaleMin: 2160 }, // daily Bet-2 resolver; 36h catches a missed cron without flapping on normal daily jitter
   forecastScorecard:   { key: 'seed-meta:forecast:scorecard',       maxStaleMin: 2160 }, // scorecard extra key written by seed-forecast-resolutions
   forecastBets:        { key: 'seed-meta:forecast:bets',            maxStaleMin: 2880 }, // #5233 shadow bet-engine seeder; daily cron (05:00 UTC), 48h = 2× interval
@@ -718,6 +720,7 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'forecastFunnel', // #5233 funnel guardrail is a new afterPublish side-write; before the first seed-forecasts run ships it the key is absent — tolerate as STALE_SEED (warn), not EMPTY (crit). A COLLAPSED funnel still surfaces via seed-meta status:'error' → SEED_ERROR, which classifyKey checks before this branch.
   'thermalEscalationBootstrap', // Compact dashboard projection is absent until the first thermal seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
   'ucdpEventsBootstrap', // Compact dashboard projection is absent until the first ucdp seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
+  'forecastsBootstrap', // Dashboard list is absent until the first seed-forecasts tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit).
   'wildfiresBootstrap', // Compact dashboard side-write is absent until the first fire seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
 ]);
 

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -10,7 +10,7 @@
     "energy": 18
   },
   "variantCount": 6,
-  "componentTopLevelTsFiles": 162,
+  "componentTopLevelTsFiles": 163,
   "serviceTopLevelEntries": 199,
   "apiEndpointEntries": 88,
   "panelClasses": 105,

--- a/scripts/_forecast-dashboard.mjs
+++ b/scripts/_forecast-dashboard.mjs
@@ -1,0 +1,52 @@
+/**
+ * Dashboard-sized projection of the forecast feed (#5300).
+ *
+ * `forecast:predictions:v2` is 188 KB for 15 predictions, and **78% of it is
+ * `caseFile`** — the per-forecast evidence dossier (~19,000 words of prose across
+ * branches, actors, worldState, supporting/counter evidence, escalatory and
+ * contrarian cases, triggers).
+ *
+ * That dossier is read in exactly ONE place: `ForecastPanel.renderDetailBody()`,
+ * which mounts it eagerly into `<div class="fc-detail fc-hidden">` and reveals it
+ * with a hover-only "Analysis" toggle. So today every visitor:
+ *   - pulls 146 KB of dossiers out of Redis on every bootstrap origin miss,
+ *   - downloads them on every page load, and
+ *   - has ~19,000 words serialised to HTML and parsed into the DOM at panel
+ *     render — on a priority-1 panel, i.e. inside the LCP/INP window —
+ * for content the overwhelming majority never expand.
+ *
+ * The bootstrap key therefore carries the LIST the panel renders (188 KB -> 41 KB).
+ * The canonical key keeps the dossiers and still serves the RPC, the MCP widget and
+ * chat-analyst-context; the panel fetches a dossier lazily when someone actually
+ * opens one.
+ *
+ * NOTE: this file must not import anything outside `scripts/` — Railway builds the
+ * seeders from a scripts-only Nixpacks root, and a `../api/` import crashes the
+ * container at startup (#5268 took the wildfire feed down for ~6h exactly that way).
+ */
+
+/** Fields dropped from the dashboard list. Only `caseFile` today — it is 78% of the payload. */
+export const FORECAST_DETAIL_FIELDS = ['caseFile'];
+
+export function compactForecastDashboardPayload(payload) {
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.predictions)) return payload;
+
+  let stripped = 0;
+  const predictions = payload.predictions.map((prediction) => {
+    if (!prediction || typeof prediction !== 'object') return prediction;
+    let touched = false;
+    const next = { ...prediction };
+    for (const field of FORECAST_DETAIL_FIELDS) {
+      if (next[field] !== undefined) {
+        delete next[field];
+        touched = true;
+      }
+    }
+    if (touched) stripped += 1;
+    // Tell the client the dossier exists but is not here, so it can lazily fetch
+    // one instead of rendering an empty Analysis pane.
+    return touched ? { ...next, hasCaseFile: true } : next;
+  });
+
+  return { ...payload, predictions, detailStripped: stripped };
+}

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -5,6 +5,7 @@
 import crypto from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { loadEnvFile, runSeed, CHROME_UA, withRetry, parseRetryAfterMs, getResponseHeader, isRetryableHttpStatus } from './_seed-utils.mjs';
+import { compactForecastDashboardPayload } from './_forecast-dashboard.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { tagRegions } from './_prediction-scoring.mjs';
 import { attachResolutionSpecs } from './_forecast-resolution.mjs';
@@ -47,6 +48,11 @@ const _isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1]
 if (_isDirectRun) loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'forecast:predictions:v2';
+// Dashboard list: the same predictions with the caseFile dossiers stripped (78% of
+// the payload). The bootstrap fast tier hydrates from THIS key so every visitor
+// stops downloading ~19,000 words of analysis prose they never open (#5300). The
+// canonical key above keeps the dossiers for the RPC, MCP and chat-analyst.
+const DASHBOARD_KEY = 'forecast:predictions-bootstrap:v1';
 const PRIOR_KEY = 'forecast:predictions:prior:v2';
 // Iran-events domain sunset (war ended 2026-07). Default OFF: the strike feed
 // no longer seeds forecast inputs or critical signals (even while the canonical
@@ -17312,6 +17318,21 @@ export function declareRecords(data) {
 
 export const FORECAST_EXTRA_KEYS = [
   {
+    key: DASHBOARD_KEY,
+    transform: compactForecastDashboardPayload,
+    // TTL_SECONDS (6h), NOT the 2h the other extra keys use. This key is the
+    // panel's PRIMARY source now, so it needs the canonical key's durability:
+    // at 2h, two missed hourly crons expire it and the panel goes blank, while
+    // the canonical it used to read would have survived (see TTL_SECONDS above —
+    // 1.75x cron was already enough to open a panel gap). 6h also outlives the
+    // 90min seed-meta staleness gate, so a stopped writer surfaces as STALE_SEED
+    // rather than the key vanishing into EMPTY.
+    ttl: TTL_SECONDS,
+    declareRecords,
+    metaKey: 'seed-meta:forecast:predictions-bootstrap',
+    skipWhenEmpty: true,
+  },
+  {
     key: PRIOR_KEY,
     transform: (data) => ({
       predictions: data.predictions.map(buildPriorForecastSnapshot),
@@ -18188,17 +18209,28 @@ async function redisAtomicPatchSimDecorations(url, token, canonicalKey, byForeca
 }
 
 /**
- * Patch forecast:predictions:v2 in-place with simulation decoration fields.
- * Called immediately after writeSimulationDecorations to update the canonical key
- * for same-run consumers — without this, ForecastPanel only sees the prior run's
- * simulation data until the next fast-path seed re-applies decorations.
+ * Patch the published prediction keys in-place with simulation decoration fields.
+ * Called immediately after writeSimulationDecorations to update them for same-run
+ * consumers — without this, ForecastPanel only sees the prior run's simulation data
+ * until the next fast-path seed re-applies decorations.
+ *
+ * BOTH keys are patched, not just the canonical one. runSeed writes extraKeys during
+ * publish and calls afterPublish (where this runs) afterwards, so DASHBOARD_KEY is
+ * written BEFORE the decorations exist. It is the key the fast tier hydrates
+ * ForecastPanel from, and the panel's list rows render all three fields (the sim bar,
+ * the sim chip, and the demoted row-dimming) — so skipping it here would reintroduce
+ * exactly the stale-decoration bug this function was written to prevent, just one key
+ * over (#5300).
+ *
+ * Each key gets its own atomic EVAL. They don't need to be atomic *together*: readers
+ * fetch them independently, and each script re-applies the same generatedAt guard
+ * against whatever is actually published under that key. The compacted dashboard
+ * payload preserves `generatedAt` and `predictions`, so the guard and the field
+ * mutations behave identically on both.
  *
  * Forecasts present in byForecastId get updated sim fields.
  * Forecasts NOT in byForecastId have their sim fields reset to 0 / false, so that
  * any stale values from a prior run are cleared at the same time.
- *
- * The patch is atomic via Lua EVAL: the read, generatedAt guard, mutations, and write
- * happen in a single Redis operation so a concurrent fast-path seed cannot be overwritten.
  *
  * Non-fatal: any failure is logged as a warning and the function returns.
  *
@@ -18208,17 +18240,19 @@ async function redisAtomicPatchSimDecorations(url, token, canonicalKey, byForeca
 async function patchPublishedForecastsWithSimDecorations(byForecastId, runGeneratedAt) {
   try {
     const { url, token } = getRedisCredentials();
-    const status = await redisAtomicPatchSimDecorations(url, token, CANONICAL_KEY, byForecastId, runGeneratedAt, TTL_SECONDS);
-    if (status.startsWith('PATCHED:')) {
-      console.log(`  [SimulationDecorations] Patched ${status.slice(8)} forecasts in ${CANONICAL_KEY} (atomic)`);
-    } else if (isRedisWriteSkippedStatus(status)) {
-      console.log(`  [SimulationDecorations] Skipping patch — canonical key is from a newer run (published=${redisWriteSkippedGeneratedAt(status)}, sim_run=${runGeneratedAt})`);
-    } else if (status === 'MISSING') {
-      console.warn('  [SimulationDecorations] Cannot patch canonical key — predictions missing or not an array');
+    for (const key of [CANONICAL_KEY, DASHBOARD_KEY]) {
+      const status = await redisAtomicPatchSimDecorations(url, token, key, byForecastId, runGeneratedAt, TTL_SECONDS);
+      if (status.startsWith('PATCHED:')) {
+        console.log(`  [SimulationDecorations] Patched ${status.slice(8)} forecasts in ${key} (atomic)`);
+      } else if (isRedisWriteSkippedStatus(status)) {
+        console.log(`  [SimulationDecorations] Skipping patch of ${key} — key is from a newer run (published=${redisWriteSkippedGeneratedAt(status)}, sim_run=${runGeneratedAt})`);
+      } else if (status === 'MISSING') {
+        console.warn(`  [SimulationDecorations] Cannot patch ${key} — predictions missing or not an array`);
+      }
+      // UNCHANGED: no-op, no log needed
     }
-    // UNCHANGED: no-op, no log needed
   } catch (err) {
-    console.warn(`  [SimulationDecorations] Canonical key patch failed (non-fatal): ${err.message}`);
+    console.warn(`  [SimulationDecorations] Published key patch failed (non-fatal): ${err.message}`);
   }
 }
 
@@ -18822,6 +18856,7 @@ async function runSimulationWorker({ once = false, runId = '' } = {}) {
 
 export {
   CANONICAL_KEY,
+  DASHBOARD_KEY,
   PRIOR_KEY,
   HISTORY_KEY,
   HISTORY_MAX_RUNS,

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -819,7 +819,11 @@ async function redisCommand(url, token, command) {
 
 /** In-memory Redis store injected by tests. When set, redisGet/redisSet skip network calls. */
 let _testRedisStore = null;
-function __setRedisStoreForTests(store) { _testRedisStore = store; }
+let _testRedisPatchFailures = new Set();
+function __setRedisStoreForTests(store, { failPatchKeys = [] } = {}) {
+  _testRedisStore = store;
+  _testRedisPatchFailures = new Set(failPatchKeys);
+}
 
 async function redisGet(url, token, key) {
   if (_testRedisStore) return _testRedisStore[key] ?? null;
@@ -18163,6 +18167,9 @@ async function redisAtomicPatchSimDecorations(url, token, canonicalKey, byForeca
   // Mirror the production Lua's envelope-aware unwrap/rewrap so test fixtures
   // can exercise both legacy bare and PR-#3097 enveloped canonical shapes.
   if (_testRedisStore) {
+    if (_testRedisPatchFailures.has(canonicalKey)) {
+      throw new Error(`Injected Redis patch failure for ${canonicalKey}`);
+    }
     const published = _testRedisStore[canonicalKey] ?? null;
     if (!published || typeof published !== 'object') return 'MISSING';
     // Match Lua's strict `type(payload._seed) == 'table'` / `type(payload.data)
@@ -18238,9 +18245,17 @@ async function redisAtomicPatchSimDecorations(url, token, canonicalKey, byForeca
  * @param {number} [runGeneratedAt] — generatedAt from the snapshot that produced byForecastId
  */
 async function patchPublishedForecastsWithSimDecorations(byForecastId, runGeneratedAt) {
+  let credentials;
   try {
-    const { url, token } = getRedisCredentials();
-    for (const key of [CANONICAL_KEY, DASHBOARD_KEY]) {
+    credentials = getRedisCredentials();
+  } catch (err) {
+    console.warn(`  [SimulationDecorations] Published key patch failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  for (const key of [CANONICAL_KEY, DASHBOARD_KEY]) {
+    try {
+      const { url, token } = credentials;
       const status = await redisAtomicPatchSimDecorations(url, token, key, byForecastId, runGeneratedAt, TTL_SECONDS);
       if (status.startsWith('PATCHED:')) {
         console.log(`  [SimulationDecorations] Patched ${status.slice(8)} forecasts in ${key} (atomic)`);
@@ -18250,9 +18265,9 @@ async function patchPublishedForecastsWithSimDecorations(byForecastId, runGenera
         console.warn(`  [SimulationDecorations] Cannot patch ${key} — predictions missing or not an array`);
       }
       // UNCHANGED: no-op, no log needed
+    } catch (err) {
+      console.warn(`  [SimulationDecorations] Cannot patch ${key} (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
     }
-  } catch (err) {
-    console.warn(`  [SimulationDecorations] Published key patch failed (non-fatal): ${err.message}`);
   }
 }
 

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -216,7 +216,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   gdeltIntel:       'intelligence:gdelt-intel:v1',
   correlationCards: 'correlation:cards-bootstrap:v1',
   securityAdvisories: 'intelligence:advisories-bootstrap:v1',
-  forecasts:          'forecast:predictions:v2',
+  forecasts:          'forecast:predictions-bootstrap:v1',
   customsRevenue:     'trade:customs-revenue:v1',
   sanctionsPressure: 'sanctions:pressure:v1',
   groceryBasket:     'economic:grocery-basket:v1',

--- a/src/components/ForecastPanel.ts
+++ b/src/components/ForecastPanel.ts
@@ -5,7 +5,7 @@ import { t } from '@/services/i18n';
 import { getForecastMacroRegion } from '../../shared/forecast-macro-regions.js';
 import { unsafeRawHtml } from '@/utils/sanitize';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
-import { mergeCachedCaseFiles, needsCaseFileRefetch } from './forecast-case-files';
+import { mergeCachedCaseFiles, needsCaseFileRefetch, shouldFetchCaseFile } from './forecast-case-files';
 
 const DOMAINS = ['all', 'conflict', 'market', 'supply_chain', 'political', 'military', 'cyber', 'infrastructure'] as const;
 const PANEL_MIN_PROBABILITY = 0.1;
@@ -327,7 +327,9 @@ export class ForecastPanel extends Panel {
         // The bootstrap payload carries the LIST, not the dossiers — 78% of the old
         // key was caseFile prose nobody expands (#5300). Fetch them the first time
         // someone actually opens one; the feed is CDN-shielded, so this is cheap.
-        if (detail && panelId?.startsWith('detail-') && !detail.classList.contains('fc-hidden') && !detail.innerHTML.trim()) {
+        const forecastId = panelId?.startsWith('detail-') ? panelId.slice('detail-'.length) : '';
+        const forecast = forecastId ? this.forecasts.find((f) => f.id === forecastId) : undefined;
+        if (detail && shouldFetchCaseFile(forecast, !detail.classList.contains('fc-hidden'), !detail.innerHTML.trim())) {
           void this.loadCaseFiles();
         }
         return;

--- a/src/components/ForecastPanel.ts
+++ b/src/components/ForecastPanel.ts
@@ -4,6 +4,8 @@ import type { Forecast } from '@/services/forecast';
 import { t } from '@/services/i18n';
 import { getForecastMacroRegion } from '../../shared/forecast-macro-regions.js';
 import { unsafeRawHtml } from '@/utils/sanitize';
+import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { mergeCachedCaseFiles, needsCaseFileRefetch } from './forecast-case-files';
 
 const DOMAINS = ['all', 'conflict', 'market', 'supply_chain', 'political', 'military', 'cyber', 'infrastructure'] as const;
 const PANEL_MIN_PROBABILITY = 0.1;
@@ -259,6 +261,23 @@ export class ForecastPanel extends Panel {
   // applied on every render() — never mutate this by filtering, or refresh
   // updates from data-loader will wipe the filter state.
   private forecasts: Forecast[] = [];
+  /** De-dupe guard for the dossier fetch. Cleared when a refresh brings a forecast we've never fetched. */
+  private caseFilesPromise: Promise<void> | null = null;
+  /**
+   * Dossiers already fetched, by forecast id. Survives refresh ticks: the bootstrap
+   * feed carries the LIST only, so without this cache a refresh would drop the dossier
+   * the user just opened and re-render the pane empty (#5300).
+   */
+  private caseFilesById = new Map<string, NonNullable<Forecast['caseFile']>>();
+  /**
+   * Every forecast id a completed fetch covered — including those that legitimately have
+   * no dossier. Tracked separately from `caseFilesById` so a dossier-less forecast counts
+   * as resolved: keying the refetch decision off a missing `caseFile` alone would refetch
+   * the whole feed on every click of such a pane.
+   */
+  private caseFilesFetchedIds = new Set<string>();
+  /** True once a fetch has completed successfully — so a refresh never cancels an in-flight one. */
+  private caseFilesSettled = false;
   private sourceState: ForecastSourceState = { generatedAt: 0, degraded: false, stale: false, error: '' };
   private activeDomain: string = 'all';
   private selectedRegion: string = '';
@@ -305,6 +324,12 @@ export class ForecastPanel extends Panel {
         const panelId = toggle.dataset.fcToggle;
         const detail = panelId ? item?.querySelector(`[data-fc-panel="${panelId}"]`) as HTMLElement | null : null;
         if (detail) detail.classList.toggle('fc-hidden');
+        // The bootstrap payload carries the LIST, not the dossiers — 78% of the old
+        // key was caseFile prose nobody expands (#5300). Fetch them the first time
+        // someone actually opens one; the feed is CDN-shielded, so this is cheap.
+        if (detail && panelId?.startsWith('detail-') && !detail.classList.contains('fc-hidden') && !detail.innerHTML.trim()) {
+          void this.loadCaseFiles();
+        }
         return;
       }
 
@@ -319,8 +344,69 @@ export class ForecastPanel extends Panel {
     });
   }
 
+  /**
+   * Fetch the evidence dossiers on first expand (#5300).
+   *
+   * The bootstrap payload is the dashboard LIST: `caseFile` was 78% of the old key —
+   * ~19,000 words of prose that were shipped to every visitor, downloaded on every
+   * page load, and parsed into hidden DOM during the LCP window, for content almost
+   * nobody opens. The full feed still carries them, and it is now CDN-shielded, so
+   * pulling it once when a user actually clicks "Analysis" is cheap.
+   *
+   * Failure is non-fatal: the detail pane just stays empty, exactly as it would if
+   * the seeder had produced no case file.
+   */
+  private async loadCaseFiles(): Promise<void> {
+    if (this.caseFilesPromise) return this.caseFilesPromise;
+
+    this.caseFilesPromise = (async () => {
+      try {
+        const { fetchForecastFeed } = await import('@/services/forecast');
+        const feed = await fetchForecastFeed();
+        for (const f of feed.forecasts) {
+          this.caseFilesFetchedIds.add(f.id);
+          if (f.caseFile) this.caseFilesById.set(f.id, f.caseFile);
+        }
+        this.caseFilesSettled = true;
+        this.forecasts = this.forecasts.map((f) => {
+          const caseFile = this.caseFilesById.get(f.id);
+          return !f.caseFile && caseFile ? { ...f, caseFile } : f;
+        });
+
+        // Patch the panes in place rather than calling render(). A full re-render
+        // rebuilds every detail div with its default `fc-hidden` class and would
+        // slam shut the pane the user just opened.
+        for (const f of this.forecasts) {
+          if (!f.caseFile) continue;
+          const pane = this.element.querySelector(
+            `[data-fc-panel="detail-${CSS.escape(f.id)}"]`,
+          ) as HTMLElement | null;
+          if (pane && !pane.innerHTML.trim()) {
+            // renderDetailBody() escapes every interpolated value (escapeHtml/renderList),
+            // exactly as it does on the eager path this replaces.
+            setTrustedHtml(pane, trustedHtml(this.renderDetailBody(f), 'ForecastPanel case-file detail; same escaped markup as the eager render path (#5300)'));
+          }
+        }
+      } catch {
+        // Leave the pane empty and allow a later retry.
+        this.caseFilesPromise = null;
+      }
+    })();
+
+    return this.caseFilesPromise;
+  }
+
   updateForecasts(forecasts: Forecast[], sourceState?: Partial<ForecastSourceState>): void {
-    this.forecasts = forecasts;
+    // Refresh ticks re-hydrate from the bootstrap feed, which carries the LIST without
+    // the dossiers (#5300). Re-merge anything already fetched, or the dossier the user
+    // has open would vanish on the next tick and re-render as an empty pane.
+    this.forecasts = mergeCachedCaseFiles(forecasts, this.caseFilesById);
+    // A refreshed list can introduce a forecast no completed fetch covered — drop the
+    // de-dupe latch so the next expand re-fetches it.
+    if (needsCaseFileRefetch(this.forecasts, this.caseFilesFetchedIds, this.caseFilesSettled)) {
+      this.caseFilesPromise = null;
+      this.caseFilesSettled = false;
+    }
     this.sourceState = {
       generatedAt: sourceState?.generatedAt ?? this.sourceState.generatedAt,
       degraded: sourceState?.degraded === true,
@@ -600,7 +686,7 @@ export class ForecastPanel extends Panel {
           <span class="fc-toggle" data-fc-toggle="detail-${escapeHtml(f.id)}">Analysis</span>
           ${sigs.length > 0 ? `<span class="fc-toggle" data-fc-toggle="signals-${escapeHtml(f.id)}">Signals (${sigs.length})</span>` : ''}
         </div>
-        <div class="fc-detail fc-hidden" data-fc-panel="detail-${escapeHtml(f.id)}">${this.renderDetailBody(f)}</div>
+        <div class="fc-detail fc-hidden" data-fc-panel="detail-${escapeHtml(f.id)}">${f.caseFile ? this.renderDetailBody(f) : ''}</div>
         ${signalsHtml ? `<div class="fc-signals fc-hidden" data-fc-panel="signals-${escapeHtml(f.id)}">${signalsHtml}</div>` : ''}
       </div>
     `;

--- a/src/components/forecast-case-files.ts
+++ b/src/components/forecast-case-files.ts
@@ -23,6 +23,7 @@
 interface HasCaseFile<C> {
   id: string;
   caseFile?: C;
+  hasCaseFile?: boolean;
 }
 
 /**
@@ -53,4 +54,16 @@ export function needsCaseFileRefetch<C>(
 ): boolean {
   if (!settled) return false;
   return forecasts.some((f) => !fetchedIds.has(f.id));
+}
+
+/**
+ * A stripped dashboard row carries this marker only when the canonical feed has
+ * a dossier for it. Do not download the full feed for an intentionally empty pane.
+ */
+export function shouldFetchCaseFile<C>(
+  forecast: HasCaseFile<C> | undefined,
+  detailIsOpen: boolean,
+  detailIsEmpty: boolean,
+): boolean {
+  return detailIsOpen && detailIsEmpty && forecast?.hasCaseFile === true;
 }

--- a/src/components/forecast-case-files.ts
+++ b/src/components/forecast-case-files.ts
@@ -1,0 +1,56 @@
+/**
+ * Case-file (dossier) cache logic for ForecastPanel (#5300).
+ *
+ * The bootstrap feed carries the forecast LIST without `caseFile` — the dossiers were
+ * 78% of the old payload. The panel fetches them lazily on first expand, which makes
+ * its state genuinely stateful across refresh ticks, and that state is where the bugs
+ * live:
+ *
+ *   - A refresh tick re-hydrates from the bootstrap feed, so any dossier already fetched
+ *     must be re-merged or the pane the user has open re-renders EMPTY.
+ *   - The fetch is de-duped by a latched promise. If a refresh introduces a forecast the
+ *     completed fetch never covered, that latch must drop or the new pane resolves
+ *     instantly against the old promise and stays empty forever.
+ *   - But a forecast that legitimately has NO dossier is still "covered". Keying the
+ *     refetch decision off a missing `caseFile` alone would refetch the whole feed on
+ *     every click of such a pane.
+ *
+ * These are pure state transitions, extracted here so they are unit-testable: this repo
+ * has no jsdom, so ForecastPanel itself can only be source-scanned. Leaf module — it must
+ * stay import-free so `tsx --test` can load it without Vite's `import.meta.env`.
+ */
+
+interface HasCaseFile<C> {
+  id: string;
+  caseFile?: C;
+}
+
+/**
+ * Re-merge already-fetched dossiers into a freshly-hydrated list. Returns `forecasts`
+ * untouched when nothing is cached, so the common (pre-fetch) path allocates nothing.
+ */
+export function mergeCachedCaseFiles<C, T extends HasCaseFile<C>>(
+  forecasts: T[],
+  cached: ReadonlyMap<string, C>,
+): T[] {
+  if (cached.size === 0) return forecasts;
+  return forecasts.map((f) => {
+    const caseFile = cached.get(f.id);
+    return !f.caseFile && caseFile ? { ...f, caseFile } : f;
+  });
+}
+
+/**
+ * Should the next expand re-fetch the dossier feed?
+ *
+ * Only once the previous fetch has SETTLED (nulling an in-flight promise would merely
+ * duplicate it), and only when the list holds a forecast that fetch never covered.
+ */
+export function needsCaseFileRefetch<C>(
+  forecasts: readonly HasCaseFile<C>[],
+  fetchedIds: ReadonlySet<string>,
+  settled: boolean,
+): boolean {
+  if (!settled) return false;
+  return forecasts.some((f) => !fetchedIds.has(f.id));
+}

--- a/src/services/forecast.ts
+++ b/src/services/forecast.ts
@@ -1,6 +1,7 @@
 
 import type { Forecast, GetForecastsResponse } from '@/generated/client/worldmonitor/forecast/v1/service_client';
 import { getRpcBaseUrl } from '@/services/rpc-client';
+import { publicRpcFetch } from '@/services/public-rpc-fetch';
 import { ForecastServiceClient } from '@/services/generated-rpc-clients';
 
 export type { Forecast };
@@ -26,8 +27,24 @@ function getClient(): InstanceType<typeof ForecastServiceClient> {
   return _client;
 }
 
+// The unfiltered feed is the shared production payload — identical for every caller —
+// so it goes through its CDN-shielded public URL (#5300). This matters because
+// getHydratedData() is one-shot: every 30-minute dashboard refresh fell through to
+// this call, and with no CDN in front of it that was ~17.5k uncached origin reads/day
+// of a 188 KB payload. A FILTERED feed (domain/region) is caller-varying, so it keeps
+// the credentialed client.
+let _publicClient: InstanceType<typeof ForecastServiceClient> | null = null;
+function getPublicClient(): InstanceType<typeof ForecastServiceClient> {
+  if (!_publicClient) {
+    _publicClient = new ForecastServiceClient(getRpcBaseUrl(), { fetch: publicRpcFetch });
+  }
+  return _publicClient;
+}
+
 export async function fetchForecastFeed(domain?: string, region?: string): Promise<ForecastFeed> {
-  const resp = await getClient().getForecasts({ domain: domain || '', region: region || '' });
+  const filtered = Boolean(domain || region);
+  const client = filtered ? getClient() : getPublicClient();
+  const resp = await client.getForecasts({ domain: domain || '', region: region || '' });
   return normalizeForecastFeed(resp);
 }
 

--- a/src/shared/public-rpc-cache.ts
+++ b/src/shared/public-rpc-cache.ts
@@ -1,6 +1,7 @@
 const PUBLIC_SHARED_RPC_PATHS = new Set([
   '/api/news/v1/list-feed-digest',
   '/api/displacement/v1/get-displacement-summary',
+  '/api/forecast/v1/get-forecasts',
 ]);
 
 const NEWS_VARIANTS = new Set(['full', 'tech', 'finance', 'happy', 'commodity', 'energy']);
@@ -13,6 +14,17 @@ const NEWS_QUERY_KEYS = new Set(['variant', 'lang', 'public']);
 // so the CDN key space stays at one entry. Compared against the raw search string —
 // order- and encoding-sensitive by design (see stripRouterInjectedRpcEcho).
 const DISPLACEMENT_PUBLIC_SEARCH = 'flow_limit=50&public=1';
+
+// The forecast feed the dashboard refreshes every 30 minutes. The client sends no
+// filters (domain/region are empty and the generated client omits zero values), so
+// the ONE public shape is the bare marker. A caller that filters by domain/region
+// gets a per-caller response and must use the credentialed URL — keeping the CDN key
+// space at a single entry.
+//
+// This refresh is why the key is expensive: getHydratedData() is one-shot, so every
+// 30-minute tick fell through to this RPC, which had no CDN shield — ~17.5k uncached
+// origin reads/day of a 188 KB payload (#5300).
+const FORECASTS_PUBLIC_SEARCH = 'public=1';
 
 function hasSingleValue(params: URLSearchParams, key: string): boolean {
   return params.getAll(key).length === 1;
@@ -83,6 +95,7 @@ export function isPublicSharedRpcRequest(urlLike: string | URL, method = 'GET'):
   if (!hasSingleValue(params, 'public') || params.get('public') !== '1') return false;
 
   if (pathname === '/api/news/v1/list-feed-digest') return isNewsDigestShape(params);
+  if (pathname === '/api/forecast/v1/get-forecasts') return search === FORECASTS_PUBLIC_SEARCH;
   return search === DISPLACEMENT_PUBLIC_SEARCH;
 }
 

--- a/tests/forecast-dashboard-projection.test.mjs
+++ b/tests/forecast-dashboard-projection.test.mjs
@@ -1,0 +1,257 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  FORECAST_DETAIL_FIELDS,
+  compactForecastDashboardPayload,
+} from '../scripts/_forecast-dashboard.mjs';
+import {
+  CANONICAL_KEY,
+  DASHBOARD_KEY,
+  patchPublishedForecastsWithSimDecorations,
+  __setRedisStoreForTests,
+} from '../scripts/seed-forecasts.mjs';
+import { __testing__ as healthTesting } from '../api/health.js';
+import { isPublicSharedRpcRequest } from '../src/shared/public-rpc-cache.ts';
+import { mergeCachedCaseFiles, needsCaseFileRefetch } from '../src/components/forecast-case-files.ts';
+
+const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+function feed(n = 15) {
+  return {
+    generatedAt: 1_700_000_000_000,
+    predictions: Array.from({ length: n }, (_, i) => ({
+      id: `f${i}`,
+      title: `Forecast ${i}`,
+      probability: 0.4,
+      signals: [{ kind: 'x' }],
+      caseFile: {
+        // The dossier: ~78% of the real payload.
+        branches: Array.from({ length: 20 }, (_, b) => ({ label: `branch ${b}`, prose: 'x'.repeat(200) })),
+        actors: Array.from({ length: 15 }, (_, a) => ({ name: `actor ${a}`, prose: 'y'.repeat(200) })),
+        baseCase: 'z'.repeat(500),
+      },
+    })),
+  };
+}
+
+test('strips the dossier from the dashboard list', () => {
+  const full = feed();
+  const compact = compactForecastDashboardPayload(full);
+
+  for (const p of compact.predictions) {
+    for (const field of FORECAST_DETAIL_FIELDS) {
+      assert.equal(p[field], undefined, `${field} must not ride in the dashboard list`);
+    }
+  }
+  assert.equal(compact.detailStripped, full.predictions.length);
+});
+
+// The whole point. caseFile is 78% of the real 188 KB key: ~19,000 words of prose
+// shipped to every visitor, downloaded on every page load, and parsed into hidden
+// DOM inside the LCP window — for content almost nobody expands (#5300).
+test('the dashboard list is a fraction of the full feed', () => {
+  const full = feed();
+  const fullBytes = JSON.stringify(full).length;
+  const compactBytes = JSON.stringify(compactForecastDashboardPayload(full)).length;
+
+  assert.ok(
+    compactBytes < fullBytes / 3,
+    `dashboard list should be well under a third of the feed (full ${fullBytes} B, list ${compactBytes} B)`,
+  );
+});
+
+test('everything the list view renders survives', () => {
+  const full = feed();
+  const compact = compactForecastDashboardPayload(full);
+
+  assert.equal(compact.generatedAt, full.generatedAt);
+  assert.equal(compact.predictions.length, full.predictions.length);
+  for (const [i, p] of compact.predictions.entries()) {
+    assert.equal(p.id, full.predictions[i].id);
+    assert.equal(p.title, full.predictions[i].title);
+    assert.equal(p.probability, full.predictions[i].probability);
+    assert.deepEqual(p.signals, full.predictions[i].signals);
+  }
+});
+
+test('flags that a dossier exists so the panel can lazily fetch it', () => {
+  const compact = compactForecastDashboardPayload(feed(2));
+  assert.ok(compact.predictions.every((p) => p.hasCaseFile === true));
+
+  // A prediction that genuinely has no dossier is untouched and unflagged.
+  const none = compactForecastDashboardPayload({ predictions: [{ id: 'a', title: 't' }] });
+  assert.equal(none.predictions[0].hasCaseFile, undefined);
+  assert.equal(none.detailStripped, 0);
+});
+
+test('tolerates malformed payloads rather than publishing garbage', () => {
+  for (const bad of [null, undefined, 'nope', 42, {}, { predictions: 'not-an-array' }]) {
+    assert.equal(compactForecastDashboardPayload(bad), bad);
+  }
+});
+
+// The refresh is the expensive half. getHydratedData() is one-shot, so every 30-minute
+// tick fell through to this RPC — and it had no CDN shield: ~17.5k uncached origin reads
+// per day of a 188 KB payload. Shield the ONE unfiltered shape the dashboard sends.
+test('the unfiltered forecast feed has a CDN-shielded public shape', () => {
+  const base = 'https://api.worldmonitor.app/api/forecast/v1/get-forecasts';
+
+  assert.equal(isPublicSharedRpcRequest(`${base}?public=1`, 'GET'), true);
+  // Vercel's [rpc].ts router echoes the matched segment into the query (#5285) — the
+  // classifier must see through it, or this 401s in production exactly as #5263 did.
+  assert.equal(isPublicSharedRpcRequest(`${base}?public=1&rpc=get-forecasts`, 'GET'), true);
+
+  // Not a bypass vector, and not widened:
+  assert.equal(isPublicSharedRpcRequest(`${base}?public=1&rpc=bogus`, 'GET'), false);
+  assert.equal(isPublicSharedRpcRequest(`${base}?domain=energy&public=1`, 'GET'), false, 'a filtered feed is caller-varying — it must stay credentialed');
+  assert.equal(isPublicSharedRpcRequest(`${base}?region=eu&public=1`, 'GET'), false);
+  assert.equal(isPublicSharedRpcRequest(base, 'GET'), false, 'no marker, no public path');
+  assert.equal(isPublicSharedRpcRequest(`${base}?public=1`, 'POST'), false);
+});
+
+test('health monitors the dashboard list the fast tier actually serves', () => {
+  const { BOOTSTRAP_KEYS, SEED_META } = healthTesting;
+
+  assert.equal(BOOTSTRAP_KEYS.forecastsBootstrap, 'forecast:predictions-bootstrap:v1');
+  assert.equal(SEED_META.forecastsBootstrap.key, 'seed-meta:forecast:predictions-bootstrap');
+  // The canonical key stays monitored: it still feeds the RPC, MCP and chat-analyst.
+  assert.equal(BOOTSTRAP_KEYS.forecasts, 'forecast:predictions:v2');
+});
+
+test('a not-yet-published dashboard list warns, it does not CRIT', () => {
+  // Absent for one cron interval after deploy. EMPTY scores as crit and would flip
+  // /api/health to DEGRADED on a false alarm — the trap #5263 hit on round two.
+  const { classifyKey, BOOTSTRAP_KEYS } = healthTesting;
+  const NOW = 1_700_000_000_000;
+  const verdict = classifyKey(
+    'forecastsBootstrap',
+    BOOTSTRAP_KEYS.forecastsBootstrap,
+    { allowOnDemand: false },
+    {
+      keyStrens: new Map([[BOOTSTRAP_KEYS.forecastsBootstrap, 0]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map(),
+      keyMetaErrors: new Map(),
+      now: NOW,
+    },
+  );
+  assert.equal(verdict.status, 'STALE_SEED');
+});
+
+test('the fast tier hydrates from the dashboard list', () => {
+  const src = readFileSync(join(root, 'api', 'bootstrap.js'), 'utf-8');
+  assert.match(src, /forecasts:\s*'forecast:predictions-bootstrap:v1'/);
+  const cacheKeys = readFileSync(join(root, 'server', '_shared', 'cache-keys.ts'), 'utf-8');
+  assert.match(cacheKeys, /forecasts:\s*'forecast:predictions-bootstrap:v1'/);
+});
+
+// Regression guard. runSeed writes extraKeys during publish and calls afterPublish
+// (where the sim patch runs) afterwards, so the dashboard list is written BEFORE the
+// decorations exist. The panel's LIST ROWS render all three sim fields — the sim bar,
+// the sim chip, and the demoted row-dimming — so patching only the canonical key left
+// the panel showing pre-patch simulation state: exactly the bug the patch was written
+// to prevent, one key over.
+test('simulation decorations reach BOTH published keys, not just the canonical one', async () => {
+  const GENERATED_AT = 1_700_000_000_000;
+  const prediction = () => ({
+    id: 'f1',
+    title: 'Forecast 1',
+    simulationAdjustment: 0,
+    simPathConfidence: 0,
+    demotedBySimulation: false,
+  });
+  const store = {
+    [CANONICAL_KEY]: { generatedAt: GENERATED_AT, predictions: [{ ...prediction(), caseFile: { baseCase: 'prose' } }] },
+    [DASHBOARD_KEY]: { generatedAt: GENERATED_AT, predictions: [prediction()] },
+  };
+  const decorations = {
+    f1: { simulationAdjustment: -0.12, simPathConfidence: 0.8, demotedBySimulation: true },
+  };
+
+  __setRedisStoreForTests(store);
+  try {
+    await patchPublishedForecastsWithSimDecorations(decorations, GENERATED_AT);
+  } finally {
+    __setRedisStoreForTests(null);
+  }
+
+  for (const key of [CANONICAL_KEY, DASHBOARD_KEY]) {
+    const patched = store[key].predictions[0];
+    assert.equal(patched.simulationAdjustment, -0.12, `${key}: sim bar reads this`);
+    assert.equal(patched.simPathConfidence, 0.8, `${key}: sim chip reads this`);
+    assert.equal(patched.demotedBySimulation, true, `${key}: row-dimming reads this`);
+  }
+  // The projection stays a projection: patching must not smuggle the dossier back in.
+  assert.equal(store[DASHBOARD_KEY].predictions[0].caseFile, undefined);
+});
+
+// ─── Panel lifecycle across refresh ticks ──────────────────────────────────────
+// Lazy-loading the dossiers makes the panel stateful, and the state only misbehaves
+// ~30 minutes in — when a refresh tick re-hydrates from the bootstrap feed. These
+// guard the three ways that goes wrong.
+
+test('a refresh tick does not wipe the dossier the user has open', () => {
+  // The tick re-hydrates from the bootstrap feed, which carries NO caseFile. Without
+  // the merge, this.forecasts loses the dossier, the pane re-renders empty, and the
+  // fetch latch is already spent — so it never comes back.
+  const cached = new Map([['f1', { baseCase: 'prose' }]]);
+  const refreshed = [{ id: 'f1', title: 'Forecast 1' }, { id: 'f2', title: 'Forecast 2' }];
+
+  const merged = mergeCachedCaseFiles(refreshed, cached);
+  assert.deepEqual(merged[0].caseFile, { baseCase: 'prose' }, 'the open dossier survives the tick');
+  assert.equal(merged[1].caseFile, undefined, 'a forecast we never fetched stays bare');
+});
+
+test('a server-sent dossier always wins over the cached one', () => {
+  const cached = new Map([['f1', { baseCase: 'stale' }]]);
+  const merged = mergeCachedCaseFiles([{ id: 'f1', caseFile: { baseCase: 'fresh' } }], cached);
+  assert.deepEqual(merged[0].caseFile, { baseCase: 'fresh' });
+});
+
+test('nothing cached means nothing to merge', () => {
+  const forecasts = [{ id: 'f1' }];
+  assert.equal(mergeCachedCaseFiles(forecasts, new Map()), forecasts, 'pre-fetch path allocates nothing');
+});
+
+test('a forecast that no completed fetch covered re-arms the fetch', () => {
+  // Otherwise its expand resolves instantly against the spent promise → pane empty forever.
+  const fetched = new Set(['f1']);
+  assert.equal(needsCaseFileRefetch([{ id: 'f1' }, { id: 'f2' }], fetched, true), true);
+});
+
+test('a forecast with genuinely no dossier does NOT re-arm the fetch', () => {
+  // It has no caseFile and never will — but the fetch DID cover it. Keying off the
+  // missing caseFile instead of the covered-id set would refetch the entire 188 KB
+  // feed on every single click of that pane.
+  const fetched = new Set(['f1', 'f2']);
+  assert.equal(needsCaseFileRefetch([{ id: 'f1' }, { id: 'f2' }], fetched, true), false);
+});
+
+test('a refresh mid-fetch never cancels the in-flight one', () => {
+  // settled=false: the fetch is still running and has not populated the covered-id set
+  // yet, so every id looks uncovered. Re-arming here would just duplicate the fetch.
+  assert.equal(needsCaseFileRefetch([{ id: 'f1' }], new Set(), false), false);
+});
+
+// The panel's primary source needs the canonical key's durability. The other extra
+// keys use 2h; at 2h, two missed hourly crons expire this one and the panel goes
+// blank — the canonical it used to read (6h) would have survived. 6h also outlives
+// the 90min seed-meta staleness gate, so a stopped writer surfaces as STALE_SEED
+// instead of the key vanishing into EMPTY (the #5309 class of bug).
+test('the dashboard list outlives a missed cron and its own staleness gate', () => {
+  const seeder = readFileSync(join(root, 'scripts', 'seed-forecasts.mjs'), 'utf-8');
+  const entry = seeder.slice(seeder.indexOf('export const FORECAST_EXTRA_KEYS'));
+  const dashboardEntry = entry.slice(entry.indexOf('key: DASHBOARD_KEY'), entry.indexOf('key: PRIOR_KEY'));
+  assert.match(dashboardEntry, /ttl:\s*TTL_SECONDS/, 'dashboard list must inherit the canonical 6h TTL');
+
+  const ttlSeconds = Number(seeder.match(/const TTL_SECONDS = (\d+)/)[1]);
+  const maxStaleMin = healthTesting.SEED_META.forecastsBootstrap.maxStaleMin;
+  assert.ok(
+    ttlSeconds > maxStaleMin * 60,
+    `TTL (${ttlSeconds}s) must outlive the staleness gate (${maxStaleMin}min) or health reports EMPTY instead of STALE_SEED`,
+  );
+});

--- a/tests/forecast-dashboard-projection.test.mjs
+++ b/tests/forecast-dashboard-projection.test.mjs
@@ -16,7 +16,7 @@ import {
 } from '../scripts/seed-forecasts.mjs';
 import { __testing__ as healthTesting } from '../api/health.js';
 import { isPublicSharedRpcRequest } from '../src/shared/public-rpc-cache.ts';
-import { mergeCachedCaseFiles, needsCaseFileRefetch } from '../src/components/forecast-case-files.ts';
+import { mergeCachedCaseFiles, needsCaseFileRefetch, shouldFetchCaseFile } from '../src/components/forecast-case-files.ts';
 
 const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 
@@ -189,6 +189,27 @@ test('simulation decorations reach BOTH published keys, not just the canonical o
   assert.equal(store[DASHBOARD_KEY].predictions[0].caseFile, undefined);
 });
 
+test('a failed canonical patch does not skip the dashboard projection patch', async () => {
+  const GENERATED_AT = 1_700_000_000_000;
+  const prediction = () => ({ id: 'f1', simulationAdjustment: 0, simPathConfidence: 0, demotedBySimulation: false });
+  const store = {
+    [CANONICAL_KEY]: { generatedAt: GENERATED_AT, predictions: [prediction()] },
+    [DASHBOARD_KEY]: { generatedAt: GENERATED_AT, predictions: [prediction()] },
+  };
+
+  __setRedisStoreForTests(store, { failPatchKeys: [CANONICAL_KEY] });
+  try {
+    await patchPublishedForecastsWithSimDecorations({
+      f1: { simulationAdjustment: -0.12, simPathConfidence: 0.8, demotedBySimulation: true },
+    }, GENERATED_AT);
+  } finally {
+    __setRedisStoreForTests(null);
+  }
+
+  assert.equal(store[CANONICAL_KEY].predictions[0].simulationAdjustment, 0, 'the injected canonical failure leaves its key untouched');
+  assert.equal(store[DASHBOARD_KEY].predictions[0].simulationAdjustment, -0.12, 'the dashboard key is patched independently');
+});
+
 // ─── Panel lifecycle across refresh ticks ──────────────────────────────────────
 // Lazy-loading the dossiers makes the panel stateful, and the state only misbehaves
 // ~30 minutes in — when a refresh tick re-hydrates from the bootstrap feed. These
@@ -229,6 +250,13 @@ test('a forecast with genuinely no dossier does NOT re-arm the fetch', () => {
   // feed on every single click of that pane.
   const fetched = new Set(['f1', 'f2']);
   assert.equal(needsCaseFileRefetch([{ id: 'f1' }, { id: 'f2' }], fetched, true), false);
+});
+
+test('only a stripped row marked with hasCaseFile triggers the dossier fetch', () => {
+  assert.equal(shouldFetchCaseFile({ id: 'f1', hasCaseFile: true }, true, true), true);
+  assert.equal(shouldFetchCaseFile({ id: 'f1' }, true, true), false, 'a forecast without a dossier must not load the full feed');
+  assert.equal(shouldFetchCaseFile({ id: 'f1', hasCaseFile: true }, false, true), false);
+  assert.equal(shouldFetchCaseFile({ id: 'f1', hasCaseFile: true }, true, false), false);
 });
 
 test('a refresh mid-fetch never cancels the in-flight one', () => {

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -104,6 +104,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'cascade-mirror: pre-compacted dashboard/RPC variant of wildfire:fires:v1 (covered by get_natural_events). It preserves the same top-500 response while avoiding canonical-payload Redis egress.'],
   ['thermal:escalation-bootstrap:v1',
     'cascade-mirror: pre-compacted dashboard view of thermal:escalation:v1 (the canonical key remains the tool/RPC source). Capped to the top-24 ranked clusters the dashboard renders — agents should read the canonical key, which carries the full cluster set (#5300).'],
+  ['forecast:predictions-bootstrap:v1',
+    'cascade-mirror: dashboard list projection of forecast:predictions:v2 (covered by get_forecast_predictions). It is the same predictions minus the caseFile dossiers — MCP callers want the dossiers, so the tool keeps reading the canonical key.'],
   ['aviation:delays:intl:v3',
     'cascade-mirror: international delays sibling of aviation:delays-bootstrap:v2 (covered by get_aviation_status) — deferred to a future expanded aviation tool that exposes the intl variant directly.'],
   ['aviation:notam:closures:v2',


### PR DESCRIPTION
Part of #5300.

## The problem

`forecast:predictions:v2` is **188 KB** for 15 predictions, and **78% of it is `caseFile`** — the per-forecast evidence dossier (~19,000 words of prose across branches, actors, worldState, supporting/counter evidence, escalatory and contrarian cases, triggers).

That dossier is read in exactly **one** place: `ForecastPanel.renderDetailBody()`, behind a hover-only "Analysis" toggle. So today every visitor:

- pulls 146 KB of dossiers out of Redis on every bootstrap origin miss,
- downloads them on every page load, and
- has ~19,000 words serialised to HTML and parsed into hidden DOM at panel render — on a priority-1 panel, i.e. **inside the LCP window** —

for content the overwhelming majority never expand.

## Revalidating the size first

I had this scoped as a 1.3 GB/day problem. It is **4x that**. Traffic-normalized against `EVALSHA`/s, `forecast:predictions:v2` is read **~26,200x/day = ~4.9 GB/day**, and bootstrap is only a third of it.

The bigger half is the **client's 30-minute refresh**. `getHydratedData()` is one-shot (it deletes on read), so every refresh tick falls straight through to the `get-forecasts` RPC — which had **no CDN shield**. That is ~17.5k uncached origin reads/day of a 188 KB payload.

I also verified the assumption that could have killed the whole approach: the RPC is **not** premium-gated. An anonymous probe returns all 15 forecasts with `caseFile` intact, so the panel can lazily fetch a dossier without an entitlement.

## The fix — both halves

**1. The bootstrap key becomes a VIEW of what the panel renders.** `seed-forecasts` publishes `forecast:predictions-bootstrap:v1`: the same predictions, dossiers stripped (**188 KB → 41 KB**). The fast tier hydrates from it. The canonical key keeps the dossiers and still serves the RPC, the MCP tool and chat-analyst-context.

**2. The refresh gets a CDN shield.** The *unfiltered* feed now goes through the public RPC URL. The filtered (`domain`/`region`) feed is caller-varying and stays credentialed, keeping the CDN key space at a single entry. The shape check strips Vercel's `?rpc=` echo — the bug that silently 401'd every public RPC in #5285.

**3. The panel loads a dossier when someone actually wants one.** The detail pane renders lazily and fetches on first expand, patching the open pane **in place** (a full `render()` would slam shut the pane the user just clicked).

## Impact

| | before | after |
|---|---|---|
| Redis egress | ~4.9 GB/day | ~0.4 GB/day |
| bootstrap payload | 188 KB | 41 KB |
| refresh tick | uncached origin read | CDN hit |

**~4.5 GB/day** of Redis egress, **147 KB** less page weight per boot, and **~19,000 words** out of the LCP-window DOM.

## Two traps this had to clear

Both were found while revalidating, and both have regression tests that fail against the pre-fix code:

- **Simulation decorations must reach both keys.** `runSeed` writes `extraKeys` during publish and calls `afterPublish` — where the sim-decoration Lua patch runs — *afterwards*. The panel's **list rows** render all three sim fields (the sim bar, the sim chip, and the demoted row-dimming), so patching only the canonical key would have left the panel showing pre-patch simulation state: precisely the stale-decoration bug that patch was written to prevent, one key over. It now patches both. Each key gets its own atomic EVAL with its own `generatedAt` guard; they don't need to be atomic together, since readers fetch them independently.

- **The dashboard key inherits the canonical 6h TTL**, not the 2h the other extra keys use. It is the panel's *primary* source now: at 2h, two missed hourly crons expire it and the panel goes blank, where the canonical it used to read would have survived (the `TTL_SECONDS` comment records that even 1.75x cron was enough to open a panel gap). 6h also outlives the 90min seed-meta staleness gate, so a stopped writer surfaces as `STALE_SEED` rather than the key vanishing into `EMPTY` — the same class of bug as #5309.

Lazy-loading also makes the panel stateful across refresh ticks, which is its own bug surface — a tick re-hydrates from the bootstrap feed and would otherwise wipe the dossier the user has open, then never restore it because the fetch latch was already spent. That logic is extracted into an import-free leaf (`src/components/forecast-case-files.ts`) so it is unit-testable; this repo has no jsdom, so `ForecastPanel` itself can only be source-scanned.

## Verification

- `tests/forecast-dashboard-projection.test.mjs` — new, 17 tests: payload shrink, list-view fields preserved, `hasCaseFile` marker, malformed-input tolerance, the public-RPC shape (including the `?rpc=` echo and that a filtered feed stays credentialed), health registration, cold-start `STALE_SEED`-not-`EMPTY`, sim decorations reaching both keys, the TTL-vs-staleness-gate invariant, and the refresh-tick lifecycle.
- Full sweep green, 701 tests: `forecast-trace-export` (333), `edge-functions` (228), `bootstrap` (39), `bootstrap-auth` (32), `gateway-cdn-origin-policy` (19), `mcp-bootstrap-parity` (11), `health-verdict-snapshot` (10), `seed-bundle-resilience-validation` (6), `forecast-integrity-provenance` (6).
- `npm run typecheck:all`, safe-HTML guard, and Biome clean.
- Health-registered (`SEED_META`, 90min gate) and excluded from the MCP U7 parity guard as a `cascade-mirror` of the canonical key.

https://claude.ai/code/session_01NTYAunDvEaTSD9oWUG3tC9