### PR TITLE
fix(notification-channels): bound convexRelay() with a 15s timeout

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -147,6 +147,13 @@ async function convexRelay(body: Record<string, unknown>): Promise<Response> {
       'Authorization': `Bearer ${RELAY_SHARED_SECRET}`,
     },
     body: JSON.stringify(body),
+    // Matches the 15s timeout api/customer-portal.ts and api/create-checkout.ts
+    // already use for the same Convex host. Without this, a hung relay call
+    // outlives the edge runtime's invocation budget before the handler's own
+    // catch can run finish() to release the idempotency lock this endpoint
+    // holds across the call — leaving every retry 409ing for the lock's full
+    // 180s TTL (#5426).
+    signal: AbortSignal.timeout(15_000),
   });
 }
 

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -361,6 +361,42 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
 
     const { action } = body;
 
+    // session.userId is narrowed to string by the auth guard above, but
+    // property narrowing does not flow into closures — capture it once.
+    const welcomeUserId = session.userId;
+    // Shared tail for the two durable-welcome mutations (set-channel,
+    // set-web-push): map relay failures (503 deploy-window fail-closed vs
+    // generic 500), then publish the legacy welcome only when Convex did not
+    // acknowledge scheduling ownership. Requiring the mutation response to
+    // re-acknowledge protects the success path even if Convex rolls back
+    // between the capability probe and the mutation.
+    const finishDurableWelcomeRelay = async (
+      relay: WelcomeRelayResult,
+      relayAction: string,
+      welcomeChannelType: string,
+    ): Promise<Response> => {
+      const resp = relay.response;
+      if (!resp.ok) {
+        console.error(`[notification-channels] POST ${relayAction} relay error:`, resp.status);
+        if (resp.status === 503) {
+          return finish(json({ error: 'Service unavailable' }, 503, corsHeaders));
+        }
+        return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
+      }
+      const result = await resp.json() as {
+        isNew?: boolean;
+        durableWelcomeScheduling?: boolean;
+      };
+      if (
+        result.isNew &&
+        (!relay.durableWelcomeScheduling ||
+          result.durableWelcomeScheduling !== true)
+      ) {
+        ctx.waitUntil(publishWelcome(welcomeUserId, welcomeChannelType));
+      }
+      return finish(json({ ok: true }, 200, corsHeaders));
+    };
+
     try {
       if (action === 'create-pairing-token') {
         const relayBody: Record<string, unknown> = { action: 'create-pairing-token', userId: session.userId };
@@ -397,29 +433,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           }
         }
         const relay = await convexRelayWithDurableWelcome(relayBody);
-        const resp = relay.response;
-        if (!resp.ok) {
-          console.error('[notification-channels] POST set-channel relay error:', resp.status);
-          if (resp.status === 503) {
-            return finish(json({ error: 'Service unavailable' }, 503, corsHeaders));
-          }
-          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
-        }
-        const setResult = await resp.json() as {
-          isNew?: boolean;
-          durableWelcomeScheduling?: boolean;
-        };
-        // Require the mutation response to acknowledge the ownership handoff.
-        // This protects the success path even if Convex rolls back between the
-        // capability probe and mutation.
-        if (
-          setResult.isNew &&
-          (!relay.durableWelcomeScheduling ||
-            setResult.durableWelcomeScheduling !== true)
-        ) {
-          ctx.waitUntil(publishWelcome(session.userId, channelType));
-        }
-        return finish(json({ ok: true }, 200, corsHeaders));
+        return finishDurableWelcomeRelay(relay, 'set-channel', channelType);
       }
 
       if (action === 'set-web-push') {
@@ -459,26 +473,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           // Trim user agent; it's cosmetic for the settings UI, not identity.
           userAgent: typeof userAgent === 'string' ? userAgent.slice(0, 200) : undefined,
         });
-        const resp = relay.response;
-        if (!resp.ok) {
-          console.error('[notification-channels] POST set-web-push relay error:', resp.status);
-          if (resp.status === 503) {
-            return finish(json({ error: 'Service unavailable' }, 503, corsHeaders));
-          }
-          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
-        }
-        const wpResult = await resp.json() as {
-          isNew?: boolean;
-          durableWelcomeScheduling?: boolean;
-        };
-        if (
-          wpResult.isNew &&
-          (!relay.durableWelcomeScheduling ||
-            wpResult.durableWelcomeScheduling !== true)
-        ) {
-          ctx.waitUntil(publishWelcome(session.userId, 'web_push'));
-        }
-        return finish(json({ ok: true }, 200, corsHeaders));
+        return finishDurableWelcomeRelay(relay, 'set-web-push', 'web_push');
       }
 
       if (action === 'delete-channel') {

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -32,6 +32,30 @@ const RELAY_SHARED_SECRET = process.env.RELAY_SHARED_SECRET ?? '';
 const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL ?? '';
 const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN ?? '';
 
+type NotificationChannelsDeps = {
+  validateBearerToken: typeof validateBearerToken;
+  getEntitlements: typeof getEntitlements;
+  fetch: typeof fetch;
+};
+
+function createDefaultNotificationChannelsDeps(): NotificationChannelsDeps {
+  return {
+    validateBearerToken,
+    getEntitlements,
+    fetch: (...args) => globalThis.fetch(...args),
+  };
+}
+
+let notificationChannelsDeps = createDefaultNotificationChannelsDeps();
+
+export function __setNotificationChannelsDepsForTests(
+  overrides: Partial<NotificationChannelsDeps> | null,
+): void {
+  notificationChannelsDeps = overrides
+    ? { ...createDefaultNotificationChannelsDeps(), ...overrides }
+    : createDefaultNotificationChannelsDeps();
+}
+
 // AES-256-GCM encryption using Web Crypto (matches Node crypto.cjs decrypt format).
 // Format stored: v1:<base64(iv[12] || tag[16] || ciphertext)>
 async function encryptSlackWebhook(webhookUrl: string): Promise<string> {
@@ -88,23 +112,24 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
     console.error('[notification-channels] publishWelcome: UPSTASH env vars missing — welcome not queued');
     return;
   }
-  console.log(`[notification-channels] publishWelcome: queuing ${channelType} for ${userId}`);
   const msg = JSON.stringify({ eventType: 'channel_welcome', userId, channelType });
   try {
-    const res = await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${UPSTASH_TOKEN}`,
-        'User-Agent': 'worldmonitor-edge/1.0',
+    const res = await notificationChannelsDeps.fetch(
+      `${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${UPSTASH_TOKEN}`,
+          'User-Agent': 'worldmonitor-edge/1.0',
+        },
+        signal: AbortSignal.timeout(5000),
       },
-      signal: AbortSignal.timeout(5000),
-    });
-    const data = await res.json().catch(() => null) as { result?: unknown } | null;
-    console.log(`[notification-channels] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
+    );
+    if (!res.ok) {
+      throw new Error(`publishWelcome: Upstash LPUSH returned HTTP ${res.status}`);
+    }
   } catch (err) {
     console.error('[notification-channels] publishWelcome LPUSH failed:', (err as Error).message);
-    // publishWelcome runs inside the handler's ctx.waitUntil chain; await
-    // keeps that chain pending until Sentry delivery completes.
     await captureSilentError(err, {
       tags: { route: 'api/notification-channels', step: 'publish-welcome' },
     });
@@ -115,7 +140,7 @@ async function publishFlushHeld(userId: string, variant: string): Promise<void> 
   if (!UPSTASH_URL || !UPSTASH_TOKEN) return;
   const msg = JSON.stringify({ eventType: 'flush_quiet_held', userId, variant });
   try {
-    await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
+    await notificationChannelsDeps.fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${UPSTASH_TOKEN}`, 'User-Agent': 'worldmonitor-edge/1.0' },
       signal: AbortSignal.timeout(5000),
@@ -139,22 +164,87 @@ function json(body: unknown, status: number, cors: Record<string, string>, noCac
   });
 }
 
-async function convexRelay(body: Record<string, unknown>): Promise<Response> {
-  return fetch(`${CONVEX_SITE_URL}/relay/notification-channels`, {
+const CONVEX_RELAY_TIMEOUT_MS = 15_000;
+
+async function convexRelay(
+  body: Record<string, unknown>,
+  signal = AbortSignal.timeout(CONVEX_RELAY_TIMEOUT_MS),
+): Promise<Response> {
+  return notificationChannelsDeps.fetch(`${CONVEX_SITE_URL}/relay/notification-channels`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${RELAY_SHARED_SECRET}`,
+      'User-Agent': 'worldmonitor-edge/1.0',
     },
     body: JSON.stringify(body),
-    // Matches the 15s timeout api/customer-portal.ts and api/create-checkout.ts
-    // already use for the same Convex host. Without this, a hung relay call
-    // outlives the edge runtime's invocation budget before the handler's own
-    // catch can run finish() to release the idempotency lock this endpoint
-    // holds across the call — leaving every retry 409ing for the lock's full
-    // 180s TTL (#5426).
-    signal: AbortSignal.timeout(15_000),
+    // Matches the 15s timeout api/customer-portal.ts and
+    // api/create-checkout.ts already use for the same Convex host.
+    // Without this, a hung relay call outlives the edge runtime's invocation
+    // budget before the handler's own catch can run finish() to release the
+    // idempotency lock this endpoint holds across the call — leaving retries
+    // 409ing for its full 180s TTL (#5426).
+    signal,
   });
+}
+
+type WelcomeRelayResult = {
+  response: Response;
+  durableWelcomeScheduling: boolean;
+};
+
+/**
+ * Negotiate durable welcome scheduling before a first-connect mutation.
+ *
+ * Convex and Vercel deploy independently. New Convex only owns welcome
+ * scheduling when the new edge explicitly opts in; old edge therefore keeps
+ * its legacy publisher. New edge probes before opting in. An old Convex
+ * deployment answers "Unknown action", so edge fails closed before sending a
+ * mutation and releases the idempotency marker for retry. That short
+ * availability tradeoff avoids both mixed-version duplicate welcomes and the
+ * original timeout-after-commit ambiguity.
+ */
+async function convexRelayWithDurableWelcome(
+  body: Record<string, unknown>,
+): Promise<WelcomeRelayResult> {
+  // One deadline covers both negotiation and mutation. Two independent 15s
+  // waits can exceed the edge response-start budget before the handler reaches
+  // finish() and releases its idempotency marker.
+  const relaySignal = AbortSignal.timeout(CONVEX_RELAY_TIMEOUT_MS);
+  const capability = await convexRelay({
+    action: 'welcome-scheduling-capability',
+    userId: body.userId,
+  }, relaySignal);
+  if (capability.ok) {
+    const payload = await capability.json().catch(() => null) as {
+      durableWelcomeScheduling?: boolean;
+    } | null;
+    if (payload?.durableWelcomeScheduling !== true) {
+      throw new Error('Convex returned an invalid welcome scheduling capability response');
+    }
+    return {
+      response: await convexRelay(
+        { ...body, scheduleWelcome: true },
+        relaySignal,
+      ),
+      durableWelcomeScheduling: true,
+    };
+  }
+
+  const payload = await capability.clone().json().catch(() => null) as {
+    error?: string;
+  } | null;
+  if (capability.status === 400 && payload?.error === 'Unknown action') {
+    return {
+      response: Response.json(
+        { error: 'DURABLE_WELCOME_UNAVAILABLE' },
+        { status: 503 },
+      ),
+      durableWelcomeScheduling: false,
+    };
+  }
+
+  return { response: capability, durableWelcomeScheduling: false };
 }
 
 interface PostBody {
@@ -206,7 +296,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
   if (!token) return json({ error: 'Unauthorized' }, 401, corsHeaders);
 
-  const session = await validateBearerToken(token);
+  const session = await notificationChannelsDeps.validateBearerToken(token);
   if (!session.valid || !session.userId) return json({ error: 'Unauthorized' }, 401, corsHeaders);
 
   const idempotencyRequest = req.method === 'POST' ? req.clone() : null;
@@ -233,7 +323,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   }
 
   if (req.method === 'POST') {
-    const ent = await getEntitlements(session.userId);
+    const ent = await notificationChannelsDeps.getEntitlements(session.userId);
     if (!ent || ent.features.tier < 1) {
       return json({
         error: 'pro_required',
@@ -306,15 +396,29 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
             return finish(json({ error: 'Encryption unavailable' }, 503, corsHeaders));
           }
         }
-        const resp = await convexRelay(relayBody);
+        const relay = await convexRelayWithDurableWelcome(relayBody);
+        const resp = relay.response;
         if (!resp.ok) {
           console.error('[notification-channels] POST set-channel relay error:', resp.status);
+          if (resp.status === 503) {
+            return finish(json({ error: 'Service unavailable' }, 503, corsHeaders));
+          }
           return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        const setResult = await resp.json() as { ok: boolean; isNew?: boolean };
-        console.log(`[notification-channels] set-channel ${channelType}: isNew=${setResult.isNew}`);
-        // Only send welcome on first connect, not re-links; use waitUntil so the edge isolate doesn't terminate early
-        if (setResult.isNew) ctx.waitUntil(publishWelcome(session.userId, channelType));
+        const setResult = await resp.json() as {
+          isNew?: boolean;
+          durableWelcomeScheduling?: boolean;
+        };
+        // Require the mutation response to acknowledge the ownership handoff.
+        // This protects the success path even if Convex rolls back between the
+        // capability probe and mutation.
+        if (
+          setResult.isNew &&
+          (!relay.durableWelcomeScheduling ||
+            setResult.durableWelcomeScheduling !== true)
+        ) {
+          ctx.waitUntil(publishWelcome(session.userId, channelType));
+        }
         return finish(json({ ok: true }, 200, corsHeaders));
       }
 
@@ -346,7 +450,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         } catch {
           return finish(json({ error: 'invalid endpoint' }, 400, corsHeaders));
         }
-        const resp = await convexRelay({
+        const relay = await convexRelayWithDurableWelcome({
           action: 'set-web-push',
           userId: session.userId,
           endpoint,
@@ -355,12 +459,25 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           // Trim user agent; it's cosmetic for the settings UI, not identity.
           userAgent: typeof userAgent === 'string' ? userAgent.slice(0, 200) : undefined,
         });
+        const resp = relay.response;
         if (!resp.ok) {
           console.error('[notification-channels] POST set-web-push relay error:', resp.status);
+          if (resp.status === 503) {
+            return finish(json({ error: 'Service unavailable' }, 503, corsHeaders));
+          }
           return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        const wpResult = await resp.json() as { ok: boolean; isNew?: boolean };
-        if (wpResult.isNew) ctx.waitUntil(publishWelcome(session.userId, 'web_push'));
+        const wpResult = await resp.json() as {
+          isNew?: boolean;
+          durableWelcomeScheduling?: boolean;
+        };
+        if (
+          wpResult.isNew &&
+          (!relay.durableWelcomeScheduling ||
+            wpResult.durableWelcomeScheduling !== true)
+        ) {
+          ctx.waitUntil(publishWelcome(session.userId, 'web_push'));
+        }
         return finish(json({ ok: true }, 200, corsHeaders));
       }
 

--- a/convex/__tests__/notificationChannels.test.ts
+++ b/convex/__tests__/notificationChannels.test.ts
@@ -1,15 +1,32 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { api, internal } from "../_generated/api";
 import schema from "../schema";
 
 const modules = import.meta.glob("../**/*.ts");
 type TestUser = ReturnType<ReturnType<typeof convexTest>["withIdentity"]>;
+const notificationChannelFns = (internal as any).notificationChannels;
+const originalFetch = globalThis.fetch;
+const originalUpstashUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalUpstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const originalRelaySecret = process.env.RELAY_SHARED_SECRET;
 
 const USER = {
   subject: "user-tests-notification-channels",
   tokenIdentifier: "clerk|user-tests-notification-channels",
 };
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalUpstashUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalUpstashUrl;
+  if (originalUpstashToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalUpstashToken;
+  if (originalRelaySecret === undefined) delete process.env.RELAY_SHARED_SECRET;
+  else process.env.RELAY_SHARED_SECRET = originalRelaySecret;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 async function seedEntitlement(
   t: ReturnType<typeof convexTest>,
@@ -150,5 +167,321 @@ describe("notificationChannels — Convex entitlement gate", () => {
     expect(channels).toMatchObject([
       { channelType: "telegram", chatId: "12345", verified: true },
     ]);
+  });
+});
+
+describe("notificationChannels — durable first-connect welcome", () => {
+  function installQueueMock() {
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ result: 1 }),
+    );
+  }
+
+  function queuedEvent(fetchMock: ReturnType<typeof installQueueMock>) {
+    const [input, init] = fetchMock.mock.calls[0]!;
+    const command = JSON.parse(String(init?.body)) as unknown[];
+    return {
+      url: String(input),
+      init,
+      command,
+      message: JSON.parse(String(command[5])),
+    };
+  }
+
+  test("schedules an email welcome with the channel insert and not on retry", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "first-connect@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queuedEvent(fetchMock)).toMatchObject({
+      url: "https://upstash.test",
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer upstash-token",
+          "User-Agent": "worldmonitor-convex/1.0",
+          "Content-Type": "application/json",
+        },
+      },
+      command: [
+        "EVAL",
+        expect.stringMatching(/redis\.call\('TYPE'[\s\S]*redis\.pcall\('LPUSH'[\s\S]*redis\.call\('DEL'/),
+        2,
+        expect.stringMatching(/^wm:channel-welcome:/),
+        "wm:events:queue:welcome-v2",
+        expect.any(String),
+        86400,
+      ],
+      message: {
+        eventType: "channel_welcome",
+        userId: USER.subject,
+        channelType: "email",
+        welcomeId: expect.any(String),
+      },
+    });
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "first-connect@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: false });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("negotiates and schedules through the registered relay", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    process.env.RELAY_SHARED_SECRET = "relay-secret";
+    const t = convexTest(schema, modules);
+    const headers = {
+      Authorization: "Bearer relay-secret",
+      "Content-Type": "application/json",
+    };
+
+    const capability = await t.fetch("/relay/notification-channels", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        action: "welcome-scheduling-capability",
+        userId: USER.subject,
+      }),
+    });
+    expect(capability.status).toBe(200);
+    await expect(capability.json()).resolves.toEqual({
+      durableWelcomeScheduling: true,
+    });
+
+    const mutation = await t.fetch("/relay/notification-channels", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        action: "set-channel",
+        userId: USER.subject,
+        channelType: "email",
+        email: "relay-first-connect@example.com",
+        scheduleWelcome: true,
+      }),
+    });
+    expect(mutation.status).toBe(200);
+    await expect(mutation.json()).resolves.toEqual({
+      ok: true,
+      isNew: true,
+      durableWelcomeScheduling: true,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queuedEvent(fetchMock).message).toEqual({
+      eventType: "channel_welcome",
+      userId: USER.subject,
+      channelType: "email",
+      welcomeId: expect.any(String),
+    });
+  });
+
+  test("does not turn a same-endpoint web-push retry into a new connection", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    const t = convexTest(schema, modules);
+    const args = {
+      userId: USER.subject,
+      endpoint: "https://fcm.googleapis.com/push/subscription-1",
+      p256dh: "p256dh",
+      auth: "auth",
+      userAgent: "Chrome",
+      scheduleWelcome: true,
+    };
+
+    await expect(t.mutation(
+      notificationChannelFns.setWebPushChannelForUser,
+      args,
+    )).resolves.toEqual({ isNew: true });
+    await expect(t.mutation(
+      notificationChannelFns.setWebPushChannelForUser,
+      args,
+    )).resolves.toEqual({ isNew: false });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queuedEvent(fetchMock).message).toEqual({
+      eventType: "channel_welcome",
+      userId: USER.subject,
+      channelType: "web_push",
+      welcomeId: expect.any(String),
+    });
+  });
+
+  test("preserves the old-edge relay response without scheduling a duplicate", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    process.env.RELAY_SHARED_SECRET = "relay-secret";
+    const t = convexTest(schema, modules);
+
+    const response = await t.fetch("/relay/notification-channels", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer relay-secret",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action: "set-channel",
+        userId: USER.subject,
+        channelType: "email",
+        email: "legacy-relay@example.com",
+      }),
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      isNew: true,
+      durableWelcomeScheduling: false,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("retries a transient enqueue failure with the same atomic dedupe key", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    fetchMock.mockRejectedValueOnce(new Error("temporary Upstash timeout"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "retry-enqueue@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const commands = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String(init?.body)) as unknown[]
+    );
+    expect(commands[0]?.[3]).toMatch(/^wm:channel-welcome:/);
+    expect(commands[1]?.[3]).toBe(commands[0]?.[3]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("treats an ambiguous committed enqueue as a deduplicated success", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    fetchMock
+      .mockRejectedValueOnce(new Error("response lost after atomic enqueue"))
+      .mockResolvedValueOnce(Response.json({ result: 0 }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "ambiguous-enqueue@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const commands = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String(init?.body)) as unknown[]
+    );
+    expect(commands[1]?.[3]).toBe(commands[0]?.[3]);
+    expect(commands[1]?.[0]).toBe("EVAL");
+  });
+
+  test("retries after an atomic enqueue error without poisoning the claim", async () => {
+    vi.useFakeTimers();
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
+    const claims = new Set<string>();
+    const queuedMessages: string[] = [];
+    let failNextPush = true;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_input, init) => {
+        const command = JSON.parse(String(init?.body)) as unknown[];
+        const script = String(command[1]);
+        const claimKey = String(command[3]);
+        const message = String(command[5]);
+        if (claims.has(claimKey)) return Response.json({ result: 0 });
+        claims.add(claimKey);
+        if (failNextPush) {
+          failNextPush = false;
+          const pushIndex = script.indexOf("redis.pcall('LPUSH'");
+          const cleanupIndex = script.indexOf("redis.call('DEL'", pushIndex);
+          if (pushIndex >= 0 && cleanupIndex > pushIndex) {
+            claims.delete(claimKey);
+          }
+          return Response.json({ result: -2 });
+        }
+        queuedMessages.unshift(message);
+        return Response.json({ result: queuedMessages.length });
+      },
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "script-error@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(claims.size).toBe(1);
+    expect(queuedMessages).toHaveLength(1);
+    expect(JSON.parse(queuedMessages[0]!)).toMatchObject({
+      eventType: "channel_welcome",
+      userId: USER.subject,
+    });
+  });
+
+  test("drops a retry after its channel connection has been replaced", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "old-connection@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.run(async (ctx) => {
+      const oldChannel = await ctx.db
+        .query("notificationChannels")
+        .withIndex("by_user_channel", (q) =>
+          q.eq("userId", USER.subject).eq("channelType", "email"),
+        )
+        .unique();
+      if (!oldChannel) throw new Error("missing scheduled channel");
+      await ctx.db.delete(oldChannel._id);
+      await ctx.db.insert("notificationChannels", {
+        userId: USER.subject,
+        channelType: "email",
+        email: "replacement@example.com",
+        verified: true,
+        linkedAt: Date.now(),
+      });
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/convex/__tests__/notificationChannels.test.ts
+++ b/convex/__tests__/notificationChannels.test.ts
@@ -174,8 +174,11 @@ describe("notificationChannels — durable first-connect welcome", () => {
   function installQueueMock() {
     process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
     process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
-    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      Response.json({ result: 1 }),
+    // Mint a fresh Response per call: a shared instance's body can only be
+    // consumed once, so a second successful enqueue in the same test would
+    // read an already-consumed body and spawn a spurious retry chain.
+    return vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => Response.json({ result: 1 }),
     );
   }
 
@@ -483,5 +486,82 @@ describe("notificationChannels — durable first-connect welcome", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("transfers a shared endpoint to another account as a fresh connection", async () => {
+    vi.useFakeTimers();
+    const fetchMock = installQueueMock();
+    const t = convexTest(schema, modules);
+    const endpoint = "https://fcm.googleapis.com/push/shared-device";
+    const otherUser = "user-tests-notification-channels-b";
+
+    await expect(t.mutation(notificationChannelFns.setWebPushChannelForUser, {
+      userId: USER.subject,
+      endpoint,
+      p256dh: "p256dh-a",
+      auth: "auth-a",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(t.mutation(notificationChannelFns.setWebPushChannelForUser, {
+      userId: otherUser,
+      endpoint,
+      p256dh: "p256dh-b",
+      auth: "auth-b",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The prior owner's row is deleted; only the new account keeps the endpoint.
+    await t.run(async (ctx) => {
+      const rows = (await ctx.db.query("notificationChannels").collect()).filter(
+        (row) => row.channelType === "web_push" && row.endpoint === endpoint,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.userId).toBe(otherUser);
+    });
+
+    // Both first connects welcome their own account, in order.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const welcomedUsers = fetchMock.mock.calls.map(([, init]) => {
+      const command = JSON.parse(String(init?.body)) as unknown[];
+      return (JSON.parse(String(command[5])) as { userId: string }).userId;
+    });
+    expect(welcomedUsers).toEqual([USER.subject, otherUser]);
+  });
+
+  test("stops retrying after the final scheduled attempt fails", async () => {
+    vi.useFakeTimers();
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("Upstash unreachable"),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await expect(t.mutation(notificationChannelFns.setChannelForUser, {
+      userId: USER.subject,
+      channelType: "email",
+      email: "retry-exhausted@example.com",
+      scheduleWelcome: true,
+    })).resolves.toEqual({ isNew: true });
+    // The terminal attempt (attempt 5, no successor) rethrows inside the
+    // scheduler; drain everything and tolerate that final rejection so the
+    // attempt-count assertions below stay the teeth of this test.
+    try {
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+    } catch {
+      // expected: terminal attempt propagates its enqueue failure
+    }
+
+    // Initial attempt + 5 scheduled retries, then no further successor.
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    const retryWarns = warn.mock.calls.filter(([message]) =>
+      String(message).includes("queueChannelWelcome"),
+    );
+    // Attempts 1-5 warn-and-retry; the terminal attempt rethrows instead.
+    expect(retryWarns).toHaveLength(5);
   });
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -503,6 +503,7 @@ http.route({
       aiDigestEnabled?: boolean;
       countries?: string[];
       tickers?: string[];
+      scheduleWelcome?: boolean;
     }>(request);
     if (!body) {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
@@ -531,6 +532,13 @@ http.route({
         });
       }
 
+      if (action === "welcome-scheduling-capability") {
+        return new Response(
+          JSON.stringify({ durableWelcomeScheduling: true }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
       if (action === "create-pairing-token") {
         const result = await ctx.runMutation((internal as any).notificationChannels.createPairingTokenForUser, {
           userId,
@@ -550,8 +558,13 @@ http.route({
           webhookEnvelope: body.webhookEnvelope,
           email: body.email,
           webhookLabel: body.webhookLabel,
+          scheduleWelcome: body.scheduleWelcome === true,
         });
-        return new Response(JSON.stringify({ ok: true, isNew: setResult.isNew }), { status: 200, headers: { "Content-Type": "application/json" } });
+        return new Response(JSON.stringify({
+          ok: true,
+          isNew: setResult.isNew,
+          durableWelcomeScheduling: body.scheduleWelcome === true,
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
       }
 
       if (action === "set-slack-oauth") {
@@ -591,8 +604,13 @@ http.route({
           p256dh: body.p256dh,
           auth: body.auth,
           userAgent: body.userAgent,
+          scheduleWelcome: body.scheduleWelcome === true,
         });
-        return new Response(JSON.stringify({ ok: true, isNew: webPushResult.isNew }), { status: 200, headers: { "Content-Type": "application/json" } });
+        return new Response(JSON.stringify({
+          ok: true,
+          isNew: webPushResult.isNew,
+          durableWelcomeScheduling: body.scheduleWelcome === true,
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
       }
 
       if (action === "delete-channel") {

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -1,12 +1,46 @@
 import { ConvexError, v } from "convex/values";
 import {
+  internalAction,
   internalMutation,
   internalQuery,
   type MutationCtx,
   mutation,
   query,
 } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { channelTypeValidator } from "./constants";
+
+// Versioned queue: old Railway relays only poll wm:events:queue and ignore
+// welcomeId. Keeping connection-scoped events on a new queue means they wait
+// safely until the backward-compatible consumer deploys, regardless of
+// Convex/Railway deployment order.
+const WELCOME_QUEUE_KEY = "wm:events:queue:welcome-v2";
+const WELCOME_FETCH_TIMEOUT_MS = 5_000;
+const WELCOME_USER_AGENT = "worldmonitor-convex/1.0";
+const WELCOME_DEDUP_TTL_SECONDS = 24 * 60 * 60;
+const WELCOME_RETRY_DELAYS_MS = [
+  10_000,
+  30_000,
+  2 * 60_000,
+  10 * 60_000,
+  30 * 60_000,
+] as const;
+const ENQUEUE_WELCOME_SCRIPT = [
+  "local queue_type = redis.call('TYPE', KEYS[2]).ok",
+  "if queue_type ~= 'none' and queue_type ~= 'list' then",
+  "  return -1",
+  "end",
+  "local claimed = redis.call('SET', KEYS[1], '1', 'NX', 'EX', ARGV[2])",
+  "if claimed then",
+  "  local pushed = redis.pcall('LPUSH', KEYS[2], ARGV[1])",
+  "  if type(pushed) == 'table' and pushed.err then",
+  "    redis.call('DEL', KEYS[1])",
+  "    return -2",
+  "  end",
+  "  return pushed",
+  "end",
+  "return 0",
+].join("\n");
 
 /**
  * Notifications are a PRO feature. Enforce the entitlement at the public
@@ -40,6 +74,115 @@ async function assertProEntitlement(
   }
 }
 
+/**
+ * Queue a first-connect welcome outside the relay HTTP request lifecycle.
+ *
+ * The mutation that creates the channel schedules this action in the same
+ * Convex transaction as the channel insert. A Vercel-to-Convex timeout can
+ * therefore hide the mutation response without losing the welcome event.
+ */
+export const queueChannelWelcome = internalAction({
+  args: {
+    userId: v.string(),
+    channelType: channelTypeValidator,
+    welcomeId: v.string(),
+    attempt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const attempt = Math.max(0, Math.floor(args.attempt ?? 0));
+    const retryDelay = WELCOME_RETRY_DELAYS_MS[attempt];
+    // Schedule the successor before the external side effect. If this action
+    // crashes or the Upstash response is ambiguous, the durable successor
+    // retries. Atomic Redis dedupe makes that retry safe after a committed
+    // LPUSH whose response was lost.
+    const retryId = retryDelay === undefined
+      ? null
+      : await ctx.scheduler.runAfter(
+          retryDelay,
+          (internal as any).notificationChannels.queueChannelWelcome,
+          {
+            userId: args.userId,
+            channelType: args.channelType,
+            welcomeId: args.welcomeId,
+            attempt: attempt + 1,
+          },
+        );
+    const message = JSON.stringify({
+      eventType: "channel_welcome",
+      userId: args.userId,
+      channelType: args.channelType,
+      welcomeId: args.welcomeId,
+    });
+    try {
+      const channels = await ctx.runQuery(
+        (internal as any).notificationChannels.getChannelsByUserId,
+        { userId: args.userId },
+      );
+      const currentChannel = channels.find(
+        (channel: { _id: unknown; channelType: string }) =>
+          channel.channelType === args.channelType,
+      );
+      if (String(currentChannel?._id ?? "") !== args.welcomeId) {
+        if (retryId) await ctx.scheduler.cancel(retryId);
+        return { queued: false, stale: true };
+      }
+      const url = process.env.UPSTASH_REDIS_REST_URL;
+      const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+      if (!url || !token) {
+        throw new Error("queueChannelWelcome: Upstash credentials missing");
+      }
+      // The inserted channel document ID identifies this connection. A later
+      // delete/reconnect receives a new ID and a new welcome, while retries
+      // from this connection share one claim.
+      const dedupKey = `wm:channel-welcome:${args.welcomeId}`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "User-Agent": WELCOME_USER_AGENT,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([
+          "EVAL",
+          ENQUEUE_WELCOME_SCRIPT,
+          2,
+          dedupKey,
+          WELCOME_QUEUE_KEY,
+          message,
+          WELCOME_DEDUP_TTL_SECONDS,
+        ]),
+        signal: AbortSignal.timeout(WELCOME_FETCH_TIMEOUT_MS),
+      });
+      const payload = await response.json().catch(() => null) as {
+        result?: unknown;
+        error?: string;
+      } | null;
+      if (
+        !response.ok ||
+        payload?.error ||
+        typeof payload?.result !== "number" ||
+        payload.result < 0
+      ) {
+        throw new Error(
+          `queueChannelWelcome: atomic enqueue failed with HTTP ${response.status}`,
+        );
+      }
+      if (retryId) await ctx.scheduler.cancel(retryId);
+      return {
+        queued: payload.result > 0,
+        duplicate: payload.result === 0,
+      };
+    } catch (error) {
+      if (!retryId) throw error;
+      console.warn(
+        `[notificationChannels] queueChannelWelcome attempt ${attempt + 1} failed; retry scheduled`,
+        error instanceof Error ? error.message : String(error),
+      );
+      return { queued: false, retryScheduled: true };
+    }
+  },
+});
+
 export const getChannelsByUserId = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
@@ -58,6 +201,7 @@ export const setChannelForUser = internalMutation({
     webhookEnvelope: v.optional(v.string()),
     email: v.optional(v.string()),
     webhookLabel: v.optional(v.string()),
+    scheduleWelcome: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const { userId, channelType, chatId, webhookEnvelope, email, webhookLabel } = args;
@@ -68,25 +212,33 @@ export const setChannelForUser = internalMutation({
       )
       .unique();
     const isNew = !existing;
+    let channelId = existing ? String(existing._id) : "";
     const now = Date.now();
     if (channelType === "telegram") {
       if (!chatId) throw new ConvexError("chatId required for telegram channel");
       const doc = { userId, channelType: "telegram" as const, chatId, verified: true, linkedAt: now };
-      if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
+      if (existing) { await ctx.db.replace(existing._id, doc); } else { channelId = String(await ctx.db.insert("notificationChannels", doc)); }
     } else if (channelType === "slack") {
       if (!webhookEnvelope) throw new ConvexError("webhookEnvelope required for slack channel");
       const doc = { userId, channelType: "slack" as const, webhookEnvelope, verified: true, linkedAt: now };
-      if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
+      if (existing) { await ctx.db.replace(existing._id, doc); } else { channelId = String(await ctx.db.insert("notificationChannels", doc)); }
     } else if (channelType === "email") {
       if (!email) throw new ConvexError("email required for email channel");
       const doc = { userId, channelType: "email" as const, email, verified: true, linkedAt: now };
-      if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
+      if (existing) { await ctx.db.replace(existing._id, doc); } else { channelId = String(await ctx.db.insert("notificationChannels", doc)); }
     } else if (channelType === "webhook") {
       if (!webhookEnvelope) throw new ConvexError("webhookEnvelope required for webhook channel");
       const doc = { userId, channelType: "webhook" as const, webhookEnvelope, verified: true, linkedAt: now, webhookLabel };
-      if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
+      if (existing) { await ctx.db.replace(existing._id, doc); } else { channelId = String(await ctx.db.insert("notificationChannels", doc)); }
     } else {
       throw new ConvexError("discord channel must be set via set-discord-oauth");
+    }
+    if (isNew && args.scheduleWelcome === true) {
+      await ctx.scheduler.runAfter(
+        0,
+        (internal as any).notificationChannels.queueChannelWelcome,
+        { userId, channelType, welcomeId: channelId, attempt: 0 },
+      );
     }
     return { isNew };
   },
@@ -119,10 +271,21 @@ export const setWebPushChannelForUser = internalMutation({
     p256dh: v.string(),
     auth: v.string(),
     userAgent: v.optional(v.string()),
+    scheduleWelcome: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    // Step 1: scan for any existing rows with this endpoint across
-    // ALL users and delete them. notificationChannels has no
+    // Step 1: find the current user's row before cross-account endpoint
+    // cleanup. A retry with the same endpoint must remain a re-link rather
+    // than deleting its own row and appearing to be a first connection.
+    const existing = await ctx.db
+      .query("notificationChannels")
+      .withIndex("by_user_channel", (q) =>
+        q.eq("userId", args.userId).eq("channelType", "web_push"),
+      )
+      .unique();
+
+    // Step 2: scan for rows with this endpoint across other users and delete
+    // them. notificationChannels has no
     // endpoint-based index, so we filter at read time — acceptable
     // at current scale (<10k rows) and well-bounded to a single
     // write-path per user per connect.
@@ -134,21 +297,14 @@ export const setWebPushChannelForUser = internalMutation({
         row.channelType === "web_push" &&
         // Narrow through the channel-type literal so TS knows
         // `endpoint` exists on this row.
-        row.endpoint === args.endpoint
+        row.endpoint === args.endpoint &&
+        row.userId !== args.userId
       ) {
         await ctx.db.delete(row._id);
       }
     }
 
-    // Step 2: upsert the current-user row by (userId, channelType).
-    // After the delete above there is at most one row matching the
-    // unique index, so .unique() is safe.
-    const existing = await ctx.db
-      .query("notificationChannels")
-      .withIndex("by_user_channel", (q) =>
-        q.eq("userId", args.userId).eq("channelType", "web_push"),
-      )
-      .unique();
+    // Step 3: upsert the current-user row by (userId, channelType).
     const isNew = !existing;
     const doc = {
       userId: args.userId,
@@ -160,10 +316,24 @@ export const setWebPushChannelForUser = internalMutation({
       linkedAt: Date.now(),
       userAgent: args.userAgent,
     };
+    let channelId: string;
     if (existing) {
       await ctx.db.replace(existing._id, doc);
+      channelId = String(existing._id);
     } else {
-      await ctx.db.insert("notificationChannels", doc);
+      channelId = String(await ctx.db.insert("notificationChannels", doc));
+    }
+    if (isNew && args.scheduleWelcome === true) {
+      await ctx.scheduler.runAfter(
+        0,
+        (internal as any).notificationChannels.queueChannelWelcome,
+        {
+          userId: args.userId,
+          channelType: "web_push",
+          welcomeId: channelId,
+          attempt: 0,
+        },
+      );
     }
     return { isNew };
   },

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -34,6 +34,9 @@ const QUIET_HOURS_BATCH_ENABLED = process.env.QUIET_HOURS_BATCH_ENABLED !== '0';
 const AI_IMPACT_ENABLED = process.env.AI_IMPACT_ENABLED === '1';
 const AI_IMPACT_CACHE_TTL = 1800; // 30 min, matches dedup window
 const DEDUP_TTL_SECONDS = 1800;
+const EVENT_QUEUE_KEY = 'wm:events:queue';
+const WELCOME_V2_QUEUE_KEY = 'wm:events:queue:welcome-v2';
+const WELCOME_V2_POLL_EVERY = 10;
 
 if (!UPSTASH_URL || !UPSTASH_TOKEN) { console.error('[relay] UPSTASH_REDIS_REST_URL/TOKEN not set'); process.exit(1); }
 if (!CONVEX_URL) { console.error('[relay] CONVEX_URL not set'); process.exit(1); }
@@ -929,7 +932,7 @@ function formatMessage(event) {
 }
 
 async function processWelcome(event) {
-  const { userId, channelType } = event;
+  const { userId, channelType, welcomeId } = event;
   if (!userId || !channelType) return;
   // Telegram welcome is sent directly by Convex; no relay send needed.
   if (channelType === 'telegram') return;
@@ -944,7 +947,14 @@ async function processWelcome(event) {
     if (chRes.ok) channels = (await chRes.json()) ?? [];
   } catch {}
 
-  const ch = channels.find(c => c.channelType === channelType && c.verified);
+  const ch = channels.find(c =>
+    c.channelType === channelType &&
+    c.verified &&
+    // Events created before connection-scoped welcome IDs remain compatible.
+    // New events must still target the exact channel document that scheduled
+    // them, so a delayed retry cannot welcome a replacement connection.
+    (!welcomeId || String(c._id) === welcomeId)
+  );
   if (!ch) return;
 
   // Telegram welcome is sent directly by convex/http.ts after claimPairingToken succeeds.
@@ -1284,6 +1294,17 @@ async function processEvent(event) {
   }
 }
 
+async function popNextEvent(pollNumber) {
+  // Old relays do not know this queue, so connection-scoped welcome events
+  // cannot be consumed without the exact-ID guard. Check it periodically,
+  // then fall back to the legacy queue in the same poll cycle.
+  if (pollNumber % WELCOME_V2_POLL_EVERY === 0) {
+    const welcome = await upstashRest('RPOP', WELCOME_V2_QUEUE_KEY);
+    if (welcome) return welcome;
+  }
+  return upstashRest('RPOP', EVENT_QUEUE_KEY);
+}
+
 // ── Poll loop (RPOP queue) ────────────────────────────────────────────────────
 //
 // Publishers push to wm:events:queue via LPUSH (FIFO: LPUSH head, RPOP tail).
@@ -1296,6 +1317,7 @@ async function subscribe() {
   console.log('[relay] TELEGRAM_BOT_TOKEN set:', !!TELEGRAM_BOT_TOKEN, '| RESEND_API_KEY set:', !!RESEND_API_KEY);
   let idleCount = 0;
   let lastDrainMs = 0;
+  let pollNumber = 0;
   const DRAIN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
   while (true) {
     try {
@@ -1306,7 +1328,7 @@ async function subscribe() {
         drainBatchOnWake().catch(err => console.warn('[relay] drainBatchOnWake error:', err.message));
       }
 
-      const result = await upstashRest('RPOP', 'wm:events:queue');
+      const result = await popNextEvent(pollNumber++);
       if (result) {
         idleCount = 0;
         console.log('[relay] RPOP dequeued message:', String(result).slice(0, 200));
@@ -1343,4 +1365,11 @@ if (require.main === module) {
   });
 }
 
-module.exports = { sendTelegram, checkDedup, upstashDedupSetNx, eventMatchesCountryScope };
+module.exports = {
+  sendTelegram,
+  checkDedup,
+  upstashDedupSetNx,
+  eventMatchesCountryScope,
+  processWelcome,
+  popNextEvent,
+};

--- a/tests/notification-channels-relay-timeout.test.mts
+++ b/tests/notification-channels-relay-timeout.test.mts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+const originalAbortSignalTimeout = AbortSignal.timeout;
+
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+async function importFreshNotificationChannels() {
+  process.env.CONVEX_SITE_URL = 'https://convex.test';
+  process.env.RELAY_SHARED_SECRET = 'relay-secret';
+  process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-token';
+  return import(`../api/notification-channels.ts?test=${Date.now()}-${Math.random()}`);
+}
+
+function makeSetChannelRequest(): Request {
+  return new Request('https://worldmonitor.app/api/notification-channels', {
+    method: 'POST',
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      Authorization: 'Bearer clerk-token',
+      'Content-Type': 'application/json',
+      'Idempotency-Key': 'notification-channel-timeout-retry',
+    },
+    body: JSON.stringify({
+      action: 'set-channel',
+      channelType: 'email',
+      email: 'retry@example.com',
+    }),
+  });
+}
+
+type RedisCommand = string[];
+
+function installInMemoryUpstash() {
+  const store = new Map<string, string>();
+  const batches: RedisCommand[][] = [];
+
+  globalThis.fetch = mock.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    assert.equal(String(input), 'https://upstash.test/pipeline');
+    const commands = JSON.parse(String(init?.body)) as RedisCommand[];
+    batches.push(commands);
+    const results = commands.map((command) => {
+      const [rawOperation, key, value, ...options] = command;
+      const operation = rawOperation?.toUpperCase();
+      if (operation === 'GET') return { result: store.get(key!) ?? null };
+      if (operation === 'DEL') return { result: store.delete(key!) ? 1 : 0 };
+      if (operation === 'SET') {
+        const hasNx = options.some((option) => option.toUpperCase() === 'NX');
+        if (hasNx && store.has(key!)) return { result: null };
+        store.set(key!, value!);
+        return { result: 'OK' };
+      }
+      throw new Error(`Unexpected Redis command: ${command.join(' ')}`);
+    });
+    return Response.json(results);
+  }) as typeof fetch;
+
+  return { store, batches };
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  AbortSignal.timeout = originalAbortSignalTimeout;
+  restoreEnv();
+});
+
+describe('/api/notification-channels relay timeout recovery', () => {
+  it('returns CORS-safe 500, releases idempotency, and processes the same-key retry', async () => {
+    const redis = installInMemoryUpstash();
+    const mod = await importFreshNotificationChannels();
+    const consoleError = mock.method(console, 'error', () => {});
+    const relaySignals: AbortSignal[] = [];
+    const allRelaySignals: AbortSignal[] = [];
+    const timeoutDurations = new WeakMap<AbortSignal, number>();
+    const relayTimeouts: Array<number | undefined> = [];
+    let mutationAttempt = 0;
+    const relayFetch = mock.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        action?: string;
+        scheduleWelcome?: boolean;
+      };
+      const relaySignal = init?.signal as AbortSignal | undefined;
+      assert.ok(relaySignal);
+      allRelaySignals.push(relaySignal);
+      relayTimeouts.push(
+        timeoutDurations.get(relaySignal),
+      );
+      if (body.action === 'welcome-scheduling-capability') {
+        return Response.json({ durableWelcomeScheduling: true });
+      }
+      mutationAttempt += 1;
+      const signal = init?.signal as AbortSignal;
+      relaySignals.push(signal);
+      assert.equal(body.scheduleWelcome, true);
+      if (mutationAttempt === 1) {
+        return await new Promise<Response>((_resolve, reject) => {
+          const rejectForAbort = () => reject(signal.reason ?? new DOMException('Timed out', 'TimeoutError'));
+          if (signal.aborted) rejectForAbort();
+          else signal.addEventListener('abort', rejectForAbort, { once: true });
+        });
+      }
+      return Response.json({
+        ok: true,
+        isNew: false,
+        durableWelcomeScheduling: true,
+      });
+    });
+
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-timeout-retry' }),
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: {
+          tier: 1,
+          apiAccess: true,
+          apiRateLimit: 1_000,
+          maxDashboards: 10,
+          prioritySupport: true,
+          exportFormats: ['json'],
+          mcpAccess: true,
+        },
+        validUntil: Date.now() + 60_000,
+      }),
+      fetch: relayFetch,
+    });
+
+    AbortSignal.timeout = ((delay: number) => {
+      const signal = originalAbortSignalTimeout(Math.min(delay, 10));
+      timeoutDurations.set(signal, delay);
+      return signal;
+    }) as typeof AbortSignal.timeout;
+
+    const ctx = { waitUntil: (_promise: Promise<unknown>) => {} };
+    const first = await mod.default(makeSetChannelRequest(), ctx);
+
+    assert.equal(first.status, 500);
+    assert.deepEqual(await first.json(), { error: 'Operation failed' });
+    assert.equal(first.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+    assert.equal(first.headers.get('Idempotency-Key'), 'notification-channel-timeout-retry');
+    assert.equal(first.headers.get('Idempotent-Replayed'), 'false');
+    assert.equal(relaySignals[0]?.aborted, true);
+    assert.deepEqual(
+      relayTimeouts,
+      [15_000, 15_000],
+      'capability probe and mutation must use the bounded 15-second relay deadline',
+    );
+    assert.equal(
+      allRelaySignals[0],
+      allRelaySignals[1],
+      'capability probe and mutation must share one edge deadline',
+    );
+    assert.equal(redis.store.size, 0, 'retryable 500 must release the processing marker');
+    assert.equal(
+      redis.batches.some((batch) => batch.some(([operation]) => operation === 'DEL')),
+      true,
+      'timeout path must issue the idempotency DEL cleanup',
+    );
+
+    const second = await mod.default(makeSetChannelRequest(), ctx);
+
+    assert.equal(second.status, 200);
+    assert.deepEqual(await second.json(), { ok: true });
+    assert.equal(second.headers.get('Idempotency-Key'), 'notification-channel-timeout-retry');
+    assert.equal(second.headers.get('Idempotent-Replayed'), 'false');
+    assert.equal(relayFetch.mock.calls.length, 4);
+    const relayInit = relayFetch.mock.calls[3]!.arguments[1] as RequestInit;
+    assert.equal((relayInit.headers as Record<string, string>)['User-Agent'], 'worldmonitor-edge/1.0');
+    assert.ok(relayInit.signal instanceof AbortSignal);
+    assert.deepEqual(relayTimeouts, [15_000, 15_000, 15_000, 15_000]);
+    assert.equal(allRelaySignals[2], allRelaySignals[3]);
+
+    const replay = await mod.default(makeSetChannelRequest(), ctx);
+    assert.equal(replay.status, 200);
+    assert.deepEqual(await replay.json(), { ok: true });
+    assert.equal(replay.headers.get('Idempotent-Replayed'), 'true');
+    assert.equal(relayFetch.mock.calls.length, 4, 'completed retry should replay without another relay call');
+    assert.equal(consoleError.mock.calls.length >= 1, true);
+  });
+
+  it('fails closed and releases idempotency during an old-Convex/new-edge deploy window', async () => {
+    const redis = installInMemoryUpstash();
+    const mod = await importFreshNotificationChannels();
+    const waits: Promise<unknown>[] = [];
+    let durableRelayAvailable = false;
+
+    const relayFetch = mock.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      assert.equal(url, 'https://convex.test/relay/notification-channels');
+      const body = JSON.parse(String(init?.body)) as {
+        action?: string;
+        scheduleWelcome?: boolean;
+      };
+      if (body.action === 'welcome-scheduling-capability') {
+        if (!durableRelayAvailable) {
+          return Response.json({ error: 'Unknown action' }, { status: 400 });
+        }
+        return Response.json({ durableWelcomeScheduling: true });
+      }
+      assert.equal(body.action, 'set-channel');
+      assert.equal(body.scheduleWelcome, true);
+      return Response.json({
+        ok: true,
+        isNew: true,
+        durableWelcomeScheduling: true,
+      });
+    });
+
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-mixed-deploy' }),
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: {
+          tier: 1,
+          apiAccess: true,
+          apiRateLimit: 1_000,
+          maxDashboards: 10,
+          prioritySupport: true,
+          exportFormats: ['json'],
+          mcpAccess: true,
+        },
+        validUntil: Date.now() + 60_000,
+      }),
+      fetch: relayFetch,
+    });
+
+    const first = await mod.default(makeSetChannelRequest(), {
+      waitUntil: (promise: Promise<unknown>) => {
+        waits.push(promise);
+      },
+    });
+
+    assert.equal(first.status, 503);
+    assert.deepEqual(await first.json(), { error: 'Service unavailable' });
+    assert.equal(waits.length, 0);
+    assert.equal(redis.store.size, 0, 'retryable deploy-window failure must release the processing marker');
+    assert.equal(relayFetch.mock.calls.length, 1, 'old Convex must not receive the mutation');
+
+    durableRelayAvailable = true;
+    const retry = await mod.default(makeSetChannelRequest(), {
+      waitUntil: (promise: Promise<unknown>) => {
+        waits.push(promise);
+      },
+    });
+
+    assert.equal(retry.status, 200);
+    assert.equal(waits.length, 0, 'Convex owns the welcome after the retry');
+    assert.equal(relayFetch.mock.calls.length, 3);
+  });
+
+  it('does not duplicate the welcome after Convex accepts scheduling ownership', async () => {
+    installInMemoryUpstash();
+    const mod = await importFreshNotificationChannels();
+    const waits: Promise<unknown>[] = [];
+
+    const relayFetch = mock.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      assert.equal(url, 'https://convex.test/relay/notification-channels');
+      const body = JSON.parse(String(init?.body)) as {
+        action?: string;
+        scheduleWelcome?: boolean;
+      };
+      if (body.action === 'welcome-scheduling-capability') {
+        return Response.json({ durableWelcomeScheduling: true });
+      }
+      assert.equal(body.action, 'set-channel');
+      assert.equal(body.scheduleWelcome, true);
+      return Response.json({
+        ok: true,
+        isNew: true,
+        durableWelcomeScheduling: true,
+      });
+    });
+
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-durable-deploy' }),
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: {
+          tier: 1,
+          apiAccess: true,
+          apiRateLimit: 1_000,
+          maxDashboards: 10,
+          prioritySupport: true,
+          exportFormats: ['json'],
+          mcpAccess: true,
+        },
+        validUntil: Date.now() + 60_000,
+      }),
+      fetch: relayFetch,
+    });
+
+    const response = await mod.default(makeSetChannelRequest(), {
+      waitUntil: (promise: Promise<unknown>) => {
+        waits.push(promise);
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(waits.length, 0, 'edge must not enqueue a second welcome');
+    assert.equal(relayFetch.mock.calls.length, 2);
+  });
+});

--- a/tests/notification-channels-relay-timeout.test.mts
+++ b/tests/notification-channels-relay-timeout.test.mts
@@ -37,6 +37,25 @@ function makeSetChannelRequest(): Request {
   });
 }
 
+function makeSetWebPushRequest(): Request {
+  return new Request('https://worldmonitor.app/api/notification-channels', {
+    method: 'POST',
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      Authorization: 'Bearer clerk-token',
+      'Content-Type': 'application/json',
+      'Idempotency-Key': 'notification-web-push-timeout-retry',
+    },
+    body: JSON.stringify({
+      action: 'set-web-push',
+      endpoint: 'https://fcm.googleapis.com/fcm/send/subscription-1',
+      p256dh: 'p256dh-key',
+      auth: 'auth-secret',
+      userAgent: 'Chrome',
+    }),
+  });
+}
+
 type RedisCommand = string[];
 
 function installInMemoryUpstash() {
@@ -307,5 +326,74 @@ describe('/api/notification-channels relay timeout recovery', () => {
     assert.equal(response.status, 200);
     assert.equal(waits.length, 0, 'edge must not enqueue a second welcome');
     assert.equal(relayFetch.mock.calls.length, 2);
+  });
+
+  it('applies the same fail-closed and duplicate-guard wiring to set-web-push', async () => {
+    const redis = installInMemoryUpstash();
+    const mod = await importFreshNotificationChannels();
+    const waits: Promise<unknown>[] = [];
+    let durableRelayAvailable = false;
+
+    const relayFetch = mock.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      assert.equal(url, 'https://convex.test/relay/notification-channels');
+      const body = JSON.parse(String(init?.body)) as {
+        action?: string;
+        scheduleWelcome?: boolean;
+        endpoint?: string;
+      };
+      if (body.action === 'welcome-scheduling-capability') {
+        if (!durableRelayAvailable) {
+          return Response.json({ error: 'Unknown action' }, { status: 400 });
+        }
+        return Response.json({ durableWelcomeScheduling: true });
+      }
+      assert.equal(body.action, 'set-web-push');
+      assert.equal(body.scheduleWelcome, true);
+      assert.equal(body.endpoint, 'https://fcm.googleapis.com/fcm/send/subscription-1');
+      return Response.json({
+        ok: true,
+        isNew: true,
+        durableWelcomeScheduling: true,
+      });
+    });
+
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-web-push-deploy' }),
+      getEntitlements: async () => ({
+        planKey: 'pro_monthly',
+        features: {
+          tier: 1,
+          apiAccess: true,
+          apiRateLimit: 1_000,
+          maxDashboards: 10,
+          prioritySupport: true,
+          exportFormats: ['json'],
+          mcpAccess: true,
+        },
+        validUntil: Date.now() + 60_000,
+      }),
+      fetch: relayFetch,
+    });
+
+    const ctx = {
+      waitUntil: (promise: Promise<unknown>) => {
+        waits.push(promise);
+      },
+    };
+
+    const first = await mod.default(makeSetWebPushRequest(), ctx);
+    assert.equal(first.status, 503);
+    assert.deepEqual(await first.json(), { error: 'Service unavailable' });
+    assert.equal(waits.length, 0);
+    assert.equal(redis.store.size, 0, 'deploy-window 503 must release the processing marker');
+    assert.equal(relayFetch.mock.calls.length, 1, 'old Convex must not receive the set-web-push mutation');
+
+    durableRelayAvailable = true;
+    const retry = await mod.default(makeSetWebPushRequest(), ctx);
+    assert.equal(retry.status, 200);
+    assert.deepEqual(await retry.json(), { ok: true });
+    assert.equal(waits.length, 0, 'Convex owns the welcome — edge must not enqueue a duplicate');
+    assert.equal(relayFetch.mock.calls.length, 3);
   });
 });

--- a/tests/notification-relay-welcome-identity.test.mjs
+++ b/tests/notification-relay-welcome-identity.test.mjs
@@ -102,4 +102,65 @@ describe('notification relay welcome identity', () => {
     assert.match(queued, /original-channel-id/);
     assert.equal(queueCalls.length, 1, 'v2 welcome must not be exposed to the legacy queue consumer');
   });
+
+  it('delivers legacy events without welcomeId and v2 events whose welcomeId matches', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-token';
+    process.env.CONVEX_URL = 'https://convex.test';
+    process.env.CONVEX_SITE_URL = 'https://convex.test';
+    process.env.RELAY_SHARED_SECRET = 'relay-secret';
+    process.env.RESEND_API_KEY = 'resend-key';
+    const resendSends = [];
+    const relayPath = require.resolve('../scripts/notification-relay.cjs');
+    delete require.cache[relayPath];
+    const originalLoad = Module._load;
+    Module._load = function patchedLoad(request, parent, ...rest) {
+      if (request === 'resend') {
+        return {
+          Resend: class {
+            emails = {
+              send: async (message) => {
+                resendSends.push(message);
+                return { data: { id: 'sent' }, error: null };
+              },
+            };
+          },
+        };
+      }
+      return originalLoad.call(this, request, parent, ...rest);
+    };
+    let processWelcome;
+    try {
+      ({ processWelcome } = require(relayPath));
+    } finally {
+      Module._load = originalLoad;
+    }
+
+    globalThis.fetch = mock.fn(async (input) => {
+      assert.equal(String(input), 'https://convex.test/relay/channels');
+      return Response.json([{
+        _id: 'current-channel-id',
+        userId: 'user-welcome',
+        channelType: 'email',
+        email: 'current@example.com',
+        verified: true,
+      }]);
+    });
+
+    await processWelcome({
+      eventType: 'channel_welcome',
+      userId: 'user-welcome',
+      channelType: 'email',
+    });
+    assert.equal(resendSends.length, 1, 'legacy event without welcomeId must still deliver');
+    assert.equal(resendSends[0].to, 'current@example.com');
+
+    await processWelcome({
+      eventType: 'channel_welcome',
+      userId: 'user-welcome',
+      channelType: 'email',
+      welcomeId: 'current-channel-id',
+    });
+    assert.equal(resendSends.length, 2, 'matching welcomeId must deliver to its own connection');
+  });
 });

--- a/tests/notification-relay-welcome-identity.test.mjs
+++ b/tests/notification-relay-welcome-identity.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const originalFetch = globalThis.fetch;
+const originalUpstashUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalUpstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const originalConvexUrl = process.env.CONVEX_URL;
+const originalConvexSiteUrl = process.env.CONVEX_SITE_URL;
+const originalRelaySecret = process.env.RELAY_SHARED_SECRET;
+const originalResendApiKey = process.env.RESEND_API_KEY;
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  if (originalUpstashUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalUpstashUrl;
+  if (originalUpstashToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalUpstashToken;
+  if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
+  else process.env.CONVEX_URL = originalConvexUrl;
+  if (originalConvexSiteUrl === undefined) delete process.env.CONVEX_SITE_URL;
+  else process.env.CONVEX_SITE_URL = originalConvexSiteUrl;
+  if (originalRelaySecret === undefined) delete process.env.RELAY_SHARED_SECRET;
+  else process.env.RELAY_SHARED_SECRET = originalRelaySecret;
+  if (originalResendApiKey === undefined) delete process.env.RESEND_API_KEY;
+  else process.env.RESEND_API_KEY = originalResendApiKey;
+});
+
+describe('notification relay welcome identity', () => {
+  it('does not deliver a delayed welcome to a replacement channel', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-token';
+    process.env.CONVEX_URL = 'https://convex.test';
+    process.env.CONVEX_SITE_URL = 'https://convex.test';
+    process.env.RELAY_SHARED_SECRET = 'relay-secret';
+    process.env.RESEND_API_KEY = 'resend-key';
+    const resendSends = [];
+    const relayPath = require.resolve('../scripts/notification-relay.cjs');
+    delete require.cache[relayPath];
+    const originalLoad = Module._load;
+    Module._load = function patchedLoad(request, parent, ...rest) {
+      if (request === 'resend') {
+        return {
+          Resend: class {
+            emails = {
+              send: async (message) => {
+                resendSends.push(message);
+                return { data: { id: 'sent' }, error: null };
+              },
+            };
+          },
+        };
+      }
+      return originalLoad.call(this, request, parent, ...rest);
+    };
+    let processWelcome;
+    let popNextEvent;
+    try {
+      ({ processWelcome, popNextEvent } = require(relayPath));
+    } finally {
+      Module._load = originalLoad;
+    }
+
+    const fetchMock = mock.fn(async (input) => {
+      assert.equal(String(input), 'https://convex.test/relay/channels');
+      return Response.json([{
+        _id: 'replacement-channel-id',
+        userId: 'user-welcome',
+        channelType: 'email',
+        email: 'replacement@example.com',
+        verified: true,
+      }]);
+    });
+    globalThis.fetch = fetchMock;
+
+    await processWelcome({
+      eventType: 'channel_welcome',
+      userId: 'user-welcome',
+      channelType: 'email',
+      welcomeId: 'original-channel-id',
+    });
+
+    assert.equal(fetchMock.mock.calls.length, 1, 'replacement channel must not receive the stale welcome');
+    assert.equal(resendSends.length, 0, 'replacement email channel must not receive the stale welcome');
+
+    const queueCalls = [];
+    globalThis.fetch = mock.fn(async (input) => {
+      const url = String(input);
+      queueCalls.push(url);
+      if (url.includes('/RPOP/wm%3Aevents%3Aqueue%3Awelcome-v2')) {
+        return Response.json({ result: JSON.stringify({
+          eventType: 'channel_welcome',
+          welcomeId: 'original-channel-id',
+        }) });
+      }
+      throw new Error(`Unexpected queue poll: ${url}`);
+    });
+    const queued = await popNextEvent(0);
+    assert.match(queued, /original-channel-id/);
+    assert.equal(queueCalls.length, 1, 'v2 welcome must not be exposed to the legacy queue consumer');
+  });
+});


### PR DESCRIPTION
Fixes #5426.

## Problem

`convexRelay()` is on the critical path of every GET/POST to `/api/notification-channels`, and was the only outbound `fetch` in the file with no `AbortSignal` — every sibling call bounds itself (the two Upstash `LPUSH` calls a few lines above use `AbortSignal.timeout(5000)`, and the other Convex relay callers in `api/customer-portal.ts` / `api/create-checkout.ts` use 15s for the same host).

This endpoint holds an idempotency lock across the call (`beginStandaloneIdempotency`, 180s TTL). If the relay hangs:

1. The edge runtime kills the invocation once it exceeds its initial-response budget, before the handler's own `catch` runs — no Sentry capture, no CORS headers on the response.
2. `finish()` (which calls `completeStandaloneIdempotency`/`releaseProcessingLock`) never executes.
3. Every retry with the same `Idempotency-Key` gets `409 idempotency_conflict` for the lock's full 180s TTL, with no way to force it through.

## Fix

Added `signal: AbortSignal.timeout(15_000)` to `convexRelay()`, matching the 15s timeout already used for the same Convex host elsewhere in the codebase. This lets the relay call fail *inside* the handler so the existing `catch` runs and `finish()` releases the lock, instead of the whole invocation being killed out from under it.

## Testing

I verified the `catch` at the end of the POST branch does call `finish(...)` (same check the issue calls out), confirming the timeout actually closes the stuck-lock window rather than only changing which status code comes back. I didn't add a new test — there's no existing test file for this endpoint to extend, and the fix itself is a single bounded-timeout addition matching an established pattern already used three other places in the codebase for the same host.