### PR TITLE
fix(research): reject incomplete daily coverage

### DIFF
--- a/scripts/build-research-reports.mjs
+++ b/scripts/build-research-reports.mjs
@@ -44,6 +44,68 @@ function inRange(history, start, end) {
   return history.filter((row) => row.date >= start && row.date <= end);
 }
 
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function assertCompleteDailyCoverage(id, series) {
+  const history = series?.history;
+  if (!Array.isArray(history) || history.length === 0) {
+    throw new Error(`${id} has incomplete daily coverage: no observations`);
+  }
+
+  const start = series.observationStart;
+  const end = series.observationEnd;
+  if (!ISO_DATE_PATTERN.test(start ?? '') || !ISO_DATE_PATTERN.test(end ?? '') || start > end) {
+    throw new Error(
+      `${id} has incomplete daily coverage: invalid observation range ${start ?? 'unknown'} → ${end ?? 'unknown'}`,
+    );
+  }
+
+  const present = new Set();
+  let previousDate = null;
+  for (const row of history) {
+    const date = row?.date;
+    if (!ISO_DATE_PATTERN.test(date ?? '')) {
+      throw new Error(`${id} has incomplete daily coverage: invalid observation date ${date ?? 'unknown'}`);
+    }
+    if (previousDate !== null && date <= previousDate) {
+      throw new Error(
+        `${id} has incomplete daily coverage: dates must be unique and ascending (${previousDate}, ${date})`,
+      );
+    }
+    present.add(date);
+    previousDate = date;
+  }
+
+  const missing = [];
+  const cursor = new Date(`${start}T00:00:00Z`);
+  const last = new Date(`${end}T00:00:00Z`);
+  for (; cursor <= last; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+    const date = cursor.toISOString().slice(0, 10);
+    if (!present.has(date)) missing.push(date);
+  }
+  if (missing.length > 0) {
+    const preview = missing.slice(0, 5).join(', ');
+    const remainder = missing.length > 5 ? ` (+${missing.length - 5} more)` : '';
+    throw new Error(`${id} has incomplete daily coverage: missing ${preview}${remainder}`);
+  }
+
+  if (history[0].date !== start || history.at(-1).date !== end) {
+    throw new Error(
+      `${id} has incomplete daily coverage: history bounds do not match ${start} → ${end}`,
+    );
+  }
+  if (series.rowCount !== history.length) {
+    throw new Error(
+      `${id} has incomplete daily coverage: rowCount ${series.rowCount} does not match ${history.length} observations`,
+    );
+  }
+  if (!Array.isArray(series.missingDates) || series.missingDates.length > 0) {
+    throw new Error(
+      `${id} has incomplete daily coverage: missingDates metadata must be an empty array`,
+    );
+  }
+}
+
 const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 function monthLabel(isoMonth) {
@@ -93,6 +155,16 @@ export function computeReportMetrics(snapshot, report) {
   }
   const focus = snapshot.chokepoints[report.focusChokepointId];
   if (!focus) throw new Error(`Snapshot has no focus chokepoint ${report.focusChokepointId}`);
+  const publishedSeriesIds = new Set([
+    ...Object.keys(snapshot.chokepoints),
+    report.focusChokepointId,
+    ...(report.contextChokepointIds ?? []),
+  ]);
+  for (const id of publishedSeriesIds) {
+    const series = snapshot.chokepoints[id];
+    if (!series) throw new Error(`Snapshot has no published chokepoint ${id}`);
+    assertCompleteDailyCoverage(id, series);
+  }
   const history = focus.history;
   const observationEnd = focus.observationEnd;
   const capturedAtDate = String(snapshot.capturedAt).slice(0, 10);

--- a/scripts/build-research-reports.mjs
+++ b/scripts/build-research-reports.mjs
@@ -46,6 +46,12 @@ function inRange(history, start, end) {
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+function isIsoCalendarDate(value) {
+  if (!ISO_DATE_PATTERN.test(value ?? '')) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
 function assertCompleteDailyCoverage(id, series) {
   const history = series?.history;
   if (!Array.isArray(history) || history.length === 0) {
@@ -54,7 +60,7 @@ function assertCompleteDailyCoverage(id, series) {
 
   const start = series.observationStart;
   const end = series.observationEnd;
-  if (!ISO_DATE_PATTERN.test(start ?? '') || !ISO_DATE_PATTERN.test(end ?? '') || start > end) {
+  if (!isIsoCalendarDate(start) || !isIsoCalendarDate(end) || start > end) {
     throw new Error(
       `${id} has incomplete daily coverage: invalid observation range ${start ?? 'unknown'} → ${end ?? 'unknown'}`,
     );
@@ -64,7 +70,7 @@ function assertCompleteDailyCoverage(id, series) {
   let previousDate = null;
   for (const row of history) {
     const date = row?.date;
-    if (!ISO_DATE_PATTERN.test(date ?? '')) {
+    if (!isIsoCalendarDate(date)) {
       throw new Error(`${id} has incomplete daily coverage: invalid observation date ${date ?? 'unknown'}`);
     }
     if (previousDate !== null && date <= previousDate) {

--- a/tests/research-report-corpus.test.mjs
+++ b/tests/research-report-corpus.test.mjs
@@ -292,9 +292,30 @@ describe('research report corpus (#5668)', () => {
     };
     assert.throws(
       () => computeReportMetrics(truncated, report),
-      /No rows for metric/,
+      /incomplete daily coverage/,
       'a snapshot missing the observation window must fail the build, not render empties',
     );
+  });
+
+  it('fails closed when any published series has an interior calendar gap', () => {
+    const missingDate = '2026-06-15';
+    const publishedSeriesIds = [
+      report.focusChokepointId,
+      report.contextChokepointIds[0],
+    ];
+
+    for (const id of publishedSeriesIds) {
+      const incomplete = structuredClone(snapshot);
+      const series = incomplete.chokepoints[id];
+      series.history = series.history.filter((row) => row.date !== missingDate);
+      series.rowCount = series.history.length;
+
+      assert.throws(
+        () => computeReportMetrics(incomplete, report),
+        new RegExp(`${id}.*incomplete daily coverage.*${missingDate}`, 'i'),
+        `${id}: a missing interior day must fail the report build even when metadata omits the gap`,
+      );
+    }
   });
 
   // Regression: the ArcGIS layer's server-side maxRecordCount (1000) is below

--- a/tests/research-report-corpus.test.mjs
+++ b/tests/research-report-corpus.test.mjs
@@ -318,6 +318,23 @@ describe('research report corpus (#5668)', () => {
     }
   });
 
+  it('fails closed when a published series contains an impossible calendar date', () => {
+    const invalidDate = '2026-02-30';
+    const invalid = structuredClone(snapshot);
+    const series = invalid.chokepoints[report.focusChokepointId];
+    const insertionIndex = series.history.findIndex((row) => row.date === '2026-03-01');
+    series.history.splice(insertionIndex, 0, {
+      ...series.history[insertionIndex - 1],
+      date: invalidDate,
+    });
+    series.rowCount = series.history.length;
+
+    assert.throws(
+      () => computeReportMetrics(invalid, report),
+      new RegExp(`${report.focusChokepointId}.*invalid observation date.*${invalidDate}`, 'i'),
+    );
+  });
+
   // Regression: the ArcGIS layer's server-side maxRecordCount (1000) is below
   // the requested page size, so advancing offset by PAGE_SIZE instead of the
   // rows actually returned silently skipped rows 1000-1999 (a contiguous


### PR DESCRIPTION
## Summary

Research report generation now stops before publishing when any included daily series is incomplete. Previously, a single missing calendar day could silently turn averages, sums, charts, and context comparisons into partial-window figures, even when `missingDates` metadata was stale or empty.

Coverage is recomputed from each series' declared observation bounds and also rejects duplicate or unsorted dates, bound mismatches, row-count drift, and inconsistent missing-date metadata.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: deterministic research report generation

## Validation

- `TMPDIR=/private/tmp node --import tsx --test tests/research-report-corpus.test.mjs` — 11/11 passed, including focus and context-series interior-gap regressions.
- `npx biome lint scripts/build-research-reports.mjs tests/research-report-corpus.test.mjs` — passed.
- Repository pre-push gates — source/API typechecks, Unicode safety, changed tests, and version synchronization passed.

## Related

Related: https://github.com/koala73/worldmonitor/pull/5721#discussion_r3661529953

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
