### PR TITLE
fix(seo): restore valid robots.txt for Lighthouse

### DIFF
--- a/public/agents.md
+++ b/public/agents.md
@@ -15,7 +15,7 @@ World Monitor is a real-time global intelligence dashboard: 500+ news feeds, 56 
 - **SDKs:** Python `pip install worldmonitor-sdk` · Ruby `gem install worldmonitor` · Go `go get github.com/koala73/worldmonitor/sdk/go` · JavaScript npm `worldmonitor` — guide: https://www.worldmonitor.app/docs/sdks
 - **Sandbox / test environment:** https://www.worldmonitor.app/sandbox/index.json — deterministic, schema-valid sample responses for representative REST operations; no auth, no quota, safe for CI. Guide: https://www.worldmonitor.app/docs/sandbox
 - **LLM briefings:** https://worldmonitor.app/llms.txt (overview) · https://worldmonitor.app/llms-full.txt (full reference) · section files: https://worldmonitor.app/api/llms.txt (API) · https://www.worldmonitor.app/docs/llms.txt (docs) · https://worldmonitor.app/developers/llms.txt (developer portal) · https://www.worldmonitor.app/blog/llms.txt (blog)
-- **Schema map:** https://www.worldmonitor.app/schemamap.xml — NLWeb schemamap indexing the structured-data surfaces (also advertised via the `Schemamap:` directive in robots.txt)
+- **Schema map:** https://www.worldmonitor.app/schemamap.xml — NLWeb schemamap indexing the structured-data surfaces
 - **Developer portal:** https://worldmonitor.app/developers.md — links every developer resource by name. Named resource pages: [MCP Server](https://worldmonitor.app/mcp-server.md) · [OpenAPI Specification](https://worldmonitor.app/openapi.md) · [SDKs](https://worldmonitor.app/sdks.md)
 
 ## Authentication

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -147,7 +147,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - [developers/llms.txt](https://worldmonitor.app/developers/llms.txt): Developer-portal-section briefing — MCP server, OpenAPI, SDKs, CLI, sandbox, and agent skills in one scoped file
 - [blog/llms.txt](https://www.worldmonitor.app/blog/llms.txt): Blog-section briefing — analysis posts, the intelligence glossary, and the RSS feed
 - [Sandbox](https://www.worldmonitor.app/sandbox/index.json): Deterministic sample responses for representative REST operations — test parsers and integrations with no key and no quota ([guide](https://www.worldmonitor.app/docs/sandbox))
-- [Schema Map](https://www.worldmonitor.app/schemamap.xml): NLWeb schemamap indexing the site's structured-data surfaces (also advertised in robots.txt)
+- [Schema Map](https://www.worldmonitor.app/schemamap.xml): NLWeb schemamap indexing the site's structured-data surfaces
 - [pricing.md](https://worldmonitor.app/pricing.md): Machine-readable pricing, limits and plan features
 - [support.md](https://worldmonitor.app/support.md): Machine-readable support channels and contact routes
 - [ai-search.md](https://worldmonitor.app/ai-search.md): AI-search answer blocks for citation and extraction

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -63,7 +63,3 @@ Sitemap: https://www.worldmonitor.app/sitemap.xml
 Sitemap: https://www.worldmonitor.app/blog/sitemap-index.xml
 # Mintlify owns the documentation index, including /docs/zh/ translations.
 Sitemap: https://www.worldmonitor.app/docs/sitemap.xml
-
-# NLWeb Schema Map — structured-data index for AI agents (kept in parity with
-# public/schemamap.xml by tests/deploy-config.test.mjs).
-Schemamap: https://www.worldmonitor.app/schemamap.xml

--- a/public/schemamap.xml
+++ b/public/schemamap.xml
@@ -3,10 +3,10 @@
      fetch schema.org data directly instead of extracting it from HTML.
      Emerging convention (NLWeb / AgentReady) with no external standard yet;
      the namespace and <url><loc><schema> shape follow the published ora.ai
-     reference implementation. Advertised via the `Schemamap:` directive in
-     public/robots.txt — both sides are guarded in tests/deploy-config.test.mjs
-     (directive parity + every <loc> must resolve to a tracked file or a live
-     route, so this file can never point at a 404). -->
+     reference implementation. Published at the stable /schemamap.xml path and
+     linked from agents.md, llms.txt, and agent-view.json. Resolution guards in
+     tests/deploy-config.test.mjs ensure every <loc> resolves to a tracked file
+     or a live route, so this file can never point at a 404. -->
 <schemamap xmlns="http://www.nlweb.ai/schemas/schemamap/0.1">
   <url>
     <loc>https://www.worldmonitor.app/</loc>

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2643,16 +2643,22 @@ describe('agent readiness: named developer-resource pages (#4953)', () => {
   });
 });
 
-// NLWeb schemamap (orank "NLWeb Schema Feeds"): the robots.txt `Schemamap:`
-// directive and public/schemamap.xml must stay in parity, and every <loc> the
-// map advertises must resolve to a tracked file or a live route — a schemamap
-// pointing at a 404 is worse than none (same dead-pointer class as the deleted
-// Wikidata QID incident).
+// NLWeb schemamap (orank "NLWeb Schema Feeds"): keep the file published and
+// discoverable without advertising it through robots.txt. Lighthouse rejects
+// the emerging `Schemamap:` directive as unknown, dropping SEO 100 -> 92 on
+// every route; #4835 tracks the upstream safelist unblock. Every <loc> must
+// still resolve to a tracked file or a live route — a schemamap pointing at a
+// 404 is worse than none (same dead-pointer class as the deleted Wikidata QID
+// incident).
 describe('NLWeb schemamap (/schemamap.xml)', () => {
   const schemamapSource = readFileSync(resolve(__dirname, '../public/schemamap.xml'), 'utf-8');
 
-  it('robots.txt advertises the schemamap and the file exists', () => {
-    assert.match(robotsSource, /^Schemamap: https:\/\/www\.worldmonitor\.app\/schemamap\.xml$/m);
+  it('keeps the file published without an unsupported robots.txt directive', () => {
+    assert.doesNotMatch(
+      robotsSource,
+      /^Schemamap:/mi,
+      'Lighthouse rejects Schemamap as an unknown robots.txt directive; see #4835'
+    );
     assert.match(schemamapSource, /^<\?xml version="1\.0" encoding="UTF-8"\?>/);
     assert.ok(
       schemamapSource.includes('<schemamap xmlns="http://www.nlweb.ai/schemas/schemamap/0.1">'),


### PR DESCRIPTION
## Summary

DebugBear/Lighthouse SEO returns from 92 to 100 across monitored routes by removing the unsupported `Schemamap:` record that invalidated the site-wide robots audit. The schema map itself remains published and directly discoverable through `agents.md`, `llms.txt`, and `agent-view.json`; only the incompatible robots advertisement is removed. A deploy-config regression guard now rejects reintroduction until Lighthouse adds upstream support.

Related: #4835

## Validation

- `tsx --test tests/deploy-config.test.mjs` — 164/164 passed
- `node --test tests/agent-mode-view.test.mjs` — 8/8 passed
- Full pre-push hook — passed (typechecks, boundary/deploy checks, Markdown lint, version sync)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
