### PR TITLE
fix(sidecar): release upstream fetch semaphore on stalled/truncated responses

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -86,6 +86,15 @@ function isTransientVerificationError(error) {
 let _activeUpstream = 0;
 const _upstreamQueue = [];
 const MAX_CONCURRENT_UPSTREAM = 6;
+// Inactivity timeout for ipv4Fetch's upstream requests. req.setTimeout fires
+// after this many ms with NO socket activity (it resets on data, so a slow
+// but active transfer is unaffected) -- protects against a peer that accepts
+// the connection and then goes fully silent (no FIN/RST, no more bytes),
+// which none of the other terminal-event listeners below ever observe.
+// Matches fetchWithTimeout()'s own default timeoutMs for consistency.
+// Mutable (not const) only so tests can shrink it -- production always runs
+// at the default.
+let _upstreamIdleTimeoutMs = 12000;
 function acquireUpstreamSlot() {
   if (_activeUpstream < MAX_CONCURRENT_UPSTREAM) {
     _activeUpstream++;
@@ -237,6 +246,14 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
     return await new Promise((resolve, reject) => {
       let settled = false;
       const settle = (fn, v) => { if (settled) return; settled = true; fn(v); };
+      // Check before ever dispatching to the network: if the caller's signal
+      // already fired (e.g. while we were awaiting the SSRF check or the
+      // upstream-slot queue above), honor it now instead of wasting a slot
+      // on a request nobody wants (#5441 follow-up review).
+      if (init?.signal?.aborted) {
+        settle(reject, new Error('aborted by signal'));
+        return;
+      }
       const req = mod.request(requestOptions, (res) => {
         const chunks = [];
         res.on('data', (c) => chunks.push(c));
@@ -257,6 +274,13 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
       });
       req.on('error', (e) => settle(reject, e));
       req.on('close', () => settle(reject, new Error('request closed before completion')));
+      // Catches a peer that accepts the connection and then goes silent
+      // forever (no error, no close, no data) -- the only stall shape none
+      // of the listeners above ever observe.
+      req.setTimeout(_upstreamIdleTimeoutMs, () => {
+        req.destroy();
+        settle(reject, new Error('upstream request idle-timed out'));
+      });
       if (init?.signal) {
         init.signal.addEventListener('abort', () => { req.destroy(); settle(reject, new Error('aborted by signal')); });
       }
@@ -1740,6 +1764,15 @@ async function dispatch(requestUrl, req, routes, context) {
     return json({ error: 'Local handler error', reason, endpoint: requestUrl.pathname }, 502);
   }
 }
+
+// Test seam: lets tests shrink ipv4Fetch's upstream idle timeout so a
+// silent-stall test doesn't have to wait out the real 12s production value.
+// Production code never calls this.
+export const __testing__ = {
+  setUpstreamIdleTimeoutMs(ms) {
+    _upstreamIdleTimeoutMs = ms;
+  },
+};
 
 export async function createLocalApiServer(options = {}) {
   const context = resolveConfig(options);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -229,10 +229,19 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
     if (pinned) {
       requestOptions.lookup = makePinnedLookup(pinned.address, pinned.family);
     }
+    // Settle idempotently and reject on every stream event that can leave a
+    // response mid-flight (upstream accepts the connection, sends headers,
+    // then stalls) — not just `res 'end'` / `req 'error'`. Without this, a
+    // stalled response never settles the Promise, the `finally` below never
+    // runs, and one upstream slot leaks permanently (#5441).
     return await new Promise((resolve, reject) => {
+      let settled = false;
+      const settle = (fn, v) => { if (settled) return; settled = true; fn(v); };
       const req = mod.request(requestOptions, (res) => {
         const chunks = [];
         res.on('data', (c) => chunks.push(c));
+        res.on('error', (e) => settle(reject, e));
+        res.on('aborted', () => settle(reject, new Error('upstream response aborted mid-body')));
         res.on('end', () => {
           const buf = Buffer.concat(chunks);
           const responseHeaders = new Headers();
@@ -240,14 +249,17 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
             if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(', ') : v);
           }
           try {
-            resolve(buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
+            settle(resolve, buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
           } catch (error) {
-            reject(error);
+            settle(reject, error);
           }
         });
       });
-      req.on('error', reject);
-      if (init?.signal) { init.signal.addEventListener('abort', () => req.destroy()); }
+      req.on('error', (e) => settle(reject, e));
+      req.on('close', () => settle(reject, new Error('request closed before completion')));
+      if (init?.signal) {
+        init.signal.addEventListener('abort', () => { req.destroy(); settle(reject, new Error('aborted by signal')); });
+      }
       if (body != null) req.write(body);
       req.end();
     });

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -9,7 +9,7 @@ import { brotliDecompressSync, gunzipSync } from 'node:zlib';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { createLocalApiServer } from './local-api-server.mjs';
+import { createLocalApiServer, __testing__ } from './local-api-server.mjs';
 
 // The sidecar default-denies when LOCAL_API_TOKEN is unset (security fix:
 // previously "unset" meant "auth disabled", which made any standalone run
@@ -2202,6 +2202,192 @@ test('releases the upstream fetch semaphore when a response stalls mid-body (#54
     });
     await new Promise((resolve, reject) => {
       healthy.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('releases the upstream fetch semaphore when a connection goes silent forever (#5441 follow-up)', async () => {
+  // Accepts the connection and never writes anything, never closes -- no
+  // FIN/RST, no data. None of res 'error'/'aborted'/'end' or req 'error'/
+  // 'close' ever fire for this shape; only the new idle timeout observes it.
+  const openSockets = new Set();
+  const silentServer = net.createServer((socket) => {
+    // Intentionally do nothing with the data -- leave the connection open
+    // and silent. Track it so cleanup can force-close it: net.Server.close()
+    // waits for every accepted socket to end on its own, and a socket we
+    // never write to or read from (by design, to simulate a true silent
+    // stall) never will.
+    openSockets.add(socket);
+    socket.once('close', () => openSockets.delete(socket));
+  });
+  const silentPort = await listen(silentServer);
+
+  __testing__.setUpstreamIdleTimeoutMs(200);
+
+  const localApi = await setupApiDir({
+    'silent-proxy.js': `
+      export default async function handler() {
+        try {
+          await fetch('http://127.0.0.1:${silentPort}/');
+          return new Response(JSON.stringify({ settled: 'resolved' }), { status: 200 });
+        } catch (error) {
+          return new Response(JSON.stringify({ settled: 'rejected', message: error.message }), { status: 200 });
+        }
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+    allowPrivateFetchOrigins: [`http://127.0.0.1:${silentPort}`],
+  });
+  const { port } = await app.start();
+
+  try {
+    const result = await Promise.race([
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/silent-proxy`).then((r) => r.json),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('silent stall never settled -- idle timeout did not fire')), 3000)
+      ),
+    ]);
+    assert.equal(result.settled, 'rejected');
+    assert.match(result.message, /idle-timed out/);
+
+    // Slot must be released: a request through the SAME fetch wrapper (any
+    // origin) must not be blocked by the leaked silent connection.
+    const stallRequests = Array.from({ length: 6 }, () =>
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/silent-proxy`).then((r) => r.json)
+    );
+    const followUp = await Promise.race([
+      Promise.all(stallRequests),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('semaphore still wedged after idle timeout')), 5000)),
+    ]);
+    for (const r of followUp) assert.equal(r.settled, 'rejected');
+  } finally {
+    __testing__.setUpstreamIdleTimeoutMs(12000);
+    await app.close();
+    await localApi.cleanup();
+    for (const socket of openSockets) socket.destroy();
+    await new Promise((resolve, reject) => {
+      silentServer.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('abort-signal path: mid-flight abort rejects promptly and releases the slot (#5441 follow-up)', async () => {
+  // Mirrors how fetchWithTimeout drives this exact branch in production: an
+  // AbortController whose signal is passed into fetch(), aborted mid-flight
+  // against an upstream that never responds.
+  const openSockets = new Set();
+  const neverResponds = net.createServer((socket) => {
+    // Accepts but never writes -- the abort must fire before any other
+    // listener would (idle timeout stays at its default 12s here). Tracked
+    // so cleanup can force-close it (see the silent-stall test above for why).
+    openSockets.add(socket);
+    socket.once('close', () => openSockets.delete(socket));
+  });
+  const neverRespondsPort = await listen(neverResponds);
+
+  const localApi = await setupApiDir({
+    'abort-proxy.js': `
+      export default async function handler() {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(), 30);
+        try {
+          await fetch('http://127.0.0.1:${neverRespondsPort}/', { signal: controller.signal });
+          return new Response(JSON.stringify({ settled: 'resolved' }), { status: 200 });
+        } catch (error) {
+          return new Response(JSON.stringify({ settled: 'rejected', message: error.message, name: error.name }), { status: 200 });
+        }
+      }
+    `,
+    'healthy-proxy.js': `
+      export default async function handler() {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+    allowPrivateFetchOrigins: [`http://127.0.0.1:${neverRespondsPort}`],
+  });
+  const { port } = await app.start();
+
+  try {
+    const result = await Promise.race([
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/abort-proxy`).then((r) => r.json),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('abort-signal path never settled -- semaphore leak reintroduced')), 2000)
+      ),
+    ]);
+    assert.equal(result.settled, 'rejected');
+    assert.match(result.message, /aborted by signal/);
+
+    // Slot released promptly (well under the 12s idle timeout): a healthy
+    // request right after must not be delayed by the aborted one.
+    const healthy = await Promise.race([
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/healthy-proxy`).then((r) => r.json),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('slot not released after abort')), 1000)),
+    ]);
+    assert.deepEqual(healthy, { ok: true });
+  } finally {
+    await app.close();
+    await localApi.cleanup();
+    for (const socket of openSockets) socket.destroy();
+    await new Promise((resolve, reject) => {
+      neverResponds.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('abort-signal path: an already-aborted signal rejects immediately without dispatching (#5441 follow-up)', async () => {
+  let connectionsReceived = 0;
+  const neverShouldConnect = net.createServer((_socket) => {
+    connectionsReceived += 1;
+  });
+  const neverShouldConnectPort = await listen(neverShouldConnect);
+
+  const localApi = await setupApiDir({
+    'preaborted-proxy.js': `
+      export default async function handler() {
+        const controller = new AbortController();
+        controller.abort();
+        try {
+          await fetch('http://127.0.0.1:${neverShouldConnectPort}/', { signal: controller.signal });
+          return new Response(JSON.stringify({ settled: 'resolved' }), { status: 200 });
+        } catch (error) {
+          return new Response(JSON.stringify({ settled: 'rejected', message: error.message }), { status: 200 });
+        }
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+    allowPrivateFetchOrigins: [`http://127.0.0.1:${neverShouldConnectPort}`],
+  });
+  const { port } = await app.start();
+
+  try {
+    const result = await Promise.race([
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/preaborted-proxy`).then((r) => r.json),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('pre-aborted fetch never settled')), 1000)),
+    ]);
+    assert.equal(result.settled, 'rejected');
+    assert.match(result.message, /aborted by signal/);
+    assert.equal(connectionsReceived, 0, 'an already-aborted signal must not dispatch to the network at all');
+  } finally {
+    await app.close();
+    await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      neverShouldConnect.close((error) => (error ? reject(error) : resolve()));
     });
   }
 });

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -4,6 +4,7 @@ import http, { createServer, request as httpRequest } from 'node:http';
 import https from 'node:https';
 import { createHmac } from 'node:crypto';
 import { EventEmitter } from 'node:events';
+import net from 'node:net';
 import { brotliDecompressSync, gunzipSync } from 'node:zlib';
 import os from 'node:os';
 import path from 'node:path';
@@ -2077,6 +2078,130 @@ test('service-status reports bound fallback port after EADDRINUSE recovery', asy
     await localApi.cleanup();
     await new Promise((resolve, reject) => {
       blocker.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('releases the upstream fetch semaphore when a response stalls mid-body (#5441)', async () => {
+  // Raw TCP, not http.createServer: sends valid headers with a Content-Length
+  // promising more body than it ever delivers, then destroys the socket
+  // shortly after — the "accepts connection, sends headers, stalls mid-body,
+  // connection eventually drops" failure mode from the issue. Node's http
+  // client surfaces this on `res` ('aborted'/'error'), not on `req` — which is
+  // exactly what the old globalThis.fetch wrapper never listened for, so the
+  // wrapped Promise never settled and the semaphore slot leaked permanently.
+  let stallConnections = 0;
+  const stallServer = net.createServer((socket) => {
+    socket.once('data', () => {
+      stallConnections += 1;
+      socket.write(
+        'HTTP/1.1 200 OK\r\n' +
+        'Content-Type: application/json\r\n' +
+        'Content-Length: 1000\r\n' +
+        '\r\n'
+      );
+      setTimeout(() => socket.destroy(), 20);
+    });
+  });
+  const stallPort = await listen(stallServer);
+
+  const healthy = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const healthyPort = await listen(healthy);
+
+  const localApi = await setupApiDir({
+    'stall-proxy.js': `
+      export default async function handler() {
+        try {
+          await fetch('http://127.0.0.1:${stallPort}/');
+          return new Response(JSON.stringify({ settled: 'resolved' }), { status: 200 });
+        } catch (error) {
+          return new Response(JSON.stringify({ settled: 'rejected', message: error.message }), { status: 200 });
+        }
+      }
+    `,
+    'healthy-proxy.js': `
+      export default async function handler() {
+        const upstream = await fetch('http://127.0.0.1:${healthyPort}/');
+        const payload = await upstream.text();
+        return new Response(payload, { status: upstream.status, headers: { 'content-type': 'application/json' } });
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+    allowPrivateFetchOrigins: [
+      `http://127.0.0.1:${stallPort}`,
+      `http://127.0.0.1:${healthyPort}`,
+    ],
+  });
+  const { port } = await app.start();
+
+  try {
+    // getJsonViaHttp, NOT authFetch/global fetch: globalThis.fetch is
+    // monkey-patched by local-api-server.mjs and shares its 6-slot semaphore
+    // with the handler-side fetches this test is exercising. A real external
+    // client (a separate process/browser) never shares that counter — using
+    // the patched fetch for these outer calls too would have each one
+    // consume a slot just reaching the local API server, before its handler
+    // ever got to make its own inner request, self-deadlocking the test
+    // rather than reproducing the issue.
+    //
+    // MAX_CONCURRENT_UPSTREAM is 6 — fire exactly that many concurrent
+    // requests through the stalling upstream to exhaust every slot. Do not
+    // await them yet: under the pre-fix code these never settle at all, so
+    // awaiting here would hang the test itself, not just prove the bug.
+    const stallRequests = Array.from({ length: 6 }, () =>
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/stall-proxy`)
+    );
+
+    // Wait until all 6 have actually reached the upstream (holding their
+    // semaphore slot) before touching the healthy endpoint, so the assertion
+    // below is exercising a genuinely exhausted semaphore, not a race.
+    const deadline = Date.now() + 2000;
+    while (stallConnections < 6 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(stallConnections, 6, 'all 6 stalling requests should have reached the upstream');
+
+    // The semaphore is now fully held by 6 in-flight stalling fetches. A 7th
+    // request to a completely healthy upstream must still complete quickly —
+    // proving the stalled slots were released rather than leaked forever.
+    const healthyResponse = await Promise.race([
+      getJsonViaHttp(`http://127.0.0.1:${port}/api/healthy-proxy`),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('healthy request did not complete — semaphore is wedged')), 3000)
+      ),
+    ]);
+    assert.equal(healthyResponse.status, 200);
+    assert.deepEqual(healthyResponse.json, { ok: true });
+
+    // The 6 stalling requests should also have settled (rejected) by now that
+    // their upstream connections were destroyed — confirm none of them hung.
+    const stallResults = await Promise.all(
+      stallRequests.map((p) =>
+        Promise.race([
+          p.then((r) => r.json),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('stall request never settled')), 1000)),
+        ])
+      )
+    );
+    for (const result of stallResults) {
+      assert.equal(result.settled, 'rejected');
+    }
+  } finally {
+    await app.close();
+    await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      stallServer.close((error) => (error ? reject(error) : resolve()));
+    });
+    await new Promise((resolve, reject) => {
+      healthy.close((error) => (error ? reject(error) : resolve()));
     });
   }
 });


### PR DESCRIPTION
Fixes #5441.

## Problem

The `globalThis.fetch` override in `src-tauri/sidecar/local-api-server.mjs` throttles every outbound request through a process-global 6-slot semaphore (`MAX_CONCURRENT_UPSTREAM = 6`), released in a `finally` after the wrapped `http(s).request` Promise settles. That Promise only ever settled on `res.on('end')` (success) or `req.on('error')` (connection-phase failure) — nothing was attached to the response stream itself.

Once an upstream accepts a connection and starts sending a response, Node surfaces further stream problems — a truncated/aborted body, the connection dropping mid-flight — on the **response** object (`res 'aborted'`, `res 'error'`) or via `req 'close'`, not via `req 'error'` (which is mostly for connection-establishment failures). So a stalled or truncated response never settled the wrapped Promise at all, the `finally` never ran, and the slot leaked permanently. In-memory RPCs never call `fetch`, so they kept responding normally while every data-fetching path eventually parked forever in `acquireUpstreamSlot()` once ~6 such stalls accumulated — matching the reported ~hourly wedge under normal OSINT feed traffic.

## Fix

Made the wrapped Promise settle idempotently and reject on `res 'aborted'`, `res 'error'`, `req 'close'`, and the existing abort-signal path — not just the two original events — so a stalled or truncated response always releases its slot now.

## Testing

Added a regression test that reproduces the exact failure mode with a raw TCP upstream (not `http.createServer`, deliberately — I needed precise control over the wire bytes): it sends valid HTTP/1.1 headers promising a `Content-Length` it never fulfills, then destroys the socket shortly after. This is exactly the "accepts connection, sends headers, stalls mid-body, connection eventually drops" scenario from the issue, and Node's http client surfaces it on `res`, not `req` — which is why the old code missed it.

I didn't just trust the reasoning — I verified both directions before finalizing:
- **Confirms the bug is real**: wrote a standalone script reproducing old-vs-new fetch behavior against the same stalling server; the old logic hangs forever (timed out at 500ms with nothing settled), the new logic rejects with `upstream response aborted mid-body`.
- **Confirms the test catches a regression**: temporarily reverted the fix in my local checkout and re-ran the new test — it hung and failed exactly as expected (`'Promise resolution is still pending...'`). Restored the fix and re-ran; it passes in ~25ms.
- **Full suite**: all 49 tests in `local-api-server.test.mjs` pass with the fix applied.
- `npx biome lint` on both changed files — no new issues (one pre-existing, unrelated warning elsewhere in the file).

One thing worth calling out from the test-writing process: my first attempt at this test used the file's existing `authFetch` helper (which wraps the global `fetch`) for the *outer* client-side calls to the local API server. Since `globalThis.fetch` is monkey-patched process-wide and shares the same semaphore with the handler-side fetches under test, that double-counted slot usage from a single client process and self-deadlocked the test. Switched to the file's `getJsonViaHttp` helper (raw `http.request`, bypassing the patched fetch) for the outer calls, matching how a real external client — a separate process — actually behaves.