### PR TITLE
fix(tech-events): stop caching a request-filtered payload under the shared key

### DIFF
--- a/server/worldmonitor/research/v1/_tech-events-paging.ts
+++ b/server/worldmonitor/research/v1/_tech-events-paging.ts
@@ -12,6 +12,12 @@ export interface TechEventsPagingPresence {
   hasDays?: boolean;
 }
 
+// Upper clamp bounds. Exported so the shared-cache fallback fetcher in
+// list-tech-events.ts can request the widest set these params allow without
+// duplicating the numbers.
+export const TECH_EVENTS_MAX_LIMIT = 200;
+export const TECH_EVENTS_MAX_DAYS = 365;
+
 function valueOrDefault(value: number | undefined, fallback: number, isPresent: boolean | undefined): number {
   if (isPresent === false || value === undefined) return fallback;
   return value;
@@ -25,7 +31,7 @@ export function resolveTechEventsPaging(
   days: number;
 } {
   return {
-    limit: clampInt(valueOrDefault(req.limit, 50, presence.hasLimit), 50, 1, 200),
-    days: clampInt(valueOrDefault(req.days, 90, presence.hasDays), 90, 1, 365),
+    limit: clampInt(valueOrDefault(req.limit, 50, presence.hasLimit), 50, 1, TECH_EVENTS_MAX_LIMIT),
+    days: clampInt(valueOrDefault(req.days, 90, presence.hasDays), 90, 1, TECH_EVENTS_MAX_DAYS),
   };
 }

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -21,7 +21,12 @@ import type {
 import { CITY_COORDS } from '../../../../api/data/city-coords';
 import filterParamContracts from '../../../../shared/openapi-filter-param-contracts.json';
 import { CHROME_UA } from '../../../_shared/constants';
-import { resolveTechEventsPaging, type TechEventsPagingPresence } from './_tech-events-paging';
+import {
+  resolveTechEventsPaging,
+  TECH_EVENTS_MAX_DAYS,
+  TECH_EVENTS_MAX_LIMIT,
+  type TechEventsPagingPresence,
+} from './_tech-events-paging';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 
@@ -463,8 +468,17 @@ export async function listTechEvents(
 
     // Primary: read from seed-populated Redis key (Railway relay seeds this every 6h)
     const result = await cachedFetchJson<ListTechEventsResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {
-      // Fallback fetcher: only runs on cold start when seed hasn't populated yet
-      const fetched = await fetchTechEvents(req, pagingPresence);
+      // Fallback fetcher: only runs on cold start when seed hasn't populated yet.
+      //
+      // REDIS_CACHE_KEY is shared and request-independent — the relay seeds the
+      // FULL event list under it — so this fetcher must not bake the calling
+      // request's filters into the cached payload. fetchTechEvents() applies
+      // type/mappable/days/limit itself, so ask it for the widest set and let
+      // filterEvents() below narrow the response for this caller.
+      const fetched = await fetchTechEvents(
+        { ...req, type: 'all', mappable: false, limit: TECH_EVENTS_MAX_LIMIT, days: TECH_EVENTS_MAX_DAYS },
+        { hasLimit: true, hasDays: true },
+      );
       return fetched.events.length > 0 ? fetched : null;
     });
 


### PR DESCRIPTION
## Summary

Fixes #5427.

`research:tech-events:v1` is a shared, request-independent cache — the Railway relay seeds the full event list under it, and `listTechEvents()` narrows per caller via `filterEvents()` after reading it.

The cold-start fallback fetcher broke that contract. It called `fetchTechEvents(req, pagingPresence)`, which applies the calling request's `type`, `mappable`, `days` and `limit` before returning, and `cachedFetchJson` then persisted that narrowed list under the shared key for the full 6h TTL. Whichever request happened to warm a cold cache decided what every other client could see until the key expired.

Concretely: with the cache cold, `?type=conference&limit=5` stores 5 conference events, and a subsequent parameterless request returns `count: 5` instead of the full list. Even a parameterless cold request pins the shared key to the `limit=50, days=90` defaults, so a later `?limit=200&days=365` can never see more.

The fallback fetcher now asks for the widest set the params allow. `filterEvents()` already re-applies this caller's filters and recomputes `count` / `conferenceCount` / `mappableCount` from the narrowed set, so **responses are unchanged on the seeded path** — only the cached payload's width changes.

The clamp maxima are exported from `_tech-events-paging.ts` and reused both in `resolveTechEventsPaging` and in the fetcher call, so the two can't drift.

## Verification

- `npm run typecheck` — passes
- `npx tsx --test tests/tech-events-paging.test.mts` — 8/8 pass (the clamp bounds are now named constants with the same values, so the existing clamp assertions still hold)
- `npx biome lint ./server/worldmonitor/research/v1/` — clean

Manual check for a reviewer: delete `research:tech-events:v1`, issue `?type=conference&limit=5`, then `GET` with no params — `count` should reflect the full event list rather than 5.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: `server/worldmonitor/research/v1/` (tech events RPC + its shared cache key)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — server-side only, not variant-specific
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked — N/A
- [ ] All required Audit Council role signoffs attached — N/A
- [ ] Generated docs regenerated from proto where applicable — N/A, no proto change
- [ ] Fixture-backed examples recomputed — N/A
- [x] Redis writers/readers enumerated for every documented key — `research:tech-events:v1` has exactly two writers (the relay seeder in `scripts/ais-relay.cjs`, and this cold-start fallback) and one reader (`listTechEvents`). This PR aligns the fallback writer with the seeder's full-list contract; the key name, TTL and shape are unchanged.
