### PR TITLE
perf(cls): reserve grid slots for immediate-tier panels — shell the top-8 mounts (#5332)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1318,7 +1318,14 @@ export class PanelLayoutManager implements AppModule {
       let mountedFromDeferred = false;
       if (config.enabled && deferred && !deferred.mounted && (!deferred.placeholder || placeholderWasHidden)) {
         mountedFromDeferred = this.mountDeferredPanel(key);
-      } else if (deferred?.placeholder) {
+      }
+      // Reconcile placeholder visibility even when the mount attempt no-ops
+      // (an in-flight load sets deferred.loading, so mountDeferredPanel
+      // returns false): a re-enable during that window must unhide the shell
+      // or the panel vanishes until the chunk resolves — and forever if the
+      // load then fails, since a hidden shell can never intersect the retry
+      // observer.
+      if (!mountedFromDeferred && deferred?.placeholder) {
         deferred.placeholder.classList.toggle('hidden', !config.enabled);
       }
       const panel = this.ctx.panels[key];
@@ -1572,8 +1579,19 @@ export class PanelLayoutManager implements AppModule {
     if (deferred.retryAttempts >= DEFERRED_PANEL_MAX_RETRY_ATTEMPTS) {
       // Give up after a bounded number of attempts so a permanently failing
       // dynamic import (offline, stale chunk) cannot spin a 1s retry loop forever.
-      // The shell stays in place as a quiet fallback, matching the prior fail-safe.
+      // The shell stays in place as a quiet fallback, and a one-shot 'online'
+      // listener re-arms the retry budget so a connectivity blip during boot
+      // doesn't strand the skeleton until a manual reload — a genuinely broken
+      // chunk fails its retries again and lands back here.
       deferred.failed = true;
+      if (typeof window !== 'undefined') {
+        window.addEventListener('online', () => {
+          if (this.deferredPanelMounts.get(key) !== deferred || deferred.mounted || this.ctx.isDestroyed) return;
+          deferred.failed = false;
+          deferred.retryAttempts = 0;
+          this.observeDeferredPanelShell(key, deferred);
+        }, { once: true });
+      }
       return;
     }
     deferred.retryAttempts += 1;
@@ -1627,11 +1645,10 @@ export class PanelLayoutManager implements AppModule {
     return true;
   }
 
-  private mountLazyPanel(key: string, grid: HTMLElement, placeholder?: HTMLElement | null): void {
+  private mountLazyPanel(key: string, grid: HTMLElement): void {
     void this.loadRegisteredPanel(key).then((panel) => {
       if (!panel || this.ctx.isDestroyed) return;
-      const targetGrid = placeholder?.parentNode ? (placeholder.parentNode as HTMLElement) : grid;
-      if (this.mountPanelElement(targetGrid, key, panel, placeholder)) {
+      if (this.mountPanelElement(grid, key, panel)) {
         this.afterPanelMounted(key, panel);
       }
     });

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1461,11 +1461,16 @@ export class PanelLayoutManager implements AppModule {
       return;
     }
     if (panel || !this.lazyPanelRegistrations.has(key)) return;
-    if (this.shouldMountPanelImmediately(key)) {
-      this.mountLazyPanel(key, grid);
-      return;
-    }
+    // Immediate-tier lazy panels go through the same slot-reserving shell
+    // contract as deferred ones (#5332): the shell occupies the panel's grid
+    // slot during this synchronous boot pass and the async chunk arrival
+    // replaces it in place. The previous placeholder-less mountLazyPanel path
+    // inserted a brand-new grid item whenever the import resolved — field
+    // mover data named those insertions as the dominant desktop CLS source.
     this.deferPanelMount(key, null, grid, this.ctx.panelSettings[key]?.enabled === true);
+    if (this.shouldMountPanelImmediately(key)) {
+      this.mountDeferredPanel(key);
+    }
   }
 
   private mountPanelElement(grid: HTMLElement, key: string, panel: Panel, placeholder?: HTMLElement | null): boolean {

--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -637,14 +637,18 @@ export class SearchManager implements AppModule {
 
   /**
    * Deep-links to a tab inside a panel by dispatching the panel's open-tab
-   * event once it's mounted. The element existing in the DOM implies the
-   * panel's constructor (and its event listener) has run, so we retry until
-   * then — mirrors scrollToPanelWhenReady for async-mounted panels.
+   * event once it's mounted. Deferred-shell placeholders carry the same
+   * data-panel attribute but no listener — only the REAL panel element (shell
+   * excluded via data-deferred-panel) proves the constructor has run, so we
+   * retry until the shell is replaced in place. The scroll helpers above
+   * intentionally still match shells: a shell occupies the panel's slot, and
+   * scrolling to it is what brings it into the IntersectionObserver margin
+   * that triggers the mount.
    */
   private dispatchPanelTab(panelId: string, tab: string, attemptsLeft = 12): void {
     // Currently only Consumer Prices exposes a tab deep-link contract.
     if (panelId !== 'consumer-prices') return;
-    if (document.querySelector(`[data-panel="${panelId}"]`)) {
+    if (document.querySelector(`[data-panel="${panelId}"]:not([data-deferred-panel])`)) {
       window.dispatchEvent(new CustomEvent('wm-consumer-prices-open-tab', { detail: { tab } }));
       return;
     }

--- a/tests/panel-mount-deferral.test.mts
+++ b/tests/panel-mount-deferral.test.mts
@@ -472,4 +472,28 @@ describe('panel mount deferral', () => {
       'mountPanelElement must flush runWhenConnected callbacks after inserting the panel element',
     );
   });
+
+  it('reserves a grid slot for immediate-tier lazy panels before their chunk loads (#5332)', async () => {
+    const source = await readFile(new URL('../src/app/panel-layout.ts', import.meta.url), 'utf8');
+    const method = source.match(/private\s+insertInitialPanelByKey\([\s\S]*?\n {2}\}/);
+
+    assert.ok(method, 'insertInitialPanelByKey method not found');
+    assert.doesNotMatch(
+      method[0],
+      /mountLazyPanel\(/,
+      'immediate-tier boot mounts must not use the placeholder-less mountLazyPanel path: the async '
+        + 'chunk arrival inserts a brand-new grid item and shoves every panel below it — field mover '
+        + 'data (#5332) named these insertions as the dominant desktop CLS mechanism',
+    );
+    assert.match(
+      method[0],
+      /this\.deferPanelMount\(key,/,
+      'insertInitialPanelByKey must reserve the panel slot with a deferred shell during the synchronous boot pass',
+    );
+    assert.match(
+      method[0],
+      /this\.mountDeferredPanel\(key\);/,
+      'immediate-tier panels must still start loading right away by triggering the deferred mount synchronously',
+    );
+  });
 });

--- a/tests/panel-mount-deferral.test.mts
+++ b/tests/panel-mount-deferral.test.mts
@@ -487,13 +487,11 @@ describe('panel mount deferral', () => {
     );
     assert.match(
       method[0],
-      /this\.deferPanelMount\(key,/,
-      'insertInitialPanelByKey must reserve the panel slot with a deferred shell during the synchronous boot pass',
-    );
-    assert.match(
-      method[0],
-      /this\.mountDeferredPanel\(key\);/,
-      'immediate-tier panels must still start loading right away by triggering the deferred mount synchronously',
+      /this\.deferPanelMount\(key, null, grid, this\.ctx\.panelSettings\[key\]\?\.enabled === true\);\s*if \(this\.shouldMountPanelImmediately\(key\)\) \{\s*this\.mountDeferredPanel\(key\);\s*\}/,
+      'insertInitialPanelByKey must reserve the slot first (withShell tied to the enabled flag), with the '
+        + 'immediate mount nested inside the shouldMountPanelImmediately budget gate and running after '
+        + 'deferPanelMount — hoisting, reordering, or dropping the enabled arg defeats the immediate-tier '
+        + 'budget or the shell reservation (#5332)',
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes the dominant desktop CLS mechanism named by the #5336 field mover instrumentation (#5332): the first `INITIAL_PANEL_MOUNT_BUDGET_DESKTOP = 8` "immediate-tier" panels were mounted by a **placeholder-less async path** — `insertInitialPanelByKey` → `mountLazyPanel(key, grid)` → dynamic import resolves whenever it resolves → raw `insertByOrder` into the live grid, shoving every panel below it. Field data: `ins:` movers dominated 149 desktop bad-CLS events (insights ×65, cii ×60, threat-timeline ×57, strategic-posture ×55, …), while `sized:` (self-growth, what #5333 pinned) never exceeded 7.

**The fix:** the immediate tier now goes through the same slot-reserving shell contract the deferred tier has always had. `deferPanelMount()` inserts a footprint-matched skeleton shell synchronously during the boot pass, then `mountDeferredPanel()` starts the chunk load immediately; the mount `replaceChild`s the shell in place. One mount pipeline for both tiers — same footprint resolution (natural registry + saved spans + #5333 pins apply to shells identically), same bounded retry on failure.

Note: this deliberately reuses the whole deferred pipeline rather than threading a placeholder through `mountLazyPanel` (the narrower fix sketched on #5332) — one contract instead of two paths, and the retry machinery comes for free. The now-dead `placeholder` param on `mountLazyPanel` was removed.

## Review (multi-agent + cross-model)

9 reviewer personas + an independent Codex (gpt-5.5) adversarial pass. Correctness, adversarial (both in-process and cross-model), and standards returned **zero findings**. Five findings raised; four independently validated, one direct-verified; **all five fixed in the second commit**:

| Sev | Finding | Fix |
|-----|---------|-----|
| P1 | `dispatchPanelTab` treats a shell's `data-panel` as "listener is ready" — one-shot `wm-consumer-prices-open-tab` fired into the void (pre-existing for deferred tier; this diff widened it to top-8 panels) | Shell-excluding selector `:not([data-deferred-panel])`; scroll helpers intentionally still match shells (scrolling to a shell is what triggers its IO mount) |
| P1 | Retry exhaustion (offline boot) left a permanently stuck skeleton, unrecoverable without reload | One-shot `online` listener re-arms the retry budget (benefits both tiers; broken chunks fail again and re-settle) |
| P2 | Re-enable during in-flight chunk load stranded a hidden placeholder (`mountDeferredPanel` no-ops on `deferred.loading`) | Placeholder visibility reconciles independently of the mount attempt |
| P2 | Guard test asserted bare substring presence — hoisting `mountDeferredPanel` out of the budget gate or dropping the `enabled` arg stayed green | Single anchored regex ties order + nesting + enabled-arg |
| P3 | `mountLazyPanel`'s `placeholder` param dead (never called 3-arg in history) | Removed |

Residual (accepted): `markLcpDebug('wm:panel:deferred-mount-*')` markers now also fire for the immediate tier (over-counts "deferred" panels by ~8 if any dashboard keys off it); ~8 short-lived IntersectionObservers created-then-disconnected at boot; runtime behavior of `panel-layout.ts` is untestable in CI (bundler-only) — the guard test is a routing tripwire, not behavioral proof.

## Verification

- Red-first: the guard test failed against the old routing for the expected reason, then passed.
- `tsx --test` across the 6 neighboring panel suites: 65 pass, 0 fail. `biome` clean, `tsc --noEmit` clean.
- **Real acceptance is field-only** (twice-proven lab-blindness on this metric): post-deploy, the 8 keys' `ins:` counts in `extra.movers` should collapse, `cold` share shrink, `div.panel` shift p75 (0.17 desktop) fall, CrUX desktop CLS recover from 63% good.

Closes nothing yet — #5332 stays open as the acceptance tracker until the field data confirms.
