### PR TITLE
fix(seed-utils): retry transient Redis blips on the read path + skip-path meta ops (#5437)

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -281,12 +281,37 @@ async function redisCommand(url, token, command) {
 }
 
 async function redisGet(url, token, key) {
-  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(5_000),
-  });
-  if (!resp.ok) return null;
-  const data = await resp.json();
+  // Retry transient failures (timeout / network tear / 5xx / 429) with the
+  // redisCommand tagging contract. A single unretried blip here silently read
+  // as "key missing", which killed seed-gdelt-intel's cache-merge fallback for
+  // 21h while the canonical key was healthy (issue #5437). The external
+  // contract is unchanged: HTTP failures still degrade to null (now loudly),
+  // thrown failures still propagate — both only after retries.
+  let data;
+  try {
+    data = await withRetry(async () => {
+      const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!resp.ok) {
+        const err = new Error(`Redis GET ${key} failed: HTTP ${resp.status}`);
+        if (PERMANENT_4XX_STATUSES.has(resp.status)) {
+          err.nonRetryable = true;
+        } else if (resp.status === 429) {
+          const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
+          if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+        }
+        err.httpStatus = resp.status;
+        throw err;
+      }
+      return resp.json();
+    }, 2, 1000);
+  } catch (err) {
+    if (err.httpStatus == null) throw err;
+    console.warn(`  Redis GET ${key}: degraded to null (${err.message})`);
+    return null;
+  }
   if (!data.result) return null;
   // Envelope-aware: returns inner `data` for seeded keys written in contract
   // mode, passes through legacy (bare-shape) values unchanged. Fixes WoW/cross-
@@ -438,7 +463,12 @@ export async function writeFreshnessMetadata(domain, resource, count, source, tt
   // Use the data TTL if it exceeds 7 days so monthly/annual seeds don't lose
   // their meta key before the health check maxStaleMin threshold is reached.
   const metaTtl = Math.max(86400 * 7, ttlSeconds || 0);
-  await redisSet(url, token, metaKey, meta, metaTtl);
+  // Retry transient Redis failures: this SET runs bare on runSeed's
+  // validate-skip path, where an unretried Upstash abort escaped to the
+  // seeder's top-level catch as `FATAL: The operation was aborted due to
+  // timeout` → exit 1 (seed-gdelt-intel, issue #5437). redisCommand tags
+  // permanent 4xx nonRetryable and 429 with Retry-After; withRetry honors both.
+  await withRetry(() => redisSet(url, token, metaKey, meta, metaTtl), 2, 1000);
   return meta;
 }
 
@@ -459,12 +489,27 @@ export async function writeFreshnessMetadata(domain, resource, count, source, tt
 export async function readCanonicalEnvelopeMeta(canonicalKey) {
   try {
     const { url, token } = getRedisCredentials();
-    const resp = await fetch(`${url}/get/${encodeURIComponent(canonicalKey)}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!resp.ok) return null;
-    const data = await resp.json();
+    // Retry transient failures before degrading: a blip here is worse than a
+    // crash — the caller falls back to writing recordCount=0 with
+    // fetchedAt=NOW, resetting the freshness clock over real staleness
+    // (issue #5437). Outer catch preserves the never-throws contract.
+    const data = await withRetry(async () => {
+      const resp = await fetch(`${url}/get/${encodeURIComponent(canonicalKey)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!resp.ok) {
+        const err = new Error(`Canonical meta GET ${canonicalKey} failed: HTTP ${resp.status}`);
+        if (PERMANENT_4XX_STATUSES.has(resp.status)) {
+          err.nonRetryable = true;
+        } else if (resp.status === 429) {
+          const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
+          if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+        }
+        throw err;
+      }
+      return resp.json();
+    }, 2, 1000);
     if (!data || !data.result) return null;
     let parsed;
     try { parsed = JSON.parse(data.result); } catch { return null; }

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -161,7 +161,14 @@ export async function fetchAllTopics(deps = {}) {
     _sleep = sleep,
     _fetchArticles = fetchWithRetry,
     _fetchTimeline = fetchTopicTimeline,
-    _loadPrevious = () => verifySeedKey(CANONICAL_KEY).catch(() => null),
+    // The cache-merge fallback is what keeps seed-meta fresh through a GDELT
+    // outage — when this read dies the run degrades to a no-write skip and
+    // freshness silently rots (21h stale before the gate fired, issue #5437),
+    // so its failure must be visible in the run log.
+    _loadPrevious = () => verifySeedKey(CANONICAL_KEY).catch((err) => {
+      console.warn(`  cache-merge: failed to load previous snapshot (${err?.message || err}) — topics will not be backfilled this run`);
+      return null;
+    }),
     _softBudgetMs = FETCH_SOFT_BUDGET_MS,
     _minTopicBudgetMs = MIN_TOPIC_BUDGET_MS,
     _interTopicDelayMs = INTER_TOPIC_DELAY_MS,

--- a/tests/seed-gdelt-intel-merge-read-warns.test.mjs
+++ b/tests/seed-gdelt-intel-merge-read-warns.test.mjs
@@ -1,0 +1,59 @@
+// Regression test for issue #5437 (seeder side): the cache-merge fallback's
+// previous-snapshot read must be RETRIED and its failure must be LOUD.
+//
+// The default `_loadPrevious` was `verifySeedKey(KEY).catch(() => null)` — a
+// silent catch. During the 2026-07-21 GDELT brownout the read blipped on every
+// run, the merge silently no-op'd, and seed-meta aged for 21h with zero
+// evidence in the run logs. The fallback is the mechanism that keeps freshness
+// alive through an upstream outage; when it dies the log must say so.
+
+import { test, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { fetchAllTopics } = await import('../scripts/seed-gdelt-intel.mjs');
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalWarn = console.warn;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+  console.warn = originalWarn;
+});
+
+test('default _loadPrevious retries the Redis read and warns loudly when it stays down', async () => {
+  let redisCalls = 0;
+  const warns = [];
+  console.warn = (...args) => { warns.push(args.join(' ')); };
+  // Collapse retry backoffs so exhaustion doesn't sleep for real.
+  globalThis.setTimeout = (cb, ms, ...args) =>
+    originalSetTimeout(cb, ms >= 500 ? 0 : ms, ...args);
+  globalThis.fetch = async () => {
+    redisCalls += 1;
+    const err = new Error('The operation was aborted due to timeout');
+    err.name = 'AbortError';
+    throw err;
+  };
+
+  // Soft budget pre-spent: no topic fetch starts, all 6 topics are empty, so
+  // the cache-merge consults the DEFAULT _loadPrevious (deliberately not
+  // injected here — this test exercises the real wiring).
+  const out = await fetchAllTopics({
+    _softBudgetMs: 1,
+    _sleep: async () => {},
+    _fetchArticles: async () => { throw new Error('must not fetch topics'); },
+    _fetchTimeline: async () => [],
+  });
+
+  assert.equal(redisCalls, 3, 'previous-snapshot read must be retried (3 attempts)');
+  assert.ok(
+    warns.some((w) => w.includes('cache-merge')),
+    `a failed merge read must warn loudly; warns were: ${JSON.stringify(warns)}`,
+  );
+  assert.equal(out.topics.length, 6, 'run still completes with all topics represented');
+  for (const t of out.topics) assert.equal(t.articles.length, 0, 'no backfill when the read is down');
+});

--- a/tests/seed-utils-redis-read-retry.test.mjs
+++ b/tests/seed-utils-redis-read-retry.test.mjs
@@ -1,0 +1,226 @@
+// Regression tests for issue #5437: transient-Redis retry on the READ path
+// (verifySeedKey/redisGet), on writeFreshnessMetadata, and on
+// readCanonicalEnvelopeMeta.
+//
+// seed-gdelt-intel's cache-merge fallback loads the previous canonical
+// snapshot via verifySeedKey. redisGet had a 5s abort with NO retry and
+// converted any non-OK status into a silent null, so a single Upstash blip at
+// the soft-budget boundary read as "no previous snapshot": the merge no-op'd,
+// validation failed, the run skipped without writing, and seed-meta aged until
+// the freshness gate fired (gdeltIntel age=882m > max=720m) — while the
+// canonical key was perfectly healthy. Sibling ops on the same skip path
+// (writeFreshnessMetadata's SET, readCanonicalEnvelopeMeta's GET) were also
+// unretried; the SET aborting is what produced the two
+// `FATAL: The operation was aborted due to timeout` exit-1 crashes.
+//
+// Contract under test (mirrors the writeExtraKey / redisCommand tagging):
+//   - timeout / network / 5xx / 429 → retried (429 honors Retry-After)
+//   - permanent 4xx → fail fast, no retry
+//   - reads NEVER gain a new throw path: HTTP failures still degrade to null
+//     after retries; thrown (network/timeout) failures still propagate.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { verifySeedKey, writeFreshnessMetadata, readCanonicalEnvelopeMeta } =
+  await import('../scripts/_seed-utils.mjs');
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+beforeEach(() => {
+  // Collapse retry backoffs (>=500ms) so exhaustion tests don't sleep for real;
+  // short timers pass through untouched.
+  globalThis.setTimeout = (cb, ms, ...args) =>
+    originalSetTimeout(cb, ms >= 500 ? 0 : ms, ...args);
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+const ENVELOPE = {
+  _seed: { fetchedAt: 1784621196406, recordCount: 6, sourceVersion: 'gdelt-doc-v2', schemaVersion: 1, state: 'OK' },
+  data: { topics: [{ id: 'military', articles: [{ title: 'cached' }] }], fetchedAt: '2026-07-21T08:06:36.406Z' },
+};
+
+function buildResponse({ ok = true, status = 200, body = { result: 'OK' }, headers = {} }) {
+  return { ok, status, json: async () => body, text: async () => JSON.stringify(body), headers };
+}
+
+function abortError() {
+  const err = new Error('The operation was aborted due to timeout');
+  err.name = 'AbortError';
+  return err;
+}
+
+// ---------- verifySeedKey (the merge-fallback read) ----------
+
+test('verifySeedKey: retries on timeout and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) throw abortError();
+    return buildResponse({ body: { result: JSON.stringify(ENVELOPE) } });
+  };
+
+  const data = await verifySeedKey('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 2, 'must retry once after timeout');
+  assert.equal(data.topics[0].articles[0].title, 'cached', 'returns unwrapped payload');
+});
+
+test('verifySeedKey: retries on 503 and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return buildResponse({ ok: false, status: 503, body: {} });
+    return buildResponse({ body: { result: JSON.stringify(ENVELOPE) } });
+  };
+
+  const data = await verifySeedKey('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 2, 'must retry once after 503');
+  assert.ok(Array.isArray(data.topics), 'returns the payload, not null');
+});
+
+test('verifySeedKey: retries on 429 honoring Retry-After', async () => {
+  let calls = 0;
+  const waits = [];
+  globalThis.setTimeout = (cb, ms, ...args) => {
+    waits.push(ms);
+    return originalSetTimeout(cb, ms >= 500 ? 0 : ms, ...args);
+  };
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return buildResponse({ ok: false, status: 429, body: {}, headers: { 'retry-after': '2' } });
+    return buildResponse({ body: { result: JSON.stringify(ENVELOPE) } });
+  };
+
+  const data = await verifySeedKey('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 2, 'must retry once after 429');
+  assert.ok(data.topics, 'returns the payload');
+  assert.ok(waits.some((ms) => ms >= 2000), 'Retry-After hint must be honored');
+});
+
+test('verifySeedKey: permanent 401 returns null without retry', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ ok: false, status: 401, body: {} });
+  };
+
+  const data = await verifySeedKey('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 1, 'must not retry permanent 401');
+  assert.equal(data, null, 'legacy null contract preserved');
+});
+
+test('verifySeedKey: persistent 503 degrades to null after exhausting retries (no new throw path)', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ ok: false, status: 503, body: {} });
+  };
+
+  const data = await verifySeedKey('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 3, 'default retry count should be 2 (3 total attempts)');
+  assert.equal(data, null, 'HTTP failure still degrades to null, never throws');
+});
+
+test('verifySeedKey: persistent timeout still propagates (legacy throw contract) after retries', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw abortError();
+  };
+
+  await assert.rejects(() => verifySeedKey('intelligence:gdelt-intel:v1'), /aborted due to timeout/);
+  assert.equal(calls, 3, 'timeouts must be retried before propagating');
+});
+
+// ---------- writeFreshnessMetadata (the skip-path seed-meta mirror SET) ----------
+
+test('writeFreshnessMetadata: retries on timeout and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) throw abortError();
+    return buildResponse({});
+  };
+
+  const meta = await writeFreshnessMetadata('intelligence', 'gdelt-intel', 6, 'gdelt-doc-v2', 86400, 1784621196406);
+  assert.equal(calls, 2, 'must retry once after timeout');
+  assert.equal(meta.fetchedAt, 1784621196406, 'mirrored fetchedAt preserved');
+});
+
+test('writeFreshnessMetadata: retries on 503 and succeeds on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return buildResponse({ ok: false, status: 503, body: {} });
+    return buildResponse({});
+  };
+
+  await writeFreshnessMetadata('intelligence', 'gdelt-intel', 6, 'gdelt-doc-v2', 86400);
+  assert.equal(calls, 2, 'must retry once after 503');
+});
+
+test('writeFreshnessMetadata: fails fast on permanent 401 without retry', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ ok: false, status: 401, body: {} });
+  };
+
+  await assert.rejects(
+    () => writeFreshnessMetadata('intelligence', 'gdelt-intel', 6, 'gdelt-doc-v2', 86400),
+    /HTTP 401/,
+  );
+  assert.equal(calls, 1, 'must not retry permanent 401');
+});
+
+test('writeFreshnessMetadata: still throws after exhausting retries', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ ok: false, status: 503, body: {} });
+  };
+
+  await assert.rejects(
+    () => writeFreshnessMetadata('intelligence', 'gdelt-intel', 6, 'gdelt-doc-v2', 86400),
+    /HTTP 503/,
+  );
+  assert.equal(calls, 3, 'default retry count should be 2 (3 total attempts)');
+});
+
+// ---------- readCanonicalEnvelopeMeta (the skip-path mirror GET) ----------
+// A transient failure here is worse than a crash: the caller falls back to
+// writing recordCount=0 with fetchedAt=NOW, resetting the freshness clock and
+// masking real staleness.
+
+test('readCanonicalEnvelopeMeta: retries on 503 and returns meta on second attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return buildResponse({ ok: false, status: 503, body: {} });
+    return buildResponse({ body: { result: JSON.stringify(ENVELOPE) } });
+  };
+
+  const meta = await readCanonicalEnvelopeMeta('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 2, 'must retry once after 503');
+  assert.equal(meta.recordCount, 6);
+  assert.equal(meta.fetchedAt, 1784621196406);
+});
+
+test('readCanonicalEnvelopeMeta: retries on timeout, still null (never throws) when exhausted', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw abortError();
+  };
+
+  const meta = await readCanonicalEnvelopeMeta('intelligence:gdelt-intel:v1');
+  assert.equal(calls, 3, 'default retry count should be 2 (3 total attempts)');
+  assert.equal(meta, null, 'defensive null contract preserved');
+});


### PR DESCRIPTION
Closes #5437.

## What happened (short version)

During the 2026-07-21 GDELT brownout, `seed-gdelt-intel`'s cache-merge fallback — the mechanism designed to keep seed-meta fresh through exactly this kind of outage — silently died on every run for 21h. The freshness gate fired (`gdeltIntel age=882m max=720m`) while the canonical key was perfectly healthy (23KB, 130ms GET, 6×10 cached articles). Two runs additionally crashed exit-1 with `FATAL: The operation was aborted due to timeout`. Full diagnosis in #5437.

Three unretried Redis ops, one shared root cause:

| Op | Failure mode before | Consequence |
|----|--------------------|-------------|
| `redisGet` (merge's previous-snapshot read) | 5s abort, no retry, non-OK → **silent null** | Merge no-ops → validation fails → no-write skip → seed-meta ages invisibly |
| `writeFreshnessMetadata` → `redisSet` | 15s abort, no retry, called bare on the skip path | Abort escapes to top-level catch → `FATAL` → exit 1 → "Deploy Crashed!" |
| `readCanonicalEnvelopeMeta` | 5s abort, no retry, any error → null | Caller falls back to `recordCount=0, fetchedAt=NOW` — resets the freshness clock over real staleness |

## Changes

- **`redisGet`**: wrapped in `withRetry` with the `redisCommand` tagging contract (permanent 4xx `nonRetryable`, 429 honors `Retry-After`, timeout/5xx backoff). **External contract unchanged**: HTTP failures still degrade to null (now with a warn), thrown failures still propagate — both only after retries. Benefits every `verifySeedKey`/`readCanonicalValue` caller (~15 seeders).
- **`writeFreshnessMetadata`**: SET wrapped in `withRetry` (2 retries, same as the earlier `writeExtraKey`/`atomicPublish` PUBLISH_TIMEOUT fix that missed these ops).
- **`readCanonicalEnvelopeMeta`**: retries before degrading; outer catch preserves the never-throws contract.
- **`seed-gdelt-intel` `_loadPrevious`**: silent `.catch(() => null)` → loud `cache-merge: failed to load previous snapshot (...)` warning. A dead fallback must be visible in run logs.

## Tests (red-first per Bug Fix Protocol)

13 new tests, all failing before the fix (12 red + 1 mock-fidelity), all green after:

- `tests/seed-utils-redis-read-retry.test.mjs` — retry/degrade/propagate contracts for all three helpers: timeout→retry→succeed, 503→retry→succeed, 429 honors Retry-After, permanent 401 fails fast without retry, persistent 503 degrades to null (no new throw path), persistent timeout still propagates (legacy throw contract).
- `tests/seed-gdelt-intel-merge-read-warns.test.mjs` — exercises the seeder's REAL default `_loadPrevious` wiring (not injected): read retried 3×, loud `cache-merge` warning emitted, run still completes.

Regression: full seeder-related suite green (794 tests — `seed-utils*`, `seed-gdelt*`, `seed*`, content-age coverage, envelope parity; the tsx-runner files verified under `tsx --test` as CI runs them). Biome clean.

## Deliberate non-goals

- The **content-age opt-in** (4 of 6 topics are ~3 weeks stale under a fresh envelope; nothing alerts on it) is flagged in #5437 as a separate decision — not bundled here.
- Latency budgets verified: worst-case merge read ~18s vs >80s post-budget headroom (#4864 math); worst-case meta SET ~48s matches `atomicPublish`'s documented ceiling. Exhausted retries on the SET still FATAL — correct once Redis is sustainedly down, and no longer reachable by a single blip.

https://claude.ai/code/session_01AKbRZXV6kKe8MTYpKZSLBM
