### PR TITLE
fix(activation): route a denied push permission to the blocked state (#5609)

### DIFF
--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -77,7 +77,10 @@ async function gotoHarness(page: Page): Promise<void> {
 }
 
 /** Open the interstitial SHELL directly with synthetic steps + injected callbacks. */
-async function openShell(page: Page, confirmResult: 'verified' | 'failed'): Promise<void> {
+async function openShell(
+  page: Page,
+  confirmResult: 'verified' | 'failed' | 'blocked',
+): Promise<void> {
   await page.evaluate(async (result) => {
     const { initI18n } = await import('/src/services/i18n.ts');
     await initI18n();
@@ -91,7 +94,7 @@ async function openShell(page: Page, confirmResult: 'verified' | 'failed'): Prom
         { id: 'power', state: 'confirmable' },
       ],
       accountEmail: 'e2e@worldmonitor.app',
-      onConfirmStep: async () => result as 'verified' | 'failed',
+      onConfirmStep: async () => result as 'verified' | 'failed' | 'blocked',
       onSkipStep: () => {},
       onExit: (results) => {
         w.__proExit = results;
@@ -556,6 +559,43 @@ test.describe('Pro activation interstitial — shell step flow', () => {
     await expect(page.locator(SUMMARY)).toBeVisible();
     await expect(page.locator('.pro-activation-summary-line.status-failed')).toHaveCount(1);
     await expect(page.locator('.pro-activation-summary-line.status-pending')).toHaveCount(2);
+  });
+
+  test('confirm resolves to blocked → blocked state, no dead-end retry (#5609)', async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+    await openShell(page, 'blocked');
+
+    // Advance to alerts — the step a browser permission can actually block.
+    await page.locator(SKIP_BTN).click();
+    await expect(page.locator(PROGRESS)).toContainText('2 of 3');
+    await page.locator(CONFIRM_BTN).click();
+
+    // Blocked badge + the site-settings instructions, not the generic error.
+    await expect(page.locator('.pro-activation-status.status-blocked')).toContainText('Blocked');
+    await expect(page.locator('.pro-activation-note.note-warn')).toContainText('site settings');
+    await expect(page.locator('.pro-activation-note.note-error')).toHaveCount(0);
+
+    // Browsers never re-prompt after a deny, so "Try again" must be gone and
+    // the step must expose exactly one way forward.
+    await expect(page.locator(CONFIRM_BTN)).toHaveCount(0);
+    await expect(page.locator(SKIP_BTN)).toHaveCount(0);
+    await expect(page.locator(ADVANCE_SKIP_BTN)).toBeVisible();
+
+    // Continuing resolves it as skipped (same as a step blocked at mount) —
+    // never 'failed', which the summary would report as "we couldn't set up".
+    await page.locator(ADVANCE_SKIP_BTN).click();
+    await expect(page.locator(PROGRESS)).toContainText('3 of 3');
+    await page.locator(SKIP_BTN).click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+    await expect(page.locator('.pro-activation-summary-line.status-failed')).toHaveCount(0);
+
+    await page.locator(FINISH_BTN).click();
+    const results = await page.evaluate(
+      () => (window as unknown as { __proExit: Array<{ outcome: string }> }).__proExit,
+    );
+    expect(results.map((r) => r.outcome)).toEqual(['skipped', 'skipped', 'skipped']);
   });
 
   test('dismiss is blocked while a confirmation write is in flight', async ({ page }) => {

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -67,8 +67,17 @@ import {
   type ActivationStepId,
   type ActivationStepOutcome,
   type ActivationStepResult,
+  type ActivationStepState,
   type ActivationSummaryLine,
 } from '@/services/pro-activation-state';
+
+/**
+ * How an in-flow confirm resolved. `blocked` means the platform refused in a
+ * way a retry cannot fix — a denied notification permission, which browsers
+ * never re-prompt for — so the shell moves the step into its blocked state
+ * instead of offering a "Try again" that can only fail identically (#5609).
+ */
+export type ActivationConfirmResult = 'verified' | 'failed' | 'blocked';
 
 export interface ProActivationInterstitialOptions {
   /** Ordered steps from `buildActivationSteps` (computed by the caller). */
@@ -76,12 +85,19 @@ export interface ProActivationInterstitialOptions {
   /** Account email for display, so the user sees which account got Pro. */
   accountEmail: string;
   /**
-   * Complete a step in-flow. Resolves `'verified'` on success, `'failed'`
-   * otherwise. Injected by a later unit; until then a stub can resolve either.
+   * Complete a step in-flow. Resolves `'verified'` on success, `'blocked'` when
+   * the platform refused unrecoverably, `'failed'` for anything retryable.
+   * Injected by a later unit; until then a stub can resolve any of them.
    */
-  onConfirmStep: (stepId: ActivationStepId) => Promise<'verified' | 'failed'>;
+  onConfirmStep: (stepId: ActivationStepId) => Promise<ActivationConfirmResult>;
   /** Fire-and-forget skip signal (bookkeeping/telemetry wired by later units). */
   onSkipStep: (stepId: ActivationStepId) => void;
+  /**
+   * Fire-and-forget signal that a confirm resolved `blocked`. The step still
+   * resolves as skipped, so without this the denial cohort is indistinguishable
+   * from users who chose to skip.
+   */
+  onBlockStep?: (stepId: ActivationStepId) => void;
   /** Called after each durable step-state transition with a full snapshot. */
   onProgress?: (results: ActivationStepResult[]) => void;
   /** Called exactly once when the flow ends, with the ordered step results. */
@@ -92,13 +108,6 @@ export interface ProActivationInterstitialOptions {
    * for `confirmable` steps (already-done/blocked/unavailable never show them).
    */
   stepExtras?: Partial<Record<ActivationStepId, ProActivationStepExtra>>;
-  /**
-   * Optional per-step override for the "it failed" note copy. Consulted live at
-   * render time so the alerts step can distinguish "you declined the prompt"
-   * (permission denied) from a genuine write error (AE3). Return null/undefined
-   * to keep the generic failure note.
-   */
-  failedNote?: (stepId: ActivationStepId) => string | null | undefined;
 }
 
 /** Controls handed to a step's `onMount` so extras can complete the step. */
@@ -237,6 +246,29 @@ function summaryVerifiedDetail(id: ActivationStepId): string {
   }
 }
 
+/**
+ * Blocked-state note. `justDenied` marks the mid-flow transition — the user
+ * acted on the browser prompt just now, so the copy acknowledges that instead
+ * of reporting a pre-existing block. Both variants point at the browser's site
+ * settings: nothing inside the wizard can undo a denied permission.
+ */
+function blockedNote(id: ActivationStepId, justDenied: boolean): string {
+  if (id !== 'alerts') {
+    return t('components.proActivation.status.blockedNote', {
+      defaultValue: "This isn't available right now — you can set it up later from settings.",
+    });
+  }
+  return justDenied
+    ? t('components.proActivation.steps.alerts.declinedNote', {
+        defaultValue:
+          "No problem — we won't send browser alerts. You can turn them on later from your browser's site settings.",
+      })
+    : t('components.proActivation.steps.alerts.blockedNote', {
+        defaultValue:
+          "Notifications are blocked in your browser. Turn them on in your browser's site settings to get alerts.",
+      });
+}
+
 function statusLabel(status: StepStatus): string {
   switch (status) {
     case 'pending':
@@ -272,12 +304,24 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
   let generation = 0;
   let finished = false;
   const outcomes = new Map<ActivationStepId, ActivationStepOutcome>();
+  // Steps whose confirm resolved `blocked` (a denied browser permission). They
+  // render exactly like a step that was already blocked at mount — the browser
+  // will not re-prompt, so a retry CTA would be a dead end (#5609).
+  const blockedByConfirm = new Set<ActivationStepId>();
 
   const onSummary = (): boolean => currentIndex >= steps.length;
 
+  /**
+   * The step's CURRENT state — its declared state plus a mid-flow permission
+   * block. Every read goes through this: reading `step.state` directly would
+   * silently miss a blocked-by-confirm step the moment a branch cares about it.
+   */
+  const effectiveState = (step: ActivationStep): ActivationStepState =>
+    blockedByConfirm.has(step.id) ? 'blocked' : step.state;
+
   /** Default disposition for a step never explicitly acted on. */
   const defaultOutcome = (step: ActivationStep): ActivationStepOutcome =>
-    step.state === 'already-done' ? 'done' : 'skipped';
+    effectiveState(step) === 'already-done' ? 'done' : 'skipped';
 
   const buildResults = (): ActivationStepResult[] =>
     steps.map((step) => ({ id: step.id, outcome: outcomes.get(step.id) ?? defaultOutcome(step) }));
@@ -285,9 +329,10 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
   const recordProgress = (): void => options.onProgress?.(buildResults());
 
   const currentStatus = (step: ActivationStep): StepStatus => {
-    if (step.state === 'already-done') return 'verified';
-    if (step.state === 'blocked') return 'blocked';
-    if (step.state === 'unavailable') return 'unavailable';
+    const state = effectiveState(step);
+    if (state === 'already-done') return 'verified';
+    if (state === 'blocked') return 'blocked';
+    if (state === 'unavailable') return 'unavailable';
     if (transient === 'in-flight') return 'in-flight';
     if (transient === 'failed') return 'failed';
     return 'pending';
@@ -298,8 +343,9 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
 
   const stepNotesHtml = (step: ActivationStep): string => {
     const copy = stepFrameCopy(step.id);
+    const state = effectiveState(step);
     const notes: string[] = [];
-    if (step.state === 'already-done') {
+    if (state === 'already-done') {
       notes.push(noteHtml(copy.doneNote, 'ok'));
       if (step.id === 'brief' && step.preservesSchedule) {
         notes.push(
@@ -311,18 +357,9 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
           ),
         );
       }
-    } else if (step.state === 'blocked') {
-      const blocked =
-        step.id === 'alerts'
-          ? t('components.proActivation.steps.alerts.blockedNote', {
-              defaultValue:
-                "Notifications are blocked in your browser. Turn them on in your browser's site settings to get alerts.",
-            })
-          : t('components.proActivation.status.blockedNote', {
-              defaultValue: "This isn't available right now — you can set it up later from settings.",
-            });
-      notes.push(noteHtml(blocked, 'warn'));
-    } else if (step.state === 'unavailable') {
+    } else if (state === 'blocked') {
+      notes.push(noteHtml(blockedNote(step.id, blockedByConfirm.has(step.id)), 'warn'));
+    } else if (state === 'unavailable') {
       notes.push(
         noteHtml(
           t('components.proActivation.status.unavailableNote', {
@@ -332,13 +369,11 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
         ),
       );
     } else if (transient === 'failed') {
-      const override = options.failedNote?.(step.id);
       notes.push(
         noteHtml(
-          override ??
-            t('components.proActivation.status.failedBody', {
-              defaultValue: 'Something went wrong. You can try again, or set it up later from settings.',
-            }),
+          t('components.proActivation.status.failedBody', {
+            defaultValue: 'Something went wrong. You can try again, or set it up later from settings.',
+          }),
           'error',
         ),
       );
@@ -359,8 +394,9 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     const cont = (action: string): string =>
       primary(t('components.proActivation.actions.continue', { defaultValue: 'Continue' }), action);
 
-    if (step.state === 'already-done') return cont('advance-done');
-    if (step.state === 'blocked' || step.state === 'unavailable') return cont('advance-skip');
+    const state = effectiveState(step);
+    if (state === 'already-done') return cont('advance-done');
+    if (state === 'blocked' || state === 'unavailable') return cont('advance-skip');
     // confirmable
     // Power step: the extras' pointers ARE the actions — render only "Continue".
     if (options.stepExtras?.[step.id]?.replacesPrimaryAction) return cont('advance-skip');
@@ -373,7 +409,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
   };
 
   const stepExtrasHtml = (step: ActivationStep): string => {
-    if (step.state !== 'confirmable') return '';
+    if (effectiveState(step) !== 'confirmable') return '';
     const extra = options.stepExtras?.[step.id];
     if (!extra) return '';
     return `<div class="pro-activation-extras" data-pro-activation-extras>${extra.html}</div>`;
@@ -496,7 +532,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     for (let i = currentIndex; i < steps.length; i += 1) {
       const step = steps[i]!;
       if (outcomes.has(step.id)) continue;
-      if (step.state === 'already-done') {
+      if (effectiveState(step) === 'already-done') {
         outcomes.set(step.id, 'done');
         continue;
       }
@@ -535,7 +571,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
     transient = 'in-flight';
     renderModal();
     const gen = generation;
-    let result: 'verified' | 'failed';
+    let result: ActivationConfirmResult;
     try {
       result = await options.onConfirmStep(step.id);
     } catch {
@@ -547,6 +583,15 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
       outcomes.set(step.id, 'confirmed');
       recordProgress();
       advance();
+    } else if (result === 'blocked') {
+      // Unrecoverable refusal: drop the retry CTA and render the blocked state
+      // so the user gets the site-settings instructions instead of a "Try
+      // again" the browser will refuse identically forever. The step still
+      // resolves as skipped (same as one blocked at mount) when they continue.
+      blockedByConfirm.add(step.id);
+      transient = 'idle';
+      options.onBlockStep?.(step.id);
+      renderModal();
     } else {
       transient = 'failed';
       renderModal();
@@ -621,7 +666,7 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
       // Wire per-step extras (brief hour picker/preview, power pointers). The
       // controls let the power pointers confirm-and-close before deep-linking
       // the user into a Pro surface.
-      const extra = step.state === 'confirmable' ? options.stepExtras?.[step.id] : undefined;
+      const extra = effectiveState(step) === 'confirmable' ? options.stepExtras?.[step.id] : undefined;
       if (extra?.onMount) {
         const extrasRoot = modal.querySelector<HTMLElement>('[data-pro-activation-extras]');
         if (extrasRoot) {
@@ -1108,14 +1153,17 @@ async function confirmBrief(
 /** Alerts confirm: request+subscribe push, then ensure a rule delivers to it. */
 async function confirmAlerts(
   options: ProActivationFlowOptions,
-): Promise<'verified' | 'failed'> {
+): Promise<ActivationConfirmResult> {
   try {
     // Requests permission, subscribes, and registers the web_push channel.
-    // A denial throws here → 'failed' (AE3: the flow continues, nothing enabled).
+    // A denial throws here (AE3: the flow continues, nothing enabled).
     await subscribeToPush(options.accountUserId);
   } catch (err) {
     console.warn('[pro-activation] push subscribe declined/failed', err);
-    return 'failed';
+    // Read the LIVE permission rather than the thrown message: once it is
+    // `denied` no browser re-prompts, so the step is blocked, not retryable.
+    // A dismissed prompt leaves it `default` and stays a retryable failure.
+    return getPushPermission() === 'denied' ? 'blocked' : 'failed';
   }
   let fresh: ActivationContext;
   try {
@@ -1139,18 +1187,6 @@ async function confirmAlerts(
     console.warn('[pro-activation] alerts rule write failed', err);
     return 'failed';
   }
-}
-
-/** Denial-aware failed-note copy for the alerts step (distinguish decline from error). */
-function alertsFailedNote(): string {
-  return getPushPermission() === 'denied'
-    ? t('components.proActivation.steps.alerts.declinedNote', {
-        defaultValue:
-          "No problem — we won't send browser alerts. You can turn them on later from your browser's site settings.",
-      })
-    : t('components.proActivation.status.failedBody', {
-        defaultValue: 'Something went wrong. You can try again, or set it up later from settings.',
-      });
 }
 
 async function confirmPresentationWithRetry(
@@ -1341,7 +1377,6 @@ export async function openProActivationFlow(
     steps,
     accountEmail: options.accountEmail,
     stepExtras,
-    failedNote: (stepId) => (stepId === 'alerts' ? alertsFailedNote() : null),
     onConfirmStep: async (stepId) => {
       if (inFlight.has(stepId)) return 'failed';
       inFlight.add(stepId);
@@ -1361,6 +1396,7 @@ export async function openProActivationFlow(
       }
     },
     onSkipStep: (stepId) => options.onEvent?.(ACTIVATION_EVENTS.stepSkipped, stepId),
+    onBlockStep: (stepId) => options.onEvent?.(ACTIVATION_EVENTS.stepBlocked, stepId),
     onProgress: (results) => persistOutcome(results, false),
     onExit: (results) => {
       options.onEvent?.(ACTIVATION_EVENTS.exit, undefined, summarizeActivationExit(results));

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -114,12 +114,14 @@ const EVENTS = {
   // correlate with non-followed threads to size the bias's effect.
   'brief-thread-open': true,
   // Pro Activation Onboarding funnel (#4771) — day-0 activation interstitial:
-  // entered → per-step confirmed/skipped → exit (with completion state). Names
+  // entered → per-step confirmed/skipped/blocked → exit (with completion
+  // state). `blocked` is a platform refusal, not a user choice (#5609). Names
   // mirror ACTIVATION_EVENTS in @/services/pro-activation-state (the single
   // naming source); this catalog matches those literals.
   'pro-activation-entered': true,
   'pro-activation-step-confirmed': true,
   'pro-activation-step-skipped': true,
+  'pro-activation-step-blocked': true,
   'pro-activation-exit': true,
 } as const;
 
@@ -638,7 +640,7 @@ export function trackCheckoutFailed(rawStatus: string): void {
 // Pro Activation Onboarding funnel (#4771)
 // ---------------------------------------------------------------------------
 
-/** The four activation funnel events — the leaf's ACTIVATION_EVENTS is the naming source. */
+/** The activation funnel events — the leaf's ACTIVATION_EVENTS is the naming source. */
 export type ProActivationEvent = ActivationEventName;
 
 /**

--- a/src/services/pro-activation-state.ts
+++ b/src/services/pro-activation-state.ts
@@ -893,6 +893,11 @@ export const ACTIVATION_EVENTS = {
   entered: 'pro-activation-entered',
   stepConfirmed: 'pro-activation-step-confirmed',
   stepSkipped: 'pro-activation-step-skipped',
+  // A step the platform refused unrecoverably (a denied notification
+  // permission). It resolves as `skipped` like a step blocked at mount, so
+  // without this event the denial cohort is indistinguishable from users who
+  // chose to skip — the funnel would read a browser block as disinterest.
+  stepBlocked: 'pro-activation-step-blocked',
   exit: 'pro-activation-exit',
 } as const;
 

--- a/tests/pro-activation-alerts-blocked.test.mts
+++ b/tests/pro-activation-alerts-blocked.test.mts
@@ -1,0 +1,503 @@
+/**
+ * #5609 — a browser-denied notification permission must move the activation
+ * wizard's alerts step into the BLOCKED state (site-settings instructions +
+ * "Continue"), never the generic failed note with a "Try again" button.
+ * Browsers never re-prompt once permission is `denied`, so a retry CTA there is
+ * a dead end: it fails identically forever.
+ *
+ * Both halves run against the real module:
+ *   1. flow  — `openProActivationFlow`'s `onConfirmStep('alerts')` classifies a
+ *              push-subscribe rejection by the LIVE permission (denied →
+ *              'blocked', anything else → retryable 'failed').
+ *   2. shell — `openProActivationInterstitial` renders the blocked state when a
+ *              confirm resolves 'blocked', and still offers retry on 'failed'.
+ *
+ * The shell half needs a DOM that PARSES assigned `innerHTML` — the wizard
+ * re-renders by assigning an HTML string and then wires its buttons through
+ * `querySelector`. `tests/helpers/mini-dom.mts` deliberately stores the string
+ * without parsing it, so this file layers a small tag-soup parser onto
+ * MiniElement rather than pulling JSDOM into the suite.
+ */
+
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { MiniDocument, MiniElement, MiniText } from './helpers/mini-dom.mts';
+
+// ---------------------------------------------------------------------------
+// Minimal parsing DOM
+// ---------------------------------------------------------------------------
+
+const TAG_RE = /<(\/)?([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[^\s"'>/=]+(?:\s*=\s*"[^"]*")?)*)\s*(\/)?>/g;
+const ATTR_RE = /([^\s"'>/=]+)(?:\s*=\s*"([^"]*)")?/g;
+/** Tags the wizard never closes explicitly (it emits none today; guard anyway). */
+const VOID_TAGS = new Set(['br', 'hr', 'img', 'input', 'meta', 'link']);
+
+function applyAttributes(element: MiniElement, raw: string): void {
+  ATTR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ATTR_RE.exec(raw)) !== null) {
+    element.setAttribute(match[1]!, match[2] ?? '');
+  }
+}
+
+/**
+ * Parse the wizard's own generated markup into MiniElements. Scope is exactly
+ * what the wizard emits: balanced tags, double-quoted attributes, text nodes.
+ */
+function parseChildren(html: string, doc: MiniDocument): Array<MiniElement | MiniText> {
+  const roots: Array<MiniElement | MiniText> = [];
+  const stack: MiniElement[] = [];
+  const push = (node: MiniElement | MiniText): void => {
+    const parent = stack.at(-1);
+    if (parent) parent.appendChild(node);
+    else roots.push(node);
+  };
+
+  let cursor = 0;
+  TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TAG_RE.exec(html)) !== null) {
+    if (match.index > cursor) push(new MiniText(html.slice(cursor, match.index)));
+    cursor = TAG_RE.lastIndex;
+    const [, closing, tagName, attributes, selfClosing] = match;
+    if (closing) {
+      const index = stack.map((el) => el.tagName).lastIndexOf(tagName!.toUpperCase());
+      if (index >= 0) stack.length = index;
+      continue;
+    }
+    const element = doc.createElement(tagName!);
+    applyAttributes(element, attributes ?? '');
+    push(element);
+    if (!selfClosing && !VOID_TAGS.has(tagName!.toLowerCase())) stack.push(element);
+  }
+  if (cursor < html.length) push(new MiniText(html.slice(cursor)));
+  return roots;
+}
+
+/** Attribute-faithful serializer — MiniElement's own `outerHTML` drops attributes. */
+function serializeNode(node: MiniElement | MiniText): string {
+  if (!(node instanceof MiniElement)) return node.textContent ?? '';
+  const tag = node.tagName.toLowerCase();
+  let attributes = '';
+  for (const [name, value] of node.attributes) attributes += ` ${name}="${value}"`;
+  const children = node.childNodes
+    .map((child) => serializeNode(child as MiniElement | MiniText))
+    .join('');
+  return `<${tag}${attributes}>${children}</${tag}>`;
+}
+
+/**
+ * MiniElement whose `innerHTML` setter also builds the child tree, so
+ * `querySelector` after a render finds the wizard's freshly written buttons.
+ * The getter serializes that LIVE tree rather than replaying the assigned
+ * string: a snapshot would go silently vacuous the moment anything mutates the
+ * subtree after render (the brief step's preview already does exactly that),
+ * turning a `doesNotMatch` assertion into a pass-by-blindness.
+ */
+class ParsingElement extends MiniElement {
+  override get innerHTML(): string {
+    return this.childNodes.map((child) => serializeNode(child as MiniElement | MiniText)).join('');
+  }
+
+  override set innerHTML(value: string) {
+    this.childNodes = [];
+    const doc = (this.ownerDocument ?? null) as ParsingDocument | null;
+    if (!doc) return;
+    for (const child of parseChildren(String(value), doc)) super.appendChild(child);
+  }
+}
+
+class ParsingDocument extends MiniDocument {
+  override createElement(tagName: string): MiniElement {
+    const element = new ParsingElement(tagName);
+    element.ownerDocument = this;
+    return element;
+  }
+}
+
+interface DomHandles {
+  document: ParsingDocument;
+  restore: () => void;
+}
+
+const GLOBAL_KEYS = ['document', 'window', 'HTMLElement', 'requestAnimationFrame'] as const;
+
+function installDom(): DomHandles {
+  const saved = GLOBAL_KEYS.map(
+    (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+  );
+  const document = new ParsingDocument();
+  const define = (key: string, value: unknown): void => {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  };
+  define('document', document);
+  define('HTMLElement', MiniElement);
+  define('requestAnimationFrame', (callback: (t: number) => void) => {
+    callback(0);
+    return 1;
+  });
+  define('window', { setTimeout, clearTimeout, document, location: { origin: 'https://test' } });
+  return {
+    document,
+    restore: () => {
+      for (const [key, descriptor] of saved) {
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else delete (globalThis as Record<string, unknown>)[key];
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Module loader (esbuild + stubs, mirroring pro-activation-controller.test.mts)
+// ---------------------------------------------------------------------------
+
+type InterstitialModule = typeof import('../src/components/ProActivationInterstitial.ts');
+
+async function loadInterstitial(): Promise<InterstitialModule> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-pro-activation-alerts-'));
+  const outfile = join(tempDir, 'interstitial.bundle.mjs');
+  // `t` returns the KEY so assertions pin the copy the wizard chose rather than
+  // its English wording (which can be reworded without changing behaviour).
+  const stubs = new Map([
+    ['i18n-stub', 'export function t(key) { return key; }'],
+    ['auth-stub', `
+      export function getAuthState() { return { user: { id: globalThis.__alertsUserId } }; }
+      export function subscribeAuthState() { return () => {}; }
+    `],
+    ['billing-stub', `
+      export async function claimProActivationPresentation() { return 'claimed'; }
+      export async function confirmProActivationPresentation() { return true; }
+      export async function recordProActivationOutcome() { return true; }
+    `],
+    ['channels-stub', `
+      export async function getChannelsData() { return globalThis.__alertsChannelsData; }
+      export async function setEmailChannel() { return true; }
+      export async function setNotificationConfig(config) {
+        globalThis.__alertsConfigWrites.push(config);
+        if (globalThis.__alertsConfigWriteThrows) throw new Error('rule write rejected');
+        return true;
+      }
+    `],
+    ['push-stub', `
+      export function isWebPushSupported() { return true; }
+      export function getPushPermission() { return globalThis.__alertsPushPermission; }
+      export async function subscribeToPush() {
+        globalThis.__alertsSubscribeCalls += 1;
+        if (globalThis.__alertsSubscribeThrows) {
+          throw new Error('Notifications are blocked. Enable them in your browser settings.');
+        }
+        return { endpoint: 'https://push.test/x', p256dh: 'k', auth: 'a', userAgent: 'test' };
+      }
+    `],
+    ['insights-stub', `
+      export function getServerInsights() { return null; }
+      export async function fetchServerInsights() { return null; }
+    `],
+    ['widgets-stub', `
+      export function loadWidgets() { return []; }
+      export function loadWidgetsStrict() { return []; }
+    `],
+    ['variant-stub', "export const SITE_VARIANT = 'full';"],
+    ['chip-stub', 'export function showFinishSetupChipForResults() {}'],
+  ]);
+  const aliases = new Map([
+    ['@/services/i18n', 'i18n-stub'],
+    ['@/services/auth-state', 'auth-stub'],
+    ['@/services/billing', 'billing-stub'],
+    ['@/services/notification-channels', 'channels-stub'],
+    ['@/services/push-notifications', 'push-stub'],
+    ['@/services/insights-loader', 'insights-stub'],
+    ['@/services/widget-store', 'widgets-stub'],
+    ['@/config/variant', 'variant-stub'],
+    ['@/components/ProActivationChip', 'chip-stub'],
+  ]);
+
+  const result = await build({
+    entryPoints: [resolve(process.cwd(), 'src/components/ProActivationInterstitial.ts')],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'es2022',
+    write: false,
+    plugins: [{
+      name: 'pro-activation-alerts-test-stubs',
+      setup(buildApi) {
+        buildApi.onResolve({ filter: /.*/ }, (args) => {
+          const target = aliases.get(args.path);
+          return target ? { path: target, namespace: 'stub' } : null;
+        });
+        buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+          contents: stubs.get(args.path),
+          loader: 'js',
+        }));
+      },
+    }],
+  });
+
+  writeFileSync(outfile, result.outputFiles![0]!.text, 'utf8');
+  const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  rmSync(tempDir, { recursive: true, force: true });
+  return mod as InterstitialModule;
+}
+
+function installPushState(permission: 'default' | 'granted' | 'denied', throws: boolean): void {
+  Object.assign(globalThis, {
+    __alertsUserId: 'user_alerts',
+    __alertsPushPermission: permission,
+    __alertsSubscribeThrows: throws,
+    __alertsSubscribeCalls: 0,
+    __alertsConfigWrites: [] as unknown[],
+    __alertsConfigWriteThrows: false,
+    __alertsChannelsData: { channels: [], alertRules: [] },
+  });
+}
+
+/** Confirmable-everywhere context: the alerts step is offered, not pre-blocked. */
+function activationContext() {
+  return {
+    config: {
+      hasVerifiedEmailChannel: false,
+      hasEmailDelivery: false,
+      hasEnabledDigestRule: false,
+      hasTunedDigestHour: false,
+      hasWebPushChannel: false,
+      hasWebPushDelivery: false,
+      hasUsedPowerFeature: false,
+    },
+    capabilities: { webPushSupported: true, pushPermission: 'default' as const },
+    channels: [] as string[],
+    channelsKnown: true,
+    hasEnabledRule: false,
+  };
+}
+
+let activeDom: DomHandles | null = null;
+let activeClose: (() => void) | null = null;
+
+afterEach(() => {
+  activeClose?.();
+  activeClose = null;
+  activeDom?.restore();
+  activeDom = null;
+});
+
+// ---------------------------------------------------------------------------
+// 1. Flow — classify the subscribe rejection by the live permission
+// ---------------------------------------------------------------------------
+
+describe('alerts confirm classification (#5609)', () => {
+  const events: Array<{ event: string; stepId?: string }> = [];
+
+  async function captureConfirm(mod: InterstitialModule) {
+    events.length = 0;
+    let captured: Parameters<typeof mod.openProActivationInterstitial>[0] | null = null;
+    const opened = await mod.openProActivationFlow(
+      {
+        accountUserId: 'user_alerts',
+        accountEmail: 'pro@worldmonitor.test',
+        isAccountCurrent: () => true,
+        onEvent: (event, stepId) => events.push({ event, stepId }),
+      },
+      {
+        readContext: async () => activationContext(),
+        openInterstitial: (interstitialOptions) => {
+          captured = interstitialOptions;
+        },
+      },
+    );
+    assert.equal(opened, 'opened');
+    assert.ok(captured, 'flow must open the interstitial');
+    return captured!;
+  }
+
+  it('returns "blocked" when the browser denied the permission mid-flow', async () => {
+    installPushState('denied', true);
+    const mod = await loadInterstitial();
+    const options = await captureConfirm(mod);
+
+    const result = await options.onConfirmStep('alerts');
+
+    assert.equal(result, 'blocked', 'a denied permission is a dead end, not a retryable failure');
+    assert.equal((globalThis as Record<string, number>).__alertsSubscribeCalls, 1);
+
+    // The flow must map the shell's block signal onto its own funnel event, or
+    // the denial cohort disappears into skippedSteps.
+    options.onBlockStep?.('alerts');
+    assert.deepEqual(events.filter((e) => e.event.includes('blocked')), [
+      { event: 'pro-activation-step-blocked', stepId: 'alerts' },
+    ]);
+  });
+
+  it('still returns retryable "failed" when the prompt was merely dismissed', async () => {
+    // Permission stays 'default' — the browser WILL prompt again, so "Try
+    // again" remains meaningful and must not be swallowed by the blocked state.
+    installPushState('default', true);
+    const mod = await loadInterstitial();
+    const options = await captureConfirm(mod);
+
+    assert.equal(await options.onConfirmStep('alerts'), 'failed');
+  });
+
+  // Both post-subscribe failure paths must stay retryable: the permission was
+  // granted, so the step is recoverable and "Try again" is the right CTA.
+  it('still returns "failed" when the post-subscribe config read fails', async () => {
+    installPushState('granted', false);
+    const mod = await loadInterstitial();
+    const options = await captureConfirm(mod);
+    (globalThis as Record<string, unknown>).__alertsChannelsData = null;
+
+    assert.equal(await options.onConfirmStep('alerts'), 'failed');
+    assert.deepEqual((globalThis as Record<string, unknown[]>).__alertsConfigWrites, []);
+  });
+
+  it('still returns "failed" when the alert-rule write itself is rejected', async () => {
+    installPushState('granted', false);
+    const mod = await loadInterstitial();
+    const options = await captureConfirm(mod);
+    (globalThis as Record<string, unknown>).__alertsConfigWriteThrows = true;
+
+    assert.equal(await options.onConfirmStep('alerts'), 'failed');
+    assert.equal(
+      (globalThis as Record<string, unknown[]>).__alertsConfigWrites.length,
+      1,
+      'the rule write must actually be attempted before it can fail',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Shell — a 'blocked' confirm must render the blocked state, not a retry
+// ---------------------------------------------------------------------------
+
+describe('activation interstitial blocked transition (#5609)', () => {
+  function renderedHtml(dom: DomHandles): string {
+    const modal = dom.document.body.querySelector('.pro-activation-modal');
+    assert.ok(modal, 'interstitial must mount a modal');
+    return modal!.innerHTML;
+  }
+
+  function clickPrimary(dom: DomHandles): string {
+    const primary = dom.document.body.querySelector('.pro-activation-primary');
+    assert.ok(primary, 'step must render a primary action');
+    const action = primary!.dataset.action ?? '';
+    primary!.dispatchEvent(new Event('click'));
+    return action;
+  }
+
+  function openAlertsStep(
+    mod: InterstitialModule,
+    onConfirmStep: () => Promise<'verified' | 'failed' | 'blocked'>,
+    state: 'confirmable' | 'blocked' = 'confirmable',
+  ): {
+    dom: DomHandles;
+    skips: string[];
+    blocks: string[];
+    exits: Array<Array<{ id: string; outcome: string }>>;
+  } {
+    const dom = activeDom!;
+    const skips: string[] = [];
+    const blocks: string[] = [];
+    const exits: Array<Array<{ id: string; outcome: string }>> = [];
+    mod.openProActivationInterstitial({
+      steps: [{ id: 'alerts', state }],
+      accountEmail: 'pro@worldmonitor.test',
+      onConfirmStep: onConfirmStep as never,
+      onSkipStep: (stepId) => skips.push(stepId),
+      onBlockStep: (stepId) => blocks.push(stepId),
+      onExit: (results) => exits.push(results as never),
+    });
+    activeClose = mod.closeProActivationInterstitial;
+    return { dom, skips, blocks, exits };
+  }
+
+  it('renders the blocked state (no retry) once the confirm resolves blocked', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const { dom, skips, blocks, exits } = openAlertsStep(mod, async () => 'blocked');
+
+    assert.equal(clickPrimary(dom), 'confirm', 'the step starts on the confirm CTA');
+    await new Promise<void>((r) => setImmediate(r));
+
+    const html = renderedHtml(dom);
+    assert.match(html, /status-blocked/, 'status badge must flip to blocked');
+    assert.match(
+      html,
+      /steps\.alerts\.declinedNote/,
+      'must point the user at their browser site settings',
+    );
+    assert.doesNotMatch(html, /status\.retry/, 'a denied permission must not offer "Try again"');
+    assert.doesNotMatch(html, /data-action="confirm"/, 'the dead-end confirm CTA must be gone');
+    assert.doesNotMatch(html, /pro-activation-skip/, 'blocked steps expose one action, not two');
+    assert.match(html, /data-action="advance-skip"/, 'blocked steps advance with Continue');
+
+    // The block itself is reported separately: the step resolves as 'skipped',
+    // so without this signal a browser refusal reads as user disinterest.
+    assert.deepEqual(blocks, ['alerts'], 'the blocked transition must be observable');
+
+    // Continuing resolves the step exactly like one blocked at mount: skipped,
+    // never 'failed' (which the summary would report as "we couldn't set up").
+    assert.equal(clickPrimary(dom), 'advance-skip');
+    assert.deepEqual(skips, ['alerts']);
+    assert.equal(clickPrimary(dom), 'finish', 'continuing lands on the exit summary');
+    assert.deepEqual(exits, [[{ id: 'alerts', outcome: 'skipped' }]]);
+  });
+
+  it('records a blocked step as skipped when the user escapes instead of continuing', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const { dom, skips, exits } = openAlertsStep(mod, async () => 'blocked');
+
+    clickPrimary(dom);
+    await new Promise<void>((r) => setImmediate(r));
+    assert.match(renderedHtml(dom), /status-blocked/);
+
+    // finalizeAndShowSummary preserves a 'failed' transient but nothing else.
+    // A blocked step must land in skippedSteps, not the failedSteps bucket the
+    // summary renders as "we couldn't set this up" — the browser refused, we
+    // did not fail.
+    dom.document.dispatchEvent(Object.assign(new Event('keydown'), { key: 'Escape' }));
+    assert.match(renderedHtml(dom), /pro-activation-summary/, 'Escape rolls into the summary');
+    assert.doesNotMatch(renderedHtml(dom), /summary-line status-failed/);
+    assert.deepEqual(skips, ['alerts']);
+
+    assert.equal(clickPrimary(dom), 'finish');
+    assert.deepEqual(exits, [[{ id: 'alerts', outcome: 'skipped' }]]);
+  });
+
+  it('keeps the pre-denied copy for a step already blocked at mount', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const { dom } = openAlertsStep(mod, async () => 'blocked', 'blocked');
+
+    const html = renderedHtml(dom);
+    assert.match(html, /status-blocked/);
+    assert.match(html, /steps\.alerts\.blockedNote/, 'mount-blocked keeps its own copy');
+    assert.doesNotMatch(html, /steps\.alerts\.declinedNote/);
+  });
+
+  it('keeps offering "Try again" when the confirm merely failed', async () => {
+    installPushState('default', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const { dom } = openAlertsStep(mod, async () => 'failed');
+
+    clickPrimary(dom);
+    await new Promise<void>((r) => setImmediate(r));
+
+    const html = renderedHtml(dom);
+    assert.match(html, /status-failed/, 'a retryable failure keeps the failed badge');
+    assert.match(html, /status\.retry/, 'retry must survive for recoverable failures');
+    assert.match(html, /data-action="confirm"/);
+    assert.doesNotMatch(html, /status-blocked/);
+  });
+});

--- a/tests/pro-activation-state.test.mts
+++ b/tests/pro-activation-state.test.mts
@@ -1086,6 +1086,7 @@ describe('telemetry event selection', () => {
     assert.equal(ACTIVATION_EVENTS.entered, 'pro-activation-entered');
     assert.equal(ACTIVATION_EVENTS.stepConfirmed, 'pro-activation-step-confirmed');
     assert.equal(ACTIVATION_EVENTS.stepSkipped, 'pro-activation-step-skipped');
+    assert.equal(ACTIVATION_EVENTS.stepBlocked, 'pro-activation-step-blocked');
     assert.equal(ACTIVATION_EVENTS.exit, 'pro-activation-exit');
   });
 


### PR DESCRIPTION
Closes #5609.

## The problem

From the live purchase repro in #5600: with notifications blocked at the browser level, the activation wizard's alerts step showed **"DIDN'T WORK — Try again"**. Browsers never re-prompt once `Notification.permission` is `denied`, so that button failed identically forever. The wizard already had a blocked state with site-settings instructions (#5534) — it just only rendered when permission was denied *at mount*.

## The fix

`onConfirmStep` resolves a third result, `blocked`:

- **`confirmAlerts` classifies by the live permission, not the error message.** After `subscribeToPush` rejects it reads `getPushPermission()`: `denied` is unrecoverable → `blocked`; a merely dismissed prompt leaves it `default` → retryable `failed`, so "Try again" survives where it still means something.
- **The shell folds the result into `effectiveState(step)`**, so a mid-flow block renders through the exact path a mount-blocked step already used: blocked badge, site-settings note, a single "Continue", no retry CTA. It resolves as `skipped` — not `failed`, which the summary would report as "we couldn't set this up" for something we never attempted to do.
- **A block fires its own funnel event** (`pro-activation-step-blocked`). Since a blocked step resolves as skipped, without this the denial cohort would be byte-identical to voluntary skips in the durable record — a browser refusal would read as disinterest. The Convex `confirmedSteps`/`skippedSteps`/`failedSteps` buckets are unchanged.
- **Dead code removed.** Once denials never reach the failed state, the `failedNote` option and `alertsFailedNote()` are unreachable, so both are deleted. The `declinedNote` copy now serves the just-denied note (it already pointed at site settings) while `blockedNote` keeps the pre-denied one — no orphaned locale keys.

Copy for a user who just declined vs. one who arrived already blocked stays distinct, which is why `blockedNote(id, justDenied)` takes the flag.

## Testing

Both halves were verified **red before the fix and green after**, and the shell fix was **mutation-tested**: disabling the `blocked` branch turns the e2e red, and making `finalizeAndShowSummary` record blocked steps as `failed` turns the new Escape test red.

- `tests/pro-activation-alerts-blocked.test.mts` (new, 8 tests) — drives the real module: the flow half asserts `denied → blocked`, `default → failed`, and both post-subscribe failure paths (config read, rule write) staying retryable; the shell half asserts the rendered blocked state, the Escape/dismiss exit recording `skipped`, the mount-blocked copy split, and that a plain `failed` still offers retry.
  The shell half needs a DOM that *parses* assigned `innerHTML` (the wizard re-renders by assigning a string then wires buttons via `querySelector`), which `tests/helpers/mini-dom.mts` deliberately does not do — three other test files depend on that non-parsing behavior, so the parser is layered on locally rather than changing the shared helper.
- `e2e/pro-activation.spec.ts` — a real-Chromium test of the same transition, mirroring the existing failed-then-Escape case. Full spec: 24/24 passing.
- Gates: `typecheck`, `biome`, `lint:safe-html`, `sync:locales:check`, `docs-stats --check`, and the activation/i18n/funnel-policy unit suites (174 tests) all green.

## Review

9 reviewers (6 always-on + adversarial + frontend-races, plus an independent cross-model adversarial pass via Codex/gpt-5.5). Four actionable findings, all applied:

| Finding | Fix |
|---|---|
| P2 — no test pinned the Escape/dismiss exit while blocked (flagged by testing, adversarial, and maintainability independently) | Added the test; mutation-verified it goes red |
| P2 — the test DOM's `innerHTML` getter replayed the assigned string, so a post-render mutation would make assertions silently vacuous | Getter now serializes the live tree, attribute-faithfully |
| P3 — a browser block became indistinguishable from a voluntary skip in the durable record | Added the `pro-activation-step-blocked` event |
| P3 (cross-model) — the "write error" test actually exercised the config-read path, never the write | Split into two tests; the write path now genuinely fails and is asserted |

Also closed a latent trap both adversarial and maintainability raised below report threshold: two `step.state` reads had not been migrated. Inert today, but they would fail silently the moment either branched on `'blocked'` — all reads now go through `effectiveState`.

## Known residuals

- `confirmAlerts` reads `getPushPermission()` after the rejection, assuming the spec guarantee that `Notification.permission` is committed before `requestPermission()` settles. On any engine that violated it, the classification would read a stale `default` and fall back to today's behavior — fails safe, but the fix would be inert there.
- Permission revoked in the narrow window between a successful subscribe and the later config write still yields `failed` rather than `blocked`.
- A non-alerts step returning `blocked` is unreachable today (only `confirmAlerts` can produce it); the shell plumbing is generic but that branch is untested.
- The unit harness cannot observe the `disabled` attribute (mini-dom does not mirror it), so the in-flight double-click guard rests on the e2e plus the flow's `inFlight` set.
- The i18n stub returns keys, so unit tests pin *which* copy key is chosen; that the copy actually says "site settings" is asserted only in the e2e.

## Post-Deploy Monitoring & Validation

- **Watch:** the new `pro-activation-step-blocked` Umami event. Expect a small non-zero volume from the moment the first denied-permission subscriber hits the wizard — it is the signal that was previously lost inside skips.
- **Healthy:** `pro-activation-step-blocked` appears with `step=alerts`; `pro-activation-step-skipped` for alerts drops by roughly the blocked volume; no change to `pro-activation-exit` completion mix.
- **Failure signals:** zero `pro-activation-step-blocked` events after a week of traffic (classification never firing — the fix is inert), or a Sentry rise in `[pro-activation] push subscribe declined/failed` with no matching blocked events.
- **Rollback trigger:** any report of the alerts step losing its retry for a *recoverable* failure (the `default`-permission path) — that would mean the classification is too broad. Revert is a single commit.
- **Window/owner:** 7 days, @koala73.
