### PR TITLE
fix(payments): persist failed Dodo webhook incidents

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -96,14 +96,26 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci --no-audit --no-fund
-      - name: Convex deploy (prod)
+      - id: deploy
+        name: Convex deploy (prod)
         # `--yes` skips the interactive "Are you sure?" prompt. The deploy
         # key in CONVEX_DEPLOY_KEY pins the target deployment, so there is
         # no ambiguity about which environment we're pushing to.
         run: npx convex deploy --yes
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-      - name: Seed followedCountries shards (idempotent)
+      - id: seed_dodo_webhook_failure_summary
+        name: Seed Dodo webhook failure summary (idempotent)
+        # Failure recording uses this pre-seeded aggregate row as its
+        # document-backed OCC lock. Keep this immediately after deploy so an
+        # unrelated followedCountries seed failure cannot leave payment
+        # failure recording uninitialized.
+        run: npx convex run --prod payments/webhookMutations:_seedFailureSummary
+        continue-on-error: true
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      - id: seed_followed_countries_shards
+        name: Seed followedCountries shards (idempotent)
         # The `followCountry` / `unfollowCountry` / `mergeAnonymousLocal`
         # mutations throw `SHARDS_NOT_SEEDED` if the `followedCountriesShards`
         # table is empty (Codex round-4 P0 v2 — pre-seeded sharded lock). The
@@ -116,20 +128,24 @@ jobs:
         # by their file:export path; `--prod` pins the production deployment
         # via CONVEX_DEPLOY_KEY.
         run: npx convex run --prod followedCountries:_seedShards
+        continue-on-error: true
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-      - name: Seed followedCountries country locks (idempotent)
+      - id: seed_followed_countries_country_locks
+        name: Seed followedCountries country locks (idempotent)
         # Counter writes are serialized by a pre-seeded per-country lock row.
         # The daily cron also self-heals this table, but deploying and then
         # seeding inline avoids a temporary COUNTRY_LOCKS_NOT_SEEDED window.
         run: npx convex run --prod followedCountries:_seedCountryLocks
+        continue-on-error: true
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-      - name: Seed Dodo webhook failure summary (idempotent)
-        # Failure recording uses this pre-seeded aggregate row as its
-        # document-backed OCC lock. Without it, two first-time failures for
-        # the same webhook-id could both insert a dead-letter row before an
-        # index read can observe either insert.
-        run: npx convex run --prod payments/webhookMutations:_seedFailureSummary
-        env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      - name: Verify post-deploy seeds
+        if: always() && steps.deploy.outcome == 'success'
+        run: |
+          if [ "${{ steps.seed_dodo_webhook_failure_summary.outcome }}" != "success" ] \
+            || [ "${{ steps.seed_followed_countries_shards.outcome }}" != "success" ] \
+            || [ "${{ steps.seed_followed_countries_country_locks.outcome }}" != "success" ]; then
+            echo "::error::One or more post-deploy seeds failed; inspect the seed steps above"
+            exit 1
+          fi

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -125,3 +125,11 @@ jobs:
         run: npx convex run --prod followedCountries:_seedCountryLocks
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      - name: Seed Dodo webhook failure summary (idempotent)
+        # Failure recording uses this pre-seeded aggregate row as its
+        # document-backed OCC lock. Without it, two first-time failures for
+        # the same webhook-id could both insert a dead-letter row before an
+        # index read can observe either insert.
+        run: npx convex run --prod payments/webhookMutations:_seedFailureSummary
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}

--- a/convex/__tests__/webhookFailures.test.ts
+++ b/convex/__tests__/webhookFailures.test.ts
@@ -122,6 +122,7 @@ function failureArgs(overrides: Record<string, unknown> = {}) {
 describe("Dodo webhook failure tracking", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     delete process.env.DODO_PAYMENTS_WEBHOOK_SECRET;
   });
 
@@ -176,6 +177,51 @@ describe("Dodo webhook failure tracking", () => {
     expect(reportLog).toHaveBeenCalledWith(
       expect.stringContaining("unresolvedCount=1"),
     );
+  });
+
+  test("queues the production operations signal after the failure commits", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.useFakeTimers({ toFake: ["setTimeout", "setInterval"] });
+    try {
+      vi.spyOn(Date, "now").mockReturnValue(BASE_TIMESTAMP);
+      process.env.DODO_PAYMENTS_WEBHOOK_SECRET = DODO_WEBHOOK_SECRET;
+      const t = await makeT();
+      const body = JSON.stringify(makeProviderValidSubscriptionPayload());
+      const webhookId = "wh_http_signal_001";
+      const timestampSeconds = String(Math.floor(BASE_TIMESTAMP / 1000));
+      const signature = await signDodoPayload(body, webhookId, timestampSeconds);
+
+      const response = await t.fetch("/dodopayments-webhook", {
+        method: "POST",
+        headers: {
+          "webhook-id": webhookId,
+          "webhook-timestamp": timestampSeconds,
+          "webhook-signature": signature,
+        },
+        body,
+      });
+
+      expect(response.status).toBe(500);
+      const scheduled = await t.run((ctx) =>
+        ctx.db.system.query("_scheduled_functions").collect(),
+      );
+      const reportJobs = scheduled.filter((job) =>
+        job.name.includes("reportDodoWebhookFailure"),
+      );
+      expect(reportJobs).toHaveLength(1);
+      expect(reportJobs[0].args).toEqual([
+        expect.objectContaining({
+          webhookId,
+          eventType: "subscription.active",
+          attemptCount: 1,
+          unresolvedCount: 1,
+          eventTypes: ["subscription.active"],
+        }),
+      ]);
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+    }
   });
 
   test("records sanitized context for a malformed subscription event", async () => {
@@ -260,9 +306,12 @@ describe("Dodo webhook failure tracking", () => {
     expect(rows[0].lastSeenAt).toBe(BASE_TIMESTAMP + 5000);
   });
 
-  test("serializes first failure writes for the same webhook ID", async () => {
+  test("keeps one row across overlapping same-ID mutation requests", async () => {
     const t = await makeT();
 
+    // convex-test currently executes top-level functions one at a time, so
+    // this proves the idempotent outcome but not a production OCC retry. The
+    // shared pre-seeded summary read is the production serialization point.
     const [first, second] = await Promise.all([
       t.mutation(
         internal.payments.webhookMutations.recordWebhookFailure,
@@ -286,6 +335,48 @@ describe("Dodo webhook failure tracking", () => {
       {},
     );
     expect(summary.unresolvedCount).toBe(1);
+  });
+
+  test("tolerates and self-heals duplicate summary seed rows", async () => {
+    const t = await makeT();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("paymentWebhookFailureSummary", {
+        key: "global",
+        unresolvedCount: 0,
+        eventTypes: [],
+        updatedAt: BASE_TIMESTAMP,
+      });
+    });
+
+    const signal = await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs(),
+    );
+    expect(signal).toMatchObject({
+      attemptCount: 1,
+      unresolvedCount: 1,
+      eventTypes: ["subscription.renewed"],
+    });
+
+    const diagnostics = await t.query(
+      internal.payments.webhookMutations.getWebhookFailureDiagnostics,
+      {},
+    );
+    expect(diagnostics.unresolvedCount).toBe(1);
+
+    const seed = await t.mutation(
+      internal.payments.webhookMutations._seedFailureSummary,
+      {},
+    );
+    expect(seed).toEqual({ seeded: 0, deduped: 1 });
+    const summaries = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailureSummary").collect(),
+    );
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      unresolvedCount: 1,
+      eventTypes: [{ eventType: "subscription.renewed", count: 1 }],
+    });
   });
 
   test("keeps distinct webhook IDs separate for the same subscription", async () => {
@@ -395,5 +486,65 @@ describe("Dodo webhook failure tracking", () => {
       resolvedBy: "dodo-retry",
       resolutionNote: "Processed successfully on provider retry",
     });
+  });
+
+  test("recovers a failure through the signed HTTP retry path", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(BASE_TIMESTAMP);
+    vi.stubEnv("RESEND_API_KEY", "");
+    process.env.DODO_PAYMENTS_WEBHOOK_SECRET = DODO_WEBHOOK_SECRET;
+    const t = await makeT();
+    const payload = makeProviderValidSubscriptionPayload();
+    const webhookId = "wh_http_recovery_001";
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_http_recovery",
+        dodoCustomerId: payload.data.customer.customer_id,
+        email: payload.data.customer.email,
+        normalizedEmail: payload.data.customer.email,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+    });
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({
+        webhookId,
+        eventType: payload.type,
+        rawPayload: payload,
+      }),
+    );
+
+    const body = JSON.stringify(payload);
+    const timestampSeconds = String(Math.floor(BASE_TIMESTAMP / 1000));
+    const signature = await signDodoPayload(body, webhookId, timestampSeconds);
+    const response = await t.fetch("/dodopayments-webhook", {
+      method: "POST",
+      headers: {
+        "webhook-id": webhookId,
+        "webhook-timestamp": timestampSeconds,
+        "webhook-signature": signature,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      webhookId,
+      unresolved: false,
+      resolvedBy: "dodo-retry",
+      resolutionNote: "Processed successfully on provider retry",
+    });
+
+    const diagnostics = await t.query(
+      internal.payments.webhookMutations.getWebhookFailureDiagnostics,
+      {},
+    );
+    expect(diagnostics.unresolvedCount).toBe(0);
+    expect(diagnostics.failures).toHaveLength(0);
   });
 });

--- a/convex/__tests__/webhookFailures.test.ts
+++ b/convex/__tests__/webhookFailures.test.ts
@@ -4,6 +4,16 @@ import schema from "../schema";
 import { internal } from "../_generated/api";
 
 const modules = import.meta.glob("../**/*.ts");
+
+async function makeT(): Promise<ReturnType<typeof convexTest>> {
+  const t = convexTest(schema, modules);
+  await t.mutation(
+    internal.payments.webhookMutations._seedFailureSummary,
+    {},
+  );
+  return t;
+}
+
 const BASE_TIMESTAMP = new Date("2026-07-23T10:00:00Z").getTime();
 const DODO_SECRET_BYTES = new Uint8Array([
   0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
@@ -118,7 +128,7 @@ describe("Dodo webhook failure tracking", () => {
   test("dead-letters an application-invalid subscription received through the HTTP handler", async () => {
     vi.spyOn(Date, "now").mockReturnValue(BASE_TIMESTAMP);
     process.env.DODO_PAYMENTS_WEBHOOK_SECRET = DODO_WEBHOOK_SECRET;
-    const t = convexTest(schema, modules);
+    const t = await makeT();
     const body = JSON.stringify(makeProviderValidSubscriptionPayload());
     const webhookId = "wh_http_failure_001";
     const timestampSeconds = String(Math.floor(BASE_TIMESTAMP / 1000));
@@ -169,7 +179,7 @@ describe("Dodo webhook failure tracking", () => {
   });
 
   test("records sanitized context for a malformed subscription event", async () => {
-    const t = convexTest(schema, modules);
+    const t = await makeT();
 
     await expect(
       t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
@@ -221,7 +231,7 @@ describe("Dodo webhook failure tracking", () => {
   });
 
   test("updates the same failure row for repeated webhook deliveries", async () => {
-    const t = convexTest(schema, modules);
+    const t = await makeT();
 
     const first = await t.mutation(
       internal.payments.webhookMutations.recordWebhookFailure,
@@ -250,8 +260,36 @@ describe("Dodo webhook failure tracking", () => {
     expect(rows[0].lastSeenAt).toBe(BASE_TIMESTAMP + 5000);
   });
 
+  test("serializes first failure writes for the same webhook ID", async () => {
+    const t = await makeT();
+
+    const [first, second] = await Promise.all([
+      t.mutation(
+        internal.payments.webhookMutations.recordWebhookFailure,
+        failureArgs(),
+      ),
+      t.mutation(
+        internal.payments.webhookMutations.recordWebhookFailure,
+        failureArgs({ errorMessage: "same delivery, concurrent attempt" }),
+      ),
+    ]);
+
+    expect([first.isNew, second.isNew].sort()).toEqual([false, true]);
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attemptCount).toBe(2);
+
+    const summary = await t.query(
+      internal.payments.webhookMutations.getWebhookFailureDiagnostics,
+      {},
+    );
+    expect(summary.unresolvedCount).toBe(1);
+  });
+
   test("keeps distinct webhook IDs separate for the same subscription", async () => {
-    const t = convexTest(schema, modules);
+    const t = await makeT();
 
     await t.mutation(
       internal.payments.webhookMutations.recordWebhookFailure,
@@ -291,7 +329,7 @@ describe("Dodo webhook failure tracking", () => {
   });
 
   test("resolves a failure and removes it from the unresolved diagnostic query", async () => {
-    const t = convexTest(schema, modules);
+    const t = await makeT();
 
     await t.mutation(
       internal.payments.webhookMutations.recordWebhookFailure,
@@ -332,7 +370,7 @@ describe("Dodo webhook failure tracking", () => {
   });
 
   test("automatically resolves a transient failure after a successful retry", async () => {
-    const t = convexTest(schema, modules);
+    const t = await makeT();
 
     await t.mutation(
       internal.payments.webhookMutations.recordWebhookFailure,

--- a/convex/__tests__/webhookFailures.test.ts
+++ b/convex/__tests__/webhookFailures.test.ts
@@ -547,4 +547,87 @@ describe("Dodo webhook failure tracking", () => {
     expect(diagnostics.unresolvedCount).toBe(0);
     expect(diagnostics.failures).toHaveLength(0);
   });
+
+  test("moves the event bucket when a redelivery changes event type", async () => {
+    const t = await makeT();
+
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs(),
+    );
+    const signal = await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({
+        eventType: "subscription.on_hold",
+        rawPayload: {
+          type: "subscription.on_hold",
+          data: { subscription_id: "sub_failure_001" },
+        },
+      }),
+    );
+
+    expect(signal).toMatchObject({
+      isNew: false,
+      attemptCount: 2,
+      unresolvedCount: 1,
+    });
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe("subscription.on_hold");
+
+    const summary = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailureSummary").collect(),
+    );
+    expect(summary[0]).toMatchObject({
+      unresolvedCount: 1,
+      eventTypes: [{ eventType: "subscription.on_hold", count: 1 }],
+    });
+  });
+
+  test("reopens a resolved incident as a fresh unresolved failure", async () => {
+    const t = await makeT();
+
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs(),
+    );
+    await t.mutation(
+      internal.payments.webhookMutations.resolveWebhookFailure,
+      {
+        webhookId: "wh_failure_001",
+        resolvedBy: "on-call@example.com",
+      },
+    );
+    const signal = await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({
+        timestamp: BASE_TIMESTAMP + 5000,
+        receivedAt: BASE_TIMESTAMP + 5000,
+      }),
+    );
+
+    expect(signal).toMatchObject({
+      isNew: false,
+      attemptCount: 2,
+      unresolvedCount: 1,
+    });
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ unresolved: true, attemptCount: 2 });
+    expect(rows[0].resolvedAt).toBeUndefined();
+    expect(rows[0].resolvedBy).toBeUndefined();
+    expect(rows[0].resolutionNote).toBeUndefined();
+
+    const summary = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailureSummary").collect(),
+    );
+    expect(summary[0]).toMatchObject({
+      unresolvedCount: 1,
+      eventTypes: [{ eventType: "subscription.renewed", count: 1 }],
+    });
+  });
 });

--- a/convex/__tests__/webhookFailures.test.ts
+++ b/convex/__tests__/webhookFailures.test.ts
@@ -230,7 +230,7 @@ describe("Dodo webhook failure tracking", () => {
     const second = await t.mutation(
       internal.payments.webhookMutations.recordWebhookFailure,
       failureArgs({
-      timestamp: BASE_TIMESTAMP + 5000,
+        timestamp: BASE_TIMESTAMP + 5000,
         receivedAt: BASE_TIMESTAMP + 5000,
         errorMessage: "still invalid",
       }),
@@ -277,6 +277,17 @@ describe("Dodo webhook failure tracking", () => {
       unresolvedCount: 2,
       eventTypes: [{ eventType: "subscription.renewed", count: 2 }],
     });
+
+    const diagnostics = await t.query(
+      internal.payments.webhookMutations.getWebhookFailureDiagnostics,
+      { limit: 10 },
+    );
+    expect(diagnostics).toMatchObject({
+      unresolvedCount: 2,
+      eventTypes: [{ eventType: "subscription.renewed", count: 2 }],
+    });
+    expect(diagnostics.failures).toHaveLength(2);
+    expect("rawPayload" in diagnostics.failures[0]).toBe(false);
   });
 
   test("resolves a failure and removes it from the unresolved diagnostic query", async () => {
@@ -310,5 +321,41 @@ describe("Dodo webhook failure tracking", () => {
       resolutionNote: "Reconciled the subscription manually",
     });
     expect(rows[0].resolvedAt).toBeTypeOf("number");
+
+    const summary = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailureSummary").collect(),
+    );
+    expect(summary[0]).toMatchObject({
+      unresolvedCount: 0,
+      eventTypes: [],
+    });
+  });
+
+  test("automatically resolves a transient failure after a successful retry", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs(),
+    );
+    await t.mutation(
+      internal.payments.webhookMutations.markWebhookFailureRecovered,
+      { webhookId: "wh_failure_001" },
+    );
+
+    const unresolved = await t.query(
+      internal.payments.webhookMutations.listUnresolvedWebhookFailures,
+      {},
+    );
+    expect(unresolved).toHaveLength(0);
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows[0]).toMatchObject({
+      unresolved: false,
+      resolvedBy: "dodo-retry",
+      resolutionNote: "Processed successfully on provider retry",
+    });
   });
 });

--- a/convex/__tests__/webhookFailures.test.ts
+++ b/convex/__tests__/webhookFailures.test.ts
@@ -1,0 +1,314 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+const BASE_TIMESTAMP = new Date("2026-07-23T10:00:00Z").getTime();
+const DODO_SECRET_BYTES = new Uint8Array([
+  0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+  0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+  0x10, 0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87,
+  0x98, 0xa9, 0xba, 0xcb, 0xdc, 0xed, 0xfe, 0x0f,
+]);
+const DODO_WEBHOOK_SECRET = `whsec_${btoa(String.fromCharCode(...DODO_SECRET_BYTES))}`;
+
+async function signDodoPayload(
+  body: string,
+  webhookId: string,
+  timestampSeconds: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    DODO_SECRET_BYTES,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${webhookId}.${timestampSeconds}.${body}`),
+  );
+  return `v1,${btoa(String.fromCharCode(...new Uint8Array(signature)))}`;
+}
+
+function makeProviderValidSubscriptionPayload() {
+  return {
+    business_id: "biz_failure_test",
+    type: "subscription.active",
+    timestamp: new Date(BASE_TIMESTAMP).toISOString(),
+    data: {
+      payload_type: "Subscription",
+      addons: [],
+      billing: { city: null, country: "US", state: null, street: null, zipcode: null },
+      cancel_at_next_billing_date: false,
+      cancelled_at: null,
+      created_at: new Date(BASE_TIMESTAMP).toISOString(),
+      currency: "USD",
+      customer: {
+        customer_id: "cus_http_failure",
+        email: "bad@example.com",
+        metadata: {},
+        name: "Unresolved Customer",
+        phone_number: null,
+      },
+      custom_field_responses: null,
+      discount_cycles_remaining: null,
+      discount_id: null,
+      expires_at: null,
+      credit_entitlement_cart: [],
+      meter_credit_entitlement_cart: [],
+      meters: [],
+      metadata: {},
+      next_billing_date: new Date(BASE_TIMESTAMP + 30 * 86400000).toISOString(),
+      on_demand: false,
+      payment_frequency_count: 1,
+      payment_frequency_interval: "Month",
+      payment_method_id: null,
+      previous_billing_date: new Date(BASE_TIMESTAMP).toISOString(),
+      product_id: "pdt_http_failure",
+      quantity: 1,
+      recurring_pre_tax_amount: 1999,
+      status: "active",
+      subscription_id: "sub_http_failure",
+      subscription_period_count: 1,
+      subscription_period_interval: "Month",
+      tax_id: null,
+      tax_inclusive: true,
+      trial_period_days: 0,
+    },
+  };
+}
+
+function failureArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    webhookId: "wh_failure_001",
+    eventType: "subscription.renewed",
+    rawPayload: {
+      type: "subscription.renewed",
+      data: {
+        subscription_id: "sub_failure_001",
+        payment_id: "pay_failure_001",
+        customer: {
+          customer_id: "cus_failure_001",
+          email: "subscriber@example.com",
+        },
+        metadata: {
+          wm_user_id: "user_failure_001",
+          secret: "should-not-be-persisted",
+        },
+        next_billing_date: "2026-08-23T10:00:00Z",
+      },
+    },
+    timestamp: BASE_TIMESTAMP,
+    receivedAt: BASE_TIMESTAMP,
+    errorKind: "ValidationError",
+    errorMessage: "invalid subscription for subscriber@example.com secret=should-not-be-persisted",
+    ...overrides,
+  };
+}
+
+describe("Dodo webhook failure tracking", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.DODO_PAYMENTS_WEBHOOK_SECRET;
+  });
+
+  test("dead-letters an application-invalid subscription received through the HTTP handler", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(BASE_TIMESTAMP);
+    process.env.DODO_PAYMENTS_WEBHOOK_SECRET = DODO_WEBHOOK_SECRET;
+    const t = convexTest(schema, modules);
+    const body = JSON.stringify(makeProviderValidSubscriptionPayload());
+    const webhookId = "wh_http_failure_001";
+    const timestampSeconds = String(Math.floor(BASE_TIMESTAMP / 1000));
+    const signature = await signDodoPayload(body, webhookId, timestampSeconds);
+
+    const response = await t.fetch("/dodopayments-webhook", {
+      method: "POST",
+      headers: {
+        "webhook-id": webhookId,
+        "webhook-timestamp": timestampSeconds,
+        "webhook-signature": signature,
+      },
+      body,
+    });
+    await t.finishInProgressScheduledFunctions();
+
+    expect(response.status).toBe(500);
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      webhookId,
+      eventType: "subscription.active",
+      dodoSubscriptionId: "sub_http_failure",
+      dodoCustomerId: "cus_http_failure",
+      unresolved: true,
+      attemptCount: 1,
+    });
+    expect("rawPayload" in rows[0]).toBe(false);
+
+    const reportLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    await t.mutation(
+      internal.payments.webhookMutations.reportDodoWebhookFailure,
+      {
+        webhookId,
+        eventType: "subscription.active",
+        errorKind: "Error",
+        errorMessage: "Cannot resolve userId",
+        attemptCount: 1,
+        unresolvedCount: 1,
+        eventTypes: ["subscription.active"],
+      },
+    );
+    expect(reportLog).toHaveBeenCalledWith(
+      expect.stringContaining("unresolvedCount=1"),
+    );
+  });
+
+  test("records sanitized context for a malformed subscription event", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+        webhookId: "wh_malformed_subscription",
+        eventType: "subscription.renewed",
+        rawPayload: {
+          type: "subscription.renewed",
+          data: { payment_id: "pay_malformed", customer: { email: "bad@example.com" } },
+        },
+        timestamp: BASE_TIMESTAMP,
+      }),
+    ).rejects.toThrow(/Missing subscription_id/);
+
+    const signal = await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({
+        webhookId: "wh_malformed_subscription",
+        rawPayload: {
+          type: "subscription.renewed",
+          data: {
+            payment_id: "pay_malformed",
+            customer: { email: "bad@example.com" },
+          },
+        },
+      }),
+    );
+
+    expect(signal).toMatchObject({
+      isNew: true,
+      attemptCount: 1,
+      unresolvedCount: 1,
+      eventTypes: ["subscription.renewed"],
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      webhookId: "wh_malformed_subscription",
+      eventType: "subscription.renewed",
+      dodoPaymentId: "pay_malformed",
+      unresolved: true,
+      attemptCount: 1,
+      dataKeys: ["customer", "payment_id"],
+    });
+    expect(rows[0].errorMessage).toBe("invalid subscription for [redacted-email] secret=[redacted]");
+    expect("rawPayload" in rows[0]).toBe(false);
+  });
+
+  test("updates the same failure row for repeated webhook deliveries", async () => {
+    const t = convexTest(schema, modules);
+
+    const first = await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs(),
+    );
+    const second = await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({
+      timestamp: BASE_TIMESTAMP + 5000,
+        receivedAt: BASE_TIMESTAMP + 5000,
+        errorMessage: "still invalid",
+      }),
+    );
+
+    expect(first.isNew).toBe(true);
+    expect(second).toMatchObject({
+      isNew: false,
+      attemptCount: 2,
+      unresolvedCount: 1,
+    });
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attemptCount).toBe(2);
+    expect(rows[0].lastSeenAt).toBe(BASE_TIMESTAMP + 5000);
+  });
+
+  test("keeps distinct webhook IDs separate for the same subscription", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({ webhookId: "wh_failure_a" }),
+    );
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs({ webhookId: "wh_failure_b" }),
+    );
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.dodoSubscriptionId)).toEqual([
+      "sub_failure_001",
+      "sub_failure_001",
+    ]);
+    const summary = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailureSummary").collect(),
+    );
+    expect(summary[0]).toMatchObject({
+      unresolvedCount: 2,
+      eventTypes: [{ eventType: "subscription.renewed", count: 2 }],
+    });
+  });
+
+  test("resolves a failure and removes it from the unresolved diagnostic query", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(
+      internal.payments.webhookMutations.recordWebhookFailure,
+      failureArgs(),
+    );
+    await t.mutation(
+      internal.payments.webhookMutations.resolveWebhookFailure,
+      {
+        webhookId: "wh_failure_001",
+        resolvedBy: "on-call@example.com",
+        resolutionNote: "Reconciled the subscription manually",
+      },
+    );
+
+    const unresolved = await t.query(
+      internal.payments.webhookMutations.listUnresolvedWebhookFailures,
+      {},
+    );
+    expect(unresolved).toHaveLength(0);
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("paymentWebhookFailures").collect(),
+    );
+    expect(rows[0]).toMatchObject({
+      unresolved: false,
+      resolvedBy: "on-call@example.com",
+      resolutionNote: "Reconciled the subscription manually",
+    });
+    expect(rows[0].resolvedAt).toBeTypeOf("number");
+  });
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -114,6 +114,16 @@ crons.daily(
   internal.followedCountries._dedupeCountryLocks,
 );
 
+// Daily self-heal for the singleton Dodo failure summary. This both restores a
+// missing deploy-time seed and removes duplicate global rows from a rare race
+// between deploy/manual/cron seed invocations. Operational reads tolerate the
+// duplicates until this idempotent pass retains the oldest authority row.
+crons.daily(
+  "dodo-webhook-failure-summary-seed",
+  { hourUTC: 3, minuteUTC: 4 },
+  internal.payments.webhookMutations._seedFailureSummary,
+);
+
 // Dunning + winback scan (#4932). Schedules the due day-3/day-7 payment-
 // failure reminders and the 30-day winback (at most one step per
 // subscription per tick; every send re-validates live state). 14:30 UTC =

--- a/convex/payments/webhookHandlers.ts
+++ b/convex/payments/webhookHandlers.ts
@@ -161,8 +161,10 @@ export const webhookHandler = httpAction(async (ctx, request) => {
 
       // `convex-test` cannot safely await a scheduler write started by an HTTP
       // action, so keep this test-only guard aligned with the existing Redis
-      // scheduler guards in subscriptionHelpers.ts. Production always queues
-      // the structured auto-Sentry signal after the failure row commits.
+      // scheduler guards in subscriptionHelpers.ts. Production attempts to
+      // queue the structured auto-Sentry signal after the failure row commits;
+      // a scheduler failure is logged and does not alter the provider-facing
+      // retry response.
       if (process.env.NODE_ENV !== "test") {
         // sentry-coverage-ok: the scheduled mutation emits a structured
         // console.error after the failure row commits, so Convex auto-Sentry

--- a/convex/payments/webhookHandlers.ts
+++ b/convex/payments/webhookHandlers.ts
@@ -139,10 +139,6 @@ export const webhookHandler = httpAction(async (ctx, request) => {
         timestamp: eventTimestamp,
       },
     );
-    await ctx.runMutation(
-      internal.payments.webhookMutations.markWebhookFailureRecovered,
-      { webhookId },
-    );
   } catch (error) {
     const errorKind = error instanceof Error && error.name
       ? error.name
@@ -198,6 +194,20 @@ export const webhookHandler = httpAction(async (ctx, request) => {
     // sentry-coverage-ok: failure details are persisted above and the
     // scheduled report mutation provides the structured Sentry signal.
     console.error("Webhook processing failed:", error);
+    return new Response("Internal processing error", { status: 500 });
+  }
+
+  // Recovery is deliberately outside the processing-failure catch. If this
+  // bookkeeping mutation is transiently unavailable, the provider should
+  // retry the delivery, but that recovery error must not be recorded as a
+  // new processing incident after billing state already committed.
+  try {
+    await ctx.runMutation(
+      internal.payments.webhookMutations.markWebhookFailureRecovered,
+      { webhookId },
+    );
+  } catch (error) {
+    console.error("[webhook] Failed to mark Dodo webhook failure recovered:", error);
     return new Response("Internal processing error", { status: 500 });
   }
 

--- a/convex/payments/webhookHandlers.ts
+++ b/convex/payments/webhookHandlers.ts
@@ -139,6 +139,10 @@ export const webhookHandler = httpAction(async (ctx, request) => {
         timestamp: eventTimestamp,
       },
     );
+    await ctx.runMutation(
+      internal.payments.webhookMutations.markWebhookFailureRecovered,
+      { webhookId },
+    );
   } catch (error) {
     const errorKind = error instanceof Error && error.name
       ? error.name

--- a/convex/payments/webhookHandlers.ts
+++ b/convex/payments/webhookHandlers.ts
@@ -113,31 +113,86 @@ export const webhookHandler = httpAction(async (ctx, request) => {
   // 5. Dispatch to internal mutation for idempotent processing.
   //    Uses the validated payload directly (not a second JSON.parse) to avoid divergence.
   //    On handler failure the mutation throws, rolling back partial writes.
-  //    We catch and return 500 so Dodo retries.
+  //    We record a sanitized failure projection in a separate mutation before
+  //    returning 500 so Dodo retries without losing the repair context.
+  const eventTimestamp = payload.timestamp
+    ? payload.timestamp.getTime()
+    : Date.now();
+
+  if (!payload.timestamp) {
+    console.warn("[webhook] Missing payload.timestamp — falling back to Date.now(). Out-of-order detection may be unreliable.");
+  }
+
+  // Round-trip through JSON to convert Date objects to ISO strings.
+  // Convex does not support Date as a value type, and the Dodo SDK
+  // parses date fields (created_at, expires_at, etc.) into Date objects.
+  const sanitizedPayload = JSON.parse(JSON.stringify(payload));
+  const eventType = typeof payload.type === "string" ? payload.type : "unknown";
+
   try {
-    const eventTimestamp = payload.timestamp
-      ? payload.timestamp.getTime()
-      : Date.now();
-
-    if (!payload.timestamp) {
-      console.warn("[webhook] Missing payload.timestamp — falling back to Date.now(). Out-of-order detection may be unreliable.");
-    }
-
-    // Round-trip through JSON to convert Date objects to ISO strings.
-    // Convex does not support Date as a value type, and the Dodo SDK
-    // parses date fields (created_at, expires_at, etc.) into Date objects.
-    const sanitizedPayload = JSON.parse(JSON.stringify(payload));
-
     await ctx.runMutation(
       internal.payments.webhookMutations.processWebhookEvent,
       {
         webhookId,
-        eventType: payload.type,
+        eventType,
         rawPayload: sanitizedPayload,
         timestamp: eventTimestamp,
       },
     );
   } catch (error) {
+    const errorKind = error instanceof Error && error.name
+      ? error.name
+      : "WebhookProcessingError";
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    try {
+      const signal = await ctx.runMutation(
+        internal.payments.webhookMutations.recordWebhookFailure,
+        {
+          webhookId,
+          eventType,
+          rawPayload: sanitizedPayload,
+          timestamp: eventTimestamp,
+          receivedAt: Date.now(),
+          errorKind,
+          errorMessage,
+        },
+      );
+
+      // `convex-test` cannot safely await a scheduler write started by an HTTP
+      // action, so keep this test-only guard aligned with the existing Redis
+      // scheduler guards in subscriptionHelpers.ts. Production always queues
+      // the structured auto-Sentry signal after the failure row commits.
+      if (process.env.NODE_ENV !== "test") {
+        // sentry-coverage-ok: the scheduled mutation emits a structured
+        // console.error after the failure row commits, so Convex auto-Sentry
+        // receives an ops signal without changing the provider-facing 500.
+        try {
+          await ctx.scheduler.runAfter(
+            0,
+            internal.payments.webhookMutations.reportDodoWebhookFailure,
+            {
+              webhookId,
+              eventType,
+              errorKind: signal.errorKind,
+              errorMessage: signal.errorMessage,
+              attemptCount: signal.attemptCount,
+              unresolvedCount: signal.unresolvedCount,
+              eventTypes: signal.eventTypes,
+            },
+          );
+        } catch (scheduleErr) {
+          console.error("[webhook] reportDodoWebhookFailure schedule failed:", scheduleErr);
+        }
+      }
+    } catch (recordErr) {
+      // The retry contract is still more important than the observability
+      // bonus. Keep returning 500 if the separate failure write is degraded.
+      console.error("[webhook] Failed to persist Dodo webhook failure:", recordErr);
+    }
+
+    // sentry-coverage-ok: failure details are persisted above and the
+    // scheduled report mutation provides the structured Sentry signal.
     console.error("Webhook processing failed:", error);
     return new Response("Internal processing error", { status: 500 });
   }

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -273,6 +273,27 @@ export const reportDodoWebhookFailure = internalMutation({
   },
 });
 
+/**
+ * Shared resolution transition for manual resolution and provider-retry
+ * recovery: one timestamp marks the failure row resolved and rebalances the
+ * aggregate. Callers keep their own lookup and missing-row policy.
+ */
+async function applyWebhookFailureResolution(
+  ctx: MutationCtx,
+  summary: Doc<"paymentWebhookFailureSummary">,
+  existing: Doc<"paymentWebhookFailures">,
+  attribution: { resolvedBy: string; resolutionNote?: string },
+) {
+  const resolvedAt = Date.now();
+  await ctx.db.patch(existing._id, {
+    unresolved: false,
+    resolvedAt,
+    resolvedBy: attribution.resolvedBy,
+    resolutionNote: attribution.resolutionNote,
+  });
+  await removeUnresolvedFailureFromSummary(ctx, summary, existing, resolvedAt);
+}
+
 export const resolveWebhookFailure = internalMutation({
   args: {
     webhookId: v.string(),
@@ -289,16 +310,12 @@ export const resolveWebhookFailure = internalMutation({
       throw new Error(`No Dodo webhook failure found for ${args.webhookId}`);
     }
 
-    await ctx.db.patch(existing._id, {
-      unresolved: false,
-      resolvedAt: Date.now(),
+    await applyWebhookFailureResolution(ctx, summary, existing, {
       resolvedBy: args.resolvedBy.slice(0, 200),
       resolutionNote: args.resolutionNote
         ? sanitizeFailureMessage(args.resolutionNote)
         : undefined,
     });
-
-    await removeUnresolvedFailureFromSummary(ctx, summary, existing, Date.now());
   },
 });
 
@@ -315,15 +332,10 @@ export const markWebhookFailureRecovered = internalMutation({
     }
 
     const summary = await readFailureSummaryLock(ctx);
-
-    const recoveredAt = Date.now();
-    await ctx.db.patch(existing._id, {
-      unresolved: false,
-      resolvedAt: recoveredAt,
+    await applyWebhookFailureResolution(ctx, summary, existing, {
       resolvedBy: "dodo-retry",
       resolutionNote: "Processed successfully on provider retry",
     });
-    await removeUnresolvedFailureFromSummary(ctx, summary, existing, recoveredAt);
   },
 });
 

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -21,6 +21,7 @@ import {
 const MAX_FAILURE_MESSAGE_LENGTH = 1000;
 const MAX_FAILURE_DATA_KEYS = 100;
 const MAX_DIAGNOSTIC_ROWS = 250;
+const GLOBAL_FAILURE_SUMMARY_KEY = "global" as const;
 type EventTypeCount = { eventType: string; count: number };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -75,27 +76,26 @@ function adjustEventTypeCount(
     .sort((a, b) => a.eventType.localeCompare(b.eventType));
 }
 
+async function readFailureSummaryLock(ctx: MutationCtx) {
+  const summary = await ctx.db
+    .query("paymentWebhookFailureSummary")
+    .withIndex("by_key", (q) => q.eq("key", GLOBAL_FAILURE_SUMMARY_KEY))
+    .first();
+  if (!summary) {
+    throw new Error(
+      "Dodo webhook failure summary is not seeded; run payments/webhookMutations:_seedFailureSummary",
+    );
+  }
+  return summary;
+}
+
 async function updateFailureSummary(
   ctx: MutationCtx,
+  summary: Doc<"paymentWebhookFailureSummary">,
   existing: Doc<"paymentWebhookFailures"> | null,
   eventType: string,
   updatedAt: number,
 ) {
-  const summary = await ctx.db
-    .query("paymentWebhookFailureSummary")
-    .withIndex("by_key", (q) => q.eq("key", "global"))
-    .unique();
-
-  if (!summary) {
-    await ctx.db.insert("paymentWebhookFailureSummary", {
-      key: "global",
-      unresolvedCount: 1,
-      eventTypes: [{ eventType, count: 1 }],
-      updatedAt,
-    });
-    return;
-  }
-
   let unresolvedCount = summary.unresolvedCount;
   let eventTypes = summary.eventTypes;
   if (existing?.unresolved) {
@@ -139,6 +139,11 @@ export const recordWebhookFailure = internalMutation({
     errorMessage: v.string(),
   },
   handler: async (ctx, args) => {
+    // This pre-seeded summary document is also the OCC serialization point
+    // for the failure row + aggregate update. Index reads do not serialize a
+    // brand-new webhookId race on their own, so the lock must exist before
+    // either mutation can insert the first row for an ID.
+    const summary = await readFailureSummaryLock(ctx);
     const receivedAt = args.receivedAt ?? Date.now();
     const context = extractFailureContext(args.rawPayload);
     const existing = await ctx.db
@@ -173,20 +178,21 @@ export const recordWebhookFailure = internalMutation({
       });
     }
 
-    await updateFailureSummary(ctx, existing, args.eventType, receivedAt);
-    const summary = await getUnresolvedFailureSummary(ctx);
+    await updateFailureSummary(ctx, summary, existing, args.eventType, receivedAt);
+    const currentSummary = await getUnresolvedFailureSummary(ctx);
     return {
       isNew: !existing,
       attemptCount,
       errorKind: failure.errorKind,
       errorMessage: failure.errorMessage,
-      ...summary,
+      ...currentSummary,
     };
   },
 });
 
 async function removeUnresolvedFailureFromSummary(
   ctx: MutationCtx,
+  summary: Doc<"paymentWebhookFailureSummary">,
   existing: Doc<"paymentWebhookFailures">,
   updatedAt: number,
 ) {
@@ -194,18 +200,37 @@ async function removeUnresolvedFailureFromSummary(
     return;
   }
 
-  const summary = await ctx.db
-    .query("paymentWebhookFailureSummary")
-    .withIndex("by_key", (q) => q.eq("key", "global"))
-    .unique();
-  if (summary) {
-    await ctx.db.patch(summary._id, {
-      unresolvedCount: Math.max(0, summary.unresolvedCount - 1),
-      eventTypes: adjustEventTypeCount(summary.eventTypes, existing.eventType, -1),
-      updatedAt,
-    });
-  }
+  await ctx.db.patch(summary._id, {
+    unresolvedCount: Math.max(0, summary.unresolvedCount - 1),
+    eventTypes: adjustEventTypeCount(summary.eventTypes, existing.eventType, -1),
+    updatedAt,
+  });
 }
+
+/**
+ * Idempotently creates the aggregate/serialization document used by the
+ * failure lifecycle. This runs after Convex deploy and is also safe to rerun.
+ */
+export const _seedFailureSummary = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<{ seeded: number }> => {
+    const existing = await ctx.db
+      .query("paymentWebhookFailureSummary")
+      .withIndex("by_key", (q) => q.eq("key", GLOBAL_FAILURE_SUMMARY_KEY))
+      .first();
+    if (existing) {
+      return { seeded: 0 };
+    }
+
+    await ctx.db.insert("paymentWebhookFailureSummary", {
+      key: GLOBAL_FAILURE_SUMMARY_KEY,
+      unresolvedCount: 0,
+      eventTypes: [],
+      updatedAt: Date.now(),
+    });
+    return { seeded: 1 };
+  },
+});
 
 /**
  * Emits one grouped Convex auto-Sentry event after a failure row commits.
@@ -240,6 +265,7 @@ export const resolveWebhookFailure = internalMutation({
     resolutionNote: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const summary = await readFailureSummaryLock(ctx);
     const existing = await ctx.db
       .query("paymentWebhookFailures")
       .withIndex("by_webhookId", (q) => q.eq("webhookId", args.webhookId))
@@ -257,7 +283,7 @@ export const resolveWebhookFailure = internalMutation({
         : undefined,
     });
 
-    await removeUnresolvedFailureFromSummary(ctx, existing, Date.now());
+    await removeUnresolvedFailureFromSummary(ctx, summary, existing, Date.now());
   },
 });
 
@@ -273,6 +299,8 @@ export const markWebhookFailureRecovered = internalMutation({
       return;
     }
 
+    const summary = await readFailureSummaryLock(ctx);
+
     const recoveredAt = Date.now();
     await ctx.db.patch(existing._id, {
       unresolved: false,
@@ -280,7 +308,7 @@ export const markWebhookFailureRecovered = internalMutation({
       resolvedBy: "dodo-retry",
       resolutionNote: "Processed successfully on provider retry",
     });
-    await removeUnresolvedFailureFromSummary(ctx, existing, recoveredAt);
+    await removeUnresolvedFailureFromSummary(ctx, summary, existing, recoveredAt);
   },
 });
 

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -121,7 +121,10 @@ async function getUnresolvedFailureSummary(ctx: QueryCtx) {
   const rows = await ctx.db
     .query("paymentWebhookFailureSummary")
     .withIndex("by_key", (q) => q.eq("key", "global"))
-    .unique();
+    // A deploy seed and the daily self-heal can both observe an empty index
+    // and insert concurrently. Operational reads must remain available until
+    // the next seed pass removes the extra row.
+    .first();
   return {
     unresolvedCount: rows?.unresolvedCount ?? 0,
     eventTypes: rows?.eventTypes.map((entry) => entry.eventType) ?? [],
@@ -213,13 +216,25 @@ async function removeUnresolvedFailureFromSummary(
  */
 export const _seedFailureSummary = internalMutation({
   args: {},
-  handler: async (ctx): Promise<{ seeded: number }> => {
+  handler: async (ctx): Promise<{ seeded: number; deduped: number }> => {
     const existing = await ctx.db
       .query("paymentWebhookFailureSummary")
       .withIndex("by_key", (q) => q.eq("key", GLOBAL_FAILURE_SUMMARY_KEY))
-      .first();
-    if (existing) {
-      return { seeded: 0 };
+      .collect();
+    if (existing.length > 0) {
+      // Concurrent first seeds can both insert because an empty index range is
+      // not a document-backed OCC lock. All operational reads use the oldest
+      // row via `.first()`, so retain that authority and remove later extras.
+      existing.sort((a, b) => a._creationTime - b._creationTime);
+      let deduped = 0;
+      for (let index = 1; index < existing.length; index++) {
+        const extra = existing[index];
+        if (extra !== undefined) {
+          await ctx.db.delete(extra._id);
+          deduped += 1;
+        }
+      }
+      return { seeded: 0, deduped };
     }
 
     await ctx.db.insert("paymentWebhookFailureSummary", {
@@ -228,7 +243,7 @@ export const _seedFailureSummary = internalMutation({
       eventTypes: [],
       updatedAt: Date.now(),
     });
-    return { seeded: 1 };
+    return { seeded: 1, deduped: 0 };
   },
 });
 
@@ -341,7 +356,7 @@ export const getWebhookFailureDiagnostics = internalQuery({
     const summary = await ctx.db
       .query("paymentWebhookFailureSummary")
       .withIndex("by_key", (q) => q.eq("key", "global"))
-      .unique();
+      .first();
     const failures = await ctx.db
       .query("paymentWebhookFailures")
       .withIndex("by_unresolved_lastSeenAt", (q) => q.eq("unresolved", true))

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -1,4 +1,10 @@
-import { internalMutation } from "../_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  type MutationCtx,
+  type QueryCtx,
+} from "../_generated/server";
+import type { Doc } from "../_generated/dataModel";
 import { v } from "convex/values";
 import {
   handleSubscriptionActive,
@@ -12,6 +18,256 @@ import {
   handleDisputeEvent,
 } from "./subscriptionHelpers";
 
+const MAX_FAILURE_MESSAGE_LENGTH = 1000;
+const MAX_FAILURE_DATA_KEYS = 100;
+const MAX_DIAGNOSTIC_ROWS = 250;
+type EventTypeCount = { eventType: string; count: number };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function boundedString(value: unknown, maxLength: number): string | undefined {
+  return typeof value === "string" && value.length > 0
+    ? value.slice(0, maxLength)
+    : undefined;
+}
+
+/** Keep failure rows useful to operators without copying payload values. */
+function sanitizeFailureMessage(value: string): string {
+  return value
+    .replace(/[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/g, "[redacted-email]")
+    .replace(/\b(bearer|token|secret|api[_-]?key|password)\s*[:=]\s*\S+/gi, "$1=[redacted]")
+    .slice(0, MAX_FAILURE_MESSAGE_LENGTH);
+}
+
+function extractFailureContext(rawPayload: unknown) {
+  const payload = asRecord(rawPayload);
+  const data = asRecord(payload?.data);
+  const customer = asRecord(data?.customer);
+
+  return {
+    dodoSubscriptionId: boundedString(data?.subscription_id, 200),
+    dodoPaymentId: boundedString(data?.payment_id, 200),
+    dodoCustomerId: boundedString(customer?.customer_id, 200),
+    dataKeys: data
+      ? Object.keys(data).sort().slice(0, MAX_FAILURE_DATA_KEYS)
+      : [],
+  };
+}
+
+function adjustEventTypeCount(
+  counts: EventTypeCount[],
+  eventType: string,
+  delta: number,
+): EventTypeCount[] {
+  const next = counts.map((entry) => ({ ...entry }));
+  const entry = next.find((candidate) => candidate.eventType === eventType);
+  if (entry) {
+    entry.count += delta;
+  } else if (delta > 0) {
+    next.push({ eventType, count: delta });
+  }
+  return next
+    .filter((candidate) => candidate.count > 0)
+    .sort((a, b) => a.eventType.localeCompare(b.eventType));
+}
+
+async function updateFailureSummary(
+  ctx: MutationCtx,
+  existing: Doc<"paymentWebhookFailures"> | null,
+  eventType: string,
+  updatedAt: number,
+) {
+  const summary = await ctx.db
+    .query("paymentWebhookFailureSummary")
+    .withIndex("by_key", (q) => q.eq("key", "global"))
+    .unique();
+
+  if (!summary) {
+    await ctx.db.insert("paymentWebhookFailureSummary", {
+      key: "global",
+      unresolvedCount: 1,
+      eventTypes: [{ eventType, count: 1 }],
+      updatedAt,
+    });
+    return;
+  }
+
+  let unresolvedCount = summary.unresolvedCount;
+  let eventTypes = summary.eventTypes;
+  if (existing?.unresolved) {
+    // A repeated failure normally keeps the same event type. Handle a
+    // provider correction defensively so the aggregate remains truthful.
+    if (existing.eventType !== eventType) {
+      eventTypes = adjustEventTypeCount(eventTypes, existing.eventType, -1);
+      eventTypes = adjustEventTypeCount(eventTypes, eventType, 1);
+    }
+  } else {
+    unresolvedCount += 1;
+    eventTypes = adjustEventTypeCount(eventTypes, eventType, 1);
+  }
+
+  await ctx.db.patch(summary._id, {
+    unresolvedCount,
+    eventTypes,
+    updatedAt,
+  });
+}
+
+async function getUnresolvedFailureSummary(ctx: QueryCtx) {
+  const rows = await ctx.db
+    .query("paymentWebhookFailureSummary")
+    .withIndex("by_key", (q) => q.eq("key", "global"))
+    .unique();
+  return {
+    unresolvedCount: rows?.unresolvedCount ?? 0,
+    eventTypes: rows?.eventTypes.map((entry) => entry.eventType) ?? [],
+  };
+}
+
+export const recordWebhookFailure = internalMutation({
+  args: {
+    webhookId: v.string(),
+    eventType: v.string(),
+    rawPayload: v.any(),
+    timestamp: v.number(),
+    receivedAt: v.optional(v.number()),
+    errorKind: v.string(),
+    errorMessage: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const receivedAt = args.receivedAt ?? Date.now();
+    const context = extractFailureContext(args.rawPayload);
+    const existing = await ctx.db
+      .query("paymentWebhookFailures")
+      .withIndex("by_webhookId", (q) => q.eq("webhookId", args.webhookId))
+      .first();
+
+    const attemptCount = (existing?.attemptCount ?? 0) + 1;
+    const failure = {
+      webhookId: args.webhookId,
+      eventType: args.eventType,
+      ...context,
+      errorKind: sanitizeFailureMessage(args.errorKind),
+      errorMessage: sanitizeFailureMessage(args.errorMessage),
+      eventTimestamp: args.timestamp,
+      lastSeenAt: receivedAt,
+      attemptCount,
+      unresolved: true,
+      // A retry after manual resolution is a fresh unresolved incident, so
+      // clear the old resolution marker while retaining receivedAt/history.
+      resolvedAt: undefined,
+      resolvedBy: undefined,
+      resolutionNote: undefined,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, failure);
+    } else {
+      await ctx.db.insert("paymentWebhookFailures", {
+        ...failure,
+        receivedAt,
+      });
+    }
+
+    await updateFailureSummary(ctx, existing, args.eventType, receivedAt);
+    const summary = await getUnresolvedFailureSummary(ctx);
+    return {
+      isNew: !existing,
+      attemptCount,
+      errorKind: failure.errorKind,
+      errorMessage: failure.errorMessage,
+      ...summary,
+    };
+  },
+});
+
+/**
+ * Emits one grouped Convex auto-Sentry event after a failure row commits.
+ * Convex forwards structured console errors to Sentry; using a non-throwing
+ * mutation keeps the provider retry path and scheduled-function bookkeeping
+ * independent of the ops signal.
+ */
+export const reportDodoWebhookFailure = internalMutation({
+  args: {
+    webhookId: v.string(),
+    eventType: v.string(),
+    errorKind: v.string(),
+    errorMessage: v.string(),
+    attemptCount: v.number(),
+    unresolvedCount: v.number(),
+    eventTypes: v.array(v.string()),
+  },
+  handler: async (_ctx, args) => {
+    // sentry-coverage-ok: Convex auto-Sentry forwards this structured ops
+    // signal. It is intentionally non-throwing so the scheduler does not
+    // retry or create an unhandled test/deployment failure.
+    console.error(
+      `[webhook] Dodo processing failure (webhookId=${args.webhookId}, eventType=${args.eventType}, errorKind=${args.errorKind}, attemptCount=${args.attemptCount}, unresolvedCount=${args.unresolvedCount}, affectedEventTypes=${args.eventTypes.join(",")}): ${sanitizeFailureMessage(args.errorMessage)}`,
+    );
+  },
+});
+
+export const resolveWebhookFailure = internalMutation({
+  args: {
+    webhookId: v.string(),
+    resolvedBy: v.string(),
+    resolutionNote: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("paymentWebhookFailures")
+      .withIndex("by_webhookId", (q) => q.eq("webhookId", args.webhookId))
+      .first();
+    if (!existing) {
+      throw new Error(`No Dodo webhook failure found for ${args.webhookId}`);
+    }
+
+    await ctx.db.patch(existing._id, {
+      unresolved: false,
+      resolvedAt: Date.now(),
+      resolvedBy: args.resolvedBy.slice(0, 200),
+      resolutionNote: args.resolutionNote
+        ? sanitizeFailureMessage(args.resolutionNote)
+        : undefined,
+    });
+
+    if (existing.unresolved) {
+      const summary = await ctx.db
+        .query("paymentWebhookFailureSummary")
+        .withIndex("by_key", (q) => q.eq("key", "global"))
+        .unique();
+      if (summary) {
+        await ctx.db.patch(summary._id, {
+          unresolvedCount: Math.max(0, summary.unresolvedCount - 1),
+          eventTypes: adjustEventTypeCount(summary.eventTypes, existing.eventType, -1),
+          updatedAt: Date.now(),
+        });
+      }
+    }
+  },
+});
+
+export const listUnresolvedWebhookFailures = internalQuery({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.max(
+      1,
+      Math.min(args.limit ?? 100, MAX_DIAGNOSTIC_ROWS),
+    );
+    return await ctx.db
+      .query("paymentWebhookFailures")
+      .withIndex("by_unresolved_lastSeenAt", (q) => q.eq("unresolved", true))
+      .order("desc")
+      .take(limit);
+  },
+});
+
 /**
  * Idempotent webhook event processor.
  *
@@ -19,9 +275,9 @@ import {
  * deduplicates by webhook-id, records the event, and dispatches
  * to event-type-specific handlers from subscriptionHelpers.
  *
- * On handler failure, the error is returned (not thrown) so Convex
- * rolls back the transaction. The HTTP handler uses the returned
- * error to send a 500 response, which triggers Dodo's retry mechanism.
+ * On handler failure, the error is thrown so Convex rolls back the
+ * transaction. The HTTP handler records a sanitized failure projection in a
+ * separate mutation before returning 500, which triggers Dodo's retry.
  */
 export const processWebhookEvent = internalMutation({
   args: {
@@ -55,9 +311,9 @@ export const processWebhookEvent = internalMutation({
 
     // Minimum shape guard — throw so Convex rolls back and returns 500,
     // causing Dodo to retry instead of silently dropping the event.
-    // Note: permanent schema mismatches will exhaust Dodo's retry budget
-    // without a durable "failed" record. Acceptable for now — Dodo caps
-    // retries, and losing events silently is worse than bounded retries.
+    // The HTTP action records a durable dead-letter projection after this
+    // mutation rejects, outside this transaction, so permanent schema
+    // mismatches remain repairable after Dodo exhausts its retries.
     if (!data || typeof data !== 'object') {
       throw new Error(
         `[webhook] rawPayload.data is missing or not an object (eventType=${args.eventType}, webhookId=${args.webhookId})`,

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -185,6 +185,28 @@ export const recordWebhookFailure = internalMutation({
   },
 });
 
+async function removeUnresolvedFailureFromSummary(
+  ctx: MutationCtx,
+  existing: Doc<"paymentWebhookFailures">,
+  updatedAt: number,
+) {
+  if (!existing.unresolved) {
+    return;
+  }
+
+  const summary = await ctx.db
+    .query("paymentWebhookFailureSummary")
+    .withIndex("by_key", (q) => q.eq("key", "global"))
+    .unique();
+  if (summary) {
+    await ctx.db.patch(summary._id, {
+      unresolvedCount: Math.max(0, summary.unresolvedCount - 1),
+      eventTypes: adjustEventTypeCount(summary.eventTypes, existing.eventType, -1),
+      updatedAt,
+    });
+  }
+}
+
 /**
  * Emits one grouped Convex auto-Sentry event after a failure row commits.
  * Convex forwards structured console errors to Sentry; using a non-throwing
@@ -235,19 +257,30 @@ export const resolveWebhookFailure = internalMutation({
         : undefined,
     });
 
-    if (existing.unresolved) {
-      const summary = await ctx.db
-        .query("paymentWebhookFailureSummary")
-        .withIndex("by_key", (q) => q.eq("key", "global"))
-        .unique();
-      if (summary) {
-        await ctx.db.patch(summary._id, {
-          unresolvedCount: Math.max(0, summary.unresolvedCount - 1),
-          eventTypes: adjustEventTypeCount(summary.eventTypes, existing.eventType, -1),
-          updatedAt: Date.now(),
-        });
-      }
+    await removeUnresolvedFailureFromSummary(ctx, existing, Date.now());
+  },
+});
+
+/** Clear a transient incident when the same provider delivery later succeeds. */
+export const markWebhookFailureRecovered = internalMutation({
+  args: { webhookId: v.string() },
+  handler: async (ctx, { webhookId }) => {
+    const existing = await ctx.db
+      .query("paymentWebhookFailures")
+      .withIndex("by_webhookId", (q) => q.eq("webhookId", webhookId))
+      .first();
+    if (!existing?.unresolved) {
+      return;
     }
+
+    const recoveredAt = Date.now();
+    await ctx.db.patch(existing._id, {
+      unresolved: false,
+      resolvedAt: recoveredAt,
+      resolvedBy: "dodo-retry",
+      resolutionNote: "Processed successfully on provider retry",
+    });
+    await removeUnresolvedFailureFromSummary(ctx, existing, recoveredAt);
   },
 });
 
@@ -265,6 +298,33 @@ export const listUnresolvedWebhookFailures = internalQuery({
       .withIndex("by_unresolved_lastSeenAt", (q) => q.eq("unresolved", true))
       .order("desc")
       .take(limit);
+  },
+});
+
+export const getWebhookFailureDiagnostics = internalQuery({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.max(
+      1,
+      Math.min(args.limit ?? 100, MAX_DIAGNOSTIC_ROWS),
+    );
+    const summary = await ctx.db
+      .query("paymentWebhookFailureSummary")
+      .withIndex("by_key", (q) => q.eq("key", "global"))
+      .unique();
+    const failures = await ctx.db
+      .query("paymentWebhookFailures")
+      .withIndex("by_unresolved_lastSeenAt", (q) => q.eq("unresolved", true))
+      .order("desc")
+      .take(limit);
+
+    return {
+      unresolvedCount: summary?.unresolvedCount ?? 0,
+      eventTypes: summary?.eventTypes ?? [],
+      failures,
+    };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -828,7 +828,11 @@ export default defineSchema({
 
   // Bounded aggregate used for the Sentry/ops signal. Keeping it separate
   // from the dead-letter rows avoids collecting an incident-sized table from
-  // every retry just to report queue counts.
+  // every retry just to report queue counts. The pre-seeded global document
+  // also serializes failure-row inserts and lifecycle transitions; see
+  // `payments/webhookMutations:_seedFailureSummary` and the Convex deploy
+  // workflow. It must not be lazily created in the failure mutation because
+  // an empty index range does not serialize concurrent first inserts.
   paymentWebhookFailureSummary: defineTable({
     key: v.literal("global"),
     unresolvedCount: v.number(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -799,6 +799,48 @@ export default defineSchema({
     .index("by_webhookId", ["webhookId"])
     .index("by_eventType", ["eventType"]),
 
+  // Durable dead-letter records for Dodo events that fail processing. Keep
+  // this projection intentionally payload-free: operators need stable Dodo
+  // identifiers and shape metadata to repair a subscription/payment, not a
+  // second copy of customer data or webhook secrets.
+  paymentWebhookFailures: defineTable({
+    webhookId: v.string(),
+    eventType: v.string(),
+    dodoSubscriptionId: v.optional(v.string()),
+    dodoPaymentId: v.optional(v.string()),
+    dodoCustomerId: v.optional(v.string()),
+    errorKind: v.string(),
+    errorMessage: v.string(),
+    dataKeys: v.array(v.string()),
+    eventTimestamp: v.number(),
+    receivedAt: v.number(),
+    lastSeenAt: v.number(),
+    attemptCount: v.number(),
+    unresolved: v.boolean(),
+    resolvedAt: v.optional(v.number()),
+    resolvedBy: v.optional(v.string()),
+    resolutionNote: v.optional(v.string()),
+  })
+    .index("by_webhookId", ["webhookId"])
+    .index("by_unresolved_lastSeenAt", ["unresolved", "lastSeenAt"])
+    .index("by_dodoSubscriptionId", ["dodoSubscriptionId"])
+    .index("by_dodoPaymentId", ["dodoPaymentId"]),
+
+  // Bounded aggregate used for the Sentry/ops signal. Keeping it separate
+  // from the dead-letter rows avoids collecting an incident-sized table from
+  // every retry just to report queue counts.
+  paymentWebhookFailureSummary: defineTable({
+    key: v.literal("global"),
+    unresolvedCount: v.number(),
+    eventTypes: v.array(
+      v.object({
+        eventType: v.string(),
+        count: v.number(),
+      }),
+    ),
+    updatedAt: v.number(),
+  }).index("by_key", ["key"]),
+
   paymentEvents: defineTable({
     userId: v.string(),
     dodoPaymentId: v.string(),


### PR DESCRIPTION
## Summary

Dodo webhook processing failures previously returned `500` for provider retries but left no durable, privacy-safe incident or repair context. Failed deliveries are now observable through a sanitized projection and bounded operations signal, while successful provider retries automatically clear transient incidents.

- Records failures by `webhookId`, updates retry attempts idempotently, and keeps distinct deliveries separate even for the same subscription.
- Stores only bounded identifiers, error metadata, event timestamps, and payload shape keys; raw payloads and sensitive values are excluded.
- Preserves the provider-facing retry contract and schedules the production Sentry/operations signal only after the failure row commits.
- Initializes failure-summary state immediately after deployment, attempts every independent post-deploy seed, and fails the aggregate deployment gate if any seed fails.
- Tolerates and deduplicates legacy/concurrent singleton summary rows, with a daily idempotent self-healing seed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Payments / Convex webhook operations

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant (not applicable: backend-only)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (not applicable: backend-only)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

Not applicable: this backend reliability change does not publish or alter documentation claims.

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

## Screenshots

Not applicable: backend-only change.

## New concepts

### Payload-free dead-letter projections

A dead-letter projection is a durable, reduced record of an event that could not be processed. It preserves enough identity and shape information for repair while deliberately discarding the original payload, which may contain secrets or customer data.

This PR uses `paymentWebhookFailures` for the projection and a bounded summary row for unresolved counts and event-type distribution. A repeated `webhookId` updates one row and increments its attempt count; a later successful retry marks that row recovered. This pattern is useful for webhook or queue consumers where retrying the original message is desirable but retaining every failed message is unsafe or too expensive.

Do not use a projection when operators must replay the exact original message; in that case, use an access-controlled encrypted queue or archive instead.

## Validation

- Focused webhook-failure suite: 10/10 tests passed, including production scheduler wiring, signed HTTP retry recovery, and duplicate-summary self-healing.
- `npm run typecheck:all`, Biome checks on the changed TypeScript, workflow YAML parsing, mutation proofs, and every active pre-push guard passed.
- All 23 observed GitHub checks completed successfully, with 2 expected skips; this includes Convex tests, unit tests, type checks, Biome, security audits, deployment gates, and Vercel previews.
- A full local Convex run passed 51/52 files and 897/898 tests; the only failure was an unrelated 5-second timeout in `poolSelection.test.ts`, which passed 12/12 in isolation and also passed in GitHub's `convex-tests` job.

Fixes #4772
