### PR TITLE
fix(sentry): suppress Clerk UI load failure and extension fetch-wrapper noise

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -320,6 +320,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /Response cannot have a body with the given status/, // Safari: Response constructor with 204/304 + body
       /ClerkJS: Network error/, // Clerk SDK transient network failures on user devices
       /^ClerkJS: Response: needs_(?:first|second)_factor\b/, // Clerk SDK auth-flow branch not yet supported; SDK-internal limitation, not our code — WORLDMONITOR-Q1. Narrow to the observed `needs_*_factor` family so future actionable `ClerkJS: Response: <something>` errors (e.g. misconfigured redirect URI) still surface.
+      /\[clerk\] failed to load/, // Clerk SDK failed to load its own UI chunk from clerk.worldmonitor.app — SDK-internal load failure, not our code (WORLDMONITOR-??: Yandex Browser 26.4).
       /doesn't provide an export named/, // stale cached chunk after deploy references removed export
       /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
       /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
@@ -544,7 +545,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // `injected/hook.js` wraps `window.fetch` and the leaked rejection frame
       // surfaces as `Object.apply`, not `window.fetch`.
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
-          && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:(?:window|Object)\.)?(?:fetch|apply)$/i.test(f.function ?? ''))) {
+          && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:(?:.*\.)?window\.|(?:window|Object)\.)?(?:fetch|apply)$/i.test(f.function ?? ''))) {
         return null;
       }
       // Bare `Failed to fetch` surfacing through the DebugBear RUM collector's

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -88,6 +88,24 @@ function extensionFrame(filename = 'blob:https://example.com/ext-1234', fn = 'in
   return { filename, lineno: 1, function: fn };
 }
 
+// ─── ignoreErrors message matches ────────────────────────────────────────
+
+describe('ignoreErrors filters', () => {
+  it('suppresses Clerk SDK UI chunk load failure', () => {
+    assert.ok(
+      isIgnored('[clerk] failed to load https://clerk.worldmonitor.app/npm/@clerk/ui@1/dist/ui.browser.js'),
+      'Clerk SDK load-failure message must be ignored',
+    );
+  });
+
+  it('does NOT suppress a generic "failed to load" error from our code', () => {
+    assert.ok(
+      !isIgnored('Failed to load dashboard config'),
+      'Generic first-party load-failure messages must NOT be ignored',
+    );
+  });
+});
+
 // ─── P2: firstPartyFile regex covers all Vite chunk patterns ─────────────
 
 describe('first-party file detection', () => {
@@ -554,6 +572,18 @@ describe('existing beforeSend filters', () => {
       { filename: 'chrome-extension://bkkbcggnhapdmkeljlodobbkopceiche/injectScriptAdjust.js', lineno: 1, function: 'doDefault' },
     ]);
     assert.equal(beforeSend(event), null, 'Extension-wrapped window.fetch network blip should be suppressed');
+  });
+
+  it('suppresses bare "Failed to fetch" when extension frame function chains to window.fetch', () => {
+    // Real 2026-07-16 stack: extension `frame_ant/frame_ant.js` wraps fetch and the
+    // leaked rejection frame function is `r.class.c.value.window.fetch`. The original
+    // SG regex only matched `window.fetch` or `Object.apply`; broaden it to any chain
+    // ending in `.window.fetch` while still rejecting `prefetch`/`fetchContent`.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/main-B1YHLdCi.js', lineno: 401, function: 'h' },
+      { filename: 'chrome-extension://hoklmmgfnpapgjgcpechhaamimifchmp/frame_ant/frame_ant.js', lineno: 2, function: 'r.class.c.value.window.fetch' },
+    ]);
+    assert.equal(beforeSend(event), null, 'Extension chain-ending-in-window.fetch fetch failure should be suppressed');
   });
 
   it('does NOT suppress bare "Failed to fetch" with a first-party frame and a NON-fetch extension frame', () => {


### PR DESCRIPTION
## Summary
- Adds `/\\[clerk\\] failed to load/` to `ignoreErrors` so Clerk SDK UI-chunk load failures (e.g. from Yandex Browser) stop paging Sentry (WORLDMONITOR-WR).
- Broadens the extension-monkeypatch `window.fetch` regex in `beforeSend` to catch chained receiver names like `r.class.c.value.window.fetch`, suppressing orphan `Failed to fetch` rejections from fetch-wrapping extensions (WORLDMONITOR-TZ).
- Adds regression tests for both filters in `tests/sentry-beforesend.test.mjs`.

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run typecheck:api` PASS
- [x] `npm run lint` PASS (warnings only, pre-existing)
- [x] `npm run test:data` PASS — 15940 pass / 0 fail
- [x] `node --test tests/edge-functions.test.mjs` PASS
- [x] `npm run lint:md` PASS
- [x] `npm run version:check` PASS
- [x] Edge function bundle check PASS