### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/app-worldmonitor-mcp)](https://mcpindex.ai/server/app-worldmonitor-mcp)
+
 # World Monitor
 
 [简体中文](README.zh-CN.md)


### PR DESCRIPTION
Hey, ran World Monitor's registered MCP server through mcpindex's screening (checks the tool description for injection/manipulation patterns, nothing deeper). Came back clean, so added the badge to your README. It's an advisory signal, not a security certification. Feel free to close this if it's not something you want on the repo.