### PR TITLE
feat(activation): make the push-denial cohort readable, not just recorded (#5617)

### DIFF
--- a/scripts/report-activation-lift.mjs
+++ b/scripts/report-activation-lift.mjs
@@ -176,6 +176,15 @@ export function analyzeActivationLift({
   const engaged = mature.filter((row) => (row.confirmedSteps?.length ?? 0) > 0);
   const presentedOnly = mature.filter((row) => (row.confirmedSteps?.length ?? 0) === 0);
 
+  // Push-denial cohort (#5617). `blockedSteps` records a step the BROWSER
+  // refused, which before #5617 was indistinguishable from a voluntary skip in
+  // this table — so this count could not be produced at all. Rows written by a
+  // client too old to report the bucket leave it ABSENT rather than empty, and
+  // those are excluded from the denominator instead of being counted as "no
+  // denial": they never looked, so they cannot testify either way.
+  const denialObservable = mature.filter((row) => Array.isArray(row.blockedSteps));
+  const denied = denialObservable.filter((row) => row.blockedSteps.length > 0);
+
   const base = {
     totalPresentations: presentations.length,
     shown: shown.length,
@@ -183,6 +192,18 @@ export function analyzeActivationLift({
     mature: mature.length,
     immature: immature.length,
     incompleteExits: incompleteExits.length,
+    // A denial is a permanent dead end — the browser never re-prompts once
+    // permission is `denied` — so this is the population for whom re-prompting
+    // is worth exactly nothing.
+    pushDenial: {
+      observable: denialObservable.length,
+      denied: denied.length,
+      unreportable: mature.length - denialObservable.length,
+      rate:
+        denialObservable.length > 0
+          ? Number((denied.length / denialObservable.length).toFixed(4))
+          : null,
+    },
     truncatedTables: [...truncatedTables],
   };
   if (truncatedTables.length > 0) {
@@ -249,6 +270,12 @@ export function formatActivationLiftReport(
     `  excluded as pre-instrumentation: ${analysis.uninstrumented}`,
     `  excluded as immature: ${analysis.immature}`,
     `  mature sessions without a recorded exit: ${analysis.incompleteExits} (included from durable presentation/progress state)`,
+    // Rendered even at 0 so the line's absence always means "old build", never
+    // "no denials" (#5617).
+    `Push denials: ${analysis.pushDenial.denied}/${analysis.pushDenial.observable}` +
+      `${analysis.pushDenial.rate === null ? "" : ` (${(analysis.pushDenial.rate * 100).toFixed(1)}%)`}` +
+      ` — permanent dead ends; re-prompting these accounts is worth nothing.` +
+      `${analysis.pushDenial.unreportable > 0 ? ` [${analysis.pushDenial.unreportable} row(s) predate the bucket and cannot testify]` : ""}`,
   ];
 
   if (analysis.verdict === "incomplete-export") {

--- a/tests/pro-activation-alerts-blocked.test.mts
+++ b/tests/pro-activation-alerts-blocked.test.mts
@@ -557,6 +557,45 @@ describe('activation interstitial blocked transition (#5609)', () => {
     );
   });
 
+  // `defaultOutcome` classifies steps the user has NOT reached yet, and every
+  // other test here mounts a single step, so this look-ahead never ran. It
+  // matters: permission is already denied at mount, so the alerts step is
+  // genuinely blocked before the subscriber ever sees it, and a progress
+  // snapshot written while they are still on step 1 must say so rather than
+  // pre-labelling it a voluntary skip.
+  it('classifies a not-yet-reached mount-blocked step as blocked in progress snapshots', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const dom = activeDom!;
+    const progress: Array<Array<{ id: string; outcome: string }>> = [];
+    mod.openProActivationInterstitial({
+      steps: [
+        { id: 'brief', state: 'confirmable' },
+        { id: 'alerts', state: 'blocked' },
+        { id: 'power', state: 'confirmable' },
+      ],
+      accountEmail: 'pro@worldmonitor.test',
+      onConfirmStep: (async () => 'verified') as never,
+      onSkipStep: () => {},
+      onBlockStep: () => {},
+      onProgress: (results) => progress.push(results as never),
+      onExit: () => {},
+    });
+    activeClose = mod.closeProActivationInterstitial;
+
+    // Confirm step 1 only. Steps 2 and 3 are still unvisited.
+    const primary = dom.document.body.querySelector('.pro-activation-primary');
+    primary!.dispatchEvent(new Event('click'));
+    await new Promise<void>((r) => setImmediate(r));
+
+    assert.deepEqual(progress[0], [
+      { id: 'brief', outcome: 'confirmed' },
+      { id: 'alerts', outcome: 'blocked' },
+      { id: 'power', outcome: 'skipped' },
+    ]);
+  });
+
   it('keeps the pre-denied copy for a step already blocked at mount', async () => {
     installPushState('denied', true);
     activeDom = installDom();

--- a/tests/report-activation-lift.test.mjs
+++ b/tests/report-activation-lift.test.mjs
@@ -247,3 +247,82 @@ test("feature indexing performs one pass and excludes inactive credentials", () 
   assert.equal(index.userApiKeys.has("user-1"), false);
   assert.equal(index.userApiKeys.size, 10_000);
 });
+
+// #5617. Before the blockedSteps bucket existed, a browser-refused step was
+// byte-identical to a voluntary skip in this table, so this report could not
+// produce a denial count at all. The cohort matters because a denial is a
+// permanent dead end -- the browser never re-prompts once permission is
+// `denied` -- so it is exactly the population for whom re-prompting is worth
+// nothing.
+test("push-denial cohort is sized, and clients that could not report are excluded from the rate", () => {
+  const observationStartedAt = NOW - WINDOW_MS;
+  const presentations = [
+    {
+      userId: "denied",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: ["brief"],
+      skippedSteps: [],
+      blockedSteps: ["alerts"],
+      exitedAt: observationStartedAt,
+    },
+    {
+      userId: "looked-and-found-none",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: ["brief"],
+      skippedSteps: ["alerts"],
+      blockedSteps: [],
+      exitedAt: observationStartedAt,
+    },
+    {
+      // Written by a client too old to know the bucket: absent, not empty.
+      // Counting it as "no denial" would silently deflate the rate.
+      userId: "could-not-report",
+      presentedAt: observationStartedAt,
+      outcomeTrackingVersion: 1,
+      confirmedSteps: [],
+      skippedSteps: ["alerts"],
+      exitedAt: observationStartedAt,
+    },
+  ];
+
+  const analysis = analyzeActivationLift({
+    presentations,
+    featureRowsByTable: emptyFeatureRows(),
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+    minGroupSize: 1,
+  });
+
+  assert.deepEqual(analysis.pushDenial, {
+    observable: 2,
+    denied: 1,
+    unreportable: 1,
+    rate: 0.5,
+  });
+});
+
+test("push-denial rate is null rather than 0 when no row can testify", () => {
+  const observationStartedAt = NOW - WINDOW_MS;
+  const analysis = analyzeActivationLift({
+    presentations: [
+      {
+        userId: "legacy-only",
+        presentedAt: observationStartedAt,
+        outcomeTrackingVersion: 1,
+        confirmedSteps: [],
+        exitedAt: observationStartedAt,
+      },
+    ],
+    featureRowsByTable: emptyFeatureRows(),
+    reportNow: NOW,
+    windowMs: WINDOW_MS,
+    minGroupSize: 1,
+  });
+
+  // A 0% denial rate and "nobody could tell us" are different claims.
+  assert.equal(analysis.pushDenial.rate, null);
+  assert.equal(analysis.pushDenial.observable, 0);
+  assert.equal(analysis.pushDenial.unreportable, 1);
+});


### PR DESCRIPTION
Follow-up to #5629 (merged). Same issue, #5617 — the half that PR left write-only.

## Why this exists

#5629 added `blockedSteps` as a fourth durable outcome bucket, correctly and with tests. But an agent-native review pass afterwards found that `blockedSteps` had **zero read paths**: grep hit only the schema, the write mutation, the client, and tests. No query, script, or docs page read it back.

So neither question #5617 exists to answer was actually answerable by any code that shipped:

> sizing the push-permission-denial population, and deciding whether re-prompting an account is worth anything

`scripts/report-activation-lift.mjs` already exports `proActivationPresentations` and buckets rows by `confirmedSteps`/`skippedSteps` for exactly this class of question. It just could not see a denial — the same conflation #5617 fixed one layer down, still present in the reporting layer.

## What changed

The lift report now sizes the push-denial cohort. Two judgment calls worth review:

- **Rows that cannot testify are excluded from the denominator, not counted as "no denial".** A client too old to report the bucket leaves `blockedSteps` **absent** (not `[]`) — #5629 made the mutation patch the raw arg precisely so that distinction survives. Such a client classified denials as skips, so folding it into the denominator would silently deflate the rate.
- **`rate` is `null`, not `0`, when nothing can testify.** "0% denied" and "nobody could tell us" are different claims, and a reader must not be able to confuse them.

The header line renders even at zero, so its absence always means "old build" rather than "no denials".

Also closes the last open review gap from #5629: `defaultOutcome`'s look-ahead classification of a *not-yet-reached* mount-blocked step had no coverage, because every other shell test mounts a single step. A three-step test now drives it through the real state machine and pins that a progress snapshot written while the subscriber is still on step 1 already reports the alerts step as `blocked`.

## Verification

- 23/23 in the two touched suites; `typecheck` and `biome` clean; rebased onto and verified against merged `main`.
- Mutations 16 and 17 verified red: reverting the look-ahead to `skipped`, and counting unreportable rows as "no denial".

## Still open (not in this PR)

There is no **per-account** read path — the issue's second question ("is re-prompting THIS account worth anything") still needs an ad-hoc query. `inspectCustomerOwnership` (`convex/payments/billing.ts`) is the established pattern: an `internalQuery` with a documented `npx convex run --prod` recipe. That is a new API surface, so I have not added it unasked; say the word and it is a small follow-up.

https://claude.ai/code/session_011wvTSMvKG7hLkJgRezBJFi