### PR TITLE
feat(blog): pinned-post support — pin the Palantir post to the top of the index

### DIFF
--- a/blog-site/src/content.config.ts
+++ b/blog-site/src/content.config.ts
@@ -15,6 +15,7 @@ const blog = defineCollection({
     authorUrl: z.string().url().optional(),
     authorBio: z.string().optional(),
     heroImage: z.string().optional(),
+    pinned: z.boolean().optional(),
   }),
 });
 

--- a/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
+++ b/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
@@ -7,6 +7,7 @@ audience: "Press, analysts, developers, investors, anyone who has seen the Palan
 heroImage: "/blog/og/worldmonitor-is-not-palantir.png"
 pubDate: "2026-07-21"
 modifiedDate: "2026-07-22"
+pinned: true
 ---
 
 Run this in a terminal:

--- a/blog-site/src/pages/index.astro
+++ b/blog-site/src/pages/index.astro
@@ -4,7 +4,9 @@ import { getCollection } from 'astro:content';
 import { coverWebpSources } from '../lib/cover-webp';
 
 const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+  (a, b) =>
+    Number(b.data.pinned ?? false) - Number(a.data.pinned ?? false) ||
+    b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 
 // Committed covers have generated .webp / -640.webp siblings (guarded by
@@ -62,7 +64,7 @@ const jsonLd = {
       {posts.map((post) => {
         const cover = coverWebpSources(post.data.heroImage);
         return (
-        <a href={`/blog/posts/${post.id}/`} class="post-card">
+        <a href={`/blog/posts/${post.id}/`} class:list={['post-card', { pinned: post.data.pinned }]}>
           {post.data.heroImage && (
             <picture>
               {cover && (
@@ -82,7 +84,10 @@ const jsonLd = {
               />
             </picture>
           )}
-          <div class="tag">{post.data.audience}</div>
+          <div class="tag">
+            {post.data.pinned && <span class="pin">Pinned</span>}
+            {post.data.audience}
+          </div>
           <h2>{post.data.title}</h2>
           <p>{post.data.description}</p>
           <div class="meta">

--- a/blog-site/src/styles/global.css
+++ b/blog-site/src/styles/global.css
@@ -328,6 +328,17 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   font-family: var(--font-mono);
 }
 
+.post-card.pinned {
+  border-color: var(--wm-green);
+}
+
+.post-card .tag .pin {
+  border: 1px solid var(--wm-green);
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+  margin-right: 0.5rem;
+}
+
 .post-card h2 {
   font-family: var(--font-display);
   font-size: 1.125rem;


### PR DESCRIPTION
Follow-up to the merged #5443, per request: the rewritten `worldmonitor-is-not-palantir` post is now pinned to the top of the blog index.

**Mechanism (reusable):**
- Optional `pinned: boolean` in the blog frontmatter schema (`content.config.ts`)
- Blog index sorts pinned-first, then `pubDate` desc — RSS keeps its own chronological sort, unaffected
- Pinned cards get a green border + a mono `Pinned` chip before the audience tag (theme-consistent, ~10 lines of CSS)
- Applied to `worldmonitor-is-not-palantir.md`; unpin later by deleting one frontmatter line

**Verified:** blog build green; built `dist/index.html` renders the Palantir post as the first card with `post-card pinned` class and the chip present.

No auto-merge.

https://claude.ai/code/session_01JEGono85MnwW7F9mm4rQEF