### PR TITLE
chore(lint): appease biome 2.4.9's promoted rules across scripts/ (unblocks all PRs)

### DIFF
--- a/scripts/_bet-baserate.mjs
+++ b/scripts/_bet-baserate.mjs
@@ -13,7 +13,7 @@ const PRIOR_ALPHA = 1; // Laplace pseudo-count for "crosses"
 const PRIOR_BETA = 1;  // Laplace pseudo-count for "does not cross"
 const NEUTRAL_PRIOR = 0.5;
 
-export function baseRateProbability(series, spec, options = {}) {
+export function baseRateProbability(series, spec, _options = {}) {
   const values = (Array.isArray(series) ? series : [])
     .map(Number)
     .filter((v) => Number.isFinite(v));

--- a/scripts/_bet-templates-commodities.mjs
+++ b/scripts/_bet-templates-commodities.mjs
@@ -78,7 +78,7 @@ function buildCommodityTemplate({ symbol, subject, unit }) {
       };
     },
 
-    buildQuestion({ metric, spec }) {
+    buildQuestion({ spec }) {
       return spec.question;
     },
 

--- a/scripts/_bet-templates-energy.mjs
+++ b/scripts/_bet-templates-energy.mjs
@@ -87,7 +87,7 @@ function buildMetricTemplate({ name, subject, fallbackUnit }) {
       };
     },
 
-    buildQuestion({ metric, spec }) {
+    buildQuestion({ spec }) {
       return spec.question;
     },
 
@@ -96,7 +96,7 @@ function buildMetricTemplate({ name, subject, fallbackUnit }) {
       return `${capitalize(metric.subject)}: ${dir} to ${spec.threshold} ${metric.unit}?`;
     },
 
-    userValueScore({ metric }) {
+    userValueScore() {
       // Prices are higher-interest than raw stock levels; nudge accordingly.
       return name === 'wti' || name === 'brent' ? 0.75 : 0.6;
     },

--- a/scripts/_clustering.mjs
+++ b/scripts/_clustering.mjs
@@ -321,6 +321,7 @@ export function computeEntityCorroboration(clusters, nowMs = Date.now()) {
  *   #4920 coverage ledger: when provided, populated with how many clusters
  *   each gate dropped — previously all three gates were silent.
  */
+// biome-ignore lint/style/useDefaultParameterLast: maxCount's default predates the trailing params; reordering would break the (clusters, maxCount, stats) call shape
 export function selectTopStories(clusters, maxCount = 8, stats, opts = {}) {
   // Positional-arg guard (#4929 external review): a caller passing
   // { demoteFinance } in the stats slot would silently get default

--- a/scripts/apply-openapi-filter-param-schemas.mjs
+++ b/scripts/apply-openapi-filter-param-schemas.mjs
@@ -213,7 +213,7 @@ function schemaLines(schema) {
 function patchYamlTarget(text, target) {
   const lines = text.split('\n');
   const pathNeedle = `    ${target.path}:`;
-  const pathIndex = lines.findIndex((line) => line === pathNeedle);
+  const pathIndex = lines.indexOf(pathNeedle);
   if (pathIndex === -1) return text;
 
   let pathEnd = lines.length;
@@ -230,7 +230,7 @@ function patchYamlTarget(text, target) {
 
   let methodEnd = pathEnd;
   for (let i = methodIndex + 1; i < pathEnd; i++) {
-    if (/^        [a-z]+:$/.test(lines[i] || '')) {
+    if (/^ {8}[a-z]+:$/.test(lines[i] || '')) {
       methodEnd = i;
       break;
     }

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -350,7 +350,6 @@ function parseChangelog(source) {
       } else if (currentBullet && /^\s{2,}\S/.test(line)) {
         currentBullet.push(line.trim());
       } else if (currentBullet && line.trim() === '') {
-        continue;
       } else if (currentBullet) {
         bulletItems.push(currentBullet.join(' '));
         currentBullet = null;

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -55,9 +55,9 @@ function extractSingleQuotedValue(text, name) {
 }
 
 function findTopLevelObjectBlocks(source) {
-  const starts = [...source.matchAll(/^  \{$/gm)].map((m) => m.index);
+  const starts = [...source.matchAll(/^ {2}\{$/gm)].map((m) => m.index);
   return starts.map((start) => {
-    const close = source.slice(start).search(/^  \},?$/m);
+    const close = source.slice(start).search(/^ {2}\},?$/m);
     if (close === -1) return source.slice(start);
     return source.slice(start, start + close);
   });

--- a/scripts/openapi-inject-async-jobs.mjs
+++ b/scripts/openapi-inject-async-jobs.mjs
@@ -178,7 +178,7 @@ function injectYaml(text) {
       }
     }
     if (acceptedIndex === -1) continue;
-    let acceptedEnd = blockEndAtIndent(lines, acceptedIndex, responsesEnd, 16);
+    const acceptedEnd = blockEndAtIndent(lines, acceptedIndex, responsesEnd, 16);
 
     // 2. Replace the success description (single-line, first 20-indent
     //    `description:` child of the 202 block).

--- a/scripts/openapi-inject-rate-limit-errors.mjs
+++ b/scripts/openapi-inject-rate-limit-errors.mjs
@@ -295,7 +295,7 @@ const YAML_POST_400_RESPONSE = [
   "                                    - $ref: '#/components/schemas/InvalidRequestBodyError'",
 ];
 
-const YAML_METHOD_LINE_RE = /^        (get|post|put|delete|patch|options|head):$/;
+const YAML_METHOD_LINE_RE = /^ {8}(get|post|put|delete|patch|options|head):$/;
 
 function findYamlSchemaRange(lines, schemaName) {
   const start = lines.indexOf(`        ${schemaName}:`);

--- a/scripts/openapi-inject-required.mjs
+++ b/scripts/openapi-inject-required.mjs
@@ -301,7 +301,7 @@ function setYamlSchemaRequired(lines, schemaName, required) {
 
     let insertAt = -1;
     const relative = lines.slice(schemaIndex, schemaEnd);
-    const propertiesIndex = relative.findIndex((line) => line === '            properties:');
+    const propertiesIndex = relative.indexOf('            properties:');
     if (propertiesIndex !== -1) {
       insertAt = schemaIndex + propertiesIndex + 1;
       while (insertAt < schemaEnd) {
@@ -310,7 +310,7 @@ function setYamlSchemaRequired(lines, schemaName, required) {
         insertAt++;
       }
     } else {
-      const typeIndex = relative.findIndex((line) => line === '            type: object');
+      const typeIndex = relative.indexOf('            type: object');
       insertAt = typeIndex === -1 ? schemaEnd : schemaIndex + typeIndex + 1;
     }
     lines.splice(insertAt, 0, ...expected);

--- a/scripts/openapi-inject-security.mjs
+++ b/scripts/openapi-inject-security.mjs
@@ -454,7 +454,7 @@ function ensureYamlSecuritySchemes(lines, hasBearer) {
 }
 
 // ── Service/bundle YAML entitlement insertion (formatting-preserving) ────────
-const YAML_METHOD_LINE_RE = /^        (get|post|put|delete|patch|options|head):$/;
+const YAML_METHOD_LINE_RE = /^ {8}(get|post|put|delete|patch|options|head):$/;
 
 const YAML_FORBIDDEN_RESPONSE = [
   '                "403":',

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2171,13 +2171,13 @@ const MARKET_ADVERSE_OUTCOME_PATTERNS = [
   /(?:^|[^a-z0-9])renew(?:s|ed|ing|al|als)?(?:[^a-z0-9]|$)/,
   /(?:^|[^a-z0-9])collaps(?:e|es|ed|ing)?(?:[^a-z0-9]|$)/,
 ];
-const MARKET_DE_ESCALATION_ANCHOR_PATTERN = String.raw`(?:ceasefire|truce|peace(?: agreement| deal)?|agreement)`;
+const MARKET_DE_ESCALATION_ANCHOR_PATTERN = '(?:ceasefire|truce|peace(?: agreement| deal)?|agreement)';
 const MARKET_DE_ESCALATION_FAILURE_PATTERN = String.raw`(?:fail(?:s|ed|ing|ure|ures)?|collaps(?:e|es|ed|ing)?|break(?:s|ing)? down|breakdown|breach(?:es|ed|ing)?|violat(?:e|es|ed|ing|ion|ions)?|reject(?:s|ed|ing|ion|ions)?|expire(?:s|d|ing)?|ends?\b(?!\s+of\b))`;
 const MARKET_FAILED_DE_ESCALATION_PATTERNS = [
   new RegExp(String.raw`\b${MARKET_DE_ESCALATION_ANCHOR_PATTERN}\b.{0,40}\b${MARKET_DE_ESCALATION_FAILURE_PATTERN}\b`),
   new RegExp(String.raw`\b${MARKET_DE_ESCALATION_FAILURE_PATTERN}\b.{0,40}\b${MARKET_DE_ESCALATION_ANCHOR_PATTERN}\b`),
 ];
-const MARKET_ADVERSE_CONDITION_PATTERN = String.raw`(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)`;
+const MARKET_ADVERSE_CONDITION_PATTERN = '(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)';
 const MARKET_ADVERSE_CONDITION_END_PATTERNS = [
   new RegExp(String.raw`\b${MARKET_ADVERSE_CONDITION_PATTERN}\b.{0,40}\bend(?:s|ed|ing)?\b(?!\s+of\b)`),
   new RegExp(String.raw`\bend(?:s|ed|ing)?\b(?:\s+of)?.{0,40}\b${MARKET_ADVERSE_CONDITION_PATTERN}\b`),
@@ -3576,7 +3576,7 @@ async function extractCriticalSignalBundle(inputs) {
     (criticalLlmOptions.providerOrder || []).join('-') || 'default',
     criticalLlmOptions.modelOverrides?.openrouter || 'table',
     criticalLlmOptions.modelOverrides?.groq || 'table',
-  ].join('_').replace(/[^a-zA-Z0-9._\/-]/g, '-');
+  ].join('_').replace(/[^a-zA-Z0-9._/-]/g, '-');
   const cacheKey = `forecast:critical-signals:llm:${criticalRouteTag}:${buildCriticalSignalCandidateHash(candidates)}`;
   const fallbackSignalsFromCandidates = (coveredIndexes = new Set()) =>
     extractRegexCriticalNewsSignals(inputs, candidates.filter((item) => !coveredIndexes.has(item.candidateIndex)));


### PR DESCRIPTION
**Every PR that triggers a full lint is currently red** — first casualty was #5397. Root cause: #5395's security-advisory lockfile refresh floated biome 2.4.7→2.4.9 within the `^2.4.7` caret range, and 2.4.9 promotes six rules that flag 20 pre-existing spots in `scripts/`. Main's path-filtered biome job hasn't re-linted `scripts/` since, so main looks green while every full-lint PR fails.

**All 20 fixes verified behavior-neutral:**
- `findIndex(l => l === x)` → `indexOf(x)`, adjacent-spaces → `{n}` regex quantifiers, `String.raw` → plain literals (no escapes present), useless `continue` dropped, `let` → `const` — all equivalence-preserving rewrites.
- Unused params dropped only after confirming call sites (`buildQuestion`/`userValueScore` template interfaces).
- **One unsafe auto-fix rejected**: biome wanted to delete `selectTopStories`' `maxCount = 8` default (silent signature change); restored under an explicit `biome-ignore` with rationale — sole caller passes 8 explicitly, verified.

Verification: `npm run lint` fully green locally on biome 2.4.9; 73 tests across all touched modules (bet-templates, baserate, clustering, forecast seeder, docs-stats) pass; `docs-stats --check` contract intact.

After this merges, re-run checks on #5397 (its biome failure is exactly this).

No auto-merge — your call, but this one gates everything else.

https://claude.ai/code/session_01EEkAczYV9o2crM8kKSM3a2