### PR TITLE
fix(activation): harden day-0 outcome ownership

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -5898,7 +5898,7 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
 
     const opened = await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
-      { activationKey, claimNonce: "day0-tab" },
+      { activationKey, claimNonce: "day0-tab", sessionStartedAt: NOW },
     );
     expect(opened.status).toBe("opened");
 
@@ -5918,7 +5918,7 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
     // Day-0 ran and every step failed — the exact #5600 cohort.
     await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
-      { activationKey, claimNonce: "day0-tab" },
+      { activationKey, claimNonce: "day0-tab", sessionStartedAt: NOW },
     );
     await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.recordProActivationOutcome,
@@ -5962,7 +5962,7 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
 
     await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
-      { activationKey, claimNonce: "day0-tab" },
+      { activationKey, claimNonce: "day0-tab", sessionStartedAt: NOW },
     );
     await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.claimProActivationPresentation,
@@ -6047,7 +6047,7 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
 
     await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
-      { activationKey, claimNonce: "first-tab" },
+      { activationKey, claimNonce: "first-tab", sessionStartedAt: NOW },
     );
     await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.recordProActivationOutcome,
@@ -6070,7 +6070,11 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
     vi.setSystemTime(NOW + 1_000);
     const retaken = await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
-      { activationKey, claimNonce: "second-tab" },
+      {
+        activationKey,
+        claimNonce: "second-tab",
+        sessionStartedAt: NOW + 1_000,
+      },
     );
     expect(retaken.status).toBe("opened");
     const retakenRows = await readCohort(t, activationKey, "day0");
@@ -6105,12 +6109,159 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
     // existing record instead of resetting the session that already exited.
     const afterExit = await t.withIdentity(IDENTITY).mutation(
       api.payments.billing.openProActivationDay0Presentation,
-      { activationKey, claimNonce: "third-tab" },
+      {
+        activationKey,
+        claimNonce: "third-tab",
+        sessionStartedAt: NOW + 2_000,
+      },
     );
     expect(afterExit.status).toBe("already_recorded");
     const [row] = await readCohort(t, activationKey, "day0");
     expect(row?.claimNonce).toBe("second-tab");
     expect(row?.confirmedSteps).toEqual(["brief"]);
+  });
+
+  test("an older or legacy delayed open cannot erase a newer session's progress", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_stale_open");
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      {
+        activationKey,
+        claimNonce: "newer-tab",
+        sessionStartedAt: NOW + 2_000,
+      },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "newer-tab",
+        cohort: "day0" as const,
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        blockedSteps: ["alerts"],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    );
+
+    // Network delay delivers an older tab's open after the newer owner has
+    // already persisted progress. Arrival order must not reset ownership.
+    const older = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      {
+        activationKey,
+        claimNonce: "older-tab",
+        sessionStartedAt: NOW + 1_000,
+      },
+    );
+    expect(older.status).toBe("superseded");
+
+    // A cached #5626 client has no explicit order. Mixed-deploy order 0 keeps
+    // it below every ordered session even when its nonce wins the tie-break.
+    const legacy = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "zzzz-legacy-tab" },
+    );
+    expect(legacy.status).toBe("superseded");
+
+    const [row] = await readCohort(t, activationKey, "day0");
+    expect(row?.claimNonce).toBe("newer-tab");
+    expect(row?.sessionStartedAt).toBe(NOW + 2_000);
+    expect(row?.confirmedSteps).toEqual(["brief"]);
+    expect(row?.blockedSteps).toEqual(["alerts"]);
+    expect(row?.outcomeRevision).toBe(1);
+  });
+
+  test("equal-time sessions converge on one deterministic nonce winner", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_equal_time");
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      {
+        activationKey,
+        claimNonce: "equal-a",
+        sessionStartedAt: NOW,
+      },
+    );
+    const winner = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      {
+        activationKey,
+        claimNonce: "equal-b",
+        sessionStartedAt: NOW,
+      },
+    );
+    expect(winner.status).toBe("opened");
+
+    const loserReplay = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      {
+        activationKey,
+        claimNonce: "equal-a",
+        sessionStartedAt: NOW,
+      },
+    );
+    expect(loserReplay.status).toBe("superseded");
+
+    const [row] = await readCohort(t, activationKey, "day0");
+    expect(row?.claimNonce).toBe("equal-b");
+    expect(row?.sessionStartedAt).toBe(NOW);
+  });
+
+  test("legacy sessions cannot displace a different unfinished legacy owner", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_legacy_owner");
+
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "legacy-owner" },
+    );
+    await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.recordProActivationOutcome,
+      {
+        activationKey,
+        claimNonce: "legacy-owner",
+        cohort: "day0" as const,
+        confirmedSteps: ["brief"],
+        skippedSteps: [],
+        failedSteps: [],
+        revision: 1,
+        finalized: false,
+      },
+    );
+
+    const delayed = await t.withIdentity(IDENTITY).mutation(
+      api.payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce: "zzzz-delayed-legacy" },
+    );
+    expect(delayed.status).toBe("superseded");
+
+    const [row] = await readCohort(t, activationKey, "day0");
+    expect(row?.claimNonce).toBe("legacy-owner");
+    expect(row?.confirmedSteps).toEqual(["brief"]);
+    expect(row?.outcomeRevision).toBe(1);
+  });
+
+  test("day-0 session order rejects invalid or implausibly future values", async () => {
+    const t = convexTest(schema, modules);
+    const activationKey = await seedProSubscription(t, "activation_day0_order_validation");
+
+    for (const sessionStartedAt of [0, -1, 1.5, Date.now() + 6 * 60 * 1000]) {
+      await expect(t.withIdentity(IDENTITY).mutation(
+        api.payments.billing.openProActivationDay0Presentation,
+        {
+          activationKey,
+          claimNonce: `invalid-${sessionStartedAt}`,
+          sessionStartedAt,
+        },
+      )).rejects.toThrow(/positive safe integer within the allowed future clock skew/);
+    }
+    expect(await readCohort(t, activationKey, "day0")).toHaveLength(0);
   });
 
   test("day-0 records nothing for another user's or a non-Pro subscription", async () => {
@@ -6134,7 +6285,7 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
     for (const activationKey of [foreignKey, apiKey]) {
       const result = await t.withIdentity(IDENTITY).mutation(
         api.payments.billing.openProActivationDay0Presentation,
-        { activationKey, claimNonce: "day0-tab" },
+        { activationKey, claimNonce: "day0-tab", sessionStartedAt: NOW },
       );
       expect(result.status).toBe("not_eligible");
       expect(await readCohort(t, activationKey, "day0")).toHaveLength(0);

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -762,6 +762,7 @@ export const confirmProActivationPresentation = mutation({
 // mutation and schema so their accepted step set cannot drift from this bound.
 const MAX_PRO_ACTIVATION_OUTCOME_REVISION =
   proActivationStepIdValidator.members.length + 2;
+const MAX_PRO_ACTIVATION_SESSION_FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 /**
  * Open the day-0 (post-checkout) activation record (#5621).
@@ -775,11 +776,18 @@ const MAX_PRO_ACTIVATION_OUTCOME_REVISION =
  * Ownership moves to the newest session because only one un-finalized day-0
  * row exists per subscription; a session that already exited is frozen and
  * takes precedence over a late re-open (e.g. the finish-setup chip).
+ * Sessions are ordered by their client-captured start time, then by nonce for
+ * a deterministic equal-time tie. That total order prevents an older delayed
+ * request from erasing a newer session's progress and cannot oscillate when
+ * two independent clients start in the same millisecond. During mixed deploys,
+ * a client without sessionStartedAt may create or replay its own row but cannot
+ * displace a different owner; every explicitly ordered session outranks it.
  */
 export const openProActivationDay0Presentation = mutation({
   args: {
     activationKey: v.id("subscriptions"),
     claimNonce: v.string(),
+    sessionStartedAt: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
@@ -798,6 +806,19 @@ export const openProActivationDay0Presentation = mutation({
     }
 
     const now = Date.now();
+    if (
+      args.sessionStartedAt !== undefined &&
+      (
+        !Number.isSafeInteger(args.sessionStartedAt) ||
+        args.sessionStartedAt <= 0 ||
+        args.sessionStartedAt > now + MAX_PRO_ACTIVATION_SESSION_FUTURE_SKEW_MS
+      )
+    ) {
+      throw new ConvexError(
+        "activation session start must be a positive safe integer within the allowed future clock skew",
+      );
+    }
+
     const existing = await activationPresentationForCohort(ctx, args.activationKey, "day0");
     if (existing === null) {
       await ctx.db.insert("proActivationPresentations", {
@@ -806,6 +827,9 @@ export const openProActivationDay0Presentation = mutation({
         cohort: "day0",
         claimNonce: args.claimNonce,
         claimedAt: now,
+        ...(args.sessionStartedAt !== undefined
+          ? { sessionStartedAt: args.sessionStartedAt }
+          : {}),
         // Day-0 has no confirm handshake, so presentation is recorded here —
         // before the interstitial renders — to keep a subscriber who closes
         // the tab immediately inside the cohort instead of invisible.
@@ -817,13 +841,57 @@ export const openProActivationDay0Presentation = mutation({
     if (existing.exitedAt !== undefined) {
       return { status: "already_recorded" as const };
     }
+    if (existing.claimNonce === args.claimNonce) {
+      if (
+        existing.sessionStartedAt !== undefined &&
+        args.sessionStartedAt !== undefined &&
+        existing.sessionStartedAt !== args.sessionStartedAt
+      ) {
+        throw new ConvexError(
+          "activation session nonce cannot change its start order",
+        );
+      }
+      // Mixed-deploy compatibility: attach the explicit order to an unfinished
+      // row opened by this same session before the field was deployed.
+      if (
+        existing.sessionStartedAt === undefined &&
+        args.sessionStartedAt !== undefined
+      ) {
+        await ctx.db.patch(existing._id, {
+          sessionStartedAt: args.sessionStartedAt,
+        });
+      }
+      return { status: "opened" as const };
+    }
     if (existing.claimNonce !== args.claimNonce) {
-      // A later session supersedes an abandoned one. Reset the full snapshot
-      // so the new session neither inherits stale classifications nor has its
-      // revisions (which restart at 1) rejected by the monotonic guard below.
+      // A cached client without sessionStartedAt can replay its own nonce (the
+      // branch above) but cannot establish that a different session is newer,
+      // so it must never reset another owner's progress. Any explicit order is
+      // newer than a legacy row; two explicit sessions use nonce only for the
+      // deterministic equal-time tie.
+      const existingOrder = existing.sessionStartedAt;
+      const incomingOrder = args.sessionStartedAt;
+      const incomingIsNewer =
+        incomingOrder !== undefined &&
+        (
+          existingOrder === undefined ||
+          incomingOrder > existingOrder ||
+          (
+            incomingOrder === existingOrder &&
+            args.claimNonce > existing.claimNonce
+          )
+        );
+      if (!incomingIsNewer) {
+        return { status: "superseded" as const };
+      }
+      // A strictly newer session (or the deterministic winner of an equal-time
+      // tie) supersedes an abandoned one. Reset the full snapshot so the new
+      // session neither inherits stale classifications nor has its revisions
+      // (which restart at 1) rejected by the monotonic guard below.
       await ctx.db.patch(existing._id, {
         claimNonce: args.claimNonce,
         claimedAt: now,
+        sessionStartedAt: args.sessionStartedAt,
         presentedAt: now,
         confirmedSteps: undefined,
         skippedSteps: undefined,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -667,6 +667,10 @@ export default defineSchema({
     cohort: v.optional(v.literal("day0")),
     claimNonce: v.string(),
     claimedAt: v.number(),
+    // Day-0 only: client-generated session start used with claimNonce as a
+    // total ownership order. Optional so rows written before the ordered
+    // takeover contract deploy without a backfill.
+    sessionStartedAt: v.optional(v.number()),
     presentedAt: v.optional(v.number()),
     // Set when a presentation is confirmed by an outcome-aware client. This
     // excludes rows created before #5582 without losing post-deploy sessions

--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -75,6 +75,12 @@ interface CapturedOutcomeCall {
   };
 }
 
+interface CapturedDay0Open {
+  activationKey: string;
+  claimNonce: string;
+  sessionStartedAt: number;
+}
+
 async function gotoHarness(page: Page): Promise<void> {
   await page.goto('/tests/runtime-harness.html');
 }
@@ -154,6 +160,12 @@ async function readCapturedOutcomes(page: Page): Promise<CapturedOutcomeCall[]> 
 async function readOutcomeAttempts(page: Page): Promise<number> {
   return page.evaluate(
     () => (window as unknown as { __proOutcomeAttempts: number }).__proOutcomeAttempts,
+  );
+}
+
+async function readDay0Opens(page: Page): Promise<CapturedDay0Open[]> {
+  return page.evaluate(
+    () => (window as unknown as { __proDay0Opens: CapturedDay0Open[] }).__proDay0Opens,
   );
 }
 
@@ -501,7 +513,7 @@ test.describe('Pro activation flow — markerless first-cycle handoff', () => {
   });
 });
 
-type Day0Status = 'opened' | 'already_recorded' | 'not_eligible';
+type Day0Status = 'opened' | 'already_recorded' | 'not_eligible' | 'superseded';
 
 /**
  * Drive the REAL day-0 (post-checkout) flow: `onlyIfUnactivated: false`, with
@@ -512,6 +524,7 @@ async function runDay0FlowHarness(
   input: {
     day0Status?: Day0Status;
     day0Throws?: boolean;
+    day0FailuresBeforeSuccess?: number;
     day0NeverResolves?: boolean;
     day0ResolveAfterMs?: number;
   } = {},
@@ -523,9 +536,11 @@ async function runDay0FlowHarness(
     const w = window as unknown as {
       __proOutcomeCalls: CapturedOutcomeCall[];
       __proOutcomeAttempts: number;
+      __proDay0Opens: CapturedDay0Open[];
     };
     w.__proOutcomeCalls = [];
     w.__proOutcomeAttempts = 0;
+    w.__proDay0Opens = [];
     let claimCalls = 0;
     let confirmCalls = 0;
     let day0Calls = 0;
@@ -536,6 +551,7 @@ async function runDay0FlowHarness(
         onlyIfUnactivated: false,
         expectedActivationKey: 'opaque-subscription',
         activationClaimNonce: 'tab-nonce',
+        activationSessionStartedAt: 1_725_000_000_000,
         isAccountCurrent: () => true,
       },
       {
@@ -562,10 +578,16 @@ async function runDay0FlowHarness(
           confirmCalls += 1;
           return true;
         },
-        openDay0Presentation: async () => {
+        openDay0Presentation: async (activationKey, claimNonce, sessionStartedAt) => {
           day0Calls += 1;
+          w.__proDay0Opens.push({ activationKey, claimNonce, sessionStartedAt });
           if (scenario.day0NeverResolves) return await new Promise<never>(() => {});
-          if (scenario.day0Throws) throw new Error('day-0 record transport failed');
+          if (
+            scenario.day0Throws ||
+            day0Calls <= (scenario.day0FailuresBeforeSuccess ?? 0)
+          ) {
+            throw new Error('day-0 record transport failed');
+          }
           if (scenario.day0ResolveAfterMs !== undefined) {
             await new Promise<void>((resolve) => setTimeout(resolve, scenario.day0ResolveAfterMs));
           }
@@ -665,15 +687,39 @@ test.describe('Pro activation flow — day-0 outcome rows (#5621)', () => {
     ]);
   });
 
+  test('rejected opens retry with one identity, then flush queued snapshots after success', async ({ page }) => {
+    const result = await runDay0FlowHarness(page, { day0FailuresBeforeSuccess: 2 });
+    expect(result.result).toBe('opened');
+    await expect(page.locator(OVERLAY)).toBeVisible();
+
+    await page.locator('.pro-activation-close').click();
+    await expect(page.locator(SUMMARY)).toBeVisible();
+    await page.locator(FINISH_BTN).click();
+
+    await expect.poll(async () => (await readDay0Opens(page)).length).toBe(3);
+    expect(await readDay0Opens(page)).toEqual(Array.from({ length: 3 }, () => ({
+      activationKey: 'opaque-subscription',
+      claimNonce: 'tab-nonce',
+      sessionStartedAt: 1_725_000_000_000,
+    })));
+    await expect.poll(async () => (await readCapturedOutcomes(page)).length).toBe(2);
+    expect((await readCapturedOutcomes(page)).map(({ outcome }) => ({
+      revision: outcome.revision,
+      finalized: outcome.finalized,
+    }))).toEqual([
+      { revision: 1, finalized: false },
+      { revision: 2, finalized: true },
+    ]);
+  });
+
   test.describe('a refused or unreachable day-0 record never blocks the welcome flow', () => {
-    for (const [name, scenario] of [
+    for (const [name, day0Status] of [
       ['server refuses (already finalized)', { day0Status: 'already_recorded' as const }],
       ['server refuses (ineligible)', { day0Status: 'not_eligible' as const }],
-      ['transport throws', { day0Throws: true }],
-      ['transport hangs past the deadline', { day0NeverResolves: true }],
+      ['server refuses (superseded)', { day0Status: 'superseded' as const }],
     ] as const) {
       test(name, async ({ page }) => {
-        const result = await runDay0FlowHarness(page, scenario);
+        const result = await runDay0FlowHarness(page, day0Status);
         // Post-checkout onboarding is the product; the ledger is telemetry.
         // It must open regardless, and never return the 'retry' that the
         // markerless path uses when its lease is in doubt.
@@ -685,17 +731,42 @@ test.describe('Pro activation flow — day-0 outcome rows (#5621)', () => {
         await page.locator(FINISH_BTN).click();
         await expect(page.locator(OVERLAY)).toHaveCount(0);
 
-        // Outlast the 200ms observation deadline. A never-resolving readiness
-        // promise stays pending, but neither blocks the UI nor attempts a
-        // write against a row that does not exist.
-        await page.waitForTimeout(400);
-
-        // No row to attach to → snapshots are dropped rather than written
-        // against a row this session does not own.
+        expect((await readDay0Opens(page)).length).toBe(1);
         expect(await readCapturedOutcomes(page)).toEqual([]);
         expect(await readOutcomeAttempts(page)).toBe(0);
       });
     }
+
+    test('permanent transport rejection performs the bounded attempt count', async ({ page }) => {
+      const result = await runDay0FlowHarness(page, { day0Throws: true });
+      expect(result.result).toBe('opened');
+      await expect(page.locator(OVERLAY)).toBeVisible();
+
+      await page.locator('.pro-activation-close').click();
+      await expect(page.locator(SUMMARY)).toBeVisible();
+      await page.locator(FINISH_BTN).click();
+      await expect(page.locator(OVERLAY)).toHaveCount(0);
+
+      await expect.poll(async () => (await readDay0Opens(page)).length).toBe(3);
+      expect(await readCapturedOutcomes(page)).toEqual([]);
+      expect(await readOutcomeAttempts(page)).toBe(0);
+    });
+
+    test('a hung request stays pending without blocking or writing', async ({ page }) => {
+      const result = await runDay0FlowHarness(page, { day0NeverResolves: true });
+      expect(result.result).toBe('opened');
+      await expect(page.locator(OVERLAY)).toBeVisible();
+
+      await page.locator('.pro-activation-close').click();
+      await expect(page.locator(SUMMARY)).toBeVisible();
+      await page.locator(FINISH_BTN).click();
+      await expect(page.locator(OVERLAY)).toHaveCount(0);
+      await page.waitForTimeout(400);
+
+      expect((await readDay0Opens(page)).length).toBe(1);
+      expect(await readCapturedOutcomes(page)).toEqual([]);
+      expect(await readOutcomeAttempts(page)).toBe(0);
+    });
   });
 });
 

--- a/src/app/pro-activation-controller.ts
+++ b/src/app/pro-activation-controller.ts
@@ -164,6 +164,8 @@ export class ProActivationController implements AppModule {
   private authStateKey: string | null = null;
   private authGeneration = 0;
   private readonly mountNonce = generateMountClaimNonce();
+  private readonly mountSessionStartedAt = Date.now();
+  private lastDay0SessionStartedAt = this.mountSessionStartedAt;
 
   constructor(
     private readonly ctx: AppContext,
@@ -422,7 +424,6 @@ export class ProActivationController implements AppModule {
           ...flowOptions,
           onlyIfUnactivated: false,
           expectedActivationKey: subscriptionKey,
-          activationClaimNonce: generateMountClaimNonce(),
         }),
       )
       .catch((error) => console.warn('[pro-activation] finish-setup chip failed to load', error));
@@ -561,6 +562,7 @@ export class ProActivationController implements AppModule {
         // these undefined and left its cohort invisible in Convex.
         expectedActivationKey: subscriptionKey,
         activationClaimNonce: this.mountNonce,
+        activationSessionStartedAt: this.mountSessionStartedAt,
       });
       // The interstitial may already be rendered by this point (opened
       // synchronously inside openProActivationFlow before it resolves). If
@@ -584,6 +586,14 @@ export class ProActivationController implements AppModule {
     return {
       accountUserId: user.id,
       accountEmail: user.email,
+      createDay0SessionIdentity: () => {
+        const sessionStartedAt = Math.max(Date.now(), this.lastDay0SessionStartedAt + 1);
+        this.lastDay0SessionStartedAt = sessionStartedAt;
+        return {
+          activationClaimNonce: generateMountClaimNonce(),
+          activationSessionStartedAt: sessionStartedAt,
+        };
+      },
       // Pro entitles MCP, not the API plans' keys (#5607). Gate on the feature
       // rather than the plan key: UnifiedSettings hides both the MCP tab and its
       // panel without `mcpAccess`, so deep-linking there would open settings on a

--- a/src/components/ProActivationChip.ts
+++ b/src/components/ProActivationChip.ts
@@ -132,7 +132,11 @@ function renderChip(options: ProActivationFlowOptions): void {
   });
   finishBtn.addEventListener('click', () => {
     removeChip();
-    void openProActivationFlow(options).catch((err) =>
+    const sessionIdentity = options.createDay0SessionIdentity?.();
+    void openProActivationFlow({
+      ...options,
+      ...(sessionIdentity ?? {}),
+    }).catch((err) =>
       console.warn('[pro-activation] failed to re-open flow from chip', err),
     );
   });

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -839,6 +839,17 @@ export interface ProActivationFlowOptions {
   expectedActivationKey?: string;
   /** Per-tab nonce used by the server-side cross-device presentation lease. */
   activationClaimNonce?: string;
+  /** Day-0 session start; paired with the nonce for ordered row ownership. */
+  activationSessionStartedAt?: number;
+  /**
+   * Finish-setup chip seam. Invoked when the chip is clicked so each reopen
+   * gets fresh identity instead of replaying the captured flow's revision
+   * namespace.
+   */
+  createDay0SessionIdentity?: () => {
+    activationClaimNonce: string;
+    activationSessionStartedAt: number;
+  };
 }
 
 /** Live activation context read once at flow open: config + platform + fields for the alerts patch. */
@@ -867,7 +878,8 @@ export interface ProActivationFlowDependencies {
   openDay0Presentation: (
     activationKey: string,
     claimNonce: string,
-  ) => Promise<'opened' | 'already_recorded' | 'not_eligible'>;
+    sessionStartedAt: number,
+  ) => Promise<'opened' | 'already_recorded' | 'not_eligible' | 'superseded'>;
   /**
    * Typed against the service's own snapshot rather than a hand-copied shape:
    * the duplicate drifted the moment a bucket was added (#5617), and a stale
@@ -894,6 +906,7 @@ const BRIEF_PREVIEW_TIMEOUT_MS = 2500;
 const ACTIVATION_CONTEXT_TIMEOUT_MS = 5_000;
 const ACTIVATION_MUTATION_TIMEOUT_MS = 5_000;
 const PRESENTATION_CONFIRM_RETRY_DELAYS_MS = [250, 750, 1_500] as const;
+const DAY0_OPEN_RETRY_DELAYS_MS = [250, 750] as const;
 const OUTCOME_WRITE_RETRY_DELAYS_MS = [250, 750] as const;
 
 /**
@@ -1384,6 +1397,41 @@ function reportActivationPersistenceFailure(
     .catch(() => {});
 }
 
+async function openDay0PresentationWithRetry(
+  options: ProActivationFlowOptions,
+  dependencies: ProActivationFlowDependencies,
+): Promise<boolean> {
+  const activationKey = options.expectedActivationKey;
+  const claimNonce = options.activationClaimNonce;
+  const sessionStartedAt = options.activationSessionStartedAt;
+  if (!activationKey || !claimNonce || sessionStartedAt === undefined) return false;
+
+  for (let attempt = 0; ; attempt += 1) {
+    if (!isFlowAccountCurrent(options)) return false;
+    try {
+      const status = await dependencies.openDay0Presentation(
+        activationKey,
+        claimNonce,
+        sessionStartedAt,
+      );
+      // Every server refusal is authoritative and terminal. Only a rejected
+      // request is eligible for transport retry.
+      return status === 'opened';
+    } catch (error) {
+      // A late rejection must not keep retrying or report against an account
+      // that is no longer active in this browser.
+      if (!isFlowAccountCurrent(options)) return false;
+      const delay = DAY0_OPEN_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined) {
+        console.warn('[pro-activation] failed to open day-0 activation record', error);
+        reportActivationPersistenceFailure(error, 'openDay0Presentation');
+        return false;
+      }
+      await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
+    }
+  }
+}
+
 function persistActivationOutcomeWithRetry(
   options: ProActivationFlowOptions,
   dependencies: ProActivationFlowDependencies,
@@ -1392,8 +1440,8 @@ function persistActivationOutcomeWithRetry(
   finalized: boolean,
   /**
    * Day-0 only: resolves once the row these snapshots attach to exists. `false`
-   * means the server refused it (ineligible, or an earlier session already
-   * finalized), so writing would be rejected anyway — skip quietly.
+   * means the server refused it (ineligible, finalized, or superseded by a
+   * newer session), so writing would be rejected anyway — skip quietly.
    */
   day0RowReady?: Promise<boolean>,
 ): void {
@@ -1533,28 +1581,25 @@ export async function openProActivationFlow(
   // unreachable. The promise is handed to the outcome writer instead, so
   // snapshots queue behind the row they attach to rather than racing it, and
   // a refusal (ineligible / already finalized) silently drops them.
-  const day0OpenRequest =
-    !options.onlyIfUnactivated && options.expectedActivationKey && options.activationClaimNonce
-      ? dependencies.openDay0Presentation(
-          options.expectedActivationKey,
-          options.activationClaimNonce,
-        )
+  const day0RowReady =
+    !options.onlyIfUnactivated &&
+    options.expectedActivationKey &&
+    options.activationClaimNonce &&
+    options.activationSessionStartedAt !== undefined
+      ? openDay0PresentationWithRetry(options, dependencies)
       : undefined;
-  const day0RowReady = day0OpenRequest
-    ?.then((status) => status === 'opened')
-    .catch(() => false);
-  if (day0OpenRequest) {
+  if (day0RowReady) {
     // Observe availability within the normal mutation budget, but keep the raw
-    // promise above as the durable readiness signal. `withTimeout` cannot
-    // cancel its source promise, so a slow successful open can still release
-    // snapshots queued behind it instead of being misclassified as a refusal.
+    // retry promise above as the durable readiness signal. `withTimeout`
+    // cannot cancel its source promise, so a slow successful open can still
+    // release snapshots queued behind it. The timeout is slow/pending
+    // telemetry only; terminal rejection is reported by the retry loop once.
     void withTimeout(
-      day0OpenRequest,
+      day0RowReady,
       dependencies.operationTimeoutMs ?? ACTIVATION_MUTATION_TIMEOUT_MS,
       'activation-open-day0-presentation',
     ).catch((error) => {
-      console.warn('[pro-activation] failed to open day-0 activation record', error);
-      reportActivationPersistenceFailure(error, 'openDay0Presentation');
+      console.warn('[pro-activation] day-0 activation record open is still pending', error);
     });
   }
 

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -188,7 +188,11 @@ export async function confirmProActivationPresentation(
   ) as boolean;
 }
 
-export type ProActivationDay0Outcome = 'opened' | 'already_recorded' | 'not_eligible';
+export type ProActivationDay0Outcome =
+  | 'opened'
+  | 'already_recorded'
+  | 'not_eligible'
+  | 'superseded';
 
 /**
  * Open the day-0 (post-checkout) activation record (#5621).
@@ -197,11 +201,13 @@ export type ProActivationDay0Outcome = 'opened' | 'already_recorded' | 'not_elig
  * exists only so the day-0 cohort has a server-side row instead of having to
  * be reconstructed from Umami sessions. `already_recorded` means an earlier
  * session already finalized this subscription's row, so outcome writes from
- * this one are expected to be rejected.
+ * this one are expected to be rejected. `superseded` means a newer unfinished
+ * session already owns the row, so this delayed opener must drop its snapshots.
  */
 export async function openProActivationDay0Presentation(
   activationKey: string,
   claimNonce: string,
+  sessionStartedAt: number,
 ): Promise<ProActivationDay0Outcome> {
   const client = await getConvexClient();
   const api = await getConvexApi();
@@ -209,7 +215,7 @@ export async function openProActivationDay0Presentation(
   await waitForConvexAuth();
   const result = await client.mutation(
     (api as any).payments.billing.openProActivationDay0Presentation,
-    { activationKey, claimNonce },
+    { activationKey, claimNonce, sessionStartedAt },
   ) as { status: ProActivationDay0Outcome };
   return result.status;
 }

--- a/tests/pro-activation-alerts-blocked.test.mts
+++ b/tests/pro-activation-alerts-blocked.test.mts
@@ -797,10 +797,17 @@ describe('durable activation outcome carries the blocked bucket (#5617)', () => 
     assert.deepEqual(ctx.tags, { component: 'pro-activation', action: 'recordOutcome' });
   });
 
-  it('reports a rejected day-0 row open once without blocking the welcome flow', async () => {
+  it('retries a rejected day-0 row open with one identity, then reports one terminal failure', async () => {
     installPushState('denied', true);
+    activeDom = installDom();
     const mod = await loadInterstitial();
     let captured: Parameters<InterstitialModule['openProActivationInterstitial']>[0] | null = null;
+    const attempts: Array<{
+      activationKey: string;
+      claimNonce: string;
+      sessionStartedAt: number;
+    }> = [];
+    let outcomeAttempts = 0;
 
     const opened = await mod.openProActivationFlow(
       {
@@ -810,28 +817,228 @@ describe('durable activation outcome carries the blocked bucket (#5617)', () => 
         onlyIfUnactivated: false,
         expectedActivationKey: 'sub_activation_key',
         activationClaimNonce: 'device-a',
+        activationSessionStartedAt: 1_725_000_000_000,
       },
       {
         readContext: async () => activationContext(),
-        openDay0Presentation: async () => {
+        openDay0Presentation: async (activationKey, claimNonce, sessionStartedAt) => {
+          attempts.push({ activationKey, claimNonce, sessionStartedAt });
           throw new Error('day-0 row rejected');
+        },
+        recordOutcome: async () => {
+          outcomeAttempts += 1;
+          return true;
         },
         openInterstitial: (interstitialOptions) => {
           captured = interstitialOptions;
         },
+        operationTimeoutMs: 20,
       },
     );
-    await new Promise<void>((r) => setImmediate(r));
 
     assert.equal(opened, 'opened', 'durable telemetry failure must not block onboarding');
     assert.ok(captured, 'the welcome interstitial must still open');
+    captured!.onExit([{ id: 'alerts', outcome: 'blocked' }]);
+    await new Promise<void>((r) => setTimeout(r, 1_200)); // outlast [250, 750]
+
+    assert.deepEqual(attempts, Array.from({ length: 3 }, () => ({
+      activationKey: 'sub_activation_key',
+      claimNonce: 'device-a',
+      sessionStartedAt: 1_725_000_000_000,
+    })));
+    assert.equal(outcomeAttempts, 0, 'snapshots must be dropped when no row was opened');
     const sentry = (globalThis as Record<string, unknown[]>).__alertsSentry!;
-    assert.equal(sentry.length, 1, 'the rejected open must reach Sentry exactly once');
+    assert.equal(sentry.length, 1, 'only exhausted rejection must reach Sentry');
     const { ctx } = sentry[0] as { ctx: { tags: Record<string, string> } };
     assert.deepEqual(ctx.tags, {
       component: 'pro-activation',
       action: 'openDay0Presentation',
     });
+  });
+
+  it('flushes queued snapshots after a slow open without reporting the observation timeout', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    let captured: Parameters<InterstitialModule['openProActivationInterstitial']>[0] | null = null;
+    const writes: Snapshot[] = [];
+
+    const opened = await mod.openProActivationFlow(
+      {
+        accountUserId: 'user_alerts',
+        accountEmail: 'pro@worldmonitor.test',
+        isAccountCurrent: () => true,
+        onlyIfUnactivated: false,
+        expectedActivationKey: 'sub_activation_key',
+        activationClaimNonce: 'device-a',
+        activationSessionStartedAt: 1_725_000_000_000,
+      },
+      {
+        readContext: async () => activationContext(),
+        openDay0Presentation: async () => {
+          await new Promise<void>((r) => setTimeout(r, 40));
+          return 'opened';
+        },
+        recordOutcome: async (_key, _nonce, snapshot) => {
+          writes.push(snapshot as Snapshot);
+          return true;
+        },
+        openInterstitial: (interstitialOptions) => {
+          captured = interstitialOptions;
+        },
+        operationTimeoutMs: 10,
+      },
+    );
+
+    assert.equal(opened, 'opened');
+    assert.ok(captured, 'the welcome interstitial must open before persistence settles');
+    captured!.onProgress?.([{ id: 'brief', outcome: 'confirmed' }]);
+    captured!.onExit([{ id: 'brief', outcome: 'confirmed' }]);
+    await new Promise<void>((r) => setTimeout(r, 100));
+
+    assert.deepEqual(writes.map(({ revision, finalized }) => ({ revision, finalized })), [
+      { revision: 1, finalized: false },
+      { revision: 2, finalized: true },
+    ]);
+    assert.deepEqual(
+      (globalThis as Record<string, unknown[]>).__alertsSentry,
+      [],
+      'a non-cancelling observation timeout is not a terminal failure',
+    );
+  });
+
+  it('does not retry terminal day-0 refusal statuses', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+
+    for (const status of ['already_recorded', 'not_eligible', 'superseded'] as const) {
+      let captured: Parameters<InterstitialModule['openProActivationInterstitial']>[0] | null = null;
+      let attempts = 0;
+      let outcomeAttempts = 0;
+      const opened = await mod.openProActivationFlow(
+        {
+          accountUserId: 'user_alerts',
+          accountEmail: 'pro@worldmonitor.test',
+          isAccountCurrent: () => true,
+          onlyIfUnactivated: false,
+          expectedActivationKey: 'sub_activation_key',
+          activationClaimNonce: `device-${status}`,
+          activationSessionStartedAt: 1_725_000_000_000,
+        },
+        {
+          readContext: async () => activationContext(),
+          openDay0Presentation: async () => {
+            attempts += 1;
+            return status;
+          },
+          recordOutcome: async () => {
+            outcomeAttempts += 1;
+            return true;
+          },
+          openInterstitial: (interstitialOptions) => {
+            captured = interstitialOptions;
+          },
+          operationTimeoutMs: 10,
+        },
+      );
+      assert.equal(opened, 'opened');
+      assert.ok(captured);
+      captured!.onExit([{ id: 'brief', outcome: 'skipped' }]);
+      await settle();
+      assert.equal(attempts, 1, `${status} must be a terminal refusal`);
+      assert.equal(outcomeAttempts, 0, `${status} owns no writable row`);
+    }
+
+    assert.deepEqual((globalThis as Record<string, unknown[]>).__alertsSentry, []);
+  });
+
+  it('leaves a hung day-0 open pending without blocking or false terminal telemetry', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    let captured: Parameters<InterstitialModule['openProActivationInterstitial']>[0] | null = null;
+    let attempts = 0;
+    let outcomeAttempts = 0;
+
+    const opened = await mod.openProActivationFlow(
+      {
+        accountUserId: 'user_alerts',
+        accountEmail: 'pro@worldmonitor.test',
+        isAccountCurrent: () => true,
+        onlyIfUnactivated: false,
+        expectedActivationKey: 'sub_activation_key',
+        activationClaimNonce: 'device-a',
+        activationSessionStartedAt: 1_725_000_000_000,
+      },
+      {
+        readContext: async () => activationContext(),
+        openDay0Presentation: async () => {
+          attempts += 1;
+          return await new Promise<never>(() => {});
+        },
+        recordOutcome: async () => {
+          outcomeAttempts += 1;
+          return true;
+        },
+        openInterstitial: (interstitialOptions) => {
+          captured = interstitialOptions;
+        },
+        operationTimeoutMs: 10,
+      },
+    );
+    assert.equal(opened, 'opened');
+    assert.ok(captured, 'the welcome UI must open without awaiting the ledger');
+    captured!.onExit([{ id: 'brief', outcome: 'skipped' }]);
+    await new Promise<void>((r) => setTimeout(r, 30));
+
+    assert.equal(attempts, 1, 'a pending request is not duplicated');
+    assert.equal(outcomeAttempts, 0, 'snapshots remain queued behind readiness');
+    assert.deepEqual((globalThis as Record<string, unknown[]>).__alertsSentry, []);
+  });
+
+  it('stops retrying when the activation account is no longer current', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    let accountChecks = 0;
+    let attempts = 0;
+
+    const opened = await mod.openProActivationFlow(
+      {
+        accountUserId: 'user_alerts',
+        accountEmail: 'pro@worldmonitor.test',
+        isAccountCurrent: () => {
+          accountChecks += 1;
+          return accountChecks < 4;
+        },
+        onlyIfUnactivated: false,
+        expectedActivationKey: 'sub_activation_key',
+        activationClaimNonce: 'device-a',
+        activationSessionStartedAt: 1_725_000_000_000,
+      },
+      {
+        readContext: async () => activationContext(),
+        openDay0Presentation: async () => {
+          attempts += 1;
+          throw new Error('day-0 row rejected after account switch');
+        },
+        openInterstitial: () => {},
+        operationTimeoutMs: 10,
+      },
+    );
+    // Outlast the first retry delay: if the ownership check did not stop the
+    // loop, a second mutation would have fired by now.
+    await new Promise<void>((r) => setTimeout(r, 350));
+
+    assert.equal(opened, 'opened');
+    assert.equal(accountChecks, 4, 'ownership is rechecked immediately after rejection');
+    assert.equal(attempts, 1);
+    assert.deepEqual(
+      (globalThis as Record<string, unknown[]>).__alertsSentry,
+      [],
+      'an obsolete account must not create terminal persistence telemetry',
+    );
   });
 
   it('sends an explicit empty blockedSteps when nothing was blocked', async () => {

--- a/tests/pro-activation-controller.test.mts
+++ b/tests/pro-activation-controller.test.mts
@@ -50,6 +50,8 @@ const stateKeys = [
   '__activationCloseCalls',
   '__activationFlowOptions',
   '__activationChipOptions',
+  '__activationChipClick',
+  '__activationChipReopenOptions',
 ] as const;
 const stateSnapshots = new Map(stateKeys.map((key) => [key, snapshotGlobal(key)]));
 
@@ -119,6 +121,12 @@ async function loadController(): Promise<typeof import('../src/app/pro-activatio
     ['chip-stub', `
       export function maybeShowFinishSetupChip(options) {
         globalThis.__activationChipOptions.push(options);
+        globalThis.__activationChipClick = () => {
+          const identity = options.createDay0SessionIdentity();
+          const reopenedOptions = { ...options, ...identity };
+          globalThis.__activationChipReopenOptions.push(reopenedOptions);
+          return reopenedOptions;
+        };
       }
     `],
   ]);
@@ -201,6 +209,8 @@ function installBrowserState(options: { fastTimers?: boolean } = {}): void {
     __activationCloseCalls: 0,
     __activationFlowOptions: [] as unknown[],
     __activationChipOptions: [] as unknown[],
+    __activationChipClick: null as (() => Record<string, unknown>) | null,
+    __activationChipReopenOptions: [] as unknown[],
   });
 }
 
@@ -699,6 +709,11 @@ describe('ProActivationController activation-record identity (#5621)', () => {
       'day-0 must carry a session nonce so its outcome writes are attributable',
     );
     assert.notEqual(day0.activationClaimNonce, '');
+    assert.equal(
+      typeof day0.activationSessionStartedAt,
+      'number',
+      'day-0 must carry a comparable session-start order',
+    );
   });
 
   it('still hands the markerless cohort its lease identity', async () => {
@@ -709,7 +724,7 @@ describe('ProActivationController activation-record identity (#5621)', () => {
     assert.equal(typeof retro.activationClaimNonce, 'string');
   });
 
-  it('gives each later Finish Setup flow fresh day-0 identity for the current subscription', async () => {
+  it('gives every click from one retained Finish Setup chip fresh ordered day-0 identity', async () => {
     installBrowserState();
     const userId = 'user-chip-identity';
     const subscriptionKey = `opaque-${userId}-subscription`;
@@ -725,49 +740,69 @@ describe('ProActivationController activation-record identity (#5621)', () => {
       container: { dispatchEvent() {} },
       unifiedSettings: { open() {} },
     };
-    const controllers = [
-      new ProActivationController(ctx as never, {
-        reloadPending: false,
-        openAiAnalyst() {},
-      }),
-      new ProActivationController(ctx as never, {
-        reloadPending: false,
-        openAiAnalyst() {},
-      }),
-    ];
+    const controller = new ProActivationController(ctx as never, {
+      reloadPending: false,
+      openAiAnalyst() {},
+    });
 
     try {
-      for (const controller of controllers) {
-        controller.init();
-        await (controller as unknown as { evaluate(): Promise<void> }).evaluate();
-      }
+      controller.init();
+      await (controller as unknown as { evaluate(): Promise<void> }).evaluate();
       const captured = (globalThis as unknown as { __activationChipOptions: unknown[] })
         .__activationChipOptions;
-      for (let attempt = 0; attempt < 40 && captured.length < 2; attempt += 1) {
+      for (let attempt = 0; attempt < 40 && captured.length === 0; attempt += 1) {
         await new Promise((resolve) => setTimeout(resolve, 25));
       }
-      assert.equal(captured.length, 2, 'each later session must offer the Finish Setup chip');
+      assert.equal(captured.length, 1, 'the later session must retain one Finish Setup chip');
 
-      const [first, second] = captured as Array<Record<string, unknown>>;
+      const chipOptions = captured[0] as Record<string, unknown>;
+      assert.equal(chipOptions.onlyIfUnactivated, false);
+      assert.equal(chipOptions.expectedActivationKey, subscriptionKey);
+      assert.equal(
+        chipOptions.activationClaimNonce,
+        undefined,
+        'the chip must not capture an identity before the user clicks',
+      );
+
+      const click = (
+        globalThis as unknown as {
+          __activationChipClick: (() => Record<string, unknown>) | null;
+        }
+      ).__activationChipClick;
+      assert.equal(typeof click, 'function');
+      click!();
+      click!();
+
+      const [first, second] = (
+        globalThis as unknown as { __activationChipReopenOptions: Array<Record<string, unknown>> }
+      ).__activationChipReopenOptions;
+      assert.ok(first);
+      assert.ok(second);
       for (const options of [first, second]) {
         assert.equal(options.onlyIfUnactivated, false);
         assert.equal(options.expectedActivationKey, subscriptionKey);
         assert.equal(typeof options.activationClaimNonce, 'string');
         assert.notEqual(options.activationClaimNonce, '');
+        assert.equal(typeof options.activationSessionStartedAt, 'number');
       }
       assert.notEqual(
         first.activationClaimNonce,
-        (controllers[0] as unknown as { mountNonce: string }).mountNonce,
+        (controller as unknown as { mountNonce: string }).mountNonce,
         'chip-triggered flows must not reuse the controller mount nonce',
       );
       assert.notEqual(
         second.activationClaimNonce,
         first.activationClaimNonce,
-        'a later chip flow must get a fresh takeover nonce',
+        'the retained chip must mint a fresh nonce on every click',
+      );
+      assert.ok(
+        (second.activationSessionStartedAt as number) >
+          (first.activationSessionStartedAt as number),
+        'the retained chip must mint a strictly newer order on every click',
       );
     } finally {
       ctx.isDestroyed = true;
-      for (const controller of controllers) controller.destroy();
+      controller.destroy();
     }
   });
 });


### PR DESCRIPTION
## Summary

Day-0 activation outcomes now survive recoverable client or authentication failures and overlapping browser sessions without letting stale work erase newer progress. The welcome flow remains non-blocking: recoverable row-open failures retry in the background, authoritative refusals stop immediately, and hung requests remain pending without delaying onboarding.

Session ownership is now a total order captured when a flow starts. An older delayed tab cannot take ownership back from a newer session, cached clients without the order field cannot displace another owner, and every click on a retained Finish Setup chip receives a fresh revision namespace. Observation timeouts are reported as slow/pending warnings; Sentry receives an exception only after the underlying open has actually exhausted its retries.

## Validation

- `npm run typecheck:all`
- `npm run test:convex` — 1,017/1,017 passed
- focused controller and persistence tests — 31/31 passed
- `npx playwright test e2e/pro-activation.spec.ts` — 35/35 passed
- Biome across all 10 changed files
- full pre-push gate, including changed tests and architectural checks

## Rollout

Deploy the Convex schema and mutation before the web bundle. The schema field is optional for rows and cached clients from the original rollout, but the new client sends the ordered-session argument and an older mutation validator will reject it.

Related: #5626

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
