### PR TITLE
feat(monitoring): probe the Umami analytics collector every 15 minutes (#5565)

### DIFF
--- a/.github/workflows/analytics-collector-monitor.yml
+++ b/.github/workflows/analytics-collector-monitor.yml
@@ -1,0 +1,28 @@
+name: Analytics Collector Monitor
+
+# Probes the self-hosted Umami collector directly. Deliberately NOT gated on a
+# green main (unlike seed-freshness-monitor.yml): the collector's health is
+# independent of repo state, and a gate is one more way for this to go quiet —
+# which is exactly how a 4-day analytics blackout went unnoticed (#5565).
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - name: Probe analytics collector
+        run: node scripts/check-analytics-collector.mjs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -370,6 +370,7 @@ Runs before every `git push`:
 | `live-api-cache-auth.yml` | 6-hourly cron, push to main (sweep paths), manual | Production cache/auth posture sweep: fake auth stays no-store and is never a cached 200, anonymous public surfaces stay cacheable, MCP/OAuth surfaces stay protocol-valid (#4497 regression net; suite was inert until #5379 wired the gate on, and the step fails if it executes 0 assertions) |
 | `security-audit.yml` | PR, push to main, daily cron, manual | Production dependency audits for every tracked `package-lock.json` workspace, failing on unbaselined high/critical advisories |
 | `seed-freshness-monitor.yml` | 15-minute cron, manual | Checks production seed metadata freshness after a green main gate and fails on stale seed sources |
+| `analytics-collector-monitor.yml` | 15-minute cron, manual | Probes the self-hosted Umami collector directly (heartbeat, tracker script, ingest route) and fails when events are being dropped — Railway reported a green deployment through the 4-day #5565 blackout, so deployment status is not trusted here |
 | `contributor-trust.yml` | PR | Gates untrusted first-time-contributor runs |
 | `deploy-gate.yml` | After Test/Typecheck/Security Audit complete | Aggregates required smoke-gate statuses onto the head SHA for branch protection |
 | `convex-deploy.yml` | Push to main, manual | Deploys Convex backend functions |

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -48,6 +48,7 @@
   ],
   "locales": 25,
   "workflows": [
+    "analytics-collector-monitor.yml",
     "build-desktop.yml",
     "contributor-trust.yml",
     "convex-deploy.yml",
@@ -71,7 +72,7 @@
     "test.yml",
     "typecheck.yml"
   ],
-  "workflowCount": 22,
+  "workflowCount": 23,
   "freshnessSources": 35,
   "freshnessRequiredForRisk": 2,
   "feedDefinitions": 567,

--- a/scripts/check-analytics-collector.mjs
+++ b/scripts/check-analytics-collector.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+/**
+ * Scheduled liveness probe for the self-hosted Umami analytics collector
+ * (`abacus.worldmonitor.app`).
+ *
+ * Why this exists: on 2026-07-20 the collector's Node process OOM-died and
+ * Railway neither restarted it nor flipped the deployment off `SUCCESS`, so
+ * nothing alerted. Every product-analytics event was dropped for 4 days
+ * (~1.1M events) and the gap was only found by hand while asking an unrelated
+ * question about a funnel. See #5565.
+ *
+ * Deliberately probes the collector directly rather than trusting Railway's
+ * deployment status, which was green throughout that outage.
+ */
+
+import { realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_COLLECTOR_ORIGIN = 'https://abacus.worldmonitor.app';
+
+/**
+ * Cloudflare's WAF 403s a bare `curl/*` User-Agent on this host (verified
+ * 2026-07-24: `curl` default → 403, named agent → 200). A probe without a
+ * named agent alerts on a perfectly healthy collector, so this is required,
+ * not cosmetic.
+ */
+const USER_AGENT = 'worldmonitor-analytics-collector-monitor/1.0';
+
+const REQUEST_TIMEOUT_MS = 20_000;
+const ATTEMPTS = 3;
+const RETRY_DELAY_MS = 3_000;
+
+export const COLLECTOR_PROBES = Object.freeze([
+  Object.freeze({
+    name: 'heartbeat',
+    path: '/api/heartbeat',
+    okStatuses: Object.freeze([200]),
+    // Proves the app process is alive and serving. The OOM death surfaced
+    // here as a Cloudflare 502 after a ~15s origin timeout.
+  }),
+  Object.freeze({
+    name: 'tracker-script',
+    path: '/script.js',
+    okStatuses: Object.freeze([200]),
+    // A 200 alone is not enough — assert the served bytes really are the
+    // tracker by requiring the ingest path it posts to. A browser that cannot
+    // load this sends no events at all, whatever the collector reports about
+    // its own health.
+    mustInclude: '/api/send',
+  }),
+  Object.freeze({
+    name: 'ingest-route',
+    path: '/api/send',
+    // The write path. GET is the wrong verb on purpose: a mounted route
+    // rejects it (405/400) without recording anything, while a dead origin
+    // returns 5xx. Never POST here — that would pollute production analytics
+    // with synthetic monitor traffic.
+    okStatuses: Object.freeze([400, 405]),
+  }),
+]);
+
+/**
+ * Classify one completed probe attempt. Returns null when healthy, otherwise a
+ * human-readable reason for the alert.
+ */
+export function evaluateProbeResult(probe, result) {
+  if (!probe || typeof probe !== 'object' || Array.isArray(probe)) {
+    throw new TypeError('probe must be an object');
+  }
+  if (!Array.isArray(probe.okStatuses) || probe.okStatuses.length === 0) {
+    throw new TypeError(`probe ${probe.name} must declare okStatuses`);
+  }
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    throw new TypeError('result must be an object');
+  }
+
+  if (result.error) return `request failed: ${result.error}`;
+
+  if (!probe.okStatuses.includes(result.status)) {
+    // 403 is the WAF rejecting the probe itself, not the collector being down.
+    // Calling that out keeps a monitor bug from reading as an outage.
+    const hint =
+      result.status === 403
+        ? ' — Cloudflare WAF rejected the probe; check the User-Agent, not the collector'
+        : '';
+    return `HTTP ${result.status} (expected ${probe.okStatuses.join(' or ')})${hint}`;
+  }
+
+  if (probe.mustInclude && !String(result.body ?? '').includes(probe.mustInclude)) {
+    return `HTTP ${result.status} but body did not contain ${probe.mustInclude}`;
+  }
+
+  return null;
+}
+
+/** Collect the probes that failed, preserving probe order for stable output. */
+export function summarizeProbeFailures(probes, resultsByName) {
+  return probes
+    .map((probe) => ({ probe, reason: evaluateProbeResult(probe, resultsByName[probe.name]) }))
+    .filter(({ reason }) => reason !== null)
+    .map(({ probe, reason }) => ({ name: probe.name, path: probe.path, reason }));
+}
+
+async function runProbe(origin, probe) {
+  const url = new URL(probe.path, origin).toString();
+  try {
+    const response = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    // Only read the body when a probe actually asserts on it — the tracker is
+    // ~4.6 KB, but /api/send responses are not worth buffering.
+    const body = probe.mustInclude ? await response.text() : '';
+    return { status: response.status, body };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Retry before alerting so a single transient blip (deploy restart, edge
+ * hiccup) does not page anyone. A sustained failure is what matters: the
+ * outage this monitor exists for lasted four days.
+ */
+async function runProbeWithRetries(origin, probe) {
+  let last;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    last = await runProbe(origin, probe);
+    if (evaluateProbeResult(probe, last) === null) return last;
+    if (attempt < ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+  return last;
+}
+
+async function main() {
+  const origin = process.env.ANALYTICS_COLLECTOR_ORIGIN || DEFAULT_COLLECTOR_ORIGIN;
+
+  const resultsByName = {};
+  for (const probe of COLLECTOR_PROBES) {
+    resultsByName[probe.name] = await runProbeWithRetries(origin, probe);
+  }
+
+  const failures = summarizeProbeFailures(COLLECTOR_PROBES, resultsByName);
+  if (failures.length === 0) {
+    console.log(`Analytics collector healthy at ${origin}: ${COLLECTOR_PROBES.length} probes OK.`);
+    return;
+  }
+
+  console.error(
+    `Analytics collector alert: ${failures.length}/${COLLECTOR_PROBES.length} probe(s) failing at ${origin} after ${ATTEMPTS} attempts.`,
+  );
+  for (const failure of failures) {
+    console.error(`- ${failure.name} (${failure.path}): ${failure.reason}`);
+  }
+  console.error(
+    'Events are being dropped while this is red. Check the Railway `umami` service — a green deployment status does not mean the process is alive (#5565).',
+  );
+  process.exitCode = 1;
+}
+
+// realpath BOTH sides: through a symlinked checkout Node sets import.meta.url
+// to the realpath while argv[1] keeps the symlink, and the naive comparison
+// silently no-ops the whole monitor (exit 0, nothing checked).
+const isMainModule =
+  Boolean(process.argv[1]) &&
+  pathToFileURL(realpathSync(process.argv[1])).href ===
+    pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tests/analytics-collector-monitor.test.mjs
+++ b/tests/analytics-collector-monitor.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  COLLECTOR_PROBES,
+  evaluateProbeResult,
+  summarizeProbeFailures,
+} from '../scripts/check-analytics-collector.mjs';
+
+const probeByName = (name) => COLLECTOR_PROBES.find((probe) => probe.name === name);
+
+describe('scheduled analytics collector monitor', () => {
+  it('accepts the live shape of a healthy collector', () => {
+    // Verified against production 2026-07-24 after the #5565 restore.
+    assert.equal(evaluateProbeResult(probeByName('heartbeat'), { status: 200 }), null);
+    assert.equal(
+      evaluateProbeResult(probeByName('tracker-script'), {
+        status: 200,
+        body: '!function(){"use strict";...\'/api/send\'...}',
+      }),
+      null,
+    );
+    assert.equal(evaluateProbeResult(probeByName('ingest-route'), { status: 405 }), null);
+  });
+
+  it('alerts on the exact failure signature of the 4-day outage', () => {
+    // Cloudflare 502 after the origin OOM-died, on every path.
+    for (const name of ['heartbeat', 'tracker-script', 'ingest-route']) {
+      assert.match(evaluateProbeResult(probeByName(name), { status: 502 }), /HTTP 502/);
+    }
+    assert.match(
+      evaluateProbeResult(probeByName('heartbeat'), { error: 'The operation was aborted' }),
+      /request failed/,
+    );
+  });
+
+  it('never POSTs to the ingest route, so probing writes no synthetic events', () => {
+    const source = readFileSync(
+      new URL('../scripts/check-analytics-collector.mjs', import.meta.url),
+      'utf8',
+    );
+    assert.doesNotMatch(source, /method:\s*['"]POST['"]/i);
+    assert.equal(probeByName('ingest-route').path, '/api/send');
+  });
+
+  it('blames the probe, not the collector, when the WAF rejects the User-Agent', () => {
+    // A bare `curl/*` agent 403s on this host — that is a monitor bug, and the
+    // alert has to say so or it reads as an outage.
+    const reason = evaluateProbeResult(probeByName('heartbeat'), { status: 403 });
+    assert.match(reason, /User-Agent/);
+    assert.match(reason, /not the collector/);
+  });
+
+  it('rejects a 200 that is not actually the tracker', () => {
+    // An error page or a proxy interstitial can answer 200 on /script.js.
+    const reason = evaluateProbeResult(probeByName('tracker-script'), {
+      status: 200,
+      body: '<!doctype html><title>Bad gateway</title>',
+    });
+    assert.match(reason, /did not contain \/api\/send/);
+  });
+
+  it('reports every failing probe, in probe order, and nothing else', () => {
+    const failures = summarizeProbeFailures(COLLECTOR_PROBES, {
+      heartbeat: { status: 502 },
+      'tracker-script': { status: 200, body: 'posts to /api/send' },
+      'ingest-route': { error: 'fetch failed' },
+    });
+    assert.deepEqual(
+      failures.map((failure) => failure.name),
+      ['heartbeat', 'ingest-route'],
+    );
+    assert.match(failures[1].reason, /fetch failed/);
+  });
+
+  it('refuses malformed probes and results instead of passing them', () => {
+    assert.throws(() => evaluateProbeResult(null, { status: 200 }), /probe must be an object/);
+    assert.throws(
+      () => evaluateProbeResult({ name: 'x', okStatuses: [] }, { status: 200 }),
+      /okStatuses/,
+    );
+    assert.throws(() => evaluateProbeResult(probeByName('heartbeat'), null), /result must be/);
+  });
+
+  it('runs on a schedule and invokes the monitor script without a main-green gate', () => {
+    const workflow = readFileSync(
+      new URL('../.github/workflows/analytics-collector-monitor.yml', import.meta.url),
+      'utf8',
+    );
+
+    assert.match(workflow, /schedule:/);
+    assert.match(workflow, /cron:\s*['"]\*\/15 \* \* \* \*['"]/);
+    assert.match(workflow, /actions\/setup-node@[a-f0-9]+/);
+    assert.match(workflow, /node-version:\s*['"]24['"]/);
+    assert.match(workflow, /node scripts\/check-analytics-collector\.mjs/);
+    // The gate that seed-freshness-monitor.yml uses must NOT appear here.
+    assert.doesNotMatch(workflow, /context\s*==\s*"gate"/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a 15-minute scheduled probe of the self-hosted Umami analytics collector, closing items 3–4 of #5565.

On 2026-07-20 17:13 UTC the collector's Node process OOM-died. Railway neither restarted it nor flipped the deployment off `SUCCESS`, so **nothing alerted for 4 days** — ~1.1M events dropped across every tracked funnel (`gate-hit`, the #4931 checkout funnel, `sign-up`, and #5534's brand-new activation events, which shipped into a dead collector). The gap was found by hand, while asking an unrelated question about whether anyone had used the #5534 onboarding.

The service side is already mitigated (`NODE_OPTIONS=--max-old-space-size=8192`, `restartPolicyType: ALWAYS`). This PR is the part that makes the *next* failure visible in ≤15 minutes instead of ≤4 days.

## Design decisions

- **Probes the collector directly, never Railway's deployment status** — that status was green for the entire outage. Trusting it is what failed.
- **Three probes, because HTTP 200 on one path proves less than it looks like.**
  | probe | expect | proves |
  |---|---|---|
  | `/api/heartbeat` | 200 | app process alive (this returned 502-after-15s for 4 days) |
  | `/script.js` | 200 **and body contains `/api/send`** | browsers can load the *real* tracker — an error page or proxy interstitial can answer 200 |
  | `GET /api/send` | 405 or 400 | the write path is mounted |
- **`GET` on the ingest route is deliberate.** A mounted route rejects the wrong verb without recording anything, while a dead origin 5xxs. Never `POST` — that would pollute production analytics with synthetic monitor traffic. A test asserts the source contains no `POST`.
- **The named User-Agent is load-bearing, not cosmetic.** Cloudflare's WAF 403s a bare `curl/*` agent on this host (verified: `curl` default → 403, named agent → 200). A probe without one alerts on a healthy collector — so a 403 is classified with its own message pointing at the probe rather than the collector.
- **Three attempts per probe** before alerting, so a deploy restart or edge hiccup cannot page anyone. The failure this exists for lasted four days; it does not need a hair trigger.
- **Deliberately NOT gated on a green main**, unlike `seed-freshness-monitor.yml`. The collector's health is independent of repo state, and a gate is one more way for the monitor to go quiet — the precise failure mode being fixed.

## Validation

- 8/8 unit tests (`node --test`), including the outage's exact signature (502 on all three paths), the 200-but-not-the-tracker case, the WAF-403 misclassification guard, and a workflow-wiring assertion.
- **Ran the real script against the live collector** — green, `3 probes OK`.
- **Proved it actually goes red**, not just that it can pass:
  - dead origin (`127.0.0.1:9`) → exit 1, all three probes `request failed`
  - live-but-wrong origin (`example.com`) → exit 1, all three `HTTP 404`
- `docs:check` (80 doc claims match code), `docs:stats` regenerated and committed (`workflowCount` 22→23), biome, markdownlint all clean.

Note: `schedule`/`workflow_dispatch` only fire from the default branch, so the workflow's first real run is post-merge. The script itself is verified end-to-end above.

## Follow-up (not in this PR)

The memory bump is a runway extension, not a fix. The upstream `sessionData.updateMany()` P2002 flood (umami-software/umami#4183) resumed at full rate on restart — ~12 errors in 51s. At the observed retention rate 8 GB buys roughly 8–10 months. Upgrading the image is not an escape hatch: #4183 is still open and reported crash-looping on v3.2.0, so `autoUpdates: {type: "patch"}` should stay. This monitor is what makes the recurrence a 15-minute incident instead of a silent one.

Refs #5565

---

[![Claude Code](https://img.shields.io/badge/Claude_Code-D97757?logo=claude&logoColor=white)](https://claude.ai/code)

https://claude.ai/code/session_017LEK5hk1YCDNTwrvJkYV2k
