### PR TITLE
fix(routing): redirect pricing to canonical section

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -671,6 +671,29 @@ describe('welcome landing page routing', () => {
     assert.equal(redirect.permanent, true);
   });
 
+  it('redirects the human pricing route to the canonical pricing section before SPA routing', () => {
+    const redirect = vercelConfig.redirects.find((r) => r.source === '/pricing');
+    assert.ok(redirect, 'expected a redirect for /pricing');
+    assert.equal(redirect.destination, '/pro#pricing');
+    assert.equal(redirect.permanent, true);
+
+    assert.equal(
+      vercelConfig.redirects.some((r) => r.source === '/pricing.md'),
+      false,
+      'the machine-readable pricing contract must remain a static asset',
+    );
+    assert.equal(
+      vercelConfig.redirects.some((r) => r.source === '/api/product-catalog'),
+      false,
+      'the live product catalog endpoint must remain unchanged',
+    );
+    assert.equal(
+      vercelConfig.rewrites.some((r) => r.source === '/pricing'),
+      false,
+      '/pricing must be handled in the redirects phase before the SPA rewrites phase',
+    );
+  });
+
   it('redirects bare corpus roots to canonical generated pages', () => {
     const changelog = vercelConfig.redirects.find((r) => r.source === '/changelog');
     assert.ok(changelog, 'expected a redirect for /changelog');

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,7 @@
     { "source": "/security.txt", "destination": "/.well-known/security.txt", "permanent": true },
     { "source": "/index.html", "destination": "/", "permanent": true },
     { "source": "/welcome", "destination": "/", "permanent": true },
+    { "source": "/pricing", "destination": "/pro#pricing", "permanent": true },
     { "source": "/blog/posts", "destination": "/blog", "permanent": true },
     { "source": "/changelog", "destination": "/reference/changelog/", "permanent": true },
     { "source": "/reference", "destination": "/reference/changelog/", "permanent": false },


### PR DESCRIPTION
## Summary

Conventional `/pricing` links now land on the Pro plan catalog instead of falling through to the dashboard SPA. The redirect is permanent and narrow: Vercel preserves incoming query parameters, while `/pricing.md` and `/api/product-catalog` remain independent machine-readable contracts.

## Validation

- Proof-first regression: the focused route test failed before the redirect existed, then passed after the config change.
- Deploy configuration suite: 165 passed, 0 failed.
- Full-variant Vite build and built-output CSS checks: build passed; 9 passed, 0 failed.
- Pre-push gate: frontend/API/Convex typechecks, edge bundle, architecture/policy guards, and change-scoped tests passed.
- Seven-reviewer `ce-code-review` pass: no actionable findings.

## Post-Deploy Monitoring & Validation

- After the production deployment, request `/pricing?source=postdeploy` and record the status plus `Location`; healthy behavior is a permanent redirect with the query parameter preserved and the final `#pricing` fragment.
- Confirm `/pricing.md` still returns the markdown pricing contract and `/api/product-catalog` still returns its JSON contract without redirecting.
- Open `/pricing?source=postdeploy` in a browser and confirm it lands on the pricing section of `/pro`.
- Treat a `200` dashboard response, a missing query/fragment, or either machine contract redirecting as a rollback signal.
- Validate on the first production deployment and recheck within 24 hours; the PR author or deploying maintainer owns the check.
- Roll back by reverting this PR if the redirect or adjacent contract checks fail.

Fixes #5542

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5.6_SOL-000000)
