### PR TITLE
fix(sentry): suppress zero-frame 'Unexpected token' SyntaxErrors

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -759,6 +759,14 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           // mirrors the EOF gate above: some engines embed the type in the
           // `value` field (WORLDMONITOR-TY).
           || /^(?:SyntaxError: )?Unexpected token '<'/.test(msg)
+          // Bare `Unexpected token '<keyword>'` with zero captured frames on ancient
+          // Android WebView (Chrome 98) — injected bridge/extension script or a
+          // browser-internal parse failure, not our already-parsed bundle. A genuine
+          // first-party SyntaxError carries a source-mapped .ts frame or an owned
+          // hashed-chunk URL in the message (handled above). The `hasAnyStack`-gated
+          // token gate below misses this zero-frame variant (WORLDMONITOR-??:
+          // Unexpected token 'else' / 'for', 2026-07-18).
+          || /^(?:SyntaxError: )?Unexpected token '(?:else|for)'$/.test(msg)
           // Firefox's wording for a failed `fetch()` — the engine-emitted
           // equivalent of Chrome's bare `Failed to fetch` (above) and Safari's
           // `Load failed`. Surfaces via `onunhandledrejection` with zero captured

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -380,6 +380,14 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // is engine-emitted only.
     ['Unexpected EOF', 'SyntaxError'],
     ['SyntaxError: Unexpected EOF', 'SyntaxError'],
+    // Ancient Android WebView (Chrome 98) parse failures from injected
+    // bridge/extension scripts — zero captured frames, bare keyword token.
+    // Our compiled bundle cannot emit runtime SyntaxErrors without a source-
+    // mapped .ts frame or an owned hashed-chunk URL (handled above).
+    ["Unexpected token 'else'", 'SyntaxError'],
+    ["Unexpected token 'for'", 'SyntaxError'],
+    ['SyntaxError: Unexpected token \'else\'', 'SyntaxError'],
+    ['SyntaxError: Unexpected token \'for\'', 'SyntaxError'],
     // Firefox's wording for a failed `fetch()` (WORLDMONITOR-RK) — the
     // engine-equivalent of Chrome's bare `Failed to fetch` above. Zero frames
     // via `onunhandledrejection` = background / service-worker / extension /


### PR DESCRIPTION
## Summary
- Adds zero-frame suppression for `Unexpected token 'else'` / `Unexpected token 'for'` in Sentry `beforeSend`.
- These events arrive from ancient Android WebView (Chrome 98) with no captured frames; they are emitted by injected bridge/extension scripts, not our already-parsed bundle.
- A genuine first-party SyntaxError still surfaces because it carries a source-mapped `.ts` frame or an owned hashed-chunk URL (handled by existing dynamic-import-failure filters).
- Adds regression coverage in `tests/sentry-beforesend.test.mjs` for both bare and type-prefixed value shapes, with empty, third-party, and first-party stacks.

## Test plan
- [x] `npm run typecheck` / `npm run typecheck:api`
- [x] `npm run lint` (exits 0; warnings are pre-existing)
- [x] `npm run test:data`
- [x] `node --test tests/sentry-beforesend.test.mjs`
- [x] `node --test tests/edge-functions.test.mjs`
- [x] `npm run lint:md`
- [x] `npm run version:check`

Closes WORLDMONITOR-VJ, WORLDMONITOR-WS