### PR TITLE
fix(analytics): verify collector writes and retry identity

### DIFF
--- a/.github/workflows/analytics-collector-monitor.yml
+++ b/.github/workflows/analytics-collector-monitor.yml
@@ -7,7 +7,7 @@ name: Analytics Collector Monitor
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/scripts/check-analytics-collector.mjs
+++ b/scripts/check-analytics-collector.mjs
@@ -18,6 +18,8 @@ import { realpathSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const DEFAULT_COLLECTOR_ORIGIN = 'https://abacus.worldmonitor.app';
+export const ANALYTICS_CANARY_WEBSITE_ID = '373c80a2-1109-42a7-868b-565bcf7bf168';
+const ANALYTICS_CANARY_HOSTNAME = 'analytics-canary.worldmonitor.app';
 
 /**
  * Cloudflare's WAF 403s a bare `curl/*` User-Agent on this host (verified
@@ -26,6 +28,8 @@ const DEFAULT_COLLECTOR_ORIGIN = 'https://abacus.worldmonitor.app';
  * not cosmetic.
  */
 const USER_AGENT = 'worldmonitor-analytics-collector-monitor/1.0';
+const BROWSER_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36';
 
 const REQUEST_TIMEOUT_MS = 20_000;
 const ATTEMPTS = 3;
@@ -52,13 +56,50 @@ export const COLLECTOR_PROBES = Object.freeze([
   Object.freeze({
     name: 'ingest-route',
     path: '/api/send',
-    // The write path. GET is the wrong verb on purpose: a mounted route
-    // rejects it (405/400) without recording anything, while a dead origin
-    // returns 5xx. Never POST here — that would pollute production analytics
-    // with synthetic monitor traffic.
+    // Keeps the original no-write route-mount check from #5565. The canary
+    // below separately proves that the database-backed write path succeeds.
     okStatuses: Object.freeze([400, 405]),
   }),
+  Object.freeze({
+    name: 'write-canary',
+    path: '/api/send',
+    method: 'POST',
+    okStatuses: Object.freeze([200]),
+    userAgent: BROWSER_USER_AGENT,
+    receiptFields: Object.freeze(['cache', 'sessionId', 'visitId']),
+    // This website is deliberately separate from World Monitor's production
+    // website id, so one synthetic event every 5 minutes cannot contaminate
+    // product funnels or pageview counts.
+    body: Object.freeze({
+      type: 'event',
+      payload: Object.freeze({
+        website: ANALYTICS_CANARY_WEBSITE_ID,
+        hostname: ANALYTICS_CANARY_HOSTNAME,
+        url: '/__monitor__/analytics-collector',
+        title: 'World Monitor analytics collector canary',
+        referrer: '',
+        screen: '1x1',
+        language: 'en-US',
+        name: 'collector-write-canary',
+        data: Object.freeze({ source: 'github-actions' }),
+      }),
+    }),
+  }),
 ]);
+
+/** Build the request shape for one probe without performing network I/O. */
+export function buildProbeRequest(probe) {
+  const headers = { 'User-Agent': probe.userAgent || USER_AGENT };
+  const request = {
+    method: probe.method || 'GET',
+    headers,
+  };
+  if (probe.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    request.body = JSON.stringify(probe.body);
+  }
+  return request;
+}
 
 /**
  * Classify one completed probe attempt. Returns null when healthy, otherwise a
@@ -91,6 +132,20 @@ export function evaluateProbeResult(probe, result) {
     return `HTTP ${result.status} but body did not contain ${probe.mustInclude}`;
   }
 
+  if (probe.receiptFields) {
+    let receipt;
+    try {
+      receipt = JSON.parse(result.body);
+    } catch {
+      return `HTTP ${result.status} but write receipt was not valid JSON`;
+    }
+    for (const field of probe.receiptFields) {
+      if (typeof receipt?.[field] !== 'string' || receipt[field].trim() === '') {
+        return `HTTP ${result.status} but write receipt missing non-empty string ${field}`;
+      }
+    }
+  }
+
   return null;
 }
 
@@ -106,12 +161,12 @@ async function runProbe(origin, probe) {
   const url = new URL(probe.path, origin).toString();
   try {
     const response = await fetch(url, {
-      headers: { 'User-Agent': USER_AGENT },
+      ...buildProbeRequest(probe),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-    // Only read the body when a probe actually asserts on it — the tracker is
-    // ~4.6 KB, but /api/send responses are not worth buffering.
-    const body = probe.mustInclude ? await response.text() : '';
+    // Only read bodies asserted by a probe — the tracker is ~4.6 KB and the
+    // write canary needs its receipt, while the other /api/send probe does not.
+    const body = probe.mustInclude || probe.receiptFields ? await response.text() : '';
     return { status: response.status, body };
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
@@ -138,10 +193,14 @@ async function runProbeWithRetries(origin, probe) {
 async function main() {
   const origin = process.env.ANALYTICS_COLLECTOR_ORIGIN || DEFAULT_COLLECTOR_ORIGIN;
 
-  const resultsByName = {};
-  for (const probe of COLLECTOR_PROBES) {
-    resultsByName[probe.name] = await runProbeWithRetries(origin, probe);
-  }
+  const resultsByName = Object.fromEntries(
+    await Promise.all(
+      COLLECTOR_PROBES.map(async (probe) => [
+        probe.name,
+        await runProbeWithRetries(origin, probe),
+      ]),
+    ),
+  );
 
   const failures = summarizeProbeFailures(COLLECTOR_PROBES, resultsByName);
   if (failures.length === 0) {

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -43,6 +43,7 @@ type QueuedUmamiCall =
       revision: number;
       retryAttempt: number;
     };
+type IdentifyCall = Extract<QueuedUmamiCall, { kind: 'identify' }>;
 
 const pendingUmamiCalls: QueuedUmamiCall[] = [];
 let umamiLoadScheduled = false;
@@ -50,6 +51,9 @@ let umamiLoadStarted = false;
 let umamiLoadAttempts = 0;
 let latestIdentityRevision = 0;
 let identifyRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let identifyInFlight = false;
+let pendingIdentityCall: IdentifyCall | null = null;
+let identifyDeliveryGeneration = 0;
 
 // ---------------------------------------------------------------------------
 // Type-safe event catalog — every event name lives here.
@@ -176,11 +180,12 @@ function createIdentifyCall(data: Record<string, unknown>): QueuedUmamiCall {
   };
 }
 
-function scheduleIdentityRetry(call: Extract<QueuedUmamiCall, { kind: 'identify' }>): void {
+function scheduleIdentityRetry(call: IdentifyCall): void {
   if (call.revision !== latestIdentityRevision) return;
   if (call.retryAttempt >= UMAMI_IDENTIFY_RETRY_LIMIT) return;
 
   clearScheduledIdentityRetry();
+  const generation = identifyDeliveryGeneration;
   const retryCall = {
     ...call,
     retryAttempt: call.retryAttempt + 1,
@@ -188,6 +193,7 @@ function scheduleIdentityRetry(call: Extract<QueuedUmamiCall, { kind: 'identify'
   const delay = UMAMI_IDENTIFY_RETRY_BASE_DELAY_MS * (2 ** call.retryAttempt);
   identifyRetryTimer = setTimeout(() => {
     identifyRetryTimer = null;
+    if (generation !== identifyDeliveryGeneration) return;
     if (retryCall.revision !== latestIdentityRevision) return;
     if (!sendUmamiCall(retryCall)) {
       queueUmamiCall(retryCall);
@@ -261,24 +267,68 @@ function identifyWithDeliveryObserver(
   }
 }
 
+function finishIdentityDelivery(call: IdentifyCall, generation: number, failed: boolean): void {
+  if (generation !== identifyDeliveryGeneration) return;
+
+  identifyInFlight = false;
+  const nextCall = pendingIdentityCall;
+  pendingIdentityCall = null;
+  if (nextCall) {
+    if (!sendUmamiCall(nextCall)) {
+      queueUmamiCall(nextCall);
+    }
+    return;
+  }
+  if (failed) {
+    scheduleIdentityRetry(call);
+  }
+}
+
+function sendIdentityCall(
+  call: IdentifyCall,
+  umami: NonNullable<Window['umami']>,
+): boolean {
+  // Umami stores each identity field independently with an update-then-create
+  // sequence. Keep a single collector write active and retain only the latest
+  // snapshot received during that write so auth and billing cannot race the
+  // same sessionData key.
+  if (identifyInFlight) {
+    pendingIdentityCall = call;
+    return true;
+  }
+
+  identifyInFlight = true;
+  const generation = identifyDeliveryGeneration;
+  try {
+    const result = identifyWithDeliveryObserver(umami, call.data);
+    if (result && typeof (result as { then?: unknown }).then === 'function') {
+      void Promise.resolve(result).then(
+        () => finishIdentityDelivery(call, generation, false),
+        () => finishIdentityDelivery(call, generation, true),
+      );
+    } else {
+      finishIdentityDelivery(call, generation, false);
+    }
+  } catch {
+    finishIdentityDelivery(call, generation, true);
+  }
+  return true;
+}
+
 function sendUmamiCall(call: QueuedUmamiCall): boolean {
   if (typeof window === 'undefined') return false;
   const umami = window.umami;
   if (!umami) return false;
+  if (call.kind === 'identify') {
+    return sendIdentityCall(call, umami);
+  }
   try {
-    const result: unknown = call.kind === 'track'
-      ? umami.track(call.event, call.data)
-      : identifyWithDeliveryObserver(umami, call.data);
+    const result: unknown = umami.track(call.event, call.data);
     // A tracker promise can reject ASYNCHRONOUSLY on a transient network
-    // failure. For identify, the observer above also turns a swallowed
-    // collector 500 into the same retry signal. Track remains at-most-once:
-    // Umami #4183 can return 500 after committing the event row.
+    // failure. Track remains at-most-once: Umami #4183 can return 500 after
+    // committing the event row.
     if (result && typeof (result as { catch?: unknown }).catch === 'function') {
-      (result as Promise<unknown>).catch(() => {
-        if (call.kind === 'identify') {
-          scheduleIdentityRetry(call);
-        }
-      });
+      void (result as Promise<unknown>).catch(() => {});
     }
     // Durable-delivery contract for the terminal funnel event (#4934
     // round-2 F2): the marker written by trackCheckoutSuccess is cleared
@@ -298,10 +348,6 @@ function sendUmamiCall(call: QueuedUmamiCall): boolean {
     }
     return true;
   } catch {
-    if (call.kind === 'identify') {
-      scheduleIdentityRetry(call);
-      return true;
-    }
     return false;
   }
 }
@@ -576,6 +622,9 @@ export function trackSignOut(): void {
  */
 export function resetAnalyticsForTesting(): void {
   clearScheduledIdentityRetry();
+  identifyDeliveryGeneration += 1;
+  identifyInFlight = false;
+  pendingIdentityCall = null;
   pendingUmamiCalls.length = 0;
   umamiLoadScheduled = false;
   umamiLoadStarted = false;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -13,6 +13,7 @@ import { DODO_PRODUCT_IDS } from '@/config/product-ids.generated';
 import type { ActivationEventName, ActivationStepId } from './pro-activation-state';
 
 const UMAMI_SCRIPT_SRC = 'https://abacus.worldmonitor.app/script.js';
+const UMAMI_IDENTIFY_ENDPOINT = new URL('/api/send', UMAMI_SCRIPT_SRC).href;
 const UMAMI_WEBSITE_ID = 'e8800335-c853-46a8-8497-c993ed2f58bc';
 // data-domains is temporarily reduced to the worldmonitor.app hosts + happy
 // while upstream Umami issue #4183 (https://github.com/umami-software/umami/issues/4183)
@@ -31,15 +32,24 @@ const UMAMI_DOMAINS = 'worldmonitor.app,www.worldmonitor.app,happy.worldmonitor.
 const UMAMI_QUEUE_LIMIT = 50;
 const UMAMI_LOAD_ATTEMPT_LIMIT = 2;
 const UMAMI_LOAD_RETRY_DELAY_MS = 5_000;
+const UMAMI_IDENTIFY_RETRY_LIMIT = 2;
+const UMAMI_IDENTIFY_RETRY_BASE_DELAY_MS = 1_000;
 
 type QueuedUmamiCall =
   | { kind: 'track'; event: UmamiEvent; data?: Record<string, unknown> }
-  | { kind: 'identify'; data: Record<string, unknown> };
+  | {
+      kind: 'identify';
+      data: Record<string, unknown>;
+      revision: number;
+      retryAttempt: number;
+    };
 
 const pendingUmamiCalls: QueuedUmamiCall[] = [];
 let umamiLoadScheduled = false;
 let umamiLoadStarted = false;
 let umamiLoadAttempts = 0;
+let latestIdentityRevision = 0;
+let identifyRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
 // ---------------------------------------------------------------------------
 // Type-safe event catalog — every event name lives here.
@@ -131,10 +141,124 @@ const EVENTS = {
 export type UmamiEvent = keyof typeof EVENTS;
 
 function queueUmamiCall(call: QueuedUmamiCall): void {
+  // Identity is a latest-snapshot write, not an append-only event. Auth and
+  // billing can both publish before the deferred tracker loads; replaying every
+  // intermediate snapshot concurrently is both wasteful and the trigger for
+  // Umami #4183's sessionData race. Keep only the newest queued identity.
+  if (call.kind === 'identify') {
+    for (let index = pendingUmamiCalls.length - 1; index >= 0; index -= 1) {
+      if (pendingUmamiCalls[index]?.kind === 'identify') {
+        pendingUmamiCalls.splice(index, 1);
+      }
+    }
+  }
   if (pendingUmamiCalls.length >= UMAMI_QUEUE_LIMIT) {
     pendingUmamiCalls.shift();
   }
   pendingUmamiCalls.push(call);
+}
+
+function clearScheduledIdentityRetry(): void {
+  if (identifyRetryTimer !== null) {
+    clearTimeout(identifyRetryTimer);
+    identifyRetryTimer = null;
+  }
+}
+
+function createIdentifyCall(data: Record<string, unknown>): QueuedUmamiCall {
+  latestIdentityRevision += 1;
+  clearScheduledIdentityRetry();
+  return {
+    kind: 'identify',
+    data,
+    revision: latestIdentityRevision,
+    retryAttempt: 0,
+  };
+}
+
+function scheduleIdentityRetry(call: Extract<QueuedUmamiCall, { kind: 'identify' }>): void {
+  if (call.revision !== latestIdentityRevision) return;
+  if (call.retryAttempt >= UMAMI_IDENTIFY_RETRY_LIMIT) return;
+
+  clearScheduledIdentityRetry();
+  const retryCall = {
+    ...call,
+    retryAttempt: call.retryAttempt + 1,
+  };
+  const delay = UMAMI_IDENTIFY_RETRY_BASE_DELAY_MS * (2 ** call.retryAttempt);
+  identifyRetryTimer = setTimeout(() => {
+    identifyRetryTimer = null;
+    if (retryCall.revision !== latestIdentityRevision) return;
+    if (!sendUmamiCall(retryCall)) {
+      queueUmamiCall(retryCall);
+    }
+  }, delay);
+}
+
+function isUmamiIdentifyBeacon(input: RequestInfo | URL, init?: RequestInit): boolean {
+  const url = typeof input === 'string'
+    ? input
+    : input instanceof URL
+      ? input.href
+      : input.url;
+  const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+  if (url !== UMAMI_IDENTIFY_ENDPOINT || method.toUpperCase() !== 'POST' || typeof init?.body !== 'string') {
+    return false;
+  }
+  try {
+    return (JSON.parse(init.body) as { type?: unknown }).type === 'identify';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Umami v3.1.0 swallows its own fetch and JSON failures, including HTTP 500s,
+ * so its public identify() promise does not tell us whether the collector
+ * accepted an identity snapshot. Observe just this synchronous beacon while
+ * leaving the native request/promise chain untouched for Umami's cache update.
+ */
+function identifyWithDeliveryObserver(
+  umami: NonNullable<Window['umami']>,
+  data: Record<string, unknown>,
+): unknown {
+  const originalFetch = window.fetch;
+  let observedDelivery: Promise<Response> | undefined;
+  const observedFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (!isUmamiIdentifyBeacon(input, init)) return originalFetch(input, init);
+    try {
+      const result = originalFetch(input, init);
+      const delivery = Promise.resolve(result).then((response) => {
+        if (!response.ok) throw new Error(`Umami identify collector returned HTTP ${response.status}`);
+        return response;
+      });
+      // Keep an unexpected synchronous tracker throw from turning the observer
+      // promise into a separate unhandled rejection. sendUmamiCall still
+      // receives the original rejecting delivery promise below.
+      void delivery.catch(() => {});
+      observedDelivery = delivery;
+      return result;
+    } catch (error) {
+      const delivery = Promise.reject<Response>(error);
+      void delivery.catch(() => {});
+      observedDelivery = delivery;
+      throw error;
+    }
+  }) as typeof window.fetch;
+
+  try {
+    window.fetch = observedFetch;
+  } catch {
+    // A non-writable fetch is not a delivery signal; preserve the native
+    // tracker behavior rather than fabricating a request or failing identity.
+    return umami.identify(data);
+  }
+  try {
+    const nativeResult = umami.identify(data);
+    return observedDelivery ?? nativeResult;
+  } finally {
+    window.fetch = originalFetch;
+  }
 }
 
 function sendUmamiCall(call: QueuedUmamiCall): boolean {
@@ -144,18 +268,17 @@ function sendUmamiCall(call: QueuedUmamiCall): boolean {
   try {
     const result: unknown = call.kind === 'track'
       ? umami.track(call.event, call.data)
-      : umami.identify(call.data);
-    // Umami's track()/identify() return the beacon `fetch()` promise, which
-    // rejects ASYNCHRONOUSLY on a transient network failure — offline, an
-    // ad-blocker extension that wraps window.fetch, or the self-hosted
-    // collector being briefly unreachable. This try/catch only guards a
-    // SYNCHRONOUS throw, so an unhandled rejection would otherwise escape to
-    // onunhandledrejection and surface in Sentry as a bare
-    // `TypeError: Failed to fetch` rooted in whatever first-party code fired
-    // the event (WORLDMONITOR-WW/WX/WY). A dropped analytics beacon is
-    // unactionable — swallow the rejection.
+      : identifyWithDeliveryObserver(umami, call.data);
+    // A tracker promise can reject ASYNCHRONOUSLY on a transient network
+    // failure. For identify, the observer above also turns a swallowed
+    // collector 500 into the same retry signal. Track remains at-most-once:
+    // Umami #4183 can return 500 after committing the event row.
     if (result && typeof (result as { catch?: unknown }).catch === 'function') {
-      (result as Promise<unknown>).catch(() => {});
+      (result as Promise<unknown>).catch(() => {
+        if (call.kind === 'identify') {
+          scheduleIdentityRetry(call);
+        }
+      });
     }
     // Durable-delivery contract for the terminal funnel event (#4934
     // round-2 F2): the marker written by trackCheckoutSuccess is cleared
@@ -175,6 +298,10 @@ function sendUmamiCall(call: QueuedUmamiCall): boolean {
     }
     return true;
   } catch {
+    if (call.kind === 'identify') {
+      scheduleIdentityRetry(call);
+      return true;
+    }
     return false;
   }
 }
@@ -252,14 +379,16 @@ export function identifyUser(
     ...(subStatus != null && { subStatus }),
     ...(planKey != null && { planKey }),
   };
-  if (!sendUmamiCall({ kind: 'identify', data })) {
-    queueUmamiCall({ kind: 'identify', data });
+  const call = createIdentifyCall(data);
+  if (!sendUmamiCall(call)) {
+    queueUmamiCall(call);
   }
 }
 
 export function clearIdentity(): void {
-  if (!sendUmamiCall({ kind: 'identify', data: {} })) {
-    queueUmamiCall({ kind: 'identify', data: {} });
+  const call = createIdentifyCall({});
+  if (!sendUmamiCall(call)) {
+    queueUmamiCall(call);
   }
 }
 
@@ -446,10 +575,12 @@ export function trackSignOut(): void {
  * across the shared module import in tests/secondary-startup.test.mts.
  */
 export function resetAnalyticsForTesting(): void {
+  clearScheduledIdentityRetry();
   pendingUmamiCalls.length = 0;
   umamiLoadScheduled = false;
   umamiLoadStarted = false;
   umamiLoadAttempts = 0;
+  latestIdentityRevision = 0;
 }
 
 export function trackGateHit(feature: string): void {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,11 +2,9 @@
 
 interface Window {
   umami?: {
-    // track()/identify() return the beacon `fetch()` promise from Umami's
-    // internal send(); it rejects ASYNCHRONOUSLY on a network blip. Typed as
-    // the real return (not `void`) so callers can swallow that rejection —
-    // otherwise it escapes to onunhandledrejection as a bare
-    // `TypeError: Failed to fetch` (WORLDMONITOR-WW/WX/WY).
+    // Tracker calls are async. Umami v3.1.0 swallows its internal fetch
+    // failures, while test/extension wrappers can still return a rejecting
+    // promise, so the facade must retain and observe the real return value.
     track: (event: string, data?: Record<string, unknown>) => void | Promise<unknown>;
     identify: (data: Record<string, unknown>) => void | Promise<unknown>;
   };

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -241,4 +241,45 @@ describe('Umami client retry policy (#5715)', () => {
       fakeTimers.restore();
     }
   });
+
+  it('serializes live identity writes and coalesces updates received while one is in flight', async () => {
+    let resolveFirstResponse: ((response: Response) => void) | undefined;
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirstResponse = resolve;
+    });
+    const payloads: Array<{ type: string; data: Record<string, unknown> }> = [];
+    let calls = 0;
+    window.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+      calls += 1;
+      payloads.push(JSON.parse(String(init?.body)));
+      return calls === 1
+        ? firstResponse
+        : Promise.resolve(collectorResponse(true, 200));
+    }) as typeof window.fetch;
+    (globalThis.window as WinWithUmami).umami = {
+      track: (_event: unknown, data?: unknown) => nativeTrackerBeacon('event', (data ?? {}) as Record<string, unknown>),
+      identify: (data: unknown) => nativeTrackerBeacon('identify', data as Record<string, unknown>),
+    };
+
+    identifyUser('user_1', 'free');
+    identifyUser('user_1', 'pro', 'active', 'monthly');
+    identifyUser('user_1', 'pro', 'cancelled', 'annual');
+    await drainPromiseHandlers();
+
+    assert.equal(calls, 1, 'a newer snapshot waits for the active collector write');
+
+    resolveFirstResponse!(collectorResponse(true, 200));
+    await drainPromiseHandlers();
+
+    assert.equal(calls, 2, 'only one coalesced snapshot follows the active write');
+    assert.deepEqual(payloads[1], {
+      type: 'identify',
+      data: {
+        userId: 'user_1',
+        plan: 'pro',
+        subStatus: 'cancelled',
+        planKey: 'annual',
+      },
+    });
+  });
 });

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -5,23 +5,18 @@ import assert from 'node:assert/strict';
  * WORLDMONITOR-WW/WX/WY — `TypeError: Failed to fetch`, onunhandledrejection,
  * 2026-07-20.
  *
- * Umami's `track()` / `identify()` return the beacon `fetch()` promise from
- * their internal send(); that promise rejects ASYNCHRONOUSLY on a transient
- * network failure (offline, an ad-blocker extension that wraps window.fetch —
- * the observed `frame_ant.js` case — or the self-hosted collector being
- * briefly unreachable). `sendUmamiCall`'s `try/catch` only guards a SYNCHRONOUS
- * throw, so the rejection escaped to `onunhandledrejection` and surfaced in
- * Sentry as a bare `TypeError: Failed to fetch` rooted in first-party frames
- * (e.g. applyMapLayerChange → track). A dropped analytics beacon is
- * unactionable; sendUmamiCall must attach a rejection handler to the returned
- * beacon promise so it never leaks.
+ * Umami's native tracker catches fetch/JSON failures internally, including a
+ * non-OK collector response, so its public promise resolves even when the
+ * identity write was not delivered. The facade observes only the synchronous
+ * `/api/send` identify fetch, then keeps native processing intact while it
+ * converts an actual delivery failure into its bounded retry signal.
  *
- * The tests below exercise the real failure mode: `umami.track()` /
- * `identify()` return a genuinely rejected promise, and the test fails if that
- * rejection reaches the process-level `unhandledRejection` hook — the exact
- * path that fed Sentry. Both call kinds are covered because `sendUmamiCall`
- * branches on `call.kind`.
+ * The fake tracker below deliberately has that same catch-and-resolve shape.
+ * The unhandled-rejection coverage remains because the observer must consume
+ * its own delivery promise too.
  */
+
+const UMAMI_SEND_URL = 'https://abacus.worldmonitor.app/api/send';
 
 const _store = new Map<string, string>();
 before(() => {
@@ -33,6 +28,7 @@ before(() => {
         setItem: (k: string, v: string) => { _store.set(k, v); },
         removeItem: (k: string) => { _store.delete(k); },
       },
+      fetch: () => Promise.reject(new TypeError('Failed to fetch')),
     },
   });
 });
@@ -43,11 +39,27 @@ type WinWithUmami = {
   umami?: { track: (...a: unknown[]) => unknown; identify: (...a: unknown[]) => unknown };
 };
 
-/** Install umami stubs whose beacon rejects async, exactly like a failed fetch(). */
+function nativeTrackerBeacon(type: 'event' | 'identify', data: Record<string, unknown> = {}): Promise<unknown> {
+  return window.fetch(UMAMI_SEND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ type, data }),
+  }).then((response) => response.json()).catch(() => undefined);
+}
+
+function collectorResponse(ok: boolean, status: number): Response {
+  return {
+    ok,
+    status,
+    json: async () => ({}),
+  } as Response;
+}
+
+/** Install a v3.1.0-shaped tracker: fetch errors are caught and resolve. */
 function stubFailingUmami(): void {
   (globalThis.window as WinWithUmami).umami = {
-    track: () => Promise.reject(new TypeError('Failed to fetch')),
-    identify: () => Promise.reject(new TypeError('Failed to fetch')),
+    track: (_event: unknown, data?: unknown) => nativeTrackerBeacon('event', (data ?? {}) as Record<string, unknown>),
+    identify: (data: unknown) => nativeTrackerBeacon('identify', data as Record<string, unknown>),
   };
 }
 
@@ -78,6 +90,7 @@ describe('umami beacon rejection is swallowed (WORLDMONITOR-WW/WX/WY)', () => {
   });
 
   afterEach(() => {
+    resetAnalyticsForTesting();
     delete (globalThis.window as WinWithUmami).umami;
   });
 
@@ -87,5 +100,145 @@ describe('umami beacon rejection is swallowed (WORLDMONITOR-WW/WX/WY)', () => {
 
   it('identifyUser(): a failed beacon fetch never escapes to unhandledRejection', async () => {
     await assertNoLeak(() => identifyUser('user_1', 'free'), 'identify');
+  });
+});
+
+type ScheduledTimer = {
+  id: number;
+  callback: () => void;
+  delay: number;
+  cancelled: boolean;
+};
+
+function installFakeTimers(): {
+  timers: ScheduledTimer[];
+  restore: () => void;
+} {
+  const timers: ScheduledTimer[] = [];
+  const savedSetTimeout = Object.getOwnPropertyDescriptor(globalThis, 'setTimeout');
+  const savedClearTimeout = Object.getOwnPropertyDescriptor(globalThis, 'clearTimeout');
+  let nextId = 1;
+
+  Object.defineProperty(globalThis, 'setTimeout', {
+    configurable: true,
+    value: ((callback: () => void, delay = 0) => {
+      const timer = { id: nextId, callback, delay, cancelled: false };
+      nextId += 1;
+      timers.push(timer);
+      return timer.id;
+    }) as typeof setTimeout,
+  });
+  Object.defineProperty(globalThis, 'clearTimeout', {
+    configurable: true,
+    value: ((timerId: number) => {
+      const timer = timers.find((candidate) => candidate.id === timerId);
+      if (timer) timer.cancelled = true;
+    }) as typeof clearTimeout,
+  });
+
+  return {
+    timers,
+    restore: () => {
+      if (savedSetTimeout) Object.defineProperty(globalThis, 'setTimeout', savedSetTimeout);
+      if (savedClearTimeout) Object.defineProperty(globalThis, 'clearTimeout', savedClearTimeout);
+    },
+  };
+}
+
+async function drainPromiseHandlers(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('Umami client retry policy (#5715)', () => {
+  beforeEach(() => {
+    resetAnalyticsForTesting();
+  });
+
+  afterEach(() => {
+    delete (globalThis.window as WinWithUmami).umami;
+  });
+
+  it('retries a swallowed HTTP 500 identity write twice at 1s and 2s, then stops after three failures', async () => {
+    const fakeTimers = installFakeTimers();
+    let calls = 0;
+    const collectorFetch = (() => {
+      calls += 1;
+      return Promise.resolve(collectorResponse(false, 500));
+    }) as typeof window.fetch;
+    window.fetch = collectorFetch;
+    (globalThis.window as WinWithUmami).umami = {
+      track: (_event: unknown, data?: unknown) => nativeTrackerBeacon('event', (data ?? {}) as Record<string, unknown>),
+      identify: (data: unknown) => nativeTrackerBeacon('identify', data as Record<string, unknown>),
+    };
+
+    try {
+      identifyUser('user_1', 'pro');
+      await drainPromiseHandlers();
+      assert.equal(calls, 1);
+      assert.equal(window.fetch, collectorFetch, 'the synchronous delivery observer restores window.fetch');
+      assert.equal(fakeTimers.timers[0]?.delay, 1_000);
+
+      fakeTimers.timers[0]!.callback();
+      await drainPromiseHandlers();
+      assert.equal(calls, 2);
+      assert.equal(fakeTimers.timers[1]?.delay, 2_000);
+
+      fakeTimers.timers[1]!.callback();
+      await drainPromiseHandlers();
+      assert.equal(calls, 3);
+      assert.equal(fakeTimers.timers.length, 2, 'the terminal failed attempt schedules no third timer');
+    } finally {
+      fakeTimers.restore();
+    }
+  });
+
+  it('never retries track calls because an Umami 500 may already have committed the event row', async () => {
+    const fakeTimers = installFakeTimers();
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return Promise.resolve(collectorResponse(false, 500));
+    }) as typeof window.fetch;
+    (globalThis.window as WinWithUmami).umami = {
+      track: (_event: unknown, data?: unknown) => nativeTrackerBeacon('event', (data ?? {}) as Record<string, unknown>),
+      identify: (data: unknown) => nativeTrackerBeacon('identify', data as Record<string, unknown>),
+    };
+
+    try {
+      track('checkout-success', { source: 'url-return' });
+      await drainPromiseHandlers();
+      assert.equal(calls, 1);
+      assert.deepEqual(fakeTimers.timers, []);
+    } finally {
+      fakeTimers.restore();
+    }
+  });
+
+  it('cancels a stale retry when a newer identity snapshot is sent', async () => {
+    const fakeTimers = installFakeTimers();
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return Promise.resolve(collectorResponse(calls !== 1, calls === 1 ? 500 : 200));
+    }) as typeof window.fetch;
+    (globalThis.window as WinWithUmami).umami = {
+      track: (_event: unknown, data?: unknown) => nativeTrackerBeacon('event', (data ?? {}) as Record<string, unknown>),
+      identify: (data: unknown) => nativeTrackerBeacon('identify', data as Record<string, unknown>),
+    };
+
+    try {
+      identifyUser('user_1', 'free');
+      await drainPromiseHandlers();
+      assert.equal(fakeTimers.timers.length, 1);
+
+      identifyUser('user_1', 'pro');
+      await drainPromiseHandlers();
+      assert.equal(calls, 2);
+      assert.equal(fakeTimers.timers[0]!.cancelled, true);
+    } finally {
+      fakeTimers.restore();
+    }
   });
 });

--- a/tests/analytics-collector-monitor.test.mjs
+++ b/tests/analytics-collector-monitor.test.mjs
@@ -3,7 +3,9 @@ import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 import {
+  ANALYTICS_CANARY_WEBSITE_ID,
   COLLECTOR_PROBES,
+  buildProbeRequest,
   evaluateProbeResult,
   summarizeProbeFailures,
 } from '../scripts/check-analytics-collector.mjs';
@@ -22,11 +24,18 @@ describe('scheduled analytics collector monitor', () => {
       null,
     );
     assert.equal(evaluateProbeResult(probeByName('ingest-route'), { status: 405 }), null);
+    assert.equal(
+      evaluateProbeResult(probeByName('write-canary'), {
+        status: 200,
+        body: JSON.stringify({ cache: 'cache-id', sessionId: 'session-id', visitId: 'visit-id' }),
+      }),
+      null,
+    );
   });
 
   it('alerts on the exact failure signature of the 4-day outage', () => {
     // Cloudflare 502 after the origin OOM-died, on every path.
-    for (const name of ['heartbeat', 'tracker-script', 'ingest-route']) {
+    for (const name of ['heartbeat', 'tracker-script', 'ingest-route', 'write-canary']) {
       assert.match(evaluateProbeResult(probeByName(name), { status: 502 }), /HTTP 502/);
     }
     assert.match(
@@ -35,13 +44,27 @@ describe('scheduled analytics collector monitor', () => {
     );
   });
 
-  it('never POSTs to the ingest route, so probing writes no synthetic events', () => {
-    const source = readFileSync(
-      new URL('../scripts/check-analytics-collector.mjs', import.meta.url),
-      'utf8',
-    );
-    assert.doesNotMatch(source, /method:\s*['"]POST['"]/i);
+  it('POSTs one synthetic event only to the dedicated canary website', () => {
     assert.equal(probeByName('ingest-route').path, '/api/send');
+    assert.equal(buildProbeRequest(probeByName('ingest-route')).method, 'GET');
+
+    const writeCanary = probeByName('write-canary');
+    assert.equal(writeCanary.path, '/api/send');
+    const request = buildProbeRequest(writeCanary);
+    assert.equal(request.method, 'POST');
+    assert.equal(request.headers['Content-Type'], 'application/json');
+    assert.match(request.headers['User-Agent'], /^Mozilla\/5\.0 /);
+
+    const body = JSON.parse(request.body);
+    assert.equal(body.type, 'event');
+    assert.equal(body.payload.website, ANALYTICS_CANARY_WEBSITE_ID);
+    assert.equal(body.payload.hostname, 'analytics-canary.worldmonitor.app');
+    assert.equal(body.payload.name, 'collector-write-canary');
+    assert.notEqual(
+      ANALYTICS_CANARY_WEBSITE_ID,
+      'e8800335-c853-46a8-8497-c993ed2f58bc',
+      'the monitor must never pollute the product analytics website',
+    );
   });
 
   it('blames the probe, not the collector, when the WAF rejects the User-Agent', () => {
@@ -61,17 +84,31 @@ describe('scheduled analytics collector monitor', () => {
     assert.match(reason, /did not contain \/api\/send/);
   });
 
+  it('rejects bot-filtered and malformed write-canary receipts despite HTTP 200', () => {
+    const writeCanary = probeByName('write-canary');
+    assert.match(
+      evaluateProbeResult(writeCanary, { status: 200, body: '{"beep":"boop"}' }),
+      /receipt missing non-empty string cache/,
+    );
+    assert.match(
+      evaluateProbeResult(writeCanary, { status: 200, body: '{not json' }),
+      /receipt was not valid JSON/,
+    );
+  });
+
   it('reports every failing probe, in probe order, and nothing else', () => {
     const failures = summarizeProbeFailures(COLLECTOR_PROBES, {
       heartbeat: { status: 502 },
       'tracker-script': { status: 200, body: 'posts to /api/send' },
       'ingest-route': { error: 'fetch failed' },
+      'write-canary': { status: 500 },
     });
     assert.deepEqual(
       failures.map((failure) => failure.name),
-      ['heartbeat', 'ingest-route'],
+      ['heartbeat', 'ingest-route', 'write-canary'],
     );
     assert.match(failures[1].reason, /fetch failed/);
+    assert.match(failures[2].reason, /HTTP 500/);
   });
 
   it('refuses malformed probes and results instead of passing them', () => {
@@ -90,7 +127,7 @@ describe('scheduled analytics collector monitor', () => {
     );
 
     assert.match(workflow, /schedule:/);
-    assert.match(workflow, /cron:\s*['"]\*\/15 \* \* \* \*['"]/);
+    assert.match(workflow, /cron:\s*['"]\*\/5 \* \* \* \*['"]/);
     assert.match(workflow, /actions\/setup-node@[a-f0-9]+/);
     assert.match(workflow, /node-version:\s*['"]24['"]/);
     assert.match(workflow, /node scripts\/check-analytics-collector\.mjs/);

--- a/tests/secondary-startup.test.mts
+++ b/tests/secondary-startup.test.mts
@@ -159,6 +159,7 @@ describe('deferred Umami loader', () => {
       const analytics = await import('../src/services/analytics.ts');
       analytics.track('search-open', { source: 'desktop' });
       analytics.identifyUser('user_1', 'free', null, null);
+      analytics.identifyUser('user_1', 'pro', null, null);
       await analytics.initAnalytics();
 
       assert.equal(appendedScripts.length, 1);
@@ -186,7 +187,7 @@ describe('deferred Umami loader', () => {
 
       assert.deepEqual(calls, [
         { kind: 'track', name: 'search-open', data: { source: 'desktop' } },
-        { kind: 'identify', data: { userId: 'user_1', plan: 'free' } },
+        { kind: 'identify', data: { userId: 'user_1', plan: 'pro' } },
       ]);
     } finally {
       delete (globalThis as { window?: unknown }).window;


### PR DESCRIPTION
## Summary

Analytics outages can no longer stay green behind a mounted-but-broken ingest route: the scheduled monitor now proves a database-backed write every five minutes and accepts only a normal Umami receipt. The synthetic event uses a dedicated canary website, so it does not contaminate World Monitor's product funnels, and its browser-shaped request cannot pass through Umami's bot-only `{"beep":"boop"}` response.

Identity snapshots now get two bounded delivery retries at 1s and 2s when the deployed Umami tracker swallows a transport failure or non-OK response. Newer auth or billing state supersedes stale retries. Event tracking remains at-most-once because the upstream session-data race can return HTTP 500 after an event row has already committed.

Railway showed 2,461 Prisma `P2002` failures in `sessionData.updateMany()` during the incident window, with no matching restart or deployment. This is consistent with the still-open upstream Umami race: https://github.com/umami-software/umami/issues/4183

## Validation

- Production canary: all four live collector probes passed, including a real write receipt.
- Relevant analytics suites: 83 assertions passed before final review; the post-rebase focused seam passed 27/27.
- Full data corpus and `VITE_VARIANT=full` production build passed; built-output dashboard CSS assertions passed 9/9.
- Frontend and API typechecks passed.
- Repository lint gates passed; remaining warnings are pre-existing and outside this diff.

## Post-deploy monitoring

- Watch the five-minute `Analytics Collector Monitor` workflow for four-probe success and alert on any non-200 or invalid write receipt.
- Watch Railway `umami` logs for `/api/send`, Prisma `P2002`, and `sessionData.updateMany()` failures for the first 24 hours and review the seven-day trend.
- If the canary fails, treat it as collector/data-health degradation even when the deployment itself is healthy; do not retry ordinary event beacons.
- Owner: World Monitor maintainer/on-call.

Fixes #5715.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
