### PR TITLE
test(rss-proxy): wire test file into CI, lock the SSRF/auth/rate-limit guards, fix relay www-tolerance (#5378)

### DIFF
--- a/api/_rss-allowed-domain-match.js
+++ b/api/_rss-allowed-domain-match.js
@@ -21,15 +21,22 @@
 
 import RSS_ALLOWED_DOMAINS from './_rss-allowed-domains.js';
 
-export function isAllowedDomain(hostname) {
-  if (typeof hostname !== 'string' || hostname.length === 0) return false;
+// The www-tolerant candidate forms for a hostname: exact, bare (leading www.
+// stripped), and www-prefixed. Any host-set membership test that must treat the
+// apex and www. forms as equivalent should test all three. Shared so the RSS
+// proxy's relay-only routing check matches hosts the SAME way the allowlist does
+// — otherwise a host allowed via its apex form (e.g. `cisa.gov`) would miss the
+// exact-match relay-only set for `www.cisa.gov` and get direct-fetched from a
+// Vercel edge IP the relay routing exists specifically to avoid.
+export function hostMatchForms(hostname) {
+  if (typeof hostname !== 'string' || hostname.length === 0) return [];
   const bare = hostname.replace(/^www\./, '');
   const withWww = hostname.startsWith('www.') ? hostname : `www.${hostname}`;
-  return (
-    RSS_ALLOWED_DOMAINS.includes(hostname) ||
-    RSS_ALLOWED_DOMAINS.includes(bare) ||
-    RSS_ALLOWED_DOMAINS.includes(withWww)
-  );
+  return [...new Set([hostname, bare, withWww])];
+}
+
+export function isAllowedDomain(hostname) {
+  return hostMatchForms(hostname).some((form) => RSS_ALLOWED_DOMAINS.includes(form));
 }
 
 export default isAllowedDomain;

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -20,7 +20,6 @@ const RELAY_ONLY_DOMAINS = new Set([
   'www.who.int',
   'www.crisisgroup.org',
   'english.alarabiya.net',
-  'www.arabnews.com',
   'www.timesofisrael.com',
   'www.scmp.com',
   'kyivindependent.com',
@@ -235,3 +234,12 @@ export default async function handler(req, ctx) {
     }, isTimeout ? 504 : 502, corsHeaders);
   }
 }
+
+// Test-only exports. Not part of the public edge handler surface — Vercel's
+// runtime invokes only `default export`. Exposed so api/rss-proxy.test.mjs can
+// assert the config-drift invariant that every relay-only host is also in the
+// RSS allowlist: the allowlist check runs first, so an unlisted relay-only host
+// would 403 before the relay routing it exists for is ever consulted.
+export const __testing__ = {
+  RELAY_ONLY_DOMAINS,
+};

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -2,7 +2,7 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateApiKey } from './_api-key.js';
 import { checkRateLimit } from './_rate-limit.js';
 import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout } from './_relay.js';
-import { isAllowedDomain } from './_rss-allowed-domain-match.js';
+import { isAllowedDomain, hostMatchForms } from './_rss-allowed-domain-match.js';
 import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
 
@@ -137,7 +137,11 @@ export default async function handler(req, ctx) {
       return jsonResponse({ error: 'Domain not allowed' }, 403, corsHeaders);
     }
 
-    const isRelayOnly = RELAY_ONLY_DOMAINS.has(hostname);
+    // Match relay-only hosts with the same www-tolerance as the allowlist:
+    // a host allowed via its apex form must still route to the relay when only
+    // its www. form is registered (and vice versa), otherwise it falls through
+    // to a direct Vercel-edge fetch these hosts block.
+    const isRelayOnly = hostMatchForms(hostname).some((form) => RELAY_ONLY_DOMAINS.has(form));
 
     // Google News is slow - use longer timeout
     const isGoogleNews = isGoogleNewsFeedUrl(feedUrl);

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -112,6 +112,31 @@ test('rejects allowlisted redirect chains that escape the RSS domain allowlist o
   assert.deepEqual(calls.map((call) => call.redirect), ['manual', 'manual']);
 });
 
+test('rejects a redirect whose later hop targets a plain non-allowlisted host', async () => {
+  const calls = [];
+  globalThis.fetch = async (input, init = {}) => {
+    calls.push({ url: String(input), redirect: init.redirect });
+    // First hop is an allowlisted canonical redirect; the second escapes to an
+    // ordinary STRANGER host (not an IP, not a lookalike). Pins that
+    // assertAllowedRedirect rejects unrelated hosts, not just the metadata IP —
+    // otherwise loosening it to admit any `.com` on a redirect hop stays green.
+    if (calls.length === 1) {
+      return new Response('', { status: 302, headers: { Location: 'https://www.techcrunch.com/feed' } });
+    }
+    return new Response('', { status: 302, headers: { Location: 'https://evil.example.com/feed' } });
+  };
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'Redirect to disallowed domain');
+  // The attacker host is never fetched — the chain stops at the disallowed hop.
+  assert.deepEqual(calls.map((call) => call.url), [
+    'https://techcrunch.com/feed',
+    'https://www.techcrunch.com/feed',
+  ]);
+});
+
 test('allows legitimate apex to www RSS canonical redirects', async () => {
   const calls = [];
   globalThis.fetch = async (input, init = {}) => {
@@ -265,6 +290,22 @@ test('rejects link-local metadata addresses supplied as the initial url', async 
   assert.deepEqual(calls, [], 'metadata endpoint must never be fetched');
 });
 
+test('rejects a plain, unrelated host that is simply not on the allowlist', async () => {
+  const calls = spyFetch();
+
+  // The other negative cases are all lookalikes of an allowlisted name (suffix/
+  // userinfo/trailing-dot confusion) or a raw IP — so they only prove the guard
+  // rejects IMPOSTORS. This pins that it also rejects a STRANGER: an ordinary,
+  // well-formed host with no relationship to any allowlisted domain. Without it,
+  // loosening the guard to `!isAllowedDomain(host) && !host.endsWith('.com')`
+  // (admit any .com) stays green.
+  const res = await handler(makeRequest('https://evil.example.com/feed'));
+
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'Domain not allowed');
+  assert.deepEqual(calls, [], 'a non-allowlisted stranger host must never be fetched');
+});
+
 test('allows an allowlisted host supplied in mixed case (URL normalizes it)', async () => {
   const calls = spyFetch(() => new Response('<rss><channel/></rss>', {
     status: 200,
@@ -279,9 +320,10 @@ test('allows an allowlisted host supplied in mixed case (URL normalizes it)', as
 });
 
 test('every relay-only domain is also in the RSS allowlist', () => {
-  // Drift guard: RELAY_ONLY_DOMAINS is matched with exact `.has(hostname)`,
-  // but the allowlist check runs FIRST. A relay-only host missing from the
-  // allowlist would 403 before the relay routing it exists for is ever used.
+  // Drift guard: the allowlist check runs FIRST, so a relay-only host missing
+  // from the allowlist would 403 before the relay routing it exists for is ever
+  // used. Both checks now share hostMatchForms() www-tolerance, so membership is
+  // tested through the same predicate the handler uses.
   const orphans = [...RELAY_ONLY_DOMAINS].filter((host) => !isAllowedDomain(host));
   assert.deepEqual(orphans, [], `relay-only hosts missing from the RSS allowlist: ${orphans.join(', ')}`);
 });
@@ -335,6 +377,9 @@ test('returns 429 and skips the feed fetch when the rate limit is exhausted', as
   assert.equal(res.headers.get('X-RateLimit-Limit'), '600');
   assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
   assert.match(res.headers.get('Retry-After') ?? '', /^\d+$/);
+  // The 429 must still carry CORS headers, or the browser client sees an opaque
+  // network error instead of a readable rate-limit response.
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
   assert.deepEqual(
     feedCalls(calls).map((c) => c.url),
     [],
@@ -360,10 +405,26 @@ test('allows the request through when the rate limiter reports headroom', async 
       })
   ));
 
-  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+  // A malformed Upstash reply also yields 200 — checkRateLimit catches the parse
+  // error and fail-opens (`return null`) — so status alone can't tell "limiter
+  // granted headroom" from "limiter threw and failed open". Capture the degraded
+  // log and assert it never fired, so this positive control has real teeth.
+  const errorLogs = [];
+  const originalConsoleError = console.error;
+  console.error = (...args) => { errorLogs.push(args.join(' ')); };
+  let res;
+  try {
+    res = await handler(makeRequest('https://techcrunch.com/feed'));
+  } finally {
+    console.error = originalConsoleError;
+  }
 
   assert.equal(res.status, 200);
   assert.deepEqual(feedCalls(calls).map((c) => c.url), ['https://techcrunch.com/feed']);
+  assert.ok(
+    !errorLogs.some((l) => l.includes('[rate-limit] redis-error')),
+    `limiter degraded (fail-open) instead of granting headroom: ${errorLogs.join(' | ')}`,
+  );
 });
 
 test('rejects a non-http initial url with 400, not the 403 domain verdict', async () => {
@@ -413,7 +474,9 @@ test('answers CORS preflight with 204 and no upstream call', async () => {
 
   assert.equal(res.status, 204);
   assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
-  assert.match(res.headers.get('Access-Control-Allow-Methods') ?? '', /GET/);
+  // Exact match, not a substring — pins the advertised verb set so widening it
+  // (e.g. to include POST/PUT/DELETE) can't slip through unnoticed.
+  assert.equal(res.headers.get('Access-Control-Allow-Methods'), 'GET, OPTIONS');
   assert.deepEqual(calls, []);
 });
 
@@ -430,7 +493,14 @@ test('rejects non-GET methods with 405', async () => {
 test('rejects a disallowed Origin before auth, method, or fetch', async () => {
   const calls = spyFetch();
 
-  const res = await handler(makeRequest('https://techcrunch.com/feed', { origin: 'https://evil.example' }));
+  // Fail ALL THREE early gates at once (bad Origin + no key + non-GET) so only
+  // the ORDERING explains a 403 'Origin not allowed' verdict — if the Origin
+  // gate ran after auth or method, this would be 401 or 405 instead.
+  const res = await handler(makeRequest('https://techcrunch.com/feed', {
+    origin: 'https://evil.example',
+    apiKey: null,
+    method: 'POST',
+  }));
 
   assert.equal(res.status, 403);
   assert.equal((await res.json()).error, 'Origin not allowed');
@@ -573,8 +643,11 @@ test('falls back to application/xml when upstream sends no content-type', async 
 
 test('maps a direct-fetch AbortError to 504 Feed timeout', async () => {
   // No WS_RELAY_URL, so the relay fallback returns null and the AbortError is
-  // rethrown into the outer catch — which must classify it as a timeout (504)
-  // and skip the Sentry capture that routine upstream timeouts would flood.
+  // rethrown into the outer catch, which classifies it as a timeout (504). Note:
+  // this asserts only the 504 mapping. The `if (!isTimeout)` Sentry-suppression
+  // gate is NOT verified here — captureSilentError is a no-op under
+  // NODE_TEST_CONTEXT, so a spy-free test can't distinguish "capture skipped"
+  // from "capture ran but no-op'd". Left unasserted deliberately.
   const calls = spyFetch(() => {
     const err = new Error('The operation was aborted');
     err.name = 'AbortError';
@@ -590,7 +663,38 @@ test('maps a direct-fetch AbortError to 504 Feed timeout', async () => {
   assert.equal(calls.length, 1);
 });
 
-test('gives Google News a 20s deadline and other feeds 12s', async () => {
+test('maps a generic direct-fetch error to 502 Failed to fetch feed when no relay is configured', async () => {
+  // Non-Abort throw + WS_RELAY_URL unset -> fetchViaRailway returns null ->
+  // directError rethrows into the outer catch: the handler's generic-failure
+  // branch and the ONLY captureSilentError call site. Untested before this.
+  const calls = spyFetch(() => { throw new Error('boom direct fetch'); });
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+  const body = await res.json();
+
+  assert.equal(res.status, 502);
+  assert.equal(body.error, 'Failed to fetch feed');
+  assert.equal(body.details, 'boom direct fetch');
+  assert.equal(body.url, 'https://techcrunch.com/feed');
+});
+
+test('maps a relay-only host to 502 when the relay is unavailable', async () => {
+  // Relay-only domain + WS_RELAY_URL unset -> fetchViaRailway returns null ->
+  // handler throws 'Railway relay unavailable ...' into the same 502 branch.
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://rss.cnn.com/rss/edition.rss'));
+  const body = await res.json();
+
+  assert.equal(res.status, 502);
+  assert.equal(body.error, 'Failed to fetch feed');
+  assert.match(body.details, /Railway relay unavailable for relay-only domain: rss\.cnn\.com/);
+  // No relay configured and direct fetch is skipped for relay-only hosts, so
+  // nothing was ever fetched.
+  assert.deepEqual(calls, []);
+});
+
+test('gives Google News a 20s deadline and other feeds 12s', { timeout: 5000 }, async () => {
   // The timeout is only observable through the AbortSignal that
   // fetchWithTimeout arms, and it is cleared as soon as fetch settles — so the
   // fetch is held pending while the fake clock is advanced across each
@@ -610,8 +714,14 @@ test('gives Google News a 20s deadline and other feeds 12s', async () => {
       };
 
       const pending = handler(makeRequest(feedUrl));
-      // Yield until the handler has entered fetch and armed the signal.
-      while (!signal) await new Promise((resolve) => setImmediate(resolve));
+      // Yield until the handler has entered fetch and armed the signal — BOUNDED
+      // so a regression that stops the handler from reaching fetch fails fast
+      // with a clear message instead of spinning until the runner's timeout.
+      // (setImmediate is unfaked here; only setTimeout is mocked.)
+      for (let i = 0; !signal && i < 1000; i += 1) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      assert.ok(signal, `${label} feed: handler never reached fetch (signal never armed)`);
 
       mock.timers.tick(deadlineMs - 1);
       assert.equal(signal.aborted, false, `${label} feed aborted before its ${deadlineMs}ms deadline`);

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -471,6 +471,34 @@ test('routes relay-only domains straight to Railway with the long cache policy',
   );
 });
 
+test('routes the apex form of a www-registered relay-only host to Railway (www-tolerant match)', async () => {
+  process.env.WS_RELAY_URL = 'wss://relay.example.com';
+
+  // 'www.cisa.gov' is relay-only; a request for the bare apex 'cisa.gov' is
+  // still allowlisted (www-tolerant) and MUST route to the relay. With an
+  // exact-match relay-only check it would fall through to a direct Vercel-edge
+  // fetch that cisa.gov blocks — the exact class of drift the shared
+  // hostMatchForms() normalization closes.
+  const feedUrl = 'https://cisa.gov/uscert/ncas/all.xml';
+  const calls = spyFetch(() => new Response('<rss><channel><title>cisa</title></channel></rss>', {
+    status: 200,
+    headers: { 'Content-Type': 'application/rss+xml' },
+  }));
+
+  const res = await handler(makeRequest(feedUrl));
+
+  assert.equal(res.status, 200);
+  // Exactly one call, to the relay — no direct fetch to cisa.gov.
+  assert.deepEqual(calls.map((c) => c.url), [
+    `https://relay.example.com/rss?url=${encodeURIComponent(feedUrl)}`,
+  ]);
+  // And the long relay-only cache policy applies, confirming isRelayOnly is set.
+  assert.equal(
+    res.headers.get('CDN-Cache-Control'),
+    'public, s-maxage=3600, stale-while-revalidate=7200, stale-if-error=14400',
+  );
+});
+
 test('applies the short cache policy to a successful non-relay-only feed', async () => {
   const calls = spyFetch(() => new Response('<rss><channel/></rss>', {
     status: 200,

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, test } from 'node:test';
+import { afterEach, beforeEach, mock, test } from 'node:test';
 import assert from 'node:assert/strict';
 
 const originalEnv = { ...process.env };
@@ -9,7 +9,10 @@ process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
 delete process.env.UPSTASH_REDIS_REST_URL;
 delete process.env.UPSTASH_REDIS_REST_TOKEN;
 
-const { default: handler } = await import('./rss-proxy.js');
+const { default: handler, __testing__ } = await import('./rss-proxy.js');
+const { RELAY_ONLY_DOMAINS } = __testing__;
+const { __resetRateLimitForTest } = await import('./_rate-limit.js');
+const { default: isAllowedDomain } = await import('./_rss-allowed-domain-match.js');
 
 function restoreEnv() {
   for (const key of Object.keys(process.env)) {
@@ -18,13 +21,46 @@ function restoreEnv() {
   Object.assign(process.env, originalEnv);
 }
 
-function makeRequest(feedUrl) {
-  return new Request(`https://api.worldmonitor.app/api/rss-proxy?url=${encodeURIComponent(feedUrl)}`, {
-    headers: {
-      Origin: 'https://worldmonitor.app',
-      'X-WorldMonitor-Key': TEST_KEY,
-    },
-  });
+const PROXY_ENDPOINT = 'https://api.worldmonitor.app/api/rss-proxy';
+
+/**
+ * @param {string | null} feedUrl  feed to proxy; `null` omits the `url` param
+ *   entirely (the missing-parameter case). Passed through encodeURIComponent
+ *   so malformed values survive the query string verbatim.
+ * @param {{ method?: string, origin?: string | null, apiKey?: string | null }} [opts]
+ *   `origin: null` / `apiKey: null` omit that header rather than sending it
+ *   empty — the handler distinguishes absent from present-but-wrong.
+ */
+function makeRequest(feedUrl, opts = {}) {
+  const { method = 'GET', origin = 'https://worldmonitor.app', apiKey = TEST_KEY } = opts;
+  const url = feedUrl === null
+    ? PROXY_ENDPOINT
+    : `${PROXY_ENDPOINT}?url=${encodeURIComponent(feedUrl)}`;
+  const headers = {};
+  if (origin !== null) headers.Origin = origin;
+  if (apiKey !== null) headers['X-WorldMonitor-Key'] = apiKey;
+  return new Request(url, { method, headers });
+}
+
+/**
+ * Installs a fetch spy and returns the recorded call list. Any fetch the
+ * handler makes is recorded; `respond` decides the reply (default: a 200 feed).
+ * Guards that reject *before* fetching assert `calls` stays empty — that is the
+ * assertion with teeth, since a bypassed guard shows up as an upstream call.
+ */
+function spyFetch(respond = () => new Response('<rss/>', { status: 200 })) {
+  const calls = [];
+  globalThis.fetch = async (input, init = {}) => {
+    calls.push({ url: String(input), redirect: init.redirect, headers: init.headers });
+    return respond(String(input), init, calls);
+  };
+  return calls;
+}
+
+/** Feed hosts these tests treat as "reachable upstream" — used to prove a
+ *  guard fired before any feed fetch, while ignoring Upstash/relay traffic. */
+function feedCalls(calls) {
+  return calls.filter((c) => !c.url.includes('upstash') && !c.url.includes('relay.example.com'));
 }
 
 beforeEach(() => {
@@ -33,11 +69,16 @@ beforeEach(() => {
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
   delete process.env.WS_RELAY_URL;
   delete process.env.RELAY_SHARED_SECRET;
+  // getRatelimit() caches limiters in a module-level Map keyed by policy, so a
+  // limiter built against the fake Upstash host in one test would survive into
+  // the next even after the env vars are deleted. Reset the cache each time.
+  __resetRateLimitForTest();
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   restoreEnv();
+  __resetRateLimitForTest();
 });
 
 test('rejects allowlisted redirect chains that escape the RSS domain allowlist on a later hop', async () => {
@@ -166,4 +207,393 @@ test('preserves Railway relay fallback for direct-fetch transport failures', asy
   assert.equal(calls[0].url, feedUrl);
   assert.equal(calls[1].url, `https://relay.example.com/rss?url=${encodeURIComponent(feedUrl)}`);
   assert.equal(calls[1].headers['x-relay-key'], 'relay-secret');
+});
+
+// ---------------------------------------------------------------------------
+// Initial-host SSRF allowlist guard (#5378)
+//
+// These lock `isAllowedDomain(parsedUrl.hostname)` in api/rss-proxy.js. The
+// adversarial sweep flagged "hostname/userinfo confusion" as a possible
+// BYPASS; probing WHATWG `new URL()` shows it is not — userinfo is stripped
+// into `username`/`password` and a suffix-confusion host stays intact, so both
+// resolve to a non-allowlisted `hostname` and 403. What the sweep actually
+// found is that the guard had ZERO coverage: deleting it changed nothing in
+// the suite while the handler happily fetched the attacker host. That is what
+// these tests close. The teeth are `calls` staying empty — a 403 alone can be
+// produced by an unrelated failure, but "never touched the network" cannot.
+// ---------------------------------------------------------------------------
+
+test('rejects suffix-confusion hosts that merely start with an allowlisted domain', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com.attacker.example/feed'));
+  const body = await res.json();
+
+  assert.equal(res.status, 403);
+  assert.equal(body.error, 'Domain not allowed');
+  assert.deepEqual(calls, [], 'attacker host must never be fetched');
+});
+
+test('rejects userinfo-confusion URLs whose real host is not allowlisted', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com@attacker.example/feed'));
+  const body = await res.json();
+
+  assert.equal(res.status, 403);
+  assert.equal(body.error, 'Domain not allowed');
+  assert.deepEqual(calls, [], 'attacker host must never be fetched');
+});
+
+test('rejects a trailing-dot FQDN form of an allowlisted host', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com./feed'));
+
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'Domain not allowed');
+  assert.deepEqual(calls, []);
+});
+
+test('rejects link-local metadata addresses supplied as the initial url', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('http://169.254.169.254/latest/meta-data'));
+
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'Domain not allowed');
+  assert.deepEqual(calls, [], 'metadata endpoint must never be fetched');
+});
+
+test('allows an allowlisted host supplied in mixed case (URL normalizes it)', async () => {
+  const calls = spyFetch(() => new Response('<rss><channel/></rss>', {
+    status: 200,
+    headers: { 'Content-Type': 'application/rss+xml' },
+  }));
+
+  const res = await handler(makeRequest('https://TechCrunch.COM/feed'));
+
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://techcrunch.com/feed');
+});
+
+test('every relay-only domain is also in the RSS allowlist', () => {
+  // Drift guard: RELAY_ONLY_DOMAINS is matched with exact `.has(hostname)`,
+  // but the allowlist check runs FIRST. A relay-only host missing from the
+  // allowlist would 403 before the relay routing it exists for is ever used.
+  const orphans = [...RELAY_ONLY_DOMAINS].filter((host) => !isAllowedDomain(host));
+  assert.deepEqual(orphans, [], `relay-only hosts missing from the RSS allowlist: ${orphans.join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// Pre-fetch gates: auth, rate limit, protocol (#5378)
+//
+// All three run BEFORE any upstream fetch. Each test asserts the status AND
+// that no feed request escaped — the sweep's mutations (dropping the 401
+// return, ignoring rateLimitResponse) manifested as an upstream fetch with a
+// 502/200, so the "no feed call" assertion is what actually kills them.
+// ---------------------------------------------------------------------------
+
+test('rejects requests with no API key before fetching the feed', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed', { apiKey: null }));
+
+  assert.equal(res.status, 401);
+  assert.equal((await res.json()).error, 'API key required');
+  assert.deepEqual(calls, [], 'unauthenticated request must not reach upstream');
+});
+
+test('rejects requests with an invalid API key before fetching the feed', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed', { apiKey: 'wrong-key' }));
+
+  assert.equal(res.status, 401);
+  assert.equal((await res.json()).error, 'Invalid API key');
+  assert.deepEqual(calls, [], 'invalid-key request must not reach upstream');
+});
+
+test('returns 429 and skips the feed fetch when the rate limit is exhausted', async () => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+  // Upstash sliding-window EVAL reply shape: [remaining, limit]. A negative
+  // remaining means blocked, and the second element surfaces as `limit` on the
+  // limiter verdict — hence 600, the handler's default policy (mirrors the
+  // `[-1, 30]` mock for the 30/min policy in api/_rate-limit.test.mjs).
+  const calls = spyFetch(() => new Response(
+    JSON.stringify([{ result: [-1, 600] }]),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  ));
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 429);
+  assert.equal((await res.json()).error, 'Too many requests');
+  assert.equal(res.headers.get('X-RateLimit-Limit'), '600');
+  assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+  assert.match(res.headers.get('Retry-After') ?? '', /^\d+$/);
+  assert.deepEqual(
+    feedCalls(calls).map((c) => c.url),
+    [],
+    'rate-limited request must not reach the feed',
+  );
+});
+
+test('allows the request through when the rate limiter reports headroom', async () => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+  // Positive counterpart to the 429 case: proves the 429 above is produced by
+  // the limiter verdict, not merely by Upstash being configured at all.
+  const calls = spyFetch((url) => (
+    url.includes('fake-upstash')
+      ? new Response(JSON.stringify([{ result: [599, 600] }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+      : new Response('<rss><channel/></rss>', {
+        status: 200,
+        headers: { 'Content-Type': 'application/rss+xml' },
+      })
+  ));
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(feedCalls(calls).map((c) => c.url), ['https://techcrunch.com/feed']);
+});
+
+test('rejects a non-http initial url with 400, not the 403 domain verdict', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('file:///etc/passwd'));
+
+  // Status is the assertion with teeth: `file:` also fails the allowlist
+  // (hostname is ''), so only the 400 distinguishes the protocol guard from
+  // the domain guard. The sweep's mutation flipped exactly this status.
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'URL protocol not allowed');
+  assert.deepEqual(calls, []);
+});
+
+// ---------------------------------------------------------------------------
+// Request-shape handling (#5378)
+// ---------------------------------------------------------------------------
+
+test('returns 400 when the url parameter is missing entirely', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest(null));
+
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'Missing url parameter');
+  assert.deepEqual(calls, []);
+});
+
+test('returns 400 (not 502) for a malformed url parameter', async () => {
+  const calls = spyFetch();
+
+  // Regression for WORLDMONITOR-TT: `new URL()` throwing inside the try block
+  // was reported to Sentry at error level and answered 502. It is a client
+  // error and must be caught by the pre-try parse.
+  const res = await handler(makeRequest('not-a-url'));
+
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'Invalid url parameter');
+  assert.deepEqual(calls, []);
+});
+
+test('answers CORS preflight with 204 and no upstream call', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed', { method: 'OPTIONS' }));
+
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+  assert.match(res.headers.get('Access-Control-Allow-Methods') ?? '', /GET/);
+  assert.deepEqual(calls, []);
+});
+
+test('rejects non-GET methods with 405', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed', { method: 'POST' }));
+
+  assert.equal(res.status, 405);
+  assert.equal((await res.json()).error, 'Method not allowed');
+  assert.deepEqual(calls, []);
+});
+
+test('rejects a disallowed Origin before auth, method, or fetch', async () => {
+  const calls = spyFetch();
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed', { origin: 'https://evil.example' }));
+
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'Origin not allowed');
+  // Never echo the attacker origin back.
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+  assert.deepEqual(calls, []);
+});
+
+// ---------------------------------------------------------------------------
+// Routing + response policy (#5378)
+// ---------------------------------------------------------------------------
+
+test('routes relay-only domains straight to Railway with the long cache policy', async () => {
+  process.env.WS_RELAY_URL = 'wss://relay.example.com';
+  process.env.RELAY_SHARED_SECRET = 'relay-secret';
+
+  const feedUrl = 'https://rss.cnn.com/rss/edition.rss';
+  const calls = spyFetch(() => new Response('<rss><channel><title>cnn</title></channel></rss>', {
+    status: 200,
+    headers: { 'Content-Type': 'application/rss+xml' },
+  }));
+
+  const res = await handler(makeRequest(feedUrl));
+
+  assert.equal(res.status, 200);
+  // Exactly one call, to the relay — the direct fetch is skipped entirely
+  // because Vercel edge IPs are blocked by these hosts.
+  assert.deepEqual(calls.map((c) => c.url), [
+    `https://relay.example.com/rss?url=${encodeURIComponent(feedUrl)}`,
+  ]);
+  assert.equal(
+    res.headers.get('Cache-Control'),
+    'public, max-age=600, s-maxage=3600, stale-while-revalidate=7200, stale-if-error=14400',
+  );
+  assert.equal(
+    res.headers.get('CDN-Cache-Control'),
+    'public, s-maxage=3600, stale-while-revalidate=7200, stale-if-error=14400',
+  );
+});
+
+test('applies the short cache policy to a successful non-relay-only feed', async () => {
+  const calls = spyFetch(() => new Response('<rss><channel/></rss>', {
+    status: 200,
+    headers: { 'Content-Type': 'application/rss+xml' },
+  }));
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(calls.map((c) => c.url), ['https://techcrunch.com/feed']);
+  assert.equal(
+    res.headers.get('Cache-Control'),
+    'public, max-age=180, s-maxage=900, stale-while-revalidate=1800, stale-if-error=3600',
+  );
+  assert.equal(
+    res.headers.get('CDN-Cache-Control'),
+    'public, s-maxage=900, stale-while-revalidate=1800, stale-if-error=3600',
+  );
+});
+
+test('passes a non-2xx upstream status through with the short error cache and no CDN-Cache-Control', async () => {
+  const calls = spyFetch(() => new Response('upstream boom', { status: 503 }));
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get('Cache-Control'), 'public, max-age=15, s-maxage=60, stale-while-revalidate=120');
+  assert.equal(
+    res.headers.get('CDN-Cache-Control'),
+    null,
+    'a failed upstream must never be pinned in the CDN',
+  );
+  assert.deepEqual(calls.map((c) => c.url), ['https://techcrunch.com/feed']);
+});
+
+test('retries through the relay when the direct fetch returns a non-2xx status', async () => {
+  process.env.WS_RELAY_URL = 'wss://relay.example.com';
+  const feedUrl = 'https://techcrunch.com/feed';
+
+  const calls = spyFetch((url) => (
+    url.includes('relay.example.com')
+      ? new Response('<rss><channel><title>relay</title></channel></rss>', {
+        status: 200,
+        headers: { 'Content-Type': 'application/rss+xml' },
+      })
+      : new Response('blocked', { status: 403 })
+  ));
+
+  const res = await handler(makeRequest(feedUrl));
+
+  assert.equal(res.status, 200);
+  assert.match(await res.text(), /relay/);
+  assert.deepEqual(calls.map((c) => c.url), [
+    feedUrl,
+    `https://relay.example.com/rss?url=${encodeURIComponent(feedUrl)}`,
+  ]);
+});
+
+test('falls back to application/xml when upstream sends no content-type', async () => {
+  const calls = spyFetch(() => {
+    const res = new Response('<rss><channel/></rss>', { status: 200 });
+    res.headers.delete('content-type');
+    return res;
+  });
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('Content-Type'), 'application/xml');
+  assert.equal(calls.length, 1);
+});
+
+test('maps a direct-fetch AbortError to 504 Feed timeout', async () => {
+  // No WS_RELAY_URL, so the relay fallback returns null and the AbortError is
+  // rethrown into the outer catch — which must classify it as a timeout (504)
+  // and skip the Sentry capture that routine upstream timeouts would flood.
+  const calls = spyFetch(() => {
+    const err = new Error('The operation was aborted');
+    err.name = 'AbortError';
+    throw err;
+  });
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+  const body = await res.json();
+
+  assert.equal(res.status, 504);
+  assert.equal(body.error, 'Feed timeout');
+  assert.equal(body.url, 'https://techcrunch.com/feed');
+  assert.equal(calls.length, 1);
+});
+
+test('gives Google News a 20s deadline and other feeds 12s', async () => {
+  // The timeout is only observable through the AbortSignal that
+  // fetchWithTimeout arms, and it is cleared as soon as fetch settles — so the
+  // fetch is held pending while the fake clock is advanced across each
+  // boundary. Fake timers keep this deterministic (no real waiting).
+  mock.timers.enable({ apis: ['setTimeout'] });
+  try {
+    for (const { feedUrl, deadlineMs, label } of [
+      { feedUrl: 'https://news.google.com/rss/search?q=test', deadlineMs: 20_000, label: 'Google News' },
+      { feedUrl: 'https://techcrunch.com/feed', deadlineMs: 12_000, label: 'default' },
+    ]) {
+      let signal;
+      let release;
+      globalThis.fetch = async (_input, init = {}) => {
+        signal = init.signal;
+        await new Promise((resolve) => { release = resolve; });
+        return new Response('<rss/>', { status: 200 });
+      };
+
+      const pending = handler(makeRequest(feedUrl));
+      // Yield until the handler has entered fetch and armed the signal.
+      while (!signal) await new Promise((resolve) => setImmediate(resolve));
+
+      mock.timers.tick(deadlineMs - 1);
+      assert.equal(signal.aborted, false, `${label} feed aborted before its ${deadlineMs}ms deadline`);
+      mock.timers.tick(2);
+      assert.equal(signal.aborted, true, `${label} feed did not abort at its ${deadlineMs}ms deadline`);
+
+      release();
+      await pending;
+    }
+  } finally {
+    mock.timers.reset();
+  }
 });

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:feeds:ci": "node scripts/validate-rss-feeds.mjs --ci",
-    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs src-tauri/open-url-safety.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/_rate-limit.test.mjs api/_sentry-common.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
+    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs src-tauri/open-url-safety.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/_rate-limit.test.mjs api/_sentry-common.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs api/rss-proxy.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual": "npm run test:e2e:visual:full && npm run test:e2e:visual:tech",

--- a/scripts/validate-rss-feeds.mjs
+++ b/scripts/validate-rss-feeds.mjs
@@ -384,10 +384,11 @@ async function main() {
   if (configDrift.length) {
     console.error(
       `\nFAIL: ${configDrift.length} feed(s) violate the CI guardrails ` +
-      `(allowlist drift or plaintext URL). Fix src/config/feeds.ts and/or the 5 ` +
+      `(allowlist drift or plaintext URL). Fix src/config/feeds.ts and/or the 4 ` +
       `allowlist mirrors (shared/rss-allowed-domains.json, .cjs, ` +
       `scripts/shared/rss-allowed-domains.json, ` +
-      `api/_rss-allowed-domains.js, vite.config.ts:RSS_PROXY_ALLOWED_DOMAINS).`
+      `api/_rss-allowed-domains.js). vite.config.ts now imports isAllowedDomain ` +
+      `from api/_rss-allowed-domain-match.js — no separate dev mirror to sync.`
     );
     process.exit(1);
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,11 @@ import {
   renderVariantDashboardHtml,
   variantDashboardFileName,
 } from './src/config/variant-dashboard-html';
+// Single source of truth for the RSS proxy allowlist — the dev-server proxy
+// below reuses the SAME www-tolerant predicate the Edge handler enforces
+// (api/rss-proxy.js) so dev and prod agree on allow/deny. Previously a
+// hand-maintained Set here had drifted ~138 domains from prod.
+import { isAllowedDomain } from './api/_rss-allowed-domain-match.js';
 
 // Env-dependent constants moved inside defineConfig function
 
@@ -692,77 +697,6 @@ function sebufApiPlugin(): Plugin {
   };
 }
 
-// RSS proxy allowlist — duplicated from api/rss-proxy.js for dev mode.
-// Keep in sync when adding new domains.
-const RSS_PROXY_ALLOWED_DOMAINS = new Set([
-  'feeds.bbci.co.uk', 'www.theguardian.com', 'feeds.npr.org', 'news.google.com',
-  'www.aljazeera.com', 'rss.cnn.com', 'hnrss.org', 'feeds.arstechnica.com',
-  'www.theverge.com', 'www.cnbc.com', 'feeds.marketwatch.com', 'www.defenseone.com',
-  'breakingdefense.com', 'www.bellingcat.com', 'techcrunch.com', 'huggingface.co',
-  'www.technologyreview.com', 'rss.arxiv.org', 'export.arxiv.org',
-  'www.federalreserve.gov', 'www.sec.gov', 'www.whitehouse.gov', 'www.state.gov',
-  'www.defense.gov', 'home.treasury.gov', 'www.justice.gov', 'tools.cdc.gov',
-  'www.fema.gov', 'www.dhs.gov', 'www.thedrive.com', 'krebsonsecurity.com',
-  'finance.yahoo.com', 'thediplomat.com', 'venturebeat.com', 'foreignpolicy.com',
-  'www.ft.com', 'openai.com', 'www.reutersagency.com', 'feeds.reuters.com',
-  'asia.nikkei.com', 'www.cfr.org', 'www.csis.org', 'www.politico.com',
-  'www.brookings.edu', 'layoffs.fyi', 'www.defensenews.com', 'www.militarytimes.com',
-  'taskandpurpose.com', 'news.usni.org', 'www.oryxspioenkop.com',
-  'www.smartraveller.gov.au', 'www.gov.uk',
-  'www.foreignaffairs.com', 'www.atlanticcouncil.org',
-  // Tech variant
-  'www.zdnet.com', 'www.techmeme.com', 'www.darkreading.com', 'www.schneier.com',
-  'rss.politico.com', 'www.anandtech.com', 'www.tomshardware.com', 'www.semianalysis.com',
-  'feed.infoq.com', 'thenewstack.io', 'devops.com', 'dev.to', 'lobste.rs', 'changelog.com',
-  'seekingalpha.com', 'news.crunchbase.com', 'www.saastr.com', 'feeds.feedburner.com',
-  'www.producthunt.com', 'www.axios.com', 'api.axios.com', 'github.blog', 'githubnext.com',
-  'mshibanami.github.io', 'www.engadget.com', 'news.mit.edu', 'dev.events',
-  'www.ycombinator.com', 'a16z.com', 'review.firstround.com', 'www.sequoiacap.com',
-  'www.nfx.com', 'www.aaronsw.com', 'bothsidesofthetable.com', 'www.lennysnewsletter.com',
-  'stratechery.com', 'www.eu-startups.com', 'tech.eu', 'sifted.eu', 'www.techinasia.com',
-  'kr-asia.com', 'techcabal.com', 'disrupt-africa.com', 'lavca.org', 'contxto.com',
-  'inc42.com', 'yourstory.com', 'pitchbook.com', 'www.cbinsights.com', 'www.techstars.com',
-  // Regional & international
-  'english.alarabiya.net', 'www.arabnews.com', 'www.timesofisrael.com', 'www.haaretz.com',
-  'www.scmp.com', 'kyivindependent.com', 'www.themoscowtimes.com', 'feeds.24.com',
-  'feeds.capi24.com', 'www.france24.com', 'www.euronews.com', 'www.lemonde.fr',
-  'rss.dw.com', 'www.africanews.com', 'www.lasillavacia.com', 'www.channelnewsasia.com',
-  'www.thehindu.com', 'news.un.org', 'www.iaea.org', 'www.who.int', 'www.cisa.gov',
-  'www.crisisgroup.org',
-  // Think tanks
-  'rusi.org', 'warontherocks.com', 'www.aei.org', 'responsiblestatecraft.org',
-  'www.fpri.org', 'jamestown.org', 'www.chathamhouse.org', 'ecfr.eu', 'www.gmfus.org',
-  'www.wilsoncenter.org', 'www.lowyinstitute.org', 'www.mei.edu', 'www.stimson.org',
-  'www.cnas.org', 'carnegieendowment.org', 'www.rand.org', 'fas.org',
-  'www.armscontrol.org', 'www.nti.org', 'thebulletin.org', 'www.iss.europa.eu',
-  // Economic & Food Security
-  'www.fao.org', 'worldbank.org', 'www.imf.org',
-  // Regional locale feeds
-  'www.hurriyet.com.tr', 'tvn24.pl', 'www.polsatnews.pl', 'www.rp.pl', 'meduza.io',
-  'novayagazeta.eu', 'www.bangkokpost.com', 'vnexpress.net', 'www.abc.net.au',
-  'news.ycombinator.com',
-  // Hindi / India feeds
-  'www.aajtak.in', 'www.amarujala.com',
-  // Hungarian / Central European feeds
-  'telex.hu', 'index.hu', 'hvg.hu', '444.hu', '24.hu', 'hirado.hu', 'portfolio.hu', 'www.portfolio.hu', 'www.atv.hu',
-  // Investigative journalism sources
-  'www.occrp.org', 'dfrlab.org', 'www.lighthousereports.com', 'thesentry.org', 'globalinitiative.net', 'vsquare.org', 'correctiv.org',
-  // Croatian feeds
-  'n1info.hr', 'www.index.hr', 'www.jutarnji.hr', 'balkaninsight.com',
-  // Finance variant
-  'www.coindesk.com', 'cointelegraph.com',
-  // Happy variant — positive news sources
-  'www.goodnewsnetwork.org', 'www.positive.news', 'reasonstobecheerful.world',
-  'www.optimistdaily.com', 'www.sunnyskyz.com', 'www.huffpost.com',
-  'www.sciencedaily.com', 'feeds.nature.com', 'www.livescience.com', 'www.newscientist.com',
-  // Feed-registry coverage (PR fix/feed-validation-unblock — kept sync with shared/rss-allowed-domains.json)
-  'abcnews.go.com', 'abcnews.com', 'www.corriere.it', 'www.rt.com', 'www.alarabiya.net', 'tuoitrenews.vn',
-  'www.yonhapnewstv.co.kr', 'www.chosun.com', 'rss.libsyn.com', 'feeds.megaphone.fm', 'rss.art19.com',
-  'idp.nature.com',
-  // #4970: DoD rebrand defense.gov→war.gov + catalog feeds missing from allowlist
-  'www.war.gov', 'www.thenationalnews.com', 'trumpstruth.org',
-]);
-
 function rssProxyPlugin(): Plugin {
   return {
     name: 'rss-proxy',
@@ -783,7 +717,7 @@ function rssProxyPlugin(): Plugin {
 
         try {
           const parsed = new URL(feedUrl);
-          if (!RSS_PROXY_ALLOWED_DOMAINS.has(parsed.hostname)) {
+          if (!isAllowedDomain(parsed.hostname)) {
             res.statusCode = 403;
             res.setHeader('Content-Type', 'application/json');
             res.end(JSON.stringify({ error: `Domain not allowed: ${parsed.hostname}` }));


### PR DESCRIPTION
Closes #5378.

## What this does

`api/rss-proxy.test.mjs` existed but was wired into **no** npm script, so its 5 tests never ran in CI — the issue's core complaint. This adds it to `test:sidecar` (run by the `sidecar` job in `.github/workflows/test.yml:170`) and grows the suite **5 → 33 tests**, closing the adversary-reachable coverage gaps the sweep found.

## On the "Critical SSRF hostname/userinfo confusion"

I could not reproduce it as a bypass, and I believe it is a **false positive** — it is a *coverage* gap, not a vulnerability. Empirically (WHATWG `new URL()` + the real `isAllowedDomain` predicate):

| Input | `URL.hostname` | allowlisted |
|---|---|---|
| `https://techcrunch.com.attacker.example/feed` | `techcrunch.com.attacker.example` | ❌ |
| `https://techcrunch.com@attacker.example/feed` | `attacker.example` | ❌ |
| `https://techcrunch.com./feed` | `techcrunch.com.` | ❌ |

`new URL()` strips userinfo into `username`/`password`; `isAllowedDomain` only strips a leading `www.` and never suffix-matches. The sweep's mutation evidence ("disabling `isAllowedDomain` fetched the attacker host") proves the guard is **load-bearing and was untested**, not that it's bypassable. The new tests lock it, each asserting the attacker host is **never fetched** (the assertion with teeth) and each **mutation-proven** red.

## Coverage added (14 mutations, each killing exactly its target test)

- **Allowlist guard** — suffix / userinfo / trailing-dot confusion + link-local metadata; asserts zero upstream fetch.
- **Auth** — missing key → 401, invalid key → 401, both before any fetch.
- **Rate limit** — exhausted → 429 with no feed fetch, plus the headroom case so the 429 is attributable to the limiter verdict, not to Upstash merely being configured.
- **Protocol** — `file://` → 400 (not the 403 domain verdict).
- **Request shape** — missing/malformed `url` → 400, OPTIONS → 204, non-GET → 405, disallowed Origin → 403 without echoing the attacker origin.
- **Response policy** — relay-only routing + long cache TTLs, short TTLs on success, no `CDN-Cache-Control` on a failed upstream, non-2xx relay retry, content-type fallback, AbortError → 504, Google News 20s vs default 12s deadline.
- **Drift invariant** — every `RELAY_ONLY_DOMAINS` entry is in the allowlist.

## Two fixes surfaced by the review (both approved)

1. **`www.arabnews.com` removed** from `RELAY_ONLY_DOMAINS` — #1626 removed it from the allowlist as a dead feed but missed this mirror; the allowlist 403s it before relay routing is consulted, so it was pure dead weight. Arab News is sourced via `news.google.com`, not a direct feed. (Caught by the new invariant test.)

2. **Relay-only routing made www-tolerant.** `RELAY_ONLY_DOMAINS.has(hostname)` was exact-match while `isAllowedDomain` is www-tolerant, so **all 17** relay-only hosts were reachable via their alternate form (e.g. `cisa.gov` for the registered `www.cisa.gov`) — passing the allowlist but skipping relay routing and getting direct-fetched from a Vercel edge IP these hosts block, paying the full 12s/20s timeout. Dormant today, but structural. Fixed by sharing one `hostMatchForms()` helper between both checks; new apex-routing test is mutation-proven.

3. **Dev allowlist de-duplicated.** `vite.config.ts` held a **third** copy of the allowlist for the dev-server proxy that had drifted ~138 domains from prod (and still carried the dead `www.arabnews.com`), while `scripts/validate-rss-feeds.mjs` claimed it was a synced mirror. Replaced the hand-maintained Set with a direct import of `isAllowedDomain` so dev and prod share one source of truth. `vite build` verified.

## Review-driven test hardening (3rd commit)

A multi-lens review (security, correctness, adversarial, testing) **confirmed** the SSRF false-positive and the `[-1, 600]` Upstash mock shape (verified against the vendored `@upstash/ratelimit` Lua), but found the guard tests only rejected *lookalikes* of allowlisted names — never a plain stranger. Fixed (29 → 33 tests, each mutation-proven):

- **Plain non-allowlisted stranger host** rejected on both the initial-host and redirect-hop allowlist. Previously, loosening the guard to admit any `.com` stayed green; now killed on both paths.
- **Generic 502 branch + its lone `captureSilentError` call site** covered (was untested) — both a non-Abort direct-fetch throw and a relay-only host with no relay.
- **Rate-limit headroom control given teeth** — it returned 200 whether the limiter granted headroom *or* failed open; now asserts the degraded log never fired.
- **Google News deadline test's unbounded spin bounded** + per-test timeout — a regression now fails in ~110ms instead of hanging the CI runner (this is a CI-wiring PR; a test that can hang the runner was the wrong thing to wire in).
- CORS Allow-Methods pinned exact; 429 asserts it carries CORS headers; guard-ordering test now fails all three early gates at once.

## Review notes

- Standards, reliability, security, correctness, adversarial, and testing lenses all completed. Both `RELAY_ONLY_DOMAINS` changes independently confirmed safe. The cross-model (Codex) adversarial pass was unavailable (usage limit).
- **`RELAY_ONLY_DOMAINS`** is exposed only via the repo's `export const __testing__ = {...}` convention (matching `api/health.js`, `api/bootstrap.js`, `api/mcp.ts`) — no widening of the public edge surface.
- Pre-existing, out-of-scope findings filed as follow-ups: **#5398** (relay-fallback exceptions mask the original error), **#5401** (dead `rsshub.app` allowlist entry / open-proxy footgun), **#5402** (`sidecar` job runs but isn't a *required* status check, so a red result doesn't block merge).

## Verification

- `api/rss-proxy.test.mjs`: 33/33 ✅ · `tests/edge-functions.test.mjs`: 228/228 ✅ · `test:feeds:ci`: pass ✅ · `vite build`: exit 0 ✅
- First two commits already **fully green in CI** (required `gate` passed, incl. `sidecar`/`biome`/`typecheck`/`unit`).
- Every guard fix and every new test mutation-proven (revert → red, restore → green).

https://claude.ai/code/session_018RkPSPXZKPpBtvAhNZx3au
