### PR TITLE
fix(china): seed country index from ais relay

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -55,6 +55,9 @@ COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
 # guards this COPY list against future regressions.
 COPY scripts/_seed-envelope-source.mjs ./scripts/_seed-envelope-source.mjs
 COPY scripts/_seed-contract.mjs ./scripts/_seed-contract.mjs
+# ais-relay dynamically imports this helper to write the China country index
+# companion cache from a one-month Yahoo chart.
+COPY scripts/_country-stock-index.mjs ./scripts/_country-stock-index.mjs
 COPY scripts/_country-resolver.mjs ./scripts/_country-resolver.mjs
 COPY scripts/_climate-news-helpers.mjs ./scripts/_climate-news-helpers.mjs
 COPY scripts/seed-climate-news.mjs ./scripts/seed-climate-news.mjs

--- a/scripts/_country-stock-index.mjs
+++ b/scripts/_country-stock-index.mjs
@@ -1,11 +1,10 @@
 export const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';
 
-export function buildCountryStockIndexSnapshot(chart, fetchedAt = new Date().toISOString()) {
-  const result = chart?.chart?.result?.[0];
-  const closes = result?.indicators?.quote?.[0]?.close?.filter((value) => Number.isFinite(value));
-  if (!Array.isArray(closes) || closes.length < 2) return null;
+export function buildCountryStockIndexSnapshotFromCloses(closes, currency = 'CNY', fetchedAt = new Date().toISOString()) {
+  const finiteCloses = Array.isArray(closes) ? closes.filter((value) => Number.isFinite(value)) : [];
+  if (finiteCloses.length < 2) return null;
 
-  const weekly = closes.slice(-6);
+  const weekly = finiteCloses.slice(-6);
   const latest = weekly.at(-1);
   const oldest = weekly[0];
   if (!Number.isFinite(latest) || !Number.isFinite(oldest) || oldest === 0) return null;
@@ -17,7 +16,13 @@ export function buildCountryStockIndexSnapshot(chart, fetchedAt = new Date().toI
     indexName: 'SSE Composite',
     price: +latest.toFixed(2),
     weekChangePercent: +(((latest - oldest) / oldest) * 100).toFixed(2),
-    currency: result.meta?.currency || 'CNY',
+    currency,
     fetchedAt,
   };
+}
+
+export function buildCountryStockIndexSnapshot(chart, fetchedAt = new Date().toISOString()) {
+  const result = chart?.chart?.result?.[0];
+  const closes = result?.indicators?.quote?.[0]?.close?.filter((value) => Number.isFinite(value));
+  return buildCountryStockIndexSnapshotFromCloses(closes, result?.meta?.currency || 'CNY', fetchedAt);
 }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -36,7 +36,9 @@ const {
 const { maintainClosedMarketEquityKeys: maintainClosedMarketEquityKeysWithDeps } = require('./shared/closed-market-equity-maintenance.cjs');
 const { getUsEquitySession, isMultiMarketEquityTradingDay } = require('./shared/market-hours.cjs');
 const { mergeLastGoodQuotes, planYahooRefresh } = require('./shared/market-quote-refresh.cjs');
+const chinaCountryStockIndexHelpersPromise = import('./_country-stock-index.mjs');
 const parseProxyUrl = parseProxyConfig;
+const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';
 
 const httpsKeepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 6, timeout: 60_000 });
 
@@ -1948,9 +1950,9 @@ let _yahooConnectProxyCooldownUntil = 0;
 let _yahooCurlProxyFailCount = 0;      // fetchYahooQuoteSummary via us.decodo.com (curl)
 let _yahooCurlProxyCooldownUntil = 0;
 
-function _fetchYahooChartNoProxy(symbol) {
+function _fetchYahooChartNoProxy(symbol, query = '') {
   return new Promise((resolve) => {
-    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}`;
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}${query}`;
     const req = https.get(url, {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       timeout: 10000,
@@ -1969,13 +1971,13 @@ function _fetchYahooChartNoProxy(symbol) {
   });
 }
 
-function fetchYahooChartDirect(symbol) {
-  return _fetchYahooChartNoProxy(symbol).then((result) => {
+function fetchYahooChartDirect(symbol, query = '') {
+  return _fetchYahooChartNoProxy(symbol, query).then((result) => {
     if (result) return result;
     if (!PROXY_URL) return null;
     if (Date.now() < _yahooConnectProxyCooldownUntil) return null;
     const proxy = { ...parseProxyUrl(PROXY_URL), tls: true };
-    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}`;
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}${query}`;
     return ytFetchViaProxy(url, proxy).then((resp) => {
       if (!resp?.ok) {
         _yahooConnectProxyFailCount++;
@@ -2148,10 +2150,11 @@ let _lastEquityQuoteCount = 0;
 let _lastYahooMarketRefreshAt = 0;
 // Log once per open↔closed transition, not every 5-minute cycle.
 let _equityGateLoggedClosed = false;
+const CHINA_COUNTRY_STOCK_SYMBOL = '000001.SS';
 
 // When every tracked equity market is on a non-trading day, skip the equity
 // fetch+publish and instead
-// keep the last-good keys alive: extend TTL on both published keys and
+// keep the last-good equity and companion keys alive: extend their TTLs and
 // refresh seed-meta:market:stocks fetchedAt so /api/health (maxStaleMin 30)
 // stays green across a 60h+ weekend. Returns true when last-good was
 // preserved; false means the keys are missing/expired and the caller must
@@ -2165,7 +2168,19 @@ async function maintainClosedMarketEquityKeys() {
     upstashGet,
     upstashSet,
     nowMs: () => Date.now(),
+    preserveKeys: [CHINA_COUNTRY_STOCK_INDEX_KEY],
   });
+}
+
+async function writeChinaCountryStockIndex() {
+  const {
+    buildCountryStockIndexSnapshotFromCloses,
+  } = await chinaCountryStockIndexHelpersPromise;
+  const chart = await fetchYahooChartDirect(CHINA_COUNTRY_STOCK_SYMBOL, '?range=1mo&interval=1d');
+  const snapshot = buildCountryStockIndexSnapshotFromCloses(chart?.sparkline, 'CNY');
+  if (!snapshot) throw new Error('China country index returned insufficient daily closes');
+  const written = await upstashSet(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, MARKET_SEED_TTL);
+  if (!written) throw new Error('China country index Redis write failed');
 }
 
 async function seedMarketQuotes() {
@@ -2224,6 +2239,13 @@ async function seedMarketQuotes() {
   // Bootstrap-friendly fixed key — frontend hydrates from /api/bootstrap without RPC
   const ok2 = await envelopeWrite('market:stocks-bootstrap:v1', payload, MARKET_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-stocks' });
   const ok3 = await upstashSet('seed-meta:market:stocks', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
+  if (freshQuotes.some((quote) => quote.symbol === CHINA_COUNTRY_STOCK_SYMBOL)) {
+    try {
+      await writeChinaCountryStockIndex();
+    } catch (err) {
+      console.warn(`[Market] China country index refresh failed: ${err.message}`);
+    }
+  }
   _lastEquityQuoteCount = quotes.length;
   console.log(`[Market] Seeded ${quotes.length}/${MARKET_SYMBOLS.length} quotes (${freshQuotes.length} fresh, ${retainedCount} retained; Yahoo ${yahooSuccessCount}/${allYahoo.length}, cadence ${MARKET_YAHOO_REFRESH_INTERVAL_MS / 60000}min; redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
   const movingStocks = quotes.filter(q => Math.abs(q.change ?? 0) >= 5).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -38,7 +38,6 @@ const { getUsEquitySession, isMultiMarketEquityTradingDay } = require('./shared/
 const { mergeLastGoodQuotes, planYahooRefresh } = require('./shared/market-quote-refresh.cjs');
 const chinaCountryStockIndexHelpersPromise = import('./_country-stock-index.mjs');
 const parseProxyUrl = parseProxyConfig;
-const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';
 
 const httpsKeepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 6, timeout: 60_000 });
 
@@ -2160,6 +2159,7 @@ const CHINA_COUNTRY_STOCK_SYMBOL = '000001.SS';
 // preserved; false means the keys are missing/expired and the caller must
 // fall back to a real fetch to repopulate.
 async function maintainClosedMarketEquityKeys() {
+  const { CHINA_COUNTRY_STOCK_INDEX_KEY } = await chinaCountryStockIndexHelpersPromise;
   return maintainClosedMarketEquityKeysWithDeps({
     marketSymbols: MARKET_SYMBOLS,
     marketSeedTtl: MARKET_SEED_TTL,
@@ -2174,6 +2174,7 @@ async function maintainClosedMarketEquityKeys() {
 
 async function writeChinaCountryStockIndex() {
   const {
+    CHINA_COUNTRY_STOCK_INDEX_KEY,
     buildCountryStockIndexSnapshotFromCloses,
   } = await chinaCountryStockIndexHelpersPromise;
   const chart = await fetchYahooChartDirect(CHINA_COUNTRY_STOCK_SYMBOL, '?range=1mo&interval=1d');

--- a/scripts/shared/closed-market-equity-maintenance.cjs
+++ b/scripts/shared/closed-market-equity-maintenance.cjs
@@ -11,6 +11,7 @@ async function maintainClosedMarketEquityKeys({
   upstashSet,
   nowMs = () => Date.now(),
   metaTtlSeconds = 604800,
+  preserveKeys = [],
 }) {
   if (!marketSymbols || typeof marketSymbols[Symbol.iterator] !== 'function') {
     throw new Error('marketSymbols iterable is required');
@@ -18,13 +19,14 @@ async function maintainClosedMarketEquityKeys({
   if (typeof upstashExpire !== 'function') throw new Error('upstashExpire dependency is required');
   if (typeof upstashGet !== 'function') throw new Error('upstashGet dependency is required');
   if (typeof upstashSet !== 'function') throw new Error('upstashSet dependency is required');
+  if (!preserveKeys || typeof preserveKeys[Symbol.iterator] !== 'function') {
+    throw new Error('preserveKeys iterable is required');
+  }
 
   const redisKey = marketQuotesKey(marketSymbols);
-  const [ok1, ok2] = await Promise.all([
-    upstashExpire(redisKey, marketSeedTtl),
-    upstashExpire('market:stocks-bootstrap:v1', marketSeedTtl),
-  ]);
-  if (!ok1 || !ok2) return false;
+  const keys = [...new Set([redisKey, 'market:stocks-bootstrap:v1', ...preserveKeys])];
+  const results = await Promise.all(keys.map((key) => upstashExpire(key, marketSeedTtl)));
+  if (results.some((ok) => !ok)) return false;
 
   let count = lastEquityQuoteCount;
   if (!count) {

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
-import { CHINA_COUNTRY_STOCK_INDEX_KEY, buildCountryStockIndexSnapshot } from '../scripts/_country-stock-index.mjs';
+import {
+  CHINA_COUNTRY_STOCK_INDEX_KEY,
+  buildCountryStockIndexSnapshot,
+  buildCountryStockIndexSnapshotFromCloses,
+} from '../scripts/_country-stock-index.mjs';
 
 const FIXED_AT = '2026-07-14T12:00:00.000Z';
 
@@ -31,6 +35,23 @@ test('buildCountryStockIndexSnapshot rejects incomplete Yahoo charts instead of 
   assert.equal(buildCountryStockIndexSnapshot({ chart: { result: [{ indicators: { quote: [{ close: [3300] }] } }] } }, FIXED_AT), null);
 });
 
+test('buildCountryStockIndexSnapshotFromCloses shares the relay-safe daily-close snapshot contract', () => {
+  assert.deepEqual(buildCountryStockIndexSnapshotFromCloses([3200, 3210, 3300, 3320, 3310, 3340, 3360, 3355], 'CNY', FIXED_AT), {
+    available: true,
+    code: 'CN',
+    symbol: '000001.SS',
+    indexName: 'SSE Composite',
+    price: 3355,
+    weekChangePercent: 1.67,
+    currency: 'CNY',
+    fetchedAt: FIXED_AT,
+  });
+});
+
+test('buildCountryStockIndexSnapshotFromCloses filters malformed closes before calculating the weekly movement', () => {
+  assert.equal(buildCountryStockIndexSnapshotFromCloses([3200, 'broken', null], 'CNY', FIXED_AT), null);
+});
+
 test('the Railway market seed maintains the China cache alongside its public stock bootstrap contract', () => {
   const source = readFileSync(new URL('../scripts/seed-market-quotes.mjs', import.meta.url), 'utf8');
   const handlerSource = readFileSync(new URL('../server/worldmonitor/market/v1/get-country-stock-index.ts', import.meta.url), 'utf8');
@@ -46,4 +67,15 @@ test('the Railway market seed maintains the China cache alongside its public sto
   assert.match(handlerSource, /const RAILWAY_SEEDED_COUNTRY_INDEX_KEY = 'market:stock-index:v1:CN';/);
   assert.match(handlerSource, /getCachedJson\(RAILWAY_SEEDED_COUNTRY_INDEX_KEY, true\)/);
   assert.doesNotMatch(handlerSource, /const REDIS_CACHE_KEY = 'market:stock-index:v1';/);
+});
+
+test('the live AIS relay writes the China index only from a fresh one-month Yahoo chart', () => {
+  const source = readFileSync(new URL('../scripts/ais-relay.cjs', import.meta.url), 'utf8');
+
+  assert.match(source, /import\('\.\/_country-stock-index\.mjs'\)/);
+  assert.match(source, /fetchYahooChartDirect\(CHINA_COUNTRY_STOCK_SYMBOL, '\?range=1mo&interval=1d'\)/);
+  assert.match(source, /freshQuotes\.some\(\(quote\) => quote\.symbol === CHINA_COUNTRY_STOCK_SYMBOL\)/);
+  assert.match(source, /upstashSet\(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, MARKET_SEED_TTL\)/);
+  assert.match(source, /const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';/);
+  assert.match(source, /preserveKeys:\s*\[CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
 });

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -76,6 +76,7 @@ test('the live AIS relay writes the China index only from a fresh one-month Yaho
   assert.match(source, /fetchYahooChartDirect\(CHINA_COUNTRY_STOCK_SYMBOL, '\?range=1mo&interval=1d'\)/);
   assert.match(source, /freshQuotes\.some\(\(quote\) => quote\.symbol === CHINA_COUNTRY_STOCK_SYMBOL\)/);
   assert.match(source, /upstashSet\(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, MARKET_SEED_TTL\)/);
-  assert.match(source, /const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';/);
+  assert.match(source, /CHINA_COUNTRY_STOCK_INDEX_KEY,\s*\n\s*buildCountryStockIndexSnapshotFromCloses,/);
+  assert.doesNotMatch(source, /const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';/);
   assert.match(source, /preserveKeys:\s*\[CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
 });

--- a/tests/closed-market-equity-maintenance.test.mjs
+++ b/tests/closed-market-equity-maintenance.test.mjs
@@ -33,13 +33,14 @@ describe('closed-market equity key maintenance', () => {
     assert.doesNotMatch(runSeedCall[0], /\.then\(async/);
   });
 
-  it('extends both stock keys and refreshes seed-meta from the last in-process quote count', async () => {
+  it('extends both stock keys and configured companion keys before refreshing seed-meta', async () => {
     const expires = [];
     const writes = [];
 
     const ok = await maintainClosedMarketEquityKeys({
       marketSymbols: ['MSFT', 'AAPL'],
       marketSeedTtl: 7200,
+      preserveKeys: ['market:stock-index:v1:CN'],
       lastEquityQuoteCount: 2,
       upstashExpire: async (key, ttl) => { expires.push([key, ttl]); return true; },
       upstashGet: async () => { throw new Error('should not read meta when last count is present'); },
@@ -51,6 +52,7 @@ describe('closed-market equity key maintenance', () => {
     assert.deepEqual(expires, [
       ['market:quotes:v1:AAPL,MSFT', 7200],
       ['market:stocks-bootstrap:v1', 7200],
+      ['market:stock-index:v1:CN', 7200],
     ]);
     assert.deepEqual(writes, [
       ['seed-meta:market:stocks', { fetchedAt: 123456, recordCount: 2 }, 604800],

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -39,6 +39,10 @@ describe('Dockerfile.relay — transitive-import closure', () => {
     assert.ok(copied.size > 0, 'Dockerfile.relay has no COPY scripts/*.mjs|cjs lines');
   });
 
+  it('copies the China country-index helper that ais-relay loads dynamically', () => {
+    assert.ok(copied.has('scripts/_country-stock-index.mjs'));
+  });
+
   it('scanner catches both ESM imports and CJS require/createRequire', () => {
     // Regression guard for the scanner itself: _seed-utils.mjs has both
     // `import { ... } from './_seed-envelope-source.mjs'` (ESM) AND


### PR DESCRIPTION
## Summary

China's country-index cache now refreshes from the production AIS relay, so the China audit no longer depends on a separate market seeder that is not deployed. The relay obtains a fresh one-month daily SSE Composite chart for the companion snapshot, while a China-only refresh failure remains visible without turning the global market seed into a false outage. Closed-market maintenance also keeps that companion key alive alongside the canonical stock caches.

Related: #5278

## Validation

- `node --import tsx --test --test-concurrency=16 tests/*.test.mjs tests/*.test.mts cli/test/*.test.mjs api/security/report.test.mjs`
- `npm run typecheck:api`
- Relay-specific regression, Docker image import, and closed-market key tests
- Pre-push quality gate (typechecks, CJS syntax, architectural checks, seed tests, and changed tests)

`npm run test:data` could not create tsx's IPC socket in the sandbox; the equivalent Node runner passed.

## Post-Deploy Monitoring & Validation

- In Railway `ais-relay` logs, search for `[Market] China country index refresh failed` during the first 20 minutes after deploy.
- Expected healthy signal: normal market seeding with no repeated China-index refresh failures, and `market:stock-index:v1:CN` present with fresh content.
- Re-run the strict China audit and expect `market.china-index` to be healthy (not `CHINA_ROW_MISSING`).
- If the relay logs repeated China refresh failures or the audit remains missing, inspect Yahoo/proxy availability and roll back this relay deployment while keeping the audit issue open.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
