### PR TITLE
fix(comtrade): restore HS preview classifier

### DIFF
--- a/scripts/seed-trade-flows.mjs
+++ b/scripts/seed-trade-flows.mjs
@@ -11,6 +11,7 @@ const CANONICAL_KEY = 'comtrade:flows:v1';
 const CACHE_TTL = 259200; // 72h = 3× daily interval
 export const KEY_PREFIX = 'comtrade:flows';
 const COMTRADE_BASE = 'https://comtradeapi.un.org/public/v1';
+const COMTRADE_PREVIEW_CLASSIFIER = 'HS'; // API route family; metadata tracks the active H6/HS2022 revision separately.
 export const INTER_REQUEST_DELAY_MS = 3_000;
 export const TRADE_FLOW_FETCH_PHASE_TIMEOUT_MS = 25 * 60 * 1000;
 export const TRADE_FLOW_LOCK_TTL_MS = 30 * 60 * 1000;
@@ -71,7 +72,6 @@ export function candidatePeriods(now = new Date()) {
 
 const require = createRequire(import.meta.url);
 const STRATEGIC_PRODUCT_METADATA = require('./shared/comtrade-strategic-products.json');
-const COMTRADE_CLASSIFICATION_CODE = STRATEGIC_PRODUCT_METADATA.classification.code;
 const COMMODITIES = STRATEGIC_PRODUCT_METADATA.products
   .filter((product) => product.tradeFlowCode)
   .map((product) => ({
@@ -96,7 +96,7 @@ let _retrySleep = sleep;
 export function __setSleepForTests(fn) { _retrySleep = typeof fn === 'function' ? fn : sleep; }
 
 export async function fetchFlows(reporter, commodity, period = recentPeriod(), opts = {}) {
-  const url = new URL(`${COMTRADE_BASE}/preview/C/A/${COMTRADE_CLASSIFICATION_CODE}`);
+  const url = new URL(`${COMTRADE_BASE}/preview/C/A/${COMTRADE_PREVIEW_CLASSIFIER}`);
   url.searchParams.set('reporterCode', reporter.code);
   url.searchParams.set('cmdCode', commodity.code);
   url.searchParams.set('flowCode', 'X,M'); // exports + imports

--- a/tests/seed-trade-flows-period-gate.test.mjs
+++ b/tests/seed-trade-flows-period-gate.test.mjs
@@ -63,6 +63,17 @@ test('fetchFlows pins an explicit lagged period (not the bleeding-edge default)'
   assert.ok(url.includes(lagYear), `period window should include the newest safely-published year (${lagYear}); got: ${url}`);
 });
 
+test('fetchFlows uses the stable HS preview route while product metadata tracks HS2022', async () => {
+  await fetchFlows({ code: '156', name: 'China' }, { code: '8542', desc: 'Semiconductors' }, '2024');
+  const url = new URL(fetchCalls[0]);
+
+  assert.equal(
+    url.pathname,
+    '/public/v1/preview/C/A/HS',
+    'the preview API route classifier is HS; H6 is the HS2022 dataset revision and returns HTTP 500 when used in this path',
+  );
+});
+
 // --- Defect 2: structurally-absent reporters must not block publish ---
 const REQUIRED_FOUR = [
   { code: '842', name: 'USA' },


### PR DESCRIPTION
UN Comtrade strategic-flow seeding can publish again instead of timing out with 0/20 coverage and aging into `STALE_SEED`. The preview API route now stays on the stable `HS` classifier while shared product metadata continues to describe the active `H6`/HS2022 revision, separating two values the upstream API treats differently.

A regression test pins the generated request pathname. The corrected live request returned HTTP 200, all 46 adjacent Comtrade and China coverage tests passed, and the repository pre-push gate completed successfully.

Observed in the [Seed Freshness Monitor failure](https://github.com/koala73/worldmonitor/actions/runs/29439454230/job/87434369219).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
