### PR TITLE
feat(mcp): add procurement opportunities tool

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -146,10 +146,10 @@ function procurementPageSize(value: unknown): number {
 }
 
 /**
- * MCP's input schema advertises the same relevance-filter semantics as the
- * canonical route: malformed/non-positive values disable the filter; values
- * above 100 are deliberately passed through so the route remains the sole
- * authority that clamps its documented upper bound.
+ * The MCP tool preserves the canonical relevance-filter semantics:
+ * malformed/non-positive values disable the filter; values above 100 are
+ * deliberately passed through so the route remains the sole authority that
+ * clamps its documented upper bound.
  */
 function procurementAutomationThreshold(value: unknown): number | null {
   return Number.isInteger(value) && (value as number) > 0 ? value as number : null;
@@ -199,7 +199,7 @@ export const RPC_TOOLS: ToolDef[] = [
         deadline_from: { type: 'string', description: 'Include deadlines on or after this ISO-8601 timestamp.' },
         deadline_to: { type: 'string', description: 'Include deadlines on or before this ISO-8601 timestamp.' },
         sort: { type: 'string', enum: ['newest', 'closing_soon', 'estimated_value', 'relevance'], description: 'Result ordering. Defaults to newest.' },
-        min_automation_score: { type: 'integer', minimum: 1, maximum: 100, description: 'Optional 1-100 keyword-relevance threshold. Non-integer or non-positive values are ignored; values above 100 keep the canonical route clamp. This is not bidding-eligibility evidence.' },
+        min_automation_score: { type: 'integer', minimum: 1, description: 'Optional positive keyword-relevance threshold. Non-integer or non-positive values are ignored; the canonical route clamps values above 100. This is not bidding-eligibility evidence.' },
         page_size: { type: 'integer', minimum: 1, maximum: PROCUREMENT_TOOL_MAX_PAGE_SIZE, description: 'Records per call. Defaults to 10; capped at 25 to protect agent context.' },
         cursor: { type: 'string', description: 'Opaque nextCursor from the prior result; keep the same filters and sort when continuing.' },
       },
@@ -216,7 +216,7 @@ export const RPC_TOOLS: ToolDef[] = [
           categoryCodes: { type: 'array', items: { type: 'string' } }, sectors: { type: 'array', items: { type: 'string' } }, participationMode: { type: 'string' },
           automationFit: { type: 'object', properties: { score: { type: 'number' }, level: { type: 'string' }, classificationVersion: { type: 'string' }, matchReasons: { type: 'array', items: { type: 'string' } } } },
         } } },
-        nextCursor: { type: 'string' }, fetchedAt: { type: 'string' }, dataAvailable: { type: 'boolean' }, availability: { type: 'string' },
+        nextCursor: { type: 'string', description: 'Opaque pagination cursor. An empty string means no further pages are available.' }, fetchedAt: { type: 'string' }, dataAvailable: { type: 'boolean' }, availability: { type: 'string' },
         sourceStatuses: { type: 'array', items: { type: 'object' } }, total: { type: 'number' }, appliedFilters: { type: 'array', items: { type: 'string' } },
         countryCoverage: { type: 'string', description: 'unknown means the requested country has not been observed in this snapshot, not that there are confirmed zero results.' },
       },

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -101,7 +101,172 @@ function countryBriefSearchTerms(countryCode: string): string[] {
   return [...new Set(terms.filter(Boolean))];
 }
 
+const PROCUREMENT_TOOL_DEFAULT_PAGE_SIZE = 10;
+const PROCUREMENT_TOOL_MAX_PAGE_SIZE = 25;
+
+type ProcurementRouteTender = {
+  id: string;
+  source: string;
+  officialUrl: string;
+  countryCode?: string;
+  region?: string;
+  title: string;
+  buyer?: string;
+  publishedAt?: string;
+  deadline?: string;
+  status: string;
+  noticeType?: string;
+  money?: { amount?: number; currency?: string };
+  categoryCodes: string[];
+  sectors: string[];
+  participationMode: string;
+  automationFit?: { level: string; score: number; classificationVersion: string; matchReasons: string[] };
+};
+
+type ProcurementRouteResponse = {
+  tenders?: ProcurementRouteTender[];
+  nextCursor?: string;
+  fetchedAt?: string;
+  dataAvailable?: boolean;
+  availability?: string;
+  sourceStatuses?: unknown[];
+  total?: number;
+  appliedFilters?: string[];
+  countryCoverage?: string;
+};
+
+function addProcurementStringParam(query: URLSearchParams, name: string, value: unknown): void {
+  if (typeof value === 'string' && value.trim()) query.set(name, value.trim());
+}
+
+function procurementPageSize(value: unknown): number {
+  return Number.isInteger(value) && (value as number) > 0
+    ? Math.min(PROCUREMENT_TOOL_MAX_PAGE_SIZE, value as number)
+    : PROCUREMENT_TOOL_DEFAULT_PAGE_SIZE;
+}
+
+/**
+ * MCP's input schema advertises the same relevance-filter semantics as the
+ * canonical route: malformed/non-positive values disable the filter; values
+ * above 100 are deliberately passed through so the route remains the sole
+ * authority that clamps its documented upper bound.
+ */
+function procurementAutomationThreshold(value: unknown): number | null {
+  return Number.isInteger(value) && (value as number) > 0 ? value as number : null;
+}
+
+function compactProcurementOpportunity(tender: ProcurementRouteTender) {
+  return {
+    id: tender.id,
+    source: tender.source,
+    officialUrl: tender.officialUrl,
+    countryCode: tender.countryCode,
+    region: tender.region,
+    title: tender.title,
+    buyer: tender.buyer,
+    publishedAt: tender.publishedAt,
+    deadline: tender.deadline,
+    status: tender.status,
+    noticeType: tender.noticeType,
+    money: tender.money,
+    categoryCodes: tender.categoryCodes,
+    sectors: tender.sectors,
+    // This remains upstream evidence, not a claim about a caller's legal
+    // ability to participate in a procurement process.
+    participationMode: tender.participationMode,
+    automationFit: tender.automationFit && {
+      score: tender.automationFit.score,
+      level: tender.automationFit.level,
+      classificationVersion: tender.automationFit.classificationVersion,
+      matchReasons: tender.automationFit.matchReasons,
+    },
+  };
+}
+
 export const RPC_TOOLS: ToolDef[] = [
+  {
+    name: 'get_procurement_opportunities',
+    _outputBudgetBytes: 65536,
+    description: 'Search open global public-procurement opportunities through the canonical Pro route. Default output is 10 compact records (maximum 25), without descriptions or submission/eligibility payloads. automationFit is keyword relevance evidence only, never bidding eligibility; participationMode "unknown" remains unknown.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        country: { type: 'string', description: 'One ISO 3166-1 alpha-2 country code.' },
+        countries: { type: 'array', items: { type: 'string' }, description: 'Additional ISO 3166-1 alpha-2 country codes. Combined with country.' },
+        source: { type: 'string', description: 'Official source adapter, such as sam, ted, contracts-finder, canada-buys, gets, or world-bank.' },
+        query: { type: 'string', description: 'Case-insensitive text search across procurement titles and descriptions.' },
+        buyer: { type: 'string', description: 'Case-insensitive buyer or contracting-authority text.' },
+        deadline_from: { type: 'string', description: 'Include deadlines on or after this ISO-8601 timestamp.' },
+        deadline_to: { type: 'string', description: 'Include deadlines on or before this ISO-8601 timestamp.' },
+        sort: { type: 'string', enum: ['newest', 'closing_soon', 'estimated_value', 'relevance'], description: 'Result ordering. Defaults to newest.' },
+        min_automation_score: { type: 'integer', minimum: 1, maximum: 100, description: 'Optional 1-100 keyword-relevance threshold. Non-integer or non-positive values are ignored; values above 100 keep the canonical route clamp. This is not bidding-eligibility evidence.' },
+        page_size: { type: 'integer', minimum: 1, maximum: PROCUREMENT_TOOL_MAX_PAGE_SIZE, description: 'Records per call. Defaults to 10; capped at 25 to protect agent context.' },
+        cursor: { type: 'string', description: 'Opaque nextCursor from the prior result; keep the same filters and sort when continuing.' },
+      },
+      required: [],
+    },
+    outputSchema: {
+      type: 'object',
+      required: ['opportunities', 'nextCursor', 'fetchedAt', 'dataAvailable', 'availability', 'sourceStatuses', 'total', 'appliedFilters', 'countryCoverage'],
+      properties: {
+        opportunities: { type: 'array', items: { type: 'object', properties: {
+          id: { type: 'string' }, source: { type: 'string' }, officialUrl: { type: 'string' }, countryCode: { type: 'string' }, region: { type: 'string' },
+          title: { type: 'string' }, buyer: { type: 'string' }, publishedAt: { type: 'string' }, deadline: { type: 'string' }, status: { type: 'string' }, noticeType: { type: 'string' },
+          money: { type: 'object', properties: { amount: { type: 'number' }, currency: { type: 'string' } } },
+          categoryCodes: { type: 'array', items: { type: 'string' } }, sectors: { type: 'array', items: { type: 'string' } }, participationMode: { type: 'string' },
+          automationFit: { type: 'object', properties: { score: { type: 'number' }, level: { type: 'string' }, classificationVersion: { type: 'string' }, matchReasons: { type: 'array', items: { type: 'string' } } } },
+        } } },
+        nextCursor: { type: 'string' }, fetchedAt: { type: 'string' }, dataAvailable: { type: 'boolean' }, availability: { type: 'string' },
+        sourceStatuses: { type: 'array', items: { type: 'object' } }, total: { type: 'number' }, appliedFilters: { type: 'array', items: { type: 'string' } },
+        countryCoverage: { type: 'string', description: 'unknown means the requested country has not been observed in this snapshot, not that there are confirmed zero results.' },
+      },
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    _execute: async (params, base, context) => {
+      const query = new URLSearchParams();
+      addProcurementStringParam(query, 'country', params.country);
+      if (Array.isArray(params.countries)) {
+        for (const country of params.countries) {
+          if (typeof country === 'string' && country.trim()) query.append('countries', country.trim());
+        }
+      }
+      for (const [name, value] of Object.entries({
+        source: params.source,
+        query: params.query,
+        buyer: params.buyer,
+        deadline_from: params.deadline_from,
+        deadline_to: params.deadline_to,
+        sort: params.sort,
+        cursor: params.cursor,
+      })) addProcurementStringParam(query, name, value);
+      query.set('page_size', String(procurementPageSize(params.page_size)));
+      const threshold = procurementAutomationThreshold(params.min_automation_score);
+      if (threshold !== null) query.set('min_automation_score', String(threshold));
+
+      const url = `${base}/api/economic/v1/list-global-tenders?${query}`;
+      const auth = await buildAuthHeaders(context, 'GET', url, null);
+      const response = await fetch(url, {
+        headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (!response.ok) throw new Error(`list-global-tenders HTTP ${response.status}`);
+      const result = await response.json() as ProcurementRouteResponse;
+      return {
+        opportunities: (result.tenders || []).map(compactProcurementOpportunity),
+        nextCursor: result.nextCursor || '',
+        fetchedAt: result.fetchedAt || '',
+        dataAvailable: result.dataAvailable === true,
+        availability: result.availability || 'unavailable',
+        sourceStatuses: result.sourceStatuses || [],
+        total: typeof result.total === 'number' ? result.total : 0,
+        appliedFilters: result.appliedFilters || [],
+        countryCoverage: result.countryCoverage || 'unknown',
+      };
+    },
+    _apiPaths: [
+      'GET /api/economic/v1/list-global-tenders',
+    ],
+  },
   {
     name: 'get_world_brief',
     _outputBudgetBytes: 65536,

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -86,7 +86,7 @@
   "leaderNames": 16,
   "populationPriorityCountries": 20,
   "sebufVersion": "v0.11.1",
-  "mcpToolCount": 40,
+  "mcpToolCount": 41,
   "mcpApps": {
     "specVersion": "2026-01-26",
     "mimeType": "text/html;profile=mcp-app",

--- a/docs/global-procurement-intelligence.mdx
+++ b/docs/global-procurement-intelligence.mdx
@@ -65,6 +65,14 @@ Supported sorts are `newest`, `closing_soon`, `estimated_value`, and `relevance`
 
 Every record contains a stable WorldMonitor ID (`source:sourceNoticeId`), its official notice URL, source notice ID, typed money fields when supplied, source timestamps, category data, and a provenance-preserving source name. Missing upstream fields remain absent rather than being inferred.
 
+## MCP tool
+
+`get_procurement_opportunities` exposes this same canonical route to authenticated MCP clients; it never reads `economic:global-tenders:v1` directly. Its intentional context budget is **10 compact opportunities by default, 25 maximum**. It exposes `country`, repeated `countries`, `source`, `query`, `buyer`, `deadline_from`, `deadline_to`, `sort`, `min_automation_score`, `page_size`, and `cursor`.
+
+The compact projection omits description text, eligibility requirements, and submission URLs while retaining each opportunity's official URL, source, title, buyer, dates, money, categories, sectors, `participationMode`, and compact `automationFit`. It also retains cursor pagination, `total`, `appliedFilters`, `countryCoverage`, availability, snapshot time, and source-health summaries. The 25-record MCP maximum is deliberately tighter than the REST route's 100-record maximum.
+
+The MCP tool is Pro-gated exactly like the HTTP route and is not part of bootstrap. An unfiltered tool call preserves all open opportunities; `min_automation_score` remains opt-in. See the [MCP tool reference](/mcp-tools-reference#get_procurement_opportunities) for the complete parameter contract.
+
 ## Technology relevance
 
 `automationFit` is a transparent keyword-based relevance signal for software, AI, data, cybersecurity, automation, cloud, and related terms. It contains a score, classification version, match reasons, and text evidence. It is **not** a legal or procurement-eligibility determination: `participationMode` remains `unknown` unless an upstream source explicitly supports it.

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -13,7 +13,7 @@ WorldMonitor exposes its intelligence stack as a [Model Context Protocol](https:
 **Pro and API tiers can both connect via OAuth — no API key required.** Pro subscribers click _"Sign in with WorldMonitor Pro"_ on the consent page; API Starter / Business / Enterprise users may sign in the same way OR paste a `wm_…` key. Free-tier users see a 401 at the OAuth step.
 </Info>
 
-All paid tiers share the same MCP server and the same 40 tools. The current hard MCP daily reservation is enforced only for OAuth contexts at the Pro counter: **50 quota-consuming `tools/call` / `resources/read` calls per UTC day**. API-key (`wm_…`) MCP clients are protected by the **60 requests/minute/key** limiter in this handler; broader API Starter / Business REST allowances are enforced outside the MCP daily reservation path. (`describe_tool`, the v1.5.0 metadata-lookup helper, is exempt from the Pro daily quota.)
+All paid tiers share the same MCP server and the same 41 tools. The current hard MCP daily reservation is enforced only for OAuth contexts at the Pro counter: **50 quota-consuming `tools/call` / `resources/read` calls per UTC day**. API-key (`wm_…`) MCP clients are protected by the **60 requests/minute/key** limiter in this handler; broader API Starter / Business REST allowances are enforced outside the MCP daily reservation path. (`describe_tool`, the v1.5.0 metadata-lookup helper, is exempt from the Pro daily quota.)
 
 Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pasting an API key — see [Pro sign-in flow](#pro-sign-in-flow) below. API Starter+ holders may continue to paste a `wm_…` key on the consent page (the original flow), or use the same OAuth path as Pro.
 
@@ -195,7 +195,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 
 ## Tool catalog
 
-The server exposes 40 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). The slower, non-cache paths are the six live LLM/external-API tools (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) plus the live geo RPC tools (`get_airspace`, `get_maritime_activity`), which proxy fresh aviation/maritime API calls with edge timeouts. One (`describe_tool`, added v1.5.0) returns the full uncompressed definition of any other tool — useful when the compressed `tools/list` description is ambiguous; exempt from the Pro daily quota.
+The server exposes 41 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). The slower, non-cache paths are the six live LLM/external-API tools (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) plus the live geo RPC tools (`get_airspace`, `get_maritime_activity`) and the bounded canonical procurement proxy (`get_procurement_opportunities`). One (`describe_tool`, added v1.5.0) returns the full uncompressed definition of any other tool — useful when the compressed `tools/list` description is ambiguous; exempt from the Pro daily quota.
 
 <Tip>
 For per-tool parameters, freshness budgets, timeouts, and concrete `curl` examples, see the [MCP Tools Reference](/mcp-tools-reference). For payload projection — every tool accepts an optional `jmespath` argument that typically cuts response size by 80-95% — see the [JMESPath guide](/mcp-jmespath).
@@ -216,6 +216,7 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 | `get_tariff_trends` | Global trade and pricing indicators: US tariff trends (HTS-coded), BigMac index, FAO Food Price Index, and per-country national debt levels. |
 | `get_chokepoint_status` | Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc. |
 | `get_consumer_prices` | Per-country consumer-prices intelligence: 30-day overview, category-level inflation, retailer spread (essentials basket), top movers, and source freshness. Requires `country_code` (currently only `ae` is seeded). |
+| `get_procurement_opportunities` | Pro-gated canonical global procurement search; compact output defaults to 10 records and caps at 25. Keyword relevance is never bidding eligibility. |
 | `get_commodity_geo` | 71 major mining sites worldwide (gold, silver, copper, lithium, uranium, coal). |
 
 ### Energy
@@ -355,11 +356,11 @@ Current follow-up trackers:
 - [#4525](https://github.com/koala73/worldmonitor/issues/4525) — pure-read deferred MCP coverage candidates.
 - [#4526](https://github.com/koala73/worldmonitor/issues/4526) — manual mapping and fetch-on-miss triage.
 
-See the [Tool catalog](#tool-catalog) above for the complete list of 40 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
+See the [Tool catalog](#tool-catalog) above for the complete list of 41 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
 
 ## Prompts and resources
 
-In addition to the 40 tools, WorldMonitor exposes MCP prompts and resources so clients can discover common workflows and address stable data slices without inventing tool plans from scratch.
+In addition to the 41 tools, WorldMonitor exposes MCP prompts and resources so clients can discover common workflows and address stable data slices without inventing tool plans from scratch.
 
 ### Prompts
 

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -3,7 +3,7 @@ title: "MCP Quickstart"
 description: "Connect Claude Desktop to World Monitor via MCP and make your first real intelligence call in five minutes — install, auth, and first query."
 ---
 
-WorldMonitor exposes 40 live tools — markets, conflict events, maritime chokepoints, aviation, climate, AI briefs — over the [Model Context Protocol](https://modelcontextprotocol.io). This page is the shortest path from zero to a useful response inside Claude. Everything else in the [MCP Server reference](/mcp-overview) is optional reading once this works.
+WorldMonitor exposes 41 live tools — markets, conflict events, maritime chokepoints, aviation, climate, AI briefs — over the [Model Context Protocol](https://modelcontextprotocol.io). This page is the shortest path from zero to a useful response inside Claude. Everything else in the [MCP Server reference](/mcp-overview) is optional reading once this works.
 
 ## 1. Pick a tier and grab credentials
 
@@ -137,7 +137,7 @@ To discover what MCP can call from your client:
 The MCP handshake is invisible from the chat side, but here's the sequence so you know where to look if something breaks:
 
 1. Claude Desktop reads `claude_desktop_config.json`, sees the WorldMonitor server, and on first use POSTs `initialize` to `https://worldmonitor.app/mcp`. The server responds with its capabilities, the negotiated protocol version (default `2025-06-18`, matching the static server card; clients pinned to `2025-03-26` still get `2025-03-26`), and a session-level `instructions` string that tells the model about the universal `jmespath` argument. Clients that advertise `text/event-stream` may receive this response as SSE with a resumable `Mcp-Session-Id` / `Last-Event-ID` cursor; clients that do not advertise SSE receive JSON. See [protocol negotiation](/mcp-overview#protocol-negotiation) and [Streamable HTTP responses](/mcp-overview#streamable-http-responses) for the rollout details.
-2. Claude Desktop calls `tools/list` and receives 40 compressed tool descriptions (`≤120` bytes per tool). The compressed form keeps `tools/list` cheap; `describe_tool` returns the full definition on demand.
+2. Claude Desktop calls `tools/list` and receives 41 compressed tool descriptions (`≤120` bytes per tool). The compressed form keeps `tools/list` cheap; `describe_tool` returns the full definition on demand.
 3. When you ask a question that needs live data, Claude picks a tool, calls `tools/call`, and inlines the response into its reply. Cache tools return in under a second; LLM-backed tools (`get_world_brief`, `analyze_situation`, etc.) take 1–4 s.
 
 ## Server-side curl

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -246,7 +246,7 @@ Search active global public-procurement opportunities through the canonical Pro-
 
 - **API endpoint:** `GET /api/economic/v1/list-global-tenders`
 - **Kind:** bounded canonical-route proxy — Pro entitlement remains enforced by the downstream route; no bootstrap or direct-cache exposure.
-- **Output budget:** 10 compact records by default, at most 25. The result retains `nextCursor`, `total`, `appliedFilters`, `countryCoverage`, `availability`, snapshot time, and per-source health summaries.
+- **Output budget:** 10 compact records by default, at most 25. The result retains `nextCursor`, `total`, `appliedFilters`, `countryCoverage`, `availability`, snapshot time, and per-source health summaries. An empty `nextCursor` means there are no further pages.
 
 Unfiltered calls preserve the standard all-open-opportunities behavior; `min_automation_score` is never implied. `automationFit` is keyword relevance evidence only, never a legal determination of whether an agent or vendor may bid. `participationMode: "unknown"` means exactly that — no participation mode was established upstream.
 

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -225,6 +225,46 @@ curl -s https://worldmonitor.app/mcp \
 
 </CodeGroup>
 
+### `get_procurement_opportunities`
+
+Search active global public-procurement opportunities through the canonical Pro-gated tender API. The tool never reads Upstash directly. It returns a compact projection of the canonical records: official notice URL, source, title, buyer, timing, money, categories, sectors, `participationMode`, and compact `automationFit`; it deliberately omits descriptions, eligibility requirements, and submission URLs.
+
+**Parameters (tool-specific):**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `country` | string | One ISO 3166-1 alpha-2 country code. |
+| `countries` | `array<string>` | Additional country codes; combines with `country`. |
+| `source` | string | Official source adapter, such as `sam`, `ted`, `contracts-finder`, `canada-buys`, `gets`, or `world-bank`. |
+| `query` | string | Case-insensitive text search across titles and descriptions. |
+| `buyer` | string | Case-insensitive buyer or contracting-authority text. |
+| `deadline_from` / `deadline_to` | string | ISO-8601 inclusive deadline range. |
+| `sort` | `string: newest / closing_soon / estimated_value / relevance` | Result ordering; defaults to `newest`. |
+| `min_automation_score` | integer | Optional keyword-relevance score threshold. Positive integers are passed to the canonical route (which clamps values above 100); non-integer and non-positive values are ignored. It is opt-in and is **not** bidding-eligibility evidence. |
+| `page_size` | integer | Default **10**, maximum **25** records. This is the MCP output budget; the REST route itself permits up to 100. |
+| `cursor` | string | Opaque `nextCursor` from the preceding result; keep the same filters and sort while paging. |
+
+- **API endpoint:** `GET /api/economic/v1/list-global-tenders`
+- **Kind:** bounded canonical-route proxy — Pro entitlement remains enforced by the downstream route; no bootstrap or direct-cache exposure.
+- **Output budget:** 10 compact records by default, at most 25. The result retains `nextCursor`, `total`, `appliedFilters`, `countryCoverage`, `availability`, snapshot time, and per-source health summaries.
+
+Unfiltered calls preserve the standard all-open-opportunities behavior; `min_automation_score` is never implied. `automationFit` is keyword relevance evidence only, never a legal determination of whether an agent or vendor may bid. `participationMode: "unknown"` means exactly that — no participation mode was established upstream.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_procurement_opportunities","arguments":{"country":"US","min_automation_score":70,"page_size":10,"sort":"relevance"}}
+  }'
+```
+
+</CodeGroup>
+
 ### `get_country_macro`
 
 Per-country macroeconomic indicators from IMF WEO (~210 countries, monthly cadence). Bundles fiscal/external balance (inflation, current account, gov revenue/expenditure/primary balance, CPI), growth & per-capita (real GDP growth, GDP/capita USD & PPP, savings & investment rates, savings-investment gap), labor & demographics (unemployment, population), and external trade (current account USD, import/export volume % changes). Latest available year per series. Use for country-level economic screening, peer benchmarking, and stagflation/imbalance flags. NOTE: export/import LEVELS in USD (exportsUsd, importsUsd, tradeBalanceUsd) are returned as null — WEO retracted broad coverage for BX/BM indicators in 2026-04; use currentAccountUsd or volume changes (import/exportVolumePctChg) instead.

--- a/docs/zh/global-procurement-intelligence.mdx
+++ b/docs/zh/global-procurement-intelligence.mdx
@@ -65,6 +65,14 @@ Railway 种子任务每小时运行一次，并把规范快照写入 `economic:g
 
 每条记录都含有稳定的 WorldMonitor ID（`source:sourceNoticeId`）、官方公告链接、来源公告 ID、上游提供时的金额字段、时间戳、分类数据和可追溯的来源名称。缺失的上游字段保持缺失，不会被推断填补。
 
+## MCP 工具
+
+`get_procurement_opportunities` 向已认证的 MCP 客户端暴露同一条规范路由；它绝不直接读取 `economic:global-tenders:v1`。其上下文预算有意设为**默认 10 条紧凑机会，最多 25 条**。它公开 `country`、重复的 `countries`、`source`、`query`、`buyer`、`deadline_from`、`deadline_to`、`sort`、`min_automation_score`、`page_size` 和 `cursor`。
+
+紧凑投影省略描述文本、资格要求和提交 URL，同时保留每条机会的官方 URL、来源、标题、买方、日期、金额、分类、领域、`participationMode` 和精简的 `automationFit`。它还保留游标分页、`total`、`appliedFilters`、`countryCoverage`、可用性、快照时间和来源健康摘要。25 条的 MCP 上限有意小于 REST 路由 100 条的上限。
+
+MCP 工具与 HTTP 路由一样仅限 Pro，且不属于 bootstrap。无筛选工具调用会保留所有开放机会；`min_automation_score` 始终是可选项。完整参数契约见 [MCP 工具参考](/zh/mcp-tools-reference#get_procurement_opportunities)。
+
 ## 技术相关性
 
 `automationFit` 是针对软件、AI、数据、网络安全、自动化、云服务及相关术语的透明关键词相关性信号。它包含评分、分类版本、匹配理由和文本证据，**不是**法律意见或采购资格判断；除非上游来源明确提供，`participationMode` 始终为 `unknown`。

--- a/docs/zh/mcp-overview.mdx
+++ b/docs/zh/mcp-overview.mdx
@@ -13,7 +13,7 @@ WorldMonitor 将其情报栈作为 [Model Context Protocol](https://modelcontext
 **Pro 和 API 套餐均可通过 OAuth 接入 —— 无需 API key。** Pro 订阅者只需在授权页点击 _"Sign in with WorldMonitor Pro"_；API Starter / Business / Enterprise 用户可以同样的方式登录，或者粘贴 `wm_…` key。Free 套餐用户在 OAuth 步骤会看到 401。
 </Info>
 
-所有付费套餐共享同一个 MCP 服务器和同样的 40 个工具。当前的硬性 MCP 每日预留仅针对 OAuth 上下文在 Pro 计数器上强制执行：**每个 UTC 日 50 次消耗配额的 `tools/call` / `resources/read` 调用**。使用 API key（`wm_…`）的 MCP 客户端受本 handler 中 **60 次请求/分钟/key** 限流器的保护；更宽松的 API Starter / Business REST 额度在 MCP 每日预留路径之外强制执行。（`describe_tool`，即 v1.5.0 的元数据查询辅助工具，不计入 Pro 每日配额。）
+所有付费套餐共享同一个 MCP 服务器和同样的 41 个工具。当前的硬性 MCP 每日预留仅针对 OAuth 上下文在 Pro 计数器上强制执行：**每个 UTC 日 50 次消耗配额的 `tools/call` / `resources/read` 调用**。使用 API key（`wm_…`）的 MCP 客户端受本 handler 中 **60 次请求/分钟/key** 限流器的保护；更宽松的 API Starter / Business REST 额度在 MCP 每日预留路径之外强制执行。（`describe_tool`，即 v1.5.0 的元数据查询辅助工具，不计入 Pro 每日配额。）
 
 Pro 订阅者无需粘贴任何 API key 即可接入 Claude Desktop / Cursor / claude.ai —— 参见下方的 [Pro 登录流程](#pro-sign-in-flow)。API Starter+ 用户可继续在授权页粘贴 `wm_…` key（原始流程），也可使用与 Pro 相同的 OAuth 路径。
 
@@ -195,7 +195,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 
 ## 工具目录
 
-服务器暴露 40 个工具。大多数是对预填充 Redis key 的缓存读取（亚秒级）。较慢的非缓存路径包括六个实时 LLM/外部 API 工具（`get_world_brief`、`get_country_brief`、`analyze_situation`、`generate_forecasts`、`search_flights`、`search_flight_prices_by_date`），以及实时地理 RPC 工具（`get_airspace`、`get_maritime_activity`），后者会带 edge 超时代理实时的航空/海事 API 调用。有一个工具（`describe_tool`，v1.5.0 新增）返回任何其他工具的完整未压缩定义 —— 在压缩后的 `tools/list` 描述含糊不清时很有用；不计入 Pro 每日配额。
+服务器暴露 41 个工具。大多数是对预填充 Redis key 的缓存读取（亚秒级）。较慢的非缓存路径包括六个实时 LLM/外部 API 工具（`get_world_brief`、`get_country_brief`、`analyze_situation`、`generate_forecasts`、`search_flights`、`search_flight_prices_by_date`）、实时地理 RPC 工具（`get_airspace`、`get_maritime_activity`）以及受预算约束的规范采购代理（`get_procurement_opportunities`）。有一个工具（`describe_tool`，v1.5.0 新增）返回任何其他工具的完整未压缩定义 —— 在压缩后的 `tools/list` 描述含糊不清时很有用；不计入 Pro 每日配额。
 
 <Tip>
 如需各工具的参数、新鲜度预算、超时以及具体的 `curl` 示例，请参阅 [MCP 工具参考](/zh/mcp-tools-reference)。关于 payload 投影 —— 每个工具都接受一个可选的 `jmespath` 参数，通常可将响应大小缩减 80-95% —— 请参阅 [JMESPath 指南](/zh/mcp-jmespath)。
@@ -216,6 +216,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 | `get_tariff_trends` | 全球贸易和定价指标：美国关税趋势（HTS 编码）、巨无霸指数、FAO 食品价格指数以及各国国债水平。 |
 | `get_chokepoint_status` | 实时海上咽喉要道状态：每个咽喉要道的船舶过境计数（10 分钟节奏）、滚动过境摘要、每个港口的活动，以及静态参考数据和流量汇总。覆盖苏伊士、霍尔木兹、马六甲、曼德海峡、巴拿马等。 |
 | `get_consumer_prices` | 各国消费者价格情报：30 天概览、品类级通胀、零售商价差（必需品篮子）、热门变动以及来源新鲜度。需要 `country_code`（目前仅填充了 `ae`）。 |
+| `get_procurement_opportunities` | 仅限 Pro 的规范全球采购搜索；紧凑输出默认 10 条、最多 25 条。关键词相关性绝不表示投标资格。 |
 | `get_commodity_geo` | 全球 71 个主要矿场（金、银、铜、锂、铀、煤）。 |
 
 ### 能源
@@ -355,11 +356,11 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 - [#4525](https://github.com/koala73/worldmonitor/issues/4525) —— 延后的纯读取 MCP 覆盖候选项。
 - [#4526](https://github.com/koala73/worldmonitor/issues/4526) —— 手动映射和 fetch-on-miss 分诊。
 
-有关完整的 40 个工具列表，请参见上方的[工具目录](#tool-catalog)；有关各工具详情，请参阅 [MCP 工具参考](/zh/mcp-tools-reference)。
+有关完整的 41 个工具列表，请参见上方的[工具目录](#tool-catalog)；有关各工具详情，请参阅 [MCP 工具参考](/zh/mcp-tools-reference)。
 
 ## Prompt 与资源
 
-除了 40 个工具之外，WorldMonitor 还暴露 MCP prompt 和资源，使客户端无需从零编排工具计划即可发现常见工作流并寻址稳定的数据切片。
+除了 41 个工具之外，WorldMonitor 还暴露 MCP prompt 和资源，使客户端无需从零编排工具计划即可发现常见工作流并寻址稳定的数据切片。
 
 ### Prompt
 

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -246,7 +246,7 @@ curl -s https://worldmonitor.app/mcp \
 
 - **API 端点：** `GET /api/economic/v1/list-global-tenders`
 - **类型：** 受预算约束的规范路由代理——Pro 权益仍由下游路由强制执行；不暴露 bootstrap 或直接缓存读取。
-- **输出预算：** 默认 10 条紧凑记录，最多 25 条。结果保留 `nextCursor`、`total`、`appliedFilters`、`countryCoverage`、`availability`、快照时间和各来源健康摘要。
+- **输出预算：** 默认 10 条紧凑记录，最多 25 条。结果保留 `nextCursor`、`total`、`appliedFilters`、`countryCoverage`、`availability`、快照时间和各来源健康摘要。空字符串 `nextCursor` 表示没有更多页面。
 
 无筛选调用保持标准的所有开放机会行为；绝不会隐式启用 `min_automation_score`。`automationFit` 仅是关键词相关性证据，绝不是代理或供应商可否投标的法律判断。`participationMode: "unknown"` 的含义不变——上游并未确定参与方式。
 

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -225,6 +225,46 @@ curl -s https://worldmonitor.app/mcp \
 
 </CodeGroup>
 
+### `get_procurement_opportunities`
+
+通过规范的、仅限 Pro 的招标 API 搜索活跃的全球公共采购机会。此工具绝不直接读取 Upstash。它返回规范记录的紧凑投影：官方公告 URL、来源、标题、买方、时间、金额、分类、领域、`participationMode` 与精简的 `automationFit`；有意省略描述、资格要求和提交 URL。
+
+**参数（工具特定）：**
+
+| 名称 | 类型 | 描述 |
+|------|------|-------------|
+| `country` | string | 一个 ISO 3166-1 alpha-2 国家代码。 |
+| `countries` | `array<string>` | 额外国家代码；与 `country` 合并。 |
+| `source` | string | 官方来源适配器，例如 `sam`、`ted`、`contracts-finder`、`canada-buys`、`gets` 或 `world-bank`。 |
+| `query` | string | 对标题和描述进行不区分大小写的文本搜索。 |
+| `buyer` | string | 不区分大小写的买方或采购机构文本。 |
+| `deadline_from` / `deadline_to` | string | ISO-8601 的包含式截止日期范围。 |
+| `sort` | `string: newest / closing_soon / estimated_value / relevance` | 排序方式；默认为 `newest`。 |
+| `min_automation_score` | integer | 可选关键词相关性评分阈值。正整数会传给规范路由（大于 100 时由其截断）；非整数和非正值会被忽略。该筛选为可选，**不是**投标资格证据。 |
+| `page_size` | integer | 默认 **10** 条，最多 **25** 条。这是 MCP 输出预算；REST 路由本身最多允许 100 条。 |
+| `cursor` | string | 上一页结果的非透明 `nextCursor`；翻页时保持相同筛选和排序。 |
+
+- **API 端点：** `GET /api/economic/v1/list-global-tenders`
+- **类型：** 受预算约束的规范路由代理——Pro 权益仍由下游路由强制执行；不暴露 bootstrap 或直接缓存读取。
+- **输出预算：** 默认 10 条紧凑记录，最多 25 条。结果保留 `nextCursor`、`total`、`appliedFilters`、`countryCoverage`、`availability`、快照时间和各来源健康摘要。
+
+无筛选调用保持标准的所有开放机会行为；绝不会隐式启用 `min_automation_score`。`automationFit` 仅是关键词相关性证据，绝不是代理或供应商可否投标的法律判断。`participationMode: "unknown"` 的含义不变——上游并未确定参与方式。
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_procurement_opportunities","arguments":{"country":"US","min_automation_score":70,"page_size":10,"sort":"relevance"}}
+  }'
+```
+
+</CodeGroup>
+
 ### `get_country_macro`
 
 来自 IMF WEO 的逐国宏观经济指标（约 210 个国家，月度节奏）。捆绑财政/外部平衡（通胀、经常账户、政府收入/支出/初级余额、CPI）、增长与人均（实际 GDP 增长、人均 GDP 美元和 PPP、储蓄和投资率、储蓄-投资缺口）、劳动力和人口统计（失业率、人口），以及对外贸易（经常账户美元、进口/出口量百分比变化）。每个序列取最新可用年份。用于国家级经济筛选、同侪基准对比和滞胀/失衡标志。注意：以美元计的出口/进口水平（exportsUsd、importsUsd、tradeBalanceUsd）返回 null — WEO 在 2026-04 收回了 BX/BM 指标的广泛覆盖；请改用 currentAccountUsd 或量变化（import/exportVolumePctChg）。

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -142,6 +142,10 @@
       "description": "Reddit geopolitical social velocity: top posts from worldnews, geopolitics, and related subreddits with engagement scores and trend signals."
     },
     {
+      "name": "get_procurement_opportunities",
+      "description": "Search open global public-procurement opportunities through the canonical Pro route. Default output is 10 compact records (maximum 25), without descriptions or submission/eligibility payloads. automationFit is keyword relevance evidence only, never bidding eligibility; participationMode \"unknown\" remains unknown."
+    },
+    {
       "name": "get_world_brief",
       "description": "AI-generated world intelligence brief. Fetches the latest geopolitical headlines along with their RSS article bodies and produces a grounded LLM-summarized brief. Supply an optional geo_context to focus on a region or topic."
     },

--- a/public/agent-view.json
+++ b/public/agent-view.json
@@ -3,13 +3,13 @@
   "kind": "agent-view",
   "product": "World Monitor",
   "url": "https://www.worldmonitor.app",
-  "description": "Live global-intelligence platform: real-time markets, conflict events, country risk and resilience, shipping chokepoints, aviation/maritime activity, energy, climate, health, cyber threats, forecasts and AI-generated briefs — machine-readable JSON, correlated across layers.",
+  "description": "Live global-intelligence platform: real-time markets, conflict events, country risk and resilience, global procurement opportunities, shipping chokepoints, aviation/maritime activity, energy, climate, health, cyber threats, forecasts and AI-generated briefs — machine-readable JSON, correlated across layers.",
   "endpoints": {
     "mcp": {
       "url": "https://worldmonitor.app/mcp",
       "transport": "streamable-http",
       "serverCard": "https://worldmonitor.app/.well-known/mcp/server-card.json",
-      "tools": 40,
+      "tools": 41,
       "note": "tools/list, prompts/list, resources/list and describe_tool are anonymous; data calls need auth."
     },
     "rest": {

--- a/public/mcp-server.md
+++ b/public/mcp-server.md
@@ -12,7 +12,7 @@ The World Monitor MCP Server exposes World Monitor's real-time global-intelligen
 
 ## Tools
 
-The server ships **40 tools** covering world and country briefs, country risk and resilience, conflict events, markets, commodities, energy, maritime and aviation activity, cyber threats, sanctions, natural disasters, health signals, prediction markets, and AI forecasts. Issue `tools/list` for the live inventory, `prompts/list` for pre-built workflow templates, and `resources/list` for read-only resources. `tools/list`, `prompts/list`, and `resources/list` are **public** — no key required. Every tool accepts an optional `jmespath` argument for [server-side projection](https://www.worldmonitor.app/docs/mcp-jmespath), typically an 80–95% response-size cut.
+The server ships **41 tools** covering world and country briefs, country risk and resilience, conflict events, markets, commodities, global procurement opportunities, energy, maritime and aviation activity, cyber threats, sanctions, natural disasters, health signals, prediction markets, and AI forecasts. Issue `tools/list` for the live inventory, `prompts/list` for pre-built workflow templates, and `resources/list` for read-only resources. `tools/list`, `prompts/list`, and `resources/list` are **public** — no key required. Every tool accepts an optional `jmespath` argument for [server-side projection](https://www.worldmonitor.app/docs/mcp-jmespath), typically an 80–95% response-size cut.
 
 ## MCP Apps
 

--- a/tests/mcp-api-parity.test.mjs
+++ b/tests/mcp-api-parity.test.mjs
@@ -199,8 +199,6 @@ const EXCLUDED_FROM_MCP_PARITY = new Map([
     "manual-mapping: parameterized cache key not statically resolvable — equivalent data covered by sibling cache tool at the prefix level"],
   ["GET /api/economic/v1/get-fred-series",
     "manual-mapping: parameterized cache key not statically resolvable — equivalent data covered by sibling cache tool at the prefix level"],
-  ["GET /api/economic/v1/list-global-tenders",
-    "manual-mapping: paginated, high-cardinality filter and cursor surface has no bounded cache-tool equivalent; expose through a dedicated procurement tool only after its query and output budget are designed"],
   ["GET /api/infrastructure/v1/get-bootstrap-data",
     "manual-mapping: parameterized cache key not statically resolvable — equivalent data covered by sibling cache tool at the prefix level"],
   ["GET /api/infrastructure/v1/get-ip-geo",

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -49,17 +49,17 @@ const EXCLUDED_FROM_MCP = new Map([
   ['health:china-coverage:v1',
     'operational: bounded China coverage verdict and reason codes consumed by api/health.js and the read-only operator audit; source content remains available through its domain tools, so this summary is not a queryable MCP slice (#5271).'],
   ['economic:global-tenders:v1:source:sam',
-    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the paginated economic RPC.'],
+    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
   ['economic:global-tenders:v1:source:ted',
-    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the paginated economic RPC.'],
+    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
   ['economic:global-tenders:v1:source:contracts-finder',
-    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the paginated economic RPC.'],
+    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
   ['economic:global-tenders:v1:source:canada-buys',
-    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the paginated economic RPC.'],
+    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
   ['economic:global-tenders:v1:source:gets',
-    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the paginated economic RPC.'],
+    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
   ['economic:global-tenders:v1:source:world-bank',
-    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the paginated economic RPC.'],
+    'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
 
   // ===========================================================================
   // Intermediate / pipeline keys (data surfaces through a sibling tool)

--- a/tests/mcp-output-budget.test.mjs
+++ b/tests/mcp-output-budget.test.mjs
@@ -19,7 +19,7 @@
 // or summary call shrinks the response further, so testing the unprojected
 // path is the bound the runtime gate cares about.
 //
-// Coverage caveat: only 3/40 tools have captured fixtures today
+// Coverage caveat: only 3/41 tools have captured fixtures today
 // (`tests/fixtures/jmespath-samples/`). Each new fixture added there will be
 // picked up by this test the next CI run. Mocked-response contract coverage
 // for the other tools is a separate follow-up.

--- a/tests/mcp-procurement-tool.test.mjs
+++ b/tests/mcp-procurement-tool.test.mjs
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HMAC_SECRET,
+  callBody,
+  makeProDeps,
+  proReq,
+} from './helpers/mcp-pro-deps.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+const canonicalResponse = {
+  tenders: [{
+    id: 'sam:abc-123', source: 'sam', sourceNoticeId: 'abc-123',
+    officialUrl: 'https://sam.gov/opp/abc-123', countryCode: 'US', region: 'North America',
+    title: 'Cloud security platform', description: 'A long procurement description that must not enter the default MCP result.',
+    buyer: 'Example agency', publishedAt: '2026-07-14T00:00:00.000Z', updatedAt: '', deadline: '2026-08-01T00:00:00.000Z',
+    status: 'open', noticeType: 'solicitation', money: { amount: 420000, currency: 'USD' },
+    categoryCodes: ['541512'], sectors: ['technology'], eligibilityRequirements: ['long upstream eligibility text'],
+    submissionUrls: ['https://sam.gov/submit/abc-123'], participationMode: 'unknown',
+    automationFit: { level: 'high', score: 91, classificationVersion: 'keyword-v1', matchReasons: ['cloud', 'cybersecurity'], evidence: ['cloud security platform'] },
+  }],
+  nextCursor: '10', fetchedAt: '2026-07-14T12:00:00.000Z', dataAvailable: true,
+  availability: 'partial', sourceStatuses: [{ source: 'sam', state: 'ok', recordCount: 1, fetchedAt: '2026-07-14T12:00:00.000Z', lastSuccessfulAt: '2026-07-14T12:00:00.000Z', stale: false }],
+  total: 22, appliedFilters: ['country', 'min_automation_score'], countryCoverage: 'unknown',
+};
+
+describe('get_procurement_opportunities MCP tool', () => {
+  let mcpHandler;
+  let requests;
+
+  beforeEach(async () => {
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+    requests = [];
+    globalThis.fetch = async (input, init = {}) => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify(canonicalResponse), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const mod = await import(`../api/mcp.ts?procurement=${Date.now()}-${Math.random()}`);
+    mcpHandler = mod.mcpHandler;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) delete process.env[key];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  async function callTool(args = {}, depsOverrides = {}) {
+    const { deps } = makeProDeps(depsOverrides);
+    const response = await mcpHandler(proReq('POST', callBody('get_procurement_opportunities', args)), deps);
+    return { response, body: await response.json() };
+  }
+
+  it('is listed and proxies the canonical route with the bounded query budget', async () => {
+    const listed = await mcpHandler(new Request('https://worldmonitor.app/mcp', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }));
+    const tool = (await listed.json()).result.tools.find((entry) => entry.name === 'get_procurement_opportunities');
+    assert.ok(tool, 'tool must be discoverable through tools/list');
+    assert.equal(tool.inputSchema.properties.page_size.maximum, 25);
+
+    const { response, body } = await callTool({
+      country: 'US', countries: ['CA', 'GB'], source: 'sam', query: 'cloud security', buyer: 'Example agency',
+      deadline_from: '2026-07-15', deadline_to: '2026-08-31', sort: 'relevance', min_automation_score: 101,
+      page_size: 100, cursor: '10',
+    });
+
+    assert.equal(response.status, 200);
+    const requestUrl = new URL(requests[0].url);
+    assert.equal(requestUrl.pathname, '/api/economic/v1/list-global-tenders');
+    assert.equal(requestUrl.searchParams.get('country'), 'US');
+    assert.deepEqual(requestUrl.searchParams.getAll('countries'), ['CA', 'GB']);
+    assert.equal(requestUrl.searchParams.get('source'), 'sam');
+    assert.equal(requestUrl.searchParams.get('query'), 'cloud security');
+    assert.equal(requestUrl.searchParams.get('buyer'), 'Example agency');
+    assert.equal(requestUrl.searchParams.get('deadline_from'), '2026-07-15');
+    assert.equal(requestUrl.searchParams.get('deadline_to'), '2026-08-31');
+    assert.equal(requestUrl.searchParams.get('sort'), 'relevance');
+    assert.equal(requestUrl.searchParams.get('min_automation_score'), '101');
+    assert.equal(requestUrl.searchParams.get('page_size'), '25');
+    assert.equal(requestUrl.searchParams.get('cursor'), '10');
+    assert.ok(requests[0].init.headers['X-WM-MCP-Internal'], 'Pro route call must retain internal entitlement identity');
+
+    const result = JSON.parse(body.result.content[0].text);
+    assert.equal(result.nextCursor, '10');
+    assert.deepEqual(result.appliedFilters, ['country', 'min_automation_score']);
+    assert.equal(result.countryCoverage, 'unknown', 'unknown coverage is never a confirmed zero-result');
+    assert.equal(result.availability, 'partial');
+    assert.deepEqual(result.sourceStatuses, canonicalResponse.sourceStatuses);
+    assert.deepEqual(result.opportunities[0], {
+      id: 'sam:abc-123', source: 'sam', officialUrl: 'https://sam.gov/opp/abc-123', countryCode: 'US', region: 'North America',
+      title: 'Cloud security platform', buyer: 'Example agency', publishedAt: '2026-07-14T00:00:00.000Z', deadline: '2026-08-01T00:00:00.000Z',
+      status: 'open', noticeType: 'solicitation', money: { amount: 420000, currency: 'USD' }, categoryCodes: ['541512'], sectors: ['technology'],
+      participationMode: 'unknown', automationFit: { score: 91, level: 'high', classificationVersion: 'keyword-v1', matchReasons: ['cloud', 'cybersecurity'] },
+    });
+    assert.equal('description' in result.opportunities[0], false);
+    assert.equal('eligibilityRequirements' in result.opportunities[0], false);
+    assert.equal('submissionUrls' in result.opportunities[0], false);
+  });
+
+  it('defaults to ten records, caps at 25, and ignores malformed relevance thresholds', async () => {
+    await callTool({ min_automation_score: 30.5, page_size: -1 });
+    let requestUrl = new URL(requests[0].url);
+    assert.equal(requestUrl.searchParams.get('page_size'), '10');
+    assert.equal(requestUrl.searchParams.has('min_automation_score'), false);
+
+    requests = [];
+    await callTool({ min_automation_score: 1, page_size: 25 });
+    requestUrl = new URL(requests[0].url);
+    assert.equal(requestUrl.searchParams.get('page_size'), '25');
+    assert.equal(requestUrl.searchParams.get('min_automation_score'), '1');
+  });
+
+  it('uses the same Pro entitlement gate as the canonical route before fetching data', async () => {
+    const { response, body } = await callTool({}, {
+      getEntitlements: async () => ({ planKey: 'free', features: { tier: 0, mcpAccess: false }, validUntil: Date.now() + 86_400_000 }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal(body.error.code, -32001);
+    assert.equal(requests.length, 0, 'failed entitlement must not reach the canonical route');
+  });
+});

--- a/tests/mcp-procurement-tool.test.mjs
+++ b/tests/mcp-procurement-tool.test.mjs
@@ -67,6 +67,8 @@ describe('get_procurement_opportunities MCP tool', () => {
     const tool = (await listed.json()).result.tools.find((entry) => entry.name === 'get_procurement_opportunities');
     assert.ok(tool, 'tool must be discoverable through tools/list');
     assert.equal(tool.inputSchema.properties.page_size.maximum, 25);
+    assert.equal(tool.inputSchema.properties.min_automation_score.maximum, undefined, 'the canonical route owns the score upper-bound clamp');
+    assert.match(tool.outputSchema.properties.nextCursor.description, /empty string means no further pages/i);
 
     const { response, body } = await callTool({
       country: 'US', countries: ['CA', 'GB'], source: 'sam', query: 'cloud security', buyer: 'Example agency',

--- a/tests/mcp-tool-output-contracts.test.mjs
+++ b/tests/mcp-tool-output-contracts.test.mjs
@@ -81,7 +81,7 @@ function minimalShape(schema) {
   return null;
 }
 
-describe('api/mcp.ts — per-tool output contract (envelope-shape, all 40 tools)', () => {
+describe('api/mcp.ts — per-tool output contract (envelope-shape, all 41 tools)', () => {
   let mod;
   let mcpHandler;
   let originalExecutes;
@@ -142,7 +142,7 @@ describe('api/mcp.ts — per-tool output contract (envelope-shape, all 40 tools)
     const matches = [...src.matchAll(/^\s{4}name:\s+'([a-z0-9_]+)'/gm)];
     return matches.map((m) => m[1]);
   })();
-  assert.ok(TOOL_NAMES.length >= 40, `expected >= 40 tools, got ${TOOL_NAMES.length}`);
+  assert.ok(TOOL_NAMES.length >= 41, `expected >= 41 tools, got ${TOOL_NAMES.length}`);
 
   for (const name of TOOL_NAMES) {
     it(`${name} — tools/call response validates against declared outputSchema`, async () => {

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -341,9 +341,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
       return JSON.parse(body.result.content[0].text);
     }
 
-    it('tools/list contains 40 tools (39 + describe_tool)', async () => {
+    it('tools/list contains 41 tools (40 + describe_tool)', async () => {
       const tools = await getToolsList();
-      assert.equal(tools.length, 40);
+      assert.equal(tools.length, 41);
     });
 
     it('describe_tool itself appears in tools/list', async () => {
@@ -390,7 +390,7 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
       assert.equal(env.error, 'unknown_tool');
       assert.equal(env.requested, 'nonexistent_tool');
       assert.ok(Array.isArray(env.available));
-      assert.equal(env.available.length, 40, 'available should list all 40 tools');
+      assert.equal(env.available.length, 41, 'available should list all 41 tools');
       // Sorted alphabetically
       const sorted = [...env.available].sort();
       assert.deepEqual(env.available, sorted);
@@ -429,14 +429,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.15.0) AND tools[] length matches (40)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.15.0) AND tools[] length matches (41)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
       assert.equal(card.serverInfo.version, '1.15.0');
       // orank (ora.ai) agent-readiness scanner reads the card's `tools` as an
       // ARRAY (tools[]) for pre-connection preview — not the old {count,categories}
       // object. Keep it an array; the count now derives from the length.
       assert.ok(Array.isArray(card.tools), 'server-card tools must be an array (tools[])');
-      assert.equal(card.tools.length, 40);
+      assert.equal(card.tools.length, 41);
       assert.equal(card.features?.toolDescriptionCompression, true);
       assert.equal(card.features?.responseProjection, 'jmespath',
         'v1.4.0 feature flag must still be present');

--- a/tests/mcp-tools-reference-docs.test.mjs
+++ b/tests/mcp-tools-reference-docs.test.mjs
@@ -86,7 +86,10 @@ function documentedCacheToolNames() {
     // tools do not. Ignore the documented RPC sections here rather than
     // making their presence look like a stale cache-tool entry.
     const tool = __testing__.TOOL_REGISTRY.find((entry) => entry.name === heading[1]);
-    return tool && tool._execute === undefined ? [heading[1]] : [];
+    // Preserve the bidirectional check: a stale heading must remain visible to
+    // the assertion below instead of being silently mistaken for an RPC tool.
+    if (!tool) return [heading[1]];
+    return tool._execute === undefined ? [heading[1]] : [];
   });
 }
 

--- a/tests/mcp-tools-reference-docs.test.mjs
+++ b/tests/mcp-tools-reference-docs.test.mjs
@@ -80,7 +80,13 @@ function documentedCacheToolNames() {
   return sections.flatMap((section) => {
     const heading = section.match(/^### `([^`]+)`/m);
     if (!heading || !section.includes('**Parameters (tool-specific):**')) return [];
-    return [heading[1]];
+    // The reference also documents selected RPC tools with dedicated query
+    // budgets. This parity suite intentionally owns cache-tool tables only,
+    // because cache tools gain the universal `summary` parameter while RPC
+    // tools do not. Ignore the documented RPC sections here rather than
+    // making their presence look like a stale cache-tool entry.
+    const tool = __testing__.TOOL_REGISTRY.find((entry) => entry.name === heading[1]);
+    return tool && tool._execute === undefined ? [heading[1]] : [];
   });
 }
 

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -432,12 +432,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 40 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 41 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 40, `Expected 40 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 41, `Expected 41 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -456,6 +456,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(toolNames.includes('get_consumer_prices'), 'get_consumer_prices must be registered (U4)');
     assert.ok(toolNames.includes('get_tariff_trends'), 'get_tariff_trends must be registered (U5)');
     assert.ok(toolNames.includes('get_chokepoint_status'), 'get_chokepoint_status must be registered (U6)');
+    assert.ok(toolNames.includes('get_procurement_opportunities'), 'get_procurement_opportunities must be registered (#5301)');
     assert.ok(toolNames.includes('describe_tool'), 'describe_tool must be registered (v1.5.0 schema compression)');
   });
 


### PR DESCRIPTION
## Summary

Agents can now query global procurement opportunities through the same Pro-gated canonical API route used by product clients, rather than a separate data path. Results default to 10 compact records and cap at 25 while retaining route-owned pagination, applied filters, source health, availability, and country-coverage semantics. automationFit is explicitly relevance evidence, not bidding eligibility, and unknown participation remains unknown.

Fixes #5301.

## Validation

- npm run typecheck
- npm run typecheck:api
- npm run lint
- node --import tsx --test --test-concurrency=16 tests/*.test.mjs tests/*.test.mts cli/test/*.test.mjs api/security/report.test.mjs (468 passed)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)