### PR TITLE
fix(china): harden coverage audit contracts

### DIFF
--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -193,6 +193,16 @@ Every displayed signal carries its source and observation or release date; a
 missing, stale, or partial source is shown as unavailable or degraded rather
 than as a zero value.
 
+JODI remains enabled for its existing global energy product, but the China
+contract stays explicitly blocked until a reviewed update verifies that JODI
+publishes a substantive `CN` row for the relevant oil or gas dataset. This
+prevents a global JODI heartbeat from being presented as China coverage.
+
+The globally ranked insights payload is likewise not used as China feed-health
+evidence: a current top-eight can legitimately contain no China story. The
+China news contract stays blocked until a source-specific coverage metric is
+persisted with the digest.
+
 The hourly Railway China coverage evaluator checks the transport heartbeat and
 content freshness independently for every launched contract. It uses the
 canonical eight-hub AviationStack `coverage` records—not the bootstrap's

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -93,6 +93,8 @@ for both a fresh producer heartbeat and fresh, substantive China content; a
 fresh seed cannot hide stale or missing source content. `CHINA_DEGRADED` is a
 warning projection for partial or stale coverage, while `CHINA_UNAVAILABLE` is
 critical when the summary is invalid or the launched content is unavailable.
+Blocked China contracts remain visible in the audit with their stable reason
+code but are excluded from the strict launched-entry health count.
 
 Operators can obtain the same sanitized, read-only audit with
 `node scripts/audit-china-coverage.mjs --json`; add `--strict` to return a

--- a/docs/solutions/test-failures/deterministic-gdelt-bulk-fixtures.md
+++ b/docs/solutions/test-failures/deterministic-gdelt-bulk-fixtures.md
@@ -1,0 +1,61 @@
+---
+title: Deterministic timestamps for GDELT bulk fallback fixtures
+date: 2026-07-14
+category: test-failures
+module: GDELT conflict-event fallback
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "CI unit tests failed after static bulk-export timestamps crossed the 24-hour rolling cutoff"
+root_cause: logic_error
+resolution_type: test_fix
+severity: medium
+tags: [gdelt, rolling-window, deterministic-tests, fixtures]
+---
+
+# Deterministic timestamps for GDELT bulk fallback fixtures
+
+## Problem
+
+Three GDELT bulk-fallback tests failed in CI even though the production fallback was behaving correctly. Their mock export timestamp was fixed at `20260713110000`, but the tests used the wall clock when evaluating the rolling window.
+
+## Symptoms
+
+- The `unit` job on PR #5314 rejected the mocked bulk events with `rolling bulk window contained no priority-country material-conflict events`.
+- The same three tests reproduced locally once the wall clock was more than 24 hours after the mocked export timestamp.
+
+## What Didn't Work
+
+- Re-running the tests without changing the fixture did not help: the cutoff moves with `Date.now()`.
+- Changing the production stale-event filter would have hidden a valid safety check rather than fixing the test input.
+
+## Solution
+
+Inject a deterministic clock into every test that supplies the static bulk export fixture:
+
+```js
+const BULK_FIXTURE_NOW = Date.parse('2026-07-13T12:00:00Z');
+
+const result = await fetchGdeltConflictEvents({
+  now: () => BULK_FIXTURE_NOW,
+  fetchBulkEvents: async () => ({
+    exportTimestamp: '20260713110000',
+    events: [{ id: 'gdelt-event-empty-doc', country: 'Sudan' }],
+  }),
+});
+```
+
+This change is in `tests/conflict-gdelt.test.mjs`; production code remains unchanged.
+
+## Why This Works
+
+The rolling merge uses `gdeltAddedAt` when an event provides it, otherwise it falls back to the export timestamp. It then excludes entries older than its 24-hour cutoff ([scripts/_conflict-gdelt-bulk.mjs](../../../scripts/_conflict-gdelt-bulk.mjs#L179-L196)). A fixed `now` keeps the intentionally static fixture inside that window, making the fallback-contract test independent of when CI runs.
+
+## Prevention
+
+- Inject `now` whenever a test combines a static timestamp fixture with rolling-window or freshness logic.
+- Keep expiry behavior in a separate test with an explicitly advanced injected clock; do not rely on wall-clock time to exercise it.
+
+## Related Issues
+
+- [PR #5314](https://github.com/koala73/worldmonitor/pull/5314) contains the CI repair and passed all required checks.

--- a/scripts/china-coverage-health.mjs
+++ b/scripts/china-coverage-health.mjs
@@ -25,7 +25,15 @@ function valuesAtPath(root, path = []) {
   return values;
 }
 
-function timestampMs(value) {
+function timestampMs(value, semantics) {
+  if (semantics === 'imf-weo-forecast-year') {
+    const year = typeof value === 'string' ? Number(value) : value;
+    if (Number.isInteger(year) && year >= 1900 && year <= 2200) {
+      // Matches imfForecastYearToMs(): a WEO horizon for N is backed by the
+      // most recently observed period at the end of N - 1.
+      return Date.UTC(year - 1, 11, 31, 23, 59, 59, 999);
+    }
+  }
   if (typeof value === 'number' && Number.isFinite(value)) {
     if (value >= 1_000_000_000_000) return value;
     if (value >= 1_000_000_000) return value * 1_000;
@@ -42,12 +50,12 @@ function timestampMs(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function newestTimestamp(items, timestampPaths) {
+function newestTimestamp(items, timestampPaths, semantics) {
   const timestamps = [];
   for (const item of items) {
     for (const path of timestampPaths ?? []) {
       for (const value of valuesAtPath(item, path)) {
-        const parsed = timestampMs(value);
+        const parsed = timestampMs(value, semantics);
         if (parsed != null) timestamps.push(parsed);
       }
     }
@@ -135,7 +143,7 @@ function evaluateContent(entry, data, now) {
   ]);
   if (!probed.rows.some((row) => hasSubstantiveValue(row, ignored))) return { ...result, status: 'empty' };
 
-  const observedAt = newestTimestamp(probed.rows, cfg.probe.timestampPaths);
+  const observedAt = newestTimestamp(probed.rows, cfg.probe.timestampPaths, cfg.probe.timestampSemantics);
   if (observedAt == null) return { ...result, status: 'timestamp_missing' };
   const ageMin = Math.round((now - observedAt) / MINUTE_MS);
   return { ...result, status: ageMin < 0 || ageMin > cfg.maxAgeMin ? 'stale' : 'fresh', ageMin };
@@ -170,7 +178,7 @@ export function evaluateChinaCoverage({
         status: entry.launchStatus,
         transport: { status: 'not_applicable', ageMin: null, maxAgeMin: null },
         content: { status: 'not_applicable', ageMin: null, maxAgeMin: null },
-        reasonCodes: [REASON.NOT_LAUNCHED],
+        reasonCodes: [REASON.NOT_LAUNCHED, ...(entry.blockedReason ? [entry.blockedReason] : [])],
       };
     }
 

--- a/scripts/china-coverage-manifest.mjs
+++ b/scripts/china-coverage-manifest.mjs
@@ -18,6 +18,8 @@ export const CHINA_COVERAGE_REASON_CODES = Object.freeze({
   CHINA_ROW_MISSING: 'CHINA_ROW_MISSING',
   CHINA_ROW_EMPTY: 'CHINA_ROW_EMPTY',
   CHINA_COVERAGE_PARTIAL: 'CHINA_COVERAGE_PARTIAL',
+  CHINA_UPSTREAM_ROW_UNAVAILABLE: 'CHINA_UPSTREAM_ROW_UNAVAILABLE',
+  CHINA_COVERAGE_PROJECTION_UNAVAILABLE: 'CHINA_COVERAGE_PROJECTION_UNAVAILABLE',
   CONTENT_TIMESTAMP_MISSING: 'CONTENT_TIMESTAMP_MISSING',
   CONTENT_STALE: 'CONTENT_STALE',
   NOT_LAUNCHED: 'NOT_LAUNCHED',
@@ -51,14 +53,25 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
     content: {
       key: 'economic:imf:macro:v2',
       maxAgeMin: 800 * 1_440,
-      probe: { kind: 'object-property', path: ['countries', 'CN'], timestampPaths: [['latestYear'], ['year']] },
+      // IMF WEO years are forecast horizons, not observation dates. The
+      // seeder maps 2026 forecasts to the end of 2025 for content freshness.
+      probe: {
+        kind: 'object-property',
+        path: ['countries', 'CN'],
+        timestampPaths: [['latestYear'], ['year']],
+        timestampSemantics: 'imf-weo-forecast-year',
+      },
     },
   },
   {
     id: 'energy.jodi-oil',
     label: 'JODI oil',
     ownerIssue: 5271,
-    launchStatus: 'launched',
+    // JODI remains a global source, but its current published country index
+    // has no substantive CN row. Do not advertise China coverage until that
+    // upstream contract recovers.
+    launchStatus: 'blocked',
+    blockedReason: CHINA_COVERAGE_REASON_CODES.CHINA_UPSTREAM_ROW_UNAVAILABLE,
     transport: metaTransport('seed-meta:energy:jodi-oil', 57_600),
     content: {
       key: 'energy:jodi-oil:v1:CN',
@@ -70,7 +83,8 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
     id: 'energy.jodi-gas',
     label: 'JODI gas',
     ownerIssue: 5271,
-    launchStatus: 'launched',
+    launchStatus: 'blocked',
+    blockedReason: CHINA_COVERAGE_REASON_CODES.CHINA_UPSTREAM_ROW_UNAVAILABLE,
     transport: metaTransport('seed-meta:energy:jodi-gas', 57_600),
     content: {
       key: 'energy:jodi-gas:v1:CN',
@@ -130,7 +144,12 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
     id: 'news.china',
     label: 'China news digest',
     ownerIssue: 5272,
-    launchStatus: 'launched',
+    // `news:insights:v1` stores only the globally ranked top stories. It
+    // cannot prove that a China source was reachable when other news ranks
+    // higher, so keep this contract blocked until a source-specific metric is
+    // persisted alongside the digest.
+    launchStatus: 'blocked',
+    blockedReason: CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PROJECTION_UNAVAILABLE,
     transport: metaTransport('seed-meta:news:insights', 30),
     content: {
       key: 'news:insights:v1',

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -104,6 +104,13 @@ describe('China coverage manifest', () => {
       'launched',
       'the canonical per-hub coverage contract is now provider-backed',
     );
+    for (const id of ['energy.jodi-oil', 'energy.jodi-gas', 'news.china']) {
+      assert.equal(
+        CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === id)?.launchStatus,
+        'blocked',
+        `${id} must remain explicit until its source-specific China contract is available`,
+      );
+    }
     assert.deepEqual(
       CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'aviation.china-hubs')?.content.probe,
       {
@@ -335,6 +342,19 @@ describe('China coverage evaluator', () => {
     assert.ok(result.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.CONTENT_STALE));
   });
 
+  it('uses the IMF WEO forecast-year freshness convention for China macro', () => {
+    const imfEntry = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'economic.imf-macro');
+    const result = evaluate(
+      imfEntry,
+      { 'economic:imf:macro:v2': { countries: { CN: { latestYear: 2026, inflationPct: 1.2 } } } },
+      { 'seed-meta:economic:imf-macro': { fetchedAt: NOW - 5 * 60_000, status: 'ok' } },
+    );
+
+    assert.equal(result.entries[0].transport.status, 'fresh');
+    assert.equal(result.entries[0].content.status, 'fresh');
+    assert.equal(result.entries[0].status, 'healthy');
+  });
+
   it('treats future-dated transport and content timestamps as stale', () => {
     const result = evaluate(
       singleEntry(),
@@ -403,6 +423,17 @@ describe('China coverage evaluator', () => {
     assert.equal(result.status, 'healthy');
     assert.equal(result.entries[0].status, 'planned');
     assert.deepEqual(result.entries[0].reasonCodes, [CHINA_COVERAGE_REASON_CODES.NOT_LAUNCHED]);
+  });
+
+  it('reports a stable reason when a China contract is blocked', () => {
+    const blocked = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'news.china');
+    const result = evaluate(blocked);
+
+    assert.equal(result.entries[0].status, 'blocked');
+    assert.deepEqual(result.entries[0].reasonCodes, [
+      CHINA_COVERAGE_REASON_CODES.NOT_LAUNCHED,
+      CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PROJECTION_UNAVAILABLE,
+    ]);
   });
 
   it('renders a bounded human-readable audit without raw upstream data', () => {

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -12,6 +12,8 @@ import {
   GDELT_MIN_SUCCESSFUL_COUNTRIES,
 } from '../scripts/seed-conflict-intel.mjs';
 
+const BULK_FIXTURE_NOW = Date.parse('2026-07-13T12:00:00Z');
+
 test('gdeltSeenDateToIso parses GDELT seendate formats to YYYY-MM-DD', () => {
   assert.equal(gdeltSeenDateToIso('20260709T140000Z'), '2026-07-09');
   assert.equal(gdeltSeenDateToIso('20260709140000'), '2026-07-09');
@@ -102,6 +104,7 @@ test('fetchGdeltConflictEvents fails closed when too many country fetches fail',
 test('fetchGdeltConflictEvents falls through to bulk when the DOC sweep succeeds but yields zero events', async () => {
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async (cc) => ({ country: cc, ok: true, events: [] }),
     fetchBulkEvents: async () => ({
@@ -121,6 +124,7 @@ test('fetchGdeltConflictEvents falls through to bulk when the DOC sweep succeeds
 test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk event feed', async () => {
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async (cc) => ({
       country: cc,
@@ -231,6 +235,7 @@ test('fetchGdeltConflictEvents preserves partial DOC coverage telemetry after bu
   let calls = 0;
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async (cc) => {
       calls += 1;


### PR DESCRIPTION
## Summary
- interpret IMF WEO forecast years with the seeder's existing end-of-prior-year freshness convention
- mark JODI oil/gas China coverage blocked while upstream CN rows are absent, without changing global JODI availability
- mark the global top-eight insights projection blocked for China coverage until a source-specific metric exists
- document the blocked-contract and strict-audit semantics

## Verification
- npm run typecheck
- full data suite via the node --import tsx IPC-safe fallback
- focused China coverage suite: 42 passing tests
- strict China audit against production Redis

## Live audit status
The final strict audit remains nonzero because the launched market.china-index cache was missing during the final live check. Keep the epic open until that independent cache recovers and a subsequent strict audit is healthy. JODI and global-ranked news are explicit blocked contracts rather than false China greens.

## Post-Deploy Monitoring & Validation
- Owner: release operator for #5278/#5279.
- Run node scripts/audit-china-coverage.mjs --json --strict after deployment, then every 30 minutes for two hours.
- Healthy signal: status=healthy with zero degraded and unavailable launched entries.
- Watch market.china-index for TRANSPORT_MISSING or CHINA_ROW_MISSING, and the hourly evaluator for CHINA_DEGRADED / CHINA_UNAVAILABLE.
- Mitigate source-cache outages directly; revert only if this audit semantic is wrong.