### PR TITLE
fix(forecast): extend EIA settlement grace

### DIFF
--- a/scripts/_bet-templates-energy.mjs
+++ b/scripts/_bet-templates-energy.mjs
@@ -11,8 +11,8 @@
 
 export const EIA_PETROLEUM_FEED = 'energy:eia-petroleum:v1';
 const DAY_MS = 24 * 60 * 60 * 1000;
-// EIA Weekly Petroleum Status Report publishes every Wednesday; a 7-day horizon
-// lands the deadline on the next release for the weekly series.
+// Keep a weekly question horizon. Resolution has a separate, feed-aware grace
+// because the report's observation date can trail its publication date.
 const EIA_HORIZON_MS = 7 * DAY_MS;
 // Floor the threshold move so a flat week (current==previous) still yields a
 // non-trivial bet instead of "value >= current" (~coin-flip, uninformative).

--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -9,9 +9,20 @@ import { readFileSync } from 'node:fs';
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const ACLED_SETTLEMENT_LAG_MS = 2 * DAY_MS;
 export const UCDP_SETTLEMENT_LAG_MS = 14 * DAY_MS;
-// Grace window for a `value` feed to publish the deadline period's reading
-// before we give up and VOID (EIA weekly releases can slip on holidays).
+// Default grace for a scalar feed to publish a deadline-period reading before
+// we give up and VOID. Live feeds (for example commodities) should not retain a
+// missing/stale observation indefinitely.
 export const VALUE_SETTLEMENT_MAX_LAG_MS = 10 * DAY_MS;
+// EIA's weekly petroleum observation date trails publication by roughly one
+// week. A deadline just after the covered period may therefore need the next
+// report (plus holiday slack) before `asOf` reaches the deadline.
+export const EIA_VALUE_SETTLEMENT_MAX_LAG_MS = 14 * DAY_MS;
+
+function valueSettlementMaxLagMs(feedKey) {
+  return feedKey === 'energy:eia-petroleum:v1'
+    ? EIA_VALUE_SETTLEMENT_MAX_LAG_MS
+    : VALUE_SETTLEMENT_MAX_LAG_MS;
+}
 
 const SUPPORTED_FUNCTIONS = new Set(['count', 'riskScore', 'present', 'yesPrice', 'hexCount', 'price', 'value']);
 const COUNTRY_ALIASES = loadCountryAliases();
@@ -179,6 +190,7 @@ export function resolveHardSpec(entry, feedData, samples, nowMs) {
 // no usable timestamp, so we can't gate — fall through to normal resolution),
 // a pending result while within the grace window, or VOID once grace elapses.
 function valueSettlementResult(parsed, feedData, deadline, nowMs, entry, spec) {
+  const maxLagMs = valueSettlementMaxLagMs(parsed.feedKey || spec?.sourceFeed);
   const record = findMatchingRecord(feedData, parsed.field, parsed.value);
   if (!record) {
     // Whole-feed-down is handled by the window path (source_feed_unavailable);
@@ -186,7 +198,7 @@ function valueSettlementResult(parsed, feedData, deadline, nowMs, entry, spec) {
     // refresh that dropped this symbol. Pend through the grace so a transient
     // gap doesn't immediately VOID; VOID only if it never returns (#5243 P2).
     if (feedData == null) return null;
-    if (nowMs < deadline + VALUE_SETTLEMENT_MAX_LAG_MS) {
+    if (nowMs < deadline + maxLagMs) {
       return { status: 'pending', evidence: { reason: 'value_source_record_missing', deadline } };
     }
     return voidResult('value_source_never_settled', entry, spec, parsed, nowMs);
@@ -195,7 +207,7 @@ function valueSettlementResult(parsed, feedData, deadline, nowMs, entry, spec) {
   if (!Number.isFinite(asOf)) return null; // record present but no timestamp → cannot gate
   const deadlineDay = Math.floor(deadline / DAY_MS) * DAY_MS;
   if (asOf >= deadlineDay) return null; // feed has caught up to the deadline period
-  if (nowMs < deadline + VALUE_SETTLEMENT_MAX_LAG_MS) {
+  if (nowMs < deadline + maxLagMs) {
     return { status: 'pending', evidence: { reason: 'value_source_not_settled', deadline, asOf } };
   }
   return voidResult('value_source_never_settled', entry, spec, parsed, nowMs);

--- a/tests/forecast-bets-seeder.test.mjs
+++ b/tests/forecast-bets-seeder.test.mjs
@@ -162,6 +162,17 @@ describe('value settlement gate (#2 — no false NO on a stale pre-release read)
     assert.equal(ledger[key].outcome, 'YES');
   });
 
+  it('uses the EIA-specific grace when a partial refresh drops the metric', () => {
+    const entry = inventoryEntry();
+    const partialFeed = shapeResolutionFeed(EIA_PETROLEUM_FEED, eiaFixture({ inventory: null }));
+    const pending = resolveHardSpec(entry, partialFeed, [], DEADLINE + 10 * DAY_MS);
+    assert.equal(pending.status, 'pending');
+    assert.equal(pending.evidence.reason, 'value_source_record_missing');
+
+    const voided = resolveHardSpec(entry, partialFeed, [], DEADLINE + 14 * DAY_MS);
+    assert.equal(voided.outcome, 'VOID');
+  });
+
   it('VOIDs once the EIA-specific settlement grace elapses and the feed never caught up', () => {
     const entry = inventoryEntry();
     const staleFeed = shapeResolutionFeed(EIA_PETROLEUM_FEED, eiaFixture({

--- a/tests/forecast-bets-seeder.test.mjs
+++ b/tests/forecast-bets-seeder.test.mjs
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { buildBetsSnapshot, computeNextSeries } from '../scripts/seed-forecast-bets.mjs';
-import { ingestHistory, shapeResolutionFeed } from '../scripts/seed-forecast-resolutions.mjs';
+import { ingestHistory, resolveDueEntries, shapeResolutionFeed } from '../scripts/seed-forecast-resolutions.mjs';
 import { EIA_PETROLEUM_FEED } from '../scripts/_bet-templates-energy.mjs';
 import { resolveHardSpec } from '../scripts/_forecast-resolution-eval.mjs';
 
@@ -144,12 +144,30 @@ describe('value settlement gate (#2 — no false NO on a stale pre-release read)
     assert.equal(res.evidence.reason, 'value_source_not_settled');
   });
 
-  it('VOIDs once the settlement grace elapses and the feed never caught up', () => {
+  it('keeps EIA pending through the default grace and resolves from the covering weekly report', () => {
+    const snap = buildBetsSnapshot({ [EIA_PETROLEUM_FEED]: eiaFixture() }, NOW, {});
+    const ledger = ingestHistory({}, [snap], NOW);
+    const key = Object.keys(ledger).find((k) => ledger[k].spec?.metricKey?.includes('inventory'));
+    const staleFeed = shapeResolutionFeed(EIA_PETROLEUM_FEED, eiaFixture({
+      inventory: { current: 390, previous: 388, date: '2026-07-12', unit: '' },
+    }));
+    resolveDueEntries(ledger, { [EIA_PETROLEUM_FEED]: staleFeed }, DEADLINE + 10 * DAY_MS);
+    assert.equal(ledger[key].status, 'pending');
+
+    const coveringReport = shapeResolutionFeed(EIA_PETROLEUM_FEED, eiaFixture({
+      inventory: { current: 396, previous: 390, date: '2026-07-24', unit: '' },
+    }));
+    resolveDueEntries(ledger, { [EIA_PETROLEUM_FEED]: coveringReport }, DEADLINE + 11 * DAY_MS);
+    assert.equal(ledger[key].status, 'resolved');
+    assert.equal(ledger[key].outcome, 'YES');
+  });
+
+  it('VOIDs once the EIA-specific settlement grace elapses and the feed never caught up', () => {
     const entry = inventoryEntry();
     const staleFeed = shapeResolutionFeed(EIA_PETROLEUM_FEED, eiaFixture({
       inventory: { current: 390, previous: 388, date: '2026-07-12', unit: '' },
     }));
-    const res = resolveHardSpec(entry, staleFeed, [], DEADLINE + 11 * DAY_MS);
+    const res = resolveHardSpec(entry, staleFeed, [], DEADLINE + 14 * DAY_MS);
     assert.equal(res.outcome, 'VOID');
   });
 });


### PR DESCRIPTION
## Summary

EIA petroleum bets now remain pending long enough for the weekly report whose observation date actually covers their deadline, instead of becoming irreversibly VOID first. The questions keep their seven-day horizon: changing that horizon to 21 days would preserve the same weekday and would not solve the report's post-deadline publication lag. Resolution therefore gives only `energy:eia-petroleum:v1` a 14-day settlement grace while every other scalar feed keeps the existing 10-day bound.

Fixes #5523

## Validation

- Regression proof first failed because the ledger had already moved to `resolved/VOID` at deadline +10 days; it now stays pending and resolves YES from the covering report at +11 days.
- 66 focused forecast, energy, commodity, and resolver tests pass.
- `npm run typecheck` and the configured lint/safe-HTML gates pass. Lint reports the repository's existing 25 warnings and 3 infos outside this patch.
- The full data suite passes 16,272 tests with 6 skips and zero failures.
- The repository pre-push gate passed, including frontend/API/Convex type checks, edge bundling, architecture checks, and change-scoped tests.

## Post-Deploy Monitoring & Validation

- Search forecast seeder logs and resolution evidence for `forecast-resolutions`, `energy:eia-petroleum:v1`, `value_source_not_settled`, and `value_source_never_settled`.
- Watch EIA seed health/freshness (`seed-meta:energy:eia-petroleum`) and the share of EIA bets ending in `VOID`; compare it with commodity VOID rates to catch accidental policy spillover.
- Healthy signal: EIA bets can remain pending after day 10, then resolve once the feed `asOf` reaches the deadline; commodity bets still use the 10-day grace.
- Failure signal: EIA bets still VOID around day 10, stay pending beyond day 14, or commodity settlement timing changes. Revert this commit if the feed-specific policy leaks; reassess the EIA bound if real publication delays routinely exceed 14 days.
- Validate across the next two EIA publication cycles. Owner: forecast seeder maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
