### PR TITLE
fix(security): bump tauri >=2.11.1 — GHSA-7gmj-67g7-phm9 origin confusion (CVE-2026-42184, CVSS 8.8)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = ">=2.11.1, <3", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "crypto-rust"] }


### PR DESCRIPTION
## Summary

worldmonitor bundles **tauri 2.10.3**, which is vulnerable to [GHSA-7gmj-67g7-phm9](https://github.com/advisories/GHSA-7gmj-67g7-phm9) / CVE-2026-42184 (CVSS **8.8 High**). This PR raises the minimum to **2.11.1**, the first patched release.

## Vulnerability details

`tauri::is_local_url()` in all 2.x versions before 2.11.1 checks only the **first subdomain label** of the hostname — not the full string — before deciding whether a URL should be treated as a local (trusted) origin. An attacker-controlled web page loaded in any webview on **Windows or Android** can craft a hostname like `tauri.evil.com` to pass this check, allowing it to invoke Tauri IPC commands as if it were the local frontend (`http://tauri.localhost/`).

**Exploitability in worldmonitor:** worldmonitor's `src-tauri/src/main.rs` guards every IPC command with `require_trusted_window(webview.label())`, which checks the Tauri _window label_ rather than the URL — providing a partial mitigation. The capabilities file (`capabilities/default.json`) does not use `"local": true`, limiting what a URL-bypass alone can grant. The risk is real but partially mitigated by the label-based gating. Bumping Tauri remains the correct fix.

## Change

```diff
-tauri = { version = "2", features = [] }
+tauri = { version = ">=2.11.1, <3", features = [] }
```

## To complete the fix

After merging, regenerate `Cargo.lock` to pull in the patched version:

```bash
cargo update -p tauri --precise 2.11.1
```

or to pull the latest 2.x patch:

```bash
cargo update -p tauri
```

then commit the updated `Cargo.lock`.

## References

- GHSA: https://github.com/advisories/GHSA-7gmj-67g7-phm9
- CVE-2026-42184
- Tauri 2.11.1 release: https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.11.1