### PR TITLE
Refactor AuthHeaderWidget to improve cleanup logic

### DIFF
--- a/src/components/AuthHeaderWidget.ts
+++ b/src/components/AuthHeaderWidget.ts
@@ -3,13 +3,13 @@ import { mountUserButton, openSignIn, openSignUp } from '@/services/clerk';
 import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
-
 export class AuthHeaderWidget {
   private container: HTMLElement;
   private unsubscribeAuth: (() => void) | null = null;
   private unmountUserButton: (() => void) | null = null;
   private onSignInClick?: () => void;
   private onSettingsClick?: () => void;
+  private isDestroyed = false;
 
   constructor(onSignInClick?: () => void, onSettingsClick?: () => void) {
     this.onSignInClick = onSignInClick;
@@ -18,6 +18,8 @@ export class AuthHeaderWidget {
     this.container.className = 'auth-header-widget';
 
     this.unsubscribeAuth = subscribeAuthState((state: AuthSession) => {
+      if (this.isDestroyed) return;
+
       if (state.isPending) {
         this.renderPending();
         return;
@@ -31,20 +33,27 @@ export class AuthHeaderWidget {
   }
 
   public destroy(): void {
-    this.unmountUserButton?.();
-    this.unmountUserButton = null;
+    this.isDestroyed = true;
+    this.cleanupUI();
+
     if (this.unsubscribeAuth) {
       this.unsubscribeAuth();
       this.unsubscribeAuth = null;
     }
   }
 
+  private cleanupUI(): void {
+    if (this.unmountUserButton) {
+      this.unmountUserButton();
+      this.unmountUserButton = null;
+    }
+    this.container.replaceChildren(); // Safely clears all child nodes
+  }
+
   private render(state: AuthSession): void {
-    this.unmountUserButton?.();
-    this.unmountUserButton = null;
+    this.cleanupUI();
     this.container.classList.remove('auth-header-widget-pending');
     this.container.removeAttribute('aria-busy');
-    setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
 
     if (!state.user) {
       this.renderSignedOut();
@@ -54,44 +63,48 @@ export class AuthHeaderWidget {
   }
 
   private renderPending(): void {
-    this.unmountUserButton?.();
-    this.unmountUserButton = null;
+    this.cleanupUI();
     this.container.classList.add('auth-header-widget-pending');
     this.container.setAttribute('aria-busy', 'true');
-    setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
 
     const signInSkeleton = document.createElement('span');
     signInSkeleton.className = 'auth-header-skeleton auth-header-skeleton-signin';
     signInSkeleton.setAttribute('aria-hidden', 'true');
-    this.container.appendChild(signInSkeleton);
 
     const signUpSkeleton = document.createElement('span');
     signUpSkeleton.className = 'auth-header-skeleton auth-header-skeleton-signup';
     signUpSkeleton.setAttribute('aria-hidden', 'true');
-    this.container.appendChild(signUpSkeleton);
+
+    this.container.append(signInSkeleton, signUpSkeleton);
   }
 
   private renderSignedOut(): void {
     const signInBtn = document.createElement('button');
+    signInBtn.type = 'button';
     signInBtn.className = 'auth-signin-btn';
     signInBtn.textContent = t('auth.signIn');
     signInBtn.addEventListener('click', () => {
-      if (this.onSignInClick) this.onSignInClick();
-      else openSignIn();
+      if (this.onSignInClick) {
+        this.onSignInClick();
+      } else {
+        openSignIn();
+      }
     });
-    this.container.appendChild(signInBtn);
 
     const signUpLink = document.createElement('button');
+    signUpLink.type = 'button';
     signUpLink.className = 'auth-signup-link';
     signUpLink.textContent = t('auth.createAccount');
     signUpLink.addEventListener('click', () => openSignUp());
-    this.container.appendChild(signUpLink);
+
+    this.container.append(signInBtn, signUpLink);
   }
 
   private renderSignedIn(): void {
     const userBtnEl = document.createElement('div');
     userBtnEl.className = 'auth-clerk-user-button';
     this.container.appendChild(userBtnEl);
+
     this.unmountUserButton = mountUserButton(userBtnEl);
 
     if (this.onSettingsClick) {
@@ -101,6 +114,7 @@ export class AuthHeaderWidget {
       settingsBtn.setAttribute('aria-label', t('auth.settings'));
       settingsBtn.title = t('auth.settings');
       setTrustedHtml(settingsBtn, trustedHtml(SETTINGS_ICON, "legacy direct innerHTML migration"));
+      
       settingsBtn.addEventListener('click', () => this.onSettingsClick?.());
       this.container.appendChild(settingsBtn);
     }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

<!-- Required for documentation-alignment PRs that touch methodology, API/MCP contracts, generated docs, examples, Redis keys, CII, CRI, news, digest, or briefing. Mark N/A only when this PR does not publish or change documentation claims. -->

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
