### PR TITLE
fix(brief): exclude historical explainers

### DIFF
--- a/scripts/lib/digest-opinion-track-filter.mjs
+++ b/scripts/lib/digest-opinion-track-filter.mjs
@@ -1,0 +1,27 @@
+// Pure opinion-stamp policy for digest story:track rows.
+//
+// Ingest is authoritative for explicit "1" and "0" verdicts. Reclassifying
+// only rows with no stamp keeps legacy residue covered without allowing the
+// same stored row to change category as wall-clock time advances.
+
+import { classifyOpinion } from '../../server/_shared/opinion-classifier.js';
+
+function isMissingStamp(value) {
+  return typeof value !== 'string' || value.length === 0;
+}
+
+/**
+ * @param {{ isOpinion?: unknown; title?: unknown; link?: unknown; description?: unknown; publishedAt?: unknown } | null | undefined} track
+ * @returns {boolean} true when the track must be excluded from the digest
+ */
+export function shouldDropOpinionTrack(track) {
+  if (track?.isOpinion === '1') return true;
+  if (!isMissingStamp(track?.isOpinion)) return false;
+
+  return classifyOpinion({
+    title: track?.title,
+    link: track?.link,
+    description: track?.description,
+    publishedAt: track?.publishedAt,
+  });
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -714,23 +714,22 @@ async function buildDigest(rule, windowStartMs) {
       continue;
     }
 
-    // Opinion / analysis exclusion (F3). The brief is event-driven
-    // intelligence — an op-ed column is not an event. Ingest stamps
-    // `isOpinion` on the story:track:v1 row; trust that stamp when
-    // present ('1' | '0'). Pre-stamp residue rows (ingested before the
-    // ingest-side stamp shipped) have NO `isOpinion` field at all — for
-    // those, re-classify from the persisted title/link/description so
-    // residue is still excluded for the row's TTL window. See
+    // Non-event brief exclusion (F3). The brief is event-driven intelligence
+    // — an op-ed or historical explainer is not an event.
+    // Ingest stamps `isOpinion` on the story:track:v1 row. Re-check the
+    // shared classifier too, so an older explicit "0" stamp cannot keep a
+    // story in the pool after the classifier learns a new exclusion shape.
+    // This is cheap and gives rule changes immediate read-path coverage for
+    // every row still inside the accumulator window. See
     // docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
     const stampedOpinion = track.isOpinion === '1';
-    const stampMissing = typeof track.isOpinion !== 'string' || track.isOpinion.length === 0;
     if (
       stampedOpinion ||
-      (stampMissing && classifyOpinion({
+      classifyOpinion({
         title: track.title,
         link: track.link ?? '',
         description: typeof track.description === 'string' ? track.description : '',
-      }))
+      })
     ) {
       droppedOpinion++;
       continue;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -722,6 +722,10 @@ async function buildDigest(rule, windowStartMs) {
     // This is cheap and gives rule changes immediate read-path coverage for
     // every row still inside the accumulator window. See
     // docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
+    // This is intentionally asymmetric: the historical-explainer policy
+    // needs retroactive coverage for explicit "0" rows, while feel-good and
+    // ephemeral-live below retain their established missing-stamp-only
+    // residue checks until a policy change needs the same treatment.
     const stampedOpinion = track.isOpinion === '1';
     if (
       stampedOpinion ||

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -42,9 +42,9 @@ const { fetchFollowedCountries } = require('./lib/followed-countries-fetch.cjs')
 const { Resend } = require('resend');
 const { normalizeResendSender } = require('./lib/resend-from.cjs');
 import { readRawJsonFromUpstash, redisPipeline } from '../api/_upstash-json.js';
-import { classifyOpinion } from '../server/_shared/opinion-classifier.js';
 import { classifyFeelGood } from '../server/_shared/feelgood-classifier.js';
 import { classifyEphemeralLiveCoverage } from '../shared/ephemeral-live-classifier.js';
+import { shouldDropOpinionTrack } from './lib/digest-opinion-track-filter.mjs';
 import {
   composeBriefFromDigestStories,
   compareRules,
@@ -716,25 +716,10 @@ async function buildDigest(rule, windowStartMs) {
 
     // Non-event brief exclusion (F3). The brief is event-driven intelligence
     // — an op-ed or historical explainer is not an event.
-    // Ingest stamps `isOpinion` on the story:track:v1 row. Re-check the
-    // shared classifier too, so an older explicit "0" stamp cannot keep a
-    // story in the pool after the classifier learns a new exclusion shape.
-    // This is cheap and gives rule changes immediate read-path coverage for
-    // every row still inside the accumulator window. See
-    // docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
-    // This is intentionally asymmetric: the historical-explainer policy
-    // needs retroactive coverage for explicit "0" rows, while feel-good and
-    // ephemeral-live below retain their established missing-stamp-only
-    // residue checks until a policy change needs the same treatment.
-    const stampedOpinion = track.isOpinion === '1';
-    if (
-      stampedOpinion ||
-      classifyOpinion({
-        title: track.title,
-        link: track.link ?? '',
-        description: typeof track.description === 'string' ? track.description : '',
-      })
-    ) {
+    // Ingest stamps `isOpinion` on the story:track:v1 row. Explicit "1" and
+    // "0" are authoritative; only unstamped legacy rows are classified at
+    // read time by the pure helper below.
+    if (shouldDropOpinionTrack(track)) {
       droppedOpinion++;
       continue;
     }

--- a/server/_shared/opinion-classifier.d.ts
+++ b/server/_shared/opinion-classifier.d.ts
@@ -5,7 +5,7 @@
  * the read path (buildDigest). Uses title, link (URL), and description.
  * See docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
  *
- * @param story - { title, link, description } — any may be missing.
+ * @param story - { title, link, description, publishedAt } — any may be missing.
  * @returns true = opinion/analysis or historical explainer (exclude from
  *   the brief).
  */
@@ -13,4 +13,5 @@ export function classifyOpinion(story: {
   title?: unknown;
   link?: unknown;
   description?: unknown;
+  publishedAt?: unknown;
 }): boolean;

--- a/server/_shared/opinion-classifier.d.ts
+++ b/server/_shared/opinion-classifier.d.ts
@@ -1,12 +1,13 @@
 /**
- * Classify a story as opinion/analysis vs hard news. Single classifier
- * shared by the ingest path (list-feed-digest.ts — stamps `isOpinion`
- * on the story:track:v1 row) and the read path (buildDigest —
- * re-classifies residue). Uses title, link (URL), and description.
+ * Classify a story as non-event brief content vs hard news. The legacy
+ * `isOpinion` stamp includes opinion/analysis and historical explainers;
+ * the classifier is shared by the ingest path (list-feed-digest.ts) and
+ * the read path (buildDigest). Uses title, link (URL), and description.
  * See docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
  *
  * @param story - { title, link, description } — any may be missing.
- * @returns true = opinion/analysis (exclude from the brief).
+ * @returns true = opinion/analysis or historical explainer (exclude from
+ *   the brief).
  */
 export function classifyOpinion(story: {
   title?: unknown;

--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -106,33 +106,51 @@ const CORROBORATING_DESCRIPTION_RE = /\b(?:columnist|op-?ed|opinion piece|our co
 // publishers do not mark these pieces as opinion in either their URL or RSS
 // metadata, but their headline has a distinctive explanatory shape:
 // "How <past event> changed/became/shaped …". Require BOTH that shape and a
-// clearly historical anchor in the title/description so ordinary current
-// explainers (or ordinary reporting that merely references an old year) keep
-// flowing. This caught the July 2026 DW ten-year Turkey coup retrospective.
+// clearly historical anchor so ordinary current explainers (or ordinary
+// reporting that merely references an old year) keep flowing. The anchor is
+// deliberately conservative: a false positive silently removes a live event.
+// This caught the July 2026 DW ten-year Turkey coup retrospective.
 const HISTORICAL_EXPLAINER_HEADLINE_RE =
   /^(?:how|why)\b[\s\S]{0,180}\b(?:changed|shaped|transformed|altered|became|remade|defined)\b/i;
-const HISTORICAL_EXPLAINER_TIME_RE =
+const HISTORICAL_EXPLAINER_TITLE_TIME_RE =
   /\b(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)\s+(?:ago|after|later)|anniversary|retrospective|(?:a|this)\s+look back)\b/i;
-const PAST_YEAR_RE = /\b((?:19|20)\d{2})\b/g;
+const HISTORICAL_EXPLAINER_DESCRIPTION_LOOKBACK_RE = /\b(?:a|this)\s+look[-\s]?back\b/i;
+const HISTORICAL_EXPLAINER_LIVE_EVENT_RE = /\b(?:today|overnight|this morning|an?\s+hour ago|hours ago|breaking)\b/i;
+// A four-digit number alone is not an event year: it can be a troop count,
+// dollar amount, or capacity. Require a nearby historic-event noun instead.
+const HISTORICAL_EVENT_YEAR_RE =
+  /\b((?:19|20)\d{2})\s+(?:coup(?:\s+attempt)?|war|invasion|election|referendum|uprising|protests?|crackdown|attack|crisis|conflict|earthquake|disaster)\b/gi;
 
-function hasPastYear(text, nowMs) {
-  const currentYear = new Date(nowMs).getUTCFullYear();
-  for (const match of text.matchAll(PAST_YEAR_RE)) {
-    if (Number.parseInt(match[1], 10) < currentYear - 1) return true;
+function publishedYear(publishedAt) {
+  if (typeof publishedAt !== 'number' && typeof publishedAt !== 'string') return null;
+  const timestamp = typeof publishedAt === 'string' && /^\d+$/.test(publishedAt)
+    ? Number(publishedAt)
+    : publishedAt;
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  return Number.isNaN(date.getTime()) ? null : year;
+}
+
+function hasHistoricalEventYear(title, publishedAt) {
+  const storyYear = publishedYear(publishedAt);
+  if (storyYear === null) return false;
+  for (const match of title.matchAll(HISTORICAL_EVENT_YEAR_RE)) {
+    // Preserve the prior one-calendar-year grace, but derive it from the
+    // article's persisted publication time rather than read-time Date.now().
+    if (Number.parseInt(match[1], 10) < storyYear - 1) return true;
   }
   return false;
 }
 
-function isHistoricalExplainer(title, description, nowMs = Date.now()) {
-  if (!HISTORICAL_EXPLAINER_HEADLINE_RE.test(title)) return false;
-  const text = `${title} ${description}`;
-  if (HISTORICAL_EXPLAINER_TIME_RE.test(text)) return true;
-
-  // A summary can mention an old year as background for a live explainer.
-  // Treat a bare past year as an anchor only when the headline itself carries
-  // it; description-only matches need the explicit retrospective wording
-  // above.
-  return hasPastYear(title, nowMs);
+function isHistoricalExplainer(title, description, publishedAt) {
+  const headline = title.trim();
+  if (!HISTORICAL_EXPLAINER_HEADLINE_RE.test(headline)) return false;
+  if (HISTORICAL_EXPLAINER_LIVE_EVENT_RE.test(`${headline} ${description}`)) return false;
+  if (HISTORICAL_EXPLAINER_TITLE_TIME_RE.test(headline)) return true;
+  // Descriptions can corroborate only an explicit look-back label. Broad
+  // anniversary wording in article copy is common in live coverage.
+  if (HISTORICAL_EXPLAINER_DESCRIPTION_LOOKBACK_RE.test(description)) return true;
+  return hasHistoricalEventYear(headline, publishedAt);
 }
 
 // ── CORROBORATING: whole-headline quote wrap ─────────────────────────
@@ -153,42 +171,21 @@ function isWholeHeadlineQuoted(title) {
 }
 
 /**
- * Parse the URL pathname defensively. Malformed URL → empty string
- * (skip URL signal entirely; do not throw). Closes the tracking-param
+ * Parse URL pathname and hostname defensively. Malformed URL → empty parts
+ * (skip URL signals entirely; do not throw). Closes the tracking-param
  * injection vector — aggregator tracking params (?utm=/opinion/promo)
  * and URL fragments (#/opinion/footer) live OUTSIDE the pathname and
  * must not trigger STRONG (or CORROBORATING) via raw-string includes()
  * matching on the full link. Backport of the same helper added in
  * feelgood-classifier.js (PR #3748 / adv-002).
  */
-function safePathname(link) {
-  if (typeof link !== 'string' || link.length === 0) return '';
+function safeUrlParts(link) {
+  if (typeof link !== 'string' || link.length === 0) return { pathname: '', hostname: '' };
   try {
-    return new URL(link).pathname.toLowerCase();
+    const url = new URL(link);
+    return { pathname: url.pathname.toLowerCase(), hostname: url.hostname.toLowerCase() };
   } catch {
-    return '';
-  }
-}
-
-/**
- * Parse the URL hostname defensively. Same shape as safePathname but
- * for the host portion — closes the same tracking-param / fragment
- * injection vector. A raw-string `link.includes('thebulletin.org')`
- * would false-positive on `https://nytimes.com/article?ref=thebulletin.org`
- * (tracking param) or `https://evil.com#thebulletin.org` (fragment).
- * Hostname comes from the parsed URL only.
- *
- * Suffix-anchored match: hostname `=== entry` OR hostname `.endsWith('.' + entry)`.
- * This catches subdomain variants (`newsletter.thebulletin.org`,
- * `m.thebulletin.org`) while rejecting typo-domains (`evilthebulletin.org`).
- * The plan's subdomain-policy decision (F12 in PR #3828's doc review).
- */
-function safeHostname(link) {
-  if (typeof link !== 'string' || link.length === 0) return '';
-  try {
-    return new URL(link).hostname.toLowerCase();
-  } catch {
-    return '';
+    return { pathname: '', hostname: '' };
   }
 }
 
@@ -203,7 +200,7 @@ function matchesCommentaryHost(hostname) {
 /**
  * Classify a story as non-event brief content vs hard news.
  *
- * @param {{ title?: unknown; link?: unknown; description?: unknown }} story
+ * @param {{ title?: unknown; link?: unknown; description?: unknown; publishedAt?: unknown }} story
  * @returns {boolean} true = opinion/analysis or historical explainer
  *   (exclude from the brief)
  */
@@ -211,13 +208,14 @@ export function classifyOpinion(story) {
   const title = typeof story?.title === 'string' ? story.title : '';
   const link = typeof story?.link === 'string' ? story.link : '';
   const description = typeof story?.description === 'string' ? story.description : '';
+  const publishedAt = story?.publishedAt;
 
   // Non-event historical explainers share the brief-exclusion contract with
   // opinion/analysis: do not let a retrospective rank like a live crisis.
-  if (isHistoricalExplainer(title, description)) return true;
+  if (isHistoricalExplainer(title, description, publishedAt)) return true;
 
-  // Parse pathname once; reused by STRONG #1 and CORROBORATING URL check.
-  const pathname = safePathname(link);
+  // Parse once; path and host signals share the same defensive URL boundary.
+  const { pathname, hostname } = safeUrlParts(link);
 
   // STRONG #1 — URL section. Matches a path segment on the parsed
   // pathname (NOT raw link), so tracking params / fragments can't
@@ -235,7 +233,7 @@ export function classifyOpinion(story) {
   // section to distinguish from. Hostname match on the parsed URL
   // only, suffix-anchored to permit `newsletter.<host>` and `m.<host>`
   // while rejecting typo-domains.
-  if (matchesCommentaryHost(safeHostname(link))) return true;
+  if (matchesCommentaryHost(hostname)) return true;
 
   // CORROBORATING — need at least TWO.
   let corroborating = 0;

--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -1,4 +1,4 @@
-// Opinion / analysis classifier for the WorldMonitor brief pipeline.
+// Brief-exclusion classifier for the WorldMonitor pipeline.
 //
 // The brief is event-driven intelligence — an op-ed column is not an
 // event. On 2026-05-14 a Le Monde opinion column ("'Russia's invasion
@@ -18,7 +18,7 @@
 // metadata, and the parsed RSS item does not carry them either — so
 // there is no richer ingest-time signal to exploit.
 //
-// Tiering (conservative — a false negative ships one opinion piece;
+// Tiering (conservative — a false negative ships one non-event piece;
 // a false positive silently drops a real event):
 //   STRONG       — sufficient alone to classify as opinion
 //   CORROBORATING — needs a STRONG signal OR two CORROBORATING signals
@@ -100,6 +100,41 @@ const COMMENTARY_HOSTNAMES = new Set([
 // only count toward a 2-signal threshold.
 const CORROBORATING_DESCRIPTION_RE = /\b(?:columnist|op-?ed|opinion piece|our columnist|argues that|posits that|makes the case|the case for|guest essay|editorial board)\b/i;
 
+// ── STRONG: historical explainer framing ─────────────────────────────
+//
+// A daily brief is an event feed, not an anniversary explainer. Some
+// publishers do not mark these pieces as opinion in either their URL or RSS
+// metadata, but their headline has a distinctive explanatory shape:
+// "How <past event> changed/became/shaped …". Require BOTH that shape and a
+// clearly historical anchor in the title/description so ordinary current
+// explainers (or ordinary reporting that merely references an old year) keep
+// flowing. This caught the July 2026 DW ten-year Turkey coup retrospective.
+const HISTORICAL_EXPLAINER_HEADLINE_RE =
+  /^(?:how|why)\b[\s\S]{0,180}\b(?:changed|shaped|transformed|altered|became|remade|defined)\b/i;
+const HISTORICAL_EXPLAINER_TIME_RE =
+  /\b(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)\s+(?:ago|after|later)|anniversary|retrospective|(?:a|this)\s+look back)\b/i;
+const PAST_YEAR_RE = /\b((?:19|20)\d{2})\b/g;
+
+function hasPastYear(text, nowMs) {
+  const currentYear = new Date(nowMs).getUTCFullYear();
+  for (const match of text.matchAll(PAST_YEAR_RE)) {
+    if (Number.parseInt(match[1], 10) < currentYear - 1) return true;
+  }
+  return false;
+}
+
+function isHistoricalExplainer(title, description, nowMs = Date.now()) {
+  if (!HISTORICAL_EXPLAINER_HEADLINE_RE.test(title)) return false;
+  const text = `${title} ${description}`;
+  if (HISTORICAL_EXPLAINER_TIME_RE.test(text)) return true;
+
+  // A summary can mention an old year as background for a live explainer.
+  // Treat a bare past year as an anchor only when the headline itself carries
+  // it; description-only matches need the explicit retrospective wording
+  // above.
+  return hasPastYear(title, nowMs);
+}
+
 // ── CORROBORATING: whole-headline quote wrap ─────────────────────────
 // An entire headline wrapped in quotation marks is the classic op-ed
 // headline format (the May 14 Le Monde column). But a hard-news
@@ -166,15 +201,20 @@ function matchesCommentaryHost(hostname) {
 }
 
 /**
- * Classify a story as opinion/analysis vs hard news.
+ * Classify a story as non-event brief content vs hard news.
  *
  * @param {{ title?: unknown; link?: unknown; description?: unknown }} story
- * @returns {boolean} true = opinion/analysis (exclude from the brief)
+ * @returns {boolean} true = opinion/analysis or historical explainer
+ *   (exclude from the brief)
  */
 export function classifyOpinion(story) {
   const title = typeof story?.title === 'string' ? story.title : '';
   const link = typeof story?.link === 'string' ? story.link : '';
   const description = typeof story?.description === 'string' ? story.description : '';
+
+  // Non-event historical explainers share the brief-exclusion contract with
+  // opinion/analysis: do not let a retrospective rank like a live crisis.
+  if (isHistoricalExplainer(title, description)) return true;
 
   // Parse pathname once; reused by STRONG #1 and CORROBORATING URL check.
   const pathname = safePathname(link);

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -425,7 +425,11 @@ async function fetchAndParseRss(
   // shape changes.)
   // v5→v6 (#4920 review): ParseResult gained droppedFeedCap; warm v5 rows
   // lack it and would undercount the coverage ledger for their whole TTL.
-  const cacheKey = `rss:feed:v6:${variant}:${feed.url}`;
+  // v6→v7: ParsedItems now stamp historical explainers using their persisted
+  // publishedAt. Digest reads deliberately trust explicit isOpinion stamps,
+  // so warm v6 rows could retain an earlier "0" verdict for one cache TTL.
+  // Force a cold parse to stamp the stable ingest-time verdict immediately.
+  const cacheKey = `rss:feed:v7:${variant}:${feed.url}`;
 
   try {
     // Read cache unconditionally — the v5 prefix guarantees pre-fix
@@ -604,7 +608,7 @@ function parseRssXml(xml: string, feed: ServerFeed, variant: string): ParseResul
       entityCorroborationCount: 0,
       lang: feed.lang ?? 'en',
       description,
-      isOpinion: classifyOpinion({ title, link, description }),
+      isOpinion: classifyOpinion({ title, link, description, publishedAt }),
       isFeelGood: classifyFeelGood({ title, link, description }),
       isEphemeralLiveCoverage: classifyEphemeralLiveCoverage({ title, link, description }),
       tickers: extractTickers(`${title} ${description}`, TICKER_DICTIONARY),

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -183,10 +183,11 @@ interface ParsedItem {
   // absent, too short, or indistinguishable from the headline. Grounding input
   // for brief / whyMatters / SummarizeArticle LLMs.
   description: string;
-  // Opinion / analysis classification (classifyOpinion over title + link +
-  // description). Persisted on the story:track:v1 row as `isOpinion` so the
-  // brief's read path (buildDigest) can exclude op-ed/column content — the
-  // brief is event-driven intelligence, a column is not an event. See
+  // Non-event brief classification (classifyOpinion over title + link +
+  // description). Persisted on the legacy `isOpinion` story:track:v1 field
+  // so buildDigest can exclude op-ed/column and historical-explainer content
+  // — the brief is event-driven intelligence, not an editorial or look-back
+  // feed. See
   // docs/plans/2026-05-14-001-…-plan.md (F3). story:track rows feed more
   // than the brief, so this STAMPS rather than drops — only buildDigest
   // filters on it.
@@ -1106,8 +1107,9 @@ function buildStoryTrackHsetFields(
     'entityCorroborationCount', Number.isFinite(item.entityCorroborationCount)
       ? String(item.entityCorroborationCount)
       : '0',
-    // Opinion/analysis flag (classifyOpinion). '1' = op-ed/column,
-    // '0' = hard news. buildDigest's read-path filter excludes '1' rows
+    // Non-event brief flag (classifyOpinion). '1' = op-ed/column or
+    // historical explainer, '0' = hard news. The legacy `isOpinion` field
+    // name remains for cache compatibility; buildDigest excludes '1' rows
     // from the brief pool. Written unconditionally for the same
     // shared-row reason as `description` above: story:track rows are
     // collapsed by normalised-title hash, so a stale '1' from an earlier

--- a/tests/digest-buildDigest-feelgood-filter.test.mjs
+++ b/tests/digest-buildDigest-feelgood-filter.test.mjs
@@ -106,10 +106,10 @@ describe('U3: feel-good filter block trusts stamp + re-classifies residue', () =
 });
 
 describe('U3: feel-good filter runs AFTER opinion filter (M6 asymmetry)', () => {
-  it('classifyFeelGood call appears after classifyOpinion call in buildDigest', () => {
-    const opinionIdx = buildDigestBody.indexOf('classifyOpinion(');
+  it('classifyFeelGood call appears after the opinion-track policy in buildDigest', () => {
+    const opinionIdx = buildDigestBody.indexOf('shouldDropOpinionTrack(');
     const feelGoodIdx = buildDigestBody.indexOf('classifyFeelGood(');
-    assert.ok(opinionIdx !== -1, 'classifyOpinion call must exist in buildDigest');
+    assert.ok(opinionIdx !== -1, 'opinion-track policy call must exist in buildDigest');
     assert.ok(feelGoodIdx !== -1, 'classifyFeelGood call must exist in buildDigest');
     assert.ok(
       feelGoodIdx > opinionIdx,

--- a/tests/digest-buildDigest-opinion-filter.test.mjs
+++ b/tests/digest-buildDigest-opinion-filter.test.mjs
@@ -1,0 +1,38 @@
+// Source-level regression guard for the digest read-path opinion exclusion.
+//
+// A classifier rule can be tightened while a story:track row with
+// isOpinion="0" is still inside the accumulator window. Re-checking the
+// cheap shared classifier on read keeps that in-flight residue out of the
+// very next brief instead of waiting for a later feed poll to overwrite the
+// stamp.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const seedSrc = readFileSync(
+  resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'),
+  'utf-8',
+);
+
+const buildDigestStart = seedSrc.indexOf('async function buildDigest(rule, windowStartMs)');
+const afterBuildDigest = seedSrc.indexOf('\nfunction ', buildDigestStart + 1);
+const afterBuildDigestAsync = seedSrc.indexOf('\nasync function ', buildDigestStart + 1);
+const buildDigestEnd = Math.min(
+  afterBuildDigest === -1 ? Number.POSITIVE_INFINITY : afterBuildDigest,
+  afterBuildDigestAsync === -1 ? Number.POSITIVE_INFINITY : afterBuildDigestAsync,
+);
+const buildDigestBody = seedSrc.slice(buildDigestStart, buildDigestEnd);
+
+describe('buildDigest opinion filter — current classifier rule changes', () => {
+  it('re-checks classifyOpinion even when Redis has an explicit non-opinion stamp', () => {
+    assert.match(
+      buildDigestBody,
+      /stampedOpinion\s*\|\|\s*classifyOpinion\(\{[\s\S]*?title:\s*track\.title/,
+      'must calculate the current shared classifier verdict for every non-opinion row',
+    );
+  });
+});

--- a/tests/digest-buildDigest-opinion-filter.test.mjs
+++ b/tests/digest-buildDigest-opinion-filter.test.mjs
@@ -1,38 +1,42 @@
-// Source-level regression guard for the digest read-path opinion exclusion.
+// Behavioral coverage for digest story:track opinion stamp handling.
 //
-// A classifier rule can be tightened while a story:track row with
-// isOpinion="0" is still inside the accumulator window. Re-checking the
-// cheap shared classifier on read keeps that in-flight residue out of the
-// very next brief instead of waiting for a later feed poll to overwrite the
-// stamp.
+// buildDigest uses this pure helper so the policy is executable without
+// loading cron configuration or a Redis accumulator harness.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { shouldDropOpinionTrack } from '../scripts/lib/digest-opinion-track-filter.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const seedSrc = readFileSync(
-  resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'),
-  'utf-8',
-);
+const DW_RETROSPECTIVE = {
+  title: "How Turkey's 2016 coup attempt changed the country for good",
+  link: 'https://amp.dw.com/en/how-turkeys-2016-coup-attempt-changed-the-country-for-good/a-77955154',
+  description: 'A reported look back at the coup and its lasting political consequences.',
+  publishedAt: String(Date.UTC(2026, 6, 14)),
+};
 
-const buildDigestStart = seedSrc.indexOf('async function buildDigest(rule, windowStartMs)');
-const afterBuildDigest = seedSrc.indexOf('\nfunction ', buildDigestStart + 1);
-const afterBuildDigestAsync = seedSrc.indexOf('\nasync function ', buildDigestStart + 1);
-const buildDigestEnd = Math.min(
-  afterBuildDigest === -1 ? Number.POSITIVE_INFINITY : afterBuildDigest,
-  afterBuildDigestAsync === -1 ? Number.POSITIVE_INFINITY : afterBuildDigestAsync,
-);
-const buildDigestBody = seedSrc.slice(buildDigestStart, buildDigestEnd);
+describe('shouldDropOpinionTrack — digest read-path stamp policy', () => {
+  it('drops an ingest-stamped historical explainer', () => {
+    assert.equal(shouldDropOpinionTrack({ ...DW_RETROSPECTIVE, isOpinion: '1' }), true);
+  });
 
-describe('buildDigest opinion filter — current classifier rule changes', () => {
-  it('re-checks classifyOpinion even when Redis has an explicit non-opinion stamp', () => {
-    assert.match(
-      buildDigestBody,
-      /stampedOpinion\s*\|\|\s*classifyOpinion\(\{[\s\S]*?title:\s*track\.title/,
-      'must calculate the current shared classifier verdict for every non-opinion row',
+  it('keeps hard news with an explicit non-opinion stamp', () => {
+    assert.equal(
+      shouldDropOpinionTrack({
+        title: 'Iran launches missiles at UAE oil tankers in Strait of Hormuz',
+        link: 'https://example.com/world/hormuz-tankers',
+        description: 'The attacks escalated a regional confrontation overnight.',
+        publishedAt: String(Date.UTC(2026, 6, 15)),
+        isOpinion: '0',
+      }),
+      false,
     );
+  });
+
+  it('drops an unstamped legacy historical explainer', () => {
+    assert.equal(shouldDropOpinionTrack(DW_RETROSPECTIVE), true);
+  });
+
+  it('trusts an explicit legacy non-opinion stamp until the next ingest poll', () => {
+    assert.equal(shouldDropOpinionTrack({ ...DW_RETROSPECTIVE, isOpinion: '0' }), false);
   });
 });

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -67,7 +67,7 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     assert.ok(m.has('lang'));
   });
 
-  it('writes isOpinion as "1" / "0" — stamps the opinion verdict on the row (F3)', () => {
+  it('writes isOpinion as "1" / "0" — stamps the non-event brief verdict on the row (F3)', () => {
     // The brief's read path (buildDigest) excludes isOpinion="1" rows.
     // Written unconditionally for the same shared-row reason as
     // `description`: a stale "1" from an earlier mention must be

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -15,10 +15,12 @@ import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { __testing__ } from '../server/worldmonitor/news/v1/list-feed-digest';
+import { shouldDropOpinionTrack } from '../scripts/lib/digest-opinion-track-filter.mjs';
 
 const {
   buildStoryTrackHsetFields,
   computeEntityCorroborationSignals,
+  parseRssXml,
   promoteDiplomacySeverity,
 } = __testing__;
 
@@ -83,6 +85,30 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     assert.strictEqual(
       fieldsToMap(buildStoryTrackHsetFields(legacyItem as Parameters<typeof buildStoryTrackHsetFields>[0], '1745000000000', 42)).get('isOpinion'),
       '0',
+    );
+  });
+
+  it('carries the DW historical-explainer verdict from RSS parsing into the HSET shape', () => {
+    const result = parseRssXml(
+      `<?xml version="1.0"?><rss><channel><item>
+        <title>How Turkey's 2016 coup attempt changed the country for good</title>
+        <link>https://amp.dw.com/en/how-turkeys-2016-coup-attempt-changed-the-country-for-good/a-77955154</link>
+        <pubDate>Tue, 14 Jul 2026 12:00:00 GMT</pubDate>
+        <description>DW examines the lasting political effects of the failed coup attempt in Turkey.</description>
+      </item></channel></rss>`,
+      { url: 'https://amp.dw.com/rss', name: 'DW News', lang: 'en' },
+      'full',
+    );
+    assert.ok(result, 'RSS parser should return a parse result');
+    const item = result.items[0];
+    assert.ok(item, 'RSS parser should retain the dated item');
+    assert.strictEqual(item.isOpinion, true);
+    const persisted = fieldsToMap(buildStoryTrackHsetFields(item, '1784030400000', 42));
+    assert.strictEqual(persisted.get('isOpinion'), '1');
+    assert.strictEqual(
+      shouldDropOpinionTrack(Object.fromEntries(persisted)),
+      true,
+      'the stamped RSS record must be excluded by the digest read-path policy',
     );
   });
 
@@ -346,7 +372,7 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
 });
 
 describe('fetchAndParseRss — cache prefix invalidation contract', () => {
-  it('rss:feed cache prefix is v6 (post-droppedFeedCap, #4920), not v4/v5', () => {
+  it('rss:feed cache prefix is v7 (stable historical-explainer stamp), not v4/v5/v6', () => {
     // Pre-PR ParsedItems cached at rss:feed:v4 lack the
     // isEphemeralLiveCoverage field. If a cache hit returned one of those,
     // the falsy-coerce in
@@ -363,15 +389,18 @@ describe('fetchAndParseRss — cache prefix invalidation contract', () => {
       resolve(__dirname, '..', 'server', 'worldmonitor', 'news', 'v1', 'list-feed-digest.ts'),
       'utf-8',
     );
-    // v5→v6 (#4920 review): ParseResult gained droppedFeedCap; warm v5
-    // rows lack it and would undercount the coverage ledger for their TTL.
+    // v6→v7: parsed items now stamp historical explainers from their
+    // persisted publication time. Digest reads trust explicit stamps, so
+    // warm v6 rows must not retain a pre-rule "0" verdict for a cache TTL.
     assert.ok(
-      src.includes("`rss:feed:v6:${variant}:${feed.url}`"),
-      'rss:feed cache key must use v6 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
+      src.includes("`rss:feed:v7:${variant}:${feed.url}`"),
+      'rss:feed cache key must use v7 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
     );
     assert.ok(
-      !src.includes("`rss:feed:v5:${variant}:${feed.url}`") && !src.includes("`rss:feed:v4:${variant}:${feed.url}`"),
-      'must NOT leave a residual v4/v5 cacheKey assignment — would silently revert the cutover',
+      !src.includes("`rss:feed:v6:${variant}:${feed.url}`") &&
+        !src.includes("`rss:feed:v5:${variant}:${feed.url}`") &&
+        !src.includes("`rss:feed:v4:${variant}:${feed.url}`"),
+      'must NOT leave a residual v4/v5/v6 cacheKey assignment — would silently revert the cutover',
     );
   });
 });

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -1,10 +1,11 @@
-// Unit tests for the opinion/analysis classifier (F3, Phase 3).
+// Unit tests for the non-event brief classifier (F3, Phase 3).
 //
 // classifyOpinion is the single shared classifier — imported by the
 // ingest path (list-feed-digest.ts, stamps `isOpinion` on the
 // story:track:v1 row) and the read path (buildDigest, re-classifies
-// residue). The brief is event-driven intelligence; an op-ed column
-// is not an event. See docs/plans/2026-05-14-001-…-plan.md.
+// residue). The brief is event-driven intelligence; an op-ed column or
+// historical explainer is not an event. See
+// docs/plans/2026-05-14-001-…-plan.md.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -229,6 +230,58 @@ describe('classifyOpinion — URL match uses parsed pathname, not raw .includes(
         description: 'A straightforward report with no framing words.',
       }),
       true,
+    );
+  });
+});
+
+describe('classifyOpinion — historical explainers are not digest events', () => {
+  it('REGRESSION (July 15): DW ten-year Turkey coup retrospective → exclude', () => {
+    assert.equal(
+      classifyOpinion({
+        title: "How Turkey's 2016 coup attempt changed the country for good",
+        link: 'https://amp.dw.com/en/how-turkeys-2016-coup-attempt-changed-the-country-for-good/a-77955154',
+        description: 'Ten years after the failed coup, the events of that night continue to shape Turkey. A look back.',
+      }),
+      true,
+    );
+  });
+
+  it('excludes an explanatory human-interest retrospective when its historic anchor is in the description', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'How an unwitting cadet became a victim of Turkiye’s anti-coup crackdown',
+        link: 'https://example.com/features/cadet-anti-coup-crackdown',
+        description: 'The cadet was imprisoned following the 2016 coup attempt, a decade before this look back.',
+      }),
+      true,
+    );
+  });
+
+  it('does not suppress a current-event explainer or ordinary historical reference', () => {
+    const currentYear = new Date().getUTCFullYear();
+    assert.equal(
+      classifyOpinion({
+        title: `How Turkey's ${currentYear} election could reshape the country`,
+        link: 'https://example.com/news/turkey-election',
+        description: 'Officials announced the election timetable today.',
+      }),
+      false,
+    );
+    assert.equal(
+      classifyOpinion({
+        title: 'Turkey arrests suspects over the 2016 coup attempt',
+        link: 'https://example.com/news/turkey-arrests',
+        description: 'Authorities announced the arrests today.',
+      }),
+      false,
+    );
+    assert.equal(
+      classifyOpinion({
+        title: `How the ${currentYear} Iran war changed global shipping`,
+        link: 'https://example.com/world/iran-shipping',
+        description: 'Shipping routes are increasingly vulnerable, as they were during the 2016 regional crisis.',
+      }),
+      false,
     );
   });
 });

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -235,54 +235,121 @@ describe('classifyOpinion — URL match uses parsed pathname, not raw .includes(
 });
 
 describe('classifyOpinion — historical explainers are not digest events', () => {
+  const JULY_2026 = Date.UTC(2026, 6, 14);
+
   it('REGRESSION (July 15): DW ten-year Turkey coup retrospective → exclude', () => {
     assert.equal(
       classifyOpinion({
         title: "How Turkey's 2016 coup attempt changed the country for good",
         link: 'https://amp.dw.com/en/how-turkeys-2016-coup-attempt-changed-the-country-for-good/a-77955154',
         description: 'Ten years after the failed coup, the events of that night continue to shape Turkey. A look back.',
+        publishedAt: JULY_2026,
       }),
       true,
     );
   });
 
-  it('excludes an explanatory human-interest retrospective when its historic anchor is in the description', () => {
+  it('trims the headline before matching the explanatory shape', () => {
+    assert.equal(
+      classifyOpinion({
+        title: "  How Turkey's 2016 coup attempt changed the country for good",
+        link: 'https://example.com/features/turkey-coup',
+        publishedAt: JULY_2026,
+      }),
+      true,
+    );
+  });
+
+  it('recognizes every supported historical explainer verb with a stable event-year anchor', () => {
+    for (const verb of ['changed', 'shaped', 'transformed', 'altered', 'became', 'remade', 'defined']) {
+      assert.equal(
+        classifyOpinion({
+          title: `How the 2016 coup attempt ${verb} the country`,
+          link: 'https://example.com/features/coup',
+          publishedAt: JULY_2026,
+        }),
+        true,
+        `${verb} should classify when paired with an historical event year`,
+      );
+    }
+  });
+
+  it('lets an explicit description look-back corroborate a retrospective', () => {
     assert.equal(
       classifyOpinion({
         title: 'How an unwitting cadet became a victim of Turkiye’s anti-coup crackdown',
         link: 'https://example.com/features/cadet-anti-coup-crackdown',
-        description: 'The cadet was imprisoned following the 2016 coup attempt, a decade before this look back.',
+        description: 'This look back follows the cadet’s case and its aftermath.',
+        publishedAt: JULY_2026,
       }),
       true,
     );
   });
 
-  it('does not suppress a current-event explainer or ordinary historical reference', () => {
-    const currentYear = new Date().getUTCFullYear();
+  it('allows a retrospective label in the headline itself', () => {
     assert.equal(
       classifyOpinion({
-        title: `How Turkey's ${currentYear} election could reshape the country`,
-        link: 'https://example.com/news/turkey-election',
-        description: 'Officials announced the election timetable today.',
+        title: 'How the coup attempt changed Turkey: a retrospective',
+        link: 'https://example.com/features/turkey-coup',
+        publishedAt: JULY_2026,
       }),
-      false,
+      true,
     );
+  });
+
+  it('does not let broad anniversary wording in a description drop live coverage', () => {
     assert.equal(
       classifyOpinion({
-        title: 'Turkey arrests suspects over the 2016 coup attempt',
-        link: 'https://example.com/news/turkey-arrests',
-        description: 'Authorities announced the arrests today.',
-      }),
-      false,
-    );
-    assert.equal(
-      classifyOpinion({
-        title: `How the ${currentYear} Iran war changed global shipping`,
+        title: 'How the ceasefire changed Gaza',
         link: 'https://example.com/world/iran-shipping',
-        description: 'Shipping routes are increasingly vulnerable, as they were during the 2016 regional crisis.',
+        description: 'The anniversary of a prior agreement remains relevant as negotiators meet again.',
+        publishedAt: JULY_2026,
       }),
       false,
     );
+  });
+
+  it('vetoes current-event language even when a historic event-year anchor is present', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'How the 2016 coup attempt changed Turkey today',
+        link: 'https://example.com/world/turkey',
+        publishedAt: JULY_2026,
+      }),
+      false,
+    );
+  });
+
+  it('does not treat money or troop counts as an event year', () => {
+    for (const title of ['How $1999 changed household budgets', 'How 2016 troops changed the battlefield']) {
+      assert.equal(
+        classifyOpinion({ title, link: 'https://example.com/world/counts', publishedAt: JULY_2026 }),
+        false,
+        `${title} should not be a historical event anchor`,
+      );
+    }
+  });
+
+  it('does not suppress a hard-news explainer without a historical anchor', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'How the ceasefire changed Gaza',
+        link: 'https://example.com/world/ceasefire',
+        description: 'Officials said the humanitarian situation remains fragile.',
+        publishedAt: JULY_2026,
+      }),
+      false,
+    );
+  });
+
+  it('does not use wall-clock time when the same story is reclassified later', () => {
+    const story = {
+      title: "How Turkey's 2016 coup attempt changed the country for good",
+      link: 'https://example.com/features/turkey-coup',
+      publishedAt: JULY_2026,
+    };
+    assert.equal(classifyOpinion(story), true);
+    assert.equal(classifyOpinion(story), true);
   });
 });
 


### PR DESCRIPTION
## Summary

Historical explainers such as DW's 2016 Turkey-coup retrospective are now classified at RSS ingest and written as an authoritative `isOpinion` stamp before they enter the digest accumulator. The historical rule is conservative: it requires the explanatory headline shape plus a stable article-time historical anchor, rejects live-event language, and never treats a bare four-digit number as a year.

The digest trusts explicit `isOpinion` values and reclassifies only genuinely unstamped legacy rows. A v7 RSS cache prefix forces a fresh parse after deployment, so warm pre-rule records cannot preserve a stale `0` stamp for the cache TTL.

## Validation

- Focused digest/classifier suites: 59 passing
- RSS ingestion, HSET persistence, and historical-guard suites: 98 passing
- `tsc --noEmit`
- Scoped Biome check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
