### PR TITLE
fix(entitlements): finish the billing-verification sweep (#5622)

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -35,6 +35,11 @@ const EXPOSED_HEADERS = [
   'Mcp-Session-Id',
   'WWW-Authenticate',
   'Retry-After',
+  // Billing-verification contract (#5447/#5622): mirrors the body `code` on
+  // the retryable 503 and the subscription_lapsed 403 so cross-origin browser
+  // clients can distinguish verification states without parsing the body —
+  // the docs and OpenAPI specs advertise the header.
+  'X-Billing-Verification',
   'Idempotency-Key',
   'Idempotent-Replayed',
   // IETF RateLimit fields (draft-ietf-httpapi-ratelimit-headers): RateLimit-Policy

--- a/api/internal/mcp-grant-context.ts
+++ b/api/internal/mcp-grant-context.ts
@@ -31,15 +31,49 @@
 export const config = { runtime: 'edge' };
 
 import { resolveClerkSession } from '../../server/_shared/auth-session';
-import { getEntitlements } from '../../server/_shared/entitlement-check';
+import { clampRetryAfterSeconds, getEntitlements } from '../../server/_shared/entitlement-check';
 
 const NO_STORE_JSON: Record<string, string> = {
   'Content-Type': 'application/json',
   'Cache-Control': 'no-store',
 };
 
-function jsonError(error: string, error_description: string, status: number): Response {
-  return new Response(JSON.stringify({ error, error_description }), { status, headers: NO_STORE_JSON });
+function jsonError(error: string, error_description: string, status: number, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify({ error, error_description }), { status, headers: { ...NO_STORE_JSON, ...headers } });
+}
+
+// #5622: a billing-verification state is not a confirmed tier denial. Answer
+// it with this endpoint's existing SERVICE_UNAVAILABLE vocabulary — callers
+// already treat that as "temporarily unavailable, retry" for the storage-blip
+// paths — instead of INSUFFICIENT_TIER, which tells a paying user mid-OAuth
+// that they lack a subscription. Retrying is protocol-safe here: this endpoint
+// is a read (consent-page context) and consumes no nonce/grant state. The
+// provider-confirmed subscription_lapsed status is NOT matched — that one is
+// a real denial and falls through to the hard INSUFFICIENT_TIER 403.
+// (Deliberately duplicated from mcp-grant-mint.ts: the two handlers keep
+// their own narrow surfaces; parity is enforced by tests, not shared code.)
+function billingVerificationRetryDenial(
+  ent: {
+    verificationUnavailable?: boolean;
+    billingStatus?: string;
+    retryAfterSeconds?: number;
+  } | null,
+): Response | null {
+  const transient = ent?.verificationUnavailable === true
+    ? 'entitlement_verification_unavailable'
+    : ent?.billingStatus === 'renewal_verification_pending' || ent?.billingStatus === 'renewal_verification_failed'
+      ? ent.billingStatus
+      : null;
+  if (!transient) return null;
+  return jsonError(
+    'SERVICE_UNAVAILABLE',
+    'Unable to verify your subscription right now. Please try again in a few seconds.',
+    503,
+    {
+      'Retry-After': String(clampRetryAfterSeconds(ent?.retryAfterSeconds)),
+      'X-Billing-Verification': transient,
+    },
+  );
 }
 
 interface NonceData {
@@ -68,7 +102,13 @@ async function rawRedisGet(key: string): Promise<unknown | null> {
 export interface ContextDeps {
   resolveUserId: (req: Request) => Promise<string | null>;
   redisGet: (key: string) => Promise<unknown | null>;
-  getEntitlements: (userId: string) => Promise<{ features: { tier: number; mcpAccess?: boolean }; validUntil: number } | null>;
+  getEntitlements: (userId: string) => Promise<{
+    features: { tier: number; mcpAccess?: boolean };
+    validUntil: number;
+    billingStatus?: string;
+    retryAfterSeconds?: number;
+    verificationUnavailable?: boolean;
+  } | null>;
   now: () => number;
 }
 
@@ -99,6 +139,8 @@ export async function grantContextHandler(req: Request, deps: ContextDeps): Prom
   // complete OAuth, get a tokenId, then have every tools/call fail at the
   // gateway. The two gates must agree.
   const ent = await deps.getEntitlements(userId);
+  const retryDenial = billingVerificationRetryDenial(ent);
+  if (retryDenial) return retryDenial;
   if (
     !ent ||
     ent.features.tier < 1 ||

--- a/api/internal/mcp-grant-mint.ts
+++ b/api/internal/mcp-grant-mint.ts
@@ -54,7 +54,7 @@
 export const config = { runtime: 'edge' };
 
 import { resolveClerkSession } from '../../server/_shared/auth-session';
-import { getEntitlements } from '../../server/_shared/entitlement-check';
+import { clampRetryAfterSeconds, getEntitlements } from '../../server/_shared/entitlement-check';
 // @ts-expect-error — JS module, no declaration file
 import { isAllowedRedirectUri } from '../oauth/register.js';
 import { GrantConfigError, signGrant } from '../_mcp-grant-hmac';
@@ -71,8 +71,40 @@ const NO_STORE_JSON: Record<string, string> = {
   'Cache-Control': 'no-store',
 };
 
-function jsonError(error: string, error_description: string, status: number): Response {
-  return new Response(JSON.stringify({ error, error_description }), { status, headers: NO_STORE_JSON });
+function jsonError(error: string, error_description: string, status: number, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify({ error, error_description }), { status, headers: { ...NO_STORE_JSON, ...headers } });
+}
+
+// #5622: a billing-verification state is not a confirmed tier denial. Answer
+// it with this endpoint's existing SERVICE_UNAVAILABLE vocabulary — callers
+// already treat that as "temporarily unavailable, retry" for the storage-blip
+// paths — instead of INSUFFICIENT_TIER, which tells a paying user mid-OAuth
+// that they lack a subscription. Retrying is protocol-safe here: the Pro gate
+// runs before any nonce/grant state is claimed or consumed. The provider-
+// confirmed subscription_lapsed status is NOT matched — that one is a real
+// denial and falls through to the hard INSUFFICIENT_TIER 403.
+function billingVerificationRetryDenial(
+  ent: {
+    verificationUnavailable?: boolean;
+    billingStatus?: string;
+    retryAfterSeconds?: number;
+  } | null,
+): Response | null {
+  const transient = ent?.verificationUnavailable === true
+    ? 'entitlement_verification_unavailable'
+    : ent?.billingStatus === 'renewal_verification_pending' || ent?.billingStatus === 'renewal_verification_failed'
+      ? ent.billingStatus
+      : null;
+  if (!transient) return null;
+  return jsonError(
+    'SERVICE_UNAVAILABLE',
+    'Unable to verify your subscription right now. Please try again in a few seconds.',
+    503,
+    {
+      'Retry-After': String(clampRetryAfterSeconds(ent?.retryAfterSeconds)),
+      'X-Billing-Verification': transient,
+    },
+  );
 }
 
 interface NonceData {
@@ -171,7 +203,13 @@ export interface MintDeps {
    */
   redisSetNxEx: (key: string, value: unknown, ttlSeconds: number) => Promise<boolean>;
   /** Returns Pro entitlement info or null. */
-  getEntitlements: (userId: string) => Promise<{ features: { tier: number; mcpAccess?: boolean }; validUntil: number } | null>;
+  getEntitlements: (userId: string) => Promise<{
+    features: { tier: number; mcpAccess?: boolean };
+    validUntil: number;
+    billingStatus?: string;
+    retryAfterSeconds?: number;
+    verificationUnavailable?: boolean;
+  } | null>;
   /** Same allowlist DCR uses. */
   isAllowedRedirectUri: (uri: string) => boolean;
   /** Signs the wire-format grant token. Throws GrantConfigError if env unset. */
@@ -235,6 +273,8 @@ export async function mintGrantHandler(req: Request, deps: MintDeps): Promise<Re
 
   const ent = await deps.getEntitlements(userId);
   const now = deps.now();
+  const retryDenial = billingVerificationRetryDenial(ent);
+  if (retryDenial) return retryDenial;
   // Mirror downstream MCP-edge gate: both tier ≥ 1 AND mcpAccess === true
   // are required. Reviewer round-2 P2 — gating on tier alone here lets a
   // tier-1 user without mcpAccess get a token row, then 401 every call.

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -358,6 +358,15 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   }
 
   if (req.method === 'POST') {
+    // #5622 decision: deliberately stricter than checkEntitlementDetailed,
+    // which waives the Convex row for `clerkRole === 'pro'` on tier<=1 gates
+    // (complimentary / tester / legacy grants). Channel writes arm ongoing
+    // server-side deliveries (email/Telegram/Slack/Discord relays, welcome
+    // and digest sends), so they require a verifiable billed entitlement row
+    // — a role claim inside a session JWT is not enough to attach recurring
+    // delivery spend to. Role-only Pros keep GET access above and all
+    // frontend Pro unlocks. Pinned by
+    // tests/notification-channels-billing-denial.test.mts.
     const ent = await notificationChannelsDeps.getEntitlements(session.userId);
     if (!ent || ent.features.tier < 1) {
       // #5600: an entitlement the backend could not VERIFY (Convex 5xx/timeout,

--- a/api/oauth/authorize-pro.ts
+++ b/api/oauth/authorize-pro.ts
@@ -65,7 +65,7 @@
 export const config = { runtime: 'edge' };
 
 import { verifyGrant, GrantConfigError } from '../_mcp-grant-hmac';
-import { getEntitlements } from '../../server/_shared/entitlement-check';
+import { clampRetryAfterSeconds, getEntitlements } from '../../server/_shared/entitlement-check';
 import {
   issueProMcpTokenForUser,
   revokeProMcpToken,
@@ -103,7 +103,7 @@ function escapeHtml(str: string): string {
  * Pro Clerk path. Status defaults to 400; pass 500/503 for server-side
  * issues so monitoring distinguishes them, but copy is vague to the user.
  */
-function htmlError(title: string, detail: string, status: number = 400): Response {
+function htmlError(title: string, detail: string, status: number = 400, extraHeaders: Record<string, string> = {}): Response {
   return new Response(
     `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Error &#x2014; WorldMonitor MCP</title>
 <style>*{box-sizing:border-box;margin:0;padding:0}body{font-family:ui-monospace,'SF Mono','Cascadia Code',monospace;background:#0a0a0a;color:#e8e8e8;min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:1.5rem}.wm-logo{display:flex;align-items:center;gap:.5rem;margin-bottom:2rem;text-decoration:none}.wm-logo svg{color:#2d8a6e}.wm-logo-text{font-size:.75rem;color:#555;letter-spacing:.1em;text-transform:uppercase}.card{width:100%;max-width:420px;background:#111;border:1px solid #1e1e1e;padding:2rem}h1{font-size:.95rem;font-weight:600;color:#ef4444;margin-bottom:.75rem;letter-spacing:.02em}p{font-size:.85rem;color:#666;line-height:1.6}.back{display:inline-block;margin-top:1.5rem;font-size:.75rem;color:#444;text-decoration:none;letter-spacing:.03em}.back:hover{color:#888}.footer{margin-top:1.5rem;font-size:.7rem;color:#2a2a2a;text-align:center}.footer a{color:#333;text-decoration:none}.footer a:hover{color:#555}</style></head>
@@ -111,7 +111,7 @@ function htmlError(title: string, detail: string, status: number = 400): Respons
 <div class="card"><h1>${escapeHtml(title)}</h1><p>${escapeHtml(detail)}</p><a href="javascript:history.back()" class="back">&#8592; go back</a></div>
 <p class="footer"><a href="https://www.worldmonitor.app" target="_blank" rel="noopener">worldmonitor.app</a></p>
 </body></html>`,
-    { status, headers: PAGE_HEADERS },
+    { status, headers: { ...PAGE_HEADERS, ...extraHeaders } },
   );
 }
 
@@ -207,7 +207,13 @@ export interface AuthorizeProDeps {
   /** Verifies the wire-format HMAC grant. */
   verifyGrant: typeof verifyGrant;
   /** Returns Pro entitlement info or null. */
-  getEntitlements: (userId: string) => Promise<{ features: { tier: number; mcpAccess?: boolean }; validUntil: number } | null>;
+  getEntitlements: (userId: string) => Promise<{
+    features: { tier: number; mcpAccess?: boolean };
+    validUntil: number;
+    billingStatus?: string;
+    retryAfterSeconds?: number;
+    verificationUnavailable?: boolean;
+  } | null>;
   /** Issues the Convex mcpProTokens row. Throws ProMcpIssueFailed on failure. */
   issueProMcpTokenForUser: typeof issueProMcpTokenForUser;
   /** Best-effort revoke for the rollback path. Must NOT throw (matches U2 contract). */
@@ -359,6 +365,33 @@ export async function authorizeProHandler(req: Request, deps: AuthorizeProDeps):
   // row, then have every tools/call fail at the gateway.
   const ent = await deps.getEntitlements(userId);
   const now = deps.now();
+  // #5622: a billing-verification state (transient lookup failure or an
+  // in-flight renewal re-check) is not a confirmed tier denial — do not tell
+  // a paying user their subscription is missing. The retryable contract is
+  // adapted for this browser-facing surface: the grant/nonce were atomically
+  // GETDEL-consumed in steps 3-4, so THIS URL can never be retried — the copy
+  // sends the user back to their MCP client to restart the connection, and
+  // the 503 + Retry-After still let the client distinguish the state.
+  // English-only like every htmlError page here (no locale fan-out). The
+  // provider-confirmed subscription_lapsed status is NOT matched — it is a
+  // real denial and falls through to the hard 403 below.
+  if (
+    ent?.verificationUnavailable === true
+    || ent?.billingStatus === 'renewal_verification_pending'
+    || ent?.billingStatus === 'renewal_verification_failed'
+  ) {
+    return htmlError(
+      'Subscription Verification In Progress',
+      'We could not confirm your Pro subscription just now — this is usually a temporary hiccup and your subscription is not affected. Please return to your MCP client and start the connection again in a few seconds.',
+      503,
+      {
+        'Retry-After': String(clampRetryAfterSeconds(ent.retryAfterSeconds)),
+        'X-Billing-Verification': ent.verificationUnavailable === true
+          ? 'entitlement_verification_unavailable'
+          : String(ent.billingStatus),
+      },
+    );
+  }
   if (
     !ent ||
     ent.features.tier < 1 ||

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -221,7 +221,7 @@ export function isEntitlementBackendConfigured(): boolean {
   return Boolean(process.env.CONVEX_SITE_URL && getConvexSharedSecret());
 }
 
-function clampRetryAfterSeconds(raw: number | undefined): number {
+export function clampRetryAfterSeconds(raw: number | undefined): number {
   return Number.isFinite(raw)
     ? Math.max(1, Math.min(60, Math.ceil(raw!)))
     : 5;
@@ -303,6 +303,14 @@ export async function getEntitlements(userId: string): Promise<CachedEntitlement
   }
 }
 
+// Negative-cache TTL for the transient-failure marker below. During a Convex
+// outage every uncached request pays the full 3s fetch timeout before the
+// gates can answer their retryable 503 — and #5600 bounding the tier-0 marker
+// to 60s made this path more reachable. A few seconds of negative caching
+// bounds that amplification to one timed-out probe per user per window while
+// staying far below the shortest honest Retry-After the gates advertise (#5622).
+const UNAVAILABLE_NEGATIVE_CACHE_TTL_SECONDS = 5;
+
 // Free-shaped deny-side value for transient lookup failures. Grants nothing
 // (tier 0, no apiAccess/mcpAccess, validUntil 0); its only power is steering
 // the gates to the retryable 503 via getBillingVerificationDenial.
@@ -323,6 +331,22 @@ function unavailableEntitlements(): CachedEntitlements {
   };
 }
 
+// Returns the transient-failure marker after best-effort negative-caching it.
+// The write is fire-and-safe: when the failure that brought us here includes
+// Redis itself, setCachedJson's own error must not mask the marker return.
+async function negativeCacheUnavailable(userId: string): Promise<CachedEntitlements> {
+  const marker = unavailableEntitlements();
+  try {
+    await setCachedJson(
+      `entitlements:${ENV_PREFIX}:${userId}`,
+      marker,
+      UNAVAILABLE_NEGATIVE_CACHE_TTL_SECONDS,
+      true,
+    );
+  } catch { /* outage may include Redis — serve the marker regardless */ }
+  return marker;
+}
+
 async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements | null> {
   try {
     // Redis cache check (raw=true: entitlements use user-scoped keys, no deployment prefix)
@@ -330,6 +354,11 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
 
     if (cached && typeof cached === 'object') {
       const ent = cached as CachedEntitlements;
+      // Negative-cached transient-failure marker (negativeCacheUnavailable):
+      // serve it for its short Redis TTL. Its validUntil is 0, so without this
+      // it would fall through to Convex on every request and defeat the
+      // negative cache entirely (#5622).
+      if (ent.verificationUnavailable === true) return ent;
       // Verification markers have their own short Redis TTL. Serve them even
       // though validUntil is expired so cooldown requests stop at Redis instead
       // of repeating the Convex action/claim chain.
@@ -380,7 +409,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
       // 5xx = Convex/platform blip -> retryable-503 posture at the gates.
       // 4xx (bad shared secret, contract rejection) = deploy defect, not a
       // transient: keep the fail-closed null so callers hold the hard posture.
-      return response.status >= 500 ? unavailableEntitlements() : null;
+      return response.status >= 500 ? await negativeCacheUnavailable(userId) : null;
     }
     const result = await response.json() as CachedEntitlements | null;
 
@@ -420,7 +449,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
     // the on-demand provider re-check (#4770) overrunning the 3s fetch budget
     // reproduced exactly the hard-denial the rework exists to eliminate.
     console.warn('[entitlement-check] getEntitlements failed:', err instanceof Error ? err.message : String(err));
-    return unavailableEntitlements();
+    return negativeCacheUnavailable(userId);
   }
 }
 

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -19,6 +19,19 @@ export type PremiumCallerIdentity =
 
 /**
  * Resolves premium status and the user-bound identity for spend controls.
+ *
+ * #5622 scope note — this helper deliberately does NOT adopt the retryable
+ * billing-verification contract (503 + Retry-After + X-Billing-Verification).
+ * It returns an identity object, not a Response, for endpoints that are
+ * PUBLIC to free callers and merely honor extra fields or higher limits for
+ * premium ones. During a transient entitlement outage (getEntitlements
+ * returns the tier-0 `verificationUnavailable` marker) the correct posture
+ * here is to degrade the caller to the free behavior the endpoint already
+ * serves — converting an otherwise-successful public request into a 503
+ * would take the free product down with the billing backend. Surfaces that
+ * hard-deny on tier must call getBillingVerificationDenial BEFORE their
+ * tier gate instead (see api/notification-channels.ts, the MCP grant
+ * handlers, and server/gateway.ts).
  */
 export async function resolvePremiumCallerIdentity(request: Request): Promise<PremiumCallerIdentity> {
   // Internal-MCP context: trusted markers are set by the gateway AFTER an

--- a/src/services/billing-retry.ts
+++ b/src/services/billing-retry.ts
@@ -1,0 +1,46 @@
+/**
+ * Client-side handling of the retryable billing-verification contract
+ * (#5447/#5622): gated endpoints answer 503 + Retry-After +
+ * X-Billing-Verification while paid access is being re-confirmed with the
+ * billing provider or the entitlement backend is briefly unreachable. A
+ * single bounded retry makes that contract real on the client — without it
+ * the activation wizard fails the step exactly as if the denial were
+ * terminal. Kept dependency-free so it is unit-testable outside the
+ * Vite/browser context.
+ */
+
+// The activation wizard bounds each mutation to ACTIVATION_MUTATION_TIMEOUT_MS
+// (5s in src/components/ProActivationInterstitial.ts). One retry must leave
+// room for two request round-trips inside that budget, so the honored
+// Retry-After is capped well below it. The server's default Retry-After for
+// entitlement_verification_unavailable is 5s — deliberately clamped here.
+export const BILLING_RETRY_MAX_DELAY_MS = 2_000;
+const BILLING_RETRY_DEFAULT_DELAY_MS = 1_000;
+
+/**
+ * Returns the delay (ms) to wait before the single retry, or null when the
+ * response is not a retryable billing-verification denial. Honors Retry-After
+ * (seconds) up to BILLING_RETRY_MAX_DELAY_MS. Only 503 is retryable — the
+ * subscription_lapsed 403 is a provider-confirmed denial by design.
+ */
+export function billingRetryDelayMs(res: Pick<Response, 'status' | 'headers'>): number | null {
+  if (res.status !== 503) return null;
+  const retryAfter = Number(res.headers.get('Retry-After'));
+  const delayMs = Number.isFinite(retryAfter) && retryAfter > 0
+    ? retryAfter * 1_000
+    : BILLING_RETRY_DEFAULT_DELAY_MS;
+  return Math.min(delayMs, BILLING_RETRY_MAX_DELAY_MS);
+}
+
+/**
+ * Runs `doFetch` and, on a retryable 503, waits the bounded delay and runs it
+ * exactly once more. The second response is returned as-is (a still-failing
+ * retry surfaces to the caller's normal error path).
+ */
+export async function fetchWithBillingRetry(doFetch: () => Promise<Response>): Promise<Response> {
+  const res = await doFetch();
+  const delay = billingRetryDelayMs(res);
+  if (delay === null) return res;
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  return doFetch();
+}

--- a/src/services/notification-channels.ts
+++ b/src/services/notification-channels.ts
@@ -1,3 +1,4 @@
+import { fetchWithBillingRetry } from '@/services/billing-retry';
 import { getClerkToken, getCurrentClerkUser } from '@/services/clerk';
 import { SITE_VARIANT } from '@/config/variant';
 
@@ -72,12 +73,21 @@ async function authFetch(
   // The token was resolved asynchronously. Re-check immediately before the
   // request so a modal opened by user A cannot write under user B's session.
   assertExpectedAccount(expectedUserId);
-  return fetch(path, {
-    ...init,
-    headers: {
-      ...(init?.headers ?? {}),
-      Authorization: `Bearer ${token}`,
-    },
+  // #5622: honor the retryable billing-verification 503 (Retry-After +
+  // X-Billing-Verification) with exactly one bounded retry, so a transient
+  // entitlement blip doesn't fail an activation step terminally. Safe for
+  // the POSTs here too: the server's billing denial fires before the request
+  // body is read or any mutation begins. The account re-check runs again
+  // before the retry for the same cross-account safety as the first attempt.
+  return fetchWithBillingRetry(() => {
+    assertExpectedAccount(expectedUserId);
+    return fetch(path, {
+      ...init,
+      headers: {
+        ...(init?.headers ?? {}),
+        Authorization: `Bearer ${token}`,
+      },
+    });
   });
 }
 

--- a/tests/billing-retry.test.mts
+++ b/tests/billing-retry.test.mts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  BILLING_RETRY_MAX_DELAY_MS,
+  billingRetryDelayMs,
+  fetchWithBillingRetry,
+} from '../src/services/billing-retry.ts';
+
+// Guards the client half of the #5447/#5622 billing-verification contract:
+// the server's retryable 503 (Retry-After + X-Billing-Verification) is inert
+// unless the client retries at least once before surfacing a failure.
+
+function res(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, { status, headers });
+}
+
+describe('billingRetryDelayMs', () => {
+  it('returns null for non-503 statuses (200, 403, 429, 500)', () => {
+    for (const status of [200, 403, 429, 500]) {
+      assert.equal(billingRetryDelayMs(res(status, { 'Retry-After': '5' })), null, `status ${status}`);
+    }
+  });
+
+  it('honors Retry-After seconds on a 503', () => {
+    assert.equal(billingRetryDelayMs(res(503, { 'Retry-After': '1' })), 1_000);
+  });
+
+  it('caps the honored Retry-After below the activation mutation budget', () => {
+    // Server default for entitlement_verification_unavailable is 5s; the
+    // wizard bounds each mutation to 5s total, so the delay must clamp.
+    assert.equal(billingRetryDelayMs(res(503, { 'Retry-After': '5' })), BILLING_RETRY_MAX_DELAY_MS);
+    assert.equal(billingRetryDelayMs(res(503, { 'Retry-After': '60' })), BILLING_RETRY_MAX_DELAY_MS);
+  });
+
+  it('falls back to a bounded default when Retry-After is missing or malformed', () => {
+    const bare = billingRetryDelayMs(res(503));
+    assert.ok(bare !== null && bare > 0 && bare <= BILLING_RETRY_MAX_DELAY_MS);
+    const junk = billingRetryDelayMs(res(503, { 'Retry-After': 'soon' }));
+    assert.equal(junk, bare);
+    const negative = billingRetryDelayMs(res(503, { 'Retry-After': '-3' }));
+    assert.equal(negative, bare);
+  });
+});
+
+describe('fetchWithBillingRetry', () => {
+  it('returns the first response untouched when it is not a retryable 503', async () => {
+    let calls = 0;
+    const ok = res(200);
+    const out = await fetchWithBillingRetry(async () => { calls++; return ok; });
+    assert.equal(out, ok);
+    assert.equal(calls, 1);
+  });
+
+  it('retries exactly once on 503, honoring Retry-After', async () => {
+    let calls = 0;
+    const start = Date.now();
+    const out = await fetchWithBillingRetry(async () => {
+      calls++;
+      return calls === 1 ? res(503, { 'Retry-After': '1' }) : res(200);
+    });
+    assert.equal(out.status, 200);
+    assert.equal(calls, 2);
+    assert.ok(Date.now() - start >= 950, 'must actually wait out the Retry-After delay');
+  });
+
+  it('a still-failing retry surfaces to the caller — no second retry', async () => {
+    let calls = 0;
+    const out = await fetchWithBillingRetry(async () => {
+      calls++;
+      return res(503, { 'Retry-After': '1' });
+    });
+    assert.equal(out.status, 503);
+    assert.equal(calls, 2);
+  });
+
+  it('does not retry the provider-confirmed 403 (subscription_lapsed is terminal by design)', async () => {
+    let calls = 0;
+    const out = await fetchWithBillingRetry(async () => {
+      calls++;
+      return res(403, { 'X-Billing-Verification': 'subscription_lapsed' });
+    });
+    assert.equal(out.status, 403);
+    assert.equal(calls, 1);
+  });
+});

--- a/tests/mcp-grant-mint.test.mjs
+++ b/tests/mcp-grant-mint.test.mjs
@@ -644,3 +644,90 @@ describe('grantContextHandler', () => {
     assert.equal(body.client_name, BASE_CLIENT_DATA.client_name);
   });
 });
+
+// =========================================================================
+// #5622 — billing-verification states answer retryable, not INSUFFICIENT_TIER
+// =========================================================================
+
+const VERIFICATION_UNAVAILABLE_ENT = {
+  features: { tier: 0, mcpAccess: false },
+  validUntil: 0,
+  verificationUnavailable: true,
+  retryAfterSeconds: 7,
+};
+
+const RENEWAL_PENDING_ENT = {
+  features: { tier: 1, mcpAccess: true },
+  validUntil: FIXED_NOW - 1000,
+  billingStatus: 'renewal_verification_pending',
+  retryAfterSeconds: 3,
+};
+
+const RENEWAL_FAILED_ENT = {
+  features: { tier: 1, mcpAccess: true },
+  validUntil: FIXED_NOW - 1000,
+  billingStatus: 'renewal_verification_failed',
+  retryAfterSeconds: 9,
+};
+
+const LAPSED_ENT = {
+  features: { tier: 0, mcpAccess: false },
+  validUntil: FIXED_NOW - 1000,
+  billingStatus: 'subscription_lapsed',
+};
+
+describe('#5622 billing-verification retryable contract (mint + context parity)', () => {
+  const handlers = [
+    ['mintGrantHandler', (deps) => mintGrantHandler(makePostReq({ nonce: 'nonce_xyz' }), deps), makeMintDeps],
+    ['grantContextHandler', (deps) => grantContextHandler(makeGetReq('nonce_xyz'), deps), makeContextDeps],
+  ];
+
+  for (const [name, run, makeDeps] of handlers) {
+    it(`${name}: verificationUnavailable answers 503 SERVICE_UNAVAILABLE with Retry-After + X-Billing-Verification`, async () => {
+      const { deps } = makeDeps({ getEntitlements: async () => VERIFICATION_UNAVAILABLE_ENT });
+      const res = await run(deps);
+      assert.equal(res.status, 503);
+      const json = await res.json();
+      assert.equal(json.error, 'SERVICE_UNAVAILABLE');
+      assert.equal(res.headers.get('Retry-After'), '7');
+      assert.equal(res.headers.get('X-Billing-Verification'), 'entitlement_verification_unavailable');
+      assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    });
+
+    it(`${name}: renewal_verification_pending answers 503 with the status code and honored Retry-After`, async () => {
+      const { deps } = makeDeps({ getEntitlements: async () => RENEWAL_PENDING_ENT });
+      const res = await run(deps);
+      assert.equal(res.status, 503);
+      const json = await res.json();
+      assert.equal(json.error, 'SERVICE_UNAVAILABLE');
+      assert.equal(res.headers.get('Retry-After'), '3');
+      assert.equal(res.headers.get('X-Billing-Verification'), 'renewal_verification_pending');
+    });
+
+    it(`${name}: renewal_verification_failed answers 503 (still retryable, not a confirmed denial)`, async () => {
+      const { deps } = makeDeps({ getEntitlements: async () => RENEWAL_FAILED_ENT });
+      const res = await run(deps);
+      assert.equal(res.status, 503);
+      assert.equal(res.headers.get('X-Billing-Verification'), 'renewal_verification_failed');
+    });
+
+    it(`${name}: subscription_lapsed stays a hard 403 INSUFFICIENT_TIER (provider-confirmed denial)`, async () => {
+      const { deps } = makeDeps({ getEntitlements: async () => LAPSED_ENT });
+      const res = await run(deps);
+      assert.equal(res.status, 403);
+      const json = await res.json();
+      assert.equal(json.error, 'INSUFFICIENT_TIER');
+      assert.equal(res.headers.get('Retry-After'), null);
+    });
+  }
+
+  it('mintGrantHandler: the retryable denial fires before any nonce/grant state is claimed', async () => {
+    const { deps, setNxExCalls, setExCalls } = makeMintDeps({
+      getEntitlements: async () => VERIFICATION_UNAVAILABLE_ENT,
+    });
+    const res = await mintGrantHandler(makePostReq({ nonce: 'nonce_xyz' }), deps);
+    assert.equal(res.status, 503);
+    assert.equal(setNxExCalls.length, 0, 'no grant claim may be written for a retryable denial');
+    assert.equal(setExCalls.length, 0, 'no state may be consumed for a retryable denial');
+  });
+});

--- a/tests/notification-channels-billing-denial.test.mts
+++ b/tests/notification-channels-billing-denial.test.mts
@@ -345,3 +345,32 @@ describe('/api/notification-channels POST billing-verification contract', () => 
     });
   });
 });
+
+describe('/api/notification-channels POST clerkRole allowance decision (#5622)', () => {
+  it('clerkRole === "pro" alone does NOT waive the entitlement row for channel writes', async () => {
+    // checkEntitlementDetailed waives the Convex row for role='pro' on
+    // tier<=1 gates (complimentary / tester / legacy grants). This endpoint
+    // is deliberately stricter: channel writes arm ongoing server-side
+    // deliveries, so a role claim inside a session JWT is not enough. This
+    // test pins that decision — if the gate ever adopts the allowance, the
+    // rationale comment in api/notification-channels.ts must go with it.
+    const mod = await importFreshNotificationChannels();
+    mod.__resetDenialCaptureDedupForTests();
+    mod.__setNotificationChannelsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: 'user-role-only-pro', role: 'pro' }),
+      // A role-only grant has no Convex row: a plain confirmed tier-0 answer
+      // (no billingStatus, no verificationUnavailable markers).
+      getEntitlements: async () => freeShapedEntitlements({}),
+      fetch: async () => {
+        throw new Error('relay must not be reached for a denied request');
+      },
+      captureSilentError: () => {},
+    });
+    mock.method(console, 'warn', () => {});
+
+    const res = await mod.default(makeSetChannelRequest(), ctx);
+    assert.equal(res.status, 403);
+    const body = await res.json() as { error?: string };
+    assert.equal(body.error, 'pro_required');
+  });
+});

--- a/tests/oauth-authorize-pro.test.mjs
+++ b/tests/oauth-authorize-pro.test.mjs
@@ -624,3 +624,70 @@ describe('authorizeProHandler — Cache-Control header invariant', () => {
     assert.equal(res.headers.get('Cache-Control'), 'no-store');
   });
 });
+
+// =========================================================================
+// #5622 — billing-verification states answer a retryable 503 page, not the
+// "Pro Subscription Required" 403 (which tells a paying user mid-blip that
+// their subscription is gone).
+// =========================================================================
+
+describe('authorizeProHandler — #5622 billing-verification retryable contract', () => {
+  const VERIFICATION_UNAVAILABLE_ENT = {
+    features: { tier: 0, mcpAccess: false },
+    validUntil: 0,
+    verificationUnavailable: true,
+    retryAfterSeconds: 7,
+  };
+  const RENEWAL_PENDING_ENT = {
+    features: { tier: 1, mcpAccess: true },
+    validUntil: FIXED_NOW - 1000,
+    billingStatus: 'renewal_verification_pending',
+    retryAfterSeconds: 3,
+  };
+  const LAPSED_ENT = {
+    features: { tier: 0, mcpAccess: false },
+    validUntil: FIXED_NOW - 1000,
+    billingStatus: 'subscription_lapsed',
+  };
+
+  it('verificationUnavailable → 503 HTML page with Retry-After + X-Billing-Verification and restart-the-flow copy', async () => {
+    const grant = await makeGrantToken();
+    const { deps, issueCalls } = await makeDeps({
+      getEntitlements: async () => VERIFICATION_UNAVAILABLE_ENT,
+    });
+    const res = await authorizeProHandler(makeReq({ nonce: NONCE, grant }), deps);
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('Retry-After'), '7');
+    assert.equal(res.headers.get('X-Billing-Verification'), 'entitlement_verification_unavailable');
+    const html = await res.text();
+    assert.match(html, /Subscription Verification In Progress/);
+    // The nonce/grant were GETDEL-consumed in steps 3-4, so the page must
+    // direct the user to restart from the MCP client, not to reload this URL.
+    assert.match(html, /start the connection again/);
+    assert.doesNotMatch(html, /Pro Subscription Required/);
+    assert.equal(issueCalls.length, 0, 'no token row may be issued during a verification blip');
+  });
+
+  it('renewal_verification_pending → 503 with the status code and honored Retry-After', async () => {
+    const grant = await makeGrantToken();
+    const { deps } = await makeDeps({
+      getEntitlements: async () => RENEWAL_PENDING_ENT,
+    });
+    const res = await authorizeProHandler(makeReq({ nonce: NONCE, grant }), deps);
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('Retry-After'), '3');
+    assert.equal(res.headers.get('X-Billing-Verification'), 'renewal_verification_pending');
+  });
+
+  it('subscription_lapsed stays the hard 403 "Pro Subscription Required" (provider-confirmed denial)', async () => {
+    const grant = await makeGrantToken();
+    const { deps } = await makeDeps({
+      getEntitlements: async () => LAPSED_ENT,
+    });
+    const res = await authorizeProHandler(makeReq({ nonce: NONCE, grant }), deps);
+    assert.equal(res.status, 403);
+    assert.equal(res.headers.get('Retry-After'), null);
+    const html = await res.text();
+    assert.match(html, /Pro Subscription Required/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5622 — extends the #5447/#5600 retryable billing-verification contract to the three deferred consumers, and lands the four "also found" items. Every remaining consumer now either adopts the contract or carries the required scope-note comment.

### The three deferred consumers

- **`api/internal/mcp-grant-mint.ts` + `mcp-grant-context.ts`** — adopted, in the handlers' **own vocabulary**: transient states (`verificationUnavailable`, `renewal_verification_pending/failed`) answer **503 `SERVICE_UNAVAILABLE`** (which the SPA already handles for the Redis storage-blip paths — no new protocol semantics) with `Retry-After` + `X-Billing-Verification`, instead of `INSUFFICIENT_TIER` telling a paying user mid-handshake they lack a subscription. Retry is protocol-safe: both gates run **before** any nonce/grant state is claimed or consumed (pinned by a test asserting no `SETEX`/`SET NX` happened). `subscription_lapsed` deliberately stays the hard 403.
- **`api/oauth/authorize-pro.ts`** — adopted, adapted for the browser surface: the same states render a **503 "Subscription Verification In Progress"** page instead of "Pro Subscription Required". Key protocol constraint discovered here: the grant/nonce are atomically GETDEL-consumed in steps 3-4 **before** the step-7 entitlement re-check, so the URL can never be retried — the copy sends the user back to their MCP client to restart the connection, and `Retry-After` + `X-Billing-Verification` still mark the state machine-readably. English-only like every existing `htmlError` page, so no locale fan-out.
- **`server/_shared/premium-check.ts`** — comment stating why it cannot adopt: it returns an identity object (not a Response) for endpoints that are **public** to free callers and merely honor premium extras. Degrading to the free behavior during an outage is correct; a 503 would take the free product down with the billing backend.

### The four "also found" items

1. **Client honors the 503** — new `src/services/billing-retry.ts` (dependency-free, unit-tested): exactly one bounded retry honoring `Retry-After`, capped at 2s to fit inside `ACTIVATION_MUTATION_TIMEOUT_MS` (5s) with room for two round-trips. Wired into `authFetch` in `src/services/notification-channels.ts`; the cross-account `assertExpectedAccount` guard re-runs before the retry. The lapsed 403 is never retried.
2. **CORS** — `X-Billing-Verification` added to `Access-Control-Expose-Headers` in `api/_cors.js` (docs advertise the header; cross-origin clients couldn't read it).
3. **`clerkRole === 'pro'` on notification writes** — decision: stay **stricter** than `checkEntitlementDetailed`'s allowance, with the rationale in a comment at the gate (channel writes arm recurring server-side deliveries — email/Telegram/Slack/Discord relays, welcome + digest sends — and a JWT role claim cannot anchor that spend; role-only Pros keep GET access and all frontend unlocks). Pinned by a new test in `tests/notification-channels-billing-denial.test.mts`. Happy to flip this to honoring the allowance if you'd rather have consistency — the test makes either decision explicit.
4. **Negative caching** — transient `unavailableEntitlements()` answers are now cached for **5s** (`negativeCacheUnavailable` in `server/_shared/entitlement-check.ts`) and served from the cache read path, so a Convex outage costs one 3s-timeout probe per user per window instead of every request re-paying it. The write is fail-safe when the outage includes Redis itself.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: `server/_shared/`, `src/services/` (activation wizard fetch path)

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant — via the full unit/integration suite; no variant-specific UI changes
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documentation claims changed; the wire contract published in #5447's docs (`docs/usage-errors.mdx`) is unchanged, this PR makes more surfaces honor it. (Related but separate: PR #5496 publishes the contract in the OpenAPI specs.)

## Acceptance criteria from #5622

- [x] Each remaining consumer either adopts the retryable contract or carries a comment stating why it cannot
- [x] The client honors a 503 at least once before surfacing a failure (`fetchWithBillingRetry`, unit-tested including the no-second-retry and no-403-retry cases)
- [x] A test pins the `clerkRole === 'pro'` decision on notification writes

## Testing done

- New tests: 9 parity cases across mint/context (503 vocabulary, honored `Retry-After`, lapsed stays 403, no state claimed on the retryable denial), 3 authorize-pro cases (503 page + restart copy, pending, lapsed 403), the clerkRole pin, and 8 unit tests for the client retry helper
- Full `npm run test:data`: **17,019 tests, 17,011 pass** — the only 2 failures (`dashboard-critical-css`) also fail on a clean checkout without this PR (they require a `vite build` artifact absent in a fresh clone); verified by running the suite on the stashed clean tree and comparing failure sets
- `npm run typecheck`, `npm run lint` (biome + safe-html), `lint:boundaries`, `lint:unicode` — all green
- Rebased onto latest `main` (7625aee8c)