### PR TITLE
fix(tech-events): cache the widest payload on cold-start fallback (#5427)

### DIFF
--- a/scripts/purge-tech-events-cache.mjs
+++ b/scripts/purge-tech-events-cache.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Operator one-shot: purge the shared tech-events cache key after the
+ * #5427 fix reaches production.
+ *
+ * WHY THIS EXISTS
+ *
+ * #5427 let the cold-start fallback write a REQUEST-NARROWED payload under
+ * the shared, request-independent `research:tech-events:v1` key, so whichever
+ * request warmed a cold cache decided what every client saw. The fix stops
+ * new poisoning, but it does not clear an entry that was already poisoned
+ * before the deploy — that entry keeps being served until it expires on its
+ * own TTL (the fallback writes 6h) or the relay's next cycle overwrites it
+ * (`TECH_EVENTS_SEED_INTERVAL_MS` is 6h in scripts/ais-relay.cjs). So the
+ * symptom can outlive the fix by up to ~6h and look like the fix did not
+ * work. One DEL makes recovery immediate: the next read repopulates from the
+ * seeder, or from the now-widest cold-start fallback.
+ *
+ * ORDERING — run this AFTER the fix is live in production. Purging while a
+ * pre-fix isolate is still serving just lets it re-poison the key. This is
+ * the same "wait for the writer to be current before purging" ordering as
+ * docs/solutions/workflow-issues/purging-the-live-product-catalog-three-layer-cache.md.
+ *
+ * SCOPE — deliberately ONE key. `research:tech-events-bootstrap:v1` is NOT
+ * purged: only the seeders ever write it (scripts/ais-relay.cjs writes both
+ * keys from the same full event list), and the cold-start fallback never
+ * touches it, so it was never poisoned by #5427. Purging it would force a
+ * needless re-seed of a correct value.
+ *
+ * This targets the unprefixed production key. Preview deployments read a
+ * `preview:<sha>:`-prefixed key (server/_shared/redis.ts getKeyPrefix), which
+ * is per-deployment and expires on its own; it is not worth purging.
+ *
+ * USAGE
+ *
+ *   node scripts/purge-tech-events-cache.mjs [--dry-run]
+ *
+ * Requires UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in the env.
+ *
+ * RETURN CODES
+ *
+ *   0 — completed. Covers both "deleted" and "already absent": the goal is
+ *       the key not holding a pre-fix payload, and an expired key satisfies
+ *       that. Distinguished in the log line, not the exit code.
+ *   1 — argument or missing-credential failure.
+ *   2 — Upstash transport failure. Means RETRY — explicitly not "nothing to
+ *       purge", so an operator never reads a dead connection as success.
+ */
+
+import { realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { defaultRedisPipeline } from './lib/_upstash-pipeline.mjs';
+
+export const TECH_EVENTS_CACHE_KEY = 'research:tech-events:v1';
+
+const EXIT_OK = 0;
+const EXIT_ARG = 1;
+const EXIT_TRANSPORT = 2;
+
+/**
+ * Flag parser. Only `--dry-run` is accepted; anything else is rejected loudly
+ * so a typo cannot silently degrade into "did nothing and exited 0".
+ *
+ * @param {string[]} argv process.argv.slice(2)
+ * @returns {{ kind: 'ok', dryRun: boolean } | { kind: 'err', message: string }}
+ */
+export function parseArgs(argv) {
+  let dryRun = false;
+  for (const flag of argv) {
+    if (flag === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    return { kind: 'err', message: `unknown flag: ${JSON.stringify(flag)} (allowed: --dry-run)` };
+  }
+  return { kind: 'ok', dryRun };
+}
+
+/**
+ * Orchestration split out from `main` so tests can drive it without
+ * process.exit and without a live Upstash.
+ *
+ * @param {object} args
+ * @param {boolean} args.dryRun
+ * @param {object} [args.deps]
+ * @param {typeof defaultRedisPipeline} [args.deps.redisPipeline]
+ * @param {(line: string) => void} [args.deps.log]
+ * @param {(line: string) => void} [args.deps.warn]
+ * @returns {Promise<{ code: number, deleted: boolean }>}
+ */
+export async function runPurge({ dryRun, deps } = {}) {
+  const log = deps?.log ?? ((line) => console.log(line));
+  const warn = deps?.warn ?? ((line) => console.warn(line));
+  const pipeline = deps?.redisPipeline ?? defaultRedisPipeline;
+
+  if (dryRun) {
+    log(`[purge-tech-events-cache] DRY RUN — would DEL key=${TECH_EVENTS_CACHE_KEY}`);
+    return { code: EXIT_OK, deleted: false };
+  }
+
+  const result = await pipeline([['DEL', TECH_EVENTS_CACHE_KEY]]);
+  // null is the helper's single failure channel (missing creds, non-2xx,
+  // timeout, throw). Callers check creds first, so here it means transport.
+  if (result == null || !Array.isArray(result)) {
+    warn('[purge-tech-events-cache] DEL pipeline returned null — Upstash transport failure; key NOT purged, retry');
+    return { code: EXIT_TRANSPORT, deleted: false };
+  }
+
+  const cell = result[0];
+  if (cell && typeof cell === 'object' && 'error' in cell) {
+    warn(`[purge-tech-events-cache] DEL key=${TECH_EVENTS_CACHE_KEY} → upstream error: ${cell.error}`);
+    return { code: EXIT_TRANSPORT, deleted: false };
+  }
+
+  const at = new Date().toISOString();
+  // DEL returns 1 when the key existed, 0 when it had already expired or was
+  // purged by someone else. Both leave the key free of a pre-fix payload.
+  if (Number(cell?.result ?? 0) >= 1) {
+    log(`[purge-tech-events-cache] DELETED key=${TECH_EVENTS_CACHE_KEY} at=${at} — next read repopulates from the seeder or the widest fallback`);
+    return { code: EXIT_OK, deleted: true };
+  }
+  log(`[purge-tech-events-cache] key=${TECH_EVENTS_CACHE_KEY} already absent at=${at} (expired or previously purged) — nothing to do`);
+  return { code: EXIT_OK, deleted: false };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.kind === 'err') {
+    console.error(`[purge-tech-events-cache] ARG ERROR: ${parsed.message}`);
+    console.error('Usage: node scripts/purge-tech-events-cache.mjs [--dry-run]');
+    process.exit(EXIT_ARG);
+  }
+  if (!parsed.dryRun && (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN)) {
+    console.error('[purge-tech-events-cache] UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN must be set in env');
+    process.exit(EXIT_ARG);
+  }
+  const { code } = await runPurge({ dryRun: parsed.dryRun });
+  process.exit(code);
+}
+
+/**
+ * True only when this file is the process entrypoint.
+ *
+ * Both sides are realpath'd before comparison: Node sets `import.meta.url` to
+ * the resolved real path while `process.argv[1]` keeps whatever symlinked path
+ * the caller typed (e.g. macOS `/tmp` -> `/private/tmp`). Comparing them raw —
+ * or via a bare `file://${process.argv[1]}` template, which also breaks on
+ * paths containing spaces — makes the script silently exit 0 without purging,
+ * which for a purge tool is indistinguishable from success.
+ */
+function isDirectInvocation() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return pathToFileURL(realpathSync(entry)).href === pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectInvocation()) {
+  main().catch((err) => {
+    console.error('[purge-tech-events-cache] FATAL:', err);
+    process.exit(EXIT_TRANSPORT);
+  });
+}

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -454,6 +454,23 @@ function filterEvents(
 
 // ---------- Handler ----------
 
+/**
+ * The cold-start fallback must cache the WIDEST payload under the shared,
+ * request-independent `research:tech-events:v1` key: the Railway relay seeds
+ * the full list there, and `filterEvents()` re-narrows per caller. Forwarding
+ * the live request's `type`/`mappable`/`limit`/`days` into the fetcher pinned
+ * one caller's narrowed view for every client for the full 6h TTL (#5427).
+ * `limit`/`days` mirror `resolveTechEventsPaging`'s clamp maxima, so this
+ * request cannot resolve narrower than the documented widest bounds.
+ * Exported for the regression test.
+ */
+export const WIDEST_TECH_EVENTS_REQUEST: ListTechEventsRequest = {
+  type: 'all',
+  mappable: false,
+  limit: 200,
+  days: 365,
+};
+
 export async function listTechEvents(
   ctx: ServerContext,
   req: ListTechEventsRequest,
@@ -463,8 +480,10 @@ export async function listTechEvents(
 
     // Primary: read from seed-populated Redis key (Railway relay seeds this every 6h)
     const result = await cachedFetchJson<ListTechEventsResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {
-      // Fallback fetcher: only runs on cold start when seed hasn't populated yet
-      const fetched = await fetchTechEvents(req, pagingPresence);
+      // Fallback fetcher: only runs on cold start when seed hasn't populated
+      // yet. MUST fetch the widest set — per-request narrowing happens in
+      // filterEvents() below, never in what gets cached under the shared key.
+      const fetched = await fetchTechEvents(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true });
       return fetched.events.length > 0 ? fetched : null;
     });
 

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -28,6 +28,14 @@ import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 const REDIS_CACHE_KEY = 'research:tech-events:v1';
 const REDIS_CACHE_TTL = 21600; // 6 hr — weekly event data
 
+/**
+ * Set on the response when neither the seeder nor the cold-start fetch could
+ * supply upstream data. Doubles as the gateway's no-store signal — see the
+ * comment at the early return in `listTechEvents`. Exported for the tests that
+ * pin that contract.
+ */
+export const TECH_EVENTS_UNAVAILABLE_ERROR = 'tech events unavailable: no upstream data';
+
 // ---------- Constants ----------
 
 const ICS_URL = 'https://www.techmeme.com/newsy_events.ics';
@@ -306,24 +314,10 @@ function parseDevEventsRSS(rssText: string): TechEvent[] {
 /** Number of external feeds (Techmeme ICS + dev.events RSS) behind a fetch. */
 const EXTERNAL_SOURCE_COUNT = 2;
 
-/**
- * A fetch plus how much of it came from upstream.
- *
- * `externalSourcesFailed` is deliberately OUTSIDE `response`: the response is
- * what gets written to the shared cache key, and it must keep the exact shape
- * the seeders write (scripts/ais-relay.cjs, scripts/seed-research.mjs). Only
- * the cache-fill path reads this counter, to decide whether the payload is
- * worth persisting at all.
- */
-interface TechEventsFetch {
-  response: ListTechEventsResponse;
-  externalSourcesFailed: number;
-}
-
 async function fetchTechEvents(
   req: ListTechEventsRequest,
   pagingPresence: TechEventsPagingPresence,
-): Promise<TechEventsFetch> {
+): Promise<ListTechEventsResponse> {
   const { type, mappable } = req;
   const { limit, days } = resolveTechEventsPaging(req, pagingPresence);
 
@@ -410,16 +404,13 @@ async function fetchTechEvents(
   }
 
   return {
-    response: {
-      success: true,
-      count: events.length,
-      conferenceCount: conferences.length,
-      mappableCount,
-      lastUpdated: new Date().toISOString(),
-      events,
-      error: '',
-    },
-    externalSourcesFailed,
+    success: true,
+    count: events.length,
+    conferenceCount: conferences.length,
+    mappableCount,
+    lastUpdated: new Date().toISOString(),
+    events,
+    error: '',
   };
 }
 
@@ -506,31 +497,31 @@ export const WIDEST_TECH_EVENTS_REQUEST: Readonly<ListTechEventsRequest> = Objec
  * with it).
  */
 export async function fetchWidestTechEvents(): Promise<ListTechEventsResponse | null> {
-  const { response, externalSourcesFailed } = await fetchTechEvents(
-    WIDEST_TECH_EVENTS_REQUEST,
-    { hasLimit: true, hasDays: true },
-  );
+  const response = await fetchTechEvents(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true });
 
-  // Returning null here makes cachedFetchJson write a 120s NEG_SENTINEL
-  // instead of a REDIS_CACHE_TTL (6h) payload, so the key recovers on the
-  // next request rather than on the seeder's next cycle.
+  // Returning null makes cachedFetchJson write a 120s NEG_SENTINEL instead of
+  // a REDIS_CACHE_TTL (6h) payload, so the shared key recovers on the next
+  // request rather than on the seeder's next cycle.
   //
-  // Refuse when NO external feed answered. `CURATED_EVENTS` alone always
-  // clears the `events.length > 0` bar, so without this check a total upstream
-  // outage pins a curated-only rump under the seeder-owned key for 6h, served
-  // to every client as `success: true` with an empty `error`. That is strictly
-  // worse than the pre-#5603 behaviour, where the caller's default 90-day
-  // window dropped the far-future curated entries, the payload came back
-  // empty, and the key self-healed in 120s. This is the Seed-Owned Key
-  // contract in CONCEPTS.md: a reader answers a miss with a short-TTL
-  // fallback and never poisons the key with a degraded payload.
+  // The test is whether any event actually came from UPSTREAM, not whether a
+  // fetch threw. `CURATED_EVENTS` alone always clears an `events.length > 0`
+  // bar, so a curated-only payload would otherwise be pinned under the
+  // seeder-owned key for 6h and served to every client as `success: true`.
+  // Keying on a fetch-failure counter misses the common shape where a feed
+  // answers HTTP 200 with an error page or an empty calendar: the body clears
+  // fetchTextWithRelay's 100-char floor, so the fetch "succeeded" while
+  // parsing yields nothing. Both shapes collapse to the same question --
+  // did upstream give us anything? -- so ask that directly.
   //
-  // A PARTIAL failure still caches: one live feed is materially complete
+  // This is the Seed-Owned Key contract in CONCEPTS.md: a reader answers a
+  // miss with a short-TTL fallback and never poisons the key with a degraded
+  // payload.
+  //
+  // A PARTIAL fetch still caches: one live feed is materially complete
   // (~26 or ~100 events), and refusing it would drop every caller into the
   // empty-response window for as long as the other feed stayed down.
-  if (externalSourcesFailed >= EXTERNAL_SOURCE_COUNT) return null;
-
-  return response.events.length > 0 ? response : null;
+  const hasUpstreamData = response.events.some(e => e.source !== 'curated');
+  return hasUpstreamData ? response : null;
 }
 
 export async function listTechEvents(
@@ -550,8 +541,24 @@ export async function listTechEvents(
       fetchWidestTechEvents,
     );
 
+    // No data at all: the seeder has not populated the key and the cold-start
+    // fetch found nothing upstream. This is NOT the same as "your filters
+    // matched nothing" -- that case flows through filterEvents() below and
+    // legitimately returns count 0 with an empty `error`.
+    //
+    // The non-empty `error` is load-bearing, not decoration: the gateway reads
+    // it via getRpcNoStoreReasonFromJson (server/gateway.ts:1933) and answers
+    // `Cache-Control: no-store`. Without it this route falls to its 'daily'
+    // tier (gateway.ts:265 -> s-maxage=14400), so an outage that Redis now
+    // shrugs off in 120s would instead sit at the shared CDN edge for 4h.
+    // It also lets a client tell "upstream is down" from "no events found".
+    //
+    // `success` stays true because the RPC itself did not fail; a dedicated
+    // `dataAvailable`/`upstreamUnavailable` proto field (as consumer-prices
+    // and natural-events have) would model this better than overloading
+    // `error`, but that needs a schema change beyond this fix.
     if (!result || result.events.length === 0) {
-      return { success: true, count: 0, conferenceCount: 0, mappableCount: 0, lastUpdated: new Date().toISOString(), events: [], error: '' };
+      return { success: true, count: 0, conferenceCount: 0, mappableCount: 0, lastUpdated: new Date().toISOString(), events: [], error: TECH_EVENTS_UNAVAILABLE_ERROR };
     }
 
     // Apply geocoding (seed stores events without coords) and filter by request params

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -303,10 +303,27 @@ function parseDevEventsRSS(rssText: string): TechEvent[] {
 
 // ---------- Fetch ----------
 
+/** Number of external feeds (Techmeme ICS + dev.events RSS) behind a fetch. */
+const EXTERNAL_SOURCE_COUNT = 2;
+
+/**
+ * A fetch plus how much of it came from upstream.
+ *
+ * `externalSourcesFailed` is deliberately OUTSIDE `response`: the response is
+ * what gets written to the shared cache key, and it must keep the exact shape
+ * the seeders write (scripts/ais-relay.cjs, scripts/seed-research.mjs). Only
+ * the cache-fill path reads this counter, to decide whether the payload is
+ * worth persisting at all.
+ */
+interface TechEventsFetch {
+  response: ListTechEventsResponse;
+  externalSourcesFailed: number;
+}
+
 async function fetchTechEvents(
   req: ListTechEventsRequest,
   pagingPresence: TechEventsPagingPresence,
-): Promise<ListTechEventsResponse> {
+): Promise<TechEventsFetch> {
   const { type, mappable } = req;
   const { limit, days } = resolveTechEventsPaging(req, pagingPresence);
 
@@ -389,17 +406,20 @@ async function fetchTechEvents(
   const mappableCount = conferences.filter(e => e.coords && !e.coords.virtual).length;
 
   if (externalSourcesFailed > 0) {
-    console.warn(`[tech-events] ${externalSourcesFailed}/2 external sources failed, returning ${events.length} events (curated fallback)`);
+    console.warn(`[tech-events] ${externalSourcesFailed}/${EXTERNAL_SOURCE_COUNT} external sources failed, returning ${events.length} events (curated fallback)`);
   }
 
   return {
-    success: true,
-    count: events.length,
-    conferenceCount: conferences.length,
-    mappableCount,
-    lastUpdated: new Date().toISOString(),
-    events,
-    error: '',
+    response: {
+      success: true,
+      count: events.length,
+      conferenceCount: conferences.length,
+      mappableCount,
+      lastUpdated: new Date().toISOString(),
+      events,
+      error: '',
+    },
+    externalSourcesFailed,
   };
 }
 
@@ -486,8 +506,31 @@ export const WIDEST_TECH_EVENTS_REQUEST: Readonly<ListTechEventsRequest> = Objec
  * with it).
  */
 export async function fetchWidestTechEvents(): Promise<ListTechEventsResponse | null> {
-  const fetched = await fetchTechEvents(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true });
-  return fetched.events.length > 0 ? fetched : null;
+  const { response, externalSourcesFailed } = await fetchTechEvents(
+    WIDEST_TECH_EVENTS_REQUEST,
+    { hasLimit: true, hasDays: true },
+  );
+
+  // Returning null here makes cachedFetchJson write a 120s NEG_SENTINEL
+  // instead of a REDIS_CACHE_TTL (6h) payload, so the key recovers on the
+  // next request rather than on the seeder's next cycle.
+  //
+  // Refuse when NO external feed answered. `CURATED_EVENTS` alone always
+  // clears the `events.length > 0` bar, so without this check a total upstream
+  // outage pins a curated-only rump under the seeder-owned key for 6h, served
+  // to every client as `success: true` with an empty `error`. That is strictly
+  // worse than the pre-#5603 behaviour, where the caller's default 90-day
+  // window dropped the far-future curated entries, the payload came back
+  // empty, and the key self-healed in 120s. This is the Seed-Owned Key
+  // contract in CONCEPTS.md: a reader answers a miss with a short-TTL
+  // fallback and never poisons the key with a degraded payload.
+  //
+  // A PARTIAL failure still caches: one live feed is materially complete
+  // (~26 or ~100 events), and refusing it would drop every caller into the
+  // empty-response window for as long as the other feed stayed down.
+  if (externalSourcesFailed >= EXTERNAL_SOURCE_COUNT) return null;
+
+  return response.events.length > 0 ? response : null;
 }
 
 export async function listTechEvents(

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -471,6 +471,25 @@ export const WIDEST_TECH_EVENTS_REQUEST: ListTechEventsRequest = {
   days: 365,
 };
 
+/**
+ * The cache-miss fetcher, exactly as handed to `cachedFetchJson`.
+ *
+ * It takes NO parameters on purpose. The bug this fixes was the handler
+ * threading the live request into the fetcher, so the shared key ended up
+ * holding one caller's narrowed view; with a zero-argument fetcher that
+ * regression cannot be reintroduced silently — passing caller state back in
+ * requires changing this signature, which is a type error at the call site
+ * rather than a behaviour change no test would notice.
+ *
+ * Exported so the wiring itself is executable in tests, not just the constant
+ * above (the constant being right proves nothing about what the handler does
+ * with it).
+ */
+export async function fetchWidestTechEvents(): Promise<ListTechEventsResponse | null> {
+  const fetched = await fetchTechEvents(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true });
+  return fetched.events.length > 0 ? fetched : null;
+}
+
 export async function listTechEvents(
   ctx: ServerContext,
   req: ListTechEventsRequest,
@@ -478,14 +497,15 @@ export async function listTechEvents(
   try {
     const pagingPresence = readTechEventsPagingPresence(ctx);
 
-    // Primary: read from seed-populated Redis key (Railway relay seeds this every 6h)
-    const result = await cachedFetchJson<ListTechEventsResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {
-      // Fallback fetcher: only runs on cold start when seed hasn't populated
-      // yet. MUST fetch the widest set — per-request narrowing happens in
-      // filterEvents() below, never in what gets cached under the shared key.
-      const fetched = await fetchTechEvents(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true });
-      return fetched.events.length > 0 ? fetched : null;
-    });
+    // Primary: read from seed-populated Redis key (Railway relay seeds this every 6h).
+    // The cold-start fallback is request-independent by construction — see
+    // fetchWidestTechEvents. Per-request narrowing happens in filterEvents()
+    // below, never in what gets cached under the shared key.
+    const result = await cachedFetchJson<ListTechEventsResponse>(
+      REDIS_CACHE_KEY,
+      REDIS_CACHE_TTL,
+      fetchWidestTechEvents,
+    );
 
     if (!result || result.events.length === 0) {
       return { success: true, count: 0, conferenceCount: 0, mappableCount: 0, lastUpdated: new Date().toISOString(), events: [], error: '' };

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -464,12 +464,12 @@ function filterEvents(
  * request cannot resolve narrower than the documented widest bounds.
  * Exported for the regression test.
  */
-export const WIDEST_TECH_EVENTS_REQUEST: ListTechEventsRequest = {
+export const WIDEST_TECH_EVENTS_REQUEST: Readonly<ListTechEventsRequest> = Object.freeze({
   type: 'all',
   mappable: false,
   limit: 200,
   days: 365,
-};
+});
 
 /**
  * The cache-miss fetcher, exactly as handed to `cachedFetchJson`.

--- a/tests/purge-tech-events-cache.test.mjs
+++ b/tests/purge-tech-events-cache.test.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  TECH_EVENTS_CACHE_KEY,
+  parseArgs,
+  runPurge,
+} from '../scripts/purge-tech-events-cache.mjs';
+
+// Importing this module must not purge anything: the entrypoint is guarded by
+// isDirectInvocation(). If that guard ever inverts, these tests would issue a
+// real DEL against whatever Upstash creds happen to be in the environment.
+// Every case below injects a fake pipeline, so a real one is never reachable.
+
+function collect() {
+  const lines = [];
+  return { lines, sink: (line) => lines.push(line) };
+}
+
+describe('purge-tech-events-cache argument parsing', () => {
+  it('defaults to a live run with no flags', () => {
+    assert.deepEqual(parseArgs([]), { kind: 'ok', dryRun: false });
+  });
+
+  it('accepts --dry-run', () => {
+    assert.deepEqual(parseArgs(['--dry-run']), { kind: 'ok', dryRun: true });
+  });
+
+  it('rejects an unknown flag rather than silently doing nothing', () => {
+    const result = parseArgs(['--force']);
+    assert.equal(result.kind, 'err');
+    assert.match(result.message, /unknown flag/);
+  });
+
+  // A typo'd --dry-run must not fall through to a live DEL.
+  it('rejects a misspelled dry-run flag instead of purging for real', () => {
+    assert.equal(parseArgs(['--dryrun']).kind, 'err');
+  });
+});
+
+describe('purge-tech-events-cache purge behaviour', () => {
+  it('purges exactly the RPC key and not the bootstrap key', async () => {
+    const sent = [];
+    const { lines, sink } = collect();
+    const result = await runPurge({
+      dryRun: false,
+      deps: {
+        redisPipeline: async (commands) => {
+          sent.push(commands);
+          return [{ result: 1 }];
+        },
+        log: sink,
+        warn: sink,
+      },
+    });
+
+    assert.deepEqual(sent, [[['DEL', TECH_EVENTS_CACHE_KEY]]]);
+    assert.equal(TECH_EVENTS_CACHE_KEY, 'research:tech-events:v1');
+    assert.ok(
+      !JSON.stringify(sent).includes('bootstrap'),
+      'the bootstrap key is seeder-owned and was never poisoned; it must not be purged',
+    );
+    assert.deepEqual(result, { code: 0, deleted: true });
+    assert.ok(lines.some((l) => l.includes('DELETED')));
+  });
+
+  it('treats an already-absent key as success, not failure', async () => {
+    const { lines, sink } = collect();
+    const result = await runPurge({
+      dryRun: false,
+      deps: { redisPipeline: async () => [{ result: 0 }], log: sink, warn: sink },
+    });
+
+    assert.deepEqual(result, { code: 0, deleted: false });
+    assert.ok(lines.some((l) => l.includes('already absent')));
+  });
+
+  // The load-bearing case. The pipeline helper collapses every failure mode
+  // (non-2xx, timeout, throw) into `null`. If that were read as "nothing to
+  // purge", an operator would believe a dead connection had cleared the key
+  // and the stale payload would keep serving for the rest of its TTL.
+  it('reports a transport failure as retryable, never as a completed purge', async () => {
+    const { lines, sink } = collect();
+    const result = await runPurge({
+      dryRun: false,
+      deps: { redisPipeline: async () => null, log: sink, warn: sink },
+    });
+
+    assert.deepEqual(result, { code: 2, deleted: false });
+    assert.notEqual(result.code, 0, 'a null pipeline result must not exit 0');
+    assert.ok(lines.some((l) => l.includes('NOT purged')));
+  });
+
+  it('reports an upstream command error as retryable', async () => {
+    const { lines, sink } = collect();
+    const result = await runPurge({
+      dryRun: false,
+      deps: {
+        redisPipeline: async () => [{ error: 'ERR max requests limit exceeded' }],
+        log: sink,
+        warn: sink,
+      },
+    });
+
+    assert.deepEqual(result, { code: 2, deleted: false });
+    assert.ok(lines.some((l) => l.includes('upstream error')));
+  });
+
+  it('issues no command at all under --dry-run', async () => {
+    let called = false;
+    const { lines, sink } = collect();
+    const result = await runPurge({
+      dryRun: true,
+      deps: {
+        redisPipeline: async () => {
+          called = true;
+          return [{ result: 1 }];
+        },
+        log: sink,
+        warn: sink,
+      },
+    });
+
+    assert.equal(called, false, '--dry-run must not reach Redis');
+    assert.deepEqual(result, { code: 0, deleted: false });
+    assert.ok(lines.some((l) => l.includes('DRY RUN')));
+  });
+});

--- a/tests/tech-events-cold-start-widest.test.mts
+++ b/tests/tech-events-cold-start-widest.test.mts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveTechEventsPaging } from '../server/worldmonitor/research/v1/_tech-events-paging.ts';
+import { WIDEST_TECH_EVENTS_REQUEST } from '../server/worldmonitor/research/v1/list-tech-events.ts';
+
+// #5427: the cold-start fallback fetcher writes to the SHARED, request-
+// independent `research:tech-events:v1` key (the same one the relay seeder
+// fills with the full list). Whatever it caches is what every client sees for
+// the 6h TTL, so the request it fetches with must be the widest the params
+// allow — narrowing belongs exclusively to filterEvents() on the read path.
+describe('cold-start fallback caches the widest tech-events payload (#5427)', () => {
+  it('applies no type or mappable narrowing', () => {
+    assert.equal(WIDEST_TECH_EVENTS_REQUEST.type, 'all');
+    assert.equal(WIDEST_TECH_EVENTS_REQUEST.mappable, false);
+  });
+
+  it('resolves to the documented clamp maxima for limit and days', () => {
+    assert.deepEqual(
+      resolveTechEventsPaging(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true }),
+      { limit: 200, days: 365 },
+    );
+  });
+
+  it('cannot resolve narrower than a maxed-out explicit request', () => {
+    const maxedExplicit = resolveTechEventsPaging({ limit: 999, days: 999 });
+    assert.deepEqual(
+      resolveTechEventsPaging(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true }),
+      maxedExplicit,
+    );
+  });
+});

--- a/tests/tech-events-cold-start-widest.test.mts
+++ b/tests/tech-events-cold-start-widest.test.mts
@@ -4,6 +4,7 @@ import { resolveTechEventsPaging } from '../server/worldmonitor/research/v1/_tec
 import {
   fetchWidestTechEvents,
   listTechEvents,
+  TECH_EVENTS_UNAVAILABLE_ERROR,
   WIDEST_TECH_EVENTS_REQUEST,
 } from '../server/worldmonitor/research/v1/list-tech-events.ts';
 import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
@@ -200,12 +201,26 @@ describe('listTechEvents cold-start cache write', () => {
     __resetKeyPrefixCacheForTests();
   });
 
+  // A 200 that clears fetchTextWithRelay's 100-char floor but parses to zero
+  // events — an empty calendar, an HTML error page, a challenge interstitial.
+  // The fetch "succeeds", so a failure counter never sees it.
+  const EVENTLESS_ICS_200 = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//worldmonitor//tech-events-fixture//EN',
+    'X-WR-CALNAME:upstream returned a valid but empty calendar',
+    'X-WR-CALDESC:padding so this body clears the 100-character floor',
+    'END:VCALENDAR',
+  ].join('\n');
+
   /**
    * Cold Redis (every GET misses) + the two upstream feeds. `icsFails` /
    * `rssFails` return 503 so `fetchTextWithRelay` falls through to its relay
    * leg, finds no WS_RELAY_URL, and yields null — the real total-outage path.
+   * `icsEventless` instead returns a healthy-looking 200 that parses to
+   * nothing. FIXTURE_RSS is already item-free, so it covers the RSS side.
    */
-  function installFetchMock({ icsFails = false, rssFails = false } = {}) {
+  function installFetchMock({ icsFails = false, rssFails = false, icsEventless = false } = {}) {
     const redisSets: RedisSetCommand[] = [];
     mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -217,7 +232,8 @@ describe('listTechEvents cold-start cache write', () => {
         return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
       }
       if (url === ICS_URL) {
-        return icsFails ? new Response('', { status: 503 }) : new Response(FIXTURE_ICS, { status: 200 });
+        if (icsFails) return new Response('', { status: 503 });
+        return new Response(icsEventless ? EVENTLESS_ICS_200 : FIXTURE_ICS, { status: 200 });
       }
       if (url === DEV_EVENTS_RSS) {
         return rssFails ? new Response('', { status: 503 }) : new Response(FIXTURE_RSS, { status: 200 });
@@ -323,6 +339,51 @@ describe('listTechEvents cold-start cache write', () => {
       const ttl = Number(writeFor(redisSets)[4]);
       assert.ok(ttl > 0 && ttl <= 300, `expected a short negative TTL, got ${ttl}s`);
       assert.notEqual(ttl, 21600, 'the outage write must not take the 6h REDIS_CACHE_TTL');
+    });
+
+    // The guard must key on "did upstream give us anything", not on a fetch
+    // failure counter. A feed answering 200 with an error page or an empty
+    // calendar never increments a failure count, so a counter-based guard
+    // lets the same curated-only rump through at the full 6h TTL.
+    it('writes a negative sentinel when feeds answer 200 with nothing parseable', async () => {
+      const redisSets = installFetchMock({ icsEventless: true });
+      await listTechEvents(ctxFor(PATH), REQ);
+
+      const write = writeFor(redisSets);
+      assert.equal(
+        JSON.parse(write[2]),
+        '__WM_NEG__',
+        `a healthy-looking 200 that parses to nothing must not persist a curated-only payload, got: ${write[2].slice(0, 200)}`,
+      );
+    });
+
+    // Without a no-store marker this route falls to its 'daily' tier
+    // (s-maxage=14400), so the CDN would pin the empty body for 4h even though
+    // Redis recovers in 120s.
+    it('marks the unavailable response no-store so the CDN cannot pin it', async () => {
+      installFetchMock({ icsFails: true, rssFails: true });
+      const response = await listTechEvents(ctxFor(PATH), REQ);
+
+      assert.equal(response.count, 0);
+      assert.equal(
+        response.error,
+        TECH_EVENTS_UNAVAILABLE_ERROR,
+        'an unavailable response must carry the error the gateway reads as a no-store reason',
+      );
+    });
+
+    // Precision check: the marker must fire ONLY on data-unavailability, never
+    // on a healthy response whose filters happened to match nothing — that is
+    // a real answer and stays cacheable.
+    it('leaves a healthy zero-match response cacheable', async () => {
+      installFetchMock();
+      const response = await listTechEvents(
+        ctxFor('/api/research/v1/list-tech-events?type=ipo'),
+        { type: 'ipo', mappable: false, limit: 0, days: 0 },
+      );
+
+      assert.equal(response.count, 0, 'fixture has no ipo events');
+      assert.equal(response.error, '', 'a healthy empty result must stay cacheable');
     });
 
     it('still caches a partial fetch, so one dead feed does not blank the endpoint', async () => {

--- a/tests/tech-events-cold-start-widest.test.mts
+++ b/tests/tech-events-cold-start-widest.test.mts
@@ -117,7 +117,7 @@ describe('fetchWidestTechEvents produces an unnarrowed payload (#5603 review)', 
 // fake Upstash and asserting on the payload that actually reaches the shared
 // `research:tech-events:v1` key — mirroring the captured-SET pattern in
 // tests/aviation-cache-poison.test.mts.
-describe('listTechEvents cold-start write is not narrowed by the warming request (#5427)', () => {
+describe('listTechEvents cold-start cache write', () => {
   const ENV_KEYS = [
     'LOCAL_API_MODE',
     'RELAY_SHARED_SECRET',
@@ -200,8 +200,12 @@ describe('listTechEvents cold-start write is not narrowed by the warming request
     __resetKeyPrefixCacheForTests();
   });
 
-  /** Cold Redis (every GET misses) + both upstream feeds served from fixtures. */
-  function installFetchMock() {
+  /**
+   * Cold Redis (every GET misses) + the two upstream feeds. `icsFails` /
+   * `rssFails` return 503 so `fetchTextWithRelay` falls through to its relay
+   * leg, finds no WS_RELAY_URL, and yields null — the real total-outage path.
+   */
+  function installFetchMock({ icsFails = false, rssFails = false } = {}) {
     const redisSets: RedisSetCommand[] = [];
     mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -212,23 +216,32 @@ describe('listTechEvents cold-start write is not narrowed by the warming request
         redisSets.push(JSON.parse(String(init?.body ?? '[]')) as RedisSetCommand);
         return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
       }
-      if (url === ICS_URL) return new Response(FIXTURE_ICS, { status: 200 });
-      if (url === DEV_EVENTS_RSS) return new Response(FIXTURE_RSS, { status: 200 });
+      if (url === ICS_URL) {
+        return icsFails ? new Response('', { status: 503 }) : new Response(FIXTURE_ICS, { status: 200 });
+      }
+      if (url === DEV_EVENTS_RSS) {
+        return rssFails ? new Response('', { status: 503 }) : new Response(FIXTURE_RSS, { status: 200 });
+      }
       throw new Error(`unexpected fetch: ${url}`);
     });
     return redisSets;
   }
 
-  function cachedPayload(redisSets: RedisSetCommand[]): { events: { id: string; type: string }[] } {
+  function writeFor(redisSets: RedisSetCommand[]): RedisSetCommand {
     const write = redisSets.find(([, key]) => key === REDIS_CACHE_KEY);
     assert.ok(write, `expected a Redis SET for ${REDIS_CACHE_KEY}, saw keys: ${JSON.stringify(redisSets.map(([, k]) => k))}`);
-    return JSON.parse(write[2]) as { events: { id: string; type: string }[] };
+    return write;
+  }
+
+  function cachedPayload(redisSets: RedisSetCommand[]): { events: { id: string; type: string }[] } {
+    return JSON.parse(writeFor(redisSets)[2]) as { events: { id: string; type: string }[] };
   }
 
   function ctxFor(path: string) {
     return { request: new Request(`https://worldmonitor.app${path}`), pathParams: {}, headers: {} } as never;
   }
 
+  describe('is not narrowed by the warming request (#5427)', () => {
   // The warming caller narrows on all three axes at once.
   const NARROW_PATH = '/api/research/v1/list-tech-events?type=conference&limit=1&days=5';
   const NARROW_REQ = { type: 'conference', mappable: false, limit: 1, days: 5 };
@@ -277,5 +290,50 @@ describe('listTechEvents cold-start write is not narrowed by the warming request
     assert.equal(response.conferenceCount, 1);
     // ...and the cache still holds the unnarrowed set behind that response.
     assert.ok(cachedPayload(redisSets).events.length >= 4);
+  });
+  });
+
+  // Review finding #2 on #5603. CURATED_EVENTS always clears the
+  // `events.length > 0` bar, so once the fallback widened to days:365 the
+  // far-future curated entries survived the cutoff and a TOTAL upstream outage
+  // began pinning a curated-only rump under the seeder-owned key for the full
+  // 6h TTL — served to every client as `success: true` with an empty `error`.
+  // Before #5603 the caller's default 90-day window dropped those entries, the
+  // payload came back empty, and the key self-healed via a 120s sentinel.
+  describe('refuses to persist a payload with no upstream data (#5603 review)', () => {
+    const PATH = '/api/research/v1/list-tech-events';
+    const REQ = { type: '', mappable: false, limit: 0, days: 0 };
+
+    it('writes a short-TTL negative sentinel when every feed is down', async () => {
+      const redisSets = installFetchMock({ icsFails: true, rssFails: true });
+      await listTechEvents(ctxFor(PATH), REQ);
+
+      const write = writeFor(redisSets);
+      assert.equal(
+        JSON.parse(write[2]),
+        '__WM_NEG__',
+        `a curated-only outage payload must not be persisted under the shared key, got: ${write[2].slice(0, 200)}`,
+      );
+    });
+
+    it('lets the key recover in seconds, not on the seeder cycle', async () => {
+      const redisSets = installFetchMock({ icsFails: true, rssFails: true });
+      await listTechEvents(ctxFor(PATH), REQ);
+
+      const ttl = Number(writeFor(redisSets)[4]);
+      assert.ok(ttl > 0 && ttl <= 300, `expected a short negative TTL, got ${ttl}s`);
+      assert.notEqual(ttl, 21600, 'the outage write must not take the 6h REDIS_CACHE_TTL');
+    });
+
+    it('still caches a partial fetch, so one dead feed does not blank the endpoint', async () => {
+      // ICS alive, RSS down: ~4 real events. Materially complete, so refusing
+      // it would drop every caller into the empty-response window for as long
+      // as the other feed stayed down.
+      const redisSets = installFetchMock({ rssFails: true });
+      await listTechEvents(ctxFor(PATH), REQ);
+
+      const ids = cachedPayload(redisSets).events.map(e => e.id);
+      assert.ok(ids.includes('wm-conf-day1'), `partial fetches must still be cached, got: ${JSON.stringify(ids)}`);
+    });
   });
 });

--- a/tests/tech-events-cold-start-widest.test.mts
+++ b/tests/tech-events-cold-start-widest.test.mts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import { resolveTechEventsPaging } from '../server/worldmonitor/research/v1/_tech-events-paging.ts';
 import {
   fetchWidestTechEvents,
+  listTechEvents,
   WIDEST_TECH_EVENTS_REQUEST,
 } from '../server/worldmonitor/research/v1/list-tech-events.ts';
+import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
 
 // #5427: the cold-start fallback fetcher writes to the SHARED, request-
 // independent `research:tech-events:v1` key (the same one the relay seeder
@@ -100,5 +102,180 @@ describe('fetchWidestTechEvents produces an unnarrowed payload (#5603 review)', 
 
   it('takes no arguments, so caller state cannot be threaded back in', () => {
     assert.equal(fetchWidestTechEvents.length, 0);
+  });
+});
+
+// The suite above tests `fetchWidestTechEvents` in isolation, which proves the
+// extracted fetcher is unnarrowed but NOT that `listTechEvents` still uses it.
+// Reintroducing #5427 does not require threading state into that function —
+// it only requires ignoring it and inlining a `req`-scoped closure at the
+// `cachedFetchJson` call site, which is neither a type error nor observable
+// from any assertion above. Verified by execution: with the call site reverted
+// that way, all six cases above stay green and `typecheck:api` stays clean.
+//
+// This suite closes that last gap by driving the handler end-to-end against a
+// fake Upstash and asserting on the payload that actually reaches the shared
+// `research:tech-events:v1` key — mirroring the captured-SET pattern in
+// tests/aviation-cache-poison.test.mts.
+describe('listTechEvents cold-start write is not narrowed by the warming request (#5427)', () => {
+  const ENV_KEYS = [
+    'LOCAL_API_MODE',
+    'RELAY_SHARED_SECRET',
+    'UPSTASH_REDIS_REST_TOKEN',
+    'UPSTASH_REDIS_REST_URL',
+    'VERCEL_ENV',
+    'VERCEL_GIT_COMMIT_SHA',
+    'WS_RELAY_URL',
+  ] as const;
+
+  const ICS_URL = 'https://www.techmeme.com/newsy_events.ics';
+  const DEV_EVENTS_RSS = 'https://dev.events/rss.xml';
+  const REDIS_CACHE_KEY = 'research:tech-events:v1';
+
+  const savedEnv = new Map<string, string | undefined>();
+  const realFetch = globalThis.fetch;
+
+  type RedisSetCommand = ['SET', string, string, 'EX', string];
+
+  /** `days` offset from today as an ICS `YYYYMMDD` stamp, so the fixture never time-bombs. */
+  function icsDate(daysFromNow: number): string {
+    const d = new Date();
+    d.setDate(d.getDate() + daysFromNow);
+    return `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+  }
+
+  function vevent(uid: string, summary: string, daysFromNow: number, location?: string): string {
+    return [
+      'BEGIN:VEVENT',
+      `UID:${uid}`,
+      `SUMMARY:${summary}`,
+      ...(location ? [`LOCATION:${location}`] : []),
+      `DTSTART;VALUE=DATE:${icsDate(daysFromNow)}`,
+      `DTEND;VALUE=DATE:${icsDate(daysFromNow + 1)}`,
+      `URL:https://example.invalid/${uid}`,
+      'END:VEVENT',
+    ].join('\n');
+  }
+
+  // Four events chosen so each narrowing axis the warming request carries
+  // (type, days, limit) would drop a DIFFERENT one of them from the cache.
+  const FIXTURE_ICS = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//worldmonitor//tech-events-fixture//EN',
+    vevent('wm-conf-day1', 'WM Fixture Conference Day One', 1, 'Paris, France'),
+    vevent('wm-conf-day2', 'WM Fixture Conference Day Two', 2, 'Berlin, Germany'),
+    vevent('wm-earnings-day3', 'Earnings: WM Fixture Corp', 3),
+    vevent('wm-conf-day200', 'WM Fixture Conference Far Future', 200, 'Tokyo, Japan'),
+    'END:VCALENDAR',
+  ].join('\n');
+
+  // Valid but item-free, and over the 100-char floor fetchTextWithRelay() uses
+  // to reject a truncated body.
+  const FIXTURE_RSS = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"><channel><title>WM fixture feed</title>
+<link>https://dev.events</link>
+<description>No items; the ICS leg carries this fixture.</description>
+</channel></rss>`;
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+    __resetKeyPrefixCacheForTests();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    globalThis.fetch = realFetch;
+    for (const key of ENV_KEYS) {
+      const value = savedEnv.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    savedEnv.clear();
+    __resetKeyPrefixCacheForTests();
+  });
+
+  /** Cold Redis (every GET misses) + both upstream feeds served from fixtures. */
+  function installFetchMock() {
+    const redisSets: RedisSetCommand[] = [];
+    mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith('https://redis.test/get/')) {
+        return new Response(JSON.stringify({ result: null }), { status: 200 });
+      }
+      if (url === 'https://redis.test/') {
+        redisSets.push(JSON.parse(String(init?.body ?? '[]')) as RedisSetCommand);
+        return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+      }
+      if (url === ICS_URL) return new Response(FIXTURE_ICS, { status: 200 });
+      if (url === DEV_EVENTS_RSS) return new Response(FIXTURE_RSS, { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    return redisSets;
+  }
+
+  function cachedPayload(redisSets: RedisSetCommand[]): { events: { id: string; type: string }[] } {
+    const write = redisSets.find(([, key]) => key === REDIS_CACHE_KEY);
+    assert.ok(write, `expected a Redis SET for ${REDIS_CACHE_KEY}, saw keys: ${JSON.stringify(redisSets.map(([, k]) => k))}`);
+    return JSON.parse(write[2]) as { events: { id: string; type: string }[] };
+  }
+
+  function ctxFor(path: string) {
+    return { request: new Request(`https://worldmonitor.app${path}`), pathParams: {}, headers: {} } as never;
+  }
+
+  // The warming caller narrows on all three axes at once.
+  const NARROW_PATH = '/api/research/v1/list-tech-events?type=conference&limit=1&days=5';
+  const NARROW_REQ = { type: 'conference', mappable: false, limit: 1, days: 5 };
+
+  it('caches event types the warming request filtered out', async () => {
+    const redisSets = installFetchMock();
+    await listTechEvents(ctxFor(NARROW_PATH), NARROW_REQ);
+
+    const ids = cachedPayload(redisSets).events.map(e => e.id);
+    assert.ok(
+      ids.includes('wm-earnings-day3'),
+      `?type=conference must not narrow the shared cache, but the earnings event is absent: ${JSON.stringify(ids)}`,
+    );
+  });
+
+  it('caches events beyond the warming request day window', async () => {
+    const redisSets = installFetchMock();
+    await listTechEvents(ctxFor(NARROW_PATH), NARROW_REQ);
+
+    const ids = cachedPayload(redisSets).events.map(e => e.id);
+    assert.ok(
+      ids.includes('wm-conf-day200'),
+      `?days=5 must not narrow the shared cache, but the far-future event is absent: ${JSON.stringify(ids)}`,
+    );
+  });
+
+  it('caches more events than the warming request limit', async () => {
+    const redisSets = installFetchMock();
+    await listTechEvents(ctxFor(NARROW_PATH), NARROW_REQ);
+
+    const events = cachedPayload(redisSets).events;
+    assert.ok(
+      events.length >= 4,
+      `?limit=1 must not truncate the shared cache, but only ${events.length} event(s) were written`,
+    );
+  });
+
+  it('still narrows the warming request own response via filterEvents', async () => {
+    const redisSets = installFetchMock();
+    const response = await listTechEvents(ctxFor(NARROW_PATH), NARROW_REQ);
+
+    // Widening what gets CACHED must not widen what the caller SEES.
+    assert.equal(response.count, 1);
+    assert.equal(response.events.length, 1);
+    assert.equal(response.events[0]?.id, 'wm-conf-day1');
+    assert.equal(response.conferenceCount, 1);
+    // ...and the cache still holds the unnarrowed set behind that response.
+    assert.ok(cachedPayload(redisSets).events.length >= 4);
   });
 });

--- a/tests/tech-events-cold-start-widest.test.mts
+++ b/tests/tech-events-cold-start-widest.test.mts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { resolveTechEventsPaging } from '../server/worldmonitor/research/v1/_tech-events-paging.ts';
-import { WIDEST_TECH_EVENTS_REQUEST } from '../server/worldmonitor/research/v1/list-tech-events.ts';
+import {
+  fetchWidestTechEvents,
+  WIDEST_TECH_EVENTS_REQUEST,
+} from '../server/worldmonitor/research/v1/list-tech-events.ts';
 
 // #5427: the cold-start fallback fetcher writes to the SHARED, request-
 // independent `research:tech-events:v1` key (the same one the relay seeder
@@ -27,5 +30,75 @@ describe('cold-start fallback caches the widest tech-events payload (#5427)', ()
       resolveTechEventsPaging(WIDEST_TECH_EVENTS_REQUEST, { hasLimit: true, hasDays: true }),
       maxedExplicit,
     );
+  });
+});
+
+// Greptile P2 on #5603: the assertions above validate the exported constant and
+// the paging resolver, but nothing proved `listTechEvents` actually hands that
+// request to the cache-miss fetcher — a wiring regression could restore
+// caller-specific shared-cache population with this suite still green. That is
+// the exact false-pass shape #5380 is about.
+//
+// Two things close it. Structurally, `fetchWidestTechEvents` takes NO
+// parameters, so threading caller state back in is a type error rather than a
+// silent behaviour change. Executably, the test below runs the very function
+// the handler passes to `cachedFetchJson` and asserts the payload it produces
+// is unnarrowed.
+describe('fetchWidestTechEvents produces an unnarrowed payload (#5603 review)', () => {
+  const ICS = [
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    'SUMMARY:Regression Test Conference 2026',
+    'LOCATION:Lisbon, Portugal',
+    'DTSTART;VALUE=DATE:20260815',
+    'DTEND;VALUE=DATE:20260816',
+    'URL:https://example.invalid/conf',
+    'UID:widest-test-conference',
+    'END:VEVENT',
+    'BEGIN:VEVENT',
+    'SUMMARY:Earnings: ExampleCorp Q3 2026',
+    'DTSTART;VALUE=DATE:20260901',
+    'DTEND;VALUE=DATE:20260901',
+    'URL:https://example.invalid/earnings',
+    'UID:widest-test-earnings',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\n');
+
+  const originalFetch = globalThis.fetch;
+
+  before(() => {
+    globalThis.fetch = (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes('techmeme.com')) return new Response(ICS, { status: 200 });
+      // dev.events RSS (and any relay attempt) contributes nothing here.
+      return new Response('', { status: 404 });
+    }) as typeof globalThis.fetch;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('keeps event types a caller-scoped fetch would have dropped', async () => {
+    const result = await fetchWidestTechEvents();
+    assert.ok(result, 'expected a payload from the cold-start fetcher');
+
+    const types = new Set(result.events.map((e) => e.type));
+    // A fallback that forwarded a `type: 'conference'` caller request would
+    // have cached conferences only, so the earnings row is the discriminator.
+    assert.ok(types.has('earnings'), `earnings event was filtered out: ${[...types].join(', ')}`);
+    assert.ok(types.has('conference'), `conference event missing: ${[...types].join(', ')}`);
+  });
+
+  it('does not apply a caller limit — more than one event survives', async () => {
+    const result = await fetchWidestTechEvents();
+    assert.ok(result);
+    // A forwarded `limit: 1` would leave exactly one event in the shared key.
+    assert.ok(result.events.length > 1, `expected the unnarrowed set, got ${result.events.length}`);
+  });
+
+  it('takes no arguments, so caller state cannot be threaded back in', () => {
+    assert.equal(fetchWidestTechEvents.length, 0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #5427.

`research:tech-events:v1` is a shared, request-independent Redis key — the Railway relay seeds the **full** event list under it every 6h, and `listTechEvents()` narrows per caller afterwards via `filterEvents()`. The cold-start fallback fetcher broke that contract: it forwarded the live request's `type`/`mappable`/`limit`/`days` into `fetchTechEvents()` and cached that **narrowed** payload under the shared key. Whichever request warmed a cold cache decided what every client saw for the next 6 hours (`?type=conference&limit=5` pinned 5 events; even a parameterless request pinned the 50/90 defaults, capping later `?limit=200&days=365` callers below the documented maxima).

**Fix:** the fallback now fetches with an exported `WIDEST_TECH_EVENTS_REQUEST` (`type: 'all'`, `mappable: false`, and the clamp maxima `limit: 200`, `days: 365`, passed with explicit presence so they resolve as-is). Per-request narrowing already happens in `filterEvents()` on the read path — it re-applies every filter and recomputes `count`/`conferenceCount`/`mappableCount` from the narrowed set — so responses on the seeded path are byte-for-byte unchanged; only the cached payload's width changes, matching what the seeder writes.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documented API contract changes: request/response schemas and per-request filter semantics are untouched; only the internally cached payload widens to the seeder's shape.

## Verification

- New `tests/tech-events-cold-start-widest.test.mts` pins the widest-request contract: no `type`/`mappable` narrowing, resolves exactly to the clamp maxima (200/365), and can never resolve narrower than a maxed-out explicit request.
- `tech-events-paging`, `shared-relay`, `relay-boot-seed-freshness-guard`, and `openapi-filter-param-schemas` suites: 84 tests green.
- `npm run typecheck` clean.

## Screenshots

N/A — server-side caching behavior.