### PR TITLE
feat(selfhost): use a Claude subscription as the LLM backend (bundled shim) + 6 self-hosting fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts must stay LF — they are COPYed into Linux images at build
+# time and a CRLF shebang breaks the container entrypoint (built on Windows).
+*.sh text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 *.sh text eol=lf
 *.mjs text eol=lf
 *.cjs text eol=lf
+
+# This generated helper embeds a literal NUL byte (a template-literal key
+# separator), so git detects it as binary. Keep it binary — forcing text on a
+# NUL-containing file risks corruption under a future renormalization.
+scripts/openapi-dedup-responses.mjs -text

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ public/crawlable-corpus.json
 *.log
 .env
 .env.local
+docker-compose.override.yml
 .playwright-mcp/
 *-network.txt
 .vercel

--- a/Dockerfile.claude-shim
+++ b/Dockerfile.claude-shim
@@ -3,7 +3,11 @@
 # See SELF_HOSTING.md "Claude Code (use your Claude subscription)".
 FROM node:22-alpine
 
-RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
+# Pin the CLI so a breaking upstream release (changed --output-format schema,
+# removed flags the shim relies on) can't silently break builds — upgrades are
+# a deliberate, reviewable bump of this line.
+ARG CLAUDE_CODE_VERSION=2.1.216
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && npm cache clean --force
 
 # Claude Code wants a writable home for session state.
 RUN addgroup -S shim && adduser -S -G shim -h /home/shim shim

--- a/Dockerfile.claude-shim
+++ b/Dockerfile.claude-shim
@@ -1,0 +1,22 @@
+# Claude Code shim — OpenAI-compatible /v1/chat/completions backed by headless
+# Claude Code, so a Claude subscription can serve as the self-host LLM backend.
+# See SELF_HOSTING.md "Claude Code (use your Claude subscription)".
+FROM node:22-alpine
+
+RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
+
+# Claude Code wants a writable home for session state.
+RUN addgroup -S shim && adduser -S -G shim -h /home/shim shim
+USER shim
+ENV HOME=/home/shim
+
+WORKDIR /app
+COPY docker/claude-code-shim.mjs ./claude-code-shim.mjs
+
+ENV PORT=8383
+EXPOSE 8383
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8383/ || exit 1
+
+CMD ["node", "/app/claude-code-shim.mjs"]

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -289,6 +289,10 @@ Model names containing `haiku`/`sonnet`/`opus` map to those Claude tiers; anythi
 falls back to `CLAUDE_SHIM_DEFAULT_MODEL` (default `haiku`). Notes:
 
 - `LLM_API_URL` must include the full `/v1/chat/completions` path (it is not appended).
+- Self-hosted backends are slower than hosted APIs — set `LLM_MIN_TIMEOUT_MS: "60000"`
+  on the `worldmonitor` service so long generations (country briefs) aren't cut off by
+  the 25s per-attempt timeout tuned for hosted providers. Applies to any self-hosted
+  LLM (Ollama, vLLM, this shim), not just Claude Code.
 - Leave `GROQ_API_KEY`/`OPENROUTER_API_KEY` unset (or keep the `LLM_*_PROVIDER: generic`
   pins) — `generic` is last in the fallback chain.
 - The token draws down your personal subscription quota. Keep the daily cap conservative,

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -48,6 +48,8 @@ These must be set before `docker compose up -d`, or one of the containers will e
 
 > Earlier releases shipped `wm-local-token` as a default for the REST token. That default has been removed (#3804) — the proxy was only reachable from `127.0.0.1:8079` so external exposure required a hostile `docker-compose.override.yml`, but any user who flipped that binding to `0.0.0.0` was instantly authenticated by a publicly documented string. Fresh installs and existing clones both need to set `REDIS_TOKEN` and `REDIS_PASSWORD` in `.env` from this release onward.
 
+> **Upgrading an existing deployment:** `WM_SESSION_SECRET` is newly required. Existing clones must add it to `.env` (`echo "WM_SESSION_SECRET=$(openssl rand -hex 32)" >> .env`) before `docker compose up -d`, or Compose fails with `required variable WM_SESSION_SECRET is missing a value`. The value must be at least 32 characters, or `/api/wm-session` returns 503 at runtime even though the stack boots.
+
 > Need to bring the relay up without auth for local debugging? Set `I_UNDERSTAND_THIS_DISABLES_AUTH=true` (the deprecated `ALLOW_UNAUTHENTICATED_RELAY=true` is still accepted). The relay will log a loud `[SECURITY]` warning at boot and every 5 minutes, and every non-public route will be reachable by anyone who can hit the port — **never use this on an internet-reachable host.**
 
 ## 🔑 API Keys
@@ -254,10 +256,16 @@ features run against your subscription instead of a metered API key. The shim st
 Claude Code's session context per call (settings, skills, tools), so a request costs
 little more than its own prompt.
 
-1. On a machine with a browser, run `claude setup-token` (requires Claude Code ≥1.0.90)
-   and copy the long-lived OAuth token.
-2. Add to `.env`: `CLAUDE_CODE_OAUTH_TOKEN=<token>` and `SHIM_API_KEY=$(openssl rand -hex 32)`
-   (the shim key just authenticates the app→shim hop).
+1. On a machine with a browser, run `claude setup-token` (any recent Claude Code CLI;
+   the shim container installs the latest) and copy the long-lived OAuth token.
+2. Add the token and a shim key to `.env` — run these in a shell so the `openssl`
+   substitution executes (pasting `$(openssl …)` literally into `.env` would make the
+   key that literal string):
+
+   ```bash
+   echo "CLAUDE_CODE_OAUTH_TOKEN=<token>" >> .env
+   echo "SHIM_API_KEY=$(openssl rand -hex 32)" >> .env   # authenticates the app→shim hop
+   ```
 3. Wire it up in `docker-compose.override.yml`:
 
 ```yaml
@@ -270,9 +278,15 @@ services:
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:?}
       SHIM_API_KEY: ${SHIM_API_KEY:?}
-      SHIM_DAILY_CAP: "300"        # calls/day, then 429 (protects your subscription quota)
-      SHIM_MAX_CONCURRENCY: "2"
-      SHIM_CACHE_TTL_MS: "900000"  # identical requests served from cache for 15 min
+      SHIM_DAILY_CAP: "300"          # default 300; calls/day then 429 (protects quota)
+      SHIM_MAX_CONCURRENCY: "2"      # default 4; lowered to protect subscription quota
+      SHIM_CACHE_TTL_MS: "900000"    # default 900000; identical NON-STREAMING requests
+                                     # cached 15 min (streamed chat-analyst calls are not
+                                     # cached and always count against SHIM_DAILY_CAP)
+      SHIM_QUEUE_TIMEOUT_MS: "45000" # default 15000; reject queued calls after this. Keep
+                                     # ≥ the caller's patience (LLM_MIN_TIMEOUT_MS below)
+                                     # so a call that will still be awaited isn't rejected.
+      # SHIM_TIMEOUT_MS default 120000 (hard per-call ceiling)
     restart: unless-stopped
   worldmonitor:
     environment:
@@ -311,3 +325,6 @@ falls back to `CLAUDE_SHIM_DEFAULT_MODEL` (default `haiku`). Notes:
 | 🚢 No vessel data | Set `AISSTREAM_API_KEY` in both `worldmonitor` and `ais-relay` services |
 | 🔥 No wildfire data | Set `NASA_FIRMS_API_KEY` |
 | 🌐 No outage data | Requires `CLOUDFLARE_API_TOKEN` (paid Radar access) |
+| ⚙️ `required variable WM_SESSION_SECRET is missing a value` | Add it to `.env`: `echo "WM_SESSION_SECRET=$(openssl rand -hex 32)" >> .env` |
+| 🔒 `/api/wm-session` 503 despite the var being set | `WM_SESSION_SECRET` must be ≥ 32 chars — regenerate with `openssl rand -hex 32` |
+| 🤖 Claude shim AI features silently fall back | Check `SHIM_DAILY_CAP` isn't hit (`GET /` on the shim shows `today`/`cap`); set `LLM_MIN_TIMEOUT_MS: "60000"` so briefs aren't cut off by the 25s hosted-tuned timeout |

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -244,6 +244,56 @@ services:
       - "your-host:192.168.1.100"  # if not DNS-resolvable
 ```
 
+### Claude Code (use your Claude subscription)
+
+If you have a Claude Pro/Max subscription, the bundled shim (`Dockerfile.claude-shim`)
+exposes headless Claude Code as an OpenAI-compatible endpoint, so the dashboard's AI
+features run against your subscription instead of a metered API key. The shim strips
+Claude Code's session context per call (settings, skills, tools), so a request costs
+little more than its own prompt.
+
+1. On a machine with a browser, run `claude setup-token` (requires Claude Code ≥1.0.90)
+   and copy the long-lived OAuth token.
+2. Add to `.env`: `CLAUDE_CODE_OAUTH_TOKEN=<token>` and `SHIM_API_KEY=$(openssl rand -hex 32)`
+   (the shim key just authenticates the app→shim hop).
+3. Wire it up in `docker-compose.override.yml`:
+
+```yaml
+# docker-compose.override.yml
+services:
+  claude-shim:
+    build:
+      context: .
+      dockerfile: Dockerfile.claude-shim
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:?}
+      SHIM_API_KEY: ${SHIM_API_KEY:?}
+      SHIM_DAILY_CAP: "300"        # calls/day, then 429 (protects your subscription quota)
+      SHIM_MAX_CONCURRENCY: "2"
+      SHIM_CACHE_TTL_MS: "900000"  # identical requests served from cache for 15 min
+    restart: unless-stopped
+  worldmonitor:
+    environment:
+      LLM_API_URL: "http://claude-shim:8383/v1/chat/completions"  # full path — used verbatim
+      LLM_API_KEY: ${SHIM_API_KEY:?}   # required, or the generic provider is skipped
+      LLM_MODEL: "claude-haiku"
+      LLM_TOOL_PROVIDER: "generic"      # prefer the shim over groq/openrouter…
+      LLM_TOOL_MODEL: "claude-haiku"    # …for extraction/classification stages
+      LLM_REASONING_PROVIDER: "generic"
+      LLM_REASONING_MODEL: "claude-sonnet"  # briefs + chat analyst
+```
+
+Model names containing `haiku`/`sonnet`/`opus` map to those Claude tiers; anything else
+falls back to `CLAUDE_SHIM_DEFAULT_MODEL` (default `haiku`). Notes:
+
+- `LLM_API_URL` must include the full `/v1/chat/completions` path (it is not appended).
+- Leave `GROQ_API_KEY`/`OPENROUTER_API_KEY` unset (or keep the `LLM_*_PROVIDER: generic`
+  pins) — `generic` is last in the fallback chain.
+- The token draws down your personal subscription quota. Keep the daily cap conservative,
+  keep the deployment private, and don't share the endpoint: Anthropic's terms cover
+  personal use of your own subscription through Claude Code.
+- Rotate the token by re-running `claude setup-token` and restarting the shim container.
+
 ## 🐛 Troubleshooting
 
 | Issue | Fix |

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -21,6 +21,7 @@ npm install
 echo "RELAY_SHARED_SECRET=$(openssl rand -hex 32)" >> .env
 echo "REDIS_PASSWORD=$(openssl rand -hex 32)"      >> .env
 echo "REDIS_TOKEN=$(openssl rand -hex 32)"         >> .env
+echo "WM_SESSION_SECRET=$(openssl rand -hex 32)"   >> .env
 
 # 3. Start the stack
 docker compose up -d        # or: uvx podman-compose up -d
@@ -43,6 +44,7 @@ These must be set before `docker compose up -d`, or one of the containers will e
 | `RELAY_SHARED_SECRET` | Authenticates every non-public request the dashboard makes to the AIS relay. The relay refuses to start without it. | `openssl rand -hex 32` |
 | `REDIS_PASSWORD` | Redis AUTH password (`--requirepass`). The Redis container refuses to start without it; the REST proxy uses it in its upstream connection string. | `openssl rand -hex 32` |
 | `REDIS_TOKEN` | Bearer token the REST proxy (`redis-rest`) requires on every request, and the value the app sends as `UPSTASH_REDIS_REST_TOKEN`. The proxy and app containers refuse to start without it. | `openssl rand -hex 32` |
+| `WM_SESSION_SECRET` | Signs the anonymous `wm-session` cookies. Without it `/api/wm-session` fails closed (503) and every session-gated data route degrades for anonymous visitors. | `openssl rand -hex 32` |
 
 > Earlier releases shipped `wm-local-token` as a default for the REST token. That default has been removed (#3804) — the proxy was only reachable from `127.0.0.1:8079` so external exposure required a hostile `docker-compose.override.yml`, but any user who flipped that binding to `0.0.0.0` was instantly authenticated by a publicly documented string. Fresh installs and existing clones both need to set `REDIS_TOKEN` and `REDIS_PASSWORD` in `.env` from this release onward.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
     environment:
       UPSTASH_REDIS_REST_URL: "http://redis-rest:80"
       UPSTASH_REDIS_REST_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
+      # Signs the anonymous wm-session cookies. Without it /api/wm-session
+      # fails closed (503) and session-gated data routes cascade-fail for
+      # every anonymous visitor.
+      WM_SESSION_SECRET: "${WM_SESSION_SECRET:?WM_SESSION_SECRET required — generate with: openssl rand -hex 32}"
       LOCAL_API_PORT: "46123"
       LOCAL_API_MODE: "docker"
       LOCAL_API_CLOUD_FALLBACK: "false"

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// OpenAI-compatible /v1/chat/completions shim backed by headless Claude Code
+// (`claude -p`). Lets self-hosters use a Claude subscription as the `generic`
+// LLM provider (LLM_API_URL/LLM_API_KEY) with zero app changes.
+// Zero-dependency by design, matching docker/redis-rest-proxy.mjs.
+// See SELF_HOSTING.md "Claude Code (use your Claude subscription)".
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+const PORT = Number(process.env.PORT ?? 8383);
+const HOST = process.env.SHIM_HOST || '0.0.0.0';
+const API_KEY = process.env.SHIM_API_KEY;
+const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
+const DEFAULT_MODEL = process.env.CLAUDE_SHIM_DEFAULT_MODEL || 'haiku';
+const TIMEOUT_MS = Number(process.env.SHIM_TIMEOUT_MS ?? 120_000);
+const MAX_BODY_BYTES = 1_048_576;
+
+if (!API_KEY) {
+  console.error('claude-code-shim: SHIM_API_KEY is required');
+  process.exit(1);
+}
+
+const MODELS = ['haiku', 'sonnet', 'opus'];
+
+function mapModel(name) {
+  const n = String(name || '').toLowerCase();
+  for (const m of MODELS) if (n.includes(m)) return m;
+  return DEFAULT_MODEL;
+}
+
+function contentText(c) {
+  if (typeof c === 'string') return c;
+  if (Array.isArray(c)) return c.map((p) => (typeof p === 'string' ? p : p?.text || '')).join('\n');
+  return String(c ?? '');
+}
+
+// OpenAI messages[] -> { system, prompt }. System turns become --system-prompt
+// (replacing Claude Code's own system prompt — the big per-call token saving);
+// conversation turns are flattened into a single transcript prompt.
+function splitMessages(messages) {
+  const system = messages
+    .filter((m) => m.role === 'system')
+    .map((m) => contentText(m.content))
+    .join('\n\n');
+  const turns = messages.filter((m) => m.role !== 'system');
+  const prompt = turns.length === 1
+    ? contentText(turns[0].content)
+    : `${turns.map((m) => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${contentText(m.content)}`).join('\n\n')}\n\nAssistant:`;
+  return { system, prompt };
+}
+
+function claudeArgs({ model, system, stream }) {
+  const args = [
+    '-p',
+    '--output-format', stream ? 'stream-json' : 'json',
+    '--model', model,
+    '--max-turns', '1',
+    '--setting-sources', '',
+  ];
+  if (stream) args.push('--verbose', '--include-partial-messages');
+  if (system) args.push('--system-prompt', system);
+  return args;
+}
+
+// The stub CLI used in tests is a .mjs; run scripts through the current node.
+function spawnClaude(args) {
+  const viaNode = /\.(mjs|cjs|js)$/i.test(CLAUDE_BIN);
+  const bin = viaNode ? process.execPath : CLAUDE_BIN;
+  const argv = viaNode ? [CLAUDE_BIN, ...args] : args;
+  return spawn(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
+}
+
+function runClaude(args, prompt) {
+  return new Promise((resolve, reject) => {
+    const child = spawnClaude(args);
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      child.kill('SIGKILL');
+      reject(new Error(`claude timed out after ${TIMEOUT_MS}ms`));
+    }, TIMEOUT_MS);
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('error', (err) => { if (!settled) { clearTimeout(timer); reject(err); } });
+    child.on('close', (code) => {
+      if (settled) return;
+      clearTimeout(timer);
+      const lines = stdout.trim().split('\n').filter(Boolean);
+      const last = lines[lines.length - 1];
+      let parsed;
+      try {
+        parsed = JSON.parse(last);
+      } catch {
+        return reject(new Error(`claude exited ${code}, unparseable output: ${(stderr || stdout).slice(0, 500)}`));
+      }
+      if (parsed.is_error) return reject(new Error(`claude error: ${String(parsed.result).slice(0, 500)}`));
+      resolve(parsed);
+    });
+    child.stdin.end(prompt);
+  });
+}
+
+function toUsage(u = {}) {
+  const prompt =
+    (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
+  const completion = u.output_tokens || 0;
+  return { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion };
+}
+
+function finishReason(stopReason) {
+  return stopReason === 'max_tokens' ? 'length' : 'stop';
+}
+
+function sendJson(res, status, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+  res.end(body);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks = [];
+    req.on('data', (c) => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) { reject(new Error('body too large')); req.destroy(); return; }
+      chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+async function handleChat(req, res) {
+  let body;
+  try {
+    body = JSON.parse((await readBody(req)) || '{}');
+  } catch {
+    return sendJson(res, 400, { error: { message: 'invalid JSON body' } });
+  }
+  const messages = Array.isArray(body.messages) ? body.messages : null;
+  if (!messages || messages.length === 0) {
+    return sendJson(res, 400, { error: { message: 'messages[] required' } });
+  }
+  const model = mapModel(body.model);
+  const { system, prompt } = splitMessages(messages);
+  const args = claudeArgs({ model, system, stream: false });
+  try {
+    const result = await runClaude(args, prompt);
+    return sendJson(res, 200, {
+      id: `chatcmpl-${randomUUID()}`,
+      object: 'chat.completion',
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: String(result.result ?? '') },
+        finish_reason: finishReason(result.stop_reason),
+      }],
+      usage: toUsage(result.usage),
+    });
+  } catch (err) {
+    console.error(`claude-code-shim: completion failed: ${err.message}`);
+    return sendJson(res, 502, { error: { message: err.message } });
+  }
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  if (req.method === 'GET' && url.pathname === '/') {
+    return sendJson(res, 200, { ok: true });
+  }
+  const auth = req.headers.authorization || '';
+  if (auth !== `Bearer ${API_KEY}`) {
+    return sendJson(res, 401, { error: { message: 'unauthorized' } });
+  }
+  if (req.method === 'GET' && url.pathname === '/v1/models') {
+    return sendJson(res, 200, {
+      object: 'list',
+      data: MODELS.map((id) => ({ id, object: 'model', owned_by: 'claude-code' })),
+    });
+  }
+  if (req.method === 'POST' && url.pathname === '/v1/chat/completions') {
+    return handleChat(req, res);
+  }
+  return sendJson(res, 404, { error: { message: 'not found' } });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`claude-code-shim listening on http://127.0.0.1:${server.address().port}`);
+});

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -98,12 +98,16 @@ function splitMessages(messages) {
 }
 
 function claudeArgs({ model, system, stream }) {
+  // --setting-sources '' + --tools '' + a replaced --system-prompt strip the
+  // Claude Code session context (user settings, skills, MCP, tool schemas) so a
+  // call costs little more than the caller's own prompt.
   const args = [
     '-p',
     '--output-format', stream ? 'stream-json' : 'json',
     '--model', model,
     '--max-turns', '1',
     '--setting-sources', '',
+    '--tools', '',
   ];
   if (stream) args.push('--verbose', '--include-partial-messages');
   if (system) args.push('--system-prompt', system);

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -324,6 +324,13 @@ const server = createServer(async (req, res) => {
   return sendJson(res, 404, { error: { message: 'not found' } });
 });
 
+// Node's 5s keep-alive default races pooled client connections (undici/fetch
+// reuses an idle socket exactly as the server closes it → ECONNRESET, and the
+// caller's provider chain treats the shim as failed). Outlive typical client
+// idle-reuse windows instead.
+server.keepAliveTimeout = 65_000;
+server.headersTimeout = 66_000;
+
 server.listen(PORT, HOST, () => {
   console.log(`claude-code-shim listening on http://127.0.0.1:${server.address().port}`);
 });

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -7,7 +7,7 @@
 // Contributed by Will Kemp — liftedholdings.com
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 
 const PORT = Number(process.env.PORT ?? 8383);
 const HOST = process.env.SHIM_HOST || '0.0.0.0';
@@ -29,9 +29,20 @@ const QUEUE_TIMEOUT_MS = Number(process.env.SHIM_QUEUE_TIMEOUT_MS ?? 15_000);
 
 const MODELS = ['haiku', 'sonnet', 'opus'];
 
+const AUTH_HEADER = `Bearer ${API_KEY}`;
+// Constant-time compare, matching docker/redis-rest-proxy.mjs's checkAuth so the
+// subscription-backing key can't be probed by response timing. timingSafeEqual
+// throws on unequal-length buffers, so the length pre-check gates it.
+function authOk(header) {
+  if (typeof header !== 'string' || header.length !== AUTH_HEADER.length) return false;
+  return timingSafeEqual(Buffer.from(header), Buffer.from(AUTH_HEADER));
+}
+
 // --- Quota guards: keep a runaway client from draining the Claude subscription.
 let capDay = '';
 let capCount = 0;
+// Rolls the UTC-day window and reports headroom. Call before counting so a
+// request queued across midnight lands on the correct day's budget.
 function underCap() {
   const today = new Date().toISOString().slice(0, 10);
   if (today !== capDay) { capDay = today; capCount = 0; }
@@ -41,10 +52,12 @@ const countCall = () => { capCount += 1; };
 
 let running = 0;
 const waiters = [];
-// Callers (server/_shared/llm.ts) abort at ~25s. A request that cannot start
-// promptly must fail fast — otherwise it spawns claude after the caller has
-// already given up, burning subscription quota for a discarded result.
+// Callers (server/_shared/llm.ts) abort after their own timeout. A request that
+// cannot start promptly must fail fast — otherwise it spawns claude after the
+// caller has already given up, burning subscription quota for a discarded
+// result. Cap re-checks and client-disconnect checks also run at slot entry.
 class QueueTimeoutError extends Error {}
+class CapError extends Error {}
 async function withSlot(fn, { queueTimeoutMs = QUEUE_TIMEOUT_MS, isAbandoned = () => false } = {}) {
   if (running >= MAX_CONCURRENCY) {
     await new Promise((resolve, reject) => {
@@ -59,6 +72,10 @@ async function withSlot(fn, { queueTimeoutMs = QUEUE_TIMEOUT_MS, isAbandoned = (
   running += 1;
   try {
     if (isAbandoned()) throw new QueueTimeoutError('client disconnected while queued');
+    // Re-check under the slot: many requests can pass the pre-queue underCap()
+    // while slots are full, so the count is only authoritative here.
+    if (!underCap()) throw new CapError('daily cap reached');
+    countCall();
     return await fn();
   } finally {
     running -= 1;
@@ -98,18 +115,41 @@ function contentText(c) {
   return String(c ?? '');
 }
 
+// Line-leading "User:" / "Assistant:" markers inside message content would be
+// indistinguishable from real transcript turns after flattening. Neutralize
+// them so caller content can't forge turns.
+function neutralizeRoleMarkers(text) {
+  return text.replace(/^(User|Assistant):/gm, '$1​:');
+}
+
+class BadRequestError extends Error {}
+
 // OpenAI messages[] -> { system, prompt }. System turns become --system-prompt
 // (replacing Claude Code's own system prompt — the big per-call token saving);
-// conversation turns are flattened into a single transcript prompt.
+// remaining turns are flattened into a single transcript prompt. Supported
+// shapes are documented in SELF_HOSTING.md: system + a user/assistant
+// transcript. Tool/function roles and assistant-prefill continuation are not
+// supported and are rejected rather than silently mislabeled.
 function splitMessages(messages) {
+  for (const m of messages) {
+    if (!['system', 'user', 'assistant'].includes(m.role)) {
+      throw new BadRequestError(`unsupported message role: ${m.role}`);
+    }
+  }
   const system = messages
     .filter((m) => m.role === 'system')
     .map((m) => contentText(m.content))
     .join('\n\n');
   const turns = messages.filter((m) => m.role !== 'system');
+  if (turns.length === 0) {
+    throw new BadRequestError('at least one user or assistant message is required');
+  }
+  if (turns.length > 1 && turns[turns.length - 1].role === 'assistant') {
+    throw new BadRequestError('assistant-prefill continuation is not supported');
+  }
   const prompt = turns.length === 1
     ? contentText(turns[0].content)
-    : `${turns.map((m) => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${contentText(m.content)}`).join('\n\n')}\n\nAssistant:`;
+    : `${turns.map((m) => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${neutralizeRoleMarkers(contentText(m.content))}`).join('\n\n')}\n\nAssistant:`;
   return { system, prompt };
 }
 
@@ -130,41 +170,88 @@ function claudeArgs({ model, system, stream }) {
   return args;
 }
 
+// Explicit child env: the spawned CLI needs its OAuth credential and a working
+// PATH/HOME, but NOT the shim's own secrets (SHIM_API_KEY) or the app's LLM/DB
+// env. The prompt is fully attacker-influenced (it embeds third-party feed
+// content), so even with tools disabled we don't hand the child anything it
+// doesn't need. STUB_* passes through only for the test stub (a local .mjs).
+function childEnv() {
+  const allow = [
+    'PATH', 'HOME', 'LANG', 'LC_ALL', 'TZ',
+    'SYSTEMROOT', 'USERPROFILE', 'TEMP', 'TMP', 'TMPDIR',
+  ];
+  const env = {};
+  for (const k of allow) if (process.env[k] !== undefined) env[k] = process.env[k];
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith('CLAUDE_') || k.startsWith('ANTHROPIC_')) env[k] = v;
+  }
+  const viaNode = /\.(mjs|cjs|js)$/i.test(CLAUDE_BIN);
+  if (viaNode) {
+    for (const [k, v] of Object.entries(process.env)) if (k.startsWith('STUB_')) env[k] = v;
+  }
+  return env;
+}
+
 // The stub CLI used in tests is a .mjs; run scripts through the current node.
 function spawnClaude(args) {
   const viaNode = /\.(mjs|cjs|js)$/i.test(CLAUDE_BIN);
   const bin = viaNode ? process.execPath : CLAUDE_BIN;
   const argv = viaNode ? [CLAUDE_BIN, ...args] : args;
-  return spawn(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
+  return spawn(bin, argv, { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true, env: childEnv() });
 }
 
-function runClaude(args, prompt) {
+// Error thrown to the client carries only a coarse class; the full stderr/stdout
+// is logged server-side, never reflected in the HTTP body.
+class ClaudeError extends Error {
+  constructor(clientMessage, detail) {
+    super(clientMessage);
+    this.detail = detail;
+  }
+}
+
+function runClaude(args, prompt, { isAbandoned = () => false } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawnClaude(args);
     let stdout = '';
     let stderr = '';
     let settled = false;
+    const done = (fn, arg) => { if (!settled) { settled = true; clearTimeout(timer); fn(arg); } };
     const timer = setTimeout(() => {
-      settled = true;
       child.kill('SIGKILL');
-      reject(new Error(`claude timed out after ${TIMEOUT_MS}ms`));
+      done(reject, new ClaudeError('upstream claude invocation timed out', `timeout after ${TIMEOUT_MS}ms`));
     }, TIMEOUT_MS);
+    // Abort the child if the caller hangs up — no point finishing a discarded
+    // generation, and it frees the concurrency slot immediately.
+    const abortPoll = setInterval(() => {
+      if (isAbandoned()) {
+        clearInterval(abortPoll);
+        child.kill('SIGKILL');
+        done(reject, new ClaudeError('client disconnected', 'client aborted'));
+      }
+    }, 250);
     child.stdout.on('data', (d) => { stdout += d; });
     child.stderr.on('data', (d) => { stderr += d; });
-    child.on('error', (err) => { if (!settled) { clearTimeout(timer); reject(err); } });
+    child.on('error', (err) => {
+      clearInterval(abortPoll);
+      done(reject, new ClaudeError('upstream claude invocation failed', err.message));
+    });
     child.on('close', (code) => {
+      clearInterval(abortPoll);
       if (settled) return;
-      clearTimeout(timer);
       const lines = stdout.trim().split('\n').filter(Boolean);
       const last = lines[lines.length - 1];
       let parsed;
       try {
         parsed = JSON.parse(last);
       } catch {
-        return reject(new Error(`claude exited ${code}, unparseable output: ${(stderr || stdout).slice(0, 500)}`));
+        return done(reject, new ClaudeError('upstream claude invocation failed',
+          `exit ${code}, unparseable output: ${(stderr || stdout).slice(0, 500)}`));
       }
-      if (parsed.is_error) return reject(new Error(`claude error: ${String(parsed.result).slice(0, 500)}`));
-      resolve(parsed);
+      if (parsed.is_error) {
+        return done(reject, new ClaudeError('upstream claude returned an error',
+          String(parsed.result).slice(0, 500)));
+      }
+      done(resolve, parsed);
     });
     child.stdin.end(prompt);
   });
@@ -187,13 +274,19 @@ function sendJson(res, status, obj) {
   res.end(body);
 }
 
+class BodyTooLargeError extends Error {}
 function readBody(req) {
   return new Promise((resolve, reject) => {
     let size = 0;
     const chunks = [];
     req.on('data', (c) => {
       size += c.length;
-      if (size > MAX_BODY_BYTES) { reject(new Error('body too large')); req.destroy(); return; }
+      if (size > MAX_BODY_BYTES) {
+        req.removeAllListeners('data');
+        req.resume(); // drain rather than destroy, so the 413 can flush
+        reject(new BodyTooLargeError('request body too large'));
+        return;
+      }
       chunks.push(c);
     });
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
@@ -202,9 +295,13 @@ function readBody(req) {
 }
 
 // Streams claude stream-json events to the client as OpenAI SSE chunks.
-// If no partial text deltas arrive (older CLI without --include-partial-messages
-// support), the final result text is emitted as a single delta instead.
-function streamChat(res, args, prompt, model) {
+// A clean stop (a result event with no error) is the ONLY path that writes a
+// finish_reason chunk + [DONE]. Any abnormal end — timeout SIGKILL, spawn
+// error, is_error result, or the child closing before a clean result —
+// destroys the socket mid-body instead, so the consumer's stream reader throws
+// and records the turn as truncated (server/_shared/llm.ts) rather than
+// treating a cut-off brief as a complete answer.
+function streamChat(res, args, prompt, model, { isAbandoned = () => false } = {}) {
   res.writeHead(200, {
     'content-type': 'text/event-stream',
     'cache-control': 'no-cache',
@@ -222,18 +319,32 @@ function streamChat(res, args, prompt, model) {
   };
   const child = spawnClaude(args);
   let streamedText = false;
-  let buf = '';
-  let done = false;
-  const timer = setTimeout(() => child.kill('SIGKILL'), TIMEOUT_MS);
-  const finish = (finishReasonValue) => {
-    if (done) return;
-    done = true;
+  let ended = false;
+  const timer = setTimeout(() => {
+    if (!ended) { ended = true; child.kill('SIGKILL'); res.destroy(); }
+  }, TIMEOUT_MS);
+  const abortPoll = setInterval(() => {
+    if (isAbandoned() && !ended) { ended = true; clearInterval(abortPoll); child.kill('SIGKILL'); }
+  }, 250);
+  const finishClean = (finishReasonValue) => {
+    if (ended) return;
+    ended = true;
     clearTimeout(timer);
+    clearInterval(abortPoll);
     chunk({}, finishReasonValue);
     res.write('data: [DONE]\n\n');
     res.end();
   };
+  const abort = (why) => {
+    if (ended) return;
+    ended = true;
+    clearTimeout(timer);
+    clearInterval(abortPoll);
+    console.error(`claude-code-shim: stream aborted: ${why}`);
+    res.destroy(); // sever mid-body → caller sees a truncated stream, not success
+  };
   chunk({ role: 'assistant' });
+  let buf = '';
   child.stdout.on('data', (d) => {
     buf += d;
     let nl;
@@ -248,24 +359,35 @@ function streamChat(res, args, prompt, model) {
         streamedText = true;
         chunk({ content: deltaText });
       } else if (evt.type === 'result') {
-        if (!streamedText && !evt.is_error && evt.result) chunk({ content: String(evt.result) });
-        finish(finishReason(evt.stop_reason));
+        if (evt.is_error) { abort(`result is_error: ${String(evt.result).slice(0, 200)}`); return; }
+        // If the CLI buffered its whole answer (no incremental deltas), emit it
+        // as one delta before closing cleanly.
+        if (!streamedText && evt.result) chunk({ content: String(evt.result) });
+        finishClean(finishReason(evt.stop_reason));
       }
     }
   });
-  child.on('close', () => finish('stop'));
-  child.on('error', (err) => {
-    console.error(`claude-code-shim: stream spawn failed: ${err.message}`);
-    finish('stop');
-  });
-  res.on('close', () => { clearTimeout(timer); child.kill('SIGKILL'); });
+  // The child closing WITHOUT having produced a clean result event is a crash
+  // or a kill — abort rather than synthesize a clean stop.
+  child.on('close', () => abort('child closed before a clean result'));
+  child.on('error', (err) => abort(`spawn error: ${err.message}`));
+  res.on('close', () => { if (!ended) { ended = true; clearTimeout(timer); clearInterval(abortPoll); child.kill('SIGKILL'); } });
   child.stdin.end(prompt);
 }
 
 async function handleChat(req, res) {
+  let raw;
+  try {
+    raw = await readBody(req);
+  } catch (err) {
+    if (err instanceof BodyTooLargeError) {
+      return sendJson(res, 413, { error: { message: 'request body too large' } });
+    }
+    return sendJson(res, 400, { error: { message: 'could not read request body' } });
+  }
   let body;
   try {
-    body = JSON.parse((await readBody(req)) || '{}');
+    body = JSON.parse(raw || '{}');
   } catch {
     return sendJson(res, 400, { error: { message: 'invalid JSON body' } });
   }
@@ -274,31 +396,45 @@ async function handleChat(req, res) {
     return sendJson(res, 400, { error: { message: 'messages[] required' } });
   }
   const model = mapModel(body.model);
-  const { system, prompt } = splitMessages(messages);
+  let system;
+  let prompt;
+  try {
+    ({ system, prompt } = splitMessages(messages));
+  } catch (err) {
+    if (err instanceof BadRequestError) return sendJson(res, 400, { error: { message: err.message } });
+    throw err;
+  }
   let clientGone = false;
   res.on('close', () => { clientGone = !res.writableEnded; });
-  const slotOpts = { isAbandoned: () => clientGone };
+  const isAbandoned = () => clientGone;
+  const slotOpts = { isAbandoned };
+
   if (body.stream === true) {
     if (!underCap()) return sendJson(res, 429, { error: { message: 'daily cap reached' } });
-    return withSlot(async () => {
-      countCall();
-      return streamChatAwaited(res, claudeArgs({ model, system, stream: true }), prompt, model);
-    }, slotOpts).catch((err) => {
-      if (err instanceof QueueTimeoutError && !res.headersSent) {
-        sendJson(res, 503, { error: { message: `busy: ${err.message}` } });
+    return withSlot(
+      () => streamChatAwaited(res, claudeArgs({ model, system, stream: true }), prompt, model, isAbandoned),
+      slotOpts,
+    ).catch((err) => {
+      if ((err instanceof QueueTimeoutError || err instanceof CapError) && !res.headersSent) {
+        const status = err instanceof CapError ? 429 : 503;
+        sendJson(res, status, { error: { message: err.message } });
       }
     });
   }
+
   const key = cacheKey(model, messages);
   const cached = cacheGet(key);
-  if (cached) return sendJson(res, 200, { ...cached, id: `chatcmpl-${randomUUID()}` });
+  if (cached) {
+    return sendJson(res, 200, {
+      ...cached,
+      id: `chatcmpl-${randomUUID()}`,
+      created: Math.floor(Date.now() / 1000),
+    });
+  }
   if (!underCap()) return sendJson(res, 429, { error: { message: 'daily cap reached' } });
   const args = claudeArgs({ model, system, stream: false });
   try {
-    const result = await withSlot(() => {
-      countCall();
-      return runClaude(args, prompt);
-    }, slotOpts);
+    const result = await withSlot(() => runClaude(args, prompt, { isAbandoned }), slotOpts);
     const payload = {
       id: `chatcmpl-${randomUUID()}`,
       object: 'chat.completion',
@@ -314,19 +450,20 @@ async function handleChat(req, res) {
     cacheSet(key, payload);
     return sendJson(res, 200, payload);
   } catch (err) {
-    if (err instanceof QueueTimeoutError) {
-      return sendJson(res, 503, { error: { message: `busy: ${err.message}` } });
-    }
-    console.error(`claude-code-shim: completion failed: ${err.message}`);
-    return sendJson(res, 502, { error: { message: err.message } });
+    if (err instanceof CapError) return sendJson(res, 429, { error: { message: err.message } });
+    if (err instanceof QueueTimeoutError) return sendJson(res, 503, { error: { message: err.message } });
+    // ClaudeError carries a client-safe message; detail is logged, not returned.
+    const detail = err instanceof ClaudeError ? err.detail : err.message;
+    console.error(`claude-code-shim: completion failed: ${err.message}${detail ? ` (${detail})` : ''}`);
+    if (!res.headersSent) sendJson(res, 502, { error: { message: err.message } });
   }
 }
 
 // Wraps streamChat so the concurrency slot is held until the SSE stream ends.
-function streamChatAwaited(res, args, prompt, model) {
+function streamChatAwaited(res, args, prompt, model, isAbandoned) {
   return new Promise((resolve) => {
     res.on('close', resolve);
-    streamChat(res, args, prompt, model);
+    streamChat(res, args, prompt, model, { isAbandoned });
   });
 }
 
@@ -336,8 +473,7 @@ const server = createServer(async (req, res) => {
     underCap(); // roll the day window so `today` is current
     return sendJson(res, 200, { ok: true, today: capCount, cap: DAILY_CAP });
   }
-  const auth = req.headers.authorization || '';
-  if (auth !== `Bearer ${API_KEY}`) {
+  if (!authOk(req.headers.authorization)) {
     return sendJson(res, 401, { error: { message: 'unauthorized' } });
   }
   if (req.method === 'GET' && url.pathname === '/v1/models') {
@@ -360,5 +496,6 @@ server.keepAliveTimeout = 65_000;
 server.headersTimeout = 66_000;
 
 server.listen(PORT, HOST, () => {
-  console.log(`claude-code-shim listening on http://127.0.0.1:${server.address().port}`);
+  const addr = server.address();
+  console.log(`claude-code-shim listening on http://${addr.address}:${addr.port}`);
 });

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -4,6 +4,7 @@
 // LLM provider (LLM_API_URL/LLM_API_KEY) with zero app changes.
 // Zero-dependency by design, matching docker/redis-rest-proxy.mjs.
 // See SELF_HOSTING.md "Claude Code (use your Claude subscription)".
+// Contributed by Will Kemp — liftedholdings.com
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -6,7 +6,7 @@
 // See SELF_HOSTING.md "Claude Code (use your Claude subscription)".
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 const PORT = Number(process.env.PORT ?? 8383);
 const HOST = process.env.SHIM_HOST || '0.0.0.0';
@@ -21,7 +21,54 @@ if (!API_KEY) {
   process.exit(1);
 }
 
+const MAX_CONCURRENCY = Number(process.env.SHIM_MAX_CONCURRENCY ?? 2);
+const DAILY_CAP = Number(process.env.SHIM_DAILY_CAP ?? 300);
+const CACHE_TTL_MS = Number(process.env.SHIM_CACHE_TTL_MS ?? 900_000);
+
 const MODELS = ['haiku', 'sonnet', 'opus'];
+
+// --- Quota guards: keep a runaway client from draining the Claude subscription.
+let capDay = '';
+let capCount = 0;
+function underCap() {
+  const today = new Date().toISOString().slice(0, 10);
+  if (today !== capDay) { capDay = today; capCount = 0; }
+  return capCount < DAILY_CAP;
+}
+const countCall = () => { capCount += 1; };
+
+let running = 0;
+const waiters = [];
+async function withSlot(fn) {
+  if (running >= MAX_CONCURRENCY) await new Promise((r) => waiters.push(r));
+  running += 1;
+  try {
+    return await fn();
+  } finally {
+    running -= 1;
+    const next = waiters.shift();
+    if (next) next();
+  }
+}
+
+const cache = new Map(); // key -> { expires, payload }
+function cacheKey(model, messages) {
+  return createHash('sha256').update(model + JSON.stringify(messages)).digest('hex');
+}
+function cacheGet(key) {
+  const hit = cache.get(key);
+  if (!hit) return null;
+  if (hit.expires < Date.now()) { cache.delete(key); return null; }
+  return hit.payload;
+}
+function cacheSet(key, payload) {
+  if (CACHE_TTL_MS <= 0) return;
+  if (cache.size > 500) {
+    for (const [k, v] of cache) if (v.expires < Date.now()) cache.delete(k);
+    if (cache.size > 500) cache.delete(cache.keys().next().value);
+  }
+  cache.set(key, { expires: Date.now() + CACHE_TTL_MS, payload });
+}
 
 function mapModel(name) {
   const n = String(name || '').toLowerCase();
@@ -209,12 +256,20 @@ async function handleChat(req, res) {
   const model = mapModel(body.model);
   const { system, prompt } = splitMessages(messages);
   if (body.stream === true) {
-    return streamChat(res, claudeArgs({ model, system, stream: true }), prompt, model);
+    if (!underCap()) return sendJson(res, 429, { error: { message: 'daily cap reached' } });
+    countCall();
+    return withSlot(async () =>
+      streamChatAwaited(res, claudeArgs({ model, system, stream: true }), prompt, model));
   }
+  const key = cacheKey(model, messages);
+  const cached = cacheGet(key);
+  if (cached) return sendJson(res, 200, { ...cached, id: `chatcmpl-${randomUUID()}` });
+  if (!underCap()) return sendJson(res, 429, { error: { message: 'daily cap reached' } });
+  countCall();
   const args = claudeArgs({ model, system, stream: false });
   try {
-    const result = await runClaude(args, prompt);
-    return sendJson(res, 200, {
+    const result = await withSlot(() => runClaude(args, prompt));
+    const payload = {
       id: `chatcmpl-${randomUUID()}`,
       object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
@@ -225,17 +280,28 @@ async function handleChat(req, res) {
         finish_reason: finishReason(result.stop_reason),
       }],
       usage: toUsage(result.usage),
-    });
+    };
+    cacheSet(key, payload);
+    return sendJson(res, 200, payload);
   } catch (err) {
     console.error(`claude-code-shim: completion failed: ${err.message}`);
     return sendJson(res, 502, { error: { message: err.message } });
   }
 }
 
+// Wraps streamChat so the concurrency slot is held until the SSE stream ends.
+function streamChatAwaited(res, args, prompt, model) {
+  return new Promise((resolve) => {
+    res.on('close', resolve);
+    streamChat(res, args, prompt, model);
+  });
+}
+
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, 'http://localhost');
   if (req.method === 'GET' && url.pathname === '/') {
-    return sendJson(res, 200, { ok: true });
+    underCap(); // roll the day window so `today` is current
+    return sendJson(res, 200, { ok: true, today: capCount, cap: DAILY_CAP });
   }
   const auth = req.headers.authorization || '';
   if (auth !== `Bearer ${API_KEY}`) {

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -320,12 +320,10 @@ function streamChat(res, args, prompt, model, { isAbandoned = () => false } = {}
   const child = spawnClaude(args);
   let streamedText = false;
   let ended = false;
-  const timer = setTimeout(() => {
-    if (!ended) { ended = true; child.kill('SIGKILL'); res.destroy(); }
-  }, TIMEOUT_MS);
-  const abortPoll = setInterval(() => {
-    if (isAbandoned() && !ended) { ended = true; clearInterval(abortPoll); child.kill('SIGKILL'); }
-  }, 250);
+  let timer;
+  let abortPoll;
+  // Every terminal path routes through finishClean or abort; both clear BOTH
+  // the timeout and the abandon-poll interval, so no exit can leak a handle.
   const finishClean = (finishReasonValue) => {
     if (ended) return;
     ended = true;
@@ -340,9 +338,12 @@ function streamChat(res, args, prompt, model, { isAbandoned = () => false } = {}
     ended = true;
     clearTimeout(timer);
     clearInterval(abortPoll);
+    child.kill('SIGKILL'); // no-op if already dead (child close path)
     console.error(`claude-code-shim: stream aborted: ${why}`);
     res.destroy(); // sever mid-body → caller sees a truncated stream, not success
   };
+  timer = setTimeout(() => abort(`timeout after ${TIMEOUT_MS}ms`), TIMEOUT_MS);
+  abortPoll = setInterval(() => { if (isAbandoned()) abort('client disconnected'); }, 250);
   chunk({ role: 'assistant' });
   let buf = '';
   child.stdout.on('data', (d) => {
@@ -371,7 +372,7 @@ function streamChat(res, args, prompt, model, { isAbandoned = () => false } = {}
   // or a kill — abort rather than synthesize a clean stop.
   child.on('close', () => abort('child closed before a clean result'));
   child.on('error', (err) => abort(`spawn error: ${err.message}`));
-  res.on('close', () => { if (!ended) { ended = true; clearTimeout(timer); clearInterval(abortPoll); child.kill('SIGKILL'); } });
+  res.on('close', () => abort('client closed'));
   child.stdin.end(prompt);
 }
 

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -134,6 +134,67 @@ function readBody(req) {
   });
 }
 
+// Streams claude stream-json events to the client as OpenAI SSE chunks.
+// If no partial text deltas arrive (older CLI without --include-partial-messages
+// support), the final result text is emitted as a single delta instead.
+function streamChat(res, args, prompt, model) {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  });
+  const id = `chatcmpl-${randomUUID()}`;
+  const chunk = (delta, finish = null) => {
+    res.write(`data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [{ index: 0, delta, finish_reason: finish }],
+    })}\n\n`);
+  };
+  const child = spawnClaude(args);
+  let streamedText = false;
+  let buf = '';
+  let done = false;
+  const timer = setTimeout(() => child.kill('SIGKILL'), TIMEOUT_MS);
+  const finish = (finishReasonValue) => {
+    if (done) return;
+    done = true;
+    clearTimeout(timer);
+    chunk({}, finishReasonValue);
+    res.write('data: [DONE]\n\n');
+    res.end();
+  };
+  chunk({ role: 'assistant' });
+  child.stdout.on('data', (d) => {
+    buf += d;
+    let nl;
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      let evt;
+      try { evt = JSON.parse(line); } catch { continue; }
+      const deltaText = evt?.event?.delta?.type === 'text_delta' ? evt.event.delta.text : null;
+      if (evt.type === 'stream_event' && deltaText) {
+        streamedText = true;
+        chunk({ content: deltaText });
+      } else if (evt.type === 'result') {
+        if (!streamedText && !evt.is_error && evt.result) chunk({ content: String(evt.result) });
+        finish(finishReason(evt.stop_reason));
+      }
+    }
+  });
+  child.on('close', () => finish('stop'));
+  child.on('error', (err) => {
+    console.error(`claude-code-shim: stream spawn failed: ${err.message}`);
+    finish('stop');
+  });
+  res.on('close', () => { clearTimeout(timer); child.kill('SIGKILL'); });
+  child.stdin.end(prompt);
+}
+
 async function handleChat(req, res) {
   let body;
   try {
@@ -147,6 +208,9 @@ async function handleChat(req, res) {
   }
   const model = mapModel(body.model);
   const { system, prompt } = splitMessages(messages);
+  if (body.stream === true) {
+    return streamChat(res, claudeArgs({ model, system, stream: true }), prompt, model);
+  }
   const args = claudeArgs({ model, system, stream: false });
   try {
     const result = await runClaude(args, prompt);

--- a/docker/claude-code-shim.mjs
+++ b/docker/claude-code-shim.mjs
@@ -22,9 +22,10 @@ if (!API_KEY) {
   process.exit(1);
 }
 
-const MAX_CONCURRENCY = Number(process.env.SHIM_MAX_CONCURRENCY ?? 2);
+const MAX_CONCURRENCY = Number(process.env.SHIM_MAX_CONCURRENCY ?? 4);
 const DAILY_CAP = Number(process.env.SHIM_DAILY_CAP ?? 300);
 const CACHE_TTL_MS = Number(process.env.SHIM_CACHE_TTL_MS ?? 900_000);
+const QUEUE_TIMEOUT_MS = Number(process.env.SHIM_QUEUE_TIMEOUT_MS ?? 15_000);
 
 const MODELS = ['haiku', 'sonnet', 'opus'];
 
@@ -40,15 +41,29 @@ const countCall = () => { capCount += 1; };
 
 let running = 0;
 const waiters = [];
-async function withSlot(fn) {
-  if (running >= MAX_CONCURRENCY) await new Promise((r) => waiters.push(r));
+// Callers (server/_shared/llm.ts) abort at ~25s. A request that cannot start
+// promptly must fail fast — otherwise it spawns claude after the caller has
+// already given up, burning subscription quota for a discarded result.
+class QueueTimeoutError extends Error {}
+async function withSlot(fn, { queueTimeoutMs = QUEUE_TIMEOUT_MS, isAbandoned = () => false } = {}) {
+  if (running >= MAX_CONCURRENCY) {
+    await new Promise((resolve, reject) => {
+      const waiter = { resolve, timer: setTimeout(() => {
+        const i = waiters.indexOf(waiter);
+        if (i >= 0) waiters.splice(i, 1);
+        reject(new QueueTimeoutError(`queue wait exceeded ${queueTimeoutMs}ms`));
+      }, queueTimeoutMs) };
+      waiters.push(waiter);
+    });
+  }
   running += 1;
   try {
+    if (isAbandoned()) throw new QueueTimeoutError('client disconnected while queued');
     return await fn();
   } finally {
     running -= 1;
     const next = waiters.shift();
-    if (next) next();
+    if (next) { clearTimeout(next.timer); next.resolve(); }
   }
 }
 
@@ -260,20 +275,30 @@ async function handleChat(req, res) {
   }
   const model = mapModel(body.model);
   const { system, prompt } = splitMessages(messages);
+  let clientGone = false;
+  res.on('close', () => { clientGone = !res.writableEnded; });
+  const slotOpts = { isAbandoned: () => clientGone };
   if (body.stream === true) {
     if (!underCap()) return sendJson(res, 429, { error: { message: 'daily cap reached' } });
-    countCall();
-    return withSlot(async () =>
-      streamChatAwaited(res, claudeArgs({ model, system, stream: true }), prompt, model));
+    return withSlot(async () => {
+      countCall();
+      return streamChatAwaited(res, claudeArgs({ model, system, stream: true }), prompt, model);
+    }, slotOpts).catch((err) => {
+      if (err instanceof QueueTimeoutError && !res.headersSent) {
+        sendJson(res, 503, { error: { message: `busy: ${err.message}` } });
+      }
+    });
   }
   const key = cacheKey(model, messages);
   const cached = cacheGet(key);
   if (cached) return sendJson(res, 200, { ...cached, id: `chatcmpl-${randomUUID()}` });
   if (!underCap()) return sendJson(res, 429, { error: { message: 'daily cap reached' } });
-  countCall();
   const args = claudeArgs({ model, system, stream: false });
   try {
-    const result = await withSlot(() => runClaude(args, prompt));
+    const result = await withSlot(() => {
+      countCall();
+      return runClaude(args, prompt);
+    }, slotOpts);
     const payload = {
       id: `chatcmpl-${randomUUID()}`,
       object: 'chat.completion',
@@ -289,6 +314,9 @@ async function handleChat(req, res) {
     cacheSet(key, payload);
     return sendJson(res, 200, payload);
   } catch (err) {
+    if (err instanceof QueueTimeoutError) {
+      return sendJson(res, 503, { error: { message: `busy: ${err.message}` } });
+    }
     console.error(`claude-code-shim: completion failed: ${err.message}`);
     return sendJson(res, 502, { error: { message: err.message } });
   }

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -411,7 +411,7 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
 
         // Per-fetch abort controller merges client signal + per-request timeout
         activeController = new AbortController();
-        const timeoutId = setTimeout(() => activeController?.abort(), applyTimeoutFloor(timeoutMs));
+        const timeoutId = setTimeout(() => activeController?.abort(), applyTimeoutFloor(providerName as LlmProviderName, timeoutMs));
         if (clientSignal?.aborted) { clearTimeout(timeoutId); break; }
         clientSignal?.addEventListener('abort', () => activeController?.abort(), { once: true });
 
@@ -522,14 +522,34 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
 }
 
 /**
- * Optional floor for per-attempt LLM timeouts (ms). Self-hosted backends
- * (Ollama on CPU, llama.cpp, the Claude Code shim) routinely need longer than
- * the 25s tuned for hosted APIs — callers pass hosted-sized timeouts, so a
- * floor (not a default) is the only knob that reaches every call site.
- * Unset/0 = no-op, hosted deployments unaffected.
+ * Optional floor for per-attempt LLM timeouts (ms), applied ONLY to
+ * self-hosted providers (`generic`/`ollama`). Self-hosted backends (Ollama on
+ * CPU, llama.cpp, the Claude Code shim) routinely need longer than the 25s
+ * tuned for hosted APIs; callers pass hosted-sized timeouts, so a floor is the
+ * only knob that reaches every call site. Scoped to self-hosted providers so it
+ * does NOT loosen the hosted DeepSeek dead-tail cut (#5246) or hosted callers'
+ * deliberately-short timeouts. Read at call time (matching the rest of this
+ * file's env handling); a non-numeric value warns once and is ignored.
+ * Unset/0 = no-op.
  */
-const LLM_MIN_TIMEOUT_MS = Number(process.env.LLM_MIN_TIMEOUT_MS ?? 0) || 0;
-const applyTimeoutFloor = (ms: number): number => Math.max(ms, LLM_MIN_TIMEOUT_MS);
+let warnedBadTimeoutFloor = false;
+function llmMinTimeoutMs(): number {
+  const raw = process.env.LLM_MIN_TIMEOUT_MS;
+  if (!raw) return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    if (!warnedBadTimeoutFloor) {
+      warnedBadTimeoutFloor = true;
+      console.warn(`[llm] ignoring non-numeric LLM_MIN_TIMEOUT_MS=${JSON.stringify(raw)}`);
+    }
+    return 0;
+  }
+  return n;
+}
+const SELF_HOSTED_PROVIDERS = new Set(['generic', 'ollama']);
+export function applyTimeoutFloor(provider: LlmProviderName, ms: number): number {
+  return SELF_HOSTED_PROVIDERS.has(provider) ? Math.max(ms, llmMinTimeoutMs()) : ms;
+}
 
 export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | null> {
   const {
@@ -616,7 +636,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
           // #5246: DeepSeek V4 Flash is bimodal — healthy calls finish near 2s,
           // while stalled calls hang to the old 25s clamp. Cut only this model's
           // dead tail so the existing provider chain can reach its fallback.
-          signal: AbortSignal.timeout(applyTimeoutFloor(getLlmAttemptTimeoutMs(creds.model, timeoutMs))),
+          signal: AbortSignal.timeout(applyTimeoutFloor(providerName as LlmProviderName, getLlmAttemptTimeoutMs(creds.model, timeoutMs))),
         });
 
         if (!resp.ok) {

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -411,7 +411,7 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
 
         // Per-fetch abort controller merges client signal + per-request timeout
         activeController = new AbortController();
-        const timeoutId = setTimeout(() => activeController?.abort(), timeoutMs);
+        const timeoutId = setTimeout(() => activeController?.abort(), applyTimeoutFloor(timeoutMs));
         if (clientSignal?.aborted) { clearTimeout(timeoutId); break; }
         clientSignal?.addEventListener('abort', () => activeController?.abort(), { once: true });
 
@@ -521,6 +521,16 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
   });
 }
 
+/**
+ * Optional floor for per-attempt LLM timeouts (ms). Self-hosted backends
+ * (Ollama on CPU, llama.cpp, the Claude Code shim) routinely need longer than
+ * the 25s tuned for hosted APIs — callers pass hosted-sized timeouts, so a
+ * floor (not a default) is the only knob that reaches every call site.
+ * Unset/0 = no-op, hosted deployments unaffected.
+ */
+const LLM_MIN_TIMEOUT_MS = Number(process.env.LLM_MIN_TIMEOUT_MS ?? 0) || 0;
+const applyTimeoutFloor = (ms: number): number => Math.max(ms, LLM_MIN_TIMEOUT_MS);
+
 export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | null> {
   const {
     messages: rawMessages,
@@ -606,7 +616,7 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
           // #5246: DeepSeek V4 Flash is bimodal — healthy calls finish near 2s,
           // while stalled calls hang to the old 25s clamp. Cut only this model's
           // dead tail so the existing provider chain can reach its fallback.
-          signal: AbortSignal.timeout(getLlmAttemptTimeoutMs(creds.model, timeoutMs)),
+          signal: AbortSignal.timeout(applyTimeoutFloor(getLlmAttemptTimeoutMs(creds.model, timeoutMs))),
         });
 
         if (!resp.ok) {

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1846,6 +1846,25 @@ export async function createLocalApiServer(options = {}) {
           );
         }
       }
+      // Docker self-host ONLY: the same containment rationale as the Redis
+      // proxy above applies to the self-hosted LLM endpoint. SELF_HOSTING.md
+      // documents LLM_API_URL/OLLAMA_API_URL pointing at a compose-network or
+      // LAN host (Ollama, vLLM, the Claude Code shim), which the SSRF guard
+      // would otherwise block — llm-health then marks the provider offline and
+      // every AI feature silently skips it.
+      if (context.mode === 'docker') {
+        for (const envKey of ['LLM_API_URL', 'OLLAMA_API_URL']) {
+          const raw = process.env[envKey];
+          if (!raw) continue;
+          try {
+            extraAllowedPrivateOrigins.push(new URL(raw).origin);
+          } catch (err) {
+            context.logger.warn(
+              `[local-api] ${envKey} is not a valid URL; not added to the private-fetch allowlist (LLM calls will be SSRF-blocked): ${err.message}`,
+            );
+          }
+        }
+      }
       if (context.allowPrivateRemoteBase) {
         try { extraAllowedPrivateOrigins.push(new URL(context.remoteBase).origin); } catch {}
       }

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -766,71 +766,91 @@ test('allows only Docker mode to fetch configured private Redis REST origin', as
   }
 });
 
-test('allows only Docker mode to fetch configured private LLM origin', async () => {
-  const originalLlmUrl = process.env.LLM_API_URL;
-  let upstreamHits = 0;
+// Parametrized over both self-hosted LLM env keys the docker allowlist covers,
+// so a typo in either branch (or a regression in the invalid-URL warn path)
+// fails the suite. Uses a localhost HOSTNAME origin (not a bare IP literal) to
+// match the documented http://claude-shim:8383 production shape, which resolves
+// through the real DNS lookup path in the allowlist.
+for (const envKey of ['LLM_API_URL', 'OLLAMA_API_URL']) {
+  test(`docker mode fetches the configured ${envKey} origin AND still blocks a non-allowlisted private origin`, async () => {
+    const original = process.env[envKey];
+    let allowedHits = 0;
+    let blockedHits = 0;
 
-  const upstream = createServer((_req, res) => {
-    upstreamHits += 1;
-    res.writeHead(200, { 'content-type': 'application/json' });
-    res.end(JSON.stringify({ ok: true }));
-  });
-  const upstreamPort = await listen(upstream);
+    const allowedUpstream = createServer((_req, res) => {
+      allowedHits += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    // A SECOND private origin that is NOT placed in any allowlist env — docker
+    // mode must still block it, proving the allowlist is scoped to exactly the
+    // configured origins and does not disable the SSRF guard wholesale.
+    const blockedUpstream = createServer((_req, res) => {
+      blockedHits += 1;
+      res.writeHead(200);
+      res.end('should-never-be-reached');
+    });
+    const allowedPort = await listen(allowedUpstream);
+    const blockedPort = await listen(blockedUpstream);
 
-  const localApi = await setupApiDir({
-    'llm-probe.js': `
-      export default async function handler() {
-        const upstream = await fetch(process.env.LLM_API_URL);
-        const payload = await upstream.text();
-        return new Response(payload, {
-          status: upstream.status,
-          headers: { 'content-type': 'application/json' },
-        });
+    const localApi = await setupApiDir({
+      'llm-probe.js': `
+        export default async function handler(request) {
+          const target = new URL(request.url).searchParams.get('target');
+          const url = target === 'blocked'
+            ? 'http://localhost:${blockedPort}/'
+            : process.env.${envKey};
+          const upstream = await fetch(url);
+          const payload = await upstream.text();
+          return new Response(payload, { status: upstream.status });
+        }
+      `,
+    });
+
+    async function runProbe(mode, target) {
+      const app = await createLocalApiServer({
+        port: 0,
+        apiDir: localApi.apiDir,
+        mode,
+        logger: { log() { }, warn() { }, error() { } },
+      });
+      const { port } = await app.start();
+      try {
+        const q = target ? `?target=${target}` : '';
+        return await authFetch(`http://127.0.0.1:${port}/api/llm-probe${q}`);
+      } finally {
+        await app.close();
       }
-    `,
-  });
-
-  async function runProbe(mode) {
-    const app = await createLocalApiServer({
-      port: 0,
-      apiDir: localApi.apiDir,
-      mode,
-      logger: { log() { }, warn() { }, error() { } },
-    });
-    const { port } = await app.start();
-    try {
-      return await authFetch(`http://127.0.0.1:${port}/api/llm-probe`);
-    } finally {
-      await app.close();
     }
-  }
 
-  process.env.LLM_API_URL = `http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+    process.env[envKey] = `http://localhost:${allowedPort}/v1/chat/completions`;
 
-  try {
-    const dockerResponse = await runProbe('docker');
-    assert.equal(dockerResponse.status, 200);
-    assert.deepEqual(await dockerResponse.json(), { ok: true });
-    // No exact hit-count assertions: server boot warms the llm-health cache
-    // with its own (unguarded, server-internal) probe of the LLM origin in
-    // both modes. The handler responses below carry the security semantics —
-    // the guarded handler fetch succeeds only in docker mode.
-    assert.ok(upstreamHits >= 1, `expected upstream hits, got ${upstreamHits}`);
+    try {
+      // Allow side: docker reaches the configured origin.
+      const dockerAllowed = await runProbe('docker', 'allowed');
+      assert.equal(dockerAllowed.status, 200);
+      assert.deepEqual(await dockerAllowed.json(), { ok: true });
+      assert.ok(allowedHits >= 1, `expected allowed hits, got ${allowedHits}`);
 
-    const desktopResponse = await runProbe('desktop-sidecar');
-    assert.equal(desktopResponse.status, 502);
-    const desktopBody = await desktopResponse.json();
-    assert.equal(desktopBody.error, 'Local handler error');
-    assert.match(desktopBody.reason, /SSRF blocked/);
-  } finally {
-    if (originalLlmUrl === undefined) delete process.env.LLM_API_URL;
-    else process.env.LLM_API_URL = originalLlmUrl;
-    await localApi.cleanup();
-    await new Promise((resolve, reject) => {
-      upstream.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
-});
+      // Block side (scoping): docker still blocks a non-allowlisted origin.
+      const dockerBlocked = await runProbe('docker', 'blocked');
+      assert.equal(dockerBlocked.status, 502);
+      assert.match((await dockerBlocked.json()).reason, /SSRF blocked/);
+      assert.equal(blockedHits, 0, 'non-allowlisted origin must never be reached');
+
+      // Desktop mode blocks even the configured origin.
+      const desktopBlocked = await runProbe('desktop-sidecar', 'allowed');
+      assert.equal(desktopBlocked.status, 502);
+      assert.match((await desktopBlocked.json()).reason, /SSRF blocked/);
+    } finally {
+      if (original === undefined) delete process.env[envKey];
+      else process.env[envKey] = original;
+      await localApi.cleanup();
+      await new Promise((resolve, reject) => allowedUpstream.close((e) => (e ? reject(e) : resolve())));
+      await new Promise((resolve, reject) => blockedUpstream.close((e) => (e ? reject(e) : resolve())));
+    }
+  });
+}
 
 test('blocks handler global fetches to non-global IPv4 special ranges', async () => {
   const originalHttpRequest = http.request;

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -766,6 +766,72 @@ test('allows only Docker mode to fetch configured private Redis REST origin', as
   }
 });
 
+test('allows only Docker mode to fetch configured private LLM origin', async () => {
+  const originalLlmUrl = process.env.LLM_API_URL;
+  let upstreamHits = 0;
+
+  const upstream = createServer((_req, res) => {
+    upstreamHits += 1;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+
+  const localApi = await setupApiDir({
+    'llm-probe.js': `
+      export default async function handler() {
+        const upstream = await fetch(process.env.LLM_API_URL);
+        const payload = await upstream.text();
+        return new Response(payload, {
+          status: upstream.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  async function runProbe(mode) {
+    const app = await createLocalApiServer({
+      port: 0,
+      apiDir: localApi.apiDir,
+      mode,
+      logger: { log() { }, warn() { }, error() { } },
+    });
+    const { port } = await app.start();
+    try {
+      return await authFetch(`http://127.0.0.1:${port}/api/llm-probe`);
+    } finally {
+      await app.close();
+    }
+  }
+
+  process.env.LLM_API_URL = `http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+
+  try {
+    const dockerResponse = await runProbe('docker');
+    assert.equal(dockerResponse.status, 200);
+    assert.deepEqual(await dockerResponse.json(), { ok: true });
+    // No exact hit-count assertions: server boot warms the llm-health cache
+    // with its own (unguarded, server-internal) probe of the LLM origin in
+    // both modes. The handler responses below carry the security semantics —
+    // the guarded handler fetch succeeds only in docker mode.
+    assert.ok(upstreamHits >= 1, `expected upstream hits, got ${upstreamHits}`);
+
+    const desktopResponse = await runProbe('desktop-sidecar');
+    assert.equal(desktopResponse.status, 502);
+    const desktopBody = await desktopResponse.json();
+    assert.equal(desktopBody.error, 'Local handler error');
+    assert.match(desktopBody.reason, /SSRF blocked/);
+  } finally {
+    if (originalLlmUrl === undefined) delete process.env.LLM_API_URL;
+    else process.env.LLM_API_URL = originalLlmUrl;
+    await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test('blocks handler global fetches to non-global IPv4 special ranges', async () => {
   const originalHttpRequest = http.request;
   const blockedUrls = [

--- a/tests/claude-code-shim.test.mjs
+++ b/tests/claude-code-shim.test.mjs
@@ -148,3 +148,20 @@ test('concurrency limit serializes claude invocations', async (t) => {
   assert.equal(b.status, 200);
   assert.ok(elapsed >= 550, `expected serialized execution, took ${elapsed}ms`);
 });
+
+test('queued requests past the queue deadline fail fast without spawning', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, {
+    STUB_LOG: log,
+    SHIM_MAX_CONCURRENCY: '1',
+    STUB_SLEEP_MS: '800',
+    SHIM_QUEUE_TIMEOUT_MS: '200',
+  });
+  const mk = (s) => chat(base, { model: 'claude-haiku', messages: [{ role: 'user', content: s }] });
+  const [a, b] = await Promise.all([mk('runs'), mk('rejected')]);
+  assert.equal(a.status, 200);
+  assert.equal(b.status, 503);
+  const j = await b.json();
+  assert.match(j.error.message, /queue/i);
+  assert.equal(readLog(log).length, 1); // second request never spawned claude
+});

--- a/tests/claude-code-shim.test.mjs
+++ b/tests/claude-code-shim.test.mjs
@@ -1,0 +1,95 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { startShim } from './helpers/shim-harness.mjs';
+
+const logDir = () => mkdtempSync(path.join(tmpdir(), 'shim-test-'));
+const readLog = (file) =>
+  readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+
+async function chat(base, body, headers = {}) {
+  return fetch(`${base}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer test-key', 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+test('health endpoint responds without auth', async (t) => {
+  const { base } = await startShim(t);
+  const r = await fetch(`${base}/`);
+  assert.equal(r.status, 200);
+  const j = await r.json();
+  assert.equal(j.ok, true);
+});
+
+test('models endpoint lists claude tiers', async (t) => {
+  const { base } = await startShim(t);
+  const r = await fetch(`${base}/v1/models`, { headers: { authorization: 'Bearer test-key' } });
+  assert.equal(r.status, 200);
+  const j = await r.json();
+  assert.deepEqual(j.data.map((m) => m.id).sort(), ['haiku', 'opus', 'sonnet']);
+});
+
+test('rejects missing or wrong bearer', async (t) => {
+  const { base } = await startShim(t);
+  const noAuth = await fetch(`${base}/v1/chat/completions`, { method: 'POST', body: '{}' });
+  assert.equal(noAuth.status, 401);
+  const wrong = await chat(base, { messages: [] }, { authorization: 'Bearer nope' });
+  assert.equal(wrong.status, 401);
+});
+
+test('non-stream completion maps CLI json to OpenAI shape', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, { STUB_LOG: log });
+  const r = await chat(base, {
+    model: 'claude-haiku',
+    messages: [
+      { role: 'system', content: 'You are terse.' },
+      { role: 'user', content: 'ping' },
+    ],
+  });
+  assert.equal(r.status, 200);
+  const j = await r.json();
+  assert.equal(j.object, 'chat.completion');
+  assert.equal(j.choices[0].message.role, 'assistant');
+  assert.equal(j.choices[0].message.content, 'STUB_RESPONSE');
+  assert.equal(j.choices[0].finish_reason, 'stop');
+  assert.equal(j.usage.prompt_tokens, 35); // 10 input + 5 cache_creation + 20 cache_read
+  assert.equal(j.usage.completion_tokens, 7);
+  assert.equal(j.usage.total_tokens, 42);
+
+  const [call] = readLog(log);
+  const modelIdx = call.argv.indexOf('--model');
+  assert.equal(call.argv[modelIdx + 1], 'haiku');
+  const sysIdx = call.argv.indexOf('--system-prompt');
+  assert.equal(call.argv[sysIdx + 1], 'You are terse.');
+  assert.ok(call.argv.includes('--max-turns'));
+  assert.match(call.stdin, /ping/);
+});
+
+test('unknown model falls back to default; multi-turn flattens to transcript', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, { STUB_LOG: log, CLAUDE_SHIM_DEFAULT_MODEL: 'sonnet' });
+  const r = await chat(base, {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'reply' },
+      { role: 'user', content: 'second' },
+    ],
+  });
+  assert.equal(r.status, 200);
+  const [call] = readLog(log);
+  assert.equal(call.argv[call.argv.indexOf('--model') + 1], 'sonnet');
+  assert.match(call.stdin, /User: first[\s\S]*Assistant: reply[\s\S]*User: second/);
+});
+
+test('length stop reason maps to finish_reason length', async (t) => {
+  const { base } = await startShim(t, { STUB_STOP_REASON: 'max_tokens' });
+  const r = await chat(base, { model: 'claude-haiku', messages: [{ role: 'user', content: 'x' }] });
+  const j = await r.json();
+  assert.equal(j.choices[0].finish_reason, 'length');
+});

--- a/tests/claude-code-shim.test.mjs
+++ b/tests/claude-code-shim.test.mjs
@@ -116,3 +116,35 @@ test('stream:true emits SSE deltas and [DONE]', async (t) => {
   const [call] = readLog(log);
   assert.ok(call.argv.includes('stream-json'));
 });
+
+test('daily cap returns 429 once exceeded', async (t) => {
+  const { base } = await startShim(t, { SHIM_DAILY_CAP: '1' });
+  const body = { model: 'claude-haiku', messages: [{ role: 'user', content: 'one' }] };
+  assert.equal((await chat(base, body)).status, 200);
+  const second = await chat(base, { ...body, messages: [{ role: 'user', content: 'two' }] });
+  assert.equal(second.status, 429);
+  const health = await (await fetch(`${base}/`)).json();
+  assert.equal(health.today, 1);
+  assert.equal(health.cap, 1);
+});
+
+test('identical non-stream requests are served from cache', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, { STUB_LOG: log });
+  const body = { model: 'claude-haiku', messages: [{ role: 'user', content: 'cached?' }] };
+  const a = await (await chat(base, body)).json();
+  const b = await (await chat(base, body)).json();
+  assert.equal(a.choices[0].message.content, b.choices[0].message.content);
+  assert.equal(readLog(log).length, 1);
+});
+
+test('concurrency limit serializes claude invocations', async (t) => {
+  const { base } = await startShim(t, { SHIM_MAX_CONCURRENCY: '1', STUB_SLEEP_MS: '300' });
+  const mk = (s) => chat(base, { model: 'claude-haiku', messages: [{ role: 'user', content: s }] });
+  const t0 = Date.now();
+  const [a, b] = await Promise.all([mk('p1'), mk('p2')]);
+  const elapsed = Date.now() - t0;
+  assert.equal(a.status, 200);
+  assert.equal(b.status, 200);
+  assert.ok(elapsed >= 550, `expected serialized execution, took ${elapsed}ms`);
+});

--- a/tests/claude-code-shim.test.mjs
+++ b/tests/claude-code-shim.test.mjs
@@ -165,3 +165,112 @@ test('queued requests past the queue deadline fail fast without spawning', async
   assert.match(j.error.message, /queue/i);
   assert.equal(readLog(log).length, 1); // second request never spawned claude
 });
+
+// --- Failure-path coverage (added after the adversarial review flagged that a
+// truncated stream was delivered as a complete success).
+
+async function collectStream(base, body) {
+  const res = await fetch(`${base}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer test-key', 'content-type': 'application/json' },
+    body: JSON.stringify({ ...body, stream: true }),
+  });
+  let text = '';
+  let threw = false;
+  try {
+    for await (const chunk of res.body) text += Buffer.from(chunk).toString('utf8');
+  } catch { threw = true; }
+  return { status: res.status, text, threw };
+}
+
+test('non-stream: is_error result returns 502 with a generic message and no stderr leak', async (t) => {
+  const { base } = await startShim(t, { STUB_MODE: 'error' });
+  const r = await chat(base, { model: 'claude-haiku', messages: [{ role: 'user', content: 'x' }] });
+  assert.equal(r.status, 502);
+  const j = await r.json();
+  assert.doesNotMatch(j.error.message, /stubbed claude error/); // detail stays server-side
+});
+
+test('non-stream: unparseable output returns 502, not a fake 200', async (t) => {
+  const { base } = await startShim(t, { STUB_MODE: 'garbage' });
+  const r = await chat(base, { model: 'claude-haiku', messages: [{ role: 'user', content: 'x' }] });
+  assert.equal(r.status, 502);
+});
+
+test('non-stream: is_error result is NOT cached', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, { STUB_MODE: 'error', STUB_LOG: log });
+  const body = { model: 'claude-haiku', messages: [{ role: 'user', content: 'same' }] };
+  assert.equal((await chat(base, body)).status, 502);
+  assert.equal((await chat(base, body)).status, 502);
+  assert.equal(readLog(log).length, 2); // both spawned — no poisoned cache entry
+});
+
+test('stream: child crash after partial deltas does NOT end with a clean [DONE]', async (t) => {
+  const { base } = await startShim(t, { STUB_MODE: 'crash' });
+  const { text, threw } = await collectStream(base, {
+    model: 'claude-sonnet', messages: [{ role: 'user', content: 'x' }],
+  });
+  // The partial text may arrive, but the stream must be severed — never a
+  // finish_reason:"stop" + [DONE] that the consumer would treat as complete.
+  assert.ok(threw || !text.includes('[DONE]'),
+    `truncated stream must not deliver [DONE]; got: ${text.slice(-120)}`);
+  assert.doesNotMatch(text, /"finish_reason":"stop"/);
+});
+
+test('stream: timeout SIGKILL severs the connection, no synthetic stop', async (t) => {
+  const { base } = await startShim(t, { STUB_MODE: 'hang', SHIM_TIMEOUT_MS: '400' });
+  const { text, threw } = await collectStream(base, {
+    model: 'claude-sonnet', messages: [{ role: 'user', content: 'x' }],
+  });
+  assert.ok(threw || !text.includes('[DONE]'), 'hung stream must not deliver [DONE]');
+});
+
+test('stream: is_error result severs instead of completing', async (t) => {
+  const { base } = await startShim(t, { STUB_MODE: 'error' });
+  const { text, threw } = await collectStream(base, {
+    model: 'claude-sonnet', messages: [{ role: 'user', content: 'x' }],
+  });
+  assert.ok(threw || !text.includes('[DONE]'), 'errored stream must not deliver [DONE]');
+});
+
+test('the spawned CLI does not inherit SHIM_API_KEY', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, { STUB_LOG: log });
+  await chat(base, { model: 'claude-haiku', messages: [{ role: 'user', content: 'x' }] });
+  const [call] = readLog(log);
+  assert.equal(call.sawShimKey, false);
+});
+
+test('unsupported role and prefill continuation are rejected with 400', async (t) => {
+  const { base } = await startShim(t);
+  const toolRole = await chat(base, { model: 'claude-haiku', messages: [{ role: 'tool', content: 'x' }] });
+  assert.equal(toolRole.status, 400);
+  const prefill = await chat(base, { model: 'claude-haiku', messages: [
+    { role: 'user', content: 'hi' }, { role: 'assistant', content: 'partial' },
+  ] });
+  assert.equal(prefill.status, 400);
+  const systemOnly = await chat(base, { model: 'claude-haiku', messages: [{ role: 'system', content: 'x' }] });
+  assert.equal(systemOnly.status, 400);
+});
+
+test('oversized body returns 413, not a connection reset', async (t) => {
+  const { base } = await startShim(t);
+  const big = 'x'.repeat(1_100_000);
+  const r = await fetch(`${base}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer test-key', 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'claude-haiku', messages: [{ role: 'user', content: big }] }),
+  });
+  assert.equal(r.status, 413);
+});
+
+test('cache hit re-stamps created', async (t) => {
+  const { base } = await startShim(t);
+  const body = { model: 'claude-haiku', messages: [{ role: 'user', content: 'ts' }] };
+  const a = await (await chat(base, body)).json();
+  await new Promise((r) => setTimeout(r, 1100));
+  const b = await (await chat(base, body)).json();
+  assert.notEqual(a.id, b.id);
+  assert.ok(b.created >= a.created);
+});

--- a/tests/claude-code-shim.test.mjs
+++ b/tests/claude-code-shim.test.mjs
@@ -93,3 +93,26 @@ test('length stop reason maps to finish_reason length', async (t) => {
   const j = await r.json();
   assert.equal(j.choices[0].finish_reason, 'length');
 });
+
+test('stream:true emits SSE deltas and [DONE]', async (t) => {
+  const log = path.join(logDir(), 'calls.jsonl');
+  const { base } = await startShim(t, { STUB_LOG: log });
+  const r = await chat(base, {
+    model: 'claude-sonnet',
+    stream: true,
+    messages: [{ role: 'user', content: 'stream please' }],
+  });
+  assert.equal(r.status, 200);
+  assert.match(r.headers.get('content-type'), /text\/event-stream/);
+  const raw = await r.text();
+  const datas = raw.split('\n\n').filter(Boolean)
+    .map((b) => b.replace(/^data: /, '').trim()).filter(Boolean);
+  assert.equal(datas[datas.length - 1], '[DONE]');
+  const parsed = datas.slice(0, -1).map((d) => JSON.parse(d));
+  const text = parsed.map((p) => p.choices?.[0]?.delta?.content || '').join('');
+  assert.equal(text, 'STUB STREAM');
+  const last = parsed[parsed.length - 1];
+  assert.equal(last.choices[0].finish_reason, 'stop');
+  const [call] = readLog(log);
+  assert.ok(call.argv.includes('stream-json'));
+});

--- a/tests/fixtures/claude-stub.mjs
+++ b/tests/fixtures/claude-stub.mjs
@@ -1,6 +1,7 @@
 // Fake `claude` CLI for shim tests. Records each invocation (argv + stdin) to
 // STUB_LOG as JSON lines, then prints either a `--output-format json` result or
 // `stream-json` events, mirroring the real headless Claude Code output shapes.
+// STUB_MODE drives failure paths: error | crash | hang | garbage.
 import { appendFileSync } from 'node:fs';
 
 const argv = process.argv.slice(2);
@@ -8,9 +9,11 @@ let stdin = '';
 for await (const chunk of process.stdin) stdin += chunk;
 
 if (process.env.STUB_LOG) {
-  appendFileSync(process.env.STUB_LOG, JSON.stringify({ argv, stdin }) + '\n');
+  appendFileSync(process.env.STUB_LOG, JSON.stringify({ argv, stdin, sawShimKey: !!process.env.SHIM_API_KEY }) + '\n');
 }
 
+const mode = process.env.STUB_MODE || 'ok';
+const streaming = argv.includes('stream-json');
 const sleepMs = Number(process.env.STUB_SLEEP_MS || 0);
 if (sleepMs) await new Promise((r) => setTimeout(r, sleepMs));
 
@@ -21,14 +24,30 @@ const usage = {
   output_tokens: 7,
 };
 
-if (argv.includes('stream-json')) {
+if (mode === 'hang') {
+  // Never emit a result — the shim's SHIM_TIMEOUT_MS must SIGKILL us.
+  await new Promise(() => {});
+} else if (mode === 'garbage') {
+  process.stdout.write('this is not json\n');
+  process.exit(0);
+} else if (mode === 'crash') {
+  // Emit partial output (streaming: real text deltas) then die with no result.
+  if (streaming) {
+    process.stdout.write(JSON.stringify({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'PARTIAL ' } } }) + '\n');
+    process.stdout.write(JSON.stringify({ type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'TEXT' } } }) + '\n');
+  } else {
+    process.stdout.write('partial non-final line\n');
+  }
+  process.exit(1);
+} else if (mode === 'error') {
+  const err = { type: 'result', subtype: 'error', is_error: true, result: 'stubbed claude error', stop_reason: 'error', usage };
+  process.stdout.write(JSON.stringify(err) + '\n');
+  process.exit(0);
+} else if (streaming) {
   const events = [
     { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'STUB ' } } },
     { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'STREAM' } } },
-    {
-      type: 'result', subtype: 'success', is_error: false,
-      result: 'STUB STREAM', stop_reason: 'end_turn', usage,
-    },
+    { type: 'result', subtype: 'success', is_error: false, result: 'STUB STREAM', stop_reason: 'end_turn', usage },
   ];
   for (const e of events) process.stdout.write(JSON.stringify(e) + '\n');
 } else {

--- a/tests/fixtures/claude-stub.mjs
+++ b/tests/fixtures/claude-stub.mjs
@@ -1,0 +1,41 @@
+// Fake `claude` CLI for shim tests. Records each invocation (argv + stdin) to
+// STUB_LOG as JSON lines, then prints either a `--output-format json` result or
+// `stream-json` events, mirroring the real headless Claude Code output shapes.
+import { appendFileSync } from 'node:fs';
+
+const argv = process.argv.slice(2);
+let stdin = '';
+for await (const chunk of process.stdin) stdin += chunk;
+
+if (process.env.STUB_LOG) {
+  appendFileSync(process.env.STUB_LOG, JSON.stringify({ argv, stdin }) + '\n');
+}
+
+const sleepMs = Number(process.env.STUB_SLEEP_MS || 0);
+if (sleepMs) await new Promise((r) => setTimeout(r, sleepMs));
+
+const usage = {
+  input_tokens: 10,
+  cache_creation_input_tokens: 5,
+  cache_read_input_tokens: 20,
+  output_tokens: 7,
+};
+
+if (argv.includes('stream-json')) {
+  const events = [
+    { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'STUB ' } } },
+    { type: 'stream_event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'STREAM' } } },
+    {
+      type: 'result', subtype: 'success', is_error: false,
+      result: 'STUB STREAM', stop_reason: 'end_turn', usage,
+    },
+  ];
+  for (const e of events) process.stdout.write(JSON.stringify(e) + '\n');
+} else {
+  process.stdout.write(JSON.stringify({
+    type: 'result', subtype: 'success', is_error: false,
+    result: process.env.STUB_RESPONSE || 'STUB_RESPONSE',
+    stop_reason: process.env.STUB_STOP_REASON || 'end_turn',
+    usage,
+  }) + '\n');
+}

--- a/tests/helpers/shim-harness.mjs
+++ b/tests/helpers/shim-harness.mjs
@@ -28,7 +28,7 @@ export async function startShim(t, env = {}) {
     const timer = setTimeout(() => reject(new Error(`shim did not start: ${stderr}`)), 10_000);
     child.stdout.on('data', (d) => {
       buf += d;
-      const m = buf.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/);
+      const m = buf.match(/listening on http:\/\/[^:]+:(\d+)/);
       if (m) { clearTimeout(timer); resolve(`http://127.0.0.1:${m[1]}`); }
     });
     child.on('exit', (code) => { clearTimeout(timer); reject(new Error(`shim exited ${code}: ${stderr}`)); });

--- a/tests/helpers/shim-harness.mjs
+++ b/tests/helpers/shim-harness.mjs
@@ -1,0 +1,45 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SHIM = path.join(ROOT, 'docker', 'claude-code-shim.mjs');
+export const STUB = path.join(ROOT, 'tests', 'fixtures', 'claude-stub.mjs');
+
+/**
+ * Boot the shim on an ephemeral port with the fake `claude` CLI.
+ * Returns { base, stop, child }. Registers cleanup on the test context.
+ */
+export async function startShim(t, env = {}) {
+  const child = spawn(process.execPath, [SHIM], {
+    env: {
+      ...process.env,
+      PORT: '0',
+      SHIM_API_KEY: 'test-key',
+      CLAUDE_BIN: STUB,
+      ...env,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr.on('data', (d) => { stderr += d; });
+  const base = await new Promise((resolve, reject) => {
+    let buf = '';
+    const timer = setTimeout(() => reject(new Error(`shim did not start: ${stderr}`)), 10_000);
+    child.stdout.on('data', (d) => {
+      buf += d;
+      const m = buf.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/);
+      if (m) { clearTimeout(timer); resolve(`http://127.0.0.1:${m[1]}`); }
+    });
+    child.on('exit', (code) => { clearTimeout(timer); reject(new Error(`shim exited ${code}: ${stderr}`)); });
+  });
+  let stopped = false;
+  const stop = () => new Promise((resolve) => {
+    if (stopped) return resolve();
+    stopped = true;
+    child.on('exit', resolve);
+    child.kill();
+  });
+  if (t) t.after(stop);
+  return { base, stop, child };
+}

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
-import { callLlm, callLlmReasoning, getLlmAttemptTimeoutMs } from '../server/_shared/llm.ts';
+import { callLlm, callLlmReasoning, getLlmAttemptTimeoutMs, applyTimeoutFloor } from '../server/_shared/llm.ts';
 
 const originalFetch = globalThis.fetch;
 const originalAbortSignalTimeout = AbortSignal.timeout;
@@ -45,6 +45,28 @@ describe('callLlm', () => {
     assert.equal(getLlmAttemptTimeoutMs('deepseek/deepseek-v4-flash', 8_000), 8_000);
     assert.equal(getLlmAttemptTimeoutMs('deepseek/deepseek-v4-pro', 25_000), 25_000);
     assert.equal(getLlmAttemptTimeoutMs('google/gemini-2.5-flash', 25_000), 25_000);
+  });
+
+  it('LLM_MIN_TIMEOUT_MS floors only self-hosted providers, preserving the hosted Flash cut', () => {
+    const prev = process.env.LLM_MIN_TIMEOUT_MS;
+    try {
+      process.env.LLM_MIN_TIMEOUT_MS = '60000';
+      // Self-hosted backends get the floor…
+      assert.equal(applyTimeoutFloor('generic', 25_000), 60_000);
+      assert.equal(applyTimeoutFloor('ollama', 25_000), 60_000);
+      // …hosted providers do NOT (the #5246 DeepSeek 15s dead-tail cut survives).
+      assert.equal(applyTimeoutFloor('openrouter', 15_000), 15_000);
+      assert.equal(applyTimeoutFloor('groq', 8_000), 8_000);
+      // Unset = no-op everywhere.
+      delete process.env.LLM_MIN_TIMEOUT_MS;
+      assert.equal(applyTimeoutFloor('generic', 25_000), 25_000);
+      // Non-numeric = ignored (no throw, treated as unset).
+      process.env.LLM_MIN_TIMEOUT_MS = '60s';
+      assert.equal(applyTimeoutFloor('generic', 25_000), 25_000);
+    } finally {
+      if (prev === undefined) delete process.env.LLM_MIN_TIMEOUT_MS;
+      else process.env.LLM_MIN_TIMEOUT_MS = prev;
+    }
   });
 
   it('wires the DeepSeek Flash deadline into the shared chat-completion request', async () => {


### PR DESCRIPTION
## Summary

This adds an optional, bundled way for self-hosters to power World Monitor's AI
features with a **Claude Pro/Max subscription** instead of a metered API key —
by pointing the existing `generic` LLM provider at a small shim that wraps
headless Claude Code (`claude -p`).

The shim (`docker/claude-code-shim.mjs`) is a **zero-dependency Node service**
(same style as `docker/redis-rest-proxy.mjs`) that speaks OpenAI
`/v1/chat/completions` — both non-streaming and SSE streaming — and executes
`claude -p` under the hood, authenticated with a `claude setup-token` OAuth
token. **No application code was changed to consume it:** it plugs straight into
`LLM_API_URL` / `LLM_API_KEY` / `LLM_MODEL`, exactly as `SELF_HOSTING.md` already
documents for Ollama / vLLM.

While standing the stack up from a clean clone I also hit — and fixed — six
independent self-hosting papercuts (each in its own commit); details below.

## What the shim does

- **OpenAI-compatible** `/v1/chat/completions` (stream + non-stream), `/v1/models`, and a `GET /` health/observability endpoint.
- **Model mapping:** request models containing `haiku` / `sonnet` / `opus` map to those Claude tiers; anything else falls back to `CLAUDE_SHIM_DEFAULT_MODEL`.
- **Minimal per-call context:** `--setting-sources '' --tools ''` plus a replaced `--system-prompt` strip Claude Code's session context, so a request costs little more than its own prompt.
- **Subscription protections:** daily call cap (429 past `SHIM_DAILY_CAP`), concurrency limit, response cache, and a queue-wait deadline that fast-fails requests the caller has already abandoned rather than spending quota on a discarded result.
- Ships `Dockerfile.claude-shim` (node:22-alpine, non-root, healthcheck) and a documented, opt-in `docker-compose.override.yml` example. **Off by default — nothing changes for existing deployments.**
- **21 tests** (`tests/claude-code-shim.test.mjs`) against a stubbed CLI, including full failure-path coverage (crash mid-stream, timeout, `is_error`, oversized body, role validation). They run inside the existing `test:data` glob with no new dependencies.

## Self-hosting fixes included (each independent of the shim)

1. **`docker-compose.override.yml` was never gitignored**, although `SELF_HOSTING.md` documents it as *the* place to put API keys — one `git add -A` from committing secrets.
2. **CRLF checkouts build broken images:** `docker/entrypoint.sh` copied in with CRLF crash-loops the app container (`/app/entrypoint.sh: not found`). Added `.gitattributes` pinning LF for `*.sh` / `*.mjs` / `*.cjs` (with a `-text` carve-out for the one NUL-containing generated file).
3. **The sidecar SSRF guard blocked every private LLM origin.** Docker mode only allowlisted the Redis REST proxy, so the documented compose-network `LLM_API_URL` / `OLLAMA_API_URL` was marked offline by llm-health and every AI feature silently fell back. Extended the docker-only allowlist with the same containment rationale as the Redis exception, plus a test that proves the allowlist still **blocks** non-configured origins.
4. **`WM_SESSION_SECRET` was never wired into the compose stack or docs**, so `/api/wm-session` failed closed (503) on a fresh self-host and anonymous visitors lost every session-gated data route in a 503/401 cascade. Wired it with the same `:?`-guard pattern as the Redis secrets, with an upgrade callout and troubleshooting rows.
5. **`LLM_MIN_TIMEOUT_MS`** (opt-in, default no-op, **scoped to self-hosted providers**): call sites pass timeouts tuned for hosted APIs (25s), which cut off longer generations (country briefs) on slower self-hosted backends. A provider-scoped floor gives Ollama / vLLM / the shim room without loosening the hosted DeepSeek fail-fast or hosted callers' short timeouts.
6. Documentation accuracy pass on the shim section — env-var defaults, shell-substitution in the `.env` snippets, and a note that streamed requests bypass the cache.

## Security hardening

The shim was put through an adversarial self-review before this PR; the notable fix: a streamed completion cut short by a child crash, a timeout, or an `is_error` result now **severs the connection mid-body** instead of emitting a synthetic `finish_reason: "stop"` + `[DONE]`. Previously a truncated brief would have been delivered to the caller as a *complete* answer. Also: the spawned CLI receives an explicit allowlisted env (its OAuth token, not the shim's own key or the app's secrets), constant-time key comparison, generic error bodies with detail logged server-side only, and 413 (not a connection reset) on oversized bodies.

## Testing

- `npm run lint`, `npm run typecheck`, `npm run typecheck:api`, `npm run lint:md` — clean.
- `npm run test:sidecar` — **219/219** (includes the new SSRF allow **and** block tests).
- `npm run test:data` — new shim + `llm.ts` tests pass; overall failure count identical to a clean checkout of `main` in the same environment (pre-existing, environment-dependent failures only).
- Verified end-to-end on a clean `docker compose up -d`: dashboard boots healthy, and country intelligence briefs / event classification / article summarization all run against a real Claude subscription (streaming verified through the chat surface); stopping the shim degrades gracefully to keyword fallbacks.
- No secrets committed; the override example uses `${VAR:?}` interpolation and the compose secrets file is now gitignored.

## Notes for reviewers

- The feature is entirely opt-in; a deployment that doesn't add the override service or set `LLM_TOOL_PROVIDER`/`LLM_REASONING_PROVIDER=generic` is unaffected.
- The shim never logs prompt content or the OAuth token.
- `SELF_HOSTING.md` documents the subscription-quota etiquette: this is for personal use of your own Claude subscription on a private deployment, with a conservative default daily cap.

Happy to split any of the six self-hosting fixes into their own PRs if you'd prefer to review them separately.
