### PR TITLE
feat(activation): record day-0 activation outcomes server-side (#5621)

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import schema from "../schema";
 import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
 import { PRODUCT_CATALOG } from "../config/productCatalog";
 import {
   PENDING_PAYMENT_BLOCK_WINDOW_MS,
@@ -5010,7 +5011,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     )).toBe(true);
     const legacyPresentation = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(legacyPresentation?.outcomeTrackingVersion).toBeUndefined();
     const afterConfirmation = await t
@@ -5046,7 +5049,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     )).toBe(true);
     const firstPresentation = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     const firstPresentedAt = firstPresentation!.presentedAt;
     expect(firstPresentedAt).toBeDefined();
@@ -5061,7 +5066,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     )).toBe(true);
     const secondPresentedAt = (await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique()))!.presentedAt;
     expect(secondPresentedAt).toBe(firstPresentedAt);
   });
@@ -5092,7 +5099,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     ]);
     const rows = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .collect());
     expect(rows).toHaveLength(1);
   });
@@ -5146,7 +5155,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
     await t.run(async (ctx) => {
       const presentation = await ctx.db
         .query("proActivationPresentations")
-        .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+        .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
         .unique();
       expect(presentation).not.toBeNull();
       await ctx.db.patch(presentation!._id, { claimedAt: Date.now() - 31_000 });
@@ -5211,7 +5222,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const rows = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .collect());
     expect(rows).toEqual([]);
   });
@@ -5246,7 +5259,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const progressRow = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(progressRow?.presentedAt).toBeTypeOf("number");
     expect(progressRow?.outcomeTrackingVersion).toBe(1);
@@ -5268,7 +5283,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const afterStaleWrite = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(afterStaleWrite?.confirmedSteps).toEqual(["brief"]);
     expect(afterStaleWrite?.failedSteps).toEqual(["power"]);
@@ -5290,7 +5307,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(row?.confirmedSteps).toEqual(["brief", "power"]);
     expect(row?.skippedSteps).toEqual(["alerts"]);
@@ -5380,7 +5399,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(row?.confirmedSteps).toBeUndefined();
     expect(row?.blockedSteps).toBeUndefined();
@@ -5518,7 +5539,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(row?.blockedSteps).toEqual(["alerts"]);
     // The whole point: the denial is queryable WITHOUT being conflated with a
@@ -5593,7 +5616,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(row?.blockedSteps).toEqual(["alerts"]);
     expect(row?.confirmedSteps).toEqual(["brief"]);
@@ -5619,7 +5644,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const afterLateWrite = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(afterLateWrite?.blockedSteps).toEqual(["alerts"]);
   });
@@ -5672,7 +5699,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(row?.blockedSteps).toBeUndefined();
     expect(row?.skippedSteps).toEqual(["alerts"]);
@@ -5755,7 +5784,9 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const row = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .unique());
     expect(row?.blockedSteps).toBeUndefined();
     expect(row?.skippedSteps).toEqual(["alerts"]);
@@ -5827,8 +5858,271 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
 
     const rows = await t.run(async (ctx) => await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", activationKey))
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+      )
       .collect());
     expect(rows).toHaveLength(1);
+  });
+});
+
+describe("Pro activation — day-0 outcome rows (#5621)", () => {
+  const IDENTITY = { subject: TEST_USER_ID, tokenIdentifier: `clerk|${TEST_USER_ID}` };
+
+  async function seedProSubscription(t: ReturnType<typeof convexTest>, suffix: string) {
+    return await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix,
+    });
+  }
+
+  async function readCohort(
+    t: ReturnType<typeof convexTest>,
+    activationKey: Id<"subscriptions">,
+    cohort: "day0" | undefined,
+  ) {
+    return await t.run(async (ctx) => await ctx.db
+      .query("proActivationPresentations")
+      .withIndex("by_subscription_cohort", (q) =>
+        q.eq("subscriptionId", activationKey).eq("cohort", cohort),
+      )
+      .collect());
+  }
+
+  test("a day-0 session is recorded as presented before it can report any step", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_open");
+
+    const opened = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "day0-tab" },
+    );
+    expect(opened.status).toBe("opened");
+
+    const [row] = await readCohort(t, activationKey, "day0");
+    // presentedAt without any outcome is the abandoned-immediately signal the
+    // #5600 forensics had to reconstruct from Umami sessions.
+    expect(row?.presentedAt).toEqual(expect.any(Number));
+    expect(row?.outcomeTrackingVersion).toBe(1);
+    expect(row?.confirmedSteps).toBeUndefined();
+    expect(row?.exitedAt).toBeUndefined();
+  });
+
+  test("a day-0 row does not block a later retro claim for the same subscription", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_no_block");
+
+    // Day-0 ran and every step failed — the exact #5600 cohort.
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "day0-tab" },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "day0-tab",
+        cohort: "day0" as const,
+        confirmedSteps: [],
+        skippedSteps: [],
+        failedSteps: ["brief", "alerts"],
+        revision: 1,
+        finalized: true,
+      },
+    );
+
+    // The markerless backfill must still be offered and claimable: nothing
+    // actually activated, so this is the recovery path for that cohort.
+    const eligibility = await t
+      .withIdentity(IDENTITY)
+      .query(api.payments.billing.getSubscriptionForUser, {});
+    expect(eligibility?.activationOnboardingEligible).toBe(true);
+
+    const claim = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "retro-tab" },
+    );
+    expect(claim.status).toBe("claimed");
+
+    // ...and the retro claim landed on its own row, leaving day-0's frozen.
+    const [retro] = await readCohort(t, activationKey, undefined);
+    const [day0] = await readCohort(t, activationKey, "day0");
+    expect(retro?.claimNonce).toBe("retro-tab");
+    expect(retro?.confirmedSteps).toBeUndefined();
+    expect(day0?.failedSteps).toEqual(["brief", "alerts"]);
+    expect(day0?.exitedAt).toEqual(expect.any(Number));
+  });
+
+  test("outcome writes stay inside their own cohort's row", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_isolation");
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "day0-tab" },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce: "retro-tab" },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.confirmProActivationPresentation,
+      { activationKey, claimNonce: "retro-tab", outcomeTrackingVersion: 1 as const },
+    );
+
+    // Each nonce only writes its own cohort; presenting the other cohort's
+    // nonce is rejected rather than silently retargeted.
+    expect(
+      await t.withIdentity(IDENTITY).mutation(
+        api.payments.billing.recordProActivationOutcome,
+        {
+          activationKey,
+          claimNonce: "day0-tab",
+          confirmedSteps: ["brief"],
+          skippedSteps: [],
+          failedSteps: [],
+          revision: 1,
+          finalized: false,
+        },
+      ),
+    ).toBe(false);
+    expect(
+      await t.withIdentity(IDENTITY).mutation(
+        api.payments.billing.recordProActivationOutcome,
+        {
+          activationKey,
+          claimNonce: "retro-tab",
+          cohort: "day0" as const,
+          confirmedSteps: ["brief"],
+          skippedSteps: [],
+          failedSteps: [],
+          revision: 1,
+          finalized: false,
+        },
+      ),
+    ).toBe(false);
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "day0-tab",
+        cohort: "day0" as const,
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "retro-tab",
+        confirmedSteps: [],
+        skippedSteps: ["alerts"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    );
+
+    const [day0] = await readCohort(t, activationKey, "day0");
+    const [retro] = await readCohort(t, activationKey, undefined);
+    expect(day0?.confirmedSteps).toEqual(["brief"]);
+    expect(day0?.skippedSteps).toEqual([]);
+    expect(retro?.confirmedSteps).toEqual([]);
+    expect(retro?.skippedSteps).toEqual(["alerts"]);
+  });
+
+  test("a re-opened day-0 session takes over an abandoned row but never a finalized one", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_takeover");
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "first-tab" },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "first-tab",
+        cohort: "day0" as const,
+        confirmedSteps: [],
+        skippedSteps: ["brief"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    );
+
+    // A later boot (storage write failed, so the marker survived) supersedes
+    // the abandoned session in place — one row, and its revision counter is
+    // reset so the new session's snapshots are not rejected as stale.
+    const retaken = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "second-tab" },
+    );
+    expect(retaken.status).toBe("opened");
+    expect(await readCohort(t, activationKey, "day0")).toHaveLength(1);
+    expect(
+      await t.withIdentity(IDENTITY).mutation(
+        api.payments.billing.recordProActivationOutcome,
+        {
+          activationKey,
+          claimNonce: "second-tab",
+          cohort: "day0" as const,
+          confirmedSteps: ["brief"],
+          skippedSteps: [],
+          failedSteps: [],
+          revision: 1,
+          finalized: true,
+        },
+      ),
+    ).toBe(true);
+
+    // Once finalized the record is frozen: a chip-driven re-open reports the
+    // existing record instead of resetting the session that already exited.
+    const afterExit = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "third-tab" },
+    );
+    expect(afterExit.status).toBe("already_recorded");
+    const [row] = await readCohort(t, activationKey, "day0");
+    expect(row?.claimNonce).toBe("second-tab");
+    expect(row?.confirmedSteps).toEqual(["brief"]);
+  });
+
+  test("day-0 records nothing for another user's or a non-Pro subscription", async () => {
+    const t = convexTest(schema, modules);
+    const foreignKey = await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_day0_foreign",
+      userId: "user_someone_else",
+    });
+    const apiKey = await seedSubscription(t, {
+      planKey: "api_starter",
+      dodoProductId: PRODUCT_CATALOG.api_starter.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "activation_day0_non_pro",
+    });
+
+    for (const activationKey of [foreignKey, apiKey]) {
+      const result = await t.withIdentity(IDENTITY).mutation(
+        api.payments.billing.openProActivationDay0Presentation,
+        { activationKey, claimNonce: "day0-tab" },
+      );
+      expect(result.status).toBe("not_eligible");
+      expect(await readCohort(t, activationKey, "day0")).toHaveLength(0);
+    }
   });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -5156,8 +5156,8 @@ describe("getSubscriptionForUser activation onboarding eligibility", () => {
       const presentation = await ctx.db
         .query("proActivationPresentations")
         .withIndex("by_subscription_cohort", (q) =>
-        q.eq("subscriptionId", activationKey).eq("cohort", undefined),
-      )
+          q.eq("subscriptionId", activationKey).eq("cohort", undefined),
+        )
         .unique();
       expect(presentation).not.toBeNull();
       await ctx.db.patch(presentation!._id, { claimedAt: Date.now() - 31_000 });
@@ -6040,6 +6040,8 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
   });
 
   test("a re-opened day-0 session takes over an abandoned row but never a finalized one", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
     const t = convexTest(schema, modules);
     const activationKey = await seedProSubscription(t, "activation_day0_takeover");
 
@@ -6055,21 +6057,34 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
         cohort: "day0" as const,
         confirmedSteps: [],
         skippedSteps: ["brief"],
-        failedSteps: [],
+        blockedSteps: ["alerts"],
+        failedSteps: ["power"],
         revision: 1,
         finalized: false,
       },
     );
 
     // A later boot (storage write failed, so the marker survived) supersedes
-    // the abandoned session in place — one row, and its revision counter is
-    // reset so the new session's snapshots are not rejected as stale.
+    // the abandoned session in place. It must reset the full outcome snapshot,
+    // not let the new session inherit the abandoned session's classifications.
+    vi.setSystemTime(NOW + 1_000);
     const retaken = await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
       { activationKey, claimNonce: "second-tab" },
     );
     expect(retaken.status).toBe("opened");
-    expect(await readCohort(t, activationKey, "day0")).toHaveLength(1);
+    const retakenRows = await readCohort(t, activationKey, "day0");
+    expect(retakenRows).toHaveLength(1);
+    const [retakenRow] = retakenRows;
+    expect(retakenRow?.claimNonce).toBe("second-tab");
+    expect(retakenRow?.claimedAt).toBe(NOW + 1_000);
+    expect(retakenRow?.presentedAt).toBe(NOW + 1_000);
+    expect(retakenRow?.confirmedSteps).toBeUndefined();
+    expect(retakenRow?.skippedSteps).toBeUndefined();
+    expect(retakenRow?.blockedSteps).toBeUndefined();
+    expect(retakenRow?.failedSteps).toBeUndefined();
+    expect(retakenRow?.outcomeRevision).toBeUndefined();
+    expect(retakenRow?.outcomeUpdatedAt).toBeUndefined();
     expect(
       await t.withIdentity(IDENTITY).mutation(
         api.payments.billing.recordProActivationOutcome,

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -14,7 +14,7 @@ import { action, mutation, query, internalAction, internalMutation, internalQuer
 import { internal } from "../_generated/api";
 import { DodoPayments } from "dodopayments";
 import type { Subscription as DodoSubscription } from "dodopayments/resources/subscriptions";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
@@ -542,14 +542,38 @@ async function hasActivatedServerProFunctionality(
   return hasConfiguredDelivery || hasApiSetup || hasMcpSetup;
 }
 
+/**
+ * The one presentation row for a subscription in a given cohort (#5621).
+ *
+ * `cohort: undefined` is the markerless retro backfill — the lease-bearing
+ * cohort, and the only one that existed before day-0 instrumentation, so this
+ * keeps matching every pre-#5621 row without a backfill. "day0" is the
+ * post-checkout welcome session, which carries its own row so it can never
+ * consume the retro lease.
+ */
+async function activationPresentationForCohort(
+  ctx: QueryCtx | MutationCtx,
+  subscriptionId: Id<"subscriptions">,
+  cohort: "day0" | undefined,
+): Promise<Doc<"proActivationPresentations"> | null> {
+  return await ctx.db
+    .query("proActivationPresentations")
+    .withIndex("by_subscription_cohort", (q) =>
+      q.eq("subscriptionId", subscriptionId).eq("cohort", cohort),
+    )
+    .first();
+}
+
 async function hasConfirmedActivationPresentation(
   ctx: QueryCtx | MutationCtx,
   subscriptionId: Id<"subscriptions">,
 ): Promise<boolean> {
-  const presentation = await ctx.db
-    .query("proActivationPresentations")
-    .withIndex("by_subscription", (q) => q.eq("subscriptionId", subscriptionId))
-    .first();
+  // Retro cohort ONLY. A day-0 row means the subscriber saw the welcome flow,
+  // not that the backfill fired — and after #5600 (a day-0 cohort whose every
+  // write 403'd) the backfill is exactly the recovery path those subscribers
+  // still need. `claimProActivationPresentation` re-checks real activation, so
+  // anyone whose day-0 session actually stuck is filtered out there.
+  const presentation = await activationPresentationForCohort(ctx, subscriptionId, undefined);
   // Pending leases arbitrate at the claim mutation. Keeping the reactive
   // eligibility verdict true until presentation is confirmed lets a losing
   // browser retry if the winner crashes and the short lease expires.
@@ -660,10 +684,7 @@ export const claimProActivationPresentation = mutation({
       return { status: "not_eligible" as const };
     }
 
-    const existing = await ctx.db
-      .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.activationKey))
-      .first();
+    const existing = await activationPresentationForCohort(ctx, args.activationKey, undefined);
     if (existing?.presentedAt !== undefined) {
       return { status: "already_presented" as const };
     }
@@ -706,10 +727,9 @@ export const confirmProActivationPresentation = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
-    const presentation = await ctx.db
-      .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.activationKey))
-      .first();
+    // Retro cohort only: presentation confirmation is the lease handshake, and
+    // the day-0 path has no lease to confirm.
+    const presentation = await activationPresentationForCohort(ctx, args.activationKey, undefined);
     if (
       presentation === null ||
       presentation.userId !== userId ||
@@ -744,6 +764,75 @@ const MAX_PRO_ACTIVATION_OUTCOME_REVISION =
   proActivationStepIdValidator.members.length + 2;
 
 /**
+ * Open the day-0 (post-checkout) activation record (#5621).
+ *
+ * Unlike the retro cohort this is NOT a lease: the day-0 flow's fire-once is
+ * the browser-local checkout marker, and the welcome interstitial must open
+ * even when this write fails. It exists purely so an abandoned or
+ * all-writes-failed day-0 session is still a queryable row rather than an
+ * absence that has to be reconstructed from Umami sessions (#5600).
+ *
+ * Ownership moves to the newest session because only one un-finalized day-0
+ * row exists per subscription; a session that already exited is frozen and
+ * takes precedence over a late re-open (e.g. the finish-setup chip).
+ */
+export const openProActivationDay0Presentation = mutation({
+  args: {
+    activationKey: v.id("subscriptions"),
+    claimNonce: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireUserId(ctx);
+    const subscription = await ctx.db.get(args.activationKey);
+    // Ownership and plan identity only. Deliberately NOT gated on
+    // isFirstBillingCycle/isCoveringAt like the retro claim is: those decide
+    // whether to OFFER onboarding, and the day-0 flow has already been shown
+    // by the time this runs. Refusing on a clock or webhook skew would
+    // re-create the blind spot this record exists to close.
+    if (
+      subscription === null ||
+      subscription.userId !== userId ||
+      !isProActivationPlan(subscription.planKey)
+    ) {
+      return { status: "not_eligible" as const };
+    }
+
+    const now = Date.now();
+    const existing = await activationPresentationForCohort(ctx, args.activationKey, "day0");
+    if (existing === null) {
+      await ctx.db.insert("proActivationPresentations", {
+        userId,
+        subscriptionId: args.activationKey,
+        cohort: "day0",
+        claimNonce: args.claimNonce,
+        claimedAt: now,
+        // Day-0 has no confirm handshake, so presentation is recorded here —
+        // before the interstitial renders — to keep a subscriber who closes
+        // the tab immediately inside the cohort instead of invisible.
+        presentedAt: now,
+        outcomeTrackingVersion: PRO_ACTIVATION_OUTCOME_TRACKING_VERSION,
+      });
+      return { status: "opened" as const };
+    }
+    if (existing.exitedAt !== undefined) {
+      return { status: "already_recorded" as const };
+    }
+    if (existing.claimNonce !== args.claimNonce) {
+      // A later session supersedes an abandoned one. Clearing the revision
+      // lets the new session's snapshots (which restart at 1) land instead of
+      // being rejected as stale by the monotonic guard below.
+      await ctx.db.patch(existing._id, {
+        claimNonce: args.claimNonce,
+        claimedAt: now,
+        outcomeRevision: undefined,
+        outcomeTrackingVersion: PRO_ACTIVATION_OUTCOME_TRACKING_VERSION,
+      });
+    }
+    return { status: "opened" as const };
+  },
+});
+
+/**
  * Persist a monotonic snapshot of the wizard outcome (#5582). Progress writes
  * happen as steps resolve so a lost exit cannot censor disengaged sessions;
  * the final write sets `exitedAt` and freezes the record. Invalid,
@@ -753,6 +842,10 @@ export const recordProActivationOutcome = mutation({
   args: {
     activationKey: v.id("subscriptions"),
     claimNonce: v.string(),
+    // Which cohort's row this snapshot belongs to (#5621). Absent = the retro
+    // backfill, so clients from before day-0 instrumentation keep writing to
+    // the row they always wrote to.
+    cohort: v.optional(v.literal("day0")),
     confirmedSteps: v.array(proActivationStepIdValidator),
     skippedSteps: v.array(proActivationStepIdValidator),
     // Optional for mixed deploys (#5617): a client from before the blocked
@@ -765,10 +858,11 @@ export const recordProActivationOutcome = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
-    const presentation = await ctx.db
-      .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.activationKey))
-      .first();
+    const presentation = await activationPresentationForCohort(
+      ctx,
+      args.activationKey,
+      args.cohort,
+    );
     if (
       presentation === null ||
       presentation.userId !== userId ||
@@ -3772,9 +3866,11 @@ export const deleteSubscriptionByDodoId = internalMutation({
     }
 
     const userId = sub.userId;
+    // Index prefix — deliberately unfiltered by cohort so deleting a
+    // subscription reaps BOTH its day-0 and retro presentation rows.
     const presentations = await ctx.db
       .query("proActivationPresentations")
-      .withIndex("by_subscription", (q) => q.eq("subscriptionId", sub._id))
+      .withIndex("by_subscription_cohort", (q) => q.eq("subscriptionId", sub._id))
       .collect();
     for (const presentation of presentations) {
       await ctx.db.delete(presentation._id);

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -818,13 +818,19 @@ export const openProActivationDay0Presentation = mutation({
       return { status: "already_recorded" as const };
     }
     if (existing.claimNonce !== args.claimNonce) {
-      // A later session supersedes an abandoned one. Clearing the revision
-      // lets the new session's snapshots (which restart at 1) land instead of
-      // being rejected as stale by the monotonic guard below.
+      // A later session supersedes an abandoned one. Reset the full snapshot
+      // so the new session neither inherits stale classifications nor has its
+      // revisions (which restart at 1) rejected by the monotonic guard below.
       await ctx.db.patch(existing._id, {
         claimNonce: args.claimNonce,
         claimedAt: now,
+        presentedAt: now,
+        confirmedSteps: undefined,
+        skippedSteps: undefined,
+        blockedSteps: undefined,
+        failedSteps: undefined,
         outcomeRevision: undefined,
+        outcomeUpdatedAt: undefined,
         outcomeTrackingVersion: PRO_ACTIVATION_OUTCOME_TRACKING_VERSION,
       });
     }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -637,9 +637,15 @@ export default defineSchema({
     // "your access ended ~a month ago", so access end is the right clock.
     .index("by_status_currentPeriodEnd", ["status", "currentPeriodEnd"]),
 
-  // Cross-device single-presentation lease for markerless Pro activation.
-  // A short pending claim closes concurrent mount races without permanently
-  // suppressing onboarding when a browser crashes before rendering the flow.
+  // What happened in a Pro-activation session, one row per subscription per
+  // cohort (see `cohort` below).
+  //
+  // For the markerless retro cohort the row is ALSO a cross-device
+  // single-presentation lease: a short pending claim closes concurrent mount
+  // races without permanently suppressing onboarding when a browser crashes
+  // before rendering the flow. The day-0 cohort has no lease — its fire-once
+  // is the browser-local checkout marker — so its row is purely the outcome
+  // record.
   //
   // The outcome buckets mirror ActivationStepOutcome
   // (pro-activation-state.ts). They are updated as the subscriber acts so a
@@ -648,6 +654,17 @@ export default defineSchema({
   proActivationPresentations: defineTable({
     userId: v.string(),
     subscriptionId: v.id("subscriptions"),
+    // Which activation cohort this row records (#5621). ABSENT is the
+    // markerless retro backfill — the only cohort that existed before, so
+    // every pre-#5621 row reads correctly with no backfill, and the lease
+    // lookups keep matching them by querying `cohort: undefined`.
+    // "day0" is the post-checkout welcome session. The two are SEPARATE rows
+    // for one subscription on purpose: day-0 carries no lease (its fire-once
+    // is the browser-local checkout marker), so a day-0 row must never occupy
+    // the retro claim slot or set the `presentedAt` gate that suppresses a
+    // later legitimate backfill for a subscriber whose day-0 writes all
+    // failed (#5600).
+    cohort: v.optional(v.literal("day0")),
     claimNonce: v.string(),
     claimedAt: v.number(),
     presentedAt: v.optional(v.number()),
@@ -672,7 +689,11 @@ export default defineSchema({
     outcomeUpdatedAt: v.optional(v.number()),
     exitedAt: v.optional(v.number()),
   })
-    .index("by_subscription", ["subscriptionId"]),
+    // Cohort is part of the key so each lookup names the row it means. A
+    // prefix query on `subscriptionId` alone still reads BOTH cohorts (used
+    // by subscription deletion); every lease/outcome lookup pins the second
+    // component so it can never cross cohorts.
+    .index("by_subscription_cohort", ["subscriptionId", "cohort"]),
 
   // Dunning/winback send ledger (#4932): one row per email step actually
   // delivered for a given subscription episode. `episodeAt` is the on_hold

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -513,6 +513,7 @@ async function runDay0FlowHarness(
     day0Status?: Day0Status;
     day0Throws?: boolean;
     day0NeverResolves?: boolean;
+    day0ResolveAfterMs?: number;
   } = {},
 ): Promise<{ result: string; claimCalls: number; confirmCalls: number; day0Calls: number }> {
   return await page.evaluate(async (scenario) => {
@@ -565,6 +566,9 @@ async function runDay0FlowHarness(
           day0Calls += 1;
           if (scenario.day0NeverResolves) return await new Promise<never>(() => {});
           if (scenario.day0Throws) throw new Error('day-0 record transport failed');
+          if (scenario.day0ResolveAfterMs !== undefined) {
+            await new Promise<void>((resolve) => setTimeout(resolve, scenario.day0ResolveAfterMs));
+          }
           return scenario.day0Status ?? 'opened';
         },
         recordOutcome: async (activationKey, claimNonce, outcome) => {
@@ -639,6 +643,28 @@ test.describe('Pro activation flow — day-0 outcome rows (#5621)', () => {
     expect(result.confirmCalls).toBe(0);
   });
 
+  test('a late successful day-0 open still flushes queued finalized snapshots', async ({ page }) => {
+    const result = await runDay0FlowHarness(page, { day0ResolveAfterMs: 350 });
+    expect(result.result).toBe('opened');
+    await expect(page.locator(OVERLAY)).toBeVisible();
+
+    // Both snapshots are queued before the open resolves, and after the 200ms
+    // observation deadline. A timeout warning must not turn that eventual
+    // server success into a permanent refusal.
+    await page.locator('.pro-activation-close').click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+    await page.locator(FINISH_BTN).click();
+
+    await expect.poll(async () => (await readCapturedOutcomes(page)).length).toBe(2);
+    expect((await readCapturedOutcomes(page)).map(({ outcome }) => ({
+      revision: outcome.revision,
+      finalized: outcome.finalized,
+    }))).toEqual([
+      { revision: 1, finalized: false },
+      { revision: 2, finalized: true },
+    ]);
+  });
+
   test.describe('a refused or unreachable day-0 record never blocks the welcome flow', () => {
     for (const [name, scenario] of [
       ['server refuses (already finalized)', { day0Status: 'already_recorded' as const }],
@@ -659,8 +685,9 @@ test.describe('Pro activation flow — day-0 outcome rows (#5621)', () => {
         await page.locator(FINISH_BTN).click();
         await expect(page.locator(OVERLAY)).toHaveCount(0);
 
-        // Outlast the 200ms operationTimeoutMs so the hung-transport case has
-        // actually resolved (to false) before asserting nothing was written.
+        // Outlast the 200ms observation deadline. A never-resolving readiness
+        // promise stays pending, but neither blocks the UI nor attempts a
+        // write against a row that does not exist.
         await page.waitForTimeout(400);
 
         // No row to attach to → snapshots are dropped rather than written

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -64,6 +64,7 @@ interface CapturedOutcomeCall {
   activationKey: string;
   claimNonce: string;
   outcome: {
+    cohort?: 'day0';
     confirmedSteps: string[];
     skippedSteps: string[];
     /** Browser-refused steps (#5617); present-and-empty when nothing was blocked. */
@@ -497,6 +498,177 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
     expect(result).toEqual({ result: 'retry', claimCalls: 1, confirmCalls: 0 });
     await expect(page.locator(OVERLAY)).toHaveCount(0);
     expect(await readCapturedOutcomes(page)).toEqual([]);
+  });
+});
+
+type Day0Status = 'opened' | 'already_recorded' | 'not_eligible';
+
+/**
+ * Drive the REAL day-0 (post-checkout) flow: `onlyIfUnactivated: false`, with
+ * the subscription identity the controller now supplies for both cohorts.
+ */
+async function runDay0FlowHarness(
+  page: Page,
+  input: {
+    day0Status?: Day0Status;
+    day0Throws?: boolean;
+    day0NeverResolves?: boolean;
+  } = {},
+): Promise<{ result: string; claimCalls: number; confirmCalls: number; day0Calls: number }> {
+  return await page.evaluate(async (scenario) => {
+    const { initI18n } = await import('/src/services/i18n.ts');
+    await initI18n();
+    const mod = await import('/src/components/ProActivationInterstitial.ts');
+    const w = window as unknown as {
+      __proOutcomeCalls: CapturedOutcomeCall[];
+      __proOutcomeAttempts: number;
+    };
+    w.__proOutcomeCalls = [];
+    w.__proOutcomeAttempts = 0;
+    let claimCalls = 0;
+    let confirmCalls = 0;
+    let day0Calls = 0;
+    const result = await mod.openProActivationFlow(
+      {
+        accountUserId: 'day0-user',
+        accountEmail: 'day0@worldmonitor.app',
+        onlyIfUnactivated: false,
+        expectedActivationKey: 'opaque-subscription',
+        activationClaimNonce: 'tab-nonce',
+        isAccountCurrent: () => true,
+      },
+      {
+        readContext: async () => ({
+          config: {
+            hasVerifiedEmailChannel: false,
+            hasEmailDelivery: false,
+            hasEnabledDigestRule: false,
+            hasTunedDigestHour: false,
+            hasWebPushChannel: false,
+            hasWebPushDelivery: false,
+            hasUsedPowerFeature: false,
+          },
+          capabilities: { webPushSupported: false },
+          channels: [],
+          channelsKnown: true,
+          hasEnabledRule: false,
+        }),
+        claimPresentation: async () => {
+          claimCalls += 1;
+          return 'claimed';
+        },
+        confirmPresentation: async () => {
+          confirmCalls += 1;
+          return true;
+        },
+        openDay0Presentation: async () => {
+          day0Calls += 1;
+          if (scenario.day0NeverResolves) return await new Promise<never>(() => {});
+          if (scenario.day0Throws) throw new Error('day-0 record transport failed');
+          return scenario.day0Status ?? 'opened';
+        },
+        recordOutcome: async (activationKey, claimNonce, outcome) => {
+          w.__proOutcomeAttempts += 1;
+          w.__proOutcomeCalls.push({ activationKey, claimNonce, outcome });
+          return true;
+        },
+        operationTimeoutMs: 200,
+      },
+    );
+    return { result, claimCalls, confirmCalls, day0Calls };
+  }, input);
+}
+
+test.describe('Pro activation flow — day-0 outcome rows (#5621)', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoHarness(page);
+  });
+
+  test('day-0 opens its own record and persists cohort-tagged outcome snapshots', async ({ page }) => {
+    // Before #5621 the day-0 path ran with no activation key or nonce, so
+    // persistActivationOutcomeWithRetry returned early and the entire
+    // post-checkout cohort was absent from Convex.
+    const result = await runDay0FlowHarness(page);
+    expect(result).toEqual({ result: 'opened', claimCalls: 0, confirmCalls: 0, day0Calls: 1 });
+    await expect(page.locator(OVERLAY)).toBeVisible();
+
+    await page.locator('.pro-activation-close').click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+    await page.locator(FINISH_BTN).click();
+
+    await expect.poll(async () => (await readCapturedOutcomes(page)).length).toBe(2);
+    expect(await readCapturedOutcomes(page)).toEqual([
+      {
+        activationKey: 'opaque-subscription',
+        claimNonce: 'tab-nonce',
+        outcome: {
+          cohort: 'day0',
+          confirmedSteps: [],
+          skippedSteps: ['brief', 'power'],
+          // Same full-replacement contract the markerless snapshots pin
+          // (#5617): the day-0 payload carries every bucket, so the cohort tag
+          // rides alongside them rather than replacing any.
+          blockedSteps: [],
+          failedSteps: [],
+          revision: 1,
+          finalized: false,
+        },
+      },
+      {
+        activationKey: 'opaque-subscription',
+        claimNonce: 'tab-nonce',
+        outcome: {
+          cohort: 'day0',
+          confirmedSteps: [],
+          skippedSteps: ['brief', 'power'],
+          blockedSteps: [],
+          failedSteps: [],
+          revision: 2,
+          finalized: true,
+        },
+      },
+    ]);
+  });
+
+  test('day-0 never touches the markerless claim/confirm lease', async ({ page }) => {
+    // The lease is what makes the retro backfill fire exactly once per
+    // subscription. Day-0 borrowing it would consume that budget and lock the
+    // subscriber out of the backfill they may still need (#5600).
+    const result = await runDay0FlowHarness(page);
+    expect(result.claimCalls).toBe(0);
+    expect(result.confirmCalls).toBe(0);
+  });
+
+  test.describe('a refused or unreachable day-0 record never blocks the welcome flow', () => {
+    for (const [name, scenario] of [
+      ['server refuses (already finalized)', { day0Status: 'already_recorded' as const }],
+      ['server refuses (ineligible)', { day0Status: 'not_eligible' as const }],
+      ['transport throws', { day0Throws: true }],
+      ['transport hangs past the deadline', { day0NeverResolves: true }],
+    ] as const) {
+      test(name, async ({ page }) => {
+        const result = await runDay0FlowHarness(page, scenario);
+        // Post-checkout onboarding is the product; the ledger is telemetry.
+        // It must open regardless, and never return the 'retry' that the
+        // markerless path uses when its lease is in doubt.
+        expect(result.result).toBe('opened');
+        await expect(page.locator(OVERLAY)).toBeVisible();
+
+        await page.locator('.pro-activation-close').click();
+        await expect(page.locator(SUMMARY)).toBeVisible();
+        await page.locator(FINISH_BTN).click();
+        await expect(page.locator(OVERLAY)).toHaveCount(0);
+
+        // Outlast the 200ms operationTimeoutMs so the hung-transport case has
+        // actually resolved (to false) before asserting nothing was written.
+        await page.waitForTimeout(400);
+
+        // No row to attach to → snapshots are dropped rather than written
+        // against a row this session does not own.
+        expect(await readCapturedOutcomes(page)).toEqual([]);
+        expect(await readOutcomeAttempts(page)).toBe(0);
+      });
+    }
   });
 });
 

--- a/scripts/report-activation-lift.mjs
+++ b/scripts/report-activation-lift.mjs
@@ -3,6 +3,10 @@
  * Compare downstream Pro-feature adoption between subscribers who confirmed
  * at least one activation-wizard step and subscribers who confirmed none.
  *
+ * Reported per cohort (#5621) — day-0 post-checkout sessions and the
+ * markerless retro backfill are separate populations with different baseline
+ * adoption, so they get separate verdicts rather than one pooled number.
+ *
  * Every shown presentation stays in the cohort. Its observation window starts
  * at the durable exit when present, otherwise the latest persisted progress,
  * otherwise `presentedAt` for a no-action abandonment. This avoids both
@@ -147,9 +151,49 @@ function summarizeGroup(rows, featureIndex, windowMs) {
   };
 }
 
+/**
+ * Which activation cohort a presentation row belongs to (#5621). An absent
+ * `cohort` is the markerless retro backfill — the only cohort that existed
+ * before day-0 sessions started writing rows, so every historical row keeps
+ * classifying the way it always did.
+ */
+export function activationCohortOf(row) {
+  return row.cohort === "day0" ? "day0" : "retro";
+}
+
+export const ACTIVATION_COHORTS = ["day0", "retro"];
+
+export const COHORT_LABELS = {
+  day0: "Day-0 (post-checkout welcome)",
+  retro: "Retro (markerless first-cycle backfill)",
+};
+
+/**
+ * Analyze each cohort on its own. They are NOT pooled: a day-0 subscriber is
+ * minutes old and a retro subscriber is mid-cycle, so their baseline adoption
+ * rates are not comparable and a combined lift number would average two
+ * different populations into one meaningless figure.
+ */
+export function analyzeActivationLiftByCohort({ presentations, ...rest }) {
+  // One index for both cohorts — building it per cohort would re-walk every
+  // feature table for no gain.
+  const featureIndex = indexFeatureRows(rest.featureRowsByTable ?? {});
+  return Object.fromEntries(
+    ACTIVATION_COHORTS.map((cohort) => [
+      cohort,
+      analyzeActivationLift({
+        ...rest,
+        featureIndex,
+        presentations: presentations.filter((row) => activationCohortOf(row) === cohort),
+      }),
+    ]),
+  );
+}
+
 export function analyzeActivationLift({
   presentations,
   featureRowsByTable,
+  featureIndex: prebuiltFeatureIndex,
   truncatedTables = [],
   reportNow,
   windowMs,
@@ -189,7 +233,7 @@ export function analyzeActivationLift({
     return { ...base, verdict: "incomplete-export", engaged: null, presentedOnly: null };
   }
 
-  const featureIndex = indexFeatureRows(featureRowsByTable);
+  const featureIndex = prebuiltFeatureIndex ?? indexFeatureRows(featureRowsByTable);
   const engagedSummary = summarizeGroup(engaged, featureIndex, windowMs);
   const presentedOnlySummary = summarizeGroup(presentedOnly, featureIndex, windowMs);
   if (mature.length === 0) {
@@ -240,10 +284,11 @@ export function formatActivationLiftReport(
     windowDays,
     limit,
     minGroupSize = MIN_GROUP_SIZE_FOR_A_CLAIM,
+    heading = `[activation-lift] window=${windowDays}d limit=${limit} per table`,
   },
 ) {
   const lines = [
-    `[activation-lift] window=${windowDays}d limit=${limit} per table`,
+    heading,
     "",
     `Presentations: ${analysis.totalPresentations} exported, ${analysis.shown} outcome-instrumented and shown, ${analysis.mature} with a complete ${windowDays}d window.`,
     `  excluded as pre-instrumentation: ${analysis.uninstrumented}`,
@@ -287,6 +332,17 @@ export function formatActivationLiftReport(
   return lines.join("\n");
 }
 
+/** One section per cohort, each with its own verdict (#5621). */
+export function formatActivationLiftReportByCohort(analysisByCohort, options) {
+  const sections = ACTIVATION_COHORTS.map((cohort) =>
+    formatActivationLiftReport(analysisByCohort[cohort], {
+      ...options,
+      heading: `=== ${COHORT_LABELS[cohort]} — window=${options.windowDays}d limit=${options.limit} per table ===`,
+    }),
+  );
+  return sections.join("\n\n");
+}
+
 function parsePositiveNumber(value, name) {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -323,14 +379,14 @@ export function runCli(argv = process.argv.slice(2), env = process.env) {
   const featureRowsByTable = Object.fromEntries(
     FEATURE_TABLES.map((table) => [table, exports[table].rows]),
   );
-  const analysis = analyzeActivationLift({
+  const analysisByCohort = analyzeActivationLiftByCohort({
     presentations: exports.proActivationPresentations.rows,
     featureRowsByTable,
     truncatedTables,
     reportNow: Date.now(),
     windowMs,
   });
-  return formatActivationLiftReport(analysis, { windowDays, limit });
+  return formatActivationLiftReportByCohort(analysisByCohort, { windowDays, limit });
 }
 
 const isMain =

--- a/src/app/pro-activation-controller.ts
+++ b/src/app/pro-activation-controller.ts
@@ -414,9 +414,17 @@ export class ProActivationController implements AppModule {
     if (decision !== 'show') return;
 
     const flowOptions = this.buildFlowOptions();
-    if (!flowOptions) return;
+    const subscriptionKey = deriveSubscriptionKey(subscription);
+    if (!flowOptions || subscriptionKey === null) return;
     void import('@/components/ProActivationChip')
-      .then((module) => module.maybeShowFinishSetupChip(flowOptions))
+      .then((module) =>
+        module.maybeShowFinishSetupChip({
+          ...flowOptions,
+          onlyIfUnactivated: false,
+          expectedActivationKey: subscriptionKey,
+          activationClaimNonce: generateMountClaimNonce(),
+        }),
+      )
       .catch((error) => console.warn('[pro-activation] finish-setup chip failed to load', error));
   }
 

--- a/src/app/pro-activation-controller.ts
+++ b/src/app/pro-activation-controller.ts
@@ -547,8 +547,12 @@ export class ProActivationController implements AppModule {
       const result = await module.openProActivationFlow({
         ...flowOptions,
         onlyIfUnactivated,
-        expectedActivationKey: onlyIfUnactivated ? subscriptionKey : undefined,
-        activationClaimNonce: onlyIfUnactivated ? this.mountNonce : undefined,
+        // Both cohorts carry the identity now (#5621). The markerless path uses
+        // it for its cross-device lease; the day-0 path uses it only to attach
+        // outcomes to a server-side row, which is why day-0 previously ran with
+        // these undefined and left its cohort invisible in Convex.
+        expectedActivationKey: subscriptionKey,
+        activationClaimNonce: this.mountNonce,
       });
       // The interstitial may already be rendered by this point (opened
       // synchronously inside openProActivationFlow before it resolves). If

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -1275,6 +1275,26 @@ async function confirmPresentationWithRetry(
   return false;
 }
 
+function reportActivationPersistenceFailure(
+  error: unknown,
+  action: 'openDay0Presentation' | 'recordOutcome',
+  extra?: Record<string, unknown>,
+): void {
+  // The activation ledger exists to remove a server-side observability blind
+  // spot, so its terminal write failures cannot stop at the user's console.
+  // Keep Sentry lazy (like the finish-setup chip) so this component retains no
+  // static bootstrap dependency, and never surface telemetry failure to the UI.
+  void import('@/bootstrap/sentry-defer')
+    .then((m) => m.enqueueSentryCall((s) => s.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        tags: { component: 'pro-activation', action },
+        ...(extra ? { extra } : {}),
+      },
+    )))
+    .catch(() => {});
+}
+
 function persistActivationOutcomeWithRetry(
   options: ProActivationFlowOptions,
   dependencies: ProActivationFlowDependencies,
@@ -1319,21 +1339,7 @@ function persistActivationOutcomeWithRetry(
         const delay = OUTCOME_WRITE_RETRY_DELAYS_MS[attempt];
         if (delay === undefined) {
           console.warn('[pro-activation] failed to record activation outcome', error);
-          // A permanently failing durable write is the one failure this whole
-          // record exists to rule out: it leaves the account's activation
-          // outcome invisible server-side, which is exactly the blind spot
-          // #5621 is filed about. A browser console line reaches nobody, so
-          // report it. Lazy-imported (like the chip below) to keep this
-          // component free of a static bootstrap import.
-          void import('@/bootstrap/sentry-defer')
-            .then((m) => m.enqueueSentryCall((s) => s.captureException(
-              error instanceof Error ? error : new Error(String(error)),
-              {
-                tags: { component: 'pro-activation', action: 'recordOutcome' },
-                extra: { revision, finalized },
-              },
-            )))
-            .catch(() => {}); // never let telemetry failure surface to the user
+          reportActivationPersistenceFailure(error, 'recordOutcome', { revision, finalized });
           return;
         }
         await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
@@ -1438,22 +1444,30 @@ export async function openProActivationFlow(
   // unreachable. The promise is handed to the outcome writer instead, so
   // snapshots queue behind the row they attach to rather than racing it, and
   // a refusal (ineligible / already finalized) silently drops them.
-  const day0RowReady =
+  const day0OpenRequest =
     !options.onlyIfUnactivated && options.expectedActivationKey && options.activationClaimNonce
-      ? withTimeout(
-          dependencies.openDay0Presentation(
-            options.expectedActivationKey,
-            options.activationClaimNonce,
-          ),
-          dependencies.operationTimeoutMs ?? ACTIVATION_MUTATION_TIMEOUT_MS,
-          'activation-open-day0-presentation',
+      ? dependencies.openDay0Presentation(
+          options.expectedActivationKey,
+          options.activationClaimNonce,
         )
-          .then((status) => status === 'opened')
-          .catch((error) => {
-            console.warn('[pro-activation] failed to open day-0 activation record', error);
-            return false;
-          })
       : undefined;
+  const day0RowReady = day0OpenRequest
+    ?.then((status) => status === 'opened')
+    .catch(() => false);
+  if (day0OpenRequest) {
+    // Observe availability within the normal mutation budget, but keep the raw
+    // promise above as the durable readiness signal. `withTimeout` cannot
+    // cancel its source promise, so a slow successful open can still release
+    // snapshots queued behind it instead of being misclassified as a refusal.
+    void withTimeout(
+      day0OpenRequest,
+      dependencies.operationTimeoutMs ?? ACTIVATION_MUTATION_TIMEOUT_MS,
+      'activation-open-day0-presentation',
+    ).catch((error) => {
+      console.warn('[pro-activation] failed to open day-0 activation record', error);
+      reportActivationPersistenceFailure(error, 'openDay0Presentation');
+    });
+  }
 
   // Holds the brief step's delivery-hour pick across the shell's re-renders.
   const selectedHourRef: DigestHourRef = { hour: null };

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -29,6 +29,7 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import {
   claimProActivationPresentation,
   confirmProActivationPresentation,
+  openProActivationDay0Presentation,
   recordProActivationOutcome,
   type ProActivationOutcomeSnapshot,
 } from '@/services/billing';
@@ -841,6 +842,11 @@ export interface ProActivationFlowDependencies {
     claimNonce: string,
   ) => Promise<'claimed' | 'not_eligible' | 'already_presented' | 'already_claimed'>;
   confirmPresentation: (activationKey: string, claimNonce: string) => Promise<boolean>;
+  /** Day-0 counterpart to claim+confirm; best-effort, never gates the flow (#5621). */
+  openDay0Presentation: (
+    activationKey: string,
+    claimNonce: string,
+  ) => Promise<'opened' | 'already_recorded' | 'not_eligible'>;
   /**
    * Typed against the service's own snapshot rather than a hand-copied shape:
    * the duplicate drifted the moment a bucket was added (#5617), and a stale
@@ -1275,12 +1281,20 @@ function persistActivationOutcomeWithRetry(
   results: readonly ActivationStepResult[],
   revision: number,
   finalized: boolean,
+  /**
+   * Day-0 only: resolves once the row these snapshots attach to exists. `false`
+   * means the server refused it (ineligible, or an earlier session already
+   * finalized), so writing would be rejected anyway — skip quietly.
+   */
+  day0RowReady?: Promise<boolean>,
 ): void {
-  if (!options.onlyIfUnactivated || !options.expectedActivationKey || !options.activationClaimNonce) {
+  if (!options.expectedActivationKey || !options.activationClaimNonce) {
     return;
   }
+  const cohort = options.onlyIfUnactivated ? undefined : ('day0' as const);
   const buckets = buildActivationOutcomeBuckets(results);
   void (async () => {
+    if (day0RowReady && !(await day0RowReady)) return;
     for (let attempt = 0; ; attempt += 1) {
       try {
         await withTimeout(
@@ -1288,6 +1302,7 @@ function persistActivationOutcomeWithRetry(
             options.expectedActivationKey!,
             options.activationClaimNonce!,
             {
+              ...(cohort ? { cohort } : {}),
               confirmedSteps: [...buckets.confirmedSteps],
               skippedSteps: [...buckets.skippedSteps],
               blockedSteps: [...buckets.blockedSteps],
@@ -1343,6 +1358,7 @@ export async function openProActivationFlow(
         : readActivationContext(expectedUserId),
     claimPresentation: claimProActivationPresentation,
     confirmPresentation: confirmProActivationPresentation,
+    openDay0Presentation: openProActivationDay0Presentation,
     recordOutcome: recordProActivationOutcome,
     openInterstitial: openProActivationInterstitial,
     ...injected,
@@ -1417,6 +1433,28 @@ export async function openProActivationFlow(
     }
   }
 
+  // Day-0's counterpart (#5621). Deliberately NOT awaited and never able to
+  // return 'retry': the post-checkout welcome must open even when Convex is
+  // unreachable. The promise is handed to the outcome writer instead, so
+  // snapshots queue behind the row they attach to rather than racing it, and
+  // a refusal (ineligible / already finalized) silently drops them.
+  const day0RowReady =
+    !options.onlyIfUnactivated && options.expectedActivationKey && options.activationClaimNonce
+      ? withTimeout(
+          dependencies.openDay0Presentation(
+            options.expectedActivationKey,
+            options.activationClaimNonce,
+          ),
+          dependencies.operationTimeoutMs ?? ACTIVATION_MUTATION_TIMEOUT_MS,
+          'activation-open-day0-presentation',
+        )
+          .then((status) => status === 'opened')
+          .catch((error) => {
+            console.warn('[pro-activation] failed to open day-0 activation record', error);
+            return false;
+          })
+      : undefined;
+
   // Holds the brief step's delivery-hour pick across the shell's re-renders.
   const selectedHourRef: DigestHourRef = { hour: null };
 
@@ -1438,6 +1476,7 @@ export async function openProActivationFlow(
       results,
       outcomeRevision,
       finalized,
+      day0RowReady,
     );
   };
 

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -188,9 +188,37 @@ export async function confirmProActivationPresentation(
   ) as boolean;
 }
 
+export type ProActivationDay0Outcome = 'opened' | 'already_recorded' | 'not_eligible';
+
+/**
+ * Open the day-0 (post-checkout) activation record (#5621).
+ *
+ * Not a lease: the welcome interstitial opens regardless of this call, which
+ * exists only so the day-0 cohort has a server-side row instead of having to
+ * be reconstructed from Umami sessions. `already_recorded` means an earlier
+ * session already finalized this subscription's row, so outcome writes from
+ * this one are expected to be rejected.
+ */
+export async function openProActivationDay0Presentation(
+  activationKey: string,
+  claimNonce: string,
+): Promise<ProActivationDay0Outcome> {
+  const client = await getConvexClient();
+  const api = await getConvexApi();
+  if (!client || !api) throw new Error('Convex unavailable');
+  await waitForConvexAuth();
+  const result = await client.mutation(
+    (api as any).payments.billing.openProActivationDay0Presentation,
+    { activationKey, claimNonce },
+  ) as { status: ProActivationDay0Outcome };
+  return result.status;
+}
+
 export type ProActivationOutcomeStepId = 'brief' | 'alerts' | 'power';
 
 export interface ProActivationOutcomeSnapshot {
+  /** Absent = the markerless retro backfill's row (#5621). */
+  cohort?: 'day0';
   confirmedSteps: ProActivationOutcomeStepId[];
   skippedSteps: ProActivationOutcomeStepId[];
   /**

--- a/tests/pro-activation-alerts-blocked.test.mts
+++ b/tests/pro-activation-alerts-blocked.test.mts
@@ -174,6 +174,7 @@ async function loadInterstitial(): Promise<InterstitialModule> {
     ['billing-stub', `
       export async function claimProActivationPresentation() { return 'claimed'; }
       export async function confirmProActivationPresentation() { return true; }
+      export async function openProActivationDay0Presentation() { return 'opened'; }
       export async function recordProActivationOutcome() { return true; }
     `],
     ['channels-stub', `

--- a/tests/pro-activation-alerts-blocked.test.mts
+++ b/tests/pro-activation-alerts-blocked.test.mts
@@ -721,6 +721,43 @@ describe('durable activation outcome carries the blocked bucket (#5617)', () => 
     assert.deepEqual(ctx.tags, { component: 'pro-activation', action: 'recordOutcome' });
   });
 
+  it('reports a rejected day-0 row open once without blocking the welcome flow', async () => {
+    installPushState('denied', true);
+    const mod = await loadInterstitial();
+    let captured: Parameters<InterstitialModule['openProActivationInterstitial']>[0] | null = null;
+
+    const opened = await mod.openProActivationFlow(
+      {
+        accountUserId: 'user_alerts',
+        accountEmail: 'pro@worldmonitor.test',
+        isAccountCurrent: () => true,
+        onlyIfUnactivated: false,
+        expectedActivationKey: 'sub_activation_key',
+        activationClaimNonce: 'device-a',
+      },
+      {
+        readContext: async () => activationContext(),
+        openDay0Presentation: async () => {
+          throw new Error('day-0 row rejected');
+        },
+        openInterstitial: (interstitialOptions) => {
+          captured = interstitialOptions;
+        },
+      },
+    );
+    await new Promise<void>((r) => setImmediate(r));
+
+    assert.equal(opened, 'opened', 'durable telemetry failure must not block onboarding');
+    assert.ok(captured, 'the welcome interstitial must still open');
+    const sentry = (globalThis as Record<string, unknown[]>).__alertsSentry!;
+    assert.equal(sentry.length, 1, 'the rejected open must reach Sentry exactly once');
+    const { ctx } = sentry[0] as { ctx: { tags: Record<string, string> } };
+    assert.deepEqual(ctx.tags, {
+      component: 'pro-activation',
+      action: 'openDay0Presentation',
+    });
+  });
+
   it('sends an explicit empty blockedSteps when nothing was blocked', async () => {
     const { interstitial, writes } = await captureOutcomeWrites();
 

--- a/tests/pro-activation-controller.test.mts
+++ b/tests/pro-activation-controller.test.mts
@@ -8,7 +8,12 @@ import { pathToFileURL } from 'node:url';
 
 // Zero-import decision leaf — safe to import directly under `tsx --test`, and
 // the only honest source for the account-key hash the marker must carry.
-import { deriveActivationAccountKey, PENDING_MARKER_KEY } from '@/services/pro-activation-state';
+import {
+  computeFireOnceRecord,
+  deriveActivationAccountKey,
+  fireOnceStorageKey,
+  PENDING_MARKER_KEY,
+} from '@/services/pro-activation-state';
 
 type GlobalSnapshot = { exists: boolean; value: unknown };
 
@@ -44,6 +49,7 @@ const stateKeys = [
   '__activationOpenGate',
   '__activationCloseCalls',
   '__activationFlowOptions',
+  '__activationChipOptions',
 ] as const;
 const stateSnapshots = new Map(stateKeys.map((key) => [key, snapshotGlobal(key)]));
 
@@ -110,7 +116,11 @@ async function loadController(): Promise<typeof import('../src/app/pro-activatio
         globalThis.__activationCloseCalls = (globalThis.__activationCloseCalls ?? 0) + 1;
       }
     `],
-    ['chip-stub', 'export function maybeShowFinishSetupChip() {}'],
+    ['chip-stub', `
+      export function maybeShowFinishSetupChip(options) {
+        globalThis.__activationChipOptions.push(options);
+      }
+    `],
   ]);
   const aliases = new Map([
     ['@/services/analytics', 'analytics-stub'],
@@ -190,6 +200,7 @@ function installBrowserState(options: { fastTimers?: boolean } = {}): void {
     __activationOpenGate: null as Promise<void> | null,
     __activationCloseCalls: 0,
     __activationFlowOptions: [] as unknown[],
+    __activationChipOptions: [] as unknown[],
   });
 }
 
@@ -696,5 +707,67 @@ describe('ProActivationController activation-record identity (#5621)', () => {
     assert.equal(retro.onlyIfUnactivated, true);
     assert.equal(retro.expectedActivationKey, 'opaque-user-retro-identity-subscription');
     assert.equal(typeof retro.activationClaimNonce, 'string');
+  });
+
+  it('gives each later Finish Setup flow fresh day-0 identity for the current subscription', async () => {
+    installBrowserState();
+    const userId = 'user-chip-identity';
+    const subscriptionKey = `opaque-${userId}-subscription`;
+    installEligibleMarkerlessAccount(userId);
+    (globalThis as unknown as { window: { localStorage: Storage } }).window.localStorage.setItem(
+      fireOnceStorageKey(deriveActivationAccountKey(userId)!),
+      JSON.stringify(computeFireOnceRecord(subscriptionKey, Date.now())),
+    );
+    const { ProActivationController } = await loadController();
+    const ctx = {
+      isDestroyed: false,
+      isDesktopApp: false,
+      container: { dispatchEvent() {} },
+      unifiedSettings: { open() {} },
+    };
+    const controllers = [
+      new ProActivationController(ctx as never, {
+        reloadPending: false,
+        openAiAnalyst() {},
+      }),
+      new ProActivationController(ctx as never, {
+        reloadPending: false,
+        openAiAnalyst() {},
+      }),
+    ];
+
+    try {
+      for (const controller of controllers) {
+        controller.init();
+        await (controller as unknown as { evaluate(): Promise<void> }).evaluate();
+      }
+      const captured = (globalThis as unknown as { __activationChipOptions: unknown[] })
+        .__activationChipOptions;
+      for (let attempt = 0; attempt < 40 && captured.length < 2; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(captured.length, 2, 'each later session must offer the Finish Setup chip');
+
+      const [first, second] = captured as Array<Record<string, unknown>>;
+      for (const options of [first, second]) {
+        assert.equal(options.onlyIfUnactivated, false);
+        assert.equal(options.expectedActivationKey, subscriptionKey);
+        assert.equal(typeof options.activationClaimNonce, 'string');
+        assert.notEqual(options.activationClaimNonce, '');
+      }
+      assert.notEqual(
+        first.activationClaimNonce,
+        (controllers[0] as unknown as { mountNonce: string }).mountNonce,
+        'chip-triggered flows must not reuse the controller mount nonce',
+      );
+      assert.notEqual(
+        second.activationClaimNonce,
+        first.activationClaimNonce,
+        'a later chip flow must get a fresh takeover nonce',
+      );
+    } finally {
+      ctx.isDestroyed = true;
+      for (const controller of controllers) controller.destroy();
+    }
   });
 });

--- a/tests/pro-activation-controller.test.mts
+++ b/tests/pro-activation-controller.test.mts
@@ -6,6 +6,10 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+// Zero-import decision leaf — safe to import directly under `tsx --test`, and
+// the only honest source for the account-key hash the marker must carry.
+import { deriveActivationAccountKey, PENDING_MARKER_KEY } from '@/services/pro-activation-state';
+
 type GlobalSnapshot = { exists: boolean; value: unknown };
 
 function snapshotGlobal(name: string): GlobalSnapshot {
@@ -615,5 +619,82 @@ describe('ProActivationController power-step surface wiring', () => {
       'without mcpAccess the power step must drop the pointer entirely',
     );
     assert.equal(options.openApiKeys, undefined, 'and must not fall back to the API-keys surface');
+  });
+});
+
+describe('ProActivationController activation-record identity (#5621)', () => {
+  /** Drive one mount for the requested cohort and return the flow options. */
+  async function captureCohortOptions(
+    cohort: 'day0' | 'markerless',
+    userId: string,
+  ): Promise<Record<string, unknown>> {
+    installBrowserState();
+    installEligibleMarkerlessAccount(userId);
+    if (cohort === 'day0') {
+      // A live checkout-return marker for THIS account takes the marker branch
+      // of decideActivationMount, which mounts with onlyIfUnactivated: false.
+      (globalThis as unknown as { window: { localStorage: Storage } }).window.localStorage.setItem(
+        PENDING_MARKER_KEY,
+        JSON.stringify({
+          createdAt: Date.now(),
+          productId: 'pdt_0Nbtt71uObulf7fGXhQup',
+          accountKey: deriveActivationAccountKey(userId),
+        }),
+      );
+    }
+    const { ProActivationController } = await loadController();
+    const ctx = {
+      isDestroyed: false,
+      isDesktopApp: false,
+      container: { dispatchEvent() {} },
+      unifiedSettings: { open() {} },
+    };
+    const controller = new ProActivationController(ctx as never, {
+      reloadPending: false,
+      openAiAnalyst() {},
+    });
+    try {
+      controller.init();
+      await (controller as unknown as { evaluate(): Promise<void> }).evaluate();
+      const captured = (globalThis as unknown as { __activationFlowOptions: unknown[] })
+        .__activationFlowOptions;
+      for (let attempt = 0; attempt < 40 && captured.length === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(captured.length, 1, `the ${cohort} cohort must mount the flow exactly once`);
+      return captured[0] as Record<string, unknown>;
+    } finally {
+      ctx.isDestroyed = true;
+      controller.destroy();
+    }
+  }
+
+  it('hands the day-0 cohort the same subscription identity the retro cohort gets', async () => {
+    // Day-0 used to mount with expectedActivationKey/activationClaimNonce
+    // undefined, which made persistActivationOutcomeWithRetry return early and
+    // left the entire post-checkout cohort absent from Convex (#5621) — the
+    // exact blind spot the #5600 investigation had to work around.
+    const day0 = await captureCohortOptions('day0', 'user-day0-identity');
+
+    assert.equal(day0.onlyIfUnactivated, false, 'a live checkout marker is the day-0 cohort');
+    assert.equal(
+      day0.expectedActivationKey,
+      'opaque-user-day0-identity-subscription',
+      'day-0 must carry the subscription identity its outcome row is keyed by',
+    );
+    assert.equal(
+      typeof day0.activationClaimNonce,
+      'string',
+      'day-0 must carry a session nonce so its outcome writes are attributable',
+    );
+    assert.notEqual(day0.activationClaimNonce, '');
+  });
+
+  it('still hands the markerless cohort its lease identity', async () => {
+    const retro = await captureCohortOptions('markerless', 'user-retro-identity');
+
+    assert.equal(retro.onlyIfUnactivated, true);
+    assert.equal(retro.expectedActivationKey, 'opaque-user-retro-identity-subscription');
+    assert.equal(typeof retro.activationClaimNonce, 'string');
   });
 });

--- a/tests/report-activation-lift.test.mjs
+++ b/tests/report-activation-lift.test.mjs
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  activationCohortOf,
   analyzeActivationLift,
+  analyzeActivationLiftByCohort,
   fetchTable,
   formatActivationLiftReport,
+  formatActivationLiftReportByCohort,
   indexFeatureRows,
   runCli,
 } from "../scripts/report-activation-lift.mjs";
@@ -233,6 +236,88 @@ test("analysis refuses capped exports before rates and enforces the mature sampl
   assert.equal(complete.engaged.n, 29);
   assert.equal(complete.presentedOnly.n, 30);
   assert.equal(complete.verdict, "below-sample-floor");
+});
+
+test("cohorts are analyzed and reported separately, never pooled (#5621)", () => {
+  const observationStartedAt = NOW - WINDOW_MS;
+  const presentations = [
+    // Day-0: engaged, and adopted a feature inside the window.
+    {
+      userId: "day0-engaged",
+      cohort: "day0",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: ["brief"],
+      exitedAt: observationStartedAt,
+    },
+    // Day-0: the #5600 shape — shown, every step failed, nothing adopted.
+    {
+      userId: "day0-all-writes-failed",
+      cohort: "day0",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: [],
+      failedSteps: ["brief", "alerts"],
+      exitedAt: observationStartedAt,
+    },
+    // Retro rows carry no `cohort` field at all — including every row written
+    // before day-0 instrumentation existed.
+    {
+      userId: "retro-engaged",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: ["alerts"],
+      exitedAt: observationStartedAt,
+    },
+    {
+      userId: "retro-presented-only",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: [],
+      exitedAt: observationStartedAt,
+    },
+  ];
+  const featureRowsByTable = {
+    ...emptyFeatureRows(),
+    notificationChannels: [
+      { userId: "day0-engaged", verified: true, linkedAt: observationStartedAt + DAY_MS },
+      { userId: "retro-presented-only", verified: true, linkedAt: observationStartedAt + DAY_MS },
+    ],
+  };
+
+  assert.equal(activationCohortOf({ cohort: "day0" }), "day0");
+  assert.equal(activationCohortOf({}), "retro");
+
+  const byCohort = analyzeActivationLiftByCohort({
+    presentations,
+    featureRowsByTable,
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+    minGroupSize: 1,
+  });
+
+  // Each cohort sees only its own rows, so neither total can include the other.
+  assert.equal(byCohort.day0.totalPresentations, 2);
+  assert.equal(byCohort.retro.totalPresentations, 2);
+  assert.equal(byCohort.day0.engaged.n, 1);
+  assert.equal(byCohort.day0.presentedOnly.n, 1);
+  assert.equal(byCohort.retro.engaged.n, 1);
+  assert.equal(byCohort.retro.presentedOnly.n, 1);
+
+  // The two cohorts have OPPOSITE lifts here; pooling them would cancel out to
+  // zero and report "no effect" for both.
+  assert.equal(byCohort.day0.lift, 1);
+  assert.equal(byCohort.retro.lift, -1);
+
+  const report = formatActivationLiftReportByCohort(byCohort, {
+    windowDays: 14,
+    limit: 20_000,
+    minGroupSize: 1,
+  });
+  assert.match(report, /=== Day-0 \(post-checkout welcome\) — window=14d/);
+  assert.match(report, /=== Retro \(markerless first-cycle backfill\) — window=14d/);
+  assert.match(report, /100\.0 percentage points higher/);
+  assert.match(report, /100\.0 percentage points lower/);
 });
 
 test("feature indexing performs one pass and excludes inactive credentials", () => {


### PR DESCRIPTION
## Summary

Day-0 Pro onboarding now produces the same durable activation evidence as the retro/backfill flow without consuming or suppressing that later recovery path. The activation report can therefore compare the newly subscribed and mid-cycle cohorts directly instead of reconstructing day-0 outcomes from unrelated tables.

The two cohorts share `proActivationPresentations`, but they do not share identity or lease state: an absent `cohort` remains the existing retro row, while `cohort: "day0"` is a separate row for the post-checkout flow. Day-0 delivery stays best-effort from the user's perspective—the welcome UI still opens during Convex failure—but successful late writes, abandoned-session takeovers, and later Finish Setup reopens now retain correct durable ownership and outcomes.

## Design decisions

- **Cohort isolation instead of a shared lease.** A compound `(subscriptionId, cohort)` index makes it structurally impossible for a day-0 row to consume the retro claim that affected subscribers may still need.
- **No backfill.** Existing rows have no `cohort` field and continue to mean retro, so historical classification and mixed-deploy clients remain compatible.
- **Clean takeover semantics.** A fresh day-0 nonce can supersede an unfinished row, resetting its presentation time, outcome buckets, revision, and update timestamp. Finalized rows remain immutable.
- **Durability is not a UI gate.** The welcome flow never waits for the row open, but queued outcomes follow the raw request so a server commit that finishes after the client observation deadline is not discarded.
- **Separate analysis.** The report never pools day-0 and retro lift; those populations have different baseline tenure and opposite results could otherwise cancel into a misleading aggregate.

## Acceptance

| Criterion | Result |
|---|---|
| Day-0 activation produces a server row with step outcomes | `openProActivationDay0Presentation` creates the day-0 row and cohort-tagged snapshots persist every outcome bucket |
| Day-0 cannot block a legitimate retro re-claim | Separate cohort rows and index lookups keep the retro lease independent |
| Reporting separates the cohorts | `report-activation-lift.mjs` analyzes and formats one verdict per cohort |
| Browser regression coverage | The Pro activation E2E suite covers successful, refused, failed, hung, and late-success row opens |

## Review hardening

The review pass found and fixed four edge cases before shipping:

- a replacement session could inherit an abandoned session's outcome buckets;
- a Convex open that committed after the timeout could leave queued outcomes permanently dropped;
- open-row failures reached only the user's console rather than Sentry;
- a later Finish Setup chip reopened without a subscription key or fresh takeover nonce.

All actionable findings were applied. File-size-only refactor suggestions were independently rejected because no project standard requires them and the suites share their existing domain fixtures.

## Verification

The regressions were proven red before the production fixes:

| Regression | Before | After |
|---|---|---|
| Abandoned-row takeover | retained the prior `presentedAt` and outcome snapshot | fresh session metadata and empty outcome state |
| Late successful open | 0 queued outcomes persisted | progress and finalized revisions both persisted |
| Open failure telemetry | 0 Sentry captures | exactly 1 tagged capture; welcome UI still opened |
| Finish Setup reopen | missing cohort identity | current subscription key plus a fresh per-flow nonce |

Current gates:

- `npm run test:convex` — 1,011/1,011 passed
- `e2e/pro-activation.spec.ts` — 31/31 passed
- focused activation/report bundle — 159/159 passed
- `npm run test:data` — passed
- `npm run typecheck:all` — passed
- Biome on all 11 changed files — passed
- pre-push typechecks, boundaries, safe HTML, Sentry coverage, premium-fetch parity, changed tests, edge tests, and version sync — passed

## Post-Deploy Monitoring & Validation

**Window and owner:** Billing/activation owner for the first 24 hours after the Convex and web deployments are live.

**Pre-deploy / rollout checks**

1. Deploy the Convex schema and mutations before, or atomically with, the web client. An old schema rejects `cohort: "day0"` documents.
2. Capture a read-only baseline:
   `npx convex data proActivationPresentations --prod --order desc --format jsonl --limit 200`
3. Confirm existing rows without `cohort` remain present; do not backfill them.

**Healthy signals**

- New post-checkout presentations contain `cohort: "day0"`, a nonce, `presentedAt`, and monotonic outcome revisions.
- Retro rows continue to omit `cohort`; a subscription may legitimately have one row in each cohort.
- `node --env-file=.env.local scripts/report-activation-lift.mjs` emits independent `[day0]` and `[retro]` verdicts without capped-export or insufficient-data errors once samples mature.
- Sentry remains quiet for `component=pro-activation` with actions `openDay0Presentation` and `recordOutcome`.

**Failure signals / mitigation trigger**

- Trigger mitigation on sustained Sentry failures, day-0 rows with no outcomes after the observation window, duplicate rows for one `(subscriptionId, cohort)`, or a retro-eligibility regression after a day-0 row exists.
- A slow-open timeout can be followed by successful outcomes; investigate the final row before treating the timeout alone as data loss.

**Forward-only rollback**

- Stop the new day-0 client writes first, but retain the optional `cohort` field and `by_subscription_cohort` index.
- Revert behavior while keeping schema compatibility; do not restore the old schema/index after any day-0 row exists.
- Do not delete day-0 rows to make an old schema deployable—those rows are the telemetry this change exists to preserve.

Closes #5621

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
