### PR TITLE
feat(market): feed stock fundamentals into the analysis overlay

### DIFF
--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -141,6 +141,19 @@ type YahooQuoteSummaryResponse = {
         targetMedianPrice?: { raw?: number };
         currentPrice?: { raw?: number };
         numberOfAnalystOpinions?: { raw?: number };
+        // Fundamentals returned in the same module but previously discarded (#5445-adjacent richness).
+        profitMargins?: { raw?: number };
+        grossMargins?: { raw?: number };
+        operatingMargins?: { raw?: number };
+        returnOnEquity?: { raw?: number };
+        returnOnAssets?: { raw?: number };
+        revenueGrowth?: { raw?: number };
+        earningsGrowth?: { raw?: number };
+        debtToEquity?: { raw?: number };
+        totalCash?: { raw?: number };
+        totalDebt?: { raw?: number };
+        freeCashflow?: { raw?: number };
+        ebitda?: { raw?: number };
       };
       upgradeDowngradeHistory?: {
         history?: YahooUpgradeEntry[];
@@ -149,10 +162,28 @@ type YahooQuoteSummaryResponse = {
   };
 };
 
+// Quality / growth / leverage fundamentals parsed from Yahoo's financialData
+// module (already fetched for price targets). Any field may be absent.
+export type StockFundamentals = {
+  profitMargin?: number;
+  grossMargin?: number;
+  operatingMargin?: number;
+  returnOnEquity?: number;
+  returnOnAssets?: number;
+  revenueGrowth?: number;
+  earningsGrowth?: number;
+  debtToEquity?: number;
+  totalCash?: number;
+  totalDebt?: number;
+  freeCashflow?: number;
+  ebitda?: number;
+};
+
 export type AnalystData = {
   analystConsensus: AnalystConsensus;
   priceTarget: PriceTarget;
   recentUpgrades: UpgradeDowngrade[];
+  fundamentals: StockFundamentals;
 };
 
 export type DividendProfile = {
@@ -739,10 +770,18 @@ function optionalPositive(field: { raw?: number } | undefined): number | undefin
   return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : undefined;
 }
 
+// Like optionalPositive but keeps negatives — margins, growth and returns can
+// legitimately be below zero, so they must not be dropped as "missing".
+function optionalFinite(field: { raw?: number } | undefined): number | undefined {
+  const raw = field?.raw;
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
 const EMPTY_ANALYST_DATA: AnalystData = {
   analystConsensus: { strongBuy: 0, buy: 0, hold: 0, sell: 0, strongSell: 0, total: 0, period: '' },
   priceTarget: { numberOfAnalysts: 0 },
   recentUpgrades: [],
+  fundamentals: {},
 };
 
 export async function fetchYahooAnalystData(symbol: string): Promise<AnalystData> {
@@ -794,7 +833,23 @@ export async function fetchYahooAnalystData(symbol: string): Promise<AnalystData
       epochGradeDate: typeof entry.epochGradeDate === 'number' ? entry.epochGradeDate : 0,
     })).filter((u) => u.firm);
 
-    return { analystConsensus, priceTarget, recentUpgrades };
+    // Quality/growth/leverage fundamentals from the same financialData module.
+    const fundamentals: StockFundamentals = fd ? {
+      profitMargin: optionalFinite(fd.profitMargins),
+      grossMargin: optionalFinite(fd.grossMargins),
+      operatingMargin: optionalFinite(fd.operatingMargins),
+      returnOnEquity: optionalFinite(fd.returnOnEquity),
+      returnOnAssets: optionalFinite(fd.returnOnAssets),
+      revenueGrowth: optionalFinite(fd.revenueGrowth),
+      earningsGrowth: optionalFinite(fd.earningsGrowth),
+      debtToEquity: optionalFinite(fd.debtToEquity),
+      totalCash: optionalFinite(fd.totalCash),
+      totalDebt: optionalFinite(fd.totalDebt),
+      freeCashflow: optionalFinite(fd.freeCashflow),
+      ebitda: optionalFinite(fd.ebitda),
+    } : {};
+
+    return { analystConsensus, priceTarget, recentUpgrades, fundamentals };
   } catch {
     return EMPTY_ANALYST_DATA;
   }
@@ -1140,13 +1195,15 @@ async function buildAiOverlay(
   name: string,
   technical: TechnicalSnapshot,
   headlines: StockAnalysisHeadline[],
+  fundamentals: StockFundamentals,
 ): Promise<AiOverlay> {
   const fallback = getFallbackOverlay(name, technical, headlines);
+  const hasFundamentals = Object.values(fundamentals).some((v) => typeof v === 'number');
   const llm = await callLlm({
     messages: [
       {
         role: 'system',
-        content: 'You are a disciplined stock analyst. Return strict JSON only with keys: summary, action, confidence, whyNow, technicalSummary, newsSummary, bullishFactors, riskFactors. Keep it concise, factual, and free of disclaimers.',
+        content: 'You are a disciplined stock analyst. Weigh the fundamentals (profitability, returns on equity/assets, revenue/earnings growth, leverage) alongside the technicals and news — do not judge on price action alone. Return strict JSON only with keys: summary, action, confidence, whyNow, technicalSummary, newsSummary, bullishFactors, riskFactors. Keep it concise, factual, and free of disclaimers.',
       },
       {
         role: 'user',
@@ -1181,6 +1238,8 @@ async function buildAiOverlay(
             source: headline.source,
             publishedAt: headline.publishedAt,
           })),
+          // Only sent when present; JSON.stringify drops undefined members.
+          fundamentals: hasFundamentals ? fundamentals : undefined,
         }),
       },
     ],
@@ -1438,7 +1497,7 @@ export async function analyzeStock(
         ? fetchExtendedHoursQuote(symbol, marketSession)
         : Promise.resolve(null),
     ]);
-    const overlay = await buildAiOverlay(symbol, name, technical, headlines);
+    const overlay = await buildAiOverlay(symbol, name, technical, headlines, analystData.fundamentals);
     const analysisAt = history.candles[history.candles.length - 1]?.timestamp || Date.now();
     const response = buildAnalysisResponse({
       symbol,


### PR DESCRIPTION
## Summary

`analyze-stock` already fetches Yahoo's `financialData` module (for price targets) but parsed only the ~6 target fields and **discarded** the fundamentals returned in the same response. The AI overlay that writes `summary`/`action`/`whyNow` therefore judged each stock on technicals + headlines alone — blind to profitability, returns, growth, and leverage.

This parses the discarded fields (profit / gross / operating margins, ROE, ROA, revenue / earnings growth, debt-to-equity, cash / debt, FCF, EBITDA) and passes them to `buildAiOverlay`, so the analyst prompt weighs fundamentals alongside the technicals and news.

- **No new upstream request** — the data was already on the wire in the existing `financialData` fetch.
- **No proto change** — the fundamentals feed the existing overlay, not a new response field. A structured `Fundamentals` response message + panel rendering + a `fundamentalScore` are natural follow-ups.
- Negative values (margins / growth can be < 0) are preserved via a finite-not-just-positive parse; missing fields are omitted from the prompt.

## Type of change

- [x] New feature (analysis enrichment)

## Affected areas

- [x] Market Radar / Crypto
- [x] AI Insights / World Brief

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] Biome lint clean

<sub>🤖 AI-assisted (Claude Opus 4.8).</sub>
