### PR TITLE
perf(gates): fix stale-hook delivery + batch esbuild check + incremental tsc (push timeouts)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,33 @@
 #!/usr/bin/env bash
+
+# Self-identity tripwire: this hook must be the copy checked out in the tree
+# being pushed. An absolute/foreign core.hooksPath silently welds every
+# worktree's push to ANOTHER checkout's (possibly ancient) hook file — the
+# 2026-07-24 "pushes take 4 minutes and time out" incident (see
+# docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md).
+# Bootstrap heals this too, but only when bootstrap runs; push time is the
+# moment that matters. Escape hatch for an intentional central-hook setup:
+# WM_ALLOW_FOREIGN_HOOKS=1.
+if [ -z "${WM_ALLOW_FOREIGN_HOOKS:-}" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
+  _hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)
+  _wt_root=$(cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null && pwd -P)
+  if [ -n "$_hook_dir" ] && [ -n "$_wt_root" ] && [ "$_hook_dir" != "$_wt_root/.husky" ]; then
+    echo "============================================================"
+    echo "ERROR: pre-push hook is executing from OUTSIDE this worktree:"
+    echo "  running:  $_hook_dir/pre-push"
+    echo "  expected: $_wt_root/.husky/pre-push"
+    echo "core.hooksPath resolves to another checkout, so pushes run that"
+    echo "checkout's (possibly stale) gate instead of this branch's."
+    echo "Fix (once, for all worktrees):  git config core.hooksPath .husky"
+    echo "Then check for a per-worktree override:"
+    echo "  git config --show-origin core.hooksPath"
+    echo "  (if origin is a config.worktree file: git config --worktree --unset core.hooksPath)"
+    echo "Intentional central hooks? Re-run with WM_ALLOW_FOREIGN_HOOKS=1."
+    echo "============================================================"
+    exit 1
+  fi
+fi
+
 echo "Checking for local Vercel env dumps..."
 node scripts/check-local-secret-dumps.mjs || exit 1
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -174,13 +174,23 @@ if changed '^(api/|server/|src/generated/)'; then
   # and generated stubs — a server-only Node-ism breaks the Vercel bundle with
   # zero api/ diff, so those paths must trigger the esbuild check too.
   echo "Running edge function bundle check..."
-  while IFS= read -r f; do
-    npx esbuild "$f" --bundle --format=esm --platform=browser --outfile=/dev/null 2>/dev/null || {
-      echo "ERROR: esbuild failed to bundle $f — this will break Vercel deployment"
-      npx esbuild "$f" --bundle --format=esm --platform=browser --outfile=/dev/null
+  # Single multi-entry esbuild invocation: one process bundling all entries in
+  # parallel instead of one npx+esbuild spawn per file (~47 sequential spawns).
+  # Errors still attribute per-file — esbuild prefixes each diagnostic with the
+  # source path. --outdir is required for multi-entry; discard it afterwards.
+  EDGE_OUT=$(mktemp -d) || exit 1
+  ESBUILD_ENTRIES=()
+  while IFS= read -r f; do ESBUILD_ENTRIES+=("$f"); done \
+    < <(find api/ -name "*.js" -not -name "_*"; find api/ -maxdepth 1 -name "*.ts" -not -name "_*")
+  if [ "${#ESBUILD_ENTRIES[@]}" -gt 0 ]; then
+    if ! npx esbuild "${ESBUILD_ENTRIES[@]}" --bundle --format=esm --platform=browser \
+        --log-level=error --outdir="$EDGE_OUT"; then
+      rm -rf "$EDGE_OUT"
+      echo "ERROR: esbuild failed to bundle edge functions (paths above) — this will break Vercel deployment"
       exit 1
-    }
-  done < <(find api/ -name "*.js" -not -name "_*"; find api/ -maxdepth 1 -name "*.ts" -not -name "_*")
+    fi
+  fi
+  rm -rf "$EDGE_OUT"
 else
   echo "Edge function bundle check skipped (no api/, server/, or src/generated changes)."
 fi

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -132,6 +132,16 @@ The composed state in which a paying subscriber receives the daily AI brief off-
 
 The day-0 post-checkout flow shown to a new Pro subscriber once the payment-to-entitlement settling window resolves: a short sequence of one-click, individually-skippable confirms that wire premium features — the Brief Loop first — rather than teach them. Defined against two constraints from production data: activation that does not happen on day 0 essentially never happens, and nothing may activate without an explicit per-item confirm. Distinct from a tour (education, no state change) and from a persistent checklist (dashboard residue; the interstitial leaves at most a dismissible finish-setup affordance). See also: Brief Loop, Billing UX State.
 
+## Shipping Gate
+
+### Tiered Gate
+
+The pre-push check suite split into two tiers: a state-dependent tier (secret guards, PR-state and branch-contamination checks, lockfile sync) that runs on every push, and a tree-dependent tier (typechecks, invariant lints, bundle checks, scoped tests) that runs only for the paths the branch diff actually touches. Configuration-file changes, or an unresolvable branch diff, escalate the tree-dependent tier to run everything. The gate is a fast local pre-flight, not the merge gate — CI remains the full-suite authority.
+
+### Green-Tree Cache
+
+The tiered gate's attestation that an exact source tree already passed the full tree-dependent tier: a re-push of an identical tree (remote-side failure, message-only amend) skips those checks instead of re-paying minutes. The attestation is keyed by tree content, so any content change invalidates it, and it is not trusted when the branch diff cannot be resolved — a blind run must not rely on an attestation minted under a scoped plan it can no longer verify. State-dependent checks always run regardless of the cache. See also: Tiered Gate.
+
 ## Localization & First Paint
 
 ### English Shell

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -7,6 +7,8 @@
     "strict": true,
     "skipLibCheck": true,
     "allowJs": true,
+    "incremental": true,
+    "tsBuildInfoFile": "../node_modules/.cache/convex-tsconfig.tsbuildinfo",
     "outDir": "./_generated"
   },
   "include": ["./**/*.ts"],

--- a/docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md
+++ b/docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md
@@ -75,6 +75,7 @@ Shipped as environment repair plus PR #5558.
 
 ## Prevention
 
+- **Push-time self-identity tripwire.** The first check in `.husky/pre-push` verifies the executing hook file lives in the current worktree's own `.husky/`; if it is running from another checkout (the exact signature of this incident), the push fails immediately with the one-line fix printed. Bootstrap can be skipped; push time cannot. Escape hatch for an intentional central-hook setup: `WM_ALLOW_FOREIGN_HOOKS=1`.
 - **Bootstrap auto-heal is in the path of every new worktree.** `bootstrapWorktree` unsets stale per-worktree `core.hooksPath` overrides automatically and prints the one-line shared-config fix (`git config core.hooksPath .husky`) when the shared value is foreign.
 - **Diagnostic recipe when a push is mysteriously slow or runs unfamiliar gate steps:**
   1. `git config --show-origin core.hooksPath` from the worktree — the origin file distinguishes a shared-config value from a `config.worktree` override (the two layers need different fixes).

--- a/docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md
+++ b/docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md
@@ -1,0 +1,91 @@
+---
+title: Stale absolute core.hooksPath ran an ancient pre-push gate from every worktree
+date: 2026-07-24
+category: performance-issues
+module: git-hooks-worktree-tooling
+problem_type: performance_issue
+component: development_workflow
+symptoms:
+  - "git push from any worktree takes roughly 4 minutes and usually hits the 120s tool timeout"
+  - "pre-push output shows gate steps (unconditional full typechecks, sequential per-file esbuild phase) that do not exist in the current .husky/pre-push on origin/main"
+  - "fixing the shared .git/config core.hooksPath does not fix existing worktrees — each config.worktree carries a copied absolute override"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+related_components:
+  - tooling
+  - testing_framework
+tags: [git-hooks, husky, core-hookspath, worktree, pre-push, incremental-tsc, esbuild-batching, push-timeout]
+---
+
+# Stale absolute core.hooksPath ran an ancient pre-push gate from every worktree
+
+## Problem
+
+`git push` from any WorldMonitor worktree took roughly 4 minutes and usually hit the tool timeout ("pushing to PR takes a lot of time and mostly times out"). This should have been impossible: PR #4800 (merged 2026-07-05) replaced the old unconditional pre-push gate with a diff-scoped tiered gate plus a green-tree cache, so the common push should complete in seconds. The gate on origin/main was fine. The gate that was actually *executing* was not the gate on origin/main.
+
+The root cause had three layers, and each layer independently kept the symptom alive:
+
+1. **Shared config pinned hooks to one working copy.** The shared `.git/config` set `core.hooksPath` to the ABSOLUTE path of the main checkout's `.husky`. Every worktree, no matter how fresh its branch, ran whatever hook files happened to sit in the main checkout's working tree.
+2. **That working copy was ancient.** The main checkout was parked detached and dirty on a commit ~816 commits behind origin/main. Its `.husky/pre-push` predated PR #4800 entirely: the OLD unconditional gate — three full `tsc` runs, all invariant lints, and a per-file loop of 47 sequential `npx esbuild` spawns. Measured sequential cost ~244s: typecheck 75.1s, esbuild loop 97.2s, typecheck:api 19.8s, convex tsc 18.8s, unicode 4.4s, premium-fetch 8.0s, md-lint 7.8s, rate-limit 5.2s, remainder under 2s each.
+3. **Per-worktree configs silently re-broke the fix.** Even after correcting the shared config, each worktree's `.git/worktrees/<name>/config.worktree` carried its own copied absolute `core.hooksPath` override, stamped by the worktree-creation tooling at creation time. Per-worktree config wins over shared config, so all existing worktrees kept executing the stale hook. This layer was caught live: during a push from a worktree whose shared config was already fixed, `ps` showed the main checkout's hook path still executing.
+
+The general shape of the bug: **an absolute `core.hooksPath` decouples "which hook runs" from "which commit you're pushing."** The hook becomes a mutable file on disk owned by a checkout nobody is looking at, and improvements merged to the hook in the repo never reach anyone.
+
+## Symptoms
+
+- Pushes from any worktree take ~4 minutes wall clock and usually exceed the push timeout, even for trivial diffs that the tiered gate should skip in seconds.
+- The pre-push output shows gate steps (unconditional full typechecks, a long sequential esbuild-per-file phase) that do not exist in the current `.husky/pre-push` on origin/main.
+- `git config --show-origin core.hooksPath` from a worktree reports an absolute path into a different checkout, originating either from the shared `.git/config` or from `.git/worktrees/<name>/config.worktree`.
+- After fixing the shared config, worktrees still misbehave — `ps` during a push shows the main checkout's literal hook path executing.
+
+## What Didn't Work
+
+- **Blaming the gate design.** The first instinct was that the tiered gate itself was slow or broken. It wasn't — the gate on origin/main (post-#4800) was already diff-scoped with a green-tree cache. Time spent optimizing a gate that wasn't the one running would have been wasted; the executing hook had to be identified first (`ps` during a live push, then diffing the resolved hook file against `origin/main:.husky/pre-push`).
+- **Fixing only the shared `.git/config`.** Setting the shared `core.hooksPath` correctly looked like a complete fix and silently wasn't: every existing worktree's `config.worktree` retained its own copied absolute override, which takes precedence. All existing worktrees kept the stale behavior; only the live `ps` observation exposed layer 3.
+- **Prior sessions' workarounds** (fast-forwarding the main checkout, temp-editing its `.husky`, `--no-verify`) treated the symptom per-push and left the bug class alive — the permanent fix is making hook resolution per-worktree.
+
+## Solution
+
+Shipped as environment repair plus PR #5558.
+
+**Environment (one-time repair):**
+
+- `git config core.hooksPath .husky` — a RELATIVE value, which git resolves against each worktree's own root, so every worktree runs its own checked-out hook at its own commit. Verified twice: first with a real `git push` in a scratch repo (the worktree's own hook fired, not another checkout's), then live in the real repo.
+- Refreshed the main checkout's `.husky/*` working copies to origin/main.
+- Deleted the `hooksPath` line from all existing `.git/worktrees/<name>/config.worktree` files.
+
+**Repo (PR #5558) — prevention plus making the real gate fast even in the worst case:**
+
+- **Bootstrap auto-heal.** `scripts/bootstrap-worktree.mjs` gains an exported pure decision function `decideHooksPathAction` and a git-wrapper `normalizeWorktreeHooksPath`, invoked during `bootstrapWorktree`. Policy: a per-worktree override pointing outside the worktree is unset (worktree-local, safe to mutate); a foreign absolute value in the SHARED config is loudly warned about with the one-line fix, but never mutated by a bootstrap script. Relative values and absolute values pointing into the current worktree are left alone. Covered by unit tests in `tests/bootstrap-worktree.test.mjs`.
+- **Batched edge-bundle check.** The `.husky/pre-push` edge-bundle check now runs ONE multi-entry esbuild invocation with `--outdir` into a `mktemp -d` directory instead of ~47 sequential `npx esbuild` spawns. One process bundles all entries in parallel; errors still attribute per-file because esbuild prefixes each diagnostic with the source path. 97.2s → 2.3s (42x).
+- **Incremental TypeScript.** `tsconfig.json`, `tsconfig.api.json`, and `convex/tsconfig.json` gain `incremental: true` with per-config `tsBuildInfoFile` paths under `node_modules/.cache/`. The build-info files must be DISTINCT per config: `tsconfig.api.json` extends the base config, so a shared build-info file would be invalidated on every alternating run and thrash. typecheck 75.1s → 14.2s warm (26.3s after touching `src/App.ts`); typecheck:api 19.8s → 7.0s; convex 18.8s → 8.4s.
+
+**Verification (mutation-tested, not just green-path):**
+
+- M1: planted a type error in `src/App.ts` → warm incremental typecheck FAILED (incremental caching does not produce false greens).
+- M2: planted `import { readFileSync } from "node:fs"` in an `api/*.ts` edge entry → the batched esbuild invocation FAILED naming the offending file (batching preserves per-file attribution).
+- End-to-end: the same worst-case RUN_ALL push (tsconfig in the diff, so every gate tier runs) went from 4m16s before to 44.8s after. (The 44.8s is an independently measured wall-clock figure for that push, not a sum of the itemized per-check timings — machine load and which checks actually re-ran differ between the profiling runs and the live push.)
+
+## Why This Works
+
+- **Relative `core.hooksPath` restores the invariant that the hook matches the checkout.** `git config core.hooksPath .husky` resolves against whichever worktree the push runs from, so each worktree executes the hook version checked out on its own branch. Hook improvements merged to main propagate the moment a worktree updates — there is no privileged working copy whose staleness silently governs everyone.
+- **The bootstrap guard closes the re-infection loop.** The worktree tooling copies config at creation time, so a single bad absolute value keeps resurfacing in every new worktree forever. Auto-unsetting a foreign per-worktree override at bootstrap (and warning on a foreign shared value rather than mutating shared state from a script) means the fix survives future worktree creation rather than depending on someone remembering this incident. The pure/wrapper split (`decideHooksPathAction` vs `normalizeWorktreeHooksPath`) makes the policy unit-testable without a git sandbox.
+- **The perf work attacks per-invocation overhead, not the checks themselves.** The 47-spawn esbuild loop paid `npx` startup plus esbuild startup 47 times for work esbuild natively parallelizes in one process; batching removes the overhead while keeping identical failure semantics. Incremental tsc converts "3 full typechecks on every worst-case push" into cheap warm re-checks, and the per-config `tsBuildInfoFile` prevents the extends-related cache thrash that would have silently negated the win. Together they make even the RUN_ALL path (44.8s) comfortably fit inside a normal push timeout, so the gate no longer relies on the diff-scoping alone to be tolerable.
+
+## Prevention
+
+- **Bootstrap auto-heal is in the path of every new worktree.** `bootstrapWorktree` unsets stale per-worktree `core.hooksPath` overrides automatically and prints the one-line shared-config fix (`git config core.hooksPath .husky`) when the shared value is foreign.
+- **Diagnostic recipe when a push is mysteriously slow or runs unfamiliar gate steps:**
+  1. `git config --show-origin core.hooksPath` from the worktree — the origin file distinguishes a shared-config value from a `config.worktree` override (the two layers need different fixes).
+  2. During a live push, `ps` shows the literal hook path executing — ground truth for WHICH file is running, immune to config-reading mistakes.
+  3. Diff the resolved hook file against `origin/main:.husky/pre-push` — if they differ, you are debugging a stale copy, not the real gate.
+- **Never set `core.hooksPath` to an absolute path into a working copy** in a multi-worktree repo: it welds every worktree's push behavior to one checkout's mutable, possibly-ancient files. Use a relative path so resolution is per-worktree.
+- **When a config fix "doesn't take," check every config layer.** Git worktrees have per-worktree config that overrides shared config; tooling that copies config values at creation time turns a one-time bad value into a self-replicating one.
+- **Operational guard:** run pushes with a generous (600s) timeout so a regressed gate surfaces as a slow-but-observable push (with readable gate output) instead of an opaque timeout kill.
+
+## Related Issues
+
+- PR #4800 — introduced the tiered pre-push gate + green-tree cache (the gate that should have been running all along).
+- PR #5558 — this fix: bootstrap hooksPath guard, batched esbuild check, incremental tsc.
+- No prior GitHub issue tracked this; it surfaced as developer-experience friction ("pushes time out") only.

--- a/scripts/bootstrap-worktree.mjs
+++ b/scripts/bootstrap-worktree.mjs
@@ -239,6 +239,68 @@ export function installDependencies({
   return result;
 }
 
+// A stale absolute core.hooksPath makes every push from this worktree run
+// ANOTHER checkout's (possibly ancient) pre-push hook — the 2026-07-24
+// "pushes take minutes and time out" incident: the main checkout was parked
+// 800+ commits behind and its unconditional pre-#4800 gate ran on every
+// worktree push. Worktree-creation tooling copies the shared value into
+// .git/worktrees/<name>/config.worktree at creation time, so a one-time
+// absolute value keeps resurfacing in new worktrees. Policy: a per-worktree
+// override pointing outside this worktree is unset (worktree-local, safe);
+// a foreign absolute value in the SHARED config is warned about but never
+// mutated from a bootstrap script.
+export function decideHooksPathAction({ rootDir, hooksPathValue, originFile }) {
+  if (!hooksPathValue) return { action: 'none', reason: 'core.hooksPath not set' };
+  if (!hooksPathValue.startsWith('/')) {
+    return { action: 'none', reason: `relative hooksPath (${hooksPathValue}) resolves per-worktree` };
+  }
+  if (hooksPathValue === resolve(rootDir, '.husky')) {
+    return { action: 'none', reason: 'absolute hooksPath already points into this worktree' };
+  }
+  if (originFile.includes('/config.worktree')) {
+    return {
+      action: 'unset-worktree',
+      reason: `per-worktree override points outside this worktree (${hooksPathValue})`,
+    };
+  }
+  return {
+    action: 'warn-shared',
+    reason: `shared config sets absolute hooksPath outside this worktree (${hooksPathValue})`,
+  };
+}
+
+export function normalizeWorktreeHooksPath({ dryRun = false, log = console.log, rootDir = process.cwd() } = {}) {
+  const probe = spawnSync(
+    'git',
+    ['config', '--show-origin', '--get', 'core.hooksPath'],
+    { cwd: rootDir, encoding: 'utf8' },
+  );
+  // Exit 1 = unset; other failures (not a repo, no git) are not bootstrap's problem.
+  if (probe.status !== 0) return { action: 'none', reason: 'core.hooksPath not set' };
+
+  const [origin = '', ...valueParts] = probe.stdout.trim().split('\t');
+  const decision = decideHooksPathAction({
+    rootDir,
+    hooksPathValue: valueParts.join('\t'),
+    originFile: origin.replace(/^file:/, ''),
+  });
+
+  if (decision.action === 'unset-worktree') {
+    log(`[worktree] removing stale hooksPath override: ${decision.reason}`);
+    if (!dryRun) {
+      spawnSync('git', ['config', '--worktree', '--unset', 'core.hooksPath'], {
+        cwd: rootDir,
+        stdio: 'inherit',
+      });
+    }
+  } else if (decision.action === 'warn-shared') {
+    log(`[worktree] WARNING: ${decision.reason}`);
+    log('[worktree]   pushes here will run that checkout\'s hook copy, which may be stale.');
+    log('[worktree]   Fix once for all worktrees: git config core.hooksPath .husky');
+  }
+  return decision;
+}
+
 export function bootstrapWorktree(options = {}) {
   const rootDir = resolve(options.rootDir || process.cwd());
   const log = options.log || console.log;
@@ -247,6 +309,8 @@ export function bootstrapWorktree(options = {}) {
     : inferEnvSource(rootDir);
 
   assertProjectRoot(rootDir);
+
+  normalizeWorktreeHooksPath({ dryRun: options.dryRun, log, rootDir });
 
   if (!options.skipEnv) {
     linkEnvFiles({

--- a/tests/bootstrap-worktree.test.mjs
+++ b/tests/bootstrap-worktree.test.mjs
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 
 import {
   assertNoForbiddenEnvDumps,
+  decideHooksPathAction,
   linkEnvFiles,
   parseArgs,
   shouldInstallDependencies,
@@ -121,5 +122,56 @@ describe('worktree bootstrap helper', () => {
     assert.equal(options.skipInstall, true);
     assert.equal(options.ignoreScripts, true);
     assert.equal(options.dryRun, true);
+  });
+
+  // A stale absolute core.hooksPath makes every worktree push run ANOTHER
+  // checkout's (possibly ancient) pre-push hook — the 2026-07-24 "pushes
+  // take minutes and time out" incident. Worktree-creation tooling stamps
+  // the shared value into .git/worktrees/<n>/config.worktree at creation
+  // time, so a one-time absolute value keeps resurfacing per worktree.
+  describe('decideHooksPathAction', () => {
+    const root = '/repos/wm/.claude/worktrees/my-feature';
+
+    it('leaves unset and relative hooksPath alone', () => {
+      assert.equal(
+        decideHooksPathAction({ rootDir: root, hooksPathValue: '', originFile: '' }).action,
+        'none',
+      );
+      assert.equal(
+        decideHooksPathAction({
+          rootDir: root,
+          hooksPathValue: '.husky',
+          originFile: '/repos/wm/.git/config',
+        }).action,
+        'none',
+      );
+    });
+
+    it('leaves an absolute hooksPath alone when it points into this worktree', () => {
+      const result = decideHooksPathAction({
+        rootDir: root,
+        hooksPathValue: `${root}/.husky`,
+        originFile: `/repos/wm/.git/worktrees/my-feature/config.worktree`,
+      });
+      assert.equal(result.action, 'none');
+    });
+
+    it('unsets a per-worktree override pointing at another checkout', () => {
+      const result = decideHooksPathAction({
+        rootDir: root,
+        hooksPathValue: '/repos/wm/.husky',
+        originFile: '/repos/wm/.git/worktrees/my-feature/config.worktree',
+      });
+      assert.equal(result.action, 'unset-worktree');
+    });
+
+    it('warns (never mutates) when the foreign absolute value is in the shared config', () => {
+      const result = decideHooksPathAction({
+        rootDir: root,
+        hooksPathValue: '/repos/wm/.husky',
+        originFile: '/repos/wm/.git/config',
+      });
+      assert.equal(result.action, 'warn-shared');
+    });
   });
 });

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "tsBuildInfoFile": "node_modules/.cache/tsconfig.api.tsbuildinfo"
   },
   "include": ["api", "src/generated", "server"],
   "exclude": ["server/__tests__/**"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Why

"Pushing to a PR takes minutes and mostly times out." The dominant root cause was environmental and is fixed outside this PR: `core.hooksPath` pointed **absolutely** at the main checkout's `.husky`, and that checkout was parked detached+dirty ~816 commits behind — so every worktree ran the pre-#4800 *unconditional* gate (measured ~4 min sequential) instead of the tiered one. `core.hooksPath` is now the relative `.husky` (git resolves it per-worktree, verified in a scratch repo) and the main checkout's hook copies were refreshed to origin/main.

This PR removes the two remaining dominant costs inside the tiered gate itself (sequential profile, loaded dev machine, 2026-07-24):

| step | before | after |
|---|---|---|
| edge bundle check (47 sequential `npx esbuild` spawns) | 97.2s | **2.3s** (one multi-entry call) |
| `npm run typecheck`, repeat push same worktree | 75.1s | **14.2s** warm / 26.3s after touching `src/App.ts` |
| `typecheck:api` | 19.8s | **7.0s** warm |
| convex tsc | 18.8s | **8.4s** warm |

First run in a fresh worktree still pays full cost (buildinfo seed). Identical-tree re-push stays ~instant via the existing green-tree cache.

A third layer made the environmental fix sticky: worktree-creation tooling copies the shared `core.hooksPath` into each worktree's `.git/worktrees/<n>/config.worktree` at creation time, so the old absolute value kept overriding the fixed shared config in existing worktrees (caught live — `ps` showed the main checkout's hook path during a push). This PR adds a bootstrap guard for that.

## What

1. **Bootstrap hooksPath guard** (`scripts/bootstrap-worktree.mjs` + tests) — `normalizeWorktreeHooksPath` runs during `npm run worktree:bootstrap`: a per-worktree override pointing outside the worktree is unset; a foreign absolute value in the shared config gets a loud warning with the one-line fix (never mutated from a bootstrap script). Pure decision function `decideHooksPathAction` is exported and unit-tested (4 new tests in `tests/bootstrap-worktree.test.mjs`).
2. **Batched edge-bundle check** (`.husky/pre-push`) — one multi-entry esbuild invocation instead of a per-file `npx esbuild` loop. `--outdir` into a `mktemp -d` (multi-entry requires it), removed afterwards; empty-entry guard included.
3. **Incremental TypeScript** — `tsconfig.json`, `tsconfig.api.json`, `convex/tsconfig.json` gain `incremental` + per-config `tsBuildInfoFile` under `node_modules/.cache/` (per-worktree, inside the already-ignored `node_modules/`, absent in CI so CI behavior is unchanged). Distinct `tsBuildInfoFile` per config because `tsconfig.api.json` extends the base and a shared file would thrash between the two program graphs. Also speeds `npm run build` (bare `tsc` step) locally.

## Verification

- **Mutation M1**: planted `const x: number = "not-a-number"` in `src/App.ts` → warm incremental `npm run typecheck` **fails** (no false green from stale buildinfo).
- **Mutation M2**: planted `import { readFileSync } from "node:fs"` into an `api/*.ts` edge entry → batched esbuild **fails and names the file** (`api/oauth-protected-resource.ts`), same attribution as the old loop.
- Both mutations reverted; `git diff` clean afterwards.
- `tests/bootstrap-worktree.test.mjs`: 10/10 pass (4 new).
- **End-to-end**: this PR's own pushes ran the full gate (tsconfig diff ⇒ `RUN_ALL`). First push (old per-file esbuild loop, cold tsc): **4m16s**. Second push (this hook + warm incremental tsc): **44.8s** — same worst-case path, 5.7× faster; `ps` confirmed `bash .husky/pre-push` (worktree-relative) executing.

## Recurrence guards (added after review question "how do we not end up with the same issue again?")

Three independent layers, each catching the failure at a different moment:

1. **Class fix** — relative `core.hooksPath .husky`: hook resolution follows each worktree's own tree; there is no privileged copy to go stale.
2. **Bootstrap auto-heal** — `normalizeWorktreeHooksPath` unsets stale per-worktree overrides and warns on a foreign shared value (unit-tested).
3. **Push-time self-identity tripwire** — the hook's first check verifies it is executing from the current worktree's own `.husky/`; a foreign path (the exact incident signature) fails the push immediately with the one-line fix printed. `WM_ALLOW_FOREIGN_HOOKS=1` escape hatch. Mutation-tested: foreign copy exits 1 with remediation; legitimate path proceeds.

Plus the knowledge layer: `docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md` (ground-validated) and `CONCEPTS.md` gains Tiered Gate / Green-Tree Cache.
