### PR TITLE
fix(premium): preserve RPC billing denial reasons

### DIFF
--- a/docs/usage-errors.mdx
+++ b/docs/usage-errors.mdx
@@ -46,9 +46,13 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 
 ### Reading `X-Billing-Verification`
 
-Every billing-verification denial sets `X-Billing-Verification` to the same value as the response body's `code`, and the header is listed in `Access-Control-Expose-Headers`, so browser clients can read it cross-origin without parsing the body. Branch on it rather than on the status alone: a `503` from these surfaces can also mean "required env not configured", which is **not** retryable, and a `403` can be either a plain `pro_required` upsell or a `subscription_lapsed` verdict.
+Every HTTP billing-verification denial sets `X-Billing-Verification` to the same value as the response body's `code`, and the header is listed in `Access-Control-Expose-Headers`, so browser clients can read it cross-origin without parsing the body. Branch on it rather than on the status alone: a `503` from these surfaces can also mean "required env not configured", which is **not** retryable, and a `403` can be either a plain `pro_required` upsell or a `subscription_lapsed` verdict.
 
 Only `subscription_lapsed` is terminal. It is the one value that never carries `Retry-After` — the absence of that header is the signal that renewal, not retry, is the way out.
+
+### Generated RPC billing denials
+
+Generated RPC handlers preserve the same billing decision in their native error shape. `summarizeArticle` reports errors inside a successful RPC envelope, so a retryable billing state uses `status: SUMMARIZE_STATUS_ERROR`, `errorType: ServiceError`, and the billing code in `statusDetail`; a provider-confirmed lapse uses `errorType: AuthError`. The scenario, shipping-v2, and forecast-simulation handlers use generated `ApiError` exceptions instead, so retryable states surface as HTTP `503` with `Retry-After`, `X-Billing-Verification`, and the same body `code`. A confirmed free caller still receives the existing Pro-required `403`.
 
 ## Common error strings
 

--- a/docs/zh/usage-errors.mdx
+++ b/docs/zh/usage-errors.mdx
@@ -45,9 +45,13 @@ OAuth 端点遵循 [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc674
 
 ### 读取 `X-Billing-Verification`
 
-每个计费校验拒绝响应都会将 `X-Billing-Verification` 设为与响应体 `code` 相同的值，且该响应头已列入 `Access-Control-Expose-Headers`，因此浏览器客户端可以跨域直接读取，无需解析响应体。请依据该响应头而非仅依据状态码分支：这些入口返回的 `503` 也可能表示「必需的环境变量未配置」——那是**不可重试**的；而 `403` 既可能是普通的 `pro_required` 升级提示，也可能是 `subscription_lapsed` 判定。
+每个 HTTP 计费校验拒绝响应都会将 `X-Billing-Verification` 设为与响应体 `code` 相同的值，且该响应头已列入 `Access-Control-Expose-Headers`，因此浏览器客户端可以跨域直接读取，无需解析响应体。请依据该响应头而非仅依据状态码分支：这些入口返回的 `503` 也可能表示「必需的环境变量未配置」——那是**不可重试**的；而 `403` 既可能是普通的 `pro_required` 升级提示，也可能是 `subscription_lapsed` 判定。
 
 只有 `subscription_lapsed` 是终态。它是唯一从不携带 `Retry-After` 的取值——缺少该响应头本身就是信号：出路是重新订阅，而不是重试。
+
+### 生成式 RPC 的计费拒绝
+
+生成式 RPC 处理程序会在各自原生的错误形态中保留同一项计费判定。`summarizeArticle` 在成功的 RPC 信封内报告错误，因此可重试的计费状态使用 `status: SUMMARIZE_STATUS_ERROR`、`errorType: ServiceError`，并在 `statusDetail` 中携带计费代码；由提供方确认的订阅失效则使用 `errorType: AuthError`。scenario、shipping-v2 与 forecast-simulation 处理程序改用生成的 `ApiError` 异常，因此可重试状态会返回 HTTP `503`，同时携带 `Retry-After`、`X-Billing-Verification` 与相同的响应体 `code`。已确认的免费调用方仍会收到原有的 Pro-required `403`。
 
 ## 常见错误字符串
 

--- a/server/__tests__/gateway-idempotency.test.ts
+++ b/server/__tests__/gateway-idempotency.test.ts
@@ -33,12 +33,13 @@ vi.mock('../_shared/rate-limit', async (importActual) => {
 
 import { createDomainGateway } from '../gateway';
 import { IDEMPOTENCY_HEADER, IDEMPOTENT_REPLAYED_HEADER } from '../_shared/idempotency';
+import { markRetryableResponse, setResponseHeader } from '../_shared/response-headers';
 
 const PATH = '/api/leads/v1/submit-contact';
 const ctx = { waitUntil: () => {} };
 
 const handler = vi.fn(
-  async () =>
+  async (_request: Request) =>
     new Response(JSON.stringify({ ok: true, id: 'lead_1' }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -221,5 +222,57 @@ describe('gateway Idempotency-Key', () => {
     expect(res.status).toBe(429);
     const releaseCmd = runRedisPipeline.mock.calls[2][0][0];
     expect(releaseCmd[0]).toBe('DEL');
+  });
+
+  test('an in-band retryable response releases the lock so the same key can recover', async () => {
+    handler
+      .mockImplementationOnce(async (request: Request) => {
+        markRetryableResponse(request);
+        setResponseHeader(request, 'Retry-After', '5');
+        setResponseHeader(
+          request,
+          'X-Billing-Verification',
+          'entitlement_verification_unavailable',
+        );
+        return new Response(JSON.stringify({
+          errorType: 'ServiceError',
+          statusDetail: 'entitlement_verification_unavailable',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      })
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, id: 'lead_recovered' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    runRedisPipeline
+      .mockResolvedValueOnce([{ result: null }]) // first peek miss
+      .mockResolvedValueOnce([{ result: 'OK' }, { result: null }]) // first claim
+      .mockResolvedValueOnce([{ result: 1 }]) // first response releases the lock
+      .mockResolvedValueOnce([{ result: null }]) // retry sees no completed record
+      .mockResolvedValueOnce([{ result: 'OK' }, { result: null }]) // retry claims
+      .mockResolvedValueOnce([{ result: 'OK' }]); // recovered response is stored
+
+    const gateway = makeGateway();
+    const transient = await gateway(post('key-in-band-retryable'), ctx);
+    expect(transient.status).toBe(200);
+    expect(transient.headers.get('Retry-After')).toBe('5');
+    expect(transient.headers.get('X-Billing-Verification')).toBe(
+      'entitlement_verification_unavailable',
+    );
+    expect(await transient.json()).toEqual({
+      errorType: 'ServiceError',
+      statusDetail: 'entitlement_verification_unavailable',
+    });
+    expect(runRedisPipeline.mock.calls[2][0][0][0]).toBe('DEL');
+
+    const recovered = await gateway(post('key-in-band-retryable'), ctx);
+    expect(recovered.status).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(await recovered.json()).toEqual({ ok: true, id: 'lead_recovered' });
+    expect(runRedisPipeline.mock.calls[5][0][0][0]).toBe('SET');
   });
 });

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -534,6 +534,13 @@ export type BillingVerificationCode =
   | BillingVerificationStatus
   | 'entitlement_verification_unavailable';
 
+export function isBillingVerificationCode(
+  value: unknown,
+): value is BillingVerificationCode {
+  return value === 'entitlement_verification_unavailable'
+    || isBillingVerificationStatus(value);
+}
+
 export interface BillingVerificationDenial {
   /**
    * False ONLY for a lapse the provider confirmed. Everything else in this

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -71,6 +71,74 @@ function denyFor(entitlements: BillingVerificationInput | null): DeniedIdentity 
   return billingDenial ? { ...DENIED, billingDenial } : DENIED;
 }
 
+type RpcApiErrorLike = Error & {
+  statusCode: number;
+  body: string;
+  retryAfter?: number;
+  exposeMessage?: boolean;
+};
+
+type RpcApiErrorConstructor<T extends RpcApiErrorLike> =
+  new (statusCode: number, message: string, body: string) => T;
+
+type PremiumRpcBillingApiError<T extends RpcApiErrorLike> = T & {
+  billingVerificationCode: BillingVerificationDenial['code'];
+};
+
+/**
+ * RPC billing denials have two transport shapes:
+ * - response-envelope RPCs use `ServiceError` for retryable verification
+ *   states and `AuthError` for the provider-confirmed terminal lapse;
+ * - exception-style RPCs throw their generated service's own `ApiError`.
+ *
+ * Both put the stable billing code in `statusDetail`/`ApiError.body`. Confirmed
+ * free and unauthenticated callers have no billing denial and keep the
+ * handler's existing Pro-required rendering.
+ */
+export function getPremiumRpcBillingErrorType(
+  denial: BillingVerificationDenial,
+): 'AuthError' | 'ServiceError' {
+  return denial.retryable ? 'ServiceError' : 'AuthError';
+}
+
+function createPremiumRpcBillingDenialError<T extends RpcApiErrorLike>(
+  identity: PremiumCallerIdentity,
+  ApiErrorConstructor: RpcApiErrorConstructor<T>,
+): PremiumRpcBillingApiError<T> | null {
+  if (identity.isPremium || !identity.billingDenial) return null;
+  const denial = identity.billingDenial;
+
+  const error = new ApiErrorConstructor(
+    denial.status,
+    denial.message,
+    denial.code,
+  ) as PremiumRpcBillingApiError<T>;
+  error.billingVerificationCode = denial.code;
+  if (denial.status === 503) {
+    error.retryAfter = denial.retryAfterSeconds;
+    error.exposeMessage = true;
+  }
+  return error;
+}
+
+/**
+ * Enforces a hard-denying premium RPC gate while preserving why verification
+ * failed. The generated constructor keeps `instanceof ApiError` service-local;
+ * the fallback message preserves each endpoint's existing `PRO`/`Pro` copy.
+ */
+export async function requirePremiumRpcAccess<T extends RpcApiErrorLike>(
+  request: Request,
+  ApiErrorConstructor: RpcApiErrorConstructor<T>,
+  fallbackMessage: string,
+): Promise<void> {
+  const identity = await resolvePremiumCallerIdentity(request);
+  if (identity.isPremium) return;
+
+  const billingError = createPremiumRpcBillingDenialError(identity, ApiErrorConstructor);
+  if (billingError) throw billingError;
+  throw new ApiErrorConstructor(403, fallbackMessage, '');
+}
+
 /**
  * Resolves premium status and the user-bound identity for spend controls.
  */

--- a/server/_shared/response-headers.ts
+++ b/server/_shared/response-headers.ts
@@ -7,6 +7,7 @@
  */
 
 const channel = new WeakMap<Request, Record<string, string>>();
+const retryableResponses = new WeakSet<Request>();
 
 export function setResponseHeader(req: Request, key: string, value: string): void {
   let headers = channel.get(req);
@@ -30,6 +31,24 @@ export function drainResponseHeaders(req: Request): Record<string, string> | und
   const headers = channel.get(req);
   if (headers) channel.delete(req);
   return headers;
+}
+
+/**
+ * Marks a successful generated RPC envelope as transient.
+ *
+ * Some generated handlers must return their typed error envelope with HTTP 200.
+ * The gateway uses this side-channel to preserve that wire contract while
+ * releasing an Idempotency-Key processing lock instead of replaying the
+ * transient result as a completed response.
+ */
+export function markRetryableResponse(req: Request): void {
+  retryableResponses.add(req);
+}
+
+export function drainRetryableResponse(req: Request): boolean {
+  const retryable = retryableResponses.has(req);
+  if (retryable) retryableResponses.delete(req);
+  return retryable;
 }
 
 /**

--- a/server/error-mapper.ts
+++ b/server/error-mapper.ts
@@ -8,6 +8,8 @@
  * - Unknown errors -- 500 Internal Server Error
  */
 
+import { isBillingVerificationCode } from './_shared/entitlement-check';
+
 /**
  * Detects network/fetch errors across runtimes. Per Fetch spec, network
  * errors throw TypeError. We also check common error message patterns
@@ -38,16 +40,28 @@ export function mapErrorToResponse(error: unknown, _req: Request): Response {
     // Only expose error.message for 4xx (client errors). Use generic message for 5xx
     // to avoid leaking internal details like upstream URLs or API key fragments (H-3 fix).
     const retryAfter = (statusCode === 429 || statusCode === 503) && 'retryAfter' in error ? Number((error as Error & { retryAfter: number }).retryAfter) : null;
+    const billingCodeCandidate = 'billingVerificationCode' in error
+      ? (error as Error & { billingVerificationCode: unknown }).billingVerificationCode
+      : null;
+    const billingVerificationCode = isBillingVerificationCode(billingCodeCandidate)
+      ? billingCodeCandidate
+      : null;
     const exposesRetryableUnavailable = statusCode === 503
       && retryAfter != null
       && Number.isFinite(retryAfter)
       && (error as Error & { exposeMessage?: boolean }).exposeMessage === true;
     const message = (statusCode >= 400 && statusCode < 500) || exposesRetryableUnavailable ? error.message : 'Internal server error';
-    const body: Record<string, unknown> = { message };
+    const extras: Record<string, unknown> = {};
+    const headers: Record<string, string> = {};
 
     // Rate limit: include retryAfter if present
     if (retryAfter != null && Number.isFinite(retryAfter)) {
-      body.retryAfter = retryAfter;
+      extras.retryAfter = retryAfter;
+      headers['Retry-After'] = String(retryAfter);
+    }
+    if (billingVerificationCode) {
+      extras.code = billingVerificationCode;
+      headers['X-Billing-Verification'] = billingVerificationCode;
     }
 
     if (statusCode >= 500) {
@@ -59,8 +73,8 @@ export function mapErrorToResponse(error: unknown, _req: Request): Response {
     return jsonMessageResponse(
       message,
       statusCode,
-      retryAfter != null && Number.isFinite(retryAfter) ? { retryAfter } : undefined,
-      retryAfter != null && Number.isFinite(retryAfter) ? { 'Retry-After': String(retryAfter) } : undefined,
+      Object.keys(extras).length > 0 ? extras : undefined,
+      Object.keys(headers).length > 0 ? headers : undefined,
     );
   }
 

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -26,7 +26,11 @@ import {
   checkFailClosedScopedIpRateLimit,
   hasEndpointRatePolicy,
 } from './_shared/rate-limit';
-import { drainResponseHeaders, drainSuccessStatusOverride } from './_shared/response-headers';
+import {
+  drainResponseHeaders,
+  drainRetryableResponse,
+  drainSuccessStatusOverride,
+} from './_shared/response-headers';
 import { projectJsonResponse } from './_shared/response-projection';
 import { getRpcNoStoreReasonFromJson } from './_shared/cache-contract';
 import {
@@ -1843,6 +1847,7 @@ export function createDomainGateway(
         mergedHeaders.set(key, value);
       }
     }
+    const retryableResponse = drainRetryableResponse(request);
     attachRequiredBboxDiagnosticHeaders(mergedHeaders, pathname, requiredBboxDiagnostic);
 
     // Handler side-channel status override (setSuccessStatusOverride): applied
@@ -1982,7 +1987,14 @@ export function createDomainGateway(
       // record rather than a lingering 'processing' lock → 409. store() is
       // best-effort/fail-open, so a Redis blip degrades to a re-executable
       // retry, never a failed response.
-      await idempotency.store(finalStatus, bodyBytes, response.headers.get('content-type'));
+      // Generated response-envelope RPCs can report a retryable ServiceError
+      // inside HTTP 200. Feed store() a retryable status only for its
+      // persist-vs-release decision; the client still receives finalStatus.
+      await idempotency.store(
+        retryableResponse ? 503 : finalStatus,
+        bodyBytes,
+        response.headers.get('content-type'),
+      );
       emitRequest(finalStatus, 'ok', resolvedCacheTier, bodyBytes.byteLength);
       maybeAttachDevHealthHeader(mergedHeaders);
       return new Response(bodyBytes, {

--- a/server/worldmonitor/forecast/v1/trigger-simulation.ts
+++ b/server/worldmonitor/forecast/v1/trigger-simulation.ts
@@ -5,7 +5,9 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/forecast/v1/service_server';
 import { ApiError } from '../../../../src/generated/server/worldmonitor/forecast/v1/service_server';
 
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  requirePremiumRpcAccess,
+} from '../../../_shared/premium-check';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import {
   enqueueSimulationTaskForServer,
@@ -54,10 +56,7 @@ export async function triggerSimulation(
   req: TriggerSimulationRequest,
 ): Promise<TriggerSimulationResponse> {
   // Step 1: Pro gate (defense-in-depth).
-  const isPro = await isCallerPremium(ctx.request);
-  if (!isPro) {
-    throw new ApiError(403, 'Pro subscription required', '');
-  }
+  await requirePremiumRpcAccess(ctx.request, ApiError, 'Pro subscription required');
 
   // Step 2: queue-depth backpressure (mirrors run-scenario:50).
   const depth = await getQueueDepth();

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -14,7 +14,14 @@ import {
 import { CHROME_UA } from '../../../_shared/constants';
 import { isProviderAvailable } from '../../../_shared/llm-health';
 import { sanitizeHeadlinesLight, sanitizeHeadlines, sanitizeForPrompt } from '../../../_shared/llm-sanitize.js';
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  getPremiumRpcBillingErrorType,
+  resolvePremiumCallerIdentity,
+} from '../../../_shared/premium-check';
+import {
+  markRetryableResponse,
+  setResponseHeader,
+} from '../../../_shared/response-headers';
 import { stripThinkingTags } from '../../../_shared/llm';
 import { buildLlmCallEvent, deliverUsageEvents } from '../../../_shared/usage';
 
@@ -64,7 +71,8 @@ export async function summarizeArticle(
   ctx: ServerContext,
   req: SummarizeArticleRequest,
 ): Promise<SummarizeArticleResponse> {
-  const isPremium = await isCallerPremium(ctx.request);
+  const premiumIdentity = await resolvePremiumCallerIdentity(ctx.request);
+  const isPremium = premiumIdentity.isPremium;
   const { provider, mode = 'brief', geoContext = '', variant = 'full', lang = 'en' } = req;
   const systemAppend = isPremium && typeof req.systemAppend === 'string' ? req.systemAppend : '';
   const requiresPremium = mode !== 'translate';
@@ -100,6 +108,25 @@ export async function summarizeArticle(
   });
 
   if (requiresPremium && !isPremium) {
+    const billingDenial = premiumIdentity.billingDenial;
+    if (billingDenial) {
+      if (billingDenial.retryable) {
+        markRetryableResponse(ctx.request);
+        setResponseHeader(ctx.request, 'Retry-After', String(billingDenial.retryAfterSeconds));
+        setResponseHeader(ctx.request, 'X-Billing-Verification', billingDenial.code);
+      }
+      return {
+        summary: '',
+        model: '',
+        provider,
+        tokens: 0,
+        fallback: true,
+        error: billingDenial.message,
+        errorType: getPremiumRpcBillingErrorType(billingDenial),
+        status: 'SUMMARIZE_STATUS_ERROR',
+        statusDetail: billingDenial.code,
+      };
+    }
     return {
       summary: '',
       model: '',

--- a/server/worldmonitor/scenario/v1/get-scenario-status.ts
+++ b/server/worldmonitor/scenario/v1/get-scenario-status.ts
@@ -6,7 +6,9 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/scenario/v1/service_server';
 import { ApiError, ValidationError } from '../../../../src/generated/server/worldmonitor/scenario/v1/service_server';
 
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  requirePremiumRpcAccess,
+} from '../../../_shared/premium-check';
 import { getRawJson } from '../../../_shared/redis';
 
 // Matches jobIds produced by run-scenario.ts: `scenario:{13-digit-ts}:{8-char-suffix}`.
@@ -61,10 +63,7 @@ export async function getScenarioStatus(
   ctx: ServerContext,
   req: GetScenarioStatusRequest,
 ): Promise<GetScenarioStatusResponse> {
-  const isPro = await isCallerPremium(ctx.request);
-  if (!isPro) {
-    throw new ApiError(403, 'PRO subscription required', '');
-  }
+  await requirePremiumRpcAccess(ctx.request, ApiError, 'PRO subscription required');
 
   const jobId = req.jobId ?? '';
   if (!JOB_ID_RE.test(jobId)) {

--- a/server/worldmonitor/scenario/v1/run-scenario.ts
+++ b/server/worldmonitor/scenario/v1/run-scenario.ts
@@ -5,7 +5,9 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/scenario/v1/service_server';
 import { ApiError, ValidationError } from '../../../../src/generated/server/worldmonitor/scenario/v1/service_server';
 
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  requirePremiumRpcAccess,
+} from '../../../_shared/premium-check';
 import { runRedisPipeline } from '../../../_shared/redis';
 import { setResponseHeader, setSuccessStatusOverride } from '../../../_shared/response-headers';
 import { getScenarioTemplate } from '../../supply-chain/v1/scenario-templates';
@@ -27,10 +29,7 @@ export async function runScenario(
   ctx: ServerContext,
   req: RunScenarioRequest,
 ): Promise<RunScenarioResponse> {
-  const isPro = await isCallerPremium(ctx.request);
-  if (!isPro) {
-    throw new ApiError(403, 'PRO subscription required', '');
-  }
+  await requirePremiumRpcAccess(ctx.request, ApiError, 'PRO subscription required');
 
   const scenarioId = (req.scenarioId ?? '').trim();
   if (!scenarioId) {

--- a/server/worldmonitor/shipping/v2/list-webhooks.ts
+++ b/server/worldmonitor/shipping/v2/list-webhooks.ts
@@ -8,7 +8,9 @@ import { ApiError } from '../../../../src/generated/server/worldmonitor/shipping
 
 // @ts-expect-error — JS module, no declaration file
 import { validateApiKey } from '../../../../api/_api-key.js';
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  requirePremiumRpcAccess,
+} from '../../../_shared/premium-check';
 import { runRedisPipeline } from '../../../_shared/redis';
 import {
   webhookKey,
@@ -33,10 +35,7 @@ export async function listWebhooks(
     throw new ApiError(401, apiKeyResult.error ?? 'API key required', '');
   }
 
-  const isPro = await isCallerPremium(ctx.request);
-  if (!isPro) {
-    throw new ApiError(403, 'PRO subscription required', '');
-  }
+  await requirePremiumRpcAccess(ctx.request, ApiError, 'PRO subscription required');
 
   const ownerHash = await callerFingerprint(ctx.request);
   const smembersResult = await runRedisPipeline([['SMEMBERS', ownerIndexKey(ownerHash)]]);

--- a/server/worldmonitor/shipping/v2/register-webhook.ts
+++ b/server/worldmonitor/shipping/v2/register-webhook.ts
@@ -10,7 +10,9 @@ import {
 
 // @ts-expect-error — JS module, no declaration file
 import { validateApiKey } from '../../../../api/_api-key.js';
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  requirePremiumRpcAccess,
+} from '../../../_shared/premium-check';
 import { runRedisPipeline } from '../../../_shared/redis';
 import {
   WEBHOOK_TTL,
@@ -43,10 +45,7 @@ export async function registerWebhook(
     throw new ApiError(401, apiKeyResult.error ?? 'API key required', '');
   }
 
-  const isPro = await isCallerPremium(ctx.request);
-  if (!isPro) {
-    throw new ApiError(403, 'PRO subscription required', '');
-  }
+  await requirePremiumRpcAccess(ctx.request, ApiError, 'PRO subscription required');
 
   const callbackUrl = (req.callbackUrl ?? '').trim();
   if (!callbackUrl) {

--- a/server/worldmonitor/shipping/v2/route-intelligence.ts
+++ b/server/worldmonitor/shipping/v2/route-intelligence.ts
@@ -10,7 +10,9 @@ import {
   ValidationError,
 } from '../../../../src/generated/server/worldmonitor/shipping/v2/service_server';
 
-import { isCallerPremium } from '../../../_shared/premium-check';
+import {
+  requirePremiumRpcAccess,
+} from '../../../_shared/premium-check';
 import { getCachedJson } from '../../../_shared/redis';
 import { CHOKEPOINT_STATUS_KEY } from '../../../_shared/cache-keys';
 import { BYPASS_CORRIDORS_BY_CHOKEPOINT, type CargoType } from '../../../_shared/bypass-corridors';
@@ -40,10 +42,7 @@ export async function routeIntelligence(
   ctx: ServerContext,
   req: RouteIntelligenceRequest,
 ): Promise<RouteIntelligenceResponse> {
-  const isPro = await isCallerPremium(ctx.request);
-  if (!isPro) {
-    throw new ApiError(403, 'PRO subscription required', '');
-  }
+  await requirePremiumRpcAccess(ctx.request, ApiError, 'PRO subscription required');
 
   const fromIso2 = (req.fromIso2 ?? '').trim().toUpperCase();
   const toIso2 = (req.toIso2 ?? '').trim().toUpperCase();

--- a/tests/rpc-premium-billing-denial.test.mts
+++ b/tests/rpc-premium-billing-denial.test.mts
@@ -1,0 +1,413 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  getPremiumRpcBillingErrorType,
+  requirePremiumRpcAccess,
+} from '../server/_shared/premium-check.ts';
+import {
+  __resetEntitlementNegativeCacheForTests,
+  type BillingVerificationDenial,
+} from '../server/_shared/entitlement-check.ts';
+import { mapErrorToResponse } from '../server/error-mapper.ts';
+import {
+  INTERNAL_MCP_VERIFIED_HEADER,
+  TRUSTED_USER_ID_HEADER,
+  getInternalMcpVerifiedNonce,
+} from '../server/_shared/mcp-internal-hmac.ts';
+import { triggerSimulation } from '../server/worldmonitor/forecast/v1/trigger-simulation.ts';
+import { summarizeArticle } from '../server/worldmonitor/news/v1/summarize-article.ts';
+import { getScenarioStatus } from '../server/worldmonitor/scenario/v1/get-scenario-status.ts';
+import { runScenario } from '../server/worldmonitor/scenario/v1/run-scenario.ts';
+import { listWebhooks } from '../server/worldmonitor/shipping/v2/list-webhooks.ts';
+import { registerWebhook } from '../server/worldmonitor/shipping/v2/register-webhook.ts';
+import { routeIntelligence } from '../server/worldmonitor/shipping/v2/route-intelligence.ts';
+import { ApiError as ForecastApiError } from '../src/generated/server/worldmonitor/forecast/v1/service_server.ts';
+import { ApiError as ScenarioApiError } from '../src/generated/server/worldmonitor/scenario/v1/service_server.ts';
+import { ApiError as ShippingApiError } from '../src/generated/server/worldmonitor/shipping/v2/service_server.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = { ...process.env };
+const ENTERPRISE_TEST_KEY = 'enterprise-rpc-billing-denial-test-key';
+
+const RETRYABLE_DENIAL: BillingVerificationDenial = {
+  retryable: true,
+  code: 'entitlement_verification_unavailable',
+  retryAfterSeconds: 5,
+  message: 'Unable to verify API access',
+  status: 503,
+};
+
+const TERMINAL_LAPSE_DENIAL: BillingVerificationDenial = {
+  retryable: false,
+  code: 'subscription_lapsed',
+  retryAfterSeconds: 0,
+  message: 'Subscription lapsed',
+  status: 403,
+};
+
+const FREE_ROW = {
+  planKey: 'free',
+  features: {
+    tier: 0,
+    apiAccess: false,
+    apiRateLimit: 0,
+    maxDashboards: 3,
+    prioritySupport: false,
+    exportFormats: ['csv'],
+    mcpAccess: false,
+  },
+  validUntil: 0,
+};
+
+function installEntitlementFetch(
+  convex: () => Promise<Response>,
+  options: { entitlementReadsOnly?: boolean } = {},
+): string[] {
+  const unexpectedRedisRequests: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string'
+      ? input
+      : String((input as Request)?.url ?? input);
+    if (url.includes('redis.test/get/')) {
+      if (!decodeURIComponent(url).includes('/get/entitlements:')) {
+        unexpectedRedisRequests.push(url);
+        throw new Error(`business Redis read reached in test: ${url}`);
+      }
+      return new Response(JSON.stringify({ result: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('redis.test')) {
+      if (options.entitlementReadsOnly) {
+        unexpectedRedisRequests.push(url);
+        throw new Error(`business Redis write reached in test: ${url}`);
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    }
+    if (url.includes('/api/internal-entitlements')) return convex();
+    throw new Error(`unexpected fetch in test: ${url}`);
+  }) as typeof fetch;
+  return unexpectedRedisRequests;
+}
+
+function markerRequest(
+  userId: string,
+  path = '/api/scenario/v1/run-scenario',
+  options: { apiKey?: string; method?: string } = {},
+): Request {
+  return new Request(`https://api.worldmonitor.app${path}`, {
+    method: options.method ?? 'POST',
+    headers: {
+      [INTERNAL_MCP_VERIFIED_HEADER]: getInternalMcpVerifiedNonce(),
+      [TRUSTED_USER_ID_HEADER]: userId,
+      ...(options.apiKey ? { 'X-WorldMonitor-Key': options.apiKey } : {}),
+    },
+  });
+}
+
+function handlerContext(request: Request) {
+  return {
+    request,
+    pathParams: {},
+    headers: Object.fromEntries(request.headers.entries()),
+  };
+}
+
+async function captureError(run: () => Promise<unknown>): Promise<Error & Record<string, unknown>> {
+  try {
+    await run();
+  } catch (error) {
+    assert.ok(error instanceof Error);
+    return error as Error & Record<string, unknown>;
+  }
+  assert.fail('expected promise to reject');
+}
+
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  Object.assign(process.env, ORIGINAL_ENV);
+}
+
+beforeEach(() => {
+  restoreEnv();
+  process.env.CONVEX_SITE_URL = 'https://fake.convex.site';
+  process.env.CONVEX_SERVER_SHARED_SECRET = 'fake-secret';
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-test-token';
+  process.env.WORLDMONITOR_VALID_KEYS = ENTERPRISE_TEST_KEY;
+  __resetEntitlementNegativeCacheForTests();
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  restoreEnv();
+  __resetEntitlementNegativeCacheForTests();
+});
+
+describe('premium RPC billing-denial representation (#5652)', () => {
+  it('uses ServiceError plus the billing code for a retryable in-band RPC denial', () => {
+    assert.equal(getPremiumRpcBillingErrorType(RETRYABLE_DENIAL), 'ServiceError');
+  });
+
+  it('keeps a provider-confirmed lapse terminal and classified', () => {
+    assert.equal(getPremiumRpcBillingErrorType(TERMINAL_LAPSE_DENIAL), 'AuthError');
+  });
+
+  for (const [service, ApiErrorConstructor] of [
+    ['scenario', ScenarioApiError],
+    ['shipping', ShippingApiError],
+    ['forecast', ForecastApiError],
+  ] as const) {
+    it(`builds the ${service} service own retryable ApiError`, async () => {
+      installEntitlementFetch(async () => new Response('upstream error', { status: 503 }));
+      const error = await captureError(() => requirePremiumRpcAccess(
+        markerRequest(`user_${service}_transient`),
+        ApiErrorConstructor,
+        'PRO subscription required',
+      ));
+
+      assert.ok(error instanceof ApiErrorConstructor);
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.message, 'Unable to verify API access');
+      assert.equal(error.body, 'entitlement_verification_unavailable');
+      assert.equal(error.retryAfter, 5);
+      assert.equal(error.exposeMessage, true);
+      assert.equal(error.billingVerificationCode, 'entitlement_verification_unavailable');
+    });
+  }
+
+  it('keeps a confirmed free caller on the existing fallback 403', async () => {
+    installEntitlementFetch(async () => new Response(JSON.stringify(FREE_ROW), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const error = await captureError(() => requirePremiumRpcAccess(
+      markerRequest('user_confirmed_free'),
+      ScenarioApiError,
+      'PRO subscription required',
+    ));
+
+    assert.ok(error instanceof ScenarioApiError);
+    assert.equal(error.statusCode, 403);
+    assert.equal(error.message, 'PRO subscription required');
+    assert.equal(error.billingVerificationCode, undefined);
+  });
+
+  it('maps a retryable ApiError to the public billing code and retry headers', async () => {
+    installEntitlementFetch(async () => new Response('upstream error', { status: 503 }));
+    const error = await captureError(() => requirePremiumRpcAccess(
+      markerRequest('user_mapped_transient'),
+      ScenarioApiError,
+      'PRO subscription required',
+    ));
+
+    const response = mapErrorToResponse(
+      error,
+      new Request('https://api.worldmonitor.app/api/scenario/v1/run-scenario'),
+    );
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('Retry-After'), '5');
+    assert.equal(
+      response.headers.get('X-Billing-Verification'),
+      'entitlement_verification_unavailable',
+    );
+    assert.deepEqual(await response.json(), {
+      message: 'Unable to verify API access',
+      retryAfter: 5,
+      code: 'entitlement_verification_unavailable',
+    });
+  });
+
+  it('maps an actual provider-confirmed lapse as terminal without retry metadata', async () => {
+    installEntitlementFetch(async () => new Response(JSON.stringify({
+      ...FREE_ROW,
+      billingStatus: 'subscription_lapsed',
+      retryAfterSeconds: 99,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const request = markerRequest('user_mapped_lapsed');
+    const error = await captureError(() => requirePremiumRpcAccess(
+      request,
+      ScenarioApiError,
+      'PRO subscription required',
+    ));
+
+    assert.ok(error instanceof ScenarioApiError);
+    assert.equal(error.statusCode, 403);
+    assert.equal(error.message, 'Subscription lapsed');
+    assert.equal(error.body, 'subscription_lapsed');
+    assert.equal(error.billingVerificationCode, 'subscription_lapsed');
+    assert.equal(error.retryAfter, undefined);
+    assert.equal(error.exposeMessage, undefined);
+
+    const response = mapErrorToResponse(error, request);
+    assert.equal(response.status, 403);
+    assert.equal(response.headers.get('X-Billing-Verification'), 'subscription_lapsed');
+    assert.equal(response.headers.get('Retry-After'), null);
+    assert.deepEqual(await response.json(), {
+      message: 'Subscription lapsed',
+      code: 'subscription_lapsed',
+    });
+  });
+
+  it('does not publish an unrecognized mapper billing code', async () => {
+    const error = new ScenarioApiError(403, 'Forbidden', 'not_a_billing_code') as
+      ScenarioApiError & { billingVerificationCode: string };
+    error.billingVerificationCode = 'not_a_billing_code';
+
+    const response = mapErrorToResponse(
+      error,
+      new Request('https://api.worldmonitor.app/api/scenario/v1/run-scenario'),
+    );
+    assert.equal(response.headers.get('X-Billing-Verification'), null);
+    assert.deepEqual(await response.json(), { message: 'Forbidden' });
+  });
+});
+
+describe('migrated premium RPC handler gates (#5652)', () => {
+  const cases = [
+    {
+      name: 'triggerSimulation',
+      path: '/api/forecast/v1/trigger-simulation',
+      ApiErrorConstructor: ForecastApiError,
+      invoke: (request: Request) => triggerSimulation(handlerContext(request), { clientVersion: '' }),
+    },
+    {
+      name: 'runScenario',
+      path: '/api/scenario/v1/run-scenario',
+      ApiErrorConstructor: ScenarioApiError,
+      invoke: (request: Request) => runScenario(handlerContext(request), { scenarioId: '', iso2: '' }),
+    },
+    {
+      name: 'getScenarioStatus',
+      path: '/api/scenario/v1/get-scenario-status',
+      ApiErrorConstructor: ScenarioApiError,
+      invoke: (request: Request) => getScenarioStatus(handlerContext(request), { jobId: '' }),
+    },
+    {
+      name: 'routeIntelligence',
+      path: '/api/shipping/v2/route-intelligence',
+      ApiErrorConstructor: ShippingApiError,
+      invoke: (request: Request) => routeIntelligence(handlerContext(request), {
+        fromIso2: '',
+        toIso2: '',
+        cargoType: '',
+        hs2: '',
+      }),
+    },
+    {
+      name: 'registerWebhook',
+      path: '/api/shipping/v2/register-webhook',
+      ApiErrorConstructor: ShippingApiError,
+      invoke: (request: Request) => registerWebhook(handlerContext(request), {
+        callbackUrl: '',
+        chokepointIds: [],
+      }),
+      requiresApiKey: true,
+    },
+    {
+      name: 'listWebhooks',
+      path: '/api/shipping/v2/list-webhooks',
+      ApiErrorConstructor: ShippingApiError,
+      invoke: (request: Request) => listWebhooks(handlerContext(request), {}),
+      requiresApiKey: true,
+    },
+  ] as const;
+
+  for (const entry of cases) {
+    it(`${entry.name} throws its service-local retryable ApiError before handler work`, async () => {
+      const unexpectedRedisRequests = installEntitlementFetch(
+        async () => new Response('convex unavailable', { status: 503 }),
+        { entitlementReadsOnly: true },
+      );
+      const request = markerRequest(
+        `user_${entry.name}_transient`,
+        entry.path,
+        {
+          apiKey: 'requiresApiKey' in entry ? ENTERPRISE_TEST_KEY : undefined,
+          method: entry.name === 'getScenarioStatus' || entry.name === 'listWebhooks'
+            ? 'GET'
+            : 'POST',
+        },
+      );
+      const error = await captureError(() => entry.invoke(request));
+
+      assert.ok(error instanceof entry.ApiErrorConstructor);
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.message, 'Unable to verify API access');
+      assert.equal(error.body, 'entitlement_verification_unavailable');
+      assert.equal(error.billingVerificationCode, 'entitlement_verification_unavailable');
+      assert.equal(error.retryAfter, 5);
+      assert.deepEqual(unexpectedRedisRequests, []);
+    });
+  }
+});
+
+describe('summarizeArticle transient entitlement regression (#5652)', () => {
+  it('does not turn a Convex 5xx into a Pro upsell', async () => {
+    installEntitlementFetch(async () => new Response('convex unavailable', { status: 503 }));
+    const request = markerRequest(
+      'user_transient_entitlement',
+      '/api/news/v1/summarize-article',
+    );
+    const result = await summarizeArticle(
+      { request, pathParams: {}, headers: Object.fromEntries(request.headers.entries()) },
+      {
+        provider: 'groq',
+        headlines: ['Headline one'],
+        mode: 'brief',
+        geoContext: '',
+        variant: 'full',
+        lang: 'en',
+        systemAppend: '',
+        bodies: [],
+      },
+    );
+
+    assert.equal(result.status, 'SUMMARIZE_STATUS_ERROR');
+    assert.equal(result.errorType, 'ServiceError');
+    assert.equal(result.statusDetail, 'entitlement_verification_unavailable');
+    assert.equal(result.error, 'Unable to verify API access');
+    assert.notEqual(result.error, 'Pro subscription required');
+  });
+
+  it('keeps a provider-confirmed lapse in the terminal AuthError envelope', async () => {
+    installEntitlementFetch(async () => new Response(JSON.stringify({
+      ...FREE_ROW,
+      billingStatus: 'subscription_lapsed',
+      retryAfterSeconds: 99,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const request = markerRequest(
+      'user_lapsed_entitlement',
+      '/api/news/v1/summarize-article',
+    );
+    const result = await summarizeArticle(
+      handlerContext(request),
+      {
+        provider: 'groq',
+        headlines: ['Headline one'],
+        mode: 'brief',
+        geoContext: '',
+        variant: 'full',
+        lang: 'en',
+        systemAppend: '',
+        bodies: [],
+      },
+    );
+
+    assert.equal(result.status, 'SUMMARIZE_STATUS_ERROR');
+    assert.equal(result.errorType, 'AuthError');
+    assert.equal(result.statusDetail, 'subscription_lapsed');
+    assert.equal(result.error, 'Subscription lapsed');
+  });
+});


### PR DESCRIPTION
## Summary

A paying RPC caller whose entitlement could not be verified was told to buy Pro, exactly like a confirmed free caller. Generated RPC hard-deniers now preserve the billing decision instead: transient and renewal-verification states are retryable, a provider-confirmed lapse stays terminal, and confirmed-free behavior is unchanged.

The two generated transport shapes remain native:

| Surface | Retryable verification state | Terminal lapse |
|---|---|---|
| `summarizeArticle` envelope | `ServiceError` with the billing code in `statusDetail` | `AuthError` with `subscription_lapsed` |
| scenario, shipping-v2, and forecast exceptions | service-local `ApiError`, HTTP `503`, `Retry-After`, and `X-Billing-Verification` | HTTP `403`, stable billing code, no retry header |

The in-band summarize response remains HTTP `200`, but now marks itself transient to the gateway. An `Idempotency-Key` lock is released instead of storing that temporary denial for 24 hours, so the same key can recover once entitlement verification does.

## Validation

- RPC billing regression: 17/17 passed, including terminal lapse, confirmed free, invalid-code suppression, and all six migrated exception handlers.
- Gateway idempotency regression: 11/11 passed, including same-key recovery after an in-band retryable envelope.
- `npm run typecheck`, `npm run typecheck:api`, docs stats, markdownlint, and `git diff --check` passed.
- `npm run lint` passed with zero errors; it reported the repository's existing 31 warnings and 3 infos.
- The broader data suite reached 17,048 passing tests with two prebuild-only failures because the clean worktree had no `dist/dashboard.html`. Regenerating that artifact was independently blocked by the shared dependency snapshot missing `@fontsource/nunito/400.css`; the changed seams and both typechecks are green.
- In-process correctness, security, API-contract, reliability, adversarial, maintainability, testing, and project-standards review completed. The optional external cross-model pass was not run because external code egress was not authorized.

## Post-Deploy Monitoring & Validation

Owner: PR author for the first 24 hours after both stacked PRs reach production.

- Search gateway logs for `billing_verification_503`, `[error-mapper] 503`, `entitlement_verification_unavailable`, `renewal_verification_pending`, and `renewal_verification_failed`, grouped by RPC route.
- Confirm retryable exception RPCs return `503` with both `Retry-After` and `X-Billing-Verification`, while summarize responses use `ServiceError` plus the same billing code.
- Treat any retryable billing code paired with a Pro upsell, `AuthError`, or terminal `403` as a rollback trigger.
- Exercise one same-key summarize retry after a transient denial; a replayed denial or a lock lasting beyond the existing 180-second fail-safe TTL is a failure trigger.

## Related

Stacked on #5661 and must land after it. Retarget this PR to `main` and add the closing reference after the prerequisite merges.

Related: #5652

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5.6-000000)
