### PR TITLE
fix(seo): prevent raw-text crawlers from extracting WWorld Monitor

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,7 @@
       .skeleton-header-right{display:flex;align-items:center;gap:12px}
       .skeleton-brand{display:flex;align-items:center;gap:8px;margin:0;color:#f5f5f5;font-size:14px;line-height:1;font-weight:800}
       .skeleton-brand-mark{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border:1px solid #2f8f68;border-radius:50%;color:#4ade80;font-size:12px;line-height:1}
+      .skeleton-brand-mark::after{content:"W"}
       .skeleton-kicker{color:#9ca3af;font-size:11px;line-height:1;white-space:nowrap}
       .skeleton-chip{display:inline-flex;align-items:center;min-height:22px;padding:0 8px;border:1px solid #2a2a2a;border-radius:4px;color:#d1d5db;background:#181818;font-size:11px;line-height:1;white-space:nowrap}
       .skeleton-chip.live{color:#86efac;border-color:#14532d;background:#062317}
@@ -455,7 +456,7 @@
       <div class="skeleton-shell" aria-busy="true" aria-label="World Monitor dashboard loading">
         <div class="skeleton-header">
           <div class="skeleton-header-left">
-            <div class="skeleton-brand"><span class="skeleton-brand-mark" aria-hidden="true">W</span><span>World Monitor</span></div>
+            <div class="skeleton-brand"><span class="skeleton-brand-mark" aria-hidden="true"></span><span>World Monitor</span></div>
             <span class="skeleton-kicker">Dashboard shell loading</span>
             <span class="skeleton-dot" aria-hidden="true"></span>
           </div>

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2776,3 +2776,28 @@ describe('section-scoped llms.txt files', () => {
     }
   });
 });
+
+describe('skeleton brand text extraction (#5541)', () => {
+  const indexHtml = readFileSync(resolve(__dirname, '../index.html'), 'utf-8');
+
+  it('.skeleton-brand raw textContent does not contain "WWorld"', () => {
+    const match = indexHtml.match(/<div class="skeleton-brand">([\s\S]*?)<\/div>/);
+    assert.ok(match, 'index.html must contain .skeleton-brand element');
+    // Simulate raw textContent: strip all HTML tags
+    const rawText = match[1].replace(/<[^>]+>/g, '');
+    assert.doesNotMatch(rawText, /WWorld/, 'skeleton-brand raw text must not concatenate as "WWorld Monitor"');
+    assert.match(rawText, /World Monitor/, 'skeleton-brand raw text must contain "World Monitor"');
+  });
+
+  it('.skeleton-brand-mark is aria-hidden and has no text content', () => {
+    const markMatch = indexHtml.match(/<span class="skeleton-brand-mark"[^>]*>([\s\S]*?)<\/span>/);
+    assert.ok(markMatch, 'index.html must contain .skeleton-brand-mark element');
+    assert.match(markMatch[0], /aria-hidden="true"/, 'skeleton-brand-mark must be aria-hidden');
+    const markText = markMatch[1].replace(/<[^>]+>/g, '').trim();
+    assert.equal(markText, '', 'skeleton-brand-mark must have no text content (use CSS ::after instead)');
+  });
+
+  it('.skeleton-brand-mark renders "W" via CSS content pseudo-element', () => {
+    assert.match(indexHtml, /\.skeleton-brand-mark::after\s*\{\s*content:\s*"W"\s*\}/, 'skeleton-brand-mark must render W via CSS ::after content');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5541 — raw-text crawlers were extracting "WWorld Monitor" from the skeleton brand due to adjacent text nodes.

## Changes

- **`index.html`**: Removed the inline `W` text from `.skeleton-brand-mark` and rendered it via CSS `::after { content: "W" }` instead. The span is now empty, so `textContent` extraction yields just "World Monitor".

- **`tests/deploy-config.test.mjs`**: Added 3 regression tests:
  - Raw text of `.skeleton-brand` does not contain "WWorld"
  - `.skeleton-brand-mark` has no text content and is `aria-hidden`
  - The "W" is rendered via CSS `::after` content

## Visual impact

None. The `::after` pseudo-element inherits the same `color`, `font-size`, and flex layout from `.skeleton-brand-mark`. First-paint footprint unchanged.

## Testing

- Verified raw text extraction yields "World Monitor" (not "WWorld Monitor")
- All 3 regression tests pass
- `aria-hidden="true"` preserved on the brand mark (no accessibility change)
