### PR TITLE
fix(seo): scope the Mintlify docs proxy to www + redirect prefix-less /api-reference/* (#5345)

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2488,6 +2488,55 @@ describe('variant subdomain dashboard SEO (#4996)', () => {
   });
 });
 
+describe('docs host scoping — Mintlify proxy is www-only (#5345)', () => {
+  // The /docs rewrite proxies worldmonitor.mintlify.dev with no host condition,
+  // so every variant subdomain served the full docs site and Googlebot crawled
+  // the duplicates. Redirects run before rewrites on Vercel, so a host-scoped
+  // redirect entry is what keeps subdomain /docs requests from reaching the
+  // proxy. The host list is derived from the /dashboard variant rewrites so a
+  // new variant subdomain cannot ship outside the docs redirect.
+  const docsHostRedirect = vercelConfig.redirects.find(
+    (r) => r.source === '/docs/:match*' && r.has
+  );
+  const variantHosts = vercelConfig.rewrites
+    .filter((r) => r.source === '/dashboard' && r.has)
+    .map((r) => (r.has ?? []).find((h) => h.type === 'host')?.value ?? '');
+
+  it('redirects subdomain /docs/* to www permanently', () => {
+    assert.ok(docsHostRedirect, 'expected a host-conditioned redirect for /docs/:match*');
+    assert.equal(docsHostRedirect.destination, 'https://www.worldmonitor.app/docs/:match*');
+    assert.equal(docsHostRedirect.permanent, true);
+  });
+
+  it('the host condition covers every variant subdomain plus api., and never www.', () => {
+    const hostValue = (docsHostRedirect?.has ?? []).find((h) => h.type === 'host')?.value ?? '';
+    const hostRe = new RegExp(hostValue);
+    assert.ok(variantHosts.length > 0, 'variant host extraction from /dashboard rewrites found nothing');
+    for (const host of [...variantHosts, 'api.worldmonitor.app']) {
+      assert.match(host, hostRe, `${host} must be caught by the docs host redirect`);
+    }
+    assert.ok(!hostRe.test('www.worldmonitor.app'), 'www must keep serving the docs proxy');
+  });
+
+  it('redirects prefix-less /api-reference/* (Googlebot fetches Mintlify RSC route strings) into /docs on www', () => {
+    // Mintlify's RSC flight payload embeds its internal routes without the
+    // /docs base path; Googlebot speculatively fetches those strings against
+    // whatever host served the page. Without this redirect they 404 (the SPA
+    // catch-all excludes ^api), flooding GSC.
+    const redirect = vercelConfig.redirects.find((r) => r.source === '/api-reference/:match*');
+    assert.ok(redirect, 'expected a redirect for /api-reference/:match*');
+    assert.equal(redirect.destination, 'https://www.worldmonitor.app/docs/api-reference/:match*');
+    assert.equal(redirect.permanent, true);
+    assert.equal(redirect.has, undefined, 'must apply on every host, www included');
+  });
+
+  it('the www docs proxy rewrite itself is untouched', () => {
+    const proxy = vercelConfig.rewrites.find((r) => r.source === '/docs/:match*');
+    assert.ok(proxy, 'expected the /docs/:match* rewrite');
+    assert.equal(proxy.destination, 'https://worldmonitor.mintlify.dev/docs/:match*');
+  });
+});
+
 describe('markdown canonical Link headers (#4999)', () => {
   // The sitemap-listed markdown pages are intentionally raw text/markdown for
   // agents, so they cannot carry a <link rel="canonical">. RFC 6596 allows the

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,8 @@
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "crons": [],
   "redirects": [
+    { "source": "/docs/:match*", "has": [{ "type": "host", "value": "^(?:tech|finance|commodity|happy|energy|api)\\.worldmonitor\\.app$" }], "destination": "https://www.worldmonitor.app/docs/:match*", "permanent": true },
+    { "source": "/api-reference/:match*", "destination": "https://www.worldmonitor.app/docs/api-reference/:match*", "permanent": true },
     { "source": "/docs", "destination": "/docs/documentation", "permanent": false },
     { "source": "/security.txt", "destination": "/.well-known/security.txt", "permanent": true },
     { "source": "/index.html", "destination": "/", "permanent": true },


### PR DESCRIPTION
Closes #5345. Companion tracking issue for the (upstream, Mintlify-side) breadcrumb JSON-LD defect: #5346.

## What

Two `vercel.json` redirects (redirects run before rewrites on Vercel):

1. **`/docs/:match*` on non-www `*.worldmonitor.app` hosts → 308 `https://www.worldmonitor.app/docs/:match*`.** The Mintlify proxy rewrite had no host condition, so tech/finance/commodity/happy/energy/api all served the complete docs site (verified live: `commodity.worldmonitor.app/docs/agent-discovery` → 200) and Googlebot crawled the duplicates. Canonicals already pointed at www; now the duplicate hosts consolidate with a permanent redirect instead of serving content.
2. **`/api-reference/:match*` (any host) → 308 `https://www.worldmonitor.app/docs/api-reference/:match*`.** Mintlify's RSC flight payload embeds its internal route strings *without* the `/docs` base path (`"/api-reference/aviationservice/getcarrierops"…` — verified in served HTML). Googlebot speculatively fetches URL-like strings from JS payloads against whatever host served the page; the SPA catch-all excludes `^api`, so these 404ed on every host and flooded GSC (`commodity.worldmonitor.app/api-reference/economicservice/getcrudeinventories` etc.).

## Guards

New describe in `tests/deploy-config.test.mjs` (`docs host scoping — Mintlify proxy is www-only (#5345)`):
- host regex must catch every variant subdomain **derived from the `/dashboard` variant rewrites** (a future variant can't ship outside the docs redirect) plus `api.`, and must NOT catch `www.`
- the `/api-reference` redirect must be host-agnostic and permanent
- the www docs proxy rewrite itself must stay untouched

Mutation-tested: reverting `vercel.json` fails all three new guards (1 pass / 3 fail), restored → 4/4. Full suite: 157/157.

## Verification after deploy

- `curl -sI https://commodity.worldmonitor.app/docs/agent-discovery` → 308 to www
- `curl -sI https://commodity.worldmonitor.app/api-reference/economicservice/getcrudeinventories` → 308 to `https://www.worldmonitor.app/docs/api-reference/...`
- `curl -sI https://www.worldmonitor.app/docs/agent-discovery` → 200 (unchanged)
- GSC: validate-fix on the 404 batch once redirects are live

https://claude.ai/code/session_01XFb8FdQV9tac2eSVZpFSG7
