### PR TITLE
fix: strip transport Authorization header before dispatch to route ha…

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1695,6 +1695,7 @@ async function dispatch(requestUrl, req, routes, context) {
 
     const body = ['GET', 'HEAD'].includes(req.method) ? undefined : await readBody(req);
     const hdrs = toHeaders(req.headers, { stripOrigin: true });
+    hdrs.delete('Authorization');
     hdrs.set('Origin', `http://127.0.0.1:${context.port}`);
     const request = new Request(requestUrl.toString(), {
       method: req.method,


### PR DESCRIPTION
Fixes #5471

## Summary

The sidecar's global auth gate validates the incoming `Authorization`
header against `LOCAL_API_TOKEN`, then forwards that same header
downstream to route handlers. Handlers like `api/mcp/auth.ts` read
`Authorization` as caller identity, so the transport token silently
overrides any caller-supplied `X-WorldMonitor-Key`, making the
`X-WorldMonitor-Key` fallback unreachable by construction and leaving
`/api/mcp` unauthenticatable in Docker self-host deployments.

**Fix:** delete the `Authorization` header after the auth gate has
consumed it, before dispatching to the route handler. This lets
caller-supplied auth (bearer or `X-WorldMonitor-Key`) reach the
handler unmodified, restoring the intended fallback behavior in
`api/mcp/auth.ts`.

One-line change in `src-tauri/sidecar/local-api-server.mjs`, no
changes to `nginx.conf.template` or `api/mcp/auth.ts` needed.

**Tested locally:** with the fix, a request carrying both a
`X-WorldMonitor-Key` and a stand-in transport bearer (simulating
nginx's injected header) now correctly authenticates via the API key
and returns a full `tools/list` result, instead of failing with
`Invalid or expired OAuth token`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas
- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other:

## Checklist
- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist
N/A — this change does not touch methodology, API/MCP contracts, generated docs, examples, Redis keys, CII, CRI, news, digest, or briefing content.

## Screenshots

Before fix (simulated nginx header clobber — `X-WorldMonitor-Key` + stand-in transport bearer):