### PR TITLE
feat(forecast): geopolitical bet family — long-horizon market slice

### DIFF
--- a/scripts/_bet-templates-markets-classify.mjs
+++ b/scripts/_bet-templates-markets-classify.mjs
@@ -18,7 +18,25 @@
 // Unambiguous conflict / statecraft vocabulary. Word-boundaried so "war" does
 // not fire on "warrant"/"forward" and "strike" is only matched in explicit
 // military compounds, never alone (no "strike price" false positive).
-const GEO_TERMS = /\b(?:cease-?fire|armistice|truce|coup(?:\sd'[ée]tat)?|uranium|enrich(?:ed|ment)|nuclear|sanctions?|invade|invasion|annex(?:ation|ed|es)?|air\s?strikes?|drone\sstrikes?|missile\sstrikes?|strikes?\son|missiles?|ballistic|warheads?|war|wartime|warfare|regime\schange|leadership\schange|hostages?|prisoner\s(?:swap|exchange)|prisoners\sof\swar|nato|occupation|martial\slaw|troops|referendum|secede|secession|assassinat(?:e|ed|ion)|territorial|border\s(?:clash|dispute)|blockade|genocide|ethnic\scleansing|militants?|insurgen(?:t|cy|ts)|militias?)\b/i;
+const GEO_TERMS = /\b(?:cease-?fire|armistice|truce|coup(?:\sd'[ée]tat)?|uranium|enrich(?:ed|ment)|sanctions?|invade|invasion|annex(?:ation|ed|es)?|air\s?strikes?|drone\sstrikes?|missile\sstrikes?|strikes?\son|missiles?|ballistic|warheads?|war|wartime|warfare|regime\schange|leadership\schange|hostages?|prisoner\s(?:swap|exchange)|prisoners\sof\swar|nato|occupation|martial\slaw|troops|referendum|secede|secession|assassinat(?:e|ed|ion)|territorial|border\s(?:clash|dispute)|blockade|genocide|ethnic\scleansing|militants?|insurgen(?:t|cy|ts)|militias?)\b/i;
+
+// "nuclear" is only geopolitical in a weapon/statecraft context — bare
+// "nuclear" would falsely tag nuclear-ENERGY company/reactor/SMR markets (a
+// real prediction-market category). Require a conflict/diplomacy qualifier;
+// "energy"/"power"/"reactor" deliberately fall through as NON-geo.
+const GEO_NUCLEAR = /\bnuclear\s(?:weapons?|warheads?|tests?|strikes?|deal|program(?:me)?|talks|enrichment|arsenal|threat|attack|bomb|war|escalation|facilit(?:y|ies)|site)\b/i;
+
+// National / legislative elections and control-of-chamber markets — core
+// geopolitical events. QUALIFIED so corporate "board election", "union
+// election", or "Hall of Fame election" never match (bare "election" is not
+// matched on its own).
+const GEO_ELECTIONS = /\b(?:(?:presidential|parliamentary|general|snap|midterm|legislative|congressional|senate|gubernatorial|federal|national|primary)\selections?|midterms?|runoff|presidenc(?:y|ies)|control\sof\s(?:the\s)?(?:senate|house|congress|parliament|bundestag|knesset|duma))\b/i;
+
+// National head-of-state / head-of-government markets — core geopolitics.
+// "prime minister" and "potus" are unambiguously national; "president" is
+// matched ONLY with a country qualifier so corporate "President of <company>"
+// or "Vice President" never fire.
+const GEO_LEADERSHIP = /\b(?:prime\sminister|potus|president\sof\s(?:the\s)?(?:united\sstates|u\.?s\.?a?|france|russia|iran|brazil|mexico|venezuela|turkey|t[üu]rkiye|egypt|ukraine|poland|argentina|colombia|philippines|south\skorea|the\seu)|next\s(?:president|prime\sminister|chancellor|premier|supreme\sleader))\b/i;
 
 // High-salience geopolitical actors and conflict placenames that are
 // effectively never the subject of a company/crypto/finance market. Excludes
@@ -30,5 +48,9 @@ const GEO_ENTITIES = /\b(?:ukraine|ukrainian|gaza|crimea|donbas|donbass|kashmir|
 export function isGeopoliticalMarket(title) {
   const text = String(title ?? '');
   if (!text.trim()) return false;
-  return GEO_TERMS.test(text) || GEO_ENTITIES.test(text);
+  return GEO_TERMS.test(text)
+    || GEO_NUCLEAR.test(text)
+    || GEO_ELECTIONS.test(text)
+    || GEO_LEADERSHIP.test(text)
+    || GEO_ENTITIES.test(text);
 }

--- a/scripts/_bet-templates-markets-classify.mjs
+++ b/scripts/_bet-templates-markets-classify.mjs
@@ -14,11 +14,21 @@
 // high-salience actors — never on bare country names ("Chinese AI model" is
 // tech, "Korea" alone is ambiguous) and never on bare "election"/"strike"
 // (company boards hold elections; options have strike prices).
+//
+// Weak terms (war, sanctions, uranium, occupation, leadership change) only
+// fire with a high-salience actor/placename co-occurrence so corporate "price
+// war", "uranium miner IPO", labor "occupation", and "CEO leadership change"
+// stay non-geo.
 
 // Unambiguous conflict / statecraft vocabulary. Word-boundaried so "war" does
-// not fire on "warrant"/"forward" and "strike" is only matched in explicit
+// not fire alone (see GEO_WEAK) and "strike" is only matched in explicit
 // military compounds, never alone (no "strike price" false positive).
-const GEO_TERMS = /\b(?:cease-?fire|armistice|truce|coup(?:\sd'[ée]tat)?|uranium|enrich(?:ed|ment)|sanctions?|invade|invasion|annex(?:ation|ed|es)?|air\s?strikes?|drone\sstrikes?|missile\sstrikes?|strikes?\son|missiles?|ballistic|warheads?|war|wartime|warfare|regime\schange|leadership\schange|hostages?|prisoner\s(?:swap|exchange)|prisoners\sof\swar|nato|occupation|martial\slaw|troops|referendum|secede|secession|assassinat(?:e|ed|ion)|territorial|border\s(?:clash|dispute)|blockade|genocide|ethnic\scleansing|militants?|insurgen(?:t|cy|ts)|militias?)\b/i;
+const GEO_STRONG = /\b(?:cease-?fire|armistice|truce|coup(?:\sd'[ée]tat)?|enrich(?:ed|ment)|invade|invasion|annex(?:ation|ed|es)?|air\s?strikes?|drone\sstrikes?|missile\sstrikes?|strikes?\son|missiles?|ballistic|warheads?|regime\schange|hostages?|prisoner\s(?:swap|exchange)|prisoners\sof\swar|nato|martial\slaw|troops|referendum|secede|secession|assassinat(?:e|ed|ion)|territorial|border\s(?:clash|dispute)|blockade|genocide|ethnic\scleansing|militants?|insurgen(?:t|cy|ts)|militias?)\b/i;
+
+// Weak terms: real geo signal only with a high-salience actor/placename.
+// Bare "war"/"sanctions"/"uranium"/"occupation"/"leadership change" alone
+// match finance, commodity, labor, and corporate titles.
+const GEO_WEAK = /\b(?:uranium|sanctions?|war|wartime|warfare|occupation|leadership\schange)\b/i;
 
 // "nuclear" is only geopolitical in a weapon/statecraft context — bare
 // "nuclear" would falsely tag nuclear-ENERGY company/reactor/SMR markets (a
@@ -32,25 +42,47 @@ const GEO_NUCLEAR = /\bnuclear\s(?:weapons?|warheads?|tests?|strikes?|deal|progr
 // matched on its own).
 const GEO_ELECTIONS = /\b(?:(?:presidential|parliamentary|general|snap|midterm|legislative|congressional|senate|gubernatorial|federal|national|primary)\selections?|midterms?|runoff|presidenc(?:y|ies)|control\sof\s(?:the\s)?(?:senate|house|congress|parliament|bundestag|knesset|duma))\b/i;
 
+// Country list shared by "president of X" and "next president of X" so corporate
+// "President of Acme" / "next president of OpenAI" never fire.
+const PRESIDENT_COUNTRIES = '(?:united\\sstates|u\\.?s\\.?a?|france|russia|iran|brazil|mexico|venezuela|turkey|t[üu]rkiye|egypt|ukraine|poland|argentina|colombia|philippines|south\\skorea|the\\seu)';
+
 // National head-of-state / head-of-government markets — core geopolitics.
-// "prime minister" and "potus" are unambiguously national; "president" is
-// matched ONLY with a country qualifier so corporate "President of <company>"
-// or "Vice President" never fire.
-const GEO_LEADERSHIP = /\b(?:prime\sminister|potus|president\sof\s(?:the\s)?(?:united\sstates|u\.?s\.?a?|france|russia|iran|brazil|mexico|venezuela|turkey|t[üu]rkiye|egypt|ukraine|poland|argentina|colombia|philippines|south\skorea|the\seu)|next\s(?:president|prime\sminister|chancellor|premier|supreme\sleader))\b/i;
+// "prime minister" and "potus" are unambiguously national; "president" and
+// "next president" require a country qualifier. "next prime minister" /
+// chancellor / premier / supreme leader stay national without "of <country>"
+// because those titles are not used for corporate roles.
+const GEO_LEADERSHIP = new RegExp(
+  String.raw`\b(?:prime\sminister|potus|president\sof\s(?:the\s)?${PRESIDENT_COUNTRIES}|next\spresident\sof\s(?:the\s)?${PRESIDENT_COUNTRIES}|next\s(?:prime\sminister|chancellor|premier|supreme\sleader))\b`,
+  'i',
+);
 
 // High-salience geopolitical actors and conflict placenames that are
-// effectively never the subject of a company/crypto/finance market. Excludes
-// ambiguous names that double as companies (Taiwan→TSMC) or broad regions
-// (China, Korea) — those only qualify via a GEO_TERMS co-occurrence.
+// effectively never the subject of a company/crypto/finance market on their
+// own. Excludes ambiguous names that double as companies (Taiwan→TSMC) or
+// broad regions/countries that appear in pure equity/macro titles (China,
+// Korea, Iran-as-stock, Russia-as-ETF) — those only qualify via a strong
+// term or as co-occurrence for GEO_WEAK below.
 const GEO_ENTITIES = /\b(?:ukraine|ukrainian|gaza|crimea|donbas|donbass|kashmir|west\sbank|hezbollah|hamas|houthis?|taliban|wagner|putin|khamenei|kim\sjong|zelensky+|netanyahu|isis|islamic\sstate)\b/i;
+
+// Broader actor/placename set used ONLY as the co-occurrence gate for weak
+// terms (war/sanctions/uranium/occupation/leadership change). Not a standalone
+// geo signal — "Russia stock market" must stay non-geo, but "Russia sanctions"
+// and "Iran leadership change" must fire.
+const GEO_WEAK_ACTORS = /\b(?:iran|iranian|ukraine|ukrainian|russia|russian|israel|israeli|gaza|crimea|donbas|donbass|kashmir|west\sbank|hezbollah|hamas|houthis?|taliban|wagner|putin|khamenei|kim\sjong|zelensky+|netanyahu|isis|islamic\sstate|venezuela|venezuelan|north\skorea|dprk|syria|syrian|nato)\b/i;
 
 // True iff the market title reads as geopolitical. Pure; no imports.
 export function isGeopoliticalMarket(title) {
   const text = String(title ?? '');
   if (!text.trim()) return false;
-  return GEO_TERMS.test(text)
+  if (
+    GEO_STRONG.test(text)
     || GEO_NUCLEAR.test(text)
     || GEO_ELECTIONS.test(text)
     || GEO_LEADERSHIP.test(text)
-    || GEO_ENTITIES.test(text);
+    || GEO_ENTITIES.test(text)
+  ) {
+    return true;
+  }
+  // Weak terms only with a high-salience actor/placename co-occurrence.
+  return GEO_WEAK.test(text) && GEO_WEAK_ACTORS.test(text);
 }

--- a/scripts/_bet-templates-markets-classify.mjs
+++ b/scripts/_bet-templates-markets-classify.mjs
@@ -1,0 +1,34 @@
+// Geopolitical classification for prediction-market titles (Phase 2 / #5525,
+// #5733). WorldMonitor's identity is geopolitical intelligence, so the market
+// bet-family is split into a dedicated geopolitical slice (long horizon, top
+// ensemble priority) and a general slice — and the split is driven by the
+// market TEXT, deliberately NOT by the bootstrap feed's geopolitical/tech/
+// finance pools. Those pools are unreliable: the same market appears in all
+// three and the "geopolitical" pool is dominated by crypto/finance titles
+// (#5733). Classifying from the title keeps this robust to the broken producer
+// labels.
+//
+// Precision over recall: a FALSE geopolitical tag pollutes the flagship slice
+// (a company/crypto market stealing a geo ensemble slot), which is worse than a
+// missed one, so the matcher keys on unambiguous conflict/statecraft terms and
+// high-salience actors — never on bare country names ("Chinese AI model" is
+// tech, "Korea" alone is ambiguous) and never on bare "election"/"strike"
+// (company boards hold elections; options have strike prices).
+
+// Unambiguous conflict / statecraft vocabulary. Word-boundaried so "war" does
+// not fire on "warrant"/"forward" and "strike" is only matched in explicit
+// military compounds, never alone (no "strike price" false positive).
+const GEO_TERMS = /\b(?:cease-?fire|armistice|truce|coup(?:\sd'[ée]tat)?|uranium|enrich(?:ed|ment)|nuclear|sanctions?|invade|invasion|annex(?:ation|ed|es)?|air\s?strikes?|drone\sstrikes?|missile\sstrikes?|strikes?\son|missiles?|ballistic|warheads?|war|wartime|warfare|regime\schange|leadership\schange|hostages?|prisoner\s(?:swap|exchange)|prisoners\sof\swar|nato|occupation|martial\slaw|troops|referendum|secede|secession|assassinat(?:e|ed|ion)|territorial|border\s(?:clash|dispute)|blockade|genocide|ethnic\scleansing|militants?|insurgen(?:t|cy|ts)|militias?)\b/i;
+
+// High-salience geopolitical actors and conflict placenames that are
+// effectively never the subject of a company/crypto/finance market. Excludes
+// ambiguous names that double as companies (Taiwan→TSMC) or broad regions
+// (China, Korea) — those only qualify via a GEO_TERMS co-occurrence.
+const GEO_ENTITIES = /\b(?:ukraine|ukrainian|gaza|crimea|donbas|donbass|kashmir|west\sbank|hezbollah|hamas|houthis?|taliban|wagner|putin|khamenei|kim\sjong|zelensky+|netanyahu|isis|islamic\sstate)\b/i;
+
+// True iff the market title reads as geopolitical. Pure; no imports.
+export function isGeopoliticalMarket(title) {
+  const text = String(title ?? '');
+  if (!text.trim()) return false;
+  return GEO_TERMS.test(text) || GEO_ENTITIES.test(text);
+}

--- a/scripts/_bet-templates-markets-geo.mjs
+++ b/scripts/_bet-templates-markets-geo.mjs
@@ -21,7 +21,7 @@
 // (crosses/yesPrice against prediction:markets-resolution:v1, slug-keyed), so
 // the resolver's updateMarketSettlements loader tracks these with no change.
 
-import { MARKET_FEED, MARKET_SETTLEMENT_FEED, MARKET_MIN_VOLUME, marketSlugFromUrl } from './_bet-templates-markets.mjs';
+import { MARKET_FEED, MARKET_SETTLEMENT_FEED, parseMarketRecord } from './_bet-templates-markets.mjs';
 import { isGeopoliticalMarket } from './_bet-templates-markets-classify.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -34,28 +34,21 @@ const MAX_HORIZON_MS = 210 * DAY_MS;
 // Dedicated geo slate size — as much room as the general family.
 export const MARKET_GEO_SLOT_COUNT = 6;
 
-// Eligible GEOPOLITICAL markets, volume-sorted, deduped by slug. Pure. Mirrors
-// eligibleMarkets but scoped to geopolitical titles on the long horizon.
+// Eligible GEOPOLITICAL markets, volume-sorted, deduped by slug. Pure. Shares
+// parseMarketRecord with the general family (identical record/liquidity gates,
+// no drift) and differs only in the geo predicate and the long horizon.
 export function eligibleGeoMarkets(feed, nowMs) {
   const pools = [feed?.geopolitical, feed?.tech, feed?.finance].filter(Array.isArray);
   const seen = new Set();
   const out = [];
   for (const record of pools.flat()) {
-    if (!record || typeof record !== 'object') continue;
-    const title = String(record.title || '').trim();
-    if (!title || !isGeopoliticalMarket(title)) continue;
-    const yesPrice = Number(record.yesPrice);
-    const volume = Number(record.volume);
-    const endDateMs = Date.parse(record.endDate ?? '');
-    const slugInfo = marketSlugFromUrl(record.url);
-    if (!slugInfo) continue;
-    if (!Number.isFinite(yesPrice)) continue;
-    if (!Number.isFinite(volume) || volume < MARKET_MIN_VOLUME) continue;
-    if (!Number.isFinite(endDateMs)) continue;
-    if (endDateMs < nowMs + MIN_LEAD_MS || endDateMs > nowMs + MAX_HORIZON_MS) continue;
-    if (seen.has(slugInfo.slug)) continue;
-    seen.add(slugInfo.slug);
-    out.push({ title, yesPrice, volume, endDateMs, ...slugInfo });
+    const market = parseMarketRecord(record);
+    if (!market) continue;
+    if (!isGeopoliticalMarket(market.title)) continue;
+    if (market.endDateMs < nowMs + MIN_LEAD_MS || market.endDateMs > nowMs + MAX_HORIZON_MS) continue;
+    if (seen.has(market.slug)) continue;
+    seen.add(market.slug);
+    out.push(market);
   }
   return out.sort((a, b) => b.volume - a.volume);
 }

--- a/scripts/_bet-templates-markets-geo.mjs
+++ b/scripts/_bet-templates-markets-geo.mjs
@@ -1,0 +1,142 @@
+// Geopolitical prediction-market bet templates (Phase 2 / #5525, #5733 — the
+// flagship geopolitical calibration slice).
+//
+// WHY A SEPARATE FAMILY. The general market family (_bet-templates-markets.mjs)
+// caps the horizon at 45 days so bets resolve fast and feed Gate-2 quickly. But
+// the liquid GEOPOLITICAL prediction markets — Iran enriched-uranium ($28M),
+// Iran leadership change ($21M), coup/ceasefire lines — almost all resolve on
+// multi-month horizons (Dec-31 and beyond). A 45-day cap therefore excludes
+// exactly the domain WorldMonitor is a reference in, leaving geo coverage to
+// the luck of a rare short-dated line. This family lifts the horizon to 210
+// days so the persistent geo bench is captured, and ranks it ABOVE every other
+// family (userValueScore 0.9) so its bets win the top-K ensemble slots.
+//
+// PARTITION. Identity is the venue slug (same settlement path as the general
+// family, KTD2). To avoid double-betting a market, the split is exhaustive and
+// disjoint: this family owns every geopolitical market (per isGeopoliticalMarket)
+// across the 2-210d window; the general family excludes them. Disjoint slug
+// sets mean the `market:<slug>` id namespace never collides.
+//
+// The resolution/settlement contract is byte-identical to the general family
+// (crosses/yesPrice against prediction:markets-resolution:v1, slug-keyed), so
+// the resolver's updateMarketSettlements loader tracks these with no change.
+
+import { MARKET_FEED, MARKET_SETTLEMENT_FEED, MARKET_MIN_VOLUME, marketSlugFromUrl } from './_bet-templates-markets.mjs';
+import { isGeopoliticalMarket } from './_bet-templates-markets-classify.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MIN_LEAD_MS = 2 * DAY_MS;
+// Long horizon: the geo bench clusters at Dec-31 (~156d out) and into Q1 of the
+// next year. 210 days captures that cluster while still excluding multi-year
+// lottery lines (2028+/2040/2099 markets in the feed) whose prices carry no
+// forecastable near-term signal.
+const MAX_HORIZON_MS = 210 * DAY_MS;
+// Dedicated geo slate size — as much room as the general family.
+export const MARKET_GEO_SLOT_COUNT = 6;
+
+// Eligible GEOPOLITICAL markets, volume-sorted, deduped by slug. Pure. Mirrors
+// eligibleMarkets but scoped to geopolitical titles on the long horizon.
+export function eligibleGeoMarkets(feed, nowMs) {
+  const pools = [feed?.geopolitical, feed?.tech, feed?.finance].filter(Array.isArray);
+  const seen = new Set();
+  const out = [];
+  for (const record of pools.flat()) {
+    if (!record || typeof record !== 'object') continue;
+    const title = String(record.title || '').trim();
+    if (!title || !isGeopoliticalMarket(title)) continue;
+    const yesPrice = Number(record.yesPrice);
+    const volume = Number(record.volume);
+    const endDateMs = Date.parse(record.endDate ?? '');
+    const slugInfo = marketSlugFromUrl(record.url);
+    if (!slugInfo) continue;
+    if (!Number.isFinite(yesPrice)) continue;
+    if (!Number.isFinite(volume) || volume < MARKET_MIN_VOLUME) continue;
+    if (!Number.isFinite(endDateMs)) continue;
+    if (endDateMs < nowMs + MIN_LEAD_MS || endDateMs > nowMs + MAX_HORIZON_MS) continue;
+    if (seen.has(slugInfo.slug)) continue;
+    seen.add(slugInfo.slug);
+    out.push({ title, yesPrice, volume, endDateMs, ...slugInfo });
+  }
+  return out.sort((a, b) => b.volume - a.volume);
+}
+
+function buildSlotTemplate(slot) {
+  return {
+    id: `market-geo:slot${slot}`,
+    feedKey: MARKET_FEED,
+    domain: 'geopolitical',
+
+    extractMetric(feed, ctx = {}) {
+      const nowMs = Number(feed?.fetchedAt) || Number(ctx.nowMs);
+      if (!Number.isFinite(nowMs)) return null;
+      const market = eligibleGeoMarkets(feed, nowMs)[slot];
+      if (!market) return null;
+      return {
+        subject: market.title,
+        value: market.yesPrice,
+        endDateMs: market.endDateMs,
+        slug: market.slug,
+        source: market.source,
+        volume: market.volume,
+      };
+    },
+
+    horizonPolicy({ metric }) {
+      return metric.endDateMs;
+    },
+
+    buildResolutionSpec({ metric, deadlineMs }) {
+      return {
+        kind: 'hard',
+        // Slug-keyed against the settlement feed — identical to the general
+        // family (KTD2): titles are mutable, only the venue slug is stable.
+        metricKey: `${MARKET_SETTLEMENT_FEED}|yesPrice(slug==${metric.slug})`,
+        operator: 'crosses',
+        threshold: 50,
+        baselineValue: round2(metric.value),
+        window: 'at-deadline',
+        deadline: deadlineMs,
+        sourceFeed: MARKET_SETTLEMENT_FEED,
+        question: normalizeQuestion(metric.subject),
+      };
+    },
+
+    buildQuestion({ spec }) {
+      return spec.question;
+    },
+
+    buildId({ metric }) {
+      // Same slug namespace as the general family; the disjoint partition
+      // guarantees no collision, and slug identity keeps settlement lookups
+      // uniform across both families.
+      return `market:${metric.slug}`;
+    },
+
+    decorate({ metric }) {
+      return {
+        marketSlug: metric.slug,
+        marketSource: metric.source,
+        calibration: { marketPrice: round2(metric.value), source: metric.source },
+      };
+    },
+
+    userValueScore() {
+      // Flagship domain: rank above every other family so geo bets claim the
+      // top-K ensemble slots (seed-forecast-bets raises TOP_K so this does not
+      // starve the fast-resolving general/commodity Gate-2 bets).
+      return 0.9;
+    },
+  };
+}
+
+export const MARKET_GEO_BET_TEMPLATES = Array.from({ length: MARKET_GEO_SLOT_COUNT }, (_, i) => buildSlotTemplate(i));
+
+function normalizeQuestion(title) {
+  const text = String(title).trim();
+  return /\?$/.test(text) ? text : `${text}?`;
+}
+
+function round2(value) {
+  if (!Number.isFinite(value)) return value;
+  return Math.round(value * 100) / 100;
+}

--- a/scripts/_bet-templates-markets.mjs
+++ b/scripts/_bet-templates-markets.mjs
@@ -18,6 +18,8 @@
 // sorted). Bet ids key on the market slug (stable across runs → the ledger's
 // id@deadline dedup and the seeder's open-window skip work per-market).
 
+import { isGeopoliticalMarket } from './_bet-templates-markets-classify.mjs';
+
 export const MARKET_FEED = 'prediction:markets-bootstrap:v1';
 export const MARKET_SETTLEMENT_FEED = 'prediction:markets-resolution:v1';
 
@@ -44,7 +46,10 @@ export function marketSlugFromUrl(url) {
   return null;
 }
 
-// Eligible markets, volume-sorted, deduped by slug. Pure.
+// Eligible markets, volume-sorted, deduped by slug. Pure. GEOPOLITICAL markets
+// are excluded here — they are owned by the dedicated long-horizon geo family
+// (_bet-templates-markets-geo.mjs), an exhaustive, disjoint partition so no
+// market is bet twice and the `market:<slug>` id namespace never collides.
 export function eligibleMarkets(feed, nowMs) {
   const pools = [feed?.geopolitical, feed?.tech, feed?.finance].filter(Array.isArray);
   const seen = new Set();
@@ -52,6 +57,7 @@ export function eligibleMarkets(feed, nowMs) {
   for (const record of pools.flat()) {
     if (!record || typeof record !== 'object') continue;
     const title = String(record.title || '').trim();
+    if (isGeopoliticalMarket(title)) continue;
     const yesPrice = Number(record.yesPrice);
     const volume = Number(record.volume);
     const endDateMs = Date.parse(record.endDate ?? '');

--- a/scripts/_bet-templates-markets.mjs
+++ b/scripts/_bet-templates-markets.mjs
@@ -46,6 +46,24 @@ export function marketSlugFromUrl(url) {
   return null;
 }
 
+// Parse + validate one bootstrap-feed record into the normalized shape both
+// market families consume, or null if it fails the shared gates (missing
+// title/slug, non-finite price/volume/date, below the liquidity floor). Pure.
+// Shared so the general and geo families cannot drift on record handling.
+export function parseMarketRecord(record) {
+  if (!record || typeof record !== 'object') return null;
+  const title = String(record.title || '').trim();
+  const yesPrice = Number(record.yesPrice);
+  const volume = Number(record.volume);
+  const endDateMs = Date.parse(record.endDate ?? '');
+  const slugInfo = marketSlugFromUrl(record.url);
+  if (!title || !slugInfo) return null;
+  if (!Number.isFinite(yesPrice)) return null;
+  if (!Number.isFinite(volume) || volume < MARKET_MIN_VOLUME) return null;
+  if (!Number.isFinite(endDateMs)) return null;
+  return { title, yesPrice, volume, endDateMs, ...slugInfo };
+}
+
 // Eligible markets, volume-sorted, deduped by slug. Pure. GEOPOLITICAL markets
 // are excluded here — they are owned by the dedicated long-horizon geo family
 // (_bet-templates-markets-geo.mjs), an exhaustive, disjoint partition so no
@@ -55,21 +73,13 @@ export function eligibleMarkets(feed, nowMs) {
   const seen = new Set();
   const out = [];
   for (const record of pools.flat()) {
-    if (!record || typeof record !== 'object') continue;
-    const title = String(record.title || '').trim();
-    if (isGeopoliticalMarket(title)) continue;
-    const yesPrice = Number(record.yesPrice);
-    const volume = Number(record.volume);
-    const endDateMs = Date.parse(record.endDate ?? '');
-    const slugInfo = marketSlugFromUrl(record.url);
-    if (!title || !slugInfo) continue;
-    if (!Number.isFinite(yesPrice)) continue;
-    if (!Number.isFinite(volume) || volume < MARKET_MIN_VOLUME) continue;
-    if (!Number.isFinite(endDateMs)) continue;
-    if (endDateMs < nowMs + MIN_LEAD_MS || endDateMs > nowMs + MAX_HORIZON_MS) continue;
-    if (seen.has(slugInfo.slug)) continue;
-    seen.add(slugInfo.slug);
-    out.push({ title, yesPrice, volume, endDateMs, ...slugInfo });
+    const market = parseMarketRecord(record);
+    if (!market) continue;
+    if (isGeopoliticalMarket(market.title)) continue;
+    if (market.endDateMs < nowMs + MIN_LEAD_MS || market.endDateMs > nowMs + MAX_HORIZON_MS) continue;
+    if (seen.has(market.slug)) continue;
+    seen.add(market.slug);
+    out.push(market);
   }
   return out.sort((a, b) => b.volume - a.volume);
 }

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -19,6 +19,7 @@ import { generateBets } from './_bet-templates.mjs';
 import { ENERGY_BET_TEMPLATES, EIA_PETROLEUM_FEED } from './_bet-templates-energy.mjs';
 import { COMMODITY_BET_TEMPLATES, COMMODITY_FEED } from './_bet-templates-commodities.mjs';
 import { MARKET_BET_TEMPLATES, MARKET_FEED } from './_bet-templates-markets.mjs';
+import { MARKET_GEO_BET_TEMPLATES } from './_bet-templates-markets-geo.mjs';
 import { MACRO_BET_TEMPLATES, FRED_FEED_KEYS } from './_bet-templates-macro.mjs';
 import { ensembleProbability } from './_forecast-ensemble.mjs';
 import { baseRateProbability } from './_bet-baserate.mjs';
@@ -46,8 +47,12 @@ const EIA_METRICS = ['inventory', 'production', 'wti', 'brent'];
 // All template families + the feeds they read. Energy (EIA, weekly) has an
 // accumulator-backed base rate; commodities (daily prices) are the fast-
 // resolving lane; prediction-markets are the market-anchored calibration slice
-// and FRED macro the market-free independence slice (#5525 Phase 2).
+// and FRED macro the market-free independence slice (#5525 Phase 2). The
+// geopolitical slice (#5733) is the flagship: it reads the SAME market feed as
+// the general family but on a long horizon, and is listed first so its bets
+// lead the registry (slug partition keeps the two market families disjoint).
 const ALL_BET_TEMPLATES = [
+  ...MARKET_GEO_BET_TEMPLATES,
   ...ENERGY_BET_TEMPLATES,
   ...COMMODITY_BET_TEMPLATES,
   ...MARKET_BET_TEMPLATES,
@@ -72,7 +77,12 @@ const FEED_MAX_GENERATION_AGE_MS = {
 // with base-rate probabilities and proves the new slices resolve (Gate 1.5)
 // before any LLM spend is enabled (Stage B sets FORECAST_BETS_ENSEMBLE=1).
 const ENSEMBLE_ENABLED = process.env.FORECAST_BETS_ENSEMBLE === '1';
-const ENSEMBLE_TOP_K = envPositiveInt('FORECAST_BETS_ENSEMBLE_TOP_K', 6);
+// Ensemble breadth. Raised 6→10 with the geo family (#5733): its 6 flagship
+// bets (userValueScore 0.9) would otherwise claim every ensemble slot and
+// starve the fast-resolving general-market / commodity Gate-2 bets. 10 covers
+// the geo bench PLUS the top short-dated lines; the deadline guard still stops
+// the loop at the run budget, so this is a ceiling, not a fixed spend.
+const ENSEMBLE_TOP_K = envPositiveInt('FORECAST_BETS_ENSEMBLE_TOP_K', 10);
 const ENSEMBLE_BUDGET_MS = envPositiveInt('FORECAST_BETS_ENSEMBLE_BUDGET_MS', 120_000);
 const RESOLUTIONS_LEDGER_KEY = 'forecast:resolutions:v1';
 

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -18,8 +18,8 @@ import {
 import { generateBets } from './_bet-templates.mjs';
 import { ENERGY_BET_TEMPLATES, EIA_PETROLEUM_FEED } from './_bet-templates-energy.mjs';
 import { COMMODITY_BET_TEMPLATES, COMMODITY_FEED } from './_bet-templates-commodities.mjs';
-import { MARKET_BET_TEMPLATES, MARKET_FEED } from './_bet-templates-markets.mjs';
-import { MARKET_GEO_BET_TEMPLATES } from './_bet-templates-markets-geo.mjs';
+import { MARKET_BET_TEMPLATES, MARKET_FEED, MARKET_SLOT_COUNT } from './_bet-templates-markets.mjs';
+import { MARKET_GEO_BET_TEMPLATES, MARKET_GEO_SLOT_COUNT } from './_bet-templates-markets-geo.mjs';
 import { MACRO_BET_TEMPLATES, FRED_FEED_KEYS } from './_bet-templates-macro.mjs';
 import { ensembleProbability } from './_forecast-ensemble.mjs';
 import { baseRateProbability } from './_bet-baserate.mjs';
@@ -76,14 +76,15 @@ const FEED_MAX_GENERATION_AGE_MS = {
 // Phase-2 ensemble stage (#5525) — OFF by default: U15 Stage A ships templates
 // with base-rate probabilities and proves the new slices resolve (Gate 1.5)
 // before any LLM spend is enabled (Stage B sets FORECAST_BETS_ENSEMBLE=1).
-const ENSEMBLE_ENABLED = process.env.FORECAST_BETS_ENSEMBLE === '1';
-// Ensemble breadth. Raised 6→12 with the geo family (#5733): its 6 flagship
-// bets (userValueScore 0.9) would otherwise claim every ensemble slot and
-// starve the fast-resolving Gate-2 lanes. 12 = the 6-deep geo bench PLUS the
-// general-market (0.8) and energy-price/commodity (0.75/0.7) lines that resolve
-// in days. The deadline guard still stops the loop at the run budget, so this
-// is a ceiling, not a fixed spend; geo ranks first so it is never starved.
-const ENSEMBLE_TOP_K = envPositiveInt('FORECAST_BETS_ENSEMBLE_TOP_K', 12);
+const ENSEMBLE_ENABLED = process.env.FORECAST_BETS_ENSEMBLE === '1';// Ensemble breadth. Score-only ranking puts geo (0.9) then general markets
+// (0.8) ahead of energy (0.75) / commodity (0.7) / macro (0.7). Default is
+// therefore: full geo slate + full general-market slate + headroom for the
+// fast-resolving Gate-2 lanes (energy prices, oil commodities, top macro).
+// 6 + 6 + 6 = 18. Env-overridable; the deadline guard still bounds spend, so
+// this is a ceiling, not a fixed cost. Geo still ranks first and is never
+// starved when the budget allows fewer attempts than K.
+export const ENSEMBLE_TOP_K_DEFAULT = MARKET_GEO_SLOT_COUNT + MARKET_SLOT_COUNT + 6;
+const ENSEMBLE_TOP_K = envPositiveInt('FORECAST_BETS_ENSEMBLE_TOP_K', ENSEMBLE_TOP_K_DEFAULT);
 const ENSEMBLE_BUDGET_MS = envPositiveInt('FORECAST_BETS_ENSEMBLE_BUDGET_MS', 120_000);
 const RESOLUTIONS_LEDGER_KEY = 'forecast:resolutions:v1';
 
@@ -165,11 +166,19 @@ export function buildBetsSnapshot(feedsByKey, nowMs, priorSeries = {}) {
 }
 
 // Phase-2 ensemble stage (#5525 U13). Ranks the snapshot's bets by
-// userValueScore, runs the 3-pass ensemble on the top-K, and replaces their
-// probability (source 'ensemble') while keeping baselineProbability intact.
-// Skips bets whose OPEN LEDGER WINDOW already holds an ensemble probability —
-// the primary cross-run cost control (updateOpenWindow never downgrades, so a
-// re-run adds nothing). Injected callLLM/news/openWindows keep this testable.
+// userValueScore, runs the 3-pass ensemble on up to top-K *new* attempts, and
+// replaces their probability (source 'ensemble') while keeping
+// baselineProbability intact.
+//
+// Open-ledger skips: bets whose OPEN LEDGER WINDOW already holds a full
+// ensemble probability are skipped (updateOpenWindow never downgrades, so a
+// re-run adds nothing) but do NOT consume a top-K slot. Otherwise long-horizon
+// geo pending windows (up to 210d) would freeze the high-score slice for
+// months and starve every lower-score Gate-2 family. topK therefore means
+// "up to K successful new ensemble attempts", not "first K rows of the ranked
+// list including already-ensembled skips".
+//
+// Injected callLLM/news/openWindows keep this testable.
 export async function attachEnsembleProbabilities(snapshot, options = {}) {
   const bets = snapshot?.predictions || [];
   if (!bets.length || typeof options.callLLM !== 'function') return { attempted: 0, ensembled: 0, skipped: 0 };
@@ -178,13 +187,14 @@ export async function attachEnsembleProbabilities(snapshot, options = {}) {
   const openEnsembleIds = options.openEnsembleIds instanceof Set ? options.openEnsembleIds : new Set();
   const news = Array.isArray(options.news) ? options.news : [];
 
-  const ranked = [...bets].sort((a, b) => (b.userValueScore || 0) - (a.userValueScore || 0)).slice(0, topK);
+  const ranked = [...bets].sort((a, b) => (b.userValueScore || 0) - (a.userValueScore || 0));
   let attempted = 0;
   let ensembled = 0;
   let partial = 0;
   let skipped = 0;
   for (const bet of ranked) {
     if (openEnsembleIds.has(bet.id)) { skipped += 1; continue; }
+    if (attempted >= topK) break; // K new attempts filled; remaining keep base-rate
     if (Date.now() >= deadlineMs) break; // remaining bets keep the base-rate
     attempted += 1;
     try {

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -77,12 +77,13 @@ const FEED_MAX_GENERATION_AGE_MS = {
 // with base-rate probabilities and proves the new slices resolve (Gate 1.5)
 // before any LLM spend is enabled (Stage B sets FORECAST_BETS_ENSEMBLE=1).
 const ENSEMBLE_ENABLED = process.env.FORECAST_BETS_ENSEMBLE === '1';
-// Ensemble breadth. Raised 6→10 with the geo family (#5733): its 6 flagship
+// Ensemble breadth. Raised 6→12 with the geo family (#5733): its 6 flagship
 // bets (userValueScore 0.9) would otherwise claim every ensemble slot and
-// starve the fast-resolving general-market / commodity Gate-2 bets. 10 covers
-// the geo bench PLUS the top short-dated lines; the deadline guard still stops
-// the loop at the run budget, so this is a ceiling, not a fixed spend.
-const ENSEMBLE_TOP_K = envPositiveInt('FORECAST_BETS_ENSEMBLE_TOP_K', 10);
+// starve the fast-resolving Gate-2 lanes. 12 = the 6-deep geo bench PLUS the
+// general-market (0.8) and energy-price/commodity (0.75/0.7) lines that resolve
+// in days. The deadline guard still stops the loop at the run budget, so this
+// is a ceiling, not a fixed spend; geo ranks first so it is never starved.
+const ENSEMBLE_TOP_K = envPositiveInt('FORECAST_BETS_ENSEMBLE_TOP_K', 12);
 const ENSEMBLE_BUDGET_MS = envPositiveInt('FORECAST_BETS_ENSEMBLE_BUDGET_MS', 120_000);
 const RESOLUTIONS_LEDGER_KEY = 'forecast:resolutions:v1';
 

--- a/tests/bet-templates-markets-geo.test.mjs
+++ b/tests/bet-templates-markets-geo.test.mjs
@@ -9,6 +9,7 @@ import {
 import {
   MARKET_BET_TEMPLATES, MARKET_FEED, MARKET_SETTLEMENT_FEED, eligibleMarkets,
 } from '../scripts/_bet-templates-markets.mjs';
+import { buildBetsSnapshot } from '../scripts/seed-forecast-bets.mjs';
 import { parseMetricKey } from '../scripts/_forecast-resolution-eval.mjs';
 
 const NOW = Date.parse('2026-07-28T00:00:00Z');
@@ -48,6 +49,62 @@ describe('isGeopoliticalMarket', () => {
       'Gaza reconstruction deal signed in 2026?',
     ]) {
       assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
+    }
+  });
+
+  it('flags NUCLEAR markets only in a weapon/statecraft context', () => {
+    for (const title of [
+      'Will Iran sign a nuclear deal by December?',
+      'North Korea conducts a nuclear test in 2026?',
+      'Will Russia issue a nuclear threat over Ukraine?',
+      'Nuclear weapons treaty ratified before 2027?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
+    }
+    // Nuclear-ENERGY markets are a real category and must stay NON-geo.
+    for (const title of [
+      'Will a new nuclear energy company IPO in 2026?',
+      'Nuclear power plant approved in Ohio this year?',
+      'Will the nuclear reactor SMR startup raise a Series C?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
+    }
+  });
+
+  it('flags national / legislative elections but not corporate ones', () => {
+    for (const title of [
+      'Who wins the 2028 US presidential election?',
+      'Will the ruling party lose the parliamentary election?',
+      'Republicans win control of the Senate in the midterms?',
+      'Will there be a runoff in the French presidential election?',
+      'Which party controls the House after the general election?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
+    }
+    for (const title of [
+      'Will the board election reinstate the former CEO?',
+      'Union election at the Detroit plant passes?',
+      'Baseball Hall of Fame election results announced?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
+    }
+  });
+
+  it('flags national head-of-state / head-of-government markets', () => {
+    for (const title of [
+      'Will Zohran Mamdani become President of the United States before 2029?',
+      'Who will be the next Prime Minister of Romania?',
+      'Will the incumbent win as POTUS in 2028?',
+      'Next Supreme Leader of Iran named by December?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
+    }
+    // Corporate leadership must NOT fire (no country qualifier).
+    for (const title of [
+      'Will Jane Doe become President of Acme Corp this year?',
+      'Vice President of Sales departs before Q4?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
     }
   });
 
@@ -154,5 +211,18 @@ describe('geo / general partition is exhaustive and disjoint', () => {
     const geoSoon = market({ title: 'NATO Article 5 invoked before September?', url: 'https://polymarket.com/event/nato-a5', endDate: new Date(NOW + 15 * DAY_MS).toISOString() });
     assert.equal(eligibleMarkets(feedFixture([geoSoon]), NOW).length, 0);
     assert.equal(eligibleGeoMarkets(feedFixture([geoSoon]), NOW).length, 1);
+  });
+});
+
+describe('geopolitical bets reach the seeder snapshot end-to-end', () => {
+  it('buildBetsSnapshot emits a geopolitical-domain bet from the market feed', () => {
+    const geo = market(); // Iran leadership change, Dec-31, $21M — inside 210d
+    const snapshot = buildBetsSnapshot({ [MARKET_FEED]: feedFixture([geo]) }, NOW);
+    const geoBet = snapshot.predictions.find((b) => b.domain === 'geopolitical');
+    assert.ok(geoBet, 'expected a geopolitical bet in the snapshot');
+    assert.equal(geoBet.id, 'market:iran-leadership-change-by');
+    assert.equal(geoBet.generationOrigin, 'bet_engine');
+    assert.equal(geoBet.resolution.sourceFeed, MARKET_SETTLEMENT_FEED);
+    assert.ok(Number.isFinite(geoBet.probability), 'carries a base-rate probability (Stage A)');
   });
 });

--- a/tests/bet-templates-markets-geo.test.mjs
+++ b/tests/bet-templates-markets-geo.test.mjs
@@ -1,0 +1,158 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { generateBets } from '../scripts/_bet-templates.mjs';
+import { isGeopoliticalMarket } from '../scripts/_bet-templates-markets-classify.mjs';
+import {
+  MARKET_GEO_BET_TEMPLATES, MARKET_GEO_SLOT_COUNT, eligibleGeoMarkets,
+} from '../scripts/_bet-templates-markets-geo.mjs';
+import {
+  MARKET_BET_TEMPLATES, MARKET_FEED, MARKET_SETTLEMENT_FEED, eligibleMarkets,
+} from '../scripts/_bet-templates-markets.mjs';
+import { parseMetricKey } from '../scripts/_forecast-resolution-eval.mjs';
+
+const NOW = Date.parse('2026-07-28T00:00:00Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function market(overrides = {}) {
+  return {
+    title: 'Iran leadership change by December 31?',
+    yesPrice: 21,
+    volume: 21_000_000,
+    url: 'https://polymarket.com/event/iran-leadership-change-by',
+    endDate: '2026-12-31T00:00:00Z', // ~156d out — inside the 210d geo horizon
+    ...overrides,
+  };
+}
+
+// All markets live in the (mislabeled) geopolitical pool — classification is by
+// TITLE, not pool, so the fixtures deliberately mix domains under one pool key.
+function feedFixture(markets, overrides = {}) {
+  return { geopolitical: markets, tech: [], finance: [], fetchedAt: NOW, ...overrides };
+}
+
+describe('isGeopoliticalMarket', () => {
+  it('flags unambiguous conflict / statecraft markets', () => {
+    for (const title of [
+      'US obtains Iranian enriched uranium by December 31',
+      'Iran agrees to surrender enriched uranium stockpile by Dec 31',
+      'Iran coup attempt by December 31?',
+      'Iran leadership change by December 31?',
+      'Israel x Iran ceasefire continues through August?',
+      'Will Russia and Ukraine reach a ceasefire in 2026?',
+      'Will NATO invoke Article 5 this year?',
+      'New US sanctions on Venezuela before September?',
+      'Will there be a war between two NATO members?',
+      'Ballistic missile launch over Japan by year end?',
+      'Hamas releases remaining hostages by August?',
+      'Gaza reconstruction deal signed in 2026?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
+    }
+  });
+
+  it('does NOT flag company / crypto / macro markets (precision guards)', () => {
+    for (const title of [
+      'Will Alibaba have the best Chinese AI model at the end of July 2026?', // "chinese" must not fire
+      'Will NVIDIA be the largest company in the world by market cap on July 31?',
+      'Will Bitcoin reach $67,500 in July?',
+      'Will no Fed rate cuts happen in 2026?',
+      'Will the S&P 500 strike a new all-time high?', // "strike" alone must not fire
+      'Will TSMC report record revenue this quarter?', // Taiwan proxy, but no conflict term
+      'Company X board election result?', // "election" alone must not fire
+      'Will oil prices rise to $90 forward this year?', // "forward" must not trip \bwar\b
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
+    }
+  });
+
+  it('handles empty / nullish titles', () => {
+    assert.equal(isGeopoliticalMarket(''), false);
+    assert.equal(isGeopoliticalMarket(null), false);
+    assert.equal(isGeopoliticalMarket(undefined), false);
+  });
+});
+
+describe('eligibleGeoMarkets', () => {
+  it('includes long-dated geopolitical markets the general 45d family cannot reach', () => {
+    const out = eligibleGeoMarkets(feedFixture([market()]), NOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].slug, 'iran-leadership-change-by');
+  });
+
+  it('excludes non-geopolitical markets even inside the horizon and volume floor', () => {
+    const nonGeo = market({ title: 'Will Bitcoin reach $67,500 in July?', url: 'https://polymarket.com/event/btc-67500', endDate: new Date(NOW + 30 * DAY_MS).toISOString() });
+    assert.equal(eligibleGeoMarkets(feedFixture([nonGeo]), NOW).length, 0);
+  });
+
+  it('excludes multi-year lottery lines beyond the 210d cap', () => {
+    const farOut = market({ endDate: '2028-01-01T00:00:00Z' });
+    assert.equal(eligibleGeoMarkets(feedFixture([farOut]), NOW).length, 0);
+  });
+
+  it('still admits short-dated geopolitical lines (2d min lead)', () => {
+    const soon = market({ title: 'Israel x Iran ceasefire holds through July 31?', url: 'https://polymarket.com/event/israel-iran-ceasefire', endDate: new Date(NOW + 3 * DAY_MS).toISOString() });
+    const out = eligibleGeoMarkets(feedFixture([soon]), NOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].slug, 'israel-iran-ceasefire');
+  });
+
+  it('enforces the liquidity floor and sorts by volume', () => {
+    const thin = market({ title: 'Minor coup rumor market', url: 'https://polymarket.com/event/thin-coup', volume: 10_000 });
+    const big = market({ title: 'Iran nuclear deal by December?', url: 'https://polymarket.com/event/iran-nuclear-deal', volume: 5_000_000 });
+    const bigger = market({ title: 'Russia Ukraine ceasefire by December?', url: 'https://polymarket.com/event/ru-ua-ceasefire', volume: 9_000_000 });
+    const out = eligibleGeoMarkets(feedFixture([thin, big, bigger]), NOW);
+    assert.deepEqual(out.map((m) => m.slug), ['ru-ua-ceasefire', 'iran-nuclear-deal']);
+  });
+});
+
+describe('geo slot templates', () => {
+  it('generates a geopolitical bet with a slug-keyed settlement spec and 0.9 value score', () => {
+    const bets = generateBets(MARKET_GEO_BET_TEMPLATES, { [MARKET_FEED]: feedFixture([market()]) }, NOW);
+    assert.equal(bets.length, 1);
+    const bet = bets[0];
+    assert.equal(bet.domain, 'geopolitical');
+    assert.equal(bet.id, 'market:iran-leadership-change-by');
+    assert.equal(bet.userValueScore, 0.9);
+    assert.equal(bet.marketSlug, 'iran-leadership-change-by');
+    assert.equal(bet.calibration.marketPrice, 21);
+    assert.equal(bet.resolution.sourceFeed, MARKET_SETTLEMENT_FEED);
+    const parsed = parseMetricKey(bet.resolution.metricKey);
+    assert.equal(parsed.feedKey, MARKET_SETTLEMENT_FEED);
+    assert.equal(parsed.fn, 'yesPrice');
+    assert.equal(parsed.field, 'slug');
+    assert.equal(parsed.value, 'iran-leadership-change-by');
+  });
+
+  it('binds slot i to the i-th eligible geo market and caps at the slate size', () => {
+    const many = Array.from({ length: MARKET_GEO_SLOT_COUNT + 2 }, (_, i) => market({
+      title: `Sanctions escalation scenario ${i}?`,
+      url: `https://polymarket.com/event/sanctions-${i}`,
+      volume: 1_000_000 + i, // ascending → reverse of volume sort
+    }));
+    const bets = generateBets(MARKET_GEO_BET_TEMPLATES, { [MARKET_FEED]: feedFixture(many) }, NOW);
+    assert.equal(bets.length, MARKET_GEO_SLOT_COUNT); // capped, extras dropped
+  });
+});
+
+describe('geo / general partition is exhaustive and disjoint', () => {
+  it('routes each market to exactly one family with no slug collision', () => {
+    const geo = market({ title: 'Iran coup by December?', url: 'https://polymarket.com/event/iran-coup', endDate: new Date(NOW + 20 * DAY_MS).toISOString() });
+    const general = market({ title: 'Will NVIDIA be the largest company on July 31?', url: 'https://polymarket.com/event/nvidia-largest', endDate: new Date(NOW + 20 * DAY_MS).toISOString() });
+    const feed = { [MARKET_FEED]: feedFixture([geo, general]) };
+
+    const geoBets = generateBets(MARKET_GEO_BET_TEMPLATES, feed, NOW);
+    const generalBets = generateBets(MARKET_BET_TEMPLATES, feed, NOW);
+    assert.deepEqual(geoBets.map((b) => b.marketSlug), ['iran-coup']);
+    assert.deepEqual(generalBets.map((b) => b.marketSlug), ['nvidia-largest']);
+
+    const geoIds = new Set(geoBets.map((b) => b.id));
+    assert.ok(generalBets.every((b) => !geoIds.has(b.id)), 'general and geo id namespaces must be disjoint');
+  });
+
+  it('general family drops a geopolitical market even inside its 45d window', () => {
+    const geoSoon = market({ title: 'NATO Article 5 invoked before September?', url: 'https://polymarket.com/event/nato-a5', endDate: new Date(NOW + 15 * DAY_MS).toISOString() });
+    assert.equal(eligibleMarkets(feedFixture([geoSoon]), NOW).length, 0);
+    assert.equal(eligibleGeoMarkets(feedFixture([geoSoon]), NOW).length, 1);
+  });
+});

--- a/tests/bet-templates-markets-geo.test.mjs
+++ b/tests/bet-templates-markets-geo.test.mjs
@@ -96,6 +96,7 @@ describe('isGeopoliticalMarket', () => {
       'Who will be the next Prime Minister of Romania?',
       'Will the incumbent win as POTUS in 2028?',
       'Next Supreme Leader of Iran named by December?',
+      'Who will be the next president of France?',
     ]) {
       assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
     }
@@ -103,6 +104,28 @@ describe('isGeopoliticalMarket', () => {
     for (const title of [
       'Will Jane Doe become President of Acme Corp this year?',
       'Vice President of Sales departs before Q4?',
+      'Who will be the next president of OpenAI?',
+      'Will Acme Corp have a leadership change this year?',
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
+    }
+  });
+
+  it('flags weak terms only with a high-salience actor co-occurrence', () => {
+    for (const title of [
+      'Iran leadership change by December 31?',
+      'New US sanctions on Venezuela before September?',
+      'Will there be a war between two NATO members?',
+      'US obtains Iranian enriched uranium by December 31', // enrich is strong; uranium+iran also weak+actor
+    ]) {
+      assert.equal(isGeopoliticalMarket(title), true, `expected geo: ${title}`);
+    }
+    for (const title of [
+      'Will Acme Corp have a leadership change this year?',
+      'Highest-paid occupation in the US this year?',
+      'Will a uranium miner IPO in 2026?',
+      'Retail price war intensifies this quarter?',
+      'Will the SEC issue new sanctions on crypto firms?',
     ]) {
       assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
     }
@@ -118,6 +141,7 @@ describe('isGeopoliticalMarket', () => {
       'Will TSMC report record revenue this quarter?', // Taiwan proxy, but no conflict term
       'Company X board election result?', // "election" alone must not fire
       'Will oil prices rise to $90 forward this year?', // "forward" must not trip \bwar\b
+      'Will the Russia stock market ETF recover this year?', // bare country, no conflict term
     ]) {
       assert.equal(isGeopoliticalMarket(title), false, `expected NON-geo: ${title}`);
     }
@@ -183,12 +207,16 @@ describe('geo slot templates', () => {
 
   it('binds slot i to the i-th eligible geo market and caps at the slate size', () => {
     const many = Array.from({ length: MARKET_GEO_SLOT_COUNT + 2 }, (_, i) => market({
-      title: `Sanctions escalation scenario ${i}?`,
-      url: `https://polymarket.com/event/sanctions-${i}`,
-      volume: 1_000_000 + i, // ascending → reverse of volume sort
+      // Strong geo term (coup) so each row is eligible; volume ascending → reverse sort.
+      title: `Coup attempt scenario ${i}?`,
+      url: `https://polymarket.com/event/coup-${i}`,
+      volume: 1_000_000 + i,
     }));
     const bets = generateBets(MARKET_GEO_BET_TEMPLATES, { [MARKET_FEED]: feedFixture(many) }, NOW);
     assert.equal(bets.length, MARKET_GEO_SLOT_COUNT); // capped, extras dropped
+    // Highest volumes win: coup-(N+1) ... coup-(N - SLOT + 2) after reverse volume sort.
+    const expected = Array.from({ length: MARKET_GEO_SLOT_COUNT }, (_, i) => `coup-${MARKET_GEO_SLOT_COUNT + 1 - i}`);
+    assert.deepEqual(bets.map((b) => b.marketSlug), expected);
   });
 });
 

--- a/tests/forecast-bets-seeder.test.mjs
+++ b/tests/forecast-bets-seeder.test.mjs
@@ -1,9 +1,14 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { buildBetsSnapshot, computeNextSeries, attachEnsembleProbabilities, collectOpenEnsembleIds } from '../scripts/seed-forecast-bets.mjs';
+import {
+  buildBetsSnapshot, computeNextSeries, attachEnsembleProbabilities, collectOpenEnsembleIds,
+  ENSEMBLE_TOP_K_DEFAULT,
+} from '../scripts/seed-forecast-bets.mjs';
 import { ingestHistory, resolveDueEntries, shapeResolutionFeed } from '../scripts/seed-forecast-resolutions.mjs';
 import { EIA_PETROLEUM_FEED } from '../scripts/_bet-templates-energy.mjs';
+import { MARKET_SLOT_COUNT } from '../scripts/_bet-templates-markets.mjs';
+import { MARKET_GEO_SLOT_COUNT } from '../scripts/_bet-templates-markets-geo.mjs';
 import { resolveHardSpec } from '../scripts/_forecast-resolution-eval.mjs';
 import { createEnsembleCache } from '../scripts/_forecast-ensemble.mjs';
 
@@ -229,17 +234,69 @@ describe('Phase-2: baselines + ensemble stage (#5525 U13)', () => {
     for (const bet of snap.predictions) assert.equal(bet.probabilitySource, 'base_rate');
   });
 
-  it('skips bets whose open ledger window already holds an ensemble probability', async () => {
+  it('skips open-ensemble ids without consuming a top-K slot (backfills lower ranks)', async () => {
     const snap = buildBetsSnapshot({ [EIA_PETROLEUM_FEED]: { _seed: { fetchedAt: NOW }, data: eiaFixture() } }, NOW, {});
-    const first = [...snap.predictions].sort((a, b) => (b.userValueScore || 0) - (a.userValueScore || 0))[0];
+    const ranked = [...snap.predictions].sort((a, b) => (b.userValueScore || 0) - (a.userValueScore || 0));
+    const first = ranked[0];
+    const second = ranked[1];
+    assert.ok(first && second && first.id !== second.id);
     const callLLM = llmDouble(0.7);
     const stats = await attachEnsembleProbabilities(snap, {
       callLLM, topK: 1, deadlineMs: Date.now() + 60_000, cache: createEnsembleCache(),
       openEnsembleIds: new Set([first.id]),
     });
+    // Open-ensemble skip frees the slot so the next-ranked bet is ensembled.
     assert.equal(stats.skipped, 1);
-    assert.equal(stats.attempted, 0);
-    assert.equal(callLLM.calls.length, 0);
+    assert.equal(stats.attempted, 1);
+    assert.equal(stats.ensembled, 1);
+    assert.equal(first.probabilitySource, 'base_rate');
+    assert.equal(second.probabilitySource, 'ensemble');
+    assert.equal(callLLM.calls.length, 3); // 3 passes × 1 new attempt
+  });
+
+  it('ENSEMBLE_TOP_K default leaves room for Gate-2 lanes after full geo+general slates', () => {
+    // 6 geo (0.9) + 6 general (0.8) must not exhaust K; energy (0.75) needs a seat.
+    assert.equal(ENSEMBLE_TOP_K_DEFAULT, MARKET_GEO_SLOT_COUNT + MARKET_SLOT_COUNT + 6);
+    assert.ok(ENSEMBLE_TOP_K_DEFAULT > MARKET_GEO_SLOT_COUNT + MARKET_SLOT_COUNT);
+  });
+
+  it('multi-family ranking: topK=12 starves energy; default K admits energy under full geo+general', async () => {
+    // Synthetic scores mirror production families without needing live market feeds.
+    const bets = [
+      ...Array.from({ length: 6 }, (_, i) => ({
+        id: `geo-${i}`, title: `geo ${i}`, userValueScore: 0.9,
+        baselineProbability: 0.4, probability: 0.4, probabilitySource: 'base_rate',
+        resolution: { operator: 'crosses', threshold: 50, baselineValue: 20 },
+      })),
+      ...Array.from({ length: 6 }, (_, i) => ({
+        id: `mkt-${i}`, title: `market ${i}`, userValueScore: 0.8,
+        baselineProbability: 0.4, probability: 0.4, probabilitySource: 'base_rate',
+        resolution: { operator: 'crosses', threshold: 50, baselineValue: 20 },
+      })),
+      {
+        id: 'energy-wti', title: 'WTI rise', userValueScore: 0.75,
+        baselineProbability: 0.4, probability: 0.4, probabilitySource: 'base_rate',
+        resolution: { operator: 'gte', threshold: 80, baselineValue: 78 },
+      },
+    ];
+    const callLLMStarved = llmDouble(0.66);
+    const starved = await attachEnsembleProbabilities(
+      { predictions: bets.map((b) => ({ ...b })) },
+      { callLLM: callLLMStarved, topK: 12, deadlineMs: Date.now() + 60_000, cache: createEnsembleCache() },
+    );
+    assert.equal(starved.attempted, 12);
+    assert.equal(starved.ensembled, 12);
+    // Rebuild — previous call mutated copies only; fresh list for the default-K case.
+    const bets2 = bets.map((b) => ({ ...b }));
+    const callLLMRoom = llmDouble(0.66);
+    const room = await attachEnsembleProbabilities(
+      { predictions: bets2 },
+      { callLLM: callLLMRoom, topK: ENSEMBLE_TOP_K_DEFAULT, deadlineMs: Date.now() + 60_000, cache: createEnsembleCache() },
+    );
+    assert.equal(room.attempted, 13); // 6 geo + 6 general + 1 energy
+    assert.equal(room.ensembled, 13);
+    const energy = bets2.find((b) => b.id === 'energy-wti');
+    assert.equal(energy.probabilitySource, 'ensemble');
   });
 
   it('collectOpenEnsembleIds indexes only pending FULL-ensemble entries — partials retry (review #3)', () => {


### PR DESCRIPTION
## Why

WorldMonitor is a reference in **geopolitical** intelligence, but the Phase-2 market bet-family (#5525) excluded exactly that domain. The general market slice caps the horizon at **45 days** so bets resolve fast for Gate-2 — yet the liquid geopolitical prediction markets almost all settle **Dec-31 or later**. A live-feed audit found geopolitical coverage was effectively **0 persistent bets** — a single transient short-dated line by luck of the feed — while the real bench sat excluded:

| Market | Volume | Resolves |
|---|---|---|
| US obtains Iranian enriched uranium | $29M | Dec-31 |
| Iran leadership change | $21M | Dec-31 |
| Iran surrenders enriched uranium stockpile | $18M | Dec-31 |
| Israel–Hamas ceasefire phase II | $3M | Dec-31 |
| Iran coup attempt | $2M | Dec-31 |
| Ukraine cedes territory to Russia | $1M | Dec-31 |

## What

A dedicated **geopolitical bet family**, ranked as the flagship slice:

- **`_bet-templates-markets-classify.mjs`** — pure `isGeopoliticalMarket(title)`, classifying from the market **text**, deliberately **not** the bootstrap feed's `geopolitical/tech/finance` pools. Those pools are unreliable (same market appears in all three; the "geopolitical" pool is dominated by crypto — see #5733), so text classification keeps this robust to the broken producer labels. Precision-first: keys on conflict/statecraft terms + high-salience actors, never bare country names (so "best Chinese AI model" stays tech) or bare "election"/"strike" (board elections, option strike prices).
- **`_bet-templates-markets-geo.mjs`** — **210-day** horizon so the Dec-31 bench qualifies; `userValueScore 0.9` (leads the ensemble top-K). Slug-keyed settlement contract byte-identical to the general family (KTD2) — the resolver's `updateMarketSettlements` loader needs no change.
- **General family now excludes geopolitical markets** — the partition is **exhaustive and disjoint**, so no market is bet twice and the `market:<slug>` id namespace never collides.
- **`ENSEMBLE_TOP_K` 6→10** so the 6 geo flagship bets don't starve the fast-resolving general/commodity Gate-2 bets. Env-overridable; the run-budget deadline still bounds actual spend.

## Proof (live feed)

- Geo family now captures **6 bets ($1M–$29M)**; general family keeps Bitcoin/NVIDIA/Alibaba; **partition overlap = 0**.
- **12 new tests**: classifier truth table incl. precision guards, horizon windowing (long + short-dated + 210d cap), slot binding, disjoint partition.
- Full forecast/bet suite **957/957 green**; biome clean.

## Scope notes

- Geo bets resolve on multi-month horizons, so they contribute to Gate-2 **calibration** later than the short slice — the value here is **coverage of the flagship domain**, not fast proof. The short-horizon Gate-2 evidence path is unchanged.
- Companion to #5733 (feed pool-classification bug). This PR sidesteps that bug entirely by classifying from title text; #5733 remains worth fixing at the producer.

Tracked under #5525 (Phase 2 epic). Opened for manual review — do not auto-merge.

https://claude.ai/code/session_01MzGi7677EGiLzbHztWvxru