### PR TITLE
fix(summarization): skip API chain entirely when entitlement gate is closed (#5377)

### DIFF
--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -292,6 +292,11 @@ async function generateSummaryInternal(
   options?: SummarizeOptions,
 ): Promise<SummarizationResult | null> {
   const bodies = options?.bodies;
+  // Entitlement/suppression snapshot for this call — when the gate is
+  // closed (anon/free or 403-suppressed), skip the entire API chain
+    // instead of iterating providers that will each bail at the per-provider
+  // gate check (#5377).
+  const serverGated = !canAttemptServerSummarization();
   // Only take the pre-chain cache-lookup shortcut when no body is present.
   // When bodies are RAW on the client but sanitised server-side before
   // keying, the keys diverge on injection content. The regular call chain
@@ -318,14 +323,14 @@ async function generateSummaryInternal(
         const browserResult = await tryBrowserT5(headlines, 'summarization-beta', bodies);
         if (browserResult) {
           const groqProvider = API_PROVIDERS.find(p => p.provider === 'groq');
-          if (groqProvider && !options?.skipCloudProviders) tryApiProvider(groqProvider, headlines, geoContext, undefined, bodies).catch(() => {});
+          if (groqProvider && !options?.skipCloudProviders && !serverGated) tryApiProvider(groqProvider, headlines, geoContext, undefined, bodies).catch(() => {});
 
           return browserResult;
         }
       }
 
       // Warm model failed inference -- fallback through API providers
-      if (!options?.skipCloudProviders) {
+      if (!options?.skipCloudProviders && !serverGated) {
         const chainResult = await runApiChain(API_PROVIDERS, headlines, geoContext, undefined, onProgress, 2, totalSteps, bodies);
         if (chainResult) return chainResult;
       }
@@ -336,7 +341,7 @@ async function generateSummaryInternal(
       }
 
       // API providers while model loads
-      if (!options?.skipCloudProviders) {
+      if (!options?.skipCloudProviders && !serverGated) {
         const chainResult = await runApiChain(API_PROVIDERS, headlines, geoContext, undefined, onProgress, 1, totalSteps, bodies);
         if (chainResult) {
           return chainResult;
@@ -353,7 +358,7 @@ async function generateSummaryInternal(
       onProgress?.(totalSteps, totalSteps, 'No providers available');
     }
 
-    console.warn('[BETA] All providers failed');
+    if (!serverGated) console.warn('[BETA] All providers failed');
     return null;
   }
 
@@ -361,7 +366,7 @@ async function generateSummaryInternal(
   const totalSteps = API_PROVIDERS.length + 1;
   let chainResult: SummarizationResult | null = null;
 
-  if (!options?.skipCloudProviders) {
+  if (!options?.skipCloudProviders && !serverGated) {
     chainResult = await runApiChain(API_PROVIDERS, headlines, geoContext, lang, onProgress, 1, totalSteps, bodies);
   }
   if (chainResult) return chainResult;
@@ -372,7 +377,7 @@ async function generateSummaryInternal(
     if (browserResult) return browserResult;
   }
 
-  console.warn('[Summarization] All providers failed');
+  if (!serverGated) console.warn('[Summarization] All providers failed');
   return null;
 }
 


### PR DESCRIPTION
## Summary

Fixes the residual issue from #5377: the #4913 enqueue gate landed (line 82 `configureSummarizeGate`, line 125 per-provider `canAttemptServerSummarization()` check), so anon/free users no longer fire 5 doomed network round-trips. However:

1. `runApiChain` still iterated all 3 providers, each entering `tryApiProvider` only to bail at the per-provider gate check — 3 wasted iterations per call.
2. `console.warn('[Summarization] All providers failed')` still fired for gated users, indistinguishable from a real provider outage in console triage.

## Changes

- Snapshot the gate state once at the top of `generateSummaryInternal` (`const serverGated = !canAttemptServerSummarization()`)
- Skip `runApiChain` entirely when the gate is closed (both BETA and normal paths)
- Skip the fire-and-forget Groq comparison call in BETA mode when gated
- Suppress the 'All providers failed' warning when the gate (not a failure) is the reason no cloud summary was produced

The per-provider gate check in `tryApiProvider` remains as defense-in-depth. `translateText` is unaffected (uses `mode='translate'` via the plain `newsClient`, which the server allows for non-premium callers).

## Verification

- `npx tsc --noEmit` — zero errors
- `npm run test:data` — 15873 pass, 2 fail (pre-existing: `bootstrap-r2-reader` timeout + `dashboard-critical-css` build check, both unrelated to this change)
- 1 file changed, +11 −6