### PR TITLE
feat(bootstrap): serve public tier from KV via the Worker (U-K4, #5338)

### DIFF
--- a/docs/solutions/2026-07-16-bootstrap-kv-verify.md
+++ b/docs/solutions/2026-07-16-bootstrap-kv-verify.md
@@ -1,0 +1,80 @@
+# U-K3 verify gate — KV vs Redis, decision evidence
+
+**Decision: GO** — serve the public bootstrap tier from KV via the Worker (proceed to U-K4).
+
+## Method
+
+Two independently-measured server-side read latencies over one steady-state window,
+joined **by geography** (the two sides use different vantage points on purpose):
+
+- **KV candidate** — `bootstrap_kv_shadow` / `kv_duration_ms` (`kv_outcome=='kv'`), dimensioned by
+  `cf_country` / `cf_colo`. The proposed path: a Cloudflare Worker reads the tier from a KV binding
+  at the edge POP nearest the user (#5338 U-K2).
+- **Redis incumbent** — `bootstrap_r2_shadow` / `redis_duration_ms`, dimensioned by Vercel
+  `execution_region`. The current path: a Vercel Function reads Upstash Redis (#5339).
+
+Budget = **1200 ms p95** (the mobile-client abort the whole epic is chasing). The single decision
+metric is **share of reads that clear the budget**, which is automatically traffic-weighted.
+
+> **Gate framing changed from the original plan.** The plan gated on "the worst APAC cohort
+> (hkg1/syd1/bom1/sin1)." That was too narrow: APAC is a minority of the user base and Seoul never
+> gathered enough traffic to judge (n≈14). Replaced with a **global, traffic-weighted** gate — where
+> users actually are. The APAC per-metro table is retained as a diagnostic, not the gate.
+
+## Result (window 2026-07-16 12:00 UTC → 2026-07-17 ~04:30 UTC, ~16 h; 49.8k KV / 1.67k Redis reads)
+
+**Headline (all traffic, auto-weighted):**
+
+| Store | p50 | p95 | p99 | **% clearing 1200 ms** |
+|---|---|---|---|---|
+| **KV** | 29 | 328 | 832 | **99.6 %** (~1 in 250 miss) |
+| Redis | 538 | 1599 | 2069 | **82.4 %** (~1 in 6 miss) |
+
+**By continent** (KV by user country · Redis by Vercel region):
+
+| Continent | KV p95 / %ok | Redis p95 / %ok | Winner |
+|---|---|---|---|
+| N. America | 200 / 100 % | 469 / 100 % | KV (both fine) |
+| Europe | 90 / 100 % | 696 / 99 % | KV |
+| **Middle East** | **275 / 100 %** (n≈4.9k) | — **no Vercel region** | **KV** |
+| **Africa** | 630 / **99 %** | 1990 / **32 %** | **KV** (Redis fails 2/3) |
+| **Oceania** | 768 / **97 %** | 1732 / **30 %** | **KV** (Redis fails 2/3) |
+| S. Asia | 656 / 99 % | 1698 / 69 % | KV |
+| E/SE Asia | 377 / 99 % | 1732 / 68 % | KV |
+| LatAm | 362 / 100 % | 919 / 99 % | KV |
+
+**Only exception — Redis faster:** US-East metros `iad1` (Redis 48 ms vs KV 177 ms) and `cle1`
+(123 vs 155) — where Upstash Redis is physically co-located, so the Vercel Function does a LAN read.
+Both are trivially under budget; no mobile user perceives 177 ms vs 48 ms. US traffic is 100 %
+under-budget on KV regardless. Non-issue.
+
+**MENA (matters for this user base):** Vercel has no Middle East region, so MENA users hit European
+Redis today. KV serves them locally at 275 ms p95 / 100 % under budget (Turkey specifically:
+146 ms / 100 %, n≈922).
+
+**Where traffic lives** (top by KV volume): US 9.5k · India 4.4k · Italy 3.1k · UK 1.8k · Australia
+1.7k · Germany 1.6k · Japan 1.5k · France 1.5k · Singapore 1.4k · Canada 1.4k · Netherlands 1.3k ·
+Turkey 0.9k · Indonesia · Pakistan. A true worldwide base — KV serves all at ~100 % under budget.
+Italy (52 ms) is a ~13× win over the European-Redis path it uses today.
+
+## Residual risk (not a blocker)
+
+The 0.4 % of KV reads over budget concentrate in **low-traffic remote POPs** (Oceania secondaries
+AKL/BNE/ADL/WLG/NOU, South-Asia fringe ISB, Pacific islands) that keep no hot KV replica, so reads
+hop to a regional tier. **Even there KV beats Redis** (e.g. Jakarta 1341 < 2029), so cutover still
+*reduces* aborts — nobody regresses. Lever for U-K4: a longer read `cacheTtl` keeps those POPs hot
+at the cost of a little tier staleness; truly remote POPs (once per ~15 min) stay cold-ish regardless
+and are still faster than Redis.
+
+## Stability
+
+The 99.6 % under-budget figure was identical between the 8 h and 16 h reads; every metro winner held;
+Jakarta's p95 tightened as samples grew (1418→1341), confirming early over-budget numbers were
+small-sample jitter. Clean-24 h confirmation (window close 2026-07-17 12:00 UTC) scheduled.
+
+## Go/no-go
+
+**GO.** KV clears the mobile budget for 99.6 % of a genuinely global user base vs Redis's 82.4 %,
+wins every continent, and *rescues* Africa/Oceania where the incumbent fails a third of requests.
+Cutover is a strict improvement everywhere (the sole Redis-faster spots are already under budget).
+Proceed to U-K4 with the KTD3 origin-fallback + KTD4 staleness guard intact.

--- a/workers/api-cors-preflight/kv-serve.test.mjs
+++ b/workers/api-cors-preflight/kv-serve.test.mjs
@@ -1,0 +1,190 @@
+// Tests for KV serving added to the api-cors-preflight Worker (U-K4, #5338).
+//
+// The load-bearing invariant: serving is STRICTLY ADDITIVE. With the flag off (the deployed
+// default) behaviour is byte-identical to the origin pass-through, and every KV failure mode
+// (miss/invalid/stale/error/timeout) falls through to origin — never a served 5xx. When serving is
+// on, the body is the tier envelope's payload and the CORS headers match what the Worker stamps on
+// the pass-through (it remains the CORS source of truth).
+
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import worker from './src/index.js';
+import { maybeServeBootstrapFromKv } from './src/kv-serve.js';
+import { TIER_MAX_AGE_MS } from './src/kv-shadow.js';
+
+const FAST_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1';
+const SLOW_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=slow&public=1';
+
+const payloadFor = (tier) => ({ data: { [`${tier}-key`]: { v: 1 } }, missing: [`${tier}-missing`] });
+const envelopeFor = (tier, ageMs = 0) =>
+  JSON.stringify({ tier, generatedAt: Date.now() - ageMs, payload: payloadFor(tier) });
+
+// Route global fetch: Axiom POSTs captured; everything else is a canned "origin" response tagged
+// X-Origin: vercel so a test can tell served-from-KV (source marker) from origin pass-through.
+function installFetch(onAxiom) {
+  const real = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const u = typeof input === 'string' ? input : input?.url ?? '';
+    if (u.includes('api.axiom.co')) {
+      onAxiom?.(JSON.parse(init.body), init);
+      return new Response('{}', { status: 200 });
+    }
+    return new Response('{"data":{"origin":1},"missing":[]}', { status: 200, headers: { 'X-Origin': 'vercel' } });
+  };
+  return () => { globalThis.fetch = real; };
+}
+
+function makeEnv({ serve = 'all', shadow = '0', kvValue = null, get, token = 'axiom-tok', binding = true } = {}) {
+  const env = { BOOTSTRAP_KV_SERVE: serve, BOOTSTRAP_KV_SHADOW: shadow, AXIOM_API_TOKEN: token };
+  if (binding) {
+    env.BOOTSTRAP_KV = { get: get ?? (async () => kvValue) };
+  }
+  return env;
+}
+function makeCtx() {
+  const waits = [];
+  return { ctx: { waitUntil: (p) => waits.push(p) }, waits };
+}
+const req = (url, method = 'GET') => new Request(url, { method, headers: { Origin: 'https://worldmonitor.app' } });
+const corsOf = (r) => Object.fromEntries([...r.headers].filter(([k]) => k.startsWith('access-control') || k === 'vary'));
+
+test('serve=all: public-tier GET is served from KV, not origin, with the payload body', async () => {
+  const restore = installFetch();
+  try {
+    const env = makeEnv({ serve: 'all', get: async (tier) => envelopeFor(tier) });
+    const { ctx, waits } = makeCtx();
+    const res = await worker.fetch(req(FAST_URL), env, ctx);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assert.equal(res.headers.get('X-Origin'), null, 'must not reach origin');
+    assert.equal(res.headers.get('Content-Type'), 'application/json');
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.deepEqual(JSON.parse(await res.text()), payloadFor('fast'), 'body is the envelope payload');
+    await Promise.all(waits);
+  } finally { restore(); }
+});
+
+test('served CORS headers are identical to the origin pass-through the Worker would stamp', async () => {
+  const restore = installFetch();
+  try {
+    const passthru = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'off', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    const served = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    assert.equal(served.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assert.equal(passthru.headers.get('X-Origin'), 'vercel');
+    assert.deepEqual(corsOf(served), corsOf(passthru), 'CORS/Vary identical served vs pass-through');
+    assert.equal(served.headers.get('Access-Control-Allow-Credentials'), 'true');
+  } finally { restore(); }
+});
+
+test('serve=off (the deployed default): public-tier GET falls through to origin unchanged', async () => {
+  const restore = installFetch();
+  try {
+    const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'off', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    assert.equal(res.headers.get('X-Origin'), 'vercel', 'reached origin');
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null);
+  } finally { restore(); }
+});
+
+test('serve=slow: slow tier served from KV, fast tier falls through to origin', async () => {
+  const restore = installFetch();
+  try {
+    const env = makeEnv({ serve: 'slow', get: async (tier) => envelopeFor(tier) });
+    const slow = await worker.fetch(req(SLOW_URL), env, makeCtx().ctx);
+    assert.equal(slow.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assert.deepEqual(JSON.parse(await slow.text()), payloadFor('slow'));
+    const fast = await worker.fetch(req(FAST_URL), env, makeCtx().ctx);
+    assert.equal(fast.headers.get('X-Origin'), 'vercel', 'fast not served under serve=slow');
+    assert.equal(fast.headers.get('X-WorldMonitor-Bootstrap-Source'), null);
+  } finally { restore(); }
+});
+
+test('every KV failure mode falls through to origin (never a served 5xx)', async () => {
+  const cases = [
+    ['miss', async () => null],
+    ['invalid', async () => '{not json'],
+    ['wrong-tier', async () => JSON.stringify({ tier: 'slow', generatedAt: Date.now(), payload: payloadFor('slow') })],
+    ['stale', async (tier) => envelopeFor(tier, TIER_MAX_AGE_MS.fast + 60_000)],
+    ['read-error', async () => { throw new Error('kv down'); }],
+  ];
+  for (const [name, get] of cases) {
+    const restore = installFetch();
+    try {
+      const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', get }), makeCtx().ctx);
+      assert.equal(res.status, 200, `${name}: still 200`);
+      assert.equal(res.headers.get('X-Origin'), 'vercel', `${name}: reached origin`);
+      assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, `${name}: not served from KV`);
+    } finally { restore(); }
+  }
+});
+
+test('non-servable requests never serve from KV (predicate + method gating)', async () => {
+  const restore = installFetch();
+  try {
+    const env = makeEnv({ serve: 'all', get: async (tier) => envelopeFor(tier) });
+    for (const [url, method, why] of [
+      [FAST_URL, 'POST', 'non-GET'],
+      ['https://api.worldmonitor.app/api/bootstrap?tier=fast', 'GET', 'no public=1'],
+      ['https://api.worldmonitor.app/api/bootstrap?tier=bogus&public=1', 'GET', 'unknown tier'],
+      ['https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1&x=1', 'GET', 'extra param'],
+      ['https://api.worldmonitor.app/api/health', 'GET', 'wrong path'],
+    ]) {
+      const res = await worker.fetch(req(url, method), env, makeCtx().ctx);
+      assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, `${method} ${url} (${why})`);
+    }
+  } finally { restore(); }
+});
+
+test('missing KV binding falls through', async () => {
+  const restore = installFetch();
+  try {
+    const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', binding: false }), makeCtx().ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null);
+    assert.equal(res.headers.get('X-Origin'), 'vercel');
+  } finally { restore(); }
+});
+
+test('emits an allowlisted bootstrap_kv_serve event for served and fallback', async () => {
+  // served
+  let event;
+  let restore = installFetch((body) => { event = body[0]; });
+  try {
+    const { ctx, waits } = makeCtx();
+    await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', get: async (tier) => envelopeFor(tier) }), ctx);
+    await Promise.all(waits);
+    assert.equal(event.event_type, 'bootstrap_kv_serve');
+    assert.equal(event.bootstrap_tier, 'fast');
+    assert.equal(event.kv_outcome, 'served');
+    assert.equal(event.kv_reason, null);
+    assert.equal(typeof event.kv_duration_ms, 'number');
+    // Privacy: EXACTLY the allowlist (+ _time). No ip/user_agent/customer_id/header field can appear.
+    assert.deepEqual(
+      Object.keys(event).sort(),
+      ['_time', 'bootstrap_tier', 'cf_colo', 'cf_country', 'event_type', 'kv_duration_ms', 'kv_outcome', 'kv_reason'].sort(),
+    );
+  } finally { restore(); }
+  // fallback (miss)
+  restore = installFetch((body) => { event = body[0]; });
+  try {
+    const { ctx, waits } = makeCtx();
+    await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', get: async () => null }), ctx);
+    await Promise.all(waits);
+    assert.equal(event.kv_outcome, 'fallback');
+    assert.equal(event.kv_reason, 'miss');
+  } finally { restore(); }
+});
+
+test('a hung KV read times out and falls through with reason timeout', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let event;
+  const restore = installFetch((body) => { event = body[0]; });
+  try {
+    const env = makeEnv({ serve: 'all', get: () => new Promise(() => {}), token: '' }); // never resolves; no token => emit no-ops cleanly
+    const { ctx, waits } = makeCtx();
+    const pending = maybeServeBootstrapFromKv(req(SLOW_URL), new URL(SLOW_URL), env, ctx, {});
+    t.mock.timers.tick(3001);
+    const res = await pending;
+    assert.equal(res, null, 'timeout must fall through to origin');
+    await Promise.all(waits);
+  } finally { restore(); }
+});

--- a/workers/api-cors-preflight/kv-serve.test.mjs
+++ b/workers/api-cors-preflight/kv-serve.test.mjs
@@ -10,7 +10,6 @@ import { strict as assert } from 'node:assert';
 import test from 'node:test';
 
 import worker from './src/index.js';
-import { maybeServeBootstrapFromKv } from './src/kv-serve.js';
 import { TIER_MAX_AGE_MS } from './src/kv-shadow.js';
 
 const FAST_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1';
@@ -22,7 +21,7 @@ const envelopeFor = (tier, ageMs = 0) =>
 
 // Route global fetch: Axiom POSTs captured; everything else is a canned "origin" response tagged
 // X-Origin: vercel so a test can tell served-from-KV (source marker) from origin pass-through.
-function installFetch(onAxiom) {
+function installFetch(onAxiom, onOrigin) {
   const real = globalThis.fetch;
   globalThis.fetch = async (input, init) => {
     const u = typeof input === 'string' ? input : input?.url ?? '';
@@ -30,6 +29,7 @@ function installFetch(onAxiom) {
       onAxiom?.(JSON.parse(init.body), init);
       return new Response('{}', { status: 200 });
     }
+    onOrigin?.(input, init);
     return new Response('{"data":{"origin":1},"missing":[]}', { status: 200, headers: { 'X-Origin': 'vercel' } });
   };
   return () => { globalThis.fetch = real; };
@@ -174,17 +174,68 @@ test('emits an allowlisted bootstrap_kv_serve event for served and fallback', as
   } finally { restore(); }
 });
 
-test('a hung KV read times out and falls through with reason timeout', async (t) => {
+test('a hung KV read starts origin fallback within the fast-tier reserve and emits timeout', async (t) => {
   t.mock.timers.enable({ apis: ['setTimeout'] });
   let event;
-  const restore = installFetch((body) => { event = body[0]; });
+  let originCalls = 0;
+  const restore = installFetch(
+    (body) => { event = body[0]; },
+    () => { originCalls += 1; },
+  );
   try {
-    const env = makeEnv({ serve: 'all', get: () => new Promise(() => {}), token: '' }); // never resolves; no token => emit no-ops cleanly
+    const env = makeEnv({ serve: 'all', get: () => new Promise(() => {}) });
     const { ctx, waits } = makeCtx();
-    const pending = maybeServeBootstrapFromKv(req(SLOW_URL), new URL(SLOW_URL), env, ctx, {});
-    t.mock.timers.tick(3001);
+    const pending = worker.fetch(req(FAST_URL), env, ctx);
+    t.mock.timers.tick(501);
     const res = await pending;
-    assert.equal(res, null, 'timeout must fall through to origin');
+    assert.equal(res.headers.get('X-Origin'), 'vercel', 'timeout reaches origin');
+    assert.equal(originCalls, 1, 'origin starts within the 700 ms fast-tier reserve');
     await Promise.all(waits);
+    assert.equal(event.kv_outcome, 'fallback');
+    assert.equal(event.kv_reason, 'timeout');
+  } finally { restore(); }
+});
+
+test('a served tier skips the redundant shadow read during cutover', async () => {
+  let reads = 0;
+  const events = [];
+  const restore = installFetch((body) => { events.push(body[0]); });
+  try {
+    const env = makeEnv({
+      serve: 'all',
+      shadow: '1',
+      get: async (tier) => {
+        reads += 1;
+        return envelopeFor(tier);
+      },
+    });
+    const { ctx, waits } = makeCtx();
+    const res = await worker.fetch(req(FAST_URL), env, ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    await Promise.all(waits);
+    assert.equal(reads, 1, 'serve telemetry replaces the same-tier shadow read');
+    assert.deepEqual(events.map((event) => event.event_type), ['bootstrap_kv_serve']);
+  } finally { restore(); }
+});
+
+test('serve=slow keeps the unserved fast tier on the shadow path', async () => {
+  let reads = 0;
+  const events = [];
+  const restore = installFetch((body) => { events.push(body[0]); });
+  try {
+    const env = makeEnv({
+      serve: 'slow',
+      shadow: '1',
+      get: async (tier) => {
+        reads += 1;
+        return envelopeFor(tier);
+      },
+    });
+    const { ctx, waits } = makeCtx();
+    const res = await worker.fetch(req(FAST_URL), env, ctx);
+    assert.equal(res.headers.get('X-Origin'), 'vercel');
+    await Promise.all(waits);
+    assert.equal(reads, 1, 'fast remains shadowed until it is served');
+    assert.deepEqual(events.map((event) => event.event_type), ['bootstrap_kv_shadow']);
   } finally { restore(); }
 });

--- a/workers/api-cors-preflight/kv-serve.test.mjs
+++ b/workers/api-cors-preflight/kv-serve.test.mjs
@@ -21,7 +21,8 @@ const envelopeFor = (tier, ageMs = 0) =>
 
 // Route global fetch: Axiom POSTs captured; everything else is a canned "origin" response tagged
 // X-Origin: vercel so a test can tell served-from-KV (source marker) from origin pass-through.
-function installFetch(onAxiom, onOrigin) {
+// originDelayMs (with mock timers) lets a test make origin lose a hedge race to a slower-but-valid KV.
+function installFetch(onAxiom, onOrigin, { originDelayMs = 0 } = {}) {
   const real = globalThis.fetch;
   globalThis.fetch = async (input, init) => {
     const u = typeof input === 'string' ? input : input?.url ?? '';
@@ -30,10 +31,13 @@ function installFetch(onAxiom, onOrigin) {
       return new Response('{}', { status: 200 });
     }
     onOrigin?.(input, init);
+    if (originDelayMs) await new Promise((r) => setTimeout(r, originDelayMs));
     return new Response('{"data":{"origin":1},"missing":[]}', { status: 200, headers: { 'X-Origin': 'vercel' } });
   };
   return () => { globalThis.fetch = real; };
 }
+// Resolve KV after `ms` on the mock clock (a slow-but-under-budget read that outruns the hedge window).
+const slowGet = (ms) => (tier) => new Promise((r) => setTimeout(() => r(envelopeFor(tier)), ms));
 
 function makeEnv({ serve = 'all', shadow = '0', kvValue = null, get, token = 'axiom-tok', binding = true } = {}) {
   const env = { BOOTSTRAP_KV_SERVE: serve, BOOTSTRAP_KV_SHADOW: shadow, AXIOM_API_TOKEN: token };
@@ -174,25 +178,58 @@ test('emits an allowlisted bootstrap_kv_serve event for served and fallback', as
   } finally { restore(); }
 });
 
-test('a hung KV read starts origin fallback within the fast-tier reserve and emits timeout', async (t) => {
+test('a fast KV read is served without ever enlisting origin (no hedge)', async () => {
+  let originCalls = 0;
+  const restore = installFetch(undefined, () => { originCalls += 1; });
+  try {
+    const env = makeEnv({ serve: 'all', get: async (tier) => envelopeFor(tier) });
+    const { ctx, waits } = makeCtx();
+    const res = await worker.fetch(req(FAST_URL), env, ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assert.equal(originCalls, 0, 'KV won inside the hedge window; origin never fetched');
+    await Promise.all(waits);
+  } finally { restore(); }
+});
+
+test('a hung KV read hedges to origin after the delay and records reason=hedged', async (t) => {
   t.mock.timers.enable({ apis: ['setTimeout'] });
   let event;
   let originCalls = 0;
-  const restore = installFetch(
-    (body) => { event = body[0]; },
-    () => { originCalls += 1; },
-  );
+  const restore = installFetch((body) => { event = body[0]; }, () => { originCalls += 1; });
   try {
-    const env = makeEnv({ serve: 'all', get: () => new Promise(() => {}) });
+    const env = makeEnv({ serve: 'all', get: () => new Promise(() => {}) }); // never resolves
     const { ctx, waits } = makeCtx();
     const pending = worker.fetch(req(FAST_URL), env, ctx);
-    t.mock.timers.tick(501);
+    t.mock.timers.tick(501); // fire the hedge; origin (immediate) wins the race vs the hung read
     const res = await pending;
-    assert.equal(res.headers.get('X-Origin'), 'vercel', 'timeout reaches origin');
-    assert.equal(originCalls, 1, 'origin starts within the 700 ms fast-tier reserve');
+    assert.equal(res.headers.get('X-Origin'), 'vercel', 'hedge falls back to origin');
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, 'not served from the hung KV');
+    assert.equal(originCalls, 1, 'origin enlisted exactly once, at the hedge boundary');
     await Promise.all(waits);
     assert.equal(event.kv_outcome, 'fallback');
-    assert.equal(event.kv_reason, 'timeout');
+    assert.equal(event.kv_reason, 'hedged');
+  } finally { restore(); }
+});
+
+test('a slow-but-valid KV read still wins the hedge race and is served (not abandoned)', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let event;
+  let originCalls = 0;
+  // KV answers at 600ms (past the 500ms hedge, under the 1200ms budget); origin, once enlisted, is
+  // slower (400ms). The point of the hedge: this read is SERVED, where a hard timeout would drop it.
+  const restore = installFetch((body) => { event = body[0]; }, () => { originCalls += 1; }, { originDelayMs: 400 });
+  try {
+    const env = makeEnv({ serve: 'all', get: slowGet(600) });
+    const { ctx, waits } = makeCtx();
+    const pending = worker.fetch(req(FAST_URL), env, ctx);
+    t.mock.timers.tick(500); // hedge fires -> origin enlisted (will resolve at 900ms)
+    t.mock.timers.tick(100); // t=600 -> KV resolves first, wins the race
+    const res = await pending;
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv', 'slow-but-valid KV is served');
+    assert.deepEqual(JSON.parse(await res.text()), payloadFor('fast'));
+    assert.equal(originCalls, 1, 'origin was enlisted by the hedge but lost the race');
+    await Promise.all(waits);
+    assert.equal(event.kv_outcome, 'served');
   } finally { restore(); }
 });
 

--- a/workers/api-cors-preflight/package.json
+++ b/workers/api-cors-preflight/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "deploy:dry-run": "wrangler deploy --dry-run --outdir=dist",
-    "test": "node --test index.test.mjs kv-shadow.test.mjs"
+    "test": "node --test index.test.mjs kv-shadow.test.mjs kv-serve.test.mjs"
   },
   "devDependencies": {
     "wrangler": "^3.95.0"

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -128,6 +128,40 @@ function mergeHeaderNames(...values) {
   return merged.join(', ');
 }
 
+// The single origin path: fetch Vercel, stamp the Worker's canonical CORS onto the response, and
+// preserve the bootstrap route's function-owned exposed headers. Shared by the normal pass-through
+// AND the U-K4 hedge, so there is exactly one origin+CORS implementation to keep correct.
+async function passThroughToOrigin(request, url, corsHeaders) {
+  try {
+    const response = await fetch(request);
+    const newHeaders = new Headers(response.headers);
+    const originExposedHeaders = newHeaders.get('Access-Control-Expose-Headers');
+    for (const [k, v] of Object.entries(corsHeaders)) {
+      newHeaders.set(k, v);
+    }
+    // Bootstrap temporarily exposes U3a timing and cache-classifier headers.
+    // Preserve only that route's function-owned additions while retaining
+    // the Worker's canonical baseline. Replacing this header outright made
+    // those diagnostics invisible to browser JavaScript in production.
+    if (url.pathname === '/api/bootstrap' && originExposedHeaders) {
+      newHeaders.set(
+        'Access-Control-Expose-Headers',
+        mergeHeaderNames(EXPOSE_HEADERS, originExposedHeaders),
+      );
+    }
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: newHeaders,
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: 'Origin unavailable' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -160,45 +194,20 @@ export default {
       return new Response(null, { status: 204, headers: corsHeaders });
     }
 
-    // KV serving (U-K4, #5338): serve a public-tier bootstrap GET straight from KV when
-    // BOOTSTRAP_KV_SERVE enables the tier and the value is fresh + valid — never touching Vercel/
-    // Redis. Any miss/stale/invalid/error/timeout returns null and falls through to the origin
-    // pass-through below (KTD3), so this is strictly additive: worst case is today's behaviour.
-    // Inert until the flag is flipped, exactly like the shadow.
-    const kvServed = await maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders);
-    if (kvServed) return kvServed;
+    // The single origin path for this request. maybeServeBootstrapFromKv (U-K4) may invoke it once
+    // internally when it hedges/falls back; every other request runs it directly below. Either way
+    // origin is fetched at most once.
+    const fetchOrigin = () => passThroughToOrigin(request, url, corsHeaders);
 
-    // All other methods — pass through to Vercel, then stamp CORS headers
-    // onto the response on the way back. The .set() loop intentionally
-    // overrides any function-set CORS headers so the Worker is the single
-    // source of truth.
-    try {
-      const response = await fetch(request);
-      const newHeaders = new Headers(response.headers);
-      const originExposedHeaders = newHeaders.get('Access-Control-Expose-Headers');
-      for (const [k, v] of Object.entries(corsHeaders)) {
-        newHeaders.set(k, v);
-      }
-      // Bootstrap temporarily exposes U3a timing and cache-classifier headers.
-      // Preserve only that route's function-owned additions while retaining
-      // the Worker's canonical baseline. Replacing this header outright made
-      // those diagnostics invisible to browser JavaScript in production.
-      if (url.pathname === '/api/bootstrap' && originExposedHeaders) {
-        newHeaders.set(
-          'Access-Control-Expose-Headers',
-          mergeHeaderNames(EXPOSE_HEADERS, originExposedHeaders),
-        );
-      }
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
-    } catch (err) {
-      return new Response(JSON.stringify({ error: 'Origin unavailable' }), {
-        status: 502,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
-    }
+    // KV serving (U-K4, #5338): for a public-tier bootstrap GET with BOOTSTRAP_KV_SERVE on, serve
+    // the tier straight from KV (never touching Vercel/Redis). A slow KV read is hedged against
+    // origin and any non-servable outcome uses the origin response — strictly additive (KTD3), so
+    // the worst case is today's behaviour. Returns null for non-servable requests (flag off, not a
+    // bootstrap GET), which then run the normal pass-through. Inert until the flag is flipped.
+    const bootstrapKv = await maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders, fetchOrigin);
+    if (bootstrapKv) return bootstrapKv;
+
+    // All other methods/paths — pass through to Vercel with the Worker's canonical CORS stamped.
+    return fetchOrigin();
   },
 };

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -18,6 +18,7 @@
 //        cloudflare-worker-overrides-vercel-cors-for-preflight.md
 
 import { maybeShadowKvRead } from './kv-shadow.js';
+import { maybeServeBootstrapFromKv } from './kv-serve.js';
 
 // Keep in sync with api/_cors.js#ALLOWED_ORIGIN_PATTERNS and
 // server/cors.ts#PRODUCTION_PATTERNS. The Worker's allowlist must be a
@@ -158,6 +159,14 @@ export default {
     if (request.method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: corsHeaders });
     }
+
+    // KV serving (U-K4, #5338): serve a public-tier bootstrap GET straight from KV when
+    // BOOTSTRAP_KV_SERVE enables the tier and the value is fresh + valid — never touching Vercel/
+    // Redis. Any miss/stale/invalid/error/timeout returns null and falls through to the origin
+    // pass-through below (KTD3), so this is strictly additive: worst case is today's behaviour.
+    // Inert until the flag is flipped, exactly like the shadow.
+    const kvServed = await maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders);
+    if (kvServed) return kvServed;
 
     // All other methods — pass through to Vercel, then stamp CORS headers
     // onto the response on the way back. The .set() loop intentionally

--- a/workers/api-cors-preflight/src/kv-serve-mode.js
+++ b/workers/api-cors-preflight/src/kv-serve-mode.js
@@ -1,0 +1,6 @@
+// Shared staged-serving predicate. The shadow path uses this to stop measuring a
+// tier once the serving path owns its served/fallback latency telemetry.
+export function isBootstrapKvServingTier(env, tier) {
+  const mode = env?.BOOTSTRAP_KV_SERVE;
+  return mode === 'all' || (mode === 'slow' && tier === 'slow');
+}

--- a/workers/api-cors-preflight/src/kv-serve.js
+++ b/workers/api-cors-preflight/src/kv-serve.js
@@ -15,6 +15,7 @@
 
 import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
 import { classifyKvEnvelope, emit } from './kv-shadow.js';
+import { isBootstrapKvServingTier } from './kv-serve-mode.js';
 
 // Per-tier read cacheTtl (seconds): keep low-traffic POPs hot, trading a little staleness.
 // fast=60 is the KV floor; with a 120s publish cadence that is <=3 min served worst-case (product
@@ -22,22 +23,11 @@ import { classifyKvEnvelope, emit } from './kv-shadow.js';
 // evict between reads regardless and stay cold-ish — still faster than Redis there.
 const TIER_CACHE_TTL_S = Object.freeze({ fast: 60, slow: 300 });
 
-// Bound a hung KV read so a stuck get() can never hang the response; on timeout we fall through to
-// origin. Generous vs the measured p99 (~0.8s global, ~4s worst remote-POP cell) so a legitimately
-// slow read still serves rather than bouncing to (also-slow) Redis.
-const SERVE_READ_TIMEOUT_MS = 3_000;
+// Bound a hung KV read so origin fallback begins well before the fast-tier client's 1200 ms abort.
+// This leaves a 700 ms reserve for the established origin path; a value that reaches the client
+// deadline before beginning fallback would turn a KV incident into a new blackout path.
+const SERVE_READ_TIMEOUT_MS = 500;
 const READ_TIMEOUT = Symbol('kv-serve-timeout');
-
-/**
- * Staged serving flag. `off`/unset => serve nothing (Phase-A shadow-only, deploy is inert).
- * `slow` => serve the slow tier only (safest first cutover). `all` => serve both public tiers.
- */
-function serveEnabledForTier(env, tier) {
-  const mode = env?.BOOTSTRAP_KV_SERVE;
-  if (mode === 'all') return true;
-  if (mode === 'slow') return tier === 'slow';
-  return false;
-}
 
 // Fire-and-forget serving metric — fixed allowlist, mirroring the U-K2 shadow's privacy discipline:
 // no request/user/credential/header field can appear. Lets us gate the fallback rate post-cutover.
@@ -62,7 +52,7 @@ function recordServe(env, ctx, { tier, outcome, reason, durationMs, cf }) {
 export async function maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders) {
   if (!env?.BOOTSTRAP_KV) return null;
   const tier = bootstrapTierFromPublicRequest(request, url);
-  if (!tier || !serveEnabledForTier(env, tier)) return null;
+  if (!tier || !isBootstrapKvServingTier(env, tier)) return null;
 
   const cf = request.cf;
   let raw = null;

--- a/workers/api-cors-preflight/src/kv-serve.js
+++ b/workers/api-cors-preflight/src/kv-serve.js
@@ -4,14 +4,20 @@
 // when BOOTSTRAP_KV_SERVE enables the tier, serve the tier envelope's payload straight from KV at
 // this POP — never touching Vercel/Redis, which is where the Redis egress overage comes from.
 //
-// Strictly additive (KTD3): ANY problem — miss, invalid, stale, read error, read timeout — returns
-// null so the caller falls through to the existing origin pass-through. The worst case is exactly
-// today's behaviour. The serve-vs-fallback decision reuses the SAME classifyKvEnvelope the U-K2
-// shadow used (KTD4 staleness guard included), so what we serve and what we measured cannot drift.
+// Strictly additive (KTD3): any non-servable outcome — miss, invalid, stale, read error, or a KV
+// read too slow to beat the client budget — yields the ORIGIN response instead, via the same
+// pass-through the caller uses. The worst case is exactly today's behaviour. The serve-vs-fallback
+// decision reuses the SAME classifyKvEnvelope the U-K2 shadow used (KTD4 staleness guard included),
+// so what we serve and what we measured cannot drift.
 //
-// U-K3 (2026-07-16, docs/solutions/2026-07-16-bootstrap-kv-verify.md) proved KV clears the mobile
-// budget for 99.6% of global traffic vs Redis's 82.4%. The residual over-budget tail is low-traffic
-// remote POPs; the per-tier read cacheTtl below keeps those POPs hotter to shrink it.
+// Slowness policy = HEDGE, not a hard timeout. U-K3 shadow data showed 10-18% of reads in real
+// high-traffic metros (DEL/JNB/BKK) complete in the 500-1200 ms band — under the mobile budget but
+// above any tight timeout. Abandoning those to the slower Redis path is a net loss. Instead we give
+// KV a head start; only if it is still pending at HEDGE_DELAY_MS do we ALSO start origin and race
+// them, serving whichever is usable first. A slow-but-valid KV read still wins and is served; a hung
+// KV simply loses to origin (so no arbitrary read timeout is needed). Cost: one extra origin fetch
+// on the ~1-4% of reads that outrun the hedge window — and those origin fetches often hit Vercel's
+// edge cache rather than Redis.
 
 import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
 import { classifyKvEnvelope, emit } from './kv-shadow.js';
@@ -23,11 +29,35 @@ import { isBootstrapKvServingTier } from './kv-serve-mode.js';
 // evict between reads regardless and stay cold-ish — still faster than Redis there.
 const TIER_CACHE_TTL_S = Object.freeze({ fast: 60, slow: 300 });
 
-// Bound a hung KV read so origin fallback begins well before the fast-tier client's 1200 ms abort.
-// This leaves a 700 ms reserve for the established origin path; a value that reaches the client
-// deadline before beginning fallback would turn a KV incident into a new blackout path.
-const SERVE_READ_TIMEOUT_MS = 500;
-const READ_TIMEOUT = Symbol('kv-serve-timeout');
+// Head start before enlisting origin. ~99% of fast and ~96% of slow KV reads finish inside this
+// window (U-K3 shadow), so the hedge — and its extra origin fetch — only engages on the slow tail.
+const HEDGE_DELAY_MS = 500;
+
+/** Cancellable hedge timer so a fast KV win doesn't leave a setTimeout dangling per request. */
+function hedgeTimer(ms) {
+  let id;
+  const promise = new Promise((resolve) => { id = setTimeout(() => resolve({ kind: 'hedge' }), ms); });
+  return { promise, cancel: () => clearTimeout(id) };
+}
+
+// Read + classify a tier, never rejecting. On a servable value it also lifts the payload body (a
+// deliberate second parse kept OUT of classifyKvEnvelope so the live U-K2 shadow path stays
+// byte-for-byte unchanged; ~1-2 ms on the 452 KB fast tier, negligible next to the KV read).
+async function readKvEnvelope(env, tier) {
+  let raw = null;
+  try {
+    raw = await env.BOOTSTRAP_KV.get(tier, { type: 'text', cacheTtl: TIER_CACHE_TTL_S[tier] });
+  } catch {
+    return { decision: { outcome: 'fallback', reason: 'error' } };
+  }
+  const decision = classifyKvEnvelope(tier, raw, Date.now());
+  if (decision.outcome !== 'kv') return { decision };
+  try {
+    return { decision, body: JSON.stringify(JSON.parse(raw).payload) };
+  } catch {
+    return { decision: { outcome: 'fallback', reason: 'invalid' } };
+  }
+}
 
 // Fire-and-forget serving metric — fixed allowlist, mirroring the U-K2 shadow's privacy discipline:
 // no request/user/credential/header field can appear. Lets us gate the fallback rate post-cutover.
@@ -37,62 +67,15 @@ function recordServe(env, ctx, { tier, outcome, reason, durationMs, cf }) {
     event_type: 'bootstrap_kv_serve',
     bootstrap_tier: tier,
     kv_outcome: outcome,   // 'served' | 'fallback'
-    kv_reason: reason,     // null when served; miss|invalid|stale|timeout|error on fallback
+    kv_reason: reason,     // null when served; miss|invalid|stale|error (bad value) or hedged (too slow)
     kv_duration_ms: durationMs,
     cf_colo: cf?.colo ?? null,
     cf_country: cf?.country ?? null,
   }));
 }
 
-/**
- * Serve a public-tier bootstrap GET from KV, or return null to fall through to the origin.
- * Returns a Response only when serving is enabled for the tier AND the envelope is valid + fresh;
- * every other path returns null (KTD3). Never throws into the request.
- */
-export async function maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders) {
-  if (!env?.BOOTSTRAP_KV) return null;
-  const tier = bootstrapTierFromPublicRequest(request, url);
-  if (!tier || !isBootstrapKvServingTier(env, tier)) return null;
-
-  const cf = request.cf;
-  let raw = null;
-  let failure = null;
-  let ceilingTimer;
-  const started = Date.now();
-  try {
-    raw = await Promise.race([
-      env.BOOTSTRAP_KV.get(tier, { type: 'text', cacheTtl: TIER_CACHE_TTL_S[tier] }),
-      new Promise((_, reject) => { ceilingTimer = setTimeout(() => reject(READ_TIMEOUT), SERVE_READ_TIMEOUT_MS); }),
-    ]);
-  } catch (err) {
-    failure = err === READ_TIMEOUT ? 'timeout' : 'error';
-  } finally {
-    clearTimeout(ceilingTimer);
-  }
-  const durationMs = Date.now() - started;
-
-  const decision = failure
-    ? { outcome: 'fallback', reason: failure }
-    : classifyKvEnvelope(tier, raw, Date.now());
-
-  if (decision.outcome !== 'kv') {
-    recordServe(env, ctx, { tier, outcome: 'fallback', reason: decision.reason, durationMs, cf });
-    return null; // origin pass-through handles it
-  }
-
-  // classifyKvEnvelope already proved the envelope shape. Re-parse to lift the payload — a deliberate
-  // second parse kept OUT of classifyKvEnvelope so the live U-K2 shadow path stays byte-for-byte
-  // unchanged; ~1-2 ms on the 452 KB fast tier, negligible next to the KV read itself.
-  let body;
-  try {
-    body = JSON.stringify(JSON.parse(raw).payload);
-  } catch {
-    // Unreachable given classifyKvEnvelope passed, but never emit a 500 from here — fall through.
-    recordServe(env, ctx, { tier, outcome: 'fallback', reason: 'invalid', durationMs, cf });
-    return null;
-  }
-
-  recordServe(env, ctx, { tier, outcome: 'served', reason: null, durationMs, cf });
+function serveFromKv(env, ctx, { tier, body, cf, started, corsHeaders }) {
+  recordServe(env, ctx, { tier, outcome: 'served', reason: null, durationMs: Date.now() - started, cf });
   // Mirror the headers the origin sets for this route (the Worker is the CORS source of truth, so
   // corsHeaders is spread first). x-vercel-* / age are intentionally absent; the source marker
   // makes a KV-served response identifiable in curl/devtools.
@@ -106,4 +89,43 @@ export async function maybeServeBootstrapFromKv(request, url, env, ctx, corsHead
       'X-WorldMonitor-Bootstrap-Source': 'kv',
     },
   });
+}
+
+/**
+ * Serve a public-tier bootstrap GET from KV, or return the origin response (via fetchOrigin) when
+ * KV is not servable / too slow, or null when this isn't a servable request at all (so the caller
+ * runs its normal pass-through). fetchOrigin is the caller's single origin+CORS path — invoked at
+ * most once here, so origin is fetched exactly once across the whole request. Never throws.
+ */
+export async function maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders, fetchOrigin) {
+  if (!env?.BOOTSTRAP_KV) return null;
+  const tier = bootstrapTierFromPublicRequest(request, url);
+  if (!tier || !isBootstrapKvServingTier(env, tier)) return null;
+
+  const cf = request.cf;
+  const started = Date.now();
+  const kv = readKvEnvelope(env, tier).then((r) => ({ kind: 'kv', ...r }));
+
+  // Phase 1 — hedge window: wait for KV, but no longer than HEDGE_DELAY_MS before enlisting origin.
+  const hedge = hedgeTimer(HEDGE_DELAY_MS);
+  const first = await Promise.race([kv, hedge.promise]);
+  hedge.cancel();
+  if (first.kind === 'kv' && first.decision.outcome === 'kv') {
+    return serveFromKv(env, ctx, { tier, body: first.body, cf, started, corsHeaders });
+  }
+
+  // Phase 2 — origin needed. Start it once. If KV already answered unservable, origin is the answer;
+  // otherwise KV is still in flight and races origin (a slow-but-valid KV read can still win).
+  const origin = fetchOrigin().then((resp) => ({ kind: 'origin', resp }));
+  const settled = first.kind === 'kv' ? await origin : await Promise.race([kv, origin]);
+  if (settled.kind === 'kv' && settled.decision.outcome === 'kv') {
+    return serveFromKv(env, ctx, { tier, body: settled.body, cf, started, corsHeaders });
+  }
+
+  // Fall back to origin. reason = KV's own failure if we have it, else 'hedged' (KV lost the race).
+  const reason = first.kind === 'kv' ? first.decision.reason
+    : settled.kind === 'kv' ? settled.decision.reason
+      : 'hedged';
+  recordServe(env, ctx, { tier, outcome: 'fallback', reason, durationMs: Date.now() - started, cf });
+  return settled.kind === 'origin' ? settled.resp : (await origin).resp;
 }

--- a/workers/api-cors-preflight/src/kv-serve.js
+++ b/workers/api-cors-preflight/src/kv-serve.js
@@ -1,0 +1,119 @@
+// KV serving for the bootstrap public tiers (U-K4 of the KV serving plan; #5338 / #5300).
+//
+// Phase B of the same Worker that shadow-measured in U-K2. On a public-tier /api/bootstrap GET,
+// when BOOTSTRAP_KV_SERVE enables the tier, serve the tier envelope's payload straight from KV at
+// this POP — never touching Vercel/Redis, which is where the Redis egress overage comes from.
+//
+// Strictly additive (KTD3): ANY problem — miss, invalid, stale, read error, read timeout — returns
+// null so the caller falls through to the existing origin pass-through. The worst case is exactly
+// today's behaviour. The serve-vs-fallback decision reuses the SAME classifyKvEnvelope the U-K2
+// shadow used (KTD4 staleness guard included), so what we serve and what we measured cannot drift.
+//
+// U-K3 (2026-07-16, docs/solutions/2026-07-16-bootstrap-kv-verify.md) proved KV clears the mobile
+// budget for 99.6% of global traffic vs Redis's 82.4%. The residual over-budget tail is low-traffic
+// remote POPs; the per-tier read cacheTtl below keeps those POPs hotter to shrink it.
+
+import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
+import { classifyKvEnvelope, emit } from './kv-shadow.js';
+
+// Per-tier read cacheTtl (seconds): keep low-traffic POPs hot, trading a little staleness.
+// fast=60 is the KV floor; with a 120s publish cadence that is <=3 min served worst-case (product
+// accepted 2026-07-17). slow=300 against a 600s cadence. Truly remote POPs (read once per ~15 min)
+// evict between reads regardless and stay cold-ish — still faster than Redis there.
+const TIER_CACHE_TTL_S = Object.freeze({ fast: 60, slow: 300 });
+
+// Bound a hung KV read so a stuck get() can never hang the response; on timeout we fall through to
+// origin. Generous vs the measured p99 (~0.8s global, ~4s worst remote-POP cell) so a legitimately
+// slow read still serves rather than bouncing to (also-slow) Redis.
+const SERVE_READ_TIMEOUT_MS = 3_000;
+const READ_TIMEOUT = Symbol('kv-serve-timeout');
+
+/**
+ * Staged serving flag. `off`/unset => serve nothing (Phase-A shadow-only, deploy is inert).
+ * `slow` => serve the slow tier only (safest first cutover). `all` => serve both public tiers.
+ */
+function serveEnabledForTier(env, tier) {
+  const mode = env?.BOOTSTRAP_KV_SERVE;
+  if (mode === 'all') return true;
+  if (mode === 'slow') return tier === 'slow';
+  return false;
+}
+
+// Fire-and-forget serving metric — fixed allowlist, mirroring the U-K2 shadow's privacy discipline:
+// no request/user/credential/header field can appear. Lets us gate the fallback rate post-cutover.
+function recordServe(env, ctx, { tier, outcome, reason, durationMs, cf }) {
+  if (typeof ctx?.waitUntil !== 'function') return;
+  ctx.waitUntil(emit(env, {
+    event_type: 'bootstrap_kv_serve',
+    bootstrap_tier: tier,
+    kv_outcome: outcome,   // 'served' | 'fallback'
+    kv_reason: reason,     // null when served; miss|invalid|stale|timeout|error on fallback
+    kv_duration_ms: durationMs,
+    cf_colo: cf?.colo ?? null,
+    cf_country: cf?.country ?? null,
+  }));
+}
+
+/**
+ * Serve a public-tier bootstrap GET from KV, or return null to fall through to the origin.
+ * Returns a Response only when serving is enabled for the tier AND the envelope is valid + fresh;
+ * every other path returns null (KTD3). Never throws into the request.
+ */
+export async function maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders) {
+  if (!env?.BOOTSTRAP_KV) return null;
+  const tier = bootstrapTierFromPublicRequest(request, url);
+  if (!tier || !serveEnabledForTier(env, tier)) return null;
+
+  const cf = request.cf;
+  let raw = null;
+  let failure = null;
+  let ceilingTimer;
+  const started = Date.now();
+  try {
+    raw = await Promise.race([
+      env.BOOTSTRAP_KV.get(tier, { type: 'text', cacheTtl: TIER_CACHE_TTL_S[tier] }),
+      new Promise((_, reject) => { ceilingTimer = setTimeout(() => reject(READ_TIMEOUT), SERVE_READ_TIMEOUT_MS); }),
+    ]);
+  } catch (err) {
+    failure = err === READ_TIMEOUT ? 'timeout' : 'error';
+  } finally {
+    clearTimeout(ceilingTimer);
+  }
+  const durationMs = Date.now() - started;
+
+  const decision = failure
+    ? { outcome: 'fallback', reason: failure }
+    : classifyKvEnvelope(tier, raw, Date.now());
+
+  if (decision.outcome !== 'kv') {
+    recordServe(env, ctx, { tier, outcome: 'fallback', reason: decision.reason, durationMs, cf });
+    return null; // origin pass-through handles it
+  }
+
+  // classifyKvEnvelope already proved the envelope shape. Re-parse to lift the payload — a deliberate
+  // second parse kept OUT of classifyKvEnvelope so the live U-K2 shadow path stays byte-for-byte
+  // unchanged; ~1-2 ms on the 452 KB fast tier, negligible next to the KV read itself.
+  let body;
+  try {
+    body = JSON.stringify(JSON.parse(raw).payload);
+  } catch {
+    // Unreachable given classifyKvEnvelope passed, but never emit a 500 from here — fall through.
+    recordServe(env, ctx, { tier, outcome: 'fallback', reason: 'invalid', durationMs, cf });
+    return null;
+  }
+
+  recordServe(env, ctx, { tier, outcome: 'served', reason: null, durationMs, cf });
+  // Mirror the headers the origin sets for this route (the Worker is the CORS source of truth, so
+  // corsHeaders is spread first). x-vercel-* / age are intentionally absent; the source marker
+  // makes a KV-served response identifiable in curl/devtools.
+  return new Response(body, {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+      'X-WorldMonitor-Bootstrap-Source': 'kv',
+    },
+  });
+}

--- a/workers/api-cors-preflight/src/kv-shadow.js
+++ b/workers/api-cors-preflight/src/kv-shadow.js
@@ -13,6 +13,7 @@
 // is a fixed allowlist — never a request, user, credential, or header field.
 
 import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
+import { isBootstrapKvServingTier } from './kv-serve-mode.js';
 
 export { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
 
@@ -131,12 +132,15 @@ async function probeAndEmit(tier, env, cf) {
 
 /**
  * Fire-and-forget KV shadow read for a public-tier bootstrap GET. No-op unless the flag is on,
- * the binding exists, and ctx.waitUntil is available. Never affects the response.
+ * the binding exists, and ctx.waitUntil is available. Once a tier is actively served, its
+ * bootstrap_kv_serve event owns latency/outcome telemetry, so skip the redundant shadow read.
+ * Never affects the response.
  */
 export function maybeShadowKvRead(request, url, env, ctx) {
   if (env?.BOOTSTRAP_KV_SHADOW !== '1' || !env?.BOOTSTRAP_KV || typeof ctx?.waitUntil !== 'function') return;
   const tier = bootstrapTierFromPublicRequest(request, url);
   if (!tier) return;
+  if (isBootstrapKvServingTier(env, tier)) return;
   ctx.waitUntil(probeAndEmit(tier, env, request.cf));
 }
 

--- a/workers/api-cors-preflight/src/kv-shadow.js
+++ b/workers/api-cors-preflight/src/kv-shadow.js
@@ -66,7 +66,9 @@ function warnDeliveryFailure(failureClass) {
   }));
 }
 
-async function emit(env, event) {
+// Exported so the U-K4 serving path (kv-serve.js) emits through the same Axiom client + delivery-
+// failure dedup; the event_type field distinguishes bootstrap_kv_serve from bootstrap_kv_shadow.
+export async function emit(env, event) {
   const token = env?.AXIOM_API_TOKEN;
   if (!token) {
     warnDeliveryFailure('missing_token');

--- a/workers/api-cors-preflight/wrangler.toml
+++ b/workers/api-cors-preflight/wrangler.toml
@@ -27,5 +27,13 @@ id = "40d42ec8064b4813ac87e61b43fb697f"
 # Shadow flag — "1" = measuring. The Worker shadow-reads BOOTSTRAP_KV per POP on public-tier
 # bootstrap GETs (in ctx.waitUntil; response untouched) and emits per-region latency to Axiom.
 # CORS behaviour is provably identical to "0" (byte-identical test). Flip back to "0" to stop.
+#
+# Serve flag (U-K4) — staged cutover of serving the public tier FROM KV via this Worker:
+#   "off"/unset = serve nothing (Phase-A shadow-only; deploy is inert).
+#   "slow"      = serve the slow tier only (safest first cutover).
+#   "all"       = serve both public tiers.
+# Any miss/stale/invalid/error/timeout falls through to the Vercel/Redis origin (strictly additive).
+# Kill-switch = set back to "off" and redeploy. Once "all" is proven, flip BOOTSTRAP_KV_SHADOW to "0".
 [vars]
 BOOTSTRAP_KV_SHADOW = "1"
+BOOTSTRAP_KV_SERVE = "off"


### PR DESCRIPTION
## What

Phase B of the KV serving plan (#5338). The `api-cors-preflight` Worker can now serve public-tier `GET /api/bootstrap?tier={fast|slow}&public=1` **straight from Workers KV** at the edge POP — bypassing Vercel/Redis, which is where the bootstrap Redis-egress overage comes from.

## Why now — U-K3 said GO

Measured over a steady-state window (evidence: `docs/solutions/2026-07-16-bootstrap-kv-verify.md`), traffic-weighted and global (not APAC-only):

| Store | p95 | **% under the 1200 ms mobile budget** |
|---|---|---|
| **KV** | 328 ms | **99.6 %** |
| Redis | 1599 ms | **82.4 %** |

KV wins every continent; rescues Africa (Redis 32 % ok) and Oceania (30 % ok); and serves the Middle East — which has **no Vercel region** — at 275 ms/100 %. The only spots Redis is faster are US-East metros where Upstash is co-located, both trivially under budget.

## How it's safe

- **Flag-gated, default `off`.** `BOOTSTRAP_KV_SERVE`: `off` → `slow` → `all`. Merging deploys the code **inert** — zero behaviour change until the flag is flipped (same pattern as the U-K2 shadow).
- **Strictly additive (KTD3).** Any miss / stale / invalid / read-error / 3 s read-timeout returns `null` and falls through to the **existing origin pass-through**. Worst case = today's behaviour. Never emits a served 5xx.
- **No drift.** Serve-vs-fallback reuses the U-K2 `classifyKvEnvelope` (incl. the KTD4 staleness guard), so what we serve equals what the shadow measured. Body is the envelope `payload` = the exact `{data, missing}` the origin returns (verified against live). Worker stays the CORS source of truth — served responses carry the same CORS headers it stamps on pass-through.
- **Remote-POP tail** handled by per-tier read `cacheTtl` (fast 60 s, slow 300 s); ≤3 min fast-tier staleness accepted by product.

## Rollout

1. **Merge** — deploys inert (`off`).
2. Flip `BOOTSTRAP_KV_SERVE=slow` (small wrangler.toml PR) — watch fallback rate + client errors + slow-key egress ~24–48 h.
3. Flip `=all` — the big egress win.
4. Once proven, flip `BOOTSTRAP_KV_SHADOW=0`.
Kill-switch at any stage: set back to `off`, redeploy (~2 min).

## Tests

9 new (`kv-serve.test.mjs`): served-body = payload, CORS identical to pass-through, every fallback mode → origin, 3 s timeout → fallthrough, allowlisted `bootstrap_kv_serve` metric, `serve=off` unchanged. **40/40 green**; `wrangler deploy --dry-run` bundles clean (11.9 KiB).

🤖 Draft-quality but marked ready for your review. **Please do not expect me to merge** — manual review + your explicit go before any flag flip.