### PR TITLE
fix(mcp): make GET /mcp crawler-readable and fix the discovery cache key

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -59,3 +59,23 @@ An element that browser and RUM layout-shift attribution names because its *posi
 ### Shift Mover
 
 The element that *causes* a layout shift by changing its own footprint — growing, shrinking, materializing (insertion), or disappearing (removal). Movers are not reported by shift-attribution APIs; naming one requires diffing element geometry across the shift itself (a cached top/height baseline compared at shift delivery). The victim/mover distinction is load-bearing for all layout-stability work in this project: two shipped fixes aimed at victims had null field effect before mover instrumentation named the true mechanism. See also: Shift Victim, Deferred-Shell Contract.
+
+## MCP & Agent Discovery
+
+### MCP Server Card
+
+A static JSON discovery document that describes the MCP server: its name, version, supported transport, endpoint URL, authentication requirements, and tool/resource/prompt catalogs. It is served at `/.well-known/mcp/server-card.json` and returned by a plain `GET` to the well-known aliases (`/.well-known/mcp`, `/.well-known/mcp.json`). It is the *machine* discovery representation; the *human* one is the server guide. Clients performing a live MCP handshake still `POST` to the transport endpoint.
+
+### Discovery Read vs. Transport Operation
+
+The distinction that lets one URL serve both crawlers and MCP clients. A `GET` carrying neither `Last-Event-ID` nor an `Accept: text/event-stream` is a **discovery read** — a human or crawler opening the endpoint — and receives a document (the markdown server guide at `/mcp`, the JSON card at the well-known aliases). Every other `GET` is a **transport operation**: an SSE stream-open, which must receive the spec-correct `405`, or an authenticated `Last-Event-ID` replay. Request semantics, never user-agent sniffing, decide which. The consequence for caching is load-bearing: because these URLs negotiate on request headers, any cacheable response must declare `Vary: Accept, Last-Event-ID`, or a shared cache keyed on URL alone will replay a stored discovery body to a transport client. The live transport URL goes further and stays `no-store`, so its correctness never depends on an intermediary honoring `Vary`.
+
+### Streamable HTTP Transport
+
+The MCP transport this server implements over HTTP: JSON-RPC 2.0 requests via `POST`, with optional Server-Sent Events when the client advertises `Accept: text/event-stream`. Its `405` on a standalone stream-open is not an error but a contract — MCP SDK clients read it as the graceful "no standalone stream" signal and complete the handshake. Anything that converts that `405` into a `200` (including a CDN replaying a cached discovery response) breaks the handshake.
+
+## Routing & Hosts
+
+### Variant Host
+
+One of the product-variant subdomains (`tech`, `finance`, `commodity`, `happy`, `energy`) that serves a themed dashboard entry and metadata. The middleware and Vercel config recognize these hosts explicitly; canonical discovery URLs for shared surfaces (such as `/mcp`) redirect retrieval-method requests from variant hosts to the apex host so discovery signals do not fragment.

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -334,6 +334,8 @@ const MCP_TRANSPORT_PATH = '/mcp';
 // contract requires 405. Never emit a cacheable discovery 200 on these paths
 // without this Vary.
 const DISCOVERY_VARY = 'Accept, Last-Event-ID';
+const STATIC_ASSET_FETCH_TIMEOUT_MS = 5_000;
+const STATIC_ASSET_USER_AGENT = 'WorldMonitor-MCP/1.0 (+https://worldmonitor.app)';
 
 // Module-scope caches: both documents are static assets, immutable per deployment.
 let serverCardCache: string | null = null;
@@ -345,12 +347,19 @@ let mcpGuideCache: string | null = null;
 // resolves. Returns null on any failure so the caller can fall back rather
 // than cache a failure.
 async function fetchStaticAsset(req: Request, path: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), STATIC_ASSET_FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(new URL(path, req.url));
+    const res = await fetch(new URL(path, req.url), {
+      headers: { 'User-Agent': STATIC_ASSET_USER_AGENT },
+      signal: controller.signal,
+    });
     if (!res.ok) return null;
     return await res.text();
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -480,7 +489,7 @@ async function mcpHandlerInner(
   if (
     req.method === 'GET' &&
     !req.headers.get('last-event-id') &&
-    !(req.headers.get('accept') ?? '').includes('text/event-stream')
+    !clientAcceptsSse(req)
   ) {
     const pathname = new URL(req.url).pathname;
     if (WELL_KNOWN_MCP_PATHS.has(pathname)) {

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -297,7 +297,7 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
 }
 
 // ---------------------------------------------------------------------------
-// /.well-known/mcp dual-role support
+// /.well-known/mcp and /mcp dual-role support
 // ---------------------------------------------------------------------------
 // vercel.json rewrites /.well-known/mcp into this handler so ONE URL is both
 // the discovery manifest (plain GET → static server card) and a live
@@ -309,23 +309,63 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
 // Two manifest aliases: bare `/.well-known/mcp` (SEP-1649 server-card style)
 // and `/.well-known/mcp.json` (the ora.ai/registry convention whose schema
 // keys the endpoint as top-level `url`). Both rewrite here via vercel.json.
+//
+// A plain GET to `/mcp` itself is NOT an MCP protocol handshake (that stays
+// POST); it is a human or a crawler opening the endpoint in a browser. They
+// get the human-readable server guide (`/mcp-server.md`) instead of the
+// spec-correct 405 that Google Search Console reports as "cannot access".
+// SSE-flavored GETs and GETs with Last-Event-ID still fall through to the
+// normal 405 / replay paths so Streamable HTTP transport semantics are
+// unchanged.
 const WELL_KNOWN_MCP_PATHS = new Set(['/.well-known/mcp', '/.well-known/mcp.json']);
-// Module-scope cache: the card is a static asset, immutable per deployment.
+const MCP_TRANSPORT_PATH = '/mcp';
+
+// These URLs content-negotiate on request headers: a plain GET gets a
+// discovery document, an `Accept: text/event-stream` GET gets the transport
+// 405, and a `Last-Event-ID` GET gets authenticated replay. Any cache in
+// front of the origin MUST key on those headers, or it will replay a stored
+// discovery body to a transport client.
+//
+// This is not theoretical. Vercel's edge keys on URL alone unless the origin
+// says otherwise, and it caches this route: a `public, max-age=3600` card
+// stored from a plain GET to /.well-known/mcp was empirically served
+// (`x-vercel-cache: HIT`) to a subsequent `Accept: text/event-stream` GET on
+// the same URL, handing an SDK client a 200 JSON body where the transport
+// contract requires 405. Never emit a cacheable discovery 200 on these paths
+// without this Vary.
+const DISCOVERY_VARY = 'Accept, Last-Event-ID';
+
+// Module-scope caches: both documents are static assets, immutable per deployment.
 let serverCardCache: string | null = null;
+let mcpGuideCache: string | null = null;
+
+// Self-fetch a static asset off our own deployment. Redirects are followed:
+// `/mcp-server.md` is NOT in the Cloudflare apex→www exemption list
+// (ARCHITECTURE.md:72), so an apex-origin self-fetch 301s to www before it
+// resolves. Returns null on any failure so the caller can fall back rather
+// than cache a failure.
+async function fetchStaticAsset(req: Request, path: string): Promise<string | null> {
+  try {
+    const res = await fetch(new URL(path, req.url));
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
 async function serveServerCard(req: Request, corsHeaders: Record<string, string>): Promise<Response> {
   if (serverCardCache === null) {
-    try {
-      const res = await fetch(new URL('/.well-known/mcp/server-card.json', req.url));
-      if (!res.ok) throw new Error(`server-card fetch ${res.status}`);
-      serverCardCache = await res.text();
-    } catch {
+    const text = await fetchStaticAsset(req, '/.well-known/mcp/server-card.json');
+    if (text === null) {
       // Self-fetch failed (deploy skew / transient) — point the fetcher at the
       // canonical static path instead of caching a failure.
       return new Response(null, {
         status: 302,
-        headers: { Location: '/.well-known/mcp/server-card.json', ...corsHeaders },
+        headers: { Location: '/.well-known/mcp/server-card.json', Vary: DISCOVERY_VARY, ...corsHeaders },
       });
     }
+    serverCardCache = text;
   }
   return new Response(serverCardCache, {
     status: 200,
@@ -334,11 +374,47 @@ async function serveServerCard(req: Request, corsHeaders: Record<string, string>
     // but the manifest is a static, immutable-per-deploy asset that must stay
     // cacheable (it was `public, max-age=3600` as a static file). Spreading last
     // would clobber that back to no-store and re-hit the function on every
-    // discovery fetch.
+    // discovery fetch. Vary is what makes that cacheable 200 SAFE — see
+    // DISCOVERY_VARY.
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
       ...corsHeaders,
       'Cache-Control': 'public, max-age=3600',
+      Vary: DISCOVERY_VARY,
+    },
+  });
+}
+
+// The human-facing representation of the transport URL. Deliberately NOT
+// cacheable: `/mcp` is the live Streamable HTTP endpoint, and a stored 200 on
+// that exact URL is the one thing that can be replayed by a shared cache to an
+// SSE stream-open or an authenticated replay GET. Vary alone would be enough
+// if every cache in the path honored it; no-store means correctness does not
+// depend on that. The cost is one function invocation per crawler GET — the
+// cacheable copy of this document still lives at `/mcp-server.md`.
+async function serveMcpGuide(req: Request, corsHeaders: Record<string, string>): Promise<Response> {
+  if (mcpGuideCache === null) {
+    const text = await fetchStaticAsset(req, '/mcp-server.md');
+    if (text === null) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: '/mcp-server.md', Vary: DISCOVERY_VARY, ...corsHeaders },
+      });
+    }
+    mcpGuideCache = text;
+  }
+  return new Response(mcpGuideCache, {
+    status: 200,
+    // corsHeaders (getMcpCorsHeaders) already carries `no-store, no-transform`
+    // — deliberately NOT overridden here. The canonical link keeps discovery
+    // signals on the apex endpoint, which is the host the Cloudflare apex→www
+    // rule exempts for /mcp (ARCHITECTURE.md:72) and the URL the server card
+    // advertises.
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      ...corsHeaders,
+      Vary: DISCOVERY_VARY,
+      Link: '<https://worldmonitor.app/mcp>; rel="canonical"',
     },
   });
 }
@@ -384,21 +460,37 @@ async function mcpHandlerInner(
   }
   if (req.method === 'HEAD') {
     usage.skip = true;
-    return new Response(null, { status: 200, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) });
+    // HEAD must advertise the representation the matching GET would return:
+    // markdown at the transport URL, JSON at the well-known manifest aliases.
+    const headContentType = new URL(req.url).pathname === MCP_TRANSPORT_PATH
+      ? 'text/markdown; charset=utf-8'
+      : 'application/json; charset=utf-8';
+    return new Response(null, {
+      status: 200,
+      headers: withMcpNoStore({ 'Content-Type': headContentType, Vary: DISCOVERY_VARY, ...corsHeaders }),
+    });
   }
 
-  // /.well-known/mcp manifest GET: the card is public static data. A GET that
-  // asks for `text/event-stream` (an SDK opening the optional standalone
-  // stream) or carries `Last-Event-ID` (SSE replay) falls through to the
-  // normal endpoint GET handling so transport semantics stay identical to /mcp.
+  // Discovery GETs. A GET with no `Last-Event-ID` and no `text/event-stream`
+  // Accept is not a transport operation: on the well-known aliases it is a
+  // manifest fetch (JSON server card), and on `/mcp` itself it is a human or
+  // crawler opening the endpoint (the markdown server guide). Both are
+  // answered BEFORE the transport GET branch, so the standalone-stream 405 and
+  // the authenticated replay path below are untouched.
   if (
     req.method === 'GET' &&
-    WELL_KNOWN_MCP_PATHS.has(new URL(req.url).pathname) &&
     !req.headers.get('last-event-id') &&
     !(req.headers.get('accept') ?? '').includes('text/event-stream')
   ) {
-    usage.skip = true;
-    return serveServerCard(req, corsHeaders);
+    const pathname = new URL(req.url).pathname;
+    if (WELL_KNOWN_MCP_PATHS.has(pathname)) {
+      usage.skip = true;
+      return serveServerCard(req, corsHeaders);
+    }
+    if (pathname === MCP_TRANSPORT_PATH) {
+      usage.skip = true;
+      return serveMcpGuide(req, corsHeaders);
+    }
   }
 
   // No Origin gate (issue #4802): the endpoint advertises CORS `*`, auth is
@@ -417,19 +509,20 @@ async function mcpHandlerInner(
   const requestHost = req.headers.get('host') ?? new URL(req.url).host;
   const resourceMetadataUrl = `https://${requestHost}/.well-known/oauth-protected-resource`;
 
-  // GET has two roles on the MCP endpoint:
-  //   1. A bare GET (no `Last-Event-ID`) is a client opening the OPTIONAL
-  //      server->client SSE stream of the Streamable HTTP transport. This
+  // GET has three roles on the MCP endpoint:
+  //   1. A plain GET (no `text/event-stream` Accept, no `Last-Event-ID`) is a
+  //      discovery read and has already been answered above — the markdown
+  //      server guide at `/mcp`, the JSON server card at the well-known
+  //      aliases. The MCP handshake itself remains POST-only.
+  //   2. A GET asking for `text/event-stream` or carrying `Last-Event-ID` is
+  //      either a client opening the OPTIONAL server->client SSE stream of the
+  //      Streamable HTTP transport, or an authenticated SSE replay. This
   //      stateless edge route offers no server-initiated stream, so the MCP
-  //      spec requires HTTP 405 Method Not Allowed here — and MCP SDK clients
+  //      spec requires HTTP 405 Method Not Allowed here — MCP SDK clients
   //      treat 405 as the graceful "no standalone stream" signal, completing
-  //      the handshake cleanly. Answering 401/400 instead makes a strict
-  //      client's `connect()` raise `Failed to open SSE stream` and an
-  //      agent-readiness scanner (orank) report "protocol handshake failed".
-  //      This 405 precedes auth so an UNauthenticated discovery client sees the
-  //      same spec-correct signal (405 leaks nothing). RFC 9110 §15.5.6 requires
-  //      the 405 to advertise `Allow`.
-  //   2. A GET WITH `Last-Event-ID` is our authenticated SSE-replay channel —
+  //      the handshake cleanly. RFC 9110 §15.5.6 requires the 405 to advertise
+  //      `Allow`.
+  //   3. A GET WITH `Last-Event-ID` is our authenticated SSE-replay channel —
   //      it re-serves previously-streamed (Pro) tool-result data, so it stays
   //      fully authenticated (never a discovery surface).
   if (req.method === 'GET') {

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -109,7 +109,7 @@ const MAX_SSE_SESSIONS = 500;
 const MAX_SSE_STREAMS_PER_SESSION = 25;
 const mcpSseStreamsBySession = new Map<string, Map<string, StoredSseEvent[]>>();
 
-function getMcpCorsHeaders(methods = 'POST, GET, OPTIONS'): Record<string, string> {
+function getMcpCorsHeaders(methods = 'POST, GET, HEAD, OPTIONS'): Record<string, string> {
   return {
     ...getPublicCorsHeaders(methods),
     'Cache-Control': MCP_CACHE_CONTROL,
@@ -393,7 +393,7 @@ async function fetchStaticAsset(req: Request, path: string): Promise<string | nu
   }
 }
 
-async function serveServerCard(req: Request, corsHeaders: Record<string, string>): Promise<Response> {
+async function serveServerCard(req: Request, corsHeaders: Record<string, string>, headOnly = false): Promise<Response> {
   if (serverCardCache === null) {
     const text = await fetchStaticAsset(req, '/.well-known/mcp/server-card.json');
     if (text === null) {
@@ -406,7 +406,7 @@ async function serveServerCard(req: Request, corsHeaders: Record<string, string>
     }
     serverCardCache = text;
   }
-  return new Response(serverCardCache, {
+  return new Response(headOnly ? null : serverCardCache, {
     status: 200,
     // Cache-Control comes AFTER the ...corsHeaders spread: getMcpCorsHeaders()
     // carries MCP_CACHE_CONTROL (`no-store`) for the live JSON-RPC/SSE endpoint,
@@ -431,7 +431,7 @@ async function serveServerCard(req: Request, corsHeaders: Record<string, string>
 // if every cache in the path honored it; no-store means correctness does not
 // depend on that. The cost is one function invocation per crawler GET — the
 // cacheable copy of this document still lives at `/mcp-server.md`.
-async function serveMcpGuide(req: Request, corsHeaders: Record<string, string>): Promise<Response> {
+async function serveMcpGuide(req: Request, corsHeaders: Record<string, string>, headOnly = false): Promise<Response> {
   if (mcpGuideCache === null) {
     const text = await fetchStaticAsset(req, '/mcp-server.md');
     if (text === null) {
@@ -442,7 +442,7 @@ async function serveMcpGuide(req: Request, corsHeaders: Record<string, string>):
     }
     mcpGuideCache = text;
   }
-  return new Response(mcpGuideCache, {
+  return new Response(headOnly ? null : mcpGuideCache, {
     status: 200,
     // corsHeaders (getMcpCorsHeaders) already carries `no-store, no-transform`
     // — deliberately NOT overridden here. The canonical link keeps discovery
@@ -517,14 +517,19 @@ async function mcpHandlerInner(
     }
 
     usage.skip = true;
-    // HEAD must advertise the representation the matching GET would return:
-    // markdown at the transport URL, JSON at the well-known manifest aliases.
-    const headContentType = new URL(req.url).pathname === MCP_TRANSPORT_PATH
-      ? 'text/markdown; charset=utf-8'
-      : 'application/json; charset=utf-8';
+    // HEAD is the matching GET with the body suppressed. Reuse the discovery
+    // helpers so cache policy, canonical Link, and static-asset fallback status
+    // cannot drift between the two methods.
+    const pathname = new URL(req.url).pathname;
+    if (WELL_KNOWN_MCP_PATHS.has(pathname)) {
+      return serveServerCard(req, corsHeaders, true);
+    }
+    if (pathname === MCP_TRANSPORT_PATH) {
+      return serveMcpGuide(req, corsHeaders, true);
+    }
     return new Response(null, {
       status: 200,
-      headers: withMcpNoStore({ 'Content-Type': headContentType, Vary: DISCOVERY_VARY, ...corsHeaders }),
+      headers: withMcpNoStore({ 'Content-Type': 'application/json; charset=utf-8', ...corsHeaders }),
     });
   }
 

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -243,7 +243,7 @@ async function maybeStreamJsonRpcResponse(req: Request, response: Response): Pro
   });
 }
 
-function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Response {
+function handleSseReplay(req: Request, corsHeaders: Record<string, string>, headOnly = false): Response {
   const lastEventId = req.headers.get('last-event-id');
   if (!clientAcceptsSse(req)) {
     return new Response(
@@ -287,13 +287,43 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
     );
   }
 
-  return new Response(createSseStream(events), {
+  return new Response(headOnly ? null : createSseStream(events), {
     status: 200,
     // corsHeaders is getMcpCorsHeaders() (MCP_CACHE_CONTROL = no-store, no-transform):
     // the replay carries previously-streamed tool-result data, so no-store forbids
     // caching it and no-transform preserves SSE framing.
     headers: { 'Content-Type': SSE_CONTENT_TYPE, ...corsHeaders },
   });
+}
+
+async function handleAuthenticatedSseReplay(
+  req: Request,
+  deps: McpHandlerDeps,
+  resourceMetadataUrl: string,
+  corsHeaders: Record<string, string>,
+  usage: McpUsage,
+  ctx: { waitUntil: (p: Promise<unknown>) => void } | undefined,
+  headOnly = false,
+): Promise<Response> {
+  const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
+  if (!auth.ok) {
+    usage.phase = 'auth';
+    return auth.response;
+  }
+  setUsageContext(usage, auth.context);
+  const getPreCheck = await runContextPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
+  if (getPreCheck) {
+    usage.phase = 'precheck';
+    return getPreCheck;
+  }
+  const getLimited = await applyPerMinuteLimit(auth.context, corsHeaders);
+  if (getLimited) {
+    usage.phase = 'limit';
+    return getLimited;
+  }
+  const replay = handleSseReplay(req, corsHeaders, headOnly);
+  if (replay.status !== 200) usage.phase = 'transport';
+  return replay;
 }
 
 // ---------------------------------------------------------------------------
@@ -467,7 +497,25 @@ async function mcpHandlerInner(
     usage.skip = true;
     return new Response(null, { status: 204, headers: withMcpNoStore(corsHeaders) });
   }
+
+  // Host-derived resource_metadata pointer matches api/oauth-protected-resource.ts.
+  const requestHost = req.headers.get('host') ?? new URL(req.url).host;
+  const resourceMetadataUrl = `https://${requestHost}/.well-known/oauth-protected-resource`;
+
   if (req.method === 'HEAD') {
+    // HEAD is GET without a response body. Preserve transport-shaped GET
+    // semantics before serving the plain discovery representation metadata.
+    if (req.headers.get('last-event-id')) {
+      return handleAuthenticatedSseReplay(req, deps, resourceMetadataUrl, corsHeaders, usage, ctx, true);
+    }
+    if (clientAcceptsSse(req)) {
+      usage.phase = 'transport';
+      return new Response(null, {
+        status: 405,
+        headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }),
+      });
+    }
+
     usage.skip = true;
     // HEAD must advertise the representation the matching GET would return:
     // markdown at the transport URL, JSON at the well-known manifest aliases.
@@ -514,10 +562,6 @@ async function mcpHandlerInner(
     return new Response(null, { status: 405, headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }) });
   }
 
-  // Host-derived resource_metadata pointer matches api/oauth-protected-resource.ts.
-  const requestHost = req.headers.get('host') ?? new URL(req.url).host;
-  const resourceMetadataUrl = `https://${requestHost}/.well-known/oauth-protected-resource`;
-
   // GET has three roles on the MCP endpoint:
   //   1. A plain GET (no `text/event-stream` Accept, no `Last-Event-ID`) is a
   //      discovery read and has already been answered above — the markdown
@@ -542,25 +586,7 @@ async function mcpHandlerInner(
         headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }),
       });
     }
-    const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
-    if (!auth.ok) {
-      usage.phase = 'auth';
-      return auth.response;
-    }
-    setUsageContext(usage, auth.context);
-    const getPreCheck = await runContextPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
-    if (getPreCheck) {
-      usage.phase = 'precheck';
-      return getPreCheck;
-    }
-    const getLimited = await applyPerMinuteLimit(auth.context, corsHeaders);
-    if (getLimited) {
-      usage.phase = 'limit';
-      return getLimited;
-    }
-    const replay = handleSseReplay(req, corsHeaders);
-    if (replay.status !== 200) usage.phase = 'transport';
-    return replay;
+    return handleAuthenticatedSseReplay(req, deps, resourceMetadataUrl, corsHeaders, usage, ctx);
   }
 
   // Parse body BEFORE auth: the method decides whether credentials are required

--- a/docs/solutions/integration-issues/mcp-crawler-get-and-method-aware-canonical-redirects.md
+++ b/docs/solutions/integration-issues/mcp-crawler-get-and-method-aware-canonical-redirects.md
@@ -1,0 +1,179 @@
+---
+title: "Make MCP endpoints crawler-accessible without letting a CDN replay discovery to transport clients"
+date: 2026-07-20
+category: integration-issues
+module: "MCP HTTP transport and canonical host routing"
+problem_type: integration_issue
+component: assistant
+severity: high
+symptoms:
+  - "Google Search Console reported https://www.worldmonitor.app/mcp and the variant-subdomain /mcp URLs as inaccessible because a plain GET returned 405 Method Not Allowed"
+  - "A cacheable discovery 200 on /.well-known/mcp was served by the Vercel edge (x-vercel-cache: HIT) to a GET carrying Accept: text/event-stream, which the MCP transport contract requires to be 405"
+root_cause: wrong_api
+resolution_type: code_fix
+tags:
+  - mcp
+  - google-search-console
+  - crawler-access
+  - canonical-url
+  - content-negotiation
+  - http-caching
+  - vary-header
+  - cache-poisoning
+  - http-transport
+  - json-rpc
+---
+
+# Make MCP endpoints crawler-accessible without letting a CDN replay discovery to transport clients
+
+## Problem
+
+Google Search Console could not access `/mcp` — on `www`, on the apex, and on every variant subdomain (`happy`, `tech`, `finance`, `commodity`, `energy`). The route is not a conventional page: `vercel.json` rewrites `/mcp` to an Edge Function implementing MCP Streamable HTTP, and a plain crawler-style `GET` fell into the transport's spec-correct `405 Method Not Allowed`.
+
+Baseline, confirmed by probing production before any change:
+
+```
+GET https://worldmonitor.app/mcp        → 405, no-store
+GET https://happy.worldmonitor.app/mcp  → 405, no-store
+```
+
+The obvious fix — answer a plain `GET` with a document — is where the real hazard lives, and it is the reason this write-up exists.
+
+## The trap: a cacheable 200 on a content-negotiated transport URL
+
+`/mcp` and the `/.well-known/mcp` aliases branch on **request headers**, not on path:
+
+| Request shape | Intended response |
+|---|---|
+| `GET`, no `Last-Event-ID`, no `text/event-stream` | discovery document |
+| `GET` with `Accept: text/event-stream` | `405` + `Allow` (the "no standalone stream" signal) |
+| `GET` with `Last-Event-ID` | authenticated SSE replay |
+| `POST` | JSON-RPC |
+
+A first attempt served the JSON server card on a plain `GET` with `Cache-Control: public, max-age=3600` and **no `Vary`**. That shipped on `/.well-known/mcp`, which made the failure directly observable in production:
+
+```
+# warm the cache with a plain GET
+GET /.well-known/mcp  Accept: application/json
+  → 200, x-vercel-cache: HIT, age: 15, vary: accept-encoding
+
+# the SSE stream-open on the SAME URL
+GET /.well-known/mcp  Accept: text/event-stream
+  → 200, x-vercel-cache: HIT, age: 15
+    content-type: application/json
+    {"name":"worldmonitor","kind":"product",...}
+```
+
+The edge keys on URL alone unless the origin says otherwise. An MCP SDK client opening the optional standalone stream received a **200 JSON body where the transport contract requires 405**. That is the #4937 failure class — an uncorrelatable response that hangs a strict client to its 30s timeout — reintroduced through the cache layer rather than the handler.
+
+Extending the same cacheable-200 pattern to `/mcp` would have moved this onto the actual transport URL.
+
+## Solution
+
+### 1. Split the two discovery representations by audience
+
+The well-known aliases keep serving the **JSON server card** (machine discovery). `/mcp` itself serves the **markdown server guide** — the same document already published at `/mcp-server.md` — so a human or crawler opening the endpoint gets something readable:
+
+```ts
+const WELL_KNOWN_MCP_PATHS = new Set(['/.well-known/mcp', '/.well-known/mcp.json']);
+const MCP_TRANSPORT_PATH = '/mcp';
+
+if (
+  req.method === 'GET' &&
+  !req.headers.get('last-event-id') &&
+  !(req.headers.get('accept') ?? '').includes('text/event-stream')
+) {
+  const pathname = new URL(req.url).pathname;
+  if (WELL_KNOWN_MCP_PATHS.has(pathname)) return serveServerCard(req, corsHeaders);
+  if (pathname === MCP_TRANSPORT_PATH) return serveMcpGuide(req, corsHeaders);
+}
+```
+
+The branch runs **before** the transport GET branch and is defined by request semantics, never by user-agent sniffing.
+
+### 2. Make the cache key match the negotiation
+
+```ts
+const DISCOVERY_VARY = 'Accept, Last-Event-ID';
+```
+
+- The well-known card **stays cacheable** (`public, max-age=3600`) and adds `Vary: Accept, Last-Event-ID`.
+- `/mcp` stays **`no-store`** (it inherits `no-store, no-transform` from the MCP CORS bundle) and also declares `Vary`.
+
+The asymmetry is deliberate. `Vary` is the correct fix, but it only works if every intermediary honors it. The transport URL is where a mistake is most expensive, so its correctness does not depend on that: it never emits a cacheable body at all. The cacheable copy of the guide still lives at `/mcp-server.md`. Crawler volume on `/mcp` is negligible, so there is nothing to gain by caching it there.
+
+### 3. Canonicalize variant hosts to the apex — apex, not www
+
+`ARCHITECTURE.md:72` documents the Cloudflare apex→www dynamic redirect whose exemption list is load-bearing: `/.well-known/*`, `/robots.txt`, `/security.txt`, `/mcp`, `/mcp/*`, `/oauth/*` are **served on the apex, never redirected**. The agent-discovery corpus is apex by design, and the server card advertises `https://worldmonitor.app/mcp`.
+
+So variant-host canonicalization targets the apex, and only for retrieval methods:
+
+```ts
+if (
+  path === '/mcp' &&
+  (request.method === 'GET' || request.method === 'HEAD') &&
+  VARIANT_HOST_MAP[host] &&
+  !request.headers.get('last-event-id') &&
+  !(request.headers.get('accept') ?? '').includes('text/event-stream')
+) {
+  return new Response(null, {
+    status: 308,
+    headers: {
+      Location: 'https://worldmonitor.app/mcp',
+      Vary: 'Accept, Last-Event-ID',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}
+```
+
+Built by hand rather than with `Response.redirect()` precisely so it can carry `Vary` — a `308` is cacheable by default (RFC 9110 §15.4.9), so the same cache-key discipline applies to the redirect. `POST` and `OPTIONS` fall through unchanged to the `/api/mcp` rewrite; redirecting them would convert the JSON-RPC handshake into a `GET` (the #4938 fingerprint).
+
+The guide response also declares `Link: <https://worldmonitor.app/mcp>; rel="canonical"`, so `www` and apex agree on one indexable URL.
+
+## Why the tests could not have caught this
+
+The transport conformance suite binds the handler to a localhost listener. The handler was **always correct** — it computed `405` for the SSE GET every time. The bug lived entirely in the edge cache between the handler and the client, exactly like #4938 ("no in-process test can see a CDN redirect rule").
+
+The regression net therefore has two layers:
+
+- `tests/mcp-transport-conformance.test.mjs` locks the *contract*: markdown guide on a plain `GET /mcp`, JSON card on the aliases, `405` preserved for SSE GETs, `HEAD` advertising the representation its `GET` returns, the card cacheable **only** with `Vary`, and the transport URL never cacheable.
+- `scripts/mcp-live-smoke.mjs` (6-hourly cron) probes *production*: it warms the cache with a plain GET, then issues the SSE GET and fails if the answer is anything but `405` — naming `x-vercel-cache: HIT` explicitly when it is a cache replay. It also asserts the variant `308` and that variant `POST` is not redirected.
+
+Run against un-fixed production, the new probe reproduced all three defects independently, including the cache HIT.
+
+## Landmines
+
+### `\bAccept\b` matches `accept-encoding`
+
+The first version of the `Vary` assertion was `/\bAccept\b/i`. `-` is a word boundary, so it matches the `accept-encoding` that the edge adds on its own — the check passed against an origin sending no `Vary` at all. It must be:
+
+```js
+/\bAccept\b(?!-)/i
+```
+
+A check written to catch a specific bug that passes on the un-fixed system is worse than no check. Always run a new probe against the broken state and confirm it fails.
+
+### Header order in the response constructor
+
+`getMcpCorsHeaders()` carries `Cache-Control: no-store, no-transform` for the live endpoint. The card's `public, max-age=3600` must come **after** the `...corsHeaders` spread or it is clobbered back to `no-store`. Conversely the guide deliberately does **not** override it.
+
+### `/mcp-server.md` is not apex-exempt
+
+`fetch(new URL('/mcp-server.md', req.url))` from an apex-origin function 301s to `www` before resolving — `/mcp-server.md` is not in the Cloudflare exemption list, unlike `/.well-known/*`. Redirect-following makes it work; the module-scope cache means it costs one extra hop per instance, not per request.
+
+## Prevention
+
+Any response on a URL that branches on request headers must satisfy:
+
+```
+cacheable(response) ⇒ Vary ⊇ {every header the branch reads}
+```
+
+and for a **live protocol endpoint**, prefer the stronger invariant: emit no cacheable body at all. State the negotiation matrix (host × method × headers) in the test suite, and probe it over the public edge — Cloudflare, Vercel middleware, the rewrite, and the handler only compose in production.
+
+## Related Issues
+
+- [Issue #4802](https://github.com/koala73/worldmonitor/issues/4802) / [PR #4808](https://github.com/koala73/worldmonitor/pull/4808): removed an overly narrow Origin allowlist from `/mcp`.
+- [PR #4809](https://github.com/koala73/worldmonitor/pull/4809): made the static MCP server card cacheable. This fix keeps that cacheability and adds the `Vary` that makes it safe.
+- #4937 / #4938: the uncorrelatable-response and redirected-POST outages that `mcp-live-smoke.mjs` was built for. The cache replay found here is #4937's failure mode arriving through the CDN.

--- a/docs/solutions/integration-issues/mcp-crawler-get-and-method-aware-canonical-redirects.md
+++ b/docs/solutions/integration-issues/mcp-crawler-get-and-method-aware-canonical-redirects.md
@@ -74,6 +74,8 @@ Extending the same cacheable-200 pattern to `/mcp` would have moved this onto th
 
 The well-known aliases keep serving the **JSON server card** (machine discovery). `/mcp` itself serves the **markdown server guide** — the same document already published at `/mcp-server.md` — so a human or crawler opening the endpoint gets something readable:
 
+Both the handler and middleware use `clientAcceptsSse`, the shared parser that treats media types case-insensitively and honors `q=0`. A raw substring check does neither.
+
 ```ts
 const WELL_KNOWN_MCP_PATHS = new Set(['/.well-known/mcp', '/.well-known/mcp.json']);
 const MCP_TRANSPORT_PATH = '/mcp';
@@ -81,7 +83,7 @@ const MCP_TRANSPORT_PATH = '/mcp';
 if (
   req.method === 'GET' &&
   !req.headers.get('last-event-id') &&
-  !(req.headers.get('accept') ?? '').includes('text/event-stream')
+  !clientAcceptsSse(req)
 ) {
   const pathname = new URL(req.url).pathname;
   if (WELL_KNOWN_MCP_PATHS.has(pathname)) return serveServerCard(req, corsHeaders);
@@ -114,7 +116,7 @@ if (
   (request.method === 'GET' || request.method === 'HEAD') &&
   VARIANT_HOST_MAP[host] &&
   !request.headers.get('last-event-id') &&
-  !(request.headers.get('accept') ?? '').includes('text/event-stream')
+  !clientAcceptsSse(request)
 ) {
   return new Response(null, {
     status: 308,

--- a/middleware.ts
+++ b/middleware.ts
@@ -126,6 +126,18 @@ function hasLegacyDashboardRootState(searchParams: URLSearchParams): boolean {
   return LEGACY_DASHBOARD_ROOT_QUERY_KEYS.some((key) => searchParams.has(key));
 }
 
+function clientAcceptsSse(request: Request): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  return accept.split(',').some((entry) => {
+    const [type, ...params] = entry.split(';').map((part) => part.trim().toLowerCase());
+    if (type !== 'text/event-stream') return false;
+    const qParam = params.find((part) => part.startsWith('q='));
+    if (!qParam) return true;
+    const q = Number(qParam.slice(2));
+    return Number.isFinite(q) && q > 0;
+  });
+}
+
 // HTML-escape a string for safe interpolation into BOTH text content and
 // double-quoted attribute values. Required because VARIANT_OG values are
 // hand-edited prose and a future double-quote, ampersand, or angle bracket
@@ -248,7 +260,7 @@ export default function middleware(request: Request) {
     (request.method === 'GET' || request.method === 'HEAD') &&
     VARIANT_HOST_MAP[host] &&
     !request.headers.get('last-event-id') &&
-    !(request.headers.get('accept') ?? '').includes('text/event-stream')
+    !clientAcceptsSse(request)
   ) {
     // Built by hand rather than via Response.redirect() so the response can
     // carry Vary. This redirect is decided by Accept and Last-Event-ID, and a

--- a/middleware.ts
+++ b/middleware.ts
@@ -233,6 +233,38 @@ export default function middleware(request: Request) {
     }
   }
 
+  // Variant subdomain MCP discovery canonicalization. The MCP endpoint's
+  // canonical URL is apex (`https://worldmonitor.app/mcp`), and the Cloudflare
+  // apex→www redirect explicitly exempts `/mcp` so POST JSON-RPC calls aren't
+  // converted to GET. Variant subdomains would otherwise serve the same `/mcp`
+  // content as the apex, fragmenting discovery signals; redirect plain GET/HEAD
+  // requests to the apex canonical. GETs that carry MCP transport headers
+  // (`Last-Event-ID` or `Accept: text/event-stream`) are NOT redirected — they
+  // are protocol operations (SSE stream open or replay) and must reach the same
+  // host/instance that handled the POST handshake. POST/OPTIONS/etc. are also
+  // NOT redirected; they continue to the `/api/mcp` rewrite unchanged.
+  if (
+    path === '/mcp' &&
+    (request.method === 'GET' || request.method === 'HEAD') &&
+    VARIANT_HOST_MAP[host] &&
+    !request.headers.get('last-event-id') &&
+    !(request.headers.get('accept') ?? '').includes('text/event-stream')
+  ) {
+    // Built by hand rather than via Response.redirect() so the response can
+    // carry Vary. This redirect is decided by Accept and Last-Event-ID, and a
+    // 308 is cacheable by default (RFC 9110 §15.4.9) — without Vary a shared
+    // cache could store it and replay it to the SSE stream-open GET that must
+    // reach this host's transport instead.
+    return new Response(null, {
+      status: 308,
+      headers: {
+        Location: 'https://worldmonitor.app/mcp',
+        Vary: 'Accept, Last-Event-ID',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  }
+
   // Only apply bot filtering to /api/* paths.
   //
   // /favico/* is deliberately NOT gated: it serves public static brand
@@ -315,5 +347,5 @@ export default function middleware(request: Request) {
 }
 
 export const config = {
-  matcher: ['/', '/api/:path*'],
+  matcher: ['/', '/mcp', '/api/:path*'],
 };

--- a/scripts/mcp-live-smoke.mjs
+++ b/scripts/mcp-live-smoke.mjs
@@ -55,10 +55,10 @@
 // instead of re-fetching it per sub-walk. Current shape: ≤16 /mcp POSTs per
 // host (≤32 total) + 3 non-/mcp OAuth probes per host — comfortable headroom
 // under the bucket even as the prompt/resource catalogs grow. The discovery
-// probes (5) add 5 GETs per host that cost NOTHING against the bucket: both
+// probes (5) add 6 GET/HEAD requests per host that cost NOTHING against the bucket: both
 // the discovery branch and the transport 405 return ahead of
 // applyAnonDiscoveryLimit (the replay-shaped GET stops at auth). The variant
-// probes (6) add one limiter-counted ping plus three GETs per variant host;
+// probes (6) add one limiter-counted ping plus four GET/HEADs per variant host;
 // redirect, stream-open, and unauthenticated replay all stop before a limiter.
 //
 // Usage: node scripts/mcp-live-smoke.mjs
@@ -318,6 +318,34 @@ async function probeDiscovery(host) {
     fail(host, 'GET /mcp (crawler)', `HANG/transport error: ${err?.name ?? err}`);
   }
 
+  // HEAD must expose the same discovery metadata without a response body.
+  // This is a separate deployed method path, so unit coverage cannot prove
+  // that the CDN and routing layers preserve it.
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, {
+      method: 'HEAD',
+      headers: { Accept: 'text/html,*/*' },
+    });
+    if (res.status !== 200) {
+      fail(host, 'HEAD /mcp (crawler)', `expected 200, got ${res.status}`);
+    } else if (!/text\/markdown/i.test(res.headers.get('content-type') ?? '')) {
+      fail(host, 'HEAD /mcp (crawler)', `expected markdown metadata, got content-type ${res.headers.get('content-type')}`);
+    } else if (!/\bno-store\b/i.test(res.headers.get('cache-control') ?? '')) {
+      fail(host, 'HEAD /mcp (crawler)', `transport URL guide must be no-store (got "${res.headers.get('cache-control')}")`);
+    } else if (!/\bAccept\b(?!-)/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'HEAD /mcp (crawler)', `guide lacks "Vary: Accept" (got "${res.headers.get('vary')}")`);
+    } else if (!/\bLast-Event-ID\b/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'HEAD /mcp (crawler)', `guide lacks "Vary: Last-Event-ID" (got "${res.headers.get('vary')}")`);
+    } else if (!/<https:\/\/worldmonitor\.app\/mcp>;\s*rel="canonical"/i.test(res.headers.get('link') ?? '')) {
+      fail(host, 'HEAD /mcp (crawler)', `guide lacks the apex canonical Link (got "${res.headers.get('link')}")`);
+    } else {
+      ok(host, 'HEAD /mcp (crawler)', '200 markdown metadata');
+    }
+  } catch (err) {
+    fail(host, 'HEAD /mcp (crawler)', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
   // The canary: an SSE stream-open on the URL just warmed must still be 405.
   checks += 1;
   try {
@@ -409,6 +437,26 @@ async function probeVariantCanonical(host) {
     }
   } catch (err) {
     fail(host, 'GET /mcp → apex canonical', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, {
+      method: 'HEAD',
+      headers: { Accept: 'text/html,*/*' },
+    });
+    const location = res.headers.get('location');
+    if (res.status !== 308 || location !== 'https://worldmonitor.app/mcp') {
+      fail(host, 'HEAD /mcp → apex canonical', `expected 308 → https://worldmonitor.app/mcp, got ${res.status} → ${location}`);
+    } else if (!/\bAccept\b(?!-)/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'HEAD /mcp → apex canonical', `cacheable 308 lacks "Vary: Accept" (got "${res.headers.get('vary')}")`);
+    } else if (!/\bLast-Event-ID\b/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'HEAD /mcp → apex canonical', `cacheable 308 lacks "Vary: Last-Event-ID" (got "${res.headers.get('vary')}")`);
+    } else {
+      ok(host, 'HEAD /mcp → apex canonical', '308');
+    }
+  } catch (err) {
+    fail(host, 'HEAD /mcp → apex canonical', `HANG/transport error: ${err?.name ?? err}`);
   }
 
   checks += 1;

--- a/scripts/mcp-live-smoke.mjs
+++ b/scripts/mcp-live-smoke.mjs
@@ -27,6 +27,21 @@
 //      /.well-known/oauth-authorization-server must be reachable by POST
 //      (no 3xx redirect, no 405 — the #4938 fingerprints). Probes use a
 //      malformed body so nothing is ever registered/minted.
+//   5. The discovery surface and the cache key behind it. /mcp and
+//      /.well-known/mcp content-negotiate on Accept: a plain GET is a
+//      crawler/human discovery read, an `Accept: text/event-stream` GET is a
+//      transport stream-open that must STILL answer 405. Vercel's edge keys
+//      on URL alone unless the origin sends Vary, and it caches these routes
+//      — a cacheable discovery 200 without Vary is replayed to the SSE GET,
+//      handing an SDK client a document body where the transport contract
+//      requires 405. This was reproduced on production against
+//      /.well-known/mcp (`x-vercel-cache: HIT` on the SSE GET). Like #4938 it
+//      lives in the CDN and is invisible to every in-process test, so the
+//      probe warms the cache with the plain GET first and only then issues
+//      the SSE GET.
+//   6. Variant-subdomain canonicalization — crawler-facing GETs on the
+//      product variants must 308 to the apex /mcp (Google reported the
+//      variant URLs as unreachable), while POST must NOT be redirected.
 //
 // Every request runs under a hard timeout that covers BODY READ, not just
 // response headers — a server/CDN that sends headers then stalls the body
@@ -39,7 +54,11 @@
 // (MAX_PROMPT_GETS / MAX_RESOURCE_READS) and reuses each catalog listing
 // instead of re-fetching it per sub-walk. Current shape: ≤16 /mcp POSTs per
 // host (≤32 total) + 3 non-/mcp OAuth probes per host — comfortable headroom
-// under the bucket even as the prompt/resource catalogs grow.
+// under the bucket even as the prompt/resource catalogs grow. The discovery
+// probes (5) add 4 GETs per host that cost NOTHING against the bucket: both
+// the discovery branch and the transport 405 return ahead of
+// applyAnonDiscoveryLimit. The variant probes (6) add one limiter-counted
+// ping per variant host (5) plus 5 redirect GETs that never reach the origin.
 //
 // Usage: node scripts/mcp-live-smoke.mjs
 //   MCP_SMOKE_HOSTS=https://a,https://b  overrides the default host list.
@@ -271,8 +290,126 @@ async function walkHost(host) {
   }
 }
 
+// Discovery + cache-key contract. These requests are answered before the
+// anonymous rate limiter (the discovery branch and the transport 405 both
+// return ahead of it), so they cost nothing against the shared 60/min bucket.
+async function probeDiscovery(host) {
+  // Plain GET /mcp — the "can Google read this?" shape.
+  checks += 1;
+  try {
+    const { res, text } = await timedFetch(`${host}/mcp`, { headers: { Accept: 'text/html,*/*' } });
+    if (res.status !== 200) {
+      fail(host, 'GET /mcp (crawler)', `expected 200, got ${res.status} — Search Console reports this shape as "cannot access"`);
+    } else if (!/text\/markdown/i.test(res.headers.get('content-type') ?? '')) {
+      fail(host, 'GET /mcp (crawler)', `expected the markdown guide, got content-type ${res.headers.get('content-type')}`);
+    } else if (!text.includes('World Monitor MCP Server')) {
+      fail(host, 'GET /mcp (crawler)', 'body is not the mcp-server.md guide');
+    } else {
+      ok(host, 'GET /mcp (crawler)', '200 markdown guide');
+    }
+  } catch (err) {
+    fail(host, 'GET /mcp (crawler)', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
+  // The canary: an SSE stream-open on the URL just warmed must still be 405.
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, { headers: { Accept: 'text/event-stream' } });
+    if (res.status !== 405) {
+      const cached = res.headers.get('x-vercel-cache') === 'HIT'
+        ? ' from a CDN cache HIT — the discovery 200 is being replayed to transport clients (missing/ignored Vary)'
+        : '';
+      fail(host, 'GET /mcp (SSE stream open)', `expected 405, got ${res.status}${cached}`);
+    } else {
+      ok(host, 'GET /mcp (SSE stream open)', '405 preserved after a discovery GET');
+    }
+  } catch (err) {
+    fail(host, 'GET /mcp (SSE stream open)', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
+  // Same contract on the well-known manifest, which IS cacheable and so
+  // depends on Vary rather than no-store.
+  checks += 1;
+  try {
+    const { res, text } = await timedFetch(`${host}/.well-known/mcp`, { headers: { Accept: 'application/json' } });
+    if (res.status !== 200) {
+      fail(host, 'GET /.well-known/mcp', `expected 200, got ${res.status}`);
+    // `(?!-)` is load-bearing: `-` is a word boundary, so a naive /\bAccept\b/
+    // matches the `accept-encoding` that the edge adds on its own and the
+    // check passes against an origin that sends no Vary at all.
+    } else if (!/\bAccept\b(?!-)/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'GET /.well-known/mcp', `cacheable manifest 200 lacks "Vary: Accept" (got "${res.headers.get('vary')}") — a shared cache will serve it to an SSE GET`);
+    } else {
+      JSON.parse(text);
+      ok(host, 'GET /.well-known/mcp', 'cacheable card, correctly varied');
+    }
+  } catch (err) {
+    fail(host, 'GET /.well-known/mcp', `not served or not JSON: ${err?.message ?? err}`);
+  }
+
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/.well-known/mcp`, { headers: { Accept: 'text/event-stream' } });
+    if (res.status !== 405) {
+      const cached = res.headers.get('x-vercel-cache') === 'HIT'
+        ? ' from a CDN cache HIT — the manifest is being replayed to transport clients'
+        : '';
+      fail(host, '/.well-known/mcp (SSE stream open)', `expected 405, got ${res.status}${cached}`);
+    } else {
+      ok(host, '/.well-known/mcp (SSE stream open)', '405 preserved after a manifest GET');
+    }
+  } catch (err) {
+    fail(host, '/.well-known/mcp (SSE stream open)', `HANG/transport error: ${err?.name ?? err}`);
+  }
+}
+
+// Variant subdomains: crawler GETs canonicalize to apex, POST never does.
+const VARIANT_HOSTS = (process.env.MCP_SMOKE_VARIANT_HOSTS
+  ?? 'tech,finance,commodity,happy,energy')
+  .split(',').map((v) => v.trim()).filter(Boolean)
+  .map((v) => `https://${v}.worldmonitor.app`);
+
+async function probeVariantCanonical(host) {
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, { headers: { Accept: 'text/html,*/*' } });
+    const location = res.headers.get('location');
+    if (res.status !== 308 || location !== 'https://worldmonitor.app/mcp') {
+      fail(host, 'GET /mcp → apex canonical', `expected 308 → https://worldmonitor.app/mcp, got ${res.status} → ${location}`);
+    } else {
+      ok(host, 'GET /mcp → apex canonical', '308');
+    }
+  } catch (err) {
+    fail(host, 'GET /mcp → apex canonical', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }),
+    });
+    if (res.status >= 300 && res.status < 400) {
+      fail(host, 'POST /mcp stays on host', `POST answered ${res.status} → ${res.headers.get('location')} — a redirected POST becomes a GET and the handshake dies (#4938)`);
+    } else if (res.status !== 200) {
+      fail(host, 'POST /mcp stays on host', `expected 200 ping, got ${res.status}`);
+    } else {
+      ok(host, 'POST /mcp stays on host', '200 — handshake not canonicalized');
+    }
+  } catch (err) {
+    fail(host, 'POST /mcp stays on host', `HANG/transport error: ${err?.name ?? err}`);
+  }
+}
+
 for (const host of HOSTS) {
   await walkHost(host);
+  await probeDiscovery(host);
+}
+
+console.log('\n── variant canonicalization ──');
+for (const host of VARIANT_HOSTS) {
+  await probeVariantCanonical(host);
 }
 
 console.log(`\n${checks} checks across ${HOSTS.length} host(s); ${failures.length} failure(s).`);

--- a/scripts/mcp-live-smoke.mjs
+++ b/scripts/mcp-live-smoke.mjs
@@ -55,10 +55,11 @@
 // instead of re-fetching it per sub-walk. Current shape: ≤16 /mcp POSTs per
 // host (≤32 total) + 3 non-/mcp OAuth probes per host — comfortable headroom
 // under the bucket even as the prompt/resource catalogs grow. The discovery
-// probes (5) add 4 GETs per host that cost NOTHING against the bucket: both
+// probes (5) add 5 GETs per host that cost NOTHING against the bucket: both
 // the discovery branch and the transport 405 return ahead of
-// applyAnonDiscoveryLimit. The variant probes (6) add one limiter-counted
-// ping per variant host (5) plus 5 redirect GETs that never reach the origin.
+// applyAnonDiscoveryLimit (the replay-shaped GET stops at auth). The variant
+// probes (6) add one limiter-counted ping plus three GETs per variant host;
+// redirect, stream-open, and unauthenticated replay all stop before a limiter.
 //
 // Usage: node scripts/mcp-live-smoke.mjs
 //   MCP_SMOKE_HOSTS=https://a,https://b  overrides the default host list.
@@ -302,6 +303,12 @@ async function probeDiscovery(host) {
       fail(host, 'GET /mcp (crawler)', `expected 200, got ${res.status} — Search Console reports this shape as "cannot access"`);
     } else if (!/text\/markdown/i.test(res.headers.get('content-type') ?? '')) {
       fail(host, 'GET /mcp (crawler)', `expected the markdown guide, got content-type ${res.headers.get('content-type')}`);
+    } else if (!/\bno-store\b/i.test(res.headers.get('cache-control') ?? '')) {
+      fail(host, 'GET /mcp (crawler)', `transport URL guide must be no-store (got "${res.headers.get('cache-control')}")`);
+    } else if (!/\bAccept\b(?!-)/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'GET /mcp (crawler)', `guide lacks "Vary: Accept" (got "${res.headers.get('vary')}")`);
+    } else if (!/\bLast-Event-ID\b/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'GET /mcp (crawler)', `guide lacks "Vary: Last-Event-ID" (got "${res.headers.get('vary')}")`);
     } else if (!text.includes('World Monitor MCP Server')) {
       fail(host, 'GET /mcp (crawler)', 'body is not the mcp-server.md guide');
     } else {
@@ -339,6 +346,8 @@ async function probeDiscovery(host) {
     // check passes against an origin that sends no Vary at all.
     } else if (!/\bAccept\b(?!-)/i.test(res.headers.get('vary') ?? '')) {
       fail(host, 'GET /.well-known/mcp', `cacheable manifest 200 lacks "Vary: Accept" (got "${res.headers.get('vary')}") — a shared cache will serve it to an SSE GET`);
+    } else if (!/\bLast-Event-ID\b/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'GET /.well-known/mcp', `cacheable manifest 200 lacks "Vary: Last-Event-ID" (got "${res.headers.get('vary')}") — a shared cache will serve it to a replay GET`);
     } else {
       JSON.parse(text);
       ok(host, 'GET /.well-known/mcp', 'cacheable card, correctly varied');
@@ -361,6 +370,21 @@ async function probeDiscovery(host) {
   } catch (err) {
     fail(host, '/.well-known/mcp (SSE stream open)', `HANG/transport error: ${err?.name ?? err}`);
   }
+
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/.well-known/mcp`, {
+      headers: { Accept: 'application/json', 'Last-Event-ID': 'smoke-canary' },
+    });
+    if (res.status !== 401 || !/^Bearer\b/i.test(res.headers.get('www-authenticate') ?? '')) {
+      const cached = res.headers.get('x-vercel-cache') === 'HIT' ? ' from a CDN cache HIT' : '';
+      fail(host, '/.well-known/mcp (replay-shaped GET)', `expected origin 401 with Bearer challenge, got ${res.status}${cached}`);
+    } else {
+      ok(host, '/.well-known/mcp (replay-shaped GET)', '401 preserved after a manifest GET');
+    }
+  } catch (err) {
+    fail(host, '/.well-known/mcp (replay-shaped GET)', `HANG/transport error: ${err?.name ?? err}`);
+  }
 }
 
 // Variant subdomains: crawler GETs canonicalize to apex, POST never does.
@@ -376,11 +400,43 @@ async function probeVariantCanonical(host) {
     const location = res.headers.get('location');
     if (res.status !== 308 || location !== 'https://worldmonitor.app/mcp') {
       fail(host, 'GET /mcp → apex canonical', `expected 308 → https://worldmonitor.app/mcp, got ${res.status} → ${location}`);
+    } else if (!/\bAccept\b(?!-)/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'GET /mcp → apex canonical', `cacheable 308 lacks "Vary: Accept" (got "${res.headers.get('vary')}")`);
+    } else if (!/\bLast-Event-ID\b/i.test(res.headers.get('vary') ?? '')) {
+      fail(host, 'GET /mcp → apex canonical', `cacheable 308 lacks "Vary: Last-Event-ID" (got "${res.headers.get('vary')}")`);
     } else {
       ok(host, 'GET /mcp → apex canonical', '308');
     }
   } catch (err) {
     fail(host, 'GET /mcp → apex canonical', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, { headers: { Accept: 'Text/Event-Stream' } });
+    if (res.status !== 405) {
+      const cached = res.headers.get('x-vercel-cache') === 'HIT' ? ' from a CDN cache HIT' : '';
+      fail(host, 'GET /mcp SSE stays on variant', `expected 405, got ${res.status}${cached}`);
+    } else {
+      ok(host, 'GET /mcp SSE stays on variant', '405 preserved after cached canonical redirect');
+    }
+  } catch (err) {
+    fail(host, 'GET /mcp SSE stays on variant', `HANG/transport error: ${err?.name ?? err}`);
+  }
+
+  checks += 1;
+  try {
+    const { res } = await timedFetch(`${host}/mcp`, {
+      headers: { Accept: 'application/json', 'Last-Event-ID': 'smoke-canary' },
+    });
+    if (res.status !== 401 || !/^Bearer\b/i.test(res.headers.get('www-authenticate') ?? '')) {
+      const cached = res.headers.get('x-vercel-cache') === 'HIT' ? ' from a CDN cache HIT' : '';
+      fail(host, 'GET /mcp replay stays on variant', `expected origin 401 with Bearer challenge, got ${res.status}${cached}`);
+    } else {
+      ok(host, 'GET /mcp replay stays on variant', '401 preserved after cached canonical redirect');
+    }
+  } catch (err) {
+    fail(host, 'GET /mcp replay stays on variant', `HANG/transport error: ${err?.name ?? err}`);
   }
 
   checks += 1;

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -590,6 +590,22 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
       assert.equal(guideFallback.headers.get('location'), '/mcp-server.md');
       assert.match(guideFallback.headers.get('vary') ?? '', /\bAccept\b(?!-)/i);
       assert.match(guideFallback.headers.get('vary') ?? '', /\bLast-Event-ID\b/i);
+
+      const cardHeadFallback = await fetch(fallbackAliasUrl, {
+        method: 'HEAD',
+        headers: { Accept: 'application/json' },
+        redirect: 'manual',
+      });
+      assert.equal(cardHeadFallback.status, cardFallback.status);
+      assert.equal(cardHeadFallback.headers.get('location'), cardFallback.headers.get('location'));
+
+      const guideHeadFallback = await fetch(fallbackServer.url, {
+        method: 'HEAD',
+        headers: { Accept: 'text/html,*/*' },
+        redirect: 'manual',
+      });
+      assert.equal(guideHeadFallback.status, guideFallback.status);
+      assert.equal(guideHeadFallback.headers.get('location'), guideFallback.headers.get('location'));
     } finally {
       globalThis.fetch = successfulStaticFetch;
       await fallbackServer.close();
@@ -647,6 +663,20 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.equal(discovery.status, 200);
     assert.match(discovery.headers.get('content-type') ?? '', /text\/markdown/i,
       'HEAD must not claim application/json when GET returns markdown');
+    assert.match(discovery.headers.get('cache-control') ?? '', /\bno-store\b/i);
+    assert.match(discovery.headers.get('vary') ?? '', /\bAccept\b(?!-)/i);
+    assert.match(discovery.headers.get('vary') ?? '', /\bLast-Event-ID\b/i);
+    assert.match(discovery.headers.get('link') ?? '', /<https:\/\/worldmonitor\.app\/mcp>;\s*rel="canonical"/,
+      'HEAD must retain the matching guide GET canonical link');
+
+    const manifest = await fetch(aliasUrl, { method: 'HEAD', headers: { Accept: 'application/json' } });
+    assert.equal(manifest.status, 200);
+    assert.match(manifest.headers.get('content-type') ?? '', /application\/json/i);
+    assert.match(manifest.headers.get('cache-control') ?? '', /max-age=3600/,
+      'HEAD must advertise the matching manifest GET cache policy');
+    assert.doesNotMatch(manifest.headers.get('cache-control') ?? '', /no-store/);
+    assert.match(manifest.headers.get('vary') ?? '', /\bAccept\b(?!-)/i);
+    assert.match(manifest.headers.get('vary') ?? '', /\bLast-Event-ID\b/i);
 
     const streamOpen = await fetch(server.url, {
       method: 'HEAD',
@@ -661,6 +691,22 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     });
     assert.equal(replay.status, 401, 'HEAD must preserve the equivalent authenticated replay GET status');
     assert.match(replay.headers.get('www-authenticate') ?? '', /^Bearer\b/i);
+  });
+
+  it('advertises transport-aware HEAD through CORS preflight', async () => {
+    const res = await fetch(server.url, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://claude.ai',
+        'Access-Control-Request-Method': 'HEAD',
+        'Access-Control-Request-Headers': 'Last-Event-ID, Mcp-Session-Id',
+      },
+    });
+    assert.equal(res.status, 204);
+    assert.match(res.headers.get('access-control-allow-methods') ?? '', /\bHEAD\b/,
+      'cross-origin replay-shaped HEAD must pass preflight');
+    assert.match(res.headers.get('access-control-allow-headers') ?? '', /\bLast-Event-ID\b/i);
+    assert.match(res.headers.get('access-control-allow-headers') ?? '', /\bMcp-Session-Id\b/i);
   });
 
   it('POST initialize completes the live Streamable HTTP handshake at the well-known URL', async () => {

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -462,6 +462,7 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
   let aliasUrl;
   const realFetch = globalThis.fetch;
   const cardText = readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8');
+  const guideText = readFileSync(new URL('../public/mcp-server.md', import.meta.url), 'utf8');
 
   beforeEach(async () => {
     process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
@@ -481,6 +482,9 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
       const href = typeof input === 'string' ? input : input.url ?? String(input);
       if (href.endsWith('/.well-known/mcp/server-card.json')) {
         return Promise.resolve(new Response(cardText, { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (href.endsWith('/mcp-server.md')) {
+        return Promise.resolve(new Response(guideText, { status: 200, headers: { 'Content-Type': 'text/markdown' } }));
       }
       return realFetch(input, init);
     };
@@ -523,6 +527,63 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.equal(res.status, 200);
     const card = await res.json();
     assert.equal(card.url, 'https://worldmonitor.app/mcp');
+  });
+
+  it('plain GET /mcp serves the human-readable server guide (crawler-accessible discovery)', async () => {
+    const res = await fetch(server.url, {
+      headers: { Accept: 'text/html,application/xhtml+xml,*/*' },
+    });
+    assert.equal(res.status, 200, 'a plain GET /mcp must not be the transport 405 (Search Console reads it as "cannot access")');
+    assert.match(res.headers.get('content-type') ?? '', /text\/markdown/i);
+    const body = await res.text();
+    assert.match(body, /# World Monitor MCP Server/, 'must be the mcp-server.md guide, not the JSON card');
+    assert.match(body, /https:\/\/worldmonitor\.app\/mcp/, 'guide must advertise the apex transport URL');
+    assert.match(res.headers.get('link') ?? '', /<https:\/\/worldmonitor\.app\/mcp>;\s*rel="canonical"/,
+      'discovery representation must declare the apex endpoint canonical');
+  });
+
+  // ── cache-key contract ────────────────────────────────────────────────────
+  // Regression net for a bug reproduced on production: /.well-known/mcp served
+  // a `public, max-age=3600` card with no Vary, and Vercel's edge (which keys
+  // on URL alone) replayed that stored 200 to a subsequent
+  // `Accept: text/event-stream` GET — handing an SDK client a JSON body where
+  // the transport contract requires 405. Any cacheable discovery 200 on these
+  // URLs MUST carry Vary; the transport URL must not be cacheable at all.
+  it('server card 200 is cacheable ONLY because it varies on the negotiating headers', async () => {
+    const res = await fetch(aliasUrl, { headers: { Accept: 'application/json' } });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('cache-control') ?? '', /max-age=3600/,
+      'server card GET must stay cacheable');
+    const vary = res.headers.get('vary') ?? '';
+    // `(?!-)` is load-bearing: `-` is a word boundary, so a naive /\bAccept\b/
+    // also matches the `accept-encoding` an edge adds on its own — the check
+    // would pass against an origin sending no Vary at all.
+    assert.match(vary, /\bAccept\b(?!-)/i,
+      'a cacheable 200 negotiated on Accept MUST Vary on Accept, or a shared cache serves it to an SSE GET');
+    assert.match(vary, /\bLast-Event-ID\b/i,
+      'the same URL branches on Last-Event-ID into authenticated replay — that must be part of the cache key too');
+  });
+
+  it('the /mcp transport URL never emits a cacheable 200 body', async () => {
+    const res = await fetch(server.url, { headers: { Accept: '*/*' } });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('cache-control') ?? '', /no-store/,
+      '/mcp is the live transport URL — a stored 200 here can be replayed to an SSE or replay GET');
+    assert.match(res.headers.get('vary') ?? '', /\bAccept\b(?!-)/i);
+  });
+
+  it('an SSE-flavoured GET /mcp still gets the transport 405, never the guide', async () => {
+    const res = await fetch(server.url, { headers: { Accept: 'text/event-stream' } });
+    assert.equal(res.status, 405, 'standalone SSE stream open must keep its graceful 405 signal');
+    assert.match(res.headers.get('allow') ?? '', /\bPOST\b/);
+    assert.doesNotMatch(res.headers.get('content-type') ?? '', /text\/markdown/i);
+  });
+
+  it('HEAD /mcp advertises the same representation the GET returns', async () => {
+    const res = await fetch(server.url, { method: 'HEAD' });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type') ?? '', /text\/markdown/i,
+      'HEAD must not claim application/json when GET returns markdown');
   });
 
   it('POST initialize completes the live Streamable HTTP handshake at the well-known URL', async () => {

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -460,6 +460,7 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
   let deps;
   let server;
   let aliasUrl;
+  let staticFetchCalls;
   const realFetch = globalThis.fetch;
   const cardText = readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8');
   const guideText = readFileSync(new URL('../public/mcp-server.md', import.meta.url), 'utf8');
@@ -475,15 +476,18 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     deps = makeProDeps().deps;
     server = await startMcpServer(mcpHandler, deps);
     aliasUrl = server.url.replace('/mcp', '/.well-known/mcp');
+    staticFetchCalls = [];
     // The handler self-fetches the static card asset; the localhost harness
     // has no static file server, so serve the on-disk card for that one URL
     // and delegate everything else (including the test's own requests).
     globalThis.fetch = (input, init) => {
       const href = typeof input === 'string' ? input : input.url ?? String(input);
       if (href.endsWith('/.well-known/mcp/server-card.json')) {
+        staticFetchCalls.push({ href, init });
         return Promise.resolve(new Response(cardText, { status: 200, headers: { 'Content-Type': 'application/json' } }));
       }
       if (href.endsWith('/mcp-server.md')) {
+        staticFetchCalls.push({ href, init });
         return Promise.resolve(new Response(guideText, { status: 200, headers: { 'Content-Type': 'text/markdown' } }));
       }
       return realFetch(input, init);
@@ -513,6 +517,13 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.equal(card.kind, 'product');
     assert.equal(card.serverUrl, 'https://worldmonitor.app/mcp');
     assert.equal(card.remotes?.[0]?.url, 'https://worldmonitor.app/mcp');
+    const cardFetch = staticFetchCalls.find(({ href }) => href.endsWith('/.well-known/mcp/server-card.json'));
+    assert.ok(cardFetch, 'server card must be loaded through the deployment self-fetch');
+    assert.equal(
+      new Headers(cardFetch.init?.headers).get('user-agent'),
+      'WorldMonitor-MCP/1.0 (+https://worldmonitor.app)',
+      'server-side fetches must identify WorldMonitor to the deployment edge',
+    );
     // The manifest is a static, immutable-per-deploy asset — it must stay
     // cacheable (it was `public, max-age=3600` as a static file). The MCP
     // no-store CORS bundle must NOT clobber that on the manifest GET, or every
@@ -577,6 +588,15 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.equal(res.status, 405, 'standalone SSE stream open must keep its graceful 405 signal');
     assert.match(res.headers.get('allow') ?? '', /\bPOST\b/);
     assert.doesNotMatch(res.headers.get('content-type') ?? '', /text\/markdown/i);
+  });
+
+  it('classifies SSE Accept values case-insensitively and honors q=0', async () => {
+    const mixedCaseSse = await fetch(server.url, { headers: { Accept: 'Text/Event-Stream' } });
+    assert.equal(mixedCaseSse.status, 405, 'media types are case-insensitive, so mixed-case SSE remains transport');
+
+    const rejectedSse = await fetch(server.url, { headers: { Accept: 'text/event-stream;q=0, text/html' } });
+    assert.equal(rejectedSse.status, 200, 'q=0 explicitly rejects SSE and must select the discovery guide');
+    assert.match(rejectedSse.headers.get('content-type') ?? '', /text\/markdown/i);
   });
 
   it('HEAD /mcp advertises the same representation the GET returns', async () => {

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -553,6 +553,49 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
       'discovery representation must declare the apex endpoint canonical');
   });
 
+  it('redirects discovery reads when deployment static-asset self-fetches fail', async () => {
+    // Import the implementation directly with a unique query so its module-scope
+    // document caches start empty; api/mcp.ts re-exports a shared handler module.
+    const fresh = await import(`../api/mcp/handler.ts?fallback=${Date.now()}-${Math.random()}`);
+    const fallbackServer = await startMcpServer(fresh.mcpHandler, deps);
+    const fallbackAliasUrl = fallbackServer.url.replace('/mcp', '/.well-known/mcp');
+    const successfulStaticFetch = globalThis.fetch;
+
+    globalThis.fetch = (input, init) => {
+      const href = typeof input === 'string' ? input : input.url ?? String(input);
+      if (href.endsWith('/.well-known/mcp/server-card.json')) {
+        return Promise.reject(new Error('deployment self-fetch failed'));
+      }
+      if (href.endsWith('/mcp-server.md')) {
+        return Promise.resolve(new Response(null, { status: 503 }));
+      }
+      return realFetch(input, init);
+    };
+
+    try {
+      const cardFallback = await fetch(fallbackAliasUrl, {
+        headers: { Accept: 'application/json' },
+        redirect: 'manual',
+      });
+      assert.equal(cardFallback.status, 302);
+      assert.equal(cardFallback.headers.get('location'), '/.well-known/mcp/server-card.json');
+      assert.match(cardFallback.headers.get('vary') ?? '', /\bAccept\b(?!-)/i);
+      assert.match(cardFallback.headers.get('vary') ?? '', /\bLast-Event-ID\b/i);
+
+      const guideFallback = await fetch(fallbackServer.url, {
+        headers: { Accept: 'text/html,*/*' },
+        redirect: 'manual',
+      });
+      assert.equal(guideFallback.status, 302);
+      assert.equal(guideFallback.headers.get('location'), '/mcp-server.md');
+      assert.match(guideFallback.headers.get('vary') ?? '', /\bAccept\b(?!-)/i);
+      assert.match(guideFallback.headers.get('vary') ?? '', /\bLast-Event-ID\b/i);
+    } finally {
+      globalThis.fetch = successfulStaticFetch;
+      await fallbackServer.close();
+    }
+  });
+
   // ── cache-key contract ────────────────────────────────────────────────────
   // Regression net for a bug reproduced on production: /.well-known/mcp served
   // a `public, max-age=3600` card with no Vary, and Vercel's edge (which keys
@@ -599,11 +642,25 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.match(rejectedSse.headers.get('content-type') ?? '', /text\/markdown/i);
   });
 
-  it('HEAD /mcp advertises the same representation the GET returns', async () => {
-    const res = await fetch(server.url, { method: 'HEAD' });
-    assert.equal(res.status, 200);
-    assert.match(res.headers.get('content-type') ?? '', /text\/markdown/i,
+  it('HEAD /mcp preserves discovery, stream-open, and replay GET semantics', async () => {
+    const discovery = await fetch(server.url, { method: 'HEAD' });
+    assert.equal(discovery.status, 200);
+    assert.match(discovery.headers.get('content-type') ?? '', /text\/markdown/i,
       'HEAD must not claim application/json when GET returns markdown');
+
+    const streamOpen = await fetch(server.url, {
+      method: 'HEAD',
+      headers: { Accept: 'text/event-stream' },
+    });
+    assert.equal(streamOpen.status, 405, 'HEAD must preserve the equivalent standalone-stream GET status');
+    assert.match(streamOpen.headers.get('allow') ?? '', /\bPOST\b/);
+
+    const replay = await fetch(server.url, {
+      method: 'HEAD',
+      headers: { Accept: 'application/json', 'Last-Event-ID': 'smoke-canary' },
+    });
+    assert.equal(replay.status, 401, 'HEAD must preserve the equivalent authenticated replay GET status');
+    assert.match(replay.headers.get('www-authenticate') ?? '', /^Bearer\b/i);
   });
 
   it('POST initialize completes the live Streamable HTTP handshake at the well-known URL', async () => {

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -340,4 +340,26 @@ describe('middleware /mcp — variant subdomains redirect to apex, POST stays', 
     const res = middleware(req) as Response | void;
     assert.equal(res, undefined, 'OPTIONS /mcp must fall through to the /api/mcp rewrite');
   });
+
+  it('does NOT redirect variant transport GETs with SSE or replay headers', () => {
+    const mixedCaseSse = new Request('https://tech.worldmonitor.app/mcp', {
+      headers: { Accept: 'Text/Event-Stream' },
+    });
+    assert.equal(middleware(mixedCaseSse), undefined, 'mixed-case SSE Accept must fall through to the transport');
+
+    const replay = new Request('https://tech.worldmonitor.app/mcp', {
+      headers: { Accept: 'application/json', 'Last-Event-ID': 'stream:0' },
+    });
+    assert.equal(middleware(replay), undefined, 'Last-Event-ID replay must stay on the session host');
+  });
+
+  it('redirects when SSE is explicitly unacceptable', () => {
+    const req = new Request('https://tech.worldmonitor.app/mcp', {
+      headers: { Accept: 'text/event-stream;q=0, text/html' },
+    });
+    const res = middleware(req) as Response | void;
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 308);
+    assert.equal(res.headers.get('location'), 'https://worldmonitor.app/mcp');
+  });
 });

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -284,3 +284,60 @@ describe('middleware /api/product-catalog — agents reach the public pricing ca
     assert.equal(res.status, 403);
   });
 });
+
+// ── /mcp variant-subdomain canonicalization ──────────────────────────────────
+// The MCP endpoint's canonical URL is apex (`https://worldmonitor.app/mcp`).
+// GET/HEAD requests from variant subdomains are redirected there so discovery
+// signals don't fragment across tech/finance/etc. POST/OPTIONS continue to the
+// /api/mcp rewrite unchanged so MCP clients configured against a variant host
+// still handshake correctly.
+
+describe('middleware /mcp — variant subdomains redirect to apex, POST stays', () => {
+  it('redirects GET /mcp from tech.worldmonitor.app to apex', () => {
+    const res = call('https://tech.worldmonitor.app/mcp', CHROME_UA);
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 308);
+    assert.equal(res.headers.get('location'), 'https://worldmonitor.app/mcp');
+  });
+
+  it('redirects HEAD /mcp from finance.worldmonitor.app to apex', () => {
+    const req = new Request('https://finance.worldmonitor.app/mcp', { method: 'HEAD' });
+    const res = middleware(req) as Response | void;
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 308);
+    assert.equal(res.headers.get('location'), 'https://worldmonitor.app/mcp');
+  });
+
+  it('redirects /mcp from every variant subdomain', () => {
+    for (const host of ['tech', 'finance', 'commodity', 'happy', 'energy']) {
+      const res = call(`https://${host}.worldmonitor.app/mcp`, CHROME_UA);
+      assert.ok(res instanceof Response, `${host} must redirect`);
+      assert.equal(res.status, 308, `${host} redirect status`);
+      assert.equal(res.headers.get('location'), 'https://worldmonitor.app/mcp', `${host} redirect location`);
+    }
+  });
+
+  it('does NOT redirect GET /mcp from apex or www', () => {
+    assert.equal(call('https://worldmonitor.app/mcp', CHROME_UA), undefined);
+    assert.equal(call('https://www.worldmonitor.app/mcp', CHROME_UA), undefined);
+  });
+
+  it('does NOT redirect POST /mcp from a variant subdomain (MCP handshake)', () => {
+    const req = new Request('https://tech.worldmonitor.app/mcp', {
+      method: 'POST',
+      headers: { 'user-agent': CHROME_UA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    const res = middleware(req) as Response | void;
+    assert.equal(res, undefined, 'POST /mcp must fall through to the /api/mcp rewrite');
+  });
+
+  it('does NOT redirect OPTIONS /mcp from a variant subdomain', () => {
+    const req = new Request('https://tech.worldmonitor.app/mcp', {
+      method: 'OPTIONS',
+      headers: { 'user-agent': CHROME_UA },
+    });
+    const res = middleware(req) as Response | void;
+    assert.equal(res, undefined, 'OPTIONS /mcp must fall through to the /api/mcp rewrite');
+  });
+});


### PR DESCRIPTION
## Summary

Google Search Console could not read `/mcp` on any host — `www`, the apex, or the five variant subdomains. A plain browser or crawler `GET` landed on the MCP transport's spec-correct `405 Method Not Allowed`. Opening `https://worldmonitor.app/mcp` now returns the readable server guide, and variant hosts send crawler GETs to the apex canonical.

The interesting part is what the obvious version of that fix would have broken.

## The cache finding

`/mcp` and `/.well-known/mcp` decide what to return by reading request *headers*, not the path. The server card was already shipping `public, max-age=3600` with no `Vary`, and Vercel's edge keys on URL alone. Probing production **before** this change:

```
# warm the cache with a plain discovery GET
GET /.well-known/mcp   Accept: application/json
  → 200, x-vercel-cache: HIT, age: 15, vary: accept-encoding

# the SSE stream-open on the SAME URL
GET /.well-known/mcp   Accept: text/event-stream
  → 200, x-vercel-cache: HIT, age: 15
    content-type: application/json
    {"name":"worldmonitor","kind":"product",...}
```

An MCP SDK client opening the optional standalone stream received a 200 JSON body where the transport contract requires `405`. That is the uncorrelatable-response hang class from the 2026-07-06 outages, arriving through the CDN instead of the handler — which is exactly why no in-process test could see it. The handler always computed `405` correctly.

This is live in production today. Extending the same cacheable-200 pattern to `/mcp` would have moved it onto the actual transport URL.

## The contract now

| Request | Response |
|---|---|
| `GET /mcp` plain | `200 text/markdown` — the server guide, `no-store` |
| `GET /mcp` `Accept: text/event-stream` | `405` + `Allow` (unchanged) |
| `GET /mcp` `Last-Event-ID` | authenticated replay (unchanged) |
| `POST /mcp` | JSON-RPC (unchanged) |
| `HEAD /mcp` | `200`, now advertising `text/markdown` |
| `GET /.well-known/mcp[.json]` plain | `200 application/json` card, cacheable **+ `Vary`** |
| variant host, `GET`/`HEAD /mcp` plain | `308` → apex |
| variant host, `POST`/`OPTIONS /mcp` | falls through to the rewrite (unchanged) |

## Design decisions

**Cacheable card, no-store transport.** The well-known card keeps `public, max-age=3600` and gains `Vary: Accept, Last-Event-ID`. The transport URL goes further and stays `no-store`. `Vary` is the correct fix, but it only works if every intermediary honors it — and the transport URL is where a mistake is most expensive, so its correctness doesn't depend on that. The cacheable copy of the guide still lives at `/mcp-server.md`; crawler volume on `/mcp` is negligible.

**Apex, not www.** `ARCHITECTURE.md:72` documents the Cloudflare apex→www rule whose exemption list is load-bearing: `/mcp` and `/mcp/*` are served on the apex and never redirected. The server card already advertises the apex endpoint, so the redirect target and the advertised canonical agree. The guide also emits a `rel="canonical"` link to it.

**The 308 is hand-built.** `Response.redirect()` can't set headers, and a `308` is cacheable by default (RFC 9110 §15.4.9) — so the redirect needs the same `Vary` discipline as the responses.

**Crawlers are identified by request semantics, never user-agent.** A plain `GET` is a discovery read; anything carrying `Last-Event-ID` or an SSE `Accept` is a transport operation. No allowlist to maintain.

## Validation

- **418 tests pass** across 7 suites (transport conformance, middleware, protocol conformance, anon-client conformance, resources, deploy-config); `tsc --noEmit` clean.
- **Mutation-tested.** Each fix was reverted individually to confirm the new tests actually fail: drop `Vary` → only the cache-key test fails; make `/mcp` cacheable → only the transport-cacheability test fails; revert to serving JSON → 2 fail.
- **The new production probe was validated against un-fixed production**, where it independently reproduced all three defects — the `405` on plain `GET /mcp`, the `x-vercel-cache: HIT` replay, and the missing variant redirect on all five hosts.

`scripts/mcp-live-smoke.mjs` (6-hourly cron) now warms the cache with a plain GET and fails if the follow-up SSE GET is anything but `405`, naming `x-vercel-cache: HIT` when it's a replay. The discovery probes cost nothing against the anonymous rate-limit bucket — both the discovery branch and the transport `405` return ahead of the limiter.

Not yet verified in production, since the fix isn't deployed. After merge, `node scripts/mcp-live-smoke.mjs` going green on all 38 checks is the real proof.

One landmine worth flagging for reviewers: the first version of the `Vary` assertion was `/\bAccept\b/i`, which **passed against un-fixed production** — `-` is a word boundary, so it matched the edge's own `accept-encoding`. It is now `/\bAccept\b(?!-)/i` in both the test and the probe. A check that passes on the broken system is worse than no check.

Related: #4937, #4938

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
