### PR TITLE
fix(seed-gdelt-intel): degrade bookkeeping failures instead of crashing; brownout-scale timeline TTL; content-age opt-in (#5478)

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -473,6 +473,33 @@ export async function writeFreshnessMetadata(domain, resource, count, source, tt
 }
 
 /**
+ * writeFreshnessMetadata for runSeed's OWN bookkeeping call sites: degrades to
+ * null (loudly) instead of throwing when Redis stays down past the retry
+ * budget. By the time runSeed writes seed-meta, the run's outcome is already
+ * decided — the canonical publish succeeded, or the skip path preserved
+ * last-good — so letting a metadata SET escape as a throw converts a Redis
+ * blip into `FATAL: … exit 1` + a "Deploy Crashed!" alert over pure
+ * bookkeeping (seed-gdelt-intel 2026-07-23, issue #5478; the #5438 retry
+ * alone was insufficient under the sustained brownout contention window).
+ * The degraded write leaves the OLD seed-meta in place, which ages naturally
+ * — /api/health STALE_SEED is the durable alarm for a persistent failure.
+ *
+ * External callers keep using writeFreshnessMetadata directly: its
+ * throw-after-retries contract is intentional and pinned by tests.
+ */
+export async function writeFreshnessMetadataSafely(domain, resource, ...rest) {
+  try {
+    return await writeFreshnessMetadata(domain, resource, ...rest);
+  } catch (err) {
+    console.warn(
+      `  WARNING: seed-meta write for ${domain}:${resource} failed after retries (${err?.message || err}) — `
+      + `continuing; seed-meta will age and /api/health STALE_SEED is the alarm if this persists`,
+    );
+    return null;
+  }
+}
+
+/**
  * Read the canonical key's contract-mode envelope meta. Used by runSeed's
  * validate-fail branch to mirror canonical state into seed-meta instead
  * of overwriting it with recordCount=0 (which makes /api/health report
@@ -1839,7 +1866,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           // Pass-through canonical's contentAge so health doesn't lose the
           // STALE_CONTENT signal exactly when last-good-with-stale-content
           // data is being served (Codex round 1 P0b).
-          await writeFreshnessMetadata(
+          await writeFreshnessMetadataSafely(
             domain, resource, canonicalMeta.recordCount,
             canonicalMeta.sourceVersion || opts.sourceVersion,
             ttlSeconds,
@@ -1853,7 +1880,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             `existing cache TTL extended`,
           );
         } else {
-          await writeFreshnessMetadata(domain, resource, 0, opts.sourceVersion, ttlSeconds);
+          await writeFreshnessMetadataSafely(domain, resource, 0, opts.sourceVersion, ttlSeconds);
           console.log(`  SKIPPED: validation failed (empty data) — seed-meta refreshed (recordCount=0), existing cache TTL extended`);
         }
       }
@@ -1981,7 +2008,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       oldestItemAt: contentOldestAt,
       maxContentAgeMin,
     } : undefined;
-    const meta = await writeFreshnessMetadata(
+    const meta = await writeFreshnessMetadataSafely(
       domain, resource, recordCount, opts.sourceVersion, ttlSeconds,
       undefined,            // fetchedAtOverride — success path uses now
       successContentAge,

--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -643,11 +643,21 @@ function extractWeatherExtreme(d) {
 
 const GDELT_TONE_TOPICS = ['military', 'nuclear', 'maritime'];
 
+// The per-topic tone keys survive up to TIMELINE_TTL (7d, #5478) so last-good
+// data stays SERVABLE through a GDELT brownout — but a days-old declining
+// trend must not keep minting deterioration signals stamped detectedAt=now.
+// 48h = two daily series points of slack; older (or undatable) payloads are
+// skipped and the bundled-canonical fallback below still provides a coarse
+// tone signal.
+const MAX_TONE_SIGNAL_AGE_MS = 48 * 3600 * 1000;
+
 function extractMediaToneDeterioration(d) {
   const signals = [];
   for (const topic of GDELT_TONE_TOPICS) {
     const tonePayload = d[`gdelt:intel:tone:${topic}`];
     if (!tonePayload) continue;
+    const fetchedMs = Date.parse(tonePayload.fetchedAt);
+    if (!Number.isFinite(fetchedMs) || Date.now() - fetchedMs > MAX_TONE_SIGNAL_AGE_MS) continue;
     const series = Array.isArray(tonePayload.data) ? tonePayload.data : [];
     if (series.length < 3) continue;
     const last3 = series.slice(-3);

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -7,7 +7,13 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'intelligence:gdelt-intel:v1';
 const CACHE_TTL = 86400; // 24h — intentionally much longer than the 2h cron so verifySeedKey always has a prior snapshot to merge from when GDELT 429s all topics
-const TIMELINE_TTL = 43200; // 12h = 2× cron interval; tone/vol must survive until next 6h run
+// 7d — brownout-scale, NOT one-missed-tick-scale. The per-run EXPIRE-extend in
+// afterPublish keeps last-good timelines alive up to this TTL while GDELT is
+// unreachable; at the previous 12h (2× cron) the 2026-07 brownout expired all
+// 12 tone/vol keys, and once a key is gone EXPIRE is a no-op and nothing
+// re-seeds it until GDELT answers again (issue #5478). Consumers get the
+// stored fetchedAt alongside the data to judge staleness.
+export const TIMELINE_TTL = 604800;
 const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
 const INTER_TOPIC_DELAY_MS = 20_000; // 20s between topics on success
 const POST_EXHAUST_DELAY_MS = 120_000; // 2min extra cooldown after a topic exhausts all retries
@@ -277,24 +283,30 @@ function publishTransform(data) {
 // the existing Redis key silently expire mid-cycle, extend its TTL with
 // EXPIRE so downstream consumers (cross-source-signals, etc.) keep seeing
 // the last successful snapshot until the next cron cycle refreshes it.
-async function afterPublish(data, _meta) {
+//
+// Runs strictly AFTER the canonical publish succeeded, so no failure here may
+// escape as a throw — writeExtraKey exhausting its retries under the same
+// Redis contention that produced the #5478 FATALs would otherwise turn an
+// already-successful run into exit 1. A failed fresh write degrades to the
+// EXPIRE-extend path (preserve last-good), loudly.
+export async function afterPublish(data, _meta) {
   const toneKeysToExtend = [];
   const volKeysToExtend = [];
+  const writeOrQueueExtend = async (key, timeline, fetchedAt, extendQueue) => {
+    if (Array.isArray(timeline) && timeline.length > 0) {
+      try {
+        await writeExtraKey(key, { data: timeline, fetchedAt }, TIMELINE_TTL);
+        return;
+      } catch (err) {
+        console.warn(`  WARNING: timeline write for ${key} failed after retries (${err?.message || err}) — falling back to EXPIRE-extend of last-good`);
+      }
+    }
+    extendQueue.push(key);
+  };
   for (const topic of data.topics ?? []) {
     const fetchedAt = topic.fetchedAt ?? data.fetchedAt;
-    const toneKey = `gdelt:intel:tone:${topic.id}`;
-    const volKey = `gdelt:intel:vol:${topic.id}`;
-
-    if (Array.isArray(topic._tone) && topic._tone.length > 0) {
-      await writeExtraKey(toneKey, { data: topic._tone, fetchedAt }, TIMELINE_TTL);
-    } else {
-      toneKeysToExtend.push(toneKey);
-    }
-    if (Array.isArray(topic._vol) && topic._vol.length > 0) {
-      await writeExtraKey(volKey, { data: topic._vol, fetchedAt }, TIMELINE_TTL);
-    } else {
-      volKeysToExtend.push(volKey);
-    }
+    await writeOrQueueExtend(`gdelt:intel:tone:${topic.id}`, topic._tone, fetchedAt, toneKeysToExtend);
+    await writeOrQueueExtend(`gdelt:intel:vol:${topic.id}`, topic._vol, fetchedAt, volKeysToExtend);
   }
   if (toneKeysToExtend.length > 0) {
     console.log(`  Extending tone TTL for ${toneKeysToExtend.length} rate-limited topic(s): ${toneKeysToExtend.map((k) => k.split(':').pop()).join(', ')}`);
@@ -310,18 +322,43 @@ export function declareRecords(data) {
   return Array.isArray(data?.topics) ? data.topics.length : 0;
 }
 
+// Content-age trio (issue #5478 strand 3, carried over from #5437's "separate
+// concern"). The cache-merge fallback republishes weeks-old articles under a
+// fresh envelope fetchedAt, so seed-meta age NEVER trips during a GDELT
+// brownout — 4 of 6 topics coasted for 3 weeks with zero alarms. Per-topic
+// fetchedAt survives the merge unchanged (the backfill copies the previous
+// snapshot's value), making it the honest coasting signal:
+//   newestItemAt = most recently fetched topic — ages only when EVERY topic
+//                  is coasting (topic[0] is fetched first each run, so any
+//                  GDELT success at all keeps this fresh);
+//   oldestItemAt = most starved topic, for operator visibility.
+export function contentMeta(data) {
+  const times = (data?.topics ?? [])
+    .map((t) => Date.parse(t?.fetchedAt))
+    .filter((ms) => Number.isFinite(ms) && ms > 0);
+  if (times.length === 0) return null;
+  return { newestItemAt: Math.max(...times), oldestItemAt: Math.min(...times) };
+}
+
+// Exported so tests can pin the exact wiring the cron entry runs with.
+export const RUN_SEED_OPTS = {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'gdelt-doc-v2',
+  publishTransform,
+  afterPublish,
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 420,
+  contentMeta,
+  // 24h = 4× the 6h cadence. Normal runs refresh at least topic[0] every
+  // tick, so only a real brownout (every topic failing every run for a day)
+  // flips health to STALE_CONTENT (warn).
+  maxContentAgeMin: 1440,
+};
+
 if (process.argv[1]?.endsWith('seed-gdelt-intel.mjs')) {
-  runSeed('intelligence', 'gdelt-intel', CANONICAL_KEY, fetchAllTopics, {
-    validateFn: validate,
-    ttlSeconds: CACHE_TTL,
-    sourceVersion: 'gdelt-doc-v2',
-    publishTransform,
-    afterPublish,
-  
-    declareRecords,
-    schemaVersion: 1,
-    maxStaleMin: 420,
-  }).catch((err) => {
+  runSeed('intelligence', 'gdelt-intel', CANONICAL_KEY, fetchAllTopics, RUN_SEED_OPTS).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);
     process.exit(1);

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -304,7 +304,12 @@ export async function afterPublish(data, _meta) {
     extendQueue.push(key);
   };
   for (const topic of data.topics ?? []) {
-    const fetchedAt = topic.fetchedAt ?? data.fetchedAt;
+    // A non-empty _tone/_vol was fetched THIS run, so stamp writes with the
+    // run-level fetchedAt: topic.fetchedAt may be coasted to the previous
+    // snapshot's time when the articles 429'd but the timeline succeeded, and
+    // a stale stamp would make cross-source-signals' 48h signal-grade guard
+    // suppress a genuinely fresh series.
+    const fetchedAt = data.fetchedAt ?? topic.fetchedAt;
     await writeOrQueueExtend(`gdelt:intel:tone:${topic.id}`, topic._tone, fetchedAt, toneKeysToExtend);
     await writeOrQueueExtend(`gdelt:intel:vol:${topic.id}`, topic._vol, fetchedAt, volKeysToExtend);
   }
@@ -333,7 +338,12 @@ export function declareRecords(data) {
 //                  GDELT success at all keeps this fresh);
 //   oldestItemAt = most starved topic, for operator visibility.
 export function contentMeta(data) {
+  // Only topics that actually carry articles count: an articleless topic keeps
+  // fetchedAt=now (the empty-topic placeholder), which would hold newestItemAt
+  // fresh precisely in the total-death scenario — brownout + expired canonical,
+  // nothing to backfill — where STALE_CONTENT matters most.
   const times = (data?.topics ?? [])
+    .filter((t) => Array.isArray(t?.articles) && t.articles.length > 0)
     .map((t) => Date.parse(t?.fetchedAt))
     .filter((ms) => Number.isFinite(ms) && ms > 0);
   if (times.length === 0) return null;

--- a/tests/cross-source-signals-tone-staleness.test.mjs
+++ b/tests/cross-source-signals-tone-staleness.test.mjs
@@ -1,0 +1,66 @@
+// Regression test for issue #5478 (strand 2 follow-through): the media-tone
+// deterioration extractor must not mint fresh-looking signals
+// (detectedAt=now) off a days-old tone series.
+//
+// The per-topic gdelt:intel:tone:* keys survive up to TIMELINE_TTL (7d after
+// #5478 — brownout-scale on purpose, so last-good data stays SERVABLE through
+// a GDELT outage). Serving old data is fine; *signaling* off it is not: a
+// week-old declining trend would keep emitting "media tone deterioration"
+// cross-source signals stamped as freshly detected for days. The extractor
+// must skip payloads it cannot date or that are older than the signal-grade
+// window, falling through to the bundled-canonical fallback.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
+
+const seedSrc = readFileSync('scripts/seed-cross-source-signals.mjs', 'utf8');
+
+const pureSrc = seedSrc
+  .replace(/^import\s.*$/gm, '')
+  .replace(/loadEnvFile\([^)]+\);\r?\n/, '')
+  .replace(/async function readAllSourceKeys[\s\S]*?\r?\n}\r?\n\r?\n\/\/ ── Signal extractors/m, '// readAllSourceKeys removed for unit test\n\n// ── Signal extractors')
+  .replace(/runSeed\('intelligence'[\s\S]*$/m, '')
+  .replace(/^export\s+(function\s+declareRecords)/m, '$1');
+
+const ctx = vm.createContext({ console, Date, Math, Number, Array, Map, Set, String, RegExp, CII_RISK_SCORE_CACHE_KEYS });
+vm.runInContext(`${pureSrc}\n;globalThis.__exports = { extractMediaToneDeterioration };`, ctx);
+
+const { extractMediaToneDeterioration } = ctx.__exports;
+
+const DECLINING_SERIES = [
+  { date: '2026-07-18', value: -0.5 },
+  { date: '2026-07-19', value: -1.2 },
+  { date: '2026-07-20', value: -2.4 },
+];
+
+function tonePayload(ageMs, series = DECLINING_SERIES) {
+  return { data: series, fetchedAt: new Date(Date.now() - ageMs).toISOString() };
+}
+
+describe('extractMediaToneDeterioration staleness guard', () => {
+  it('emits a signal for a recent declining tone series', () => {
+    const signals = extractMediaToneDeterioration({
+      'gdelt:intel:tone:military': tonePayload(3600 * 1000), // 1h old
+    });
+    assert.equal(signals.length, 1, 'fresh declining series must still signal');
+    assert.equal(signals[0].id, 'gdelt-tone:military');
+  });
+
+  it('does not signal off a tone series older than the signal-grade window', () => {
+    const signals = extractMediaToneDeterioration({
+      'gdelt:intel:tone:military': tonePayload(3 * 24 * 3600 * 1000), // 3 days old
+    });
+    assert.equal(signals.length, 0,
+      'a days-old trend must not mint a fresh-looking deterioration signal (7d TTL keeps last-good servable, not signal-grade)');
+  });
+
+  it('does not signal off a payload it cannot date', () => {
+    const signals = extractMediaToneDeterioration({
+      'gdelt:intel:tone:military': { data: DECLINING_SERIES }, // no fetchedAt
+    });
+    assert.equal(signals.length, 0, 'undatable payloads are not signal-grade');
+  });
+});

--- a/tests/seed-gdelt-intel-timeline-resilience.test.mjs
+++ b/tests/seed-gdelt-intel-timeline-resilience.test.mjs
@@ -63,7 +63,7 @@ test('TIMELINE_TTL is brownout-scale (7 days), not one-missed-tick-scale', () =>
     '12h TTL dies on the first >12h GDELT outage; the per-run EXPIRE-extend keeps last-good alive up to the TTL, so the TTL must cover a realistic brownout');
 });
 
-test('afterPublish writes fresh timelines with the brownout-scale TTL', async () => {
+test('afterPublish writes fresh timelines with the brownout-scale TTL and the RUN-level fetchedAt', async () => {
   globalThis.fetch = async (url, opts = {}) => {
     const body = opts?.body ? JSON.parse(opts.body) : null;
     calls.push({ u: String(url), body });
@@ -71,14 +71,20 @@ test('afterPublish writes fresh timelines with the brownout-scale TTL', async ()
     return jsonResponse({ result: 'OK' });
   };
 
+  // topic.fetchedAt is COASTED (articles 429'd and were backfilled from the
+  // previous snapshot) but the timeline succeeded THIS run — the write must
+  // carry the run-level fetchedAt, or the cross-source 48h signal-grade guard
+  // would suppress a genuinely fresh series.
   await afterPublish({
     fetchedAt: '2026-07-23T08:00:00.000Z',
-    topics: [{ id: 'military', _tone: [{ date: '20260723', value: -2.1 }], _vol: [] }],
+    topics: [{ id: 'military', fetchedAt: '2026-07-01T00:00:00.000Z', _tone: [{ date: '20260723', value: -2.1 }], _vol: [] }],
   });
 
   const toneSet = calls.find((c) => Array.isArray(c.body) && c.body[0] === 'SET' && c.body[1] === 'gdelt:intel:tone:military');
   assert.ok(toneSet, 'fresh tone timeline must be written');
   assert.equal(toneSet.body[4], 604800, 'timeline SET must carry the brownout-scale TTL');
+  assert.equal(JSON.parse(toneSet.body[2]).fetchedAt, '2026-07-23T08:00:00.000Z',
+    'a timeline fetched this run must be stamped with the run-level fetchedAt, not the coasted article time');
   const expire = calls.find((c) => Array.isArray(c.body) && Array.isArray(c.body[0]));
   assert.ok(expire, 'empty vol timeline must fall back to EXPIRE-extend');
   assert.deepEqual(expire.body[0], ['EXPIRE', 'gdelt:intel:vol:military', 604800],
@@ -137,8 +143,27 @@ test('contentMeta reports newest/oldest per-topic fetch times', () => {
 
 test('contentMeta returns null when no topic carries a usable fetch time', () => {
   assert.equal(contentMeta({ topics: [] }), null);
-  assert.equal(contentMeta({ topics: [{ id: 'military', fetchedAt: 'garbage' }] }), null);
+  assert.equal(contentMeta({ topics: [{ id: 'military', fetchedAt: 'garbage', articles: [{}] }] }), null);
   assert.equal(contentMeta(null), null);
+});
+
+test('contentMeta ignores articleless topics so a total outage cannot mask STALE_CONTENT', () => {
+  // Total-death scenario: brownout + expired canonical → no backfill possible,
+  // every topic is empty but carries fetchedAt=now. Counting those would hold
+  // newestItemAt fresh exactly when the alarm matters most.
+  const meta = contentMeta({
+    topics: [
+      { id: 'military', fetchedAt: '2026-07-23T08:00:00.000Z', articles: [] },
+      { id: 'nuclear', fetchedAt: '2026-07-01T00:00:00.000Z', articles: [{}] },
+    ],
+  });
+  assert.equal(meta.newestItemAt, Date.parse('2026-07-01T00:00:00.000Z'),
+    'only topics that actually carry articles count toward content age');
+  assert.equal(
+    contentMeta({ topics: [{ id: 'military', fetchedAt: '2026-07-23T08:00:00.000Z', articles: [] }] }),
+    null,
+    'all-empty topics → null → health reads STALE_CONTENT',
+  );
 });
 
 test('runSeed opts wire in the content-age trio and the resilient afterPublish', () => {

--- a/tests/seed-gdelt-intel-timeline-resilience.test.mjs
+++ b/tests/seed-gdelt-intel-timeline-resilience.test.mjs
@@ -1,0 +1,151 @@
+// Regression tests for issue #5478 (strands 2 + 3): the tone/vol timeline
+// keys must survive a multi-day GDELT brownout, and the seeder must expose a
+// content-age signal so cache-merge coasting is visible to /api/health.
+//
+// Strand 2 background: TIMELINE_TTL was 12h (2x the 6h cron) — sized for one
+// missed tick, not a brownout. During the 2026-07 GDELT outage every run's
+// timeline fetch came back empty, the per-run EXPIRE-extend kept last-good
+// alive only until the first sequence of failed runs crossed 12h, and then
+// all 12 gdelt:intel:{tone,vol}:* keys expired (verified 2026-07-23: every
+// key EXISTS=0). Once expired, EXPIRE is a no-op and nothing re-seeds them.
+// Also: a timeline writeExtraKey exhausting its retries crashed the whole
+// run AFTER the canonical publish had already succeeded.
+//
+// Strand 3 background: the cache-merge fallback republishes weeks-old
+// articles under a fresh envelope fetchedAt, so seed-meta age never trips.
+// Per-topic fetchedAt is the honest coasting signal — contentMeta feeds it
+// to the health classifier via the content-age trio (STALE_CONTENT).
+
+import { test, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { afterPublish, contentMeta, TIMELINE_TTL, RUN_SEED_OPTS } =
+  await import('../scripts/seed-gdelt-intel.mjs');
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalWarn = console.warn;
+
+let calls;
+let warns;
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+function abortError() {
+  const err = new Error('The operation was aborted due to timeout');
+  err.name = 'AbortError';
+  return err;
+}
+
+beforeEach(() => {
+  calls = [];
+  warns = [];
+  console.warn = (...args) => { warns.push(args.join(' ')); };
+  globalThis.setTimeout = (cb, ms, ...args) =>
+    originalSetTimeout(cb, ms >= 500 ? 0 : ms, ...args);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+  console.warn = originalWarn;
+});
+
+// ---------- strand 2: TTL sized for brownouts ----------
+
+test('TIMELINE_TTL is brownout-scale (7 days), not one-missed-tick-scale', () => {
+  assert.equal(TIMELINE_TTL, 604800,
+    '12h TTL dies on the first >12h GDELT outage; the per-run EXPIRE-extend keeps last-good alive up to the TTL, so the TTL must cover a realistic brownout');
+});
+
+test('afterPublish writes fresh timelines with the brownout-scale TTL', async () => {
+  globalThis.fetch = async (url, opts = {}) => {
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u: String(url), body });
+    if (String(url).endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    return jsonResponse({ result: 'OK' });
+  };
+
+  await afterPublish({
+    fetchedAt: '2026-07-23T08:00:00.000Z',
+    topics: [{ id: 'military', _tone: [{ date: '20260723', value: -2.1 }], _vol: [] }],
+  });
+
+  const toneSet = calls.find((c) => Array.isArray(c.body) && c.body[0] === 'SET' && c.body[1] === 'gdelt:intel:tone:military');
+  assert.ok(toneSet, 'fresh tone timeline must be written');
+  assert.equal(toneSet.body[4], 604800, 'timeline SET must carry the brownout-scale TTL');
+  const expire = calls.find((c) => Array.isArray(c.body) && Array.isArray(c.body[0]));
+  assert.ok(expire, 'empty vol timeline must fall back to EXPIRE-extend');
+  assert.deepEqual(expire.body[0], ['EXPIRE', 'gdelt:intel:vol:military', 604800],
+    'EXPIRE-extend must also use the brownout-scale TTL');
+});
+
+// ---------- strand 2: a timeline write failure must not crash a published run ----------
+
+test('afterPublish degrades a timeline write failure to EXPIRE-extend instead of crashing the run', async () => {
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u, body });
+    if (u.endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    if (Array.isArray(body) && body[0] === 'SET' && String(body[1]).startsWith('gdelt:intel:')) {
+      throw abortError(); // every write attempt times out — retry exhaustion
+    }
+    return jsonResponse({ result: 'OK' });
+  };
+
+  // Must resolve: by the time afterPublish runs, the canonical publish already
+  // succeeded — a timeline bookkeeping failure must not turn the run FATAL.
+  await afterPublish({
+    fetchedAt: '2026-07-23T08:00:00.000Z',
+    topics: [{ id: 'military', _tone: [{ date: '20260723', value: -2.1 }], _vol: [] }],
+  });
+
+  const expired = calls
+    .filter((c) => Array.isArray(c.body) && Array.isArray(c.body[0]))
+    .flatMap((c) => c.body)
+    .filter((cmd) => cmd[0] === 'EXPIRE')
+    .map((cmd) => cmd[1]);
+  assert.ok(expired.includes('gdelt:intel:tone:military'),
+    'a failed fresh write must fall back to preserving last-good via EXPIRE-extend');
+  assert.ok(
+    warns.some((w) => w.includes('gdelt:intel:tone:military')),
+    `the degraded write must be loud; warns were: ${JSON.stringify(warns)}`,
+  );
+});
+
+// ---------- strand 3: content-age signal ----------
+
+test('contentMeta reports newest/oldest per-topic fetch times', () => {
+  const meta = contentMeta({
+    fetchedAt: '2026-07-23T08:00:00.000Z',
+    topics: [
+      { id: 'military', fetchedAt: '2026-07-20T04:00:00.000Z', articles: [{}] },
+      { id: 'nuclear', fetchedAt: '2026-07-01T00:00:00.000Z', articles: [{}] },
+    ],
+  });
+  assert.equal(meta.newestItemAt, Date.parse('2026-07-20T04:00:00.000Z'),
+    'newestItemAt = most recently fetched topic — ages only when EVERY topic is coasting');
+  assert.equal(meta.oldestItemAt, Date.parse('2026-07-01T00:00:00.000Z'),
+    'oldestItemAt = most starved topic');
+});
+
+test('contentMeta returns null when no topic carries a usable fetch time', () => {
+  assert.equal(contentMeta({ topics: [] }), null);
+  assert.equal(contentMeta({ topics: [{ id: 'military', fetchedAt: 'garbage' }] }), null);
+  assert.equal(contentMeta(null), null);
+});
+
+test('runSeed opts wire in the content-age trio and the resilient afterPublish', () => {
+  assert.equal(RUN_SEED_OPTS.contentMeta, contentMeta, 'content-age opt-in must use the exported contentMeta');
+  assert.equal(RUN_SEED_OPTS.maxContentAgeMin, 1440,
+    '24h = 4x the 6h cadence; only a real brownout (every topic failing every run for a day) trips STALE_CONTENT');
+  assert.equal(RUN_SEED_OPTS.afterPublish, afterPublish, 'main entry must run the degrade-not-crash afterPublish');
+  assert.equal(typeof RUN_SEED_OPTS.validateFn, 'function');
+  assert.equal(RUN_SEED_OPTS.declareRecords.length, 1);
+});

--- a/tests/seed-utils-meta-write-degrades.test.mjs
+++ b/tests/seed-utils-meta-write-degrades.test.mjs
@@ -1,0 +1,149 @@
+// Regression test for issue #5478 (strand 1): runSeed's own seed-meta
+// bookkeeping writes must DEGRADE, not crash, when Redis stays down past the
+// retry budget.
+//
+// The #5438 fix wrapped writeFreshnessMetadata's SET in withRetry, but the
+// helper still (correctly — external callers depend on it) throws after
+// exhausting retries. On 2026-07-23 the sustained GDELT-brownout contention
+// window produced three consecutive Upstash aborts in one run, the throw
+// escaped runSeed's phase-2 try, and seed-gdelt-intel exited 1 with
+// `FATAL: The operation was aborted due to timeout` — a red badge + alert
+// over pure bookkeeping. By the time these writes run, the run's outcome is
+// already decided (publish succeeded, or the skip path preserved last-good):
+// the honest failure mode is a loud warning + an aging seed-meta key, which
+// /api/health reports as STALE_SEED independently.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { runSeed } = await import('../scripts/_seed-utils.mjs');
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalExit = process.exit;
+const originalWarn = console.warn;
+const ORIGINAL_SIGTERM_LISTENERS = new Set(process.rawListeners('SIGTERM'));
+
+const CANONICAL_ENVELOPE = {
+  _seed: { fetchedAt: 1784621196406, recordCount: 6, sourceVersion: 'test-v1', schemaVersion: 1, state: 'OK' },
+  data: { items: ['cached'] },
+};
+
+let calls;
+let warns;
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+function abortError() {
+  const err = new Error('The operation was aborted due to timeout');
+  err.name = 'AbortError';
+  return err;
+}
+
+beforeEach(() => {
+  calls = [];
+  warns = [];
+  console.warn = (...args) => { warns.push(args.join(' ')); originalWarn(...args); };
+  // Collapse retry backoffs (>=500ms) so exhaustion tests don't sleep for real.
+  globalThis.setTimeout = (cb, ms, ...args) =>
+    originalSetTimeout(cb, ms >= 500 ? 0 : ms, ...args);
+  // Route every Redis surface runSeed touches; the seed-meta SET is the one
+  // that stays down for the whole run (timeout-flavored, like the incident).
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u, body });
+    if (u.includes('/get/')) return jsonResponse({ result: JSON.stringify(CANONICAL_ENVELOPE) });
+    if (u.endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    if (Array.isArray(body) && body[0] === 'SET' && String(body[1]).startsWith('seed-meta:')) {
+      throw abortError();
+    }
+    return jsonResponse({ result: 'OK' });
+  };
+  // Convert exits to throws so the test can inspect the exit code.
+  process.exit = (code) => {
+    const e = new Error(`__test_exit__:${code}`);
+    e.exitCode = code;
+    throw e;
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+  process.exit = originalExit;
+  console.warn = originalWarn;
+  for (const listener of process.rawListeners('SIGTERM')) {
+    if (!ORIGINAL_SIGTERM_LISTENERS.has(listener)) process.removeListener('SIGTERM', listener);
+  }
+});
+
+async function runWithExitTrap(fn) {
+  try {
+    await fn();
+    return { exitCode: null, threw: null };
+  } catch (err) {
+    if (String(err.message).startsWith('__test_exit__:')) return { exitCode: err.exitCode, threw: null };
+    return { exitCode: null, threw: err };
+  }
+}
+
+function metaSetAttempts(resource) {
+  return calls.filter((c) =>
+    Array.isArray(c.body) && c.body[0] === 'SET' && c.body[1] === `seed-meta:test:${resource}`,
+  ).length;
+}
+
+test('validate-skip path: seed-meta mirror write exhausting retries degrades to exit 0, not FATAL', async () => {
+  const { exitCode, threw } = await runWithExitTrap(() =>
+    runSeed('test', 'meta-degrade-skip', 'test:meta-degrade-skip:v1',
+      async () => ({ items: [] }),
+      {
+        validateFn: (d) => Array.isArray(d?.items) && d.items.length > 0, // fails → skip path
+        ttlSeconds: 3600,
+        declareRecords: (d) => (Array.isArray(d?.items) ? 1 : 0) || 1, // >0 → contract OK, reaches atomicPublish
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 720,
+      }),
+  );
+
+  assert.equal(threw, null, `a bookkeeping SET must not escape runSeed as a crash; got: ${threw}`);
+  assert.equal(exitCode, 0, 'skip path must still exit 0 when the seed-meta mirror write stays down');
+  assert.ok(metaSetAttempts('meta-degrade-skip') >= 3, 'the SET must still be retried before degrading');
+  assert.ok(
+    warns.some((w) => w.includes('seed-meta write') && w.includes('STALE_SEED')),
+    `degrade must be loud and name the surviving alarm; warns were: ${JSON.stringify(warns)}`,
+  );
+});
+
+test('publish-success path: seed-meta write exhausting retries degrades to exit 0, not FATAL', async () => {
+  const { exitCode, threw } = await runWithExitTrap(() =>
+    runSeed('test', 'meta-degrade-pub', 'test:meta-degrade-pub:v1',
+      async () => ({ items: [1, 2, 3] }),
+      {
+        validateFn: (d) => Array.isArray(d?.items) && d.items.length > 0, // passes → publish path
+        ttlSeconds: 3600,
+        declareRecords: (d) => d.items.length,
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 720,
+      }),
+  );
+
+  assert.equal(threw, null, `the canonical publish already succeeded; a meta SET must not crash the run; got: ${threw}`);
+  assert.equal(exitCode, 0, 'publish path must still exit 0 when the seed-meta write stays down');
+  const canonicalSets = calls.filter((c) =>
+    Array.isArray(c.body) && c.body[0] === 'SET' && c.body[1] === 'test:meta-degrade-pub:v1',
+  );
+  assert.ok(canonicalSets.length >= 1, 'canonical publish must have happened before the degraded meta write');
+  assert.ok(
+    warns.some((w) => w.includes('seed-meta write')),
+    `degrade must be loud; warns were: ${JSON.stringify(warns)}`,
+  );
+});


### PR DESCRIPTION
Fixes #5478 — all three strands.

## Strand 1 — bookkeeping failures must not crash the run

`runSeed`'s own seed-meta writes (the validate-skip mirror, the zero fallback, and the success path) now go through a new `writeFreshnessMetadataSafely`: on retry exhaustion it logs a loud warning naming the surviving alarm (`/api/health` STALE_SEED) and continues, instead of letting the `TimeoutError` escape phase 2 as `FATAL: The operation was aborted due to timeout` → exit 1 → "Deploy Crashed!".

The #5438 retry was necessary but insufficient: on 2026-07-23 (deployment `b4114aad`) the wrapped SET timed out on **every** attempt under the sustained brownout contention window and the throw still crashed the run. By the time these writes execute, the run's outcome is already decided — the canonical publish succeeded, or the skip path preserved last-good — so exit-1 buys nothing over an aging seed-meta key that health reports independently.

`writeFreshnessMetadata` itself keeps its throw-after-retries contract — five external callers depend on it and the existing test pins it.

## Strand 2 — timelines must survive a brownout

- `TIMELINE_TTL` 12h → **7d**. The per-run EXPIRE-extend keeps last-good tone/vol alive only up to the TTL; at 12h the brownout expired **all 12** `gdelt:intel:{tone,vol}:*` keys (verified via Upstash probe: every key `EXISTS=0`), and EXPIRE-on-missing is a no-op forever after.
- `afterPublish` (runs strictly after the canonical publish succeeded) now degrades a timeline `writeExtraKey` that exhausts retries to the EXPIRE-extend path, loudly, instead of throwing.
- Backfill: GDELT still answers `HTTP 429` (13.6s) even from residential, so no manual backfill is possible from anywhere yet. The keys repopulate automatically on the first successful timeline fetch once GDELT recovers; the 7d TTL then protects them through the next brownout.

## Strand 3 — content-age opt-in (the #5437 "separate concern")

The cache-merge fallback republishes weeks-old articles under a fresh envelope `fetchedAt`, so seed-meta age never trips during a brownout — 4 of 6 topics coasted for 3 weeks with zero alarms. Opted in via `contentMeta` over **per-topic `fetchedAt`** (survives the merge unchanged) with `maxContentAgeMin: 1440`:

- `newestItemAt` = most recently fetched topic. Topic[0] (military) is fetched first every run, so any GDELT success at all keeps it fresh; only a real brownout (every topic failing every run for 24h) flips health to `STALE_CONTENT` (**warn** severity — health.js:996).
- ⚠️ Expected on deploy: gdeltIntel will report STALE_CONTENT immediately, because the current brownout means no topic has fetched fresh articles recently. That is the blindspot closing, not a regression — it clears on GDELT recovery.

## Tests

8 new, red-first: the two runSeed-level cases reproduce the exact production `AbortError` escape before the fix (verified failing with the same signature as the crashed deployment). Full seed-utils + gdelt sweep: **137/137**.

https://claude.ai/code/session_01H8UoDBYAtyR37vxCavLS3A

## Follow-through (commit 2) — consumer staleness guard

`seed-cross-source-signals`' `extractMediaToneDeterioration` stamped `detectedAt: Date.now()` on whatever series the tone key held, with no age check — with the 7d TTL a week-old declining trend would mint fresh-looking escalation signals for days. Payloads older than **48h** (or with no parseable `fetchedAt`) are now skipped; the bundled-canonical fallback still provides the coarse tone signal. Red-first vm-harness tests pin all three cases (fresh → signal, stale → skip, undatable → skip).
