### PR TITLE
feat(agent-readiness): SDKs in the agent view + homepage rel=alternate pointer (orank round 2)

### DIFF
--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -164,6 +164,7 @@
     <meta name="twitter:title" content="World Monitor — By the time it's news, you already knew." />
     <meta name="twitter:description" content="500+ live feeds, conflict tracking, markets, chokepoints, satellites and AI analysis in one free real-time dashboard. No signup." />
     <link rel="icon" type="image/png" href="https://www.worldmonitor.app/favico/favicon-32x32.png" />
+    <link rel="alternate" type="application/json" href="https://www.worldmonitor.app/?mode=agent" title="World Monitor agent-mode view (machine-readable)" />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/public/agent-view.json
+++ b/public/agent-view.json
@@ -31,6 +31,14 @@
       "install": "npm install -g worldmonitor",
       "url": "https://www.npmjs.com/package/worldmonitor"
     },
+    "sdks": {
+      "javascript": { "install": "npm install worldmonitor", "url": "https://www.npmjs.com/package/worldmonitor" },
+      "python": { "install": "pip install worldmonitor-sdk", "url": "https://pypi.org/project/worldmonitor-sdk/" },
+      "ruby": { "install": "gem install worldmonitor", "url": "https://rubygems.org/gems/worldmonitor" },
+      "go": { "install": "go get github.com/koala73/worldmonitor/sdk/go", "url": "https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go" },
+      "guide": "https://www.worldmonitor.app/docs/sdks",
+      "note": "Official zero-dependency SDK packages; every registry entry sets its homepage to worldmonitor.app for provenance."
+    },
     "docsMcp": {
       "url": "https://www.worldmonitor.app/docs/mcp",
       "transport": "streamable-http",

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -164,6 +164,7 @@
     <meta name="twitter:title" content="World Monitor — By the time it's news, you already knew." />
     <meta name="twitter:description" content="500+ live feeds, conflict tracking, markets, chokepoints, satellites and AI analysis in one free real-time dashboard. No signup." />
     <link rel="icon" type="image/png" href="https://www.worldmonitor.app/favico/favicon-32x32.png" />
+    <link rel="alternate" type="application/json" href="https://www.worldmonitor.app/?mode=agent" title="World Monitor agent-mode view (machine-readable)" />
     <script type="application/ld+json" nonce="wm-static-bootstrap">
     {
       "@context": "https://schema.org",

--- a/tests/agent-mode-view.test.mjs
+++ b/tests/agent-mode-view.test.mjs
@@ -47,6 +47,36 @@ describe('agent-mode view (/?mode=agent)', () => {
     assert.doesNotThrow(() => readFileSync(join(ROOT, 'public/sandbox/get-resilience-score.json')));
   });
 
+  it('advertises every official SDK ecosystem with an install command', () => {
+    const sdks = view.endpoints.sdks;
+    assert.deepEqual(
+      Object.keys(sdks).filter((k) => !['guide', 'note'].includes(k)).sort(),
+      ['go', 'javascript', 'python', 'ruby'],
+    );
+    assert.equal(sdks.python.install, 'pip install worldmonitor-sdk');
+    assert.match(sdks.go.install, /^go get github\.com\/koala73\/worldmonitor\/sdk\/go$/);
+    for (const key of ['javascript', 'python', 'ruby', 'go']) {
+      assert.match(sdks[key].url, /^https:\/\//, `sdks.${key}.url must be a registry URL`);
+    }
+    // The SDK sources these advertise must exist in-repo.
+    for (const dir of ['sdk/python', 'sdk/ruby', 'sdk/go']) {
+      assert.doesNotThrow(() => readFileSync(join(ROOT, dir, 'README.md')), `${dir} must exist`);
+    }
+  });
+
+  it('the marketing homepage points at the agent view via link rel=alternate', () => {
+    // Hand-synced pair: the pro-test source and the committed build artifact
+    // must both carry the pointer (the pre-push gate rebuilds and compares).
+    const linkTag =
+      '<link rel="alternate" type="application/json" href="https://www.worldmonitor.app/?mode=agent"';
+    for (const path of ['pro-test/welcome.html', 'public/pro/welcome.html']) {
+      assert.ok(
+        readFileSync(join(ROOT, path), 'utf-8').includes(linkTag),
+        `${path} must advertise the agent-mode view via <link rel="alternate">`,
+      );
+    }
+  });
+
   it('advertises the schemamap and every section llms.txt', () => {
     assert.equal(view.discovery.schemamap, 'https://www.worldmonitor.app/schemamap.xml');
     assert.doesNotThrow(() => readFileSync(join(ROOT, 'public/schemamap.xml')));


### PR DESCRIPTION
Follow-up to #5469 after the 96/100 rescan. Diagnosis of the three remaining warnings, what this PR fixes, and what needs off-repo action.

## Diagnosis (verified against the live site — the #5469 deploy IS live)

- **Agent mode view (1/2)** — the scanner detected the exact same 6 signals (`llms.txt, openapi, mcp, api, endpoint, agent`) before and after we added sandbox/quickstart/schemamap content, so its signal vocabulary is fixed and keyword additions don't register. Notably, ora.ai's own `?mode=agent` is just their llms.txt rendered in an overlay — ours is already more machine-readable than theirs.
- **JSON-LD sameAs (1/2)** — the live main entity now carries github + npm + x.com + discord + WIRED, yet the finding still says "github.com" only: their authority-profile matcher counts only **Wikipedia / Wikidata / LinkedIn / GitHub**, ignores the nested Person entity (which has real LinkedIn + Wikidata links), and ignores x/discord/WIRED. We hold exactly 1 of their 4.
- **Multi-language SDKs (2/3)** — detection is **exact-name registry matching**, not metadata: PyPI `worldmonitor` is squatted by an unrelated package (`anzechannel`, "monits the working signals"); our `worldmonitor-sdk` already sets `project_urls.Homepage = worldmonitor.app` and is still not counted. The Go module (`github.com/koala73/worldmonitor/sdk/go`) is live on pkg.go.dev and also not counted.

## What this PR changes (honest content, not keyword-stuffing)

1. **Agent view now advertises the SDKs** — `endpoints.sdks` with install command + registry URL for npm / PyPI / RubyGems / Go and the docs guide. This was a genuine content gap: the machine-readable view never mentioned the SDKs at all. It also gives the scanner's SDK/agent-view checks a first-party provenance surface to read.
2. **Homepage → agent view pointer** — `<link rel="alternate" type="application/json" href=".../?mode=agent">` in the welcome.html head, so the agent view is discoverable from the marketing HTML instead of guessable. Hand-synced in `pro-test/welcome.html` + committed artifact; a full `build:pro` rebuild reproduces the artifact exactly (verified).
3. **Guard tests** — the SDK block is pinned to the in-repo `sdk/` sources; the link tag is asserted in both welcome.html copies.

## Needs off-repo action (the actual remaining points)

- **LinkedIn company page** (none exists — searched): creating one and adding `linkedin.com/company/<slug>` to the org sameAs is the highest-probability sameAs fix; ora itself full-scores with linkedin+github+x.
- **Wikidata**: recreate the app entity *with references* (WIRED story + official site + developer→Q121365724) → new QID → add to sameAs. The old QID was deleted for notability; the WIRED citation now satisfies it. Never re-add a dead QID.
- **PyPI**: file a PEP 541 name-transfer request for `worldmonitor` (squatted, effectively abandoned) — metadata on `worldmonitor-sdk` is already correct, only the name mismatches their matcher.
- Optionally report two scanner findings to ora (they accept check feedback): sameAs ignores nested-entity links, and SDK detection misses correctly-attributed non-exact-name packages.

https://claude.ai/code/session_01AghrNeK9K9Zjk1ewip1gAd
