### PR TITLE
fix(security): bump find-my-way to 9.7.0 — GHSA-c96f-x56v-gq3h reds every PR's lockfile audit

### DIFF
--- a/consumer-prices-core/package-lock.json
+++ b/consumer-prices-core/package-lock.json
@@ -1965,9 +1965,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
## Why

A **new high advisory published today** — [GHSA-c96f-x56v-gq3h](https://github.com/advisories/GHSA-c96f-x56v-gq3h) (find-my-way ≤ 9.6.0, HTTP/2 DDoS; fastify's router, transitive in consumer-prices-core) — reds the `audit-lockfile (consumer-prices-core)` check on **every open PR** (first seen on #5526, which touches zero consumer-prices files). Path-filtered main runs stay green, so main looks healthy while all PRs fail.

## What

Lockfile-only bump to the first patched version, **9.7.0** (`npm update find-my-way --package-lock-only`). No source changes.

## Evidence

Verified with the exact CI invocation:
```
node .github/scripts/audit-production-dependencies.mjs --workspace consumer-prices-core \
  --package-json consumer-prices-core/package.json --lockfile consumer-prices-core/package-lock.json
→ Production audit OK for consumer-prices-core/package-lock.json: 0 high+ advisories are baselined or absent.
```

Merging this first unblocks #5526 and any other open PR. Refs #5525.

https://claude.ai/code/session_01StNurp4TGC3JLHbTtKJhbp