### PR TITLE
docs(solutions): compound #4771 learnings — coverage semantics + i18n shell convention

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -89,3 +89,31 @@ The MCP transport this server implements over HTTP: JSON-RPC 2.0 requests via `P
 ### Variant Host
 
 One of the product-variant subdomains (`tech`, `finance`, `commodity`, `happy`, `energy`) that serves a themed dashboard entry and metadata. The middleware and Vercel config recognize these hosts explicitly; canonical discovery URLs for shared surfaces (such as `/mcp`) redirect retrieval-method requests from variant hosts to the apex host so discovery signals do not fragment.
+
+## Billing & Entitlements
+
+### Entitlement
+
+The per-user record granting feature access — a plan key, feature flags with a tier, and a validity horizon — derived from subscriptions by the server and replicated to clients as a reactive snapshot. An entitlement is evidence of paid access *now*; it says nothing about why access exists or when it will renew. When its validity horizon passes without a renewal being recorded, readers fall back to free-tier defaults, which is the moment stale local state can misrepresent a still-paying customer.
+
+### Covering Subscription
+
+A subscription that currently grants paid coverage. Coverage is decided per status, not by the status name's plain-English reading: an active subscription covers; an on-hold subscription (payment failed, provider retrying) still covers through its retry window; a cancelled subscription covers until the end of the period already paid for; an expired subscription never covers regardless of its recorded period end. The server owns these rules; any client-side derivation must mirror them rather than re-deriving from status-string intuition. See also: Cancelled-But-Paid-Through, Billing UX State.
+
+### Cancelled-But-Paid-Through
+
+The state of a subscription whose auto-renew has been turned off but whose paid period has not yet ended. Colloquially "cancelled" reads as terminal; here it is a covering state until period end, and only afterwards does coverage lapse. UI and copy must not treat it as ended while the paid window is open — telling such a customer their subscription "has ended" invites duplicate checkout. See also: Covering Subscription.
+
+### Renewal Verification
+
+The bounded, on-demand re-check against the payment provider that runs when locally-stale paid evidence would otherwise cause a denial — instead of trusting a possibly-missed webhook, the provider is asked directly. It records a verdict (pending while queued or in flight, failed when the provider check errored, lapsed when the provider confirms coverage ended) that both the denial surfaces and the client UI consume. It shares provider-evidence bookkeeping with the scheduled reconciliation sweep but is deliberately independent of it, so one path failing cannot suppress the other. See also: Billing UX State.
+
+### Billing UX State
+
+The single client-derived state that decides what a customer sees when premium access is in question: free (never paid), active (access works), on-hold (payment failed, retry window), renewal-verification pending or failed (paid evidence went stale and the provider re-check is running or errored), or lapsed (coverage confirmed over). Its purpose is to prevent the misleading collapse of every non-paying state into a generic upgrade prompt — a paying customer whose renewal is being verified must be told that, not sold to. Derived purely from the entitlement and subscription snapshots, it changes copy and actions only; it never grants access the server would deny. See also: Covering Subscription, Renewal Verification.
+
+## Localization & First Paint
+
+### English Shell
+
+The small, byte-budgeted subset of English UI strings inlined so first-paint chrome renders real text before the full locale file loads. Membership is decided by namespace: keys under the shell prefixes and referenced from eager chrome must be mirrored into the shell byte-identically, and the whole shell lives under a hard byte cap that is a first-paint performance budget, not a formatting limit. The consequence cuts both ways: post-boot copy placed in a shell namespace pays first-paint bytes for strings nobody can see yet, while first-paint copy placed outside the shell flashes raw keys until the full locale arrives. Choosing a key's namespace is therefore a rendering-time decision, not a taxonomy one.

--- a/docs/solutions/conventions/i18n-shell-namespaces-are-byte-budgeted-first-paint-surface.md
+++ b/docs/solutions/conventions/i18n-shell-namespaces-are-byte-budgeted-first-paint-surface.md
@@ -1,0 +1,53 @@
+---
+title: "i18n shell namespaces are a byte-budgeted first-paint surface — post-boot copy must live outside them"
+date: 2026-07-23
+category: conventions
+module: i18n
+problem_type: convention
+component: frontend
+applies_when:
+  - "Adding new t() keys referenced from eager chrome files (src/App.ts, src/app/panel-layout.ts, src/settings-main.ts, src/settings-window.ts, or anything under src/components/)"
+  - "Choosing a namespace for UI copy that renders only after boot-time data resolves (auth, Convex snapshots, entitlements)"
+tags: [i18n, en-shell, first-paint, byte-budget, locale-gates, premium-namespace, billing-state]
+---
+
+# i18n shell namespaces are a byte-budgeted first-paint surface — post-boot copy must live outside them
+
+## Context
+
+While adding billing-state CTA copy for panel gating (PR #5494, issue #4771), the natural home for the new keys looked like the existing `premium.*` namespace — the panel CTA already used `premium.signInToUnlock`, `premium.upgradeToPro`, etc. But `tests/i18n-english-shell.test.mjs` failed: it statically scans the eager chrome files (`src/App.ts`, `src/app/panel-layout.ts`, `src/settings-main.ts`, `src/settings-window.ts`, and everything under `src/components/`) for `t('...')` calls whose keys fall under `SHELL_KEY_PREFIXES` (a list that includes `premium.`, `shell.`, `header.`, `panels.`, `common.`, and others — see the constant near the top of the test), and requires every such key to exist **byte-identical** in `src/locales/en.shell.json`. And `en.shell.json` is capped by `SHELL_BUDGET_BYTES` (50 KB) — at the time of PR #5494 it sat 69 bytes under the cap, so adding even one new mirrored key meant either raising a first-paint performance budget or finding another home.
+
+## Guidance
+
+The shell (`en.shell.json`) exists so first-paint chrome renders English text before the full locale loads. Its namespaces are therefore a *scarce, perf-budgeted surface*, not a semantic taxonomy:
+
+- **Copy that can only render after boot-time data resolves does not belong in a shell namespace.** Billing-state CTAs render after Clerk auth plus a Convex entitlement round-trip — by then the full locale file has long since loaded. PR #5494 put them under `components.billingState.*` (mirroring the existing non-shell `components.checkoutFailureBanner.*` precedent) instead of `premium.*`.
+- **Check `SHELL_KEY_PREFIXES` in `tests/i18n-english-shell.test.mjs` before choosing a namespace** for any key referenced from an eager chrome file. A prefix hit means: mirrored entry in `en.shell.json` + budget pressure. `components.` is only shell-gated for the specific sub-prefixes listed there (`components.map.`, `components.panel.`, `components.proBanner.`, `components.settings.`, `components.deckgl.views.`); other `components.*` children are free.
+- **Do not silently bump `SHELL_BUDGET_BYTES`.** The cap is a first-paint payload budget; raising it is a performance decision, not a namespace convenience.
+- Remember the other two locale gates still apply wherever the key lives: the static key-existence scan (every literal `t('...')` key must exist in `en.json`) and locale completeness (every `en.json` key must exist in all ~25 locale files, `en.shell.json` exempt). Dynamic keys (`t(variable)`) bypass the static scan — when using them, add an explicit test asserting each possible key resolves in `en.json`, as `tests/billing-state-wiring.test.mts` does for the banner variant keys.
+
+## Why This Matters
+
+Choosing a shell namespace for post-boot copy either reds CI (budget exceeded) or, worse, quietly grows the first-paint payload every visitor downloads — paying real bytes for strings no one can see until seconds after boot. Choosing a non-shell namespace for genuinely first-paint copy is the opposite failure: raw i18n keys flash on screen before the full locale loads. The namespace decision is a rendering-time decision.
+
+## When to Apply
+
+Any new `t()` key referenced from an eager chrome file, and any copy addition to an existing shell namespace (`premium.`, `shell.`, `header.`, `panels.`, `common.`, and the rest of `SHELL_KEY_PREFIXES`). Ask one question: can this string render before the full locale file loads? If no, keep it out of shell namespaces.
+
+## Examples
+
+PR #5494's billing CTA keys, referenced from `src/components/Panel.ts` (an eager chrome file):
+
+```ts
+// Rejected: trips the shell mirror + 50KB budget (premium. is in SHELL_KEY_PREFIXES)
+t('premium.billingRenewalPendingDesc')
+
+// Shipped: components.billingState. is not shell-gated; these CTAs render
+// post-entitlement-resolution, well after full-locale load
+t('components.billingState.renewalPendingDesc')
+```
+
+## Related Issues
+
+- PR #5494 (issue #4771) — where the constraint was hit and the `components.billingState.*` home was chosen.
+- The three-gate interaction (static key existence, locale completeness, shell mirror + budget) makes a genuinely-new shell key a ~27-file change; a genuinely-new non-shell key is ~26 files (all full locales, no shell mirror).

--- a/docs/solutions/logic-errors/billing-state-cancelled-but-paid-through-misclassified-as-lapsed.md
+++ b/docs/solutions/logic-errors/billing-state-cancelled-but-paid-through-misclassified-as-lapsed.md
@@ -1,0 +1,118 @@
+---
+title: "deriveBillingUxState fallthrough misclassified cancelled-but-paid-through subscriptions as lapsed"
+date: 2026-07-23
+category: logic-errors
+module: billing-state
+problem_type: logic_error
+component: payments
+severity: high
+symptoms:
+  - "deriveBillingUxState (src/services/billing-state.ts) returned 'lapsed' for status 'cancelled' subscriptions unconditionally, without checking whether currentPeriodEnd was still in the future"
+  - "A cancelled-but-paid-through customer whose entitlement snapshot resolves after the subscription watch would transiently see 'Your Pro subscription has ended - Resubscribe'"
+  - "Diverged from the server's own coverage semantics in isCoveringAt (convex/payments/subscriptionHelpers.ts), which treats cancelled-with-future-currentPeriodEnd as covering, not lapsed"
+  - "Four of the ten review personas independently flagged the same fallthrough line pre-merge"
+root_cause: logic_error
+resolution_type: code_fix
+related_components: [testing_framework]
+tags: [billing, entitlements, subscription-state, coverage-semantics, cancelled-but-paid-through, client-side-derivation, convex-watch-race]
+---
+
+# deriveBillingUxState fallthrough misclassified cancelled-but-paid-through subscriptions as lapsed
+
+## Problem
+
+`deriveBillingUxState(sub, ent, now)` (`src/services/billing-state.ts`) is a new pure client-side function (issue #4771, shipped in PR #5494) that maps the two independent reactive Convex snapshots — the subscription row and the entitlement row — into one of six billing UX states (`free` / `active` / `on_hold` / `renewal_verification_pending` / `renewal_verification_failed` / `lapsed`) driving both the panel-gating CTA and a top-of-page banner.
+
+The function's job is to reproduce, on the client, the same coverage semantics the server already enforces in `isCoveringAt` (`convex/payments/subscriptionHelpers.ts:236-245`):
+
+```ts
+function isCoveringAt<T extends Pick<SubscriptionRow, "status" | "currentPeriodEnd">>(
+  s: T,
+  at: number,
+): boolean {
+  return (
+    s.status === "active" ||
+    s.status === "on_hold" ||
+    (s.status === "cancelled" && s.currentPeriodEnd > at)
+  );
+}
+```
+
+`isCoveringAt` treats three statuses very differently: `active` and `on_hold` always cover; `cancelled` covers conditionally — only while `currentPeriodEnd` is still in the future ("cancelled-but-paid-through," e.g. a customer who cancelled auto-renew but is still inside the period they already paid for); `expired` never covers. `cancelled` and `expired` are not semantically interchangeable — one is a conditional, time-boxed state and the other is unconditionally terminal.
+
+The initial client-side implementation collapsed that distinction. Its fallthrough after the `active`-status branch was:
+
+```ts
+return 'lapsed';
+```
+
+with no separate check for `sub.status === 'cancelled'` and `currentPeriodEnd`. Any subscription that reached this point — `cancelled` regardless of period end, or `expired` — was unconditionally mapped to `lapsed`, the state that renders "Your Pro subscription has ended — Resubscribe."
+
+Because the subscription watch and the entitlement watch are two independent Convex subscriptions, either can resolve first on the client. A customer who cancelled but is still inside their paid-through window, whose entitlement snapshot happens to arrive late (or is still `null` while both watches settle), would transiently hit this fallthrough: `sub.status === 'cancelled'`, `entitledNow` false (entitlement snapshot not yet loaded/refreshed), no `active`-status branch taken (status isn't `'active'`) → falls through to `'lapsed'`. The customer sees a false terminal "subscription has ended" message and a resubscribe CTA while still paying and still covered — exactly the duplicate-checkout/support-ticket failure mode issue #4771 was opened to eliminate.
+
+## Symptoms
+
+- `deriveBillingUxState` returned `'lapsed'` for `status: 'cancelled'` subscriptions unconditionally, without checking whether `currentPeriodEnd` was still in the future.
+- A customer who cancelled but is still within their paid-through period, whose entitlement snapshot resolves after the subscription watch (or is still `null`), would transiently see "Your Pro subscription has ended — Resubscribe."
+- The derivation diverged from the server's own coverage semantics in `isCoveringAt` (`convex/payments/subscriptionHelpers.ts:236-245`), which treats `cancelled`-with-`currentPeriodEnd`-in-the-future as covering, not lapsed.
+- The function's own docstring rule 5 (pre-fix) read "`cancelled`/`expired` past their paid window: provider-confirmed end of coverage — `lapsed`" — asserting a "past their paid window" precondition for `cancelled` that the code itself never checked, i.e. the comment and the implementation directly contradicted each other.
+- Four of the ten review personas independently flagged the same fallthrough line pre-merge (per this session's review run: the correctness, maintainability, api-contract, and adversarial lenses; the PR body records only the count), with one citing both the `isCoveringAt` precedent and the docstring/code contradiction.
+
+## What Didn't Work
+
+The bug was not caught by writing the code, by a subsequent cleanup pass, or by a full green local test run — it took a dedicated adversarial multi-persona review to surface it, all within the same PR before merge.
+
+Sequence of events inside PR #5494 (pre-squash branch history, described rather than SHA-cited — the squash rewrote these commits, so their SHAs are not reachable from `main`):
+
+1. The initial implementation commit ("feat(billing): pure billing UX state derivation for #4771") shipped the bare `return 'lapsed';` fallthrough together with 25 `it()` cases in `tests/billing-state.test.mts`. All 25 passed.
+2. A later simplify/cleanup commit ("refactor(billing): localize banner via shared i18n keys; per-pass gating derivation; skip no-op CTA rebuilds") touched both `src/services/billing-state.ts` and `tests/billing-state.test.mts` — and the fallthrough bug passed through completely unchanged: the `return 'lapsed';` line was untouched and no new cancelled-status test was added (test count remained 25).
+3. Local test battery: the PR body records a full green run — `test:data` (16k tests), vitest (832), typecheck, i18n gates, lint boundaries, biome, etc. (Aside: the PR body describes the post-fix derivation suite as "34 pure derivation/variant/override cases"; the merged file actually contains 30 `it()` blocks — 22 derivation + 5 banner + 3 gate-override. The PR's own count was inflated; 30 is what the tree substantiates.) None of this caught the bug either, for a structural reason, not bad luck.
+4. Only the adversarial review pass (10 personas + an independent cross-model Codex pass, per-finding validated) converged on the fallthrough line — 4 reviewers independently, per the PR body — leading to the review-fix commit ("fix(review): cancelled-in-period coverage, billing-denial on-call log, behavioral + wiring test locks") in the same PR.
+
+Why the pre-fix test suite was green despite the bug: through both pre-fix commits, the suite had exactly two `cancelled`-status cases:
+
+- `sub({ status: 'cancelled' })` paired with a **valid** entitlement (`ent()`) — asserts `'active'`. This passes, but not because the fallthrough is correct: `entitledNow` is `true`, so the function returns `'active'` on the earlier `if (entitledNow) return 'active';` branch (`billing-state.ts:69`) — it never reaches the `cancelled` branch at all.
+- `sub({ status: 'cancelled', currentPeriodEnd: NOW - DAY })` (past-period) paired with an **expired** entitlement — asserts `'lapsed'`. This is the one case that does exercise the fallthrough, and it happens to be correct, because the subscription is genuinely past its period.
+
+No case in the original matrix paired `cancelled` **in-period** with a null or expired (not-yet-loaded / stale) entitlement snapshot — the exact combination the fallthrough mishandled. Every `cancelled`-status test either short-circuited before reaching the buggy line via the `entitledNow` guard, or landed in the one case where the buggy fallthrough happened to produce the right answer by coincidence. The happy-path/fully-loaded matrix was complete; the snapshot-not-yet-loaded matrix was not.
+
+## Solution
+
+Added an explicit in-period guard mirroring `isCoveringAt`'s `cancelled` branch, inserted immediately before the `lapsed` fallthrough (`src/services/billing-state.ts:76-77`):
+
+```ts
+if (sub.status === 'cancelled' && sub.currentPeriodEnd >= now) return 'active';
+return 'lapsed';
+```
+
+(Note: `billing-state.ts` uses `>=` where the server's `isCoveringAt` uses strict `>` at `convex/payments/subscriptionHelpers.ts:243` — the client boundary is inclusive of the instant `currentPeriodEnd === now`, consistent with the rest of this function's other period-end checks, e.g. `billing-state.ts:73`'s `sub.currentPeriodEnd >= now` for the `active`-status branch. This is a deliberate, symmetric choice, not a mismatch to reconcile.)
+
+The precedence docstring (`billing-state.ts:41-60`) was corrected at the same time — rule 5 now reads:
+
+> `cancelled` still inside its paid window keeps coverage (`active`) even when the entitlement snapshot is late — mirrors `isCoveringAt` in `convex/payments/subscriptionHelpers.ts` ("cancelled-but-paid-through"). `cancelled` past the window and `expired` (never covering, same helper): provider-confirmed end of coverage — `lapsed`, not `free`, so copy can say "resubscribe".
+
+This explicitly names `isCoveringAt` as the source of truth and separates `cancelled`'s conditional coverage from `expired`'s unconditional non-coverage — closing the docstring/code contradiction that api-contract review flagged.
+
+Four new matrix cases were added to `tests/billing-state.test.mts` targeting exactly the previously-untested snapshot-not-yet-loaded combinations:
+
+- `tests/billing-state.test.mts:139-141` — cancelled in-period + **null** entitlement → `active` ("cancelled-but-paid-through, never over-gate").
+- `tests/billing-state.test.mts:143-148` — cancelled in-period + **expired** entitlement snapshot → `active` ("coverage runs to period end").
+- `tests/billing-state.test.mts:150-155` — `expired` status with a **future** `currentPeriodEnd` + null entitlement → `lapsed` ("expired subscription never covers, even with a future period end (mirrors isCoveringAt)") — locking in that `expired` is unconditionally terminal, unlike `cancelled`.
+- `tests/billing-state.test.mts:157-160` — an unrecognized/bogus status string → `lapsed` ("unknown runtime status strings stay locked-side (lapsed), never unlock") — locking the fail-closed default for any future status value the client doesn't recognize.
+
+## Why This Works
+
+The fix works because it stops re-deriving per-status coverage semantics from the status string's English connotation and instead copies the server's canonical rule verbatim. `isCoveringAt` (`convex/payments/subscriptionHelpers.ts:236-245`) is the single place the server decides what "covering" means per status; the client's job is to mirror it, not reinterpret it. `cancelled` *sounds* terminal — colloquially "I cancelled my subscription" reads as "it's over" — but the product semantics are "auto-renew is off, coverage continues until the period you already paid for ends." `expired`, by contrast, really is unconditional: `isCoveringAt` never returns `true` for it regardless of `currentPeriodEnd`. Collapsing both into one fallthrough branch was a plausible-looking simplification that was quietly wrong for one of the two statuses it covered.
+
+The new tests work because they target the actual failure mode rather than re-testing the already-correct happy path. The original suite was complete for the case where both snapshots are fully loaded and agree; it had a blind spot for the case where one snapshot (the entitlement row) is missing or stale relative to the other (the subscription row) — which is precisely the situation this whole `deriveBillingUxState` function exists to handle gracefully (per its own top-of-file docstring, `billing-state.ts:1-17`: reconciling two independently-arriving reactive snapshots). A pure function whose entire purpose is reconciling out-of-sync inputs needs its test matrix built around the *out-of-sync* input combinations, not just the settled ones.
+
+## Prevention
+
+- **When a client-side function derives UX/display state from replicated data that a server also governs, treat the server's canonical helper as the spec, not inspiration.** If a helper like `isCoveringAt` already encodes per-status coverage rules, the client derivation should cite it in a docstring (as `billing-state.ts:41-60` now does) and structurally mirror its branches one-for-one — never re-derive coverage from a status string's plain-English connotation. "Cancelled" and "expired" are easy to mentally merge into "not active, so not covered"; only reading the authoritative helper's actual branches (not just its name) reveals that one is conditional and one isn't.
+- **For any pure function that reconciles two independently-updating inputs (e.g. two separate Convex/GraphQL/subscription watches), the test matrix must explicitly include the "one input hasn't arrived yet / is stale" combinations for every status branch that can be reached before the fresher input lands** — not just the fully-loaded, mutually-consistent matrix. A matrix that only pairs each status with a "settled" partner value will look complete (every state is asserted "somewhere") while leaving the actual race-prone combinations — the reason the function exists — completely untested. Concretely: for every conditional-coverage status, add a case pairing it with a `null`/expired/not-yet-loaded partner snapshot, in addition to the case pairing it with a valid one.
+- **A green test suite through implementation and a refactor/simplify pass is not evidence of correctness for logic a human intuitively "knows" the answer to** — this bug survived both because every test that could exercise the buggy line either short-circuited around it via an earlier `if` branch or coincidentally landed on the one input combination where the wrong logic produced the right output. Adversarial/multi-persona review (or, cheaper going forward, deliberately writing the "what if the other snapshot hasn't loaded yet" test cases *first*, before the happy-path ones) is what actually catches this class of bug — a single-author implementation-then-test pass tends to test the mental model it just used to write the code, reproducing the same blind spot on both sides.
+
+## Related Issues
+
+- Issue lineage (server-to-client hardening arc): #4765 (reconcile missed Dodo renewal webhooks) -> #4770 (on-demand Dodo re-check before hard denial; merged via PR #5447, transient-vs-confirmed refined in PR #5483) -> #4771 (surface explicit billing states in the UI; closed by PR #5494 - the PR whose pre-merge bug this doc records).
+- Methodological neighbor: [test-guard-assertions-and-module-state-reset](../best-practices/test-guard-assertions-and-module-state-reset.md) - same class of testing lesson (a test that claims to cover a branch must actually reach that branch via genuinely distinct precondition combinations), stated there for JWT/session guards.


### PR DESCRIPTION
Knowledge-store capture from PR #5494 (issue #4771), per the compound-engineering workflow:

- **docs/solutions/logic-errors/billing-state-cancelled-but-paid-through-misclassified-as-lapsed.md** — the pre-merge derivation bug (cancelled-but-paid-through treated as unconditionally lapsed, contradicting `isCoveringAt`), why a 25-case green suite missed it (the snapshot-not-yet-loaded matrix was untested), and the prevention rules. First payments-domain doc in the corpus.
- **docs/solutions/conventions/i18n-shell-namespaces-are-byte-budgeted-first-paint-surface.md** — the shell-namespace/byte-budget constraint that routed billing CTA copy to `components.billingState.*` instead of `premium.*`.
- **CONCEPTS.md** — seeded a Billing & Entitlements cluster (Entitlement, Covering Subscription, Cancelled-But-Paid-Through, Renewal Verification, Billing UX State) and an English Shell entry.

All factual claims grounding-validated against current source and live GitHub state (28 claims checked; 2 corrected during validation, including the PR #5494 body's own inflated test count).

Docs-only change — no runtime impact; no additional operational monitoring required.

https://claude.ai/code/session_01VUcnpsWficDVsPmEZEUJP7