### PR TITLE
fix(deps): clear high-severity DoS advisories failing the security-audit gate

### DIFF
--- a/.github/scripts/audit-production-dependencies.mjs
+++ b/.github/scripts/audit-production-dependencies.mjs
@@ -17,7 +17,14 @@ export const BASELINE_ADVISORIES_BY_LOCKFILE = {
   'package-lock.json': [],
   'consumer-prices-core/package-lock.json': [],
   'blog-site/package-lock.json': [],
-  'pro-test/package-lock.json': ['GHSA-qjx8-664m-686j', 'GHSA-w24r-5266-9c3c'],
+  // GHSA-395f-4hp3-45gv (shell-quote quadratic-complexity DoS in parse()) reaches
+  // pro-test only via react-native -> react-devtools-core, a mobile/dev-tooling
+  // chain the Vite web build never bundles into public/pro/. The parse() DoS is
+  // unreachable from the shipped browser bundle, and forcing shell-quote up (an
+  // `overrides` pin bump) would drag an otherwise-untouched public/pro/ rebuild
+  // into a lockfile-hygiene change. Baselined rather than patched here; drop it
+  // once react-native leaves pro-test's tree. (GHSA-qjx8/w24r predate this.)
+  'pro-test/package-lock.json': ['GHSA-qjx8-664m-686j', 'GHSA-w24r-5266-9c3c', 'GHSA-395f-4hp3-45gv'],
   'scripts/package-lock.json': [],
   'docker/runtime-package-lock.json': [],
 };

--- a/blog-site/package-lock.json
+++ b/blog-site/package-lock.json
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
-      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.5.7",
@@ -1697,9 +1697,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
-      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -2517,9 +2517,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2851,9 +2851,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,20 +1110,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -1453,13 +1453,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3209,13 +3209,13 @@
       }
     },
     "node_modules/@clerk/clerk-js": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-6.13.0.tgz",
-      "integrity": "sha512-WJGUV7u+DvblUkFqDFK3Ym3zgfNu4X9BwrsEfJv91t0XOjrx27JDOxV1jyYFp/C6ecEo58HXcFqY+t2WBKoTNw==",
+      "version": "6.25.5",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-6.25.5.tgz",
+      "integrity": "sha512-RcMZLAj3nKJd4cVGdPFGmUjaLN4JlY1eLrQOmnP9z8Z7vX8Y3YXhIpD/M2KHvh4N5UNpArkjYOOzsIfUqfn/HA==",
       "license": "MIT",
       "dependencies": {
         "@base-org/account": "2.0.1",
-        "@clerk/shared": "^4.14.0",
+        "@clerk/shared": "^4.25.5",
         "@coinbase/wallet-sdk": "4.3.7",
         "@solana/wallet-adapter-base": "0.9.27",
         "@solana/wallet-adapter-react": "0.15.39",
@@ -3237,17 +3237,15 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.14.0.tgz",
-      "integrity": "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ==",
-      "hasInstallScript": true,
+      "version": "4.25.5",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.5.tgz",
+      "integrity": "sha512-pb+pA+88OACHSuE0JhsnV7Qzl1j9UhI9KrXivS831x1BJOtNYORnDqRg3xss2SPFcC46clE9S5QqkRQqv1lSsg==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.7",
-        "std-env": "^3.9.0"
+        "js-cookie": "3.0.7"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4816,9 +4814,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7723,49 +7721,44 @@
       }
     },
     "node_modules/@solana-mobile/mobile-wallet-adapter-protocol": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.2.8.tgz",
-      "integrity": "sha512-c3FQsrM7nV62DqVaHGKtr2osE2w5gS3/wjy8ILF0zczS/s1mERX+JTmf+UHd8xgESmEj/IM7q+U2Qhrmac1PdA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.2.9.tgz",
+      "integrity": "sha512-qtWJq0hzKgngVG0So2ViBRPYDculaxgj40WDSP1nzgdg85MXyAmTEjQqV10uSVbZRm9b1hl601HDJX1sHTgeiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/codecs-strings": "^6.0.0",
+        "@solana/kit": "^6.0.0",
         "@solana/wallet-standard-features": "^1.3.0",
         "@solana/wallet-standard-util": "^1.1.2",
-        "@wallet-standard/core": "^1.1.1",
-        "js-base64": "^3.7.5"
+        "@wallet-standard/core": "^1.1.1"
       },
       "peerDependencies": {
         "react-native": ">0.74"
       }
     },
     "node_modules/@solana-mobile/mobile-wallet-adapter-protocol-web3js": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.2.8.tgz",
-      "integrity": "sha512-W9DbsFvl5lSOe7KT3dJX4tjbxfYIoOtOTJpvLMgkojyRU0UKChQ4vHvbOZQ3GkUJ8wOIS4qdrM0Yytd1Vy+YQQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.2.9.tgz",
+      "integrity": "sha512-TAMItAuOb7duwYQ+PZ6JNqw/6TEhCWLObHF5uOBGV9tjCozHGVunxa7lTeuHAWIgO68IAo86MZdE5kethDATpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
-        "bs58": "^6.0.0",
-        "js-base64": "^3.7.5"
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.9"
       },
       "peerDependencies": {
         "@solana/web3.js": "^1.98.4"
       }
     },
     "node_modules/@solana-mobile/wallet-adapter-mobile": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.2.8.tgz",
-      "integrity": "sha512-ZbXY3/0+UnnyS0hvArpO1b1pYzaQAiVIp+HBUm11aLEkE5+ISvHTRPr/bCEUXZfPkez/1n9zH3H0leK25Lj6Nw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.2.9.tgz",
+      "integrity": "sha512-IWzI2pUmEqBsTNo+XqMTY38NL5TSdMetES59N0Cmuf+zYqiS56rHdMwD/R2IOy7E4yKa1CsuHfCh6CE6zk4ViQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
-        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.8",
-        "@solana-mobile/wallet-standard-mobile": "^0.5.2",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.9",
+        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.9",
+        "@solana-mobile/wallet-standard-mobile": "^0.5.3",
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/core": "^1.1.1",
-        "bs58": "^6.0.0",
-        "js-base64": "^3.7.5",
         "tslib": "^2.8.1"
       },
       "optionalDependencies": {
@@ -7777,24 +7770,91 @@
       }
     },
     "node_modules/@solana-mobile/wallet-standard-mobile": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-standard-mobile/-/wallet-standard-mobile-0.5.2.tgz",
-      "integrity": "sha512-orEGv4N/Ttd0umwfWUzGcEnVc9eJDTgRSEcDitvFWpIf2D968h6128L0rq9/y7sUw88Gvu/lU0euoC2ASEijqQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-standard-mobile/-/wallet-standard-mobile-0.5.3.tgz",
+      "integrity": "sha512-/Ea/CNIWHExpXsA6syVy7fUUhONtYob+VMsmF8flm8GEAZQyzX6UtKSy4NQMMTGBTAGlmmmbBVrZF+Tp5/fDxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.9",
         "@solana/wallet-standard-chains": "^1.1.1",
         "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",
         "@wallet-standard/wallet": "^1.1.0",
-        "bs58": "^6.0.0",
-        "js-base64": "^3.7.5",
         "qrcode": "^1.5.4",
         "tslib": "^2.8.1"
       },
       "optionalDependencies": {
         "@react-native-async-storage/async-storage": "^1.17.7"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.10.0.tgz",
+      "integrity": "sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.10.0.tgz",
+      "integrity": "sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.10.0.tgz",
+      "integrity": "sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/buffer-layout": {
@@ -7810,13 +7870,60 @@
         "node": ">=5.10"
       }
     },
-    "node_modules/@solana/codecs-core": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
-      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+    "node_modules/@solana/codecs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.10.0.tgz",
+      "integrity": "sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "6.9.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/options": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.10.0.tgz",
+      "integrity": "sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.10.0.tgz",
+      "integrity": "sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7831,13 +7938,13 @@
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
-      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.10.0.tgz",
+      "integrity": "sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/errors": "6.9.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7852,14 +7959,14 @@
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
-      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.10.0.tgz",
+      "integrity": "sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/errors": "6.9.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7878,16 +7985,830 @@
       }
     },
     "node_modules/@solana/errors": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
-      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.10.0.tgz",
+      "integrity": "sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "commander": "14.0.3"
+        "commander": "15.0.0"
       },
       "bin": {
         "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.10.0.tgz",
+      "integrity": "sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.10.0.tgz",
+      "integrity": "sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.10.0.tgz",
+      "integrity": "sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.10.0.tgz",
+      "integrity": "sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.10.0.tgz",
+      "integrity": "sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.10.0.tgz",
+      "integrity": "sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.10.0.tgz",
+      "integrity": "sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/plugin-core": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/program-client-core": "6.10.0",
+        "@solana/programs": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "@solana/sysvars": "6.10.0",
+        "@solana/transaction-confirmation": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.10.0.tgz",
+      "integrity": "sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.10.0.tgz",
+      "integrity": "sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.10.0.tgz",
+      "integrity": "sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.10.0.tgz",
+      "integrity": "sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.10.0.tgz",
+      "integrity": "sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.10.0.tgz",
+      "integrity": "sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/signers": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.10.0.tgz",
+      "integrity": "sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.10.0.tgz",
+      "integrity": "sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.10.0.tgz",
+      "integrity": "sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-transport-http": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.10.0.tgz",
+      "integrity": "sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.10.0.tgz",
+      "integrity": "sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.10.0.tgz",
+      "integrity": "sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.10.0.tgz",
+      "integrity": "sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.10.0.tgz",
+      "integrity": "sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions-api": "6.10.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.10.0.tgz",
+      "integrity": "sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.10.0.tgz",
+      "integrity": "sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.10.0.tgz",
+      "integrity": "sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.10.0.tgz",
+      "integrity": "sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.10.0.tgz",
+      "integrity": "sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "undici-types": "^8.4.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.8.0.tgz",
+      "integrity": "sha512-nNSnIK0VcEoNWrYwxCz9DFT1W7ASyBRWX7Hju/p9RAfVDcHoH07hkMg/na9U/2S04fhkPc4pDUK5NblZoaCvwg==",
+      "license": "MIT"
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.10.0.tgz",
+      "integrity": "sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.10.0.tgz",
+      "integrity": "sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.10.0.tgz",
+      "integrity": "sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.10.0.tgz",
+      "integrity": "sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.10.0.tgz",
+      "integrity": "sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.10.0.tgz",
+      "integrity": "sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.10.0.tgz",
+      "integrity": "sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7951,15 +8872,15 @@
       }
     },
     "node_modules/@solana/wallet-standard-chains": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.1.tgz",
-      "integrity": "sha512-Us3TgL4eMVoVWhuC4UrePlYnpWN+lwteCBlhZDUhFZBJ5UMGh94mYPXno3Ho7+iHPYRtuCi/ePvPcYBqCGuBOw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.2.tgz",
+      "integrity": "sha512-EZobEGclDBAFplpJC5F3d/s8Xnlqc5isNKuPrd5o9ZPZ7tWN84O0e68yIZ8MAOj9V7ieRadNiHtql7uIXCTyXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-core": {
@@ -7977,62 +8898,62 @@
       }
     },
     "node_modules/@solana/wallet-standard-features": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
-      "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.4.0.tgz",
+      "integrity": "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-util": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.2.tgz",
-      "integrity": "sha512-rUXFNP4OY81Ddq7qOjQV4Kmkozx4wjYAxljvyrqPx8Ycz0FYChG/hQVWqvgpK3sPsEaO/7ABG1NOACsyAKWNOA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.3.tgz",
+      "integrity": "sha512-aweR5y5FjYaeS9TkoqAWERFpGUj2MJepsDhcekCuoPLcNCquJL85Nsnuy01tBybspN5+Y09SWkxwsODOFGSfkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.8.0",
-        "@solana/wallet-standard-chains": "^1.1.1",
-        "@solana/wallet-standard-features": "^1.3.0"
+        "@noble/curves": "^1.8.2",
+        "@solana/wallet-standard-chains": "^1.1.2",
+        "@solana/wallet-standard-features": "^1.4.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-wallet-adapter": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter/-/wallet-standard-wallet-adapter-1.1.4.tgz",
-      "integrity": "sha512-YSBrxwov4irg2hx9gcmM4VTew3ofNnkqsXQ42JwcS6ykF1P1ecVY8JCbrv75Nwe6UodnqeoZRbN7n/p3awtjNQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter/-/wallet-standard-wallet-adapter-1.1.5.tgz",
+      "integrity": "sha512-6EMRyXzLcXQY9P5Bo8XWh8It6lb4rUbwO+RDdSpEySz/v+ric0W9H3Yzlqted4AIXQMJgxZifgyFxTp6g/bfZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/wallet-standard-wallet-adapter-base": "^1.1.4",
-        "@solana/wallet-standard-wallet-adapter-react": "^1.1.4"
+        "@solana/wallet-standard-wallet-adapter-base": "^1.1.5",
+        "@solana/wallet-standard-wallet-adapter-react": "^1.1.5"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-wallet-adapter-base": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.4.tgz",
-      "integrity": "sha512-Q2Rie9YaidyFA4UxcUIxUsvynW+/gE2noj/Wmk+IOwDwlVrJUAXCvFaCNsPDSyKoiYEKxkSnlG13OA1v08G4iw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.5.tgz",
+      "integrity": "sha512-dbk+4mJAsZ1a2R/v5/Qvp6SleviuSNWd9LnuQ0ekH0HRRJTOWyTBJsdQsVDdAymdPnLAaIN5J10ni1CT2Z+ERg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/wallet-adapter-base": "^0.9.23",
-        "@solana/wallet-standard-chains": "^1.1.1",
-        "@solana/wallet-standard-features": "^1.3.0",
-        "@solana/wallet-standard-util": "^1.1.2",
+        "@solana/wallet-adapter-base": "^0.9.24",
+        "@solana/wallet-standard-chains": "^1.1.2",
+        "@solana/wallet-standard-features": "^1.4.0",
+        "@solana/wallet-standard-util": "^1.1.3",
         "@wallet-standard/app": "^1.1.0",
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0",
         "@wallet-standard/wallet": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@solana/web3.js": "^1.98.0",
@@ -8040,17 +8961,17 @@
       }
     },
     "node_modules/@solana/wallet-standard-wallet-adapter-react": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-react/-/wallet-standard-wallet-adapter-react-1.1.4.tgz",
-      "integrity": "sha512-xa4KVmPgB7bTiWo4U7lg0N6dVUtt2I2WhEnKlIv0jdihNvtyhOjCKMjucWet6KAVhir6I/mSWrJk1U9SvVvhCg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-react/-/wallet-standard-wallet-adapter-react-1.1.5.tgz",
+      "integrity": "sha512-JfKBU2Mc332pR+9xhxjr5U/Q2aL03mMmSbrcnvfvAjML6zUEzAQ/bV6DchRsdtAT8Rx0zEg8h4OhsXbmteu0Yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/wallet-standard-wallet-adapter-base": "^1.1.4",
+        "@solana/wallet-standard-wallet-adapter-base": "^1.1.5",
         "@wallet-standard/app": "^1.1.0",
         "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@solana/wallet-adapter-base": "*",
@@ -8186,9 +9107,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
-      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "version": "5.101.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.3.tgz",
+      "integrity": "sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10640,7 +11561,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -10799,9 +11721,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10877,6 +11799,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -11331,6 +12254,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -15642,12 +16566,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-cookie": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
@@ -18608,9 +19526,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -19806,9 +20724,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -20166,12 +21084,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -2396,9 +2396,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3745,9 +3745,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/tests/security-audit-baseline.test.mjs
+++ b/tests/security-audit-baseline.test.mjs
@@ -112,14 +112,35 @@ describe('security audit baseline', () => {
   });
 
   it('flags baseline entries that no longer match any current advisory', () => {
-    const report = auditReportWith({
-      name: '@clerk/clerk-js',
-      severity: 'high',
-      title: 'known clerk advisory',
-      url: 'https://github.com/advisories/GHSA-w24r-5266-9c3c',
-    });
+    // Report carries the two pro-test advisories that ARE present in the current
+    // audit (the clerk advisory + shell-quote); only GHSA-qjx8, which no longer
+    // matches anything, must be flagged stale.
+    const report = {
+      vulnerabilities: {
+        '@clerk/clerk-js': {
+          name: '@clerk/clerk-js',
+          severity: 'high',
+          via: [{
+            name: '@clerk/clerk-js',
+            severity: 'high',
+            title: 'known clerk advisory',
+            url: 'https://github.com/advisories/GHSA-w24r-5266-9c3c',
+          }],
+        },
+        'shell-quote': {
+          name: 'shell-quote',
+          severity: 'high',
+          via: [{
+            name: 'shell-quote',
+            severity: 'high',
+            title: 'shell-quote DoS',
+            url: 'https://github.com/advisories/GHSA-395f-4hp3-45gv',
+          }],
+        },
+      },
+    };
 
-    // The still-present id is not reported as stale.
+    // The still-present ids are not reported as stale; GHSA-qjx8 (absent) is.
     assert.deepEqual(collectStaleBaselineEntries(report, 'pro-test/package-lock.json'), ['GHSA-qjx8-664m-686j']);
     // The empty root baseline has nothing to mark stale.
     assert.deepEqual(collectStaleBaselineEntries(report, 'package-lock.json'), []);


### PR DESCRIPTION
## Summary

The required `security-audit` gate was failing on **every open PR** — three newly-disclosed high-severity advisories sit in the shared lockfiles, and the `audit-lockfile` matrix flags any unbaselined high+ production advisory. Because they're transitive, they surface regardless of a PR's diff (e.g. the analytics-only #5393 failed `security-audit` identically). This unblocks the whole queue.

| Advisory | Package | Issue |
|----------|---------|-------|
| [GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv) | shell-quote | quadratic-complexity DoS in `parse()` |
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | brace-expansion | DoS via exponential `{}` expansion |
| [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | js-yaml | merge-key chains force quadratic CPU |

## Approach

**Patched** where the fix is a clean, in-range lockfile bump — `npm audit fix --package-lock-only` on `root`, `blog-site`, and `scripts`. No `package.json` changes, so every bump stays within the already-declared semver ranges. (The root run preserves the deliberate esbuild arrangement — root pinned to `0.28.1` via the `convex` override, Vite keeping its own `0.25.x` — which the baseline unit test guards.)

**Baselined** the one case where patching is disproportionate: pro-test's `shell-quote` reaches the tree only via `react-native → react-devtools-core`, a mobile/dev-tooling chain the Vite **web** build never bundles into `public/pro/`. The `parse()` DoS is unreachable from the shipped browser bundle, and bumping the `shell-quote` `overrides` pin would drag an otherwise-untouched `public/pro/` bundle rebuild into a lockfile-hygiene change. Added to `BASELINE_ADVISORIES_BY_LOCKFILE` with a documented rationale (and a note to drop it once `react-native` leaves pro-test's tree), alongside the two advisories pro-test already baselines. The baseline unit test's stale-entry fixture was updated to keep asserting the same behavior.

## Testing

- All six `audit-lockfile` matrix legs (root, scripts, consumer-prices-core, blog-site, pro-test, docker-runtime) now pass `.github/scripts/audit-production-dependencies.mjs` locally — replicating the exact CI invocation.
- `tests/security-audit-baseline.test.mjs`: 8/8 pass (guards the audit script + the esbuild arrangement).

Fixes #5394

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
