### PR TITLE
perf(cls): pin always-full panels to deterministic row heights (#5332)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1660,6 +1660,44 @@ canvas,
   min-height: var(--dashboard-first-grid-reservation) !important;
 }
 
+/* #5332: eager always-full panels grow their grid row when populated content
+   replaces the loading state — rows are minmax(--dashboard-panel-row-min,
+   --dashboard-panel-row-max) sized from the panel's intrinsic content height,
+   so the growth shoves every row below (field: div.panel shift p75 0.244 on
+   9% of desktop views; the dominant remaining desktop CLS mechanism, #4580).
+   Pin the known always-full panels to the row max so their row lands at its
+   final height from first paint; .panel-content already scrolls. User-set
+   spans (.span-N) keep their own min-height reservation contract and are
+   excluded. Keep this key list in sync with the ranked offenders in #5332. */
+.panel[data-panel="threat-timeline"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="gdelt-intel"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="intel"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="live-news"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="politics"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="energy-complex"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="global-procurement"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="strategic-posture"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="cascade"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
+.panel[data-panel="live-webcams"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide) {
+  height: var(--dashboard-panel-row-max);
+}
+
+/* Offenders that are two-row by default — span-2 defaults and the 2x2
+   .panel-wide pair — get the populated two-row max (2 rows + gap) so their
+   footprint is identical loading vs populated, INCLUDING the deferred-shell
+   phase (the shell carries the same classes, so shell->panel swap is
+   shift-free). A user demoting one to span-1 drops the class and lands in
+   the rule above. */
+.panel[data-panel="threat-timeline"].span-2,
+.panel[data-panel="gdelt-intel"].span-2,
+.panel[data-panel="energy-complex"].span-2,
+.panel[data-panel="strategic-posture"].span-2,
+.panel[data-panel="global-procurement"].span-2,
+.panel[data-panel="live-news"].panel-wide,
+.panel[data-panel="live-webcams"].panel-wide {
+  height: calc(var(--dashboard-panel-row-max) * 2 + var(--dashboard-grid-gap));
+}
+
 .panel.span-3 {
   grid-row: span 3 !important;
   min-height: 600px !important;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1669,16 +1669,16 @@ canvas,
    final height from first paint; .panel-content already scrolls. User-set
    spans (.span-N) keep their own min-height reservation contract and are
    excluded. Keep this key list in sync with the ranked offenders in #5332. */
-.panel[data-panel="threat-timeline"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="gdelt-intel"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="intel"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="live-news"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="politics"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="energy-complex"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="global-procurement"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="strategic-posture"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="cascade"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide),
-.panel[data-panel="live-webcams"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide) {
+#panelsGrid > .panel[data-panel="threat-timeline"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="gdelt-intel"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="intel"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="live-news"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="politics"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="energy-complex"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="global-procurement"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="strategic-posture"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="cascade"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized),
+#panelsGrid > .panel[data-panel="live-webcams"]:not(.span-2):not(.span-3):not(.span-4):not(.panel-wide):not(.resized) {
   height: var(--dashboard-panel-row-max);
 }
 
@@ -1686,15 +1686,18 @@ canvas,
    .panel-wide pair — get the populated two-row max (2 rows + gap) so their
    footprint is identical loading vs populated, INCLUDING the deferred-shell
    phase (the shell carries the same classes, so shell->panel swap is
-   shift-free). A user demoting one to span-1 drops the class and lands in
-   the rule above. */
-.panel[data-panel="threat-timeline"].span-2,
-.panel[data-panel="gdelt-intel"].span-2,
-.panel[data-panel="energy-complex"].span-2,
-.panel[data-panel="strategic-posture"].span-2,
-.panel[data-panel="global-procurement"].span-2,
-.panel[data-panel="live-news"].panel-wide,
-.panel[data-panel="live-webcams"].panel-wide {
+   shift-free). The pins apply to NATURAL footprints only: user-resized
+   panels (.resized, PR #5333 review P1) and explicit .span-N overrides keep
+   the resize contract, and the #panelsGrid scope keeps panels dragged into
+   the ultra-wide .map-bottom-grid (height:100%/1fr tracks) on that grid's
+   own sizing contract. */
+#panelsGrid > .panel[data-panel="threat-timeline"].span-2:not(.resized),
+#panelsGrid > .panel[data-panel="gdelt-intel"].span-2:not(.resized),
+#panelsGrid > .panel[data-panel="energy-complex"].span-2:not(.resized),
+#panelsGrid > .panel[data-panel="strategic-posture"].span-2:not(.resized),
+#panelsGrid > .panel[data-panel="global-procurement"].span-2:not(.resized),
+#panelsGrid > .panel[data-panel="live-news"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4),
+#panelsGrid > .panel[data-panel="live-webcams"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4) {
   height: calc(var(--dashboard-panel-row-max) * 2 + var(--dashboard-grid-gap));
 }
 

--- a/tests/panel-row-stability.test.mjs
+++ b/tests/panel-row-stability.test.mjs
@@ -8,60 +8,76 @@ import { fileURLToPath } from 'node:url';
 // populated content replaces the loading state (rows are minmax-sized from
 // intrinsic content height), shoving every row below — the dominant remaining
 // desktop CLS mechanism (field: div.panel shift p75 0.244 on 9% of views).
-// The fix pins the ranked offender panels to the row max so the row height is
-// deterministic from first paint. This guard keeps the pin present, keyed to
-// the ranked offender list, and excluded for user-set spans.
+// The fix pins the ranked offenders to their populated max so row height is
+// deterministic from first paint. PR #5333 review hardened the contract:
+// pins apply to NATURAL footprints only (user-resized .resized/.span-N
+// panels keep the resize contract) and only inside #panelsGrid (panels
+// dragged to the ultra-wide .map-bottom-grid keep that grid's sizing).
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const css = readFileSync(resolve(root, 'src/styles/main.css'), 'utf-8');
 const panels = readFileSync(resolve(root, 'src/config/panels.ts'), 'utf-8');
 
-const OFFENDER_KEYS = [
+const SPAN1_KEYS = [
   'threat-timeline', 'gdelt-intel', 'intel', 'live-news', 'politics',
   'energy-complex', 'global-procurement', 'strategic-posture', 'cascade',
   'live-webcams',
 ];
+const SPAN2_DEFAULT_KEYS = ['threat-timeline', 'gdelt-intel', 'energy-complex', 'strategic-posture', 'global-procurement'];
+const WIDE_KEYS = ['live-news', 'live-webcams'];
+
+// The two pin blocks, extracted by their shared height declarations. Regex
+// anchors on a line START so `min-height:` can never satisfy it (review P2).
+const pinBlocks = [...css.matchAll(/(^|\n)([^{}]*?)\{\s*\n\s*height:\s*(var\(--dashboard-panel-row-max\)|calc\(var\(--dashboard-panel-row-max\) \* 2 \+ var\(--dashboard-grid-gap\)\));\s*\n\}/g)]
+  .map((m) => ({ selectors: m[2].replace(/\/\*[\s\S]*?\*\//g, '').trim(), value: m[3] }));
 
 describe('always-full panel row stability (#5332)', () => {
-  it('pins every ranked offender panel to the row max, excluding user spans', () => {
-    for (const key of OFFENDER_KEYS) {
-      assert.match(
-        css,
-        new RegExp(`\\.panel\\[data-panel="${key}"\\]:not\\(\\.span-2\\):not\\(\\.span-3\\):not\\(\\.span-4\\):not\\(\\.panel-wide\\)`),
-        `.panel[data-panel="${key}"] must carry the fixed-row pin — without it the panel's row grows on content arrival and shifts every row below`,
-      );
-    }
-    const block = css.slice(css.indexOf('.panel[data-panel="threat-timeline"]'));
-    assert.match(
-      block.slice(0, block.indexOf('}')),
-      /height:\s*var\(--dashboard-panel-row-max\)/,
-      'the pin must be a fixed height at the row max (min-height would still allow growth)',
-    );
+  it('has exactly two pin blocks with FIXED height (not min-height)', () => {
+    assert.equal(pinBlocks.length, 2, 'expected the span-1 pin block and the two-row pin block, each declaring a bare `height:` line');
+    const values = pinBlocks.map((b) => b.value).sort();
+    assert.match(values[0], /^calc/, 'one block must pin the two-row populated max');
+    assert.match(values[1], /^var/, 'one block must pin the single-row max');
   });
 
-  it('pins the two-row-default offenders (span-2 + panel-wide) at the populated two-row max', () => {
-    for (const key of ['threat-timeline', 'gdelt-intel', 'energy-complex', 'strategic-posture', 'global-procurement']) {
+  it('pins every ranked offender in its natural footprint, scoped to #panelsGrid', () => {
+    const single = pinBlocks.find((b) => b.value.startsWith('var'));
+    const double = pinBlocks.find((b) => b.value.startsWith('calc'));
+    assert.ok(single && double, 'both pin blocks must exist');
+    for (const key of SPAN1_KEYS) {
       assert.match(
-        css,
-        new RegExp(`\\.panel\\[data-panel="${key}"\\]\\.span-2`),
-        `span-2 default '${key}' needs its own pin — the span-1 rule excludes .span-2 and these grow 404px toward ~764px in the field`,
+        single.selectors,
+        new RegExp(`#panelsGrid > \\.panel\\[data-panel="${key}"\\]:not\\(\\.span-2\\):not\\(\\.span-3\\):not\\(\\.span-4\\):not\\(\\.panel-wide\\):not\\(\\.resized\\)`),
+        `'${key}' must carry the #panelsGrid-scoped natural-footprint pin`,
       );
     }
-    for (const key of ['live-news', 'live-webcams']) {
+    for (const key of SPAN2_DEFAULT_KEYS) {
       assert.match(
-        css,
-        new RegExp(`\\.panel\\[data-panel="${key}"\\]\\.panel-wide`),
-        `'${key}' uses .panel-wide (2x2 grid area), not .span-2 — it needs the panel-wide pin or it keeps growing 404px toward ~764px`,
+        double.selectors,
+        new RegExp(`#panelsGrid > \\.panel\\[data-panel="${key}"\\]\\.span-2:not\\(\\.resized\\)`),
+        `span-2 default '${key}' must be pinned at the two-row max for its NATURAL state only`,
       );
     }
-    assert.match(
-      css,
-      /\.panel\[data-panel="live-webcams"\]\.panel-wide \{\s*height:\s*calc\(var\(--dashboard-panel-row-max\) \* 2 \+ var\(--dashboard-grid-gap\)\)/,
-      'the two-row pin must be the populated two-row max (2 x row-max + gap)',
-    );
+    for (const key of WIDE_KEYS) {
+      assert.match(
+        double.selectors,
+        new RegExp(`#panelsGrid > \\.panel\\[data-panel="${key}"\\]\\.panel-wide:not\\(\\.resized\\):not\\(\\.span-1\\)`),
+        `'${key}' uses .panel-wide (2x2), needs the wide pin excluding user-resized span states (review P1: a .panel-wide.span-1.resized panel must NOT stay 764px)`,
+      );
+    }
+  });
+
+  it('never pins a resized panel or a panel outside #panelsGrid', () => {
+    for (const block of pinBlocks) {
+      for (const selector of block.selectors.split(',')) {
+        const sel = selector.trim();
+        if (!sel) continue;
+        assert.ok(sel.startsWith('#panelsGrid > '), `pin selector must be scoped to #panelsGrid (review P1 bottom-grid leak): ${sel}`);
+        assert.ok(sel.includes(':not(.resized)'), `pin selector must exclude user-resized panels (review P1): ${sel}`);
+      }
+    }
   });
 
   it('every pinned key still exists in the panel config (rename guard)', () => {
-    for (const key of OFFENDER_KEYS) {
+    for (const key of SPAN1_KEYS) {
       assert.match(
         panels,
         new RegExp(`(?:'${key}'|(?<![\\w-])${key}):\\s*\\{`),

--- a/tests/panel-row-stability.test.mjs
+++ b/tests/panel-row-stability.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// #5332 (#4580 slice A): eager always-full panels grow their grid row when
+// populated content replaces the loading state (rows are minmax-sized from
+// intrinsic content height), shoving every row below — the dominant remaining
+// desktop CLS mechanism (field: div.panel shift p75 0.244 on 9% of views).
+// The fix pins the ranked offender panels to the row max so the row height is
+// deterministic from first paint. This guard keeps the pin present, keyed to
+// the ranked offender list, and excluded for user-set spans.
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const css = readFileSync(resolve(root, 'src/styles/main.css'), 'utf-8');
+const panels = readFileSync(resolve(root, 'src/config/panels.ts'), 'utf-8');
+
+const OFFENDER_KEYS = [
+  'threat-timeline', 'gdelt-intel', 'intel', 'live-news', 'politics',
+  'energy-complex', 'global-procurement', 'strategic-posture', 'cascade',
+  'live-webcams',
+];
+
+describe('always-full panel row stability (#5332)', () => {
+  it('pins every ranked offender panel to the row max, excluding user spans', () => {
+    for (const key of OFFENDER_KEYS) {
+      assert.match(
+        css,
+        new RegExp(`\\.panel\\[data-panel="${key}"\\]:not\\(\\.span-2\\):not\\(\\.span-3\\):not\\(\\.span-4\\):not\\(\\.panel-wide\\)`),
+        `.panel[data-panel="${key}"] must carry the fixed-row pin — without it the panel's row grows on content arrival and shifts every row below`,
+      );
+    }
+    const block = css.slice(css.indexOf('.panel[data-panel="threat-timeline"]'));
+    assert.match(
+      block.slice(0, block.indexOf('}')),
+      /height:\s*var\(--dashboard-panel-row-max\)/,
+      'the pin must be a fixed height at the row max (min-height would still allow growth)',
+    );
+  });
+
+  it('pins the two-row-default offenders (span-2 + panel-wide) at the populated two-row max', () => {
+    for (const key of ['threat-timeline', 'gdelt-intel', 'energy-complex', 'strategic-posture', 'global-procurement']) {
+      assert.match(
+        css,
+        new RegExp(`\\.panel\\[data-panel="${key}"\\]\\.span-2`),
+        `span-2 default '${key}' needs its own pin — the span-1 rule excludes .span-2 and these grow 404px toward ~764px in the field`,
+      );
+    }
+    for (const key of ['live-news', 'live-webcams']) {
+      assert.match(
+        css,
+        new RegExp(`\\.panel\\[data-panel="${key}"\\]\\.panel-wide`),
+        `'${key}' uses .panel-wide (2x2 grid area), not .span-2 — it needs the panel-wide pin or it keeps growing 404px toward ~764px`,
+      );
+    }
+    assert.match(
+      css,
+      /\.panel\[data-panel="live-webcams"\]\.panel-wide \{\s*height:\s*calc\(var\(--dashboard-panel-row-max\) \* 2 \+ var\(--dashboard-grid-gap\)\)/,
+      'the two-row pin must be the populated two-row max (2 x row-max + gap)',
+    );
+  });
+
+  it('every pinned key still exists in the panel config (rename guard)', () => {
+    for (const key of OFFENDER_KEYS) {
+      assert.match(
+        panels,
+        new RegExp(`(?:'${key}'|(?<![\\w-])${key}):\\s*\\{`),
+        `pinned panel key '${key}' no longer exists in src/config/panels.ts — update the #5332 pin list and this test together`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the dominant remaining desktop CLS mechanism (#5332, #4580's intra-grid class): the eager always-full panels grow their grid row when populated content replaces the loading state (`grid-auto-rows: minmax(200px, 380px)` sizes rows from intrinsic content height), shoving every row below. Field evidence (07-13→15, 5,000 desktop views): 9% carry a ≥0.1 shift, `div.panel` shift p75 0.244, concentrated in the first ~2s, with the offenders named by their shifted content.

The fix pins the ten ranked offenders to their populated maximum so the row lands at its final height from first paint (user-approved "pin at max" design): span-1 keys at `var(--dashboard-panel-row-max)` (380px), the two-row-by-default cohort — `.span-2` defaults **and** the 2×2 `.panel-wide` pair — at `calc(2 × row-max + gap)` (764px). Content already scrolls inside (`overflow-y: auto`); user-set spans keep their own reservation contract via `:not()` exclusions; the pin also covers the deferred-shell phase (shells carry the same classes), so shell→panel swaps are shift-free.

Two probe-caught traps are handled that a naive version would have missed: `live-news`/`live-webcams` use `.panel-wide` (not `.span-2`) and needed their own tier, and `global-procurement` is span-2-by-default behind a deferred shell.

## Validation (probe = red/green, 1365×768, 4× CPU, Slow-4G, prod APIs)

| | pre-patch | patched |
|---|---|---|
| span-1 offenders (intel, politics, cascade) | 200px loading, grows in field | **380px constant, zero height changes** |
| two-row cohort (threat-timeline, gdelt-intel, energy-complex, strategic-posture, global-procurement, live-news, live-webcams) | 404px minimum, grows toward ~764 in field | **764px constant, zero height changes** |

- Guard: `tests/panel-row-stability.test.mjs` — pin present per key, fixed `height` (not `min-height`), span exclusions, and a key-rename guard tied to `src/config/panels.ts`.
- 38/38 across the panel/skeleton/critical-css guard suites; `tsc` clean; full `vite build`.
- Known visual tradeoff (user-approved): during the ~1–2s loading window these panels occupy their final size (taller skeletons) instead of starting short.

## Post-Deploy Monitoring & Validation

- DebugBear `rumMetrics?groupBy=clsSelector&device=desktop&urlPath=/dashboard`: `#panelsGrid div.panel` shift p75 falling within 48h (baseline 0.244; mobile tail baseline 0.451); `#main div#panelsGrid` (victim attribution of the same mechanism) following.
- CrUX desktop CLS %good (63%, the last failing CWV) resumes climbing toward 75 over the following weekly windows.
- Failure signal: offender rows persist at baseline → the remaining tail is other panels (slice B: extend the footprint contract to every eager mount) or the unattributed bucket has a different mechanism.

Closes #5332. Part of #4580 / #4487.

https://claude.ai/code/session_01PgggD2v8bpN5evLAgNCuZ6
