### PR TITLE
fix(payments): re-check Dodo before stale-subscription denial

### DIFF
--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -19,12 +19,13 @@ const USER_KEY_CACHE_PREFIX = 'user-api-key:';
 const BOOTSTRAP_USER_KEY_NEGATIVE_CACHE_PREFIX = 'bootstrap-user-api-key-invalid:';
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
 // Mirrors server/_shared/entitlement-check.ts (this .js file cannot import the
-// .ts module under node --test): lapsed markers stay short because their TTL
-// is the worst-case wrongful-denial window; not_applicable markers stay long
-// because syncEntitlementCache unconditionally overwrites the key on any tier
-// change.
+// .ts module under node --test; tests/billing-marker-ttl-parity.test.mjs pins
+// the two copies together): lapsed markers stay short because their TTL is
+// the worst-case wrongful-denial window; not_applicable markers get the full
+// default TTL because syncEntitlementCache unconditionally overwrites the key
+// on any tier change.
 const LAPSED_BILLING_MARKER_TTL_SECONDS = 60;
-const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 300;
+const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 900;
 const ENTITLEMENT_ENV_PREFIX = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live' : 'test';
 const NEG_SENTINEL = '__WM_NEG__';
 

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -260,6 +260,40 @@ function hasCurrentApiAccess(value) {
   return Boolean(value.features?.apiAccess === true && Number.isFinite(validUntil) && validUntil >= Date.now());
 }
 
+function billingVerificationFailure(value) {
+  const status = value?.billingStatus;
+  if (status === 'subscription_lapsed') {
+    return {
+      ok: false,
+      status: 403,
+      error: 'API access subscription lapsed',
+      reason: status,
+      headers: noStoreHeaders({ 'X-Billing-Verification': status }),
+    };
+  }
+  if (status !== 'renewal_verification_pending' && status !== 'renewal_verification_failed') {
+    return null;
+  }
+
+  const rawRetryAfter = Number(value?.retryAfterSeconds);
+  const retryAfter = Number.isFinite(rawRetryAfter)
+    ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter)))
+    : VALIDATION_RETRY_AFTER_SECONDS;
+  return {
+    ok: false,
+    status: 503,
+    error: status === 'renewal_verification_pending'
+      ? 'Renewal verification pending'
+      : 'Renewal verification failed',
+    reason: status,
+    unavailable: true,
+    headers: noStoreHeaders({
+      'Retry-After': String(retryAfter),
+      'X-Billing-Verification': status,
+    }),
+  };
+}
+
 export async function validateBootstrapUserApiAccess(userId) {
   if (!userId || typeof userId !== 'string') {
     return { ok: false, status: 403, error: 'API access subscription required', reason: 'missing-user' };
@@ -287,6 +321,9 @@ async function validateBootstrapUserApiAccessUncached(userId) {
   if (result.value && typeof result.value === 'object') {
     await writeCachedJson(cacheKey, result.value, ENTITLEMENT_CACHE_TTL_SECONDS);
   }
+
+  const billingFailure = billingVerificationFailure(result.value);
+  if (billingFailure) return billingFailure;
 
   if (!hasCurrentApiAccess(result.value)) {
     return { ok: false, status: 403, error: 'API access subscription required', reason: 'forbidden' };

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -18,7 +18,13 @@ const USER_KEY_NEGATIVE_CACHE_TTL_SECONDS = 60;
 const USER_KEY_CACHE_PREFIX = 'user-api-key:';
 const BOOTSTRAP_USER_KEY_NEGATIVE_CACHE_PREFIX = 'bootstrap-user-api-key-invalid:';
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
-const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 60;
+// Mirrors server/_shared/entitlement-check.ts (this .js file cannot import the
+// .ts module under node --test): lapsed markers stay short because their TTL
+// is the worst-case wrongful-denial window; not_applicable markers stay long
+// because syncEntitlementCache unconditionally overwrites the key on any tier
+// change.
+const LAPSED_BILLING_MARKER_TTL_SECONDS = 60;
+const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 300;
 const ENTITLEMENT_ENV_PREFIX = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live' : 'test';
 const NEG_SENTINEL = '__WM_NEG__';
 
@@ -316,7 +322,7 @@ function notApplicableVerificationTtlSeconds(value) {
 
 function entitlementCacheTtlSeconds(value) {
   const status = value?.billingStatus;
-  if (status === 'subscription_lapsed') return 300;
+  if (status === 'subscription_lapsed') return LAPSED_BILLING_MARKER_TTL_SECONDS;
   if (status === 'renewal_verification_pending' || status === 'renewal_verification_failed') {
     return clampRetryAfterSeconds(value?.retryAfterSeconds);
   }

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -294,6 +294,18 @@ function billingVerificationFailure(value) {
   };
 }
 
+function entitlementCacheTtlSeconds(value) {
+  const status = value?.billingStatus;
+  if (status === 'subscription_lapsed') return 300;
+  if (status !== 'renewal_verification_pending' && status !== 'renewal_verification_failed') {
+    return ENTITLEMENT_CACHE_TTL_SECONDS;
+  }
+  const rawRetryAfter = Number(value?.retryAfterSeconds);
+  return Number.isFinite(rawRetryAfter)
+    ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter)))
+    : VALIDATION_RETRY_AFTER_SECONDS;
+}
+
 export async function validateBootstrapUserApiAccess(userId) {
   if (!userId || typeof userId !== 'string') {
     return { ok: false, status: 403, error: 'API access subscription required', reason: 'missing-user' };
@@ -306,6 +318,8 @@ async function validateBootstrapUserApiAccessUncached(userId) {
   const cacheKey = `entitlements:${ENTITLEMENT_ENV_PREFIX}:${userId}`;
   const cached = await readCachedJson(cacheKey);
   if (cached.status === 'hit' && cached.value && typeof cached.value === 'object') {
+    const cachedBillingFailure = billingVerificationFailure(cached.value);
+    if (cachedBillingFailure) return cachedBillingFailure;
     const validUntil = Number(cached.value.validUntil ?? 0);
     if (Number.isFinite(validUntil) && validUntil >= Date.now()) {
       if (hasCurrentApiAccess(cached.value)) return { ok: true };
@@ -319,7 +333,7 @@ async function validateBootstrapUserApiAccessUncached(userId) {
   }
 
   if (result.value && typeof result.value === 'object') {
-    await writeCachedJson(cacheKey, result.value, ENTITLEMENT_CACHE_TTL_SECONDS);
+    await writeCachedJson(cacheKey, result.value, entitlementCacheTtlSeconds(result.value));
   }
 
   const billingFailure = billingVerificationFailure(result.value);

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -357,7 +357,22 @@ async function validateBootstrapUserApiAccessUncached(userId) {
 
   const result = await postConvexJson(CONVEX_ENTITLEMENTS_PATH, { userId });
   if (!result.ok) {
-    return serviceUnavailable();
+    // The entitlement backend could not be reached to verify a wm_ key: emit
+    // the documented entitlement_verification_unavailable contract
+    // (docs/usage-errors.mdx), matching server/gateway.ts's wm_-key branch.
+    // X-Validation-Mode: degraded is kept for existing monitors.
+    return {
+      ok: false,
+      status: 503,
+      error: 'Unable to verify API access',
+      reason: 'entitlement_verification_unavailable',
+      unavailable: true,
+      headers: noStoreHeaders({
+        'Retry-After': String(VALIDATION_RETRY_AFTER_SECONDS),
+        'X-Validation-Mode': 'degraded',
+        'X-Billing-Verification': 'entitlement_verification_unavailable',
+      }),
+    };
   }
 
   if (result.value && typeof result.value === 'object') {

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -18,6 +18,7 @@ const USER_KEY_NEGATIVE_CACHE_TTL_SECONDS = 60;
 const USER_KEY_CACHE_PREFIX = 'user-api-key:';
 const BOOTSTRAP_USER_KEY_NEGATIVE_CACHE_PREFIX = 'bootstrap-user-api-key-invalid:';
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
+const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 60;
 const ENTITLEMENT_ENV_PREFIX = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live' : 'test';
 const NEG_SENTINEL = '__WM_NEG__';
 
@@ -294,16 +295,32 @@ function billingVerificationFailure(value) {
   };
 }
 
+function notApplicableVerificationTtlSeconds(value) {
+  const marker = value?.renewalVerificationFreshness;
+  if (marker?.status !== 'not_applicable') return null;
+  if (typeof marker.checkedAt !== 'number' || !Number.isFinite(marker.checkedAt)) return null;
+  const remainingMs = marker.checkedAt
+    + NOT_APPLICABLE_VERIFICATION_TTL_SECONDS * 1_000
+    - Date.now();
+  return remainingMs > 0
+    ? Math.max(1, Math.min(
+      NOT_APPLICABLE_VERIFICATION_TTL_SECONDS,
+      Math.ceil(remainingMs / 1_000),
+    ))
+    : null;
+}
+
 function entitlementCacheTtlSeconds(value) {
   const status = value?.billingStatus;
   if (status === 'subscription_lapsed') return 300;
-  if (status !== 'renewal_verification_pending' && status !== 'renewal_verification_failed') {
-    return ENTITLEMENT_CACHE_TTL_SECONDS;
+  if (status === 'renewal_verification_pending' || status === 'renewal_verification_failed') {
+    const rawRetryAfter = Number(value?.retryAfterSeconds);
+    return Number.isFinite(rawRetryAfter)
+      ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter)))
+      : VALIDATION_RETRY_AFTER_SECONDS;
   }
-  const rawRetryAfter = Number(value?.retryAfterSeconds);
-  return Number.isFinite(rawRetryAfter)
-    ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter)))
-    : VALIDATION_RETRY_AFTER_SECONDS;
+  const notApplicableTtl = notApplicableVerificationTtlSeconds(value);
+  return notApplicableTtl ?? ENTITLEMENT_CACHE_TTL_SECONDS;
 }
 
 export async function validateBootstrapUserApiAccess(userId) {
@@ -320,6 +337,9 @@ async function validateBootstrapUserApiAccessUncached(userId) {
   if (cached.status === 'hit' && cached.value && typeof cached.value === 'object') {
     const cachedBillingFailure = billingVerificationFailure(cached.value);
     if (cachedBillingFailure) return cachedBillingFailure;
+    if (notApplicableVerificationTtlSeconds(cached.value) !== null) {
+      return { ok: false, status: 403, error: 'API access subscription required', reason: 'cached-forbidden' };
+    }
     const validUntil = Number(cached.value.validUntil ?? 0);
     if (Number.isFinite(validUntil) && validUntil >= Date.now()) {
       if (hasCurrentApiAccess(cached.value)) return { ok: true };

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -261,6 +261,13 @@ function hasCurrentApiAccess(value) {
   return Boolean(value.features?.apiAccess === true && Number.isFinite(validUntil) && validUntil >= Date.now());
 }
 
+function clampRetryAfterSeconds(rawRetryAfter) {
+  const parsed = Number(rawRetryAfter);
+  return Number.isFinite(parsed)
+    ? Math.max(1, Math.min(60, Math.ceil(parsed)))
+    : VALIDATION_RETRY_AFTER_SECONDS;
+}
+
 function billingVerificationFailure(value) {
   const status = value?.billingStatus;
   if (status === 'subscription_lapsed') {
@@ -276,10 +283,7 @@ function billingVerificationFailure(value) {
     return null;
   }
 
-  const rawRetryAfter = Number(value?.retryAfterSeconds);
-  const retryAfter = Number.isFinite(rawRetryAfter)
-    ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter)))
-    : VALIDATION_RETRY_AFTER_SECONDS;
+  const retryAfter = clampRetryAfterSeconds(value?.retryAfterSeconds);
   return {
     ok: false,
     status: 503,
@@ -314,10 +318,7 @@ function entitlementCacheTtlSeconds(value) {
   const status = value?.billingStatus;
   if (status === 'subscription_lapsed') return 300;
   if (status === 'renewal_verification_pending' || status === 'renewal_verification_failed') {
-    const rawRetryAfter = Number(value?.retryAfterSeconds);
-    return Number.isFinite(rawRetryAfter)
-      ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter)))
-      : VALIDATION_RETRY_AFTER_SECONDS;
+    return clampRetryAfterSeconds(value?.retryAfterSeconds);
   }
   const notApplicableTtl = notApplicableVerificationTtlSeconds(value);
   return notApplicableTtl ?? ENTITLEMENT_CACHE_TTL_SECONDS;

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -94,11 +94,14 @@ async function withMockedConvex(fn, options = {}) {
     }
 
     if (url.endsWith('/api/internal-entitlements')) {
-      return new Response(JSON.stringify({
-        planKey: 'api_starter',
-        validUntil: Date.now() + 86_400_000,
-        features: { apiAccess: true },
-      }), {
+      const value = Object.hasOwn(options, 'entitlementResponse')
+        ? options.entitlementResponse
+        : {
+            planKey: 'api_starter',
+            validUntil: Date.now() + 86_400_000,
+            features: { apiAccess: true },
+          };
+      return new Response(JSON.stringify(value), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -394,6 +397,78 @@ test('short-lived verification marker is served from Redis without another Conve
         features: { apiAccess: false },
         billingStatus: 'renewal_verification_failed',
         retryAfterSeconds: 9,
+      },
+    },
+  });
+});
+
+test('recent not-applicable freshness marker is served from Redis without another Convex request', async () => {
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 403);
+    assert.equal(result.reason, 'cached-forbidden');
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-entitlements')), false);
+  }, {
+    redisCache: {
+      'entitlements:test:user_api_owner': {
+        planKey: 'free',
+        validUntil: 0,
+        features: { apiAccess: false },
+        renewalVerificationFreshness: {
+          status: 'not_applicable',
+          checkedAt: Date.now(),
+        },
+      },
+    },
+  });
+});
+
+test('expired not-applicable freshness marker falls through to Convex', async () => {
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-entitlements')), true);
+  }, {
+    redisCache: {
+      'entitlements:test:user_api_owner': {
+        planKey: 'free',
+        validUntil: 0,
+        features: { apiAccess: false },
+        renewalVerificationFreshness: {
+          status: 'not_applicable',
+          checkedAt: Date.now() - 60_001,
+        },
+      },
+    },
+  });
+});
+
+test('not-applicable freshness marker is cached for at most 60 seconds', async () => {
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 403);
+    const cacheWrite = calls.find((call) => {
+      if (!call.url.startsWith('https://upstash.test') || !call.body.includes('"SET"')) return false;
+      const command = JSON.parse(call.body).find((entry) => entry[0] === 'SET');
+      return command?.[1] === 'entitlements:test:user_api_owner';
+    });
+    assert.ok(cacheWrite);
+    const setCommand = JSON.parse(cacheWrite.body).find((entry) => entry[0] === 'SET');
+    const ttl = Number(setCommand[4]);
+    assert.ok(ttl > 0 && ttl <= 60, `unexpected marker TTL: ${ttl}`);
+  }, {
+    entitlementResponse: {
+      planKey: 'free',
+      validUntil: 0,
+      features: { apiAccess: false },
+      renewalVerificationFreshness: {
+        status: 'not_applicable',
+        checkedAt: Date.now(),
       },
     },
   });

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -439,14 +439,14 @@ test('expired not-applicable freshness marker falls through to Convex', async ()
         features: { apiAccess: false },
         renewalVerificationFreshness: {
           status: 'not_applicable',
-          checkedAt: Date.now() - 60_001,
+          checkedAt: Date.now() - 300_001,
         },
       },
     },
   });
 });
 
-test('not-applicable freshness marker is cached for at most 60 seconds', async () => {
+test('not-applicable freshness marker is cached for at most 300 seconds', async () => {
   await withMockedConvex(async (calls) => {
     const result = await validateBootstrapUserApiAccess('user_api_owner');
 
@@ -460,7 +460,7 @@ test('not-applicable freshness marker is cached for at most 60 seconds', async (
     assert.ok(cacheWrite);
     const setCommand = JSON.parse(cacheWrite.body).find((entry) => entry[0] === 'SET');
     const ttl = Number(setCommand[4]);
-    assert.ok(ttl > 0 && ttl <= 60, `unexpected marker TTL: ${ttl}`);
+    assert.ok(ttl > 0 && ttl <= 300, `unexpected marker TTL: ${ttl}`);
   }, {
     entitlementResponse: {
       planKey: 'free',

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -342,6 +342,42 @@ test('apiAccess entitlement past validUntil fails closed with 403 posture', asyn
   });
 });
 
+test('renewal verification pending is a distinct retryable 503', async () => {
+  await withMockedEntitlement({
+    planKey: 'free',
+    validUntil: 0,
+    features: { apiAccess: false },
+    billingStatus: 'renewal_verification_pending',
+    retryAfterSeconds: 19,
+  }, async () => {
+    const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 503);
+    assert.equal(result.reason, 'renewal_verification_pending');
+    assert.equal(result.error, 'Renewal verification pending');
+    assert.equal(result.headers['Retry-After'], '19');
+    assert.equal(result.headers['X-Billing-Verification'], 'renewal_verification_pending');
+  });
+});
+
+test('confirmed subscription lapse is distinct from verification failure', async () => {
+  await withMockedEntitlement({
+    planKey: 'free',
+    validUntil: 0,
+    features: { apiAccess: false },
+    billingStatus: 'subscription_lapsed',
+  }, async () => {
+    const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 403);
+    assert.equal(result.reason, 'subscription_lapsed');
+    assert.equal(result.error, 'API access subscription lapsed');
+    assert.equal(result.headers['X-Billing-Verification'], 'subscription_lapsed');
+  });
+});
+
 test('malformed entitlement response fails closed with 403 posture', async () => {
   await withMockedEntitlement({ ok: true }, async () => {
     const result = await validateBootstrapUserApiAccess('user_api_owner');

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -502,7 +502,7 @@ test('stale cached entitlement (past validUntil) re-validates against Convex', a
   });
 });
 
-test('transient Convex HTTP 5xx on entitlement check is a retryable 503, not 403', async () => {
+test('transient Convex HTTP 5xx on entitlement check emits the entitlement_verification_unavailable contract', async () => {
   await withMockedConvex(async (calls) => {
     globalThis.fetch = async (input, init) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -525,7 +525,13 @@ test('transient Convex HTTP 5xx on entitlement check is a retryable 503, not 403
     assert.equal(result.ok, false);
     assert.equal(result.status, 503);
     assert.equal(result.unavailable, true);
-    assert.equal(result.error, 'Service temporarily unavailable');
+    // Matches server/gateway.ts's wm_-key branch and docs/usage-errors.mdx —
+    // the bootstrap surface must speak the same billing-verification contract.
+    assert.equal(result.error, 'Unable to verify API access');
+    assert.equal(result.reason, 'entitlement_verification_unavailable');
+    assert.equal(result.headers['X-Billing-Verification'], 'entitlement_verification_unavailable');
+    assert.equal(result.headers['X-Validation-Mode'], 'degraded');
+    assert.equal(result.headers['Retry-After'], '5');
   });
 });
 

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -439,14 +439,14 @@ test('expired not-applicable freshness marker falls through to Convex', async ()
         features: { apiAccess: false },
         renewalVerificationFreshness: {
           status: 'not_applicable',
-          checkedAt: Date.now() - 300_001,
+          checkedAt: Date.now() - 900_001,
         },
       },
     },
   });
 });
 
-test('not-applicable freshness marker is cached for at most 300 seconds', async () => {
+test('not-applicable freshness marker is cached for at most 900 seconds', async () => {
   await withMockedConvex(async (calls) => {
     const result = await validateBootstrapUserApiAccess('user_api_owner');
 
@@ -460,7 +460,7 @@ test('not-applicable freshness marker is cached for at most 300 seconds', async 
     assert.ok(cacheWrite);
     const setCommand = JSON.parse(cacheWrite.body).find((entry) => entry[0] === 'SET');
     const ttl = Number(setCommand[4]);
-    assert.ok(ttl > 0 && ttl <= 300, `unexpected marker TTL: ${ttl}`);
+    assert.ok(ttl > 0 && ttl <= 900, `unexpected marker TTL: ${ttl}`);
   }, {
     entitlementResponse: {
       planKey: 'free',

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -378,6 +378,27 @@ test('confirmed subscription lapse is distinct from verification failure', async
   });
 });
 
+test('short-lived verification marker is served from Redis without another Convex request', async () => {
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 503);
+    assert.equal(result.reason, 'renewal_verification_failed');
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-entitlements')), false);
+  }, {
+    redisCache: {
+      'entitlements:test:user_api_owner': {
+        planKey: 'free',
+        validUntil: 0,
+        features: { apiAccess: false },
+        billingStatus: 'renewal_verification_failed',
+        retryAfterSeconds: 9,
+      },
+    },
+  });
+});
+
 test('malformed entitlement response fails closed with 403 posture', async () => {
   await withMockedEntitlement({ ok: true }, async () => {
     const result = await validateBootstrapUserApiAccess('user_api_owner');

--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -59,6 +59,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/billing-denial.ts",
+      "category": "internal-helper",
+      "reason": "Typed billing-denial propagation for MCP tool _execute fetches (#4770): BillingDenialError + header-detection helpers so a gateway 403/503 billing denial survives dispatch's catch-all instead of flattening into a generic -32603. Pure helper module for the external-protocol MCP handler family above — exports no route.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp/usage.ts",
       "category": "external-protocol",
       "reason": "MCP wm_api_usage emission (#4866) — phase-to-reason mapper + ctx.waitUntil RequestEvent emitter for the /mcp funnel. Ops/observability plumbing for the same external-protocol handler, not a JSON data API; reuses server/_shared/usage.ts builders.",

--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -333,6 +333,45 @@ test('revoked wm_ user key returns generic non-cacheable 401 without leaking gat
   });
 });
 
+test('billing-verification lapse on a wm_ user key exposes a machine-readable code', async () => {
+  await withMockedBootstrapAuth({
+    entitlement: {
+      planKey: 'free',
+      validUntil: 0,
+      features: { apiAccess: false },
+      billingStatus: 'subscription_lapsed',
+    },
+  }, async () => {
+    const resp = await handler(makeBootstrapRequest({ 'X-WorldMonitor-Key': USER_KEY }));
+    const body = await resp.json();
+
+    assert.equal(resp.status, 403);
+    assert.equal(resp.headers.get('x-billing-verification'), 'subscription_lapsed');
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
+    assert.equal(body.error, 'API access subscription lapsed');
+    assert.equal(body.code, 'subscription_lapsed');
+  });
+});
+
+test('retryable billing verification on a wm_ user key keeps Retry-After and code on the wire', async () => {
+  await withMockedBootstrapAuth({
+    entitlement: {
+      planKey: 'free',
+      validUntil: 0,
+      features: { apiAccess: false },
+      billingStatus: 'renewal_verification_pending',
+      retryAfterSeconds: 19,
+    },
+  }, async () => {
+    const resp = await handler(makeBootstrapRequest({ 'X-WorldMonitor-Key': USER_KEY }));
+    const body = await resp.json();
+
+    assert.equal(resp.status, 503);
+    assert.equal(resp.headers.get('retry-after'), '19');
+    assert.equal(body.code, 'renewal_verification_pending');
+  });
+});
+
 test('malformed wm_ user key is rejected before Redis or Convex validation', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
     const resp = await handler(makeBootstrapRequest({ 'X-WorldMonitor-Key': 'wm_notcanonical' }));

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -322,7 +322,15 @@ async function validateBootstrapAuth(req, cors) {
       return {
         ok: false,
         response: authFailure(
-          { error: entitlementResult.error },
+          {
+            error: entitlementResult.error,
+            // Billing-verification denials (#4770) expose their machine-readable
+            // code in the body, matching the {error, code} shape the REST
+            // gateway emits for the same statuses.
+            ...(entitlementResult.headers?.['X-Billing-Verification']
+              ? { code: entitlementResult.reason }
+              : {}),
+          },
           entitlementResult.status,
           cors,
           entitlementResult.headers,

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -13,8 +13,8 @@ import { redisPipeline as rawRedisPipeline } from '../_upstash-json.js';
 import {
   getBillingVerificationDenial,
   getEntitlements,
-  type BillingVerificationStatus,
 } from '../../server/_shared/entitlement-check';
+import type { BillingVerificationCode } from './billing-denial';
 import {
   buildInternalMcpHeaders,
   signInternalMcpRequest,
@@ -157,18 +157,52 @@ export function wwwAuthHeader(resourceMetadataUrl: string, errorParam = ''): str
 
 export function getMcpBillingVerificationDenial(
   entitlements: {
-    billingStatus?: BillingVerificationStatus;
+    billingStatus?: BillingVerificationCode;
     retryAfterSeconds?: number;
   } | null | undefined,
   corsHeaders: Record<string, string>,
   id: unknown = null,
 ): Response | null {
+  const billingStatus = entitlements?.billingStatus;
+  if (billingStatus === 'entitlement_verification_unavailable') {
+    // Gateway-synthesized backend-unreachable 503 (server/gateway.ts wm_-key
+    // branch). The shared Convex-facing helper doesn't recognize this code, so
+    // build the same retryable envelope here; clamp mirrors the shared helper.
+    const raw = entitlements?.retryAfterSeconds;
+    const retryAfter = Number.isFinite(raw)
+      ? Math.max(1, Math.min(60, Math.ceil(raw as number)))
+      : 5;
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: id ?? null,
+        error: {
+          code: -32603,
+          message: 'Unable to verify API access. Retry shortly.',
+          data: { code: billingStatus },
+        },
+      }),
+      {
+        status: 503,
+        headers: new Headers({
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'Retry-After': String(retryAfter),
+          'X-Billing-Verification': billingStatus,
+        }),
+      },
+    );
+  }
+
   // The shared helper owns status, retry normalization, no-store, and billing
   // headers. Its parameter asks only for the billing fields, so both the
   // McpHandlerDeps entitlement shape and dispatch's synthesized
   // BillingDenialError shape are directly assignable.
-  const denial = getBillingVerificationDenial(entitlements, corsHeaders);
-  const billingStatus = entitlements?.billingStatus;
+  const denial = getBillingVerificationDenial(
+    billingStatus ? { billingStatus, retryAfterSeconds: entitlements?.retryAfterSeconds } : null,
+    corsHeaders,
+  );
   if (!denial || !billingStatus) return null;
 
   const retryable = denial.status === 503;

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -154,20 +154,28 @@ export function wwwAuthHeader(resourceMetadataUrl: string, errorParam = ''): str
   return `Bearer realm="worldmonitor"${errSegment}, resource_metadata="${resourceMetadataUrl}"`;
 }
 
-function getMcpBillingVerificationDenial(
-  entitlements: Awaited<ReturnType<McpHandlerDeps['getEntitlements']>>,
+export function getMcpBillingVerificationDenial(
+  entitlements: {
+    billingStatus?:
+      | 'subscription_lapsed'
+      | 'renewal_verification_pending'
+      | 'renewal_verification_failed';
+    retryAfterSeconds?: number;
+  } | null | undefined,
   corsHeaders: Record<string, string>,
+  id: unknown = null,
 ): Response | null {
   // The shared helper owns status, retry normalization, no-store, and billing
-  // headers. Its parameter asks only for the billing fields, so the narrower
-  // McpHandlerDeps entitlement shape is directly assignable.
+  // headers. Its parameter asks only for the billing fields, so both the
+  // McpHandlerDeps entitlement shape and dispatch's synthesized
+  // BillingDenialError shape are directly assignable.
   const denial = getBillingVerificationDenial(entitlements, corsHeaders);
   const billingStatus = entitlements?.billingStatus;
   if (!denial || !billingStatus) return null;
 
   const retryable = denial.status === 503;
   const message = {
-    subscription_lapsed: 'Subscription lapsed.',
+    subscription_lapsed: 'Subscription lapsed. Re-authenticating will not help — resubscribe to restore access.',
     renewal_verification_pending: 'Renewal verification pending. Retry shortly.',
     renewal_verification_failed: 'Renewal verification failed. Retry shortly.',
   }[billingStatus];
@@ -178,9 +186,13 @@ function getMcpBillingVerificationDenial(
   return new Response(
     JSON.stringify({
       jsonrpc: '2.0',
-      id: null,
+      id: id ?? null,
       error: {
-        code: retryable ? -32603 : -32001,
+        // -32002 is the confirmed-lapse code (HTTP 403, no WWW-Authenticate).
+        // -32001 stays reserved for authentication failures at HTTP 401 per
+        // docs/mcp-error-catalog.mdx — reusing it here sent doc-following
+        // agents into a pointless OAuth re-auth loop.
+        code: retryable ? -32603 : -32002,
         message,
         data: { code: billingStatus },
       },

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -13,7 +13,6 @@ import { redisPipeline as rawRedisPipeline } from '../_upstash-json.js';
 import {
   getBillingVerificationDenial,
   getEntitlements,
-  type CachedEntitlements,
 } from '../../server/_shared/entitlement-check';
 import {
   buildInternalMcpHeaders,
@@ -160,13 +159,9 @@ function getMcpBillingVerificationDenial(
   corsHeaders: Record<string, string>,
 ): Response | null {
   // The shared helper owns status, retry normalization, no-store, and billing
-  // headers. McpHandlerDeps intentionally exposes only the entitlement fields
-  // this edge needs, while the helper's wider CachedEntitlements contract is
-  // what the production dependency returns.
-  const denial = getBillingVerificationDenial(
-    entitlements as CachedEntitlements | null,
-    corsHeaders,
-  );
+  // headers. Its parameter asks only for the billing fields, so the narrower
+  // McpHandlerDeps entitlement shape is directly assignable.
+  const denial = getBillingVerificationDenial(entitlements, corsHeaders);
   const billingStatus = entitlements?.billingStatus;
   if (!denial || !billingStatus) return null;
 

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -13,6 +13,7 @@ import { redisPipeline as rawRedisPipeline } from '../_upstash-json.js';
 import {
   getBillingVerificationDenial,
   getEntitlements,
+  type BillingVerificationStatus,
 } from '../../server/_shared/entitlement-check';
 import {
   buildInternalMcpHeaders,
@@ -156,10 +157,7 @@ export function wwwAuthHeader(resourceMetadataUrl: string, errorParam = ''): str
 
 export function getMcpBillingVerificationDenial(
   entitlements: {
-    billingStatus?:
-      | 'subscription_lapsed'
-      | 'renewal_verification_pending'
-      | 'renewal_verification_failed';
+    billingStatus?: BillingVerificationStatus;
     retryAfterSeconds?: number;
   } | null | undefined,
   corsHeaders: Record<string, string>,

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -10,7 +10,11 @@ import { getClientIp } from '../_client-ip.js';
 import { captureSilentError } from '../_sentry-edge.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline as rawRedisPipeline } from '../_upstash-json.js';
-import { getEntitlements } from '../../server/_shared/entitlement-check';
+import {
+  getBillingVerificationDenial,
+  getEntitlements,
+  type CachedEntitlements,
+} from '../../server/_shared/entitlement-check';
 import {
   buildInternalMcpHeaders,
   signInternalMcpRequest,
@@ -149,6 +153,45 @@ export const PRODUCTION_DEPS: McpHandlerDeps = {
 export function wwwAuthHeader(resourceMetadataUrl: string, errorParam = ''): string {
   const errSegment = errorParam ? `, error="${errorParam}"` : '';
   return `Bearer realm="worldmonitor"${errSegment}, resource_metadata="${resourceMetadataUrl}"`;
+}
+
+function getMcpBillingVerificationDenial(
+  entitlements: Awaited<ReturnType<McpHandlerDeps['getEntitlements']>>,
+  corsHeaders: Record<string, string>,
+): Response | null {
+  // The shared helper owns status, retry normalization, no-store, and billing
+  // headers. McpHandlerDeps intentionally exposes only the entitlement fields
+  // this edge needs, while the helper's wider CachedEntitlements contract is
+  // what the production dependency returns.
+  const denial = getBillingVerificationDenial(
+    entitlements as CachedEntitlements | null,
+    corsHeaders,
+  );
+  const billingStatus = entitlements?.billingStatus;
+  if (!denial || !billingStatus) return null;
+
+  const retryable = denial.status === 503;
+  const message = {
+    subscription_lapsed: 'Subscription lapsed.',
+    renewal_verification_pending: 'Renewal verification pending. Retry shortly.',
+    renewal_verification_failed: 'Renewal verification failed. Retry shortly.',
+  }[billingStatus];
+  const headers = new Headers(denial.headers);
+  headers.set('Cache-Control', 'no-store');
+  headers.set('Content-Type', 'application/json');
+
+  return new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: null,
+      error: {
+        code: retryable ? -32603 : -32001,
+        message,
+        data: { code: billingStatus },
+      },
+    }),
+    { status: denial.status, headers },
+  );
 }
 
 export async function resolveAuthContext(
@@ -315,6 +358,8 @@ async function checkMcpEntitlementGate(
   const tier = ent?.features?.tier ?? 0;
   const mcpAccess = ent?.features?.mcpAccess === true;
   const validUntil = ent?.validUntil ?? 0;
+  const billingDenial = getMcpBillingVerificationDenial(ent, corsHeaders);
+  if (billingDenial) return billingDenial;
   if (!ent || tier < 1 || !mcpAccess || validUntil < Date.now()) {
     return rejected();
   }

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -397,6 +397,11 @@ async function checkMcpEntitlementGate(
   const tier = ent?.features?.tier ?? 0;
   const mcpAccess = ent?.features?.mcpAccess === true;
   const validUntil = ent?.validUntil ?? 0;
+  // Renewal uncertainty on a stronger subscription must not revoke MCP when
+  // a separate, current fallback subscription still authorizes MCP access.
+  if (ent && tier >= 1 && mcpAccess && validUntil >= Date.now()) {
+    return null;
+  }
   const billingDenial = getMcpBillingVerificationDenial(ent, corsHeaders);
   if (billingDenial) return billingDenial;
   if (!ent || tier < 1 || !mcpAccess || validUntil < Date.now()) {

--- a/api/mcp/billing-denial.ts
+++ b/api/mcp/billing-denial.ts
@@ -1,0 +1,76 @@
+// #4770 review: billing-verification denials from the gateway must survive the
+// tool `_execute` fetch layer. Without this, a mid-request entitlement lapse
+// (gateway 403/503 with X-Billing-Verification) is flattened by dispatch's
+// catch-all into HTTP 200 / -32603 "Internal error: data fetch failed" — the
+// agent loses the retry/billing signal for exactly the window the on-demand
+// renewal verification exists to cover.
+
+export type BillingVerificationCode =
+  | 'subscription_lapsed'
+  | 'renewal_verification_pending'
+  | 'renewal_verification_failed';
+
+const BILLING_VERIFICATION_CODES: ReadonlySet<string> = new Set([
+  'subscription_lapsed',
+  'renewal_verification_pending',
+  'renewal_verification_failed',
+] satisfies BillingVerificationCode[]);
+
+export class BillingDenialError extends Error {
+  readonly status: number;
+  readonly billingCode: BillingVerificationCode;
+  readonly retryAfterSeconds: number | undefined;
+
+  constructor(
+    label: string,
+    status: number,
+    billingCode: BillingVerificationCode,
+    retryAfterSeconds: number | undefined,
+  ) {
+    // Keep the `<tool> HTTP <status>` shape: dispatch's log-severity downgrade
+    // for expected 4xx keys on this message format.
+    super(`${label} HTTP ${status} (${billingCode})`);
+    this.name = 'BillingDenialError';
+    this.status = status;
+    this.billingCode = billingCode;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+// Structural subset of Response so test doubles that stub only {ok, status}
+// (several suites do) pass through the non-billing path instead of throwing
+// on a missing headers object.
+type ToolFetchResponse = {
+  ok: boolean;
+  status: number;
+  headers?: { get(name: string): string | null };
+};
+
+/**
+ * Throws BillingDenialError when a non-ok gateway response carries the
+ * billing-verification marker header. Detection is header-only, so callers
+ * that read the error body for detail can still consume it afterwards.
+ */
+export function throwIfBillingDenial(response: ToolFetchResponse, label: string): void {
+  if (response.ok) return;
+  const marker = response.headers?.get('X-Billing-Verification');
+  if (!marker || !BILLING_VERIFICATION_CODES.has(marker)) return;
+  const rawRetryAfter = Number(response.headers?.get('Retry-After'));
+  throw new BillingDenialError(
+    label,
+    response.status,
+    marker as BillingVerificationCode,
+    Number.isFinite(rawRetryAfter) ? rawRetryAfter : undefined,
+  );
+}
+
+/**
+ * Standard non-ok handling for tool `_execute` gateway fetches: billing
+ * denials become typed errors dispatch can re-emit faithfully; everything
+ * else keeps the existing `<label> HTTP <status>` Error contract.
+ */
+export function assertToolFetchOk(response: ToolFetchResponse, label: string): void {
+  if (response.ok) return;
+  throwIfBillingDenial(response, label);
+  throw new Error(`${label} HTTP ${response.status}`);
+}

--- a/api/mcp/billing-denial.ts
+++ b/api/mcp/billing-denial.ts
@@ -5,10 +5,9 @@
 // agent loses the retry/billing signal for exactly the window the on-demand
 // renewal verification exists to cover.
 
-export type BillingVerificationCode =
-  | 'subscription_lapsed'
-  | 'renewal_verification_pending'
-  | 'renewal_verification_failed';
+import type { BillingVerificationStatus } from '../../server/_shared/entitlement-check';
+
+export type BillingVerificationCode = BillingVerificationStatus;
 
 const BILLING_VERIFICATION_CODES: ReadonlySet<string> = new Set([
   'subscription_lapsed',
@@ -55,7 +54,10 @@ export function throwIfBillingDenial(response: ToolFetchResponse, label: string)
   if (response.ok) return;
   const marker = response.headers?.get('X-Billing-Verification');
   if (!marker || !BILLING_VERIFICATION_CODES.has(marker)) return;
-  const rawRetryAfter = Number(response.headers?.get('Retry-After'));
+  // Distinguish a missing header from a present-but-zero value: Number(null)
+  // is 0 (finite), which would silently masquerade as an explicit 0s hint.
+  const retryHeader = response.headers?.get('Retry-After');
+  const rawRetryAfter = retryHeader == null ? Number.NaN : Number(retryHeader);
   throw new BillingDenialError(
     label,
     response.status,

--- a/api/mcp/billing-denial.ts
+++ b/api/mcp/billing-denial.ts
@@ -7,12 +7,18 @@
 
 import type { BillingVerificationStatus } from '../../server/_shared/entitlement-check';
 
-export type BillingVerificationCode = BillingVerificationStatus;
+export type BillingVerificationCode =
+  | BillingVerificationStatus
+  // Gateway-synthesized (server/gateway.ts wm_-key branch): backend-unreachable
+  // fail-closed 503. Deliberately NOT in the Convex-facing
+  // BillingVerificationStatus union — Convex never produces it.
+  | 'entitlement_verification_unavailable';
 
 const BILLING_VERIFICATION_CODES: ReadonlySet<string> = new Set([
   'subscription_lapsed',
   'renewal_verification_pending',
   'renewal_verification_failed',
+  'entitlement_verification_unavailable',
 ] satisfies BillingVerificationCode[]);
 
 export class BillingDenialError extends Error {

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -6,6 +6,8 @@ import {
   PRO_DAILY_QUOTA_LIMIT,
   secondsUntilUtcMidnight,
 } from '../../server/_shared/pro-mcp-token';
+import { getMcpBillingVerificationDenial } from './auth';
+import { BillingDenialError } from './billing-denial';
 import { mcpErrorFingerprint } from './error-fingerprint';
 import { argBool, summarizeData } from './filters';
 import { evaluateFreshness } from './freshness';
@@ -284,6 +286,19 @@ export async function dispatchToolsCall(
       error_kind: isClient4xx ? 'client_4xx' : 'server_error',
       budget_exceeded: false,
     });
+    // #4770: a mid-request billing denial from the gateway keeps its full
+    // contract (status, Retry-After, X-Billing-Verification, data.code)
+    // instead of flattening into the generic -32603. The pre-dispatch
+    // entitlement gate catches most billing denials; this covers the window
+    // between that pre-check and the tool's downstream fetch.
+    if (err instanceof BillingDenialError) {
+      const denial = getMcpBillingVerificationDenial(
+        { billingStatus: err.billingCode, retryAfterSeconds: err.retryAfterSeconds },
+        corsHeaders,
+        id,
+      );
+      if (denial) return denial;
+    }
     return rpcError(id, -32603, 'Internal error: data fetch failed', corsHeaders);
   }
 }

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -263,7 +263,11 @@ export async function dispatchToolsCall(
     // fire on 4xx while Sentry does not, defeating the downgrade.
     const message = err instanceof Error ? err.message : String(err);
     const isClient4xx = /HTTP 4\d\d\b/.test(message);
-    const log = isClient4xx ? console.warn : console.error;
+    // A typed billing denial (incl. its 503 pending/failed variants) is an
+    // expected, handled customer state — warning-level, not error-level, so
+    // Sentry/log alerts don't page on ordinary billing churn.
+    const isExpectedDenial = err instanceof BillingDenialError;
+    const log = isClient4xx || isExpectedDenial ? console.warn : console.error;
     log('[mcp] tool execution error:', err);
     captureSilentError(err, {
       tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
@@ -271,7 +275,7 @@ export async function dispatchToolsCall(
       // Split the api/mcp catch-all (WORLDMONITOR-T8) into per-tool,
       // per-status groups — see api/mcp/error-fingerprint.ts.
       fingerprint: mcpErrorFingerprint('tool-execution', tool.name, err),
-      ...(isClient4xx ? { level: 'warning' as const } : {}),
+      ...(isClient4xx || isExpectedDenial ? { level: 'warning' as const } : {}),
     });
     emitTelemetry('mcp.toolcall', {
       tool: tool.name,

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -741,7 +741,14 @@ async function mcpHandlerInner(
         return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
       }
       const dispatched = await dispatchToolsCall(req, context, deps, body, corsHeaders, ctx);
-      if (dispatched.status === 429 || dispatched.status === 503) usage.phase = 'dispatch';
+      // Mid-call billing denials (dispatch's BillingDenialError re-emit) must
+      // classify like the pre-check sites: 'billing' -> billing_verification_503
+      // / tier_403, not rate_limit_degraded (503) or 'ok' (403).
+      if (dispatched.headers.get('X-Billing-Verification')) {
+        usage.phase = 'billing';
+      } else if (dispatched.status === 429 || dispatched.status === 503) {
+        usage.phase = 'dispatch';
+      }
       return maybeStreamJsonRpcResponse(req, dispatched);
     }
     // Prompts are metadata-class — they ship a workflow template, not data.

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -313,7 +313,7 @@ async function handleAuthenticatedSseReplay(
   setUsageContext(usage, auth.context);
   const getPreCheck = await runContextPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
   if (getPreCheck) {
-    usage.phase = 'precheck';
+    usage.phase = getPreCheck.headers.get('X-Billing-Verification') ? 'billing' : 'precheck';
     return getPreCheck;
   }
   const getLimited = await applyPerMinuteLimit(auth.context, corsHeaders);
@@ -671,7 +671,7 @@ async function mcpHandlerInner(
     setUsageContext(usage, context);
     const preCheck = await runContextPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
     if (preCheck) {
-      usage.phase = 'precheck';
+      usage.phase = preCheck.headers.get('X-Billing-Verification') ? 'billing' : 'precheck';
       return preCheck;
     }
     const limited = await applyPerMinuteLimit(context, corsHeaders);

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -4,6 +4,7 @@ import MINING_SITES_RAW from '../../../shared/mining-sites.js';
 // @ts-expect-error — JS module, no declaration file
 import { readJsonFromUpstash } from '../../_upstash-json.js';
 import { buildAuthHeaders } from '../auth';
+import { assertToolFetchOk, throwIfBillingDenial } from '../billing-denial';
 import { SUPPORTED_CONSUMER_PRICES_COUNTRIES } from '../constants';
 import { evaluateFreshness } from '../freshness';
 import type { FreshnessCheck, ToolDef } from '../types';
@@ -249,7 +250,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(8_000),
       });
-      if (!response.ok) throw new Error(`list-global-tenders HTTP ${response.status}`);
+      assertToolFetchOk(response, 'list-global-tenders');
       const result = await response.json() as ProcurementRouteResponse;
       return {
         opportunities: (result.tenders || []).map(compactProcurementOpportunity),
@@ -318,7 +319,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...digestAuth, 'User-Agent': UA },
         signal: AbortSignal.timeout(6_000),
       });
-      if (!digestRes.ok) throw new Error(`feed-digest HTTP ${digestRes.status}`);
+      assertToolFetchOk(digestRes, 'feed-digest');
       type DigestPayload = { categories?: Record<string, { items?: DigestItemForBrief[] }> };
       const digest = await digestRes.json() as DigestPayload;
       // Pair headlines with their RSS snippets so the LLM grounds per-story
@@ -355,7 +356,7 @@ export const RPC_TOOLS: ToolDef[] = [
         body: briefBody,
         signal: AbortSignal.timeout(18_000),
       });
-      if (!briefRes.ok) throw new Error(`summarize-article HTTP ${briefRes.status}`);
+      assertToolFetchOk(briefRes, 'summarize-article');
       const result = await briefRes.json() as Record<string, unknown>;
       return { ...result, headlines, sources };
     },
@@ -457,6 +458,7 @@ export const RPC_TOOLS: ToolDef[] = [
         signal: AbortSignal.timeout(22_000),
       });
       if (!res.ok) {
+        throwIfBillingDenial(res, 'get-country-intel-brief');
         // Surface the gateway's error code in the thrown message so Sentry
         // groups the failure by root cause, not just status. Body reads are
         // best-effort; a read failure must not mask the HTTP status.
@@ -530,7 +532,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(8_000),
       });
-      if (!res.ok) throw new Error(`get-country-risk HTTP ${res.status}`);
+      assertToolFetchOk(res, 'get-country-risk');
       return res.json();
     },
     _apiPaths: [
@@ -874,6 +876,7 @@ export const RPC_TOOLS: ToolDef[] = [
         signal: AbortSignal.timeout(8_000),
       });
       if (!res.ok) {
+        throwIfBillingDenial(res, 'get-vessel-snapshot');
         const detail = (await res.text().catch(() => '')).slice(0, 200);
         throw new Error(`get-vessel-snapshot HTTP ${res.status}${detail ? ` — ${detail}` : ''}`);
       }
@@ -967,7 +970,7 @@ export const RPC_TOOLS: ToolDef[] = [
         body,
         signal: AbortSignal.timeout(25_000),
       });
-      if (!res.ok) throw new Error(`deduct-situation HTTP ${res.status}`);
+      assertToolFetchOk(res, 'deduct-situation');
       return res.json();
     },
     _apiPaths: [
@@ -1010,7 +1013,7 @@ export const RPC_TOOLS: ToolDef[] = [
         body,
         signal: AbortSignal.timeout(25_000),
       });
-      if (!res.ok) throw new Error(`get-forecasts HTTP ${res.status}`);
+      assertToolFetchOk(res, 'get-forecasts');
       return res.json();
     },
     _apiPaths: [],
@@ -1073,7 +1076,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(25_000),
       });
-      if (!res.ok) throw new Error(`search-google-flights HTTP ${res.status}`);
+      assertToolFetchOk(res, 'search-google-flights');
       return res.json();
     },
     _apiPaths: [
@@ -1131,7 +1134,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(25_000),
       });
-      if (!res.ok) throw new Error(`search-google-dates HTTP ${res.status}`);
+      assertToolFetchOk(res, 'search-google-dates');
       return res.json();
     },
     _apiPaths: [

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -4,7 +4,7 @@ import MINING_SITES_RAW from '../../../shared/mining-sites.js';
 // @ts-expect-error — JS module, no declaration file
 import { readJsonFromUpstash } from '../../_upstash-json.js';
 import { buildAuthHeaders } from '../auth';
-import { assertToolFetchOk, throwIfBillingDenial } from '../billing-denial';
+import { assertToolFetchOk, BillingDenialError, throwIfBillingDenial } from '../billing-denial';
 import { SUPPORTED_CONSUMER_PRICES_COUNTRIES } from '../constants';
 import { evaluateFreshness } from '../freshness';
 import type { FreshnessCheck, ToolDef } from '../types';
@@ -755,12 +755,28 @@ export const RPC_TOOLS: ToolDef[] = [
         type === 'military' || !civAuth
           ? Promise.resolve(null)
           : fetch(civUrl, { headers: { ...civAuth, 'User-Agent': UA }, signal: AbortSignal.timeout(8_000) })
-              .then(r => r.ok ? r.json() as Promise<CivilianResp> : Promise.reject(new Error(`HTTP ${r.status}`))),
+              .then(r => {
+                throwIfBillingDenial(r, 'get-airspace-civilian');
+                return r.ok ? r.json() as Promise<CivilianResp> : Promise.reject(new Error(`HTTP ${r.status}`));
+              }),
         type === 'civilian' || !milAuth
           ? Promise.resolve(null)
           : fetch(milUrl, { headers: { ...milAuth, 'User-Agent': UA }, signal: AbortSignal.timeout(8_000) })
-              .then(r => r.ok ? r.json() as Promise<MilResp> : Promise.reject(new Error(`HTTP ${r.status}`))),
+              .then(r => {
+                throwIfBillingDenial(r, 'get-airspace-military');
+                return r.ok ? r.json() as Promise<MilResp> : Promise.reject(new Error(`HTTP ${r.status}`));
+              }),
       ]);
+
+      // A billing denial is user-level, not a data-source outage: never serve
+      // partial data or a generic both-failed error over it — rethrow so
+      // dispatch re-emits the full billing contract (status, Retry-After,
+      // X-Billing-Verification, data.code).
+      for (const result of [civResult, milResult]) {
+        if (result.status === 'rejected' && result.reason instanceof BillingDenialError) {
+          throw result.reason;
+        }
+      }
 
       const civOk = type === 'military' || civResult.status === 'fulfilled';
       const milOk = type === 'civilian' || milResult.status === 'fulfilled';

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -235,7 +235,16 @@ export interface QuotaRejected {
 export interface McpHandlerDeps {
   resolveBearerToContext: (token: string) => Promise<McpAuthContext | null>;
   validateProMcpToken: (tokenId: string) => Promise<{ userId: string } | null>;
-  getEntitlements: (userId: string) => Promise<{ planKey?: string; features: { tier: number; mcpAccess?: boolean }; validUntil: number } | null>;
+  getEntitlements: (userId: string) => Promise<{
+    planKey?: string;
+    features: { tier: number; mcpAccess?: boolean };
+    validUntil: number;
+    billingStatus?:
+      | 'subscription_lapsed'
+      | 'renewal_verification_pending'
+      | 'renewal_verification_failed';
+    retryAfterSeconds?: number;
+  } | null>;
   // #4859: Convex userApiKeys hash lookup (same shared helper as the REST
   // gateway). Returns the key owner, or null for unknown/revoked keys. The
   // production impl fail-softs to null internally; a THROW from a dep is

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -2,6 +2,8 @@
 // Pure types only — no runtime exports — so this module is safe to import
 // from anywhere without creating evaluation-order surprises or cycles.
 
+import type { BillingVerificationStatus } from '../../server/_shared/entitlement-check';
+
 // ---------------------------------------------------------------------------
 // Auth-context shape passed into tool _execute. U7 widened the previous
 // `apiKey: string` to a discriminated union so per-tool fetches can branch
@@ -239,10 +241,7 @@ export interface McpHandlerDeps {
     planKey?: string;
     features: { tier: number; mcpAccess?: boolean };
     validUntil: number;
-    billingStatus?:
-      | 'subscription_lapsed'
-      | 'renewal_verification_pending'
-      | 'renewal_verification_failed';
+    billingStatus?: BillingVerificationStatus;
     retryAfterSeconds?: number;
   } | null>;
   // #4859: Convex userApiKeys hash lookup (same shared helper as the REST

--- a/api/mcp/usage.ts
+++ b/api/mcp/usage.ts
@@ -34,6 +34,7 @@ import type { McpAuthContext } from './types';
 export type McpPhase =
   | 'auth'       // credential resolution rejected (invalid key/bearer, backend down)
   | 'precheck'   // identity ok, entitlement/token pre-check rejected
+  | 'billing'    // pre-check rejected with a billing-verification denial (#4770)
   | 'limit'      // per-minute rate limit
   | 'dispatch'   // tools/call quota (429) / reservation unavailable (503)
   | 'malformed'  // unparseable JSON-RPC envelope
@@ -78,6 +79,12 @@ export function mcpReasonFor(phase: McpPhase, status: number): RequestReason {
       return status === 503 ? 'auth_unavailable' : 'auth_401';
     case 'precheck':
       return status === 503 ? 'auth_unavailable' : 'tier_403';
+    case 'billing':
+      // Mirrors server/gateway.ts's classification of the same denial: a
+      // billing-verification 503 is provider-verification churn, not the
+      // auth backend being unreachable — keeping it out of auth_unavailable
+      // stops Axiom outage alerts from paging on ordinary billing states.
+      return status === 503 ? 'billing_verification_503' : 'tier_403';
     case 'limit':
       return 'rate_limit_429';
     case 'dispatch':

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -3694,4 +3694,148 @@ describe("payments billing missed renewal reconciliation", () => {
     expect(errorSpy).toHaveBeenCalledTimes(1);
     errorSpy.mockRestore();
   });
+
+  describe("on-demand renewal verification", () => {
+    test("restores premium access immediately when Dodo reports a future active period", async () => {
+      const t = convexTest(schema, modules);
+      const renewedEnd = NOW + 30 * DAY_MS;
+      await seedStaleActiveForReconcile(t, { suffix: "on_demand_active" });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_active",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW).toISOString(),
+              next_billing_date: new Date(renewedEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(result).toEqual({ status: "active" });
+      expect((await readSub(t, "on_demand_active"))?.currentPeriodEnd).toBe(renewedEnd);
+      expect((await readEntitlement(t, TEST_USER_ID))?.validUntil).toBe(renewedEnd);
+    });
+
+    test("corrects an inactive remote subscription and reports a confirmed lapse", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_expired",
+        currentPeriodEnd: staleEnd,
+      });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_expired",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "expired",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(staleEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(result).toEqual({ status: "subscription_lapsed" });
+      expect((await readSub(t, "on_demand_expired"))?.status).toBe("expired");
+      expect((await readEntitlement(t, TEST_USER_ID))?.planKey).toBe("free");
+    });
+
+    test("surfaces Dodo failure and throttles an immediate retry", async () => {
+      const t = convexTest(schema, modules);
+      await seedStaleActiveForReconcile(t, { suffix: "on_demand_failure" });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const first = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [],
+        },
+      );
+      const second = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW + 1_000,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_failure",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW).toISOString(),
+              next_billing_date: new Date(NOW + 30 * DAY_MS).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(first).toMatchObject({ status: "renewal_verification_failed" });
+      expect(second).toMatchObject({
+        status: "renewal_verification_failed",
+        retryAfterSeconds: expect.any(Number),
+      });
+      expect((await readSub(t, "on_demand_failure"))?.currentPeriodEnd).toBe(NOW - DAY_MS);
+      errorSpy.mockRestore();
+    });
+
+    test("atomically coalesces concurrent claims for the same stale subscription", async () => {
+      const t = convexTest(schema, modules);
+      await seedStaleActiveForReconcile(t, { suffix: "on_demand_coalesce" });
+
+      const claims = await Promise.all([
+        t.mutation(
+          internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+          { userId: TEST_USER_ID, now: NOW },
+        ),
+        t.mutation(
+          internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+          { userId: TEST_USER_ID, now: NOW },
+        ),
+      ]);
+
+      expect(claims.map((claim) => claim.kind).sort()).toEqual(["claimed", "pending"]);
+    });
+
+    test("does not call Dodo for an active row outside the recent-staleness window", async () => {
+      const t = convexTest(schema, modules);
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_old",
+        currentPeriodEnd: NOW - 4 * DAY_MS,
+      });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_old",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW).toISOString(),
+              next_billing_date: new Date(NOW + 30 * DAY_MS).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(result).toEqual({ status: "subscription_lapsed" });
+      expect((await readSub(t, "on_demand_old"))?.currentPeriodEnd).toBe(NOW - 4 * DAY_MS);
+    });
+  });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -9,6 +9,7 @@ import {
   STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS,
   safeMarkReconcileAttempt,
 } from "../payments/billing";
+import { upsertEntitlements } from "../payments/subscriptionHelpers";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { signAnonClaimToken } from "../lib/identitySigning";
 
@@ -4049,7 +4050,7 @@ describe("payments billing missed renewal reconciliation", () => {
         { userId: TEST_USER_ID, now: NOW + 1_000 },
       );
 
-      expect(claim).toEqual({ kind: "pending", retryAfterSeconds: 14 });
+      expect(claim).toEqual({ kind: "pending", retryAfterSeconds: 2 });
       expect((await t.run((ctx) => ctx.db.get(strongerId)))?.renewalVerificationState).toBeUndefined();
     });
 
@@ -4188,6 +4189,34 @@ describe("payments billing missed renewal reconciliation", () => {
       expect(result).toEqual({ status: "subscription_lapsed" });
       expect((await readSub(t, "on_demand_lapsed_cooldown"))?.currentPeriodEnd).toBe(NOW - DAY_MS);
       expect((await readSub(t, "on_demand_lapsed_cooldown"))?.renewalVerificationState).toBe("lapsed");
+    });
+  });
+
+  describe("entitlement cache re-sync (#4770 marker race)", () => {
+    test("schedules an immediate and a delayed cache sync when Redis is configured", async () => {
+      const t = convexTest(schema, modules);
+      vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://upstash.test");
+      try {
+        await t.run(async (ctx) => {
+          await upsertEntitlements(ctx, TEST_USER_ID, "pro_monthly", NOW + 30 * DAY_MS, NOW);
+        });
+
+        const scheduled = await t.run((ctx) =>
+          ctx.db.system.query("_scheduled_functions").collect(),
+        );
+        const syncs = scheduled
+          .filter((job) => job.name.includes("syncEntitlementCache"))
+          .sort((a, b) => a.scheduledTime - b.scheduledTime);
+
+        // The delayed second sync overwrites any stale billing-denial marker a
+        // still-in-flight request writes AFTER the immediate sync (bare SET,
+        // last-writer-wins) — without it a just-renewed user can be re-denied
+        // until the marker TTL expires.
+        expect(syncs).toHaveLength(2);
+        expect(syncs[1].scheduledTime - syncs[0].scheduledTime).toBe(15_000);
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
   });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -3753,6 +3753,204 @@ describe("payments billing missed renewal reconciliation", () => {
       expect((await readEntitlement(t, TEST_USER_ID))?.planKey).toBe("free");
     });
 
+    test("does not report a user-level lapse until every recently-stale subscription is resolved", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      const renewedEnd = NOW + 30 * DAY_MS;
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_stronger_lapsed",
+        planKey: "enterprise",
+        dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+        currentPeriodEnd: staleEnd,
+      });
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_weaker_renewed",
+        planKey: "pro_monthly",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        currentPeriodEnd: staleEnd,
+        seedEntitlement: false,
+      });
+
+      const strongerResult = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_stronger_lapsed",
+              product_id: PRODUCT_CATALOG.enterprise.dodoProductId!,
+              status: "expired",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(staleEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(strongerResult).toEqual({
+        status: "renewal_verification_pending",
+        retryAfterSeconds: 1,
+      });
+      expect((await readSub(t, "on_demand_stronger_lapsed"))?.status).toBe("expired");
+
+      const weakerResult = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW + 1,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_weaker_renewed",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW).toISOString(),
+              next_billing_date: new Date(renewedEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(weakerResult).toEqual({ status: "active" });
+      expect((await readSub(t, "on_demand_weaker_renewed"))?.currentPeriodEnd).toBe(renewedEnd);
+      expect((await readEntitlement(t, TEST_USER_ID))?.validUntil).toBe(renewedEnd);
+    });
+
+    test("treats an unchanged active provider period as verification uncertainty", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_active_unchanged",
+        currentPeriodEnd: staleEnd,
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_active_unchanged",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(staleEnd).toISOString(),
+            },
+          ],
+          // The first failed-state finalization throws; the bounded best-effort
+          // retry must contain it and durably leave this row in failed cooldown.
+          convexFailureInjectionForTest: "finalize",
+        },
+      );
+
+      expect(result).toEqual({
+        status: "renewal_verification_failed",
+        retryAfterSeconds: 60,
+      });
+      expect((await readSub(t, "on_demand_active_unchanged"))?.renewalVerificationState).toBe("failed");
+      errorSpy.mockRestore();
+    });
+
+    test("treats a newer but still-past active provider period as verification uncertainty", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - 2 * DAY_MS;
+      const stillPastEnd = NOW - DAY_MS;
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_active_still_past",
+        currentPeriodEnd: staleEnd,
+      });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_active_still_past",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(stillPastEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(result).toEqual({
+        status: "renewal_verification_failed",
+        retryAfterSeconds: 60,
+      });
+      expect((await readSub(t, "on_demand_active_still_past"))?.currentPeriodEnd).toBe(stillPastEnd);
+      expect((await readSub(t, "on_demand_active_still_past"))?.renewalVerificationState).toBe("failed");
+    });
+
+    test("contains a post-reconcile Convex query failure and returns a retryable result", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_post_query_failure",
+        currentPeriodEnd: staleEnd,
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_post_query_failure",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "expired",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(staleEnd).toISOString(),
+            },
+          ],
+          convexFailureInjectionForTest: "post_reconcile_query",
+        },
+      );
+
+      expect(result).toEqual({
+        status: "renewal_verification_failed",
+        retryAfterSeconds: 60,
+      });
+      expect((await readSub(t, "on_demand_post_query_failure"))?.status).toBe("expired");
+      errorSpy.mockRestore();
+    });
+
+    test("contains a finalize failure and preserves a confirmed active result", async () => {
+      const t = convexTest(schema, modules);
+      const renewedEnd = NOW + 30 * DAY_MS;
+      await seedStaleActiveForReconcile(t, { suffix: "on_demand_finalize_failure" });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_finalize_failure",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW).toISOString(),
+              next_billing_date: new Date(renewedEnd).toISOString(),
+            },
+          ],
+          convexFailureInjectionForTest: "finalize",
+        },
+      );
+
+      expect(result).toEqual({ status: "active" });
+      expect((await readEntitlement(t, TEST_USER_ID))?.validUntil).toBe(renewedEnd);
+      errorSpy.mockRestore();
+    });
+
     test("surfaces Dodo failure and throttles an immediate retry", async () => {
       const t = convexTest(schema, modules);
       await seedStaleActiveForReconcile(t, { suffix: "on_demand_failure" });
@@ -3790,6 +3988,69 @@ describe("payments billing missed renewal reconciliation", () => {
       });
       expect((await readSub(t, "on_demand_failure"))?.currentPeriodEnd).toBe(NOW - DAY_MS);
       errorSpy.mockRestore();
+    });
+
+    test.each(["failed", "lapsed"] as const)(
+      "progresses past a stronger subscription in the %s cooldown",
+      async (verificationState) => {
+        const t = convexTest(schema, modules);
+        const strongerId = await seedStaleActiveForReconcile(t, {
+          suffix: `on_demand_${verificationState}_stronger`,
+          planKey: "enterprise",
+          dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+        });
+        const weakerId = await seedStaleActiveForReconcile(t, {
+          suffix: `on_demand_${verificationState}_weaker`,
+          planKey: "pro_monthly",
+          dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          seedEntitlement: false,
+        });
+        await t.run(async (ctx) => {
+          await ctx.db.patch(strongerId, {
+            renewalVerificationState: verificationState,
+            renewalVerificationAttemptAt: NOW,
+          });
+        });
+
+        const claim = await t.mutation(
+          internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+          { userId: TEST_USER_ID, now: NOW + 1_000 },
+        );
+
+        expect(claim.kind).toBe("claimed");
+        if (claim.kind === "claimed") {
+          expect(claim.subscription._id).toBe(weakerId);
+        }
+      },
+    );
+
+    test("coalesces at the user level when a different stale subscription is pending", async () => {
+      const t = convexTest(schema, modules);
+      const strongerId = await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_pending_stronger",
+        planKey: "enterprise",
+        dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+      });
+      const weakerId = await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_pending_weaker",
+        planKey: "pro_monthly",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        seedEntitlement: false,
+      });
+      await t.run(async (ctx) => {
+        await ctx.db.patch(weakerId, {
+          renewalVerificationState: "pending",
+          renewalVerificationAttemptAt: NOW,
+        });
+      });
+
+      const claim = await t.mutation(
+        internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+        { userId: TEST_USER_ID, now: NOW + 1_000 },
+      );
+
+      expect(claim).toEqual({ kind: "pending", retryAfterSeconds: 14 });
+      expect((await t.run((ctx) => ctx.db.get(strongerId)))?.renewalVerificationState).toBeUndefined();
     });
 
     test("atomically coalesces concurrent claims for the same stale subscription", async () => {

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -4098,5 +4098,96 @@ describe("payments billing missed renewal reconciliation", () => {
       expect(result).toEqual({ status: "subscription_lapsed" });
       expect((await readSub(t, "on_demand_old"))?.currentPeriodEnd).toBe(NOW - 4 * DAY_MS);
     });
+
+    test("rejects test-injection args outside NODE_ENV=test", async () => {
+      const t = convexTest(schema, modules);
+      vi.stubEnv("NODE_ENV", "production");
+      try {
+        await expect(
+          t.action(internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand, {
+            userId: TEST_USER_ID,
+            now: NOW,
+            remoteSubscriptionsForTest: [],
+          }),
+        ).rejects.toThrow(/test injection args are only allowed under test/);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    test("returns active via post-reconcile resolution when another subscription already covers", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      const coveredEnd = NOW + 20 * DAY_MS;
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_resolution_expired",
+        currentPeriodEnd: staleEnd,
+        seedEntitlement: false,
+      });
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_resolution_cover",
+        planKey: "enterprise",
+        dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+        currentPeriodEnd: coveredEnd,
+      });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_resolution_expired",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "expired",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(staleEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      // The claimed row is confirmed non-covering, so this "active" must come
+      // from the post-reconcile resolution read of the covering subscription,
+      // not the outcomeConfirmsCoveringPeriod short-circuit.
+      expect(result).toEqual({ status: "active" });
+      expect((await readSub(t, "on_demand_resolution_expired"))?.status).toBe("expired");
+      expect((await readEntitlement(t, TEST_USER_ID))?.validUntil).toBe(coveredEnd);
+    });
+
+    test("serves the lapsed cooldown without a provider call when every stale row is lapsed", async () => {
+      const t = convexTest(schema, modules);
+      const subId = await seedStaleActiveForReconcile(t, { suffix: "on_demand_lapsed_cooldown" });
+      await t.run(async (ctx) => {
+        await ctx.db.patch(subId, {
+          renewalVerificationState: "lapsed",
+          renewalVerificationAttemptAt: NOW,
+        });
+      });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW + 1_000,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_lapsed_cooldown",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "active",
+              previous_billing_date: new Date(NOW).toISOString(),
+              next_billing_date: new Date(NOW + 30 * DAY_MS).toISOString(),
+            },
+          ],
+        },
+      );
+
+      // The remote payload reports a covering renewal; a cooldown-honoring
+      // claim never consults it, so the row must stay stale and lapsed.
+      expect(result).toEqual({ status: "subscription_lapsed" });
+      expect((await readSub(t, "on_demand_lapsed_cooldown"))?.currentPeriodEnd).toBe(NOW - DAY_MS);
+      expect((await readSub(t, "on_demand_lapsed_cooldown"))?.renewalVerificationState).toBe("lapsed");
+    });
   });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -4190,12 +4190,72 @@ describe("payments billing missed renewal reconciliation", () => {
       expect((await readSub(t, "on_demand_lapsed_cooldown"))?.currentPeriodEnd).toBe(NOW - DAY_MS);
       expect((await readSub(t, "on_demand_lapsed_cooldown"))?.renewalVerificationState).toBe("lapsed");
     });
+
+    test("finalize is a no-op when a newer claim superseded the caller's lease", async () => {
+      const t = convexTest(schema, modules);
+      const subId = await seedStaleActiveForReconcile(t, { suffix: "on_demand_stale_finalize" });
+      const claim = await t.mutation(
+        internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+        { userId: TEST_USER_ID, now: NOW },
+      );
+      expect(claim.kind).toBe("claimed");
+
+      // A newer claim supersedes the original lease (fresh attempt timestamp);
+      // the original owner's finalize must not clobber it.
+      await t.run(async (ctx) => {
+        await ctx.db.patch(subId, { renewalVerificationAttemptAt: NOW + 20_000 });
+      });
+      await t.mutation(
+        internal.payments.billing.finalizeRecentlyStaleSubscriptionVerification,
+        { subscriptionId: subId, claimedAt: NOW, status: "lapsed" },
+      );
+
+      const row = await readSub(t, "on_demand_stale_finalize");
+      expect(row?.renewalVerificationState).toBe("pending");
+      expect(row?.renewalVerificationAttemptAt).toBe(NOW + 20_000);
+    });
+
+    test("an unusable remote status maps to a retryable verification failure", async () => {
+      const t = convexTest(schema, modules);
+      await seedStaleActiveForReconcile(t, { suffix: "on_demand_unusable" });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_unusable",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "pending",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(NOW - DAY_MS).toISOString(),
+            },
+          ],
+        },
+      );
+
+      expect(result).toEqual({
+        status: "renewal_verification_failed",
+        retryAfterSeconds: 60,
+      });
+      expect((await readSub(t, "on_demand_unusable"))?.renewalVerificationState).toBe("failed");
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
   });
 
   describe("entitlement cache re-sync (#4770 marker race)", () => {
-    test("schedules an immediate and a delayed cache sync when Redis is configured", async () => {
+    test("schedules an immediate snapshot sync and a delayed from-DB re-sync", async () => {
       const t = convexTest(schema, modules);
       vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://upstash.test");
+      // Freeze timers so the enqueued jobs are inspectable but never execute —
+      // convex-test runs a 0-delay scheduled action after the transaction
+      // closes, which trips its "Write outside of transaction" guard.
+      vi.useFakeTimers({ toFake: ["setTimeout", "setInterval"] });
       try {
         await t.run(async (ctx) => {
           await upsertEntitlements(ctx, TEST_USER_ID, "pro_monthly", NOW + 30 * DAY_MS, NOW);
@@ -4204,17 +4264,75 @@ describe("payments billing missed renewal reconciliation", () => {
         const scheduled = await t.run((ctx) =>
           ctx.db.system.query("_scheduled_functions").collect(),
         );
-        const syncs = scheduled
-          .filter((job) => job.name.includes("syncEntitlementCache"))
+        const jobs = scheduled
+          .filter((job) => job.name.includes("cacheActions"))
           .sort((a, b) => a.scheduledTime - b.scheduledTime);
 
         // The delayed second sync overwrites any stale billing-denial marker a
         // still-in-flight request writes AFTER the immediate sync (bare SET,
-        // last-writer-wins) — without it a just-renewed user can be re-denied
-        // until the marker TTL expires.
-        expect(syncs).toHaveLength(2);
-        expect(syncs[1].scheduledTime - syncs[0].scheduledTime).toBe(15_000);
+        // last-writer-wins). It must be the from-DB variant: replaying this
+        // upsert's snapshot could revert a NEWER entitlement write landing
+        // inside the delay (a stale re-grant).
+        expect(jobs).toHaveLength(2);
+        expect(jobs[0].name).toContain("syncEntitlementCache");
+        expect(jobs[0].name).not.toContain("resync");
+        expect(jobs[1].name).toContain("resyncEntitlementCacheFromDb");
+        expect(jobs[1].args).toEqual([{ userId: TEST_USER_ID }]);
+        expect(jobs[1].scheduledTime - jobs[0].scheduledTime).toBe(15_000);
       } finally {
+        vi.useRealTimers();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    test("delayed re-sync writes CURRENT entitlement state, not a caller snapshot", async () => {
+      const t = convexTest(schema, modules);
+      vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://upstash.test");
+      vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "token-test");
+      const setCalls: string[] = [];
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        setCalls.push(String(input));
+        return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+      });
+      try {
+        await t.run(async (ctx) => {
+          await ctx.db.insert("entitlements", {
+            userId: TEST_USER_ID,
+            planKey: "pro_monthly",
+            features: getFeaturesForPlan("pro_monthly"),
+            validUntil: NOW + 30 * DAY_MS,
+            updatedAt: NOW,
+          });
+        });
+        await t.action(internal.payments.cacheActions.resyncEntitlementCacheFromDb, {
+          userId: TEST_USER_ID,
+        });
+        expect(setCalls).toHaveLength(1);
+        expect(setCalls[0]).toContain(encodeURIComponent('"planKey":"pro_monthly"'));
+
+        // A downgrade landing before the delayed job fires must be what the
+        // re-sync writes — the action reads at fire time by construction.
+        await t.run(async (ctx) => {
+          const row = await ctx.db
+            .query("entitlements")
+            .withIndex("by_userId", (q) => q.eq("userId", TEST_USER_ID))
+            .first();
+          if (row) {
+            await ctx.db.patch(row._id, {
+              planKey: "free",
+              features: getFeaturesForPlan("free"),
+              validUntil: 0,
+              updatedAt: NOW + 1,
+            });
+          }
+        });
+        await t.action(internal.payments.cacheActions.resyncEntitlementCacheFromDb, {
+          userId: TEST_USER_ID,
+        });
+        expect(setCalls).toHaveLength(2);
+        expect(setCalls[1]).toContain(encodeURIComponent('"planKey":"free"'));
+      } finally {
+        fetchSpy.mockRestore();
         vi.unstubAllEnvs();
       }
     });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -3754,6 +3754,81 @@ describe("payments billing missed renewal reconciliation", () => {
       expect((await readEntitlement(t, TEST_USER_ID))?.planKey).toBe("free");
     });
 
+    test("threads a sibling's failed cooldown into the resolution-stage Retry-After", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      const strongerId = await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_sibling_failed_stronger",
+        planKey: "enterprise",
+        dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+        currentPeriodEnd: staleEnd,
+      });
+      await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_sibling_failed_weaker",
+        currentPeriodEnd: staleEnd,
+        seedEntitlement: false,
+      });
+      // The stronger sibling is 20s into its 60s failed cooldown, so the claim
+      // skips it and verifies the weaker row.
+      await t.run(async (ctx) => {
+        await ctx.db.patch(strongerId, {
+          renewalVerificationState: "failed",
+          renewalVerificationAttemptAt: NOW - 20_000,
+        });
+      });
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [
+            {
+              subscription_id: "sub_on_demand_sibling_failed_weaker",
+              product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+              status: "expired",
+              previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+              next_billing_date: new Date(staleEnd).toISOString(),
+            },
+          ],
+        },
+      );
+
+      // The resolution stage must quote the SIBLING's remaining failed
+      // cooldown (60s - 20s elapsed = 40s), not the fixed 1s progress retry
+      // the neighboring 'unresolved' branch returns.
+      expect(result).toEqual({
+        status: "renewal_verification_failed",
+        retryAfterSeconds: 40,
+      });
+      expect((await readSub(t, "on_demand_sibling_failed_weaker"))?.status).toBe("expired");
+    });
+
+    test("getOnDemandRenewalResolution reports a live sibling lease as pending", async () => {
+      const t = convexTest(schema, modules);
+      const staleEnd = NOW - DAY_MS;
+      const rowId = await seedStaleActiveForReconcile(t, {
+        suffix: "on_demand_resolution_pending",
+        currentPeriodEnd: staleEnd,
+      });
+      await t.run(async (ctx) => {
+        await ctx.db.patch(rowId, {
+          renewalVerificationState: "pending",
+          renewalVerificationAttemptAt: NOW - 1_000,
+        });
+      });
+
+      const resolution = await t.query(
+        internal.payments.billing.getOnDemandRenewalResolution,
+        { userId: TEST_USER_ID, now: NOW },
+      );
+
+      // Reachable only when a sibling lease starts between this request's
+      // claim and its resolution read; the guard must quote the leader's
+      // expected completion (3s - 1s elapsed = 2s), not lapsed/unresolved.
+      expect(resolution).toEqual({ kind: "pending", retryAfterSeconds: 2 });
+    });
+
     test("does not report a user-level lapse until every recently-stale subscription is resolved", async () => {
       const t = convexTest(schema, modules);
       const staleEnd = NOW - DAY_MS;

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -4278,7 +4278,12 @@ describe("payments billing missed renewal reconciliation", () => {
         expect(jobs[0].name).not.toContain("resync");
         expect(jobs[1].name).toContain("resyncEntitlementCacheFromDb");
         expect(jobs[1].args).toEqual([{ userId: TEST_USER_ID }]);
-        expect(jobs[1].scheduledTime - jobs[0].scheduledTime).toBe(15_000);
+        // Each runAfter stamps its own Date.now() (not faked), so the two
+        // calls can straddle a millisecond tick — assert the delay with a
+        // small tolerance instead of exact equality.
+        const delta = jobs[1].scheduledTime - jobs[0].scheduledTime;
+        expect(delta).toBeGreaterThanOrEqual(15_000);
+        expect(delta).toBeLessThan(15_100);
       } finally {
         vi.useRealTimers();
         vi.unstubAllEnvs();

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -4066,6 +4066,60 @@ describe("payments billing missed renewal reconciliation", () => {
       errorSpy.mockRestore();
     });
 
+    test("on-demand Dodo failure does not inflate the cron's reconcile backoff", async () => {
+      const t = convexTest(schema, modules);
+      const subId = await seedStaleActiveForReconcile(t, { suffix: "on_demand_no_backoff" });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [],
+          errorInjectionForTest: { sub_on_demand_no_backoff: "server_error" },
+        },
+      );
+
+      expect(result).toMatchObject({ status: "renewal_verification_failed" });
+      // The request path owns its own cooldown (renewalVerificationState); the
+      // cron's backoff pair must stay untouched, or a customer retrying through
+      // a Dodo blip (one attempt per 60s cooldown) defers the nightly safety
+      // net toward the 30-day backoff cap.
+      const row = await t.run((ctx) => ctx.db.get(subId));
+      expect(row?.reconcileFailureCount).toBeUndefined();
+      expect(row?.lastReconcileAttemptAt).toBeUndefined();
+      expect(row?.renewalVerificationState).toBe("failed");
+      errorSpy.mockRestore();
+    });
+
+    test("on-demand definitive 404 advances the terminal not-found streak without backoff", async () => {
+      const t = convexTest(schema, modules);
+      const subId = await seedStaleActiveForReconcile(t, { suffix: "on_demand_streak" });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await t.action(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        {
+          userId: TEST_USER_ID,
+          now: NOW,
+          remoteSubscriptionsForTest: [],
+          errorInjectionForTest: { sub_on_demand_streak: "not_found" },
+        },
+      );
+
+      expect(result).toMatchObject({ status: "renewal_verification_failed" });
+      // A definitive 404 is provider evidence regardless of which path saw it:
+      // it must advance reconcileNotFoundCount (the consecutive-404 streak
+      // gating the terminal "deleted in Dodo" downgrade) while leaving the
+      // cron-only backoff pair alone.
+      const row = await t.run((ctx) => ctx.db.get(subId));
+      expect(row?.reconcileNotFoundCount).toBe(1);
+      expect(row?.reconcileFailureCount).toBeUndefined();
+      expect(row?.lastReconcileAttemptAt).toBeUndefined();
+      errorSpy.mockRestore();
+    });
+
     test.each(["failed", "lapsed"] as const)(
       "progresses past a stronger subscription in the %s cooldown",
       async (verificationState) => {

--- a/convex/__tests__/internal-entitlements.test.ts
+++ b/convex/__tests__/internal-entitlements.test.ts
@@ -138,7 +138,7 @@ describe("/api/internal-entitlements HTTP action", () => {
     expect(await res.json()).toMatchObject({
       planKey: "free",
       billingStatus: "renewal_verification_pending",
-      retryAfterSeconds: 15,
+      retryAfterSeconds: 3,
     });
   });
 

--- a/convex/__tests__/internal-entitlements.test.ts
+++ b/convex/__tests__/internal-entitlements.test.ts
@@ -1,11 +1,16 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import schema from "../schema";
+import { internal } from "../_generated/api";
+import { PRODUCT_CATALOG } from "../config/productCatalog";
+import { getFeaturesForPlan } from "../lib/entitlements";
 
 const modules = import.meta.glob("../**/*.ts");
 
 const CONVEX_SECRET = "test-convex-secret-internal-entitlements-46chXX";
 const USER_A = "user-test-entitlements";
+const NOW = 1_750_000_000_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 function validHeaders(): Record<string, string> {
   return {
@@ -18,11 +23,14 @@ describe("/api/internal-entitlements HTTP action", () => {
   let originalSecret: string | undefined;
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
     originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
     process.env.CONVEX_SERVER_SHARED_SECRET = CONVEX_SECRET;
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalSecret === undefined) {
       delete process.env.CONVEX_SERVER_SHARED_SECRET;
     } else {
@@ -41,6 +49,83 @@ describe("/api/internal-entitlements HTTP action", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { planKey: string };
     expect(body.planKey).toBe("free");
+  });
+
+  test("recently stale verification lease surfaces renewal_verification_pending", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: USER_A,
+        dodoSubscriptionId: "sub_http_pending",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd: NOW - DAY_MS,
+        rawPayload: {},
+        updatedAt: NOW - DAY_MS,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: USER_A,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+    await t.mutation(
+      internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+      { userId: USER_A, now: NOW },
+    );
+
+    const res = await t.fetch("/api/internal-entitlements", {
+      method: "POST",
+      headers: validHeaders(),
+      body: JSON.stringify({ userId: USER_A }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      planKey: "free",
+      billingStatus: "renewal_verification_pending",
+      retryAfterSeconds: 15,
+    });
+  });
+
+  test("billing history without a verification candidate surfaces subscription_lapsed", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: USER_A,
+        dodoSubscriptionId: "sub_http_lapsed",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "expired",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd: NOW - DAY_MS,
+        rawPayload: {},
+        updatedAt: NOW - DAY_MS,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: USER_A,
+        planKey: "free",
+        features: getFeaturesForPlan("free"),
+        validUntil: NOW - 1,
+        updatedAt: NOW - 1,
+      });
+    });
+
+    const res = await t.fetch("/api/internal-entitlements", {
+      method: "POST",
+      headers: validHeaders(),
+      body: JSON.stringify({ userId: USER_A }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      planKey: "free",
+      billingStatus: "subscription_lapsed",
+    });
   });
 
   test("missing secret header → 401 UNAUTHORIZED", async () => {

--- a/convex/__tests__/internal-entitlements.test.ts
+++ b/convex/__tests__/internal-entitlements.test.ts
@@ -2,8 +2,10 @@ import { convexTest } from "convex-test";
 import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import schema from "../schema";
 import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
 import { PRODUCT_CATALOG } from "../config/productCatalog";
 import { getFeaturesForPlan } from "../lib/entitlements";
+import { internalEntitlementsHttpHandler } from "../http";
 
 const modules = import.meta.glob("../**/*.ts");
 
@@ -47,8 +49,56 @@ describe("/api/internal-entitlements HTTP action", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { planKey: string };
+    const body = (await res.json()) as {
+      planKey: string;
+      renewalVerificationFreshness?: {
+        status: string;
+        checkedAt: number;
+      };
+    };
     expect(body.planKey).toBe("free");
+    expect(body.renewalVerificationFreshness).toEqual({
+      status: "not_applicable",
+      checkedAt: NOW,
+    });
+  });
+
+  test("a concurrent paid refresh wins over a non-active verification result", async () => {
+    const free = {
+      planKey: "free",
+      features: getFeaturesForPlan("free"),
+      validUntil: 0,
+    };
+    const active = {
+      planKey: "pro_monthly",
+      features: getFeaturesForPlan("pro_monthly"),
+      validUntil: NOW + 30 * DAY_MS,
+    };
+    const runQuery = vi.fn()
+      .mockResolvedValueOnce(free)
+      .mockResolvedValueOnce(active);
+    const runAction = vi.fn().mockResolvedValue({
+      status: "renewal_verification_failed",
+      retryAfterSeconds: 12,
+    });
+
+    const res = await internalEntitlementsHttpHandler(
+      { runQuery, runAction } as unknown as ActionCtx,
+      new Request("https://example.convex.site/api/internal-entitlements", {
+        method: "POST",
+        headers: validHeaders(),
+        body: JSON.stringify({ userId: USER_A }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject(active);
+    expect(body).not.toHaveProperty("billingStatus");
+    expect(body).not.toHaveProperty("retryAfterSeconds");
+    expect(body).not.toHaveProperty("renewalVerificationFreshness");
+    expect(runQuery).toHaveBeenCalledTimes(2);
+    expect(runAction).toHaveBeenCalledTimes(1);
   });
 
   test("recently stale verification lease surfaces renewal_verification_pending", async () => {

--- a/convex/__tests__/internal-entitlements.test.ts
+++ b/convex/__tests__/internal-entitlements.test.ts
@@ -97,7 +97,9 @@ describe("/api/internal-entitlements HTTP action", () => {
     expect(body).not.toHaveProperty("billingStatus");
     expect(body).not.toHaveProperty("retryAfterSeconds");
     expect(body).not.toHaveProperty("renewalVerificationFreshness");
-    expect(runQuery).toHaveBeenCalledTimes(2);
+    // The third query resolves any current lower-plan fallback and checks
+    // whether the still-stale plan could expand coverage.
+    expect(runQuery).toHaveBeenCalledTimes(3);
     expect(runAction).toHaveBeenCalledTimes(1);
   });
 
@@ -141,6 +143,70 @@ describe("/api/internal-entitlements HTTP action", () => {
       retryAfterSeconds: 3,
     });
   });
+
+  test.each([
+    ["pending", "renewal_verification_pending", 3],
+    ["failed", "renewal_verification_failed", 60],
+  ] as const)(
+    "preserves current Pro fallback while stronger Enterprise verification is %s",
+    async (verificationState, billingStatus, retryAfterSeconds) => {
+      const t = convexTest(schema, modules);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("subscriptions", {
+          userId: USER_A,
+          dodoSubscriptionId: `sub_http_enterprise_${verificationState}`,
+          dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+          planKey: "enterprise",
+          status: "active",
+          currentPeriodStart: NOW - 31 * DAY_MS,
+          currentPeriodEnd: NOW - DAY_MS,
+          renewalVerificationState: verificationState,
+          renewalVerificationAttemptAt: NOW,
+          rawPayload: {},
+          updatedAt: NOW - DAY_MS,
+        });
+        await ctx.db.insert("subscriptions", {
+          userId: USER_A,
+          dodoSubscriptionId: `sub_http_pro_${verificationState}`,
+          dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          planKey: "pro_monthly",
+          status: "active",
+          currentPeriodStart: NOW - DAY_MS,
+          currentPeriodEnd: NOW + 30 * DAY_MS,
+          rawPayload: {},
+          updatedAt: NOW,
+        });
+        // Reproduce the pre-fix stored state: the one-row materialization still
+        // points at the stronger subscription whose paid period has elapsed.
+        await ctx.db.insert("entitlements", {
+          userId: USER_A,
+          planKey: "enterprise",
+          features: getFeaturesForPlan("enterprise"),
+          validUntil: NOW - DAY_MS,
+          updatedAt: NOW - DAY_MS,
+        });
+      });
+
+      const res = await t.fetch("/api/internal-entitlements", {
+        method: "POST",
+        headers: validHeaders(),
+        body: JSON.stringify({ userId: USER_A }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        planKey: "pro_monthly",
+        features: {
+          tier: 1,
+          mcpAccess: true,
+          apiAccess: false,
+        },
+        validUntil: NOW + 30 * DAY_MS,
+        billingStatus,
+        retryAfterSeconds,
+      });
+    },
+  );
 
   test("billing history without a verification candidate surfaces subscription_lapsed", async () => {
     const t = convexTest(schema, modules);

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -159,11 +159,43 @@ http.route({
       });
     }
 
-    const result = await ctx.runQuery(
+    let result = await ctx.runQuery(
       internal.entitlements.getEntitlementsByUserId,
       { userId: body.userId },
     );
-    return new Response(JSON.stringify(result), {
+    let billingStatus:
+      | "subscription_lapsed"
+      | "renewal_verification_pending"
+      | "renewal_verification_failed"
+      | undefined;
+    let retryAfterSeconds: number | undefined;
+
+    // Expired stored entitlements are deliberately returned as free-tier
+    // defaults by the query. Before the gateway turns that into a hard denial,
+    // give a recently-stale active subscription one bounded provider re-check.
+    if (result.features.tier === 0) {
+      const verification = await ctx.runAction(
+        internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
+        { userId: body.userId },
+      );
+      if (verification.status === "active") {
+        result = await ctx.runQuery(
+          internal.entitlements.getEntitlementsByUserId,
+          { userId: body.userId },
+        );
+      } else if (verification.status !== "not_applicable") {
+        billingStatus = verification.status;
+        if ("retryAfterSeconds" in verification) {
+          retryAfterSeconds = verification.retryAfterSeconds;
+        }
+      }
+    }
+
+    return new Response(JSON.stringify({
+      ...result,
+      ...(billingStatus ? { billingStatus } : {}),
+      ...(retryAfterSeconds != null ? { retryAfterSeconds } : {}),
+    }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,5 @@
 import { anyApi, httpRouter } from "convex/server";
-import { httpAction } from "./_generated/server";
+import { httpAction, type ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { webhookHandler } from "./payments/webhookHandlers";
 import { resendWebhookHandler } from "./resendWebhookHandler";
@@ -125,12 +125,10 @@ function setRateLimitResponseHeaders(headers: Headers, limit: number, reset: num
   headers.set("Retry-After", String(retryAfter));
 }
 
-const http = httpRouter();
-
-http.route({
-  path: "/api/internal-entitlements",
-  method: "POST",
-  handler: httpAction(async (ctx, request) => {
+export async function internalEntitlementsHttpHandler(
+  ctx: ActionCtx,
+  request: Request,
+): Promise<Response> {
     const providedSecret = request.headers.get("x-convex-shared-secret") ?? "";
     const expectedSecret = process.env.CONVEX_SERVER_SHARED_SECRET ?? "";
     if (!expectedSecret || !(await timingSafeEqualStrings(providedSecret, expectedSecret))) {
@@ -169,6 +167,9 @@ http.route({
       | "renewal_verification_failed"
       | undefined;
     let retryAfterSeconds: number | undefined;
+    let renewalVerificationFreshness:
+      | { status: "not_applicable"; checkedAt: number }
+      | undefined;
 
     // Expired stored entitlements are deliberately returned as free-tier
     // defaults by the query. Before the gateway turns that into a hard denial,
@@ -178,15 +179,24 @@ http.route({
         internal.payments.billing.verifyRecentlyStaleSubscriptionOnDemand,
         { userId: body.userId },
       );
-      if (verification.status === "active") {
+      if (verification.status === "not_applicable") {
+        renewalVerificationFreshness = {
+          status: "not_applicable",
+          checkedAt: Date.now(),
+        };
+      } else {
+        // The provider action and a webhook can interleave. Always re-read the
+        // source of truth before attaching a denial marker so a concurrent
+        // renewal wins over a stale action result.
         result = await ctx.runQuery(
           internal.entitlements.getEntitlementsByUserId,
           { userId: body.userId },
         );
-      } else if (verification.status !== "not_applicable") {
-        billingStatus = verification.status;
-        if ("retryAfterSeconds" in verification) {
-          retryAfterSeconds = verification.retryAfterSeconds;
+        if (result.features.tier === 0 && verification.status !== "active") {
+          billingStatus = verification.status;
+          if ("retryAfterSeconds" in verification) {
+            retryAfterSeconds = verification.retryAfterSeconds;
+          }
         }
       }
     }
@@ -195,11 +205,19 @@ http.route({
       ...result,
       ...(billingStatus ? { billingStatus } : {}),
       ...(retryAfterSeconds != null ? { retryAfterSeconds } : {}),
+      ...(renewalVerificationFreshness ? { renewalVerificationFreshness } : {}),
     }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
-  }),
+}
+
+const http = httpRouter();
+
+http.route({
+  path: "/api/internal-entitlements",
+  method: "POST",
+  handler: httpAction(internalEntitlementsHttpHandler),
 });
 
 http.route({

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -192,7 +192,34 @@ export async function internalEntitlementsHttpHandler(
           internal.entitlements.getEntitlementsByUserId,
           { userId: body.userId },
         );
-        if (result.features.tier === 0 && verification.status !== "active") {
+        // A stale materialized entitlement can point at the stronger row under
+        // verification even while another lower-plan subscription is still
+        // current. Preserve that known-good coverage in this response; the
+        // billing marker remains attached so callers deny only capabilities
+        // the fallback plan does not authorize.
+        const fallbackState = await ctx.runQuery(
+          internal.payments.billing.getOnDemandRenewalFallbackState,
+          { userId: body.userId, now: Date.now() },
+        );
+        if (
+          result.features.tier === 0 &&
+          fallbackState?.currentEntitlement
+        ) {
+          result = fallbackState.currentEntitlement;
+        }
+        const staleFeatures = fallbackState?.strongestRecentlyStaleFeatures;
+        const verificationCouldExpandCoverage = !!staleFeatures && (
+          staleFeatures.tier > result.features.tier ||
+          (staleFeatures.apiAccess && !result.features.apiAccess) ||
+          (staleFeatures.mcpAccess && !result.features.mcpAccess)
+        );
+        if (
+          verification.status !== "active" &&
+          (
+            result.features.tier === 0 ||
+            verificationCouldExpandCoverage
+          )
+        ) {
           billingStatus = verification.status;
           if ("retryAfterSeconds" in verification) {
             retryAfterSeconds = verification.retryAfterSeconds;

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -667,21 +667,20 @@ export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
     now: v.number(),
   },
   handler: async (ctx, args): Promise<OnDemandRenewalClaim> => {
+    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
     const subscriptions = await ctx.db
       .query("subscriptions")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .withIndex("by_userId_status_currentPeriodEnd", (q) =>
+        q
+          .eq("userId", args.userId)
+          .eq("status", "active")
+          .gte("currentPeriodEnd", recentCutoff)
+          .lt("currentPeriodEnd", args.now),
+      )
       .collect();
 
-    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
     let candidate: (typeof subscriptions)[number] | null = null;
     for (const subscription of subscriptions) {
-      if (
-        subscription.status !== "active" ||
-        subscription.currentPeriodEnd >= args.now ||
-        subscription.currentPeriodEnd < recentCutoff
-      ) {
-        continue;
-      }
       if (
         candidate === null ||
         compareEntitlementPlans(
@@ -697,7 +696,11 @@ export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
       // A caller with billing history but no recently-stale active row has no
       // uncertain provider state to verify on the request path. Preserve a
       // definitive lapse signal for corrected inactive rows and old churn.
-      return subscriptions.length > 0 ? { kind: "lapsed" } : { kind: "not_applicable" };
+      const hasBillingHistory = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+        .first();
+      return hasBillingHistory ? { kind: "lapsed" } : { kind: "not_applicable" };
     }
 
     const attemptedAt = candidate.renewalVerificationAttemptAt;

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -10,7 +10,7 @@
  */
 
 import { ConvexError, v } from "convex/values";
-import { action, mutation, query, internalAction, internalMutation, internalQuery, type ActionCtx } from "../_generated/server";
+import { action, mutation, query, internalAction, internalMutation, internalQuery, type ActionCtx, type QueryCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { DodoPayments } from "dodopayments";
 import type { Subscription as DodoSubscription } from "dodopayments/resources/subscriptions";
@@ -680,6 +680,24 @@ function retryAfterSeconds(windowMs: number, elapsedMs: number): number {
   return Math.max(1, Math.ceil((windowMs - elapsedMs) / 1000));
 }
 
+function queryRecentlyStaleActiveSubscriptions(
+  ctx: QueryCtx,
+  userId: string,
+  now: number,
+) {
+  const recentCutoff = now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
+  return ctx.db
+    .query("subscriptions")
+    .withIndex("by_userId_status_currentPeriodEnd", (q) =>
+      q
+        .eq("userId", userId)
+        .eq("status", "active")
+        .gte("currentPeriodEnd", recentCutoff)
+        .lt("currentPeriodEnd", now),
+    )
+    .collect();
+}
+
 /**
  * Classifies all recently-stale rows for one user without starting provider
  * work. A live pending lease is user-scoped: claiming a different row while
@@ -760,17 +778,11 @@ export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
     now: v.number(),
   },
   handler: async (ctx, args): Promise<OnDemandRenewalClaim> => {
-    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
-    const subscriptions = await ctx.db
-      .query("subscriptions")
-      .withIndex("by_userId_status_currentPeriodEnd", (q) =>
-        q
-          .eq("userId", args.userId)
-          .eq("status", "active")
-          .gte("currentPeriodEnd", recentCutoff)
-          .lt("currentPeriodEnd", args.now),
-      )
-      .collect();
+    const subscriptions = await queryRecentlyStaleActiveSubscriptions(
+      ctx,
+      args.userId,
+      args.now,
+    );
 
     if (subscriptions.length === 0) {
       // A caller with billing history but no recently-stale active row has no
@@ -833,17 +845,11 @@ export const getOnDemandRenewalResolution = internalQuery({
       return { kind: "active" };
     }
 
-    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
-    const subscriptions = await ctx.db
-      .query("subscriptions")
-      .withIndex("by_userId_status_currentPeriodEnd", (q) =>
-        q
-          .eq("userId", args.userId)
-          .eq("status", "active")
-          .gte("currentPeriodEnd", recentCutoff)
-          .lt("currentPeriodEnd", args.now),
-      )
-      .collect();
+    const subscriptions = await queryRecentlyStaleActiveSubscriptions(
+      ctx,
+      args.userId,
+      args.now,
+    );
 
     if (subscriptions.length === 0) {
       return { kind: "lapsed" };

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -229,15 +229,21 @@ type StaleActiveSubscriptionsPage = {
   isDone: boolean;
 };
 
+// Shared cooldown vocabulary for the on-demand renewal state machines below:
+// a live pending lease, a failed-verification cooldown, or an affirmative
+// lapse. Composed (not repeated) so a shape change propagates to every union.
+type RenewalCooldownOutcome =
+  | { kind: "pending"; retryAfterSeconds: number }
+  | { kind: "failed"; retryAfterSeconds: number }
+  | { kind: "lapsed" };
+
 type OnDemandRenewalClaim =
   | {
       kind: "claimed";
       claimedAt: number;
       subscription: StaleActiveSubscriptionForRenewalReconciliation;
     }
-  | { kind: "pending"; retryAfterSeconds: number }
-  | { kind: "failed"; retryAfterSeconds: number }
-  | { kind: "lapsed" }
+  | RenewalCooldownOutcome
   | { kind: "not_applicable" };
 
 type OnDemandRenewalCandidate = {
@@ -250,16 +256,12 @@ type OnDemandRenewalCandidate = {
 
 type OnDemandRenewalCandidateSelection<T extends OnDemandRenewalCandidate> =
   | { kind: "candidate"; candidate: T }
-  | { kind: "pending"; retryAfterSeconds: number }
-  | { kind: "failed"; retryAfterSeconds: number }
-  | { kind: "lapsed" };
+  | RenewalCooldownOutcome;
 
 type OnDemandRenewalResolution =
   | { kind: "active" }
   | { kind: "unresolved" }
-  | { kind: "pending"; retryAfterSeconds: number }
-  | { kind: "failed"; retryAfterSeconds: number }
-  | { kind: "lapsed" };
+  | RenewalCooldownOutcome;
 
 type OnDemandRenewalResult =
   | { status: "active" }
@@ -1459,49 +1461,40 @@ export const verifyRecentlyStaleSubscriptionOnDemand = internalAction({
       return onDemandRenewalFailureResult();
     }
 
+    // Every non-active resolution finalizes the claimed row as "lapsed"
+    // (definitively non-covering) and differs only in what the caller is told.
+    // Single-copy so finalize-failure handling cannot drift between cases.
+    const finalizeLapsedAndReturn = async (
+      onSuccess: OnDemandRenewalResult,
+    ): Promise<OnDemandRenewalResult> => {
+      const finalized = await safeFinalize("lapsed");
+      if (!finalized) await bestEffortFinalizeFailed();
+      return finalized ? onSuccess : onDemandRenewalFailureResult();
+    };
+
     switch (resolution.kind) {
       case "active":
         // A concurrent webhook or another subscription proves coverage. As
         // above, finalization is cleanup and cannot revoke that confirmation.
         await safeFinalize("active");
         return { status: "active" };
-      case "pending": {
-        const finalized = await safeFinalize("lapsed");
-        if (!finalized) await bestEffortFinalizeFailed();
-        return finalized
-          ? {
-              status: "renewal_verification_pending",
-              retryAfterSeconds: resolution.retryAfterSeconds,
-            }
-          : onDemandRenewalFailureResult();
-      }
-      case "unresolved": {
-        const finalized = await safeFinalize("lapsed");
-        if (!finalized) await bestEffortFinalizeFailed();
-        return finalized
-          ? {
-              status: "renewal_verification_pending",
-              retryAfterSeconds: ON_DEMAND_RENEWAL_PROGRESS_RETRY_SECONDS,
-            }
-          : onDemandRenewalFailureResult();
-      }
-      case "failed": {
-        const finalized = await safeFinalize("lapsed");
-        if (!finalized) await bestEffortFinalizeFailed();
-        return finalized
-          ? {
-              status: "renewal_verification_failed",
-              retryAfterSeconds: resolution.retryAfterSeconds,
-            }
-          : onDemandRenewalFailureResult();
-      }
-      case "lapsed": {
-        const finalized = await safeFinalize("lapsed");
-        if (!finalized) await bestEffortFinalizeFailed();
-        return finalized
-          ? { status: "subscription_lapsed" }
-          : onDemandRenewalFailureResult();
-      }
+      case "pending":
+        return finalizeLapsedAndReturn({
+          status: "renewal_verification_pending",
+          retryAfterSeconds: resolution.retryAfterSeconds,
+        });
+      case "unresolved":
+        return finalizeLapsedAndReturn({
+          status: "renewal_verification_pending",
+          retryAfterSeconds: ON_DEMAND_RENEWAL_PROGRESS_RETRY_SECONDS,
+        });
+      case "failed":
+        return finalizeLapsedAndReturn({
+          status: "renewal_verification_failed",
+          retryAfterSeconds: resolution.retryAfterSeconds,
+        });
+      case "lapsed":
+        return finalizeLapsedAndReturn({ status: "subscription_lapsed" });
     }
   },
 });

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -104,6 +104,24 @@ const DODO_RENEWAL_RECONCILIATION_BACKOFF_FIRST_MS = 6 * 60 * 60 * 1000;
 const DODO_RENEWAL_RECONCILIATION_BACKOFF_BASE_MS = 2 * 24 * 60 * 60 * 1000;
 const DODO_RENEWAL_RECONCILIATION_BACKOFF_MAX_MS = 30 * 24 * 60 * 60 * 1000;
 
+// Request-path renewal verification (#4770). Only subscriptions whose paid
+// period ended in the last three days are eligible: this closes the daily-cron
+// denial window without turning every long-lapsed request into a Dodo lookup.
+const ON_DEMAND_RENEWAL_RECENT_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+// The gateway gives /api/internal-entitlements three seconds. Leave one second
+// for Convex/query/mutation overhead and disable SDK retries below.
+const ON_DEMAND_RENEWAL_TIMEOUT_MS = 2_000;
+// A durable lease coalesces simultaneous route/API-key hits across action
+// instances. It exceeds the provider timeout so a second request observes
+// `pending` while the first owns the lookup.
+const ON_DEMAND_RENEWAL_LEASE_MS = 15_000;
+// Transient failures are retryable, but no more than once per minute per
+// subscription. The response carries the remaining cooldown to callers.
+const ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS = 60_000;
+// If Dodo is reachable but still reports no covering period, avoid re-querying
+// on every route hit. Organic webhooks clear this state immediately.
+const ON_DEMAND_RENEWAL_LAPSED_COOLDOWN_MS = 5 * 60_000;
+
 function reconcileBackoffMs(failureCount: number): number {
   if (failureCount <= 0) return 0;
   if (failureCount === 1) return DODO_RENEWAL_RECONCILIATION_BACKOFF_FIRST_MS;
@@ -200,6 +218,26 @@ type StaleActiveSubscriptionsPage = {
   continueCursor: string;
   isDone: boolean;
 };
+
+type OnDemandRenewalClaim =
+  | {
+      kind: "claimed";
+      claimedAt: number;
+      subscription: StaleActiveSubscriptionForRenewalReconciliation;
+    }
+  | { kind: "pending"; retryAfterSeconds: number }
+  | { kind: "failed"; retryAfterSeconds: number }
+  | { kind: "lapsed" }
+  | { kind: "not_applicable" };
+
+type OnDemandRenewalResult =
+  | { status: "active" }
+  | { status: "subscription_lapsed" }
+  | {
+      status: "renewal_verification_pending" | "renewal_verification_failed";
+      retryAfterSeconds: number;
+    }
+  | { status: "not_applicable" };
 
 type ReconciliationSkipReason =
   | "local_missing"
@@ -613,6 +651,132 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
   },
 });
 
+function retryAfterSeconds(windowMs: number, elapsedMs: number): number {
+  return Math.max(1, Math.ceil((windowMs - elapsedMs) / 1000));
+}
+
+/**
+ * Atomically claims the strongest recently-stale active subscription for a
+ * user. Convex mutations serialize conflicting writes, so concurrent premium
+ * requests see one `claimed` result and the rest see the durable `pending`
+ * lease instead of each starting a Dodo request.
+ */
+export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
+  args: {
+    userId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, args): Promise<OnDemandRenewalClaim> => {
+    const subscriptions = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .collect();
+
+    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
+    let candidate: (typeof subscriptions)[number] | null = null;
+    for (const subscription of subscriptions) {
+      if (
+        subscription.status !== "active" ||
+        subscription.currentPeriodEnd >= args.now ||
+        subscription.currentPeriodEnd < recentCutoff
+      ) {
+        continue;
+      }
+      if (
+        candidate === null ||
+        compareEntitlementPlans(
+          { planKey: subscription.planKey, validUntil: subscription.currentPeriodEnd },
+          { planKey: candidate.planKey, validUntil: candidate.currentPeriodEnd },
+        ) > 0
+      ) {
+        candidate = subscription;
+      }
+    }
+
+    if (!candidate) {
+      // A caller with billing history but no recently-stale active row has no
+      // uncertain provider state to verify on the request path. Preserve a
+      // definitive lapse signal for corrected inactive rows and old churn.
+      return subscriptions.length > 0 ? { kind: "lapsed" } : { kind: "not_applicable" };
+    }
+
+    const attemptedAt = candidate.renewalVerificationAttemptAt;
+    if (attemptedAt != null) {
+      const elapsed = Math.max(0, args.now - attemptedAt);
+      if (
+        candidate.renewalVerificationState === "pending" &&
+        elapsed < ON_DEMAND_RENEWAL_LEASE_MS
+      ) {
+        return {
+          kind: "pending",
+          retryAfterSeconds: retryAfterSeconds(ON_DEMAND_RENEWAL_LEASE_MS, elapsed),
+        };
+      }
+      if (
+        candidate.renewalVerificationState === "failed" &&
+        elapsed < ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS
+      ) {
+        return {
+          kind: "failed",
+          retryAfterSeconds: retryAfterSeconds(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS, elapsed),
+        };
+      }
+      if (
+        candidate.renewalVerificationState === "lapsed" &&
+        elapsed < ON_DEMAND_RENEWAL_LAPSED_COOLDOWN_MS
+      ) {
+        return { kind: "lapsed" };
+      }
+    }
+
+    await ctx.db.patch(candidate._id, {
+      renewalVerificationState: "pending",
+      renewalVerificationAttemptAt: args.now,
+    });
+    return {
+      kind: "claimed",
+      claimedAt: args.now,
+      subscription: {
+        _id: candidate._id,
+        userId: candidate.userId,
+        dodoSubscriptionId: candidate.dodoSubscriptionId,
+        currentPeriodEnd: candidate.currentPeriodEnd,
+        lastReconcileAttemptAt: candidate.lastReconcileAttemptAt,
+        reconcileFailureCount: candidate.reconcileFailureCount,
+        reconcileNotFoundCount: candidate.reconcileNotFoundCount,
+      },
+    };
+  },
+});
+
+export const finalizeRecentlyStaleSubscriptionVerification = internalMutation({
+  args: {
+    subscriptionId: v.id("subscriptions"),
+    claimedAt: v.number(),
+    status: v.union(
+      v.literal("active"),
+      v.literal("failed"),
+      v.literal("lapsed"),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.subscriptionId);
+    if (
+      !existing ||
+      existing.renewalVerificationState !== "pending" ||
+      existing.renewalVerificationAttemptAt !== args.claimedAt
+    ) {
+      return;
+    }
+    await ctx.db.patch(args.subscriptionId, args.status === "active"
+      ? {
+          renewalVerificationState: undefined,
+          renewalVerificationAttemptAt: undefined,
+        }
+      : { renewalVerificationState: args.status });
+  },
+});
+
 /**
  * Marks a reconcile attempt on a stale-active subscription row: bumps
  * `reconcileFailureCount` and stamps `lastReconcileAttemptAt` so the
@@ -767,6 +931,8 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
             lastReconcileAttemptAt: undefined,
             reconcileFailureCount: undefined,
             reconcileNotFoundCount: undefined,
+            renewalVerificationState: undefined,
+            renewalVerificationAttemptAt: undefined,
           }),
       ...(args.remote.status === "cancelled"
         ? { cancelledAt: args.remote.cancelledAt ?? existing.cancelledAt ?? args.observedAt }
@@ -827,6 +993,8 @@ export const expireMissingDodoSubscription = internalMutation({
       lastReconcileAttemptAt: undefined,
       reconcileFailureCount: undefined,
       reconcileNotFoundCount: undefined,
+      renewalVerificationState: undefined,
+      renewalVerificationAttemptAt: undefined,
     });
     await recomputeEntitlementFromAllSubs(ctx, existing.userId, args.observedAt);
     return { kind: "expired" };
@@ -835,7 +1003,10 @@ export const expireMissingDodoSubscription = internalMutation({
 
 type StaleRowOutcome =
   | { kind: "reconciled" }
-  | { kind: "skipped" }
+  | {
+      kind: "skipped";
+      reason: ReconciliationSkipReason | "remote_status_unusable";
+    }
   | { kind: "failed"; error: string }
   // Confirmed terminal not-found (definitive 404 past the confirmation
   // threshold). The row is NOT downgraded here — the action loop decides,
@@ -915,7 +1086,7 @@ async function reconcileOneStaleRow(
       );
       // Row is still stale-active — back it off (not a 404, resets the streak).
       await safeMarkReconcileAttempt(ctx, sub._id, now, false);
-      return { kind: "skipped" };
+      return { kind: "skipped", reason: "remote_status_unusable" };
     }
 
     const result = (await ctx.runMutation(
@@ -928,7 +1099,9 @@ async function reconcileOneStaleRow(
       },
     )) as ReconciliationMutationResult;
     // `apply` records its own backoff for the still-stale skip reasons.
-    return result.kind === "reconciled" ? { kind: "reconciled" } : { kind: "skipped" };
+    return result.kind === "reconciled"
+      ? { kind: "reconciled" }
+      : { kind: "skipped", reason: result.reason };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const notFound = isDefinitiveDodoNotFound(err);
@@ -957,6 +1130,139 @@ async function reconcileOneStaleRow(
     return { kind: "failed", error: message };
   }
 }
+
+async function finalizeOnDemandRenewalVerification(
+  ctx: Pick<ActionCtx, "runMutation">,
+  claim: Extract<OnDemandRenewalClaim, { kind: "claimed" }>,
+  status: "active" | "failed" | "lapsed",
+): Promise<void> {
+  await ctx.runMutation(
+    internal.payments.billing.finalizeRecentlyStaleSubscriptionVerification,
+    {
+      subscriptionId: claim.subscription._id,
+      claimedAt: claim.claimedAt,
+      status,
+    },
+  );
+}
+
+/**
+ * Bounded request-path rescue for a recently expired local entitlement.
+ * Reuses the cron's provider normalization + race-safe apply mutation, while a
+ * durable claim prevents concurrent premium requests from fanning out to Dodo.
+ */
+export const verifyRecentlyStaleSubscriptionOnDemand = internalAction({
+  args: {
+    userId: v.string(),
+    now: v.optional(v.number()),
+    remoteSubscriptionsForTest: v.optional(
+      v.array(dodoReconciliationRemoteSubscriptionValidator),
+    ),
+    errorInjectionForTest: v.optional(
+      v.record(
+        v.string(),
+        v.union(v.literal("not_found"), v.literal("server_error")),
+      ),
+    ),
+  },
+  handler: async (ctx, args): Promise<OnDemandRenewalResult> => {
+    const usesTestInjection =
+      args.remoteSubscriptionsForTest !== undefined ||
+      args.errorInjectionForTest !== undefined;
+    if (usesTestInjection && process.env.NODE_ENV !== "test") {
+      throw new Error(
+        "[billing/on-demand-renewal] test injection args are only allowed under test",
+      );
+    }
+
+    const now = args.now ?? Date.now();
+    const claim = (await ctx.runMutation(
+      internal.payments.billing.claimRecentlyStaleSubscriptionForVerification,
+      { userId: args.userId, now },
+    )) as OnDemandRenewalClaim;
+
+    switch (claim.kind) {
+      case "pending":
+        return {
+          status: "renewal_verification_pending",
+          retryAfterSeconds: claim.retryAfterSeconds,
+        };
+      case "failed":
+        return {
+          status: "renewal_verification_failed",
+          retryAfterSeconds: claim.retryAfterSeconds,
+        };
+      case "lapsed":
+        return { status: "subscription_lapsed" };
+      case "not_applicable":
+        return { status: "not_applicable" };
+      case "claimed":
+        break;
+    }
+
+    const remoteById = new Map(
+      (args.remoteSubscriptionsForTest ?? []).map((remote) => [
+        remote.subscription_id,
+        remote,
+      ]),
+    );
+    const errorInjection = new Map<string, "not_found" | "server_error">(
+      Object.entries(args.errorInjectionForTest ?? {}),
+    );
+
+    let outcome: StaleRowOutcome;
+    try {
+      const client = usesTestInjection
+        ? null
+        : getDodoClient({ timeout: ON_DEMAND_RENEWAL_TIMEOUT_MS, maxRetries: 0 });
+      outcome = await reconcileOneStaleRow(ctx, claim.subscription, {
+        now,
+        useTestRemotes: usesTestInjection,
+        remoteById,
+        errorInjection,
+        client,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // sentry-coverage-ok: Convex auto-Sentry captures console.error. Do not
+      // include provider response bodies or secrets in this customer-path log.
+      console.error(
+        `[billing/on-demand-renewal] Failed before Dodo verification dodoSubscriptionId=${claim.subscription.dodoSubscriptionId} userId=${claim.subscription.userId}: ${message}`,
+      );
+      await finalizeOnDemandRenewalVerification(ctx, claim, "failed");
+      return {
+        status: "renewal_verification_failed",
+        retryAfterSeconds: Math.ceil(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS / 1000),
+      };
+    }
+
+    if (
+      outcome.kind === "failed" ||
+      outcome.kind === "terminal_not_found" ||
+      (outcome.kind === "skipped" &&
+        (outcome.reason === "remote_status_unusable" ||
+          outcome.reason === "local_updated_concurrently"))
+    ) {
+      await finalizeOnDemandRenewalVerification(ctx, claim, "failed");
+      return {
+        status: "renewal_verification_failed",
+        retryAfterSeconds: Math.ceil(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS / 1000),
+      };
+    }
+
+    const entitlement = await ctx.runQuery(
+      internal.entitlements.getEntitlementsByUserId,
+      { userId: args.userId },
+    );
+    if (entitlement.features.tier > 0 && entitlement.validUntil >= now) {
+      await finalizeOnDemandRenewalVerification(ctx, claim, "active");
+      return { status: "active" };
+    }
+
+    await finalizeOnDemandRenewalVerification(ctx, claim, "lapsed");
+    return { status: "subscription_lapsed" };
+  },
+});
 
 export const reconcileMissedDodoRenewals = internalAction({
   args: {

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -115,6 +115,12 @@ const ON_DEMAND_RENEWAL_TIMEOUT_MS = 2_000;
 // instances. It exceeds the provider timeout so a second request observes
 // `pending` while the first owns the lookup.
 const ON_DEMAND_RENEWAL_LEASE_MS = 15_000;
+// Concurrent waiters retry against the leader's EXPECTED completion (provider
+// timeout + Convex overhead), not the full lease: the lease is a crash-safety
+// bound, and quoting it as Retry-After made a waiting paid client sit out 15s
+// for a lookup that resolves in 2-3s. A stuck leader just means a few 1s polls
+// until the lease reopens.
+const ON_DEMAND_RENEWAL_EXPECTED_COMPLETION_MS = ON_DEMAND_RENEWAL_TIMEOUT_MS + 1_000;
 // Transient failures are retryable, but no more than once per minute per
 // subscription. The response carries the remaining cooldown to callers.
 const ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS = 60_000;
@@ -728,7 +734,10 @@ function selectOnDemandRenewalCandidate<T extends OnDemandRenewalCandidate>(
       if (elapsed < ON_DEMAND_RENEWAL_LEASE_MS) {
         return {
           kind: "pending",
-          retryAfterSeconds: retryAfterSeconds(ON_DEMAND_RENEWAL_LEASE_MS, elapsed),
+          retryAfterSeconds: retryAfterSeconds(
+            ON_DEMAND_RENEWAL_EXPECTED_COMPLETION_MS,
+            elapsed,
+          ),
         };
       }
     }

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -121,6 +121,10 @@ const ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS = 60_000;
 // If Dodo is reachable but still reports no covering period, avoid re-querying
 // on every route hit. Organic webhooks clear this state immediately.
 const ON_DEMAND_RENEWAL_LAPSED_COOLDOWN_MS = 5 * 60_000;
+// A request that affirmatively resolves one subscription as non-covering can
+// leave another recently-stale subscription to inspect. Tell the caller to
+// retry promptly without starting a second provider call in this invocation.
+const ON_DEMAND_RENEWAL_PROGRESS_RETRY_SECONDS = 1;
 
 function reconcileBackoffMs(failureCount: number): number {
   if (failureCount <= 0) return 0;
@@ -229,6 +233,27 @@ type OnDemandRenewalClaim =
   | { kind: "failed"; retryAfterSeconds: number }
   | { kind: "lapsed" }
   | { kind: "not_applicable" };
+
+type OnDemandRenewalCandidate = {
+  _id: Id<"subscriptions">;
+  planKey: string;
+  currentPeriodEnd: number;
+  renewalVerificationState?: "pending" | "failed" | "lapsed";
+  renewalVerificationAttemptAt?: number;
+};
+
+type OnDemandRenewalCandidateSelection<T extends OnDemandRenewalCandidate> =
+  | { kind: "candidate"; candidate: T }
+  | { kind: "pending"; retryAfterSeconds: number }
+  | { kind: "failed"; retryAfterSeconds: number }
+  | { kind: "lapsed" };
+
+type OnDemandRenewalResolution =
+  | { kind: "active" }
+  | { kind: "unresolved" }
+  | { kind: "pending"; retryAfterSeconds: number }
+  | { kind: "failed"; retryAfterSeconds: number }
+  | { kind: "lapsed" };
 
 type OnDemandRenewalResult =
   | { status: "active" }
@@ -656,6 +681,74 @@ function retryAfterSeconds(windowMs: number, elapsedMs: number): number {
 }
 
 /**
+ * Classifies all recently-stale rows for one user without starting provider
+ * work. A live pending lease is user-scoped: claiming a different row while
+ * it is in flight would fan concurrent requests out to Dodo. Failed and
+ * affirmatively-lapsed cooldowns, however, do not block progress to the next
+ * unresolved row.
+ */
+function selectOnDemandRenewalCandidate<T extends OnDemandRenewalCandidate>(
+  subscriptions: T[],
+  now: number,
+): OnDemandRenewalCandidateSelection<T> {
+  const ordered = [...subscriptions].sort((a, b) =>
+    compareEntitlementPlans(
+      { planKey: b.planKey, validUntil: b.currentPeriodEnd },
+      { planKey: a.planKey, validUntil: a.currentPeriodEnd },
+    ),
+  );
+
+  // A request already verifying any row may restore the user's entitlement.
+  // Coalesce at the user level before looking for another claimable row.
+  for (const subscription of ordered) {
+    const attemptedAt = subscription.renewalVerificationAttemptAt;
+    if (
+      attemptedAt != null &&
+      subscription.renewalVerificationState === "pending"
+    ) {
+      const elapsed = Math.max(0, now - attemptedAt);
+      if (elapsed < ON_DEMAND_RENEWAL_LEASE_MS) {
+        return {
+          kind: "pending",
+          retryAfterSeconds: retryAfterSeconds(ON_DEMAND_RENEWAL_LEASE_MS, elapsed),
+        };
+      }
+    }
+  }
+
+  let failedRetryAfterSeconds: number | null = null;
+  for (const subscription of ordered) {
+    const attemptedAt = subscription.renewalVerificationAttemptAt;
+    if (attemptedAt != null) {
+      const elapsed = Math.max(0, now - attemptedAt);
+      if (
+        subscription.renewalVerificationState === "failed" &&
+        elapsed < ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS
+      ) {
+        failedRetryAfterSeconds = Math.max(
+          failedRetryAfterSeconds ?? 0,
+          retryAfterSeconds(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS, elapsed),
+        );
+        continue;
+      }
+      if (
+        subscription.renewalVerificationState === "lapsed" &&
+        elapsed < ON_DEMAND_RENEWAL_LAPSED_COOLDOWN_MS
+      ) {
+        continue;
+      }
+    }
+
+    return { kind: "candidate", candidate: subscription };
+  }
+
+  if (failedRetryAfterSeconds != null) {
+    return { kind: "failed", retryAfterSeconds: failedRetryAfterSeconds };
+  }
+  return { kind: "lapsed" };
+}
+
+/**
  * Atomically claims the strongest recently-stale active subscription for a
  * user. Convex mutations serialize conflicting writes, so concurrent premium
  * requests see one `claimed` result and the rest see the durable `pending`
@@ -679,20 +772,7 @@ export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
       )
       .collect();
 
-    let candidate: (typeof subscriptions)[number] | null = null;
-    for (const subscription of subscriptions) {
-      if (
-        candidate === null ||
-        compareEntitlementPlans(
-          { planKey: subscription.planKey, validUntil: subscription.currentPeriodEnd },
-          { planKey: candidate.planKey, validUntil: candidate.currentPeriodEnd },
-        ) > 0
-      ) {
-        candidate = subscription;
-      }
-    }
-
-    if (!candidate) {
+    if (subscriptions.length === 0) {
       // A caller with billing history but no recently-stale active row has no
       // uncertain provider state to verify on the request path. Preserve a
       // definitive lapse signal for corrected inactive rows and old churn.
@@ -703,34 +783,11 @@ export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
       return hasBillingHistory ? { kind: "lapsed" } : { kind: "not_applicable" };
     }
 
-    const attemptedAt = candidate.renewalVerificationAttemptAt;
-    if (attemptedAt != null) {
-      const elapsed = Math.max(0, args.now - attemptedAt);
-      if (
-        candidate.renewalVerificationState === "pending" &&
-        elapsed < ON_DEMAND_RENEWAL_LEASE_MS
-      ) {
-        return {
-          kind: "pending",
-          retryAfterSeconds: retryAfterSeconds(ON_DEMAND_RENEWAL_LEASE_MS, elapsed),
-        };
-      }
-      if (
-        candidate.renewalVerificationState === "failed" &&
-        elapsed < ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS
-      ) {
-        return {
-          kind: "failed",
-          retryAfterSeconds: retryAfterSeconds(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS, elapsed),
-        };
-      }
-      if (
-        candidate.renewalVerificationState === "lapsed" &&
-        elapsed < ON_DEMAND_RENEWAL_LAPSED_COOLDOWN_MS
-      ) {
-        return { kind: "lapsed" };
-      }
+    const selection = selectOnDemandRenewalCandidate(subscriptions, args.now);
+    if (selection.kind !== "candidate") {
+      return selection;
     }
+    const candidate = selection.candidate;
 
     await ctx.db.patch(candidate._id, {
       renewalVerificationState: "pending",
@@ -749,6 +806,53 @@ export const claimRecentlyStaleSubscriptionForVerification = internalMutation({
         reconcileNotFoundCount: candidate.reconcileNotFoundCount,
       },
     };
+  },
+});
+
+/**
+ * Resolves the user-level state after one claimed row has been reconciled.
+ * This is deliberately read-only: if another row is unresolved, the current
+ * action returns a short retry instead of claiming it and accidentally
+ * stranding a lease without making the corresponding provider call.
+ */
+export const getOnDemandRenewalResolution = internalQuery({
+  args: {
+    userId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, args): Promise<OnDemandRenewalResolution> => {
+    const entitlement = await ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .first();
+    if (
+      entitlement &&
+      entitlement.features.tier > 0 &&
+      entitlement.validUntil >= args.now
+    ) {
+      return { kind: "active" };
+    }
+
+    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
+    const subscriptions = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId_status_currentPeriodEnd", (q) =>
+        q
+          .eq("userId", args.userId)
+          .eq("status", "active")
+          .gte("currentPeriodEnd", recentCutoff)
+          .lt("currentPeriodEnd", args.now),
+      )
+      .collect();
+
+    if (subscriptions.length === 0) {
+      return { kind: "lapsed" };
+    }
+
+    const selection = selectOnDemandRenewalCandidate(subscriptions, args.now);
+    return selection.kind === "candidate"
+      ? { kind: "unresolved" }
+      : selection;
   },
 });
 
@@ -1005,7 +1109,11 @@ export const expireMissingDodoSubscription = internalMutation({
 });
 
 type StaleRowOutcome =
-  | { kind: "reconciled" }
+  | {
+      kind: "reconciled";
+      status: SubscriptionStatus;
+      currentPeriodEnd: number;
+    }
   | {
       kind: "skipped";
       reason: ReconciliationSkipReason | "remote_status_unusable";
@@ -1103,7 +1211,11 @@ async function reconcileOneStaleRow(
     )) as ReconciliationMutationResult;
     // `apply` records its own backoff for the still-stale skip reasons.
     return result.kind === "reconciled"
-      ? { kind: "reconciled" }
+      ? {
+          kind: "reconciled",
+          status: result.status,
+          currentPeriodEnd: result.currentPeriodEnd,
+        }
       : { kind: "skipped", reason: result.reason };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1149,6 +1261,17 @@ async function finalizeOnDemandRenewalVerification(
   );
 }
 
+const ON_DEMAND_RENEWAL_FAILURE_RETRY_SECONDS = Math.ceil(
+  ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS / 1000,
+);
+
+function onDemandRenewalFailureResult(): OnDemandRenewalResult {
+  return {
+    status: "renewal_verification_failed",
+    retryAfterSeconds: ON_DEMAND_RENEWAL_FAILURE_RETRY_SECONDS,
+  };
+}
+
 /**
  * Bounded request-path rescue for a recently expired local entitlement.
  * Reuses the cron's provider normalization + race-safe apply mutation, while a
@@ -1167,11 +1290,18 @@ export const verifyRecentlyStaleSubscriptionOnDemand = internalAction({
         v.union(v.literal("not_found"), v.literal("server_error")),
       ),
     ),
+    convexFailureInjectionForTest: v.optional(
+      v.union(
+        v.literal("post_reconcile_query"),
+        v.literal("finalize"),
+      ),
+    ),
   },
   handler: async (ctx, args): Promise<OnDemandRenewalResult> => {
     const usesTestInjection =
       args.remoteSubscriptionsForTest !== undefined ||
-      args.errorInjectionForTest !== undefined;
+      args.errorInjectionForTest !== undefined ||
+      args.convexFailureInjectionForTest !== undefined;
     if (usesTestInjection && process.env.NODE_ENV !== "test") {
       throw new Error(
         "[billing/on-demand-renewal] test injection args are only allowed under test",
@@ -1212,6 +1342,35 @@ export const verifyRecentlyStaleSubscriptionOnDemand = internalAction({
     const errorInjection = new Map<string, "not_found" | "server_error">(
       Object.entries(args.errorInjectionForTest ?? {}),
     );
+    let injectFinalizeFailure = args.convexFailureInjectionForTest === "finalize";
+    const safeFinalize = async (
+      status: "active" | "failed" | "lapsed",
+    ): Promise<boolean> => {
+      try {
+        if (injectFinalizeFailure) {
+          injectFinalizeFailure = false;
+          throw new Error("simulated post-claim finalize failure");
+        }
+        await finalizeOnDemandRenewalVerification(ctx, claim, status);
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // sentry-coverage-ok: Convex auto-Sentry captures console.error. This
+        // action must return a typed retry response instead of letting a
+        // post-provider Convex failure become an opaque 500.
+        console.error(
+          `[billing/on-demand-renewal] Failed to finalize ${status} verification dodoSubscriptionId=${claim.subscription.dodoSubscriptionId} userId=${claim.subscription.userId}: ${message}`,
+        );
+        return false;
+      }
+    };
+    const bestEffortFinalizeFailed = async (): Promise<void> => {
+      if (!(await safeFinalize("failed"))) {
+        // One bounded retry contains a transient Convex failure without
+        // turning the request into an unbounded mutation loop.
+        await safeFinalize("failed");
+      }
+    };
 
     let outcome: StaleRowOutcome;
     try {
@@ -1232,38 +1391,103 @@ export const verifyRecentlyStaleSubscriptionOnDemand = internalAction({
       console.error(
         `[billing/on-demand-renewal] Failed before Dodo verification dodoSubscriptionId=${claim.subscription.dodoSubscriptionId} userId=${claim.subscription.userId}: ${message}`,
       );
-      await finalizeOnDemandRenewalVerification(ctx, claim, "failed");
-      return {
-        status: "renewal_verification_failed",
-        retryAfterSeconds: Math.ceil(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS / 1000),
-      };
+      await bestEffortFinalizeFailed();
+      return onDemandRenewalFailureResult();
     }
 
-    if (
-      outcome.kind === "failed" ||
-      outcome.kind === "terminal_not_found" ||
-      (outcome.kind === "skipped" &&
-        (outcome.reason === "remote_status_unusable" ||
-          outcome.reason === "local_updated_concurrently"))
-    ) {
-      await finalizeOnDemandRenewalVerification(ctx, claim, "failed");
-      return {
-        status: "renewal_verification_failed",
-        retryAfterSeconds: Math.ceil(ON_DEMAND_RENEWAL_FAILURE_COOLDOWN_MS / 1000),
-      };
-    }
-
-    const entitlement = await ctx.runQuery(
-      internal.entitlements.getEntitlementsByUserId,
-      { userId: args.userId },
-    );
-    if (entitlement.features.tier > 0 && entitlement.validUntil >= now) {
-      await finalizeOnDemandRenewalVerification(ctx, claim, "active");
+    const outcomeConfirmsCoveringPeriod =
+      outcome.kind === "reconciled" &&
+      outcome.status !== "expired" &&
+      outcome.currentPeriodEnd >= now;
+    if (outcomeConfirmsCoveringPeriod) {
+      // `applyDodoSubscriptionReconciliation` atomically wrote the covering
+      // subscription and recomputed entitlement before returning. Finalize is
+      // only lease cleanup here, so a cleanup failure must not hide confirmed
+      // paid access from this request.
+      await safeFinalize("active");
       return { status: "active" };
     }
 
-    await finalizeOnDemandRenewalVerification(ctx, claim, "lapsed");
-    return { status: "subscription_lapsed" };
+    const outcomeIsUncertain =
+      outcome.kind === "failed" ||
+      outcome.kind === "terminal_not_found" ||
+      (outcome.kind === "skipped" &&
+        (outcome.reason === "local_missing" ||
+          outcome.reason === "remote_status_unusable" ||
+          outcome.reason === "local_updated_concurrently" ||
+          outcome.reason === "remote_not_newer")) ||
+      (outcome.kind === "reconciled" &&
+        (outcome.status === "active" || outcome.status === "on_hold"));
+    if (outcomeIsUncertain) {
+      await bestEffortFinalizeFailed();
+      return onDemandRenewalFailureResult();
+    }
+
+    let resolution: OnDemandRenewalResolution;
+    try {
+      if (args.convexFailureInjectionForTest === "post_reconcile_query") {
+        throw new Error("simulated post-claim resolution query failure");
+      }
+      resolution = (await ctx.runQuery(
+        internal.payments.billing.getOnDemandRenewalResolution,
+        { userId: args.userId, now },
+      )) as OnDemandRenewalResolution;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // sentry-coverage-ok: Convex auto-Sentry captures console.error. The
+      // provider call already happened, so contain this post-claim Convex
+      // failure and leave a short, durable retry cooldown when possible.
+      console.error(
+        `[billing/on-demand-renewal] Failed to resolve post-reconcile user state dodoSubscriptionId=${claim.subscription.dodoSubscriptionId} userId=${claim.subscription.userId}: ${message}`,
+      );
+      await bestEffortFinalizeFailed();
+      return onDemandRenewalFailureResult();
+    }
+
+    switch (resolution.kind) {
+      case "active":
+        // A concurrent webhook or another subscription proves coverage. As
+        // above, finalization is cleanup and cannot revoke that confirmation.
+        await safeFinalize("active");
+        return { status: "active" };
+      case "pending": {
+        const finalized = await safeFinalize("lapsed");
+        if (!finalized) await bestEffortFinalizeFailed();
+        return finalized
+          ? {
+              status: "renewal_verification_pending",
+              retryAfterSeconds: resolution.retryAfterSeconds,
+            }
+          : onDemandRenewalFailureResult();
+      }
+      case "unresolved": {
+        const finalized = await safeFinalize("lapsed");
+        if (!finalized) await bestEffortFinalizeFailed();
+        return finalized
+          ? {
+              status: "renewal_verification_pending",
+              retryAfterSeconds: ON_DEMAND_RENEWAL_PROGRESS_RETRY_SECONDS,
+            }
+          : onDemandRenewalFailureResult();
+      }
+      case "failed": {
+        const finalized = await safeFinalize("lapsed");
+        if (!finalized) await bestEffortFinalizeFailed();
+        return finalized
+          ? {
+              status: "renewal_verification_failed",
+              retryAfterSeconds: resolution.retryAfterSeconds,
+            }
+          : onDemandRenewalFailureResult();
+      }
+      case "lapsed": {
+        const finalized = await safeFinalize("lapsed");
+        if (!finalized) await bestEffortFinalizeFailed();
+        return finalized
+          ? { status: "subscription_lapsed" }
+          : onDemandRenewalFailureResult();
+      }
+    }
   },
 });
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -707,6 +707,72 @@ function queryRecentlyStaleActiveSubscriptions(
 }
 
 /**
+ * Returns the known-good current fallback plus the strongest recently-stale
+ * plan that may still be restored by on-demand verification.
+ *
+ * The materialized entitlement row can temporarily point at that stale,
+ * stronger subscription while another lower plan is still current. Keeping
+ * both sides of the comparison lets the request path preserve known coverage
+ * without retaining a billing marker after an equal-or-stronger concurrent
+ * entitlement refresh.
+ */
+export const getOnDemandRenewalFallbackState = internalQuery({
+  args: {
+    userId: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const subscriptions = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .collect();
+
+    const currentSubscription = subscriptions
+      .filter((subscription) =>
+        subscription.currentPeriodEnd >= args.now &&
+        (
+          subscription.status === "active" ||
+          subscription.status === "on_hold" ||
+          subscription.status === "cancelled"
+        ),
+      )
+      .sort((a, b) =>
+        compareEntitlementPlans(
+          { planKey: b.planKey, validUntil: b.currentPeriodEnd },
+          { planKey: a.planKey, validUntil: a.currentPeriodEnd },
+        ),
+      )[0];
+
+    const recentCutoff = args.now - ON_DEMAND_RENEWAL_RECENT_WINDOW_MS;
+    const strongestRecentlyStaleSubscription = subscriptions
+      .filter((subscription) =>
+        subscription.status === "active" &&
+        subscription.currentPeriodEnd >= recentCutoff &&
+        subscription.currentPeriodEnd < args.now,
+      )
+      .sort((a, b) =>
+        compareEntitlementPlans(
+          { planKey: b.planKey, validUntil: b.currentPeriodEnd },
+          { planKey: a.planKey, validUntil: a.currentPeriodEnd },
+        ),
+      )[0];
+
+    return {
+      currentEntitlement: currentSubscription
+        ? {
+            planKey: currentSubscription.planKey,
+            features: getFeaturesForPlan(currentSubscription.planKey),
+            validUntil: currentSubscription.currentPeriodEnd,
+          }
+        : null,
+      strongestRecentlyStaleFeatures: strongestRecentlyStaleSubscription
+        ? getFeaturesForPlan(strongestRecentlyStaleSubscription.planKey)
+        : null,
+    };
+  },
+});
+
+/**
  * Classifies all recently-stale rows for one user without starting provider
  * work. A live pending lease is user-scoped: claiming a different row while
  * it is in flight would fan concurrent requests out to Dodo. Failed and

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -992,13 +992,24 @@ export const markDodoReconcileAttempt = internalMutation({
     // consecutive-not-found counter that gates the terminal downgrade; a
     // non-404 attempt resets that streak (a 404 must REPEAT consecutively).
     notFound: v.boolean(),
+    // "on_demand" attempts (#4770 request-path verification) participate in
+    // the 404 streak — provider evidence counts regardless of which path saw
+    // it — but must NOT touch the cron's backoff fields: a customer retrying
+    // through a Dodo blip (one attempt per 60s failure cooldown) would
+    // otherwise push reconcileFailureCount to the 30-day backoff cap and
+    // silence the nightly safety net for that row. Default: "cron".
+    source: v.optional(v.union(v.literal("cron"), v.literal("on_demand"))),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.subscriptionId);
     if (!existing || existing.status !== "active") return;
     await ctx.db.patch(args.subscriptionId, {
-      lastReconcileAttemptAt: args.observedAt,
-      reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+      ...(args.source === "on_demand"
+        ? {}
+        : {
+            lastReconcileAttemptAt: args.observedAt,
+            reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+          }),
       reconcileNotFoundCount: args.notFound
         ? (existing.reconcileNotFoundCount ?? 0) + 1
         : 0,
@@ -1011,6 +1022,9 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
     subscriptionId: v.id("subscriptions"),
     dodoSubscriptionId: v.string(),
     observedAt: v.number(),
+    // See markDodoReconcileAttempt: "on_demand" keeps the 404-streak semantics
+    // but never bumps the cron backoff fields. Default: "cron".
+    source: v.optional(v.union(v.literal("cron"), v.literal("on_demand"))),
     remote: v.object({
       dodoSubscriptionId: v.string(),
       productId: v.string(),
@@ -1051,10 +1065,14 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
     // touches `updatedAt` (that carries webhook ordering semantics).
     const recordAttempt = async (): Promise<void> => {
       await ctx.db.patch(existing._id, {
-        lastReconcileAttemptAt: args.observedAt,
-        reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+        ...(args.source === "on_demand"
+          ? {}
+          : {
+              lastReconcileAttemptAt: args.observedAt,
+              reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+            }),
         // These skips prove the sub still EXISTS in Dodo, so any prior 404
-        // streak is broken.
+        // streak is broken (both sources — provider evidence either way).
         reconcileNotFoundCount: 0,
       });
     };
@@ -1111,8 +1129,12 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       // broken (reset to 0 while still stale, cleared once it leaves the set).
       ...(stillStaleAfterPatch
         ? {
-            lastReconcileAttemptAt: args.observedAt,
-            reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+            ...(args.source === "on_demand"
+              ? {}
+              : {
+                  lastReconcileAttemptAt: args.observedAt,
+                  reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+                }),
             reconcileNotFoundCount: 0,
           }
         : {
@@ -1217,12 +1239,14 @@ export async function safeMarkReconcileAttempt(
   subscriptionId: Id<"subscriptions">,
   observedAt: number,
   notFound: boolean,
+  source: "cron" | "on_demand" = "cron",
 ): Promise<void> {
   try {
     await ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
       subscriptionId,
       observedAt,
       notFound,
+      source,
     });
   } catch (markErr) {
     // sentry-coverage-ok: structured console.error is forwarded by Convex
@@ -1248,9 +1272,12 @@ async function reconcileOneStaleRow(
     remoteById: Map<string, DodoReconciliationRemoteSubscription>;
     errorInjection: Map<string, "not_found" | "server_error">;
     client: DodoPayments | null;
+    // "on_demand" (#4770 request path) advances/resets the 404 streak like any
+    // provider attempt but never bumps the cron backoff fields. Default "cron".
+    source?: "cron" | "on_demand";
   },
 ): Promise<StaleRowOutcome> {
-  const { now, useTestRemotes, remoteById, errorInjection, client } = opts;
+  const { now, useTestRemotes, remoteById, errorInjection, client, source = "cron" } = opts;
   try {
     let remote: DodoSubscription | DodoReconciliationRemoteSubscription | undefined;
     if (useTestRemotes) {
@@ -1279,7 +1306,7 @@ async function reconcileOneStaleRow(
         `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: ${normalized.reason} Dodo status "${normalized.status}"`,
       );
       // Row is still stale-active — back it off (not a 404, resets the streak).
-      await safeMarkReconcileAttempt(ctx, sub._id, now, false);
+      await safeMarkReconcileAttempt(ctx, sub._id, now, false, source);
       return { kind: "skipped", reason: "remote_status_unusable" };
     }
 
@@ -1290,6 +1317,7 @@ async function reconcileOneStaleRow(
         dodoSubscriptionId: sub.dodoSubscriptionId,
         observedAt: now,
         remote: normalized.value,
+        source,
       },
     )) as ReconciliationMutationResult;
     // `apply` records its own backoff for the still-stale skip reasons.
@@ -1324,7 +1352,7 @@ async function reconcileOneStaleRow(
     console.error(
       `[billing/reconcile] Failed to reconcile dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${message}`,
     );
-    await safeMarkReconcileAttempt(ctx, sub._id, now, notFound);
+    await safeMarkReconcileAttempt(ctx, sub._id, now, notFound, source);
     return { kind: "failed", error: message };
   }
 }
@@ -1466,6 +1494,7 @@ export const verifyRecentlyStaleSubscriptionOnDemand = internalAction({
         remoteById,
         errorInjection,
         client,
+        source: "on_demand",
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/convex/payments/cacheActions.ts
+++ b/convex/payments/cacheActions.ts
@@ -9,6 +9,7 @@
  */
 
 import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
 import { v } from "convex/values";
 
 // 15 min — short enough that subscription expiry is reflected promptly
@@ -62,6 +63,34 @@ export const syncEntitlementCache = internalAction({
     validUntil: v.number(),
   },
   handler: async (_ctx, args) => {
+    await writeEntitlementCacheToRedis(args.userId, args);
+  },
+});
+
+/**
+ * Re-syncs a user's entitlement cache from the CURRENT database state.
+ *
+ * Used for the delayed race-covering sync (#4770 review): replaying the
+ * caller's upsert-time snapshot could revert a newer entitlement write that
+ * landed inside the delay (e.g. a renewal followed by a cancellation),
+ * re-granting stale paid access for up to the cache TTL. Reading at fire
+ * time means the delayed write always reflects the latest state.
+ */
+export const resyncEntitlementCacheFromDb = internalAction({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    const current = await ctx.runQuery(
+      internal.entitlements.getEntitlementsByUserId,
+      { userId: args.userId },
+    );
+    await writeEntitlementCacheToRedis(args.userId, current);
+  },
+});
+
+async function writeEntitlementCacheToRedis(
+  userId: string,
+  payload: { planKey: string; features: unknown; validUntil: number },
+): Promise<void> {
     const url = process.env.UPSTASH_REDIS_REST_URL;
     const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 
@@ -72,11 +101,11 @@ export const syncEntitlementCache = internalAction({
       return;
     }
 
-    const key = getEntitlementKey(args.userId);
+    const key = getEntitlementKey(userId);
     const value = JSON.stringify({
-      planKey: args.planKey,
-      features: args.features,
-      validUntil: args.validUntil,
+      planKey: payload.planKey,
+      features: payload.features,
+      validUntil: payload.validUntil,
     });
 
     const controller = new AbortController();
@@ -99,7 +128,7 @@ export const syncEntitlementCache = internalAction({
         // outages invisible — users who upgraded would not see PRO
         // features until next manual cache rebuild.
         throw new Error(
-          `[cacheActions] Redis SET failed: HTTP ${resp.status} for user ${args.userId}`,
+          `[cacheActions] Redis SET failed: HTTP ${resp.status} for user ${userId}`,
         );
       }
     } catch (err) {
@@ -113,8 +142,7 @@ export const syncEntitlementCache = internalAction({
     } finally {
       clearTimeout(timeout);
     }
-  },
-});
+}
 
 /**
  * Deletes a user's entitlement cache entry from Redis.

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -130,8 +130,10 @@ export function isNewerEvent(
 }
 
 // Delay for the second, race-covering entitlement cache sync (#4770 review):
-// must exceed the longest edge request that could hold a pre-write Convex read
-// (3s entitlement fetch budget, 8s tool fetch timeouts) with margin.
+// must exceed an edge request's Convex-read -> Redis-marker-write span, which
+// happens entirely inside the entitlement check (3s Convex fetch budget + 5s
+// Redis write timeout, ~8s worst case). Tool-level fetch timeouts (up to 25s)
+// do NOT extend that span — the marker write is not deferred to request end.
 const ENTITLEMENT_CACHE_RESYNC_DELAY_MS = 15_000;
 
 /**
@@ -197,13 +199,15 @@ export async function upsertEntitlements(
     // #4770 review: a request that read Convex BEFORE this write can still be
     // in flight and will write its stale billing-denial marker to the same
     // Redis key AFTER the sync above (bare SET, last-writer-wins, no version
-    // guard). Edge requests are bounded well under this delay, so a second
-    // sync overwrites any such late marker instead of letting it deny a
-    // just-renewed user until its TTL expires.
+    // guard). Edge requests' read->write span is bounded well under this
+    // delay, so a delayed re-sync overwrites any such late marker. The
+    // delayed job re-reads CURRENT state at fire time: replaying this
+    // upsert's snapshot could revert a newer entitlement write that landed
+    // inside the delay (a stale re-GRANT, worse than the race it fixes).
     await ctx.scheduler.runAfter(
       ENTITLEMENT_CACHE_RESYNC_DELAY_MS,
-      internal.payments.cacheActions.syncEntitlementCache,
-      { userId, planKey, features, validUntil },
+      internal.payments.cacheActions.resyncEntitlementCacheFromDb,
+      { userId },
     );
   }
 }

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -129,6 +129,11 @@ export function isNewerEvent(
   return incomingTimestamp > existingUpdatedAt;
 }
 
+// Delay for the second, race-covering entitlement cache sync (#4770 review):
+// must exceed the longest edge request that could hold a pre-write Convex read
+// (3s entitlement fetch budget, 8s tool fetch timeouts) with margin.
+const ENTITLEMENT_CACHE_RESYNC_DELAY_MS = 15_000;
+
 /**
  * Creates or updates the entitlements record for a given user.
  * Only one entitlement row exists per userId (upsert semantics).
@@ -186,6 +191,17 @@ export async function upsertEntitlements(
   if (process.env.UPSTASH_REDIS_REST_URL) {
     await ctx.scheduler.runAfter(
       0,
+      internal.payments.cacheActions.syncEntitlementCache,
+      { userId, planKey, features, validUntil },
+    );
+    // #4770 review: a request that read Convex BEFORE this write can still be
+    // in flight and will write its stale billing-denial marker to the same
+    // Redis key AFTER the sync above (bare SET, last-writer-wins, no version
+    // guard). Edge requests are bounded well under this delay, so a second
+    // sync overwrites any such late marker instead of letting it deny a
+    // just-renewed user until its TTL expires.
+    await ctx.scheduler.runAfter(
+      ENTITLEMENT_CACHE_RESYNC_DELAY_MS,
       internal.payments.cacheActions.syncEntitlementCache,
       { userId, planKey, features, validUntil },
     );

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -598,6 +598,8 @@ export async function handleSubscriptionActive(
       lastReconcileAttemptAt: undefined,
       reconcileFailureCount: undefined,
       reconcileNotFoundCount: undefined,
+      renewalVerificationState: undefined,
+      renewalVerificationAttemptAt: undefined,
     });
   } else {
     await ctx.db.insert("subscriptions", {
@@ -746,6 +748,8 @@ export async function handleSubscriptionRenewed(
     lastReconcileAttemptAt: undefined,
     reconcileFailureCount: undefined,
     reconcileNotFoundCount: undefined,
+    renewalVerificationState: undefined,
+    renewalVerificationAttemptAt: undefined,
   });
 
   // Recompute from ALL subs — a renewal on a lower-tier sub must NOT

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -598,9 +598,10 @@ export default defineSchema({
     // Request-path renewal verification (#4770). The state + attempt timestamp
     // form a durable lease/cooldown shared by every Convex action instance, so
     // concurrent premium requests cannot fan out into duplicate Dodo lookups.
-    // Kept separate from the daily reconciler's backoff fields above: a cron
-    // failure should not suppress the bounded customer-facing rescue attempt,
-    // and a request-path failure should not perturb the cron's paging policy.
+    // Kept separate from the daily reconciler's backoff fields above so a cron
+    // failure does not suppress the bounded customer-facing rescue attempt.
+    // Provider outcomes still update the shared reconciliation bookkeeping;
+    // only request coalescing/cooldown ownership lives in these fields.
     renewalVerificationState: v.optional(v.union(
       v.literal("pending"),
       v.literal("failed"),
@@ -609,6 +610,7 @@ export default defineSchema({
     renewalVerificationAttemptAt: v.optional(v.number()),
   })
     .index("by_userId", ["userId"])
+    .index("by_userId_status_currentPeriodEnd", ["userId", "status", "currentPeriodEnd"])
     .index("by_dodoSubscriptionId", ["dodoSubscriptionId"])
     .index("by_dodoCustomerId", ["dodoCustomerId"])
     // Dunning scan (#4932): on_hold is a small TRANSIENT set (tens of rows),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -595,6 +595,18 @@ export default defineSchema({
     // kinds for backoff) so the terminal "subscription deleted in Dodo"
     // downgrade requires repeated 404s specifically, not just any prior failure.
     reconcileNotFoundCount: v.optional(v.number()),
+    // Request-path renewal verification (#4770). The state + attempt timestamp
+    // form a durable lease/cooldown shared by every Convex action instance, so
+    // concurrent premium requests cannot fan out into duplicate Dodo lookups.
+    // Kept separate from the daily reconciler's backoff fields above: a cron
+    // failure should not suppress the bounded customer-facing rescue attempt,
+    // and a request-path failure should not perturb the cron's paging policy.
+    renewalVerificationState: v.optional(v.union(
+      v.literal("pending"),
+      v.literal("failed"),
+      v.literal("lapsed"),
+    )),
+    renewalVerificationAttemptAt: v.optional(v.number()),
   })
     .index("by_userId", ["userId"])
     .index("by_dodoSubscriptionId", ["dodoSubscriptionId"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -599,9 +599,12 @@ export default defineSchema({
     // form a durable lease/cooldown shared by every Convex action instance, so
     // concurrent premium requests cannot fan out into duplicate Dodo lookups.
     // Kept separate from the daily reconciler's backoff fields above so a cron
-    // failure does not suppress the bounded customer-facing rescue attempt.
-    // Provider outcomes still update the shared reconciliation bookkeeping;
-    // only request coalescing/cooldown ownership lives in these fields.
+    // failure does not suppress the bounded customer-facing rescue attempt —
+    // and vice versa: on-demand attempts advance/reset only the shared
+    // consecutive-404 streak (reconcileNotFoundCount — provider evidence
+    // counts from either path); the backoff pair (reconcileFailureCount /
+    // lastReconcileAttemptAt) is cron-only, so request-path failures cannot
+    // defer the nightly safety net (see markDodoReconcileAttempt `source`).
     renewalVerificationState: v.optional(v.union(
       v.literal("pending"),
       v.literal("failed"),

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -12,6 +12,7 @@ description: "Every error shape the World Monitor MCP server emits — JSON-RPC 
   - Method gate (405 + Allow)           api/mcp/handler.ts (mcpHandler method check)
   - Top-level dispatch / -32600/-32601  api/mcp/handler.ts (POST body parse and dispatch switch)
   - Auth -32001 / -32603 emitters       api/mcp/auth.ts (resolveAuthContext and entitlement checks)
+  - Billing -32002 / -32603 denials     api/mcp/auth.ts (getMcpBillingVerificationDenial) + api/mcp/dispatch.ts (BillingDenialError re-emit)
   - Per-minute -32029 + hit telemetry   api/mcp/auth.ts (applyPerMinuteLimit, applyAnonDiscoveryLimit, emitMcpRateLimitHit)
   - Pro daily-cap -32029 (HTTP 429)     api/mcp/dispatch.ts (reserveDailyQuotaForRequest)
   - Tool exec -32603                    api/mcp/dispatch.ts (dispatchToolsCall)
@@ -29,7 +30,7 @@ For the projection grammar itself, see the [JMESPath guide](/mcp-jmespath). For 
 ## Quick orientation
 
 - **HTTP status** is the transport-layer answer. Most JSON-RPC replies — successes AND errors — come back as **HTTP 200**, per the JSON-RPC 2.0 convention. The handler only escalates the status when the failure is something a generic HTTP client must react to (auth, daily cap, service unavailable) and benefits from a `Retry-After` / `WWW-Authenticate` header.
-- **JSON-RPC `error.code`** is the application-layer answer. Six codes are in use: `-32001`, `-32029`, `-32600`, `-32601`, `-32602`, `-32603`. The handler never emits another code — if you see one, treat it as a wire bug and file an issue.
+- **JSON-RPC `error.code`** is the application-layer answer. Seven codes are in use: `-32001`, `-32002`, `-32029`, `-32600`, `-32601`, `-32602`, `-32603`. The handler never emits another code — if you see one, treat it as a wire bug and file an issue.
 - **Soft-behavior envelopes** are the high-volume failure mode. `tools/call` succeeds at the JSON-RPC layer (HTTP 200, no `error` field), but the JSON sitting inside `result.content[0].text` carries a `_budget_exceeded` or `_jmespath_error` discriminator. Clients that only inspect the JSON-RPC envelope will silently treat these as successes — parse `result.content[0].text` and check for a leading `_` key before consuming the payload as data.
 - **Executed calls stay charged.** `_budget_exceeded`, `_jmespath_error`, and tool-execution errors (`-32603`) all happen after the tool has run, so they consume the Pro daily-quota slot. Only pre-dispatch failures such as daily-cap rejection or quota-reservation service failure avoid charging the slot.
 - **Both 401 paths set `WWW-Authenticate`** with `realm="worldmonitor"` and a `resource_metadata` pointer at `/.well-known/oauth-protected-resource`. RFC 9728-aware clients (Claude Desktop, MCP Inspector) bounce through the OAuth flow on this header without further intervention.
@@ -39,6 +40,7 @@ For the projection grammar itself, see the [JMESPath guide](/mcp-jmespath). For 
 | Code      | Meaning (this server)                                                  | Paired HTTP status        | Recovery                                                              |
 |-----------|------------------------------------------------------------------------|---------------------------|-----------------------------------------------------------------------|
 | `-32001`  | Unauthenticated, invalid token, or subscription not active             | **401**                   | Re-authenticate via OAuth or fix the `X-WorldMonitor-Key` header      |
+| `-32002`  | Subscription lapsed — confirmed with the billing provider              | **403**                   | Do NOT re-authenticate (the identity is still valid). Resubscribe to restore access |
 | `-32029`  | Rate-limited — per-minute throttle OR Pro daily quota cap              | **200** (per-min) / **429** (daily) | Honour `Retry-After`; for 200/per-min back off ~1s                    |
 | `-32600`  | Malformed JSON-RPC request envelope                                    | **200**                   | Fix the request encoder; this is a client bug                         |
 | `-32601`  | Method not found                                                       | **200**                   | Use a method advertised in the initialize result's `capabilities`     |
@@ -55,7 +57,7 @@ Fires from six `api/mcp/auth.ts` emission sites, always paired with HTTP **401**
 2. **`Authorization: Bearer <token>` but `<token>` is invalid or expired** — the token didn't resolve to a context (revoked / TTL expired / never minted by `/api/oauth/token`).
 3. **`X-WorldMonitor-Key: <key>` but `<key>` isn't in the valid set** — the API key is wrong.
 4. **OAuth token resolves but the Pro MCP token row is missing or cross-bound** — the `mcpTokenId` no longer maps to the userId. Typically a revoke from Settings → Connected MCP clients.
-5. **OAuth token resolves but the subscription went away** — entitlement re-check found `tier < 1`, `mcpAccess !== true`, or `validUntil < now`. Includes the entitlements-service-unavailable fail-closed path.
+5. **OAuth token resolves but the subscription went away** — entitlement re-check found `tier < 1`, `mcpAccess !== true`, or `validUntil < now`. Includes the entitlements-service-unavailable fail-closed path. A lapse the billing provider has *confirmed* does NOT use this code — it returns `-32002` at HTTP 403 (see below), because re-authenticating cannot fix it.
 
 Example wire payload (case 1):
 
@@ -77,6 +79,31 @@ Content-Type: application/json
 ```
 
 **What to do.** Re-run the OAuth flow (`/api/oauth/token` with a fresh authorization code, OR refresh-grant with a valid refresh token). For API-key clients, double-check the `X-WorldMonitor-Key` header — user-issued `wm_` keys and operator-issued enterprise keys must go in that header, NOT as `Authorization: Bearer`. The `WWW-Authenticate` header's `resource_metadata` pointer is the canonical place to start the discovery flow from scratch.
+
+### `-32002` — Subscription lapsed (confirmed)
+
+Fires from the entitlement pre-check (`api/mcp/auth.ts` `getMcpBillingVerificationDenial`) and, for a lapse that lands mid-call between the pre-check and a tool's downstream fetch, from `api/mcp/dispatch.ts` (typed `BillingDenialError` re-emit). Always paired with HTTP **403**, `Cache-Control: no-store`, and an `X-Billing-Verification: subscription_lapsed` header. No `WWW-Authenticate` header is set — the credential is still valid; the subscription is not.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32002,
+    "message": "Subscription lapsed. Re-authenticating will not help — resubscribe to restore access.",
+    "data": { "code": "subscription_lapsed" }
+  }
+}
+```
+
+```http
+HTTP/1.1 403 Forbidden
+Cache-Control: no-store
+X-Billing-Verification: subscription_lapsed
+Content-Type: application/json
+```
+
+**What to do.** Do not retry and do not re-run OAuth — both will reproduce the same denial. Surface the state to the user: the subscription must be renewed (worldmonitor.app → Pricing) before MCP access resumes. Renewal takes effect within seconds of the provider webhook; no re-authentication is needed afterwards. While the same subscription is still being *verified* (provider re-check in flight), the server instead returns a retryable `-32603` at HTTP 503 with `X-Billing-Verification: renewal_verification_pending|renewal_verification_failed` and a dynamic `Retry-After` — see `-32603` below.
 
 ### `-32029` — Rate limited (per-minute OR daily)
 
@@ -183,7 +210,7 @@ The most common error code, shared across `tools/call`, `prompts/get`, `resource
 
 ### `-32603` — Internal error
 
-Three distinct conditions share this code; the HTTP status disambiguates whether retry is reasonable.
+Four distinct conditions share this code; the HTTP status (and, for billing verification, the `X-Billing-Verification` header) disambiguates whether retry is reasonable.
 
 **HTTP 200 — tool-execution failure.** A tool dispatcher threw. Most commonly: every Redis key the tool reads returned null (`cache_all_null` — transient Redis blip or a still-warming seeder), or a sibling internal fetch failed mid-call. Pro quota is not rolled back: the tool already executed, so retrying consumes another slot.
 
@@ -211,15 +238,17 @@ Retry-After: 5
 Content-Type: application/json
 ```
 
-The `message` text identifies the trigger. Three sites emit a 503; two distinct strings:
+The `message` text identifies the trigger. Five sites emit a 503; four distinct strings:
 
 | Trigger                                         | `message`                                              | Site                              |
 |-------------------------------------------------|--------------------------------------------------------|-----------------------------------|
 | OAuth resolution service threw (Convex blip)    | `Auth service temporarily unavailable. Try again.`     | `api/mcp/auth.ts` `resolveAuthContext` bearer branch |
 | `MCP_INTERNAL_HMAC_SECRET` unset (Pro path)     | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/auth.ts` `runProPreChecks` secret preflight |
 | Pro quota-reservation Redis failure (non-cap)   | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/dispatch.ts` `dispatchToolsCall` quota reservation |
+| Renewal verification in flight (#4770)          | `Renewal verification pending. Retry shortly.`         | `api/mcp/auth.ts` `getMcpBillingVerificationDenial` (pre-check) or `api/mcp/dispatch.ts` (mid-call re-emit) |
+| Renewal verification failed, in cooldown (#4770)| `Renewal verification failed. Retry shortly.`          | same two sites as above           |
 
-Client recovery is identical for all three (honour `Retry-After: 5`); the message disambiguates only for log analysis.
+Recovery for the first three is identical (honour `Retry-After: 5`). The two billing-verification rows differ: they carry an `X-Billing-Verification: renewal_verification_pending|renewal_verification_failed` header, a `data.code` mirroring it, and a **dynamic `Retry-After` between 1 and 60 seconds** sized to the actual provider re-check — honour the header value rather than assuming 5. They mean the subscription recently expired locally and the server is re-confirming it with the billing provider before denying; a renewed subscription typically recovers within one or two retries.
 
 **HTTP 200 — `resources/read` payload was empty or unparseable.** Defensive guard inside `resources/read` for the never-should-happen case where the inner `tools/call` dispatcher returned no `content[0].text` or non-JSON text.
 
@@ -235,9 +264,10 @@ Every status the MCP handler can return. Most JSON-RPC replies — including mos
 | **202** | empty                     | n/a              | `notifications/initialized` — JSON-RPC notifications take no response body, per spec |
 | **204** | empty                     | n/a              | `OPTIONS` preflight                                                  |
 | **401** | JSON-RPC envelope         | `-32001`         | Missing/invalid/expired credentials, revoked Pro MCP token, inactive subscription. `WWW-Authenticate` header set. |
+| **403** | JSON-RPC envelope         | `-32002`         | Subscription lapse confirmed with the billing provider. `X-Billing-Verification: subscription_lapsed` set; no `WWW-Authenticate` (re-auth cannot fix it). |
 | **405** | empty                     | n/a              | Request method is not `POST`, `GET`, `HEAD`, or `OPTIONS` (or a bare `GET` with no `Last-Event-ID`). `Allow: POST, GET, HEAD, OPTIONS` header set. |
 | **429** | JSON-RPC envelope         | `-32029`         | **Pro daily cap exceeded only.** `Retry-After: <seconds-until-UTC-midnight>` set. (Per-minute throttle returns `-32029` inside HTTP 200 — see `-32029` above.) |
-| **503** | JSON-RPC envelope         | `-32603`         | Auth service unavailable, `MCP_INTERNAL_HMAC_SECRET` misconfigured, or quota-reservation Redis failure. `Retry-After: 5`. |
+| **503** | JSON-RPC envelope         | `-32603`         | Auth service unavailable, `MCP_INTERNAL_HMAC_SECRET` misconfigured, or quota-reservation Redis failure (`Retry-After: 5`); OR renewal verification pending/failed (`X-Billing-Verification` set, dynamic `Retry-After` 1-60s). |
 
 One HTTP status appears that isn't a JSON-RPC error:
 

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -238,7 +238,7 @@ Retry-After: 5
 Content-Type: application/json
 ```
 
-The `message` text identifies the trigger. Five sites emit a 503; four distinct strings:
+The `message` text identifies the trigger. Six sites emit a 503; five distinct strings:
 
 | Trigger                                         | `message`                                              | Site                              |
 |-------------------------------------------------|--------------------------------------------------------|-----------------------------------|
@@ -247,8 +247,9 @@ The `message` text identifies the trigger. Five sites emit a 503; four distinct 
 | Pro quota-reservation Redis failure (non-cap)   | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/dispatch.ts` `dispatchToolsCall` quota reservation |
 | Renewal verification in flight (#4770)          | `Renewal verification pending. Retry shortly.`         | `api/mcp/auth.ts` `getMcpBillingVerificationDenial` (pre-check) or `api/mcp/dispatch.ts` (mid-call re-emit) |
 | Renewal verification failed, in cooldown (#4770)| `Renewal verification failed. Retry shortly.`          | same two sites as above           |
+| Entitlement backend unreachable mid-call (#4770)| `Unable to verify API access. Retry shortly.`          | `api/mcp/dispatch.ts` mid-call re-emit of a gateway `entitlement_verification_unavailable` 503 (wm\_-key tool fetches) |
 
-Recovery for the first three is identical (honour `Retry-After: 5`). The two billing-verification rows differ: they carry an `X-Billing-Verification: renewal_verification_pending|renewal_verification_failed` header, a `data.code` mirroring it, and a **dynamic `Retry-After` between 1 and 60 seconds** sized to the actual provider re-check — honour the header value rather than assuming 5. They mean the subscription recently expired locally and the server is re-confirming it with the billing provider before denying; a renewed subscription typically recovers within one or two retries.
+Recovery for the first three is identical (honour `Retry-After: 5`). The billing-verification rows differ: they carry an `X-Billing-Verification` header (`renewal_verification_pending|renewal_verification_failed`, or `entitlement_verification_unavailable` for the backend-unreachable row), a `data.code` mirroring it, and — for the two renewal-verification codes — a **dynamic `Retry-After` between 1 and 60 seconds** sized to the actual provider re-check; honour the header value rather than assuming 5 (the backend-unreachable row uses a fixed `Retry-After: 5`). The renewal-verification codes mean the subscription recently expired locally and the server is re-confirming it with the billing provider before denying; a renewed subscription typically recovers within one or two retries.
 
 **HTTP 200 — `resources/read` payload was empty or unparseable.** Defensive guard inside `resources/read` for the never-should-happen case where the inner `tools/call` dispatcher returned no `content[0].text` or non-JSON text.
 

--- a/docs/usage-errors.mdx
+++ b/docs/usage-errors.mdx
@@ -32,7 +32,7 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `304` | Not Modified (conditional cache hit) | — |
 | `400` | Bad request — validation error | No — fix input |
 | `401` | Missing / invalid auth | No — fix auth |
-| `403` | Authenticated but not entitled (usually `pro_required`) | No — upgrade |
+| `403` | Authenticated but not entitled (usually `pro_required`), or `subscription_lapsed` — a lapse confirmed with the billing provider (`X-Billing-Verification` header set) | No — upgrade / resubscribe |
 | `404` | Resource / tool / brief / entity not found | No |
 | `405` | Method not allowed | No |
 | `409` | `Idempotency-Key` request still in progress, or another conflict such as duplicate webhook registration. | Yes for keyed in-flight requests — honor `Retry-After: 2`; otherwise no |
@@ -41,7 +41,7 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `429` | Rate limited | Yes — honor `Retry-After` |
 | `500` | Server bug | Yes — with backoff, then report |
 | `502` | Upstream / Convex / Dodo failure | Yes — exponential backoff |
-| `503` | Service unavailable — missing env or dependency down | Yes — exponential backoff |
+| `503` | Service unavailable — missing env or dependency down; or billing verification in progress (`renewal_verification_pending` / `renewal_verification_failed` / `entitlement_verification_unavailable` — honor the dynamic `Retry-After`) | Yes — honor `Retry-After`, else exponential backoff |
 | `504` | Upstream timeout | Yes — with backoff |
 
 ## Common error strings
@@ -57,6 +57,10 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `Service temporarily unavailable` | Upstash or another hard dependency missing at request time. |
 | `service_unavailable` | Signing secret / required env not configured. |
 | `Failed to enqueue scenario job` | Redis pipeline failure on `/api/scenario/v1/run-scenario`. |
+| `subscription_lapsed` | The subscription lapse was confirmed with the billing provider. Re-authenticating will not help — resubscribe to restore access. Response carries `X-Billing-Verification: subscription_lapsed`. |
+| `renewal_verification_pending` | Your subscription recently expired locally and the server is re-confirming it with the billing provider. Retryable 503 — honor `Retry-After` (1-60s); a renewed subscription typically recovers within one or two retries. |
+| `renewal_verification_failed` | The provider re-check could not complete and is in a short cooldown. Retryable 503 — honor `Retry-After`. |
+| `entitlement_verification_unavailable` | The billing backend could not be reached to verify a `wm_` API key. Retryable 503 with `Retry-After: 5`. |
 | `idempotency_conflict` | A POST with this `Idempotency-Key` is still processing. Retry after `Retry-After: 2`. |
 | `idempotency_key_reused` | The same `Idempotency-Key` was already used with a different request body. |
 | `invalid_idempotency_key` | The `Idempotency-Key` header is too long or contains non-printable characters. Generated OpenAPI POSTs also reject an empty key. |

--- a/docs/usage-errors.mdx
+++ b/docs/usage-errors.mdx
@@ -41,7 +41,7 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `429` | Rate limited | Yes — honor `Retry-After` |
 | `500` | Server bug | Yes — with backoff, then report |
 | `502` | Upstream / Convex / Dodo failure | Yes — exponential backoff |
-| `503` | Service unavailable — missing env or dependency down; or billing verification in progress (`renewal_verification_pending` / `renewal_verification_failed` / `entitlement_verification_unavailable` — honor the dynamic `Retry-After`) | Yes — honor `Retry-After`, else exponential backoff |
+| `503` | Service unavailable — missing env or dependency down; billing verification in progress (`renewal_verification_pending` / `renewal_verification_failed` — dynamic `Retry-After`, 1-60s); or billing backend unreachable (`entitlement_verification_unavailable` — fixed `Retry-After: 5`) | Yes — honor `Retry-After`, else exponential backoff |
 | `504` | Upstream timeout | Yes — with backoff |
 
 ## Common error strings
@@ -60,7 +60,7 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `subscription_lapsed` | The subscription lapse was confirmed with the billing provider. Re-authenticating will not help — resubscribe to restore access. Response carries `X-Billing-Verification: subscription_lapsed`. |
 | `renewal_verification_pending` | Your subscription recently expired locally and the server is re-confirming it with the billing provider. Retryable 503 — honor `Retry-After` (1-60s); a renewed subscription typically recovers within one or two retries. |
 | `renewal_verification_failed` | The provider re-check could not complete and is in a short cooldown. Retryable 503 — honor `Retry-After`. |
-| `entitlement_verification_unavailable` | The billing backend could not be reached to verify a `wm_` API key. Retryable 503 with `Retry-After: 5`. |
+| `entitlement_verification_unavailable` | The billing backend could not be reached to verify a `wm_` API key. Retryable 503 with fixed `Retry-After: 5` and `X-Billing-Verification: entitlement_verification_unavailable`. |
 | `idempotency_conflict` | A POST with this `Idempotency-Key` is still processing. Retry after `Retry-After: 2`. |
 | `idempotency_key_reused` | The same `Idempotency-Key` was already used with a different request body. |
 | `invalid_idempotency_key` | The `Idempotency-Key` header is too long or contains non-printable characters. Generated OpenAPI POSTs also reject an empty key. |

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -164,6 +164,30 @@ describe("gateway entitlement check", () => {
     });
   });
 
+  test("serves a short-lived verification marker from Redis without another Convex request", async () => {
+    vi.mocked(getCachedJson).mockResolvedValueOnce({
+      ...makeEntitlements(0),
+      validUntil: 0,
+      billingStatus: "renewal_verification_pending",
+      retryAfterSeconds: 11,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const result = await checkEntitlement(
+        "test-user",
+        "/api/market/v1/analyze-stock",
+        {},
+      );
+
+      expect(result?.status).toBe(503);
+      expect(result?.headers.get("Retry-After")).toBe("11");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   test("checkEntitlement accepts Clerk role=pro for tier-1 gates without Convex entitlements", async () => {
     const result = await checkEntitlement(
       "test-user",

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -219,7 +219,7 @@ describe("gateway entitlement check", () => {
       validUntil: 0,
       renewalVerificationFreshness: {
         status: "not_applicable",
-        checkedAt: Date.now() - 300_001,
+        checkedAt: Date.now() - 900_001,
       },
     });
     const originalSiteUrl = process.env.CONVEX_SITE_URL;
@@ -251,7 +251,7 @@ describe("gateway entitlement check", () => {
     }
   });
 
-  test("caches a not-applicable freshness marker for at most 300 seconds", async () => {
+  test("caches a not-applicable freshness marker for at most 900 seconds", async () => {
     const marker = {
       ...makeEntitlements(0),
       validUntil: 0,
@@ -266,7 +266,7 @@ describe("gateway entitlement check", () => {
 
     const ttl = vi.mocked(setCachedJson).mock.calls.at(-1)?.[2];
     expect(ttl).toBeGreaterThan(0);
-    expect(ttl).toBeLessThanOrEqual(300);
+    expect(ttl).toBeLessThanOrEqual(900);
   });
 
   test("checkEntitlement accepts Clerk role=pro for tier-1 gates without Convex entitlements", async () => {

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -219,7 +219,7 @@ describe("gateway entitlement check", () => {
       validUntil: 0,
       renewalVerificationFreshness: {
         status: "not_applicable",
-        checkedAt: Date.now() - 60_001,
+        checkedAt: Date.now() - 300_001,
       },
     });
     const originalSiteUrl = process.env.CONVEX_SITE_URL;
@@ -251,7 +251,7 @@ describe("gateway entitlement check", () => {
     }
   });
 
-  test("caches a not-applicable freshness marker for at most 60 seconds", async () => {
+  test("caches a not-applicable freshness marker for at most 300 seconds", async () => {
     const marker = {
       ...makeEntitlements(0),
       validUntil: 0,
@@ -266,7 +266,7 @@ describe("gateway entitlement check", () => {
 
     const ttl = vi.mocked(setCachedJson).mock.calls.at(-1)?.[2];
     expect(ttl).toBeGreaterThan(0);
-    expect(ttl).toBeLessThanOrEqual(60);
+    expect(ttl).toBeLessThanOrEqual(300);
   });
 
   test("checkEntitlement accepts Clerk role=pro for tier-1 gates without Convex entitlements", async () => {

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -55,6 +55,32 @@ function makeEntitlements(tier: number, planKey = "free") {
   };
 }
 
+async function withConvexEntitlementResponse<T>(
+  payload: unknown,
+  run: () => Promise<T>,
+): Promise<T> {
+  const originalSiteUrl = process.env.CONVEX_SITE_URL;
+  const originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  process.env.CONVEX_SITE_URL = "https://example-deployment.convex.site";
+  process.env.CONVEX_SERVER_SHARED_SECRET = "test-secret";
+  vi.mocked(getCachedJson).mockResolvedValueOnce(null);
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  ));
+  try {
+    return await run();
+  } finally {
+    if (originalSiteUrl === undefined) delete process.env.CONVEX_SITE_URL;
+    else process.env.CONVEX_SITE_URL = originalSiteUrl;
+    if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+    else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
+    vi.unstubAllGlobals();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -98,6 +124,44 @@ describe("gateway entitlement check", () => {
     const body = await result!.json();
     expect(body.error).toBe("Unable to verify entitlements");
     expect(body.requiredTier).toBe(1);
+  });
+
+  test.each([
+    ["renewal_verification_pending", "Renewal verification pending"],
+    ["renewal_verification_failed", "Renewal verification failed"],
+  ] as const)("%s returns a distinct retryable 503", async (billingStatus, error) => {
+    const result = await withConvexEntitlementResponse(
+      {
+        ...makeEntitlements(0),
+        validUntil: 0,
+        billingStatus,
+        retryAfterSeconds: 17,
+      },
+      () => checkEntitlement("test-user", "/api/market/v1/analyze-stock", {}),
+    );
+
+    expect(result?.status).toBe(503);
+    expect(result?.headers.get("Retry-After")).toBe("17");
+    expect(result?.headers.get("X-Billing-Verification")).toBe(billingStatus);
+    expect(await result?.json()).toMatchObject({ error, code: billingStatus });
+  });
+
+  test("subscription_lapsed returns a distinct hard-denial code", async () => {
+    const result = await withConvexEntitlementResponse(
+      {
+        ...makeEntitlements(0),
+        validUntil: 0,
+        billingStatus: "subscription_lapsed",
+      },
+      () => checkEntitlement("test-user", "/api/market/v1/analyze-stock", {}),
+    );
+
+    expect(result?.status).toBe(403);
+    expect(result?.headers.get("X-Billing-Verification")).toBe("subscription_lapsed");
+    expect(await result?.json()).toMatchObject({
+      error: "Subscription lapsed",
+      code: "subscription_lapsed",
+    });
   });
 
   test("checkEntitlement accepts Clerk role=pro for tier-1 gates without Convex entitlements", async () => {

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -22,7 +22,7 @@ vi.mock("../_shared/redis", () => ({
   setCachedJson: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { getCachedJson } from "../_shared/redis";
+import { getCachedJson, setCachedJson } from "../_shared/redis";
 import {
   getRequiredTier,
   checkEntitlement,
@@ -186,6 +186,87 @@ describe("gateway entitlement check", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  test("serves a recent not-applicable freshness marker without another Convex request", async () => {
+    vi.mocked(getCachedJson).mockResolvedValueOnce({
+      ...makeEntitlements(0),
+      validUntil: 0,
+      renewalVerificationFreshness: {
+        status: "not_applicable",
+        checkedAt: Date.now(),
+      },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const result = await checkEntitlement(
+        "test-user",
+        "/api/market/v1/analyze-stock",
+        {},
+      );
+
+      expect(result?.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test("an expired not-applicable freshness marker falls through to Convex", async () => {
+    vi.mocked(getCachedJson).mockResolvedValueOnce({
+      ...makeEntitlements(0),
+      validUntil: 0,
+      renewalVerificationFreshness: {
+        status: "not_applicable",
+        checkedAt: Date.now() - 60_001,
+      },
+    });
+    const originalSiteUrl = process.env.CONVEX_SITE_URL;
+    const originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+    process.env.CONVEX_SITE_URL = "https://example-deployment.convex.site";
+    process.env.CONVEX_SERVER_SHARED_SECRET = "test-secret";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeEntitlements(1, "pro_monthly")), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const result = await checkEntitlement(
+        "test-user",
+        "/api/market/v1/analyze-stock",
+        {},
+      );
+
+      expect(result).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      if (originalSiteUrl === undefined) delete process.env.CONVEX_SITE_URL;
+      else process.env.CONVEX_SITE_URL = originalSiteUrl;
+      if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+      else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test("caches a not-applicable freshness marker for at most 60 seconds", async () => {
+    const marker = {
+      ...makeEntitlements(0),
+      validUntil: 0,
+      renewalVerificationFreshness: {
+        status: "not_applicable",
+        checkedAt: Date.now(),
+      },
+    };
+    await withConvexEntitlementResponse(marker, async () => {
+      await getEntitlements("test-user-marker-ttl");
+    });
+
+    const ttl = vi.mocked(setCachedJson).mock.calls.at(-1)?.[2];
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(60);
   });
 
   test("checkEntitlement accepts Clerk role=pro for tier-1 gates without Convex entitlements", async () => {

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -146,6 +146,29 @@ describe("gateway entitlement check", () => {
     expect(await result?.json()).toMatchObject({ error, code: billingStatus });
   });
 
+  test.each([
+    "renewal_verification_pending",
+    "renewal_verification_failed",
+  ] as const)(
+    "current Pro fallback authorizes tier-1 REST while stronger verification is %s",
+    async (billingStatus) => {
+      const result = await withConvexEntitlementResponse(
+        {
+          ...makeEntitlements(1, "pro_monthly"),
+          billingStatus,
+          retryAfterSeconds: 17,
+        },
+        () => checkEntitlement(
+          "test-user",
+          "/api/market/v1/analyze-stock",
+          {},
+        ),
+      );
+
+      expect(result).toBeNull();
+    },
+  );
+
   test("subscription_lapsed returns a distinct hard-denial code", async () => {
     const result = await withConvexEntitlementResponse(
       {

--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -54,12 +54,16 @@ const STARTER = {
   validUntil: Date.now() + 86_400_000,
 };
 let entitlement: typeof STARTER | { planKey: string; features: Record<string, unknown>; validUntil: number } | null = STARTER;
-vi.mock("../_shared/entitlement-check", () => ({
-  getRequiredTier: () => null, // not tier-gated
-  checkEntitlement: vi.fn().mockResolvedValue(null), // passes
-  checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }), // passes
-  getEntitlements: vi.fn(async () => entitlement),
-}));
+vi.mock("../_shared/entitlement-check", async (importActual) => {
+  const actual = await importActual<typeof import("../_shared/entitlement-check")>();
+  return {
+    ...actual,
+    getRequiredTier: () => null, // not tier-gated
+    checkEntitlement: vi.fn().mockResolvedValue(null), // passes
+    checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }), // passes
+    getEntitlements: vi.fn(async () => entitlement),
+  };
+});
 
 // --- Stub user-key validation: a valid wm_ key resolves to a userId ----------
 vi.mock("../_shared/user-api-key", () => ({

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -75,13 +75,17 @@ const requiredTiers = new Map<string, number>();
 const entitlementsByUser = new Map<string, Ent>();
 const getEntitlements = vi.fn(async (userId: string) => entitlementsByUser.get(userId) ?? entitlement);
 let entitlementBackendConfigured = true;
+const checkEntitlementDetailedMock = vi.fn(
+  async (): Promise<{ response: Response | null; entitlements: unknown }> =>
+    ({ response: null, entitlements: null }),
+);
 vi.mock("../_shared/entitlement-check", async (importActual) => {
   const actual = await importActual<typeof import("../_shared/entitlement-check")>();
   return {
     ...actual,
     getRequiredTier: (pathname: string) => requiredTiers.get(pathname) ?? null,
     checkEntitlement: vi.fn().mockResolvedValue(null),
-    checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
+    checkEntitlementDetailed: (...a: unknown[]) => checkEntitlementDetailedMock(...(a as [])),
     getEntitlements: (...a: unknown[]) => getEntitlements(...a),
     isEntitlementBackendConfigured: () => entitlementBackendConfigured,
   };
@@ -159,6 +163,7 @@ beforeEach(() => {
   resolveClerkSession.mockClear();
   validateBearerToken.mockClear();
   entitlementBackendConfigured = true;
+  checkEntitlementDetailedMock.mockReset().mockResolvedValue({ response: null, entitlements: null });
   validateUserApiKey.mockClear().mockResolvedValue({ userId: "acct_lapsed", keyId: "k1", name: "t" });
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -286,9 +291,36 @@ describe("#4611 — expired wm_ key rejected on all route classes", () => {
     expect(res.status).toBe(503);
     expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(res.headers.get("Retry-After")).toBe("5");
+    expect(res.headers.get("X-Billing-Verification")).toBe("entitlement_verification_unavailable");
     expect(await res.json()).toMatchObject({ code: "entitlement_verification_unavailable" });
     expect(checkBurst).not.toHaveBeenCalled();
     expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("tier-gated route passes through a billing-verification 503 from checkEntitlementDetailed", async () => {
+    entitlement = ACTIVE;
+    checkEntitlementDetailedMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({ error: "Renewal verification pending", code: "renewal_verification_pending" }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+            "Retry-After": "17",
+            "X-Billing-Verification": "renewal_verification_pending",
+          },
+        },
+      ),
+      entitlements: null,
+    });
+
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("17");
+    expect(res.headers.get("X-Billing-Verification")).toBe("renewal_verification_pending");
+    expect(await res.json()).toMatchObject({ code: "renewal_verification_pending" });
   });
 
   test("null entitlement with UNCONFIGURED backend → fail-open 200 (deploy defect, not billing state)", async () => {

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -63,7 +63,13 @@ const ACTIVE = {
   },
   validUntil: Date.now() + 86_400_000,
 };
-type Ent = { planKey: string; features: Record<string, unknown>; validUntil: number } | null;
+type Ent = {
+  planKey: string;
+  features: Record<string, unknown>;
+  validUntil: number;
+  billingStatus?: "subscription_lapsed" | "renewal_verification_pending" | "renewal_verification_failed";
+  retryAfterSeconds?: number;
+} | null;
 let entitlement: Ent = ACTIVE;
 const requiredTiers = new Map<string, number>();
 const entitlementsByUser = new Map<string, Ent>();
@@ -73,6 +79,26 @@ vi.mock("../_shared/entitlement-check", () => ({
   checkEntitlement: vi.fn().mockResolvedValue(null),
   checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
   getEntitlements: (...a: unknown[]) => getEntitlements(...a),
+  getBillingVerificationDenial: (ent: Ent, corsHeaders: Record<string, string>) => {
+    if (!ent?.billingStatus) return null;
+    const retryable = ent.billingStatus !== "subscription_lapsed";
+    return new Response(JSON.stringify({
+      error: retryable
+        ? ent.billingStatus === "renewal_verification_pending"
+          ? "Renewal verification pending"
+          : "Renewal verification failed"
+        : "Subscription lapsed",
+      code: ent.billingStatus,
+    }), {
+      status: retryable ? 503 : 403,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Billing-Verification": ent.billingStatus,
+        ...(retryable ? { "Retry-After": String(ent.retryAfterSeconds ?? 5) } : {}),
+        ...corsHeaders,
+      },
+    });
+  },
 }));
 
 // --- Stub user-key validation: a valid wm_ key resolves to a userId. ---------
@@ -85,8 +111,17 @@ vi.mock("../_shared/user-api-key", () => ({
 type MockClerkSession = { userId: string; orgId: string | null } | null;
 let clerkSession: MockClerkSession = null;
 const resolveClerkSession = vi.fn(async () => clerkSession);
+const validateBearerToken = vi.fn(async () => ({
+  valid: true,
+  userId: "acct_lapsed",
+  role: "free" as const,
+}));
 vi.mock("../_shared/auth-session", () => ({
   resolveClerkSession: (...a: unknown[]) => resolveClerkSession(...a),
+  validateBearerToken: (...a: unknown[]) => validateBearerToken(...a),
+}));
+vi.mock("../auth-session", () => ({
+  validateBearerToken: (...a: unknown[]) => validateBearerToken(...a),
 }));
 
 import { createDomainGateway } from "../gateway";
@@ -136,6 +171,7 @@ beforeEach(() => {
   checkRateLimit.mockClear().mockResolvedValue(null);
   getEntitlements.mockClear();
   resolveClerkSession.mockClear();
+  validateBearerToken.mockClear();
   validateUserApiKey.mockClear().mockResolvedValue({ userId: "acct_lapsed", keyId: "k1", name: "t" });
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -205,6 +241,56 @@ describe("#4611 — expired wm_ key rejected on all route classes", () => {
     entitlement = { planKey: "api_starter", features: { tier: 2, apiAccess: true, apiRateLimit: 60 }, validUntil: Date.now() - 1_000 };
     const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
     expect(res.status).toBe(403);
+  });
+
+  test("renewal verification pending on a wm_ key returns retryable 503", async () => {
+    entitlement = {
+      planKey: "free",
+      features: { tier: 0, apiAccess: false, apiRateLimit: 0 },
+      validUntil: 0,
+      billingStatus: "renewal_verification_pending",
+      retryAfterSeconds: 13,
+    };
+
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("13");
+    expect(await res.json()).toMatchObject({ code: "renewal_verification_pending" });
+  });
+
+  test("confirmed lapse on a wm_ key returns subscription_lapsed", async () => {
+    entitlement = {
+      planKey: "free",
+      features: { tier: 0, apiAccess: false, apiRateLimit: 0 },
+      validUntil: 0,
+      billingStatus: "subscription_lapsed",
+    };
+
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "subscription_lapsed" });
+  });
+
+  test("legacy premium bearer surfaces renewal verification failure", async () => {
+    entitlement = {
+      planKey: "free",
+      features: { tier: 0, apiAccess: false, apiRateLimit: 0 },
+      validUntil: 0,
+      billingStatus: "renewal_verification_failed",
+      retryAfterSeconds: 23,
+    };
+    const req = new Request(`https://www.worldmonitor.app${PREMIUM_PATH}`, {
+      method: "POST",
+      headers: { Authorization: "Bearer valid-legacy-session" },
+    });
+
+    const res = await makeGateway()(req, ctx);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("23");
+    expect(await res.json()).toMatchObject({ code: "renewal_verification_failed" });
   });
 
   test("null entitlement (transient Convex/cache failure) → 200 fail-open, active customers not locked out", async () => {

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -12,8 +12,8 @@
  *   - regular non-tier-gated keyed RPC and PREMIUM_RPC_PATHS: a wm_ key whose
  *     owner lacks ACTIVE apiAccess (downgraded or past validUntil) → 403,
  *     BEFORE the #3199 rate-limit block; active keys unaffected.
- *   - transient/unresolvable entitlement (getEntitlements null) → fail-OPEN
- *     (served), so a Convex/cache blip never 403s active subscribers.
+ *   - transient/unresolvable entitlement (getEntitlements null) → retryable
+ *     fail-closed 503, so a verification timeout cannot grant paid access.
  *   - PUBLIC_NO_AUTH_RPC_PATHS serve free data to everyone: the wm_ key is NOT
  *     re-validated there (no unauthenticated Convex-lookup amplification, no
  *     gating the anonymous lead forms) — served as anonymous.
@@ -277,14 +277,15 @@ describe("#4611 — expired wm_ key rejected on all route classes", () => {
     expect(await res.json()).toMatchObject({ code: "renewal_verification_failed" });
   });
 
-  test("null entitlement (transient Convex/cache failure) → 200 fail-open, active customers not locked out", async () => {
+  test("null entitlement (verification timeout/cache failure) → retryable no-store 503", async () => {
     entitlement = null;
     const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
-    // Fail-OPEN: an unresolvable entitlement is "unknown", not "denied", so a
-    // backend blip never 403s active subscribers fleet-wide. The systematic
-    // churn leak is still closed on the warm path, where the downgraded
-    // entitlement resolves and 403s (the downgraded/expired tests above).
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(await res.json()).toMatchObject({ code: "entitlement_verification_unavailable" });
+    expect(checkBurst).not.toHaveBeenCalled();
+    expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
   // --- active subscription unaffected --------------------------------------

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -74,32 +74,16 @@ let entitlement: Ent = ACTIVE;
 const requiredTiers = new Map<string, number>();
 const entitlementsByUser = new Map<string, Ent>();
 const getEntitlements = vi.fn(async (userId: string) => entitlementsByUser.get(userId) ?? entitlement);
-vi.mock("../_shared/entitlement-check", () => ({
-  getRequiredTier: (pathname: string) => requiredTiers.get(pathname) ?? null,
-  checkEntitlement: vi.fn().mockResolvedValue(null),
-  checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
-  getEntitlements: (...a: unknown[]) => getEntitlements(...a),
-  getBillingVerificationDenial: (ent: Ent, corsHeaders: Record<string, string>) => {
-    if (!ent?.billingStatus) return null;
-    const retryable = ent.billingStatus !== "subscription_lapsed";
-    return new Response(JSON.stringify({
-      error: retryable
-        ? ent.billingStatus === "renewal_verification_pending"
-          ? "Renewal verification pending"
-          : "Renewal verification failed"
-        : "Subscription lapsed",
-      code: ent.billingStatus,
-    }), {
-      status: retryable ? 503 : 403,
-      headers: {
-        "Content-Type": "application/json",
-        "X-Billing-Verification": ent.billingStatus,
-        ...(retryable ? { "Retry-After": String(ent.retryAfterSeconds ?? 5) } : {}),
-        ...corsHeaders,
-      },
-    });
-  },
-}));
+vi.mock("../_shared/entitlement-check", async (importActual) => {
+  const actual = await importActual<typeof import("../_shared/entitlement-check")>();
+  return {
+    ...actual,
+    getRequiredTier: (pathname: string) => requiredTiers.get(pathname) ?? null,
+    checkEntitlement: vi.fn().mockResolvedValue(null),
+    checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
+    getEntitlements: (...a: unknown[]) => getEntitlements(...a),
+  };
+});
 
 // --- Stub user-key validation: a valid wm_ key resolves to a userId. ---------
 const validateUserApiKey = vi.fn(async () => ({ userId: "acct_lapsed", keyId: "k1", name: "t" }));

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -74,6 +74,7 @@ let entitlement: Ent = ACTIVE;
 const requiredTiers = new Map<string, number>();
 const entitlementsByUser = new Map<string, Ent>();
 const getEntitlements = vi.fn(async (userId: string) => entitlementsByUser.get(userId) ?? entitlement);
+let entitlementBackendConfigured = true;
 vi.mock("../_shared/entitlement-check", async (importActual) => {
   const actual = await importActual<typeof import("../_shared/entitlement-check")>();
   return {
@@ -82,6 +83,7 @@ vi.mock("../_shared/entitlement-check", async (importActual) => {
     checkEntitlement: vi.fn().mockResolvedValue(null),
     checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
     getEntitlements: (...a: unknown[]) => getEntitlements(...a),
+    isEntitlementBackendConfigured: () => entitlementBackendConfigured,
   };
 });
 
@@ -156,6 +158,7 @@ beforeEach(() => {
   getEntitlements.mockClear();
   resolveClerkSession.mockClear();
   validateBearerToken.mockClear();
+  entitlementBackendConfigured = true;
   validateUserApiKey.mockClear().mockResolvedValue({ userId: "acct_lapsed", keyId: "k1", name: "t" });
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -286,6 +289,24 @@ describe("#4611 — expired wm_ key rejected on all route classes", () => {
     expect(await res.json()).toMatchObject({ code: "entitlement_verification_unavailable" });
     expect(checkBurst).not.toHaveBeenCalled();
     expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("null entitlement with UNCONFIGURED backend → fail-open 200 (deploy defect, not billing state)", async () => {
+    entitlement = null;
+    entitlementBackendConfigured = false;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+      // Missing CONVEX_SITE_URL / shared secret means NO lookup could ever
+      // succeed: 503ing here would turn a config regression into a fleet-wide
+      // outage for every wm_ key. Serve (pre-#4770 posture) and log loudly.
+      expect(res.status).toBe(200);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("entitlement backend unconfigured"),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   // --- active subscription unaffected --------------------------------------

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -251,6 +251,29 @@ describe("#4611 — expired wm_ key rejected on all route classes", () => {
     expect(await res.json()).toMatchObject({ code: "renewal_verification_pending" });
   });
 
+  test("current Pro fallback still returns retryable 503 for API-key access", async () => {
+    entitlement = {
+      planKey: "pro_monthly",
+      features: {
+        tier: 1,
+        apiAccess: false,
+        apiRateLimit: 0,
+        mcpAccess: true,
+      },
+      validUntil: Date.now() + 86_400_000,
+      billingStatus: "renewal_verification_pending",
+      retryAfterSeconds: 13,
+    };
+
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("13");
+    expect(await res.json()).toMatchObject({
+      code: "renewal_verification_pending",
+    });
+  });
+
   test("confirmed lapse on a wm_ key returns subscription_lapsed", async () => {
     entitlement = {
       planKey: "free",

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -17,6 +17,14 @@ import { getCachedJson, setCachedJson } from './redis';
 // Types
 // ---------------------------------------------------------------------------
 
+// Single source of truth for the billing-verification status union — imported
+// by api/mcp/types.ts, api/mcp/auth.ts, and api/mcp/billing-denial.ts so the
+// four surfaces cannot silently drift when a status is added.
+export type BillingVerificationStatus =
+  | 'subscription_lapsed'
+  | 'renewal_verification_pending'
+  | 'renewal_verification_failed';
+
 export interface CachedEntitlements {
   planKey: string;
   features: {
@@ -45,10 +53,7 @@ export interface CachedEntitlements {
     apiDailyAllowance?: number;
   };
   validUntil: number;
-  billingStatus?:
-    | 'subscription_lapsed'
-    | 'renewal_verification_pending'
-    | 'renewal_verification_failed';
+  billingStatus?: BillingVerificationStatus;
   retryAfterSeconds?: number;
   renewalVerificationFreshness?: {
     status: 'not_applicable';
@@ -141,10 +146,11 @@ const LAPSED_BILLING_MARKER_TTL_SECONDS = 60;
 // No-billing-history is structurally invariant while tier stays 0, and every
 // tier-changing write path unconditionally overwrites this cache key via
 // syncEntitlementCache — so a longer marker cannot delay a new subscription
-// from taking effect. 300s keeps the never-subscribed cohort (the bulk of
-// tier-0 traffic) off the action/claim path instead of re-running it every
-// minute.
-const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 300;
+// from taking effect (invariant re-audited in the fresh review round). Full
+// 900s restores pre-#4770 cache economics for the never-subscribed cohort,
+// the bulk of tier-0 traffic; short/dynamic TTLs stay reserved for the
+// genuinely uncertain lapsed/pending/failed states.
+const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 900;
 
 /**
  * True when the Convex entitlement backend is reachable in principle. Callers

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -50,6 +50,10 @@ export interface CachedEntitlements {
     | 'renewal_verification_pending'
     | 'renewal_verification_failed';
   retryAfterSeconds?: number;
+  renewalVerificationFreshness?: {
+    status: 'not_applicable';
+    checkedAt: number;
+  };
 }
 
 export interface EntitlementCheckResult {
@@ -128,6 +132,7 @@ const ENV_PREFIX = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live
 // Cache TTL: 15 min — short enough that subscription expiry is reflected promptly (P2-5)
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
 const LAPSED_BILLING_MARKER_TTL_SECONDS = 300;
+const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 60;
 
 function isBillingVerificationStatus(
   value: unknown,
@@ -146,6 +151,32 @@ function billingMarkerTtlSeconds(entitlements: CachedEntitlements): number | nul
   return Number.isFinite(retryAfter)
     ? Math.max(1, Math.min(60, Math.ceil(retryAfter!)))
     : 5;
+}
+
+function notApplicableVerificationTtlSeconds(
+  entitlements: CachedEntitlements,
+): number | null {
+  const marker = entitlements.renewalVerificationFreshness;
+  if (
+    marker?.status !== 'not_applicable'
+    || !Number.isFinite(marker.checkedAt)
+  ) {
+    return null;
+  }
+  const remainingMs = marker.checkedAt
+    + NOT_APPLICABLE_VERIFICATION_TTL_SECONDS * 1_000
+    - Date.now();
+  return remainingMs > 0
+    ? Math.max(1, Math.min(
+      NOT_APPLICABLE_VERIFICATION_TTL_SECONDS,
+      Math.ceil(remainingMs / 1_000),
+    ))
+    : null;
+}
+
+function entitlementMarkerTtlSeconds(entitlements: CachedEntitlements): number | null {
+  return billingMarkerTtlSeconds(entitlements)
+    ?? notApplicableVerificationTtlSeconds(entitlements);
 }
 
 // ---------------------------------------------------------------------------
@@ -192,7 +223,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
       // Verification markers have their own short Redis TTL. Serve them even
       // though validUntil is expired so cooldown requests stop at Redis instead
       // of repeating the Convex action/claim chain.
-      if (billingMarkerTtlSeconds(ent) !== null) return ent;
+      if (entitlementMarkerTtlSeconds(ent) !== null) return ent;
       // Only use cached data if it hasn't expired AND has the post-U10 shape.
       //
       // Legacy cache entries written before plan 2026-05-10-001 U10 lack the
@@ -250,7 +281,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
         await setCachedJson(
           `entitlements:${ENV_PREFIX}:${userId}`,
           result,
-          billingMarkerTtlSeconds(result) ?? ENTITLEMENT_CACHE_TTL_SECONDS,
+          entitlementMarkerTtlSeconds(result) ?? ENTITLEMENT_CACHE_TTL_SECONDS,
           true,
         );
       } catch (cacheErr) {

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -134,6 +134,12 @@ const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
 const LAPSED_BILLING_MARKER_TTL_SECONDS = 300;
 const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 60;
 
+function clampRetryAfterSeconds(raw: number | undefined): number {
+  return Number.isFinite(raw)
+    ? Math.max(1, Math.min(60, Math.ceil(raw!)))
+    : 5;
+}
+
 function isBillingVerificationStatus(
   value: unknown,
 ): value is NonNullable<CachedEntitlements['billingStatus']> {
@@ -147,10 +153,7 @@ function billingMarkerTtlSeconds(entitlements: CachedEntitlements): number | nul
   if (entitlements.billingStatus === 'subscription_lapsed') {
     return LAPSED_BILLING_MARKER_TTL_SECONDS;
   }
-  const retryAfter = entitlements.retryAfterSeconds;
-  return Number.isFinite(retryAfter)
-    ? Math.max(1, Math.min(60, Math.ceil(retryAfter!)))
-    : 5;
+  return clampRetryAfterSeconds(entitlements.retryAfterSeconds);
 }
 
 function notApplicableVerificationTtlSeconds(
@@ -304,7 +307,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
  * provider outage is never flattened into a misleading "upgrade required".
  */
 export function getBillingVerificationDenial(
-  entitlements: CachedEntitlements | null | undefined,
+  entitlements: Pick<CachedEntitlements, 'billingStatus' | 'retryAfterSeconds'> | null | undefined,
   corsHeaders: Record<string, string>,
   requiredTier?: number,
 ): Response | null {
@@ -330,10 +333,7 @@ export function getBillingVerificationDenial(
     );
   }
 
-  const rawRetryAfter = entitlements?.retryAfterSeconds;
-  const retryAfter = Number.isFinite(rawRetryAfter)
-    ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter!)))
-    : 5;
+  const retryAfter = clampRetryAfterSeconds(entitlements?.retryAfterSeconds);
   return new Response(
     JSON.stringify({
       error: status === 'renewal_verification_pending'

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -131,8 +131,30 @@ const ENV_PREFIX = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live
 
 // Cache TTL: 15 min — short enough that subscription expiry is reflected promptly (P2-5)
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
-const LAPSED_BILLING_MARKER_TTL_SECONDS = 300;
-const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 60;
+// Hard-403 markers are served for their FULL Redis TTL with no Convex
+// fallback, so this TTL is also the worst-case wrongful-denial window when a
+// stale marker write races a renewal webhook. Keep it short: the row-level
+// 5-min lapsed cooldown (billing.ts) already suppresses Dodo calls, so the
+// only cost of a short marker is ~1 cheap Convex round-trip per minute per
+// actively-retrying lapsed user.
+const LAPSED_BILLING_MARKER_TTL_SECONDS = 60;
+// No-billing-history is structurally invariant while tier stays 0, and every
+// tier-changing write path unconditionally overwrites this cache key via
+// syncEntitlementCache — so a longer marker cannot delay a new subscription
+// from taking effect. 300s keeps the never-subscribed cohort (the bulk of
+// tier-0 traffic) off the action/claim path instead of re-running it every
+// minute.
+const NOT_APPLICABLE_VERIFICATION_TTL_SECONDS = 300;
+
+/**
+ * True when the Convex entitlement backend is reachable in principle. Callers
+ * that fail closed on a null entitlement use this to distinguish a genuine
+ * verification failure (fail closed) from a deploy misconfiguration where no
+ * lookup could ever succeed (fail open + page).
+ */
+export function isEntitlementBackendConfigured(): boolean {
+  return Boolean(process.env.CONVEX_SITE_URL && getConvexSharedSecret());
+}
 
 function clampRetryAfterSeconds(raw: number | undefined): number {
   return Number.isFinite(raw)

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -127,6 +127,26 @@ const ENV_PREFIX = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live
 
 // Cache TTL: 15 min — short enough that subscription expiry is reflected promptly (P2-5)
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
+const LAPSED_BILLING_MARKER_TTL_SECONDS = 300;
+
+function isBillingVerificationStatus(
+  value: unknown,
+): value is NonNullable<CachedEntitlements['billingStatus']> {
+  return value === 'subscription_lapsed'
+    || value === 'renewal_verification_pending'
+    || value === 'renewal_verification_failed';
+}
+
+function billingMarkerTtlSeconds(entitlements: CachedEntitlements): number | null {
+  if (!isBillingVerificationStatus(entitlements.billingStatus)) return null;
+  if (entitlements.billingStatus === 'subscription_lapsed') {
+    return LAPSED_BILLING_MARKER_TTL_SECONDS;
+  }
+  const retryAfter = entitlements.retryAfterSeconds;
+  return Number.isFinite(retryAfter)
+    ? Math.max(1, Math.min(60, Math.ceil(retryAfter!)))
+    : 5;
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -169,6 +189,10 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
 
     if (cached && typeof cached === 'object') {
       const ent = cached as CachedEntitlements;
+      // Verification markers have their own short Redis TTL. Serve them even
+      // though validUntil is expired so cooldown requests stop at Redis instead
+      // of repeating the Convex action/claim chain.
+      if (billingMarkerTtlSeconds(ent) !== null) return ent;
       // Only use cached data if it hasn't expired AND has the post-U10 shape.
       //
       // Legacy cache entries written before plan 2026-05-10-001 U10 lack the
@@ -223,7 +247,12 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
       // very call paths this file gates — the same shape PR #3505 fixed for the
       // Clerk-only-no-Convex outlier in api/widget-agent.ts.
       try {
-        await setCachedJson(`entitlements:${ENV_PREFIX}:${userId}`, result, ENTITLEMENT_CACHE_TTL_SECONDS, true);
+        await setCachedJson(
+          `entitlements:${ENV_PREFIX}:${userId}`,
+          result,
+          billingMarkerTtlSeconds(result) ?? ENTITLEMENT_CACHE_TTL_SECONDS,
+          true,
+        );
       } catch (cacheErr) {
         console.warn('[entitlement-check] cache write failed (non-fatal):', cacheErr instanceof Error ? cacheErr.message : String(cacheErr));
       }
@@ -249,7 +278,7 @@ export function getBillingVerificationDenial(
   requiredTier?: number,
 ): Response | null {
   const status = entitlements?.billingStatus;
-  if (!status) return null;
+  if (!isBillingVerificationStatus(status)) return null;
 
   const commonHeaders = {
     'Content-Type': 'application/json',
@@ -270,7 +299,7 @@ export function getBillingVerificationDenial(
     );
   }
 
-  const rawRetryAfter = entitlements.retryAfterSeconds;
+  const rawRetryAfter = entitlements?.retryAfterSeconds;
   const retryAfter = Number.isFinite(rawRetryAfter)
     ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter!)))
     : 5;

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -45,6 +45,11 @@ export interface CachedEntitlements {
     apiDailyAllowance?: number;
   };
   validUntil: number;
+  billingStatus?:
+    | 'subscription_lapsed'
+    | 'renewal_verification_pending'
+    | 'renewal_verification_failed';
+  retryAfterSeconds?: number;
 }
 
 export interface EntitlementCheckResult {
@@ -234,6 +239,57 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
 }
 
 /**
+ * Turns Convex's billing-verification metadata into the shared gateway denial
+ * contract. Callers use this before their ordinary tier/feature checks so a
+ * provider outage is never flattened into a misleading "upgrade required".
+ */
+export function getBillingVerificationDenial(
+  entitlements: CachedEntitlements | null | undefined,
+  corsHeaders: Record<string, string>,
+  requiredTier?: number,
+): Response | null {
+  const status = entitlements?.billingStatus;
+  if (!status) return null;
+
+  const commonHeaders = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    'X-Billing-Verification': status,
+    ...corsHeaders,
+  };
+  const requiredTierBody = requiredTier == null ? {} : { requiredTier };
+
+  if (status === 'subscription_lapsed') {
+    return new Response(
+      JSON.stringify({
+        error: 'Subscription lapsed',
+        code: status,
+        ...requiredTierBody,
+      }),
+      { status: 403, headers: commonHeaders },
+    );
+  }
+
+  const rawRetryAfter = entitlements.retryAfterSeconds;
+  const retryAfter = Number.isFinite(rawRetryAfter)
+    ? Math.max(1, Math.min(60, Math.ceil(rawRetryAfter!)))
+    : 5;
+  return new Response(
+    JSON.stringify({
+      error: status === 'renewal_verification_pending'
+        ? 'Renewal verification pending'
+        : 'Renewal verification failed',
+      code: status,
+      ...requiredTierBody,
+    }),
+    {
+      status: 503,
+      headers: { ...commonHeaders, 'Retry-After': String(retryAfter) },
+    },
+  );
+}
+
+/**
  * Checks whether the current request is allowed based on tier entitlements.
  *
  * Returns:
@@ -295,6 +351,11 @@ export async function checkEntitlementDetailed(
       ),
       entitlements: null,
     };
+  }
+
+  const billingDenial = getBillingVerificationDenial(ent, corsHeaders, requiredTier);
+  if (billingDenial) {
+    return { response: billingDenial, entitlements: ent };
   }
 
   if (ent.features.tier >= requiredTier) {

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -441,14 +441,20 @@ export async function checkEntitlementDetailed(
     };
   }
 
+  // A stronger recently-stale subscription can be under verification while a
+  // lower plan still provides current, known-good coverage. Let that fallback
+  // authorize requests within its tier; the billing marker remains relevant
+  // only to capabilities above the fallback.
+  if (
+    ent.features.tier >= requiredTier &&
+    ent.validUntil >= Date.now()
+  ) {
+    return { response: null, entitlements: ent };
+  }
+
   const billingDenial = getBillingVerificationDenial(ent, corsHeaders, requiredTier);
   if (billingDenial) {
     return { response: billingDenial, entitlements: ent };
-  }
-
-  if (ent.features.tier >= requiredTier) {
-    // User has sufficient tier -- allow
-    return { response: null, entitlements: ent };
   }
 
   // User lacks required tier -- return 403

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -70,6 +70,7 @@ export type RequestReason =
   | 'auth_401'
   | 'auth_403'
   | 'tier_403'
+  | 'billing_verification_503'
   // F8/F14 (U7+U8 review pass): body-buffer / payload-size rejections.
   // Distinct from auth_401 so telemetry separates malformed requests
   // from auth failures.

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1244,6 +1244,7 @@ export function createDomainGateway(
                 'Content-Type': 'application/json',
                 'Cache-Control': 'no-store',
                 'Retry-After': '5',
+                'X-Billing-Verification': 'entitlement_verification_unavailable',
               },
             },
           );

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -730,6 +730,21 @@ export function createDomainGateway(
     // volume signal Phase-2 pricing reuses isn't double-counted. Overrides only
     // a successful terminal reason (status < 400); a real 4xx/5xx outcome wins.
     let pendingShadowReason: RequestReason | null = null;
+    // Shared emit+return for the three billing-verification denial sites below
+    // (internal-MCP re-check, wm_ key, legacy bearer).
+    function denyForBillingVerification(
+      ent: CachedEntitlements | null | undefined,
+      cors: Record<string, string>,
+    ): Response | null {
+      const billingDenial = getBillingVerificationDenial(ent, cors);
+      if (!billingDenial) return null;
+      emitRequest(
+        billingDenial.status,
+        billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
+        null,
+      );
+      return billingDenial;
+    }
     function emitRequest(status: number, reason: RequestReason, cacheTier: UsageCacheTier | null, resBytes = 0): void {
       if (!ctx?.waitUntil) return;
       const effectiveReason: RequestReason =
@@ -1021,15 +1036,8 @@ export function createDomainGateway(
       // re-check via the fallback path. Mirror the per-handler runProPreChecks
       // and authorize-pro entitlement guards.
       const ent = await getEntitlements(verified.userId);
-      const billingDenial = getBillingVerificationDenial(ent, corsHeaders);
-      if (billingDenial) {
-        emitRequest(
-          billingDenial.status,
-          billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
-          null,
-        );
-        return billingDenial;
-      }
+      const billingDenial = denyForBillingVerification(ent, corsHeaders);
+      if (billingDenial) return billingDenial;
       if (
         !ent ||
         ent.features.tier < 1 ||
@@ -1210,15 +1218,8 @@ export function createDomainGateway(
     if (isUserApiKey && sessionUserId) {
       userKeyEntitlement = await getEntitlements(sessionUserId);
       recordUsageEntitlement(userKeyEntitlement);
-      const billingDenial = getBillingVerificationDenial(userKeyEntitlement, corsHeaders);
-      if (billingDenial) {
-        emitRequest(
-          billingDenial.status,
-          billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
-          null,
-        );
-        return billingDenial;
-      }
+      const billingDenial = denyForBillingVerification(userKeyEntitlement, corsHeaders);
+      if (billingDenial) return billingDenial;
       // A validated wm_ key proves key ownership, not current paid access.
       // getEntitlements() returns null for a missing row and for bounded
       // verification failures/timeouts, so allowing null would turn a billing
@@ -1293,15 +1294,8 @@ export function createDomainGateway(
           if (!allowed && session.userId) {
             const ent = await getEntitlements(session.userId);
             recordUsageEntitlement(ent);
-            const billingDenial = getBillingVerificationDenial(ent, corsHeaders);
-            if (billingDenial) {
-              emitRequest(
-                billingDenial.status,
-                billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
-                null,
-              );
-              return billingDenial;
-            }
+            const billingDenial = denyForBillingVerification(ent, corsHeaders);
+            if (billingDenial) return billingDenial;
             allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
           }
           if (!allowed) {

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -28,7 +28,13 @@ import {
 import { drainResponseHeaders, drainSuccessStatusOverride } from './_shared/response-headers';
 import { projectJsonResponse } from './_shared/response-projection';
 import { getRpcNoStoreReasonFromJson } from './_shared/cache-contract';
-import { checkEntitlementDetailed, getRequiredTier, getEntitlements, type CachedEntitlements } from './_shared/entitlement-check';
+import {
+  checkEntitlementDetailed,
+  getBillingVerificationDenial,
+  getRequiredTier,
+  getEntitlements,
+  type CachedEntitlements,
+} from './_shared/entitlement-check';
 import { resolveClerkSession } from './_shared/auth-session';
 import {
   INTERNAL_MCP_SIG_HEADER,
@@ -1195,6 +1201,15 @@ export function createDomainGateway(
     if (isUserApiKey && sessionUserId) {
       userKeyEntitlement = await getEntitlements(sessionUserId);
       recordUsageEntitlement(userKeyEntitlement);
+      const billingDenial = getBillingVerificationDenial(userKeyEntitlement, corsHeaders);
+      if (billingDenial) {
+        emitRequest(
+          billingDenial.status,
+          billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
+          null,
+        );
+        return billingDenial;
+      }
       // Fail-OPEN on an unresolved entitlement (null ⇒ transient Convex/cache
       // failure, indistinguishable from "no row"): mirrors the #3199 block below
       // and avoids 403-ing an ACTIVE subscriber fleet-wide during a backend
@@ -1253,6 +1268,15 @@ export function createDomainGateway(
           if (!allowed && session.userId) {
             const ent = await getEntitlements(session.userId);
             recordUsageEntitlement(ent);
+            const billingDenial = getBillingVerificationDenial(ent, corsHeaders);
+            if (billingDenial) {
+              emitRequest(
+                billingDenial.status,
+                billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
+                null,
+              );
+              return billingDenial;
+            }
             allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
           }
           if (!allowed) {
@@ -1291,6 +1315,7 @@ export function createDomainGateway(
         const entReason: RequestReason =
           entitlementResponse.status === 401 ? 'auth_401'
           : entitlementResponse.status === 403 ? 'tier_403'
+          : entitlementResponse.status === 503 ? 'billing_verification_503'
           : 'ok';
         emitRequest(entitlementResponse.status, entReason, null);
         return entitlementResponse.status === 401 || entitlementResponse.status === 403

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1021,6 +1021,15 @@ export function createDomainGateway(
       // re-check via the fallback path. Mirror the per-handler runProPreChecks
       // and authorize-pro entitlement guards.
       const ent = await getEntitlements(verified.userId);
+      const billingDenial = getBillingVerificationDenial(ent, corsHeaders);
+      if (billingDenial) {
+        emitRequest(
+          billingDenial.status,
+          billingDenial.status === 503 ? 'billing_verification_503' : 'tier_403',
+          null,
+        );
+        return billingDenial;
+      }
       if (
         !ent ||
         ent.features.tier < 1 ||
@@ -1210,16 +1219,32 @@ export function createDomainGateway(
         );
         return billingDenial;
       }
-      // Fail-OPEN on an unresolved entitlement (null ⇒ transient Convex/cache
-      // failure, indistinguishable from "no row"): mirrors the #3199 block below
-      // and avoids 403-ing an ACTIVE subscriber fleet-wide during a backend
-      // blip. Reject only on an AFFIRMATIVELY inactive/expired entitlement — the
-      // systematic churn case (#4611), always resolvable under normal operation
-      // (the warm 15-min entitlement cache closes the leak; an outage degrades
-      // to prior behavior rather than denying paying customers).
+      // A validated wm_ key proves key ownership, not current paid access.
+      // getEntitlements() returns null for a missing row and for bounded
+      // verification failures/timeouts, so allowing null would turn a billing
+      // backend timeout into paid API access. Fail closed with a retryable 503;
+      // only an affirmative, current apiAccess entitlement may proceed.
+      if (!userKeyEntitlement) {
+        emitRequest(503, 'billing_verification_503', null);
+        return new Response(
+          JSON.stringify({
+            error: 'Unable to verify API access',
+            code: 'entitlement_verification_unavailable',
+          }),
+          {
+            status: 503,
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json',
+              'Cache-Control': 'no-store',
+              'Retry-After': '5',
+            },
+          },
+        );
+      }
       if (
-        userKeyEntitlement &&
-        (!userKeyEntitlement.features.apiAccess || userKeyEntitlement.validUntil < Date.now())
+        !userKeyEntitlement.features.apiAccess ||
+        userKeyEntitlement.validUntil < Date.now()
       ) {
         emitRequest(403, 'tier_403', null);
         return createGatewayAuthErrorResponse(

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -33,6 +33,7 @@ import {
   getBillingVerificationDenial,
   getRequiredTier,
   getEntitlements,
+  isEntitlementBackendConfigured,
   type CachedEntitlements,
 } from './_shared/entitlement-check';
 import { resolveClerkSession } from './_shared/auth-session';
@@ -1223,27 +1224,34 @@ export function createDomainGateway(
       // A validated wm_ key proves key ownership, not current paid access.
       // getEntitlements() returns null for a missing row and for bounded
       // verification failures/timeouts, so allowing null would turn a billing
-      // backend timeout into paid API access. Fail closed with a retryable 503;
-      // only an affirmative, current apiAccess entitlement may proceed.
+      // backend timeout into paid API access. Fail closed with a retryable 503
+      // — EXCEPT when the entitlement backend itself is unconfigured: that is
+      // a deploy defect, not customer billing state, and 503ing every wm_ key
+      // fleet-wide would convert a config regression into a total API outage.
+      // Misconfig serves fail-open (pre-#4770 behavior) and logs loudly.
       if (!userKeyEntitlement) {
-        emitRequest(503, 'billing_verification_503', null);
-        return new Response(
-          JSON.stringify({
-            error: 'Unable to verify API access',
-            code: 'entitlement_verification_unavailable',
-          }),
-          {
-            status: 503,
-            headers: {
-              ...corsHeaders,
-              'Content-Type': 'application/json',
-              'Cache-Control': 'no-store',
-              'Retry-After': '5',
+        if (isEntitlementBackendConfigured()) {
+          emitRequest(503, 'billing_verification_503', null);
+          return new Response(
+            JSON.stringify({
+              error: 'Unable to verify API access',
+              code: 'entitlement_verification_unavailable',
+            }),
+            {
+              status: 503,
+              headers: {
+                ...corsHeaders,
+                'Content-Type': 'application/json',
+                'Cache-Control': 'no-store',
+                'Retry-After': '5',
+              },
             },
-          },
+          );
+        }
+        console.error(
+          '[gateway] entitlement backend unconfigured (CONVEX_SITE_URL / shared secret missing) — serving wm_-key request fail-open',
         );
-      }
-      if (
+      } else if (
         !userKeyEntitlement.features.apiAccess ||
         userKeyEntitlement.validUntil < Date.now()
       ) {

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -736,7 +736,9 @@ export function createDomainGateway(
     function denyForBillingVerification(
       ent: CachedEntitlements | null | undefined,
       cors: Record<string, string>,
+      capabilityCovered = false,
     ): Response | null {
+      if (capabilityCovered) return null;
       const billingDenial = getBillingVerificationDenial(ent, cors);
       if (!billingDenial) return null;
       emitRequest(
@@ -1037,7 +1039,15 @@ export function createDomainGateway(
       // re-check via the fallback path. Mirror the per-handler runProPreChecks
       // and authorize-pro entitlement guards.
       const ent = await getEntitlements(verified.userId);
-      const billingDenial = denyForBillingVerification(ent, corsHeaders);
+      const mcpCovered = !!ent &&
+        ent.features.tier >= 1 &&
+        (ent.features as { mcpAccess?: boolean }).mcpAccess === true &&
+        ent.validUntil >= Date.now();
+      const billingDenial = denyForBillingVerification(
+        ent,
+        corsHeaders,
+        mcpCovered,
+      );
       if (billingDenial) return billingDenial;
       if (
         !ent ||
@@ -1219,7 +1229,14 @@ export function createDomainGateway(
     if (isUserApiKey && sessionUserId) {
       userKeyEntitlement = await getEntitlements(sessionUserId);
       recordUsageEntitlement(userKeyEntitlement);
-      const billingDenial = denyForBillingVerification(userKeyEntitlement, corsHeaders);
+      const apiAccessCovered = !!userKeyEntitlement &&
+        userKeyEntitlement.features.apiAccess &&
+        userKeyEntitlement.validUntil >= Date.now();
+      const billingDenial = denyForBillingVerification(
+        userKeyEntitlement,
+        corsHeaders,
+        apiAccessCovered,
+      );
       if (billingDenial) return billingDenial;
       // A validated wm_ key proves key ownership, not current paid access.
       // getEntitlements() returns null for a missing row and for bounded
@@ -1303,7 +1320,14 @@ export function createDomainGateway(
           if (!allowed && session.userId) {
             const ent = await getEntitlements(session.userId);
             recordUsageEntitlement(ent);
-            const billingDenial = denyForBillingVerification(ent, corsHeaders);
+            const proCovered = !!ent &&
+              ent.features.tier >= 1 &&
+              ent.validUntil >= Date.now();
+            const billingDenial = denyForBillingVerification(
+              ent,
+              corsHeaders,
+              proCovered,
+            );
             if (billingDenial) return billingDenial;
             allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
           }

--- a/tests/billing-marker-ttl-parity.test.mjs
+++ b/tests/billing-marker-ttl-parity.test.mjs
@@ -42,3 +42,20 @@ test('Retry-After clamp bounds match across the TS/JS mirror', () => {
     );
   }
 });
+
+test('Retry-After fallback default matches across the TS/JS mirror', () => {
+  const ts = read('server/_shared/entitlement-check.ts');
+  const js = read('api/_user-api-key.js');
+
+  // The TS clampRetryAfterSeconds falls back to a hardcoded literal while the
+  // JS mirror falls back to VALIDATION_RETRY_AFTER_SECONDS — previously
+  // unpinned, so the two surfaces could quote different Retry-After hints for
+  // the same failure without any test going red.
+  const tsFallback = ts.match(/function clampRetryAfterSeconds[\s\S]*?:\s*(\d+);\n\}/);
+  assert.ok(tsFallback, 'clampRetryAfterSeconds fallback literal not found in entitlement-check.ts');
+  assert.equal(
+    Number(tsFallback[1]),
+    constant(js, '_user-api-key.js', 'VALIDATION_RETRY_AFTER_SECONDS'),
+    'Retry-After fallback default drifted between entitlement-check.ts and _user-api-key.js',
+  );
+});

--- a/tests/billing-marker-ttl-parity.test.mjs
+++ b/tests/billing-marker-ttl-parity.test.mjs
@@ -1,0 +1,44 @@
+// Pins the intentionally-duplicated billing marker TTL constants and the
+// Retry-After clamp bounds between server/_shared/entitlement-check.ts (TS,
+// gateway/session surfaces) and api/_user-api-key.js (plain JS, bootstrap
+// surface — cannot import the TS module under node --test). A unilateral edit
+// to either copy desyncs the denial contract between surfaces; this test
+// makes that drift red instead of silent.
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const read = (rel) => readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+
+function constant(src, file, name) {
+  const match = src.match(new RegExp(`const ${name} = (\\d+);`));
+  assert.ok(match, `${name} not found in ${file}`);
+  return Number(match[1]);
+}
+
+test('billing marker TTL constants stay identical across the TS/JS mirror', () => {
+  const ts = read('server/_shared/entitlement-check.ts');
+  const js = read('api/_user-api-key.js');
+
+  for (const name of [
+    'LAPSED_BILLING_MARKER_TTL_SECONDS',
+    'NOT_APPLICABLE_VERIFICATION_TTL_SECONDS',
+    'ENTITLEMENT_CACHE_TTL_SECONDS',
+  ]) {
+    assert.equal(
+      constant(ts, 'entitlement-check.ts', name),
+      constant(js, '_user-api-key.js', name),
+      `${name} drifted between entitlement-check.ts and _user-api-key.js`,
+    );
+  }
+});
+
+test('Retry-After clamp bounds match across the TS/JS mirror', () => {
+  for (const rel of ['server/_shared/entitlement-check.ts', 'api/_user-api-key.js']) {
+    assert.match(
+      read(rel),
+      /Math\.max\(1, Math\.min\(60,/,
+      `${rel} lost the [1,60] Retry-After clamp`,
+    );
+  }
+});

--- a/tests/convex-http-json-object-guard.test.mjs
+++ b/tests/convex-http-json-object-guard.test.mjs
@@ -42,7 +42,20 @@ describe('convex/http JSON object body guard', () => {
       assert.notEqual(routeStart, -1, `missing ${path} route`);
       const nextRoute = source.indexOf('http.route({', routeStart + 1);
       const route = source.slice(routeStart, nextRoute === -1 ? undefined : nextRoute);
-      assert.match(route, /parseJsonObjectBody[\s\S]*?\(request\)/, `${path} bypasses object guard`);
+      const namedHandler = route.match(/handler:\s*httpAction\(([A-Za-z0-9_]+)\)/)?.[1];
+      let guardSurface = route;
+      if (namedHandler) {
+        const handlerStart = source.indexOf(`function ${namedHandler}`);
+        assert.notEqual(handlerStart, -1, `missing ${namedHandler} implementation for ${path}`);
+        const handlerEnd = source.indexOf('\n}\n', handlerStart);
+        assert.notEqual(handlerEnd, -1, `could not bound ${namedHandler} implementation for ${path}`);
+        guardSurface += source.slice(handlerStart, handlerEnd + 2);
+      }
+      assert.match(
+        guardSurface,
+        /parseJsonObjectBody[\s\S]*?\(request\)/,
+        `${path} bypasses object guard`,
+      );
     }
   });
 });

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -1012,6 +1012,59 @@ describe('gateway internal-MCP — F1: validUntil re-check', () => {
   });
 });
 
+describe('gateway internal-MCP — billing renewal verification', () => {
+  for (const billingStatus of ['renewal_verification_pending', 'renewal_verification_failed']) {
+    it(`${billingStatus} → retryable no-store 503`, async () => {
+      installFetchStub({
+        entitlement: () => ({
+          planKey: 'free',
+          features: {
+            tier: 0, apiAccess: false, apiRateLimit: 0, maxDashboards: 1,
+            prioritySupport: false, exportFormats: [], mcpAccess: false,
+          },
+          validUntil: 0,
+          billingStatus,
+          retryAfterSeconds: 17,
+        }),
+      });
+      const handler = makeGateway();
+      const req = await buildSignedRequest();
+      const res = await handler(req);
+
+      assert.equal(res.status, 503);
+      assert.equal(res.headers.get('Cache-Control'), 'no-store');
+      assert.equal(res.headers.get('Retry-After'), '17');
+      assert.equal(res.headers.get('X-Billing-Verification'), billingStatus);
+      assert.equal((await res.json()).code, billingStatus);
+      assert.equal(lastHandlerRequest, null, 'handler must not run while renewal verification is unresolved');
+    });
+  }
+
+  it('subscription_lapsed → distinct hard denial', async () => {
+    installFetchStub({
+      entitlement: () => ({
+        planKey: 'free',
+        features: {
+          tier: 0, apiAccess: false, apiRateLimit: 0, maxDashboards: 1,
+          prioritySupport: false, exportFormats: [], mcpAccess: false,
+        },
+        validUntil: 0,
+        billingStatus: 'subscription_lapsed',
+      }),
+    });
+    const handler = makeGateway();
+    const req = await buildSignedRequest();
+    const res = await handler(req);
+
+    assert.equal(res.status, 403);
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.equal(res.headers.get('Retry-After'), null);
+    assert.equal(res.headers.get('X-Billing-Verification'), 'subscription_lapsed');
+    assert.equal((await res.json()).code, 'subscription_lapsed');
+    assert.equal(lastHandlerRequest, null, 'handler must not run after a confirmed lapse');
+  });
+});
+
 describe('gateway internal-MCP — F7: HMAC headers stripped before handler sees request', () => {
   it('handler receives no X-WM-MCP-Internal or X-WM-MCP-User-Id; only the trusted-marker pair', async () => {
     const handler = makeGateway();

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -1040,6 +1040,27 @@ describe('gateway internal-MCP — billing renewal verification', () => {
     });
   }
 
+  it('current Pro fallback remains usable while stronger renewal verification is pending', async () => {
+    installFetchStub({
+      entitlement: () => ({
+        planKey: 'pro_monthly',
+        features: {
+          tier: 1, apiAccess: false, apiRateLimit: 0, maxDashboards: 10,
+          prioritySupport: false, exportFormats: ['csv'], mcpAccess: true,
+        },
+        validUntil: Date.now() + 86_400_000,
+        billingStatus: 'renewal_verification_pending',
+        retryAfterSeconds: 17,
+      }),
+    });
+    const handler = makeGateway();
+    const req = await buildSignedRequest();
+    const res = await handler(req);
+
+    assert.equal(res.status, 200);
+    assert.notEqual(lastHandlerRequest, null, 'covered MCP request must reach the handler');
+  });
+
   it('subscription_lapsed → distinct hard denial', async () => {
     installFetchStub({
       entitlement: () => ({

--- a/tests/mcp-billing-denial.test.mjs
+++ b/tests/mcp-billing-denial.test.mjs
@@ -50,11 +50,23 @@ describe('billing-denial propagation helpers', () => {
     );
   });
 
-  it('entitlement_verification_unavailable is not a tool-level typed denial', () => {
-    // That code is wm_-key-surface-only; tool fetches sign with internal-MCP
-    // HMAC and must treat it as an ordinary retryable failure.
-    const res = response(503, { 'X-Billing-Verification': 'entitlement_verification_unavailable' });
-    throwIfBillingDenial(res, 'tool');
+  it('entitlement_verification_unavailable throws a typed retryable denial', () => {
+    // env_key/user_key tool fetches sign with X-WorldMonitor-Key (api/mcp/auth.ts
+    // buildAuthHeaders), so the gateway's backend-unreachable 503 reaches this
+    // layer and must keep its billing contract instead of flattening into the
+    // generic -32603 at HTTP 200.
+    const res = response(503, {
+      'X-Billing-Verification': 'entitlement_verification_unavailable',
+      'Retry-After': '5',
+    });
+    assert.throws(
+      () => throwIfBillingDenial(res, 'tool'),
+      (err) =>
+        err instanceof BillingDenialError &&
+        err.status === 503 &&
+        err.billingCode === 'entitlement_verification_unavailable' &&
+        err.retryAfterSeconds === 5,
+    );
   });
 
   it('tolerates test doubles without a headers object', () => {

--- a/tests/mcp-billing-denial.test.mjs
+++ b/tests/mcp-billing-denial.test.mjs
@@ -1,0 +1,87 @@
+// Unit tests for api/mcp/billing-denial.ts — the typed propagation layer that
+// keeps gateway billing denials from flattening into generic -32603 errors.
+// Locks the allowlist boundary (unknown marker values must NOT become typed
+// denials) and the structural-Response tolerances the module documents.
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  assertToolFetchOk,
+  BillingDenialError,
+  throwIfBillingDenial,
+} from '../api/mcp/billing-denial.ts';
+
+function response(status, headerMap = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name) => headerMap[name] ?? null },
+  };
+}
+
+describe('billing-denial propagation helpers', () => {
+  it('does nothing on an OK response, even with a billing header present', () => {
+    const res = response(200, { 'X-Billing-Verification': 'subscription_lapsed' });
+    throwIfBillingDenial(res, 'tool');
+    assertToolFetchOk(res, 'tool');
+  });
+
+  it('throws a typed denial carrying status, code, and Retry-After', () => {
+    const res = response(503, {
+      'X-Billing-Verification': 'renewal_verification_pending',
+      'Retry-After': '21',
+    });
+    assert.throws(
+      () => throwIfBillingDenial(res, 'tool'),
+      (err) =>
+        err instanceof BillingDenialError &&
+        err.status === 503 &&
+        err.billingCode === 'renewal_verification_pending' &&
+        err.retryAfterSeconds === 21 &&
+        /tool HTTP 503/.test(err.message),
+    );
+  });
+
+  it('an UNKNOWN marker value falls through to the generic Error, never a typed denial', () => {
+    const res = response(503, { 'X-Billing-Verification': 'grant_everything' });
+    throwIfBillingDenial(res, 'tool');
+    assert.throws(
+      () => assertToolFetchOk(res, 'tool'),
+      (err) => !(err instanceof BillingDenialError) && err.message === 'tool HTTP 503',
+    );
+  });
+
+  it('entitlement_verification_unavailable is not a tool-level typed denial', () => {
+    // That code is wm_-key-surface-only; tool fetches sign with internal-MCP
+    // HMAC and must treat it as an ordinary retryable failure.
+    const res = response(503, { 'X-Billing-Verification': 'entitlement_verification_unavailable' });
+    throwIfBillingDenial(res, 'tool');
+  });
+
+  it('tolerates test doubles without a headers object', () => {
+    const bare = { ok: false, status: 503 };
+    throwIfBillingDenial(bare, 'tool');
+    assert.throws(
+      () => assertToolFetchOk(bare, 'tool'),
+      (err) => !(err instanceof BillingDenialError) && err.message === 'tool HTTP 503',
+    );
+  });
+
+  it('missing Retry-After yields undefined, not 0', () => {
+    const res = response(403, { 'X-Billing-Verification': 'subscription_lapsed' });
+    assert.throws(
+      () => throwIfBillingDenial(res, 'tool'),
+      (err) => err instanceof BillingDenialError && err.retryAfterSeconds === undefined,
+    );
+  });
+
+  it('a non-numeric Retry-After yields undefined', () => {
+    const res = response(503, {
+      'X-Billing-Verification': 'renewal_verification_failed',
+      'Retry-After': 'Wed, 21 Oct 2026 07:28:00 GMT',
+    });
+    assert.throws(
+      () => throwIfBillingDenial(res, 'tool'),
+      (err) => err instanceof BillingDenialError && err.retryAfterSeconds === undefined,
+    );
+  });
+});

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2929,6 +2929,36 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     }
   });
 
+  it('error: mid-call backend-unreachable 503 keeps the entitlement_verification_unavailable contract', async () => {
+    const { deps } = makeProDeps();
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({ error: 'Unable to verify API access', code: 'entitlement_verification_unavailable' }),
+      {
+        status: 503,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'Retry-After': '5',
+          'X-Billing-Verification': 'entitlement_verification_unavailable',
+        },
+      },
+    );
+    try {
+      const res = await mcpHandler(proReq('POST', callBody('get_country_risk', { country_code: 'US' })), deps);
+
+      assert.equal(res.status, 503);
+      assert.equal(res.headers.get('Retry-After'), '5');
+      assert.equal(res.headers.get('Cache-Control'), 'no-store');
+      assert.equal(res.headers.get('X-Billing-Verification'), 'entitlement_verification_unavailable');
+      const body = await res.json();
+      assert.equal(body.error?.code, -32603);
+      assert.equal(body.error?.data?.code, 'entitlement_verification_unavailable');
+      assert.equal(body.id, 100);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('error: mid-call confirmed lapse from the gateway surfaces -32002 + 403', async () => {
     const { deps } = makeProDeps();
     globalThis.fetch = async () => new Response(

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2831,9 +2831,76 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.equal(res.headers.get('X-Billing-Verification'), 'subscription_lapsed');
     const body = await res.json();
     assert.equal(body.jsonrpc, '2.0');
-    assert.equal(body.error?.code, -32001);
+    // -32002, NOT -32001: the catalog reserves -32001 for HTTP 401 auth
+    // failures with OAuth-reauth recovery; a confirmed lapse cannot be fixed
+    // by re-authenticating.
+    assert.equal(body.error?.code, -32002);
     assert.equal(body.error?.data?.code, 'subscription_lapsed');
     assert.equal(pipe.count, 0);
+  });
+
+  it('error: mid-call billing 503 from the gateway keeps its contract (no -32603 flatten)', async () => {
+    const { deps } = makeProDeps();
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({ error: 'Renewal verification pending', code: 'renewal_verification_pending' }),
+      {
+        status: 503,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'Retry-After': '21',
+          'X-Billing-Verification': 'renewal_verification_pending',
+        },
+      },
+    );
+    try {
+      const res = await mcpHandler(proReq('POST', callBody('get_country_risk', { country_code: 'US' })), deps);
+
+      assert.equal(res.status, 503);
+      assert.equal(res.headers.get('Retry-After'), '21');
+      assert.equal(res.headers.get('Cache-Control'), 'no-store');
+      assert.equal(res.headers.get('X-Billing-Verification'), 'renewal_verification_pending');
+      const body = await res.json();
+      assert.equal(body.error?.code, -32603);
+      assert.equal(body.error?.data?.code, 'renewal_verification_pending');
+      assert.equal(body.id, 100);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('error: mid-call confirmed lapse from the gateway surfaces -32002 + 403', async () => {
+    const { deps } = makeProDeps();
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({ error: 'Subscription lapsed', code: 'subscription_lapsed' }),
+      {
+        status: 403,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'X-Billing-Verification': 'subscription_lapsed',
+        },
+      },
+    );
+    try {
+      const res = await mcpHandler(proReq('POST', callBody('get_country_risk', { country_code: 'US' })), deps);
+
+      assert.equal(res.status, 403);
+      assert.equal(res.headers.get('X-Billing-Verification'), 'subscription_lapsed');
+      const body = await res.json();
+      assert.equal(body.error?.code, -32002);
+      assert.equal(body.error?.data?.code, 'subscription_lapsed');
+      assert.equal(body.id, 100);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('classifies billing-verification denials distinctly in usage telemetry', async () => {
+    const { mcpReasonFor } = await import('../api/mcp/usage.ts');
+    assert.equal(mcpReasonFor('billing', 503), 'billing_verification_503');
+    assert.equal(mcpReasonFor('billing', 403), 'tier_403');
+    assert.equal(mcpReasonFor('precheck', 503), 'auth_unavailable');
   });
 
   it('error: Redis pipeline throws on INCR → -32603 + 503 + Retry-After', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2789,6 +2789,53 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.equal(res.status, 401);
   });
 
+  for (const billingStatus of ['renewal_verification_pending', 'renewal_verification_failed']) {
+    it(`error: ${billingStatus} → JSON-RPC retryable no-store 503`, async () => {
+      const { deps, pipe } = makeProDeps({
+        getEntitlements: async () => ({
+          planKey: 'free',
+          features: { tier: 0, mcpAccess: false },
+          validUntil: 0,
+          billingStatus,
+          retryAfterSeconds: 19,
+        }),
+      });
+      const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps);
+
+      assert.equal(res.status, 503);
+      assert.equal(res.headers.get('Cache-Control'), 'no-store');
+      assert.equal(res.headers.get('Retry-After'), '19');
+      assert.equal(res.headers.get('X-Billing-Verification'), billingStatus);
+      const body = await res.json();
+      assert.equal(body.jsonrpc, '2.0');
+      assert.equal(body.error?.code, -32603);
+      assert.equal(body.error?.data?.code, billingStatus);
+      assert.equal(pipe.count, 0);
+    });
+  }
+
+  it('error: subscription_lapsed → distinct JSON-RPC hard denial', async () => {
+    const { deps, pipe } = makeProDeps({
+      getEntitlements: async () => ({
+        planKey: 'free',
+        features: { tier: 0, mcpAccess: false },
+        validUntil: 0,
+        billingStatus: 'subscription_lapsed',
+      }),
+    });
+    const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps);
+
+    assert.equal(res.status, 403);
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.equal(res.headers.get('Retry-After'), null);
+    assert.equal(res.headers.get('X-Billing-Verification'), 'subscription_lapsed');
+    const body = await res.json();
+    assert.equal(body.jsonrpc, '2.0');
+    assert.equal(body.error?.code, -32001);
+    assert.equal(body.error?.data?.code, 'subscription_lapsed');
+    assert.equal(pipe.count, 0);
+  });
+
   it('error: Redis pipeline throws on INCR → -32603 + 503 + Retry-After', async () => {
     const { deps, pipe } = makeProDeps({ pipelineOpts: { throwOnIncr: true } });
     const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps);

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2424,6 +2424,66 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(body.error?.code, -32603, 'total outage must return -32603');
   });
 
+  it('get_airspace surfaces a mid-call billing denial instead of a generic failure', async () => {
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({ error: 'Renewal verification pending', code: 'renewal_verification_pending' }),
+      {
+        status: 503,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'Retry-After': '21',
+          'X-Billing-Verification': 'renewal_verification_pending',
+        },
+      },
+    );
+
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 15, method: 'tools/call',
+      params: { name: 'get_airspace', arguments: { country_code: 'GB' } },
+    }));
+
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('Retry-After'), '21');
+    assert.equal(res.headers.get('X-Billing-Verification'), 'renewal_verification_pending');
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.data?.code, 'renewal_verification_pending');
+  });
+
+  it('get_airspace type=civilian rethrows a billing denial instead of serving partial data', async () => {
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes('/api/aviation/v1/track-aircraft')) {
+        return new Response(
+          JSON.stringify({ error: 'Subscription lapsed', code: 'subscription_lapsed' }),
+          {
+            status: 403,
+            headers: {
+              'Content-Type': 'application/json',
+              'Cache-Control': 'no-store',
+              'X-Billing-Verification': 'subscription_lapsed',
+            },
+          },
+        );
+      }
+      return originalFetch(url);
+    };
+
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 16, method: 'tools/call',
+      params: { name: 'get_airspace', arguments: { country_code: 'DE', type: 'civilian' } },
+    }));
+
+    // Pre-fix behavior was a plausible-looking 200 with partial:true — a
+    // billing lapse masked as a data-source outage.
+    assert.equal(res.status, 403);
+    assert.equal(res.headers.get('X-Billing-Verification'), 'subscription_lapsed');
+    const body = await res.json();
+    assert.equal(body.error?.code, -32002);
+    assert.equal(body.error?.data?.code, 'subscription_lapsed');
+  });
+
   it('get_airspace type=civilian skips military fetch', async () => {
     let militaryFetched = false;
     globalThis.fetch = async (url) => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2849,6 +2849,32 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.equal(res.status, 401);
   });
 
+  it('current Pro fallback remains usable while stronger renewal verification is pending', async () => {
+    const { deps, pipe } = makeProDeps({
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: { tier: 1, mcpAccess: true },
+        validUntil: Date.now() + 86_400_000,
+        billingStatus: 'renewal_verification_pending',
+        retryAfterSeconds: 19,
+      }),
+    });
+    process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'stub';
+    globalThis.fetch = async () => new Response(
+      JSON.stringify({ result: JSON.stringify({ ok: 1 }) }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const res = await mcpHandler(
+      proReq('POST', callBody('get_market_data')),
+      deps,
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(pipe.count, 1);
+  });
+
   for (const billingStatus of ['renewal_verification_pending', 'renewal_verification_failed']) {
     it(`error: ${billingStatus} → JSON-RPC retryable no-store 503`, async () => {
       const { deps, pipe } = makeProDeps({


### PR DESCRIPTION
## Summary

Customers whose renewal had reached Dodo but not yet the local entitlement row could be denied Pro, API, or MCP access at the old `validUntil`. Recently stale subscriptions are now verified on demand: active provider state refreshes access, affirmative inactive state confirms lapse, and timeouts, provider lag, or unresolved multi-subscription state remain fail-closed but retryable with `503` instead of becoming a hard denial.

- A durable claim coalesces concurrent verification, while a two-second Dodo budget, no retries, and short outcome cooldowns keep the request hot path bounded.
- A fresh entitlement read after reconciliation lets a concurrent renewal webhook win. Multiple stale subscriptions advance safely with at most one provider call per action, and an active provider response without a future period is treated as uncertain rather than lapsed.
- HTTP, `wm_` API-key, internal MCP, and edge MCP paths preserve the same billing contract: confirmed lapse is a hard denial; pending or failed verification carries `Retry-After` and `no-store`. Short-lived markers also prevent free users from repeatedly invoking reconciliation.
- Structured billing logs and the `billing_verification_503` usage reason expose provider failures and retryable denials without logging secrets.

The provider lookup intentionally remains fail-closed: if Dodo cannot be verified within the budget, access is not granted, but callers receive a bounded retry signal rather than a misleading auth or lapse response.

Fixes #4770.

## Validation

- `npm run test:data` — 16,050 passed, 0 failed, 6 skipped
- `npm run test:convex` — 803 passed
- `npm run test:sidecar` — 256 passed
- `npm run typecheck:all` and Convex TypeScript check — passed
- `npm run lint` — passed (pre-existing warnings only)
- `npm run build` — production build passed
- Post-rebase pre-push gate — frontend/API/Convex typechecks, edge bundle checks, architectural guards, and changed tests passed

## Post-Deploy Monitoring & Validation

- **Owner/window:** Payments/API on-call for the first 24 hours after deployment.
- **Logs:** watch `[billing/on-demand-renewal]` and `[billing/reconcile]` for claim, active, lapse, timeout, and failure outcomes; correlate gateway traffic tagged with `billing_verification_503`.
- **Healthy criteria:** recently renewed users recover paid access without manual intervention; retryable `503`s are brief; confirmed-lapse `403`s do not spike; repeated requests for one user remain inside the verification cooldowns.
- **Validation:** compare Dodo verification attempts, active recoveries, hard lapses, and retryable failures before and after deploy; spot-check API-key and MCP responses for matching `403`/`503` semantics.
- **Rollback trigger:** sustained growth in Dodo timeouts or verification actions, prolonged `503`s for renewed users, or an unexpected hard-denial increase. Revert this PR to return to webhook/daily reconciliation while investigating.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
