### PR TITLE
fix(china): complete coverage audit contract

### DIFF
--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -184,6 +184,23 @@ The Security Advisories panel displays advisories with colored level badges and 
 
 **Severity thresholds**: Average delay ≥15min or ≥15% delayed flights = minor; ≥30min/30% = moderate; ≥45min/45% = major; ≥60min/60% = severe. Cancellation rate ≥80% with ≥10 flights = closure. All results are cached for 30 minutes in Redis. When no AviationStack API key is configured, the system generates probabilistic simulated delays for demonstration — rush-hour windows and high-traffic airports receive higher delay probability.
 
+### China Coverage, Attribution, and Freshness
+
+The China country deep-dive composes existing global product contracts rather
+than operating a China-only fetch path. Its attributable signals come from
+BIS, IMF, JODI, UN Comtrade, CCFI, AviationStack, NBS/PBoC, JMA, and HKO.
+Every displayed signal carries its source and observation or release date; a
+missing, stale, or partial source is shown as unavailable or degraded rather
+than as a zero value.
+
+The hourly Railway China coverage evaluator checks the transport heartbeat and
+content freshness independently for every launched contract. It uses the
+canonical eight-hub AviationStack `coverage` records—not the bootstrap's
+presentation-only airport rows—so an upstream omission remains observable.
+The audit records aggregate status and reason codes only: it never logs
+credentials or raw upstream payloads. Detailed bilateral trade data remains
+Pro-only and is not included in the public China summary.
+
 ### Aviation Intelligence Panel
 
 The Airline Intel panel provides a comprehensive 6-tab aviation monitoring interface covering operations, flights, carriers, tracking, news, and pricing:
@@ -503,6 +520,8 @@ WorldMonitor is grateful to the following organizations for making their data pu
 | USA Spending | US federal spending and contracts | [api.usaspending.gov](https://api.usaspending.gov) |
 | Global procurement opportunities | US SAM.gov, EU TED, UK Contracts Finder, CanadaBuys, New Zealand GETS, and World Bank procurement notices | [Coverage and freshness](/global-procurement-intelligence) |
 | UN Comtrade | Global merchandise trade flows | [comtradeapi.un.org](https://comtradeapi.un.org) |
+| National Bureau of Statistics of China | China release-calendar context | [stats.gov.cn](https://www.stats.gov.cn/english/) |
+| People's Bank of China | Loan-prime-rate calendar context | [pbc.gov.cn](http://www.pbc.gov.cn/en/3688110/index.html) |
 | CoinGecko | Cryptocurrency prices and market data | [coingecko.com](https://www.coingecko.com) |
 
 ### Geopolitics & Conflict
@@ -523,6 +542,7 @@ WorldMonitor is grateful to the following organizations for making their data pu
 | NASA EONET | Natural events — storms, volcanoes, floods | [eonet.gsfc.nasa.gov](https://eonet.gsfc.nasa.gov) |
 | GDACS | UN-coordinated global disaster alerts | [gdacs.org](https://www.gdacs.org) |
 | Hong Kong Observatory | Local tropical-cyclone warning signals | [data.weather.gov.hk](https://data.weather.gov.hk/weatherAPI/opendata/weather.php?dataType=warnsum&lang=en) |
+| Japan Meteorological Agency | Western North Pacific tropical-cyclone observations | [jma.go.jp](https://www.jma.go.jp/bosai/map.html#contents=typhoon) |
 | Open-Meteo | ERA5 reanalysis climate data | [open-meteo.com](https://open-meteo.com) |
 
 ### Infrastructure & Cyber
@@ -542,3 +562,4 @@ WorldMonitor is grateful to the following organizations for making their data pu
 | OpenSky Network | ADS-B flight tracking (fallback) | [opensky-network.org](https://opensky-network.org) |
 | FAA ASWS | US airport delay and ground stop data | [nasstatus.faa.gov](https://nasstatus.faa.gov) |
 | ICAO | NOTAM airspace closure data | [icao.int](https://www.icao.int) |
+| AviationStack | International airport delay coverage | [aviationstack.com](https://aviationstack.com/) |

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -85,6 +85,21 @@ Keys are grouped into three tiers that determine alert severity:
 | `EMPTY` | Crit | Bootstrap or seeded standalone key has no data |
 | `EMPTY_DATA` | Crit | Key exists but contains zero records (and 0 is not a valid state for it) |
 
+### China Coverage Projection
+
+`chinaCoverage` projects the hourly Railway summary at
+`health:china-coverage:v1`. The evaluator checks each launched China contract
+for both a fresh producer heartbeat and fresh, substantive China content; a
+fresh seed cannot hide stale or missing source content. `CHINA_DEGRADED` is a
+warning projection for partial or stale coverage, while `CHINA_UNAVAILABLE` is
+critical when the summary is invalid or the launched content is unavailable.
+
+Operators can obtain the same sanitized, read-only audit with
+`node scripts/audit-china-coverage.mjs --json`; add `--strict` to return a
+nonzero exit code unless every launched entry is healthy. The audit reads only
+the compact Redis contracts and emits status, age, and reason-code summaries—
+never credentials or raw upstream payloads.
+
 ### Cascade Groups
 
 Some keys use fallback chains. If any sibling has data, empty siblings report `OK_CASCADE`:

--- a/scripts/china-coverage-health.mjs
+++ b/scripts/china-coverage-health.mjs
@@ -87,12 +87,15 @@ function probeContent(payload, probe) {
   const matched = source.filter((row) => wanted.has(String(row?.[probe.field] ?? '')));
 
   if (probe.kind === 'array-coverage') {
-    const presentValues = new Set(matched.map((row) => String(row?.[probe.field] ?? '')));
+    const validRows = probe.validValues
+      ? matched.filter((row) => probe.validValues.includes(String(row?.[probe.validField ?? 'status'] ?? '')))
+      : matched;
+    const presentValues = new Set(validRows.map((row) => String(row?.[probe.field] ?? '')));
     if (presentValues.size === 0) return { status: 'missing', rows: [], required: wanted.size, present: 0 };
     if (presentValues.size < wanted.size) {
-      return { status: 'partial', rows: matched, required: wanted.size, present: presentValues.size };
+      return { status: 'partial', rows: validRows, required: wanted.size, present: presentValues.size };
     }
-    return { status: 'present', rows: matched, required: wanted.size, present: presentValues.size };
+    return { status: 'present', rows: validRows, required: wanted.size, present: presentValues.size };
   }
 
   return matched.length > 0 ? { status: 'present', rows: matched } : { status: 'missing', rows: [] };

--- a/scripts/china-coverage-manifest.mjs
+++ b/scripts/china-coverage-manifest.mjs
@@ -148,20 +148,20 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
     id: 'aviation.china-hubs',
     label: 'China aviation hubs',
     ownerIssue: 5273,
-    // The current bootstrap fills every monitored IATA with NORMAL/UNKNOWN
-    // presentation rows, so alerts[] presence is not provider-coverage proof.
-    // Keep this lane planned until issue #5273's per-hub coverage[] contract is
-    // merged and the manifest can require normal/disruption provider statuses.
-    launchStatus: 'planned',
+    // Per-hub coverage comes from the canonical provider payload. Do not use
+    // bootstrap alerts here: they include presentation-only NORMAL/UNKNOWN rows.
+    launchStatus: 'launched',
     transport: metaTransport('seed-meta:aviation:intl', 90),
     content: {
       key: 'aviation:delays-bootstrap:v2',
       maxAgeMin: 120,
       probe: {
         kind: 'array-coverage',
-        path: ['alerts'],
+        path: ['coverage'],
         field: 'iata',
-        values: ['PEK', 'PVG', 'CAN', 'HKG'],
+        values: ['PEK', 'PVG', 'CAN', 'SZX', 'CTU', 'KMG', 'URC', 'HKG'],
+        validField: 'status',
+        validValues: ['normal', 'disruption'],
         timestampPaths: [['updatedAt']],
       },
     },

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -540,6 +540,7 @@ export async function seedIntlDelays({
           iata: r.value.iata,
           status: r.value.status,
           flightCount: r.value.flightCount,
+          updatedAt: Date.now(),
         });
         if (r.value.status === 'failed') failed++;
         else if (r.value.status === 'omitted') omitted++;
@@ -547,7 +548,7 @@ export async function seedIntlDelays({
         if (r.value.alert) alerts.push(r.value.alert);
       } else {
         failed++;
-        coverage.push({ iata: chunk[j].iata, status: 'failed', flightCount: 0 });
+        coverage.push({ iata: chunk[j].iata, status: 'failed', flightCount: 0, updatedAt: Date.now() });
       }
     }
   }
@@ -1427,6 +1428,7 @@ export function validate(publishData) {
       && ['normal', 'disruption', 'omitted', 'failed'].includes(hub.status)
       && Number.isInteger(hub.flightCount)
       && hub.flightCount >= 0
+      && Number.isFinite(hub.updatedAt)
     ))
   );
 }

--- a/tests/china-aviation-coverage.test.mjs
+++ b/tests/china-aviation-coverage.test.mjs
@@ -75,9 +75,11 @@ describe('China AviationStack hub contract', () => {
     const published = publishTransform(result);
     assert.deepEqual(published.alerts.map((alert) => alert.iata), ['CAN']);
     assert.deepEqual(published.coverage, result.coverage);
+    assert.ok(published.coverage.every((hub) => Number.isFinite(hub.updatedAt)), 'coverage rows retain their observation timestamp');
     assert.equal(validate(published), true);
     assert.equal(validate({ alerts: published.alerts }), false, 'coverage is part of the canonical contract');
     assert.equal(validate({ alerts: [], coverage: [{ iata: 'PEK', status: 'unknown', flightCount: 0 }] }), false);
+    assert.equal(validate({ alerts: [], coverage: [{ iata: 'PEK', status: 'normal', flightCount: 0 }] }), false, 'coverage timestamps are required');
 
     const bootstrap = buildDelaysBootstrapPayload({
       faaPayload: null,

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -235,6 +235,22 @@ describe('China coverage manifest', () => {
       status: 'partial', ageMin: null, maxAgeMin: 120, required: 8, present: 7,
     });
     assert.ok(providerFailure.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL));
+
+    const providerOmission = evaluate(
+      aviation,
+      {
+        'aviation:delays-bootstrap:v2': {
+          alerts,
+          coverage: coverage.map((hub) => (hub.iata === 'KMG' ? { ...hub, status: 'omitted' } : hub)),
+        },
+      },
+      { 'seed-meta:aviation:intl': { fetchedAt: NOW, status: 'ok' } },
+    );
+    assert.equal(providerOmission.entries[0].status, 'degraded');
+    assert.deepEqual(providerOmission.entries[0].content, {
+      status: 'partial', ageMin: null, maxAgeMin: 120, required: 8, present: 7,
+    });
+    assert.ok(providerOmission.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL));
   });
 
   it('fails read-only audits cleanly on missing credentials and partial pipelines', async () => {

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -101,8 +101,20 @@ describe('China coverage manifest', () => {
     );
     assert.equal(
       CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'aviation.china-hubs')?.launchStatus,
-      'planned',
-      'synthetic bootstrap alert rows are not truthful provider coverage',
+      'launched',
+      'the canonical per-hub coverage contract is now provider-backed',
+    );
+    assert.deepEqual(
+      CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'aviation.china-hubs')?.content.probe,
+      {
+        kind: 'array-coverage',
+        path: ['coverage'],
+        field: 'iata',
+        values: ['PEK', 'PVG', 'CAN', 'SZX', 'CTU', 'KMG', 'URC', 'HKG'],
+        validField: 'status',
+        validValues: ['normal', 'disruption'],
+        timestampPaths: [['updatedAt']],
+      },
     );
   });
 
@@ -185,23 +197,44 @@ describe('China coverage manifest', () => {
     assert.deepEqual(missing, { status: 'EMPTY', records: 0 });
   });
 
-  it('does not count synthetic aviation bootstrap filler as launched China coverage', () => {
+  it('counts canonical provider coverage rather than synthetic aviation bootstrap filler', () => {
     const aviation = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'aviation.china-hubs');
     const alerts = ['PEK', 'PVG', 'CAN', 'HKG'].map((iata) => ({
       iata,
       severity: 'FLIGHT_DELAY_SEVERITY_NORMAL',
       updatedAt: NOW,
     }));
+    const coverage = ['PEK', 'PVG', 'CAN', 'SZX', 'CTU', 'KMG', 'URC', 'HKG'].map((iata) => ({
+      iata,
+      status: 'normal',
+      updatedAt: NOW,
+    }));
     const result = evaluate(
       aviation,
-      { 'aviation:delays-bootstrap:v2': { alerts } },
+      { 'aviation:delays-bootstrap:v2': { alerts, coverage } },
       { 'seed-meta:aviation:intl': { fetchedAt: NOW, status: 'ok' } },
     );
 
-    assert.equal(result.entries[0].launchStatus, 'planned');
-    assert.equal(result.entries[0].status, 'planned');
-    assert.equal(result.counts.launched, 0);
-    assert.equal(result.counts.planned, 1);
+    assert.equal(result.entries[0].launchStatus, 'launched');
+    assert.equal(result.entries[0].status, 'healthy');
+    assert.equal(result.counts.launched, 1);
+    assert.equal(result.counts.planned, 0);
+
+    const providerFailure = evaluate(
+      aviation,
+      {
+        'aviation:delays-bootstrap:v2': {
+          alerts,
+          coverage: coverage.map((hub) => (hub.iata === 'URC' ? { ...hub, status: 'failed' } : hub)),
+        },
+      },
+      { 'seed-meta:aviation:intl': { fetchedAt: NOW, status: 'ok' } },
+    );
+    assert.equal(providerFailure.entries[0].status, 'degraded');
+    assert.deepEqual(providerFailure.entries[0].content, {
+      status: 'partial', ageMin: null, maxAgeMin: 120, required: 8, present: 7,
+    });
+    assert.ok(providerFailure.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL));
   });
 
   it('fails read-only audits cleanly on missing credentials and partial pipelines', async () => {

--- a/tests/china-coverage-production-registration.test.mts
+++ b/tests/china-coverage-production-registration.test.mts
@@ -10,6 +10,8 @@ const runbook = readFileSync(resolve(root, 'docs/railway-seed-consolidation-runb
 const cacheKeys = readFileSync(resolve(root, 'server/_shared/cache-keys.ts'), 'utf8');
 const seedHealth = readFileSync(resolve(root, 'api/seed-health.js'), 'utf8');
 const naturalSeed = readFileSync(resolve(root, 'scripts/seed-natural-events.mjs'), 'utf8');
+const dataSources = readFileSync(resolve(root, 'docs/data-sources.mdx'), 'utf8');
+const healthDocs = readFileSync(resolve(root, 'docs/health-endpoints.mdx'), 'utf8');
 
 describe('China coverage production registration', () => {
   it('runs the compact evaluator in the hourly Railway health bundle', () => {
@@ -36,5 +38,15 @@ describe('China coverage production registration', () => {
     const audit = readFileSync(resolve(root, 'scripts/audit-china-coverage.mjs'), 'utf8');
     assert.doesNotMatch(audit, /runSeed|writeExtraKey|\['SET'/);
     assert.match(audit, /--json/);
+  });
+
+  it('documents the public China source contract and its operator health projection', () => {
+    assert.match(dataSources, /### China Coverage, Attribution, and Freshness/);
+    assert.match(dataSources, /BIS, IMF, JODI, UN Comtrade, CCFI, AviationStack, NBS\/PBoC, JMA, and HKO/);
+    assert.match(dataSources, /detailed bilateral trade data remains\s+Pro-only/i);
+    assert.match(healthDocs, /### China Coverage Projection/);
+    assert.match(healthDocs, /CHINA_DEGRADED/);
+    assert.match(healthDocs, /CHINA_UNAVAILABLE/);
+    assert.match(healthDocs, /read-only audit/i);
   });
 });


### PR DESCRIPTION
## Summary

China's final coverage audit now evaluates the provider-backed eight-hub aviation contract, so presentation-only bootstrap rows and failed or omitted provider results can no longer be reported as healthy. Coverage rows now include an observation timestamp, and the public documentation explains source attribution, the Pro boundary, and the sanitized health projection.

## Validation

- Full pre-push gate passed: frontend and API typechecks, boundary and safety checks, changed China suites, and Markdown/MDX lint.
- `node --import tsx --test tests/list-airport-delays.test.mjs tests/china-energy-coverage.test.mjs` (35 passing)

## Post-deploy validation

The read-only staging audit on 2026-07-14 reported 10 healthy and 4 degraded launched contracts: missing JODI China rows, a future-dated IMF observation, and the pre-deploy aviation payload without coverage timestamps. No remote state was changed for this PR.

After deployment and the next hourly seed, run `node scripts/audit-china-coverage.mjs --json --strict`. Keep the issue open unless all 14 launched contracts are healthy with no planned or blocked entries; otherwise use its reason codes to remediate the owning source.

Related: #5278

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
