### PR TITLE
fix(china): proxy SZSE disclosures after direct failure

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -10,12 +10,13 @@ function parseProxyConfig(raw) {
   // Standard URL format: http://user:pass@host:port or https://user:pass@host:port
   try {
     const u = new URL(raw);
-    if (u.hostname) {
+    if (u.hostname && (u.protocol === 'http:' || u.protocol === 'https:')) {
+      const tls = u.protocol === 'https:';
       return {
         host: u.hostname,
-        port: parseInt(u.port, 10),
+        port: u.port ? parseInt(u.port, 10) : (tls ? 443 : 80),
         auth: u.username ? `${decodeURIComponent(u.username)}:${decodeURIComponent(u.password)}` : null,
-        tls: u.protocol === 'https:',
+        tls,
       };
     }
   } catch { /* fall through */ }
@@ -170,11 +171,32 @@ function proxyConnectTunnel(targetHostname, proxyConfig, { timeoutMs = 20_000, t
   });
 }
 
+function readBoundedResponseStream(stream, maxResponseBytes = Infinity) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let responseBytes = 0;
+    stream.on('data', (chunk) => {
+      responseBytes += chunk.byteLength;
+      if (responseBytes > maxResponseBytes) {
+        stream.destroy();
+        reject(Object.assign(new Error('proxy response too large'), {
+          code: 'RESPONSE_TOO_LARGE',
+        }));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    stream.on('end', () => resolve(Buffer.concat(chunks)));
+    stream.on('error', reject);
+  });
+}
+
 function proxyFetch(url, proxyConfig, {
   accept = '*/*',
   headers = {},
   method = 'GET',
   body = null,
+  maxResponseBytes = Infinity,
   timeoutMs = 20_000,
   signal,
 } = {}) {
@@ -226,17 +248,15 @@ function proxyFetch(url, proxyConfig, {
         if (enc === 'gzip') stream = resp.pipe(zlib.createGunzip());
         else if (enc === 'deflate') stream = resp.pipe(zlib.createInflate());
 
-        const chunks = [];
-        stream.on('data', (c) => chunks.push(c));
-        stream.on('end', () => {
-          resolveOnce({
+        readBoundedResponseStream(stream, maxResponseBytes).then(
+          (buffer) => resolveOnce({
             ok: resp.statusCode >= 200 && resp.statusCode < 300,
             status: resp.statusCode,
-            buffer: Buffer.concat(chunks),
+            buffer,
             contentType: resp.headers['content-type'] || '',
-          });
-        });
-        stream.on('error', rejectOnce);
+          }),
+          rejectOnce,
+        );
       });
       req.on('error', rejectOnce);
       if (body != null) req.write(body);
@@ -245,4 +265,13 @@ function proxyFetch(url, proxyConfig, {
   });
 }
 
-module.exports = { parseProxyConfig, resolveProxyConfig, resolveProxyConfigWithFallback, resolveProxyString, resolveProxyStringConnect, proxyConnectTunnel, proxyFetch };
+module.exports = {
+  parseProxyConfig,
+  resolveProxyConfig,
+  resolveProxyConfigWithFallback,
+  resolveProxyString,
+  resolveProxyStringConnect,
+  proxyConnectTunnel,
+  proxyFetch,
+  _readBoundedResponseStream: readBoundedResponseStream,
+};

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -78,6 +78,10 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     maxDirectRequestsPerRun: 1,
     maxProxyRequestsPerRun: 1,
     fallbackPolicy: 'direct_then_proxy_on_transport_failure',
+    // Railway registers PROXY_URL as required config for this service: without
+    // it the source still runs direct-only (no hard failure), but it loses
+    // the one capability this contract exists to provide, so an unset
+    // PROXY_URL in production is a deployment gap worth alerting on.
     proxyEnvironmentVariable: 'PROXY_URL',
     maxResponseBytes: 131_072,
     redirectPolicy: 'error',
@@ -156,6 +160,10 @@ const MAX_UNCLASSIFIED_REVISIONS = 100;
 const SSE_PAGE_SIZE = 100;
 const SSE_REQUEST_TIMEOUT_MS = 30_000;
 const SZSE_PAGE_SIZE = 50;
+// Worst case (direct attempt times out, then the proxy retry also times out)
+// this source can take up to SZSE_DIRECT_TIMEOUT_MS + SZSE_PROXY_TIMEOUT_MS
+// (~35s) before the bundle moves on. Keep this comfortably inside the
+// per-section timeoutMs configured for it in seed-bundle-market-backup.mjs.
 const SZSE_DIRECT_TIMEOUT_MS = 15_000;
 const SZSE_PROXY_TIMEOUT_MS = 20_000;
 const LAUNCHED_SOURCE_FETCHERS = Object.freeze([
@@ -461,12 +469,20 @@ async function fetchViaConfiguredProxy(input, init, {
 }) {
   const proxyConfig = parseProxyConfig(proxyUrl);
   if (!proxyConfig) throw sourceError('PROXY_NOT_CONFIGURED');
+  // init.headers carries the same Referer/User-Agent/Content-Type the direct
+  // request used (requestInit() below), deliberately: we're routing the exact
+  // same declared client through a different egress point, not masquerading
+  // as a browser, which matches the source's terms-of-use posture.
   const result = await proxyRequestFn(String(input), proxyConfig, {
     accept: 'application/json',
     headers: init?.headers,
     method: init?.method,
     body: init?.body,
     maxResponseBytes: maxBytes,
+    // signal already enforces requestInit()'s timeoutMs; timeoutMs here is a
+    // second, independent backstop inside proxyFetch's own socket/tunnel
+    // handling in case the AbortSignal doesn't propagate through a stalled
+    // CONNECT tunnel. Both are pinned to SZSE_PROXY_TIMEOUT_MS on purpose.
     timeoutMs: SZSE_PROXY_TIMEOUT_MS,
     signal: init?.signal,
   });

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -1,7 +1,14 @@
+import { createRequire } from 'node:module';
+
 import {
   CHINA_CORPORATE_DISCLOSURE_TYPES,
   CHINA_DISCLOSURE_DOCUMENT_HOSTS,
 } from '../shared/china-corporate-disclosure-policy.js';
+
+const {
+  parseProxyConfig,
+  proxyFetch,
+} = createRequire(import.meta.url)('../_proxy-utils.cjs');
 
 export const CHINA_CORPORATE_DISCLOSURE_KEY = 'market:china:corporate-disclosures:v1';
 
@@ -67,7 +74,11 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     metadataEndpoint: 'https://www.szse.cn/api/disc/announcement/annList',
     metadataHost: 'www.szse.cn',
     documentHosts: CHINA_DISCLOSURE_DOCUMENT_HOSTS.SZSE,
-    maxRequestsPerRun: 1,
+    maxRequestsPerRun: 2,
+    maxDirectRequestsPerRun: 1,
+    maxProxyRequestsPerRun: 1,
+    fallbackPolicy: 'direct_then_proxy_on_transport_failure',
+    proxyEnvironmentVariable: 'PROXY_URL',
     maxResponseBytes: 131_072,
     redirectPolicy: 'error',
     documentRetrieval: 'lazy-link-only',
@@ -145,6 +156,8 @@ const MAX_UNCLASSIFIED_REVISIONS = 100;
 const SSE_PAGE_SIZE = 100;
 const SSE_REQUEST_TIMEOUT_MS = 30_000;
 const SZSE_PAGE_SIZE = 50;
+const SZSE_DIRECT_TIMEOUT_MS = 15_000;
+const SZSE_PROXY_TIMEOUT_MS = 20_000;
 const LAUNCHED_SOURCE_FETCHERS = Object.freeze([
   Object.freeze(['sse', fetchSseAnnouncements]),
   Object.freeze(['szse', fetchSzseAnnouncements]),
@@ -423,6 +436,50 @@ function errorCodeFor(error) {
   return 'FETCH_FAILED';
 }
 
+function transportFailureReason(error) {
+  const causeCode = String(error?.cause?.code ?? '');
+  return /^[A-Z][A-Z0-9_]+$/u.test(causeCode)
+    ? causeCode
+    : errorCodeFor(error);
+}
+
+function shouldProxySzseFailure(error) {
+  const code = errorCodeFor(error);
+  if (code === 'FETCH_FAILED' || code === 'TIMEOUT') return true;
+  const status = Number(/^HTTP_(\d{3})$/u.exec(code)?.[1]);
+  return status === 403
+    || status === 408
+    || status === 425
+    || status === 429
+    || status >= 500;
+}
+
+async function fetchViaConfiguredProxy(input, init, {
+  proxyUrl,
+  maxBytes,
+  proxyRequestFn,
+}) {
+  const proxyConfig = parseProxyConfig(proxyUrl);
+  if (!proxyConfig) throw sourceError('PROXY_NOT_CONFIGURED');
+  const result = await proxyRequestFn(String(input), proxyConfig, {
+    accept: 'application/json',
+    headers: init?.headers,
+    method: init?.method,
+    body: init?.body,
+    maxResponseBytes: maxBytes,
+    timeoutMs: SZSE_PROXY_TIMEOUT_MS,
+    signal: init?.signal,
+  });
+  if (result.buffer.byteLength > maxBytes) throw sourceError('RESPONSE_TOO_LARGE');
+  return new Response(result.buffer, {
+    status: result.status,
+    headers: {
+      'Content-Length': String(result.buffer.byteLength),
+      'Content-Type': result.contentType || 'application/octet-stream',
+    },
+  });
+}
+
 async function fetchSseAnnouncements(fetchFn, now) {
   const contract = OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse;
   const issuers = REVIEWED_DISCLOSURE_ISSUERS.filter((issuer) => issuer.exchange === 'SSE');
@@ -496,14 +553,23 @@ async function fetchSseAnnouncements(fetchFn, now) {
   };
 }
 
-async function fetchSzseAnnouncements(fetchFn, now) {
+async function fetchSzseAnnouncements(fetchFn, now, {
+  proxyFetchFn = null,
+} = {}) {
   const contract = OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse;
   const { begin, end } = dateWindow(now);
   const retrievedAt = new Date(now).toISOString();
   const issuers = REVIEWED_DISCLOSURE_ISSUERS.filter((issuer) => issuer.exchange === 'SZSE');
   const url = new URL(contract.metadataEndpoint);
   url.searchParams.set('random', '0.5');
-  const response = await fetchFn(url, {
+  const body = JSON.stringify({
+    seDate: [begin, end],
+    channelCode: ['listedNotice_disc'],
+    stock: issuers.map((issuer) => issuer.securityCode),
+    pageSize: SZSE_PAGE_SIZE,
+    pageNum: 1,
+  });
+  const requestInit = (timeoutMs) => ({
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -511,28 +577,54 @@ async function fetchSzseAnnouncements(fetchFn, now) {
       'Content-Type': 'application/json',
       'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
     },
-    body: JSON.stringify({
-      seDate: [begin, end],
-      channelCode: ['listedNotice_disc'],
-      stock: issuers.map((issuer) => issuer.securityCode),
-      pageSize: SZSE_PAGE_SIZE,
-      pageNum: 1,
-    }),
+    body,
     redirect: contract.redirectPolicy,
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(timeoutMs),
   });
-  assertMetadataResponse(response, contract);
-  const payload = await readBoundedJsonResponse(response, contract.maxResponseBytes);
-  const announcements = normalizeSzseAnnouncements(payload, { retrievedAt });
-  const contentTruncated = Number(payload.announceCount) > SZSE_PAGE_SIZE;
+  const request = async (requestFn, timeoutMs) => {
+    const response = await requestFn(url, requestInit(timeoutMs));
+    assertMetadataResponse(response, contract);
+    const payload = await readBoundedJsonResponse(response, contract.maxResponseBytes);
+    return {
+      payload,
+      announcements: normalizeSzseAnnouncements(payload, { retrievedAt }),
+    };
+  };
+
+  let fetched;
+  let requestCount = 1;
+  let transportPath = 'direct';
+  let fallbackReason = null;
+  try {
+    fetched = await request(fetchFn, SZSE_DIRECT_TIMEOUT_MS);
+  } catch (directError) {
+    fallbackReason = transportFailureReason(directError);
+    if (!proxyFetchFn || !shouldProxySzseFailure(directError)) throw directError;
+    requestCount += 1;
+    transportPath = 'proxy';
+    try {
+      fetched = await request(proxyFetchFn, SZSE_PROXY_TIMEOUT_MS);
+    } catch (proxyError) {
+      const failure = sourceError(errorCodeFor(proxyError), proxyError);
+      failure.requestCount = requestCount;
+      failure.transportPath = transportPath;
+      failure.fallbackReason = fallbackReason;
+      failure.proxyFailureReason = transportFailureReason(proxyError);
+      throw failure;
+    }
+  }
+
+  const contentTruncated = Number(fetched.payload.announceCount) > SZSE_PAGE_SIZE;
   return {
     sourceId: 'szse',
     ok: !contentTruncated,
     partial: contentTruncated,
     transportOk: true,
-    requestCount: 1,
-    announcements,
+    requestCount,
+    announcements: fetched.announcements,
     errorCode: contentTruncated ? 'PAGE_LIMIT_REACHED' : null,
+    transportPath,
+    ...(fallbackReason ? { fallbackReason } : {}),
   };
 }
 
@@ -620,6 +712,7 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         checkedAt: generatedAt,
         lastSuccessAt: null,
         requestCount: 0,
+        transportPath: 'not_applicable',
         emptyResultCount: 0,
         errorCode: contract.blockedReason,
       };
@@ -638,6 +731,8 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         checkedAt: generatedAt,
         lastSuccessAt: generatedAt,
         requestCount: outcome.requestCount,
+        transportPath: outcome.transportPath ?? 'direct',
+        ...(outcome.fallbackReason ? { fallbackReason: outcome.fallbackReason } : {}),
         emptyResultCount,
         errorCode: coverageGap ? 'COVERAGE_GAP' : null,
       };
@@ -653,6 +748,8 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         checkedAt: generatedAt,
         lastSuccessAt: transportSucceeded ? generatedAt : previous?.lastSuccessAt ?? null,
         requestCount: outcome.requestCount,
+        transportPath: outcome.transportPath ?? 'direct',
+        ...(outcome.fallbackReason ? { fallbackReason: outcome.fallbackReason } : {}),
         emptyResultCount,
         errorCode: outcome.errorCode ?? (coverageGap ? 'COVERAGE_GAP' : 'PARTIAL_FETCH'),
       };
@@ -666,6 +763,11 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
       checkedAt: generatedAt,
       lastSuccessAt: previous?.lastSuccessAt ?? null,
       requestCount: outcome?.requestCount ?? 0,
+      transportPath: outcome?.transportPath ?? 'direct',
+      ...(outcome?.fallbackReason ? { fallbackReason: outcome.fallbackReason } : {}),
+      ...(outcome?.proxyFailureReason
+        ? { proxyFailureReason: outcome.proxyFailureReason }
+        : {}),
       emptyResultCount,
       errorCode: outcome?.errorCode ?? 'NOT_ATTEMPTED',
     };
@@ -1018,9 +1120,19 @@ export function buildChinaCorporateDisclosureSnapshot({
       metadataEndpoint: contract.metadataEndpoint,
       documentHosts: contract.documentHosts,
       maxRequestsPerRun: contract.maxRequestsPerRun,
+      ...(contract.maxDirectRequestsPerRun
+        ? { maxDirectRequestsPerRun: contract.maxDirectRequestsPerRun }
+        : {}),
+      ...(contract.maxProxyRequestsPerRun
+        ? { maxProxyRequestsPerRun: contract.maxProxyRequestsPerRun }
+        : {}),
       maxResponseBytes: contract.maxResponseBytes,
       redirectPolicy: contract.redirectPolicy,
       documentRetrieval: contract.documentRetrieval,
+      ...(contract.fallbackPolicy ? { fallbackPolicy: contract.fallbackPolicy } : {}),
+      ...(contract.proxyEnvironmentVariable
+        ? { proxyEnvironmentVariable: contract.proxyEnvironmentVariable }
+        : {}),
       ...(contract.paginationPolicy ? { paginationPolicy: contract.paginationPolicy } : {}),
       ...(contract.saturationBehavior ? { saturationBehavior: contract.saturationBehavior } : {}),
       ...(contract.emptyResultPolicy ? { emptyResultPolicy: contract.emptyResultPolicy } : {}),
@@ -1033,10 +1145,19 @@ export function buildChinaCorporateDisclosureSnapshot({
 
 export async function fetchChinaCorporateDisclosureSnapshot({
   fetchFn = globalThis.fetch,
+  proxyUrl = process.env.PROXY_URL ?? '',
+  proxyRequestFn = proxyFetch,
   now = Date.now(),
   previousSnapshot = null,
   onDecision = (entry) => console.log(JSON.stringify({ event: 'china_corporate_disclosure_source', ...entry })),
 } = {}) {
+  const resolvedProxyFetchFn = proxyUrl
+    ? (input, init) => fetchViaConfiguredProxy(input, init, {
+        proxyUrl,
+        maxBytes: OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
+        proxyRequestFn,
+      })
+    : null;
   const outcomes = [];
   for (const [sourceId, fetchSource] of LAUNCHED_SOURCE_FETCHERS) {
     let requestCount = 0;
@@ -1044,14 +1165,21 @@ export async function fetchChinaCorporateDisclosureSnapshot({
       const outcome = await fetchSource(async (input, init) => {
         requestCount += 1;
         return fetchFn(input, init);
-      }, now);
+      }, now, {
+        proxyFetchFn: sourceId === 'szse' ? resolvedProxyFetchFn : null,
+      });
       outcomes.push(outcome);
     } catch (error) {
       const outcome = {
         sourceId,
         ok: false,
-        requestCount,
+        requestCount: error?.requestCount ?? requestCount,
         errorCode: errorCodeFor(error),
+        transportPath: error?.transportPath ?? 'direct',
+        ...(error?.fallbackReason ? { fallbackReason: error.fallbackReason } : {}),
+        ...(error?.proxyFailureReason
+          ? { proxyFailureReason: error.proxyFailureReason }
+          : {}),
       };
       outcomes.push(outcome);
     }
@@ -1073,6 +1201,11 @@ export async function fetchChinaCorporateDisclosureSnapshot({
       ...(source.errorCode ? { reason: source.errorCode } : {}),
       ...(source.launchStatus === 'launched'
         ? { emptyResultCount: source.emptyResultCount }
+        : {}),
+      ...(source.transportPath ? { transportPath: source.transportPath } : {}),
+      ...(source.fallbackReason ? { fallbackReason: source.fallbackReason } : {}),
+      ...(source.proxyFailureReason
+        ? { proxyFailureReason: source.proxyFailureReason }
         : {}),
       checkedAt: source.checkedAt,
     });

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -205,6 +205,9 @@
     "entry": "scripts/seed-bundle-market-backup.mjs",
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-bundle-market-backup",
+    "requiredEnv": [
+      "PROXY_URL"
+    ],
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#bundle-10-seed-bundle-market-backup"
   },
   {

--- a/tests/china-corporate-disclosure-production-registration.test.mts
+++ b/tests/china-corporate-disclosure-production-registration.test.mts
@@ -44,6 +44,13 @@ describe('China corporate disclosure production registration (#5577)', () => {
     );
     assert.equal(BOOTSTRAP_TIERS.chinaCorporateDisclosures, 'slow');
     assert.match(read('scripts/seed-bundle-market-backup.mjs'), /seed-china-corporate-disclosures\.mjs/);
+    const railwayServices = JSON.parse(
+      read('scripts/railway-services.json'),
+    ) as Array<{ service: string; requiredEnv?: string[] }>;
+    assert.deepEqual(
+      railwayServices.find((entry) => entry.service === 'seed-bundle-market-backup')?.requiredEnv,
+      ['PROXY_URL'],
+    );
     assert.match(
       read('scripts/china-coverage-manifest.mjs'),
       /id:\s*'market\.china-corporate-disclosures'[\s\S]*?ownerIssue:\s*5577[\s\S]*?launchStatus:\s*'launched'/,

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -739,6 +739,198 @@ describe('official China corporate disclosures (#5577)', () => {
     );
   });
 
+  it('falls back to one bounded proxy request when the direct SZSE transport fails', async () => {
+    const directCalls: Array<{ url: string; init?: RequestInit }> = [];
+    const proxyCalls: Array<{
+      url: string;
+      proxyConfig: Record<string, unknown>;
+      options: Record<string, unknown>;
+    }> = [];
+    const decisions: Array<{
+      sourceId: string;
+      status: string;
+      requestCount: number;
+      transportPath?: string;
+      fallbackReason?: string;
+    }> = [];
+
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      onDecision: (decision) => decisions.push(decision),
+      fetchFn: async (input, init) => {
+        const url = String(input);
+        directCalls.push({ url, init });
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('connect timed out'), {
+            code: 'UND_ERR_CONNECT_TIMEOUT',
+          }),
+        });
+      },
+      proxyRequestFn: async (input, proxyConfig, options) => {
+        proxyCalls.push({
+          url: String(input),
+          proxyConfig,
+          options,
+        });
+        return {
+          buffer: Buffer.from(JSON.stringify(fixture('szse.json'))),
+          status: 200,
+          contentType: 'application/json',
+        };
+      },
+    });
+
+    assert.equal(snapshot.status, 'healthy');
+    assert.equal(directCalls.filter((call) => call.url.includes('www.szse.cn')).length, 1);
+    assert.equal(proxyCalls.length, 1);
+    assert.match(proxyCalls[0].url, /^https:\/\/www\.szse\.cn\/api\/disc\/announcement\/annList/);
+    assert.deepEqual(proxyCalls[0].proxyConfig, {
+      host: 'proxy.test',
+      port: 443,
+      auth: 'proxy-user:proxy-secret',
+      tls: true,
+    });
+    assert.equal(proxyCalls[0].options.method, 'POST');
+    assert.equal(
+      proxyCalls[0].options.maxResponseBytes,
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
+    );
+    assert.deepEqual(
+      JSON.parse(String(proxyCalls[0].options.body)),
+      {
+        seDate: ['2026-04-26', '2026-07-25'],
+        channelCode: ['listedNotice_disc'],
+        stock: ['300750'],
+        pageSize: 50,
+        pageNum: 1,
+      },
+    );
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal(szse?.transportStatus, 'fresh');
+    assert.equal(szse?.contentStatus, 'current');
+    assert.equal(szse?.requestCount, 2);
+    assert.equal(szse?.transportPath, 'proxy');
+    assert.equal(szse?.fallbackReason, 'UND_ERR_CONNECT_TIMEOUT');
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 2);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun, 1);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun, 1);
+    assert.equal(
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.fallbackPolicy,
+      'direct_then_proxy_on_transport_failure',
+    );
+
+    const szseDecision = decisions.find((decision) => decision.sourceId === 'szse');
+    assert.deepEqual(szseDecision, {
+      sourceId: 'szse',
+      status: 'accepted',
+      requestCount: 2,
+      emptyResultCount: 0,
+      transportPath: 'proxy',
+      fallbackReason: 'UND_ERR_CONNECT_TIMEOUT',
+      checkedAt: retrievedAt,
+    });
+    assert.doesNotMatch(JSON.stringify(decisions), /proxy-user|proxy-secret/);
+  });
+
+  it('keeps last-good SZSE data and records both transport failures when the proxy also fails', async () => {
+    const healthy = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      onDecision: () => {},
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify(fixture('szse.json')), { status: 200 });
+      },
+    });
+    const decisions: Array<Record<string, unknown>> = [];
+
+    const degraded = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse('2026-07-25T11:00:00.000Z'),
+      previousSnapshot: healthy,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      onDecision: (decision) => decisions.push(decision),
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }),
+        });
+      },
+      proxyRequestFn: async () => {
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('proxy DNS failed'), { code: 'EAI_AGAIN' }),
+        });
+      },
+    });
+
+    const szse = degraded.sources.find((source) => source.id === 'szse');
+    assert.equal(degraded.status, 'degraded');
+    assert.equal(szse?.transportStatus, 'error');
+    assert.equal(szse?.contentStatus, 'stale');
+    assert.equal(szse?.lastSuccessAt, retrievedAt);
+    assert.equal(szse?.requestCount, 2);
+    assert.equal(szse?.transportPath, 'proxy');
+    assert.equal(szse?.fallbackReason, 'ECONNRESET');
+    assert.equal(szse?.proxyFailureReason, 'EAI_AGAIN');
+    assert.equal(szse?.errorCode, 'FETCH_FAILED');
+    assert.equal(degraded.events.some((event) => event.exchange === 'SZSE'), true);
+    assert.doesNotMatch(JSON.stringify(decisions), /proxy-user|proxy-secret/);
+  });
+
+  it('does not proxy malformed SZSE responses', async () => {
+    let proxyCalls = 0;
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      onDecision: () => {},
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      },
+      proxyRequestFn: async () => {
+        proxyCalls += 1;
+        return {
+          buffer: Buffer.from(JSON.stringify(fixture('szse.json'))),
+          status: 200,
+          contentType: 'application/json',
+        };
+      },
+    });
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal(proxyCalls, 0);
+    assert.equal(szse?.transportStatus, 'error');
+    assert.equal(szse?.errorCode, 'MALFORMED_RESPONSE');
+    assert.equal(szse?.requestCount, 1);
+  });
+
   it('rejects malformed HTTP-200 exchange envelopes instead of refreshing stale content', async () => {
     assert.throws(
       () => normalizeSseAnnouncements({ pageHelp: { total: 0 } }, { retrievedAt }),

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { Readable } from 'node:stream';
+import { describe, it } from 'node:test';
+
+const {
+  _readBoundedResponseStream,
+  parseProxyConfig,
+} = createRequire(import.meta.url)('../scripts/_proxy-utils.cjs');
+
+describe('proxy utilities', () => {
+  it('applies standard ports when URL parsing normalizes them away', () => {
+    assert.deepEqual(
+      parseProxyConfig('https://proxy-user:proxy-secret@proxy.test:443'),
+      {
+        host: 'proxy.test',
+        port: 443,
+        auth: 'proxy-user:proxy-secret',
+        tls: true,
+      },
+    );
+    assert.equal(parseProxyConfig('ftp://proxy.test/resource'), null);
+  });
+
+  it('rejects a response stream as soon as it exceeds the byte limit', async () => {
+    await assert.rejects(
+      _readBoundedResponseStream(
+        Readable.from([Buffer.alloc(64), Buffer.alloc(65)]),
+        128,
+      ),
+      (error) => error.code === 'RESPONSE_TOO_LARGE',
+    );
+
+    const exactLimit = await _readBoundedResponseStream(
+      Readable.from([Buffer.alloc(64), Buffer.alloc(64)]),
+      128,
+    );
+    assert.equal(exactLimit.byteLength, 128);
+  });
+});


### PR DESCRIPTION
## Summary

Railway can now recover SZSE corporate disclosures through the configured proxy when its direct egress fails, instead of dropping the source after one attempt. The fallback still requests the exact official SZSE endpoint with the same body and is capped at one direct plus one proxy request; malformed successful responses do not trigger proxying. If both paths fail, the snapshot retains last-good SZSE data and records sanitized transport diagnostics without exposing proxy credentials.

Proxy responses are streamed behind the existing 128 KiB source limit, and the Railway service registry now treats `PROXY_URL` as required configuration.

## Validation

- Pre-push gates passed, including source/API type checks and 23 changed-file tests.
- Focused China and proxy coverage passed (33 tests), including direct failure, proxy success, dual failure, malformed-response, byte-limit, and Railway registration cases.
- The full data suite reached 16,958 passing and 6 skipped tests. Its only two failures were unrelated built-dashboard CSS assertions whose documented precondition (`dist/dashboard.html` from a Vite build) was absent in the clean worktree.

Related: #5577

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
