### PR TITLE
feat(cls): shift-time mover attribution — name what grew, not what moved (#5332)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2292,6 +2292,7 @@ export class PanelLayoutManager implements AppModule {
     // "+" Add Panel block at the end of the grid
     const addPanelBlock = document.createElement('button');
     addPanelBlock.className = 'add-panel-block';
+    addPanelBlock.dataset.clsMover = 'add-panel';
     addPanelBlock.setAttribute('aria-label', t('components.panel.addPanel'));
     const addIcon = document.createElement('span');
     addIcon.className = 'add-panel-block-icon';
@@ -2309,6 +2310,7 @@ export class PanelLayoutManager implements AppModule {
     // Always create Pro and MCP add-panel blocks — show/hide reactively via auth state.
     const proBlock = document.createElement('button');
     proBlock.className = 'add-panel-block ai-widget-block ai-widget-block-pro';
+    proBlock.dataset.clsMover = 'pro-widget-cta';
     proBlock.setAttribute('aria-label', t('widgets.createInteractive'));
     const proIcon = document.createElement('span');
     proIcon.className = 'add-panel-block-icon';
@@ -2338,6 +2340,7 @@ export class PanelLayoutManager implements AppModule {
 
     const mcpBlock = document.createElement('button');
     mcpBlock.className = 'add-panel-block mcp-panel-block';
+    mcpBlock.dataset.clsMover = 'mcp-cta';
     mcpBlock.setAttribute('aria-label', t('mcp.connectPanel'));
     const mcpIcon = document.createElement('span');
     mcpIcon.className = 'add-panel-block-icon';

--- a/src/bootstrap/cls-mover-tracker.ts
+++ b/src/bootstrap/cls-mover-tracker.ts
@@ -79,7 +79,7 @@ export function diffPanelGeometry(
 
 /**
  * Pure: compact per-record strings for the Sentry extra, largest shift first,
- * capped at three. Example: "t=1240 v=0.31 grew:threat-timeline+180 moved:2".
+ * capped at three. Example: "t=1240 v=0.31 sized:threat-timeline+180 moved:2".
  */
 export function formatMoverRecords(records: MoverRecord[]): string[] {
   return [...records]

--- a/src/bootstrap/cls-mover-tracker.ts
+++ b/src/bootstrap/cls-mover-tracker.ts
@@ -8,12 +8,12 @@
  * left field CLS unmoved because the pinned panels were themselves victims.
  *
  * This tracker names movers directly. It keeps a per-panel geometry cache
- * (`data-panel` → {top, height}) and, on every qualifying layout-shift entry,
+ * (stable mover key -> {top, height}) and, on every qualifying layout-shift delivery,
  * diffs the current geometry against the cache: a panel whose HEIGHT changed
  * is a mover; a panel whose position changed at constant height is a victim;
  * a panel present now but absent from the cache is an insertion (mount-order
- * suspects). The most recent records ride the CLS Sentry report (bad-tail
- * only, same volume policy) as compact strings.
+ * suspects). The six-record ring's three largest deliveries ride the CLS
+ * Sentry report (bad-tail only, same volume policy) as compact strings.
  *
  * The diff core is pure and unit-tested without DOM (tests/cls-mover-tracker).
  */
@@ -33,10 +33,12 @@ export interface PanelGeometryDiff {
 }
 
 export interface MoverRecord extends PanelGeometryDiff {
-  /** performance.now() of the triggering layout-shift entry, rounded. */
+  /** startTime of the latest layout-shift entry in this delivery, rounded. */
   t: number;
-  /** The layout-shift entry's value. */
+  /** Sum of the non-input layout-shift values delivered together. */
   value: number;
+  /** Number of layout-shift entries represented when a delivery was batched. */
+  entryCount?: number;
   /** The shift arrived before any baseline snapshot existed — the mover is
    *  unattributable, but the report should still show a big shift happened. */
   coldStart?: boolean;
@@ -99,6 +101,7 @@ export function formatMoverRecords(records: MoverRecord[]): string[] {
       if (r.inserted.length > 0) parts.push(`ins:${r.inserted.join(',')}`);
       if (r.removed.length > 0) parts.push(`rem:${r.removed.join(',')}`);
       if (r.movedOnly.length > 0) parts.push(`moved:${r.movedOnly.length}`);
+      if ((r.entryCount ?? 1) > 1) parts.push(`n=${r.entryCount}`);
       if (r.coldStart) parts.push('cold');
       return parts.join(' ');
     });
@@ -108,18 +111,30 @@ let records: MoverRecord[] = [];
 let cache: Record<string, PanelRect> | null = null;
 let lastRefresh = 0;
 let started = false;
+let observer: PerformanceObserver | null = null;
+let onPageShow: ((event: PageTransitionEvent) => void) | null = null;
 
 function snapshotPanels(): Record<string, PanelRect> | null {
-  const grid = document.getElementById('panelsGrid');
-  if (!grid) return null;
+  const grids = ['panelsGrid', 'mapBottomGrid']
+    .map((id) => document.getElementById(id))
+    .filter((grid): grid is HTMLElement => grid !== null);
+  if (grids.length === 0) return null;
   const out: Record<string, PanelRect> = {};
-  for (const el of grid.querySelectorAll<HTMLElement>(':scope > [data-panel]')) {
-    const key = el.dataset.panel;
-    if (!key) continue;
-    const rect = el.getBoundingClientRect();
-    out[key] = { top: Math.round(rect.top + window.scrollY), height: Math.round(rect.height) };
+  for (const grid of grids) {
+    for (const el of grid.querySelectorAll<HTMLElement>(':scope > [data-panel], :scope > [data-cls-mover]')) {
+      const key = el.dataset.panel ?? el.dataset.clsMover;
+      if (!key) continue;
+      const rect = el.getBoundingClientRect();
+      out[key] = { top: Math.round(rect.top + window.scrollY), height: Math.round(rect.height) };
+    }
   }
-  return Object.keys(out).length > 0 ? out : null;
+  return out;
+}
+
+function resetMoverState(): void {
+  records = [];
+  cache = snapshotPanels();
+  lastRefresh = cache ? performance.now() : 0;
 }
 
 /** Records captured at shift time, for the CLS report to attach at hide time. */
@@ -129,6 +144,10 @@ export function getMoverRecordStrings(): string[] {
 
 /** Test hook: reset module state. */
 export function resetClsMoverTrackingForTesting(): void {
+  observer?.disconnect();
+  observer = null;
+  if (onPageShow && typeof window !== 'undefined') window.removeEventListener('pageshow', onPageShow);
+  onPageShow = null;
   records = [];
   cache = null;
   lastRefresh = 0;
@@ -144,48 +163,60 @@ export function resetClsMoverTrackingForTesting(): void {
 export function startClsMoverTracking(): void {
   if (started || typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') return;
   started = true;
-  cache = snapshotPanels();
-  if (cache) lastRefresh = performance.now();
+  resetMoverState();
   try {
-    new PerformanceObserver((list) => {
-      for (const entry of list.getEntries() as Array<PerformanceEntry & { value: number; hadRecentInput: boolean }>) {
-        if (entry.hadRecentInput) continue;
-        const now = performance.now();
-        if (entry.value >= RECORD_SHIFT_THRESHOLD && !cache) {
-          // Cold cache: the mover is unattributable (no baseline), but a big
-          // shift before first snapshot is exactly the boot/skeleton-swap
-          // class — record its existence and seed the cache (review P2).
-          const current = snapshotPanels();
-          if (current) {
-            records.push({
-              t: Math.round(entry.startTime),
-              value: Math.round(entry.value * 1000) / 1000,
-              heightChangers: [], movedOnly: [], inserted: [], removed: [],
-              coldStart: true,
-            });
-            cache = current;
-            lastRefresh = now;
-          }
-        } else if (entry.value >= RECORD_SHIFT_THRESHOLD && cache) {
-          const current = snapshotPanels();
-          if (current) {
-            const diff = diffPanelGeometry(cache, current);
-            if (diff.heightChangers.length > 0 || diff.inserted.length > 0 || diff.removed.length > 0 || diff.movedOnly.length > 0) {
-              records.push({ t: Math.round(entry.startTime), value: Math.round(entry.value * 1000) / 1000, ...diff });
-              if (records.length > MAX_RECORDS) records = records.slice(-MAX_RECORDS);
-            }
-            cache = current;
-            lastRefresh = now;
-          }
-        } else if (now - lastRefresh > CACHE_REFRESH_MIN_MS) {
-          const current = snapshotPanels();
-          if (current) {
-            cache = current;
-            lastRefresh = now;
+    observer = new PerformanceObserver((list) => {
+      const entries = list.getEntries() as Array<PerformanceEntry & { value: number; hadRecentInput: boolean }>;
+      if (entries.length === 0) return;
+      const now = performance.now();
+
+      // Callback-time geometry cannot be separated when input and non-input
+      // entries are delivered together. Refresh the baseline once and skip
+      // attribution rather than charging input-driven movement to a later CLS.
+      if (entries.some((entry) => entry.hadRecentInput)) {
+        const current = snapshotPanels();
+        if (current) {
+          cache = current;
+          lastRefresh = now;
+        }
+        return;
+      }
+
+      const value = entries.reduce((sum, entry) => sum + entry.value, 0);
+      const latest = entries[entries.length - 1]!;
+      if (value >= RECORD_SHIFT_THRESHOLD) {
+        const current = snapshotPanels();
+        if (!current) return;
+        const roundedValue = Math.round(value * 1000) / 1000;
+        const entryCount = entries.length > 1 ? entries.length : undefined;
+        if (!cache) {
+          records.push({
+            t: Math.round(latest.startTime), value: roundedValue, entryCount,
+            heightChangers: [], movedOnly: [], inserted: [], removed: [],
+            coldStart: true,
+          });
+        } else {
+          const diff = diffPanelGeometry(cache, current);
+          if (diff.heightChangers.length > 0 || diff.inserted.length > 0 || diff.removed.length > 0 || diff.movedOnly.length > 0) {
+            records.push({ t: Math.round(latest.startTime), value: roundedValue, entryCount, ...diff });
           }
         }
+        if (records.length > MAX_RECORDS) records = records.slice(-MAX_RECORDS);
+        cache = current;
+        lastRefresh = now;
+      } else if (now - lastRefresh > CACHE_REFRESH_MIN_MS) {
+        const current = snapshotPanels();
+        if (current) {
+          cache = current;
+          lastRefresh = now;
+        }
       }
-    }).observe({ type: 'layout-shift', buffered: true });
+    });
+    observer.observe({ type: 'layout-shift', buffered: true });
+    onPageShow = (event: PageTransitionEvent): void => {
+      if (event.persisted) resetMoverState();
+    };
+    window.addEventListener('pageshow', onPageShow);
   } catch {
     /* layout-shift unsupported (Safari/Firefox) — CLS reporting is Chromium-sourced anyway. */
   }

--- a/src/bootstrap/cls-mover-tracker.ts
+++ b/src/bootstrap/cls-mover-tracker.ts
@@ -1,0 +1,164 @@
+/**
+ * CLS mover attribution (#5332, #4580).
+ *
+ * `largestShiftTarget`/shifted-content rankings name shift VICTIMS — what
+ * moved — not MOVERS — what changed size and pushed them. That distinction
+ * was proven the hard way twice: fixing the banner (#5137) removed `#main`
+ * from the victim rankings, and pinning the ranked panels' heights (#5333)
+ * left field CLS unmoved because the pinned panels were themselves victims.
+ *
+ * This tracker names movers directly. It keeps a per-panel geometry cache
+ * (`data-panel` → {top, height}) and, on every qualifying layout-shift entry,
+ * diffs the current geometry against the cache: a panel whose HEIGHT changed
+ * is a mover; a panel whose position changed at constant height is a victim;
+ * a panel present now but absent from the cache is an insertion (mount-order
+ * suspects). The most recent records ride the CLS Sentry report (bad-tail
+ * only, same volume policy) as compact strings.
+ *
+ * The diff core is pure and unit-tested without DOM (tests/cls-mover-tracker).
+ */
+
+export interface PanelRect {
+  top: number;
+  height: number;
+}
+
+export interface PanelGeometryDiff {
+  heightChangers: Array<{ key: string; delta: number }>;
+  movedOnly: string[];
+  inserted: string[];
+}
+
+export interface MoverRecord extends PanelGeometryDiff {
+  /** performance.now() of the triggering layout-shift entry, rounded. */
+  t: number;
+  /** The layout-shift entry's value. */
+  value: number;
+}
+
+/** Ignore sub-pixel/jitter deltas — real row growth is tens of pixels. */
+const GEOMETRY_JITTER_PX = 2;
+/** Only diff on shifts big enough to matter; the cache still refreshes below it. */
+const RECORD_SHIFT_THRESHOLD = 0.05;
+/** Ring size for recorded diffs; the report keeps the top 3 by value. */
+const MAX_RECORDS = 6;
+/** Cache refreshes are rate-limited between recorded diffs. */
+const CACHE_REFRESH_MIN_MS = 500;
+
+/** Pure: classify panels by what changed between two geometry snapshots. */
+export function diffPanelGeometry(
+  cache: Record<string, PanelRect>,
+  current: Record<string, PanelRect>,
+): PanelGeometryDiff {
+  const heightChangers: Array<{ key: string; delta: number }> = [];
+  const movedOnly: string[] = [];
+  const inserted: string[] = [];
+  for (const [key, rect] of Object.entries(current)) {
+    const prev = cache[key];
+    if (!prev) {
+      inserted.push(key);
+      continue;
+    }
+    const dH = rect.height - prev.height;
+    const dTop = rect.top - prev.top;
+    if (Math.abs(dH) > GEOMETRY_JITTER_PX) {
+      heightChangers.push({ key, delta: Math.round(dH) });
+    } else if (Math.abs(dTop) > GEOMETRY_JITTER_PX) {
+      movedOnly.push(key);
+    }
+  }
+  return { heightChangers, movedOnly, inserted };
+}
+
+/**
+ * Pure: compact per-record strings for the Sentry extra, largest shift first,
+ * capped at three. Example: "t=1240 v=0.31 grew:threat-timeline+180 moved:2".
+ */
+export function formatMoverRecords(records: MoverRecord[]): string[] {
+  return [...records]
+    .sort((a, b) => b.value - a.value)
+    .slice(0, 3)
+    .map((r) => {
+      const parts = [`t=${r.t} v=${r.value}`];
+      if (r.heightChangers.length > 0) {
+        parts.push(
+          `grew:${r.heightChangers
+            .map((c) => `${c.key}${c.delta >= 0 ? '+' : ''}${c.delta}`)
+            .join(',')}`,
+        );
+      }
+      if (r.inserted.length > 0) parts.push(`ins:${r.inserted.join(',')}`);
+      if (r.movedOnly.length > 0) parts.push(`moved:${r.movedOnly.length}`);
+      return parts.join(' ');
+    });
+}
+
+let records: MoverRecord[] = [];
+let cache: Record<string, PanelRect> | null = null;
+let lastRefresh = 0;
+let started = false;
+
+function snapshotPanels(): Record<string, PanelRect> | null {
+  const grid = document.getElementById('panelsGrid');
+  if (!grid) return null;
+  const out: Record<string, PanelRect> = {};
+  for (const el of grid.querySelectorAll<HTMLElement>(':scope > [data-panel]')) {
+    const key = el.dataset.panel;
+    if (!key) continue;
+    const rect = el.getBoundingClientRect();
+    out[key] = { top: Math.round(rect.top + window.scrollY), height: Math.round(rect.height) };
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/** Records captured at shift time, for the CLS report to attach at hide time. */
+export function getMoverRecordStrings(): string[] {
+  return formatMoverRecords(records);
+}
+
+/** Test hook: reset module state. */
+export function resetClsMoverTrackingForTesting(): void {
+  records = [];
+  cache = null;
+  lastRefresh = 0;
+  started = false;
+}
+
+/**
+ * Start shift-time geometry tracking. Browser-only, idempotent, and inert
+ * when PerformanceObserver/layout-shift is unavailable. Reads ~80 panel rects
+ * per qualifying shift — the observer callback runs after layout, so the
+ * reads are clean; refreshes between recorded shifts are rate-limited.
+ */
+export function startClsMoverTracking(): void {
+  if (started || typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') return;
+  started = true;
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries() as Array<PerformanceEntry & { value: number; hadRecentInput: boolean }>) {
+        if (entry.hadRecentInput) continue;
+        const now = performance.now();
+        if (entry.value >= RECORD_SHIFT_THRESHOLD && cache) {
+          const current = snapshotPanels();
+          if (current) {
+            const diff = diffPanelGeometry(cache, current);
+            if (diff.heightChangers.length > 0 || diff.inserted.length > 0 || diff.movedOnly.length > 0) {
+              records.push({ t: Math.round(entry.startTime), value: Math.round(entry.value * 1000) / 1000, ...diff });
+              if (records.length > MAX_RECORDS) records = records.slice(-MAX_RECORDS);
+            }
+            cache = current;
+            lastRefresh = now;
+          }
+        } else if (now - lastRefresh > CACHE_REFRESH_MIN_MS) {
+          const current = snapshotPanels();
+          if (current) {
+            cache = current;
+            lastRefresh = now;
+          }
+        }
+      }
+    }).observe({ type: 'layout-shift', buffered: true });
+  } catch {
+    /* layout-shift unsupported (Safari/Firefox) — CLS reporting is Chromium-sourced anyway. */
+  }
+}

--- a/src/bootstrap/cls-mover-tracker.ts
+++ b/src/bootstrap/cls-mover-tracker.ts
@@ -27,6 +27,9 @@ export interface PanelGeometryDiff {
   heightChangers: Array<{ key: string; delta: number }>;
   movedOnly: string[];
   inserted: string[];
+  /** Panels in the cache but gone from the layout — removal collapses their
+   *  occupied height and pulls siblings up, a mover class of its own. */
+  removed: string[];
 }
 
 export interface MoverRecord extends PanelGeometryDiff {
@@ -34,6 +37,9 @@ export interface MoverRecord extends PanelGeometryDiff {
   t: number;
   /** The layout-shift entry's value. */
   value: number;
+  /** The shift arrived before any baseline snapshot existed — the mover is
+   *  unattributable, but the report should still show a big shift happened. */
+  coldStart?: boolean;
 }
 
 /** Ignore sub-pixel/jitter deltas — real row growth is tens of pixels. */
@@ -53,6 +59,7 @@ export function diffPanelGeometry(
   const heightChangers: Array<{ key: string; delta: number }> = [];
   const movedOnly: string[] = [];
   const inserted: string[] = [];
+  const removed = Object.keys(cache).filter((key) => !(key in current));
   for (const [key, rect] of Object.entries(current)) {
     const prev = cache[key];
     if (!prev) {
@@ -67,7 +74,7 @@ export function diffPanelGeometry(
       movedOnly.push(key);
     }
   }
-  return { heightChangers, movedOnly, inserted };
+  return { heightChangers, movedOnly, inserted, removed };
 }
 
 /**
@@ -81,14 +88,18 @@ export function formatMoverRecords(records: MoverRecord[]): string[] {
     .map((r) => {
       const parts = [`t=${r.t} v=${r.value}`];
       if (r.heightChangers.length > 0) {
+        // 'sized:' not 'grew:' — the signed delta carries direction, and a
+        // shrinking panel that pulled space away is a mover too (review P2).
         parts.push(
-          `grew:${r.heightChangers
+          `sized:${r.heightChangers
             .map((c) => `${c.key}${c.delta >= 0 ? '+' : ''}${c.delta}`)
             .join(',')}`,
         );
       }
       if (r.inserted.length > 0) parts.push(`ins:${r.inserted.join(',')}`);
+      if (r.removed.length > 0) parts.push(`rem:${r.removed.join(',')}`);
       if (r.movedOnly.length > 0) parts.push(`moved:${r.movedOnly.length}`);
+      if (r.coldStart) parts.push('cold');
       return parts.join(' ');
     });
 }
@@ -133,16 +144,33 @@ export function resetClsMoverTrackingForTesting(): void {
 export function startClsMoverTracking(): void {
   if (started || typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') return;
   started = true;
+  cache = snapshotPanels();
+  if (cache) lastRefresh = performance.now();
   try {
     new PerformanceObserver((list) => {
       for (const entry of list.getEntries() as Array<PerformanceEntry & { value: number; hadRecentInput: boolean }>) {
         if (entry.hadRecentInput) continue;
         const now = performance.now();
-        if (entry.value >= RECORD_SHIFT_THRESHOLD && cache) {
+        if (entry.value >= RECORD_SHIFT_THRESHOLD && !cache) {
+          // Cold cache: the mover is unattributable (no baseline), but a big
+          // shift before first snapshot is exactly the boot/skeleton-swap
+          // class — record its existence and seed the cache (review P2).
+          const current = snapshotPanels();
+          if (current) {
+            records.push({
+              t: Math.round(entry.startTime),
+              value: Math.round(entry.value * 1000) / 1000,
+              heightChangers: [], movedOnly: [], inserted: [], removed: [],
+              coldStart: true,
+            });
+            cache = current;
+            lastRefresh = now;
+          }
+        } else if (entry.value >= RECORD_SHIFT_THRESHOLD && cache) {
           const current = snapshotPanels();
           if (current) {
             const diff = diffPanelGeometry(cache, current);
-            if (diff.heightChangers.length > 0 || diff.inserted.length > 0 || diff.movedOnly.length > 0) {
+            if (diff.heightChangers.length > 0 || diff.inserted.length > 0 || diff.removed.length > 0 || diff.movedOnly.length > 0) {
               records.push({ t: Math.round(entry.startTime), value: Math.round(entry.value * 1000) / 1000, ...diff });
               if (records.length > MAX_RECORDS) records = records.slice(-MAX_RECORDS);
             }

--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -93,6 +93,9 @@ export function reportClsMetric(
   if (!keep()) return;
   const a = metric.attribution ?? {};
   const formFactor = getWebVitalsFormFactor();
+  // Snapshot at metric-report time. The Sentry closure may drain ~12s later,
+  // after more shifts or a bfcache lifecycle reset have changed tracker state.
+  const moverRecords = [...movers()];
   enqueue((s) => {
     s.captureMessage('web-vital: CLS', {
       level: 'info',
@@ -117,7 +120,7 @@ export function reportClsMetric(
         // (movers) vs merely moved (victims) vs got inserted, captured by
         // cls-mover-tracker at the moment of each qualifying shift. The
         // victim-only largestShiftTarget cannot distinguish these.
-        movers: movers(),
+        movers: moverRecords,
       },
     });
   });

--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -14,6 +14,7 @@
  * the reportable logic free of that import so it builds and is unit-tested
  * without the package present.
  */
+import { getMoverRecordStrings, startClsMoverTracking } from '@/bootstrap/cls-mover-tracker';
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 import {
   getWebVitalsFormFactor,
@@ -82,6 +83,7 @@ export function reportClsMetric(
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
   env: ClsReportEnv = collectClsReportEnv(),
   keep: () => boolean = shouldSampleWebVital,
+  movers: () => string[] = getMoverRecordStrings,
 ): void {
   // Volume trim: skip 'good' (<0.1) CLS and report needs-improvement / poor /
   // unknown only, so field attribution stays focused on actionable shifts.
@@ -111,6 +113,11 @@ export function reportClsMetric(
         visibilityState: env.visibilityState,
         scrollY: env.scrollY,
         viewport: env.viewport,
+        // #5332: shift-time mover attribution — which panels CHANGED HEIGHT
+        // (movers) vs merely moved (victims) vs got inserted, captured by
+        // cls-mover-tracker at the moment of each qualifying shift. The
+        // victim-only largestShiftTarget cannot distinguish these.
+        movers: movers(),
       },
     });
   });
@@ -132,6 +139,10 @@ export function registerClsReporting(): void {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') hadHiddenPeriod = true;
   });
+  // #5332: shift-time geometry tracking must start now — the CLS report fires
+  // at hide time, long after the shifts, so movers are only nameable if the
+  // per-panel cache diffs were captured when each shift happened.
+  startClsMoverTracking();
   void import('web-vitals/attribution')
     .then(({ onCLS }) => {
       onCLS((metric) => reportClsMetric(metric as unknown as ClsMetricLike));

--- a/tests/cls-mover-tracker.test.mts
+++ b/tests/cls-mover-tracker.test.mts
@@ -3,6 +3,9 @@ import { describe, it } from 'node:test';
 import {
   diffPanelGeometry,
   formatMoverRecords,
+  getMoverRecordStrings,
+  resetClsMoverTrackingForTesting,
+  startClsMoverTracking,
   type PanelRect,
 } from '../src/bootstrap/cls-mover-tracker';
 
@@ -15,6 +18,99 @@ import {
 // insertion. The diff core is pure and tested here without DOM.
 
 const r = (top: number, height: number): PanelRect => ({ top, height });
+
+function withGlobals<T>(values: Record<string, unknown>, fn: () => T): T {
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    descriptors.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { configurable: true, value });
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [key, descriptor] of descriptors) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else delete (globalThis as Record<string, unknown>)[key];
+    }
+  }
+}
+
+interface FakePanel {
+  dataset: { panel?: string; clsMover?: string };
+  top: number;
+  height: number;
+  getBoundingClientRect: () => { top: number; height: number };
+}
+
+function fakePanel(key: string, top: number, height: number, kind: 'panel' | 'mover' = 'panel'): FakePanel {
+  const panel: FakePanel = {
+    dataset: kind === 'panel' ? { panel: key } : { clsMover: key },
+    top,
+    height,
+    getBoundingClientRect: () => ({ top: panel.top, height: panel.height }),
+  };
+  return panel;
+}
+
+function withTrackerHarness<T>(
+  initialGrid: FakePanel[] | null,
+  fn: (harness: {
+    setGrid: (panels: FakePanel[] | null) => void;
+    deliver: (entries: Array<{ startTime: number; value: number; hadRecentInput: boolean }>) => void;
+    restoreFromBfcache: () => void;
+    observeCalls: () => number;
+  }) => T,
+): T {
+  let panelsGrid = initialGrid;
+  let callback: ((list: { getEntries: () => unknown[] }) => void) | undefined;
+  let observeCount = 0;
+  const pageShowListeners = new Set<(event: { persisted: boolean }) => void>();
+  const grid = {
+    querySelectorAll: () => panelsGrid ?? [],
+  };
+  const fakeDocument = {
+    getElementById: (id: string) => id === 'panelsGrid' && panelsGrid !== null ? grid : null,
+  };
+  const fakeWindow = {
+    scrollY: 0,
+    addEventListener: (type: string, listener: (event: { persisted: boolean }) => void) => {
+      if (type === 'pageshow') pageShowListeners.add(listener);
+    },
+    removeEventListener: (type: string, listener: (event: { persisted: boolean }) => void) => {
+      if (type === 'pageshow') pageShowListeners.delete(listener);
+    },
+  };
+  class FakePerformanceObserver {
+    constructor(cb: (list: { getEntries: () => unknown[] }) => void) {
+      callback = cb;
+    }
+    observe(): void {
+      observeCount += 1;
+    }
+    disconnect(): void {}
+  }
+
+  return withGlobals({
+    document: fakeDocument,
+    window: fakeWindow,
+    performance: { now: () => 1_000 },
+    PerformanceObserver: FakePerformanceObserver,
+  }, () => {
+    resetClsMoverTrackingForTesting();
+    try {
+      return fn({
+        setGrid: (panels) => { panelsGrid = panels; },
+        deliver: (entries) => callback?.({ getEntries: () => entries }),
+        restoreFromBfcache: () => {
+          for (const listener of pageShowListeners) listener({ persisted: true });
+        },
+        observeCalls: () => observeCount,
+      });
+    } finally {
+      resetClsMoverTrackingForTesting();
+    }
+  });
+}
 
 describe('diffPanelGeometry (#5332 mover attribution)', () => {
   it('classifies height changes as movers with signed deltas', () => {
@@ -87,5 +183,66 @@ describe('removed-panel detection (review P2)', () => {
     );
     assert.deepEqual(d.removed, ['live-news']);
     assert.deepEqual(d.heightChangers, []);
+  });
+});
+
+describe('startClsMoverTracking observer lifecycle', () => {
+  it('refreshes after input shifts and attributes one combined observer delivery', () => {
+    const intel = fakePanel('intel', 100, 200);
+    const politics = fakePanel('politics', 320, 200);
+    withTrackerHarness([intel, politics], ({ deliver, observeCalls }) => {
+      startClsMoverTracking();
+      startClsMoverTracking();
+      assert.equal(observeCalls(), 1, 'tracker startup is idempotent');
+
+      intel.height = 300;
+      politics.top = 420;
+      deliver([{ startTime: 100, value: 0.03, hadRecentInput: true }]);
+      assert.deepEqual(getMoverRecordStrings(), [], 'input-driven shifts only refresh the baseline');
+
+      politics.top = 450;
+      deliver([
+        { startTime: 200, value: 0.03, hadRecentInput: false },
+        { startTime: 220, value: 0.03, hadRecentInput: false },
+      ]);
+      assert.deepEqual(getMoverRecordStrings(), ['t=220 v=0.06 moved:1 n=2']);
+    });
+  });
+
+  it('tracks stable CTA mover keys and clears the ring on bfcache restore', () => {
+    const intel = fakePanel('intel', 100, 200);
+    const proCta = fakePanel('pro-widget-cta', 320, 200, 'mover');
+    withTrackerHarness([intel], ({ setGrid, deliver, restoreFromBfcache }) => {
+      startClsMoverTracking();
+      setGrid([intel, proCta]);
+      deliver([{ startTime: 300, value: 0.1, hadRecentInput: false }]);
+      assert.deepEqual(getMoverRecordStrings(), ['t=300 v=0.1 ins:pro-widget-cta']);
+
+      restoreFromBfcache();
+      assert.deepEqual(getMoverRecordStrings(), []);
+      proCta.height = 260;
+      deliver([{ startTime: 900, value: 0.12, hadRecentInput: false }]);
+      assert.deepEqual(getMoverRecordStrings(), ['t=900 v=0.12 sized:pro-widget-cta+60']);
+    });
+  });
+
+  it('records all tracked children disappearing as removals', () => {
+    const intel = fakePanel('intel', 100, 200);
+    withTrackerHarness([intel], ({ setGrid, deliver }) => {
+      startClsMoverTracking();
+      setGrid([]);
+      deliver([{ startTime: 500, value: 0.1, hadRecentInput: false }]);
+      assert.deepEqual(getMoverRecordStrings(), ['t=500 v=0.1 rem:intel']);
+    });
+  });
+
+  it('marks the first qualifying shift cold when registration precedes the grid', () => {
+    const intel = fakePanel('intel', 100, 200);
+    withTrackerHarness(null, ({ setGrid, deliver }) => {
+      startClsMoverTracking();
+      setGrid([intel]);
+      deliver([{ startTime: 120, value: 0.2, hadRecentInput: false }]);
+      assert.deepEqual(getMoverRecordStrings(), ['t=120 v=0.2 cold']);
+    });
   });
 });

--- a/tests/cls-mover-tracker.test.mts
+++ b/tests/cls-mover-tracker.test.mts
@@ -25,6 +25,7 @@ describe('diffPanelGeometry (#5332 mover attribution)', () => {
     assert.deepEqual(d.heightChangers, [{ key: 'intel', delta: 180 }]);
     assert.deepEqual(d.movedOnly, ['politics']);
     assert.deepEqual(d.inserted, []);
+    assert.deepEqual(d.removed, []);
   });
 
   it('classifies shrinkage as a mover too', () => {
@@ -53,18 +54,38 @@ describe('diffPanelGeometry (#5332 mover attribution)', () => {
 describe('formatMoverRecords', () => {
   it('formats compact strings, largest shift first, capped at three', () => {
     const out = formatMoverRecords([
-      { t: 1200, value: 0.31, heightChangers: [{ key: 'threat-timeline', delta: 180 }], inserted: [], movedOnly: ['intel', 'politics'] },
-      { t: 400, value: 0.08, heightChangers: [], inserted: ['live-news'], movedOnly: [] },
-      { t: 3000, value: 0.5, heightChangers: [{ key: 'cascade', delta: -64 }], inserted: [], movedOnly: [] },
-      { t: 9000, value: 0.02, heightChangers: [{ key: 'x', delta: 10 }], inserted: [], movedOnly: [] },
+      { t: 1200, value: 0.31, heightChangers: [{ key: 'threat-timeline', delta: 180 }], inserted: [], removed: [], movedOnly: ['intel', 'politics'] },
+      { t: 400, value: 0.08, heightChangers: [], inserted: ['live-news'], removed: [], movedOnly: [] },
+      { t: 3000, value: 0.5, heightChangers: [{ key: 'cascade', delta: -64 }], inserted: [], removed: [], movedOnly: [] },
+      { t: 9000, value: 0.02, heightChangers: [{ key: 'x', delta: 10 }], inserted: [], removed: [], movedOnly: [] },
     ]);
     assert.equal(out.length, 3);
-    assert.match(out[0], /^t=3000 v=0\.5 grew:cascade-64/);
-    assert.match(out[1], /^t=1200 v=0\.31 grew:threat-timeline\+180 moved:2/);
+    assert.match(out[0], /^t=3000 v=0\.5 sized:cascade-64/);
+    assert.match(out[1], /^t=1200 v=0\.31 sized:threat-timeline\+180 moved:2/);
     assert.match(out[2], /^t=400 v=0\.08 ins:live-news/);
   });
 
   it('returns an empty array for no records', () => {
     assert.deepEqual(formatMoverRecords([]), []);
+  });
+
+  it('labels removed panels and cold-start records (review P2s)', () => {
+    const out = formatMoverRecords([
+      { t: 800, value: 0.2, heightChangers: [], inserted: [], removed: ['live-news'], movedOnly: ['intel'] },
+      { t: 300, value: 0.4, heightChangers: [], inserted: [], removed: [], movedOnly: [], coldStart: true },
+    ]);
+    assert.match(out[0], /^t=300 v=0\.4 cold$/);
+    assert.match(out[1], /^t=800 v=0\.2 rem:live-news moved:1$/);
+  });
+});
+
+describe('removed-panel detection (review P2)', () => {
+  it('reports panels in the cache but gone from the layout as removed movers', () => {
+    const d = diffPanelGeometry(
+      { intel: r(100, 200), 'live-news': r(320, 764) },
+      { intel: r(100, 200) },
+    );
+    assert.deepEqual(d.removed, ['live-news']);
+    assert.deepEqual(d.heightChangers, []);
   });
 });

--- a/tests/cls-mover-tracker.test.mts
+++ b/tests/cls-mover-tracker.test.mts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  diffPanelGeometry,
+  formatMoverRecords,
+  type PanelRect,
+} from '../src/bootstrap/cls-mover-tracker';
+
+// #5332: the clsText/largestShiftTarget rankings measure shift VICTIMS (what
+// moved), not MOVERS (what changed size and pushed them) — proven when pinning
+// the ranked panels' heights left field CLS unmoved. This module names movers
+// directly: at shift time it diffs a per-panel geometry cache; a panel whose
+// HEIGHT changed is a mover, a panel whose position changed at constant height
+// is a victim, and a panel present now but absent from the cache is an
+// insertion. The diff core is pure and tested here without DOM.
+
+const r = (top: number, height: number): PanelRect => ({ top, height });
+
+describe('diffPanelGeometry (#5332 mover attribution)', () => {
+  it('classifies height changes as movers with signed deltas', () => {
+    const d = diffPanelGeometry(
+      { intel: r(100, 200), politics: r(320, 200) },
+      { intel: r(100, 380), politics: r(500, 200) },
+    );
+    assert.deepEqual(d.heightChangers, [{ key: 'intel', delta: 180 }]);
+    assert.deepEqual(d.movedOnly, ['politics']);
+    assert.deepEqual(d.inserted, []);
+  });
+
+  it('classifies shrinkage as a mover too', () => {
+    const d = diffPanelGeometry({ intel: r(100, 380) }, { intel: r(100, 200) });
+    assert.deepEqual(d.heightChangers, [{ key: 'intel', delta: -180 }]);
+  });
+
+  it('ignores sub-threshold jitter (<=2px)', () => {
+    const d = diffPanelGeometry({ intel: r(100, 200) }, { intel: r(101, 202) });
+    assert.deepEqual(d.heightChangers, []);
+    assert.deepEqual(d.movedOnly, []);
+  });
+
+  it('reports panels present now but not in the cache as insertions', () => {
+    const d = diffPanelGeometry({ intel: r(100, 200) }, { intel: r(100, 200), 'live-news': r(320, 764) });
+    assert.deepEqual(d.inserted, ['live-news']);
+  });
+
+  it('a mover is not double-counted as a victim', () => {
+    const d = diffPanelGeometry({ intel: r(100, 200) }, { intel: r(50, 380) });
+    assert.deepEqual(d.heightChangers, [{ key: 'intel', delta: 180 }]);
+    assert.deepEqual(d.movedOnly, []);
+  });
+});
+
+describe('formatMoverRecords', () => {
+  it('formats compact strings, largest shift first, capped at three', () => {
+    const out = formatMoverRecords([
+      { t: 1200, value: 0.31, heightChangers: [{ key: 'threat-timeline', delta: 180 }], inserted: [], movedOnly: ['intel', 'politics'] },
+      { t: 400, value: 0.08, heightChangers: [], inserted: ['live-news'], movedOnly: [] },
+      { t: 3000, value: 0.5, heightChangers: [{ key: 'cascade', delta: -64 }], inserted: [], movedOnly: [] },
+      { t: 9000, value: 0.02, heightChangers: [{ key: 'x', delta: 10 }], inserted: [], movedOnly: [] },
+    ]);
+    assert.equal(out.length, 3);
+    assert.match(out[0], /^t=3000 v=0\.5 grew:cascade-64/);
+    assert.match(out[1], /^t=1200 v=0\.31 grew:threat-timeline\+180 moved:2/);
+    assert.match(out[2], /^t=400 v=0\.08 ins:live-news/);
+  });
+
+  it('returns an empty array for no records', () => {
+    assert.deepEqual(formatMoverRecords([]), []);
+  });
+});

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -124,6 +124,26 @@ test('reportClsMetric captures formFactor before deferred Sentry drain', () => {
   assert.equal(out.ctx.tags.formFactor, 'mobile');
 });
 
+test('reportClsMetric snapshots movers before deferred Sentry drain', () => {
+  let queued: ((s: any) => void) | undefined;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    queued = fn;
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  const movers = ['t=100 v=0.2 sized:intel+80'];
+  reportClsMetric(
+    { value: 0.22, rating: 'poor' },
+    fakeEnqueue,
+    undefined,
+    () => true,
+    () => movers,
+  );
+  movers.push('t=900 v=0.4 ins:late-panel');
+
+  let ctx: any;
+  queued?.({ captureMessage: (_msg: string, value: unknown) => { ctx = value; } });
+  assert.deepEqual(ctx.extra.movers, ['t=100 v=0.2 sized:intel+80']);
+});
+
 test('collectClsReportEnv is safe (empty) in non-browser contexts', () => {
   // Node test runner has no window/document; the collector must not throw and
   // the report path must still work with the resulting empty env.


### PR DESCRIPTION
## Summary

PR #5333's field verdict (posted on #5332) proved that our CLS offender rankings measure **victims, not movers** — pinning the ranked panels' heights left field CLS flat (`div.panel` p75 0.169→0.172-0.175) because those panels were being *pushed*, not growing. Same trap as the cached-mode banner (#5137), one level down.

This PR adds direct mover attribution instead of a third inference: `src/bootstrap/cls-mover-tracker.ts` keeps a per-panel geometry cache and, at the moment of each qualifying layout-shift entry (≥0.05, no recent input), diffs current geometry against it — height-changers = movers, moved-at-constant-height = victims, absent-from-cache = insertions. The most recent records ride the existing CLS Sentry report as `extra.movers` compact strings (same bad-tail + sampling policy, zero extra events).

Key design constraint honored: `onCLS` reports at hide time, long after the shifts — so capture happens at shift time via the tracker's own observer, started from `registerClsReporting()`.

## Validation
- Red-first pure-core tests: `tests/cls-mover-tracker.test.mts` (7 cases — grow/shrink/jitter-threshold/insertion/mover-not-victim/formatting/caps); reporter suite unchanged and green (17/17 combined); `tsc` + biome clean.
- Build + browser smoke: zero pageerrors with the tracker active; observer inert where `layout-shift` is unsupported.
- Perf posture: rect reads only inside PO callbacks (post-layout), cache refreshes rate-limited (500ms) between recorded shifts, ring capped at 6 records / top-3 reported.

## Post-Deploy
24h of `extra.movers` in Sentry (`webvital:cls`, `formFactor:desktop`) names the true grid mover among the suspects (late panel insertion / col-span restoration / dense packing / add-panel-block). The fix for the named mechanism is then scoped from data. Part of #5332 / #4580 — not auto-closing either.

https://claude.ai/code/session_01PgggD2v8bpN5evLAgNCuZ6
