### PR TITLE
fix(military): stop cross-Strait seeder crashing on every publish (#5614)

### DIFF
--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -104,6 +104,18 @@ export async function writePublicationCompletion(
   }, CROSS_STRAIT_ACTIVITY_TTL_SECONDS);
 }
 
+/**
+ * runSeed invokes the hook as `afterPublish(data, { canonicalKey, ttlSeconds,
+ * recordCount, runId })`. `writePublicationCompletion` takes its injectable
+ * writer in that same positional slot, and a `= writeExtraKey` default only
+ * applies to `undefined` — so wiring it in bare put the meta object in `writer`
+ * and threw `TypeError: writer is not a function` on every run (#5614). Keep
+ * the runSeed meta in its own ignored slot and the writer seam after it.
+ */
+export function crossStraitActivityAfterPublish(snapshot, _runSeedMeta, writer = writeExtraKey) {
+  return writePublicationCompletion(snapshot, writer);
+}
+
 export function crossStraitActivityContentMeta(snapshot) {
   return tokensToContentMeta((snapshot?.observations ?? [])
     .filter((row) => row?.sourceId === 'taiwan-mnd')
@@ -151,6 +163,6 @@ if (process.argv[1]?.endsWith('seed-cross-strait-activity.mjs')) {
       metaKey: CROSS_STRAIT_ACTIVITY_BOOTSTRAP_META_KEY,
       metaCritical: true,
     }],
-    afterPublish: writePublicationCompletion,
+    afterPublish: crossStraitActivityAfterPublish,
   });
 }

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -12,6 +12,7 @@ import {
   CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS,
   CROSS_STRAIT_ACTIVITY_LOCK_TTL_MS,
   CROSS_STRAIT_ACTIVITY_PUBLISH_CLEANUP_HEADROOM_MS,
+  crossStraitActivityAfterPublish,
   projectCrossStraitActivityBootstrap,
   writePublicationCompletion,
 } from '../scripts/seed-cross-strait-activity.mjs';
@@ -188,6 +189,52 @@ test('cross-Strait completion marker is absent when any source-health write fail
     CROSS_STRAIT_ACTIVITY_BOOTSTRAP_META_KEY,
     CROSS_STRAIT_ACTIVITY_COMPLETION_META_KEY,
     'bundle freshness must not fall back to a projection write',
+  );
+});
+
+// #5614: the seeder crashed on every bundle tick because runSeed passes its
+// meta object where writePublicationCompletion expects an injectable writer.
+// Existing coverage always supplied a writer explicitly, so the production
+// call shape was never exercised. Pin it here.
+test('afterPublish hook survives runSeed passing its meta object in slot 2', async () => {
+  const writes: string[] = [];
+  const writer = async (key: string) => {
+    writes.push(key);
+  };
+  await crossStraitActivityAfterPublish(
+    {
+      observations: [{ sourceId: 'taiwan-mnd' }],
+      sources: [{
+        id: 'taiwan-mnd',
+        transportStatus: 'fresh',
+        lastSuccessAt: '2026-07-25T08:00:00.000Z',
+      }],
+    },
+    // The exact shape runSeed hands the hook (scripts/_seed-utils.mjs).
+    {
+      canonicalKey: 'military:cross-strait-activity:v1',
+      ttlSeconds: 15_552_000,
+      recordCount: 1,
+      runId: 'run-5614',
+    },
+    writer,
+  );
+  assert.ok(writes.includes('military:cross-strait-activity:v1:source:taiwan-mnd'));
+  assert.ok(writes.includes('seed-meta:military:cross-strait-activity:taiwan-mnd'));
+  assert.equal(
+    writes.at(-1),
+    CROSS_STRAIT_ACTIVITY_COMPLETION_META_KEY,
+    'completion marker must still be the final write through the runSeed hook',
+  );
+});
+
+test('runSeed wires the meta-tolerant hook, not the writer-injected helper', () => {
+  const source = read('scripts/seed-cross-strait-activity.mjs');
+  assert.match(source, /afterPublish:\s*crossStraitActivityAfterPublish,/);
+  assert.doesNotMatch(
+    source,
+    /afterPublish:\s*writePublicationCompletion,/,
+    'wiring the writer-injected helper straight into afterPublish puts runSeed meta in the writer slot (#5614)',
   );
 });
 


### PR DESCRIPTION
Closes #5614.

`seed-cross-strait-activity` has crashed on **every** bundle tick since #5596 with `TypeError: writer is not a function`. Found by `/diagnose-railway-seeders`; deployment `c177edb3-f23e-4b74-aca5-54d16122c819`.

## Root cause

`runSeed` invokes the hook with a **metadata object** in slot 2 (`scripts/_seed-utils.mjs:1998`):

```js
await afterPublish(data, { canonicalKey, ttlSeconds, recordCount, runId });
```

`writePublicationCompletion` takes its **injectable writer** in that same slot, and `= writeExtraKey` only defaults on `undefined`. Wiring the helper in bare put the meta object into `writer`, so the first call threw. Every other seeder wraps the hook in a lambda (`seed-commodity-quotes.mjs:310`, `seed-cross-source-signals.mjs:890`), which is why only this one broke.

## Why it was invisible

The throw lands **after** the canonical + bootstrap writes but **before** `writeFreshnessMetadataSafely` (`scripts/_seed-utils.mjs:2018`). The panel kept rendering from the bootstrap key while three keys went permanently unwritten — confirmed on `/api/health?compact=1`:

| health entry | state |
|---|---|
| `crossStraitActivity` | `STALE_SEED`, `seedAgeMin` undefined — never written |
| `crossStraitActivityTaiwanMnd` | `EMPTY` (crit) |
| `crossStraitActivityJapanMod` | `EMPTY` (crit) |
| `seed-meta:…:complete` | never written |

Plus `seed-bundle-derived-signals` exited 1 every tick (`ran:1 … failed:1`), firing a "Deploy Crashed!" alert and burning the run's compute. 100% deterministic — it could never self-heal.

## Fix

Give runSeed's meta its own ignored slot and move the writer seam after it:

```js
export function crossStraitActivityAfterPublish(snapshot, _runSeedMeta, writer = writeExtraKey) {
  return writePublicationCompletion(snapshot, writer);
}
```

`writePublicationCompletion` itself is unchanged, so existing coverage still exercises the injected-writer path.

## Verification (red → green)

Existing tests always passed a writer explicitly (`tests/cross-strait-activity-shipping.test.mts:181,196`), so the production call shape was never exercised — the DI seam hid the wiring bug.

Reproduced against pre-fix source with runSeed's exact call shape:

```
TypeError: writer is not a function
```

Two new tests, both red before the fix:
1. **Behavioural** — calls the exported hook with runSeed's exact `(data, meta, writer)` shape and asserts the source-health writes land and the completion marker is still last.
2. **Wiring guard** — asserts the script wires `crossStraitActivityAfterPublish` and *not* the writer-injected helper, so the trap can't be reintroduced.

After the fix, run locally in this worktree:
- `tests/cross-strait-activity-shipping.test.mts` — 8/8 pass
- `tests/cross-strait-activity.test.mts` — 30/30 pass
- `tests/cross-strait-activity-production-registration.test.mts` + `-ui` — 9/9 pass
- `biome check` on both changed files — clean

## Note for reviewers

There is uncommitted work in a parallel local worktree (`codex/fix-cross-strait-source-health`, unpushed) that moves source-health into a new `beforePublish` hook. As written it **keeps this bug and adds a second instance of it** — it calls `beforePublish(data, { canonicalKey, ttlSeconds, runId })` into `writeSourceHealth(snapshot, writer = writeExtraKey)`, the identical trap, and still wires `afterPublish: writePublicationCompletion` bare. If that work lands later it needs the same treatment.

https://claude.ai/code/session_01Xcz83xQWc6XVqrzevDm5hd
