### PR TITLE
test(edge): assert the api/ SSRF allowlist mirror matches its source of truth

### DIFF
--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -80,6 +80,27 @@ describe('Edge Function shared helpers resolve', () => {
     assert.ok(domains.length > 200, `Expected 200+ domains, got ${domains.length}`);
     assert.ok(domains.includes('feeds.bbci.co.uk'), 'Expected BBC feed domain in list');
   });
+
+  // The api/ copy is the list the internet-facing Edge SSRF guard actually enforces,
+  // and it was the only mirror with no parity assertion: the sync block above covers
+  // shared/ vs scripts/shared/, and the two .cjs files are `require()` re-exports that
+  // cannot drift. A host added to (or dropped from) the api/ mirror alone therefore
+  // passed PR CI silently — scripts/validate-rss-feeds.mjs --ci is the only other
+  // reader and feed-validation.yml deliberately excludes pull_request (SSRF guard).
+  // Ordered deep-equal, because the api/ file is JS source (Vercel esbuild cannot do
+  // `import ... with { type: 'json' }`), so a byte-compare against the JSON is not possible.
+  it('_rss-allowed-domains.js stays an exact ordered copy of the shared JSON', async () => {
+    const mod = await import(pathToFileURL(join(apiDir, '_rss-allowed-domains.js')).href);
+    const shared = JSON.parse(
+      readFileSync(join(sharedDir, 'rss-allowed-domains.json'), 'utf8'),
+    );
+    assert.deepStrictEqual(
+      mod.default,
+      shared,
+      'api/_rss-allowed-domains.js drifted from shared/rss-allowed-domains.json — ' +
+        'the Edge SSRF allowlist must match its stated source of truth exactly (order included)',
+    );
+  });
 });
 
 describe('Edge Function no node: built-ins', () => {


### PR DESCRIPTION
## Summary

Follow-up hardening from the review of #5405. `api/_rss-allowed-domains.js` is the list the internet-facing Edge RSS proxy actually enforces, and it was the only one of the three allowlist copies with **no parity assertion**.

- The existing sync block (`tests/edge-functions.test.mjs`) byte-compares `shared/` vs `scripts/shared/`.
- Both `.cjs` files are `module.exports = require('./rss-allowed-domains.json')` re-exports, so they cannot drift.
- The `api/` copy is hand-maintained JS — Vercel's esbuild cannot do `import ... with { type: 'json' }` — and was checked only for `Array.isArray`, `length > 200`, and one hardcoded BBC host.

Net effect: a host added to, or dropped from, the production SSRF allowlist **in that file alone** passed PR CI silently. The only other reader, `scripts/validate-rss-feeds.mjs --ci`, is deliberately excluded from `pull_request` triggers because fork PRs are themselves an SSRF surface — which is exactly the shape of change that reaches this file.

## Change

One assertion: ordered `deepStrictEqual` of the `api/` default export against the parsed `shared/rss-allowed-domains.json`. Ordered rather than set-equal, because the file's own header declares it an exact copy of that source of truth.

## Testing

Mutation-proved both drift directions, restoring the tree byte-identically after each:

| Mutation | Result |
|---|---|
| Extra host in the `api/` mirror only | red (233 pass / 1 fail) |
| Reorder only, identical membership | red (233 pass / 1 fail) |
| Unmodified | green (234 pass / 0 fail) |

The reorder case confirms it catches ordering drift, not just membership drift (verified same-members / different-order explicitly).

## Type of change

- [x] CI / Build / Infrastructure

## Affected areas

- [x] API endpoints (`/api/*`) — test-only, no runtime change

## Documentation Alignment Checklist

N/A — test-only change; no methodology, API/MCP contract, generated doc, fixture, or Redis key is modified.

https://claude.ai/code/session_01APwcA88rWvQ5FrdEu4Wtp7