### PR TITLE
fix(seo): avoid crawlable live-tool 401 regressions

### DIFF
--- a/scripts/crawlable-live-tools.mjs
+++ b/scripts/crawlable-live-tools.mjs
@@ -533,25 +533,95 @@ async function fetchWithTimeout(
   }
 }
 
+const ANONYMOUS_SESSION_STORAGE_KEY = 'wm-session-exp';
+const ANONYMOUS_SESSION_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
 let anonymousSessionPromise = null;
+let anonymousSessionGeneration = 0;
+let anonymousSessionFallbackExpiry = null;
+let anonymousSessionFallbackStorage = null;
+
+function currentAnonymousSessionStorage() {
+  try {
+    return typeof globalThis.sessionStorage === 'undefined' ? null : globalThis.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function loadAnonymousSessionExpiry() {
+  const storage = currentAnonymousSessionStorage();
+  if (!storage) {
+    return anonymousSessionFallbackStorage === null ? anonymousSessionFallbackExpiry : null;
+  }
+  try {
+    const parsed = JSON.parse(storage.getItem(ANONYMOUS_SESSION_STORAGE_KEY) || 'null');
+    return typeof parsed?.exp === 'number' ? parsed.exp : null;
+  } catch {
+    return anonymousSessionFallbackStorage === storage ? anonymousSessionFallbackExpiry : null;
+  }
+}
+
+function saveAnonymousSessionExpiry(exp) {
+  const storage = currentAnonymousSessionStorage();
+  anonymousSessionFallbackExpiry = exp;
+  anonymousSessionFallbackStorage = storage;
+  if (!storage) return;
+  try {
+    storage.setItem(ANONYMOUS_SESSION_STORAGE_KEY, JSON.stringify({ exp }));
+  } catch {
+    // Storage can be unavailable in privacy-restricted browsers.
+  }
+}
+
+function clearAnonymousSession() {
+  const storage = currentAnonymousSessionStorage();
+  anonymousSessionFallbackExpiry = null;
+  anonymousSessionFallbackStorage = storage;
+  if (!storage) return;
+  try {
+    storage.removeItem(ANONYMOUS_SESSION_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable in privacy-restricted browsers.
+  }
+}
+
+function hasFreshAnonymousSession() {
+  const expiry = loadAnonymousSessionExpiry();
+  return expiry !== null && expiry - ANONYMOUS_SESSION_REFRESH_MARGIN_MS > Date.now();
+}
 
 async function ensureAnonymousSession(fetchImpl, timeoutMs) {
-  if (!anonymousSessionPromise) {
-    anonymousSessionPromise = fetchWithTimeout('/api/wm-session', {
-      method: 'POST',
-    }, fetchImpl, timeoutMs).then(({ response }) => {
-      if (!response.ok) throw new Error(`Anonymous session request failed (${response.status})`);
-    }).finally(() => {
-      anonymousSessionPromise = null;
-    });
-  }
+  if (anonymousSessionPromise) return anonymousSessionPromise;
+  if (hasFreshAnonymousSession()) return;
+  anonymousSessionPromise = fetchWithTimeout('/api/wm-session', {
+    method: 'POST',
+  }, fetchImpl, timeoutMs, true).then(({ response, payload }) => {
+    if (!response.ok) throw new Error(`Anonymous session request failed (${response.status})`);
+    if (typeof payload?.exp !== 'number') {
+      throw new Error('Anonymous session response did not include an expiry');
+    }
+    saveAnonymousSessionExpiry(payload.exp);
+    anonymousSessionGeneration += 1;
+  }).finally(() => {
+    anonymousSessionPromise = null;
+  });
   return anonymousSessionPromise;
 }
 
 export async function requestLiveJson(
   url,
-  { fetchImpl = fetch, signal, timeoutMs = REQUEST_TIMEOUT_MS } = {},
+  {
+    fetchImpl = fetch,
+    signal,
+    timeoutMs = REQUEST_TIMEOUT_MS,
+    preflightSession = false,
+  } = {},
 ) {
+  if (preflightSession) {
+    await ensureAnonymousSession(fetchImpl, timeoutMs);
+  }
+  const requestSessionGeneration = anonymousSessionGeneration;
   let { response, payload } = await fetchWithTimeout(
     url,
     { signal },
@@ -560,7 +630,10 @@ export async function requestLiveJson(
     true,
   );
   if (response.status === 401) {
-    await ensureAnonymousSession(fetchImpl, timeoutMs);
+    if (requestSessionGeneration === anonymousSessionGeneration) {
+      clearAnonymousSession();
+      await ensureAnonymousSession(fetchImpl, timeoutMs);
+    }
     ({ response, payload } = await fetchWithTimeout(
       url,
       { signal },
@@ -747,7 +820,7 @@ async function loadCountryRisk(tool) {
       async (signal) => {
         const payload = await requestLiveJson(
           `/api/intelligence/v1/get-country-risk?country_code=${encodeURIComponent(countryCode)}`,
-          { signal },
+          { signal, preflightSession: true },
         );
         return liveRiskViewModel(payload);
       },
@@ -765,6 +838,7 @@ async function loadChokepoint(tool) {
   try {
     const payload = await requestLiveJson('/api/supply-chain/v1/get-chokepoint-status', {
       signal: state.controller.signal,
+      preflightSession: true,
     });
     const view = chokepointStatusViewModel(payload, id);
     if (!isCurrentRequest(tool, state)) return;
@@ -803,7 +877,7 @@ async function loadCrisis(tool) {
       code: country.code,
       payload: await requestLiveJson(
         `/api/conflict/v1/get-humanitarian-summary?country_code=${encodeURIComponent(country.code)}`,
-        { signal: state.controller.signal },
+        { signal: state.controller.signal, preflightSession: true },
       ),
     })));
     const results = settled.map((result, index) => (
@@ -936,8 +1010,8 @@ async function loadAirspace(tool) {
   await runLatestToolRequest(
     tool,
     async (signal) => Promise.allSettled([
-      requestLiveJson(airportUrl, { signal }),
-      requestLiveJson(militaryUrl, { signal }),
+      requestLiveJson(airportUrl, { signal, preflightSession: true }),
+      requestLiveJson(militaryUrl, { signal, preflightSession: true }),
     ]),
     ([airportResult, militaryResult]) => {
       let readySections = 0;

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -101,6 +101,7 @@ describe('crawlable corpus generator', () => {
       assert.match(liveRiskScript, /\/api\/wm-session/);
       assert.match(liveRiskScript, /\/api\/intelligence\/v1\/get-country-risk\?country_code=/);
       assert.match(liveRiskScript, /credentials:\s*'include'/);
+      assert.match(liveRiskScript, /preflightSession:\s*true/);
       assert.match(liveRiskScript, /response\.status === 401/);
       assert.match(liveRiskScript, /payload\.upstreamUnavailable === true/);
 

--- a/tests/crawlable-live-tools.test.mjs
+++ b/tests/crawlable-live-tools.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
   airportDisruptionViewModel,
@@ -15,7 +15,33 @@ import {
 
 const NOW = Date.UTC(2026, 6, 24, 12);
 
+function anonymousSessionResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ exp: Date.now() + 60 * 60 * 1000 }),
+  };
+}
+
 describe('crawlable live intelligence view models', () => {
+  let previousSessionStorage;
+  let storedSessionValues;
+
+  beforeEach(() => {
+    previousSessionStorage = globalThis.sessionStorage;
+    storedSessionValues = new Map();
+    globalThis.sessionStorage = {
+      getItem: (key) => storedSessionValues.get(key) ?? null,
+      setItem: (key, value) => storedSessionValues.set(key, value),
+      removeItem: (key) => storedSessionValues.delete(key),
+    };
+  });
+
+  afterEach(() => {
+    if (previousSessionStorage === undefined) delete globalThis.sessionStorage;
+    else globalThis.sessionStorage = previousSessionStorage;
+  });
+
   it('matches the requested chokepoint and preserves partial transit coverage', () => {
     const payload = {
       fetchedAt: new Date(NOW - 60_000).toISOString(),
@@ -384,11 +410,202 @@ describe('crawlable live intelligence view models', () => {
     assert.equal(view.flights[0].aircraftType, 'Reconnaissance');
   });
 
+  it('mints an anonymous session before a session-gated live request', async () => {
+    const calls = [];
+    const responses = [
+      anonymousSessionResponse(),
+      { ok: true, status: 200, json: async () => ({ value: 42 }) },
+    ];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET', credentials: options.credentials });
+      return responses.shift();
+    };
+
+    const payload = await requestLiveJson('/api/example', {
+      fetchImpl,
+      preflightSession: true,
+    });
+    assert.deepEqual(payload, { value: 42 });
+    assert.deepEqual(calls, [
+      { url: '/api/wm-session', method: 'POST', credentials: 'include' },
+      { url: '/api/example', method: 'GET', credentials: 'include' },
+    ]);
+  });
+
+  it('reuses a fresh anonymous session for serial protected requests', async () => {
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET' });
+      if (url === '/api/wm-session') return anonymousSessionResponse();
+      return { ok: true, status: 200, json: async () => ({ url }) };
+    };
+
+    await requestLiveJson('/api/one', { fetchImpl, preflightSession: true });
+    await requestLiveJson('/api/two', { fetchImpl, preflightSession: true });
+    assert.deepEqual(calls.map(({ url }) => url), [
+      '/api/wm-session',
+      '/api/one',
+      '/api/two',
+    ]);
+  });
+
+  it('reuses a fresh anonymous session when browser storage is unavailable', async () => {
+    globalThis.sessionStorage = {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+      setItem: () => {
+        throw new Error('storage disabled');
+      },
+      removeItem: () => {
+        throw new Error('storage disabled');
+      },
+    };
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET' });
+      if (url === '/api/wm-session') return anonymousSessionResponse();
+      return { ok: true, status: 200, json: async () => ({ url }) };
+    };
+
+    await requestLiveJson('/api/one', { fetchImpl, preflightSession: true });
+    await requestLiveJson('/api/two', { fetchImpl, preflightSession: true });
+    assert.deepEqual(calls.map(({ url }) => url), [
+      '/api/wm-session',
+      '/api/one',
+      '/api/two',
+    ]);
+  });
+
+  it('refreshes a stored session after a protected request returns 401', async () => {
+    globalThis.sessionStorage.setItem(
+      'wm-session-exp',
+      JSON.stringify({ exp: Date.now() + 60 * 60 * 1000 }),
+    );
+    const calls = [];
+    const responses = [
+      { ok: false, status: 401 },
+      anonymousSessionResponse(),
+      { ok: true, status: 200, json: async () => ({ value: 42 }) },
+    ];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET' });
+      return responses.shift();
+    };
+
+    assert.deepEqual(
+      await requestLiveJson('/api/example', { fetchImpl, preflightSession: true }),
+      { value: 42 },
+    );
+    assert.deepEqual(calls, [
+      { url: '/api/example', method: 'GET' },
+      { url: '/api/wm-session', method: 'POST' },
+      { url: '/api/example', method: 'GET' },
+    ]);
+  });
+
+  it('does not send a session-gated live request when session minting fails', async () => {
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET', credentials: options.credentials });
+      return { ok: false, status: 503 };
+    };
+
+    await assert.rejects(
+      requestLiveJson('/api/example', { fetchImpl, preflightSession: true }),
+      /Anonymous session request failed \(503\)/,
+    );
+    assert.deepEqual(calls, [
+      { url: '/api/wm-session', method: 'POST', credentials: 'include' },
+    ]);
+  });
+
+  it('coalesces concurrent session preflights before protected request fan-out', async () => {
+    const calls = [];
+    let releaseSession;
+    const sessionResponse = new Promise((resolve) => {
+      releaseSession = resolve;
+    });
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET', credentials: options.credentials });
+      if (url === '/api/wm-session') return sessionResponse;
+      return { ok: true, status: 200, json: async () => ({ url }) };
+    };
+
+    const requests = [
+      requestLiveJson('/api/one', { fetchImpl, preflightSession: true }),
+      requestLiveJson('/api/two', { fetchImpl, preflightSession: true }),
+    ];
+    await Promise.resolve();
+    assert.equal(
+      calls.filter(({ url }) => url === '/api/wm-session').length,
+      1,
+      'concurrent protected calls should share one session mint',
+    );
+
+    releaseSession(anonymousSessionResponse());
+    assert.deepEqual(await Promise.all(requests), [
+      { url: '/api/one' },
+      { url: '/api/two' },
+    ]);
+    assert.deepEqual(calls.map(({ url }) => url), [
+      '/api/wm-session',
+      '/api/one',
+      '/api/two',
+    ]);
+  });
+
+  it('does not remint for a late 401 after another request refreshed the session', async () => {
+    let resolveFirst;
+    let resolveSecond;
+    const firstResponse = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondResponse = new Promise((resolve) => {
+      resolveSecond = resolve;
+    });
+    let resolveFirstRetryStarted;
+    const firstRetryStarted = new Promise((resolve) => {
+      resolveFirstRetryStarted = resolve;
+    });
+    const calls = [];
+    const requestCounts = new Map();
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, method: options.method || 'GET' });
+      if (url === '/api/wm-session') return anonymousSessionResponse();
+      const count = (requestCounts.get(url) || 0) + 1;
+      requestCounts.set(url, count);
+      if (count > 1) {
+        if (url === '/api/one') resolveFirstRetryStarted();
+        return { ok: true, status: 200, json: async () => ({ url }) };
+      }
+      return url === '/api/one' ? firstResponse : secondResponse;
+    };
+
+    const requests = [
+      requestLiveJson('/api/one', { fetchImpl, preflightSession: true }),
+      requestLiveJson('/api/two', { fetchImpl, preflightSession: true }),
+    ];
+    await Promise.resolve();
+    resolveFirst({ ok: false, status: 401 });
+    await firstRetryStarted;
+    resolveSecond({ ok: false, status: 401 });
+    assert.deepEqual(await Promise.all(requests), [
+      { url: '/api/one' },
+      { url: '/api/two' },
+    ]);
+    assert.equal(
+      calls.filter(({ url }) => url === '/api/wm-session').length,
+      2,
+      'the late 401 should reuse the newer session generation',
+    );
+  });
+
   it('mints an anonymous session after a 401 and retries the original request once', async () => {
     const calls = [];
     const responses = [
       { ok: false, status: 401 },
-      { ok: true, status: 200 },
+      anonymousSessionResponse(),
       { ok: true, status: 200, json: async () => ({ value: 42 }) },
     ];
     const fetchImpl = async (url, options) => {


### PR DESCRIPTION
## Summary

DebugBear and Lighthouse currently record an initial `401` from protected crawlable live tools before the page mints its anonymous browser session, producing console errors and dropping Best Practices from 100 to 96. Protected country-risk, chokepoint, crisis, airport, and military-flight requests now establish the session first, while the public natural-events request stays unchanged.

Successful sessions reuse the existing `wm-session-exp` freshness contract, including an in-memory fallback when browser storage is restricted. The retained `401` recovery path refreshes expired or rejected cookies once, and a generation guard prevents late concurrent failures from consuming another session issuance.

## Validation

- `node --test tests/crawlable-live-tools.test.mjs` — 18 passed
- `TMPDIR=/private/tmp ./node_modules/.bin/tsx --test tests/crawlable-corpus.test.mjs` — 2 passed
- `npm run typecheck`
- Biome check on all three changed files
- `git diff --check`

## Post-deploy monitoring

- Re-run DebugBear on `/chokepoints/strait-of-hormuz` and `/countries/uk`; expect no console `401`, live state `API result`, and Lighthouse Best Practices restored to 100.
- Watch `/api/wm-session` for `429`/`503` and the protected routes for `auth_401` during the first 24 hours.
- Revert this commit if first-load `401`s persist, live tools stop resolving, or session issuance rises unexpectedly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
