### PR TITLE
fix(session): tell a dropped cookie apart from a rejected one

### DIFF
--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -6,7 +6,7 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { timingSafeEqualSecret, timingSafeIncludes } from './_crypto.js';
 import { checkRateLimit } from './_rate-limit.js';
-import { issueSessionToken } from './_session.js';
+import { issueSessionToken, validateSessionToken } from './_session.js';
 import { emitWmSessionUsage } from './_usage-telemetry.js';
 
 export const config = { runtime: 'edge' };
@@ -33,6 +33,46 @@ function appendHeader(headers, name, value) {
   const next = new Headers(headers);
   next.append(name, value);
   return next;
+}
+
+/**
+ * Read one cookie off the request. Mirrors the reader in `_api-key.js`; kept
+ * local because this endpoint is the only other consumer and `_api-key.js`
+ * does not export it.
+ */
+function readCookie(req, name) {
+  const raw = req.headers.get('Cookie') || req.headers.get('cookie') || '';
+  if (!raw) return '';
+  const prefix = `${name}=`;
+  for (const part of raw.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed.startsWith(prefix)) continue;
+    try {
+      return decodeURIComponent(trimmed.slice(prefix.length));
+    } catch {
+      return trimmed.slice(prefix.length);
+    }
+  }
+  return '';
+}
+
+/**
+ * Did THIS request arrive already carrying a usable session cookie?
+ *
+ * The client cannot answer this itself — the cookie is HttpOnly, so JS can
+ * neither read it nor tell "the server rejected my cookie" apart from "my
+ * browser never stored it." Those two need opposite responses: the first is
+ * worth a re-mint, the second makes every re-mint useless because no route can
+ * ever succeed. Reporting it back lets the client stop after one wasted mint
+ * instead of spending one per route and blaming the API for a browser-side
+ * storage failure (WORLDMONITOR-WG/XP).
+ *
+ * Computed from the INCOMING request, before this response's Set-Cookie.
+ */
+async function hadValidSessionCookie(req) {
+  const presented = readCookie(req, SESSION_COOKIE);
+  if (!presented) return false;
+  return validateSessionToken(presented);
 }
 
 function shouldUseSharedCookieDomain(req) {
@@ -147,6 +187,15 @@ export default async function handler(req, ctx) {
     return rl;
   }
 
+  // Before the new Set-Cookie: whether the caller's browser gave the previous
+  // cookie back. Never fails the request — it is diagnostic, not a gate.
+  let hadSession = false;
+  try {
+    hadSession = await hadValidSessionCookie(req);
+  } catch {
+    hadSession = false;
+  }
+
   let issued;
   try {
     issued = await issueSessionToken();
@@ -180,5 +229,5 @@ export default async function handler(req, ctx) {
     headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, PRO_KEY_COOKIE, proKey));
   }
 
-  return respond({ ok: true, exp: issued.exp }, 200, headers, 'ok');
+  return respond({ ok: true, exp: issued.exp, hadSession }, 200, headers, 'ok');
 }

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -606,3 +606,57 @@ test('Returns 503 when WM_SESSION_SECRET is missing', async () => {
     process.env.WM_SESSION_SECRET = stash;
   }
 });
+
+// --- hadSession: does the caller's browser give the cookie back? -------------
+// The client cannot answer this itself (HttpOnly), so it could not tell "the
+// server rejected my cookie" from "my browser never stored it" — and re-minted
+// forever on the second, reporting it as a server-side retry_401. See
+// WORLDMONITOR-WG/XP.
+
+function makeReqWithCookie(cookie) {
+  const headers = new Headers({ origin: 'https://worldmonitor.app' });
+  if (cookie) headers.set('cookie', cookie);
+  return new Request('https://api.worldmonitor.app/api/wm-session', { method: 'POST', headers });
+}
+
+test('mint reports hadSession:false when the request carries no session cookie', async () => {
+  const resp = await handler(makeReqWithCookie(null));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.equal(body.hadSession, false, 'a first-ever visitor presents no cookie');
+});
+
+test('mint reports hadSession:true when the browser returns the cookie it was issued', async () => {
+  const first = await handler(makeReqWithCookie(null));
+  const token = cookieValue(setCookies(first), 'wm-session');
+  assert.match(token, /^wms_/);
+
+  // Exactly what a browser that stored the cookie sends on the next mint.
+  const resp = await handler(makeReqWithCookie(`wm-session=${encodeURIComponent(token)}`));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.equal(body.hadSession, true, 'a cookie that made the round trip must be reported');
+});
+
+test('mint reports hadSession:false for a tampered or foreign session cookie', async () => {
+  // A cookie that exists but does not verify is not evidence of a working
+  // round trip — it must not suppress the client's re-mint.
+  const first = await handler(makeReqWithCookie(null));
+  const token = cookieValue(setCookies(first), 'wm-session');
+  const tampered = `${token.slice(0, -2)}${token.slice(-2) === 'AA' ? 'BB' : 'AA'}`;
+
+  const resp = await handler(makeReqWithCookie(`wm-session=${encodeURIComponent(tampered)}`));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.equal(body.hadSession, false);
+});
+
+test('mint still succeeds when the cookie header is malformed', async () => {
+  // hadSession is diagnostic, never a gate: a junk Cookie header must not
+  // turn a routine mint into an error.
+  const resp = await handler(makeReqWithCookie('wm-session=%%%not-a-token%%%; other=1'));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.equal(body.hadSession, false);
+  assert.match(cookieValue(setCookies(resp), 'wm-session'), /^wms_/);
+});

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -63,7 +63,15 @@ const SESSION_DEAD_ROUTE_STRIKE_TTL_MS = SESSION_DEAD_COOLDOWN_MS;
 const PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS = new Set(bootstrapTierKeyNames('on-demand'));
 export const WM_SESSION_DEGRADED_EVENT = 'wm-session-degraded';
 
-type WmSessionDeadReason = 'mint_failed' | 'retry_401';
+type WmSessionDeadReason = 'mint_failed' | 'retry_401' | 'cookie_not_persisted';
+
+// Whether a mint in THIS page session has already handed the browser a cookie.
+// The next mint must arrive carrying it — `/api/wm-session` reports that as
+// `hadSession`. A first-ever mint legitimately carries none, so the flag is
+// what separates "new visitor" from "browser is dropping our cookie."
+let cookieIssuedThisSession = false;
+// Latched once a mint proves the browser did not keep the previous cookie.
+let cookiePersistenceBroken = false;
 
 interface StoredSession {
   exp: number;
@@ -222,10 +230,16 @@ function noteRouteSuccess(rawPath: string): void {
   // quorum, including when that success was already in flight as the quorum
   // formed. Lift only retry-derived cooldowns here: mint_failed means the
   // session endpoint itself is unavailable and retains its immediate guard.
-  if (sessionDeadReason === 'retry_401') {
+  //
+  // cookie_not_persisted is lifted for the same reason and is even more
+  // clear-cut: a credentialed route just succeeded, so the browser demonstrably
+  // DID deliver the cookie. Clear the latch too, or the next mint would
+  // immediately re-derive the verdict this success just disproved.
+  if (sessionDeadReason === 'retry_401' || sessionDeadReason === 'cookie_not_persisted') {
     sessionDeadUntil = 0;
     sessionDeadReason = null;
   }
+  cookiePersistenceBroken = false;
 }
 
 function addSessionBreadcrumb(message: string, data: Record<string, string>): void {
@@ -278,7 +292,11 @@ function markWmSessionDead(reason: WmSessionDeadReason, rawPath: string): void {
   // endpoints under the same tag name that means "the denied route" elsewhere.
   // The bystander is still worth having, so it rides the breadcrumb instead.
   const blockedTag = toRouteTag(rawPath);
-  const routeTag = reason === 'mint_failed' ? '/api/wm-session' : blockedTag;
+  // Only retry_401 implicates a specific endpoint. mint_failed and
+  // cookie_not_persisted are both session-scoped verdicts learned AT the mint,
+  // so whichever route happened to be in flight is a bystander — tagging it
+  // would seed the census with innocent endpoints.
+  const routeTag = reason === 'retry_401' ? blockedTag : '/api/wm-session';
   addSessionBreadcrumb('wm-session recovery failed', { route: routeTag, blocked: blockedTag, reason });
   try {
     sentryEnqueue((s) => s.captureMessage(
@@ -359,6 +377,36 @@ function saveToStorage(s: StoredSession): void {
   try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify(s)); } catch { /* ignore */ }
 }
 
+/**
+ * Fold one mint's cookie evidence into the persistence latch.
+ *
+ * `hadSession` is the server's answer to the one question the client cannot
+ * ask itself: did this request arrive carrying a usable cookie? The cookie is
+ * HttpOnly, so "the server rejected a good cookie" and "my browser never kept
+ * it" are indistinguishable from JS — and they need opposite responses. The
+ * first deserves a re-mint; the second makes every further mint pointless,
+ * because no credentialed route can ever succeed.
+ */
+function noteMintCookieEvidence(hadSession: boolean): void {
+  if (hadSession) {
+    // The cookie completed a round trip. Any earlier suspicion is void —
+    // direct evidence outranks inference, same doctrine as noteRouteSuccess.
+    cookieIssuedThisSession = true;
+    cookiePersistenceBroken = false;
+    return;
+  }
+  if (!cookieIssuedThisSession) {
+    // Every first-time visitor mints without a cookie. Reading that as a
+    // failure would black out the anonymous surface on arrival.
+    cookieIssuedThisSession = true;
+    return;
+  }
+  // We were handed a cookie earlier in this page session and this mint still
+  // arrived without one, so the browser is not storing it (strict cookie
+  // settings, an in-app WebView, partitioned storage, a privacy extension).
+  cookiePersistenceBroken = true;
+}
+
 async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): Promise<StoredSession | null> {
   try {
     const fetchImpl = nativeSessionFetch ?? globalThis.fetch;
@@ -370,8 +418,11 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
       signal: AbortSignal.timeout(fetchNewSessionTimeoutMs),
     });
     if (!resp.ok) return null;
-    const data = await resp.json() as { exp?: unknown };
+    const data = await resp.json() as { exp?: unknown; hadSession?: unknown };
     if (typeof data?.exp !== 'number') return null;
+    // Absent on an older deployment: treat as "no evidence either way" and
+    // leave the latch alone rather than accusing a healthy browser.
+    if (typeof data.hadSession === 'boolean') noteMintCookieEvidence(data.hadSession);
     return { exp: data.exp };
   } catch {
     return null;
@@ -395,6 +446,14 @@ export async function ensureWmSession(): Promise<boolean> {
       cached = fresh;
       sessionGeneration += 1;
       saveToStorage(fresh);
+      // A cookie the browser will not keep cannot authorize anything, and the
+      // next route's 401 would buy another useless mint. Suppress up front and
+      // name the real cause, instead of letting the retry_401 quorum report it
+      // as the API rejecting a good cookie (WORLDMONITOR-WG/XP).
+      if (cookiePersistenceBroken) {
+        markWmSessionDead('cookie_not_persisted', '/api/wm-session');
+        return false;
+      }
       return true;
     }
     return false;
@@ -418,9 +477,14 @@ export async function establishWmKeySession(keys: { widgetKey?: string; proKey?:
   sessionDeadUntil = 0;
   sessionDeadReason = null;
   // A key-bound session is a clean slate: strikes recorded against the old
-  // anonymous identity say nothing about what this one may reach.
+  // anonymous identity say nothing about what this one may reach. The
+  // persistence latch is cleared for the same reason — this mint just set a
+  // fresh cookie, and the new identity is entitled to prove itself rather than
+  // inherit a verdict reached before the upgrade. If the browser really is
+  // dropping cookies, the very next mint re-derives it.
   routeStrikes.clear();
   recentRouteFailures.clear();
+  cookiePersistenceBroken = false;
   saveToStorage(fresh);
   return true;
 }
@@ -450,6 +514,8 @@ export function __resetWmSessionForTests(): void {
   sessionDeadReason = null;
   routeStrikes.clear();
   recentRouteFailures.clear();
+  cookieIssuedThisSession = false;
+  cookiePersistenceBroken = false;
   sentryEnqueue = enqueueSentryCall;
   fetchNewSessionTimeoutMs = 10_000;
 }

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -387,7 +387,7 @@ function saveToStorage(s: StoredSession): void {
  * first deserves a re-mint; the second makes every further mint pointless,
  * because no credentialed route can ever succeed.
  */
-function noteMintCookieEvidence(hadSession: boolean): void {
+function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boolean): void {
   if (hadSession) {
     // The cookie completed a round trip. Any earlier suspicion is void —
     // direct evidence outranks inference, same doctrine as noteRouteSuccess.
@@ -395,19 +395,27 @@ function noteMintCookieEvidence(hadSession: boolean): void {
     cookiePersistenceBroken = false;
     return;
   }
-  if (!cookieIssuedThisSession) {
-    // Every first-time visitor mints without a cookie. Reading that as a
-    // failure would black out the anonymous surface on arrival.
-    cookieIssuedThisSession = true;
-    return;
-  }
-  // We were handed a cookie earlier in this page session and this mint still
-  // arrived without one, so the browser is not storing it (strict cookie
-  // settings, an in-app WebView, partitioned storage, a privacy extension).
+  cookieIssuedThisSession = true;
+  // Only a mint DISPATCHED after some earlier mint had already been answered
+  // can testify. `aCookieExistedWhenSent` is sampled at request time for
+  // exactly that reason: mints overlap in flight at page boot, because
+  // establishWmKeySession bypasses ensureWmSession's `inflight` dedupe and both
+  // migrateLegacyKeysToHttpOnlySession() call sites are fire-and-forget. Two
+  // requests that left before either response installed a cookie BOTH report
+  // hadSession:false honestly — judging that at response time would read the
+  // second one as proof and black out a healthy session.
+  if (!aCookieExistedWhenSent) return;
+  // A cookie was already in hand when this request left, and it still arrived
+  // without one: the browser is not storing it (strict cookie settings, an
+  // in-app WebView, partitioned storage, a privacy extension).
   cookiePersistenceBroken = true;
 }
 
 async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): Promise<StoredSession | null> {
+  // Sampled BEFORE the request leaves, not when it returns: concurrent mints
+  // would otherwise let the first response to land make the others look like
+  // follow-up mints that came back empty. See noteMintCookieEvidence.
+  const aCookieExistedWhenSent = cookieIssuedThisSession;
   try {
     const fetchImpl = nativeSessionFetch ?? globalThis.fetch;
     const resp = await fetchImpl(toApiUrl('/api/wm-session'), {
@@ -422,7 +430,9 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
     if (typeof data?.exp !== 'number') return null;
     // Absent on an older deployment: treat as "no evidence either way" and
     // leave the latch alone rather than accusing a healthy browser.
-    if (typeof data.hadSession === 'boolean') noteMintCookieEvidence(data.hadSession);
+    if (typeof data.hadSession === 'boolean') {
+      noteMintCookieEvidence(data.hadSession, aCookieExistedWhenSent);
+    }
     return { exp: data.exp };
   } catch {
     return null;

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1847,3 +1847,104 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Layer 3 — cookie-persistence detection
+//
+// The failure mode WORLDMONITOR-WG/XP actually describes: the mint succeeds
+// (200 + Set-Cookie) but the browser never sends the cookie back, so every
+// credentialed route 401s no matter how many times we re-mint. The client
+// cannot read the HttpOnly cookie to check, so it used to assume the SERVER
+// rejected a good cookie and reported `retry_401` — blaming the API for a
+// browser-side storage failure, and spending one mint per route on the way.
+//
+// The mint response now reports whether the request ARRIVED with a valid
+// session cookie. A second mint that still reports `hadSession: false` proves
+// the cookie we just set never came back.
+// ---------------------------------------------------------------------------
+
+describe('wm-session cookie-persistence detection (Layer 3)', () => {
+  it('reports cookie_not_persisted and stops spending mints once the cookie proves unstorable', async () => {
+    memoryStorage.clear();
+
+    const captures: Array<{ ctx: { tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({
+        addBreadcrumb: () => {},
+        captureMessage: (_m: string, ctx: { tags?: Record<string, string> }) => { captures.push({ ctx }); },
+      });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+
+    let mints = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mints += 1;
+        // The browser stores nothing, so EVERY mint arrives without a cookie.
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE, hadSession: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('no cookie presented', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/conflict/v1/get-humanitarian-summary-batch');
+      const afterFirstRoute = mints;
+      await wrappedFetch('https://api.worldmonitor.app/api/military/v1/get-aircraft-details-batch');
+      assert.equal(
+        mints,
+        afterFirstRoute,
+        'a cookie proven unstorable must not be re-minted for the next route',
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'exactly one session-dead episode');
+    assert.equal(
+      dead[0].ctx.tags?.reason,
+      'cookie_not_persisted',
+      'must name the browser-side storage failure, not blame the server with retry_401',
+    );
+  });
+
+  it('does not accuse a brand-new browser whose first mint legitimately carries no cookie', async () => {
+    // Every first-time visitor mints without a cookie. Reading that as
+    // non-persistence would black out the whole anonymous surface on arrival.
+    memoryStorage.clear();
+
+    const captures: Array<{ ctx: { tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({
+        addBreadcrumb: () => {},
+        captureMessage: (_m: string, ctx: { tags?: Record<string, string> }) => { captures.push({ ctx }); },
+      });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        // First mint: no cookie yet, which is normal and not evidence of anything.
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE, hadSession: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    };
+
+    const resp = await wrappedFetch('https://api.worldmonitor.app/api/news/v1/list-feed-digest?variant=full&lang=en');
+    assert.equal(resp.status, 200, 'a working first-visit session must be untouched');
+    assert.equal(
+      captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead').length,
+      0,
+      'a first mint without a cookie must not be reported as a dead session',
+    );
+    assert.equal(mod.isWmSessionDead(), false, 'a first-time visitor must not be blacked out');
+  });
+});

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1948,3 +1948,67 @@ describe('wm-session cookie-persistence detection (Layer 3)', () => {
     assert.equal(mod.isWmSessionDead(), false, 'a first-time visitor must not be blacked out');
   });
 });
+
+describe('wm-session cookie-persistence detection — concurrent mints', () => {
+  it('does not accuse the browser when an anonymous mint and a key-session mint overlap', async () => {
+    // The real page-boot shape: widget-store.ts and user-identity.ts both fire
+    // migrateLegacyKeysToHttpOnlySession() fire-and-forget (`void`) at module
+    // init, and establishWmKeySession bypasses ensureWmSession's `inflight`
+    // dedupe — so two mints leave before EITHER response installs a cookie.
+    // Both then honestly report hadSession:false, and reading the second one as
+    // proof of non-persistence would black out a perfectly healthy session.
+    memoryStorage.clear();
+
+    const captures: Array<{ ctx: { tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({
+        addBreadcrumb: () => {},
+        captureMessage: (_m: string, ctx: { tags?: Record<string, string> }) => { captures.push({ ctx }); },
+      });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+
+    const release: Array<() => void> = [];
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        return new Promise((resolve) => {
+          release.push(() => resolve(new Response(
+            JSON.stringify({ exp: FAR_FUTURE, hadSession: false }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )));
+        });
+      }
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const anon = mod.ensureWmSession();
+      const keyed = mod.establishWmKeySession({ proKey: 'legacy-pro-key' });
+      await new Promise((r) => setTimeout(r, 0));
+      assert.equal(release.length, 2, 'both mints must be in flight before either resolves');
+
+      // Harmful ordering: the key-session response lands first and marks a
+      // cookie as issued, so the anonymous response — sent before that cookie
+      // existed — looks like a second mint that came back empty.
+      release[1]();
+      await keyed;
+      release[0]();
+      await anon;
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(
+      mod.isWmSessionDead(),
+      false,
+      'two mints that overlapped in flight are not evidence that the browser dropped a cookie',
+    );
+    assert.equal(
+      captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead').length,
+      0,
+      'an in-flight overlap must not report a dead session',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`WORLDMONITOR-WG`/`XP` report `retry_401` — "the API rejected a freshly minted cookie" — for a failure that is usually the exact opposite: the browser never stored the cookie, so every credentialed route 401s no matter how often the client re-mints. Because the cookie is `HttpOnly`, JS can neither read it nor observe that it was dropped, so the client assumed server fault and bought one mint per route on the way to the `retry_401` quorum.

The server was never at fault. Probing production directly: minting a cookie and replaying it on a gateway route returns `200`, while the same route without the cookie returns `401 {"error":"API key required"}`. A traced Android WebView session shows the real shape — **5 mints in 18 seconds**, every credentialed call 401, and the replay-after-fresh-mint failing on two distinct routes.

`/api/wm-session` now answers the one question the client cannot ask itself: did *this* request arrive already carrying a usable cookie (`hadSession`, computed before the new `Set-Cookie`)? A mint that was **dispatched after an earlier mint had already been answered** and still reports `false` proves the cookie never came back. The client latches that, stops re-minting, and reports `cookie_not_persisted` — so the telemetry names the browser-side storage failure instead of accusing the API.

This does not make those browsers work; nothing client-side can authorize a cookie the browser refuses to keep. What changes is that we stop spending a mint per route, and WG/XP stop misattributing a browser problem to the API — the misdirection that sent the wm-session investigation down the wrong path twice in one day.

## Guarding against false positives

A wrong latch would black out the whole anonymous surface for the 15-minute cooldown, so every inference here is deliberately one-sided:

| Situation | Behavior |
|---|---|
| First-ever mint of a new visitor | Never accused — a first mint legitimately carries no cookie |
| Two mints overlapping in flight | Never accused — neither can testify about the other (see below) |
| `hadSession` absent (older deployment) | Treated as "no evidence", not a verdict — safe in both rollout directions |
| A credentialed route later succeeds | Latch cleared — direct evidence outranks inference |
| Malformed or junk `Cookie` header | Still a normal `200` mint; `hadSession` is diagnostic, never a gate |
| Key-bound session upgrade | Latch cleared, so the new identity proves itself rather than inheriting a verdict |

**Why the evidence is judged at dispatch, not at response.** Mints genuinely overlap at page boot: `establishWmKeySession` bypasses `ensureWmSession`'s `inflight` dedupe, and both `migrateLegacyKeysToHttpOnlySession()` call sites are fire-and-forget `void` calls at module init. Two requests that leave before either response installs a cookie *both* report `hadSession: false` honestly — and judging that at response time read whichever landed second as proof, blacking out a healthy session. So the latch samples "did a cookie already exist when this request left?" at request time; only a mint dispatched after an earlier one was answered can testify. Sequential detection is unaffected.

Useful side effect: a `credentials:'omit'` 401 can no longer masquerade as a dead session, because the mint itself always sends credentials. That is exactly the confound behind the bootstrap fix in #5683.

Scope note: the residual this targets was running at roughly 2-3 events/hour after #5677 and #5683 landed, down from ~200/hour combined. This is correctness and observability work, not an outage fix.

## Validation

- **Reproduced against production** before writing code: fresh cookie replayed on a gateway route → `200`; same route without it → `401`. The stateless-HMAC path is sound.
- **Red before green, twice.** The client test failed pre-fix on the real symptom (3 mints where 2 are correct). The concurrency test — which drives both mints and releases the key-session response first, the harmful order — failed with `true !== false` on a healthy session.
- **Mutation-tested,** since a test that cannot fail proves nothing:

  | Mutation | Result |
  |---|---|
  | Cookie detection disabled server-side | 1 server test reddens |
  | `hadSession` dropped from the response | 4 server tests redden |
  | First-visit exemption removed client-side | the false-positive guard reddens |
  | Evidence judged at response time again | the concurrency test reddens, and only that test |

- The sequential-detection test stayed green across the concurrency fix — a change that quietly neutered detection would not have passed.
- 169 session-related unit tests, 296 sidecar tests, `npm run typecheck` and `npm run lint` all pass.

Related: #5674

## New concepts

**Server-as-oracle for state the client structurally cannot observe.**

An `HttpOnly` cookie is deliberately invisible to JavaScript. That buys XSS resistance, but it also means the client cannot distinguish two failure modes that demand opposite responses: *"the server rejected my credential"* (retry — a fresh one may work) and *"my browser never stored the credential"* (stop — no retry can ever work). Both surface identically as a 401.

```mermaid
flowchart TB
    A["401 on a credentialed route"] --> B{"Client's view"}
    B --> C["Cookie sent, server rejected it<br/>→ re-mint is worth it"]
    B --> D["Cookie never stored, never sent<br/>→ every re-mint is wasted"]
    C -.->|"indistinguishable from JS"| D
    E["Mint reports hadSession"] --> F["Disambiguated at the only<br/>vantage point that sees the request"]
```

The fix is to stop inferring and ask the one party that can actually see whether the credential arrived. The server reads the incoming request *before* setting the new cookie and reports the answer back, turning an unobservable client-side property into an explicit signal. Here that is one boolean on the mint response; the client compares it against "a cookie had already been issued when this request left" and concludes non-persistence only when those two contradict.

The alternative we could have used — a JS-readable sentinel cookie set alongside the real one — was rejected because it measures a *different* cookie under different browser policies, so it can disagree with the credential it is supposed to describe.

Don't reach for this when the client can observe the state directly: a plain round-trip check is cheaper and needs no protocol change. It earns its keep only where the platform deliberately hides the state, and it costs a field on the wire plus a server-side verify per call.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

