### PR TITLE
feat(bootstrap): Workers KV serving path — publisher write + shadow measurement (U-K1, U-K2, #5338)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,15 @@ R2_BOOTSTRAP_READ_SECRET=
 # production, and disable it before the R2 serving cutover.
 BOOTSTRAP_R2_SHADOW_MEASURE=
 
+# ------ Bootstrap tiers on Workers KV (Railway publisher; #5300 KV serving plan) ------
+# The publisher writes each tier envelope to KV alongside R2 (best-effort; absent = skipped).
+# Namespace id is config, not a secret. Account id falls back to CLOUDFLARE_R2_ACCOUNT_ID.
+# The write token needs Workers KV Storage: Edit; KV's fast READ path is a Worker binding,
+# never this REST token.
+KV_BOOTSTRAP_NAMESPACE_ID=
+KV_BOOTSTRAP_WRITE_TOKEN=
+KV_BOOTSTRAP_ACCOUNT_ID=
+
 
 # ------ Satellite Fire Detection (Vercel) ------
 

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -15,6 +15,7 @@ on:
     branches: [main]
     paths:
       - 'workers/api-cors-preflight/**'
+      - 'api/_bootstrap-public-tier.js'
       - '.github/workflows/deploy-worker.yml'
   workflow_dispatch:
 
@@ -36,7 +37,7 @@ jobs:
       - name: Install
         run: npm install --no-audit --no-fund
       - name: Run unit tests
-        run: node --test index.test.mjs
+        run: npm test
 
   deploy:
     name: Wrangler deploy

--- a/api/_bootstrap-public-tier.js
+++ b/api/_bootstrap-public-tier.js
@@ -1,0 +1,28 @@
+export const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
+
+/**
+ * Return the tier for the two fixed public bootstrap request shapes, else null.
+ * This dependency-free helper is shared by the Vercel handler and Cloudflare
+ * shadow Worker so their routing contract cannot drift independently.
+ */
+export function bootstrapTierFromPublicRequest(req, parsedUrl = new URL(req.url)) {
+  if (req.method !== 'GET') return null;
+
+  const pathname = parsedUrl.pathname.length > 1
+    ? parsedUrl.pathname.replace(/\/+$/, '')
+    : parsedUrl.pathname;
+  if (pathname !== '/api/bootstrap') return null;
+
+  const params = Array.from(parsedUrl.searchParams.keys());
+  if (params.some((key) => key !== 'tier' && key !== 'public')) return null;
+
+  const tierParams = parsedUrl.searchParams.getAll('tier');
+  const publicParams = parsedUrl.searchParams.getAll('public');
+  if (tierParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return null;
+
+  return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]) ? tierParams[0] : null;
+}
+
+export function isPublicTierBootstrapRequest(req) {
+  return bootstrapTierFromPublicRequest(req) !== null;
+}

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -1,5 +1,9 @@
 import { waitUntil as vercelWaitUntil } from '@vercel/functions';
 
+import {
+  PUBLIC_BOOTSTRAP_TIERS,
+  isPublicTierBootstrapRequest,
+} from './_bootstrap-public-tier.js';
 import { getCorsHeaders, getPublicCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import {
   USER_API_KEY_GATEWAY_VALIDATION_ERROR,
@@ -66,7 +70,6 @@ export function isPublicWeatherBootstrapRequest(req) {
   return requested.length === 1 && requested[0] === 'weatherAlerts';
 }
 
-const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
 let nextBootstrapR2ShadowProbeIsCold = true;
 let scheduleBootstrapR2Shadow = vercelWaitUntil;
 let readBootstrapR2ShadowTier = readBootstrapTierObject;
@@ -151,22 +154,7 @@ function finishBootstrapR2ShadowResponse(req, ctx, tier, response, redisDuration
 // GET only: a HEAD here would still run the full registry Redis read to build a
 // body it must not return — the exact unshielded egress this path exists to
 // avoid. HEAD tier reads have no client and fall through to the no-store path.
-export function isPublicTierBootstrapRequest(req) {
-  if (req.method !== 'GET') return false;
-
-  const url = new URL(req.url);
-  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
-  if (pathname !== '/api/bootstrap') return false;
-
-  const params = Array.from(url.searchParams.keys());
-  if (params.some((key) => key !== 'tier' && key !== 'public')) return false;
-
-  const tierParams = url.searchParams.getAll('tier');
-  const publicParams = url.searchParams.getAll('public');
-  if (tierParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return false;
-
-  return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]);
-}
+export { isPublicTierBootstrapRequest } from './_bootstrap-public-tier.js';
 
 // The on-demand counterpart to the tier URL above: `?keys=<name>&public=1` for a
 // SINGLE on-demand key. Same reasoning — the payload is the shared production

--- a/scripts/_kv-storage.mjs
+++ b/scripts/_kv-storage.mjs
@@ -1,0 +1,67 @@
+/**
+ * Cloudflare Workers KV **write** helper for the bootstrap publisher (#5300 / #5338).
+ *
+ * WRITE ONLY. KV's fast, edge-local READ path is a binding inside a Cloudflare Worker —
+ * never this REST call, which is a centralized API request (fine for a latency-insensitive
+ * publisher write, wrong for serving). See the KV serving plan
+ * (docs/plans/2026-07-16-001-…): the publisher writes both tier envelopes here; a Worker
+ * reads them via binding.
+ *
+ * Self-contained by requirement: Railway builds seeders from a scripts-only Nixpacks root,
+ * so this file must NOT import from ../api, ../src, or ../server — a cross-root import
+ * crashes the container at startup (#5268). Only global `fetch` + `Buffer` are used.
+ */
+
+/** KV's hard per-value limit. A payload above this is a bug, not a big object (#5311 discipline). */
+export const MAX_KV_VALUE_BYTES = 25 * 1024 * 1024; // 25 MiB
+
+/**
+ * Resolve KV write config from env, or `null` when unconfigured — so the publisher skips KV
+ * gracefully on deploys without the credentials (backward-compatible, flag-by-presence).
+ */
+export function resolveKvStorageConfig(env = process.env) {
+  const accountId = env.KV_BOOTSTRAP_ACCOUNT_ID || env.CLOUDFLARE_R2_ACCOUNT_ID;
+  const namespaceId = env.KV_BOOTSTRAP_NAMESPACE_ID;
+  const token = env.KV_BOOTSTRAP_WRITE_TOKEN;
+  if (!accountId || !namespaceId || !token) return null;
+  return { accountId, namespaceId, token };
+}
+
+/**
+ * Write one JSON value to a KV namespace. Enforces the 25 MiB cap BEFORE the network call and
+ * throws on breach — a bloated tier must fail loudly, never truncate silently (the 11.5 MB
+ * #5311 lesson). The caller treats KV writes as best-effort and never lets this abort the
+ * canonical R2 publish.
+ *
+ * @returns {Promise<{ key: string, bytes: number }>}
+ */
+export async function putKvJsonValue(config, key, value, { fetchFn = fetch, timeoutMs = 15_000 } = {}) {
+  const body = JSON.stringify(value);
+  const bytes = Buffer.byteLength(body, 'utf8');
+  if (bytes > MAX_KV_VALUE_BYTES) {
+    throw new Error(
+      `KV value for '${key}' is ${bytes} bytes, over the ${MAX_KV_VALUE_BYTES}-byte (25 MiB) cap — refusing to write`,
+    );
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${config.accountId}`
+    + `/storage/kv/namespaces/${config.namespaceId}/values/${encodeURIComponent(key)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetchFn(url, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${config.token}`, 'Content-Type': 'application/json' },
+      body,
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '');
+      throw new Error(`KV write '${key}' failed: HTTP ${resp.status} ${detail.slice(0, 200)}`);
+    }
+    return { key, bytes };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/_kv-storage.mjs
+++ b/scripts/_kv-storage.mjs
@@ -52,7 +52,11 @@ export async function putKvJsonValue(config, key, value, { fetchFn = fetch, time
   try {
     const resp = await fetchFn(url, {
       method: 'PUT',
-      headers: { Authorization: `Bearer ${config.token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'WorldMonitor Bootstrap Publisher/1.0',
+      },
       body,
       signal: controller.signal,
     });

--- a/scripts/publish-bootstrap-tiers.mjs
+++ b/scripts/publish-bootstrap-tiers.mjs
@@ -13,6 +13,10 @@ import {
   putR2JsonObject,
   resolveR2StorageConfig,
 } from './_r2-storage.mjs';
+import {
+  putKvJsonValue,
+  resolveKvStorageConfig,
+} from './_kv-storage.mjs';
 
 const NEG_SENTINEL = '__WM_NEG__';
 const REDIS_PIPELINE_TIMEOUT_MS = 30_000;
@@ -148,7 +152,35 @@ export async function publishBootstrapTier(tier, options = {}) {
     tier,
     generatedAt: String(generatedAt),
   });
-  return { tier, generatedAt, missing: payload.missing.length, bytes: write?.bytes ?? null };
+
+  // KV parity write (#5300 KV serving plan). The SAME envelope, keyed by bare tier name
+  // (`fast`/`slow`) so the serving Worker reads `env.KV.get(tier)`. Best-effort and gated by
+  // credential presence: a KV failure — including the 25 MiB guard tripping — must never abort
+  // the canonical R2 publish, but it is logged loudly so a chronic failure is visible.
+  const kv = await publishTierToKv(tier, envelope, { ...options, env, logger: options.logger });
+
+  return { tier, generatedAt, missing: payload.missing.length, bytes: write?.bytes ?? null, kv };
+}
+
+/**
+ * Best-effort KV write of a tier envelope. Skips silently when KV is unconfigured (so R2-only
+ * deploys are unaffected); on failure, logs and returns `{ ok: false }` without throwing.
+ */
+export async function publishTierToKv(tier, envelope, options = {}) {
+  const env = options.env ?? process.env;
+  const resolveKv = options.resolveKvStorage ?? resolveKvStorageConfig;
+  const config = resolveKv(env);
+  if (!config) return { skipped: true };
+
+  const putKv = options.putKv ?? putKvJsonValue;
+  const logger = options.logger ?? console;
+  try {
+    const result = await putKv(config, tier, envelope, { fetchFn: options.kvFetchFn });
+    return { ok: true, bytes: result?.bytes ?? null };
+  } catch (err) {
+    logger.error?.(`[bootstrap-kv] tier=${tier} KV write failed: ${err?.message ?? err}`);
+    return { ok: false, error: err?.message ?? String(err) };
+  }
 }
 
 function defaultSleep(ms, signal) {
@@ -192,7 +224,10 @@ export async function runPublisherLoop(options = {}) {
     const tier = due[0];
     try {
       const result = await publishTier(tier);
-      logger.info?.(`[bootstrap-r2] published tier=${tier} generatedAt=${result?.generatedAt ?? 'unknown'} bytes=${result?.bytes ?? 'unknown'} missing=${result?.missing ?? 'unknown'}`);
+      const kvStatus = result?.kv?.skipped ? 'skipped'
+        : result?.kv?.ok ? `${result.kv.bytes}b`
+        : `FAILED(${result?.kv?.error ?? 'unknown'})`;
+      logger.info?.(`[bootstrap-r2] published tier=${tier} generatedAt=${result?.generatedAt ?? 'unknown'} bytes=${result?.bytes ?? 'unknown'} missing=${result?.missing ?? 'unknown'} kv=${kvStatus}`);
     } catch (error) {
       logger.warn?.(`[bootstrap-r2] publish failed tier=${tier}: ${error?.message ?? String(error)}`);
     } finally {

--- a/tests/bootstrap-kv-publisher.test.mjs
+++ b/tests/bootstrap-kv-publisher.test.mjs
@@ -76,6 +76,7 @@ describe('putKvJsonValue', () => {
     assert.equal(seen.init.method, 'PUT');
     assert.equal(seen.url, 'https://api.cloudflare.com/client/v4/accounts/A/storage/kv/namespaces/N/values/fast');
     assert.equal(seen.init.headers.Authorization, 'Bearer T');
+    assert.equal(seen.init.headers['User-Agent'], 'WorldMonitor Bootstrap Publisher/1.0');
     assert.equal(seen.init.body, JSON.stringify(value), 'writes the exact serialized envelope');
     assert.equal(out.bytes, Buffer.byteLength(JSON.stringify(value), 'utf8'));
   });
@@ -97,6 +98,21 @@ describe('putKvJsonValue', () => {
     await assert.rejects(
       putKvJsonValue({ accountId: 'A', namespaceId: 'N', token: 'T' }, 'fast', { a: 1 }, { fetchFn }),
       /KV write 'fast' failed: HTTP 404/,
+    );
+  });
+
+  it('aborts a KV write that exceeds its deadline', async () => {
+    const fetchFn = async (_url, { signal }) => new Promise((resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+    await assert.rejects(
+      putKvJsonValue(
+        { accountId: 'A', namespaceId: 'N', token: 'T' },
+        'fast',
+        { a: 1 },
+        { fetchFn, timeoutMs: 5 },
+      ),
+      { name: 'AbortError' },
     );
   });
 });
@@ -147,6 +163,18 @@ describe('publishBootstrapTier — KV parity', () => {
     assert.equal(result.bytes, 10, 'R2 write still succeeded');
     assert.equal(result.kv.ok, false);
     assert.ok(logs.some((l) => /bootstrap-kv/.test(l)));
+  });
+
+  it('never attempts the best-effort KV mirror when the canonical R2 write fails', async () => {
+    let kvCalled = false;
+    await assert.rejects(
+      runPublish({
+        putObject: async () => { throw new Error('r2 down'); },
+        putKv: async () => { kvCalled = true; return { bytes: 1 }; },
+      }),
+      /r2 down/,
+    );
+    assert.equal(kvCalled, false);
   });
 
   it('skips KV entirely when unconfigured, leaving the R2-only path intact', async () => {

--- a/tests/bootstrap-kv-publisher.test.mjs
+++ b/tests/bootstrap-kv-publisher.test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  MAX_KV_VALUE_BYTES,
+  putKvJsonValue,
+  resolveKvStorageConfig,
+} from '../scripts/_kv-storage.mjs';
+import {
+  publishBootstrapTier,
+  publishTierToKv,
+} from '../scripts/publish-bootstrap-tiers.mjs';
+
+const TEST_ENV = {
+  UPSTASH_REDIS_REST_URL: 'https://redis.example.test',
+  UPSTASH_REDIS_REST_TOKEN: 'redis-token',
+};
+const KV_ENV = {
+  KV_BOOTSTRAP_ACCOUNT_ID: 'acct123',
+  KV_BOOTSTRAP_NAMESPACE_ID: 'ns456',
+  KV_BOOTSTRAP_WRITE_TOKEN: 'kv-token',
+};
+
+function pipelineResponse(results, status = 200) {
+  return new Response(JSON.stringify(results), { status, headers: { 'Content-Type': 'application/json' } });
+}
+const raw = (value) => ({ result: JSON.stringify(value) });
+
+// A publishBootstrapTier call with everything but the storage writers stubbed, so a test can
+// capture exactly what the R2 and KV writers each receive.
+async function runPublish(overrides = {}) {
+  const captured = { r2: null, kv: null };
+  const result = await publishBootstrapTier('fast', {
+    env: { ...TEST_ENV, ...KV_ENV },
+    now: () => 1_721_000_000_000,
+    resolveRegistry: () => ({ fast: { example: 'example:key' } }),
+    fetchFn: async () => pipelineResponse([raw({ answer: 42 })]),
+    resolveStorage: () => ({ mode: 's3' }),
+    putObject: async (_s, key, envelope) => { captured.r2 = { key, envelope }; return { bytes: 10 }; },
+    resolveKvStorage: () => ({ accountId: 'a', namespaceId: 'n', token: 't' }),
+    putKv: async (_c, key, envelope) => { captured.kv = { key, envelope }; return { bytes: 20 }; },
+    ...overrides,
+  });
+  return { result, captured };
+}
+
+describe('resolveKvStorageConfig', () => {
+  it('returns config when the three fields are present', () => {
+    assert.deepEqual(resolveKvStorageConfig(KV_ENV), {
+      accountId: 'acct123', namespaceId: 'ns456', token: 'kv-token',
+    });
+  });
+
+  it('falls back to the R2 account id', () => {
+    const cfg = resolveKvStorageConfig({
+      CLOUDFLARE_R2_ACCOUNT_ID: 'r2acct',
+      KV_BOOTSTRAP_NAMESPACE_ID: 'ns', KV_BOOTSTRAP_WRITE_TOKEN: 't',
+    });
+    assert.equal(cfg.accountId, 'r2acct');
+  });
+
+  it('returns null when unconfigured (so the publisher skips KV gracefully)', () => {
+    assert.equal(resolveKvStorageConfig({}), null);
+    assert.equal(resolveKvStorageConfig({ KV_BOOTSTRAP_NAMESPACE_ID: 'ns' }), null); // token missing
+  });
+});
+
+describe('putKvJsonValue', () => {
+  it('PUTs the serialized value to the namespace values endpoint with the bearer token', async () => {
+    let seen;
+    const fetchFn = async (url, init) => { seen = { url, init }; return new Response('{}', { status: 200 }); };
+    const value = { generatedAt: 1, tier: 'fast', payload: { data: {}, missing: [] } };
+
+    const out = await putKvJsonValue({ accountId: 'A', namespaceId: 'N', token: 'T' }, 'fast', value, { fetchFn });
+
+    assert.equal(seen.init.method, 'PUT');
+    assert.equal(seen.url, 'https://api.cloudflare.com/client/v4/accounts/A/storage/kv/namespaces/N/values/fast');
+    assert.equal(seen.init.headers.Authorization, 'Bearer T');
+    assert.equal(seen.init.body, JSON.stringify(value), 'writes the exact serialized envelope');
+    assert.equal(out.bytes, Buffer.byteLength(JSON.stringify(value), 'utf8'));
+  });
+
+  it('refuses a value over the 25 MiB cap BEFORE any network call (#5311 discipline)', async () => {
+    let called = false;
+    const fetchFn = async () => { called = true; return new Response('{}'); };
+    const huge = { blob: 'x'.repeat(MAX_KV_VALUE_BYTES + 10) };
+
+    await assert.rejects(
+      putKvJsonValue({ accountId: 'A', namespaceId: 'N', token: 'T' }, 'slow', huge, { fetchFn }),
+      /over the .*25 MiB.* cap — refusing to write/,
+    );
+    assert.equal(called, false, 'the guard fires before the fetch');
+  });
+
+  it('throws on a non-2xx KV response', async () => {
+    const fetchFn = async () => new Response('bad namespace', { status: 404 });
+    await assert.rejects(
+      putKvJsonValue({ accountId: 'A', namespaceId: 'N', token: 'T' }, 'fast', { a: 1 }, { fetchFn }),
+      /KV write 'fast' failed: HTTP 404/,
+    );
+  });
+});
+
+describe('publishTierToKv (best-effort wrapper)', () => {
+  const envelope = { generatedAt: 1, tier: 'fast', payload: { data: {}, missing: [] } };
+
+  it('skips silently when KV is unconfigured', async () => {
+    assert.deepEqual(await publishTierToKv('fast', envelope, { resolveKvStorage: () => null }), { skipped: true });
+  });
+
+  it('returns ok with bytes on success', async () => {
+    const out = await publishTierToKv('fast', envelope, {
+      resolveKvStorage: () => ({ accountId: 'a', namespaceId: 'n', token: 't' }),
+      putKv: async () => ({ bytes: 128 }),
+    });
+    assert.deepEqual(out, { ok: true, bytes: 128 });
+  });
+
+  it('never throws on failure — logs loudly and returns ok:false', async () => {
+    const logs = [];
+    const out = await publishTierToKv('fast', envelope, {
+      resolveKvStorage: () => ({ accountId: 'a', namespaceId: 'n', token: 't' }),
+      putKv: async () => { throw new Error('kv boom'); },
+      logger: { error: (m) => logs.push(m) },
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error, /kv boom/);
+    assert.ok(logs.some((l) => /\[bootstrap-kv\] tier=fast/.test(l)), 'failure is logged loudly');
+  });
+});
+
+describe('publishBootstrapTier — KV parity', () => {
+  it('writes the SAME envelope to KV and R2, R2 keyed by <tier>.json, KV by bare <tier>', async () => {
+    const { result, captured } = await runPublish();
+    assert.deepEqual(captured.kv.envelope, captured.r2.envelope, 'KV must get the identical envelope');
+    assert.equal(captured.r2.key, 'fast.json');
+    assert.equal(captured.kv.key, 'fast', 'KV key is the bare tier so the Worker reads env.KV.get(tier)');
+    assert.equal(result.kv.ok, true);
+  });
+
+  it('a KV failure never aborts the canonical R2 publish', async () => {
+    const logs = [];
+    const { result } = await runPublish({
+      putKv: async () => { throw new Error('kv down'); },
+      logger: { error: (m) => logs.push(m) },
+    });
+    assert.equal(result.bytes, 10, 'R2 write still succeeded');
+    assert.equal(result.kv.ok, false);
+    assert.ok(logs.some((l) => /bootstrap-kv/.test(l)));
+  });
+
+  it('skips KV entirely when unconfigured, leaving the R2-only path intact', async () => {
+    const { result } = await runPublish({ resolveKvStorage: () => null });
+    assert.deepEqual(result.kv, { skipped: true });
+    assert.equal(result.bytes, 10);
+  });
+});

--- a/workers/api-cors-preflight/kv-shadow.test.mjs
+++ b/workers/api-cors-preflight/kv-shadow.test.mjs
@@ -1,0 +1,163 @@
+// Tests for the KV shadow measurement added to the api-cors-preflight Worker (U-K2, #5338).
+//
+// The load-bearing assertion is the FIRST one: the CORS response must be byte-identical whether
+// the shadow is on or off. This Worker is the CORS source of truth (a 2026-05-27 outage lived
+// here); the shadow is only allowed in because it cannot change what the browser sees.
+
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import worker from './src/index.js';
+import {
+  bootstrapTierFromPublicRequest,
+  classifyKvEnvelope,
+  maybeShadowKvRead,
+  TIER_MAX_AGE_MS,
+} from './src/kv-shadow.js';
+
+const BOOT_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1';
+const freshEnvelope = (tier = 'fast', ageMs = 0) =>
+  JSON.stringify({ tier, generatedAt: Date.now() - ageMs, payload: { data: {}, missing: [] } });
+
+// Route global fetch: Axiom POSTs are captured; everything else is a canned "origin" response.
+function installFetch(onAxiom) {
+  const real = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const u = typeof input === 'string' ? input : input?.url ?? '';
+    if (u.includes('api.axiom.co')) {
+      onAxiom?.(JSON.parse(init.body));
+      return new Response('{}', { status: 200 });
+    }
+    return new Response('{"data":{}}', { status: 200, headers: { 'X-Origin': 'vercel' } });
+  };
+  return () => { globalThis.fetch = real; };
+}
+
+function makeEnv({ shadow = '1', kvValue = null, kvThrows = false, token = 'axiom-tok' } = {}) {
+  return {
+    BOOTSTRAP_KV_SHADOW: shadow,
+    AXIOM_API_TOKEN: token,
+    BOOTSTRAP_KV: { get: async () => { if (kvThrows) throw new Error('kv down'); return kvValue; } },
+  };
+}
+function makeCtx() {
+  const waits = [];
+  return { ctx: { waitUntil: (p) => waits.push(p) }, waits };
+}
+const bootReq = () => new Request(BOOT_URL, { method: 'GET', headers: { Origin: 'https://worldmonitor.app' } });
+
+test('CORS response is byte-identical whether the KV shadow is on or off', async () => {
+  const restore = installFetch(() => {});
+  try {
+    const c1 = makeCtx();
+    const off = await worker.fetch(bootReq(), makeEnv({ shadow: '0' }), c1.ctx);
+
+    const c2 = makeCtx();
+    const on = await worker.fetch(bootReq(), makeEnv({ shadow: '1', kvValue: freshEnvelope() }), c2.ctx);
+    await Promise.all(c2.waits);
+
+    assert.equal(off.status, on.status);
+    assert.deepEqual([...off.headers].sort(), [...on.headers].sort(), 'headers identical');
+    assert.equal(await off.text(), await on.text(), 'body identical');
+    assert.equal(c1.waits.length, 0, 'shadow off => no waitUntil work');
+  } finally { restore(); }
+});
+
+test('shadow off emits nothing', async () => {
+  let emitted = 0;
+  const restore = installFetch(() => { emitted += 1; });
+  try {
+    const { ctx, waits } = makeCtx();
+    await worker.fetch(bootReq(), makeEnv({ shadow: '0' }), ctx);
+    await Promise.all(waits);
+    assert.equal(emitted, 0);
+  } finally { restore(); }
+});
+
+test('a non-bootstrap request never probes KV', async () => {
+  let probed = false;
+  const env = makeEnv({ kvValue: freshEnvelope() });
+  env.BOOTSTRAP_KV.get = async () => { probed = true; return null; };
+  const { ctx, waits } = makeCtx();
+  maybeShadowKvRead(new Request('https://api.worldmonitor.app/api/health'), new URL('https://api.worldmonitor.app/api/health'), env, ctx);
+  await Promise.all(waits);
+  assert.equal(probed, false);
+});
+
+test('emits an allowlisted event with outcome kv on a fresh value', async () => {
+  let event;
+  const restore = installFetch((body) => { event = body[0]; });
+  try {
+    const env = makeEnv({ kvValue: freshEnvelope('fast') });
+    const { ctx, waits } = makeCtx();
+    const req = { method: 'GET', cf: { colo: 'SIN', country: 'SG' } };
+    maybeShadowKvRead(req, new URL(BOOT_URL), env, ctx);
+    await Promise.all(waits);
+
+    assert.equal(event.event_type, 'bootstrap_kv_shadow');
+    assert.equal(event.bootstrap_tier, 'fast');
+    assert.equal(event.kv_outcome, 'kv');
+    assert.equal(event.kv_reason, null);
+    assert.equal(typeof event.kv_duration_ms, 'number');
+    assert.equal(event.cf_colo, 'SIN');
+    assert.equal(event.cf_country, 'SG');
+    // Privacy: EXACTLY the allowlist (+ _time). No ip/user_agent/customer_id/etc. can appear.
+    assert.deepEqual(
+      Object.keys(event).sort(),
+      ['_time', 'bootstrap_tier', 'cf_colo', 'cf_country', 'event_type', 'execution_cold', 'kv_duration_ms', 'kv_outcome', 'kv_reason'].sort(),
+    );
+  } finally { restore(); }
+});
+
+test('failure modes map to the right reason and never throw', async () => {
+  for (const [setup, expected] of [
+    [{ kvValue: null }, { outcome: 'fallback', reason: 'miss' }],
+    [{ kvValue: '{not json' }, { outcome: 'fallback', reason: 'invalid' }],
+    [{ kvValue: freshEnvelope('fast', TIER_MAX_AGE_MS.fast + 60_000) }, { outcome: 'fallback', reason: 'stale' }],
+    [{ kvValue: JSON.stringify({ tier: 'slow', generatedAt: Date.now(), payload: {} }) }, { outcome: 'fallback', reason: 'invalid' }], // wrong tier
+    [{ kvThrows: true }, { outcome: 'fallback', reason: 'error' }],
+  ]) {
+    let event;
+    const restore = installFetch((body) => { event = body[0]; });
+    try {
+      const { ctx, waits } = makeCtx();
+      maybeShadowKvRead({ method: 'GET', cf: { colo: 'HKG' } }, new URL(BOOT_URL), makeEnv(setup), ctx);
+      await Promise.all(waits);
+      assert.equal(event.kv_outcome, expected.outcome, JSON.stringify(setup));
+      assert.equal(event.kv_reason, expected.reason, JSON.stringify(setup));
+    } finally { restore(); }
+  }
+});
+
+test('execution_cold is a boolean and a consecutive probe is warm', async () => {
+  const events = [];
+  const restore = installFetch((body) => { events.push(body[0]); });
+  try {
+    for (let i = 0; i < 2; i++) {
+      const { ctx, waits } = makeCtx();
+      maybeShadowKvRead({ method: 'GET', cf: {} }, new URL(BOOT_URL), makeEnv({ kvValue: freshEnvelope() }), ctx);
+      await Promise.all(waits);
+    }
+    assert.equal(typeof events[0].execution_cold, 'boolean');
+    assert.equal(events[1].execution_cold, false, 'the second consecutive probe in an isolate is warm');
+  } finally { restore(); }
+});
+
+test('bootstrapTierFromPublicRequest mirrors the public-tier contract', () => {
+  const tier = (u, method = 'GET') => bootstrapTierFromPublicRequest({ method }, new URL(u));
+  assert.equal(tier(BOOT_URL), 'fast');
+  assert.equal(tier('https://api.worldmonitor.app/api/bootstrap?tier=slow&public=1'), 'slow');
+  assert.equal(tier(BOOT_URL, 'POST'), null, 'non-GET');
+  assert.equal(tier('https://api.worldmonitor.app/api/bootstrap?tier=fast'), null, 'no public=1');
+  assert.equal(tier('https://api.worldmonitor.app/api/bootstrap?tier=bogus&public=1'), null, 'unknown tier');
+  assert.equal(tier('https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1&x=1'), null, 'extra param');
+  assert.equal(tier('https://api.worldmonitor.app/api/other?tier=fast&public=1'), null, 'wrong path');
+});
+
+test('classifyKvEnvelope decides serve-vs-fallback like the serving path', () => {
+  const now = Date.now();
+  assert.deepEqual(classifyKvEnvelope('fast', null, now), { outcome: 'fallback', reason: 'miss' });
+  assert.deepEqual(classifyKvEnvelope('fast', freshEnvelope('fast'), now), { outcome: 'kv', reason: null });
+  assert.equal(classifyKvEnvelope('fast', freshEnvelope('fast', TIER_MAX_AGE_MS.fast + 1000), now).reason, 'stale');
+  assert.equal(classifyKvEnvelope('fast', 'garbage{', now).reason, 'invalid');
+});

--- a/workers/api-cors-preflight/kv-shadow.test.mjs
+++ b/workers/api-cors-preflight/kv-shadow.test.mjs
@@ -9,6 +9,7 @@ import test from 'node:test';
 
 import worker from './src/index.js';
 import {
+  __resetKvShadowForTests,
   bootstrapTierFromPublicRequest,
   classifyKvEnvelope,
   maybeShadowKvRead,
@@ -20,13 +21,14 @@ const freshEnvelope = (tier = 'fast', ageMs = 0) =>
   JSON.stringify({ tier, generatedAt: Date.now() - ageMs, payload: { data: {}, missing: [] } });
 
 // Route global fetch: Axiom POSTs are captured; everything else is a canned "origin" response.
-function installFetch(onAxiom) {
+function installFetch(onAxiom, { axiomStatus = 200, axiomError = null } = {}) {
   const real = globalThis.fetch;
   globalThis.fetch = async (input, init) => {
     const u = typeof input === 'string' ? input : input?.url ?? '';
     if (u.includes('api.axiom.co')) {
-      onAxiom?.(JSON.parse(init.body));
-      return new Response('{}', { status: 200 });
+      onAxiom?.(JSON.parse(init.body), init);
+      if (axiomError) throw axiomError;
+      return new Response('{}', { status: axiomStatus });
     }
     return new Response('{"data":{}}', { status: 200, headers: { 'X-Origin': 'vercel' } });
   };
@@ -47,19 +49,26 @@ function makeCtx() {
 const bootReq = () => new Request(BOOT_URL, { method: 'GET', headers: { Origin: 'https://worldmonitor.app' } });
 
 test('CORS response is byte-identical whether the KV shadow is on or off', async () => {
+  __resetKvShadowForTests();
   const restore = installFetch(() => {});
   try {
     const c1 = makeCtx();
     const off = await worker.fetch(bootReq(), makeEnv({ shadow: '0' }), c1.ctx);
 
+    let probes = 0;
+    const onEnv = makeEnv({ shadow: '1', kvValue: freshEnvelope() });
+    const readKv = onEnv.BOOTSTRAP_KV.get;
+    onEnv.BOOTSTRAP_KV.get = async (...args) => { probes += 1; return readKv(...args); };
     const c2 = makeCtx();
-    const on = await worker.fetch(bootReq(), makeEnv({ shadow: '1', kvValue: freshEnvelope() }), c2.ctx);
+    const on = await worker.fetch(bootReq(), onEnv, c2.ctx);
+    assert.equal(c2.waits.length, 1, 'shadow on schedules exactly one probe');
     await Promise.all(c2.waits);
 
     assert.equal(off.status, on.status);
     assert.deepEqual([...off.headers].sort(), [...on.headers].sort(), 'headers identical');
     assert.equal(await off.text(), await on.text(), 'body identical');
     assert.equal(c1.waits.length, 0, 'shadow off => no waitUntil work');
+    assert.equal(probes, 1, 'the scheduled shadow work reads KV exactly once');
   } finally { restore(); }
 });
 
@@ -86,7 +95,8 @@ test('a non-bootstrap request never probes KV', async () => {
 
 test('emits an allowlisted event with outcome kv on a fresh value', async () => {
   let event;
-  const restore = installFetch((body) => { event = body[0]; });
+  let requestInit;
+  const restore = installFetch((body, init) => { event = body[0]; requestInit = init; });
   try {
     const env = makeEnv({ kvValue: freshEnvelope('fast') });
     const { ctx, waits } = makeCtx();
@@ -101,6 +111,7 @@ test('emits an allowlisted event with outcome kv on a fresh value', async () => 
     assert.equal(typeof event.kv_duration_ms, 'number');
     assert.equal(event.cf_colo, 'SIN');
     assert.equal(event.cf_country, 'SG');
+    assert.equal(requestInit.headers['User-Agent'], 'WorldMonitor Bootstrap KV Shadow/1.0');
     // Privacy: EXACTLY the allowlist (+ _time). No ip/user_agent/customer_id/etc. can appear.
     assert.deepEqual(
       Object.keys(event).sort(),
@@ -115,6 +126,9 @@ test('failure modes map to the right reason and never throw', async () => {
     [{ kvValue: '{not json' }, { outcome: 'fallback', reason: 'invalid' }],
     [{ kvValue: freshEnvelope('fast', TIER_MAX_AGE_MS.fast + 60_000) }, { outcome: 'fallback', reason: 'stale' }],
     [{ kvValue: JSON.stringify({ tier: 'slow', generatedAt: Date.now(), payload: {} }) }, { outcome: 'fallback', reason: 'invalid' }], // wrong tier
+    [{ kvValue: JSON.stringify({ tier: 'fast', generatedAt: Date.now(), payload: { missing: [] } }) }, { outcome: 'fallback', reason: 'invalid' }], // missing data
+    [{ kvValue: JSON.stringify({ tier: 'fast', generatedAt: Date.now() + 6 * 60_000, payload: { data: {}, missing: [] } }) }, { outcome: 'fallback', reason: 'invalid' }], // future skew
+    [{ kvValue: JSON.stringify({ tier: 'fast', generatedAt: Date.now() + 0.5, payload: { data: {}, missing: [] } }) }, { outcome: 'fallback', reason: 'invalid' }], // non-integer timestamp
     [{ kvThrows: true }, { outcome: 'fallback', reason: 'error' }],
   ]) {
     let event;
@@ -130,6 +144,7 @@ test('failure modes map to the right reason and never throw', async () => {
 });
 
 test('execution_cold is a boolean and a consecutive probe is warm', async () => {
+  __resetKvShadowForTests();
   const events = [];
   const restore = installFetch((body) => { events.push(body[0]); });
   try {
@@ -138,7 +153,7 @@ test('execution_cold is a boolean and a consecutive probe is warm', async () => 
       maybeShadowKvRead({ method: 'GET', cf: {} }, new URL(BOOT_URL), makeEnv({ kvValue: freshEnvelope() }), ctx);
       await Promise.all(waits);
     }
-    assert.equal(typeof events[0].execution_cold, 'boolean');
+    assert.equal(events[0].execution_cold, true, 'the first probe in a fresh isolate is cold');
     assert.equal(events[1].execution_cold, false, 'the second consecutive probe in an isolate is warm');
   } finally { restore(); }
 });
@@ -154,10 +169,41 @@ test('bootstrapTierFromPublicRequest mirrors the public-tier contract', () => {
   assert.equal(tier('https://api.worldmonitor.app/api/other?tier=fast&public=1'), null, 'wrong path');
 });
 
+test('Axiom delivery failures produce bounded operator-visible warnings', async () => {
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (message) => warnings.push(JSON.parse(message));
+  const restore = installFetch(() => {}, { axiomStatus: 503 });
+  try {
+    __resetKvShadowForTests();
+    for (let i = 0; i < 2; i++) {
+      const { ctx, waits } = makeCtx();
+      maybeShadowKvRead({ method: 'GET', cf: {} }, new URL(BOOT_URL), makeEnv({ token: '' }), ctx);
+      await Promise.all(waits);
+    }
+    assert.equal(
+      warnings.filter((event) => event.failure_class === 'missing_token').length,
+      1,
+      'each failure class is logged at most once per isolate',
+    );
+
+    __resetKvShadowForTests();
+    const { ctx, waits } = makeCtx();
+    maybeShadowKvRead({ method: 'GET', cf: {} }, new URL(BOOT_URL), makeEnv(), ctx);
+    await Promise.all(waits);
+    assert.ok(warnings.some((event) => event.failure_class === 'http_error'));
+  } finally {
+    restore();
+    console.warn = realWarn;
+  }
+});
+
 test('classifyKvEnvelope decides serve-vs-fallback like the serving path', () => {
   const now = Date.now();
   assert.deepEqual(classifyKvEnvelope('fast', null, now), { outcome: 'fallback', reason: 'miss' });
   assert.deepEqual(classifyKvEnvelope('fast', freshEnvelope('fast'), now), { outcome: 'kv', reason: null });
   assert.equal(classifyKvEnvelope('fast', freshEnvelope('fast', TIER_MAX_AGE_MS.fast + 1000), now).reason, 'stale');
   assert.equal(classifyKvEnvelope('fast', 'garbage{', now).reason, 'invalid');
+  assert.equal(classifyKvEnvelope('fast', JSON.stringify({ tier: 'fast', generatedAt: now, payload: [] }), now).reason, 'invalid');
+  assert.equal(classifyKvEnvelope('fast', JSON.stringify({ tier: 'fast', generatedAt: now + 6 * 60_000, payload: { data: {}, missing: [] } }), now).reason, 'invalid');
 });

--- a/workers/api-cors-preflight/package.json
+++ b/workers/api-cors-preflight/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "deploy:dry-run": "wrangler deploy --dry-run --outdir=dist",
-    "test": "node --test index.test.mjs"
+    "test": "node --test index.test.mjs kv-shadow.test.mjs"
   },
   "devDependencies": {
     "wrangler": "^3.95.0"

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -17,6 +17,8 @@
 //      ~/.claude/skills/worldmonitor-architecture-gotchas/reference/
 //        cloudflare-worker-overrides-vercel-cors-for-preflight.md
 
+import { maybeShadowKvRead } from './kv-shadow.js';
+
 // Keep in sync with api/_cors.js#ALLOWED_ORIGIN_PATTERNS and
 // server/cors.ts#PRODUCTION_PATTERNS. The Worker's allowlist must be a
 // superset of (or identical to) the function-side allowlist; if it's narrower,
@@ -126,8 +128,14 @@ function mergeHeaderNames(...values) {
 }
 
 export default {
-  async fetch(request) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
+
+    // KV shadow measurement (U-K2, #5338). Self-gating: no-op unless BOOTSTRAP_KV_SHADOW==='1'
+    // and this is a public-tier bootstrap GET. Runs in ctx.waitUntil — never touches the
+    // response or the CORS logic below. Kept entirely in kv-shadow.js so CORS stays untouched.
+    maybeShadowKvRead(request, url, env, ctx);
+
     if (!url.pathname.startsWith('/api/')) {
       return fetch(request);
     }

--- a/workers/api-cors-preflight/src/kv-shadow.js
+++ b/workers/api-cors-preflight/src/kv-shadow.js
@@ -12,31 +12,26 @@
 // deploys inert and the measurement is flipped on/off by a single var. Privacy: the emitted event
 // is a fixed allowlist — never a request, user, credential, or header field.
 
-const PUBLIC_TIERS = new Set(['fast', 'slow']);
+import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
+
+export { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
+
 // Staleness thresholds mirror KTD4 of the serving plan (fast 15 min, slow 60 min): a value older
 // than this would fall through to origin at serve time, so it counts as a non-serving read here.
 export const TIER_MAX_AGE_MS = Object.freeze({ fast: 15 * 60_000, slow: 60 * 60_000 });
 const PROBE_CEILING_MS = 5_000; // bounds a pathological read; NOT a serving budget (this is waitUntil)
+const AXIOM_TIMEOUT_MS = 1_500;
 const AXIOM_INGEST_URL = 'https://api.axiom.co/v1/datasets/wm_api_usage/ingest';
 const PROBE_TIMEOUT = Symbol('kv-probe-timeout');
+const MAX_FUTURE_SKEW_MS = 5 * 60_000;
 
 let isolateCold = true; // true until the first probe in this isolate — gives explicit cold/warm split
+const loggedDeliveryFailures = new Set();
 
-/**
- * The bare tier name for a public-tier bootstrap GET, else null. Mirrors
- * api/bootstrap.js#isPublicTierBootstrapRequest exactly: GET /api/bootstrap with precisely
- * `tier=fast|slow` and `public=1` and no other params.
- */
-export function bootstrapTierFromPublicRequest(request, url) {
-  if (request.method !== 'GET') return null;
-  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
-  if (pathname !== '/api/bootstrap') return null;
-  const keys = [...url.searchParams.keys()];
-  if (keys.some((k) => k !== 'tier' && k !== 'public')) return null;
-  const tiers = url.searchParams.getAll('tier');
-  const pub = url.searchParams.getAll('public');
-  if (tiers.length !== 1 || pub.length !== 1 || pub[0] !== '1') return null;
-  return PUBLIC_TIERS.has(tiers[0]) ? tiers[0] : null;
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 /** Classify a raw KV value the way the serving path would decide to serve vs fall through. */
@@ -48,24 +43,53 @@ export function classifyKvEnvelope(tier, raw, now) {
   } catch {
     return { outcome: 'fallback', reason: 'invalid' };
   }
-  if (!envelope || envelope.tier !== tier || typeof envelope.generatedAt !== 'number' || !envelope.payload) {
+  if (!isPlainObject(envelope)
+    || envelope.tier !== tier
+    || !Number.isFinite(envelope.generatedAt)
+    || !Number.isInteger(envelope.generatedAt)
+    || envelope.generatedAt > now + MAX_FUTURE_SKEW_MS
+    || !isPlainObject(envelope.payload)
+    || !isPlainObject(envelope.payload.data)
+    || !Array.isArray(envelope.payload.missing)) {
     return { outcome: 'fallback', reason: 'invalid' };
   }
   if (now - envelope.generatedAt > TIER_MAX_AGE_MS[tier]) return { outcome: 'fallback', reason: 'stale' };
   return { outcome: 'kv', reason: null };
 }
 
+function warnDeliveryFailure(failureClass) {
+  if (loggedDeliveryFailures.has(failureClass)) return;
+  loggedDeliveryFailures.add(failureClass);
+  console.warn(JSON.stringify({
+    event_type: 'bootstrap_kv_shadow_delivery',
+    failure_class: failureClass,
+  }));
+}
+
 async function emit(env, event) {
   const token = env?.AXIOM_API_TOKEN;
-  if (!token) return; // no token (e.g. inert deploy) → measured silently, never throws
+  if (!token) {
+    warnDeliveryFailure('missing_token');
+    return;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), AXIOM_TIMEOUT_MS);
   try {
-    await fetch(AXIOM_INGEST_URL, {
+    const response = await fetch(AXIOM_INGEST_URL, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'WorldMonitor Bootstrap KV Shadow/1.0',
+      },
       body: JSON.stringify([{ _time: new Date().toISOString(), ...event }]),
+      signal: controller.signal,
     });
+    if (!response.ok) warnDeliveryFailure('http_error');
   } catch {
-    // Observability must never surface into the request path.
+    warnDeliveryFailure(controller.signal.aborted ? 'timeout' : 'network_error');
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -75,14 +99,19 @@ async function probeAndEmit(tier, env, cf) {
   const started = Date.now();
   let outcome = 'fallback';
   let reason = 'error';
+  let ceilingTimer;
   try {
     const raw = await Promise.race([
       env.BOOTSTRAP_KV.get(tier, { type: 'text' }),
-      new Promise((_, reject) => setTimeout(() => reject(PROBE_TIMEOUT), PROBE_CEILING_MS)),
+      new Promise((_, reject) => {
+        ceilingTimer = setTimeout(() => reject(PROBE_TIMEOUT), PROBE_CEILING_MS);
+      }),
     ]);
     ({ outcome, reason } = classifyKvEnvelope(tier, raw, Date.now()));
   } catch (err) {
     reason = err === PROBE_TIMEOUT ? 'timeout' : 'error';
+  } finally {
+    clearTimeout(ceilingTimer);
   }
   const kvDurationMs = Date.now() - started;
   // Fixed allowlist — no request/user/credential/header fields can appear here.
@@ -107,4 +136,9 @@ export function maybeShadowKvRead(request, url, env, ctx) {
   const tier = bootstrapTierFromPublicRequest(request, url);
   if (!tier) return;
   ctx.waitUntil(probeAndEmit(tier, env, request.cf));
+}
+
+export function __resetKvShadowForTests() {
+  isolateCold = true;
+  loggedDeliveryFailures.clear();
 }

--- a/workers/api-cors-preflight/src/kv-shadow.js
+++ b/workers/api-cors-preflight/src/kv-shadow.js
@@ -1,0 +1,110 @@
+// KV shadow measurement for the bootstrap public tiers (U-K2 of the KV serving plan; #5338 / #5300).
+//
+// Rides on this Worker's existing pass-through. On real public-tier /api/bootstrap traffic it
+// measures how long `env.BOOTSTRAP_KV.get(tier)` takes AT THIS POP and emits it per region —
+// WITHOUT serving from KV. Every read runs in ctx.waitUntil; the response is never touched.
+//
+// Purpose: prove (or disprove) that KV beats the incumbent Redis in the far cohorts (hkg1/syd1/
+// bom1/sin1) before any serving cutover (U-K3 gate). This is the "measure, don't assume" step —
+// KV's docs promise local-POP reads, but the decision rides on your traffic, not the docs.
+//
+// Gated by BOOTSTRAP_KV_SHADOW: unset/"0" makes every function here a no-op, so the Worker
+// deploys inert and the measurement is flipped on/off by a single var. Privacy: the emitted event
+// is a fixed allowlist — never a request, user, credential, or header field.
+
+const PUBLIC_TIERS = new Set(['fast', 'slow']);
+// Staleness thresholds mirror KTD4 of the serving plan (fast 15 min, slow 60 min): a value older
+// than this would fall through to origin at serve time, so it counts as a non-serving read here.
+export const TIER_MAX_AGE_MS = Object.freeze({ fast: 15 * 60_000, slow: 60 * 60_000 });
+const PROBE_CEILING_MS = 5_000; // bounds a pathological read; NOT a serving budget (this is waitUntil)
+const AXIOM_INGEST_URL = 'https://api.axiom.co/v1/datasets/wm_api_usage/ingest';
+const PROBE_TIMEOUT = Symbol('kv-probe-timeout');
+
+let isolateCold = true; // true until the first probe in this isolate — gives explicit cold/warm split
+
+/**
+ * The bare tier name for a public-tier bootstrap GET, else null. Mirrors
+ * api/bootstrap.js#isPublicTierBootstrapRequest exactly: GET /api/bootstrap with precisely
+ * `tier=fast|slow` and `public=1` and no other params.
+ */
+export function bootstrapTierFromPublicRequest(request, url) {
+  if (request.method !== 'GET') return null;
+  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
+  if (pathname !== '/api/bootstrap') return null;
+  const keys = [...url.searchParams.keys()];
+  if (keys.some((k) => k !== 'tier' && k !== 'public')) return null;
+  const tiers = url.searchParams.getAll('tier');
+  const pub = url.searchParams.getAll('public');
+  if (tiers.length !== 1 || pub.length !== 1 || pub[0] !== '1') return null;
+  return PUBLIC_TIERS.has(tiers[0]) ? tiers[0] : null;
+}
+
+/** Classify a raw KV value the way the serving path would decide to serve vs fall through. */
+export function classifyKvEnvelope(tier, raw, now) {
+  if (raw == null) return { outcome: 'fallback', reason: 'miss' };
+  let envelope;
+  try {
+    envelope = JSON.parse(raw);
+  } catch {
+    return { outcome: 'fallback', reason: 'invalid' };
+  }
+  if (!envelope || envelope.tier !== tier || typeof envelope.generatedAt !== 'number' || !envelope.payload) {
+    return { outcome: 'fallback', reason: 'invalid' };
+  }
+  if (now - envelope.generatedAt > TIER_MAX_AGE_MS[tier]) return { outcome: 'fallback', reason: 'stale' };
+  return { outcome: 'kv', reason: null };
+}
+
+async function emit(env, event) {
+  const token = env?.AXIOM_API_TOKEN;
+  if (!token) return; // no token (e.g. inert deploy) → measured silently, never throws
+  try {
+    await fetch(AXIOM_INGEST_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify([{ _time: new Date().toISOString(), ...event }]),
+    });
+  } catch {
+    // Observability must never surface into the request path.
+  }
+}
+
+async function probeAndEmit(tier, env, cf) {
+  const cold = isolateCold;
+  isolateCold = false;
+  const started = Date.now();
+  let outcome = 'fallback';
+  let reason = 'error';
+  try {
+    const raw = await Promise.race([
+      env.BOOTSTRAP_KV.get(tier, { type: 'text' }),
+      new Promise((_, reject) => setTimeout(() => reject(PROBE_TIMEOUT), PROBE_CEILING_MS)),
+    ]);
+    ({ outcome, reason } = classifyKvEnvelope(tier, raw, Date.now()));
+  } catch (err) {
+    reason = err === PROBE_TIMEOUT ? 'timeout' : 'error';
+  }
+  const kvDurationMs = Date.now() - started;
+  // Fixed allowlist — no request/user/credential/header fields can appear here.
+  await emit(env, {
+    event_type: 'bootstrap_kv_shadow',
+    bootstrap_tier: tier,
+    kv_outcome: outcome,
+    kv_reason: reason,
+    kv_duration_ms: kvDurationMs,
+    execution_cold: cold,
+    cf_colo: cf?.colo ?? null,
+    cf_country: cf?.country ?? null,
+  });
+}
+
+/**
+ * Fire-and-forget KV shadow read for a public-tier bootstrap GET. No-op unless the flag is on,
+ * the binding exists, and ctx.waitUntil is available. Never affects the response.
+ */
+export function maybeShadowKvRead(request, url, env, ctx) {
+  if (env?.BOOTSTRAP_KV_SHADOW !== '1' || !env?.BOOTSTRAP_KV || typeof ctx?.waitUntil !== 'function') return;
+  const tier = bootstrapTierFromPublicRequest(request, url);
+  if (!tier) return;
+  ctx.waitUntil(probeAndEmit(tier, env, request.cf));
+}

--- a/workers/api-cors-preflight/wrangler.toml
+++ b/workers/api-cors-preflight/wrangler.toml
@@ -16,3 +16,16 @@ zone_name = "worldmonitor.app"
 # Observability: surface Worker errors in CF dashboard logs.
 [observability]
 enabled = true
+
+# Bootstrap tier objects on Workers KV — read-only, for the U-K2 shadow measurement (#5338).
+# The publisher (Railway) writes these keys; here the Worker only reads them to time the read
+# per POP. Namespace id is config, not a secret.
+[[kv_namespaces]]
+binding = "BOOTSTRAP_KV"
+id = "40d42ec8064b4813ac87e61b43fb697f"
+
+# Shadow flag — "0" = inert (Worker behaves exactly as the CORS-only version). Flip to "1" to
+# start measuring (a one-line change + CI redeploy, or a dashboard var override). AXIOM_API_TOKEN
+# is set as a Worker secret (never committed) and is only needed once the flag is on.
+[vars]
+BOOTSTRAP_KV_SHADOW = "0"


### PR DESCRIPTION
Storage-primitive decision (from #5338): serve the public bootstrap tiers from **Workers KV**, not R2. Both cost ~\$0/mo at this scale, but an R2 bucket is **single-location** — ours is Eastern North America (ENAM, confirmed in the dashboard) — so every APAC read hops to North America (the 1.3–2.3 s p99 the R2 shadow measured). KV is **globally replicated**, served from the local POP. It is the managed version of the R2 + Smart Tiered Cache + Cache Reserve stack we were hand-assembling.

This PR lands the first two units. **Nothing serves from KV yet, and nothing is measured yet** — both stages deploy inert and are flag-gated.

## U-K1 — publisher writes tier envelopes to KV
`scripts/publish-bootstrap-tiers.mjs` now writes each tier's exact `{generatedAt, tier, payload}` envelope to KV alongside R2, keyed by bare tier (`fast`/`slow`) so the serving Worker reads `env.KV.get(tier)`.
- **Best-effort + gated by credential presence**: absent KV creds ⇒ skipped (R2-only deploys unaffected); a KV failure — including the 25 MiB cap guard — **never aborts the canonical R2 publish**, but logs loudly.
- **25 MiB guard fires before the network call** (the 11.5 MB #5311 lesson — a bloated tier fails loud, never truncates).
- Self-contained helper `scripts/_kv-storage.mjs` — no `../api`/`../src`/`../server` imports (Railway #5268), verified by the import-graph guard.
- **Validated against real data**, not just mocks: `putKvJsonValue` wrote a real envelope to the live namespace and read it back byte-identical. 12 unit tests; existing publisher suite still 12/12.

## U-K2 — KV shadow measurement in the CORS Worker
Measures `env.BOOTSTRAP_KV.get(tier)` latency **per POP** on real public-tier traffic, to prove KV beats the incumbent Redis in the far cohorts (hkg1/syd1/bom1/sin1) **before** any serving cutover. It does **not** serve from KV — every read is in `ctx.waitUntil`, the response is untouched.
- **Extends the existing `api-cors-preflight` Worker**, not a new one: it already sits on `api.worldmonitor.app/*` and is already a pass-through. A second Worker on `/api/bootstrap*` would be more-specific and steal traffic from the CORS Worker — reintroducing the exact CORS outage its own header documents. The shadow lives entirely in `src/kv-shadow.js`; CORS code is untouched.
- **Load-bearing test:** the CORS response is **byte-identical whether the shadow is on or off**. 22 existing CORS tests + 8 new shadow tests all pass; wrangler dry-run bundles clean.
- **Self-gating flag** `BOOTSTRAP_KV_SHADOW="0"` ⇒ deploys inert (behaves exactly as today). Flip to `"1"` to measure.
- **Allowlisted telemetry only** (`bootstrap_kv_shadow`): `bootstrap_tier, kv_outcome/reason, kv_duration_ms, execution_cold, cf_colo, cf_country` — no request/user/credential/header field can appear (exact-keys test). Emitted to the same Axiom `wm_api_usage` dataset the Vercel side uses.

## Ops already staged
- Railway `publish-bootstrap-tiers` service has the three `KV_BOOTSTRAP_*` vars (inert until this merges and the publisher redeploys).
- `AXIOM_API_TOKEN` set as a repo secret, for when the flag flips.

## Staged rollout after merge
1. Publisher starts writing KV; the Worker deploys **inert** (CORS-only behaviour).
2. Verify prod `/api/bootstrap` + CORS unaffected.
3. **Flag-flip PR**: set `BOOTSTRAP_KV_SHADOW="1"` + add one `wrangler secret put AXIOM_API_TOKEN` step → measurement begins.
4. **U-K3 verify** (24 h window): does KV beat Redis in the worst APAC cohort? → decide the cutover (U-K4).

## Coordination
This is the KV serving path; it **supersedes the R2 serve-from-Vercel cutover** the parallel sessions built (#5325/#5328/#5331). The R2 publisher, bucket, and #5339's `redis_duration_ms` are **not wasted** — R2 stays a working fallback and the A/B baseline. The R2 serving cutover should **pause** so the endpoint isn't cut two ways at once.

## Verification
- `bootstrap-kv-publisher` (12), `publish-bootstrap-tiers` (12), worker CORS+shadow (30), `seed-bundle-resilience-validation` (6) — all green.
- Full pre-push gate passed (typecheck, boundaries, safe-HTML, rate-limit, premium-fetch, edge-bundle, version sync).
- KV write round-tripped against the live namespace; token scoped + validated 5/5.

https://claude.ai/code/session_01NTYAunDvEaTSD9oWUG3tC9