### PR TITLE
fix(health): detect vanished compact projections

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -724,6 +724,18 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'wildfiresBootstrap', // Compact dashboard side-write is absent until the first fire seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
 ]);
 
+// These compact projections must leave a payload on every successful publish.
+// This is deliberately narrower than EMPTY_DATA_OK_KEYS: DDoS, traffic, and
+// weather refresh only their seed metadata during quiet periods, so an absent
+// payload is valid for those sources.
+const MISSING_DATA_IS_FAILURE_KEYS = new Set([
+  'thermalEscalationBootstrap',
+  'ucdpEventsBootstrap',
+  'wildfiresBootstrap',
+  'forecastsBootstrap',
+  'positiveGeoEvents',
+]);
+
 // Keys where a present payload with meta recordCount=0 is valid, but the data
 // key itself must still exist. Do not use this set in the missing-key branch.
 const ZERO_RECORD_DATA_OK_KEYS = new Set([
@@ -801,12 +813,12 @@ function keyHasData(redisKey, len) {
 
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, metaReadFailed: false, metaCount: null, contentAge: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, metaReadFailed: true, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, metaReadFailed: true, metaCount: null, contentAge: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -815,7 +827,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // the dependency so behavior stays byte-identical in PR 1.
   const meta = unwrapEnvelope(parseRedisValue(keyMetaValues.get(seedCfg.key))).data;
   if (meta?.status === 'error') {
-    return { seedAge: null, seedStale: true, seedError: true, sourceUnavailable: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return { hasMeta: true, seedAge: null, seedStale: true, seedError: true, sourceUnavailable: false, metaReadFailed: false, metaCount: null, contentAge: null };
   }
   let seedAge = null;
   let seedStale = true;
@@ -863,7 +875,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
-  return { seedAge, seedStale, seedError: sourceDegraded, sourceUnavailable, metaReadFailed: false, metaCount, contentAge };
+  return { hasMeta: meta != null, seedAge, seedStale, seedError: sourceDegraded, sourceUnavailable, metaReadFailed: false, metaCount, contentAge };
 }
 
 function isCascadeCovered(name, hasData, keyStrens, keyErrors) {
@@ -898,7 +910,7 @@ function classifyKey(name, redisKey, opts, ctx) {
 
   const strlen = keyStrens.get(redisKey) ?? 0;
   const hasData = keyHasData(redisKey, strlen);
-  const { seedAge, seedStale, seedError, sourceUnavailable, metaCount, contentAge } = meta;
+  const { hasMeta, seedAge, seedStale, seedError, sourceUnavailable, metaCount, contentAge } = meta;
 
   // When the data key is gone the meta count is meaningless; force records=0
   // so we never display the contradictory "EMPTY records=N>0" pair (item 1).
@@ -915,6 +927,7 @@ function classifyKey(name, redisKey, opts, ctx) {
   else if (seedError) status = 'SEED_ERROR';
   else if (!hasData) {
     if (cascadeCovered) status = 'OK_CASCADE';
+    else if (MISSING_DATA_IS_FAILURE_KEYS.has(name) && hasMeta && seedStale !== true) status = 'EMPTY';
     else if (EMPTY_DATA_OK_KEYS.has(name)) status = seedStale === true ? 'STALE_SEED' : 'OK';
     else if (isOnDemand) status = 'EMPTY_ON_DEMAND';
     else status = 'EMPTY';

--- a/api/health.js
+++ b/api/health.js
@@ -730,7 +730,9 @@ const EMPTY_DATA_OK_KEYS = new Set([
 // These compact projections must leave a payload on every successful publish.
 // This is deliberately narrower than EMPTY_DATA_OK_KEYS: DDoS, traffic, and
 // weather refresh only their seed metadata during quiet periods, so an absent
-// payload is valid for those sources.
+// payload is valid for those sources. Every entry here must also be in
+// EMPTY_DATA_OK_KEYS so a pre-first-publish absence remains STALE_SEED rather
+// than a false-critical EMPTY; tests/health-empty-data-ok.test.mjs enforces it.
 const MISSING_DATA_IS_FAILURE_KEYS = new Set([
   'thermalEscalationBootstrap',
   'ucdpEventsBootstrap',
@@ -1622,5 +1624,6 @@ export const __testing__ = {
   STANDALONE_KEYS,
   SEED_META,
   EMPTY_DATA_OK_KEYS,
+  MISSING_DATA_IS_FAILURE_KEYS,
   ZERO_RECORD_DATA_OK_KEYS,
 };

--- a/api/health.js
+++ b/api/health.js
@@ -718,10 +718,13 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'cableHealth', // `cables: {}` = no active subsea cable disruptions per NGA NAVAREA warnings — all cables implicitly healthy. Also covers NGA-upstream-down windows where get-cable-health writes back the fallback response (empty cables); without this, those would alarm EMPTY_DATA.
   'forecastBets', // #5233 shadow bet-engine stream; absent before the cron ships it and empty on weeks the energy feed yields no bet — tolerate as STALE_SEED (warn), not EMPTY (crit).
   'forecastFunnel', // #5233 funnel guardrail is a new afterPublish side-write; before the first seed-forecasts run ships it the key is absent — tolerate as STALE_SEED (warn), not EMPTY (crit). A COLLAPSED funnel still surfaces via seed-meta status:'error' → SEED_ERROR, which classifyKey checks before this branch.
-  'thermalEscalationBootstrap', // Compact dashboard projection is absent until the first thermal seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
-  'ucdpEventsBootstrap', // Compact dashboard projection is absent until the first ucdp seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
-  'forecastsBootstrap', // Dashboard list is absent until the first seed-forecasts tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit).
-  'wildfiresBootstrap', // Compact dashboard side-write is absent until the first fire seeder tick after deploy — tolerate as STALE_SEED (warn), not EMPTY (crit). Once published, seed-meta staleness still catches a stopped writer.
+  // Compact projections stay STALE_SEED before their first producer tick or
+  // after metadata turns stale. Fresh metadata plus a missing payload is
+  // deliberately strict: MISSING_DATA_IS_FAILURE_KEYS reports EMPTY (crit).
+  'thermalEscalationBootstrap',
+  'ucdpEventsBootstrap',
+  'forecastsBootstrap',
+  'wildfiresBootstrap',
 ]);
 
 // These compact projections must leave a payload on every successful publish.

--- a/docs/solutions/logic-errors/bootstrap-key-health-missing-payload.md
+++ b/docs/solutions/logic-errors/bootstrap-key-health-missing-payload.md
@@ -1,0 +1,70 @@
+---
+title: Bootstrap health reports missing compact projections as EMPTY
+date: 2026-07-14
+category: logic-errors
+module: api/health.js
+problem_type: logic_error
+component: service_object
+severity: high
+symptoms:
+  - "Fresh seed metadata with a missing compact projection payload reported OK in /api/health."
+  - "Dashboard panels could render blank without an actionable health signal."
+root_cause: logic_error
+resolution_type: code_fix
+tags: [bootstrap-hydration, seed-meta, freshness-tracking, redis, health]
+---
+
+# Bootstrap health reports missing compact projections as EMPTY
+
+## Problem
+
+[`/api/health`](../../../api/health.js) previously allowed every `EMPTY_DATA_OK` source to report `OK` when its `seed-meta` was fresh, even if its Redis payload was absent. That contract was too broad for compact bootstrap projections: a writer or transform failure could blank a user-facing panel while health remained green. The affected issue is [#5321](https://github.com/koala73/worldmonitor/issues/5321).
+
+`api/health.js:710-725` puts both quiet metadata-only sources and bootstrap projections in `EMPTY_DATA_OK_KEYS`. Treating both categories alike erased the distinction between an expected quiet result and a missing required projection.
+
+## Symptoms
+
+- Health reported `OK` for a fresh bootstrap seed even though its data key was gone.
+- Panels backed by compact projections could render empty without an actionable health signal.
+- Operators could not distinguish a quiet successful source cycle from a missing projection payload.
+
+## What Didn't Work
+
+Making every `EMPTY_DATA_OK` key fail when the payload was missing would have fixed the projection blind spot, but it would also have broken normal quiet-source behavior. `ddosAttacks`, `trafficAnomalies`, `weatherAlerts`, and `newsThreatSummary` legitimately write fresh metadata without a payload after a successful quiet cycle; they must remain healthy in that state. The test contract at `tests/health-empty-data-ok.test.mjs:16-92` covers this distinction.
+
+Earlier bootstrap work had correctly added compact dashboard-shaped side keys, but it also showed that a side key needs its own availability signal; healthy metadata alone cannot prove that a required projection is present (session history).
+
+## Solution
+
+Keep the broad `EMPTY_DATA_OK_KEYS` list, then add an explicit strict subset for projections that must have a payload:
+
+```js
+const MISSING_DATA_IS_FAILURE_KEYS = new Set([
+  'thermalEscalationBootstrap',
+  'ucdpEventsBootstrap',
+  'wildfiresBootstrap',
+  'forecastsBootstrap',
+  'positiveGeoEvents',
+]);
+```
+
+The set is defined at `api/health.js:727-737`. In the health evaluation, a strict key with fresh seed metadata and no data key now reports `EMPTY` before the general `EMPTY_DATA_OK` path runs. All other `EMPTY_DATA_OK` keys retain the prior `OK`-when-fresh and stale-status behavior (`api/health.js:926-933`).
+
+## Why This Works
+
+The check is narrow and expresses the real operational invariant: the five named projections represent expected bootstrap data, whereas the quiet sources represent an optional observation that may legitimately have no payload. Giving strict missing-payload detection precedence catches projection writer and transform failures without turning expected no-event cycles into false alarms. The exact source categorization is visible in `api/health.js:710-737`, and the two resulting contracts are exercised in `tests/health-empty-data-ok.test.mjs:16-92`: strict keys are expected to be `EMPTY`, while quiet keys are expected to be `OK`.
+
+## Prevention
+
+When adding a source to `EMPTY_DATA_OK_KEYS`, decide explicitly which contract it needs:
+
+- Quiet or metadata-only sources may stay in the general list, where fresh metadata plus no payload is healthy.
+- Bootstrap projections or other data-required outputs must also be added to `MISSING_DATA_IS_FAILURE_KEYS` so a missing fresh payload is visible as `EMPTY`.
+
+Extend `tests/health-empty-data-ok.test.mjs` with both the intended strict and quiet expectation for any new category. This protects the distinction at the Vercel Edge health endpoint instead of relying on an implicit interpretation of `EMPTY_DATA_OK`.
+
+## Related Issues
+
+- [#5321: health: EMPTY_DATA_OK bootstrap projections report OK while their key is GONE](https://github.com/koala73/worldmonitor/issues/5321)
+- [Health must not grade an unconfigured optional source](health-must-not-grade-an-unconfigured-optional-source.md) — related classifier precedent for preserving an actionable source-state distinction.
+- [Merged is not ran long cron seeders](../integration-issues/merged-is-not-ran-long-cron-seeders.md) — distinguishes this fresh-metadata/missing-payload condition from a producer that has not run.

--- a/tests/health-empty-data-ok.test.mjs
+++ b/tests/health-empty-data-ok.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ as healthTesting } from '../api/health.js';
+
+const {
+  BOOTSTRAP_KEYS,
+  EMPTY_DATA_OK_KEYS,
+  SEED_META,
+  STANDALONE_KEYS,
+  STATUS_COUNTS,
+  classifyKey,
+} = healthTesting;
+const NOW = 1_700_000_000_000;
+
+// Successful publishers for these compact projections always leave a payload. A
+// missing key after a fresh meta is therefore a failed publish, not quiet data.
+const STRICT_PROJECTIONS = [
+  'thermalEscalationBootstrap',
+  'ucdpEventsBootstrap',
+  'wildfiresBootstrap',
+  'forecastsBootstrap',
+  'positiveGeoEvents',
+];
+
+// These sources intentionally refresh only metadata on quiet cycles, so a missing
+// payload with fresh metadata remains healthy rather than generating a false alarm.
+const QUIET_META_ONLY_KEYS = [
+  'ddosAttacks',
+  'trafficAnomalies',
+  'weatherAlerts',
+  'newsThreatSummary',
+];
+
+function classifyMissing(name, meta) {
+  const redisKey = BOOTSTRAP_KEYS[name] ?? STANDALONE_KEYS[name];
+  const seedCfg = SEED_META[name];
+  return classifyKey(name, redisKey, { allowOnDemand: false }, {
+    keyStrens: new Map([[redisKey, 0]]),
+    keyErrors: new Map(),
+    keyMetaValues: meta == null ? new Map() : new Map([[seedCfg.key, JSON.stringify(meta)]]),
+    keyMetaErrors: new Map(),
+    now: NOW,
+  });
+}
+
+test('published strict projections escalate when their data key vanishes', () => {
+  for (const name of STRICT_PROJECTIONS) {
+    const seedCfg = SEED_META[name];
+    assert.ok(EMPTY_DATA_OK_KEYS.has(name), `${name} remains tolerant of a present empty payload`);
+    assert.ok(seedCfg, `${name} has seed metadata that records a successful publication`);
+
+    const entry = classifyMissing(name, {
+      fetchedAt: NOW - Math.floor(seedCfg.maxStaleMin / 2) * 60_000,
+      recordCount: 0,
+    });
+    assert.equal(entry.status, 'EMPTY', `${name}: fresh metadata + missing key is a vanished projection`);
+    assert.equal(STATUS_COUNTS[entry.status], 'crit', `${name}: vanished projection must be critical`);
+    assert.equal(entry.records, 0);
+  }
+});
+
+test('strict projections retain cold-start and stale-seed handling', () => {
+  for (const name of STRICT_PROJECTIONS) {
+    const seedCfg = SEED_META[name];
+
+    assert.equal(
+      classifyMissing(name).status,
+      'STALE_SEED',
+      `${name}: no metadata means it has never been published, not that it vanished`,
+    );
+    assert.equal(
+      classifyMissing(name, {
+        fetchedAt: NOW - (seedCfg.maxStaleMin + 1) * 60_000,
+        recordCount: 0,
+      }).status,
+      'STALE_SEED',
+      `${name}: a late publisher remains a stale-seed warning`,
+    );
+  }
+});
+
+test('quiet metadata-only sources remain healthy while their payload is absent', () => {
+  for (const name of QUIET_META_ONLY_KEYS) {
+    const seedCfg = SEED_META[name];
+    const entry = classifyMissing(name, {
+      fetchedAt: NOW - Math.floor(seedCfg.maxStaleMin / 2) * 60_000,
+      recordCount: 0,
+    });
+    assert.equal(entry.status, 'OK', `${name}: a quiet successful cycle may publish metadata without a payload`);
+    assert.equal(STATUS_COUNTS[entry.status], 'ok');
+  }
+});

--- a/tests/health-empty-data-ok.test.mjs
+++ b/tests/health-empty-data-ok.test.mjs
@@ -6,6 +6,7 @@ import { __testing__ as healthTesting } from '../api/health.js';
 const {
   BOOTSTRAP_KEYS,
   EMPTY_DATA_OK_KEYS,
+  MISSING_DATA_IS_FAILURE_KEYS,
   SEED_META,
   STANDALONE_KEYS,
   STATUS_COUNTS,
@@ -15,13 +16,7 @@ const NOW = 1_700_000_000_000;
 
 // Successful publishers for these compact projections always leave a payload. A
 // missing key after a fresh meta is therefore a failed publish, not quiet data.
-const STRICT_PROJECTIONS = [
-  'thermalEscalationBootstrap',
-  'ucdpEventsBootstrap',
-  'wildfiresBootstrap',
-  'forecastsBootstrap',
-  'positiveGeoEvents',
-];
+const STRICT_PROJECTIONS = [...MISSING_DATA_IS_FAILURE_KEYS];
 
 // These sources intentionally refresh only metadata on quiet cycles, so a missing
 // payload with fresh metadata remains healthy rather than generating a false alarm.


### PR DESCRIPTION
## Summary

A failed or expired compact projection can no longer leave its panel blank while `/api/health` reports it healthy. Fresh metadata now proves a missing strict projection is an `EMPTY` critical condition.

The rule is intentionally scoped: DDoS, traffic, weather, and news-threat feeds may legitimately emit metadata without a payload on quiet cycles, so they remain healthy rather than false-paging.

Fixes #5321.

## Validation

- `node --import tsx --test --test-concurrency=16 tests/*.test.mjs tests/*.test.mts cli/test/*.test.mjs api/security/report.test.mjs`
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint` (existing unrelated Biome warnings remain; the safe-HTML guard passes)
- `npm run lint:md`
- Pre-push gate: typechecks, edge bundle/tests, and policy guards passed.

## Post-Deploy Monitoring & Validation

- Owner: WorldMonitor on-call; window: first 24 hours after deploy.
- Inspect `/api/health` `checks` for `thermalEscalationBootstrap`, `ucdpEventsBootstrap`, `wildfiresBootstrap`, `forecastsBootstrap`, and `positiveGeoEvents`.
- Expected: a missing strict key with fresh seed metadata shows `EMPTY`, `records: 0`, and contributes to critical health; DDoS, traffic, weather, and news-threat quiet runs stay `OK`.
- Failure signal / mitigation: any recurring critical result during a known quiet source cycle means the strict projection set is too broad; revert this commit and inspect the producer's write contract.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)