### PR TITLE
fix(parsing): decode &amp;amp; last in all 13 hand-rolled entity decoders (#5436)

### DIFF
--- a/scripts/_trade-parse-utils.mjs
+++ b/scripts/_trade-parse-utils.mjs
@@ -18,9 +18,10 @@ export function htmlToPlainText(html) {
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s[^<>]*?)?>/g, ' ')
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, '\'')
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/gi, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5932,8 +5932,9 @@ function _redditEpochSeconds(v) {
 // Reddit emits to keep panel titles identical across paths.
 function _decodeRedditEntities(s) {
   if (typeof s !== 'string') return s;
-  return s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+  // `&amp;` decoded last so one pass decodes one level (#5436).
+  return s.replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&amp;/g, '&');
 }
 
 // Normalize a ScrapeCreators post so its shape matches the OAuth/public paths

--- a/scripts/seed-climate-news.mjs
+++ b/scripts/seed-climate-news.mjs
@@ -34,10 +34,11 @@ function decodeHtmlEntities(text) {
   return text
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
+    .replace(/&nbsp;/g, ' ')
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/g, '&');
 }
 
 function extractTag(block, tagName) {

--- a/scripts/seed-disease-outbreaks.mjs
+++ b/scripts/seed-disease-outbreaks.mjs
@@ -88,7 +88,8 @@ async function fetchRssItems(url, sourceName) {
       const link = (block.match(/<link>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/link>/) || [])[1]?.trim() || '';
       const rawDesc = (block.match(/<description>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/description>/) || [])[1] || '';
       const desc = rawDesc
-        .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ')
+        // `&amp;` decoded last so one pass decodes one level (#5436).
+        .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&')
         .replace(/<[^>]+>/g, '').trim().slice(0, 300);
       const pubDate = (block.match(/<pubDate>(.*?)<\/pubDate>/) || [])[1]?.trim() || '';
       // Per-item synthetic-tag normalization lives in _disease-outbreaks-helpers.mjs

--- a/scripts/seed-energy-intelligence.mjs
+++ b/scripts/seed-energy-intelligence.mjs
@@ -31,11 +31,16 @@ export function stableHash(str) {
   return Math.abs(h).toString(36);
 }
 
-function decodeHtmlEntities(text) {
+// Reject out-of-range/malformed numeric refs instead of letting
+// String.fromCodePoint throw RangeError mid-seed (#5436).
+function decodeNumericReference(codePoint) {
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : '';
+}
+
+export function decodeHtmlEntities(text) {
   return text
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
@@ -45,7 +50,11 @@ function decodeHtmlEntities(text) {
     .replace(/&mdash;/g, '—')
     .replace(/&ndash;/g, '–')
     .replace(/&lsquo;|&rsquo;/g, "'")
-    .replace(/&ldquo;|&rdquo;/g, '"');
+    .replace(/&ldquo;|&rdquo;/g, '"')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => decodeNumericReference(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => decodeNumericReference(parseInt(dec, 10)))
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/g, '&');
 }
 
 function extractTag(block, tagName) {

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -407,14 +407,15 @@ export function extractListedCountries(html, nameLookup) {
 // text (&#39; for apostrophe, &amp; for ampersand, &nbsp; for space).
 // Full-fledged decoders pull in 100KB of dependencies; this targeted
 // list covers what we actually see in the fixtures.
-function decodeHtmlEntities(s) {
+export function decodeHtmlEntities(s) {
   return String(s)
     .replace(/&#39;/g, "'")
     .replace(/&#34;/g, '"')
-    .replace(/&amp;/g, '&')
     .replace(/&nbsp;/g, ' ')
     .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+    .replace(/&gt;/g, '>')
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/g, '&');
 }
 
 // Try to extract the publication date from the URL slug or the page

--- a/scripts/seed-global-tenders.mjs
+++ b/scripts/seed-global-tenders.mjs
@@ -200,16 +200,17 @@ export async function fetchCanadaBuys({ now = Date.now(), fetchTextFn = fetchTex
   return { records, status: sourceStatus('canada-buys', 'ok', records, '', now) };
 }
 
-function decodeHtml(value) {
+export function decodeHtml(value) {
   return String(value || '')
     .replace(/<br\s*\/?\s*>/gi, '\n')
     .replace(/<[^>]+>/g, '')
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;|&apos;/gi, "'")
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/gi, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/seed-hormuz.mjs
+++ b/scripts/seed-hormuz.mjs
@@ -181,7 +181,6 @@ async function fetchPbiCharts() {
 function decodeHtmlEntities(s) {
   return s
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&#039;/g, "'")
@@ -193,7 +192,9 @@ function decodeHtmlEntities(s) {
     .replace(/&ndash;/g, '\u2013')
     .replace(/&#8217;/g, '\u2019')
     .replace(/&#8220;/g, '\u201c')
-    .replace(/&#8221;/g, '\u201d');
+    .replace(/&#8221;/g, '\u201d')
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/g, '&');
 }
 
 function stripTags(s) {

--- a/scripts/seed-regulatory-actions.mjs
+++ b/scripts/seed-regulatory-actions.mjs
@@ -42,19 +42,26 @@ const REGULATORY_FEEDS = [
   { agency: 'FINRA', url: 'http://feeds.finra.org/FINRANotices' },
 ];
 
+// Reject out-of-range/malformed numeric refs instead of letting
+// String.fromCodePoint throw RangeError mid-seed (#5436).
+function decodeNumericReference(codePoint) {
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : '';
+}
+
 function decodeEntities(input) {
   if (!input) return '';
-  const named = input
-    .replace(/&amp;/gi, '&')
+  return input
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&apos;/gi, "'")
-    .replace(/&nbsp;/gi, ' ');
-
-  return named
-    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(parseInt(code, 16)));
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&#(\d+);/g, (_, code) => decodeNumericReference(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => decodeNumericReference(parseInt(code, 16)))
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/gi, '&');
 }
 
 function stripHtml(input) {

--- a/scripts/seed-security-advisories.mjs
+++ b/scripts/seed-security-advisories.mjs
@@ -95,11 +95,15 @@ function isValidUrl(link) {
   } catch { return false; }
 }
 
-function stripHtml(html) {
+export function stripHtml(html) {
   return html.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
-    .replace(/<[^>]+>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<')
+    .replace(/<[^>]+>/g, '').replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ').replace(/&#8217;/g, "'")
-    .replace(/&#8220;/g, '"').replace(/&#8221;/g, '"').replace(/\s+/g, ' ').trim();
+    .replace(/&#8220;/g, '"').replace(/&#8221;/g, '"')
+    // `&amp;` decoded last: amp-first let `&amp;lt;script&amp;gt;` survive the
+    // tag strip above and re-emerge as a live `<script>` (#5436).
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ').trim();
 }
 
 export function parseRssItems(xml) {

--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -339,8 +339,10 @@ function stripHtmlInline(value) {
   return String(value || '')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&nbsp;/g, ' ')
+    // Catch-all must skip `&amp;` so the amp decode below stays one-level:
+    // amp-first turned `&amp;nbsp;` into a decodable second pass (#5436).
+    .replace(/&(?!amp;)[#\w]+;/g, ' ')
     .replace(/&amp;/g, '&')
-    .replace(/&[#\w]+;/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/components/CountryDeepDivePanel-news-utils.ts
+++ b/src/components/CountryDeepDivePanel-news-utils.ts
@@ -2,13 +2,14 @@ import type { NewsItem } from '../types';
 
 export function decodeHtmlEntities(text: string): string {
   return text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, '/');
+    .replace(/&#x2F;/g, '/')
+    // `&amp;` decoded last so one pass decodes one level (#5436).
+    .replace(/&amp;/g, '&');
 }
 
 export function normalizeHeadlineKey(title: string): string {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -52,7 +52,7 @@ import type {
 } from '@/services/supply-chain';
 import { fetchMultiSectorCostShock, HS2_SHORT_LABELS } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
-import { dedupeHeadlines } from './CountryDeepDivePanel-news-utils';
+import { decodeHtmlEntities, dedupeHeadlines } from './CountryDeepDivePanel-news-utils';
 import { renderFollowButton } from '@/utils/follow-button';
 import { renderNotifyCountryLink } from '@/utils/notify-country-link';
 import { exportCountryEvidenceMarkdown } from '@/utils/export';
@@ -3199,14 +3199,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   }
 
   private decodeEntities(text: string): string {
-    return text
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#x27;/g, "'")
-      .replace(/&#x2F;/g, '/');
+    return decodeHtmlEntities(text);
   }
 
   private toThreatLevel(level: string | undefined): ThreatLevel {

--- a/tests/entity-decode-ordering.test.mts
+++ b/tests/entity-decode-ordering.test.mts
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// #5436: every hand-rolled entity decoder must decode `&amp;` LAST. Decoding
+// it first turns the escaped ampersand of `&amp;lt;` into a live `&`, which a
+// later replace then consumes as `&lt;` — one pass decoding two levels, so
+// double-escaped payloads (`&amp;lt;script&amp;gt;`) re-emerge as live markup
+// after tag-stripping. Two decoders also fed unvalidated numeric refs straight
+// into String.fromCodePoint, which throws RangeError above 0x10FFFF.
+
+import { htmlToPlainText } from '../scripts/_trade-parse-utils.mjs';
+import { decodeHtmlEntities as decodeEnergy } from '../scripts/seed-energy-intelligence.mjs';
+import { decodeHtmlEntities as decodeFatf } from '../scripts/seed-fatf-listing.mjs';
+import { decodeHtml as decodeGlobalTenders } from '../scripts/seed-global-tenders.mjs';
+import { decodeEntities as decodeRegulatory } from '../scripts/seed-regulatory-actions.mjs';
+import { stripHtml as stripAdvisoriesHtml } from '../scripts/seed-security-advisories.mjs';
+import { decodeHtmlEntities as decodePanelNews } from '../src/components/CountryDeepDivePanel-news-utils';
+
+const DOUBLE_ESCAPED = '&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;';
+
+describe('single-level decode: &amp;lt; must yield the text "&lt;", never "<"', () => {
+  const plainDecoders: Array<[string, (s: string) => string]> = [
+    ['seed-energy-intelligence', decodeEnergy],
+    ['seed-fatf-listing', decodeFatf],
+    ['seed-regulatory-actions', decodeRegulatory],
+    ['CountryDeepDivePanel-news-utils', decodePanelNews],
+  ];
+
+  for (const [name, decode] of plainDecoders) {
+    it(`${name}: double-escaped markup stays escaped one level`, () => {
+      const out = decode(DOUBLE_ESCAPED);
+      assert.ok(!out.includes('<script'), `${name} produced live markup: ${out}`);
+      assert.ok(out.includes('&lt;script&gt;'), `${name} lost the single-escaped form: ${out}`);
+    });
+
+    it(`${name}: plain &amp; still decodes`, () => {
+      assert.equal(decode('Fish &amp; Chips'), 'Fish & Chips');
+    });
+
+    it(`${name}: singly-escaped entities still decode`, () => {
+      assert.equal(decode('&lt;b&gt;'), '<b>');
+    });
+  }
+});
+
+describe('strip-then-decode pipelines cannot be re-armed by double escaping', () => {
+  it('seed-security-advisories stripHtml: double-escaped <script> does not survive the strip', () => {
+    const out = stripAdvisoriesHtml(`<p>ACSC alert</p> ${DOUBLE_ESCAPED}`);
+    assert.ok(!out.includes('<script'), `live markup in: ${out}`);
+    assert.ok(out.includes('ACSC alert'));
+  });
+
+  it('seed-global-tenders decodeHtml: double-escaped <script> does not survive the strip', () => {
+    const out = decodeGlobalTenders(`<b>Tender</b> ${DOUBLE_ESCAPED}`);
+    assert.ok(!out.includes('<script'), `live markup in: ${out}`);
+    assert.ok(out.includes('Tender'));
+  });
+
+  it('_trade-parse-utils htmlToPlainText: &amp;quot; stays one level', () => {
+    assert.equal(htmlToPlainText('&amp;quot;x&amp;quot;'), '&quot;x&quot;');
+    assert.equal(htmlToPlainText('&quot;x&quot;'), '"x"');
+  });
+});
+
+describe('numeric refs are bounds-checked instead of throwing RangeError', () => {
+  const numericDecoders: Array<[string, (s: string) => string]> = [
+    ['seed-energy-intelligence', decodeEnergy],
+    ['seed-regulatory-actions', decodeRegulatory],
+  ];
+
+  for (const [name, decode] of numericDecoders) {
+    it(`${name}: out-of-range refs are dropped without throwing`, () => {
+      assert.doesNotThrow(() => decode('&#x110000;'));
+      assert.doesNotThrow(() => decode('&#9999999999;'));
+      assert.equal(decode('a&#x110000;b'), 'ab');
+    });
+
+    it(`${name}: valid refs still decode (incl. astral plane)`, () => {
+      assert.equal(decode('&#128512;'), '\u{1F600}');
+      assert.equal(decode('&#x27;'), "'");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #5436.

The entity-decode ordering bug fixed for `list-feed-digest`'s `decodeXmlEntities` in #5432 existed in **every other hand-rolled decoder in the repo**: decoding `&amp;` before the other entity replaces turns the escaped ampersand of `&amp;lt;` into a live `&`, which the very next replace consumes as `&lt;` — one pass decoding two levels. In the strip-then-decode pipelines (`seed-security-advisories`, `seed-global-tenders`) a double-escaped `&amp;lt;script&amp;gt;` survived the tag strip and re-emerged as a live `<script>` in seeded content.

**All 13 decoders reordered so `&amp;` is decoded last** (mirroring the #5432 reference, with the same explanatory comment):

- 10 seeder/parse scripts: `_trade-parse-utils`, `seed-climate-news`, `seed-disease-outbreaks`, `seed-energy-intelligence`, `seed-fatf-listing`, `seed-global-tenders`, `seed-hormuz`, `seed-regulatory-actions`, `seed-security-advisories`, `seed-sovereign-wealth`
- `ais-relay.cjs` (`_decodeRedditEntities`)
- both `CountryDeepDivePanel` decoders — the panel's private copy was an exact duplicate of the `CountryDeepDivePanel-news-utils` export and now delegates to it

Details:
- `seed-sovereign-wealth`'s catch-all `&[#\w]+;` replace gets a `(?!amp;)` lookahead so the trailing `&amp;` decode stays one-level.
- The two decoders that fed unvalidated numeric refs straight into `String.fromCodePoint` (`seed-energy-intelligence`, `seed-regulatory-actions` — `RangeError` above `0x10FFFF` killed the whole seed run on one malformed ref) now bounds-check via the same `decodeNumericReference` guard the reference fix uses; out-of-range refs are dropped, astral-plane refs still decode.

## Type of change

- [x] Bug fix

## Affected areas

- [x] News panels / RSS feeds
- [x] Other: seeder scripts (`scripts/seed-*`), AIS relay Reddit path, `CountryDeepDivePanel`

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documentation claims or generated docs change.

## Verification

- New `tests/entity-decode-ordering.test.mts` (19 cases): single-level decode (`&amp;lt;script&amp;gt;` yields the text `&lt;script&gt;`, never live markup), strip-pipeline re-arm prevention for `seed-security-advisories`/`seed-global-tenders`, `RangeError` guards (`&#x110000;`, `&#9999999999;` dropped without throwing; `&#128512;` → 😀), and plain/singly-escaped input still decodes. **RED on the pre-fix code.**
- `seed-climate-news` and `seed-hormuz` execute their seed at import time (no main guard), so their decoders carry the fix + comment but are not directly imported by the test — noted here so a future import-safety refactor can add them.
- Affected existing suites all green (291 tests): `regulatory-seed-unit`, `seed-fatf-listing`, `energy-spine-seed`, `security-advisory-source-contract`, `ais-relay-rss`, `seed-bundle-resilience-recovery`, `swf-*`, `seed-sovereign-wealth-*`, `country-news-dedupe`, `nixpacks-seeder-import-graph`, `seed-ttl-outlives-staleness-fleet`.
- `npm run typecheck` clean.

## Screenshots

N/A — text-parsing change; no UI rendering difference for well-formed content.