### PR TITLE
ci(security): bump postcss 8.5.23 to fix GHSA-r28c-9q8g-f849

### DIFF
--- a/.github/scripts/audit-production-dependencies.mjs
+++ b/.github/scripts/audit-production-dependencies.mjs
@@ -33,7 +33,7 @@ export const BASELINE_ADVISORIES_BY_LOCKFILE = {
   // `overrides` pin bump) would drag an otherwise-untouched public/pro/ rebuild
   // into a lockfile-hygiene change. Baselined rather than patched here; drop it
   // once react-native leaves pro-test's tree. (GHSA-qjx8/w24r predate this.)
-  'pro-test/package-lock.json': ['GHSA-qjx8-664m-686j', 'GHSA-w24r-5266-9c3c', 'GHSA-395f-4hp3-45gv'],
+  'pro-test/package-lock.json': ['GHSA-395f-4hp3-45gv'],
   'scripts/package-lock.json': [],
   'docker/runtime-package-lock.json': [],
 };

--- a/blog-site/package-lock.json
+++ b/blog-site/package-lock.json
@@ -3756,9 +3756,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4007,9 +4007,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4026,7 +4026,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/pro-test/package-lock.json
+++ b/pro-test/package-lock.json
@@ -36,12 +36,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -50,29 +50,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -95,13 +95,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -111,13 +111,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -127,36 +127,36 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -175,52 +175,52 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -269,31 +269,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -301,13 +301,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -330,14 +330,14 @@
       }
     },
     "node_modules/@clerk/clerk-js": {
-      "version": "5.125.10",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-5.125.10.tgz",
-      "integrity": "sha512-R0sZ5n4ND7xnHKkMoSuhcYa5+qcgHeYEsQ8eN0ti5hUgGH3LzQX1vJg0GHTEceJI68SrVETArRR7bxyMwS8QAg==",
+      "version": "5.127.1",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-js/-/clerk-js-5.127.1.tgz",
+      "integrity": "sha512-Tw6CrN5efDrlrNjVPCY6gnnj2WJJ9zZrglsmKjhUm8kp6B3Y3jvOh6SqQjHj5FzHX/dtgTKPOYGTXtvDbFPn+Q==",
       "license": "MIT",
       "dependencies": {
         "@base-org/account": "2.0.1",
-        "@clerk/localizations": "^3.37.5",
-        "@clerk/shared": "^3.47.5",
+        "@clerk/localizations": "^3.37.8",
+        "@clerk/shared": "^3.47.8",
         "@coinbase/wallet-sdk": "4.3.0",
         "@emotion/cache": "11.11.0",
         "@emotion/react": "11.11.1",
@@ -372,21 +372,21 @@
       }
     },
     "node_modules/@clerk/localizations": {
-      "version": "3.37.7",
-      "resolved": "https://registry.npmjs.org/@clerk/localizations/-/localizations-3.37.7.tgz",
-      "integrity": "sha512-mEIPSg0EYveROmza8MlqPH6P+YCzgsQIAnCtbem74ekXG7Y0X/hne+E9T5xPsuf9FHaavNMbECn5SiYXTgUfmA==",
+      "version": "3.37.8",
+      "resolved": "https://registry.npmjs.org/@clerk/localizations/-/localizations-3.37.8.tgz",
+      "integrity": "sha512-ib/8WciLkflXsg72IM9BjMZgENUv3nfXx1BrygKkpDqFPb1Dshron1+u+sG7dD+quQpZOLn6iie2Vno5YJy3zQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.101.25"
+        "@clerk/types": "^4.101.26"
       },
       "engines": {
         "node": ">=18.17.0"
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.7",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.7.tgz",
-      "integrity": "sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==",
+      "version": "3.47.8",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.8.tgz",
+      "integrity": "sha512-cPURU1it/Eal4uXO9SOcHzw9sfE6Opi21W8EJUg+Ri80Q6JKtK8qBmyOpIyqgf09EanexhTzS4xrmYlvn2p7Iw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -414,12 +414,12 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.101.25",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.25.tgz",
-      "integrity": "sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==",
+      "version": "4.101.26",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.26.tgz",
+      "integrity": "sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.7"
+        "@clerk/shared": "^3.47.8"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -2026,49 +2026,44 @@
       "peer": true
     },
     "node_modules/@solana-mobile/mobile-wallet-adapter-protocol": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.2.8.tgz",
-      "integrity": "sha512-c3FQsrM7nV62DqVaHGKtr2osE2w5gS3/wjy8ILF0zczS/s1mERX+JTmf+UHd8xgESmEj/IM7q+U2Qhrmac1PdA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.2.9.tgz",
+      "integrity": "sha512-qtWJq0hzKgngVG0So2ViBRPYDculaxgj40WDSP1nzgdg85MXyAmTEjQqV10uSVbZRm9b1hl601HDJX1sHTgeiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/codecs-strings": "^6.0.0",
+        "@solana/kit": "^6.0.0",
         "@solana/wallet-standard-features": "^1.3.0",
         "@solana/wallet-standard-util": "^1.1.2",
-        "@wallet-standard/core": "^1.1.1",
-        "js-base64": "^3.7.5"
+        "@wallet-standard/core": "^1.1.1"
       },
       "peerDependencies": {
         "react-native": ">0.74"
       }
     },
     "node_modules/@solana-mobile/mobile-wallet-adapter-protocol-web3js": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.2.8.tgz",
-      "integrity": "sha512-W9DbsFvl5lSOe7KT3dJX4tjbxfYIoOtOTJpvLMgkojyRU0UKChQ4vHvbOZQ3GkUJ8wOIS4qdrM0Yytd1Vy+YQQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.2.9.tgz",
+      "integrity": "sha512-TAMItAuOb7duwYQ+PZ6JNqw/6TEhCWLObHF5uOBGV9tjCozHGVunxa7lTeuHAWIgO68IAo86MZdE5kethDATpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
-        "bs58": "^6.0.0",
-        "js-base64": "^3.7.5"
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.9"
       },
       "peerDependencies": {
         "@solana/web3.js": "^1.98.4"
       }
     },
     "node_modules/@solana-mobile/wallet-adapter-mobile": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.2.8.tgz",
-      "integrity": "sha512-ZbXY3/0+UnnyS0hvArpO1b1pYzaQAiVIp+HBUm11aLEkE5+ISvHTRPr/bCEUXZfPkez/1n9zH3H0leK25Lj6Nw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.2.9.tgz",
+      "integrity": "sha512-IWzI2pUmEqBsTNo+XqMTY38NL5TSdMetES59N0Cmuf+zYqiS56rHdMwD/R2IOy7E4yKa1CsuHfCh6CE6zk4ViQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
-        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.8",
-        "@solana-mobile/wallet-standard-mobile": "^0.5.2",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.9",
+        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.9",
+        "@solana-mobile/wallet-standard-mobile": "^0.5.3",
         "@solana/wallet-adapter-base": "^0.9.27",
         "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/core": "^1.1.1",
-        "bs58": "^6.0.0",
-        "js-base64": "^3.7.5",
         "tslib": "^2.8.1"
       },
       "optionalDependencies": {
@@ -2080,24 +2075,91 @@
       }
     },
     "node_modules/@solana-mobile/wallet-standard-mobile": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-standard-mobile/-/wallet-standard-mobile-0.5.2.tgz",
-      "integrity": "sha512-orEGv4N/Ttd0umwfWUzGcEnVc9eJDTgRSEcDitvFWpIf2D968h6128L0rq9/y7sUw88Gvu/lU0euoC2ASEijqQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-standard-mobile/-/wallet-standard-mobile-0.5.3.tgz",
+      "integrity": "sha512-/Ea/CNIWHExpXsA6syVy7fUUhONtYob+VMsmF8flm8GEAZQyzX6UtKSy4NQMMTGBTAGlmmmbBVrZF+Tp5/fDxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.9",
         "@solana/wallet-standard-chains": "^1.1.1",
         "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",
         "@wallet-standard/wallet": "^1.1.0",
-        "bs58": "^6.0.0",
-        "js-base64": "^3.7.5",
         "qrcode": "^1.5.4",
         "tslib": "^2.8.1"
       },
       "optionalDependencies": {
         "@react-native-async-storage/async-storage": "^1.17.7"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.10.0.tgz",
+      "integrity": "sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.10.0.tgz",
+      "integrity": "sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.10.0.tgz",
+      "integrity": "sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/buffer-layout": {
@@ -2113,19 +2175,66 @@
         "node": ">=5.10"
       }
     },
-    "node_modules/@solana/codecs-core": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
-      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+    "node_modules/@solana/codecs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.10.0.tgz",
+      "integrity": "sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "6.8.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/options": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.10.0.tgz",
+      "integrity": "sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.10.0.tgz",
+      "integrity": "sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2134,19 +2243,19 @@
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
-      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.10.0.tgz",
+      "integrity": "sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "6.8.0",
-        "@solana/errors": "6.8.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2155,21 +2264,21 @@
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
-      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.10.0.tgz",
+      "integrity": "sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "6.8.0",
-        "@solana/codecs-numbers": "6.8.0",
-        "@solana/errors": "6.8.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "fastestsmallesttextencoderdecoder": {
@@ -2181,13 +2290,13 @@
       }
     },
     "node_modules/@solana/errors": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
-      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.10.0.tgz",
+      "integrity": "sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "commander": "14.0.3"
+        "commander": "15.0.0"
       },
       "bin": {
         "errors": "bin/cli.mjs"
@@ -2196,7 +2305,821 @@
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.10.0.tgz",
+      "integrity": "sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.10.0.tgz",
+      "integrity": "sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.10.0.tgz",
+      "integrity": "sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.10.0.tgz",
+      "integrity": "sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.10.0.tgz",
+      "integrity": "sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.10.0.tgz",
+      "integrity": "sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.10.0.tgz",
+      "integrity": "sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/plugin-core": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/program-client-core": "6.10.0",
+        "@solana/programs": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "@solana/sysvars": "6.10.0",
+        "@solana/transaction-confirmation": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.10.0.tgz",
+      "integrity": "sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.10.0.tgz",
+      "integrity": "sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.10.0.tgz",
+      "integrity": "sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.10.0.tgz",
+      "integrity": "sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.10.0.tgz",
+      "integrity": "sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.10.0.tgz",
+      "integrity": "sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/signers": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.10.0.tgz",
+      "integrity": "sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.10.0.tgz",
+      "integrity": "sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.10.0.tgz",
+      "integrity": "sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-transport-http": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.10.0.tgz",
+      "integrity": "sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.10.0.tgz",
+      "integrity": "sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.10.0.tgz",
+      "integrity": "sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.10.0.tgz",
+      "integrity": "sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.10.0.tgz",
+      "integrity": "sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions-api": "6.10.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.10.0.tgz",
+      "integrity": "sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.10.0.tgz",
+      "integrity": "sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.10.0.tgz",
+      "integrity": "sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.10.0.tgz",
+      "integrity": "sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.10.0.tgz",
+      "integrity": "sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "undici-types": "^8.4.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "license": "MIT"
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.10.0.tgz",
+      "integrity": "sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.10.0.tgz",
+      "integrity": "sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.10.0.tgz",
+      "integrity": "sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.10.0.tgz",
+      "integrity": "sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.10.0.tgz",
+      "integrity": "sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.10.0.tgz",
+      "integrity": "sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.10.0.tgz",
+      "integrity": "sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -2254,15 +3177,15 @@
       }
     },
     "node_modules/@solana/wallet-standard-chains": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.1.tgz",
-      "integrity": "sha512-Us3TgL4eMVoVWhuC4UrePlYnpWN+lwteCBlhZDUhFZBJ5UMGh94mYPXno3Ho7+iHPYRtuCi/ePvPcYBqCGuBOw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.2.tgz",
+      "integrity": "sha512-EZobEGclDBAFplpJC5F3d/s8Xnlqc5isNKuPrd5o9ZPZ7tWN84O0e68yIZ8MAOj9V7ieRadNiHtql7uIXCTyXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-core": {
@@ -2280,62 +3203,62 @@
       }
     },
     "node_modules/@solana/wallet-standard-features": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
-      "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.4.0.tgz",
+      "integrity": "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-util": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.2.tgz",
-      "integrity": "sha512-rUXFNP4OY81Ddq7qOjQV4Kmkozx4wjYAxljvyrqPx8Ycz0FYChG/hQVWqvgpK3sPsEaO/7ABG1NOACsyAKWNOA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.3.tgz",
+      "integrity": "sha512-aweR5y5FjYaeS9TkoqAWERFpGUj2MJepsDhcekCuoPLcNCquJL85Nsnuy01tBybspN5+Y09SWkxwsODOFGSfkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.8.0",
-        "@solana/wallet-standard-chains": "^1.1.1",
-        "@solana/wallet-standard-features": "^1.3.0"
+        "@noble/curves": "^1.8.2",
+        "@solana/wallet-standard-chains": "^1.1.2",
+        "@solana/wallet-standard-features": "^1.4.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-wallet-adapter": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter/-/wallet-standard-wallet-adapter-1.1.4.tgz",
-      "integrity": "sha512-YSBrxwov4irg2hx9gcmM4VTew3ofNnkqsXQ42JwcS6ykF1P1ecVY8JCbrv75Nwe6UodnqeoZRbN7n/p3awtjNQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter/-/wallet-standard-wallet-adapter-1.1.5.tgz",
+      "integrity": "sha512-6EMRyXzLcXQY9P5Bo8XWh8It6lb4rUbwO+RDdSpEySz/v+ric0W9H3Yzlqted4AIXQMJgxZifgyFxTp6g/bfZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/wallet-standard-wallet-adapter-base": "^1.1.4",
-        "@solana/wallet-standard-wallet-adapter-react": "^1.1.4"
+        "@solana/wallet-standard-wallet-adapter-base": "^1.1.5",
+        "@solana/wallet-standard-wallet-adapter-react": "^1.1.5"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@solana/wallet-standard-wallet-adapter-base": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.4.tgz",
-      "integrity": "sha512-Q2Rie9YaidyFA4UxcUIxUsvynW+/gE2noj/Wmk+IOwDwlVrJUAXCvFaCNsPDSyKoiYEKxkSnlG13OA1v08G4iw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.5.tgz",
+      "integrity": "sha512-dbk+4mJAsZ1a2R/v5/Qvp6SleviuSNWd9LnuQ0ekH0HRRJTOWyTBJsdQsVDdAymdPnLAaIN5J10ni1CT2Z+ERg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/wallet-adapter-base": "^0.9.23",
-        "@solana/wallet-standard-chains": "^1.1.1",
-        "@solana/wallet-standard-features": "^1.3.0",
-        "@solana/wallet-standard-util": "^1.1.2",
+        "@solana/wallet-adapter-base": "^0.9.24",
+        "@solana/wallet-standard-chains": "^1.1.2",
+        "@solana/wallet-standard-features": "^1.4.0",
+        "@solana/wallet-standard-util": "^1.1.3",
         "@wallet-standard/app": "^1.1.0",
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0",
         "@wallet-standard/wallet": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@solana/web3.js": "^1.98.0",
@@ -2343,17 +3266,17 @@
       }
     },
     "node_modules/@solana/wallet-standard-wallet-adapter-react": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-react/-/wallet-standard-wallet-adapter-react-1.1.4.tgz",
-      "integrity": "sha512-xa4KVmPgB7bTiWo4U7lg0N6dVUtt2I2WhEnKlIv0jdihNvtyhOjCKMjucWet6KAVhir6I/mSWrJk1U9SvVvhCg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-react/-/wallet-standard-wallet-adapter-react-1.1.5.tgz",
+      "integrity": "sha512-JfKBU2Mc332pR+9xhxjr5U/Q2aL03mMmSbrcnvfvAjML6zUEzAQ/bV6DchRsdtAT8Rx0zEg8h4OhsXbmteu0Yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/wallet-standard-wallet-adapter-base": "^1.1.4",
+        "@solana/wallet-standard-wallet-adapter-base": "^1.1.5",
         "@wallet-standard/app": "^1.1.0",
         "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@solana/wallet-adapter-base": "*",
@@ -3215,7 +4138,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3239,9 +4163,9 @@
       "peer": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3313,9 +4237,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3332,10 +4256,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -3350,6 +4274,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -3434,9 +4359,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3548,6 +4473,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -3767,9 +4693,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4733,12 +5659,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
       "version": "3.0.7",
@@ -5756,9 +6676,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5825,10 +6745,13 @@
       "peer": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "license": "MIT"
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nullthrows": {
       "version": "1.1.1",
@@ -6060,9 +6983,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6079,7 +7002,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6555,9 +7478,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7283,12 +8206,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/pro-test/package.json
+++ b/pro-test/package.json
@@ -32,7 +32,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
-    "postcss": "8.5.12",
+    "postcss": "8.5.23",
     "ws": "8.21.0",
     "shell-quote": "1.8.4"
   }


### PR DESCRIPTION
## Summary

Fixes #5559 — unbaselined postcss GHSA-r28c-9q8g-f849 reds `audit-lockfile (pro-test)` and `audit-lockfile (blog-site)` on all PRs since 2026-07-24.

## Changes

- **`pro-test/package.json`**: Bumped postcss override pin from 8.5.12 to 8.5.23
- **`pro-test/package-lock.json`**: Regenerated with postcss 8.5.23
- **`blog-site/package-lock.json`**: Bumped postcss from 8.5.15 to 8.5.23 via `npm audit fix`
- **`.github/scripts/audit-production-dependencies.mjs`**: Removed stale baseline entries `GHSA-qjx8-664m-686j` and `GHSA-w24r-5266-9c3c` (no longer match any current advisory in pro-test)

## Verification

