### PR TITLE
fix(deps): bump postcss to 8.5.18+ to clear GHSA-r28c-9q8g-f849

### DIFF
--- a/blog-site/package-lock.json
+++ b/blog-site/package-lock.json
@@ -3756,9 +3756,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4007,9 +4007,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4026,7 +4026,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/blog-site/package.json
+++ b/blog-site/package.json
@@ -27,7 +27,7 @@
     "fast-xml-parser": "^5.8.0",
     "h3": "^1.15.9",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "smol-toml": "^1.6.1",
     "vite": "^7.3.2"
   }

--- a/pro-test/package-lock.json
+++ b/pro-test/package-lock.json
@@ -5756,9 +5756,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6060,9 +6060,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6079,7 +6079,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/pro-test/package.json
+++ b/pro-test/package.json
@@ -32,7 +32,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
-    "postcss": "8.5.12",
+    "postcss": "8.5.18",
     "ws": "8.21.0",
     "shell-quote": "1.8.4"
   }


### PR DESCRIPTION
## Summary

A freshly-published high advisory — **GHSA-r28c-9q8g-f849** (PostCSS path traversal in `sourceMappingURL` source-map auto-loading; vulnerable `<= 8.5.17`, patched `8.5.18`) — was unbaselined in the `blog-site` and `pro-test` lockfiles. The `security-audit` gate runs on every `pull_request`, so `audit-lockfile (blog-site)` and `audit-lockfile (pro-test)` started failing on **all** open PRs, blocking merges repo-wide (same recurring pattern as #5418).

This bumps the transitive `postcss` override past the patched floor and regenerates both lockfiles — no application code changes:

| Workspace | postcss before | postcss after | override change |
|---|---|---|---|
| blog-site | 8.5.15 | 8.5.23 | `^8.5.10` → `^8.5.18` |
| pro-test | 8.5.12 | 8.5.18 | `8.5.12` → `8.5.18` (exact pin) |

The regen also pulls postcss's own `nanoid` subdep forward (3.3.x); nothing else changes.

## Validation

Ran the CI gate script itself against both regenerated lockfiles:

```
node .github/scripts/audit-production-dependencies.mjs --workspace blog-site --lockfile blog-site/package-lock.json  → exit 0
node .github/scripts/audit-production-dependencies.mjs --workspace pro-test --lockfile pro-test/package-lock.json    → exit 0
```

Both now report only their pre-existing baselined advisories (sharp `GHSA-f88m`, shell-quote `GHSA-395f`); `GHSA-r28c-9q8g-f849` is gone.

Note: the pro-test audit now emits two *stale baseline* warnings (`GHSA-qjx8-664m-686j`, `GHSA-w24r-5266-9c3c` no longer match any advisory) — pre-existing, non-fatal, and left for a separate baseline-cleanup pass to keep this PR to the security bump.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01R24zSbmbkFkWzY8DtY9mXH
