### PR TITLE
fix(renewable): replace hardcoded fallback with last-known-good data

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -3879,11 +3879,11 @@ export class DataLoaderManager implements AppModule {
 
   private async loadRenewableData(): Promise<void> {
     const { fetchRenewableEnergyData, fetchEnergyCapacity } = await import('@/services/renewable-energy-data');
-    const data = await fetchRenewableEnergyData();
-    this.callPanel('renewable', 'setData', data);
-    if (SITE_VARIANT === 'happy' && data?.globalPercentage) {
+    const result = await fetchRenewableEnergyData();
+    this.callPanel('renewable', 'setData', result);
+    if (SITE_VARIANT === 'happy' && result.state === 'live' && result.data?.globalPercentage) {
       checkMilestones({
-        renewablePercent: data.globalPercentage,
+        renewablePercent: result.data.globalPercentage,
       });
     }
     try {

--- a/src/components/RenewableEnergyPanel.ts
+++ b/src/components/RenewableEnergyPanel.ts
@@ -9,7 +9,12 @@
 import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import * as d3 from 'd3';
-import type { RenewableEnergyData, RegionRenewableData, CapacitySeries } from '@/services/renewable-energy-data';
+import type {
+  RenewableEnergyFetchResult,
+  RegionRenewableData,
+  CapacitySeries,
+} from '@/services/renewable-energy-data';
+import { describeFreshness } from '@/services/persistent-cache';
 import { getCSSColor } from '@/utils';
 import { replaceChildren } from '@/utils/dom-utils';
 
@@ -21,11 +26,18 @@ export class RenewableEnergyPanel extends Panel {
   /**
    * Set data and render the full panel: gauge + sparkline + regional breakdown.
    */
-  public setData(data: RenewableEnergyData): void {
+  public setData(result: RenewableEnergyFetchResult): void {
     replaceChildren(this.content);
+    const { data, state, cachedAt } = result;
 
-    // Empty state
-    if (data.globalPercentage === 0 && !data.regions?.length) {
+    if (state === 'cached') {
+      this.setDataBadge('cached', cachedAt === null ? undefined : describeFreshness(cachedAt));
+    } else {
+      this.setDataBadge(state);
+    }
+
+    // Fail closed when neither live nor bounded last-known-good data exists.
+    if (data === null || (data.globalPercentage === 0 && !data.regions?.length)) {
       const empty = document.createElement('div');
       empty.className = 'renewable-empty';
       Object.assign(empty.style, {

--- a/src/services/renewable-energy-data.ts
+++ b/src/services/renewable-energy-data.ts
@@ -160,7 +160,10 @@ export function createRenewableEnergyService(options: RenewableEnergyServiceOpti
         shouldCache: isRenewableEnergySnapshot,
       },
     );
-    if (snapshot === null) {
+    if (
+      snapshot === null
+      || Date.now() - snapshot.cachedAt > RENEWABLE_DATA_STALE_CEILING_MS
+    ) {
       return {
         data: null,
         state: 'unavailable',

--- a/src/services/renewable-energy-data.ts
+++ b/src/services/renewable-energy-data.ts
@@ -9,8 +9,7 @@
  * endpoint since it's a different data source (not World Bank).
  */
 
-import { fetchEnergyCapacityRpc } from '@/services/economic';
-import { createCircuitBreaker } from '@/utils';
+import { createCircuitBreaker } from '@/utils/circuit-breaker';
 import { getHydratedData } from '@/services/bootstrap';
 import { toApiUrl } from '@/services/runtime';
 
@@ -30,37 +29,74 @@ export interface RenewableEnergyData {
   regions: RegionRenewableData[];    // Regional breakdown
 }
 
-// ---- Default / Empty ----
+export type RenewableDataState = 'live' | 'cached' | 'unavailable';
 
-// Static fallback when seed data is unavailable and no cache exists.
-// Source: https://data.worldbank.org/indicator/EG.ELC.RNEW.ZS — last verified Feb 2026
-const FALLBACK_DATA: RenewableEnergyData = {
-  globalPercentage: 29.6,
-  globalYear: 2022,
-  historicalData: [
-    { year: 1990, value: 19.8 }, { year: 1995, value: 19.2 }, { year: 2000, value: 18.6 },
-    { year: 2005, value: 18.0 }, { year: 2010, value: 20.3 }, { year: 2012, value: 21.6 },
-    { year: 2014, value: 22.6 }, { year: 2016, value: 24.0 }, { year: 2018, value: 25.7 },
-    { year: 2020, value: 28.2 }, { year: 2021, value: 28.7 }, { year: 2022, value: 29.6 },
-  ],
-  regions: [
-    { code: 'LCN', name: 'Latin America & Caribbean', percentage: 58.1, year: 2022 },
-    { code: 'SSF', name: 'Sub-Saharan Africa', percentage: 47.2, year: 2022 },
-    { code: 'ECS', name: 'Europe & Central Asia', percentage: 35.8, year: 2022 },
-    { code: 'SAS', name: 'South Asia', percentage: 22.1, year: 2022 },
-    { code: 'EAS', name: 'East Asia & Pacific', percentage: 21.9, year: 2022 },
-    { code: 'NAC', name: 'North America', percentage: 21.5, year: 2022 },
-    { code: 'MEA', name: 'Middle East & N. Africa', percentage: 5.3, year: 2022 },
-  ],
-};
+export interface RenewableEnergyFetchResult {
+  data: RenewableEnergyData | null;
+  state: RenewableDataState;
+  cachedAt: number | null;
+}
 
-// ---- Circuit Breaker (persistent cache for instant reload) ----
+interface RenewableEnergySnapshot {
+  data: RenewableEnergyData;
+  cachedAt: number;
+}
 
-const renewableBreaker = createCircuitBreaker<RenewableEnergyData>({
-  name: 'Renewable Energy',
-  cacheTtlMs: 60 * 60 * 1000, // 1h — World Bank data changes yearly
-  persistCache: true,
-});
+export const RENEWABLE_DATA_STALE_CEILING_MS = 7 * 24 * 60 * 60 * 1000;
+export const RENEWABLE_DATA_CACHE_KEY = 'world-bank-v2';
+
+export interface RenewableEnergyServiceOptions {
+  breakerName?: string;
+  cacheKey?: string;
+  persistCache?: boolean;
+  getHydrated?: () => unknown;
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+function isPercentage(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 100;
+}
+
+function isObservationYear(value: unknown): value is number {
+  return Number.isInteger(value)
+    && (value as number) >= 1900
+    && (value as number) <= new Date().getUTCFullYear() + 1;
+}
+
+export function isRenewableEnergyData(value: unknown): value is RenewableEnergyData {
+  if (typeof value !== 'object' || value === null) return false;
+  const data = value as Partial<RenewableEnergyData>;
+
+  if (!isPercentage(data.globalPercentage) || !isObservationYear(data.globalYear)) return false;
+  if (!Array.isArray(data.historicalData) || data.historicalData.length === 0) return false;
+  if (!data.historicalData.every(point =>
+    typeof point === 'object'
+    && point !== null
+    && isObservationYear(point.year)
+    && isPercentage(point.value)
+  )) return false;
+  if (!Array.isArray(data.regions)) return false;
+
+  return data.regions.every(region =>
+    typeof region === 'object'
+    && region !== null
+    && typeof region.code === 'string'
+    && region.code.length > 0
+    && typeof region.name === 'string'
+    && region.name.length > 0
+    && isPercentage(region.percentage)
+    && isObservationYear(region.year)
+  );
+}
+
+function isRenewableEnergySnapshot(value: unknown): value is RenewableEnergySnapshot {
+  if (typeof value !== 'object' || value === null) return false;
+  const snapshot = value as Partial<RenewableEnergySnapshot>;
+  return isRenewableEnergyData(snapshot.data)
+    && typeof snapshot.cachedAt === 'number'
+    && Number.isFinite(snapshot.cachedAt)
+    && snapshot.cachedAt > 0;
+}
 
 const capacityBreaker = createCircuitBreaker<CapacitySeries[]>({
   name: 'Energy Capacity',
@@ -70,32 +106,96 @@ const capacityBreaker = createCircuitBreaker<CapacitySeries[]>({
 
 // ---- Data Fetching (from Railway seed via bootstrap) ----
 
-async function fetchRenewableEnergyDataFresh(): Promise<RenewableEnergyData> {
-  // 1. Try bootstrap hydration cache (first page load)
-  const hydrated = getHydratedData('renewableEnergy') as RenewableEnergyData | undefined;
-  if (hydrated?.historicalData?.length) return hydrated;
+export function createRenewableEnergyService(options: RenewableEnergyServiceOptions = {}) {
+  const breaker = createCircuitBreaker<RenewableEnergySnapshot | null>({
+    name: options.breakerName ?? 'Renewable Energy',
+    cacheTtlMs: 60 * 60 * 1000, // 1h — World Bank data changes yearly
+    persistCache: options.persistCache ?? true,
+    // Match the weekly seed-health contract. Older observations remain visible
+    // in the payload's `globalYear`; this ceiling bounds retrieval staleness.
+    persistentStaleCeilingMs: RENEWABLE_DATA_STALE_CEILING_MS,
+  });
+  const cacheKey = options.cacheKey ?? RENEWABLE_DATA_CACHE_KEY;
+  const getHydrated = options.getHydrated ?? (() => getHydratedData('renewableEnergy'));
+  const fetchImpl = options.fetchImpl ?? ((...args) => globalThis.fetch(...args));
 
-  // 2. Fallback: fetch from bootstrap endpoint directly
-  try {
-    const resp = await fetch(toApiUrl('/api/bootstrap?keys=renewableEnergy'), {
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (resp.ok) {
-      const { data } = (await resp.json()) as { data: { renewableEnergy?: RenewableEnergyData } };
-      if (data.renewableEnergy?.historicalData?.length) return data.renewableEnergy;
+  async function fetchFresh(): Promise<RenewableEnergyData> {
+    // 1. Try bootstrap hydration cache (first page load)
+    const hydrated = getHydrated();
+    if (isRenewableEnergyData(hydrated)) return hydrated;
+
+    // 2. Fetch from the canonical bootstrap endpoint directly.
+    try {
+      const resp = await fetchImpl(toApiUrl('/api/bootstrap?keys=renewableEnergy'), {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (resp.ok) {
+        const payload = (await resp.json()) as { data?: { renewableEnergy?: unknown } };
+        if (isRenewableEnergyData(payload.data?.renewableEnergy)) {
+          return payload.data.renewableEnergy;
+        }
+      }
+    } catch { /* fall through */ }
+
+    // Throw so the breaker can preserve a validated last-known-good entry.
+    // Without one, execute() returns null and the panel fails closed.
+    throw new Error('Renewable energy data unavailable');
+  }
+
+  async function fetchData(): Promise<RenewableEnergyFetchResult> {
+    let freshSnapshot: RenewableEnergySnapshot | null = null;
+    const snapshot = await breaker.execute<RenewableEnergySnapshot | null>(
+      async () => {
+        freshSnapshot = {
+          data: await fetchFresh(),
+          cachedAt: Date.now(),
+        };
+        return freshSnapshot;
+      },
+      null,
+      {
+        // The versioned key prevents pre-fix entries—which may contain the old
+        // hardcoded snapshot—from being mistaken for canonical observations.
+        cacheKey,
+        shouldCache: isRenewableEnergySnapshot,
+      },
+    );
+    if (snapshot === null) {
+      return {
+        data: null,
+        state: 'unavailable',
+        cachedAt: null,
+      };
     }
-  } catch { /* fall through */ }
 
-  // 3. Static fallback
-  return FALLBACK_DATA;
+    // Object identity keeps classification atomic even when stale-while-
+    // revalidate completes between execute() and this continuation.
+    const state: RenewableDataState = snapshot === freshSnapshot ? 'live' : 'cached';
+
+    return {
+      data: snapshot.data,
+      state,
+      cachedAt: state === 'cached' ? snapshot.cachedAt : null,
+    };
+  }
+
+  return {
+    fetchFresh,
+    fetch: fetchData,
+  };
+}
+
+const renewableEnergyService = createRenewableEnergyService();
+
+export async function fetchRenewableEnergyDataFresh(): Promise<RenewableEnergyData> {
+  return renewableEnergyService.fetchFresh();
 }
 
 /**
- * Fetch renewable energy data with persistent caching.
- * Returns instantly from IndexedDB cache on subsequent loads.
+ * Fetch renewable energy data with bounded persistent last-known-good caching.
  */
-export async function fetchRenewableEnergyData(): Promise<RenewableEnergyData> {
-  return renewableBreaker.execute(() => fetchRenewableEnergyDataFresh(), FALLBACK_DATA);
+export async function fetchRenewableEnergyData(): Promise<RenewableEnergyFetchResult> {
+  return renewableEnergyService.fetch();
 }
 
 // ========================================================================
@@ -120,6 +220,7 @@ export interface CapacitySeries {
  */
 export async function fetchEnergyCapacity(): Promise<CapacitySeries[]> {
   return capacityBreaker.execute(async () => {
+    const { fetchEnergyCapacityRpc } = await import('@/services/economic');
     const resp = await fetchEnergyCapacityRpc(['SUN', 'WND', 'COL'], 25);
     return resp.series.map(s => ({
       source: s.energySource,

--- a/tests/helpers/mini-dom.mts
+++ b/tests/helpers/mini-dom.mts
@@ -170,12 +170,40 @@ interface MiniAttributeSelector {
   value: string | null;
 }
 
+type MiniStyleDeclaration = Record<string, string> & {
+  getPropertyValue(name: string): string;
+  removeProperty(name: string): string;
+  setProperty(name: string, value: string): void;
+};
+
+function createMiniStyleDeclaration(): MiniStyleDeclaration {
+  const style = {} as MiniStyleDeclaration;
+  Object.defineProperties(style, {
+    getPropertyValue: {
+      value: (name: string) => style[name] ?? '',
+    },
+    removeProperty: {
+      value: (name: string) => {
+        const previous = style[name] ?? '';
+        delete style[name];
+        return previous;
+      },
+    },
+    setProperty: {
+      value: (name: string, value: string) => {
+        style[name] = String(value);
+      },
+    },
+  });
+  return style;
+}
+
 export class MiniElement extends MiniNode {
   readonly nodeType = MiniNode.ELEMENT_NODE;
   readonly attributes = new Map<string, string>();
   readonly classList = new MiniClassList();
   readonly dataset: Record<string, string> = {};
-  readonly style: Record<string, string> = {};
+  readonly style = createMiniStyleDeclaration();
   ownerDocument?: MiniDocument;
   private innerHtml = '';
   id = '';
@@ -360,6 +388,10 @@ export class MiniDocument extends EventTarget {
     const element = new MiniElement(tagName);
     element.ownerDocument = this;
     return element;
+  }
+
+  createElementNS(_namespace: string | null, qualifiedName: string): MiniElement {
+    return this.createElement(qualifiedName);
   }
 
   createTextNode(value: string): MiniText {

--- a/tests/renewable-energy-last-known-good.test.mts
+++ b/tests/renewable-energy-last-known-good.test.mts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import {
   createRenewableEnergyService,
   RENEWABLE_DATA_CACHE_KEY,
+  RENEWABLE_DATA_STALE_CEILING_MS,
 } from '../src/services/renewable-energy-data.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -199,6 +200,35 @@ describe('renewable energy last-known-good recovery (#5497)', () => {
     assert.equal(refreshCalls, 2, 'stale last-known-good data must still trigger a refresh attempt');
   });
 
+  it('stops serving in-memory last-known-good data after the seven-day ceiling', async () => {
+    let refreshCalls = 0;
+    let online = true;
+    const service = createTestService('Renewable Test Long-Lived', async () => {
+      refreshCalls++;
+      if (!online) throw new Error('simulated bootstrap outage');
+      return new Response(JSON.stringify({
+        data: { renewableEnergy: canonicalRenewableData() },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    await service.fetch();
+
+    now += RENEWABLE_DATA_STALE_CEILING_MS + 1;
+    online = false;
+
+    const result = await service.fetch();
+    await flushPersistence();
+
+    assert.deepEqual(result, {
+      data: null,
+      state: 'unavailable',
+      cachedAt: null,
+    });
+    assert.equal(refreshCalls, 2, 'the expired snapshot must still trigger a refresh attempt');
+  });
+
   it('fails closed when no last-known-good data exists', async () => {
     const service = createTestService('Renewable Test Empty', async () => {
       throw new Error('simulated bootstrap outage');
@@ -246,7 +276,7 @@ describe('renewable energy last-known-good recovery (#5497)', () => {
     await seedService.fetch();
     await flushPersistence();
 
-    now += (7 * 24 * 60 * 60 * 1000) + 1;
+    now += RENEWABLE_DATA_STALE_CEILING_MS + 1;
     const recoveryService = createTestService(breakerName, async () => {
       throw new Error('simulated bootstrap outage');
     }, true);

--- a/tests/renewable-energy-last-known-good.test.mts
+++ b/tests/renewable-energy-last-known-good.test.mts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createRenewableEnergyService,
+  RENEWABLE_DATA_CACHE_KEY,
+} from '../src/services/renewable-energy-data.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+type StorageSnapshot = {
+  exists: boolean;
+  value: unknown;
+};
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function snapshotGlobal(name: string): StorageSnapshot {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: (globalThis as Record<string, unknown>)[name],
+  };
+}
+
+function restoreGlobal(name: string, snapshot: StorageSnapshot): void {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete (globalThis as Record<string, unknown>)[name];
+}
+
+function defineGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function canonicalRenewableData() {
+  return {
+    globalPercentage: 42,
+    globalYear: 2024,
+    historicalData: [
+      { year: 2022, value: 38 },
+      { year: 2023, value: 40 },
+      { year: 2024, value: 42 },
+    ],
+    regions: [
+      { code: 'EUU', name: 'European Union', percentage: 50, year: 2024 },
+    ],
+  };
+}
+
+function legacyHardcodedSnapshot() {
+  return {
+    globalPercentage: 29.6,
+    globalYear: 2022,
+    historicalData: [{ year: 2022, value: 29.6 }],
+    regions: [
+      { code: 'LCN', name: 'Latin America & Caribbean', percentage: 58.1, year: 2022 },
+    ],
+  };
+}
+
+function createTestService(
+  breakerName: string,
+  fetchImpl: typeof globalThis.fetch,
+  persistCache = false,
+) {
+  return createRenewableEnergyService({
+    breakerName,
+    persistCache,
+    getHydrated: () => undefined,
+    fetchImpl,
+  });
+}
+
+async function flushPersistence(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+const originalGlobals = {
+  localStorage: snapshotGlobal('localStorage'),
+  window: snapshotGlobal('window'),
+};
+const originalNow = Date.now;
+const originalWarn = console.warn;
+const originalError = console.error;
+
+let storage: MemoryStorage;
+let now: number;
+
+beforeEach(() => {
+  storage = new MemoryStorage();
+  now = Date.UTC(2026, 6, 24, 12, 0, 0);
+  Date.now = () => now;
+  defineGlobal('localStorage', storage);
+  delete (globalThis as Record<string, unknown>).window;
+  console.warn = () => {};
+  console.error = () => {};
+});
+
+afterEach(() => {
+  Date.now = originalNow;
+  restoreGlobal('localStorage', originalGlobals.localStorage);
+  restoreGlobal('window', originalGlobals.window);
+  console.warn = originalWarn;
+  console.error = originalError;
+});
+
+describe('renewable energy last-known-good recovery (#5497)', () => {
+  it('stores a validated canonical response and reports it as live', async () => {
+    const breakerName = 'Renewable Test Live';
+    const service = createTestService(breakerName, async () =>
+      new Response(JSON.stringify({
+        data: { renewableEnergy: canonicalRenewableData() },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }), true);
+
+    const result = await service.fetch();
+    await flushPersistence();
+
+    assert.deepEqual(result, {
+      data: canonicalRenewableData(),
+      state: 'live',
+      cachedAt: null,
+    });
+    assert.ok(
+      storage.getItem(`worldmonitor-persistent-cache:breaker:${breakerName}:${RENEWABLE_DATA_CACHE_KEY}`),
+      'validated World Bank data must be persisted under the versioned cache key',
+    );
+  });
+
+  it('serves bounded last-known-good data when a stale refresh fails', async () => {
+    let refreshCalls = 0;
+    let online = true;
+    const cachedAt = now;
+    const service = createTestService('Renewable Test Recovery', async () => {
+      refreshCalls++;
+      if (!online) throw new Error('simulated bootstrap outage');
+      return new Response(JSON.stringify({
+        data: { renewableEnergy: canonicalRenewableData() },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    await service.fetch();
+
+    now += 2 * 60 * 60 * 1000;
+    online = false;
+
+    const result = await service.fetch();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.deepEqual(result, {
+      data: canonicalRenewableData(),
+      state: 'cached',
+      cachedAt,
+    });
+    assert.equal(refreshCalls, 2, 'stale last-known-good data must still trigger a refresh attempt');
+  });
+
+  it('fails closed when no last-known-good data exists', async () => {
+    const service = createTestService('Renewable Test Empty', async () => {
+      throw new Error('simulated bootstrap outage');
+    });
+
+    const result = await service.fetch();
+
+    assert.deepEqual(result, {
+      data: null,
+      state: 'unavailable',
+      cachedAt: null,
+    });
+  });
+
+  it('does not reuse the legacy cache key that may contain the hardcoded snapshot', async () => {
+    const breakerName = 'Renewable Test Legacy';
+    const legacyKey = `breaker:${breakerName}`;
+    storage.setItem(
+      `worldmonitor-persistent-cache:${legacyKey}`,
+      JSON.stringify({
+        key: legacyKey,
+        updatedAt: now,
+        data: legacyHardcodedSnapshot(),
+      }),
+    );
+    const service = createTestService(breakerName, async () => {
+      throw new Error('simulated bootstrap outage');
+    }, true);
+
+    const result = await service.fetch();
+
+    assert.equal(result.data, null);
+    assert.equal(result.state, 'unavailable');
+  });
+
+  it('rejects last-known-good data outside the seven-day ceiling', async () => {
+    const breakerName = 'Renewable Test Expired';
+    const seedService = createTestService(breakerName, async () =>
+      new Response(JSON.stringify({
+        data: { renewableEnergy: canonicalRenewableData() },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }), true);
+    await seedService.fetch();
+    await flushPersistence();
+
+    now += (7 * 24 * 60 * 60 * 1000) + 1;
+    const recoveryService = createTestService(breakerName, async () => {
+      throw new Error('simulated bootstrap outage');
+    }, true);
+
+    const result = await recoveryService.fetch();
+
+    assert.deepEqual(result, {
+      data: null,
+      state: 'unavailable',
+      cachedAt: null,
+    });
+  });
+
+  it('does not cache malformed bootstrap payloads', async () => {
+    const breakerName = 'Renewable Test Malformed';
+    const service = createTestService(breakerName, async () =>
+      new Response(JSON.stringify({
+        data: {
+          renewableEnergy: {
+            globalPercentage: 142,
+            globalYear: 2024,
+            historicalData: [],
+            regions: [],
+          },
+        },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }), true);
+
+    const result = await service.fetch();
+    await flushPersistence();
+
+    assert.equal(result.data, null);
+    assert.equal(
+      storage.getItem(`worldmonitor-persistent-cache:breaker:${breakerName}:${RENEWABLE_DATA_CACHE_KEY}`),
+      null,
+    );
+  });
+
+  it('only allows live canonical observations to trigger happy-variant milestones', () => {
+    const dataLoader = readFileSync(resolve(root, 'src/app/data-loader.ts'), 'utf8');
+    assert.match(
+      dataLoader,
+      /SITE_VARIANT === 'happy'\s*&&\s*result\.state === 'live'\s*&&\s*result\.data\?\.globalPercentage/,
+    );
+    assert.match(dataLoader, /renewablePercent:\s*result\.data\.globalPercentage/);
+  });
+});

--- a/tests/renewable-energy-panel-state.test.mts
+++ b/tests/renewable-energy-panel-state.test.mts
@@ -220,17 +220,27 @@ describe('RenewableEnergyPanel data-state disclosure (#5497)', () => {
 
     panel.setData({
       data: {
-        globalPercentage: 0,
+        globalPercentage: 42,
         globalYear: 2024,
-        historicalData: [],
-        regions: [],
+        historicalData: [
+          { year: 2022, value: 38 },
+          { year: 2023, value: 40 },
+          { year: 2024, value: 42 },
+        ],
+        regions: [
+          { code: 'EUU', name: 'European Union', percentage: 50, year: 2024 },
+        ],
       },
       state: 'cached',
       cachedAt,
     });
 
-    const badge = panel.getElement().querySelector('.panel-data-badge');
+    const element = panel.getElement();
+    const badge = element.querySelector('.panel-data-badge');
     assert.ok(badge?.classList.contains('cached'));
     assert.match(badge?.textContent ?? '', /2h ago/);
+    assert.ok(element.querySelector('.renewable-container'));
+    assert.equal(element.querySelector('.renewable-empty'), null);
+    assert.equal(element.querySelector('.gauge-value')?.textContent, '42.0%');
   });
 });

--- a/tests/renewable-energy-panel-state.test.mts
+++ b/tests/renewable-energy-panel-state.test.mts
@@ -1,0 +1,236 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { createBrowserEnvironment } from './helpers/runtime-config-panel-harness.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+type GlobalSnapshot = {
+  exists: boolean;
+  value: unknown;
+};
+
+function snapshotGlobal(name: string): GlobalSnapshot {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: (globalThis as Record<string, unknown>)[name],
+  };
+}
+
+function restoreGlobal(name: string, snapshot: GlobalSnapshot): void {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete (globalThis as Record<string, unknown>)[name];
+}
+
+function defineGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+const globalNames = [
+  'document',
+  'window',
+  'localStorage',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'navigator',
+  'location',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'Node',
+] as const;
+const originalGlobals = Object.fromEntries(
+  globalNames.map(name => [name, snapshotGlobal(name)]),
+) as Record<(typeof globalNames)[number], GlobalSnapshot>;
+
+let RenewableEnergyPanel: typeof import('../src/components/RenewableEnergyPanel.ts').RenewableEnergyPanel;
+let cleanupBundle: (() => void) | null = null;
+
+async function loadRenewableEnergyPanel() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-renewable-panel-'));
+  const outfile = join(tempDir, 'RenewableEnergyPanel.bundle.mjs');
+  const panelPath = resolve(root, 'src/components/RenewableEnergyPanel.ts').replace(/\\/g, '/');
+  const virtualEntrySource = `
+    import { RenewableEnergyPanel } from '${panelPath}';
+    export { RenewableEnergyPanel };
+  `;
+
+  const stubModules = new Map([
+    ['virtual-entry', virtualEntrySource],
+    ['i18n-stub', `
+      const labels = {
+        'common.live': 'Live',
+        'common.cached': 'Cached',
+        'common.unavailable': 'Unavailable',
+        'components.renewable.infoTooltip': '',
+      };
+      export function t(key, options = {}) {
+        return labels[key] ?? (typeof options.defaultValue === 'string' ? options.defaultValue : key);
+      }
+    `],
+    ['runtime-stub', `export function isDesktopRuntime() { return false; }`],
+    ['tauri-bridge-stub', `export function invokeTauri() { return Promise.reject(new Error('not wired in test')); }`],
+    ['analytics-stub', `export function trackPanelResized() {}`],
+    ['ai-flow-settings-stub', `export function getAiFlowSettings() { return { badgeAnimation: false }; }`],
+    ['runtime-config-stub', `export function getSecretState() { return { present: true }; }`],
+    ['panel-gating-stub', `
+      export const PanelGateReason = Object.freeze({
+        NONE: 'none',
+        ANONYMOUS: 'anonymous',
+        FREE_TIER: 'free_tier',
+      });
+    `],
+    ['checkout-stub', `export function startCheckout() {}`],
+    ['products-stub', `export const DEFAULT_UPGRADE_PRODUCT = 'pro';`],
+    ['theme-colors-stub', `export function getCSSColor() { return '#000'; }`],
+    ['persistent-cache-stub', `
+      export function describeFreshness(updatedAt) {
+        const hours = Math.floor(Math.max(0, Date.now() - updatedAt) / 3_600_000);
+        return hours < 1 ? 'just now' : hours + 'h ago';
+      }
+    `],
+  ]);
+
+  const aliasMap = new Map([
+    ['@/services/i18n', 'i18n-stub'],
+    ['../services/i18n', 'i18n-stub'],
+    ['@/services/runtime', 'runtime-stub'],
+    ['../services/runtime', 'runtime-stub'],
+    ['@/services/tauri-bridge', 'tauri-bridge-stub'],
+    ['../services/tauri-bridge', 'tauri-bridge-stub'],
+    ['@/services/analytics', 'analytics-stub'],
+    ['@/services/ai-flow-settings', 'ai-flow-settings-stub'],
+    ['@/services/runtime-config', 'runtime-config-stub'],
+    ['@/services/panel-gating', 'panel-gating-stub'],
+    ['@/services/checkout', 'checkout-stub'],
+    ['@/services/persistent-cache', 'persistent-cache-stub'],
+    ['@/config/products', 'products-stub'],
+    ['@/utils', 'theme-colors-stub'],
+    ['@/utils/theme-colors', 'theme-colors-stub'],
+    ['virtual:renewable-entry', 'virtual-entry'],
+  ]);
+
+  const plugin = {
+    name: 'renewable-panel-test-stubs',
+    setup(buildApi: import('esbuild').PluginBuild) {
+      buildApi.onResolve({ filter: /.*/ }, args => {
+        const target = aliasMap.get(args.path);
+        return target ? { path: target, namespace: 'stub' } : null;
+      });
+      buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, args => ({
+        contents: stubModules.get(args.path),
+        loader: 'ts',
+        resolveDir: root,
+      }));
+    },
+  };
+
+  const result = await build({
+    entryPoints: [{ in: 'virtual:renewable-entry', out: 'RenewableEnergyPanel.bundle' }],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [plugin],
+  });
+
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
+  const module = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  return {
+    RenewableEnergyPanel: module.RenewableEnergyPanel,
+    cleanup() {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+before(async () => {
+  const browser = createBrowserEnvironment();
+  const MiniNode = Object.getPrototypeOf(browser.HTMLElement.prototype).constructor;
+
+  defineGlobal('document', browser.document);
+  defineGlobal('window', browser.window);
+  defineGlobal('localStorage', browser.localStorage);
+  defineGlobal('requestAnimationFrame', browser.requestAnimationFrame);
+  defineGlobal('cancelAnimationFrame', browser.cancelAnimationFrame);
+  defineGlobal('navigator', browser.window.navigator);
+  defineGlobal('location', {
+    ...browser.window.location,
+    hostname: 'worldmonitor.test',
+    host: 'worldmonitor.test',
+    protocol: 'https:',
+  });
+  defineGlobal('HTMLElement', browser.HTMLElement);
+  defineGlobal('HTMLButtonElement', browser.HTMLButtonElement);
+  defineGlobal('Node', MiniNode);
+
+  const loaded = await loadRenewableEnergyPanel();
+  RenewableEnergyPanel = loaded.RenewableEnergyPanel;
+  cleanupBundle = loaded.cleanup;
+});
+
+after(() => {
+  cleanupBundle?.();
+  for (const name of globalNames) {
+    restoreGlobal(name, originalGlobals[name]);
+  }
+});
+
+describe('RenewableEnergyPanel data-state disclosure (#5497)', () => {
+  it('shows unavailable and renders no chart when no last-known-good data exists', () => {
+    const panel = new RenewableEnergyPanel();
+
+    panel.setData({
+      data: null,
+      state: 'unavailable',
+      cachedAt: null,
+    });
+
+    const element = panel.getElement();
+    const badge = element.querySelector('.panel-data-badge');
+    assert.ok(badge?.classList.contains('unavailable'));
+    assert.equal(badge?.style.display, 'inline-flex');
+    assert.equal(
+      element.querySelector('.renewable-empty')?.textContent,
+      'No renewable energy data available',
+    );
+    assert.equal(element.querySelector('.renewable-container'), null);
+  });
+
+  it('shows cache age when rendering last-known-good data', () => {
+    const panel = new RenewableEnergyPanel();
+    const cachedAt = Date.now() - (2 * 60 * 60 * 1000);
+
+    panel.setData({
+      data: {
+        globalPercentage: 0,
+        globalYear: 2024,
+        historicalData: [],
+        regions: [],
+      },
+      state: 'cached',
+      cachedAt,
+    });
+
+    const badge = panel.getElement().querySelector('.panel-data-badge');
+    assert.ok(badge?.classList.contains('cached'));
+    assert.match(badge?.textContent ?? '', /2h ago/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5497.

- remove the hardcoded 2022 renewable-energy snapshot from the production recovery path
- persist only validated World Bank payloads and serve them as bounded last-known-good data for up to seven days
- version the breaker cache key so pre-fix entries that may contain the static snapshot are never reused
- expose `live`, `cached`, and `unavailable` states to the panel, including cache age
- prevent cached or unavailable renewable data from triggering happy-variant record celebrations

This is an alternative to #5521's disclosure-banner approach: the static fallback is deleted rather than retained and labelled.

## Intent and non-goals

The intent is to preserve availability with canonical last-known-good data while failing closed when no trustworthy observation exists.

Non-goals:

- no direct browser-to-World-Bank fallback
- no bootstrap/KV deployment flag changes
- no generic circuit-breaker redesign
- no changes to the independent EIA capacity series

## Validation matrix

| Check | Result |
|---|---|
| Renewable last-known-good, expiry, malformed payload, legacy cache, and milestone regression tests | Pass (7/7) |
| Rendered panel cached/unavailable state tests | Pass (2/2) |
| Energy-variant renewable wiring tests | Pass (3/3) |
| `npm run typecheck` | Pass |
| Full `test:data` inside the sandbox | Environment-blocked: tsx IPC was denied and the fallback run hung on the unrelated Clerk/JWKS test |
| `tests/auth-session.test.mts` outside the sandbox | Pass (23/23) |

## Review gates

- Reviewed for cache integrity, stale-state races, failure semantics, and milestone side effects.
- A stale-while-revalidate race found during review was fixed by storing cache timestamps with each snapshot and classifying the returned object atomically.
- No unresolved review findings.

## Documentation

Not applicable. This changes an internal recovery contract and reuses the existing panel data-badge convention.

## Screenshots / UI evidence

Automated rendered-DOM coverage verifies the unavailable state renders no World Bank chart and the cached state displays cache age. No durable screenshot is attached.

## CI and review follow-up

Pending after publication.

## Residual findings

None.
