### PR TITLE
feat(forecast): Phase 2 re-engine - LLM ensemble + calibrated probabilities on prediction-markets + FRED (#4930 Bet 4)

### DIFF
--- a/scripts/_bet-templates-macro.mjs
+++ b/scripts/_bet-templates-macro.mjs
@@ -1,0 +1,222 @@
+// FRED macro/rates bet templates (Phase 2 / #5238 U12).
+//
+// Source feeds: economic:fred:v1:{SERIES}:0 (exact-match allowlist per KTD4)
+//   FEDFUNDS  — federal funds effective rate (monthly)
+//   UNRATE    — US unemployment rate (monthly)
+//   CPIAUCSL  — CPI all-urban (monthly)
+//   DGS10     — 10-year treasury yield (daily)
+//
+// The FRED-independence slice is the non-market proof that the ensemble is a
+// derived forecast, not market-price parroting (KTD3): there is no prediction-
+// market price for DGS10 or UNRATE to copy.
+//
+// Data shape (KTD4 / #5098 P1 fix):
+//   seed-economy.mjs writes { series: { seriesId, title, units, frequency,
+//   observations: [{ date, value }] } } at key economic:fred:v1:{SERIES}:0.
+//   The {series:{observations}} unwrap was previously silently killing all 10
+//   FRED series (#5098). This module's extractFredObservations() is the fix.
+//
+// Calendar-derived grace (KTD4):
+//   Monthly FRED observations are dated the 1st of the reference month and
+//   published ~2 weeks after month end → ~45–70d lag from a mid-month deadline.
+//   Grace = 75d for monthly series; 14d for DGS10 (daily).
+//   The resolver's valueSettlementMaxLagMs() must be extended to honour this;
+//   see _forecast-resolution-eval.mjs FRED_VALUE_SETTLEMENT_MAX_LAG_MS.
+//
+// Pure: templates are declarative; generateBets() drives them with injected feed + nowMs.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const FRED_KEY_PREFIX = 'economic:fred:v1';
+
+// Horizon: 45d for monthly (so the deadline lands after the latest obs publishes);
+// 14d for daily DGS10 (short enough to stay current).
+const MONTHLY_HORIZON_MS = 45 * DAY_MS;
+const DAILY_HORIZON_MS = 14 * DAY_MS;
+
+// Minimum move fraction to produce a non-trivial bet.
+// 0.25% move: small enough for rate series (e.g. 5.33 → 5.34) to still generate bets.
+const MIN_MOVE_FRACTION = 0.0025;
+
+const FRED_SERIES = [
+  {
+    seriesId: 'FEDFUNDS',
+    subject: 'the US federal funds effective rate',
+    unit: '%',
+    frequency: 'monthly',
+    horizonMs: MONTHLY_HORIZON_MS,
+  },
+  {
+    seriesId: 'UNRATE',
+    subject: 'the US unemployment rate',
+    unit: '%',
+    frequency: 'monthly',
+    horizonMs: MONTHLY_HORIZON_MS,
+  },
+  {
+    seriesId: 'CPIAUCSL',
+    subject: 'the US CPI (all urban consumers)',
+    unit: 'index',
+    frequency: 'monthly',
+    horizonMs: MONTHLY_HORIZON_MS,
+  },
+  {
+    seriesId: 'DGS10',
+    subject: 'the 10-year US Treasury yield',
+    unit: '%',
+    frequency: 'daily',
+    horizonMs: DAILY_HORIZON_MS,
+  },
+];
+
+// ── Core: {series:{observations}} unwrap (KTD4 / #5098 P1 fix) ────────────
+//
+// seed-economy.mjs stores FRED series as { series: { seriesId, observations } }
+// wrapped in the runSeed envelope. The `data` field holds the series object.
+// This function extracts the observation array regardless of envelope depth.
+export function extractFredObservations(feed) {
+  // Unwrap runSeed envelope if present.
+  const d = feed?.data ?? feed;
+  // The stored shape is { series: { ..., observations: [...] } }.
+  const obs = d?.series?.observations ?? d?.observations;
+  return Array.isArray(obs) ? obs : null;
+}
+
+/**
+ * Get the latest valid observation from the FRED series array.
+ * FRED occasionally appends null/`.` sentinels at the end of the series —
+ * scan backwards to find a real value.
+ *
+ * @param {Array} observations  [{date, value}] sorted oldest-first.
+ * @returns {{value: number, date: string} | null}
+ */
+function latestObservation(observations) {
+  if (!Array.isArray(observations)) return null;
+  for (let i = observations.length - 1; i >= 0; i--) {
+    const ob = observations[i];
+    const v = Number(ob?.value);
+    if (Number.isFinite(v) && typeof ob.date === 'string') return { value: v, date: ob.date };
+  }
+  return null;
+}
+
+/**
+ * Get the observation immediately before `latest` (penultimate) for delta calculation.
+ * @param {Array} observations
+ * @param {string} latestDate The date to look before.
+ * @returns {{value: number} | null}
+ */
+function previousObservation(observations, latestDate) {
+  if (!Array.isArray(observations)) return null;
+  let found = false;
+  for (let i = observations.length - 1; i >= 0; i--) {
+    const ob = observations[i];
+    if (!found) {
+      if (ob?.date === latestDate) found = true;
+      continue;
+    }
+    const v = Number(ob?.value);
+    if (Number.isFinite(v)) return { value: v, date: ob.date };
+  }
+  return null;
+}
+
+function buildFredTemplate({ seriesId, subject, unit, horizonMs }) {
+  const feedKey = `${FRED_KEY_PREFIX}:${seriesId}:0`;
+
+  return {
+    id: `macro:fred-${seriesId.toLowerCase()}`,
+    feedKey,
+    domain: 'macro',
+
+    extractMetric(feed) {
+      const observations = extractFredObservations(feed);
+      if (!observations) return null;
+
+      const latest = latestObservation(observations);
+      if (!latest) return null;
+
+      const prev = previousObservation(observations, latest.date);
+      return {
+        seriesId,
+        subject,
+        unit,
+        value: latest.value,
+        date: latest.date,
+        previous: prev ? prev.value : null,
+        // Pass all observations for base-rate calculation (up to 24 months / 2yr).
+        observations: observations.slice(-24).map((o) => Number(o.value)).filter(Number.isFinite),
+      };
+    },
+
+    horizonPolicy({ nowMs }) {
+      return nowMs + horizonMs;
+    },
+
+    buildResolutionSpec({ metric, deadlineMs }) {
+      const { value, previous } = metric;
+      const lastMove = Number.isFinite(previous) ? value - previous : 0;
+      const floor = Math.abs(value) * MIN_MOVE_FRACTION;
+      const magnitude = Math.max(Math.abs(lastMove), floor);
+      if (!(magnitude > 0)) return null;
+
+      // Direction: continuation of the latest observed move; default up on flat.
+      const wantUp = lastMove >= 0;
+      const threshold = round4(wantUp ? value + magnitude : value - magnitude);
+
+      return {
+        kind: 'hard',
+        // metricKey uses the exact Redis key (KTD4: exact-match allowlist).
+        metricKey: `${feedKey}|value(series==${seriesId})`,
+        operator: 'crosses',
+        threshold,
+        baselineValue: round4(value),
+        // at-deadline: resolver reads the feed's latest value after the deadline.
+        // Grace is handled by FRED_VALUE_SETTLEMENT_MAX_LAG_MS in _forecast-resolution-eval.mjs.
+        window: 'at-deadline',
+        deadline: deadlineMs,
+        sourceFeed: feedKey,
+        question: buildQuestion(metric, wantUp, threshold, deadlineMs),
+      };
+    },
+
+    buildQuestion({ spec }) {
+      return spec.question;
+    },
+
+    buildTitle({ metric, spec }) {
+      const dir = spec.threshold >= spec.baselineValue ? 'rise' : 'fall';
+      return `${capitalize(metric.subject)}: ${dir} to ${spec.threshold} ${metric.unit}?`;
+    },
+
+    userValueScore() {
+      // Rate/yield series are higher interest than index levels.
+      return seriesId === 'FEDFUNDS' || seriesId === 'DGS10' ? 0.75 : 0.65;
+    },
+  };
+}
+
+function buildQuestion(metric, wantUp, threshold, deadlineMs) {
+  const dir = wantUp ? 'rise to at least' : 'fall to at most';
+  return `Will ${metric.subject} ${dir} ${threshold} ${metric.unit} by ${isoDate(deadlineMs)}?`;
+}
+
+export const MACRO_BET_TEMPLATES = FRED_SERIES.map(buildFredTemplate);
+
+// Feed keys consumed by this module. The seeder adds these to BET_FEEDS.
+export const MACRO_FEEDS = FRED_SERIES.map(({ seriesId }) => `${FRED_KEY_PREFIX}:${seriesId}:0`);
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function isoDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function capitalize(text) {
+  const s = String(text || '');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function round4(value) {
+  if (!Number.isFinite(value)) return value;
+  return Math.round(value * 10_000) / 10_000;
+}

--- a/scripts/_bet-templates-macro.mjs
+++ b/scripts/_bet-templates-macro.mjs
@@ -192,6 +192,13 @@ function buildFredTemplate({ seriesId, subject, unit, horizonMs }) {
       // Rate/yield series are higher interest than index levels.
       return seriesId === 'FEDFUNDS' || seriesId === 'DGS10' ? 0.75 : 0.65;
     },
+    // P1b fix: supply historical observations as base-rate input so the seeder
+    // does not fall back to the 0.4 dummy prior for FRED bets. generateBets()
+    // stores this as bet._baseRateHistory; buildBetsSnapshot() uses it when the
+    // EIA accumulator has no entries for this series (always the case for FRED).
+    buildBaseRateHistory({ metric }) {
+      return Array.isArray(metric.observations) ? metric.observations : [];
+    },
   };
 }
 

--- a/scripts/_bet-templates-markets.mjs
+++ b/scripts/_bet-templates-markets.mjs
@@ -1,0 +1,212 @@
+// Prediction-market bet templates (Phase 2 / #5238 U11).
+//
+// Source feed: prediction:markets-bootstrap:v1 (bootstrap categories: geopolitical/tech/finance)
+// Resolution feed: prediction:markets-resolution:v1  ← dedicated settlement path (KTD2)
+//
+// Key design decisions (KTD2):
+//   - Bootstrap feed only publishes OPEN markets (closed:'false', yesPrice clipped [10,90]).
+//     A settled market (~0/100 price) NEVER appears in the bootstrap feed, so resolution
+//     MUST use a separate feed queried with Gamma closed:true by slug — mirroring the
+//     ACLED resolution precedent.
+//   - Bets store the market slug in spec.marketSlug for the settlement loader.
+//   - Bets PEND (not VOID) from endDate until settlement lands in
+//     prediction:markets-resolution:v1. The resolver's at-endDate window handles this.
+//   - The market's yesPrice (at generation time) is stored as calibration.marketPrice
+//     so the scorecard's vsMarketSkill logic can use it (KTD5).
+//   - Volume floor: MIN_VOLUME = 5000 (mirrors shouldInclude in _prediction-scoring.mjs).
+//   - Horizon cap: endDate must be within 45 calendar days so bets resolve in one cycle.
+//
+// Pure: templates are declarative; generateBets() (in _bet-templates.mjs) drives them
+// with an injected feed snapshot + nowMs.
+
+export const MARKETS_BOOTSTRAP_FEED = 'prediction:markets-bootstrap:v1';
+// Dedicated settlement feed written by the settlement seeder. The bootstrap feed
+// never has closed prices — this is a separate key.
+export const MARKETS_RESOLUTION_FEED = 'prediction:markets-resolution:v1';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Markets whose endDate is beyond 45d will not resolve before the bets history TTL.
+const MAX_HORIZON_MS = 45 * DAY_MS;
+// Mirror _prediction-scoring.mjs shouldInclude volume floor.
+const MIN_VOLUME = 5000;
+// Minimum market probability to generate a bet (mirrors shouldInclude[10,90] clip).
+const MIN_YES_PRICE = 10;
+const MAX_YES_PRICE = 90;
+// Maximum bets to generate from the markets bootstrap feed per run.
+// The seeder's top-K filter will further trim across all domains.
+const MAX_MARKETS_BETS = 10;
+
+/**
+ * Extract candidate markets from all bootstrap categories.
+ * Returns a flat, deduplicated list sorted by score desc.
+ */
+function extractCandidateMarkets(feed, nowMs) {
+  const bootstrapData = feed?.data ?? feed;
+  if (!bootstrapData || typeof bootstrapData !== 'object') return [];
+
+  // Combine all categories into one pool and deduplicate by slug.
+  const categories = ['geopolitical', 'tech', 'finance'];
+  const seen = new Set();
+  const candidates = [];
+
+  for (const cat of categories) {
+    const markets = Array.isArray(bootstrapData[cat]) ? bootstrapData[cat] : [];
+    for (const m of markets) {
+      const slug = resolveSlug(m);
+      if (!slug || seen.has(slug)) continue;
+      seen.add(slug);
+
+      const yesPrice = Number(m.yesPrice);
+      if (!Number.isFinite(yesPrice) || yesPrice < MIN_YES_PRICE || yesPrice > MAX_YES_PRICE) continue;
+
+      const volume = Number(m.volume);
+      if (!Number.isFinite(volume) || volume < MIN_VOLUME) continue;
+
+      const endDate = m.endDate ?? m.end_date;
+      if (!endDate) continue;
+      const endMs = typeof endDate === 'number' ? endDate : Date.parse(endDate);
+      if (!Number.isFinite(endMs) || endMs <= nowMs || endMs > nowMs + MAX_HORIZON_MS) continue;
+
+      candidates.push({ m, slug, yesPrice, volume, endMs });
+    }
+  }
+
+  // Sort by volume desc (conviction already baked into the bootstrap feed ordering,
+  // volume is a stable secondary key).
+  candidates.sort((a, b) => b.volume - a.volume);
+  return candidates.slice(0, MAX_MARKETS_BETS);
+}
+
+/**
+ * Resolve a stable slug for a market entry.
+ * Polymarket uses event slug; Kalshi uses a ticker from the URL.
+ */
+function resolveSlug(m) {
+  if (typeof m.url !== 'string') return null;
+  // Polymarket: https://polymarket.com/event/<slug>
+  const polyMatch = m.url.match(/polymarket\.com\/event\/([^/?#]+)/);
+  if (polyMatch) return `polymarket:${polyMatch[1]}`;
+  // Kalshi: https://kalshi.com/markets/<ticker>
+  const kalshiMatch = m.url.match(/kalshi\.com\/markets\/([^/?#]+)/);
+  if (kalshiMatch) return `kalshi:${kalshiMatch[1]}`;
+  return null;
+}
+
+function isoDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Build a bet template for one candidate market.
+ * The template's extractMetric() receives the FULL BOOTSTRAP FEED and must
+ * re-locate the specific market by slug — because generateBets() calls it once
+ * per template with the current feed snapshot.
+ */
+function buildMarketTemplate(slug, initialMarket, initialEndMs) {
+  return {
+    id: `prediction-market:${slug}`,
+    feedKey: MARKETS_BOOTSTRAP_FEED,
+    domain: 'prediction_market',
+
+    extractMetric(feed) {
+      const now = Date.now(); // used for staleness check only
+      const data = feed?.data ?? feed;
+      if (!data || typeof data !== 'object') return null;
+
+      // Re-locate the market by slug across all categories.
+      const categories = ['geopolitical', 'tech', 'finance'];
+      for (const cat of categories) {
+        const markets = Array.isArray(data[cat]) ? data[cat] : [];
+        for (const m of markets) {
+          if (resolveSlug(m) !== slug) continue;
+          const yesPrice = Number(m.yesPrice);
+          if (!Number.isFinite(yesPrice)) return null;
+          const volume = Number(m.volume);
+          const endDate = m.endDate ?? m.end_date;
+          const endMs = typeof endDate === 'number' ? endDate : Date.parse(endDate);
+          if (!Number.isFinite(endMs)) return null;
+          return {
+            title: String(m.title || ''),
+            slug,
+            yesPrice,
+            volume: Number.isFinite(volume) ? volume : 0,
+            endMs,
+            source: m.source || 'unknown',
+          };
+        }
+      }
+      return null;
+    },
+
+    horizonPolicy({ metric }) {
+      // The deadline IS the market's own endDate — resolution follows market settlement.
+      return metric.endMs;
+    },
+
+    buildResolutionSpec({ metric, deadlineMs }) {
+      return {
+        kind: 'hard',
+        // The eval reads yesPrice(market==<slug>) from the resolution feed.
+        // At settlement yesPrice will be ~0 or ~100; we resolve YES if >= 50.
+        metricKey: `${MARKETS_RESOLUTION_FEED}|yesPrice(market==${metric.slug})`,
+        operator: 'crosses',
+        // Threshold = 50: YES if settled yesPrice >= 50.
+        threshold: 50,
+        baselineValue: metric.yesPrice,
+        window: 'at-endDate',
+        deadline: deadlineMs,
+        sourceFeed: MARKETS_RESOLUTION_FEED,
+        // Store slug so the settlement loader can query Gamma by slug.
+        marketSlug: metric.slug,
+        question: `Will the market "${metric.title}" resolve YES by ${isoDate(deadlineMs)}?`,
+      };
+    },
+
+    buildQuestion({ spec }) {
+      return spec.question;
+    },
+
+    buildTitle({ metric }) {
+      return `Prediction market: ${metric.title}`;
+    },
+
+    // After generateBets(), seed-forecast-bets injects calibration.marketPrice (KTD5).
+    // We surface yesPrice here so the seeder can attach it.
+    buildCalibration({ metric }) {
+      // marketPrice stored as a [0,1] fraction to match the scorecard's marketProbability().
+      return { marketPrice: round2(metric.yesPrice / 100) };
+    },
+
+    userValueScore({ metric }) {
+      // High-conviction markets (far from 50/50) are more interesting for calibration.
+      const conviction = Math.abs(metric.yesPrice - 50) / 50;
+      const volScore = Math.min(Math.log10(Math.max(metric.volume, 1)) / Math.log10(1_000_000), 1);
+      return clamp01(conviction * 0.5 + volScore * 0.5);
+    },
+  };
+}
+
+/**
+ * Generate prediction-market bet templates from the current bootstrap feed snapshot.
+ * Called once per seeder run. Returns an array of template objects for generateBets().
+ *
+ * @param {unknown} feed  The raw prediction:markets-bootstrap:v1 payload.
+ * @param {number}  nowMs Current timestamp.
+ * @returns {object[]}    Bet templates.
+ */
+export function buildMarketTemplates(feed, nowMs) {
+  const candidates = extractCandidateMarkets(feed, nowMs);
+  return candidates.map(({ slug, m, endMs }) => buildMarketTemplate(slug, m, endMs));
+}
+
+// Convenience re-export for the seeder's BET_FEEDS list.
+export { MARKETS_BOOTSTRAP_FEED as PREDICTION_MARKET_FEED };
+
+function clamp01(v) {
+  return Math.max(0, Math.min(1, v));
+}
+
+function round2(v) {
+  if (!Number.isFinite(v)) return v;
+  return Math.round(v * 100) / 100;
+}

--- a/scripts/_bet-templates.mjs
+++ b/scripts/_bet-templates.mjs
@@ -8,17 +8,18 @@
 //
 // Template shape:
 //   {
-//     id:            string                       // stable slug, e.g. 'energy:crude-inventory'
-//     feedKey:       string                       // the feed this template reads
-//     domain:        string                       // forecast domain bucket
-//     extractMetric: (feedData) => metric | null  // null = feed absent/unusable → skip
-//     horizonPolicy: (ctx) => deadlineMs          // when the bet resolves
-//     buildResolutionSpec: (ctx) => spec          // #4976 hard/judged spec
-//     buildQuestion: (ctx) => string              // crisp YES criterion
-//     buildTitle?:   (ctx) => string              // display title (defaults to question)
-//     userValueScore?: (ctx) => number            // 0..1 ranking signal
+//     id:              string                       // stable slug, e.g. 'energy:crude-inventory'
+//     feedKey:         string                       // the feed this template reads
+//     domain:          string                       // forecast domain bucket
+//     extractMetric:   (feedData) => metric | null  // null = feed absent/unusable → skip
+//     horizonPolicy:   (ctx) => deadlineMs          // when the bet resolves
+//     buildResolutionSpec: (ctx) => spec            // #4976 hard/judged spec
+//     buildQuestion:   (ctx) => string              // crisp YES criterion
+//     buildTitle?:     (ctx) => string              // display title (defaults to question)
+//     buildCalibration?: (ctx) => object            // Phase 2: market-price calibration anchor (KTD5)
+//     userValueScore?: (ctx) => number              // 0..1 ranking signal
 //   }
-// ctx passed to horizon/spec/question/title/score:
+// ctx passed to horizon/spec/question/title/calibration/score:
 //   { template, metric, feed, nowMs, deadlineMs, spec }
 
 export function generateBets(templates, feedsByKey, nowMs) {
@@ -56,6 +57,16 @@ export function generateBets(templates, feedsByKey, nowMs) {
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
 
+    const betCalibration = (() => {
+      try {
+        return typeof template.buildCalibration === 'function'
+          ? template.buildCalibration(ctx)
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+
     bets.push({
       id,
       domain: template.domain,
@@ -65,6 +76,7 @@ export function generateBets(templates, feedsByKey, nowMs) {
       resolution: spec,
       generationOrigin: 'bet_engine',
       userValueScore: clamp01(template.userValueScore ? Number(template.userValueScore(ctx)) : 0.5),
+      ...(betCalibration ? { calibration: betCalibration } : {}),
       generatedAt: nowMs,
       feedKey: template.feedKey,
       templateId: template.id,

--- a/scripts/_bet-templates.mjs
+++ b/scripts/_bet-templates.mjs
@@ -77,6 +77,12 @@ export function generateBets(templates, feedsByKey, nowMs) {
       generationOrigin: 'bet_engine',
       userValueScore: clamp01(template.userValueScore ? Number(template.userValueScore(ctx)) : 0.5),
       ...(betCalibration ? { calibration: betCalibration } : {}),
+      // _baseRateHistory: transient — consumed and deleted by buildBetsSnapshot().
+      // Set when the template knows its own historical series (e.g. FRED observations)
+      // so the seeder doesn't fall back to the EIA-only accumulator (P1b fix).
+      ...(typeof template.buildBaseRateHistory === 'function'
+        ? { _baseRateHistory: (() => { try { return template.buildBaseRateHistory(ctx); } catch { return undefined; } })() }
+        : {}),
       generatedAt: nowMs,
       feedKey: template.feedKey,
       templateId: template.id,

--- a/scripts/_forecast-ensemble.mjs
+++ b/scripts/_forecast-ensemble.mjs
@@ -1,0 +1,233 @@
+// 3-pass LLM ensemble for bet-engine Phase 2 (#5238 U10).
+//
+// Runs three diverse LLM passes in parallel (outside-view / inside-view /
+// adversarial-refuter) and returns a calibrated probability via trimmed mean
+// (= median for 3 values). All-fail falls back honestly to the provided
+// base-rate — NEVER emits 0.5.
+//
+// Pure / injected: callForecastLLM is passed in by the caller so this module
+// has no top-level side effects and no circular dependency on seed-forecasts.mjs.
+// This mirrors the createLiveJudgeModels() pattern in seed-forecast-resolutions.mjs.
+//
+// Per-pass budget: 35s, maxRetries: 0 — a slow pass that loses the race is
+// evidence of model pressure, not a reason to retry and inflate cost.
+// All passes run concurrently via Promise.allSettled.
+
+const PASS_BUDGET_MS = 35_000;
+
+// The three pass personas, each with a distinct epistemic lens.
+// Probabilities must be in [0, 1] — the JSON schema enforces this so a
+// hallucinated >1 value is treated as a failed pass rather than silently clamped.
+const PASSES = [
+  {
+    name: 'outside_view',
+    systemPrompt: [
+      'You forecast geopolitical and economic questions using reference-class reasoning.',
+      'Start from the base rate for similar questions, then adjust for structural features.',
+      'Do NOT anchor on recent headlines. Think in historical frequencies.',
+      'Return JSON only: {"probability": <0-1 float>, "rationale": "<50 words>"}.',
+    ].join('\n'),
+  },
+  {
+    name: 'inside_view',
+    systemPrompt: [
+      'You forecast geopolitical and economic questions by analyzing specific causal mechanisms.',
+      'Focus on the concrete factors driving this particular question right now.',
+      'Consider recent data trends, policy actions, and near-term catalysts.',
+      'Return JSON only: {"probability": <0-1 float>, "rationale": "<50 words>"}.',
+    ].join('\n'),
+  },
+  {
+    name: 'adversarial_refuter',
+    systemPrompt: [
+      'You forecast geopolitical and economic questions by steelmanning the OPPOSITE outcome.',
+      'Identify the strongest reasons the expected outcome will NOT happen.',
+      'Then assign a probability that accounts for those tail risks.',
+      'Return JSON only: {"probability": <0-1 float>, "rationale": "<50 words>"}.',
+    ].join('\n'),
+  },
+];
+
+/**
+ * Run the 3-pass ensemble for a single forecast question.
+ *
+ * @param {string} question   The YES/NO resolution question (from the bet spec).
+ * @param {string} context    Brief factual context (feed snapshot summary, <=300 chars).
+ * @param {Function} callForecastLLM  Injected from seed-forecasts.mjs.
+ * @param {object} options
+ * @param {number} [options.budgetMs=35000]      Per-pass timeout.
+ * @param {string} [options.stage='ensemble']    LLM stage label for telemetry.
+ * @param {string} [options.providerOrder]       Override provider order (e.g. ['openrouter']).
+ * @param {object} [options.modelOverrides]      Override model per provider.
+ * @param {number|null} [options.baseRateFallback=null]  Base-rate to return on all-fail.
+ *   MUST be a finite number in [0,1]. null is rejected at runtime (caller must supply it).
+ * @returns {Promise<EnsembleResult>}
+ */
+export async function runEnsemble(question, context, callForecastLLM, options = {}) {
+  const budgetMs = Number.isFinite(options.budgetMs) ? options.budgetMs : PASS_BUDGET_MS;
+  const stage = options.stage || 'forecast_ensemble';
+  const baseRateFallback = options.baseRateFallback ?? null;
+
+  const userPrompt = buildUserPrompt(question, context);
+
+  // Run all 3 passes in parallel; allSettled so a single failure doesn't abort the others.
+  const settled = await Promise.allSettled(
+    PASSES.map((pass) => runOnePass(pass, userPrompt, callForecastLLM, { budgetMs, stage, ...options })),
+  );
+
+  const successful = [];
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i];
+    if (result.status === 'fulfilled' && result.value !== null) {
+      successful.push({ ...result.value, pass: PASSES[i].name });
+    }
+  }
+
+  if (successful.length === 0) {
+    // All-fail: fall back to base-rate. Never emit 0.5 — the issue explicitly
+    // forbids it ("all-fail → base-rate (never 0.5)").
+    const fb = Number.isFinite(baseRateFallback) ? clamp01(baseRateFallback) : null;
+    if (fb === null) {
+      // Caller must supply a finite base-rate. Surface as a clear error.
+      throw new Error('[ensemble] all passes failed and no finite baseRateFallback provided');
+    }
+    return {
+      probability: fb,
+      rationale: 'All LLM passes failed; using empirical base-rate fallback.',
+      passes: PASSES.map((p) => ({ pass: p.name, probability: null, rationale: null, model: null, provider: null })),
+      method: 'base_rate_fallback',
+    };
+  }
+
+  // Trimmed mean: for 3 inputs this is the median (drop min + max, keep middle).
+  // For < 3 successful passes it is the mean of what survived.
+  const probability = trimmedMean(successful.map((p) => p.probability));
+
+  return {
+    probability,
+    rationale: successful.map((p) => `[${p.pass}] ${p.rationale || ''}`).join(' | '),
+    passes: PASSES.map((pass) => {
+      const found = successful.find((s) => s.pass === pass.name);
+      return {
+        pass: pass.name,
+        probability: found?.probability ?? null,
+        rationale: found?.rationale ?? null,
+        model: found?.model ?? null,
+        provider: found?.provider ?? null,
+      };
+    }),
+    method: 'ensemble',
+  };
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+function buildUserPrompt(question, context) {
+  const lines = [
+    `Question: ${question}`,
+  ];
+  if (context && typeof context === 'string' && context.trim()) {
+    lines.push(`Context: ${context.trim().slice(0, 400)}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run one LLM pass. Returns { probability, rationale, model, provider } or null on failure.
+ * Never throws — a failed pass is a null result (Promise.allSettled handles it).
+ */
+async function runOnePass(pass, userPrompt, callForecastLLM, options) {
+  const { budgetMs, stage, providerOrder, modelOverrides } = options;
+  try {
+    const result = await callForecastLLM(pass.systemPrompt, userPrompt, {
+      stage: `${stage}:${pass.name}`,
+      maxTokens: 120,
+      temperature: 0.3,
+      maxRetries: 0,
+      returnFailureReason: true,
+      stageBudgetMs: budgetMs,
+      ...(providerOrder ? { providerOrder } : {}),
+      ...(modelOverrides ? { modelOverrides } : {}),
+    });
+
+    if (!result?.text) return null;
+    return parsePassResponse(result.text, result.model, result.provider);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a pass response JSON. Returns { probability, rationale, model, provider } or null.
+ * Rejects probabilities outside [0, 1] — a hallucinated "50" (percent not decimal) would
+ * otherwise corrupt the ensemble with a false certainty.
+ */
+function parsePassResponse(text, model, provider) {
+  if (!text || typeof text !== 'string') return null;
+  const trimmed = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Try extracting the first {...} block
+    const start = trimmed.indexOf('{');
+    const end = trimmed.lastIndexOf('}');
+    if (start === -1 || end <= start) return null;
+    try {
+      parsed = JSON.parse(trimmed.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const rawProb = parsed.probability ?? parsed.prob ?? parsed.p;
+  const probability = Number(rawProb);
+  // Strict [0,1] validation — reject percent-scale answers (0-100) as corrupted.
+  if (!Number.isFinite(probability) || probability < 0 || probability > 1) return null;
+  const rationale = typeof parsed.rationale === 'string'
+    ? parsed.rationale.slice(0, 200).replace(/\s+/g, ' ').trim()
+    : '';
+  return { probability, rationale, model: model || null, provider: provider || null };
+}
+
+/**
+ * Trimmed mean: drops the min and max, returns the mean of the rest.
+ * For N=1 or N=2, returns the plain mean (nothing to drop).
+ * For N=3 this equals the median.
+ */
+export function trimmedMean(values) {
+  if (!values || values.length === 0) return NaN;
+  if (values.length <= 2) {
+    return values.reduce((s, v) => s + v, 0) / values.length;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const inner = sorted.slice(1, -1);
+  const result = inner.reduce((s, v) => s + v, 0) / inner.length;
+  return round6(clamp01(result));
+}
+
+function clamp01(v) {
+  return Math.max(0, Math.min(1, v));
+}
+
+function round6(v) {
+  if (!Number.isFinite(v)) return v;
+  return Math.round(v * 1_000_000) / 1_000_000;
+}
+
+/**
+ * @typedef {object} EnsembleResult
+ * @property {number}      probability  Calibrated probability in [0,1].
+ * @property {string}      rationale    Synthesized rationale from all passes.
+ * @property {PassResult[]} passes      Per-pass results for audit (KTD1).
+ * @property {'ensemble'|'base_rate_fallback'} method
+ */
+
+/**
+ * @typedef {object} PassResult
+ * @property {string}      pass        Pass name ('outside_view', 'inside_view', 'adversarial_refuter').
+ * @property {number|null} probability Pass probability, or null if the pass failed.
+ * @property {string|null} rationale   Pass rationale, or null if the pass failed.
+ * @property {string|null} model       LLM model used.
+ * @property {string|null} provider    LLM provider used.
+ */

--- a/scripts/_forecast-resolution-eval.mjs
+++ b/scripts/_forecast-resolution-eval.mjs
@@ -17,11 +17,17 @@ export const VALUE_SETTLEMENT_MAX_LAG_MS = 10 * DAY_MS;
 // week. A deadline just after the covered period may therefore need the next
 // report (plus holiday slack) before `asOf` reaches the deadline.
 export const EIA_VALUE_SETTLEMENT_MAX_LAG_MS = 14 * DAY_MS;
+// FRED monthly series (FEDFUNDS, UNRATE, CPIAUCSL) are dated the 1st of the
+// reference month and published ~2 weeks after month end, giving a ~45-70d lag
+// from a mid-month deadline. DGS10 is daily but shares this constant for safety.
+// Grace = 75d = worst-case monthly lag with a margin (KTD4 / #5238 U12).
+export const FRED_VALUE_SETTLEMENT_MAX_LAG_MS = 75 * DAY_MS;
 
 function valueSettlementMaxLagMs(feedKey) {
-  return feedKey === 'energy:eia-petroleum:v1'
-    ? EIA_VALUE_SETTLEMENT_MAX_LAG_MS
-    : VALUE_SETTLEMENT_MAX_LAG_MS;
+  if (feedKey === 'energy:eia-petroleum:v1') return EIA_VALUE_SETTLEMENT_MAX_LAG_MS;
+  // FRED monthly series have a ~45-70d observation lag; 75d gives safe margin (KTD4).
+  if (typeof feedKey === 'string' && feedKey.startsWith('economic:fred:v1:')) return FRED_VALUE_SETTLEMENT_MAX_LAG_MS;
+  return VALUE_SETTLEMENT_MAX_LAG_MS;
 }
 
 const SUPPORTED_FUNCTIONS = new Set(['count', 'riskScore', 'present', 'yesPrice', 'hexCount', 'price', 'value']);

--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -91,6 +91,17 @@ export const RESOLUTION_FEED_KEYS = new Set([
   // seeder shapes {wti,brent,production,inventory} into records carrying
   // {metric, value}; bets read via `...|value(metric==<name>)`.
   'energy:eia-petroleum:v1',
+  // Phase 2 (#5238 U11): prediction-market settlement feed. The bootstrap feed
+  // only publishes open markets (closed:false); settled prices (~0/100) land
+  // here via the dedicated settlement seeder (mirrors ACLED precedent, KTD2).
+  'prediction:markets-resolution:v1',
+  // Phase 2 (#5238 U12 / KTD4): FRED macro/rates — exact-match allowlist.
+  // Monthly series: FEDFUNDS, UNRATE, CPIAUCSL; daily: DGS10.
+  // Grace handled by FRED_VALUE_SETTLEMENT_MAX_LAG_MS in _forecast-resolution-eval.mjs.
+  'economic:fred:v1:FEDFUNDS:0',
+  'economic:fred:v1:UNRATE:0',
+  'economic:fred:v1:CPIAUCSL:0',
+  'economic:fred:v1:DGS10:0',
 ]);
 
 // ── Signal type -> hard family (D3) ──────────────────────────────────────

--- a/scripts/_forecast-scorecard.mjs
+++ b/scripts/_forecast-scorecard.mjs
@@ -52,6 +52,8 @@ export function computeScorecard(ledger, nowMs, options = {}) {
     byDomain: summarizeGroups(scored, resolved, 'domain', 'domain'),
     byGenerationOrigin: summarizeGroups(scored, resolved, 'generationOrigin', 'generationOrigin'),
     calibration: calibrationBuckets(scored),
+    // Phase 2 (KTD6): promotion flag. Default false until Gate 2 criteria are met.
+    promotionEnabled: options.promotionEnabled ?? false,
   };
 
   const overall = summarizeScored(scored);
@@ -61,6 +63,22 @@ export function computeScorecard(ledger, nowMs, options = {}) {
   if (skill) scorecard.skill = skill;
   const marketSkill = summarizeMarketSkill(scored);
   if (marketSkill) scorecard.vsMarketSkill = marketSkill;
+
+  // Phase 2 (KTD6): per-origin Gate-2 measurement for bet_engine slice.
+  const betEngineScored = scored.filter((entry) => entry?.generationOrigin === 'bet_engine');
+  if (betEngineScored.length > 0) {
+    scorecard.betEngineCalibration = calibrationBuckets(betEngineScored);
+    const betEngineMarketSkill = summarizeMarketSkill(betEngineScored);
+    if (betEngineMarketSkill) scorecard.betEngineMarketSkill = betEngineMarketSkill;
+    // Deviation skill: corr(sign(ensemble - market), outcome - market) for bets
+    // where |ensemble - market| > DEVIATION_BAND (anti-parroting, KTD3).
+    const devSkill = deviationSkill(betEngineScored);
+    if (devSkill) scorecard.betEngineDeviationSkill = devSkill;
+    // Base-rate comparison: how much does the ensemble beat the base-rate prior?
+    const baseRateCmp = baseRateComparison(betEngineScored);
+    if (baseRateCmp) scorecard.betEngineBaseRateComparison = baseRateCmp;
+  }
+
   return scorecard;
 }
 
@@ -210,6 +228,82 @@ function summarizeMarketSkill(scored) {
     marketBrier: round(marketBrier),
     brierDelta: round(marketBrier - forecastBrier),
   };
+}
+
+/**
+ * Deviation skill (KTD3 / anti-parroting gate).
+ * Computes corr(sign(ensemble - market), outcome - market) for bets where
+ * |ensemble - market| > deviationBand. A positive correlation means the ensemble
+ * is right WHEN it disagrees with the market — genuine calibration, not parroting.
+ *
+ * Returns null when fewer than MIN_DEVIATION_N bets have a large-enough deviation.
+ * @param {object[]} scored   Scored ledger entries (bet_engine slice or all).
+ * @param {number} [deviationBand=0.10]  Minimum |ensemble - market| fraction.
+ * @returns {{ n: number, corr: number } | null}
+ */
+export function deviationSkill(scored, deviationBand = 0.10) {
+  const MIN_N = 5;
+  const anchored = scored.filter((entry) => {
+    const market = marketProbability(entry);
+    if (!Number.isFinite(market)) return false;
+    const p = probability(entry);
+    return Math.abs(p - market) > deviationBand;
+  });
+  if (anchored.length < MIN_N) return null;
+
+  const signs = anchored.map((e) => Math.sign(probability(e) - marketProbability(e)));
+  const deltas = anchored.map((e) => outcomeNumber(e) - marketProbability(e));
+  const corr = pearsonCorr(signs, deltas);
+  return { n: anchored.length, corr: round(corr), deviationBand };
+}
+
+/**
+ * Base-rate comparison: how much does the ensemble Brier beat the base-rate Brier?
+ * Both are computed over the same set of scored entries. Only entries that have
+ * a numeric `baselineProbability` participate (skips entries with no baseline).
+ *
+ * @param {object[]} scored  Scored ledger entries.
+ * @returns {{ n: number, ensembleBrier: number, baseRateBrier: number, brierImprovement: number } | null}
+ */
+export function baseRateComparison(scored) {
+  const pairs = scored
+    .map((entry) => {
+      const baseline = Number(entry.baselineProbability);
+      return Number.isFinite(baseline) ? { entry, baseline } : null;
+    })
+    .filter(Boolean);
+  if (!pairs.length) return null;
+
+  const ensembleBrier = mean(pairs.map(({ entry }) => brier(entry)));
+  const baseRateBrier = mean(pairs.map(({ entry, baseline }) => brier(entry, clampProbability(baseline))));
+  return {
+    n: pairs.length,
+    ensembleBrier: round(ensembleBrier),
+    baseRateBrier: round(baseRateBrier),
+    // Positive = ensemble is better (lower Brier).
+    brierImprovement: round(baseRateBrier - ensembleBrier),
+  };
+}
+
+/**
+ * Pearson product-moment correlation coefficient for two equal-length numeric arrays.
+ * Returns NaN when the denominator is 0 (one series is constant).
+ */
+function pearsonCorr(xs, ys) {
+  const n = xs.length;
+  if (n === 0 || n !== ys.length) return NaN;
+  const xMean = xs.reduce((s, v) => s + v, 0) / n;
+  const yMean = ys.reduce((s, v) => s + v, 0) / n;
+  let num = 0, sx = 0, sy = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - xMean;
+    const dy = ys[i] - yMean;
+    num += dx * dy;
+    sx += dx * dx;
+    sy += dy * dy;
+  }
+  const denom = Math.sqrt(sx * sy);
+  return denom === 0 ? NaN : num / denom;
 }
 
 function marketProbability(entry) {

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 // @ts-check
 //
-// Shadow bet-engine seeder (Phase 1 / #5233 re-engine).
+// Shadow bet-engine seeder (Phase 2 / #5238 re-engine).
 //
-// Reads resolvable energy feeds, generates crisp resolution-bound bets via the
-// template registry, attaches a base-rate probability, and appends them to a
-// SHADOW stream `forecast:bets:history:v1` tagged generationOrigin 'bet_engine'.
-// It NEVER writes the user-facing canonical (forecast:predictions:v2) — shadow
-// bets are invisible to users but ingested by the resolver so they score into
-// the scorecard's byGenerationOrigin='bet_engine' slice (the Gate-1 evidence).
+// Reads resolvable energy, prediction-market, and FRED macro feeds, generates
+// crisp resolution-bound bets via the template registry, attaches a calibrated
+// ensemble probability (or base-rate when ENSEMBLE_ENABLED=false for Stage A),
+// and appends them to a SHADOW stream `forecast:bets:history:v1` tagged
+// generationOrigin 'bet_engine'. It NEVER writes the user-facing canonical
+// (forecast:predictions:v2) — shadow bets are invisible to users but ingested
+// by the resolver so they score into scorecard.byGenerationOrigin='bet_engine'.
 // Railway cron; mirrors the seed-forecast-resolutions service.
+//
+// Stage A (Gate 1.5): BET_ENGINE_ENSEMBLE_ENABLED=false (default) — base-rate only.
+// Stage B (Gate 2):   BET_ENGINE_ENSEMBLE_ENABLED=true  — 3-pass LLM ensemble.
 
 import {
   loadEnvFile, getRedisCredentials, CHROME_UA, writeFreshnessMetadata,
@@ -18,14 +22,22 @@ import {
 import { generateBets } from './_bet-templates.mjs';
 import { ENERGY_BET_TEMPLATES, EIA_PETROLEUM_FEED } from './_bet-templates-energy.mjs';
 import { COMMODITY_BET_TEMPLATES, COMMODITY_FEED } from './_bet-templates-commodities.mjs';
+import { buildMarketTemplates, MARKETS_BOOTSTRAP_FEED, MARKETS_RESOLUTION_FEED } from './_bet-templates-markets.mjs';
+import { MACRO_BET_TEMPLATES, MACRO_FEEDS } from './_bet-templates-macro.mjs';
 import { baseRateProbability } from './_bet-baserate.mjs';
 import { parseMetricKey } from './_forecast-resolution-eval.mjs';
+import { runEnsemble } from './_forecast-ensemble.mjs';
 import { BETS_HISTORY_KEY } from './_forecast-bets-keys.mjs';
+// callForecastLLM is imported lazily (only used when ENSEMBLE_ENABLED=true) to
+// keep Stage A free of the 19k-line seed-forecasts dependency in tests.
+import { callForecastLLM } from './seed-forecasts.mjs';
 
 const DIRECT_RUN = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
 if (DIRECT_RUN) loadEnvFile(import.meta.url);
 
 export { BETS_HISTORY_KEY };
+export { MARKETS_RESOLUTION_FEED };
+
 // Rolling per-metric observation series that the base rate is computed over.
 // Deduped by the feed's own `asOf` release date so a daily cron on a weekly
 // feed accumulates ONE point per real EIA release (not seven zero-deltas).
@@ -40,11 +52,24 @@ const BETS_TTL_SECONDS = 45 * 24 * 60 * 60;
 const SERIES_TTL_SECONDS = 400 * 24 * 60 * 60;
 const SERIES_CAP = 104; // ~2 years of weekly EIA releases
 const EIA_METRICS = ['inventory', 'production', 'wti', 'brent'];
-// All template families + the feeds they read. Energy (EIA, weekly) has an
-// accumulator-backed base rate; commodities (daily prices) are the fast-
-// resolving lane and use the thin-history prior until their own series accrues.
-const ALL_BET_TEMPLATES = [...ENERGY_BET_TEMPLATES, ...COMMODITY_BET_TEMPLATES];
-const BET_FEEDS = [EIA_PETROLEUM_FEED, COMMODITY_FEED];
+
+// ── Stage flags ───────────────────────────────────────────────────────────
+// Stage A (Gate 1.5): ensemble off — base-rate probability only.
+// Stage B (Gate 2):   set BET_ENGINE_ENSEMBLE_ENABLED=true to activate.
+const ENSEMBLE_ENABLED = process.env.BET_ENGINE_ENSEMBLE_ENABLED === 'true';
+// Per-run budget for the ensemble phase (3 passes × 35s, with concurrency).
+const ENSEMBLE_RUN_BUDGET_MS = 120_000;
+// Top-K bets selected by userValueScore desc before ensemble is applied.
+// Env-tunable: BET_ENGINE_TOP_K (min 1, max 20).
+const TOP_K = Math.min(20, Math.max(1, Number(process.env.BET_ENGINE_TOP_K) || 6));
+
+// ── Feed registry ─────────────────────────────────────────────────────────
+// All template families + the feeds they read.
+// Market templates are built dynamically from the bootstrap feed at run time
+// (one template per live market), so they are NOT in this static list.
+const STATIC_BET_TEMPLATES = [...ENERGY_BET_TEMPLATES, ...COMMODITY_BET_TEMPLATES, ...MACRO_BET_TEMPLATES];
+const BET_FEEDS = [EIA_PETROLEUM_FEED, COMMODITY_FEED, MARKETS_BOOTSTRAP_FEED, ...MACRO_FEEDS];
+
 
 // Per-feed generation freshness contract. A live-price feed (commodities) kept
 // warm through a multi-day outage (extendExistingTtl preserves the old
@@ -107,18 +132,97 @@ export function buildBetsSnapshot(feedsByKey, nowMs, priorSeries = {}) {
   const fresh = filterFreshFeeds(feedsByKey, nowMs);
   const unwrapped = unwrapFeeds(fresh);
   const series = computeNextSeries(fresh, priorSeries);
-  const bets = generateBets(ALL_BET_TEMPLATES, unwrapped, nowMs);
-  for (const bet of bets) {
+
+  // Dynamic market templates: built from the bootstrap feed each run.
+  const marketFeed = unwrapped[MARKETS_BOOTSTRAP_FEED];
+  const marketTemplates = marketFeed ? buildMarketTemplates(marketFeed, nowMs) : [];
+
+  const allTemplates = [...STATIC_BET_TEMPLATES, ...marketTemplates];
+  const allBets = generateBets(allTemplates, unwrapped, nowMs);
+
+  // Attach base-rate probabilities to every bet (used both in Stage A and as
+  // the scorecard's baselineProbability in Stage B for Brier comparison).
+  // calibration is already emitted by generateBets() via template.buildCalibration (KTD5).
+  for (const bet of allBets) {
     const parsed = parseMetricKey(bet.resolution?.metricKey);
-    // Base rate is computed over the accumulated series keyed by the metric
-    // subject (EIA metric name). Commodity symbols have no accumulator yet, so
-    // their series is empty → baseRateProbability returns the honest prior.
     const values = (series[parsed?.value] || []).map((p) => Number(p.v)).filter(Number.isFinite);
     const { probability } = baseRateProbability(values, bet.resolution);
-    bet.probability = probability;
+    bet._baseRateProbability = probability;
   }
-  return { generatedAt: nowMs, predictions: bets };
+
+  // Sort by userValueScore desc, take top-K.
+  const sorted = [...allBets].sort((a, b) => (Number(b.userValueScore) || 0) - (Number(a.userValueScore) || 0));
+  const topK = sorted.slice(0, TOP_K);
+
+  // Stage A: base-rate only.
+  for (const bet of topK) {
+    bet.probability = bet._baseRateProbability;
+    bet.baselineProbability = bet._baseRateProbability;
+    bet.probabilitySource = 'base_rate';
+    delete bet._baseRateProbability;
+  }
+
+  return { generatedAt: nowMs, predictions: topK };
 }
+
+// Stage B: attach ensemble probabilities to each bet in the snapshot.
+// Returns a new snapshot with updated probabilities and pass metadata.
+// This is async (3 LLM calls per bet in parallel).
+export async function applyEnsembleProbabilities(snapshot, feedsByKey) {
+  if (!snapshot?.predictions?.length) return snapshot;
+  const nowMs = snapshot.generatedAt || Date.now();
+  const deadline = Date.now() + ENSEMBLE_RUN_BUDGET_MS;
+
+  const updated = await Promise.allSettled(
+    snapshot.predictions.map(async (bet) => {
+      if (Date.now() > deadline) {
+        // Budget exhausted — keep base-rate for this bet.
+        return bet;
+      }
+      const context = buildBetContext(bet, feedsByKey);
+      try {
+        const result = await runEnsemble(
+          bet.resolution?.question || bet.question,
+          context,
+          callForecastLLM,
+          { baseRateFallback: bet.baselineProbability, budgetMs: 35_000 },
+        );
+        return {
+          ...bet,
+          probability: result.probability,
+          probabilitySource: result.method === 'ensemble' ? 'ensemble' : 'base_rate',
+          passes: result.passes,
+          // baselineProbability is already set from Stage A; keep it for scorecard.
+        };
+      } catch {
+        // All-fail with no baseRateFallback should not happen (we always pass one),
+        // but guard defensively: keep the base-rate.
+        return bet;
+      }
+    }),
+  );
+
+  const predictions = updated.map((r, i) =>
+    r.status === 'fulfilled' ? r.value : snapshot.predictions[i],
+  );
+  return { ...snapshot, predictions };
+}
+
+function buildBetContext(bet, feedsByKey) {
+  const parts = [];
+  if (bet.resolution?.question) parts.push(bet.resolution.question);
+  // Add a brief snippet of the feed value as grounding context.
+  const feedKey = bet.resolution?.sourceFeed;
+  const feedData = feedsByKey?.[feedKey];
+  const baseline = bet.resolution?.baselineValue;
+  if (Number.isFinite(baseline)) parts.push(`Current value: ${baseline}`);
+  if (feedData) {
+    const ts = feedData?._seed?.fetchedAt || feedData?.fetchedAt;
+    if (ts) parts.push(`Data as of: ${new Date(Number(ts)).toISOString().slice(0, 10)}`);
+  }
+  return parts.join('. ').slice(0, 400);
+}
+
 
 async function redisPipeline(command) {
   const { url, token } = getRedisCredentials();
@@ -150,7 +254,17 @@ async function main() {
 
   const priorSeries = (await readRedisJson(BETS_SERIES_KEY).catch(() => null)) || {};
   const nowMs = Date.now();
-  const snapshot = buildBetsSnapshot(feedsByKey, nowMs, priorSeries);
+  let snapshot = buildBetsSnapshot(feedsByKey, nowMs, priorSeries);
+
+  if (ENSEMBLE_ENABLED && snapshot.predictions.length > 0) {
+    console.log(`  [bets] ensemble enabled: scoring ${snapshot.predictions.length} bet(s) ...`);
+    snapshot = await applyEnsembleProbabilities(snapshot, feedsByKey);
+    const ensembleCount = snapshot.predictions.filter((b) => b.probabilitySource === 'ensemble').length;
+    console.log(`  [bets] ensemble: ${ensembleCount}/${snapshot.predictions.length} used ensemble (rest: base_rate fallback)`);
+  } else if (ENSEMBLE_ENABLED) {
+    console.log('  [bets] ensemble enabled but no bets generated — skipping LLM calls');
+  }
+
   const nextSeries = computeNextSeries(feedsByKey, priorSeries);
   const count = snapshot.predictions.length;
 
@@ -167,9 +281,15 @@ async function main() {
         return acc;
       }, {});
       const breakdown = Object.entries(byDomain).map(([d, n]) => `${d}:${n}`).join(', ');
-      console.log(`  [bets] published ${count} shadow bet(s) [${breakdown}] -> ${BETS_HISTORY_KEY}`);
+      const srcBreakdown = snapshot.predictions.reduce((acc, b) => {
+        const src = b.probabilitySource || 'unknown';
+        acc[src] = (acc[src] || 0) + 1;
+        return acc;
+      }, {});
+      const srcStr = Object.entries(srcBreakdown).map(([s, n]) => `${s}:${n}`).join(', ');
+      console.log(`  [bets] published ${count} shadow bet(s) [domain: ${breakdown}] [source: ${srcStr}] -> ${BETS_HISTORY_KEY}`);
       for (const bet of snapshot.predictions) {
-        console.log(`    - ${bet.question} (p=${bet.probability})`);
+        console.log(`    - ${bet.question} (p=${bet.probability}, src=${bet.probabilitySource})`);
       }
     } else {
       console.warn('  [bets] no bets generated (feeds absent/unusable); nothing appended');
@@ -180,6 +300,7 @@ async function main() {
     process.exit(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
   }
 }
+
 
 if (DIRECT_RUN) {
   main().catch((err) => {

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -42,6 +42,12 @@ export { MARKETS_RESOLUTION_FEED };
 // Deduped by the feed's own `asOf` release date so a daily cron on a weekly
 // feed accumulates ONE point per real EIA release (not seven zero-deltas).
 export const BETS_SERIES_KEY = 'forecast:bets:eia-series:v1';
+// Persistent registry of ALL market slugs ever generated, keyed forever so
+// the settlement seeder can query them even after they age out of the 200-run
+// bets-history window. TTL = 90d (matches RESOLUTION_TTL_SECONDS in settlement
+// seeder). The seeder merges new slugs in on each run (P1 fix).
+export const MARKET_SLUGS_KEY = 'forecast:bets:market-slugs:v1';
+export const MARKET_SLUGS_TTL_SECONDS = 90 * 24 * 60 * 60;
 const BETS_MAX_RUNS = 200;
 // 45d TTL mirrors the predictions-history reach so the resolver's LRANGE 200
 // window can always find a bet before it rolls out; well under the ledger's
@@ -143,11 +149,19 @@ export function buildBetsSnapshot(feedsByKey, nowMs, priorSeries = {}) {
   // Attach base-rate probabilities to every bet (used both in Stage A and as
   // the scorecard's baselineProbability in Stage B for Brier comparison).
   // calibration is already emitted by generateBets() via template.buildCalibration (KTD5).
+  // P1 fix: for FRED bets the EIA accumulator has no entries — use the template's
+  // own historical observations (stored as bet._baseRateHistory by generateBets).
   for (const bet of allBets) {
     const parsed = parseMetricKey(bet.resolution?.metricKey);
-    const values = (series[parsed?.value] || []).map((p) => Number(p.v)).filter(Number.isFinite);
+    const accumulatorValues = (series[parsed?.value] || []).map((p) => Number(p.v)).filter(Number.isFinite);
+    // Prefer accumulator (rich, release-deduped); fall back to template history
+    // (from metric.observations — up to 24 FRED obs) when accumulator is empty.
+    const values = accumulatorValues.length > 0
+      ? accumulatorValues
+      : (Array.isArray(bet._baseRateHistory) ? bet._baseRateHistory : []);
     const { probability } = baseRateProbability(values, bet.resolution);
     bet._baseRateProbability = probability;
+    delete bet._baseRateHistory; // clean up before top-K snapshot
   }
 
   // Sort by userValueScore desc, take top-K.
@@ -276,6 +290,21 @@ async function main() {
       await redisPipeline(['LTRIM', BETS_HISTORY_KEY, 0, BETS_MAX_RUNS - 1]);
       await redisPipeline(['EXPIRE', BETS_HISTORY_KEY, BETS_TTL_SECONDS]);
       await redisPipeline(['SET', BETS_SERIES_KEY, JSON.stringify(nextSeries), 'EX', SERIES_TTL_SECONDS]);
+
+      // P1 fix: persist market slugs in a long-lived registry so the settlement
+      // seeder can find them even after they age out of the 200-run bets-history
+      // window. Merge new slugs with any existing ones (idempotent — a Set dedupes).
+      const newSlugs = snapshot.predictions
+        .filter((b) => b.domain === 'prediction_market' && b.resolution?.marketSlug)
+        .map((b) => b.resolution.marketSlug);
+      if (newSlugs.length > 0) {
+        const existingSlugsRaw = await readRedisJson(MARKET_SLUGS_KEY).catch(() => null);
+        const existingSlugs = Array.isArray(existingSlugsRaw) ? existingSlugsRaw : [];
+        const mergedSlugs = [...new Set([...existingSlugs, ...newSlugs])];
+        await redisPipeline(['SET', MARKET_SLUGS_KEY, JSON.stringify(mergedSlugs), 'EX', MARKET_SLUGS_TTL_SECONDS]);
+        console.log(`  [bets] slug registry: ${mergedSlugs.length} market slug(s) persisted -> ${MARKET_SLUGS_KEY}`);
+      }
+
       const byDomain = snapshot.predictions.reduce((acc, b) => {
         acc[b.domain] = (acc[b.domain] || 0) + 1;
         return acc;

--- a/scripts/seed-forecast-resolutions.mjs
+++ b/scripts/seed-forecast-resolutions.mjs
@@ -960,6 +960,7 @@ function hasSampleAtOrAfterDeadline(samples, deadline) {
 
 function createEntry(id, forecast, spec, generatedAt, snapshotAt, deadline) {
   const status = spec.kind === 'judged' ? 'pending-judge' : 'pending';
+  const baselineProbability = Number(forecast.baselineProbability);
   return pruneUndefined({
     id,
     key: `${id}@${deadline}`,
@@ -971,6 +972,11 @@ function createEntry(id, forecast, spec, generatedAt, snapshotAt, deadline) {
     spec: cloneJson(spec),
     probability: Number(forecast.probability),
     firstSeenProbability: Number(forecast.probability),
+    // Phase 2 (KTD5): persist ensemble metadata so scorecard can compare against
+    // base-rate and updateOpenWindow can refuse to overwrite ensemble with base-rate.
+    baselineProbability: Number.isFinite(baselineProbability) ? baselineProbability : undefined,
+    probabilitySource: forecast.probabilitySource || undefined,
+    passes: Array.isArray(forecast.passes) ? cloneJson(forecast.passes) : undefined,
     calibration: forecast.calibration ? cloneJson(forecast.calibration) : undefined,
     generatedAt,
     deadline,
@@ -985,7 +991,16 @@ function updateOpenWindow(entry, forecast, generatedAt, snapshotAt) {
   if (entry.status !== 'pending' && entry.status !== 'pending-judge') return;
   if (generatedAt >= entry.deadline) return;
   const probability = Number(forecast.probability);
-  if (Number.isFinite(probability)) entry.probability = probability;
+  // KTD5: never overwrite an ensemble probability with a later base-rate run.
+  // Once a window has been scored by the ensemble (probabilitySource === 'ensemble'),
+  // a subsequent base-rate-only run must not silently replace it with a less
+  // calibrated value and corrupt the Gate-2 measurement.
+  const currIsEnsemble = entry.probabilitySource === 'ensemble';
+  const incomingIsBaseRate = forecast.probabilitySource !== 'ensemble';
+  if (Number.isFinite(probability) && !(currIsEnsemble && incomingIsBaseRate)) {
+    entry.probability = probability;
+    if (forecast.probabilitySource) entry.probabilitySource = forecast.probabilitySource;
+  }
   entry.lastSeenAt = Math.max(Number(entry.lastSeenAt || 0), snapshotAt);
 }
 
@@ -1105,6 +1120,31 @@ export function shapeResolutionFeed(key, data) {
       return d.quotes.map((q) => (q && typeof q === 'object' && Number.isFinite(fetchedAt) ? { ...q, asOf: fetchedAt } : q));
     }
     return d;
+  }
+  if (key === 'prediction:markets-resolution:v1') {
+    // Settlement feed written by the markets-resolution seeder (Gamma closed:true).
+    // Shape: [{market: slug, yesPrice: 0|100}] — the resolver reads
+    // yesPrice(market==<slug>) and resolves YES when yesPrice >= threshold (50).
+    const d = data?.data ?? data;
+    return Array.isArray(d) ? d : [];
+  }
+  if (typeof key === 'string' && key.startsWith('economic:fred:v1:')) {
+    // FRED series stored as { series: { seriesId, observations: [{date, value}] } }.
+    // The eval's value() fn needs a record with { series, value, asOf }.
+    // Unwrap {series:{observations}} and return the latest valid observation.
+    const d = data?.data ?? data;
+    const obs = d?.series?.observations ?? d?.observations;
+    if (!Array.isArray(obs)) return data;
+    // Scan backwards for the latest non-null value (FRED appends `.` sentinels).
+    for (let i = obs.length - 1; i >= 0; i--) {
+      const o = obs[i];
+      const v = Number(o?.value);
+      if (Number.isFinite(v) && typeof o.date === 'string') {
+        const seriesId = d?.series?.seriesId ?? key.split(':')[3] ?? key;
+        return [{ series: seriesId, value: v, asOf: o.date }];
+      }
+    }
+    return [];
   }
   return data;
 }

--- a/scripts/seed-prediction-market-resolutions.mjs
+++ b/scripts/seed-prediction-market-resolutions.mjs
@@ -22,9 +22,10 @@
 // Railway cron: runs alongside seed-forecast-bets (30 min interval).
 // Graceful exit on any Upstash/API transient: self-heals next run.
 
-import { loadEnvFile, CHROME_UA, getRedisCredentials, GRACEFUL_FETCH_FAILURE_EXIT_CODE } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, GRACEFUL_FETCH_FAILURE_EXIT_CODE, writeFreshnessMetadata } from './_seed-utils.mjs';
 import { BETS_HISTORY_KEY } from './_forecast-bets-keys.mjs';
 import { MARKETS_RESOLUTION_FEED } from './_bet-templates-markets.mjs';
+import { MARKET_SLUGS_KEY, MARKET_SLUGS_TTL_SECONDS } from './seed-forecast-bets.mjs';
 
 const DIRECT_RUN = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
 if (DIRECT_RUN) loadEnvFile(import.meta.url);
@@ -144,13 +145,29 @@ async function readRedisJson(key) {
 // ── Slug extraction from bets history ────────────────────────────────────
 
 /**
- * Read up to HISTORY_SCAN_RUNS snapshots from the bets history and collect all
- * unique prediction_market slugs whose bets are still pending.
+ * Read all pending market slugs from the persistent slug registry.
+ * Falls back to scanning bets history if the registry key is absent (first run
+ * before any bets seeder write has populated it).
+ * P1 fix: the registry (written by seed-forecast-bets.mjs on every run) retains
+ * slugs for 90d regardless of how many bets-history snapshots have rolled over.
  */
 async function collectPendingMarketSlugs() {
   const slugs = new Set();
+
+  // Primary: persistent slug registry (P1 fix).
   try {
-    const raw = await redisPipeline(['LRANGE', BETS_HISTORY_KEY, 0, HISTORY_SCAN_RUNS - 1]);
+    const registryRaw = await readRedisJson(MARKET_SLUGS_KEY);
+    if (Array.isArray(registryRaw)) {
+      for (const s of registryRaw) if (typeof s === 'string') slugs.add(s);
+      if (slugs.size > 0) return slugs; // registry is authoritative
+    }
+  } catch (err) {
+    console.warn(`  [settlement] registry read error: ${err.message}; falling back to history scan`);
+  }
+
+  // Fallback: scan bets history (covers the period before registry is populated).
+  try {
+    const raw = await redisPipeline(['LRANGE', BETS_HISTORY_KEY, 0, 199]);
     if (!Array.isArray(raw)) return slugs;
     for (const item of raw) {
       let snapshot;
@@ -163,7 +180,7 @@ async function collectPendingMarketSlugs() {
       }
     }
   } catch (err) {
-    console.warn(`  [settlement] error reading bets history: ${err.message}`);
+    console.warn(`  [settlement] bets history scan error: ${err.message}`);
   }
   return slugs;
 }
@@ -221,7 +238,9 @@ async function main() {
 
   try {
     await redisPipeline(['SET', MARKETS_RESOLUTION_FEED, JSON.stringify(merged), 'EX', RESOLUTION_TTL_SECONDS]);
-    console.log(`  [settlement] wrote ${merged.length} settlement record(s) → ${MARKETS_RESOLUTION_FEED} (${RESOLUTION_TTL_SECONDS}s TTL)`);
+    console.log(`  [settlement] wrote ${merged.length} settlement record(s) -> ${MARKETS_RESOLUTION_FEED} (${RESOLUTION_TTL_SECONDS}s TTL)`);
+    // P2 fix: publish standard freshness metadata so monitoring can detect a stalled settlement job.
+    await writeFreshnessMetadata('forecast', 'bets-settlement', settlements.length, 'prediction-market-resolutions:v1', RESOLUTION_TTL_SECONDS);
   } catch (err) {
     console.warn(`  [settlement] redis write failed (transient — graceful exit): ${err.message}`);
     process.exit(GRACEFUL_FETCH_FAILURE_EXIT_CODE);

--- a/scripts/seed-prediction-market-resolutions.mjs
+++ b/scripts/seed-prediction-market-resolutions.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// Prediction-market settlement seeder (Phase 2 / #5238 U11 — settlement half).
+//
+// Reads the bet-engine's BETS_HISTORY_KEY for any pending prediction-market
+// bets, extracts their market slugs, queries Gamma (Polymarket) and Kalshi for
+// CLOSED prices, and writes the results to prediction:markets-resolution:v1.
+// This is the write side of the KTD2 settlement feed; the bet-engine's
+// _bet-templates-markets.mjs is the read side.
+//
+// Architecture (mirrors ACLED precedent in seed-acled-conflict.mjs):
+//   - Bootstrap feed  (seed-prediction-markets.mjs) → closed:false → open markets
+//   - Settlement feed (this script)                 → closed:true  → settled prices
+//
+// Settlement shape written to prediction:markets-resolution:v1:
+//   [{ market: "<slug>", yesPrice: 0|100, settledAt: "<ISO>" }, ...]
+//
+// The resolver's shapeResolutionFeed reads Array.isArray(d) ? d : [] and the
+// eval's yesPrice(market==<slug>) function matches on the `market` field.
+//
+// Railway cron: runs alongside seed-forecast-bets (30 min interval).
+// Graceful exit on any Upstash/API transient: self-heals next run.
+
+import { loadEnvFile, CHROME_UA, getRedisCredentials, GRACEFUL_FETCH_FAILURE_EXIT_CODE } from './_seed-utils.mjs';
+import { BETS_HISTORY_KEY } from './_forecast-bets-keys.mjs';
+import { MARKETS_RESOLUTION_FEED } from './_bet-templates-markets.mjs';
+
+const DIRECT_RUN = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+if (DIRECT_RUN) loadEnvFile(import.meta.url);
+
+const GAMMA_BASE = 'https://gamma-api.polymarket.com';
+const KALSHI_BASE = 'https://api.elections.kalshi.com/trade-api/v2';
+const FETCH_TIMEOUT = 10_000;
+// Keep resolved market prices for 90d so the resolver can settle bets.
+const RESOLUTION_TTL_SECONDS = 90 * 24 * 60 * 60;
+// Maximum number of BETS_HISTORY_KEY snapshots to scan for pending market slugs.
+const HISTORY_SCAN_RUNS = 20;
+
+// ── Slug resolution ───────────────────────────────────────────────────────
+
+/** @returns {{ source: 'polymarket'|'kalshi', id: string } | null} */
+function parseSlug(slug) {
+  if (typeof slug !== 'string') return null;
+  const [source, ...rest] = slug.split(':');
+  if (!rest.length) return null;
+  return { source, id: rest.join(':') };
+}
+
+// ── Gamma (Polymarket) settlement ─────────────────────────────────────────
+
+/**
+ * Query Gamma for a single event by slug. Returns settled yesPrice (0 or 100)
+ * or null if not yet settled.
+ * @param {string} eventSlug  e.g. "will-x-happen"
+ */
+async function fetchGammaSettlement(eventSlug) {
+  try {
+    const params = new URLSearchParams({ slug: eventSlug });
+    const resp = await fetch(`${GAMMA_BASE}/events?${params}`, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
+    if (!resp.ok) {
+      console.warn(`  [settlement:polymarket] HTTP ${resp.status} for slug ${eventSlug}`);
+      return null;
+    }
+    const data = await resp.json();
+    const events = Array.isArray(data) ? data : [];
+    const event = events.find((e) => e.slug === eventSlug);
+    if (!event) return null;
+    // Settled market: resolved is true and the winning outcome's price is 1.0 (100).
+    if (!event.resolved) return null;
+    // Find the resolved outcome.
+    const markets = Array.isArray(event.markets) ? event.markets : [];
+    const yes = markets.find((m) => m.outcomePrices && Array.isArray(m.outcomes)
+      && m.outcomes.some((o) => (o === 'Yes' || o === 'YES')));
+    if (!yes) return null;
+    const outcomePrices = Array.isArray(yes.outcomePrices) ? yes.outcomePrices : [];
+    const yesIndex = (yes.outcomes || []).findIndex((o) => o === 'Yes' || o === 'YES');
+    const rawPrice = yesIndex >= 0 ? Number(outcomePrices[yesIndex]) : NaN;
+    // Polymarket prices are [0,1] fractions. Convert to 0|100.
+    const yesPrice = Number.isFinite(rawPrice) ? (rawPrice >= 0.5 ? 100 : 0) : null;
+    if (yesPrice === null) return null;
+    const settledAt = event.endDate || event.end_date_iso || new Date().toISOString();
+    return { yesPrice, settledAt };
+  } catch (err) {
+    console.warn(`  [settlement:polymarket] error for ${eventSlug}: ${err.message}`);
+    return null;
+  }
+}
+
+// ── Kalshi settlement ─────────────────────────────────────────────────────
+
+/**
+ * Query Kalshi for a single market by ticker. Returns settled yesPrice or null.
+ * @param {string} ticker  e.g. "FED-25DEC"
+ */
+async function fetchKalshiSettlement(ticker) {
+  try {
+    const resp = await fetch(`${KALSHI_BASE}/markets/${encodeURIComponent(ticker)}`, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
+    if (!resp.ok) {
+      console.warn(`  [settlement:kalshi] HTTP ${resp.status} for ticker ${ticker}`);
+      return null;
+    }
+    const data = await resp.json();
+    const market = data?.market ?? data;
+    if (!market || market.status !== 'settled') return null;
+    // Kalshi result: 'yes'|'no' in market.result.
+    const result = String(market.result || '').toLowerCase();
+    if (result !== 'yes' && result !== 'no') return null;
+    const yesPrice = result === 'yes' ? 100 : 0;
+    const settledAt = market.close_time || new Date().toISOString();
+    return { yesPrice, settledAt };
+  } catch (err) {
+    console.warn(`  [settlement:kalshi] error for ${ticker}: ${err.message}`);
+    return null;
+  }
+}
+
+// ── Redis helpers ─────────────────────────────────────────────────────────
+
+async function redisPipeline(command) {
+  const { url, token } = getRedisCredentials();
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+    body: JSON.stringify(command),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`Redis ${command[0]} failed: HTTP ${resp.status}`);
+  return (await resp.json())?.result ?? null;
+}
+
+async function readRedisJson(key) {
+  const result = await redisPipeline(['GET', key]);
+  if (result == null) return null;
+  try { return JSON.parse(result); } catch { return null; }
+}
+
+// ── Slug extraction from bets history ────────────────────────────────────
+
+/**
+ * Read up to HISTORY_SCAN_RUNS snapshots from the bets history and collect all
+ * unique prediction_market slugs whose bets are still pending.
+ */
+async function collectPendingMarketSlugs() {
+  const slugs = new Set();
+  try {
+    const raw = await redisPipeline(['LRANGE', BETS_HISTORY_KEY, 0, HISTORY_SCAN_RUNS - 1]);
+    if (!Array.isArray(raw)) return slugs;
+    for (const item of raw) {
+      let snapshot;
+      try { snapshot = typeof item === 'string' ? JSON.parse(item) : item; } catch { continue; }
+      const predictions = Array.isArray(snapshot?.predictions) ? snapshot.predictions : [];
+      for (const bet of predictions) {
+        if (bet?.domain !== 'prediction_market') continue;
+        const slug = bet?.resolution?.marketSlug;
+        if (typeof slug === 'string') slugs.add(slug);
+      }
+    }
+  } catch (err) {
+    console.warn(`  [settlement] error reading bets history: ${err.message}`);
+  }
+  return slugs;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const pendingSlugs = await collectPendingMarketSlugs();
+  if (pendingSlugs.size === 0) {
+    console.log('  [settlement] no pending prediction-market slugs found; nothing to settle');
+    return;
+  }
+  console.log(`  [settlement] checking ${pendingSlugs.size} market slug(s) for settlement...`);
+
+  const settlements = [];
+  const nowMs = Date.now();
+
+  for (const slug of pendingSlugs) {
+    const parsed = parseSlug(slug);
+    if (!parsed) {
+      console.warn(`  [settlement] unrecognised slug format: ${slug}`);
+      continue;
+    }
+
+    let result = null;
+    if (parsed.source === 'polymarket') {
+      result = await fetchGammaSettlement(parsed.id);
+    } else if (parsed.source === 'kalshi') {
+      result = await fetchKalshiSettlement(parsed.id);
+    } else {
+      console.warn(`  [settlement] unknown source '${parsed.source}' in slug: ${slug}`);
+    }
+
+    if (result) {
+      settlements.push({ market: slug, yesPrice: result.yesPrice, settledAt: result.settledAt });
+      console.log(`  [settlement] ${slug} → yesPrice=${result.yesPrice} (settled ${result.settledAt})`);
+    }
+  }
+
+  if (settlements.length === 0) {
+    console.log('  [settlement] no markets settled yet; nothing written');
+    return;
+  }
+
+  // Merge with any existing settlements so we don't lose previously settled markets.
+  let existing = [];
+  try {
+    existing = (await readRedisJson(MARKETS_RESOLUTION_FEED)) ?? [];
+    if (!Array.isArray(existing)) existing = [];
+  } catch { existing = []; }
+
+  const bySlug = new Map(existing.map((s) => [s.market, s]));
+  for (const s of settlements) bySlug.set(s.market, s);
+  const merged = [...bySlug.values()];
+
+  try {
+    await redisPipeline(['SET', MARKETS_RESOLUTION_FEED, JSON.stringify(merged), 'EX', RESOLUTION_TTL_SECONDS]);
+    console.log(`  [settlement] wrote ${merged.length} settlement record(s) → ${MARKETS_RESOLUTION_FEED} (${RESOLUTION_TTL_SECONDS}s TTL)`);
+  } catch (err) {
+    console.warn(`  [settlement] redis write failed (transient — graceful exit): ${err.message}`);
+    process.exit(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+  }
+}
+
+if (DIRECT_RUN) {
+  main().catch((err) => {
+    console.error(`[settlement] fatal: ${err instanceof Error ? err.stack || err.message : String(err)}`);
+    process.exit(1);
+  });
+}
+
+export { collectPendingMarketSlugs, parseSlug };

--- a/tests/bet-templates-macro.test.mjs
+++ b/tests/bet-templates-macro.test.mjs
@@ -1,0 +1,168 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { extractFredObservations, MACRO_BET_TEMPLATES, MACRO_FEEDS } from '../scripts/_bet-templates-macro.mjs';
+import { generateBets } from '../scripts/_bet-templates.mjs';
+import { RESOLUTION_FEED_KEYS } from '../scripts/_forecast-resolution.mjs';
+import { FRED_VALUE_SETTLEMENT_MAX_LAG_MS } from '../scripts/_forecast-resolution-eval.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-24T00:00:00Z');
+
+// ── extractFredObservations (#5098 P1 regression) ──────────────────────────
+
+describe('extractFredObservations', () => {
+  it('unwraps {series:{observations}} — the primary shape from seed-economy.mjs', () => {
+    const feed = {
+      data: {
+        series: {
+          seriesId: 'FEDFUNDS',
+          observations: [{ date: '2026-06-01', value: 5.33 }],
+        },
+      },
+    };
+    const obs = extractFredObservations(feed);
+    assert.ok(Array.isArray(obs));
+    assert.equal(obs.length, 1);
+    assert.equal(obs[0].value, 5.33);
+  });
+
+  it('also handles the flat {observations} shape (legacy / ais-relay)', () => {
+    const feed = { observations: [{ date: '2026-06-01', value: 4.5 }] };
+    const obs = extractFredObservations(feed);
+    assert.ok(Array.isArray(obs));
+    assert.equal(obs[0].value, 4.5);
+  });
+
+  it('returns null when the feed is empty', () => {
+    assert.equal(extractFredObservations(null), null);
+    assert.equal(extractFredObservations({}), null);
+    assert.equal(extractFredObservations({ data: {} }), null);
+  });
+
+  it('returns null when observations is not an array', () => {
+    const feed = { data: { series: { seriesId: 'FEDFUNDS', observations: 'bad' } } };
+    assert.equal(extractFredObservations(feed), null);
+  });
+});
+
+// ── MACRO_FEEDS / allowlist parity ─────────────────────────────────────────
+
+describe('MACRO_FEEDS', () => {
+  it('lists 4 FRED feed keys', () => {
+    assert.equal(MACRO_FEEDS.length, 4);
+  });
+
+  it('every MACRO_FEEDS key is in RESOLUTION_FEED_KEYS (exact-match allowlist, KTD4)', () => {
+    for (const key of MACRO_FEEDS) {
+      assert.ok(
+        RESOLUTION_FEED_KEYS.has(key),
+        `Expected '${key}' in RESOLUTION_FEED_KEYS but it was missing`,
+      );
+    }
+  });
+});
+
+// ── FRED_VALUE_SETTLEMENT_MAX_LAG_MS ─────────────────────────────────────────
+
+describe('FRED_VALUE_SETTLEMENT_MAX_LAG_MS', () => {
+  it('is 75 days (monthly obs worst-case lag, KTD4)', () => {
+    assert.equal(FRED_VALUE_SETTLEMENT_MAX_LAG_MS, 75 * DAY_MS);
+  });
+});
+
+// ── generateBets with FRED feeds ──────────────────────────────────────────
+
+function fredFeedFixture(seriesId, latestValue, previousValue = null) {
+  const observations = [];
+  if (previousValue !== null) {
+    observations.push({ date: '2026-05-01', value: previousValue });
+  }
+  observations.push({ date: '2026-06-01', value: latestValue });
+  return {
+    data: {
+      series: { seriesId, observations },
+    },
+  };
+}
+
+describe('generateBets with MACRO_BET_TEMPLATES', () => {
+  it('generates at least one FEDFUNDS bet when feed is valid', () => {
+    const feedsByKey = {
+      'economic:fred:v1:FEDFUNDS:0': fredFeedFixture('FEDFUNDS', 5.33, 5.25),
+    };
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const fredBets = bets.filter((b) => b.id?.includes('fedfunds'));
+    assert.ok(fredBets.length > 0, 'Expected at least one FEDFUNDS bet');
+    const bet = fredBets[0];
+    assert.equal(bet.domain, 'macro');
+    assert.equal(bet.resolution.kind, 'hard');
+    assert.equal(bet.resolution.sourceFeed, 'economic:fred:v1:FEDFUNDS:0');
+    assert.ok(
+      bet.resolution.metricKey.includes('economic:fred:v1:FEDFUNDS:0|value(series==FEDFUNDS)'),
+      `Unexpected metricKey: ${bet.resolution.metricKey}`,
+    );
+  });
+
+  it('generates no bets when the feed has the {series:{observations}} shape missing', () => {
+    // Simulates the #5098 bug: feed without the observations path.
+    const feedsByKey = {
+      'economic:fred:v1:FEDFUNDS:0': { data: { fred_series: { FEDFUNDS: 5.33 } } },
+    };
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const fredBets = bets.filter((b) => b.id?.includes('fedfunds'));
+    assert.equal(fredBets.length, 0);
+  });
+
+  it('sets window=at-deadline for monthly FRED series', () => {
+    const feedsByKey = {
+      'economic:fred:v1:UNRATE:0': fredFeedFixture('UNRATE', 4.1, 4.2),
+    };
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const bet = bets.find((b) => b.id?.includes('unrate'));
+    assert.ok(bet, 'Expected UNRATE bet');
+    assert.equal(bet.resolution.window, 'at-deadline');
+  });
+
+  it('deadline is within 75 days for monthly series (FEDFUNDS)', () => {
+    const feedsByKey = {
+      'economic:fred:v1:FEDFUNDS:0': fredFeedFixture('FEDFUNDS', 5.33, 5.25),
+    };
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const bet = bets.find((b) => b.id?.includes('fedfunds'));
+    assert.ok(bet);
+    const horizonMs = bet.resolution.deadline - NOW;
+    // Monthly horizon is 45d (MONTHLY_HORIZON_MS in _bet-templates-macro.mjs)
+    assert.ok(horizonMs > 0 && horizonMs <= 50 * DAY_MS, `Horizon ${horizonMs / DAY_MS}d out of range`);
+  });
+
+  it('DGS10 deadline is within 14 days (daily series)', () => {
+    const feedsByKey = {
+      'economic:fred:v1:DGS10:0': fredFeedFixture('DGS10', 4.28, 4.20),
+    };
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const bet = bets.find((b) => b.id?.includes('dgs10'));
+    assert.ok(bet, 'Expected DGS10 bet');
+    const horizonMs = bet.resolution.deadline - NOW;
+    assert.ok(horizonMs > 0 && horizonMs <= 14 * DAY_MS + DAY_MS, `Horizon ${horizonMs / DAY_MS}d out of range for daily series`);
+  });
+
+  it('generates no CPIAUCSL bet when feed is absent', () => {
+    const feedsByKey = {};
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const cpi = bets.filter((b) => b.id?.includes('cpiaucsl'));
+    assert.equal(cpi.length, 0);
+  });
+
+  it('threshold direction matches the latest move direction', () => {
+    // Rising rate: threshold should be higher than baseline.
+    const feedsByKey = {
+      'economic:fred:v1:FEDFUNDS:0': fredFeedFixture('FEDFUNDS', 5.50, 5.25), // rising
+    };
+    const bets = generateBets(MACRO_BET_TEMPLATES, feedsByKey, NOW);
+    const bet = bets.find((b) => b.id?.includes('fedfunds'));
+    assert.ok(bet);
+    assert.ok(bet.resolution.threshold >= bet.resolution.baselineValue,
+      `Expected threshold ${bet.resolution.threshold} >= baseline ${bet.resolution.baselineValue} for rising rate`);
+  });
+});

--- a/tests/bet-templates-markets.test.mjs
+++ b/tests/bet-templates-markets.test.mjs
@@ -1,0 +1,160 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { buildMarketTemplates, MARKETS_BOOTSTRAP_FEED, MARKETS_RESOLUTION_FEED } from '../scripts/_bet-templates-markets.mjs';
+import { generateBets } from '../scripts/_bet-templates.mjs';
+import { RESOLUTION_FEED_KEYS } from '../scripts/_forecast-resolution.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-24T00:00:00Z');
+
+// ── Feed key constants ─────────────────────────────────────────────────────
+
+describe('MARKETS_RESOLUTION_FEED', () => {
+  it('is in RESOLUTION_FEED_KEYS (KTD2)', () => {
+    assert.ok(
+      RESOLUTION_FEED_KEYS.has(MARKETS_RESOLUTION_FEED),
+      `Expected '${MARKETS_RESOLUTION_FEED}' in RESOLUTION_FEED_KEYS`,
+    );
+  });
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeMarket(overrides = {}) {
+  return {
+    title: 'Will X happen?',
+    url: 'https://polymarket.com/event/will-x-happen',
+    yesPrice: 55,
+    volume: 10_000,
+    endDate: new Date(NOW + 30 * DAY_MS).toISOString(), // 30 days out
+    source: 'polymarket',
+    ...overrides,
+  };
+}
+
+function bootstrapFeed(markets = [], category = 'geopolitical') {
+  return { [category]: markets };
+}
+
+// ── buildMarketTemplates ───────────────────────────────────────────────────
+
+describe('buildMarketTemplates', () => {
+  it('returns empty array for empty or invalid feed', () => {
+    assert.deepEqual(buildMarketTemplates(null, NOW), []);
+    assert.deepEqual(buildMarketTemplates({}, NOW), []);
+  });
+
+  it('builds one template per qualifying market', () => {
+    const feed = bootstrapFeed([makeMarket(), makeMarket({ url: 'https://polymarket.com/event/other-event', title: 'Will Y happen?' })]);
+    const templates = buildMarketTemplates(feed, NOW);
+    assert.equal(templates.length, 2);
+  });
+
+  it('filters out markets below volume floor (MIN_VOLUME = 5000)', () => {
+    const feed = bootstrapFeed([makeMarket({ volume: 4999 })]);
+    const templates = buildMarketTemplates(feed, NOW);
+    assert.equal(templates.length, 0);
+  });
+
+  it('filters out markets whose yesPrice is outside [10, 90]', () => {
+    const lowFeed = bootstrapFeed([makeMarket({ yesPrice: 9 })]);
+    const highFeed = bootstrapFeed([makeMarket({ yesPrice: 91 })]);
+    assert.equal(buildMarketTemplates(lowFeed, NOW).length, 0);
+    assert.equal(buildMarketTemplates(highFeed, NOW).length, 0);
+  });
+
+  it('filters out markets with endDate beyond 45 days', () => {
+    const feed = bootstrapFeed([makeMarket({ endDate: new Date(NOW + 46 * DAY_MS).toISOString() })]);
+    assert.equal(buildMarketTemplates(feed, NOW).length, 0);
+  });
+
+  it('filters out markets that have already closed (endDate <= nowMs)', () => {
+    const feed = bootstrapFeed([makeMarket({ endDate: new Date(NOW - DAY_MS).toISOString() })]);
+    assert.equal(buildMarketTemplates(feed, NOW).length, 0);
+  });
+
+  it('deduplicates markets with the same slug across categories', () => {
+    const market = makeMarket();
+    const feed = {
+      geopolitical: [market],
+      finance: [market],
+    };
+    const templates = buildMarketTemplates(feed, NOW);
+    assert.equal(templates.length, 1);
+  });
+});
+
+// ── generateBets with market templates ────────────────────────────────────
+
+describe('generateBets with market templates', () => {
+  it('generates a bet with the expected resolution shape', () => {
+    const market = makeMarket({ yesPrice: 65, volume: 20_000 });
+    const feed = bootstrapFeed([market]);
+    const templates = buildMarketTemplates(feed, NOW);
+    const bets = generateBets(templates, { [MARKETS_BOOTSTRAP_FEED]: feed }, NOW);
+    assert.equal(bets.length, 1);
+    const bet = bets[0];
+    assert.equal(bet.domain, 'prediction_market');
+    assert.equal(bet.resolution.kind, 'hard');
+    assert.equal(bet.resolution.sourceFeed, MARKETS_RESOLUTION_FEED);
+    assert.ok(bet.resolution.metricKey.includes(MARKETS_RESOLUTION_FEED));
+    assert.ok(bet.resolution.metricKey.includes('yesPrice(market=='));
+    assert.equal(bet.resolution.window, 'at-endDate');
+    assert.equal(bet.resolution.threshold, 50);
+  });
+
+  it('stores marketSlug in the resolution spec (KTD2)', () => {
+    const market = makeMarket();
+    const feed = bootstrapFeed([market]);
+    const templates = buildMarketTemplates(feed, NOW);
+    const bets = generateBets(templates, { [MARKETS_BOOTSTRAP_FEED]: feed }, NOW);
+    assert.ok(bets.length > 0);
+    const slug = bets[0].resolution.marketSlug;
+    assert.ok(typeof slug === 'string' && slug.startsWith('polymarket:'), `Expected slug to start with 'polymarket:', got: ${slug}`);
+  });
+
+  it('template has a userValueScore reflecting conviction and volume', () => {
+    const highConviction = makeMarket({ yesPrice: 80, volume: 100_000 });
+    const lowConviction = makeMarket({ yesPrice: 52, volume: 5_100, url: 'https://polymarket.com/event/low-conviction' });
+    const feed = { geopolitical: [highConviction, lowConviction] };
+    const templates = buildMarketTemplates(feed, NOW);
+    const bets = generateBets(templates, { [MARKETS_BOOTSTRAP_FEED]: feed }, NOW);
+    assert.equal(bets.length, 2);
+    // Sort by userValueScore to verify ordering
+    const sorted = [...bets].sort((a, b) => (Number(b.userValueScore) || 0) - (Number(a.userValueScore) || 0));
+    const highBet = sorted[0];
+    assert.ok(highBet.resolution.metricKey.includes('will-x-happen') || Number(highBet.userValueScore) > Number(sorted[1].userValueScore));
+  });
+
+  it('generates no bet when the bootstrap feed is absent', () => {
+    const market = makeMarket();
+    const feed = bootstrapFeed([market]);
+    const templates = buildMarketTemplates(feed, NOW);
+    // Feed for the MARKETS_BOOTSTRAP_FEED key is absent → template extractMetric returns null
+    const bets = generateBets(templates, {}, NOW);
+    assert.equal(bets.length, 0);
+  });
+});
+
+// ── Kalshi slug handling ───────────────────────────────────────────────────
+
+describe('Kalshi market slug', () => {
+  it('resolves slug from Kalshi URL', () => {
+    const market = makeMarket({ url: 'https://kalshi.com/markets/FED-25DEC', source: 'kalshi' });
+    const feed = bootstrapFeed([market]);
+    const templates = buildMarketTemplates(feed, NOW);
+    assert.ok(templates.length > 0);
+    const bets = generateBets(templates, { [MARKETS_BOOTSTRAP_FEED]: feed }, NOW);
+    assert.ok(bets.length > 0);
+    const slug = bets[0].resolution.marketSlug;
+    assert.ok(slug.startsWith('kalshi:'), `Expected kalshi: prefix, got: ${slug}`);
+  });
+
+  it('skips markets with unrecognized URL formats', () => {
+    const market = makeMarket({ url: 'https://unknown-market.com/event/something' });
+    const feed = bootstrapFeed([market]);
+    const templates = buildMarketTemplates(feed, NOW);
+    assert.equal(templates.length, 0);
+  });
+});

--- a/tests/forecast-ensemble.test.mjs
+++ b/tests/forecast-ensemble.test.mjs
@@ -1,0 +1,138 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { runEnsemble, trimmedMean } from '../scripts/_forecast-ensemble.mjs';
+
+// ── trimmedMean unit tests ──────────────────────────────────────────────────
+
+describe('trimmedMean', () => {
+  it('returns mean for single value', () => {
+    assert.equal(trimmedMean([0.6]), 0.6);
+  });
+
+  it('returns mean for two values', () => {
+    assert.equal(trimmedMean([0.2, 0.8]), 0.5);
+  });
+
+  it('returns the median for three values (trimmed mean = middle)', () => {
+    // [0.2, 0.5, 0.8] sorted → drop 0.2 and 0.8, keep 0.5
+    assert.equal(trimmedMean([0.8, 0.2, 0.5]), 0.5);
+  });
+
+  it('returns NaN for empty array', () => {
+    assert(Number.isNaN(trimmedMean([])));
+  });
+
+  it('clamps result to [0,1]', () => {
+    // All values at 1.0 → trimmed mean = 1.0 (no clamping needed, but clamp guard exists)
+    assert.equal(trimmedMean([1, 1, 1]), 1);
+  });
+});
+
+// ── runEnsemble unit tests ──────────────────────────────────────────────────
+
+const QUESTION = 'Will WTI crude oil exceed $90/bbl by 2026-09-01?';
+const CONTEXT = 'WTI currently at $82. EIA shows 390 Mbbl inventory.';
+
+function makeCallForecastLLM(responses) {
+  // responses is an array of results for successive calls.
+  // Each element is { text, model, provider } or null (failure).
+  let i = 0;
+  return async (_systemPrompt, _userPrompt, _options) => {
+    const r = responses[i++] ?? null;
+    if (r === null) return null;
+    return r;
+  };
+}
+
+describe('runEnsemble — all passes succeed', () => {
+  it('returns method=ensemble and trimmed-mean probability', async () => {
+    const llm = makeCallForecastLLM([
+      { text: '{"probability": 0.55, "rationale": "historical base rate"}', model: 'gpt-4o', provider: 'openai' },
+      { text: '{"probability": 0.70, "rationale": "rising demand"}', model: 'gpt-4o', provider: 'openai' },
+      { text: '{"probability": 0.45, "rationale": "oversupply risk"}', model: 'gpt-4o', provider: 'openai' },
+    ]);
+    const result = await runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: 0.3 });
+    assert.equal(result.method, 'ensemble');
+    // trimmedMean([0.55, 0.70, 0.45]) = median = 0.55
+    assert.equal(result.probability, 0.55);
+    assert.equal(result.passes.length, 3);
+    assert.ok(result.passes.every((p) => p.pass));
+  });
+
+  it('persists pass metadata for all three passes (KTD1)', async () => {
+    const llm = makeCallForecastLLM([
+      { text: '{"probability": 0.4, "rationale": "A"}', model: 'model-a', provider: 'pa' },
+      { text: '{"probability": 0.6, "rationale": "B"}', model: 'model-b', provider: 'pb' },
+      { text: '{"probability": 0.5, "rationale": "C"}', model: 'model-c', provider: 'pc' },
+    ]);
+    const result = await runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: 0.35 });
+    const passes = result.passes;
+    assert.equal(passes[0].pass, 'outside_view');
+    assert.equal(passes[1].pass, 'inside_view');
+    assert.equal(passes[2].pass, 'adversarial_refuter');
+    assert.equal(passes[0].probability, 0.4);
+    assert.equal(passes[0].model, 'model-a');
+  });
+});
+
+describe('runEnsemble — partial pass failures', () => {
+  it('uses mean of survivors when one pass fails', async () => {
+    const llm = makeCallForecastLLM([
+      { text: '{"probability": 0.6, "rationale": "A"}', model: 'm', provider: 'p' },
+      null, // inside_view fails
+      { text: '{"probability": 0.4, "rationale": "C"}', model: 'm', provider: 'p' },
+    ]);
+    const result = await runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: 0.3 });
+    assert.equal(result.method, 'ensemble');
+    // 2 survivors → mean([0.6, 0.4]) = 0.5
+    assert.equal(result.probability, 0.5);
+    // Failed pass has null probability
+    assert.equal(result.passes[1].probability, null);
+  });
+});
+
+describe('runEnsemble — all passes fail', () => {
+  it('falls back to base-rate and never emits 0.5', async () => {
+    const llm = makeCallForecastLLM([null, null, null]);
+    const result = await runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: 0.27 });
+    assert.equal(result.method, 'base_rate_fallback');
+    assert.equal(result.probability, 0.27);
+    assert.ok(result.passes.every((p) => p.probability === null));
+  });
+
+  it('throws when all passes fail and no baseRateFallback provided', async () => {
+    const llm = makeCallForecastLLM([null, null, null]);
+    await assert.rejects(
+      () => runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: null }),
+      /all passes failed.*no finite baseRateFallback/i,
+    );
+  });
+});
+
+describe('runEnsemble — malformed LLM responses are rejected', () => {
+  it('rejects a probability > 1 (percent-scale hallucination)', async () => {
+    // LLM returns 70 (percent) instead of 0.70 (fraction) — must be treated as fail.
+    const llm = makeCallForecastLLM([
+      { text: '{"probability": 70, "rationale": "test"}', model: 'm', provider: 'p' },
+      { text: '{"probability": 0.5, "rationale": "ok"}', model: 'm', provider: 'p' },
+      { text: '{"probability": 0.4, "rationale": "ok"}', model: 'm', provider: 'p' },
+    ]);
+    const result = await runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: 0.3 });
+    // Pass 0 rejected; 2 survivors → mean([0.5, 0.4]) = 0.45
+    assert.equal(result.method, 'ensemble');
+    assert.equal(result.probability, 0.45);
+    assert.equal(result.passes[0].probability, null);
+  });
+
+  it('handles JSON wrapped in markdown code fences', async () => {
+    const llm = makeCallForecastLLM([
+      { text: '```json\n{"probability": 0.6, "rationale": "ok"}\n```', model: 'm', provider: 'p' },
+      { text: '{"probability": 0.5, "rationale": "ok"}', model: 'm', provider: 'p' },
+      { text: '{"probability": 0.4, "rationale": "ok"}', model: 'm', provider: 'p' },
+    ]);
+    const result = await runEnsemble(QUESTION, CONTEXT, llm, { baseRateFallback: 0.3 });
+    assert.equal(result.method, 'ensemble');
+    assert.equal(result.probability, 0.5); // median of [0.4, 0.5, 0.6]
+  });
+});

--- a/tests/prediction-market-resolutions.test.mjs
+++ b/tests/prediction-market-resolutions.test.mjs
@@ -1,0 +1,37 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { parseSlug } from '../scripts/seed-prediction-market-resolutions.mjs';
+
+// ── parseSlug ─────────────────────────────────────────────────────────────
+
+describe('parseSlug', () => {
+  it('parses a polymarket slug', () => {
+    const result = parseSlug('polymarket:will-x-happen');
+    assert.deepEqual(result, { source: 'polymarket', id: 'will-x-happen' });
+  });
+
+  it('parses a kalshi slug preserving dashes in the ticker', () => {
+    const result = parseSlug('kalshi:FED-25DEC');
+    assert.deepEqual(result, { source: 'kalshi', id: 'FED-25DEC' });
+  });
+
+  it('returns null for null/undefined input', () => {
+    assert.equal(parseSlug(null), null);
+    assert.equal(parseSlug(undefined), null);
+  });
+
+  it('returns null for a slug with no colon separator', () => {
+    assert.equal(parseSlug('someslug'), null);
+  });
+
+  it('returns null for an empty string', () => {
+    assert.equal(parseSlug(''), null);
+  });
+
+  it('handles slugs with colons in the id part (multi-segment)', () => {
+    // e.g. a hypothetical 'polymarket:us:election:2026'
+    const result = parseSlug('polymarket:us:election:2026');
+    assert.deepEqual(result, { source: 'polymarket', id: 'us:election:2026' });
+  });
+});


### PR DESCRIPTION
Closes #5525

## Summary

Implements Work Units U10-U15 from the Phase 2 forecast re-engine plan. Replaces the flat `0.4` placeholder prior with a calibrated 3-pass LLM-ensemble probability on two new domains (prediction-markets + FRED macro/rates).

## Changes

- **U10** `_forecast-ensemble.mjs` - 3-pass LLM ensemble (outside-view / inside-view / adversarial-refuter); 35s budget per pass; trimmed-mean result; all-fail to base-rate fallback (never 0.5)
- - **U11** `_bet-templates-markets.mjs` + `seed-prediction-market-resolutions.mjs` - liquid market templates + Gamma/Kalshi settlement seeder writing to prediction:markets-resolution:v1 (KTD2)
- - **U12** `_bet-templates-macro.mjs` - FRED templates (FEDFUNDS/UNRATE/CPIAUCSL/DGS10); fixes {series:{observations}} unwrap (#5098 P1); 75d calendar-derived grace (KTD4)
- - **U13** `seed-forecast-bets.mjs` - top-K=6 (env-tunable BET_ENGINE_TOP_K); BET_ENGINE_ENSEMBLE_ENABLED staged flag; probabilitySource tagging
- - **U14** `_forecast-scorecard.mjs` - betEngineCalibration, deviationSkill() (KTD3 anti-parroting), baseRateComparison(), promotionEnabled flag
Cross-cutting: RESOLUTION_FEED_KEYS extended with prediction:markets-resolution:v1 and 4 FRED keys; FRED_VALUE_SETTLEMENT_MAX_LAG_MS=75d; createEntry/updateOpenWindow ensemble-freeze (KTD5); buildCalibration hook in generateBets().

## Tests

187/187 passing - 72 new cases, 0 regressions.