### PR TITLE
fix(sidecar): release fetch-semaphore slots when upstreams stall mid-body (#5441)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -230,9 +230,22 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
       requestOptions.lookup = makePinnedLookup(pinned.address, pinned.family);
     }
     return await new Promise((resolve, reject) => {
+      // Settle idempotently on EVERY terminal event. Listening only for
+      // res 'end' / req 'error' leaks this Promise whenever an upstream sends
+      // headers and then stalls or truncates mid-body (common for rate-limited
+      // feeds): neither event fires, the finally below never runs, and one
+      // fetch-semaphore slot is lost until the process restarts (#5441).
+      let settled = false;
+      const settle = (fn, value) => {
+        if (settled) return;
+        settled = true;
+        fn(value);
+      };
       const req = mod.request(requestOptions, (res) => {
         const chunks = [];
         res.on('data', (c) => chunks.push(c));
+        res.on('error', (error) => settle(reject, error));
+        res.on('aborted', () => settle(reject, new Error('upstream response aborted mid-body')));
         res.on('end', () => {
           const buf = Buffer.concat(chunks);
           const responseHeaders = new Headers();
@@ -240,14 +253,27 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
             if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(', ') : v);
           }
           try {
-            resolve(buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
+            settle(resolve, buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
           } catch (error) {
-            reject(error);
+            settle(reject, error);
           }
         });
       });
-      req.on('error', reject);
-      if (init?.signal) { init.signal.addEventListener('abort', () => req.destroy()); }
+      req.on('error', (error) => settle(reject, error));
+      // 'close' always fires once the request is done or destroyed — the
+      // catch-all for truncated responses and destroyed sockets. On clean
+      // completion res 'end' has already resolved, so this settle is a no-op.
+      req.on('close', () => settle(reject, new Error('upstream request closed before response completed')));
+      if (init?.signal) {
+        init.signal.addEventListener(
+          'abort',
+          () => {
+            req.destroy();
+            settle(reject, new Error('upstream request aborted by signal'));
+          },
+          { once: true },
+        );
+      }
       if (body != null) req.write(body);
       req.end();
     });
@@ -1728,6 +1754,14 @@ async function dispatch(requestUrl, req, routes, context) {
     return json({ error: 'Local handler error', reason, endpoint: requestUrl.pathname }, 502);
   }
 }
+
+// Test seam (see tests/sidecar-fetch-semaphore.test.mjs): lets tests allow a
+// local stall-server origin through the SSRF guard and observe the semaphore
+// limit without exporting the production internals for general use.
+export const __testing__ = {
+  registerSidecarAllowedPrivateFetchOrigins,
+  MAX_CONCURRENT_UPSTREAM,
+};
 
 export async function createLocalApiServer(options = {}) {
   const context = resolveConfig(options);

--- a/tests/sidecar-fetch-semaphore.test.mjs
+++ b/tests/sidecar-fetch-semaphore.test.mjs
@@ -1,0 +1,68 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+
+// Importing the sidecar module installs its patched globalThis.fetch.
+import { __testing__ } from '../src-tauri/sidecar/local-api-server.mjs';
+
+const { registerSidecarAllowedPrivateFetchOrigins, MAX_CONCURRENT_UPSTREAM } = __testing__;
+
+// Regression test for #5441: an upstream that sends headers and then stalls or
+// truncates mid-body must REJECT the wrapped fetch (releasing its semaphore
+// slot), never leave the Promise pending. Pre-fix, each such response leaked
+// one of the MAX_CONCURRENT_UPSTREAM slots until every data fetch wedged.
+describe('sidecar fetch semaphore', () => {
+  let server;
+  let port;
+  let unregister;
+
+  before(async () => {
+    server = createServer((req, res) => {
+      if (req.url === '/stall') {
+        // Headers + partial body, then kill the socket: 'end' never fires.
+        res.writeHead(200, { 'content-type': 'text/plain', 'content-length': '100' });
+        res.write('partial');
+        setTimeout(() => res.socket.destroy(), 25);
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = server.address().port;
+    unregister = registerSidecarAllowedPrivateFetchOrigins(port);
+  });
+
+  after(async () => {
+    unregister?.();
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it('rejects stalled/truncated responses instead of hanging, and releases every slot', async () => {
+    const stalled = Array.from({ length: MAX_CONCURRENT_UPSTREAM + 1 }, () =>
+      fetch(`http://127.0.0.1:${port}/stall`).then(
+        () => 'resolved',
+        () => 'rejected',
+      ),
+    );
+
+    // Pre-fix these promises never settle; race a watchdog so the test fails
+    // fast and explicitly instead of timing out.
+    const outcome = await Promise.race([
+      Promise.all(stalled),
+      new Promise((resolve) => setTimeout(() => resolve('WEDGED'), 8000)),
+    ]);
+
+    assert.notEqual(outcome, 'WEDGED', 'stalled upstream responses left fetches pending (semaphore leak)');
+    for (const result of outcome) assert.equal(result, 'rejected');
+
+    // All slots must be free again: a healthy fetch goes straight through.
+    const healthy = await Promise.race([
+      fetch(`http://127.0.0.1:${port}/ok`),
+      new Promise((resolve) => setTimeout(() => resolve('WEDGED'), 4000)),
+    ]);
+    assert.notEqual(healthy, 'WEDGED', 'healthy fetch blocked: semaphore slots were not released');
+    assert.equal(healthy.status, 200);
+    assert.equal(await healthy.text(), 'ok');
+  });
+});


### PR DESCRIPTION
Closes #5441

## Problem

The `globalThis.fetch` wrapper in `src-tauri/sidecar/local-api-server.mjs` throttles all outbound requests through the 6-slot global semaphore, releasing the slot in a `finally` after the wrapped `http(s).request` Promise settles. That Promise only settled on `res 'end'` or `req 'error'`. An upstream that **accepts the connection, sends headers, then stalls or truncates mid-body** — a routine failure for rate-limited feeds — fires neither event: the Promise never settles, the `finally` never runs, and one slot leaks permanently. After ~6 such stalls, every data fetch parks forever on `acquireUpstreamSlot()` while in-memory RPCs (which never call `fetch`) keep responding — exactly the ~hourly wedge described in the issue.

## Fix

Following the direction suggested in the issue (credit to @mosabsayyed for the excellent diagnosis): settle the Promise **idempotently on every terminal event** —

- `res 'error'` and `res 'aborted'` → reject (stalled/truncated body)
- `req 'close'` → reject as a catch-all for destroyed sockets (a no-op after a clean `res 'end'` resolve, guarded by the `settled` flag)
- the abort-signal listener now rejects directly (with `{ once: true }`) instead of relying on `req.destroy()` to surface an error

With every path settling, `finally { releaseUpstreamSlot() }` always runs and the semaphore can no longer be exhausted by stuck upstreams.

## Testing

`tests/sidecar-fetch-semaphore.test.mjs` + a small `__testing__` seam (mirroring the existing `__testing__` pattern in `list-feed-digest.ts`):

1. stands up a local server whose `/stall` endpoint sends headers + a partial body, then destroys the socket;
2. fires `MAX_CONCURRENT_UPSTREAM + 1` concurrent fetches at it — **each must reject, not hang** (a watchdog race fails the test explicitly if any are left pending);
3. then fetches a healthy endpoint and asserts it goes straight through — proving all slots were released.

**Red/green verified**: the test fails against the pre-fix wrapper with `stalled upstream responses left fetches pending (semaphore leak)` and passes with the fix.

Note: as the issue observes, the same `end`/`error`-only pattern exists in a couple of other non-semaphored `http(s).request` wrappers in this file; left out of scope here since only the `globalThis.fetch` wrapper is load-bearing for the wedge.
