### PR TITLE
feat(provenance): add decision-signal contract

### DIFF
--- a/docs/decision-signal-provenance.mdx
+++ b/docs/decision-signal-provenance.mdx
@@ -1,0 +1,166 @@
+---
+title: "Decision-Signal Provenance"
+description: "Shared provenance declarations, validation, and serialization rules for normalized observations, events, conditions, and derived comparisons."
+---
+
+WorldMonitor's decision-signal provenance contract keeps domain payloads
+separate while giving every normalized observation or event the same
+fail-closed evidence vocabulary. It is the boundary between a source-specific
+adapter and cache, API, MCP, or UI consumers.
+
+The contract is additive. Existing feed payloads are not implicitly migrated,
+and a domain lane still owns its source adapter, payload model, cache behavior,
+and domain tests.
+
+## Envelope and claims
+
+The runtime-neutral modules are:
+
+- `shared/decision-signal-provenance-contract.ts` — TypeScript vocabulary
+- `shared/decision-signal-provenance-families.ts` — family declarations and
+  the CI registration frontier
+- `shared/decision-signal-provenance.ts` — runtime validation and canonical
+  serialization adapters
+
+Every envelope carries `contractVersion`, a stable `signalId`, a declared
+`familyId`, and the complete `claims` object. Each claim has exactly one status:
+
+| Claim status | Meaning |
+| --- | --- |
+| `known` | The claim has a validated value. |
+| `unknown` | The dimension applies, but the value is unavailable or has not been established. A non-empty reason is required. |
+| `not_applicable` | The dimension does not apply to this family. A non-empty reason is required. |
+
+`unknown` and `not_applicable` claims cannot carry a value. This prevents an
+absent field from turning into a current, official, independent, verified,
+normal, or zero-valued presentation claim.
+
+## Family declarations
+
+Each family declares every dimension as `required`, `unknown_allowed`, or
+`not_applicable`. The shared reference families cover:
+
+- official numeric observations
+- typed document events
+- operational activity records
+- exchange disclosures
+- composed corridor conditions
+- derived comparisons
+
+A `required` dimension accepts only a `known` claim.
+`unknown_allowed` accepts `known` or explicit `unknown`.
+`not_applicable` accepts only explicit `not_applicable`.
+Omitting any dimension is invalid under every policy.
+
+The dimensions cover publisher identity, source URL, original evidence,
+language, translation, four distinct time roles, revision and supersession,
+two independent confidence claims, corroboration, transport freshness, content
+freshness, and derivation.
+
+## Publisher and evidence identity
+
+Source-backed publishers retain a stable publisher ID and a
+`registryReference` snapshot containing the canonical source name, source
+type, and propaganda-risk state from `shared/source-provenance.ts`. Validation
+fails when the source is undeclared or the snapshot has drifted from the
+registry established by the source-level provenance contract.
+
+Publisher classes are separate from confidence or corroboration:
+
+- `official_government` is a direct government publisher.
+- `state_controlled_media` remains distinct from government ministries.
+- `official_exchange` identifies an official market or disclosure authority.
+- `independent_observation`, `independent_media`, `wire_service`, and
+  `market_publisher` retain their own meanings.
+- `derived_output` has no source-registry reference. Its input signal IDs and
+  method belong in the required derivation claim.
+- `unknown` is an explicit non-favorable publisher classification.
+
+Independent publisher claims require an explicitly low-risk registry entry and
+cannot relabel a government, wire, or market source.
+
+The source URL must be an absolute credential-free HTTPS URL. The original
+reference independently identifies a document, text, observation, event, or
+dataset and can carry a SHA-256 content hash.
+
+## Language and translation
+
+Original language is independent of translation state. Translation values use
+only:
+
+- `unavailable`
+- `not_translated`
+- `machine_assisted`
+- `human_reviewed`
+
+Machine-assisted and human-reviewed translations require a target language.
+When translation does not apply, the claim itself uses `not_applicable`; it is
+not represented as a favorable translation state.
+
+## Time, lineage, and confidence
+
+Observation, effective, publication, and retrieval time are separate claims.
+Each known time value also carries its semantic role, so a serializer or
+adapter cannot substitute one timestamp for another without validation
+failing. Precision is explicit (`instant`, `day`, `month`, or `year`).
+
+Revision claims preserve a stable vintage ID, monotonic sequence, and
+`original`, `revised`, or `corrected` state. Supersession separately records
+`current`, `corrected`, `cancelled`, or `superseded`; corrected and superseded
+records link to the related signal, while cancellation requires a reason.
+`current` records cannot carry correction, cancellation, or replacement
+metadata.
+Historical vintages therefore remain addressable.
+
+Extraction confidence and classification confidence are independent values
+with their own score and method. Publisher authority never supplies either
+score. Corroboration is another claim, with explicit source signal IDs; an
+official source does not imply independent verification.
+
+## Freshness and last-good data
+
+Transport freshness reports whether collection is `fresh`, `stale`, `missing`,
+or in `error`. Content freshness independently reports `current`, `stale`,
+`unavailable`, `partial`, or `timestamp_unknown`.
+
+This distinction survives last-good fallback. A fresh transport can return
+stale content, and stale transport can coexist with still-current cached
+content. Consumers must render both claims rather than collapsing them into a
+single green or red state. `timestamp_unknown` cannot carry a `contentAsOf`
+value.
+
+## Serialization parity
+
+`DECISION_SIGNAL_PROVENANCE_SURFACE_ADAPTERS` exposes the same canonical wire
+shape for:
+
+- `cache_storage`
+- `api`
+- `mcp`
+- `ui`
+
+Every adapter validates before serialization and after deserialization. Stable
+IDs, claim statuses, timestamp roles, and unknown/not-applicable reasons
+therefore round-trip unchanged.
+
+## Extending the contract
+
+When a domain lane launches a provenance-bearing signal family:
+
+1. Add a complete family declaration in
+   `shared/decision-signal-provenance-families.ts`.
+2. Add the matching registration and explicitly choose `launchStatus:
+   'launched'`.
+3. Add a positive serialization fixture under
+   `tests/fixtures/decision-signal-provenance/` and point the registration at
+   its fixture ID.
+4. Add domain-specific positive and negative fixtures for its own payload
+   semantics.
+5. Validate at the adapter boundary before writing cache/storage data or
+   exposing API, MCP, or UI output.
+6. Run the focused provenance test plus frontend and API typechecks.
+
+CI compares family declarations and registrations exactly, requires a positive
+fixture for every family, exercises every surface adapter, and rejects missing
+claims, stale registry references, invalid vocabulary, semantic timestamp
+substitution, or untested serialization paths.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -231,6 +231,7 @@
                   "cors",
                   "health-endpoints",
                   "relay-parameters",
+                  "decision-signal-provenance",
                   "data-sources"
                 ]
               },
@@ -687,6 +688,7 @@
                   "zh/cors",
                   "zh/health-endpoints",
                   "zh/relay-parameters",
+                  "zh/decision-signal-provenance",
                   "zh/data-sources"
                 ]
               },

--- a/docs/zh/decision-signal-provenance.mdx
+++ b/docs/zh/decision-signal-provenance.mdx
@@ -1,0 +1,107 @@
+---
+title: "决策信号溯源"
+description: "规范化观测、事件、状态和派生比较所共用的溯源声明、验证与序列化规则。"
+---
+
+WorldMonitor 的决策信号溯源契约在保留各领域负载差异的同时，为每个规范化观测或事件提供统一、失败即关闭的证据词汇。它位于来源专用适配器与缓存、API、MCP 或 UI 消费者之间。
+
+该契约是增量式的。现有数据源负载不会被隐式迁移；各领域管线仍负责自己的来源适配器、负载模型、缓存行为和领域测试。
+
+## 信封与声明
+
+与运行时无关的模块包括：
+
+- `shared/decision-signal-provenance-contract.ts` — TypeScript 词汇
+- `shared/decision-signal-provenance-families.ts` — 信号族声明和 CI 注册边界
+- `shared/decision-signal-provenance.ts` — 运行时验证和规范序列化适配器
+
+每个信封都包含 `contractVersion`、稳定的 `signalId`、已声明的 `familyId`，以及完整的 `claims` 对象。每项声明只能具有以下一种状态：
+
+| 声明状态 | 含义 |
+| --- | --- |
+| `known` | 声明具有经过验证的值。 |
+| `unknown` | 该维度适用，但值不可用或尚未确定；必须提供非空原因。 |
+| `not_applicable` | 该维度不适用于此信号族；必须提供非空原因。 |
+
+`unknown` 和 `not_applicable` 声明不能携带值。这可以防止缺失字段被误解为当前、官方、独立、已验证、正常或零值的展示声明。
+
+## 信号族声明
+
+每个信号族必须将每个维度声明为 `required`、`unknown_allowed` 或 `not_applicable`。共享参考信号族覆盖：
+
+- 官方数值观测
+- 类型化文档事件
+- 运行活动记录
+- 交易所披露
+- 组合走廊状态
+- 派生比较
+
+`required` 维度只接受 `known` 声明；`unknown_allowed` 接受 `known` 或显式 `unknown`；`not_applicable` 只接受显式 `not_applicable`。任何策略下，遗漏任一维度都无效。
+
+这些维度覆盖发布者身份、来源 URL、原始证据、语言、翻译、四种独立时间角色、修订与替代、两种独立置信度声明、佐证、传输新鲜度、内容新鲜度和派生关系。
+
+## 发布者与证据身份
+
+有来源支持的发布者保留稳定的发布者 ID，以及包含 `shared/source-provenance.ts` 中规范来源名称、来源类型和宣传风险状态的 `registryReference` 快照。如果来源未声明，或快照与来源级溯源契约建立的注册表发生漂移，验证将失败。
+
+发布者类别与置信度或佐证相互独立：
+
+- `official_government` 表示政府直接发布者。
+- `state_controlled_media` 与政府部门保持明确区分。
+- `official_exchange` 表示官方市场或披露机构。
+- `independent_observation`、`independent_media`、`wire_service` 和 `market_publisher` 保留各自含义。
+- `derived_output` 没有来源注册表引用；其输入信号 ID 和方法必须写入必需的派生声明。
+- `unknown` 是显式的非正向发布者分类。
+
+独立发布者声明要求注册表条目明确为低风险，且不能将政府、通讯社或市场来源重新标记为独立来源。
+
+来源 URL 必须是绝对、无凭据的 HTTPS URL。原始引用独立标识文档、文本、观测、事件或数据集，并可携带 SHA-256 内容哈希。
+
+## 语言与翻译
+
+原始语言与翻译状态相互独立。翻译值只能使用：
+
+- `unavailable`
+- `not_translated`
+- `machine_assisted`
+- `human_reviewed`
+
+机器辅助和人工审校翻译必须包含目标语言。当翻译不适用时，声明本身使用 `not_applicable`，不能用有利的翻译状态代替。
+
+## 时间、沿袭与置信度
+
+观测时间、生效时间、发布时间和检索时间是独立声明。每个已知时间值还携带其语义角色，因此序列化器或适配器若用一个时间戳替代另一个，验证就会失败。精度必须显式指定为 `instant`、`day`、`month` 或 `year`。
+
+修订声明保留稳定的版本 ID、单调递增序列，以及 `original`、`revised` 或 `corrected` 状态。替代声明则分别记录 `current`、`corrected`、`cancelled` 或 `superseded`；更正和被替代记录要链接相关信号，取消则必须提供原因。`current` 记录不能携带更正、取消或替换元数据。因此历史版本始终可以寻址。
+
+提取置信度和分类置信度是相互独立的值，各自具有分数和方法。发布者权威性不能提供任何一种分数。佐证也是独立声明，并显式列出来源信号 ID；官方来源并不意味着已获独立验证。
+
+## 新鲜度与最后良好数据
+
+传输新鲜度报告采集状态是 `fresh`、`stale`、`missing` 还是 `error`。内容新鲜度则独立报告 `current`、`stale`、`unavailable`、`partial` 或 `timestamp_unknown`。
+
+使用最后良好数据回退时，这一区分仍然保留。新鲜传输可能返回陈旧内容，陈旧传输也可能与仍然当前的缓存内容共存。消费者必须同时呈现两项声明，不能将它们折叠成单一的绿色或红色状态。`timestamp_unknown` 不能携带 `contentAsOf` 值。
+
+## 序列化一致性
+
+`DECISION_SIGNAL_PROVENANCE_SURFACE_ADAPTERS` 为以下表面公开相同的规范线格式：
+
+- `cache_storage`
+- `api`
+- `mcp`
+- `ui`
+
+每个适配器都在序列化之前和反序列化之后执行验证。因此稳定 ID、声明状态、时间戳角色以及未知或不适用原因都能原样往返。
+
+## 扩展契约
+
+当领域管线推出携带溯源信息的信号族时：
+
+1. 在 `shared/decision-signal-provenance-families.ts` 中添加完整的信号族声明。
+2. 添加匹配的注册项，并显式选择 `launchStatus: 'launched'`。
+3. 在 `tests/fixtures/decision-signal-provenance/` 下添加正向序列化夹具，并让注册项指向其夹具 ID。
+4. 为该领域自身的负载语义添加正向和负向夹具。
+5. 在写入缓存或存储数据，或公开 API、MCP、UI 输出之前，在适配器边界执行验证。
+6. 运行聚焦溯源测试以及前端和 API 类型检查。
+
+CI 会精确比较信号族声明与注册项，要求每个信号族都有正向夹具，遍历所有表面适配器，并拒绝缺失声明、过期注册表引用、无效词汇、语义时间戳替换或未经测试的序列化路径。

--- a/shared/decision-signal-provenance-contract.ts
+++ b/shared/decision-signal-provenance-contract.ts
@@ -1,0 +1,216 @@
+import type { PropagandaRisk, SourceType } from './source-provenance';
+
+export const DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION = 'decision-signal-provenance/v1' as const;
+
+export const DECISION_SIGNAL_PROVENANCE_DIMENSIONS = [
+  'publisher',
+  'source_url',
+  'original_reference',
+  'original_language',
+  'translation',
+  'observation_time',
+  'effective_time',
+  'publication_time',
+  'retrieval_time',
+  'revision',
+  'supersession',
+  'extraction_confidence',
+  'classification_confidence',
+  'corroboration',
+  'transport_freshness',
+  'content_freshness',
+  'derivation',
+] as const;
+
+export type DecisionSignalProvenanceDimension =
+  (typeof DECISION_SIGNAL_PROVENANCE_DIMENSIONS)[number];
+
+export const DECISION_SIGNAL_PROVENANCE_DECLARATION_POLICIES = [
+  'required',
+  'unknown_allowed',
+  'not_applicable',
+] as const;
+
+export type DecisionSignalProvenanceDeclarationPolicy =
+  (typeof DECISION_SIGNAL_PROVENANCE_DECLARATION_POLICIES)[number];
+
+export const DECISION_SIGNAL_PROVENANCE_CLAIM_STATUSES = [
+  'known',
+  'unknown',
+  'not_applicable',
+] as const;
+
+export type DecisionSignalProvenanceClaimStatus =
+  (typeof DECISION_SIGNAL_PROVENANCE_CLAIM_STATUSES)[number];
+
+export type KnownProvenanceClaim<T> = Readonly<{
+  status: 'known';
+  value: T;
+}>;
+
+export type UnknownProvenanceClaim = Readonly<{
+  status: 'unknown';
+  reason: string;
+}>;
+
+export type NotApplicableProvenanceClaim = Readonly<{
+  status: 'not_applicable';
+  reason: string;
+}>;
+
+export type DecisionSignalProvenanceClaim<T> =
+  | KnownProvenanceClaim<T>
+  | UnknownProvenanceClaim
+  | NotApplicableProvenanceClaim;
+
+export const DECISION_SIGNAL_PUBLISHER_TYPES = [
+  'official_government',
+  'state_controlled_media',
+  'official_exchange',
+  'independent_observation',
+  'independent_media',
+  'wire_service',
+  'market_publisher',
+  'derived_output',
+  'unknown',
+] as const;
+
+export type DecisionSignalPublisherType = (typeof DECISION_SIGNAL_PUBLISHER_TYPES)[number];
+
+export interface DecisionSignalSourceRegistryReference {
+  sourceName: string;
+  sourceType: SourceType;
+  propagandaRisk: PropagandaRisk;
+}
+
+export interface DecisionSignalPublisherReference {
+  id: string;
+  name: string;
+  type: DecisionSignalPublisherType;
+  registryReference: DecisionSignalSourceRegistryReference | null;
+}
+
+export interface DecisionSignalOriginalReference {
+  kind: 'document' | 'text' | 'observation' | 'event' | 'dataset';
+  id: string;
+  contentHash?: string;
+}
+
+export interface DecisionSignalTranslation {
+  state: 'unavailable' | 'not_translated' | 'machine_assisted' | 'human_reviewed';
+  targetLanguage?: string;
+}
+
+export interface DecisionSignalTimeReference {
+  role: 'observation' | 'effective' | 'publication' | 'retrieval';
+  value: string;
+  precision: 'instant' | 'day' | 'month' | 'year';
+}
+
+export interface DecisionSignalRevision {
+  vintageId: string;
+  sequence: number;
+  state: 'original' | 'revised' | 'corrected';
+}
+
+export interface DecisionSignalSupersession {
+  state: 'current' | 'corrected' | 'cancelled' | 'superseded';
+  relatedSignalId?: string;
+  reason?: string;
+}
+
+export interface DecisionSignalConfidence {
+  score: number;
+  method: string;
+}
+
+export interface DecisionSignalCorroboration {
+  state: 'single_source' | 'multi_source' | 'independently_corroborated' | 'contradicted';
+  sourceSignalIds: string[];
+}
+
+export interface DecisionSignalTransportFreshness {
+  state: 'fresh' | 'stale' | 'missing' | 'error';
+  assessedAt: string;
+  lastSuccessAt?: string;
+}
+
+export interface DecisionSignalContentFreshness {
+  state: 'current' | 'stale' | 'unavailable' | 'partial' | 'timestamp_unknown';
+  assessedAt: string;
+  contentAsOf?: string;
+}
+
+export interface DecisionSignalDerivation {
+  methodId: string;
+  methodVersion: string;
+  computedAt: string;
+  inputSignalIds: string[];
+}
+
+export interface DecisionSignalProvenanceValueMap {
+  publisher: DecisionSignalPublisherReference;
+  source_url: string;
+  original_reference: DecisionSignalOriginalReference;
+  original_language: string;
+  translation: DecisionSignalTranslation;
+  observation_time: DecisionSignalTimeReference;
+  effective_time: DecisionSignalTimeReference;
+  publication_time: DecisionSignalTimeReference;
+  retrieval_time: DecisionSignalTimeReference;
+  revision: DecisionSignalRevision;
+  supersession: DecisionSignalSupersession;
+  extraction_confidence: DecisionSignalConfidence;
+  classification_confidence: DecisionSignalConfidence;
+  corroboration: DecisionSignalCorroboration;
+  transport_freshness: DecisionSignalTransportFreshness;
+  content_freshness: DecisionSignalContentFreshness;
+  derivation: DecisionSignalDerivation;
+}
+
+export type DecisionSignalProvenanceClaims = Readonly<{
+  [Dimension in DecisionSignalProvenanceDimension]:
+    DecisionSignalProvenanceClaim<DecisionSignalProvenanceValueMap[Dimension]>;
+}>;
+
+export interface DecisionSignalProvenance {
+  contractVersion: typeof DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION;
+  signalId: string;
+  familyId: string;
+  claims: DecisionSignalProvenanceClaims;
+}
+
+export const DECISION_SIGNAL_FAMILY_KINDS = [
+  'official_numeric_observation',
+  'typed_document_event',
+  'operational_activity_record',
+  'exchange_disclosure',
+  'composed_corridor_condition',
+  'derived_comparison',
+] as const;
+
+export type DecisionSignalFamilyKind = (typeof DECISION_SIGNAL_FAMILY_KINDS)[number];
+
+export interface DecisionSignalProvenanceFamilyDeclaration {
+  id: string;
+  kind: DecisionSignalFamilyKind;
+  description: string;
+  dimensions: Readonly<
+    Record<DecisionSignalProvenanceDimension, DecisionSignalProvenanceDeclarationPolicy>
+  >;
+}
+
+export interface DecisionSignalProvenanceFamilyRegistration {
+  launchStatus: 'reference' | 'launched';
+  serializationFixtureId: string;
+}
+
+export const DECISION_SIGNAL_PROVENANCE_SURFACES = [
+  'cache_storage',
+  'api',
+  'mcp',
+  'ui',
+] as const;
+
+export type DecisionSignalProvenanceSurface =
+  (typeof DECISION_SIGNAL_PROVENANCE_SURFACES)[number];

--- a/shared/decision-signal-provenance-families.ts
+++ b/shared/decision-signal-provenance-families.ts
@@ -1,0 +1,207 @@
+import type {
+  DecisionSignalFamilyKind,
+  DecisionSignalProvenanceDeclarationPolicy,
+  DecisionSignalProvenanceDimension,
+  DecisionSignalProvenanceFamilyDeclaration,
+  DecisionSignalProvenanceFamilyRegistration,
+} from './decision-signal-provenance-contract';
+
+type DimensionPolicies = Readonly<
+  Record<DecisionSignalProvenanceDimension, DecisionSignalProvenanceDeclarationPolicy>
+>;
+
+function dimensions(policies: DimensionPolicies): DimensionPolicies {
+  return Object.freeze(policies);
+}
+
+function declaration(
+  id: string,
+  kind: DecisionSignalFamilyKind,
+  description: string,
+  policies: DimensionPolicies,
+): Readonly<DecisionSignalProvenanceFamilyDeclaration> {
+  return Object.freeze({
+    id,
+    kind,
+    description,
+    dimensions: dimensions(policies),
+  });
+}
+
+export const DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS: Readonly<
+  Record<string, Readonly<DecisionSignalProvenanceFamilyDeclaration>>
+> = Object.freeze({
+  official_numeric_observation: declaration(
+    'official_numeric_observation',
+    'official_numeric_observation',
+    'A revision-aware numeric observation released by an official publisher.',
+    {
+      publisher: 'required',
+      source_url: 'required',
+      original_reference: 'required',
+      original_language: 'unknown_allowed',
+      translation: 'not_applicable',
+      observation_time: 'required',
+      effective_time: 'unknown_allowed',
+      publication_time: 'required',
+      retrieval_time: 'required',
+      revision: 'required',
+      supersession: 'required',
+      extraction_confidence: 'required',
+      classification_confidence: 'not_applicable',
+      corroboration: 'unknown_allowed',
+      transport_freshness: 'required',
+      content_freshness: 'required',
+      derivation: 'not_applicable',
+    },
+  ),
+  typed_document_event: declaration(
+    'typed_document_event',
+    'typed_document_event',
+    'A typed event extracted from a policy, enforcement, or other source document.',
+    {
+      publisher: 'required',
+      source_url: 'required',
+      original_reference: 'required',
+      original_language: 'required',
+      translation: 'required',
+      observation_time: 'not_applicable',
+      effective_time: 'unknown_allowed',
+      publication_time: 'required',
+      retrieval_time: 'required',
+      revision: 'unknown_allowed',
+      supersession: 'required',
+      extraction_confidence: 'required',
+      classification_confidence: 'required',
+      corroboration: 'unknown_allowed',
+      transport_freshness: 'required',
+      content_freshness: 'required',
+      derivation: 'not_applicable',
+    },
+  ),
+  operational_activity_record: declaration(
+    'operational_activity_record',
+    'operational_activity_record',
+    'A time-bounded operational observation such as activity, movement, or disruption.',
+    {
+      publisher: 'required',
+      source_url: 'required',
+      original_reference: 'required',
+      original_language: 'unknown_allowed',
+      translation: 'unknown_allowed',
+      observation_time: 'required',
+      effective_time: 'unknown_allowed',
+      publication_time: 'unknown_allowed',
+      retrieval_time: 'required',
+      revision: 'unknown_allowed',
+      supersession: 'required',
+      extraction_confidence: 'required',
+      classification_confidence: 'required',
+      corroboration: 'unknown_allowed',
+      transport_freshness: 'required',
+      content_freshness: 'required',
+      derivation: 'not_applicable',
+    },
+  ),
+  exchange_disclosure: declaration(
+    'exchange_disclosure',
+    'exchange_disclosure',
+    'An issuer disclosure or correction published through an official market authority.',
+    {
+      publisher: 'required',
+      source_url: 'required',
+      original_reference: 'required',
+      original_language: 'required',
+      translation: 'required',
+      observation_time: 'not_applicable',
+      effective_time: 'unknown_allowed',
+      publication_time: 'required',
+      retrieval_time: 'required',
+      revision: 'required',
+      supersession: 'required',
+      extraction_confidence: 'required',
+      classification_confidence: 'required',
+      corroboration: 'unknown_allowed',
+      transport_freshness: 'required',
+      content_freshness: 'required',
+      derivation: 'not_applicable',
+    },
+  ),
+  composed_corridor_condition: declaration(
+    'composed_corridor_condition',
+    'composed_corridor_condition',
+    'A derived corridor state composed from explicitly identified operational inputs.',
+    {
+      publisher: 'required',
+      source_url: 'not_applicable',
+      original_reference: 'not_applicable',
+      original_language: 'not_applicable',
+      translation: 'not_applicable',
+      observation_time: 'required',
+      effective_time: 'required',
+      publication_time: 'not_applicable',
+      retrieval_time: 'required',
+      revision: 'required',
+      supersession: 'required',
+      extraction_confidence: 'not_applicable',
+      classification_confidence: 'required',
+      corroboration: 'required',
+      transport_freshness: 'required',
+      content_freshness: 'required',
+      derivation: 'required',
+    },
+  ),
+  derived_comparison: declaration(
+    'derived_comparison',
+    'derived_comparison',
+    'A transparent comparison derived from time-aligned source observations.',
+    {
+      publisher: 'required',
+      source_url: 'not_applicable',
+      original_reference: 'not_applicable',
+      original_language: 'not_applicable',
+      translation: 'not_applicable',
+      observation_time: 'required',
+      effective_time: 'required',
+      publication_time: 'not_applicable',
+      retrieval_time: 'required',
+      revision: 'required',
+      supersession: 'required',
+      extraction_confidence: 'not_applicable',
+      classification_confidence: 'required',
+      corroboration: 'required',
+      transport_freshness: 'required',
+      content_freshness: 'required',
+      derivation: 'required',
+    },
+  ),
+});
+
+export const DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS: Readonly<
+  Record<string, Readonly<DecisionSignalProvenanceFamilyRegistration>>
+> = Object.freeze({
+  official_numeric_observation: Object.freeze({
+    launchStatus: 'reference',
+    serializationFixtureId: 'official-numeric-revised',
+  }),
+  typed_document_event: Object.freeze({
+    launchStatus: 'reference',
+    serializationFixtureId: 'typed-document-translated',
+  }),
+  operational_activity_record: Object.freeze({
+    launchStatus: 'reference',
+    serializationFixtureId: 'operational-stale-transport',
+  }),
+  exchange_disclosure: Object.freeze({
+    launchStatus: 'reference',
+    serializationFixtureId: 'exchange-disclosure-superseded',
+  }),
+  composed_corridor_condition: Object.freeze({
+    launchStatus: 'reference',
+    serializationFixtureId: 'corridor-stale-content',
+  }),
+  derived_comparison: Object.freeze({
+    launchStatus: 'reference',
+    serializationFixtureId: 'derived-comparison',
+  }),
+});

--- a/shared/decision-signal-provenance.ts
+++ b/shared/decision-signal-provenance.ts
@@ -687,6 +687,7 @@ function validateClaim(
       'CLAIM_STATUS_VIOLATES_DECLARATION',
       `${claim.status as string} is not allowed by ${policy}`,
     );
+    return;
   }
 
   if (claim.status === 'known') {

--- a/shared/decision-signal-provenance.ts
+++ b/shared/decision-signal-provenance.ts
@@ -1,0 +1,831 @@
+import {
+  DECISION_SIGNAL_PROVENANCE_CLAIM_STATUSES,
+  DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION,
+  DECISION_SIGNAL_PROVENANCE_DIMENSIONS,
+  DECISION_SIGNAL_PROVENANCE_SURFACES,
+  DECISION_SIGNAL_PUBLISHER_TYPES,
+  type DecisionSignalConfidence,
+  type DecisionSignalContentFreshness,
+  type DecisionSignalCorroboration,
+  type DecisionSignalDerivation,
+  type DecisionSignalOriginalReference,
+  type DecisionSignalProvenance,
+  type DecisionSignalProvenanceDimension,
+  type DecisionSignalProvenanceFamilyDeclaration,
+  type DecisionSignalProvenanceSurface,
+  type DecisionSignalPublisherReference,
+  type DecisionSignalRevision,
+  type DecisionSignalSupersession,
+  type DecisionSignalTimeReference,
+  type DecisionSignalTranslation,
+  type DecisionSignalTransportFreshness,
+} from './decision-signal-provenance-contract';
+import {
+  DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS,
+  DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS,
+} from './decision-signal-provenance-families';
+import { getSourceProvenanceState } from './source-provenance';
+
+export * from './decision-signal-provenance-contract';
+export {
+  DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS,
+  DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS,
+} from './decision-signal-provenance-families';
+
+export interface DecisionSignalProvenanceValidationIssue {
+  path: string;
+  code: string;
+  message: string;
+}
+
+export type DecisionSignalProvenanceValidationResult =
+  | { ok: true; value: DecisionSignalProvenance }
+  | { ok: false; errors: DecisionSignalProvenanceValidationIssue[] };
+
+type RecordValue = Record<string, unknown>;
+
+const TOP_LEVEL_KEYS = ['contractVersion', 'signalId', 'familyId', 'claims'] as const;
+const CLAIM_KNOWN_KEYS = ['status', 'value'] as const;
+const CLAIM_UNAVAILABLE_KEYS = ['status', 'reason'] as const;
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function pushIssue(
+  errors: DecisionSignalProvenanceValidationIssue[],
+  path: string,
+  code: string,
+  message: string,
+): void {
+  errors.push({ path, code, message });
+}
+
+function validateExactKeys(
+  value: RecordValue,
+  allowed: readonly string[],
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      pushIssue(errors, `${path}.${key}`, 'INVALID_SHAPE', `Unexpected field ${key}`);
+    }
+  }
+}
+
+function validateRequiredString(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is string {
+  if (!isNonEmptyString(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Expected a non-empty string');
+    return false;
+  }
+  return true;
+}
+
+function isIsoInstant(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?Z$/,
+  );
+  if (!match) return false;
+  return isValidCalendarDate(Number(match[1]), Number(match[2]), Number(match[3]))
+    && Number(match[4]) <= 23
+    && Number(match[5]) <= 59
+    && Number(match[6]) <= 59;
+}
+
+function isValidCalendarDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1) return false;
+  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    isLeapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return day <= daysInMonth[month - 1];
+}
+
+function isCalendarMonth(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = value.match(/^(\d{4})-(\d{2})$/);
+  if (!match) return false;
+  const month = Number(match[2]);
+  return month >= 1 && month <= 12;
+}
+
+function isCalendarDay(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  return isValidCalendarDate(Number(match[1]), Number(match[2]), Number(match[3]));
+}
+
+function isProvenanceTimestamp(value: unknown): value is string {
+  return isIsoInstant(value)
+    || isCalendarDay(value)
+    || isCalendarMonth(value)
+    || (typeof value === 'string' && /^\d{4}$/.test(value));
+}
+
+function validateTimestampValue(
+  value: unknown,
+  precision: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): void {
+  let valid = false;
+  if (precision === 'instant') valid = isIsoInstant(value);
+  if (precision === 'day') valid = isCalendarDay(value);
+  if (precision === 'month') valid = isCalendarMonth(value);
+  if (precision === 'year') valid = typeof value === 'string' && /^\d{4}$/.test(value);
+  if (!valid) {
+    pushIssue(errors, path, 'INVALID_VALUE', `Invalid ${String(precision)} timestamp`);
+  }
+}
+
+function validatePublisher(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalPublisherReference {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Publisher must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['id', 'name', 'type', 'registryReference'], path, errors);
+  validateRequiredString(value.id, `${path}.id`, errors);
+  validateRequiredString(value.name, `${path}.name`, errors);
+  if (!DECISION_SIGNAL_PUBLISHER_TYPES.includes(value.type as never)) {
+    pushIssue(errors, `${path}.type`, 'INVALID_STATUS_VOCABULARY', 'Unknown publisher type');
+  }
+
+  if (value.type === 'derived_output') {
+    if (value.registryReference !== null) {
+      pushIssue(
+        errors,
+        `${path}.registryReference`,
+        'INVALID_SOURCE_REFERENCE',
+        'Derived outputs must not masquerade as a source-registry publisher',
+      );
+    }
+    return true;
+  }
+
+  if (!isRecord(value.registryReference)) {
+    pushIssue(
+      errors,
+      `${path}.registryReference`,
+      'UNKNOWN_SOURCE_REFERENCE',
+      'Source-backed publishers require a #5571 registry reference',
+    );
+    return false;
+  }
+
+  const registryReference = value.registryReference;
+  validateExactKeys(
+    registryReference,
+    ['sourceName', 'sourceType', 'propagandaRisk'],
+    `${path}.registryReference`,
+    errors,
+  );
+  if (!validateRequiredString(
+    registryReference.sourceName,
+    `${path}.registryReference.sourceName`,
+    errors,
+  )) {
+    return false;
+  }
+
+  const registryState = getSourceProvenanceState(registryReference.sourceName);
+  if (!registryState.typeDeclared || !registryState.riskDeclared) {
+    pushIssue(
+      errors,
+      `${path}.registryReference.sourceName`,
+      'UNKNOWN_SOURCE_REFERENCE',
+      `${registryReference.sourceName} is not explicitly declared in the #5571 source registry`,
+    );
+    return false;
+  }
+  if (
+    registryReference.sourceType !== registryState.type
+    || registryReference.propagandaRisk !== registryState.risk
+  ) {
+    pushIssue(
+      errors,
+      `${path}.registryReference`,
+      'STALE_SOURCE_REFERENCE',
+      'Publisher registry snapshot no longer matches the canonical #5571 source registry',
+    );
+  }
+  if (value.type === 'official_government' && registryState.type !== 'gov') {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'Official-government publishers must resolve to a government registry type',
+    );
+  }
+  if (
+    value.type === 'state_controlled_media'
+    && (!registryState.stateAffiliated || registryState.type === 'gov')
+  ) {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'State-controlled media must remain distinct from direct government publishers',
+    );
+  }
+  if (
+    (value.type === 'independent_media' || value.type === 'independent_observation')
+    && (
+      registryState.risk !== 'low'
+      || registryState.type === 'gov'
+      || registryState.type === 'wire'
+      || registryState.type === 'market'
+    )
+  ) {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'Independent publisher claims require a low-risk non-government, non-wire, non-market registry entry',
+    );
+  }
+  if (
+    registryState.risk === 'high'
+    && registryState.stateAffiliated
+    && registryState.type !== 'gov'
+    && value.type !== 'state_controlled_media'
+    && value.type !== 'unknown'
+  ) {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'State-controlled media cannot be relabeled as a wire or independent publisher',
+    );
+  }
+  if (
+    value.type === 'wire_service'
+    && (registryState.type !== 'wire' || registryState.risk === 'high')
+  ) {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'Wire-service claims require a non-state-controlled wire registry entry',
+    );
+  }
+  if (value.type === 'market_publisher' && registryState.type !== 'market') {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'Market-publisher claims require a market registry entry',
+    );
+  }
+  if (
+    value.type === 'official_exchange'
+    && registryState.type !== 'market'
+    && registryState.type !== 'gov'
+  ) {
+    pushIssue(
+      errors,
+      `${path}.type`,
+      'PUBLISHER_CLASS_MISMATCH',
+      'Official-exchange claims require a market or government registry entry',
+    );
+  }
+  return true;
+}
+
+function validateSourceUrl(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is string {
+  if (!validateRequiredString(value, path, errors)) return false;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) throw new Error('unsafe URL');
+  } catch {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Source URL must be an absolute credential-free HTTPS URL');
+    return false;
+  }
+  return true;
+}
+
+function validateOriginalReference(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalOriginalReference {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Original reference must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['kind', 'id', 'contentHash'], path, errors);
+  if (!['document', 'text', 'observation', 'event', 'dataset'].includes(String(value.kind))) {
+    pushIssue(errors, `${path}.kind`, 'INVALID_STATUS_VOCABULARY', 'Unknown original-reference kind');
+  }
+  validateRequiredString(value.id, `${path}.id`, errors);
+  if (value.contentHash !== undefined && (
+    typeof value.contentHash !== 'string'
+    || !/^sha256:[a-f0-9]{64}$/.test(value.contentHash)
+  )) {
+    pushIssue(errors, `${path}.contentHash`, 'INVALID_VALUE', 'Expected a lowercase sha256 content hash');
+  }
+  return true;
+}
+
+function validateTranslation(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalTranslation {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Translation must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['state', 'targetLanguage'], path, errors);
+  const states = ['unavailable', 'not_translated', 'machine_assisted', 'human_reviewed'];
+  if (!states.includes(String(value.state))) {
+    pushIssue(errors, `${path}.state`, 'INVALID_STATUS_VOCABULARY', 'Unknown translation state');
+  }
+  if (value.state === 'machine_assisted' || value.state === 'human_reviewed') {
+    validateRequiredString(value.targetLanguage, `${path}.targetLanguage`, errors);
+  } else if (value.targetLanguage !== undefined) {
+    pushIssue(
+      errors,
+      `${path}.targetLanguage`,
+      'INVALID_VALUE',
+      'Unavailable or untranslated evidence cannot claim a target language',
+    );
+  }
+  return true;
+}
+
+const TIME_ROLES: Readonly<
+  Record<
+    Extract<
+      DecisionSignalProvenanceDimension,
+      'observation_time' | 'effective_time' | 'publication_time' | 'retrieval_time'
+    >,
+    DecisionSignalTimeReference['role']
+  >
+> = {
+  observation_time: 'observation',
+  effective_time: 'effective',
+  publication_time: 'publication',
+  retrieval_time: 'retrieval',
+};
+
+function validateTimeReference(
+  dimension: keyof typeof TIME_ROLES,
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalTimeReference {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Time reference must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['role', 'value', 'precision'], path, errors);
+  if (value.role !== TIME_ROLES[dimension]) {
+    pushIssue(
+      errors,
+      `${path}.role`,
+      'TIMESTAMP_ROLE_MISMATCH',
+      `${dimension} must retain its ${TIME_ROLES[dimension]} semantic role`,
+    );
+  }
+  if (!['instant', 'day', 'month', 'year'].includes(String(value.precision))) {
+    pushIssue(errors, `${path}.precision`, 'INVALID_STATUS_VOCABULARY', 'Unknown timestamp precision');
+  } else {
+    validateTimestampValue(value.value, value.precision, `${path}.value`, errors);
+  }
+  return true;
+}
+
+function validateRevision(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalRevision {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Revision must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['vintageId', 'sequence', 'state'], path, errors);
+  validateRequiredString(value.vintageId, `${path}.vintageId`, errors);
+  if (!Number.isInteger(value.sequence) || Number(value.sequence) < 1) {
+    pushIssue(errors, `${path}.sequence`, 'INVALID_VALUE', 'Revision sequence must be a positive integer');
+  }
+  if (!['original', 'revised', 'corrected'].includes(String(value.state))) {
+    pushIssue(errors, `${path}.state`, 'INVALID_STATUS_VOCABULARY', 'Unknown revision state');
+  }
+  if (value.state === 'original' && value.sequence !== 1) {
+    pushIssue(errors, `${path}.sequence`, 'INVALID_LINEAGE', 'Original vintages must use sequence 1');
+  }
+  if ((value.state === 'revised' || value.state === 'corrected') && Number(value.sequence) < 2) {
+    pushIssue(errors, `${path}.sequence`, 'INVALID_LINEAGE', 'Revised vintages must advance the sequence');
+  }
+  return true;
+}
+
+function validateSupersession(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalSupersession {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Supersession must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['state', 'relatedSignalId', 'reason'], path, errors);
+  if (!['current', 'corrected', 'cancelled', 'superseded'].includes(String(value.state))) {
+    pushIssue(errors, `${path}.state`, 'INVALID_STATUS_VOCABULARY', 'Unknown supersession state');
+  }
+  if (value.state === 'corrected' || value.state === 'superseded') {
+    validateRequiredString(value.relatedSignalId, `${path}.relatedSignalId`, errors);
+  }
+  if (value.state === 'cancelled') {
+    validateRequiredString(value.reason, `${path}.reason`, errors);
+  }
+  if (
+    value.state === 'current'
+    && (value.relatedSignalId !== undefined || value.reason !== undefined)
+  ) {
+    pushIssue(
+      errors,
+      path,
+      'INVALID_LINEAGE',
+      'Current signals cannot carry correction, cancellation, or supersession metadata',
+    );
+  }
+  return true;
+}
+
+function validateConfidence(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalConfidence {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Confidence must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['score', 'method'], path, errors);
+  if (
+    typeof value.score !== 'number'
+    || !Number.isFinite(value.score)
+    || value.score < 0
+    || value.score > 1
+  ) {
+    pushIssue(errors, `${path}.score`, 'INVALID_VALUE', 'Confidence score must be finite and between 0 and 1');
+  }
+  validateRequiredString(value.method, `${path}.method`, errors);
+  return true;
+}
+
+function validateSignalIds(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is string[] {
+  if (!Array.isArray(value) || value.some((item) => !isNonEmptyString(item))) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Expected an array of non-empty signal IDs');
+    return false;
+  }
+  if (new Set(value).size !== value.length) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Signal IDs must be unique');
+    return false;
+  }
+  return true;
+}
+
+function validateCorroboration(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalCorroboration {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Corroboration must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['state', 'sourceSignalIds'], path, errors);
+  const states = ['single_source', 'multi_source', 'independently_corroborated', 'contradicted'];
+  if (!states.includes(String(value.state))) {
+    pushIssue(errors, `${path}.state`, 'INVALID_STATUS_VOCABULARY', 'Unknown corroboration state');
+  }
+  if (validateSignalIds(value.sourceSignalIds, `${path}.sourceSignalIds`, errors)) {
+    const count = value.sourceSignalIds.length;
+    if (value.state === 'single_source' && count !== 1) {
+      pushIssue(errors, `${path}.sourceSignalIds`, 'INVALID_VALUE', 'single_source requires exactly one source');
+    }
+    if (
+      (value.state === 'multi_source'
+        || value.state === 'independently_corroborated'
+        || value.state === 'contradicted')
+      && count < 2
+    ) {
+      pushIssue(errors, `${path}.sourceSignalIds`, 'INVALID_VALUE', `${String(value.state)} requires two sources`);
+    }
+  }
+  return true;
+}
+
+function validateTransportFreshness(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalTransportFreshness {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Transport freshness must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['state', 'assessedAt', 'lastSuccessAt'], path, errors);
+  if (!['fresh', 'stale', 'missing', 'error'].includes(String(value.state))) {
+    pushIssue(errors, `${path}.state`, 'INVALID_STATUS_VOCABULARY', 'Unknown transport-freshness state');
+  }
+  if (!isIsoInstant(value.assessedAt)) {
+    pushIssue(errors, `${path}.assessedAt`, 'INVALID_VALUE', 'assessedAt must be an ISO instant');
+  }
+  if (value.lastSuccessAt !== undefined && !isIsoInstant(value.lastSuccessAt)) {
+    pushIssue(errors, `${path}.lastSuccessAt`, 'INVALID_VALUE', 'lastSuccessAt must be an ISO instant');
+  }
+  return true;
+}
+
+function validateContentFreshness(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalContentFreshness {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Content freshness must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['state', 'assessedAt', 'contentAsOf'], path, errors);
+  const states = ['current', 'stale', 'unavailable', 'partial', 'timestamp_unknown'];
+  if (!states.includes(String(value.state))) {
+    pushIssue(errors, `${path}.state`, 'INVALID_STATUS_VOCABULARY', 'Unknown content-freshness state');
+  }
+  if (!isIsoInstant(value.assessedAt)) {
+    pushIssue(errors, `${path}.assessedAt`, 'INVALID_VALUE', 'assessedAt must be an ISO instant');
+  }
+  if (value.contentAsOf !== undefined && !isProvenanceTimestamp(value.contentAsOf)) {
+    pushIssue(
+      errors,
+      `${path}.contentAsOf`,
+      'INVALID_VALUE',
+      'contentAsOf must be a valid instant, day, month, or year',
+    );
+  }
+  if ((value.state === 'current' || value.state === 'stale') && !isNonEmptyString(value.contentAsOf)) {
+    pushIssue(errors, `${path}.contentAsOf`, 'INVALID_VALUE', `${String(value.state)} content requires contentAsOf`);
+  }
+  if (value.state === 'timestamp_unknown' && value.contentAsOf !== undefined) {
+    pushIssue(
+      errors,
+      `${path}.contentAsOf`,
+      'INVALID_VALUE',
+      'timestamp_unknown content cannot carry a known content timestamp',
+    );
+  }
+  return true;
+}
+
+function validateDerivation(
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): value is DecisionSignalDerivation {
+  if (!isRecord(value)) {
+    pushIssue(errors, path, 'INVALID_VALUE', 'Derivation must be an object');
+    return false;
+  }
+  validateExactKeys(value, ['methodId', 'methodVersion', 'computedAt', 'inputSignalIds'], path, errors);
+  validateRequiredString(value.methodId, `${path}.methodId`, errors);
+  validateRequiredString(value.methodVersion, `${path}.methodVersion`, errors);
+  if (!isIsoInstant(value.computedAt)) {
+    pushIssue(errors, `${path}.computedAt`, 'INVALID_VALUE', 'computedAt must be an ISO instant');
+  }
+  if (validateSignalIds(value.inputSignalIds, `${path}.inputSignalIds`, errors) && value.inputSignalIds.length === 0) {
+    pushIssue(errors, `${path}.inputSignalIds`, 'INVALID_VALUE', 'Derived outputs require at least one input signal');
+  }
+  return true;
+}
+
+function validateKnownClaimValue(
+  dimension: DecisionSignalProvenanceDimension,
+  value: unknown,
+  path: string,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): void {
+  if (dimension === 'publisher') validatePublisher(value, path, errors);
+  if (dimension === 'source_url') validateSourceUrl(value, path, errors);
+  if (dimension === 'original_reference') validateOriginalReference(value, path, errors);
+  if (dimension === 'original_language') validateRequiredString(value, path, errors);
+  if (dimension === 'translation') validateTranslation(value, path, errors);
+  if (dimension in TIME_ROLES) {
+    validateTimeReference(dimension as keyof typeof TIME_ROLES, value, path, errors);
+  }
+  if (dimension === 'revision') validateRevision(value, path, errors);
+  if (dimension === 'supersession') validateSupersession(value, path, errors);
+  if (dimension === 'extraction_confidence' || dimension === 'classification_confidence') {
+    validateConfidence(value, path, errors);
+  }
+  if (dimension === 'corroboration') validateCorroboration(value, path, errors);
+  if (dimension === 'transport_freshness') validateTransportFreshness(value, path, errors);
+  if (dimension === 'content_freshness') validateContentFreshness(value, path, errors);
+  if (dimension === 'derivation') validateDerivation(value, path, errors);
+}
+
+function validateClaim(
+  dimension: DecisionSignalProvenanceDimension,
+  claim: unknown,
+  declaration: DecisionSignalProvenanceFamilyDeclaration,
+  errors: DecisionSignalProvenanceValidationIssue[],
+): void {
+  const path = `claims.${dimension}`;
+  if (!isRecord(claim)) {
+    pushIssue(errors, path, 'INVALID_CLAIM', 'Claim must be an object');
+    return;
+  }
+  if (!DECISION_SIGNAL_PROVENANCE_CLAIM_STATUSES.includes(claim.status as never)) {
+    pushIssue(errors, `${path}.status`, 'INVALID_STATUS_VOCABULARY', 'Unknown claim status');
+    return;
+  }
+  const policy = declaration.dimensions[dimension];
+  if (
+    (policy === 'required' && claim.status !== 'known')
+    || (policy === 'not_applicable' && claim.status !== 'not_applicable')
+    || (policy === 'unknown_allowed' && claim.status === 'not_applicable')
+  ) {
+    pushIssue(
+      errors,
+      `${path}.status`,
+      'CLAIM_STATUS_VIOLATES_DECLARATION',
+      `${claim.status as string} is not allowed by ${policy}`,
+    );
+  }
+
+  if (claim.status === 'known') {
+    validateExactKeys(claim, CLAIM_KNOWN_KEYS, path, errors);
+    if (!Object.hasOwn(claim, 'value')) {
+      pushIssue(errors, `${path}.value`, 'MISSING_CLAIM_VALUE', 'Known claims require a value');
+      return;
+    }
+    validateKnownClaimValue(dimension, claim.value, `${path}.value`, errors);
+    return;
+  }
+
+  validateExactKeys(claim, CLAIM_UNAVAILABLE_KEYS, path, errors);
+  validateRequiredString(claim.reason, `${path}.reason`, errors);
+  if (Object.hasOwn(claim, 'value')) {
+    pushIssue(
+      errors,
+      `${path}.value`,
+      'INVALID_CLAIM',
+      'Unknown or not-applicable claims cannot carry an inferred value',
+    );
+  }
+}
+
+export function validateDecisionSignalProvenance(
+  input: unknown,
+): DecisionSignalProvenanceValidationResult {
+  const errors: DecisionSignalProvenanceValidationIssue[] = [];
+  if (!isRecord(input)) {
+    return {
+      ok: false,
+      errors: [{ path: '$', code: 'INVALID_SHAPE', message: 'Provenance must be an object' }],
+    };
+  }
+  validateExactKeys(input, TOP_LEVEL_KEYS, '$', errors);
+  if (input.contractVersion !== DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION) {
+    pushIssue(
+      errors,
+      'contractVersion',
+      'UNSUPPORTED_CONTRACT_VERSION',
+      `Expected ${DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION}`,
+    );
+  }
+  validateRequiredString(input.signalId, 'signalId', errors);
+  const hasFamilyId = validateRequiredString(input.familyId, 'familyId', errors);
+  const declaration = hasFamilyId
+    ? DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS[input.familyId]
+    : undefined;
+  if (!declaration) {
+    pushIssue(errors, 'familyId', 'UNKNOWN_FAMILY', 'Signal family has no provenance declaration');
+  }
+  if (!isRecord(input.claims)) {
+    pushIssue(errors, 'claims', 'INVALID_SHAPE', 'Claims must be an object');
+  } else if (declaration) {
+    validateExactKeys(input.claims, DECISION_SIGNAL_PROVENANCE_DIMENSIONS, 'claims', errors);
+    for (const dimension of DECISION_SIGNAL_PROVENANCE_DIMENSIONS) {
+      if (!Object.hasOwn(input.claims, dimension)) {
+        pushIssue(
+          errors,
+          `claims.${dimension}`,
+          'MISSING_CLAIM',
+          'Every provenance dimension must be declared explicitly',
+        );
+        continue;
+      }
+      validateClaim(dimension, input.claims[dimension], declaration, errors);
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, value: input as unknown as DecisionSignalProvenance };
+}
+
+export class DecisionSignalProvenanceValidationError extends Error {
+  readonly errors: DecisionSignalProvenanceValidationIssue[];
+
+  constructor(errors: DecisionSignalProvenanceValidationIssue[]) {
+    super(errors.map((error) => `${error.path}: ${error.message}`).join('; '));
+    this.name = 'DecisionSignalProvenanceValidationError';
+    this.errors = errors;
+  }
+}
+
+function requireValidDecisionSignalProvenance(input: unknown): DecisionSignalProvenance {
+  const result = validateDecisionSignalProvenance(input);
+  if (!result.ok) throw new DecisionSignalProvenanceValidationError(result.errors);
+  return result.value;
+}
+
+export function serializeDecisionSignalProvenance(input: unknown): string {
+  return JSON.stringify(requireValidDecisionSignalProvenance(input));
+}
+
+export function parseDecisionSignalProvenance(serialized: string): DecisionSignalProvenance {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    throw new DecisionSignalProvenanceValidationError([
+      { path: '$', code: 'INVALID_JSON', message: 'Serialized provenance is not valid JSON' },
+    ]);
+  }
+  return requireValidDecisionSignalProvenance(parsed);
+}
+
+function serializeSurface(input: unknown): DecisionSignalProvenance {
+  return JSON.parse(serializeDecisionSignalProvenance(input)) as DecisionSignalProvenance;
+}
+
+function deserializeSurface(input: unknown): DecisionSignalProvenance {
+  return requireValidDecisionSignalProvenance(input);
+}
+
+export interface DecisionSignalProvenanceSurfaceAdapter {
+  serialize(input: unknown): DecisionSignalProvenance;
+  deserialize(input: unknown): DecisionSignalProvenance;
+}
+
+function surfaceAdapter(): Readonly<DecisionSignalProvenanceSurfaceAdapter> {
+  return Object.freeze({
+    serialize: serializeSurface,
+    deserialize: deserializeSurface,
+  });
+}
+
+const CANONICAL_SURFACE_ADAPTER = surfaceAdapter();
+
+export const DECISION_SIGNAL_PROVENANCE_SURFACE_ADAPTERS: Readonly<
+  Record<DecisionSignalProvenanceSurface, Readonly<DecisionSignalProvenanceSurfaceAdapter>>
+> = Object.freeze({
+  cache_storage: CANONICAL_SURFACE_ADAPTER,
+  api: CANONICAL_SURFACE_ADAPTER,
+  mcp: CANONICAL_SURFACE_ADAPTER,
+  ui: CANONICAL_SURFACE_ADAPTER,
+});
+
+if (
+  Object.keys(DECISION_SIGNAL_PROVENANCE_SURFACE_ADAPTERS).length
+  !== DECISION_SIGNAL_PROVENANCE_SURFACES.length
+) {
+  throw new Error('Decision-signal provenance surface adapter registry is incomplete');
+}

--- a/tests/decision-signal-provenance.test.mts
+++ b/tests/decision-signal-provenance.test.mts
@@ -1,0 +1,326 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION,
+  DECISION_SIGNAL_PROVENANCE_DIMENSIONS,
+  DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS,
+  DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS,
+  DECISION_SIGNAL_PROVENANCE_SURFACE_ADAPTERS,
+  DECISION_SIGNAL_PROVENANCE_SURFACES,
+  DecisionSignalProvenanceValidationError,
+  parseDecisionSignalProvenance,
+  serializeDecisionSignalProvenance,
+  validateDecisionSignalProvenance,
+} from '../shared/decision-signal-provenance';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const fixtureRoot = join(root, 'tests/fixtures/decision-signal-provenance');
+
+interface Fixture {
+  id: string;
+  familyId: string;
+  scenarios: string[];
+  provenance: Record<string, unknown>;
+}
+
+interface InvalidFixture {
+  id: string;
+  baseFixtureId: string;
+  mutations: Array<{
+    operation: 'delete' | 'set';
+    path: string;
+    value?: unknown;
+  }>;
+  expectedCodes: string[];
+}
+
+const positiveFixtures = JSON.parse(
+  readFileSync(join(fixtureRoot, 'positive.json'), 'utf8'),
+) as Fixture[];
+const negativeFixtures = JSON.parse(
+  readFileSync(join(fixtureRoot, 'negative.json'), 'utf8'),
+) as InvalidFixture[];
+
+function positiveFixture(id: string): Fixture {
+  const fixture = positiveFixtures.find((candidate) => candidate.id === id);
+  assert.ok(fixture, `missing positive fixture ${id}`);
+  return fixture;
+}
+
+function invalidFixtureProvenance(fixture: InvalidFixture): Record<string, unknown> {
+  const provenance = structuredClone(positiveFixture(fixture.baseFixtureId).provenance);
+  for (const mutation of fixture.mutations) {
+    const segments = mutation.path.split('.');
+    const finalSegment = segments.pop();
+    assert.ok(finalSegment, `${fixture.id} mutation path must not be empty`);
+    let target: Record<string, unknown> = provenance;
+    for (const segment of segments) {
+      const next = target[segment];
+      assert.ok(next && typeof next === 'object' && !Array.isArray(next), `${fixture.id} invalid path`);
+      target = next as Record<string, unknown>;
+    }
+    if (mutation.operation === 'delete') {
+      delete target[finalSegment];
+    } else {
+      target[finalSegment] = mutation.value;
+    }
+  }
+  return provenance;
+}
+
+function assertValid(fixture: Fixture) {
+  const result = validateDecisionSignalProvenance(fixture.provenance);
+  assert.equal(
+    result.ok,
+    true,
+    `${fixture.id}: ${result.ok ? '' : result.errors.map((error) => `${error.path} ${error.code}`).join(', ')}`,
+  );
+  return result.value;
+}
+
+describe('decision-signal provenance contract (#5581)', () => {
+  it('publishes one explicit declaration policy for every shared provenance dimension', () => {
+    assert.equal(DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION, 'decision-signal-provenance/v1');
+    assert.deepEqual(DECISION_SIGNAL_PROVENANCE_DIMENSIONS, [
+      'publisher',
+      'source_url',
+      'original_reference',
+      'original_language',
+      'translation',
+      'observation_time',
+      'effective_time',
+      'publication_time',
+      'retrieval_time',
+      'revision',
+      'supersession',
+      'extraction_confidence',
+      'classification_confidence',
+      'corroboration',
+      'transport_freshness',
+      'content_freshness',
+      'derivation',
+    ]);
+
+    const expectedKinds = [
+      'official_numeric_observation',
+      'typed_document_event',
+      'operational_activity_record',
+      'exchange_disclosure',
+      'composed_corridor_condition',
+      'derived_comparison',
+    ];
+    assert.deepEqual(
+      Object.values(DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS)
+        .map((declaration) => declaration.kind)
+        .sort(),
+      [...expectedKinds].sort(),
+    );
+
+    for (const declaration of Object.values(DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS)) {
+      assert.deepEqual(
+        Object.keys(declaration.dimensions).sort(),
+        [...DECISION_SIGNAL_PROVENANCE_DIMENSIONS].sort(),
+        `${declaration.id} must declare every provenance dimension`,
+      );
+      for (const policy of Object.values(declaration.dimensions)) {
+        assert.ok(
+          policy === 'required' || policy === 'unknown_allowed' || policy === 'not_applicable',
+          `${declaration.id} has invalid declaration policy ${policy}`,
+        );
+      }
+    }
+  });
+
+  it('keeps the family registration and fixture completeness frontier exact', () => {
+    assert.deepEqual(
+      Object.keys(DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS).sort(),
+      Object.keys(DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS).sort(),
+      'a registered or launched family cannot exist without a declaration, and stale declarations cannot linger',
+    );
+
+    const fixtureIds = new Set(positiveFixtures.map((fixture) => fixture.id));
+    const fixtureFamilyIds = new Set(positiveFixtures.map((fixture) => fixture.familyId));
+    for (const [familyId, registration] of Object.entries(
+      DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS,
+    )) {
+      const serializationFixture = positiveFixture(registration.serializationFixtureId);
+      assert.equal(
+        serializationFixture.familyId,
+        familyId,
+        `${familyId} serialization fixture points at ${serializationFixture.familyId}`,
+      );
+      assert.ok(fixtureIds.has(registration.serializationFixtureId), `${familyId} missing serialization fixture`);
+      assert.ok(fixtureFamilyIds.has(familyId), `${familyId} missing a positive contract fixture`);
+      assert.ok(
+        registration.launchStatus === 'reference' || registration.launchStatus === 'launched',
+        `${familyId} missing explicit launch status`,
+      );
+    }
+
+    for (const familyId of fixtureFamilyIds) {
+      assert.ok(
+        DECISION_SIGNAL_PROVENANCE_FAMILY_DECLARATIONS[familyId],
+        `fixture uses undeclared family ${familyId}`,
+      );
+    }
+  });
+
+  it('accepts the positive reference matrix across every supported family', () => {
+    assert.equal(positiveFixtures.length, 7);
+    for (const fixture of positiveFixtures) {
+      const value = assertValid(fixture);
+      assert.equal(value.familyId, fixture.familyId);
+      assert.equal(value.contractVersion, DECISION_SIGNAL_PROVENANCE_CONTRACT_VERSION);
+    }
+
+    const scenarios = new Set(positiveFixtures.flatMap((fixture) => fixture.scenarios));
+    for (const scenario of [
+      'translated_document',
+      'revised_observation',
+      'cancelled_or_superseded_event',
+      'stale_transport_current_content',
+      'current_transport_stale_content',
+      'derived_output',
+    ]) {
+      assert.ok(scenarios.has(scenario), `missing positive scenario ${scenario}`);
+    }
+  });
+
+  it('rejects omissions, invalid vocabulary, stale source references, and semantic substitutions', () => {
+    assert.ok(negativeFixtures.length >= 7);
+    for (const fixture of negativeFixtures) {
+      const result = validateDecisionSignalProvenance(invalidFixtureProvenance(fixture));
+      assert.equal(result.ok, false, `${fixture.id} should fail validation`);
+      if (result.ok) continue;
+      const codes = new Set(result.errors.map((error) => error.code));
+      for (const expectedCode of fixture.expectedCodes) {
+        assert.ok(codes.has(expectedCode), `${fixture.id} missing ${expectedCode}: ${[...codes].join(', ')}`);
+      }
+    }
+  });
+
+  it('resolves source-backed publishers through the #5571 registry without conflating publisher classes', () => {
+    const government = assertValid(positiveFixture('official-numeric-revised'));
+    const stateMedia = assertValid(positiveFixture('typed-document-translated'));
+    const marketAuthority = assertValid(positiveFixture('exchange-disclosure-superseded'));
+    const derived = assertValid(positiveFixture('derived-comparison'));
+
+    assert.deepEqual(government.claims.publisher, {
+      status: 'known',
+      value: {
+        id: 'publisher:miit-cn',
+        name: 'Ministry of Industry and Information Technology',
+        type: 'official_government',
+        registryReference: {
+          sourceName: 'MIIT (China)',
+          sourceType: 'gov',
+          propagandaRisk: 'high',
+        },
+      },
+    });
+    assert.equal(
+      (stateMedia.claims.publisher as { value: { type: string } }).value.type,
+      'state_controlled_media',
+    );
+    assert.equal(
+      (marketAuthority.claims.publisher as { value: { type: string } }).value.type,
+      'official_exchange',
+    );
+    assert.deepEqual(
+      (derived.claims.publisher as { value: { type: string; registryReference: null } }).value,
+      {
+        id: 'publisher:worldmonitor-derived',
+        name: 'WorldMonitor derived output',
+        type: 'derived_output',
+        registryReference: null,
+      },
+    );
+  });
+
+  it('keeps time roles, confidence claims, and freshness claims independent through serialization', () => {
+    const translated = assertValid(positiveFixture('typed-document-translated'));
+    const observation = assertValid(positiveFixture('official-numeric-revised'));
+    const staleTransport = assertValid(positiveFixture('operational-stale-transport'));
+    const staleContent = assertValid(positiveFixture('corridor-stale-content'));
+
+    assert.notDeepEqual(translated.claims.effective_time, translated.claims.publication_time);
+    assert.notDeepEqual(translated.claims.publication_time, translated.claims.retrieval_time);
+    assert.deepEqual(
+      parseDecisionSignalProvenance(serializeDecisionSignalProvenance(translated)),
+      translated,
+    );
+
+    assert.equal(
+      (observation.claims.extraction_confidence as { value: { score: number } }).value.score,
+      0.42,
+      'official publisher authority must not inflate extraction confidence',
+    );
+    assert.equal(observation.claims.classification_confidence.status, 'not_applicable');
+    assert.equal(translated.claims.corroboration.status, 'unknown');
+
+    assert.equal(
+      (staleTransport.claims.transport_freshness as { value: { state: string } }).value.state,
+      'stale',
+    );
+    assert.equal(
+      (staleTransport.claims.content_freshness as { value: { state: string } }).value.state,
+      'current',
+    );
+    assert.equal(
+      (staleContent.claims.transport_freshness as { value: { state: string } }).value.state,
+      'fresh',
+    );
+    assert.equal(
+      (staleContent.claims.content_freshness as { value: { state: string } }).value.state,
+      'stale',
+    );
+  });
+
+  it('round-trips the same stable IDs and status vocabulary across cache, API, MCP, and UI adapters', () => {
+    assert.deepEqual(DECISION_SIGNAL_PROVENANCE_SURFACES, [
+      'cache_storage',
+      'api',
+      'mcp',
+      'ui',
+    ]);
+
+    for (const registration of Object.values(DECISION_SIGNAL_PROVENANCE_FAMILY_REGISTRATIONS)) {
+      const fixture = positiveFixture(registration.serializationFixtureId);
+      const canonical = assertValid(fixture);
+      const encodings = DECISION_SIGNAL_PROVENANCE_SURFACES.map((surface) => {
+        const adapter = DECISION_SIGNAL_PROVENANCE_SURFACE_ADAPTERS[surface];
+        const wire = adapter.serialize(canonical);
+        const roundTripped = adapter.deserialize(JSON.parse(JSON.stringify(wire)));
+        assert.deepEqual(roundTripped, canonical, `${fixture.id} ${surface} round trip`);
+        return JSON.stringify(wire);
+      });
+      assert.equal(new Set(encodings).size, 1, `${fixture.id} surface serialization drift`);
+    }
+  });
+
+  it('fails closed before serializing invalid provenance', () => {
+    const invalid = negativeFixtures[0];
+    assert.ok(invalid);
+    assert.throws(
+      () => serializeDecisionSignalProvenance(invalidFixtureProvenance(invalid)),
+      (error: unknown) => {
+        assert.ok(error instanceof DecisionSignalProvenanceValidationError);
+        assert.ok(error.errors.length > 0);
+        return true;
+      },
+    );
+  });
+
+  it('is included in the required CI test path', () => {
+    const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    const testWorkflow = readFileSync(join(root, '.github/workflows/test.yml'), 'utf8');
+    assert.match(packageJson.scripts?.['test:data'] ?? '', /tests\/\*\.test\.mts/);
+    assert.match(testWorkflow, /npm run test:data/);
+  });
+});

--- a/tests/decision-signal-provenance.test.mts
+++ b/tests/decision-signal-provenance.test.mts
@@ -191,7 +191,7 @@ describe('decision-signal provenance contract (#5581)', () => {
   });
 
   it('rejects omissions, invalid vocabulary, stale source references, and semantic substitutions', () => {
-    assert.ok(negativeFixtures.length >= 7);
+    assert.equal(negativeFixtures.length, 23);
     for (const fixture of negativeFixtures) {
       const result = validateDecisionSignalProvenance(invalidFixtureProvenance(fixture));
       assert.equal(result.ok, false, `${fixture.id} should fail validation`);
@@ -310,6 +310,17 @@ describe('decision-signal provenance contract (#5581)', () => {
       (error: unknown) => {
         assert.ok(error instanceof DecisionSignalProvenanceValidationError);
         assert.ok(error.errors.length > 0);
+        return true;
+      },
+    );
+  });
+
+  it('fails closed on malformed JSON before it ever reaches shape validation', () => {
+    assert.throws(
+      () => parseDecisionSignalProvenance('{not valid json'),
+      (error: unknown) => {
+        assert.ok(error instanceof DecisionSignalProvenanceValidationError);
+        assert.deepEqual(error.errors.map((issue) => issue.code), ['INVALID_JSON']);
         return true;
       },
     );

--- a/tests/fixtures/decision-signal-provenance/negative.json
+++ b/tests/fixtures/decision-signal-provenance/negative.json
@@ -204,5 +204,89 @@
       }
     ],
     "expectedCodes": ["INVALID_VALUE"]
+  },
+  {
+    "id": "unsupported-contract-version",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "contractVersion",
+        "value": "decision-signal-provenance/v2"
+      }
+    ],
+    "expectedCodes": ["UNSUPPORTED_CONTRACT_VERSION"]
+  },
+  {
+    "id": "unknown-family-id",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "familyId",
+        "value": "unregistered_family"
+      }
+    ],
+    "expectedCodes": ["UNKNOWN_FAMILY"]
+  },
+  {
+    "id": "known-claim-missing-value",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publisher",
+        "value": { "status": "known" }
+      }
+    ],
+    "expectedCodes": ["MISSING_CLAIM_VALUE"]
+  },
+  {
+    "id": "not-applicable-claim-carries-value",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.translation.value",
+        "value": "en"
+      }
+    ],
+    "expectedCodes": ["INVALID_CLAIM"]
+  },
+  {
+    "id": "insecure-source-url",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.source_url.value",
+        "value": "http://www.miit.gov.cn/example/industrial-output-2026-06"
+      }
+    ],
+    "expectedCodes": ["INVALID_VALUE"]
+  },
+  {
+    "id": "source-url-embeds-credentials",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.source_url.value",
+        "value": "https://user:pass@www.miit.gov.cn/example/industrial-output-2026-06"
+      }
+    ],
+    "expectedCodes": ["INVALID_VALUE"]
+  },
+  {
+    "id": "malformed-content-hash",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.original_reference.value.contentHash",
+        "value": "sha1:deadbeef"
+      }
+    ],
+    "expectedCodes": ["INVALID_VALUE"]
   }
 ]

--- a/tests/fixtures/decision-signal-provenance/negative.json
+++ b/tests/fixtures/decision-signal-provenance/negative.json
@@ -1,0 +1,208 @@
+[
+  {
+    "id": "missing-required-publisher",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "delete",
+        "path": "claims.publisher"
+      }
+    ],
+    "expectedCodes": ["MISSING_CLAIM"]
+  },
+  {
+    "id": "missing-unknown-allowed-dimension",
+    "baseFixtureId": "operational-explicit-unknowns",
+    "mutations": [
+      {
+        "operation": "delete",
+        "path": "claims.original_language"
+      }
+    ],
+    "expectedCodes": ["MISSING_CLAIM"]
+  },
+  {
+    "id": "unknown-cannot-become-known-default",
+    "baseFixtureId": "operational-explicit-unknowns",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.corroboration",
+        "value": {
+          "status": "known",
+          "value": {
+            "state": "independently_verified",
+            "sourceSignalIds": []
+          }
+        }
+      }
+    ],
+    "expectedCodes": ["INVALID_STATUS_VOCABULARY"]
+  },
+  {
+    "id": "not-applicable-cannot-carry-zero",
+    "baseFixtureId": "derived-comparison",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.extraction_confidence",
+        "value": {
+          "status": "known",
+          "value": {
+            "score": 0,
+            "method": "default"
+          }
+        }
+      }
+    ],
+    "expectedCodes": ["CLAIM_STATUS_VIOLATES_DECLARATION"]
+  },
+  {
+    "id": "stale-source-registry-snapshot",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publisher.value.registryReference.sourceType",
+        "value": "wire"
+      }
+    ],
+    "expectedCodes": ["STALE_SOURCE_REFERENCE"]
+  },
+  {
+    "id": "undeclared-source-reference",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publisher.value.registryReference.sourceName",
+        "value": "Unregistered Favorable Source"
+      }
+    ],
+    "expectedCodes": ["UNKNOWN_SOURCE_REFERENCE"]
+  },
+  {
+    "id": "publication-time-substituted-as-observation",
+    "baseFixtureId": "typed-document-translated",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publication_time.value.role",
+        "value": "observation"
+      }
+    ],
+    "expectedCodes": ["TIMESTAMP_ROLE_MISMATCH"]
+  },
+  {
+    "id": "revised-vintage-without-sequence-advance",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.revision.value.sequence",
+        "value": 1
+      }
+    ],
+    "expectedCodes": ["INVALID_LINEAGE"]
+  },
+  {
+    "id": "invalid-translation-vocabulary",
+    "baseFixtureId": "typed-document-translated",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.translation.value.state",
+        "value": "verified"
+      }
+    ],
+    "expectedCodes": ["INVALID_STATUS_VOCABULARY"]
+  },
+  {
+    "id": "derived-output-masquerades-as-source",
+    "baseFixtureId": "derived-comparison",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publisher.value.registryReference",
+        "value": {
+          "sourceName": "Reuters",
+          "sourceType": "wire",
+          "propagandaRisk": "low"
+        }
+      }
+    ],
+    "expectedCodes": ["INVALID_SOURCE_REFERENCE"]
+  },
+  {
+    "id": "state-controlled-source-masquerades-as-wire",
+    "baseFixtureId": "typed-document-translated",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publisher.value.type",
+        "value": "wire_service"
+      }
+    ],
+    "expectedCodes": ["PUBLISHER_CLASS_MISMATCH"]
+  },
+  {
+    "id": "invalid-calendar-month",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.observation_time.value.value",
+        "value": "2026-99"
+      }
+    ],
+    "expectedCodes": ["INVALID_VALUE"]
+  },
+  {
+    "id": "invalid-calendar-instant",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publication_time.value.value",
+        "value": "2026-02-31T02:00:00Z"
+      }
+    ],
+    "expectedCodes": ["INVALID_VALUE"]
+  },
+  {
+    "id": "wire-source-masquerades-as-independent",
+    "baseFixtureId": "operational-stale-transport",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.publisher.value.type",
+        "value": "independent_media"
+      }
+    ],
+    "expectedCodes": ["PUBLISHER_CLASS_MISMATCH"]
+  },
+  {
+    "id": "current-signal-carries-replacement-link",
+    "baseFixtureId": "official-numeric-revised",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.supersession.value.relatedSignalId",
+        "value": "signal:replacement"
+      }
+    ],
+    "expectedCodes": ["INVALID_LINEAGE"]
+  },
+  {
+    "id": "unknown-content-timestamp-carries-date",
+    "baseFixtureId": "operational-explicit-unknowns",
+    "mutations": [
+      {
+        "operation": "set",
+        "path": "claims.content_freshness.value.contentAsOf",
+        "value": "2026-07-24"
+      }
+    ],
+    "expectedCodes": ["INVALID_VALUE"]
+  }
+]

--- a/tests/fixtures/decision-signal-provenance/positive.json
+++ b/tests/fixtures/decision-signal-provenance/positive.json
@@ -1,0 +1,869 @@
+[
+  {
+    "id": "official-numeric-revised",
+    "familyId": "official_numeric_observation",
+    "scenarios": ["revised_observation"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:miit-industrial-output:2026-06:v2",
+      "familyId": "official_numeric_observation",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:miit-cn",
+            "name": "Ministry of Industry and Information Technology",
+            "type": "official_government",
+            "registryReference": {
+              "sourceName": "MIIT (China)",
+              "sourceType": "gov",
+              "propagandaRisk": "high"
+            }
+          }
+        },
+        "source_url": {
+          "status": "known",
+          "value": "https://www.miit.gov.cn/example/industrial-output-2026-06"
+        },
+        "original_reference": {
+          "status": "known",
+          "value": {
+            "kind": "observation",
+            "id": "miit:industrial-output:2026-06:v2"
+          }
+        },
+        "original_language": {
+          "status": "known",
+          "value": "zh-CN"
+        },
+        "translation": {
+          "status": "not_applicable",
+          "reason": "The normalized signal is numeric and carries no translated text."
+        },
+        "observation_time": {
+          "status": "known",
+          "value": {
+            "role": "observation",
+            "value": "2026-06",
+            "precision": "month"
+          }
+        },
+        "effective_time": {
+          "status": "unknown",
+          "reason": "The release does not declare a separate effective date."
+        },
+        "publication_time": {
+          "status": "known",
+          "value": {
+            "role": "publication",
+            "value": "2026-07-18T02:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-18T02:07:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "known",
+          "value": {
+            "vintageId": "miit:industrial-output:2026-06:v2",
+            "sequence": 2,
+            "state": "revised"
+          }
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "current"
+          }
+        },
+        "extraction_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.42,
+            "method": "structured-table-parser/v1"
+          }
+        },
+        "classification_confidence": {
+          "status": "not_applicable",
+          "reason": "The series identity is configured rather than inferred."
+        },
+        "corroboration": {
+          "status": "unknown",
+          "reason": "No independent comparison has been performed."
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "fresh",
+            "assessedAt": "2026-07-18T02:08:00Z",
+            "lastSuccessAt": "2026-07-18T02:07:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "current",
+            "assessedAt": "2026-07-18T02:08:00Z",
+            "contentAsOf": "2026-06"
+          }
+        },
+        "derivation": {
+          "status": "not_applicable",
+          "reason": "This is a source observation, not a computed output."
+        }
+      }
+    }
+  },
+  {
+    "id": "typed-document-translated",
+    "familyId": "typed_document_event",
+    "scenarios": ["translated_document", "cancelled_or_superseded_event"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:xinhua-policy-event:2026-07-21:cancelled",
+      "familyId": "typed_document_event",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:xinhua",
+            "name": "Xinhua News Agency",
+            "type": "state_controlled_media",
+            "registryReference": {
+              "sourceName": "Xinhua",
+              "sourceType": "wire",
+              "propagandaRisk": "high"
+            }
+          }
+        },
+        "source_url": {
+          "status": "known",
+          "value": "https://english.news.cn/example/policy-notice"
+        },
+        "original_reference": {
+          "status": "known",
+          "value": {
+            "kind": "document",
+            "id": "xinhua:policy-notice:2026-07-21"
+          }
+        },
+        "original_language": {
+          "status": "known",
+          "value": "zh-CN"
+        },
+        "translation": {
+          "status": "known",
+          "value": {
+            "state": "machine_assisted",
+            "targetLanguage": "en"
+          }
+        },
+        "observation_time": {
+          "status": "not_applicable",
+          "reason": "The record is a document event, not a sampled observation."
+        },
+        "effective_time": {
+          "status": "known",
+          "value": {
+            "role": "effective",
+            "value": "2026-07-22",
+            "precision": "day"
+          }
+        },
+        "publication_time": {
+          "status": "known",
+          "value": {
+            "role": "publication",
+            "value": "2026-07-21T08:30:00Z",
+            "precision": "instant"
+          }
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-21T08:42:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "unknown",
+          "reason": "The publisher supplies no version number."
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "cancelled",
+            "reason": "The publisher withdrew the announced event."
+          }
+        },
+        "extraction_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.61,
+            "method": "document-extractor/v2"
+          }
+        },
+        "classification_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.92,
+            "method": "typed-policy-classifier/v1"
+          }
+        },
+        "corroboration": {
+          "status": "unknown",
+          "reason": "Publisher authority is not independent corroboration."
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "fresh",
+            "assessedAt": "2026-07-21T08:43:00Z",
+            "lastSuccessAt": "2026-07-21T08:42:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "current",
+            "assessedAt": "2026-07-21T08:43:00Z",
+            "contentAsOf": "2026-07-21T08:30:00Z"
+          }
+        },
+        "derivation": {
+          "status": "not_applicable",
+          "reason": "This event is extracted from original evidence."
+        }
+      }
+    }
+  },
+  {
+    "id": "operational-stale-transport",
+    "familyId": "operational_activity_record",
+    "scenarios": ["stale_transport_current_content"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:operational-activity:strait:2026-07-24T08:00Z",
+      "familyId": "operational_activity_record",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:reuters",
+            "name": "Reuters",
+            "type": "wire_service",
+            "registryReference": {
+              "sourceName": "Reuters",
+              "sourceType": "wire",
+              "propagandaRisk": "low"
+            }
+          }
+        },
+        "source_url": {
+          "status": "known",
+          "value": "https://www.reuters.com/example/operational-activity"
+        },
+        "original_reference": {
+          "status": "known",
+          "value": {
+            "kind": "event",
+            "id": "reuters:event:operational-activity:2026-07-24"
+          }
+        },
+        "original_language": {
+          "status": "known",
+          "value": "en"
+        },
+        "translation": {
+          "status": "known",
+          "value": {
+            "state": "not_translated"
+          }
+        },
+        "observation_time": {
+          "status": "known",
+          "value": {
+            "role": "observation",
+            "value": "2026-07-24T08:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "effective_time": {
+          "status": "unknown",
+          "reason": "No separate effective interval is published."
+        },
+        "publication_time": {
+          "status": "known",
+          "value": {
+            "role": "publication",
+            "value": "2026-07-24T08:05:00Z",
+            "precision": "instant"
+          }
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-24T08:07:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "unknown",
+          "reason": "The event publisher does not expose vintages."
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "current"
+          }
+        },
+        "extraction_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.88,
+            "method": "event-parser/v1"
+          }
+        },
+        "classification_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.7,
+            "method": "activity-classifier/v1"
+          }
+        },
+        "corroboration": {
+          "status": "known",
+          "value": {
+            "state": "multi_source",
+            "sourceSignalIds": [
+              "signal:source-a:2026-07-24",
+              "signal:source-b:2026-07-24"
+            ]
+          }
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "stale",
+            "assessedAt": "2026-07-24T09:30:00Z",
+            "lastSuccessAt": "2026-07-24T08:07:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "current",
+            "assessedAt": "2026-07-24T09:30:00Z",
+            "contentAsOf": "2026-07-24T08:00:00Z"
+          }
+        },
+        "derivation": {
+          "status": "not_applicable",
+          "reason": "This is a normalized source event."
+        }
+      }
+    }
+  },
+  {
+    "id": "exchange-disclosure-superseded",
+    "familyId": "exchange_disclosure",
+    "scenarios": ["cancelled_or_superseded_event"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:sec-disclosure:issuer-42:2026-07-23:v2",
+      "familyId": "exchange_disclosure",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:sec",
+            "name": "US Securities and Exchange Commission",
+            "type": "official_exchange",
+            "registryReference": {
+              "sourceName": "SEC",
+              "sourceType": "gov",
+              "propagandaRisk": "unknown"
+            }
+          }
+        },
+        "source_url": {
+          "status": "known",
+          "value": "https://www.sec.gov/example/issuer-42-correction"
+        },
+        "original_reference": {
+          "status": "known",
+          "value": {
+            "kind": "document",
+            "id": "sec:issuer-42:filing:2026-07-23:v2"
+          }
+        },
+        "original_language": {
+          "status": "known",
+          "value": "en"
+        },
+        "translation": {
+          "status": "known",
+          "value": {
+            "state": "not_translated"
+          }
+        },
+        "observation_time": {
+          "status": "not_applicable",
+          "reason": "A disclosure is a published document, not an observation."
+        },
+        "effective_time": {
+          "status": "unknown",
+          "reason": "The correction does not declare a separate effective time."
+        },
+        "publication_time": {
+          "status": "known",
+          "value": {
+            "role": "publication",
+            "value": "2026-07-23T15:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-23T15:04:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "known",
+          "value": {
+            "vintageId": "sec:issuer-42:filing:2026-07-23:v2",
+            "sequence": 2,
+            "state": "corrected"
+          }
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "superseded",
+            "relatedSignalId": "signal:sec-disclosure:issuer-42:2026-07-23:v3"
+          }
+        },
+        "extraction_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.99,
+            "method": "structured-filing-parser/v1"
+          }
+        },
+        "classification_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.95,
+            "method": "disclosure-type-map/v1"
+          }
+        },
+        "corroboration": {
+          "status": "unknown",
+          "reason": "No independent issuer comparison has been performed."
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "fresh",
+            "assessedAt": "2026-07-23T15:05:00Z",
+            "lastSuccessAt": "2026-07-23T15:04:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "current",
+            "assessedAt": "2026-07-23T15:05:00Z",
+            "contentAsOf": "2026-07-23T15:00:00Z"
+          }
+        },
+        "derivation": {
+          "status": "not_applicable",
+          "reason": "This is a source disclosure."
+        }
+      }
+    }
+  },
+  {
+    "id": "corridor-stale-content",
+    "familyId": "composed_corridor_condition",
+    "scenarios": ["current_transport_stale_content", "derived_output"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:corridor-condition:demo:2026-07-24T10:00Z",
+      "familyId": "composed_corridor_condition",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:worldmonitor-derived",
+            "name": "WorldMonitor derived output",
+            "type": "derived_output",
+            "registryReference": null
+          }
+        },
+        "source_url": {
+          "status": "not_applicable",
+          "reason": "The derived condition links its inputs through derivation."
+        },
+        "original_reference": {
+          "status": "not_applicable",
+          "reason": "There is no single original record."
+        },
+        "original_language": {
+          "status": "not_applicable",
+          "reason": "The derived condition has no original-language text."
+        },
+        "translation": {
+          "status": "not_applicable",
+          "reason": "The derived condition has no translated source text."
+        },
+        "observation_time": {
+          "status": "known",
+          "value": {
+            "role": "observation",
+            "value": "2026-07-24T10:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "effective_time": {
+          "status": "known",
+          "value": {
+            "role": "effective",
+            "value": "2026-07-24T10:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "publication_time": {
+          "status": "not_applicable",
+          "reason": "The computed condition is not a publisher release."
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-24T10:01:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "known",
+          "value": {
+            "vintageId": "corridor-condition:demo:2026-07-24T10:00Z",
+            "sequence": 1,
+            "state": "original"
+          }
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "current"
+          }
+        },
+        "extraction_confidence": {
+          "status": "not_applicable",
+          "reason": "Inputs own extraction confidence."
+        },
+        "classification_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.86,
+            "method": "corridor-condition/v1"
+          }
+        },
+        "corroboration": {
+          "status": "known",
+          "value": {
+            "state": "multi_source",
+            "sourceSignalIds": [
+              "signal:corridor-input:a",
+              "signal:corridor-input:b"
+            ]
+          }
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "fresh",
+            "assessedAt": "2026-07-24T10:01:00Z",
+            "lastSuccessAt": "2026-07-24T10:01:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "stale",
+            "assessedAt": "2026-07-24T10:01:00Z",
+            "contentAsOf": "2026-07-20T00:00:00Z"
+          }
+        },
+        "derivation": {
+          "status": "known",
+          "value": {
+            "methodId": "worldmonitor:corridor-condition",
+            "methodVersion": "1",
+            "computedAt": "2026-07-24T10:01:00Z",
+            "inputSignalIds": [
+              "signal:corridor-input:a",
+              "signal:corridor-input:b"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "derived-comparison",
+    "familyId": "derived_comparison",
+    "scenarios": ["derived_output"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:derived-comparison:official-vs-proxy:2026-07",
+      "familyId": "derived_comparison",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:worldmonitor-derived",
+            "name": "WorldMonitor derived output",
+            "type": "derived_output",
+            "registryReference": null
+          }
+        },
+        "source_url": {
+          "status": "not_applicable",
+          "reason": "Inputs retain their own stable source URLs."
+        },
+        "original_reference": {
+          "status": "not_applicable",
+          "reason": "Inputs retain their own original references."
+        },
+        "original_language": {
+          "status": "not_applicable",
+          "reason": "The comparison is numeric."
+        },
+        "translation": {
+          "status": "not_applicable",
+          "reason": "The comparison is numeric."
+        },
+        "observation_time": {
+          "status": "known",
+          "value": {
+            "role": "observation",
+            "value": "2026-07",
+            "precision": "month"
+          }
+        },
+        "effective_time": {
+          "status": "known",
+          "value": {
+            "role": "effective",
+            "value": "2026-07",
+            "precision": "month"
+          }
+        },
+        "publication_time": {
+          "status": "not_applicable",
+          "reason": "The comparison is computed, not published by a source."
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-24T11:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "known",
+          "value": {
+            "vintageId": "comparison:official-vs-proxy:2026-07:v1",
+            "sequence": 1,
+            "state": "original"
+          }
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "current"
+          }
+        },
+        "extraction_confidence": {
+          "status": "not_applicable",
+          "reason": "Inputs own extraction confidence."
+        },
+        "classification_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.75,
+            "method": "agreement-comparison/v1"
+          }
+        },
+        "corroboration": {
+          "status": "known",
+          "value": {
+            "state": "contradicted",
+            "sourceSignalIds": [
+              "signal:official-input:2026-07",
+              "signal:proxy-input:2026-07"
+            ]
+          }
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "fresh",
+            "assessedAt": "2026-07-24T11:00:00Z",
+            "lastSuccessAt": "2026-07-24T11:00:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "current",
+            "assessedAt": "2026-07-24T11:00:00Z",
+            "contentAsOf": "2026-07"
+          }
+        },
+        "derivation": {
+          "status": "known",
+          "value": {
+            "methodId": "worldmonitor:agreement-comparison",
+            "methodVersion": "1",
+            "computedAt": "2026-07-24T11:00:00Z",
+            "inputSignalIds": [
+              "signal:official-input:2026-07",
+              "signal:proxy-input:2026-07"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "operational-explicit-unknowns",
+    "familyId": "operational_activity_record",
+    "scenarios": ["missing_metadata_explicit_unknown"],
+    "provenance": {
+      "contractVersion": "decision-signal-provenance/v1",
+      "signalId": "signal:operational-activity:unknown-metadata:2026-07-24",
+      "familyId": "operational_activity_record",
+      "claims": {
+        "publisher": {
+          "status": "known",
+          "value": {
+            "id": "publisher:reuters",
+            "name": "Reuters",
+            "type": "wire_service",
+            "registryReference": {
+              "sourceName": "Reuters",
+              "sourceType": "wire",
+              "propagandaRisk": "low"
+            }
+          }
+        },
+        "source_url": {
+          "status": "known",
+          "value": "https://www.reuters.com/example/unknown-metadata-event"
+        },
+        "original_reference": {
+          "status": "known",
+          "value": {
+            "kind": "event",
+            "id": "reuters:event:unknown-metadata:2026-07-24"
+          }
+        },
+        "original_language": {
+          "status": "unknown",
+          "reason": "The upstream payload omits language metadata."
+        },
+        "translation": {
+          "status": "unknown",
+          "reason": "Translation state cannot be established without language metadata."
+        },
+        "observation_time": {
+          "status": "known",
+          "value": {
+            "role": "observation",
+            "value": "2026-07-24",
+            "precision": "day"
+          }
+        },
+        "effective_time": {
+          "status": "unknown",
+          "reason": "No effective time was supplied."
+        },
+        "publication_time": {
+          "status": "unknown",
+          "reason": "No publication timestamp was supplied."
+        },
+        "retrieval_time": {
+          "status": "known",
+          "value": {
+            "role": "retrieval",
+            "value": "2026-07-24T12:00:00Z",
+            "precision": "instant"
+          }
+        },
+        "revision": {
+          "status": "unknown",
+          "reason": "No revision metadata was supplied."
+        },
+        "supersession": {
+          "status": "known",
+          "value": {
+            "state": "current"
+          }
+        },
+        "extraction_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.6,
+            "method": "event-parser/v1"
+          }
+        },
+        "classification_confidence": {
+          "status": "known",
+          "value": {
+            "score": 0.5,
+            "method": "activity-classifier/v1"
+          }
+        },
+        "corroboration": {
+          "status": "unknown",
+          "reason": "No corroboration assessment was supplied."
+        },
+        "transport_freshness": {
+          "status": "known",
+          "value": {
+            "state": "fresh",
+            "assessedAt": "2026-07-24T12:00:00Z",
+            "lastSuccessAt": "2026-07-24T12:00:00Z"
+          }
+        },
+        "content_freshness": {
+          "status": "known",
+          "value": {
+            "state": "timestamp_unknown",
+            "assessedAt": "2026-07-24T12:00:00Z"
+          }
+        },
+        "derivation": {
+          "status": "not_applicable",
+          "reason": "This is a normalized source event."
+        }
+      }
+    }
+  }
+]

--- a/tests/fixtures/decision-signal-provenance/positive.json
+++ b/tests/fixtures/decision-signal-provenance/positive.json
@@ -29,7 +29,8 @@
           "status": "known",
           "value": {
             "kind": "observation",
-            "id": "miit:industrial-output:2026-06:v2"
+            "id": "miit:industrial-output:2026-06:v2",
+            "contentHash": "sha256:62d42e59ae40a23dd63c594c613471cea77d04a938c435a0521476131db95588"
           }
         },
         "original_language": {


### PR DESCRIPTION
## Summary

Normalized decision signals now have one runtime-neutral, fail-closed provenance contract that can round-trip unchanged through cache, API, MCP, and UI boundaries.

- define the complete claim vocabulary for publisher identity, original evidence, language/translation, time roles, lineage, confidence, corroboration, freshness, and derivation
- require every signal family to declare every dimension as required, explicitly unknown-capable, or not applicable
- validate source-backed publishers against the source-provenance registry from #5571 without conflating government, state-media, wire, market, or independent publishers
- provide canonical serialization adapters for cache storage, API, MCP, and UI surfaces
- enforce declaration, registration, fixture, and serialization completeness through a focused CI contract
- document the shared extension workflow in English and Chinese

This is additive infrastructure only. It does not migrate existing feed payloads or implement any China domain adapters or product surfaces.

## Verification

- `node --import tsx --test tests/decision-signal-provenance.test.mts` — 9 passed
- mutation proof: intentionally cross-wiring an official-numeric registration to the typed-document fixture failed the completeness gate
- `node --test tests/docs-i18n-parity.test.mjs` — 231 passed
- `npm run typecheck`
- `npm run typecheck:api`
- `VITE_VARIANT=full ./node_modules/.bin/vite build`
- `npm run test:data` — 16,643 tests; 16,637 passed, 0 failed, 6 skipped
- `npm run docs:check`
- `npm run lint:public-docs`
- `markdownlint-cli2 docs/decision-signal-provenance.mdx docs/zh/decision-signal-provenance.mdx`

## Post-Deploy Monitoring & Validation

No production lane consumes this contract yet, so this PR does not change runtime traffic or stored payloads. The first Phase 2 domain integration should monitor validator rejection counts and verify cache/API/MCP/UI canonical serialization parity during its initial deployment window. The integrating domain owner and WorldMonitor maintainers own that validation; rollback is a revert of the consuming integration before provenance-bearing payloads become an external dependency.

Closes #5581

Related: #5573

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering) and Codex.