### PR TITLE
feat(growth): establish SEO and AI-citation scorecard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
             --paginate --jq '.[].filename')
           CODE=$(echo "$FILES" | awk '
+            /^docs\/research\/seo-ai-visibility\// { count++; next }
             /\.md$/ { next }
             /^docs\// { next }
             /^src-tauri\// && $0 !~ /^src-tauri\/sidecar\// { next }

--- a/docs/research/seo-ai-visibility/README.md
+++ b/docs/research/seo-ai-visibility/README.md
@@ -1,0 +1,179 @@
+# SEO and AI-citation visibility scorecard
+
+This directory is the inspectable measurement artifact for issue #5667. It keeps
+traditional search, AI answers, referrals, and product outcomes separate so a
+missing source cannot silently become a zero or a site-wide vanity score.
+
+## Files
+
+- `query-set.json` — 25 reviewed decision queries with intent, audience, target
+  page, conversion goal, and named comparison/source entities.
+- `baselines/<date>.json` — normalized source availability, search/referral
+  windows, manual AI observations, reproduction context, and the prioritized
+  opportunity queue.
+- `scorecards/<date>.md` — deterministic human report generated from a baseline.
+- `scripts/seo-ai-visibility-scorecard.mjs` — validator, scorecard renderer, and
+  monthly comparison.
+- `tests/seo-ai-visibility-scorecard.test.mjs` — schema, missingness, aggregation,
+  comparison, and reproducibility coverage.
+
+The committed initial period is `2026-07-27`. It contains a four-platform manual
+observation for `q01`. Search Console, Bing Webmaster, and referral values are
+explicitly unavailable because the clean worktree had no property access or
+supported exports. That is an incomplete data source, not zero demand.
+
+Committed source `property` fields must remain `null`; property identifiers and
+credentials belong only in secure operator configuration. `aiSurfaces` records
+whether each requested surface was available, partial, or unavailable, with a
+reason for any non-available state. `aiObservations` contains only
+query/platform pairs that were actually inspected.
+
+## Reproduce the current scorecard
+
+From a clean repository checkout:
+
+```bash
+node scripts/seo-ai-visibility-scorecard.mjs \
+  --queries docs/research/seo-ai-visibility/query-set.json \
+  --baseline docs/research/seo-ai-visibility/baselines/2026-07-27.json \
+  --output docs/research/seo-ai-visibility/scorecards/2026-07-27.md \
+  --check
+```
+
+To generate a later scorecard, copy the prior baseline to a new dated file,
+replace only observations and supported-export values, then omit `--check` and
+point `--output` at the new date. Do not edit an older observation in place.
+
+## Weekly collection
+
+### 1. Search Console
+
+Use the Search Console UI export or Search Analytics API. Do not scrape Google
+result pages.
+
+For both the trailing 28-day and 90-day windows:
+
+1. Export search performance grouped by query and page, retaining clicks,
+   impressions, CTR, and average position.
+2. Export or record the supported Page Indexing summary for indexed pages.
+3. Join reviewed query rows to `query-set.json` by the exact query text.
+4. Group target pages into the ten `targetPage.family` values in the query set.
+5. Put site aggregates in `search.googleSearchConsole.windows`, reviewed-query
+   rows in `queryRows` (`windowLabel`, `queryId`, performance metrics), and
+   bounded page-family rows in `pageFamilyRows` (`windowLabel`, `pageFamily`,
+   indexation and performance metrics).
+6. Preserve the source export beside the operator's secure working files, not
+   in this repo.
+
+If the export or indexing view is unavailable, keep every metric `null`, set
+`status` to `partial` or `unavailable`, and explain the missing source in
+`reason`. An unavailable provider has empty `queryRows` and `pageFamilyRows`.
+A partial provider may retain supported finite values while unavailable metrics
+remain `null`. A zero is valid only when the provider explicitly reported zero.
+
+### 2. Bing Webmaster
+
+Where property access exists, export query/page performance and indexation using
+Bing Webmaster's supported UI/API. Normalize the same metric names and periods
+under `search.bingWebmaster`. IndexNow submission is not evidence of indexing,
+impressions, clicks, or rank.
+
+### 3. Manual AI-answer panel
+
+Run the exact query text without paraphrasing. The target matrix is 25 queries
+by four surfaces:
+
+- ChatGPT Search
+- Perplexity
+- Google AI Overview/AI Mode where available
+- Copilot Search
+
+For each observation record:
+
+- UTC date/time, country-level geography, locale, device, and signed-in state;
+- brand mention;
+- direct citation only when a visible answer link resolves to a
+  `worldmonitor.app` host;
+- all visible cited URLs and competitors cited;
+- sentiment and an accuracy judgment;
+- platform limitations, personalization, and any claim that needs correction.
+
+Do not save account identifiers, precise location, unrelated history, personal
+prompts, or hidden/collapsed data that was not actually inspected. If a platform
+is unavailable, set its `aiSurfaces` status and reason and omit fabricated
+observations. Do not substitute another surface while labeling it as the
+requested one.
+
+### 4. Referral and outcome reconciliation
+
+Use read-only aggregate exports from the existing analytics and commerce
+providers. Keep dimensions bounded to referrer family, landing-page family,
+reviewed topic/query cluster, and conversion step. Do not collect prompt text.
+
+The normalized outcome fields are:
+
+| Field | Current evidence seam |
+| --- | --- |
+| `sessions` | Referrer/UTM-attributed analytics sessions |
+| `dashboardLaunches` | Canonical homepage/dashboard landing pageviews |
+| `pricingViews` | `/pro` pricing pageviews |
+| `signUps` | `sign-up` |
+| `proConversions` | `checkout-success`, reconciled to aggregate commerce totals |
+| `apiActions` | Bounded API-reference/key-management actions when available |
+| `mcpActions` | `mcp-connect-attempt` / `mcp-connect-success` |
+
+Put aggregate totals in `referrals.windows`. Put bounded cross-sections in
+`referrals.segments`, keyed by `windowLabel`, `referrerFamily`, and
+`landingPageFamily`. Each segment carries the same normalized outcome metrics,
+which lets the report connect acquisition source to a product handoff without
+storing a prompt or user-level event.
+
+The blog's `blog-product-cta-click` event supplies bounded article,
+destination, and placement context. Preserve inbound UTM attribution. Never use
+`ref=` for internal SEO/AI source tags: the dashboard treats it as an affiliate
+referral code.
+
+## Monthly comparison
+
+Generate the current scorecard with the previous normalized baseline:
+
+```bash
+node scripts/seo-ai-visibility-scorecard.mjs \
+  --queries docs/research/seo-ai-visibility/query-set.json \
+  --previous docs/research/seo-ai-visibility/baselines/2026-07-27.json \
+  --baseline docs/research/seo-ai-visibility/baselines/2026-08-27.json \
+  --output docs/research/seo-ai-visibility/scorecards/2026-08-27.md
+```
+
+The comparison reports:
+
+- new and lost direct citations only when the same exact query/platform pair was
+  observed in both periods and its citation state changed;
+- newly observed and no-longer-observed pairs separately, so sparse audit
+  coverage cannot masquerade as citation gain or loss;
+- meaningful impression, click, CTR, average-position, and indexed-page changes
+  when both periods have supported provider data;
+- referral/outcome movement when both periods are available;
+- mixed or inaccurate entity answers that need correction;
+- the current evidence-backed experiment queue.
+
+Thresholds are diagnostics, not causal claims. A single answer, citation, or
+traffic change never proves uplift.
+
+## Secure configuration
+
+No credential or property identifier belongs in this directory. Future API
+collectors must read secrets from ignored local environment state or the
+deployment secret store, request read-only scopes, and write only normalized,
+reviewed aggregates. Do not commit raw account exports when they contain user,
+query, or property data outside this reviewed measurement contract.
+
+## Expansion gate
+
+Do not add a content/page family solely because a vendor score or one AI answer
+suggests it. Expansion requires all four:
+
+1. evidence of search or customer demand;
+2. healthy indexation;
+3. useful engagement rather than undifferentiated traffic;
+4. a credible dashboard, pricing, API, or MCP handoff.

--- a/docs/research/seo-ai-visibility/README.md
+++ b/docs/research/seo-ai-visibility/README.md
@@ -147,15 +147,22 @@ node scripts/seo-ai-visibility-scorecard.mjs \
 
 The comparison reports:
 
-- new and lost direct citations only when the same exact query/platform pair was
-  observed in both periods and its citation state changed;
-- newly observed and no-longer-observed pairs separately, so sparse audit
-  coverage cannot masquerade as citation gain or loss;
+- new and lost direct citations only when the same exact query, platform,
+  geography, locale, and signed-in context was observed in both periods and its
+  citation state changed;
+- newly observed and no-longer-observed query/platform/context combinations
+  separately, so sparse audit coverage cannot masquerade as citation gain or
+  loss;
 - meaningful impression, click, CTR, average-position, and indexed-page changes
   when both periods have supported provider data;
 - referral/outcome movement when both periods are available;
 - mixed or inaccurate entity answers that need correction;
 - the current evidence-backed experiment queue.
+
+The comparison rejects reversed periods, a changed query-set ID, or a changed
+collection geography, locale, device, or signed-in schedule. Change those
+dimensions by starting a new baseline series instead of presenting incomparable
+audits as month-over-month movement.
 
 Thresholds are diagnostics, not causal claims. A single answer, citation, or
 traffic change never proves uplift.

--- a/docs/research/seo-ai-visibility/README.md
+++ b/docs/research/seo-ai-visibility/README.md
@@ -9,8 +9,8 @@ missing source cannot silently become a zero or a site-wide vanity score.
 - `query-set.json` — 25 reviewed decision queries with intent, audience, target
   page, conversion goal, and named comparison/source entities.
 - `baselines/<date>.json` — normalized source availability, search/referral
-  windows, manual AI observations, reproduction context, and the prioritized
-  opportunity queue.
+  windows, manual AI observations, the exact query-contract digest,
+  reproduction context, and the prioritized opportunity queue.
 - `scorecards/<date>.md` — deterministic human report generated from a baseline.
 - `scripts/seo-ai-visibility-scorecard.mjs` — validator, scorecard renderer, and
   monthly comparison.
@@ -43,6 +43,14 @@ node scripts/seo-ai-visibility-scorecard.mjs \
 To generate a later scorecard, copy the prior baseline to a new dated file,
 replace only observations and supported-export values, then omit `--check` and
 point `--output` at the new date. Do not edit an older observation in place.
+The copied `querySetDigest` pins the exact query text, intent, target, conversion,
+and reference-entity contract used by the period.
+
+If any comparison-critical query field changes, assign a new `querySetId` and
+start a new baseline series with the digest computed by
+`computeQuerySetDigest()` in the scorecard module. Existing baselines must keep
+their original ID and digest; the validator rejects silently reinterpreting
+historical observations with a newer query definition.
 
 ## Weekly collection
 
@@ -70,6 +78,7 @@ If the export or indexing view is unavailable, keep every metric `null`, set
 `reason`. An unavailable provider has empty `queryRows` and `pageFamilyRows`.
 A partial provider may retain supported finite values while unavailable metrics
 remain `null`. A zero is valid only when the provider explicitly reported zero.
+Every provider window must end on or before the baseline's `observedAt` date.
 
 ### 2. Bing Webmaster
 
@@ -97,6 +106,10 @@ For each observation record:
 - all visible cited URLs and competitors cited;
 - sentiment and an accuracy judgment;
 - platform limitations, personalization, and any claim that needs correction.
+
+Each observation timestamp must be at or before the baseline's `observedAt`
+snapshot. Move the baseline timestamp forward when later evidence is added
+instead of backdating that evidence into an earlier scorecard.
 
 Do not save account identifiers, precise location, unrelated history, personal
 prompts, or hidden/collapsed data that was not actually inspected. If a platform
@@ -154,15 +167,18 @@ The comparison reports:
   separately, so sparse audit coverage cannot masquerade as citation gain or
   loss;
 - meaningful impression, click, CTR, average-position, and indexed-page changes
-  when both periods have supported provider data;
+  when both periods have supported provider data and the current provider
+  window's start and end dates both advance beyond the previous window;
 - referral/outcome movement when both periods are available;
 - mixed or inaccurate entity answers that need correction;
 - the current evidence-backed experiment queue.
 
-The comparison rejects reversed periods, a changed query-set ID, or a changed
-collection geography, locale, device, or signed-in schedule. Change those
-dimensions by starting a new baseline series instead of presenting incomparable
-audits as month-over-month movement.
+The comparison rejects reversed periods, same/backward provider windows, a
+changed query-set ID or digest, or a changed collection geography, locale,
+device, or signed-in schedule. The report prints the exact previous/current
+provider date ranges beside meaningful deltas. Change comparison dimensions by
+starting a new baseline series instead of presenting incomparable audits as
+month-over-month movement.
 
 Thresholds are diagnostics, not causal claims. A single answer, citation, or
 traffic change never proves uplift.

--- a/docs/research/seo-ai-visibility/baselines/2026-07-27.json
+++ b/docs/research/seo-ai-visibility/baselines/2026-07-27.json
@@ -1,0 +1,410 @@
+{
+  "schemaVersion": 1,
+  "baselineId": "2026-07-27",
+  "querySetId": "seo-ai-visibility-v1",
+  "observedAt": "2026-07-27T17:15:05Z",
+  "repositoryRevision": "902b108f8239dce64f5577e366da0858cdaf17db",
+  "collectionContext": {
+    "geography": "France",
+    "locale": "en",
+    "signedInStates": [
+      "signed-out",
+      "signed-in"
+    ],
+    "device": "desktop web",
+    "limitations": [
+      "Google Search Console, Bing Webmaster, and analytics exports were not available in this clean worktree because no read-only credentials or exported reports were provided.",
+      "The manual AI audit is an initial four-platform sample for q01, not a population estimate across all 25 queries.",
+      "Google results were signed-in and personalized; the other three observations were signed-out.",
+      "Model names were not exposed consistently by the anonymous/search surfaces, so the platform and observation time are recorded without inventing a model identifier."
+    ]
+  },
+  "aiSurfaces": [
+    {
+      "platform": "chatgpt_search",
+      "status": "available",
+      "reason": null
+    },
+    {
+      "platform": "perplexity",
+      "status": "available",
+      "reason": null
+    },
+    {
+      "platform": "google_ai",
+      "status": "available",
+      "reason": null
+    },
+    {
+      "platform": "copilot_search",
+      "status": "available",
+      "reason": null
+    }
+  ],
+  "search": {
+    "googleSearchConsole": {
+      "status": "unavailable",
+      "property": null,
+      "reason": "No supported Search Console export or read-only property credential was available. Values remain null rather than being estimated from public result pages.",
+      "windows": [
+        {
+          "label": "28d",
+          "startDate": "2026-06-30",
+          "endDate": "2026-07-27",
+          "metrics": {
+            "indexedPages": null,
+            "impressions": null,
+            "clicks": null,
+            "ctr": null,
+            "averagePosition": null
+          }
+        },
+        {
+          "label": "90d",
+          "startDate": "2026-04-29",
+          "endDate": "2026-07-27",
+          "metrics": {
+            "indexedPages": null,
+            "impressions": null,
+            "clicks": null,
+            "ctr": null,
+            "averagePosition": null
+          }
+        }
+      ],
+      "queryRows": [],
+      "pageFamilyRows": []
+    },
+    "bingWebmaster": {
+      "status": "unavailable",
+      "property": null,
+      "reason": "No Bing Webmaster export or property access was available. IndexNow support does not substitute for Bing query and click reporting.",
+      "windows": [
+        {
+          "label": "28d",
+          "startDate": "2026-06-30",
+          "endDate": "2026-07-27",
+          "metrics": {
+            "indexedPages": null,
+            "impressions": null,
+            "clicks": null,
+            "ctr": null,
+            "averagePosition": null
+          }
+        },
+        {
+          "label": "90d",
+          "startDate": "2026-04-29",
+          "endDate": "2026-07-27",
+          "metrics": {
+            "indexedPages": null,
+            "impressions": null,
+            "clicks": null,
+            "ctr": null,
+            "averagePosition": null
+          }
+        }
+      ],
+      "queryRows": [],
+      "pageFamilyRows": []
+    }
+  },
+  "referrals": {
+    "status": "unavailable",
+    "property": null,
+    "reason": "The Umami/commerce aggregates were not exported into this clean environment. Existing event names are documented for the next read-only reconciliation, but no session or conversion count is inferred.",
+    "classification": {
+      "dimensions": [
+        "referrerHost",
+        "utmSource",
+        "landingPageFamily"
+      ],
+      "families": [
+        {
+          "id": "chatgpt",
+          "label": "ChatGPT",
+          "hostSuffixes": [
+            "chatgpt.com",
+            "chat.openai.com"
+          ],
+          "utmSources": [
+            "chatgpt.com"
+          ]
+        },
+        {
+          "id": "perplexity",
+          "label": "Perplexity",
+          "hostSuffixes": [
+            "perplexity.ai"
+          ],
+          "utmSources": [
+            "perplexity"
+          ]
+        },
+        {
+          "id": "google_search_ai",
+          "label": "Google Search / AI",
+          "hostSuffixes": [
+            "google.com",
+            "google.fr",
+            "gemini.google.com"
+          ],
+          "utmSources": [
+            "google"
+          ]
+        },
+        {
+          "id": "copilot_bing",
+          "label": "Copilot / Bing",
+          "hostSuffixes": [
+            "bing.com",
+            "copilot.microsoft.com"
+          ],
+          "utmSources": [
+            "bing",
+            "copilot"
+          ]
+        },
+        {
+          "id": "claude",
+          "label": "Claude",
+          "hostSuffixes": [
+            "claude.ai"
+          ],
+          "utmSources": [
+            "claude"
+          ]
+        },
+        {
+          "id": "other_ai_search",
+          "label": "Other identified AI/search",
+          "hostSuffixes": [],
+          "utmSources": []
+        },
+        {
+          "id": "unknown_direct",
+          "label": "Unknown / direct",
+          "hostSuffixes": [],
+          "utmSources": []
+        }
+      ]
+    },
+    "segments": [],
+    "windows": [
+      {
+        "label": "28d",
+        "startDate": "2026-06-30",
+        "endDate": "2026-07-27",
+        "metrics": {
+          "sessions": null,
+          "dashboardLaunches": null,
+          "pricingViews": null,
+          "signUps": null,
+          "proConversions": null,
+          "apiActions": null,
+          "mcpActions": null
+        }
+      },
+      {
+        "label": "90d",
+        "startDate": "2026-04-29",
+        "endDate": "2026-07-27",
+        "metrics": {
+          "sessions": null,
+          "dashboardLaunches": null,
+          "pricingViews": null,
+          "signUps": null,
+          "proConversions": null,
+          "apiActions": null,
+          "mcpActions": null
+        }
+      }
+    ]
+  },
+  "aiObservations": [
+    {
+      "queryId": "q01",
+      "platform": "chatgpt_search",
+      "observedAt": "2026-07-27T17:10:00Z",
+      "geography": "France",
+      "locale": "en",
+      "signedInState": "signed-out",
+      "brandMention": true,
+      "directCitation": true,
+      "citedUrls": [
+        "https://www.worldmonitor.app/?utm_source=chatgpt.com",
+        "https://gridline.world/?utm_source=chatgpt.com"
+      ],
+      "competitorsCited": [
+        "ACLED Explorer",
+        "GDELT",
+        "Dataminr",
+        "Recorded Future",
+        "Janes",
+        "S&P Global Market Intelligence"
+      ],
+      "sentiment": "positive",
+      "accuracy": "mixed",
+      "summary": "Named World Monitor the best all-around open OSINT dashboard and linked the homepage directly. The answer also made broad numeric and adoption claims that require recurring source-of-truth review before they are treated as accurate product facts.",
+      "limitations": [
+        "Anonymous ChatGPT Search did not expose a stable model identifier.",
+        "Only the visible direct links were recorded; collapsed source metadata was not inferred."
+      ]
+    },
+    {
+      "queryId": "q01",
+      "platform": "perplexity",
+      "observedAt": "2026-07-27T17:11:00Z",
+      "geography": "France",
+      "locale": "en",
+      "signedInState": "signed-out",
+      "brandMention": true,
+      "directCitation": false,
+      "citedUrls": [
+        "https://utilo.io/fr/home/tools/V0K-Vu7bhLfEs-k_47vUTuSYd71"
+      ],
+      "competitorsCited": [],
+      "sentiment": "positive",
+      "accuracy": "mixed",
+      "summary": "Called World Monitor the strongest free single pick, but supported the claim with a third-party directory rather than a World Monitor URL. Its 435+ sources and 45+ layer counts need fact review.",
+      "limitations": [
+        "The answer was generated without signing in.",
+        "A third-party page mentioning World Monitor is a mention source, not a direct World Monitor citation."
+      ]
+    },
+    {
+      "queryId": "q01",
+      "platform": "google_ai",
+      "observedAt": "2026-07-27T17:12:00Z",
+      "geography": "France",
+      "locale": "en",
+      "signedInState": "signed-in",
+      "brandMention": true,
+      "directCitation": true,
+      "citedUrls": [
+        "https://www.worldmonitor.app/",
+        "https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/",
+        "https://www.nexusai-tech.com/ai-apps/world-monitor-ai-global-intelligence-and-real-time-osint-dashboard"
+      ],
+      "competitorsCited": [
+        "BlackRock Geopolitical Risk Dashboard",
+        "Hegemon Global",
+        "Graphika"
+      ],
+      "sentiment": "positive",
+      "accuracy": "mixed",
+      "summary": "The AI Overview called World Monitor the leading open-source geopolitical dashboard and cited the homepage plus the first-party explainer. It also used subjective ranking language and mutable provider-count claims that should remain dated and reviewable.",
+      "limitations": [
+        "The result was personalized because the Google session was signed in.",
+        "No account identifier or precise location was retained in the artifact."
+      ]
+    },
+    {
+      "queryId": "q01",
+      "platform": "copilot_search",
+      "observedAt": "2026-07-27T17:13:00Z",
+      "geography": "France",
+      "locale": "en",
+      "signedInState": "signed-out",
+      "brandMention": true,
+      "directCitation": true,
+      "citedUrls": [
+        "https://www.worldmonitor.app/",
+        "https://github.com/koala73/worldmonitor",
+        "https://www.worldmonitor.io/"
+      ],
+      "competitorsCited": [],
+      "sentiment": "positive",
+      "accuracy": "mixed",
+      "summary": "Presented World Monitor as the most comprehensive current option and cited the homepage and repository. The answer mixed first-party and similarly named third-party domains and included mutable layer, provider, SDK, and feature counts that require correction monitoring.",
+      "limitations": [
+        "Bing wrapped outbound citations in redirect URLs; the normalized destination URLs are recorded.",
+        "The answer was generated without signing in."
+      ]
+    }
+  ],
+  "opportunities": [
+    {
+      "priority": 1,
+      "title": "Complete credentialed search and referral exports",
+      "evidence": "Search Console, Bing Webmaster, and referral/conversion metrics are unavailable, so the baseline cannot yet size demand, indexation health, CTR, or downstream conversion.",
+      "experiment": "Provide a supported 28-day and 90-day Search Console export, a Bing export where property access exists, and read-only aggregate analytics grouped by bounded referrer and page family.",
+      "successCriteria": "The next scorecard contains non-null provider metrics reconciled to their source exports, with no credentials or property identifiers committed.",
+      "queryIds": [
+        "q01",
+        "q06",
+        "q11",
+        "q16",
+        "q21"
+      ]
+    },
+    {
+      "priority": 2,
+      "title": "Expand the four-platform audit from one query to the reviewed panel",
+      "evidence": "All four named AI/search surfaces were observed for q01, but overall coverage is only 4 of 100 possible query-platform observations.",
+      "experiment": "Run the unchanged 25-query panel on the documented geography, locale, and signed-in schedule, prioritizing five queries per weekly pass.",
+      "successCriteria": "Every query has one observation on each required platform, and missing surfaces carry an explicit platform limitation rather than a zero.",
+      "queryIds": [
+        "q01",
+        "q07",
+        "q11",
+        "q16",
+        "q21"
+      ]
+    },
+    {
+      "priority": 3,
+      "title": "Correct and centralize AI-surfaced product facts",
+      "evidence": "The four answers used conflicting source, feed, layer, adoption, SDK, and feature counts; all were therefore marked mixed accuracy even when they cited World Monitor.",
+      "experiment": "Audit the cited homepage, explainer, pricing, machine-readable product files, and repository description against the canonical product-fact source before the next observation window.",
+      "successCriteria": "Repeated answers cite first-party pages with current, mutually consistent facts; mixed/inaccurate entity-answer observations decline without rewriting history.",
+      "queryIds": [
+        "q01",
+        "q21",
+        "q22",
+        "q23",
+        "q25"
+      ]
+    },
+    {
+      "priority": 4,
+      "title": "Earn a first-party Perplexity citation for the category query",
+      "evidence": "Perplexity mentioned World Monitor positively but cited only a third-party directory, while ChatGPT, Google AI, and Copilot linked first-party pages.",
+      "experiment": "Improve the first-party category explainer's dated evidence, visible source links, entity clarity, and internal path from homepage to explainer; then rerun q01 unchanged.",
+      "successCriteria": "Perplexity links a worldmonitor.app URL directly for q01 without paid placement, reciprocal-link manipulation, or a claim-only content rewrite.",
+      "queryIds": [
+        "q01",
+        "q03",
+        "q17"
+      ]
+    },
+    {
+      "priority": 5,
+      "title": "Gate new content on measured developer and use-case demand",
+      "evidence": "The reviewed set covers developer/MCP, chokepoint, country-risk, crisis, airspace, and supply-chain intents, but no credentialed impression, engagement, or conversion data is available yet.",
+      "experiment": "After exports arrive, rank q06-q15 by impressions, indexation health, qualified engagement, and credible product handoff; choose at most one evidence-rich report or page-family experiment.",
+      "successCriteria": "A new page or report proceeds only when demand, healthy indexation, useful engagement, and an intent-matched dashboard/API/MCP conversion path are all evidenced.",
+      "queryIds": [
+        "q06",
+        "q07",
+        "q08",
+        "q09",
+        "q10",
+        "q11",
+        "q12",
+        "q13",
+        "q14",
+        "q15"
+      ]
+    }
+  ],
+  "guardrails": [
+    "Do not automate unauthorized search-result scraping.",
+    "Do not treat an AI mention without a worldmonitor.app source link as a direct citation.",
+    "Do not claim causal uplift from a single observation.",
+    "Do not store personal prompts, account identifiers, or sensitive query context.",
+    "Do not convert unavailable data to zero or estimate it from unrelated public results.",
+    "Do not expand the content corpus solely because an SEO vendor assigns a score.",
+    "Use UTM fields for internal acquisition attribution; ref= remains affiliate attribution."
+  ]
+}

--- a/docs/research/seo-ai-visibility/baselines/2026-07-27.json
+++ b/docs/research/seo-ai-visibility/baselines/2026-07-27.json
@@ -2,6 +2,7 @@
   "schemaVersion": 1,
   "baselineId": "2026-07-27",
   "querySetId": "seo-ai-visibility-v1",
+  "querySetDigest": "sha256:b31f4c299f414d1ffe889d1a3cdbb8614e45bf1f91e79380f89b3f1061de3f39",
   "observedAt": "2026-07-27T17:15:05Z",
   "repositoryRevision": "902b108f8239dce64f5577e366da0858cdaf17db",
   "collectionContext": {

--- a/docs/research/seo-ai-visibility/query-set.json
+++ b/docs/research/seo-ai-visibility/query-set.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "querySetId": "seo-ai-visibility-v1",
+  "reviewedAt": "2026-07-27",
+  "reviewNotes": "Twenty-five English-language decision queries reviewed against World Monitor's current page families. Reference entities are comparison candidates or primary sources to inspect; their inclusion is not an endorsement or a ranking claim.",
+  "queries": [
+    {
+      "id": "q01",
+      "query": "best real-time global intelligence dashboard for geopolitical risk monitoring",
+      "intent": "category_definition",
+      "targetAudience": "Security analysts and cross-domain risk teams",
+      "targetPage": {
+        "family": "homepage",
+        "url": "https://www.worldmonitor.app/"
+      },
+      "conversionGoal": "Launch the dashboard",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Dataminr",
+          "url": "https://www.dataminr.com/"
+        },
+        {
+          "role": "competitor",
+          "name": "Recorded Future",
+          "url": "https://www.recordedfuture.com/"
+        }
+      ]
+    },
+    {
+      "id": "q02",
+      "query": "open-source OSINT dashboard for global events",
+      "intent": "category_definition",
+      "targetAudience": "OSINT practitioners, journalists, and researchers",
+      "targetPage": {
+        "family": "dashboard",
+        "url": "https://www.worldmonitor.app/dashboard"
+      },
+      "conversionGoal": "Open the live map and inspect a source",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Liveuamap",
+          "url": "https://liveuamap.com/"
+        },
+        {
+          "role": "source",
+          "name": "GDELT Project",
+          "url": "https://www.gdeltproject.org/"
+        }
+      ]
+    },
+    {
+      "id": "q03",
+      "query": "what is a global intelligence dashboard",
+      "intent": "category_definition",
+      "targetAudience": "New evaluators and non-specialist decision-makers",
+      "targetPage": {
+        "family": "blog",
+        "url": "https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/"
+      },
+      "conversionGoal": "Continue from the explainer to the dashboard",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "BlackRock Geopolitical Risk Dashboard",
+          "url": "https://www.blackrock.com/corporate/insights/blackrock-investment-institute/interactive-charts/geopolitical-risk-dashboard"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor GitHub repository",
+          "url": "https://github.com/koala73/worldmonitor"
+        }
+      ]
+    },
+    {
+      "id": "q04",
+      "query": "real-time situational awareness map for conflicts shipping and markets",
+      "intent": "category_definition",
+      "targetAudience": "Operations and crisis-management teams",
+      "targetPage": {
+        "family": "homepage",
+        "url": "https://www.worldmonitor.app/"
+      },
+      "conversionGoal": "Launch the dashboard with relevant layers",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "ACLED Explorer",
+          "url": "https://acleddata.com/explorer/"
+        },
+        {
+          "role": "competitor",
+          "name": "MarineTraffic",
+          "url": "https://www.marinetraffic.com/"
+        }
+      ]
+    },
+    {
+      "id": "q05",
+      "query": "geopolitical monitoring methodology and data sources",
+      "intent": "category_definition",
+      "targetAudience": "Analysts validating provenance and methodology",
+      "targetPage": {
+        "family": "documentation",
+        "url": "https://www.worldmonitor.app/docs/data-sources"
+      },
+      "conversionGoal": "Review methodology and source documentation",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "ACLED methodology",
+          "url": "https://acleddata.com/methodology/"
+        },
+        {
+          "role": "source",
+          "name": "UCDP methodology",
+          "url": "https://ucdp.uu.se/methodology"
+        }
+      ]
+    },
+    {
+      "id": "q06",
+      "query": "country risk monitoring dashboard for analysts",
+      "intent": "use_case",
+      "targetAudience": "Country-risk, macro, and supply-chain analysts",
+      "targetPage": {
+        "family": "country_pages",
+        "url": "https://www.worldmonitor.app/countries/"
+      },
+      "conversionGoal": "Open a country page and continue into the dashboard",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "S&P Global Country Risk",
+          "url": "https://www.spglobal.com/market-intelligence/en/solutions/products/country-risk"
+        },
+        {
+          "role": "source",
+          "name": "World Bank Worldwide Governance Indicators",
+          "url": "https://www.worldbank.org/en/publication/worldwide-governance-indicators"
+        }
+      ]
+    },
+    {
+      "id": "q07",
+      "query": "Strait of Hormuz live traffic and disruption tracker",
+      "intent": "use_case",
+      "targetAudience": "Energy traders, maritime analysts, and logistics teams",
+      "targetPage": {
+        "family": "chokepoints",
+        "url": "https://www.worldmonitor.app/chokepoints/"
+      },
+      "conversionGoal": "Inspect live chokepoint status and open the dashboard",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "MarineTraffic",
+          "url": "https://www.marinetraffic.com/"
+        },
+        {
+          "role": "source",
+          "name": "IMF PortWatch",
+          "url": "https://portwatch.imf.org/"
+        }
+      ]
+    },
+    {
+      "id": "q08",
+      "query": "live geopolitical crisis tracker with sources",
+      "intent": "use_case",
+      "targetAudience": "Newsrooms, researchers, and crisis-response teams",
+      "targetPage": {
+        "family": "crises",
+        "url": "https://www.worldmonitor.app/crises/"
+      },
+      "conversionGoal": "Open a bounded crisis tracker and verify its sources",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "International Crisis Group CrisisWatch",
+          "url": "https://www.crisisgroup.org/crisiswatch"
+        },
+        {
+          "role": "competitor",
+          "name": "Liveuamap",
+          "url": "https://liveuamap.com/"
+        }
+      ]
+    },
+    {
+      "id": "q09",
+      "query": "airspace disruption checker for security teams",
+      "intent": "use_case",
+      "targetAudience": "Travel-security, aviation, and duty-of-care teams",
+      "targetPage": {
+        "family": "tools",
+        "url": "https://www.worldmonitor.app/tools/airspace-disruption-checker/"
+      },
+      "conversionGoal": "Run the checker and open the aviation dashboard context",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Flightradar24",
+          "url": "https://www.flightradar24.com/"
+        },
+        {
+          "role": "source",
+          "name": "OpenSky Network",
+          "url": "https://opensky-network.org/"
+        }
+      ]
+    },
+    {
+      "id": "q10",
+      "query": "supply-chain early warning dashboard for chokepoints and country risk",
+      "intent": "use_case",
+      "targetAudience": "Procurement, logistics, and supply-chain risk teams",
+      "targetPage": {
+        "family": "blog",
+        "url": "https://www.worldmonitor.app/blog/posts/supply-chain-early-warning-dashboard-worldmonitor-api/"
+      },
+      "conversionGoal": "Review the workflow and start an API or dashboard path",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Everstream Analytics",
+          "url": "https://www.everstream.ai/"
+        },
+        {
+          "role": "competitor",
+          "name": "Interos",
+          "url": "https://www.interos.ai/"
+        }
+      ]
+    },
+    {
+      "id": "q11",
+      "query": "geopolitical risk API with real-time global data",
+      "intent": "developer_agent",
+      "targetAudience": "Developers building risk and monitoring products",
+      "targetPage": {
+        "family": "developer_mcp",
+        "url": "https://www.worldmonitor.app/docs/api-reference"
+      },
+      "conversionGoal": "Review the API reference and pricing",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "GDELT API documentation",
+          "url": "https://www.gdeltproject.org/data.html"
+        },
+        {
+          "role": "source",
+          "name": "ACLED API documentation",
+          "url": "https://acleddata.com/acleddatanew/wp-content/uploads/dlm_uploads/2024/03/API-Documentation.pdf"
+        }
+      ]
+    },
+    {
+      "id": "q12",
+      "query": "MCP server for live geopolitical intelligence",
+      "intent": "developer_agent",
+      "targetAudience": "AI-agent developers and MCP client users",
+      "targetPage": {
+        "family": "developer_mcp",
+        "url": "https://www.worldmonitor.app/docs/mcp-overview"
+      },
+      "conversionGoal": "Connect an MCP client",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "Model Context Protocol",
+          "url": "https://modelcontextprotocol.io/"
+        },
+        {
+          "role": "source",
+          "name": "Anthropic MCP documentation",
+          "url": "https://docs.anthropic.com/en/docs/agents-and-tools/mcp"
+        }
+      ]
+    },
+    {
+      "id": "q13",
+      "query": "build a geopolitical risk agent with live world data",
+      "intent": "developer_agent",
+      "targetAudience": "Agent engineers and technical analysts",
+      "targetPage": {
+        "family": "blog",
+        "url": "https://www.worldmonitor.app/blog/posts/build-geopolitical-risk-agent-worldmonitor-mcp/"
+      },
+      "conversionGoal": "Follow the tutorial and connect MCP",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "OpenAI agents documentation",
+          "url": "https://platform.openai.com/docs/guides/agents"
+        },
+        {
+          "role": "source",
+          "name": "Anthropic tool use documentation",
+          "url": "https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview"
+        }
+      ]
+    },
+    {
+      "id": "q14",
+      "query": "REST API for conflicts markets shipping and aviation data",
+      "intent": "developer_agent",
+      "targetAudience": "Data engineers and application developers",
+      "targetPage": {
+        "family": "documentation",
+        "url": "https://www.worldmonitor.app/docs/api-reference"
+      },
+      "conversionGoal": "Inspect endpoint coverage and create an API integration",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "OpenSky Network API",
+          "url": "https://openskynetwork.github.io/opensky-api/"
+        },
+        {
+          "role": "source",
+          "name": "USGS Earthquake API",
+          "url": "https://earthquake.usgs.gov/fdsnws/event/1/"
+        }
+      ]
+    },
+    {
+      "id": "q15",
+      "query": "give Claude or GPT real-time geopolitical context",
+      "intent": "developer_agent",
+      "targetAudience": "AI product teams and advanced assistant users",
+      "targetPage": {
+        "family": "developer_mcp",
+        "url": "https://www.worldmonitor.app/docs/mcp-quickstart"
+      },
+      "conversionGoal": "Connect an assistant through MCP",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "OpenAI MCP documentation",
+          "url": "https://platform.openai.com/docs/mcp"
+        },
+        {
+          "role": "source",
+          "name": "Anthropic MCP documentation",
+          "url": "https://docs.anthropic.com/en/docs/agents-and-tools/mcp"
+        }
+      ]
+    },
+    {
+      "id": "q16",
+      "query": "free vs paid real-time intelligence dashboard",
+      "intent": "evaluation",
+      "targetAudience": "Individual analysts comparing free and paid options",
+      "targetPage": {
+        "family": "pricing",
+        "url": "https://www.worldmonitor.app/pro#pricing"
+      },
+      "conversionGoal": "Review plans and start a Pro checkout",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Dataminr",
+          "url": "https://www.dataminr.com/"
+        },
+        {
+          "role": "competitor",
+          "name": "Palantir",
+          "url": "https://www.palantir.com/"
+        }
+      ]
+    },
+    {
+      "id": "q17",
+      "query": "World Monitor alternatives for geopolitical intelligence",
+      "intent": "evaluation",
+      "targetAudience": "Buyers shortlisting intelligence platforms",
+      "targetPage": {
+        "family": "blog",
+        "url": "https://www.worldmonitor.app/blog/posts/worldmonitor-vs-traditional-intelligence-tools/"
+      },
+      "conversionGoal": "Compare fit and continue to the appropriate product tier",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Recorded Future",
+          "url": "https://www.recordedfuture.com/"
+        },
+        {
+          "role": "competitor",
+          "name": "Janes",
+          "url": "https://www.janes.com/"
+        }
+      ]
+    },
+    {
+      "id": "q18",
+      "query": "World Monitor vs GDELT",
+      "intent": "evaluation",
+      "targetAudience": "Researchers and developers choosing data workflows",
+      "targetPage": {
+        "family": "documentation",
+        "url": "https://www.worldmonitor.app/docs/data-sources"
+      },
+      "conversionGoal": "Understand source composition and inspect the API",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "GDELT Project",
+          "url": "https://www.gdeltproject.org/"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor source catalog",
+          "url": "https://www.worldmonitor.app/docs/data-sources"
+        }
+      ]
+    },
+    {
+      "id": "q19",
+      "query": "World Monitor vs Liveuamap",
+      "intent": "evaluation",
+      "targetAudience": "News, OSINT, and security analysts",
+      "targetPage": {
+        "family": "dashboard",
+        "url": "https://www.worldmonitor.app/dashboard"
+      },
+      "conversionGoal": "Evaluate the live dashboard using a current event",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "Liveuamap",
+          "url": "https://liveuamap.com/"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor GitHub repository",
+          "url": "https://github.com/koala73/worldmonitor"
+        }
+      ]
+    },
+    {
+      "id": "q20",
+      "query": "geopolitical intelligence platform pricing for individual analysts",
+      "intent": "evaluation",
+      "targetAudience": "Independent analysts, researchers, and consultants",
+      "targetPage": {
+        "family": "pricing",
+        "url": "https://www.worldmonitor.app/pro#pricing"
+      },
+      "conversionGoal": "Select an individual plan or remain on the free tier",
+      "referenceEntities": [
+        {
+          "role": "competitor",
+          "name": "S&P Global Market Intelligence",
+          "url": "https://www.spglobal.com/market-intelligence/en"
+        },
+        {
+          "role": "competitor",
+          "name": "Recorded Future",
+          "url": "https://www.recordedfuture.com/"
+        }
+      ]
+    },
+    {
+      "id": "q21",
+      "query": "World Monitor capabilities",
+      "intent": "branded_entity",
+      "targetAudience": "Prospective users checking product scope",
+      "targetPage": {
+        "family": "homepage",
+        "url": "https://www.worldmonitor.app/"
+      },
+      "conversionGoal": "Launch the dashboard or choose a focused variant",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "World Monitor product reference",
+          "url": "https://www.worldmonitor.app/llms.txt"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor GitHub repository",
+          "url": "https://github.com/koala73/worldmonitor"
+        }
+      ]
+    },
+    {
+      "id": "q22",
+      "query": "World Monitor data sources and methodology",
+      "intent": "branded_entity",
+      "targetAudience": "Analysts performing source due diligence",
+      "targetPage": {
+        "family": "documentation",
+        "url": "https://www.worldmonitor.app/docs/data-sources"
+      },
+      "conversionGoal": "Validate provenance and continue to a methodology page",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "World Monitor data-source catalog",
+          "url": "https://www.worldmonitor.app/docs/data-sources"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor health endpoint documentation",
+          "url": "https://www.worldmonitor.app/docs/health-endpoints"
+        }
+      ]
+    },
+    {
+      "id": "q23",
+      "query": "World Monitor pricing",
+      "intent": "branded_entity",
+      "targetAudience": "Users evaluating paid access",
+      "targetPage": {
+        "family": "pricing",
+        "url": "https://www.worldmonitor.app/pro#pricing"
+      },
+      "conversionGoal": "View current pricing and start checkout",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "World Monitor pricing reference",
+          "url": "https://www.worldmonitor.app/pricing.md"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor Pro page",
+          "url": "https://www.worldmonitor.app/pro#pricing"
+        }
+      ]
+    },
+    {
+      "id": "q24",
+      "query": "World Monitor MCP access",
+      "intent": "branded_entity",
+      "targetAudience": "Developers and assistant users checking MCP access",
+      "targetPage": {
+        "family": "developer_mcp",
+        "url": "https://www.worldmonitor.app/docs/mcp-overview"
+      },
+      "conversionGoal": "Review access requirements and connect a client",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "World Monitor MCP server reference",
+          "url": "https://www.worldmonitor.app/mcp-server.md"
+        },
+        {
+          "role": "source",
+          "name": "Model Context Protocol",
+          "url": "https://modelcontextprotocol.io/"
+        }
+      ]
+    },
+    {
+      "id": "q25",
+      "query": "how fresh is World Monitor data",
+      "intent": "branded_entity",
+      "targetAudience": "Analysts validating operational freshness",
+      "targetPage": {
+        "family": "crises",
+        "url": "https://www.worldmonitor.app/crises/"
+      },
+      "conversionGoal": "Inspect source health and open a live crisis view",
+      "referenceEntities": [
+        {
+          "role": "source",
+          "name": "World Monitor health endpoint documentation",
+          "url": "https://www.worldmonitor.app/docs/health-endpoints"
+        },
+        {
+          "role": "source",
+          "name": "World Monitor compact health API",
+          "url": "https://www.worldmonitor.app/api/health?compact=1"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/research/seo-ai-visibility/scorecards/2026-07-27.md
+++ b/docs/research/seo-ai-visibility/scorecards/2026-07-27.md
@@ -1,0 +1,171 @@
+# SEO and AI-citation visibility scorecard — 2026-07-27
+
+Generated from repository revision `902b108f8239dce64f5577e366da0858cdaf17db` at
+`2026-07-27T17:15:05Z`. Missing provider data is reported as unavailable,
+never coerced to zero.
+
+## Collection context
+
+- Geography: France
+- Locale: en
+- Signed-in state: signed-out / signed-in
+- Device: desktop web
+- Limitations: Google Search Console, Bing Webmaster, and analytics exports were not available in this clean worktree because no read-only credentials or exported reports were provided. The manual AI audit is an initial four-platform sample for q01, not a population estimate across all 25 queries. Google results were signed-in and personalized; the other three observations were signed-out. Model names were not exposed consistently by the anonymous/search surfaces, so the platform and observation time are recorded without inventing a model identifier.
+
+## Data availability
+
+| Source | Status | Windows |
+| --- | --- | --- |
+| Google Search Console | Unavailable — No supported Search Console export or read-only property credential was available. Values remain null rather than being estimated from public result pages. | 28d, 90d |
+| Bing Webmaster | Unavailable — No Bing Webmaster export or property access was available. IndexNow support does not substitute for Bing query and click reporting. | 28d, 90d |
+| Referral analytics | Unavailable — The Umami/commerce aggregates were not exported into this clean environment. Existing event names are documented for the next read-only reconciliation, but no session or conversion count is inferred. | 28d, 90d |
+
+| AI surface | Status |
+| --- | --- |
+| ChatGPT Search | Available |
+| Perplexity | Available |
+| Google AI Overview | Available |
+| Copilot Search | Available |
+
+Referral families: ChatGPT, Perplexity, Google Search / AI, Copilot / Bing, Claude, Other identified AI/search, Unknown / direct.
+
+## Query registry
+
+25 reviewed queries, split by decision intent and target page family.
+
+| Intent | Queries | GSC query performance | Bing query performance | AI observations | Mention rate | Direct-citation rate |
+| --- | ---: | --- | --- | ---: | ---: | ---: |
+| Category / definition | 5 | Unavailable | Unavailable | 4/20 | 100% | 75% |
+| Use case | 5 | Unavailable | Unavailable | 0/20 | Unavailable | Unavailable |
+| Developer / agent | 5 | Unavailable | Unavailable | 0/20 | Unavailable | Unavailable |
+| Evaluation | 5 | Unavailable | Unavailable | 0/20 | Unavailable | Unavailable |
+| Branded / entity | 5 | Unavailable | Unavailable | 0/20 | Unavailable | Unavailable |
+
+| Page family | Queries | GSC page performance | Bing page performance | AI observations | Mention rate | Direct-citation rate |
+| --- | ---: | --- | --- | ---: | ---: | ---: |
+| Homepage | 3 | Unavailable | Unavailable | 4/12 | 100% | 75% |
+| Dashboard | 2 | Unavailable | Unavailable | 0/8 | Unavailable | Unavailable |
+| Blog | 4 | Unavailable | Unavailable | 0/16 | Unavailable | Unavailable |
+| Documentation | 4 | Unavailable | Unavailable | 0/16 | Unavailable | Unavailable |
+| Country pages | 1 | Unavailable | Unavailable | 0/4 | Unavailable | Unavailable |
+| Chokepoints | 1 | Unavailable | Unavailable | 0/4 | Unavailable | Unavailable |
+| Crises | 2 | Unavailable | Unavailable | 0/8 | Unavailable | Unavailable |
+| Tools | 1 | Unavailable | Unavailable | 0/4 | Unavailable | Unavailable |
+| Pricing | 3 | Unavailable | Unavailable | 0/12 | Unavailable | Unavailable |
+| Developer / MCP | 4 | Unavailable | Unavailable | 0/16 | Unavailable | Unavailable |
+
+## Referral and product outcomes
+
+Referral segments retain both the major referrer family and landing-page family.
+Unavailable aggregates remain unavailable in every slice.
+
+| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| ChatGPT | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Perplexity | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Google Search / AI | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Copilot / Bing | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Claude | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Other identified AI/search | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Unknown / direct | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+
+| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Homepage | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Dashboard | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Blog | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Documentation | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Country pages | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Chokepoints | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Crises | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Tools | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Pricing | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Developer / MCP | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+
+## AI-answer audit
+
+Coverage: 4/100 (4%).
+Full target matrix: 100 query/platform pairs.
+Observed mention rate: 100%.
+Observed direct-citation rate: 75%.
+These are descriptive observations, not causal or population-level estimates.
+
+| Platform | Brand | Citation | Sentiment | Accuracy | Cited URLs |
+| --- | --- | --- | --- | --- | --- |
+| ChatGPT Search | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/?utm_source=chatgpt.com), [link](https://gridline.world/?utm_source=chatgpt.com) |
+| Perplexity | Mention | No direct citation | positive | mixed | [link](https://utilo.io/fr/home/tools/V0K-Vu7bhLfEs-k_47vUTuSYd71) |
+| Google AI Overview | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/), [link](https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/), [link](https://www.nexusai-tech.com/ai-apps/world-monitor-ai-global-intelligence-and-real-time-osint-dashboard) |
+| Copilot Search | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/), [link](https://github.com/koala73/worldmonitor), [link](https://www.worldmonitor.io/) |
+
+### Accuracy and entity risks
+
+- ChatGPT Search / q01: Named World Monitor the best all-around open OSINT dashboard and linked the homepage directly. The answer also made broad numeric and adoption claims that require recurring source-of-truth review before they are treated as accurate product facts.
+- Perplexity / q01: Called World Monitor the strongest free single pick, but supported the claim with a third-party directory rather than a World Monitor URL. Its 435+ sources and 45+ layer counts need fact review.
+- Google AI Overview / q01: The AI Overview called World Monitor the leading open-source geopolitical dashboard and cited the homepage plus the first-party explainer. It also used subjective ranking language and mutable provider-count claims that should remain dated and reviewable.
+- Copilot Search / q01: Presented World Monitor as the most comprehensive current option and cited the homepage and repository. The answer mixed first-party and similarly named third-party domains and included mutable layer, provider, SDK, and feature counts that require correction monitoring.
+
+## Monthly comparison
+
+First recorded period; no previous baseline was supplied. The next run should
+pass `--previous <baseline.json>` to report new/lost citations, meaningful
+search and CTR changes, referral movement, and entity-answer risks.
+
+## Top five opportunities
+
+### 1. Complete credentialed search and referral exports
+
+- Evidence: Search Console, Bing Webmaster, and referral/conversion metrics are unavailable, so the baseline cannot yet size demand, indexation health, CTR, or downstream conversion.
+- Experiment: Provide a supported 28-day and 90-day Search Console export, a Bing export where property access exists, and read-only aggregate analytics grouped by bounded referrer and page family.
+- Success criteria: The next scorecard contains non-null provider metrics reconciled to their source exports, with no credentials or property identifiers committed.
+- Query IDs: q01, q06, q11, q16, q21
+
+### 2. Expand the four-platform audit from one query to the reviewed panel
+
+- Evidence: All four named AI/search surfaces were observed for q01, but overall coverage is only 4 of 100 possible query-platform observations.
+- Experiment: Run the unchanged 25-query panel on the documented geography, locale, and signed-in schedule, prioritizing five queries per weekly pass.
+- Success criteria: Every query has one observation on each required platform, and missing surfaces carry an explicit platform limitation rather than a zero.
+- Query IDs: q01, q07, q11, q16, q21
+
+### 3. Correct and centralize AI-surfaced product facts
+
+- Evidence: The four answers used conflicting source, feed, layer, adoption, SDK, and feature counts; all were therefore marked mixed accuracy even when they cited World Monitor.
+- Experiment: Audit the cited homepage, explainer, pricing, machine-readable product files, and repository description against the canonical product-fact source before the next observation window.
+- Success criteria: Repeated answers cite first-party pages with current, mutually consistent facts; mixed/inaccurate entity-answer observations decline without rewriting history.
+- Query IDs: q01, q21, q22, q23, q25
+
+### 4. Earn a first-party Perplexity citation for the category query
+
+- Evidence: Perplexity mentioned World Monitor positively but cited only a third-party directory, while ChatGPT, Google AI, and Copilot linked first-party pages.
+- Experiment: Improve the first-party category explainer's dated evidence, visible source links, entity clarity, and internal path from homepage to explainer; then rerun q01 unchanged.
+- Success criteria: Perplexity links a worldmonitor.app URL directly for q01 without paid placement, reciprocal-link manipulation, or a claim-only content rewrite.
+- Query IDs: q01, q03, q17
+
+### 5. Gate new content on measured developer and use-case demand
+
+- Evidence: The reviewed set covers developer/MCP, chokepoint, country-risk, crisis, airspace, and supply-chain intents, but no credentialed impression, engagement, or conversion data is available yet.
+- Experiment: After exports arrive, rank q06-q15 by impressions, indexation health, qualified engagement, and credible product handoff; choose at most one evidence-rich report or page-family experiment.
+- Success criteria: A new page or report proceeds only when demand, healthy indexation, useful engagement, and an intent-matched dashboard/API/MCP conversion path are all evidenced.
+- Query IDs: q06, q07, q08, q09, q10, q11, q12, q13, q14, q15
+
+## Reproduction contract
+
+1. Use the same query text from `query-set.json`; do not paraphrase between platforms.
+2. Record UTC date/time, country-level geography, locale, device, and whether the
+   surface was signed-out or signed-in. Do not record account identifiers or prompts
+   unrelated to this reviewed query set.
+3. Count a direct citation only when the answer links to a `worldmonitor.app` URL.
+   A mention supported only by a directory, review, or social post is not a direct citation.
+4. Export Search Console/Bing data through supported product exports or APIs. Do not
+   scrape search-result pages or commit property IDs, tokens, or credentials.
+5. Reconcile referral aggregates with the analytics provider and keep prompt text out
+   of analytics. Use bounded source/page-family fields and existing UTM attribution.
+
+## Guardrails
+
+- Do not automate unauthorized search-result scraping.
+- Do not treat an AI mention without a worldmonitor.app source link as a direct citation.
+- Do not claim causal uplift from a single observation.
+- Do not store personal prompts, account identifiers, or sensitive query context.
+- Do not convert unavailable data to zero or estimate it from unrelated public results.
+- Do not expand the content corpus solely because an SEO vendor assigns a score.
+- Use UTM fields for internal acquisition attribution; ref= remains affiliate attribution.

--- a/docs/research/seo-ai-visibility/scorecards/2026-07-27.md
+++ b/docs/research/seo-ai-visibility/scorecards/2026-07-27.md
@@ -3,6 +3,7 @@
 Generated from repository revision `902b108f8239dce64f5577e366da0858cdaf17db` at
 `2026-07-27T17:15:05Z`. Missing provider data is reported as unavailable,
 never coerced to zero.
+Query contract: `seo-ai-visibility-v1` / `sha256:b31f4c299f414d1ffe889d1a3cdbb8614e45bf1f91e79380f89b3f1061de3f39`.
 
 ## Collection context
 
@@ -90,12 +91,12 @@ Observed mention rate: 100%.
 Observed direct-citation rate: 75%.
 These are descriptive observations, not causal or population-level estimates.
 
-| Platform | Brand | Citation | Sentiment | Accuracy | Cited URLs |
-| --- | --- | --- | --- | --- | --- |
-| ChatGPT Search | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/?utm_source=chatgpt.com), [link](https://gridline.world/?utm_source=chatgpt.com) |
-| Perplexity | Mention | No direct citation | positive | mixed | [link](https://utilo.io/fr/home/tools/V0K-Vu7bhLfEs-k_47vUTuSYd71) |
-| Google AI Overview | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/), [link](https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/), [link](https://www.nexusai-tech.com/ai-apps/world-monitor-ai-global-intelligence-and-real-time-osint-dashboard) |
-| Copilot Search | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/), [link](https://github.com/koala73/worldmonitor), [link](https://www.worldmonitor.io/) |
+| Query | Platform | Observed at (UTC) | Context | Brand | Citation | Sentiment | Accuracy | Cited URLs |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| q01 | ChatGPT Search | 2026-07-27T17:10:00Z | France / en / signed-out | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/?utm_source=chatgpt.com), [link](https://gridline.world/?utm_source=chatgpt.com) |
+| q01 | Perplexity | 2026-07-27T17:11:00Z | France / en / signed-out | Mention | No direct citation | positive | mixed | [link](https://utilo.io/fr/home/tools/V0K-Vu7bhLfEs-k_47vUTuSYd71) |
+| q01 | Google AI Overview | 2026-07-27T17:12:00Z | France / en / signed-in | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/), [link](https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/), [link](https://www.nexusai-tech.com/ai-apps/world-monitor-ai-global-intelligence-and-real-time-osint-dashboard) |
+| q01 | Copilot Search | 2026-07-27T17:13:00Z | France / en / signed-out | Mention | Direct citation | positive | mixed | [link](https://www.worldmonitor.app/), [link](https://github.com/koala73/worldmonitor), [link](https://www.worldmonitor.io/) |
 
 ### Accuracy and entity risks
 

--- a/scripts/audit-china-decision-parity.mjs
+++ b/scripts/audit-china-decision-parity.mjs
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
 
-import { readFileSync, realpathSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import {
   arrayLiteralHasStringMember,
   extractDelimitedBlock,
   objectLiteralEntryValue,
 } from './lib/js-source-structure.mjs';
+import { isMainModule } from './lib/main-module.mjs';
 import { readChinaDecisionSignalWireContract } from './lib/openapi-codegen.mjs';
 import { validateChinaDecisionSignalSnapshot } from './seed-china-decision-signals.mjs';
+
+export { isMainModule } from './lib/main-module.mjs';
 
 const wireContract = readChinaDecisionSignalWireContract();
 export const CHINA_DECISION_PARITY_MANIFEST = Object.freeze(
@@ -502,38 +505,6 @@ async function main() {
   const result = { static: staticAudit, ...(live ? { live } : {}) };
   console.log(JSON.stringify(result, null, 2));
   process.exitCode = resolveChinaParityExitCode({ staticOk: staticAudit.ok, live, requireLive });
-}
-
-/**
- * Report whether `moduleUrl` is the entrypoint the process was started with.
- *
- * Both sides are resolved through `realpathSync` first. Node sets
- * `import.meta.url` to the real path while `process.argv[1]` keeps whatever
- * path the caller typed, so the naive comparison silently no-ops — exit 0, zero
- * output — whenever the checkout is reached through a symlink (`/tmp` ->
- * `/private/tmp` on macOS is the common one). For an audit that is the worst
- * possible failure: it looks exactly like a clean run.
- *
- * @param {string} moduleUrl
- * @param {string | undefined} argv1
- * @returns {boolean}
- */
-export function isMainModule(moduleUrl, argv1) {
-  if (!argv1) return false;
-  try {
-    return pathToFileURL(realpathSync(fileURLToPath(moduleUrl))).href
-      === pathToFileURL(realpathSync(argv1)).href;
-  } catch {
-    // Degrade to the plain comparison rather than answering `false`: a throw
-    // here (an unresolvable path, a permission error) must not put the audit
-    // back to exiting 0 with no output, which is the silent no-op this
-    // function exists to prevent.
-    try {
-      return moduleUrl === pathToFileURL(argv1).href;
-    } catch {
-      return false;
-    }
-  }
 }
 
 if (isMainModule(import.meta.url, process.argv[1])) {

--- a/scripts/lib/main-module.mjs
+++ b/scripts/lib/main-module.mjs
@@ -1,0 +1,23 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/**
+ * Report whether `moduleUrl` is the entrypoint the process was started with.
+ *
+ * Resolve both sides through their real paths first because Node resolves
+ * `import.meta.url` while `process.argv[1]` preserves a caller-supplied symlink.
+ * Fall back to a plain URL comparison when either path cannot be resolved.
+ */
+export function isMainModule(moduleUrl, argv1) {
+  if (!argv1) return false;
+  try {
+    return pathToFileURL(realpathSync(fileURLToPath(moduleUrl))).href
+      === pathToFileURL(realpathSync(argv1)).href;
+  } catch {
+    try {
+      return moduleUrl === pathToFileURL(argv1).href;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/scripts/lib/main-module.mjs
+++ b/scripts/lib/main-module.mjs
@@ -4,9 +4,12 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 /**
  * Report whether `moduleUrl` is the entrypoint the process was started with.
  *
- * Resolve both sides through their real paths first because Node resolves
- * `import.meta.url` while `process.argv[1]` preserves a caller-supplied symlink.
- * Fall back to a plain URL comparison when either path cannot be resolved.
+ * Both sides are resolved through `realpathSync` first. Node sets
+ * `import.meta.url` to the real path while `process.argv[1]` keeps whatever
+ * path the caller typed, so the naive comparison silently no-ops — exit 0, zero
+ * output — whenever the checkout is reached through a symlink (`/tmp` ->
+ * `/private/tmp` on macOS is the common one). For an audit or gate that is the
+ * worst possible failure: it looks exactly like a clean run.
  */
 export function isMainModule(moduleUrl, argv1) {
   if (!argv1) return false;
@@ -14,6 +17,10 @@ export function isMainModule(moduleUrl, argv1) {
     return pathToFileURL(realpathSync(fileURLToPath(moduleUrl))).href
       === pathToFileURL(realpathSync(argv1)).href;
   } catch {
+    // Degrade to the plain comparison rather than answering `false`: a throw
+    // here (an unresolvable path, a permission error) must not put the caller
+    // back to exiting 0 with no output, which is the silent no-op this
+    // function exists to prevent.
     try {
       return moduleUrl === pathToFileURL(argv1).href;
     } catch {

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -159,6 +159,29 @@ function validateWindowedSource(source, metricNames, label) {
     invariant(isNonEmptyString(window.label), `${windowLabel}.label is required`);
     assertIsoDate(window.startDate, `${windowLabel}.startDate`);
     assertIsoDate(window.endDate, `${windowLabel}.endDate`);
+    const start = Date.parse(window.startDate);
+    const end = Date.parse(window.endDate);
+    invariant(start <= end, `${windowLabel}.startDate must not be after endDate`);
+    const numericLabel = /^(\d+)d$/.exec(window.label);
+    if (numericLabel) {
+      const startDate = new Date(start);
+      const endDate = new Date(end);
+      const startDay = Date.UTC(
+        startDate.getUTCFullYear(),
+        startDate.getUTCMonth(),
+        startDate.getUTCDate(),
+      );
+      const endDay = Date.UTC(
+        endDate.getUTCFullYear(),
+        endDate.getUTCMonth(),
+        endDate.getUTCDate(),
+      );
+      const inclusiveDays = ((endDay - startDay) / 86_400_000) + 1;
+      invariant(
+        Number(numericLabel[1]) === inclusiveDays,
+        `${windowLabel}.label must match the inclusive calendar-day span`,
+      );
+    }
     assertNullableMetrics(window.metrics, metricNames, windowLabel, source.status);
   }
 }
@@ -768,12 +791,14 @@ function compareWindowedSource(previous, current, metricNames) {
   ) {
     return null;
   }
-  const currentWindow = current.windows.find(
-    (window) => window.label === previous.windows[0].label,
-  ) ?? current.windows[0];
+  const currentWindowsByLabel = new Map(
+    current.windows.map((window) => [window.label, window]),
+  );
   const previousWindow = previous.windows.find(
-    (window) => window.label === currentWindow.label,
-  ) ?? previous.windows[0];
+    (window) => currentWindowsByLabel.has(window.label),
+  );
+  if (!previousWindow) return null;
+  const currentWindow = currentWindowsByLabel.get(previousWindow.label);
   return Object.fromEntries(
     metricNames.map((metric) => [
       metric,

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -794,17 +794,24 @@ function compareWindowedSource(previous, current, metricNames) {
   const currentWindowsByLabel = new Map(
     current.windows.map((window) => [window.label, window]),
   );
-  const previousWindow = previous.windows.find(
+  const sharedWindows = previous.windows.filter(
     (window) => currentWindowsByLabel.has(window.label),
   );
-  if (!previousWindow) return null;
+  if (sharedWindows.length === 0) return null;
+  // Single-window comparison: prefer the canonical 28d label (mirroring
+  // preferredWindow) so selection never depends on authored window order.
+  const previousWindow = sharedWindows.find(({ label }) => label === '28d')
+    ?? sharedWindows[0];
   const currentWindow = currentWindowsByLabel.get(previousWindow.label);
-  return Object.fromEntries(
-    metricNames.map((metric) => [
-      metric,
-      metricDelta(previousWindow, currentWindow, metric),
-    ]),
-  );
+  return {
+    windowLabel: previousWindow.label,
+    metrics: Object.fromEntries(
+      metricNames.map((metric) => [
+        metric,
+        metricDelta(previousWindow, currentWindow, metric),
+      ]),
+    ),
+  };
 }
 
 export function compareScorecards(previous, current) {
@@ -910,6 +917,19 @@ function referralMetricCell(source, metric) {
   return value === null ? 'Unavailable' : value;
 }
 
+function formatReferralRow(label, source) {
+  const cells = REFERRAL_METRICS.map((metric) => referralMetricCell(source, metric));
+  return `| ${label} | ${cells.join(' | ')} |`;
+}
+
+function markdownLink(url) {
+  const target = url
+    .replaceAll('(', '%28')
+    .replaceAll(')', '%29')
+    .replaceAll(' ', '%20');
+  return `[link](${target})`;
+}
+
 function formatComparison(comparison) {
   if (!comparison) {
     return [
@@ -926,25 +946,27 @@ function formatComparison(comparison) {
   );
   const meaningfulSearch = [];
   const indexingRegressions = [];
-  for (const [provider, metrics] of Object.entries(comparison.search)) {
-    if (!metrics) continue;
+  for (const [provider, windowComparison] of Object.entries(comparison.search)) {
+    if (!windowComparison) continue;
+    const { windowLabel, metrics } = windowComparison;
     for (const [metric, delta] of Object.entries(metrics)) {
       if (delta?.meaningful) {
         meaningfulSearch.push(
-          `${provider}.${metric}: ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`,
+          `${provider}.${metric} (${windowLabel}): ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`,
         );
       }
     }
     if (metrics.indexedPages?.meaningful && metrics.indexedPages.absolute < 0) {
       indexingRegressions.push(
-        `${provider}: ${metrics.indexedPages.before} → ${metrics.indexedPages.after}`,
+        `${provider} (${windowLabel}): ${metrics.indexedPages.before} → ${metrics.indexedPages.after}`,
       );
     }
   }
-  const meaningfulReferrals = Object.entries(comparison.referrals ?? {})
+  const referralComparison = comparison.referrals;
+  const meaningfulReferrals = Object.entries(referralComparison?.metrics ?? {})
     .filter(([, delta]) => delta?.meaningful)
     .map(([metric, delta]) => (
-      `${metric}: ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`
+      `${metric} (${referralComparison.windowLabel}): ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`
     ));
   return [
     '## Monthly comparison',
@@ -1018,15 +1040,14 @@ export function formatScorecardMarkdown(scorecard) {
     '',
     '| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |',
     '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
-    ...scorecard.referrals.classification.families.map(({ id, label }) => {
-      const source = scorecard.referrals.byReferrerFamily[id];
-      return `| ${label} | ${referralMetricCell(source, 'sessions')} | ${referralMetricCell(source, 'dashboardLaunches')} | ${referralMetricCell(source, 'pricingViews')} | ${referralMetricCell(source, 'signUps')} | ${referralMetricCell(source, 'proConversions')} | ${referralMetricCell(source, 'apiActions')} | ${referralMetricCell(source, 'mcpActions')} |`;
-    }),
+    ...scorecard.referrals.classification.families.map(({ id, label }) => (
+      formatReferralRow(label, scorecard.referrals.byReferrerFamily[id])
+    )),
     '',
     '| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |',
     '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
     ...Object.entries(scorecard.referrals.byPageFamily).map(([family, source]) => (
-      `| ${PAGE_FAMILY_LABELS[family]} | ${referralMetricCell(source, 'sessions')} | ${referralMetricCell(source, 'dashboardLaunches')} | ${referralMetricCell(source, 'pricingViews')} | ${referralMetricCell(source, 'signUps')} | ${referralMetricCell(source, 'proConversions')} | ${referralMetricCell(source, 'apiActions')} | ${referralMetricCell(source, 'mcpActions')} |`
+      formatReferralRow(PAGE_FAMILY_LABELS[family], source)
     )),
     '',
     '## AI-answer audit',
@@ -1040,14 +1061,14 @@ export function formatScorecardMarkdown(scorecard) {
     '| Platform | Brand | Citation | Sentiment | Accuracy | Cited URLs |',
     '| --- | --- | --- | --- | --- | --- |',
     ...scorecard.ai.observations.map((observation) => (
-      `| ${PLATFORM_LABELS[observation.platform]} | ${observation.brandMention ? 'Mention' : 'No mention'} | ${observation.directCitation ? 'Direct citation' : 'No direct citation'} | ${observation.sentiment} | ${observation.accuracy} | ${observation.citedUrls.map((url) => `[link](${url})`).join(', ') || 'none'} |`
+      `| ${PLATFORM_LABELS[observation.platform]} | ${observation.brandMention ? 'Mention' : 'No mention'} | ${observation.directCitation ? 'Direct citation' : 'No direct citation'} | ${observation.sentiment} | ${observation.accuracy} | ${markdownCell(observation.citedUrls.map(markdownLink).join(', ')) || 'none'} |`
     )),
     '',
     '### Accuracy and entity risks',
     '',
     ...(scorecard.ai.accuracyRisks.length
       ? scorecard.ai.accuracyRisks.map((observation) => (
-        `- ${PLATFORM_LABELS[observation.platform]} / ${observation.queryId}: ${observation.summary}`
+        `- ${PLATFORM_LABELS[observation.platform]} / ${observation.queryId}: ${markdownCell(observation.summary)}`
       ))
       : ['- No mixed or inaccurate answers recorded.']),
     '',

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -105,10 +105,35 @@ function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
-function assertIsoDate(value, field) {
+function isIsoCalendarDate(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const [, year, month, day] = match.map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day;
+}
+
+function assertIsoCalendarDate(value, field) {
   invariant(
-    isNonEmptyString(value) && Number.isFinite(Date.parse(value)),
-    `${field} must be an ISO date/date-time`,
+    isNonEmptyString(value) && isIsoCalendarDate(value),
+    `${field} must be an ISO calendar date (YYYY-MM-DD)`,
+  );
+}
+
+function assertIsoUtcDateTime(value, field) {
+  const match = isNonEmptyString(value)
+    ? /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?Z$/.exec(value)
+    : null;
+  invariant(
+    match
+      && isIsoCalendarDate(match[1])
+      && Number(match[2]) <= 23
+      && Number(match[3]) <= 59
+      && Number(match[4]) <= 59
+      && Number.isFinite(Date.parse(value)),
+    `${field} must be an ISO UTC date-time`,
   );
 }
 
@@ -121,6 +146,18 @@ function assertNullableMetrics(metrics, metricNames, label, status) {
       value === null || (typeof value === 'number' && Number.isFinite(value)),
       `${label}.metrics.${metric} must be a finite number or null`,
     );
+    if (value !== null) {
+      invariant(
+        value >= 0,
+        `${label}.metrics.${metric} must be non-negative`,
+      );
+      if (metric === 'ctr') {
+        invariant(
+          value <= 1,
+          `${label}.metrics.ctr must be between 0 and 1`,
+        );
+      }
+    }
     if (status === 'unavailable') {
       invariant(
         value === null,
@@ -157,8 +194,8 @@ function validateWindowedSource(source, metricNames, label) {
   for (const [index, window] of source.windows.entries()) {
     const windowLabel = `${label}.windows[${index}]`;
     invariant(isNonEmptyString(window.label), `${windowLabel}.label is required`);
-    assertIsoDate(window.startDate, `${windowLabel}.startDate`);
-    assertIsoDate(window.endDate, `${windowLabel}.endDate`);
+    assertIsoCalendarDate(window.startDate, `${windowLabel}.startDate`);
+    assertIsoCalendarDate(window.endDate, `${windowLabel}.endDate`);
     const start = Date.parse(window.startDate);
     const end = Date.parse(window.endDate);
     invariant(start <= end, `${windowLabel}.startDate must not be after endDate`);
@@ -305,7 +342,7 @@ function validateAiSurfaces(aiSurfaces) {
 export function validateQuerySet(querySet) {
   invariant(querySet?.schemaVersion === 1, 'query set schemaVersion must be 1');
   invariant(isNonEmptyString(querySet.querySetId), 'querySetId is required');
-  assertIsoDate(querySet.reviewedAt, 'reviewedAt');
+  assertIsoCalendarDate(querySet.reviewedAt, 'reviewedAt');
   invariant(
     Array.isArray(querySet.queries)
       && querySet.queries.length >= 20
@@ -372,7 +409,7 @@ export function validateBaseline(baseline, querySet) {
     baseline.querySetId === querySet.querySetId,
     `baseline querySetId must equal ${querySet.querySetId}`,
   );
-  assertIsoDate(baseline.observedAt, 'observedAt');
+  assertIsoUtcDateTime(baseline.observedAt, 'observedAt');
   invariant(
     isNonEmptyString(baseline.repositoryRevision),
     'repositoryRevision is required',
@@ -385,6 +422,11 @@ export function validateBaseline(baseline, querySet) {
   invariant(
     Array.isArray(context.signedInStates) && context.signedInStates.length > 0,
     'collectionContext.signedInStates is required',
+  );
+  invariant(
+    context.signedInStates.every(isNonEmptyString)
+      && new Set(context.signedInStates).size === context.signedInStates.length,
+    'collectionContext.signedInStates must contain unique non-empty strings',
   );
   invariant(isNonEmptyString(context.device), 'collectionContext.device is required');
   invariant(
@@ -453,7 +495,7 @@ export function validateBaseline(baseline, querySet) {
     const key = `${observation.queryId}:${observation.platform}`;
     invariant(!observationKeys.has(key), `duplicate AI observation ${key}`);
     observationKeys.add(key);
-    assertIsoDate(observation.observedAt, `${label}.observedAt`);
+    assertIsoUtcDateTime(observation.observedAt, `${label}.observedAt`);
     invariant(typeof observation.brandMention === 'boolean', `${label}.brandMention is required`);
     invariant(typeof observation.directCitation === 'boolean', `${label}.directCitation is required`);
     invariant(Array.isArray(observation.citedUrls), `${label}.citedUrls must be an array`);
@@ -473,6 +515,18 @@ export function validateBaseline(baseline, querySet) {
     invariant(isNonEmptyString(observation.geography), `${label}.geography is required`);
     invariant(isNonEmptyString(observation.locale), `${label}.locale is required`);
     invariant(isNonEmptyString(observation.signedInState), `${label}.signedInState is required`);
+    invariant(
+      observation.geography === context.geography,
+      `${label}.geography must equal collectionContext.geography`,
+    );
+    invariant(
+      observation.locale === context.locale,
+      `${label}.locale must equal collectionContext.locale`,
+    );
+    invariant(
+      context.signedInStates.includes(observation.signedInState),
+      `${label}.signedInState must be declared in collectionContext.signedInStates`,
+    );
     invariant(
       Array.isArray(observation.limitations),
       `${label}.limitations must be an array`,
@@ -737,13 +791,51 @@ export function buildScorecard(querySet, baseline) {
   };
 }
 
+function observationKey(observation) {
+  return JSON.stringify([
+    observation.queryId,
+    observation.platform,
+    observation.geography,
+    observation.locale,
+    observation.signedInState,
+  ]);
+}
+
 function observationIndex(scorecard) {
   return new Map(
     scorecard.ai.observations
       .map((observation) => [
-        `${observation.queryId}:${observation.platform}`,
+        observationKey(observation),
         observation,
       ]),
+  );
+}
+
+function assertComparableScorecards(previous, current) {
+  invariant(
+    previous.querySetId === current.querySetId,
+    'scorecard querySetId must match for comparison',
+  );
+  assertIsoUtcDateTime(previous.generatedAt, 'previous.generatedAt');
+  assertIsoUtcDateTime(current.generatedAt, 'current.generatedAt');
+  invariant(
+    Date.parse(current.generatedAt) > Date.parse(previous.generatedAt),
+    'current scorecard must be newer than previous scorecard',
+  );
+  for (const field of ['geography', 'locale', 'device']) {
+    invariant(
+      previous.collectionContext?.[field] === current.collectionContext?.[field],
+      `collectionContext.${field} must match for comparison`,
+    );
+  }
+  const previousSignedInStates = [...previous.collectionContext.signedInStates].sort();
+  const currentSignedInStates = [...current.collectionContext.signedInStates].sort();
+  invariant(
+    previousSignedInStates.length === currentSignedInStates.length
+      && previousSignedInStates.every(
+        (state, index) => state === currentSignedInStates[index],
+      ),
+    'collectionContext.signedInStates must match for comparison',
   );
 }
 
@@ -815,6 +907,7 @@ function compareWindowedSource(previous, current, metricNames) {
 }
 
 export function compareScorecards(previous, current) {
+  assertComparableScorecards(previous, current);
   const previousObservations = observationIndex(previous);
   const currentObservations = observationIndex(current);
   const newCitations = [];
@@ -838,7 +931,7 @@ export function compareScorecards(previous, current) {
     }
   }
   const byObservationKey = (left, right) => (
-    `${left.queryId}:${left.platform}`.localeCompare(`${right.queryId}:${right.platform}`)
+    observationKey(left).localeCompare(observationKey(right))
   );
 
   return {
@@ -943,6 +1036,7 @@ function formatComparison(comparison) {
   }
   const citationLabel = (observation) => (
     `${observation.queryId} on ${PLATFORM_LABELS[observation.platform]}`
+    + ` (${observation.geography}, ${observation.locale}, ${observation.signedInState})`
   );
   const meaningfulSearch = [];
   const indexingRegressions = [];
@@ -975,8 +1069,8 @@ function formatComparison(comparison) {
     '',
     `- New citations: ${comparison.newCitations.length ? comparison.newCitations.map(citationLabel).join('; ') : 'none'}`,
     `- Lost citations: ${comparison.lostCitations.length ? comparison.lostCitations.map(citationLabel).join('; ') : 'none'}`,
-    `- Newly observed query/platform pairs: ${comparison.newlyObserved.length ? comparison.newlyObserved.map(citationLabel).join('; ') : 'none'}`,
-    `- No longer observed query/platform pairs: ${comparison.noLongerObserved.length ? comparison.noLongerObserved.map(citationLabel).join('; ') : 'none'}`,
+    `- Newly observed query/platform/context combinations: ${comparison.newlyObserved.length ? comparison.newlyObserved.map(citationLabel).join('; ') : 'none'}`,
+    `- No longer observed query/platform/context combinations: ${comparison.noLongerObserved.length ? comparison.noLongerObserved.map(citationLabel).join('; ') : 'none'}`,
     `- Meaningful search changes: ${meaningfulSearch.length ? meaningfulSearch.join('; ') : 'none or unavailable'}`,
     `- Indexing regressions: ${indexingRegressions.length ? indexingRegressions.join('; ') : 'none or unavailable'}`,
     `- Referral/outcome movement: ${meaningfulReferrals.length ? meaningfulReferrals.join('; ') : 'none or unavailable'}`,

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -24,6 +24,7 @@ import {
   readFileSync,
   writeFileSync,
 } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { dirname, resolve } from 'node:path';
 
 import { isMainModule } from './lib/main-module.mjs';
@@ -137,6 +138,38 @@ function assertIsoUtcDateTime(value, field) {
   );
 }
 
+export function computeQuerySetDigest(querySet) {
+  const queries = [...querySet.queries]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((query) => ({
+      id: query.id,
+      query: query.query,
+      intent: query.intent,
+      targetAudience: query.targetAudience,
+      targetPage: {
+        family: query.targetPage.family,
+        url: query.targetPage.url,
+      },
+      conversionGoal: query.conversionGoal,
+      referenceEntities: [...query.referenceEntities]
+        .sort((left, right) => (
+          `${left.role}:${left.name}:${left.url}`
+            .localeCompare(`${right.role}:${right.name}:${right.url}`)
+        ))
+        .map((entity) => ({
+          role: entity.role,
+          name: entity.name,
+          url: entity.url,
+        })),
+    }));
+  const contract = JSON.stringify({
+    schemaVersion: querySet.schemaVersion,
+    querySetId: querySet.querySetId,
+    queries,
+  });
+  return `sha256:${createHash('sha256').update(contract).digest('hex')}`;
+}
+
 function assertNullableMetrics(metrics, metricNames, label, status) {
   invariant(metrics && typeof metrics === 'object', `${label}.metrics is required`);
   for (const metric of metricNames) {
@@ -172,7 +205,12 @@ function assertNullableMetrics(metrics, metricNames, label, status) {
   }
 }
 
-function validateWindowedSource(source, metricNames, label) {
+function validateWindowedSource(
+  source,
+  metricNames,
+  label,
+  latestEndDate,
+) {
   invariant(source && typeof source === 'object', `${label} is required`);
   invariant(
     source.property === null,
@@ -199,6 +237,12 @@ function validateWindowedSource(source, metricNames, label) {
     const start = Date.parse(window.startDate);
     const end = Date.parse(window.endDate);
     invariant(start <= end, `${windowLabel}.startDate must not be after endDate`);
+    if (latestEndDate !== undefined) {
+      invariant(
+        end <= Date.parse(latestEndDate),
+        `${windowLabel}.endDate must not be after the baseline observation date`,
+      );
+    }
     const numericLabel = /^(\d+)d$/.exec(window.label);
     if (numericLabel) {
       const startDate = new Date(start);
@@ -223,8 +267,8 @@ function validateWindowedSource(source, metricNames, label) {
   }
 }
 
-function validateSearchSource(source, label, queryIds) {
-  validateWindowedSource(source, SEARCH_METRICS, label);
+function validateSearchSource(source, label, queryIds, latestEndDate) {
+  validateWindowedSource(source, SEARCH_METRICS, label, latestEndDate);
   const windowLabels = new Set(source.windows.map(({ label: windowLabel }) => windowLabel));
   const rowContracts = [
     {
@@ -409,7 +453,17 @@ export function validateBaseline(baseline, querySet) {
     baseline.querySetId === querySet.querySetId,
     `baseline querySetId must equal ${querySet.querySetId}`,
   );
+  invariant(
+    baseline.querySetDigest === computeQuerySetDigest(querySet),
+    'baseline querySetDigest must match the supplied query set',
+  );
   assertIsoUtcDateTime(baseline.observedAt, 'observedAt');
+  const baselineObservedAt = Date.parse(baseline.observedAt);
+  const baselineObservationDate = baseline.observedAt.slice(0, 10);
+  invariant(
+    Date.parse(querySet.reviewedAt) <= Date.parse(baselineObservationDate),
+    'query set reviewedAt must not be after baseline.observedAt',
+  );
   invariant(
     isNonEmptyString(baseline.repositoryRevision),
     'repositoryRevision is required',
@@ -441,16 +495,19 @@ export function validateBaseline(baseline, querySet) {
     baseline.search.googleSearchConsole,
     'search.googleSearchConsole',
     queryIds,
+    baselineObservationDate,
   );
   validateSearchSource(
     baseline.search.bingWebmaster,
     'search.bingWebmaster',
     queryIds,
+    baselineObservationDate,
   );
   validateWindowedSource(
     baseline.referrals,
     REFERRAL_METRICS,
     'referrals',
+    baselineObservationDate,
   );
   invariant(
     baseline.referrals.classification
@@ -496,6 +553,10 @@ export function validateBaseline(baseline, querySet) {
     invariant(!observationKeys.has(key), `duplicate AI observation ${key}`);
     observationKeys.add(key);
     assertIsoUtcDateTime(observation.observedAt, `${label}.observedAt`);
+    invariant(
+      Date.parse(observation.observedAt) <= baselineObservedAt,
+      `${label}.observedAt must not be after baseline.observedAt`,
+    );
     invariant(typeof observation.brandMention === 'boolean', `${label}.brandMention is required`);
     invariant(typeof observation.directCitation === 'boolean', `${label}.directCitation is required`);
     invariant(Array.isArray(observation.citedUrls), `${label}.citedUrls must be an array`);
@@ -749,6 +810,7 @@ export function buildScorecard(querySet, baseline) {
     schemaVersion: 1,
     baselineId: baseline.baselineId,
     querySetId: querySet.querySetId,
+    querySetDigest: baseline.querySetDigest,
     generatedAt: baseline.observedAt,
     repositoryRevision: baseline.repositoryRevision,
     collectionContext: structuredClone(baseline.collectionContext),
@@ -816,6 +878,10 @@ function assertComparableScorecards(previous, current) {
     previous.querySetId === current.querySetId,
     'scorecard querySetId must match for comparison',
   );
+  invariant(
+    previous.querySetDigest === current.querySetDigest,
+    'scorecard querySetDigest must match for comparison',
+  );
   assertIsoUtcDateTime(previous.generatedAt, 'previous.generatedAt');
   assertIsoUtcDateTime(current.generatedAt, 'current.generatedAt');
   invariant(
@@ -874,7 +940,7 @@ function metricDelta(previous, current, metric) {
   return { before, after, absolute, relative, meaningful };
 }
 
-function compareWindowedSource(previous, current, metricNames) {
+function compareWindowedSource(previous, current, metricNames, label) {
   if (
     previous?.status === 'unavailable'
     || current?.status === 'unavailable'
@@ -895,8 +961,28 @@ function compareWindowedSource(previous, current, metricNames) {
   const previousWindow = sharedWindows.find(({ label }) => label === '28d')
     ?? sharedWindows[0];
   const currentWindow = currentWindowsByLabel.get(previousWindow.label);
+  for (const [period, window] of [
+    ['previous', previousWindow],
+    ['current', currentWindow],
+  ]) {
+    assertIsoCalendarDate(window.startDate, `${label}.${period}.startDate`);
+    assertIsoCalendarDate(window.endDate, `${label}.${period}.endDate`);
+  }
+  invariant(
+    Date.parse(currentWindow.startDate) > Date.parse(previousWindow.startDate)
+      && Date.parse(currentWindow.endDate) > Date.parse(previousWindow.endDate),
+    `${label} current ${previousWindow.label} window must advance beyond the previous window`,
+  );
   return {
     windowLabel: previousWindow.label,
+    previousPeriod: {
+      startDate: previousWindow.startDate,
+      endDate: previousWindow.endDate,
+    },
+    currentPeriod: {
+      startDate: currentWindow.startDate,
+      endDate: currentWindow.endDate,
+    },
     metrics: Object.fromEntries(
       metricNames.map((metric) => [
         metric,
@@ -946,17 +1032,20 @@ export function compareScorecards(previous, current) {
         previous.search.googleSearchConsole,
         current.search.googleSearchConsole,
         SEARCH_METRICS,
+        'googleSearchConsole',
       ),
       bingWebmaster: compareWindowedSource(
         previous.search.bingWebmaster,
         current.search.bingWebmaster,
         SEARCH_METRICS,
+        'bingWebmaster',
       ),
     },
     referrals: compareWindowedSource(
       previous.referrals,
       current.referrals,
       REFERRAL_METRICS,
+      'referrals',
     ),
     entityAnswerRisks: structuredClone(current.ai.accuracyRisks),
   };
@@ -1040,33 +1129,48 @@ function formatComparison(comparison) {
   );
   const meaningfulSearch = [];
   const indexingRegressions = [];
+  const periodTransition = ({ previousPeriod, currentPeriod }) => (
+    `${previousPeriod.startDate}..${previousPeriod.endDate}`
+    + ` → ${currentPeriod.startDate}..${currentPeriod.endDate}`
+  );
   for (const [provider, windowComparison] of Object.entries(comparison.search)) {
     if (!windowComparison) continue;
     const { windowLabel, metrics } = windowComparison;
     for (const [metric, delta] of Object.entries(metrics)) {
       if (delta?.meaningful) {
         meaningfulSearch.push(
-          `${provider}.${metric} (${windowLabel}): ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`,
+          `${provider}.${metric} (${windowLabel}): ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute}); periods ${periodTransition(windowComparison)}`,
         );
       }
     }
     if (metrics.indexedPages?.meaningful && metrics.indexedPages.absolute < 0) {
       indexingRegressions.push(
-        `${provider} (${windowLabel}): ${metrics.indexedPages.before} → ${metrics.indexedPages.after}`,
+        `${provider} (${windowLabel}): ${metrics.indexedPages.before} → ${metrics.indexedPages.after}; periods ${periodTransition(windowComparison)}`,
       );
     }
   }
   const referralComparison = comparison.referrals;
+  const comparedPeriods = [
+    ...Object.entries(comparison.search)
+      .filter(([, windowComparison]) => windowComparison)
+      .map(([provider, windowComparison]) => (
+        `${provider} ${windowComparison.windowLabel}: ${periodTransition(windowComparison)}`
+      )),
+    ...(referralComparison
+      ? [`referrals ${referralComparison.windowLabel}: ${periodTransition(referralComparison)}`]
+      : []),
+  ];
   const meaningfulReferrals = Object.entries(referralComparison?.metrics ?? {})
     .filter(([, delta]) => delta?.meaningful)
     .map(([metric, delta]) => (
-      `${metric} (${referralComparison.windowLabel}): ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`
+      `${metric} (${referralComparison.windowLabel}): ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute}); periods ${periodTransition(referralComparison)}`
     ));
   return [
     '## Monthly comparison',
     '',
     `Compared \`${comparison.previousBaselineId}\` with \`${comparison.currentBaselineId}\`.`,
     '',
+    `- Compared provider periods: ${comparedPeriods.length ? comparedPeriods.join('; ') : 'none available'}`,
     `- New citations: ${comparison.newCitations.length ? comparison.newCitations.map(citationLabel).join('; ') : 'none'}`,
     `- Lost citations: ${comparison.lostCitations.length ? comparison.lostCitations.map(citationLabel).join('; ') : 'none'}`,
     `- Newly observed query/platform/context combinations: ${comparison.newlyObserved.length ? comparison.newlyObserved.map(citationLabel).join('; ') : 'none'}`,
@@ -1086,6 +1190,7 @@ export function formatScorecardMarkdown(scorecard) {
     `Generated from repository revision \`${scorecard.repositoryRevision}\` at`,
     `\`${scorecard.generatedAt}\`. Missing provider data is reported as unavailable,`,
     'never coerced to zero.',
+    `Query contract: \`${scorecard.querySetId}\` / \`${scorecard.querySetDigest}\`.`,
     '',
     '## Collection context',
     '',
@@ -1152,10 +1257,10 @@ export function formatScorecardMarkdown(scorecard) {
     `Observed direct-citation rate: ${percent(scorecard.ai.directCitationRate)}.`,
     'These are descriptive observations, not causal or population-level estimates.',
     '',
-    '| Platform | Brand | Citation | Sentiment | Accuracy | Cited URLs |',
-    '| --- | --- | --- | --- | --- | --- |',
+    '| Query | Platform | Observed at (UTC) | Context | Brand | Citation | Sentiment | Accuracy | Cited URLs |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
     ...scorecard.ai.observations.map((observation) => (
-      `| ${PLATFORM_LABELS[observation.platform]} | ${observation.brandMention ? 'Mention' : 'No mention'} | ${observation.directCitation ? 'Direct citation' : 'No direct citation'} | ${observation.sentiment} | ${observation.accuracy} | ${markdownCell(observation.citedUrls.map(markdownLink).join(', ')) || 'none'} |`
+      `| ${observation.queryId} | ${PLATFORM_LABELS[observation.platform]} | ${observation.observedAt} | ${markdownCell(`${observation.geography} / ${observation.locale} / ${observation.signedInState}`)} | ${observation.brandMention ? 'Mention' : 'No mention'} | ${observation.directCitation ? 'Direct citation' : 'No direct citation'} | ${observation.sentiment} | ${observation.accuracy} | ${markdownCell(observation.citedUrls.map(markdownLink).join(', ')) || 'none'} |`
     )),
     '',
     '### Accuracy and entity risks',

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -1,0 +1,1121 @@
+#!/usr/bin/env node
+/**
+ * Validate and render the file-based SEO / AI-citation visibility scorecard.
+ *
+ * This is intentionally a local, file-based pipeline:
+ * - supported Search Console/Bing/analytics exports are normalized before use;
+ * - unavailable inputs remain null and carry a reason;
+ * - manual AI observations distinguish a brand mention from a direct citation;
+ * - no search-result scraping or credentials are introduced.
+ *
+ * Usage:
+ *   node scripts/seo-ai-visibility-scorecard.mjs \
+ *     --queries docs/research/seo-ai-visibility/query-set.json \
+ *     --baseline docs/research/seo-ai-visibility/baselines/2026-07-27.json \
+ *     --output docs/research/seo-ai-visibility/scorecards/2026-07-27.md
+ *
+ * Optional:
+ *   --previous <baseline.json>  include a monthly new/lost citation comparison
+ *   --check                     fail when --output differs from generated content
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import { isMainModule } from './lib/main-module.mjs';
+
+const defineDomain = (entries) => Object.freeze(
+  entries.map(([id, label]) => Object.freeze({ id, label })),
+);
+const domainIds = (domain) => Object.freeze(domain.map(({ id }) => id));
+const domainLabels = (domain) => Object.freeze(Object.fromEntries(
+  domain.map(({ id, label }) => [id, label]),
+));
+
+const AI_PLATFORM_DOMAIN = defineDomain([
+  ['chatgpt_search', 'ChatGPT Search'],
+  ['perplexity', 'Perplexity'],
+  ['google_ai', 'Google AI Overview'],
+  ['copilot_search', 'Copilot Search'],
+]);
+const PAGE_FAMILY_DOMAIN = defineDomain([
+  ['homepage', 'Homepage'],
+  ['dashboard', 'Dashboard'],
+  ['blog', 'Blog'],
+  ['documentation', 'Documentation'],
+  ['country_pages', 'Country pages'],
+  ['chokepoints', 'Chokepoints'],
+  ['crises', 'Crises'],
+  ['tools', 'Tools'],
+  ['pricing', 'Pricing'],
+  ['developer_mcp', 'Developer / MCP'],
+]);
+const INTENT_DOMAIN = defineDomain([
+  ['category_definition', 'Category / definition'],
+  ['use_case', 'Use case'],
+  ['developer_agent', 'Developer / agent'],
+  ['evaluation', 'Evaluation'],
+  ['branded_entity', 'Branded / entity'],
+]);
+
+export const AI_PLATFORMS = domainIds(AI_PLATFORM_DOMAIN);
+export const PAGE_FAMILIES = domainIds(PAGE_FAMILY_DOMAIN);
+const INTENTS = domainIds(INTENT_DOMAIN);
+
+const AVAILABILITY_STATES = new Set(['available', 'partial', 'unavailable']);
+const SENTIMENTS = new Set(['positive', 'neutral', 'negative', 'mixed']);
+const ACCURACY_STATES = new Set(['accurate', 'mixed', 'inaccurate', 'unverified']);
+const REFERENCE_ROLES = new Set(['competitor', 'source']);
+const SEARCH_METRICS = Object.freeze([
+  'indexedPages',
+  'impressions',
+  'clicks',
+  'ctr',
+  'averagePosition',
+]);
+const SEARCH_PERFORMANCE_METRICS = Object.freeze([
+  'impressions',
+  'clicks',
+  'ctr',
+  'averagePosition',
+]);
+const REFERRAL_METRICS = Object.freeze([
+  'sessions',
+  'dashboardLaunches',
+  'pricingViews',
+  'signUps',
+  'proConversions',
+  'apiActions',
+  'mcpActions',
+]);
+
+const PLATFORM_LABELS = domainLabels(AI_PLATFORM_DOMAIN);
+const PAGE_FAMILY_LABELS = domainLabels(PAGE_FAMILY_DOMAIN);
+const INTENT_LABELS = domainLabels(INTENT_DOMAIN);
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(`[seo-visibility] ${message}`);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function assertIsoDate(value, field) {
+  invariant(
+    isNonEmptyString(value) && Number.isFinite(Date.parse(value)),
+    `${field} must be an ISO date/date-time`,
+  );
+}
+
+function assertNullableMetrics(metrics, metricNames, label, status) {
+  invariant(metrics && typeof metrics === 'object', `${label}.metrics is required`);
+  for (const metric of metricNames) {
+    invariant(metric in metrics, `${label}.metrics.${metric} is required`);
+    const value = metrics[metric];
+    invariant(
+      value === null || (typeof value === 'number' && Number.isFinite(value)),
+      `${label}.metrics.${metric} must be a finite number or null`,
+    );
+    if (status === 'unavailable') {
+      invariant(
+        value === null,
+        `${label}: unavailable metrics must be null (${metric})`,
+      );
+    } else if (status === 'available') {
+      invariant(
+        typeof value === 'number' && Number.isFinite(value),
+        `${label}: available metrics must be finite numbers (${metric})`,
+      );
+    }
+  }
+}
+
+function validateWindowedSource(source, metricNames, label) {
+  invariant(source && typeof source === 'object', `${label} is required`);
+  invariant(
+    source.property === null,
+    `${label}.property must remain null in committed artifacts`,
+  );
+  invariant(
+    AVAILABILITY_STATES.has(source.status),
+    `${label}.status must be available, partial, or unavailable`,
+  );
+  if (source.status !== 'available') {
+    invariant(isNonEmptyString(source.reason), `${label}.reason is required`);
+  }
+  invariant(Array.isArray(source.windows) && source.windows.length > 0, `${label}.windows is required`);
+  const windowLabels = source.windows.map(({ label: windowLabel }) => windowLabel);
+  invariant(
+    new Set(windowLabels).size === windowLabels.length,
+    `${label}.window labels must be unique`,
+  );
+  for (const [index, window] of source.windows.entries()) {
+    const windowLabel = `${label}.windows[${index}]`;
+    invariant(isNonEmptyString(window.label), `${windowLabel}.label is required`);
+    assertIsoDate(window.startDate, `${windowLabel}.startDate`);
+    assertIsoDate(window.endDate, `${windowLabel}.endDate`);
+    assertNullableMetrics(window.metrics, metricNames, windowLabel, source.status);
+  }
+}
+
+function validateSearchSource(source, label, queryIds) {
+  validateWindowedSource(source, SEARCH_METRICS, label);
+  const windowLabels = new Set(source.windows.map(({ label: windowLabel }) => windowLabel));
+  const rowContracts = [
+    {
+      field: 'queryRows',
+      groupField: 'queryId',
+      groupIds: queryIds,
+      metrics: SEARCH_PERFORMANCE_METRICS,
+    },
+    {
+      field: 'pageFamilyRows',
+      groupField: 'pageFamily',
+      groupIds: new Set(PAGE_FAMILIES),
+      metrics: SEARCH_METRICS,
+    },
+  ];
+  for (const contract of rowContracts) {
+    const rows = source[contract.field];
+    invariant(Array.isArray(rows), `${label}.${contract.field} must be an array`);
+    if (source.status === 'unavailable') {
+      invariant(
+        rows.length === 0,
+        `${label}.${contract.field} must be empty when the source is unavailable`,
+      );
+    }
+    const rowKeys = new Set();
+    for (const [index, row] of rows.entries()) {
+      const rowLabel = `${label}.${contract.field}[${index}]`;
+      invariant(
+        windowLabels.has(row.windowLabel),
+        `${rowLabel}.windowLabel must reference a source window`,
+      );
+      invariant(
+        contract.groupIds.has(row[contract.groupField]),
+        `${rowLabel}.${contract.groupField} is invalid`,
+      );
+      const rowKey = `${row.windowLabel}:${row[contract.groupField]}`;
+      invariant(!rowKeys.has(rowKey), `${label}.${contract.field} has duplicate ${rowKey}`);
+      rowKeys.add(rowKey);
+      assertNullableMetrics(row.metrics, contract.metrics, rowLabel, source.status);
+    }
+  }
+}
+
+function validateReferralSegments(referrals, referrerFamilyIds) {
+  invariant(Array.isArray(referrals.segments), 'referrals.segments must be an array');
+  if (referrals.status === 'unavailable') {
+    invariant(
+      referrals.segments.length === 0,
+      'referrals.segments must be empty when referrals are unavailable',
+    );
+  }
+  const windowLabels = new Set(referrals.windows.map(({ label }) => label));
+  const segmentKeys = new Set();
+  for (const [index, segment] of referrals.segments.entries()) {
+    const label = `referrals.segments[${index}]`;
+    invariant(
+      windowLabels.has(segment.windowLabel),
+      `${label}.windowLabel must reference a referral window`,
+    );
+    invariant(
+      referrerFamilyIds.has(segment.referrerFamily),
+      `${label}.referrerFamily is invalid`,
+    );
+    invariant(
+      PAGE_FAMILIES.includes(segment.landingPageFamily),
+      `${label}.landingPageFamily is invalid`,
+    );
+    const segmentKey = [
+      segment.windowLabel,
+      segment.referrerFamily,
+      segment.landingPageFamily,
+    ].join(':');
+    invariant(!segmentKeys.has(segmentKey), `duplicate referral segment ${segmentKey}`);
+    segmentKeys.add(segmentKey);
+    assertNullableMetrics(segment.metrics, REFERRAL_METRICS, label, referrals.status);
+  }
+}
+
+function isWorldMonitorUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.hostname === 'worldmonitor.app'
+      || url.hostname.endsWith('.worldmonitor.app');
+  } catch {
+    return false;
+  }
+}
+
+function validateAiSurfaces(aiSurfaces) {
+  invariant(Array.isArray(aiSurfaces), 'aiSurfaces must be an array');
+  invariant(
+    aiSurfaces.length === AI_PLATFORMS.length,
+    'aiSurfaces must contain every supported platform exactly once',
+  );
+  const platforms = new Set();
+  for (const [index, surface] of aiSurfaces.entries()) {
+    const label = `aiSurfaces[${index}]`;
+    invariant(AI_PLATFORMS.includes(surface.platform), `${label}.platform is invalid`);
+    invariant(!platforms.has(surface.platform), `duplicate AI surface ${surface.platform}`);
+    platforms.add(surface.platform);
+    invariant(
+      AVAILABILITY_STATES.has(surface.status),
+      `${label}.status must be available, partial, or unavailable`,
+    );
+    if (surface.status !== 'available') {
+      invariant(isNonEmptyString(surface.reason), `${label}.reason is required`);
+    }
+  }
+  for (const platform of AI_PLATFORMS) {
+    invariant(platforms.has(platform), `aiSurfaces is missing ${platform}`);
+  }
+  return new Map(aiSurfaces.map((surface) => [surface.platform, surface]));
+}
+
+export function validateQuerySet(querySet) {
+  invariant(querySet?.schemaVersion === 1, 'query set schemaVersion must be 1');
+  invariant(isNonEmptyString(querySet.querySetId), 'querySetId is required');
+  assertIsoDate(querySet.reviewedAt, 'reviewedAt');
+  invariant(
+    Array.isArray(querySet.queries)
+      && querySet.queries.length >= 20
+      && querySet.queries.length <= 30,
+    'queries must contain 20-30 reviewed entries',
+  );
+
+  const ids = new Set();
+  const intents = new Set();
+  const pageFamilies = new Set();
+  for (const [index, query] of querySet.queries.entries()) {
+    const label = `queries[${index}]`;
+    invariant(isNonEmptyString(query.id), `${label}.id is required`);
+    invariant(!ids.has(query.id), `duplicate query id: ${query.id}`);
+    ids.add(query.id);
+    invariant(isNonEmptyString(query.query), `${query.id}.query is required`);
+    invariant(INTENTS.includes(query.intent), `${query.id}.intent is invalid`);
+    intents.add(query.intent);
+    invariant(isNonEmptyString(query.targetAudience), `${query.id}.targetAudience is required`);
+    invariant(isNonEmptyString(query.conversionGoal), `${query.id}.conversionGoal is required`);
+    invariant(
+      PAGE_FAMILIES.includes(query.targetPage?.family),
+      `${query.id}.targetPage.family is invalid`,
+    );
+    pageFamilies.add(query.targetPage.family);
+    invariant(
+      isNonEmptyString(query.targetPage.url) && query.targetPage.url.startsWith('https://'),
+      `${query.id}.targetPage.url must be HTTPS`,
+    );
+    invariant(
+      Array.isArray(query.referenceEntities) && query.referenceEntities.length > 0,
+      `${query.id}.referenceEntities must contain at least one named competitor/source`,
+    );
+    for (const [entityIndex, entity] of query.referenceEntities.entries()) {
+      invariant(
+        REFERENCE_ROLES.has(entity.role),
+        `${query.id}.referenceEntities[${entityIndex}].role is invalid`,
+      );
+      invariant(
+        isNonEmptyString(entity.name),
+        `${query.id}.referenceEntities[${entityIndex}].name is required`,
+      );
+      invariant(
+        isNonEmptyString(entity.url) && entity.url.startsWith('https://'),
+        `${query.id}.referenceEntities[${entityIndex}].url must be HTTPS`,
+      );
+    }
+  }
+
+  for (const intent of INTENTS) {
+    invariant(intents.has(intent), `query set is missing intent ${intent}`);
+  }
+  for (const family of PAGE_FAMILIES) {
+    invariant(pageFamilies.has(family), `query set is missing page family ${family}`);
+  }
+  return querySet;
+}
+
+export function validateBaseline(baseline, querySet) {
+  validateQuerySet(querySet);
+  invariant(baseline?.schemaVersion === 1, 'baseline schemaVersion must be 1');
+  invariant(isNonEmptyString(baseline.baselineId), 'baselineId is required');
+  invariant(
+    baseline.querySetId === querySet.querySetId,
+    `baseline querySetId must equal ${querySet.querySetId}`,
+  );
+  assertIsoDate(baseline.observedAt, 'observedAt');
+  invariant(
+    isNonEmptyString(baseline.repositoryRevision),
+    'repositoryRevision is required',
+  );
+
+  const context = baseline.collectionContext;
+  invariant(context && typeof context === 'object', 'collectionContext is required');
+  invariant(isNonEmptyString(context.geography), 'collectionContext.geography is required');
+  invariant(isNonEmptyString(context.locale), 'collectionContext.locale is required');
+  invariant(
+    Array.isArray(context.signedInStates) && context.signedInStates.length > 0,
+    'collectionContext.signedInStates is required',
+  );
+  invariant(isNonEmptyString(context.device), 'collectionContext.device is required');
+  invariant(
+    Array.isArray(context.limitations),
+    'collectionContext.limitations must be an array',
+  );
+
+  const aiSurfaces = validateAiSurfaces(baseline.aiSurfaces);
+  const queryIds = new Set(querySet.queries.map((query) => query.id));
+  invariant(baseline.search && typeof baseline.search === 'object', 'search is required');
+  validateSearchSource(
+    baseline.search.googleSearchConsole,
+    'search.googleSearchConsole',
+    queryIds,
+  );
+  validateSearchSource(
+    baseline.search.bingWebmaster,
+    'search.bingWebmaster',
+    queryIds,
+  );
+  validateWindowedSource(
+    baseline.referrals,
+    REFERRAL_METRICS,
+    'referrals',
+  );
+  invariant(
+    baseline.referrals.classification
+      && typeof baseline.referrals.classification === 'object',
+    'referrals.classification is required',
+  );
+  invariant(
+    Array.isArray(baseline.referrals.classification.dimensions)
+      && baseline.referrals.classification.dimensions.length > 0,
+    'referrals.classification.dimensions is required',
+  );
+  invariant(
+    Array.isArray(baseline.referrals.classification.families)
+      && baseline.referrals.classification.families.length > 0,
+    'referrals.classification.families is required',
+  );
+  const referrerFamilyIds = new Set();
+  for (const [index, family] of baseline.referrals.classification.families.entries()) {
+    const label = `referrals.classification.families[${index}]`;
+    invariant(isNonEmptyString(family.id), `${label}.id is required`);
+    invariant(!referrerFamilyIds.has(family.id), `duplicate referral family ${family.id}`);
+    referrerFamilyIds.add(family.id);
+    invariant(isNonEmptyString(family.label), `${label}.label is required`);
+    invariant(Array.isArray(family.hostSuffixes), `${label}.hostSuffixes must be an array`);
+    invariant(Array.isArray(family.utmSources), `${label}.utmSources must be an array`);
+  }
+  validateReferralSegments(baseline.referrals, referrerFamilyIds);
+
+  invariant(
+    Array.isArray(baseline.aiObservations),
+    'aiObservations must be an array',
+  );
+  const observationKeys = new Set();
+  for (const [index, observation] of baseline.aiObservations.entries()) {
+    const label = `aiObservations[${index}]`;
+    invariant(queryIds.has(observation.queryId), `${label}.queryId is unknown`);
+    invariant(AI_PLATFORMS.includes(observation.platform), `${label}.platform is invalid`);
+    invariant(
+      aiSurfaces.get(observation.platform)?.status !== 'unavailable',
+      `${label}.platform is unavailable`,
+    );
+    const key = `${observation.queryId}:${observation.platform}`;
+    invariant(!observationKeys.has(key), `duplicate AI observation ${key}`);
+    observationKeys.add(key);
+    assertIsoDate(observation.observedAt, `${label}.observedAt`);
+    invariant(typeof observation.brandMention === 'boolean', `${label}.brandMention is required`);
+    invariant(typeof observation.directCitation === 'boolean', `${label}.directCitation is required`);
+    invariant(Array.isArray(observation.citedUrls), `${label}.citedUrls must be an array`);
+    invariant(
+      observation.citedUrls.every((url) => isNonEmptyString(url) && url.startsWith('https://')),
+      `${label}.citedUrls must contain HTTPS URLs`,
+    );
+    const hasWorldMonitorCitation = observation.citedUrls.some(isWorldMonitorUrl);
+    invariant(
+      observation.directCitation === hasWorldMonitorCitation,
+      `${label}: directCitation must match World Monitor cited URLs`,
+    );
+    invariant(Array.isArray(observation.competitorsCited), `${label}.competitorsCited must be an array`);
+    invariant(SENTIMENTS.has(observation.sentiment), `${label}.sentiment is invalid`);
+    invariant(ACCURACY_STATES.has(observation.accuracy), `${label}.accuracy is invalid`);
+    invariant(isNonEmptyString(observation.summary), `${label}.summary is required`);
+    invariant(isNonEmptyString(observation.geography), `${label}.geography is required`);
+    invariant(isNonEmptyString(observation.locale), `${label}.locale is required`);
+    invariant(isNonEmptyString(observation.signedInState), `${label}.signedInState is required`);
+    invariant(
+      Array.isArray(observation.limitations),
+      `${label}.limitations must be an array`,
+    );
+  }
+
+  invariant(
+    Array.isArray(baseline.opportunities) && baseline.opportunities.length === 5,
+    'opportunities must contain exactly five prioritized entries',
+  );
+  const priorities = baseline.opportunities.map((opportunity) => opportunity.priority);
+  const sortedPriorities = [...priorities].sort((left, right) => left - right);
+  invariant(
+    sortedPriorities.every(
+      (priority, index) => Number.isInteger(priority) && priority === index + 1,
+    ),
+    'opportunity priorities must be exactly the integers 1-5',
+  );
+  for (const opportunity of baseline.opportunities) {
+    invariant(isNonEmptyString(opportunity.title), 'opportunity.title is required');
+    invariant(isNonEmptyString(opportunity.evidence), 'opportunity.evidence is required');
+    invariant(isNonEmptyString(opportunity.experiment), 'opportunity.experiment is required');
+    invariant(isNonEmptyString(opportunity.successCriteria), 'opportunity.successCriteria is required');
+    invariant(
+      Array.isArray(opportunity.queryIds)
+        && opportunity.queryIds.length > 0
+        && opportunity.queryIds.every((id) => queryIds.has(id)),
+      `${opportunity.title}: queryIds must reference the query set`,
+    );
+  }
+  invariant(
+    Array.isArray(baseline.guardrails)
+      && baseline.guardrails.length > 0
+      && baseline.guardrails.every(isNonEmptyString),
+    'guardrails must be a non-empty array of strings',
+  );
+  return baseline;
+}
+
+function round(value, digits = 4) {
+  if (!Number.isFinite(value)) return null;
+  return Number(value.toFixed(digits));
+}
+
+function rate(numerator, denominator) {
+  return denominator > 0 ? round(numerator / denominator) : null;
+}
+
+function sumMetric(rows, metric) {
+  if (
+    rows.length === 0
+    || rows.some(({ metrics }) => !Number.isFinite(metrics[metric]))
+  ) {
+    return null;
+  }
+  return round(rows.reduce((total, { metrics }) => total + metrics[metric], 0));
+}
+
+function aggregateSearchMetrics(rows, includeIndexedPages) {
+  const impressions = sumMetric(rows, 'impressions');
+  const clicks = sumMetric(rows, 'clicks');
+  let ctr = null;
+  if (impressions !== null && clicks !== null) {
+    if (impressions > 0) ctr = round(clicks / impressions);
+    else if (clicks === 0) ctr = 0;
+  }
+  const hasWeightedPositions = impressions !== null
+    && impressions > 0
+    && rows.every(({ metrics }) => (
+      Number.isFinite(metrics.averagePosition)
+      && Number.isFinite(metrics.impressions)
+    ));
+  const averagePosition = hasWeightedPositions
+    ? round(
+      rows.reduce(
+        (total, { metrics }) => total + metrics.averagePosition * metrics.impressions,
+        0,
+      ) / impressions,
+    )
+    : null;
+  return {
+    indexedPages: includeIndexedPages ? sumMetric(rows, 'indexedPages') : null,
+    impressions,
+    clicks,
+    ctr,
+    averagePosition,
+  };
+}
+
+function aggregateAdditiveMetrics(rows, metricNames) {
+  return Object.fromEntries(
+    metricNames.map((metric) => [metric, sumMetric(rows, metric)]),
+  );
+}
+
+function aggregateWindowedRows(source, rows, aggregateMetrics) {
+  return {
+    status: source.status,
+    reason: source.reason,
+    windows: source.windows.map((window) => ({
+      label: window.label,
+      startDate: window.startDate,
+      endDate: window.endDate,
+      metrics: aggregateMetrics(
+        rows.filter((row) => row.windowLabel === window.label),
+      ),
+    })),
+  };
+}
+
+const INTENT_SLICE = Object.freeze({
+  domain: INTENT_DOMAIN,
+  matchesQuery: (query, group) => query.intent === group,
+  searchRows: (source, _group, queryIds) => (
+    source.queryRows.filter((row) => queryIds.has(row.queryId))
+  ),
+  includeIndexedPages: false,
+});
+const PAGE_FAMILY_SLICE = Object.freeze({
+  domain: PAGE_FAMILY_DOMAIN,
+  matchesQuery: (query, group) => query.targetPage.family === group,
+  searchRows: (source, group) => (
+    source.pageFamilyRows.filter((row) => row.pageFamily === group)
+  ),
+  includeIndexedPages: true,
+});
+
+function buildSlices(
+  querySet,
+  observations,
+  search,
+  eligiblePlatformCount,
+  descriptor,
+) {
+  return Object.fromEntries(descriptor.domain.map(({ id: group }) => {
+    const queries = querySet.queries.filter(
+      (query) => descriptor.matchesQuery(query, group),
+    );
+    const queryIds = new Set(queries.map((query) => query.id));
+    const rows = observations.filter((observation) => queryIds.has(observation.queryId));
+    const mentions = rows.filter((observation) => observation.brandMention).length;
+    const citations = rows.filter((observation) => observation.directCitation).length;
+    const providerSearch = Object.fromEntries(
+      Object.entries(search).map(([provider, source]) => [
+        provider,
+        aggregateWindowedRows(
+          source,
+          descriptor.searchRows(source, group, queryIds),
+          (searchRows) => aggregateSearchMetrics(
+            searchRows,
+            descriptor.includeIndexedPages,
+          ),
+        ),
+      ]),
+    );
+    const possibleObservations = queries.length * eligiblePlatformCount;
+    return [group, {
+      queries: queries.length,
+      observations: rows.length,
+      possibleObservations,
+      brandMentions: mentions,
+      directCitations: citations,
+      coverageRate: rate(rows.length, possibleObservations),
+      brandMentionRate: rate(mentions, rows.length),
+      directCitationRate: rate(citations, rows.length),
+      targetUrls: [...new Set(queries.map((query) => query.targetPage.url))],
+      search: providerSearch,
+    }];
+  }));
+}
+
+function buildReferralSlices(referrals, domain, matchesSegment) {
+  return Object.fromEntries(domain.map(({ id }) => [
+    id,
+    aggregateWindowedRows(
+      referrals,
+      referrals.segments.filter((segment) => matchesSegment(segment, id)),
+      (segments) => aggregateAdditiveMetrics(segments, REFERRAL_METRICS),
+    ),
+  ]));
+}
+
+export function buildScorecard(querySet, baseline) {
+  validateBaseline(baseline, querySet);
+  const observations = structuredClone(baseline.aiObservations);
+  const mentions = observations.filter((observation) => observation.brandMention).length;
+  const citations = observations.filter((observation) => observation.directCitation).length;
+  const eligiblePlatformCount = baseline.aiSurfaces.filter(
+    ({ status }) => status !== 'unavailable',
+  ).length;
+  const targetPossible = querySet.queries.length * AI_PLATFORMS.length;
+  const possible = querySet.queries.length * eligiblePlatformCount;
+  const byIntent = buildSlices(
+    querySet,
+    observations,
+    baseline.search,
+    eligiblePlatformCount,
+    INTENT_SLICE,
+  );
+  const byPageFamily = buildSlices(
+    querySet,
+    observations,
+    baseline.search,
+    eligiblePlatformCount,
+    PAGE_FAMILY_SLICE,
+  );
+  const referrals = structuredClone(baseline.referrals);
+  referrals.byReferrerFamily = buildReferralSlices(
+    baseline.referrals,
+    baseline.referrals.classification.families,
+    (segment, family) => segment.referrerFamily === family,
+  );
+  referrals.byPageFamily = buildReferralSlices(
+    baseline.referrals,
+    PAGE_FAMILY_DOMAIN,
+    (segment, family) => segment.landingPageFamily === family,
+  );
+
+  return {
+    schemaVersion: 1,
+    baselineId: baseline.baselineId,
+    querySetId: querySet.querySetId,
+    generatedAt: baseline.observedAt,
+    repositoryRevision: baseline.repositoryRevision,
+    collectionContext: structuredClone(baseline.collectionContext),
+    querySet: {
+      total: querySet.queries.length,
+      byIntent: Object.fromEntries(
+        Object.entries(byIntent).map(([intent, slice]) => [intent, slice.queries]),
+      ),
+      byPageFamily: Object.fromEntries(
+        Object.entries(byPageFamily).map(
+          ([family, slice]) => [family, slice.queries],
+        ),
+      ),
+    },
+    search: structuredClone(baseline.search),
+    referrals,
+    ai: {
+      surfaces: structuredClone(baseline.aiSurfaces),
+      observed: observations.length,
+      targetPossible,
+      possible,
+      coverageRate: rate(observations.length, possible),
+      brandMentions: mentions,
+      directCitations: citations,
+      brandMentionRate: rate(mentions, observations.length),
+      directCitationRate: rate(citations, observations.length),
+      observations,
+      accuracyRisks: observations.filter(
+        (observation) => observation.accuracy === 'mixed'
+          || observation.accuracy === 'inaccurate',
+      ),
+    },
+    byIntent,
+    byPageFamily,
+    opportunities: [...baseline.opportunities].sort(
+      (left, right) => left.priority - right.priority,
+    ),
+    guardrails: structuredClone(baseline.guardrails),
+    comparison: null,
+  };
+}
+
+function observationIndex(scorecard) {
+  return new Map(
+    scorecard.ai.observations
+      .map((observation) => [
+        `${observation.queryId}:${observation.platform}`,
+        observation,
+      ]),
+  );
+}
+
+const MEANINGFUL_ABSOLUTE_CHANGE = Object.freeze({
+  ctr: 0.01,
+  averagePosition: 1,
+  indexedPages: 5,
+  clicks: 10,
+  impressions: 100,
+  sessions: 10,
+  dashboardLaunches: 1,
+  pricingViews: 1,
+  signUps: 1,
+  proConversions: 1,
+  apiActions: 1,
+  mcpActions: 1,
+});
+const RELATIVE_CHANGE_METRICS = new Set([
+  'clicks',
+  'impressions',
+  ...REFERRAL_METRICS,
+]);
+
+function metricDelta(previous, current, metric) {
+  const before = previous.metrics[metric];
+  const after = current.metrics[metric];
+  if (!Number.isFinite(before) || !Number.isFinite(after)) return null;
+  const absolute = round(after - before);
+  const relative = before === 0 ? null : round((after - before) / Math.abs(before));
+  const exceedsAbsoluteThreshold = Math.abs(absolute)
+    >= MEANINGFUL_ABSOLUTE_CHANGE[metric];
+  const exceedsRelativeThreshold = RELATIVE_CHANGE_METRICS.has(metric)
+    && relative !== null
+    && Math.abs(relative) >= 0.1;
+  const meaningful = exceedsAbsoluteThreshold || exceedsRelativeThreshold;
+  return { before, after, absolute, relative, meaningful };
+}
+
+function compareWindowedSource(previous, current, metricNames) {
+  if (
+    previous?.status === 'unavailable'
+    || current?.status === 'unavailable'
+    || !previous.windows?.length
+    || !current.windows?.length
+  ) {
+    return null;
+  }
+  const currentWindow = current.windows.find(
+    (window) => window.label === previous.windows[0].label,
+  ) ?? current.windows[0];
+  const previousWindow = previous.windows.find(
+    (window) => window.label === currentWindow.label,
+  ) ?? previous.windows[0];
+  return Object.fromEntries(
+    metricNames.map((metric) => [
+      metric,
+      metricDelta(previousWindow, currentWindow, metric),
+    ]),
+  );
+}
+
+export function compareScorecards(previous, current) {
+  const previousObservations = observationIndex(previous);
+  const currentObservations = observationIndex(current);
+  const newCitations = [];
+  const lostCitations = [];
+  const newlyObserved = [];
+  const noLongerObserved = [];
+  for (const [key, observation] of currentObservations) {
+    const previousObservation = previousObservations.get(key);
+    if (!previousObservation) {
+      newlyObserved.push(structuredClone(observation));
+    } else if (!previousObservation.directCitation && observation.directCitation) {
+      newCitations.push(structuredClone(observation));
+    }
+  }
+  for (const [key, observation] of previousObservations) {
+    const currentObservation = currentObservations.get(key);
+    if (!currentObservation) {
+      noLongerObserved.push(structuredClone(observation));
+    } else if (observation.directCitation && !currentObservation.directCitation) {
+      lostCitations.push(structuredClone(observation));
+    }
+  }
+  const byObservationKey = (left, right) => (
+    `${left.queryId}:${left.platform}`.localeCompare(`${right.queryId}:${right.platform}`)
+  );
+
+  return {
+    previousBaselineId: previous.baselineId,
+    currentBaselineId: current.baselineId,
+    newCitations: newCitations.sort(byObservationKey),
+    lostCitations: lostCitations.sort(byObservationKey),
+    newlyObserved: newlyObserved.sort(byObservationKey),
+    noLongerObserved: noLongerObserved.sort(byObservationKey),
+    search: {
+      googleSearchConsole: compareWindowedSource(
+        previous.search.googleSearchConsole,
+        current.search.googleSearchConsole,
+        SEARCH_METRICS,
+      ),
+      bingWebmaster: compareWindowedSource(
+        previous.search.bingWebmaster,
+        current.search.bingWebmaster,
+        SEARCH_METRICS,
+      ),
+    },
+    referrals: compareWindowedSource(
+      previous.referrals,
+      current.referrals,
+      REFERRAL_METRICS,
+    ),
+    entityAnswerRisks: structuredClone(current.ai.accuracyRisks),
+  };
+}
+
+function percent(value) {
+  return value === null ? 'Unavailable' : `${round(value * 100, 1)}%`;
+}
+
+function displayStatus(source) {
+  const status = source.status[0].toUpperCase() + source.status.slice(1);
+  return source.status === 'available'
+    ? status
+    : `${status} — ${source.reason}`;
+}
+
+function markdownCell(value) {
+  return String(value ?? '').replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function searchProviderRows(scorecard) {
+  return [
+    ['Google Search Console', scorecard.search.googleSearchConsole],
+    ['Bing Webmaster', scorecard.search.bingWebmaster],
+    ['Referral analytics', scorecard.referrals],
+  ];
+}
+
+function preferredWindow(source) {
+  return source.windows.find(({ label }) => label === '28d') ?? source.windows[0];
+}
+
+function formatSearchPerformance(source, includeIndexedPages = false) {
+  const window = preferredWindow(source);
+  const { metrics } = window;
+  if (Object.values(metrics).every((value) => value === null)) {
+    return source.status === 'available' ? 'No normalized rows' : 'Unavailable';
+  }
+  const fields = [
+    ...(includeIndexedPages ? [`${metrics.indexedPages ?? '—'} indexed`] : []),
+    `${metrics.impressions ?? '—'} imp`,
+    `${metrics.clicks ?? '—'} clicks`,
+    `${percent(metrics.ctr)}`,
+    `pos ${metrics.averagePosition ?? '—'}`,
+  ];
+  return `${window.label}: ${fields.join(' / ')}`;
+}
+
+function referralMetricCell(source, metric) {
+  const value = preferredWindow(source).metrics[metric];
+  return value === null ? 'Unavailable' : value;
+}
+
+function formatComparison(comparison) {
+  if (!comparison) {
+    return [
+      '## Monthly comparison',
+      '',
+      'First recorded period; no previous baseline was supplied. The next run should',
+      'pass `--previous <baseline.json>` to report new/lost citations, meaningful',
+      'search and CTR changes, referral movement, and entity-answer risks.',
+      '',
+    ];
+  }
+  const citationLabel = (observation) => (
+    `${observation.queryId} on ${PLATFORM_LABELS[observation.platform]}`
+  );
+  const meaningfulSearch = [];
+  const indexingRegressions = [];
+  for (const [provider, metrics] of Object.entries(comparison.search)) {
+    if (!metrics) continue;
+    for (const [metric, delta] of Object.entries(metrics)) {
+      if (delta?.meaningful) {
+        meaningfulSearch.push(
+          `${provider}.${metric}: ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`,
+        );
+      }
+    }
+    if (metrics.indexedPages?.meaningful && metrics.indexedPages.absolute < 0) {
+      indexingRegressions.push(
+        `${provider}: ${metrics.indexedPages.before} → ${metrics.indexedPages.after}`,
+      );
+    }
+  }
+  const meaningfulReferrals = Object.entries(comparison.referrals ?? {})
+    .filter(([, delta]) => delta?.meaningful)
+    .map(([metric, delta]) => (
+      `${metric}: ${delta.before} → ${delta.after} (${delta.absolute >= 0 ? '+' : ''}${delta.absolute})`
+    ));
+  return [
+    '## Monthly comparison',
+    '',
+    `Compared \`${comparison.previousBaselineId}\` with \`${comparison.currentBaselineId}\`.`,
+    '',
+    `- New citations: ${comparison.newCitations.length ? comparison.newCitations.map(citationLabel).join('; ') : 'none'}`,
+    `- Lost citations: ${comparison.lostCitations.length ? comparison.lostCitations.map(citationLabel).join('; ') : 'none'}`,
+    `- Newly observed query/platform pairs: ${comparison.newlyObserved.length ? comparison.newlyObserved.map(citationLabel).join('; ') : 'none'}`,
+    `- No longer observed query/platform pairs: ${comparison.noLongerObserved.length ? comparison.noLongerObserved.map(citationLabel).join('; ') : 'none'}`,
+    `- Meaningful search changes: ${meaningfulSearch.length ? meaningfulSearch.join('; ') : 'none or unavailable'}`,
+    `- Indexing regressions: ${indexingRegressions.length ? indexingRegressions.join('; ') : 'none or unavailable'}`,
+    `- Referral/outcome movement: ${meaningfulReferrals.length ? meaningfulReferrals.join('; ') : 'none or unavailable'}`,
+    `- Entity answers needing review: ${comparison.entityAnswerRisks.length}`,
+    '',
+  ];
+}
+
+export function formatScorecardMarkdown(scorecard) {
+  const lines = [
+    `# SEO and AI-citation visibility scorecard — ${scorecard.baselineId}`,
+    '',
+    `Generated from repository revision \`${scorecard.repositoryRevision}\` at`,
+    `\`${scorecard.generatedAt}\`. Missing provider data is reported as unavailable,`,
+    'never coerced to zero.',
+    '',
+    '## Collection context',
+    '',
+    `- Geography: ${scorecard.collectionContext.geography}`,
+    `- Locale: ${scorecard.collectionContext.locale}`,
+    `- Signed-in state: ${scorecard.collectionContext.signedInStates.join(' / ')}`,
+    `- Device: ${scorecard.collectionContext.device}`,
+    `- Limitations: ${scorecard.collectionContext.limitations.join(' ')}`,
+    '',
+    '## Data availability',
+    '',
+    '| Source | Status | Windows |',
+    '| --- | --- | --- |',
+    ...searchProviderRows(scorecard).map(([label, source]) => (
+      `| ${label} | ${markdownCell(displayStatus(source))} | ${source.windows.map((window) => window.label).join(', ')} |`
+    )),
+    '',
+    '| AI surface | Status |',
+    '| --- | --- |',
+    ...scorecard.ai.surfaces.map((surface) => (
+      `| ${PLATFORM_LABELS[surface.platform]} | ${markdownCell(displayStatus(surface))} |`
+    )),
+    '',
+    `Referral families: ${scorecard.referrals.classification.families.map((family) => family.label).join(', ')}.`,
+    '',
+    '## Query registry',
+    '',
+    `${scorecard.querySet.total} reviewed queries, split by decision intent and target page family.`,
+    '',
+    '| Intent | Queries | GSC query performance | Bing query performance | AI observations | Mention rate | Direct-citation rate |',
+    '| --- | ---: | --- | --- | ---: | ---: | ---: |',
+    ...Object.entries(scorecard.byIntent).map(([intent, slice]) => (
+      `| ${INTENT_LABELS[intent]} | ${slice.queries} | ${formatSearchPerformance(slice.search.googleSearchConsole)} | ${formatSearchPerformance(slice.search.bingWebmaster)} | ${slice.observations}/${slice.possibleObservations} | ${percent(slice.brandMentionRate)} | ${percent(slice.directCitationRate)} |`
+    )),
+    '',
+    '| Page family | Queries | GSC page performance | Bing page performance | AI observations | Mention rate | Direct-citation rate |',
+    '| --- | ---: | --- | --- | ---: | ---: | ---: |',
+    ...Object.entries(scorecard.byPageFamily).map(([family, slice]) => (
+      `| ${PAGE_FAMILY_LABELS[family]} | ${slice.queries} | ${formatSearchPerformance(slice.search.googleSearchConsole, true)} | ${formatSearchPerformance(slice.search.bingWebmaster, true)} | ${slice.observations}/${slice.possibleObservations} | ${percent(slice.brandMentionRate)} | ${percent(slice.directCitationRate)} |`
+    )),
+    '',
+    '## Referral and product outcomes',
+    '',
+    'Referral segments retain both the major referrer family and landing-page family.',
+    'Unavailable aggregates remain unavailable in every slice.',
+    '',
+    '| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ...scorecard.referrals.classification.families.map(({ id, label }) => {
+      const source = scorecard.referrals.byReferrerFamily[id];
+      return `| ${label} | ${referralMetricCell(source, 'sessions')} | ${referralMetricCell(source, 'dashboardLaunches')} | ${referralMetricCell(source, 'pricingViews')} | ${referralMetricCell(source, 'signUps')} | ${referralMetricCell(source, 'proConversions')} | ${referralMetricCell(source, 'apiActions')} | ${referralMetricCell(source, 'mcpActions')} |`;
+    }),
+    '',
+    '| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ...Object.entries(scorecard.referrals.byPageFamily).map(([family, source]) => (
+      `| ${PAGE_FAMILY_LABELS[family]} | ${referralMetricCell(source, 'sessions')} | ${referralMetricCell(source, 'dashboardLaunches')} | ${referralMetricCell(source, 'pricingViews')} | ${referralMetricCell(source, 'signUps')} | ${referralMetricCell(source, 'proConversions')} | ${referralMetricCell(source, 'apiActions')} | ${referralMetricCell(source, 'mcpActions')} |`
+    )),
+    '',
+    '## AI-answer audit',
+    '',
+    `Coverage: ${scorecard.ai.observed}/${scorecard.ai.possible} (${percent(scorecard.ai.coverageRate)}).`,
+    `Full target matrix: ${scorecard.ai.targetPossible} query/platform pairs.`,
+    `Observed mention rate: ${percent(scorecard.ai.brandMentionRate)}.`,
+    `Observed direct-citation rate: ${percent(scorecard.ai.directCitationRate)}.`,
+    'These are descriptive observations, not causal or population-level estimates.',
+    '',
+    '| Platform | Brand | Citation | Sentiment | Accuracy | Cited URLs |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...scorecard.ai.observations.map((observation) => (
+      `| ${PLATFORM_LABELS[observation.platform]} | ${observation.brandMention ? 'Mention' : 'No mention'} | ${observation.directCitation ? 'Direct citation' : 'No direct citation'} | ${observation.sentiment} | ${observation.accuracy} | ${observation.citedUrls.map((url) => `[link](${url})`).join(', ') || 'none'} |`
+    )),
+    '',
+    '### Accuracy and entity risks',
+    '',
+    ...(scorecard.ai.accuracyRisks.length
+      ? scorecard.ai.accuracyRisks.map((observation) => (
+        `- ${PLATFORM_LABELS[observation.platform]} / ${observation.queryId}: ${observation.summary}`
+      ))
+      : ['- No mixed or inaccurate answers recorded.']),
+    '',
+    ...formatComparison(scorecard.comparison),
+    '## Top five opportunities',
+    '',
+    ...scorecard.opportunities.flatMap((opportunity) => [
+      `### ${opportunity.priority}. ${opportunity.title}`,
+      '',
+      `- Evidence: ${opportunity.evidence}`,
+      `- Experiment: ${opportunity.experiment}`,
+      `- Success criteria: ${opportunity.successCriteria}`,
+      `- Query IDs: ${opportunity.queryIds.join(', ')}`,
+      '',
+    ]),
+    '## Reproduction contract',
+    '',
+    '1. Use the same query text from `query-set.json`; do not paraphrase between platforms.',
+    '2. Record UTC date/time, country-level geography, locale, device, and whether the',
+    '   surface was signed-out or signed-in. Do not record account identifiers or prompts',
+    '   unrelated to this reviewed query set.',
+    '3. Count a direct citation only when the answer links to a `worldmonitor.app` URL.',
+    '   A mention supported only by a directory, review, or social post is not a direct citation.',
+    '4. Export Search Console/Bing data through supported product exports or APIs. Do not',
+    '   scrape search-result pages or commit property IDs, tokens, or credentials.',
+    '5. Reconcile referral aggregates with the analytics provider and keep prompt text out',
+    '   of analytics. Use bounded source/page-family fields and existing UTM attribution.',
+    '',
+    '## Guardrails',
+    '',
+    ...scorecard.guardrails.map((guardrail) => `- ${guardrail}`),
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function parseArgs(args) {
+  const options = { check: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--check') {
+      options.check = true;
+      continue;
+    }
+    invariant(
+      ['--queries', '--baseline', '--previous', '--output'].includes(argument),
+      `unknown argument ${argument}`,
+    );
+    const value = args[index + 1];
+    invariant(isNonEmptyString(value), `${argument} requires a value`);
+    options[argument.slice(2)] = value;
+    index += 1;
+  }
+  invariant(options.queries, '--queries is required');
+  invariant(options.baseline, '--baseline is required');
+  if (options.check) invariant(options.output, '--check requires --output');
+  return options;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(path), 'utf8'));
+}
+
+export async function runCli(args) {
+  const options = parseArgs(args);
+  const querySet = readJson(options.queries);
+  const baseline = readJson(options.baseline);
+  const scorecard = buildScorecard(querySet, baseline);
+  if (options.previous) {
+    const previous = buildScorecard(querySet, readJson(options.previous));
+    scorecard.comparison = compareScorecards(previous, scorecard);
+  }
+  const markdown = formatScorecardMarkdown(scorecard);
+  if (!options.output) {
+    process.stdout.write(markdown);
+    return markdown;
+  }
+  const outputPath = resolve(options.output);
+  if (options.check) {
+    const committed = readFileSync(outputPath, 'utf8');
+    invariant(
+      committed === markdown,
+      `${options.output} is stale; regenerate it without --check`,
+    );
+    return markdown;
+  }
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, markdown);
+  return markdown;
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -30,6 +30,16 @@ const baseline = readJson(
   'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
 );
 
+function buildComparableScorecards() {
+  const currentBaseline = structuredClone(baseline);
+  currentBaseline.baselineId = '2026-08-27';
+  currentBaseline.observedAt = '2026-08-27T12:00:00Z';
+  return [
+    buildScorecard(querySet, baseline),
+    buildScorecard(querySet, currentBaseline),
+  ];
+}
+
 describe('SEO and AI visibility query registry', () => {
   it('keeps a reviewed 20-30 query set with every required decision field', () => {
     assert.doesNotThrow(() => validateQuerySet(querySet));
@@ -70,6 +80,17 @@ describe('SEO and AI visibility query registry', () => {
       () => validateQuerySet(missingReference),
       /referenceEntities must contain at least one/,
     );
+  });
+
+  it('rejects impossible and non-ISO review dates', () => {
+    for (const reviewedAt of ['2026-02-30', 'July 27, 2026']) {
+      const invalid = structuredClone(querySet);
+      invalid.reviewedAt = reviewedAt;
+      assert.throws(
+        () => validateQuerySet(invalid),
+        /reviewedAt must be an ISO calendar date/,
+      );
+    }
   });
 });
 
@@ -201,6 +222,71 @@ describe('SEO and AI visibility baseline', () => {
     assert.throws(
       () => validateBaseline(mislabeled, querySet),
       /label must match the inclusive calendar-day span/,
+    );
+  });
+
+  it('rejects impossible calendar dates and malformed UTC observation times', () => {
+    const impossibleDate = structuredClone(baseline);
+    impossibleDate.search.googleSearchConsole.windows[0].startDate = '2026-02-30';
+    impossibleDate.search.googleSearchConsole.windows[0].endDate = '2026-03-29';
+    assert.throws(
+      () => validateBaseline(impossibleDate, querySet),
+      /startDate must be an ISO calendar date/,
+    );
+
+    const malformedTimestamp = structuredClone(baseline);
+    malformedTimestamp.observedAt = '2026-02-30T17:15:05Z';
+    assert.throws(
+      () => validateBaseline(malformedTimestamp, querySet),
+      /observedAt must be an ISO UTC date-time/,
+    );
+  });
+
+  it('rejects metrics outside their measurement domains', () => {
+    const availableSource = (metrics) => ({
+      status: 'available',
+      property: null,
+      reason: null,
+      windows: baseline.search.googleSearchConsole.windows.map((window) => ({
+        ...structuredClone(window),
+        metrics,
+      })),
+      queryRows: [],
+      pageFamilyRows: [],
+    });
+    const invalidMetrics = [
+      ['impressions', -1, /impressions must be non-negative/],
+      ['ctr', 1.01, /ctr must be between 0 and 1/],
+      ['averagePosition', -0.1, /averagePosition must be non-negative/],
+    ];
+
+    for (const [metric, value, expected] of invalidMetrics) {
+      const invalid = structuredClone(baseline);
+      invalid.search.googleSearchConsole = availableSource({
+        indexedPages: 1,
+        impressions: 10,
+        clicks: 1,
+        ctr: 0.1,
+        averagePosition: 2,
+        [metric]: value,
+      });
+      assert.throws(() => validateBaseline(invalid, querySet), expected);
+    }
+  });
+
+  it('keeps observation context inside the declared collection contract', () => {
+    const wrongGeography = structuredClone(baseline);
+    wrongGeography.aiObservations[0].geography = 'United States';
+    assert.throws(
+      () => validateBaseline(wrongGeography, querySet),
+      /geography must equal collectionContext.geography/,
+    );
+
+    const undeclaredSignedInState = structuredClone(baseline);
+    undeclaredSignedInState.collectionContext.signedInStates = ['signed-out'];
+    assert.throws(
+      () => validateBaseline(undeclaredSignedInState, querySet),
+      /signedInState must be declared in collectionContext.signedInStates/,
     );
   });
 
@@ -545,8 +631,7 @@ describe('scorecard computation', () => {
   });
 
   it('compares finite metrics from partial provider exports', () => {
-    const previous = buildScorecard(querySet, baseline);
-    const current = buildScorecard(querySet, baseline);
+    const [previous, current] = buildComparableScorecards();
     previous.search.googleSearchConsole = {
       status: 'partial',
       reason: 'Indexation was not exported.',
@@ -583,8 +668,7 @@ describe('scorecard computation', () => {
   });
 
   it('prefers the 28d window for comparisons regardless of authored window order', () => {
-    const previous = buildScorecard(querySet, baseline);
-    const current = buildScorecard(querySet, baseline);
+    const [previous, current] = buildComparableScorecards();
     const searchWindow = (label, impressions) => ({
       label,
       metrics: {
@@ -619,8 +703,7 @@ describe('scorecard computation', () => {
   });
 
   it('classifies meaningful changes via the relative arm and guards before=0 ratios', () => {
-    const previous = buildScorecard(querySet, baseline);
-    const current = buildScorecard(querySet, baseline);
+    const [previous, current] = buildComparableScorecards();
     const referralWindow = (metrics) => ({ label: '28d', metrics });
     previous.referrals = {
       ...previous.referrals,
@@ -678,8 +761,7 @@ describe('scorecard computation', () => {
   });
 
   it('does not compare provider metrics for disjoint window labels', () => {
-    const previous = buildScorecard(querySet, baseline);
-    const current = buildScorecard(querySet, baseline);
+    const [previous, current] = buildComparableScorecards();
     previous.search.googleSearchConsole = {
       status: 'partial',
       reason: 'Only a 28-day export was available.',
@@ -712,6 +794,49 @@ describe('scorecard computation', () => {
     const comparison = compareScorecards(previous, current);
 
     assert.equal(comparison.search.googleSearchConsole, null);
+  });
+
+  it('rejects reversed or incompatible scorecard comparisons', () => {
+    const [previous, current] = buildComparableScorecards();
+    current.generatedAt = previous.generatedAt;
+    assert.throws(
+      () => compareScorecards(previous, current),
+      /current scorecard must be newer than previous scorecard/,
+    );
+
+    current.generatedAt = '2026-08-27T12:00:00Z';
+    current.collectionContext.geography = 'United States';
+    assert.throws(
+      () => compareScorecards(previous, current),
+      /collectionContext.geography must match/,
+    );
+
+    current.collectionContext.geography = previous.collectionContext.geography;
+    current.querySetId = 'different-query-set';
+    assert.throws(
+      () => compareScorecards(previous, current),
+      /querySetId must match/,
+    );
+  });
+
+  it('does not classify citation changes across different observation contexts', () => {
+    const previousBaseline = structuredClone(baseline);
+    previousBaseline.aiObservations[0].directCitation = false;
+    previousBaseline.aiObservations[0].citedUrls = ['https://example.com/source'];
+    const currentBaseline = structuredClone(baseline);
+    currentBaseline.baselineId = '2026-08-27';
+    currentBaseline.observedAt = '2026-08-27T12:00:00Z';
+    currentBaseline.aiObservations[0].signedInState = 'signed-in';
+
+    const comparison = compareScorecards(
+      buildScorecard(querySet, previousBaseline),
+      buildScorecard(querySet, currentBaseline),
+    );
+
+    assert.deepEqual(comparison.newCitations, []);
+    assert.deepEqual(comparison.lostCitations, []);
+    assert.equal(comparison.newlyObserved[0].signedInState, 'signed-in');
+    assert.equal(comparison.noLongerObserved[0].signedInState, 'signed-out');
   });
 
   it('renders availability, reproducibility, risks, and the top-five work queue', () => {

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -1,0 +1,610 @@
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  AI_PLATFORMS,
+  PAGE_FAMILIES,
+  buildScorecard,
+  compareScorecards,
+  formatScorecardMarkdown,
+  runCli,
+  validateBaseline,
+  validateQuerySet,
+} from '../scripts/seo-ai-visibility-scorecard.mjs';
+
+const readJson = (relativePath) => JSON.parse(
+  readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
+);
+
+const querySet = readJson('docs/research/seo-ai-visibility/query-set.json');
+const baseline = readJson(
+  'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+);
+
+describe('SEO and AI visibility query registry', () => {
+  it('keeps a reviewed 20-30 query set with every required decision field', () => {
+    assert.doesNotThrow(() => validateQuerySet(querySet));
+    assert.equal(querySet.queries.length, 25);
+    assert.deepEqual(
+      [...new Set(querySet.queries.map((query) => query.intent))].sort(),
+      [
+        'branded_entity',
+        'category_definition',
+        'developer_agent',
+        'evaluation',
+        'use_case',
+      ],
+    );
+    assert.deepEqual(
+      [...new Set(querySet.queries.map((query) => query.targetPage.family))].sort(),
+      [...PAGE_FAMILIES].sort(),
+    );
+    for (const query of querySet.queries) {
+      assert.ok(query.targetAudience.length > 0, query.id);
+      assert.ok(query.conversionGoal.length > 0, query.id);
+      assert.ok(query.referenceEntities.length > 0, query.id);
+      assert.ok(
+        query.referenceEntities.every((entity) => entity.name && entity.url),
+        `${query.id}: named competitors/sources need URLs`,
+      );
+    }
+  });
+
+  it('rejects duplicate IDs and incomplete competitor/source evidence', () => {
+    const duplicate = structuredClone(querySet);
+    duplicate.queries[1].id = duplicate.queries[0].id;
+    assert.throws(() => validateQuerySet(duplicate), /duplicate query id/);
+
+    const missingReference = structuredClone(querySet);
+    missingReference.queries[0].referenceEntities = [];
+    assert.throws(
+      () => validateQuerySet(missingReference),
+      /referenceEntities must contain at least one/,
+    );
+  });
+});
+
+describe('SEO and AI visibility baseline', () => {
+  it('validates explicit availability, observation, and reproduction contracts', () => {
+    assert.doesNotThrow(() => validateBaseline(baseline, querySet));
+    assert.deepEqual(
+      [...new Set(baseline.aiObservations.map((row) => row.platform))].sort(),
+      [...AI_PLATFORMS].sort(),
+    );
+    assert.equal(baseline.aiObservations.length, 4);
+    assert.equal(baseline.opportunities.length, 5);
+    assert.equal(baseline.collectionContext.geography, 'France');
+    assert.equal(baseline.collectionContext.locale, 'en');
+    assert.deepEqual(
+      baseline.aiSurfaces.map(({ platform }) => platform).sort(),
+      [...AI_PLATFORMS].sort(),
+    );
+    assert.deepEqual(
+      baseline.referrals.classification.families.map((family) => family.id),
+      [
+        'chatgpt',
+        'perplexity',
+        'google_search_ai',
+        'copilot_bing',
+        'claude',
+        'other_ai_search',
+        'unknown_direct',
+      ],
+    );
+    assert.deepEqual(baseline.search.googleSearchConsole.queryRows, []);
+    assert.deepEqual(baseline.search.googleSearchConsole.pageFamilyRows, []);
+    assert.deepEqual(baseline.search.bingWebmaster.queryRows, []);
+    assert.deepEqual(baseline.search.bingWebmaster.pageFamilyRows, []);
+    assert.deepEqual(baseline.referrals.segments, []);
+  });
+
+  it('never lets unavailable data masquerade as zero', () => {
+    const invalid = structuredClone(baseline);
+    invalid.search.googleSearchConsole.windows[0].metrics.impressions = 0;
+    assert.throws(
+      () => validateBaseline(invalid, querySet),
+      /unavailable metrics must be null/,
+    );
+  });
+
+  it('distinguishes an AI brand mention from a direct citation', () => {
+    const invalid = structuredClone(baseline);
+    invalid.aiObservations[0].directCitation = true;
+    invalid.aiObservations[0].citedUrls = [];
+    assert.throws(
+      () => validateBaseline(invalid, querySet),
+      /directCitation must match World Monitor cited URLs/,
+    );
+
+    const citationWithoutBrandText = structuredClone(baseline);
+    citationWithoutBrandText.aiObservations[0].brandMention = false;
+    assert.doesNotThrow(
+      () => validateBaseline(citationWithoutBrandText, querySet),
+    );
+
+    const contradictory = structuredClone(baseline);
+    contradictory.aiObservations[0].directCitation = false;
+    assert.throws(
+      () => validateBaseline(contradictory, querySet),
+      /directCitation must match World Monitor cited URLs/,
+    );
+  });
+
+  it('represents unavailable AI surfaces without fabricating observations', () => {
+    const unavailable = structuredClone(baseline);
+    const perplexity = unavailable.aiSurfaces.find(
+      ({ platform }) => platform === 'perplexity',
+    );
+    perplexity.status = 'unavailable';
+    perplexity.reason = 'Surface was not available in the recorded geography.';
+    unavailable.aiObservations = unavailable.aiObservations.filter(
+      ({ platform }) => platform !== 'perplexity',
+    );
+
+    assert.doesNotThrow(() => validateBaseline(unavailable, querySet));
+    const scorecard = buildScorecard(querySet, unavailable);
+    assert.equal(scorecard.ai.targetPossible, 100);
+    assert.equal(scorecard.ai.possible, 75);
+    assert.equal(scorecard.ai.observed, 3);
+    assert.equal(scorecard.ai.coverageRate, 0.04);
+  });
+
+  it('rejects committed property IDs, malformed guardrails, and invalid priorities', () => {
+    const property = structuredClone(baseline);
+    property.search.googleSearchConsole.property = 'sc-domain:worldmonitor.app';
+    assert.throws(
+      () => validateBaseline(property, querySet),
+      /property must remain null/,
+    );
+
+    const guardrails = structuredClone(baseline);
+    guardrails.guardrails = 'do not scrape';
+    assert.throws(
+      () => validateBaseline(guardrails, querySet),
+      /guardrails must be a non-empty array/,
+    );
+
+    const priority = structuredClone(baseline);
+    priority.opportunities[4].priority = 4.5;
+    assert.throws(
+      () => validateBaseline(priority, querySet),
+      /priorities must be exactly the integers 1-5/,
+    );
+
+    const duplicateWindow = structuredClone(baseline);
+    duplicateWindow.search.googleSearchConsole.windows[1].label = '28d';
+    assert.throws(
+      () => validateBaseline(duplicateWindow, querySet),
+      /window labels must be unique/,
+    );
+  });
+});
+
+describe('scorecard computation', () => {
+  it('reports intent and page-family slices without inventing missing search data', () => {
+    const scorecard = buildScorecard(querySet, baseline);
+
+    assert.equal(scorecard.querySet.total, 25);
+    assert.equal(scorecard.ai.observed, 4);
+    assert.equal(scorecard.ai.possible, 100);
+    assert.equal(scorecard.ai.brandMentions, 4);
+    assert.equal(scorecard.ai.directCitations, 3);
+    assert.equal(scorecard.ai.coverageRate, 0.04);
+    assert.equal(scorecard.ai.brandMentionRate, 1);
+    assert.equal(scorecard.ai.directCitationRate, 0.75);
+    assert.equal(scorecard.search.googleSearchConsole.status, 'unavailable');
+    assert.equal(
+      scorecard.search.googleSearchConsole.windows[0].metrics.impressions,
+      null,
+    );
+    assert.equal(scorecard.referrals.status, 'unavailable');
+    assert.equal(Object.keys(scorecard.byIntent).length, 5);
+    assert.equal(
+      Object.keys(scorecard.byPageFamily).length,
+      PAGE_FAMILIES.length,
+    );
+    assert.equal(
+      scorecard.byIntent.category_definition.search.googleSearchConsole
+        .windows[0].metrics.impressions,
+      null,
+    );
+    assert.equal(
+      scorecard.byPageFamily.homepage.search.googleSearchConsole
+        .windows[0].metrics.indexedPages,
+      null,
+    );
+    assert.equal(
+      scorecard.referrals.byReferrerFamily.chatgpt.windows[0].metrics.sessions,
+      null,
+    );
+  });
+
+  it('aggregates supported query, page-family, and referral outcome rows', () => {
+    const measured = structuredClone(baseline);
+    measured.search.googleSearchConsole = {
+      status: 'available',
+      property: null,
+      reason: null,
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-06-30',
+          endDate: '2026-07-27',
+          metrics: {
+            indexedPages: 12,
+            impressions: 150,
+            clicks: 15,
+            ctr: 0.1,
+            averagePosition: 9.3333,
+          },
+        },
+      ],
+      queryRows: [
+        {
+          windowLabel: '28d',
+          queryId: 'q01',
+          metrics: {
+            impressions: 100,
+            clicks: 10,
+            ctr: 0.1,
+            averagePosition: 8,
+          },
+        },
+        {
+          windowLabel: '28d',
+          queryId: 'q02',
+          metrics: {
+            impressions: 50,
+            clicks: 5,
+            ctr: 0.1,
+            averagePosition: 12,
+          },
+        },
+      ],
+      pageFamilyRows: [
+        {
+          windowLabel: '28d',
+          pageFamily: 'homepage',
+          metrics: {
+            indexedPages: 3,
+            impressions: 100,
+            clicks: 10,
+            ctr: 0.1,
+            averagePosition: 8,
+          },
+        },
+      ],
+    };
+    measured.referrals = {
+      ...measured.referrals,
+      status: 'available',
+      property: null,
+      reason: null,
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-06-30',
+          endDate: '2026-07-27',
+          metrics: {
+            sessions: 12,
+            dashboardLaunches: 4,
+            pricingViews: 3,
+            signUps: 2,
+            proConversions: 1,
+            apiActions: 1,
+            mcpActions: 1,
+          },
+        },
+      ],
+      segments: [
+        {
+          windowLabel: '28d',
+          referrerFamily: 'chatgpt',
+          landingPageFamily: 'homepage',
+          metrics: {
+            sessions: 8,
+            dashboardLaunches: 4,
+            pricingViews: 2,
+            signUps: 1,
+            proConversions: 1,
+            apiActions: 0,
+            mcpActions: 0,
+          },
+        },
+        {
+          windowLabel: '28d',
+          referrerFamily: 'perplexity',
+          landingPageFamily: 'homepage',
+          metrics: {
+            sessions: 4,
+            dashboardLaunches: 0,
+            pricingViews: 1,
+            signUps: 1,
+            proConversions: 0,
+            apiActions: 1,
+            mcpActions: 1,
+          },
+        },
+      ],
+    };
+
+    const scorecard = buildScorecard(querySet, measured);
+    const intentMetrics = scorecard.byIntent.category_definition.search
+      .googleSearchConsole.windows[0].metrics;
+    assert.deepEqual(intentMetrics, {
+      indexedPages: null,
+      impressions: 150,
+      clicks: 15,
+      ctr: 0.1,
+      averagePosition: 9.3333,
+    });
+    assert.deepEqual(
+      scorecard.byPageFamily.homepage.search.googleSearchConsole
+        .windows[0].metrics,
+      {
+        indexedPages: 3,
+        impressions: 100,
+        clicks: 10,
+        ctr: 0.1,
+        averagePosition: 8,
+      },
+    );
+    assert.equal(
+      scorecard.referrals.byReferrerFamily.chatgpt.windows[0].metrics
+        .proConversions,
+      1,
+    );
+    assert.equal(
+      scorecard.referrals.byPageFamily.homepage.windows[0].metrics.sessions,
+      12,
+    );
+  });
+
+  it('finds new/lost citations and meaningful search changes between periods', () => {
+    const previousBaseline = structuredClone(baseline);
+    previousBaseline.aiObservations.push({
+      ...structuredClone(previousBaseline.aiObservations[0]),
+      queryId: 'q21',
+      platform: 'chatgpt_search',
+      directCitation: false,
+      citedUrls: [],
+      summary: 'World Monitor was mentioned without a direct citation.',
+    });
+    const previous = buildScorecard(querySet, previousBaseline);
+    const nextBaseline = structuredClone(baseline);
+    nextBaseline.baselineId = '2026-08-27';
+    nextBaseline.observedAt = '2026-08-27T12:00:00Z';
+    nextBaseline.aiObservations[0].directCitation = false;
+    nextBaseline.aiObservations[0].citedUrls = [];
+    nextBaseline.aiObservations.push({
+      ...structuredClone(nextBaseline.aiObservations[0]),
+      queryId: 'q21',
+      platform: 'chatgpt_search',
+      directCitation: true,
+      citedUrls: ['https://www.worldmonitor.app/pricing.md'],
+    });
+    nextBaseline.search.googleSearchConsole = {
+      status: 'available',
+      property: null,
+      reason: null,
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-07-31',
+          endDate: '2026-08-27',
+          metrics: {
+            indexedPages: 210,
+            impressions: 1500,
+            clicks: 90,
+            ctr: 0.06,
+            averagePosition: 11.2,
+          },
+        },
+      ],
+      queryRows: [],
+      pageFamilyRows: [],
+    };
+    const next = buildScorecard(querySet, nextBaseline);
+    previous.search.googleSearchConsole = {
+      status: 'available',
+      property: null,
+      reason: null,
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-07-03',
+          endDate: '2026-07-30',
+          metrics: {
+            indexedPages: 220,
+            impressions: 1000,
+            clicks: 50,
+            ctr: 0.05,
+            averagePosition: 13.5,
+          },
+        },
+      ],
+    };
+    previous.referrals = {
+      ...previous.referrals,
+      status: 'available',
+      windows: [{
+        label: '28d',
+        metrics: {
+          sessions: 20,
+          dashboardLaunches: 5,
+          pricingViews: 4,
+          signUps: 2,
+          proConversions: 1,
+          apiActions: 1,
+          mcpActions: 0,
+        },
+      }],
+    };
+    next.referrals = {
+      ...next.referrals,
+      status: 'available',
+      windows: [{
+        label: '28d',
+        metrics: {
+          sessions: 35,
+          dashboardLaunches: 7,
+          pricingViews: 6,
+          signUps: 3,
+          proConversions: 2,
+          apiActions: 2,
+          mcpActions: 1,
+        },
+      }],
+    };
+
+    const comparison = compareScorecards(previous, next);
+
+    assert.deepEqual(
+      comparison.newCitations.map(({ queryId, platform }) => ({ queryId, platform })),
+      [{ queryId: 'q21', platform: 'chatgpt_search' }],
+    );
+    assert.deepEqual(
+      comparison.lostCitations.map(({ queryId, platform }) => ({ queryId, platform })),
+      [{ queryId: 'q01', platform: 'chatgpt_search' }],
+    );
+    assert.equal(comparison.search.googleSearchConsole.impressions.absolute, 500);
+    assert.equal(comparison.search.googleSearchConsole.impressions.relative, 0.5);
+    assert.equal(comparison.search.googleSearchConsole.ctr.absolute, 0.01);
+    assert.equal(comparison.search.googleSearchConsole.indexedPages.absolute, -10);
+    assert.equal(comparison.referrals.sessions.absolute, 15);
+
+    next.comparison = comparison;
+    const markdown = formatScorecardMarkdown(next);
+    assert.match(markdown, /Indexing regressions: googleSearchConsole: 220 → 210/);
+    assert.match(markdown, /Referral\/outcome movement: sessions: 20 → 35/);
+  });
+
+  it('does not turn sparse audit coverage into new or lost citations', () => {
+    const previous = buildScorecard(querySet, baseline);
+    const sparse = structuredClone(baseline);
+    sparse.baselineId = '2026-08-03';
+    sparse.observedAt = '2026-08-03T12:00:00Z';
+    sparse.aiObservations = sparse.aiObservations.filter(
+      ({ platform }) => platform !== 'chatgpt_search',
+    );
+    const current = buildScorecard(querySet, sparse);
+
+    const comparison = compareScorecards(previous, current);
+
+    assert.deepEqual(comparison.lostCitations, []);
+    assert.deepEqual(comparison.newCitations, []);
+    assert.deepEqual(
+      comparison.noLongerObserved.map(({ queryId, platform }) => ({
+        queryId,
+        platform,
+      })),
+      [{ queryId: 'q01', platform: 'chatgpt_search' }],
+    );
+  });
+
+  it('compares finite metrics from partial provider exports', () => {
+    const previous = buildScorecard(querySet, baseline);
+    const current = buildScorecard(querySet, baseline);
+    previous.search.googleSearchConsole = {
+      status: 'partial',
+      reason: 'Indexation was not exported.',
+      windows: [{
+        label: '28d',
+        metrics: {
+          indexedPages: null,
+          impressions: 100,
+          clicks: 10,
+          ctr: 0.1,
+          averagePosition: 12,
+        },
+      }],
+    };
+    current.search.googleSearchConsole = {
+      status: 'partial',
+      reason: 'Indexation was not exported.',
+      windows: [{
+        label: '28d',
+        metrics: {
+          indexedPages: null,
+          impressions: 250,
+          clicks: 30,
+          ctr: 0.12,
+          averagePosition: 10,
+        },
+      }],
+    };
+
+    const comparison = compareScorecards(previous, current);
+
+    assert.equal(comparison.search.googleSearchConsole.impressions.absolute, 150);
+    assert.equal(comparison.search.googleSearchConsole.indexedPages, null);
+  });
+
+  it('renders availability, reproducibility, risks, and the top-five work queue', () => {
+    const markdown = formatScorecardMarkdown(buildScorecard(querySet, baseline));
+
+    assert.match(markdown, /Google Search Console \\| Unavailable/);
+    assert.match(markdown, /Perplexity \\| Mention \\| No direct citation/);
+    assert.match(markdown, /France/);
+    assert.match(markdown, /signed-out/);
+    assert.match(markdown, /signed-in/);
+    assert.match(markdown, /## Top five opportunities/);
+    assert.doesNotMatch(markdown, /0 impressions/);
+  });
+
+  it('reproduces the committed scorecard from a clean output path', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'seo-scorecard-'));
+    const output = join(directory, 'scorecard.md');
+    try {
+      await runCli([
+        '--queries',
+        'docs/research/seo-ai-visibility/query-set.json',
+        '--baseline',
+        'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+        '--output',
+        output,
+      ]);
+      const generated = readFileSync(output, 'utf8');
+      const committed = readFileSync(
+        new URL(
+          '../docs/research/seo-ai-visibility/scorecards/2026-07-27.md',
+          import.meta.url,
+        ),
+        'utf8',
+      );
+      assert.equal(generated, committed);
+      await runCli([
+        '--queries',
+        'docs/research/seo-ai-visibility/query-set.json',
+        '--baseline',
+        'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+        '--output',
+        output,
+        '--check',
+      ]);
+      writeFileSync(output, 'stale scorecard\n');
+      await assert.rejects(
+        runCli([
+          '--queries',
+          'docs/research/seo-ai-visibility/query-set.json',
+          '--baseline',
+          'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+          '--output',
+          output,
+          '--check',
+        ]),
+        /is stale/,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -242,6 +242,43 @@ describe('SEO and AI visibility baseline', () => {
     );
   });
 
+  it('pins baselines to the exact reviewed query contract', () => {
+    const changedQuerySet = structuredClone(querySet);
+    changedQuerySet.queries[0].query = 'a materially different category query';
+
+    assert.throws(
+      () => validateBaseline(baseline, changedQuerySet),
+      /querySetDigest must match the supplied query set/,
+    );
+  });
+
+  it('rejects evidence recorded after the baseline snapshot', () => {
+    const futureObservation = structuredClone(baseline);
+    futureObservation.aiObservations[0].observedAt = '2026-07-27T18:00:00Z';
+    assert.throws(
+      () => validateBaseline(futureObservation, querySet),
+      /aiObservations\[0\]\.observedAt must not be after baseline\.observedAt/,
+    );
+
+    const futureWindow = structuredClone(baseline);
+    futureWindow.search.googleSearchConsole.windows[0] = {
+      ...futureWindow.search.googleSearchConsole.windows[0],
+      startDate: '2026-07-01',
+      endDate: '2026-07-28',
+    };
+    assert.throws(
+      () => validateBaseline(futureWindow, querySet),
+      /endDate must not be after the baseline observation date/,
+    );
+
+    const futureReview = structuredClone(querySet);
+    futureReview.reviewedAt = '2026-07-28';
+    assert.throws(
+      () => validateBaseline(baseline, futureReview),
+      /reviewedAt must not be after baseline\.observedAt/,
+    );
+  });
+
   it('rejects metrics outside their measurement domains', () => {
     const availableSource = (metrics) => ({
       status: 'available',
@@ -538,8 +575,8 @@ describe('scorecard computation', () => {
       windows: [
         {
           label: '28d',
-          startDate: '2026-07-03',
-          endDate: '2026-07-30',
+          startDate: '2026-06-30',
+          endDate: '2026-07-27',
           metrics: {
             indexedPages: 220,
             impressions: 1000,
@@ -555,6 +592,8 @@ describe('scorecard computation', () => {
       status: 'available',
       windows: [{
         label: '28d',
+        startDate: '2026-06-30',
+        endDate: '2026-07-27',
         metrics: {
           sessions: 20,
           dashboardLaunches: 5,
@@ -571,6 +610,8 @@ describe('scorecard computation', () => {
       status: 'available',
       windows: [{
         label: '28d',
+        startDate: '2026-07-31',
+        endDate: '2026-08-27',
         metrics: {
           sessions: 35,
           dashboardLaunches: 7,
@@ -605,6 +646,10 @@ describe('scorecard computation', () => {
     const markdown = formatScorecardMarkdown(next);
     assert.match(markdown, /Indexing regressions: googleSearchConsole \(28d\): 220 → 210/);
     assert.match(markdown, /Referral\/outcome movement: sessions \(28d\): 20 → 35/);
+    assert.match(
+      markdown,
+      /periods 2026-06-30\.\.2026-07-27 → 2026-07-31\.\.2026-08-27/,
+    );
   });
 
   it('does not turn sparse audit coverage into new or lost citations', () => {
@@ -637,6 +682,8 @@ describe('scorecard computation', () => {
       reason: 'Indexation was not exported.',
       windows: [{
         label: '28d',
+        startDate: '2026-06-30',
+        endDate: '2026-07-27',
         metrics: {
           indexedPages: null,
           impressions: 100,
@@ -651,6 +698,8 @@ describe('scorecard computation', () => {
       reason: 'Indexation was not exported.',
       windows: [{
         label: '28d',
+        startDate: '2026-07-31',
+        endDate: '2026-08-27',
         metrics: {
           indexedPages: null,
           impressions: 250,
@@ -669,8 +718,10 @@ describe('scorecard computation', () => {
 
   it('prefers the 28d window for comparisons regardless of authored window order', () => {
     const [previous, current] = buildComparableScorecards();
-    const searchWindow = (label, impressions) => ({
+    const searchWindow = (label, startDate, endDate, impressions) => ({
       label,
+      startDate,
+      endDate,
       metrics: {
         indexedPages: null,
         impressions,
@@ -682,12 +733,18 @@ describe('scorecard computation', () => {
     previous.search.googleSearchConsole = {
       status: 'partial',
       reason: 'Only aggregate exports were available.',
-      windows: [searchWindow('90d', 900), searchWindow('28d', 100)],
+      windows: [
+        searchWindow('90d', '2026-04-29', '2026-07-27', 900),
+        searchWindow('28d', '2026-06-30', '2026-07-27', 100),
+      ],
     };
     current.search.googleSearchConsole = {
       status: 'partial',
       reason: 'Only aggregate exports were available.',
-      windows: [searchWindow('28d', 250), searchWindow('90d', 2000)],
+      windows: [
+        searchWindow('28d', '2026-07-31', '2026-08-27', 250),
+        searchWindow('90d', '2026-05-30', '2026-08-27', 2000),
+      ],
     };
 
     const comparison = compareScorecards(previous, current);
@@ -704,11 +761,16 @@ describe('scorecard computation', () => {
 
   it('classifies meaningful changes via the relative arm and guards before=0 ratios', () => {
     const [previous, current] = buildComparableScorecards();
-    const referralWindow = (metrics) => ({ label: '28d', metrics });
+    const referralWindow = (startDate, endDate, metrics) => ({
+      label: '28d',
+      startDate,
+      endDate,
+      metrics,
+    });
     previous.referrals = {
       ...previous.referrals,
       status: 'available',
-      windows: [referralWindow({
+      windows: [referralWindow('2026-06-30', '2026-07-27', {
         sessions: 50,
         dashboardLaunches: 5,
         pricingViews: 4,
@@ -721,7 +783,7 @@ describe('scorecard computation', () => {
     current.referrals = {
       ...current.referrals,
       status: 'available',
-      windows: [referralWindow({
+      windows: [referralWindow('2026-07-31', '2026-08-27', {
         sessions: 59,
         dashboardLaunches: 5,
         pricingViews: 4,
@@ -796,6 +858,43 @@ describe('scorecard computation', () => {
     assert.equal(comparison.search.googleSearchConsole, null);
   });
 
+  it('rejects provider comparisons whose reporting windows do not advance', () => {
+    const [previous, current] = buildComparableScorecards();
+    const searchWindow = (startDate, endDate, impressions) => ({
+      label: '28d',
+      startDate,
+      endDate,
+      metrics: {
+        indexedPages: 10,
+        impressions,
+        clicks: 10,
+        ctr: 0.1,
+        averagePosition: 5,
+      },
+    });
+    previous.search.googleSearchConsole = {
+      status: 'available',
+      windows: [searchWindow('2026-06-30', '2026-07-27', 100)],
+    };
+    current.search.googleSearchConsole = {
+      status: 'available',
+      windows: [searchWindow('2026-05-01', '2026-05-28', 200)],
+    };
+
+    assert.throws(
+      () => compareScorecards(previous, current),
+      /googleSearchConsole current 28d window must advance beyond the previous window/,
+    );
+
+    current.search.googleSearchConsole.windows = [
+      searchWindow('2026-06-30', '2026-07-27', 200),
+    ];
+    assert.throws(
+      () => compareScorecards(previous, current),
+      /googleSearchConsole current 28d window must advance beyond the previous window/,
+    );
+  });
+
   it('rejects reversed or incompatible scorecard comparisons', () => {
     const [previous, current] = buildComparableScorecards();
     current.generatedAt = previous.generatedAt;
@@ -816,6 +915,13 @@ describe('scorecard computation', () => {
     assert.throws(
       () => compareScorecards(previous, current),
       /querySetId must match/,
+    );
+
+    current.querySetId = previous.querySetId;
+    current.querySetDigest = 'sha256:changed-query-contract';
+    assert.throws(
+      () => compareScorecards(previous, current),
+      /querySetDigest must match/,
     );
   });
 
@@ -847,6 +953,11 @@ describe('scorecard computation', () => {
     assert.match(markdown, /France/);
     assert.match(markdown, /signed-out/);
     assert.match(markdown, /signed-in/);
+    assert.match(markdown, /\| Query \| Platform \| Observed at \(UTC\) \| Context \|/);
+    assert.match(
+      markdown,
+      /\| q01 \| ChatGPT Search \| 2026-07-27T17:10:00Z \| France \/ en \/ signed-out \|/,
+    );
     assert.match(markdown, /## Top five opportunities/);
     assert.doesNotMatch(markdown, /0 impressions/);
   });

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -201,6 +202,21 @@ describe('SEO and AI visibility baseline', () => {
       () => validateBaseline(mislabeled, querySet),
       /label must match the inclusive calendar-day span/,
     );
+  });
+
+  it('validates every committed baseline in the directory', () => {
+    const baselinesDir = new URL(
+      '../docs/research/seo-ai-visibility/baselines/',
+      import.meta.url,
+    );
+    const names = readdirSync(baselinesDir).filter((name) => name.endsWith('.json'));
+    assert.ok(names.length >= 1, 'expected at least one committed baseline');
+    for (const name of names) {
+      const committed = JSON.parse(
+        readFileSync(new URL(name, baselinesDir), 'utf8'),
+      );
+      assert.doesNotThrow(() => validateBaseline(committed, querySet), name);
+    }
   });
 });
 
@@ -491,16 +507,18 @@ describe('scorecard computation', () => {
       comparison.lostCitations.map(({ queryId, platform }) => ({ queryId, platform })),
       [{ queryId: 'q01', platform: 'chatgpt_search' }],
     );
-    assert.equal(comparison.search.googleSearchConsole.impressions.absolute, 500);
-    assert.equal(comparison.search.googleSearchConsole.impressions.relative, 0.5);
-    assert.equal(comparison.search.googleSearchConsole.ctr.absolute, 0.01);
-    assert.equal(comparison.search.googleSearchConsole.indexedPages.absolute, -10);
-    assert.equal(comparison.referrals.sessions.absolute, 15);
+    assert.equal(comparison.search.googleSearchConsole.windowLabel, '28d');
+    assert.equal(comparison.search.googleSearchConsole.metrics.impressions.absolute, 500);
+    assert.equal(comparison.search.googleSearchConsole.metrics.impressions.relative, 0.5);
+    assert.equal(comparison.search.googleSearchConsole.metrics.ctr.absolute, 0.01);
+    assert.equal(comparison.search.googleSearchConsole.metrics.indexedPages.absolute, -10);
+    assert.equal(comparison.referrals.windowLabel, '28d');
+    assert.equal(comparison.referrals.metrics.sessions.absolute, 15);
 
     next.comparison = comparison;
     const markdown = formatScorecardMarkdown(next);
-    assert.match(markdown, /Indexing regressions: googleSearchConsole: 220 → 210/);
-    assert.match(markdown, /Referral\/outcome movement: sessions: 20 → 35/);
+    assert.match(markdown, /Indexing regressions: googleSearchConsole \(28d\): 220 → 210/);
+    assert.match(markdown, /Referral\/outcome movement: sessions \(28d\): 20 → 35/);
   });
 
   it('does not turn sparse audit coverage into new or lost citations', () => {
@@ -560,8 +578,103 @@ describe('scorecard computation', () => {
 
     const comparison = compareScorecards(previous, current);
 
-    assert.equal(comparison.search.googleSearchConsole.impressions.absolute, 150);
-    assert.equal(comparison.search.googleSearchConsole.indexedPages, null);
+    assert.equal(comparison.search.googleSearchConsole.metrics.impressions.absolute, 150);
+    assert.equal(comparison.search.googleSearchConsole.metrics.indexedPages, null);
+  });
+
+  it('prefers the 28d window for comparisons regardless of authored window order', () => {
+    const previous = buildScorecard(querySet, baseline);
+    const current = buildScorecard(querySet, baseline);
+    const searchWindow = (label, impressions) => ({
+      label,
+      metrics: {
+        indexedPages: null,
+        impressions,
+        clicks: 10,
+        ctr: 0.1,
+        averagePosition: 12,
+      },
+    });
+    previous.search.googleSearchConsole = {
+      status: 'partial',
+      reason: 'Only aggregate exports were available.',
+      windows: [searchWindow('90d', 900), searchWindow('28d', 100)],
+    };
+    current.search.googleSearchConsole = {
+      status: 'partial',
+      reason: 'Only aggregate exports were available.',
+      windows: [searchWindow('28d', 250), searchWindow('90d', 2000)],
+    };
+
+    const comparison = compareScorecards(previous, current);
+    const compared = comparison.search.googleSearchConsole;
+
+    assert.equal(compared.windowLabel, '28d');
+    assert.equal(compared.metrics.impressions.before, 100);
+    assert.equal(compared.metrics.impressions.after, 250);
+
+    current.comparison = comparison;
+    const markdown = formatScorecardMarkdown(current);
+    assert.match(markdown, /googleSearchConsole\.impressions \(28d\): 100 → 250/);
+  });
+
+  it('classifies meaningful changes via the relative arm and guards before=0 ratios', () => {
+    const previous = buildScorecard(querySet, baseline);
+    const current = buildScorecard(querySet, baseline);
+    const referralWindow = (metrics) => ({ label: '28d', metrics });
+    previous.referrals = {
+      ...previous.referrals,
+      status: 'available',
+      windows: [referralWindow({
+        sessions: 50,
+        dashboardLaunches: 5,
+        pricingViews: 4,
+        signUps: 2,
+        proConversions: 1,
+        apiActions: 1,
+        mcpActions: 0,
+      })],
+    };
+    current.referrals = {
+      ...current.referrals,
+      status: 'available',
+      windows: [referralWindow({
+        sessions: 59,
+        dashboardLaunches: 5,
+        pricingViews: 4,
+        signUps: 2,
+        proConversions: 1,
+        apiActions: 1,
+        mcpActions: 1,
+      })],
+    };
+
+    const { metrics } = compareScorecards(previous, current).referrals;
+
+    assert.equal(metrics.sessions.absolute, 9);
+    assert.equal(metrics.sessions.relative, 0.18);
+    assert.equal(metrics.sessions.meaningful, true);
+    assert.equal(metrics.mcpActions.relative, null);
+    assert.equal(metrics.mcpActions.meaningful, true);
+    assert.equal(metrics.dashboardLaunches.meaningful, false);
+  });
+
+  it('escapes markdown-significant characters in cited URLs and summaries', () => {
+    const hostile = structuredClone(baseline);
+    const observation = hostile.aiObservations[0];
+    observation.citedUrls = ['https://www.worldmonitor.app/report(2026)?q=a|b'];
+    observation.directCitation = true;
+    observation.accuracy = 'mixed';
+    observation.summary = 'Line one\nwith | pipe';
+
+    const markdown = formatScorecardMarkdown(buildScorecard(querySet, hostile));
+
+    assert.ok(
+      markdown.includes('[link](https://www.worldmonitor.app/report%282026%29?q=a\\|b)'),
+      'cited URL must be rendered with encoded parentheses and escaped pipe',
+    );
+    assert.ok(markdown.includes('Line one with \\| pipe'));
+    assert.doesNotMatch(markdown, /report\(2026\)/);
   });
 
   it('does not compare provider metrics for disjoint window labels', () => {
@@ -659,5 +772,18 @@ describe('scorecard computation', () => {
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
+  });
+});
+
+describe('CLI argument validation', () => {
+  it('rejects malformed invocations before reading any input', async () => {
+    await assert.rejects(runCli(['--bogus']), /unknown argument --bogus/);
+    await assert.rejects(runCli(['--queries']), /--queries requires a value/);
+    await assert.rejects(runCli(['--baseline', 'b.json']), /--queries is required/);
+    await assert.rejects(runCli(['--queries', 'q.json']), /--baseline is required/);
+    await assert.rejects(
+      runCli(['--queries', 'q.json', '--baseline', 'b.json', '--check']),
+      /--check requires --output/,
+    );
   });
 });

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -186,6 +186,22 @@ describe('SEO and AI visibility baseline', () => {
       /window labels must be unique/,
     );
   });
+
+  it('rejects reversed and mislabeled numeric reporting periods', () => {
+    const reversed = structuredClone(baseline);
+    reversed.search.googleSearchConsole.windows[0].startDate = '2026-07-28';
+    assert.throws(
+      () => validateBaseline(reversed, querySet),
+      /startDate must not be after endDate/,
+    );
+
+    const mislabeled = structuredClone(baseline);
+    mislabeled.search.googleSearchConsole.windows[0].label = '7d';
+    assert.throws(
+      () => validateBaseline(mislabeled, querySet),
+      /label must match the inclusive calendar-day span/,
+    );
+  });
 });
 
 describe('scorecard computation', () => {
@@ -546,6 +562,43 @@ describe('scorecard computation', () => {
 
     assert.equal(comparison.search.googleSearchConsole.impressions.absolute, 150);
     assert.equal(comparison.search.googleSearchConsole.indexedPages, null);
+  });
+
+  it('does not compare provider metrics for disjoint window labels', () => {
+    const previous = buildScorecard(querySet, baseline);
+    const current = buildScorecard(querySet, baseline);
+    previous.search.googleSearchConsole = {
+      status: 'partial',
+      reason: 'Only a 28-day export was available.',
+      windows: [{
+        label: '28d',
+        metrics: {
+          indexedPages: null,
+          impressions: 100,
+          clicks: 10,
+          ctr: 0.1,
+          averagePosition: 12,
+        },
+      }],
+    };
+    current.search.googleSearchConsole = {
+      status: 'partial',
+      reason: 'Only a 7-day export was available.',
+      windows: [{
+        label: '7d',
+        metrics: {
+          indexedPages: null,
+          impressions: 250,
+          clicks: 30,
+          ctr: 0.12,
+          averagePosition: 10,
+        },
+      }],
+    };
+
+    const comparison = compareScorecards(previous, current);
+
+    assert.equal(comparison.search.googleSearchConsole, null);
   });
 
   it('renders availability, reproducibility, risks, and the top-five work queue', () => {


### PR DESCRIPTION
## Summary

World Monitor can now run a reproducible, query-level visibility loop that keeps
traditional search, AI answers, referrals, and product outcomes distinct. The
first inspectable baseline covers 25 reviewed decision queries across five
intents and ten page families, with a deterministic weekly scorecard and monthly
comparison contract.

The initial manual audit records the same category query across ChatGPT Search,
Perplexity, Google AI, and Copilot Search. ChatGPT, Google AI, and Copilot linked
first-party World Monitor surfaces; Perplexity mentioned World Monitor but cited
only a third party. All four answers carried mutable or conflicting product
claims, so the baseline marks their accuracy as mixed rather than presenting
ranking language as verified fact.

## Design decisions

- Provider availability is first-class. Missing Search Console, Bing, referral,
  or AI-surface inputs remain `null`/unavailable with reasons and never become
  zeros, failed mentions, or fabricated citation losses.
- Search and AI results are sliced by intent and page family; referral outcomes
  retain both acquisition family and landing-page family.
- Monthly citation changes require the same query/platform pair to be observed
  in both periods. Newly observed and no-longer-observed pairs are reported
  separately from true citation gains and losses.
- Committed artifacts reject property identifiers, credentials, malformed
  guardrails, ambiguous window labels, and invalid opportunity priorities.

## Validation

Proof-first development exercised the missing implementation, referral
segmentation, and review regressions before the fixes:

- the initial test failed because the scorecard module did not exist;
- the referral slice test failed before segment aggregation was implemented;
- the review-fix run exposed six failing behaviors around surface availability,
  citation semantics, sparse comparisons, partial metrics, and secure schema
  validation before those paths were repaired.

Final evidence:

- 43 focused tests pass across the scorecard and shared China audit helper;
- the repository pre-push gate passes typechecks, Unicode safety, changed tests,
  full Markdown lint, version sync, and scoped freshness checks;
- deterministic `--check` reproduction passes and rejects a deliberately stale
  output;
- frontend and API typechecks pass independently.

Search Console, Bing Webmaster, and referral exports remain explicitly
unavailable because no read-only property access or supported export was
provided. The schema, secure runbook, and manual baseline are complete without
inventing those values or committing a property identifier.

## Post-Deploy Monitoring & Validation

This change has no web runtime or deployment behavior; it is a repository-local
research artifact and CLI workflow.

- Healthy: focused tests and deterministic `--check` stay green, and the next
  weekly/monthly collection replaces only supported values while preserving
  explicit missingness.
- Failure signal: a `[seo-visibility]` validation error or stale-artifact error.
- Rollback: revert this commit; no production data migration or runtime rollback
  is required.
- Follow-up window/owner: Growth/SEO should populate supported 28-day and 90-day
  exports at the next collection checkpoint and reconcile bounded referral
  aggregates with the analytics provider.

Fixes #5667

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
