### PR TITLE
fix(observability): detect silent catch blocks in Sentry coverage audit

### DIFF
--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -3,11 +3,11 @@ import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout, buildRelayResponse 
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
- 
+
 export const config = { runtime: 'edge' };
- 
+
 const EPOCH_ISO = new Date(0).toISOString();
- 
+
 /**
  * @typedef {{
  *   id?: string | number;
@@ -27,7 +27,7 @@ const EPOCH_ISO = new Date(0).toISOString();
  *   mediaUrls?: unknown[];
  * }} RawTelegramMessage
  */
- 
+
 /**
  * @typedef {{
  *   enabled?: boolean;
@@ -39,7 +39,7 @@ const EPOCH_ISO = new Date(0).toISOString();
  *   items?: RawTelegramMessage[];
  * }} RawTelegramFeedResponse
  */
- 
+
 /**
  * @typedef {{
  *   id: string;
@@ -55,7 +55,7 @@ const EPOCH_ISO = new Date(0).toISOString();
  *   mediaUrls: string[];
  * }} TelegramFeedItem
  */
- 
+
 /**
  * @param {unknown} value
  * @returns {string}
@@ -63,7 +63,7 @@ const EPOCH_ISO = new Date(0).toISOString();
 function toText(value) {
   return value == null ? '' : String(value);
 }
- 
+
 /**
  * @param {unknown} value
  * @returns {string}
@@ -78,7 +78,7 @@ function toHttpUrl(value) {
     return '';
   }
 }
- 
+
 /**
  * @param {unknown} value
  * @returns {string}
@@ -97,7 +97,7 @@ function toIsoTimestamp(value) {
   const parsed = Date.parse(raw);
   return Number.isFinite(parsed) && parsed > 0 ? new Date(parsed).toISOString() : EPOCH_ISO;
 }
- 
+
 /**
  * @param {unknown[] | undefined} values
  * @param {(value: unknown) => string} mapper
@@ -107,7 +107,7 @@ function toTextArray(values, mapper = toText) {
   if (!Array.isArray(values)) return [];
   return values.map(mapper).filter(Boolean);
 }
- 
+
 /**
  * @param {RawTelegramMessage} message
  * @returns {TelegramFeedItem}
@@ -118,7 +118,7 @@ function normalizeTelegramMessage(message) {
   const ts = toIsoTimestamp(message.timestampMs ?? message.timestamp ?? message.ts);
   const text = toText(message.text).trim();
   const id = toText(message.id).trim() || `${channel || 'telegram'}:${ts}:${text.slice(0, 32)}`;
- 
+
   return {
     id,
     source: 'telegram',
@@ -133,7 +133,7 @@ function normalizeTelegramMessage(message) {
     mediaUrls: toTextArray(message.mediaUrls, toHttpUrl),
   };
 }
- 
+
 /**
  * @param {RawTelegramFeedResponse} parsed
  */
@@ -153,10 +153,10 @@ function normalizeTelegramFeed(parsed) {
     items,
   };
 }
- 
+
 export default async function handler(req) {
   const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
- 
+
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403, corsHeaders);
   }
@@ -166,12 +166,12 @@ export default async function handler(req) {
   if (req.method !== 'GET') {
     return jsonResponse({ error: 'Method not allowed' }, 405, corsHeaders);
   }
- 
+
   const relayBaseUrl = getRelayBaseUrl();
   if (!relayBaseUrl) {
     return jsonResponse({ error: 'WS_RELAY_URL is not configured' }, 503, corsHeaders);
   }
- 
+
   try {
     const url = new URL(req.url);
     const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10) || 50));
@@ -181,14 +181,14 @@ export default async function handler(req) {
     params.set('limit', String(limit));
     if (topic) params.set('topic', topic);
     if (channel) params.set('channel', channel);
- 
+
     const relayUrl = `${relayBaseUrl}/telegram/feed?${params}`;
     const response = await fetchWithTimeout(relayUrl, {
       headers: getRelayHeaders({ Accept: 'application/json' }),
     }, 15000);
- 
+
     const body = await response.text();
- 
+
     let cacheControl = 'public, max-age=30, s-maxage=120, stale-while-revalidate=60, stale-if-error=120';
     if (!response.ok) {
       return buildRelayResponse(response, body, {
@@ -196,7 +196,7 @@ export default async function handler(req) {
         ...corsHeaders,
       });
     }
- 
+
     try {
       const parsed = /** @type {RawTelegramFeedResponse} */ (JSON.parse(body));
       const normalized = normalizeTelegramFeed(parsed);
@@ -214,7 +214,7 @@ export default async function handler(req) {
       console.warn('[telegram-feed] normalization failed:', normalizeError?.message || String(normalizeError));
       void captureSilentError(normalizeError, { tags: { route: 'api/telegram-feed', step: 'normalize' } });
     }
- 
+
     return buildRelayResponse(response, body, {
       'Cache-Control': cacheControl,
       ...corsHeaders,

--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -2,11 +2,12 @@
 import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout, buildRelayResponse } from './_relay.js';
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
-
+import { captureSilentError } from './_sentry-edge.js';
+ 
 export const config = { runtime: 'edge' };
-
+ 
 const EPOCH_ISO = new Date(0).toISOString();
-
+ 
 /**
  * @typedef {{
  *   id?: string | number;
@@ -26,7 +27,7 @@ const EPOCH_ISO = new Date(0).toISOString();
  *   mediaUrls?: unknown[];
  * }} RawTelegramMessage
  */
-
+ 
 /**
  * @typedef {{
  *   enabled?: boolean;
@@ -38,7 +39,7 @@ const EPOCH_ISO = new Date(0).toISOString();
  *   items?: RawTelegramMessage[];
  * }} RawTelegramFeedResponse
  */
-
+ 
 /**
  * @typedef {{
  *   id: string;
@@ -54,7 +55,7 @@ const EPOCH_ISO = new Date(0).toISOString();
  *   mediaUrls: string[];
  * }} TelegramFeedItem
  */
-
+ 
 /**
  * @param {unknown} value
  * @returns {string}
@@ -62,7 +63,7 @@ const EPOCH_ISO = new Date(0).toISOString();
 function toText(value) {
   return value == null ? '' : String(value);
 }
-
+ 
 /**
  * @param {unknown} value
  * @returns {string}
@@ -77,7 +78,7 @@ function toHttpUrl(value) {
     return '';
   }
 }
-
+ 
 /**
  * @param {unknown} value
  * @returns {string}
@@ -96,7 +97,7 @@ function toIsoTimestamp(value) {
   const parsed = Date.parse(raw);
   return Number.isFinite(parsed) && parsed > 0 ? new Date(parsed).toISOString() : EPOCH_ISO;
 }
-
+ 
 /**
  * @param {unknown[] | undefined} values
  * @param {(value: unknown) => string} mapper
@@ -106,7 +107,7 @@ function toTextArray(values, mapper = toText) {
   if (!Array.isArray(values)) return [];
   return values.map(mapper).filter(Boolean);
 }
-
+ 
 /**
  * @param {RawTelegramMessage} message
  * @returns {TelegramFeedItem}
@@ -117,7 +118,7 @@ function normalizeTelegramMessage(message) {
   const ts = toIsoTimestamp(message.timestampMs ?? message.timestamp ?? message.ts);
   const text = toText(message.text).trim();
   const id = toText(message.id).trim() || `${channel || 'telegram'}:${ts}:${text.slice(0, 32)}`;
-
+ 
   return {
     id,
     source: 'telegram',
@@ -132,7 +133,7 @@ function normalizeTelegramMessage(message) {
     mediaUrls: toTextArray(message.mediaUrls, toHttpUrl),
   };
 }
-
+ 
 /**
  * @param {RawTelegramFeedResponse} parsed
  */
@@ -152,10 +153,10 @@ function normalizeTelegramFeed(parsed) {
     items,
   };
 }
-
+ 
 export default async function handler(req) {
   const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
-
+ 
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403, corsHeaders);
   }
@@ -165,12 +166,12 @@ export default async function handler(req) {
   if (req.method !== 'GET') {
     return jsonResponse({ error: 'Method not allowed' }, 405, corsHeaders);
   }
-
+ 
   const relayBaseUrl = getRelayBaseUrl();
   if (!relayBaseUrl) {
     return jsonResponse({ error: 'WS_RELAY_URL is not configured' }, 503, corsHeaders);
   }
-
+ 
   try {
     const url = new URL(req.url);
     const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10) || 50));
@@ -180,14 +181,14 @@ export default async function handler(req) {
     params.set('limit', String(limit));
     if (topic) params.set('topic', topic);
     if (channel) params.set('channel', channel);
-
+ 
     const relayUrl = `${relayBaseUrl}/telegram/feed?${params}`;
     const response = await fetchWithTimeout(relayUrl, {
       headers: getRelayHeaders({ Accept: 'application/json' }),
     }, 15000);
-
+ 
     const body = await response.text();
-
+ 
     let cacheControl = 'public, max-age=30, s-maxage=120, stale-while-revalidate=60, stale-if-error=120';
     if (!response.ok) {
       return buildRelayResponse(response, body, {
@@ -195,7 +196,7 @@ export default async function handler(req) {
         ...corsHeaders,
       });
     }
-
+ 
     try {
       const parsed = /** @type {RawTelegramFeedResponse} */ (JSON.parse(body));
       const normalized = normalizeTelegramFeed(parsed);
@@ -206,8 +207,14 @@ export default async function handler(req) {
         'Cache-Control': cacheControl,
         ...corsHeaders,
       });
-    } catch {}
-
+    } catch (normalizeError) {
+      // Fall through to the raw relay body so a shape change upstream still
+      // serves data, but never silently: clients receive an un-normalized
+      // payload, which is a bug worth an alert.
+      console.warn('[telegram-feed] normalization failed:', normalizeError?.message || String(normalizeError));
+      void captureSilentError(normalizeError, { tags: { route: 'api/telegram-feed', step: 'normalize' } });
+    }
+ 
     return buildRelayResponse(response, body, {
       'Cache-Control': cacheControl,
       ...corsHeaders,

--- a/scripts/check-sentry-coverage.mjs
+++ b/scripts/check-sentry-coverage.mjs
@@ -33,16 +33,16 @@
  *   node scripts/check-sentry-coverage.mjs            # diff mode
  *   node scripts/check-sentry-coverage.mjs --all      # full scan
  */
- 
+
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
- 
+
 const args = process.argv.slice(2);
 const SCAN_ALL = args.includes('--all');
- 
+
 const TARGET_DIRS = ['api', 'convex', 'server'];
- 
+
 // A catch block is "OK" if it contains at least one of these markers.
 // `throw` covers re-throws (auto-Sentry catches the propagated throw).
 // `captureSilentError` is our helper. `captureEdgeException` is the
@@ -63,7 +63,7 @@ const SAFE_PATTERNS = [
   /\bthrow\b/,
   /\bstatus:\s*5\d\d\b/,
 ];
- 
+
 // Inline override marker — when a catch body needs to swallow on the
 // HTTP path but surfaces to Sentry through a non-obvious channel (e.g.,
 // `ctx.scheduler.runAfter(...)` to a Convex mutation that throws). The
@@ -71,9 +71,9 @@ const SAFE_PATTERNS = [
 // removal — we check the raw catch body for it before falling through
 // to the safety patterns.
 const OVERRIDE_MARKER = /\/\/\s*sentry-coverage-ok\b/;
- 
+
 const LOG_PATTERN = /\bconsole\.(error|warn)\b/;
- 
+
 // Skip the helper files themselves — their `console.warn` on Sentry
 // delivery failure is the right behaviour (a Sentry capture inside the
 // Sentry helper would loop forever).
@@ -82,7 +82,7 @@ const SKIP_FILE_PATTERNS = [
   /\/api\/_sentry-node\.(js|mjs|ts)$/,
   /\/api\/_sentry-common\.(js|mjs|ts)$/,
 ];
- 
+
 /**
  * Replace JavaScript comments and string literals with spaces of equal
  * length, preserving line numbers and overall indexing. We don't need to
@@ -108,19 +108,19 @@ const SKIP_FILE_PATTERNS = [
 function stripCommentsAndStrings(src) {
   const out = new Array(src.length);
   for (let i = 0; i < src.length; i++) out[i] = src[i];
- 
+
   function blank(start, end) {
     for (let k = start; k < end; k++) {
       // Preserve newlines so line numbers stay correct.
       if (out[k] !== '\n') out[k] = ' ';
     }
   }
- 
+
   let i = 0;
   while (i < src.length) {
     const c = src[i];
     const next = src[i + 1];
- 
+
     // Line comment
     if (c === '/' && next === '/') {
       let j = i + 2;
@@ -204,10 +204,10 @@ function stripCommentsAndStrings(src) {
     }
     i++;
   }
- 
+
   return out.join('');
 }
- 
+
 // Helper — skip past a string starting at `i`, return index after closing.
 function stripStringFrom(src, i) {
   const c = src[i];
@@ -225,7 +225,7 @@ function stripStringFrom(src, i) {
   }
   return j;
 }
- 
+
 function listChangedFiles() {
   try {
     const out = execSync('git diff --name-only origin/main...HEAD', {
@@ -240,7 +240,7 @@ function listChangedFiles() {
     return [];
   }
 }
- 
+
 /**
  * For a given file in diff mode, parse `git diff --unified=0` to extract
  * the set of line ranges that were added/modified vs origin/main. Used
@@ -267,14 +267,14 @@ function changedLineRanges(filePath) {
     return [];
   }
 }
- 
+
 function rangesOverlap(catchStart, catchEnd, ranges) {
   for (const [s, e] of ranges) {
     if (catchEnd >= s && catchStart <= e) return true;
   }
   return false;
 }
- 
+
 function listAllFiles() {
   const out = execSync(
     `find ${TARGET_DIRS.join(' ')} -type f \\( -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' -o -name '*.js' \\) -not -path '*/node_modules/*' -not -path '*/_generated/*'`,
@@ -282,12 +282,12 @@ function listAllFiles() {
   );
   return out.split('\n').filter(Boolean);
 }
- 
+
 function findUnsafeCatches(filePath, restrictToRanges) {
   const rawSrc = readFileSync(filePath, 'utf8');
   const src = stripCommentsAndStrings(rawSrc);
   const offenders = [];
- 
+
   // Scan for catch blocks. We balance braces manually to handle nesting
   // (regex alone misses nested `{ }` inside the catch body). Operating on
   // the comment/string-stripped source means brace counts inside string
@@ -299,7 +299,7 @@ function findUnsafeCatches(filePath, restrictToRanges) {
     const startInRest = m.index;
     const absStart = i + startInRest;
     const bodyOpenAbs = absStart + m[0].length - 1; // index of the opening `{`
- 
+
     // Walk forward to find the matching closing brace.
     let depth = 1;
     let j = bodyOpenAbs + 1;
@@ -311,10 +311,10 @@ function findUnsafeCatches(filePath, restrictToRanges) {
     }
     const bodyEnd = j; // exclusive
     const body = src.slice(bodyOpenAbs + 1, bodyEnd - 1);
- 
+
     const rawBody = rawSrc.slice(bodyOpenAbs + 1, bodyEnd - 1);
     const hasOverride = OVERRIDE_MARKER.test(rawBody);
- 
+
     const logsWithoutReporting =
       LOG_PATTERN.test(body) && !SAFE_PATTERNS.some((p) => p.test(body));
     // A bare `} catch {}` — no statements AND no comment explaining why the
@@ -323,7 +323,7 @@ function findUnsafeCatches(filePath, restrictToRanges) {
     // cases passing while flagging the accidental ones, where nothing
     // reaches Sentry, the console, or the next reader.
     const isSilent = body.trim() === '' && rawBody.trim() === '';
- 
+
     if (!hasOverride && (logsWithoutReporting || isSilent)) {
       const startLine = src.slice(0, absStart).split('\n').length;
       const endLine = src.slice(0, bodyEnd).split('\n').length;
@@ -336,20 +336,20 @@ function findUnsafeCatches(filePath, restrictToRanges) {
         });
       }
     }
- 
+
     i = bodyEnd;
   }
- 
+
   return offenders;
 }
- 
+
 function main() {
   const files = SCAN_ALL ? listAllFiles() : listChangedFiles();
   if (files.length === 0) {
     if (!SCAN_ALL) console.log('  Sentry coverage: no api/ or convex/ files changed.');
     return 0;
   }
- 
+
   const allOffenders = [];
   for (const f of files) {
     const abs = resolve(f);
@@ -363,12 +363,12 @@ function main() {
       if (err && err.code !== 'ENOENT') throw err;
     }
   }
- 
+
   if (allOffenders.length === 0) {
     console.log(`  Sentry coverage: clean (${files.length} file${files.length === 1 ? '' : 's'} checked).`);
     return 0;
   }
- 
+
   console.error('');
   console.error('============================================================');
   console.error('Sentry coverage check FAILED');
@@ -392,5 +392,5 @@ function main() {
   console.error('============================================================');
   return 1;
 }
- 
+
 process.exit(main());

--- a/scripts/check-sentry-coverage.mjs
+++ b/scripts/check-sentry-coverage.mjs
@@ -2,16 +2,23 @@
 /**
  * Sentry-coverage lint guard.
  *
- * Flags catch blocks in api/ and convex/ that log via console.error /
- * console.warn but don't surface to Sentry — i.e., the silent-swallow
- * pattern that hid the canary OCC bug (Sentry issue WORLDMONITOR-PA)
- * for hours and made the post-mortem impossible.
+ * Flags catch blocks in api/, convex/ and server/ that swallow the error —
+ * the pattern that hid the canary OCC bug (Sentry issue WORLDMONITOR-PA)
+ * for hours and made the post-mortem impossible. `server/` counts because
+ * its code is bundled INTO the edge functions at deploy time, so a swallow
+ * there is invisible in exactly the same way.
  *
- * Heuristic: for each file under api/ or convex/, find catch blocks
- * (`} catch (...) { ... }`). If a block contains console.error/warn
- * but no `captureSilentError`, `captureEdgeException`, `Sentry.`, `throw`,
- * or `status: 5xx` (after stripping comments and string literals to avoid
- * matching those tokens inside text) — fail.
+ * Two heuristics run per catch block (`} catch (...) { ... }`), against a
+ * source with comments and string literals stripped so tokens inside text
+ * never count as code:
+ *
+ *   1. Logged but not reported — the body has console.error/warn but none
+ *      of `captureSilentError`, `captureEdgeException`, `Sentry.`, `throw`,
+ *      or `status: 5xx`.
+ *   2. Bare `catch {}` — no statements and no comment. Nothing reaches
+ *      Sentry, the console, or the next reader. Deliberate best-effort
+ *      swallows document themselves with a `/* why *\/` note (or the
+ *      override marker below), so this only fires on accidental ones.
  *
  * Mode:
  *   - `--diff` (default in pre-push): only flags catch blocks that
@@ -26,16 +33,16 @@
  *   node scripts/check-sentry-coverage.mjs            # diff mode
  *   node scripts/check-sentry-coverage.mjs --all      # full scan
  */
-
+ 
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-
+ 
 const args = process.argv.slice(2);
 const SCAN_ALL = args.includes('--all');
-
-const TARGET_DIRS = ['api', 'convex'];
-
+ 
+const TARGET_DIRS = ['api', 'convex', 'server'];
+ 
 // A catch block is "OK" if it contains at least one of these markers.
 // `throw` covers re-throws (auto-Sentry catches the propagated throw).
 // `captureSilentError` is our helper. `captureEdgeException` is the
@@ -56,7 +63,7 @@ const SAFE_PATTERNS = [
   /\bthrow\b/,
   /\bstatus:\s*5\d\d\b/,
 ];
-
+ 
 // Inline override marker — when a catch body needs to swallow on the
 // HTTP path but surfaces to Sentry through a non-obvious channel (e.g.,
 // `ctx.scheduler.runAfter(...)` to a Convex mutation that throws). The
@@ -64,9 +71,9 @@ const SAFE_PATTERNS = [
 // removal — we check the raw catch body for it before falling through
 // to the safety patterns.
 const OVERRIDE_MARKER = /\/\/\s*sentry-coverage-ok\b/;
-
+ 
 const LOG_PATTERN = /\bconsole\.(error|warn)\b/;
-
+ 
 // Skip the helper files themselves — their `console.warn` on Sentry
 // delivery failure is the right behaviour (a Sentry capture inside the
 // Sentry helper would loop forever).
@@ -75,7 +82,7 @@ const SKIP_FILE_PATTERNS = [
   /\/api\/_sentry-node\.(js|mjs|ts)$/,
   /\/api\/_sentry-common\.(js|mjs|ts)$/,
 ];
-
+ 
 /**
  * Replace JavaScript comments and string literals with spaces of equal
  * length, preserving line numbers and overall indexing. We don't need to
@@ -101,19 +108,19 @@ const SKIP_FILE_PATTERNS = [
 function stripCommentsAndStrings(src) {
   const out = new Array(src.length);
   for (let i = 0; i < src.length; i++) out[i] = src[i];
-
+ 
   function blank(start, end) {
     for (let k = start; k < end; k++) {
       // Preserve newlines so line numbers stay correct.
       if (out[k] !== '\n') out[k] = ' ';
     }
   }
-
+ 
   let i = 0;
   while (i < src.length) {
     const c = src[i];
     const next = src[i + 1];
-
+ 
     // Line comment
     if (c === '/' && next === '/') {
       let j = i + 2;
@@ -197,10 +204,10 @@ function stripCommentsAndStrings(src) {
     }
     i++;
   }
-
+ 
   return out.join('');
 }
-
+ 
 // Helper — skip past a string starting at `i`, return index after closing.
 function stripStringFrom(src, i) {
   const c = src[i];
@@ -218,7 +225,7 @@ function stripStringFrom(src, i) {
   }
   return j;
 }
-
+ 
 function listChangedFiles() {
   try {
     const out = execSync('git diff --name-only origin/main...HEAD', {
@@ -233,7 +240,7 @@ function listChangedFiles() {
     return [];
   }
 }
-
+ 
 /**
  * For a given file in diff mode, parse `git diff --unified=0` to extract
  * the set of line ranges that were added/modified vs origin/main. Used
@@ -260,14 +267,14 @@ function changedLineRanges(filePath) {
     return [];
   }
 }
-
+ 
 function rangesOverlap(catchStart, catchEnd, ranges) {
   for (const [s, e] of ranges) {
     if (catchEnd >= s && catchStart <= e) return true;
   }
   return false;
 }
-
+ 
 function listAllFiles() {
   const out = execSync(
     `find ${TARGET_DIRS.join(' ')} -type f \\( -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' -o -name '*.js' \\) -not -path '*/node_modules/*' -not -path '*/_generated/*'`,
@@ -275,12 +282,12 @@ function listAllFiles() {
   );
   return out.split('\n').filter(Boolean);
 }
-
+ 
 function findUnsafeCatches(filePath, restrictToRanges) {
   const rawSrc = readFileSync(filePath, 'utf8');
   const src = stripCommentsAndStrings(rawSrc);
   const offenders = [];
-
+ 
   // Scan for catch blocks. We balance braces manually to handle nesting
   // (regex alone misses nested `{ }` inside the catch body). Operating on
   // the comment/string-stripped source means brace counts inside string
@@ -292,7 +299,7 @@ function findUnsafeCatches(filePath, restrictToRanges) {
     const startInRest = m.index;
     const absStart = i + startInRest;
     const bodyOpenAbs = absStart + m[0].length - 1; // index of the opening `{`
-
+ 
     // Walk forward to find the matching closing brace.
     let depth = 1;
     let j = bodyOpenAbs + 1;
@@ -304,39 +311,45 @@ function findUnsafeCatches(filePath, restrictToRanges) {
     }
     const bodyEnd = j; // exclusive
     const body = src.slice(bodyOpenAbs + 1, bodyEnd - 1);
-
+ 
     const rawBody = rawSrc.slice(bodyOpenAbs + 1, bodyEnd - 1);
     const hasOverride = OVERRIDE_MARKER.test(rawBody);
-
-    if (
-      !hasOverride &&
-      LOG_PATTERN.test(body) &&
-      !SAFE_PATTERNS.some((p) => p.test(body))
-    ) {
+ 
+    const logsWithoutReporting =
+      LOG_PATTERN.test(body) && !SAFE_PATTERNS.some((p) => p.test(body));
+    // A bare `} catch {}` — no statements AND no comment explaining why the
+    // error is dropped. Deliberate best-effort swallows in this codebase
+    // carry a `/* why */` note, so requiring one keeps the intentional
+    // cases passing while flagging the accidental ones, where nothing
+    // reaches Sentry, the console, or the next reader.
+    const isSilent = body.trim() === '' && rawBody.trim() === '';
+ 
+    if (!hasOverride && (logsWithoutReporting || isSilent)) {
       const startLine = src.slice(0, absStart).split('\n').length;
       const endLine = src.slice(0, bodyEnd).split('\n').length;
       if (!restrictToRanges || rangesOverlap(startLine, endLine, restrictToRanges)) {
         offenders.push({
           filePath,
           lineNo: startLine,
+          reason: isSilent ? 'empty catch' : 'logged, not reported',
           snippet: rawBody.split('\n').find((l) => l.trim())?.trim().slice(0, 100) ?? '',
         });
       }
     }
-
+ 
     i = bodyEnd;
   }
-
+ 
   return offenders;
 }
-
+ 
 function main() {
   const files = SCAN_ALL ? listAllFiles() : listChangedFiles();
   if (files.length === 0) {
     if (!SCAN_ALL) console.log('  Sentry coverage: no api/ or convex/ files changed.');
     return 0;
   }
-
+ 
   const allOffenders = [];
   for (const f of files) {
     const abs = resolve(f);
@@ -350,22 +363,23 @@ function main() {
       if (err && err.code !== 'ENOENT') throw err;
     }
   }
-
+ 
   if (allOffenders.length === 0) {
     console.log(`  Sentry coverage: clean (${files.length} file${files.length === 1 ? '' : 's'} checked).`);
     return 0;
   }
-
+ 
   console.error('');
   console.error('============================================================');
   console.error('Sentry coverage check FAILED');
   console.error('');
   console.error(
-    `Found ${allOffenders.length} catch block(s) that log via console.error/warn`,
+    `Found ${allOffenders.length} catch block(s) that swallow the error`,
   );
-  console.error('but do not surface to Sentry. Either:');
+  console.error('(logged without reporting, or an empty catch body). Either:');
   console.error('  - call `captureSilentError(err, { tags: { ... } })` next to the log, OR');
-  console.error('  - re-throw the error (Convex auto-Sentry will capture it).');
+  console.error('  - re-throw the error (Convex auto-Sentry will capture it), OR');
+  console.error('  - if the swallow is intentional, add `// sentry-coverage-ok <reason>`.');
   console.error('');
   console.error('Helpers:');
   console.error('  api/ edge:  import { captureSilentError } from \'./_sentry-edge.js\';');
@@ -373,10 +387,10 @@ function main() {
   console.error('');
   console.error('Offenders:');
   for (const o of allOffenders) {
-    console.error(`  ${o.filePath}:${o.lineNo}  ${o.snippet}`);
+    console.error(`  ${o.filePath}:${o.lineNo}  [${o.reason}]  ${o.snippet}`);
   }
   console.error('============================================================');
   return 1;
 }
-
+ 
 process.exit(main());

--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -14,11 +14,12 @@ import {
 } from '../../../../src/config/airports';
 import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+// @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../../../api/_sentry-edge.js';
 export { parseStringArray } from '../../../_shared/parse-string-array';
- 
+
 // ---------- Constants ----------
- 
+
 export const FAA_URL = 'https://nasstatus.faa.gov/api/airport-status-information';
 export const AVIATIONSTACK_URL = 'https://api.aviationstack.com/v1/flights';
 export const ICAO_NOTAM_URL = 'https://dataservices.icao.int/api/notams-realtime-list';
@@ -28,9 +29,9 @@ const MIN_FLIGHTS_FOR_CLOSURE = 10;
 const RESOLVED_STATUSES = new Set(['cancelled', 'landed', 'active', 'arrived', 'diverted']);
 const NOTAM_CLOSURE_QCODES = new Set(['FA', 'AH', 'AL', 'AW', 'AC', 'AM']);
 const NOTAM_RESTRICTION_QCODES = new Set(['RA', 'RO']);
- 
+
 // ---------- XML Parser ----------
- 
+
 export const xmlParser = new XMLParser({
   ignoreAttributes: true,
   isArray: (_name: string, jpath: unknown) => {
@@ -38,18 +39,18 @@ export const xmlParser = new XMLParser({
     return typeof jpath === 'string' && /\.(Ground_Delay|Ground_Stop|Delay|Airport)$/.test(jpath);
   },
 });
- 
+
 // ---------- Internal types ----------
- 
+
 export interface FAADelayInfo {
   airport: string;
   reason: string;
   avgDelay: number;
   type: string;
 }
- 
+
 // ---------- Helpers ----------
- 
+
 export function parseDelayTypeFromReason(reason: string): string {
   const r = reason.toLowerCase();
   if (r.includes('ground stop')) return 'ground_stop';
@@ -59,18 +60,18 @@ export function parseDelayTypeFromReason(reason: string): string {
   if (r.includes('clos')) return 'ground_stop';
   return 'general';
 }
- 
+
 export function parseFaaXml(xml: string): Map<string, FAADelayInfo> {
   const delays = new Map<string, FAADelayInfo>();
   const parsed = xmlParser.parse(xml);
   const root = parsed?.AIRPORT_STATUS_INFORMATION;
   if (!root) return delays;
- 
+
   // Delay_type may be array or single object
   const delayTypes = Array.isArray(root.Delay_type)
     ? root.Delay_type
     : root.Delay_type ? [root.Delay_type] : [];
- 
+
   for (const dt of delayTypes) {
     // Ground Delays
     if (dt.Ground_Delay_List?.Ground_Delay) {
@@ -131,12 +132,12 @@ export function parseFaaXml(xml: string): Map<string, FAADelayInfo> {
       }
     }
   }
- 
+
   return delays;
 }
- 
+
 // ---------- Proto enum mappers ----------
- 
+
 export function toProtoDelayType(t: string): FlightDelayType {
   const map: Record<string, FlightDelayType> = {
     ground_stop: 'FLIGHT_DELAY_TYPE_GROUND_STOP',
@@ -148,7 +149,7 @@ export function toProtoDelayType(t: string): FlightDelayType {
   };
   return map[t] || 'FLIGHT_DELAY_TYPE_GENERAL';
 }
- 
+
 export function toProtoSeverity(s: string): FlightDelaySeverity {
   const map: Record<string, FlightDelaySeverity> = {
     normal: 'FLIGHT_DELAY_SEVERITY_NORMAL',
@@ -163,7 +164,7 @@ export function toProtoSeverity(s: string): FlightDelaySeverity {
   // healthy.
   return map[s] || 'FLIGHT_DELAY_SEVERITY_UNKNOWN';
 }
- 
+
 export function toProtoRegion(r: string): AirportRegion {
   const map: Record<string, AirportRegion> = {
     americas: 'AIRPORT_REGION_AMERICAS',
@@ -174,7 +175,7 @@ export function toProtoRegion(r: string): AirportRegion {
   };
   return map[r] || 'AIRPORT_REGION_UNSPECIFIED';
 }
- 
+
 export function toProtoSource(s: string): FlightDelaySource {
   const map: Record<string, FlightDelaySource> = {
     unspecified: 'FLIGHT_DELAY_SOURCE_UNSPECIFIED',
@@ -186,9 +187,9 @@ export function toProtoSource(s: string): FlightDelaySource {
   };
   return map[s] || 'FLIGHT_DELAY_SOURCE_COMPUTED';
 }
- 
+
 // ---------- Severity classification ----------
- 
+
 export function severityFromCancelRate(cancelRate: number): string {
   if (cancelRate >= 80) return 'severe';
   if (cancelRate >= 50) return 'major';
@@ -196,7 +197,7 @@ export function severityFromCancelRate(cancelRate: number): string {
   if (cancelRate >= 10) return 'minor';
   return 'normal';
 }
- 
+
 export function determineSeverity(avgDelayMinutes: number, delayedPct?: number): string {
   const t = DELAY_SEVERITY_THRESHOLDS;
   if (avgDelayMinutes >= t.severe.avgDelayMinutes || (delayedPct && delayedPct >= t.severe.delayedPct)) return 'severe';
@@ -205,20 +206,20 @@ export function determineSeverity(avgDelayMinutes: number, delayedPct?: number):
   if (avgDelayMinutes >= t.minor.avgDelayMinutes || (delayedPct && delayedPct >= t.minor.delayedPct)) return 'minor';
   return 'normal';
 }
- 
+
 // ---------- AviationStack integration ----------
- 
+
 interface AviationStackFlight {
   flight_status?: string;
   flight_date?: string;
   departure?: { delay?: number };
 }
- 
+
 export interface AviationStackResult {
   alerts: AirportDelayAlert[];
   healthy: boolean;
 }
- 
+
 export async function fetchAviationStackDelays(
   allAirports: MonitoredAirport[]
 ): Promise<AviationStackResult> {
@@ -227,11 +228,11 @@ export async function fetchAviationStackDelays(
     console.warn('[Aviation] No AVIATIONSTACK_API key — skipping');
     return { alerts: [], healthy: false };
   }
- 
+
   const alerts: AirportDelayAlert[] = [];
   let succeeded = 0, failed = 0;
   const deadline = Date.now() + 50_000;
- 
+
   for (let i = 0; i < allAirports.length; i += BATCH_CONCURRENCY) {
     if (Date.now() >= deadline) {
       console.warn(`[Aviation] Deadline hit after ${succeeded + failed}/${allAirports.length} airports`);
@@ -250,7 +251,7 @@ export async function fetchAviationStackDelays(
       }
     }
   }
- 
+
   const healthy = allAirports.length < 5 || failed <= succeeded;
   console.warn(`[Aviation] Done: ${succeeded} ok, ${failed} failed, ${alerts.length} alerts, healthy=${healthy}`);
   if (!healthy) {
@@ -258,9 +259,9 @@ export async function fetchAviationStackDelays(
   }
   return { alerts, healthy };
 }
- 
+
 interface FetchResult { ok: boolean; alert: AirportDelayAlert | null; }
- 
+
 async function fetchSingleAirport(
   apiKey: string, airport: MonitoredAirport
 ): Promise<FetchResult> {
@@ -294,12 +295,12 @@ async function fetchSingleAirport(
     return { ok: false, alert: null };
   }
 }
- 
+
 function aggregateFlights(
   airport: MonitoredAirport, flights: AviationStackFlight[]
 ): AirportDelayAlert | null {
   if (flights.length === 0) return null;
- 
+
   let delayed = 0, cancelled = 0, totalDelay = 0, resolved = 0;
   for (const f of flights) {
     if (RESOLVED_STATUSES.has(f.flight_status ?? '')) resolved++;
@@ -309,12 +310,12 @@ function aggregateFlights(
       totalDelay += f.departure.delay;
     }
   }
- 
+
   const total = resolved >= MIN_FLIGHTS_FOR_CLOSURE ? resolved : flights.length;
   const cancelledPct = (cancelled / total) * 100;
   const delayedPct = (delayed / total) * 100;
   const avgDelay = delayed > 0 ? Math.round(totalDelay / delayed) : 0;
- 
+
   let severity: string, delayType: string, reason: string;
   if (cancelledPct >= 80 && total >= MIN_FLIGHTS_FOR_CLOSURE) {
     severity = 'severe'; delayType = 'closure';
@@ -336,7 +337,7 @@ function aggregateFlights(
     return null;
   }
   if (severity === 'normal') return null;
- 
+
   return {
     id: `avstack-${airport.iata}`,
     iata: airport.iata, icao: airport.icao,
@@ -354,9 +355,9 @@ function aggregateFlights(
     updatedAt: Date.now(),
   };
 }
- 
+
 // ---------- NOTAM closure detection (ICAO API) ----------
- 
+
 interface IcaoNotam {
   id?: string;
   location?: string;
@@ -368,16 +369,16 @@ interface IcaoNotam {
   startvalidity?: number;
   endvalidity?: number;
 }
- 
+
 export interface NotamClosureResult {
   closedIcaoCodes: Set<string>;
   restrictedIcaoCodes: Set<string>;
   notamsByIcao: Map<string, string>;
 }
- 
+
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 export { getRelayBaseUrl, getRelayHeaders };
- 
+
 export async function fetchNotamClosures(
   airports: MonitoredAirport[]
 ): Promise<NotamClosureResult> {
@@ -387,15 +388,15 @@ export async function fetchNotamClosures(
     console.warn('[Aviation] NOTAM: no ICAO_API_KEY — skipping');
     return result;
   }
- 
+
   const relayBase = getRelayBaseUrl();
   const icaoCodes = airports.map(a => a.icao);
   const now = Math.floor(Date.now() / 1000);
- 
+
   // Send all locations in one request (relay or direct)
   const locations = icaoCodes.join(',');
   let notams: IcaoNotam[] = [];
- 
+
   try {
     if (relayBase) {
       // Route through Railway relay — avoids Vercel edge timeout / CloudFront blocking
@@ -433,12 +434,12 @@ export async function fetchNotamClosures(
     console.warn(`[Aviation] NOTAM fetch: ${err instanceof Error ? err.message : 'unknown'}`);
     return result;
   }
- 
+
   for (const n of notams) {
     const icao = n.itema || n.location || '';
     if (!icao || !icaoCodes.includes(icao)) continue;
     if (n.endvalidity && n.endvalidity < now) continue;
- 
+
     const code23 = (n.code23 || '').toUpperCase();
     const code45 = (n.code45 || '').toUpperCase();
     const text = (n.iteme || '').toUpperCase();
@@ -448,7 +449,7 @@ export async function fetchNotamClosures(
     const isRestrictionCode = (NOTAM_RESTRICTION_QCODES.has(code23) || NOTAM_CLOSURE_QCODES.has(code23)) && restrictionCode45;
     const isClosureText = /\b(AD CLSD|AIRPORT CLOSED|AIRSPACE CLOSED|AD NOT AVBL|CLSD TO ALL)\b/.test(text);
     const isRestrictionText = /\b(RESTRICTED AREA|PROHIBITED AREA|DANGER AREA|TFR|TEMPORARY FLIGHT RESTRICTION)\b/.test(text);
- 
+
     if (isClosureCode || isClosureText) {
       result.closedIcaoCodes.add(icao);
       result.notamsByIcao.set(icao, n.iteme || 'Airport closure (NOTAM)');
@@ -457,13 +458,13 @@ export async function fetchNotamClosures(
       result.notamsByIcao.set(icao, n.iteme || 'Airspace restriction (NOTAM)');
     }
   }
- 
+
   if (result.closedIcaoCodes.size > 0 || result.restrictedIcaoCodes.size > 0) {
     console.warn(`[Aviation] NOTAM: ${result.closedIcaoCodes.size} closures [${[...result.closedIcaoCodes].join(', ')}], ${result.restrictedIcaoCodes.size} restrictions [${[...result.restrictedIcaoCodes].join(', ')}]`);
   }
   return result;
 }
- 
+
 export function buildNotamAlert(
   airport: MonitoredAirport,
   reason: string,
@@ -490,24 +491,24 @@ export function buildNotamAlert(
     updatedAt: Date.now(),
   };
 }
- 
+
 // ---------- Shared NOTAM loader (used by both list-airport-delays and get-airport-ops-summary) ----------
- 
+
 const NOTAM_CACHE_KEY = 'aviation:notam:closures:v2';
 const NOTAM_CACHE_TTL = 1800; // 30 minutes
 const SEED_FRESHNESS_MS = 20 * 60 * 1000; // 20 minutes
- 
+
 export interface LoadedNotamResult {
   closedIcaos: string[];
   restrictedIcaos: string[];
   reasons: Record<string, string>;
 }
- 
+
 export async function loadNotamClosures(): Promise<LoadedNotamResult | null> {
   const t0 = Date.now();
   let notamResult: LoadedNotamResult | null = null;
   let fromSeed = false;
- 
+
   try {
     const notamMeta = await getCachedJson('seed-meta:aviation:notam', true) as { fetchedAt?: number } | null;
     const notamAge = notamMeta?.fetchedAt ? t0 - notamMeta.fetchedAt : Infinity;
@@ -520,7 +521,7 @@ export async function loadNotamClosures(): Promise<LoadedNotamResult | null> {
     console.warn(`[Aviation] NOTAM seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
     void captureSilentError(err, { tags: { route: 'aviation/notam', step: 'seed-read' } });
   }
- 
+
   if (!fromSeed && process.env.ICAO_API_KEY) {
     try {
       notamResult = await cachedFetchJson<LoadedNotamResult>(
@@ -539,14 +540,14 @@ export async function loadNotamClosures(): Promise<LoadedNotamResult | null> {
       void captureSilentError(err, { tags: { route: 'aviation/notam', step: 'live-fetch' } });
     }
   }
- 
+
   return notamResult;
 }
- 
+
 // ---------- NOTAM + flight data merge ----------
- 
+
 const SEV_ORDER = ['normal', 'minor', 'moderate', 'major', 'severe'];
- 
+
 export function mergeNotamWithExistingAlert(
   airport: MonitoredAirport,
   notamReason: string,
@@ -557,11 +558,11 @@ export function mergeNotamWithExistingAlert(
   if (!existing || existing.totalFlights === 0) {
     return buildNotamAlert(airport, notamReason, severity, delayType);
   }
- 
+
   const cancelRate = (existing.cancelledFlights / existing.totalFlights) * 100;
   const notamCancelSev = severityFromCancelRate(cancelRate);
   const notamFloor = 'moderate';
- 
+
   const existingSevName = (existing.severity ?? '')
     .replace('FLIGHT_DELAY_SEVERITY_', '').toLowerCase() || 'normal';
   const effectiveSev = SEV_ORDER[Math.max(
@@ -569,10 +570,10 @@ export function mergeNotamWithExistingAlert(
     SEV_ORDER.indexOf(notamCancelSev),
     SEV_ORDER.indexOf(notamFloor),
   )] ?? 'moderate';
- 
+
   const cancelText = `${Math.round(cancelRate)}% cxl`;
   const reason = `NOTAM: ${notamReason.slice(0, 120)} — ${cancelText}`;
- 
+
   return {
     ...existing,
     id: `notam-${airport.iata}`,

--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -14,10 +14,11 @@ import {
 } from '../../../../src/config/airports';
 import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import { captureSilentError } from '../../../../api/_sentry-edge.js';
 export { parseStringArray } from '../../../_shared/parse-string-array';
-
+ 
 // ---------- Constants ----------
-
+ 
 export const FAA_URL = 'https://nasstatus.faa.gov/api/airport-status-information';
 export const AVIATIONSTACK_URL = 'https://api.aviationstack.com/v1/flights';
 export const ICAO_NOTAM_URL = 'https://dataservices.icao.int/api/notams-realtime-list';
@@ -27,9 +28,9 @@ const MIN_FLIGHTS_FOR_CLOSURE = 10;
 const RESOLVED_STATUSES = new Set(['cancelled', 'landed', 'active', 'arrived', 'diverted']);
 const NOTAM_CLOSURE_QCODES = new Set(['FA', 'AH', 'AL', 'AW', 'AC', 'AM']);
 const NOTAM_RESTRICTION_QCODES = new Set(['RA', 'RO']);
-
+ 
 // ---------- XML Parser ----------
-
+ 
 export const xmlParser = new XMLParser({
   ignoreAttributes: true,
   isArray: (_name: string, jpath: unknown) => {
@@ -37,18 +38,18 @@ export const xmlParser = new XMLParser({
     return typeof jpath === 'string' && /\.(Ground_Delay|Ground_Stop|Delay|Airport)$/.test(jpath);
   },
 });
-
+ 
 // ---------- Internal types ----------
-
+ 
 export interface FAADelayInfo {
   airport: string;
   reason: string;
   avgDelay: number;
   type: string;
 }
-
+ 
 // ---------- Helpers ----------
-
+ 
 export function parseDelayTypeFromReason(reason: string): string {
   const r = reason.toLowerCase();
   if (r.includes('ground stop')) return 'ground_stop';
@@ -58,18 +59,18 @@ export function parseDelayTypeFromReason(reason: string): string {
   if (r.includes('clos')) return 'ground_stop';
   return 'general';
 }
-
+ 
 export function parseFaaXml(xml: string): Map<string, FAADelayInfo> {
   const delays = new Map<string, FAADelayInfo>();
   const parsed = xmlParser.parse(xml);
   const root = parsed?.AIRPORT_STATUS_INFORMATION;
   if (!root) return delays;
-
+ 
   // Delay_type may be array or single object
   const delayTypes = Array.isArray(root.Delay_type)
     ? root.Delay_type
     : root.Delay_type ? [root.Delay_type] : [];
-
+ 
   for (const dt of delayTypes) {
     // Ground Delays
     if (dt.Ground_Delay_List?.Ground_Delay) {
@@ -130,12 +131,12 @@ export function parseFaaXml(xml: string): Map<string, FAADelayInfo> {
       }
     }
   }
-
+ 
   return delays;
 }
-
+ 
 // ---------- Proto enum mappers ----------
-
+ 
 export function toProtoDelayType(t: string): FlightDelayType {
   const map: Record<string, FlightDelayType> = {
     ground_stop: 'FLIGHT_DELAY_TYPE_GROUND_STOP',
@@ -147,7 +148,7 @@ export function toProtoDelayType(t: string): FlightDelayType {
   };
   return map[t] || 'FLIGHT_DELAY_TYPE_GENERAL';
 }
-
+ 
 export function toProtoSeverity(s: string): FlightDelaySeverity {
   const map: Record<string, FlightDelaySeverity> = {
     normal: 'FLIGHT_DELAY_SEVERITY_NORMAL',
@@ -162,7 +163,7 @@ export function toProtoSeverity(s: string): FlightDelaySeverity {
   // healthy.
   return map[s] || 'FLIGHT_DELAY_SEVERITY_UNKNOWN';
 }
-
+ 
 export function toProtoRegion(r: string): AirportRegion {
   const map: Record<string, AirportRegion> = {
     americas: 'AIRPORT_REGION_AMERICAS',
@@ -173,7 +174,7 @@ export function toProtoRegion(r: string): AirportRegion {
   };
   return map[r] || 'AIRPORT_REGION_UNSPECIFIED';
 }
-
+ 
 export function toProtoSource(s: string): FlightDelaySource {
   const map: Record<string, FlightDelaySource> = {
     unspecified: 'FLIGHT_DELAY_SOURCE_UNSPECIFIED',
@@ -185,9 +186,9 @@ export function toProtoSource(s: string): FlightDelaySource {
   };
   return map[s] || 'FLIGHT_DELAY_SOURCE_COMPUTED';
 }
-
+ 
 // ---------- Severity classification ----------
-
+ 
 export function severityFromCancelRate(cancelRate: number): string {
   if (cancelRate >= 80) return 'severe';
   if (cancelRate >= 50) return 'major';
@@ -195,7 +196,7 @@ export function severityFromCancelRate(cancelRate: number): string {
   if (cancelRate >= 10) return 'minor';
   return 'normal';
 }
-
+ 
 export function determineSeverity(avgDelayMinutes: number, delayedPct?: number): string {
   const t = DELAY_SEVERITY_THRESHOLDS;
   if (avgDelayMinutes >= t.severe.avgDelayMinutes || (delayedPct && delayedPct >= t.severe.delayedPct)) return 'severe';
@@ -204,20 +205,20 @@ export function determineSeverity(avgDelayMinutes: number, delayedPct?: number):
   if (avgDelayMinutes >= t.minor.avgDelayMinutes || (delayedPct && delayedPct >= t.minor.delayedPct)) return 'minor';
   return 'normal';
 }
-
+ 
 // ---------- AviationStack integration ----------
-
+ 
 interface AviationStackFlight {
   flight_status?: string;
   flight_date?: string;
   departure?: { delay?: number };
 }
-
+ 
 export interface AviationStackResult {
   alerts: AirportDelayAlert[];
   healthy: boolean;
 }
-
+ 
 export async function fetchAviationStackDelays(
   allAirports: MonitoredAirport[]
 ): Promise<AviationStackResult> {
@@ -226,11 +227,11 @@ export async function fetchAviationStackDelays(
     console.warn('[Aviation] No AVIATIONSTACK_API key — skipping');
     return { alerts: [], healthy: false };
   }
-
+ 
   const alerts: AirportDelayAlert[] = [];
   let succeeded = 0, failed = 0;
   const deadline = Date.now() + 50_000;
-
+ 
   for (let i = 0; i < allAirports.length; i += BATCH_CONCURRENCY) {
     if (Date.now() >= deadline) {
       console.warn(`[Aviation] Deadline hit after ${succeeded + failed}/${allAirports.length} airports`);
@@ -249,7 +250,7 @@ export async function fetchAviationStackDelays(
       }
     }
   }
-
+ 
   const healthy = allAirports.length < 5 || failed <= succeeded;
   console.warn(`[Aviation] Done: ${succeeded} ok, ${failed} failed, ${alerts.length} alerts, healthy=${healthy}`);
   if (!healthy) {
@@ -257,9 +258,9 @@ export async function fetchAviationStackDelays(
   }
   return { alerts, healthy };
 }
-
+ 
 interface FetchResult { ok: boolean; alert: AirportDelayAlert | null; }
-
+ 
 async function fetchSingleAirport(
   apiKey: string, airport: MonitoredAirport
 ): Promise<FetchResult> {
@@ -293,12 +294,12 @@ async function fetchSingleAirport(
     return { ok: false, alert: null };
   }
 }
-
+ 
 function aggregateFlights(
   airport: MonitoredAirport, flights: AviationStackFlight[]
 ): AirportDelayAlert | null {
   if (flights.length === 0) return null;
-
+ 
   let delayed = 0, cancelled = 0, totalDelay = 0, resolved = 0;
   for (const f of flights) {
     if (RESOLVED_STATUSES.has(f.flight_status ?? '')) resolved++;
@@ -308,12 +309,12 @@ function aggregateFlights(
       totalDelay += f.departure.delay;
     }
   }
-
+ 
   const total = resolved >= MIN_FLIGHTS_FOR_CLOSURE ? resolved : flights.length;
   const cancelledPct = (cancelled / total) * 100;
   const delayedPct = (delayed / total) * 100;
   const avgDelay = delayed > 0 ? Math.round(totalDelay / delayed) : 0;
-
+ 
   let severity: string, delayType: string, reason: string;
   if (cancelledPct >= 80 && total >= MIN_FLIGHTS_FOR_CLOSURE) {
     severity = 'severe'; delayType = 'closure';
@@ -335,7 +336,7 @@ function aggregateFlights(
     return null;
   }
   if (severity === 'normal') return null;
-
+ 
   return {
     id: `avstack-${airport.iata}`,
     iata: airport.iata, icao: airport.icao,
@@ -353,9 +354,9 @@ function aggregateFlights(
     updatedAt: Date.now(),
   };
 }
-
+ 
 // ---------- NOTAM closure detection (ICAO API) ----------
-
+ 
 interface IcaoNotam {
   id?: string;
   location?: string;
@@ -367,16 +368,16 @@ interface IcaoNotam {
   startvalidity?: number;
   endvalidity?: number;
 }
-
+ 
 export interface NotamClosureResult {
   closedIcaoCodes: Set<string>;
   restrictedIcaoCodes: Set<string>;
   notamsByIcao: Map<string, string>;
 }
-
+ 
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 export { getRelayBaseUrl, getRelayHeaders };
-
+ 
 export async function fetchNotamClosures(
   airports: MonitoredAirport[]
 ): Promise<NotamClosureResult> {
@@ -386,15 +387,15 @@ export async function fetchNotamClosures(
     console.warn('[Aviation] NOTAM: no ICAO_API_KEY — skipping');
     return result;
   }
-
+ 
   const relayBase = getRelayBaseUrl();
   const icaoCodes = airports.map(a => a.icao);
   const now = Math.floor(Date.now() / 1000);
-
+ 
   // Send all locations in one request (relay or direct)
   const locations = icaoCodes.join(',');
   let notams: IcaoNotam[] = [];
-
+ 
   try {
     if (relayBase) {
       // Route through Railway relay — avoids Vercel edge timeout / CloudFront blocking
@@ -432,12 +433,12 @@ export async function fetchNotamClosures(
     console.warn(`[Aviation] NOTAM fetch: ${err instanceof Error ? err.message : 'unknown'}`);
     return result;
   }
-
+ 
   for (const n of notams) {
     const icao = n.itema || n.location || '';
     if (!icao || !icaoCodes.includes(icao)) continue;
     if (n.endvalidity && n.endvalidity < now) continue;
-
+ 
     const code23 = (n.code23 || '').toUpperCase();
     const code45 = (n.code45 || '').toUpperCase();
     const text = (n.iteme || '').toUpperCase();
@@ -447,7 +448,7 @@ export async function fetchNotamClosures(
     const isRestrictionCode = (NOTAM_RESTRICTION_QCODES.has(code23) || NOTAM_CLOSURE_QCODES.has(code23)) && restrictionCode45;
     const isClosureText = /\b(AD CLSD|AIRPORT CLOSED|AIRSPACE CLOSED|AD NOT AVBL|CLSD TO ALL)\b/.test(text);
     const isRestrictionText = /\b(RESTRICTED AREA|PROHIBITED AREA|DANGER AREA|TFR|TEMPORARY FLIGHT RESTRICTION)\b/.test(text);
-
+ 
     if (isClosureCode || isClosureText) {
       result.closedIcaoCodes.add(icao);
       result.notamsByIcao.set(icao, n.iteme || 'Airport closure (NOTAM)');
@@ -456,13 +457,13 @@ export async function fetchNotamClosures(
       result.notamsByIcao.set(icao, n.iteme || 'Airspace restriction (NOTAM)');
     }
   }
-
+ 
   if (result.closedIcaoCodes.size > 0 || result.restrictedIcaoCodes.size > 0) {
     console.warn(`[Aviation] NOTAM: ${result.closedIcaoCodes.size} closures [${[...result.closedIcaoCodes].join(', ')}], ${result.restrictedIcaoCodes.size} restrictions [${[...result.restrictedIcaoCodes].join(', ')}]`);
   }
   return result;
 }
-
+ 
 export function buildNotamAlert(
   airport: MonitoredAirport,
   reason: string,
@@ -489,24 +490,24 @@ export function buildNotamAlert(
     updatedAt: Date.now(),
   };
 }
-
+ 
 // ---------- Shared NOTAM loader (used by both list-airport-delays and get-airport-ops-summary) ----------
-
+ 
 const NOTAM_CACHE_KEY = 'aviation:notam:closures:v2';
 const NOTAM_CACHE_TTL = 1800; // 30 minutes
 const SEED_FRESHNESS_MS = 20 * 60 * 1000; // 20 minutes
-
+ 
 export interface LoadedNotamResult {
   closedIcaos: string[];
   restrictedIcaos: string[];
   reasons: Record<string, string>;
 }
-
+ 
 export async function loadNotamClosures(): Promise<LoadedNotamResult | null> {
   const t0 = Date.now();
   let notamResult: LoadedNotamResult | null = null;
   let fromSeed = false;
-
+ 
   try {
     const notamMeta = await getCachedJson('seed-meta:aviation:notam', true) as { fetchedAt?: number } | null;
     const notamAge = notamMeta?.fetchedAt ? t0 - notamMeta.fetchedAt : Infinity;
@@ -515,8 +516,11 @@ export async function loadNotamClosures(): Promise<LoadedNotamResult | null> {
       notamResult = seedNotam;
       fromSeed = true;
     }
-  } catch {}
-
+  } catch (err) {
+    console.warn(`[Aviation] NOTAM seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
+    void captureSilentError(err, { tags: { route: 'aviation/notam', step: 'seed-read' } });
+  }
+ 
   if (!fromSeed && process.env.ICAO_API_KEY) {
     try {
       notamResult = await cachedFetchJson<LoadedNotamResult>(
@@ -532,16 +536,17 @@ export async function loadNotamClosures(): Promise<LoadedNotamResult | null> {
       );
     } catch (err) {
       console.warn(`[Aviation] NOTAM fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
+      void captureSilentError(err, { tags: { route: 'aviation/notam', step: 'live-fetch' } });
     }
   }
-
+ 
   return notamResult;
 }
-
+ 
 // ---------- NOTAM + flight data merge ----------
-
+ 
 const SEV_ORDER = ['normal', 'minor', 'moderate', 'major', 'severe'];
-
+ 
 export function mergeNotamWithExistingAlert(
   airport: MonitoredAirport,
   notamReason: string,
@@ -552,11 +557,11 @@ export function mergeNotamWithExistingAlert(
   if (!existing || existing.totalFlights === 0) {
     return buildNotamAlert(airport, notamReason, severity, delayType);
   }
-
+ 
   const cancelRate = (existing.cancelledFlights / existing.totalFlights) * 100;
   const notamCancelSev = severityFromCancelRate(cancelRate);
   const notamFloor = 'moderate';
-
+ 
   const existingSevName = (existing.severity ?? '')
     .replace('FLIGHT_DELAY_SEVERITY_', '').toLowerCase() || 'normal';
   const effectiveSev = SEV_ORDER[Math.max(
@@ -564,10 +569,10 @@ export function mergeNotamWithExistingAlert(
     SEV_ORDER.indexOf(notamCancelSev),
     SEV_ORDER.indexOf(notamFloor),
   )] ?? 'moderate';
-
+ 
   const cancelText = `${Math.round(cancelRate)}% cxl`;
   const reason = `NOTAM: ${notamReason.slice(0, 120)} — ${cancelText}`;
-
+ 
   return {
     ...existing,
     id: `notam-${airport.iata}`,

--- a/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+++ b/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { MONITORED_AIRPORTS } from '../../../../src/config/airports';
 import { getCachedJson } from '../../../_shared/redis';
+// @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../../../api/_sentry-edge.js';
 import {
     determineSeverity,
@@ -16,9 +17,9 @@ import {
     DEFAULT_WATCHED_AIRPORTS,
     loadNotamClosures,
 } from './_shared';
- 
+
 const SEED_CACHE_KEY = 'aviation:delays:intl:v3';
- 
+
 export async function getAirportOpsSummary(
     _ctx: ServerContext,
     req: GetAirportOpsSummaryRequest,
@@ -27,13 +28,13 @@ export async function getAirportOpsSummary(
     const requested = rawAirports.length > 0
         ? rawAirports.map(a => a.toUpperCase())
         : DEFAULT_WATCHED_AIRPORTS;
- 
+
     const now = Date.now();
- 
+
     try {
         const airports = MONITORED_AIRPORTS.filter(a => requested.includes(a.iata));
         const summaries: AirportOpsSummary[] = [];
- 
+
         // Read delay alerts from relay seed cache (no direct AviationStack call)
         let alerts: AirportDelayAlert[] = [];
         let healthy = false;
@@ -50,7 +51,7 @@ export async function getAirportOpsSummary(
             console.warn(`[Aviation] Ops summary seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
             void captureSilentError(err, { tags: { route: 'aviation/get-airport-ops-summary', step: 'seed-read' } });
         }
- 
+
         // Fetch NOTAM closures via shared loader
         let notamClosedIcaos = new Set<string>();
         let notamRestrictedIcaos = new Set<string>();
@@ -66,19 +67,19 @@ export async function getAirportOpsSummary(
             console.warn(`[Aviation] Ops summary NOTAM load failed: ${err instanceof Error ? err.message : 'unknown'}`);
             void captureSilentError(err, { tags: { route: 'aviation/get-airport-ops-summary', step: 'notam-load' } });
         }
- 
+
         for (const airport of airports) {
             const alert = alerts.find(a => a.iata === airport.iata);
             const isClosed = notamClosedIcaos.has(airport.icao);
             const isRestricted = notamRestrictedIcaos.has(airport.icao);
             const notamText = notamReasons[airport.icao];
- 
+
             const delayPct = alert?.delayedFlightsPct ?? 0;
             const avgDelay = alert?.avgDelayMinutes ?? 0;
             const cancelledFlights = alert?.cancelledFlights ?? 0;
             const totalFlights = alert?.totalFlights ?? 0;
             const cancelRate = totalFlights > 0 ? (cancelledFlights / totalFlights) * 100 : 0;
- 
+
             const cancelSev = severityFromCancelRate(cancelRate);
             const delaySev = determineSeverity(avgDelay, delayPct);
             const notamFloor = isClosed
@@ -91,16 +92,16 @@ export async function getAirportOpsSummary(
                 sevOrder.indexOf(notamFloor),
             )] ?? 'normal';
             const severity = `FLIGHT_DELAY_SEVERITY_${sevStr.toUpperCase()}` as FlightDelaySeverity;
- 
+
             const notamFlags: string[] = [];
             if (isClosed) notamFlags.push('CLOSED');
             if (isRestricted) notamFlags.push('RESTRICTED');
             if (notamText) notamFlags.push('NOTAM');
- 
+
             const topDelayReasons: string[] = [];
             if (alert?.reason) topDelayReasons.push(alert.reason);
             if ((isClosed || isRestricted) && notamText) topDelayReasons.push(notamText.slice(0, 80));
- 
+
             summaries.push({
                 iata: airport.iata,
                 icao: airport.icao,
@@ -118,7 +119,7 @@ export async function getAirportOpsSummary(
                 updatedAt: now,
             });
         }
- 
+
         // Add requested airports not found in MONITORED_AIRPORTS
         for (const iata of requested) {
             if (!summaries.find(s => s.iata === iata)) {
@@ -140,7 +141,7 @@ export async function getAirportOpsSummary(
                 });
             }
         }
- 
+
         return { summaries, cacheHit: false };
     } catch (err) {
         console.warn(`[Aviation] GetAirportOpsSummary failed: ${err instanceof Error ? err.message : err}`);

--- a/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+++ b/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { MONITORED_AIRPORTS } from '../../../../src/config/airports';
 import { getCachedJson } from '../../../_shared/redis';
+import { captureSilentError } from '../../../../api/_sentry-edge.js';
 import {
     determineSeverity,
     severityFromCancelRate,
@@ -15,9 +16,9 @@ import {
     DEFAULT_WATCHED_AIRPORTS,
     loadNotamClosures,
 } from './_shared';
-
+ 
 const SEED_CACHE_KEY = 'aviation:delays:intl:v3';
-
+ 
 export async function getAirportOpsSummary(
     _ctx: ServerContext,
     req: GetAirportOpsSummaryRequest,
@@ -26,13 +27,13 @@ export async function getAirportOpsSummary(
     const requested = rawAirports.length > 0
         ? rawAirports.map(a => a.toUpperCase())
         : DEFAULT_WATCHED_AIRPORTS;
-
+ 
     const now = Date.now();
-
+ 
     try {
         const airports = MONITORED_AIRPORTS.filter(a => requested.includes(a.iata));
         const summaries: AirportOpsSummary[] = [];
-
+ 
         // Read delay alerts from relay seed cache (no direct AviationStack call)
         let alerts: AirportDelayAlert[] = [];
         let healthy = false;
@@ -42,8 +43,14 @@ export async function getAirportOpsSummary(
                 alerts = seedData.alerts;
                 healthy = true;
             }
-        } catch { /* graceful degradation */ }
-
+        } catch (err) {
+            // Degrade to "no delay telemetry" (healthy stays false) but surface
+            // the cause — otherwise a broken cache read is indistinguishable
+            // from an empty seed.
+            console.warn(`[Aviation] Ops summary seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
+            void captureSilentError(err, { tags: { route: 'aviation/get-airport-ops-summary', step: 'seed-read' } });
+        }
+ 
         // Fetch NOTAM closures via shared loader
         let notamClosedIcaos = new Set<string>();
         let notamRestrictedIcaos = new Set<string>();
@@ -55,20 +62,23 @@ export async function getAirportOpsSummary(
                 notamRestrictedIcaos = new Set(notamResult.restrictedIcaos ?? []);
                 notamReasons = notamResult.reasons;
             }
-        } catch { /* graceful degradation */ }
-
+        } catch (err) {
+            console.warn(`[Aviation] Ops summary NOTAM load failed: ${err instanceof Error ? err.message : 'unknown'}`);
+            void captureSilentError(err, { tags: { route: 'aviation/get-airport-ops-summary', step: 'notam-load' } });
+        }
+ 
         for (const airport of airports) {
             const alert = alerts.find(a => a.iata === airport.iata);
             const isClosed = notamClosedIcaos.has(airport.icao);
             const isRestricted = notamRestrictedIcaos.has(airport.icao);
             const notamText = notamReasons[airport.icao];
-
+ 
             const delayPct = alert?.delayedFlightsPct ?? 0;
             const avgDelay = alert?.avgDelayMinutes ?? 0;
             const cancelledFlights = alert?.cancelledFlights ?? 0;
             const totalFlights = alert?.totalFlights ?? 0;
             const cancelRate = totalFlights > 0 ? (cancelledFlights / totalFlights) * 100 : 0;
-
+ 
             const cancelSev = severityFromCancelRate(cancelRate);
             const delaySev = determineSeverity(avgDelay, delayPct);
             const notamFloor = isClosed
@@ -81,16 +91,16 @@ export async function getAirportOpsSummary(
                 sevOrder.indexOf(notamFloor),
             )] ?? 'normal';
             const severity = `FLIGHT_DELAY_SEVERITY_${sevStr.toUpperCase()}` as FlightDelaySeverity;
-
+ 
             const notamFlags: string[] = [];
             if (isClosed) notamFlags.push('CLOSED');
             if (isRestricted) notamFlags.push('RESTRICTED');
             if (notamText) notamFlags.push('NOTAM');
-
+ 
             const topDelayReasons: string[] = [];
             if (alert?.reason) topDelayReasons.push(alert.reason);
             if ((isClosed || isRestricted) && notamText) topDelayReasons.push(notamText.slice(0, 80));
-
+ 
             summaries.push({
                 iata: airport.iata,
                 icao: airport.icao,
@@ -108,7 +118,7 @@ export async function getAirportOpsSummary(
                 updatedAt: now,
             });
         }
-
+ 
         // Add requested airports not found in MONITORED_AIRPORTS
         for (const iata of requested) {
             if (!summaries.find(s => s.iata === iata)) {
@@ -130,7 +140,7 @@ export async function getAirportOpsSummary(
                 });
             }
         }
-
+ 
         return { summaries, cacheHit: false };
     } catch (err) {
         console.warn(`[Aviation] GetAirportOpsSummary failed: ${err instanceof Error ? err.message : err}`);

--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -19,15 +19,16 @@ import {
   mergeNotamWithExistingAlert,
 } from './_shared';
 import { getCachedJson, setCachedJson } from '../../../_shared/redis';
+// @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../../../api/_sentry-edge.js';
- 
+
 const FAA_CACHE_KEY = 'aviation:delays:faa:v1';
 const INTL_CACHE_KEY = 'aviation:delays:intl:v3';
- 
+
 const FAA_AIRPORT_SET = new Set(FAA_AIRPORTS);
 const INTL_AIRPORT_SET = new Set(AVIATIONSTACK_AIRPORTS);
 type IntlCoverage = { iata: string; status: 'normal' | 'disruption' | 'omitted' | 'failed'; flightCount: number };
- 
+
 export async function listAirportDelays(
   _ctx: ServerContext,
   _req: ListAirportDelaysRequest,
@@ -57,7 +58,7 @@ export async function listAirportDelays(
     console.warn(`[Aviation] FAA seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
     void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'faa-seed-read' } });
   }
- 
+
   // 2. International — read-only from Redis (Railway relay seeds the cache)
   // A cache hit alone does not prove every configured hub was covered. The
   // seeder records each hub as normal/disruption/omitted/failed so an omitted
@@ -80,7 +81,7 @@ export async function listAirportDelays(
     console.warn(`[Aviation] Intl fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
     void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'intl-cache-read' } });
   }
- 
+
   // 3. NOTAM alerts — shared loader (seed-first with live fallback).
   // loadNotamClosures swallows both the seed-read and live-fetch failures
   // internally (returns null on error), so no outer try/catch is needed — a
@@ -115,7 +116,7 @@ export async function listAirportDelays(
       console.warn(`[Aviation] NOTAM: ${notamResult.closedIcaos?.length ?? 0} closures, ${notamResult.restrictedIcaos?.length ?? 0} restrictions applied`);
     }
   }
- 
+
   // 4. Fill in monitored airports without an active alert.
   //   - Covered (the airport's primary source returned data this tick) →
   //     emit a NORMAL row sourced to the actual upstream (FAA or AviationStack),
@@ -126,11 +127,11 @@ export async function listAirportDelays(
   const alertedIatas = new Set(allAlerts.map(a => a.iata));
   for (const airport of MONITORED_AIRPORTS) {
     if (alertedIatas.has(airport.iata)) continue;
- 
+
     const isFaaCovered = FAA_AIRPORT_SET.has(airport.iata) && faaSourceCovered;
     const isIntlCovered = INTL_AIRPORT_SET.has(airport.iata) && intlCoveredIatas.has(airport.iata);
     const covered = isFaaCovered || isIntlCovered;
- 
+
     if (covered) {
       allAlerts.push({
         id: `status-${airport.iata}`,
@@ -173,7 +174,7 @@ export async function listAirportDelays(
       });
     }
   }
- 
+
   // Write bootstrap key for initial page load hydration. Canonical writer is
   // scripts/seed-aviation.mjs (BOOTSTRAP_TTL=7200). This RPC-side write is a
   // courtesy mid-tick refresh — TTL kept in lockstep so a user-triggered RPC
@@ -182,6 +183,6 @@ export async function listAirportDelays(
   try {
     await setCachedJson('aviation:delays-bootstrap:v2', { alerts: allAlerts, coverage: intlCoverage }, 7200);
   } catch { /* non-critical */ }
- 
+
   return { alerts: allAlerts };
 }

--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -19,14 +19,15 @@ import {
   mergeNotamWithExistingAlert,
 } from './_shared';
 import { getCachedJson, setCachedJson } from '../../../_shared/redis';
-
+import { captureSilentError } from '../../../../api/_sentry-edge.js';
+ 
 const FAA_CACHE_KEY = 'aviation:delays:faa:v1';
 const INTL_CACHE_KEY = 'aviation:delays:intl:v3';
-
+ 
 const FAA_AIRPORT_SET = new Set(FAA_AIRPORTS);
 const INTL_AIRPORT_SET = new Set(AVIATIONSTACK_AIRPORTS);
 type IntlCoverage = { iata: string; status: 'normal' | 'disruption' | 'omitted' | 'failed'; flightCount: number };
-
+ 
 export async function listAirportDelays(
   _ctx: ServerContext,
   _req: ListAirportDelaysRequest,
@@ -52,8 +53,11 @@ export async function listAirportDelays(
         })
         .filter((a): a is AirportDelayAlert => a !== null);
     }
-  } catch {}
-
+  } catch (err) {
+    console.warn(`[Aviation] FAA seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
+    void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'faa-seed-read' } });
+  }
+ 
   // 2. International — read-only from Redis (Railway relay seeds the cache)
   // A cache hit alone does not prove every configured hub was covered. The
   // seeder records each hub as normal/disruption/omitted/failed so an omitted
@@ -74,8 +78,9 @@ export async function listAirportDelays(
     }
   } catch (err) {
     console.warn(`[Aviation] Intl fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
+    void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'intl-cache-read' } });
   }
-
+ 
   // 3. NOTAM alerts — shared loader (seed-first with live fallback).
   // loadNotamClosures swallows both the seed-read and live-fetch failures
   // internally (returns null on error), so no outer try/catch is needed — a
@@ -110,7 +115,7 @@ export async function listAirportDelays(
       console.warn(`[Aviation] NOTAM: ${notamResult.closedIcaos?.length ?? 0} closures, ${notamResult.restrictedIcaos?.length ?? 0} restrictions applied`);
     }
   }
-
+ 
   // 4. Fill in monitored airports without an active alert.
   //   - Covered (the airport's primary source returned data this tick) →
   //     emit a NORMAL row sourced to the actual upstream (FAA or AviationStack),
@@ -121,11 +126,11 @@ export async function listAirportDelays(
   const alertedIatas = new Set(allAlerts.map(a => a.iata));
   for (const airport of MONITORED_AIRPORTS) {
     if (alertedIatas.has(airport.iata)) continue;
-
+ 
     const isFaaCovered = FAA_AIRPORT_SET.has(airport.iata) && faaSourceCovered;
     const isIntlCovered = INTL_AIRPORT_SET.has(airport.iata) && intlCoveredIatas.has(airport.iata);
     const covered = isFaaCovered || isIntlCovered;
-
+ 
     if (covered) {
       allAlerts.push({
         id: `status-${airport.iata}`,
@@ -168,7 +173,7 @@ export async function listAirportDelays(
       });
     }
   }
-
+ 
   // Write bootstrap key for initial page load hydration. Canonical writer is
   // scripts/seed-aviation.mjs (BOOTSTRAP_TTL=7200). This RPC-side write is a
   // courtesy mid-tick refresh — TTL kept in lockstep so a user-triggered RPC
@@ -177,6 +182,6 @@ export async function listAirportDelays(
   try {
     await setCachedJson('aviation:delays-bootstrap:v2', { alerts: allAlerts, coverage: intlCoverage }, 7200);
   } catch { /* non-critical */ }
-
+ 
   return { alerts: allAlerts };
 }


### PR DESCRIPTION
## Summary

Fixes #5585.

This PR improves the Sentry coverage audit by detecting previously missed silent exception handling in server-side code.

### Changes

- Include the `server/` directory in the Sentry coverage scan.
- Detect bare/silent `catch` blocks in addition to logged-but-unreported catches.
- Preserve support for intentionally documented best-effort catches.
- Fix all silent catches identified by the enhanced audit:
  - `server/worldmonitor/aviation/v1/list-airport-delays.ts`
  - `server/worldmonitor/aviation/v1/_shared.ts`
  - `server/worldmonitor/aviation/v1/get-airport-ops-summary.ts`
  - `api/telegram-feed.js`

This closes an observability gap where exceptions could be swallowed without being reported to Sentry or detected by the audit script.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Developer tooling / Observability

## Checklist

- [ ] Tested on worldmonitor.app variant
- [ ] Tested on tech.worldmonitor.app variant (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [ ] N/A

## Testing

- ✅ TypeScript typecheck
- ✅ ESLint
- ✅ Aviation edge-function tests
- ✅ Telegram tests

## Screenshots

N/A (server-side observability change; no UI changes)