### PR TITLE
fix(e2e): retry once in CI so a Playwright protocol glitch stops reddening gates

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,20 @@ export default defineConfig({
   expect: {
     timeout: 30000,
   },
-  retries: 0,
+  // One retry in CI, none locally (#5685). Playwright can throw from its own
+  // event dispatch — `Object with guid response@<id> was not bound in the
+  // connection` — when the client receives a `response` event referencing an
+  // object it cannot resolve. That fires BEFORE any listener body runs, so no
+  // defensive code in a spec can prevent it: variant-live-smoke's capture
+  // helper already try/catches every accessor it touches and the throw still
+  // escaped, reddening a required gate 2.3s into a boot test whose own
+  // assertions had not yet run.
+  //
+  // A retry cannot hide a deterministic failure — that fails both attempts.
+  // When the second attempt passes, Playwright reports the test as `flaky`
+  // rather than silently green, so a genuine product race still surfaces.
+  // Local runs stay at 0 so a flake is felt immediately while iterating.
+  retries: process.env.CI ? 1 : 0,
   reporter: 'list',
   use: {
     baseURL: 'http://127.0.0.1:4173',


### PR DESCRIPTION
A required e2e gate could go red without anything being wrong with the PR under test. Playwright throws from its own event dispatch — `Object with guid response@<id> was not bound in the connection` — when the client receives a `response` event referencing an object it cannot resolve. On #5683 that killed `variant-smoke-full` 2.3 seconds in, before any assertion in the spec had run; re-running the identical SHA passed.

Nothing in a spec can defend against it. The throw fires before any listener body executes — `variant-live-smoke-response-capture.ts` already try/catches every accessor it touches (`url()`, `request()`, `status()`) and the error still escaped. With `retries: 0` a single glitch reddened the gate, and the only honest way to tell "my change broke it" from "CI hiccuped" was to re-run the same SHA by hand.

CI now gets one retry; local runs stay at 0 so a flake is felt immediately while iterating. This does not buy quiet at the cost of signal: a deterministic failure fails both attempts, and a test that passes on retry is reported `flaky` rather than silently green, so a genuine product race still surfaces in the run output.

Rejected alternative: hardening the smoke spec's listeners. The throw originates upstream of our callbacks, so there is nothing there to harden.

Fixes #5685

Verified with a temporary probe run against this config — fail-then-pass across attempts, with the counter held outside the worker process because Playwright discards the worker after a failure (my first probe used a module-level counter and reset on every retry, which read as a hard failure):

| Environment | Result | Exit |
|---|---|---|
| `CI=true` | `1 flaky` | 0 |
| `CI` unset | `1 failed` | 1 |

The probe was deleted before commit; the diff is the config line and its rationale.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
