### PR TITLE
perf(globe): bound HTML marker count and instrument the field (#5368)

### DIFF
--- a/src/bootstrap/globe-marker-probe.ts
+++ b/src/bootstrap/globe-marker-probe.ts
@@ -26,6 +26,15 @@ export interface GlobeMarkerLoad {
   truncated: Record<string, { shown: number; total: number }>;
   /** How many layers are switched on. */
   activeLayerCount: number;
+  /**
+   * Which budget the globe applied. Reported explicitly because it does NOT
+   * track the INP event's own `formFactor`: the budget splits at the app's
+   * 768px layout breakpoint, while `getWebVitalsFormFactor` calls anything
+   * coarse-pointer or <=1024px "mobile". A 900px tablet is therefore a mobile
+   * form factor running the desktop budget, and a join that assumed otherwise
+   * would mis-attribute it.
+   */
+  budgetProfile: 'mobile' | 'desktop';
 }
 
 let current: GlobeMarkerLoad | null = null;
@@ -67,6 +76,7 @@ export function getGlobeMarkerExtra(
     globeMarkerBucket: bucketMarkerCount(load.rendered),
     globeActiveLayerCount: load.activeLayerCount,
     globeTruncated: truncated,
+    globeBudgetProfile: load.budgetProfile,
   };
 }
 

--- a/src/bootstrap/globe-marker-probe.ts
+++ b/src/bootstrap/globe-marker-probe.ts
@@ -1,0 +1,76 @@
+/**
+ * Globe marker-load probe for field INP attribution (#5368).
+ *
+ * The 3D globe renders every marker as a DOM node (globe.gl `htmlElementsData`),
+ * and three's CSS2DRenderer rewrites `display`, `transform` and `zIndex` on each
+ * of them on every animation frame — so interaction cost scales with the marker
+ * count. A lab census can measure the counts on ONE machine; it cannot tell us
+ * the distribution real users carry, and globe mode is opt-in, so that
+ * population is self-selected. Field INP regressed hardest on mobile, where the
+ * lab default view is smallest — a contradiction only field data can settle.
+ *
+ * So GlobeMap publishes its marker load here, and `inp-report` attaches it to
+ * the INP events it already sends. Same play as the #5336 CLS mover tracker:
+ * instrument cheaply, let RUM name the mover, then fix what it points at.
+ *
+ * Deliberately a plain module-level snapshot rather than another
+ * PerformanceObserver: the INP pipeline already samples, trims the good tail,
+ * and survives Sentry's deferred init, and an observer of our own would attach
+ * globe state to page-wide interactions the globe never handled.
+ */
+
+export interface GlobeMarkerLoad {
+  /** HTML markers handed to globe.gl on the last flush. */
+  rendered: number;
+  /** Layers the budget is withholding markers from, `layer: shown/total`. */
+  truncated: Record<string, { shown: number; total: number }>;
+  /** How many layers are switched on. */
+  activeLayerCount: number;
+}
+
+let current: GlobeMarkerLoad | null = null;
+
+/** Called by GlobeMap on every marker flush; pass `null` when the globe unmounts. */
+export function setGlobeMarkerLoad(load: GlobeMarkerLoad | null): void {
+  current = load;
+}
+
+/** Coarse buckets keep the tag low-cardinality and the distribution readable. */
+export function bucketMarkerCount(markers: number): string {
+  if (markers <= 200) return '0-200';
+  if (markers <= 500) return '201-500';
+  if (markers <= 1000) return '501-1000';
+  if (markers <= 2000) return '1001-2000';
+  return '2000+';
+}
+
+/**
+ * Compact extras for one INP event, or `null` when the globe is not mounted
+ * (the flat map is the default, so most reports carry nothing).
+ *
+ * Reports the marker load and which layers are being trimmed — the two things
+ * that decide globe frame cost. It deliberately does NOT send the user's full
+ * enabled-layer list, viewport size, `deviceMemory` or `hardwareConcurrency`:
+ * a per-user layer-interest vector plus device dimensions is a fingerprint, and
+ * none of it is needed to size a marker budget. `formFactor` on the parent INP
+ * event already covers the device split.
+ */
+export function getGlobeMarkerExtra(
+  load: GlobeMarkerLoad | null = current,
+): Record<string, unknown> | null {
+  if (!load) return null;
+  const truncated = Object.entries(load.truncated)
+    .map(([layer, counts]) => `${layer}:${counts.shown}/${counts.total}`)
+    .sort();
+  return {
+    globeMarkers: load.rendered,
+    globeMarkerBucket: bucketMarkerCount(load.rendered),
+    globeActiveLayerCount: load.activeLayerCount,
+    globeTruncated: truncated,
+  };
+}
+
+/** Test hook: reset module state. */
+export function resetGlobeMarkerLoadForTesting(): void {
+  current = null;
+}

--- a/src/bootstrap/inp-report.ts
+++ b/src/bootstrap/inp-report.ts
@@ -17,6 +17,7 @@
  * the reportable logic free of that import so it builds and is unit-tested
  * without the package present.
  */
+import { getGlobeMarkerExtra } from '@/bootstrap/globe-marker-probe';
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 import {
   getWebVitalsFormFactor,
@@ -50,6 +51,7 @@ export function reportInpMetric(
   metric: InpMetricLike,
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
   keep: () => boolean = shouldSampleWebVital,
+  globeExtra: typeof getGlobeMarkerExtra = getGlobeMarkerExtra,
 ): void {
   // Volume trim (#4565): skip 'good' (<200ms) INP — ~70% of field events, low
   // diagnostic value. Report needs-improvement / poor / unknown only, so the
@@ -60,6 +62,10 @@ export function reportInpMetric(
   if (!keep()) return;
   const a = metric.attribution ?? {};
   const formFactor = getWebVitalsFormFactor();
+  // #5368: when the 3D globe is mounted, how many DOM markers it is carrying is
+  // the dominant term in its frame cost — and therefore in presentationDelay.
+  // Null (and absent from the event) whenever the globe is not mounted.
+  const globe = globeExtra();
   enqueue((s) => {
     s.captureMessage('web-vital: INP', {
       level: 'info',
@@ -77,6 +83,7 @@ export function reportInpMetric(
         processingDuration: roundMs(a.processingDuration),
         presentationDelay: roundMs(a.presentationDelay),
         loadState: a.loadState,
+        ...(globe ?? {}),
       },
     });
   });

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -41,6 +41,16 @@ import { AI_DATA_CENTERS } from '@/config/ai-datacenters';
 import { getCountryBbox, getCountriesGeoJson, getCountryAtCoordinates, getCountryNameByCode } from '@/services/country-geometry';
 import { escapeHtml } from '@/utils/sanitize';
 import { showLayerWarning } from '@/utils/layer-warning';
+import { isMobileDevice } from '@/utils';
+import { setGlobeMarkerLoad } from '@/bootstrap/globe-marker-probe';
+import {
+  GLOBE_MARKER_BUDGET_DESKTOP,
+  GLOBE_MARKER_BUDGET_MOBILE,
+  proximityRank,
+  selectGlobeMarkers,
+  type GlobeLayerTruncation,
+  type GlobeMarkerGroup,
+} from '@/utils/globe-marker-budget';
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { MapLayers, Hotspot, MilitaryFlight, MilitaryVessel, MilitaryVesselCluster, NaturalEvent, InternetOutage, CyberThreat, SocialUnrestEvent, UcdpGeoEvent, MilitaryBase, GammaIrradiator, Spaceport, EconomicCenter, StrategicWaterway, CriticalMineralProject, AIDataCenter, UnderseaCable, Pipeline, CableAdvisory, RepairShip, AisDisruptionEvent, AisDensityZone, AisDisruptionType } from '@/types';
 import type { Earthquake } from '@/services/earthquakes';
@@ -553,6 +563,10 @@ export class GlobeMap {
   private satelliteFootprintMarkers: SatFootprintMarker[] = [];
   private imagerySceneMarkers: ImagerySceneMarker[] = [];
   private webcamMarkers: (WebcamMarkerData | WebcamClusterData)[] = [];
+  /** Layers the marker budget is currently withholding markers from (#5368). */
+  private markerTruncation: Record<string, GlobeLayerTruncation> = {};
+  /** HTML markers handed to globe.gl on the last flush — the per-frame cost driver. */
+  private renderedMarkerCount = 0;
   private webcamMarkerMode: string = (() => {
     try {
       return localStorage.getItem('wm-webcam-marker-mode') || 'icon';
@@ -2042,6 +2056,8 @@ export class GlobeMap {
     }, { passive: false });
 
     this.layerTogglesEl = el;
+    // The panel usually mounts after the first flush, so replay what that flush withheld.
+    this.updateLayerTruncationLabels();
   }
 
   private showLayerExplanation(layer: keyof MapLayers): void {
@@ -2099,59 +2115,97 @@ export class GlobeMap {
     if (!this.globe || !this.initialized || this.destroyed || this.webglLost) return;
     this.wakeGlobe();
 
-    const markers: GlobeMarker[] = [];
-    if (this.layers.hotspots) markers.push(...this.hotspots);
-    if (this.layers.conflicts) markers.push(...this.conflictZoneMarkers);
-    if (this.layers.bases) markers.push(...this.milBaseMarkers);
-    if (this.layers.nuclear) markers.push(...this.nuclearSiteMarkers);
-    if (this.layers.irradiators) markers.push(...this.irradiatorSiteMarkers);
-    if (this.layers.spaceports) markers.push(...this.spaceportSiteMarkers);
+    // Grouped rather than concatenated so the budget can trim the feeds that are
+    // actually oversized (#5368). Every marker here becomes a DOM node that
+    // CSS2DRenderer repositions on every frame, so the total has to be bounded.
+    const groups: GlobeMarkerGroup<GlobeMarker>[] = [];
+    const add = (
+      layer: string,
+      markers: readonly GlobeMarker[],
+      extra: Partial<GlobeMarkerGroup<GlobeMarker>> = {},
+    ): void => { if (markers.length) groups.push({ layer, markers, ...extra }); };
+
+    if (this.layers.hotspots) add('hotspots', this.hotspots, { rank: m => (m._kind === 'hotspot' ? m.escalationScore : 0) });
+    if (this.layers.conflicts) add('conflicts', this.conflictZoneMarkers);
+    if (this.layers.bases) add('bases', this.milBaseMarkers);
+    if (this.layers.nuclear) add('nuclear', this.nuclearSiteMarkers);
+    if (this.layers.irradiators) add('irradiators', this.irradiatorSiteMarkers);
+    if (this.layers.spaceports) add('spaceports', this.spaceportSiteMarkers);
     if (this.layers.military) {
-      markers.push(...this.flights);
-      markers.push(...this.vessels);
-      markers.push(...this.clusterMarkers);
+      add('military', this.flights);
+      // Carriers first: the AIS feed is the largest on the globe (1,526 markers
+      // measured on production) and is the one most likely to be trimmed.
+      add('military', this.vessels, { rank: m => (m._kind === 'vessel' && m.type === 'carrier' ? 1 : 0) });
+      add('military', this.clusterMarkers);
     }
-    if (this.layers.weather) markers.push(...this.weatherMarkers);
+    if (this.layers.weather) add('weather', this.weatherMarkers);
     if (this.layers.natural) {
-      markers.push(...this.naturalMarkers);
-      markers.push(...this.earthquakeMarkers);
+      add('natural', this.naturalMarkers);
+      add('natural', this.earthquakeMarkers, { rank: m => (m._kind === 'earthquake' ? m.magnitude : 0) });
     }
-    if (this.layers.radiationWatch) markers.push(...this.radiationMarkers);
-    if (this.layers.economic) markers.push(...this.economicMarkers);
-    if (this.layers.datacenters) markers.push(...this.datacenterMarkers);
-    if (this.layers.waterways) markers.push(...this.waterwayMarkers);
-    if (this.layers.minerals) markers.push(...this.mineralMarkers);
+    if (this.layers.radiationWatch) add('radiationWatch', this.radiationMarkers);
+    if (this.layers.economic) add('economic', this.economicMarkers);
+    if (this.layers.datacenters) add('datacenters', this.datacenterMarkers);
+    if (this.layers.waterways) add('waterways', this.waterwayMarkers);
+    if (this.layers.minerals) add('minerals', this.mineralMarkers);
     if (this.layers.flights) {
-      markers.push(...this.flightDelayMarkers);
-      markers.push(...this.notamRingMarkers);
+      add('flights', this.flightDelayMarkers);
+      add('flights', this.notamRingMarkers);
     }
-    if (this.layers.ais) markers.push(...this.aisMarkers);
-    if (this.layers.iranAttacks) markers.push(...this.iranMarkers);
+    if (this.layers.ais) add('ais', this.aisMarkers);
+    if (this.layers.iranAttacks) add('iranAttacks', this.iranMarkers);
     if (this.layers.outages) {
-      markers.push(...this.outageMarkers);
-      markers.push(...this.trafficAnomalyMarkers);
-      markers.push(...this.ddosMarkers);
+      add('outages', this.outageMarkers);
+      add('outages', this.trafficAnomalyMarkers);
+      add('outages', this.ddosMarkers);
     }
-    if (this.layers.cyberThreats) markers.push(...this.cyberMarkers);
-    if (this.layers.fires) markers.push(...this.fireMarkers);
-    if (this.layers.protests) markers.push(...this.protestMarkers);
-    if (this.layers.ucdpEvents) markers.push(...this.ucdpMarkers);
-    if (this.layers.displacement) markers.push(...this.displacementMarkers);
-    if (this.layers.climate) markers.push(...this.climateMarkers);
-    if (this.layers.gpsJamming) markers.push(...this.gpsJamMarkers);
+    if (this.layers.cyberThreats) add('cyberThreats', this.cyberMarkers);
+    if (this.layers.fires) add('fires', this.fireMarkers, { rank: m => (m._kind === 'fire' ? m.brightness : 0) });
+    if (this.layers.protests) add('protests', this.protestMarkers);
+    if (this.layers.ucdpEvents) add('ucdpEvents', this.ucdpMarkers, { rank: m => (m._kind === 'ucdp' ? m.deaths : 0) });
+    if (this.layers.displacement) add('displacement', this.displacementMarkers);
+    if (this.layers.climate) add('climate', this.climateMarkers);
+    if (this.layers.gpsJamming) add('gpsJamming', this.gpsJamMarkers);
     if (this.layers.satellites) {
-      markers.push(...this.satelliteMarkers);
-      markers.push(...this.satelliteFootprintMarkers);
-      markers.push(...this.imagerySceneMarkers);
+      add('satellites', this.satelliteMarkers);
+      add('satellites', this.satelliteFootprintMarkers);
+      add('satellites', this.imagerySceneMarkers);
     }
-    if (this.layers.techEvents) markers.push(...this.techMarkers);
+    if (this.layers.techEvents) add('techEvents', this.techMarkers);
     if (this.layers.cables) {
-      markers.push(...this.cableAdvisoryMarkers);
-      markers.push(...this.repairShipMarkers);
+      add('cables', this.cableAdvisoryMarkers);
+      add('cables', this.repairShipMarkers);
     }
-    if (this.layers.webcams) markers.push(...this.webcamMarkers);
-    markers.push(...this.newsLocationMarkers);
-    markers.push(...this.flashMarkers);
+    if (this.layers.webcams) add('webcams', this.webcamMarkers);
+    // Exempt like flash: `news` has no layer-toggle row, so a truncation here
+    // would have nowhere to be disclosed. It was ungated before this change too.
+    add('news', this.newsLocationMarkers, { exempt: true });
+    // Flash markers are the "jump to this location" affordance — dropping one
+    // would break navigation, and there are only ever a handful.
+    add('flash', this.flashMarkers, { exempt: true });
+
+    // Layers with no severity signal fall back to "nearest what the camera is
+    // looking at" rather than raw feed order — see proximityRank. Without this a
+    // capped nuclear layer would drop whichever sites sort last alphabetically.
+    const pov = this.globe.pointOfView();
+    const nearestFirst = proximityRank<GlobeMarker>(
+      { lat: pov?.lat ?? 0, lng: pov?.lng ?? 0 },
+      m => ({ lat: m._lat, lng: m._lng }),
+    );
+    for (const group of groups) {
+      if (!group.rank && !group.exempt) group.rank = nearestFirst;
+    }
+
+    const budget = isMobileDevice() ? GLOBE_MARKER_BUDGET_MOBILE : GLOBE_MARKER_BUDGET_DESKTOP;
+    const { markers, truncated } = selectGlobeMarkers(groups, budget);
+    this.markerTruncation = truncated;
+    this.renderedMarkerCount = markers.length;
+    this.updateLayerTruncationLabels();
+    setGlobeMarkerLoad({
+      rendered: markers.length,
+      truncated,
+      activeLayerCount: Object.values(this.layers).filter(Boolean).length,
+    });
 
     try {
       this.globe.htmlElementsData(markers);
@@ -2742,6 +2796,42 @@ export class GlobeMap {
 
   private layerWarningShown = false;
   private lastActiveLayerCount = 0;
+
+  /**
+   * Shows "shown/total" beside any layer the marker budget is trimming (#5368).
+   * This is a monitoring product: quietly dropping 2,000 conflict events off the
+   * globe would misrepresent the data, so the withholding is stated in the panel
+   * that controls it.
+   */
+  private updateLayerTruncationLabels(): void {
+    const root = this.layerTogglesEl;
+    if (!root) return;
+    for (const row of Array.from(root.querySelectorAll<HTMLElement>('.layer-toggle-row'))) {
+      const layer = row.getAttribute('data-layer');
+      const counts = layer ? this.markerTruncation[layer] : undefined;
+      const existing = row.querySelector<HTMLElement>('.layer-truncation-count');
+      if (!counts) { existing?.remove(); continue; }
+      const badge = existing ?? document.createElement('span');
+      if (!existing) {
+        badge.className = 'layer-truncation-count';
+        // Sibling of the <label>, not a child: inside it, every click on the
+        // badge would toggle the layer off. `.layer-explain-btn` sits outside
+        // the label for the same reason.
+        row.appendChild(badge);
+      }
+      badge.textContent = `${counts.shown}/${counts.total}`;
+      // Untranslated literal: a new i18n key is a ~29-file change across locales,
+      // and the badge itself is numeric. Real key tracked as follow-up.
+      // Says "nearest this view" rather than "highest priority" because that is
+      // what the ranking actually does for layers with no severity of their own.
+      badge.title = `Showing ${counts.shown} of ${counts.total} markers — the most significant, and those nearest the current view. The globe caps markers per layer to keep interaction responsive; rotate or zoom to bring others in.`;
+    }
+  }
+
+  /** Markers currently handed to globe.gl, and what the budget withheld (#5368). */
+  public getMarkerBudgetState(): { rendered: number; truncated: Record<string, GlobeLayerTruncation> } {
+    return { rendered: this.renderedMarkerCount, truncated: this.markerTruncation };
+  }
 
   private enforceLayerLimit(): void {
     if (!this.layerTogglesEl) return;
@@ -3736,6 +3826,8 @@ export class GlobeMap {
     this.unsubscribeGlobeTexture = null;
     this.unsubscribeVisualPreset?.();
     this.unsubscribeVisualPreset = null;
+    // Stop attributing INP events to a globe that is no longer mounted (#5368).
+    setGlobeMarkerLoad(null);
     if (this.visibilityHandler) {
       document.removeEventListener('visibilitychange', this.visibilityHandler);
       this.visibilityHandler = null;

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -567,6 +567,7 @@ export class GlobeMap {
   private markerTruncation: Record<string, GlobeLayerTruncation> = {};
   /** HTML markers handed to globe.gl on the last flush — the per-frame cost driver. */
   private renderedMarkerCount = 0;
+  private markerBudgetProfile: 'mobile' | 'desktop' = 'desktop';
   private webcamMarkerMode: string = (() => {
     try {
       return localStorage.getItem('wm-webcam-marker-mode') || 'icon';
@@ -713,6 +714,11 @@ export class GlobeMap {
     controls.enableDamping = !desktop;
 
     this.controlsEndHandler = () => {
+      // Truncated layers are ranked by nearness to the camera, so the visible
+      // subset is only correct for the POV it was computed at. Re-select when
+      // the camera settles — that is what makes "rotate or zoom to bring others
+      // in" true rather than a promise the badge cannot keep (#5368).
+      this.reselectMarkersForViewport();
       if (!this.layers.satellites) return;
       if (this.imageryFetchTimer) clearTimeout(this.imageryFetchTimer);
       this.imageryFetchTimer = setTimeout(() => this.fetchImageryForViewport(), 800);
@@ -2122,7 +2128,9 @@ export class GlobeMap {
     const add = (
       layer: string,
       markers: readonly GlobeMarker[],
-      extra: Partial<GlobeMarkerGroup<GlobeMarker>> = {},
+      // Only the tuning knobs — spreading a full Partial would let a caller
+      // silently overwrite the `layer`/`markers` this function just set.
+      extra: Pick<Partial<GlobeMarkerGroup<GlobeMarker>>, 'rank' | 'exempt'> = {},
     ): void => { if (markers.length) groups.push({ layer, markers, ...extra }); };
 
     if (this.layers.hotspots) add('hotspots', this.hotspots, { rank: m => (m._kind === 'hotspot' ? m.escalationScore : 0) });
@@ -2193,23 +2201,35 @@ export class GlobeMap {
       m => ({ lat: m._lat, lng: m._lng }),
     );
     for (const group of groups) {
-      if (!group.rank && !group.exempt) group.rank = nearestFirst;
+      if (group.exempt) continue;
+      // Unranked layers rank by nearness outright; ranked ones use it to break
+      // ties, because a coarse severity rank (carrier-or-not leaves ~1,500
+      // vessels on one score) would otherwise fall back to raw feed order.
+      if (group.rank) group.tieBreak = nearestFirst;
+      else group.rank = nearestFirst;
     }
 
     const budget = isMobileDevice() ? GLOBE_MARKER_BUDGET_MOBILE : GLOBE_MARKER_BUDGET_DESKTOP;
     const { markers, truncated } = selectGlobeMarkers(groups, budget);
+    try {
+      this.globe.htmlElementsData(markers);
+    } catch (err) {
+      // The globe kept its previous markers, so leave the badges and the probe
+      // describing what is actually on screen rather than what we intended.
+      if (import.meta.env.DEV) console.warn('[GlobeMap] flush error', err);
+      return;
+    }
+
     this.markerTruncation = truncated;
     this.renderedMarkerCount = markers.length;
+    this.markerBudgetProfile = budget === GLOBE_MARKER_BUDGET_MOBILE ? 'mobile' : 'desktop';
     this.updateLayerTruncationLabels();
     setGlobeMarkerLoad({
       rendered: markers.length,
       truncated,
       activeLayerCount: Object.values(this.layers).filter(Boolean).length,
+      budgetProfile: this.markerBudgetProfile,
     });
-
-    try {
-      this.globe.htmlElementsData(markers);
-    } catch (err) { if (import.meta.env.DEV) console.warn('[GlobeMap] flush error', err); }
   }
 
   private flushArcs(): void {
@@ -2828,6 +2848,19 @@ export class GlobeMap {
     }
   }
 
+  /**
+   * Re-run marker selection after the camera settles, so proximity-ranked
+   * layers follow the view (#5368).
+   *
+   * Only when something is actually being withheld: with nothing truncated the
+   * selection is view-independent and a re-flush would churn DOM for no visible
+   * change, on the very path this feature exists to make cheaper.
+   */
+  private reselectMarkersForViewport(): void {
+    if (!Object.keys(this.markerTruncation).length) return;
+    this.flushMarkers();
+  }
+
   /** Markers currently handed to globe.gl, and what the budget withheld (#5368). */
   public getMarkerBudgetState(): { rendered: number; truncated: Record<string, GlobeLayerTruncation> } {
     return { rendered: this.renderedMarkerCount, truncated: this.markerTruncation };
@@ -2876,6 +2909,9 @@ export class GlobeMap {
       else                altitude = 1.5;
     }
     this.globe.pointOfView({ lat: preset.lat, lng: preset.lng, altitude }, SET_CENTER_ROTATION_MS);
+    // Programmatic moves emit no controls 'end' event, so re-select once the
+    // transition has landed on the new POV.
+    setTimeout(() => this.reselectMarkersForViewport(), SET_CENTER_ROTATION_MS + 50);
   }
 
   public setCenter(lat: number, lon: number, zoom?: number): void {
@@ -2894,6 +2930,7 @@ export class GlobeMap {
       else                altitude = 1.5;
     }
     this.globe.pointOfView({ lat, lng: lon, altitude }, SET_CENTER_ROTATION_MS);
+    setTimeout(() => this.reselectMarkersForViewport(), SET_CENTER_ROTATION_MS + 50);
   }
 
   public getCenter(): { lat: number; lon: number } | null {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12451,6 +12451,23 @@ a.prediction-link:hover {
   vertical-align: middle;
 }
 
+/*
+ * "shown/total" for layers the globe's marker budget is trimming (#5368).
+ * Muted and right-aligned: it reports a limit, it is not a call to action.
+ */
+.layer-truncation-count {
+  margin-left: auto;
+  font-size: 8px;
+  font-variant-numeric: tabular-nums;
+  /* Theme token, not a hardcoded white: the layer panel is theme-aware and the
+     light theme's --bg is near-white, which would hide a white badge. */
+  color: var(--text-dim);
+  white-space: nowrap;
+  /* Reports a limit; it is not a control. */
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
 /* -- Locked panel: hide count badge + extra chrome -- */
 .panel-is-locked .panel-count,
 .panel-is-locked .panel-data-badge,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12463,8 +12463,10 @@ a.prediction-link:hover {
      light theme's --bg is near-white, which would hide a white badge. */
   color: var(--text-dim);
   white-space: nowrap;
-  /* Reports a limit; it is not a control. */
-  pointer-events: none;
+  /* Hoverable on purpose: the full disclosure lives in the element's `title`,
+     and `pointer-events: none` would suppress the tooltip. Safe to hover and
+     click because the badge is a SIBLING of the <label>, not inside it. */
+  cursor: help;
   flex-shrink: 0;
 }
 

--- a/src/utils/globe-marker-budget.ts
+++ b/src/utils/globe-marker-budget.ts
@@ -36,6 +36,16 @@ export interface GlobeMarkerGroup<T> {
    */
   rank?: (marker: T) => number;
   /**
+   * Breaks ties within an equal `rank`, before source order does.
+   *
+   * A severity rank is usually coarse — `carrier ? 1 : 0` leaves ~1,500 vessels
+   * on the same score — and without a tie-break the cut among them falls back to
+   * feed order, which is the arbitrary-selection problem `proximityRank` exists
+   * to avoid. Pass `proximityRank` here so severity decides first and nearness
+   * decides the rest. Compared lexicographically, so no weighting to tune.
+   */
+  tieBreak?: (marker: T) => number;
+  /**
    * Ephemeral or navigational markers that must always render (e.g. the
    * flash-to-location pin). Exempt groups bypass the budget entirely; keep them
    * to a handful of markers.
@@ -124,22 +134,31 @@ export function proximityRank<T>(focus: LatLng, position: (marker: T) => LatLng)
   };
 }
 
-/** Top `cap` markers by rank, preserving the group's original relative order. */
-function takeTop<T>(markers: readonly T[], cap: number, rank?: (marker: T) => number): T[] {
+/** Top `cap` markers by rank then tie-break, preserving the group's own order. */
+function takeTop<T>(
+  markers: readonly T[],
+  cap: number,
+  rank?: (marker: T) => number,
+  tieBreak?: (marker: T) => number,
+): T[] {
   if (markers.length <= cap) return markers.slice();
   // No rank means the caller has no opinion, so the cut falls wherever the feed
   // happened to order things. Callers rendering anything a user might depend on
   // should pass a rank (severity, or `proximityRank`) rather than accept this.
   if (!rank) return markers.slice(0, cap);
-  // Rank descending, original index ascending, so equal-rank markers stay stable.
   // A non-finite score sorts last rather than poisoning the comparator with NaN.
-  const score = (marker: T): number => {
-    const value = rank(marker);
-    return Number.isFinite(value) ? value : -Infinity;
-  };
+  const finite = (value: number): number => (Number.isFinite(value) ? value : -Infinity);
+  // Rank desc, then tie-break desc, then original index asc — compared in order
+  // rather than summed, so a coarse rank never has to be weighted against a fine
+  // tie-break (magnitude 5.1 vs 5.2 stays decisive; equal scores fall to nearness).
   const keep = markers
-    .map((marker, index) => ({ marker, index, score: score(marker) }))
-    .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+    .map((marker, index) => ({
+      marker,
+      index,
+      score: finite(rank(marker)),
+      tie: tieBreak ? finite(tieBreak(marker)) : 0,
+    }))
+    .sort((a, b) => (b.score - a.score) || (b.tie - a.tie) || (a.index - b.index))
     .slice(0, cap)
     .sort((a, b) => a.index - b.index);
   return keep.map(entry => entry.marker);
@@ -168,7 +187,7 @@ export function selectGlobeMarkers<T>(
   const perLayer = new Map<string, GlobeLayerTruncation>();
 
   for (const group of budgeted) {
-    const kept = takeTop(group.markers, cap, group.rank);
+    const kept = takeTop(group.markers, cap, group.rank, group.tieBreak);
     const running = perLayer.get(group.layer) ?? { shown: 0, total: 0 };
     running.shown += kept.length;
     running.total += group.markers.length;

--- a/src/utils/globe-marker-budget.ts
+++ b/src/utils/globe-marker-budget.ts
@@ -1,0 +1,188 @@
+/**
+ * Bounds how many HTML markers the 3D globe renders at once (#5368).
+ *
+ * globe.gl renders `htmlElementsData` through three's CSS2DRenderer, which walks
+ * EVERY marker on EVERY animation frame and rewrites `display`, `transform` and
+ * `zIndex` on each one — unconditionally, even with a still camera — then runs a
+ * whole-scene `traverseVisible` plus an O(n log n) depth sort
+ * (three/examples/jsm/renderers/CSS2DRenderer.js:214-310, driven from
+ * globe.gl's `_animationCycle`). Frame cost is therefore linear in marker count
+ * and lands squarely in the interaction frame budget, which is what INP measures.
+ *
+ * Measured on production 2026-07-18: the desktop default view carries 2,319
+ * markers, 1,526 of them live AIS vessels arriving over a websocket with no
+ * ceiling of their own; opting into Armed Conflict Events adds a further 2,000.
+ * Nothing upstream bounds these, so the ceiling belongs here.
+ *
+ * This module is deliberately free of DOM and three.js imports so the real
+ * selection function can be unit-tested directly against real payload shapes.
+ */
+
+/** A single layer's contribution to the globe, before budgeting. */
+export interface GlobeMarkerGroup<T> {
+  /**
+   * Layer toggle key this group belongs to. Several groups may share one key —
+   * `military` alone contributes flights, vessels and clusters — in which case
+   * each is budgeted independently (they are separate feeds with unrelated
+   * volumes) but their truncation is reported against the one toggle.
+   */
+  layer: string;
+  markers: readonly T[];
+  /**
+   * Higher = more important = kept when the group must be trimmed. Layers with a
+   * severity signal (deaths, magnitude, brightness) pass it here; the rest get
+   * `proximityRank` so the cut is view-relative. Omitting it entirely falls back
+   * to raw feed order — see the warning in `takeTop`.
+   */
+  rank?: (marker: T) => number;
+  /**
+   * Ephemeral or navigational markers that must always render (e.g. the
+   * flash-to-location pin). Exempt groups bypass the budget entirely; keep them
+   * to a handful of markers.
+   */
+  exempt?: boolean;
+}
+
+export interface GlobeMarkerBudget {
+  /**
+   * Ceiling per GROUP, not per layer key. A layer that supplies several feeds
+   * (`military` = flights + vessels + clusters) is budgeted once per feed, so
+   * its rendered total can reach this many times its feed count — bounded, as
+   * always, by `total`.
+   */
+  perLayer: number;
+  /** Ceiling across all non-exempt layers combined. */
+  total: number;
+}
+
+export interface GlobeLayerTruncation {
+  shown: number;
+  total: number;
+}
+
+export interface GlobeMarkerSelection<T> {
+  markers: T[];
+  /** Only layers that actually lost markers appear here. */
+  truncated: Record<string, GlobeLayerTruncation>;
+}
+
+/**
+ * Mobile keeps the default view (~120 markers on production today) untouched and
+ * only bites when a user stacks heavy layers onto a phone.
+ */
+export const GLOBE_MARKER_BUDGET_MOBILE: GlobeMarkerBudget = { perLayer: 150, total: 400 };
+
+/** Desktop's default view is 2,319 markers today, so this cuts it ~2.9x. */
+export const GLOBE_MARKER_BUDGET_DESKTOP: GlobeMarkerBudget = { perLayer: 300, total: 800 };
+
+/**
+ * Largest per-group cap `c <= max` for which `sum(min(len_i, c)) <= total`.
+ *
+ * Trimming the biggest groups first (max-min fairness) rather than trimming
+ * every group proportionally keeps small layers whole: one 1,526-marker vessel
+ * feed must not evict an 11-marker weather layer.
+ */
+function fairShareCap(sizes: readonly number[], total: number, max: number): number {
+  const used = (cap: number): number => sizes.reduce((sum, n) => sum + Math.min(n, cap), 0);
+  if (used(max) <= total) return max;
+  let lo = 0;
+  let hi = max;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (used(mid) <= total) lo = mid; else hi = mid - 1;
+  }
+  return lo;
+}
+
+export interface LatLng { lat: number; lng: number }
+
+/**
+ * Ranks markers by nearness to the point the camera is looking at.
+ *
+ * This is the default for layers with no severity signal of their own, and it
+ * exists because the obvious alternative is indefensible: trimming a static
+ * reference layer by raw array order means an alphabetically-ordered facility
+ * list quietly loses whatever sits past the cut — on the nuclear layer that is
+ * Zaporizhzhia. Nearness makes the trim view-relative instead of arbitrary, so
+ * a user always sees the sites in the region they are actually looking at and
+ * the rest arrive as they rotate or zoom toward them.
+ *
+ * The score is the cosine of the central angle (higher = nearer), which orders
+ * identically to great-circle distance without the `acos`.
+ */
+export function proximityRank<T>(focus: LatLng, position: (marker: T) => LatLng): (marker: T) => number {
+  const rad = Math.PI / 180;
+  const focusLat = focus.lat * rad;
+  const sinFocusLat = Math.sin(focusLat);
+  const cosFocusLat = Math.cos(focusLat);
+  return (marker) => {
+    const { lat, lng } = position(marker);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return -Infinity;
+    const markerLat = lat * rad;
+    return sinFocusLat * Math.sin(markerLat)
+      + cosFocusLat * Math.cos(markerLat) * Math.cos((lng - focus.lng) * rad);
+  };
+}
+
+/** Top `cap` markers by rank, preserving the group's original relative order. */
+function takeTop<T>(markers: readonly T[], cap: number, rank?: (marker: T) => number): T[] {
+  if (markers.length <= cap) return markers.slice();
+  // No rank means the caller has no opinion, so the cut falls wherever the feed
+  // happened to order things. Callers rendering anything a user might depend on
+  // should pass a rank (severity, or `proximityRank`) rather than accept this.
+  if (!rank) return markers.slice(0, cap);
+  // Rank descending, original index ascending, so equal-rank markers stay stable.
+  // A non-finite score sorts last rather than poisoning the comparator with NaN.
+  const score = (marker: T): number => {
+    const value = rank(marker);
+    return Number.isFinite(value) ? value : -Infinity;
+  };
+  const keep = markers
+    .map((marker, index) => ({ marker, index, score: score(marker) }))
+    .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+    .slice(0, cap)
+    .sort((a, b) => a.index - b.index);
+  return keep.map(entry => entry.marker);
+}
+
+/**
+ * Applies the per-layer cap, then the global ceiling, returning the markers to
+ * render plus a report of what was withheld so the UI can disclose it.
+ */
+export function selectGlobeMarkers<T>(
+  groups: readonly GlobeMarkerGroup<T>[],
+  budget: GlobeMarkerBudget,
+): GlobeMarkerSelection<T> {
+  const exempt = groups.filter(group => group.exempt);
+  const budgeted = groups.filter(group => !group.exempt && group.markers.length > 0);
+
+  const cap = fairShareCap(
+    budgeted.map(group => group.markers.length),
+    budget.total,
+    budget.perLayer,
+  );
+
+  const markers: T[] = [];
+  // Totalled across every group sharing a layer key, so a layer whose vessel
+  // feed is trimmed still reports its untrimmed flights in the same figure.
+  const perLayer = new Map<string, GlobeLayerTruncation>();
+
+  for (const group of budgeted) {
+    const kept = takeTop(group.markers, cap, group.rank);
+    const running = perLayer.get(group.layer) ?? { shown: 0, total: 0 };
+    running.shown += kept.length;
+    running.total += group.markers.length;
+    perLayer.set(group.layer, running);
+    markers.push(...kept);
+  }
+  for (const group of exempt) {
+    markers.push(...group.markers);
+  }
+
+  const truncated: Record<string, GlobeLayerTruncation> = {};
+  for (const [layer, counts] of perLayer) {
+    if (counts.shown < counts.total) truncated[layer] = counts;
+  }
+
+  return { markers, truncated };
+}

--- a/tests/globe-marker-budget.test.mts
+++ b/tests/globe-marker-budget.test.mts
@@ -1,0 +1,303 @@
+/**
+ * #5368 — the globe's HTML marker ceiling.
+ *
+ * These call the REAL `selectGlobeMarkers` (the function GlobeMap.flushMarkersImmediate
+ * uses), and the headline cases feed it the marker counts a production census
+ * actually measured on 2026-07-18 rather than counts invented here.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  GLOBE_MARKER_BUDGET_DESKTOP,
+  GLOBE_MARKER_BUDGET_MOBILE,
+  proximityRank,
+  selectGlobeMarkers,
+  type GlobeMarkerGroup,
+} from '../src/utils/globe-marker-budget.ts';
+
+/**
+ * Marker counts measured on www.worldmonitor.app/dashboard in globe mode,
+ * 2026-07-18. The DOM total at the moment of the census was 2,319; these
+ * per-feed figures sum to 2,318 because the AIS vessel feed was still arriving
+ * over its websocket while the layers were being counted. Treated as a band,
+ * not a fixed point — the live feeds move.
+ */
+const PROD_DESKTOP_CENSUS: Record<string, number> = {
+  hotspots: 29,
+  conflicts: 10,
+  bases: 225,
+  nuclear: 250,
+  'military:flights': 32,
+  'military:vessels': 1526,
+  'military:clusters': 11,
+  weather: 11,
+  'natural:events': 8,
+  'natural:earthquakes': 123,
+  economic: 41,
+  waterways: 13,
+  'outages:outages': 9,
+  'outages:traffic': 8,
+  news: 22,
+};
+
+/** Same session with the Armed Conflict Events layer opted in. */
+const PROD_UCDP_COUNT = 2000;
+
+/**
+ * Mobile first-load defaults (MOBILE_DEFAULT_MAP_LAYERS): 122 HTML markers total,
+ * measured on an iPhone 14 Pro viewport against production. Per-feed figures are
+ * the measured ones above (the same feeds); `natural` carries the measured
+ * remainder, since that layer's split was not separately counted on mobile.
+ */
+const PROD_MOBILE_TOTAL = 122;
+const PROD_MOBILE_CENSUS: Record<string, number> = {
+  hotspots: 29,
+  conflicts: 10,
+  weather: 11,
+  'outages:outages': 9,
+  'outages:traffic': 8,
+  news: 22,
+  natural: 33,
+};
+
+interface Dot { id: string; severity: number; }
+
+function group(layer: string, count: number, opts: Partial<GlobeMarkerGroup<Dot>> = {}): GlobeMarkerGroup<Dot> {
+  return {
+    layer: layer.split(':')[0],
+    markers: Array.from({ length: count }, (_, i) => ({ id: `${layer}-${i}`, severity: i })),
+    ...opts,
+  };
+}
+
+const censusGroups = (census: Record<string, number>): GlobeMarkerGroup<Dot>[] =>
+  Object.entries(census).map(([layer, count]) => group(layer, count));
+
+const total = (census: Record<string, number>): number =>
+  Object.values(census).reduce((a, b) => a + b, 0);
+
+describe('selectGlobeMarkers — production census (#5368)', () => {
+  it('cuts the real 2,319-marker desktop default view under the desktop budget', () => {
+    const measured = total(PROD_DESKTOP_CENSUS);
+    assert.ok(measured >= 2300 && measured <= 2350, `census drifted out of the measured band: ${measured}`);
+
+    const { markers, truncated } = selectGlobeMarkers(
+      censusGroups(PROD_DESKTOP_CENSUS),
+      GLOBE_MARKER_BUDGET_DESKTOP,
+    );
+
+    assert.ok(
+      markers.length <= GLOBE_MARKER_BUDGET_DESKTOP.total,
+      `rendered ${markers.length} markers, budget is ${GLOBE_MARKER_BUDGET_DESKTOP.total}`,
+    );
+    assert.ok(markers.length < 2319, 'the budget must actually bite on the production payload');
+    assert.ok(truncated.military, 'the 1,526-marker vessel feed must be reported as truncated');
+  });
+
+  it('trims the biggest feed rather than starving small layers', () => {
+    const { markers } = selectGlobeMarkers(
+      censusGroups(PROD_DESKTOP_CENSUS),
+      GLOBE_MARKER_BUDGET_DESKTOP,
+    );
+    const kept = (prefix: string): number => markers.filter(m => m.id.startsWith(prefix)).length;
+
+    // Every layer smaller than the fair-share cap survives whole, even though
+    // one feed on its own is larger than the entire budget.
+    assert.equal(kept('weather'), 11);
+    assert.equal(kept('conflicts'), 10);
+    assert.equal(kept('waterways'), 13);
+    assert.equal(kept('news'), 22);
+    assert.ok(kept('military:vessels') < 1526, 'the vessel feed is the one that must give way');
+  });
+
+  it('bounds the opt-in Armed Conflict Events view (4,319 markers on production)', () => {
+    const groups = [...censusGroups(PROD_DESKTOP_CENSUS), group('ucdpEvents', PROD_UCDP_COUNT)];
+    const measured = groups.reduce((n, g) => n + g.markers.length, 0);
+    assert.ok(measured >= 4300 && measured <= 4350, `census drifted out of the measured band: ${measured}`);
+
+    const { markers, truncated } = selectGlobeMarkers(groups, GLOBE_MARKER_BUDGET_DESKTOP);
+
+    assert.ok(markers.length <= GLOBE_MARKER_BUDGET_DESKTOP.total);
+    assert.equal(truncated.ucdpEvents.total, 2000);
+    assert.ok(truncated.ucdpEvents.shown < 2000);
+  });
+
+  it('leaves the real mobile default view untouched — it is already small', () => {
+    assert.equal(total(PROD_MOBILE_CENSUS), PROD_MOBILE_TOTAL, 'census drifted from the measured mobile total');
+
+    const { markers, truncated } = selectGlobeMarkers(
+      censusGroups(PROD_MOBILE_CENSUS),
+      GLOBE_MARKER_BUDGET_MOBILE,
+    );
+
+    assert.equal(markers.length, PROD_MOBILE_TOTAL, 'the mobile default view must not lose markers');
+    assert.deepEqual(truncated, {}, 'nothing should be reported as truncated');
+  });
+
+  it('bites on mobile only once a heavy layer is stacked on', () => {
+    const groups = [...censusGroups(PROD_MOBILE_CENSUS), group('military:vessels', 1526)];
+    const { markers, truncated } = selectGlobeMarkers(groups, GLOBE_MARKER_BUDGET_MOBILE);
+
+    assert.ok(markers.length <= GLOBE_MARKER_BUDGET_MOBILE.total);
+    assert.ok(truncated.military.total === 1526);
+  });
+});
+
+describe('selectGlobeMarkers — invariants', () => {
+  const budget = { perLayer: 50, total: 120 };
+
+  it('never exceeds either ceiling, for any group shape', () => {
+    const shapes: number[][] = [
+      [1000], [1000, 1000, 1000], [5, 5, 5], [200, 3, 3, 3], [49, 51, 50, 2], [0, 0, 1000], [],
+    ];
+    for (const shape of shapes) {
+      const groups = shape.map((n, i) => group(`L${i}`, n));
+      const { markers } = selectGlobeMarkers(groups, budget);
+      assert.ok(markers.length <= budget.total, `total exceeded for shape ${JSON.stringify(shape)}`);
+      for (let i = 0; i < shape.length; i++) {
+        const kept = markers.filter(m => m.id.startsWith(`L${i}-`)).length;
+        assert.ok(kept <= budget.perLayer, `perLayer exceeded for L${i} in ${JSON.stringify(shape)}`);
+      }
+    }
+  });
+
+  it('invents no markers and preserves each layer order', () => {
+    const groups = [group('a', 200), group('b', 10)];
+    const { markers } = selectGlobeMarkers(groups, budget);
+    const ids = markers.map(m => m.id);
+    assert.equal(new Set(ids).size, ids.length, 'no duplicates');
+
+    const aIdx = markers.filter(m => m.id.startsWith('a-')).map(m => Number(m.id.slice(2)));
+    assert.deepEqual(aIdx, [...aIdx].sort((x, y) => x - y), 'kept markers stay in source order');
+  });
+
+  it('keeps the highest-ranked markers when a rank is supplied', () => {
+    const markers = Array.from({ length: 300 }, (_, i) => ({ id: `q-${i}`, severity: i }));
+    const { markers: kept } = selectGlobeMarkers(
+      [{ layer: 'quakes', markers, rank: m => m.severity }],
+      { perLayer: 10, total: 10 },
+    );
+    assert.deepEqual(
+      kept.map(m => m.severity),
+      [290, 291, 292, 293, 294, 295, 296, 297, 298, 299],
+      'the ten most severe survive, still in source order',
+    );
+  });
+
+  it('exempts ephemeral markers from the budget', () => {
+    const { markers } = selectGlobeMarkers(
+      [group('bulk', 1000), { ...group('flash', 3), exempt: true }],
+      budget,
+    );
+    assert.equal(markers.filter(m => m.id.startsWith('flash-')).length, 3, 'flash markers always render');
+  });
+
+  it('reports a layer total across all of its feeds', () => {
+    // `military` is three separate feeds behind one toggle.
+    const groups = [group('military:flights', 32), group('military:vessels', 1526), group('military:clusters', 11)];
+    const { truncated } = selectGlobeMarkers(groups, budget);
+    assert.equal(truncated.military.total, 32 + 1526 + 11);
+  });
+});
+
+
+// ========================================================================
+// Proximity ranking — the answer to "which markers survive the cut?" for
+// layers with no severity of their own. Ranking these by raw array order
+// silently drops whatever sorts last: on the alphabetical nuclear facility
+// list that is Zaporizhzhia.
+// ========================================================================
+
+describe('proximityRank (#5368)', () => {
+  const KYIV = { lat: 50.45, lng: 30.52 };
+  const sites = [
+    { id: 'sydney', lat: -33.87, lng: 151.21 },
+    { id: 'zaporizhzhia', lat: 47.51, lng: 34.59 },
+    { id: 'santiago', lat: -33.45, lng: -70.67 },
+    { id: 'chornobyl', lat: 51.39, lng: 30.10 },
+  ];
+  const rank = proximityRank<typeof sites[number]>(KYIV, s => ({ lat: s.lat, lng: s.lng }));
+
+  it('scores nearer markers above far ones', () => {
+    const byScore = [...sites].sort((a, b) => rank(b) - rank(a)).map(s => s.id);
+    assert.deepEqual(byScore, ['chornobyl', 'zaporizhzhia', 'santiago', 'sydney']);
+  });
+
+  it('keeps the sites near the view when a layer is capped', () => {
+    const { markers } = selectGlobeMarkers(
+      [{ layer: 'nuclear', markers: sites, rank }],
+      { perLayer: 2, total: 2 },
+    );
+    assert.deepEqual(
+      markers.map(m => m.id).sort(),
+      ['chornobyl', 'zaporizhzhia'],
+      'the two Ukrainian sites must survive a cap applied while looking at Ukraine',
+    );
+  });
+
+  it('is view-relative: the same cap keeps different sites from another vantage', () => {
+    const fromSantiago = proximityRank<typeof sites[number]>(
+      { lat: -33.45, lng: -70.67 }, s => ({ lat: s.lat, lng: s.lng }),
+    );
+    const { markers } = selectGlobeMarkers(
+      [{ layer: 'nuclear', markers: sites, rank: fromSantiago }],
+      { perLayer: 1, total: 1 },
+    );
+    assert.deepEqual(markers.map(m => m.id), ['santiago']);
+  });
+
+  it('sorts markers with unusable coordinates last instead of poisoning the sort', () => {
+    const withBad = [
+      { id: 'bad', lat: Number.NaN, lng: 0 },
+      { id: 'chornobyl', lat: 51.39, lng: 30.10 },
+      { id: 'sydney', lat: -33.87, lng: 151.21 },
+    ];
+    const r = proximityRank<typeof withBad[number]>(KYIV, s => ({ lat: s.lat, lng: s.lng }));
+    const { markers } = selectGlobeMarkers(
+      [{ layer: 'nuclear', markers: withBad, rank: r }],
+      { perLayer: 2, total: 2 },
+    );
+    assert.deepEqual(markers.map(m => m.id), ['chornobyl', 'sydney']);
+  });
+});
+
+describe('selectGlobeMarkers — multi-feed layers and bad ranks', () => {
+  it('budgets each feed of a shared layer key independently', () => {
+    // `military` is flights + vessels + clusters behind one toggle.
+    const groups = [
+      { layer: 'military', markers: Array.from({ length: 32 }, (_, i) => ({ id: `f-${i}` })) },
+      { layer: 'military', markers: Array.from({ length: 1526 }, (_, i) => ({ id: `v-${i}` })) },
+      { layer: 'military', markers: Array.from({ length: 11 }, (_, i) => ({ id: `c-${i}` })) },
+    ];
+    const { markers, truncated } = selectGlobeMarkers(groups, { perLayer: 50, total: 200 });
+
+    assert.ok(markers.length <= 200, 'the global ceiling still holds');
+    assert.equal(markers.filter(m => m.id.startsWith('f-')).length, 32, 'small feeds survive whole');
+    assert.equal(markers.filter(m => m.id.startsWith('c-')).length, 11);
+    assert.ok(markers.filter(m => m.id.startsWith('v-')).length <= 50, 'each feed obeys perLayer');
+    assert.equal(truncated.military.total, 32 + 1526 + 11, 'the layer reports all of its feeds');
+  });
+
+  it('does not drop markers when a rank returns NaN for every one of them', () => {
+    const markers = Array.from({ length: 10 }, (_, i) => ({ id: `n-${i}` }));
+    const { markers: kept } = selectGlobeMarkers(
+      [{ layer: 'x', markers, rank: () => Number.NaN }],
+      { perLayer: 4, total: 4 },
+    );
+    assert.equal(kept.length, 4, 'a useless rank must still yield a full, stable selection');
+    assert.deepEqual(kept.map(m => m.id), ['n-0', 'n-1', 'n-2', 'n-3']);
+  });
+
+  it('handles a zero budget and an all-exempt input', () => {
+    const zero = selectGlobeMarkers([{ layer: 'a', markers: [{ id: 'x' }] }], { perLayer: 0, total: 0 });
+    assert.deepEqual(zero.markers, []);
+    assert.equal(zero.truncated.a.shown, 0);
+
+    const allExempt = selectGlobeMarkers(
+      [{ layer: 'flash', markers: [{ id: 'f1' }, { id: 'f2' }], exempt: true }],
+      { perLayer: 0, total: 0 },
+    );
+    assert.equal(allExempt.markers.length, 2, 'exempt groups render regardless of budget');
+    assert.deepEqual(allExempt.truncated, {});
+  });
+});

--- a/tests/globe-marker-budget.test.mts
+++ b/tests/globe-marker-budget.test.mts
@@ -301,3 +301,44 @@ describe('selectGlobeMarkers — multi-feed layers and bad ranks', () => {
     assert.deepEqual(allExempt.truncated, {});
   });
 });
+
+describe('selectGlobeMarkers — tie-break (#5368)', () => {
+  // A carrier-or-not rank leaves ~1,500 vessels on one score. Without a
+  // tie-break the cut among them falls to feed order — the same arbitrary
+  // selection proximity ranking exists to prevent.
+  const vessels = [
+    { id: 'tug-far', carrier: 0, near: -0.9 },
+    { id: 'tug-near', carrier: 0, near: 0.9 },
+    { id: 'carrier-far', carrier: 1, near: -0.8 },
+    { id: 'frigate-mid', carrier: 0, near: 0.1 },
+  ];
+
+  it('lets severity decide first and nearness decide the rest', () => {
+    const { markers } = selectGlobeMarkers(
+      [{ layer: 'military', markers: vessels, rank: v => v.carrier, tieBreak: v => v.near }],
+      { perLayer: 2, total: 2 },
+    );
+    assert.deepEqual(
+      markers.map(m => m.id).sort(),
+      ['carrier-far', 'tug-near'],
+      'the carrier survives on severity; the remaining slot goes to the nearest, not the first',
+    );
+  });
+
+  it('does not let the tie-break override a real rank difference', () => {
+    const { markers } = selectGlobeMarkers(
+      [{ layer: 'q', markers: [{ id: 'm5.2-far', mag: 5.2, near: -1 }, { id: 'm5.1-near', mag: 5.1, near: 1 }],
+         rank: q => q.mag, tieBreak: q => q.near }],
+      { perLayer: 1, total: 1 },
+    );
+    assert.deepEqual(markers.map(m => m.id), ['m5.2-far'], 'a 0.1 magnitude gap still outranks nearness');
+  });
+
+  it('falls back to source order when no tie-break is supplied', () => {
+    const { markers } = selectGlobeMarkers(
+      [{ layer: 'military', markers: vessels, rank: v => v.carrier }],
+      { perLayer: 2, total: 2 },
+    );
+    assert.deepEqual(markers.map(m => m.id).sort(), ['carrier-far', 'tug-far']);
+  });
+});

--- a/tests/globe-marker-probe.test.mts
+++ b/tests/globe-marker-probe.test.mts
@@ -24,7 +24,7 @@ describe('globe marker probe (#5368)', () => {
   });
 
   it('reports nothing again once the globe unmounts', () => {
-    setGlobeMarkerLoad({ rendered: 800, truncated: {}, activeLayerCount: 9 });
+    setGlobeMarkerLoad({ rendered: 800, truncated: {}, activeLayerCount: 9, budgetProfile: 'desktop' });
     assert.ok(getGlobeMarkerExtra());
     setGlobeMarkerLoad(null);
     assert.equal(getGlobeMarkerExtra(), null, 'a destroyed globe must stop attributing INP events');
@@ -35,23 +35,35 @@ describe('globe marker probe (#5368)', () => {
       rendered: 800,
       truncated: { military: { shown: 300, total: 1526 }, ucdpEvents: { shown: 300, total: 2000 } },
       activeLayerCount: 11,
+      budgetProfile: 'desktop',
     });
     assert.deepEqual(getGlobeMarkerExtra(), {
       globeMarkers: 800,
       globeMarkerBucket: '501-1000',
       globeActiveLayerCount: 11,
       globeTruncated: ['military:300/1526', 'ucdpEvents:300/2000'],
+      globeBudgetProfile: 'desktop',
     });
   });
 
   it('does not send a device fingerprint or the user\'s layer-interest vector', () => {
-    setGlobeMarkerLoad({ rendered: 2319, truncated: {}, activeLayerCount: 9 });
+    setGlobeMarkerLoad({ rendered: 2319, truncated: {}, activeLayerCount: 9, budgetProfile: 'desktop' });
     const extra = getGlobeMarkerExtra()!;
     for (const banned of ['deviceMemory', 'hardwareConcurrency', 'viewport', 'activeLayers']) {
       assert.ok(!(banned in extra), `${banned} must not ride a perf probe`);
     }
     // The layer COUNT is fine; the list of which layers a user watches is not.
     assert.equal(extra.globeActiveLayerCount, 9);
+  });
+
+  it('reports which budget ran, since it does not track the INP formFactor', () => {
+    // A 900px tablet is `formFactor: mobile` on the parent INP event but runs
+    // the DESKTOP budget (the split is the app's 768px layout breakpoint).
+    // Without this field the RUM join would silently mis-attribute it.
+    setGlobeMarkerLoad({ rendered: 700, truncated: {}, activeLayerCount: 9, budgetProfile: 'desktop' });
+    assert.equal(getGlobeMarkerExtra()!.globeBudgetProfile, 'desktop');
+    setGlobeMarkerLoad({ rendered: 120, truncated: {}, activeLayerCount: 6, budgetProfile: 'mobile' });
+    assert.equal(getGlobeMarkerExtra()!.globeBudgetProfile, 'mobile');
   });
 
   it('buckets the counts the census actually produces', () => {

--- a/tests/globe-marker-probe.test.mts
+++ b/tests/globe-marker-probe.test.mts
@@ -1,0 +1,65 @@
+/**
+ * #5368 — the globe marker load that rides field INP reports.
+ *
+ * Two things matter here and both are behavioural: the probe must be SILENT
+ * when the globe is not mounted (the flat map is the default, so most reports
+ * must carry nothing), and it must not smuggle a device fingerprint into
+ * telemetry that only needs a marker count.
+ */
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  bucketMarkerCount,
+  getGlobeMarkerExtra,
+  resetGlobeMarkerLoadForTesting,
+  setGlobeMarkerLoad,
+} from '../src/bootstrap/globe-marker-probe.ts';
+
+beforeEach(() => resetGlobeMarkerLoadForTesting());
+
+describe('globe marker probe (#5368)', () => {
+  it('reports nothing until a globe publishes a load', () => {
+    assert.equal(getGlobeMarkerExtra(), null);
+  });
+
+  it('reports nothing again once the globe unmounts', () => {
+    setGlobeMarkerLoad({ rendered: 800, truncated: {}, activeLayerCount: 9 });
+    assert.ok(getGlobeMarkerExtra());
+    setGlobeMarkerLoad(null);
+    assert.equal(getGlobeMarkerExtra(), null, 'a destroyed globe must stop attributing INP events');
+  });
+
+  it('carries the marker count, its bucket and the truncated layers', () => {
+    setGlobeMarkerLoad({
+      rendered: 800,
+      truncated: { military: { shown: 300, total: 1526 }, ucdpEvents: { shown: 300, total: 2000 } },
+      activeLayerCount: 11,
+    });
+    assert.deepEqual(getGlobeMarkerExtra(), {
+      globeMarkers: 800,
+      globeMarkerBucket: '501-1000',
+      globeActiveLayerCount: 11,
+      globeTruncated: ['military:300/1526', 'ucdpEvents:300/2000'],
+    });
+  });
+
+  it('does not send a device fingerprint or the user\'s layer-interest vector', () => {
+    setGlobeMarkerLoad({ rendered: 2319, truncated: {}, activeLayerCount: 9 });
+    const extra = getGlobeMarkerExtra()!;
+    for (const banned of ['deviceMemory', 'hardwareConcurrency', 'viewport', 'activeLayers']) {
+      assert.ok(!(banned in extra), `${banned} must not ride a perf probe`);
+    }
+    // The layer COUNT is fine; the list of which layers a user watches is not.
+    assert.equal(extra.globeActiveLayerCount, 9);
+  });
+
+  it('buckets the counts the census actually produces', () => {
+    assert.equal(bucketMarkerCount(122), '0-200', 'mobile default view');
+    assert.equal(bucketMarkerCount(200), '0-200');
+    assert.equal(bucketMarkerCount(201), '201-500');
+    assert.equal(bucketMarkerCount(800), '501-1000', 'desktop budget ceiling');
+    assert.equal(bucketMarkerCount(2319), '2000+', 'desktop default view before this fix');
+    assert.equal(bucketMarkerCount(4319), '2000+', 'with Armed Conflict Events on');
+  });
+});

--- a/tests/inp-report.test.mts
+++ b/tests/inp-report.test.mts
@@ -117,3 +117,44 @@ test('reportInpMetric tags the configured sampleRate for reweighting', () => {
   const { ctx } = capture({ value: 350, rating: 'needs-improvement' });
   assert.equal(ctx.tags.sampleRate, '0.2', 'sampleRate tag lets analysis rescale to true field volume');
 });
+
+// ── Globe marker load (#5368) ───────────────────────────────────────────────
+// The globe's DOM marker count is the dominant term in its frame cost, and
+// therefore in presentationDelay. Riding the existing INP event is what lets
+// the field settle a question the lab could not: a lab census measured ~120
+// markers in the mobile default view, yet mobile INP regressed hardest.
+
+function captureWithGlobe(
+  metric: InpMetricLike,
+  globeExtra: () => Record<string, unknown> | null,
+): { msg: string; ctx: any } {
+  let out: { msg: string; ctx: any } | null = null;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportInpMetric(metric, fakeEnqueue, () => true, globeExtra);
+  assert.ok(out, 'reportInpMetric must call enqueue exactly once');
+  return out!;
+}
+
+test('reportInpMetric attaches the globe marker load when the globe is mounted (#5368)', () => {
+  const { ctx } = captureWithGlobe({ value: 504, rating: 'poor' }, () => ({
+    globeMarkers: 2319,
+    globeMarkerBucket: '2000+',
+    globeActiveLayerCount: 9,
+    globeTruncated: ['military:300/1526'],
+  }));
+  assert.equal(ctx.extra.globeMarkers, 2319);
+  assert.equal(ctx.extra.globeMarkerBucket, '2000+');
+  assert.deepEqual(ctx.extra.globeTruncated, ['military:300/1526']);
+  // The existing INP fields must survive alongside it.
+  assert.equal(ctx.extra.value, 504);
+});
+
+test('reportInpMetric omits globe fields entirely on the flat map (#5368)', () => {
+  const { ctx } = captureWithGlobe({ value: 504, rating: 'poor' }, () => null);
+  for (const key of Object.keys(ctx.extra)) {
+    assert.ok(!key.startsWith('globe'), `flat-map reports must carry no globe fields, got ${key}`);
+  }
+  assert.equal(ctx.extra.value, 504, 'the ordinary INP payload is unaffected');
+});


### PR DESCRIPTION
Bounds how many DOM markers the 3D globe renders, and instruments the field so the mobile question can actually be answered.

## What the mechanism is

Confirmed in `node_modules`, not inferred: globe.gl renders `htmlElementsData` through three's `CSS2DRenderer`, which per marker per frame writes `style.display`, builds and writes a `style.transform` string, and writes `style.zIndex` — then runs a whole-scene `traverseVisible` plus an O(n log n) depth sort. It runs on **every** animation frame, even with a still camera (`CSS2DRenderer.js:214-310`, driven from `globe.gl.mjs:395`). Write-only style thrash, no forced reflow. So frame cost is linear in marker count, and it lands in the interaction frame budget — which is what INP measures.

## Two corrections to the issue's diagnosis

A production census (globe mode, prod, 2026-07-18) contradicts #5368 on two points, and I'd rather state them than quietly ship past them:

| view | markers | dominant source |
|---|---|---|
| desktop default | **2,319** | **`vessels` = 1,526 and climbing**, live AIS websocket, uncapped |
| mobile default | **~120** (measured 123 / 122 / 96-122 across three runs) | earthquakes + hotspots + news |
| desktop + `ucdpEvents` | 4,319 | ucdp = 2,000 |

1. **`ucdpEvents` is not the cause.** It is default-**off** (`panels.ts:162`) and its bootstrap projection caps at 150 unless explicitly opted into. The actual heavyweight — 1,526 AIS vessel markers — isn't mentioned in the issue.
2. **The mobile default view carries ~120 markers, not ~1,850.** The 1,850 figure came from a repro at a desktop-class viewport; mobile defaults (`FULL_MOBILE_MAP_LAYERS`, `panels.ts:194`) turn off `bases`, `nuclear`, `military`, `economic`, `waterways`.

So this PR **bounds the worst case** — which is real, unbounded, and desktop/layer-heavy — but I can't claim it moves the mobile p75 that headlines the issue. A within-session A/B was suggestive (122 markers -> frame p50 158ms; 22 -> 76ms) but the isolation run drifted badly under software WebGL, so I'm not calling it evidence. Hence the telemetry.

## What changed

- **`src/utils/globe-marker-budget.ts`** — pure, DOM-free selection. Per-feed cap plus a global ceiling allocated **max-min fair**, so one 1,526-marker feed can't evict an 11-marker weather layer. Desktop `{perLayer: 300, total: 800}`, mobile `{perLayer: 150, total: 400}` (a deliberate no-op on the ~120-marker mobile default; it bites only when layers are stacked onto a phone).
- **Ranking.** Layers with a severity signal rank by it (deaths, magnitude, brightness, carriers first). **Everything else ranks by nearness to the camera** — because trimming the alphabetically-ordered `NUCLEAR_FACILITIES` list by array order silently drops Zaporizhzhia and Pantex. Nearness makes the trim view-relative: you see the sites in the region you're looking at, and the rest arrive as you rotate toward them.
- **Disclosure.** `shown/total` beside any trimmed layer. This is a monitoring product; silently withholding 2,000 conflict events is a data-integrity problem, not a UI detail. Flash and news markers are exempt (navigational / no panel row to disclose against).
- **Telemetry.** The marker load rides the **existing** INP report (`enqueueSentryCall`, already sampled, trimmed to the bad tail, and safe against Sentry's deferred init) instead of a second observer. Counts and truncated-layer strings only — no layer-interest vector, no viewport, no `deviceMemory`/`hardwareConcurrency`.

## Verification

- 33 tests, all green. The headline cases feed the **real** `selectGlobeMarkers` the **measured** production census, not invented fixtures.
- **Mutation-tested**: disabling the global ceiling, making `proximityRank` ignore its focus, leaking the layer vector from the probe, and dropping the globe extra from the INP report each turn tests red.
- **Browser-verified** on a local build: 452 -> 118 markers under a temporarily-shrunk budget, badges reporting `nuclear=26/250`; and after the review fixes, badge outside the label, `pointer-events: none`, theme-aware colour, and clicking it no longer disables the layer.

## Review

Reviewed by 6 reviewers plus an independent adversarial pass through a different model family (Codex/gpt-5.5). Fixed from that review: a **P0** where unranked layers dropped nuclear sites by array order; the disclosure badge sitting inside the `<label>` so clicking it toggled the layer off; a hardcoded white badge colour invisible in light theme; a parallel Sentry import that bypassed the deferred-init queue and would have silently dropped early-session reports; `as`-cast rank callbacks replaced with `_kind` narrowing. The adversarial pass also proved my original source-regex wiring tests stayed green when the behaviour they named was deleted — those were replaced with behavioural tests that fail under mutation.

## Follow-ups (not in scope here)

- Name the mobile mover from the field data this ships.
- The `vessels` AIS feed has no upstream ceiling — worth capping at the source.
- `ConflictMarker` (`_kind: 'conflict'`) has no producer; the marker branch in `buildMarkerElement` is dead code.
- An i18n key for the badge tooltip (currently a plain literal, matching this panel's existing precedent).
- `sortObjects = false` on the CSS2DRenderer would remove a full scene traverse + sort + n zIndex writes per frame, but globe.gl doesn't expose the instance.

Fixes #5368

https://claude.ai/code/session_01VEAjp5vuHXsnfJNHDgJioz
