### PR TITLE
fix(feed-digest): decode &amp; last so RSS entities aren't decoded twice

### DIFF
--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -748,15 +748,30 @@ function extractTag(xml: string, tag: string): string {
   return match ? decodeXmlEntities(match[1]!.trim()) : '';
 }
 
+/**
+ * `String.fromCodePoint` throws `RangeError` on anything outside the Unicode
+ * range, which would turn one malformed numeric reference into a failed feed
+ * parse. Drop those instead. `fromCharCode` is not usable here: it truncates to
+ * 16 bits, so `&#128512;` decoded to U+F600 (a private-use glyph) rather than 😀.
+ */
+function decodeNumericReference(codePoint: number): string {
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : '';
+}
+
 function decodeXmlEntities(s: string): string {
   return s
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)));
+    .replace(/&#(\d+);/g, (_, n) => decodeNumericReference(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => decodeNumericReference(parseInt(n, 16)))
+    // `&amp;` MUST be decoded last. Decoding it first turns the escaped
+    // ampersand of `&amp;lt;` into a live `&`, which the very next replace then
+    // consumes as `&lt;` — one pass decoding twice.
+    .replace(/&amp;/g, '&');
 }
 
 async function enrichWithAiCache(items: ParsedItem[]): Promise<void> {
@@ -1547,6 +1562,7 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
 /** Internal exports for unit tests only — do not import in production code. */
 export const __testing__ = {
   parseRssXml,
+  decodeXmlEntities,
   extractDescription,
   extractRawTagBody,
   extractFirstDateTag,

--- a/tests/news-feed-digest-entity-decode.test.mts
+++ b/tests/news-feed-digest-entity-decode.test.mts
@@ -11,7 +11,8 @@ function escapeXml(text: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
 }
 
 describe('decodeXmlEntities: one pass must decode exactly one level', () => {
@@ -21,6 +22,7 @@ describe('decodeXmlEntities: one pass must decode exactly one level', () => {
       'XSS via &lt;script&gt; in Acme SDK',
       'Q3 revenue > $2B & rising',
       'He said "no comment"',
+      "Ireland's PM: 'no deal' & <no> comment",
       'plain headline with no entities',
     ];
     for (const original of originals) {

--- a/tests/news-feed-digest-entity-decode.test.mts
+++ b/tests/news-feed-digest-entity-decode.test.mts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ } from '../server/worldmonitor/news/v1/list-feed-digest';
+
+const { decodeXmlEntities, extractDescription } = __testing__;
+
+/** Mirrors what a well-formed feed generator produces for a plain-text string. */
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+describe('decodeXmlEntities: one pass must decode exactly one level', () => {
+  it('round-trips escaped text back to the original', () => {
+    const originals = [
+      'AT&T completes merger',
+      'XSS via &lt;script&gt; in Acme SDK',
+      'Q3 revenue > $2B & rising',
+      'He said "no comment"',
+      'plain headline with no entities',
+    ];
+    for (const original of originals) {
+      assert.equal(decodeXmlEntities(escapeXml(original)), original);
+    }
+  });
+
+  it('does not double-decode escaped markup into live markup', () => {
+    // A headline whose literal text is `&lt;script&gt;` escapes to `&amp;lt;script&amp;gt;`.
+    // Decoding `&amp;` first would yield `<script>`.
+    assert.equal(
+      decodeXmlEntities('XSS via &amp;lt;script&amp;gt; in Acme SDK'),
+      'XSS via &lt;script&gt; in Acme SDK',
+    );
+  });
+
+  it('decodes numeric references above the BMP', () => {
+    assert.equal(decodeXmlEntities('&#128512;'), '\u{1F600}');
+    assert.equal(decodeXmlEntities('&#x1F600;'), '\u{1F600}');
+  });
+
+  it('drops out-of-range numeric references instead of throwing', () => {
+    assert.equal(decodeXmlEntities('a&#999999999;b'), 'ab');
+  });
+
+  it('still decodes a single level of the predefined entities', () => {
+    assert.equal(decodeXmlEntities('5 &lt; 6 &amp; 7 &gt; 2'), '5 < 6 & 7 > 2');
+    assert.equal(decodeXmlEntities('&quot;quoted&quot; &apos;single&apos;'), '"quoted" \'single\'');
+  });
+});
+
+describe('extractDescription: escaped markup survives the tag strip', () => {
+  it('keeps text that was escaped twice by the publisher', () => {
+    const block = `<item><description>Acme patched an XSS triggered by &amp;lt;script&amp;gt; tags in user-supplied profile bios.</description></item>`;
+    const description = extractDescription(block, false, 'Unrelated headline');
+    // Double-decoding produced `<script>`, which the `<[^>]+>` strip then
+    // deleted along with the surrounding words.
+    assert.match(description, /&lt;script&gt;/);
+    assert.match(description, /tags in user-supplied profile bios/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5428.

`decodeXmlEntities` decoded `&amp;` first. That turns the escaped ampersand of `&amp;lt;` into a live `&`, which the very next `.replace` immediately consumes as `&lt;` — so a single pass decodes two levels. `&amp;` has to go last.

The visible damage differs by call site:

- **`extractTag`** (titles): a headline whose literal text is `&lt;script&gt;` arrives escaped as `&amp;lt;script&amp;gt;` and comes back as `<script>` — raw markup injected into `ParsedItem.title` and emitted on the wire instead of the text the publisher wrote.
- **`extractDescription`**: it strips tags *after* decoding, so the same input loses the words entirely — `"XSS triggered by &lt;script&gt; tags in profile bios"` becomes `"XSS triggered by  tags in profile bios"`. That is a silent content deletion.

This also switches the numeric-reference branches from `String.fromCharCode` to `String.fromCodePoint`. `fromCharCode` truncates to 16 bits, so `&#128512;` decoded to U+F600 (private use) instead of 😀. Out-of-range values are dropped rather than allowed to throw `RangeError`, which would otherwise fail an entire feed parse over one malformed reference.

## Verification

Adds `tests/news-feed-digest-entity-decode.test.mts`. The load-bearing case is a **produce-then-consume round-trip** — escape a plain string, decode it, assert the original comes back — rather than only asserting the specific symptom is gone:

```ts
for (const original of originals) {
  assert.equal(decodeXmlEntities(escapeXml(original)), original);
}
```

Results:

- Against the previous implementation: **5 of 6 cases fail** (title double-decode, round-trip, astral numeric refs, out-of-range refs, and the description-deletion case).
- Against this branch: **6/6 pass**.
- `npx tsx --test` over the 10 neighbouring digest/feed suites (`news-feed-digest-rss-sniff`, `digest-buildDigest-*`, `digest-no-reclassify`, `digest-score-floor`, `news-digest-timeout-budget`, `feed-date`, plus the new file): **79/79 pass**.
- `npm run typecheck` — passes.
- `npx biome lint` on both changed files — clean.

`decodeXmlEntities` is added to the existing `__testing__` export so the test can reach it; no public surface changes.

## Type of change

- [x] Bug fix

## Affected areas

- [x] News panels / RSS feeds

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — server-side parser, covered by unit tests; not variant-specific
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A, no new feeds
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documented methodology, API/MCP contract, generated doc, Redis key or example output changes. This only corrects entity decoding inside the feed parser.
