### PR TITLE
fix(china): classify Japan MOD proxy failures

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -850,12 +850,12 @@ function keyHasData(redisKey, len) {
 
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, metaReadFailed: true, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -864,7 +864,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // the dependency so behavior stays byte-identical in PR 1.
   const meta = unwrapEnvelope(parseRedisValue(keyMetaValues.get(seedCfg.key))).data;
   if (meta?.status === 'error') {
-    return { hasMeta: true, seedAge: null, seedStale: true, seedError: true, sourceUnavailable: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return { hasMeta: true, seedAge: null, seedStale: true, seedError: true, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null };
   }
   let seedAge = null;
   let seedStale = true;
@@ -879,12 +879,17 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // same makes an optional, deliberately-unconfigured source an eternal warn that
   // no amount of operator work can clear — so it is classified separately below.
   const sourceUnavailable = meta?.sourceState === 'unavailable';
+  // A current, bounded upstream classification can prove that every admitted
+  // transport path is externally blocked. Keep that state visible without
+  // treating it as a broken producer that can be repaired by another retry.
+  const sourceBlocked = meta?.sourceState === 'blocked';
   // Source-specific producers can preserve usable last-good records while a
   // current upstream attempt is degraded. Surface that state immediately as a
   // warning without discarding the retained record count from health output.
   const sourceDegraded = typeof meta?.sourceState === 'string'
     && meta.sourceState !== 'ok'
-    && !sourceUnavailable;
+    && !sourceUnavailable
+    && !sourceBlocked;
   // Content-age trio (2026-05-04 health-readiness plan). Presence of
   // maxContentAgeMin is the opt-in signal — legacy seeders without it
   // get contentAge: null and skip the STALE_CONTENT branch in classifyKey.
@@ -912,7 +917,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
-  return { hasMeta: meta != null, seedAge, seedStale, seedError: sourceDegraded, sourceUnavailable, metaReadFailed: false, metaCount, contentAge };
+  return { hasMeta: meta != null, seedAge, seedStale, seedError: sourceDegraded, sourceUnavailable, sourceBlocked, metaReadFailed: false, metaCount, contentAge };
 }
 
 function isCascadeCovered(name, hasData, keyStrens, keyErrors) {
@@ -947,7 +952,7 @@ function classifyKey(name, redisKey, opts, ctx) {
 
   const strlen = keyStrens.get(redisKey) ?? 0;
   const hasData = keyHasData(redisKey, strlen);
-  const { hasMeta, seedAge, seedStale, seedError, sourceUnavailable, metaCount, contentAge } = meta;
+  const { hasMeta, seedAge, seedStale, seedError, sourceUnavailable, sourceBlocked, metaCount, contentAge } = meta;
 
   // When the data key is gone the meta count is meaningless; force records=0
   // so we never display the contradictory "EMPTY records=N>0" pair (item 1).
@@ -961,6 +966,12 @@ function classifyKey(name, redisKey, opts, ctx) {
   // the moment the credential lands the next run reports sourceState 'ok' and this
   // flips to OK on its own — no health-config change needed.
   if (sourceUnavailable) status = 'NOT_CONFIGURED';
+  else if (sourceBlocked && name !== 'crossStraitActivityJapanMod') {
+    // Keep the fleet-wide escape hatch narrow: only the Japan MOD adapter has
+    // a reviewed-data contract and explicit two-path proof for this state.
+    status = 'SEED_ERROR';
+  }
+  else if (sourceBlocked && hasData && records > 0 && seedStale !== true) status = 'SOURCE_BLOCKED';
   else if (seedError) status = 'SEED_ERROR';
   else if (!hasData) {
     if (cascadeCovered) status = 'OK_CASCADE';
@@ -1016,6 +1027,11 @@ const STATUS_COUNTS = {
   // Must stay registered here: the summary does `STATUS_COUNTS[status] ?? 'warn'`,
   // so an unlisted status would silently re-become the warn this exists to stop.
   NOT_CONFIGURED: 'ok',
+  // The producer ran and classified an external transport refusal with a
+  // documented reason. Retained reviewed data remains usable, and retrying the
+  // same bounded paths cannot clear it, so this is informational rather than a
+  // fleet-health warning.
+  SOURCE_BLOCKED: 'ok',
   STALE_SEED: 'warn',
   SEED_ERROR: 'warn',
   EMPTY_ON_DEMAND: 'warn',

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -395,9 +395,14 @@ export default async function handler(req) {
     // `unavailable` means an optional adapter was never configured, matching
     // api/health.js's NOT_CONFIGURED treatment rather than a broken source.
     const sourceUnavailable = meta.sourceState === 'unavailable';
+    const sourceBlocked = domain === 'military:cross-strait-activity:japan-mod'
+      && meta.sourceState === 'blocked'
+      && recordCount != null
+      && recordCount > 0;
     const sourceError = typeof meta.sourceState === 'string'
       && meta.sourceState !== 'ok'
-      && !sourceUnavailable;
+      && !sourceUnavailable
+      && !sourceBlocked;
     const isError = meta.status === 'error' || sourceError;
     const probe = evaluateDataProbe(cfg.dataProbe, probeMap.get(domain));
     const sourceMismatch = Boolean(
@@ -422,6 +427,8 @@ export default async function handler(req) {
               ? 'coverage_partial'
               : stale
               ? 'stale'
+              : sourceBlocked
+                ? 'source_blocked'
               : 'ok',
       fetchedAt: meta.fetchedAt,
       recordCount: recordCount ?? meta.recordCount ?? null,

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -112,10 +112,17 @@ observations are regional augmentation and do not satisfy the Taiwan MND
 content requirement. `/api/health` separately monitors
 `military:cross-strait-activity-bootstrap:v1`; fresh canonical data cannot hide
 a missing compact UI projection. It also exposes dedicated MND and Japan Joint
-Staff transport records; either source reports `SEED_ERROR` immediately when
-its current fetch fails, while the last-good archive remains available. The
-bundle freshness gate advances only after the archive, projection, and both
-source-health records publish successfully.
+Staff transport records. Japan Joint Staff alone reports `SOURCE_BLOCKED` when
+retained reviewed records exist and the current direct and proxy paths both
+prove an external HTTP 403 block. Stale metadata, a missing source record, or
+any other source using the blocked state still fails closed through the
+existing `STALE_SEED`, `EMPTY`, or `SEED_ERROR` statuses. Other current fetch
+failures report `SEED_ERROR` while the last-good archive remains available.
+The bundle freshness gate advances only after the archive, projection, and
+both source-health records publish successfully. The public bootstrap retains
+the bounded reason codes used for disclosure but omits proxy response
+diagnostics; full sanitized diagnostics remain in the authenticated operator
+source record.
 
 Operators can obtain the same sanitized, read-only audit with
 `node scripts/audit-china-coverage.mjs --json`; add `--strict` to return a

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -76,7 +76,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `OK` | Green | Data present, seed fresh |
 | `OK_CASCADE` | Green | Key empty but a sibling in the cascade group has data (e.g., theater posture fallback chain) |
 | `NOT_CONFIGURED` | Green | An optional source adapter this deployment never supplied a credential for (producer wrote `sourceState: "unavailable"`, e.g. the Global Tenders SAM.gov adapter without `SAM_GOV_API_KEY`). Not a fault and not counted as a problem; flips to `OK` on the first run after the credential is added |
-| `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved direct and proxy HTTP 403 blocks while retaining fresh reviewed records. Stale, empty, or unreviewed blocked states still fail closed |
+| `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved a direct HTTP 403 and another upstream HTTP 403 after a successful proxy CONNECT while retaining fresh reviewed records. CONNECT-layer refusals, stale, empty, or unreviewed states still fail closed |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
 | `STALE_CONTENT` | Warn | Seeder is fresh but the upstream content stopped advancing (frozen feed); counted in `summary.staleContent` |
 | `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints or 139/174 PortWatch port-activity countries) |
@@ -114,11 +114,12 @@ content requirement. `/api/health` separately monitors
 `military:cross-strait-activity-bootstrap:v1`; fresh canonical data cannot hide
 a missing compact UI projection. It also exposes dedicated MND and Japan Joint
 Staff transport records. Japan Joint Staff alone reports `SOURCE_BLOCKED` when
-retained reviewed records exist and the current direct and proxy paths both
-prove an external HTTP 403 block. Stale metadata, a missing source record, or
-any other source using the blocked state still fails closed through the
-existing `STALE_SEED`, `EMPTY`, or `SEED_ERROR` statuses. Other current fetch
-failures report `SEED_ERROR` while the last-good archive remains available.
+retained reviewed records exist and the current direct request plus an
+upstream response after a successful proxy CONNECT both return HTTP 403.
+CONNECT-layer refusals, stale metadata, a missing source record, or any other
+source using the blocked state still fail closed through the existing
+`STALE_SEED`, `EMPTY`, or `SEED_ERROR` statuses. Other current fetch failures
+report `SEED_ERROR` while the last-good archive remains available.
 The bundle freshness gate advances only after the archive, projection, and
 both source-health records publish successfully. The public bootstrap retains
 the bounded reason codes used for disclosure but omits proxy response

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -76,6 +76,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `OK` | Green | Data present, seed fresh |
 | `OK_CASCADE` | Green | Key empty but a sibling in the cascade group has data (e.g., theater posture fallback chain) |
 | `NOT_CONFIGURED` | Green | An optional source adapter this deployment never supplied a credential for (producer wrote `sourceState: "unavailable"`, e.g. the Global Tenders SAM.gov adapter without `SAM_GOV_API_KEY`). Not a fault and not counted as a problem; flips to `OK` on the first run after the credential is added |
+| `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved direct and proxy HTTP 403 blocks while retaining fresh reviewed records. Stale, empty, or unreviewed blocked states still fail closed |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
 | `STALE_CONTENT` | Warn | Seeder is fresh but the upstream content stopped advancing (frozen feed); counted in `summary.staleContent` |
 | `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints or 139/174 PortWatch port-activity countries) |

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -1929,9 +1929,10 @@ function proxyErrorCode(error) {
 
 function blockedJapanProxyReason(directFailureCode, proxyFailureCode) {
   if (directFailureCode !== 'HTTP_403') return null;
-  return proxyFailureCode === 'PROXY_CONNECT_FORBIDDEN' || proxyFailureCode === 'HTTP_403'
-    ? proxyFailureCode
-    : null;
+  // A CONNECT refusal is emitted by the proxy before the TLS tunnel reaches
+  // Japan MOD. Only a 403 response received after CONNECT proves that both
+  // source-facing transport paths are externally blocked.
+  return proxyFailureCode === 'HTTP_403' ? proxyFailureCode : null;
 }
 
 function rotatingRefreshCandidates(previousMnd, excludedUrls, now) {

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -29,6 +29,7 @@ const MND_REFRESH_ROTATION_INTERVAL_MS = 3 * 60 * 60 * 1_000;
 const DAY_MS = 86_400_000;
 const MAX_PERSISTED_STRING_LENGTH = 2_048;
 const MAX_SOURCE_URL_LENGTH = 512;
+const PROXY_DIAGNOSTIC_MAX_CHARS = 256;
 
 function monotonicNow() {
   return globalThis.performance.now();
@@ -1477,10 +1478,42 @@ async function fetchJapanModViaConfiguredProxy(input, init, {
   });
   const status = Number(result.status);
   if (!Number.isInteger(status) || status < 200 || status >= 300) {
-    throw new Error(`HTTP_${Number.isInteger(status) ? status : 'UNKNOWN'}`);
+    throw Object.assign(
+      new Error(`HTTP_${Number.isInteger(status) ? status : 'UNKNOWN'}`),
+      {
+        status: Number.isInteger(status) ? status : null,
+        contentType: result?.contentType,
+        bodyPrefix: proxyBodyPrefix(result?.buffer),
+        proxyStage: 'response',
+      },
+    );
   }
-  if (result.buffer.byteLength > maxResponseBytes) throw new Error('RESPONSE_TOO_LARGE');
-  return result.buffer.toString('utf8');
+  if (!Buffer.isBuffer(result?.buffer)) {
+    throw Object.assign(new Error('PROXY_RESPONSE_INVALID'), {
+      status,
+      contentType: result?.contentType,
+      proxyStage: 'response',
+    });
+  }
+  if (result.buffer.byteLength > maxResponseBytes) {
+    throw Object.assign(new Error('RESPONSE_TOO_LARGE'), {
+      status,
+      contentType: result.contentType,
+      bodyPrefix: proxyBodyPrefix(result.buffer),
+      proxyStage: 'response',
+    });
+  }
+  return {
+    html: result.buffer.toString('utf8'),
+    detail: buildProxyDiagnosticDetail({
+      stage: 'response',
+      httpStatus: status,
+      contentType: result.contentType,
+      bodyPrefix: proxyBodyPrefix(result.buffer),
+      errorCode: null,
+      errorMessage: null,
+    }),
+  };
 }
 
 function withoutNestedHistory(observation) {
@@ -1775,11 +1808,17 @@ export function buildCrossStraitActivitySnapshot({
       transportStatus: japanOutcome?.ok ? 'fresh' : 'error',
       requestCount: japanOutcome?.requestCount ?? 0,
       transportPath: japanOutcome?.transportPath ?? 'direct',
+      ...(japanOutcome?.blockedReason
+        ? { blockedReason: japanOutcome.blockedReason }
+        : {}),
       ...(japanOutcome?.fallbackReason
         ? { fallbackReason: japanOutcome.fallbackReason }
         : {}),
       ...(japanOutcome?.proxyFailureReason
         ? { proxyFailureReason: japanOutcome.proxyFailureReason }
+        : {}),
+      ...(japanOutcome?.proxyFailureDetail
+        ? { proxyFailureDetail: japanOutcome.proxyFailureDetail }
         : {}),
       errorCodes: japanOutcome?.errorCodes ?? [],
       lastSuccessAt: japanOutcome?.ok
@@ -1791,7 +1830,9 @@ export function buildCrossStraitActivitySnapshot({
         : {}),
     },
   ];
-  const anyError = sources.some((source) => source.transportStatus === 'error');
+  const anyError = sources.some(
+    (source) => source.transportStatus === 'error' && !source.blockedReason,
+  );
   return constrainCrossStraitActivitySnapshotSize({
     schemaVersion: 1,
     generatedAt,
@@ -1820,6 +1861,58 @@ function errorCode(error) {
   return 'SOURCE_ERROR';
 }
 
+function boundedDiagnosticString(value, maxChars = PROXY_DIAGNOSTIC_MAX_CHARS) {
+  if (typeof value !== 'string') return null;
+  const normalized = value
+    .replace(/(https?:\/\/)[^@\s/]+@/giu, '$1[redacted]@')
+    .replace(/(Proxy-Authorization:\s*)\S+/giu, '$1[redacted]')
+    .replace(/\s+/gu, ' ')
+    .trim();
+  return normalized ? normalized.slice(0, maxChars) : null;
+}
+
+function proxyBodyPrefix(value) {
+  if (!Buffer.isBuffer(value)) return null;
+  return boundedDiagnosticString(
+    value.toString('utf8', 0, 1_024),
+  );
+}
+
+function buildProxyDiagnosticDetail({
+  stage,
+  httpStatus = null,
+  contentType = null,
+  bodyPrefix = null,
+  errorCode: detailErrorCode = null,
+  errorMessage = null,
+}) {
+  const status = Number(httpStatus);
+  return {
+    stage,
+    httpStatus: Number.isInteger(status) && status >= 100 && status <= 599
+      ? status
+      : null,
+    contentType: boundedDiagnosticString(contentType, 128),
+    bodyPrefix: boundedDiagnosticString(bodyPrefix),
+    errorCode: boundedDiagnosticString(detailErrorCode, 64),
+    errorMessage: boundedDiagnosticString(errorMessage),
+  };
+}
+
+function proxyFailureDetail(error) {
+  const message = String(error?.message ?? '');
+  return buildProxyDiagnosticDetail({
+    stage: error?.proxyStage === 'response'
+      ? 'response'
+      : (/Proxy CONNECT:/i.test(message) ? 'connect' : 'request'),
+    httpStatus: error?.status,
+    contentType: error?.contentType,
+    bodyPrefix: error?.bodyPrefix,
+    errorCode: error?.code,
+    errorMessage: message,
+  });
+}
+
 function proxyErrorCode(error) {
   const code = errorCode(error);
   if (Number(error?.status) === 407
@@ -1827,7 +1920,18 @@ function proxyErrorCode(error) {
     || /Proxy CONNECT:[^\n]*\b407\b/i.test(String(error?.message ?? ''))) {
     return 'PROXY_AUTH_FAILED';
   }
+  if (Number(error?.status) === 403
+    && /Proxy CONNECT:[^\n]*\b403\b/i.test(String(error?.message ?? ''))) {
+    return 'PROXY_CONNECT_FORBIDDEN';
+  }
   return String(error?.message ?? '').match(/PROXY_[A-Z0-9_]+/)?.[0] ?? code;
+}
+
+function blockedJapanProxyReason(directFailureCode, proxyFailureCode) {
+  if (directFailureCode !== 'HTTP_403') return null;
+  return proxyFailureCode === 'PROXY_CONNECT_FORBIDDEN' || proxyFailureCode === 'HTTP_403'
+    ? proxyFailureCode
+    : null;
 }
 
 function rotatingRefreshCandidates(previousMnd, excludedUrls, now) {
@@ -1866,6 +1970,7 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
   let requestCount = 1;
   let transportPath = 'direct';
   let fallbackReason = null;
+  let proxyResponseDetail = null;
   try {
     await sleepFn(REQUEST_CADENCE_MS);
     html = await fetchBoundedText(fetchFn, contract.indexUrl, contract);
@@ -1884,15 +1989,20 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
     transportPath = 'proxy';
     try {
       await sleepFn(REQUEST_CADENCE_MS);
-      html = await proxyFetchFn(contract.indexUrl, boundedHtmlRequestInit(contract));
+      const proxyResult = await proxyFetchFn(contract.indexUrl, boundedHtmlRequestInit(contract));
+      html = proxyResult.html;
+      proxyResponseDetail = proxyResult.detail;
     } catch (proxyError) {
       const failureCode = proxyErrorCode(proxyError);
+      const blockedReason = blockedJapanProxyReason(fallbackReason, failureCode);
       return {
         ok: false,
+        ...(blockedReason ? { blockedReason } : {}),
         requestCount,
         transportPath,
         fallbackReason,
         proxyFailureReason: failureCode,
+        proxyFailureDetail: proxyFailureDetail(proxyError),
         availableDocumentUrls: [],
         errorCodes: [...new Set([fallbackReason, failureCode])],
       };
@@ -1919,6 +2029,16 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
       ...(fallbackReason ? { fallbackReason } : {}),
       ...(transportPath === 'proxy'
         ? { proxyFailureReason: failureCode }
+        : {}),
+      ...(transportPath === 'proxy'
+        ? {
+            proxyFailureDetail: buildProxyDiagnosticDetail({
+              ...proxyResponseDetail,
+              stage: 'parse',
+              errorCode: failureCode,
+              errorMessage: error?.message,
+            }),
+          }
         : {}),
       availableDocumentUrls: [],
       errorCodes: fallbackReason

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -1865,7 +1865,7 @@ function boundedDiagnosticString(value, maxChars = PROXY_DIAGNOSTIC_MAX_CHARS) {
   if (typeof value !== 'string') return null;
   const normalized = value
     .replace(/(https?:\/\/)[^@\s/]+@/giu, '$1[redacted]@')
-    .replace(/(Proxy-Authorization:\s*)\S+/giu, '$1[redacted]')
+    .replace(/(Proxy-Authorization:\s*)[^\r\n]+/giu, '$1[redacted]')
     .replace(/\s+/gu, ' ')
     .trim();
   return normalized ? normalized.slice(0, maxChars) : null;

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -35,6 +35,11 @@ function withoutRevisionHistory(observation) {
   return currentRevision;
 }
 
+function withoutProxyFailureDetail(source) {
+  const { proxyFailureDetail: _proxyFailureDetail, ...publicSource } = source;
+  return publicSource;
+}
+
 /**
  * The durable record retains the bounded MND backfill and correction vintages.
  * Bootstrap only needs the current MND row plus reviewed Japan context; keeping
@@ -51,7 +56,7 @@ export function projectCrossStraitActivityBootstrap(snapshot) {
     schemaVersion: snapshot?.schemaVersion,
     generatedAt: snapshot?.generatedAt,
     status: snapshot?.status,
-    sources: snapshot?.sources ?? [],
+    sources: (snapshot?.sources ?? []).map(withoutProxyFailureDetail),
     coverage: snapshot?.coverage ?? {},
     observations: [...mnd, ...reviewedJapan].map(withoutRevisionHistory),
     baselines: snapshot?.baselines ?? {},
@@ -80,7 +85,10 @@ function sourceRecordCount(snapshot, sourceId) {
 export async function writeSourceHealth(snapshot, writer = writeExtraKey) {
   const outcomes = await Promise.allSettled((snapshot?.sources ?? []).map(async (source) => {
     const healthy = source?.transportStatus === 'fresh';
-    const fetchedAt = Date.parse(source?.lastSuccessAt ?? '');
+    const blocked = typeof source?.blockedReason === 'string';
+    const fetchedAt = Date.parse(
+      blocked ? snapshot?.generatedAt ?? '' : source?.lastSuccessAt ?? '',
+    );
     const writeData = () => writer(
       sourceHealthKey(source.id),
       source,
@@ -89,14 +97,14 @@ export async function writeSourceHealth(snapshot, writer = writeExtraKey) {
     const writeMeta = () => writer(sourceHealthMetaKey(source.id), {
       fetchedAt: Number.isFinite(fetchedAt) ? fetchedAt : 0,
       recordCount: sourceRecordCount(snapshot, source.id),
-      sourceState: healthy ? 'ok' : 'error',
-      stale: !healthy,
+      sourceState: healthy ? 'ok' : (blocked ? 'blocked' : 'error'),
+      stale: !healthy && !blocked,
     }, CROSS_STRAIT_ACTIVITY_TTL_SECONDS);
 
     // Never leave health claiming success when an error detail write fails.
     // Healthy observations may publish data first because an older `ok` meta
     // remains truthful; degraded observations publish the error meta first.
-    if (healthy) {
+    if (healthy || blocked) {
       await writeData();
       await writeMeta();
     } else {

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -85,7 +85,7 @@ function sourceRecordCount(snapshot, sourceId) {
 export async function writeSourceHealth(snapshot, writer = writeExtraKey) {
   const outcomes = await Promise.allSettled((snapshot?.sources ?? []).map(async (source) => {
     const healthy = source?.transportStatus === 'fresh';
-    const blocked = typeof source?.blockedReason === 'string';
+    const blocked = source?.blockedReason === 'HTTP_403';
     const fetchedAt = Date.parse(
       blocked ? snapshot?.generatedAt ?? '' : source?.lastSuccessAt ?? '',
     );

--- a/src/components/MilitaryCorrelationPanel.ts
+++ b/src/components/MilitaryCorrelationPanel.ts
@@ -5,6 +5,7 @@ import { getGeoHubById } from '@/services/geo-hub-index';
 import { h } from '@/utils/dom-utils';
 import type { CrossStraitActivitySnapshot } from '@/types/cross-strait-activity';
 import {
+  crossStraitSourceHealthHeading,
   isCrossStraitActivitySnapshot,
   tryBuildCrossStraitActivityPanelModel,
 } from './cross-strait-activity-summary';
@@ -64,7 +65,7 @@ export class MilitaryCorrelationPanel extends CorrelationPanel {
         role: 'status',
         style: 'font-size:8px;line-height:1.35;margin:0 0 7px;padding:5px;border-left:2px solid #ff9800;background:rgba(255,152,0,0.10);',
       },
-      h('strong', {}, model.sourceHealth.state === 'unavailable' ? 'Official activity unavailable' : 'Official activity degraded'),
+      h('strong', {}, crossStraitSourceHealthHeading(model.sourceHealth.state)),
       h('div', { style: 'opacity:0.82;' }, model.sourceHealth.summary),
       ...model.sourceHealth.sources.map((source) => h('div', { style: 'margin-top:2px;' },
         `${source.publisher}: ${source.transportStatus}; errors: ${source.errorCodes.join(', ') || 'none'}; last success: ${source.lastSuccessAt ?? 'not recorded'}`,

--- a/src/components/cross-strait-activity-summary.ts
+++ b/src/components/cross-strait-activity-summary.ts
@@ -44,6 +44,21 @@ export interface CrossStraitActivityPanelModel {
   } | null;
 }
 
+type CrossStraitSourceHealthState =
+  NonNullable<CrossStraitActivityPanelModel['sourceHealth']>['state'];
+
+const SOURCE_HEALTH_HEADINGS = {
+  blocked: 'Official activity source blocked',
+  degraded: 'Official activity degraded',
+  unavailable: 'Official activity unavailable',
+} satisfies Record<CrossStraitSourceHealthState, string>;
+
+export function crossStraitSourceHealthHeading(
+  state: CrossStraitSourceHealthState,
+): string {
+  return SOURCE_HEALTH_HEADINGS[state];
+}
+
 const CATEGORY_LABELS: ReadonlyArray<[
   keyof TaiwanMndActivityCategories,
   string,
@@ -208,7 +223,7 @@ function isSourceHealth(value: unknown): boolean {
     )
     && (
       value.blockedReason === undefined
-      || typeof value.blockedReason === 'string'
+      || value.blockedReason === 'HTTP_403'
     )
     && (
       value.fallbackReason === undefined
@@ -347,7 +362,7 @@ export function buildCrossStraitActivityPanelModel(
 
   const progress = `${snapshot.coverage.usableMndReportingDays} usable reporting days`;
   const hasBlockedSource = snapshot.sources.some(
-    (source) => typeof source.blockedReason === 'string',
+    (source) => source.blockedReason === 'HTTP_403',
   );
   const sourceHealth = snapshot.status === 'degraded'
     || snapshot.status === 'unavailable'

--- a/src/components/cross-strait-activity-summary.ts
+++ b/src/components/cross-strait-activity-summary.ts
@@ -1,7 +1,7 @@
 import type {
+  CrossStraitActivitySourceHealth,
   CrossStraitActivitySnapshot,
   CrossStraitBaselineWindow,
-  CrossStraitSourceId,
   TaiwanMndActivityCategories,
 } from '@/types/cross-strait-activity';
 
@@ -35,15 +35,12 @@ export interface CrossStraitActivityPanelModel {
     sourceUrl: string;
   }>;
   sourceHealth: {
-    state: 'degraded' | 'unavailable';
+    state: 'blocked' | 'degraded' | 'unavailable';
     summary: string;
-    sources: Array<{
-      id: CrossStraitSourceId;
-      publisher: string;
-      transportStatus: 'fresh' | 'error';
-      errorCodes: string[];
-      lastSuccessAt: string | null;
-    }>;
+    sources: Array<Pick<
+      CrossStraitActivitySourceHealth,
+      'id' | 'publisher' | 'transportStatus' | 'blockedReason' | 'errorCodes' | 'lastSuccessAt'
+    >>;
   } | null;
 }
 
@@ -86,6 +83,27 @@ function isDateString(value: unknown): value is string {
 
 function isNullableDateString(value: unknown): boolean {
   return value === null || isDateString(value);
+}
+
+function isNullableString(value: unknown): boolean {
+  return value === null || typeof value === 'string';
+}
+
+function isProxyFailureDetail(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (!['connect', 'request', 'response', 'parse'].includes(String(value.stage))) return false;
+  if (
+    value.httpStatus !== null
+    && (
+      !Number.isInteger(value.httpStatus)
+      || Number(value.httpStatus) < 100
+      || Number(value.httpStatus) > 599
+    )
+  ) return false;
+  return isNullableString(value.contentType)
+    && isNullableString(value.bodyPrefix)
+    && isNullableString(value.errorCode)
+    && isNullableString(value.errorMessage);
 }
 
 function isStringRecord(value: unknown): boolean {
@@ -178,12 +196,19 @@ function isSourceHealth(value: unknown): boolean {
     && typeof value.publisher === 'string'
     && typeof value.publisherType === 'string'
     && typeof value.claimSemantics === 'string'
-    && (value.transportStatus === 'fresh' || value.transportStatus === 'error')
+    && (
+      value.transportStatus === 'fresh'
+      || value.transportStatus === 'error'
+    )
     && isNonNegativeInteger(value.requestCount)
     && (
       value.transportPath === undefined
       || value.transportPath === 'direct'
       || value.transportPath === 'proxy'
+    )
+    && (
+      value.blockedReason === undefined
+      || typeof value.blockedReason === 'string'
     )
     && (
       value.fallbackReason === undefined
@@ -192,6 +217,10 @@ function isSourceHealth(value: unknown): boolean {
     && (
       value.proxyFailureReason === undefined
       || typeof value.proxyFailureReason === 'string'
+    )
+    && (
+      value.proxyFailureDetail === undefined
+      || isProxyFailureDetail(value.proxyFailureDetail)
     )
     && Array.isArray(value.errorCodes)
     && value.errorCodes.every((code) => typeof code === 'string')
@@ -317,16 +346,26 @@ export function buildCrossStraitActivityPanelModel(
     });
 
   const progress = `${snapshot.coverage.usableMndReportingDays} usable reporting days`;
-  const sourceHealth = snapshot.status === 'degraded' || snapshot.status === 'unavailable'
+  const hasBlockedSource = snapshot.sources.some(
+    (source) => typeof source.blockedReason === 'string',
+  );
+  const sourceHealth = snapshot.status === 'degraded'
+    || snapshot.status === 'unavailable'
+    || hasBlockedSource
     ? {
-        state: snapshot.status,
+        state: snapshot.status === 'degraded' || snapshot.status === 'unavailable'
+          ? snapshot.status
+          : 'blocked' as const,
         summary: snapshot.status === 'unavailable'
           ? 'Official activity snapshot unavailable; no current source transport is confirmed.'
-          : 'Official source transport is degraded; last-good counts may be retained.',
+          : snapshot.status === 'degraded'
+            ? 'Official source transport is degraded; last-good counts may be retained.'
+            : 'An official source is externally blocked; reviewed last-good counts remain identified.',
         sources: snapshot.sources.map((source) => ({
           id: source.id,
           publisher: source.publisher,
           transportStatus: source.transportStatus,
+          blockedReason: source.blockedReason,
           errorCodes: source.errorCodes,
           lastSuccessAt: source.lastSuccessAt,
         })),

--- a/src/types/cross-strait-activity.ts
+++ b/src/types/cross-strait-activity.ts
@@ -102,7 +102,7 @@ export interface CrossStraitActivitySourceHealth {
   transportStatus: 'fresh' | 'error';
   requestCount: number;
   transportPath?: 'direct' | 'proxy';
-  blockedReason?: string;
+  blockedReason?: 'HTTP_403';
   fallbackReason?: string;
   proxyFailureReason?: string;
   proxyFailureDetail?: CrossStraitProxyFailureDetail;

--- a/src/types/cross-strait-activity.ts
+++ b/src/types/cross-strait-activity.ts
@@ -85,6 +85,15 @@ export interface CrossStraitCategoryBaseline {
   };
 }
 
+export interface CrossStraitProxyFailureDetail {
+  stage: 'connect' | 'request' | 'response' | 'parse';
+  httpStatus: number | null;
+  contentType: string | null;
+  bodyPrefix: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+}
+
 export interface CrossStraitActivitySourceHealth {
   id: CrossStraitSourceId;
   publisher: string;
@@ -93,8 +102,10 @@ export interface CrossStraitActivitySourceHealth {
   transportStatus: 'fresh' | 'error';
   requestCount: number;
   transportPath?: 'direct' | 'proxy';
+  blockedReason?: string;
   fallbackReason?: string;
   proxyFailureReason?: string;
+  proxyFailureDetail?: CrossStraitProxyFailureDetail;
   errorCodes: string[];
   lastSuccessAt: string | null;
   admittedDocumentCount?: number;

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -48,14 +48,14 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
       {
         id: 'japan-mod',
         transportStatus: 'error',
-        blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+        blockedReason: 'HTTP_403',
         proxyFailureDetail: {
-          stage: 'connect',
+          stage: 'response',
           httpStatus: 403,
           contentType: null,
           bodyPrefix: null,
           errorCode: null,
-          errorMessage: 'Proxy CONNECT: HTTP/1.1 403 Forbidden',
+          errorMessage: 'HTTP_403',
         },
       },
     ],
@@ -130,7 +130,7 @@ test('a freshly classified blocked source is explicit and does not pin fleet hea
     sources: [{
       id: 'japan-mod',
       transportStatus: 'error',
-      blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+      blockedReason: 'HTTP_403',
       lastSuccessAt: null,
     }],
   };
@@ -234,7 +234,7 @@ test('blocked source health never publishes fresh metadata before its detail rec
       sources: [{
         id: 'japan-mod',
         transportStatus: 'error',
-        blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+        blockedReason: 'HTTP_403',
         lastSuccessAt: null,
       }],
     }, async (key: string) => {
@@ -247,6 +247,32 @@ test('blocked source health never publishes fresh metadata before its detail rec
   );
 
   assert.deepEqual(writes, ['military:cross-strait-activity:v1:source:japan-mod']);
+});
+
+test('a proxy CONNECT refusal remains an operator-visible source error', async () => {
+  const writes = new Map<string, unknown>();
+  await writeSourceHealth({
+    generatedAt: '2026-07-27T20:00:00.000Z',
+    observations: [{ sourceId: 'japan-mod' }],
+    sources: [{
+      id: 'japan-mod',
+      transportStatus: 'error',
+      blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+      lastSuccessAt: null,
+    }],
+  }, async (key: string, value: unknown) => {
+    writes.set(key, value);
+  });
+
+  assert.deepEqual(
+    writes.get('seed-meta:military:cross-strait-activity:japan-mod'),
+    {
+      fetchedAt: 0,
+      recordCount: 1,
+      sourceState: 'error',
+      stale: true,
+    },
+  );
 });
 
 test('operator seed-health matches the fail-closed Japan blocked classification', async () => {

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import test from 'node:test';
 
 import { __testing__ } from '../api/health.js';
+import seedHealthHandler from '../api/seed-health.js';
 import { atomicPublish, runSeed } from '../scripts/_seed-utils.mjs';
 import { CROSS_STRAIT_ACTIVITY_KEY } from '../scripts/cross-strait-activity/adapters.mjs';
 import {
@@ -42,7 +43,22 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
     schemaVersion: 1,
     generatedAt: '2026-07-25T12:00:00.000Z',
     status: 'degraded',
-    sources: [{ id: 'taiwan-mnd', transportStatus: 'error' }, { id: 'japan-mod', transportStatus: 'fresh' }],
+    sources: [
+      { id: 'taiwan-mnd', transportStatus: 'error' },
+      {
+        id: 'japan-mod',
+        transportStatus: 'error',
+        blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+        proxyFailureDetail: {
+          stage: 'connect',
+          httpStatus: 403,
+          contentType: null,
+          bodyPrefix: null,
+          errorCode: null,
+          errorMessage: 'Proxy CONNECT: HTTP/1.1 403 Forbidden',
+        },
+      },
+    ],
     coverage: { latestMndReportingDay: '2026-07-25' },
     observations: [
       observation('taiwan-mnd', '2026-07-24', [{ obsolete: true }]),
@@ -60,7 +76,14 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
     'japan-mod:2026-07-20',
   ]);
   assert.ok(projection.observations.every((row) => !('history' in row)));
-  assert.deepEqual(projection.sources, snapshot.sources);
+  assert.deepEqual(projection.sources, snapshot.sources.map((source) => {
+    const { proxyFailureDetail: _proxyFailureDetail, ...publicSource } = source;
+    return publicSource;
+  }));
+  assert.equal(
+    projection.sources.some((source) => 'proxyFailureDetail' in source),
+    false,
+  );
   assert.deepEqual(projection.coverage, snapshot.coverage);
   assert.deepEqual(projection.baselines, snapshot.baselines);
   assert.ok(Buffer.byteLength(JSON.stringify(projection), 'utf8') <= CROSS_STRAIT_ACTIVITY_BOOTSTRAP_MAX_BYTES);
@@ -91,6 +114,275 @@ test('cross-Strait source transport health degrades immediately without discardi
 
     assert.equal(entry.status, 'SEED_ERROR', name);
     assert.equal(entry.records, 91, name);
+  }
+});
+
+test('a freshly classified blocked source is explicit and does not pin fleet health', async () => {
+  const { classifyKey, STATUS_COUNTS, SEED_META, STANDALONE_KEYS } = __testing__;
+  const now = Date.parse('2026-07-27T20:00:00.000Z');
+  const writes = new Map<string, unknown>();
+  const snapshot = {
+    generatedAt: new Date(now).toISOString(),
+    observations: [
+      { sourceId: 'japan-mod' },
+      { sourceId: 'japan-mod' },
+    ],
+    sources: [{
+      id: 'japan-mod',
+      transportStatus: 'error',
+      blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+      lastSuccessAt: null,
+    }],
+  };
+
+  await writeSourceHealth(snapshot, async (key: string, value: unknown) => {
+    writes.set(key, value);
+  });
+
+  const metaKey = SEED_META.crossStraitActivityJapanMod.key;
+  const dataKey = STANDALONE_KEYS.crossStraitActivityJapanMod;
+  assert.deepEqual([...writes.keys()], [dataKey, metaKey]);
+  assert.deepEqual(writes.get(metaKey), {
+    fetchedAt: now,
+    recordCount: 2,
+    sourceState: 'blocked',
+    stale: false,
+  });
+
+  const entry = classifyKey('crossStraitActivityJapanMod', dataKey, { allowOnDemand: true }, {
+    keyStrens: new Map([[dataKey, 1024]]),
+    keyErrors: new Map(),
+    keyMetaValues: new Map([[metaKey, JSON.stringify(writes.get(metaKey))]]),
+    keyMetaErrors: new Map(),
+    now,
+  });
+
+  assert.equal(entry.status, 'SOURCE_BLOCKED');
+  assert.equal(entry.records, 2);
+  assert.equal(STATUS_COUNTS.SOURCE_BLOCKED, 'ok');
+
+  const mndMetaKey = SEED_META.crossStraitActivityTaiwanMnd.key;
+  const mndDataKey = STANDALONE_KEYS.crossStraitActivityTaiwanMnd;
+  const mndEntry = classifyKey(
+    'crossStraitActivityTaiwanMnd',
+    mndDataKey,
+    { allowOnDemand: true },
+    {
+      keyStrens: new Map([[mndDataKey, 1024]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([[
+        mndMetaKey,
+        JSON.stringify({
+          fetchedAt: now,
+          recordCount: 2,
+          sourceState: 'blocked',
+          stale: false,
+        }),
+      ]]),
+      keyMetaErrors: new Map(),
+      now,
+    },
+  );
+
+  assert.equal(mndEntry.status, 'SEED_ERROR');
+  assert.equal(STATUS_COUNTS[mndEntry.status], 'warn');
+
+  const staleEntry = classifyKey(
+    'crossStraitActivityJapanMod',
+    dataKey,
+    { allowOnDemand: true },
+    {
+      keyStrens: new Map([[dataKey, 1024]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([[
+        metaKey,
+        JSON.stringify({
+          fetchedAt: now - ((SEED_META.crossStraitActivityJapanMod.maxStaleMin + 1) * 60_000),
+          recordCount: 2,
+          sourceState: 'blocked',
+          stale: false,
+        }),
+      ]]),
+      keyMetaErrors: new Map(),
+      now,
+    },
+  );
+  assert.equal(staleEntry.status, 'STALE_SEED');
+
+  const missingEntry = classifyKey(
+    'crossStraitActivityJapanMod',
+    dataKey,
+    { allowOnDemand: true },
+    {
+      keyStrens: new Map([[dataKey, 0]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([[metaKey, JSON.stringify(writes.get(metaKey))]]),
+      keyMetaErrors: new Map(),
+      now,
+    },
+  );
+  assert.notEqual(missingEntry.status, 'SOURCE_BLOCKED');
+  assert.equal(STATUS_COUNTS[missingEntry.status], 'crit');
+});
+
+test('blocked source health never publishes fresh metadata before its detail record', async () => {
+  const writes: string[] = [];
+  await assert.rejects(
+    writeSourceHealth({
+      generatedAt: '2026-07-27T20:00:00.000Z',
+      observations: [{ sourceId: 'japan-mod' }],
+      sources: [{
+        id: 'japan-mod',
+        transportStatus: 'error',
+        blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+        lastSuccessAt: null,
+      }],
+    }, async (key: string) => {
+      writes.push(key);
+      if (key === 'military:cross-strait-activity:v1:source:japan-mod') {
+        throw new Error('injected blocked detail write failure');
+      }
+    }),
+    /blocked detail write failure/,
+  );
+
+  assert.deepEqual(writes, ['military:cross-strait-activity:v1:source:japan-mod']);
+});
+
+test('operator seed-health matches the fail-closed Japan blocked classification', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = {
+    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+    WORLDMONITOR_VALID_KEYS: process.env.WORLDMONITOR_VALID_KEYS,
+    RESILIENCE_PILLAR_COMBINE_ENABLED: process.env.RESILIENCE_PILLAR_COMBINE_ENABLED,
+    RESILIENCE_SCHEMA_V2_ENABLED: process.env.RESILIENCE_SCHEMA_V2_ENABLED,
+  };
+  const operatorKey = 'cross-strait-source-health-test-key';
+  const japanMetaKey = 'seed-meta:military:cross-strait-activity:japan-mod';
+  const taiwanMetaKey = 'seed-meta:military:cross-strait-activity:taiwan-mnd';
+  const probeKey = 'resilience:intervals:v9:US';
+
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+  process.env.WORLDMONITOR_VALID_KEYS = operatorKey;
+  process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
+  process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
+
+  const readEntry = async ({
+    japanMeta,
+    taiwanMeta,
+  }: {
+    japanMeta: Record<string, unknown> | null;
+    taiwanMeta?: Record<string, unknown>;
+  }) => {
+    globalThis.fetch = async (_url, init) => {
+      const commands = JSON.parse(String(init?.body));
+      const results = commands.map(([operation, key]: [string, string]) => {
+        if (operation === 'EXISTS') return { result: 0 };
+        assert.equal(operation, 'GET');
+        if (key === japanMetaKey) {
+          return { result: japanMeta == null ? null : JSON.stringify(japanMeta) };
+        }
+        if (key === taiwanMetaKey && taiwanMeta) {
+          return { result: JSON.stringify(taiwanMeta) };
+        }
+        if (key === probeKey) {
+          return {
+            result: JSON.stringify({
+              p05: 65.2,
+              p95: 72.8,
+              _formula: 'd6',
+              methodology: 'weight-perturbation-sensitivity-v3',
+              computedAt: new Date().toISOString(),
+            }),
+          };
+        }
+        return {
+          result: JSON.stringify({
+            fetchedAt: Date.now(),
+            recordCount: 10_000,
+            sourceVersion: key === 'seed-meta:resilience:intervals'
+              ? 'resilience-intervals:resilience:intervals:v9:weight-perturbation-sensitivity-v3'
+              : 'test',
+          }),
+        };
+      });
+      return new Response(JSON.stringify(results), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const response = await seedHealthHandler(new Request(
+      'https://api.worldmonitor.app/api/seed-health',
+      { headers: { 'X-WorldMonitor-Key': operatorKey } },
+    ));
+    return {
+      response,
+      body: await response.json(),
+    };
+  };
+
+  try {
+    const fresh = await readEntry({
+      japanMeta: {
+        fetchedAt: Date.now(),
+        recordCount: 2,
+        sourceState: 'blocked',
+      },
+    });
+    assert.equal(fresh.response.status, 200);
+    assert.equal(
+      fresh.body.seeds['military:cross-strait-activity:japan-mod'].status,
+      'source_blocked',
+    );
+    assert.equal(
+      fresh.body.seeds['military:cross-strait-activity:japan-mod'].stale,
+      false,
+    );
+
+    const stale = await readEntry({
+      japanMeta: {
+        fetchedAt: Date.now() - (361 * 60_000),
+        recordCount: 2,
+        sourceState: 'blocked',
+      },
+    });
+    assert.equal(stale.body.seeds['military:cross-strait-activity:japan-mod'].status, 'stale');
+
+    const zeroCount = await readEntry({
+      japanMeta: {
+        fetchedAt: Date.now(),
+        recordCount: 0,
+        sourceState: 'blocked',
+      },
+    });
+    assert.equal(zeroCount.body.seeds['military:cross-strait-activity:japan-mod'].status, 'error');
+
+    const wrongDomain = await readEntry({
+      japanMeta: {
+        fetchedAt: Date.now(),
+        recordCount: 2,
+        sourceState: 'ok',
+      },
+      taiwanMeta: {
+        fetchedAt: Date.now(),
+        recordCount: 2,
+        sourceState: 'blocked',
+      },
+    });
+    assert.equal(wrongDomain.body.seeds['military:cross-strait-activity:taiwan-mnd'].status, 'error');
+
+    const missing = await readEntry({ japanMeta: null });
+    assert.equal(missing.response.status, 503);
+    assert.equal(missing.body.seeds['military:cross-strait-activity:japan-mod'].status, 'missing');
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value == null) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 });
 

--- a/tests/cross-strait-activity-ui.test.mts
+++ b/tests/cross-strait-activity-ui.test.mts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 
 import {
   buildCrossStraitActivityPanelModel,
+  crossStraitSourceHealthHeading,
   isCrossStraitActivitySnapshot,
   tryBuildCrossStraitActivityPanelModel,
 } from '../src/components/cross-strait-activity-summary';
@@ -313,18 +314,26 @@ describe('Force Posture official-activity supplement (#5575)', () => {
         {
           ...snapshot.sources[1],
           transportStatus: 'error',
-          blockedReason: 'PROXY_CONNECT_FORBIDDEN',
-          errorCodes: ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN'],
+          blockedReason: 'HTTP_403',
+          errorCodes: ['HTTP_403'],
           lastSuccessAt: '2026-07-24T09:00:00.000Z',
         },
       ],
     });
     assert.equal(blocked.sourceHealth?.state, 'blocked');
     assert.match(blocked.sourceHealth?.summary ?? '', /externally blocked/);
-    assert.equal(blocked.sourceHealth?.sources[1]?.blockedReason, 'PROXY_CONNECT_FORBIDDEN');
+    assert.equal(blocked.sourceHealth?.sources[1]?.blockedReason, 'HTTP_403');
     assert.equal(
       blocked.sourceHealth?.sources[1]?.lastSuccessAt,
       '2026-07-24T09:00:00.000Z',
+    );
+    assert.equal(
+      crossStraitSourceHealthHeading(blocked.sourceHealth?.state ?? 'degraded'),
+      'Official activity source blocked',
+    );
+    assert.equal(
+      crossStraitSourceHealthHeading(unavailable.sourceHealth?.state ?? 'degraded'),
+      'Official activity unavailable',
     );
   });
 
@@ -388,6 +397,7 @@ describe('Force Posture official-activity supplement (#5575)', () => {
     assert.match(panel, /if \(this\.officialActivity\) this\.requestRender\(\)/);
     assert.match(panel, /override destroy\(\): void \{[\s\S]*?this\.officialActivityDestroyed = true;/);
     assert.match(panel, /model\.sourceHealth/);
+    assert.match(panel, /crossStraitSourceHealthHeading\(model\.sourceHealth\.state\)/);
     assert.match(panel, /last success:/);
     assert.match(basePanel, /protected requestRender\(\): void/);
     assert.match(renderer, /url\.port === ''/);

--- a/tests/cross-strait-activity-ui.test.mts
+++ b/tests/cross-strait-activity-ui.test.mts
@@ -304,6 +304,28 @@ describe('Force Posture official-activity supplement (#5575)', () => {
     const unavailable = buildCrossStraitActivityPanelModel({ ...snapshot, status: 'unavailable' });
     assert.equal(unavailable.sourceHealth?.state, 'unavailable');
     assert.match(unavailable.sourceHealth?.summary ?? '', /snapshot unavailable/);
+
+    const blocked = buildCrossStraitActivityPanelModel({
+      ...snapshot,
+      status: 'healthy',
+      sources: [
+        snapshot.sources[0],
+        {
+          ...snapshot.sources[1],
+          transportStatus: 'error',
+          blockedReason: 'PROXY_CONNECT_FORBIDDEN',
+          errorCodes: ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN'],
+          lastSuccessAt: '2026-07-24T09:00:00.000Z',
+        },
+      ],
+    });
+    assert.equal(blocked.sourceHealth?.state, 'blocked');
+    assert.match(blocked.sourceHealth?.summary ?? '', /externally blocked/);
+    assert.equal(blocked.sourceHealth?.sources[1]?.blockedReason, 'PROXY_CONNECT_FORBIDDEN');
+    assert.equal(
+      blocked.sourceHealth?.sources[1]?.lastSuccessAt,
+      '2026-07-24T09:00:00.000Z',
+    );
   });
 
   it('rejects malformed nested cache snapshots and soft-fails the supplement model', () => {

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1205,6 +1205,160 @@ describe('quantified cross-Strait activity (#5575)', () => {
     );
   });
 
+  it('keeps bounded proxy diagnostics when a generic failure follows the direct Japan MOD 403', async () => {
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => {
+        throw Object.assign(
+          new Error(
+            `socket hang up via https://proxy-user:proxy-secret@proxy.test ${'x'.repeat(500)}`,
+          ),
+          { code: 'ECONNRESET' },
+        );
+      },
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.transportStatus, 'error');
+    assert.equal(japan?.fallbackReason, 'HTTP_403');
+    assert.equal(japan?.proxyFailureReason, 'SOURCE_ERROR');
+    assert.deepEqual(japan?.errorCodes, ['HTTP_403', 'SOURCE_ERROR']);
+    assert.deepEqual(japan?.proxyFailureDetail, {
+      stage: 'request',
+      httpStatus: null,
+      contentType: null,
+      bodyPrefix: null,
+      errorCode: 'ECONNRESET',
+      errorMessage: `socket hang up via https://[redacted]@proxy.test ${'x'.repeat(500)}`
+        .slice(0, 256),
+    });
+    assert.doesNotMatch(JSON.stringify(japan), /proxy-user|proxy-secret/);
+  });
+
+  it('classifies a proxy CONNECT 403 as a documented blocked Japan MOD path', async () => {
+    const previousSnapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response(fixture('jmod-index.html')),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: '',
+    });
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse('2026-07-25T11:30:00.000Z'),
+      previousSnapshot,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => {
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+          { status: 403 },
+        );
+      },
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.transportStatus, 'error');
+    assert.equal(japan?.blockedReason, 'PROXY_CONNECT_FORBIDDEN');
+    assert.equal(japan?.fallbackReason, 'HTTP_403');
+    assert.equal(japan?.proxyFailureReason, 'PROXY_CONNECT_FORBIDDEN');
+    assert.deepEqual(japan?.errorCodes, ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN']);
+    assert.deepEqual(japan?.proxyFailureDetail, {
+      stage: 'connect',
+      httpStatus: 403,
+      contentType: null,
+      bodyPrefix: null,
+      errorCode: null,
+      errorMessage: 'Proxy CONNECT: HTTP/1.1 403 Forbidden',
+    });
+    assert.equal(japan?.lastSuccessAt, retrievedAt);
+    assert.equal(
+      japan?.unreviewedCandidateCount,
+      previousSnapshot.sources.find((source: { id: string }) => source.id === 'japan-mod')
+        ?.unreviewedCandidateCount,
+    );
+    assert.deepEqual(
+      snapshot.observations.filter((row: { sourceId: string }) => row.sourceId === 'japan-mod'),
+      previousSnapshot.observations.filter(
+        (row: { sourceId: string }) => row.sourceId === 'japan-mod',
+      ),
+    );
+  });
+
+  it('classifies direct and proxied Japan MOD HTTP 403 responses as explicitly blocked', async () => {
+    const responseBody = `Denied via https://proxy-user:proxy-secret@proxy.test ${'x'.repeat(500)}`;
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => ({
+        buffer: Buffer.from(responseBody),
+        status: 403,
+        contentType: 'text/html; charset=UTF-8',
+      }),
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.transportStatus, 'error');
+    assert.equal(japan?.blockedReason, 'HTTP_403');
+    assert.equal(japan?.fallbackReason, 'HTTP_403');
+    assert.equal(japan?.proxyFailureReason, 'HTTP_403');
+    assert.deepEqual(japan?.errorCodes, ['HTTP_403']);
+    assert.deepEqual(japan?.proxyFailureDetail, {
+      stage: 'response',
+      httpStatus: 403,
+      contentType: 'text/html; charset=UTF-8',
+      bodyPrefix: `Denied via https://[redacted]@proxy.test ${'x'.repeat(500)}`.slice(0, 256),
+      errorCode: null,
+      errorMessage: 'HTTP_403',
+    });
+    assert.doesNotMatch(JSON.stringify(japan), /proxy-user|proxy-secret/);
+  });
+
+  it('does not classify mixed direct failures and proxy 403 as a two-path block', async () => {
+    for (const [directResult, fallbackReason] of [
+      [() => { throw new Error('network reset'); }, 'SOURCE_ERROR'],
+      [() => { throw new Error('request timeout'); }, 'TIMEOUT'],
+      [() => new Response('Unavailable', { status: 500 }), 'HTTP_500'],
+    ] as const) {
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        fetchFn: crossStraitFixtureFetch(directResult),
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        sleepFn: async () => {},
+        proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+        proxyRequestFn: async () => {
+          throw Object.assign(
+            new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+            { status: 403 },
+          );
+        },
+      });
+
+      const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+      assert.equal(japan?.transportStatus, 'error');
+      assert.equal(japan?.blockedReason, undefined);
+      assert.equal(japan?.fallbackReason, fallbackReason);
+      assert.equal(japan?.proxyFailureReason, 'PROXY_CONNECT_FORBIDDEN');
+      assert.deepEqual(japan?.errorCodes, [fallbackReason, 'PROXY_CONNECT_FORBIDDEN']);
+      assert.equal(snapshot.status, 'degraded');
+    }
+  });
+
   it('records an unusable proxy response without hiding the direct Japan MOD rejection', async () => {
     const snapshot = await fetchCrossStraitActivitySnapshot({
       fetchFn: crossStraitFixtureFetch(
@@ -1228,6 +1382,14 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(japan?.fallbackReason, 'HTTP_403');
     assert.equal(japan?.proxyFailureReason, 'JMOD_INDEX_EMPTY');
     assert.deepEqual(japan?.errorCodes, ['HTTP_403', 'JMOD_INDEX_EMPTY']);
+    assert.deepEqual(japan?.proxyFailureDetail, {
+      stage: 'parse',
+      httpStatus: 200,
+      contentType: 'text/html',
+      bodyPrefix: '<html><title>Proxy access denied</title></html>',
+      errorCode: 'JMOD_INDEX_EMPTY',
+      errorMessage: 'JMOD_INDEX_EMPTY',
+    });
   });
 
   it('reports a malformed configured proxy as configuration failure', async () => {

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1244,7 +1244,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     );
   });
 
-  it('classifies a proxy CONNECT 403 as a documented blocked Japan MOD path', async () => {
+  it('keeps a proxy CONNECT 403 degraded because the request never reached Japan MOD', async () => {
     const previousSnapshot = await fetchCrossStraitActivitySnapshot({
       fetchFn: crossStraitFixtureFetch(
         () => new Response(fixture('jmod-index.html')),
@@ -1272,10 +1272,11 @@ describe('quantified cross-Strait activity (#5575)', () => {
 
     const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
     assert.equal(japan?.transportStatus, 'error');
-    assert.equal(japan?.blockedReason, 'PROXY_CONNECT_FORBIDDEN');
+    assert.equal(japan?.blockedReason, undefined);
     assert.equal(japan?.fallbackReason, 'HTTP_403');
     assert.equal(japan?.proxyFailureReason, 'PROXY_CONNECT_FORBIDDEN');
     assert.deepEqual(japan?.errorCodes, ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN']);
+    assert.equal(snapshot.status, 'degraded');
     assert.deepEqual(japan?.proxyFailureDetail, {
       stage: 'connect',
       httpStatus: 403,

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1217,7 +1217,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
       proxyRequestFn: async () => {
         throw Object.assign(
           new Error(
-            `socket hang up via https://proxy-user:proxy-secret@proxy.test ${'x'.repeat(500)}`,
+            `socket hang up\nProxy-Authorization: Basic cHJveHktc2VjcmV0\nvia https://proxy-user:proxy-secret@proxy.test ${'x'.repeat(500)}`,
           ),
           { code: 'ECONNRESET' },
         );
@@ -1235,10 +1235,13 @@ describe('quantified cross-Strait activity (#5575)', () => {
       contentType: null,
       bodyPrefix: null,
       errorCode: 'ECONNRESET',
-      errorMessage: `socket hang up via https://[redacted]@proxy.test ${'x'.repeat(500)}`
+      errorMessage: `socket hang up Proxy-Authorization: [redacted] via https://[redacted]@proxy.test ${'x'.repeat(500)}`
         .slice(0, 256),
     });
-    assert.doesNotMatch(JSON.stringify(japan), /proxy-user|proxy-secret/);
+    assert.doesNotMatch(
+      JSON.stringify(japan),
+      /proxy-user|proxy-secret|cHJveHktc2VjcmV0/,
+    );
   });
 
   it('classifies a proxy CONNECT 403 as a documented blocked Japan MOD path', async () => {


### PR DESCRIPTION
## Summary

Japan MOD proxy failures now retain enough bounded, redacted evidence to distinguish an upstream source refusal from a proxy-path failure.

The adapter records proxy stage, HTTP status, content type, and a truncated body prefix. A direct `HTTP_403` followed by another upstream `HTTP_403` after a successful proxy CONNECT can be classified as `SOURCE_BLOCKED` when reviewed records remain fresh. A proxy `CONNECT 403` occurs before TLS reaches Japan MOD, so it remains degraded as `PROXY_CONNECT_FORBIDDEN` / `SEED_ERROR` instead of being promoted to a green source state.

The public bootstrap retains bounded reason codes but omits proxy response detail. Authenticated operator records retain the sanitized diagnostic, and the Force Posture disclosure renders blocked, degraded, and unavailable states with distinct headings.

Refs #5714.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: cross-Strait source ingestion, seed health, and Force Posture source disclosure

## Validation

- Live evidence: direct Japan MOD returned HTTP 403; the configured proxy refused CONNECT with HTTP 403 before TLS.
- Focused cross-Strait suites: 85 passed, 0 failed.
- `npm run typecheck`
- `npm run typecheck:api`
- Biome, markdownlint, and `git diff --check`
- Full change-scoped pre-push gate: passed, including 85 changed tests and 482 Edge/MDX tests.

## Checklist

- [ ] Tested on [worldmonitor.app](https://www.worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (not applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A: this documents an operational health classification and does not change methodology, generated API/MCP contracts, Redis key names, CII/CRI, news, digest, or briefing claims.

## Post-Deploy Monitoring & Validation

- After the next two to three scheduled three-hour cross-Strait runs, inspect authenticated `/api/health` and `/api/seed-health`.
- `SOURCE_BLOCKED` / `source_blocked` is valid only when direct and successfully proxied requests both receive upstream HTTP 403 and retained reviewed records remain positive and fresh.
- A diagnostic with stage `connect` and `PROXY_CONNECT_FORBIDDEN` must remain `SEED_ERROR`; it means the request did not reach Japan MOD and the proxy path still requires remediation.
- Treat missing diagnostic detail, `PROXY_AUTH_FAILED`, loss of reviewed records, a stale blocked record, or parent-feed degradation as rollout failures.
- Owner: WorldMonitor maintainer/on-call.

Production acceptance for #5714 remains open until this commit is merged and deployed, a scheduled seed run publishes the expected diagnostic, and either the proxy path is restored or a successful CONNECT produces enough upstream evidence for the narrowly guarded blocked classification. This PR does not merge or enable auto-merge.

## Screenshots

Not applicable; the UI change is a source-health disclosure heading covered by focused model-and-wiring tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with_Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
