### PR TITLE
fix(notifications): enforce Country Scope uniformly across all alert categories (#5359)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -24,6 +24,20 @@ The delivery contract of the boot payload: a hydrated value can be read exactly 
 
 The project's costing heuristic for cache and egress work: egress ≈ origin-miss count × transferred payload size. Client count, reader count, and total request volume are absorbed by the CDN and do not appear in the formula, so a proposed optimization reduces egress only if it reduces the miss rate or the bytes per miss. Applied before scoping any bandwidth work; proposals whose arithmetic nets to zero (deduplicating identical stored bytes while both read paths survive, flipping a client-side default that never touches the served payload) are discarded on paper. See also: One-Shot Hydration, Bootstrap View Key.
 
+## Notifications & Alert Delivery
+
+### Alert Rule
+
+A per-user notification subscription that decides which published events reach that user's channels. A rule combines a sensitivity floor, a delivery mode (realtime or a digest cadence), and optional scopes — countries and tickers. Rules are fan-out targets: one published event is tested against every enabled rule independently. See also: Country Scope, Event Attribution.
+
+### Country Scope
+
+An Alert Rule's optional country restriction. Empty means unscoped — every event qualifies. Populated means opt-in narrowing: an event attributed to a country matches only if that country is in the scope, and an *unattributed* event is dropped unless its type is on the explicit news-permissive allowlist (breaking-news origins, whose publishers cannot reliably attribute yet) or it is region-scoped and one of the rule's countries belongs to that region. The default for unknown or unattributed event types is drop, not deliver — the filter fails closed. See also: Event Attribution, Alert Rule.
+
+### Event Attribution
+
+The country identity a notification publisher attaches to an event at publish time, normalized to ISO-3166 alpha-2 through the shared country-name map. Attribution is the publisher's job, not the dispatcher's: a publisher that knows the country must attach it, because a missing or unresolvable attribution is indistinguishable downstream from a genuinely global event. A name-normalization miss that silently omits the attribution converts "lookup failed" into "field never existed" — the failure mode that lets scoped delivery leak. See also: Country Scope.
+
 ## Panel Mounting & Layout Stability
 
 ### Immediate Tier

--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -32,6 +32,12 @@ COPY scripts/lib/usni-fleet-parser.cjs ./scripts/lib/usni-fleet-parser.cjs
 # telemetry flush, #4954) — missing it = silent startup crash in the image.
 COPY scripts/lib/llm-telemetry.cjs ./scripts/lib/llm-telemetry.cjs
 COPY scripts/shared/country-name-to-iso2.cjs ./scripts/shared/country-name-to-iso2.cjs
+# country-names.json backs the full name→ISO2 map (#5359 uniform country
+# scoping); required by country-name-to-iso2.cjs at startup.
+COPY scripts/shared/country-names.json ./scripts/shared/country-names.json
+# iso2-to-region.json backs regional_* country-scope matching in
+# notification-relay.cjs (#5359).
+COPY scripts/shared/iso2-to-region.json ./scripts/shared/iso2-to-region.json
 # notification-dedup.cjs is required by ais-relay.cjs and notification-relay.cjs
 # (Slot B dedup-material helper, #4985). Missing it = ERR_MODULE_NOT_FOUND at
 # relay startup. Guarded by tests/dockerfile-relay-imports.test.mjs.

--- a/docs/solutions/logic-errors/country-scope-filter-permissive-default-leaked-unattributed-alerts.md
+++ b/docs/solutions/logic-errors/country-scope-filter-permissive-default-leaked-unattributed-alerts.md
@@ -1,0 +1,148 @@
+---
+title: Country Scope filter's permissive default leaked every unattributed alert category
+date: 2026-07-18
+category: logic-errors
+module: notification-relay
+problem_type: logic_error
+component: background_job
+severity: high
+symptoms:
+  - "User scoped to 10 Eastern-European countries received CRITICAL alerts for São Paulo/Hong Kong/Kuala Lumpur/Guangzhou airport disruptions"
+  - "VIX surge (Commodity Market) and Sudan conflict casualties (UCDP) delivered despite neither matching the configured Country Scope"
+  - "Existing country-filter test suite stayed green throughout — it asserted the filter's own semantics, not delivery outcomes for real publisher payloads"
+root_cause: logic_error
+resolution_type: code_fix
+related_components: [service_object, testing_framework]
+tags: [notifications, country-scope, fail-open, denylist-vs-allowlist, attribution, normalization, mutation-testing]
+---
+
+# Country Scope filter's permissive default leaked every unattributed alert category
+
+## Problem
+
+The notification relay's per-rule Country Scope filter treated events without
+country attribution as "deliver to everyone" unless their type was on a
+two-entry denylist. Since most publishers attached no attribution — and one
+publisher's attribution silently failed — a user who restricted alerts to 10
+countries received critical alerts from three unrelated categories (aviation,
+markets, conflict data). Reported in #5359, fixed in PR #5366.
+
+## Symptoms
+
+- Country Scope `[CZ, LV, LT, EE, PL, UA, XK, RS, BY, RU]` + sensitivity
+  "Critical only" still delivered: `aviation_closure` for GRU/HKG/KUL/CAN,
+  `market_alert` for a VIX surge, and `conflict_escalation` for Sudan.
+- The user's report correctly inferred the mechanism: "Country Scope filtering
+  is only applied to certain alert types … not consistently enforced across
+  all notification sources."
+
+## What Didn't Work (as protection)
+
+- **The denylist patch (#4737).** An earlier report of the same shape was
+  fixed by adding the two offending event types (`corridor_risk`,
+  `shipping_stress`) to an `UNATTRIBUTED_GLOBAL_EVENT_TYPES` denylist. That
+  fixed those two types and silently re-exposed the bug for every *other*
+  unattributed type — the fix hardened instances, not the default.
+- **The mirror test.** `tests/notification-relay-country-filter.test.mjs`
+  re-implemented the filter as a local copy plus a source-grep contract. It
+  verified the filter's *own* semantics (which were "working as coded") but
+  never fed it what publishers actually emit — payloads with no
+  `countryCode` — against a scoped rule, so the leak was invisible to it.
+- **Spot-check aliases in the name map.** The shared name→ISO2 helper had 12
+  entries and tests asserting `UK`/`USA`/`UAE` resolved. The covered cases
+  passed while ~290 country names (including `Sudan`) returned `null`.
+
+## Root Cause
+
+Three layers compounded, and each hid the others:
+
+1. **Fail-open default** — `eventMatchesCountryScope` in
+   `scripts/notification-relay.cjs` returned `true` for any event without
+   resolvable attribution unless its type was denylisted. New event types and
+   publishers joined the leak by default.
+2. **Publishers omitted attribution they had** — `scripts/seed-aviation.mjs`
+   built `aviation_closure`/`notam_closure` payloads from an airport registry
+   whose rows carry `country: 'Brazil' | 'China' | …` but never attached it.
+3. **Silent normalization miss** — `scripts/ais-relay.cjs` UCDP/cyber
+   publishers *did* look up a code
+   (`const countryCode = normalizeNotificationCountryCode(e.country)`,
+   `scripts/ais-relay.cjs:1739`) and then spread
+   `...(countryCode ? { countryCode } : {})` — so a `null` from the 12-entry
+   stub map silently deleted the attribution, dropping the event into the
+   permissive branch. A lookup miss and a genuinely-global event were
+   indistinguishable downstream.
+
+## Solution
+
+Inverted the default and repaired both attribution paths (all cites at PR
+#5366's head):
+
+- **Default DROP with an explicit allowlist**
+  (`scripts/notification-relay.cjs:704-778`): unattributed events now match a
+  scoped rule only if their type is in
+  `PERMISSIVE_UNATTRIBUTED_EVENT_TYPES` — news origins (`rss_alert`,
+  `keyword_spike`, `hotspot_escalation`, `military_surge`; RSS still has no
+  reliable attribution and scoped users shouldn't lose keyword-relevant news)
+  plus `watchlist_story_alert` (scoped by ticker instead, an explicit
+  opt-in).
+- **Region-scoped events match via membership**
+  (`regionalEventMatchesCountryScope`,
+  `scripts/notification-relay.cjs:724-730`): `regional_*` events carry
+  `payload.region_id`, so a scoped rule matches when any of its countries
+  maps into that region via `shared/iso2-to-region.json`.
+- **Attribution at the publisher**: `scripts/seed-aviation.mjs:886` resolves
+  the alert row's country name; `:917` resolves NOTAM ICAOs through the
+  airport registry. The browser path forwards `countryCode` too
+  (`src/services/breaking-news-alerts.ts`, OREF sirens → `IL`).
+- **Complete name map**: `scripts/shared/country-name-to-iso2.cjs` is now
+  backed by the full ~306-entry `shared/country-names.json` with the same
+  key-normalization as `scripts/build-country-names.cjs`, UCDP
+  historical-parenthetical stripping (`Yemen (North Yemen)` → `YE`), and a
+  `bosnia herzegovina` alias. The root `shared/` duplicate copy was synced in
+  the same commit.
+- **Container guard extended**: the new JSON data deps are COPY'd in
+  `Dockerfile.relay`, and `tests/dockerfile-relay-imports.test.mjs` now
+  tracks `require()`'d `.json` files — the guard caught the missing COPY
+  during development (a missing data file is a startup crash, exactly like a
+  missing `.cjs`).
+
+## Why This Works
+
+With DROP as the default, an unknown or attribution-less event type fails
+*closed* for scoped users: the worst regression a future publisher can cause
+is an over-filtered alert (visible, complainable), not a silent leak
+(invisible until a user files a bug). The allowlist is small, documented, and
+each entry carries its own justification — the reviewable artifact is "why is
+this type allowed to bypass scope," not "did anyone remember to denylist the
+new type."
+
+## Prevention
+
+- **Scope/permission filters default closed.** A per-item filter with a
+  permissive default plus a maintained denylist silently fails open for every
+  new case; each incident produces another denylist patch (#4737 → #5359).
+  Invert once: default-DROP, explicit allowlist, one justification comment
+  per entry.
+- **A normalization helper returning `null` on miss must not silently erase
+  data.** The `...(code ? { code } : {})` spread pattern converts "lookup
+  failed" into "field never existed." Either make the map complete (back it
+  with the canonical dataset instead of a hand-typed stub) or make the miss
+  observable before the field is dropped.
+- **Test the registered function against real payloads.** Export the filter
+  and exercise the actual export with what publishers actually emit — the
+  regression suite (`tests/notification-relay-country-scope-5359.test.mjs`)
+  loads the real relay module via a `Module._load` stub and replays the
+  reporter's exact rule against all three leaked categories.
+- **Mutation-test multi-part fixes.** Each of the three fixes was reverted
+  individually to confirm the suite goes red for each — proving no single
+  layer's tests were riding on another layer's fix.
+
+## Related Issues
+
+- #5359 (this bug), PR #5366 (the fix; this doc ships with it), #4737 (the
+  earlier denylist patch for the same structural flaw), #3632 (original
+  country-scoping feature)
+- `docs/solutions/logic-errors/health-must-not-grade-an-unconfigured-optional-source.md`
+  — sibling lesson on distinguishing "absent by design" from "absent by
+  failure"; here the same conflation (unattributed vs. global) drove the
+  permissive default.

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -720,6 +720,14 @@ function isPermissiveUnattributedEvent(event) {
  * belongs to the event's region (shared/iso2-to-region.json, World Bank
  * taxonomy). Missing/unknown region_id — including the 'global' region, which
  * has no member countries — drops for scoped rules.
+ *
+ * PRECEDENCE (intentional): regional_* events are routed here BEFORE the
+ * countryCode/country extraction in eventMatchesCountryScope, so any
+ * payload.countryCode on a regional event is ignored. region_id is the sole
+ * scope identity for these events — a region-wide regime shift is not "about"
+ * one member country, and letting a stray countryCode narrow it would hide
+ * the event from the rest of the region's subscribers. Do not "fix" this by
+ * consulting countryCode first.
  */
 function regionalEventMatchesCountryScope(event, rule) {
   const regionId = event?.payload?.region_id;
@@ -1132,6 +1140,25 @@ async function processEvent(event) {
     (!event.variant || !r.variant || r.variant === event.variant) &&
     (!event.userId || r.userId === event.userId)
   );
+
+  // Deploy observability for the #5359 default-DROP change: count rules that
+  // passed every OTHER gate but were excluded by country scope, so support can
+  // distinguish "working as intended" from "delivery bug" for scoped users.
+  // No userIds in the line — event identity + count is enough to correlate.
+  const countryScopeDrops = enabledRules.filter(r =>
+    (!r.digestMode || r.digestMode === 'realtime') &&
+    ruleMatchesEventType(r, event) &&
+    shouldNotify(r, event) &&
+    !eventMatchesCountryScope(event, r) &&
+    eventMatchesTickerScope(event, r) &&
+    (!event.variant || !r.variant || r.variant === event.variant) &&
+    (!event.userId || r.userId === event.userId)
+  ).length;
+  if (countryScopeDrops > 0) {
+    const rawAttribution = event?.payload?.countryCode ?? event?.payload?.country ?? event?.country ?? '(unattributed)';
+    const attribution = String(rawAttribution).replace(/[\r\n]/g, ' ').slice(0, 60);
+    console.log(`[relay] Country-scope drop: ${event.eventType} attribution=${attribution} excluded ${countryScopeDrops} scoped rule(s)`);
+  }
 
   if (matching.length === 0) return;
 

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -10,6 +10,7 @@ const {
 const { callLLM } = require('./lib/llm-chain.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
+const ISO2_TO_REGION = require('./shared/iso2-to-region.json');
 const {
   buildDedupMaterial,
   classifySetNxResult,
@@ -688,13 +689,44 @@ function normalizeEventCountryCode(raw) {
   return countryNameToIso2(raw);
 }
 
-const UNATTRIBUTED_GLOBAL_EVENT_TYPES = new Set([
-  'corridor_risk',
-  'shipping_stress',
+// Event types that remain PERMISSIVE when they carry no country attribution.
+// Everything else without attribution is DROPPED for country-scoped rules
+// (#5359: a scoped user received aviation/market/conflict criticals because
+// the old default was permissive with a two-entry global denylist).
+//
+//  - rss_alert + the browser-submitted news origins (keyword_spike,
+//    hotspot_escalation, military_surge): RSS publishers still lack reliable
+//    country attribution; dropping them would silence keyword-relevant news
+//    for scoped users. Browser-submitted copies are additionally self-scoped
+//    via event.userId.
+//  - watchlist_story_alert: scoped by ticker (eventMatchesTickerScope), not
+//    by country — an explicit per-rule opt-in that country scope must not veto.
+const PERMISSIVE_UNATTRIBUTED_EVENT_TYPES = new Set([
+  'rss_alert',
+  'keyword_spike',
+  'hotspot_escalation',
+  'military_surge',
+  'watchlist_story_alert',
 ]);
 
-function isUnattributedGlobalEvent(event) {
-  return UNATTRIBUTED_GLOBAL_EVENT_TYPES.has(event?.eventType);
+function isPermissiveUnattributedEvent(event) {
+  return PERMISSIVE_UNATTRIBUTED_EVENT_TYPES.has(event?.eventType);
+}
+
+/**
+ * Regional-intelligence events (regional_regime_shift, regional_corridor_break,
+ * regional_trigger_activation, regional_buffer_failure) are region-scoped, not
+ * country-attributed. A country-scoped rule matches when ANY of its countries
+ * belongs to the event's region (shared/iso2-to-region.json, World Bank
+ * taxonomy). Missing/unknown region_id — including the 'global' region, which
+ * has no member countries — drops for scoped rules.
+ */
+function regionalEventMatchesCountryScope(event, rule) {
+  const regionId = event?.payload?.region_id;
+  if (typeof regionId !== 'string' || regionId.length === 0) return false;
+  return rule.countries.some(
+    (c) => ISO2_TO_REGION[String(c).toUpperCase()] === regionId,
+  );
 }
 
 /**
@@ -711,40 +743,39 @@ function isUnattributedGlobalEvent(event) {
 /**
  * Filter events by per-rule country-scope.
  *
- * When `rule.countries` is empty / absent, all events match (current behavior,
- * full backwards-compat for pre-migration rules).
+ * When `rule.countries` is empty / absent, all events match (full
+ * backwards-compat for pre-migration rules).
  *
  * When `rule.countries` is populated, the user explicitly opted into country-
- * scoped alerts. We try multiple payload shapes for the event's country
- * attribution because publishers are inconsistent: regional-snapshot uses
- * `payload.countryCode`, ais-relay sometimes uses `payload.country`, browser-
- * submitted rss_alert events occasionally lift `country` to the event root.
+ * scoped alerts — the UI copy says "Restrict alerts to specific countries".
+ * We try multiple payload shapes for the event's country attribution because
+ * publishers are inconsistent: seeders use `payload.countryCode`, ais-relay
+ * sometimes uses `payload.country`, browser-submitted rss_alert events
+ * occasionally lift `country` to the event root.
  *
- * Known-global semantics for unattributed events: when a rule has
- * countries=['US'] and a known global event has NO country attribution, do not
- * deliver it. A populated country scope means "only alerts matching my
- * selected countries"; delivering global Corridor Risk / Shipping Stress alerts
- * to a Ukraine/Romania-scoped user is worse than omitting those unscoped alerts.
+ * Default for UNATTRIBUTED events is DROP (#5359). The old default was
+ * permissive with a two-entry denylist (corridor_risk, shipping_stress), so
+ * every new or attribution-less event type — aviation_closure, market_alert,
+ * conflict_escalation with an unmapped country name — leaked to scoped users.
+ * Only the news-origin types in PERMISSIVE_UNATTRIBUTED_EVENT_TYPES stay
+ * permissive (RSS has no reliable attribution yet; scoped users should not
+ * lose keyword-relevant news), and watchlist_story_alert is scoped by ticker
+ * instead. Regional-intelligence events match via region membership.
  *
- * RATIONALE: the UI copy says "Restrict alerts to specific countries" and
- * users now rely on it to narrow noisy global feeds. RSS publishers still lack
- * reliable country attribution, so they stay permissive until attribution is
- * available; otherwise a scoped user would lose keyword-relevant news alerts.
- * Publishers that know a country must emit `payload.countryCode` or
- * `payload.country` to reach scoped rules reliably.
+ * Strict semantics when the event IS attributed but doesn't match:
+ * rule.countries=['US'] + event.payload.countryCode='IR' → drop.
  *
- * Strict semantics still apply when the event IS attributed but doesn't
- * match: rule.countries=['US'] + event.payload.countryCode='IR' → drop.
- *
- * Country values are normalized to uppercase ISO-3166 alpha-2 before
- * matching. Known malformed values emitted by current publishers (for
- * example 'USA', 'United States', 'UAE') are mapped to ISO2 and filtered
- * strictly. Unknown malformed values fall through to the "unattributed"
- * branch and are dropped only for known-global events.
+ * Country values are normalized to uppercase ISO-3166 alpha-2 via the full
+ * shared/country-names.json map before matching. Values the map cannot
+ * resolve fall through to the unattributed branch above.
  */
 function eventMatchesCountryScope(event, rule) {
   // Empty/absent countries on the rule → all events (no filter applied).
   if (!Array.isArray(rule.countries) || rule.countries.length === 0) return true;
+
+  if (typeof event?.eventType === 'string' && event.eventType.startsWith('regional_')) {
+    return regionalEventMatchesCountryScope(event, rule);
+  }
 
   const eventCountry =
     event?.payload?.countryCode
@@ -752,15 +783,14 @@ function eventMatchesCountryScope(event, rule) {
     ?? event?.country
     ?? null;
 
-  // Unattributed -> drop only known global/noisy events; keep RSS permissive
-  // until publishers provide reliable country attribution.
+  // Unattributed → drop unless the type is explicitly news-permissive.
   if (typeof eventCountry !== 'string' || eventCountry.trim().length === 0) {
-    return !isUnattributedGlobalEvent(event);
+    return isPermissiveUnattributedEvent(event);
   }
 
   const normalized = normalizeEventCountryCode(eventCountry);
-  // Unknown malformed value -> treat as unattributed.
-  if (normalized === null) return !isUnattributedGlobalEvent(event);
+  // Unresolvable country value → treat as unattributed.
+  if (normalized === null) return isPermissiveUnattributedEvent(event);
 
   return rule.countries.includes(normalized);
 }
@@ -1286,4 +1316,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { sendTelegram, checkDedup, upstashDedupSetNx };
+module.exports = { sendTelegram, checkDedup, upstashDedupSetNx, eventMatchesCountryScope };

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -883,7 +883,12 @@ async function dispatchAviationNotifications(alerts) {
     // Alert rows carry the registry's country NAME ('Brazil', 'China');
     // normalize so country-scoped rules can filter (#5359 — GRU/HKG/KUL/CAN
     // criticals leaked to an Eastern-Europe-scoped user as unattributed).
+    // A miss means scoped users never see this airport's alerts (relay drops
+    // unattributed non-news events) — warn so it reads as a data-quality bug,
+    // not silent filtering. tests/notification-relay-country-scope-5359.test.mjs
+    // asserts every registry country name currently normalizes.
     const countryCode = countryNameToIso2(a.country);
+    if (!countryCode) console.warn(`[Notify] aviation_closure ${a.iata}: registry country ${JSON.stringify(a.country ?? null)} did not normalize — publishing unattributed (invisible to country-scoped rules)`);
     await publishNotificationEvent({
       eventType: 'aviation_closure',
       payload: {
@@ -913,8 +918,10 @@ async function dispatchNotamNotifications(closedIcaos, reasons) {
 
   for (const icao of newClosures.slice(0, 3)) {
     // NOTAM rows are keyed by ICAO; resolve country through the airport
-    // registry so country-scoped rules can filter (#5359).
+    // registry so country-scoped rules can filter (#5359). Same miss-warn
+    // rationale as dispatchAviationNotifications above.
     const countryCode = countryNameToIso2(AIRPORTS.find(a => a.icao === icao)?.country);
+    if (!countryCode) console.warn(`[Notify] notam_closure ${icao}: no registry country normalized — publishing unattributed (invisible to country-scoped rules)`);
     await publishNotificationEvent({
       eventType: 'notam_closure',
       payload: {

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -39,6 +39,7 @@ import {
   readCanonicalValue,
 } from './_seed-utils.mjs';
 import notificationDedup from './shared/notification-dedup.cjs';
+import countryNameMap from './shared/country-name-to-iso2.cjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const {
@@ -46,6 +47,7 @@ const {
   classifySetNxResult,
   recordDedupOutcome,
 } = notificationDedup;
+const { countryNameToIso2 } = countryNameMap;
 
 loadEnvFile(import.meta.url);
 
@@ -878,11 +880,16 @@ async function dispatchAviationNotifications(alerts) {
 
   for (const a of newAlerts.slice(0, 3)) {
     const severity = aviationSeverityBand(a);
+    // Alert rows carry the registry's country NAME ('Brazil', 'China');
+    // normalize so country-scoped rules can filter (#5359 — GRU/HKG/KUL/CAN
+    // criticals leaked to an Eastern-Europe-scoped user as unattributed).
+    const countryCode = countryNameToIso2(a.country);
     await publishNotificationEvent({
       eventType: 'aviation_closure',
       payload: {
         title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`,
         source: 'AviationStack',
+        ...(countryCode ? { countryCode } : {}),
         // Coalesce by airport + severity band: repeated same-band disruptions
         // collapse, but a MAJOR->SEVERE escalation produces a distinct key — and
         // the prev-state diff above uses the SAME identity, so the escalation is
@@ -905,12 +912,16 @@ async function dispatchNotamNotifications(closedIcaos, reasons) {
   await upstashSet(NOTAM_PREV_CLOSED_KEY, closedIcaos, PREV_STATE_TTL);
 
   for (const icao of newClosures.slice(0, 3)) {
+    // NOTAM rows are keyed by ICAO; resolve country through the airport
+    // registry so country-scoped rules can filter (#5359).
+    const countryCode = countryNameToIso2(AIRPORTS.find(a => a.icao === icao)?.country);
     await publishNotificationEvent({
       eventType: 'notam_closure',
       payload: {
         title: `NOTAM: ${icao} — ${reasons[icao] || 'Airport closure'}`,
         source: 'ICAO NOTAM',
         coalesceKey: `notam:closure:${icao}`,
+        ...(countryCode ? { countryCode } : {}),
       },
       severity: 'high',
       variant: undefined,

--- a/scripts/shared/country-name-to-iso2.cjs
+++ b/scripts/shared/country-name-to-iso2.cjs
@@ -1,25 +1,49 @@
 'use strict';
 
-const COUNTRY_NAME_TO_ISO2 = Object.freeze({
-  bahrain: 'BH',
-  israel: 'IL',
-  kuwait: 'KW',
-  oman: 'OM',
-  qatar: 'QA',
-  'saudi arabia': 'SA',
-  uae: 'AE',
-  'united arab emirates': 'AE',
-  'united kingdom': 'GB',
-  uk: 'GB',
-  'united states': 'US',
-  usa: 'US',
+// Canonical country-name → ISO-3166 alpha-2 map (~306 entries incl. aliases,
+// maintained by scripts/build-country-names.cjs). Keys are pre-normalized:
+// lowercase, diacritics stripped, '&' → ' and ', punctuation collapsed.
+const COUNTRY_NAMES = require('./country-names.json');
+
+// Aliases the canonical map lacks. UCDP emits 'Bosnia-Herzegovina' (hyphen,
+// no 'and'), which normalizes to a token country-names.json doesn't carry.
+const EXTRA_ALIASES = Object.freeze({
+  'bosnia herzegovina': 'BA',
 });
+
+const COUNTRY_NAME_TO_ISO2 = Object.freeze(
+  Object.assign({}, COUNTRY_NAMES, EXTRA_ALIASES),
+);
+
+// Mirrors the key normalization in scripts/build-country-names.cjs so lookups
+// hit the same token space the JSON was built with.
+function normalizeCountryToken(raw) {
+  return String(raw || '')
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[''‘’`.(),/-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 function countryNameToIso2(raw) {
   if (typeof raw !== 'string' || raw.trim().length === 0) return null;
   const trimmed = raw.trim();
-  const alias = COUNTRY_NAME_TO_ISO2[trimmed.toLowerCase()];
-  if (alias) return alias;
+
+  const direct = COUNTRY_NAME_TO_ISO2[normalizeCountryToken(trimmed)];
+  if (direct) return direct;
+
+  // UCDP-style historical parenthetical: 'Yemen (North Yemen)',
+  // 'Russia (Soviet Union)', 'DR Congo (Zaire)' — resolve via the modern name.
+  const stripped = trimmed.replace(/\s*\([^)]*\)\s*$/, '');
+  if (stripped !== trimmed) {
+    const viaStripped = COUNTRY_NAME_TO_ISO2[normalizeCountryToken(stripped)];
+    if (viaStripped) return viaStripped;
+  }
+
+  // Bare ISO2 passthrough. Checked AFTER the alias map so 'UK' → GB, not 'UK'.
   const upper = trimmed.toUpperCase();
   if (/^[A-Z]{2}$/.test(upper)) return upper;
   return null;

--- a/shared/country-name-to-iso2.cjs
+++ b/shared/country-name-to-iso2.cjs
@@ -1,25 +1,49 @@
 'use strict';
 
-const COUNTRY_NAME_TO_ISO2 = Object.freeze({
-  bahrain: 'BH',
-  israel: 'IL',
-  kuwait: 'KW',
-  oman: 'OM',
-  qatar: 'QA',
-  'saudi arabia': 'SA',
-  uae: 'AE',
-  'united arab emirates': 'AE',
-  'united kingdom': 'GB',
-  uk: 'GB',
-  'united states': 'US',
-  usa: 'US',
+// Canonical country-name → ISO-3166 alpha-2 map (~306 entries incl. aliases,
+// maintained by scripts/build-country-names.cjs). Keys are pre-normalized:
+// lowercase, diacritics stripped, '&' → ' and ', punctuation collapsed.
+const COUNTRY_NAMES = require('./country-names.json');
+
+// Aliases the canonical map lacks. UCDP emits 'Bosnia-Herzegovina' (hyphen,
+// no 'and'), which normalizes to a token country-names.json doesn't carry.
+const EXTRA_ALIASES = Object.freeze({
+  'bosnia herzegovina': 'BA',
 });
+
+const COUNTRY_NAME_TO_ISO2 = Object.freeze(
+  Object.assign({}, COUNTRY_NAMES, EXTRA_ALIASES),
+);
+
+// Mirrors the key normalization in scripts/build-country-names.cjs so lookups
+// hit the same token space the JSON was built with.
+function normalizeCountryToken(raw) {
+  return String(raw || '')
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[''‘’`.(),/-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 function countryNameToIso2(raw) {
   if (typeof raw !== 'string' || raw.trim().length === 0) return null;
   const trimmed = raw.trim();
-  const alias = COUNTRY_NAME_TO_ISO2[trimmed.toLowerCase()];
-  if (alias) return alias;
+
+  const direct = COUNTRY_NAME_TO_ISO2[normalizeCountryToken(trimmed)];
+  if (direct) return direct;
+
+  // UCDP-style historical parenthetical: 'Yemen (North Yemen)',
+  // 'Russia (Soviet Union)', 'DR Congo (Zaire)' — resolve via the modern name.
+  const stripped = trimmed.replace(/\s*\([^)]*\)\s*$/, '');
+  if (stripped !== trimmed) {
+    const viaStripped = COUNTRY_NAME_TO_ISO2[normalizeCountryToken(stripped)];
+    if (viaStripped) return viaStripped;
+  }
+
+  // Bare ISO2 passthrough. Checked AFTER the alias map so 'UK' → GB, not 'UK'.
   const upper = trimmed.toUpperCase();
   if (/^[A-Z]{2}$/.test(upper)) return upper;
   return null;

--- a/src/services/breaking-news-alerts.ts
+++ b/src/services/breaking-news-alerts.ts
@@ -22,6 +22,13 @@ export interface BreakingAlert {
   origin: 'rss_alert' | 'keyword_spike' | 'hotspot_escalation' | 'military_surge' | 'oref_siren';
   importanceScore?: number;
   /**
+   * ISO-3166 alpha-2 country attribution, when the producer knows it (OREF
+   * sirens are always IL). Forwarded to the relay so country-scoped rules
+   * filter correctly — unattributed non-news events are dropped for scoped
+   * rules since #5359.
+   */
+  countryCode?: string;
+  /**
    * RSS article description (cleaned, ≤400 chars). Present on rss_alert
    * origins when the upstream NewsItem carried a snippet. Enables the relay
    * to render a context line under the push/Telegram title without a second
@@ -199,6 +206,7 @@ function dispatchAlert(alert: BreakingAlert): void {
           source: alert.source,
           link: alert.link,
           ...(alert.description ? { description: alert.description } : {}),
+          ...(alert.countryCode ? { countryCode: alert.countryCode } : {}),
         },
         severity: alert.threatLevel,
         variant: SITE_VARIANT,
@@ -319,6 +327,7 @@ export function dispatchOrefBreakingAlert(alerts: OrefAlert[]): void {
     threatLevel: 'critical',
     timestamp: new Date(),
     origin: 'oref_siren',
+    countryCode: 'IL',
   });
 }
 

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -435,7 +435,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             </div>
           </div>
           <div class="ai-flow-section-label" style="margin-top:8px">Country scope</div>
-          <div class="ai-flow-toggle-desc" style="margin-bottom:6px">Restrict alerts to specific countries (ISO-3166 alpha-2). Leave empty to receive alerts from all countries.</div>
+          <div class="ai-flow-toggle-desc" style="margin-bottom:6px">Restrict alerts to specific countries (ISO-3166 alpha-2). Leave empty to receive alerts from all countries. When set, global alerts without a country (markets, shipping) are excluded; breaking-news alerts are still delivered.</div>
           <div id="usNotifCountryPicker"></div>
           <div class="ai-flow-section-label" style="margin-top:8px">Timezone</div>
           <select class="unified-settings-select" id="usSharedTimezone" style="width:100%">${makeTzOptions(sharedTz)}</select>`;

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -24,10 +24,13 @@ const root = resolve(__dirname, '..');
 
 // This guard tracks file-level `COPY scripts/foo.mjs ...` lines only; the
 // COPY grammar itself is parsed by the shared tests/_lib parser so all three
-// container guards read Dockerfiles identically.
+// container guards read Dockerfiles identically. `.json` is included because
+// require()'d data files (e.g. country-names.json behind
+// country-name-to-iso2.cjs, #5359) crash the container at startup when
+// missing, exactly like a missing .cjs.
 function readCopyList(dockerfilePath) {
   const { files } = parseDockerfileCopy(readFileSync(dockerfilePath, 'utf-8'));
-  return new Set([...files].filter((f) => /^scripts\/.+\.(mjs|cjs)$/.test(f)));
+  return new Set([...files].filter((f) => /^scripts\/.+\.(mjs|cjs|json)$/.test(f)));
 }
 
 describe('Dockerfile.relay — transitive-import closure', () => {

--- a/tests/notification-relay-country-filter.test.mjs
+++ b/tests/notification-relay-country-filter.test.mjs
@@ -39,19 +39,25 @@ function normalizeEventCountryCode(raw) {
   return countryNameToIso2(raw);
 }
 
-const UNATTRIBUTED_GLOBAL_EVENT_TYPES = new Set([
-  'corridor_risk',
-  'shipping_stress',
+// Since #5359 the default for unattributed events is DROP; only news-origin
+// types stay permissive (mirrors PERMISSIVE_UNATTRIBUTED_EVENT_TYPES in the
+// relay — the source-grep below keeps this in sync).
+const PERMISSIVE_UNATTRIBUTED_EVENT_TYPES = new Set([
+  'rss_alert',
+  'keyword_spike',
+  'hotspot_escalation',
+  'military_surge',
+  'watchlist_story_alert',
 ]);
 
-function isUnattributedGlobalEvent(event) {
-  return UNATTRIBUTED_GLOBAL_EVENT_TYPES.has(event?.eventType);
+function isPermissiveUnattributedEvent(event) {
+  return PERMISSIVE_UNATTRIBUTED_EVENT_TYPES.has(event?.eventType);
 }
 
-// Mirror the relay's eventMatchesCountryScope so we can run behavioural
-// assertions without requiring the .cjs module export. The relay file is a
-// runtime script (no exports) — we validate via source-grep AND a parallel
-// implementation that the source-grep ensures stays in sync.
+// Mirror the relay's eventMatchesCountryScope (regional_* branch omitted —
+// covered against the REAL export in
+// tests/notification-relay-country-scope-5359.test.mjs). The source-grep
+// contract keeps this mirror in sync.
 function eventMatchesCountryScope(event, rule) {
   if (!Array.isArray(rule.countries) || rule.countries.length === 0) return true;
   const eventCountry =
@@ -59,13 +65,13 @@ function eventMatchesCountryScope(event, rule) {
     ?? event?.payload?.country
     ?? event?.country
     ?? null;
-  // Unattributed → drop known-global events, keep RSS permissive.
+  // Unattributed → drop unless explicitly news-permissive.
   if (typeof eventCountry !== 'string' || eventCountry.trim().length === 0) {
-    return !isUnattributedGlobalEvent(event);
+    return isPermissiveUnattributedEvent(event);
   }
   const normalized = normalizeEventCountryCode(eventCountry);
-  // Unknown malformed → treat as unattributed.
-  if (normalized === null) return !isUnattributedGlobalEvent(event);
+  // Unresolvable → treat as unattributed.
+  if (normalized === null) return isPermissiveUnattributedEvent(event);
   return rule.countries.includes(normalized);
 }
 
@@ -121,27 +127,32 @@ describe('notification-relay eventMatchesCountryScope — source-grep contract',
     );
   });
 
-  it('known global unattributed events return false for country-scoped rules', () => {
-    // A populated country scope is a user opt-in to narrower delivery. Global
-    // corridor-risk events that carry no country attribution must not leak to
-    // Europe/Ukraine/Romania-scoped users.
+  it('unattributed events default to DROP with an explicit news-permissive allowlist (#5359)', () => {
+    // A populated country scope is a user opt-in to narrower delivery. Any
+    // event without country attribution must not leak to scoped users unless
+    // its type is explicitly news-permissive.
     assert.match(
       relaySrc,
-      /UNATTRIBUTED_GLOBAL_EVENT_TYPES/,
-      'relay must define known global unattributed event types',
+      /PERMISSIVE_UNATTRIBUTED_EVENT_TYPES/,
+      'relay must define the permissive-unattributed allowlist',
     );
     assert.match(
       relaySrc,
-      /return\s+!\s*isUnattributedGlobalEvent\(event\)/,
-      'missing/empty country attribution must drop only known global events',
+      /return\s+isPermissiveUnattributedEvent\(event\)/,
+      'missing/empty country attribution must drop unless news-permissive',
+    );
+    assert.doesNotMatch(
+      relaySrc,
+      /UNATTRIBUTED_GLOBAL_EVENT_TYPES/,
+      'the pre-#5359 global denylist must not come back (default is DROP now)',
     );
   });
 
-  it('unknown malformed country (non-2-letter) follows the known-global unattributed gate', () => {
+  it('unknown malformed country (non-2-letter) follows the same permissive-unattributed gate', () => {
     assert.match(
       relaySrc,
-      /if\s*\(\s*normalized\s*===\s*null\s*\)\s*return\s+!\s*isUnattributedGlobalEvent\(event\)/,
-      'unknown malformed country must use the same known-global unattributed gate',
+      /if\s*\(\s*normalized\s*===\s*null\s*\)\s*return\s+isPermissiveUnattributedEvent\(event\)/,
+      'unknown malformed country must use the same permissive-unattributed gate',
     );
   });
 

--- a/tests/notification-relay-country-scope-5359.test.mjs
+++ b/tests/notification-relay-country-scope-5359.test.mjs
@@ -237,6 +237,90 @@ describe('#5359 — aviation publisher attaches countryCode (source-grep contrac
   });
 });
 
+describe('#5359 — browser-submitted origins stay deliverable to scoped users (allowlist contract)', () => {
+  // Fail-closed default means a NEW browser origin added without country
+  // attribution silently disappears for country-scoped users. This contract
+  // makes that a red test instead: every origin in the BreakingAlert union
+  // must either be in the relay's permissive allowlist or have countryCode
+  // attached at its dispatch site.
+  const alertsSrc = readFileSync(
+    resolve(__dirname, '..', 'src', 'services', 'breaking-news-alerts.ts'),
+    'utf-8',
+  );
+  const relaySrc = readFileSync(
+    resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'),
+    'utf-8',
+  );
+
+  it('every BreakingAlert origin is allowlisted or attributed', () => {
+    const unionMatch = alertsSrc.match(/origin:\s*((?:'[a-z_]+'\s*\|\s*)+'[a-z_]+');/);
+    assert.ok(unionMatch, 'BreakingAlert origin union not found in breaking-news-alerts.ts');
+    const origins = [...unionMatch[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    assert.ok(origins.length >= 5, `expected ≥5 origins, parsed: ${origins.join(',')}`);
+
+    const allowlistMatch = relaySrc.match(/PERMISSIVE_UNATTRIBUTED_EVENT_TYPES = new Set\(\[([\s\S]*?)\]\)/);
+    assert.ok(allowlistMatch, 'PERMISSIVE_UNATTRIBUTED_EVENT_TYPES not found in relay');
+    const allowlist = new Set([...allowlistMatch[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]));
+
+    for (const origin of origins) {
+      if (allowlist.has(origin)) continue;
+      // Not allowlisted → its dispatch object literal must carry countryCode
+      // (e.g. oref_siren sets IL). Scan the object literal around the origin.
+      const dispatchRe = new RegExp(`origin:\\s*'${origin}'[^}]*countryCode|countryCode[^}]*origin:\\s*'${origin}'`);
+      assert.match(
+        alertsSrc,
+        dispatchRe,
+        `browser origin '${origin}' is neither in PERMISSIVE_UNATTRIBUTED_EVENT_TYPES nor dispatched with countryCode — ` +
+        'country-scoped users would silently never receive it. Either attach countryCode at the dispatch site ' +
+        'or add it to the allowlist in scripts/notification-relay.cjs with a justification comment.',
+      );
+    }
+  });
+});
+
+describe('#5359 — duplicate shared copies must stay byte-identical', () => {
+  // scripts/shared/ and root shared/ both carry the country helper + data
+  // (the relay container COPYs scripts/shared/; edge/server code reads root
+  // shared/). Divergence would mean the relay and the rest of the platform
+  // normalize the same country name differently.
+  for (const file of ['country-name-to-iso2.cjs', 'country-names.json']) {
+    it(`scripts/shared/${file} === shared/${file}`, () => {
+      const a = readFileSync(resolve(__dirname, '..', 'scripts', 'shared', file), 'utf-8');
+      const b = readFileSync(resolve(__dirname, '..', 'shared', file), 'utf-8');
+      assert.equal(a, b, `scripts/shared/${file} and shared/${file} have diverged — sync them (they are duplicate copies, not independent files)`);
+    });
+  }
+});
+
+describe('#5359 — aviation registry country names all normalize', () => {
+  // A registry row whose country name misses the map publishes unattributed
+  // and becomes invisible to scoped users (the seeder warns at runtime; this
+  // catches it at PR time instead).
+  it('every AIRPORTS country name resolves to ISO2', () => {
+    const src = readFileSync(resolve(__dirname, '..', 'scripts', 'seed-aviation.mjs'), 'utf-8');
+    const code = src.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+    const names = [...new Set([...code.matchAll(/country:\s*'([^']+)'/g)].map((m) => m[1]))];
+    assert.ok(names.length >= 50, `expected ≥50 registry country entries, parsed ${names.length}`);
+    const misses = names.filter((n) => countryNameToIso2(n) === null);
+    assert.deepEqual(misses, [], `aviation registry country names that fail to normalize: ${misses.join(', ')} — add them to shared/country-names.json`);
+  });
+});
+
+describe('#5359 — region taxonomy parity between emitter and scope matcher', () => {
+  it('iso2-to-region.json values ⊆ REGION_IDS; every region except global has members', async () => {
+    const { REGION_IDS } = await import('../shared/geography.js');
+    const regionMap = JSON.parse(
+      readFileSync(resolve(__dirname, '..', 'scripts', 'shared', 'iso2-to-region.json'), 'utf-8'),
+    );
+    const emitted = new Set(REGION_IDS);
+    const mappedValues = new Set(Object.values(regionMap));
+    const unknownRegions = [...mappedValues].filter((r) => !emitted.has(r));
+    assert.deepEqual(unknownRegions, [], `iso2-to-region.json maps countries to regions the emitter never uses: ${unknownRegions.join(', ')}`);
+    const memberless = REGION_IDS.filter((r) => r !== 'global' && !mappedValues.has(r));
+    assert.deepEqual(memberless, [], `regions with zero member countries would drop for ALL scoped rules: ${memberless.join(', ')}`);
+  });
+});
+
 describe('#5359 — regional_* events match through their region membership', () => {
   it('europe-region event reaches a rule scoped to European countries', () => {
     const event = {

--- a/tests/notification-relay-country-scope-5359.test.mjs
+++ b/tests/notification-relay-country-scope-5359.test.mjs
@@ -1,0 +1,275 @@
+/**
+ * Regression tests for #5359: CRITICAL alerts bypassed the Country Scope
+ * filter across three publisher categories. A user scoped to Eastern Europe
+ * (CZ, LV, LT, EE, PL, UA, XK, RS, BY, RU) received:
+ *
+ *   1. aviation_closure — GRU São Paulo / HKG Hong Kong / KUL Kuala Lumpur /
+ *      CAN Guangzhou. The publisher (scripts/seed-aviation.mjs) attached NO
+ *      country attribution even though the airport registry carries country
+ *      names, so the relay treated the events as unattributed-permissive.
+ *   2. market_alert — VIX surge. Market events are inherently global and were
+ *      not in UNATTRIBUTED_GLOBAL_EVENT_TYPES, so they leaked to scoped rules.
+ *   3. conflict_escalation — UCDP Sudan. The publisher DID look up a
+ *      countryCode, but scripts/shared/country-name-to-iso2.cjs was a
+ *      12-entry stub (Gulf + US/UK aliases): countryNameToIso2('Sudan')
+ *      returned null, the attribution was dropped at publish time, and the
+ *      relay fell into the same unattributed-permissive branch.
+ *
+ * These tests exercise the REAL eventMatchesCountryScope exported by
+ * scripts/notification-relay.cjs (not a mirror) and the REAL shared
+ * country-name normalizer, so a revert of any of the three fixes goes red.
+ *
+ * Run: npx tsx --test tests/notification-relay-country-scope-5359.test.mjs
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// Stub env vars BEFORE requiring the relay module so the top-of-file
+// validation block does not call process.exit(1).
+process.env.UPSTASH_REDIS_REST_URL ??= 'https://stub.upstash.io';
+process.env.UPSTASH_REDIS_REST_TOKEN ??= 'stub-token';
+process.env.CONVEX_URL ??= 'https://stub.convex.cloud';
+process.env.RELAY_SHARED_SECRET ??= 'stub-secret';
+process.env.TELEGRAM_BOT_TOKEN ??= 'stub-bot-token';
+
+// The relay's runtime deps (`resend`, `convex/browser`) live in
+// scripts/package.json and are only installed in the Railway container —
+// stub them at the loader level (same pattern as
+// tests/notification-relay-telegram-retry.test.mjs).
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, ...rest) {
+  if (request === 'resend') return { Resend: class {} };
+  if (request === 'convex/browser') {
+    return { ConvexHttpClient: class { async query() {} } };
+  }
+  return originalLoad.call(this, request, parent, ...rest);
+};
+
+const { countryNameToIso2 } = require('../scripts/shared/country-name-to-iso2.cjs');
+
+let eventMatchesCountryScope;
+
+before(() => {
+  // The relay only starts its poll loop when require.main === module, so
+  // requiring it from a test is a side-effect-free import.
+  ({ eventMatchesCountryScope } = require(
+    resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'),
+  ));
+  assert.equal(
+    typeof eventMatchesCountryScope,
+    'function',
+    'eventMatchesCountryScope export missing from notification-relay.cjs',
+  );
+});
+
+// The reporter's exact configured scope.
+const EASTERN_EUROPE_RULE = {
+  countries: ['CZ', 'LV', 'LT', 'EE', 'PL', 'UA', 'XK', 'RS', 'BY', 'RU'],
+  sensitivity: 'critical',
+};
+
+describe('#5359 — shared country-name map covers publisher-attributed names', () => {
+  it('resolves the UCDP names from the report (previously null → attribution dropped)', () => {
+    assert.equal(countryNameToIso2('Sudan'), 'SD');
+    assert.equal(countryNameToIso2('South Sudan'), 'SS');
+  });
+
+  it('resolves the aviation registry country names for the reported airports', () => {
+    assert.equal(countryNameToIso2('Brazil'), 'BR');    // GRU
+    assert.equal(countryNameToIso2('China'), 'CN');     // HKG, CAN
+    assert.equal(countryNameToIso2('Malaysia'), 'MY');  // KUL
+  });
+
+  it('resolves UCDP historical-parenthetical and hyphenated forms', () => {
+    assert.equal(countryNameToIso2('Yemen (North Yemen)'), 'YE');
+    assert.equal(countryNameToIso2('Myanmar (Burma)'), 'MM');
+    assert.equal(countryNameToIso2('Russia (Soviet Union)'), 'RU');
+    assert.equal(countryNameToIso2('Cambodia (Kampuchea)'), 'KH');
+    assert.equal(countryNameToIso2('Bosnia-Herzegovina'), 'BA');
+    assert.equal(countryNameToIso2("Côte d'Ivoire"), 'CI');
+    assert.equal(countryNameToIso2('DR Congo (Zaire)'), 'CD');
+  });
+
+  it('keeps the pre-existing alias + ISO2 passthrough semantics', () => {
+    assert.equal(countryNameToIso2('UK'), 'GB');            // alias beats ISO2 passthrough
+    assert.equal(countryNameToIso2('USA'), 'US');
+    assert.equal(countryNameToIso2('United Arab Emirates'), 'AE');
+    assert.equal(countryNameToIso2('us'), 'US');            // ISO2 passthrough
+    assert.equal(countryNameToIso2(''), null);
+    assert.equal(countryNameToIso2('   '), null);
+    assert.equal(countryNameToIso2('Atlantis Federation'), null);
+  });
+});
+
+describe('#5359 — real eventMatchesCountryScope drops out-of-scope domain events', () => {
+  it('aviation_closure GRU with countryCode BR → dropped for the Eastern-Europe rule', () => {
+    const event = {
+      eventType: 'aviation_closure',
+      severity: 'critical',
+      payload: {
+        title: 'GRU (São Paulo): Airport closure / airspace restrictions',
+        source: 'AviationStack',
+        countryCode: 'BR',
+      },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+    // A Brazil-scoped rule still receives it.
+    assert.equal(eventMatchesCountryScope(event, { countries: ['BR'] }), true);
+  });
+
+  it('aviation_closure with MISSING attribution (publisher bug) → dropped, not leaked', () => {
+    const event = {
+      eventType: 'aviation_closure',
+      severity: 'critical',
+      payload: { title: 'HKG (Hong Kong): 87% flights cancelled', source: 'AviationStack' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+  });
+
+  it('notam_closure with MISSING attribution → dropped for scoped rules', () => {
+    const event = {
+      eventType: 'notam_closure',
+      severity: 'high',
+      payload: { title: 'NOTAM: VHHH — Airport closure', source: 'ICAO NOTAM' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+  });
+
+  it('market_alert (VIX surge, global) → dropped for scoped rules, kept for unscoped', () => {
+    const event = {
+      eventType: 'market_alert',
+      severity: 'critical',
+      payload: { title: 'VIX Volatility: +32% surge', source: 'Commodity Market' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+    assert.equal(eventMatchesCountryScope(event, { countries: [] }), true);
+    assert.equal(eventMatchesCountryScope(event, {}), true);
+  });
+
+  it('conflict_escalation Sudan with resolved countryCode SD → dropped for Eastern-Europe scope', () => {
+    const event = {
+      eventType: 'conflict_escalation',
+      severity: 'critical',
+      payload: {
+        title: 'Sudan: SFA vs Civilians — 76 casualties',
+        source: 'UCDP',
+        countryCode: countryNameToIso2('Sudan'),
+      },
+    };
+    // Pre-fix, countryNameToIso2('Sudan') was null and the publisher omitted
+    // countryCode entirely; the permissive branch then delivered it.
+    assert.equal(event.payload.countryCode, 'SD');
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+  });
+
+  it('conflict_escalation with UNRESOLVABLE country name → dropped, not leaked', () => {
+    const event = {
+      eventType: 'conflict_escalation',
+      severity: 'critical',
+      payload: { title: 'Unknown: A vs B — 20 casualties', source: 'UCDP' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+  });
+
+  it('conflict_escalation Ukraine → still delivered to the Eastern-Europe rule', () => {
+    const event = {
+      eventType: 'conflict_escalation',
+      severity: 'critical',
+      payload: {
+        title: 'Ukraine: forces — 40 casualties',
+        source: 'UCDP',
+        countryCode: 'UA',
+      },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), true);
+  });
+
+  it('cyber_threat with no attribution → dropped for scoped rules', () => {
+    const event = {
+      eventType: 'cyber_threat',
+      severity: 'critical',
+      payload: { title: 'c2 server: 203.0.113.7 (QakBot)', source: 'feodo' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+  });
+
+  it('rss_alert without attribution stays permissive (documented news semantics)', () => {
+    const event = {
+      eventType: 'rss_alert',
+      severity: 'critical',
+      payload: { title: 'Breaking: something keyword-relevant', source: 'rss' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), true);
+  });
+});
+
+describe('#5359 — aviation publisher attaches countryCode (source-grep contract)', () => {
+  const aviationSrc = readFileSync(
+    resolve(__dirname, '..', 'scripts', 'seed-aviation.mjs'),
+    'utf-8',
+  );
+
+  it('aviation_closure and notam_closure publish normalized countryCode', () => {
+    assert.match(
+      aviationSrc,
+      /eventType:\s*'aviation_closure'[\s\S]{0,600}?countryCode/,
+      'aviation_closure must include countryCode in its payload',
+    );
+    assert.match(
+      aviationSrc,
+      /eventType:\s*'notam_closure'[\s\S]{0,600}?countryCode/,
+      'notam_closure must include countryCode in its payload',
+    );
+    assert.match(
+      aviationSrc,
+      /require\(['"]\.\/shared\/country-name-to-iso2\.cjs['"]\)|from\s+['"]\.\/shared\/country-name-to-iso2\.cjs['"]/,
+      'seed-aviation must normalize through the shared country-name map',
+    );
+  });
+});
+
+describe('#5359 — regional_* events match through their region membership', () => {
+  it('europe-region event reaches a rule scoped to European countries', () => {
+    const event = {
+      eventType: 'regional_regime_shift',
+      severity: 'critical',
+      payload: { title: 'Europe: regime pressure → confrontation', region_id: 'europe' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), true);
+  });
+
+  it('mena-region event is dropped for an Eastern-Europe-scoped rule', () => {
+    const event = {
+      eventType: 'regional_corridor_break',
+      severity: 'critical',
+      payload: { title: 'MENA: corridor degraded — hormuz', region_id: 'mena' },
+    };
+    assert.equal(eventMatchesCountryScope(event, EASTERN_EUROPE_RULE), false);
+  });
+
+  it('regional event with unknown/missing region_id is dropped for scoped rules', () => {
+    const noRegion = {
+      eventType: 'regional_buffer_failure',
+      severity: 'high',
+      payload: { title: 'buffer failure' },
+    };
+    const unknownRegion = {
+      eventType: 'regional_trigger_activation',
+      severity: 'high',
+      payload: { title: 'trigger', region_id: 'atlantis' },
+    };
+    assert.equal(eventMatchesCountryScope(noRegion, EASTERN_EUROPE_RULE), false);
+    assert.equal(eventMatchesCountryScope(unknownRegion, EASTERN_EUROPE_RULE), false);
+    // Unscoped rules keep receiving regional events.
+    assert.equal(eventMatchesCountryScope(noRegion, { countries: [] }), true);
+  });
+});


### PR DESCRIPTION
Fixes #5359 — a user with Country Scope `CZ, LV, LT, EE, PL, UA, XK, RS, BY, RU` and Sensitivity "Critical only" received CRITICAL alerts for GRU/HKG/KUL/CAN airport disruptions (AviationStack), a VIX surge (Commodity Market), and Sudan SFA-vs-civilians casualties (UCDP).

## Root causes (three, compounding)

1. **Relay filter defaulted permissive for unattributed events** (`scripts/notification-relay.cjs`). The only strict cases were a two-entry denylist (`corridor_risk`, `shipping_stress`) from #4737. Every other event type published without country attribution — aviation, NOTAM, market, cyber, unresolved-country conflict — sailed through populated country scopes.
2. **Aviation publisher attached no attribution** (`scripts/seed-aviation.mjs`). The airport registry rows carry `country: 'Brazil' | 'China' | …` but `aviation_closure` / `notam_closure` payloads omitted it entirely.
3. **The shared name→ISO2 map was a 12-entry stub** (`scripts/shared/country-name-to-iso2.cjs`: Gulf states + US/UK/UAE aliases). UCDP publishes `country: 'Sudan'` and the publisher normalizes before attaching — `countryNameToIso2('Sudan')` returned `null`, so `conflict_escalation` went out unattributed and hit cause 1. Same for cyber threat country names.

## Fix (option a from the report: uniform enforcement)

- **Default DROP for unattributed events on scoped rules**, with an explicit permissive allowlist for news origins (`rss_alert`, `keyword_spike`, `hotspot_escalation`, `military_surge` — RSS still has no reliable attribution; scoped users shouldn't lose keyword-relevant news) and `watchlist_story_alert` (ticker-scoped opt-in, orthogonal to country).
- **`regional_*` events match via region membership**: a scoped rule matches when any of its countries maps into the event's `region_id` via `shared/iso2-to-region.json` (all 10 of the reporter's countries are in `europe`, so they keep Europe regional intel and lose MENA/global).
- **Aviation + NOTAM events now carry `payload.countryCode`**, resolved from the airport registry through the shared map.
- **The shared map is now backed by the full ~306-entry `shared/country-names.json`** (same file the FATF/resolver paths use), with build-script-parity normalization, UCDP historical-parenthetical handling (`Yemen (North Yemen)` → `YE`), and a `Bosnia-Herzegovina` alias. Root `shared/` duplicate copy kept in sync.
- **Browser-submitted alerts forward `countryCode`** (OREF sirens → `IL`; relay-side OREF already did this).
- **`Dockerfile.relay`** COPYs the two new JSON deps; the transitive-import guard now tracks `require()`'d `.json` files so a missing data file fails CI instead of crashing the container at startup.
- **Settings copy** now states the semantics: "When set, global alerts without a country (markets, shipping) are excluded; breaking-news alerts are still delivered." (plain literal — no i18n key gate).

## Verification

- New `tests/notification-relay-country-scope-5359.test.mjs` exercises the **real `eventMatchesCountryScope` export** (newly exported, same loader-stub pattern as the telegram-retry test) + the real normalizer, replaying the reporter's exact rule against all three leaked categories.
- **Mutation-tested**: reverting each of the three fixes individually turns the suite red (map revert → 4 failures; relay revert → export missing; aviation revert → source-grep failure).
- Updated `tests/notification-relay-country-filter.test.mjs` mirror + source-grep contract to the new DROP-default semantics (also asserts the old denylist cannot come back).
- Full relay/notification/aviation/country-map sweep green: 45 + 73 + 89 + 39 + 52 + 60 + 13 tests. `npm run typecheck` clean.

## Behavior change note

Scoped users stop receiving: unattributed market/aviation/cyber/shipping criticals, out-of-region regional intel, and conflict events for countries outside their scope. This is the documented intent of the feature ("Restrict alerts to specific countries"); unscoped users (empty list) see zero change.
