### PR TITLE
fix(entity-decode): single-pass decoder shared across seeders (#5436)

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -66,6 +66,7 @@ COPY scripts/_seed-contract.mjs ./scripts/_seed-contract.mjs
 COPY scripts/_country-stock-index.mjs ./scripts/_country-stock-index.mjs
 COPY scripts/_country-resolver.mjs ./scripts/_country-resolver.mjs
 COPY scripts/_climate-news-helpers.mjs ./scripts/_climate-news-helpers.mjs
+COPY scripts/shared/entity-decode.mjs ./scripts/shared/entity-decode.mjs
 COPY scripts/seed-climate-news.mjs ./scripts/seed-climate-news.mjs
 COPY scripts/seed-chokepoint-flows.mjs ./scripts/seed-chokepoint-flows.mjs
 COPY scripts/seed-ember-electricity.mjs ./scripts/seed-ember-electricity.mjs

--- a/scripts/_trade-parse-utils.mjs
+++ b/scripts/_trade-parse-utils.mjs
@@ -1,3 +1,4 @@
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 /**
  * Pure parse helpers for trade-data seed scripts.
  * Extracted so test files can import directly without new Function() hacks.
@@ -12,15 +13,17 @@ const MONTH_MAP = {
 };
 
 export function htmlToPlainText(html) {
-  return String(html ?? '')
+  const stripped = String(html ?? '')
     .replace(/<script[\s\S]*?<\/script>/gi, ' ')
     .replace(/<style[\s\S]*?<\/style>/gi, ' ')
     .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s[^<>]*?)?>/g, ' ')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, '\'')
+    .replace(/<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s[^<>]*?)?>/g, ' ');
+  return decodeEntities(stripped, {
+    named: { nbsp: ' ', amp: '&', quot: '"' },
+    numericOverrides: { 39: "'" },
+    numericDefault: 'literal',
+    caseInsensitive: true,
+  })
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/china-macro/calendar.mjs
+++ b/scripts/china-macro/calendar.mjs
@@ -1,3 +1,4 @@
+import { decodeHtmlEntities as decodeEntities } from '../shared/entity-decode.mjs';
 export const NBS_CALENDAR_INDEX_URL = 'https://www.stats.gov.cn/english/PressRelease/ReleaseCalendar/';
 export const CHINAMONEY_LPR_URL = 'https://www.chinamoney.com.cn/chinese/bklpr/?tab=2';
 export const CHINAMONEY_LPR_NOTICE_API = 'https://www.chinamoney.com.cn/ags/ms/cm-s-notice-query/contentsinshorttime';
@@ -24,13 +25,15 @@ function isoDate(year, month, day) {
 }
 
 function stripHtml(value) {
-  return value
+  const stripped = value
     .replace(/<br\s*\/?\s*>/gi, '\n')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;|&#160;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&#39;|&apos;/gi, "'")
-    .replace(/&quot;/gi, '"')
+    .replace(/<[^>]+>/g, ' ');
+  return decodeEntities(stripped, {
+    named: { nbsp: ' ', amp: '&', apos: "'", quot: '"' },
+    numericOverrides: { 160: ' ', 39: "'" },
+    numericDefault: 'literal',
+    caseInsensitive: true,
+  })
     .replace(/[ \t]+/g, ' ')
     .trim();
 }

--- a/scripts/seed-climate-news.mjs
+++ b/scripts/seed-climate-news.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 // Pure contentMeta helper lives in its own module so tests can import the
 // real code (no replicas, no drift). See helpers module header for rationale.
 import { climateNewsContentMeta, CLIMATE_NEWS_MAX_CONTENT_AGE_MIN } from './_climate-news-helpers.mjs';
@@ -31,13 +32,11 @@ function stableHash(str) {
 }
 
 function decodeHtmlEntities(text) {
-  return text
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
+  return decodeEntities(text, {
+    named: { lt: '<', gt: '>', amp: '&', quot: '"', nbsp: ' ' },
+    numericOverrides: { 39: "'" },
+    numericDefault: 'literal',
+  });
 }
 
 function extractTag(block, tagName) {

--- a/scripts/seed-disease-outbreaks.mjs
+++ b/scripts/seed-disease-outbreaks.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 // Reuse the battle-tested schema-anchored parser from seed-vpd-tracker.mjs.
 // The 2026-04 webpack rebuild changed the TGH bundle from the legacy
 // `var a=[{Alert_ID:"..."}]` shape (unquoted keys) to `eval("var res = [...]")`
@@ -87,8 +88,11 @@ async function fetchRssItems(url, sourceName) {
       const title = (block.match(/<title>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/title>/) || [])[1]?.trim() || '';
       const link = (block.match(/<link>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/link>/) || [])[1]?.trim() || '';
       const rawDesc = (block.match(/<description>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/description>/) || [])[1] || '';
-      const desc = rawDesc
-        .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ')
+      const desc = decodeEntities(rawDesc, {
+        named: { lt: '<', gt: '>', amp: '&', quot: '"', nbsp: ' ' },
+        numericOverrides: { 39: "'" },
+        numericDefault: 'literal',
+      })
         .replace(/<[^>]+>/g, '').trim().slice(0, 300);
       const pubDate = (block.match(/<pubDate>(.*?)<\/pubDate>/) || [])[1]?.trim() || '';
       // Per-item synthetic-tag normalization lives in _disease-outbreaks-helpers.mjs

--- a/scripts/seed-energy-intelligence.mjs
+++ b/scripts/seed-energy-intelligence.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 import { resolveProxyStringConnect } from './_proxy-utils.cjs';
 
 loadEnvFile(import.meta.url);
@@ -32,20 +33,14 @@ export function stableHash(str) {
 }
 
 function decodeHtmlEntities(text) {
-  return text
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;|&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&hellip;/g, '…')
-    .replace(/&mdash;/g, '—')
-    .replace(/&ndash;/g, '–')
-    .replace(/&lsquo;|&rsquo;/g, "'")
-    .replace(/&ldquo;|&rdquo;/g, '"');
+  return decodeEntities(text, {
+    named: {
+      amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+      hellip: '…', mdash: '—', ndash: '–',
+      lsquo: "'", rsquo: "'", ldquo: '"', rdquo: '"',
+    },
+    numericDefault: 'decode',
+  });
 }
 
 function extractTag(block, tagName) {

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -17,6 +17,7 @@
 // drop the full listing.
 
 import { gunzipSync, inflateSync, brotliDecompressSync } from 'node:zlib';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw, describeErr } from './_seed-utils.mjs';
 import countryNames from './shared/country-names.json' with { type: 'json' };
 
@@ -408,13 +409,11 @@ export function extractListedCountries(html, nameLookup) {
 // Full-fledged decoders pull in 100KB of dependencies; this targeted
 // list covers what we actually see in the fixtures.
 function decodeHtmlEntities(s) {
-  return String(s)
-    .replace(/&#39;/g, "'")
-    .replace(/&#34;/g, '"')
-    .replace(/&amp;/g, '&')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+  return decodeEntities(String(s), {
+    named: { amp: '&', nbsp: ' ', lt: '<', gt: '>' },
+    numericOverrides: { 39: "'", 34: '"' },
+    numericDefault: 'literal',
+  });
 }
 
 // Try to extract the publication date from the URL slug or the page

--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from 'node:url';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 import { XMLParser } from 'fast-xml-parser';
 import Papa from 'papaparse';
 
@@ -163,15 +164,15 @@ export async function fetchCanadaBuys({ now = Date.now(), fetchTextFn = fetchTex
 }
 
 function decodeHtml(value) {
-  return String(value || '')
+  const stripped = String(value || '')
     .replace(/<br\s*\/?\s*>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/<[^>]+>/g, '');
+  return decodeEntities(stripped, {
+    named: { nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" },
+    numericOverrides: { 39: "'" },
+    numericDefault: 'literal',
+    caseInsensitive: true,
+  })
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/seed-hormuz.mjs
+++ b/scripts/seed-hormuz.mjs
@@ -13,6 +13,7 @@
 // Chart window: last 30 days
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -179,21 +180,15 @@ async function fetchPbiCharts() {
 
 // Decode common HTML entities in scraped text.
 function decodeHtmlEntities(s) {
-  return s
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#039;/g, "'")
-    .replace(/&ldquo;/g, '\u201c')
-    .replace(/&rdquo;/g, '\u201d')
-    .replace(/&lsquo;/g, '\u2018')
-    .replace(/&rsquo;/g, '\u2019')
-    .replace(/&mdash;/g, '\u2014')
-    .replace(/&ndash;/g, '\u2013')
-    .replace(/&#8217;/g, '\u2019')
-    .replace(/&#8220;/g, '\u201c')
-    .replace(/&#8221;/g, '\u201d');
+  return decodeEntities(s, {
+    named: {
+      nbsp: ' ', amp: '&', lt: '<', gt: '>',
+      ldquo: '\u201c', rdquo: '\u201d', lsquo: '\u2018', rsquo: '\u2019',
+      mdash: '\u2014', ndash: '\u2013',
+    },
+    numericOverrides: { 39: "'", 8217: '\u2019', 8220: '\u201c', 8221: '\u201d' },
+    numericDefault: 'literal',
+  });
 }
 
 function stripTags(s) {

--- a/scripts/seed-regulatory-actions.mjs
+++ b/scripts/seed-regulatory-actions.mjs
@@ -2,6 +2,7 @@
 // @ts-check
 
 import { pathToFileURL } from 'node:url';
+import { decodeHtmlEntities as decodeEntitiesShared } from './shared/entity-decode.mjs';
 import { CHROME_UA, loadEnvFile, runSeed } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
@@ -44,17 +45,11 @@ const REGULATORY_FEEDS = [
 
 function decodeEntities(input) {
   if (!input) return '';
-  const named = input
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&apos;/gi, "'")
-    .replace(/&nbsp;/gi, ' ');
-
-  return named
-    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(parseInt(code, 16)));
+  return decodeEntitiesShared(input, {
+    named: { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' },
+    numericDefault: 'decode',
+    caseInsensitive: true,
+  });
 }
 
 function stripHtml(input) {

--- a/scripts/seed-security-advisories.mjs
+++ b/scripts/seed-security-advisories.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -96,10 +97,13 @@ function isValidUrl(link) {
 }
 
 function stripHtml(html) {
-  return html.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
-    .replace(/<[^>]+>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ').replace(/&#8217;/g, "'")
-    .replace(/&#8220;/g, '"').replace(/&#8221;/g, '"').replace(/\s+/g, ' ').trim();
+  const stripped = html.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/<[^>]+>/g, '');
+  return decodeEntities(stripped, {
+    named: { amp: '&', lt: '<', gt: '>', nbsp: ' ' },
+    numericOverrides: { 8217: "'", 8220: '"', 8221: '"' },
+    numericDefault: 'literal',
+  }).replace(/\s+/g, ' ').trim();
 }
 
 export function parseRssItems(xml) {

--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -81,6 +81,7 @@
 // missing SWF seed key.
 
 import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, SHARED_FX_FALLBACKS, getSharedFxRates, getBundleRunStartedAtMs } from './_seed-utils.mjs';
+import { decodeHtmlEntities as decodeEntities } from './shared/entity-decode.mjs';
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 import { groupFundsByCountry, loadSwfManifest } from './shared/swf-manifest-loader.mjs';
 
@@ -336,11 +337,13 @@ function stripHtmlInline(value) {
   // `302.0<sup>41</sup>` becomes `302.0 41` — otherwise the decimal
   // value and its trailing footnote ref get welded into `302.041`,
   // which the Assets regex then mis-parses as a single number.
-  return String(value || '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&[#\w]+;/g, ' ')
+  const stripped = String(value || '')
+    .replace(/<[^>]+>/g, ' ');
+  return decodeEntities(stripped, {
+    named: { nbsp: ' ', amp: '&' },
+    numericDefault: 'space',
+    unknownToSpace: true,
+  })
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/shared/entity-decode.mjs
+++ b/scripts/shared/entity-decode.mjs
@@ -1,0 +1,93 @@
+// Single-pass HTML/XML entity decoder shared by the RSS/HTML seeders and the
+// client-side news utilities.
+//
+// Why this exists (issue #5436): every hand-rolled decoder in the repo used a
+// chain of sequential `.replace()` calls that decoded `&amp;` in the same pass
+// as the other entities. That decodes two levels in one pass — `&amp;lt;`
+// becomes `&` and the next replace then turns the resulting `&lt;` into `<`, so
+// escaped-once text like `&amp;lt;script&amp;gt;` surfaced as live `<script>`.
+// A single-pass alternation decodes exactly one level for every input, and the
+// numeric decoder is range-guarded so a malformed `&#999999999;` yields '' via
+// a caught RangeError source instead of throwing.
+//
+// Each call site keeps its own behaviour by passing its own config, so this is
+// a pure de-duplication of the decode *mechanism* with no change to any
+// seeder's output.
+
+// Decode a numeric character reference, guarding the RangeError that
+// String.fromCodePoint throws for values outside the Unicode range or for
+// non-integers (e.g. from an overflowing `&#999999999;`).
+export function decodeNumericReference(codePoint) {
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : '';
+}
+
+function escapeForRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Decode HTML/XML entities in a single left-to-right pass.
+ *
+ * @param {string} text
+ * @param {object} [config]
+ * @param {Record<string,string>} [config.named]
+ *   Named entity (without the leading `&` / trailing `;`) to its replacement,
+ *   e.g. `{ amp: '&', lt: '<', ldquo: '“' }`.
+ * @param {Record<number,string>} [config.numericOverrides]
+ *   Fixed replacements for specific numeric code points (decimal and hex refs
+ *   are both normalised to a number key), e.g. `{ 8217: "'" }`.
+ * @param {'decode'|'literal'|'space'} [config.numericDefault='decode']
+ *   What to do with numeric refs not covered by `numericOverrides`: guarded
+ *   `decode`, leave the ref `literal`, or replace with a single `space`.
+ * @param {boolean} [config.caseInsensitive=false] Match entity names case-insensitively.
+ * @param {boolean} [config.unknownToSpace=false]
+ *   Replace any remaining `&…;` that matched no named entity with a single
+ *   space (mirrors the catch-all a couple of seeders relied on).
+ * @returns {string}
+ */
+export function decodeHtmlEntities(text, config = {}) {
+  const {
+    named = {},
+    numericOverrides = {},
+    numericDefault = 'decode',
+    caseInsensitive = false,
+    unknownToSpace = false,
+  } = config;
+
+  const lookup = caseInsensitive
+    ? Object.fromEntries(Object.entries(named).map(([k, v]) => [k.toLowerCase(), v]))
+    : named;
+
+  const names = Object.keys(named).map(escapeForRegExp);
+  // Named capture groups keep the callback position-independent regardless of
+  // which alternatives are present.
+  const parts = [];
+  if (names.length > 0) parts.push(`(?<name>${names.join('|')})`);
+  parts.push('#[xX](?<hex>[0-9a-fA-F]+)', '#(?<dec>\\d+)');
+  if (unknownToSpace) parts.push('(?<unknown>[a-zA-Z][a-zA-Z0-9]*)');
+
+  const re = new RegExp(`&(?:${parts.join('|')});`, caseInsensitive ? 'gi' : 'g');
+
+  return text.replace(re, (...args) => {
+    const match = args[0];
+    const { name, hex, dec, unknown } = args[args.length - 1];
+    if (name !== undefined) {
+      const key = caseInsensitive ? name.toLowerCase() : name;
+      return Object.prototype.hasOwnProperty.call(lookup, key) ? lookup[key] : match;
+    }
+    if (hex !== undefined || dec !== undefined) {
+      const codePoint = hex !== undefined ? parseInt(hex, 16) : Number(dec);
+      if (Object.prototype.hasOwnProperty.call(numericOverrides, codePoint)) {
+        return numericOverrides[codePoint];
+      }
+      if (numericDefault === 'literal') return match;
+      if (numericDefault === 'space') return ' ';
+      return decodeNumericReference(codePoint);
+    }
+    // Reached only when unknownToSpace added the bare-name catch-all.
+    if (unknown !== undefined) return ' ';
+    return match;
+  });
+}

--- a/scripts/shared/entity-decode.mjs
+++ b/scripts/shared/entity-decode.mjs
@@ -27,6 +27,27 @@ function escapeForRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Compiled-regex cache. Call sites pass a fresh config object literal per call
+// (hundreds of times per seeder run), so memoise on a stable string derived
+// from the parts that shape the pattern rather than on object identity.
+const _regexCache = new Map();
+
+function compiledRegExp(names, caseInsensitive, unknownToSpace) {
+  const key = `${caseInsensitive ? 'i' : '-'}${unknownToSpace ? 'u' : '-'}|${names.join(',')}`;
+  let re = _regexCache.get(key);
+  if (!re) {
+    // Named capture groups keep the replace callback position-independent
+    // regardless of which alternatives are present.
+    const parts = [];
+    if (names.length > 0) parts.push(`(?<name>${names.join('|')})`);
+    parts.push('#[xX](?<hex>[0-9a-fA-F]+)', '#(?<dec>\\d+)');
+    if (unknownToSpace) parts.push('(?<unknown>[a-zA-Z][a-zA-Z0-9]*)');
+    re = new RegExp(`&(?:${parts.join('|')});`, caseInsensitive ? 'gi' : 'g');
+    _regexCache.set(key, re);
+  }
+  return re;
+}
+
 /**
  * Decode HTML/XML entities in a single left-to-right pass.
  *
@@ -61,14 +82,7 @@ export function decodeHtmlEntities(text, config = {}) {
     : named;
 
   const names = Object.keys(named).map(escapeForRegExp);
-  // Named capture groups keep the callback position-independent regardless of
-  // which alternatives are present.
-  const parts = [];
-  if (names.length > 0) parts.push(`(?<name>${names.join('|')})`);
-  parts.push('#[xX](?<hex>[0-9a-fA-F]+)', '#(?<dec>\\d+)');
-  if (unknownToSpace) parts.push('(?<unknown>[a-zA-Z][a-zA-Z0-9]*)');
-
-  const re = new RegExp(`&(?:${parts.join('|')});`, caseInsensitive ? 'gi' : 'g');
+  const re = compiledRegExp(names, caseInsensitive, unknownToSpace);
 
   return text.replace(re, (...args) => {
     const match = args[0];

--- a/src/components/CountryDeepDivePanel-news-utils.ts
+++ b/src/components/CountryDeepDivePanel-news-utils.ts
@@ -1,14 +1,17 @@
 import type { NewsItem } from '../types';
 
 export function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, '/');
+  // Single-pass decode (issue #5436): decode exactly one entity level.
+  return text.replace(/&(?:amp|lt|gt|quot|#(\d+)|#[xX]([0-9a-fA-F]+));/g, (m, dec, hex) => {
+    if (dec !== undefined || hex !== undefined) {
+      const cp = hex !== undefined ? parseInt(hex, 16) : Number(dec);
+      if (cp === 39) return "'";
+      if (cp === 47) return '/';
+      return m;
+    }
+    const named: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' };
+    return named[m] ?? m;
+  });
 }
 
 export function normalizeHeadlineKey(title: string): string {

--- a/src/components/CountryDeepDivePanel-news-utils.ts
+++ b/src/components/CountryDeepDivePanel-news-utils.ts
@@ -1,18 +1,7 @@
 import type { NewsItem } from '../types';
+import { decodeHtmlEntities } from '../utils/decode-entities';
 
-export function decodeHtmlEntities(text: string): string {
-  // Single-pass decode (issue #5436): decode exactly one entity level.
-  return text.replace(/&(?:amp|lt|gt|quot|#(\d+)|#[xX]([0-9a-fA-F]+));/g, (m, dec, hex) => {
-    if (dec !== undefined || hex !== undefined) {
-      const cp = hex !== undefined ? parseInt(hex, 16) : Number(dec);
-      if (cp === 39) return "'";
-      if (cp === 47) return '/';
-      return m;
-    }
-    const named: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' };
-    return named[m] ?? m;
-  });
-}
+export { decodeHtmlEntities };
 
 export function normalizeHeadlineKey(title: string): string {
   return decodeHtmlEntities(title)

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -47,6 +47,7 @@ import type {
 import { fetchMultiSectorCostShock, HS2_SHORT_LABELS } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
 import { dedupeHeadlines } from './CountryDeepDivePanel-news-utils';
+import { decodeHtmlEntities } from '../utils/decode-entities';
 import { renderFollowButton } from '@/utils/follow-button';
 import { renderNotifyCountryLink } from '@/utils/notify-country-link';
 import { exportCountryEvidenceMarkdown } from '@/utils/export';
@@ -3175,18 +3176,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   }
 
   private decodeEntities(text: string): string {
-    // Single-pass decode (issue #5436): decode exactly one entity level so
-    // escaped-once markup like `&amp;lt;` stays literal instead of double-decoding.
-    return text.replace(/&(?:amp|lt|gt|quot|#(\d+)|#[xX]([0-9a-fA-F]+));/g, (m, dec, hex) => {
-      if (dec !== undefined || hex !== undefined) {
-        const cp = hex !== undefined ? parseInt(hex, 16) : Number(dec);
-        if (cp === 39) return "'";
-        if (cp === 47) return '/';
-        return m;
-      }
-      const named: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' };
-      return named[m] ?? m;
-    });
+    // Single-pass decode (issue #5436) — shared client implementation.
+    return decodeHtmlEntities(text);
   }
 
   private toThreatLevel(level: string | undefined): ThreatLevel {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -3175,14 +3175,18 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   }
 
   private decodeEntities(text: string): string {
-    return text
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#x27;/g, "'")
-      .replace(/&#x2F;/g, '/');
+    // Single-pass decode (issue #5436): decode exactly one entity level so
+    // escaped-once markup like `&amp;lt;` stays literal instead of double-decoding.
+    return text.replace(/&(?:amp|lt|gt|quot|#(\d+)|#[xX]([0-9a-fA-F]+));/g, (m, dec, hex) => {
+      if (dec !== undefined || hex !== undefined) {
+        const cp = hex !== undefined ? parseInt(hex, 16) : Number(dec);
+        if (cp === 39) return "'";
+        if (cp === 47) return '/';
+        return m;
+      }
+      const named: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' };
+      return named[m] ?? m;
+    });
   }
 
   private toThreatLevel(level: string | undefined): ThreatLevel {

--- a/src/utils/decode-entities.ts
+++ b/src/utils/decode-entities.ts
@@ -1,0 +1,22 @@
+// Single-pass HTML entity decoder for client-side news/text sanitising.
+//
+// Decodes exactly one entity level per call (issue #5436): sequential
+// `.replace()` chains that decode `&amp;` alongside other entities turn
+// escaped-once markup like `&amp;lt;script&amp;gt;` into live `<script>`.
+// Shared by CountryDeepDivePanel and its news utils; the seeder-side
+// equivalent lives in `scripts/shared/entity-decode.mjs` (kept separate to
+// avoid a `scripts/ → src/` build dependency).
+
+const NAMED: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"' };
+
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(?:amp|lt|gt|quot|#(\d+)|#[xX]([0-9a-fA-F]+));/g, (m, dec, hex) => {
+    if (dec !== undefined || hex !== undefined) {
+      const cp = hex !== undefined ? parseInt(hex, 16) : Number(dec);
+      if (cp === 39) return "'";
+      if (cp === 47) return '/';
+      return m;
+    }
+    return NAMED[m] ?? m;
+  });
+}

--- a/tests/entity-decode-shared.test.mjs
+++ b/tests/entity-decode-shared.test.mjs
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decodeHtmlEntities, decodeNumericReference } from '../scripts/shared/entity-decode.mjs';
+
+const STD = { named: { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" } };
+
+// Mirrors what a well-formed feed generator produces for a plain-text string.
+function escapeXml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+describe('decodeHtmlEntities: one pass decodes exactly one level', () => {
+  it('round-trips singly-escaped text', () => {
+    for (const original of [
+      'AT&T completes merger',
+      'XSS via <script> in Acme SDK',
+      'Q3 revenue > $2B & rising',
+      'He said "no comment"',
+      "Ireland's PM: 'no deal' & <no> comment",
+    ]) {
+      assert.equal(decodeHtmlEntities(escapeXml(original), STD), original);
+    }
+  });
+
+  it('does NOT double-decode escaped-once markup (issue #5436)', () => {
+    // `&amp;lt;script&amp;gt;` is the escaping of the literal text
+    // `&lt;script&gt;` and must stay literal, never become `<script>`.
+    assert.equal(decodeHtmlEntities('&amp;lt;script&amp;gt;', STD), '&lt;script&gt;');
+    assert.equal(decodeHtmlEntities('a &amp;#38; b', STD), 'a &#38; b');
+  });
+});
+
+describe('numeric references', () => {
+  it('decodes decimal and hex when numericDefault is "decode"', () => {
+    assert.equal(decodeHtmlEntities('&#65;&#x42;', { numericDefault: 'decode' }), 'AB');
+  });
+
+  it('range-guards malformed refs instead of throwing (RangeError source)', () => {
+    assert.equal(decodeHtmlEntities('x&#999999999;y', { numericDefault: 'decode' }), 'xy');
+    assert.equal(decodeNumericReference(0x110000), '');
+    assert.equal(decodeNumericReference(Number.NaN), '');
+  });
+
+  it('applies numericOverrides and leaves others literal', () => {
+    const cfg = { numericOverrides: { 8217: "'", 8220: '"', 8221: '"' }, numericDefault: 'literal' };
+    assert.equal(decodeHtmlEntities('&#8217;&#8220;x&#8221;', cfg), '\'"x"');
+    assert.equal(decodeHtmlEntities('&#65;', cfg), '&#65;');
+  });
+});
+
+describe('config variants used by the seeders', () => {
+  it('preserves curly quotes when a seeder maps them so (hormuz)', () => {
+    const cfg = { named: { ldquo: '“', rdquo: '”' }, numericOverrides: { 8220: '“', 8221: '”' }, numericDefault: 'literal' };
+    assert.equal(decodeHtmlEntities('&ldquo;x&rdquo; &#8220;y&#8221;', cfg), '“x” “y”');
+  });
+
+  it('matches names case-insensitively when requested (regulatory)', () => {
+    assert.equal(decodeHtmlEntities('A&AMP;B', { named: { amp: '&' }, caseInsensitive: true }), 'A&B');
+  });
+
+  it('routes unknown entities and numerics to a space (sovereign-wealth)', () => {
+    assert.equal(
+      decodeHtmlEntities('a&nbsp;b&mdash;c&#8212;d', { named: { nbsp: ' ', amp: '&' }, numericDefault: 'space', unknownToSpace: true }),
+      'a b c d',
+    );
+  });
+});


### PR DESCRIPTION
Closes #5436

## Problem

Every hand-rolled entity decoder in the repo chained sequential `.replace()` calls that decoded `&amp;` in the same pass as the other named entities. That decodes **two levels in one pass**: `&amp;lt;` becomes `&`, and the next replace turns the resulting `&lt;` into `<`. So escaped-once text like `&amp;lt;script&amp;gt;` surfaced as live `<script>` (notably in `seed-security-advisories`, which strips tags *before* decoding). Separately, several numeric decoders called `String.fromCodePoint` unguarded — a malformed `&#999999999;` throws `RangeError` and, depending on catch scope, can fail the whole seeder parse (`seed-energy-intelligence`, `seed-regulatory-actions`).

## Fix

New `scripts/shared/entity-decode.mjs` — a **single-pass alternation decoder** (decodes exactly one level for every input) with a range-guarded `decodeNumericReference`. It is config-driven so each call site keeps its **exact** behaviour:

- `named` — the site's own entity→char map (so e.g. hormuz keeps curly `“`, energy keeps straight `"`)
- `numericOverrides` / `numericDefault: decode | literal | space` — reproduces per-seeder numeric handling (e.g. security-advisories normalising `&#8217;`→`'`, sovereign-wealth's catch-all→space)
- `caseInsensitive`, `unknownToSpace` — for the `/gi` seeders and the sovereign-wealth catch-all

All 13 decoders from the issue now delegate to it (output unchanged, bugs fixed):

- **11 seeders** migrated: energy-intelligence, regulatory-actions, security-advisories, global-tenders, hormuz, climate-news, disease-outbreaks, `_trade-parse-utils`, china-macro/calendar, fatf-listing, sovereign-wealth
- **2 client components** (`CountryDeepDivePanel.ts`, `CountryDeepDivePanel-news-utils.ts`) apply the same single-pass logic **inline**, to avoid introducing a `scripts/ → src/` build dependency
- **`Dockerfile.relay`** copies the new shared module (the relay image builds `seed-climate-news`, the one containerised affected seeder — the COPY gotcha noted in the issue)

## Testing

`tests/entity-decode-shared.test.mjs` (node:test) covers: single-level round-trip, the double-decode case from this issue (`&amp;lt;script&amp;gt;` stays literal), the `RangeError` guard, numeric overrides, curly-quote preservation, case-insensitive matching, and the sovereign-wealth catch-all. All pass locally.

**Note:** I verified the shared decoder unit tests, syntax/import loading on every touched file, and faithful per-seeder output on spot-checks, and matched the 2-space style. I could not run the full `lint`/`typecheck`/`full`-variant e2e locally (dependency install), so please let CI confirm those — happy to adjust for any nits.
