### PR TITLE
test(bootstrap): cover DebugBear sampling boundaries

### DIFF
--- a/tests/debugbear-rum.test.mts
+++ b/tests/debugbear-rum.test.mts
@@ -57,7 +57,11 @@ interface FakeDebugBearScript {
   fetchPriority?: string;
 }
 
-function installDebugBearHarness(hostname: string, existingScript: FakeDebugBearScript | null = null): {
+function installDebugBearHarness(
+  hostname: string,
+  existingScript: FakeDebugBearScript | null = null,
+  random: () => number = () => 0,
+): {
   appendedScripts: FakeDebugBearScript[];
   listeners: Map<string, (event: Event) => void>;
   win: Window & { dbbRum?: unknown[] };
@@ -94,7 +98,7 @@ function installDebugBearHarness(hostname: string, existingScript: FakeDebugBear
   // Force the sample gate to pass deterministically so these tests verify behavior WHEN sampled,
   // independent of DEBUGBEAR_RUM_SAMPLE_RATE (< 100 makes real Math.random probabilistic).
   const savedRandom = Math.random;
-  Math.random = () => 0;
+  Math.random = random;
 
   return {
     appendedScripts,
@@ -201,12 +205,28 @@ describe('DebugBear RUM loader', () => {
       h.restore();
     }
   });
+
+  it('keeps the RUM sample rate at 10% and skips out-of-sample loads', () => {
+    assert.equal(DEBUGBEAR_RUM_SAMPLE_RATE, 10);
+
+    const h = installDebugBearHarness('worldmonitor.app', null, () => 0.1);
+    try {
+      initDebugBearRum();
+
+      assert.equal(h.appendedScripts.length, 0);
+      assert.equal(h.win.dbbRum, undefined);
+      assert.equal(h.listeners.size, 0);
+    } finally {
+      h.restore();
+    }
+  });
 });
 
 describe('DebugBear RUM marketing loader', () => {
   it('uses the same script endpoint and sample rate as the dashboard loader', () => {
     assert.equal(MARKETING_DEBUGBEAR_RUM_SCRIPT_SRC, DEBUGBEAR_RUM_SCRIPT_SRC);
     assert.equal(MARKETING_DEBUGBEAR_RUM_SAMPLE_RATE, DEBUGBEAR_RUM_SAMPLE_RATE);
+    assert.equal(MARKETING_DEBUGBEAR_RUM_SAMPLE_RATE, 10);
   });
 
   it('uses the same production-host gate as the dashboard loader', () => {
@@ -242,6 +262,19 @@ describe('DebugBear RUM marketing loader', () => {
       assert.deepEqual(h.win.dbbRum?.[0], ['presampling', MARKETING_DEBUGBEAR_RUM_SAMPLE_RATE]);
       assert.ok(h.listeners.has('error'), 'window error listener missing');
       assert.ok(h.listeners.has('unhandledrejection'), 'window unhandledrejection listener missing');
+    } finally {
+      h.restore();
+    }
+  });
+
+  it('skips out-of-sample marketing page loads', () => {
+    const h = installDebugBearHarness('worldmonitor.app', null, () => 0.1);
+    try {
+      initMarketingDebugBearRum();
+
+      assert.equal(h.appendedScripts.length, 0);
+      assert.equal(h.win.dbbRum, undefined);
+      assert.equal(h.listeners.size, 0);
     } finally {
       h.restore();
     }


### PR DESCRIPTION
## Summary

DebugBear's 10% RUM sampling boundary is now protected on both dashboard and marketing pages. An out-of-sample page load is verified to create no script, queue, or event listener, so an accidental always-on sampling change fails the suite.

Related: #5536

## Validation

- `TMPDIR=/tmp npx --no-install tsx --test tests/debugbear-rum.test.mts`
- Repository pre-push suite, including frontend and API typechecks plus changed-test checks

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000?logoColor=white)
