### PR TITLE
fix(seed-utils): retry transient Redis failures in writeExtraKey / extendExistingTtl

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -668,13 +668,28 @@ export function shouldEnvelopeKey(key) {
 export async function writeExtraKey(key, data, ttl, envelopeMeta) {
   const { url, token } = getRedisCredentials();
   const payload = serializeExtraKeyValue(key, data, envelopeMeta);
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify(['SET', key, payload, 'EX', ttl]),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`Extra key ${key}: write failed (HTTP ${resp.status})`);
+  // Retry transient Redis timeouts / 5xx / network tears so a single Upstash
+  // blip in afterPublish doesn't crash the whole seeder run. Permanent 4xx
+  // (auth, payload-too-large) fail fast; 429 honors Retry-After. Mirrors the
+  // redisCommand / atomicPublish contract (seed-gdelt-intel PUBLISH_TIMEOUT fix).
+  await withRetry(async () => {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+      body: JSON.stringify(['SET', key, payload, 'EX', ttl]),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) {
+      const err = new Error(`Extra key ${key}: write failed (HTTP ${resp.status})`);
+      if (PERMANENT_4XX_STATUSES.has(resp.status)) {
+        err.nonRetryable = true;
+      } else if (resp.status === 429) {
+        const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
+        if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+      }
+      throw err;
+    }
+  }, 2, 1000);
   console.log(`  Extra key ${key}: written`);
 }
 
@@ -730,13 +745,28 @@ export async function extendExistingTtl(keys, ttlSeconds = 600) {
     // EXPIRE only refreshes TTL when key already exists (returns 0 on missing keys — no-op).
     // Check each result: keys that returned 0 are missing/expired and cannot be extended.
     const pipeline = keys.map(k => ['EXPIRE', k, ttlSeconds]);
-    const resp = await fetch(`${url}/pipeline`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify(pipeline),
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!resp.ok) return false;
+    // Retry the pipeline call on transient Redis failures. A successful response
+    // with some EXPIRE no-ops is a real missing-key condition, NOT a transient
+    // error, so we only retry HTTP/network failures and return false for no-ops.
+    const resp = await withRetry(async () => {
+      const r = await fetch(`${url}/pipeline`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(pipeline),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!r.ok) {
+        const err = new Error(`TTL extension pipeline failed (HTTP ${r.status})`);
+        if (PERMANENT_4XX_STATUSES.has(r.status)) {
+          err.nonRetryable = true;
+        } else if (r.status === 429) {
+          const retryAfterMs = parseRetryAfterMs(getResponseHeader(r.headers, 'Retry-After'));
+          if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+        }
+        throw err;
+      }
+      return r;
+    }, 2, 1000);
     const results = await resp.json();
     const extended = results.filter(r => r?.result === 1).length;
     const missing = results.filter(r => r?.result === 0).length;

--- a/tests/seed-utils-extend-ttl-confirms.test.mjs
+++ b/tests/seed-utils-extend-ttl-confirms.test.mjs
@@ -80,3 +80,63 @@ test('seed-market-quotes gates the closed-market exit on the extend result', asy
   const exitIdx = src.indexOf('process.exit(0)');
   assert.ok(gateIdx > 0 && exitIdx > gateIdx, 'exit(0) must be gated behind if(extended)');
 });
+
+// Transient-Redis retry contract for extendExistingTtl (seed-gdelt-intel
+// PUBLISH_TIMEOUT fix). The helper must retry timeout/5xx/network errors and
+// only fail fast on permanent 4xx. A successful response with some EXPIRE
+// no-ops (missing keys) is a *real* missing-key condition, not a transient
+// error, so it must return false without retrying.
+
+test('extendExistingTtl: retries on timeout and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      const err = new Error('The operation was aborted due to timeout');
+      err.name = 'AbortError';
+      throw err;
+    }
+    return { ok: true, json: async () => [{ result: 1 }, { result: 1 }] };
+  };
+
+  const ok = await extendExistingTtl(['a', 'b'], 1800);
+  assert.equal(ok, true);
+  assert.equal(calls, 2, 'must retry once after timeout');
+});
+
+test('extendExistingTtl: retries on 503 and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return { ok: false, status: 503, json: async () => ({}) };
+    return { ok: true, json: async () => [{ result: 1 }] };
+  };
+
+  const ok = await extendExistingTtl(['a'], 1800);
+  assert.equal(ok, true);
+  assert.equal(calls, 2, 'must retry once after 503');
+});
+
+test('extendExistingTtl: fails fast on permanent 4xx without retry', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return { ok: false, status: 401, json: async () => ({}) };
+  };
+
+  const ok = await extendExistingTtl(['a'], 1800);
+  assert.equal(ok, false);
+  assert.equal(calls, 1, 'must not retry permanent 401');
+});
+
+test('extendExistingTtl: does NOT retry when response is OK but a key is missing', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return { ok: true, json: async () => [{ result: 1 }, { result: 0 }] };
+  };
+
+  const ok = await extendExistingTtl(['alive', 'missing'], 1800);
+  assert.equal(ok, false);
+  assert.equal(calls, 1, 'missing-key no-op is a real condition, not a transient error');
+});

--- a/tests/seed-utils-write-extra-key-retry.test.mjs
+++ b/tests/seed-utils-write-extra-key-retry.test.mjs
@@ -1,0 +1,108 @@
+// Regression tests for transient-Redis retry on writeExtraKey.
+//
+// seed-gdelt-intel (and other seeders) call writeExtraKey in afterPublish for
+// auxiliary timeline keys. A single Upstash latency spike / timeout on that
+// SET would previously crash the whole seeder run with:
+//   FATAL: The operation was aborted due to timeout
+// The helper should retry transient network/5xx/timeout errors and only fail
+// fast on permanent 4xx (auth, payload-too-large, etc.), mirroring the
+// redisCommand / atomicPublish contract.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { writeExtraKey } = await import('../scripts/_seed-utils.mjs');
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => { globalThis.fetch = originalFetch; });
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+function buildResponse({ ok = true, status = 200, body = { result: 'OK' }, headers = {} }) {
+  return { ok, status, json: async () => body, headers };
+}
+
+test('writeExtraKey: retries on timeout and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      const err = new Error('The operation was aborted due to timeout');
+      err.name = 'AbortError';
+      throw err;
+    }
+    return buildResponse({ ok: true, status: 200 });
+  };
+
+  await writeExtraKey('gdelt:intel:tone:military', { data: [], fetchedAt: '2026-07-17T00:00:00.000Z' }, 600);
+  assert.equal(calls, 2, 'must retry once after timeout');
+});
+
+test('writeExtraKey: retries on 503 and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return buildResponse({ ok: false, status: 503 });
+    return buildResponse({ ok: true, status: 200 });
+  };
+
+  await writeExtraKey('gdelt:intel:vol:military', { data: [], fetchedAt: '2026-07-17T00:00:00.000Z' }, 600);
+  assert.equal(calls, 2, 'must retry once after 503');
+});
+
+test('writeExtraKey: retries on 429 honoring Retry-After', async () => {
+  let calls = 0;
+  const sleeps = [];
+  const originalSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (cb, ms) => {
+    sleeps.push(ms);
+    queueMicrotask(cb);
+    return 0;
+  };
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return buildResponse({ ok: false, status: 429, headers: { 'retry-after': '2' } });
+    }
+    return buildResponse({ ok: true, status: 200 });
+  };
+
+  try {
+    await writeExtraKey('gdelt:intel:tone:cyber', { data: [], fetchedAt: '2026-07-17T00:00:00.000Z' }, 600);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+  assert.equal(calls, 2, 'must retry once after 429');
+  assert.ok(sleeps.some(ms => ms >= 2000), 'Retry-After hint must be honored');
+});
+
+test('writeExtraKey: fails fast on permanent 4xx without retry', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ ok: false, status: 401 });
+  };
+
+  await assert.rejects(
+    () => writeExtraKey('gdelt:intel:tone:nuclear', { data: [], fetchedAt: '2026-07-17T00:00:00.000Z' }, 600),
+    /HTTP 401/,
+  );
+  assert.equal(calls, 1, 'must not retry permanent 401');
+});
+
+test('writeExtraKey: still throws after exhausting retries', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ ok: false, status: 503 });
+  };
+
+  await assert.rejects(
+    () => writeExtraKey('gdelt:intel:tone:sanctions', { data: [], fetchedAt: '2026-07-17T00:00:00.000Z' }, 600),
+    /HTTP 503/,
+  );
+  assert.equal(calls, 3, 'default retry count should be 2 (3 total attempts)');
+});


### PR DESCRIPTION
## Problem
`seed-gdelt-intel` has been crashing with `FATAL: The operation was aborted due to timeout` during the post-fetch Redis write phase (PUBLISH_TIMEOUT class from the seeder diagnostic). A single Upstash latency spike on an auxiliary `writeExtraKey` SET or the `extendExistingTtl` EXPIRE pipeline was crashing the whole run instead of retrying.

## Fix
Add transient-Redis retry to the two helpers used in `afterPublish` (and elsewhere), mirroring the existing `redisCommand` / `atomicPublish` contract:

- `writeExtraKey`: wrap the SET call in `withRetry` (2 retries, 1s base).
  - Permanent 4xx → `nonRetryable` fast-fail.
  - 429 → honor `Retry-After`.
  - 5xx / timeout / network tear → exponential backoff.
- `extendExistingTtl`: wrap the `/pipeline` call in `withRetry`.
  - Preserves the boolean contract: `true` only when every `EXPIRE` returns `1`.
  - A successful response with some `EXPIRE` no-ops (missing/expired keys) is a real condition, so it returns `false` without wasting retries.

## Tests
- `tests/seed-utils-write-extra-key-retry.test.mjs` (new): timeout, 503, 429 Retry-After, permanent 401 fast-fail, exhaustion.
- `tests/seed-utils-extend-ttl-confirms.test.mjs`: timeout, 503, 401, and missing-key no-op regression guards.

## Verification
```bash
node --test tests/seed-utils-write-extra-key-retry.test.mjs tests/seed-utils-extend-ttl-confirms.test.mjs
```
All 15 tests pass.
