### PR TITLE
fix(bootstrap): preserve R2 origin RUM on Vercel

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -78,11 +78,27 @@ function shouldMeasureBootstrapR2Shadow(authKind, tier) {
 }
 
 function finishBootstrapR2ShadowResponse(req, ctx, tier, response, redisDurationMs) {
-  response.headers.set('Server-Timing', `wm_bootstrap_redis;dur=${redisDurationMs.toFixed(3)}`);
+  const serializedRedisDurationMs = redisDurationMs.toFixed(3);
+  response.headers.set('Server-Timing', `wm_bootstrap_redis;dur=${serializedRedisDurationMs}`);
+  // Vercel strips user-authored Server-Timing from Edge responses. Keep it for
+  // runtimes that preserve the standard header, but expose the same temporary
+  // U3a diagnostic through a platform-safe header so browser RUM can observe it.
+  response.headers.set('X-WorldMonitor-Bootstrap-Redis-Duration', serializedRedisDurationMs);
+  // A browser cache replay preserves the origin-MISS headers and would make a
+  // local response look like a fresh origin sample. Disable only browser
+  // storage during U3a; CDN-Cache-Control continues to shield the Vercel origin.
+  response.headers.set('Cache-Control', 'no-store');
   const exposedHeaders = response.headers.get('Access-Control-Expose-Headers');
   response.headers.set(
     'Access-Control-Expose-Headers',
-    [exposedHeaders, 'Server-Timing', 'Age', 'X-Vercel-Cache', 'CF-Cache-Status']
+    [
+      exposedHeaders,
+      'Server-Timing',
+      'X-WorldMonitor-Bootstrap-Redis-Duration',
+      'Age',
+      'X-Vercel-Cache',
+      'CF-Cache-Status',
+    ]
       .filter(Boolean)
       .join(', '),
   );

--- a/src/bootstrap/bootstrap-r2-rum.ts
+++ b/src/bootstrap/bootstrap-r2-rum.ts
@@ -23,6 +23,8 @@ export type BootstrapR2RumResult =
   | { accepted: false; reason: BootstrapR2RumRejectReason };
 
 const SERVER_TIMING_RE = /(?:^|,)\s*wm_bootstrap_redis\s*;\s*dur\s*=\s*(\d+(?:\.\d+)?)\s*(?:,|$)/i;
+const REDIS_DURATION_RE = /^\d+(?:\.\d+)?$/;
+const REDIS_DURATION_HEADER = 'x-worldmonitor-bootstrap-redis-duration';
 const CLOUDFLARE_ORIGIN_STATES = new Set(['DYNAMIC', 'BYPASS', 'MISS']);
 
 export function selectBootstrapR2RumTier(rng: () => number = Math.random): BootstrapR2RumTier {
@@ -30,6 +32,14 @@ export function selectBootstrapR2RumTier(rng: () => number = Math.random): Boots
 }
 
 function readRedisDuration(headers: Headers): number | null | 'invalid' {
+  const rawPlatformSafeDuration = headers.get(REDIS_DURATION_HEADER);
+  if (rawPlatformSafeDuration !== null) {
+    const platformSafeDuration = rawPlatformSafeDuration.trim();
+    if (!REDIS_DURATION_RE.test(platformSafeDuration)) return 'invalid';
+    const duration = Number(platformSafeDuration);
+    return Number.isFinite(duration) && duration >= 0 ? duration : 'invalid';
+  }
+
   const raw = headers.get('server-timing');
   if (!raw) return null;
   const match = raw.match(SERVER_TIMING_RE);

--- a/tests/bootstrap-r2-rum.test.mts
+++ b/tests/bootstrap-r2-rum.test.mts
@@ -17,6 +17,22 @@ function headers(overrides: Record<string, string> = {}): Headers {
 }
 
 describe('bootstrap R2 client RUM', () => {
+  it('accepts the platform-safe Redis duration header when Vercel strips Server-Timing', () => {
+    const result = buildBootstrapR2RumSample(
+      'fast',
+      'success',
+      300.25,
+      headers({
+        'server-timing': '',
+        'x-worldmonitor-bootstrap-redis-duration': '125.5',
+      }),
+      'mobile',
+    );
+
+    assert.equal(result.accepted, true);
+    assert.equal(result.accepted && result.sample.redis_duration_ms, 125.5);
+  });
+
   it('accepts only a same-response origin MISS and derives exact overhead', () => {
     const result = buildBootstrapR2RumSample('fast', 'success', 300.25, headers(), 'mobile');
 
@@ -66,6 +82,11 @@ describe('bootstrap R2 client RUM', () => {
     ['non-decimal zero cache age', { age: '0x0' }, 'cached-age'],
     ['fractional zero cache age', { age: '0.0' }, 'cached-age'],
     ['unknown cache age', { age: 'unknown' }, 'cached-age'],
+    [
+      'malformed platform-safe Redis timing',
+      { 'x-worldmonitor-bootstrap-redis-duration': 'nope' },
+      'invalid-server-timing',
+    ],
     ['malformed Redis timing', { 'server-timing': 'wm_bootstrap_redis;dur=nope' }, 'invalid-server-timing'],
   ] as const) {
     it(`rejects ${label}`, () => {

--- a/tests/bootstrap-r2-shadow.test.mjs
+++ b/tests/bootstrap-r2-shadow.test.mjs
@@ -92,6 +92,7 @@ test('flag-off public tier response performs no probe and preserves the normal r
 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get('server-timing'), null);
+  assert.equal(response.headers.get('x-worldmonitor-bootstrap-redis-duration'), null);
   assert.equal(calls.redis, 1);
   assert.equal(calls.r2, 0);
   assert.equal(calls.axiom, 0);
@@ -107,6 +108,7 @@ test('shadow credentials are never exercised outside the production Vercel envir
   const response = await handler(makeRequest('tier=fast&public=1'), wait.ctx);
 
   assert.equal(response.headers.get('server-timing'), null);
+  assert.equal(response.headers.get('x-worldmonitor-bootstrap-redis-duration'), null);
   assert.equal(calls.redis, 1);
   assert.equal(calls.r2, 0);
   assert.equal(calls.axiom, 0);
@@ -128,6 +130,12 @@ for (const [label, r2Status, expectedOutcome, expectedReason] of [
 
     assert.equal(response.status, 200);
     assert.match(response.headers.get('server-timing') ?? '', /^wm_bootstrap_redis;dur=\d+(?:\.\d+)?$/);
+    assert.match(
+      response.headers.get('x-worldmonitor-bootstrap-redis-duration') ?? '',
+      /^\d+(?:\.\d+)?$/,
+    );
+    assert.equal(response.headers.get('cache-control'), 'no-store');
+    assert.match(response.headers.get('cdn-cache-control') ?? '', /^public, /);
     assert.equal(calls.redis, 1);
     assert.equal(calls.r2, 1);
     assert.equal(calls.axiom, 1);
@@ -145,6 +153,7 @@ for (const [label, r2Status, expectedOutcome, expectedReason] of [
     );
     const exposed = response.headers.get('access-control-expose-headers') ?? '';
     assert.match(exposed, /Server-Timing/i);
+    assert.match(exposed, /X-WorldMonitor-Bootstrap-Redis-Duration/i);
     assert.match(exposed, /X-Vercel-Cache/i);
     assert.match(exposed, /CF-Cache-Status/i);
   });


### PR DESCRIPTION
## Summary

Vercel strips user-authored `Server-Timing` from bootstrap Edge responses, leaving U3a browser RUM with zero accepted origin samples even while shadow probes succeed. This exposes the same numeric Redis duration through a temporary CORS-readable header while preserving the standard header for runtimes that support it. Instrumented responses are browser `no-store` but retain `CDN-Cache-Control`, preventing local cache replay of origin-MISS headers from contaminating calibration. Serving timeouts and the R2 cutover remain gated on the full measured sample.

Related: #5300

## Validation

- Focused bootstrap RUM and shadow suite: 23/23 passed.
- Frontend and API typechecks passed.
- Full pre-push gate passed, including 228 Edge Function tests and the Edge bundle check.
- Production transport still requires a post-deploy origin-MISS browser/CORS probe before samples are trusted.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)