### PR TITLE
fix(china): keep country-index audit cache Railway-backed

### DIFF
--- a/scripts/_country-stock-index.mjs
+++ b/scripts/_country-stock-index.mjs
@@ -1,0 +1,23 @@
+export const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';
+
+export function buildCountryStockIndexSnapshot(chart, fetchedAt = new Date().toISOString()) {
+  const result = chart?.chart?.result?.[0];
+  const closes = result?.indicators?.quote?.[0]?.close?.filter((value) => Number.isFinite(value));
+  if (!Array.isArray(closes) || closes.length < 2) return null;
+
+  const weekly = closes.slice(-6);
+  const latest = weekly.at(-1);
+  const oldest = weekly[0];
+  if (!Number.isFinite(latest) || !Number.isFinite(oldest) || oldest === 0) return null;
+
+  return {
+    available: true,
+    code: 'CN',
+    symbol: '000001.SS',
+    indexName: 'SSE Composite',
+    price: +latest.toFixed(2),
+    weekChangePercent: +(((latest - oldest) / oldest) * 100).toFixed(2),
+    currency: result.meta?.currency || 'CNY',
+    fetchedAt,
+  };
+}

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1332,6 +1332,9 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     ttlSeconds,
     lockTtlMs = 120_000,
     extraKeys,
+    // Keys written outside runSeed's normal extra-key phase that still need
+    // last-good TTL protection when the primary fetch fails or is skipped.
+    preserveKeys = [],
     afterPublish,
     publishTransform,
     declareRecords,        // new — contract opt-in. When present, runSeed enters
@@ -1371,6 +1374,12 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
   }
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const startMs = Date.now();
+  const preservationKeys = () => [...new Set([
+    canonicalKey,
+    `seed-meta:${domain}:${resource}`,
+    ...(extraKeys || []).map((ek) => ek.key),
+    ...preserveKeys,
+  ].filter((key) => typeof key === 'string' && key.length > 0))];
 
   console.log(`=== ${domain}:${resource} Seed ===`);
   console.log(`  Run ID:  ${runId}`);
@@ -1416,11 +1425,9 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     try {
       if (currentPhase === 'fetch') {
         const ttl = ttlSeconds || 600;
-        const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
-        if (extraKeys) keys.push(...extraKeys.map((ek) => ek.key));
         await Promise.allSettled([
           releaseLock(`${domain}:${resource}`, runId),
-          extendExistingTtl(keys, ttl),
+          extendExistingTtl(preservationKeys(), ttl),
         ]);
       } else {
         await releaseLock(`${domain}:${resource}`, runId);
@@ -1466,9 +1473,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     console.error(`  FETCH FAILED: ${err.message || err}${cause}`);
 
     const ttl = ttlSeconds || 600;
-    const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
-    if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
-    await extendExistingTtl(keys, ttl);
+    await extendExistingTtl(preservationKeys(), ttl);
 
     console.log(`\n=== Failed gracefully (${Math.round(durationMs)}ms) ===`);
     await exitAfterTelemetryFlush(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
@@ -1559,9 +1564,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     // and /api/health already carries the alarm).
     if (contractState === 'RETRY') {
       const durationMs = Date.now() - startMs;
-      const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
-      if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
-      const preserved = await extendExistingTtl(keys, ttlSeconds || 600);
+      const preserved = await extendExistingTtl(preservationKeys(), ttlSeconds || 600);
 
       // #5256: the RETRY-FAILED exit below assumes A LATER TICK CAN RESTORE THE DATA. When
       // the seeder reports it had no usable source at all (primary unconfigured AND every
@@ -1607,9 +1610,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     const publishResult = await atomicPublish(canonicalKey, publishData, validateFn, ttlSeconds, { envelopeMeta });
     if (publishResult.skipped) {
       const durationMs = Date.now() - startMs;
-      const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
-      if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
-      await extendExistingTtl(keys, ttlSeconds || 600);
+      await extendExistingTtl(preservationKeys(), ttlSeconds || 600);
       const strictFailure = Boolean(opts.emptyDataIsFailure);
       if (strictFailure) {
         // Strict-floor seeders (e.g. IMF-External, floor=180 countries) treat

--- a/scripts/china-coverage-manifest.mjs
+++ b/scripts/china-coverage-manifest.mjs
@@ -133,7 +133,11 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
     label: 'China country market index',
     ownerIssue: 5271,
     launchStatus: 'launched',
-    transport: { key: 'market:stock-index:v1:CN', maxAgeMin: 1_440, timestampPaths: [['fetchedAt']] },
+    // The country-index RPC cache is a user-facing read-through cache. Railway
+    // seeds the same CN Yahoo source through the market bundle, so its seed
+    // metadata is the transport proof; the CN cache below proves the actual
+    // country-index payload remains available without waiting for a user read.
+    transport: metaTransport('seed-meta:market:stocks', 1_440),
     content: {
       key: 'market:stock-index:v1:CN',
       maxAgeMin: 7 * 1_440,

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -3,6 +3,7 @@
 import { loadEnvFile, loadSharedConfig, sleep, CHROME_UA, runSeed, parseYahooChart, writeExtraKey, extendExistingTtl, readCanonicalEnvelopeMeta, readSeedSnapshot, writeFreshnessMetadata } from './_seed-utils.mjs';
 import { fetchYahooJson } from './_yahoo-fetch.mjs';
 import { fetchAvBulkQuotes } from './_shared-av.mjs';
+import { CHINA_COUNTRY_STOCK_INDEX_KEY, buildCountryStockIndexSnapshot } from './_country-stock-index.mjs';
 import { getUsEquitySession, isMultiMarketEquityTradingDay } from './shared/market-hours.cjs';
 import { mergeLastGoodQuotes } from './shared/market-quote-refresh.cjs';
 
@@ -138,7 +139,7 @@ export function declareRecords(data) {
 if (!isMultiMarketEquityTradingDay()) {
   const lastGood = await readCanonicalEnvelopeMeta(CANONICAL_KEY);
   if (lastGood) {
-    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY], CACHE_TTL);
+    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, CHINA_COUNTRY_STOCK_INDEX_KEY], CACHE_TTL);
     if (extended) {
       await writeFreshnessMetadata('market', 'stocks', lastGood.recordCount, lastGood.sourceVersion || 'alphavantage+finnhub+yahoo', CACHE_TTL);
       console.log(`[seed-market-quotes] Tracked equity markets closed (US session=${getUsEquitySession()}) — skipping upstream fetch, extended TTL`);
@@ -153,6 +154,26 @@ if (!isMultiMarketEquityTradingDay()) {
 async function writeRequiredCompanionKeys(data) {
   if (!data) return;
   await writeExtraKey(RPC_KEY, data, CACHE_TTL);
+  try {
+    await writeChinaCountryStockIndex();
+  } catch (err) {
+    // A China-specific source failure must remain visible to its audit without
+    // turning an otherwise successful global market seed into a false outage.
+    console.warn(`[seed-market-quotes] China country index refresh failed: ${err.message}`);
+  }
+}
+
+async function writeChinaCountryStockIndex() {
+  // Keep the China deep-dive cache Railway-backed. The RPC may still refresh
+  // on demand, but audit health cannot depend on someone opening the panel.
+  await sleep(YAHOO_DELAY_MS);
+  const chart = await fetchYahooJson(
+    'https://query1.finance.yahoo.com/v8/finance/chart/000001.SS?range=1mo&interval=1d',
+    { label: 'China country index' },
+  );
+  const snapshot = buildCountryStockIndexSnapshot(chart);
+  if (!snapshot) throw new Error('China country index returned insufficient closes');
+  await writeExtraKey(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, CACHE_TTL);
 }
 
 runSeed('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, {
@@ -162,6 +183,10 @@ runSeed('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, {
   declareRecords,
   schemaVersion: 1,
   maxStaleMin: 30,
+  // This companion payload is written after the global market publish because
+  // it needs a different Yahoo chart shape. Preserve its last-good TTL across
+  // every runSeed graceful path, just like normal extra keys.
+  preserveKeys: [CHINA_COUNTRY_STOCK_INDEX_KEY],
   afterPublish: async (data) => {
     // runSeed exits the process on success; required companion writes must be
     // awaited here so the RPC key is published before the terminal exit.

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -159,7 +159,13 @@ async function writeRequiredCompanionKeys(data) {
   } catch (err) {
     // A China-specific source failure must remain visible to its audit without
     // turning an otherwise successful global market seed into a false outage.
-    console.warn(`[seed-market-quotes] China country index refresh failed: ${err.message}`);
+    // Preserve last-good long enough for the audit's content-age budget to
+    // distinguish a transient provider error from a missing cache.
+    const preserved = await extendExistingTtl([CHINA_COUNTRY_STOCK_INDEX_KEY], CACHE_TTL);
+    console.warn(
+      `[seed-market-quotes] China country index refresh failed: ${err.message}; `
+      + (preserved ? 'preserved last-good cache TTL' : 'no last-good cache TTL to preserve'),
+    );
   }
 }
 

--- a/server/worldmonitor/market/v1/get-country-stock-index.ts
+++ b/server/worldmonitor/market/v1/get-country-stock-index.ts
@@ -11,7 +11,7 @@ import type {
 import filterParamContracts from '../../../../shared/openapi-filter-param-contracts.json';
 import { UPSTREAM_TIMEOUT_MS, type YahooChartResponse } from './_shared';
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 // ========================================================================
 // Country-to-index mapping
@@ -23,11 +23,24 @@ const COUNTRY_INDEX = filterParamContracts.marketCountryStockIndexes as Record<s
 // Cache
 // ========================================================================
 
-const REDIS_CACHE_KEY = 'market:stock-index:v1';
+// Railway owns `market:stock-index:v1:<country>` for audit-backed snapshots.
+// Keep request-driven cachedFetchJson writes separate: a slow request that
+// ends in a negative sentinel must never overwrite the seed's last-good data.
+const REDIS_CACHE_KEY = 'market:stock-index:rpc:v1';
+const RAILWAY_SEEDED_COUNTRY_INDEX_KEY = 'market:stock-index:v1:CN';
 const REDIS_CACHE_TTL = 1800; // 30 min — weekly data, slow-moving
 
 const stockIndexCache: Record<string, { data: GetCountryStockIndexResponse; ts: number }> = {};
 const STOCK_INDEX_CACHE_TTL = 3_600_000; // 1 hour (in-memory fallback)
+
+function isAvailableCountryStockIndex(value: unknown): value is GetCountryStockIndexResponse {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && (value as GetCountryStockIndexResponse).available
+    && (value as GetCountryStockIndexResponse).code === 'CN',
+  );
+}
 
 // ========================================================================
 // Handler
@@ -46,6 +59,18 @@ export async function getCountryStockIndex(
 
   const index = COUNTRY_INDEX[code];
   if (!index) return notAvailable;
+
+  // Railway owns the CN snapshot and writes it without the Vercel environment
+  // prefix. Prefer that raw last-good payload before serving the RPC cache.
+  // The fallback cache below intentionally uses a separate key so a failed
+  // request cannot replace this seed-owned record with a negative sentinel.
+  if (code === 'CN') {
+    const railwaySnapshot = await getCachedJson(RAILWAY_SEEDED_COUNTRY_INDEX_KEY, true);
+    if (isAvailableCountryStockIndex(railwaySnapshot)) {
+      stockIndexCache[code] = { data: railwaySnapshot, ts: Date.now() };
+      return railwaySnapshot;
+    }
+  }
 
   const cached = stockIndexCache[code];
   if (cached && Date.now() - cached.ts < STOCK_INDEX_CACHE_TTL) return cached.data;

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { CHINA_COUNTRY_STOCK_INDEX_KEY, buildCountryStockIndexSnapshot } from '../scripts/_country-stock-index.mjs';
+
+const FIXED_AT = '2026-07-14T12:00:00.000Z';
+
+test('buildCountryStockIndexSnapshot writes the public CN RPC shape from a one-month Yahoo chart', () => {
+  const snapshot = buildCountryStockIndexSnapshot({
+    chart: {
+      result: [{
+        meta: { currency: 'CNY' },
+        indicators: { quote: [{ close: [3200, 3210, null, 3300, 3320, 3310, 3340, 3360, 3355] }] },
+      }],
+    },
+  }, FIXED_AT);
+
+  assert.deepEqual(snapshot, {
+    available: true,
+    code: 'CN',
+    symbol: '000001.SS',
+    indexName: 'SSE Composite',
+    price: 3355,
+    weekChangePercent: 1.67,
+    currency: 'CNY',
+    fetchedAt: FIXED_AT,
+  });
+});
+
+test('buildCountryStockIndexSnapshot rejects incomplete Yahoo charts instead of publishing an unavailable cache row', () => {
+  assert.equal(buildCountryStockIndexSnapshot({ chart: { result: [{ indicators: { quote: [{ close: [3300] }] } }] } }, FIXED_AT), null);
+});
+
+test('the Railway market seed maintains the China cache alongside its public stock bootstrap contract', () => {
+  const source = readFileSync(new URL('../scripts/seed-market-quotes.mjs', import.meta.url), 'utf8');
+
+  assert.match(source, /CHINA_COUNTRY_STOCK_INDEX_KEY/);
+  assert.match(source, /writeChinaCountryStockIndex/);
+  assert.match(source, /preserveKeys:\s*\[CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
+  assert.match(source, /China country index refresh failed/);
+  assert.match(source, /await writeExtraKey\(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, CACHE_TTL\)/);
+  assert.match(source, /extendExistingTtl\(\[CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
+});

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -33,11 +33,17 @@ test('buildCountryStockIndexSnapshot rejects incomplete Yahoo charts instead of 
 
 test('the Railway market seed maintains the China cache alongside its public stock bootstrap contract', () => {
   const source = readFileSync(new URL('../scripts/seed-market-quotes.mjs', import.meta.url), 'utf8');
+  const handlerSource = readFileSync(new URL('../server/worldmonitor/market/v1/get-country-stock-index.ts', import.meta.url), 'utf8');
 
   assert.match(source, /CHINA_COUNTRY_STOCK_INDEX_KEY/);
   assert.match(source, /writeChinaCountryStockIndex/);
   assert.match(source, /preserveKeys:\s*\[CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
   assert.match(source, /China country index refresh failed/);
+  assert.match(source, /await extendExistingTtl\(\[CHINA_COUNTRY_STOCK_INDEX_KEY\], CACHE_TTL\)/);
   assert.match(source, /await writeExtraKey\(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, CACHE_TTL\)/);
   assert.match(source, /extendExistingTtl\(\[CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
+  assert.match(handlerSource, /const REDIS_CACHE_KEY = 'market:stock-index:rpc:v1';/);
+  assert.match(handlerSource, /const RAILWAY_SEEDED_COUNTRY_INDEX_KEY = 'market:stock-index:v1:CN';/);
+  assert.match(handlerSource, /getCachedJson\(RAILWAY_SEEDED_COUNTRY_INDEX_KEY, true\)/);
+  assert.doesNotMatch(handlerSource, /const REDIS_CACHE_KEY = 'market:stock-index:v1';/);
 });

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -260,6 +260,30 @@ describe('China coverage manifest', () => {
     assert.ok(providerOmission.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL));
   });
 
+  it('uses Railway market transport plus the seeded CN index payload for China market coverage', () => {
+    const market = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'market.china-index');
+    const data = {
+      'market:stock-index:v1:CN': {
+        available: true,
+        price: 3355,
+        fetchedAt: NOW,
+      },
+    };
+
+    const healthy = evaluate(market, data, { 'seed-meta:market:stocks': { fetchedAt: NOW, status: 'ok' } });
+    assert.equal(healthy.entries[0].status, 'healthy');
+
+    const staleTransport = evaluate(market, data, {
+      'seed-meta:market:stocks': { fetchedAt: NOW - 1_441 * 60_000, status: 'ok' },
+    });
+    assert.equal(staleTransport.entries[0].status, 'degraded');
+    assert.ok(staleTransport.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.TRANSPORT_STALE));
+
+    const missingTransport = evaluate(market, data);
+    assert.equal(missingTransport.entries[0].status, 'degraded');
+    assert.ok(missingTransport.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.TRANSPORT_MISSING));
+  });
+
   it('fails read-only audits cleanly on missing credentials and partial pipelines', async () => {
     const priorUrl = process.env.UPSTASH_REDIS_REST_URL;
     const priorToken = process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/tests/country-stock-index-cache-isolation.test.mts
+++ b/tests/country-stock-index-cache-isolation.test.mts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+function restoreEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_ENV.url == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.url;
+  if (ORIGINAL_ENV.token == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.token;
+}
+
+test('CN country-index RPC prefers Railway data and leaves its key seed-owned', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  const requested = [] as string[];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    requested.push(url);
+    if (url.includes('/get/market%3Astock-index%3Av1%3ACN')) {
+      return new Response(JSON.stringify({ result: JSON.stringify({
+        available: true,
+        code: 'CN',
+        symbol: '000001.SS',
+        indexName: 'SSE Composite',
+        price: 3355,
+        weekChangePercent: 1.67,
+        currency: 'CNY',
+        fetchedAt: '2026-07-14T12:00:00.000Z',
+      }) }), { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  const { getCountryStockIndex } = await import('../server/worldmonitor/market/v1/get-country-stock-index.ts');
+  const result = await getCountryStockIndex({} as never, { countryCode: 'CN' } as never);
+
+  assert.equal(result.available, true);
+  assert.equal(result.price, 3355);
+  assert.deepEqual(requested, ['https://redis.example.test/get/market%3Astock-index%3Av1%3ACN']);
+});

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -93,7 +93,7 @@ function expireKeys() {
     .map(cmd => cmd[1]);
 }
 
-function runEmptyContractRetry(resource) {
+function runEmptyContractRetry(resource, opts = {}) {
   return runWithExitTrap(() =>
     runSeed('test', resource, `test:${resource}:v1`, async () => ({ items: [] }), {
       validateFn: (d) => Array.isArray(d?.items),
@@ -102,6 +102,7 @@ function runEmptyContractRetry(resource) {
       schemaVersion: 1,
       maxStaleMin: 120,
       declareRecords: (d) => d.items.length,
+      ...opts,
     }),
   );
 }
@@ -138,14 +139,16 @@ test('fetch failure extends existing TTL and exits with graceful-failure code', 
 
 test('contract RETRY hard-fails when expired keys make last-good preservation impossible', async () => {
   expireResult = 0;
-  const exitCode = await runEmptyContractRetry('retry-missing');
+  const exitCode = await runEmptyContractRetry('retry-missing', {
+    preserveKeys: ['test:retry-missing:preserve-only'],
+  });
 
   assert.equal(exitCode, 1,
     'zero-yield RETRY must be a hard failure when EXPIRE confirms the last-good keys are gone');
   assert.deepEqual(
     new Set(expireKeys()),
-    new Set(['test:retry-missing:v1', 'seed-meta:test:retry-missing']),
-    'RETRY must attempt to preserve both canonical and seed-meta keys before deciding its exit state',
+    new Set(['test:retry-missing:v1', 'seed-meta:test:retry-missing', 'test:retry-missing:preserve-only']),
+    'RETRY must preserve explicit companion keys before deciding its exit state',
   );
   assert.equal(countMetaSets('retry-missing'), 0,
     'a failed RETRY must not write fresh seed-meta and mask the outage');
@@ -153,14 +156,16 @@ test('contract RETRY hard-fails when expired keys make last-good preservation im
 
 test('contract RETRY remains graceful when every last-good key is preserved', async () => {
   expireResult = 1;
-  const exitCode = await runEmptyContractRetry('retry-preserved');
+  const exitCode = await runEmptyContractRetry('retry-preserved', {
+    preserveKeys: ['test:retry-preserved:preserve-only'],
+  });
 
   assert.equal(exitCode, 0,
     'zero-yield RETRY may remain exit 0 when every last-good key was actually preserved');
   assert.deepEqual(
     new Set(expireKeys()),
-    new Set(['test:retry-preserved:v1', 'seed-meta:test:retry-preserved']),
-    'RETRY must attempt to preserve both keys before treating the zero-yield run as graceful',
+    new Set(['test:retry-preserved:v1', 'seed-meta:test:retry-preserved', 'test:retry-preserved:preserve-only']),
+    'RETRY must preserve explicit companion keys before treating the zero-yield run as graceful',
   );
 });
 

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -116,6 +116,7 @@ test('fetch failure extends existing TTL and exits with graceful-failure code', 
       validateFn: (d) => Boolean(d),
       ttlSeconds: 3600,
       extraKeys: [{ key: 'test:fetch-fail:extra' }],
+      preserveKeys: ['test:fetch-fail:preserve-only'],
     }),
   );
 
@@ -126,8 +127,8 @@ test('fetch failure extends existing TTL and exits with graceful-failure code', 
   );
   assert.deepEqual(
     new Set(expireKeys()),
-    new Set(['test:fetch-fail:v1', 'seed-meta:test:fetch-fail', 'test:fetch-fail:extra']),
-    'fetch failure should still preserve last-good data by extending canonical, seed-meta, and extra-key TTLs',
+    new Set(['test:fetch-fail:v1', 'seed-meta:test:fetch-fail', 'test:fetch-fail:extra', 'test:fetch-fail:preserve-only']),
+    'fetch failure should still preserve canonical, seed-meta, extra-key, and explicitly preserved last-good TTLs',
   );
   assert.equal(
     countMetaSets('fetch-fail'), 0,


### PR DESCRIPTION
Fixes #5316. The Railway market seed now writes market:stock-index:v1:CN, treats market seed metadata as transport evidence, preserves the CN cache on every graceful seed-failure path, and covers the market audit contract with regression tests. This unblocks deployment validation for #5278 and epic #5279.