### PR TITLE
fix(conflict): recover HAPI from egress bot blocks

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -526,7 +526,20 @@ function latestDatedChangelogRelease(changelog) {
   return dates[dates.length - 1] || null;
 }
 
-function gitFileLastmod(rootDir, relativePath) {
+function hasCompleteGitHistory(rootDir) {
+  try {
+    return execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() === 'false';
+  } catch {
+    return false;
+  }
+}
+
+export function gitFileLastmod(rootDir, relativePath) {
+  if (!hasCompleteGitHistory(rootDir)) return null;
   try {
     const out = execFileSync('git', ['log', '-1', '--format=%cs', '--', relativePath], {
       cwd: rootDir,

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -30,6 +30,7 @@ import {
 import { fetchGdeltJson } from './_gdelt-fetch.mjs';
 import { buildGdeltConflictUrl, mapGdeltArticlesToEvents, GDELT_COUNTRY_NAMES } from './_conflict-gdelt.mjs';
 import { fetchGdeltBulkConflictEvents, GDELT_ROLLING_WINDOW_MS, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
+import { parseProxyConfig, proxyFetch } from './_proxy-utils.cjs';
 
 loadEnvFile(import.meta.url);
 
@@ -82,6 +83,7 @@ const HAPI_REQUEST_TIMEOUT_MS = 15_000;
 const HAPI_REQUEST_DELAY_MS = 1_100;
 const HAPI_PAGE_LIMIT = 10_000;
 const HAPI_MAX_PAGES = 3;
+const HAPI_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
 const PIZZINT_TTL = 600;
 
 export const CONFLICT_COUNTRIES = [
@@ -572,6 +574,75 @@ async function defaultPreserveHapiLastGood() {
   );
 }
 
+function hapiFailureReason(status, providerMessage = '') {
+  if (Number(status) === 429 && /blocked due to bot activity/i.test(providerMessage)) {
+    return 'HAPI_BOT_BLOCK';
+  }
+  if (Number(status) === 429) return 'HAPI_RATE_LIMIT';
+  return Number.isInteger(Number(status)) ? `HTTP_${Number(status)}` : 'HAPI_FETCH_FAILED';
+}
+
+async function hapiResponseError(resp) {
+  let providerMessage = '';
+  try {
+    const rawBody = await resp.text();
+    try {
+      const body = JSON.parse(rawBody);
+      providerMessage = String(body?.error || body?.detail || rawBody);
+    } catch {
+      providerMessage = rawBody;
+    }
+  } catch {
+    // Status and status text remain sufficient when the provider sends no body.
+  }
+  return Object.assign(
+    new Error(`HTTP ${resp.status} ${resp.statusText}${providerMessage ? `: ${providerMessage}` : ''}`),
+    {
+      status: resp.status,
+      reasonCode: hapiFailureReason(resp.status, providerMessage),
+    },
+  );
+}
+
+function hapiProxyFailureReason(error) {
+  if (
+    Number(error?.status) === 407
+    || /Proxy CONNECT:[^\n]*\b407\b/i.test(String(error?.message ?? ''))
+  ) return 'PROXY_AUTH_FAILED';
+  if (error?.reasonCode) return error.reasonCode;
+  if (/PROXY_CONFIG_INVALID/i.test(String(error?.message ?? ''))) return 'PROXY_CONFIG_INVALID';
+  if (
+    error?.code === 'RESPONSE_TOO_LARGE'
+    || /RESPONSE_TOO_LARGE/i.test(String(error?.message ?? ''))
+  ) return 'RESPONSE_TOO_LARGE';
+  return 'PROXY_FETCH_FAILED';
+}
+
+async function fetchHapiViaConfiguredProxy(input, init, {
+  proxyConfig,
+  proxyRequestFn,
+}) {
+  if (!proxyConfig) throw new Error('PROXY_CONFIG_INVALID');
+  const result = await proxyRequestFn(String(input), proxyConfig, {
+    accept: 'application/json',
+    headers: init?.headers,
+    method: init?.method ?? 'GET',
+    maxResponseBytes: HAPI_MAX_RESPONSE_BYTES,
+    timeoutMs: HAPI_REQUEST_TIMEOUT_MS,
+    signal: init?.signal,
+  });
+  if (result.buffer.byteLength > HAPI_MAX_RESPONSE_BYTES) {
+    throw new Error('RESPONSE_TOO_LARGE');
+  }
+  return new Response(result.buffer, {
+    status: result.status,
+    headers: {
+      'Content-Length': String(result.buffer.byteLength),
+      'Content-Type': result.contentType || 'application/json',
+    },
+  });
+}
+
 async function fetchHapiRows({
   fetchFn,
   nowMs,
@@ -594,17 +665,7 @@ async function fetchHapiRows({
       },
     );
     if (!resp.ok) {
-      let providerMessage = '';
-      try {
-        const body = await resp.json();
-        providerMessage = String(body?.error || body?.detail || '');
-      } catch {
-        // Status and status text remain sufficient when the provider sends no JSON.
-      }
-      throw Object.assign(
-        new Error(`HTTP ${resp.status} ${resp.statusText}${providerMessage ? `: ${providerMessage}` : ''}`),
-        { status: resp.status },
-      );
+      throw await hapiResponseError(resp);
     }
 
     const rawData = await resp.json();
@@ -632,10 +693,17 @@ export async function fetchAllHumanitarianSummaries({
   requiredCountryCodes = countryCodes === HAPI_COUNTRIES ? HAPI_REQUIRED_COUNTRIES : countryCodes,
   loadPreviousMarker = () => readSeedSnapshot(HAPI_CACHE_KEY_PREFIX),
   loadFailureBackoff = () => readSeedSnapshot(HAPI_FAILURE_BACKOFF_KEY),
+  proxyUrl = process.env.PROXY_URL ?? '',
+  proxyRequestFn = proxyFetch,
   writeFailureBackoff = (value) => writeExtraKey(
     HAPI_FAILURE_BACKOFF_KEY,
     value,
     Math.ceil(HAPI_FAILURE_BACKOFF_MS / 1000),
+  ),
+  writeFailureMeta = (value) => writeExtraKey(
+    HAPI_SEED_META_KEY,
+    value,
+    HAPI_SEED_META_TTL_SECONDS,
   ),
   preserveLastGood = defaultPreserveHapiLastGood,
 } = {}) {
@@ -661,12 +729,56 @@ export async function fetchAllHumanitarianSummaries({
     return null;
   }
 
+  const proxyConfig = proxyUrl ? parseProxyConfig(proxyUrl) : null;
+  const configuredProxyFetch = proxyUrl
+    ? (input, init) => fetchHapiViaConfiguredProxy(input, init, {
+        proxyConfig,
+        proxyRequestFn,
+      })
+    : null;
+  let useProxy = false;
+  let proxyTriggerFailure = null;
+  const fetchRowsViaProxy = async (options) => {
+    try {
+      return await fetchHapiRows({ ...options, fetchFn: configuredProxyFetch });
+    } catch (proxyFailure) {
+      throw Object.assign(
+        new Error('HAPI proxy fallback failed after direct bot detection'),
+        {
+          status: Number.isFinite(Number(proxyFailure?.status))
+            ? Number(proxyFailure.status)
+            : Number(proxyTriggerFailure?.status),
+          reasonCode: 'HAPI_PROXY_FALLBACK_FAILED',
+          directFailureReason: proxyTriggerFailure?.reasonCode ?? 'HAPI_BOT_BLOCK',
+          proxyFailureReason: hapiProxyFailureReason(proxyFailure),
+        },
+      );
+    }
+  };
+  const fetchRows = async (options) => {
+    if (useProxy) {
+      return fetchRowsViaProxy(options);
+    }
+    try {
+      return await fetchHapiRows({ ...options, fetchFn });
+    } catch (directFailure) {
+      if (
+        !configuredProxyFetch
+        || directFailure?.reasonCode !== 'HAPI_BOT_BLOCK'
+      ) throw directFailure;
+
+      useProxy = true;
+      proxyTriggerFailure = directFailure;
+      console.warn('  HAPI direct request hit provider bot detection — retrying through configured proxy');
+      return fetchRowsViaProxy(options);
+    }
+  };
+
   let failure;
   try {
     // Most countries have national rows, so one global admin-0 request covers
     // them without the old per-country fan-out.
-    const nationalRows = await fetchHapiRows({
-      fetchFn,
+    const nationalRows = await fetchRows({
       nowMs,
       adminLevel: '0',
     });
@@ -681,8 +793,7 @@ export async function fetchAllHumanitarianSummaries({
     for (let i = 0; i < missingCountries.length; i += 1) {
       const countryCode = missingCountries[i];
       try {
-        const rows = await fetchHapiRows({
-          fetchFn,
+        const rows = await fetchRows({
           nowMs,
           countryCode,
           adminLevel: null,
@@ -695,6 +806,7 @@ export async function fetchAllHumanitarianSummaries({
       } catch (error) {
         fallbackFailure = error;
         console.warn(`  HAPI ${countryCode} fallback failed: ${error.message}`);
+        if (error.reasonCode === 'HAPI_PROXY_FALLBACK_FAILED') throw error;
         if (error.status === 429 || error.status === 403) break;
       }
       if (i < missingCountries.length - 1) await pace(HAPI_REQUEST_DELAY_MS);
@@ -707,7 +819,18 @@ export async function fetchAllHumanitarianSummaries({
       // results empty.
       throw Object.assign(
         new Error('bulk response contained no target-country national summaries'),
-        fallbackFailure?.status != null ? { status: fallbackFailure.status } : {},
+        fallbackFailure
+          ? {
+              ...(fallbackFailure.status != null ? { status: fallbackFailure.status } : {}),
+              ...(fallbackFailure.reasonCode ? { reasonCode: fallbackFailure.reasonCode } : {}),
+              ...(fallbackFailure.directFailureReason
+                ? { directFailureReason: fallbackFailure.directFailureReason }
+                : {}),
+              ...(fallbackFailure.proxyFailureReason
+                ? { proxyFailureReason: fallbackFailure.proxyFailureReason }
+                : {}),
+            }
+          : {},
       );
     }
 
@@ -715,6 +838,7 @@ export async function fetchAllHumanitarianSummaries({
       const retryAt = nowMs + HAPI_FAILURE_BACKOFF_MS;
       await writeFailureBackoff({
         status: Number.isFinite(Number(fallbackFailure.status)) ? Number(fallbackFailure.status) : 0,
+        reasonCode: fallbackFailure.reasonCode ?? 'HAPI_FETCH_FAILED',
         failedAt: nowMs,
         retryAt,
       }).catch((error) => console.warn(`  HAPI backoff write failed: ${error.message}`));
@@ -729,9 +853,27 @@ export async function fetchAllHumanitarianSummaries({
   }
 
   const retryAt = nowMs + HAPI_FAILURE_BACKOFF_MS;
+  const reasonCode = failure?.reasonCode ?? 'HAPI_FETCH_FAILED';
   console.warn(`  HAPI bulk failed: ${failure.message} — preserving last-good data and backing off until ${new Date(retryAt).toISOString()}`);
+  await writeFailureMeta({
+    fetchedAt: nowMs,
+    recordCount: Number(previousMarker?.requiredCountriesCovered) || 0,
+    status: 'error',
+    errorReason: reasonCode,
+    failedAt: nowMs,
+    ...(Number.isFinite(Number(previousMarker?.updatedAt))
+      ? { lastSuccessAt: Number(previousMarker.updatedAt) }
+      : {}),
+    ...(failure?.directFailureReason
+      ? { directFailureReason: failure.directFailureReason }
+      : {}),
+    ...(failure?.proxyFailureReason
+      ? { proxyFailureReason: failure.proxyFailureReason }
+      : {}),
+  }).catch((error) => console.warn(`  HAPI failure health write failed: ${error.message}`));
   await writeFailureBackoff({
     status: Number.isFinite(Number(failure.status)) ? Number(failure.status) : 0,
+    reasonCode,
     failedAt: nowMs,
     retryAt,
   }).catch((error) => console.warn(`  HAPI backoff write failed: ${error.message}`));

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, it } from 'node:test';
 
 import {
   buildCorpus,
+  gitFileLastmod,
   loadCorpusData,
 } from '../scripts/build-crawlable-corpus.mjs';
 import { buildSitemapEntries } from '../scripts/build-sitemap.mjs';
@@ -33,6 +35,68 @@ function productionScriptNonce() {
 }
 
 describe('crawlable corpus generator', () => {
+  it('does not treat a shallow boundary commit as a source update', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'wm-corpus-shallow-'));
+    const sourceRoot = join(tempRoot, 'source');
+    const shallowRoot = join(tempRoot, 'shallow');
+    const gitEnv = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_')),
+    );
+    try {
+      mkdirSync(sourceRoot);
+      execFileSync('git', ['init', '--initial-branch=main'], { cwd: sourceRoot, env: gitEnv });
+      execFileSync(
+        'git',
+        ['config', 'user.email', 'corpus-test@worldmonitor.app'],
+        { cwd: sourceRoot, env: gitEnv },
+      );
+      execFileSync(
+        'git',
+        ['config', 'user.name', 'Corpus Test'],
+        { cwd: sourceRoot, env: gitEnv },
+      );
+
+      writeFileSync(join(sourceRoot, 'material.txt'), 'material version one\n');
+      execFileSync('git', ['add', 'material.txt'], { cwd: sourceRoot, env: gitEnv });
+      execFileSync('git', ['commit', '-m', 'add material'], {
+        cwd: sourceRoot,
+        env: {
+          ...gitEnv,
+          GIT_AUTHOR_DATE: '2026-06-01T00:00:00Z',
+          GIT_COMMITTER_DATE: '2026-06-01T00:00:00Z',
+        },
+      });
+
+      writeFileSync(join(sourceRoot, 'unrelated.txt'), 'release-only change\n');
+      execFileSync('git', ['add', 'unrelated.txt'], { cwd: sourceRoot, env: gitEnv });
+      execFileSync('git', ['commit', '-m', 'release change'], {
+        cwd: sourceRoot,
+        env: {
+          ...gitEnv,
+          GIT_AUTHOR_DATE: '2026-07-28T00:00:00Z',
+          GIT_COMMITTER_DATE: '2026-07-28T00:00:00Z',
+        },
+      });
+
+      execFileSync(
+        'git',
+        ['clone', '--depth', '1', pathToFileURL(sourceRoot).href, shallowRoot],
+        { env: gitEnv },
+      );
+      assert.equal(
+        execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+          cwd: shallowRoot,
+          encoding: 'utf8',
+          env: gitEnv,
+        }).trim(),
+        'true',
+      );
+      assert.equal(gitFileLastmod(shallowRoot, 'material.txt'), null);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('builds a non-trivial static corpus with canonical raw HTML pages', async () => {
     const outDir = mkdtempSync(join(tmpdir(), 'wm-crawlable-corpus-'));
     try {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -128,6 +128,24 @@ test('classifyKey: socialVelocity error seed-meta → SEED_ERROR while data is p
   assert.equal(entry.records, 1);
 });
 
+test('classifyKey: a permanently blocked humanitarian provider surfaces as SEED_ERROR', () => {
+  const dataKey = STANDALONE_KEYS.humanitarianSummary;
+  const metaKey = SEED_META.humanitarianSummary.key;
+  const entry = classifyKey('humanitarianSummary', dataKey, { allowOnDemand: false },
+    makeCtx({
+      strens: { [dataKey]: 1234 },
+      metaValues: {
+        [metaKey]: seedMeta({
+          status: 'error',
+          errorReason: 'HAPI_PROXY_FALLBACK_FAILED',
+        }),
+      },
+    }));
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 test('classifyKey: socialVelocity/wsbTickers tolerate the 3h cadence — fresh at 300min → OK', () => {
   // Cadence dropped 1h→3h (ScrapeCreators), so maxStaleMin was raised 180→540.
   // A healthy seed-meta aged 300min (5h, inside 540) must NOT false-alarm.

--- a/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
+++ b/tests/seed-conflict-intel-hapi-circuit-breaker.test.mjs
@@ -5,7 +5,8 @@
 // of requests per day. The durable contract is:
 //   - one national-level bulk request for the target countries,
 //   - no new request while the last successful snapshot is fresh,
-//   - a persisted failure backoff after a provider rejection, and
+//   - direct bot-block failures switch to the configured residential proxy,
+//   - quota/identifier throttles persist a failure backoff without proxying,
 //   - last-known-good Redis rows preserved without refreshing their fetchedAt.
 
 import { test } from 'node:test';
@@ -250,33 +251,217 @@ test('HAPI ingestion falls back only for targets missing national rows', async (
   assert.deepEqual(Object.keys(result).sort(), ['SD', 'UA']);
 });
 
-test('HAPI provider rejection persists a backoff and preserves last-known-good rows', async () => {
-  let calls = 0;
-  let backoff;
-  let preserved = 0;
+test('HAPI bot-detection rejection retries the bulk request through the configured proxy', async () => {
+  let directCalls = 0;
+  let proxyCalls = 0;
+  const rows = [{
+    location_code: 'SDN',
+    location_name: 'Sudan',
+    reference_period_start: '2026-07-01',
+    admin_level: 0,
+    event_type: 'political_violence',
+    events: 12,
+    fatalities: 3,
+  }];
   const result = await fetchAllHumanitarianSummaries({
     now: () => NOW,
     countryCodes: ['SD'],
     pace: async () => {},
     loadPreviousMarker: async () => null,
     loadFailureBackoff: async () => null,
-    writeFailureBackoff: async (value) => { backoff = value; },
-    preserveLastGood: async () => { preserved += 1; },
+    writeFailureBackoff: async () => assert.fail('successful proxy recovery must not back off'),
+    writeFailureMeta: async () => assert.fail('successful proxy recovery must not publish SEED_ERROR'),
+    preserveLastGood: async () => assert.fail('successful proxy recovery must not preserve stale rows'),
+    proxyUrl: 'https://user:pass@proxy.example:443',
+    proxyRequestFn: async (url, proxyConfig, options) => {
+      proxyCalls += 1;
+      assert.match(url, /hapi\.humdata\.org/);
+      assert.equal(proxyConfig.host, 'proxy.example');
+      assert.ok(options.headers['X-HDX-HAPI-APP-IDENTIFIER']);
+      return {
+        status: 200,
+        buffer: Buffer.from(JSON.stringify({ data: rows })),
+        contentType: 'application/json',
+      };
+    },
     fetchFn: async () => {
-      calls += 1;
-      return new Response(JSON.stringify({ error: 'Blocked due to bot activity.' }), { status: 429 });
+      directCalls += 1;
+      return new Response('Blocked due to bot activity.', { status: 429 });
+    },
+  });
+
+  assert.equal(directCalls, 1);
+  assert.equal(proxyCalls, 1);
+  assert.deepEqual(Object.keys(result), ['SD']);
+});
+
+test('HAPI quota rejection backs off without using the proxy and publishes failure health', async () => {
+  let directCalls = 0;
+  let backoff;
+  let failureMeta;
+  let preserved = 0;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => ({
+      updatedAt: NOW - 10 * HAPI_REFRESH_INTERVAL_MS,
+      requiredCountriesCovered: 23,
+    }),
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    writeFailureMeta: async (value) => { failureMeta = value; },
+    preserveLastGood: async () => { preserved += 1; },
+    proxyUrl: 'https://user:pass@proxy.example:443',
+    proxyRequestFn: async () => assert.fail('quota/identifier 429 must not use the egress proxy'),
+    fetchFn: async () => {
+      directCalls += 1;
+      return new Response(JSON.stringify({ error: 'Too Many Requests' }), { status: 429 });
     },
   });
 
   assert.equal(result, null);
-  assert.equal(calls, 1, 'a blocked bulk request must not fan out into per-country retries');
+  assert.equal(directCalls, 1, 'a quota rejection must not fan out into per-country retries');
   assert.equal(preserved, 1);
   assert.equal(backoff.status, 429);
+  assert.equal(backoff.reasonCode, 'HAPI_RATE_LIMIT');
   assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
+  assert.equal(failureMeta.status, 'error');
+  assert.equal(failureMeta.errorReason, 'HAPI_RATE_LIMIT');
+  assert.equal(failureMeta.lastSuccessAt, NOW - 10 * HAPI_REFRESH_INTERVAL_MS);
+  assert.equal(failureMeta.recordCount, 23);
+});
+
+test('HAPI dual-leg bot block publishes SEED_ERROR metadata before entering backoff', async () => {
+  let failureMeta;
+  let backoff;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    writeFailureMeta: async (value) => { failureMeta = value; },
+    preserveLastGood: async () => {},
+    proxyUrl: 'https://user:pass@proxy.example:443',
+    proxyRequestFn: async () => ({
+      status: 429,
+      buffer: Buffer.from(JSON.stringify({ error: 'Blocked due to bot activity.' })),
+      contentType: 'application/json',
+    }),
+    fetchFn: async () => (
+      new Response(JSON.stringify({ error: 'Blocked due to bot activity.' }), { status: 429 })
+    ),
+  });
+
+  assert.equal(result, null);
+  assert.equal(backoff.reasonCode, 'HAPI_PROXY_FALLBACK_FAILED');
+  assert.equal(failureMeta.status, 'error');
+  assert.equal(failureMeta.errorReason, 'HAPI_PROXY_FALLBACK_FAILED');
+  assert.equal(failureMeta.failedAt, NOW);
+});
+
+test('HAPI proxy response limit failure keeps its operator-actionable reason', async () => {
+  let failureMeta;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD'],
+    pace: async () => {},
+    loadPreviousMarker: async () => null,
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async () => {},
+    writeFailureMeta: async (value) => { failureMeta = value; },
+    preserveLastGood: async () => {},
+    proxyUrl: 'https://user:pass@proxy.example:443',
+    proxyRequestFn: async (_url, _proxyConfig, options) => {
+      assert.equal(options.maxResponseBytes, 16 * 1024 * 1024);
+      return {
+        status: 200,
+        buffer: Buffer.alloc(options.maxResponseBytes + 1),
+        contentType: 'application/json',
+      };
+    },
+    fetchFn: async () => (
+      new Response(JSON.stringify({ error: 'Blocked due to bot activity.' }), { status: 429 })
+    ),
+  });
+
+  assert.equal(result, null);
+  assert.equal(failureMeta.proxyFailureReason, 'RESPONSE_TOO_LARGE');
+});
+
+test('HAPI sticky proxy failure aborts the cycle without publishing a partial aggregate', async () => {
+  const proxyUrls = [];
+  let directCalls = 0;
+  let failureMeta;
+  let backoff;
+  let preserved = 0;
+  const result = await fetchAllHumanitarianSummaries({
+    now: () => NOW,
+    countryCodes: ['SD', 'UA', 'IR'],
+    pace: async () => assert.fail('a terminal proxy failure must stop before pacing another fallback'),
+    loadPreviousMarker: async () => ({
+      updatedAt: NOW - 10 * HAPI_REFRESH_INTERVAL_MS,
+      requiredCountriesCovered: 3,
+    }),
+    loadFailureBackoff: async () => null,
+    writeFailureBackoff: async (value) => { backoff = value; },
+    writeFailureMeta: async (value) => { failureMeta = value; },
+    preserveLastGood: async () => { preserved += 1; },
+    proxyUrl: 'https://user:pass@proxy.example:443',
+    proxyRequestFn: async (url) => {
+      const parsed = new URL(url);
+      proxyUrls.push(parsed);
+      if (proxyUrls.length === 1) {
+        assert.equal(parsed.searchParams.has('location_code'), false);
+        return {
+          status: 200,
+          buffer: Buffer.from(JSON.stringify({
+            data: [{
+              location_code: 'SDN',
+              location_name: 'Sudan',
+              reference_period_start: '2026-07-01',
+              admin_level: 0,
+              event_type: 'political_violence',
+              events: 12,
+              fatalities: 3,
+            }],
+          })),
+          contentType: 'application/json',
+        };
+      }
+      assert.equal(parsed.searchParams.get('location_code'), 'UKR');
+      return {
+        status: 407,
+        buffer: Buffer.from('Proxy Authentication Required'),
+        contentType: 'text/plain',
+      };
+    },
+    fetchFn: async () => {
+      directCalls += 1;
+      return new Response('Blocked due to bot activity.', { status: 429 });
+    },
+  });
+
+  assert.equal(result, null, 'a terminal sticky-proxy failure must discard the partial Sudan result');
+  assert.equal(directCalls, 1, 'only the initial direct bulk request should run');
+  assert.equal(proxyUrls.length, 2, 'the failed Ukraine fallback must stop the Iran proxy attempt');
+  assert.equal(preserved, 1);
+  assert.equal(backoff.status, 407);
+  assert.equal(backoff.reasonCode, 'HAPI_PROXY_FALLBACK_FAILED');
+  assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
+  assert.equal(failureMeta.status, 'error');
+  assert.equal(failureMeta.errorReason, 'HAPI_PROXY_FALLBACK_FAILED');
+  assert.equal(failureMeta.directFailureReason, 'HAPI_BOT_BLOCK');
+  assert.equal(failureMeta.proxyFailureReason, 'PROXY_AUTH_FAILED');
+  assert.equal(failureMeta.lastSuccessAt, NOW - 10 * HAPI_REFRESH_INTERVAL_MS);
+  assert.equal(failureMeta.recordCount, 3);
 });
 
 test('HAPI backoff records the fallback rejection status when the national sweep is empty', async () => {
   let backoff;
+  let failureMeta;
   let preserved = 0;
   const result = await fetchAllHumanitarianSummaries({
     now: () => NOW,
@@ -285,6 +470,7 @@ test('HAPI backoff records the fallback rejection status when the national sweep
     loadPreviousMarker: async () => null,
     loadFailureBackoff: async () => null,
     writeFailureBackoff: async (value) => { backoff = value; },
+    writeFailureMeta: async (value) => { failureMeta = value; },
     preserveLastGood: async () => { preserved += 1; },
     fetchFn: async (url) => {
       const parsed = new URL(url);
@@ -293,13 +479,14 @@ test('HAPI backoff records the fallback rejection status when the national sweep
         return new Response(JSON.stringify({ data: [] }), { status: 200 });
       }
       // Bounded per-country fallback is the one that gets throttled.
-      return new Response(JSON.stringify({ error: 'Blocked due to bot activity.' }), { status: 429 });
+      return new Response(JSON.stringify({ error: 'Too Many Requests' }), { status: 429 });
     },
   });
 
   assert.equal(result, null);
   assert.equal(preserved, 1);
   assert.equal(backoff.status, 429, 'must record the fallback rejection status, not fall back to 0');
+  assert.equal(failureMeta.errorReason, 'HAPI_RATE_LIMIT');
   assert.equal(backoff.retryAt, NOW + HAPI_FAILURE_BACKOFF_MS);
 });
 


### PR DESCRIPTION
## Summary

Humanitarian summaries can now recover when HAPI blocks Railway's direct egress: only the provider's explicit bot-detection 429 switches the current batch to the configured proxy. Ordinary quota/identifier 429 responses still take the existing two-hour backoff path and never use the proxy.

The proxy remains sticky for the rest of a recovered batch, uses the existing 15-second timeout and a 16 MiB response limit, and aborts rather than publishing a partial aggregate if a later proxy request fails. If both routes fail, the seeder preserves last-good rows while publishing `HAPI_PROXY_FALLBACK_FAILED` metadata, so `/api/health` reports `SEED_ERROR` with direct and proxy failure reasons instead of masking the outage as a fresh success.

The branch also hardens crawlable-corpus freshness resolution exposed by the first CI run: depth-1 synthetic merge commits are no longer treated as source edits, preventing false future `lastmod` failures in the full unit gate.

Closes #5713.

## Validation

- Current-head GitHub Actions is fully green, including the built-output unit suite, typecheck, lint, sidecar, Convex, DOM, variant-smoke, security, and Vercel gates.
- Pre-push gate passed after both commits: frontend/API typechecks, Unicode and version checks, plus all 50 change-scoped tests.
- Focused proxy/health suite passed 49/49; the wider conflict-intel suite passed 96/96.
- The shallow-history corpus regression passes 3/3 under the same inherited `GIT_DIR` context used by the pre-push hook.
- Structured review findings covering partial-publication safety, sticky-proxy failure normalization, and response-size coverage were fixed and re-verified.

## Post-Deploy Monitoring & Validation

- **Logs:** watch the Railway `seed-conflict-intel` service for `HAPI direct request hit provider bot detection`, `Humanitarian:`, `HAPI bulk failed`, and `HAPI_PROXY_FALLBACK_FAILED`.
- **Health:** inspect `humanitarianSummary` in `https://www.worldmonitor.app/api/health?compact=1`.
- **Healthy:** after the next eligible HAPI refresh, the batch uses the proxy when direct egress is bot-blocked, publishes at least 23 required-country records, and returns `OK` without fresh HAPI backoff/error metadata.
- **Failure / rollback:** a dual-leg failure must preserve last-good data and surface `SEED_ERROR`; continued stale or partial coverage is the rollback trigger. Revert this PR to restore the prior direct-only behavior while retaining quota backoff.
- **Window / owner:** maintainer/on-call should observe the next eligible seed run and three subsequent 15-minute cron executions, including at least one two-hour HAPI refresh window.

Production acceptance remains pending until the PR is merged, deployed, and an eligible seed run completes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
