### PR TITLE
fix: gitignore docker-compose.override.yml and secrets/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,9 @@ e2e
 src-tauri/target
 src-tauri/sidecar/node
 *.log
+# Local self-hosting credentials must not enter Docker build contexts or caches.
+docker-compose.override.yml
+secrets/
 *.md
 !README.md
 !CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ public/crawlable-corpus.json
 *.log
 .env
 .env.local
+# Self-hosting secrets (SELF_HOSTING.md). Both of these are places the docs
+# tell operators to put real API keys, so neither should ever be stageable:
+#   - docker-compose.override.yml holds WORLDMONITOR_VALID_KEYS and the
+#     upstream provider keys; SELF_HOSTING.md already states it is gitignored.
+#   - secrets/ is the Docker-secrets layout documented in docker-compose.yml,
+#     which instructs `echo "gsk_abc123" > secrets/groq_api_key.txt`.
+docker-compose.override.yml
+secrets/
 .playwright-mcp/
 *-network.txt
 .vercel

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -244,6 +244,19 @@ describe('crawlable content corpus deployment contracts', () => {
     assert.ok(changelogInclude > markdownIgnore, 'CHANGELOG.md must be re-included after *.md for Docker corpus builds');
   });
 
+  it('keeps local self-hosting credentials out of Docker build contexts', () => {
+    const ignoreRules = new Set(
+      dockerignoreSource
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#'))
+    );
+
+    for (const path of ['docker-compose.override.yml', 'secrets/']) {
+      assert.ok(ignoreRules.has(path), `${path} must never enter Docker build contexts or caches`);
+    }
+  });
+
   it('keeps generated corpus prefixes out of the SPA catch-all while preserving normal app deep links', () => {
     const catchAll = getSpaCatchAllRewrite();
     assert.ok(catchAll, 'expected the SPA catch-all rewrite');


### PR DESCRIPTION
Two files the self-hosting docs tell operators to put **real API keys** into are
not gitignored, so a `git add -A` in a self-hosted checkout stages them. Forks of
this repo are public, which is where that bites.

### `docker-compose.override.yml`

`SELF_HOSTING.md` already tells operators this file is safe:

> Create a `docker-compose.override.yml` to inject your keys. This file is
> **gitignored** — your secrets stay local.

Only `.env` is actually covered. The file holds `WORLDMONITOR_VALID_KEYS` plus
whatever provider keys the operator adds — `GROQ_API_KEY`, `FRED_API_KEY`,
`FINNHUB_API_KEY`, `ACLED_EMAIL`/`ACLED_PASSWORD`, and so on. So this change
makes the documentation true rather than changing the advice.

### `secrets/`

Same gap, sharper edge — `docker-compose.yml` documents the Docker-secrets
layout as:

```
# Example: echo "gsk_abc123" > secrets/groq_api_key.txt
```

A raw key written to an unignored path, on the instruction of a comment in the
repo.

### Verification

On `main` before the change:

```
$ git check-ignore -v docker-compose.override.yml
(no output — not ignored)
$ git check-ignore -v secrets/groq_api_key.txt
(no output — not ignored)
```

After:

```
.gitignore:19:docker-compose.override.yml   docker-compose.override.yml
.gitignore:20:secrets/                      secrets/groq_api_key.txt
```

Placed adjacent to the existing `.env` rules so the "parent `.env` / secrets
ignore rules stay in effect" note further down the file keeps its meaning.

### Context

Found while self-hosting the stack as a data provider for a personal project.
Nothing leaked — I caught it before committing and patched locally via
`.git/info/exclude`, but that fix doesn't survive a fresh clone, which is why
it seemed worth sending upstream.

Unrelated and lower priority, so not included here: the `worldmonitor` service
publishes `${WM_PORT:-3000}:8080`, which binds all interfaces, while
`redis-rest` is correctly scoped to `127.0.0.1`. Defaulting the app to loopback
too would match it. Happy to open a separate PR if you'd want that.