### PR TITLE
feat(bootstrap): turn on the KV shadow measurement (U-K3 gate, #5338)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -53,6 +53,21 @@ jobs:
           node-version: '24'
       - name: Install
         run: npm install --no-audit --no-fund
+      # The KV shadow (BOOTSTRAP_KV_SHADOW=1) emits to Axiom; the Worker reads AXIOM_API_TOKEN
+      # as a secret. Set it before deploy. Absent secret => the shadow no-ops silently
+      # (warnDeliveryFailure 'missing_token'), never an error — so a missing secret can't
+      # break the CORS deploy.
+      - name: Set Axiom secret
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AXIOM_API_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
+        run: |
+          if [ -n "$AXIOM_API_TOKEN" ]; then
+            printf '%s' "$AXIOM_API_TOKEN" | npx wrangler secret put AXIOM_API_TOKEN
+          else
+            echo "AXIOM_API_TOKEN not set — KV shadow telemetry no-ops (measured silently)"
+          fi
       - name: Deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -58,6 +58,12 @@ jobs:
       # (warnDeliveryFailure 'missing_token'), never an error — so a missing secret can't
       # break the CORS deploy.
       - name: Set Axiom secret
+        # Must never gate the CORS deploy. A secret-put that fails (token lacks the
+        # Workers-secret scope, transient CF error) would otherwise fail the job and skip
+        # Deploy below — coupling the fragile CORS deploy to Axiom telemetry, the exact
+        # invariant this path promises not to break. On failure the shadow just no-ops
+        # (missing_token); the failure still surfaces in the job log.
+        continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/workers/api-cors-preflight/wrangler.toml
+++ b/workers/api-cors-preflight/wrangler.toml
@@ -24,8 +24,8 @@ enabled = true
 binding = "BOOTSTRAP_KV"
 id = "40d42ec8064b4813ac87e61b43fb697f"
 
-# Shadow flag — "0" = inert (Worker behaves exactly as the CORS-only version). Flip to "1" to
-# start measuring (a one-line change + CI redeploy, or a dashboard var override). AXIOM_API_TOKEN
-# is set as a Worker secret (never committed) and is only needed once the flag is on.
+# Shadow flag — "1" = measuring. The Worker shadow-reads BOOTSTRAP_KV per POP on public-tier
+# bootstrap GETs (in ctx.waitUntil; response untouched) and emits per-region latency to Axiom.
+# CORS behaviour is provably identical to "0" (byte-identical test). Flip back to "0" to stop.
 [vars]
-BOOTSTRAP_KV_SHADOW = "0"
+BOOTSTRAP_KV_SHADOW = "1"


### PR DESCRIPTION
**This is the PR that turns measurement on.** #5341 landed the plumbing inert; this flips `BOOTSTRAP_KV_SHADOW="0"→"1"` so the `api-cors-preflight` Worker starts shadow-reading KV per POP and emitting per-region latency. It does **not** serve from KV — that's U-K4, gated on what this measures.

## What it changes (2 files)
- `workers/api-cors-preflight/wrangler.toml`: `BOOTSTRAP_KV_SHADOW` `"0"` → `"1"`.
- `.github/workflows/deploy-worker.yml`: sets `AXIOM_API_TOKEN` as a Worker secret before deploy (guarded — an absent secret makes the shadow no-op silently, never breaking the CORS deploy).

## Why it's safe to flip
Everything here was proven by #5341's tests, which are unchanged:
- **CORS output is byte-identical** whether the flag is `"0"` or `"1"` (the load-bearing test). The shadow rides in `ctx.waitUntil`; the response is never touched.
- **Instantly reversible** — flip back to `"0"`.
- **Allowlisted telemetry only** — `bootstrap_tier, kv_outcome/reason, kv_duration_ms, execution_cold, cf_colo, cf_country`. No request/user/credential field can appear.
- The CI Cloudflare token now has **Workers KV Storage**, so the KV-binding deploy authorizes.

## What to check after merge
1. Prod `/api/bootstrap` + CORS unaffected (the Worker's CORS behaviour is identical).
2. `bootstrap_kv_shadow` events landing in Axiom `wm_api_usage` across multiple colos, with populated `kv_duration_ms`.
3. Note: until the Railway publisher's first KV write lands, shadow reads return `miss` (not an error) — expected. Once #5341's publisher redeploy writes KV, they return `kv`.

## Then — the actual decision (U-K3)
Let one **steady-state 24h window** run, then compare KV (`bootstrap_kv_shadow`, by `cf_colo`) against the incumbent Redis (`redis_duration_ms` from #5339, by `execution_region`), **gated on the worst APAC cohort** (hkg1/syd1/bom1/sin1). If KV wins there materially, U-K4 (serve from KV) is worth building. If it doesn't — like the R2 fast tier — we stop, having spent one flag.

Reminder: this is still a bet, not a proven win. The whole point of this PR is to replace the argument ("KV is globally replicated, ENAM R2 is single-region") with a measured per-region number.

https://claude.ai/code/session_01NTYAunDvEaTSD9oWUG3tC9