### PR TITLE
fix(deps): clear high-severity svgo + fast-uri advisories redding audit-lockfile on all PRs (#5417)

### DIFF
--- a/blog-site/package-lock.json
+++ b/blog-site/package-lock.json
@@ -4587,9 +4587,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/consumer-prices-core/package-lock.json
+++ b/consumer-prices-core/package-lock.json
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes #5417.

Two high advisories published upstream today red the `audit-lockfile` matrix (and therefore the required `security-audit` → `gate`) on **every PR**, regardless of diff — observed on #5403: identical lockfiles passed at 10:40Z, failed at 21:30Z after a markdown-only push. Same rot class as #5394/#5395.

**Fix — targeted bumps only, 6 lockfile lines each:**
- `blog-site`: svgo 4.0.1 → **4.0.2** (GHSA-2p49-hgcm-8545, transitive via astro)
- `consumer-prices-core`: fast-uri → **3.1.4** (GHSA-4c8g-83qw-93j6)

Deliberately **not** a lockfile refresh — the #5395 refresh floated biome and redded all full-lint PRs (see memory of that incident); this diff touches exactly the two vulnerable packages.

**Verification:**
- `.github/scripts/audit-production-dependencies.mjs` run locally with CI's exact args: green for both workspaces ("0 high+ advisories")
- `npm audit --omit=dev`: consumer-prices-core 0 vulns; blog-site left with 1 moderate (astro XSS trio, needs breaking astro@7 — out of scope for the high+ gate)
- blog-site astro build green on svgo 4.0.2

Unblocks #5403 and any other PR that re-runs CI after ~21:00Z today.

https://claude.ai/code/session_01JEGono85MnwW7F9mm4rQEF