### PR TITLE
fix(ml-worker): clear in-flight load entry when a model download fails

### DIFF
--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -161,7 +161,6 @@ async function loadModel(modelId: string): Promise<void> {
     });
 
     loadedPipelines.set(modelId, pipe);
-    loadingPromises.delete(modelId);
     console.log(`[MLWorker] Model loaded in ${Date.now() - startTime}ms: ${modelId}`);
 
     // Notify manager that model is now available (no id = unsolicited notification)
@@ -169,6 +168,14 @@ async function loadModel(modelId: string): Promise<void> {
   })();
 
   loadingPromises.set(modelId, loadPromise);
+  // Clear the in-flight entry on BOTH settle paths. Clearing only on success
+  // leaves a rejected promise cached here, and the early return above then
+  // hands that same rejection to every later loadModel() call — one transient
+  // model download failure would disable the model for the worker's lifetime.
+  const clearInFlight = () => {
+    loadingPromises.delete(modelId);
+  };
+  void loadPromise.then(clearInFlight, clearInFlight);
   return loadPromise;
 }
 

--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -172,8 +172,11 @@ async function loadModel(modelId: string): Promise<void> {
   // leaves a rejected promise cached here, and the early return above then
   // hands that same rejection to every later loadModel() call — one transient
   // model download failure would disable the model for the worker's lifetime.
+  // Only retract our OWN entry: if something else has already replaced or
+  // cleared it, a bare delete here would evict a newer in-flight load and
+  // break the de-dupe for its waiters.
   const clearInFlight = () => {
-    loadingPromises.delete(modelId);
+    if (loadingPromises.get(modelId) === loadPromise) loadingPromises.delete(modelId);
   };
   void loadPromise.then(clearInFlight, clearInFlight);
   return loadPromise;


### PR DESCRIPTION
## Summary

Fixes #5425.

`loadModel()` de-dupes concurrent model loads by caching the in-flight promise in `loadingPromises`, but the matching `delete` sat after the `await` inside the async IIFE, so it only ran on the success path. When `pipeline()` rejects, the rejected promise stays in the map forever and the early return at the top of `loadModel()` hands that same rejection to every later call, without re-attempting the download.

Nothing else clears it — `unloadModel()` and the `reset` handler only touch `loadedPipelines`, and `src/services/ml-worker.ts` keeps the worker alive after a post-ready error. So one transient failure disables embeddings / summarization / sentiment / NER / vector search for the rest of the page session.

This registers the cleanup on **both** settle paths instead. Attaching it after `loadingPromises.set(...)` rather than using `try/finally` inside the IIFE is deliberate: if `pipeline()` ever threw synchronously, a `finally` would delete the entry *before* it was inserted, reintroducing a stale entry.

Behaviour of the de-dupe itself is unchanged — concurrent callers still share one download, and a successful load still clears the entry.

## Verification

Reducing the same logic to a standalone harness (stub `pipeline` that rejects once, then succeeds):

```
before: call 1 rejected -> call 2 rejected  | pipeline() invoked 1x
after:  call 1 rejected -> call 2 resolved  | pipeline() invoked 2x
```

- `npm run typecheck` — passes
- `npx biome lint ./src/workers/ml.worker.ts` — clean

## Type of change

- [x] Bug fix

## Affected areas

- [x] AI Insights / World Brief
- [x] Other: `src/workers/ml.worker.ts` (ML web worker — affects every ML-backed panel)

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — not variant-specific
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documentation claims, API/MCP contracts, generated docs, Redis keys or methodology are changed.
