### PR TITLE
feat(content): 13 blog posts — undocumented features (tenders, sanctions, aviation, radiation, energy dashboard…) + 'not Palantir' positioning

### DIFF
--- a/blog-site/src/content/blog/ai-forecast-accuracy-brier-scorecard-worldmonitor.md
+++ b/blog-site/src/content/blog/ai-forecast-accuracy-brier-scorecard-worldmonitor.md
@@ -1,0 +1,60 @@
+---
+title: "We Grade Our Own Forecasts: Inside the Forecast Scorecard"
+description: "WorldMonitor resolves its AI forecasts against reality and publishes the results: Brier scores, log scores, calibration buckets, and per-domain accuracy breakdowns."
+metaTitle: "AI Forecast Accuracy & Brier Scorecard | WorldMonitor"
+keywords: "AI forecast accuracy, Brier score forecasting, geopolitical forecast track record, forecast calibration, prediction accountability, forecast verification"
+audience: "Forecasters, superforecasting community, quant researchers, skeptical analysts, AI evaluation researchers"
+heroImage: "/blog/og/ai-forecast-accuracy-brier-scorecard-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Every AI product now makes predictions. Almost none of them tell you their error rate.
+
+That asymmetry is the oldest trick in forecasting: make many confident calls, showcase the hits, let the misses expire quietly. It works because nobody keeps the ledger. WorldMonitor generates [AI geopolitical and economic forecasts](/blog/posts/prediction-markets-ai-forecasting-geopolitics/) — so we built the ledger, and we publish it.
+
+## How the scorecard works
+
+Every forecast enters a **resolution ledger** when it's made: the claim, the probability, and what would count as resolution. When the outcome is knowable, the forecast is judged and scored. No retroactive editing, no quiet expiry — pending forecasts are counted as pending, and judged forecasts keep their original probabilities forever.
+
+From the resolved ledger, the scorecard computes the metrics forecasting research actually uses:
+
+- **Brier score** — the mean squared error of probability forecasts. Lower is better; 0.25 is what coin-flipping "50% on everything" scores. It punishes confident wrongness hardest, which is the failure mode that matters.
+- **Log score** — the harsher cousin, which severely penalizes being both extreme and wrong.
+- **Calibration buckets** — the honesty test: of everything we called "70% likely," did roughly 70% happen? A forecaster can have decent averages while being systematically overconfident; calibration buckets expose that.
+- **Domain breakdowns** — accuracy sliced by forecast domain, because being sharp on commodity moves doesn't certify you on diplomatic outcomes, and pretending one number covers both is how track records mislead.
+
+The scoring runs over a rolling window with judged and pending counts visible, so you can see not just how good the record is but how much record there is.
+
+## Why publish it
+
+Three reasons, in ascending order of importance:
+
+1. **It's the standard we hold others to.** WorldMonitor puts [Polymarket and Kalshi probabilities](/blog/posts/prediction-markets-ai-forecasting-geopolitics/) next to its own forecasts. Prediction markets keep score by construction — their prices are public history. Publishing our own Brier scores is the price of sitting in that company.
+2. **It makes the forecasts usable.** A "78% probability" from a black box is decoration. The same number from a system whose calibration you can inspect is an input you can size decisions with.
+3. **It improves the system.** Scored errors are training signal. The domains where calibration drifts are the domains where the pipeline gets fixed next.
+
+## For developers and agents
+
+The `get_forecast_scorecard` MCP tool returns the full scorecard — Brier and log scores, calibration buckets, domain breakdowns, judged and pending counts — in one structured call, and `get_forecast_predictions` returns the current forecasts it will eventually grade. An agent can do something genuinely new with that pair: weight a forecast by the demonstrated track record of its domain before acting on it. The [risk-agent tutorial](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/) shows the wiring; the [daily briefing workflow](/blog/posts/daily-intelligence-briefing-workflow-15-minutes/) shows where forecasts fit a human routine.
+
+## Limits
+
+The ledger only proves what it contains: domains with few resolved forecasts have wide uncertainty around their scores, and the rolling window means the record is a moving sample, not an all-time monument. Resolution requires judgeable outcomes, so inherently vague geopolitical claims either get sharpened into resolvable form or don't enter the ledger. And a good historical Brier score is evidence, not a promise — regimes change, and calibration is always trailing.
+
+## Frequently Asked Questions
+
+**What is a Brier score?**
+
+The mean squared difference between forecast probabilities and outcomes (0 or 1). Lower is better. Answering "50%" to everything scores 0.25, so a real track record needs to beat that meaningfully.
+
+**Can forecasts be edited or deleted after the fact?**
+
+No. Once a forecast enters the resolution ledger, its probability and claim are fixed. It resolves, or it's counted as pending — the two ways forecasts quietly vanish elsewhere are exactly what the ledger exists to prevent.
+
+**Where can I see or query the scorecard?**
+
+In the forecast panel on the dashboard, and programmatically via the `get_forecast_scorecard` MCP tool or the forecast REST endpoints in the [API reference](https://www.worldmonitor.app/docs/api-reference).
+
+---
+
+**Anyone can make predictions. The scorecard is the difference between forecasting and content — and it only counts if you publish it before you know how it ends.**

--- a/blog-site/src/content/blog/alerts-notification-channels-worldmonitor.md
+++ b/blog-site/src/content/blog/alerts-notification-channels-worldmonitor.md
@@ -1,0 +1,70 @@
+---
+title: "Six Ways WorldMonitor Reaches You When the World Changes"
+description: "Telegram, Slack, Discord, email, webhooks, and web push — WorldMonitor's alert rules deliver scoped intelligence with digest modes and quiet hours, no code required."
+metaTitle: "Intelligence Alerts: 6 Notification Channels | WorldMonitor"
+keywords: "geopolitical alerts app, telegram news alerts, discord intelligence alerts, web push breaking news, alert fatigue quiet hours, intelligence notifications"
+audience: "Analysts, ops and security teams, traders, journalists, anyone who can't watch a dashboard all day"
+heroImage: "/blog/og/alerts-notification-channels-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+A dashboard you have to watch is a part-time job. The whole point of monitoring infrastructure is inverted attention: you ignore the world safely because the system knows what you care about and interrupts you only when it happens.
+
+WorldMonitor's alert system is built for that inversion — no code, no webhook glue, unless you want it.
+
+## Six channels, your choice
+
+Alert rules can deliver to **six channel types**:
+
+- **Telegram** — the de facto channel of the OSINT world.
+- **Slack** — for teams that live there; webhook credentials are stored encrypted.
+- **Discord** — where trading groups and research communities actually are.
+- **Email** — for the paper trail and the people who check nothing else.
+- **Webhook** — the escape hatch into your own systems: ticketing, SIEM, home automation, anything with a URL.
+- **Web push** — browser-native notifications with no third-party account at all.
+
+The same rule can feed different channels for different severities — critical events to the phone, routine matches to email.
+
+## Scoped rules, not firehoses
+
+An alert system that forwards everything is just a louder feed. WorldMonitor rules are scoped on three axes:
+
+- **What**: the event types you care about — not the whole stream.
+- **Where**: rules respect **Country Scope**, so "unrest events" can mean "unrest events in the four countries my team operates in," not the planet.
+- **Which dashboard**: rules are variant-aware, so a finance-focused rule set and a geopolitical one don't contaminate each other.
+
+Then the delivery controls do the work that separates a usable system from a muted one:
+
+- **Digest modes** — realtime, daily, twice daily, or weekly. Most intelligence doesn't need to interrupt you; it needs to be waiting, summarized, when you check.
+- **Sensitivity thresholds** — all events, high-priority only, or critical only.
+- **Quiet hours** — with three behaviors: let only critical through, silence everything, or batch alerts for delivery when you wake. That last one is the correct default for most humans: nothing lost, nothing at 3 a.m.
+
+Alert fatigue is the failure mode that kills every monitoring setup. The [alert-design guide](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/) goes deep on the principles; the in-product rules implement them without you writing a line.
+
+## Alerts complete the workflows
+
+Every workflow on this blog ends with the same step. The [country-risk routine](/blog/posts/country-risk-monitoring-workflow-for-analysts/) ends with "put the watchlist on continuous watch." The [15-minute briefing](/blog/posts/daily-intelligence-briefing-workflow-15-minutes/) ends with automation carrying the other 23 hours. Alert rules are that step: pin your entities, set your monitors and watchlists, scope the rules, pick the channel you actually read, and the dashboard keeps working when you close it.
+
+Developers who want full control still have it — the API path with your own scheduler and delivery logic is the [Slack/Teams tutorial](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/). The in-product system is for everyone who wants the outcome without owning the plumbing.
+
+## Limits
+
+Delivery depends on the receiving platform's own reliability and rate limits — Telegram, Slack, and Discord each have their own weather. Web push requires a browser that supports it and permission you can revoke anytime. And no alert system substitutes for judgment about what deserves a rule: start with fewer rules at higher sensitivity, and widen only when you find yourself checking the dashboard for things it should have told you.
+
+## Frequently Asked Questions
+
+**Do I need to write code to set up alerts?**
+
+No. Rules, scoping, digest modes, quiet hours, and all six channels are configured in the product. Code is only for the webhook channel's receiving end — or for developers who prefer the raw API.
+
+**Can I limit alerts to specific countries?**
+
+Yes — alert rules respect Country Scope, so rules fire only for the countries you've scoped, which is the single most effective alert-fatigue control the system has.
+
+**What happens to alerts during quiet hours?**
+
+Your choice per rule: critical-only passes through, full silence, or batch-on-wake — everything held and delivered together when quiet hours end.
+
+---
+
+**The dashboard is for when you're looking. The alert rules are for the other 23 hours — set them once, and the world starts reporting to you.**

--- a/blog-site/src/content/blog/aviation-intelligence-airports-airspace-flight-prices.md
+++ b/blog-site/src/content/blog/aviation-intelligence-airports-airspace-flight-prices.md
@@ -1,0 +1,64 @@
+---
+title: "Aviation Intelligence: Airports, Airspace, and Flight Prices as Signals"
+description: "WorldMonitor tracks 115 airports, FAA delays, NOTAM closures, military aircraft, GPS jamming, and live Google Flights prices — because aviation reacts to risk first."
+metaTitle: "Aviation Intelligence Dashboard | WorldMonitor"
+keywords: "aviation intelligence dashboard, airport delay monitoring, NOTAM airspace closures, military aircraft tracking, flight prices API, GPS jamming map"
+audience: "Airline and ops teams, travel security managers, OSINT analysts, journalists, frequent travelers"
+heroImage: "/blog/og/aviation-intelligence-airports-airspace-flight-prices.png"
+pubDate: "2026-07-21"
+---
+
+Aviation is the most reactive layer in the global system. Airlines reroute around risk hours before governments issue statements; insurers reprice overflight before analysts publish; evacuation demand hits booking engines before it hits the news. If you can read the aviation layer, you often get the earliest civilian-visible signal that something changed.
+
+WorldMonitor gives that layer a dedicated panel — and wires it into the same map as conflicts, chokepoints, and infrastructure.
+
+## The six-tab Aviation Intelligence panel
+
+The **Aviation Intelligence panel** covers 115 monitored airports worldwide across six tabs:
+
+- **Ops** — operational status and delay conditions, including FAA delay programs for US hubs.
+- **Flights** — flight activity for the airports you care about.
+- **Airlines** — carrier-level news and operational signals.
+- **Track** — aircraft tracking, including military aircraft identified from live ADS-B data.
+- **News** — aviation-sector news, classified and deduplicated like every other WorldMonitor feed.
+- **Prices** — live flight-price search backed by Google Flights data.
+
+Around the panel, the map adds the **flights layer** for delay conditions, the **GPS jamming layer** for GNSS interference zones — one of the strongest passive indicators of electronic warfare activity — and live military tracking that feeds the [conflict monitoring workflow](/blog/posts/track-global-conflicts-in-real-time/).
+
+## Airspace as a country-level question
+
+The `get_airspace` MCP tool answers "what is flying over this country right now" — civilian traffic from OpenSky plus identified military aircraft. Its sibling `get_aviation_status` returns airport delays, NOTAM-based closure context, and tracked military aircraft in one call.
+
+That combination matters because absence is a signal too. Civilian traffic thinning out over a region while military tracks persist is one of the classic OSINT tells — the pattern that made "flight-tracker Twitter" famous, available as a structured query instead of a screenshot. The [breaking-news verification workflow](/blog/posts/verify-breaking-news-osint-workflow-journalists/) uses exactly this check.
+
+## Flight prices are a sensor
+
+WorldMonitor can search real-time flight options and prices between any two airports (`search_flights`), and scan a whole date range for the cheapest fare per day (`search_flight_prices_by_date`) — live Google Flights data, exposed to both the Prices tab and MCP agents.
+
+The obvious use is practical: an AI travel assistant with real fares. The less obvious use is analytical. Prices out of a stressed city spiking while inbound fares collapse is demand-side evidence of departure pressure. Routes quietly disappearing from results tell you about airspace and slot decisions before they're announced. When you need to know whether "people are leaving" is a rumor or a fact, the booking engine is a witness.
+
+## For developers and agents
+
+All of it is queryable: `get_aviation_status` and `get_airspace` for the intelligence layer, `search_flights` and `search_flight_prices_by_date` for fares, alongside the versioned aviation REST endpoints in the [API reference](https://www.worldmonitor.app/docs/api-reference). An agent can chain them: check a country's airspace activity, confirm airport status, then price the exit routes — the full [risk-agent pattern](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/).
+
+## Limits
+
+ADS-B and OpenSky coverage degrades exactly where things get interesting — conflict zones, jamming areas, and regions with sparse receiver networks — and military aircraft that don't want to be tracked aren't. Flight-price data reflects what Google Flights serves at query time; it's a live search, not a booked-fare archive. Delay data is strongest for FAA-covered US airports. Treat every aviation signal as one witness among several, which is how the verification workflow uses it.
+
+## Frequently Asked Questions
+
+**Can I track a specific flight?**
+
+The panel is built around airports, airspace, and patterns rather than individual flight following. For a single tail number, dedicated flight trackers are the right tool; WorldMonitor tells you what the pattern around it means.
+
+**Where does the flight-price data come from?**
+
+Live Google Flights results, queried on demand with IATA airport codes — single-date searches with airline, stops, and segment detail, or a date-grid scan for the cheapest fare per day.
+
+**Is military aircraft tracking reliable?**
+
+It's real but partial: identification works from live ADS-B transponder data, and military aircraft can and do fly dark. Persistent visible military activity is signal; silence is not proof of absence.
+
+---
+
+**Airlines are risk-pricing machines with wings. Watch where they fly, what they avoid, and what the seats cost — the aviation layer usually knows first.**

--- a/blog-site/src/content/blog/disease-outbreak-air-quality-monitoring-health-signals.md
+++ b/blog-site/src/content/blog/disease-outbreak-air-quality-monitoring-health-signals.md
@@ -1,0 +1,58 @@
+---
+title: "Monitor Disease Outbreaks and Air Quality on One Map"
+description: "WorldMonitor merges WHO outbreak news, CDC travel notices, and outbreak trackers with OpenAQ and WAQI air-quality sensors into one global health-signals layer."
+metaTitle: "Disease Outbreak & Air Quality Monitoring | WorldMonitor"
+keywords: "disease outbreak map, epidemic monitoring dashboard, WHO outbreak tracker, air quality PM2.5 map, global health surveillance, health signals API"
+audience: "Public-health analysts, NGO and travel-security teams, researchers, journalists, expats and frequent travelers"
+heroImage: "/blog/og/disease-outbreak-air-quality-monitoring-health-signals.png"
+pubDate: "2026-07-21"
+---
+
+Health signals are geopolitical signals. An outbreak reshapes trade and travel; a smoke or smog crisis empties cities and moves elections; and health infrastructure under strain is one of the most concrete measures of a state losing capacity. Yet health monitoring usually lives in separate tools from the conflict, disaster, and market layers it interacts with.
+
+WorldMonitor folds both halves — outbreaks and air quality — into the same dashboard as everything else.
+
+## Outbreak tracking from official and specialist sources
+
+The disease-outbreak pipeline merges complementary sources rather than betting on one:
+
+- **WHO Disease Outbreak News** — the official record of internationally significant events, read from WHO's own API.
+- **CDC travel health notices** — the practical layer: what a major public-health agency thinks travelers need to know, by destination.
+- **Outbreak News Today** — specialist reporting that often moves days ahead of official confirmation.
+- A dedicated **outbreak tracker dataset** for structured, ongoing events.
+
+Outbreaks appear in the **Disease Outbreaks panel** and as a map layer, so an event sits in geographic context: next to the airports it may close, the displacement it may cause, and the [country risk](/blog/posts/country-risk-monitoring-due-diligence-worldmonitor/) it feeds into.
+
+## Air quality as ground truth
+
+The second half of the health layer is instrumented, not reported: **PM2.5 readings from OpenAQ's global sensor network plus WAQI station data**. Air quality is one of the few global datasets that is dense, numeric, and hourly — and it moonlights as an indirect sensor for other events. Wildfire smoke plumes, industrial incidents, and even conflict damage show up in particulate readings, sometimes before anything official is published.
+
+For daily use it's simpler than that: if you live in, travel to, or manage people in a city with episodic air crises, a live PM2.5 layer next to your news feeds is just operationally useful.
+
+## One health layer, one query
+
+For agents and developers, the `get_health_signals` MCP tool returns current outbreak signals and air-quality readings in a single structured call, with the REST equivalents under the versioned health API. The [humanitarian workflow](/blog/posts/humanitarian-situational-awareness-ngo-security-monitoring-worldmonitor/) shows the field-security use; pairing it with [displacement data](/blog/posts/track-refugee-displacement-flows-unhcr-worldmonitor/) gives the fuller picture of pressure on a population.
+
+A useful habit from the [15-minute briefing routine](/blog/posts/daily-intelligence-briefing-workflow-15-minutes/): scan health signals for the countries already on your watchlist. Outbreaks rarely stay health stories — they become border stories, supply stories, and political stories, and the analysts who tracked them from the WHO bulletin onward are never surprised by that.
+
+## Limits
+
+Outbreak reporting inherits the biases of surveillance: countries with strong health systems report more, so more reports don't always mean more disease. Official WHO confirmation lags the specialist press by design — that's what verification costs. Air-quality sensor density varies sharply by region, with the thinnest coverage often where conditions are worst. Read gaps as gaps, not as clean air or absent disease.
+
+## Frequently Asked Questions
+
+**Which outbreak sources does WorldMonitor track?**
+
+WHO Disease Outbreak News via WHO's API, CDC travel health notices, Outbreak News Today's specialist reporting, and a structured outbreak-tracker dataset — merged and deduplicated.
+
+**Where does the air-quality data come from?**
+
+PM2.5 measurements from OpenAQ's open sensor network and WAQI station data, displayed live and available through the same health-signals API.
+
+**Is this a replacement for official public-health guidance?**
+
+No. It's situational awareness — early, aggregated, and geographically contextualized. Decisions about vaccination, treatment, or travel restrictions belong with official guidance.
+
+---
+
+**Epidemics and air don't respect the borders between your dashboards. One health layer, on the same map as everything it affects, is how you stop being surprised.**

--- a/blog-site/src/content/blog/energy-security-dashboard-worldmonitor.md
+++ b/blog-site/src/content/blog/energy-security-dashboard-worldmonitor.md
@@ -1,0 +1,68 @@
+---
+title: "The Energy Security Dashboard: Oil, Gas, and Grid Risk on One Screen"
+description: "energy.worldmonitor.app is WorldMonitor's dedicated energy dashboard: 26 panels covering chokepoints, 88 pipelines, gas storage, fuel shortages, crisis policies, and prices."
+metaTitle: "Energy Security Dashboard | WorldMonitor"
+keywords: "energy security dashboard, oil and gas monitoring, energy intelligence platform, European gas storage levels, pipeline status map, energy crisis tracker, Strait of Hormuz monitoring"
+audience: "Energy analysts, commodity traders, utilities and policy researchers, logistics teams, macro investors"
+heroImage: "/blog/og/energy-security-dashboard-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Energy is the transmission belt between geopolitics and everything else. A strait closes, a pipeline drops pressure, a cold snap lands on thin storage — and within weeks the same event has become a freight story, an inflation story, and a political story. That's why energy analysis can't live inside a single market feed: the causes are physical and geopolitical, and only the consequences are financial.
+
+WorldMonitor's [energy-shock monitoring workflow](/blog/posts/energy-shock-monitoring-chokepoints-worldmonitor/) taught readers to assemble that picture by hand across the main dashboard. Now there's a purpose-built instrument: **energy.worldmonitor.app**, a dedicated energy dashboard with 26 panels arranged around one question — *is energy flowing, and at what price?*
+
+## The physical layer: flows, chokepoints, infrastructure
+
+The dashboard opens on the **Energy Atlas map** and a **Chokepoint Status strip** covering the [13 monitored waterways](/blog/posts/what-is-a-maritime-chokepoint/), seven of which publish live oil-and-gas flow estimates against EIA baselines. The **Strait of Hormuz Tracker** gets its own panel, because roughly a fifth of global oil transit deserves one.
+
+Around the chokepoints sits the fixed infrastructure:
+
+- **Oil & Gas Pipeline Status** — 88 mapped pipelines with status tracking.
+- **Strategic Storage Atlas** — where the buffers physically are.
+- **Global Fuel Shortage Registry** — where the buffers have already failed.
+- **Energy Disruptions Log** — the running record of outages, attacks, and force majeure events.
+
+This is the layer most market tools skip entirely: they show you the price of the disruption, not the disruption.
+
+## The market and policy layers
+
+The market panels reuse WorldMonitor's finance engine, curated for energy: the **Oil & Gas Complex**, **EIA inventories**, **WTI, Brent, and natural-gas quotes**, and the **Market Regime** signal. The policy layer is what makes it an energy-*security* dashboard rather than a commodity screen: the **Energy Crisis Policy Tracker** follows government interventions — price caps, subsidies, export bans — while [**Sanctions Pressure**](/blog/posts/monitor-global-sanctions-pressure-worldmonitor/), **Gulf & OPEC Economies**, and **GCC Energy Investments** track the actors who move supply on purpose.
+
+The demand side closes the loop: **Retail Fuel Prices** (the number citizens actually feel — the same [ground-truth philosophy](/blog/posts/ground-truth-inflation-shelf-price-tracking-worldmonitor/) as the shelf-price tracker), **Climate & Weather Impact** as the demand driver, and **Renewable Energy** for the structural shift underneath it all.
+
+## The data backbone
+
+The panels sit on named, official sources rather than a scraped mash: **EIA** petroleum stocks and flow baselines, **JODI** oil and gas data, **Ember** electricity data, **GIE AGSI+** for European gas storage levels, **Our World in Data** energy-mix series, and **IMF PortWatch with live AIS** for chokepoint transits. Where a source lags or a series is missing, the dashboard shows the gap — the same no-silent-zeros discipline as the chokepoint model.
+
+## How to read it: the escalation chain
+
+Energy shocks propagate in a fixed order, and the dashboard is arranged to match: chokepoint status turns yellow → tanker traffic reroutes → the disruptions log confirms the physical event → storage starts drawing → crisis policies appear → retail prices move. Each hop has a panel. When you can watch the whole chain on one screen, you stop discovering shocks at the retail-price stage — which is where most people, and most portfolios, currently discover them.
+
+For pre-event work, the [Scenario Engine's](/blog/posts/stress-test-supply-chain-scenario-engine-worldmonitor/) Hormuz and Suez stress tests pair naturally with this dashboard; for the market translation, the [geopolitics-to-markets pipeline](/blog/posts/geopolitics-to-markets-pipeline-macro-traders-worldmonitor/) picks up where the chain ends.
+
+## For developers and agents
+
+The `get_energy_intelligence` MCP tool returns the core bundle — petroleum stocks, electricity prices, gas storage, fuel shortages, disruptions, and crisis policies — in one call, with `get_chokepoint_status` covering live transits and `get_commodity_geo` the production geography. There's even a pre-built **energy-shock-watch** prompt template on the MCP server that wires the right tools and projections together for you. The [risk-agent tutorial](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/) shows the general pattern.
+
+## Limits
+
+Live flow estimates cover seven of the 13 chokepoints — the ones with EIA baselines. Gas-storage depth is strongest for Europe, where GIE's AGSI+ transparency regime exists; most of the world publishes nothing comparable. Electricity data inherits Ember's reporting cadence, and retail fuel-price coverage varies by country. The dashboard's job is to show you what's knowable and label what isn't — not to interpolate confidence where the world doesn't publish data.
+
+## Frequently Asked Questions
+
+**Is the energy dashboard free?**
+
+Yes — like every WorldMonitor variant, energy.worldmonitor.app is free with no login. The Latest Brief panel is the one Pro-locked element at launch.
+
+**How is this different from the main WorldMonitor dashboard?**
+
+Same engine, different curation: the energy variant strips the general geopolitical panels and assembles every energy-relevant panel — chokepoints, pipelines, storage, shortages, policies, prices — into one purpose-built layout with its own Energy Atlas map.
+
+**Can AI agents query the energy data?**
+
+Yes — `get_energy_intelligence`, `get_chokepoint_status`, and `get_commodity_geo` via the MCP server, plus the pre-built energy-shock-watch prompt template. REST equivalents are in the [API reference](https://www.worldmonitor.app/docs/api-reference).
+
+---
+
+**Every energy shock is visible somewhere physical before it's visible in your bill. This dashboard is the somewhere — one screen, arranged in the order shocks actually travel.**

--- a/blog-site/src/content/blog/government-tenders-procurement-intelligence-worldmonitor.md
+++ b/blog-site/src/content/blog/government-tenders-procurement-intelligence-worldmonitor.md
@@ -1,0 +1,80 @@
+---
+title: "Track Government Tenders Worldwide in One Feed"
+description: "WorldMonitor aggregates open tenders from SAM.gov, TED, Contracts Finder, CanadaBuys, GETS, and the World Bank into one searchable, hourly-refreshed procurement feed."
+metaTitle: "Global Government Tender Tracking | WorldMonitor"
+keywords: "government tender tracking, global procurement opportunities, SAM.gov TED tenders, government contracts monitoring, procurement intelligence, tender alerts API"
+audience: "Business development teams, government contractors, consultancies, market-entry analysts, procurement researchers"
+heroImage: "/blog/og/government-tenders-procurement-intelligence-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Governments announce their priorities through procurement before they announce them through policy. A defense ministry tendering for drone-detection systems, a health agency buying cold-chain logistics, a municipality procuring flood barriers — each notice is a documented, budgeted statement of intent, published weeks or months before the contract shows up in any news cycle.
+
+The problem is that this signal is scattered across national portals that share no format, no API conventions, and no common vocabulary. WorldMonitor's Global Procurement panel pulls the major official sources into one searchable feed.
+
+## Six official sources, one feed
+
+The procurement pipeline reads only official public interfaces — no scraping of portal HTML:
+
+| Source | Coverage |
+|---|---|
+| SAM.gov | United States federal opportunities |
+| TED | European Union public procurement notices |
+| Contracts Finder | United Kingdom (OCDS tender releases) |
+| CanadaBuys | Canada federal open tenders |
+| GETS | New Zealand / Oceania |
+| World Bank Procurement Notices | Multilateral, across borrower countries |
+
+A seeder refreshes the canonical snapshot hourly. If one source fails, the others keep flowing and the response reports `availability: "partial"` with that source's last-good records retained — a failed adapter is never displayed as "zero tenders."
+
+One deliberate gap: Australia. AusTender publishes no machine-readable feed that includes closing dates, and WorldMonitor never represents an opportunity without a verifiable deadline. Australian coverage stays absent rather than inferred — the reasoning is documented in the [Global Procurement Intelligence docs](https://www.worldmonitor.app/docs/global-procurement-intelligence).
+
+## Opportunities, not just awards
+
+WorldMonitor separates two different questions:
+
+- **What has been awarded?** Historical US award data from USASpending remains in the free Economic panel. Awards tell you who won and what a government spent.
+- **What is open right now?** The Global Procurement panel is forward-looking: open tenders you can still act on, with deadlines, buyers, estimated values, and official notice links.
+
+Within the panel you can search titles and descriptions, filter by buyer, country, and source, and sort by newest, closing soon, estimated value, or relevance. Every record keeps its official notice URL and source ID, so the panel is a discovery layer, never a substitute for the official portal where you actually bid.
+
+## The technology-relevance filter
+
+For software, AI, data, cybersecurity, and cloud vendors, most of a raw tender feed is noise — road resurfacing, catering contracts, office furniture. Each record carries an `automationFit` score: a transparent, keyword-based relevance signal with match reasons and text evidence. The panel exposes it as a **Technology relevant only** checkbox; the API exposes it as `min_automation_score`.
+
+It is deliberately labeled a relevance signal, not an eligibility determination. Whether your company can legally bid on a French defense tender is a question for the official notice, and `participationMode` stays `unknown` unless the source states it.
+
+## For developers and agents
+
+The same feed is available programmatically:
+
+- **REST:** `GET /api/economic/v1/list-global-tenders` — paginated up to 100 records per page, with filters for country, region, source, status, buyer, publish and deadline dates, value range, currency, category, and free-text query. See the [API reference](https://www.worldmonitor.app/docs/api-reference).
+- **MCP:** the `get_procurement_opportunities` tool gives AI agents a compact projection (10 records by default, 25 max) so an agent can ask "open cybersecurity tenders in the EU closing in the next 30 days" without flooding its context window.
+
+Both paths are part of WorldMonitor Pro and enforce the subscription server-side. Pair the feed with [country risk screening](/blog/posts/country-risk-monitoring-due-diligence-worldmonitor/) before chasing an opportunity in an unfamiliar market, and with the [tariff and trade-policy trackers](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/) when the contract involves cross-border delivery.
+
+## Procurement as an intelligence signal
+
+Even if you never bid on anything, tender flow is worth watching. Clusters of notices reveal budget priorities: a spike in border-surveillance procurement, a wave of grid-hardening contracts, a sudden multilateral push for emergency food logistics. Because notices carry official buyers, values, and deadlines, they are among the least ambiguous signals in open-source intelligence — nobody publishes a tender by accident.
+
+## Limits
+
+Coverage is currently six sources — strong for the US, EU, UK, Canada, New Zealand, and World Bank-financed projects, absent elsewhere until more official machine-readable sources ship. Estimated values are only present when the source publishes them. The `automationFit` score is keyword-based by design: transparent and auditable, but not a semantic model, so skim beyond your filter occasionally.
+
+## Frequently Asked Questions
+
+**Is the tender feed free?**
+
+No. Global Procurement is a Pro feature, enforced server-side on both the panel and the API. Historical US award data in the Economic panel remains free.
+
+**How fresh is the data?**
+
+The seeder runs hourly and the snapshot carries a three-hour retention window, so a single missed run serves the prior successful snapshot rather than an empty feed. Every response includes its snapshot time and per-source health.
+
+**Can I get alerts for new tenders matching my keywords?**
+
+Use the API with a saved query and your own scheduler, or point an MCP-connected agent at `get_procurement_opportunities` on a schedule — the [Slack and Teams alerting guide](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/) shows the pattern.
+
+---
+
+**A tender is a government telling you, in writing and with a budget attached, what it cares about next quarter. Now all the major official feeds are in one place.**

--- a/blog-site/src/content/blog/ground-truth-inflation-shelf-price-tracking-worldmonitor.md
+++ b/blog-site/src/content/blog/ground-truth-inflation-shelf-price-tracking-worldmonitor.md
@@ -1,0 +1,64 @@
+---
+title: "Ground-Truth Inflation: Tracking Real Shelf Prices, Not Just CPI"
+description: "WorldMonitor scrapes real supermarket shelf prices — starting with four UAE retailers — and pairs them with the Big Mac Index, FAO food prices, fuel prices, and IMF CPI."
+metaTitle: "Real-Time Shelf Price & Inflation Tracking | WorldMonitor"
+keywords: "real time inflation data, grocery price tracker, consumer prices API, shelf price monitoring, cost of living dashboard, food price index"
+audience: "Economists, macro analysts, journalists, expats, cost-of-living researchers"
+heroImage: "/blog/og/ground-truth-inflation-shelf-price-tracking-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Official inflation is a lagging average of an averaged lag. A national CPI print arrives weeks after the month it measures, blends thousands of items into one number, and tells you nothing about whether *your* basket at *your* store got more expensive on Tuesday.
+
+The interesting question — what do things actually cost, right now, on the shelf? — has a different answer. You collect the prices yourself. That's what WorldMonitor's consumer-prices system does.
+
+## Shelf prices, scraped daily
+
+The pilot market is the **United Arab Emirates**, where WorldMonitor tracks a defined essentials basket across **four major grocery retailers: Carrefour, Spinneys, Lulu, and Noon**. Real product pages, real listed prices — collected continuously and normalized into a comparable basket.
+
+From that raw feed, the Consumer Prices panel serves:
+
+- a **30-day overview** of basket-level price movement,
+- **category inflation** — which aisles are moving, not just whether "food" is up,
+- **retailer spread** — the same essentials basket priced across all four chains, which is both a shopping tool and a market-structure measurement,
+- **top movers** — the specific items repricing fastest,
+- and a **freshness readout**, because a price feed that hides its own staleness is just CPI with better marketing.
+
+Basket definitions for additional countries — the US, UK, Australia, India, Brazil, Singapore, Switzerland, Kenya, and more — are already staged in the pipeline, waiting on live retailer coverage. The UAE proves the model; the roadmap is geographic.
+
+## The context instruments
+
+Shelf-price truth is most useful next to its slower official cousins, so the platform keeps them adjacent:
+
+- **IMF WEO official CPI** for ~195 countries — the world-inflation reference layer.
+- The **Big Mac Index** — the classic purchasing-power shorthand.
+- The **FAO Food Price Index** — global food-commodity pressure upstream of your grocery store.
+- **Retail fuel prices** — the other price everyone feels weekly.
+
+Read them as a chain: FAO tells you global food inputs are rising; tariff and freight data tells you the [transmission path](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/) is stressed; shelf prices tell you the exact week it reached the checkout. That last link is the one official statistics can't give you.
+
+## For developers and agents
+
+The `get_consumer_prices` MCP tool (UAE today) returns the overview, category inflation, retailer spread, and movers in one structured call; the consumer-prices REST endpoints expose the same series, and `get_tariff_trends` adds the Big Mac, FAO, and fiscal context. For [macro traders](/blog/posts/geopolitics-to-markets-pipeline-macro-traders-worldmonitor/), shelf-price velocity is an inflation nowcast; for journalists, "bread rose 11% across four chains in three weeks" is a story with receipts.
+
+## Limits
+
+Coverage is honest about being narrow: one country live, four retailers, an essentials basket — a precise instrument, not yet a global one. Scraped prices reflect listed shelf prices, not loyalty discounts or in-store promotions. And a retailer basket is deliberately not a CPI replacement: it trades statistical breadth for speed and specificity. Use both — that's why both are on the dashboard.
+
+## Frequently Asked Questions
+
+**Which countries have live shelf-price tracking?**
+
+The UAE, across Carrefour, Spinneys, Lulu, and Noon. Basket configurations for the US, UK, Australia, India, Brazil, Singapore, Switzerland, Kenya, and others are staged for expansion. Official IMF CPI context covers ~195 countries today.
+
+**How is this different from official inflation statistics?**
+
+Official CPI is broad, methodologically rigorous, and weeks delayed. Shelf-price tracking is narrow, literal, and current — actual listed prices for a fixed basket, updated continuously with freshness reported.
+
+**Can I query the price data programmatically?**
+
+Yes — the `get_consumer_prices` MCP tool and the consumer-prices REST endpoints in the [API reference](https://www.worldmonitor.app/docs/api-reference) return the overview, categories, movers, and retailer spread as structured series.
+
+---
+
+**Inflation isn't a monthly press release — it's this week's shelf tag. Measure the shelf, keep the official number for context, and you'll know before the statistics do.**

--- a/blog-site/src/content/blog/monitor-global-sanctions-pressure-worldmonitor.md
+++ b/blog-site/src/content/blog/monitor-global-sanctions-pressure-worldmonitor.md
@@ -1,0 +1,57 @@
+---
+title: "Sanctions Monitoring: Designations and Country Pressure in Real Time"
+description: "WorldMonitor tracks OFAC SDN and consolidated designations, computes per-country sanctions pressure, and folds exposure into country risk — on the map and via API."
+metaTitle: "Real-Time Sanctions Monitoring | WorldMonitor"
+keywords: "sanctions tracking tool, OFAC SDN list monitoring, sanctions dashboard, country sanctions exposure, sanctions data API, sanctions pressure score"
+audience: "Compliance analysts, trade and export teams, risk researchers, macro analysts, journalists"
+heroImage: "/blog/og/monitor-global-sanctions-pressure-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Sanctions move faster than most reference data. A designation published on a Tuesday morning can strand a cargo, freeze a counterparty, or reprice a bond by Tuesday afternoon — and the analysts who noticed early are usually the ones who were watching the source lists, not waiting for coverage.
+
+WorldMonitor treats sanctions as a live intelligence layer rather than a quarterly compliance export.
+
+## What gets tracked
+
+The sanctions pipeline reads the US Treasury's official OFAC publication service directly — both the **SDN list** (Specially Designated Nationals) and the **consolidated non-SDN list** — in their full advanced XML form, not a simplified mirror.
+
+From those designations WorldMonitor computes a per-country **sanctions pressure** view: which jurisdictions are accumulating designations, how pressure is distributed, and which countries sit at the top of the list right now. That surfaces in three places:
+
+- The **Sanctions Pressure panel**, available in the geopolitical, finance, commodity, and energy dashboards.
+- The **sanctions map layer**, which puts designation pressure in geographic context next to conflicts, chokepoints, and trade routes.
+- **Country risk**: the [country risk view](/blog/posts/country-risk-monitoring-due-diligence-worldmonitor/) includes OFAC exposure alongside the instability score and travel advisories, so a screening query returns sanctions context without a separate lookup.
+
+## Why pressure, not just presence
+
+Binary "is this country sanctioned?" answers hide the dynamics that matter. Iran and a country with three targeted designations are both "sanctioned" in a yes/no model. Pressure scoring keeps the gradient: direction and concentration of designations tell you whether a jurisdiction is being progressively isolated — which is exactly the kind of trend that precedes trade rerouting, shadow-fleet activity, and payment-channel shifts.
+
+That makes the sanctions layer useful beyond compliance. Macro traders read it next to the [geopolitics-to-markets pipeline](/blog/posts/geopolitics-to-markets-pipeline-macro-traders-worldmonitor/); supply-chain teams read it next to chokepoint status, because sanctioned trade doesn't disappear — it reroutes, and reroutes show up in maritime data.
+
+## For developers and agents
+
+The `get_sanctions_data` MCP tool returns current designations context and per-country pressure scores to any connected AI agent, and the REST surface exposes the same under the versioned API. An agent asked to "screen this supplier's country before we sign" can combine `get_sanctions_data` with `get_country_risk` in one pass — the [risk-agent tutorial](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/) shows the pattern.
+
+If you're watching a specific jurisdiction continuously, pair the sanctions layer with [tariff and trade-policy monitoring](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/) — sanctions and tariffs are two instruments of the same economic-pressure toolkit, and they increasingly move together.
+
+## Limits
+
+This is OFAC-centric today: US Treasury designations, not a merged EU/UN/UK screening database. It is an intelligence and awareness layer, not a compliance screening service — a positive or negative here doesn't discharge a legal screening obligation, and entity-level matching (aliases, transliterations, ownership chains) belongs in dedicated screening tooling. WorldMonitor tells you where pressure is building and when the ground shifts; your compliance stack tells you whether a specific counterparty is clear.
+
+## Frequently Asked Questions
+
+**Which sanctions lists does WorldMonitor track?**
+
+The US OFAC SDN list and OFAC's consolidated non-SDN list, read from the Treasury's official publication service in full advanced XML form.
+
+**Is this a sanctions screening tool?**
+
+No. It's a monitoring and intelligence layer — pressure trends, designation context, and country exposure. Entity-level compliance screening with fuzzy matching and audit trails needs dedicated software.
+
+**How do I get sanctions context into my AI assistant?**
+
+Connect the WorldMonitor MCP server and call `get_sanctions_data`, or use `get_country_risk`, which includes OFAC exposure in its response. The [MCP quickstart](https://www.worldmonitor.app/docs/mcp-quickstart) covers setup in a few minutes.
+
+---
+
+**Sanctions are policy you can parse. Watch the designations and the pressure gradient, and you'll see economic statecraft move before the headlines do.**

--- a/blog-site/src/content/blog/positive-news-dashboard-happy-worldmonitor.md
+++ b/blog-site/src/content/blog/positive-news-dashboard-happy-worldmonitor.md
@@ -1,0 +1,61 @@
+---
+title: "The Good News Dashboard: Positive News with an Intelligence Engine"
+description: "happy.worldmonitor.app runs 27 curated positive feeds through WorldMonitor's real intelligence pipeline: conservation wins, breakthroughs, clean energy, and live progress counters."
+metaTitle: "Positive News Dashboard | World Monitor Happy"
+keywords: "positive news website, good news dashboard, uplifting news aggregator, human progress tracker, conservation wins, science breakthrough news"
+audience: "General readers, educators, parents, mental-health-conscious news consumers, optimists who want evidence"
+heroImage: "/blog/og/positive-news-dashboard-happy-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+The news industry has a structural bias, not a conspiracy: bad news is sudden and good news is gradual. A pipeline explosion is an event; a species recovering is a decade. Feeds optimized for events will always overweight catastrophe — which is how you end up with an audience that knows every disaster and none of the progress.
+
+WorldMonitor's answer isn't a filter that hides the bad news. It's a sixth dashboard with the polarity reversed: **happy.worldmonitor.app**, the same intelligence engine pointed at what's improving.
+
+## Same engine, inverted filter
+
+The Happy variant is not a greeting-card site. It runs the same infrastructure as the geopolitical dashboard — feed ingestion, deduplication, classification, mapping — over **27 curated positive-news feeds across six categories**: dedicated positive outlets (Good News Network, Positive.News, Reasons to be Cheerful, Optimist Daily, and others), science sources (Nature News, ScienceDaily, New Scientist, Human Progress), conservation reporting (Mongabay, Conservation Optimism), health, community, and everyday-hero stories.
+
+The panels are built around measurable progress, not just pleasant headlines:
+
+- **Good News Feed** — the classified, deduplicated positive stream.
+- **Human Progress** — the long arc: development, health, and quality-of-life gains.
+- **Live Counters** — running counts of things going right.
+- **5 Good Things** — a daily digest for people who want a ritual, not a feed.
+- **Today's Hero** — one person who did something worth knowing about.
+- **Breakthroughs** — science and medicine that actually advanced.
+- **Conservation Wins** — species recoveries and protected-area gains.
+- **Renewable Energy** — the clean-energy buildout as it happens.
+- **Global Giving** — philanthropy and aid flows.
+
+The map inverts too: layers for positive events, acts of kindness, world happiness, species recovery, and clean-energy installations replace conflict zones and threat markers.
+
+## Why a serious platform ships a good-news dashboard
+
+Two reasons. The honest one: sustained doom consumption degrades judgment. Analysts who marinate in threat feeds develop a risk perception that's miscalibrated high — everything reads as escalation. A deliberate dose of base-rate progress is calibration, not escapism. It's the same reasoning that puts [prediction markets](/blog/posts/prediction-markets-ai-forecasting-geopolitics/) next to the news: outside views correct inside spirals.
+
+The structural one: positive events are intelligence. Peace agreements, humanitarian aid flows, and diplomatic breakthroughs are state actions with consequences, and the `get_positive_events` MCP tool exposes them — diplomatic agreements, aid commitments, peace initiatives — to the same agents that consume conflict data. A model of the world built only from negatives is simply wrong.
+
+The Happy variant is one of [six dashboards on the platform](/blog/posts/five-dashboards-one-platform-worldmonitor-variants/), and like the others it's free, no login, and switchable in one click — same account, same infrastructure, same [21-language support](/blog/posts/worldmonitor-in-21-languages-global-intelligence-for-everyone/).
+
+## Limits
+
+Curation is editorial: 27 feeds chosen for credibility and signal, which means judgment calls about what counts as "positive." Progress data is slower-moving than event data by nature — the counters and progress panels update on the cadence of their underlying sources. And no, reading good news doesn't change the world state; it changes whether your model of the world state is complete.
+
+## Frequently Asked Questions
+
+**Is the Happy dashboard free?**
+
+Yes — free and login-free like the other WorldMonitor variants. It's at happy.worldmonitor.app.
+
+**Is this just filtered regular news?**
+
+No. It's a separate curated feed set — 27 positive-news, science, conservation, and community sources — run through the same classification and deduplication pipeline as the intelligence dashboards, with its own panels and map layers.
+
+**Can apps and agents use the positive-events data?**
+
+Yes. The `get_positive_events` MCP tool returns diplomatic agreements, humanitarian aid, and peace initiatives in structured form — the counterweight layer for any agent consuming conflict data.
+
+---
+
+**The world contains both the fire and the reforestation. A complete intelligence picture shows you both — this is the dashboard for the half your feed forgot.**

--- a/blog-site/src/content/blog/real-time-radiation-monitoring-radnet-safecast.md
+++ b/blog-site/src/content/blog/real-time-radiation-monitoring-radnet-safecast.md
@@ -1,0 +1,60 @@
+---
+title: "Real-Time Radiation Monitoring: Read the Sensors, Not the Rumors"
+description: "WorldMonitor merges EPA RadNet stations and the Safecast citizen-sensor network into a live radiation layer, with nuclear sites and IAEA irradiators for context."
+metaTitle: "Real-Time Radiation Monitoring Map | WorldMonitor"
+keywords: "real time radiation map, radiation levels live, nuclear radiation monitoring, Safecast radiation data, EPA RadNet, radiation monitoring dashboard"
+audience: "OSINT analysts, journalists, researchers, emergency-preparedness planners, concerned readers during nuclear events"
+heroImage: "/blog/og/real-time-radiation-monitoring-radnet-safecast.png"
+pubDate: "2026-07-21"
+---
+
+Every nuclear scare follows the same script. An incident at a plant, shelling near a reactor, a test rumor — and within an hour, social media fills with screenshots of dosimeters, decade-old maps, and numbers with no units. Radiation is uniquely suited to panic because it's invisible, poorly understood, and genuinely serious when real.
+
+It's also one of the best-instrumented hazards on Earth. The sane response to a radiation rumor is to read the sensor networks — which is exactly what WorldMonitor's Radiation Watch does.
+
+## Two networks, merged
+
+The radiation layer merges two complementary systems:
+
+- **EPA RadNet** — the United States' official fixed monitoring network, read directly from the EPA's public data service. Calibrated, maintained, government-operated stations.
+- **Safecast** — the global citizen-science network born after Fukushima, with volunteer-operated sensors contributing measurements worldwide through an open API.
+
+The merge is deliberate. Official networks are trustworthy but geographically bounded; Safecast reaches places no government feed covers. Each observation keeps its source attribution, so you always know whether you're reading a federal station or a community sensor.
+
+Readings appear in the **Radiation Watch panel** and on the **radiation map layer** — and the map gives them context that a standalone radiation site can't: **nuclear facilities** and **IAEA-listed gamma irradiator** locations as reference layers, plus conflicts, fires, and weather on the same canvas. A radiation question is never just "what's the reading?" — it's "what's the reading, where, relative to what, and which way does the wind blow?"
+
+## How to read a radiation event
+
+When radiation is in the news, three checks separate signal from noise:
+
+1. **Are sensors actually elevated, or is the map just red on social media?** Look at readings near the event, with units and source attribution.
+2. **Is the elevation local or spreading?** One anomalous sensor is an instrument story; a coherent gradient across stations is an event.
+3. **Does the pattern match the claim?** Real releases propagate with weather and distance. The [breaking-news verification workflow](/blog/posts/verify-breaking-news-osint-workflow-journalists/) applies here directly: multiple independent instruments, or it's still a rumor.
+
+Background radiation also varies naturally from place to place — granite geology, altitude, and medical facilities all move the baseline. Absolute numbers matter less than deviation from a location's own normal.
+
+## For developers and agents
+
+The `get_radiation_data` MCP tool returns current observation levels from the monitoring stations in structured form, alongside the radiation REST endpoints. An agent fielding "is the radiation spike near X real?" can pull actual sensor readings with source attribution instead of summarizing panic — and cross-reference [natural-disaster](/blog/posts/natural-disaster-monitoring-earthquakes-fires-volcanoes/) and conflict layers in the same pass.
+
+## Limits
+
+Sensor coverage is uneven: dense in the US, Japan, and Europe, sparse exactly where geopolitical radiation risk is highest — active conflict zones rarely host functioning public sensor networks. Citizen sensors vary in calibration and siting. A quiet map in an uninstrumented region means "no data," never "no radiation." And a dashboard is not a civil-defense system: in a genuine emergency, official local guidance wins.
+
+## Frequently Asked Questions
+
+**Where does the radiation data come from?**
+
+Two merged networks: the US EPA's RadNet fixed monitoring stations and the global Safecast citizen-sensor network, with per-observation source attribution.
+
+**Why do some regions show no readings?**
+
+Because no public sensors report there. Coverage follows sensor deployment, not risk. WorldMonitor shows gaps as gaps rather than interpolating reassuring values.
+
+**What should I do if readings genuinely rise near me?**
+
+Follow official emergency guidance for your area. WorldMonitor is a situational-awareness tool for understanding events; it is not an emergency-alert or civil-defense system.
+
+---
+
+**Radiation is the rare threat you can actually measure from your desk. When the next scare hits, skip the screenshots and read the instruments.**

--- a/blog-site/src/content/blog/tariff-tracker-trade-policy-monitoring-worldmonitor.md
+++ b/blog-site/src/content/blog/tariff-tracker-trade-policy-monitoring-worldmonitor.md
@@ -1,0 +1,60 @@
+---
+title: "Track Tariffs and Trade Policy Before They Hit Your Costs"
+description: "WorldMonitor's Trade Policy tracker combines WTO tariff baselines, US customs revenue, food-price indices, and trade news so you see policy shifts before invoices do."
+metaTitle: "Tariff Tracker & Trade Policy Monitoring | WorldMonitor"
+keywords: "tariff tracker, trade policy monitoring, US tariff trends, customs revenue data, trade war dashboard, tariff data API, import tariffs"
+audience: "Importers and exporters, procurement teams, supply-chain analysts, macro traders, trade researchers"
+heroImage: "/blog/og/tariff-tracker-trade-policy-monitoring-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Tariffs are the rare geopolitical instrument with a direct line item on your invoice. A new duty schedule doesn't just signal intent like a speech does — it reprices goods on a date certain, and everyone in the affected supply chain either saw it coming or didn't.
+
+WorldMonitor's trade-policy surface is built for seeing it coming.
+
+## What the Trade Policy tracker shows
+
+The **Trade Policy panel** (a Pro panel in the geopolitical, finance, and commodity dashboards) brings together the layers a trade decision actually touches:
+
+- **WTO MFN tariff baselines** — the structural starting point: what tariffs look like before anyone starts a trade dispute.
+- **US tariff trends and customs revenue** — effective tariff context and what the US actually collects at the border, which is the cleanest scoreboard for whether announced tariffs are biting.
+- **Bilateral trade flows** — UN COMTRADE data connects a tariff line to the actual goods volumes exposed to it.
+- **Trade and policy news** — classified feeds covering negotiations, retaliation threats, and carve-outs, because the gap between announcement and implementation is where planning happens.
+
+Around the dedicated panel, the free tier keeps the context instruments: the **Big Mac Index**, the **FAO Food Price Index**, retail **fuel prices**, and national-debt context — the consumer-facing end of the same transmission chain.
+
+## From tariff line to decision
+
+A tariff announcement raises three questions in order:
+
+1. **Is it real?** Announcements get walked back, delayed, and carved out. Watch the policy news flow and the implementation dates, not the press conference.
+2. **What's exposed?** Trade-flow data tells you the actual goods volume moving on the affected lanes. A 25% tariff on a $100M flow and a 25% tariff on a $40B flow are different events.
+3. **What reroutes?** Trade doesn't stop; it detours. That's when tariffs become a logistics story — and why the trade-policy view sits next to [chokepoint and freight monitoring](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/) on the same platform.
+
+For question three, the [Scenario Engine](/blog/posts/stress-test-supply-chain-scenario-engine-worldmonitor/) includes pre-built tariff scenarios so you can stress-test exposure before the implementation date instead of after.
+
+## For developers and agents
+
+The `get_tariff_trends` MCP tool returns the tariff-trend series with customs revenue, Big Mac Index, FAO Food Price Index, and national-debt context in one call, and `get_supply_chain_data` adds COMTRADE bilateral flows and customs revenue for lane-level analysis. An agent handling "what does the new steel tariff mean for our Q4 landed costs?" can ground itself in actual baselines and flows rather than headlines — the [supply-chain early-warning tutorial](/blog/posts/build-supply-chain-early-warning-system-api/) and [tender-tracking guide](/blog/posts/government-tenders-procurement-intelligence-worldmonitor/) both build on the same API surface.
+
+## Limits
+
+Tariff data is strongest for the US (trends, customs revenue) and for WTO-published MFN baselines; it is not a customs-broker-grade HS-code lookup for every country pair. Effective rates on a specific product still require the official tariff schedule. What the tracker gives you is the trend, the exposure, and the early warning — the inputs to a decision, not the customs filing itself.
+
+## Frequently Asked Questions
+
+**Can I look up the tariff on a specific product?**
+
+Not at HS-line granularity for every country pair. The tracker covers WTO MFN baselines, US tariff trends, and customs revenue — the macro picture. Product-level filings still need the official schedule for the importing country.
+
+**How is this different from reading trade news?**
+
+News tells you what was announced. The tracker pairs announcements with what's measurable: baselines, collected revenue, and the trade flows actually exposed — which is how you distinguish escalation from theater.
+
+**Is the Trade Policy panel free?**
+
+The dedicated panel is Pro. Context instruments — Big Mac Index, FAO Food Price Index, fuel prices, and trade news feeds — are part of the free dashboards.
+
+---
+
+**Tariffs are geopolitics with an invoice date. Track the baseline, the revenue, and the exposed flows, and the announcement stops being a surprise.**

--- a/blog-site/src/content/blog/track-refugee-displacement-flows-unhcr-worldmonitor.md
+++ b/blog-site/src/content/blog/track-refugee-displacement-flows-unhcr-worldmonitor.md
@@ -1,0 +1,57 @@
+---
+title: "Track Refugee and Displacement Flows with UNHCR Data"
+description: "WorldMonitor maps refugee and IDP populations from UNHCR's official API — displacement flows on the map, a dedicated panel, and structured data for agents."
+metaTitle: "Refugee & Displacement Tracking | WorldMonitor"
+keywords: "refugee flow data, displacement tracking dashboard, UNHCR data visualization, IDP monitoring, forced displacement statistics, displacement data API"
+audience: "Humanitarian and NGO teams, researchers, journalists, policy analysts, students"
+heroImage: "/blog/og/track-refugee-displacement-flows-unhcr-worldmonitor.png"
+pubDate: "2026-07-21"
+---
+
+Displacement is the human ledger of every crisis. Conflict, drought, floods, economic collapse — whatever the driver, people moving in numbers is both the consequence that matters most and one of the most reliable indicators that a situation has crossed from tension into emergency.
+
+WorldMonitor builds displacement into the same dashboard as the conflicts, disasters, and risk scores that drive it.
+
+## What the displacement layer shows
+
+The data comes from **UNHCR's official population API** — refugee populations by country of origin and country of asylum, plus internally displaced persons — the same statistics that anchor humanitarian planning worldwide.
+
+It surfaces in three places:
+
+- The **Displacement panel**: per-country refugee and IDP counts, ready to scan.
+- The **displacement flows map layer**: origin-to-asylum movements drawn on the global map, so you can see corridor structure — who is leaving where, and where they arrive — next to the conflict zones and disasters producing the movement.
+- The **population-exposure view**, which connects hazard footprints to the people inside them.
+
+The point of the placement is context. A displacement chart in isolation tells you magnitude. The same numbers on a map with [live conflict events](/blog/posts/track-global-conflicts-in-real-time/), disaster tracking, and country instability scores tell you mechanism — and mechanism is what forecasting needs.
+
+## Displacement as an early-warning input
+
+For humanitarian teams, displacement data answers the operational questions: where caseloads are growing, which asylum countries are absorbing pressure, which corridors are active. The [NGO situational-awareness workflow](/blog/posts/humanitarian-situational-awareness-ngo-security-monitoring-worldmonitor/) walks through pairing it with advisories, disease alerts, and country risk for field-security planning.
+
+For analysts, it's a lagging-but-honest confirmation layer. Rhetoric and skirmishes can be noise; six figures of new displacement is not. When the [Country Instability Index](/blog/posts/country-instability-index-methodology-explained/) rises and displacement follows, you're watching escalation confirm itself in the most consequential data there is.
+
+## For developers and agents
+
+The `get_displacement_data` MCP tool returns refugee and IDP counts by country in structured form, and the displacement REST endpoints expose the same under the versioned API. Combined with `get_country_risk` and `get_conflict_events`, an agent can produce a grounded humanitarian snapshot for any country in one pass — numbers with provenance, not vibes. Pair it with the [outbreak and air-quality signals](/blog/posts/disease-outbreak-air-quality-monitoring-health-signals/) for the fuller picture of conditions on the ground.
+
+## Limits
+
+UNHCR statistics are authoritative but not real-time: they update on reporting cycles, not hourly. Displacement flows drawn on a map represent stock and corridor structure, not live movement of individuals — nothing here tracks people, only aggregate populations as officially reported. Fast-moving situations will show up in news, conflict events, and advisories before they appear in the official counts; use the layers together and mind the lag.
+
+## Frequently Asked Questions
+
+**Where does the displacement data come from?**
+
+UNHCR's official population API — refugee populations by origin and asylum country, plus IDP figures — the reference dataset used across the humanitarian sector.
+
+**Is it real-time?**
+
+No, and no honest tool would claim otherwise. Official displacement statistics follow reporting cycles. WorldMonitor pairs them with real-time layers — conflict events, disasters, news — so you can see the leading edge and the confirmed magnitude side by side.
+
+**Can I use this data in my own analysis or app?**
+
+Yes — via the `get_displacement_data` MCP tool or the displacement REST endpoints. See the [API reference](https://www.worldmonitor.app/docs/api-reference) and the [developer platform overview](/blog/posts/build-on-worldmonitor-developer-api-open-source/).
+
+---
+
+**Every crisis eventually gets measured in people who had to move. Watch displacement next to its drivers, and you see both the cost and the confirmation.**

--- a/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
+++ b/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
@@ -1,0 +1,76 @@
+---
+title: "WorldMonitor Is Not Palantir (But Thank You)"
+description: "The Palantir comparison is flattering and wrong: WorldMonitor is an open platform for the world's public data — markets, trade, energy, and economics first — that anyone can use and build on."
+metaTitle: "WorldMonitor Is Not Palantir | World Monitor"
+keywords: "WorldMonitor vs Palantir, Palantir alternative open source, open intelligence platform, economic intelligence dashboard, global financial data platform, build on intelligence API"
+audience: "Press, analysts, developers, investors, anyone who has seen the Palantir comparison"
+heroImage: "/blog/og/worldmonitor-is-not-palantir.png"
+pubDate: "2026-07-21"
+---
+
+Ever since WorldMonitor started getting attention, one comparison has followed it everywhere: "open-source Palantir." It shows up in press mentions, Reddit threads, and half the introductions supporters write for us.
+
+First, sincerely: thank you. When people reach for Palantir as the reference point, they're saying the ambition registers — a live map of the world's data, built by a small team, holding its own next to a company worth hundreds of billions. We'll take that compliment every time.
+
+But the comparison is wrong, and the ways it's wrong are exactly the ways WorldMonitor is interesting.
+
+## What Palantir actually is
+
+Palantir builds data-integration software for institutions. Gotham, Foundry, and AIP ingest a customer's *own* data — case files, supply ledgers, sensor logs — into a private ontology that the customer's analysts query behind their own walls. It is excellent at that job. It is also, definitionally, closed: the data is yours, the deployment is yours, and the contract is negotiated.
+
+Palantir doesn't primarily *provide* data. It organizes data you already have.
+
+## What WorldMonitor actually is
+
+WorldMonitor inverts every one of those properties. It's a real-time intelligence layer over the **world's public data** — and it publishes the result to everyone, starting at free with no login.
+
+And despite the war-room aesthetic, the center of gravity is economic. Look at what the platform actually ships:
+
+- [92 stock exchanges, 13 central banks, and a 7-signal macro radar](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/) on the finance dashboard
+- [Chokepoints, freight indices, and trade-route monitoring](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/) for physical trade
+- [Tariff trends, customs revenue, and trade policy](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/)
+- [Government tenders from six official procurement sources](/blog/posts/government-tenders-procurement-intelligence-worldmonitor/)
+- [Sanctions designations and country pressure](/blog/posts/monitor-global-sanctions-pressure-worldmonitor/)
+- [Shelf-price inflation tracking](/blog/posts/ground-truth-inflation-shelf-price-tracking-worldmonitor/), commodity markets, energy intelligence, prediction markets, and EU macro series
+
+Conflict tracking is real and serious on WorldMonitor — but it's there because **war is an economic event**. Chokepoints close, freight reprices, energy flows shift, currencies move. The conflict layer feeds the economic picture as much as the reverse. "Palantir" pattern-matches to the map with red dots; it misses that most of the platform is telling you what those dots do to prices, routes, and policy.
+
+The scale is public too: [six specialized dashboards](/blog/posts/five-dashboards-one-platform-worldmonitor-variants/), 500+ curated feeds, 56 map layers, and [21 languages](/blog/posts/worldmonitor-in-21-languages-global-intelligence-for-everyone/) — with the [full comparison against Bloomberg, Dataminr, Recorded Future, and yes, Palantir](/blog/posts/worldmonitor-vs-traditional-intelligence-tools/) already written.
+
+## The deeper difference: open, in every direction
+
+The Palantir model is access-gated at every layer. WorldMonitor is open at every layer:
+
+- **Open product** — the dashboards are free, no signup, right now.
+- **Open source** — the entire platform is AGPL-3.0. You can [read it, fork it, and self-host it](/blog/posts/self-host-worldmonitor-open-source-osint-dashboard/).
+- **Open interfaces** — a versioned [REST API with typed SDKs](/blog/posts/build-on-worldmonitor-developer-api-open-source/), an [MCP server with 40 live tools for AI agents](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/), and an [embeddable live map](/blog/posts/embed-live-global-map-worldmonitor/).
+- **Open pricing** — published on the site, from $0 to [flat monthly tiers](/blog/posts/free-vs-paid-real-time-intelligence-dashboards/). No sales call.
+
+That's not a smaller Palantir. It's a different species. If Palantir is a private ontology for your institution's data, WorldMonitor is public infrastructure for the world's data.
+
+## Build on it — that's the point
+
+The clearest proof that the comparison fails: you can't build on Palantir this afternoon. You can build on WorldMonitor this afternoon.
+
+- Wire a [supply-chain early-warning system](/blog/posts/build-supply-chain-early-warning-system-api/) to chokepoint and disruption data
+- Give Claude or your own agent [live world context through MCP](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/)
+- Pipe [risk alerts into Slack or Teams](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/)
+- Or start from the [API reference](https://www.worldmonitor.app/docs/api-reference) and build the thing we haven't thought of
+
+## Frequently Asked Questions
+
+**Is WorldMonitor a Palantir alternative?**
+
+For integrating your institution's private data into a closed ontology — no, and it doesn't try to be. For real-time intelligence over public data — markets, trade, conflicts, energy, economics — it does something Palantir doesn't sell at any price: it's open, and it starts free.
+
+**Is WorldMonitor a defense or war-focused platform?**
+
+No. Conflict monitoring is one layer among dozens; by surface area, most of the platform is financial, economic, and trade intelligence. War matters on WorldMonitor because it reprices the world, not because it's the product.
+
+**Can I build a commercial product on WorldMonitor?**
+
+Yes — through the API tiers, with the open-source core available under AGPL-3.0 obligations if you self-host. The [developer platform overview](/blog/posts/build-on-worldmonitor-developer-api-open-source/) covers both paths.
+
+---
+
+**Keep the comparisons coming — we're grateful for every one. Just know the real story is better: not a private war room for the few, but open economic intelligence for anyone who wants it.**


### PR DESCRIPTION
## What

13 new blog posts closing the gap between what the product ships and what the blog documents, plus the "not Palantir" positioning post. All posts follow the corpus conventions: frontmatter schema, deploy-generated OG covers (`/blog/og/<slug>.png`, nothing committed), corpus-format FAQ blocks, internal cross-links, and a closing thesis.

### Feature-gap posts (features with zero prior blog coverage)

| Post | Feature exposed | Key verified facts used |
|---|---|---|
| `government-tenders-procurement-intelligence-worldmonitor` | Global Procurement (Pro) | 6 official sources (SAM.gov/TED/Contracts Finder/CanadaBuys/GETS/World Bank), hourly seeder, availability semantics, `automationFit`, deliberate AusTender gap — all from `docs/global-procurement-intelligence.mdx` |
| `monitor-global-sanctions-pressure-worldmonitor` | Sanctions pressure + layer | OFAC SDN + consolidated advanced XML (verified in `scripts/seed-sanctions-pressure.mjs`) |
| `tariff-tracker-trade-policy-monitoring-worldmonitor` | Trade Policy (Pro) | WTO MFN baselines + US customs revenue (`src/services/trade/index.ts`), COMTRADE flows |
| `aviation-intelligence-airports-airspace-flight-prices` | Airline Intelligence panel | 115 monitored airports + 6 tabs verified in code; Google Flights price search via `search_flights` |
| `track-refugee-displacement-flows-unhcr-worldmonitor` | Displacement panel/layer | UNHCR population API (verified in seeder) |
| `disease-outbreak-air-quality-monitoring-health-signals` | Health signals | WHO DON API, CDC notices, Outbreak News Today, OpenAQ v3 + WAQI (all verified in seeders) |
| `real-time-radiation-monitoring-radnet-safecast` | Radiation Watch | EPA RadNet + Safecast merge (verified: `epa-radnet-safecast-merge-v1`) |
| `positive-news-dashboard-happy-worldmonitor` | Happy variant | 27 positive feeds / 6 categories counted in `feeds.ts`; happy.worldmonitor.app returns 200 |
| `ai-forecast-accuracy-brier-scorecard-worldmonitor` | Forecast scorecard | Brier/log/calibration/byDomain verified in `scripts/_forecast-scorecard.mjs` |
| `ground-truth-inflation-shelf-price-tracking-worldmonitor` | Consumer prices | 4 UAE retailer configs verified; staged baskets (us/gb/au/in/br/sg/ch/ke); World tab (IMF WEO) verified merged in `ConsumerPricesPanel.ts` |
| `alerts-notification-channels-worldmonitor` | Alert rules | 6 channel types + quiet-hours modes verified in `convex/constants.ts` |

### Positioning post (requested mid-session)

`worldmonitor-is-not-palantir` — gracious to supporters/press for the comparison, then makes the case: Palantir organizes institutions' private data behind closed deployments; WorldMonitor is open (product/source/interfaces/pricing) intelligence over the world's public data, with an economic center of gravity. Heavy internal linking into the markets/trade/tenders/API posts; ends on the build-with-the-API path.

## Verification

- `npm run build` in `blog-site/` green — 74 pages, sitemap + RSS regenerated
- FAQPage JSON-LD confirmed **firing** in built HTML for all 12 posts (3 questions each) — guard against the #5001 never-firing regression
- Internal link check: every `/blog/posts/<slug>/` reference in the new posts resolves to an existing file
- OG covers generated for all 12 slugs at build time; nothing committed under `public/` (matches `blog-cover-webp` test expectations for `/blog/og/` covers)
- Data-source claims spot-verified against seeders/panels (see table) rather than taken from summaries

## Notes for reviewer

- Existing `five-dashboards-one-platform-worldmonitor-variants.md` still says **five** dashboards; the energy variant makes it six (energy.worldmonitor.app is live). New posts say "six" — the old post needs a refresh, tracked separately.
- No auto-merge on purpose — content wants a human read.

https://claude.ai/code/session_01JEGono85MnwW7F9mm4rQEF

**Added in second commit:** `energy-security-dashboard-worldmonitor` — the energy variant (energy.worldmonitor.app) had zero corpus coverage and zero inbound links; this post documents the 26-panel layout, 88 pipelines, GIE AGSI+/EIA/JODI/Ember backbone, and the escalation-chain reading order. Verified: build green, FAQ-LD firing (3 questions), OG generated, links resolve. Partially addresses the docs side of #5404.