### PR TITLE
fix(ml): stop caching a rejected model-load promise for the whole session

### DIFF
--- a/src/workers/load-dedupe.ts
+++ b/src/workers/load-dedupe.ts
@@ -1,0 +1,29 @@
+/**
+ * De-duplicates concurrent async loads by key: while a load is in flight,
+ * every caller shares the same promise; once it SETTLES — success or failure —
+ * the entry is dropped so the next call starts a fresh attempt.
+ *
+ * The settle-time cleanup is the load-bearing part (#5425): deleting the
+ * entry only on the success path caches a REJECTED promise forever, so one
+ * transient failure (offline, CDN hiccup) replays the same rejection to every
+ * later caller without ever re-attempting the load. Callers that want a
+ * success cache (e.g. the ML worker's loadedPipelines) keep it separately —
+ * this map only tracks in-flight work.
+ */
+export function createLoadDeduper<K = string>() {
+  const inFlight = new Map<K, Promise<void>>();
+  return {
+    run(key: K, loader: () => Promise<void>): Promise<void> {
+      const existing = inFlight.get(key);
+      if (existing) return existing;
+      const load = loader().finally(() => {
+        inFlight.delete(key);
+      });
+      inFlight.set(key, load);
+      return load;
+    },
+    isLoading(key: K): boolean {
+      return inFlight.has(key);
+    },
+  };
+}

--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -5,6 +5,7 @@
 
 import { pipeline, env } from '@xenova/transformers';
 import { MODEL_CONFIGS, type ModelConfig } from '@/config/ml-config';
+import { createLoadDeduper } from './load-dedupe';
 import { storeVectors, searchVectors, getCount, resetStore, sanitizeTitle, type VectorSearchResult } from './vector-db';
 
 // Configure transformers.js
@@ -119,7 +120,11 @@ type MLWorkerMessage =
 // Loaded pipelines (using unknown since pipeline types vary)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loadedPipelines = new Map<string, any>();
-const loadingPromises = new Map<string, Promise<void>>();
+// Concurrent loads of the same model share one download; the entry clears
+// when the load settles (NOT only on success), so a transient failure is
+// retried on the next request instead of poisoning the model for the whole
+// session (#5425).
+const modelLoads = createLoadDeduper<string>();
 
 function getModelConfig(modelId: string): ModelConfig | undefined {
   return MODEL_CONFIGS.find(m => m.id === modelId);
@@ -132,17 +137,15 @@ function isSupportedModelId(modelId: string): boolean {
 async function loadModel(modelId: string): Promise<void> {
   if (loadedPipelines.has(modelId)) return;
 
-  // Prevent concurrent loads - return existing promise if loading
-  const existing = loadingPromises.get(modelId);
-  if (existing) return existing;
-
   const config = getModelConfig(modelId);
   if (!config) throw new Error(`Unknown model: ${modelId}`);
 
-  console.log(`[MLWorker] Loading model: ${config.hfModel}`);
-  const startTime = Date.now();
+  // Concurrent callers share one in-flight load; a failed load clears on
+  // settle so the next request re-attempts the download (#5425).
+  return modelLoads.run(modelId, async () => {
+    console.log(`[MLWorker] Loading model: ${config.hfModel}`);
+    const startTime = Date.now();
 
-  const loadPromise = (async () => {
     // Suppress verbose ONNX Runtime warnings (CleanUnusedInitializersAndNodeArgs)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ort = (globalThis as any).ort;
@@ -161,15 +164,11 @@ async function loadModel(modelId: string): Promise<void> {
     });
 
     loadedPipelines.set(modelId, pipe);
-    loadingPromises.delete(modelId);
     console.log(`[MLWorker] Model loaded in ${Date.now() - startTime}ms: ${modelId}`);
 
     // Notify manager that model is now available (no id = unsolicited notification)
     self.postMessage({ type: 'model-loaded', modelId });
-  })();
-
-  loadingPromises.set(modelId, loadPromise);
-  return loadPromise;
+  });
 }
 
 function unloadModel(modelId: string): void {

--- a/tests/ml-worker-load-dedupe.test.mts
+++ b/tests/ml-worker-load-dedupe.test.mts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
 import { createLoadDeduper } from '../src/workers/load-dedupe.ts';
@@ -21,6 +22,24 @@ function deferred() {
 }
 
 describe('createLoadDeduper', () => {
+  it('the ML worker binds one module-scoped deduper around the real pipeline load', async () => {
+    const workerSource = await readFile(
+      new URL('../src/workers/ml.worker.ts', import.meta.url),
+      'utf8',
+    );
+
+    assert.match(
+      workerSource,
+      /const modelLoads = createLoadDeduper<string>\(\);/,
+      'the worker must keep one shared deduper for the module lifetime',
+    );
+    assert.match(
+      workerSource,
+      /return modelLoads\.run\(modelId, async \(\) => \{/,
+      'loadModel must route the real pipeline construction through the shared deduper',
+    );
+  });
+
   it('concurrent callers share one loader invocation', async () => {
     const deduper = createLoadDeduper();
     const gate = deferred();

--- a/tests/ml-worker-load-dedupe.test.mts
+++ b/tests/ml-worker-load-dedupe.test.mts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createLoadDeduper } from '../src/workers/load-dedupe.ts';
+
+// Guards the in-flight load de-duplication the ML worker uses for model
+// downloads (#5425). The original inline implementation deleted the shared
+// promise only on the SUCCESS path, so one transient pipeline() failure
+// (offline, HF CDN hiccup) cached a rejected promise for the rest of the
+// session — every ML feature stayed dead until a page reload even after the
+// network recovered.
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createLoadDeduper', () => {
+  it('concurrent callers share one loader invocation', async () => {
+    const deduper = createLoadDeduper();
+    const gate = deferred();
+    let invocations = 0;
+    const loader = () => {
+      invocations++;
+      return gate.promise;
+    };
+
+    const first = deduper.run('embeddings', loader);
+    const second = deduper.run('embeddings', loader);
+    assert.equal(invocations, 1, 'second concurrent call must reuse the in-flight load');
+    assert.equal(deduper.isLoading('embeddings'), true);
+
+    gate.resolve();
+    await Promise.all([first, second]);
+    assert.equal(deduper.isLoading('embeddings'), false, 'entry must clear after settle');
+  });
+
+  it('#5425 regression: a failed load is retried on the next call instead of replaying the cached rejection', async () => {
+    const deduper = createLoadDeduper();
+    let invocations = 0;
+    const loader = () => {
+      invocations++;
+      return invocations === 1
+        ? Promise.reject(new Error('Failed to fetch'))
+        : Promise.resolve();
+    };
+
+    // Call 1: offline — the load rejects.
+    await assert.rejects(deduper.run('embeddings', loader), /Failed to fetch/);
+    assert.equal(deduper.isLoading('embeddings'), false, 'a settled (rejected) load must not stay cached');
+
+    // Call 2: back online — must re-invoke the loader and succeed.
+    // (The pre-fix behavior returned the cached rejection with invocations
+    // stuck at 1: `call 1 rejected -> call 2 rejected | pipeline() invoked 1x`.)
+    await deduper.run('embeddings', loader);
+    assert.equal(invocations, 2, 'the next call after a failure must start a fresh load');
+  });
+
+  it('a failure is shared by callers that joined DURING the load, not by later ones', async () => {
+    const deduper = createLoadDeduper();
+    const gate = deferred();
+    let invocations = 0;
+    const loader = () => {
+      invocations++;
+      return invocations === 1 ? gate.promise : Promise.resolve();
+    };
+
+    const first = deduper.run('m', loader);
+    const joined = deduper.run('m', loader);
+    gate.reject(new Error('CDN hiccup'));
+
+    // Both in-flight callers see the same failure (one download, one answer)...
+    await assert.rejects(first, /CDN hiccup/);
+    await assert.rejects(joined, /CDN hiccup/);
+    assert.equal(invocations, 1);
+
+    // ...but a caller arriving after the settle gets a fresh attempt.
+    await deduper.run('m', loader);
+    assert.equal(invocations, 2);
+  });
+
+  it('keys are independent — one model failing does not affect another', async () => {
+    const deduper = createLoadDeduper();
+    await assert.rejects(
+      deduper.run('summarization', () => Promise.reject(new Error('boom'))),
+      /boom/,
+    );
+    let loaded = false;
+    await deduper.run('embeddings', () => {
+      loaded = true;
+      return Promise.resolve();
+    });
+    assert.equal(loaded, true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5425. `loadModel()` in the ML worker cached its in-flight load promise in `loadingPromises` for concurrent-caller de-duplication, but the matching `delete` sat after the `await` inside the async IIFE — success path only. One rejected `pipeline()` call (offline, flaky connection, HF CDN hiccup) left the rejected promise cached, and the early-return at the top of `loadModel()` replayed that rejection to every later call without ever re-attempting the download. Every ML-backed feature (semantic clustering, trending keywords, summarization, sentiment, NER, vector search) stayed dead until a page reload.

### Fix

The de-dupe logic is extracted into a small seam, `src/workers/load-dedupe.ts`, where the in-flight entry is dropped when the load **settles** (`.finally`) rather than only on success:

- concurrent callers still share exactly one download and one answer (success or failure),
- the next call after a settle starts a fresh attempt — the issue's expected behavior,
- the success cache (`loadedPipelines`) is untouched, so loaded models still short-circuit.

`loadModel()` now wraps its pipeline construction in `modelLoads.run(modelId, …)`; the poisonable `loadingPromises` map is gone. Extraction rather than an inline `.finally` because the worker itself isn't unit-testable (module-level `@xenova/transformers` import + `self.postMessage`), and the repo convention is a testable seam.

Matches the issue's minimal reduction exactly:

```
old (delete on success only): call 1 rejected -> call 2 rejected  | pipeline() invoked 1x
new (delete on settle):       call 1 rejected -> call 2 resolved  | pipeline() invoked 2x
```

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: `src/workers/` (ML worker)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — behavior verified via unit tests on the extracted seam; no UI changes
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documentation claims changed.

## Testing done

- `tests/ml-worker-load-dedupe.test.mts` (4 tests): the exact #5425 regression (call 1 rejects → call 2 re-invokes the loader and resolves), concurrent callers sharing one invocation, failure shared only by callers that joined during the load, and per-key independence
- Full `npm run test:data`: 17,087 tests, 17,079 pass — the only 2 failures (`dashboard-critical-css`) are pre-existing on clean `main` (they require a `vite build` artifact; verified against a clean-tree baseline run earlier)
- `npm run typecheck`, `npm run lint` (biome + safe-html), `lint:boundaries`, `lint:unicode` — all green