### PR TITLE
docs(bootstrap): finalize U-K3 evidence with clean-24h confirmation (#5338)

### DIFF
--- a/docs/solutions/2026-07-16-bootstrap-kv-verify.md
+++ b/docs/solutions/2026-07-16-bootstrap-kv-verify.md
@@ -21,27 +21,27 @@ metric is **share of reads that clear the budget**, which is automatically traff
 > gathered enough traffic to judge (n≈14). Replaced with a **global, traffic-weighted** gate — where
 > users actually are. The APAC per-metro table is retained as a diagnostic, not the gate.
 
-## Result (window 2026-07-16 12:00 UTC → 2026-07-17 ~04:30 UTC, ~16 h; 49.8k KV / 1.67k Redis reads)
+## Result (CLEAN 24 h window 2026-07-16 12:00 UTC → 2026-07-17 12:00 UTC; 77.5k KV / 2.48k Redis reads)
 
 **Headline (all traffic, auto-weighted):**
 
 | Store | p50 | p95 | p99 | **% clearing 1200 ms** |
 |---|---|---|---|---|
-| **KV** | 29 | 328 | 832 | **99.6 %** (~1 in 250 miss) |
-| Redis | 538 | 1599 | 2069 | **82.4 %** (~1 in 6 miss) |
+| **KV** | 28 | 321 | 816 | **99.6 %** (~1 in 250 miss) |
+| Redis | 507 | 1567 | 2029 | **84.4 %** (~1 in 6 miss) |
 
 **By continent** (KV by user country · Redis by Vercel region):
 
 | Continent | KV p95 / %ok | Redis p95 / %ok | Winner |
 |---|---|---|---|
-| N. America | 200 / 100 % | 469 / 100 % | KV (both fine) |
-| Europe | 90 / 100 % | 696 / 99 % | KV |
-| **Middle East** | **275 / 100 %** (n≈4.9k) | — **no Vercel region** | **KV** |
-| **Africa** | 630 / **99 %** | 1990 / **32 %** | **KV** (Redis fails 2/3) |
-| **Oceania** | 768 / **97 %** | 1732 / **30 %** | **KV** (Redis fails 2/3) |
-| S. Asia | 656 / 99 % | 1698 / 69 % | KV |
-| E/SE Asia | 377 / 99 % | 1732 / 68 % | KV |
-| LatAm | 362 / 100 % | 919 / 99 % | KV |
+| N. America | 204 / 100 % | 469 / 100 % | KV (both fine) |
+| Europe | 89 / 100 % | 669 / 99 % | KV |
+| **Middle East** | **269 / 100 %** (n≈7.3k) | — **no Vercel region** | **KV** |
+| **Africa** | 630 / **99 %** | 1990 / **40 %** | **KV** (Redis fails 3/5) |
+| **Oceania** | 724 / **97 %** | 1698 / **39 %** | **KV** (Redis fails 3/5) |
+| S. Asia | 583 / 99 % | 1664 / 74 % | KV |
+| E/SE Asia | 362 / 100 % | 1698 / 71 % | KV |
+| LatAm | 355 / 100 % | 919 / 99 % | KV |
 
 **Only exception — Redis faster:** US-East metros `iad1` (Redis 48 ms vs KV 177 ms) and `cle1`
 (123 vs 155) — where Upstash Redis is physically co-located, so the Vercel Function does a LAN read.
@@ -49,32 +49,36 @@ Both are trivially under budget; no mobile user perceives 177 ms vs 48 ms. US tr
 under-budget on KV regardless. Non-issue.
 
 **MENA (matters for this user base):** Vercel has no Middle East region, so MENA users hit European
-Redis today. KV serves them locally at 275 ms p95 / 100 % under budget (Turkey specifically:
-146 ms / 100 %, n≈922).
+Redis today. KV serves them locally at 269 ms p95 / 100 % under budget (UAE 249 ms / 100 %, n≈1.8k;
+Turkey 140 ms / 100 %, n≈1.2k).
 
-**Where traffic lives** (top by KV volume): US 9.5k · India 4.4k · Italy 3.1k · UK 1.8k · Australia
-1.7k · Germany 1.6k · Japan 1.5k · France 1.5k · Singapore 1.4k · Canada 1.4k · Netherlands 1.3k ·
-Turkey 0.9k · Indonesia · Pakistan. A true worldwide base — KV serves all at ~100 % under budget.
-Italy (52 ms) is a ~13× win over the European-Redis path it uses today.
+**Where traffic lives** (top by KV volume): US 12.8k · India 8.0k · Italy 4.2k · Australia 2.8k ·
+Germany 2.7k · UK 2.7k · Japan 2.6k · France 2.5k · Singapore 2.3k · Netherlands 1.9k · Canada 1.9k ·
+UAE 1.8k · Pakistan 1.6k · Indonesia 1.4k · Turkey 1.2k. A true worldwide base — KV serves all at
+~100 % under budget. Italy (55 ms) is a ~12× win over the European-Redis path it uses today.
 
 ## Residual risk (not a blocker)
 
-The 0.4 % of KV reads over budget concentrate in **low-traffic remote POPs** (Oceania secondaries
-AKL/BNE/ADL/WLG/NOU, South-Asia fringe ISB, Pacific islands) that keep no hot KV replica, so reads
-hop to a regional tier. **Even there KV beats Redis** (e.g. Jakarta 1341 < 2029), so cutover still
-*reduces* aborts — nobody regresses. Lever for U-K4: a longer read `cacheTtl` keeps those POPs hot
-at the cost of a little tier staleness; truly remote POPs (once per ~15 min) stay cold-ish regardless
-and are still faster than Redis.
+The 0.40 % of KV reads over budget (307 of 77.5k, only 9 Worker-cold) concentrate in **low-traffic
+remote POPs** (Oceania secondaries AKL/BNE/ADL, Pacific islands PPT, East-Africa EBB/JIB, South-Asia
+fringe LHE) that keep no hot KV replica, so reads hop to a regional tier. **Even there KV beats
+Redis**, so cutover still *reduces* aborts — nobody regresses. Lever for U-K4: a longer read
+`cacheTtl` keeps those POPs hot at the cost of a little tier staleness; truly remote POPs
+(once per ~15 min) stay cold-ish regardless and are still faster than Redis.
 
-## Stability
+## Stability — CONFIRMED at the clean 24 h window
 
-The 99.6 % under-budget figure was identical between the 8 h and 16 h reads; every metro winner held;
-Jakarta's p95 tightened as samples grew (1418→1341), confirming early over-budget numbers were
-small-sample jitter. Clean-24 h confirmation (window close 2026-07-17 12:00 UTC) scheduled.
+The 99.6 % under-budget figure was **identical across the 8 h, 16 h and full 24 h reads** (99.60 % on
+77.5k reads with peak captured); every continent still won; no high-traffic metro regressed. **Jakarta,
+flagged over-budget at 16 h (1341 ms), now PASSES at 799 ms** as its samples fattened — confirming the
+early number was small-sample jitter exactly as predicted. Pipeline health over the window: **99.90 %
+valid `kv`, zero stale/miss/invalid** (the 0.10 % remainder is the shadow's 5 s probe-ceiling, not a
+serving path); publisher still writing valid fast+slow envelopes at window close.
 
 ## Go/no-go
 
-**GO.** KV clears the mobile budget for 99.6 % of a genuinely global user base vs Redis's 82.4 %,
-wins every continent, and *rescues* Africa/Oceania where the incumbent fails a third of requests.
-Cutover is a strict improvement everywhere (the sole Redis-faster spots are already under budget).
-Proceed to U-K4 with the KTD3 origin-fallback + KTD4 staleness guard intact.
+**GO — confirmed.** KV clears the mobile budget for 99.6 % of a genuinely global user base vs Redis's
+84.4 %, wins every continent, and *rescues* Africa (Redis 40 % ok) / Oceania (39 %) where the incumbent
+fails the majority of requests. Cutover is a strict improvement everywhere (the sole Redis-faster spots,
+US-East `iad1`/`cle1`, are already trivially under budget). Proceed to U-K4 (implemented as PR #5357,
+with the hedge + KTD3 origin-fallback + KTD4 staleness guard) — merge inert, then stage the flag flip.


### PR DESCRIPTION
Follow-up to #5357 (merged). Updates the U-K3 verify artifact from the ~16h read to the **clean 24h window** (2026-07-16 12:00 → 2026-07-17 12:00 UTC) that the scheduled confirmation just ran.

**Verdict unchanged: GO, now confirmed at the full window.**
- KV **99.6%** under the 1200ms mobile budget (77.5k reads) vs Redis **84.4%** — identical to the 8h/16h reads, peak captured.
- KV wins **every continent**; rescues Africa (Redis 40% ok) and Oceania (39%); serves MENA at 269ms/100% (Vercel has no ME region). Only US-East has Redis faster, both trivially under budget.
- **Jakarta now passes** (799ms, was 1341 at 16h) — small-sample jitter resolved as predicted; no high-traffic metro regressed.
- Pipeline health over the window: **99.90% valid kv, zero stale/miss/invalid**; publisher still writing valid envelopes at window close.

Docs-only. The U-K4 serving code (hedge + KTD3/KTD4 guards) already merged inert via #5357; the staged flag flip (off→slow→all) remains a separate, manual step.