### PR TITLE
docs(solutions): capture two reusable learnings from the KV cutover (#5338)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -24,6 +24,12 @@ The delivery contract of the boot payload: a hydrated value can be read exactly 
 
 The project's costing heuristic for cache and egress work: egress ≈ origin-miss count × transferred payload size. Client count, reader count, and total request volume are absorbed by the CDN and do not appear in the formula, so a proposed optimization reduces egress only if it reduces the miss rate or the bytes per miss. Applied before scoping any bandwidth work; proposals whose arithmetic nets to zero (deduplicating identical stored bytes while both read paths survive, flipping a client-side default that never touches the served payload) are discarded on paper. See also: One-Shot Hydration, Bootstrap View Key.
 
+### Shadow Measurement
+
+Running a candidate read path against real production traffic while continuing to serve from the incumbent — the candidate's result is timed and discarded, never delivered — so a storage or routing cutover is decided on this project's own traffic rather than on a vendor's published performance characteristics.
+
+Two rules make a shadow comparable rather than merely reassuring. The candidate must be measured entirely off the response path, so enabling it on live traffic cannot change what any client receives. And the incumbent must be measured on the *same* traffic over the *same* window, because a candidate's latency means nothing against a baseline drawn from different requests or a different hour. A shadow that clears its gate answers only "is the candidate faster here"; the serving path's own failure and slowness handling still has to be proven separately, since a shadow never exercises them. See also: The Lever Test, Bootstrap Tier.
+
 ## Notifications & Alert Delivery
 
 ### Alert Rule

--- a/docs/solutions/best-practices/gate-rollouts-on-traffic-weighted-data-not-a-hand-picked-cohort.md
+++ b/docs/solutions/best-practices/gate-rollouts-on-traffic-weighted-data-not-a-hand-picked-cohort.md
@@ -1,0 +1,142 @@
+---
+title: "Gate a rollout on traffic-weighted data, not a hand-picked cohort"
+date: 2026-07-18
+category: best-practices
+module: "Bootstrap storage cutover verification (U-K3 gate, #5338)"
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when: "Writing the pass/fail gate for a migration, cutover, or A/B rollout — especially when the plan names a specific 'worst case' cohort to gate on"
+tags: [verification-gate, rollout, percentile, sample-size, traffic-weighted, decision-criteria, measurement, cutover, p95]
+---
+
+# Gate a rollout on traffic-weighted data, not a hand-picked cohort
+
+## Context
+
+The plan for cutting the bootstrap public tier over to a new storage backend specified its verify
+gate up front as: *"gate on the worst APAC cohort (hkg1/syd1/bom1/sin1) — the candidate's p99 must
+be materially below the incumbent there."* Picking the worst-looking region and demanding the
+candidate win there feels like the conservative, rigorous choice.
+
+It was neither. When the measurement window actually ran, that gate produced a table nobody could
+act on:
+
+- **APAC is a minority of the traffic.** The user base was genuinely worldwide — the top countries
+  by volume were the US, India, Italy, Australia, Germany, the UK, Japan, France, Singapore, and
+  the UAE. Gating on four APAC cities decided a global cutover on a slice of it.
+- **One of the four named cities never gathered enough data to judge.** Seoul finished the window
+  with roughly 14–20 samples per side. It reported a "win" that meant nothing.
+- **A per-city p95 on a thin cell is noise, not a verdict.** With ~20 samples, the 95th percentile
+  *is* essentially the maximum observed value, so one slow read moves it arbitrarily.
+
+Jakarta made the last point unmissable. Its p95 read **222 ms at n=4, then 1418 ms at n=32, then
+1341 ms at n=56, then 799 ms at n=86** — a ~6× swing driven by sample count alone, before it
+settled. A gate evaluated at any single one of those moments would have returned a confident and
+different answer.
+
+## Guidance
+
+**Pick the gate's denominator from where users actually are.** Replace "does the candidate win in
+cohort X" with a single traffic-weighted metric over *all* traffic — here, *the share of all reads
+clearing the client latency budget*. Weighting is automatic, no cohort has to be chosen, and the
+number is directly meaningful to the decision being made.
+
+Then structure the gate as **two separate tests**, because they answer different questions:
+
+1. **Relative (the blocker):** does the candidate regress anyone? Compare candidate vs incumbent
+   per region, *but only in cells with enough samples to judge*. A regression in a well-sampled
+   region blocks the rollout.
+2. **Absolute (the quality bar):** what share of all traffic clears the target? Report it; hold it
+   to a threshold. This is a bulk-quality measure, **not** a per-region hard requirement.
+
+**Add a minimum-sample threshold so thin cells report `inconclusive` rather than a false PASS or
+FAIL.** This is the single highest-value line in a gate script. Without it, small cells emit
+confident verdicts that flip run to run.
+
+Finally, keep the absolute bar from masquerading as a blocker. A region where the candidate is
+*better than the incumbent yet still misses the absolute target* is a follow-up, not a stop —
+because shipping still improves those users. Conflating the two is what made the first version of
+this gate hard-fail on a 32-sample remote city while the candidate was beating the incumbent there.
+
+## Why This Matters
+
+Reframing from the APAC cohort to a global traffic-weighted metric did two things.
+
+It produced a **decisive** answer where the cohort gate had produced an ambiguous one: the
+candidate cleared the budget for **99.6 %** of all reads versus the incumbent's **84.4 %** — the
+incumbent was missing roughly one request in six, globally.
+
+More importantly, it **surfaced the findings the cohort lens had hidden entirely**:
+
+- The incumbent was *catastrophic* in regions nobody had named as the worst case — clearing the
+  budget for only ~40 % of reads in Africa and ~39 % in Oceania. The APAC-only gate would never
+  have looked there.
+- The incumbent's platform had **no Middle East region at all**, so MENA users were being served
+  from Europe — while the candidate served them locally at ~270 ms with 100 % clearing the budget.
+  For a MENA-centred user base this was arguably the single most valuable finding of the exercise,
+  and the original gate could not have produced it.
+
+The hand-picked cohort did not just measure the wrong thing — it pointed attention away from where
+the real problem was.
+
+## When to Apply
+
+Apply whenever writing the accept/reject criteria for a cutover, migration, dependency swap,
+infrastructure change, or performance A/B — particularly when a plan or ticket already names a
+"worst case" cohort to gate on. Treat that named cohort as a *diagnostic view*, not the gate.
+
+Also apply when reviewing a gate someone else wrote. The tells:
+
+- The gate's denominator is a chosen subset rather than all traffic.
+- Percentiles are computed per narrow cell with no sample-count guard.
+- A single threshold serves as both "did anyone regress" and "is quality good enough".
+
+Less relevant when the cohort genuinely *is* the population (a region-specific launch), or when
+per-cell volumes are large enough that thin-cell noise cannot arise.
+
+## Examples
+
+**Before — cohort gate with a hard absolute clause and no sample guard:**
+
+```python
+APAC = ["hkg1", "syd1", "bom1", "sin1"]
+for city in APAC:
+    ok = kv_p95[city] < redis_p95[city] and kv_p95[city] < BUDGET_MS
+    if not ok:
+        gate_pass = False          # a 32-sample city can hard-fail the whole rollout
+```
+
+**After — traffic-weighted headline, sample-guarded relative test, separate quality bar:**
+
+```python
+MIN_SAMPLES  = 25    # below this a per-cell p95 sits on the near-max sample => inconclusive
+BULK_TARGET  = 99.0  # % of ALL reads that must clear the budget
+
+# 1. Relative test (the blocker) — only where the cell can actually be judged.
+for city in regions:
+    if kv_n[city] < MIN_SAMPLES or rds_n[city] < MIN_SAMPLES:
+        verdict[city] = "thin"                      # inconclusive, NOT a pass or fail
+    elif kv_p95[city] > rds_p95[city]:
+        regressions.append(city)                    # this is what blocks
+    elif kv_p95[city] > BUDGET_MS:
+        budget_misses.append(city)                  # beats incumbent but misses target => follow-up
+
+# 2. Absolute quality bar (traffic-weighted over ALL reads, no cohort chosen).
+under_pct = 100.0 * reads_under_budget / reads_total
+
+gate = (not regressions) and under_pct >= BULK_TARGET
+```
+
+The rewritten gate changed the reported outcome without any change in the underlying data: the
+same window that "FAIL"ed on a 32-sample remote city under the first version returned a clean pass
+with that city correctly reported as *"beats incumbent, misses absolute target — follow-up"*, and
+the thin cell reported as *inconclusive* instead of a fabricated win.
+
+## Related
+
+- `docs/solutions/2026-07-16-bootstrap-kv-verify.md` — the verify artifact this gate produced,
+  including the continent-level table that the cohort framing would have omitted.
+- `docs/solutions/design-patterns/hedge-cache-read-against-origin-not-hard-timeout.md` — the same
+  window's data used for a different decision, and another instance of the general habit: measure
+  the distribution before committing to a constant.

--- a/docs/solutions/design-patterns/hedge-cache-read-against-origin-not-hard-timeout.md
+++ b/docs/solutions/design-patterns/hedge-cache-read-against-origin-not-hard-timeout.md
@@ -1,0 +1,150 @@
+---
+title: "Hedge a cache read against origin instead of hard-timing it out"
+date: 2026-07-18
+category: design-patterns
+module: "Bootstrap public-tier serving (workers/api-cors-preflight/src/kv-serve.js)"
+problem_type: design_pattern
+component: service_object
+severity: medium
+applies_when: "A read path has a fast primary (cache/replica/edge store) and a fallback origin, and you are about to pick a timeout value that decides when to abandon the primary"
+tags: [hedge, hedged-request, timeout, cache-fallback, cloudflare-kv, edge-serving, tail-latency, p95, latency-budget]
+---
+
+# Hedge a cache read against origin instead of hard-timing it out
+
+## Context
+
+The bootstrap public tier was being cut over from Vercel-Function→Upstash-Redis to a Cloudflare
+Worker reading Workers KV at the edge (#5338, shipped in #5357). The serving path needed a policy
+for "what if the KV read is slow?"
+
+The first implementation used a **3 s hard read timeout**. A reviewer correctly flagged it: a hung
+KV read delayed the start of origin fallback by ~3 s, far past the ~1200 ms mobile-client abort
+budget the whole project was chasing. The proposed fix was to tighten the timeout to **500 ms**,
+reasoned as *"leaves a 700 ms reserve for the established origin path before the client deadline."*
+
+That reasoning is where the trap is. It sounds prudent, and it is wrong whenever **origin is the
+slow thing** — which was exactly the case here (the incumbent Redis path measured p95 ≈ 1600 ms).
+A 500 ms cap does not buy a 700 ms origin reserve; it abandons a read that was about to succeed
+under budget and hands the request to a path that is *slower*.
+
+## Guidance
+
+**Before choosing any timeout value, measure what percentage of real reads land in the band the
+timeout would abandon** — i.e. reads slower than the timeout but still faster than the client
+budget. That band is pure downside: those requests would have succeeded in time.
+
+From the U-K3 shadow window (2026-07-16 → 07-17), share of successful KV reads by band:
+
+| tier | ≤500 ms (served) | **500–1200 ms (abandoned by a 500 ms cap, yet under budget)** | >1200 ms |
+|---|---|---|---|
+| fast | 99.0 % | **0.9 %** | 0.2 % |
+| slow | 96.3 % | **3.0 %** | 0.7 % |
+
+The global average hides the real cost — the band concentrates in specific high-traffic metros:
+
+| colo | % of reads in the 500–1200 ms band | n |
+|---|---|---|
+| ADL (Adelaide) | 18.6 % | 86 |
+| BKK (Bangkok) | 16.3 % | 221 |
+| CPT (Cape Town) | 14.9 % | 308 |
+| DAC (Dhaka) | 14.8 % | 243 |
+| JNB (Johannesburg) | 13.4 % | 769 |
+| DEL (Delhi) | 11.4 % | 905 |
+
+Delhi and Johannesburg are not fringe POPs — India was the #2 traffic country. A 500 ms cap would
+have bounced ~11–13 % of their reads to a slower path.
+
+**When the fallback is not reliably faster than the primary, a hard timeout is the wrong shape.
+Use a hedge instead:** give the primary a head start; if it has not answered by then, start origin
+*in parallel* and serve whichever becomes usable first.
+
+The hedge's real elegance is that **it removes the need to pick a timeout value at all**. A
+slow-but-valid read still wins and is served; a genuinely hung read simply loses the race to
+origin. There is no threshold to mis-calibrate, and no tier-specific tuning to keep in sync.
+
+## Why This Matters
+
+A hard timeout forces one number to answer two unrelated questions: *"is this read hung?"* and
+*"should I stop waiting?"* Those have different right answers. A read progressing normally toward
+completion at 700 ms is not hung, and abandoning it is a pure loss when origin costs more.
+
+Framed as expected value, a tight cap trades a **certain** win (serve the under-budget read) for a
+**gamble** (origin might hit its edge cache and be fast, or might miss and hit slow Redis). The
+band it sacrifices (0.9 % fast / 3.0 % slow, far higher in specific metros) is larger than the
+band it helps (0.2 % / 0.7 % over budget) — and it only helps that smaller band probabilistically.
+
+A secondary trap: the tight cap bit hardest on the **slow tier**, which had 3× the at-risk band
+*and* was the first tier scheduled for cutover. A single global timeout value silently mis-fits
+per-tier reality; the hedge is self-correcting and needs no per-tier variant.
+
+## When to Apply
+
+Reach for a hedge, not a timeout, when **all** of these hold:
+
+- There is a fast primary and a fallback, and the fallback is **not reliably faster** than a slow
+  primary read (cache↔origin, edge store↔regional DB, replica↔primary, CDN↔origin).
+- The primary's latency distribution has a meaningful tail that still lands inside the client
+  budget — check this with data; do not assume.
+- A redundant fallback request is affordable. Cost here was one extra origin fetch on the ~1–4 % of
+  reads that outrun the hedge window, and those often hit Vercel's edge cache rather than Redis.
+
+Prefer a plain timeout when the fallback is genuinely and reliably faster, when the primary has no
+meaningful in-budget tail, or when a duplicate downstream request is unacceptable (non-idempotent
+writes, metered/expensive calls).
+
+**Pick the head-start from the distribution, not intuition:** ~99 % of fast-tier and ~96 % of
+slow-tier reads finished inside 500 ms, so a 500 ms head start means the hedge — and its redundant
+fetch — engages only on the slow tail.
+
+## Examples
+
+**Before — a hard cap that abandons in-budget reads:**
+
+```js
+const SERVE_READ_TIMEOUT_MS = 500; // "leaves 700ms reserve for origin"  <-- unsound if origin is slower
+const raw = await Promise.race([
+  env.BOOTSTRAP_KV.get(tier, { type: 'text' }),
+  new Promise((_, reject) => setTimeout(() => reject(READ_TIMEOUT), SERVE_READ_TIMEOUT_MS)),
+]);
+// a read that would have completed at 700ms is discarded -> routed to a ~1600ms p95 path
+```
+
+**After — hedge (`workers/api-cors-preflight/src/kv-serve.js:34`, `:109`, `:120` on `main`):**
+
+```js
+const HEDGE_DELAY_MS = 500; // head start, not a deadline
+
+// Phase 1 — wait for KV, but no longer than the head start before enlisting origin.
+const hedge = hedgeTimer(HEDGE_DELAY_MS);
+const first = await Promise.race([kv, hedge.promise]);
+hedge.cancel();                       // fast win: origin is never fetched at all
+if (first.kind === 'kv' && first.decision.outcome === 'kv') return serveFromKv(...);
+
+// Phase 2 — origin enlisted once; a slow-but-valid KV read can still win the race.
+const origin = fetchOrigin().then((resp) => ({ kind: 'origin', resp }));
+const settled = first.kind === 'kv' ? await origin : await Promise.race([kv, origin]);
+```
+
+Two structural details that made this safe:
+
+1. **One origin implementation.** `fetchOrigin` is injected from the caller
+   (`workers/api-cors-preflight/src/index.js:200`), and is the *same* `passThroughToOrigin`
+   (`:134`) used by the normal pass-through (`:211`). The hedge never re-implements origin+CORS, so
+   the two paths cannot drift, and origin is fetched **at most once** per request.
+2. **A distinct fallback reason.** The serving metric emits `kv_reason: 'hedged'` when origin wins,
+   separate from `miss | stale | invalid | error`. That makes "primary was too slow" a directly
+   observable rate post-cutover rather than an assumption baked into a constant.
+
+Test coverage that locks the behaviour (`workers/api-cors-preflight/kv-serve.test.mjs`): a fast read
+is served with origin never enlisted; a hung read hedges to origin and records `hedged`; and — the
+one that would have caught the original bug — **a slow-but-valid read still wins the race and is
+served, rather than being abandoned.**
+
+## Related
+
+- `docs/solutions/2026-07-16-bootstrap-kv-verify.md` — the U-K3 verify gate whose shadow data
+  supplied the band measurement above.
+- Staleness fallback is a *separate* concern from slowness: validity/freshness is decided by
+  `classifyKvEnvelope` with per-tier bounds (`workers/api-cors-preflight/src/kv-shadow.js:22`,
+  fast 15 min / slow 60 min). The hedge answers "too slow"; the staleness guard answers "too old".


### PR DESCRIPTION
Compounds the durable lessons from the bootstrap KV serving arc (#5357 / #5363, both merged). Docs-only — no code, no behavior change.

### 1. `design-patterns/hedge-cache-read-against-origin-not-hard-timeout.md`
**Before picking any timeout, measure the % of real reads in the band it would abandon.** A 500ms hard cap on the KV serve path looked prudent ("leaves 700ms reserve for origin before the 1200ms mobile abort") — but shadow data showed **10–18% of reads in real high-traffic metros** (Delhi 11.4% of 905, Johannesburg 13.4% of 769, Bangkok 16.3%) complete in the **500–1200ms band — under budget** — and would have been abandoned to a *slower* origin (p95 ~1600ms). The "reserve for origin" reasoning is unsound when origin is the slow thing. A hedge (head start, then race origin) serves the slow-but-valid read and removes the need for a timeout value entirely.

### 2. `best-practices/gate-rollouts-on-traffic-weighted-data-not-a-hand-picked-cohort.md`
The verify gate was specified up front as *"gate on the worst APAC cohort."* APAC was a minority of traffic, Seoul never reached judgeable samples (n≈14–20), and a per-city p95 on a thin cell is the near-max sample — Jakarta read **222ms@n=4, 1418@n=32, 1341@n=56, 799@n=86**. Reframing to a global traffic-weighted metric gave the decisive answer (99.6% vs 84.4% under budget) **and surfaced what the cohort lens hid**: the incumbent clearing only ~40% in Africa / ~39% in Oceania, and having **no Middle East region at all** while MENA users hit European origin.

### CONCEPTS.md
Adds `Shadow Measurement` — the named method both learnings depend on, with the two rules that make a shadow comparable (measure off the response path; measure the incumbent on the *same* traffic and window).

Both docs pass the frontmatter parser-safety and mechanical claims validators.