### PR TITLE
fix(brief): catch duration-led historical explainers

### DIFF
--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -111,9 +111,18 @@ const CORROBORATING_DESCRIPTION_RE = /\b(?:columnist|op-?ed|opinion piece|our co
 // deliberately conservative: a false positive silently removes a live event.
 // This caught the July 2026 DW ten-year Turkey coup retrospective.
 const HISTORICAL_EXPLAINER_HEADLINE_RE =
-  /^(?:how|why)\b[\s\S]{0,180}\b(?:changed|shaped|transformed|altered|became|remade|defined)\b/i;
+  /^(?:how|why)\b[\s\S]{0,180}\b(?:changed|(?:re)?shaped|transformed|altered|became|remade|defined)\b/i;
+// Duration-led anniversary explainers use a different headline shape from the
+// How/Why form above: "10 years on from <past event>". That shape alone is not
+// enough because publishers also use it for live commemorations and new
+// enforcement actions. Require legacy/lasting-impact framing in the title or
+// description as the second, retrospective signal.
+const HISTORICAL_ANNIVERSARY_HEADLINE_RE =
+  /^(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)|a\s+decade)\s+(?:on(?:\s+from)?|after|since)\b/i;
+const HISTORICAL_ANNIVERSARY_CONTEXT_RE =
+  /\b(?:legacy|lasting\s+(?:impact|effects?|consequences?)|long[-\s]?term\s+(?:impact|effects?|consequences?)|continues?\s+to\s+(?:shape|influence|define)|remains?\s+divided)\b/i;
 const HISTORICAL_EXPLAINER_TITLE_TIME_RE =
-  /\b(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)\s+(?:ago|after|later)|anniversary|retrospective|(?:a|this)\s+look back)\b/i;
+  /\b(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)\s+(?:ago|after|later|on(?:\s+from)?|since)|anniversary|retrospective|(?:a|this)\s+look back)\b/i;
 const HISTORICAL_EXPLAINER_DESCRIPTION_LOOKBACK_RE = /\b(?:a|this)\s+look[-\s]?back\b/i;
 const HISTORICAL_EXPLAINER_LIVE_EVENT_RE = /\b(?:today|overnight|this morning|an?\s+hour ago|hours ago|breaking)\b/i;
 // A four-digit number alone is not an event year: it can be a troop count,
@@ -144,8 +153,13 @@ function hasHistoricalEventYear(title, publishedAt) {
 
 function isHistoricalExplainer(title, description, publishedAt) {
   const headline = title.trim();
+  const fullText = `${headline} ${description}`;
+  if (HISTORICAL_EXPLAINER_LIVE_EVENT_RE.test(fullText)) return false;
+  if (
+    HISTORICAL_ANNIVERSARY_HEADLINE_RE.test(headline) &&
+    HISTORICAL_ANNIVERSARY_CONTEXT_RE.test(fullText)
+  ) return true;
   if (!HISTORICAL_EXPLAINER_HEADLINE_RE.test(headline)) return false;
-  if (HISTORICAL_EXPLAINER_LIVE_EVENT_RE.test(`${headline} ${description}`)) return false;
   if (HISTORICAL_EXPLAINER_TITLE_TIME_RE.test(headline)) return true;
   // Descriptions can corroborate only an explicit look-back label. Broad
   // anniversary wording in article copy is common in live coverage.

--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -115,12 +115,13 @@ const HISTORICAL_EXPLAINER_HEADLINE_RE =
 // Duration-led anniversary explainers use a different headline shape from the
 // How/Why form above: "10 years on from <past event>". That shape alone is not
 // enough because publishers also use it for live commemorations and new
-// enforcement actions. Require legacy/lasting-impact framing in the title or
-// description as the second, retrospective signal.
+// enforcement actions. Require explicit legacy/lasting-impact framing in the
+// title or description as the second, retrospective signal; ordinary analytic
+// verbs and current-state language are deliberately insufficient.
 const HISTORICAL_ANNIVERSARY_HEADLINE_RE =
   /^(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)|a\s+decade)\s+(?:on(?:\s+from)?|after|since)\b/i;
 const HISTORICAL_ANNIVERSARY_CONTEXT_RE =
-  /\b(?:legacy|lasting\s+(?:impact|effects?|consequences?)|long[-\s]?term\s+(?:impact|effects?|consequences?)|continues?\s+to\s+(?:shape|influence|define)|remains?\s+divided)\b/i;
+  /\b(?:legacy|(?:lasting|long[-\s]?term)\s+(?:impact|effects?|consequences?))\b/i;
 const HISTORICAL_EXPLAINER_TITLE_TIME_RE =
   /\b(?:(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:years?|decades?)\s+(?:ago|after|later|on(?:\s+from)?|since)|anniversary|retrospective|(?:a|this)\s+look back)\b/i;
 const HISTORICAL_EXPLAINER_DESCRIPTION_LOOKBACK_RE = /\b(?:a|this)\s+look[-\s]?back\b/i;

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -429,7 +429,10 @@ async function fetchAndParseRss(
   // publishedAt. Digest reads deliberately trust explicit isOpinion stamps,
   // so warm v6 rows could retain an earlier "0" verdict for one cache TTL.
   // Force a cold parse to stamp the stable ingest-time verdict immediately.
-  const cacheKey = `rss:feed:v7:${variant}:${feed.url}`;
+  // v7→v8: extend the same exclusion policy to duration-led anniversary
+  // explainers ("10 years on from …"). Warm v7 rows already carry an
+  // authoritative isOpinion="0", so force another cold parse on rollout.
+  const cacheKey = `rss:feed:v8:${variant}:${feed.url}`;
 
   try {
     // Read cache unconditionally — the v5 prefix guarantees pre-fix

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -112,6 +112,30 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     );
   });
 
+  it('carries the Al Jazeera duration-led retrospective verdict from RSS into the digest filter', () => {
+    const result = parseRssXml(
+      `<?xml version="1.0"?><rss><channel><item>
+        <title>10 years on from Turkiye’s failed coup attempt on Erdogan</title>
+        <link>https://www.aljazeera.com/video/newsfeed/2026/7/15/10-years-on-from-turkiyes-failed-coup-attempt-on-erdogan?traffic_source=rss</link>
+        <pubDate>Wed, 15 Jul 2026 20:35:09 +0000</pubDate>
+        <description>10 years on from Turkiye’s coup attempt to overthrow President Erdogan, the country remains divided over its legacy.</description>
+      </item></channel></rss>`,
+      { url: 'https://www.aljazeera.com/xml/rss/all.xml', name: 'Al Jazeera', lang: 'en' },
+      'full',
+    );
+    assert.ok(result, 'RSS parser should return a parse result');
+    const item = result.items[0];
+    assert.ok(item, 'RSS parser should retain the dated item');
+    assert.strictEqual(item.isOpinion, true);
+    const persisted = fieldsToMap(buildStoryTrackHsetFields(item, '1784147709000', 42));
+    assert.strictEqual(persisted.get('isOpinion'), '1');
+    assert.strictEqual(
+      shouldDropOpinionTrack(Object.fromEntries(persisted)),
+      true,
+      'the stamped anniversary retrospective must be excluded before severity bucketing',
+    );
+  });
+
   it('writes isFeelGood as "1" / "0" — stamps the feel-good verdict on the row (Veterans-warplanes anchor)', () => {
     // Sibling to isOpinion stamp. buildDigest excludes isFeelGood="1"
     // rows. Same shared-row semantics: stale "1" from an earlier
@@ -372,7 +396,7 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
 });
 
 describe('fetchAndParseRss — cache prefix invalidation contract', () => {
-  it('rss:feed cache prefix is v7 (stable historical-explainer stamp), not v4/v5/v6', () => {
+  it('rss:feed cache prefix is v8 (duration-led historical-explainer stamp), not v4/v5/v6/v7', () => {
     // Pre-PR ParsedItems cached at rss:feed:v4 lack the
     // isEphemeralLiveCoverage field. If a cache hit returned one of those,
     // the falsy-coerce in
@@ -389,18 +413,19 @@ describe('fetchAndParseRss — cache prefix invalidation contract', () => {
       resolve(__dirname, '..', 'server', 'worldmonitor', 'news', 'v1', 'list-feed-digest.ts'),
       'utf-8',
     );
-    // v6→v7: parsed items now stamp historical explainers from their
-    // persisted publication time. Digest reads trust explicit stamps, so
-    // warm v6 rows must not retain a pre-rule "0" verdict for a cache TTL.
+    // v7→v8: duration-led historical explainers now receive the same stable
+    // ingest stamp. Digest reads trust explicit stamps, so warm v7 rows must
+    // not retain a pre-rule "0" verdict for a cache TTL.
     assert.ok(
-      src.includes("`rss:feed:v7:${variant}:${feed.url}`"),
-      'rss:feed cache key must use v7 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
+      src.includes("`rss:feed:v8:${variant}:${feed.url}`"),
+      'rss:feed cache key must use v8 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
     );
     assert.ok(
-      !src.includes("`rss:feed:v6:${variant}:${feed.url}`") &&
+      !src.includes("`rss:feed:v7:${variant}:${feed.url}`") &&
+        !src.includes("`rss:feed:v6:${variant}:${feed.url}`") &&
         !src.includes("`rss:feed:v5:${variant}:${feed.url}`") &&
         !src.includes("`rss:feed:v4:${variant}:${feed.url}`"),
-      'must NOT leave a residual v4/v5/v6 cacheKey assignment — would silently revert the cutover',
+      'must NOT leave a residual v4/v5/v6/v7 cacheKey assignment — would silently revert the cutover',
     );
   });
 });

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -249,6 +249,42 @@ describe('classifyOpinion — historical explainers are not digest events', () =
     );
   });
 
+  it('REGRESSION (July 16): Al Jazeera duration-led coup retrospective → exclude', () => {
+    assert.equal(
+      classifyOpinion({
+        title: '10 years on from Turkiye’s failed coup attempt on Erdogan',
+        link: 'https://www.aljazeera.com/video/newsfeed/2026/7/15/10-years-on-from-turkiyes-failed-coup-attempt-on-erdogan?traffic_source=rss',
+        description: '10 years on from Turkiye’s coup attempt to overthrow President Erdogan, the country remains divided over its legacy.',
+        publishedAt: Date.parse('2026-07-15T20:35:09Z'),
+      }),
+      true,
+    );
+  });
+
+  it('recognizes publisher rewrites that use reshaped with an historical event year', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'How the failed 2016 coup reshaped Turkiye’s civil-military relations',
+        link: 'https://www.aljazeera.com/news/2026/7/15/how-failed-2016-coup-reshaped-turkiyes-and-civil-military-relations',
+        description: 'The attempted takeover 10 years ago accelerated changes to civilian oversight.',
+        publishedAt: JULY_2026,
+      }),
+      true,
+    );
+  });
+
+  it('keeps duration-led live anniversary coverage without retrospective legacy framing', () => {
+    assert.equal(
+      classifyOpinion({
+        title: '10 years on from the coup attempt, authorities launch nationwide arrests',
+        link: 'https://example.com/world/turkey-arrests',
+        description: 'Police detained hundreds of suspects in operations across the country.',
+        publishedAt: JULY_2026,
+      }),
+      false,
+    );
+  });
+
   it('trims the headline before matching the explanatory shape', () => {
     assert.equal(
       classifyOpinion({

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -285,6 +285,30 @@ describe('classifyOpinion — historical explainers are not digest events', () =
     );
   });
 
+  it('keeps an anniversary-timed live development with ordinary analytical framing', () => {
+    assert.equal(
+      classifyOpinion({
+        title: '10 years since the nuclear deal, Iran resumes enrichment',
+        link: 'https://example.com/world/iran-enrichment',
+        description: 'Analysts say the move continues to shape regional security.',
+        publishedAt: JULY_2026,
+      }),
+      false,
+    );
+  });
+
+  it('keeps anniversary-timed current politics described as remaining divided', () => {
+    assert.equal(
+      classifyOpinion({
+        title: '10 years on from the election, parliament remains divided on the new sanctions bill',
+        link: 'https://example.com/world/parliament-sanctions',
+        description: 'Lawmakers will vote on the measure this week.',
+        publishedAt: JULY_2026,
+      }),
+      false,
+    );
+  });
+
   it('trims the headline before matching the explanatory shape', () => {
     assert.equal(
       classifyOpinion({


### PR DESCRIPTION
## Summary

- classify duration-led anniversary retrospectives only when the headline shape is corroborated by legacy or lasting-impact framing
- recognize publisher rewrites using reshaped with a stable historical event-year anchor
- bump the parsed RSS cache prefix from v7 to v8 so previously cached isOpinion=0 verdicts are cold-reparsed on rollout

## Root cause

PR #5335 covered How/Why plus changed/shaped retrospective headlines. Al Jazeera emitted 10 years on from Turkiye’s failed coup attempt on Erdogan, which bypassed that headline-shape gate and was stamped as non-opinion before entering the CRITICAL digest bucket.

## Validation

- exact live Al Jazeera RSS parse -> isOpinion=1 -> persisted stamp -> digest drop
- negative live-anniversary coverage guard
- 59 changed-file tests passed in pre-push
- 106 server handler tests passed in pre-push
- npm run typecheck
- npm run typecheck:api
- scoped Biome check
- git diff --check