### PR TITLE
fix(data): recover humanitarian, China, and PortWatch coverage

### DIFF
--- a/Dockerfile.seed-bundle-portwatch-port-activity
+++ b/Dockerfile.seed-bundle-portwatch-port-activity
@@ -1,5 +1,5 @@
 # =============================================================================
-# Seed Bundle: PortWatch Port-Activity (daily cron, standalone)
+# Seed Bundle: PortWatch Port-Activity (12-hour cron, standalone)
 # =============================================================================
 # Runs scripts/seed-bundle-portwatch-port-activity.mjs which spawns the single
 # PW-Port-Activity section via _bundle-runner.mjs. Split out of the main

--- a/api/health.js
+++ b/api/health.js
@@ -344,14 +344,15 @@ const STANDALONE_KEYS = {
 };
 
 const SEED_META = {
-  // scripts/seed-conflict-intel.mjs cron runs every 30min. Bounded above by
+  // scripts/seed-conflict-intel.mjs cron runs every 15min, while HAPI is gated
+  // to one bulk refresh every 2h. Bounded above by
   // HAPI_TTL (360min / 6h) — the per-country data key's own Redis TTL — not
   // by cron headroom alone: this MUST fire before a per-country key can expire,
   // or users see empty data for up to 6h before health notices (#5554 review;
   // an earlier 720min value left exactly that blind spot). 300 (5h) is ~10x
-  // the cron interval (headroom for missed/lock-contended ticks) while staying
+  // the HAPI refresh interval (headroom for missed/lock-contended ticks) while staying
   // a full hour below the 6h data-expiry floor.
-  humanitarianSummary: { key: 'seed-meta:conflict:humanitarian',  maxStaleMin: 300 },
+  humanitarianSummary: { key: 'seed-meta:conflict:humanitarian',  maxStaleMin: 300, minRecordCount: 23 },
   chinaCoverage:   { key: 'seed-meta:health:china-coverage',   maxStaleMin: 180 },
   earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
   wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 360 }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -31,6 +31,7 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     metadataHost: 'query.sse.com.cn',
     documentHosts: CHINA_DISCLOSURE_DOCUMENT_HOSTS.SSE,
     maxRequestsPerRun: 4,
+    maxConcurrentRequests: 2,
     maxResponseBytes: 262_144,
     redirectPolicy: 'error',
     documentRetrieval: 'lazy-link-only',
@@ -50,10 +51,10 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     robots: Object.freeze({ status: 'not_published', httpStatus: 404 }),
     preflight: Object.freeze({
       environment: 'railway-production',
-      checkedOn: '2026-07-25',
+      checkedOn: '2026-07-26',
       reachable: true,
       metadataHttpStatus: 200,
-      observedResponseBytes: 63_610,
+      observedResponseBytes: 143_020,
       documentRedirects: 1,
     }),
   }),
@@ -136,7 +137,13 @@ const ISO_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_EVENTS = 100;
 const MAX_REVISIONS_PER_EVENT = 20;
 const MAX_UNCLASSIFIED_REVISIONS = 100;
-const SSE_PAGE_SIZE = 25;
+// The exchange accepts 100 rows in the same bounded first-page request. The
+// reviewed 90-day basket currently reaches 50-55 rows for active issuers, so
+// the former 25-row page permanently reported PAGE_LIMIT_REACHED even though
+// the complete response remains comfortably below the 256 KiB byte ceiling
+// (largest live response observed 2026-07-26: 143,020 bytes).
+const SSE_PAGE_SIZE = 100;
+const SSE_REQUEST_TIMEOUT_MS = 30_000;
 const SZSE_PAGE_SIZE = 50;
 const LAUNCHED_SOURCE_FETCHERS = Object.freeze([
   Object.freeze(['sse', fetchSseAnnouncements]),
@@ -426,40 +433,55 @@ async function fetchSseAnnouncements(fetchFn, now) {
   let contentTruncated = false;
   let successfulRequests = 0;
   let requestCount = 0;
-  for (const issuer of issuers) {
-    if (requestCount >= contract.maxRequestsPerRun) throw sourceError('REQUEST_BUDGET_EXCEEDED');
-    const url = new URL(contract.metadataEndpoint);
-    const params = {
-      isPagination: 'true',
-      productId: issuer.securityCode,
-      securityType: '0101,120100,020100,020200,120200',
-      beginDate: begin,
-      endDate: end,
-      'pageHelp.pageSize': String(SSE_PAGE_SIZE),
-      'pageHelp.pageNo': '1',
-      'pageHelp.beginPage': '1',
-      'pageHelp.endPage': '1',
-    };
-    for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
-    requestCount += 1;
-    try {
-      const response = await fetchFn(url, {
-        headers: {
-          Accept: 'application/json',
-          Referer: 'https://www.sse.com.cn/',
-          'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
-        },
-        redirect: contract.redirectPolicy,
-        signal: AbortSignal.timeout(20_000),
-      });
-      assertMetadataResponse(response, contract);
-      const payload = await readBoundedJsonResponse(response, contract.maxResponseBytes);
-      const normalized = normalizeSseAnnouncements(payload, { retrievedAt });
-      if (Number(payload.pageHelp.total) > SSE_PAGE_SIZE) contentTruncated = true;
-      announcements.push(...normalized);
+  for (let offset = 0; offset < issuers.length; offset += contract.maxConcurrentRequests) {
+    const batch = issuers.slice(offset, offset + contract.maxConcurrentRequests);
+    if (requestCount + batch.length > contract.maxRequestsPerRun) {
+      throw sourceError('REQUEST_BUDGET_EXCEEDED');
+    }
+    requestCount += batch.length;
+    const outcomes = await Promise.all(batch.map(async (issuer) => {
+      const url = new URL(contract.metadataEndpoint);
+      const params = {
+        isPagination: 'true',
+        productId: issuer.securityCode,
+        securityType: '0101,120100,020100,020200,120200',
+        beginDate: begin,
+        endDate: end,
+        'pageHelp.pageSize': String(SSE_PAGE_SIZE),
+        'pageHelp.pageNo': '1',
+        'pageHelp.beginPage': '1',
+        'pageHelp.endPage': '1',
+      };
+      for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+      try {
+        const response = await fetchFn(url, {
+          headers: {
+            Accept: 'application/json',
+            Referer: 'https://www.sse.com.cn/',
+            'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
+          },
+          redirect: contract.redirectPolicy,
+          signal: AbortSignal.timeout(SSE_REQUEST_TIMEOUT_MS),
+        });
+        assertMetadataResponse(response, contract);
+        const payload = await readBoundedJsonResponse(response, contract.maxResponseBytes);
+        return {
+          announcements: normalizeSseAnnouncements(payload, { retrievedAt }),
+          contentTruncated: Number(payload.pageHelp.total) > SSE_PAGE_SIZE,
+        };
+      } catch (error) {
+        return { errorCode: errorCodeFor(error) };
+      }
+    }));
+
+    for (const outcome of outcomes) {
+      if (outcome.errorCode) {
+        errors.push(outcome.errorCode);
+        continue;
+      }
+      announcements.push(...outcome.announcements);
+      if (outcome.contentTruncated) contentTruncated = true;
       successfulRequests += 1;
-    } catch (error) {
-      errors.push(errorCodeFor(error));
     }
   }
   const transportOk = errors.length === 0;

--- a/scripts/china-coverage-health.mjs
+++ b/scripts/china-coverage-health.mjs
@@ -82,6 +82,13 @@ function probeContent(payload, probe) {
     if (probe.requiredTruthyPaths?.some((path) => !valuesAtPath(payload, path).some(Boolean))) {
       return { status: 'empty', rows: [payload] };
     }
+    if (
+      Array.isArray(probe.validStatusValues)
+      && !valuesAtPath(payload, probe.statusPath ?? ['status'])
+        .some((value) => probe.validStatusValues.includes(String(value)))
+    ) {
+      return { status: 'partial', rows: [payload] };
+    }
     return { status: 'present', rows: [payload] };
   }
   if (probe.kind === 'object-property') {

--- a/scripts/china-coverage-manifest.mjs
+++ b/scripts/china-coverage-manifest.mjs
@@ -163,6 +163,12 @@ export const CHINA_COVERAGE_ENTRIES = Object.freeze([
       probe: {
         kind: 'object',
         requiredTruthyPaths: [['sources']],
+        // A fresh seed run can still retain a degraded source snapshot (for
+        // example an intermittent exchange fetch or a bounded page limit).
+        // Treat that as partial coverage directly instead of collapsing it
+        // into the misleading CONTENT_TIMESTAMP_MISSING reason.
+        statusPath: ['status'],
+        validStatusValues: ['healthy'],
         timestampPaths: [
           ['events', '*', 'publicationTime', 'value'],
           ['coverageThrough'],

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -18,6 +18,17 @@
     "deployMode": "dockerfile",
     "dockerfile": "Dockerfile.seed-bundle-portwatch-port-activity",
     "service": "seed-bundle-portwatch-port-activity",
+    "requiredEnv": [
+      "UPSTASH_REDIS_REST_URL",
+      "UPSTASH_REDIS_REST_TOKEN",
+      "PROXY_URL"
+    ],
+    "watchPatterns": [
+      "scripts/**",
+      "shared/**",
+      "Dockerfile.seed-bundle-portwatch-port-activity"
+    ],
+    "cronSchedule": "0 */12 * * *",
     "documentedAt": "Dockerfile.seed-bundle-portwatch-port-activity"
   },
   {

--- a/scripts/seed-bundle-portwatch-port-activity.mjs
+++ b/scripts/seed-bundle-portwatch-port-activity.mjs
@@ -11,14 +11,16 @@
 // portwatch bundle and lets it run on an interval appropriate to the
 // ~10-day upstream dataset lag.
 //
-// Railway service provisioning checklist (after merge):
-//   1. Create new service: portwatch-port-activity-seed
+// Railway service settings checklist (after merge):
+//   1. Service: seed-bundle-portwatch-port-activity
 //   2. Builder: DOCKERFILE, dockerfilePath: Dockerfile.seed-bundle-portwatch-port-activity
 //   3. Root directory: "" (empty) — avoids NIXPACKS auto-detection (see
 //      feedback_railway_dockerfile_autodetect_overrides_builder.md)
-//   4. Cron schedule: "0 */24 * * *" (daily, UTC) — dataset lag means
-//      12h cadence is overkill; 24h keeps us inside the freshness
-//      expectations downstream
+//   4. Cron schedule: "0 */12 * * *" (twice daily, UTC). Each run caps
+//      cold refreshes at 30 countries to stay inside the ArcGIS and container
+//      budgets. A 12h trigger lets a 54-country upstream advance recover in
+//      two runs (~24h) instead of two daily runs (~48h), while the interval
+//      gate below still prevents rapid-fire manual retriggers.
 //   5. Env vars (copy from existing seed services):
 //      UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN,
 //      PROXY_URL (for 429 fallback)
@@ -39,9 +41,8 @@ await runBundle('portwatch-port-activity', [
     script: 'seed-portwatch-port-activity.mjs',
     seedMetaKey: 'supply_chain:portwatch-ports',
     canonicalKey: 'supply_chain:portwatch-ports:v1:_countries',
-    // 12h interval gate — matches the historical cadence. Actual Railway
-    // cron should trigger at 24h; the interval gate prevents rapid-fire
-    // re-runs if someone manually retriggers mid-day.
+    // 12h interval gate matches the declared Railway cron and prevents
+    // rapid-fire manual retriggers.
     intervalMs: 12 * HOUR,
     // 540s section timeout — full budget for the one section. Bundle
     // runner still SIGTERMs if the child hangs, and the seeder's

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -16,7 +16,17 @@
  * - searchGdeltDocuments: per-query GDELT search
  */
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, loadSharedConfig, readSeedSnapshot } from './_seed-utils.mjs';
+import {
+  loadEnvFile,
+  CHROME_UA,
+  runSeed,
+  writeExtraKey,
+  writeExtraKeyWithMeta,
+  extendExistingTtl,
+  sleep,
+  loadSharedConfig,
+  readSeedSnapshot,
+} from './_seed-utils.mjs';
 import { fetchGdeltJson } from './_gdelt-fetch.mjs';
 import { buildGdeltConflictUrl, mapGdeltArticlesToEvents, GDELT_COUNTRY_NAMES } from './_conflict-gdelt.mjs';
 import { fetchGdeltBulkConflictEvents, GDELT_ROLLING_WINDOW_MS, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
@@ -53,7 +63,7 @@ const HAPI_TTL = 21600;
 // don't share a common non-country-specific prefix writeSeedMeta could roll up
 // automatically. maxStaleMin in health.js is 300 (5h) — bounded above by HAPI_TTL
 // (360min/6h, the per-country data key's own Redis TTL) so the alarm fires BEFORE
-// per-country data can expire, not just against this seeder's 30min cron cadence
+// per-country data can expire, not just against this seeder's 15min cron cadence
 // (30 days would NOT have caught #5554 promptly, and even 12h left a 6h blind
 // spot where data was already empty but health still reported OK — #5554 review).
 // The TTL here must clearly OUTLIVE that staleness threshold — matching the
@@ -61,20 +71,17 @@ const HAPI_TTL = 21600;
 // headroom against a single missed/late tick, and reports EMPTY instead of STALE).
 const HAPI_SEED_META_KEY = 'seed-meta:conflict:humanitarian';
 const HAPI_SEED_META_TTL_SECONDS = 3 * 86400;
-// HDX asks callers to moderate HAPI traffic to ~1 req/s (this is per-app_identifier
-// tracked, not per-IP — see the HAPI_APP_IDENTIFIER comment above). 1100ms gives
-// margin above that floor. Timeout is tightened from the previous 15s to keep the
-// worst-case sweep (all HAPI_COUNTRIES timing out) bounded — see fetchAll's
-// GDELT_SWEEP_BUDGET_MS comment for how this feeds the shared fetch-phase deadline.
-const HAPI_REQUEST_DELAY_MS = 1100;
-const HAPI_REQUEST_TIMEOUT_MS = 8_000;
-// Bounds worst-case sweep time AND avoids re-earning a throttle on the freshly-minted
-// identifier if HDX starts flagging us again mid-sweep. Counts ANY consecutive failure
-// (429, 401/403 from an invalidated identifier, 5xx, network timeout) — not 429 only.
-// An earlier version only counted 429s and reset the streak on other failure types,
-// which meant an interleaved pattern like 429/timeout/429/timeout never tripped the
-// breaker at all, defeating the whole point (#5554 review).
-const HAPI_MAX_CONSECUTIVE_FAILURES = 3;
+// HAPI publishes this ACLED-derived table weekly. The conflict seeder runs every
+// 15 minutes for its other feeds, so a freshness gate prevents that unrelated
+// cadence from repeatedly hitting HAPI. The 2h interval remains comfortably
+// inside the 5h health threshold and 6h per-country data TTL.
+export const HAPI_REFRESH_INTERVAL_MS = 2 * 60 * 60 * 1000;
+export const HAPI_FAILURE_BACKOFF_MS = 2 * 60 * 60 * 1000;
+const HAPI_FAILURE_BACKOFF_KEY = 'conflict:humanitarian:hapi-backoff:v1';
+const HAPI_REQUEST_TIMEOUT_MS = 15_000;
+const HAPI_REQUEST_DELAY_MS = 1_100;
+const HAPI_PAGE_LIMIT = 10_000;
+const HAPI_MAX_PAGES = 3;
 const PIZZINT_TTL = 600;
 
 export const CONFLICT_COUNTRIES = [
@@ -89,33 +96,39 @@ export const GDELT_MIN_SUCCESSFUL_COUNTRIES = Math.ceil(CONFLICT_COUNTRIES.lengt
 // break its fixed-count tests (#5554 — a prior fix attempt did exactly this).
 const HAPI_ONLY_COUNTRIES = ['IR', 'IL', 'RU', 'SA', 'DJ', 'ER'];
 // The dashboard's country-tension widget (src/services/conflict/index.ts
-// HAPI_COUNTRY_CODES) requests a broader 20-country watchlist that only partially
-// overlaps CONFLICT_COUNTRIES/HAPI_ONLY_COUNTRIES. Before this fix, a cache miss on
-// any of these fell back to a live HAPI fetch, so the gap was invisible; the RPC
-// handlers are now cache-only (#5554 review), so anything missing here silently
-// goes empty for the widget instead. Keep in sync with that file's list.
-const HAPI_DASHBOARD_COUNTRIES = ['US', 'CN', 'TW', 'KP', 'TR', 'PL', 'DE', 'FR', 'GB', 'IN', 'PK', 'VE'];
-// Order matters under a circuit-breaker trip: HAPI_ONLY_COUNTRIES (the actual subject
-// of #5554) and HAPI_DASHBOARD_COUNTRIES go first so a mid-sweep abort disadvantages
-// the lower-priority CONFLICT_COUNTRIES tail instead of the countries this fix exists
-// for (#5554 review — these previously sat last and could be starved every cycle).
+// HAPI_COUNTRY_CODES) requests this 20-country watchlist. Before this fix, a cache
+// miss fell back to a live HAPI fetch, so incomplete seed coverage was invisible;
+// the RPC handlers are now cache-only (#5554 review), so every widget country is
+// part of the guaranteed coverage contract. Keep the complete list in sync with
+// that file rather than listing only the countries unique to the dashboard.
+const HAPI_DASHBOARD_COUNTRIES = [
+  'US', 'RU', 'CN', 'UA', 'IR', 'IL', 'TW', 'KP', 'SA', 'TR',
+  'PL', 'DE', 'FR', 'GB', 'IN', 'PK', 'SY', 'YE', 'MM', 'VE',
+];
+const HAPI_CRISIS_COUNTRIES = ['IR', 'IL', 'UA', 'RU', 'SD', 'YE', 'SA', 'DJ', 'ER'];
+// Public crisis trackers and the dashboard batch are the guaranteed coverage
+// contract. The broader conflict set is still collected when national rows are
+// present, but it does not trigger a per-country fallback fan-out.
+export const HAPI_REQUIRED_COUNTRIES = [
+  ...new Set([...HAPI_CRISIS_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES]),
+];
 const HAPI_COUNTRIES = [...new Set([...HAPI_ONLY_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES, ...CONFLICT_COUNTRIES])];
 // A throttled failure, as it reaches us: fetchGdeltCountryEvents flattens the direct and
 // proxy attempts into one message, e.g. "...(last direct: HTTP 429) (last proxy: HTTP 429)".
 const RATE_LIMIT_ERROR = /\b429\b|rate.?limit|too many requests/i;
 // #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
 // fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
-// an absolute deadline down, so slow aux feeds — HAPI is sequential, ~346s worst
-// (38 HAPI_COUNTRIES × (HAPI_REQUEST_TIMEOUT_MS + HAPI_REQUEST_DELAY_MS), #5554) —
-// automatically shrink the sweep window instead of stacking on top of it). One
+// an absolute deadline down, so slow aux feeds automatically shrink the sweep
+// window instead of stacking on top of it). HAPI now uses one bounded bulk request
+// instead of a 38-country sequential sweep. One
 // in-flight batch may still drain past the cutoff: ≤~100s at the knobs below
 // (15s concurrent direct legs + 4 × 20s SERIALIZED sync proxy curls — curlFetch is
 // execFileSync, so "concurrent" proxy attempts block the event loop one at a time;
 // 92s observed live 2026-07-10). Worst single fetchAll attempt before the bulk
-// fallback ≈ max(HAPI 346s, 120s + 100s). Without this cap a
+// fallback is now dominated by the GDELT path. Without this cap a
 // GDELT brownout ran 5 batches ≈ 375s+ → deadline breach → exit 75 every tick.
 // The bulk fallback runs after those parallel feeds settle, so its 60s bound
-// and 30s publish slack are additive: max(346s, 220s) + 60s + 30s = 436s — still
+// and 30s publish slack are additive: 220s + 60s + 30s = 310s — still
 // comfortably under ACLED_INTEL_LOCK_TTL_MS's 540s fetch deadline (lockTtlMs+120s)
 // below (re-verified #5554 review after growing HAPI_COUNTRIES to 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
@@ -129,10 +142,13 @@ export const GDELT_COUNTRY_FETCH_OPTS = Object.freeze({ maxRetries: 0, proxyMaxA
 // _seed-utils.mjs: "a healthy seeder is designed never to outlive its own lock");
 // it also sets the fetch deadline (lockTtlMs + 120s margin = 540s). The default
 // 120s lock was ALREADY shorter than this seeder's worst case. Cron cadence is
-// 30min, so a hard-crashed run's dangling lock costs at most 7 of those minutes.
+// 15min, so a hard-crashed run's dangling lock costs at most 7 of those minutes.
 export const ACLED_INTEL_LOCK_TTL_MS = 420_000;
 
 const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = new Map(
+  Object.entries(ISO2_TO_ISO3).map(([iso2, iso3]) => [String(iso3).toUpperCase(), iso2]),
+);
 
 // HDX HAPI's `app_identifier` is used for per-client tracking/rate-limiting, not
 // just auth. The previous identifier (`worldmonitor:monitor@worldmonitor.app`)
@@ -150,9 +166,10 @@ const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
 // name:monitor@worldmonitor.app` also got 200 in the same probe run. shared/
 // hapi-app-identifier.json's `application` value intentionally avoids the
 // substring for this reason; `email` doesn't need to. Whatever identifier is
-// configured there must ALSO stay within HDX's documented ~1 req/s courtesy
-// limit going forward (HAPI_REQUEST_DELAY_MS below) — this seeder is the ONLY
-// source of HAPI traffic; the RPC handlers only ever read the Redis keys this writes.
+// configured there must ALSO stay low-volume going forward. This seeder is the
+// ONLY source of HAPI traffic; the RPC handlers only ever read the Redis keys
+// this writes. The current implementation makes one bulk request at most every
+// two hours, rather than 38 per-country requests every 15 minutes.
 const HAPI_APP_IDENTIFIER_CONFIG = loadSharedConfig('hapi-app-identifier.json');
 const HAPI_APP_IDENTIFIER = Buffer.from(
   `${HAPI_APP_IDENTIFIER_CONFIG.application}:${HAPI_APP_IDENTIFIER_CONFIG.email}`,
@@ -439,79 +456,280 @@ export async function fetchGdeltConflictEvents({
 
 // ─── Humanitarian Summary (HAPI) ───
 
-async function fetchHapiSummary(countryCode) {
-  const iso3 = ISO2_TO_ISO3[countryCode];
-  if (!iso3) return null;
-
-  const url = `https://hapi.humdata.org/api/v2/coordination-context/conflict-events?output_format=json&limit=1000&offset=0&app_identifier=${HAPI_APP_IDENTIFIER}&location_code=${iso3}`;
-
-  const resp = await fetch(url, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(HAPI_REQUEST_TIMEOUT_MS),
-  });
-  if (!resp.ok) {
-    throw Object.assign(new Error(`HTTP ${resp.status} ${resp.statusText}`), { status: resp.status });
-  }
-  const rawData = await resp.json();
-  const records = rawData.data || [];
-
-  const agg = { eventsTotal: 0, eventsPV: 0, eventsCT: 0, eventsDem: 0, fatPV: 0, fatCT: 0, month: '', locationName: '' };
-  for (const r of records) {
-    if ((r.location_code || '') !== iso3) continue;
-    const month = r.reference_period_start || '';
-    const eventType = (r.event_type || '').toLowerCase();
-    const events = r.events || 0;
-    const fatalities = r.fatalities || 0;
-    if (!agg.locationName) agg.locationName = r.location_name || '';
-    if (month > agg.month) { agg.month = month; agg.eventsTotal = 0; agg.eventsPV = 0; agg.eventsCT = 0; agg.eventsDem = 0; agg.fatPV = 0; agg.fatCT = 0; }
-    if (month === agg.month) {
-      agg.eventsTotal += events;
-      if (eventType.includes('political_violence')) { agg.eventsPV += events; agg.fatPV += fatalities; }
-      if (eventType.includes('civilian_targeting')) { agg.eventsCT += events; agg.fatCT += fatalities; }
-      if (eventType.includes('demonstration')) agg.eventsDem += events;
-    }
-  }
-  if (!agg.month) return null;
-
-  return {
-    summary: {
-      countryCode: countryCode.toUpperCase(),
-      countryName: agg.locationName,
-      conflictEventsTotal: agg.eventsTotal,
-      conflictPoliticalViolenceEvents: agg.eventsPV + agg.eventsCT,
-      conflictFatalities: agg.fatPV + agg.fatCT,
-      referencePeriod: agg.month,
-      conflictDemonstrations: agg.eventsDem,
-      updatedAt: Date.now(),
-    },
-  };
+function previousMonthStart(nowMs) {
+  const now = new Date(nowMs);
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+    .toISOString()
+    .slice(0, 10);
 }
 
-async function fetchAllHumanitarianSummaries() {
-  const results = {};
-  let consecutiveFailures = 0;
-  let attempted = 0;
-  for (const cc of HAPI_COUNTRIES) {
-    attempted++;
-    try {
-      const data = await fetchHapiSummary(cc);
-      if (data?.summary) results[cc] = data;
-      consecutiveFailures = 0;
-    } catch (e) {
-      console.warn(`  HAPI ${cc}: ${e.message}`);
-      consecutiveFailures++;
-      if (consecutiveFailures >= HAPI_MAX_CONSECUTIVE_FAILURES) {
-        console.warn(`  HAPI: ${consecutiveFailures} consecutive failures (last: ${e.status ? `HTTP ${e.status}` : e.message}) — aborting sweep early (app_identifier throttled again, or a broader outage? see #5554) after ${attempted}/${HAPI_COUNTRIES.length} countries`);
-        break;
-      }
-    }
-    // Paced unconditionally (success, non-2xx, or network error) — this is the ONLY
-    // source of HAPI traffic in the app, so this loop's pacing is what keeps combined
-    // traffic within HDX's ~1 req/s courtesy ask (#5554).
-    await sleep(HAPI_REQUEST_DELAY_MS);
+export function buildHapiConflictEventsUrl({
+  nowMs = Date.now(),
+  offset = 0,
+  countryCode,
+  adminLevel = '0',
+} = {}) {
+  const url = new URL('https://hapi.humdata.org/api/v2/coordination-context/conflict-events');
+  url.searchParams.set('output_format', 'json');
+  if (adminLevel != null) url.searchParams.set('admin_level', String(adminLevel));
+  url.searchParams.set('start_date', previousMonthStart(nowMs));
+  url.searchParams.set('limit', String(HAPI_PAGE_LIMIT));
+  url.searchParams.set('offset', String(offset));
+  if (countryCode) {
+    const iso3 = ISO2_TO_ISO3[countryCode];
+    if (!iso3) throw new Error(`No ISO3 mapping for HAPI country ${countryCode}`);
+    url.searchParams.set('location_code', iso3);
   }
-  console.log(`  Humanitarian: ${Object.keys(results).length}/${HAPI_COUNTRIES.length} countries`);
+  return url.toString();
+}
+
+function finiteCount(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function aggregateHapiConflictEvents(
+  records,
+  { nowMs = Date.now(), countryCodes = HAPI_COUNTRIES } = {},
+) {
+  const targetCountries = new Set(countryCodes);
+  const aggregates = new Map();
+
+  for (const row of Array.isArray(records) ? records : []) {
+    const countryCode = ISO3_TO_ISO2.get(String(row?.location_code || '').toUpperCase());
+    if (!countryCode || !targetCountries.has(countryCode)) continue;
+
+    const referencePeriod = String(row?.reference_period_start || '');
+    if (!referencePeriod) continue;
+    const parsedAdminLevel = Number(row?.admin_level ?? 0);
+    const adminLevel = Number.isFinite(parsedAdminLevel) ? parsedAdminLevel : 0;
+
+    let aggregate = aggregates.get(countryCode);
+    if (
+      !aggregate
+      || referencePeriod > aggregate.referencePeriod
+      || (referencePeriod === aggregate.referencePeriod && adminLevel > aggregate.adminLevel)
+    ) {
+      aggregate = {
+        referencePeriod,
+        adminLevel,
+        countryName: String(row?.location_name || ''),
+        eventsTotal: 0,
+        eventsPV: 0,
+        eventsCT: 0,
+        eventsDem: 0,
+        fatalitiesPV: 0,
+        fatalitiesCT: 0,
+      };
+      aggregates.set(countryCode, aggregate);
+    }
+    if (
+      referencePeriod !== aggregate.referencePeriod
+      || adminLevel !== aggregate.adminLevel
+    ) continue;
+
+    const eventType = String(row?.event_type || '').toLowerCase();
+    const events = finiteCount(row?.events);
+    const fatalities = finiteCount(row?.fatalities);
+    aggregate.eventsTotal += events;
+    if (eventType === 'political_violence') {
+      aggregate.eventsPV += events;
+      aggregate.fatalitiesPV += fatalities;
+    } else if (eventType === 'civilian_targeting') {
+      aggregate.eventsCT += events;
+      aggregate.fatalitiesCT += fatalities;
+    } else if (eventType === 'demonstration') {
+      aggregate.eventsDem += events;
+    }
+  }
+
+  const results = {};
+  for (const [countryCode, aggregate] of aggregates) {
+    results[countryCode] = {
+      summary: {
+        countryCode,
+        countryName: aggregate.countryName,
+        conflictEventsTotal: aggregate.eventsTotal,
+        conflictPoliticalViolenceEvents: aggregate.eventsPV + aggregate.eventsCT,
+        conflictFatalities: aggregate.fatalitiesPV + aggregate.fatalitiesCT,
+        referencePeriod: aggregate.referencePeriod,
+        conflictDemonstrations: aggregate.eventsDem,
+        updatedAt: nowMs,
+      },
+    };
+  }
   return results;
+}
+
+async function defaultPreserveHapiLastGood() {
+  await extendExistingTtl(
+    HAPI_COUNTRIES.map((countryCode) => `${HAPI_CACHE_KEY_PREFIX}:${countryCode}`),
+    HAPI_TTL,
+  );
+  await extendExistingTtl(
+    [HAPI_CACHE_KEY_PREFIX, HAPI_SEED_META_KEY],
+    HAPI_SEED_META_TTL_SECONDS,
+  );
+}
+
+async function fetchHapiRows({
+  fetchFn,
+  nowMs,
+  countryCode,
+  adminLevel,
+}) {
+  const records = [];
+  let fullyRead = false;
+  for (let page = 0; page < HAPI_MAX_PAGES; page += 1) {
+    const offset = page * HAPI_PAGE_LIMIT;
+    const resp = await fetchFn(
+      buildHapiConflictEventsUrl({ nowMs, offset, countryCode, adminLevel }),
+      {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': CHROME_UA,
+          'X-HDX-HAPI-APP-IDENTIFIER': HAPI_APP_IDENTIFIER,
+        },
+        signal: AbortSignal.timeout(HAPI_REQUEST_TIMEOUT_MS),
+      },
+    );
+    if (!resp.ok) {
+      let providerMessage = '';
+      try {
+        const body = await resp.json();
+        providerMessage = String(body?.error || body?.detail || '');
+      } catch {
+        // Status and status text remain sufficient when the provider sends no JSON.
+      }
+      throw Object.assign(
+        new Error(`HTTP ${resp.status} ${resp.statusText}${providerMessage ? `: ${providerMessage}` : ''}`),
+        { status: resp.status },
+      );
+    }
+
+    const rawData = await resp.json();
+    const pageRows = Array.isArray(rawData?.data) ? rawData.data : [];
+    records.push(...pageRows);
+    if (pageRows.length < HAPI_PAGE_LIMIT) {
+      fullyRead = true;
+      break;
+    }
+  }
+
+  if (!fullyRead) {
+    throw new Error(
+      `${countryCode || 'global'} bulk response exceeded ${HAPI_MAX_PAGES * HAPI_PAGE_LIMIT} rows`,
+    );
+  }
+  return records;
+}
+
+export async function fetchAllHumanitarianSummaries({
+  fetchFn = (...args) => globalThis.fetch(...args),
+  now = Date.now,
+  pace = sleep,
+  countryCodes = HAPI_COUNTRIES,
+  requiredCountryCodes = countryCodes === HAPI_COUNTRIES ? HAPI_REQUIRED_COUNTRIES : countryCodes,
+  loadPreviousMarker = () => readSeedSnapshot(HAPI_CACHE_KEY_PREFIX),
+  loadFailureBackoff = () => readSeedSnapshot(HAPI_FAILURE_BACKOFF_KEY),
+  writeFailureBackoff = (value) => writeExtraKey(
+    HAPI_FAILURE_BACKOFF_KEY,
+    value,
+    Math.ceil(HAPI_FAILURE_BACKOFF_MS / 1000),
+  ),
+  preserveLastGood = defaultPreserveHapiLastGood,
+} = {}) {
+  const nowMs = now();
+  const failureBackoff = await loadFailureBackoff().catch((error) => {
+    console.warn(`  HAPI backoff read failed: ${error.message}`);
+    return null;
+  });
+  if (Number(failureBackoff?.retryAt) > nowMs) {
+    console.log(`  Humanitarian: provider backoff active until ${new Date(failureBackoff.retryAt).toISOString()}`);
+    return null;
+  }
+
+  const previousMarker = await loadPreviousMarker().catch((error) => {
+    console.warn(`  HAPI freshness marker read failed: ${error.message}`);
+    return null;
+  });
+  if (
+    Number.isFinite(Number(previousMarker?.updatedAt))
+    && nowMs - Number(previousMarker.updatedAt) < HAPI_REFRESH_INTERVAL_MS
+  ) {
+    console.log(`  Humanitarian: recent bulk snapshot still fresh (${Object.keys(previousMarker).length > 0 ? previousMarker.countriesCovered ?? 'unknown' : 'unknown'} countries)`);
+    return null;
+  }
+
+  let failure;
+  try {
+    // Most countries have national rows, so one global admin-0 request covers
+    // them without the old per-country fan-out.
+    const nationalRows = await fetchHapiRows({
+      fetchFn,
+      nowMs,
+      adminLevel: '0',
+    });
+    const results = aggregateHapiConflictEvents(nationalRows, { nowMs, countryCodes });
+
+    // HRP/GHO countries may only publish subnational rows. Fetch only the
+    // national-missing target countries and aggregate their deepest available
+    // administrative level, pacing the bounded fallback sequentially.
+    const missingCountries = requiredCountryCodes.filter((countryCode) => !results[countryCode]);
+    let fallbackFailure = null;
+    let fallbackRows = 0;
+    for (let i = 0; i < missingCountries.length; i += 1) {
+      const countryCode = missingCountries[i];
+      try {
+        const rows = await fetchHapiRows({
+          fetchFn,
+          nowMs,
+          countryCode,
+          adminLevel: null,
+        });
+        fallbackRows += rows.length;
+        Object.assign(
+          results,
+          aggregateHapiConflictEvents(rows, { nowMs, countryCodes: [countryCode] }),
+        );
+      } catch (error) {
+        fallbackFailure = error;
+        console.warn(`  HAPI ${countryCode} fallback failed: ${error.message}`);
+        if (error.status === 429 || error.status === 403) break;
+      }
+      if (i < missingCountries.length - 1) await pace(HAPI_REQUEST_DELAY_MS);
+    }
+
+    if (Object.keys(results).length === 0) {
+      throw new Error('bulk response contained no target-country national summaries');
+    }
+
+    if (fallbackFailure) {
+      const retryAt = nowMs + HAPI_FAILURE_BACKOFF_MS;
+      await writeFailureBackoff({
+        status: Number.isFinite(Number(fallbackFailure.status)) ? Number(fallbackFailure.status) : 0,
+        failedAt: nowMs,
+        retryAt,
+      }).catch((error) => console.warn(`  HAPI backoff write failed: ${error.message}`));
+      await preserveLastGood().catch((error) => console.warn(`  HAPI last-good preservation failed: ${error.message}`));
+    }
+
+    const requiredCovered = requiredCountryCodes.filter((countryCode) => results[countryCode]).length;
+    console.log(`  Humanitarian: ${Object.keys(results).length}/${countryCodes.length} countries (${requiredCovered}/${requiredCountryCodes.length} required) from ${nationalRows.length + fallbackRows} bulk rows`);
+    return results;
+  } catch (error) {
+    failure = error;
+  }
+
+  const retryAt = nowMs + HAPI_FAILURE_BACKOFF_MS;
+  console.warn(`  HAPI bulk failed: ${failure.message} — preserving last-good data and backing off until ${new Date(retryAt).toISOString()}`);
+  await writeFailureBackoff({
+    status: Number.isFinite(Number(failure.status)) ? Number(failure.status) : 0,
+    failedAt: nowMs,
+    retryAt,
+  }).catch((error) => console.warn(`  HAPI backoff write failed: ${error.message}`));
+  await preserveLastGood().catch((error) => console.warn(`  HAPI last-good preservation failed: ${error.message}`));
+  return null;
 }
 
 // ─── PizzINT Status ───
@@ -587,9 +805,10 @@ async function fetchGdeltTensions() {
 // global-fetch stub can intercept, so it must be injectable to keep tests hermetic.
 export async function fetchAll({ fetchGdeltFallback = fetchGdeltConflictEvents } = {}) {
   // #5140: anchor the GDELT-fallback sweep cutoff at the START of the fetch phase,
-  // not at sweep entry — the aux feeds below (HAPI is sequential, ~346s worst) and
-  // the sweep share runSeed's single fetch deadline, so time the aux stage burns
-  // must come out of the sweep's window, not be added to it.
+  // not at sweep entry — the aux feeds below and the sweep share runSeed's
+  // single fetch deadline, so time the aux stage burns must come out of the
+  // sweep's window, not be added to it. HAPI is now one bulk request plus only
+  // bounded missing-country fallbacks rather than a 38-country sweep.
   const sweepDeadlineAt = Date.now() + GDELT_SWEEP_BUDGET_MS;
   const [acled, acledResolution, hapi, pizzint, gdelt] = await Promise.allSettled([
     fetchAcledEvents({ label: 'ACLED display' }),
@@ -632,11 +851,17 @@ export async function fetchAll({ fetchGdeltFallback = fetchGdeltConflictEvents }
     // degraded) to a path that previously did nothing at all in that scenario —
     // staleness still surfaces naturally once the last real marker's TTL/maxStaleMin
     // window elapses, no need to force a write here.
+    const requiredCountriesCovered = HAPI_REQUIRED_COUNTRIES.filter((countryCode) => ha[countryCode]).length;
     await writeExtraKeyWithMeta(
       HAPI_CACHE_KEY_PREFIX,
-      { countriesCovered: Object.keys(ha).length, updatedAt: Date.now() },
+      {
+        countriesCovered: Object.keys(ha).length,
+        requiredCountriesCovered,
+        requiredCountriesTotal: HAPI_REQUIRED_COUNTRIES.length,
+        updatedAt: Date.now(),
+      },
       HAPI_SEED_META_TTL_SECONDS,
-      Object.keys(ha).length,
+      requiredCountriesCovered,
       HAPI_SEED_META_KEY,
       HAPI_SEED_META_TTL_SECONDS,
     );

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -701,7 +701,14 @@ export async function fetchAllHumanitarianSummaries({
     }
 
     if (Object.keys(results).length === 0) {
-      throw new Error('bulk response contained no target-country national summaries');
+      // Carry the fallback's status (e.g. 429/403) onto the thrown error so the
+      // outer catch's backoff write below records the real provider status
+      // instead of falling back to 0 when a fallback rejection is what left
+      // results empty.
+      throw Object.assign(
+        new Error('bulk response contained no target-country national summaries'),
+        fallbackFailure?.status != null ? { status: fallbackFailure.status } : {},
+      );
     }
 
     if (fallbackFailure) {

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -662,10 +662,12 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(snapshot.status, 'healthy');
     const sseCalls = calls.filter((call) => call.url.includes('query.sse.com.cn'));
     assert.equal(sseCalls.length, 4);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse.maxConcurrentRequests, 2);
     assert.equal(calls.filter((call) => call.url.includes('www.szse.cn')).length, 1);
     assert.equal(calls.every((call) => call.init?.redirect === 'error'), true);
     assert.equal(calls.some((call) => /\.pdf/i.test(call.url)), false);
     const firstSseUrl = new URL(sseCalls[0].url);
+    assert.equal(firstSseUrl.searchParams.get('pageHelp.pageSize'), '100');
     assert.equal(
       Date.parse(firstSseUrl.searchParams.get('endDate')!)
         - Date.parse(firstSseUrl.searchParams.get('beginDate')!),
@@ -712,8 +714,8 @@ describe('official China corporate disclosures (#5577)', () => {
         if (url.includes('query.sse.com.cn')) {
           const productId = new URL(url).searchParams.get('productId');
           const payload = productId === '600519'
-            ? { ...fixture('sse.json'), pageHelp: { pageNo: 1, pageSize: 25, total: 26 } }
-            : { pageHelp: { pageNo: 1, pageSize: 25, total: 0 }, result: [] };
+            ? { ...fixture('sse.json'), pageHelp: { pageNo: 1, pageSize: 100, total: 101 } }
+            : { pageHelp: { pageNo: 1, pageSize: 100, total: 0 }, result: [] };
           return new Response(JSON.stringify(payload), { status: 200 });
         }
         return new Response(JSON.stringify({ ...fixture('szse.json'), announceCount: 51 }), {

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -302,6 +302,39 @@ describe('China coverage manifest', () => {
     assert.ok(missingTransport.entries[0].reasonCodes.includes(CHINA_COVERAGE_REASON_CODES.TRANSPORT_MISSING));
   });
 
+  it('reports a fresh but degraded disclosure snapshot as partial coverage', () => {
+    const disclosures = CHINA_COVERAGE_ENTRIES.find(
+      (entry) => entry.id === 'market.china-corporate-disclosures',
+    );
+    const result = evaluate(
+      disclosures,
+      {
+        'market:china:corporate-disclosures:v1': {
+          status: 'degraded',
+          coverageThrough: null,
+          events: [],
+          sources: [
+            { id: 'sse', transportStatus: 'fresh', contentStatus: 'partial' },
+            { id: 'szse', transportStatus: 'error', contentStatus: 'unavailable' },
+          ],
+        },
+      },
+      {
+        'seed-meta:market:china-corporate-disclosures': {
+          fetchedAt: NOW,
+          status: 'ok',
+        },
+      },
+    );
+
+    assert.equal(result.entries[0].status, 'degraded');
+    assert.equal(result.entries[0].content.status, 'partial');
+    assert.deepEqual(
+      result.entries[0].reasonCodes,
+      [CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL],
+    );
+  });
+
   it('uses the source-specific China news projection rather than global top stories', () => {
     const news = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'news.china');
     const data = {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -705,6 +705,22 @@ describe('standalone Railway cron split', () => {
   it('Dockerfile sets dns-result-order=ipv4first (matches other seed services)', () => {
     assert.match(dockerfileSrc, /dns-result-order=ipv4first/);
   });
+
+  it('declares the 12-hour recovery cadence in the Railway service registry', () => {
+    const registry = JSON.parse(
+      readFileSync(resolve(root, 'scripts/railway-services.json'), 'utf8'),
+    );
+    const service = registry.find(
+      (entry) => entry.service === 'seed-bundle-portwatch-port-activity',
+    );
+    assert.equal(service?.cronSchedule, '0 */12 * * *');
+    assert.deepEqual(service?.requiredEnv, [
+      'UPSTASH_REDIS_REST_URL',
+      'UPSTASH_REDIS_REST_TOKEN',
+      'PROXY_URL',
+    ]);
+    assert.match(bundleSrc, /Cron schedule:\s*"0 \*\/12 \* \* \*"/);
+  });
 });
 
 describe('SKIPPED log message', () => {

--- a/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
+++ b/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
@@ -1,107 +1,305 @@
-// Regression tests for #5554: the HAPI sweep's circuit breaker.
+// Regression coverage for the HAPI bot-block follow-up to #5554.
 //
-// fetchAllHumanitarianSummaries() aborts the per-country HAPI sweep after
-// HAPI_MAX_CONSECUTIVE_FAILURES consecutive failures, counting ANY failure type
-// (429, other HTTP errors, network/timeout) -- not just 429. An earlier version
-// only counted 429s and reset the streak on any other failure type, so a mixed
-// pattern like 429/timeout/429/timeout never tripped the breaker at all, defeating
-// the whole point of bounding worst-case sweep time (review finding on #5554).
-//
-// fetchHapiSummary/fetchAllHumanitarianSummaries aren't exported, so these tests
-// drive the breaker indirectly through fetchAll() and count HAPI-bound fetch calls.
+// The first repair paced 38 per-country requests at ~1 request/second, but the
+// production identifier was blocked again after that still produced thousands
+// of requests per day. The durable contract is:
+//   - one national-level bulk request for the target countries,
+//   - no new request while the last successful snapshot is fresh,
+//   - a persisted failure backoff after a provider rejection, and
+//   - last-known-good Redis rows preserved without refreshing their fetchedAt.
 
-import { test, beforeEach, afterEach } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
-import { fetchAll } from '../scripts/seed-conflict-intel.mjs';
+import {
+  HAPI_FAILURE_BACKOFF_MS,
+  HAPI_REFRESH_INTERVAL_MS,
+  HAPI_REQUIRED_COUNTRIES,
+  aggregateHapiConflictEvents,
+  buildHapiConflictEventsUrl,
+  fetchAllHumanitarianSummaries,
+} from '../scripts/seed-conflict-intel.mjs';
 
-const ORIGINAL_FETCH = globalThis.fetch;
-const ORIGINAL_ENV = {
-  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
-  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
-  ACLED_EMAIL: process.env.ACLED_EMAIL,
-  ACLED_PASSWORD: process.env.ACLED_PASSWORD,
-  ACLED_ACCESS_TOKEN: process.env.ACLED_ACCESS_TOKEN,
-};
+const NOW = Date.parse('2026-07-26T13:30:00Z');
 
-beforeEach(() => {
-  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
-  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
-  delete process.env.ACLED_EMAIL;
-  delete process.env.ACLED_PASSWORD;
-  delete process.env.ACLED_ACCESS_TOKEN;
-});
-
-afterEach(() => {
-  globalThis.fetch = ORIGINAL_FETCH;
-  for (const [k, v] of Object.entries(ORIGINAL_ENV)) {
-    if (v == null) delete process.env[k];
-    else process.env[k] = v;
-  }
-});
-
-// A fast GDELT stub so these tests exercise only the HAPI sweep's timing, not
-// GDELT's own (much slower, curl-proxy-involving) fallback path.
-const FAST_GDELT_FALLBACK = async () => ({ events: [], source: 'gdelt' });
-
-test('HAPI sweep aborts after 3 consecutive failures of the SAME type (429)', async () => {
-  let hapiCalls = 0;
-  globalThis.fetch = async (url) => {
-    const u = String(url);
-    if (u.includes('hapi.humdata.org')) {
-      hapiCalls++;
-      return new Response('rate limited', { status: 429 });
-    }
-    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
-  };
-
-  await fetchAll({ fetchGdeltFallback: FAST_GDELT_FALLBACK });
-
-  assert.equal(hapiCalls, 3, 'sweep should stop after exactly 3 consecutive HAPI failures, not attempt every country');
-});
-
-test('HAPI sweep aborts after 3 consecutive failures of MIXED types (429, timeout, 500)', async () => {
-  let hapiCalls = 0;
-  globalThis.fetch = async (url) => {
-    const u = String(url);
-    if (u.includes('hapi.humdata.org')) {
-      hapiCalls++;
-      if (hapiCalls === 1) return new Response('rate limited', { status: 429 });
-      if (hapiCalls === 2) throw new Error('fetch failed: network timeout');
-      return new Response('server error', { status: 500 });
-    }
-    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
-  };
-
-  await fetchAll({ fetchGdeltFallback: FAST_GDELT_FALLBACK });
-
-  assert.equal(
-    hapiCalls, 3,
-    'a mixed failure pattern (429 -> timeout -> 500) must still trip the breaker at 3 -- ' +
-    'this is the exact bug: an earlier version only counted 429s and reset on any other ' +
-    'failure type, so this pattern never aborted',
+test('humanitarian health reports partial target-country coverage', () => {
+  const healthSource = readFileSync(new URL('../api/health.js', import.meta.url), 'utf8');
+  const seedSource = readFileSync(new URL('../scripts/seed-conflict-intel.mjs', import.meta.url), 'utf8');
+  assert.match(
+    healthSource,
+    /humanitarianSummary:\s*\{[^}]*maxStaleMin:\s*300,\s*minRecordCount:\s*23\s*\}/,
+  );
+  assert.match(
+    seedSource,
+    /const requiredCountriesCovered = HAPI_REQUIRED_COUNTRIES\.filter\([^;]+/,
+  );
+  assert.match(
+    seedSource,
+    /HAPI_SEED_META_TTL_SECONDS,\s*requiredCountriesCovered,\s*HAPI_SEED_META_KEY/,
+  );
+  assert.equal(HAPI_REQUIRED_COUNTRIES.length, 23);
+  assert.deepEqual(
+    new Set(HAPI_REQUIRED_COUNTRIES),
+    new Set([
+      'US', 'RU', 'CN', 'UA', 'IR', 'IL', 'TW', 'KP', 'SA', 'TR',
+      'PL', 'DE', 'FR', 'GB', 'IN', 'PK', 'SY', 'YE', 'MM', 'VE',
+      'SD', 'DJ', 'ER',
+    ]),
   );
 });
 
-test('HAPI sweep streak resets on an intervening success, allowing more attempts', async () => {
-  let hapiCalls = 0;
-  globalThis.fetch = async (url) => {
-    const u = String(url);
-    if (u.includes('hapi.humdata.org')) {
-      hapiCalls++;
-      // fail, fail, SUCCEED (empty data), fail, fail, fail -> breaker should only
-      // trip on the second run of 3, i.e. after the 6th HAPI call, not the 3rd.
-      if (hapiCalls === 3) return new Response(JSON.stringify({ data: [] }), { status: 200 });
-      return new Response('server error', { status: 500 });
-    }
-    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+test('HAPI bulk URL requests national totals for the current and previous month', () => {
+  const url = new URL(buildHapiConflictEventsUrl({ nowMs: NOW }));
+
+  assert.equal(url.origin, 'https://hapi.humdata.org');
+  assert.equal(url.pathname, '/api/v2/coordination-context/conflict-events');
+  assert.equal(url.searchParams.get('admin_level'), '0');
+  assert.equal(url.searchParams.get('start_date'), '2026-06-01');
+  assert.equal(url.searchParams.get('limit'), '10000');
+  assert.equal(url.searchParams.get('offset'), '0');
+  assert.equal(url.searchParams.has('location_code'), false);
+  assert.equal(url.searchParams.has('app_identifier'), false, 'identifier belongs in the supported request header');
+});
+
+test('HAPI bulk rows are grouped by country and only the latest reference period is published', () => {
+  const rows = [
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-06-01',
+      admin_level: 0,
+      event_type: 'political_violence',
+      events: 99,
+      fatalities: 10,
+    },
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-07-01',
+      admin_level: 0,
+      event_type: 'political_violence',
+      events: 12,
+      fatalities: 3,
+    },
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-07-01',
+      admin_level: 0,
+      event_type: 'civilian_targeting',
+      events: 4,
+      fatalities: 2,
+    },
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-07-01',
+      admin_level: 0,
+      event_type: 'demonstration',
+      events: 7,
+      fatalities: 0,
+    },
+    {
+      location_code: 'ZZZ',
+      location_name: 'Unknown',
+      reference_period_start: '2026-07-01',
+      admin_level: 0,
+      event_type: 'political_violence',
+      events: 500,
+      fatalities: 500,
+    },
+  ];
+
+  const result = aggregateHapiConflictEvents(rows, { nowMs: NOW, countryCodes: ['SD'] });
+
+  assert.deepEqual(result, {
+    SD: {
+      summary: {
+        countryCode: 'SD',
+        countryName: 'Sudan',
+        conflictEventsTotal: 23,
+        conflictPoliticalViolenceEvents: 16,
+        conflictFatalities: 5,
+        referencePeriod: '2026-07-01',
+        conflictDemonstrations: 7,
+        updatedAt: NOW,
+      },
+    },
+  });
+});
+
+test('HAPI aggregation uses the deepest available administrative level without double counting', () => {
+  const result = aggregateHapiConflictEvents([
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-07-01',
+      admin_level: 1,
+      event_type: 'political_violence',
+      events: 100,
+      fatalities: 10,
+    },
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-07-01',
+      admin_level: 2,
+      event_type: 'political_violence',
+      events: 12,
+      fatalities: 3,
+    },
+    {
+      location_code: 'SDN',
+      location_name: 'Sudan',
+      reference_period_start: '2026-07-01',
+      admin_level: 2,
+      event_type: 'demonstration',
+      events: 7,
+      fatalities: 0,
+    },
+  ], { nowMs: NOW, countryCodes: ['SD'] });
+
+  assert.equal(result.SD.summary.conflictEventsTotal, 19);
+  assert.equal(result.SD.summary.conflictFatalities, 3);
+});
+
+test('HAPI ingestion makes one bulk request and maps all returned target countries', async () => {
+  const calls = [];
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD', 'UA'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async () => assert.fail('success must not write a failure backoff'),
+    preserveLastGood: async () => assert.fail('success must not extend stale rows'),
+    fetchFn: async (url, options) => {
+      calls.push({ url: String(url), options });
+      return new Response(JSON.stringify({
+        data: [
+          {
+            location_code: 'SDN',
+            location_name: 'Sudan',
+            reference_period_start: '2026-07-01',
+            admin_level: 0,
+            event_type: 'political_violence',
+            events: 12,
+            fatalities: 3,
+          },
+          {
+            location_code: 'UKR',
+            location_name: 'Ukraine',
+            reference_period_start: '2026-07-01',
+            admin_level: 0,
+            event_type: 'demonstration',
+            events: 8,
+            fatalities: 0,
+          },
+        ],
+      }), { status: 200 });
+    },
+  });
+
+  assert.equal(calls.length, 1, 'one bulk request replaces the 38-request per-country sweep');
+  assert.ok(calls[0].options.headers['X-HDX-HAPI-APP-IDENTIFIER']);
+  assert.deepEqual(Object.keys(result).sort(), ['SD', 'UA']);
+});
+
+test('HAPI ingestion falls back only for targets missing national rows', async () => {
+  const urls = [];
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD', 'UA'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async () => assert.fail('complete coverage must not write a failure backoff'),
+    preserveLastGood: async () => assert.fail('complete coverage must not extend stale rows'),
+    fetchFn: async (url) => {
+      const parsed = new URL(url);
+      urls.push(parsed);
+      const data = parsed.searchParams.get('location_code') === 'SDN'
+        ? [{
+            location_code: 'SDN',
+            location_name: 'Sudan',
+            reference_period_start: '2026-07-01',
+            admin_level: 2,
+            event_type: 'political_violence',
+            events: 12,
+            fatalities: 3,
+          }]
+        : [{
+            location_code: 'UKR',
+            location_name: 'Ukraine',
+            reference_period_start: '2026-07-01',
+            admin_level: 0,
+            event_type: 'demonstration',
+            events: 8,
+            fatalities: 0,
+          }];
+      return new Response(JSON.stringify({ data }), { status: 200 });
+    },
+  });
+
+  assert.equal(urls.length, 2);
+  assert.equal(urls[0].searchParams.get('admin_level'), '0');
+  assert.equal(urls[0].searchParams.has('location_code'), false);
+  assert.equal(urls[1].searchParams.has('admin_level'), false);
+  assert.equal(urls[1].searchParams.get('location_code'), 'SDN');
+  assert.deepEqual(Object.keys(result).sort(), ['SD', 'UA']);
+});
+
+test('HAPI provider rejection persists a backoff and preserves last-known-good rows', async () => {
+  let calls = 0;
+  let backoff;
+  let preserved = 0;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    preserveLastGood: async () => { preserved += 1; },
+    fetchFn: async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ error: 'Blocked due to bot activity.' }), { status: 429 });
+    },
+  });
+
+  assert.equal(result, null);
+  assert.equal(calls, 1, 'a blocked bulk request must not fan out into per-country retries');
+  assert.equal(preserved, 1);
+  assert.equal(backoff.status, 429);
+  assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
+});
+
+test('HAPI ingestion skips network calls during success and failure backoff windows', async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return new Response(JSON.stringify({ data: [] }), { status: 200 });
   };
 
-  await fetchAll({ fetchGdeltFallback: FAST_GDELT_FALLBACK });
+  const recent = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => ({ updatedAt: NOW - HAPI_REFRESH_INTERVAL_MS + 1 }),
+    loadFailureBackoff: async () => null,
+    fetchFn,
+  });
+  const blocked = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => ({ retryAt: NOW + 1 }),
+    fetchFn,
+  });
 
-  assert.equal(
-    hapiCalls, 6,
-    'a success between two failure runs must reset the streak, so the breaker only trips ' +
-    'on the second run of 3 consecutive failures (call #6), not the first (call #3)',
-  );
+  assert.equal(recent, null);
+  assert.equal(blocked, null);
+  assert.equal(calls, 0);
 });

--- a/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
+++ b/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
@@ -275,6 +275,34 @@ test('HAPI provider rejection persists a backoff and preserves last-known-good r
   assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
 });
 
+test('HAPI backoff records the fallback rejection status when the national sweep is empty', async () => {
+  let backoff;
+  let preserved = 0;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    preserveLastGood: async () => { preserved += 1; },
+    fetchFn: async (url) => {
+      const parsed = new URL(url);
+      if (!parsed.searchParams.has('location_code')) {
+        // National admin-0 sweep covers nothing for this target country.
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      // Bounded per-country fallback is the one that gets throttled.
+      return new Response(JSON.stringify({ error: 'Blocked due to bot activity.' }), { status: 429 });
+    },
+  });
+
+  assert.equal(result, null);
+  assert.equal(preserved, 1);
+  assert.equal(backoff.status, 429, 'must record the fallback rejection status, not fall back to 0');
+  assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
+});
+
 test('HAPI ingestion skips network calls during success and failure backoff windows', async () => {
   let calls = 0;
   const fetchFn = async () => {

--- a/tests/server-handlers.test.mjs
+++ b/tests/server-handlers.test.mjs
@@ -2,8 +2,8 @@
  * Tests for server handler correctness after PR #106 review fixes.
  *
  * These tests verify:
- * - Humanitarian summary handler rejects unmapped country codes
- * - Humanitarian summary returns ISO-2 country_code (not ISO-3)
+ * - Humanitarian summary aggregation rejects unmapped country codes
+ * - Humanitarian summary aggregation returns ISO-2 country_code (not ISO-3)
  * - Hardcoded political context is removed from LLM prompts
  * - Headline deduplication logic works correctly
  * - Cache key builder produces deterministic output
@@ -27,31 +27,27 @@ const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
 // 1. Humanitarian summary: country fallback + ISO-2 contract
 // ========================================================================
 
-describe('fetchHapiSummary (scripts/seed-conflict-intel.mjs)', () => {
+describe('aggregateHapiConflictEvents (scripts/seed-conflict-intel.mjs)', () => {
   // #5554: server/worldmonitor/conflict/v1/get-humanitarian-summary.ts no longer
   // fetches HAPI at all — it's a cache-only read of what this seeder writes (HDX's
   // app_identifier rate limiting is per-identifier, so a per-request RPC fetch would
-  // stack uncoordinated traffic on top of the seeder's own paced loop). The
+  // stack uncoordinated traffic on top of the seeder's bulk refresh). The
   // BLOCKING-1/BLOCKING-2/MEDIUM-1 guards below (originally PR #106, against the old
   // RPC-handler implementation) moved here with the fetch/aggregation logic itself.
   const src = readSrc('scripts/seed-conflict-intel.mjs');
 
-  it('returns null when country has no ISO3 mapping (BLOCKING-1)', () => {
-    // Must have early return when no ISO3 mapping (before the HAPI fetch)
-    assert.match(src, /if\s*\(\s*!iso3\s*\)\s*return\s+null/,
-      'fetchHapiSummary should return null when no ISO3 mapping exists');
-    // Unlike the old RPC-handler implementation (a byCountry map with a
-    // countryCode-absent fallback to the first entry), the seeder only ever
-    // aggregates records matching the ONE requested iso3 — there is no map to
-    // silently fall back into, so this pattern must never reappear here.
+  it('ignores rows whose ISO3 location has no ISO2 mapping (BLOCKING-1)', () => {
+    assert.match(src, /ISO3_TO_ISO2\.get\(/,
+      'bulk aggregation must translate HAPI ISO3 locations through the canonical map');
+    assert.match(src, /if\s*\(\s*!countryCode\s*\|\|\s*!targetCountries\.has\(countryCode\)\s*\)\s*continue/,
+      'unmapped and out-of-scope HAPI rows must be skipped');
     assert.doesNotMatch(src, /Object\.values\(byCountry\)\[0\]/,
-      'fetchHapiSummary must not fall back to an arbitrary country\'s data');
+      'bulk aggregation must not fall back to an arbitrary country\'s data');
   });
 
   it('returns ISO-2 country_code per proto contract (BLOCKING-2)', () => {
-    // Should return the original countryCode (uppercased), not the ISO-3 lookup key
-    assert.match(src, /countryCode:\s*countryCode\.toUpperCase\(\)/,
-      'Should return original ISO-2 countryCode uppercased');
+    assert.match(src, /results\[countryCode\]\s*=\s*\{\s*summary:\s*\{\s*countryCode,/,
+      'Should publish the ISO-2 key produced by the reverse mapping');
   });
 
   it('uses renamed conflict-event proto fields (MEDIUM-1)', () => {


### PR DESCRIPTION
## Summary

Humanitarian summaries can recover without re-triggering HAPI's bot block, official China disclosure health can distinguish partial coverage from missing timestamps, and PortWatch can rotate its bounded refresh queue quickly enough to reach the 174-country floor.

| Surface | Production failure | Patch behavior and operational result |
|---|---|---|
| Humanitarian | A 38-country sweep inherited the conflict seeder's 15-minute cadence and repeatedly hit provider throttling. | One national bulk request runs at most every two hours, with paced fallbacks only for missing required countries, persisted failure backoff, and last-good preservation. Health now verifies the complete 23-country dashboard and crisis-tracker contract. |
| China disclosures | SSE's 25-row first page saturated for reviewed issuers, while degraded source snapshots were mislabeled as missing timestamps. | The same four-request and 256 KiB bounds admit up to 100 rows with two-way concurrency; degraded source state now reports partial coverage directly. |
| PortWatch | The 30-country cold-refresh cap ran daily, so a 54-country upstream advance needed roughly 48 hours and the canonical projection remained at 159/174. | The registry and runbook return the intended cadence to 12 hours without increasing the per-run upstream or container budget; the live Railway setting still requires application after merge. |

Official Taiwan MND and Japan MOD observations remain separate from ADS-B, AIS, NOTAM, news, and market context. Last-good records remain available when an official transport fails, and no source is promoted to healthy without a successful current fetch.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [x] Config / Settings
- [x] Other: Railway seeders and health contracts

## Validation

- Focused humanitarian, GDELT, cache, China disclosure, China coverage, cross-Strait, PortWatch, and Railway registry suites: 469 passed, 0 failed.
- Pre-push gate: source and API typechecks, boundary and policy checks, 167 changed-file tests, 233 Edge tests, version sync, and bundle/import checks all passed.
- One bounded live HAPI bulk request returned 1,308 admin-0 records covering 19 target countries. Direct probing stopped after the provider throttled later requests, so deployed fallback recovery remains to be observed.
- Live SSE preflight returned the complete reviewed-issuer windows at page size 100; the largest response was 143,020 bytes, below the existing 256 KiB ceiling.
- Production PortWatch logs showed 174 eligible countries, 54 cache misses, the 30-country cap, and a 159-country publication, matching the cadence diagnosis.

## Operational follow-up

- Apply `0 */12 * * *` to the `seed-bundle-portwatch-port-activity` Railway service after merge and monitor two terminal runs.
- Japan MOD still returns HTTP 403 through both the production-style direct request and configured proxy. It remains `SEED_ERROR`; this PR does not add a bypass or claim recovery.
- The unrelated `comtradeBilateralHs4` critical health failure is intentionally outside this PR.

## Related

Related: #5554

Related: #5577

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — deployment required
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant — not applicable to seed-only behavior
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist — not applicable
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

Not applicable: this PR changes operational seed behavior and health classification without changing published methodology, API/MCP contracts, examples, or generated documentation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
