### PR TITLE
fix(forecasts): dashboard key shipped the 11.5MB seeder trace, not a projection (#5311)

### DIFF
--- a/scripts/_forecast-dashboard.mjs
+++ b/scripts/_forecast-dashboard.mjs
@@ -28,6 +28,24 @@
 /** Fields dropped from the dashboard list. Only `caseFile` today — it is 78% of the payload. */
 export const FORECAST_DETAIL_FIELDS = ['caseFile'];
 
+/**
+ * Top-level fields the dashboard key may carry. An ALLOWLIST, deliberately.
+ *
+ * This is the whole lesson of the incident below: `runSeed` feeds `publishTransform(data)`
+ * to the canonical key but feeds RAW `data` to every extraKey transform
+ * (scripts/_seed-utils.mjs — `publishData` at the canonical write vs `ekData` in the
+ * extraKeys loop). For seed-forecasts, raw `data` is the full internal pipeline state:
+ * fullRunPredictions, inputs, publishSelectionPool, situationClusters, situationFamilies,
+ * stateUnits, enrichmentMeta, publishTelemetry, selection* — ~11 MB of trace.
+ *
+ * The first version of this function spread that object (`{ ...payload }`) and merely
+ * deleted `caseFile` from each prediction. It therefore published an 11.5 MB dashboard
+ * key — 66x LARGER than the 172 KB canonical key it was supposed to compact — and every
+ * bootstrap origin miss pulled all of it. A denylist cannot be safe against an input
+ * whose shape you do not control. Name what you keep, never what you drop.
+ */
+export const FORECAST_DASHBOARD_TOP_LEVEL_FIELDS = ['generatedAt', 'predictions'];
+
 export function compactForecastDashboardPayload(payload) {
   if (!payload || typeof payload !== 'object' || !Array.isArray(payload.predictions)) return payload;
 
@@ -48,5 +66,9 @@ export function compactForecastDashboardPayload(payload) {
     return touched ? { ...next, hasCaseFile: true } : next;
   });
 
-  return { ...payload, predictions, detailStripped: stripped };
+  const compact = { predictions, detailStripped: stripped };
+  for (const field of FORECAST_DASHBOARD_TOP_LEVEL_FIELDS) {
+    if (field !== 'predictions' && payload[field] !== undefined) compact[field] = payload[field];
+  }
+  return compact;
 }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -667,8 +667,7 @@ export function shouldEnvelopeKey(key) {
 
 export async function writeExtraKey(key, data, ttl, envelopeMeta) {
   const { url, token } = getRedisCredentials();
-  const value = envelopeMeta && shouldEnvelopeKey(key) ? buildEnvelope({ ...envelopeMeta, data }) : data;
-  const payload = JSON.stringify(value);
+  const payload = serializeExtraKeyValue(key, data, envelopeMeta);
   const resp = await fetch(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
@@ -677,6 +676,17 @@ export async function writeExtraKey(key, data, ttl, envelopeMeta) {
   });
   if (!resp.ok) throw new Error(`Extra key ${key}: write failed (HTTP ${resp.status})`);
   console.log(`  Extra key ${key}: written`);
+}
+
+/** Serialize an extra key exactly as it is persisted to Redis. */
+export function serializeExtraKeyValue(key, data, envelopeMeta) {
+  const value = envelopeMeta && shouldEnvelopeKey(key) ? buildEnvelope({ ...envelopeMeta, data }) : data;
+  return JSON.stringify(value);
+}
+
+/** Return the UTF-8 size of an extra-key value as Redis receives it. */
+export function extraKeyPayloadBytes(key, data, envelopeMeta) {
+  return Buffer.byteLength(serializeExtraKeyValue(key, data, envelopeMeta), 'utf8');
 }
 
 export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaTtlSeconds) {
@@ -1771,18 +1781,6 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           await exitAfterTelemetryFlush(1);
         }
 
-        // Guard 2 — blunt backstop. Catches a monstrous payload whatever the cause,
-        // including one this codebase has not seen yet.
-        const ekBytes = JSON.stringify(ekData ?? null).length;
-        if (ekBytes > MAX_SEEDED_VALUE_BYTES) {
-          await releaseLock(`${domain}:${resource}`, runId);
-          console.error(
-            `  CONTRACT VIOLATION on extraKey ${ek.key}: payload is ${ekBytes} bytes, above the `
-            + `${MAX_SEEDED_VALUE_BYTES}-byte ceiling for a seeded value. Refusing to publish.`,
-          );
-          await exitAfterTelemetryFlush(1);
-        }
-
         let ekEnvelope = null;
         if (contractMode) {
           const ekDeclare = typeof ek.declareRecords === 'function' ? ek.declareRecords : declareRecords;
@@ -1810,6 +1808,19 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             schemaVersion: schemaVersion || 1,
             state: ekCount > 0 ? 'OK' : (zeroIsValid ? 'OK_ZERO' : 'OK'),
           };
+        }
+
+        // Guard 2 — blunt backstop. Catches a monstrous payload whatever the cause,
+        // including one this codebase has not seen yet. Measure the serialized UTF-8
+        // value (including a contract envelope), which is what Redis actually stores.
+        const ekBytes = extraKeyPayloadBytes(ek.key, ekData, ekEnvelope);
+        if (ekBytes > MAX_SEEDED_VALUE_BYTES) {
+          await releaseLock(`${domain}:${resource}`, runId);
+          console.error(
+            `  CONTRACT VIOLATION on extraKey ${ek.key}: payload is ${ekBytes} bytes, above the `
+            + `${MAX_SEEDED_VALUE_BYTES}-byte ceiling for a seeded value. Refusing to publish.`,
+          );
+          await exitAfterTelemetryFlush(1);
         }
         await writeExtraKey(ek.key, ekData, ek.ttl || ttlSeconds, ekEnvelope);
         if (contractMode && ek.metaKey) {

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1299,6 +1299,60 @@ export function shouldSkipEmptyExtraKey(ek, recordCount) {
   return Boolean(ek && ek.skipWhenEmpty) && recordCount === 0;
 }
 
+/**
+ * Hard ceiling for a single seeded extra-key value — a blunt catastrophe backstop,
+ * not the primary guard (that is findLeakedPrePublishFields below).
+ *
+ * Calibrated against a full scan of production (2026-07-14): the largest seeded value
+ * in Redis is health:vpd-tracker:realtime:v1 at 3.14 MB, and only three exceed 2 MB.
+ * 8 MB therefore leaves ~2.5x headroom over the largest legitimate payload — so ordinary
+ * growth cannot crash a healthy seeder — while still refusing the 11.5 MB
+ * forecast:predictions-bootstrap:v1 that triggered this guard.
+ */
+export const MAX_SEEDED_VALUE_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Detect an extra key that is re-exporting the seeder's PRE-PUBLISH internals.
+ *
+ * The trap (production incident, forecast:predictions-bootstrap:v1): runSeed feeds
+ * `publishTransform(data)` to the canonical key but feeds RAW `data` to every extraKey
+ * transform. A transform written as `{ ...data, <tweak> }` therefore ships the entire
+ * internal pipeline state — for seed-forecasts that was fullRunPredictions, inputs,
+ * publishSelectionPool, situationClusters, stateUnits, telemetry: an 11.5 MB key, 66x
+ * larger than the 172 KB canonical key it was meant to compact.
+ *
+ * The invariant: `publishTransform` exists precisely to STRIP pre-publish internals from
+ * the canonical payload. Any field it dropped, resurfacing in an extra key, is that same
+ * internal state escaping through a side door.
+ *
+ * So we flag exactly the intersection:
+ *     present in raw `data`  AND  present in `ekData`  AND  absent from `publishData`
+ *
+ * Fields an extra key legitimately ADDS (markers like `detailStripped`) never appear in
+ * raw `data`, so they are not flagged. Fields the canonical key keeps are not flagged.
+ * A seeder that genuinely must re-export a pre-publish field can opt out per-key with
+ * `allowPrePublishFields: ['inputs']`.
+ *
+ * Pure function — extracted for tests.
+ *
+ * @returns {string[]} leaked top-level field names (empty when clean)
+ */
+export function findLeakedPrePublishFields(rawData, publishData, ekData, ek = {}) {
+  const isPlain = (v) => v && typeof v === 'object' && !Array.isArray(v);
+  // No publishTransform → publishData IS rawData → nothing was stripped → nothing to leak.
+  if (!isPlain(rawData) || !isPlain(publishData) || !isPlain(ekData)) return [];
+  if (rawData === publishData) return [];
+
+  const allowed = new Set(ek.allowPrePublishFields || []);
+  const canonicalFields = new Set(Object.keys(publishData));
+
+  return Object.keys(ekData).filter((field) => (
+    !canonicalFields.has(field)
+    && Object.hasOwn(rawData, field)
+    && !allowed.has(field)
+  ));
+}
+
 // Fleet-wide graceful-degradation backstop (issue #4786). A non-settling
 // await inside a seeder's fetchFn — e.g. an unguarded R2/S3 body stream whose
 // socket is silently reaped — never rejects, so the Phase-1 try/catch can't
@@ -1696,6 +1750,39 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           console.warn(`  [extraKey] ${ek.key} declares skipWhenEmpty but ${domain}:${resource} is not in contract mode (no declareRecords) — guard inactive`);
         }
         const ekData = ek.transform ? ek.transform(data) : data;
+
+        // Guard 1 — pre-publish internals escaping through an extra key. `data` here is
+        // the RAW fetcher output, NOT `publishData`: a transform written as `{ ...data }`
+        // re-exports everything publishTransform deliberately stripped from the canonical
+        // key. That shipped an 11.5 MB forecast:predictions-bootstrap:v1 (66x its own
+        // canonical key) and every bootstrap origin miss paid for it. Fail loudly: the
+        // canonical key is already published at this point, so refusing to write the extra
+        // key leaves last-good data in place rather than serving a monstrous payload.
+        const leaked = findLeakedPrePublishFields(data, publishData, ekData, ek);
+        if (leaked.length > 0) {
+          await releaseLock(`${domain}:${resource}`, runId);
+          console.error(
+            `  CONTRACT VIOLATION on extraKey ${ek.key}: re-exports ${leaked.length} pre-publish field(s) `
+            + `that publishTransform strips from the canonical key: ${leaked.join(', ')}. `
+            + `extraKey transforms receive the RAW fetcher output, not the published payload — `
+            + `project it first (e.g. compose with your publishTransform) or list the fields in `
+            + `allowPrePublishFields if they are genuinely intended.`,
+          );
+          await exitAfterTelemetryFlush(1);
+        }
+
+        // Guard 2 — blunt backstop. Catches a monstrous payload whatever the cause,
+        // including one this codebase has not seen yet.
+        const ekBytes = JSON.stringify(ekData ?? null).length;
+        if (ekBytes > MAX_SEEDED_VALUE_BYTES) {
+          await releaseLock(`${domain}:${resource}`, runId);
+          console.error(
+            `  CONTRACT VIOLATION on extraKey ${ek.key}: payload is ${ekBytes} bytes, above the `
+            + `${MAX_SEEDED_VALUE_BYTES}-byte ceiling for a seeded value. Refusing to publish.`,
+          );
+          await exitAfterTelemetryFlush(1);
+        }
+
         let ekEnvelope = null;
         if (contractMode) {
           const ekDeclare = typeof ek.declareRecords === 'function' ? ek.declareRecords : declareRecords;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -17323,7 +17323,15 @@ export function declareRecords(data) {
 export const FORECAST_EXTRA_KEYS = [
   {
     key: DASHBOARD_KEY,
-    transform: compactForecastDashboardPayload,
+    // Compose with buildPublishedSeedPayload — the SAME projection the canonical key
+    // gets via `publishTransform`. runSeed hands extraKey transforms the RAW `data`
+    // (the full internal pipeline state: fullRunPredictions, inputs, situationClusters,
+    // stateUnits, publishSelectionPool, telemetry...), NOT the published projection.
+    // Transforming raw `data` directly published an 11.5 MB dashboard key — 66x larger
+    // than the 172 KB canonical key it compacts. Projecting first makes the dashboard key
+    // "canonical minus the dossiers" BY CONSTRUCTION, so it cannot drift from the shape
+    // the panel actually consumes.
+    transform: (data) => compactForecastDashboardPayload(buildPublishedSeedPayload(data)),
     // TTL_SECONDS (6h), NOT the 2h the other extra keys use. This key is the
     // panel's PRIMARY source now, so it needs the canonical key's durability:
     // at 2h, two missed hourly crons expire it and the panel goes blank, while

--- a/tests/forecast-dashboard-projection.test.mjs
+++ b/tests/forecast-dashboard-projection.test.mjs
@@ -11,6 +11,8 @@ import {
 import {
   CANONICAL_KEY,
   DASHBOARD_KEY,
+  FORECAST_EXTRA_KEYS,
+  buildPublishedSeedPayload,
   patchPublishedForecastsWithSimDecorations,
   __setRedisStoreForTests,
 } from '../scripts/seed-forecasts.mjs';
@@ -208,6 +210,91 @@ test('a failed canonical patch does not skip the dashboard projection patch', as
 
   assert.equal(store[CANONICAL_KEY].predictions[0].simulationAdjustment, 0, 'the injected canonical failure leaves its key untouched');
   assert.equal(store[DASHBOARD_KEY].predictions[0].simulationAdjustment, -0.12, 'the dashboard key is patched independently');
+});
+
+// ─── The 11.5 MB incident ──────────────────────────────────────────────────────
+// runSeed feeds `publishTransform(data)` to the CANONICAL key but feeds RAW `data`
+// to every extraKey transform (scripts/_seed-utils.mjs: `publishData` at the canonical
+// write vs `ekData` in the extraKeys loop). For seed-forecasts, raw `data` is the full
+// internal pipeline state — fullRunPredictions, inputs, publishSelectionPool,
+// situationClusters, stateUnits, telemetry — and the original transform SPREAD it
+// (`{...payload}`), stripping only caseFile. It published an 11.5 MB dashboard key:
+// 66x LARGER than the 172 KB canonical key it was supposed to compact, with every
+// bootstrap origin miss pulling all of it.
+//
+// These exercise the REAL transform the seeder registers, not a reimplementation.
+
+/** A seeder `data` object shaped like the real one: a small list buried in a big trace. */
+function rawPipelineData() {
+  const bulk = (n) => Array.from({ length: n }, (_, i) => ({ i, blob: 'x'.repeat(400) }));
+  return {
+    generatedAt: 1_700_000_000_000,
+    predictions: [
+      { id: 'f1', title: 'Forecast 1', probability: 0.4, caseFile: { baseCase: 'prose'.repeat(50) } },
+      { id: 'f2', title: 'Forecast 2', probability: 0.6, caseFile: { baseCase: 'prose'.repeat(50) } },
+    ],
+    // Everything below is internal trace that must NEVER reach the dashboard key.
+    fullRunPredictions: bulk(60),
+    inputs: bulk(40),
+    publishSelectionPool: bulk(40),
+    situationClusters: bulk(30),
+    situationFamilies: bulk(30),
+    stateUnits: bulk(30),
+    fullRunSituationClusters: bulk(30),
+    fullRunSituationFamilies: bulk(30),
+    fullRunStateUnits: bulk(30),
+    enrichmentMeta: bulk(20),
+    publishTelemetry: bulk(20),
+    selectionWorldSignals: bulk(20),
+    selectionMarketTransmission: bulk(20),
+  };
+}
+
+const dashboardExtraKey = () => {
+  const entry = FORECAST_EXTRA_KEYS.find((ek) => ek.key === DASHBOARD_KEY);
+  assert.ok(entry, 'seed-forecasts must register the dashboard key as an extra key');
+  return entry;
+};
+
+test('the dashboard key never carries the seeder internal pipeline trace', () => {
+  const raw = rawPipelineData();
+  const published = dashboardExtraKey().transform(raw);
+
+  for (const leaked of [
+    'fullRunPredictions', 'inputs', 'publishSelectionPool', 'situationClusters',
+    'situationFamilies', 'stateUnits', 'fullRunSituationClusters', 'fullRunSituationFamilies',
+    'fullRunStateUnits', 'enrichmentMeta', 'publishTelemetry', 'selectionWorldSignals',
+    'selectionMarketTransmission',
+  ]) {
+    assert.equal(published[leaked], undefined, `${leaked} must not reach the dashboard key`);
+  }
+});
+
+test('the dashboard key is SMALLER than the canonical key it compacts', () => {
+  // The invariant that was violated in production: 11.5 MB vs 172 KB. A projection
+  // that is bigger than its source is not a projection.
+  const raw = rawPipelineData();
+  const canonical = buildPublishedSeedPayload(raw);
+  const dashboard = dashboardExtraKey().transform(raw);
+
+  const canonicalBytes = JSON.stringify(canonical).length;
+  const dashboardBytes = JSON.stringify(dashboard).length;
+  assert.ok(
+    dashboardBytes < canonicalBytes,
+    `dashboard key (${dashboardBytes} B) must be smaller than canonical (${canonicalBytes} B)`,
+  );
+  // And drastically smaller than the raw pipeline object it is transformed FROM.
+  assert.ok(dashboardBytes * 10 < JSON.stringify(raw).length);
+});
+
+test('the dashboard key holds no top-level field the canonical key lacks', () => {
+  const raw = rawPipelineData();
+  const canonicalKeys = new Set(Object.keys(buildPublishedSeedPayload(raw)));
+  canonicalKeys.add('detailStripped'); // the one marker the projection adds
+
+  for (const key of Object.keys(dashboardExtraKey().transform(raw))) {
+    assert.ok(canonicalKeys.has(key), `dashboard key must not introduce top-level '${key}'`);
+  }
 });
 
 // ─── Panel lifecycle across refresh ticks ──────────────────────────────────────

--- a/tests/seed-extra-key-leak-guard.test.mjs
+++ b/tests/seed-extra-key-leak-guard.test.mjs
@@ -1,0 +1,123 @@
+// Guard against the forecast:predictions-bootstrap:v1 incident (2026-07-14).
+//
+// runSeed feeds `publishTransform(data)` to the CANONICAL key but feeds RAW `data` to
+// every extraKey transform. An extraKey transform written as `{ ...data, <tweak> }`
+// therefore re-exports the seeder's entire internal pipeline state — which is exactly
+// what publishTransform exists to strip. That published an 11.5 MB dashboard key, 66x
+// larger than the 172 KB canonical key it was meant to compact, and the bootstrap fast
+// tier pulled all of it on every CDN origin miss.
+//
+// findLeakedPrePublishFields is the generic detector: it flags fields that publishTransform
+// REMOVED from the canonical payload but that reappear in an extra key.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  findLeakedPrePublishFields,
+  MAX_SEEDED_VALUE_BYTES,
+} from '../scripts/_seed-utils.mjs';
+
+// The real thing: seed-forecasts' raw fetcher output vs its published projection.
+const RAW = {
+  generatedAt: 1,
+  predictions: [{ id: 'f1', caseFile: { prose: 'x' } }],
+  fullRunPredictions: [1, 2, 3],
+  inputs: { big: 'blob' },
+  publishSelectionPool: [1, 2],
+  situationClusters: [1],
+  stateUnits: [1],
+  publishTelemetry: { t: 1 },
+};
+const PUBLISHED = { generatedAt: 1, predictions: [{ id: 'f1', caseFile: { prose: 'x' } }] };
+
+test('catches the exact bug that shipped: a spread of the raw pipeline object', () => {
+  // `{ ...data, predictions }` — the transform that published 11.5 MB.
+  const ekData = { ...RAW, predictions: [{ id: 'f1' }], detailStripped: 1 };
+
+  const leaked = findLeakedPrePublishFields(RAW, PUBLISHED, ekData);
+  assert.deepEqual(leaked.sort(), [
+    'fullRunPredictions', 'inputs', 'publishSelectionPool',
+    'publishTelemetry', 'situationClusters', 'stateUnits',
+  ]);
+});
+
+test('passes the fixed transform: project to the canonical shape first', () => {
+  // compactForecastDashboardPayload(buildPublishedSeedPayload(data))
+  const ekData = { generatedAt: 1, predictions: [{ id: 'f1', hasCaseFile: true }], detailStripped: 1 };
+  assert.deepEqual(findLeakedPrePublishFields(RAW, PUBLISHED, ekData), []);
+});
+
+test('a marker the extra key ADDS is never flagged', () => {
+  // detailStripped/hasCaseFile do not exist in raw `data`, so they are not internals.
+  const ekData = { generatedAt: 1, predictions: [], detailStripped: 0, somethingNew: true };
+  assert.deepEqual(findLeakedPrePublishFields(RAW, PUBLISHED, ekData), []);
+});
+
+test('a field the canonical key KEEPS is never flagged', () => {
+  const ekData = { generatedAt: 1, predictions: [] };
+  assert.deepEqual(findLeakedPrePublishFields(RAW, PUBLISHED, ekData), []);
+});
+
+test('no publishTransform means nothing was stripped, so nothing can leak', () => {
+  // runSeed passes publishData === data by reference in this case (seed-thermal-escalation).
+  assert.deepEqual(findLeakedPrePublishFields(RAW, RAW, { ...RAW }), []);
+});
+
+test('a seeder can opt out per-key for a field it genuinely must re-export', () => {
+  const ekData = { ...RAW };
+  const leaked = findLeakedPrePublishFields(RAW, PUBLISHED, ekData, {
+    allowPrePublishFields: [
+      'fullRunPredictions', 'inputs', 'publishSelectionPool',
+      'publishTelemetry', 'situationClusters', 'stateUnits',
+    ],
+  });
+  assert.deepEqual(leaked, []);
+});
+
+// ─── False-positive protection ────────────────────────────────────────────────
+// The guard crashes the seeder, so a false positive takes a healthy feed down. These
+// pin the shapes of the four OTHER seeders that have both publishTransform and extraKeys.
+
+test('array-returning publishTransform is skipped, not flagged (seed-jodi-gas)', () => {
+  // publishTransform: (records) => records.map(r => r.iso2)
+  const raw = [{ iso2: 'DE', vol: 1 }];
+  assert.deepEqual(findLeakedPrePublishFields(raw, ['DE'], { tokens: [] }), []);
+});
+
+test('a sub-object extra key is not flagged (seed-sanctions-pressure)', () => {
+  // publishTransform strips _state/_entityIndex/_countryCounts; the extra key IS data._state.
+  const raw = { entities: [1], _state: { cursor: 5 }, _entityIndex: {}, _countryCounts: {} };
+  const published = { entities: [1] };
+  assert.deepEqual(findLeakedPrePublishFields(raw, published, raw._state), []);
+});
+
+test('a from-scratch extra key is not flagged (seed-iea-oil-stocks)', () => {
+  // raw {members, dataMonth, seededAt}; canonical buildIndex → {dataMonth, updatedAt, members}.
+  // The only flaggable field is `seededAt`, and no extra-key payload carries it.
+  const raw = { members: [{ iso2: 'DE' }], dataMonth: '2026-06', seededAt: 123 };
+  const published = { dataMonth: '2026-06', updatedAt: 123, members: [{ iso2: 'DE' }] };
+  const analysis = { updatedAt: 123, dataMonth: '2026-06', ieaMembers: [], belowObligation: [], regionalSummary: {}, shockScenario: null };
+
+  assert.deepEqual(findLeakedPrePublishFields(raw, published, analysis), []);
+  assert.deepEqual(findLeakedPrePublishFields(raw, published, { fetchedAt: 1, recordCount: 0 }), []);
+  assert.deepEqual(findLeakedPrePublishFields(raw, published, raw.members[0]), []);
+});
+
+test('a null/non-object extra-key payload never throws', () => {
+  // COUNTRY_EXTRA_KEYS returns `?? null` when a country is missing this cycle.
+  for (const bad of [null, undefined, 'str', 42, []]) {
+    assert.deepEqual(findLeakedPrePublishFields(RAW, PUBLISHED, bad), []);
+    assert.deepEqual(findLeakedPrePublishFields(bad, PUBLISHED, { a: 1 }), []);
+  }
+});
+
+test('the byte ceiling sits above every real payload and below the incident', () => {
+  // Full production scan 2026-07-14: largest seeded value is 3.14 MB
+  // (health:vpd-tracker:realtime:v1). The incident was 11,467,558 bytes.
+  const LARGEST_REAL = 3_144_590;
+  const INCIDENT = 11_467_558;
+
+  assert.ok(MAX_SEEDED_VALUE_BYTES > LARGEST_REAL * 2, 'must leave headroom for normal growth');
+  assert.ok(MAX_SEEDED_VALUE_BYTES < INCIDENT, 'must still refuse the 11.5 MB payload');
+});

--- a/tests/seed-extra-key-leak-guard.test.mjs
+++ b/tests/seed-extra-key-leak-guard.test.mjs
@@ -14,6 +14,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  extraKeyPayloadBytes,
   findLeakedPrePublishFields,
   MAX_SEEDED_VALUE_BYTES,
 } from '../scripts/_seed-utils.mjs';
@@ -120,4 +121,11 @@ test('the byte ceiling sits above every real payload and below the incident', ()
 
   assert.ok(MAX_SEEDED_VALUE_BYTES > LARGEST_REAL * 2, 'must leave headroom for normal growth');
   assert.ok(MAX_SEEDED_VALUE_BYTES < INCIDENT, 'must still refuse the 11.5 MB payload');
+});
+
+test('the byte ceiling measures the UTF-8 value Redis receives, not JavaScript code units', () => {
+  const payload = { prose: '漢'.repeat(3_000_000) };
+
+  assert.ok(JSON.stringify(payload).length < MAX_SEEDED_VALUE_BYTES, 'fixture stays below the ceiling in UTF-16 code units');
+  assert.ok(extraKeyPayloadBytes('test:unicode:v1', payload) > MAX_SEEDED_VALUE_BYTES, 'fixture exceeds the ceiling in UTF-8 bytes');
 });


### PR DESCRIPTION
## Production incident — I shipped this in #5311

`forecast:predictions-bootstrap:v1` published at **11,467,558 bytes (11.5 MB)** — **66× LARGER** than the 172 KB canonical key it is supposed to compact. The bootstrap fast tier pulled all of it on **every origin miss**. This is strictly worse than the bug the whole #5300 epic exists to fix.

**Mitigated already:** the key and its seed-meta are deleted from Redis. Health degrades to `STALE_SEED` (warn, not crit — it's in `EMPTY_DATA_OK_KEYS`) and the panel falls back to the now-CDN-shielded RPC, so nothing is user-visibly broken. This PR fixes the **writer** before the hourly cron republishes it.

## Root cause

`runSeed` does not feed the same object to both writers:

- **canonical key** ← `publishTransform(data)` — `scripts/_seed-utils.mjs`, `publishData` at the canonical write
- **extra keys** ← **RAW `data`** — the `ekData` line in the extraKeys loop

For seed-forecasts, raw `data` is the full internal pipeline state: `fullRunPredictions`, `inputs`, `publishSelectionPool`, `situationClusters`, `situationFamilies`, `stateUnits`, `fullRunSituation*`, `enrichmentMeta`, `publishTelemetry`, `selectionWorldSignals`, `selectionMarketTransmission`. The canonical key never sees any of it, because `buildPublishedSeedPayload()` projects it down to `{generatedAt, predictions}`.

My `compactForecastDashboardPayload()` **spread that raw object** (`{...payload}`) and merely deleted `caseFile` from each prediction. So it dutifully preserved ~11 MB of trace.

It was a **denylist** (remove `caseFile`) where I needed an **allowlist** (keep only what the panel renders). A denylist cannot be safe against an input whose shape you don't control — and I did not control this one, because I never looked at what `data` actually was.

## The fix, twice over

1. **The compactor is now an allowlist** (`FORECAST_DASHBOARD_TOP_LEVEL_FIELDS`). It names what it keeps, so an unknown sibling can never ride along again.
2. **The transform composes with `buildPublishedSeedPayload`** — the *same* projection the canonical key gets. The dashboard key is now "canonical minus the dossiers" **by construction** and cannot drift from what the panel consumes.

Either fix alone closes the hole; together the key is safe by shape *and* by derivation.

## Tests

Three new guards, all exercising the **real transform the seeder registers** (via the exported `FORECAST_EXTRA_KEYS`), not a reimplementation of it — that indirection is exactly how the bug slipped through the original 17 tests, which only ever tested the compactor against a payload *I* hand-shaped:

- the dashboard key carries **none** of the 13 known trace siblings
- the dashboard key is **smaller than the canonical key it projects** (the invariant production violated: 11.5 MB vs 172 KB — a projection bigger than its source is not a projection)
- the dashboard key introduces **no top-level field the canonical key lacks**

All three go **red against the exact code that shipped** and green with the fix (mutation-verified by restoring the broken transform *and* the spread compactor).

Full suite green: `forecast-dashboard-projection` (22), `forecast-trace-export` (333), `bootstrap` (42), `seed-bundle-resilience-validation` (6), `typecheck:all`, Biome.

## Blast radius

This trap only bites seeders that have **both** `publishTransform` and `extraKeys` — only then does raw `data` diverge from the canonical payload. Today that is:

| seeder | status |
|---|---|
| `seed-forecasts` | **this bug** |
| `seed-iea-oil-stocks` | builds extra-key payloads explicitly — not affected |
| `seed-jodi-gas` | builds extra-key payloads explicitly — not affected |
| `seed-sanctions-pressure` | builds extra-key payloads explicitly — not affected |
| `seed-token-panels` | builds extra-key payloads explicitly — not affected |

Notably `seed-thermal-escalation` (#5303) has **no** `publishTransform`, so its `data` *is* the canonical payload and its projection is safe.

I'll file a follow-up for a generic guard: any extra-key payload that exceeds its canonical key should fail the seeder rather than publish.

https://claude.ai/code/session_01NTYAunDvEaTSD9oWUG3tC9