### PR TITLE
fix(auth): follow-up to #5369 — fix Infinity-exp test and reset leaked timeout

### DIFF
--- a/api/_session.test.mjs
+++ b/api/_session.test.mjs
@@ -102,9 +102,11 @@ test('validateSessionToken rejects exact-boundary and non-finite expirations', a
   const boundarySig = Buffer.from(new Uint8Array(boundarySigBuf)).toString('base64url');
   assert.equal(await validateSessionToken(`wms_${boundaryBody}.${boundarySig}`), false);
 
-  // JSON numeric overflow parses to Infinity; such a token must not be treated
-  // as never-expiring.
-  const infiniteBody = Buffer.from(JSON.stringify({ iat: now, exp: Infinity, n: 'infinite02' })).toString('base64url');
+  // A JSON number that overflows to Infinity must not be treated as never-expiring.
+  // JSON.stringify turns Infinity into null, so we build the literal JSON string
+  // with the unquoted numeric literal 1e309; JSON.parse yields Infinity for it and
+  // exercises the Number.isFinite guard.
+  const infiniteBody = Buffer.from(`{"iat":${now},"exp":1e309,"n":"infinite02"}`).toString('base64url');
   const infiniteSigBuf = await crypto.subtle.sign('HMAC', key, enc.encode(infiniteBody));
   const infiniteSig = Buffer.from(new Uint8Array(infiniteSigBuf)).toString('base64url');
   assert.equal(await validateSessionToken(`wms_${infiniteBody}.${infiniteSig}`), false);

--- a/docs/solutions/best-practices/test-guard-assertions-and-module-state-reset.md
+++ b/docs/solutions/best-practices/test-guard-assertions-and-module-state-reset.md
@@ -1,0 +1,118 @@
+---
+title: Test guard assertions must exercise the real guard, and test helpers must reset module state
+date: 2026-07-18
+category: best-practices
+module: auth/session tests
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - Writing regression tests for numeric boundary or non-finite value guards
+  - Writing test-only escape hatches that mutate module-level state
+tags:
+  - testing
+  - regression-tests
+  - json-stringify
+  - module-state
+  - test-helpers
+  - infinity
+  - guard-coverage
+---
+
+# Test guard assertions must exercise the real guard, and test helpers must reset module state
+
+## Context
+
+PR #5369 hardened the auth/session/bootstrap surface after an adversarial sweep. Greptile's post-merge review flagged two test-quality regressions: the tests looked like they covered production guards, but one test exercised the wrong branch entirely, and a test helper leaked mutated state to later tests in the same process.
+
+## Guidance
+
+### 1. A test that claims to cover a guard must actually reach that guard
+
+When a production check has multiple rejection paths, the regression test must force execution through the path it claims to cover. A common trap is `JSON.stringify`, which silently replaces `Infinity` (and `-Infinity`) with `null` and `NaN` with `null`:
+
+```js
+// WRONG: payload.exp is null, not Infinity
+const body = Buffer.from(JSON.stringify({ iat: now, exp: Infinity, n: 'x' })).toString('base64url');
+```
+
+In `api/_session.js:129`, the validation order is:
+
+1. `typeof payload.exp !== 'number'` -> reject
+2. `!Number.isFinite(payload.exp)` -> reject
+3. `Date.now() >= payload.exp` -> reject
+
+With `exp: null`, the test stops at step 1 and never reaches `Number.isFinite`. To exercise the non-finite guard, build a JSON literal that `JSON.parse` converts to `Infinity`:
+
+```js
+// RIGHT: JSON.parse turns the unquoted literal 1e309 into Infinity
+const infiniteBody = Buffer.from(`{"iat":${now},"exp":1e309,"n":"infinite02"}`).toString('base64url');
+```
+
+Confirm the guard is actually covered by temporarily removing it: the test must fail.
+
+### 2. Test-only reset helpers must restore every mutable field they touch
+
+A helper that lets tests mutate module-level state (`__setXForTests`) must be paired with a reset helper (`__resetXForTests`) that restores the production default. In `src/services/wm-session.ts`, `__setWmSessionFetchTimeoutForTests(ms)` changed `fetchNewSessionTimeoutMs`, but `__resetWmSessionForTests` reset every other module field without restoring the timeout. Later tests in the same Node.js process inherited the shrunken timeout and could flake.
+
+The fix adds the missing reset:
+
+```ts
+export function __resetWmSessionForTests(): void {
+  cached = null;
+  inflight = null;
+  recoveryInFlight = null;
+  sessionGeneration = 0;
+  interceptorInstalled = false;
+  sessionDeadUntil = 0;
+  sentryEnqueue = enqueueSentryCall;
+  fetchNewSessionTimeoutMs = 10_000; // <- was missing
+}
+```
+
+Add a regression test that sets the timeout to a small value, calls reset, and verifies production behavior is restored.
+
+## Why This Matters
+
+- **False confidence**: a passing regression test that does not reach the claimed guard hides the fact that the guard can be removed without consequence.
+- **Flaky later tests**: leaked module state creates order-dependent failures that are hard to reproduce and debug.
+- **Merged PRs still need review**: automated merge plus green CI does not mean the test suite is actually hardened.
+
+## When to Apply
+
+- Any regression test for a guard, boundary, or rejection path with multiple sequential checks.
+- Any test helper that exposes a setter for module-level configuration/state.
+- Post-merge or post-review follow-ups where an external reviewer (human or bot) flags test-quality issues.
+
+## Examples
+
+### Verifying a non-finite guard
+
+```js
+// Builds a body JSON.parse will read as { ..., exp: Infinity }
+const infiniteBody = Buffer.from(`{"iat":${now},"exp":1e309,"n":"x"}`).toString('base64url');
+const sig = /* sign infiniteBody with the test HMAC key */;
+assert.equal(await validateSessionToken(`wms_${infiniteBody}.${sig}`), false);
+```
+
+### Reset helper coverage
+
+```ts
+const mod = await import('../src/services/wm-session.ts?reset-repro=1');
+mod.__setWmSessionFetchTimeoutForTests(50);
+mod.__resetWmSessionForTests();
+
+// With the default 10 s timeout restored, a fetch that resolves after 100 ms succeeds.
+const outcome = await Promise.race([
+  mod.ensureWmSession().then(() => 'settled'),
+  after(500, 'still-pending'),
+]);
+assert.equal(outcome, 'settled');
+```
+
+## Related
+
+- PR #5369 — original auth/session/bootstrap adversarial sweep
+- PR #5370 — follow-up that fixed the two test-quality regressions
+- `api/_session.js:129` — non-finite expiration guard
+- `src/services/wm-session.ts:184` — `__resetWmSessionForTests`

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -189,6 +189,7 @@ export function __resetWmSessionForTests(): void {
   interceptorInstalled = false;
   sessionDeadUntil = 0;
   sentryEnqueue = enqueueSentryCall;
+  fetchNewSessionTimeoutMs = 10_000;
 }
 
 // Test-only: shrink the mint timeout so adversarial repros for hung fetches

--- a/tests/auth-resource-timeout.test.mts
+++ b/tests/auth-resource-timeout.test.mts
@@ -49,6 +49,7 @@ test('frontend session mint must not block API callers forever', async () => {
   ])));
 
   assert.equal(outcomes.filter((value) => value === 'still-pending').length, 0);
+  mod.__resetWmSessionForTests();
 });
 
 test('wm-session request-body read must terminate for a body that never ends', async () => {
@@ -126,4 +127,39 @@ test('widget-agent request-body read must terminate for a body that never ends',
     globalThis.fetch = originalFetch;
     delete process.env.WIDGET_AGENT_BODY_TIMEOUT_MS;
   }
+});
+
+test('__resetWmSessionForTests restores the default mint timeout', async () => {
+  (globalThis as unknown as { window: unknown }).window = globalThis;
+  (globalThis as unknown as { location: Location }).location = {
+    href: 'https://worldmonitor.app/',
+    origin: 'https://worldmonitor.app',
+    hostname: 'worldmonitor.app',
+    protocol: 'https:',
+    host: 'worldmonitor.app',
+  } as Location;
+  (globalThis as unknown as { sessionStorage: Storage }).sessionStorage = storage();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = storage();
+  (globalThis as unknown as { document: unknown }).document = {
+    visibilityState: 'visible',
+    addEventListener() {},
+  };
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = ((_input, init) => new Promise<Response>((resolve, reject) => {
+    if (init?.signal?.aborted) {
+      reject(new Error('Aborted'));
+      return;
+    }
+    init?.signal?.addEventListener('abort', () => reject(new Error('Aborted')), { once: true });
+    setTimeout(() => resolve(new Response(JSON.stringify({ exp: Date.now() + 3600000 }))), 100);
+  })) as typeof fetch;
+
+  const mod = await import('../src/services/wm-session.ts?reset-timeout-repro=1');
+  mod.__setWmSessionFetchTimeoutForTests(50);
+  mod.__resetWmSessionForTests();
+
+  const outcome = await Promise.race([
+    mod.ensureWmSession().then(() => 'settled'),
+    after(500, 'still-pending'),
+  ]);
+  assert.equal(outcome, 'settled');
 });


### PR DESCRIPTION
## What

Addresses two test-quality findings from Greptile's review of #5369:

1. **Infinity-exp regression test did not exercise `Number.isFinite` guard** — `JSON.stringify({ exp: Infinity })` serializes `Infinity` as `null`, so the token payload reached `validateSessionToken` with `exp: null` and was rejected by the `typeof` check, never reaching `Number.isFinite`. The test now builds a literal JSON body with `1e309`, which `JSON.parse` converts to `Infinity`, so the guard is actually covered.

2. **`__resetWmSessionForTests` leaked the shrunken mint timeout** — `__setWmSessionFetchTimeoutForTests(50)` mutated the module-level timeout, but `__resetWmSessionForTests` restored every other module field without resetting `fetchNewSessionTimeoutMs`. Any later test in the same Node.js process that called reset would still run with a 50 ms mint timeout. Reset now restores the production default (10 s), and a new regression test pins the behavior.

## Verification

- `npm run test:sidecar` ✅ (217 pass)
- `npx tsx --test tests/auth-resource-timeout.test.mts` ✅ (4 pass)
- Pre-push gate (typecheck, lint, boundaries, safe-html, rate-limit policies, edge-function tests) ✅

## Notes

- Production code is unchanged; this only fixes tests and test helpers.
- Does not auto-merge per standing rule; manual review requested.
