### PR TITLE
docs(legal): clarify optional World Monitor attribution

### DIFF
--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -38,6 +38,8 @@ Choose by who benefits from the work and where World Monitor data will appear:
 
 Pro Business permits normal client deliverables such as analysis and reports; it does not permit a live customer-facing data product. API Starter crosses the programmatic boundary inside your organization; it does not cross the customer boundary. API Business crosses that customer boundary when World Monitor data is part of a product or service with its own material value, but it does not permit raw-data resale, shared API access, or a standalone substitute for World Monitor.
 
+World Monitor attribution is optional in reports, presentations, and derived analysis permitted by your plan. If you choose to credit us, "Source: World Monitor" or "via World Monitor" is sufficient. Source-specific notices supplied with an output still apply.
+
 These are subscription licenses for the hosted Service and its outputs. They are separate from the AGPL-3.0-only platform source-code license and the MIT licenses on the official thin clients. See the [Terms of Service](/terms#subscription-license-scope) for the full scope, restrictions, examples, and post-cancellation rules.
 
 ## What each plan includes

--- a/docs/terms.mdx
+++ b/docs/terms.mdx
@@ -73,7 +73,7 @@ If your use expands beyond the scope of your plan, you must upgrade or obtain wr
 
 - A seat belongs to one named user. Credentials, sessions, license keys, and API keys may not be sold, transferred, published, or shared outside the people and systems authorized by the plan.
 - Customer redistribution under API Business must be part of a product or service with material value beyond providing a copy of World Monitor data.
-- You must preserve source citations, attribution, timestamps, license notices, and usage restrictions supplied with an output.
+- Attribution to World Monitor is optional for reports, presentations, and derived analysis permitted by your plan. If you choose to credit us, "Source: World Monitor" or "via World Monitor" is sufficient. You must still preserve any source-specific citation, attribution, timestamp, license notice, or usage restriction supplied with an output.
 - A plan grants only rights that World Monitor can grant. Third-party data remains subject to its provider's license and terms, which may impose additional restrictions.
 - No plan transfers ownership of the Service or underlying data, grants trademark or branding rights, or permits you to imply that World Monitor endorses your product.
 - When a subscription ends, you may retain reports and analysis lawfully created during the subscription, but you must stop fetching, refreshing, distributing, or operating integrations that require an active entitlement.

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -14,6 +14,8 @@ Live tier/price/product-ID data (JSON): `GET https://www.worldmonitor.app/api/pr
 - **API Business — Commercial license for your customers:** the subscribing organization may display, embed or deliver API outputs as part of its own customer-facing product or service. It does not permit raw-data resale, shared API access or a standalone substitute for World Monitor.
 - **Enterprise — Custom agreement:** required for higher-volume redistribution, additional seats, white-labeling, standalone data feeds and custom deployments.
 
+World Monitor attribution is optional in reports, presentations and derived analysis permitted by your plan. If you choose to credit us, "Source: World Monitor" or "via World Monitor" is sufficient. Source-specific notices supplied with an output still apply.
+
 These subscription licenses cover the hosted Service and its outputs. They are separate from the AGPL-3.0-only platform source-code license and the MIT licenses on the official thin clients. Full scope, examples and restrictions: https://worldmonitor.app/docs/terms#subscription-license-scope
 
 ## Free

--- a/tests/license-docs.test.mjs
+++ b/tests/license-docs.test.mjs
@@ -91,10 +91,32 @@ describe('project license docs', () => {
     }
     assert.match(terms, /customer-facing product/i);
     assert.match(terms, /standalone database or substantially similar feed/i);
-    assert.match(terms, /Attribution to World Monitor is optional/i);
-    assert.match(terms, /"Source: World Monitor" or "via World Monitor" is sufficient/i);
-    assert.match(terms, /must still preserve any source-specific citation/i);
     assert.match(terms, /source code remains subject to AGPL-3\.0-only/i);
     assert.match(terms, /official thin client packages remain subject to MIT/i);
+  });
+
+  it('keeps hosted-service attribution guidance consistent across legal and pricing docs', () => {
+    const documents = [
+      {
+        relativePath: 'docs/terms.mdx',
+        sourceNoticePattern: /must still preserve any source-specific citation/i,
+      },
+      {
+        relativePath: 'docs/pricing.mdx',
+        sourceNoticePattern: /Source-specific notices supplied with an output still apply/i,
+      },
+      {
+        relativePath: 'public/pricing.md',
+        sourceNoticePattern: /Source-specific notices supplied with an output still apply/i,
+      },
+    ];
+
+    for (const { relativePath, sourceNoticePattern } of documents) {
+      const text = readFileSync(join(root, relativePath), 'utf8');
+
+      assert.match(text, /(?:Attribution to World Monitor|World Monitor attribution) is optional/i);
+      assert.match(text, /"Source: World Monitor" or "via World Monitor" is sufficient/i);
+      assert.match(text, sourceNoticePattern);
+    }
   });
 });

--- a/tests/license-docs.test.mjs
+++ b/tests/license-docs.test.mjs
@@ -91,6 +91,9 @@ describe('project license docs', () => {
     }
     assert.match(terms, /customer-facing product/i);
     assert.match(terms, /standalone database or substantially similar feed/i);
+    assert.match(terms, /Attribution to World Monitor is optional/i);
+    assert.match(terms, /"Source: World Monitor" or "via World Monitor" is sufficient/i);
+    assert.match(terms, /must still preserve any source-specific citation/i);
     assert.match(terms, /source code remains subject to AGPL-3\.0-only/i);
     assert.match(terms, /official thin client packages remain subject to MIT/i);
   });


### PR DESCRIPTION
## Summary

Paid-plan users can now rely on the Terms for a direct attribution answer: World Monitor credit is optional in reports, presentations, and derived analysis permitted by their plan. If they choose to credit World Monitor, either "Source: World Monitor" or "via World Monitor" is sufficient, while source-specific citations, attribution, timestamps, license notices, and usage restrictions supplied with an output remain mandatory.

The human-facing pricing guide and machine-readable pricing page carry the same rule so customer guidance and agent answers stay aligned.

## Validation

- `TMPDIR=/private/tmp node --import tsx --test tests/license-docs.test.mjs tests/public-product-facts.test.mjs tests/pricing-docs-drift.test.mjs` — 37/37 passed
- `npm run product:facts -- --check` and `node scripts/docs-stats.mjs --check` — no generated-facts or documentation-stat drift
- Full pre-push gate — typecheck, focused license tests, markdown/MDX lint, Unicode safety, and version sync passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
