### PR TITLE
fix(ml-worker): clear de-dupe entry when a model load rejects

### DIFF
--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -161,7 +161,6 @@ async function loadModel(modelId: string): Promise<void> {
     });
 
     loadedPipelines.set(modelId, pipe);
-    loadingPromises.delete(modelId);
     console.log(`[MLWorker] Model loaded in ${Date.now() - startTime}ms: ${modelId}`);
 
     // Notify manager that model is now available (no id = unsolicited notification)
@@ -169,6 +168,23 @@ async function loadModel(modelId: string): Promise<void> {
   })();
 
   loadingPromises.set(modelId, loadPromise);
+
+  // Clear the de-dupe entry once the load settles, on both the success and
+  // failure paths, so a transient failure (offline, flaky connection, HF CDN
+  // hiccup) doesn't permanently pin a rejected promise here and disable the
+  // model for the rest of the worker's lifetime. Attached after `.set(...)`
+  // rather than via try/finally inside the IIFE above, so a synchronous throw
+  // before the entry is inserted can never delete it prematurely.
+  loadPromise
+    .finally(() => {
+      loadingPromises.delete(modelId);
+    })
+    .catch(() => {
+      // Already surfaced to the caller via the returned/awaited loadPromise;
+      // this only suppresses the duplicate unhandled-rejection warning on
+      // the derived promise that .finally() creates.
+    });
+
   return loadPromise;
 }
 


### PR DESCRIPTION
Fixes #5425.

## Problem

`loadModel()` caches the in-flight load promise in `loadingPromises` so concurrent callers share one download. The matching `delete` only ran on the success path, inside the async IIFE after the awaited `pipeline()` call resolved. If `pipeline()` rejected (offline, flaky connection, HF CDN hiccup), the rejected promise stayed cached forever — every later call for that model got the identical rejection instantly, with no retry, until the page reloaded.

## Fix

Moved the cleanup to a `.finally()` chained onto `loadPromise` after it's inserted into `loadingPromises`, so it runs on both the success and failure paths — matching the fix direction described in the issue.

Attaching it there (rather than a `try/finally` inside the IIFE) matters: if anything in the IIFE threw synchronously before the map insertion at the bottom runs, an internal `finally` could end up deleting an entry that was never there. Chaining onto the already-created `loadPromise` after `.set(...)` avoids that ordering hazard entirely.

I also added a `.catch(() => {})` on the `.finally()` chain — `.finally()` forwards the original rejection to the promise it returns, and nothing else was observing that derived promise, so it would have shown up as a *second*, unhandled rejection distinct from the one the caller already sees via the returned/awaited `loadPromise`. Caught this with a small standalone reproduction of the same pattern before applying it here — worth flagging since it's an easy thing to miss when reaching for `.finally()` for cleanup.

## Testing

I verified the core de-dupe/cleanup logic in isolation with a minimal reproduction of the same promise-caching pattern (reject → resolve → confirm `pipeline()` is invoked twice and the map ends up empty), matching the "old vs new" comparison in the issue description. I didn't run the actual worker end-to-end against a real offline/online network transition, since that needs the full app running in a browser.