### PR TITLE
feat(activation): persist wizard outcome + activation-lift analysis script

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -5032,7 +5032,7 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     expect(rows).toEqual([]);
   });
 
-  test("recordProActivationOutcome persists confirmed/skipped/failed steps and an exit timestamp", async () => {
+  test("recordProActivationOutcome persists monotonic progress and freezes the finalized outcome", async () => {
     const t = convexTest(schema, modules);
     const activationKey = await seedSubscription(t, {
       planKey: "pro_monthly",
@@ -5046,8 +5046,50 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
       { activationKey, claimNonce: "device-a" },
     );
 
+    const progressed = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: ["alerts"],
+        failedSteps: ["power"],
+        revision: 1,
+        finalized: false,
+      },
+    );
+    expect(progressed).toBe(true);
+
+    const progressRow = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(progressRow?.presentedAt).toBeTypeOf("number");
+    expect(progressRow?.outcomeRevision).toBe(1);
+    expect(progressRow?.exitedAt).toBeUndefined();
+
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: [],
+        skippedSteps: ["brief", "alerts", "power"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    )).toBe(false);
+
+    const afterStaleWrite = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(afterStaleWrite?.confirmedSteps).toEqual(["brief"]);
+    expect(afterStaleWrite?.failedSteps).toEqual(["power"]);
+
     const before = Date.now();
-    const persisted = await t.withIdentity(IDENTITY).mutation(
+    const finalized = await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.recordProActivationOutcome,
       {
         activationKey,
@@ -5055,9 +5097,11 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
         confirmedSteps: ["brief", "power"],
         skippedSteps: ["alerts"],
         failedSteps: [],
+        revision: 2,
+        finalized: true,
       },
     );
-    expect(persisted).toBe(true);
+    expect(finalized).toBe(true);
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
@@ -5066,7 +5110,21 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     expect(row?.confirmedSteps).toEqual(["brief", "power"]);
     expect(row?.skippedSteps).toEqual(["alerts"]);
     expect(row?.failedSteps).toEqual([]);
+    expect(row?.outcomeRevision).toBe(2);
     expect(row?.exitedAt).toBeGreaterThanOrEqual(before);
+
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: [],
+        skippedSteps: ["brief", "alerts", "power"],
+        failedSteps: [],
+        revision: 3,
+        finalized: true,
+      },
+    )).toBe(false);
   });
 
   test("recordProActivationOutcome no-ops on a claimNonce mismatch, another user's row, or a never-claimed subscription", async () => {
@@ -5082,7 +5140,15 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     // No presentation row exists yet -- never claimed.
     expect(await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.recordProActivationOutcome,
-      { activationKey, claimNonce: "device-a", confirmedSteps: [], skippedSteps: [], failedSteps: [] },
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: [],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: true,
+      },
     )).toBe(false);
 
     await t.withIdentity(IDENTITY).mutation(
@@ -5093,7 +5159,15 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     // Wrong nonce.
     expect(await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.recordProActivationOutcome,
-      { activationKey, claimNonce: "wrong-nonce", confirmedSteps: ["brief"], skippedSteps: [], failedSteps: [] },
+      {
+        activationKey,
+        claimNonce: "wrong-nonce",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: true,
+      },
     )).toBe(false);
 
     // Different user.
@@ -5103,7 +5177,15 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     };
     expect(await t.withIdentity(otherIdentity).mutation(
       api.payments.billing.recordProActivationOutcome,
-      { activationKey, claimNonce: "device-a", confirmedSteps: ["brief"], skippedSteps: [], failedSteps: [] },
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: true,
+      },
     )).toBe(false);
 
     const row = await t.run(async (ctx) => await ctx.db
@@ -5112,6 +5194,86 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
       .unique());
     expect(row?.confirmedSteps).toBeUndefined();
     expect(row?.exitedAt).toBeUndefined();
+  });
+
+  test("recordProActivationOutcome rejects invalid revisions, unknown steps, duplicates, and overlaps", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_outcome_validation",
+    });
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "device-a" },
+    );
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 0,
+        finalized: false,
+      },
+    )).rejects.toThrow(/integer from 1 to 4/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 5,
+        finalized: false,
+      },
+    )).rejects.toThrow(/integer from 1 to 4/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: ["brief"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    )).rejects.toThrow(/disjoint/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief", "brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    )).rejects.toThrow(/disjoint/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["unknown"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      } as never,
+    )).rejects.toThrow();
   });
 
   test("a disabled alert rule with a verified channel stays onboarding-eligible", async () => {

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -5031,4 +5031,86 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
       .collect());
     expect(rows).toEqual([]);
   });
+
+  test("recordProActivationOutcome persists confirmed/skipped/failed steps and an exit timestamp", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_outcome",
+    });
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "device-a" },
+    );
+
+    const before = Date.now();
+    const persisted = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief", "power"],
+        skippedSteps: ["alerts"],
+        failedSteps: [],
+      },
+    );
+    expect(persisted).toBe(true);
+
+    const row = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(row?.confirmedSteps).toEqual(["brief", "power"]);
+    expect(row?.skippedSteps).toEqual(["alerts"]);
+    expect(row?.failedSteps).toEqual([]);
+    expect(row?.exitedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  test("recordProActivationOutcome no-ops on a claimNonce mismatch, another user's row, or a never-claimed subscription", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_outcome_guard",
+    });
+
+    // No presentation row exists yet -- never claimed.
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      { activationKey, claimNonce: "device-a", confirmedSteps: [], skippedSteps: [], failedSteps: [] },
+    )).toBe(false);
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "device-a" },
+    );
+
+    // Wrong nonce.
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      { activationKey, claimNonce: "wrong-nonce", confirmedSteps: ["brief"], skippedSteps: [], failedSteps: [] },
+    )).toBe(false);
+
+    // Different user.
+    const otherIdentity = {
+      subject: "user_activation_outcome_other",
+      tokenIdentifier: "clerk|user_activation_outcome_other",
+    };
+    expect(await t.withIdentity(otherIdentity).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      { activationKey, claimNonce: "device-a", confirmedSteps: ["brief"], skippedSteps: [], failedSteps: [] },
+    )).toBe(false);
+
+    const row = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(row?.confirmedSteps).toBeUndefined();
+    expect(row?.exitedAt).toBeUndefined();
+  });
 });

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -718,23 +718,28 @@ export const confirmProActivationPresentation = mutation({
   },
 });
 
+const proActivationStepIdValidator = v.union(
+  v.literal("brief"),
+  v.literal("alerts"),
+  v.literal("power"),
+);
+const MAX_PRO_ACTIVATION_OUTCOME_REVISION = 4;
+
 /**
- * Persist the wizard's actual outcome once the subscriber exits (#5582):
- * which steps confirmed, which were skipped, which failed. Independent of
- * the Umami funnel event -- Umami carries no userId to join against Convex
- * feature-usage tables, and was found dead for 4 days spanning most of
- * #5534's launch window (#5565). Best-effort: a missing/mismatched
- * presentation row (e.g. the lease already expired and a different device
- * reclaimed it) silently no-ops rather than surfacing an error to a
- * subscriber who is already leaving the flow.
+ * Persist a monotonic snapshot of the wizard outcome (#5582). Progress writes
+ * happen as steps resolve so a lost exit cannot censor disengaged sessions;
+ * the final write sets `exitedAt` and freezes the record. Invalid,
+ * overlapping, stale, and replayed classifications are rejected.
  */
 export const recordProActivationOutcome = mutation({
   args: {
     activationKey: v.id("subscriptions"),
     claimNonce: v.string(),
-    confirmedSteps: v.array(v.string()),
-    skippedSteps: v.array(v.string()),
-    failedSteps: v.array(v.string()),
+    confirmedSteps: v.array(proActivationStepIdValidator),
+    skippedSteps: v.array(proActivationStepIdValidator),
+    failedSteps: v.array(proActivationStepIdValidator),
+    revision: v.number(),
+    finalized: v.boolean(),
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
@@ -745,15 +750,42 @@ export const recordProActivationOutcome = mutation({
     if (
       presentation === null ||
       presentation.userId !== userId ||
-      presentation.claimNonce !== args.claimNonce
+      presentation.claimNonce !== args.claimNonce ||
+      presentation.exitedAt !== undefined
     ) {
       return false;
     }
+
+    if (
+      !Number.isSafeInteger(args.revision) ||
+      args.revision < 1 ||
+      args.revision > MAX_PRO_ACTIVATION_OUTCOME_REVISION
+    ) {
+      throw new ConvexError(
+        `activation outcome revision must be an integer from 1 to ${MAX_PRO_ACTIVATION_OUTCOME_REVISION}`,
+      );
+    }
+    const allSteps = [
+      ...args.confirmedSteps,
+      ...args.skippedSteps,
+      ...args.failedSteps,
+    ];
+    if (allSteps.length > 3 || new Set(allSteps).size !== allSteps.length) {
+      throw new ConvexError("activation outcome buckets must be disjoint and contain at most three steps");
+    }
+    if (args.revision <= (presentation.outcomeRevision ?? 0)) {
+      return false;
+    }
+
+    const now = Date.now();
     await ctx.db.patch(presentation._id, {
       confirmedSteps: args.confirmedSteps,
       skippedSteps: args.skippedSteps,
       failedSteps: args.failedSteps,
-      exitedAt: Date.now(),
+      outcomeRevision: args.revision,
+      outcomeUpdatedAt: now,
+      ...(presentation.presentedAt === undefined ? { presentedAt: now } : {}),
+      ...(args.finalized ? { exitedAt: now } : {}),
     });
     return true;
   },

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -719,6 +719,47 @@ export const confirmProActivationPresentation = mutation({
 });
 
 /**
+ * Persist the wizard's actual outcome once the subscriber exits (#5582):
+ * which steps confirmed, which were skipped, which failed. Independent of
+ * the Umami funnel event -- Umami carries no userId to join against Convex
+ * feature-usage tables, and was found dead for 4 days spanning most of
+ * #5534's launch window (#5565). Best-effort: a missing/mismatched
+ * presentation row (e.g. the lease already expired and a different device
+ * reclaimed it) silently no-ops rather than surfacing an error to a
+ * subscriber who is already leaving the flow.
+ */
+export const recordProActivationOutcome = mutation({
+  args: {
+    activationKey: v.id("subscriptions"),
+    claimNonce: v.string(),
+    confirmedSteps: v.array(v.string()),
+    skippedSteps: v.array(v.string()),
+    failedSteps: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireUserId(ctx);
+    const presentation = await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.activationKey))
+      .first();
+    if (
+      presentation === null ||
+      presentation.userId !== userId ||
+      presentation.claimNonce !== args.claimNonce
+    ) {
+      return false;
+    }
+    await ctx.db.patch(presentation._id, {
+      confirmedSteps: args.confirmedSteps,
+      skippedSteps: args.skippedSteps,
+      failedSteps: args.failedSteps,
+      exitedAt: Date.now(),
+    });
+    return true;
+  },
+});
+
+/**
  * Internal query to retrieve a customer record by userId.
  *
  * NOTE: As of WORLDMONITOR-R5 follow-up, this is no longer used by the

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -55,6 +55,12 @@ const apiPlanLimitCtaKind = v.union(
   v.literal("none"),
 );
 
+const proActivationStepId = v.union(
+  v.literal("brief"),
+  v.literal("alerts"),
+  v.literal("power"),
+);
+
 export default defineSchema({
   userPreferences: defineTable({
     userId: v.string(),
@@ -635,25 +641,21 @@ export default defineSchema({
   // A short pending claim closes concurrent mount races without permanently
   // suppressing onboarding when a browser crashes before rendering the flow.
   //
-  // `confirmedSteps`/`skippedSteps`/`failedSteps`/`exitedAt` mirror the
-  // ActivationStepOutcome taxonomy (pro-activation-state.ts) and are the
-  // durable outcome record (#5582): what the subscriber actually did in the
-  // wizard, independent of the Umami funnel side, which has no userId to
-  // join against Convex feature-usage tables and was found dead for 4 days
-  // spanning most of #5534's launch window (#5565). Written once on exit,
-  // alongside (not instead of) the existing Umami event. `confirmedSteps`
-  // includes steps already done before the flow opened ('done' outcome), not
-  // only ones newly confirmed in-flow -- both count as "verified" for the
-  // adoption-lift comparison this exists to support.
+  // The outcome buckets mirror ActivationStepOutcome
+  // (pro-activation-state.ts). They are updated as the subscriber acts so a
+  // tab close cannot erase engagement, then frozen when `exitedAt` is set.
+  // `outcomeRevision` rejects late/out-of-order best-effort writes.
   proActivationPresentations: defineTable({
     userId: v.string(),
     subscriptionId: v.id("subscriptions"),
     claimNonce: v.string(),
     claimedAt: v.number(),
     presentedAt: v.optional(v.number()),
-    confirmedSteps: v.optional(v.array(v.string())),
-    skippedSteps: v.optional(v.array(v.string())),
-    failedSteps: v.optional(v.array(v.string())),
+    confirmedSteps: v.optional(v.array(proActivationStepId)),
+    skippedSteps: v.optional(v.array(proActivationStepId)),
+    failedSteps: v.optional(v.array(proActivationStepId)),
+    outcomeRevision: v.optional(v.number()),
+    outcomeUpdatedAt: v.optional(v.number()),
     exitedAt: v.optional(v.number()),
   })
     .index("by_subscription", ["subscriptionId"]),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -634,12 +634,27 @@ export default defineSchema({
   // Cross-device single-presentation lease for markerless Pro activation.
   // A short pending claim closes concurrent mount races without permanently
   // suppressing onboarding when a browser crashes before rendering the flow.
+  //
+  // `confirmedSteps`/`skippedSteps`/`failedSteps`/`exitedAt` mirror the
+  // ActivationStepOutcome taxonomy (pro-activation-state.ts) and are the
+  // durable outcome record (#5582): what the subscriber actually did in the
+  // wizard, independent of the Umami funnel side, which has no userId to
+  // join against Convex feature-usage tables and was found dead for 4 days
+  // spanning most of #5534's launch window (#5565). Written once on exit,
+  // alongside (not instead of) the existing Umami event. `confirmedSteps`
+  // includes steps already done before the flow opened ('done' outcome), not
+  // only ones newly confirmed in-flow -- both count as "verified" for the
+  // adoption-lift comparison this exists to support.
   proActivationPresentations: defineTable({
     userId: v.string(),
     subscriptionId: v.id("subscriptions"),
     claimNonce: v.string(),
     claimedAt: v.number(),
     presentedAt: v.optional(v.number()),
+    confirmedSteps: v.optional(v.array(v.string())),
+    skippedSteps: v.optional(v.array(v.string())),
+    failedSteps: v.optional(v.array(v.string())),
+    exitedAt: v.optional(v.number()),
   })
     .index("by_subscription", ["subscriptionId"]),
 

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -60,6 +60,18 @@ interface CapturedProEvent {
   };
 }
 
+interface CapturedOutcomeCall {
+  activationKey: string;
+  claimNonce: string;
+  outcome: {
+    confirmedSteps: string[];
+    skippedSteps: string[];
+    failedSteps: string[];
+    revision: number;
+    finalized: boolean;
+  };
+}
+
 async function gotoHarness(page: Page): Promise<void> {
   await page.goto('/tests/runtime-harness.html');
 }
@@ -123,6 +135,12 @@ async function readCapturedEvents(page: Page): Promise<CapturedProEvent[]> {
   return page.evaluate(() => (window as unknown as { __proEvents: CapturedProEvent[] }).__proEvents);
 }
 
+async function readCapturedOutcomes(page: Page): Promise<CapturedOutcomeCall[]> {
+  return page.evaluate(
+    () => (window as unknown as { __proOutcomeCalls: CapturedOutcomeCall[] }).__proOutcomeCalls,
+  );
+}
+
 type ClaimStatus = 'claimed' | 'not_eligible' | 'already_presented' | 'already_claimed';
 
 async function runMarkerlessFlowHarness(
@@ -141,6 +159,8 @@ async function runMarkerlessFlowHarness(
     const { initI18n } = await import('/src/services/i18n.ts');
     await initI18n();
     const mod = await import('/src/components/ProActivationInterstitial.ts');
+    const w = window as unknown as { __proOutcomeCalls: CapturedOutcomeCall[] };
+    w.__proOutcomeCalls = [];
     let ownerChecks = 0;
     let claimCalls = 0;
     let confirmCalls = 0;
@@ -188,10 +208,10 @@ async function runMarkerlessFlowHarness(
           }
           return scenario.confirmResult !== false;
         },
-        // Stubbed so these tests never depend on a real Convex client; the
-        // outcome-recording wiring itself is covered at the unit level
-        // (buildActivationOutcomeBuckets in pro-activation-state.test.mts).
-        recordOutcome: async () => {},
+        recordOutcome: async (activationKey, claimNonce, outcome) => {
+          w.__proOutcomeCalls.push({ activationKey, claimNonce, outcome });
+          return true;
+        },
         operationTimeoutMs: 20,
       },
     );
@@ -211,6 +231,7 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     });
     expect(result).toEqual({ result: 'retry', claimCalls: 0, confirmCalls: 0 });
     await expect(page.locator(OVERLAY)).toHaveCount(0);
+    expect(await readCapturedOutcomes(page)).toEqual([]);
   });
 
   test('a stalled claim reaches the controller retry path within its deadline', async ({ page }) => {
@@ -250,6 +271,41 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     await expect(page.locator(OVERLAY)).toBeVisible();
   });
 
+  test('markerless progress and final exit persist exact lease-bound outcome snapshots', async ({ page }) => {
+    const result = await runMarkerlessFlowHarness(page, { claimStatus: 'claimed' });
+    expect(result).toEqual({ result: 'opened', claimCalls: 1, confirmCalls: 1 });
+
+    await page.locator('.pro-activation-close').click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+    await page.locator(FINISH_BTN).click();
+
+    await expect.poll(async () => (await readCapturedOutcomes(page)).length).toBe(2);
+    expect(await readCapturedOutcomes(page)).toEqual([
+      {
+        activationKey: 'opaque-subscription',
+        claimNonce: 'tab-nonce',
+        outcome: {
+          confirmedSteps: [],
+          skippedSteps: ['brief', 'power'],
+          failedSteps: [],
+          revision: 1,
+          finalized: false,
+        },
+      },
+      {
+        activationKey: 'opaque-subscription',
+        claimNonce: 'tab-nonce',
+        outcome: {
+          confirmedSteps: [],
+          skippedSteps: ['brief', 'power'],
+          failedSteps: [],
+          revision: 2,
+          finalized: true,
+        },
+      },
+    ]);
+  });
+
   test('lost confirmation ownership closes the flow and remains retryable', async ({ page }) => {
     const result = await runMarkerlessFlowHarness(page, {
       claimStatus: 'claimed',
@@ -287,6 +343,7 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     });
     expect(result).toEqual({ result: 'retry', claimCalls: 1, confirmCalls: 0 });
     await expect(page.locator(OVERLAY)).toHaveCount(0);
+    expect(await readCapturedOutcomes(page)).toEqual([]);
   });
 });
 

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -184,6 +184,10 @@ async function runMarkerlessFlowHarness(
           confirmCalls += 1;
           return scenario.confirmResult !== false;
         },
+        // Stubbed so these tests never depend on a real Convex client; the
+        // outcome-recording wiring itself is covered at the unit level
+        // (buildActivationOutcomeBuckets in pro-activation-state.test.mts).
+        recordOutcome: async () => {},
         operationTimeoutMs: 20,
       },
     );

--- a/scripts/report-activation-lift.mjs
+++ b/scripts/report-activation-lift.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Reports whether subscribers who engaged with the Pro Activation wizard
+ * (#5534/#5564) went on to create/verify more delivery-channel, alert-rule,
+ * API-key, or MCP-token rows than subscribers who only saw it and confirmed
+ * nothing. Not a randomized control -- both groups were equally shown the
+ * wizard, so this isolates an engagement effect, not the effect of the
+ * wizard existing at all. See issue #5582 for the full design rationale and
+ * the read-me-first caveats: no cohort join existed before this, and the
+ * historical record has a permanent gap from the #5565 Umami outage.
+ *
+ * Usage:
+ *   1. Source prod env: `set -a; source <main-repo>/.env.local; set +a`
+ *      Required: CONVEX_DEPLOY_KEY, CONVEX_DEPLOYMENT.
+ *   2. `node scripts/report-activation-lift.mjs [--window-days=14] [--limit=20000]`
+ *
+ * Read-only: uses `npx convex data <table>`, never `convex run` with a
+ * mutation. Safe to run anytime, as often as wanted.
+ */
+
+import { spawnSync } from "node:child_process";
+
+const CONVEX_DEPLOY_KEY = process.env.CONVEX_DEPLOY_KEY;
+const CONVEX_DEPLOYMENT = process.env.CONVEX_DEPLOYMENT;
+if (!CONVEX_DEPLOY_KEY || !CONVEX_DEPLOYMENT) {
+  console.error(
+    "[activation-lift] CONVEX_DEPLOY_KEY and CONVEX_DEPLOYMENT env vars required. " +
+      "Source them from .env.local first (see file header for the exact command) -- " +
+      "plain `source` can silently yield an empty CONVEX_DEPLOY_KEY; verify with " +
+      "`node -e \"console.log(!!process.env.CONVEX_DEPLOY_KEY)\"` before running this.",
+  );
+  process.exit(2);
+}
+
+const args = new Map(
+  process.argv.slice(2).map((a) => {
+    const [k, v] = a.replace(/^--/, "").split("=");
+    return [k, v ?? true];
+  }),
+);
+const WINDOW_DAYS = Number(args.get("window-days") ?? 14);
+const LIMIT = Number(args.get("limit") ?? 20000);
+const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+const FEATURE_TABLES = ["notificationChannels", "alertRules", "userApiKeys", "mcpProTokens"];
+const MIN_GROUP_SIZE_FOR_A_CLAIM = 30;
+
+function fetchTable(table) {
+  const result = spawnSync(
+    "npx",
+    ["convex", "data", table, "--limit", String(LIMIT), "--order", "desc", "--format", "jsonl"],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 * 256 },
+  );
+  if (result.status !== 0) {
+    throw new Error(`npx convex data ${table} failed: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function main() {
+  console.log(`[activation-lift] window=${WINDOW_DAYS}d limit=${LIMIT} per table\n`);
+
+  const presentations = fetchTable("proActivationPresentations");
+  const featureRowsByTable = Object.fromEntries(FEATURE_TABLES.map((t) => [t, fetchTable(t)]));
+
+  const shown = presentations.filter((p) => p.presentedAt !== undefined);
+  const withOutcome = shown.filter((p) => p.exitedAt !== undefined);
+  const engaged = withOutcome.filter((p) => (p.confirmedSteps?.length ?? 0) > 0);
+  const presentedOnly = withOutcome.filter((p) => (p.confirmedSteps?.length ?? 0) === 0);
+
+  console.log(`Presentations: ${presentations.length} total, ${shown.length} actually shown, ${withOutcome.length} with a recorded exit outcome.`);
+  console.log(`  engaged (confirmed >=1 step): ${engaged.length}`);
+  console.log(`  presented-only (confirmed 0 steps): ${presentedOnly.length}\n`);
+
+  if (withOutcome.length === 0) {
+    console.log("No outcome-recorded presentations yet -- nothing to compare. This is expected until subscribers start exiting the wizard after this instrumentation ships.");
+    return;
+  }
+
+  function featureCreatedAfter(userId, sinceMs) {
+    const hits = {};
+    let any = false;
+    for (const table of FEATURE_TABLES) {
+      const rows = featureRowsByTable[table].filter(
+        (r) => r.userId === userId && r._creationTime > sinceMs && r._creationTime <= sinceMs + WINDOW_MS,
+      );
+      hits[table] = rows.length;
+      if (rows.length > 0) any = true;
+    }
+    return { any, hits };
+  }
+
+  function summarizeGroup(name, rows) {
+    let anyCount = 0;
+    const perTable = Object.fromEntries(FEATURE_TABLES.map((t) => [t, 0]));
+    for (const row of rows) {
+      const { any, hits } = featureCreatedAfter(row.userId, row.exitedAt);
+      if (any) anyCount += 1;
+      for (const t of FEATURE_TABLES) perTable[t] += hits[t];
+    }
+    const rate = rows.length > 0 ? anyCount / rows.length : 0;
+    console.log(`${name}: n=${rows.length}, created >=1 feature within ${WINDOW_DAYS}d: ${anyCount} (${(rate * 100).toFixed(1)}%)`);
+    for (const t of FEATURE_TABLES) console.log(`    ${t}: ${perTable[t]} rows created`);
+    if (rows.length < MIN_GROUP_SIZE_FOR_A_CLAIM) {
+      console.log(`    ⚠ n=${rows.length} is below the ${MIN_GROUP_SIZE_FOR_A_CLAIM}-sample floor this script enforces before treating a rate as meaningful -- do not draw a conclusion from this group alone yet.`);
+    }
+    return { n: rows.length, anyCount, rate };
+  }
+
+  console.log("--- Adoption within the window, by engagement ---");
+  const engagedSummary = summarizeGroup("Engaged", engaged);
+  const presentedOnlySummary = summarizeGroup("Presented-only", presentedOnly);
+
+  console.log("\n--- Verdict ---");
+  if (engagedSummary.n < MIN_GROUP_SIZE_FOR_A_CLAIM || presentedOnlySummary.n < MIN_GROUP_SIZE_FOR_A_CLAIM) {
+    console.log("Not enough post-exit outcomes recorded yet in one or both groups to say anything. Re-run this report after more subscribers have gone through the wizard.");
+  } else {
+    const lift = engagedSummary.rate - presentedOnlySummary.rate;
+    console.log(`Engaged-group adoption rate is ${(lift * 100).toFixed(1)} percentage points ${lift >= 0 ? "higher" : "lower"} than presented-only.`);
+    console.log("This is an engagement comparison within one exposed population, not a randomized control -- selection effects (subscribers already inclined to explore config may also be the ones who confirm steps) are not ruled out.");
+  }
+}
+
+main();

--- a/scripts/report-activation-lift.mjs
+++ b/scripts/report-activation-lift.mjs
@@ -1,128 +1,341 @@
 #!/usr/bin/env node
 /**
- * Reports whether subscribers who engaged with the Pro Activation wizard
- * (#5534/#5564) went on to create/verify more delivery-channel, alert-rule,
- * API-key, or MCP-token rows than subscribers who only saw it and confirmed
- * nothing. Not a randomized control -- both groups were equally shown the
- * wizard, so this isolates an engagement effect, not the effect of the
- * wizard existing at all. See issue #5582 for the full design rationale and
- * the read-me-first caveats: no cohort join existed before this, and the
- * historical record has a permanent gap from the #5565 Umami outage.
+ * Compare downstream Pro-feature adoption between subscribers who confirmed
+ * at least one activation-wizard step and subscribers who confirmed none.
+ *
+ * Every shown presentation stays in the cohort. Its observation window starts
+ * at the durable exit when present, otherwise the latest persisted progress,
+ * otherwise `presentedAt` for a no-action abandonment. This avoids both
+ * lost-exit censorship and counting the wizard's own writes as downstream
+ * adoption.
+ * Only presentations with a complete observation window are analyzed, and a
+ * verdict is refused when any newest-first Convex export may be truncated.
  *
  * Usage:
  *   1. Source prod env: `set -a; source <main-repo>/.env.local; set +a`
  *      Required: CONVEX_DEPLOY_KEY, CONVEX_DEPLOYMENT.
  *   2. `node scripts/report-activation-lift.mjs [--window-days=14] [--limit=20000]`
  *
- * Read-only: uses `npx convex data <table>`, never `convex run` with a
- * mutation. Safe to run anytime, as often as wanted.
+ * Read-only: uses `npx convex data <table>`, never a mutation.
  */
 
 import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
-const CONVEX_DEPLOY_KEY = process.env.CONVEX_DEPLOY_KEY;
-const CONVEX_DEPLOYMENT = process.env.CONVEX_DEPLOYMENT;
-if (!CONVEX_DEPLOY_KEY || !CONVEX_DEPLOYMENT) {
-  console.error(
-    "[activation-lift] CONVEX_DEPLOY_KEY and CONVEX_DEPLOYMENT env vars required. " +
-      "Source them from .env.local first (see file header for the exact command) -- " +
-      "plain `source` can silently yield an empty CONVEX_DEPLOY_KEY; verify with " +
-      "`node -e \"console.log(!!process.env.CONVEX_DEPLOY_KEY)\"` before running this.",
-  );
-  process.exit(2);
+export const FEATURE_TABLES = [
+  "notificationChannels",
+  "alertRules",
+  "userApiKeys",
+  "mcpProTokens",
+];
+export const MIN_GROUP_SIZE_FOR_A_CLAIM = 30;
+export const DEFAULT_EXPORT_TIMEOUT_MS = 60_000;
+
+function parseJsonLines(table, stdout) {
+  try {
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch (error) {
+    throw new Error(
+      `[activation-lift] could not parse the ${table} export: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
-const args = new Map(
-  process.argv.slice(2).map((a) => {
-    const [k, v] = a.replace(/^--/, "").split("=");
-    return [k, v ?? true];
-  }),
-);
-const WINDOW_DAYS = Number(args.get("window-days") ?? 14);
-const LIMIT = Number(args.get("limit") ?? 20000);
-const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1000;
-
-const FEATURE_TABLES = ["notificationChannels", "alertRules", "userApiKeys", "mcpProTokens"];
-const MIN_GROUP_SIZE_FOR_A_CLAIM = 30;
-
-function fetchTable(table) {
-  const result = spawnSync(
+export function fetchTable(
+  table,
+  {
+    limit,
+    timeoutMs = DEFAULT_EXPORT_TIMEOUT_MS,
+    runner = spawnSync,
+  },
+) {
+  const result = runner(
     "npx",
-    ["convex", "data", table, "--limit", String(LIMIT), "--order", "desc", "--format", "jsonl"],
-    { encoding: "utf8", maxBuffer: 1024 * 1024 * 256 },
+    ["convex", "data", table, "--limit", String(limit), "--order", "desc", "--format", "jsonl"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 256,
+      timeout: timeoutMs,
+    },
   );
-  if (result.status !== 0) {
-    throw new Error(`npx convex data ${table} failed: ${result.stderr || result.stdout}`);
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(
+      `[activation-lift] npx convex data ${table} timed out after ${timeoutMs}ms`,
+    );
   }
-  return result.stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
+  if (result.error || result.status !== 0) {
+    const details = [
+      result.error instanceof Error ? result.error.message : result.error,
+      result.signal ? `signal=${result.signal}` : null,
+      result.stderr,
+      result.stdout,
+    ].filter(Boolean);
+    throw new Error(
+      `[activation-lift] npx convex data ${table} failed${
+        details.length > 0 ? `: ${details.join(" | ")}` : ""
+      }`,
+    );
+  }
+  const rows = parseJsonLines(table, result.stdout ?? "");
+  return { rows, truncated: rows.length >= limit };
 }
 
-function main() {
-  console.log(`[activation-lift] window=${WINDOW_DAYS}d limit=${LIMIT} per table\n`);
-
-  const presentations = fetchTable("proActivationPresentations");
-  const featureRowsByTable = Object.fromEntries(FEATURE_TABLES.map((t) => [t, fetchTable(t)]));
-
-  const shown = presentations.filter((p) => p.presentedAt !== undefined);
-  const withOutcome = shown.filter((p) => p.exitedAt !== undefined);
-  const engaged = withOutcome.filter((p) => (p.confirmedSteps?.length ?? 0) > 0);
-  const presentedOnly = withOutcome.filter((p) => (p.confirmedSteps?.length ?? 0) === 0);
-
-  console.log(`Presentations: ${presentations.length} total, ${shown.length} actually shown, ${withOutcome.length} with a recorded exit outcome.`);
-  console.log(`  engaged (confirmed >=1 step): ${engaged.length}`);
-  console.log(`  presented-only (confirmed 0 steps): ${presentedOnly.length}\n`);
-
-  if (withOutcome.length === 0) {
-    console.log("No outcome-recorded presentations yet -- nothing to compare. This is expected until subscribers start exiting the wizard after this instrumentation ships.");
-    return;
+function activityTimestamp(table, row) {
+  switch (table) {
+    case "notificationChannels":
+      return row.verified === true ? row.linkedAt : null;
+    case "alertRules":
+      return row.enabled === true ? row.updatedAt : null;
+    case "userApiKeys":
+    case "mcpProTokens":
+      return row.revokedAt === undefined ? row.createdAt : null;
+    default:
+      return null;
   }
+}
 
-  function featureCreatedAfter(userId, sinceMs) {
-    const hits = {};
+/**
+ * Build the user index once. The previous implementation filtered every full
+ * table for every presentation (up to 1.6B predicate evaluations at 20k rows).
+ */
+export function indexFeatureRows(featureRowsByTable) {
+  return Object.fromEntries(
+    FEATURE_TABLES.map((table) => {
+      const byUser = new Map();
+      for (const row of featureRowsByTable[table] ?? []) {
+        if (typeof row.userId !== "string") continue;
+        const timestamp = activityTimestamp(table, row);
+        if (typeof timestamp !== "number") continue;
+        const rows = byUser.get(row.userId);
+        if (rows) rows.push(timestamp);
+        else byUser.set(row.userId, [timestamp]);
+      }
+      return [table, byUser];
+    }),
+  );
+}
+
+function summarizeGroup(rows, featureIndex, windowMs) {
+  let anyCount = 0;
+  const perTable = Object.fromEntries(FEATURE_TABLES.map((table) => [table, 0]));
+  for (const presentation of rows) {
     let any = false;
+    const sinceMs = presentation.observationStartedAt;
     for (const table of FEATURE_TABLES) {
-      const rows = featureRowsByTable[table].filter(
-        (r) => r.userId === userId && r._creationTime > sinceMs && r._creationTime <= sinceMs + WINDOW_MS,
-      );
-      hits[table] = rows.length;
-      if (rows.length > 0) any = true;
+      const timestamps = featureIndex[table].get(presentation.userId) ?? [];
+      let count = 0;
+      for (const timestamp of timestamps) {
+        if (timestamp > sinceMs && timestamp <= sinceMs + windowMs) count += 1;
+      }
+      perTable[table] += count;
+      if (count > 0) any = true;
     }
-    return { any, hits };
+    if (any) anyCount += 1;
   }
-
-  function summarizeGroup(name, rows) {
-    let anyCount = 0;
-    const perTable = Object.fromEntries(FEATURE_TABLES.map((t) => [t, 0]));
-    for (const row of rows) {
-      const { any, hits } = featureCreatedAfter(row.userId, row.exitedAt);
-      if (any) anyCount += 1;
-      for (const t of FEATURE_TABLES) perTable[t] += hits[t];
-    }
-    const rate = rows.length > 0 ? anyCount / rows.length : 0;
-    console.log(`${name}: n=${rows.length}, created >=1 feature within ${WINDOW_DAYS}d: ${anyCount} (${(rate * 100).toFixed(1)}%)`);
-    for (const t of FEATURE_TABLES) console.log(`    ${t}: ${perTable[t]} rows created`);
-    if (rows.length < MIN_GROUP_SIZE_FOR_A_CLAIM) {
-      console.log(`    ⚠ n=${rows.length} is below the ${MIN_GROUP_SIZE_FOR_A_CLAIM}-sample floor this script enforces before treating a rate as meaningful -- do not draw a conclusion from this group alone yet.`);
-    }
-    return { n: rows.length, anyCount, rate };
-  }
-
-  console.log("--- Adoption within the window, by engagement ---");
-  const engagedSummary = summarizeGroup("Engaged", engaged);
-  const presentedOnlySummary = summarizeGroup("Presented-only", presentedOnly);
-
-  console.log("\n--- Verdict ---");
-  if (engagedSummary.n < MIN_GROUP_SIZE_FOR_A_CLAIM || presentedOnlySummary.n < MIN_GROUP_SIZE_FOR_A_CLAIM) {
-    console.log("Not enough post-exit outcomes recorded yet in one or both groups to say anything. Re-run this report after more subscribers have gone through the wizard.");
-  } else {
-    const lift = engagedSummary.rate - presentedOnlySummary.rate;
-    console.log(`Engaged-group adoption rate is ${(lift * 100).toFixed(1)} percentage points ${lift >= 0 ? "higher" : "lower"} than presented-only.`);
-    console.log("This is an engagement comparison within one exposed population, not a randomized control -- selection effects (subscribers already inclined to explore config may also be the ones who confirm steps) are not ruled out.");
-  }
+  return {
+    n: rows.length,
+    anyCount,
+    rate: rows.length > 0 ? anyCount / rows.length : 0,
+    perTable,
+  };
 }
 
-main();
+export function analyzeActivationLift({
+  presentations,
+  featureRowsByTable,
+  truncatedTables = [],
+  reportNow,
+  windowMs,
+  minGroupSize = MIN_GROUP_SIZE_FOR_A_CLAIM,
+}) {
+  const shown = presentations.filter((row) => typeof row.presentedAt === "number");
+  const observed = shown.map((row) => ({
+    ...row,
+    observationStartedAt:
+      typeof row.exitedAt === "number"
+        ? row.exitedAt
+        : typeof row.outcomeUpdatedAt === "number"
+          ? row.outcomeUpdatedAt
+          : row.presentedAt,
+  }));
+  const mature = observed.filter(
+    (row) => row.observationStartedAt + windowMs <= reportNow,
+  );
+  const immature = observed.filter(
+    (row) => row.observationStartedAt + windowMs > reportNow,
+  );
+  const incompleteExits = mature.filter((row) => typeof row.exitedAt !== "number");
+  const engaged = mature.filter((row) => (row.confirmedSteps?.length ?? 0) > 0);
+  const presentedOnly = mature.filter((row) => (row.confirmedSteps?.length ?? 0) === 0);
+
+  const base = {
+    totalPresentations: presentations.length,
+    shown: shown.length,
+    mature: mature.length,
+    immature: immature.length,
+    incompleteExits: incompleteExits.length,
+    truncatedTables: [...truncatedTables],
+  };
+  if (truncatedTables.length > 0) {
+    return { ...base, verdict: "incomplete-export", engaged: null, presentedOnly: null };
+  }
+
+  const featureIndex = indexFeatureRows(featureRowsByTable);
+  const engagedSummary = summarizeGroup(engaged, featureIndex, windowMs);
+  const presentedOnlySummary = summarizeGroup(presentedOnly, featureIndex, windowMs);
+  if (mature.length === 0) {
+    return {
+      ...base,
+      verdict: "no-mature-outcomes",
+      engaged: engagedSummary,
+      presentedOnly: presentedOnlySummary,
+    };
+  }
+  if (engagedSummary.n < minGroupSize || presentedOnlySummary.n < minGroupSize) {
+    return {
+      ...base,
+      verdict: "below-sample-floor",
+      engaged: engagedSummary,
+      presentedOnly: presentedOnlySummary,
+    };
+  }
+  return {
+    ...base,
+    verdict: "comparison",
+    lift: engagedSummary.rate - presentedOnlySummary.rate,
+    engaged: engagedSummary,
+    presentedOnly: presentedOnlySummary,
+  };
+}
+
+function formatGroup(name, summary, windowDays, minGroupSize) {
+  const lines = [
+    `${name}: n=${summary.n}, adopted >=1 feature within ${windowDays}d: ${summary.anyCount} (${(
+      summary.rate * 100
+    ).toFixed(1)}%)`,
+  ];
+  for (const table of FEATURE_TABLES) {
+    lines.push(`    ${table}: ${summary.perTable[table]} qualifying rows`);
+  }
+  if (summary.n < minGroupSize) {
+    lines.push(
+      `    WARNING: n=${summary.n} is below the ${minGroupSize}-sample verdict floor.`,
+    );
+  }
+  return lines;
+}
+
+export function formatActivationLiftReport(
+  analysis,
+  {
+    windowDays,
+    limit,
+    minGroupSize = MIN_GROUP_SIZE_FOR_A_CLAIM,
+  },
+) {
+  const lines = [
+    `[activation-lift] window=${windowDays}d limit=${limit} per table`,
+    "",
+    `Presentations: ${analysis.totalPresentations} exported, ${analysis.shown} shown, ${analysis.mature} with a complete ${windowDays}d window.`,
+    `  excluded as immature: ${analysis.immature}`,
+    `  mature sessions without a recorded exit: ${analysis.incompleteExits} (included from durable presentation/progress state)`,
+  ];
+
+  if (analysis.verdict === "incomplete-export") {
+    lines.push(
+      "",
+      "--- Verdict ---",
+      `Inconclusive: these exports reached the ${limit}-row cap and may be incomplete: ${analysis.truncatedTables.join(", ")}. Re-run with a higher limit; no adoption rates were computed.`,
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    "",
+    "--- Adoption within the complete window, by engagement ---",
+    ...formatGroup("Engaged", analysis.engaged, windowDays, minGroupSize),
+    ...formatGroup("Presented-only", analysis.presentedOnly, windowDays, minGroupSize),
+    "",
+    "--- Verdict ---",
+  );
+  if (analysis.verdict === "no-mature-outcomes") {
+    lines.push(
+      `No presentations have completed the full ${windowDays}-day observation window yet.`,
+    );
+  } else if (analysis.verdict === "below-sample-floor") {
+    lines.push(
+      "Not enough mature presentations in one or both groups to make a comparison yet.",
+    );
+  } else {
+    lines.push(
+      `Engaged-group adoption rate is ${(analysis.lift * 100).toFixed(1)} percentage points ${
+        analysis.lift >= 0 ? "higher" : "lower"
+      } than presented-only.`,
+      "This is an engagement comparison within one exposed population, not a randomized control; selection effects are not ruled out.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function parsePositiveNumber(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`[activation-lift] --${name} must be a positive number`);
+  }
+  return parsed;
+}
+
+export function runCli(argv = process.argv.slice(2), env = process.env) {
+  if (!env.CONVEX_DEPLOY_KEY || !env.CONVEX_DEPLOYMENT) {
+    throw new Error(
+      "[activation-lift] CONVEX_DEPLOY_KEY and CONVEX_DEPLOYMENT env vars required. " +
+        "Source them from .env.local first (see file header).",
+    );
+  }
+  const args = new Map(
+    argv.map((arg) => {
+      const [key, value] = arg.replace(/^--/, "").split("=");
+      return [key, value ?? true];
+    }),
+  );
+  const windowDays = parsePositiveNumber(args.get("window-days") ?? 14, "window-days");
+  const limit = parsePositiveNumber(args.get("limit") ?? 20_000, "limit");
+  const timeoutMs = parsePositiveNumber(
+    args.get("timeout-ms") ?? DEFAULT_EXPORT_TIMEOUT_MS,
+    "timeout-ms",
+  );
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  const tableNames = ["proActivationPresentations", ...FEATURE_TABLES];
+  const exports = Object.fromEntries(
+    tableNames.map((table) => [table, fetchTable(table, { limit, timeoutMs })]),
+  );
+  const truncatedTables = tableNames.filter((table) => exports[table].truncated);
+  const featureRowsByTable = Object.fromEntries(
+    FEATURE_TABLES.map((table) => [table, exports[table].rows]),
+  );
+  const analysis = analyzeActivationLift({
+    presentations: exports.proActivationPresentations.rows,
+    featureRowsByTable,
+    truncatedTables,
+    reportNow: Date.now(),
+    windowMs,
+  });
+  return formatActivationLiftReport(analysis, { windowDays, limit });
+}
+
+const isMain =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  try {
+    console.log(runCli());
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -82,6 +82,8 @@ export interface ProActivationInterstitialOptions {
   onConfirmStep: (stepId: ActivationStepId) => Promise<'verified' | 'failed'>;
   /** Fire-and-forget skip signal (bookkeeping/telemetry wired by later units). */
   onSkipStep: (stepId: ActivationStepId) => void;
+  /** Called after each durable step-state transition with a full snapshot. */
+  onProgress?: (results: ActivationStepResult[]) => void;
   /** Called exactly once when the flow ends, with the ordered step results. */
   onExit: (results: ActivationStepResult[]) => void;
   /**
@@ -279,6 +281,8 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
 
   const buildResults = (): ActivationStepResult[] =>
     steps.map((step) => ({ id: step.id, outcome: outcomes.get(step.id) ?? defaultOutcome(step) }));
+
+  const recordProgress = (): void => options.onProgress?.(buildResults());
 
   const currentStatus = (step: ActivationStep): StepStatus => {
     if (step.state === 'already-done') return 'verified';
@@ -506,6 +510,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     }
     transient = 'idle';
     currentIndex = steps.length;
+    recordProgress();
     renderModal();
   };
 
@@ -522,6 +527,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
   const handleSkip = (step: ActivationStep): void => {
     options.onSkipStep(step.id);
     outcomes.set(step.id, transient === 'failed' ? 'failed' : 'skipped');
+    recordProgress();
     advance();
   };
 
@@ -539,6 +545,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     if (!overlay || generation !== gen) return;
     if (result === 'verified') {
       outcomes.set(step.id, 'confirmed');
+      recordProgress();
       advance();
     } else {
       transient = 'failed';
@@ -598,11 +605,13 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
             break;
           case 'advance-done':
             outcomes.set(step.id, 'done');
+            recordProgress();
             advance();
             break;
           case 'advance-skip':
             options.onSkipStep(step.id);
             outcomes.set(step.id, 'skipped');
+            recordProgress();
             advance();
             break;
         }
@@ -619,6 +628,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
           extra.onMount(extrasRoot, {
             confirmAndFinish: () => {
               outcomes.set(step.id, 'confirmed');
+              recordProgress();
               finishFlow();
             },
           });
@@ -736,8 +746,14 @@ export interface ProActivationFlowDependencies {
   recordOutcome: (
     activationKey: string,
     claimNonce: string,
-    outcome: { confirmedSteps: string[]; skippedSteps: string[]; failedSteps: string[] },
-  ) => Promise<void>;
+    outcome: {
+      confirmedSteps: ActivationStepId[];
+      skippedSteps: ActivationStepId[];
+      failedSteps: ActivationStepId[];
+      revision: number;
+      finalized: boolean;
+    },
+  ) => Promise<boolean>;
   openInterstitial: typeof openProActivationInterstitial;
   /** Per-operation deadline; injectable only to keep timeout regressions fast. */
   operationTimeoutMs?: number;
@@ -754,6 +770,7 @@ const BRIEF_PREVIEW_TIMEOUT_MS = 2500;
 const ACTIVATION_CONTEXT_TIMEOUT_MS = 5_000;
 const ACTIVATION_MUTATION_TIMEOUT_MS = 5_000;
 const PRESENTATION_CONFIRM_RETRY_DELAYS_MS = [250, 750, 1_500] as const;
+const OUTCOME_WRITE_RETRY_DELAYS_MS = [250, 750] as const;
 
 /**
  * The brief step's chosen delivery hour, held outside the re-rendered DOM. The
@@ -1164,6 +1181,48 @@ async function confirmPresentationWithRetry(
   return false;
 }
 
+function persistActivationOutcomeWithRetry(
+  options: ProActivationFlowOptions,
+  dependencies: ProActivationFlowDependencies,
+  results: readonly ActivationStepResult[],
+  revision: number,
+  finalized: boolean,
+): void {
+  if (!options.onlyIfUnactivated || !options.expectedActivationKey || !options.activationClaimNonce) {
+    return;
+  }
+  const buckets = buildActivationOutcomeBuckets(results);
+  void (async () => {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await withTimeout(
+          dependencies.recordOutcome(
+            options.expectedActivationKey!,
+            options.activationClaimNonce!,
+            {
+              confirmedSteps: [...buckets.confirmedSteps],
+              skippedSteps: [...buckets.skippedSteps],
+              failedSteps: [...buckets.failedSteps],
+              revision,
+              finalized,
+            },
+          ),
+          dependencies.operationTimeoutMs ?? ACTIVATION_MUTATION_TIMEOUT_MS,
+          'activation-record-outcome',
+        );
+        return;
+      } catch (error) {
+        const delay = OUTCOME_WRITE_RETRY_DELAYS_MS[attempt];
+        if (delay === undefined) {
+          console.warn('[pro-activation] failed to record activation outcome', error);
+          return;
+        }
+        await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
+      }
+    }
+  })();
+}
+
 /**
  * Open the full Pro-activation flow: read the subscriber's config, build the
  * ordered steps, wire the real per-step handlers, and on exit decide the
@@ -1242,6 +1301,17 @@ export async function openProActivationFlow(
   // the confirm button while in-flight (guard the handler itself against a
   // double-fire, e.g. a stray second click before the first await settles).
   const inFlight = new Set<ActivationStepId>();
+  let outcomeRevision = 0;
+  const persistOutcome = (results: readonly ActivationStepResult[], finalized: boolean): void => {
+    outcomeRevision += 1;
+    persistActivationOutcomeWithRetry(
+      options,
+      dependencies,
+      results,
+      outcomeRevision,
+      finalized,
+    );
+  };
 
   options.onEvent?.(ACTIVATION_EVENTS.entered);
 
@@ -1269,24 +1339,13 @@ export async function openProActivationFlow(
       }
     },
     onSkipStep: (stepId) => options.onEvent?.(ACTIVATION_EVENTS.stepSkipped, stepId),
+    onProgress: (results) => persistOutcome(results, false),
     onExit: (results) => {
       options.onEvent?.(ACTIVATION_EVENTS.exit, undefined, summarizeActivationExit(results));
-      // Durable outcome record (#5582), independent of the Umami event above
-      // -- only for the markerless cohort, which is what has a presentation
-      // row to attach it to. Fire-and-forget: never blocks the subscriber's
-      // exit or the finish-setup chip below.
-      if (options.onlyIfUnactivated && options.expectedActivationKey && options.activationClaimNonce) {
-        const buckets = buildActivationOutcomeBuckets(results);
-        void dependencies.recordOutcome(
-          options.expectedActivationKey,
-          options.activationClaimNonce,
-          {
-            confirmedSteps: [...buckets.confirmedSteps],
-            skippedSteps: [...buckets.skippedSteps],
-            failedSteps: [...buckets.failedSteps],
-          },
-        );
-      }
+      // Freeze the latest durable snapshot. Progress was already recorded as
+      // steps resolved, so a tab close before this best-effort write cannot
+      // erase engagement from the cohort.
+      persistOutcome(results, true);
       // Chip decision + all localStorage live in the chip module (lazy-imported
       // to keep this component ↔ chip pair free of a static import cycle).
       void import('@/components/ProActivationChip')

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -29,6 +29,7 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import {
   claimProActivationPresentation,
   confirmProActivationPresentation,
+  recordProActivationOutcome,
 } from '@/services/billing';
 import { escapeHtml } from '@/utils/sanitize';
 import { getFocusableElements, setTrustedHtml, trustedHtml, type TrustedHtml } from '@/utils/dom-utils';
@@ -54,6 +55,7 @@ import {
   buildBriefDigestPayload,
   buildCriticalAlertsPayload,
   buildExitSummary,
+  buildActivationOutcomeBuckets,
   summarizeActivationExit,
   DEFAULT_DIGEST_HOUR,
   type ActivationEventName,
@@ -730,6 +732,11 @@ export interface ProActivationFlowDependencies {
     claimNonce: string,
   ) => Promise<'claimed' | 'not_eligible' | 'already_presented' | 'already_claimed'>;
   confirmPresentation: (activationKey: string, claimNonce: string) => Promise<boolean>;
+  recordOutcome: (
+    activationKey: string,
+    claimNonce: string,
+    outcome: { confirmedSteps: string[]; skippedSteps: string[]; failedSteps: string[] },
+  ) => Promise<void>;
   openInterstitial: typeof openProActivationInterstitial;
   /** Per-operation deadline; injectable only to keep timeout regressions fast. */
   operationTimeoutMs?: number;
@@ -1200,6 +1207,7 @@ export async function openProActivationFlow(
         : readActivationContext(expectedUserId),
     claimPresentation: claimProActivationPresentation,
     confirmPresentation: confirmProActivationPresentation,
+    recordOutcome: recordProActivationOutcome,
     openInterstitial: openProActivationInterstitial,
     ...injected,
   };
@@ -1289,6 +1297,22 @@ export async function openProActivationFlow(
     onSkipStep: (stepId) => options.onEvent?.(ACTIVATION_EVENTS.stepSkipped, stepId),
     onExit: (results) => {
       options.onEvent?.(ACTIVATION_EVENTS.exit, undefined, summarizeActivationExit(results));
+      // Durable outcome record (#5582), independent of the Umami event above
+      // -- only for the markerless cohort, which is what has a presentation
+      // row to attach it to. Fire-and-forget: never blocks the subscriber's
+      // exit or the finish-setup chip below.
+      if (options.onlyIfUnactivated && options.expectedActivationKey && options.activationClaimNonce) {
+        const buckets = buildActivationOutcomeBuckets(results);
+        void dependencies.recordOutcome(
+          options.expectedActivationKey,
+          options.activationClaimNonce,
+          {
+            confirmedSteps: [...buckets.confirmedSteps],
+            skippedSteps: [...buckets.skippedSteps],
+            failedSteps: [...buckets.failedSteps],
+          },
+        );
+      }
       // Chip decision + all localStorage live in the chip module (lazy-imported
       // to keep this component ↔ chip pair free of a static import cycle).
       void import('@/components/ProActivationChip')

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -187,30 +187,34 @@ export async function confirmProActivationPresentation(
   ) as boolean;
 }
 
+export type ProActivationOutcomeStepId = 'brief' | 'alerts' | 'power';
+
+export interface ProActivationOutcomeSnapshot {
+  confirmedSteps: ProActivationOutcomeStepId[];
+  skippedSteps: ProActivationOutcomeStepId[];
+  failedSteps: ProActivationOutcomeStepId[];
+  revision: number;
+  finalized: boolean;
+}
+
 /**
- * Persist the wizard's actual outcome once the subscriber exits (#5582),
- * independent of the Umami funnel event, so activation-lift can be measured
- * even when Umami is unavailable or its events carry no userId to join
- * against Convex feature-usage tables. Best-effort: swallow errors so a
- * failed write never blocks the subscriber's exit or the finish-setup chip.
+ * Persist one monotonic activation-outcome snapshot. The flow keeps this
+ * best-effort and non-blocking, but errors propagate here so its bounded retry
+ * loop can distinguish a transport failure from a server-side rejection.
  */
 export async function recordProActivationOutcome(
   activationKey: string,
   claimNonce: string,
-  outcome: { confirmedSteps: string[]; skippedSteps: string[]; failedSteps: string[] },
-): Promise<void> {
-  try {
-    const client = await getConvexClient();
-    const api = await getConvexApi();
-    if (!client || !api) return;
-    await waitForConvexAuth();
-    await client.mutation(
-      (api as any).payments.billing.recordProActivationOutcome,
-      { activationKey, claimNonce, ...outcome },
-    );
-  } catch (error) {
-    console.warn('[pro-activation] failed to record activation outcome', error);
-  }
+  outcome: ProActivationOutcomeSnapshot,
+): Promise<boolean> {
+  const client = await getConvexClient();
+  const api = await getConvexApi();
+  if (!client || !api) throw new Error('Convex unavailable');
+  await waitForConvexAuth();
+  return await client.mutation(
+    (api as any).payments.billing.recordProActivationOutcome,
+    { activationKey, claimNonce, ...outcome },
+  ) as boolean;
 }
 
 const DODO_PORTAL_FALLBACK_URL = 'https://customer.dodopayments.com';

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -187,6 +187,32 @@ export async function confirmProActivationPresentation(
   ) as boolean;
 }
 
+/**
+ * Persist the wizard's actual outcome once the subscriber exits (#5582),
+ * independent of the Umami funnel event, so activation-lift can be measured
+ * even when Umami is unavailable or its events carry no userId to join
+ * against Convex feature-usage tables. Best-effort: swallow errors so a
+ * failed write never blocks the subscriber's exit or the finish-setup chip.
+ */
+export async function recordProActivationOutcome(
+  activationKey: string,
+  claimNonce: string,
+  outcome: { confirmedSteps: string[]; skippedSteps: string[]; failedSteps: string[] },
+): Promise<void> {
+  try {
+    const client = await getConvexClient();
+    const api = await getConvexApi();
+    if (!client || !api) return;
+    await waitForConvexAuth();
+    await client.mutation(
+      (api as any).payments.billing.recordProActivationOutcome,
+      { activationKey, claimNonce, ...outcome },
+    );
+  } catch (error) {
+    console.warn('[pro-activation] failed to record activation outcome', error);
+  }
+}
+
 const DODO_PORTAL_FALLBACK_URL = 'https://customer.dodopayments.com';
 
 /**

--- a/src/services/pro-activation-state.ts
+++ b/src/services/pro-activation-state.ts
@@ -739,6 +739,29 @@ export function summarizeActivationExit(
   return { completion, verified, pending, failed, total };
 }
 
+/** Per-step outcome IDs, bucketed for the durable activation-outcome record (#5582). */
+export interface ActivationOutcomeBuckets {
+  /** Steps that ended verified -- confirmed in-flow or already-done. */
+  readonly confirmedSteps: readonly ActivationStepId[];
+  readonly skippedSteps: readonly ActivationStepId[];
+  readonly failedSteps: readonly ActivationStepId[];
+}
+
+/** Bucket step results by outcome for persistence, independent of the Umami exit event. */
+export function buildActivationOutcomeBuckets(
+  results: readonly ActivationStepResult[],
+): ActivationOutcomeBuckets {
+  const confirmedSteps: ActivationStepId[] = [];
+  const skippedSteps: ActivationStepId[] = [];
+  const failedSteps: ActivationStepId[] = [];
+  for (const r of results) {
+    if (r.outcome === 'confirmed' || r.outcome === 'done') confirmedSteps.push(r.id);
+    else if (r.outcome === 'skipped') skippedSteps.push(r.id);
+    else failedSteps.push(r.id);
+  }
+  return { confirmedSteps, skippedSteps, failedSteps };
+}
+
 /** Versioned localStorage key for the finish-setup chip dismissal. */
 export const FINISH_SETUP_CHIP_DISMISS_KEY = 'wm-pro-activation-chip-dismissed-v1';
 

--- a/tests/pro-activation-state.test.mts
+++ b/tests/pro-activation-state.test.mts
@@ -35,6 +35,7 @@ import {
   buildCriticalAlertsPayload,
   DEFAULT_DIGEST_HOUR,
   buildExitSummary,
+  buildActivationOutcomeBuckets,
   ACTIVATION_FLOW_RETRY_DELAYS_MS,
   activationFlowRetryDelay,
   summarizeActivationExit,
@@ -947,6 +948,48 @@ describe('summarizeActivationExit — funnel exit completion state', () => {
       pending: 0,
       failed: 0,
       total: 0,
+    });
+  });
+});
+
+describe('buildActivationOutcomeBuckets — durable outcome record (#5582)', () => {
+  it('confirmed and done both land in confirmedSteps (both count as verified)', () => {
+    assert.deepEqual(
+      buildActivationOutcomeBuckets([
+        { id: 'brief', outcome: 'confirmed' },
+        { id: 'alerts', outcome: 'done' },
+      ]),
+      { confirmedSteps: ['brief', 'alerts'], skippedSteps: [], failedSteps: [] },
+    );
+  });
+
+  it('skipped and failed bucket separately from confirmed', () => {
+    assert.deepEqual(
+      buildActivationOutcomeBuckets([
+        { id: 'brief', outcome: 'confirmed' },
+        { id: 'alerts', outcome: 'skipped' },
+        { id: 'power', outcome: 'failed' },
+      ]),
+      { confirmedSteps: ['brief'], skippedSteps: ['alerts'], failedSteps: ['power'] },
+    );
+  });
+
+  it('preserves step order within each bucket', () => {
+    assert.deepEqual(
+      buildActivationOutcomeBuckets([
+        { id: 'power', outcome: 'skipped' },
+        { id: 'brief', outcome: 'skipped' },
+        { id: 'alerts', outcome: 'skipped' },
+      ]),
+      { confirmedSteps: [], skippedSteps: ['power', 'brief', 'alerts'], failedSteps: [] },
+    );
+  });
+
+  it('empty flow → all buckets empty', () => {
+    assert.deepEqual(buildActivationOutcomeBuckets([]), {
+      confirmedSteps: [],
+      skippedSteps: [],
+      failedSteps: [],
     });
   });
 });

--- a/tests/report-activation-lift.test.mjs
+++ b/tests/report-activation-lift.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  analyzeActivationLift,
+  fetchTable,
+  formatActivationLiftReport,
+  indexFeatureRows,
+} from "../scripts/report-activation-lift.mjs";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 6, 25);
+const WINDOW_MS = 14 * DAY_MS;
+
+function emptyFeatureRows() {
+  return {
+    notificationChannels: [],
+    alertRules: [],
+    userApiKeys: [],
+    mcpProTokens: [],
+  };
+}
+
+test("fetchTable bounds a hung Convex export and reports the table", () => {
+  const timeout = Object.assign(new Error("spawnSync npx ETIMEDOUT"), { code: "ETIMEDOUT" });
+  assert.throws(
+    () => fetchTable("alertRules", {
+      limit: 20_000,
+      timeoutMs: 1234,
+      runner: () => ({
+        error: timeout,
+        status: null,
+        signal: "SIGTERM",
+        stdout: "",
+        stderr: "",
+      }),
+    }),
+    /alertRules timed out after 1234ms/,
+  );
+});
+
+test("fetchTable marks a cap hit instead of treating a newest-first slice as complete", () => {
+  const result = fetchTable("userApiKeys", {
+    limit: 2,
+    runner: () => ({
+      status: 0,
+      signal: null,
+      stdout: '{"userId":"a"}\n{"userId":"b"}\n',
+      stderr: "",
+    }),
+  });
+  assert.equal(result.truncated, true);
+  assert.equal(result.rows.length, 2);
+});
+
+test("analysis uses only mature presentations and table-specific adoption timestamps", () => {
+  const observationStartedAt = NOW - WINDOW_MS;
+  const presentedBeforeExit = observationStartedAt - DAY_MS;
+  const presentations = [
+    {
+      userId: "engaged",
+      presentedAt: presentedBeforeExit,
+      confirmedSteps: ["brief"],
+      exitedAt: observationStartedAt,
+    },
+    {
+      userId: "presented-only",
+      presentedAt: observationStartedAt,
+      confirmedSteps: [],
+      // Deliberately no exitedAt: lost exits stay in the cohort.
+    },
+    {
+      userId: "immature",
+      presentedAt: NOW - WINDOW_MS + 1,
+      confirmedSteps: ["brief"],
+    },
+    {
+      userId: "progress-immature",
+      presentedAt: presentedBeforeExit,
+      confirmedSteps: ["brief"],
+      outcomeUpdatedAt: NOW - WINDOW_MS + 1,
+    },
+  ];
+  const featureRowsByTable = {
+    ...emptyFeatureRows(),
+    notificationChannels: [
+      {
+        userId: "engaged",
+        verified: true,
+        // Existing row re-verified at the inclusive end boundary.
+        linkedAt: observationStartedAt + WINDOW_MS,
+        _creationTime: observationStartedAt - 100 * DAY_MS,
+      },
+      {
+        userId: "presented-only",
+        verified: false,
+        linkedAt: observationStartedAt + DAY_MS,
+      },
+    ],
+    alertRules: [
+      {
+        userId: "presented-only",
+        enabled: true,
+        // Existing rule updated just outside the observation window.
+        updatedAt: observationStartedAt + WINDOW_MS + 1,
+        _creationTime: observationStartedAt - 100 * DAY_MS,
+      },
+    ],
+    userApiKeys: [
+      {
+        userId: "engaged",
+        // A row created inside the wizard, before exit, is not downstream adoption.
+        createdAt: presentedBeforeExit + 1,
+      },
+    ],
+  };
+
+  const analysis = analyzeActivationLift({
+    presentations,
+    featureRowsByTable,
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+    minGroupSize: 1,
+  });
+
+  assert.equal(analysis.verdict, "comparison");
+  assert.equal(analysis.mature, 2);
+  assert.equal(analysis.immature, 2);
+  assert.equal(analysis.incompleteExits, 1);
+  assert.deepEqual(analysis.engaged, {
+    n: 1,
+    anyCount: 1,
+    rate: 1,
+    perTable: {
+      notificationChannels: 1,
+      alertRules: 0,
+      userApiKeys: 0,
+      mcpProTokens: 0,
+    },
+  });
+  assert.equal(analysis.presentedOnly.anyCount, 0);
+  assert.equal(analysis.lift, 1);
+});
+
+test("analysis refuses capped exports before rates and enforces the mature sample floor", () => {
+  const presentations = Array.from({ length: 59 }, (_, index) => ({
+    userId: `user-${index}`,
+    presentedAt: NOW - WINDOW_MS,
+    confirmedSteps: index < 29 ? ["brief"] : [],
+  }));
+
+  const capped = analyzeActivationLift({
+    presentations,
+    featureRowsByTable: emptyFeatureRows(),
+    truncatedTables: ["alertRules"],
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+  });
+  assert.equal(capped.verdict, "incomplete-export");
+  assert.equal(capped.engaged, null);
+  assert.match(
+    formatActivationLiftReport(capped, { windowDays: 14, limit: 20_000 }),
+    /Inconclusive.*alertRules.*no adoption rates were computed/s,
+  );
+
+  const complete = analyzeActivationLift({
+    presentations,
+    featureRowsByTable: emptyFeatureRows(),
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+  });
+  assert.equal(complete.engaged.n, 29);
+  assert.equal(complete.presentedOnly.n, 30);
+  assert.equal(complete.verdict, "below-sample-floor");
+});
+
+test("feature indexing performs one pass and excludes inactive credentials", () => {
+  const featureRows = emptyFeatureRows();
+  featureRows.userApiKeys = Array.from({ length: 20_000 }, (_, index) => ({
+    userId: `user-${index}`,
+    createdAt: index,
+    ...(index % 2 === 0 ? {} : { revokedAt: index + 1 }),
+  }));
+  const index = indexFeatureRows(featureRows);
+  assert.deepEqual(index.userApiKeys.get("user-0"), [0]);
+  assert.equal(index.userApiKeys.has("user-1"), false);
+  assert.equal(index.userApiKeys.size, 10_000);
+});


### PR DESCRIPTION
## Summary

Follow-up to #5534/#5564. Neither the Umami funnel side (events carry no `userId`, unjoinable to Convex feature-usage tables) nor the Convex side (no outcome record existed) could answer "did the Pro Activation wizard actually improve feature adoption?" — see #5582 for the full investigation, including the #5565 Umami outage that blacked out ~4 days spanning almost all of #5534's post-launch window.

**Base note:** targets `codex/pro-activation-first-cycle-backfill` (#5564), not `main` — this PR extends `proActivationPresentations`, which #5564 introduces. Depends on #5564 merging first; this diff shows only the incremental work.

## What this adds

- `convex/schema.ts`: `proActivationPresentations` gains `confirmedSteps`/`skippedSteps`/`failedSteps`/`exitedAt` — the durable per-subscription outcome record.
- `convex/payments/billing.ts`: `recordProActivationOutcome` mutation, ownership + nonce checked like the existing `confirmProActivationPresentation`. Best-effort — no-ops on a stale/mismatched presentation row rather than erroring on a subscriber who's already leaving.
- `src/services/pro-activation-state.ts`: `buildActivationOutcomeBuckets`, a pure helper alongside the existing `summarizeActivationExit` — unit-testable without a DOM.
- `src/components/ProActivationInterstitial.ts`: calls the new mutation from `onExit`, gated to the markerless cohort (the only flow with a presentation row to attach outcomes to).
- `scripts/report-activation-lift.mjs`: read-only report comparing post-exit feature creation (`notificationChannels`/`alertRules`/`userApiKeys`/`mcpProTokens`) between subscribers who confirmed >=1 step vs. subscribers who were shown the wizard and confirmed nothing. **Not a randomized control** — both groups were equally exposed, so this isolates an engagement effect, not the wizard's existence. Enforces a 30-sample floor per group before printing a rate comparison, to avoid the exact small-sample trap that motivated this issue.

## Verification

- `tsc --noEmit` and `tsc --noEmit -p tsconfig.api.json` clean.
- Convex: 142/142 `convex/__tests__/billing.test.ts` pass (2 new: outcome persists correctly; no-ops on nonce mismatch / wrong user / never-claimed subscription).
- Frontend: 343/343 across `pro-activation-controller`, `pro-activation-state`, `widget-store`, `widget-builder` test files (4 new: `buildActivationOutcomeBuckets` bucketing/ordering/empty-flow cases).
- `scripts/report-activation-lift.mjs` run against real (read-only) production Convex data: correctly reports the table doesn't exist yet (since #5564 hasn't merged) instead of crashing.

## Non-goals (v1)

- No live dashboard — on-demand script only.
- No true randomized control.
- Not retroactive — the Umami blackout and pre-this-PR launch window have no recoverable step-level data.

Closes #5582.
