### PR TITLE
fix(deps): clear sharp + fast-xml-parser high advisories redding audit-lockfile on all PRs (#5423)

### DIFF
--- a/.github/scripts/audit-production-dependencies.mjs
+++ b/.github/scripts/audit-production-dependencies.mjs
@@ -14,9 +14,18 @@ const SEVERITY_RANK = new Map([
 ]);
 
 export const BASELINE_ADVISORIES_BY_LOCKFILE = {
-  'package-lock.json': [],
+  // GHSA-f88m-g3jw-g9cj (sharp inherited libvips decode CVEs) needs attacker-
+  // crafted image BYTES fed to sharp. Neither root chain decodes untrusted
+  // input: @vercel/og's sharp only converts satori-rendered first-party
+  // buffers (brief carousel), and @xenova/transformers is consumed solely by
+  // the browser ML worker (src/workers/ml.worker.ts) — its Node-only sharp
+  // binary never executes server-side. The clean fix (sharp 0.35.x) is
+  // semver-major across both chains; baselined until the parents bump. The
+  // same reasoning covers blog-site below: sharp runs only at Astro build
+  // time over repo-owned images, and the fix requires astro@7 (semver-major).
+  'package-lock.json': ['GHSA-f88m-g3jw-g9cj'],
   'consumer-prices-core/package-lock.json': [],
-  'blog-site/package-lock.json': [],
+  'blog-site/package-lock.json': ['GHSA-f88m-g3jw-g9cj'],
   // GHSA-395f-4hp3-45gv (shell-quote quadratic-complexity DoS in parse()) reaches
   // pro-test only via react-native -> react-devtools-core, a mobile/dev-tooling
   // chain the Vite web build never bundles into public/pro/. The parse() DoS is

--- a/package-lock.json
+++ b/package-lock.json
@@ -3209,13 +3209,13 @@
       }
     },
     "node_modules/@clerk/clerk-js": {
-      "version": "6.25.5",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-6.25.5.tgz",
-      "integrity": "sha512-RcMZLAj3nKJd4cVGdPFGmUjaLN4JlY1eLrQOmnP9z8Z7vX8Y3YXhIpD/M2KHvh4N5UNpArkjYOOzsIfUqfn/HA==",
+      "version": "6.25.6",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-6.25.6.tgz",
+      "integrity": "sha512-Zxw+R3FJytPHQXsjSgmuM1BNgMIGLsR97F1TuRob0SjpiDyyR+37Wu3uDItbh3dlM70WostMrtwpVn7rFLADGg==",
       "license": "MIT",
       "dependencies": {
         "@base-org/account": "2.0.1",
-        "@clerk/shared": "^4.25.5",
+        "@clerk/shared": "^4.25.6",
         "@coinbase/wallet-sdk": "4.3.7",
         "@solana/wallet-adapter-base": "0.9.27",
         "@solana/wallet-adapter-react": "0.15.39",
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.25.5",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.5.tgz",
-      "integrity": "sha512-pb+pA+88OACHSuE0JhsnV7Qzl1j9UhI9KrXivS831x1BJOtNYORnDqRg3xss2SPFcC46clE9S5QqkRQqv1lSsg==",
+      "version": "4.25.6",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.6.tgz",
+      "integrity": "sha512-d7Yhi0T5QE0/NCm0ZHgokQMrWHjOCPqU5few3C6Fujw8VR6w16wdAEcGJPS1xo47SXMr8DptXwDE9myyHj71MQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
@@ -9107,9 +9107,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.3.tgz",
-      "integrity": "sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13599,9 +13599,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -14301,9 +14301,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -14414,9 +14414,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16839,10 +16839,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -19963,9 +19973,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22974,9 +22984,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24025,9 +24035,9 @@
       }
     },
     "node_modules/workbox-build/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -2905,9 +2905,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
-      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -2916,7 +2916,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.2.0",
+        "@nodable/entities": "^3.0.0",
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^2.0.0",
         "path-expression-matcher": "^1.6.2",
@@ -2926,6 +2926,18 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/fast-xml-parser/node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser/node_modules/xml-naming": {
       "version": "0.3.0",

--- a/tests/security-audit-baseline.test.mjs
+++ b/tests/security-audit-baseline.test.mjs
@@ -137,12 +137,22 @@ describe('security audit baseline', () => {
             url: 'https://github.com/advisories/GHSA-395f-4hp3-45gv',
           }],
         },
+        'sharp': {
+          name: 'sharp',
+          severity: 'high',
+          via: [{
+            name: 'sharp',
+            severity: 'high',
+            title: 'sharp inherited vulnerabilities in libvips',
+            url: 'https://github.com/advisories/GHSA-f88m-g3jw-g9cj',
+          }],
+        },
       },
     };
 
     // The still-present ids are not reported as stale; GHSA-qjx8 (absent) is.
     assert.deepEqual(collectStaleBaselineEntries(report, 'pro-test/package-lock.json'), ['GHSA-qjx8-664m-686j']);
-    // The empty root baseline has nothing to mark stale.
+    // Root's baselined sharp advisory is present in the report, so nothing is stale.
     assert.deepEqual(collectStaleBaselineEntries(report, 'package-lock.json'), []);
   });
 


### PR DESCRIPTION
Fixes #5423 — the second advisory-rot round in a day (same class as #5417/#5418): the required `security-audit` gate is red on every open PR, observed on docs-only #5422 which touches no lockfiles.

## Advisories

- **GHSA-8r6m-32jq-jx6q** (`fast-xml-parser`, high) → `scripts` leg: cleared via `npm audit fix --package-lock-only` (within-range, `package.json` untouched).
- **GHSA-f88m-g3jw-g9cj** (`sharp` inherited libvips decode CVEs, high) → `root` + `blog-site` legs: the clean fix (sharp 0.35.x) is **semver-major in every chain** (root: `@vercel/og@0.11.1`, `@xenova/transformers@2.17.2`; blog-site: direct + `astro@6`, whose audit-fix wants `astro@7.1.3`). No chain decodes attacker-supplied image bytes: `@vercel/og`'s sharp converts satori-rendered first-party buffers (`api/brief/carousel/…`), `@xenova/transformers` is consumed only by the browser ML worker (`src/workers/ml.worker.ts`) so its Node-only sharp binary never executes server-side, and blog-site runs sharp only at Astro build time over repo-owned images. **Baselined** for root + blog-site with in-file rationale, per the #5395 pro-test precedent — drop once the parents bump to sharp 0.35.x.

Root also picked up within-range hygiene bumps from the audit fix (clerk-js, fast-uri, brace-expansion copies, dompurify, vite patch).

## Verification

- All six audit legs exit 0 locally via the exact CI command (`node .github/scripts/audit-production-dependencies.mjs --workspace … `).
- `tests/security-audit-baseline.test.mjs` 8/8 — stale-entry fixture updated so the new baseline id reads present-not-stale, and the root esbuild override arrangement is confirmed undisturbed.

## Follow-up

Bumping `sharp` to 0.35.x across the three parents (and `astro` to 7.x in blog-site) would let both baseline entries be removed.

https://claude.ai/code/session_01AKbRZXV6kKe8MTYpKZSLBM