### PR TITLE
fix(auth): honor current API access during renewal checks

### DIFF
--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -343,6 +343,7 @@ async function validateBootstrapUserApiAccessUncached(userId) {
   const cacheKey = `entitlements:${ENTITLEMENT_ENV_PREFIX}:${userId}`;
   const cached = await readCachedJson(cacheKey);
   if (cached.status === 'hit' && cached.value && typeof cached.value === 'object') {
+    if (hasCurrentApiAccess(cached.value)) return { ok: true };
     const cachedBillingFailure = billingVerificationFailure(cached.value);
     if (cachedBillingFailure) return cachedBillingFailure;
     if (notApplicableVerificationTtlSeconds(cached.value) !== null) {
@@ -350,7 +351,6 @@ async function validateBootstrapUserApiAccessUncached(userId) {
     }
     const validUntil = Number(cached.value.validUntil ?? 0);
     if (Number.isFinite(validUntil) && validUntil >= Date.now()) {
-      if (hasCurrentApiAccess(cached.value)) return { ok: true };
       return { ok: false, status: 403, error: 'API access subscription required', reason: 'cached-forbidden' };
     }
   }
@@ -379,12 +379,9 @@ async function validateBootstrapUserApiAccessUncached(userId) {
     await writeCachedJson(cacheKey, result.value, entitlementCacheTtlSeconds(result.value));
   }
 
+  if (hasCurrentApiAccess(result.value)) return { ok: true };
   const billingFailure = billingVerificationFailure(result.value);
   if (billingFailure) return billingFailure;
 
-  if (!hasCurrentApiAccess(result.value)) {
-    return { ok: false, status: 403, error: 'API access subscription required', reason: 'forbidden' };
-  }
-
-  return { ok: true };
+  return { ok: false, status: 403, error: 'API access subscription required', reason: 'forbidden' };
 }

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -303,6 +303,31 @@ test('current apiAccess entitlement can be served from Redis cache without Conve
   });
 });
 
+for (const billingStatus of [
+  'subscription_lapsed',
+  'renewal_verification_pending',
+  'renewal_verification_failed',
+]) {
+  test(`current cached apiAccess remains usable with ${billingStatus}`, async () => {
+    await withMockedConvex(async (calls) => {
+      const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+      assert.equal(result.ok, true);
+      assert.equal(calls.some((call) => call.url.endsWith('/api/internal-entitlements')), false);
+    }, {
+      redisCache: {
+        'entitlements:test:user_api_owner': {
+          planKey: 'api_starter',
+          validUntil: Date.now() + 86_400_000,
+          features: { apiAccess: true },
+          billingStatus,
+          retryAfterSeconds: 19,
+        },
+      },
+    });
+  });
+}
+
 async function withMockedEntitlement(entitlement, fn) {
   await withMockedConvex(async (calls) => {
     globalThis.fetch = async (input, init) => {
@@ -316,6 +341,26 @@ async function withMockedEntitlement(entitlement, fn) {
     };
 
     return fn(calls);
+  });
+}
+
+for (const billingStatus of [
+  'subscription_lapsed',
+  'renewal_verification_pending',
+  'renewal_verification_failed',
+]) {
+  test(`current fresh apiAccess remains usable with ${billingStatus}`, async () => {
+    await withMockedEntitlement({
+      planKey: 'api_starter',
+      validUntil: Date.now() + 86_400_000,
+      features: { apiAccess: true },
+      billingStatus,
+      retryAfterSeconds: 19,
+    }, async () => {
+      const result = await validateBootstrapUserApiAccess('user_api_owner');
+
+      assert.equal(result.ok, true);
+    });
   });
 }
 

--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -372,6 +372,22 @@ test('retryable billing verification on a wm_ user key keeps Retry-After and cod
   });
 });
 
+test('current API access keeps wm_ bootstrap usable while a stronger renewal is pending', async () => {
+  await withMockedBootstrapAuth({
+    entitlement: {
+      ...activeApiEntitlement(),
+      billingStatus: 'renewal_verification_pending',
+      retryAfterSeconds: 19,
+    },
+  }, async () => {
+    const resp = await handler(makeBootstrapRequest({ 'X-WorldMonitor-Key': USER_KEY }));
+
+    assert.equal(resp.status, 200);
+    assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);
+    assertNonSharedCacheHeaders(resp);
+  });
+});
+
 test('malformed wm_ user key is rejected before Redis or Convex validation', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
     const resp = await handler(makeBootstrapRequest({ 'X-WorldMonitor-Key': 'wm_notcanonical' }));


### PR DESCRIPTION
## Summary
- let current API access satisfy bootstrap auth before interpreting a stronger subscription's billing-verification marker
- apply the precedence consistently to cached and fresh entitlement reads
- cover every billing marker plus the wire-level wm_ bootstrap regression

Follow-up to #5447.

## Why
A user with a current API Starter entitlement and a stronger subscription under renewal verification could call the gateway successfully but receive 403/503 from bootstrap with the same key.

## Verification
- ./node_modules/.bin/tsx --test api/_user-api-key.test.mjs api/bootstrap-auth.test.mjs (75 passed)
- npm run typecheck:api
- Biome check for the three changed files
- full pre-push gate (frontend/API/Convex typechecks, edge bundle, 230 edge tests, policy checks)