### PR TITLE
feat(onboarding): surface command search in Pro setup

### DIFF
--- a/e2e/pro-activation.spec.ts
+++ b/e2e/pro-activation.spec.ts
@@ -123,8 +123,12 @@ async function openFlow(page: Page, withOpeners: boolean): Promise<void> {
     const { initI18n } = await import('/src/services/i18n.ts');
     await initI18n();
     const mod = await import('/src/components/ProActivationInterstitial.ts');
-    const w = window as unknown as { __proEvents: CapturedProEvent[] };
+    const w = window as unknown as {
+      __proEvents: CapturedProEvent[];
+      __proSearchOpened: boolean;
+    };
     w.__proEvents = [];
+    w.__proSearchOpened = false;
     const options: Record<string, unknown> = {
       accountUserId: 'e2e-user',
       accountEmail: 'e2e@worldmonitor.app',
@@ -134,6 +138,9 @@ async function openFlow(page: Page, withOpeners: boolean): Promise<void> {
       },
     };
     if (openers) {
+      options.openSearch = () => {
+        w.__proSearchOpened = true;
+      };
       options.openWidgetBuilder = () => {};
       options.openAiAnalyst = () => {};
       options.openMcpClients = () => {};
@@ -1083,14 +1090,14 @@ test.describe('Pro activation flow — telemetry + finish-setup chip', () => {
     expect(briefCapture?.message).toContain('Authenticated account changed during notification setup');
   });
 
-  test('power-toolkit pointer confirms the step and fires step-confirmed telemetry', async ({
+  test('power-toolkit command search teaches the shortcut and invokes the app opener', async ({
     page,
   }) => {
     await gotoHarness(page);
     await openFlow(page, /* withOpeners */ true);
 
     // Skip forward until the power step's injected pointer is on screen.
-    const pointer = page.locator('.pro-activation-pointer[data-pointer="widgets"]');
+    const pointer = page.locator('.pro-activation-pointer[data-pointer="search"]');
     for (let i = 0; i < 5; i += 1) {
       if (await pointer.count()) break;
       const skip = page.locator(SKIP_BTN);
@@ -1098,6 +1105,10 @@ test.describe('Pro activation flow — telemetry + finish-setup chip', () => {
       else break;
     }
     await expect(pointer).toBeVisible();
+    await expect(pointer).toContainText('Search the entire dashboard');
+    await expect(pointer.locator('kbd')).toHaveCount(2);
+    await expect(pointer).toHaveAttribute('aria-label', /Search the entire dashboard \((?:⌘K|Ctrl\+K)\)/);
+    await expect(page.locator('.pro-activation-pointer').first()).toHaveAttribute('data-pointer', 'search');
 
     // #5607: Pro is apiAccess:false / mcpAccess:true, so the third pointer sells
     // MCP setup — never "API & MCP keys" deep-linked at the API-plan upsell.
@@ -1106,10 +1117,13 @@ test.describe('Pro activation flow — telemetry + finish-setup chip', () => {
     ).toContainText('Set up MCP');
     await expect(page.locator('.pro-activation-pointer[data-pointer="apiKeys"]')).toHaveCount(0);
 
-    // Clicking a pointer confirms the power step (stepConfirmed) and finishes
-    // the flow (a deep-link closes the full-screen overlay first).
-    await pointer.click();
+    // The advertised keyboard shortcut must work while the full-screen
+    // interstitial is still open, not launch an invisible search layer behind it.
+    await page.keyboard.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+K`);
     await expect(page.locator(OVERLAY)).toHaveCount(0);
+    await expect.poll(
+      () => page.evaluate(() => (window as unknown as { __proSearchOpened: boolean }).__proSearchOpened),
+    ).toBe(true);
 
     const events = await readCapturedEvents(page);
     expect(events[0]?.event).toBe('pro-activation-entered');

--- a/src/App.ts
+++ b/src/App.ts
@@ -77,7 +77,7 @@ import type { GoldIntelligencePanel } from '@/components/GoldIntelligencePanel';
 import { isDesktopRuntime, waitForSidecarReady } from '@/services/runtime';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { BETA_MODE } from '@/config/beta';
-import { trackEvent, trackDeeplinkOpened, initAuthAnalytics } from '@/services/analytics';
+import { track, trackEvent, trackDeeplinkOpened, initAuthAnalytics } from '@/services/analytics';
 import { preloadCountryGeometry, isCountryGeometryLoaded, getCountryNameByCode } from '@/services/country-geometry';
 import { initI18n, t, I18N_RESOURCES_LOADED_EVENT, type I18nResourcesLoadedDetail } from '@/services/i18n';
 import { initDeferredDashboardFonts } from '@/bootstrap/secondary-startup';
@@ -1011,6 +1011,10 @@ export class App {
           this.state.map?.setRenderPaused(false);
           showToast('Country brief failed to open. Please try again.');
         });
+      },
+      openSearch: () => {
+        track('search-open', { source: 'pro-onboarding' });
+        void this.openSearch();
       },
       loadAllData: () => this.dataLoader.loadAllData(),
       updateMonitorResults: () => this.dataLoader.updateMonitorResults(),

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -305,6 +305,7 @@ function warnOnBootShellFootprintDrift(snapshot: BootShellFootprintSnapshot): vo
 export interface PanelLayoutManagerCallbacks {
   openCountryStory: (code: string, name: string) => void;
   openCountryBrief: (code: string) => void;
+  openSearch: () => void;
   loadAllData: (forceAll?: boolean) => Promise<void>;
   updateMonitorResults: () => void;
   loadSecurityAdvisories?: () => Promise<void>;
@@ -385,6 +386,7 @@ export class PanelLayoutManager implements AppModule {
     this.proActivationController = new ProActivationController(ctx, {
       reloadPending: returnedFromCheckout,
       openAiAnalyst: () => this.revealAnalystPanel(),
+      openSearch: callbacks.openSearch,
     });
     if (returnedFromCheckout) {
       // Funnel (#4931): the purchase-complete signal on the client side.

--- a/src/app/pro-activation-controller.ts
+++ b/src/app/pro-activation-controller.ts
@@ -142,6 +142,8 @@ export interface ProActivationControllerOptions {
   reloadPending: boolean;
   /** Panel-owned surface opener that cannot be implemented outside the layout. */
   openAiAnalyst: () => void;
+  /** App-owned global command-search opener. */
+  openSearch?: () => void;
 }
 
 type ChipDecision = 'show' | 'wait' | 'hide';
@@ -615,6 +617,7 @@ export class ProActivationController implements AppModule {
       openWidgetBuilder: () =>
         ctx.container.dispatchEvent(new CustomEvent('wm:open-widget-creator', { detail: {} })),
       openAiAnalyst: this.options.openAiAnalyst,
+      openSearch: this.options.openSearch,
       onEvent: (event, stepId, exit) =>
         trackProActivation(event, {
           planKey: getEntitlementState()?.planKey ?? null,

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -666,6 +666,18 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
 
   const onKeydown = (e: KeyboardEvent): void => {
     if (!overlay) return;
+    // The power step teaches Command Search inside a full-screen modal. Handle
+    // the shortcut at capture time so it activates the visible pointer instead
+    // of opening the search overlay underneath this higher-z-index interstitial.
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'k') {
+      const searchPointer = modal.querySelector<HTMLButtonElement>('[data-pointer="search"]');
+      if (searchPointer) {
+        e.preventDefault();
+        e.stopPropagation();
+        searchPointer.click();
+        return;
+      }
+    }
     if (e.key === 'Escape') {
       e.stopPropagation();
       handleDismiss();
@@ -820,6 +832,8 @@ export interface ProActivationFlowOptions {
   openAiAnalyst?: () => void;
   /** Open the custom-widget builder. Boot hook: dispatch `wm:open-widget-creator` on `ctx.container`. */
   openWidgetBuilder?: () => void;
+  /** Open the global command search. Boot hook: `App.openSearch()`. */
+  openSearch?: () => void;
   /** Open notification settings for multi-step channels (R8). Boot hook: `ctx.unifiedSettings.open('notifications')`. */
   openChannelSettings?: () => void;
   /**
@@ -1150,24 +1164,56 @@ function buildBriefExtra(syncBrief: string | null, hourRef: DigestHourRef): ProA
   };
 }
 
-/** Power-step extras: deep-link pointers into the Pro surfaces (R8-aware). */
+function commandSearchShortcut(): { keys: readonly string[]; label: string } {
+  const isApplePlatform =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  return isApplePlatform
+    ? { keys: ['⌘', 'K'], label: '⌘K' }
+    : { keys: ['Ctrl', 'K'], label: 'Ctrl+K' };
+}
+
+/** Power-step extras: command search + deep-link pointers into the Pro surfaces (R8-aware). */
 function buildPowerExtra(options: ProActivationFlowOptions): ProActivationStepExtra {
-  const pointers: Array<{ id: string; label: string; open: () => void }> = [];
-  const add = (id: string, key: string, defaultValue: string, open?: () => void): void => {
+  const pointers: Array<{
+    id: string;
+    label: string;
+    open: () => void;
+    shortcut?: { keys: readonly string[]; label: string };
+  }> = [];
+  const add = (
+    id: string,
+    key: string,
+    defaultValue: string,
+    open?: () => void,
+    shortcut?: { keys: readonly string[]; label: string },
+  ): void => {
     if (typeof open !== 'function') return;
-    pointers.push({ id, label: t(key, { defaultValue }), open });
+    pointers.push({ id, label: t(key, { defaultValue }), open, shortcut });
   };
+  add(
+    'search',
+    'components.proActivation.steps.power.pointers.search',
+    'Search the entire dashboard',
+    options.openSearch,
+    commandSearchShortcut(),
+  );
   add('widgets', 'components.proActivation.steps.power.pointers.widgets', 'Build a custom widget', options.openWidgetBuilder);
   add('analyst', 'components.proActivation.steps.power.pointers.analyst', 'Ask the AI analyst', options.openAiAnalyst);
   add('mcpClients', 'components.proActivation.steps.power.pointers.mcpClients', 'Set up MCP', options.openMcpClients);
 
   const pointerButtons = pointers
-    .map(
-      (p) =>
-        `<button type="button" class="pro-activation-pointer" data-pointer="${p.id}">${escapeHtml(
-          p.label,
-        )}<span class="pro-activation-pointer-arrow" aria-hidden="true">→</span></button>`,
-    )
+    .map((p) => {
+      const trailing = p.shortcut
+        ? `<span class="pro-activation-pointer-shortcut" aria-hidden="true">${p.shortcut.keys
+            .map((key) => `<kbd>${escapeHtml(key)}</kbd>`)
+            .join('')}</span>`
+        : '<span class="pro-activation-pointer-arrow" aria-hidden="true">→</span>';
+      const ariaLabel = p.shortcut ? `${p.label} (${p.shortcut.label})` : p.label;
+      return `<button type="button" class="pro-activation-pointer" data-pointer="${p.id}" aria-label="${escapeHtml(
+        ariaLabel,
+      )}"><span class="pro-activation-pointer-label">${escapeHtml(p.label)}</span>${trailing}</button>`;
+    })
     .join('');
 
   // R8: multi-step channels are never embedded — link out to settings instead.

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -2291,6 +2291,7 @@
           "summaryVerified": "غير مقفلة وجاهزة عندما تكون جاهزًا.",
           "channelsNote": "تفضّل Telegram أو Slack أو Discord أو webhook؟",
           "pointers": {
+            "search": "البحث في لوحة المعلومات بالكامل",
             "widgets": "إنشاء أداة مخصصة",
             "analyst": "اسأل المحلل الذكي",
             "mcpClients": "إعداد MCP",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "Отключен и готов, когато сте готови и вие.",
           "channelsNote": "Предпочитате Telegram, Slack, Discord или уебхук?",
           "pointers": {
+            "search": "Търси в цялото табло",
             "widgets": "Създай персонализиран уиджет",
             "analyst": "Попитай AI анализатора",
             "mcpClients": "Настрой MCP",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -2273,6 +2273,7 @@
           "summaryVerified": "Odemčeno a připraveno, až budete chtít.",
           "channelsNote": "Preferujete Telegram, Slack, Discord nebo webhook?",
           "pointers": {
+            "search": "Prohledat celý panel",
             "widgets": "Vytvořit vlastní widget",
             "analyst": "Zeptat se AI analytika",
             "mcpClients": "Nastavit MCP",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "Freigeschaltet und einsatzbereit, wenn Sie es sind.",
           "channelsNote": "Lieber Telegram, Slack, Discord oder ein Webhook?",
           "pointers": {
+            "search": "Das gesamte Dashboard durchsuchen",
             "widgets": "Ein individuelles Widget erstellen",
             "analyst": "Den KI-Analysten fragen",
             "mcpClients": "MCP einrichten",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "Ξεκλειδωμένο και έτοιμο όποτε είστε κι εσείς.",
           "channelsNote": "Προτιμάτε Telegram, Slack, Discord ή ένα webhook;",
           "pointers": {
+            "search": "Αναζήτηση σε ολόκληρο τον πίνακα",
             "widgets": "Δημιουργία προσαρμοσμένου widget",
             "analyst": "Ρωτήστε τον αναλυτή AI",
             "mcpClients": "Ρύθμιση MCP",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2343,6 +2343,7 @@
           "summaryVerified": "Unlocked and ready when you are.",
           "channelsNote": "Prefer Telegram, Slack, Discord, or a webhook?",
           "pointers": {
+            "search": "Search the entire dashboard",
             "widgets": "Build a custom widget",
             "analyst": "Ask the AI analyst",
             "mcpClients": "Set up MCP",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2264,6 +2264,7 @@
           "summaryVerified": "Desbloqueado y listo cuando tú lo estés.",
           "channelsNote": "¿Prefieres Telegram, Slack, Discord o un webhook?",
           "pointers": {
+            "search": "Buscar en todo el panel",
             "widgets": "Crear un widget personalizado",
             "analyst": "Preguntar al analista de IA",
             "mcpClients": "Configurar MCP",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -2327,6 +2327,7 @@
           "summaryVerified": "Unlocked and ready when you are.",
           "channelsNote": "Prefer Telegram, Slack, Discord, or a webhook?",
           "pointers": {
+            "search": "جستجو در کل داشبورد",
             "widgets": "Build a custom widget",
             "analyst": "Ask the AI analyst",
             "mcpClients": "Set up MCP",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2264,6 +2264,7 @@
           "summaryVerified": "Débloquée et prête quand vous le serez.",
           "channelsNote": "Vous préférez Telegram, Slack, Discord ou un webhook ?",
           "pointers": {
+            "search": "Rechercher dans tout le tableau de bord",
             "widgets": "Créer un widget personnalisé",
             "analyst": "Interroger l'analyste IA",
             "mcpClients": "Configurer MCP",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -2324,6 +2324,7 @@
           "summaryVerified": "अनलॉक और तैयार, जब आप हों।",
           "channelsNote": "Telegram, Slack, Discord या वेबहुक पसंद करेंगे?",
           "pointers": {
+            "search": "पूरे डैशबोर्ड में खोजें",
             "widgets": "एक कस्टम विजेट बनाएं",
             "analyst": "AI विश्लेषक से पूछें",
             "mcpClients": "MCP सेट करें",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -2501,6 +2501,7 @@
           "summaryVerified": "Otključano i spremno kad i vi budete.",
           "channelsNote": "Preferirate Telegram, Slack, Discord ili webhook?",
           "pointers": {
+            "search": "Pretraži cijelu nadzornu ploču",
             "widgets": "Izradi prilagođeni widget",
             "analyst": "Pitaj AI analitičara",
             "mcpClients": "Postavi MCP",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -2324,6 +2324,7 @@
           "summaryVerified": "Feloldva és készen áll, amikor Ön is az.",
           "channelsNote": "Inkább Telegramot, Slacket, Discordot vagy egy webhookot szeretne?",
           "pointers": {
+            "search": "Keresés a teljes irányítópulton",
             "widgets": "Egyéni widget létrehozása",
             "analyst": "Kérdezze meg az AI elemzőt",
             "mcpClients": "MCP beállítása",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2264,6 +2264,7 @@
           "summaryVerified": "Sbloccato e pronto quando lo sei tu.",
           "channelsNote": "Preferisci Telegram, Slack, Discord o un webhook?",
           "pointers": {
+            "search": "Cerca nell'intera dashboard",
             "widgets": "Crea un widget personalizzato",
             "analyst": "Chiedi all'analista IA",
             "mcpClients": "Configura MCP",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "解放済み — いつでも準備完了です。",
           "channelsNote": "Telegram、Slack、Discord、またはWebhookがお好みですか？",
           "pointers": {
+            "search": "ダッシュボード全体を検索",
             "widgets": "カスタムウィジェットを作成",
             "analyst": "AIアナリストに質問",
             "mcpClients": "MCPをセットアップ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "잠금 해제됨 — 준비되면 언제든지 사용하세요.",
           "channelsNote": "Telegram, Slack, Discord 또는 웹훅을 선호하시나요?",
           "pointers": {
+            "search": "대시보드 전체 검색",
             "widgets": "맞춤 위젯 만들기",
             "analyst": "AI 분석가에게 질문하기",
             "mcpClients": "MCP 설정하기",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1995,6 +1995,7 @@
           "summaryVerified": "Ontgrendeld en klaar wanneer jij dat bent.",
           "channelsNote": "Heb je liever Telegram, Slack, Discord of een webhook?",
           "pointers": {
+            "search": "Het hele dashboard doorzoeken",
             "widgets": "Een aangepaste widget maken",
             "analyst": "Stel de AI-analist een vraag",
             "mcpClients": "MCP instellen",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2273,6 +2273,7 @@
           "summaryVerified": "Odblokowane i gotowe, gdy Ty będziesz gotowy.",
           "channelsNote": "Wolisz Telegram, Slack, Discord czy webhook?",
           "pointers": {
+            "search": "Przeszukaj cały pulpit",
             "widgets": "Utwórz niestandardowy widżet",
             "analyst": "Zapytaj analityka AI",
             "mcpClients": "Skonfiguruj MCP",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -2002,6 +2002,7 @@
           "summaryVerified": "Desbloqueado e pronto quando você estiver.",
           "channelsNote": "Prefere Telegram, Slack, Discord ou um webhook?",
           "pointers": {
+            "search": "Pesquisar em todo o painel",
             "widgets": "Criar um widget personalizado",
             "analyst": "Perguntar ao analista de IA",
             "mcpClients": "Configurar MCP",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -2264,6 +2264,7 @@
           "summaryVerified": "Deblocată și pregătită oricând ești și tu.",
           "channelsNote": "Preferi Telegram, Slack, Discord sau un webhook?",
           "pointers": {
+            "search": "Caută în întregul tablou de bord",
             "widgets": "Creează un widget personalizat",
             "analyst": "Întreabă analistul AI",
             "mcpClients": "Configurează MCP",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -2273,6 +2273,7 @@
           "summaryVerified": "Разблокировано и готово, когда будете готовы вы.",
           "channelsNote": "Предпочитаете Telegram, Slack, Discord или вебхук?",
           "pointers": {
+            "search": "Искать по всей панели",
             "widgets": "Создать пользовательский виджет",
             "analyst": "Спросить AI-аналитика",
             "mcpClients": "Настроить MCP",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1995,6 +1995,7 @@
           "summaryVerified": "Upplåst och redo när du är det.",
           "channelsNote": "Föredrar du Telegram, Slack, Discord eller en webhook?",
           "pointers": {
+            "search": "Sök i hela instrumentpanelen",
             "widgets": "Skapa en anpassad widget",
             "analyst": "Fråga AI-analytikern",
             "mcpClients": "Konfigurera MCP",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "ปลดล็อกแล้ว พร้อมใช้งานเมื่อคุณพร้อม",
           "channelsNote": "ต้องการ Telegram, Slack, Discord หรือเว็บฮุกมากกว่ากัน?",
           "pointers": {
+            "search": "ค้นหาทั่วทั้งแดชบอร์ด",
             "widgets": "สร้างวิดเจ็ตที่กำหนดเอง",
             "analyst": "ถามนักวิเคราะห์ AI",
             "mcpClients": "ตั้งค่า MCP",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "Kilidi açıldı, siz hazır olduğunuzda kullanıma hazır.",
           "channelsNote": "Telegram, Slack, Discord veya bir webhook mu tercih edersiniz?",
           "pointers": {
+            "search": "Tüm panoda ara",
             "widgets": "Özel bir widget oluşturun",
             "analyst": "Yapay zeka analistine sorun",
             "mcpClients": "MCP'yi kurun",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "Đã mở khóa và sẵn sàng khi bạn sẵn sàng.",
           "channelsNote": "Bạn thích Telegram, Slack, Discord hay webhook hơn?",
           "pointers": {
+            "search": "Tìm kiếm toàn bộ bảng điều khiển",
             "widgets": "Tạo widget tùy chỉnh",
             "analyst": "Hỏi nhà phân tích AI",
             "mcpClients": "Thiết lập MCP",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -2255,6 +2255,7 @@
           "summaryVerified": "已解锁，随时可用。",
           "channelsNote": "更喜欢 Telegram、Slack、Discord 还是 Webhook？",
           "pointers": {
+            "search": "搜索整个仪表板",
             "widgets": "创建自定义小组件",
             "analyst": "咨询 AI 分析师",
             "mcpClients": "设置 MCP",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8191,6 +8191,36 @@ a.prediction-link:hover {
   background: color-mix(in srgb, var(--green) 8%, transparent);
 }
 
+.pro-activation-pointer:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
+.pro-activation-pointer-label {
+  min-width: 0;
+}
+
+.pro-activation-pointer-shortcut {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+.pro-activation-pointer-shortcut kbd {
+  min-width: 26px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-bottom-color: var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--green);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  text-align: center;
+}
+
 .pro-activation-pointer-arrow {
   color: var(--text-dim);
 }

--- a/tests/pro-activation-controller.test.mts
+++ b/tests/pro-activation-controller.test.mts
@@ -545,11 +545,13 @@ describe('ProActivationController power-step surface wiring', () => {
   ): Promise<{
     options: Record<string, unknown>;
     settingsOpens: string[];
+    searchOpens: string[];
   }> {
     installBrowserState();
     installEligibleMarkerlessAccount(userId, features);
     const { ProActivationController } = await loadController();
     const settingsOpens: string[] = [];
+    const searchOpens: string[] = [];
     const ctx = {
       isDestroyed: false,
       isDesktopApp: false,
@@ -559,6 +561,7 @@ describe('ProActivationController power-step surface wiring', () => {
     const controller = new ProActivationController(ctx as never, {
       reloadPending: false,
       openAiAnalyst() {},
+      openSearch: () => searchOpens.push('search'),
     });
     try {
       controller.init();
@@ -569,12 +572,23 @@ describe('ProActivationController power-step surface wiring', () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       }
       assert.equal(captured.length, 1, 'the eligible Pro account must mount the flow exactly once');
-      return { options: captured[0] as Record<string, unknown>, settingsOpens };
+      return { options: captured[0] as Record<string, unknown>, settingsOpens, searchOpens };
     } finally {
       ctx.isDestroyed = true;
       controller.destroy();
     }
   }
+
+  it('wires the power step to the app-owned command search', async () => {
+    const { options, searchOpens } = await captureFlowOptions('user-search-pointer', {
+      apiAccess: false,
+      mcpAccess: true,
+    });
+
+    assert.equal(typeof options.openSearch, 'function');
+    (options.openSearch as () => void)();
+    assert.deepEqual(searchOpens, ['search']);
+  });
 
   it('deep-links the power step to MCP Clients — the capability Pro actually has (#5607)', async () => {
     const { options, settingsOpens } = await captureFlowOptions('user-mcp-pointer', {


### PR DESCRIPTION
## Summary

Pro subscribers now discover Command Search in the “Your Pro toolkit” onboarding step and can launch it immediately with the displayed platform shortcut.

The shortcut is handled while the full-screen onboarding interstitial is open, so search opens visibly after onboarding closes instead of rendering behind the modal. The action is also clickable, emits the existing search-open analytics event with a Pro-onboarding source, and is translated across every supported locale.

## Validation

- `npm run typecheck`
- `node --import tsx --test tests/pro-activation-controller.test.mts tests/locale-completeness.test.mjs` — 37 passed
- `node --test tests/search-open-state-machine.test.mjs` — 8 passed
- `npx playwright test e2e/pro-activation.spec.ts --grep "power-toolkit command search"` — 1 passed
- Full pre-push gate — typecheck, architecture/safe-HTML/premium-fetch checks, changed tests, 235 edge-function tests, version sync
- Styled browser review — command search appears first in the Pro toolkit step with legible platform-specific keycaps