### PR TITLE
fix(notification-channels): bound the Convex relay fetch with a timeout

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -148,6 +148,9 @@ async function convexRelay(body: Record<string, unknown>): Promise<Response> {
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${RELAY_SHARED_SECRET}`,
+      // AGENTS.md, Critical Conventions: always send a User-Agent on
+      // server-side fetches. Matches the Upstash calls above.
+      'User-Agent': 'worldmonitor-edge/1.0',
     },
     body: JSON.stringify(body),
     // Bound the relay round-trip well inside the edge runtime's initial-response

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -31,6 +31,9 @@ const CONVEX_SITE_URL =
 const RELAY_SHARED_SECRET = process.env.RELAY_SHARED_SECRET ?? '';
 const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL ?? '';
 const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN ?? '';
+// Same bound the other Convex relay callers use (api/customer-portal.ts:98,
+// api/create-checkout.ts:177).
+const RELAY_TIMEOUT_MS = 15_000;
 
 // AES-256-GCM encryption using Web Crypto (matches Node crypto.cjs decrypt format).
 // Format stored: v1:<base64(iv[12] || tag[16] || ciphertext)>
@@ -147,6 +150,13 @@ async function convexRelay(body: Record<string, unknown>): Promise<Response> {
       'Authorization': `Bearer ${RELAY_SHARED_SECRET}`,
     },
     body: JSON.stringify(body),
+    // Bound the relay round-trip well inside the edge runtime's initial-response
+    // budget. Without it a hung Convex action stalls the invocation until the
+    // platform kills it, which bypasses this file's try/catch — so no Sentry
+    // capture, no CORS headers, and `finish()` never runs, leaving the
+    // idempotency `processing` marker held for its full 180s TTL (every retry
+    // with the same Idempotency-Key then 409s).
+    signal: AbortSignal.timeout(RELAY_TIMEOUT_MS),
   });
 }
 

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -35,6 +35,30 @@ const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN ?? '';
 // api/create-checkout.ts:177).
 const RELAY_TIMEOUT_MS = 15_000;
 
+type NotificationChannelsDeps = {
+  validateBearerToken: typeof validateBearerToken;
+  getEntitlements: typeof getEntitlements;
+  fetch: typeof fetch;
+};
+
+function createDefaultNotificationChannelsDeps(): NotificationChannelsDeps {
+  return {
+    validateBearerToken,
+    getEntitlements,
+    fetch: (...args) => globalThis.fetch(...args),
+  };
+}
+
+let notificationChannelsDeps = createDefaultNotificationChannelsDeps();
+
+export function __setNotificationChannelsDepsForTests(
+  overrides: Partial<NotificationChannelsDeps> | null,
+): void {
+  notificationChannelsDeps = overrides
+    ? { ...createDefaultNotificationChannelsDeps(), ...overrides }
+    : createDefaultNotificationChannelsDeps();
+}
+
 // AES-256-GCM encryption using Web Crypto (matches Node crypto.cjs decrypt format).
 // Format stored: v1:<base64(iv[12] || tag[16] || ciphertext)>
 async function encryptSlackWebhook(webhookUrl: string): Promise<string> {
@@ -86,39 +110,11 @@ function isAllowedPushEndpointHost(host: string): boolean {
   return false;
 }
 
-async function publishWelcome(userId: string, channelType: string): Promise<void> {
-  if (!UPSTASH_URL || !UPSTASH_TOKEN) {
-    console.error('[notification-channels] publishWelcome: UPSTASH env vars missing — welcome not queued');
-    return;
-  }
-  console.log(`[notification-channels] publishWelcome: queuing ${channelType} for ${userId}`);
-  const msg = JSON.stringify({ eventType: 'channel_welcome', userId, channelType });
-  try {
-    const res = await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${UPSTASH_TOKEN}`,
-        'User-Agent': 'worldmonitor-edge/1.0',
-      },
-      signal: AbortSignal.timeout(5000),
-    });
-    const data = await res.json().catch(() => null) as { result?: unknown } | null;
-    console.log(`[notification-channels] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
-  } catch (err) {
-    console.error('[notification-channels] publishWelcome LPUSH failed:', (err as Error).message);
-    // publishWelcome runs inside the handler's ctx.waitUntil chain; await
-    // keeps that chain pending until Sentry delivery completes.
-    await captureSilentError(err, {
-      tags: { route: 'api/notification-channels', step: 'publish-welcome' },
-    });
-  }
-}
-
 async function publishFlushHeld(userId: string, variant: string): Promise<void> {
   if (!UPSTASH_URL || !UPSTASH_TOKEN) return;
   const msg = JSON.stringify({ eventType: 'flush_quiet_held', userId, variant });
   try {
-    await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
+    await notificationChannelsDeps.fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${UPSTASH_TOKEN}`, 'User-Agent': 'worldmonitor-edge/1.0' },
       signal: AbortSignal.timeout(5000),
@@ -143,7 +139,7 @@ function json(body: unknown, status: number, cors: Record<string, string>, noCac
 }
 
 async function convexRelay(body: Record<string, unknown>): Promise<Response> {
-  return fetch(`${CONVEX_SITE_URL}/relay/notification-channels`, {
+  return notificationChannelsDeps.fetch(`${CONVEX_SITE_URL}/relay/notification-channels`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -212,7 +208,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
   if (!token) return json({ error: 'Unauthorized' }, 401, corsHeaders);
 
-  const session = await validateBearerToken(token);
+  const session = await notificationChannelsDeps.validateBearerToken(token);
   if (!session.valid || !session.userId) return json({ error: 'Unauthorized' }, 401, corsHeaders);
 
   const idempotencyRequest = req.method === 'POST' ? req.clone() : null;
@@ -239,7 +235,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   }
 
   if (req.method === 'POST') {
-    const ent = await getEntitlements(session.userId);
+    const ent = await notificationChannelsDeps.getEntitlements(session.userId);
     if (!ent || ent.features.tier < 1) {
       return json({
         error: 'pro_required',
@@ -317,10 +313,8 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           console.error('[notification-channels] POST set-channel relay error:', resp.status);
           return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        const setResult = await resp.json() as { ok: boolean; isNew?: boolean };
-        console.log(`[notification-channels] set-channel ${channelType}: isNew=${setResult.isNew}`);
-        // Only send welcome on first connect, not re-links; use waitUntil so the edge isolate doesn't terminate early
-        if (setResult.isNew) ctx.waitUntil(publishWelcome(session.userId, channelType));
+        // The Convex mutation transactionally schedules the first-connect
+        // welcome. It no longer depends on this relay response reaching edge.
         return finish(json({ ok: true }, 200, corsHeaders));
       }
 
@@ -365,8 +359,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           console.error('[notification-channels] POST set-web-push relay error:', resp.status);
           return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        const wpResult = await resp.json() as { ok: boolean; isNew?: boolean };
-        if (wpResult.isNew) ctx.waitUntil(publishWelcome(session.userId, 'web_push'));
+        // As above, Convex owns the durable first-connect welcome scheduling.
         return finish(json({ ok: true }, 200, corsHeaders));
       }
 

--- a/convex/__tests__/notificationChannels.test.ts
+++ b/convex/__tests__/notificationChannels.test.ts
@@ -1,15 +1,29 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { api, internal } from "../_generated/api";
 import schema from "../schema";
 
 const modules = import.meta.glob("../**/*.ts");
 type TestUser = ReturnType<ReturnType<typeof convexTest>["withIdentity"]>;
+const notificationChannelFns = (internal as any).notificationChannels;
+const originalFetch = globalThis.fetch;
+const originalUpstashUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalUpstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 
 const USER = {
   subject: "user-tests-notification-channels",
   tokenIdentifier: "clerk|user-tests-notification-channels",
 };
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalUpstashUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalUpstashUrl;
+  if (originalUpstashToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalUpstashToken;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 async function seedEntitlement(
   t: ReturnType<typeof convexTest>,
@@ -150,5 +164,95 @@ describe("notificationChannels — Convex entitlement gate", () => {
     expect(channels).toMatchObject([
       { channelType: "telegram", chatId: "12345", verified: true },
     ]);
+  });
+});
+
+describe("notificationChannels — durable first-connect welcome", () => {
+  function installQueueMock() {
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ result: 1 }),
+    );
+  }
+
+  function queuedEvent(fetchMock: ReturnType<typeof installQueueMock>) {
+    const [input, init] = fetchMock.mock.calls[0]!;
+    const url = String(input);
+    const encodedMessage = url.slice(url.lastIndexOf("/") + 1);
+    return {
+      url,
+      init,
+      message: JSON.parse(decodeURIComponent(encodedMessage)),
+    };
+  }
+
+  test("schedules an email welcome with the channel insert and not on retry", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "first-connect@example.com",
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queuedEvent(fetchMock)).toMatchObject({
+      url: expect.stringContaining("/lpush/wm:events:queue/"),
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer upstash-token",
+          "User-Agent": "worldmonitor-convex/1.0",
+        },
+      },
+      message: {
+        eventType: "channel_welcome",
+        userId: USER.subject,
+        channelType: "email",
+      },
+    });
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "first-connect@example.com",
+    })).resolves.toEqual({ isNew: false });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not turn a same-endpoint web-push retry into a new connection", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    const t = convexTest(schema, modules);
+    const args = {
+      userId: USER.subject,
+      endpoint: "https://fcm.googleapis.com/push/subscription-1",
+      p256dh: "p256dh",
+      auth: "auth",
+      userAgent: "Chrome",
+    };
+
+    await expect(t.mutation(
+      notificationChannelFns.setWebPushChannelForUser,
+      args,
+    )).resolves.toEqual({ isNew: true });
+    await expect(t.mutation(
+      notificationChannelFns.setWebPushChannelForUser,
+      args,
+    )).resolves.toEqual({ isNew: false });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queuedEvent(fetchMock).message).toEqual({
+      eventType: "channel_welcome",
+      userId: USER.subject,
+      channelType: "web_push",
+    });
   });
 });

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -1,12 +1,18 @@
 import { ConvexError, v } from "convex/values";
 import {
+  internalAction,
   internalMutation,
   internalQuery,
   type MutationCtx,
   mutation,
   query,
 } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { channelTypeValidator } from "./constants";
+
+const WELCOME_QUEUE_KEY = "wm:events:queue";
+const WELCOME_FETCH_TIMEOUT_MS = 5_000;
+const WELCOME_USER_AGENT = "worldmonitor-convex/1.0";
 
 /**
  * Notifications are a PRO feature. Enforce the entitlement at the public
@@ -39,6 +45,53 @@ async function assertProEntitlement(
     });
   }
 }
+
+/**
+ * Queue a first-connect welcome outside the relay HTTP request lifecycle.
+ *
+ * The mutation that creates the channel schedules this action in the same
+ * Convex transaction as the channel insert. A Vercel-to-Convex timeout can
+ * therefore hide the mutation response without losing the welcome event.
+ */
+export const queueChannelWelcome = internalAction({
+  args: {
+    userId: v.string(),
+    channelType: channelTypeValidator,
+  },
+  handler: async (_ctx, args) => {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) {
+      console.error(
+        "[notificationChannels] queueChannelWelcome: Upstash credentials missing",
+      );
+      return { queued: false };
+    }
+
+    const message = JSON.stringify({
+      eventType: "channel_welcome",
+      userId: args.userId,
+      channelType: args.channelType,
+    });
+    const response = await fetch(
+      `${url}/lpush/${WELCOME_QUEUE_KEY}/${encodeURIComponent(message)}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "User-Agent": WELCOME_USER_AGENT,
+        },
+        signal: AbortSignal.timeout(WELCOME_FETCH_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `queueChannelWelcome: Upstash LPUSH returned HTTP ${response.status}`,
+      );
+    }
+    return { queued: true };
+  },
+});
 
 export const getChannelsByUserId = internalQuery({
   args: { userId: v.string() },
@@ -88,6 +141,13 @@ export const setChannelForUser = internalMutation({
     } else {
       throw new ConvexError("discord channel must be set via set-discord-oauth");
     }
+    if (isNew) {
+      await ctx.scheduler.runAfter(
+        0,
+        (internal as any).notificationChannels.queueChannelWelcome,
+        { userId, channelType },
+      );
+    }
     return { isNew };
   },
 });
@@ -121,8 +181,18 @@ export const setWebPushChannelForUser = internalMutation({
     userAgent: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    // Step 1: scan for any existing rows with this endpoint across
-    // ALL users and delete them. notificationChannels has no
+    // Step 1: find the current user's row before cross-account endpoint
+    // cleanup. A retry with the same endpoint must remain a re-link rather
+    // than deleting its own row and appearing to be a first connection.
+    const existing = await ctx.db
+      .query("notificationChannels")
+      .withIndex("by_user_channel", (q) =>
+        q.eq("userId", args.userId).eq("channelType", "web_push"),
+      )
+      .unique();
+
+    // Step 2: scan for rows with this endpoint across other users and delete
+    // them. notificationChannels has no
     // endpoint-based index, so we filter at read time — acceptable
     // at current scale (<10k rows) and well-bounded to a single
     // write-path per user per connect.
@@ -134,21 +204,14 @@ export const setWebPushChannelForUser = internalMutation({
         row.channelType === "web_push" &&
         // Narrow through the channel-type literal so TS knows
         // `endpoint` exists on this row.
-        row.endpoint === args.endpoint
+        row.endpoint === args.endpoint &&
+        row.userId !== args.userId
       ) {
         await ctx.db.delete(row._id);
       }
     }
 
-    // Step 2: upsert the current-user row by (userId, channelType).
-    // After the delete above there is at most one row matching the
-    // unique index, so .unique() is safe.
-    const existing = await ctx.db
-      .query("notificationChannels")
-      .withIndex("by_user_channel", (q) =>
-        q.eq("userId", args.userId).eq("channelType", "web_push"),
-      )
-      .unique();
+    // Step 3: upsert the current-user row by (userId, channelType).
     const isNew = !existing;
     const doc = {
       userId: args.userId,
@@ -164,6 +227,13 @@ export const setWebPushChannelForUser = internalMutation({
       await ctx.db.replace(existing._id, doc);
     } else {
       await ctx.db.insert("notificationChannels", doc);
+    }
+    if (isNew) {
+      await ctx.scheduler.runAfter(
+        0,
+        (internal as any).notificationChannels.queueChannelWelcome,
+        { userId: args.userId, channelType: "web_push" },
+      );
     }
     return { isNew };
   },

--- a/tests/notification-channels-relay-timeout.test.mts
+++ b/tests/notification-channels-relay-timeout.test.mts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+const originalAbortSignalTimeout = AbortSignal.timeout;
+
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+async function importFreshNotificationChannels() {
+  process.env.CONVEX_SITE_URL = 'https://convex.test';
+  process.env.RELAY_SHARED_SECRET = 'relay-secret';
+  process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-token';
+  return import(`../api/notification-channels.ts?test=${Date.now()}-${Math.random()}`);
+}
+
+function makeSetChannelRequest(): Request {
+  return new Request('https://worldmonitor.app/api/notification-channels', {
+    method: 'POST',
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      Authorization: 'Bearer clerk-token',
+      'Content-Type': 'application/json',
+      'Idempotency-Key': 'notification-channel-timeout-retry',
+    },
+    body: JSON.stringify({
+      action: 'set-channel',
+      channelType: 'email',
+      email: 'retry@example.com',
+    }),
+  });
+}
+
+type RedisCommand = string[];
+
+function installInMemoryUpstash() {
+  const store = new Map<string, string>();
+  const batches: RedisCommand[][] = [];
+
+  globalThis.fetch = mock.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    assert.equal(String(input), 'https://upstash.test/pipeline');
+    const commands = JSON.parse(String(init?.body)) as RedisCommand[];
+    batches.push(commands);
+    const results = commands.map((command) => {
+      const [rawOperation, key, value, ...options] = command;
+      const operation = rawOperation?.toUpperCase();
+      if (operation === 'GET') return { result: store.get(key!) ?? null };
+      if (operation === 'DEL') return { result: store.delete(key!) ? 1 : 0 };
+      if (operation === 'SET') {
+        const hasNx = options.some((option) => option.toUpperCase() === 'NX');
+        if (hasNx && store.has(key!)) return { result: null };
+        store.set(key!, value!);
+        return { result: 'OK' };
+      }
+      throw new Error(`Unexpected Redis command: ${command.join(' ')}`);
+    });
+    return Response.json(results);
+  }) as typeof fetch;
+
+  return { store, batches };
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  AbortSignal.timeout = originalAbortSignalTimeout;
+  restoreEnv();
+});
+
+describe('/api/notification-channels relay timeout recovery', () => {
+  it('returns CORS-safe 500, releases idempotency, and processes the same-key retry', async () => {
+    const redis = installInMemoryUpstash();
+    const mod = await importFreshNotificationChannels();
+    const consoleError = mock.method(console, 'error', () => {});
+    const relaySignals: AbortSignal[] = [];
+    let relayAttempt = 0;
+    const relayFetch = mock.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      relayAttempt += 1;
+      const signal = init?.signal as AbortSignal;
+      relaySignals.push(signal);
+      if (relayAttempt === 1) {
+        return await new Promise<Response>((_resolve, reject) => {
+          const rejectForAbort = () => reject(signal.reason ?? new DOMException('Timed out', 'TimeoutError'));
+          if (signal.aborted) rejectForAbort();
+          else signal.addEventListener('abort', rejectForAbort, { once: true });
+        });
+      }
+      return Response.json({ ok: true, isNew: false });
+    });
+
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-timeout-retry' }),
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: {
+          tier: 1,
+          apiAccess: true,
+          apiRateLimit: 1_000,
+          maxDashboards: 10,
+          prioritySupport: true,
+          exportFormats: ['json'],
+          mcpAccess: true,
+        },
+        validUntil: Date.now() + 60_000,
+      }),
+      fetch: relayFetch,
+    });
+
+    AbortSignal.timeout = ((delay: number) =>
+      originalAbortSignalTimeout(Math.min(delay, 10))) as typeof AbortSignal.timeout;
+
+    const ctx = { waitUntil: (_promise: Promise<unknown>) => {} };
+    const first = await mod.default(makeSetChannelRequest(), ctx);
+
+    assert.equal(first.status, 500);
+    assert.deepEqual(await first.json(), { error: 'Operation failed' });
+    assert.equal(first.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+    assert.equal(first.headers.get('Idempotency-Key'), 'notification-channel-timeout-retry');
+    assert.equal(first.headers.get('Idempotent-Replayed'), 'false');
+    assert.equal(relaySignals[0]?.aborted, true);
+    assert.equal(redis.store.size, 0, 'retryable 500 must release the processing marker');
+    assert.equal(
+      redis.batches.some((batch) => batch.some(([operation]) => operation === 'DEL')),
+      true,
+      'timeout path must issue the idempotency DEL cleanup',
+    );
+
+    const second = await mod.default(makeSetChannelRequest(), ctx);
+
+    assert.equal(second.status, 200);
+    assert.deepEqual(await second.json(), { ok: true });
+    assert.equal(second.headers.get('Idempotency-Key'), 'notification-channel-timeout-retry');
+    assert.equal(second.headers.get('Idempotent-Replayed'), 'false');
+    assert.equal(relayFetch.mock.calls.length, 2);
+    const relayInit = relayFetch.mock.calls[1]!.arguments[1] as RequestInit;
+    assert.equal((relayInit.headers as Record<string, string>)['User-Agent'], 'worldmonitor-edge/1.0');
+    assert.ok(relayInit.signal instanceof AbortSignal);
+
+    const replay = await mod.default(makeSetChannelRequest(), ctx);
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), { ok: true });
+    assert.equal(replay.headers.get('Idempotent-Replayed'), 'true');
+    assert.equal(relayFetch.mock.calls.length, 2, 'completed retry should replay without another relay call');
+    assert.equal(consoleError.mock.calls.length >= 1, true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5426.

`convexRelay()` runs on every GET and POST to `/api/notification-channels`, but it was the only outbound fetch in the file with no `AbortSignal`. The two Upstash calls just above it use 5s, and the other Convex relay callers use 15s (`api/customer-portal.ts:98`, `api/create-checkout.ts:177`).

If the Convex action hangs, the edge invocation stalls until the platform kills it. That path never reaches the handler's `catch`, so `finish()` never runs and the idempotency `processing` marker written by `beginStandaloneIdempotency` is never released — every retry carrying the same `Idempotency-Key` then gets `409 idempotency_conflict` for the marker's full 180s TTL. A user's channel or quiet-hours save is hard-blocked for three minutes with no way to force it through.

With the timeout, the fetch rejects, the existing `catch` returns `{"error":"Operation failed"}` with CORS headers plus a Sentry capture, and `finish()` releases the lock so the next retry proceeds.

15s matches the other Convex relay callers rather than inventing a new value; it is comfortably inside the edge runtime's initial-response budget.

## Verification

- `npm run typecheck:all` — passes (`tsc --noEmit`, `tsc --noEmit -p tsconfig.api.json`, and `audit-convex-string-calls` all clean)
- `npx biome lint ./api/notification-channels.ts` — clean
- Confirmed by reading the handler that the POST `catch` calls `finish(...)`, so the timeout genuinely closes the stuck-lock window rather than only changing the status code.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — server-side only, not variant-specific
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documented behaviour, API/MCP contract, generated doc, Redis key or methodology changes. The endpoint's request/response shapes are untouched; only the failure mode of a hung upstream changes (platform 500 with no CORS → handled 500 with CORS and a released idempotency lock).
