### PR TITLE
fix(forecast): present() observes 0 (not NaN) on absence — VOID-rate regression

### DIFF
--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -242,10 +242,18 @@ export function extractMetricValue(parsed, feedData) {
 // over the fresh feed (#5243 P1). asOf is null when the record has no timestamp.
 export function extractMetricObservation(parsed, feedData) {
   const record = findMatchingRecord(feedData, parsed.field, parsed.value);
+  // present() is a boolean existence check: a missing matched record means the
+  // event did NOT occur → observe 0, NOT NaN. Returning NaN here (as the initial
+  // refactor did) makes a quiet subject store an error sample instead of a valid
+  // 0, so a legitimately-NO within-horizon spec strands with an empty timeline
+  // and VOIDs. Mirror extractMetricValue's `record ? 1 : 0`.
+  if (parsed.fn === 'present') {
+    const asOf = record ? parseAsOfMs(record.asOf ?? record.date) : NaN;
+    return { value: record ? 1 : 0, asOf: Number.isFinite(asOf) ? asOf : null };
+  }
   if (!record) return { value: NaN, asOf: null };
   const asOf = parseAsOfMs(record.asOf ?? record.date);
-  const value = parsed.fn === 'present' ? 1 : valueFromRecord(parsed.fn, record);
-  return { value, asOf: Number.isFinite(asOf) ? asOf : null };
+  return { value: valueFromRecord(parsed.fn, record), asOf: Number.isFinite(asOf) ? asOf : null };
 }
 
 function compareResult(value, spec, entry, parsed, nowMs, extraEvidence = {}) {

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -677,6 +677,7 @@ describe('extractMetricObservation present() semantics (#void-triage)', () => {
     const feed = { outages: [{ country: 'Cuba', date: '2026-07-14' }] };
     const obs = extractMetricObservation(parsed, feed);
     assert.equal(obs.value, 1);
+    assert.equal(obs.asOf, Date.parse('2026-07-14'));
   });
 
   it('lets a within-horizon present spec resolve NO on a sampled absence (not VOID)', () => {

--- a/tests/forecast-resolution-eval.test.mjs
+++ b/tests/forecast-resolution-eval.test.mjs
@@ -7,6 +7,8 @@ import {
   countSettlementLagMs,
   parseMetricKey,
   resolveHardSpec,
+  extractMetricObservation,
+  extractMetricValue,
 } from '../scripts/_forecast-resolution-eval.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -657,5 +659,42 @@ describe('resolveHardSpec', () => {
 
   it('fixtures stay omission-shaped', () => {
     assertNoNullFields(entry());
+  });
+});
+
+describe('extractMetricObservation present() semantics (#void-triage)', () => {
+  const parsed = parseMetricKey('infra:outages:v1|present(country==Cuba)');
+
+  it('observes 0 (not NaN) when the subject is absent, matching extractMetricValue', () => {
+    const feed = { outages: [{ country: 'Iraq' }] }; // Cuba absent (no outage)
+    assert.equal(extractMetricValue(parsed, feed), 0);
+    const obs = extractMetricObservation(parsed, feed);
+    assert.equal(obs.value, 0); // was NaN → error sample → false VOID
+    assert.equal(obs.asOf, null);
+  });
+
+  it('observes 1 when the subject is present', () => {
+    const feed = { outages: [{ country: 'Cuba', date: '2026-07-14' }] };
+    const obs = extractMetricObservation(parsed, feed);
+    assert.equal(obs.value, 1);
+  });
+
+  it('lets a within-horizon present spec resolve NO on a sampled absence (not VOID)', () => {
+    const now = Date.parse('2026-07-14T00:00:00Z');
+    const spec = {
+      kind: 'hard',
+      metricKey: 'infra:outages:v1|present(country==Cuba)',
+      operator: '>=',
+      threshold: 1,
+      window: 'within-horizon',
+      deadline: now,
+      sourceFeed: 'infra:outages:v1',
+    };
+    const entry = { spec, generatedAt: now - DAY_MS };
+    // a sampled absence within the window (value 0) — must resolve NO, not VOID
+    const samples = [{ ts: now - DAY_MS / 2, value: 0 }];
+    const res = resolveHardSpec(entry, { outages: [{ country: 'Iraq' }] }, samples, now + 1);
+    assert.equal(res.status, 'resolved');
+    assert.equal(res.outcome, 'NO');
   });
 });


### PR DESCRIPTION
## Why

Triaging the **68% resolution VOID rate** surfaced a regression I introduced in the sampling refactor (#5243 P1).

`extractMetricObservation` returned `NaN` for a missing matched record. But `present()` is a boolean existence check — an **absent** subject means the event did **not** occur → `0`, not `NaN`. So `samplePendingEntries` stored an *error* sample instead of a valid `0`, and a legitimately-NO within-horizon `present` spec (e.g. `infra:outages:v1|present(country==X)` for a quiet country) stranded with an empty timeline and **VOIDed** (`no_establishable_metric`) instead of resolving **NO**. The old `extractMetricValue` did `record ? 1 : 0`; the refactored helper must match it.

## What

- `extractMetricObservation`: `present()` now observes `record ? 1 : 0` (0 on absence), `asOf` from the record when present.

## Evidence

- Tests: present-absent → `0` (parity with `extractMetricValue`); a within-horizon `present` spec resolves **NO** on a sampled absence.
- 908/908 forecast+bet suites green; api tsc exit 0.

## VOID-rate triage context (separate from this fix)

Historical VOIDs are **all legacy-detector hard specs, zero bet_engine**, two causes, both aging out:
1. `unsupported_window: "sustained-48h"` (gpsjam/chokepoint) — an old generator window the resolver never implemented; the current generator no longer emits it (0 in the pending pool).
2. `present` within-horizon 24h on a daily resolver — sparse sampling + this NaN bug (fixed here). The cadence + vague-forecast issues are what the bet-template re-engine supersedes.

Refs #5233, #4930