### PR TITLE
feat(desktop): add uninstall scripts for macOS, Linux, and Windows

### DIFF
--- a/docs/desktop-app.mdx
+++ b/docs/desktop-app.mdx
@@ -220,3 +220,42 @@ The desktop app checks for new versions by polling `worldmonitor.app/api/version
 Update prompts are dismissable per-version — dismissing v2.5.0 won't suppress v2.6.0 notifications. The updater is variant-aware: a Tech Monitor desktop build links to the Tech Monitor release asset, not the full variant.
 
 The `/api/version` endpoint reads the latest GitHub Release tag and caches the result for 1 hour, so version checks don't hit the GitHub API on every request.
+
+## Uninstall
+
+The repository ships uninstall scripts that remove the app, its data directories (config, caches, WebView storage, logs), and the OS keychain secrets vault for every installed variant (World, Tech, and Finance Monitor).
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/koala73/worldmonitor/main/scripts/uninstall-desktop.sh | bash
+```
+
+Or from a repository checkout: `bash scripts/uninstall-desktop.sh`
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/koala73/worldmonitor/main/scripts/uninstall-desktop.ps1 -OutFile uninstall-desktop.ps1
+powershell -ExecutionPolicy Bypass -File .\uninstall-desktop.ps1
+```
+
+On Windows the script runs the bundled NSIS/MSI uninstaller (the same one available in **Settings → Apps → Installed apps**) and then cleans up the app-data directories and Credential Manager entries the bundled uninstaller leaves behind.
+
+Both scripts list everything they found and ask for confirmation before removing anything. Options:
+
+| Option | Effect |
+|---|---|
+| `--variant <world\|tech\|finance\|all>` / `-Variant` | Uninstall a single variant (default: all) |
+| `--keep-data` / `-KeepData` | Keep app data, caches, and logs |
+| `--keep-secrets` / `-KeepSecrets` | Keep API keys stored in the OS keychain |
+| `--dry-run` / `-DryRun` | Preview what would be removed |
+| `--yes` / `-Yes` | Skip the confirmation prompt |
+
+The keychain secrets vault (service `world-monitor`, entry `secrets-vault`) is shared by all variants, so it is only removed when uninstalling all variants without `--keep-secrets`.
+
+**Manual uninstall** — if you prefer to remove things by hand:
+
+- **macOS**: drag the app from `/Applications` to the Trash, then delete `~/Library/Application Support/app.worldmonitor.desktop`, `~/Library/Caches/app.worldmonitor.desktop`, `~/Library/WebKit/app.worldmonitor.desktop`, `~/Library/Logs/app.worldmonitor.desktop`, and the `world-monitor` entry in Keychain Access (Tech and Finance variants use the `app.worldmonitor.tech.desktop` / `app.worldmonitor.finance.desktop` identifiers)
+- **Windows**: uninstall from **Settings → Apps**, then delete `%APPDATA%\app.worldmonitor.desktop` and `%LOCALAPPDATA%\app.worldmonitor.desktop`, and remove `world-monitor` entries in Credential Manager
+- **Linux**: delete the AppImage file plus `~/.config/app.worldmonitor.desktop`, `~/.local/share/app.worldmonitor.desktop`, and `~/.cache/app.worldmonitor.desktop`; if you integrated the AppImage into your launcher, also remove its `.desktop` entry from `~/.local/share/applications`

--- a/scripts/uninstall-desktop.ps1
+++ b/scripts/uninstall-desktop.ps1
@@ -1,0 +1,172 @@
+<#
+.SYNOPSIS
+  Uninstalls the World Monitor desktop app on Windows.
+
+.DESCRIPTION
+  Runs the bundled NSIS/MSI uninstaller for each installed variant, then
+  removes leftover app data (unless -KeepData) and Credential Manager
+  secrets (unless -KeepSecrets).
+
+  macOS/Linux users: use scripts/uninstall-desktop.sh instead.
+
+.PARAMETER Variant
+  Which desktop variant to uninstall: world, tech, finance, or all (default).
+
+.PARAMETER KeepData
+  Keep app data, caches, and logs under %APPDATA% / %LOCALAPPDATA%.
+
+.PARAMETER KeepSecrets
+  Keep API keys stored in Windows Credential Manager.
+
+.PARAMETER DryRun
+  Show what would be removed without removing anything.
+
+.PARAMETER Yes
+  Skip the confirmation prompt.
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File scripts\uninstall-desktop.ps1 -DryRun
+#>
+[CmdletBinding()]
+param(
+  [ValidateSet('world', 'tech', 'finance', 'all')]
+  [string]$Variant = 'all',
+  [switch]$KeepData,
+  [switch]$KeepSecrets,
+  [switch]$DryRun,
+  [switch]$Yes
+)
+
+$ErrorActionPreference = 'Stop'
+
+# variant -> product name / binary name / bundle identifier
+# (mirrors src-tauri/tauri*.conf.json)
+$AllVariants = @{
+  world   = @{ Product = 'World Monitor';   Binary = 'world-monitor';   Identifier = 'app.worldmonitor.desktop' }
+  tech    = @{ Product = 'Tech Monitor';    Binary = 'tech-monitor';    Identifier = 'app.worldmonitor.tech.desktop' }
+  finance = @{ Product = 'Finance Monitor'; Binary = 'finance-monitor'; Identifier = 'app.worldmonitor.finance.desktop' }
+}
+$KeyringService = 'world-monitor'
+
+$Selected = if ($Variant -eq 'all') { @('world', 'tech', 'finance') } else { @($Variant) }
+
+function Find-Uninstallers {
+  param([string]$Product)
+  $roots = @(
+    'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+    'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+    'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+  )
+  $found = @()
+  foreach ($root in $roots) {
+    if (-not (Test-Path $root)) { continue }
+    Get-ChildItem $root -ErrorAction SilentlyContinue | ForEach-Object {
+      $props = Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue
+      if ($props.DisplayName -eq $Product -and $props.UninstallString) {
+        $found += $props
+      }
+    }
+  }
+  return $found
+}
+
+function Stop-VariantProcesses {
+  param([hashtable]$Info)
+  # Best-effort: stop the main binary and any bundled sidecar Node runtime
+  # (matches the NSIS pre-uninstall hook in src-tauri/nsis/installer-hooks.nsh).
+  Get-Process -Name $Info.Binary -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+    Where-Object { $_.ExecutablePath -and $_.ExecutablePath -match 'resources\\sidecar\\node' } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+}
+
+# Collect what exists
+$uninstallers = @()
+$dataDirs = @()
+foreach ($v in $Selected) {
+  $info = $AllVariants[$v]
+  foreach ($entry in (Find-Uninstallers -Product $info.Product)) {
+    $uninstallers += @{ Variant = $v; Entry = $entry }
+  }
+  if (-not $KeepData) {
+    foreach ($dir in @(
+      (Join-Path $env:APPDATA $info.Identifier),
+      (Join-Path $env:LOCALAPPDATA $info.Identifier)
+    )) {
+      if (Test-Path $dir) { $dataDirs += $dir }
+    }
+  }
+}
+
+# Credential Manager entries (shared by all variants; only offered on -Variant all)
+$credTargets = @()
+if (-not $KeepSecrets -and $Variant -eq 'all') {
+  $credTargets = cmdkey /list 2>$null |
+    Where-Object { $_ -match 'Target:' -and $_ -match [regex]::Escape($KeyringService) } |
+    ForEach-Object { ($_ -split 'Target:\s*', 2)[1].Trim() }
+}
+
+if ($uninstallers.Count -eq 0 -and $dataDirs.Count -eq 0 -and $credTargets.Count -eq 0) {
+  Write-Host 'Nothing to uninstall — no World Monitor desktop installation found.'
+  exit 0
+}
+
+Write-Host 'The following will be removed:'
+foreach ($u in $uninstallers) {
+  Write-Host "  $($u.Entry.DisplayName) $($u.Entry.DisplayVersion) (via bundled uninstaller)"
+}
+foreach ($d in $dataDirs) { Write-Host "  $d" }
+foreach ($c in $credTargets) { Write-Host "  Credential Manager entry: $c" }
+
+if ($DryRun) {
+  Write-Host 'Dry run — nothing was removed.'
+  exit 0
+}
+
+if (-not $Yes) {
+  $answer = Read-Host 'Proceed? [y/N]'
+  if ($answer -notmatch '^(y|yes)$') {
+    Write-Host 'Aborted.'
+    exit 1
+  }
+}
+
+foreach ($v in $Selected) {
+  Stop-VariantProcesses -Info $AllVariants[$v]
+}
+
+foreach ($u in $uninstallers) {
+  $cmd = $u.Entry.UninstallString
+  Write-Host "Running uninstaller for $($u.Entry.DisplayName)..."
+  if ($cmd -match 'msiexec') {
+    # MSI: switch to quiet uninstall by product code
+    $productCode = if ($u.Entry.PSChildName -match '^\{.*\}$') { $u.Entry.PSChildName } else { $null }
+    if ($productCode) {
+      Start-Process 'msiexec.exe' -ArgumentList "/x $productCode /qb" -Wait
+    } else {
+      Start-Process 'cmd.exe' -ArgumentList "/c $cmd /qb" -Wait
+    }
+  } else {
+    # NSIS: /S = silent
+    if ($cmd.StartsWith('"')) {
+      $exe, $rest = $cmd -split '(?<=")\s+', 2
+      Start-Process $exe.Trim('"') -ArgumentList "$rest /S".Trim() -Wait
+    } else {
+      Start-Process $cmd -ArgumentList '/S' -Wait
+    }
+  }
+}
+
+foreach ($d in $dataDirs) {
+  if (Test-Path $d) {
+    Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "Removed $d"
+  }
+}
+
+foreach ($c in $credTargets) {
+  cmdkey /delete:$c | Out-Null
+  Write-Host "Removed Credential Manager entry: $c"
+}
+
+Write-Host 'Done. World Monitor desktop has been uninstalled.'

--- a/scripts/uninstall-desktop.sh
+++ b/scripts/uninstall-desktop.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Uninstalls the World Monitor desktop app (macOS / Linux).
+#
+# Removes, per variant found on this machine:
+#   - the app bundle (macOS) or AppImage + desktop entries (Linux)
+#   - app data, caches, WebView storage, and logs (unless --keep-data)
+#   - OS keychain secrets vault (unless --keep-secrets)
+#
+# Windows users: use scripts/uninstall-desktop.ps1 instead (the NSIS/MSI
+# uninstaller from "Add or Remove Programs" also works, but leaves app data).
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/uninstall-desktop.sh [options]
+
+Options:
+  --variant <world|tech|finance|all>  Which desktop variant to uninstall (default: all)
+  --keep-data      Keep app data, caches, and logs
+  --keep-secrets   Keep API keys stored in the OS keychain
+  --dry-run        Show what would be removed without removing anything
+  --yes            Skip the confirmation prompt
+  -h, --help       Show this help
+
+The keychain secrets vault (service "world-monitor") is shared by all
+variants; it is only offered for removal when uninstalling with
+--variant all (the default).
+EOF
+}
+
+VARIANT="all"
+KEEP_DATA=0
+KEEP_SECRETS=0
+DRY_RUN=0
+ASSUME_YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --variant)
+      VARIANT="${2:-}"
+      shift 2
+      ;;
+    --keep-data) KEEP_DATA=1; shift ;;
+    --keep-secrets) KEEP_SECRETS=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --yes) ASSUME_YES=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$VARIANT" in
+  world|tech|finance|all) ;;
+  *)
+    echo "Invalid --variant: ${VARIANT} (expected world, tech, finance, or all)" >&2
+    exit 1
+    ;;
+esac
+
+OS="$(uname -s)"
+if [ "$OS" != "Darwin" ] && [ "$OS" != "Linux" ]; then
+  echo "Unsupported OS: ${OS}. On Windows, run scripts/uninstall-desktop.ps1." >&2
+  exit 1
+fi
+
+# variant -> product name / binary name / bundle identifier
+# (mirrors src-tauri/tauri*.conf.json)
+variant_product() {
+  case "$1" in
+    world) echo "World Monitor" ;;
+    tech) echo "Tech Monitor" ;;
+    finance) echo "Finance Monitor" ;;
+  esac
+}
+
+variant_binary() {
+  case "$1" in
+    world) echo "world-monitor" ;;
+    tech) echo "tech-monitor" ;;
+    finance) echo "finance-monitor" ;;
+  esac
+}
+
+variant_identifier() {
+  case "$1" in
+    world) echo "app.worldmonitor.desktop" ;;
+    tech) echo "app.worldmonitor.tech.desktop" ;;
+    finance) echo "app.worldmonitor.finance.desktop" ;;
+  esac
+}
+
+KEYRING_SERVICE="world-monitor"
+KEYRING_VAULT_ACCOUNT="secrets-vault"
+# Legacy per-key entries from before the consolidated vault
+# (see SUPPORTED_SECRET_KEYS in src-tauri/src/main.rs).
+LEGACY_SECRET_KEYS="GROQ_API_KEY OPENROUTER_API_KEY FRED_API_KEY EIA_API_KEY FINNHUB_API_KEY CLOUDFLARE_API_TOKEN ACLED_ACCESS_TOKEN URLHAUS_AUTH_KEY OTX_API_KEY ABUSEIPDB_API_KEY NASA_FIRMS_API_KEY WINGBITS_API_KEY WS_RELAY_URL VITE_WS_RELAY_URL VITE_OPENSKY_RELAY_URL OPENSKY_CLIENT_ID OPENSKY_CLIENT_SECRET AISSTREAM_API_KEY OLLAMA_API_URL OLLAMA_MODEL WORLDMONITOR_API_KEY WTO_API_KEY AVIATIONSTACK_API ICAO_API_KEY UCDP_ACCESS_TOKEN"
+
+if [ "$VARIANT" = "all" ]; then
+  VARIANTS="world tech finance"
+else
+  VARIANTS="$VARIANT"
+fi
+
+REMOVE_PATHS=()
+
+add_path_if_exists() {
+  if [ -e "$1" ]; then
+    REMOVE_PATHS+=("$1")
+  fi
+}
+
+collect_macos_paths() {
+  local product="$1" identifier="$2"
+  add_path_if_exists "/Applications/${product}.app"
+  add_path_if_exists "${HOME}/Applications/${product}.app"
+  if [ "$KEEP_DATA" -eq 0 ]; then
+    add_path_if_exists "${HOME}/Library/Application Support/${identifier}"
+    add_path_if_exists "${HOME}/Library/Caches/${identifier}"
+    add_path_if_exists "${HOME}/Library/WebKit/${identifier}"
+    add_path_if_exists "${HOME}/Library/HTTPStorages/${identifier}"
+    add_path_if_exists "${HOME}/Library/Logs/${identifier}"
+    add_path_if_exists "${HOME}/Library/Preferences/${identifier}.plist"
+    add_path_if_exists "${HOME}/Library/Saved Application State/${identifier}.savedState"
+  fi
+}
+
+collect_linux_paths() {
+  local product="$1" binary="$2" identifier="$3"
+
+  # AppImages in the usual download/install locations. Tauri names the
+  # bundle after the product name ("World Monitor_2.10.0_amd64.AppImage");
+  # match both space- and dash-separated forms.
+  local pattern_space pattern_dash dir
+  pattern_space="${product}*.AppImage"
+  pattern_dash="${product// /-}*.AppImage"
+  for dir in "${HOME}/Applications" "${HOME}/Downloads" "${HOME}/.local/bin" "${HOME}/bin" "${HOME}/Desktop" "${HOME}/AppImages"; do
+    [ -d "$dir" ] || continue
+    while IFS= read -r appimage; do
+      add_path_if_exists "$appimage"
+    done < <(find "$dir" -maxdepth 1 \( -iname "$pattern_space" -o -iname "$pattern_dash" \) 2>/dev/null)
+  done
+
+  # Desktop entries and icons created by AppImage integration tools.
+  if [ -d "${HOME}/.local/share/applications" ]; then
+    while IFS= read -r entry; do
+      if grep -qiE "(${binary}|${product})" "$entry" 2>/dev/null; then
+        add_path_if_exists "$entry"
+      fi
+    done < <(find "${HOME}/.local/share/applications" -maxdepth 1 -name '*.desktop' 2>/dev/null)
+  fi
+
+  if [ "$KEEP_DATA" -eq 0 ]; then
+    add_path_if_exists "${HOME}/.config/${identifier}"
+    add_path_if_exists "${HOME}/.local/share/${identifier}"
+    add_path_if_exists "${HOME}/.cache/${identifier}"
+  fi
+}
+
+stop_processes() {
+  local binary="$1" product="$2"
+  # Best-effort: stop the main binary and any bundled sidecar Node runtime
+  # it spawned (matches the NSIS pre-uninstall hook behavior on Windows).
+  pkill -x "$binary" 2>/dev/null || true
+  if [ "$OS" = "Darwin" ]; then
+    pkill -f "${product}.app/Contents/Resources/resources/sidecar" 2>/dev/null || true
+  else
+    pkill -f "resources/sidecar/node" 2>/dev/null || true
+  fi
+}
+
+remove_keychain_secrets() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] would remove keychain secrets (service: ${KEYRING_SERVICE})"
+    return
+  fi
+  if [ "$OS" = "Darwin" ]; then
+    security delete-generic-password -s "$KEYRING_SERVICE" -a "$KEYRING_VAULT_ACCOUNT" >/dev/null 2>&1 || true
+    for key in $LEGACY_SECRET_KEYS; do
+      security delete-generic-password -s "$KEYRING_SERVICE" -a "$key" >/dev/null 2>&1 || true
+    done
+    echo "Removed keychain secrets (service: ${KEYRING_SERVICE})."
+  else
+    if command -v secret-tool >/dev/null 2>&1; then
+      secret-tool clear service "$KEYRING_SERVICE" username "$KEYRING_VAULT_ACCOUNT" 2>/dev/null || true
+      for key in $LEGACY_SECRET_KEYS; do
+        secret-tool clear service "$KEYRING_SERVICE" username "$key" 2>/dev/null || true
+      done
+      echo "Removed keyring secrets (service: ${KEYRING_SERVICE})."
+    else
+      echo "secret-tool not found — skipping keyring cleanup. Remove entries for service '${KEYRING_SERVICE}' with your keyring manager (e.g. GNOME Seahorse)."
+    fi
+  fi
+}
+
+for v in $VARIANTS; do
+  product="$(variant_product "$v")"
+  binary="$(variant_binary "$v")"
+  identifier="$(variant_identifier "$v")"
+  if [ "$OS" = "Darwin" ]; then
+    collect_macos_paths "$product" "$identifier"
+  else
+    collect_linux_paths "$product" "$binary" "$identifier"
+  fi
+done
+
+keychain_secrets_exist() {
+  if [ "$OS" = "Darwin" ]; then
+    security find-generic-password -s "$KEYRING_SERVICE" >/dev/null 2>&1
+  else
+    command -v secret-tool >/dev/null 2>&1 &&
+      [ -n "$(secret-tool lookup service "$KEYRING_SERVICE" username "$KEYRING_VAULT_ACCOUNT" 2>/dev/null)" ]
+  fi
+}
+
+REMOVE_SECRETS=0
+if [ "$KEEP_SECRETS" -eq 0 ] && [ "$VARIANT" = "all" ] && keychain_secrets_exist; then
+  REMOVE_SECRETS=1
+fi
+
+if [ "${#REMOVE_PATHS[@]}" -eq 0 ] && [ "$REMOVE_SECRETS" -eq 0 ]; then
+  echo "Nothing to uninstall — no World Monitor desktop installation found."
+  exit 0
+fi
+
+echo "The following will be removed:"
+# ${arr[@]+...} guards empty-array expansion under `set -u` on bash 3.2 (macOS default)
+for p in ${REMOVE_PATHS[@]+"${REMOVE_PATHS[@]}"}; do
+  echo "  ${p}"
+done
+if [ "$REMOVE_SECRETS" -eq 1 ]; then
+  echo "  OS keychain secrets (service: ${KEYRING_SERVICE})"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "Dry run — nothing was removed."
+  exit 0
+fi
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+  printf "Proceed? [y/N] "
+  read -r answer
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *)
+      echo "Aborted."
+      exit 1
+      ;;
+  esac
+fi
+
+for v in $VARIANTS; do
+  stop_processes "$(variant_binary "$v")" "$(variant_product "$v")"
+done
+
+for p in ${REMOVE_PATHS[@]+"${REMOVE_PATHS[@]}"}; do
+  rm -rf "$p"
+  echo "Removed ${p}"
+done
+
+if [ "$REMOVE_SECRETS" -eq 1 ]; then
+  remove_keychain_secrets
+fi
+
+echo "Done. World Monitor desktop has been uninstalled."

--- a/scripts/uninstall-desktop.sh
+++ b/scripts/uninstall-desktop.sh
@@ -163,14 +163,36 @@ collect_linux_paths() {
 
 stop_processes() {
   local binary="$1" product="$2"
-  # Best-effort: stop the main binary and any bundled sidecar Node runtime
-  # it spawned (matches the NSIS pre-uninstall hook behavior on Windows).
-  pkill -x "$binary" 2>/dev/null || true
+  local pid ppid pcomm mount_prefix
+  # Best-effort: stop this variant's bundled sidecar Node runtime, then the
+  # main binary (matches the NSIS pre-uninstall hook behavior on Windows).
+  # The sidecar kill is variant-scoped so uninstalling one variant never takes
+  # down another variant's running local API server.
+  #
+  # 1. Live sidecars: the sidecar is spawned by the variant binary, so match
+  #    sidecar Node processes whose PARENT command is this variant's binary.
+  for pid in $(pgrep -f "sidecar/node" 2>/dev/null || true); do
+    ppid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+    [ -n "$ppid" ] || continue
+    pcomm="$(ps -o comm= -p "$ppid" 2>/dev/null || true)"
+    case "$pcomm" in
+      *"$binary"*) kill "$pid" 2>/dev/null || true ;;
+    esac
+  done
+  # 2. Orphaned sidecars (parent already exited, reparented to init): match by
+  #    a variant-scoped executable path instead.
   if [ "$OS" = "Darwin" ]; then
-    pkill -f "${product}.app/Contents/Resources/resources/sidecar" 2>/dev/null || true
+    # Layout-agnostic under the bundle's Resources dir (Tauri places bundled
+    # resources at Contents/Resources/sidecar/...).
+    pkill -f "${product}\.app/Contents/Resources/.*sidecar" 2>/dev/null || true
   else
-    pkill -f "resources/sidecar/node" 2>/dev/null || true
+    # AppImages run from a FUSE mount named after the AppImage file
+    # (/tmp/.mount_<name-prefix>XXXXXX). The first characters of the product
+    # name distinguish the variants (World/Tech/Finance).
+    mount_prefix="$(printf '%s' "${product%% *}" | cut -c1-4)"
+    pkill -f "\.mount_${mount_prefix}.*sidecar/node" 2>/dev/null || true
   fi
+  pkill -x "$binary" 2>/dev/null || true
 }
 
 remove_keychain_secrets() {


### PR DESCRIPTION
## Summary

Adds desktop uninstall scripts, closing #5435 ("I'd like to see the uninstall script. Because I can't uninstall it right now.").

- **`scripts/uninstall-desktop.sh`** (macOS / Linux) and **`scripts/uninstall-desktop.ps1`** (Windows), covering all three desktop variants (World / Tech / Finance Monitor). They:
  - stop the running app and its bundled sidecar Node runtime first (mirrors the existing NSIS pre-uninstall hook in `src-tauri/nsis/installer-hooks.nsh`)
  - remove the app bundle (macOS), the AppImage + integrated launcher `.desktop` entries (Linux), or run the bundled NSIS/MSI uninstaller found in the registry (Windows)
  - clean up app data, caches, WebView storage, and logs under the `app.worldmonitor.desktop` / `app.worldmonitor.tech.desktop` / `app.worldmonitor.finance.desktop` identifiers (`--keep-data` to retain)
  - remove OS keychain secrets (service `world-monitor`: the `secrets-vault` entry plus the legacy per-key entries from `SUPPORTED_SECRET_KEYS`), only when uninstalling **all** variants since the vault is shared (`--keep-secrets` to retain)
  - list everything found and require confirmation before deleting; both support `--dry-run` / `-DryRun`, `--yes` / `-Yes`, and `--variant` / `-Variant`
- New **"Uninstall"** section in `docs/desktop-app.mdx` with the script usage and manual per-platform removal steps.

## Type of change

- [x] New feature
- [x] Documentation

## Affected areas

- [x] Desktop app (Tauri)
- [x] Other: `scripts/`

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A (no web-app changes)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`) — no TS changes; `docs:check` and `lint:unicode` pass

## Documentation Alignment Checklist

N/A — no methodology, API/MCP contract, or generated-doc claims changed.

## Testing done

- `bash -n` syntax check; `--help`, `--dry-run`, `--variant tech`, and invalid-variant paths exercised
- End-to-end against a faked `$HOME` on macOS: planted `World Monitor.app`, `Tech Monitor.app`, and the Application Support / Caches / Logs / WebKit / Preferences artifacts — dry-run listed exactly those paths, the real run removed them all, and `--keep-data` preserved the data dirs while removing the app bundle
- Keychain removal is only offered when a `world-monitor` keychain entry actually exists, so a machine with no install exits with "Nothing to uninstall"
- The empty-array expansion is guarded for bash 3.2 (macOS default shell)
- **Not tested:** the PowerShell script on a real Windows machine (no Windows box available) — it parses the same registry `DisplayName` entries Tauri's NSIS/MSI bundlers write, but a smoke test on Windows before merge would be prudent