### PR TITLE
fix(bootstrap): preserve R2 RUM CORS headers at edge

### DIFF
--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -208,6 +208,57 @@ test('GET response from origin has CORS headers stamped by the Worker', async ()
   }
 });
 
+test('GET response preserves function-specific exposed headers (bootstrap U3a regression)', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Expose-Headers': [
+        'Server-Timing',
+        'X-WorldMonitor-Bootstrap-Redis-Duration',
+        'Age',
+        'X-Vercel-Cache',
+        'CF-Cache-Status',
+        // A baseline name must not be duplicated when the lists are merged.
+        'Retry-After',
+      ].join(', '),
+    },
+  });
+  try {
+    const req = makeRequest('GET', 'https://api.worldmonitor.app/api/bootstrap?tier=slow&public=1', {
+      Origin: KNOWN_GOOD,
+    });
+    const resp = await worker.fetch(req);
+    assert.equal(
+      resp.headers.get('access-control-expose-headers'),
+      `${ACEH_EXPECTED}, Server-Timing, X-WorldMonitor-Bootstrap-Redis-Duration, Age, X-Vercel-Cache, CF-Cache-Status`,
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('GET response does not preserve function-specific exposed headers outside bootstrap', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Expose-Headers': 'X-Internal-Diagnostic',
+    },
+  });
+  try {
+    const req = makeRequest('GET', 'https://api.worldmonitor.app/api/health', {
+      Origin: KNOWN_GOOD,
+    });
+    const resp = await worker.fetch(req);
+    assert.equal(resp.headers.get('access-control-expose-headers'), ACEH_EXPECTED);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
 // --- public-CORS path bypass (MCP / OAuth / discovery / public utilities) ----
 
 test('hasPublicCorsPolicy: exact-match paths', () => {

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -110,6 +110,21 @@ export function buildCorsHeaders(origin) {
   };
 }
 
+function mergeHeaderNames(...values) {
+  const seen = new Set();
+  const merged = [];
+  for (const value of values) {
+    for (const name of (value || '').split(',')) {
+      const trimmed = name.trim();
+      const normalized = trimmed.toLowerCase();
+      if (!trimmed || seen.has(normalized)) continue;
+      seen.add(normalized);
+      merged.push(trimmed);
+    }
+  }
+  return merged.join(', ');
+}
+
 export default {
   async fetch(request) {
     const url = new URL(request.url);
@@ -143,8 +158,19 @@ export default {
     try {
       const response = await fetch(request);
       const newHeaders = new Headers(response.headers);
+      const originExposedHeaders = newHeaders.get('Access-Control-Expose-Headers');
       for (const [k, v] of Object.entries(corsHeaders)) {
         newHeaders.set(k, v);
+      }
+      // Bootstrap temporarily exposes U3a timing and cache-classifier headers.
+      // Preserve only that route's function-owned additions while retaining
+      // the Worker's canonical baseline. Replacing this header outright made
+      // those diagnostics invisible to browser JavaScript in production.
+      if (url.pathname === '/api/bootstrap' && originExposedHeaders) {
+        newHeaders.set(
+          'Access-Control-Expose-Headers',
+          mergeHeaderNames(EXPOSE_HEADERS, originExposedHeaders),
+        );
       }
       return new Response(response.body, {
         status: response.status,


### PR DESCRIPTION
## Summary

- preserve the api/bootstrap function-specific Access-Control-Expose-Headers additions through the authoritative Cloudflare CORS Worker
- keep the canonical Worker CORS policy unchanged for every other API route
- add regressions for the bootstrap exception and the non-bootstrap security boundary

## Why

Post-merge browser verification of #5328 showed the Vercel response carried X-WorldMonitor-Bootstrap-Redis-Duration, but browser JavaScript could not read it or X-Vercel-Cache. The api-cors-preflight Worker replaces Access-Control-Expose-Headers on every non-OPTIONS response, silently deleting the temporary U3a timing and cache-classifier additions. That makes the RUM classifier fail closed and collect zero calibration samples.

This fix is deliberately scoped to /api/bootstrap; arbitrary function-specific diagnostic headers remain hidden on other routes.

## Verification

- Worker tests: 22 passed
- bootstrap API tests: 35 passed
- client RUM and DebugBear tests: 25 passed
- Wrangler deploy dry-run passed
- full pre-push gate passed, including frontend, API, and Convex typechecks, architecture checks, edge bundle, and version sync

Follow-up to #5328 for #5300.