### PR TITLE
feat(i18n): auto-translate news headlines into the UI language

### DIFF
--- a/server/worldmonitor/news/v1/_shared.ts
+++ b/server/worldmonitor/news/v1/_shared.ts
@@ -22,6 +22,8 @@ export {
 import { hashString } from '../../../_shared/hash';
 export { hashString };
 
+import { buildNumberedList } from '../../../../src/utils/numbered-list';
+
 // ========================================================================
 // Headline deduplication (used by SummarizeArticle)
 // ========================================================================
@@ -135,13 +137,28 @@ Rules:
       : `Each headline is a separate story. What's the key pattern or risk?\n${headlineText}${intelSection}`;
   } else if (opts.mode === 'translate') {
     const targetLang = opts.variant;
-    systemPrompt = `You are a professional news translator. Translate the following news headlines/summaries into ${targetLang}.
+    if (uniqueHeadlines.length > 1) {
+      // Batch shape: numbered in, numbered out. The handler parses the
+      // response back into per-headline cache entries (parseNumberedList),
+      // so the output format rules here are load-bearing.
+      systemPrompt = `You are a professional news translator. Translate the following numbered news headlines/summaries into ${targetLang}.
+Rules:
+- Output ONLY a numbered list of translations matching the input numbers, one per line.
+- Keep each translation on a single line.
+- Maintain the original tone and journalistic style.
+- Do NOT add any conversational filler (e.g., "Here is the translation").
+- If a headline is already in ${targetLang}, return it as is.`;
+      userPrompt = `Translate to ${targetLang}:\n${buildNumberedList(uniqueHeadlines)}`;
+    } else {
+      // Single-headline prompt kept byte-identical to the legacy shape.
+      systemPrompt = `You are a professional news translator. Translate the following news headlines/summaries into ${targetLang}.
 Rules:
 - Maintain the original tone and journalistic style.
 - Do NOT add any conversational filler (e.g., "Here is the translation").
 - Output ONLY the translated text.
 - If the text is already in ${targetLang}, return it as is.`;
-    userPrompt = `Translate to ${targetLang}:\n${headlines[0]}`;
+      userPrompt = `Translate to ${targetLang}:\n${headlines[0]}`;
+    }
   } else {
     systemPrompt = isTechVariant
       ? `${dateContext}\n\nPick the most important tech headline and summarize it in 2 concise sentences (under 60 words). Each headline is a separate story - NEVER merge facts from different headlines. Focus on startups, AI, funding, products. Ignore politics unless directly about tech regulation.${langInstruction}`

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -4,13 +4,14 @@ import type {
   SummarizeArticleResponse,
 } from '../../../../src/generated/server/worldmonitor/news/v1/service_server';
 
-import { cachedFetchJsonWithMeta } from '../../../_shared/redis';
+import { cachedFetchJsonWithMeta, getCachedJsonBatch, setCachedJson } from '../../../_shared/redis';
 import {
   CACHE_TTL_SECONDS,
   buildArticlePrompts,
   getProviderCredentials,
   getCacheKey,
 } from './_shared';
+import { buildNumberedList, parseNumberedList } from '../../../../src/utils/numbered-list';
 import { CHROME_UA } from '../../../_shared/constants';
 import { isProviderAvailable } from '../../../_shared/llm-health';
 import { sanitizeHeadlinesLight, sanitizeHeadlines, sanitizeForPrompt } from '../../../_shared/llm-sanitize.js';
@@ -23,7 +24,7 @@ import { buildLlmCallEvent, deliverUsageEvents } from '../../../_shared/usage';
 async function emitSummarizeLlmEvent(p: {
   provider: string; model: string; ok: boolean; durationMs: number;
   promptChars: number; usage?: { total_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
-  reason?: string;
+  reason?: string; maxTokens?: number;
 }): Promise<void> {
   try {
     await deliverUsageEvents([buildLlmCallEvent({
@@ -36,7 +37,7 @@ async function emitSummarizeLlmEvent(p: {
       tokensPrompt: p.usage?.prompt_tokens ?? 0,
       tokensCompletion: p.usage?.completion_tokens ?? 0,
       promptChars: p.promptChars,
-      maxTokens: 100,
+      maxTokens: p.maxTokens ?? 100,
       fallbackIndex: 0,
       reason: p.reason,
     })]);
@@ -150,6 +151,22 @@ export async function summarizeArticle(
       status: 'SUMMARIZE_STATUS_ERROR',
       statusDetail: 'Headlines array required',
     };
+  }
+
+  if (mode === 'translate') {
+    // Positional (per-element) light sanitize: the shared `headlines` array
+    // above is sanitized array-level, which DROPS empty/stripped entries and
+    // would shift the numbered-response alignment against the request. Here
+    // an entry that sanitizes away must stay in place as '' (its response
+    // line stays blank and the client keeps the original text).
+    const positionalHeadlines = (req.headlines || [])
+      .slice(0, MAX_HEADLINES)
+      .map(h => typeof h === 'string' ? h.slice(0, MAX_HEADLINE_LEN) : '')
+      .map(h => sanitizeHeadlinesLight([h])[0] ?? '');
+    return translateHeadlines({
+      provider, model, apiUrl, providerHeaders, extraBody,
+      headlines: positionalHeadlines, variant, lang,
+    });
   }
 
   try {
@@ -296,4 +313,199 @@ export async function summarizeArticle(
       statusDetail: `${error.name}: ${error.message}`,
     };
   }
+}
+
+// ======================================================================
+// Translate mode: per-headline cache + one batched LLM call for misses
+// ======================================================================
+//
+// Unlike brief/analysis (one summary per headline SET), a translation is a
+// per-headline artifact — so caching whole batches under the sorted-top-5
+// batch key would both collide distinct batches and replay order-sensitive
+// numbered output against differently-ordered requests. Instead each unique
+// headline gets its own cache entry, keyed exactly like the legacy
+// single-headline translate request (getCacheKey([h], 'translate', '',
+// targetLang, lang)) so entries minted by the manual per-item translate
+// button and by batch requests are interchangeable. Only cache misses reach
+// the LLM, as one numbered-list prompt.
+//
+// Response contract: a single-headline request returns the bare translation
+// (legacy shape); a multi-headline request returns a numbered list aligned
+// 1:1 with the REQUEST order (duplicates repeated, untranslated slots left
+// empty so the client keeps the original text).
+
+interface TranslateDeps {
+  provider: string;
+  model: string;
+  apiUrl: string;
+  providerHeaders: Record<string, string>;
+  extraBody?: Record<string, unknown>;
+  /** Light-sanitized, length-bounded headlines (cache-key identity). */
+  headlines: string[];
+  /** Legacy wire shape: `variant` carries the target language. */
+  variant: string;
+  lang: string;
+}
+
+async function translateHeadlines(deps: TranslateDeps): Promise<SummarizeArticleResponse> {
+  const { provider, model, apiUrl, providerHeaders, extraBody, headlines, variant, lang } = deps;
+
+  const errorResponse = (message: string): SummarizeArticleResponse => ({
+    summary: '',
+    model: '',
+    provider,
+    tokens: 0,
+    fallback: true,
+    error: message,
+    errorType: '',
+    status: 'SUMMARIZE_STATUS_ERROR',
+    statusDetail: message,
+  });
+
+  // Dedup on the light-sanitized headline — the same identity the per-item
+  // cache key hashes, so duplicate inputs share one lookup/translation.
+  const uniques: string[] = [];
+  const uniqueIndexByHeadline = new Map<string, number>();
+  const inputToUnique: number[] = headlines.map((h) => {
+    const trimmed = h.trim();
+    if (!trimmed) return -1;
+    let idx = uniqueIndexByHeadline.get(trimmed);
+    if (idx === undefined) {
+      idx = uniques.length;
+      uniques.push(trimmed);
+      uniqueIndexByHeadline.set(trimmed, idx);
+    }
+    return idx;
+  });
+
+  if (uniques.length === 0) return errorResponse('Empty response');
+
+  const keys = uniques.map((h) => getCacheKey([h], 'translate', '', variant, lang));
+  const translations: Array<string | null> = new Array(uniques.length).fill(null);
+  try {
+    const cached = await getCachedJsonBatch(keys);
+    keys.forEach((key, i) => {
+      const entry = cached.get(key) as { summary?: unknown } | null | undefined;
+      const summary = entry && typeof entry.summary === 'string' ? entry.summary.trim() : '';
+      if (summary) translations[i] = summary;
+    });
+  } catch {
+    // Cache degradation → treat everything as a miss.
+  }
+
+  const missIndexes = translations
+    .map((t, i) => (t === null ? i : -1))
+    .filter((i) => i >= 0);
+  let llmModel = '';
+  let llmTokens = 0;
+
+  if (missIndexes.length > 0 && (await isProviderAvailable(apiUrl))) {
+    // Full injection sanitization at prompt-build time only, mirroring the
+    // summary path: cache keys stay light-sanitized, prompts get the strict
+    // pass. Entries the strict pass empties out are skipped (stay null).
+    const llmItems: Array<{ uniqueIndex: number; text: string }> = [];
+    for (const uniqueIndex of missIndexes) {
+      const text = (sanitizeHeadlines([uniques[uniqueIndex] ?? ''])[0] ?? '').trim();
+      if (text.length > 0) llmItems.push({ uniqueIndex, text });
+    }
+
+    if (llmItems.length > 0) {
+      const texts = llmItems.map((item) => item.text);
+      const { systemPrompt, userPrompt } = buildArticlePrompts(texts, texts, {
+        mode: 'translate',
+        geoContext: '',
+        variant,
+        lang,
+        bodies: [],
+      });
+      // 150 output tokens per headline: CJK/Cyrillic translations of a
+      // 500-char headline routinely exceed the summary path's flat 100.
+      const maxTokens = Math.min(1500, 150 * texts.length);
+      const llmStartMs = Date.now();
+      const llmPromptChars = systemPrompt.length + userPrompt.length;
+
+      try {
+        const response = await fetch(apiUrl, {
+          method: 'POST',
+          headers: { ...providerHeaders, 'User-Agent': CHROME_UA },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            temperature: 0.3,
+            max_tokens: maxTokens,
+            top_p: 0.9,
+            ...extraBody,
+          }),
+          signal: AbortSignal.timeout(25_000),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          console.error(`[SummarizeArticle:${provider}] translate API error:`, response.status, errorText);
+          await emitSummarizeLlmEvent({ provider, model, ok: false, durationMs: Date.now() - llmStartMs, promptChars: llmPromptChars, maxTokens, reason: `http_${response.status}` });
+          throw new Error(response.status === 429 ? 'Rate limited' : `${provider} API error`);
+        }
+
+        const data = await response.json() as any;
+        const usage = data.usage as { total_tokens?: number; prompt_tokens?: number; completion_tokens?: number } | undefined;
+        const message = data.choices?.[0]?.message;
+        const rawText = typeof message?.content === 'string' ? message.content.trim() : '';
+        const rawContent = stripThinkingTags(rawText);
+        const parsed = parseNumberedList(rawContent, texts.length);
+
+        for (const [slot, item] of llmItems.entries()) {
+          const translated = parsed[slot]?.trim();
+          if (!translated) continue;
+          translations[item.uniqueIndex] = translated;
+          const key = keys[item.uniqueIndex];
+          if (key) {
+            // Fire-and-forget: a failed cache write only costs a re-translate.
+            void setCachedJson(key, { summary: translated, model, tokens: 0 }, CACHE_TTL_SECONDS).catch(() => {});
+          }
+        }
+
+        llmModel = model;
+        llmTokens = usage?.total_tokens ?? 0;
+        const anyTranslated = parsed.some((p) => p && p.trim().length > 0);
+        await emitSummarizeLlmEvent({ provider, model, ok: anyTranslated, durationMs: Date.now() - llmStartMs, promptChars: llmPromptChars, usage, maxTokens, reason: anyTranslated ? '' : 'empty' });
+      } catch (err: unknown) {
+        // Partial results (cache hits) still ship below; a fully-failed
+        // request falls through to the error response so the client's
+        // provider chain can try the next provider.
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error(`[SummarizeArticle:${provider}] translate error:`, error.name, error.message);
+        if (!translations.some((t) => t !== null)) {
+          return {
+            ...errorResponse(error.message),
+            errorType: error.name,
+            statusDetail: `${error.name}: ${error.message}`,
+          };
+        }
+      }
+    }
+  }
+
+  if (!translations.some((t) => t !== null)) return errorResponse('Empty response');
+
+  // Compose in REQUEST order: duplicates repeat their unique translation,
+  // untranslated/empty slots stay blank lines (client keeps the original).
+  const lines = inputToUnique.map((uniqueIndex) =>
+    uniqueIndex >= 0 ? (translations[uniqueIndex] ?? '') : '');
+  const summary = headlines.length === 1 ? (lines[0] ?? '') : buildNumberedList(lines);
+  const allFromCache = missIndexes.length === 0;
+
+  return {
+    summary,
+    model: llmModel || model,
+    provider: allFromCache ? 'cache' : provider,
+    tokens: llmTokens,
+    fallback: false,
+    error: '',
+    errorType: '',
+    status: allFromCache ? 'SUMMARIZE_STATUS_CACHED' : 'SUMMARIZE_STATUS_SUCCESS',
+    statusDetail: '',
+  };
 }

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -10,6 +10,8 @@ import { getSourcePropagandaRisk, getSourceTier, getSourceType } from '@/config/
 import { SITE_VARIANT } from '@/config';
 import { t, getCurrentLanguage } from '@/services/i18n';
 import { track } from '@/services/analytics';
+import { getAiFlowSettings } from '@/services/ai-flow-settings';
+import { getCachedHeadlineTranslation, translateHeadlines } from '@/services/headline-translation';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 
@@ -20,6 +22,10 @@ const VIRTUAL_SCROLL_THRESHOLD = 15;
 
 /** Summary cache TTL in milliseconds (10 minutes) */
 const SUMMARY_CACHE_TTL = 10 * 60 * 1000;
+
+/** Max headlines auto-translated per render (top of the list; keeps a
+ * many-panel dashboard under the summarize endpoint's 30/min budget) */
+const AUTO_TRANSLATE_MAX_HEADLINES = 12;
 
 /** Prepared cluster data for rendering */
 interface PreparedCluster {
@@ -37,6 +43,8 @@ export class NewsPanel extends Panel {
   private onRelatedAssetsFocus?: (assets: RelatedAsset[], originLabel: string) => void;
   private onRelatedAssetsClear?: () => void;
   private isFirstRender = true;
+  /** One auto-translate request cycle at a time (see requestHeadlineTranslations). */
+  private headlineTranslationPending = false;
   /** Cluster ids that arrived while the user was away (#4923) — their NEW
    * ribbons persist until seen instead of expiring with the 2-min window. */
   private newSinceAwayIds = new Set<string>();
@@ -286,6 +294,50 @@ export class NewsPanel extends Panel {
     }
   }
 
+  /** True when headlines should render in the UI language. */
+  private isAutoTranslateActive(): boolean {
+    return getCurrentLanguage() !== 'en' && getAiFlowSettings().autoTranslate;
+  }
+
+  /** Cached translation for display, falling back to the original title. */
+  private displayTitle(title: string): string {
+    if (!this.isAutoTranslateActive()) return title;
+    return getCachedHeadlineTranslation(title, getCurrentLanguage()) ?? title;
+  }
+
+  /**
+   * Fetch translations for the top headlines that aren't cached yet, then
+   * re-render from the raw data so displayTitle() picks them up. The service
+   * layer dedups in-flight requests and cools down after total failure, and
+   * the pending flag keeps one request cycle per panel — so the
+   * request → re-render → request loop terminates as soon as a cycle brings
+   * in nothing new.
+   */
+  private requestHeadlineTranslations(titles: string[]): void {
+    if (!this.isAutoTranslateActive() || this.headlineTranslationPending) return;
+    const lang = getCurrentLanguage();
+    const missing = titles
+      .filter((title) => title.trim().length > 0 && getCachedHeadlineTranslation(title, lang) === null)
+      .slice(0, AUTO_TRANSLATE_MAX_HEADLINES);
+    if (missing.length === 0) return;
+
+    this.headlineTranslationPending = true;
+    void translateHeadlines(missing, lang)
+      .then((translated) => {
+        this.headlineTranslationPending = false;
+        if (translated.size === 0 || !this.element?.isConnected) return;
+        if (getCurrentLanguage() !== lang) return; // language changed mid-flight
+        if (this.lastRawClusters) {
+          this.renderClusters(this.lastRawClusters);
+        } else if (this.lastRawItems) {
+          this.renderFlat(this.lastRawItems);
+        }
+      })
+      .catch(() => {
+        this.headlineTranslationPending = false;
+      });
+  }
+
   private async handleTranslate(element: HTMLElement, text: string): Promise<void> {
     const currentLang = getCurrentLanguage();
     if (currentLang === 'en') return; // Assume news is mostly English, no need to translate if UI is English (or add detection later)
@@ -490,7 +542,7 @@ export class NewsPanel extends Panel {
           ${item.storyMeta?.phase === 'sustained' ? '<span class="phase-badge sustained">ONGOING</span>' : ''}
           ${item.isAlert ? '<span class="alert-tag">ALERT</span>' : ''}
         </div>
-        <a class="item-title" href="${sanitizeUrl(item.link)}" target="_blank" rel="noopener">${escapeHtml(item.title)}</a>
+        <a class="item-title" href="${sanitizeUrl(item.link)}" target="_blank" rel="noopener">${escapeHtml(this.displayTitle(item.title))}</a>
         ${item.snippet ? `<div class="item-snippet">${escapeHtml(item.snippet.length > 200 ? item.snippet.slice(0, 200).replace(/\s+\S*$/, '') + '…' : item.snippet)}</div>` : ''}
         <div class="item-time">
           ${formatTime(item.pubDate)}
@@ -502,6 +554,11 @@ export class NewsPanel extends Panel {
       .join('');
 
     this.setSafeContent(unsafeRawHtml(html, 'legacy Panel.setContent() migration'));
+    // Only English-source items: the on-device translator pair is en→UI-lang,
+    // and non-English items already render with their lang badge.
+    this.requestHeadlineTranslations(
+      sorted.filter((item) => !item.lang || item.lang === 'en').map((item) => item.title),
+    );
   }
 
   private renderClusters(clusters: ClusteredEvent[]): void {
@@ -588,6 +645,9 @@ export class NewsPanel extends Panel {
       this.setSafeContent(unsafeRawHtml(html, 'legacy Panel.setContent() migration'));
     }
     this.refreshRelatedAssetsAfterLazyTables(sorted);
+    this.requestHeadlineTranslations(
+      sorted.filter((cluster) => !cluster.lang || cluster.lang === 'en').map((cluster) => cluster.primaryTitle),
+    );
   }
 
   private refreshRelatedAssetsAfterLazyTables(clusters: ClusteredEvent[]): void {
@@ -753,7 +813,7 @@ export class NewsPanel extends Panel {
           ${categoryBadge}
           ${riskBadge}
         </div>
-        <a class="item-title" href="${sanitizeUrl(cluster.primaryLink)}" target="_blank" rel="noopener">${escapeHtml(cluster.primaryTitle)}</a>
+        <a class="item-title" href="${sanitizeUrl(cluster.primaryLink)}" target="_blank" rel="noopener">${escapeHtml(this.displayTitle(cluster.primaryTitle))}</a>
         <div class="cluster-meta">
           <span class="top-sources">${topSourcesHtml}</span>
           <span class="item-time">${formatTime(cluster.lastUpdated)}</span>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -3142,7 +3142,9 @@
     "fontFamily": "عائلة الخط",
     "fontFamilyDesc": "خط أحادي المسافة للمظهر التقني، أو الخط الافتراضي للقراءة الأسهل.",
     "fontMono": "أحادي المسافة",
-    "fontSystem": "الخط الافتراضي"
+    "fontSystem": "الخط الافتراضي",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "فتح ملخص البلد",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Семейство шрифтове",
     "fontFamilyDesc": "Монопространствен за технически вид, системен по подразбиране за по-лесно четене.",
     "fontMono": "Монопространствен",
-    "fontSystem": "Системен по подразбиране"
+    "fontSystem": "Системен по подразбиране",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Отвори обзор на страната",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -3106,7 +3106,9 @@
     "fontFamily": "Typ písma",
     "fontFamilyDesc": "Monospace pro technický vzhled, systémové výchozí pro snazší čtení.",
     "fontMono": "Monospace",
-    "fontSystem": "Systémové výchozí"
+    "fontSystem": "Systémové výchozí",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Otevřít přehled země",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Schriftfamilie",
     "fontFamilyDesc": "Monospace für technisches Aussehen, Systemstandard für leichtere Lesbarkeit.",
     "fontMono": "Monospace",
-    "fontSystem": "Systemstandard"
+    "fontSystem": "Systemstandard",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Länderübersicht öffnen",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Οικογένεια Γραμματοσειράς",
     "fontFamilyDesc": "Monospace για τεχνικό περιβάλλον, προεπιλογή συστήματος για ευκολότερη ανάγνωση.",
     "fontMono": "Monospace",
-    "fontSystem": "Προεπιλογή Συστήματος"
+    "fontSystem": "Προεπιλογή Συστήματος",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Άνοιγμα επισκόπησης χώρας",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3141,6 +3141,8 @@
     "mapThemeDesc": "Visual style of the map tiles. Options vary by provider.",
     "globePreset": "Visual Preset",
     "globePresetDesc": "Switch between classic and enhanced globe visuals to compare.",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language (on-device browser translation when available, AI cloud otherwise)",
     "fontFamily": "Font Family",
     "fontFamilyDesc": "Monospace for a technical look, system default for easier reading.",
     "fontMono": "Monospace",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3088,7 +3088,9 @@
     "fontFamily": "Familia de Fuente",
     "fontFamilyDesc": "Monoespaciada para un aspecto técnico, sistema predeterminado para lectura más fácil.",
     "fontMono": "Monoespaciada",
-    "fontSystem": "Sistema Predeterminado"
+    "fontSystem": "Sistema Predeterminado",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Abrir resumen del país",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -3144,7 +3144,9 @@
     "fontFamily": "Font Family",
     "fontFamilyDesc": "Monospace for a technical look, system default for easier reading.",
     "fontMono": "Monospace",
-    "fontSystem": "System Default"
+    "fontSystem": "System Default",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "premium": {
     "pro": "PRO",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3088,7 +3088,9 @@
     "fontFamily": "Famille de polices",
     "fontFamilyDesc": "Monospace pour un look technique, police système par défaut pour une lecture plus facile.",
     "fontMono": "Monospace",
-    "fontSystem": "Police système par défaut"
+    "fontSystem": "Police système par défaut",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Ouvrir la fiche pays",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -3144,7 +3144,9 @@
     "fontFamily": "फॉन्ट परिवार",
     "fontFamilyDesc": "तकनीकी लुक के लिए मोनोस्पेस, आसानी से पढ़ने के लिए सिस्टम डिफ़ॉल्ट।",
     "fontMono": "मोनोस्पेस",
-    "fontSystem": "सिस्टम डिफ़ॉल्ट"
+    "fontSystem": "सिस्टम डिफ़ॉल्ट",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "premium": {
     "pro": "PRO",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -3359,7 +3359,9 @@
     "fontFamily": "Obitelj Fonta",
     "fontFamilyDesc": "Monospace za tehnički izgled, zadanu vrijednost sustava za lakše čitanje.",
     "fontMono": "Monospace",
-    "fontSystem": "Zadana vrijednost sustava"
+    "fontSystem": "Zadana vrijednost sustava",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "premium": {
     "pro": "PRO",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -3144,7 +3144,9 @@
     "fontFamily": "Betűtípus család",
     "fontFamilyDesc": "Monospace a technikai megjelenéshez, rendszer alapértelmezés az olvashatóság kedvéért.",
     "fontMono": "Monospace",
-    "fontSystem": "Rendszer alapértelmezés"
+    "fontSystem": "Rendszer alapértelmezés",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "premium": {
     "pro": "PRO",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -3088,7 +3088,9 @@
     "fontFamily": "Famiglia di Caratteri",
     "fontFamilyDesc": "Monospace per un aspetto tecnico, predefinito di sistema per una lettura più agevole.",
     "fontMono": "Monospace",
-    "fontSystem": "Predefinito di Sistema"
+    "fontSystem": "Predefinito di Sistema",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Apri scheda paese",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3067,6 +3067,8 @@
     "mapThemeDesc": "マップタイルのビジュアルスタイル。",
     "globePreset": "ビジュアルプリセット",
     "globePresetDesc": "クラシックと拡張地球表示を切り替えます。",
+    "autoTranslateLabel": "ニュース見出しの自動翻訳",
+    "autoTranslateDesc": "ニュースの見出しを表示言語へ自動翻訳します(対応ブラウザでは端末内翻訳、それ以外はAIクラウド)",
     "fontFamily": "フォントファミリー",
     "fontFamilyDesc": "テクニカルな見た目にはモノスペース、より読みやすくするにはシステムデフォルトを選択できます。",
     "fontMono": "モノスペース",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "글꼴 패밀리",
     "fontFamilyDesc": "기술적 모양을 위해 모노스페이스, 더 쉬운 읽기를 위해 시스템 기본값.",
     "fontMono": "모노스페이스",
-    "fontSystem": "시스템 기본값"
+    "fontSystem": "시스템 기본값",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "국가 개요 열기",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Lettertype",
     "fontFamilyDesc": "Monospace voor een technische uitstraling, systeemstandaard voor gemakkelijker lezen.",
     "fontMono": "Monospace",
-    "fontSystem": "Systeemstandaard"
+    "fontSystem": "Systeemstandaard",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Landenoverzicht openen",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -3106,7 +3106,9 @@
     "fontFamily": "Rodzina czcionki",
     "fontFamilyDesc": "Monospace dla wyglądu technicznego, domyślna czcionka systemowa dla łatwiejszego czytania.",
     "fontMono": "Monospace",
-    "fontSystem": "Domyślna czcionka systemowa"
+    "fontSystem": "Domyślna czcionka systemowa",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Otwórz przegląd kraju",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -3088,7 +3088,9 @@
     "fontFamily": "Família de Fontes",
     "fontFamilyDesc": "Monospace para uma aparência técnica, fonte padrão do sistema para leitura mais fácil.",
     "fontMono": "Monospace",
-    "fontSystem": "Padrão do Sistema"
+    "fontSystem": "Padrão do Sistema",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Abrir resumo do país",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -3088,7 +3088,9 @@
     "fontFamily": "Familie de fonturi",
     "fontFamilyDesc": "Monospace pentru aspect tehnic, font implicit pentru citire mai ușoară.",
     "fontMono": "Monospace",
-    "fontSystem": "Font implicit"
+    "fontSystem": "Font implicit",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Deschide prezentarea țării",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -3106,7 +3106,9 @@
     "fontFamily": "Шрифт",
     "fontFamilyDesc": "Моноширинный для технического вида, системный по умолчанию для удобства чтения.",
     "fontMono": "Моноширинный",
-    "fontSystem": "Системный шрифт"
+    "fontSystem": "Системный шрифт",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Открыть обзор страны",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Teckensnitt",
     "fontFamilyDesc": "Monospace för teknisk stil, systemstandard för lättare läsning.",
     "fontMono": "Monospace",
-    "fontSystem": "Systemstandard"
+    "fontSystem": "Systemstandard",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Öppna landsöversikt",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "ตระกูลฟอนต์",
     "fontFamilyDesc": "Monospace สำหรับลักษณะเทคนิค ฟอนต์เริ่มต้นของระบบสำหรับการอ่านที่ง่ายกว่า",
     "fontMono": "Monospace",
-    "fontSystem": "ค่าเริ่มต้นของระบบ"
+    "fontSystem": "ค่าเริ่มต้นของระบบ",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "เปิดภาพรวมประเทศ",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Yazı Tipi Ailesi",
     "fontFamilyDesc": "Teknik görünüş için Monospace, daha kolay okuma için sistem varsayılanı.",
     "fontMono": "Monospace",
-    "fontSystem": "Sistem Varsayılanı"
+    "fontSystem": "Sistem Varsayılanı",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Ülke özetini aç",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "Họ phông chữ",
     "fontFamilyDesc": "Monospace cho giao diện kỹ thuật, phông chữ hệ thống mặc định để dễ đọc hơn.",
     "fontMono": "Monospace",
-    "fontSystem": "Phông chữ hệ thống"
+    "fontSystem": "Phông chữ hệ thống",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "Mở tổng quan quốc gia",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -3070,7 +3070,9 @@
     "fontFamily": "字体",
     "fontFamilyDesc": "等宽字体用于技术外观，系统默认字体便于阅读。",
     "fontMono": "等宽字体",
-    "fontSystem": "系统默认"
+    "fontSystem": "系统默认",
+    "autoTranslateLabel": "Auto-translate headlines",
+    "autoTranslateDesc": "Automatically translate news headlines into your display language using AI"
   },
   "contextMenu": {
     "openCountryBrief": "打开国家简报",

--- a/src/services/ai-flow-settings.ts
+++ b/src/services/ai-flow-settings.ts
@@ -13,6 +13,7 @@ const STORAGE_KEY_CLOUD_LLM = 'wm-ai-flow-cloud-llm';
 const STORAGE_KEY_MAP_NEWS_FLASH = 'wm-map-news-flash';
 const STORAGE_KEY_HEADLINE_MEMORY = 'wm-headline-memory';
 const STORAGE_KEY_BADGE_ANIMATION = 'wm-badge-animation';
+const STORAGE_KEY_AUTO_TRANSLATE = 'wm-auto-translate-headlines';
 const STORAGE_KEY_STREAM_QUALITY = 'wm-stream-quality';
 const EVENT_NAME = 'ai-flow-changed';
 const STREAM_QUALITY_EVENT = 'stream-quality-changed';
@@ -23,6 +24,8 @@ export interface AiFlowSettings {
   mapNewsFlash: boolean;
   headlineMemory: boolean;
   badgeAnimation: boolean;
+  /** Auto-translate news headlines into the UI language (no-op when the UI language is English). */
+  autoTranslate: boolean;
 }
 
 function readBool(key: string, defaultValue: boolean): boolean {
@@ -49,6 +52,7 @@ const STORAGE_KEY_MAP: Record<keyof AiFlowSettings, string> = {
   mapNewsFlash: STORAGE_KEY_MAP_NEWS_FLASH,
   headlineMemory: STORAGE_KEY_HEADLINE_MEMORY,
   badgeAnimation: STORAGE_KEY_BADGE_ANIMATION,
+  autoTranslate: STORAGE_KEY_AUTO_TRANSLATE,
 };
 
 const DEFAULTS: AiFlowSettings = {
@@ -57,6 +61,7 @@ const DEFAULTS: AiFlowSettings = {
   mapNewsFlash: true,
   headlineMemory: false,
   badgeAnimation: false,
+  autoTranslate: true,
 };
 
 export function getAiFlowSettings(): AiFlowSettings {
@@ -66,6 +71,7 @@ export function getAiFlowSettings(): AiFlowSettings {
     mapNewsFlash: readBool(STORAGE_KEY_MAP_NEWS_FLASH, DEFAULTS.mapNewsFlash),
     headlineMemory: readBool(STORAGE_KEY_HEADLINE_MEMORY, DEFAULTS.headlineMemory),
     badgeAnimation: readBool(STORAGE_KEY_BADGE_ANIMATION, DEFAULTS.badgeAnimation),
+    autoTranslate: readBool(STORAGE_KEY_AUTO_TRANSLATE, DEFAULTS.autoTranslate),
   };
 }
 

--- a/src/services/browser-translator.ts
+++ b/src/services/browser-translator.ts
@@ -1,0 +1,135 @@
+/**
+ * On-device translation via the browser's built-in Translator API
+ * (Chromium 138+; https://developer.mozilla.org/docs/Web/API/Translator).
+ *
+ * This is the zero-setup path for headline auto-translation: no API keys, no
+ * server spend, works offline once the browser has the language pack. The
+ * headline-translation service tries this first and falls back to the server
+ * LLM chain (Ollama/Groq/OpenRouter) when the API or language pair is
+ * unavailable (non-Chromium browsers, unsupported pairs).
+ *
+ * Caveats handled here:
+ *  - Language-pack downloads may require a user gesture. warmBrowserTranslator()
+ *    is called from settings interactions (toggle / language select) so the
+ *    download can start inside a click; background translate attempts simply
+ *    fail closed to the server chain until the pack is present.
+ *  - create() can hang while a pack downloads — attempts are capped by a soft
+ *    timeout and retried on later calls.
+ */
+
+const CREATE_TIMEOUT_MS = 10_000;
+
+interface TranslatorInstance {
+  translate(text: string): Promise<string>;
+}
+
+interface TranslatorStatic {
+  availability(opts: { sourceLanguage: string; targetLanguage: string }): Promise<string>;
+  create(opts: { sourceLanguage: string; targetLanguage: string }): Promise<TranslatorInstance>;
+}
+
+function getTranslatorApi(): TranslatorStatic | null {
+  const api = (globalThis as { Translator?: unknown }).Translator;
+  if (!api || (typeof api !== 'object' && typeof api !== 'function')) return null;
+  const candidate = api as Partial<TranslatorStatic>;
+  return typeof candidate.availability === 'function' && typeof candidate.create === 'function'
+    ? candidate as TranslatorStatic
+    : null;
+}
+
+/**
+ * BCP-47 candidates for an app language code. The app uses bare codes ('ja',
+ * 'zh'); the Translator API wants BCP-47 and Chinese is only served as
+ * script-tagged variants, so 'zh' probes 'zh-Hans' first.
+ */
+export function translatorLanguageCandidates(lang: string): string[] {
+  const norm = (lang || '').trim();
+  if (!norm) return [];
+  if (norm === 'zh') return ['zh-Hans', 'zh'];
+  return [norm];
+}
+
+/** target lang → resolved instance (null = resolved as unavailable) */
+const instances = new Map<string, TranslatorInstance | null>();
+/** target lang → in-flight resolution */
+const pending = new Map<string, Promise<TranslatorInstance | null>>();
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('translator create timeout')), ms);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (err) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
+async function resolveTranslator(targetLang: string): Promise<TranslatorInstance | null> {
+  const api = getTranslatorApi();
+  if (!api) return null;
+  for (const candidate of translatorLanguageCandidates(targetLang)) {
+    try {
+      const availability = await api.availability({ sourceLanguage: 'en', targetLanguage: candidate });
+      if (availability === 'unavailable') continue;
+      return await withTimeout(api.create({ sourceLanguage: 'en', targetLanguage: candidate }), CREATE_TIMEOUT_MS);
+    } catch {
+      // Pack still downloading, user-activation required, or pair rejected —
+      // try the next candidate / leave uncached so a later attempt retries.
+    }
+  }
+  return null;
+}
+
+function getTranslator(targetLang: string): Promise<TranslatorInstance | null> {
+  const cached = instances.get(targetLang);
+  if (cached !== undefined) return Promise.resolve(cached);
+  let inFlight = pending.get(targetLang);
+  if (!inFlight) {
+    inFlight = resolveTranslator(targetLang).then((instance) => {
+      pending.delete(targetLang);
+      // Only cache positive results — a null may just mean "pack not ready
+      // yet"; retrying on a later chunk is cheap and self-heals.
+      if (instance) instances.set(targetLang, instance);
+      return instance;
+    });
+    pending.set(targetLang, inFlight);
+  }
+  return inFlight;
+}
+
+/**
+ * Kick off translator resolution (and thereby the language-pack download)
+ * from inside a user gesture. Fire-and-forget.
+ */
+export function warmBrowserTranslator(targetLang: string): void {
+  if (!targetLang || targetLang === 'en') return;
+  void getTranslator(targetLang);
+}
+
+/**
+ * Translate English texts on-device. Returns null when the API/pair is
+ * unavailable (caller falls back to the server chain); otherwise an array
+ * aligned 1:1 with `texts` (per-text failures stay null).
+ */
+export async function translateTextsInBrowser(
+  texts: string[],
+  targetLang: string,
+): Promise<Array<string | null> | null> {
+  const translator = await getTranslator(targetLang);
+  if (!translator) return null;
+  const out: Array<string | null> = [];
+  for (const text of texts) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      out.push(null);
+      continue;
+    }
+    try {
+      const translated = (await translator.translate(trimmed)).trim();
+      out.push(translated.length > 0 ? translated : null);
+    } catch {
+      out.push(null);
+    }
+  }
+  return out;
+}

--- a/src/services/headline-translation.ts
+++ b/src/services/headline-translation.ts
@@ -1,0 +1,188 @@
+/**
+ * Headline auto-translation with a local per-headline cache.
+ *
+ * Sits on top of translateTexts() (SummarizeArticle mode='translate', which
+ * the server serves per-headline from Redis and only LLM-translates misses).
+ * This layer adds what panels need to translate whole feeds cheaply:
+ *   - an in-memory + localStorage cache with a SYNC getter, so render paths
+ *     can substitute translations inline (works with windowed/virtual lists)
+ *     and re-renders/reloads cost zero RPCs
+ *   - chunking (server accepts up to 10 headlines per request)
+ *   - a global sequential queue so a cold dashboard with many news panels
+ *     paces itself under the 30/min endpoint rate limit instead of bursting
+ *   - in-flight dedup so overlapping panels don't double-translate
+ *   - a short cooldown after total failure so a dead provider chain doesn't
+ *     get re-hammered on every feed refresh
+ */
+
+import { hashString } from '@/utils/hash';
+import { translateTextsInBrowser } from './browser-translator';
+import { translateTexts } from './summarization';
+
+const STORE_KEY = 'wm-headline-translations-v1';
+const ENTRY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 800;
+const CHUNK_SIZE = 10;
+const FAILURE_COOLDOWN_MS = 60 * 1000;
+
+interface StoreEntry {
+  /** translated text */
+  t: string;
+  /** last-used timestamp (refreshed on read → LRU eviction) */
+  ts: number;
+}
+
+type Store = Record<string, StoreEntry>;
+
+let memCache: Store | null = null;
+let lastTotalFailureTs = 0;
+/** headline-hash → resolves when the chunk containing it settles */
+const inFlight = new Map<string, Promise<void>>();
+/** serializes chunk RPCs across all panels */
+let queueTail: Promise<void> = Promise.resolve();
+
+function entryKey(text: string, lang: string): string {
+  return hashString(`${lang}:${text}`);
+}
+
+function getStore(): Store {
+  if (memCache) return memCache;
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    const parsed = raw ? JSON.parse(raw) as unknown : null;
+    memCache = parsed && typeof parsed === 'object' ? parsed as Store : {};
+  } catch {
+    memCache = {};
+  }
+  return memCache;
+}
+
+function persistStore(): void {
+  const store = getStore();
+  try {
+    const now = Date.now();
+    let entries = Object.entries(store).filter(([, v]) =>
+      v && typeof v.t === 'string' && typeof v.ts === 'number' && now - v.ts < ENTRY_TTL_MS);
+    if (entries.length > MAX_ENTRIES) {
+      entries = entries.sort((a, b) => b[1].ts - a[1].ts).slice(0, MAX_ENTRIES);
+    }
+    localStorage.setItem(STORE_KEY, JSON.stringify(Object.fromEntries(entries)));
+  } catch {
+    // Quota / private browsing — translations just won't persist.
+  }
+}
+
+function readEntry(text: string, lang: string): string | null {
+  const store = getStore();
+  const entry = store[entryKey(text, lang)];
+  if (!entry || typeof entry.t !== 'string' || typeof entry.ts !== 'number') return null;
+  if (Date.now() - entry.ts >= ENTRY_TTL_MS) return null;
+  return entry.t;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+async function translateChunk(texts: string[], lang: string): Promise<void> {
+  // Zero-setup path first: the browser's built-in on-device translator
+  // (Chromium). Free and local, so it beats the server LLM chain whenever
+  // the language pack is available; otherwise fall back to the server.
+  let results = await translateTextsInBrowser(texts, lang);
+  if (!results || !results.some((r) => r && r.trim().length > 0)) {
+    results = await translateTexts(texts, lang);
+  }
+  if (!results.some((r) => r && r.trim().length > 0)) {
+    lastTotalFailureTs = Date.now();
+    return;
+  }
+  const store = getStore();
+  const now = Date.now();
+  for (const [i, text] of texts.entries()) {
+    const translated = results[i]?.trim();
+    if (!translated) continue;
+    store[entryKey(text, lang)] = { t: translated, ts: now };
+  }
+  persistStore();
+}
+
+/**
+ * Synchronous cache-only lookup for render paths. Refreshes the entry's
+ * LRU timestamp in memory (persisted on the next write).
+ */
+export function getCachedHeadlineTranslation(text: string, lang: string): string | null {
+  if (!lang || lang === 'en') return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const translated = readEntry(trimmed, lang);
+  if (translated !== null) {
+    const entry = getStore()[entryKey(trimmed, lang)];
+    if (entry) entry.ts = Date.now();
+  }
+  return translated;
+}
+
+/**
+ * Translate headlines into `lang`, serving from cache where possible.
+ * Returns a map of original → translated containing only the headlines that
+ * have a translation (callers keep the original text for the rest).
+ * Failures are silent — auto-translation must never break feed rendering.
+ */
+export async function translateHeadlines(
+  texts: string[],
+  lang: string,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  if (!lang || lang === 'en') return result;
+
+  const wanted = [...new Set(texts.map((t) => t.trim()).filter(Boolean))];
+  if (wanted.length === 0) return result;
+
+  const misses: string[] = [];
+  const waits: Promise<void>[] = [];
+
+  for (const text of wanted) {
+    const cached = getCachedHeadlineTranslation(text, lang);
+    if (cached !== null) {
+      result.set(text, cached);
+      continue;
+    }
+    const pending = inFlight.get(entryKey(text, lang));
+    if (pending) {
+      waits.push(pending);
+    } else {
+      misses.push(text);
+    }
+  }
+
+  if (misses.length > 0 && Date.now() - lastTotalFailureTs > FAILURE_COOLDOWN_MS) {
+    for (const group of chunk(misses, CHUNK_SIZE)) {
+      const run = queueTail.then(() => translateChunk(group, lang)).catch(() => {
+        lastTotalFailureTs = Date.now();
+      });
+      queueTail = run;
+      for (const text of group) {
+        const key = entryKey(text, lang);
+        inFlight.set(key, run);
+        void run.finally(() => {
+          if (inFlight.get(key) === run) inFlight.delete(key);
+        });
+      }
+      waits.push(run);
+    }
+  }
+
+  if (waits.length > 0) {
+    await Promise.all(waits);
+    // Chunk completions (ours and other panels') have landed in the store.
+    for (const text of wanted) {
+      if (result.has(text)) continue;
+      const translated = readEntry(text, lang);
+      if (translated !== null) result.set(text, translated);
+    }
+  }
+
+  return result;
+}

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -1,4 +1,5 @@
 import { LANGUAGES, getCurrentLanguage, changeLanguage, t } from '@/services/i18n';
+import { warmBrowserTranslator } from '@/services/browser-translator';
 import { getAiFlowSettings, setAiFlowSetting, getStreamQuality, setStreamQuality, STREAM_QUALITY_OPTIONS } from '@/services/ai-flow-settings';
 import { getMapProvider, setMapProvider, MAP_PROVIDER_OPTIONS, MAP_THEME_OPTIONS, getMapTheme, setMapTheme, type MapProvider } from '@/config/basemap';
 import { getLiveStreamsAlwaysOn, setLiveStreamsAlwaysOn } from '@/services/live-stream-settings';
@@ -214,6 +215,8 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   if (currentLang === 'vi') {
     html += `<div class="ai-flow-toggle-desc">${t('components.languageSelector.mapLabelsFallbackVi')}</div>`;
   }
+
+  html += toggleRowHtml('us-auto-translate', t('preferences.autoTranslateLabel'), t('preferences.autoTranslateDesc'), settings.autoTranslate);
 
   html += `</div></details>`;
 
@@ -458,6 +461,9 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
         }
         if (target.id === 'us-language') {
           trackLanguageChange(target.value);
+          // Inside the click gesture so the browser translator may start its
+          // language-pack download (Chromium gates downloads on activation).
+          if (target.value !== 'en') warmBrowserTranslator(target.value);
           void changeLanguage(target.value);
           return;
         }
@@ -485,6 +491,9 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
           setAiFlowSetting('mapNewsFlash', target.checked);
         } else if (target.id === 'us-headline-memory') {
           setAiFlowSetting('headlineMemory', target.checked);
+        } else if (target.id === 'us-auto-translate') {
+          setAiFlowSetting('autoTranslate', target.checked);
+          if (target.checked) warmBrowserTranslator(getCurrentLanguage());
         } else if (target.id === 'us-badge-anim') {
           setAiFlowSetting('badgeAnimation', target.checked);
         }

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -16,6 +16,7 @@ import { trackLLMUsage, trackLLMFailure } from './analytics';
 import { getCurrentLanguage } from './i18n';
 import type { SummarizeArticleResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
+import { parseNumberedList } from '@/utils/numbered-list';
 import { buildSummaryCacheKey } from '@/utils/summary-cache-key';
 import { NewsServiceClient } from '@/services/generated-rpc-clients';
 import { premiumFetch } from '@/services/premium-fetch';
@@ -377,16 +378,31 @@ async function generateSummaryInternal(
 }
 
 /**
- * Translate text using the fallback chain (via SummarizeArticle RPC with mode='translate')
- * @param text Text to translate
- * @param targetLang Target language code (e.g., 'fr', 'es')
+ * Translate a batch of texts in ONE RPC (SummarizeArticle mode='translate').
+ * The server caches each headline individually and only sends cache misses
+ * to the LLM, so callers should batch freely instead of looping.
+ *
+ * @param texts Up to 10 texts, deduplicated by the caller (the server dedups
+ *   too, but the returned numbered list is aligned to the request order, so
+ *   duplicates simply repeat).
+ * @param targetLang Target language code (e.g., 'ja', 'fr')
+ * @returns Array aligned 1:1 with `texts`; null = untranslated (keep original)
  */
-export async function translateText(
-  text: string,
+export async function translateTexts(
+  texts: string[],
   targetLang: string,
   onProgress?: ProgressCallback
-): Promise<string | null> {
-  if (!text) return null;
+): Promise<Array<string | null>> {
+  const nothing: Array<string | null> = texts.map(() => null);
+  // Send only non-empty texts — the server's numbered response is aligned to
+  // the request array, so blank entries would just waste batch slots. The
+  // entries list remaps parsed results back to the caller's indexes.
+  const entries = texts
+    .map((text, index) => ({ index, text: typeof text === 'string' ? text.trim() : '' }))
+    .filter((entry) => entry.text.length > 0)
+    .slice(0, 10);
+  if (entries.length === 0) return nothing;
+  const payload = entries.map((entry) => entry.text);
 
   const totalSteps = API_PROVIDERS.length;
   for (const [i, providerDef] of API_PROVIDERS.entries()) {
@@ -397,7 +413,7 @@ export async function translateText(
       const resp = await summaryBreaker.execute(async () => {
         return newsClient.summarizeArticle({
           provider: providerDef.provider,
-          headlines: [text],
+          headlines: payload,
           mode: 'translate',
           geoContext: '',
           variant: targetLang,
@@ -409,11 +425,35 @@ export async function translateText(
 
       if (resp.fallback || resp.status === 'SUMMARIZE_STATUS_SKIPPED') continue;
       const summary = typeof resp.summary === 'string' ? resp.summary.trim() : '';
-      if (summary) return summary;
+      if (!summary) continue;
+
+      const parsed = parseNumberedList(summary, payload.length);
+      if (parsed.some((p) => p && p.trim().length > 0)) {
+        const result = [...nothing];
+        for (const [slot, entry] of entries.entries()) {
+          result[entry.index] = parsed[slot]?.trim() || null;
+        }
+        return result;
+      }
     } catch (e) {
       console.warn(`${providerDef.label} translation failed`, e);
     }
   }
 
-  return null;
+  return nothing;
+}
+
+/**
+ * Translate text using the fallback chain (via SummarizeArticle RPC with mode='translate')
+ * @param text Text to translate
+ * @param targetLang Target language code (e.g., 'fr', 'es')
+ */
+export async function translateText(
+  text: string,
+  targetLang: string,
+  onProgress?: ProgressCallback
+): Promise<string | null> {
+  if (!text) return null;
+  const [translated] = await translateTexts([text], targetLang, onProgress);
+  return translated ?? null;
 }

--- a/src/utils/numbered-list.ts
+++ b/src/utils/numbered-list.ts
@@ -1,0 +1,41 @@
+/**
+ * Numbered-list helpers shared by the translate pipeline.
+ *
+ * The batch translate path (SummarizeArticle mode='translate' with multiple
+ * headlines) round-trips translations through a plain-text numbered list:
+ * the server composes `1. …\n2. …` from per-headline cache/LLM results and
+ * the client parses it back into per-headline strings. Both sides MUST use
+ * this module so the framing stays aligned (server/ imports from src/utils
+ * the same way summary-cache-key.ts is shared).
+ */
+
+export function buildNumberedList(items: string[]): string {
+  return items.map((item, i) => `${i + 1}. ${item}`).join('\n');
+}
+
+/**
+ * Parse a numbered list back into `count` slots. Lines that are missing,
+ * empty, or numbered out of range stay null — callers treat null as
+ * "untranslated" and keep the original text. Duplicate numbers keep the
+ * first occurrence. A single-item request accepts bare (un-numbered) text
+ * for backward compatibility with the legacy one-headline translate shape.
+ */
+export function parseNumberedList(text: string, count: number): Array<string | null> {
+  const out: Array<string | null> = new Array(count).fill(null);
+  if (!text) return out;
+  if (count === 1) {
+    // Legacy single-headline responses are bare text, but a model may still
+    // echo the numbering — strip it when the whole response is one line.
+    const trimmed = text.trim();
+    const single = trimmed.match(/^\s*1\s*[.)::.、]\s*(.*\S)\s*$/);
+    out[0] = single?.[1] ?? (trimmed.length > 0 ? trimmed : null);
+    return out;
+  }
+  for (const line of text.split('\n')) {
+    const m = line.match(/^\s*(\d{1,3})\s*[.)::.、]\s*(.*\S)\s*$/);
+    if (!m || m[1] === undefined || m[2] === undefined) continue;
+    const idx = Number(m[1]) - 1;
+    if (idx >= 0 && idx < count && out[idx] === null) out[idx] = m[2];
+  }
+  return out;
+}

--- a/tests/translate-batch.test.mts
+++ b/tests/translate-batch.test.mts
@@ -1,0 +1,110 @@
+/**
+ * Batch headline translation (SummarizeArticle mode='translate').
+ *
+ * Covers:
+ * - numbered-list round-trip framing shared by client and server
+ * - translate prompt shapes: single-headline stays legacy-identical,
+ *   multi-headline switches to the numbered batch contract
+ * - per-headline cache key identity: a batch item's key must equal the
+ *   legacy single-headline translate key so old cache entries stay valid
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildNumberedList, parseNumberedList } from '../src/utils/numbered-list.ts';
+import { buildSummaryCacheKey } from '../src/utils/summary-cache-key.ts';
+import { buildArticlePrompts } from '../server/worldmonitor/news/v1/_shared.ts';
+import { translatorLanguageCandidates } from '../src/services/browser-translator.ts';
+
+describe('buildNumberedList / parseNumberedList round-trip', () => {
+  it('round-trips a batch', () => {
+    const items = ['Inflation rises to 3.5%', 'Fed holds rates steady', 'Markets react'];
+    const parsed = parseNumberedList(buildNumberedList(items), items.length);
+    assert.deepEqual(parsed, items);
+  });
+
+  it('keeps blank slots null so callers preserve the original text', () => {
+    const parsed = parseNumberedList('1. 見出しA\n2. \n3. 見出しC', 3);
+    assert.deepEqual(parsed, ['見出しA', null, '見出しC']);
+  });
+
+  it('accepts bare text for a single item (legacy shape)', () => {
+    assert.deepEqual(parseNumberedList('インフレ率が3.5%に上昇', 1), ['インフレ率が3.5%に上昇']);
+  });
+
+  it('strips echoed numbering on a single item', () => {
+    assert.deepEqual(parseNumberedList('1. インフレ率が3.5%に上昇', 1), ['インフレ率が3.5%に上昇']);
+  });
+
+  it('tolerates alternative separators and out-of-order lines', () => {
+    const parsed = parseNumberedList('2) 二番目\n1、 一番目', 2);
+    assert.deepEqual(parsed, ['一番目', '二番目']);
+  });
+
+  it('ignores out-of-range and duplicate numbers', () => {
+    const parsed = parseNumberedList('1. first\n1. dupe\n9. out of range', 2);
+    assert.deepEqual(parsed, ['first', null]);
+  });
+
+  it('returns all nulls for empty/conversational output', () => {
+    assert.deepEqual(parseNumberedList('', 2), [null, null]);
+    assert.deepEqual(parseNumberedList('Here are the translations you asked for!', 2), [null, null]);
+  });
+});
+
+describe('translate prompt shapes', () => {
+  const opts = { mode: 'translate', geoContext: '', variant: 'ja', lang: '', bodies: [] };
+
+  it('single headline keeps the legacy prompt byte-identical', () => {
+    const { systemPrompt, userPrompt } = buildArticlePrompts(['Fed holds rates'], ['Fed holds rates'], opts);
+    assert.equal(userPrompt, 'Translate to ja:\nFed holds rates');
+    assert.match(systemPrompt, /Output ONLY the translated text\./);
+    assert.doesNotMatch(systemPrompt, /numbered/);
+  });
+
+  it('multiple headlines switch to the numbered batch contract', () => {
+    const headlines = ['Fed holds rates', 'Markets react'];
+    const { systemPrompt, userPrompt } = buildArticlePrompts(headlines, headlines, opts);
+    assert.equal(userPrompt, 'Translate to ja:\n1. Fed holds rates\n2. Markets react');
+    assert.match(systemPrompt, /numbered list of translations matching the input numbers/);
+    assert.match(systemPrompt, /one per line/);
+  });
+});
+
+describe('per-headline translate cache key identity', () => {
+  it('batch item key equals the legacy single-headline translate key', () => {
+    // The server's translate path keys each unique headline as
+    // getCacheKey([h], 'translate', '', targetLang, lang) — exactly the
+    // legacy shape minted by the manual per-item translate button.
+    const legacy = buildSummaryCacheKey(['Fed holds rates'], 'translate', '', 'ja', 'en');
+    const perItem = buildSummaryCacheKey(['Fed holds rates'], 'translate', '', 'ja', 'en');
+    assert.equal(perItem, legacy);
+  });
+
+  it('translate keys ignore bodies (per-headline identity is stable)', () => {
+    const without = buildSummaryCacheKey(['Fed holds rates'], 'translate', '', 'ja', 'en');
+    const withBodies = buildSummaryCacheKey(['Fed holds rates'], 'translate', '', 'ja', 'en', undefined, ['some rss description']);
+    assert.equal(withBodies, without);
+  });
+
+  it('different target languages mint different keys', () => {
+    const ja = buildSummaryCacheKey(['Fed holds rates'], 'translate', '', 'ja', 'en');
+    const fr = buildSummaryCacheKey(['Fed holds rates'], 'translate', '', 'fr', 'en');
+    assert.notEqual(ja, fr);
+  });
+});
+
+describe('browser translator language candidates', () => {
+  it('passes plain codes through', () => {
+    assert.deepEqual(translatorLanguageCandidates('ja'), ['ja']);
+  });
+
+  it('probes script-tagged Chinese first', () => {
+    assert.deepEqual(translatorLanguageCandidates('zh'), ['zh-Hans', 'zh']);
+  });
+
+  it('rejects empty input', () => {
+    assert.deepEqual(translatorLanguageCandidates(''), []);
+    assert.deepEqual(translatorLanguageCandidates('  '), []);
+  });
+});


### PR DESCRIPTION
## Summary

Feed headlines now render in the selected UI language instead of English. The zero-setup first path uses the browser's built-in on-device Translator API (Chromium), falling back to the existing server LLM chain (Ollama/Groq/OpenRouter) where configured. `SummarizeArticle` `mode='translate'` now batches up to 10 headlines per request, caches each headline individually in Redis (keys stay compatible with the legacy single-headline entries), and only LLM-translates misses via one numbered-list prompt; a new client-side headline-translation service adds a localStorage+memory cache, chunking, a global sequential queue under the endpoint's 30/min budget, in-flight dedup, and a post-failure cooldown. A new "Auto-translate headlines" toggle (default on) lives in Settings → Display and warms the browser translator inside the user gesture so language packs can download.

## Type of change

- [x] New feature

## Affected areas

- [x] News panels / RSS feeds
- [x] API endpoints (`/api/*`)
- [x] Config / Settings

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A (no feeds added)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- N/A — this PR does not publish or change documentation claims (locale key sync only).

## Screenshots

<!-- Auto-translation is provider-gated; verify with a Chromium translator or configured LLM key. -->
