### PR TITLE
fix(seed-research): isolate arXiv categories + retry + TTL so a single blip can't empty prod (#5409)

### DIFF
--- a/scripts/seed-research.mjs
+++ b/scripts/seed-research.mjs
@@ -12,55 +12,88 @@ import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep } from '.
 
 loadEnvFile(import.meta.url);
 
-const ARXIV_TTL = 3600;
+// The canonical key's staleness gate. Exported so the TTL invariant below is pinned by a test.
+export const RESEARCH_MAX_STALE_MIN = 150;
+// 3h. MUST outlive the health staleness gate (RESEARCH_MAX_STALE_MIN → 9000s) so a merely-late
+// tick degrades to STALE_SEED (last-good still served) instead of an EMPTY crit, and it is ≈3×
+// the ~hourly cron so a single arXiv blip stays a graceful exit-0 RETRY rather than exit-1 +
+// `researchArxivHnTrending` EMPTY in prod (issue #5409). Was 3600 (≈1× cron, BELOW the gate).
+export const ARXIV_TTL = 10800;
 const HN_TTL = 600;
 const TECH_EVENTS_TTL = 28800; // 8h — outlives maxStaleMin:480 for health buffer
 const TRENDING_TTL = 3600;
 
 // ─── arXiv Papers ───
 
-async function fetchArxivPapers() {
-  const categories = ['cs.AI', 'cs.CL', 'cs.CR'];
+const ARXIV_CATEGORIES = ['cs.AI', 'cs.CL', 'cs.CR'];
+
+// Parse arXiv Atom XML into paper records. Pure — split out so the fetch path stays testable.
+function parseArxivEntries(xml) {
+  const papers = [];
+  const entryBlocks = xml.split('<entry>').slice(1);
+  for (const block of entryBlocks) {
+    const id = (block.match(/<id>([\s\S]*?)<\/id>/)?.[1] || '').trim().split('/').pop() || '';
+    const title = (block.match(/<title>([\s\S]*?)<\/title>/)?.[1] || '').trim().replace(/\s+/g, ' ');
+    const summary = (block.match(/<summary>([\s\S]*?)<\/summary>/)?.[1] || '').trim().replace(/\s+/g, ' ');
+    const published = block.match(/<published>([\s\S]*?)<\/published>/)?.[1]?.trim() || '';
+    const publishedAt = published ? new Date(published).getTime() : 0;
+    const urlMatch = block.match(/<link[^>]*rel="alternate"[^>]*href="([^"]+)"/);
+    const paperUrl = urlMatch?.[1] || `https://arxiv.org/abs/${id}`;
+
+    const authors = [];
+    const authorMatches = block.matchAll(/<author>\s*<name>([\s\S]*?)<\/name>/g);
+    for (const m of authorMatches) authors.push(m[1].trim());
+
+    const cats = [];
+    const catMatches = block.matchAll(/<category[^>]*term="([^"]+)"/g);
+    for (const m of catMatches) cats.push(m[1]);
+
+    if (title && id) papers.push({ id, title, summary, authors, categories: cats, publishedAt, url: paperUrl });
+  }
+  return papers;
+}
+
+// Fetch ONE arXiv category with a bounded retry. arXiv intermittently times out (#5409); a
+// single transient timeout on the PRIMARY category (cs.AI) used to zero the whole record set,
+// so retry once before giving up. Returns [] on a non-retryable HTTP error; throws only if
+// every attempt failed (the caller isolates that per-category). `fetchFn`/`sleepFn` injectable
+// for tests.
+export async function fetchArxivCategory(cat, { fetchFn = fetch, retries = 1, sleepFn = sleep } = {}) {
+  const url = `https://export.arxiv.org/api/query?search_query=cat:${cat}&start=0&max_results=50`;
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      const resp = await fetchFn(url, {
+        headers: { Accept: 'application/xml', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!resp.ok) { console.warn(`  arXiv ${cat}: HTTP ${resp.status}`); return []; }
+      return parseArxivEntries(await resp.text());
+    } catch (e) {
+      lastErr = e;
+      if (attempt < retries) await sleepFn(2000); // brief backoff before the retry
+    }
+  }
+  throw lastErr;
+}
+
+// Fetch all arXiv categories with PER-CATEGORY ISOLATION (#5409). A timeout on one category
+// must not discard the others — in particular a good cs.AI (the primary record key that drives
+// declareRecords) must survive a cs.CL/cs.CR blip. Previously the loop let any category error
+// reject the whole function, so a single arXiv timeout zeroed the primary record set → exit 1 +
+// `researchArxivHnTrending` EMPTY in prod. Never throws: a total outage returns {} so the caller's
+// Promise.allSettled stays fulfilled and runSeed takes the graceful last-good RETRY path.
+export async function fetchArxivPapers({ fetchFn = fetch, retries = 1, sleepFn = sleep } = {}) {
   const results = {};
-
-  for (const cat of categories) {
-    const url = `https://export.arxiv.org/api/query?search_query=cat:${cat}&start=0&max_results=50`;
-    const resp = await fetch(url, {
-      headers: { Accept: 'application/xml', 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(15_000),
-    });
-    if (!resp.ok) { console.warn(`  arXiv ${cat}: HTTP ${resp.status}`); continue; }
-    const xml = await resp.text();
-
-    // Simple XML parse for arXiv entries
-    const papers = [];
-    const entryBlocks = xml.split('<entry>').slice(1);
-    for (const block of entryBlocks) {
-      const id = (block.match(/<id>([\s\S]*?)<\/id>/)?.[1] || '').trim().split('/').pop() || '';
-      const title = (block.match(/<title>([\s\S]*?)<\/title>/)?.[1] || '').trim().replace(/\s+/g, ' ');
-      const summary = (block.match(/<summary>([\s\S]*?)<\/summary>/)?.[1] || '').trim().replace(/\s+/g, ' ');
-      const published = block.match(/<published>([\s\S]*?)<\/published>/)?.[1]?.trim() || '';
-      const publishedAt = published ? new Date(published).getTime() : 0;
-      const urlMatch = block.match(/<link[^>]*rel="alternate"[^>]*href="([^"]+)"/);
-      const paperUrl = urlMatch?.[1] || `https://arxiv.org/abs/${id}`;
-
-      const authors = [];
-      const authorMatches = block.matchAll(/<author>\s*<name>([\s\S]*?)<\/name>/g);
-      for (const m of authorMatches) authors.push(m[1].trim());
-
-      const cats = [];
-      const catMatches = block.matchAll(/<category[^>]*term="([^"]+)"/g);
-      for (const m of catMatches) cats.push(m[1]);
-
-      if (title && id) papers.push({ id, title, summary, authors, categories: cats, publishedAt, url: paperUrl });
+  for (const cat of ARXIV_CATEGORIES) {
+    try {
+      const papers = await fetchArxivCategory(cat, { fetchFn, retries, sleepFn });
+      if (papers.length > 0) results[`research:arxiv:v1:${cat}::50`] = { papers, pagination: undefined };
+      console.log(`  arXiv ${cat}: ${papers.length} papers`);
+    } catch (e) {
+      console.warn(`  arXiv ${cat} failed: ${e?.message || e} — other categories unaffected`);
     }
-
-    const cacheKey = `research:arxiv:v1:${cat}::50`;
-    if (papers.length > 0) {
-      results[cacheKey] = { papers, pagination: undefined };
-    }
-    console.log(`  arXiv ${cat}: ${papers.length} papers`);
-    await sleep(3000); // arXiv rate limit: 1 req/3s
+    await sleepFn(3000); // arXiv rate limit: 1 req/3s
   }
   return results;
 }
@@ -340,14 +373,19 @@ export function declareRecords(data) {
   return data?.papers?.length ?? 0;
 }
 
-runSeed('research', 'arxiv-hn-trending', 'research:arxiv:v1:cs.AI::50', fetchAll, {
-  validateFn: validate,
-  ttlSeconds: ARXIV_TTL,
-  sourceVersion: 'arxiv-hn-gitter',
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 150,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+// Only run the seeder when invoked directly, so tests can import the fetch helpers above
+// without the top-level runSeed firing (mirrors seed-economy.mjs). `.endsWith` avoids the
+// import.meta.url-vs-argv symlink realpath fail-open (see test-ci-gotchas).
+if (process.argv[1]?.endsWith('seed-research.mjs')) {
+  runSeed('research', 'arxiv-hn-trending', 'research:arxiv:v1:cs.AI::50', fetchAll, {
+    validateFn: validate,
+    ttlSeconds: ARXIV_TTL,
+    sourceVersion: 'arxiv-hn-gitter',
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: RESEARCH_MAX_STALE_MIN,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/tests/seed-research-arxiv-isolation.test.mjs
+++ b/tests/seed-research-arxiv-isolation.test.mjs
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchArxivPapers,
+  fetchArxivCategory,
+  ARXIV_TTL,
+  RESEARCH_MAX_STALE_MIN,
+} from '../scripts/seed-research.mjs';
+
+// #5409: seed-research crashed (exit 1, ZERO_YIELD) and left `researchArxivHnTrending` EMPTY in
+// prod because a single arXiv timeout zeroed the primary record set (cs.AI drives declareRecords).
+// The last-good key had expired (TTL ≈ cron), so the runner's zero-yield RETRY path could not
+// extend it → exit 1 instead of a graceful STALE_SEED. Three fixes are pinned here:
+//   (1) per-category isolation — a cs.CL/cs.CR blip must not discard a good cs.AI;
+//   (2) retry — a transient primary timeout is retried once before yielding zero;
+//   (3) ARXIV_TTL must outlive the health staleness gate so a late tick degrades, not empties.
+//
+// Importing the seeder must NOT run it: the module guards its top-level runSeed on
+// `process.argv[1].endsWith('seed-research.mjs')`. If that guard regresses, this import hangs/exits
+// and the whole file fails — which is itself the signal.
+
+const noSleep = async () => {};
+
+const okResp = (xml) => ({ ok: true, status: 200, text: async () => xml });
+
+// Minimal arXiv Atom payload with one entry.
+const arxivXml = (id, title) =>
+  `<feed><entry><id>http://arxiv.org/abs/${id}</id><title>${title}</title>` +
+  '<summary>s</summary><published>2026-07-20T00:00:00Z</published>' +
+  `<link rel="alternate" href="https://arxiv.org/abs/${id}"/>` +
+  '<author><name>A</name></author><category term="cs.AI"/></entry></feed>';
+
+const catOf = (url) => url.match(/cat:(cs\.\w+)/)[1];
+
+test('a cs.CL timeout does NOT discard a good cs.AI (per-category isolation, #5409)', async () => {
+  const fetchFn = async (url) => {
+    if (url.includes('cat:cs.CL')) throw new Error('The operation was aborted due to timeout');
+    const cat = catOf(url);
+    return okResp(arxivXml(`${cat}-1`, `${cat} paper`));
+  };
+
+  const results = await fetchArxivPapers({ fetchFn, retries: 0, sleepFn: noSleep });
+
+  // The primary key (cs.AI) must survive the sibling category's failure — this is the exact
+  // record set whose absence drove declareRecords to 0 → EMPTY in prod.
+  assert.ok(results['research:arxiv:v1:cs.AI::50'], 'cs.AI (primary) must be present');
+  assert.equal(results['research:arxiv:v1:cs.AI::50'].papers.length, 1);
+  assert.ok(results['research:arxiv:v1:cs.CR::50'], 'cs.CR must be present too');
+  assert.ok(!results['research:arxiv:v1:cs.CL::50'], 'cs.CL failed → absent, not fatal');
+});
+
+test('a transient cs.AI timeout is retried and recovers (no zero-yield, #5409)', async () => {
+  let aiAttempts = 0;
+  const fetchFn = async (url) => {
+    if (url.includes('cat:cs.AI')) {
+      aiAttempts += 1;
+      if (aiAttempts === 1) throw new Error('The operation was aborted due to timeout');
+    }
+    return okResp(arxivXml(`${catOf(url)}-1`, 'paper'));
+  };
+
+  const papers = await fetchArxivCategory('cs.AI', { fetchFn, retries: 1, sleepFn: noSleep });
+
+  assert.equal(aiAttempts, 2, 'first attempt threw, the retry fired');
+  assert.equal(papers.length, 1, 'the retry recovered the primary papers');
+});
+
+test('a total arXiv outage returns {} without throwing (runner keeps the graceful RETRY path, #5409)', async () => {
+  const fetchFn = async () => { throw new Error('The operation was aborted due to timeout'); };
+
+  const results = await fetchArxivPapers({ fetchFn, retries: 1, sleepFn: noSleep });
+
+  // Crucially it must NOT throw: fetchAll runs this under Promise.allSettled, and a rejection
+  // there (the old behavior) made allData.arxiv=null and was the top of the crash chain.
+  assert.deepEqual(results, {}, 'no key written, and no throw');
+});
+
+test('ARXIV_TTL outlives the health staleness gate so a late tick is STALE_SEED, not EMPTY (#5409)', () => {
+  assert.ok(
+    ARXIV_TTL > RESEARCH_MAX_STALE_MIN * 60,
+    `ARXIV_TTL (${ARXIV_TTL}s) must exceed the staleness gate ` +
+      `(maxStaleMin ${RESEARCH_MAX_STALE_MIN}min = ${RESEARCH_MAX_STALE_MIN * 60}s)`,
+  );
+});

--- a/tests/seed-ttl-outlives-staleness-fleet.test.mjs
+++ b/tests/seed-ttl-outlives-staleness-fleet.test.mjs
@@ -110,7 +110,6 @@ const KNOWN_VIOLATIONS = new Set([
   'seed-recovery-external-debt.mjs',
   'seed-recovery-fiscal-space.mjs',
   'seed-recovery-reserve-adequacy.mjs',
-  'seed-research.mjs',
   'seed-sovereign-wealth.mjs',
   'seed-spr-policies.mjs',
   'seed-submarine-cables.mjs',


### PR DESCRIPTION
Fixes #5409.

## Problem

`seed-research` crashed (exit 1, `ZERO_YIELD`) and left `researchArxivHnTrending` **EMPTY in prod** — found via `/diagnose-railway-seeders`, confirmed on `/api/health` (`records: 0`, site `DEGRADED`, EMPTY for 78+ min with no self-recovery).

Root cause: the primary record count is driven **solely by arXiv cs.AI** (`declareRecords` = `data.papers.length`). A single arXiv timeout rejected the whole `fetchArxivPapers` (no per-category isolation) → `allData.arxiv = null` → `declareRecords` returned **0 even though HN, trending and tech-events all fetched fine**. With `ARXIV_TTL=3600s` ≈ the hourly cron, the last-good key had already expired, so the runner's zero-yield RETRY path couldn't extend it → **exit 1 + EMPTY** instead of a graceful exit-0.

## Fix (three composable parts)

1. **Per-category isolation** in `fetchArxivPapers` — a `cs.CL`/`cs.CR` timeout no longer discards a good `cs.AI`. The function never throws now: a total outage returns `{}` so the caller's `Promise.allSettled` stays fulfilled and `runSeed` takes the graceful last-good RETRY path.
2. **Bounded retry** per arXiv category (`fetchArxivCategory`) so a single transient timeout on the primary is retried once before yielding zero.
3. **`ARXIV_TTL` 3600 → 10800 (3h)** — now outlives the health staleness gate (`maxStaleMin 150` → 9000s) and is ~3× the hourly cron, so a merely-late tick degrades to `STALE_SEED` (last-good still served) instead of exit 1 + EMPTY. Retires the `seed-research.mjs` entry in the `ttl-outlives-staleness` fleet allowlist (the "allowlist does not rot" guard requires it).

Top-level `runSeed` is now guarded on `process.argv[1].endsWith('seed-research.mjs')` (mirrors `seed-economy.mjs`) so the fetch helpers are importable/testable without firing the seeder. `.endsWith` avoids the symlink-realpath main-module fail-open.

## Tests

New `tests/seed-research-arxiv-isolation.test.mjs` pins all three fixes — **proven red against the original bug, green after** (each of the 4 assertions fails without its corresponding fix). Fleet TTL guards (`seed-ttl-outlives-staleness-fleet`, `seeder-canonical-ttl-vs-cron`, 17 tests) stay green. Biome clean.

> Note: the local pre-push edge-function bundle gate failed to resolve `@vercel/functions`/`aws4fetch` — a stale shared-worktree `node_modules` artifact unrelated to this diff (which touches no edge functions). Both are declared deps in the lockfile; CI's clean install validates the bundle.

https://claude.ai/code/session_01Qi24RkJBFBh4rGhutVtFny