### PR TITLE
fix(payments): distinguish transient entitlement-lookup failure from confirmed denial

### DIFF
--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -159,11 +159,17 @@ export function getMcpBillingVerificationDenial(
   entitlements: {
     billingStatus?: BillingVerificationCode;
     retryAfterSeconds?: number;
+    // Transient entitlement-lookup failure marker from getEntitlements()
+    // (server/_shared/entitlement-check.ts) — mapped to the same retryable
+    // envelope as a gateway-synthesized entitlement_verification_unavailable.
+    verificationUnavailable?: boolean;
   } | null | undefined,
   corsHeaders: Record<string, string>,
   id: unknown = null,
 ): Response | null {
-  const billingStatus = entitlements?.billingStatus;
+  const billingStatus = entitlements?.verificationUnavailable
+    ? 'entitlement_verification_unavailable'
+    : entitlements?.billingStatus;
   if (billingStatus === 'entitlement_verification_unavailable') {
     // Gateway-synthesized backend-unreachable 503 (server/gateway.ts wm_-key
     // branch). The shared Convex-facing helper doesn't recognize this code, so

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -243,6 +243,7 @@ export interface McpHandlerDeps {
     validUntil: number;
     billingStatus?: BillingVerificationStatus;
     retryAfterSeconds?: number;
+    verificationUnavailable?: boolean;
   } | null>;
   // #4859: Convex userApiKeys hash lookup (same shared helper as the REST
   // gateway). Returns the key owner, or null for unknown/revoked keys. The

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -238,7 +238,7 @@ Retry-After: 5
 Content-Type: application/json
 ```
 
-The `message` text identifies the trigger. Six sites emit a 503; five distinct strings:
+The `message` text identifies the trigger. Seven sites emit a 503; five distinct strings:
 
 | Trigger                                         | `message`                                              | Site                              |
 |-------------------------------------------------|--------------------------------------------------------|-----------------------------------|
@@ -247,7 +247,7 @@ The `message` text identifies the trigger. Six sites emit a 503; five distinct s
 | Pro quota-reservation Redis failure (non-cap)   | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/dispatch.ts` `dispatchToolsCall` quota reservation |
 | Renewal verification in flight (#4770)          | `Renewal verification pending. Retry shortly.`         | `api/mcp/auth.ts` `getMcpBillingVerificationDenial` (pre-check) or `api/mcp/dispatch.ts` (mid-call re-emit) |
 | Renewal verification failed, in cooldown (#4770)| `Renewal verification failed. Retry shortly.`          | same two sites as above           |
-| Entitlement backend unreachable mid-call (#4770)| `Unable to verify API access. Retry shortly.`          | `api/mcp/dispatch.ts` mid-call re-emit of a gateway `entitlement_verification_unavailable` 503 (wm\_-key tool fetches) |
+| Entitlement backend unreachable (#4770)         | `Unable to verify API access. Retry shortly.`          | `api/mcp/auth.ts` `getMcpBillingVerificationDenial` (pre-check, transient entitlement-lookup failure) or `api/mcp/dispatch.ts` (mid-call re-emit of a gateway `entitlement_verification_unavailable` 503 on wm\_-key tool fetches) |
 
 Recovery for the first three is identical (honour `Retry-After: 5`). The billing-verification rows differ: they carry an `X-Billing-Verification` header (`renewal_verification_pending|renewal_verification_failed`, or `entitlement_verification_unavailable` for the backend-unreachable row), a `data.code` mirroring it, and — for the two renewal-verification codes — a **dynamic `Retry-After` between 1 and 60 seconds** sized to the actual provider re-check; honour the header value rather than assuming 5 (the backend-unreachable row uses a fixed `Retry-After: 5`). The renewal-verification codes mean the subscription recently expired locally and the server is re-confirming it with the billing provider before denying; a renewed subscription typically recovers within one or two retries.
 

--- a/docs/usage-errors.mdx
+++ b/docs/usage-errors.mdx
@@ -60,7 +60,7 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `subscription_lapsed` | The subscription lapse was confirmed with the billing provider. Re-authenticating will not help — resubscribe to restore access. Response carries `X-Billing-Verification: subscription_lapsed`. |
 | `renewal_verification_pending` | Your subscription recently expired locally and the server is re-confirming it with the billing provider. Retryable 503 — honor `Retry-After` (1-60s); a renewed subscription typically recovers within one or two retries. |
 | `renewal_verification_failed` | The provider re-check could not complete and is in a short cooldown. Retryable 503 — honor `Retry-After`. |
-| `entitlement_verification_unavailable` | The billing backend could not be reached to verify a `wm_` API key. Retryable 503 with fixed `Retry-After: 5` and `X-Billing-Verification: entitlement_verification_unavailable`. |
+| `entitlement_verification_unavailable` | The billing backend could not be reached to verify access — emitted on every authenticated surface (`wm_` API keys, bootstrap, session/bearer tier checks, MCP). Retryable 503 with `Retry-After: 5` and `X-Billing-Verification: entitlement_verification_unavailable`. |
 | `idempotency_conflict` | A POST with this `Idempotency-Key` is still processing. Retry after `Retry-After: 2`. |
 | `idempotency_key_reused` | The same `Idempotency-Key` was already used with a different request body. |
 | `invalid_idempotency_key` | The `Idempotency-Key` header is too long or contains non-printable characters. Generated OpenAPI POSTs also reject an empty key. |

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -81,6 +81,29 @@ async function withConvexEntitlementResponse<T>(
   }
 }
 
+// Like withConvexEntitlementResponse, but with full control over the fetch
+// outcome (throw, 5xx, 4xx) — used to pin the transient-vs-confirmed split.
+async function withConvexEntitlementFetch<T>(
+  fetchImpl: () => Promise<Response>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const originalSiteUrl = process.env.CONVEX_SITE_URL;
+  const originalSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  process.env.CONVEX_SITE_URL = "https://example-deployment.convex.site";
+  process.env.CONVEX_SERVER_SHARED_SECRET = "test-secret";
+  vi.mocked(getCachedJson).mockResolvedValueOnce(null);
+  vi.stubGlobal("fetch", vi.fn().mockImplementation(fetchImpl));
+  try {
+    return await run();
+  } finally {
+    if (originalSiteUrl === undefined) delete process.env.CONVEX_SITE_URL;
+    else process.env.CONVEX_SITE_URL = originalSiteUrl;
+    if (originalSecret === undefined) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+    else process.env.CONVEX_SERVER_SHARED_SECRET = originalSecret;
+    vi.unstubAllGlobals();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -124,6 +147,59 @@ describe("gateway entitlement check", () => {
     const body = await result!.json();
     expect(body.error).toBe("Unable to verify entitlements");
     expect(body.requiredTier).toBe(1);
+  });
+
+  test("transient Convex fetch failure returns a verificationUnavailable marker, not null", async () => {
+    await withConvexEntitlementFetch(
+      () => Promise.reject(Object.assign(new Error("The operation was aborted due to timeout"), { name: "TimeoutError" })),
+      async () => {
+        const ent = await getEntitlements("user-transient-timeout");
+        expect(ent).not.toBeNull();
+        expect(ent?.verificationUnavailable).toBe(true);
+        // Deny-side: the marker must never carry an affirmative grant.
+        expect(ent?.features.tier).toBe(0);
+        expect(ent?.features.apiAccess).toBe(false);
+        expect(ent?.validUntil).toBe(0);
+      },
+    );
+  });
+
+  test("Convex 5xx returns the verificationUnavailable marker; 4xx stays a fail-closed null", async () => {
+    await withConvexEntitlementFetch(
+      () => Promise.resolve(new Response("upstream error", { status: 503 })),
+      async () => {
+        const ent = await getEntitlements("user-transient-5xx");
+        expect(ent?.verificationUnavailable).toBe(true);
+      },
+    );
+    await withConvexEntitlementFetch(
+      () => Promise.resolve(new Response("forbidden", { status: 403 })),
+      async () => {
+        // A 4xx (bad shared secret / contract rejection) is a deploy defect,
+        // not a transient — the hard fail-closed null posture must hold.
+        const ent = await getEntitlements("user-config-4xx");
+        expect(ent).toBeNull();
+      },
+    );
+  });
+
+  test("checkEntitlement answers a transient lookup failure with the retryable 503 contract, not a hard 403", async () => {
+    await withConvexEntitlementFetch(
+      () => Promise.reject(new Error("fetch failed")),
+      async () => {
+        const result = await checkEntitlement("user-transient-check", "/api/market/v1/analyze-stock", {});
+        expect(result).not.toBeNull();
+        expect(result!.status).toBe(503);
+        expect(result!.headers.get("X-Billing-Verification")).toBe("entitlement_verification_unavailable");
+        expect(result!.headers.get("Retry-After")).toBe("5");
+        expect(result!.headers.get("Cache-Control")).toBe("no-store");
+
+        const body = await result!.json();
+        expect(body.error).toBe("Unable to verify API access");
+        expect(body.code).toBe("entitlement_verification_unavailable");
+        expect(body.requiredTier).toBe(1);
+      },
+    );
   });
 
   test.each([

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -59,6 +59,15 @@ export interface CachedEntitlements {
     status: 'not_applicable';
     checkedAt: number;
   };
+  // Synthesized by getEntitlements() when the backend lookup failed
+  // TRANSIENTLY (fetch abort at the 3s budget — which the #4770 on-demand
+  // provider re-check can consume — network error, Convex 5xx): a free-shaped,
+  // deny-side value that getBillingVerificationDenial turns into the retryable
+  // entitlement_verification_unavailable 503 instead of a hard "upgrade
+  // required"/401. Never originates from Convex and is never written to the
+  // Redis cache. A null return now means the backend is unconfigured or gave a
+  // confirmed/malformed answer — callers keep their fail-closed posture there.
+  verificationUnavailable?: true;
 }
 
 export interface EntitlementCheckResult {
@@ -244,6 +253,26 @@ export async function getEntitlements(userId: string): Promise<CachedEntitlement
   }
 }
 
+// Free-shaped deny-side value for transient lookup failures. Grants nothing
+// (tier 0, no apiAccess/mcpAccess, validUntil 0); its only power is steering
+// the gates to the retryable 503 via getBillingVerificationDenial.
+function unavailableEntitlements(): CachedEntitlements {
+  return {
+    planKey: 'free',
+    features: {
+      tier: 0,
+      apiAccess: false,
+      apiRateLimit: 0,
+      maxDashboards: 3,
+      prioritySupport: false,
+      exportFormats: ['csv'],
+      mcpAccess: false,
+    },
+    validUntil: 0,
+    verificationUnavailable: true,
+  };
+}
+
 async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements | null> {
   try {
     // Redis cache check (raw=true: entitlements use user-scoped keys, no deployment prefix)
@@ -292,7 +321,12 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
       body: JSON.stringify({ userId }),
       signal: AbortSignal.timeout(3_000),
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      // 5xx = Convex/platform blip -> retryable-503 posture at the gates.
+      // 4xx (bad shared secret, contract rejection) = deploy defect, not a
+      // transient: keep the fail-closed null so callers hold the hard posture.
+      return response.status >= 500 ? unavailableEntitlements() : null;
+    }
     const result = await response.json() as CachedEntitlements | null;
 
     if (result) {
@@ -323,9 +357,15 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
 
     return null;
   } catch (err) {
-    // Fail-closed: any error in entitlement lookup returns null (caller blocks the request)
+    // Still fail-closed — nothing is granted — but a TRANSIENT failure
+    // (timeout/abort, network, a throwing cache read) is distinguishable from
+    // "no entitlement": return the verificationUnavailable marker so every
+    // gate answers with the retryable entitlement_verification_unavailable
+    // 503 (Retry-After) instead of a misleading hard 403/401. Without this,
+    // the on-demand provider re-check (#4770) overrunning the 3s fetch budget
+    // reproduced exactly the hard-denial the rework exists to eliminate.
     console.warn('[entitlement-check] getEntitlements failed:', err instanceof Error ? err.message : String(err));
-    return null;
+    return unavailableEntitlements();
   }
 }
 
@@ -335,10 +375,32 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
  * provider outage is never flattened into a misleading "upgrade required".
  */
 export function getBillingVerificationDenial(
-  entitlements: Pick<CachedEntitlements, 'billingStatus' | 'retryAfterSeconds'> | null | undefined,
+  entitlements: Pick<CachedEntitlements, 'billingStatus' | 'retryAfterSeconds' | 'verificationUnavailable'> | null | undefined,
   corsHeaders: Record<string, string>,
   requiredTier?: number,
 ): Response | null {
+  if (entitlements?.verificationUnavailable) {
+    // Transient lookup failure: same wire contract as server/gateway.ts's
+    // wm_-key null-entitlement branch (docs/usage-errors.mdx).
+    return new Response(
+      JSON.stringify({
+        error: 'Unable to verify API access',
+        code: 'entitlement_verification_unavailable',
+        ...(requiredTier == null ? {} : { requiredTier }),
+      }),
+      {
+        status: 503,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          'X-Billing-Verification': 'entitlement_verification_unavailable',
+          'Retry-After': String(clampRetryAfterSeconds(entitlements.retryAfterSeconds)),
+          ...corsHeaders,
+        },
+      },
+    );
+  }
+
   const status = entitlements?.billingStatus;
   if (!isBillingVerificationStatus(status)) return null;
 

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1239,9 +1239,11 @@ export function createDomainGateway(
       );
       if (billingDenial) return billingDenial;
       // A validated wm_ key proves key ownership, not current paid access.
-      // getEntitlements() returns null for a missing row and for bounded
-      // verification failures/timeouts, so allowing null would turn a billing
-      // backend timeout into paid API access. Fail closed with a retryable 503
+      // Transient lookup failures now arrive as a verificationUnavailable
+      // marker and were already answered with the retryable 503 by
+      // denyForBillingVerification above; a null here means the backend is
+      // unconfigured or gave a confirmed/malformed answer, and allowing it
+      // would turn that state into paid API access. Fail closed with a 503
       // — EXCEPT when the entitlement backend itself is unconfigured: that is
       // a deploy defect, not customer billing state, and 503ing every wm_ key
       // fleet-wide would convert a config regression into a total API outage.

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2925,6 +2925,30 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.equal(pipe.count, 0);
   });
 
+  it('error: transient entitlement-lookup failure → retryable 503, not a -32001 re-auth loop', async () => {
+    const { deps, pipe } = makeProDeps({
+      getEntitlements: async () => ({
+        planKey: 'free',
+        features: { tier: 0, mcpAccess: false },
+        validUntil: 0,
+        verificationUnavailable: true,
+      }),
+    });
+    const res = await mcpHandler(proReq('POST', callBody('get_market_data')), deps);
+
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.equal(res.headers.get('Retry-After'), '5');
+    assert.equal(res.headers.get('X-Billing-Verification'), 'entitlement_verification_unavailable');
+    const body = await res.json();
+    assert.equal(body.jsonrpc, '2.0');
+    // Retryable class, NOT -32001: re-authenticating cannot fix a backend
+    // blip, and the old 401 sent doc-following agents into an OAuth loop.
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.data?.code, 'entitlement_verification_unavailable');
+    assert.equal(pipe.count, 0);
+  });
+
   it('error: mid-call billing 503 from the gateway keeps its contract (no -32603 flatten)', async () => {
     const { deps } = makeProDeps();
     globalThis.fetch = async () => new Response(


### PR DESCRIPTION
## Summary

Follow-up to #5447 (fixes the last open P1 from its round-4 review — the commit reached the PR branch as `2589ad8c3` moments after the squash-merge cut at `ec4049ae6`, so it missed the train; this PR cherry-picks it onto main).

When the on-demand Dodo re-check pushes `/api/internal-entitlements` past the gateway's 3s fetch budget, the abort collapsed into the same `null` as "no entitlement", and every non-`wm_` surface hard-denied: `checkEntitlementDetailed` returned a plain 403 *before* the billing-denial branch (making #5447's graceful path unreachable on exactly that input), and the internal-MCP / MCP gates returned 401 — telling agents to re-authenticate, which cannot fix a backend blip. That reproduced the hard-denial-instead-of-retryable-503 behavior #5447 exists to eliminate, via ordinary latency variance, for precisely the renewed-but-stale customers it rescues.

- `getEntitlements()` now returns a synthesized, deny-side `verificationUnavailable` marker (free-shaped, tier 0, never cached) on TRANSIENT failures: fetch abort/timeout, network error, Convex 5xx. `null` narrows to "unconfigured backend or confirmed/malformed answer" (4xx stays `null`: a bad shared secret is a deploy defect, not a transient), so the `wm_`-key misconfig fail-open carve-out is unchanged.
- `getBillingVerificationDenial()` maps the marker to the retryable `entitlement_verification_unavailable` 503 (`Retry-After: 5`, `no-store`, `X-Billing-Verification`), lighting up all three gateway sites (wm_ key, internal-MCP re-check, legacy bearer) and `checkEntitlementDetailed` through their existing denial-first calls — no per-site changes.
- `getMcpBillingVerificationDenial()` maps the marker to the same `-32603` @ 503 JSON-RPC envelope, replacing the `-32001` @ 401 re-auth advice at the MCP entitlement gate; combined with #5447's allowlist fix, wm_-key tool fetches propagate the denial end-to-end through dispatch.
- Docs: `usage-errors.mdx` code table broadened to all surfaces; `mcp-error-catalog.mdx` 503 site list updated.

Deliberately NOT included: an elapsed-time short-circuit inside `verifyRecentlyStaleSubscriptionOnDemand` — the Dodo call is already hard-bounded (2000ms, `maxRetries: 0`) and the remaining chain is fast mutations; a wall-clock guard would shave sub-second tails at the cost of nondeterminism in a payments action.

## Validation

- `vitest` (convex + server suites) — 824 passed, including 4 new transient-vs-confirmed split tests
- `tsx --test` MCP/gateway/parity suites — 205 passed, including the new MCP pre-check 503 test
- Mutation-tested both load-bearing changes: reverting the sentinel (`catch -> null`) turns 2 tests red; removing the MCP mapping turns 1 red
- `typecheck:api`, root `tsc`, and Convex `tsc` — clean

## Post-Deploy Monitoring

Watch `billing_verification_503` usage-reason volume: transient Convex blips that previously surfaced as `tier_403`/`auth_401` will now (correctly) appear here. A sustained rise means backend latency, not a regression — the denials were happening before, mislabeled and non-retryable.

https://claude.ai/code/session_01S1xbUWd2W7nNQVE21U2LQw