### PR TITLE
fix(consumer-prices): gate implausible movers as parse artifacts (#5445)

### DIFF
--- a/consumer-prices-core/src/snapshots/worldmonitor.test.ts
+++ b/consumer-prices-core/src/snapshots/worldmonitor.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { isPlausiblePriceMove, MAX_MOVE_RATIO } from './worldmonitor.js';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+vi.mock('../db/client.js', () => ({ query: mockQuery }));
+
+const { buildMoversSnapshot, isPlausiblePriceMove, MAX_MOVE_RATIO } = await import(
+  './worldmonitor.js'
+);
 
 describe('isPlausiblePriceMove', () => {
   it('rejects the parse-artifact movers reported in #5445', () => {
@@ -27,5 +33,69 @@ describe('isPlausiblePriceMove', () => {
   it('rejects non-finite change values', () => {
     expect(isPlausiblePriceMove(Number.NaN)).toBe(false);
     expect(isPlausiblePriceMove(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe('buildMoversSnapshot', () => {
+  const row = (id: string, changePct: string) => ({
+    product_id: id,
+    raw_title: `Product ${id}`,
+    category_text: 'grocery',
+    retailer_slug: 'lulu_ae',
+    current_price: '10.00',
+    currency_code: 'AED',
+    change_pct: changePct,
+  });
+
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('ranks risers/fallers over the gated set, not the raw rows (#5445)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        row('1', '874.68'), // White Sugar 1kg artifact — must be dropped
+        row('2', '-99.25'), // Yaumi bread artifact — must be dropped
+        row('3', '12.5'),
+        row('4', '-40'),
+      ],
+    });
+
+    const snap = await buildMoversSnapshot('ae', 7);
+
+    expect(snap.risers.map((m) => m.productId)).toEqual(['3']);
+    expect(snap.fallers.map((m) => m.productId)).toEqual(['4']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('dropped 2/4');
+  });
+
+  it('publishes an empty snapshot when every fetched row is implausible', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [row('1', '874.68'), row('2', '608.86'), row('3', '-99.25')],
+    });
+
+    const snap = await buildMoversSnapshot('ae', 7);
+
+    expect(snap.risers).toEqual([]);
+    expect(snap.fallers).toEqual([]);
+    expect(snap.upstreamUnavailable).toBe(false);
+    expect(String(warn.mock.calls[0][0])).toContain('dropped 3/3');
+  });
+
+  it('does not warn when every mover is plausible', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row('1', '12.5'), row('2', '-40')] });
+
+    const snap = await buildMoversSnapshot('ae', 7);
+
+    expect(snap.risers).toHaveLength(1);
+    expect(snap.fallers).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/consumer-prices-core/src/snapshots/worldmonitor.test.ts
+++ b/consumer-prices-core/src/snapshots/worldmonitor.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isPlausiblePriceMove, MAX_MOVE_RATIO } from './worldmonitor.js';
+
+describe('isPlausiblePriceMove', () => {
+  it('rejects the parse-artifact movers reported in #5445', () => {
+    expect(isPlausiblePriceMove(874.68)).toBe(false); // White Sugar 1kg, lulu_ae
+    expect(isPlausiblePriceMove(608.86)).toBe(false); // Whole Chicken, spinneys_ae
+    expect(isPlausiblePriceMove(-99.25)).toBe(false); // Yaumi bread
+  });
+
+  it('keeps realistic weekly moves', () => {
+    expect(isPlausiblePriceMove(0)).toBe(true);
+    expect(isPlausiblePriceMove(12.5)).toBe(true);
+    expect(isPlausiblePriceMove(-40)).toBe(true);
+  });
+
+  it('gates exactly at the bilateral MAX_MOVE_RATIO bound', () => {
+    expect(MAX_MOVE_RATIO).toBe(4);
+    // upper bound: new price = 4x past -> +300%
+    expect(isPlausiblePriceMove(300)).toBe(true);
+    expect(isPlausiblePriceMove(300.1)).toBe(false);
+    // lower bound: new price = 0.25x past -> -75%
+    expect(isPlausiblePriceMove(-75)).toBe(true);
+    expect(isPlausiblePriceMove(-75.1)).toBe(false);
+  });
+
+  it('rejects non-finite change values', () => {
+    expect(isPlausiblePriceMove(Number.NaN)).toBe(false);
+    expect(isPlausiblePriceMove(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});

--- a/consumer-prices-core/src/snapshots/worldmonitor.test.ts
+++ b/consumer-prices-core/src/snapshots/worldmonitor.test.ts
@@ -74,19 +74,43 @@ describe('buildMoversSnapshot', () => {
     expect(snap.fallers.map((m) => m.productId)).toEqual(['4']);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(String(warn.mock.calls[0][0])).toContain('dropped 2/4');
+    // the gate is bilateral — the warn must not claim only the >4x direction
+    expect(String(warn.mock.calls[0][0])).toContain('outside 0.25x-4x');
   });
 
-  it('publishes an empty snapshot when every fetched row is implausible', async () => {
+  it('throws instead of publishing an empty snapshot when every row is gated', async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [row('1', '874.68'), row('2', '608.86'), row('3', '-99.25')],
     });
+
+    // The publish job's per-snapshot catch skips the write on throw, keeping
+    // the previous (real) snapshot alive instead of overwriting it with a
+    // false-healthy empty one.
+    await expect(buildMoversSnapshot('ae', 7)).rejects.toThrow(
+      /all 3 candidates gated as implausible/,
+    );
+    expect(String(warn.mock.calls[0][0])).toContain('dropped 3/3');
+  });
+
+  it('returns an empty snapshot when the window has no movers at all', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const snap = await buildMoversSnapshot('ae', 7);
 
     expect(snap.risers).toEqual([]);
     expect(snap.fallers).toEqual([]);
     expect(snap.upstreamUnavailable).toBe(false);
-    expect(String(warn.mock.calls[0][0])).toContain('dropped 3/3');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('fetches a 200-row candidate window so the gate cannot starve the top-10 lists', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await buildMoversSnapshot('ae', 7);
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('LIMIT 200');
+    expect(sql).toContain('ORDER BY ABS');
   });
 
   it('does not warn when every mover is plausible', async () => {

--- a/consumer-prices-core/src/snapshots/worldmonitor.ts
+++ b/consumer-prices-core/src/snapshots/worldmonitor.ts
@@ -295,6 +295,19 @@ export async function buildOverviewSnapshot(marketCode: string): Promise<WMOverv
   };
 }
 
+// A shelf-price change beyond a 4x ratio in either direction is far more likely
+// a unit/pack-size parse artifact (single vs multipack, per-kg vs per-100g,
+// currency drift) than a real move. Gating these keeps movers trustworthy
+// (#5445); the 4x bilateral bound mirrors the grocery-basket outlier gate
+// (#2322).
+export const MAX_MOVE_RATIO = 4;
+
+export function isPlausiblePriceMove(changePct: number): boolean {
+  if (!Number.isFinite(changePct)) return false;
+  const ratio = 1 + changePct / 100; // newPrice / pastPrice
+  return ratio >= 1 / MAX_MOVE_RATIO && ratio <= MAX_MOVE_RATIO;
+}
+
 export async function buildMoversSnapshot(
   marketCode: string,
   rangeDays: number,
@@ -349,12 +362,22 @@ export async function buildMoversSnapshot(
     changePct: parseFloat(r.change_pct),
   }));
 
+  // Drop implausible movers (unit/pack-size parse artifacts) before ranking so
+  // the published risers/fallers stay trustworthy (#5445).
+  const plausible = all.filter((r) => isPlausiblePriceMove(r.changePct));
+  const dropped = all.length - plausible.length;
+  if (dropped > 0) {
+    console.warn(
+      `[movers] ${marketCode} ${range}: dropped ${dropped}/${all.length} implausible movers (>${MAX_MOVE_RATIO}x — likely unit/parse artifacts)`,
+    );
+  }
+
   return {
     marketCode,
     asOf: String(now),
     range,
-    risers: all.filter((r) => r.changePct > 0).slice(0, 10),
-    fallers: all.filter((r) => r.changePct < 0).slice(0, 10),
+    risers: plausible.filter((r) => r.changePct > 0).slice(0, 10),
+    fallers: plausible.filter((r) => r.changePct < 0).slice(0, 10),
     upstreamUnavailable: false,
   };
 }

--- a/consumer-prices-core/src/snapshots/worldmonitor.ts
+++ b/consumer-prices-core/src/snapshots/worldmonitor.ts
@@ -348,7 +348,10 @@ export async function buildMoversSnapshot(
      JOIN past p ON p.id = l.id
      WHERE p.past_price > 0
      ORDER BY ABS((l.price - p.past_price) / p.past_price) DESC
-     LIMIT 30`,
+     -- 200 (not 30): the biggest-magnitude rows are exactly the ones the
+     -- plausibility gate below rejects, so the window needs headroom or
+     -- artifacts starve the top-10 lists (#5445)
+     LIMIT 200`,
     [marketCode, rangeDays],
   );
 
@@ -368,7 +371,16 @@ export async function buildMoversSnapshot(
   const dropped = all.length - plausible.length;
   if (dropped > 0) {
     console.warn(
-      `[movers] ${marketCode} ${range}: dropped ${dropped}/${all.length} implausible movers (>${MAX_MOVE_RATIO}x — likely unit/parse artifacts)`,
+      `[movers] ${marketCode} ${range}: dropped ${dropped}/${all.length} implausible movers (outside ${1 / MAX_MOVE_RATIO}x-${MAX_MOVE_RATIO}x — likely unit/parse artifacts)`,
+    );
+  }
+  if (all.length > 0 && plausible.length === 0) {
+    // Every candidate was gated as a parse artifact. Publishing an empty but
+    // "healthy" snapshot would overwrite the last good one and render as a
+    // false "no movers" — fail loudly instead; the publish job's per-snapshot
+    // catch keeps the previous snapshot alive under its TTL (#5445).
+    throw new Error(
+      `[movers] ${marketCode} ${range}: all ${all.length} candidates gated as implausible — refusing to publish an empty movers snapshot`,
     );
   }
 


### PR DESCRIPTION
## Summary

`buildMoversSnapshot` (`consumer-prices-core/src/snapshots/worldmonitor.ts`) ranked `topMovers` straight from the raw current-vs-past price delta with no sanity bound, so a unit/pack-size **parse glitch surfaced as a headline mover** — e.g. White Sugar 1kg **+874.68%**, Whole Chicken **+608.86%**, Yaumi bread **−99.25%** (#5445). That blocks publishing shelf-price receipts because the movers can't be trusted.

This adds a bilateral plausibility gate (`isPlausiblePriceMove`): drop moves whose new/past price ratio falls outside `[1/4, 4]` — the same factor-4 bound already used by the grocery-basket outlier gate (#2322). Ranking now runs over the gated set, and dropped counts are logged so upstream parse drift stays visible instead of silently vanishing.

The retailer-spread half of the issue is **already floored** (`MIN_SPREAD_ITEMS = 4`, so `spreadPct` correctly reads 0 when the common basket is too thin) — no change needed there.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Market Radar / Crypto <!-- consumer-prices / shelf-price movers -->
- [x] Other: consumer-prices-core (movers snapshot)

## Checklist

- [x] No API keys or secrets committed
- [x] `consumer-prices-core` builds clean (`npm run build` / `tsc`)
- [x] Full vitest suite green (105 tests, incl. 4 new covering the reported artifacts, realistic moves, exact ±ratio boundaries, and non-finite inputs)

<sub>🤖 AI-assisted (Claude Opus 4.8).</sub>
