### PR TITLE
test(checkout): close #5380 coverage gaps — false-passing idempotency test, webhook rollback, boundaries

### DIFF
--- a/convex/__tests__/webhook-rollback-boundaries.test.ts
+++ b/convex/__tests__/webhook-rollback-boundaries.test.ts
@@ -1,0 +1,264 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { PRODUCT_CATALOG } from "../config/productCatalog";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+import {
+  PENDING_PAYMENT_BLOCK_WINDOW_MS,
+} from "../payments/billing";
+import { isNewerEvent } from "../payments/subscriptionHelpers";
+
+const modules = import.meta.glob("../**/*.ts");
+
+// Permanent regressions for #5380: malformed-late-webhook transactional
+// rollback, exact TTL/paid-through boundaries, and equal-timestamp lifecycle
+// ordering — each previously proven only by temporary tests or untested.
+
+const BASE_TIMESTAMP = new Date("2026-03-21T10:00:00Z").getTime();
+
+function makeSubscriptionPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "subscription.active",
+    business_id: "biz_test",
+    timestamp: "2026-03-21T10:00:00Z",
+    data: {
+      payload_type: "Subscription",
+      subscription_id: "sub_test_001",
+      product_id: "pdt_test_pro",
+      status: "active",
+      customer: {
+        customer_id: "cust_test_001",
+        email: "test@example.com",
+        name: "Test User",
+      },
+      metadata: { wm_user_id: "test-user-001" },
+      previous_billing_date: "2026-03-21T00:00:00Z",
+      next_billing_date: "2026-04-21T00:00:00Z",
+      ...overrides,
+    },
+  };
+}
+
+async function seedProductPlan(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("productPlans", {
+      dodoProductId: "pdt_test_pro",
+      planKey: "pro_monthly",
+      displayName: "Pro Monthly",
+      isActive: true,
+    });
+  });
+}
+
+async function seedCustomer(t: ReturnType<typeof convexTest>) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("customers", {
+      userId: "test-user-001",
+      dodoCustomerId: "cust_test_001",
+      email: "test@example.com",
+      createdAt: BASE_TIMESTAMP,
+      updatedAt: BASE_TIMESTAMP,
+    });
+  });
+}
+
+async function processEvent(
+  t: ReturnType<typeof convexTest>,
+  webhookId: string,
+  eventType: string,
+  rawPayload: Record<string, unknown>,
+  timestamp: number,
+) {
+  await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+    webhookId,
+    eventType,
+    rawPayload,
+    timestamp,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// #5380 High-2: malformed late webhook must roll back atomically
+// ---------------------------------------------------------------------------
+
+describe("malformed webhook transactional rollback", () => {
+  test("a crash mid-handler leaves ZERO subscription/entitlement/webhook rows", async () => {
+    const t = convexTest(schema, modules);
+    await seedProductPlan(t);
+    await seedCustomer(t);
+
+    // `customer.email` as a number crashes the post-insert customer upsert
+    // (`email.trim()`), i.e. AFTER the subscription insert and entitlement
+    // recompute in the same mutation — the exact partial-write hazard.
+    const malformed = makeSubscriptionPayload({
+      customer: { customer_id: "cust_test_001", email: 12345, name: "Bad" },
+    });
+
+    await expect(
+      processEvent(t, "wh_malformed_1", "subscription.active", malformed, BASE_TIMESTAMP),
+    ).rejects.toThrow();
+
+    const { subs, ents, events } = await t.run(async (ctx) => ({
+      subs: await ctx.db.query("subscriptions").collect(),
+      ents: await ctx.db.query("entitlements").collect(),
+      events: await ctx.db.query("webhookEvents").collect(),
+    }));
+    expect(subs).toHaveLength(0);
+    expect(ents).toHaveLength(0);
+    // No dedup ledger row either — the retry must be able to re-process.
+    expect(events).toHaveLength(0);
+  });
+
+  test("Dodo's retry of the rolled-back webhookId then processes cleanly", async () => {
+    const t = convexTest(schema, modules);
+    await seedProductPlan(t);
+    await seedCustomer(t);
+
+    const malformed = makeSubscriptionPayload({
+      customer: { customer_id: "cust_test_001", email: 12345, name: "Bad" },
+    });
+    await expect(
+      processEvent(t, "wh_retry_1", "subscription.active", malformed, BASE_TIMESTAMP),
+    ).rejects.toThrow();
+
+    // Same webhookId, corrected payload — must NOT be treated as a duplicate.
+    await processEvent(t, "wh_retry_1", "subscription.active", makeSubscriptionPayload(), BASE_TIMESTAMP + 1);
+
+    const { subs, ents } = await t.run(async (ctx) => ({
+      subs: await ctx.db.query("subscriptions").collect(),
+      ents: await ctx.db.query("entitlements").collect(),
+    }));
+    expect(subs).toHaveLength(1);
+    expect(subs[0]?.status).toBe("active");
+    expect(ents).toHaveLength(1);
+    expect(ents[0]?.planKey).toBe("pro_monthly");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5380 Medium-9: equal-timestamp lifecycle ordering
+// ---------------------------------------------------------------------------
+
+describe("equal-timestamp lifecycle ordering", () => {
+  test("isNewerEvent rejects an equal timestamp (replay must not reorder state)", () => {
+    expect(isNewerEvent(1_000, 1_000)).toBe(false);
+    expect(isNewerEvent(1_000, 999)).toBe(false);
+    expect(isNewerEvent(1_000, 1_001)).toBe(true);
+  });
+
+  test("a cancellation carrying the SAME timestamp as the activation is ignored", async () => {
+    const t = convexTest(schema, modules);
+    await seedProductPlan(t);
+    await seedCustomer(t);
+
+    await processEvent(t, "wh_eq_1", "subscription.active", makeSubscriptionPayload(), BASE_TIMESTAMP);
+    await processEvent(
+      t,
+      "wh_eq_2",
+      "subscription.cancelled",
+      makeSubscriptionPayload({ status: "cancelled" }),
+      BASE_TIMESTAMP,
+    );
+
+    const sub = await t.run(async (ctx) =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", "sub_test_001"))
+        .unique(),
+    );
+    expect(sub?.status).toBe("active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5380 Medium-7: pending-payment block window boundary
+// ---------------------------------------------------------------------------
+
+describe("pending-payment block window boundary", () => {
+  async function seedPendingCharge(t: ReturnType<typeof convexTest>, occurredAt: number) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("paymentEvents", {
+        userId: "test-user-001",
+        dodoPaymentId: "pay_pending_001",
+        type: "charge",
+        amount: 999,
+        currency: "USD",
+        status: "requires_customer_action",
+        planKey: "pro_monthly",
+        rawPayload: {},
+        occurredAt,
+      });
+    });
+  }
+
+  test("a pending payment exactly AT the window edge no longer blocks", async () => {
+    const t = convexTest(schema, modules);
+    // occurredAt == Date.now() - WINDOW at seed time; by query time it is
+    // strictly older than the edge, and the index read is `.gt(windowStart)`,
+    // so the exact-boundary row is excluded — the block has expired.
+    await seedPendingCharge(t, Date.now() - PENDING_PAYMENT_BLOCK_WINDOW_MS);
+
+    const blocking = await t.query(internal.payments.billing.getBlockingPendingPayment, {
+      userId: "test-user-001",
+      productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+    });
+    expect(blocking).toBeNull();
+  });
+
+  test("a pending payment well inside the window still blocks the same tier group", async () => {
+    const t = convexTest(schema, modules);
+    await seedPendingCharge(t, Date.now() - PENDING_PAYMENT_BLOCK_WINDOW_MS + 60_000);
+
+    const blocking = await t.query(internal.payments.billing.getBlockingPendingPayment, {
+      userId: "test-user-001",
+      productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+    });
+    expect(blocking).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5380 Medium-8: cancelled paid-through period-end boundary (checkout guard)
+// ---------------------------------------------------------------------------
+
+describe("cancelled paid-through boundary at checkout", () => {
+  async function seedCancelledSub(t: ReturnType<typeof convexTest>, currentPeriodEnd: number) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: "test-user-001",
+        dodoSubscriptionId: "sub_cancelled_boundary",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "cancelled",
+        currentPeriodStart: currentPeriodEnd - 30 * 86_400_000,
+        currentPeriodEnd,
+        rawPayload: {},
+        updatedAt: currentPeriodEnd - 86_400_000,
+      });
+    });
+  }
+
+  test("a cancellation whose period ends exactly NOW no longer blocks re-subscribing", async () => {
+    const t = convexTest(schema, modules);
+    // The guard requires `currentPeriodEnd > now` to block; the equal-boundary
+    // row (strictly older by query time) must fall on the unblocked side.
+    await seedCancelledSub(t, Date.now());
+
+    const blocking = await t.query(internal.payments.billing.getCheckoutBlockingSubscription, {
+      userId: "test-user-001",
+      productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+    });
+    expect(blocking).toBeNull();
+  });
+
+  test("a cancellation still paid-through blocks checkout in the same family", async () => {
+    const t = convexTest(schema, modules);
+    await seedCancelledSub(t, Date.now() + 5 * 60_000);
+
+    const blocking = await t.query(internal.payments.billing.getCheckoutBlockingSubscription, {
+      userId: "test-user-001",
+      productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+    });
+    expect(blocking).toMatchObject({ status: "cancelled" });
+  });
+});

--- a/convex/__tests__/webhook-rollback-boundaries.test.ts
+++ b/convex/__tests__/webhook-rollback-boundaries.test.ts
@@ -1,5 +1,5 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { PRODUCT_CATALOG } from "../config/productCatalog";
 import schema from "../schema";
 import { internal } from "../_generated/api";
@@ -15,6 +15,9 @@ const modules = import.meta.glob("../**/*.ts");
 // ordering — each previously proven only by temporary tests or untested.
 
 const BASE_TIMESTAMP = new Date("2026-03-21T10:00:00Z").getTime();
+// Wall clock for the boundary suites below, which pin `Date.now()` so a seeded
+// row can sit EXACTLY on the comparison edge.
+const FROZEN_NOW = new Date("2026-03-21T12:00:00Z").getTime();
 
 function makeSubscriptionPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -94,9 +97,14 @@ describe("malformed webhook transactional rollback", () => {
       customer: { customer_id: "cust_test_001", email: 12345, name: "Bad" },
     });
 
+    // Pin the CRASH SITE, not just "it threw". `email.trim` is reached after
+    // the subscription insert and entitlement recompute, which is what makes
+    // this a rollback proof at all. If a future refactor validates the payload
+    // up front, this assertion reds and forces a new post-write crash site
+    // rather than silently degrading into an "early validation rejects" test.
     await expect(
       processEvent(t, "wh_malformed_1", "subscription.active", malformed, BASE_TIMESTAMP),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/trim is not a function/);
 
     const { subs, ents, events } = await t.run(async (ctx) => ({
       subs: await ctx.db.query("subscriptions").collect(),
@@ -191,12 +199,22 @@ describe("pending-payment block window boundary", () => {
     });
   }
 
-  test("a pending payment exactly AT the window edge no longer blocks", async () => {
+  // Time MUST be frozen for these two. Seeding `Date.now() - WINDOW` and
+  // letting real time advance puts the row a few ms PAST the edge, where `.gt`
+  // and `.gte` agree — a `.gt` -> `.gte` mutant survived that version of this
+  // test. With the clock pinned, `occurredAt === windowStart` exactly, which is
+  // the only seed value that can tell the two operators apart.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a pending payment exactly AT the window edge does not block (.gt is exclusive)", async () => {
     const t = convexTest(schema, modules);
-    // occurredAt == Date.now() - WINDOW at seed time; by query time it is
-    // strictly older than the edge, and the index read is `.gt(windowStart)`,
-    // so the exact-boundary row is excluded — the block has expired.
-    await seedPendingCharge(t, Date.now() - PENDING_PAYMENT_BLOCK_WINDOW_MS);
+    await seedPendingCharge(t, FROZEN_NOW - PENDING_PAYMENT_BLOCK_WINDOW_MS);
 
     const blocking = await t.query(internal.payments.billing.getBlockingPendingPayment, {
       userId: "test-user-001",
@@ -205,9 +223,22 @@ describe("pending-payment block window boundary", () => {
     expect(blocking).toBeNull();
   });
 
+  test("one millisecond inside the window still blocks — the edge is exactly windowStart", async () => {
+    const t = convexTest(schema, modules);
+    // Partner to the test above: together they pin the boundary to the ms.
+    // Alone, the exclusion test would also pass if the window were shorter.
+    await seedPendingCharge(t, FROZEN_NOW - PENDING_PAYMENT_BLOCK_WINDOW_MS + 1);
+
+    const blocking = await t.query(internal.payments.billing.getBlockingPendingPayment, {
+      userId: "test-user-001",
+      productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+    });
+    expect(blocking).not.toBeNull();
+  });
+
   test("a pending payment well inside the window still blocks the same tier group", async () => {
     const t = convexTest(schema, modules);
-    await seedPendingCharge(t, Date.now() - PENDING_PAYMENT_BLOCK_WINDOW_MS + 60_000);
+    await seedPendingCharge(t, FROZEN_NOW - PENDING_PAYMENT_BLOCK_WINDOW_MS + 60_000);
 
     const blocking = await t.query(internal.payments.billing.getBlockingPendingPayment, {
       userId: "test-user-001",
@@ -238,11 +269,21 @@ describe("cancelled paid-through boundary at checkout", () => {
     });
   }
 
-  test("a cancellation whose period ends exactly NOW no longer blocks re-subscribing", async () => {
+  // Frozen for the same reason as the pending-payment window above: with a
+  // live clock, `currentPeriodEnd = Date.now()` is already in the past by the
+  // time the query reads it, so `>` and `>=` behave identically and a `>=`
+  // mutant survives.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a cancellation whose period ends exactly NOW does not block (> is strict)", async () => {
     const t = convexTest(schema, modules);
-    // The guard requires `currentPeriodEnd > now` to block; the equal-boundary
-    // row (strictly older by query time) must fall on the unblocked side.
-    await seedCancelledSub(t, Date.now());
+    await seedCancelledSub(t, FROZEN_NOW);
 
     const blocking = await t.query(internal.payments.billing.getCheckoutBlockingSubscription, {
       userId: "test-user-001",
@@ -251,9 +292,20 @@ describe("cancelled paid-through boundary at checkout", () => {
     expect(blocking).toBeNull();
   });
 
+  test("one millisecond of paid-through time still blocks — the edge is exactly now", async () => {
+    const t = convexTest(schema, modules);
+    await seedCancelledSub(t, FROZEN_NOW + 1);
+
+    const blocking = await t.query(internal.payments.billing.getCheckoutBlockingSubscription, {
+      userId: "test-user-001",
+      productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+    });
+    expect(blocking).toMatchObject({ status: "cancelled" });
+  });
+
   test("a cancellation still paid-through blocks checkout in the same family", async () => {
     const t = convexTest(schema, modules);
-    await seedCancelledSub(t, Date.now() + 5 * 60_000);
+    await seedCancelledSub(t, FROZEN_NOW + 5 * 60_000);
 
     const blocking = await t.query(internal.payments.billing.getCheckoutBlockingSubscription, {
       userId: "test-user-001",

--- a/convex/__tests__/webhook-rollback-boundaries.test.ts
+++ b/convex/__tests__/webhook-rollback-boundaries.test.ts
@@ -154,6 +154,50 @@ describe("malformed webhook transactional rollback", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #5380 Medium-11 (PARTIAL): exactly-once under concurrent DISPATCH
+// ---------------------------------------------------------------------------
+
+// Scope, stated precisely so this test is not mistaken for a race proof:
+// `convex-test` runs mutations to completion one at a time, so dispatching both
+// deliveries without awaiting between them does NOT interleave their
+// transactions. What this pins is the invariant at the boundary the HTTP action
+// actually uses — two in-flight deliveries of one webhookId leave exactly one
+// activation — with the second landing on the dedup-ledger branch.
+//
+// The genuine interleaving (both handlers reading an empty `by_webhookId` index
+// before either inserts) is not reproducible in this harness. In production
+// Convex's serializable isolation is what closes it: the first insert
+// invalidates the second transaction's read set, so it retries and then sees
+// the ledger row. That is a property of the Convex runtime, not of this code,
+// and it is why census #11 stays open rather than being claimed here.
+describe("concurrent dispatch of one webhookId", () => {
+  test("two in-flight deliveries activate exactly one subscription", async () => {
+    const t = convexTest(schema, modules);
+    await seedProductPlan(t);
+    await seedCustomer(t);
+
+    const payload = makeSubscriptionPayload();
+    const settled = await Promise.allSettled([
+      processEvent(t, "wh_concurrent_1", "subscription.active", payload, BASE_TIMESTAMP),
+      processEvent(t, "wh_concurrent_1", "subscription.active", payload, BASE_TIMESTAMP),
+    ]);
+    // Neither delivery may error: the loser is a dedup skip, not a failure —
+    // a rejection here would make the HTTP action return 500 and have Dodo
+    // retry an event that was already applied.
+    expect(settled.map((r) => r.status)).toEqual(["fulfilled", "fulfilled"]);
+
+    const { subs, ents, events } = await t.run(async (ctx) => ({
+      subs: await ctx.db.query("subscriptions").collect(),
+      ents: await ctx.db.query("entitlements").collect(),
+      events: await ctx.db.query("webhookEvents").collect(),
+    }));
+    expect(subs).toHaveLength(1);
+    expect(ents).toHaveLength(1);
+    expect(events).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #5380 Medium-10: Dodo error contract, against REAL SDK error instances
 // ---------------------------------------------------------------------------
 

--- a/convex/__tests__/webhook-rollback-boundaries.test.ts
+++ b/convex/__tests__/webhook-rollback-boundaries.test.ts
@@ -4,6 +4,16 @@ import { PRODUCT_CATALOG } from "../config/productCatalog";
 import schema from "../schema";
 import { internal } from "../_generated/api";
 import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  APIUserAbortError,
+  AuthenticationError,
+  InternalServerError,
+  NotFoundError,
+  RateLimitError,
+} from "dodopayments";
+import {
+  isDefinitiveDodoNotFound,
   PENDING_PAYMENT_BLOCK_WINDOW_MS,
 } from "../payments/billing";
 import { isNewerEvent } from "../payments/subscriptionHelpers";
@@ -140,6 +150,46 @@ describe("malformed webhook transactional rollback", () => {
     expect(subs[0]?.status).toBe("active");
     expect(ents).toHaveLength(1);
     expect(ents[0]?.planKey).toBe("pro_monthly");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5380 Medium-10: Dodo error contract, against REAL SDK error instances
+// ---------------------------------------------------------------------------
+
+// `isDefinitiveDodoNotFound` decides whether reconciliation may downgrade a
+// paying customer. Every existing test drives it through the action's
+// `errorInjectionForTest` seam, which throws a hand-rolled
+// `Object.assign(new Error(), { status: 404 | 500 })` — so the assertions only
+// ever proved our own stub matches our own reader. billing.test.ts additionally
+// replaces the whole `dodopayments` module with a two-property class, so the
+// real error classes are absent there by construction.
+//
+// This table feeds the classifier the SDK's actual exported errors. It fails if
+// the vendor renames `.status`, moves to a different error hierarchy, or ever
+// starts stamping a status onto a connection/timeout error — each of which
+// would silently convert a transient blip into a customer downgrade.
+describe("dodo error classification (real SDK instances)", () => {
+  test("a real NotFoundError is the ONLY definitive-404 shape", () => {
+    expect(isDefinitiveDodoNotFound(new NotFoundError(404, { detail: "gone" }, "Not Found", {})))
+      .toBe(true);
+  });
+
+  test.each([
+    ["AuthenticationError (401)", new AuthenticationError(401, {}, "Unauthorized", {})],
+    ["RateLimitError (429)", new RateLimitError(429, {}, "Too Many Requests", {})],
+    ["InternalServerError (500)", new InternalServerError(500, {}, "Server Error", {})],
+    ["APIConnectionError (no status)", new APIConnectionError({ message: "socket hang up" })],
+    ["APIConnectionTimeoutError (no status)", new APIConnectionTimeoutError({ message: "timed out" })],
+    ["APIUserAbortError (no status)", new APIUserAbortError()],
+  ])("%s must NOT downgrade — it is transient/ambiguous", (_label, err) => {
+    expect(isDefinitiveDodoNotFound(err)).toBe(false);
+  });
+
+  test("non-Error throwables never downgrade", () => {
+    for (const value of [null, undefined, 404, "404", { status: "404" }, {}]) {
+      expect(isDefinitiveDodoNotFound(value)).toBe(false);
+    }
   });
 });
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -173,7 +173,13 @@ const DODO_RENEWAL_MASS_NOTFOUND_ABSOLUTE_CAP = 5;
 // `NotFoundError extends APIError<404>` (a `.status` of 404). Transient failures
 // (network, timeout, 5xx, 429) carry a different/absent status and must stay on
 // the backoff-and-retry path, never downgrade.
-function isDefinitiveDodoNotFound(err: unknown): boolean {
+//
+// Exported for #5380 census #10: every reconciliation test drives this through
+// a hand-rolled `Object.assign(new Error(), { status })` stub, so nothing pinned
+// it against the SDK's REAL error classes. It is the gate that decides whether a
+// paying customer gets downgraded, so the vendor's error shape is a contract —
+// see the real-instance table in convex/__tests__/webhook-rollback-boundaries.test.ts.
+export function isDefinitiveDodoNotFound(err: unknown): boolean {
   return (
     typeof err === "object" &&
     err !== null &&

--- a/src/services/checkout-no-user-policy.ts
+++ b/src/services/checkout-no-user-policy.ts
@@ -34,3 +34,46 @@ export function decideNoUserPathOutcome(fallbackToPricingPage: boolean): NoUserP
   }
   return { kind: 'inline-signin', persist: true };
 }
+
+/**
+ * The side effects the signed-out branch performs, injected by the caller.
+ *
+ * `startCheckout` supplies the real implementations (sessionStorage writes,
+ * `window.location.assign`, Clerk's `openSignIn`); tests supply a recorder.
+ */
+export interface NoUserPathHandlers {
+  navigate: (url: string) => void;
+  persistIntent: () => void;
+  persistAttempt: () => void;
+  openSignIn: () => void;
+}
+
+/**
+ * Executes the signed-out branch: WHICH effects run, and in WHAT ORDER.
+ *
+ * The decision above is pure, but for #5380-High-3 that was not enough — the
+ * ordering and the "redirect must not persist" contract lived only in
+ * `checkout.ts`'s inline if/else, where no test could reach them. Two
+ * mutations proved it: persisting inside the redirect branch, and moving
+ * `openSignIn()` above the persist calls, each restored a real bug with the
+ * suite green.
+ *
+ * Keeping the sequencing here (rather than a source-grep guard over
+ * `checkout.ts`) makes both mutations executable failures: the caller is
+ * reduced to a handler literal that binds each effect to its implementation.
+ * Persisting BEFORE `openSignIn()` is load-bearing — Clerk's post-auth
+ * listener fires as soon as sign-in resolves and reads the pending intent.
+ */
+export function runNoUserPath(
+  fallbackToPricingPage: boolean,
+  handlers: NoUserPathHandlers,
+): void {
+  const outcome = decideNoUserPathOutcome(fallbackToPricingPage);
+  if (outcome.kind === 'redirect-pro') {
+    handlers.navigate(outcome.redirectUrl);
+    return;
+  }
+  handlers.persistIntent();
+  handlers.persistAttempt();
+  handlers.openSignIn();
+}

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -41,7 +41,7 @@ import {
   createDefaultCheckoutTransportDeps,
   postCreateCheckout,
 } from './checkout-transport';
-import { decideNoUserPathOutcome } from './checkout-no-user-policy';
+import { runNoUserPath } from './checkout-no-user-policy';
 import { shouldSkipSentryForAction } from './checkout-sentry-policy';
 import { isEntitled, onEntitlementChange } from './entitlements';
 import {
@@ -805,23 +805,22 @@ export async function startCheckout(
       classifySyntheticCheckoutError('unauthorized'),
       { productId, action: 'no-user' },
     );
-    // Pure policy decision lives in checkout-no-user-policy.ts; tested
-    // against regression in tests/checkout-no-user-policy.test.mts. The
-    // contract: redirect path MUST NOT write sessionStorage (would
+    // Both the decision AND the effect sequencing live in
+    // checkout-no-user-policy.ts, exercised in
+    // tests/checkout-no-user-policy.test.mts against a recording double.
+    // The contract: redirect path MUST NOT write sessionStorage (would
     // create a stale dashboard intent that a later unrelated sign-in
-    // would auto-resume); inline path MUST write so the post-auth
-    // Clerk listener can resume the exact checkout.
-    const outcome = decideNoUserPathOutcome(fallbackToPricingPage);
-    if (outcome.kind === 'redirect-pro') {
-      window.location.assign(outcome.redirectUrl);
-    } else {
-      savePendingCheckoutIntent(intent);
-      saveCheckoutAttempt({
-        ...intent,
-        startedAt: Date.now(),
-      });
-      openSignIn();
-    }
+    // would auto-resume); inline path MUST write BEFORE openSignIn so the
+    // post-auth Clerk listener can resume the exact checkout. Keeping that
+    // ordering in the policy module (not this if/else) is deliberate —
+    // #5380-High-3 proved a source-grep guard over this file stays green
+    // with either contract violated.
+    runNoUserPath(fallbackToPricingPage, {
+      navigate: (url) => window.location.assign(url),
+      persistIntent: () => savePendingCheckoutIntent(intent),
+      persistAttempt: () => saveCheckoutAttempt({ ...intent, startedAt: Date.now() }),
+      openSignIn: () => openSignIn(),
+    });
     return false;
   }
 

--- a/tests/checkout-no-user-policy.test.mts
+++ b/tests/checkout-no-user-policy.test.mts
@@ -28,6 +28,9 @@
 
 import { describe, it, beforeEach, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 class MemoryStorage {
   private readonly store = new Map<string, string>();
@@ -142,5 +145,46 @@ describe('cross-page redirect leak regression', () => {
     } else {
       assert.fail('expected redirect-pro outcome');
     }
+  });
+});
+
+// #5380 High-3: the policy module is pure, so a mutation wiring
+// `savePendingCheckoutIntent(intent)` into checkout.ts's REDIRECT branch left
+// this suite green — the leak this file documents would be back with every
+// test passing. Pin the caller's wiring by source-grep (checkout.ts needs the
+// full Clerk + Dodo tree and cannot load under node:test).
+describe('startCheckout no-user wiring (source-grep)', () => {
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(path.join(dirname, '..', 'src', 'services', 'checkout.ts'), 'utf8');
+
+  function noUserBlock(): { redirectBranch: string; inlineBranch: string } {
+    const start = src.indexOf('const outcome = decideNoUserPathOutcome');
+    assert.ok(start > -1, 'expected decideNoUserPathOutcome call in checkout.ts');
+    const ifIdx = src.indexOf("if (outcome.kind === 'redirect-pro')", start);
+    const elseIdx = src.indexOf('} else {', ifIdx);
+    const endIdx = src.indexOf('return false;', elseIdx);
+    assert.ok(ifIdx > -1 && elseIdx > ifIdx && endIdx > elseIdx, 'no-user branch shape changed — update this test');
+    return {
+      redirectBranch: src.slice(ifIdx, elseIdx),
+      inlineBranch: src.slice(elseIdx, endIdx),
+    };
+  }
+
+  it('redirect-pro branch must NOT persist a pending checkout intent', () => {
+    const { redirectBranch } = noUserBlock();
+    assert.ok(redirectBranch.includes('window.location.assign'), 'redirect branch must navigate');
+    assert.ok(
+      !redirectBranch.includes('savePendingCheckoutIntent'),
+      'redirect path persisting intent recreates the stale auto-resume leak this suite exists to prevent',
+    );
+    assert.ok(!redirectBranch.includes('saveCheckoutAttempt'), 'redirect path must not persist attempt state either');
+  });
+
+  it('inline sign-in branch MUST persist the intent before opening sign-in', () => {
+    const { inlineBranch } = noUserBlock();
+    const saveIdx = inlineBranch.indexOf('savePendingCheckoutIntent(intent)');
+    const signInIdx = inlineBranch.indexOf('openSignIn()');
+    assert.ok(saveIdx > -1, 'inline path must persist the pending intent');
+    assert.ok(signInIdx > saveIdx, 'intent must be persisted BEFORE openSignIn so the post-auth listener can resume');
   });
 });

--- a/tests/checkout-no-user-policy.test.mts
+++ b/tests/checkout-no-user-policy.test.mts
@@ -31,6 +31,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { stripJsComments } from '../scripts/lib/js-source-structure.mjs';
 
 class MemoryStorage {
   private readonly store = new Map<string, string>();
@@ -77,7 +78,9 @@ beforeEach(() => {
   _sessionStorage.clear();
 });
 
-const { decideNoUserPathOutcome } = await import('../src/services/checkout-no-user-policy.ts');
+const { decideNoUserPathOutcome, runNoUserPath } = await import(
+  '../src/services/checkout-no-user-policy.ts'
+);
 
 describe('decideNoUserPathOutcome', () => {
   it('default (fallbackToPricingPage=true) returns redirect-pro with persist=false', () => {
@@ -148,43 +151,88 @@ describe('cross-page redirect leak regression', () => {
   });
 });
 
-// #5380 High-3: the policy module is pure, so a mutation wiring
-// `savePendingCheckoutIntent(intent)` into checkout.ts's REDIRECT branch left
-// this suite green — the leak this file documents would be back with every
-// test passing. Pin the caller's wiring by source-grep (checkout.ts needs the
-// full Clerk + Dodo tree and cannot load under node:test).
-describe('startCheckout no-user wiring (source-grep)', () => {
-  const dirname = path.dirname(fileURLToPath(import.meta.url));
-  const src = readFileSync(path.join(dirname, '..', 'src', 'services', 'checkout.ts'), 'utf8');
-
-  function noUserBlock(): { redirectBranch: string; inlineBranch: string } {
-    const start = src.indexOf('const outcome = decideNoUserPathOutcome');
-    assert.ok(start > -1, 'expected decideNoUserPathOutcome call in checkout.ts');
-    const ifIdx = src.indexOf("if (outcome.kind === 'redirect-pro')", start);
-    const elseIdx = src.indexOf('} else {', ifIdx);
-    const endIdx = src.indexOf('return false;', elseIdx);
-    assert.ok(ifIdx > -1 && elseIdx > ifIdx && endIdx > elseIdx, 'no-user branch shape changed — update this test');
-    return {
-      redirectBranch: src.slice(ifIdx, elseIdx),
-      inlineBranch: src.slice(elseIdx, endIdx),
-    };
+// #5380 High-3: `decideNoUserPathOutcome` alone could not see the caller's
+// wiring, so a mutation persisting inside the REDIRECT branch left this suite
+// green. The first attempt at closing that used a source-grep guard over
+// checkout.ts — and two mutations proved a regex cannot do this job:
+//
+//   a) moving `openSignIn()` ABOVE the persist calls and leaving a comment
+//      naming `savePendingCheckoutIntent(intent)` above it — `indexOf` found
+//      the comment, so the ordering assertion held with the bug restored;
+//   b) writing `sessionStorage.setItem(...)` directly in the redirect branch —
+//      the negative grep for `savePendingCheckoutIntent` never fired.
+//
+// Both are now executable failures: `runNoUserPath` owns the sequencing, and
+// this suite runs it against a recorder.
+describe('runNoUserPath effect sequencing', () => {
+  function record(fallbackToPricingPage: boolean): string[] {
+    const log: string[] = [];
+    runNoUserPath(fallbackToPricingPage, {
+      navigate: (url) => log.push(`navigate:${url}`),
+      persistIntent: () => log.push('persistIntent'),
+      persistAttempt: () => log.push('persistAttempt'),
+      openSignIn: () => log.push('openSignIn'),
+    });
+    return log;
   }
 
-  it('redirect-pro branch must NOT persist a pending checkout intent', () => {
-    const { redirectBranch } = noUserBlock();
-    assert.ok(redirectBranch.includes('window.location.assign'), 'redirect branch must navigate');
-    assert.ok(
-      !redirectBranch.includes('savePendingCheckoutIntent'),
-      'redirect path persisting intent recreates the stale auto-resume leak this suite exists to prevent',
-    );
-    assert.ok(!redirectBranch.includes('saveCheckoutAttempt'), 'redirect path must not persist attempt state either');
+  it('redirect path navigates and performs NO persistence at all', () => {
+    assert.deepEqual(record(true), ['navigate:https://worldmonitor.app/pro']);
   });
 
-  it('inline sign-in branch MUST persist the intent before opening sign-in', () => {
-    const { inlineBranch } = noUserBlock();
-    const saveIdx = inlineBranch.indexOf('savePendingCheckoutIntent(intent)');
-    const signInIdx = inlineBranch.indexOf('openSignIn()');
-    assert.ok(saveIdx > -1, 'inline path must persist the pending intent');
-    assert.ok(signInIdx > saveIdx, 'intent must be persisted BEFORE openSignIn so the post-auth listener can resume');
+  it('inline path persists intent AND attempt BEFORE opening sign-in', () => {
+    // Exact sequence, not just membership: Clerk's post-auth listener fires as
+    // soon as sign-in resolves, so a persist that lands after openSignIn can
+    // miss the resume window.
+    assert.deepEqual(record(false), ['persistIntent', 'persistAttempt', 'openSignIn']);
+  });
+
+  it('inline path never navigates away from the dashboard', () => {
+    assert.ok(!record(false).some((entry) => entry.startsWith('navigate:')));
+  });
+});
+
+// What regex IS reliable for: call-site COUNTS. The handler literal in
+// checkout.ts is the only wiring the executable tests above cannot reach, so
+// pin how many times this module writes checkout state. Any NEW write site —
+// including a direct `sessionStorage.setItem` in the redirect handler (bypass
+// (b) above) — moves a count and reds this test. Counts survive the comment
+// and indirection tricks that defeat proximity and negative greps.
+describe('checkout.ts checkout-state write sites (count pins)', () => {
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const src = stripJsComments(
+    readFileSync(path.join(dirname, '..', 'src', 'services', 'checkout.ts'), 'utf8'),
+  );
+
+  function countOf(token: string): number {
+    return src.split(token).length - 1;
+  }
+
+  it('delegates the signed-out branch to runNoUserPath exactly once', () => {
+    assert.equal(countOf('runNoUserPath('), 1);
+  });
+
+  it('pins every checkout-state write site in checkout.ts', () => {
+    // savePendingCheckoutIntent: 1 declaration + 3 calls (the /pro-origin
+    // capture, the signed-out handler, the mid-flight session-expired retry).
+    assert.equal(
+      countOf('savePendingCheckoutIntent('),
+      4,
+      'a new pending-intent write site appeared — confirm it cannot fire on the redirect path (#5380)',
+    );
+    // saveCheckoutAttempt: 3 calls (/pro-origin capture, signed-out handler,
+    // pre-network attempt record); imported, not declared here.
+    assert.equal(
+      countOf('saveCheckoutAttempt('),
+      3,
+      'a new attempt write site appeared — confirm it cannot fire on the redirect path (#5380)',
+    );
+    // Direct sessionStorage writes: the post-checkout flag and the pending
+    // intent serializer. A third means someone bypassed both helpers.
+    assert.equal(
+      countOf('sessionStorage.setItem('),
+      2,
+      'a direct sessionStorage write bypasses the persistence helpers — see #5380 bypass (b)',
+    );
   });
 });

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -187,7 +187,14 @@ const stubSources: Record<string, string> = {
     export const showCheckoutErrorToast = () => {};
   `,
   './checkout-no-user-policy': `
-    export const decideNoUserPathOutcome = () => ({ kind: 'inline-signin', persist: true });
+    // Mirrors the real module's inline-signin sequencing (persist BEFORE
+    // sign-in); the ordering itself is owned by
+    // tests/checkout-no-user-policy.test.mts against the real function.
+    export const runNoUserPath = (_fallbackToPricingPage, handlers) => {
+      handlers.persistIntent();
+      handlers.persistAttempt();
+      handlers.openSignIn();
+    };
   `,
   './checkout-sentry-policy': `
     export const shouldSkipSentryForAction = () => false;

--- a/tests/checkout-pending-dialog.test.mts
+++ b/tests/checkout-pending-dialog.test.mts
@@ -169,7 +169,14 @@ const stubSources: Record<string, string> = {
     export const showCheckoutErrorToast = () => {};
   `,
   './checkout-no-user-policy': `
-    export const decideNoUserPathOutcome = () => ({ kind: 'inline-signin', persist: true });
+    // Mirrors the real module's inline-signin sequencing (persist BEFORE
+    // sign-in); the ordering itself is owned by
+    // tests/checkout-no-user-policy.test.mts against the real function.
+    export const runNoUserPath = (_fallbackToPricingPage, handlers) => {
+      handlers.persistIntent();
+      handlers.persistAttempt();
+      handlers.openSignIn();
+    };
   `,
   './checkout-sentry-policy': `
     export const shouldSkipSentryForAction = () => false;

--- a/tests/checkout-transport.test.mts
+++ b/tests/checkout-transport.test.mts
@@ -33,9 +33,11 @@ function makeDeps(outcomes: FetchOutcome[]): {
   deps: CreateCheckoutTransportDeps;
   calls: { url: string; init: RequestInit }[];
   delays: number[];
+  keyCalls: { count: number };
 } {
   const calls: { url: string; init: RequestInit }[] = [];
   const delays: number[] = [];
+  const keyCalls = { count: 0 };
   let i = 0;
   const deps: CreateCheckoutTransportDeps = {
     fetch: async (url, init) => {
@@ -48,10 +50,16 @@ function makeDeps(outcomes: FetchOutcome[]): {
     delay: async (ms) => {
       delays.push(ms);
     },
-    generateIdempotencyKey: () => 'test-key-1234',
+    // DISTINCT key per invocation (#5380): the old constant fixture made the
+    // "same key on retry" assertions tautological — a mutant that regenerated
+    // the key per attempt still returned the same literal and stayed green.
+    generateIdempotencyKey: () => {
+      keyCalls.count += 1;
+      return `test-key-${keyCalls.count}`;
+    },
     createTimeoutSignal: () => new AbortController().signal,
   };
-  return { deps, calls, delays };
+  return { deps, calls, delays, keyCalls };
 }
 
 const ARGS = {
@@ -76,7 +84,7 @@ describe('postCreateCheckout transport', () => {
     assert.equal(delays.length, 0);
     assert.equal(calls[0].url, '/api/create-checkout');
     assert.equal(calls[0].init.method, 'POST');
-    assert.equal(headerOf(calls[0].init, 'Idempotency-Key'), 'test-key-1234');
+    assert.equal(headerOf(calls[0].init, 'Idempotency-Key'), 'test-key-1');
     assert.equal(headerOf(calls[0].init, 'Authorization'), 'Bearer tok_abc');
     assert.equal(headerOf(calls[0].init, 'Content-Type'), 'application/json');
     assert.deepEqual(JSON.parse(String(calls[0].init.body)), { productId: 'pdt_x' });
@@ -85,15 +93,28 @@ describe('postCreateCheckout transport', () => {
   it('retries once on 502 with the SAME idempotency key, after a delay', async () => {
     const bad = new Response('<html>cloudflare 502</html>', { status: 502 });
     const good = new Response('{"checkout_url":"https://x"}', { status: 200 });
-    const { deps, calls, delays } = makeDeps([{ response: bad }, { response: good }]);
+    const { deps, calls, delays, keyCalls } = makeDeps([{ response: bad }, { response: good }]);
 
     const resp = await postCreateCheckout(deps, ARGS);
 
     assert.equal(resp.status, 200);
     assert.equal(calls.length, 2);
     assert.deepEqual(delays, [CHECKOUT_RETRY_DELAY_MS]);
-    assert.equal(headerOf(calls[0].init, 'Idempotency-Key'), 'test-key-1234');
-    assert.equal(headerOf(calls[1].init, 'Idempotency-Key'), 'test-key-1234');
+    // One generator invocation, reused verbatim on the retry — with the
+    // distinct-per-invocation fixture, a per-attempt regeneration would show
+    // up as 'test-key-2' on the second call (#5380 false-pass fix).
+    assert.equal(keyCalls.count, 1, 'idempotency key must be generated exactly once per checkout');
+    assert.equal(headerOf(calls[0].init, 'Idempotency-Key'), 'test-key-1');
+    assert.equal(headerOf(calls[1].init, 'Idempotency-Key'), 'test-key-1');
+    // The retry must be byte-identical to the original request — same URL,
+    // method, headers, and body — or Dodo-side dedup cannot key on it.
+    assert.equal(calls[1].url, calls[0].url);
+    assert.equal(calls[1].init.method, calls[0].init.method);
+    assert.deepEqual(calls[1].init.headers, calls[0].init.headers);
+    assert.equal(String(calls[1].init.body), String(calls[0].init.body));
+    // And the caller must receive the FINAL attempt's Response object.
+    assert.equal(resp, good, 'must resolve with the retry attempt\'s Response identity');
+    assert.equal(await resp.text(), '{"checkout_url":"https://x"}');
   });
 
   it('returns the second failure as-is when the retry also fails', async () => {
@@ -104,6 +125,13 @@ describe('postCreateCheckout transport', () => {
 
     assert.equal(resp.status, 502);
     assert.equal(calls.length, 2);
+  });
+
+  it('retryable set is exactly {502, 503, 504} — pinned, not read back from the code', () => {
+    // #5380: iterating RETRYABLE_CHECKOUT_STATUSES in the test below is
+    // tautological on its own — shrinking or widening the set would silently
+    // reshape the loop. Pin the literal contents here.
+    assert.deepEqual([...RETRYABLE_CHECKOUT_STATUSES].sort(), [502, 503, 504]);
   });
 
   it('treats every status in RETRYABLE_CHECKOUT_STATUSES as retryable', async () => {

--- a/tests/checkout-unparsable-success-body.test.mts
+++ b/tests/checkout-unparsable-success-body.test.mts
@@ -31,6 +31,8 @@ interface CapturedReport {
 interface HarnessState {
   reports: CapturedReport[];
   assignedUrls: string[];
+  checkoutEffects: string[];
+  currentUser: { id: string; email: string } | null;
   /** Body + headers the stub fetch should answer the create-checkout POST with. */
   responseBody: string;
   responseHeaders: Record<string, string>;
@@ -45,11 +47,13 @@ declare global {
 
 class MemoryStorage {
   private readonly store = new Map<string, string>();
+  constructor(private readonly onSet?: (key: string) => void) {}
   getItem(key: string): string | null {
     return this.store.has(key) ? (this.store.get(key) as string) : null;
   }
   setItem(key: string, value: string): void {
     this.store.set(key, String(value));
+    this.onSet?.(key);
   }
   removeItem(key: string): void {
     this.store.delete(key);
@@ -60,7 +64,10 @@ class MemoryStorage {
 }
 
 function installBrowserGlobals(): void {
-  Object.defineProperty(globalThis, 'sessionStorage', { configurable: true, value: new MemoryStorage() });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: new MemoryStorage((key) => globalThis.__xvHarness.checkoutEffects.push(`session:${key}`)),
+  });
   Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: new MemoryStorage() });
   Object.defineProperty(globalThis, 'window', {
     configurable: true,
@@ -77,6 +84,7 @@ function installBrowserGlobals(): void {
         hash: '',
         assign: (url: string) => {
           globalThis.__xvHarness.assignedUrls.push(url);
+          globalThis.__xvHarness.checkoutEffects.push(`navigate:${url}`);
         },
       },
       history: { replaceState: () => {} },
@@ -103,8 +111,19 @@ function installBrowserGlobals(): void {
   });
 }
 
-function resetHarness(responseBody: string, responseHeaders: Record<string, string> = {}): void {
-  globalThis.__xvHarness = { reports: [], assignedUrls: [], responseBody, responseHeaders };
+function resetHarness(
+  responseBody: string,
+  responseHeaders: Record<string, string> = {},
+  currentUser: HarnessState['currentUser'] = { id: 'user_1', email: 'pro@example.com' },
+): void {
+  globalThis.__xvHarness = {
+    reports: [],
+    assignedUrls: [],
+    checkoutEffects: [],
+    currentUser,
+    responseBody,
+    responseHeaders,
+  };
   installBrowserGlobals();
 }
 
@@ -130,9 +149,9 @@ const stubSources: Record<string, string> = {
     export const prereserveBillingPortalTab = () => null;
   `,
   './clerk': `
-    export const getCurrentClerkUser = () => ({ id: 'user_1', email: 'pro@example.com' });
+    export const getCurrentClerkUser = () => globalThis.__xvHarness.currentUser;
     export const getClerkToken = async () => 'tok_test';
-    export const openSignIn = () => {};
+    export const openSignIn = () => globalThis.__xvHarness.checkoutEffects.push('openSignIn');
   `,
   './analytics': `
     export const trackCheckoutStart = () => {};
@@ -141,22 +160,12 @@ const stubSources: Record<string, string> = {
     export const subscribeAuthState = () => () => {};
   `,
   './checkout-attempt': `
-    export const saveCheckoutAttempt = () => {};
+    export const saveCheckoutAttempt = () => globalThis.__xvHarness.checkoutEffects.push('saveCheckoutAttempt');
     export const loadCheckoutAttempt = () => null;
     export const clearCheckoutAttempt = () => {};
   `,
   './checkout-error-toast': `
     export const showCheckoutErrorToast = () => {};
-  `,
-  './checkout-no-user-policy': `
-    // Mirrors the real module's inline-signin sequencing (persist BEFORE
-    // sign-in); the ordering itself is owned by
-    // tests/checkout-no-user-policy.test.mts against the real function.
-    export const runNoUserPath = (_fallbackToPricingPage, handlers) => {
-      handlers.persistIntent();
-      handlers.persistAttempt();
-      handlers.openSignIn();
-    };
   `,
   './entitlements': `
     export const isEntitled = () => false;
@@ -224,6 +233,37 @@ function soleReport(): CapturedReport {
   assert.equal(reports.length, 1, `expected exactly one Sentry report, got ${reports.length}`);
   return reports[0];
 }
+
+describe('signed-out checkout production wiring', () => {
+  it('redirects without persisting checkout state on the default path', async () => {
+    resetHarness('', {}, null);
+    const checkout = await loadCheckoutModule();
+
+    assert.equal(await checkout.startCheckout('prod_monthly'), false);
+    assert.deepEqual(globalThis.__xvHarness.checkoutEffects, [
+      'navigate:https://worldmonitor.app/pro',
+    ]);
+  });
+
+  it('persists intent and attempt before opening inline sign-in', async () => {
+    resetHarness('', {}, null);
+    const checkout = await loadCheckoutModule();
+
+    assert.equal(
+      await checkout.startCheckout(
+        'prod_monthly',
+        undefined,
+        { fallbackToPricingPage: false },
+      ),
+      false,
+    );
+    assert.deepEqual(globalThis.__xvHarness.checkoutEffects, [
+      'session:wm-pending-checkout',
+      'saveCheckoutAttempt',
+      'openSignIn',
+    ]);
+  });
+});
 
 describe('create-checkout 200 with an unparsable body (WORLDMONITOR-XV)', () => {
   it('reports the contract violation instead of letting the parse error escape', async () => {

--- a/tests/checkout-unparsable-success-body.test.mts
+++ b/tests/checkout-unparsable-success-body.test.mts
@@ -149,7 +149,14 @@ const stubSources: Record<string, string> = {
     export const showCheckoutErrorToast = () => {};
   `,
   './checkout-no-user-policy': `
-    export const decideNoUserPathOutcome = () => ({ kind: 'inline-signin', persist: true });
+    // Mirrors the real module's inline-signin sequencing (persist BEFORE
+    // sign-in); the ordering itself is owned by
+    // tests/checkout-no-user-policy.test.mts against the real function.
+    export const runNoUserPath = (_fallbackToPricingPage, handlers) => {
+      handlers.persistIntent();
+      handlers.persistAttempt();
+      handlers.openSignIn();
+    };
   `,
   './entitlements': `
     export const isEntitled = () => false;

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -159,12 +159,37 @@ function findHomeDirReferences(source) {
 // sweeps cost nothing to extend.
 const SCANNED_TREES = ['scripts', 'api', 'server', 'cli', 'middleware.ts'];
 
+/**
+ * Yields `[entry, source]` for every scannable file.
+ *
+ * The read lives HERE, not at the call sites, for two reasons. It is the same
+ * read four sweeps below would otherwise each spell out, and — the reason it
+ * moved — a file can be unlinked between the glob yield and the read. Sibling
+ * tests spawn fixtures inside these very trees, and under
+ * `--test-concurrency=16` one of those disappearing mid-sweep used to fail an
+ * unrelated sweep with a bare `ENOENT ... scripts/_sigterm-fixture-<ts>.mjs`.
+ * A file that is not on disk when we read it cannot be a committed source, so
+ * skipping it is correct rather than merely convenient — but ONLY for ENOENT;
+ * any other read error is a real problem and still throws.
+ *
+ * The polluter this was diagnosed against (tests/seed-utils-sigterm-cleanup.test.mjs)
+ * now writes to a temp dir, so this is defense in depth against the next one.
+ * The `scanned > 100` floor below is what keeps the skip from silently
+ * degrading into "scanned nothing, found nothing".
+ */
 async function* scanSources() {
   for (const tree of SCANNED_TREES) {
     const pattern = tree.includes('.') ? tree : `${tree}/**/*.{mjs,cjs,js,mts,ts}`;
     for await (const entry of glob(pattern, { cwd: REPO_ROOT })) {
       if (entry.includes('node_modules')) continue;
-      yield entry;
+      let source;
+      try {
+        source = readFileSync(join(REPO_ROOT, entry), 'utf8');
+      } catch (err) {
+        if (err?.code === 'ENOENT') continue;
+        throw err;
+      }
+      yield [entry, source];
     }
   }
 }
@@ -442,9 +467,9 @@ describe('seeder env hermeticity (#5767)', () => {
     it('no source bakes a home path into the repo', async () => {
       const offenders = [];
       let scanned = 0;
-      for await (const entry of scanSources()) {
+      for await (const [entry, source] of scanSources()) {
         scanned += 1;
-        const found = findCheckoutEscapingEnvPaths(readFileSync(join(REPO_ROOT, entry), 'utf8'));
+        const found = findCheckoutEscapingEnvPaths(source);
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
       }
       assert.ok(scanned > 100, `expected to scan the seeder fleet, scanned ${scanned}`);
@@ -459,8 +484,7 @@ describe('seeder env hermeticity (#5767)', () => {
       // read-half gate has no such bypass: naming a `.env` file (or a loader)
       // is unavoidable, so anything reaching for $HOME to find one lands here.
       const offenders = [];
-      for await (const entry of scanSources()) {
-        const source = readFileSync(join(REPO_ROOT, entry), 'utf8');
+      for await (const [entry, source] of scanSources()) {
         if (!accessesEnvFileItself(source)) continue;
         const found = findHomeDirReferences(stripJsComments(source));
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
@@ -514,9 +538,9 @@ describe('seeder env hermeticity (#5767)', () => {
 
     it('no source outside the allowlist reads a .env file', async () => {
       const offenders = [];
-      for await (const entry of scanSources()) {
+      for await (const [entry, source] of scanSources()) {
         if (ENV_PARSER_ALLOWLIST.has(entry)) continue;
-        if (accessesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8'))) offenders.push(entry);
+        if (accessesEnvFileItself(source)) offenders.push(entry);
       }
       assert.deepEqual(
         offenders,

--- a/tests/seed-utils-sigterm-cleanup.test.mjs
+++ b/tests/seed-utils-sigterm-cleanup.test.mjs
@@ -13,15 +13,48 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const SCRIPTS_DIR = fileURLToPath(new URL('../scripts/', import.meta.url));
+// The fixture used to be written into the real `scripts/` directory so its
+// `./_seed-utils.mjs` import would resolve. That made this test a source of
+// FLAKY CI failures for every suite that scans that tree: under
+// `--test-concurrency=16`, tests/seed-env-hermeticity.test.mjs globs
+// `scripts/**` and readFileSync's each hit, so a fixture unlinked between the
+// glob yield and the read produced
+// `ENOENT ... scripts/_sigterm-fixture-<ts>.mjs` in an unrelated test.
+// Fixtures now live in a private temp dir and reach the helper by absolute
+// URL, so no scanned tree ever sees them.
+const SEED_UTILS_URL = pathToFileURL(
+  fileURLToPath(new URL('../scripts/_seed-utils.mjs', import.meta.url)),
+).href;
+const FIXTURE_DIR = mkdtempSync(join(tmpdir(), 'wm-sigterm-fixture-'));
+
+process.on('exit', () => {
+  try { rmSync(FIXTURE_DIR, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+let fixtureSeq = 0;
+
+/**
+ * Writes a fixture into the private temp dir and returns its path.
+ *
+ * Every fixture in this file goes through here — four separate writers used to
+ * hand-roll their own `join(SCRIPTS_DIR, ...)` path, so each was an independent
+ * source of the ENOENT flake described above.
+ */
+function writeFixture(label, bodyJs) {
+  const path = join(FIXTURE_DIR, `${label}-${fixtureSeq++}.mjs`);
+  // Keep the readable relative form at every call site; rewrite it here, since
+  // the fixture no longer sits next to the helper.
+  writeFileSync(path, bodyJs.replaceAll("'./_seed-utils.mjs'", JSON.stringify(SEED_UTILS_URL)));
+  return path;
+}
 
 function runFixture(bodyJs) {
-  const path = join(SCRIPTS_DIR, `_sigterm-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, bodyJs);
+  const path = writeFixture('sigterm', bodyJs);
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [path], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -152,8 +185,7 @@ test('runSeed SIGTERM handler fires once even if multiple SIGTERMs arrive', { sk
       lockTtlMs: 60_000,
     });
   `;
-  const path = join(SCRIPTS_DIR, `_sigterm-once-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, body);
+  const path = writeFixture('sigterm-once', body);
   try {
     await new Promise((resolve) => {
       const child = spawn(process.execPath, [path], {
@@ -260,8 +292,7 @@ test('publish-phase SIGTERM releases lock but does NOT extend TTL (strict-floor 
       lockTtlMs: 60_000,
     });
   `;
-  const path = join(SCRIPTS_DIR, `_sigterm-postfetch-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, body);
+  const path = writeFixture('sigterm-postfetch', body);
   try {
     await new Promise((resolve) => {
       const child = spawn(process.execPath, [path], {
@@ -399,8 +430,7 @@ test('SIGTERM during fetch-failure cleanup still triggers handler (no leak windo
       maxRetries: 0,  // fail fast — no withRetry retries
     });
   `;
-  const path = join(SCRIPTS_DIR, `_sigterm-fetchfail-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, body);
+  const path = writeFixture('sigterm-fetchfail', body);
   try {
     await new Promise((resolve) => {
       const child = spawn(process.execPath, [path], {


### PR DESCRIPTION
## Summary

Closes the High and Medium findings of #5380 (adversarial sweep of checkout/payment lifecycle coverage).

The first pass (992bc77) closed census #1–#9. A follow-up adversarial pass then mutation-tested that pass itself and found **four of its own assertions were false-passing** — the same defect class #5380 is about. Those are fixed here, each proven by execution, and censuses #10 and #11 are addressed too.

---

## Part 1 — original coverage work

### High

1. **False-passing idempotency test (census #1).** The fixture generator in `tests/checkout-transport.test.mts` returned a constant literal, so asserting "same key on both attempts" was tautological — a mutant regenerating the key per attempt stayed 9/9 green. The fixture now issues **distinct keys per invocation** and counts calls; the retry test asserts exactly one generator invocation reused verbatim across both attempts. **Mutation-verified.** The same test also asserts the retry request is byte-identical (URL/method/headers/body) and that the caller receives the final attempt's `Response` identity — covering census **#5** and **#6**.
2. **Malformed late webhook rollback (census #2)** — permanent regression in `convex/__tests__/webhook-rollback-boundaries.test.ts`: `customer.email` arriving as a number crashes the customer upsert **after** the subscription insert + entitlement recompute in the same mutation; the test proves `processWebhookEvent` rolls back entirely (zero `subscriptions`/`entitlements`/`webhookEvents` rows) and that Dodo's retry of the **same webhookId** then processes cleanly.
3. **No-user wiring (census #3)** — see Part 2, finding 3; the original source-grep approach did not hold.

### Medium

4. `RETRYABLE_CHECKOUT_STATUSES` contents pinned literally as `{502, 503, 504}` (census #4).
7. Pending-payment block window boundary (census #7) — see Part 2, finding 1.
8. Cancelled paid-through boundary at the checkout guard (census #8) — see Part 2, finding 2.
9. Equal-timestamp lifecycle ordering: `isNewerEvent` rejects equal timestamps, and a same-timestamp cancellation replay leaves the activated subscription untouched (census #9).

---

## Part 2 — hardening pass: four false-passes in the above, each proven by execution

### 1 + 2. The two "exact boundary" tests never touched the boundary

Both seeded from a live `Date.now()`, so by query time the row sat a few ms **past** the edge — where `.gt` and `.gte` agree. Mutations against 992bc77, both surviving 8/8 green:

| mutation | before | after |
|---|---|---|
| `.gt("occurredAt", windowStart)` → `.gte(...)` | 8/8 green | **RED** |
| `sub.currentPeriodEnd > now` → `>= now` | 8/8 green | **RED** |

Fixed by freezing the clock (the `convex/__tests__/businessSeats.test.ts` pattern) so the seeded value lands exactly on the edge, plus a `+1ms` partner case for each so the pair pins the edge **position**, not just its exclusivity.

### 3. The no-user wiring source-grep guard stayed green with the bug restored — twice

Two mutations, both verified green against the guard at 992bc77:

- **(a) comment-ordering.** Moving `openSignIn()` above the persist calls and leaving a comment naming `savePendingCheckoutIntent(intent)` above it — `indexOf` found the comment first, so the ordering assertion held while the real ordering was inverted.
- **(b) helper bypass.** Writing `sessionStorage.setItem(...)` directly in the redirect branch — the negative grep for `savePendingCheckoutIntent` never fired, so the stale auto-resume leak this suite exists to prevent came back silently.

**Fix (small production change):** the effect *sequencing* moves out of `checkout.ts`'s inline if/else into `runNoUserPath()` in the leaf policy module, reducing the caller to a handler literal. The suite now runs the real function against a recorder and asserts the exact effect sequence — which kills (a). For the residual handler literal, the guard is now a **call-site count pin** (what regex is actually reliable for), which kills (b): any new write site in `checkout.ts` moves a count. Both mutations now go **RED**.

### 4. Rollback test could silently stop testing rollback

`rejects.toThrow()` accepted any error, so upfront payload validation would keep it green while it no longer proved anything transactional. Now pinned to the post-insert `email.trim` crash site.

---

## Part 3 — the two censuses previously left open

**Census #10 (Dodo timeout/retry mock contract).** `isDefinitiveDodoNotFound` is the gate that decides whether reconciliation may **downgrade a paying customer**, but every test drove it through the action's `errorInjectionForTest` seam — a hand-rolled `Object.assign(new Error(), { status })` stub, so the assertions only proved our stub matches our own reader. `billing.test.ts` additionally `vi.mock`s the whole `dodopayments` module with a two-property class, so the real error classes are absent there by construction.

Now pinned against the SDK's **actual exported error instances**. Statuses the vendor really stamps, verified by probe:

| real SDK error | `.status` | may downgrade? |
|---|---|---|
| `NotFoundError` | 404 | ✅ yes — the only one |
| `AuthenticationError` | 401 | ❌ |
| `RateLimitError` | 429 | ❌ |
| `InternalServerError` | 500 | ❌ |
| `APIConnectionError` | *(none)* | ❌ |
| `APIConnectionTimeoutError` | *(none)* | ❌ |
| `APIUserAbortError` | *(none)* | ❌ |

Mutating the classifier to `.status !== undefined` reds 4 of these. This also fails if the vendor renames `.status` or ever stamps a status onto a timeout error — either of which would convert a transient blip into a customer downgrade.

**Census #11 (concurrent webhook exactly-once) — deliberately still open.** Probed the harness: `convex-test` runs mutations to completion one at a time, so dispatching both deliveries without awaiting does **not** interleave their transactions. Added a test that pins what *is* provable — two in-flight deliveries of one webhookId leave exactly one activation, the second on the dedup branch, and neither rejects (a rejection would make the HTTP action 500 and have Dodo retry an already-applied event). The genuine interleaving is closed in production by Convex's serializable isolation (the first insert invalidates the second's read set), which is a property of the runtime, not of this code. The test comment says exactly this so it is not mistaken for a race proof.

---

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: test coverage for checkout transport, webhook lifecycle, checkout guards; small extraction in `checkout.ts` / `checkout-no-user-policy.ts`

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck:all`)

## Documentation Alignment Checklist

N/A — no documented contract changes. The one production change moves existing effect sequencing into the leaf policy module with identical behavior.

## Verification

- `npm run test:convex`: **58 files / 1139 tests green**.
- Checkout family `tests/checkout-*.test.mts`: **169/169**.
  - Note: the `runNoUserPath` rename initially broke 20 of these — three harnesses stub `./checkout-no-user-policy` with an esbuild string that only exported `decideNoUserPathOutcome`. All three stubs repointed and the family is green.
- Adjacent suites touching `checkout.ts` (email-masking, pro-checkout-intent-url, funnel-analytics-policy, pro-banner-entitlement-race, product-catalog-freshness, deploy-config): **261/261**; chunk-graph guards (panel-cluster-chunks, dashboard-eager-chunks): **10/10**.
- `npm run typecheck:all` clean; `biome check` clean on all changed files.
- **Mutation matrix (every claim proven by execution, not inspection):**

| mutation | before | after |
|---|---|---|
| per-attempt idempotency key regeneration | RED | RED |
| `.gt` → `.gte` on the pending-payment window | 🟢 **green (false pass)** | RED |
| `currentPeriodEnd > now` → `>= now` | 🟢 **green (false pass)** | RED |
| `openSignIn()` above the persists, comment naming the persist | 🟢 **green (false pass)** | RED |
| direct `sessionStorage.setItem` in the redirect branch | 🟢 **green (false pass)** | RED |
| `isDefinitiveDodoNotFound`: `=== 404` → `!== undefined` | n/a (uncovered) | RED |

## Screenshots

N/A — test-only behavior; the one production change is a behavior-preserving extraction.
