### PR TITLE
fix(china): retry transient SZSE proxy failures

### DIFF
--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -74,9 +74,9 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     metadataEndpoint: 'https://www.szse.cn/api/disc/announcement/annList',
     metadataHost: 'www.szse.cn',
     documentHosts: CHINA_DISCLOSURE_DOCUMENT_HOSTS.SZSE,
-    maxRequestsPerRun: 2,
+    maxRequestsPerRun: 3,
     maxDirectRequestsPerRun: 1,
-    maxProxyRequestsPerRun: 1,
+    maxProxyRequestsPerRun: 2,
     fallbackPolicy: 'direct_then_proxy_on_transport_failure',
     // Railway registers PROXY_URL as required config for this service: without
     // it the source still runs direct-only (no hard failure), but it loses
@@ -160,12 +160,22 @@ const MAX_UNCLASSIFIED_REVISIONS = 100;
 const SSE_PAGE_SIZE = 100;
 const SSE_REQUEST_TIMEOUT_MS = 30_000;
 const SZSE_PAGE_SIZE = 50;
-// Worst case (direct attempt times out, then the proxy retry also times out)
-// this source can take up to SZSE_DIRECT_TIMEOUT_MS + SZSE_PROXY_TIMEOUT_MS
-// (~35s) before the bundle moves on. Keep this comfortably inside the
-// per-section timeoutMs configured for it in seed-bundle-market-backup.mjs.
+// Worst case (direct attempt times out, then both proxy attempts time out) this
+// source can take about 39s before the bundle moves on. Keep this comfortably
+// inside the per-section timeoutMs configured in seed-bundle-market-backup.mjs.
 const SZSE_DIRECT_TIMEOUT_MS = 15_000;
-const SZSE_PROXY_TIMEOUT_MS = 20_000;
+const SZSE_PROXY_TIMEOUT_MS = 12_000;
+const SZSE_PROXY_RETRY_DELAY_MS = 250;
+export const CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS = (
+  Math.ceil(
+    OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse.maxRequestsPerRun
+    / OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse.maxConcurrentRequests
+  ) * SSE_REQUEST_TIMEOUT_MS
+  + SZSE_DIRECT_TIMEOUT_MS
+  + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun * SZSE_PROXY_TIMEOUT_MS
+  + (OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun - 1)
+    * SZSE_PROXY_RETRY_DELAY_MS
+);
 const LAUNCHED_SOURCE_FETCHERS = Object.freeze([
   Object.freeze(['sse', fetchSseAnnouncements]),
   Object.freeze(['szse', fetchSzseAnnouncements]),
@@ -439,6 +449,8 @@ function dateWindow(now, days = 90) {
 
 function errorCodeFor(error) {
   if (typeof error?.code === 'string') return error.code;
+  const status = Number(error?.status);
+  if (Number.isInteger(status) && status >= 100 && status <= 599) return `HTTP_${status}`;
   if (error?.name === 'TimeoutError' || error?.name === 'AbortError') return 'TIMEOUT';
   if (/timeout/i.test(String(error?.message))) return 'TIMEOUT';
   return 'FETCH_FAILED';
@@ -451,15 +463,26 @@ function transportFailureReason(error) {
     : errorCodeFor(error);
 }
 
-function shouldProxySzseFailure(error) {
-  const code = errorCodeFor(error);
-  if (code === 'FETCH_FAILED' || code === 'TIMEOUT') return true;
+function isRetryableSzseHttpStatus(code) {
   const status = Number(/^HTTP_(\d{3})$/u.exec(code)?.[1]);
-  return status === 403
-    || status === 408
+  return status === 408
     || status === 425
     || status === 429
     || status >= 500;
+}
+
+function shouldProxySzseFailure(error) {
+  const code = errorCodeFor(error);
+  if (code === 'FETCH_FAILED' || code === 'TIMEOUT') return true;
+  return code === 'HTTP_403' || isRetryableSzseHttpStatus(code);
+}
+
+function shouldRetrySzseProxyFailure(error) {
+  const reason = transportFailureReason(error);
+  return reason === 'FETCH_FAILED'
+    || reason === 'TIMEOUT'
+    || /^(?:ECONNRESET|ETIMEDOUT|EPIPE|EAI_AGAIN|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET)$/u.test(reason)
+    || isRetryableSzseHttpStatus(reason);
 }
 
 async function fetchViaConfiguredProxy(input, init, {
@@ -616,11 +639,27 @@ async function fetchSzseAnnouncements(fetchFn, now, {
   } catch (directError) {
     fallbackReason = transportFailureReason(directError);
     if (!proxyFetchFn || !shouldProxySzseFailure(directError)) throw directError;
-    requestCount += 1;
     transportPath = 'proxy';
-    try {
-      fetched = await request(proxyFetchFn, SZSE_PROXY_TIMEOUT_MS);
-    } catch (proxyError) {
+    let proxyError = null;
+    for (let attempt = 0; attempt < contract.maxProxyRequestsPerRun; attempt += 1) {
+      requestCount += 1;
+      try {
+        fetched = await request(proxyFetchFn, SZSE_PROXY_TIMEOUT_MS);
+        proxyError = null;
+        break;
+      } catch (error) {
+        proxyError = error;
+        if (
+          attempt + 1 < contract.maxProxyRequestsPerRun
+          && shouldRetrySzseProxyFailure(error)
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, SZSE_PROXY_RETRY_DELAY_MS));
+          continue;
+        }
+        break;
+      }
+    }
+    if (proxyError) {
       const failure = sourceError(errorCodeFor(proxyError), proxyError);
       failure.requestCount = requestCount;
       failure.transportPath = transportPath;

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -471,6 +471,23 @@ function isRetryableSzseHttpStatus(code) {
     || status >= 500;
 }
 
+const RETRYABLE_SZSE_PROXY_FAILURE_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ERR_SOCKET_CLOSED',
+  'ERR_STREAM_PREMATURE_CLOSE',
+  'ERR_TLS_HANDSHAKE_TIMEOUT',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
 function shouldProxySzseFailure(error) {
   const code = errorCodeFor(error);
   if (code === 'FETCH_FAILED' || code === 'TIMEOUT') return true;
@@ -481,7 +498,7 @@ function shouldRetrySzseProxyFailure(error) {
   const reason = transportFailureReason(error);
   return reason === 'FETCH_FAILED'
     || reason === 'TIMEOUT'
-    || /^(?:ECONNRESET|ETIMEDOUT|EPIPE|EAI_AGAIN|UND_ERR_CONNECT_TIMEOUT|UND_ERR_SOCKET)$/u.test(reason)
+    || RETRYABLE_SZSE_PROXY_FAILURE_CODES.has(reason)
     || isRetryableSzseHttpStatus(reason);
 }
 

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -852,6 +852,11 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun, 1);
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun, 2);
     assert.equal(
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun,
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun
+        + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun,
+    );
+    assert.equal(
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.fallbackPolicy,
       'direct_then_proxy_on_transport_failure',
     );
@@ -870,8 +875,24 @@ describe('official China corporate disclosures (#5577)', () => {
   });
 
   it('retries one transient proxy transport failure before degrading SZSE coverage', async () => {
+    const transientProxyErrorCodes = [
+      'EAI_AGAIN',
+      'ECONNABORTED',
+      'ECONNREFUSED',
+      'ECONNRESET',
+      'EHOSTUNREACH',
+      'ENETUNREACH',
+      'ENOTFOUND',
+      'EPIPE',
+      'ERR_SOCKET_CLOSED',
+      'ERR_STREAM_PREMATURE_CLOSE',
+      'ERR_TLS_HANDSHAKE_TIMEOUT',
+      'ETIMEDOUT',
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_SOCKET',
+    ];
     const transientProxyErrors = [
-      Object.assign(new Error('proxy tunnel reset'), { code: 'ECONNRESET' }),
+      ...transientProxyErrorCodes.map((code) => Object.assign(new Error(code), { code })),
       Object.assign(new Error('Proxy CONNECT: HTTP/1.1 502 Bad Gateway'), { status: 502 }),
       new Error('CONNECT tunnel timeout'),
       new TypeError('fetch failed'),

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 
 import { validateDecisionSignalProvenance } from '../shared/decision-signal-provenance';
 import {
+  CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS,
   CHINA_CORPORATE_DISCLOSURE_KEY,
   DISCLOSURE_TYPES,
   EMPTY_RESULT_DEGRADE_AFTER,
@@ -78,6 +79,23 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(hkex.admissionDecision, 'rejected');
     assert.equal(hkex.blockedReason, 'TERMS_PROHIBIT_AUTOMATED_ACCESS');
     assert.match(hkex.termsUrl, /^https:/);
+  });
+
+  it('keeps the worst-case network budget below the Railway section timeout', () => {
+    const bundleSource = readFileSync(
+      resolve(import.meta.dirname, '../scripts/seed-bundle-market-backup.mjs'),
+      'utf8',
+    );
+    const timeoutMatch = /label:\s*'China-Corporate-Disclosures'[^\n]*timeoutMs:\s*([\d_]+)/u
+      .exec(bundleSource);
+    assert.ok(timeoutMatch, 'China disclosure bundle section must declare timeoutMs');
+    const sectionTimeoutMs = Number(timeoutMatch[1].replaceAll('_', ''));
+
+    assert.equal(CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS, 99_250);
+    assert.ok(
+      sectionTimeoutMs - CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS >= 20_000,
+      'network attempts must leave at least 20s for startup, parsing, publication, and shutdown',
+    );
   });
 
   it('classifies the seven owned categories without collision inflation', () => {
@@ -749,7 +767,7 @@ describe('official China corporate disclosures (#5577)', () => {
     );
   });
 
-  it('falls back to one bounded proxy request when the direct SZSE transport fails', async () => {
+  it('falls back to a bounded proxy request when the direct SZSE transport fails', async () => {
     const directCalls: Array<{ url: string; init?: RequestInit }> = [];
     const proxyCalls: Array<{
       url: string;
@@ -830,9 +848,9 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(szse?.requestCount, 2);
     assert.equal(szse?.transportPath, 'proxy');
     assert.equal(szse?.fallbackReason, 'UND_ERR_CONNECT_TIMEOUT');
-    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 2);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 3);
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun, 1);
-    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun, 1);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun, 2);
     assert.equal(
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.fallbackPolicy,
       'direct_then_proxy_on_transport_failure',
@@ -849,6 +867,107 @@ describe('official China corporate disclosures (#5577)', () => {
       checkedAt: retrievedAt,
     });
     assert.doesNotMatch(JSON.stringify(decisions), /proxy-user|proxy-secret/);
+  });
+
+  it('retries one transient proxy transport failure before degrading SZSE coverage', async () => {
+    const transientProxyErrors = [
+      Object.assign(new Error('proxy tunnel reset'), { code: 'ECONNRESET' }),
+      Object.assign(new Error('Proxy CONNECT: HTTP/1.1 502 Bad Gateway'), { status: 502 }),
+      new Error('CONNECT tunnel timeout'),
+      new TypeError('fetch failed'),
+    ];
+
+    for (const transientProxyError of transientProxyErrors) {
+      let proxyCalls = 0;
+      const decisions: Array<Record<string, unknown>> = [];
+      const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+        onDecision: (decision) => decisions.push(decision),
+        fetchFn: async (input) => {
+          const url = String(input);
+          if (url.includes('query.sse.com.cn')) {
+            return new Response(JSON.stringify({
+              pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+              result: [],
+            }), { status: 200 });
+          }
+          throw Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+          });
+        },
+        proxyRequestFn: async () => {
+          proxyCalls += 1;
+          if (proxyCalls === 1) throw transientProxyError;
+          return {
+            buffer: Buffer.from(JSON.stringify(fixture('szse.json'))),
+            status: 200,
+            contentType: 'application/json',
+          };
+        },
+      });
+
+      const szse = snapshot.sources.find((source) => source.id === 'szse');
+      assert.equal(snapshot.status, 'healthy');
+      assert.equal(proxyCalls, 2);
+      assert.equal(szse?.transportStatus, 'fresh');
+      assert.equal(szse?.contentStatus, 'current');
+      assert.equal(szse?.requestCount, 3);
+      assert.equal(szse?.transportPath, 'proxy');
+      assert.equal(szse?.fallbackReason, 'ETIMEDOUT');
+      assert.deepEqual(
+        decisions.find((decision) => decision.sourceId === 'szse'),
+        {
+          sourceId: 'szse',
+          status: 'accepted',
+          requestCount: 3,
+          emptyResultCount: 0,
+          transportPath: 'proxy',
+          fallbackReason: 'ETIMEDOUT',
+          checkedAt: retrievedAt,
+        },
+      );
+    }
+  });
+
+  it('does not retry a non-transport SZSE proxy rejection', async () => {
+    let proxyCalls = 0;
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      onDecision: () => {},
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+        });
+      },
+      proxyRequestFn: async () => {
+        proxyCalls += 1;
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required'),
+          { status: 407 },
+        );
+      },
+    });
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal(snapshot.status, 'degraded');
+    assert.equal(proxyCalls, 1);
+    assert.equal(szse?.transportStatus, 'error');
+    assert.equal(szse?.requestCount, 2);
+    assert.equal(szse?.transportPath, 'proxy');
+    assert.equal(szse?.fallbackReason, 'ETIMEDOUT');
+    assert.equal(szse?.proxyFailureReason, 'HTTP_407');
+    assert.equal(szse?.errorCode, 'HTTP_407');
   });
 
   it('keeps last-good SZSE data and records both transport failures when the proxy also fails', async () => {
@@ -868,6 +987,7 @@ describe('official China corporate disclosures (#5577)', () => {
       },
     });
     const decisions: Array<Record<string, unknown>> = [];
+    let proxyCalls = 0;
 
     const degraded = await fetchChinaCorporateDisclosureSnapshot({
       now: Date.parse('2026-07-25T11:00:00.000Z'),
@@ -887,6 +1007,7 @@ describe('official China corporate disclosures (#5577)', () => {
         });
       },
       proxyRequestFn: async () => {
+        proxyCalls += 1;
         throw Object.assign(new TypeError('fetch failed'), {
           cause: Object.assign(new Error('proxy DNS failed'), { code: 'EAI_AGAIN' }),
         });
@@ -898,12 +1019,19 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(szse?.transportStatus, 'error');
     assert.equal(szse?.contentStatus, 'stale');
     assert.equal(szse?.lastSuccessAt, retrievedAt);
-    assert.equal(szse?.requestCount, 2);
+    assert.equal(proxyCalls, 2);
+    assert.equal(szse?.requestCount, 3);
     assert.equal(szse?.transportPath, 'proxy');
     assert.equal(szse?.fallbackReason, 'ECONNRESET');
     assert.equal(szse?.proxyFailureReason, 'EAI_AGAIN');
     assert.equal(szse?.errorCode, 'FETCH_FAILED');
-    assert.equal(degraded.events.some((event) => event.exchange === 'SZSE'), true);
+    const withoutProvenance = (events: typeof healthy.events) => JSON.parse(
+      JSON.stringify(events, (key, value) => (key === 'provenance' ? undefined : value)),
+    );
+    assert.deepEqual(
+      withoutProvenance(degraded.events.filter((event) => event.exchange === 'SZSE')),
+      withoutProvenance(healthy.events.filter((event) => event.exchange === 'SZSE')),
+    );
     assert.doesNotMatch(JSON.stringify(decisions), /proxy-user|proxy-secret/);
   });
 


### PR DESCRIPTION
## Summary

- retry one transient SZSE proxy transport failure after the direct leg fails
- cover common Node, Undici, DNS, socket, and TLS transient failure codes
- fail fast on permanent proxy errors while preserving direct and proxy failure provenance
- pin the 99.25s worst-case network budget beneath the Railway section timeout
- keep request-cap accounting explicit: total requests equal direct plus proxy requests

Related: #5693

## Production evidence

- Production health is still CHINA_DEGRADED, with corporate disclosures reporting CHINA_COVERAGE_PARTIAL until this change is deployed and a seed run succeeds.
- The deployed Railway seed-bundle-market-backup job accepted SSE data, then exhausted the direct SZSE request and its only proxy attempt, leaving 0 classified events and 14 unclassified rows.
- A forced direct timeout reproduced an initial proxy ECONNRESET; three identical follow-up proxy requests succeeded, supporting one bounded retry rather than a proxy bypass.

## Scope split

The unrelated shallow-Git regression-fixture hardening was removed from this PR and merged separately through #5732. Current main contains both that fixture isolation and the runtime shallow-history guard.

## Validation

- focused China corporate-disclosure suite: 18/18 passed
- transient retry table covers 14 explicit transport codes plus retryable HTTP, timeout, and uncoded fetch failures
- frontend typecheck passed
- API typecheck and Convex string-call audit passed
- pre-push changed-test, Unicode, version-sync, and scoped repository gates passed against current main
- exact head: c8e4b90b2ec69c36dc923f2ebb8f536606226210

## Post-deploy acceptance

After merge and deployment, confirm the next 30-minute Railway seed run publishes classified SZSE events, corporate disclosure coverage returns healthy, and the retained last-good fallback remains available if the source regresses.