### PR TITLE
fix(activation): land outcome tracking on main

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -5209,6 +5209,250 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     expect(rows).toEqual([]);
   });
 
+  test("recordProActivationOutcome persists monotonic progress and freezes the finalized outcome", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_outcome",
+    });
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "device-a" },
+    );
+
+    const progressed = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: ["alerts"],
+        failedSteps: ["power"],
+        revision: 1,
+        finalized: false,
+      },
+    );
+    expect(progressed).toBe(true);
+
+    const progressRow = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(progressRow?.presentedAt).toBeTypeOf("number");
+    expect(progressRow?.outcomeRevision).toBe(1);
+    expect(progressRow?.exitedAt).toBeUndefined();
+
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: [],
+        skippedSteps: ["brief", "alerts", "power"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    )).toBe(false);
+
+    const afterStaleWrite = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(afterStaleWrite?.confirmedSteps).toEqual(["brief"]);
+    expect(afterStaleWrite?.failedSteps).toEqual(["power"]);
+
+    const before = Date.now();
+    const finalized = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief", "power"],
+        skippedSteps: ["alerts"],
+        failedSteps: [],
+        revision: 2,
+        finalized: true,
+      },
+    );
+    expect(finalized).toBe(true);
+
+    const row = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(row?.confirmedSteps).toEqual(["brief", "power"]);
+    expect(row?.skippedSteps).toEqual(["alerts"]);
+    expect(row?.failedSteps).toEqual([]);
+    expect(row?.outcomeRevision).toBe(2);
+    expect(row?.exitedAt).toBeGreaterThanOrEqual(before);
+
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: [],
+        skippedSteps: ["brief", "alerts", "power"],
+        failedSteps: [],
+        revision: 3,
+        finalized: true,
+      },
+    )).toBe(false);
+  });
+
+  test("recordProActivationOutcome no-ops on a claimNonce mismatch, another user's row, or a never-claimed subscription", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_outcome_guard",
+    });
+
+    // No presentation row exists yet -- never claimed.
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: [],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: true,
+      },
+    )).toBe(false);
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "device-a" },
+    );
+
+    // Wrong nonce.
+    expect(await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "wrong-nonce",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: true,
+      },
+    )).toBe(false);
+
+    // Different user.
+    const otherIdentity = {
+      subject: "user_activation_outcome_other",
+      tokenIdentifier: "clerk|user_activation_outcome_other",
+    };
+    expect(await t.withIdentity(otherIdentity).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: true,
+      },
+    )).toBe(false);
+
+    const row = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(row?.confirmedSteps).toBeUndefined();
+    expect(row?.exitedAt).toBeUndefined();
+  });
+
+  test("recordProActivationOutcome rejects invalid revisions, unknown steps, duplicates, and overlaps", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_outcome_validation",
+    });
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "device-a" },
+    );
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 0,
+        finalized: false,
+      },
+    )).rejects.toThrow(/integer from 1 to 4/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 5,
+        finalized: false,
+      },
+    )).rejects.toThrow(/integer from 1 to 4/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief"],
+        skippedSteps: ["brief"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    )).rejects.toThrow(/disjoint/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["brief", "brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    )).rejects.toThrow(/disjoint/);
+
+    await expect(t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "device-a",
+        confirmedSteps: ["unknown"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      } as never,
+    )).rejects.toThrow();
+  });
+
   test("a disabled alert rule with a verified channel stays onboarding-eligible", async () => {
     const t = convexTest(schema, modules);
     const activationKey = await seedSubscription(t, {

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -5008,6 +5008,11 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
       api.payments.billing.confirmProActivationPresentation,
       { activationKey, claimNonce: "device-a" },
     )).toBe(true);
+    const legacyPresentation = await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .unique());
+    expect(legacyPresentation?.outcomeTrackingVersion).toBeUndefined();
     const afterConfirmation = await t
       .withIdentity(IDENTITY)
       .query(api.payments.billing.getSubscriptionForUser, {});
@@ -5037,20 +5042,22 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     expect(await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.confirmProActivationPresentation,
-      { activationKey, claimNonce: "device-a" },
+      { activationKey, claimNonce: "device-a", outcomeTrackingVersion: 1 },
     )).toBe(true);
-    const firstPresentedAt = (await t.run(async (ctx) => await ctx.db
+    const firstPresentation = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
       .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
-      .unique()))!.presentedAt;
+      .unique());
+    const firstPresentedAt = firstPresentation!.presentedAt;
     expect(firstPresentedAt).toBeDefined();
+    expect(firstPresentation?.outcomeTrackingVersion).toBe(1);
 
     // A retried confirm call (e.g. a client that timed out but the server
     // call actually succeeded) must still return true and must not clobber
     // the original presentedAt timestamp.
     expect(await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.confirmProActivationPresentation,
-      { activationKey, claimNonce: "device-a" },
+      { activationKey, claimNonce: "device-a", outcomeTrackingVersion: 1 },
     )).toBe(true);
     const secondPresentedAt = (await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
@@ -5242,6 +5249,7 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
       .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
       .unique());
     expect(progressRow?.presentedAt).toBeTypeOf("number");
+    expect(progressRow?.outcomeTrackingVersion).toBe(1);
     expect(progressRow?.outcomeRevision).toBe(1);
     expect(progressRow?.exitedAt).toBeUndefined();
 

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -28,6 +28,12 @@ export const digestModeValidator = v.union(
   v.literal("weekly"),
 );
 
+export const proActivationStepIdValidator = v.union(
+  v.literal("brief"),
+  v.literal("alerts"),
+  v.literal("power"),
+);
+
 export const CURRENT_PREFS_SCHEMA_VERSION = 1;
 
 export const MAX_PREFS_BLOB_SIZE = 65536;

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -19,6 +19,7 @@ import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
 import { PLAN_PRECEDENCE, PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
+import { proActivationStepId } from "../schema";
 import {
   isCoveringAt,
   isNewerEvent,
@@ -734,12 +735,11 @@ export const confirmProActivationPresentation = mutation({
   },
 });
 
-const proActivationStepIdValidator = v.union(
-  v.literal("brief"),
-  v.literal("alerts"),
-  v.literal("power"),
-);
-const MAX_PRO_ACTIVATION_OUTCOME_REVISION = 4;
+// One progress write per step plus one final write on exit -- derived so a
+// future step added to buildActivationSteps (pro-activation-state.ts) can't
+// silently desync this cap from the step union it's meant to bound (review
+// finding: the two were previously independent hardcoded literals).
+const MAX_PRO_ACTIVATION_OUTCOME_REVISION = proActivationStepId.members.length + 1;
 
 /**
  * Persist a monotonic snapshot of the wizard outcome (#5582). Progress writes
@@ -751,9 +751,9 @@ export const recordProActivationOutcome = mutation({
   args: {
     activationKey: v.id("subscriptions"),
     claimNonce: v.string(),
-    confirmedSteps: v.array(proActivationStepIdValidator),
-    skippedSteps: v.array(proActivationStepIdValidator),
-    failedSteps: v.array(proActivationStepIdValidator),
+    confirmedSteps: v.array(proActivationStepId),
+    skippedSteps: v.array(proActivationStepId),
+    failedSteps: v.array(proActivationStepId),
     revision: v.number(),
     finalized: v.boolean(),
   },
@@ -786,8 +786,13 @@ export const recordProActivationOutcome = mutation({
       ...args.skippedSteps,
       ...args.failedSteps,
     ];
-    if (allSteps.length > 3 || new Set(allSteps).size !== allSteps.length) {
-      throw new ConvexError("activation outcome buckets must be disjoint and contain at most three steps");
+    if (
+      allSteps.length > proActivationStepId.members.length ||
+      new Set(allSteps).size !== allSteps.length
+    ) {
+      throw new ConvexError(
+        `activation outcome buckets must be disjoint and contain at most ${proActivationStepId.members.length} steps`,
+      );
     }
     if (args.revision <= (presentation.outcomeRevision ?? 0)) {
       return false;

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -19,7 +19,7 @@ import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
 import { PLAN_PRECEDENCE, PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
-import { proActivationStepId } from "../schema";
+import { proActivationStepIdValidator } from "../constants";
 import {
   isCoveringAt,
   isNewerEvent,
@@ -735,11 +735,11 @@ export const confirmProActivationPresentation = mutation({
   },
 });
 
-// One progress write per step plus one final write on exit -- derived so a
-// future step added to buildActivationSteps (pro-activation-state.ts) can't
-// silently desync this cap from the step union it's meant to bound (review
-// finding: the two were previously independent hardcoded literals).
-const MAX_PRO_ACTIVATION_OUTCOME_REVISION = proActivationStepId.members.length + 1;
+// One progress write per allowed step plus one final write on exit. Keep the
+// cap derived from the same validator used by the mutation and schema so their
+// accepted step set cannot drift from this bound.
+const MAX_PRO_ACTIVATION_OUTCOME_REVISION =
+  proActivationStepIdValidator.members.length + 1;
 
 /**
  * Persist a monotonic snapshot of the wizard outcome (#5582). Progress writes
@@ -751,9 +751,9 @@ export const recordProActivationOutcome = mutation({
   args: {
     activationKey: v.id("subscriptions"),
     claimNonce: v.string(),
-    confirmedSteps: v.array(proActivationStepId),
-    skippedSteps: v.array(proActivationStepId),
-    failedSteps: v.array(proActivationStepId),
+    confirmedSteps: v.array(proActivationStepIdValidator),
+    skippedSteps: v.array(proActivationStepIdValidator),
+    failedSteps: v.array(proActivationStepIdValidator),
     revision: v.number(),
     finalized: v.boolean(),
   },
@@ -787,11 +787,11 @@ export const recordProActivationOutcome = mutation({
       ...args.failedSteps,
     ];
     if (
-      allSteps.length > proActivationStepId.members.length ||
+      allSteps.length > proActivationStepIdValidator.members.length ||
       new Set(allSteps).size !== allSteps.length
     ) {
       throw new ConvexError(
-        `activation outcome buckets must be disjoint and contain at most ${proActivationStepId.members.length} steps`,
+        `activation outcome buckets must be disjoint and contain at most ${proActivationStepIdValidator.members.length} steps`,
       );
     }
     if (args.revision <= (presentation.outcomeRevision ?? 0)) {

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -718,6 +718,79 @@ export const confirmProActivationPresentation = mutation({
   },
 });
 
+const proActivationStepIdValidator = v.union(
+  v.literal("brief"),
+  v.literal("alerts"),
+  v.literal("power"),
+);
+const MAX_PRO_ACTIVATION_OUTCOME_REVISION = 4;
+
+/**
+ * Persist a monotonic snapshot of the wizard outcome (#5582). Progress writes
+ * happen as steps resolve so a lost exit cannot censor disengaged sessions;
+ * the final write sets `exitedAt` and freezes the record. Invalid,
+ * overlapping, stale, and replayed classifications are rejected.
+ */
+export const recordProActivationOutcome = mutation({
+  args: {
+    activationKey: v.id("subscriptions"),
+    claimNonce: v.string(),
+    confirmedSteps: v.array(proActivationStepIdValidator),
+    skippedSteps: v.array(proActivationStepIdValidator),
+    failedSteps: v.array(proActivationStepIdValidator),
+    revision: v.number(),
+    finalized: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireUserId(ctx);
+    const presentation = await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.activationKey))
+      .first();
+    if (
+      presentation === null ||
+      presentation.userId !== userId ||
+      presentation.claimNonce !== args.claimNonce ||
+      presentation.exitedAt !== undefined
+    ) {
+      return false;
+    }
+
+    if (
+      !Number.isSafeInteger(args.revision) ||
+      args.revision < 1 ||
+      args.revision > MAX_PRO_ACTIVATION_OUTCOME_REVISION
+    ) {
+      throw new ConvexError(
+        `activation outcome revision must be an integer from 1 to ${MAX_PRO_ACTIVATION_OUTCOME_REVISION}`,
+      );
+    }
+    const allSteps = [
+      ...args.confirmedSteps,
+      ...args.skippedSteps,
+      ...args.failedSteps,
+    ];
+    if (allSteps.length > 3 || new Set(allSteps).size !== allSteps.length) {
+      throw new ConvexError("activation outcome buckets must be disjoint and contain at most three steps");
+    }
+    if (args.revision <= (presentation.outcomeRevision ?? 0)) {
+      return false;
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(presentation._id, {
+      confirmedSteps: args.confirmedSteps,
+      skippedSteps: args.skippedSteps,
+      failedSteps: args.failedSteps,
+      outcomeRevision: args.revision,
+      outcomeUpdatedAt: now,
+      ...(presentation.presentedAt === undefined ? { presentedAt: now } : {}),
+      ...(args.finalized ? { exitedAt: now } : {}),
+    });
+    return true;
+  },
+});
+
 /**
  * Internal query to retrieve a customer record by userId.
  *

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -692,11 +692,16 @@ export const claimProActivationPresentation = mutation({
   },
 });
 
+const PRO_ACTIVATION_OUTCOME_TRACKING_VERSION = 1 as const;
+
 /** Confirm that the browser holding the claim actually rendered the flow. */
 export const confirmProActivationPresentation = mutation({
   args: {
     activationKey: v.id("subscriptions"),
     claimNonce: v.string(),
+    // Optional for mixed deploys: legacy clients can still confirm presentation
+    // without marking their row as outcome-aware.
+    outcomeTrackingVersion: v.optional(v.literal(1)),
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
@@ -711,8 +716,19 @@ export const confirmProActivationPresentation = mutation({
     ) {
       return false;
     }
-    if (presentation.presentedAt === undefined) {
-      await ctx.db.patch(presentation._id, { presentedAt: Date.now() });
+    if (
+      presentation.presentedAt === undefined ||
+      (
+        args.outcomeTrackingVersion === PRO_ACTIVATION_OUTCOME_TRACKING_VERSION &&
+        presentation.outcomeTrackingVersion !== PRO_ACTIVATION_OUTCOME_TRACKING_VERSION
+      )
+    ) {
+      await ctx.db.patch(presentation._id, {
+        ...(presentation.presentedAt === undefined ? { presentedAt: Date.now() } : {}),
+        ...(args.outcomeTrackingVersion === PRO_ACTIVATION_OUTCOME_TRACKING_VERSION
+          ? { outcomeTrackingVersion: PRO_ACTIVATION_OUTCOME_TRACKING_VERSION }
+          : {}),
+      });
     }
     return true;
   },
@@ -784,6 +800,7 @@ export const recordProActivationOutcome = mutation({
       failedSteps: args.failedSteps,
       outcomeRevision: args.revision,
       outcomeUpdatedAt: now,
+      outcomeTrackingVersion: PRO_ACTIVATION_OUTCOME_TRACKING_VERSION,
       ...(presentation.presentedAt === undefined ? { presentedAt: now } : {}),
       ...(args.finalized ? { exitedAt: now } : {}),
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,12 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { channelTypeValidator, digestModeValidator, quietHoursOverrideValidator, sensitivityValidator } from "./constants";
+import {
+  channelTypeValidator,
+  digestModeValidator,
+  proActivationStepIdValidator,
+  quietHoursOverrideValidator,
+  sensitivityValidator,
+} from "./constants";
 
 // Subscription status enum — maps Dodo statuses to our internal set
 const subscriptionStatus = v.union(
@@ -53,12 +59,6 @@ const apiPlanLimitCtaKind = v.union(
   v.literal("billing_portal"),
   v.literal("contact_support"),
   v.literal("none"),
-);
-
-export const proActivationStepId = v.union(
-  v.literal("brief"),
-  v.literal("alerts"),
-  v.literal("power"),
 );
 
 export default defineSchema({
@@ -655,9 +655,9 @@ export default defineSchema({
     // excludes rows created before #5582 without losing post-deploy sessions
     // that abandon the flow before their first progress snapshot.
     outcomeTrackingVersion: v.optional(v.literal(1)),
-    confirmedSteps: v.optional(v.array(proActivationStepId)),
-    skippedSteps: v.optional(v.array(proActivationStepId)),
-    failedSteps: v.optional(v.array(proActivationStepId)),
+    confirmedSteps: v.optional(v.array(proActivationStepIdValidator)),
+    skippedSteps: v.optional(v.array(proActivationStepIdValidator)),
+    failedSteps: v.optional(v.array(proActivationStepIdValidator)),
     outcomeRevision: v.optional(v.number()),
     outcomeUpdatedAt: v.optional(v.number()),
     exitedAt: v.optional(v.number()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -651,6 +651,10 @@ export default defineSchema({
     claimNonce: v.string(),
     claimedAt: v.number(),
     presentedAt: v.optional(v.number()),
+    // Set when a presentation is confirmed by an outcome-aware client. This
+    // excludes rows created before #5582 without losing post-deploy sessions
+    // that abandon the flow before their first progress snapshot.
+    outcomeTrackingVersion: v.optional(v.literal(1)),
     confirmedSteps: v.optional(v.array(proActivationStepId)),
     skippedSteps: v.optional(v.array(proActivationStepId)),
     failedSteps: v.optional(v.array(proActivationStepId)),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -55,7 +55,7 @@ const apiPlanLimitCtaKind = v.union(
   v.literal("none"),
 );
 
-const proActivationStepId = v.union(
+export const proActivationStepId = v.union(
   v.literal("brief"),
   v.literal("alerts"),
   v.literal("power"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -55,6 +55,12 @@ const apiPlanLimitCtaKind = v.union(
   v.literal("none"),
 );
 
+const proActivationStepId = v.union(
+  v.literal("brief"),
+  v.literal("alerts"),
+  v.literal("power"),
+);
+
 export default defineSchema({
   userPreferences: defineTable({
     userId: v.string(),
@@ -634,12 +640,23 @@ export default defineSchema({
   // Cross-device single-presentation lease for markerless Pro activation.
   // A short pending claim closes concurrent mount races without permanently
   // suppressing onboarding when a browser crashes before rendering the flow.
+  //
+  // The outcome buckets mirror ActivationStepOutcome
+  // (pro-activation-state.ts). They are updated as the subscriber acts so a
+  // tab close cannot erase engagement, then frozen when `exitedAt` is set.
+  // `outcomeRevision` rejects late/out-of-order best-effort writes.
   proActivationPresentations: defineTable({
     userId: v.string(),
     subscriptionId: v.id("subscriptions"),
     claimNonce: v.string(),
     claimedAt: v.number(),
     presentedAt: v.optional(v.number()),
+    confirmedSteps: v.optional(v.array(proActivationStepId)),
+    skippedSteps: v.optional(v.array(proActivationStepId)),
+    failedSteps: v.optional(v.array(proActivationStepId)),
+    outcomeRevision: v.optional(v.number()),
+    outcomeUpdatedAt: v.optional(v.number()),
+    exitedAt: v.optional(v.number()),
   })
     .index("by_subscription", ["subscriptionId"]),
 

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -60,6 +60,18 @@ interface CapturedProEvent {
   };
 }
 
+interface CapturedOutcomeCall {
+  activationKey: string;
+  claimNonce: string;
+  outcome: {
+    confirmedSteps: string[];
+    skippedSteps: string[];
+    failedSteps: string[];
+    revision: number;
+    finalized: boolean;
+  };
+}
+
 async function gotoHarness(page: Page): Promise<void> {
   await page.goto('/tests/runtime-harness.html');
 }
@@ -123,6 +135,12 @@ async function readCapturedEvents(page: Page): Promise<CapturedProEvent[]> {
   return page.evaluate(() => (window as unknown as { __proEvents: CapturedProEvent[] }).__proEvents);
 }
 
+async function readCapturedOutcomes(page: Page): Promise<CapturedOutcomeCall[]> {
+  return page.evaluate(
+    () => (window as unknown as { __proOutcomeCalls: CapturedOutcomeCall[] }).__proOutcomeCalls,
+  );
+}
+
 type ClaimStatus = 'claimed' | 'not_eligible' | 'already_presented' | 'already_claimed';
 
 async function runMarkerlessFlowHarness(
@@ -141,6 +159,8 @@ async function runMarkerlessFlowHarness(
     const { initI18n } = await import('/src/services/i18n.ts');
     await initI18n();
     const mod = await import('/src/components/ProActivationInterstitial.ts');
+    const w = window as unknown as { __proOutcomeCalls: CapturedOutcomeCall[] };
+    w.__proOutcomeCalls = [];
     let ownerChecks = 0;
     let claimCalls = 0;
     let confirmCalls = 0;
@@ -188,6 +208,10 @@ async function runMarkerlessFlowHarness(
           }
           return scenario.confirmResult !== false;
         },
+        recordOutcome: async (activationKey, claimNonce, outcome) => {
+          w.__proOutcomeCalls.push({ activationKey, claimNonce, outcome });
+          return true;
+        },
         operationTimeoutMs: 20,
       },
     );
@@ -207,6 +231,7 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     });
     expect(result).toEqual({ result: 'retry', claimCalls: 0, confirmCalls: 0 });
     await expect(page.locator(OVERLAY)).toHaveCount(0);
+    expect(await readCapturedOutcomes(page)).toEqual([]);
   });
 
   test('a stalled claim reaches the controller retry path within its deadline', async ({ page }) => {
@@ -246,6 +271,41 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     await expect(page.locator(OVERLAY)).toBeVisible();
   });
 
+  test('markerless progress and final exit persist exact lease-bound outcome snapshots', async ({ page }) => {
+    const result = await runMarkerlessFlowHarness(page, { claimStatus: 'claimed' });
+    expect(result).toEqual({ result: 'opened', claimCalls: 1, confirmCalls: 1 });
+
+    await page.locator('.pro-activation-close').click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+    await page.locator(FINISH_BTN).click();
+
+    await expect.poll(async () => (await readCapturedOutcomes(page)).length).toBe(2);
+    expect(await readCapturedOutcomes(page)).toEqual([
+      {
+        activationKey: 'opaque-subscription',
+        claimNonce: 'tab-nonce',
+        outcome: {
+          confirmedSteps: [],
+          skippedSteps: ['brief', 'power'],
+          failedSteps: [],
+          revision: 1,
+          finalized: false,
+        },
+      },
+      {
+        activationKey: 'opaque-subscription',
+        claimNonce: 'tab-nonce',
+        outcome: {
+          confirmedSteps: [],
+          skippedSteps: ['brief', 'power'],
+          failedSteps: [],
+          revision: 2,
+          finalized: true,
+        },
+      },
+    ]);
+  });
+
   test('lost confirmation ownership closes the flow and remains retryable', async ({ page }) => {
     const result = await runMarkerlessFlowHarness(page, {
       claimStatus: 'claimed',
@@ -283,6 +343,7 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     });
     expect(result).toEqual({ result: 'retry', claimCalls: 1, confirmCalls: 0 });
     await expect(page.locator(OVERLAY)).toHaveCount(0);
+    expect(await readCapturedOutcomes(page)).toEqual([]);
   });
 });
 

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -141,6 +141,12 @@ async function readCapturedOutcomes(page: Page): Promise<CapturedOutcomeCall[]> 
   );
 }
 
+async function readOutcomeAttempts(page: Page): Promise<number> {
+  return page.evaluate(
+    () => (window as unknown as { __proOutcomeAttempts: number }).__proOutcomeAttempts,
+  );
+}
+
 type ClaimStatus = 'claimed' | 'not_eligible' | 'already_presented' | 'already_claimed';
 
 async function runMarkerlessFlowHarness(
@@ -153,14 +159,19 @@ async function runMarkerlessFlowHarness(
     confirmResult?: boolean;
     confirmFailures?: number;
     neverResolveClaim?: boolean;
+    outcomeAlwaysFails?: boolean;
   },
 ): Promise<{ result: string; claimCalls: number; confirmCalls: number }> {
   return await page.evaluate(async (scenario) => {
     const { initI18n } = await import('/src/services/i18n.ts');
     await initI18n();
     const mod = await import('/src/components/ProActivationInterstitial.ts');
-    const w = window as unknown as { __proOutcomeCalls: CapturedOutcomeCall[] };
+    const w = window as unknown as {
+      __proOutcomeCalls: CapturedOutcomeCall[];
+      __proOutcomeAttempts: number;
+    };
     w.__proOutcomeCalls = [];
+    w.__proOutcomeAttempts = 0;
     let ownerChecks = 0;
     let claimCalls = 0;
     let confirmCalls = 0;
@@ -209,6 +220,10 @@ async function runMarkerlessFlowHarness(
           return scenario.confirmResult !== false;
         },
         recordOutcome: async (activationKey, claimNonce, outcome) => {
+          w.__proOutcomeAttempts += 1;
+          if (scenario.outcomeAlwaysFails) {
+            throw new Error('record outcome transport failed');
+          }
           w.__proOutcomeCalls.push({ activationKey, claimNonce, outcome });
           return true;
         },
@@ -304,6 +319,39 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
         },
       },
     ]);
+  });
+
+  test('outcome-write retries exhaust and give up without blocking the flow', async ({ page }) => {
+    // persistActivationOutcomeWithRetry doesn't distinguish transport errors
+    // from permanent rejections -- every failure gets the same bounded
+    // retry-then-give-up treatment (OUTCOME_WRITE_RETRY_DELAYS_MS = [250, 750]).
+    // This locks in that give-up behavior: no test previously exercised a
+    // recordOutcome call that fails every attempt.
+    const opened = await runMarkerlessFlowHarness(page, {
+      claimStatus: 'claimed',
+      outcomeAlwaysFails: true,
+    });
+    expect(opened.result).toBe('opened');
+
+    // finalizeAndShowSummary fires exactly one recordProgress() call
+    // (revision 1, finalized: false).
+    await page.locator('.pro-activation-close').click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+
+    // 1 initial attempt + 2 scheduled retries = 3 attempts, then the
+    // fire-and-forget loop gives up (console.warn) instead of retrying
+    // forever or throwing an unhandled rejection.
+    await expect.poll(() => readOutcomeAttempts(page), { timeout: 5_000 }).toBe(3);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(await readOutcomeAttempts(page)).toBe(3);
+
+    // Every attempt failed, so nothing was ever durably captured.
+    expect(await readCapturedOutcomes(page)).toEqual([]);
+
+    // The best-effort write failing never blocks the UI: the summary is
+    // still interactive and finishing closes normally.
+    await page.locator(FINISH_BTN).click();
+    await expect(page.locator(OVERLAY)).toHaveCount(0);
   });
 
   test('lost confirmation ownership closes the flow and remains retryable', async ({ page }) => {

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -336,6 +336,97 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     await expect(page.locator(OVERLAY)).toHaveCount(0);
   });
 
+  test('interstitial stays unmounted while confirmation is pending, so a lost claim cannot leave a stray outcome write', async ({ page }) => {
+    // Regression test for a presentedAt race (review of #5584/#5590):
+    // openProActivationFlow used to open the interstitial (wiring
+    // onProgress/onExit to recordProActivationOutcome) BEFORE awaiting
+    // confirmPresentationWithRetry. If a step got interacted with in that
+    // window and confirm then failed, recordProActivationOutcome's own
+    // presentedAt backfill had already fired, permanently blocking a
+    // legitimate re-claim via claimProActivationPresentation's
+    // already_presented check -- even though the server never acknowledged
+    // this presentation. The interstitial must not exist (and therefore
+    // cannot record an outcome) until confirm actually succeeds.
+    await page.evaluate(async () => {
+      const { initI18n } = await import('/src/services/i18n.ts');
+      await initI18n();
+      const mod = await import('/src/components/ProActivationInterstitial.ts');
+      const w = window as unknown as {
+        __resolveProConfirm?: (ok: boolean) => void;
+        __flowResult?: Promise<string>;
+        __proOutcomeCalls: CapturedOutcomeCall[];
+      };
+      w.__proOutcomeCalls = [];
+      const context = {
+        config: {
+          hasVerifiedEmailChannel: false,
+          hasEmailDelivery: false,
+          hasEnabledDigestRule: false,
+          hasTunedDigestHour: false,
+          hasWebPushChannel: false,
+          hasWebPushDelivery: false,
+          hasUsedPowerFeature: false,
+        },
+        capabilities: { webPushSupported: false },
+        channels: [],
+        channelsKnown: true,
+        hasEnabledRule: false,
+      };
+      // Deliberately never resolves on its own -- held open so the test can
+      // assert on interstitial state while confirm is genuinely in flight,
+      // then resolve it explicitly to drive the failure path.
+      w.__flowResult = mod.openProActivationFlow(
+        {
+          accountUserId: 'markerless-user',
+          accountEmail: 'markerless@worldmonitor.app',
+          onlyIfUnactivated: true,
+          expectedActivationKey: 'opaque-subscription',
+          activationClaimNonce: 'tab-nonce',
+          isAccountCurrent: () => true,
+        },
+        {
+          readContext: async () => context,
+          claimPresentation: async () => 'claimed',
+          confirmPresentation: () =>
+            new Promise<boolean>((resolve) => {
+              w.__resolveProConfirm = resolve;
+            }),
+          recordOutcome: async (activationKey, claimNonce, outcome) => {
+            w.__proOutcomeCalls.push({ activationKey, claimNonce, outcome });
+            return true;
+          },
+          // Large enough that withTimeout never races the manual resolve below.
+          operationTimeoutMs: 20_000,
+        },
+      );
+    });
+
+    // Confirm is still pending: the interstitial must not be mounted, so
+    // there is no onProgress/onConfirmStep handler a (simulated) click could
+    // reach, and no way for a recordOutcome write to fire yet.
+    await page.waitForTimeout(100);
+    await expect(page.locator(OVERLAY)).toHaveCount(0);
+
+    // Server rejects the claim (lost ownership) -- the real failure mode this
+    // guards against.
+    await page.evaluate(() => {
+      (
+        window as unknown as { __resolveProConfirm?: (ok: boolean) => void }
+      ).__resolveProConfirm?.(false);
+    });
+
+    const result = await page.evaluate(
+      () => (window as unknown as { __flowResult: Promise<string> }).__flowResult,
+    );
+    expect(result).toBe('retry');
+    await expect(page.locator(OVERLAY)).toHaveCount(0);
+
+    const outcomeCalls = await page.evaluate(
+      () => (window as unknown as { __proOutcomeCalls: CapturedOutcomeCall[] }).__proOutcomeCalls,
+    );
+    expect(outcomeCalls).toEqual([]);
+  });
+
   test('account switch after claim retries without opening or confirming', async ({ page }) => {
     const result = await runMarkerlessFlowHarness(page, {
       claimStatus: 'claimed',

--- a/scripts/report-activation-lift.mjs
+++ b/scripts/report-activation-lift.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * Compare downstream Pro-feature adoption between subscribers who confirmed
+ * at least one activation-wizard step and subscribers who confirmed none.
+ *
+ * Every shown presentation stays in the cohort. Its observation window starts
+ * at the durable exit when present, otherwise the latest persisted progress,
+ * otherwise `presentedAt` for a no-action abandonment. This avoids both
+ * lost-exit censorship and counting the wizard's own writes as downstream
+ * adoption.
+ * Only presentations with a complete observation window are analyzed, and a
+ * verdict is refused when any newest-first Convex export may be truncated.
+ *
+ * Usage:
+ *   1. Source prod env: `set -a; source <main-repo>/.env.local; set +a`
+ *      Required: CONVEX_DEPLOY_KEY, CONVEX_DEPLOYMENT.
+ *   2. `node scripts/report-activation-lift.mjs [--window-days=14] [--limit=20000]`
+ *
+ * Read-only: uses `npx convex data <table>`, never a mutation.
+ */
+
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const FEATURE_TABLES = [
+  "notificationChannels",
+  "alertRules",
+  "userApiKeys",
+  "mcpProTokens",
+];
+export const MIN_GROUP_SIZE_FOR_A_CLAIM = 30;
+export const DEFAULT_EXPORT_TIMEOUT_MS = 60_000;
+
+function parseJsonLines(table, stdout) {
+  try {
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch (error) {
+    throw new Error(
+      `[activation-lift] could not parse the ${table} export: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+export function fetchTable(
+  table,
+  {
+    limit,
+    timeoutMs = DEFAULT_EXPORT_TIMEOUT_MS,
+    runner = spawnSync,
+  },
+) {
+  const result = runner(
+    "npx",
+    ["convex", "data", table, "--limit", String(limit), "--order", "desc", "--format", "jsonl"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 256,
+      timeout: timeoutMs,
+    },
+  );
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(
+      `[activation-lift] npx convex data ${table} timed out after ${timeoutMs}ms`,
+    );
+  }
+  if (result.error || result.status !== 0) {
+    const details = [
+      result.error instanceof Error ? result.error.message : result.error,
+      result.signal ? `signal=${result.signal}` : null,
+      result.stderr,
+      result.stdout,
+    ].filter(Boolean);
+    throw new Error(
+      `[activation-lift] npx convex data ${table} failed${
+        details.length > 0 ? `: ${details.join(" | ")}` : ""
+      }`,
+    );
+  }
+  const rows = parseJsonLines(table, result.stdout ?? "");
+  return { rows, truncated: rows.length >= limit };
+}
+
+function activityTimestamp(table, row) {
+  switch (table) {
+    case "notificationChannels":
+      return row.verified === true ? row.linkedAt : null;
+    case "alertRules":
+      return row.enabled === true ? row.updatedAt : null;
+    case "userApiKeys":
+    case "mcpProTokens":
+      return row.revokedAt === undefined ? row.createdAt : null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build the user index once. The previous implementation filtered every full
+ * table for every presentation (up to 1.6B predicate evaluations at 20k rows).
+ */
+export function indexFeatureRows(featureRowsByTable) {
+  return Object.fromEntries(
+    FEATURE_TABLES.map((table) => {
+      const byUser = new Map();
+      for (const row of featureRowsByTable[table] ?? []) {
+        if (typeof row.userId !== "string") continue;
+        const timestamp = activityTimestamp(table, row);
+        if (typeof timestamp !== "number") continue;
+        const rows = byUser.get(row.userId);
+        if (rows) rows.push(timestamp);
+        else byUser.set(row.userId, [timestamp]);
+      }
+      return [table, byUser];
+    }),
+  );
+}
+
+function summarizeGroup(rows, featureIndex, windowMs) {
+  let anyCount = 0;
+  const perTable = Object.fromEntries(FEATURE_TABLES.map((table) => [table, 0]));
+  for (const presentation of rows) {
+    let any = false;
+    const sinceMs = presentation.observationStartedAt;
+    for (const table of FEATURE_TABLES) {
+      const timestamps = featureIndex[table].get(presentation.userId) ?? [];
+      let count = 0;
+      for (const timestamp of timestamps) {
+        if (timestamp > sinceMs && timestamp <= sinceMs + windowMs) count += 1;
+      }
+      perTable[table] += count;
+      if (count > 0) any = true;
+    }
+    if (any) anyCount += 1;
+  }
+  return {
+    n: rows.length,
+    anyCount,
+    rate: rows.length > 0 ? anyCount / rows.length : 0,
+    perTable,
+  };
+}
+
+export function analyzeActivationLift({
+  presentations,
+  featureRowsByTable,
+  truncatedTables = [],
+  reportNow,
+  windowMs,
+  minGroupSize = MIN_GROUP_SIZE_FOR_A_CLAIM,
+}) {
+  const shown = presentations.filter((row) => typeof row.presentedAt === "number");
+  const observed = shown.map((row) => ({
+    ...row,
+    observationStartedAt:
+      typeof row.exitedAt === "number"
+        ? row.exitedAt
+        : typeof row.outcomeUpdatedAt === "number"
+          ? row.outcomeUpdatedAt
+          : row.presentedAt,
+  }));
+  const mature = observed.filter(
+    (row) => row.observationStartedAt + windowMs <= reportNow,
+  );
+  const immature = observed.filter(
+    (row) => row.observationStartedAt + windowMs > reportNow,
+  );
+  const incompleteExits = mature.filter((row) => typeof row.exitedAt !== "number");
+  const engaged = mature.filter((row) => (row.confirmedSteps?.length ?? 0) > 0);
+  const presentedOnly = mature.filter((row) => (row.confirmedSteps?.length ?? 0) === 0);
+
+  const base = {
+    totalPresentations: presentations.length,
+    shown: shown.length,
+    mature: mature.length,
+    immature: immature.length,
+    incompleteExits: incompleteExits.length,
+    truncatedTables: [...truncatedTables],
+  };
+  if (truncatedTables.length > 0) {
+    return { ...base, verdict: "incomplete-export", engaged: null, presentedOnly: null };
+  }
+
+  const featureIndex = indexFeatureRows(featureRowsByTable);
+  const engagedSummary = summarizeGroup(engaged, featureIndex, windowMs);
+  const presentedOnlySummary = summarizeGroup(presentedOnly, featureIndex, windowMs);
+  if (mature.length === 0) {
+    return {
+      ...base,
+      verdict: "no-mature-outcomes",
+      engaged: engagedSummary,
+      presentedOnly: presentedOnlySummary,
+    };
+  }
+  if (engagedSummary.n < minGroupSize || presentedOnlySummary.n < minGroupSize) {
+    return {
+      ...base,
+      verdict: "below-sample-floor",
+      engaged: engagedSummary,
+      presentedOnly: presentedOnlySummary,
+    };
+  }
+  return {
+    ...base,
+    verdict: "comparison",
+    lift: engagedSummary.rate - presentedOnlySummary.rate,
+    engaged: engagedSummary,
+    presentedOnly: presentedOnlySummary,
+  };
+}
+
+function formatGroup(name, summary, windowDays, minGroupSize) {
+  const lines = [
+    `${name}: n=${summary.n}, adopted >=1 feature within ${windowDays}d: ${summary.anyCount} (${(
+      summary.rate * 100
+    ).toFixed(1)}%)`,
+  ];
+  for (const table of FEATURE_TABLES) {
+    lines.push(`    ${table}: ${summary.perTable[table]} qualifying rows`);
+  }
+  if (summary.n < minGroupSize) {
+    lines.push(
+      `    WARNING: n=${summary.n} is below the ${minGroupSize}-sample verdict floor.`,
+    );
+  }
+  return lines;
+}
+
+export function formatActivationLiftReport(
+  analysis,
+  {
+    windowDays,
+    limit,
+    minGroupSize = MIN_GROUP_SIZE_FOR_A_CLAIM,
+  },
+) {
+  const lines = [
+    `[activation-lift] window=${windowDays}d limit=${limit} per table`,
+    "",
+    `Presentations: ${analysis.totalPresentations} exported, ${analysis.shown} shown, ${analysis.mature} with a complete ${windowDays}d window.`,
+    `  excluded as immature: ${analysis.immature}`,
+    `  mature sessions without a recorded exit: ${analysis.incompleteExits} (included from durable presentation/progress state)`,
+  ];
+
+  if (analysis.verdict === "incomplete-export") {
+    lines.push(
+      "",
+      "--- Verdict ---",
+      `Inconclusive: these exports reached the ${limit}-row cap and may be incomplete: ${analysis.truncatedTables.join(", ")}. Re-run with a higher limit; no adoption rates were computed.`,
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    "",
+    "--- Adoption within the complete window, by engagement ---",
+    ...formatGroup("Engaged", analysis.engaged, windowDays, minGroupSize),
+    ...formatGroup("Presented-only", analysis.presentedOnly, windowDays, minGroupSize),
+    "",
+    "--- Verdict ---",
+  );
+  if (analysis.verdict === "no-mature-outcomes") {
+    lines.push(
+      `No presentations have completed the full ${windowDays}-day observation window yet.`,
+    );
+  } else if (analysis.verdict === "below-sample-floor") {
+    lines.push(
+      "Not enough mature presentations in one or both groups to make a comparison yet.",
+    );
+  } else {
+    lines.push(
+      `Engaged-group adoption rate is ${(analysis.lift * 100).toFixed(1)} percentage points ${
+        analysis.lift >= 0 ? "higher" : "lower"
+      } than presented-only.`,
+      "This is an engagement comparison within one exposed population, not a randomized control; selection effects are not ruled out.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function parsePositiveNumber(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`[activation-lift] --${name} must be a positive number`);
+  }
+  return parsed;
+}
+
+export function runCli(argv = process.argv.slice(2), env = process.env) {
+  if (!env.CONVEX_DEPLOY_KEY || !env.CONVEX_DEPLOYMENT) {
+    throw new Error(
+      "[activation-lift] CONVEX_DEPLOY_KEY and CONVEX_DEPLOYMENT env vars required. " +
+        "Source them from .env.local first (see file header).",
+    );
+  }
+  const args = new Map(
+    argv.map((arg) => {
+      const [key, value] = arg.replace(/^--/, "").split("=");
+      return [key, value ?? true];
+    }),
+  );
+  const windowDays = parsePositiveNumber(args.get("window-days") ?? 14, "window-days");
+  const limit = parsePositiveNumber(args.get("limit") ?? 20_000, "limit");
+  const timeoutMs = parsePositiveNumber(
+    args.get("timeout-ms") ?? DEFAULT_EXPORT_TIMEOUT_MS,
+    "timeout-ms",
+  );
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  const tableNames = ["proActivationPresentations", ...FEATURE_TABLES];
+  const exports = Object.fromEntries(
+    tableNames.map((table) => [table, fetchTable(table, { limit, timeoutMs })]),
+  );
+  const truncatedTables = tableNames.filter((table) => exports[table].truncated);
+  const featureRowsByTable = Object.fromEntries(
+    FEATURE_TABLES.map((table) => [table, exports[table].rows]),
+  );
+  const analysis = analyzeActivationLift({
+    presentations: exports.proActivationPresentations.rows,
+    featureRowsByTable,
+    truncatedTables,
+    reportNow: Date.now(),
+    windowMs,
+  });
+  return formatActivationLiftReport(analysis, { windowDays, limit });
+}
+
+const isMain =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  try {
+    console.log(runCli());
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/report-activation-lift.mjs
+++ b/scripts/report-activation-lift.mjs
@@ -12,9 +12,10 @@
  * verdict is refused when any newest-first Convex export may be truncated.
  *
  * Usage:
- *   1. Source prod env: `set -a; source <main-repo>/.env.local; set +a`
- *      Required: CONVEX_DEPLOY_KEY, CONVEX_DEPLOYMENT.
- *   2. `node scripts/report-activation-lift.mjs [--window-days=14] [--limit=20000]`
+ *   `node --env-file=.env.local scripts/report-activation-lift.mjs
+ *      [--window-days=14] [--limit=20000]`
+ *
+ * Required env: CONVEX_DEPLOY_KEY, CONVEX_DEPLOYMENT.
  *
  * Read-only: uses `npx convex data <table>`, never a mutation.
  */
@@ -154,7 +155,8 @@ export function analyzeActivationLift({
   windowMs,
   minGroupSize = MIN_GROUP_SIZE_FOR_A_CLAIM,
 }) {
-  const shown = presentations.filter((row) => typeof row.presentedAt === "number");
+  const presented = presentations.filter((row) => typeof row.presentedAt === "number");
+  const shown = presented.filter((row) => row.outcomeTrackingVersion === 1);
   const observed = shown.map((row) => ({
     ...row,
     observationStartedAt:
@@ -177,6 +179,7 @@ export function analyzeActivationLift({
   const base = {
     totalPresentations: presentations.length,
     shown: shown.length,
+    uninstrumented: presented.length - shown.length,
     mature: mature.length,
     immature: immature.length,
     incompleteExits: incompleteExits.length,
@@ -242,7 +245,8 @@ export function formatActivationLiftReport(
   const lines = [
     `[activation-lift] window=${windowDays}d limit=${limit} per table`,
     "",
-    `Presentations: ${analysis.totalPresentations} exported, ${analysis.shown} shown, ${analysis.mature} with a complete ${windowDays}d window.`,
+    `Presentations: ${analysis.totalPresentations} exported, ${analysis.shown} outcome-instrumented and shown, ${analysis.mature} with a complete ${windowDays}d window.`,
+    `  excluded as pre-instrumentation: ${analysis.uninstrumented}`,
     `  excluded as immature: ${analysis.immature}`,
     `  mature sessions without a recorded exit: ${analysis.incompleteExits} (included from durable presentation/progress state)`,
   ];
@@ -295,7 +299,7 @@ export function runCli(argv = process.argv.slice(2), env = process.env) {
   if (!env.CONVEX_DEPLOY_KEY || !env.CONVEX_DEPLOYMENT) {
     throw new Error(
       "[activation-lift] CONVEX_DEPLOY_KEY and CONVEX_DEPLOYMENT env vars required. " +
-        "Source them from .env.local first (see file header).",
+        "Run with `node --env-file=.env.local` (see file header).",
     );
   }
   const args = new Map(

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -1289,6 +1289,30 @@ export async function openProActivationFlow(
   }
   const steps = buildActivationSteps(ctx.capabilities, ctx.config);
 
+  options.onEvent?.(ACTIVATION_EVENTS.entered);
+
+  // Confirmed BEFORE the interstitial opens -- and therefore before its
+  // onProgress/onExit handlers exist to fire a recordProActivationOutcome
+  // write -- so a lost claim can never leave a presentedAt side effect from a
+  // step the user was never actually given a chance to interact with. This
+  // used to run after openInterstitial below; if a step got confirmed/skipped
+  // in the window before this awaited call resolved and it then failed here,
+  // recordProActivationOutcome's own presentedAt backfill had already fired,
+  // permanently blocking a legitimate re-claim via
+  // claimProActivationPresentation's already_presented check (review finding,
+  // #5584/#5590).
+  if (
+    options.onlyIfUnactivated &&
+    options.expectedActivationKey &&
+    options.activationClaimNonce
+  ) {
+    if (!(await confirmPresentationWithRetry(options, dependencies))) {
+      // A false result means this browser no longer owns the server claim;
+      // repeated transport errors remain retryable under the short lease.
+      return 'retry';
+    }
+  }
+
   // Holds the brief step's delivery-hour pick across the shell's re-renders.
   const selectedHourRef: DigestHourRef = { hour: null };
 
@@ -1312,8 +1336,6 @@ export async function openProActivationFlow(
       finalized,
     );
   };
-
-  options.onEvent?.(ACTIVATION_EVENTS.entered);
 
   dependencies.openInterstitial({
     steps,
@@ -1362,17 +1384,5 @@ export async function openProActivationFlow(
       if (!isFlowAccountCurrent(options)) closeProActivationInterstitial();
     });
   });
-  if (
-    options.onlyIfUnactivated &&
-    options.expectedActivationKey &&
-    options.activationClaimNonce
-  ) {
-    if (!(await confirmPresentationWithRetry(options, dependencies))) {
-      // A false result means this browser no longer owns the server claim;
-      // repeated transport errors remain retryable under the short lease.
-      closeProActivationInterstitial();
-      return 'retry';
-    }
-  }
   return 'opened';
 }

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -29,6 +29,7 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import {
   claimProActivationPresentation,
   confirmProActivationPresentation,
+  recordProActivationOutcome,
 } from '@/services/billing';
 import { escapeHtml } from '@/utils/sanitize';
 import { withTimeout } from '@/utils/with-timeout';
@@ -55,6 +56,7 @@ import {
   buildBriefDigestPayload,
   buildCriticalAlertsPayload,
   buildExitSummary,
+  buildActivationOutcomeBuckets,
   summarizeActivationExit,
   DEFAULT_DIGEST_HOUR,
   type ActivationEventName,
@@ -80,6 +82,8 @@ export interface ProActivationInterstitialOptions {
   onConfirmStep: (stepId: ActivationStepId) => Promise<'verified' | 'failed'>;
   /** Fire-and-forget skip signal (bookkeeping/telemetry wired by later units). */
   onSkipStep: (stepId: ActivationStepId) => void;
+  /** Called after each durable step-state transition with a full snapshot. */
+  onProgress?: (results: ActivationStepResult[]) => void;
   /** Called exactly once when the flow ends, with the ordered step results. */
   onExit: (results: ActivationStepResult[]) => void;
   /**
@@ -277,6 +281,8 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
 
   const buildResults = (): ActivationStepResult[] =>
     steps.map((step) => ({ id: step.id, outcome: outcomes.get(step.id) ?? defaultOutcome(step) }));
+
+  const recordProgress = (): void => options.onProgress?.(buildResults());
 
   const currentStatus = (step: ActivationStep): StepStatus => {
     if (step.state === 'already-done') return 'verified';
@@ -504,6 +510,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     }
     transient = 'idle';
     currentIndex = steps.length;
+    recordProgress();
     renderModal();
   };
 
@@ -520,6 +527,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
   const handleSkip = (step: ActivationStep): void => {
     options.onSkipStep(step.id);
     outcomes.set(step.id, transient === 'failed' ? 'failed' : 'skipped');
+    recordProgress();
     advance();
   };
 
@@ -537,6 +545,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     if (!overlay || generation !== gen) return;
     if (result === 'verified') {
       outcomes.set(step.id, 'confirmed');
+      recordProgress();
       advance();
     } else {
       transient = 'failed';
@@ -596,11 +605,13 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
             break;
           case 'advance-done':
             outcomes.set(step.id, 'done');
+            recordProgress();
             advance();
             break;
           case 'advance-skip':
             options.onSkipStep(step.id);
             outcomes.set(step.id, 'skipped');
+            recordProgress();
             advance();
             break;
         }
@@ -617,6 +628,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
           extra.onMount(extrasRoot, {
             confirmAndFinish: () => {
               outcomes.set(step.id, 'confirmed');
+              recordProgress();
               finishFlow();
             },
           });
@@ -731,6 +743,17 @@ export interface ProActivationFlowDependencies {
     claimNonce: string,
   ) => Promise<'claimed' | 'not_eligible' | 'already_presented' | 'already_claimed'>;
   confirmPresentation: (activationKey: string, claimNonce: string) => Promise<boolean>;
+  recordOutcome: (
+    activationKey: string,
+    claimNonce: string,
+    outcome: {
+      confirmedSteps: ActivationStepId[];
+      skippedSteps: ActivationStepId[];
+      failedSteps: ActivationStepId[];
+      revision: number;
+      finalized: boolean;
+    },
+  ) => Promise<boolean>;
   openInterstitial: typeof openProActivationInterstitial;
   /** Per-operation deadline; injectable only to keep timeout regressions fast. */
   operationTimeoutMs?: number;
@@ -747,6 +770,7 @@ const BRIEF_PREVIEW_TIMEOUT_MS = 2500;
 const ACTIVATION_CONTEXT_TIMEOUT_MS = 5_000;
 const ACTIVATION_MUTATION_TIMEOUT_MS = 5_000;
 const PRESENTATION_CONFIRM_RETRY_DELAYS_MS = [250, 750, 1_500] as const;
+const OUTCOME_WRITE_RETRY_DELAYS_MS = [250, 750] as const;
 
 /**
  * The brief step's chosen delivery hour, held outside the re-rendered DOM. The
@@ -1157,6 +1181,48 @@ async function confirmPresentationWithRetry(
   return false;
 }
 
+function persistActivationOutcomeWithRetry(
+  options: ProActivationFlowOptions,
+  dependencies: ProActivationFlowDependencies,
+  results: readonly ActivationStepResult[],
+  revision: number,
+  finalized: boolean,
+): void {
+  if (!options.onlyIfUnactivated || !options.expectedActivationKey || !options.activationClaimNonce) {
+    return;
+  }
+  const buckets = buildActivationOutcomeBuckets(results);
+  void (async () => {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await withTimeout(
+          dependencies.recordOutcome(
+            options.expectedActivationKey!,
+            options.activationClaimNonce!,
+            {
+              confirmedSteps: [...buckets.confirmedSteps],
+              skippedSteps: [...buckets.skippedSteps],
+              failedSteps: [...buckets.failedSteps],
+              revision,
+              finalized,
+            },
+          ),
+          dependencies.operationTimeoutMs ?? ACTIVATION_MUTATION_TIMEOUT_MS,
+          'activation-record-outcome',
+        );
+        return;
+      } catch (error) {
+        const delay = OUTCOME_WRITE_RETRY_DELAYS_MS[attempt];
+        if (delay === undefined) {
+          console.warn('[pro-activation] failed to record activation outcome', error);
+          return;
+        }
+        await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
+      }
+    }
+  })();
+}
+
 /**
  * Open the full Pro-activation flow: read the subscriber's config, build the
  * ordered steps, wire the real per-step handlers, and on exit decide the
@@ -1173,6 +1239,7 @@ export async function openProActivationFlow(
         : readActivationContext(expectedUserId),
     claimPresentation: claimProActivationPresentation,
     confirmPresentation: confirmProActivationPresentation,
+    recordOutcome: recordProActivationOutcome,
     openInterstitial: openProActivationInterstitial,
     ...injected,
   };
@@ -1234,6 +1301,17 @@ export async function openProActivationFlow(
   // the confirm button while in-flight (guard the handler itself against a
   // double-fire, e.g. a stray second click before the first await settles).
   const inFlight = new Set<ActivationStepId>();
+  let outcomeRevision = 0;
+  const persistOutcome = (results: readonly ActivationStepResult[], finalized: boolean): void => {
+    outcomeRevision += 1;
+    persistActivationOutcomeWithRetry(
+      options,
+      dependencies,
+      results,
+      outcomeRevision,
+      finalized,
+    );
+  };
 
   options.onEvent?.(ACTIVATION_EVENTS.entered);
 
@@ -1261,8 +1339,13 @@ export async function openProActivationFlow(
       }
     },
     onSkipStep: (stepId) => options.onEvent?.(ACTIVATION_EVENTS.stepSkipped, stepId),
+    onProgress: (results) => persistOutcome(results, false),
     onExit: (results) => {
       options.onEvent?.(ACTIVATION_EVENTS.exit, undefined, summarizeActivationExit(results));
+      // Freeze the latest durable snapshot. Progress was already recorded as
+      // steps resolved, so a tab close before this best-effort write cannot
+      // erase engagement from the cohort.
+      persistOutcome(results, true);
       // Chip decision + all localStorage live in the chip module (lazy-imported
       // to keep this component ↔ chip pair free of a static import cycle).
       void import('@/components/ProActivationChip')

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -188,6 +188,36 @@ export async function confirmProActivationPresentation(
   ) as boolean;
 }
 
+export type ProActivationOutcomeStepId = 'brief' | 'alerts' | 'power';
+
+export interface ProActivationOutcomeSnapshot {
+  confirmedSteps: ProActivationOutcomeStepId[];
+  skippedSteps: ProActivationOutcomeStepId[];
+  failedSteps: ProActivationOutcomeStepId[];
+  revision: number;
+  finalized: boolean;
+}
+
+/**
+ * Persist one monotonic activation-outcome snapshot. The flow keeps this
+ * best-effort and non-blocking, but errors propagate here so its bounded retry
+ * loop can distinguish a transport failure from a server-side rejection.
+ */
+export async function recordProActivationOutcome(
+  activationKey: string,
+  claimNonce: string,
+  outcome: ProActivationOutcomeSnapshot,
+): Promise<boolean> {
+  const client = await getConvexClient();
+  const api = await getConvexApi();
+  if (!client || !api) throw new Error('Convex unavailable');
+  await waitForConvexAuth();
+  return await client.mutation(
+    (api as any).payments.billing.recordProActivationOutcome,
+    { activationKey, claimNonce, ...outcome },
+  ) as boolean;
+}
+
 const DODO_PORTAL_FALLBACK_URL = 'https://customer.dodopayments.com';
 
 /**

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -184,7 +184,7 @@ export async function confirmProActivationPresentation(
   await waitForConvexAuth();
   return await client.mutation(
     (api as any).payments.billing.confirmProActivationPresentation,
-    { activationKey, claimNonce },
+    { activationKey, claimNonce, outcomeTrackingVersion: 1 },
   ) as boolean;
 }
 

--- a/src/services/pro-activation-state.ts
+++ b/src/services/pro-activation-state.ts
@@ -743,6 +743,29 @@ export function summarizeActivationExit(
   return { completion, verified, pending, failed, total };
 }
 
+/** Per-step outcome IDs, bucketed for the durable activation-outcome record (#5582). */
+export interface ActivationOutcomeBuckets {
+  /** Steps that ended verified -- confirmed in-flow or already-done. */
+  readonly confirmedSteps: readonly ActivationStepId[];
+  readonly skippedSteps: readonly ActivationStepId[];
+  readonly failedSteps: readonly ActivationStepId[];
+}
+
+/** Bucket step results by outcome for persistence, independent of the Umami exit event. */
+export function buildActivationOutcomeBuckets(
+  results: readonly ActivationStepResult[],
+): ActivationOutcomeBuckets {
+  const confirmedSteps: ActivationStepId[] = [];
+  const skippedSteps: ActivationStepId[] = [];
+  const failedSteps: ActivationStepId[] = [];
+  for (const r of results) {
+    if (r.outcome === 'confirmed' || r.outcome === 'done') confirmedSteps.push(r.id);
+    else if (r.outcome === 'skipped') skippedSteps.push(r.id);
+    else failedSteps.push(r.id);
+  }
+  return { confirmedSteps, skippedSteps, failedSteps };
+}
+
 /** Versioned localStorage key for the finish-setup chip dismissal. */
 export const FINISH_SETUP_CHIP_DISMISS_KEY = 'wm-pro-activation-chip-dismissed-v1';
 

--- a/tests/pro-activation-state.test.mts
+++ b/tests/pro-activation-state.test.mts
@@ -35,6 +35,7 @@ import {
   buildCriticalAlertsPayload,
   DEFAULT_DIGEST_HOUR,
   buildExitSummary,
+  buildActivationOutcomeBuckets,
   ACTIVATION_FLOW_RETRY_DELAYS_MS,
   activationFlowRetryDelay,
   summarizeActivationExit,
@@ -937,6 +938,48 @@ describe('summarizeActivationExit — funnel exit completion state', () => {
       pending: 0,
       failed: 0,
       total: 0,
+    });
+  });
+});
+
+describe('buildActivationOutcomeBuckets — durable outcome record (#5582)', () => {
+  it('confirmed and done both land in confirmedSteps (both count as verified)', () => {
+    assert.deepEqual(
+      buildActivationOutcomeBuckets([
+        { id: 'brief', outcome: 'confirmed' },
+        { id: 'alerts', outcome: 'done' },
+      ]),
+      { confirmedSteps: ['brief', 'alerts'], skippedSteps: [], failedSteps: [] },
+    );
+  });
+
+  it('skipped and failed bucket separately from confirmed', () => {
+    assert.deepEqual(
+      buildActivationOutcomeBuckets([
+        { id: 'brief', outcome: 'confirmed' },
+        { id: 'alerts', outcome: 'skipped' },
+        { id: 'power', outcome: 'failed' },
+      ]),
+      { confirmedSteps: ['brief'], skippedSteps: ['alerts'], failedSteps: ['power'] },
+    );
+  });
+
+  it('preserves step order within each bucket', () => {
+    assert.deepEqual(
+      buildActivationOutcomeBuckets([
+        { id: 'power', outcome: 'skipped' },
+        { id: 'brief', outcome: 'skipped' },
+        { id: 'alerts', outcome: 'skipped' },
+      ]),
+      { confirmedSteps: [], skippedSteps: ['power', 'brief', 'alerts'], failedSteps: [] },
+    );
+  });
+
+  it('empty flow → all buckets empty', () => {
+    assert.deepEqual(buildActivationOutcomeBuckets([]), {
+      confirmedSteps: [],
+      skippedSteps: [],
+      failedSteps: [],
     });
   });
 });

--- a/tests/report-activation-lift.test.mjs
+++ b/tests/report-activation-lift.test.mjs
@@ -160,6 +160,48 @@ test("analysis uses only mature presentations and table-specific adoption timest
   assert.equal(analysis.lift, 1);
 });
 
+test("analysis reports no-mature-outcomes when every presentation is still within its observation window", () => {
+  const presentations = [
+    {
+      userId: "too-recent-1",
+      // One ms short of maturing: observationStartedAt + windowMs > reportNow.
+      presentedAt: NOW - WINDOW_MS + 1,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: ["brief"],
+    },
+    {
+      userId: "too-recent-2",
+      presentedAt: NOW,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: [],
+    },
+  ];
+
+  const analysis = analyzeActivationLift({
+    presentations,
+    featureRowsByTable: emptyFeatureRows(),
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+  });
+
+  assert.equal(analysis.verdict, "no-mature-outcomes");
+  assert.equal(analysis.mature, 0);
+  assert.equal(analysis.immature, 2);
+  const emptyGroup = {
+    n: 0,
+    anyCount: 0,
+    rate: 0,
+    perTable: { notificationChannels: 0, alertRules: 0, userApiKeys: 0, mcpProTokens: 0 },
+  };
+  assert.deepEqual(analysis.engaged, emptyGroup);
+  assert.deepEqual(analysis.presentedOnly, emptyGroup);
+
+  assert.match(
+    formatActivationLiftReport(analysis, { windowDays: 14, limit: 20_000 }),
+    /No presentations have completed the full 14-day observation window yet\./,
+  );
+});
+
 test("analysis refuses capped exports before rates and enforces the mature sample floor", () => {
   const presentations = Array.from({ length: 59 }, (_, index) => ({
     userId: `user-${index}`,

--- a/tests/report-activation-lift.test.mjs
+++ b/tests/report-activation-lift.test.mjs
@@ -5,6 +5,7 @@ import {
   fetchTable,
   formatActivationLiftReport,
   indexFeatureRows,
+  runCli,
 } from "../scripts/report-activation-lift.mjs";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -19,6 +20,13 @@ function emptyFeatureRows() {
     mcpProTokens: [],
   };
 }
+
+test("CLI points operators at Node's dotenv loader when credentials are absent", () => {
+  assert.throws(
+    () => runCli([], {}),
+    /node --env-file=\.env\.local/,
+  );
+});
 
 test("fetchTable bounds a hung Convex export and reports the table", () => {
   const timeout = Object.assign(new Error("spawnSync npx ETIMEDOUT"), { code: "ETIMEDOUT" });
@@ -59,25 +67,34 @@ test("analysis uses only mature presentations and table-specific adoption timest
     {
       userId: "engaged",
       presentedAt: presentedBeforeExit,
+      outcomeTrackingVersion: 1,
       confirmedSteps: ["brief"],
       exitedAt: observationStartedAt,
     },
     {
       userId: "presented-only",
       presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
       confirmedSteps: [],
       // Deliberately no exitedAt: lost exits stay in the cohort.
     },
     {
       userId: "immature",
       presentedAt: NOW - WINDOW_MS + 1,
+      outcomeTrackingVersion: 1,
       confirmedSteps: ["brief"],
     },
     {
       userId: "progress-immature",
       presentedAt: presentedBeforeExit,
+      outcomeTrackingVersion: 1,
       confirmedSteps: ["brief"],
       outcomeUpdatedAt: NOW - WINDOW_MS + 1,
+    },
+    {
+      userId: "legacy-pre-instrumentation",
+      presentedAt: presentedBeforeExit,
+      confirmedSteps: [],
     },
   ];
   const featureRowsByTable = {
@@ -123,6 +140,8 @@ test("analysis uses only mature presentations and table-specific adoption timest
   });
 
   assert.equal(analysis.verdict, "comparison");
+  assert.equal(analysis.totalPresentations, 5);
+  assert.equal(analysis.uninstrumented, 1);
   assert.equal(analysis.mature, 2);
   assert.equal(analysis.immature, 2);
   assert.equal(analysis.incompleteExits, 1);
@@ -145,6 +164,7 @@ test("analysis refuses capped exports before rates and enforces the mature sampl
   const presentations = Array.from({ length: 59 }, (_, index) => ({
     userId: `user-${index}`,
     presentedAt: NOW - WINDOW_MS,
+    outcomeTrackingVersion: 1,
     confirmedSteps: index < 29 ? ["brief"] : [],
   }));
 

--- a/tests/report-activation-lift.test.mjs
+++ b/tests/report-activation-lift.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  analyzeActivationLift,
+  fetchTable,
+  formatActivationLiftReport,
+  indexFeatureRows,
+} from "../scripts/report-activation-lift.mjs";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 6, 25);
+const WINDOW_MS = 14 * DAY_MS;
+
+function emptyFeatureRows() {
+  return {
+    notificationChannels: [],
+    alertRules: [],
+    userApiKeys: [],
+    mcpProTokens: [],
+  };
+}
+
+test("fetchTable bounds a hung Convex export and reports the table", () => {
+  const timeout = Object.assign(new Error("spawnSync npx ETIMEDOUT"), { code: "ETIMEDOUT" });
+  assert.throws(
+    () => fetchTable("alertRules", {
+      limit: 20_000,
+      timeoutMs: 1234,
+      runner: () => ({
+        error: timeout,
+        status: null,
+        signal: "SIGTERM",
+        stdout: "",
+        stderr: "",
+      }),
+    }),
+    /alertRules timed out after 1234ms/,
+  );
+});
+
+test("fetchTable marks a cap hit instead of treating a newest-first slice as complete", () => {
+  const result = fetchTable("userApiKeys", {
+    limit: 2,
+    runner: () => ({
+      status: 0,
+      signal: null,
+      stdout: '{"userId":"a"}\n{"userId":"b"}\n',
+      stderr: "",
+    }),
+  });
+  assert.equal(result.truncated, true);
+  assert.equal(result.rows.length, 2);
+});
+
+test("analysis uses only mature presentations and table-specific adoption timestamps", () => {
+  const observationStartedAt = NOW - WINDOW_MS;
+  const presentedBeforeExit = observationStartedAt - DAY_MS;
+  const presentations = [
+    {
+      userId: "engaged",
+      presentedAt: presentedBeforeExit,
+      confirmedSteps: ["brief"],
+      exitedAt: observationStartedAt,
+    },
+    {
+      userId: "presented-only",
+      presentedAt: observationStartedAt,
+      confirmedSteps: [],
+      // Deliberately no exitedAt: lost exits stay in the cohort.
+    },
+    {
+      userId: "immature",
+      presentedAt: NOW - WINDOW_MS + 1,
+      confirmedSteps: ["brief"],
+    },
+    {
+      userId: "progress-immature",
+      presentedAt: presentedBeforeExit,
+      confirmedSteps: ["brief"],
+      outcomeUpdatedAt: NOW - WINDOW_MS + 1,
+    },
+  ];
+  const featureRowsByTable = {
+    ...emptyFeatureRows(),
+    notificationChannels: [
+      {
+        userId: "engaged",
+        verified: true,
+        // Existing row re-verified at the inclusive end boundary.
+        linkedAt: observationStartedAt + WINDOW_MS,
+        _creationTime: observationStartedAt - 100 * DAY_MS,
+      },
+      {
+        userId: "presented-only",
+        verified: false,
+        linkedAt: observationStartedAt + DAY_MS,
+      },
+    ],
+    alertRules: [
+      {
+        userId: "presented-only",
+        enabled: true,
+        // Existing rule updated just outside the observation window.
+        updatedAt: observationStartedAt + WINDOW_MS + 1,
+        _creationTime: observationStartedAt - 100 * DAY_MS,
+      },
+    ],
+    userApiKeys: [
+      {
+        userId: "engaged",
+        // A row created inside the wizard, before exit, is not downstream adoption.
+        createdAt: presentedBeforeExit + 1,
+      },
+    ],
+  };
+
+  const analysis = analyzeActivationLift({
+    presentations,
+    featureRowsByTable,
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+    minGroupSize: 1,
+  });
+
+  assert.equal(analysis.verdict, "comparison");
+  assert.equal(analysis.mature, 2);
+  assert.equal(analysis.immature, 2);
+  assert.equal(analysis.incompleteExits, 1);
+  assert.deepEqual(analysis.engaged, {
+    n: 1,
+    anyCount: 1,
+    rate: 1,
+    perTable: {
+      notificationChannels: 1,
+      alertRules: 0,
+      userApiKeys: 0,
+      mcpProTokens: 0,
+    },
+  });
+  assert.equal(analysis.presentedOnly.anyCount, 0);
+  assert.equal(analysis.lift, 1);
+});
+
+test("analysis refuses capped exports before rates and enforces the mature sample floor", () => {
+  const presentations = Array.from({ length: 59 }, (_, index) => ({
+    userId: `user-${index}`,
+    presentedAt: NOW - WINDOW_MS,
+    confirmedSteps: index < 29 ? ["brief"] : [],
+  }));
+
+  const capped = analyzeActivationLift({
+    presentations,
+    featureRowsByTable: emptyFeatureRows(),
+    truncatedTables: ["alertRules"],
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+  });
+  assert.equal(capped.verdict, "incomplete-export");
+  assert.equal(capped.engaged, null);
+  assert.match(
+    formatActivationLiftReport(capped, { windowDays: 14, limit: 20_000 }),
+    /Inconclusive.*alertRules.*no adoption rates were computed/s,
+  );
+
+  const complete = analyzeActivationLift({
+    presentations,
+    featureRowsByTable: emptyFeatureRows(),
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+  });
+  assert.equal(complete.engaged.n, 29);
+  assert.equal(complete.presentedOnly.n, 30);
+  assert.equal(complete.verdict, "below-sample-floor");
+});
+
+test("feature indexing performs one pass and excludes inactive credentials", () => {
+  const featureRows = emptyFeatureRows();
+  featureRows.userApiKeys = Array.from({ length: 20_000 }, (_, index) => ({
+    userId: `user-${index}`,
+    createdAt: index,
+    ...(index % 2 === 0 ? {} : { revokedAt: index + 1 }),
+  }));
+  const index = indexFeatureRows(featureRows);
+  assert.deepEqual(index.userApiKeys.get("user-0"), [0]);
+  assert.equal(index.userApiKeys.has("user-1"), false);
+  assert.equal(index.userApiKeys.size, 10_000);
+});


### PR DESCRIPTION
## Summary

- forward-port the complete activation-outcome implementation from #5584 onto `main`
- preserve #5584's complete 10-file implementation without carrying its stacked branch history
- fix two forward-port validation findings: shell-safe dotenv loading and explicit exclusion of pre-instrumentation presentations
- derive the server outcome-step validator and revision bound from one shared Convex constant without importing the full schema into a mutation module
- close #5582 from the default branch, where GitHub can apply the closing reference

## Intent

#5584 was merged into `codex/pro-activation-first-cycle-backfill` after #5564 had already merged into `main`. Its implementation and `Closes #5582` reference therefore never reached the default branch.

This PR applies that implementation to current `main`:

- durable confirmed/skipped/failed activation outcome snapshots in Convex
- authenticated, nonce-bound, monotonic outcome writes
- interstitial progress and final-exit persistence alongside existing Umami telemetry
- a bounded, read-only activation-lift report with mature-window and minimum-sample safeguards
- a mixed-deploy-safe outcome tracking version so legacy clients remain valid while pre-instrumentation rows stay outside the comparison cohort

Non-goals remain unchanged: no live dashboard, randomized control, retroactive reconstruction, or unrelated refactor.

Closes #5582.

## Validation Matrix

| Gate | Result |
|---|---|
| #5584 implementation parity | PASS — original patch applied with identical patch ID `1734c5465fec98e30743b12840a7e6016afeb250`; follow-up changes preserve that implementation and add one shared-constants file |
| Final diff scope | PASS — 11 files, 1,174 additions, 8 deletions |
| Activation state + report tests | PASS — 122/122 |
| Controller/widget source-affinity tests | PASS — 228/228 |
| Convex billing tests | PASS — 149/149 |
| Pro Activation Playwright spec | PASS — 21/21 |
| Frontend typecheck | PASS |
| API/Convex typecheck and string-call audit | PASS |
| Biome + safe HTML | PASS — only unrelated pre-existing warnings |
| Boundary and staged Unicode guards | PASS |
| Full pre-push gate | PASS |
| GitHub/Vercel checks | PASS — 24 succeeded, 1 intentionally skipped, 0 failed or pending |
| Read-only production report smoke | PASS — 9 existing presentations exported; all 9 correctly excluded as pre-instrumentation |

## Review Gates

- Baseline diff review: PASS
- Code Review Expert: PASS on the exact final head, including the shared-validator hardening; no remaining P0-P3 findings
- Outcome review against #5582: PASS; production evidence confirms the non-retroactive cohort boundary

## Documentation

Not applicable. The on-demand script includes its usage, read-only behavior, cohort caveat, and configuration flags; no public API or user documentation contract changes.

## Screenshots / UI Evidence

Not applicable. This forward-port adds persistence and an operator report without changing rendered UI.

## Residual Findings

None.
