### PR TITLE
fix(premium): stop rendering a 403 as "Pro required — upgrade" when the client says Pro (#5608)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 173
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 173 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (204 service modules and domain directories)
+│   ├── services/           # Business logic (205 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 173,
-  "serviceTopLevelEntries": 204,
+  "serviceTopLevelEntries": 205,
   "apiEndpointEntries": 89,
   "panelClasses": 105,
   "protoFiles": 281,

--- a/src/App.ts
+++ b/src/App.ts
@@ -1447,6 +1447,16 @@ export class App {
 
         // Rebind Convex watches to the real Clerk userId (was bound to anon UUID at init)
         destroyEntitlementSubscription();
+        // destroyEntitlementSubscription deliberately PRESERVES the last
+        // snapshot so a WebSocket reconnect doesn't flash paying users back to
+        // locked. That preservation is wrong across an account change: until
+        // the new user's first snapshot lands, getEntitlementState() still
+        // describes the previous one. Anything reading it then attributes A's
+        // plan to B — e.g. premium-denial's clientBelievesPro would read B's
+        // legitimate 403 as A's entitlement desync and retry instead of
+        // showing the upgrade CTA. Sign-out already resets for this reason;
+        // an account switch carries the same hazard.
+        resetEntitlementState();
         destroySubscriptionWatch();
         void initEntitlementSubscription(userId);
         void initSubscriptionWatch(userId);

--- a/src/components/ChatAnalystPanel.ts
+++ b/src/components/ChatAnalystPanel.ts
@@ -5,6 +5,9 @@ import DOMPurify from 'dompurify';
 import { postProcessAnalystHtml } from '@/utils/analyst-markdown';
 import { yieldToMain } from '@/utils/after-paint';
 import { premiumFetch } from '@/services/premium-fetch';
+import { getAuthState } from '@/services/auth-state';
+import { readClientEntitlementBelief } from '@/services/panel-gating';
+import { classifyPremiumDenial, readDenialErrorCode } from '@/services/premium-denial';
 import { trackAnalystControlAction } from '@/services/analytics';
 import { h, replaceChildren, setTrustedHtml, trustedHtml, type TrustedHtml } from '@/utils/dom-utils';
 import {
@@ -51,6 +54,40 @@ interface MetaEvent {
 }
 
 type DashboardControlStatus = 'applied' | 'denied' | 'invalid' | 'skipped';
+
+/**
+ * Turn a failed /api/chat-analyst response into user-facing copy.
+ *
+ * A 403 has several causes and only one of them is "you need to buy Pro":
+ * the route 403s on a missing plan (api/chat-analyst.ts:126), and the shared
+ * gateway also 403s an unidentified caller and a failed entitlement lookup.
+ * Telling a customer who paid minutes ago to buy a subscription — which is
+ * what the old blanket `status === 403` branch did during the #5600 poison
+ * window — is worse than saying nothing (#5608).
+ *
+ * Consumes the response body, so it is only called on the !ok path where the
+ * stream is never read.
+ */
+async function describeDenial(res: Response): Promise<string> {
+  const isDenial = res.status === 401 || res.status === 403;
+  const verdict = classifyPremiumDenial({
+    status: res.status,
+    errorCode: isDenial ? await readDenialErrorCode(res) : null,
+    belief: readClientEntitlementBelief(getAuthState()),
+  });
+  switch (verdict) {
+    case 'sign_in_required':
+      return 'Sign in to use the analyst.';
+    case 'upgrade_required':
+      return 'Pro subscription required.';
+    case 'entitlement_desync':
+      return 'Verifying your Pro access — try again in a moment.';
+    case 'access_denied':
+      return 'Analyst temporarily unavailable — try again in a moment.';
+    default:
+      return `Error ${res.status}`;
+  }
+}
 
 interface DashboardControlResult {
   ok: boolean;
@@ -503,8 +540,7 @@ export class ChatAnalystPanel extends Panel {
       });
 
       if (!res.ok) {
-        const err = res.status === 403 ? 'Pro subscription required.' : `Error ${res.status}`;
-        this.finalizeStreamingBubble(streamingBody, `⚠ ${err}`, false);
+        this.finalizeStreamingBubble(streamingBody, `⚠ ${await describeDenial(res)}`, false);
         return;
       }
 

--- a/src/components/ChatAnalystPanel.ts
+++ b/src/components/ChatAnalystPanel.ts
@@ -7,7 +7,7 @@ import { yieldToMain } from '@/utils/after-paint';
 import { premiumFetch } from '@/services/premium-fetch';
 import { getAuthState } from '@/services/auth-state';
 import { readClientEntitlementBelief } from '@/services/panel-gating';
-import { classifyPremiumDenial, readDenialErrorCode } from '@/services/premium-denial';
+import { classifyDenialResponse } from '@/services/premium-denial';
 import { trackAnalystControlAction } from '@/services/analytics';
 import { h, replaceChildren, setTrustedHtml, trustedHtml, type TrustedHtml } from '@/utils/dom-utils';
 import {
@@ -69,12 +69,7 @@ type DashboardControlStatus = 'applied' | 'denied' | 'invalid' | 'skipped';
  * stream is never read.
  */
 async function describeDenial(res: Response): Promise<string> {
-  const isDenial = res.status === 401 || res.status === 403;
-  const verdict = classifyPremiumDenial({
-    status: res.status,
-    errorCode: isDenial ? await readDenialErrorCode(res) : null,
-    belief: readClientEntitlementBelief(getAuthState()),
-  });
+  const verdict = await classifyDenialResponse(res, readClientEntitlementBelief(getAuthState()));
   switch (verdict) {
     case 'sign_in_required':
       return 'Sign in to use the analyst.';
@@ -523,7 +518,8 @@ export class ChatAnalystPanel extends Panel {
     const { bubble, body: streamingBody } = this.appendStreamingBubble();
     let accumulatedText = '';
 
-    this.streamAbort = new AbortController();
+    const controller = new AbortController();
+    this.streamAbort = controller;
 
     try {
       const res = await premiumFetch(API_URL, {
@@ -536,7 +532,7 @@ export class ChatAnalystPanel extends Panel {
           // geoContext (ISO-2 country focus) is supported by the API but wired in Phase 2
           // when the panel can read the map's selected country. Agent callers can pass it directly.
         }),
-        signal: this.streamAbort.signal,
+        signal: controller.signal,
       });
 
       if (!res.ok) {
@@ -576,9 +572,17 @@ export class ChatAnalystPanel extends Panel {
         this.finalizeStreamingBubble(streamingBody, '⚠ Network error. Try again.', false);
       }
     } finally {
-      this.streamAbort = null;
-      this.isStreaming = false;
-      this.setSendDisabled(false);
+      // Only tear down the shared streaming state if we still OWN it. Every
+      // exit path here follows an await, and clear() resets isStreaming, so a
+      // user who clears mid-flight can start a second send before this block
+      // runs — unconditionally nulling streamAbort would then cancel-proof the
+      // NEW stream and leave the send button stuck. Keying on controller
+      // identity makes a superseded invocation clean up only its own bubble.
+      if (this.streamAbort === controller) {
+        this.streamAbort = null;
+        this.isStreaming = false;
+        this.setSendDisabled(false);
+      }
       bubble.classList.remove('chat-msg-streaming');
     }
   }

--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -21,9 +21,15 @@
 
 import { Panel } from './Panel';
 import { getClerkToken, clearClerkTokenCache } from '@/services/clerk';
-import { PanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
+import { PanelGateReason, hasPremiumAccess, readClientEntitlementBelief } from '@/services/panel-gating';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
-import { hasTier, getEntitlementState } from '@/services/entitlements';
+import { getEntitlementState } from '@/services/entitlements';
+import {
+  classifyPremiumDenial,
+  clientBelievesPro,
+  readDenialErrorCode,
+  type PremiumDenialVerdict,
+} from '@/services/premium-denial';
 import { trackBriefThreadOpen } from '@/services/analytics';
 import { h, rawHtml, replaceChildren, clearChildren, trustedHtml, type TrustedHtml } from '@/utils/dom-utils';
 
@@ -45,12 +51,12 @@ type LatestBriefResponse = LatestBriefReady | LatestBriefComposing;
 
 /**
  * Typed access-failure surface. Lets the refresh loop branch on the
- * specific condition (sign-in / upgrade) instead of retrying as if
- * the error were transient.
+ * specific condition (sign-in / upgrade / server-side desync) instead
+ * of collapsing every denial into one render.
  */
 class BriefAccessError extends Error {
-  readonly code: 'sign_in_required' | 'upgrade_required';
-  constructor(code: BriefAccessError['code']) {
+  readonly code: PremiumDenialVerdict;
+  constructor(code: PremiumDenialVerdict) {
     super(code);
     this.code = code;
     this.name = 'BriefAccessError';
@@ -197,9 +203,14 @@ export class LatestBriefPanel extends Panel {
     // snapshot for AFFIRMATIVE DENIAL: skip the doomed fetch when
     // we KNOW the user is free. If the snapshot is missing, stale,
     // or the Convex subscription failed to establish, we fall
-    // through and let the server decide. The server's 403 response
-    // is translated to renderUpgradeRequired() in the catch block
-    // below (via BriefAccessError).
+    // through and let the server decide, and fetchLatest classifies
+    // its denial (via BriefAccessError).
+    //
+    // "KNOW the user is free" means a snapshot arrived AND no signal
+    // contradicts it — a snapshot that says free while the Clerk
+    // session claims the Pro role is a contradiction, not knowledge,
+    // so we let the server break the tie rather than paint an upsell
+    // over it (#5608).
     //
     // Consequence: an API-key-only user with a free Clerk account
     // will fire one doomed fetch per refresh and see the upgrade
@@ -208,7 +219,7 @@ export class LatestBriefPanel extends Panel {
     // a gate) locked legitimate Pro users out whenever the Convex
     // entitlement subscription was skipped or failed, which is a
     // worse failure mode.
-    if (getEntitlementState() !== null && !hasTier(1)) {
+    if (getEntitlementState() !== null && !clientBelievesPro(readClientEntitlementBelief(authState))) {
       this.renderUpgradeRequired();
       return;
     }
@@ -224,6 +235,9 @@ export class LatestBriefPanel extends Panel {
       // across account changes.
       if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
       if ((getAuthState().user?.id ?? null) !== requestUserId) return;
+      // We have data — retire any auto-retry countdown a previous transient
+      // denial (entitlement_desync / access_denied) left armed.
+      this.clearErrorState();
       if (data.status === 'ready') {
         this.renderReady(data);
       } else {
@@ -234,11 +248,24 @@ export class LatestBriefPanel extends Panel {
       if ((err as { name?: string } | null)?.name === 'AbortError') return;
       if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
       if ((getAuthState().user?.id ?? null) !== requestUserId) return;
-      // Structured access errors render a terminal CTA, not a retry
-      // error — retrying a 401 or 403 can't flip the outcome.
+      // Terminal access errors render a CTA — retrying can't flip a
+      // missing session or a genuinely free plan. Transient ones fall
+      // through to showError(), which retries on the panel's backoff.
       if (err instanceof BriefAccessError) {
-        if (err.code === 'sign_in_required') this.renderSignInRequired();
-        else this.renderUpgradeRequired();
+        if (err.code === 'sign_in_required') {
+          this.renderSignInRequired();
+          return;
+        }
+        if (err.code === 'upgrade_required') {
+          this.renderUpgradeRequired();
+          return;
+        }
+        this.showError(
+          err.code === 'entitlement_desync'
+            ? 'Verifying your Pro access — your brief will appear shortly.'
+            : 'Brief service unavailable — retrying shortly.',
+          () => { void this.refresh(); },
+        );
         return;
       }
       const message = err instanceof Error ? err.message : 'Brief unavailable — try again shortly.';
@@ -299,16 +326,28 @@ export class LatestBriefPanel extends Panel {
       signal,
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (res.status === 401) {
-      throw new BriefAccessError('sign_in_required');
-    }
-    if (res.status === 403) {
-      // Server says the Clerk userId is not Pro. This can happen
-      // when the client's authState says role=pro but the server's
-      // entitlement source (Convex) disagrees, or when the Clerk
-      // plan claim goes stale. Surface as upgrade CTA — not a
-      // retryable error, since retrying won't flip entitlement.
-      throw new BriefAccessError('upgrade_required');
+    // 401/403 are classified rather than assumed. `/api/latest-brief`
+    // returns 403 for BOTH a free plan (`pro_required`) and a rejected
+    // origin (`Origin not allowed`), and a `pro_required` the client's own
+    // entitlement state contradicts is a server-side desync — rendering
+    // any of those as "Upgrade to Pro" tells a paying user to buy the
+    // plan they already bought (#5608).
+    // Only denials get their body read here — res.json() below needs an
+    // unconsumed stream on the success path.
+    const verdict = (res.status === 401 || res.status === 403)
+      ? classifyPremiumDenial({
+        status: res.status,
+        errorCode: await readDenialErrorCode(res),
+        belief: readClientEntitlementBelief(getAuthState()),
+      })
+      : null;
+    if (verdict !== null) {
+      // Reading the body is awaited, so a gate-lock or account-switch abort
+      // can land mid-parse — where readDenialErrorCode swallows it. Without
+      // this, that abort would surface as a denial render instead of the
+      // no-op the abort was asking for.
+      if (signal.aborted) throw new DOMException('aborted while reading denial body', 'AbortError');
+      throw new BriefAccessError(verdict);
     }
     if (!res.ok) {
       throw new Error(`Brief service unavailable (${res.status})`);
@@ -336,6 +375,8 @@ export class LatestBriefPanel extends Panel {
    * this is an error state.
    */
   private renderSignInRequired(): void {
+    // Terminal state — retire any auto-retry a prior transient denial armed.
+    this.clearErrorState();
     clearChildren(this.content);
     const logo = h('div', { className: 'latest-brief-logo' });
     logo.appendChild(rawHtml(WM_LOGO_SVG));
@@ -351,11 +392,15 @@ export class LatestBriefPanel extends Panel {
   }
 
   /**
-   * Free Clerk account (either via local authState or via a 403
-   * from the server). Render an upgrade CTA instead of retrying —
-   * the user needs a plan change, not a fresh fetch.
+   * Free Clerk account, confirmed by BOTH the client snapshot and the
+   * server (or asserted by the server while the client has no opinion).
+   * Render an upgrade CTA instead of retrying — the user needs a plan
+   * change, not a fresh fetch. A 403 the client's own entitlement state
+   * contradicts does NOT land here; see classifyPremiumDenial (#5608).
    */
   private renderUpgradeRequired(): void {
+    // Terminal state — retire any auto-retry a prior transient denial armed.
+    this.clearErrorState();
     clearChildren(this.content);
     const logo = h('div', { className: 'latest-brief-logo' });
     logo.appendChild(rawHtml(WM_LOGO_SVG));

--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -25,9 +25,10 @@ import { PanelGateReason, hasPremiumAccess, readClientEntitlementBelief } from '
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { getEntitlementState } from '@/services/entitlements';
 import {
-  classifyPremiumDenial,
-  clientBelievesPro,
-  readDenialErrorCode,
+  classifyDenialResponse,
+  isTransientDenial,
+  routeDenial,
+  shouldSkipDoomedFetch,
   type PremiumDenialVerdict,
 } from '@/services/premium-denial';
 import { trackBriefThreadOpen } from '@/services/analytics';
@@ -87,6 +88,16 @@ const WM_LOGO_SVG: TrustedHtml = trustedHtml(
 // Upstash with 401-path checks from backgrounded tabs".
 const COMPOSING_POLL_MS = 60_000;
 
+/**
+ * Consecutive transient denials to auto-retry before giving up.
+ *
+ * Panel.showError backs off 15s, 30s, 60s, 120s, then 180s per attempt, so 8
+ * attempts is roughly 16 minutes of grace — deliberately longer than the ~15
+ * minute entitlement-cache poison window observed in #5600, so a real desync
+ * resolves itself while a permanent one still terminates.
+ */
+const MAX_TRANSIENT_DENIALS = 8;
+
 export class LatestBriefPanel extends Panel {
   private refreshing = false;
   private refreshQueued = false;
@@ -104,6 +115,12 @@ export class LatestBriefPanel extends Panel {
   private onVisibility: (() => void) | null = null;
   /** Last Clerk user-id seen. Used to detect sign-in / sign-out transitions. */
   private lastUserId: string | null = null;
+  /**
+   * Consecutive transient denials. Reset on any successful load and on every
+   * auth-id transition, so the budget is per-desync-episode rather than
+   * per-session.
+   */
+  private transientDenials = 0;
 
   constructor() {
     super({
@@ -137,6 +154,9 @@ export class LatestBriefPanel extends Panel {
       this.inflightAbort?.abort();
       this.inflightAbort = null;
       this.clearComposingPoll();
+      // New account, new retry budget — the previous user's desync says
+      // nothing about this one's entitlement.
+      this.transientDenials = 0;
       // The Clerk token cache is keyed by time, not user. On every
       // id transition we MUST drop it so the next fetch reflects
       // the new session. Without this, /api/latest-brief derives
@@ -219,7 +239,7 @@ export class LatestBriefPanel extends Panel {
     // a gate) locked legitimate Pro users out whenever the Convex
     // entitlement subscription was skipped or failed, which is a
     // worse failure mode.
-    if (getEntitlementState() !== null && !clientBelievesPro(readClientEntitlementBelief(authState))) {
+    if (shouldSkipDoomedFetch(getEntitlementState() !== null, readClientEntitlementBelief(authState))) {
       this.renderUpgradeRequired();
       return;
     }
@@ -236,8 +256,10 @@ export class LatestBriefPanel extends Panel {
       if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
       if ((getAuthState().user?.id ?? null) !== requestUserId) return;
       // We have data — retire any auto-retry countdown a previous transient
-      // denial (entitlement_desync / access_denied) left armed.
+      // denial (entitlement_desync / access_denied) left armed, and refund the
+      // retry budget so a later, unrelated desync gets its own full grace.
       this.clearErrorState();
+      this.transientDenials = 0;
       if (data.status === 'ready') {
         this.renderReady(data);
       } else {
@@ -252,21 +274,33 @@ export class LatestBriefPanel extends Panel {
       // missing session or a genuinely free plan. Transient ones fall
       // through to showError(), which retries on the panel's backoff.
       if (err instanceof BriefAccessError) {
-        if (err.code === 'sign_in_required') {
-          this.renderSignInRequired();
-          return;
+        if (isTransientDenial(err.code)) this.transientDenials += 1;
+        // routeDenial owns the truth table (see premium-denial.ts) so the
+        // transient-vs-upsell decision is unit-tested rather than asserted by
+        // a source-level regex — this branch is exactly where #5608 lived.
+        switch (routeDenial(err.code, this.transientDenials, MAX_TRANSIENT_DENIALS)) {
+          case 'sign_in':
+            this.renderSignInRequired();
+            return;
+          case 'upgrade':
+            this.renderUpgradeRequired();
+            return;
+          case 'give_up':
+            // Auto-retry has had longer than the #5600 poison window to
+            // resolve and hasn't. An endless "verifying…" spinner is its own
+            // kind of lie, and a permanently-contradicted client belief (a
+            // stale Pro role on a free account) would spin here forever.
+            this.renderDesyncExhausted();
+            return;
+          default:
+            this.showError(
+              err.code === 'entitlement_desync'
+                ? 'Verifying your Pro access — your brief will appear shortly.'
+                : 'Brief service unavailable — retrying shortly.',
+              () => { void this.refresh(); },
+            );
+            return;
         }
-        if (err.code === 'upgrade_required') {
-          this.renderUpgradeRequired();
-          return;
-        }
-        this.showError(
-          err.code === 'entitlement_desync'
-            ? 'Verifying your Pro access — your brief will appear shortly.'
-            : 'Brief service unavailable — retrying shortly.',
-          () => { void this.refresh(); },
-        );
-        return;
       }
       const message = err instanceof Error ? err.message : 'Brief unavailable — try again shortly.';
       this.showError(message, () => { void this.refresh(); });
@@ -332,15 +366,9 @@ export class LatestBriefPanel extends Panel {
     // entitlement state contradicts is a server-side desync — rendering
     // any of those as "Upgrade to Pro" tells a paying user to buy the
     // plan they already bought (#5608).
-    // Only denials get their body read here — res.json() below needs an
-    // unconsumed stream on the success path.
-    const verdict = (res.status === 401 || res.status === 403)
-      ? classifyPremiumDenial({
-        status: res.status,
-        errorCode: await readDenialErrorCode(res),
-        belief: readClientEntitlementBelief(getAuthState()),
-      })
-      : null;
+    // classifyDenialResponse reads the body ONLY on a denial status, so
+    // res.json() below still has an unconsumed stream on the success path.
+    const verdict = await classifyDenialResponse(res, readClientEntitlementBelief(getAuthState()));
     if (verdict !== null) {
       // Reading the body is awaited, so a gate-lock or account-switch abort
       // can land mid-parse — where readDenialErrorCode swallows it. Without
@@ -410,6 +438,30 @@ export class LatestBriefPanel extends Panel {
         h('div', { className: 'latest-brief-empty-title' }, 'Pro required.'),
         h('div', { className: 'latest-brief-empty-body' },
           'The WorldMonitor Brief is included with the Pro plan. Upgrade to unlock today\u2019s issue.',
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Auto-retry spent its budget and the server still denies us while the
+   * client's own entitlement state says otherwise. Deliberately NOT an upsell
+   * — we have no evidence the user needs to buy anything, which is the whole
+   * point of #5608 — and deliberately no armed retry, so the panel stops
+   * polling. Returning to the tab re-runs refresh() via visibilitychange.
+   */
+  private renderDesyncExhausted(): void {
+    this.clearErrorState();
+    clearChildren(this.content);
+    const logo = h('div', { className: 'latest-brief-logo' });
+    logo.appendChild(rawHtml(WM_LOGO_SVG));
+    this.content.appendChild(
+      h('div', { className: 'latest-brief-card latest-brief-card--composing' },
+        logo,
+        h('div', { className: 'latest-brief-empty-title' }, 'We couldn’t confirm your plan.'),
+        h('div', { className: 'latest-brief-empty-body' },
+          'Your account looks active here, but the brief service still can’t verify it. '
+          + 'Reload the page — if this keeps happening, contact support and we’ll sort it out.',
         ),
       ),
     );

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -897,6 +897,19 @@ export class Panel {
     this.retryAttempt = 0;
   }
 
+  /**
+   * Drop the error badge, the pending auto-retry countdown, and the backoff.
+   * `setContentHtml` does this implicitly, but panels that paint their content
+   * with `replaceChildren` bypass it — without this, a showError() countdown
+   * scheduled before a successful load keeps ticking and fires one redundant
+   * refresh after the panel has already recovered.
+   */
+  public clearErrorState(): void {
+    this.setErrorState(false);
+    this.clearRetryCountdown();
+    this.retryAttempt = 0;
+  }
+
   public showLocked(features: string[] = []): void {
     this._locked = true;
     this.clearRetryCountdown();

--- a/src/services/panel-gating.ts
+++ b/src/services/panel-gating.ts
@@ -2,6 +2,7 @@ import type { AuthSession } from './auth-state';
 import { getSubscription } from './billing';
 import { deriveBillingUxState, getBillingGateOverride } from './billing-state';
 import { getEntitlementState } from './entitlements';
+import type { ClientEntitlementBelief } from './premium-denial';
 import { getSecretState } from './runtime-config';
 import { isProUser } from './widget-store';
 
@@ -40,6 +41,20 @@ export function hasPremiumAccess(authState?: AuthSession): boolean {
   if (isProUser()) return true;
   if (authState?.user?.role === 'pro') return true;
   return false;
+}
+
+/**
+ * Snapshot what the CLIENT believes about this account's plan, for
+ * `classifyPremiumDenial` (#5608). Deliberately narrower than
+ * hasPremiumAccess: the desktop API key and the browser tester keys unlock
+ * panels locally but assert nothing about the signed-in Clerk account, so
+ * they must not suppress a legitimate upgrade CTA.
+ */
+export function readClientEntitlementBelief(authState: AuthSession): ClientEntitlementBelief {
+  return {
+    entitlementTier: getEntitlementState()?.features.tier ?? null,
+    authRole: authState.user?.role ?? null,
+  };
 }
 
 /**

--- a/src/services/premium-denial.ts
+++ b/src/services/premium-denial.ts
@@ -1,0 +1,151 @@
+/**
+ * What a premium endpoint's denial actually means for the UI (#5608).
+ *
+ * A 403 has more than one cause, and they need opposite treatments:
+ *
+ *   - The account really is on the free plan  → upsell. Retrying is futile.
+ *   - The server's entitlement source glitched → transient. Retrying wins,
+ *     and an upsell is actively wrong: during the #5600 entitlement-cache
+ *     poison window a user who had paid minutes earlier was told to
+ *     "Upgrade to unlock today's issue".
+ *   - The request never reached the entitlement check at all (rejected
+ *     origin, WAF) → transient, and not a statement about the plan.
+ *
+ * The discriminator for the middle case is the client's own entitlement
+ * state. It is NOT authoritative — the server always wins on whether to
+ * serve content — but a client that affirmatively believes the user is Pro
+ * while the server denies is evidence of a desync, and the honest render is
+ * "temporarily unavailable", not an upsell.
+ *
+ * Zero-import leaf so it stays unit-testable under `tsx --test`. Call sites
+ * build the belief snapshot via `readClientEntitlementBelief` in
+ * `panel-gating.ts`.
+ */
+
+/** Minimum entitlement tier that counts as Pro (mirrors api/latest-brief.ts). */
+export const PRO_TIER = 1;
+
+export type PremiumDenialVerdict =
+  /** 401 — the session is gone. Re-auth, don't retry. */
+  | 'sign_in_required'
+  /** 403 entitlement denial the client agrees with. Terminal; show the upsell. */
+  | 'upgrade_required'
+  /** 403 entitlement denial the client's own state contradicts. Transient; retry. */
+  | 'entitlement_desync'
+  /** 403 that never reached the entitlement check (origin/WAF). Transient; retry. */
+  | 'access_denied';
+
+/**
+ * Snapshot of what the CLIENT believes about the user's plan, independent of
+ * the server's answer.
+ */
+export interface ClientEntitlementBelief {
+  /** `features.tier` from the Convex entitlement snapshot; null when none has arrived. */
+  entitlementTier: number | null;
+  /** `role` on the Clerk session; null when signed out or unset. */
+  authRole: string | null;
+}
+
+export interface PremiumDenialInput {
+  status: number;
+  /** The `error` field of the response body, when it parsed as a string. */
+  errorCode: string | null;
+  belief: ClientEntitlementBelief;
+}
+
+/**
+ * Lowercase and collapse `_`/`-` to spaces so the several spellings the
+ * backends use (`pro_required`, `Pro subscription required`, `INSUFFICIENT_TIER`)
+ * compare as one vocabulary.
+ */
+function normalizeCode(code: string): string {
+  return code.trim().toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ');
+}
+
+/**
+ * Codes that are a genuine "this account is not on the required plan" verdict,
+ * as opposed to a 403 raised before entitlement was ever consulted.
+ *
+ *   api/latest-brief.ts:201                 → pro_required
+ *   api/chat-analyst.ts:126                 → Pro subscription required
+ *   server/_shared/entitlement-check.ts:556 → Upgrade required
+ *   server/_shared/entitlement-check.ts:446 → Subscription lapsed
+ *   api/internal/mcp-grant-*.ts             → INSUFFICIENT_TIER
+ *
+ * Deliberately excludes `Unable to verify entitlements`
+ * (entitlement-check.ts:527): that 403 is a fail-closed lookup error, so it
+ * states nothing about the plan and must never produce an upsell.
+ */
+const ENTITLEMENT_DENIAL_CODES = new Set([
+  'pro required',
+  'pro subscription required',
+  'upgrade required',
+  'plan required',
+  'subscription lapsed',
+  'insufficient tier',
+]);
+
+/**
+ * Codes that mean "we could not identify you", which the shared gateway
+ * serves as a 403 rather than a 401 (entitlement-check.ts:508). The fix is a
+ * session, not a purchase.
+ */
+const AUTHENTICATION_CODES = new Set([
+  'authentication required',
+  'unauthenticated',
+  'sign in required',
+]);
+
+/**
+ * Does the client affirmatively believe this user is Pro?
+ *
+ * Deliberately excludes the desktop `WORLDMONITOR_API_KEY` and the browser
+ * tester keys that `hasPremiumAccess` also honours: those unlock panels
+ * locally but say nothing about the signed-in Clerk account's plan, so an
+ * API-key user with a free account should still get the upsell.
+ */
+export function clientBelievesPro(belief: ClientEntitlementBelief): boolean {
+  if (belief.entitlementTier !== null && belief.entitlementTier >= PRO_TIER) return true;
+  return belief.authRole === 'pro';
+}
+
+/**
+ * Classify a premium endpoint's response. Returns null for any status that is
+ * not an access denial — the caller keeps its own handling for those.
+ */
+export function classifyPremiumDenial(input: PremiumDenialInput): PremiumDenialVerdict | null {
+  if (input.status === 401) return 'sign_in_required';
+  if (input.status !== 403) return null;
+  if (input.errorCode !== null) {
+    const code = normalizeCode(input.errorCode);
+    if (AUTHENTICATION_CODES.has(code)) return 'sign_in_required';
+    // An unrecognised code means the request was rejected before the plan was
+    // ever consulted (origin, WAF, failed entitlement lookup). Never an
+    // upsell, whatever the client believes.
+    if (!ENTITLEMENT_DENIAL_CODES.has(code)) return 'access_denied';
+  }
+  return clientBelievesPro(input.belief) ? 'entitlement_desync' : 'upgrade_required';
+}
+
+/** Whether the verdict is worth retrying. Terminal verdicts need user action. */
+export function isTransientDenial(verdict: PremiumDenialVerdict | null): boolean {
+  return verdict === 'entitlement_desync' || verdict === 'access_denied';
+}
+
+/**
+ * Pull the `error` string out of a denial response body for `errorCode`.
+ * Every failure mode (non-JSON body, already-consumed stream, missing or
+ * non-string field) collapses to null, which `classifyPremiumDenial` treats
+ * as an unlabelled entitlement verdict.
+ *
+ * Consumes the body — only call it on a response you are not going to read
+ * again.
+ */
+export async function readDenialErrorCode(res: Response): Promise<string | null> {
+  try {
+    const body = (await res.json()) as { error?: unknown } | null;
+    return typeof body?.error === 'string' ? body.error : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/services/premium-denial.ts
+++ b/src/services/premium-denial.ts
@@ -69,21 +69,37 @@ function normalizeCode(code: string): string {
  *   api/latest-brief.ts:201                 → pro_required
  *   api/chat-analyst.ts:126                 → Pro subscription required
  *   server/_shared/entitlement-check.ts:556 → Upgrade required
- *   server/_shared/entitlement-check.ts:446 → Subscription lapsed
  *   api/internal/mcp-grant-*.ts             → INSUFFICIENT_TIER
  *
  * Deliberately excludes `Unable to verify entitlements`
  * (entitlement-check.ts:527): that 403 is a fail-closed lookup error, so it
  * states nothing about the plan and must never produce an upsell.
+ * `Subscription lapsed` is excluded too — see BILLING_TERMINAL_CODES below.
+ *
+ * The vocabulary is pinned against the real server sources by a contract test
+ * in tests/premium-denial.test.mts, so a backend rename fails CI instead of
+ * silently rerouting a denial.
  */
 const ENTITLEMENT_DENIAL_CODES = new Set([
   'pro required',
   'pro subscription required',
   'upgrade required',
-  'plan required',
-  'subscription lapsed',
   'insufficient tier',
 ]);
+
+/**
+ * Billing verdicts the client has no standing to contradict.
+ *
+ * `Subscription lapsed` (entitlement-check.ts:446) comes from
+ * `entitlements.billingStatus` — the payment provider confirmed coverage
+ * ended. That is a different question from the tier check, and it is not the
+ * cache-poisonable path. The client cannot disagree with it either way:
+ * `EntitlementState` carries planKey/features/validUntil and no billingStatus,
+ * so `clientBelievesPro` would still say "Pro" from a row whose validUntil has
+ * not yet passed. Routing it through the desync branch would retry a lapsed
+ * subscriber forever instead of giving them a way back.
+ */
+const BILLING_TERMINAL_CODES = new Set(['subscription lapsed']);
 
 /**
  * Codes that mean "we could not identify you", which the shared gateway
@@ -116,15 +132,37 @@ export function clientBelievesPro(belief: ClientEntitlementBelief): boolean {
 export function classifyPremiumDenial(input: PremiumDenialInput): PremiumDenialVerdict | null {
   if (input.status === 401) return 'sign_in_required';
   if (input.status !== 403) return null;
-  if (input.errorCode !== null) {
-    const code = normalizeCode(input.errorCode);
-    if (AUTHENTICATION_CODES.has(code)) return 'sign_in_required';
-    // An unrecognised code means the request was rejected before the plan was
-    // ever consulted (origin, WAF, failed entitlement lookup). Never an
-    // upsell, whatever the client believes.
-    if (!ENTITLEMENT_DENIAL_CODES.has(code)) return 'access_denied';
-  }
+  // Every entitlement 403 our handlers emit carries a JSON `error` string, so
+  // a 403 without a parseable code did not come from our entitlement logic at
+  // all — it is an intermediary (WAF, CDN, proxy). Same for an unrecognised
+  // code (rejected origin, fail-closed lookup). Neither is a statement about
+  // the plan, so neither may produce an upsell, whatever the client believes.
+  if (input.errorCode === null) return 'access_denied';
+  const code = normalizeCode(input.errorCode);
+  if (AUTHENTICATION_CODES.has(code)) return 'sign_in_required';
+  if (BILLING_TERMINAL_CODES.has(code)) return 'upgrade_required';
+  if (!ENTITLEMENT_DENIAL_CODES.has(code)) return 'access_denied';
   return clientBelievesPro(input.belief) ? 'entitlement_desync' : 'upgrade_required';
+}
+
+/**
+ * Should the client skip a fetch it believes is doomed and render the upgrade
+ * CTA directly?
+ *
+ * Only when a snapshot has ARRIVED and nothing contradicts it. A snapshot that
+ * says free while the Clerk session claims the Pro role is a contradiction, not
+ * knowledge — let the server break the tie rather than painting an upsell over
+ * it (#5608). With no snapshot at all the client has no opinion, so it must not
+ * pre-empt the server either.
+ *
+ * Kept here, as a pure predicate over the two inputs, so the boolean
+ * composition is directly testable — a source-level guard cannot verify it.
+ */
+export function shouldSkipDoomedFetch(
+  hasEntitlementSnapshot: boolean,
+  belief: ClientEntitlementBelief,
+): boolean {
+  return hasEntitlementSnapshot && !clientBelievesPro(belief);
 }
 
 /** Whether the verdict is worth retrying. Terminal verdicts need user action. */
@@ -132,11 +170,43 @@ export function isTransientDenial(verdict: PremiumDenialVerdict | null): boolean
   return verdict === 'entitlement_desync' || verdict === 'access_denied';
 }
 
+/** What a panel should actually render for a denial. */
+export type DenialAction =
+  /** Terminal: the session is gone. */
+  | 'sign_in'
+  /** Terminal: the plan really is insufficient. The only honest upsell. */
+  | 'upgrade'
+  /** Transient: show the unavailable state and retry. */
+  | 'retry'
+  /** Transient budget spent: terminal, but NOT an upsell — we have no evidence
+   *  the user needs to buy anything. */
+  | 'give_up';
+
+/**
+ * Route a denial verdict to the render a panel should perform.
+ *
+ * Extracted as a pure function on purpose. This routing is the exact place the
+ * #5608 bug lived — sending a transient verdict to the upsell — and a
+ * source-level guard cannot prove a branch body is correct, only that certain
+ * identifiers appear near each other. Keeping the truth table here makes it
+ * executable, so a mutation that re-points the transient branch at the upsell
+ * fails a real assertion instead of slipping past a regex.
+ */
+export function routeDenial(
+  verdict: PremiumDenialVerdict,
+  consecutiveTransientDenials: number,
+  maxTransientDenials: number,
+): DenialAction {
+  if (verdict === 'sign_in_required') return 'sign_in';
+  if (verdict === 'upgrade_required') return 'upgrade';
+  return consecutiveTransientDenials > maxTransientDenials ? 'give_up' : 'retry';
+}
+
 /**
  * Pull the `error` string out of a denial response body for `errorCode`.
  * Every failure mode (non-JSON body, already-consumed stream, missing or
- * non-string field) collapses to null, which `classifyPremiumDenial` treats
- * as an unlabelled entitlement verdict.
+ * non-string field) collapses to null, which `classifyPremiumDenial` reads as
+ * "not one of ours" — an intermediary's 403, never an upsell.
  *
  * Consumes the body — only call it on a response you are not going to read
  * again.
@@ -148,4 +218,25 @@ export async function readDenialErrorCode(res: Response): Promise<string | null>
   } catch {
     return null;
   }
+}
+
+/**
+ * Classify a response end to end: gate on the denial statuses, read the body
+ * only for those, and return the verdict. Returns null for anything that is
+ * not an access denial, so callers keep their own handling for those.
+ *
+ * The status gate is what keeps this safe to call on every response: the body
+ * is consumed ONLY on a 401/403, leaving the stream intact for the success
+ * path (a JSON payload in LatestBriefPanel, an SSE stream in ChatAnalystPanel).
+ */
+export async function classifyDenialResponse(
+  res: Response,
+  belief: ClientEntitlementBelief,
+): Promise<PremiumDenialVerdict | null> {
+  if (res.status !== 401 && res.status !== 403) return null;
+  return classifyPremiumDenial({
+    status: res.status,
+    errorCode: await readDenialErrorCode(res),
+    belief,
+  });
 }

--- a/tests/helpers/chat-analyst-panel-harness.mjs
+++ b/tests/helpers/chat-analyst-panel-harness.mjs
@@ -75,6 +75,17 @@ async function loadChatAnalystPanel() {
         ANONYMOUS: 'anonymous',
         FREE_TIER: 'free_tier',
       });
+      // No entitlement snapshot and no role claim — the panel's denial
+      // classifier then treats a 403 as an honest upsell. Tests that care
+      // about the desync branch drive classifyPremiumDenial directly
+      // (tests/premium-denial.test.mts); @/services/premium-denial is a pure
+      // leaf and is bundled for real here rather than stubbed.
+      export function readClientEntitlementBelief() {
+        return { entitlementTier: null, authRole: null };
+      }
+    `],
+    ['auth-state-stub', `
+      export function getAuthState() { return { user: null }; }
     `],
     ['premium-fetch-stub', `
       export function premiumFetch() { return Promise.reject(new Error('not wired in test')); }
@@ -107,6 +118,7 @@ async function loadChatAnalystPanel() {
     ['@/services/ai-flow-settings', 'ai-flow-settings-stub'],
     ['@/services/runtime-config', 'runtime-config-stub'],
     ['@/services/panel-gating', 'panel-gating-stub'],
+    ['@/services/auth-state', 'auth-state-stub'],
     ['@/services/premium-fetch', 'premium-fetch-stub'],
     ['@/utils/analyst-markdown', 'analyst-markdown-stub'],
     ['@/services/checkout', 'checkout-stub'],

--- a/tests/premium-denial.test.mts
+++ b/tests/premium-denial.test.mts
@@ -19,10 +19,13 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  classifyDenialResponse,
   classifyPremiumDenial,
   clientBelievesPro,
   isTransientDenial,
   readDenialErrorCode,
+  routeDenial,
+  shouldSkipDoomedFetch,
   PRO_TIER,
   type ClientEntitlementBelief,
 } from '@/services/premium-denial';
@@ -129,15 +132,21 @@ describe('classifyPremiumDenial — 403 entitlement denials', () => {
     );
   });
 
-  it('a bare 403 with no error code is still treated as an entitlement verdict', () => {
-    assert.equal(
-      classifyPremiumDenial({ status: 403, errorCode: null, belief: FREE }),
-      'upgrade_required',
-    );
-    assert.equal(
-      classifyPremiumDenial({ status: 403, errorCode: null, belief: PRO }),
-      'entitlement_desync',
-    );
+  /**
+   * Every entitlement 403 our own handlers emit carries a JSON `error` string
+   * (api/latest-brief.ts:199-207, api/chat-analyst.ts:126, and every branch of
+   * entitlement-check.ts). So a 403 with no parseable code did NOT come from
+   * our entitlement logic — it is an intermediary (WAF, CDN, proxy). Calling
+   * that "Pro required" is the exact conflation this change exists to remove.
+   */
+  it('a 403 with no parseable error code is infrastructure, not an entitlement verdict', () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: null, belief }),
+        'access_denied',
+        'a bodyless/unlabelled 403 must never be rendered as a missing plan',
+      );
+    }
   });
 
   /**
@@ -155,8 +164,6 @@ describe('classifyPremiumDenial — 403 entitlement denials', () => {
       'Pro subscription required',
       'upgrade_required',
       'Upgrade required',
-      'plan_required',
-      'Subscription lapsed',
       'INSUFFICIENT_TIER',
       'PRO_REQUIRED',
     ]) {
@@ -180,6 +187,34 @@ describe('classifyPremiumDenial — 403 entitlement denials', () => {
         'upgrade_required',
       );
     }
+  });
+});
+
+describe('classifyPremiumDenial — billing verdicts the client cannot contradict', () => {
+  /**
+   * `Subscription lapsed` (server/_shared/entitlement-check.ts:446) comes from
+   * `entitlements.billingStatus` — the provider confirmed coverage ended. It is
+   * NOT the cache-poisonable tier check, and the client literally cannot
+   * disagree with it: `EntitlementState` (src/services/entitlements.ts) carries
+   * planKey/features/validUntil and no billingStatus. Treating it as a desync
+   * would retry a lapsed subscriber forever behind "Verifying your Pro access"
+   * instead of giving them a way back.
+   */
+  it('Subscription lapsed stays terminal even when the client believes it is Pro', () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: 'Subscription lapsed', belief }),
+        'upgrade_required',
+        'a provider-confirmed lapse must never become an infinite retry',
+      );
+    }
+  });
+
+  it('normalises the lapsed code the same way as the rest', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'subscription_lapsed', belief: PRO }),
+      'upgrade_required',
+    );
   });
 });
 
@@ -285,10 +320,11 @@ describe('readDenialErrorCode', () => {
     assert.equal(await readDenialErrorCode(res), null);
   });
 
-  it('null → an unlabelled 403 still classifies, so the two compose', async () => {
+  it('null composes into access_denied — an unreadable 403 is never an upsell', async () => {
     const code = await readDenialErrorCode(new Response('not json', { status: 403 }));
-    assert.equal(classifyPremiumDenial({ status: 403, errorCode: code, belief: PRO }), 'entitlement_desync');
-    assert.equal(classifyPremiumDenial({ status: 403, errorCode: code, belief: FREE }), 'upgrade_required');
+    assert.equal(code, null);
+    assert.equal(classifyPremiumDenial({ status: 403, errorCode: code, belief: PRO }), 'access_denied');
+    assert.equal(classifyPremiumDenial({ status: 403, errorCode: code, belief: FREE }), 'access_denied');
   });
 });
 
@@ -329,8 +365,8 @@ const WIRED_PANELS = [
 
 describe('premium panels route their denials through the classifier', () => {
   for (const rel of WIRED_PANELS) {
-    it(`${rel} calls classifyPremiumDenial`, () => {
-      assert.match(readSource(rel), /classifyPremiumDenial\(/);
+    it(`${rel} classifies denials through the shared helper`, () => {
+      assert.match(readSource(rel), /classifyDenialResponse\(/);
     });
 
     /**
@@ -355,16 +391,30 @@ describe('premium panels route their denials through the classifier', () => {
     });
   }
 
-  it('LatestBriefPanel renders the upgrade CTA only for the upgrade_required verdict', () => {
+  /**
+   * The routing itself is proven by the executable `routeDenial` truth table
+   * below, not by grepping this file — an earlier proximity-regex version of
+   * this guard was shown to stay green with the #5608 bug restored verbatim,
+   * because a neighbouring branch supplied the token it searched for.
+   *
+   * What IS worth pinning in source: the panel must route through routeDenial
+   * rather than re-deriving the decision inline, and there must be exactly the
+   * expected number of upsell call sites — a third one is the mutation that
+   * reintroduces the bug.
+   */
+  it('LatestBriefPanel routes its denials through routeDenial', () => {
+    assert.match(readSource('src/components/LatestBriefPanel.ts'), /routeDenial\(/);
+  });
+
+  it('LatestBriefPanel has exactly two renderUpgradeRequired call sites', () => {
     const source = readSource('src/components/LatestBriefPanel.ts');
-    for (const call of [...source.matchAll(/this\.renderUpgradeRequired\(\)/g)]) {
-      const preceding = source.slice(Math.max(0, call.index - 400), call.index);
-      assert.ok(
-        /upgrade_required|clientBelievesPro/.test(preceding),
-        'every renderUpgradeRequired() call must be guarded by an explicit '
-        + 'upgrade_required verdict or a client-belief check, never a raw 403',
-      );
-    }
+    const calls = [...source.matchAll(/this\.renderUpgradeRequired\(\)/g)];
+    assert.equal(
+      calls.length,
+      2,
+      'expected exactly two upsell call sites — the pre-fetch affirmative-denial '
+      + "gate and routeDenial's 'upgrade' case. A third is how #5608 comes back.",
+    );
   });
 
   it("ChatAnalystPanel no longer hardcodes the upsell as its only 403 copy", () => {
@@ -377,5 +427,263 @@ describe('premium panels route their denials through the classifier', () => {
       /case 'upgrade_required':/,
       'the upsell string must sit under the upgrade_required case',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server-vocabulary contract
+// ---------------------------------------------------------------------------
+
+/**
+ * The classifier matches on error strings the backends emit, which is an
+ * implicit unversioned contract: a server-side rename silently reroutes a
+ * denial (an upsell becomes an infinite retry, or vice versa) with nothing
+ * failing. Parse the real server sources and assert every 401/403 string they
+ * emit is one the classifier deliberately accounts for.
+ *
+ * A new server denial string fails this test. Fix it by classifying the string
+ * — add it to ENTITLEMENT_DENIAL_CODES / AUTHENTICATION_CODES in
+ * src/services/premium-denial.ts, or to KNOWN_NON_ENTITLEMENT_CODES below if it
+ * is genuinely not a statement about the user's plan.
+ */
+const DENIAL_SOURCES = [
+  'api/latest-brief.ts',
+  'api/chat-analyst.ts',
+  'server/_shared/entitlement-check.ts',
+];
+
+/**
+ * 403/401 strings that are deliberately NOT entitlement verdicts, so the
+ * classifier routes them to access_denied / sign_in_required rather than an
+ * upsell. Each must stay non-upselling.
+ */
+const KNOWN_NON_ENTITLEMENT_CODES = new Set([
+  'Origin not allowed',            // api/latest-brief.ts — rejected origin
+  'Unable to verify entitlements', // entitlement-check.ts — fail-closed lookup
+  'Unable to verify API access',   // entitlement-check.ts — 503 verification path
+  'UNAUTHENTICATED',               // api/latest-brief.ts — 401
+  'Authentication required',       // entitlement-check.ts — 403-shaped 401
+]);
+
+/**
+ * Pull every `error: '<literal>'` whose OWN response carries a 401/403.
+ *
+ * Pairing matters: a proximity window would attribute the 401 a few lines
+ * below `{ error: 'Method not allowed' }, 405` to that 405, so scan forward to
+ * the FIRST status literal after the error string and use only that one.
+ */
+function extractDenialStrings(source: string): string[] {
+  const found = new Set<string>();
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const match = /error:\s*'([^']+)'/.exec(lines[i]);
+    if (!match) continue;
+    const ahead = lines.slice(i, i + 10).join('\n').slice(match.index);
+    // Status appears either as a positional arg (`}, 403,`) or a property
+    // (`status: 403`). Take the first one — it belongs to this response.
+    const status = /(?:,\s*|status:\s*)(\d{3})\b/.exec(ahead);
+    if (status && (status[1] === '401' || status[1] === '403')) found.add(match[1]);
+  }
+  return [...found];
+}
+
+describe('classifier vocabulary matches what the servers actually emit', () => {
+  for (const rel of DENIAL_SOURCES) {
+    it(`every 401/403 error string in ${rel} is accounted for`, () => {
+      const strings = extractDenialStrings(readSource(rel));
+      assert.ok(strings.length > 0, `${rel} should emit at least one denial string`);
+      for (const code of strings) {
+        if (KNOWN_NON_ENTITLEMENT_CODES.has(code)) {
+          // Must NOT upsell — not even a client with no entitlement opinion.
+          assert.notEqual(
+            classifyPremiumDenial({ status: 403, errorCode: code, belief: UNKNOWN }),
+            'upgrade_required',
+            `${rel}: '${code}' is not an entitlement verdict and must never upsell`,
+          );
+          continue;
+        }
+        // Everything else must be a recognised entitlement verdict: it upsells
+        // a client that agrees it is free, and never upsells one that believes
+        // it is Pro (unless it is a terminal billing verdict).
+        const asFree = classifyPremiumDenial({ status: 403, errorCode: code, belief: FREE });
+        assert.equal(
+          asFree,
+          'upgrade_required',
+          `${rel}: '${code}' is unclassified — it would silently route to access_denied `
+          + 'and retry forever instead of showing the upgrade CTA. Add it to '
+          + 'ENTITLEMENT_DENIAL_CODES or KNOWN_NON_ENTITLEMENT_CODES.',
+        );
+      }
+    });
+  }
+
+  it('pro_required and Pro subscription required are the live blast radius', () => {
+    // The two panels wired today only call /api/latest-brief and
+    // /api/chat-analyst; the gateway strings are forward-looking coverage.
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'pro_required', belief: PRO }),
+      'entitlement_desync',
+    );
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'Pro subscription required', belief: PRO }),
+      'entitlement_desync',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeDenial — the executable truth table that replaces the regex guard
+// ---------------------------------------------------------------------------
+
+/**
+ * This is the decision #5608 got wrong: a transient verdict routed to the
+ * upsell. An earlier source-regex guard was demonstrated to pass with the bug
+ * fully restored, so the contract lives here, where it is actually executed.
+ */
+describe('routeDenial', () => {
+  const MAX = 8;
+
+  it('sign_in_required is terminal sign-in, at any streak', () => {
+    for (const streak of [0, 1, MAX, MAX + 100]) {
+      assert.equal(routeDenial('sign_in_required', streak, MAX), 'sign_in');
+    }
+  });
+
+  it('upgrade_required is the upsell, at any streak', () => {
+    for (const streak of [0, 1, MAX, MAX + 100]) {
+      assert.equal(routeDenial('upgrade_required', streak, MAX), 'upgrade');
+    }
+  });
+
+  it('#5608: a transient verdict NEVER routes to the upsell', () => {
+    for (const verdict of ['entitlement_desync', 'access_denied'] as const) {
+      for (const streak of [0, 1, MAX, MAX + 1, MAX + 100]) {
+        assert.notEqual(
+          routeDenial(verdict, streak, MAX),
+          'upgrade',
+          `${verdict} at streak ${streak} must never become an upsell`,
+        );
+      }
+    }
+  });
+
+  it('transient verdicts retry while the budget lasts', () => {
+    for (const verdict of ['entitlement_desync', 'access_denied'] as const) {
+      for (let streak = 0; streak <= MAX; streak++) {
+        assert.equal(routeDenial(verdict, streak, MAX), 'retry', `streak ${streak} still retries`);
+      }
+    }
+  });
+
+  it('the loop terminates once the budget is spent', () => {
+    for (const verdict of ['entitlement_desync', 'access_denied'] as const) {
+      assert.equal(routeDenial(verdict, MAX + 1, MAX), 'give_up');
+      assert.equal(routeDenial(verdict, MAX + 50, MAX), 'give_up');
+    }
+  });
+
+  it('give_up is terminal but is not an upsell', () => {
+    // The whole point: exhausting retries means we could not verify, which is
+    // not evidence the user needs to buy anything.
+    assert.equal(routeDenial('entitlement_desync', MAX + 1, MAX), 'give_up');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldSkipDoomedFetch — the pre-fetch gate's boolean composition
+// ---------------------------------------------------------------------------
+
+describe('shouldSkipDoomedFetch', () => {
+  it('no snapshot yet → never pre-empt the server', () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(shouldSkipDoomedFetch(false, belief), false);
+    }
+  });
+
+  it('snapshot says free and nothing contradicts it → skip the doomed fetch', () => {
+    assert.equal(shouldSkipDoomedFetch(true, FREE), true);
+    assert.equal(shouldSkipDoomedFetch(true, UNKNOWN), true);
+  });
+
+  it('#5608: snapshot says Pro → fetch, never pre-render the upsell', () => {
+    assert.equal(shouldSkipDoomedFetch(true, PRO), false);
+  });
+
+  it('#5608: a free snapshot contradicted by a Clerk Pro role → let the server decide', () => {
+    assert.equal(shouldSkipDoomedFetch(true, { entitlementTier: 0, authRole: 'pro' }), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyDenialResponse — the real glue, against real Response objects
+// ---------------------------------------------------------------------------
+
+/**
+ * Both panels call this instead of reimplementing the status gate + body read.
+ * Driving it with genuine Response objects covers the seam the source-level
+ * guards cannot reach (wrong field, missing await, wrong status gate).
+ */
+describe('classifyDenialResponse', () => {
+  const denial = (body: unknown, status: number) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  it('leaves a success body unconsumed so the caller can still read it', async () => {
+    const res = denial({ status: 'ready', issueDate: '2026-07-25' }, 200);
+    assert.equal(await classifyDenialResponse(res, PRO), null);
+    assert.equal(res.bodyUsed, false, 'the success stream must survive classification');
+    assert.deepEqual(await res.json(), { status: 'ready', issueDate: '2026-07-25' });
+  });
+
+  it('leaves a 500 body unconsumed too — only denials are read', async () => {
+    const res = denial({ error: 'boom' }, 500);
+    assert.equal(await classifyDenialResponse(res, PRO), null);
+    assert.equal(res.bodyUsed, false);
+  });
+
+  it("#5608: the real api/latest-brief 403 body + a Pro client → desync, not upsell", async () => {
+    const res = denial({
+      error: 'pro_required',
+      message: 'The Brief is available on the Pro plan.',
+      upgradeUrl: 'https://worldmonitor.app/pro',
+    }, 403);
+    assert.equal(await classifyDenialResponse(res, PRO), 'entitlement_desync');
+  });
+
+  it('the same body with a free client → the honest upsell', async () => {
+    const res = denial({ error: 'pro_required' }, 403);
+    assert.equal(await classifyDenialResponse(res, FREE), 'upgrade_required');
+  });
+
+  it("api/chat-analyst's 403 body classifies the same way", async () => {
+    assert.equal(
+      await classifyDenialResponse(denial({ error: 'Pro subscription required' }, 403), PRO),
+      'entitlement_desync',
+    );
+    assert.equal(
+      await classifyDenialResponse(denial({ error: 'Pro subscription required' }, 403), FREE),
+      'upgrade_required',
+    );
+  });
+
+  it("a rejected origin is never an upsell", async () => {
+    assert.equal(
+      await classifyDenialResponse(denial({ error: 'Origin not allowed' }, 403), FREE),
+      'access_denied',
+    );
+  });
+
+  it('a 401 is sign_in_required', async () => {
+    assert.equal(
+      await classifyDenialResponse(denial({ error: 'UNAUTHENTICATED' }, 401), PRO),
+      'sign_in_required',
+    );
+  });
+
+  it('a non-JSON WAF 403 page is access_denied, not an upsell', async () => {
+    const res = new Response('<html><body>403 Forbidden</body></html>', { status: 403 });
+    assert.equal(await classifyDenialResponse(res, FREE), 'access_denied');
   });
 });

--- a/tests/premium-denial.test.mts
+++ b/tests/premium-denial.test.mts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for the pure premium-denial classifier (#5608).
+ *
+ * The module under test is a zero-import leaf, so it stays importable under
+ * `tsx --test` (no jsdom, no Vite globals) — same pattern as
+ * tests/billing-state.test.mts and tests/pro-activation-state.test.mts.
+ *
+ * The bug: a 403 from a premium endpoint was rendered as "Pro required —
+ * upgrade" unconditionally, so a user who had paid minutes earlier saw an
+ * upsell during the #5600 entitlement-cache poison window. A 403 the client's
+ * own entitlement state disagrees with is a server-side desync, not a missing
+ * plan, and `/api/latest-brief` additionally returns 403 for a rejected origin
+ * — which is not an entitlement verdict at all.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  classifyPremiumDenial,
+  clientBelievesPro,
+  isTransientDenial,
+  readDenialErrorCode,
+  PRO_TIER,
+  type ClientEntitlementBelief,
+} from '@/services/premium-denial';
+
+/** No entitlement snapshot has arrived and the session carries no Pro role. */
+const UNKNOWN: ClientEntitlementBelief = { entitlementTier: null, authRole: null };
+/** Convex snapshot arrived and says free. */
+const FREE: ClientEntitlementBelief = { entitlementTier: 0, authRole: null };
+/** Convex snapshot arrived and says Pro — the #5608 case. */
+const PRO: ClientEntitlementBelief = { entitlementTier: PRO_TIER, authRole: null };
+/** No snapshot, but the Clerk session claims the Pro role. */
+const CLERK_PRO: ClientEntitlementBelief = { entitlementTier: null, authRole: 'pro' };
+
+describe('clientBelievesPro', () => {
+  it('no snapshot and no role claim → no affirmative Pro belief', () => {
+    assert.equal(clientBelievesPro(UNKNOWN), false);
+  });
+
+  it('snapshot says free → no affirmative Pro belief', () => {
+    assert.equal(clientBelievesPro(FREE), false);
+  });
+
+  it('snapshot at or above the Pro tier → affirmative Pro belief', () => {
+    assert.equal(clientBelievesPro(PRO), true);
+    assert.equal(clientBelievesPro({ entitlementTier: PRO_TIER + 5, authRole: null }), true);
+  });
+
+  it('Clerk role claim alone is an affirmative Pro belief', () => {
+    assert.equal(clientBelievesPro(CLERK_PRO), true);
+  });
+
+  it('a free snapshot does not veto a Pro role claim (either signal suffices)', () => {
+    assert.equal(clientBelievesPro({ entitlementTier: 0, authRole: 'pro' }), true);
+  });
+
+  it('non-pro role strings are not a Pro belief', () => {
+    assert.equal(clientBelievesPro({ entitlementTier: null, authRole: 'free' }), false);
+    assert.equal(clientBelievesPro({ entitlementTier: null, authRole: 'admin' }), false);
+    assert.equal(clientBelievesPro({ entitlementTier: null, authRole: 'PRO' }), false);
+  });
+
+  it('a negative or fractional tier below PRO_TIER is not a Pro belief', () => {
+    assert.equal(clientBelievesPro({ entitlementTier: -1, authRole: null }), false);
+    assert.equal(clientBelievesPro({ entitlementTier: 0.5, authRole: null }), false);
+  });
+});
+
+describe('classifyPremiumDenial — non-denial statuses', () => {
+  it('returns null for success and for server errors the caller retries anyway', () => {
+    for (const status of [200, 204, 400, 404, 429, 500, 502, 503]) {
+      assert.equal(
+        classifyPremiumDenial({ status, errorCode: null, belief: PRO }),
+        null,
+        `status ${status} is not a denial the classifier owns`,
+      );
+    }
+  });
+});
+
+describe('classifyPremiumDenial — 401', () => {
+  it('is always sign_in_required, whatever the client believes', () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 401, errorCode: 'UNAUTHENTICATED', belief }),
+        'sign_in_required',
+      );
+    }
+  });
+
+  it('does not need an error code', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 401, errorCode: null, belief: PRO }),
+      'sign_in_required',
+    );
+  });
+});
+
+describe('classifyPremiumDenial — 403 entitlement denials', () => {
+  it('client agrees it is free → upgrade_required (the honest upsell)', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'pro_required', belief: FREE }),
+      'upgrade_required',
+    );
+  });
+
+  it('client has no opinion yet → upgrade_required (server is authoritative)', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'pro_required', belief: UNKNOWN }),
+      'upgrade_required',
+    );
+  });
+
+  it('#5608: client entitlement snapshot says Pro → entitlement_desync, never an upsell', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'pro_required', belief: PRO }),
+      'entitlement_desync',
+    );
+  });
+
+  it('#5608: Clerk Pro role claim also blocks the upsell', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'pro_required', belief: CLERK_PRO }),
+      'entitlement_desync',
+    );
+  });
+
+  it('a bare 403 with no error code is still treated as an entitlement verdict', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: null, belief: FREE }),
+      'upgrade_required',
+    );
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: null, belief: PRO }),
+      'entitlement_desync',
+    );
+  });
+
+  /**
+   * Every string a 403 actually carries today. Drift here silently turns an
+   * upsell into a retry loop (or back again), so they are pinned explicitly:
+   *   api/latest-brief.ts:201                  → 'pro_required'
+   *   api/chat-analyst.ts:126                  → 'Pro subscription required'
+   *   server/_shared/entitlement-check.ts:556  → 'Upgrade required'
+   *   server/_shared/entitlement-check.ts:446  → 'Subscription lapsed'
+   *   api/internal/mcp-grant-*.ts              → 'INSUFFICIENT_TIER'
+   */
+  it('recognises every entitlement code the REST, RPC and MCP surfaces emit', () => {
+    for (const code of [
+      'pro_required',
+      'Pro subscription required',
+      'upgrade_required',
+      'Upgrade required',
+      'plan_required',
+      'Subscription lapsed',
+      'INSUFFICIENT_TIER',
+      'PRO_REQUIRED',
+    ]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: code, belief: FREE }),
+        'upgrade_required',
+        `${code} is an entitlement denial`,
+      );
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: code, belief: PRO }),
+        'entitlement_desync',
+        `${code} must not upsell a client that believes it is Pro`,
+      );
+    }
+  });
+
+  it('normalises separators and case so pro_required and "Pro required" agree', () => {
+    for (const code of ['pro_required', 'PRO-REQUIRED', 'Pro required', '  pro_required  ']) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: code, belief: FREE }),
+        'upgrade_required',
+      );
+    }
+  });
+});
+
+describe('classifyPremiumDenial — 403 that means "authenticate", not "upgrade"', () => {
+  /**
+   * The shared gateway 403s (not 401s) an unauthenticated caller —
+   * server/_shared/entitlement-check.ts:508. Rendering that as an upsell
+   * tells a signed-out user to buy a plan they may already own.
+   */
+  it("gateway 'Authentication required' is sign_in_required", () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: 'Authentication required', belief }),
+        'sign_in_required',
+      );
+    }
+  });
+
+  it("'UNAUTHENTICATED' on a 403 is also sign_in_required", () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'UNAUTHENTICATED', belief: FREE }),
+      'sign_in_required',
+    );
+  });
+});
+
+describe('classifyPremiumDenial — 403 that is not about entitlement', () => {
+  it("api/latest-brief's 'Origin not allowed' is access_denied, not an upsell", () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: 'Origin not allowed', belief }),
+        'access_denied',
+        'a rejected origin must never be rendered as a missing plan',
+      );
+    }
+  });
+
+  it('an unrecognised 403 code is access_denied even for a free client', () => {
+    assert.equal(
+      classifyPremiumDenial({ status: 403, errorCode: 'forbidden_by_waf', belief: FREE }),
+      'access_denied',
+    );
+  });
+
+  /**
+   * server/_shared/entitlement-check.ts:527 fails CLOSED when Redis and Convex
+   * are both unreachable. That 403 states nothing about the plan, so it must
+   * never upsell — not even a client with no entitlement snapshot.
+   */
+  it("'Unable to verify entitlements' is access_denied for every belief", () => {
+    for (const belief of [UNKNOWN, FREE, PRO, CLERK_PRO]) {
+      assert.equal(
+        classifyPremiumDenial({ status: 403, errorCode: 'Unable to verify entitlements', belief }),
+        'access_denied',
+        'a failed entitlement lookup is not a verdict about the plan',
+      );
+    }
+  });
+});
+
+describe('readDenialErrorCode', () => {
+  const json = (body: unknown, status = 403) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  it("extracts the real api/latest-brief 403 body's error field", async () => {
+    const res = json({
+      error: 'pro_required',
+      message: 'The Brief is available on the Pro plan.',
+      upgradeUrl: 'https://worldmonitor.app/pro',
+    });
+    assert.equal(await readDenialErrorCode(res), 'pro_required');
+  });
+
+  it("extracts the gateway's 'Upgrade required' body", async () => {
+    const res = json({ error: 'Upgrade required', requiredTier: 1, currentTier: 0, planKey: 'free' });
+    assert.equal(await readDenialErrorCode(res), 'Upgrade required');
+  });
+
+  it('a non-JSON body yields null rather than throwing', async () => {
+    const res = new Response('<html>403 Forbidden</html>', { status: 403 });
+    assert.equal(await readDenialErrorCode(res), null);
+  });
+
+  it('an empty body yields null', async () => {
+    assert.equal(await readDenialErrorCode(new Response(null, { status: 403 })), null);
+  });
+
+  it('a JSON body with no error field yields null', async () => {
+    assert.equal(await readDenialErrorCode(json({ message: 'nope' })), null);
+  });
+
+  it('a non-string error field yields null (no [object Object] codes)', async () => {
+    assert.equal(await readDenialErrorCode(json({ error: { code: 'pro_required' } })), null);
+    assert.equal(await readDenialErrorCode(json({ error: 403 })), null);
+  });
+
+  it('an already-consumed body yields null rather than throwing', async () => {
+    const res = json({ error: 'pro_required' });
+    await res.text();
+    assert.equal(await readDenialErrorCode(res), null);
+  });
+
+  it('null → an unlabelled 403 still classifies, so the two compose', async () => {
+    const code = await readDenialErrorCode(new Response('not json', { status: 403 }));
+    assert.equal(classifyPremiumDenial({ status: 403, errorCode: code, belief: PRO }), 'entitlement_desync');
+    assert.equal(classifyPremiumDenial({ status: 403, errorCode: code, belief: FREE }), 'upgrade_required');
+  });
+});
+
+describe('isTransientDenial', () => {
+  it('desync and access_denied are worth retrying', () => {
+    assert.equal(isTransientDenial('entitlement_desync'), true);
+    assert.equal(isTransientDenial('access_denied'), true);
+  });
+
+  it('sign-in and upgrade are terminal — retrying cannot flip them', () => {
+    assert.equal(isTransientDenial('sign_in_required'), false);
+    assert.equal(isTransientDenial('upgrade_required'), false);
+  });
+
+  it('null (no denial) is not transient', () => {
+    assert.equal(isTransientDenial(null), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring guard
+// ---------------------------------------------------------------------------
+
+/**
+ * The classifier is only worth anything if the panels actually call it. These
+ * panels build their DOM with `replaceChildren`, so there is no jsdom in this
+ * repo to drive them end-to-end (see tests/panel-attached-fetch-guard.test.mts
+ * for the same constraint). Pin the wiring at the source level instead, so a
+ * future edit cannot quietly restore the blanket `403 → upsell` branch.
+ */
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readSource = (rel: string): string => readFileSync(resolve(root, rel), 'utf8');
+
+const WIRED_PANELS = [
+  'src/components/LatestBriefPanel.ts',
+  'src/components/ChatAnalystPanel.ts',
+];
+
+describe('premium panels route their denials through the classifier', () => {
+  for (const rel of WIRED_PANELS) {
+    it(`${rel} calls classifyPremiumDenial`, () => {
+      assert.match(readSource(rel), /classifyPremiumDenial\(/);
+    });
+
+    /**
+     * The only legitimate reason these panels still mention 403 is deciding
+     * whether to read the body for the classifier — and that check always
+     * pairs 403 with 401. A line that inspects 403 alone is a verdict reached
+     * without consulting the client's entitlement state, which is the bug.
+     */
+    it(`${rel} never inspects a 403 on its own`, () => {
+      const offenders = readSource(rel)
+        .split('\n')
+        .map((line, i) => ({ line: line.trim(), lineNumber: i + 1 }))
+        // Prose about the old behaviour is not the old behaviour.
+        .filter(({ line }) => !/^(\/\/|\/\*|\*)/.test(line))
+        .filter(({ line }) => /\bstatus\s*[!=]==?\s*403\b/.test(line))
+        .filter(({ line }) => !/\bstatus\s*[!=]==?\s*401\b/.test(line));
+      assert.deepEqual(
+        offenders,
+        [],
+        `${rel} branches on a bare 403 instead of classifying it`,
+      );
+    });
+  }
+
+  it('LatestBriefPanel renders the upgrade CTA only for the upgrade_required verdict', () => {
+    const source = readSource('src/components/LatestBriefPanel.ts');
+    for (const call of [...source.matchAll(/this\.renderUpgradeRequired\(\)/g)]) {
+      const preceding = source.slice(Math.max(0, call.index - 400), call.index);
+      assert.ok(
+        /upgrade_required|clientBelievesPro/.test(preceding),
+        'every renderUpgradeRequired() call must be guarded by an explicit '
+        + 'upgrade_required verdict or a client-belief check, never a raw 403',
+      );
+    }
+  });
+
+  it("ChatAnalystPanel no longer hardcodes the upsell as its only 403 copy", () => {
+    const source = readSource('src/components/ChatAnalystPanel.ts');
+    const upsells = [...source.matchAll(/'Pro subscription required\.'/g)];
+    assert.equal(upsells.length, 1, 'exactly one upsell string, in the verdict switch');
+    const preceding = source.slice(Math.max(0, upsells[0].index - 200), upsells[0].index);
+    assert.match(
+      preceding,
+      /case 'upgrade_required':/,
+      'the upsell string must sit under the upgrade_required case',
+    );
+  });
+});


### PR DESCRIPTION
Closes #5608.

## The bug

During the #5600 entitlement-cache poison window, the Latest Brief panel told a user who had paid minutes earlier to **"Upgrade to unlock today's issue."** Every 403 was mapped to the upsell, so three different server conditions produced the same wrong render:

| Server condition | Old render | Correct render |
|---|---|---|
| Genuinely free plan | upsell | upsell (the only honest one) |
| Server-side entitlement desync | upsell | transient, retry |
| 403 raised before entitlement was read (origin/WAF, fail-closed lookup) | upsell | transient, retry |

## The premise, verified

The fix keys on the client's own entitlement state contradicting the server. That only works if the two read *different* sources — so I checked rather than assumed:

- Client: `convex/entitlements.ts:64` `getEntitlementsForUser`, a live reactive Convex query.
- Server: `server/_shared/entitlement-check.ts:302` reads Redis `entitlements:${ENV_PREFIX}:${userId}` on a 900s TTL.

In #5600 the edge served a sticky tier-0 answer for ~15 minutes after the webhook wrote the Pro row to Convex. So the client said Pro while the server said free — exactly the discriminating condition. The classifier is targeted at the real incident, and the retry actually resolves it when the cache expires.

## What changed

`src/services/premium-denial.ts` (new, zero-import leaf) classifies a denial from the status, the server's error code, and a snapshot of what the client believes:

- `upgrade_required` — the client agrees it's free, or has no opinion. Terminal.
- `entitlement_desync` — the client's own state contradicts the server. Transient.
- `access_denied` — the 403 never reached the entitlement check. Transient.
- `sign_in_required` — 401, or a gateway 403 that means "authenticate".

Wired into `LatestBriefPanel` and `ChatAnalystPanel`. `WidgetChatModal` already split its 403 on client belief (the in-repo precedent) and is unchanged.

## Review round

Nine reviewers plus an independent cross-model pass (gpt-5.5) reviewed the first commit; the second commit addresses every confirmed finding:

- **Bounded retry.** Four reviewers independently flagged that transient denials retried forever. Now capped at 8 attempts (~16 min, longer than the observed poison window), then a terminal card that is deliberately *not* an upsell — exhausting retries isn't evidence the user must buy anything.
- **`Subscription lapsed` is terminal.** It comes from `billingStatus` (provider-confirmed) and `EntitlementState` has no `billingStatus`, so `clientBelievesPro` would have retried a lapsed subscriber forever.
- **Unlabelled 403 → `access_denied`.** Every entitlement 403 we emit carries a JSON `error`, so a bodyless one is an intermediary. The code already claimed this; now it does it.
- **Cross-user leak** (found only by the cross-model pass): an account switch destroyed the entitlement subscription but never reset the snapshot — only sign-out did — so user B was classified against user A's Pro entitlement.
- **Race:** the new `await` on ChatAnalystPanel's denial path let a superseded `send()` null a newer stream's controller in its `finally`. Now keyed on controller identity.

## Verification

The first cut's source-regex wiring guard was **proven by execution** to stay green with the #5608 bug restored verbatim — a neighbouring branch supplied the token it searched for. That's fixed properly: the routing decision now lives in a pure `routeDenial` with an executable truth table, alongside `shouldSkipDoomedFetch` (the pre-fetch gate's boolean composition) and `classifyDenialResponse` (the glue, tested against real `Response` objects, which also covers the body-lifecycle seam).

Mutation-tested — each of these now fails loudly:

| Mutation | Result |
|---|---|
| Classifier always upsells on 403 | 5 tests fail |
| `LatestBriefPanel` reverted to blanket 403 | 2 tests fail |
| `ChatAnalystPanel` reverted to blanket 403 | 2 tests fail |
| Bug restored in the catch block (the one that fooled the old guard) | fails |
| `routeDenial` flipped to upsell | 4 tests fail |

A contract test parses `api/latest-brief.ts`, `api/chat-analyst.ts` and `entitlement-check.ts` and asserts every 401/403 string they emit is classified, so a backend rename fails CI instead of silently rerouting a denial. It already earned its keep — it caught a status-pairing bug in its own extractor.

64 tests in `tests/premium-denial.test.mts`; 166 passing across the panel/premium/entitlement suites; typecheck, lint, full build, and the `docs-stats` gate all green.

## Not in scope (filed separately)

Server-side conflations this change surfaced but cannot fix from the client, plus the observability gap:

- #5619 — `api/latest-brief.ts`, `api/chat-analyst.ts` and `mcp-grant-context.ts` each collapse a failed entitlement lookup (or an unauthenticated caller) into the same body as a genuine free plan, capping how honest the client can be.
- #5620 — `entitlement_desync` is now recognisable but unreported, so a #5600 recurrence still looks like "no incidents" on every dashboard.

https://claude.ai/code/session_01VoA8BAbLgdYxLTRH8zQvPc