### PR TITLE
test(china): lock quiet disclosure health semantics

### DIFF
--- a/scripts/shared/china-corporate-disclosure-policy.js
+++ b/scripts/shared/china-corporate-disclosure-policy.js
@@ -1,3 +1,6 @@
+// This is an intentionally narrow, market-moving event taxonomy. Routine
+// governance/system-rule revisions remain visible in unclassifiedRevisions
+// unless they can inherit a unique owned-category lineage; they are not events.
 export const CHINA_CORPORATE_DISCLOSURE_TYPES = Object.freeze([
   'halt',
   'resumption',

--- a/shared/china-corporate-disclosure-policy.js
+++ b/shared/china-corporate-disclosure-policy.js
@@ -1,3 +1,6 @@
+// This is an intentionally narrow, market-moving event taxonomy. Routine
+// governance/system-rule revisions remain visible in unclassifiedRevisions
+// unless they can inherit a unique owned-category lineage; they are not events.
 export const CHINA_CORPORATE_DISCLOSURE_TYPES = Object.freeze([
   'halt',
   'resumption',

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -94,6 +94,16 @@ describe('official China corporate disclosures (#5577)', () => {
     for (const row of fixture('collisions.json') as Array<{ title: string; expected: string | null }>) {
       assert.equal(classifyDisclosureTitle(row.title), row.expected, row.title);
     }
+    assert.equal(
+      classifyDisclosureTitle('董事会秘书工作细则'),
+      null,
+      'routine governance rules are not market-moving disclosure events',
+    );
+    assert.equal(
+      classifyDisclosureTitle('修订公司制度'),
+      null,
+      'routine system revisions remain outside the owned event taxonomy',
+    );
   });
 
   it('normalizes official metadata, rejects unreviewed issuers, and never fetches document bodies', () => {

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -335,6 +335,52 @@ describe('China coverage manifest', () => {
     );
   });
 
+  it('keeps a healthy zero-event disclosure window healthy when fetched filings are outside the owned taxonomy', () => {
+    const disclosures = CHINA_COVERAGE_ENTRIES.find(
+      (entry) => entry.id === 'market.china-corporate-disclosures',
+    );
+    const result = evaluate(
+      disclosures,
+      {
+        'market:china:corporate-disclosures:v1': {
+          status: 'healthy',
+          coverageThrough: '2026-07-13',
+          events: [],
+          unclassifiedRevisions: [
+            {
+              titleOriginal: '董事会秘书工作细则',
+              revisionState: 'corrected',
+              publicationTime: { value: '2026-07-13' },
+            },
+            {
+              titleOriginal: '修订公司制度',
+              revisionState: 'corrected',
+              publicationTime: { value: '2026-07-13' },
+            },
+          ],
+          sources: [
+            { id: 'sse', transportStatus: 'fresh', contentStatus: 'current' },
+            { id: 'szse', transportStatus: 'fresh', contentStatus: 'current' },
+            { id: 'hkex', launchStatus: 'blocked' },
+          ],
+        },
+      },
+      {
+        'seed-meta:market:china-corporate-disclosures': {
+          fetchedAt: NOW,
+          recordCount: 0,
+          status: 'ok',
+        },
+      },
+    );
+
+    assert.equal(result.status, 'healthy');
+    assert.equal(result.counts.healthy, 1);
+    assert.equal(result.entries[0].status, 'healthy');
+    assert.equal(result.entries[0].content.status, 'fresh');
+    assert.deepEqual(result.entries[0].reasonCodes, []);
+  });
+
   it('uses the source-specific China news projection rather than global top stories', () => {
     const news = CHINA_COVERAGE_ENTRIES.find((entry) => entry.id === 'news.china');
     const data = {


### PR DESCRIPTION
## Summary

Routine governance and system-rule revisions are now explicitly provenance-only rather than members of the seven market-moving disclosure categories. A fresh/current SSE and SZSE window remains healthy when those filings produce zero admitted events, preventing this quiet state from regressing into `CHINA_DEGRADED`.

The runtime path was already correct on `main`; this PR records the product decision and locks it at the real classifier and China coverage evaluator seams.

Fixes #5693

## Validation

- `TMPDIR=/private/tmp node --import tsx --test --test-concurrency=1 tests/scripts-shared-mirror.test.mjs tests/china-corporate-disclosures.test.mts tests/china-coverage-health.test.mjs` — 49 passed.
- Mutation proof: admitting the two governance titles made the classifier test fail; removing `coverageThrough` made the healthy zero-event test fail. Both mutations were restored and the focused suite returned green.
- `npm run typecheck` and `npm run lint` completed successfully.
- `VITE_VARIANT=full vite build` completed successfully.
- `TMPDIR=/private/tmp npm run test:data` — 17,729 passed, 0 failed, 6 skipped.
- The pre-push hook also passed source/API typechecks, Unicode safety, changed tests, and version sync.

## Post-Deploy Monitoring & Validation

This PR changes only policy documentation and regression coverage, so it requires no runtime rollback or deployment-specific error-rate watch. As an operational acceptance check after the next China coverage seed, inspect `/api/health?compact=1`: when the canonical disclosure snapshot is present, SSE/SZSE are fresh/current, and `events` is empty, `market.china-corporate-disclosures` should not appear in the China coverage problem list.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
