### PR TITLE
fix(bootstrap): stop non-on-demand keys triggering wm-session recovery

### DIFF
--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -8,6 +8,7 @@ import {
 } from '@/bootstrap/bootstrap-r2-rum';
 import { reportBootstrapR2Rum } from '@/bootstrap/debugbear-rum';
 import { getWebVitalsFormFactor } from '@/bootstrap/web-vitals-utils';
+import { bootstrapTierKeyNames } from '../../shared/bootstrap-tier-keys.js';
 
 const hydrationCache = new Map<string, unknown>();
 const BOOTSTRAP_CACHE_PREFIX = 'bootstrap:tier:';
@@ -74,6 +75,14 @@ export function getHydratedData(key: string): unknown | undefined {
 // for the same key in the same tick, and we want one request, not two.
 const onDemandInflight = new Map<string, Promise<unknown | undefined>>();
 
+// The set of keys `/api/bootstrap?keys=<name>&public=1` will serve without
+// credentials. Derived from the SAME registry call the server uses to build its
+// allowlist (ON_DEMAND_KEYS, api/bootstrap.js) and the wm-session interceptor
+// uses to decide which credential-less reads may bypass session recovery
+// (PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS, wm-session.ts:63) — all three read
+// `bootstrapTierKeyNames('on-demand')`, so they cannot drift apart.
+const PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS = new Set(bootstrapTierKeyNames('on-demand'));
+
 /**
  * Hydration for keys that ride in NEITHER bootstrap tier (#5300).
  *
@@ -91,6 +100,21 @@ const onDemandInflight = new Map<string, Promise<unknown | undefined>>();
 export async function ensureHydrated(key: string): Promise<unknown | undefined> {
   const hydrated = getHydratedData(key);
   if (hydrated !== undefined) return hydrated;
+
+  // The public URL below only serves keys in the on-demand tier
+  // (isPublicOnDemandBootstrapRequest, api/bootstrap.js); anything else falls
+  // through to validateApiKey, which sees no credential — this request omits
+  // them — and answers 401. Issuing it anyway is not merely wasted: the
+  // wm-session interceptor waves through credential-less bootstrap reads only
+  // for on-demand keys (PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS, wm-session.ts:63), so
+  // a non-on-demand key enters session recovery, which mints a fresh cookie and
+  // replays a request that still omits credentials, draws the same 401, and
+  // reports `wm_session_route_401` — blaming the anonymous session for a
+  // request that never presented one. That was 100% of WORLDMONITOR-XP
+  // (~125/hr, all route `/api/bootstrap`), via the `slow`-tier key
+  // `crossStraitActivity`. Callers already treat undefined as "use your own
+  // fallback", which is exactly what the 401 produced.
+  if (!PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS.has(key)) return undefined;
 
   const existing = onDemandInflight.get(key);
   if (existing) return existing;

--- a/tests/bootstrap-ondemand-public-key-guard.test.mts
+++ b/tests/bootstrap-ondemand-public-key-guard.test.mts
@@ -1,0 +1,91 @@
+// `ensureHydrated()` fetches a key through its own CDN-shielded public URL,
+// `/api/bootstrap?keys=<name>&public=1`, sent with `credentials: 'omit'`.
+//
+// The server serves that URL publicly for ONE key drawn from the on-demand
+// tier (isPublicOnDemandBootstrapRequest, api/bootstrap.js). For any other key
+// it falls through to validateApiKey, sees no credential — the request omitted
+// them — and answers 401 {"error":"API key required"}. Verified against
+// production 2026-07-27:
+//
+//   ?keys=crossStraitActivity&public=1   no cookie -> 401
+//   ?keys=crossStraitActivity&public=1   w/ cookie -> 200
+//   ?keys=chinaDecisionSignals&public=1  no cookie -> 200   (on-demand)
+//
+// So a non-on-demand key can never be served by this URL, and the request is
+// guaranteed-dead work. Worse, it is not inert: the wm-session interceptor only
+// waves through credential-less bootstrap reads whose key IS on-demand
+// (PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS, wm-session.ts), so this one enters session
+// recovery — which mints a fresh cookie and replays a request that omits
+// credentials, gets the same 401, and reports `wm_session_route_401`. That is
+// WORLDMONITOR-XP: 100% of its events were route `/api/bootstrap`, ~125/hr,
+// each one blaming the anonymous session for a request that never presented it.
+//
+// `crossStraitActivity` is the live instance — a `slow`-tier key that
+// MilitaryCorrelationPanel re-reads through ensureHydrated() after
+// getHydratedData() has drained it.
+
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+
+import { ensureHydrated } from '../src/services/bootstrap.ts';
+import { bootstrapTierKeyNames } from '../shared/bootstrap-tier-keys.js';
+
+const ON_DEMAND = new Set(bootstrapTierKeyNames('on-demand'));
+
+const originalFetch = globalThis.fetch;
+let requested: string[] = [];
+
+beforeEach(() => {
+  requested = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    requested.push(url);
+    // Mirror production: the public URL only serves on-demand keys.
+    const key = new URL(url, 'https://api.worldmonitor.app').searchParams.get('keys') ?? '';
+    if (!ON_DEMAND.has(key)) {
+      return new Response(JSON.stringify({ error: 'API key required' }), { status: 401 });
+    }
+    return new Response(JSON.stringify({ data: { [key]: { ok: true } } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('ensureHydrated public on-demand key guard (WORLDMONITOR-XP)', () => {
+  it('does not issue a guaranteed-401 public read for a key outside the on-demand tier', async () => {
+    assert.equal(
+      ON_DEMAND.has('crossStraitActivity'),
+      false,
+      'precondition: crossStraitActivity is a slow-tier key, so the public URL cannot serve it',
+    );
+
+    const value = await ensureHydrated('crossStraitActivity');
+
+    assert.equal(value, undefined, 'callers already treat a miss as "fall back to your own path"');
+    assert.deepEqual(
+      requested,
+      [],
+      'no request may be issued: the public URL provably 401s for this key, and the '
+      + 'wm-session interceptor turns that 401 into a mint + replay + wm_session_route_401 report',
+    );
+  });
+
+  it('still fetches keys the public on-demand URL genuinely serves', async () => {
+    // Guard rail: the fix keys off the registry, so every real on-demand key
+    // must keep its CDN-cached path. A fix that simply stopped fetching would
+    // pass the test above and silently disable #5300 hydration everywhere.
+    const onDemandKey = 'chinaDecisionSignals';
+    assert.equal(ON_DEMAND.has(onDemandKey), true, 'precondition: this key IS on-demand');
+
+    const value = await ensureHydrated(onDemandKey);
+
+    assert.deepEqual(value, { ok: true }, 'the on-demand payload still hydrates');
+    assert.equal(requested.length, 1, 'exactly one CDN read');
+    assert.match(requested[0] ?? '', /\/api\/bootstrap\?keys=chinaDecisionSignals&public=1$/);
+  });
+});


### PR DESCRIPTION
`ensureHydrated()` sent every key through `/api/bootstrap?keys=<k>&public=1` with `credentials: 'omit'`, but that URL serves only on-demand-tier keys without credentials — anything else falls through to `validateApiKey`, sees no credential, and 401s. The request was therefore guaranteed dead, and it was not inert: the wm-session interceptor waves credential-less bootstrap reads past session recovery only for on-demand keys, so any other key entered recovery, minted a fresh cookie, replayed a request that still omitted credentials, drew the same 401, and reported `wm_session_route_401` — telemetry blaming the anonymous session for a request that never presented one.

That was all of Sentry WORLDMONITOR-XP: ~125 events/hour, route `/api/bootstrap`, a single distinct route value, roughly one event per user. The live instance is `crossStraitActivity`, a `slow`-tier key that `MilitaryCorrelationPanel` re-reads through `ensureHydrated()` once `getHydratedData()` has drained it.

The public read is now gated on the same `bootstrapTierKeyNames('on-demand')` registry that the server's allowlist and the interceptor already derive from, so the three cannot drift. Callers already treated `undefined` as "use your own fallback" — exactly what the 401 produced — so all that disappears is the dead round trip, the burned mint, and the false telemetry.

This does not give `crossStraitActivity` a CDN-cached path; it never had one, and restoring it is a server-side call (moving its tier would drop it from the `?tier=slow` payload), left as follow-up.

Related: #5674

Validated against production on 2026-07-27: `?keys=crossStraitActivity&public=1` returns 401 without a cookie and 200 with one, while the genuinely on-demand `?keys=chinaDecisionSignals&public=1` returns 200 either way. The new test in `tests/bootstrap-ondemand-public-key-guard.test.mts` fails on the pre-fix code (it asserts no request is issued) and passes after; a companion case pins that real on-demand keys still fetch, so a fix that simply stopped fetching would not pass. `npm run typecheck`, biome, and the bootstrap / wm-session / cross-strait / china-decision suites all pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
