### PR TITLE
feat(content): receipts round — Palantir rewrite + real scorecard/radiation/tender data in-post

### DIFF
--- a/blog-site/src/content/blog/ai-forecast-accuracy-brier-scorecard-worldmonitor.md
+++ b/blog-site/src/content/blog/ai-forecast-accuracy-brier-scorecard-worldmonitor.md
@@ -1,11 +1,12 @@
 ---
 title: "We Grade Our Own Forecasts: Inside the Forecast Scorecard"
-description: "WorldMonitor resolves its AI forecasts against reality and publishes the results: Brier scores, log scores, calibration buckets, and per-domain accuracy breakdowns."
+description: "WorldMonitor grades its AI forecasts and prints the results: Brier 0.202 over 32 scored calls, the calibration table showing where we're overconfident, and a head-to-head loss to the markets."
 metaTitle: "AI Forecast Accuracy & Brier Scorecard | WorldMonitor"
 keywords: "AI forecast accuracy, Brier score forecasting, geopolitical forecast track record, forecast calibration, prediction accountability, forecast verification"
 audience: "Forecasters, superforecasting community, quant researchers, skeptical analysts, AI evaluation researchers"
 heroImage: "/blog/og/ai-forecast-accuracy-brier-scorecard-worldmonitor.png"
 pubDate: "2026-07-21"
+modifiedDate: "2026-07-22"
 ---
 
 Every AI product now makes predictions. Almost none of them tell you their error rate.
@@ -24,6 +25,33 @@ From the resolved ledger, the scorecard computes the metrics forecasting researc
 - **Domain breakdowns** — accuracy sliced by forecast domain, because being sharp on commodity moves doesn't certify you on diplomatic outcomes, and pretending one number covers both is how track records mislead.
 
 The scoring runs over a rolling window with judged and pending counts visible, so you can see not just how good the record is but how much record there is.
+
+## The actual scorecard, as of July 22, 2026
+
+A post about publishing your numbers should publish the numbers. These were pulled from the live `get_forecast_scorecard` endpoint while writing, over the current 180-day rolling window:
+
+**Overall: 32 scored forecasts, Brier 0.202, log score 0.575.** Answering "50%" to everything scores 0.25, so the system beats maximal ignorance — modestly.
+
+**The calibration table, including the ugly rows:**
+
+| Confidence bucket | Forecasts | Avg predicted | Actually happened |
+|---|---|---|---|
+| 0–10% | 4 | 8% | 0% |
+| 10–20% | 2 | 11% | 0% |
+| 30–40% | 4 | 33% | 25% |
+| 40–50% | 9 | 43% | 22% |
+| 50–60% | 8 | 54% | 13% |
+| 60–70% | 5 | 62% | 20% |
+
+Read the bottom three rows: the system is **systematically overconfident in the 40–70% band** — events it calls roughly even-odds happen about a fifth of the time. The low buckets are honest; the middle is the current failure mode, and it's now a named engineering target rather than a private embarrassment. Notice also what the table doesn't contain: no scored forecast above 70% yet — the system hasn't been willing to make high-confidence calls that resolve.
+
+**Head-to-head against prediction markets:** on the three resolved questions where a forecast overlapped a liquid market, our Brier was 0.040 against the market's 0.010. Three questions is anecdote, not statistics — but the market won, and pretending otherwise would defeat the point of this page.
+
+**The void ledger:** of 124 resolved entries, 92 (74%) were voided — resolution criteria that turned out too vague to judge cleanly. Voids are counted and published rather than quietly dropped, and driving that rate down (mostly in infrastructure forecasts, where 76 of 87 resolutions voided) is the pipeline's current top fix.
+
+**By domain:** cyber is the strongest slice (Brier 0.111 over 11 scored); markets sit at 0.210 (n=4); infrastructure is the weakest at 0.286 with the void problem above. Exactly the kind of spread that makes a single blended "accuracy" number misleading — which is why the tool returns the breakdown.
+
+Thirty-two scored forecasts is a young ledger, not a track record. Publishing it anyway — small, unflattering rows included — is the deposit on the claim that this scorecard means something. Metaculus and Good Judgment publish theirs; prediction markets publish by construction; a forecasting product that hides its ledger until the numbers flatter it isn't doing forecasting, it's doing marketing.
 
 ## Why publish it
 
@@ -57,4 +85,4 @@ In the forecast panel on the dashboard, and programmatically via the `get_foreca
 
 ---
 
-**Anyone can make predictions. The scorecard is the difference between forecasting and content — and it only counts if you publish it before you know how it ends.**
+**Anyone can make predictions. The ledger currently reads Brier 0.202 over 32 scored calls, overconfident in the middle, beaten by the market head-to-head — published anyway, because a scorecard only counts if you print it before it flatters you.**

--- a/blog-site/src/content/blog/government-tenders-procurement-intelligence-worldmonitor.md
+++ b/blog-site/src/content/blog/government-tenders-procurement-intelligence-worldmonitor.md
@@ -6,6 +6,7 @@ keywords: "government tender tracking, global procurement opportunities, SAM.gov
 audience: "Business development teams, government contractors, consultancies, market-entry analysts, procurement researchers"
 heroImage: "/blog/og/government-tenders-procurement-intelligence-worldmonitor.png"
 pubDate: "2026-07-21"
+modifiedDate: "2026-07-22"
 ---
 
 Governments announce their priorities through procurement before they announce them through policy. A defense ministry tendering for drone-detection systems, a health agency buying cold-chain logistics, a municipality procuring flood barriers — each notice is a documented, budgeted statement of intent, published weeks or months before the contract shows up in any news cycle.
@@ -28,6 +29,23 @@ The procurement pipeline reads only official public interfaces — no scraping o
 A seeder refreshes the canonical snapshot hourly. If one source fails, the others keep flowing and the response reports `availability: "partial"` with that source's last-good records retained — a failed adapter is never displayed as "zero tenders."
 
 One deliberate gap: Australia. AusTender publishes no machine-readable feed that includes closing dates, and WorldMonitor never represents an opportunity without a verifiable deadline. Australian coverage stays absent rather than inferred — the reasoning is documented in the [Global Procurement Intelligence docs](https://www.worldmonitor.app/docs/global-procurement-intelligence).
+
+## What's in the feed right now
+
+Talk is cheap; here is one live query — `query: "software", sort: closing_soon` — run against the feed on July 22, 2026:
+
+| Opportunity | Buyer | Source | Closes |
+|---|---|---|---|
+| [Software and IT System Support](https://projects.worldbank.org/en/projects-operations/procurement-detail/OP00455744) | World Bank project | World Bank | Jul 23 |
+| [Collaborative Autonomy Software Framework Development](https://sam.gov/workspace/contract/opp/fc8c15f3161248be842ae9c07527d15a/view) | US Air Force — AFLCMC, ISR directorate | SAM.gov | Aug 1 |
+| [Culture and Employee Experience Evolution Support RFP](https://www.merx.com/public/solicitations/4019038063/abstract?language=EN) | Farm Credit Canada | CanadaBuys | Aug 4 |
+| [Portable Ultrasound Simulator](https://www.gets.govt.nz//UA/ExternalTenderDetails.htm?id=34516070) | University of Auckland | GETS (NZ) | Aug 14 |
+
+Four sources, four jurisdictions, one query, official notice links intact. An Air Force autonomy-software solicitation sitting next to a World Bank IT tender and a New Zealand university's simulator purchase is exactly what a cross-portal feed is for — no single national portal shows you that row set.
+
+## If you already live in SAM.gov
+
+Then you don't need this feed for the US — SAM.gov's saved searches and NAICS/PSC alerts are precise, free, and native, and GovWin adds the enterprise-grade capture layer if you can pay for it. The honest pitch is different: **the cross-portal problem.** The moment your pipeline crosses a border, you're juggling TED's schema, Contracts Finder's OCDS releases, CanadaBuys CSVs, and GETS RSS — separately, in different vocabularies, with different alert mechanics. This feed's job is one schema and one query across all six official sources, with US coverage as a member of the set rather than the whole set. If your business is US-only, keep your SAM alerts; if it isn't, this is the aggregation you'd otherwise build yourself.
 
 ## Opportunities, not just awards
 

--- a/blog-site/src/content/blog/real-time-radiation-monitoring-radnet-safecast.md
+++ b/blog-site/src/content/blog/real-time-radiation-monitoring-radnet-safecast.md
@@ -6,6 +6,7 @@ keywords: "real time radiation map, radiation levels live, nuclear radiation mon
 audience: "OSINT analysts, journalists, researchers, emergency-preparedness planners, concerned readers during nuclear events"
 heroImage: "/blog/og/real-time-radiation-monitoring-radnet-safecast.png"
 pubDate: "2026-07-21"
+modifiedDate: "2026-07-22"
 ---
 
 Every nuclear scare follows the same script. An incident at a plant, shelling near a reactor, a test rumor — and within an hour, social media fills with screenshots of dosimeters, decade-old maps, and numbers with no units. Radiation is uniquely suited to panic because it's invisible, poorly understood, and genuinely serious when real.
@@ -22,6 +23,18 @@ The radiation layer merges two complementary systems:
 The merge is deliberate. Official networks are trustworthy but geographically bounded; Safecast reaches places no government feed covers. Each observation keeps its source attribution, so you always know whether you're reading a federal station or a community sensor.
 
 Readings appear in the **Radiation Watch panel** and on the **radiation map layer** — and the map gives them context that a standalone radiation site can't: **nuclear facilities** and **IAEA-listed gamma irradiator** locations as reference layers, plus conflicts, fires, and weather on the same canvas. A radiation question is never just "what's the reading?" — it's "what's the reading, where, relative to what, and which way does the wind blow?"
+
+## What the network read while this was written
+
+Pulled live from the merged feed on July 22, 2026:
+
+| Station | Reading | Its own baseline | Deviation | Verdict |
+|---|---|---|---|---|
+| Honolulu (EPA RadNet) | 28 nSv/h | 27.8 | +0.2 (z = 0.2) | normal |
+| Seattle (EPA RadNet) | 27 nSv/h | 26.9 | +0.1 (z = 0.1) | normal |
+| Houston (EPA RadNet) | 39 nSv/h | 36.4 | +2.6 (z = 1.8) | normal |
+
+The Houston row is the whole lesson in one line. Its 39 nSv/h is forty percent "hotter" than Seattle — and completely normal, because Houston's own baseline runs high. Someone screenshotting absolute numbers would call that a story; the z-score says it's a Tuesday. Every observation in the feed carries exactly this context: source attribution, freshness, the station's own baseline, a z-score, and a severity classification — so "elevated" means elevated *for that place*, not elevated compared to a city with different geology.
 
 ## How to read a radiation event
 

--- a/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
+++ b/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
@@ -1,76 +1,93 @@
 ---
-title: "WorldMonitor Is Not Palantir (But Thank You)"
-description: "The Palantir comparison is flattering and wrong: WorldMonitor is an open platform for the world's public data — markets, trade, energy, and economics first — that anyone can use and build on."
-metaTitle: "WorldMonitor Is Not Palantir | World Monitor"
+title: "WorldMonitor Is Not an Open-Source Palantir"
+description: "One command shows the difference: Palantir organizes your institution's private data behind closed deployments. WorldMonitor publishes intelligence on the world's public data — live, free, forkable."
+metaTitle: "WorldMonitor Is Not an Open-Source Palantir | World Monitor"
 keywords: "WorldMonitor vs Palantir, Palantir alternative open source, open intelligence platform, economic intelligence dashboard, global financial data platform, build on intelligence API"
 audience: "Press, analysts, developers, investors, anyone who has seen the Palantir comparison"
 heroImage: "/blog/og/worldmonitor-is-not-palantir.png"
 pubDate: "2026-07-21"
+modifiedDate: "2026-07-22"
 ---
 
-Ever since WorldMonitor started getting attention, one comparison has followed it everywhere: "open-source Palantir." It shows up in press mentions, Reddit threads, and half the introductions supporters write for us.
+Run this in a terminal:
 
-First, sincerely: thank you. When people reach for Palantir as the reference point, they're saying the ambition registers — a live map of the world's data, built by a small team, holding its own next to a company worth hundreds of billions. We'll take that compliment every time.
+```bash
+curl "https://www.worldmonitor.app/api/health?compact=1"
+```
 
-But the comparison is wrong, and the ways it's wrong are exactly the ways WorldMonitor is interesting.
+No API key. No sales call. No contract. Here's what it returned the moment this paragraph was written (July 22, 2026):
 
-## What Palantir actually is
+```json
+{
+  "status": "WARNING",
+  "summary": { "total": 232, "ok": 229, "warn": 2, "onDemandWarn": 1, "crit": 0 },
+  "problems": {
+    "globalTendersSam": { "status": "SEED_ERROR", "records": 77, "seedAgeMin": 355 }
+  }
+}
+```
 
-Palantir builds data-integration software for institutions. Gotham, Foundry, and AIP ingest a customer's *own* data — case files, supply ledgers, sensor logs — into a private ontology that the customer's analysts query behind their own walls. It is excellent at that job. It is also, definitionally, closed: the data is yours, the deployment is yours, and the contract is negotiated.
+That's WorldMonitor monitoring 232 of its own data sources — and publicly reporting, to anyone who asks, that its US government-tenders feed was stale at that moment because SAM.gov was rate-limiting us. We didn't clean that up for this post. The failure report *is* the point.
 
-Palantir doesn't primarily *provide* data. It organizes data you already have.
+Now try getting Palantir to show you anything at all this afternoon.
 
-## What WorldMonitor actually is
+## The comparison we keep getting
 
-WorldMonitor inverts every one of those properties. It's a real-time intelligence layer over the **world's public data** — and it publishes the result to everyone, starting at free with no login.
+There's a third-party explainer of our codebase titled ["worldmonitor: The Open-Source Palantir Running in Your Browser."](https://repo-explainer.com/koala73/worldmonitor) Supporters introduce us the same way. "Open-source Palantir" has become a whole genre — other projects [market themselves with exactly that phrase](https://osirisai.live/). We understand the shorthand: dark map, live data, global scope. One thank-you covers it: when people reach for a $400-billion company as the reference point for a free dashboard, the ambition landed.
 
-And despite the war-room aesthetic, the center of gravity is economic. Look at what the platform actually ships:
+But the comparison mistakes what both things are. And the mistake is worth correcting precisely, because what WorldMonitor actually is turns out to be more useful to more people.
 
-- [92 stock exchanges, 13 central banks, and a 7-signal macro radar](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/) on the finance dashboard
-- [Chokepoints, freight indices, and trade-route monitoring](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/) for physical trade
-- [Tariff trends, customs revenue, and trade policy](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/)
-- [Government tenders from six official procurement sources](/blog/posts/government-tenders-procurement-intelligence-worldmonitor/)
-- [Sanctions designations and country pressure](/blog/posts/monitor-global-sanctions-pressure-worldmonitor/)
-- [Shelf-price inflation tracking](/blog/posts/ground-truth-inflation-shelf-price-tracking-worldmonitor/), commodity markets, energy intelligence, prediction markets, and EU macro series
+## What Palantir is — credit where due
 
-Conflict tracking is real and serious on WorldMonitor — but it's there because **war is an economic event**. Chokepoints close, freight reprices, energy flows shift, currencies move. The conflict layer feeds the economic picture as much as the reverse. "Palantir" pattern-matches to the map with red dots; it misses that most of the platform is telling you what those dots do to prices, routes, and policy.
+Palantir builds data-integration software for institutions. Gotham, Foundry, and AIP take a customer's *own* data — case files, logistics ledgers, sensor logs — and make it queryable inside a private ontology, behind the customer's walls, under a negotiated contract. It is genuinely excellent at that job, which is why institutions pay what they pay.
 
-The scale is public too: [six specialized dashboards](/blog/posts/five-dashboards-one-platform-worldmonitor-variants/), 500+ curated feeds, 56 map layers, and [21 languages](/blog/posts/worldmonitor-in-21-languages-global-intelligence-for-everyone/) — with the [full comparison against Bloomberg, Dataminr, Recorded Future, and yes, Palantir](/blog/posts/worldmonitor-vs-traditional-intelligence-tools/) already written.
+Note what that job is: **Palantir makes your private data usable by you.** It doesn't primarily provide data. If your organization has nothing to integrate, Palantir has nothing to sell you.
 
-## The deeper difference: open, in every direction
+## What WorldMonitor is
 
-The Palantir model is access-gated at every layer. WorldMonitor is open at every layer:
+WorldMonitor inverts every term of that sentence: **it makes the world's public data usable by everyone.** UCDP conflict events, IMF PortWatch ship transits, EIA petroleum stocks, OFAC designations, UNHCR displacement, USGS seismographs, Eurostat series, prediction-market odds, 567 curated news feeds — ingested continuously, classified, mapped, and published to a URL with no login.
 
-- **Open product** — the dashboards are free, no signup, right now.
-- **Open source** — the entire platform is AGPL-3.0. You can [read it, fork it, and self-host it](/blog/posts/self-host-worldmonitor-open-source-osint-dashboard/).
-- **Open interfaces** — a versioned [REST API with typed SDKs](/blog/posts/build-on-worldmonitor-developer-api-open-source/), an [MCP server with 40 live tools for AI agents](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/), and an [embeddable live map](/blog/posts/embed-live-global-map-worldmonitor/).
-- **Open pricing** — published on the site, from $0 to [flat monthly tiers](/blog/posts/free-vs-paid-real-time-intelligence-dashboards/). No sales call.
+And despite the war-room aesthetic that invites the Palantir shorthand, the center of gravity is **economic**. Count the surface: [markets and central-bank trackers](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/), [chokepoints and freight](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/), [tariffs and customs revenue](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/), [government tenders from six official portals](/blog/posts/government-tenders-procurement-intelligence-worldmonitor/), [shelf-price inflation](/blog/posts/ground-truth-inflation-shelf-price-tracking-worldmonitor/), energy intelligence, prediction markets.
 
-That's not a smaller Palantir. It's a different species. If Palantir is a private ontology for your institution's data, WorldMonitor is public infrastructure for the world's data.
+Here's the sanctions layer, queried live while writing this (July 22, 2026): **20,398 active OFAC designations** — 19,345 SDN plus 1,053 consolidated — including 1,517 vessels and 344 aircraft. Russia carries 5,931 country-tagged entries against Iran's 1,607, and the single largest program, `RUSSIA-EO14024`, holds 6,794. That's not a marketing claim about "tracking sanctions." That's the data, and you can pull the same numbers right now through the [MCP server](https://www.worldmonitor.app/docs/mcp-quickstart) or the [API](https://www.worldmonitor.app/docs/api-reference).
 
-## Build on it — that's the point
+Conflict tracking is real and serious on WorldMonitor — but it's there because **war is an economic event**. When Hormuz goes yellow, tankers reroute, freight and insurance reprice, energy flows shift, sanctions programs swell. The red dots matter because of what they do to prices, routes, and policy. Palantir pattern-matches to the map; it misses that most of the platform is telling you what the map costs.
 
-The clearest proof that the comparison fails: you can't build on Palantir this afternoon. You can build on WorldMonitor this afternoon.
+## The structural difference: open at the layers that matter
 
-- Wire a [supply-chain early-warning system](/blog/posts/build-supply-chain-early-warning-system-api/) to chokepoint and disruption data
-- Give Claude or your own agent [live world context through MCP](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/)
-- Pipe [risk alerts into Slack or Teams](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/)
-- Or start from the [API reference](https://www.worldmonitor.app/docs/api-reference) and build the thing we haven't thought of
+- **The product is open**: six dashboards, free, no signup, right now.
+- **The source is open**: the entire platform is AGPL-3.0 — [read it, fork it, self-host it](/blog/posts/self-host-worldmonitor-open-source-osint-dashboard/).
+- **The interfaces are open**: a versioned REST API built on 35 typed proto services, an [MCP server with 41 tools](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/) that answers anonymous connections, an [embeddable live map](/blog/posts/embed-live-global-map-worldmonitor/), 25 UI languages.
+- **The pricing is open**: [published on the site](/blog/posts/free-vs-paid-real-time-intelligence-dashboards/), $0 to flat monthly tiers, no "contact sales."
+
+And, in fairness, what WorldMonitor is **not**: it is not fully free at every layer — a handful of compute-heavy panels (the AI analyst, the Scenario Engine, tender search, trade policy) are paid, and they fund the free rest. It has no classified feeds and no private ontology for your internal data — if you need *your* data integrated, that's genuinely Palantir's job, not ours. And public data has gaps; where sensors don't exist, WorldMonitor shows the gap rather than interpolating confidence.
+
+That last habit is the deepest difference. A closed platform's failures are private. Ours are on the health endpoint you curled above.
+
+## Build on it this afternoon — literally
+
+The claim "you can build on it" is cheap, so here is the afternoon, itemized:
+
+1. **Minute 1:** `curl "https://www.worldmonitor.app/api/health?compact=1"` — you did this already.
+2. **Minute 5:** Add `https://worldmonitor.app/mcp` to Claude or any MCP client — the server accepts anonymous connections with a daily quota, no account — and ask *"what's the chokepoint status in Hormuz right now?"*
+3. **The rest of the afternoon:** wire a [supply-chain early-warning pipeline](/blog/posts/build-supply-chain-early-warning-system-api/), pipe [risk alerts into Slack](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/), or [give your agent live world context](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/) — or fork the repo and change what you don't like.
+
+Palantir is excellent software you cannot try this afternoon. That's not a criticism — it's a different species of thing. But it's why the comparison fails in our favor for everyone who isn't a government or a Fortune 100.
 
 ## Frequently Asked Questions
 
 **Is WorldMonitor a Palantir alternative?**
 
-For integrating your institution's private data into a closed ontology — no, and it doesn't try to be. For real-time intelligence over public data — markets, trade, conflicts, energy, economics — it does something Palantir doesn't sell at any price: it's open, and it starts free.
+For integrating your institution's private data into a closed ontology — no, and it doesn't try to be. For real-time intelligence over public data — markets, trade, conflicts, energy, sanctions — it does something Palantir doesn't sell at any price: it's live in your browser right now, free, with the source published.
 
 **Is WorldMonitor a defense or war-focused platform?**
 
-No. Conflict monitoring is one layer among dozens; by surface area, most of the platform is financial, economic, and trade intelligence. War matters on WorldMonitor because it reprices the world, not because it's the product.
+No. Conflict monitoring is one layer among dozens; by surface area most of the platform is financial, economic, and trade intelligence. War matters on WorldMonitor because it reprices the world — which is why traders and supply-chain teams read it alongside OSINT analysts.
 
-**Can I build a commercial product on WorldMonitor?**
+**Is everything really free?**
 
-Yes — through the API tiers, with the open-source core available under AGPL-3.0 obligations if you self-host. The [developer platform overview](/blog/posts/build-on-worldmonitor-developer-api-open-source/) covers both paths.
+The dashboards, the map layers, the briefs, and anonymous MCP access are free with no login. A few compute-heavy features (AI analyst, Scenario Engine, tender search, trade policy) are paid and fund the rest. The source is AGPL-3.0 — self-hosters get everything their own keys can feed.
 
 ---
 
-**Keep the comparisons coming — we're grateful for every one. Just know the real story is better: not a private war room for the few, but open economic intelligence for anyone who wants it.**
+**Palantir helps institutions see what they already own. WorldMonitor helps anyone see what the world is already saying — and you're one `curl` away from checking that claim yourself.**


### PR DESCRIPTION
## Why

Four-perspective editorial review of yesterday's 13-post batch (marketer lens, five target-reader personas, cross-family editor, author pass) converged on one diagnosis: the posts **describe live data and never show any** — fatal for a product whose pitch is "look at the real thing." This round fixes the four highest-leverage posts. Full review details in the session; headline: codex scored the old Palantir post 3/10 as front-page material ("a press-kit FAQ wearing a provocative title").

## What changed

**`worldmonitor-is-not-palantir` — full rewrite (flagship):**
- Opens with a runnable `curl` and its real output — including our own SAM tender feed erroring at the time of writing. The self-reported failure is the openness argument.
- The comparison is now documented with real links (third-party repo explainer titled "The Open-Source Palantir…"; the genre's existence), not asserted.
- Prints the live sanctions ledger (20,398 designations, Russia 5,931 / Iran 1,607, RUSSIA-EO14024 at 6,794) as evidence the economic layer is real.
- Owns open-core honestly (names the Pro-locked panels) — removes the "open at every layer" absolutism HN would have dunked on.
- Number drift fixed against `docs/generated/stats.json`: 567 feeds, 41 MCP tools, 35 proto services, 25 locales (was: "500+", "40", "21 languages", "92 exchanges").
- Thank-you register cut from ~a third of the post to one line; "build this afternoon" is now an itemized, verified 3-step demo (anonymous MCP initialize confirmed working).

**`ai-forecast-accuracy-brier-scorecard-worldmonitor` — publishes the actual scorecard, warts included:**
Brier 0.202 / n=32 / 180d window, the full calibration table (overconfident 40–70% band: predicted ~half, realized ~a fifth), the head-to-head loss to prediction markets (0.040 vs 0.010, n=3), the 74% void rate with its infrastructure-domain concentration, per-domain spread. This was the reviewers' consensus worst offender ("a scorecard post with no scorecard") and is now the most credible post in the corpus.

**`real-time-radiation-monitoring-radnet-safecast`:** live 3-station table with per-station baselines and z-scores; Houston (39 nSv/h, 40% "hotter" than Seattle, z=1.8, verdict: normal) is the teaching row for deviation-from-own-baseline.

**`government-tenders-procurement-intelligence-worldmonitor`:** 4 real records from one live query (US Air Force autonomy-software solicitation, World Bank IT tender, Farm Credit Canada RFP, U. Auckland via GETS) with official links, plus an honest "if you already live in SAM.gov" section positioning against SAM alerts/GovWin (cross-portal is the pitch, not US coverage).

## Verification

- Every number pulled first-hand from the live MCP/API on 2026-07-22 and dated in-post ("as of" stamps + `modifiedDate`)
- Blog build green; FAQPage JSON-LD confirmed firing (3 questions) on all four; internal links resolve
- Anonymous demo commands verified working before being printed (health curl; MCP initialize)

## Not in this PR (deliberate)

- Inflation post receipts — blocked on consumer-prices data quality (movers feed has parse artifacts: +874% sugar, −99% bread); ops issue being filed
- SAM staleness (429/SEED_ERROR at 355min) — ops issue being filed
- Template/aphorism cleanup on the remaining 9 posts — next round if this direction lands

No auto-merge — content wants a human read.

https://claude.ai/code/session_01JEGono85MnwW7F9mm4rQEF