### PR TITLE
docs(blog): clarify WorldMonitor and Palantir positioning

### DIFF
--- a/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
+++ b/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
@@ -59,7 +59,7 @@ UCDP conflict events, IMF PortWatch ship transits, EIA petroleum stocks, OFAC de
 - **Compare countries and exposures.** Use country briefs, instability and resilience indicators, travel advisories, sanctions, displacement, and macroeconomic data to understand relative pressure and capacity.
 - **Monitor what matters to you.** Follow countries, markets, airports, airlines, commodities, routes, and other watchlist items; Pro workflows add richer analysis and scheduled digests.
 - **Explore possible consequences.** Route Explorer and the Scenario Engine model how conflict, weather, sanctions, and tariff shocks could move through chokepoints, sectors, and countries; WM Analyst lets you question the live intelligence stack with citations.
-- **Build on the intelligence layer.** Authenticated API and MCP access can feed structured intelligence into software and agents; the CLI and official SDKs shorten the integration path; the embeddable map and AGPL source let you publish, fork, or self-host a version of your own.
+- **Build on the intelligence layer.** Public REST routes expose health, discovery, and dashboard-support data without a key; authenticated API and MCP access can feed the broader structured intelligence layer into software and agents. The CLI and official SDKs shorten the integration path; the embeddable map and AGPL source let you publish, fork, or self-host a version of your own.
 
 The core dashboards, map layers, feeds, briefs, and watchlists remain free and require no account. Compute-heavy analysis and programmatic data access support the paid tiers. The source remains inspectable, adaptable, and self-hostable under AGPL-3.0.
 

--- a/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
+++ b/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
@@ -1,6 +1,6 @@
 ---
 title: "WorldMonitor Is Not an Open-Source Palantir"
-description: "One command shows the difference: Palantir organizes your institution's private data behind closed deployments. WorldMonitor publishes intelligence on the world's public data — live, free, forkable."
+description: "WorldMonitor turns public data across markets, trade, conflict, energy, and infrastructure into live dashboards, APIs, and agent tools — not a Palantir clone."
 metaTitle: "WorldMonitor Is Not an Open-Source Palantir | World Monitor"
 keywords: "WorldMonitor vs Palantir, Palantir alternative open source, open intelligence platform, economic intelligence dashboard, global financial data platform, build on intelligence API"
 audience: "Press, analysts, developers, investors, anyone who has seen the Palantir comparison"
@@ -28,66 +28,84 @@ No API key. No sales call. No contract. Here's what it returned the moment this 
 }
 ```
 
-That's WorldMonitor monitoring 232 of its own data sources — and publicly reporting, to anyone who asks, that its US government-tenders feed was stale at that moment because SAM.gov was rate-limiting us. We didn't clean that up for this post. The failure report *is* the point.
+That's 232 monitored data contracts across WorldMonitor's own platform — and a public admission, to anyone who asks, that its US government-tenders feed was stale because SAM.gov was rate-limiting us. We didn't clean that up for this post. The failure report *is* the point.
 
-Now try getting Palantir to show you anything at all this afternoon.
+That is the difference in miniature: WorldMonitor begins with the public-world data layer already assembled, running, and showing its own cracks.
 
 ## The comparison we keep getting
 
-There's a third-party explainer of our codebase titled ["worldmonitor: The Open-Source Palantir Running in Your Browser."](https://repo-explainer.com/koala73/worldmonitor) Supporters introduce us the same way. "Open-source Palantir" has become a whole genre — other projects [market themselves with exactly that phrase](https://osirisai.live/). We understand the shorthand: dark map, live data, global scope. One thank-you covers it: when people reach for a $400-billion company as the reference point for a free dashboard, the ambition landed.
+There's a third-party explainer of our codebase titled ["worldmonitor: The Open-Source Palantir Running in Your Browser."](https://repo-explainer.com/koala73/worldmonitor) Supporters introduce us the same way. "Open-source Palantir" has become a whole genre — other projects [market themselves with exactly that phrase](https://osirisai.live/). We understand the shorthand: dark map, live data, global scope. One thank-you covers it: when people reach for Palantir as the reference point for a free dashboard, the ambition landed.
 
-But the comparison mistakes what both things are. And the mistake is worth correcting precisely, because what WorldMonitor actually is turns out to be more useful to more people.
+But the comparison mistakes what both things are. And the mistake is worth correcting precisely, because what WorldMonitor actually is turns out to be available to — and useful for — far more than institutional buyers.
 
 ## What Palantir is — credit where due
 
-Palantir builds data-integration software for institutions. Gotham, Foundry, and AIP take a customer's *own* data — case files, logistics ledgers, sensor logs — and make it queryable inside a private ontology, behind the customer's walls, under a negotiated contract. It is genuinely excellent at that job, which is why institutions pay what they pay.
+Palantir builds data-integration and operational software for institutions. Gotham, Foundry, and AIP are designed to take an organization's *own* data — case files, logistics ledgers, sensor logs — and make it usable inside a governed ontology, with the organization's permissions and workflows wrapped around it. It is genuinely excellent at that job, which is why institutions pay what they pay. Palantir also offers an [AIP Developer Tier](https://www.palantir.com/docs/foundry/getting-started/overview) for trying Foundry and AIP, so the distinction is not whether someone can open the software at all.
 
-Note what that job is: **Palantir makes your private data usable by you.** It doesn't primarily provide data. If your organization has nothing to integrate, Palantir has nothing to sell you.
+Note what that job is: **Palantir makes your institution's data operational inside your institution.** It is a platform onto which the customer brings data, models, users, and workflows. WorldMonitor starts from the other end.
 
 ## What WorldMonitor is
 
-WorldMonitor inverts every term of that sentence: **it makes the world's public data usable by everyone.** UCDP conflict events, IMF PortWatch ship transits, EIA petroleum stocks, OFAC designations, UNHCR displacement, USGS seismographs, Eurostat series, prediction-market odds, 567 curated news feeds — ingested continuously, classified, mapped, and published to a URL with no login.
+WorldMonitor is an open-source, real-time intelligence platform that turns public data into a live operating picture of the world — for people, software, and AI agents. It continuously collects signals from official datasets, market venues, sensors, newsrooms, and open-source networks; normalizes and classifies them; tracks their provenance and freshness; and publishes them through interactive dashboards and structured interfaces.
 
-And despite the war-room aesthetic that invites the Palantir shorthand, the center of gravity is **economic**. Count the surface: [markets and central-bank trackers](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/), [chokepoints and freight](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/), [tariffs and customs revenue](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/), [government tenders from six official portals](/blog/posts/government-tenders-procurement-intelligence-worldmonitor/), [shelf-price inflation](/blog/posts/ground-truth-inflation-shelf-price-tracking-worldmonitor/), energy intelligence, prediction markets.
+It doesn't merely put dots on a map. The map answers *where* something is happening. Panels and briefs explain *what changed*. Country indices, timelines, and cross-stream correlation help assess *how significant it may be*. Route Explorer, the Scenario Engine, and WM Analyst help investigate *what it affects* and *what could happen next*. The same data spine supports six focused dashboards; software and agents can query it through the REST API, MCP server, CLI, and official SDKs.
 
-Here's the sanctions layer, queried live while writing this (July 22, 2026): **20,398 active OFAC designations** — 19,345 SDN plus 1,053 consolidated — including 1,517 vessels and 344 aircraft. Russia carries 5,931 country-tagged entries against Iran's 1,607, and the single largest program, `RUSSIA-EO14024`, holds 6,794. That's not a marketing claim about "tracking sanctions." That's the data, and you can pull the same numbers right now through the [MCP server](https://www.worldmonitor.app/docs/mcp-quickstart) or the [API](https://www.worldmonitor.app/docs/api-reference).
+UCDP conflict events, IMF PortWatch ship transits, EIA petroleum stocks, OFAC designations, UNHCR displacement, USGS earthquakes, Eurostat series, prediction-market odds, and 500+ curated news feeds all enter that system. The important product is not any single event, price, or headline. It is the ability to see signals that normally live in separate systems together, while retaining enough source and freshness information to judge them.
 
-Conflict tracking is real and serious on WorldMonitor — but it's there because **war is an economic event**. When Hormuz goes yellow, tankers reroute, freight and insurance reprice, energy flows shift, sanctions programs swell. The red dots matter because of what they do to prices, routes, and policy. Palantir pattern-matches to the map; it misses that most of the platform is telling you what the map costs.
+## What you can do with it
+
+- **Build a situation picture in minutes.** Combine conflict, maritime, aviation, infrastructure, disaster, cyber, market, and news signals in one live view instead of rebuilding it across a dozen tabs.
+- **Trace second-order effects.** Move from an incident at Hormuz to vessel traffic, energy flows, freight exposure, sanctions, markets, and related reporting without losing the thread between them.
+- **Compare countries and exposures.** Use country briefs, instability and resilience indicators, travel advisories, sanctions, displacement, and macroeconomic data to understand relative pressure and capacity.
+- **Monitor what matters to you.** Follow countries, markets, airports, airlines, commodities, routes, and other watchlist items; Pro workflows add richer analysis and scheduled digests.
+- **Explore possible consequences.** Route Explorer and the Scenario Engine model how conflict, weather, sanctions, and tariff shocks could move through chokepoints, sectors, and countries; WM Analyst lets you question the live intelligence stack with citations.
+- **Build on the intelligence layer.** Authenticated API and MCP access can feed structured intelligence into software and agents; the CLI and official SDKs shorten the integration path; the embeddable map and AGPL source let you publish, fork, or self-host a version of your own.
+
+The core dashboards, map layers, feeds, briefs, and watchlists remain free and require no account. Compute-heavy analysis and programmatic data access support the paid tiers. The source remains inspectable, adaptable, and self-hostable under AGPL-3.0.
+
+Despite the war-room aesthetic that invites the Palantir shorthand, economic and operational consequence is one of WorldMonitor's strongest organizing ideas. Count the surface: [markets and central-bank trackers](/blog/posts/real-time-market-intelligence-for-traders-and-analysts/), [chokepoints and freight](/blog/posts/tracking-global-trade-routes-chokepoints-freight-costs/), [tariffs and customs revenue](/blog/posts/tariff-tracker-trade-policy-monitoring-worldmonitor/), [government tenders from six official portals](/blog/posts/government-tenders-procurement-intelligence-worldmonitor/), [shelf-price inflation](/blog/posts/ground-truth-inflation-shelf-price-tracking-worldmonitor/), energy intelligence, prediction markets.
+
+Conflict tracking is real and serious on WorldMonitor, but the product does not stop at the red dots. **War is also an economic event.** When Hormuz goes yellow, tankers reroute, freight and insurance reprice, energy flows shift, sanctions programs swell. The map explains why the Palantir comparison starts. The economic and operational workflows explain why it stops.
+
+Here's the sanctions layer, queried live while writing this (July 22, 2026): **20,398 active OFAC designations** — 19,345 SDN plus 1,053 consolidated — including 1,517 vessels and 344 aircraft. Russia carries 5,931 country-tagged entries against Iran's 1,607, and the single largest program, `RUSSIA-EO14024`, holds 6,794. That's not a marketing claim about "tracking sanctions." That's the data, and authenticated users can pull the same numbers through the [MCP server](https://www.worldmonitor.app/docs/mcp-quickstart) or the [API](https://www.worldmonitor.app/docs/api-reference).
 
 ## The structural difference: open at the layers that matter
 
 - **The product is open**: six dashboards, free, no signup, right now.
 - **The source is open**: the entire platform is AGPL-3.0 — [read it, fork it, self-host it](/blog/posts/self-host-worldmonitor-open-source-osint-dashboard/).
-- **The interfaces are open**: a versioned REST API built on 35 typed proto services, an [MCP server with 41 tools](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/) that answers anonymous connections, an [embeddable live map](/blog/posts/embed-live-global-map-worldmonitor/), 25 UI languages.
+- **The interfaces are open**: a versioned REST API built on 35 typed proto services, an [MCP server with 40+ tools](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/) whose catalog is publicly discoverable while data calls authenticate through OAuth or an API key, an [embeddable live map](/blog/posts/embed-live-global-map-worldmonitor/), 25 UI languages.
 - **The pricing is open**: [published on the site](/blog/posts/free-vs-paid-real-time-intelligence-dashboards/), $0 to flat monthly tiers, no "contact sales."
 
-And, in fairness, what WorldMonitor is **not**: it is not fully free at every layer — a handful of compute-heavy panels (the AI analyst, the Scenario Engine, tender search, trade policy) are paid, and they fund the free rest. It has no classified feeds and no private ontology for your internal data — if you need *your* data integrated, that's genuinely Palantir's job, not ours. And public data has gaps; where sensors don't exist, WorldMonitor shows the gap rather than interpolating confidence.
+And, in fairness, what WorldMonitor is **not**: it is not fully free at every layer — WM Analyst, the Scenario Engine, Route Explorer, scheduled AI digests, custom widgets, MCP data calls, and the REST API are paid, and they fund the free rest. It has no classified feeds and no private ontology for your internal data — if you need *your* data integrated, that's genuinely Palantir's job, not ours. And public data has gaps; where sensors don't exist, WorldMonitor shows the gap rather than interpolating confidence.
 
-That last habit is the deepest difference. A closed platform's failures are private. Ours are on the health endpoint you curled above.
+That last habit may be the deepest difference. In a private deployment, source health is visible inside the customer's environment. WorldMonitor exposes its own publicly, on the health endpoint you curled above.
 
 ## Build on it this afternoon — literally
 
 The claim "you can build on it" is cheap, so here is the afternoon, itemized:
 
 1. **Minute 1:** `curl "https://www.worldmonitor.app/api/health?compact=1"` — you did this already.
-2. **Minute 5:** Add `https://worldmonitor.app/mcp` to Claude or any MCP client — the server accepts anonymous connections with a daily quota, no account — and ask *"what's the chokepoint status in Hormuz right now?"*
-3. **The rest of the afternoon:** wire a [supply-chain early-warning pipeline](/blog/posts/build-supply-chain-early-warning-system-api/), pipe [risk alerts into Slack](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/), or [give your agent live world context](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/) — or fork the repo and change what you don't like.
+2. **Minute 5:** Open the [Energy dashboard](https://energy.worldmonitor.app) and inspect Hormuz alongside maritime, conflict, energy, and market signals — no account required.
+3. **Minute 15:** Run `npx worldmonitor tools` to inspect the MCP catalog anonymously. Pro and API users can then connect an MCP client through OAuth or an API key and ask *"what's the chokepoint status in Hormuz right now?"*
+4. **The rest of the afternoon:** wire a [supply-chain early-warning pipeline](/blog/posts/build-supply-chain-early-warning-system-api/), pipe [risk alerts into Slack](/blog/posts/geopolitical-risk-alerts-slack-teams-worldmonitor-api/), or [give your agent live world context](/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/) — or fork the repo and change what you don't like.
 
-Palantir is excellent software you cannot try this afternoon. That's not a criticism — it's a different species of thing. But it's why the comparison fails in our favor for everyone who isn't a government or a Fortune 100.
+Palantir has a Developer Tier, so yes: you can try Palantir this afternoon. What you cannot reasonably do in one afternoon is reconstruct the breadth of WorldMonitor's public intelligence coverage inside it. You would first have to discover and evaluate hundreds of public sources, negotiate their limits, build collectors, normalize incompatible schemas, geocode and deduplicate events, establish freshness budgets, correlate signals across domains, and keep the whole pipeline running. By the time you have built that data layer, you have built a different company.
+
+That's not a criticism — it's a different species of thing. Palantir gives you a platform for building around data you bring. WorldMonitor opens with a public intelligence layer already assembled, monitored, and live.
 
 ## Frequently Asked Questions
 
 **Is WorldMonitor a Palantir alternative?**
 
-For integrating your institution's private data into a closed ontology — no, and it doesn't try to be. For real-time intelligence over public data — markets, trade, conflicts, energy, sanctions — it does something Palantir doesn't sell at any price: it's live in your browser right now, free, with the source published.
+For integrating your institution's private data into a governed ontology — no, and it doesn't try to be. For real-time intelligence over public data — markets, trade, conflicts, energy, sanctions — WorldMonitor starts where a Palantir implementation would still have to begin: sourcing, normalizing, and operating the data. It is live in your browser now, with a free core product and published source.
 
 **Is WorldMonitor a defense or war-focused platform?**
 
-No. Conflict monitoring is one layer among dozens; by surface area most of the platform is financial, economic, and trade intelligence. War matters on WorldMonitor because it reprices the world — which is why traders and supply-chain teams read it alongside OSINT analysts.
+No. Conflict monitoring is one layer among dozens spanning markets, trade, energy, infrastructure, climate, disasters, aviation, cyber, and news. War matters on WorldMonitor because it reprices and reroutes the world — which is why traders and supply-chain teams read it alongside journalists, researchers, and OSINT analysts.
 
 **Is everything really free?**
 
-The dashboards, the map layers, the briefs, and anonymous MCP access are free with no login. A few compute-heavy features (AI analyst, Scenario Engine, tender search, trade policy) are paid and fund the rest. The source is AGPL-3.0 — self-hosters get everything their own keys can feed.
+The core dashboards, map layers, feeds, briefs, breaking alerts, and watchlists are free with no login. WM Analyst, the Scenario Engine, Route Explorer, scheduled digests, custom widgets, MCP data calls, and REST API access are paid and fund the rest. Anyone can inspect the MCP catalog and public health metadata anonymously, but data-bearing tool calls require Pro or API authentication. The source is AGPL-3.0 — self-hosters get everything their own keys can feed.
 
 ---
 

--- a/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
+++ b/blog-site/src/content/blog/worldmonitor-is-not-palantir.md
@@ -76,7 +76,7 @@ Here's the sanctions layer, queried live while writing this (July 22, 2026): **2
 - **The interfaces are open**: a versioned REST API built on 35 typed proto services, an [MCP server with 40+ tools](/blog/posts/worldmonitor-mcp-server-ai-agents-real-time-intelligence/) whose catalog is publicly discoverable while data calls authenticate through OAuth or an API key, an [embeddable live map](/blog/posts/embed-live-global-map-worldmonitor/), 25 UI languages.
 - **The pricing is open**: [published on the site](/blog/posts/free-vs-paid-real-time-intelligence-dashboards/), $0 to flat monthly tiers, no "contact sales."
 
-And, in fairness, what WorldMonitor is **not**: it is not fully free at every layer — WM Analyst, the Scenario Engine, Route Explorer, scheduled AI digests, custom widgets, MCP data calls, and the REST API are paid, and they fund the free rest. It has no classified feeds and no private ontology for your internal data — if you need *your* data integrated, that's genuinely Palantir's job, not ours. And public data has gaps; where sensors don't exist, WorldMonitor shows the gap rather than interpolating confidence.
+And, in fairness, what WorldMonitor is **not**: it is not fully free at every layer — WM Analyst, the Scenario Engine, Route Explorer, scheduled AI digests, custom widgets, authenticated MCP data calls, and full REST API access are paid, and they fund the free rest. Public REST routes still expose health, discovery, and the data needed by the free dashboards without an API key. WorldMonitor has no classified feeds and no private ontology for your internal data — if you need *your* data integrated, that's genuinely Palantir's job, not ours. And public data has gaps; where sensors don't exist, WorldMonitor shows the gap rather than interpolating confidence.
 
 That last habit may be the deepest difference. In a private deployment, source health is visible inside the customer's environment. WorldMonitor exposes its own publicly, on the health endpoint you curled above.
 
@@ -105,7 +105,7 @@ No. Conflict monitoring is one layer among dozens spanning markets, trade, energ
 
 **Is everything really free?**
 
-The core dashboards, map layers, feeds, briefs, breaking alerts, and watchlists are free with no login. WM Analyst, the Scenario Engine, Route Explorer, scheduled digests, custom widgets, MCP data calls, and REST API access are paid and fund the rest. Anyone can inspect the MCP catalog and public health metadata anonymously, but data-bearing tool calls require Pro or API authentication. The source is AGPL-3.0 — self-hosters get everything their own keys can feed.
+The core dashboards, map layers, feeds, briefs, breaking alerts, and watchlists are free with no login. Public REST routes cover health, discovery, and dashboard support. WM Analyst, the Scenario Engine, Route Explorer, scheduled digests, custom widgets, authenticated MCP data calls, and full REST API access are paid and fund the rest. Anyone can inspect the MCP catalog and public health metadata anonymously, but data-bearing MCP tool calls require Pro or API authentication. The source is AGPL-3.0 — self-hosters get everything their own keys can feed.
 
 ---
 


### PR DESCRIPTION
## Summary

Readers now get a concrete picture of what WorldMonitor is, how its public-data layer becomes operational intelligence, and what they can do across the free dashboards, analytical workflows, authenticated API/MCP surfaces, and open-source deployment.

The Palantir comparison now acknowledges its Developer Tier while centering the harder distinction: trying a platform can take an afternoon; researching, normalizing, freshness-monitoring, correlating, and operating WorldMonitor's public intelligence coverage cannot. Product claims also distinguish the 232 monitored data contracts from upstream providers and public MCP discovery from authenticated data-bearing calls.

## Validation

- `markdownlint-cli2 blog-site/src/content/blog/worldmonitor-is-not-palantir.md` — 0 errors
- `node --test tests/blog-faq-ld.test.mjs` — 4 tests passed
- `tsx --test tests/blog-cover-webp.test.mjs` — 3 tests passed
- `cd blog-site && npm run build` — 75 static pages built
- Rendered the article locally and checked the expanded sections, links, FAQ structure, and browser console

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
