### PR TITLE
fix(security): baseline unreachable brace expansion advisory

### DIFF
--- a/.github/scripts/audit-production-dependencies.mjs
+++ b/.github/scripts/audit-production-dependencies.mjs
@@ -23,7 +23,13 @@ export const BASELINE_ADVISORIES_BY_LOCKFILE = {
   // semver-major across both chains; baselined until the parents bump. The
   // same reasoning covers blog-site below: sharp runs only at Astro build
   // time over repo-owned images, and the fix requires astro@7 (semver-major).
-  'package-lock.json': ['GHSA-f88m-g3jw-g9cj'],
+  // GHSA-mh99-v99m-4gvg (brace-expansion OOM from unbounded brace patterns)
+  // reaches root only through Clerk's optional Solana wallet -> react-native ->
+  // babel-jest/test-exclude tooling chain. It never executes in the Vite web
+  // bundle or API runtime. The sole patched release, brace-expansion 5.0.8,
+  // changes the CommonJS export shape and breaks this chain's minimatch 3.x;
+  // keep the advisory baselined until the upstream parents move to minimatch 10.
+  'package-lock.json': ['GHSA-f88m-g3jw-g9cj', 'GHSA-mh99-v99m-4gvg'],
   'consumer-prices-core/package-lock.json': [],
   'blog-site/package-lock.json': ['GHSA-f88m-g3jw-g9cj'],
   // GHSA-395f-4hp3-45gv (shell-quote quadratic-complexity DoS in parse()) reaches
@@ -41,7 +47,12 @@ export const BASELINE_ADVISORIES_BY_LOCKFILE = {
   // which drags a public/pro/ bundle rebuild into a lockfile-hygiene change —
   // same trade-off as GHSA-395f below. Drop when the pin next bumps.
   'pro-test/package-lock.json': ['GHSA-qjx8-664m-686j', 'GHSA-w24r-5266-9c3c', 'GHSA-395f-4hp3-45gv', 'GHSA-r28c-9q8g-f849'],
-  'scripts/package-lock.json': [],
+  // GHSA-mh99-v99m-4gvg reaches scripts only through ExcelJS's archive
+  // dependencies. ExcelJS is used by operator-run seed/backfill scripts with
+  // exact workbook paths; no request input reaches a minimatch brace pattern.
+  // Forcing brace-expansion 5.0.8 breaks minimatch 3.x/5.x's callable require,
+  // while replacing ExcelJS's archiver stack requires unrelated major upgrades.
+  'scripts/package-lock.json': ['GHSA-mh99-v99m-4gvg'],
   'docker/runtime-package-lock.json': [],
 };
 

--- a/tests/security-audit-baseline.test.mjs
+++ b/tests/security-audit-baseline.test.mjs
@@ -147,6 +147,16 @@ describe('security audit baseline', () => {
             url: 'https://github.com/advisories/GHSA-f88m-g3jw-g9cj',
           }],
         },
+        'brace-expansion': {
+          name: 'brace-expansion',
+          severity: 'high',
+          via: [{
+            name: 'brace-expansion',
+            severity: 'high',
+            title: 'brace-expansion uncontrolled resource consumption',
+            url: 'https://github.com/advisories/GHSA-mh99-v99m-4gvg',
+          }],
+        },
         'postcss': {
           name: 'postcss',
           severity: 'high',
@@ -162,8 +172,9 @@ describe('security audit baseline', () => {
 
     // The still-present ids are not reported as stale; GHSA-qjx8 (absent) is.
     assert.deepEqual(collectStaleBaselineEntries(report, 'pro-test/package-lock.json'), ['GHSA-qjx8-664m-686j']);
-    // Root's baselined sharp advisory is present in the report, so nothing is stale.
+    // Root and scripts baselines are represented, so neither reports a stale entry.
     assert.deepEqual(collectStaleBaselineEntries(report, 'package-lock.json'), []);
+    assert.deepEqual(collectStaleBaselineEntries(report, 'scripts/package-lock.json'), []);
   });
 
   it('treats a symlinked entry path as direct invocation (no silent fail-open)', () => {


### PR DESCRIPTION
## Summary

Security audits can pass again without forcing patched `brace-expansion` 5.0.8 into incompatible legacy `minimatch` consumers. GHSA-mh99-v99m-4gvg is confined to non-runtime dependency paths: Clerk's optional Solana/React Native test tooling in the root lockfile, and ExcelJS archive helpers used only by operator-run scripts with exact local workbook paths.

A global override was rejected because 5.0.8 changes the CommonJS export shape and breaks `minimatch` 3.x/5.x (`TypeError: expand is not a function`). This records a narrow lockfile-specific baseline until upstream parents migrate, while stale-baseline coverage ensures the exception must be removed once the advisory disappears.

Related: #5464

## Validation

- Exact production audit passed for the root lockfile with only the existing `sharp` advisory and GHSA-mh99-v99m-4gvg baselined.
- Exact production audit passed for `scripts/package-lock.json` with only GHSA-mh99-v99m-4gvg baselined.
- `node --test tests/security-audit-baseline.test.mjs` — 8/8 passing.
- Full pre-push gate passed, including frontend typecheck, Unicode safety, version synchronization, and changed-test execution.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
