### PR TITLE
fix(notifications): bound the Convex relay fetch with a timeout (#5426)

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -32,6 +32,12 @@ const RELAY_SHARED_SECRET = process.env.RELAY_SHARED_SECRET ?? '';
 const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL ?? '';
 const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN ?? '';
 
+// Bound the Convex relay round-trip. Without it a hung Convex action keeps the
+// caller open past the idempotency PROCESSING TTL, so the lock stays held and
+// every retry 409s until it expires (#5426). Kept above the 5s Upstash-queue
+// timeouts since a Convex action does more work, but well under the lock TTL.
+const CONVEX_RELAY_TIMEOUT_MS = 10_000;
+
 // AES-256-GCM encryption using Web Crypto (matches Node crypto.cjs decrypt format).
 // Format stored: v1:<base64(iv[12] || tag[16] || ciphertext)>
 async function encryptSlackWebhook(webhookUrl: string): Promise<string> {
@@ -147,6 +153,7 @@ async function convexRelay(body: Record<string, unknown>): Promise<Response> {
       'Authorization': `Bearer ${RELAY_SHARED_SECRET}`,
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(CONVEX_RELAY_TIMEOUT_MS),
   });
 }
 


### PR DESCRIPTION
## Summary

`convexRelay()` in `api/notification-channels.ts` issued its `fetch` with no `AbortSignal`, so a hung Convex action kept the request open past the idempotency `PROCESSING` TTL — the lock stayed held and every retry `409`'d for ~180s (#5426). The two sibling Upstash-queue fetches in the same file already bound their calls with `AbortSignal.timeout(5000)`.

This bounds the relay round-trip with `AbortSignal.timeout(10_000)` — long enough for a real Convex action, well under the lock TTL. On timeout the fetch rejects; the existing POST `catch` already calls `finish()` → `completeStandaloneIdempotency()`, which **releases the lock** and returns 500, so retries proceed immediately instead of 409-looping. The GET path benefits from the same bound (no more hang) and already returns 500 on error.

Fixes #5426.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck:api` passes, incl. the Convex-call audit)
- [x] Biome lint clean

<sub>🤖 AI-assisted (Claude Opus 4.8).</sub>
