### PR TITLE
fix(bootstrap): schedule R2 shadow work on Vercel

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -1,3 +1,5 @@
+import { waitUntil as vercelWaitUntil } from '@vercel/functions';
+
 import { getCorsHeaders, getPublicCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import {
   USER_API_KEY_GATEWAY_VALIDATION_ERROR,
@@ -66,13 +68,13 @@ export function isPublicWeatherBootstrapRequest(req) {
 
 const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
 let nextBootstrapR2ShadowProbeIsCold = true;
+let scheduleBootstrapR2Shadow = vercelWaitUntil;
 
-function shouldMeasureBootstrapR2Shadow(authKind, tier, ctx) {
+function shouldMeasureBootstrapR2Shadow(authKind, tier) {
   return process.env.BOOTSTRAP_R2_SHADOW_MEASURE === '1'
     && process.env.VERCEL_ENV === 'production'
     && authKind === 'public-tier'
-    && PUBLIC_BOOTSTRAP_TIERS.has(tier)
-    && typeof ctx?.waitUntil === 'function';
+    && PUBLIC_BOOTSTRAP_TIERS.has(tier);
 }
 
 function finishBootstrapR2ShadowResponse(req, ctx, tier, response, redisDurationMs) {
@@ -110,7 +112,12 @@ function finishBootstrapR2ShadowResponse(req, ctx, tier, response, redisDuration
       status: response.status,
     });
   });
-  ctx.waitUntil(probe);
+  try {
+    if (typeof ctx?.waitUntil === 'function') ctx.waitUntil(probe);
+    else scheduleBootstrapR2Shadow(probe);
+  } catch {
+    // Background measurement must never alter the Redis response path.
+  }
   return response;
 }
 
@@ -385,7 +392,7 @@ export default async function handler(req, ctx) {
 
   const keys = Object.values(registry);
   const names = Object.keys(registry);
-  const measureR2Shadow = shouldMeasureBootstrapR2Shadow(auth.kind, tier, ctx);
+  const measureR2Shadow = shouldMeasureBootstrapR2Shadow(auth.kind, tier);
   const redisStartedAt = measureR2Shadow ? performance.now() : null;
 
   let cached;
@@ -459,5 +466,9 @@ export default async function handler(req, ctx) {
 export const __testing__ = {
   resetBootstrapR2ShadowForTests() {
     nextBootstrapR2ShadowProbeIsCold = true;
+    scheduleBootstrapR2Shadow = vercelWaitUntil;
+  },
+  setWaitUntilForTests(waitUntil) {
+    scheduleBootstrapR2Shadow = waitUntil;
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.36.1",
         "@vercel/analytics": "^2.0.0",
+        "@vercel/functions": "^3.7.5",
         "@vercel/og": "^0.11.1",
         "@xenova/transformers": "^2.17.2",
         "aws4fetch": "^1.0.20",
@@ -9472,6 +9473,61 @@
         }
       }
     },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.7.5.tgz",
+      "integrity": "sha512-ESf8BbeDebqRUyMi09JwRbQqpLn4g6fjcVVHPsHB56j2dSqRrSHO4h3X4aaxJf6iQQjzhAtDGI2xCWQ27JE8PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.8.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*",
+        "ws": ">=8"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vercel/og": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.11.1.tgz",
@@ -9553,6 +9609,29 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/oidc/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@vitest/expect": {
@@ -13167,6 +13246,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -13800,6 +13902,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -14176,6 +14290,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -14847,7 +14970,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16286,8 +16408,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -17393,6 +17514,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -17630,6 +17760,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
@@ -17743,6 +17885,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/onnx-proto": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
@@ -17814,6 +17971,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -19739,8 +19905,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -20227,6 +20392,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -23297,6 +23471,31 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml-naming": {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.1",
     "@vercel/analytics": "^2.0.0",
+    "@vercel/functions": "^3.7.5",
     "@vercel/og": "^0.11.1",
     "@xenova/transformers": "^2.17.2",
     "aws4fetch": "^1.0.20",

--- a/tests/bootstrap-r2-shadow.test.mjs
+++ b/tests/bootstrap-r2-shadow.test.mjs
@@ -162,20 +162,27 @@ test('only the first shadow probe in an isolate is marked cold', async () => {
   assert.deepEqual(calls.events.map(event => event.execution_cold), [true, false]);
 });
 
-test('shadow ignores on-demand and public-tier requests without waitUntil', async () => {
+test('shadow ignores on-demand requests but uses the Vercel scheduler without handler context', async () => {
   process.env.BOOTSTRAP_R2_SHADOW_MEASURE = '1';
   const calls = installFetchHarness();
   const onDemand = makeWaitUntilCtx();
+  const background = makeWaitUntilCtx();
+  __testing__.setWaitUntilForTests(background.ctx.waitUntil);
 
   const onDemandResponse = await handler(makeRequest('keys=bisDsr&public=1'), onDemand.ctx);
   const noContextResponse = await handler(makeRequest('tier=fast&public=1'));
+  await background.settle();
 
   assert.equal(onDemandResponse.headers.get('server-timing'), null);
-  assert.equal(noContextResponse.headers.get('server-timing'), null);
+  assert.match(
+    noContextResponse.headers.get('server-timing') ?? '',
+    /^wm_bootstrap_redis;dur=\d+(?:\.\d+)?$/,
+  );
   assert.equal(calls.redis, 2);
-  assert.equal(calls.r2, 0);
-  assert.equal(calls.axiom, 0);
+  assert.equal(calls.r2, 1);
+  assert.equal(calls.axiom, 1);
   assert.equal(onDemand.pending.length, 0);
+  assert.equal(background.pending.length, 1);
 });
 
 test('shadow source pins the uncensored probe ceiling and cannot consume serving timeouts', () => {


### PR DESCRIPTION
## Summary

Production bootstrap cache misses could not emit the R2 shadow measurements needed to calibrate the rollout because Vercel no longer supplies the deprecated handler `context.waitUntil` path this code required. Shadow probes now use Vercel's supported lifecycle scheduler, while Redis remains the authoritative response path and scheduling failures stay fail-soft.

Related: #5300

## Validation

- 44 focused bootstrap R2 tests passed.
- 228 edge-function tests passed.
- Frontend and API typechecks passed.
- The full pre-push gate passed, including edge bundling and change-scoped tests.
- Production verification remains the next rollout step after merge: a cold public-tier miss must expose `wm_bootstrap_redis` timing and deliver a shadow event before calibration resumes.

## New concepts

### Function-lifetime scheduling

`waitUntil(promise)` lets background work continue after an HTTP response is returned. It is the right boundary here because the user-facing Redis response must not wait for the R2 measurement, but Vercel still needs to keep the function alive long enough to deliver that measurement.

This change uses the platform helper instead of relying on a handler-context shape that is no longer guaranteed. It keeps an injected scheduler for deterministic tests and the legacy context path for compatible local callers.

Do not use this pattern for work that must complete before the response is correct; those operations still need to be awaited on the request path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
