### PR TITLE
test(dom): cover sanitizer and construction contracts

### DIFF
--- a/tests/dom-utils.test.mts
+++ b/tests/dom-utils.test.mts
@@ -134,6 +134,21 @@ function withBrowserDom(fn: () => void): void {
 }
 
 describe('dom-utils construction helpers', () => {
+  it('withBrowserDom exposes standard node-type contracts', () => {
+    withBrowserDom(() => {
+      const element = document.createElement('div');
+      const text = document.createTextNode('content');
+      const fragment = document.createDocumentFragment();
+
+      assert.equal(Node.ELEMENT_NODE, 1);
+      assert.equal(Node.TEXT_NODE, 3);
+      assert.equal(Node.DOCUMENT_FRAGMENT_NODE, 11);
+      assert.equal(element.nodeType, Node.ELEMENT_NODE);
+      assert.equal(text.nodeType, Node.TEXT_NODE);
+      assert.equal(fragment.nodeType, Node.DOCUMENT_FRAGMENT_NODE);
+    });
+  });
+
   it('h applies attributes, datasets, and both supported style forms', () => {
     withBrowserDom(() => {
       const element = h('button', {

--- a/tests/dom-utils.test.mts
+++ b/tests/dom-utils.test.mts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { ensureNoopenerRel, safeHtml } from '../src/utils/dom-utils.ts';
+import { h, ensureNoopenerRel, replaceChildren, safeHtml } from '../src/utils/dom-utils.ts';
+import { createBrowserEnvironment, MiniNode } from './helpers/mini-dom.mts';
 
 class TestElement {
   readonly nodeType = 1;
@@ -107,6 +108,109 @@ function withMinimalDom(fn: () => void): void {
     else globals.Node = originalNode;
   }
 }
+
+function withBrowserDom(fn: () => void): void {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+  const originalNode = Object.getOwnPropertyDescriptor(globalThis, 'Node');
+  const browser = createBrowserEnvironment();
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: browser.document,
+  });
+  Object.defineProperty(globalThis, 'Node', {
+    configurable: true,
+    value: MiniNode,
+  });
+
+  try {
+    fn();
+  } finally {
+    if (originalDocument) Object.defineProperty(globalThis, 'document', originalDocument);
+    else delete (globalThis as { document?: unknown }).document;
+    if (originalNode) Object.defineProperty(globalThis, 'Node', originalNode);
+    else delete (globalThis as { Node?: unknown }).Node;
+  }
+}
+
+describe('dom-utils construction helpers', () => {
+  it('h applies attributes, datasets, and both supported style forms', () => {
+    withBrowserDom(() => {
+      const element = h('button', {
+        className: 'primary',
+        id: 'launch',
+        dataset: { role: 'action', active: 'true' },
+        style: { color: 'blue', display: 'none' },
+        'aria-label': 'Launch',
+        disabled: true,
+        ignored: null,
+      });
+      const stringStyled = h('span', { style: 'color: red;' });
+
+      assert.equal(element.className, 'primary');
+      assert.equal(element.id, 'launch');
+      assert.deepEqual(
+        { role: element.dataset.role, active: element.dataset.active },
+        { role: 'action', active: 'true' },
+      );
+      assert.deepEqual(
+        { color: element.style.color, display: element.style.display },
+        { color: 'blue', display: 'none' },
+      );
+      assert.equal(stringStyled.style.cssText, 'color: red;');
+      assert.equal(element.getAttribute('aria-label'), 'Launch');
+      assert.equal(element.hasAttribute('disabled'), true);
+      assert.equal(element.hasAttribute('ignored'), false);
+    });
+  });
+
+  it('h registers event handlers from on-prefixed props', () => {
+    withBrowserDom(() => {
+      let clicks = 0;
+      const button = h('button', { onClick: () => { clicks += 1; } });
+
+      button.dispatchEvent(new Event('click'));
+
+      assert.equal(clicks, 1);
+    });
+  });
+
+  it('h preserves node children, stringifies numbers, and skips empty children', () => {
+    withBrowserDom(() => {
+      const child = document.createElement('span');
+      const element = h(
+        'div',
+        'first',
+        child,
+        42,
+        null,
+        undefined,
+        false,
+        'last',
+      );
+
+      assert.equal(element.childNodes.length, 4);
+      assert.equal(element.childNodes[0]!.textContent, 'first');
+      assert.equal(element.childNodes[1], child);
+      assert.equal(element.childNodes[2]!.textContent, '42');
+      assert.equal(element.childNodes[3]!.textContent, 'last');
+    });
+  });
+
+  it('replaceChildren removes prior content before appending replacements', () => {
+    withBrowserDom(() => {
+      const element = h('div', null, 'old', h('span'));
+      const replacement = h('strong');
+
+      replaceChildren(element, replacement, 'new', 7);
+
+      assert.equal(element.childNodes.length, 3);
+      assert.equal(element.childNodes[0], replacement);
+      assert.equal(element.childNodes[1]!.textContent, 'new');
+      assert.equal(element.childNodes[2]!.textContent, '7');
+    });
+  });
+});
 
 describe('dom-utils safe link helpers', () => {
   it('adds noopener and noreferrer for blank-target links (#3550)', () => {

--- a/tests/helpers/mini-dom.mts
+++ b/tests/helpers/mini-dom.mts
@@ -40,6 +40,10 @@ export class MiniClassList {
 }
 
 export class MiniNode extends EventTarget {
+  static readonly ELEMENT_NODE = 1;
+  static readonly TEXT_NODE = 3;
+  static readonly DOCUMENT_FRAGMENT_NODE = 11;
+
   childNodes: Array<MiniElement | MiniText | MiniDocumentFragment> = [];
   parentNode: MiniNode | null = null;
   parentElement: MiniElement | null = null;
@@ -132,6 +136,7 @@ export class MiniNode extends EventTarget {
 }
 
 export class MiniText extends MiniNode {
+  readonly nodeType = MiniNode.TEXT_NODE;
   private value: string;
 
   constructor(value: string | number) {
@@ -153,6 +158,8 @@ export class MiniText extends MiniNode {
 }
 
 export class MiniDocumentFragment extends MiniNode {
+  readonly nodeType = MiniNode.DOCUMENT_FRAGMENT_NODE;
+
   get outerHTML(): string {
     return this.childNodes.map((child) => child.outerHTML ?? child.textContent ?? '').join('');
   }
@@ -164,6 +171,7 @@ interface MiniAttributeSelector {
 }
 
 export class MiniElement extends MiniNode {
+  readonly nodeType = MiniNode.ELEMENT_NODE;
   readonly attributes = new Map<string, string>();
   readonly classList = new MiniClassList();
   readonly dataset: Record<string, string> = {};

--- a/tests/sanitize.test.mts
+++ b/tests/sanitize.test.mts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { escapeHtml, sanitizeUrl } from '../src/utils/sanitize.ts';
+
+describe('sanitize utility contracts', () => {
+  it('escapeHtml escapes every HTML delimiter while preserving safe text', () => {
+    assert.deepEqual(
+      [escapeHtml(`<>&"'`), escapeHtml('World Monitor 123')],
+      ['&lt;&gt;&amp;&quot;&#39;', 'World Monitor 123'],
+    );
+  });
+
+  it('sanitizeUrl rejects executable, data, non-HTTP, and bare relative URLs', () => {
+    assert.deepEqual(
+      [
+        'javascript:alert(1)',
+        'data:text/html,<script>alert(1)</script>',
+        'ftp://example.com/file',
+        'relative/path',
+      ].map(sanitizeUrl),
+      ['', '', '', ''],
+    );
+  });
+
+  it('sanitizeUrl preserves supported relative references as attribute-safe values', () => {
+    assert.deepEqual(
+      ['/local/path', './local/path', '../local/path', '?q=1&b=2', '#section'].map(sanitizeUrl),
+      ['/local/path', './local/path', '../local/path', '?q=1&amp;b=2', '#section'],
+    );
+  });
+
+  it('sanitizeUrl normalizes HTTP URLs and attribute-escapes query delimiters', () => {
+    assert.deepEqual(
+      [sanitizeUrl('https://example.com'), sanitizeUrl('http://example.com/a?x=1&y=2')],
+      ['https://example.com/', 'http://example.com/a?x=1&amp;y=2'],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Locks down the sanitizer and DOM-construction contracts that were missing from the current test suite, without adding a browser-emulation dependency or lockfile churn. The existing mini DOM now exercises public element construction, event, child, and replacement behavior; it also exposes standard node-type constants and instance values so DOM-walking tests cannot silently skip elements. Direct sanitizer tests pin escaping, protocol rejection, and supported relative URLs.

Related: #5343

## Validation

- Mutation checks proved each new contract fails when its production behavior is broken.
- Focused sanitizer/DOM/safe-HTML run: 19 passed.
- Repository pre-push gate passed after both commits, including typechecks, lint guardrails, bundle checks, and 12 changed-file tests on the final head.
- `npm run test:data` was repeated after review; its only 2 failures require a prebuilt `dist/dashboard.html`, which this test-only worktree does not contain.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
