### PR TITLE
fix(news): audit China source coverage by locale

### DIFF
--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -200,8 +200,10 @@ prevents a global JODI heartbeat from being presented as China coverage.
 
 The globally ranked insights payload is likewise not used as China feed-health
 evidence: a current top-eight can legitimately contain no China story. The
-China news contract stays blocked until a source-specific coverage metric is
-persisted with the digest.
+insights seeder persists a separate China-source projection for Xinhua, MIIT,
+and MOFCOM. It records each source as available only when the digest fetch
+completed with dated content; a timeout, empty response, or undated feed stays
+visible as degraded coverage.
 
 The hourly Railway China coverage evaluator checks the transport heartbeat and
 content freshness independently for every launched contract. It uses the

--- a/docs/solutions/logic-errors/locale-specific-china-news-coverage-projection.md
+++ b/docs/solutions/logic-errors/locale-specific-china-news-coverage-projection.md
@@ -1,6 +1,7 @@
 ---
 title: Keep China news coverage projections locale-aware
 date: 2026-07-14
+last_updated: 2026-07-14
 category: logic-errors
 module: News insights seeder and China coverage audit
 problem_type: logic_error
@@ -44,18 +45,19 @@ export const CHINA_NEWS_SOURCES = Object.freeze([
 
 `scripts/seed-insights.mjs` reads the normal English digest, reads or warms the supplemental Chinese digest, and passes both to `buildChinaNewsCoverage`. The helper emits `available` only for a digest with a valid `generatedAt` timestamp and no exceptional feed status; absent, timeout, all-undated, and missing-locale cases remain unavailable.
 
-Publish the projection separately at `news:insights:v1:CN`. Strip it from the canonical `news:insights:v1` payload, so the user-facing global digest contract remains unchanged. The China manifest requires all three named sources to be available and timestamped before `news.china` is healthy.
+Publish the projection separately at `news:insights:v1:CN`. Strip it from the canonical `news:insights:v1` payload, so the user-facing global digest contract remains unchanged. When a fresh digest run retains a last-known-good global brief, carry the fresh projection through that return solely for `afterPublish`; the transform still removes it before the public payload is written. The China manifest requires all three named sources to be available and timestamped before `news.china` is healthy.
 
 ## Why This Works
 
 `list-feed-digest` stores results under `news:digest:v1:${variant}:${lang}`, so its per-feed status is authoritative only for the requested locale. Evaluating each source against its own locale prevents missing Chinese feeds from being interpreted as normal absent-status entries.
 
-The Chinese check is supplemental: its failure is caught and produces an unavailable projection rather than preventing the existing global insights seed from publishing. If the global seed falls back to last-known-good data with no new projection, the old projection is only TTL-extended and the audit eventually reports it stale instead of green.
+The Chinese check is supplemental: its failure is caught and produces an unavailable projection rather than preventing the existing global insights seed from publishing. A brief-only degradation can retain the last-known-good global payload while still publishing fresh source evidence. If the English digest itself is unavailable, there is no new projection, so the old projection is only TTL-extended and the audit eventually reports it stale instead of green.
 
 ## Prevention
 
 - For a country-specific audit built from locale-filtered inputs, record the locale beside every source and test a missing supplemental digest explicitly.
 - Keep audit-only projections separate from ranked or public payloads, then make the audit require the projection's per-source timestamps and statuses.
+- Test the last-known-good branch separately: preserve fresh audit-only evidence when the public payload falls back for an unrelated brief-generation failure.
 
 ## Related Issues
 

--- a/docs/solutions/logic-errors/locale-specific-china-news-coverage-projection.md
+++ b/docs/solutions/logic-errors/locale-specific-china-news-coverage-projection.md
@@ -1,0 +1,63 @@
+---
+title: Keep China news coverage projections locale-aware
+date: 2026-07-14
+category: logic-errors
+module: News insights seeder and China coverage audit
+problem_type: logic_error
+component: background_job
+symptoms:
+  - A successful English digest could be mistaken for successful Chinese-source coverage
+  - China news audit status could become healthy while MIIT or MOFCOM had not been evaluated
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags: [china-coverage, news-insights, locale-digest, seed-audit]
+---
+
+# Keep China news coverage projections locale-aware
+
+## Problem
+
+The global insights payload is ranked and locale-specific. It cannot prove that every China source completed: Xinhua belongs to the English digest, while MIIT and MOFCOM belong to the Chinese digest. A source-status projection built from only the English digest would treat the absent Chinese entries as successful.
+
+## Symptoms
+
+- The China coverage manifest could mark `news.china` launched without a source-level Chinese digest check.
+- A healthy English digest could mask an unavailable or stale MIIT or MOFCOM feed.
+
+## What Didn't Work
+
+- Inferring source health from globally ranked top stories loses per-feed outcomes after ranking.
+- Reading only `news:digest:v1:full:en` is insufficient because the feed-digest cache key includes the requested locale.
+
+## Solution
+
+Define each audited China source with the locale of the digest that evaluates it:
+
+```js
+export const CHINA_NEWS_SOURCES = Object.freeze([
+  { source: 'Xinhua', digestLanguage: 'en' },
+  { source: 'MIIT (China)', digestLanguage: 'zh' },
+  { source: 'MOFCOM (China)', digestLanguage: 'zh' },
+]);
+```
+
+`scripts/seed-insights.mjs` reads the normal English digest, reads or warms the supplemental Chinese digest, and passes both to `buildChinaNewsCoverage`. The helper emits `available` only for a digest with a valid `generatedAt` timestamp and no exceptional feed status; absent, timeout, all-undated, and missing-locale cases remain unavailable.
+
+Publish the projection separately at `news:insights:v1:CN`. Strip it from the canonical `news:insights:v1` payload, so the user-facing global digest contract remains unchanged. The China manifest requires all three named sources to be available and timestamped before `news.china` is healthy.
+
+## Why This Works
+
+`list-feed-digest` stores results under `news:digest:v1:${variant}:${lang}`, so its per-feed status is authoritative only for the requested locale. Evaluating each source against its own locale prevents missing Chinese feeds from being interpreted as normal absent-status entries.
+
+The Chinese check is supplemental: its failure is caught and produces an unavailable projection rather than preventing the existing global insights seed from publishing. If the global seed falls back to last-known-good data with no new projection, the old projection is only TTL-extended and the audit eventually reports it stale instead of green.
+
+## Prevention
+
+- For a country-specific audit built from locale-filtered inputs, record the locale beside every source and test a missing supplemental digest explicitly.
+- Keep audit-only projections separate from ranked or public payloads, then make the audit require the projection's per-source timestamps and statuses.
+
+## Related Issues
+
+- [Issue #5272](https://github.com/koala73/worldmonitor/issues/5272)
+- [Issue #5278](https://github.com/koala73/worldmonitor/issues/5278)

--- a/scripts/_china-news-coverage.mjs
+++ b/scripts/_china-news-coverage.mjs
@@ -1,0 +1,50 @@
+// Compact China-source health projection for the insights seeder. The digest
+// intentionally records only exceptional feed states: an absent feedStatuses
+// entry means that feed completed with at least one dated item. This projection
+// keeps that source-level truth separate from the globally ranked top stories.
+
+export const CHINA_NEWS_SOURCES = Object.freeze([
+  { source: 'Xinhua', digestLanguage: 'en' },
+  { source: 'MIIT (China)', digestLanguage: 'zh' },
+  { source: 'MOFCOM (China)', digestLanguage: 'zh' },
+]);
+
+export const CHINA_NEWS_SOURCE_NAMES = Object.freeze(CHINA_NEWS_SOURCES.map(({ source }) => source));
+
+const AVAILABLE_FEED_STATUSES = new Set([undefined, 'partial-undated']);
+
+function toIsoTimestamp(value) {
+  const ms = typeof value === 'number' ? value : Date.parse(value ?? '');
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+export function buildChinaNewsCoverage(digestsByLanguage = {}) {
+  const sources = CHINA_NEWS_SOURCES.map(({ source, digestLanguage }) => {
+    const digest = digestsByLanguage[digestLanguage];
+    if (!digest || typeof digest !== 'object') {
+      return { source, status: 'unavailable', reason: 'digest_unavailable' };
+    }
+    const observedAt = toIsoTimestamp(digest.generatedAt);
+    const feedStatuses = digest.feedStatuses && typeof digest.feedStatuses === 'object'
+      ? digest.feedStatuses
+      : {};
+    const reason = feedStatuses[source];
+    if (!observedAt) {
+      return { source, status: 'unavailable', reason: 'digest_timestamp_missing' };
+    }
+    if (!AVAILABLE_FEED_STATUSES.has(reason)) {
+      return { source, status: 'unavailable', reason: typeof reason === 'string' ? reason : 'unknown' };
+    }
+    return {
+      source,
+      status: 'available',
+      observedAt,
+      ...(reason ? { reason } : {}),
+    };
+  });
+
+  return {
+    countryCode: 'CN',
+    sources,
+  };
+}

--- a/scripts/china-coverage-manifest.mjs
+++ b/scripts/china-coverage-manifest.mjs
@@ -2,6 +2,8 @@
 // change their domain implementations, but they extend this manifest only after
 // the serialized shared-registry frontier reaches them (issue #5271).
 
+import { CHINA_NEWS_SOURCE_NAMES } from './_china-news-coverage.mjs';
+
 export const CHINA_COVERAGE_SUMMARY_KEY = 'health:china-coverage:v1';
 export const CHINA_COVERAGE_SEED_META_KEY = 'seed-meta:health:china-coverage';
 export const CHINA_COVERAGE_ACTIVATION_KEY = 'seed-activated:health:china-coverage';
@@ -148,22 +150,22 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
     id: 'news.china',
     label: 'China news digest',
     ownerIssue: 5272,
-    // `news:insights:v1` stores only the globally ranked top stories. It
-    // cannot prove that a China source was reachable when other news ranks
-    // higher, so keep this contract blocked until a source-specific metric is
-    // persisted alongside the digest.
-    launchStatus: 'blocked',
-    blockedReason: CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PROJECTION_UNAVAILABLE,
+    launchStatus: 'launched',
     transport: metaTransport('seed-meta:news:insights', 30),
     content: {
-      key: 'news:insights:v1',
+      // The canonical digest remains globally ranked. The insights seeder
+      // writes this source-status projection before ranking, so a China feed
+      // that is merely outranked cannot look like a China coverage outage.
+      key: 'news:insights:v1:CN',
       maxAgeMin: 7 * 1_440,
       probe: {
-        kind: 'array-match',
-        path: ['topStories'],
-        field: 'countryCode',
-        values: ['CN'],
-        timestampPaths: [['pubDate'], ['lastUpdated']],
+        kind: 'array-coverage',
+        path: ['sources'],
+        field: 'source',
+        values: CHINA_NEWS_SOURCE_NAMES,
+        validField: 'status',
+        validValues: ['available'],
+        timestampPaths: [['observedAt']],
       },
     },
   },

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -487,6 +487,14 @@ async function readChinaNewsDigest() {
   }
 }
 
+// A degraded global brief may reuse the last known-good public payload even
+// though this run obtained fresh per-source digest evidence. Keep that audit
+// projection attached for afterPublish; publishTransform still prevents it
+// from entering the public insights cache.
+export function preserveChinaNewsCoverageInLkg(existing, chinaNewsCoverage) {
+  return chinaNewsCoverage ? { ...existing, chinaNewsCoverage } : existing;
+}
+
 async function fetchInsights() {
   const digest = await readOrWarmDigest('en');
   if (!digest) {
@@ -703,7 +711,7 @@ async function fetchInsights() {
     const existing = await readExistingInsights();
     if (existing?.status === 'ok') {
       console.log('  LKG preservation: existing payload is "ok", skipping degraded overwrite');
-      return existing;
+      return preserveChinaNewsCoverageInLkg(existing, chinaNewsCoverage);
     }
   }
 

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -512,7 +512,7 @@ async function fetchInsights() {
   // a compact, audit-only projection before the global ranking can discard it.
   const chinaNewsCoverage = buildChinaNewsCoverage({
     en: digest,
-    zh: await readChinaNewsDigest(),
+    [CHINA_NEWS_DIGEST_LANGUAGE]: await readChinaNewsDigest(),
   });
 
   // Digest shape: { categories: { politics: { items: [...] }, ... }, feedStatuses, generatedAt }

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, getRedisCredentials, runSeed, withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError } from './_seed-utils.mjs';
+import {
+  loadEnvFile,
+  CHROME_UA,
+  getRedisCredentials,
+  runSeed,
+  withRetry,
+  httpRetryError,
+  createLlmBudgetError,
+  extendExistingTtl,
+  isLlmBudgetError,
+  writeExtraKey,
+} from './_seed-utils.mjs';
 import {
   clusterItems,
   computeEntityCorroboration,
@@ -9,6 +20,7 @@ import {
   ENTITY_BIGRAMS,
 } from './_clustering.mjs';
 import { extractCountryCode } from './shared/geo-extract.mjs';
+import { buildChinaNewsCoverage } from './_china-news-coverage.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import {
   pickBriefCluster,
@@ -48,6 +60,8 @@ if (_isDirectRun) loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'news:insights:v1';
 const DIGEST_KEY = 'news:digest:v1:full:en';
+const CHINA_COVERAGE_KEY = 'news:insights:v1:CN';
+const CHINA_NEWS_DIGEST_LANGUAGE = 'zh';
 
 // Defense-in-depth auth — see seed-infra.mjs for the same pattern + rationale.
 // Set WORLDMONITOR_RELAY_KEY on the Railway service (must match a value in
@@ -178,9 +192,13 @@ async function generateLegacySingleHeadlineBrief(topStories) {
   };
 }
 
-async function readDigestFromRedis() {
+function digestKeyForLanguage(language) {
+  return `news:digest:v1:full:${language}`;
+}
+
+async function readDigestFromRedis(key = DIGEST_KEY) {
   const { url, token } = getRedisCredentials();
-  const resp = await fetch(`${url}/get/${encodeURIComponent(DIGEST_KEY)}`, {
+  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(5_000),
   });
@@ -422,7 +440,7 @@ function buildImportanceObservability(clusters, topStories) {
   };
 }
 
-async function warmDigestCache() {
+async function warmDigestCache(language = 'en') {
   const apiBase = process.env.API_BASE_URL || 'https://api.worldmonitor.app';
   const headers = {
     'User-Agent': CHROME_UA,
@@ -430,11 +448,11 @@ async function warmDigestCache() {
   };
   if (RELAY_API_KEY) headers['X-WorldMonitor-Key'] = RELAY_API_KEY;
   try {
-    const resp = await fetch(`${apiBase}/api/news/v1/list-feed-digest?variant=full&lang=en`, {
+    const resp = await fetch(`${apiBase}/api/news/v1/list-feed-digest?variant=full&lang=${encodeURIComponent(language)}`, {
       headers,
       signal: AbortSignal.timeout(30_000),
     });
-    if (resp.ok) console.log('  Digest cache warmed via RPC');
+    if (resp.ok) console.log(`  ${language} digest cache warmed via RPC`);
     else {
       const keyNote = RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
       console.warn(`  Digest warm failed: HTTP ${resp.status}${keyNote}`);
@@ -444,15 +462,33 @@ async function warmDigestCache() {
   }
 }
 
-async function fetchInsights() {
-  let digest = await readDigestFromRedis();
-  if (!digest) {
-    console.log('  Digest not in Redis, warming cache via RPC...');
-    await warmDigestCache();
-    // Wait for RPC write to propagate to Redis
-    await new Promise(r => setTimeout(r, 3_000));
-    digest = await readDigestFromRedis();
+async function readOrWarmDigest(language) {
+  const key = digestKeyForLanguage(language);
+  let digest = await readDigestFromRedis(key);
+  if (digest) return digest;
+  console.log(`  ${language} digest not in Redis, warming cache via RPC...`);
+  await warmDigestCache(language);
+  // Wait for the Edge write to propagate before the readback. This is the
+  // existing full/en warm-cache contract, now reused for the Chinese digest.
+  await new Promise(r => setTimeout(r, 3_000));
+  digest = await readDigestFromRedis(key);
+  return digest;
+}
+
+async function readChinaNewsDigest() {
+  try {
+    return await readOrWarmDigest(CHINA_NEWS_DIGEST_LANGUAGE);
+  } catch (err) {
+    // China-source coverage must degrade independently. A Redis or Edge
+    // failure for the supplemental locale digest must not suppress the global
+    // insights payload that the existing English path can still publish.
+    console.warn(`  ${CHINA_NEWS_DIGEST_LANGUAGE} digest coverage check failed: ${err.message}`);
+    return null;
   }
+}
+
+async function fetchInsights() {
+  const digest = await readOrWarmDigest('en');
   if (!digest) {
     // LKG fallback: reuse existing insights if digest is unavailable
     const existing = await readExistingInsights();
@@ -462,6 +498,14 @@ async function fetchInsights() {
     }
     throw new Error('No news digest found in Redis');
   }
+
+  // The global top-eight list is intentionally rank-limited and cannot prove
+  // that a China source completed. Preserve the digest's per-feed outcome as
+  // a compact, audit-only projection before the global ranking can discard it.
+  const chinaNewsCoverage = buildChinaNewsCoverage({
+    en: digest,
+    zh: await readChinaNewsDigest(),
+  });
 
   // Digest shape: { categories: { politics: { items: [...] }, ... }, feedStatuses, generatedAt }
   let items;
@@ -651,6 +695,7 @@ async function fetchInsights() {
     fastMovingCount,
     importanceSignals: observability,
     provenance,
+    chinaNewsCoverage,
   };
 
   // LKG preservation: don't overwrite "ok" with "degraded"
@@ -684,6 +729,20 @@ if (_isDirectRun) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 30,
+    // The source-status projection is not user-facing digest content. It is
+    // retained separately so the China audit can distinguish an unavailable
+    // source from a globally outranked one without changing the public payload.
+    preserveKeys: [CHINA_COVERAGE_KEY],
+    publishTransform: ({ chinaNewsCoverage: _chinaNewsCoverage, ...payload }) => payload,
+    afterPublish: async (data) => {
+      if (!data?.chinaNewsCoverage) {
+        // LKG fallback predates the projection. Keep its timestamp honest: an
+        // extended old projection will become CONTENT_STALE rather than green.
+        await extendExistingTtl([CHINA_COVERAGE_KEY], CACHE_TTL);
+        return;
+      }
+      await writeExtraKey(CHINA_COVERAGE_KEY, data.chinaNewsCoverage, CACHE_TTL);
+    },
   }).catch(async (err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
     // Exit gracefully for cron — health endpoint flags stale data via

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -104,13 +104,18 @@ describe('China coverage manifest', () => {
       'launched',
       'the canonical per-hub coverage contract is now provider-backed',
     );
-    for (const id of ['energy.jodi-oil', 'energy.jodi-gas', 'news.china']) {
+    for (const id of ['energy.jodi-oil', 'energy.jodi-gas']) {
       assert.equal(
         CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === id)?.launchStatus,
         'blocked',
         `${id} must remain explicit until its source-specific China contract is available`,
       );
     }
+    assert.equal(
+      CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'news.china')?.launchStatus,
+      'launched',
+      'China news is now backed by a source-specific projection, not global ranking',
+    );
     assert.deepEqual(
       CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'aviation.china-hubs')?.content.probe,
       {
@@ -284,6 +289,36 @@ describe('China coverage manifest', () => {
     assert.ok(missingTransport.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.TRANSPORT_MISSING));
   });
 
+  it('uses the source-specific China news projection rather than global top stories', () => {
+    const news = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'news.china');
+    const data = {
+      'news:insights:v1:CN': {
+        countryCode: 'CN',
+        sources: ['Xinhua', 'MIIT (China)', 'MOFCOM (China)'].map((source) => ({
+          source,
+          status: 'available',
+          observedAt: new Date(NOW).toISOString(),
+        })),
+      },
+    };
+    const healthy = evaluate(news, data, { 'seed-meta:news:insights': { fetchedAt: NOW, status: 'ok' } });
+    assert.equal(healthy.entries[0].status, 'healthy');
+
+    const sourceOutage = evaluate(news, {
+      'news:insights:v1:CN': {
+        countryCode: 'CN',
+        sources: data['news:insights:v1:CN'].sources.map((row) => (
+          row.source === 'MIIT (China)' ? { source: row.source, status: 'unavailable', reason: 'timeout' } : row
+        )),
+      },
+    }, { 'seed-meta:news:insights': { fetchedAt: NOW, status: 'ok' } });
+    assert.equal(sourceOutage.entries[0].status, 'degraded');
+    assert.deepEqual(sourceOutage.entries[0].content, {
+      status: 'partial', ageMin: null, maxAgeMin: 10_080, required: 3, present: 2,
+    });
+    assert.ok(sourceOutage.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL));
+  });
+
   it('fails read-only audits cleanly on missing credentials and partial pipelines', async () => {
     const priorUrl = process.env.UPSTASH_REDIS_REST_URL;
     const priorToken = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -450,13 +485,13 @@ describe('China coverage evaluator', () => {
   });
 
   it('reports a stable reason when a China contract is blocked', () => {
-    const blocked = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'news.china');
+    const blocked = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'energy.jodi-oil');
     const result = evaluate(blocked);
 
     assert.equal(result.entries[0].status, 'blocked');
     assert.deepEqual(result.entries[0].reasonCodes, [
       CHINA_COVERAGE_REASON_CODES.NOT_LAUNCHED,
-      CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PROJECTION_UNAVAILABLE,
+      CHINA_COVERAGE_REASON_CODES.CHINA_UPSTREAM_ROW_UNAVAILABLE,
     ]);
   });
 

--- a/tests/china-coverage-production-registration.test.mts
+++ b/tests/china-coverage-production-registration.test.mts
@@ -46,6 +46,7 @@ describe('China coverage production registration', () => {
     assert.match(insightsSeed, /buildChinaNewsCoverage\(\{/);
     assert.match(insightsSeed, /CHINA_NEWS_DIGEST_LANGUAGE = 'zh'/);
     assert.match(insightsSeed, /readChinaNewsDigest\(\)/);
+    assert.match(insightsSeed, /\[CHINA_NEWS_DIGEST_LANGUAGE\]: await readChinaNewsDigest\(\)/);
     assert.match(insightsSeed, /digest coverage check failed/);
     assert.match(insightsSeed, /preserveKeys: \[CHINA_COVERAGE_KEY\]/);
     assert.match(insightsSeed, /return preserveChinaNewsCoverageInLkg\(existing, chinaNewsCoverage\)/);

--- a/tests/china-coverage-production-registration.test.mts
+++ b/tests/china-coverage-production-registration.test.mts
@@ -10,6 +10,7 @@ const runbook = readFileSync(resolve(root, 'docs/railway-seed-consolidation-runb
 const cacheKeys = readFileSync(resolve(root, 'server/_shared/cache-keys.ts'), 'utf8');
 const seedHealth = readFileSync(resolve(root, 'api/seed-health.js'), 'utf8');
 const naturalSeed = readFileSync(resolve(root, 'scripts/seed-natural-events.mjs'), 'utf8');
+const insightsSeed = readFileSync(resolve(root, 'scripts/seed-insights.mjs'), 'utf8');
 const dataSources = readFileSync(resolve(root, 'docs/data-sources.mdx'), 'utf8');
 const healthDocs = readFileSync(resolve(root, 'docs/health-endpoints.mdx'), 'utf8');
 
@@ -38,6 +39,16 @@ describe('China coverage production registration', () => {
     const audit = readFileSync(resolve(root, 'scripts/audit-china-coverage.mjs'), 'utf8');
     assert.doesNotMatch(audit, /runSeed|writeExtraKey|\['SET'/);
     assert.match(audit, /--json/);
+  });
+
+  it('persists China feed availability beside the global insights ranking', () => {
+    assert.match(insightsSeed, /const CHINA_COVERAGE_KEY = 'news:insights:v1:CN'/);
+    assert.match(insightsSeed, /buildChinaNewsCoverage\(\{/);
+    assert.match(insightsSeed, /CHINA_NEWS_DIGEST_LANGUAGE = 'zh'/);
+    assert.match(insightsSeed, /readChinaNewsDigest\(\)/);
+    assert.match(insightsSeed, /digest coverage check failed/);
+    assert.match(insightsSeed, /preserveKeys: \[CHINA_COVERAGE_KEY\]/);
+    assert.match(insightsSeed, /writeExtraKey\(CHINA_COVERAGE_KEY, data\.chinaNewsCoverage, CACHE_TTL\)/);
   });
 
   it('documents the public China source contract and its operator health projection', () => {

--- a/tests/china-coverage-production-registration.test.mts
+++ b/tests/china-coverage-production-registration.test.mts
@@ -48,6 +48,7 @@ describe('China coverage production registration', () => {
     assert.match(insightsSeed, /readChinaNewsDigest\(\)/);
     assert.match(insightsSeed, /digest coverage check failed/);
     assert.match(insightsSeed, /preserveKeys: \[CHINA_COVERAGE_KEY\]/);
+    assert.match(insightsSeed, /return preserveChinaNewsCoverageInLkg\(existing, chinaNewsCoverage\)/);
     assert.match(insightsSeed, /writeExtraKey\(CHINA_COVERAGE_KEY, data\.chinaNewsCoverage, CACHE_TTL\)/);
   });
 

--- a/tests/china-news-coverage.test.mjs
+++ b/tests/china-news-coverage.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  CHINA_NEWS_SOURCE_NAMES,
+  buildChinaNewsCoverage,
+} from '../scripts/_china-news-coverage.mjs';
+
+const GENERATED_AT = '2026-07-14T12:00:00.000Z';
+
+test('China news coverage treats completed dated feeds as available without depending on global ranking', () => {
+  const coverage = buildChinaNewsCoverage({ en: {
+    generatedAt: GENERATED_AT,
+    // list-feed-digest intentionally records only exceptional feed states;
+    // absence means the feed completed with at least one dated item.
+    feedStatuses: {},
+  }, zh: { generatedAt: GENERATED_AT, feedStatuses: {} } });
+
+  assert.equal(coverage.countryCode, 'CN');
+  assert.deepEqual(coverage.sources, CHINA_NEWS_SOURCE_NAMES.map((source) => ({
+    source,
+    status: 'available',
+    observedAt: GENERATED_AT,
+  })));
+});
+
+test('China news coverage preserves per-source outage truth instead of publishing a global success', () => {
+  const coverage = buildChinaNewsCoverage({ en: {
+    generatedAt: GENERATED_AT,
+    feedStatuses: {
+      Xinhua: 'timeout',
+    },
+  }, zh: {
+    generatedAt: GENERATED_AT,
+    feedStatuses: {
+      'MIIT (China)': 'partial-undated',
+      'MOFCOM (China)': 'all-undated',
+    },
+  } });
+
+  assert.deepEqual(coverage.sources, [
+    { source: 'Xinhua', status: 'unavailable', reason: 'timeout' },
+    { source: 'MIIT (China)', status: 'available', observedAt: GENERATED_AT, reason: 'partial-undated' },
+    { source: 'MOFCOM (China)', status: 'unavailable', reason: 'all-undated' },
+  ]);
+});
+
+test('China news coverage refuses to mint a fresh source observation from an undated digest', () => {
+  const coverage = buildChinaNewsCoverage({ en: { feedStatuses: {} }, zh: { feedStatuses: {} } });
+
+  assert.deepEqual(
+    coverage.sources,
+    CHINA_NEWS_SOURCE_NAMES.map((source) => ({
+      source,
+      status: 'unavailable',
+      reason: 'digest_timestamp_missing',
+    })),
+  );
+});
+
+test('China news coverage marks Chinese-language sources unavailable when their locale digest is absent', () => {
+  const coverage = buildChinaNewsCoverage({
+    en: { generatedAt: GENERATED_AT, feedStatuses: {} },
+  });
+
+  assert.deepEqual(coverage.sources, [
+    { source: 'Xinhua', status: 'available', observedAt: GENERATED_AT },
+    { source: 'MIIT (China)', status: 'unavailable', reason: 'digest_unavailable' },
+    { source: 'MOFCOM (China)', status: 'unavailable', reason: 'digest_unavailable' },
+  ]);
+});

--- a/tests/china-news-coverage.test.mjs
+++ b/tests/china-news-coverage.test.mjs
@@ -4,6 +4,7 @@ import {
   CHINA_NEWS_SOURCE_NAMES,
   buildChinaNewsCoverage,
 } from '../scripts/_china-news-coverage.mjs';
+import { preserveChinaNewsCoverageInLkg } from '../scripts/seed-insights.mjs';
 
 const GENERATED_AT = '2026-07-14T12:00:00.000Z';
 
@@ -67,4 +68,18 @@ test('China news coverage marks Chinese-language sources unavailable when their 
     { source: 'MIIT (China)', status: 'unavailable', reason: 'digest_unavailable' },
     { source: 'MOFCOM (China)', status: 'unavailable', reason: 'digest_unavailable' },
   ]);
+});
+
+test('LKG global brief preservation still publishes fresh China source evidence', () => {
+  const existing = { status: 'ok', topStories: [{ primaryTitle: 'Last-known-good brief' }] };
+  const chinaNewsCoverage = buildChinaNewsCoverage({
+    en: { generatedAt: GENERATED_AT, feedStatuses: {} },
+    zh: { generatedAt: GENERATED_AT, feedStatuses: {} },
+  });
+
+  assert.deepEqual(preserveChinaNewsCoverageInLkg(existing, chinaNewsCoverage), {
+    ...existing,
+    chinaNewsCoverage,
+  });
+  assert.deepEqual(existing, { status: 'ok', topStories: [{ primaryTitle: 'Last-known-good brief' }] });
 });


### PR DESCRIPTION
## Summary
- derive a source-specific China news coverage projection from the English and Chinese feed digests
- keep the audit-only projection out of the public global insights payload
- make the China coverage audit require fresh, available status for Xinhua, MIIT, and MOFCOM

## Validation
- npm run typecheck
- npm run lint
- focused China coverage and source-parity tests
- pre-push full scoped gate (type checks, changed tests, markdown/MDX lint, and guards)

## Operational follow-up
Issue #5278 must remain open until this deploys and both seed-insights and seed-market-quotes populate news:insights:v1:CN and market:stock-index:v1:CN. Then run the strict China coverage audit. JODI Oil/Gas remain intentionally blocked because current upstream data has no China row.