### PR TITLE
fix(auth): bound Clerk token cache by the token's own expiry

### DIFF
--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -493,8 +493,9 @@ export function clearClerkTokenCache(): void {
  * Uses the 'convex' JWT template which includes the `plan` claim.
  * Returns null if no active session.
  *
- * Tokens are cached for 50s (Clerk tokens expire at 60s) with in-flight
- * deduplication to prevent concurrent panels from racing against Clerk.
+ * Tokens are cached with in-flight deduplication to prevent concurrent panels
+ * from racing against Clerk, bounded by BOTH the flat TTL below and the token's
+ * own `exp` (see shouldReuseCachedClerkToken — the TTL alone is not enough).
  * A monotonic _tokenGen counter lets clearClerkTokenCache() invalidate
  * any mid-flight fetch whose result would otherwise paint the previous
  * user's JWT into the new session.
@@ -505,8 +506,66 @@ let _tokenInflight: Promise<string | null> | null = null;
 let _tokenGen = 0;
 const TOKEN_CACHE_TTL_MS = 50_000;
 
+/**
+ * How long before a token's own `exp` we stop reusing it.
+ *
+ * `server/auth-session.ts` verifies with `jose`'s `jwtVerify` and sets no
+ * `clockTolerance`, so an `exp` in the past is a hard 401. This margin is the
+ * only thing absorbing client/server clock skew plus the request's flight time.
+ */
+const TOKEN_EXPIRY_SAFETY_MARGIN_MS = 10_000;
+
+/**
+ * The `exp` claim of a Clerk JWT as epoch ms, or null when it cannot be read.
+ *
+ * Null (rather than throwing, or assuming expiry) keeps an unreadable token on
+ * the flat-TTL path — the behaviour that predates this function — so a Clerk
+ * token-format change degrades to the old caching instead of signing everyone
+ * out. Reading `exp` needs no signature check: the server is the authority, and
+ * a forged `exp` can only make this client refresh sooner.
+ */
+export function clerkTokenExpiresAtMs(token: string | null): number | null {
+  const payload = token?.split('.')[1];
+  if (!payload) return null;
+  try {
+    const b64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const exp = (
+      JSON.parse(atob(b64 + '='.repeat((4 - (b64.length % 4)) % 4))) as { exp?: unknown }
+    ).exp;
+    return typeof exp === 'number' && Number.isFinite(exp) ? exp * 1_000 : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the cached token can still sign a request. Both bounds must hold.
+ *
+ * The TTL alone was the bug (Sentry WORLDMONITOR-XR/XQ): Clerk's `getToken()`
+ * is stale-while-revalidate — within 15s of expiry it returns the CACHED token
+ * immediately and refreshes in the background — so the premise this cache was
+ * built on ("Clerk tokens expire at 60s", i.e. every token arrives fresh) does
+ * not hold. Stamping a token that had 12s left with a flat 50s TTL left ~38s in
+ * which every request it signed came back 401, healing only when the TTL lapsed.
+ *
+ * The TTL is still enforced on top: it is what bounds how long a session that
+ * was revoked but not yet expired keeps working.
+ */
+export function shouldReuseCachedClerkToken(input: {
+  token: string | null;
+  cachedAt: number;
+  now: number;
+}): boolean {
+  const { token, cachedAt, now } = input;
+  if (!token) return false;
+  if (now - cachedAt >= TOKEN_CACHE_TTL_MS) return false;
+  const expiresAt = clerkTokenExpiresAtMs(token);
+  if (expiresAt === null) return true;
+  return now < expiresAt - TOKEN_EXPIRY_SAFETY_MARGIN_MS;
+}
+
 export async function getClerkToken(): Promise<string | null> {
-  if (_cachedToken && Date.now() - _cachedTokenAt < TOKEN_CACHE_TTL_MS) {
+  if (shouldReuseCachedClerkToken({ token: _cachedToken, cachedAt: _cachedTokenAt, now: Date.now() })) {
     return _cachedToken;
   }
   if (_tokenInflight) return _tokenInflight;

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -25,6 +25,7 @@ import type { Clerk } from '@clerk/clerk-js';
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 
 type ClerkInstance = Clerk;
+type ClerkSession = NonNullable<ClerkInstance['session']>;
 
 function readPublishableKey(): string | undefined {
   try {
@@ -564,6 +565,12 @@ export function shouldReuseCachedClerkToken(input: {
   return now < expiresAt - TOKEN_EXPIRY_SAFETY_MARGIN_MS;
 }
 
+async function fetchClerkToken(session: ClerkSession, skipCache = false): Promise<string | null> {
+  const cacheOptions = skipCache ? { skipCache: true } : {};
+  return (await session.getToken({ template: 'convex', ...cacheOptions }).catch(() => null))
+    ?? await session.getToken(cacheOptions).catch(() => null);
+}
+
 export async function getClerkToken(): Promise<string | null> {
   if (shouldReuseCachedClerkToken({ token: _cachedToken, cachedAt: _cachedTokenAt, now: Date.now() })) {
     return _cachedToken;
@@ -585,17 +592,25 @@ export async function getClerkToken(): Promise<string | null> {
     try {
       // Try the 'convex' template first (includes plan claim for faster server-side checks).
       // Fall back to the standard session token if the template isn't configured in Clerk.
-      const token = (await session.getToken({ template: 'convex' }).catch(() => null))
-        ?? await session.getToken().catch(() => null);
+      let token = await fetchClerkToken(session);
+      const firstFetchedAt = Date.now();
+      if (token && !shouldReuseCachedClerkToken({ token, cachedAt: firstFetchedAt, now: firstFetchedAt })) {
+        // Clerk may return a near-expiry cached token while refreshing it in the
+        // background. The initiating caller must not receive that stale token:
+        // force one server refresh, then accept only a token outside the margin.
+        token = await fetchClerkToken(session, true);
+      }
       // If the session generation advanced while getToken() was in
       // flight, this JWT belongs to the previous user. Drop it on the
       // floor — do not cache, do not return.
       if (myGen !== _tokenGen) return null;
-      if (token) {
+      const fetchedAt = Date.now();
+      if (shouldReuseCachedClerkToken({ token, cachedAt: fetchedAt, now: fetchedAt })) {
         _cachedToken = token;
-        _cachedTokenAt = Date.now();
+        _cachedTokenAt = fetchedAt;
+        return token;
       }
-      return token;
+      return null;
     } catch {
       return null;
     } finally {
@@ -608,6 +623,11 @@ export async function getClerkToken(): Promise<string | null> {
   })();
   _tokenInflight = promise;
   return promise;
+}
+
+export function __setClerkInstanceForTests(instance: ClerkInstance | null): void {
+  clerkInstance = instance;
+  clearClerkTokenCache();
 }
 
 

--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -23,15 +23,21 @@
  * The truth table below is the bound; `honours a near-expiry token from Clerk's
  * stale-while-revalidate path` is the case that was live in production.
  */
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  __setClerkInstanceForTests,
   clerkTokenExpiresAtMs,
+  getClerkToken,
   shouldReuseCachedClerkToken,
 } from '../src/services/clerk.ts';
 
 const NOW = 1_760_000_000_000;
+
+afterEach(() => {
+  __setClerkInstanceForTests(null);
+});
 
 /** A JWT whose payload carries `exp`, the only claim this cache decision reads. */
 function tokenExpiringAt(expMs: number): string {
@@ -133,5 +139,38 @@ describe('shouldReuseCachedClerkToken', () => {
 
   it('never reuses a missing token', () => {
     assert.equal(shouldReuseCachedClerkToken({ token: null, cachedAt: NOW, now: NOW }), false);
+  });
+});
+
+describe('getClerkToken', () => {
+  it('forces a refresh instead of returning Clerk\'s near-expiry cached token', async () => {
+    const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
+    const refreshed = tokenExpiringAt(Date.now() + 60_000);
+    const calls: Array<{ template?: string; skipCache?: boolean }> = [];
+    const tokens = [nearExpiry, refreshed];
+    const session = {
+      async getToken(options: { template?: string; skipCache?: boolean } = {}) {
+        calls.push(options);
+        return tokens.shift() ?? null;
+      },
+    };
+    __setClerkInstanceForTests({ session } as never);
+
+    assert.equal(await getClerkToken(), refreshed);
+    assert.deepEqual(calls, [
+      { template: 'convex' },
+      { template: 'convex', skipCache: true },
+    ]);
+  });
+
+  it('returns null when a forced refresh still yields a near-expiry token', async () => {
+    const session = {
+      async getToken() {
+        return tokenExpiringAt(Date.now() + 5_000);
+      },
+    };
+    __setClerkInstanceForTests({ session } as never);
+
+    assert.equal(await getClerkToken(), null);
   });
 });

--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -1,0 +1,137 @@
+/**
+ * The Clerk token cache must respect the token's OWN expiry, not just a flat TTL.
+ *
+ * Why this exists (Sentry WORLDMONITOR-XR / XQ, 2026-07-27): a Pro user's
+ * session lost its identity on two unrelated endpoints inside the same second —
+ * `/api/notification-channels` answered 401 and the gateway logged
+ * `/api/intelligence/v1/classify-event` 401 with `customer_id` NULL — bracketed
+ * by authenticated 429s for the same `customer_id` a minute either side. So the
+ * session was alive; one short window of requests carried a token the server
+ * rejected, and it healed on its own.
+ *
+ * The mechanism is a stacked pair of caches. Clerk's `session.getToken()` is
+ * stale-while-revalidate (documented: "when a token is within 15 seconds of
+ * expiration, getToken() returns the valid cached token immediately" and
+ * refreshes in the background). `getClerkToken()` then stamped whatever it got
+ * with a flat 50s TTL, on the premise recorded in its own comment — "Tokens are
+ * cached for 50s (Clerk tokens expire at 60s)" — which assumes every token
+ * arrives freshly minted. A token handed over with 12s of life left was
+ * therefore served for 50s, and the ~38s remainder is dead: `server/auth-session.ts`
+ * verifies with `jose` `jwtVerify` and sets no `clockTolerance`, so an expired
+ * `exp` is a hard 401.
+ *
+ * The truth table below is the bound; `honours a near-expiry token from Clerk's
+ * stale-while-revalidate path` is the case that was live in production.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  clerkTokenExpiresAtMs,
+  shouldReuseCachedClerkToken,
+} from '../src/services/clerk.ts';
+
+const NOW = 1_760_000_000_000;
+
+/** A JWT whose payload carries `exp`, the only claim this cache decision reads. */
+function tokenExpiringAt(expMs: number): string {
+  const payload = Buffer.from(JSON.stringify({ sub: 'user_1', exp: Math.floor(expMs / 1_000) }))
+    .toString('base64url');
+  return `header.${payload}.signature`;
+}
+
+describe('clerkTokenExpiresAtMs', () => {
+  it('reads the exp claim as epoch milliseconds', () => {
+    assert.equal(clerkTokenExpiresAtMs(tokenExpiringAt(NOW + 60_000)), NOW + 60_000);
+  });
+
+  it('returns null for a token with no exp claim', () => {
+    const payload = Buffer.from(JSON.stringify({ sub: 'user_1' })).toString('base64url');
+    assert.equal(clerkTokenExpiresAtMs(`header.${payload}.signature`), null);
+  });
+
+  it('returns null rather than throwing on a malformed token', () => {
+    for (const bad of [null, '', 'not-a-jwt', 'header..signature', 'a.!!!not-base64!!!.c']) {
+      assert.equal(clerkTokenExpiresAtMs(bad as string | null), null);
+    }
+  });
+});
+
+describe('shouldReuseCachedClerkToken', () => {
+  it('reuses a freshly minted token well inside both bounds', () => {
+    assert.equal(
+      shouldReuseCachedClerkToken({
+        token: tokenExpiringAt(NOW + 50_000),
+        cachedAt: NOW - 10_000,
+        now: NOW,
+      }),
+      true,
+    );
+  });
+
+  // The production bug. Clerk's stale-while-revalidate hands back a token with
+  // 12s left; the flat 50s TTL alone would still call this cache entry fresh
+  // 20s later, and every request it signs would 401.
+  it('honours a near-expiry token from Clerk\'s stale-while-revalidate path', () => {
+    assert.equal(
+      shouldReuseCachedClerkToken({
+        token: tokenExpiringAt(NOW - 8_000), // expired 8s ago
+        cachedAt: NOW - 20_000, // ...but only 20s into the 50s TTL
+        now: NOW,
+      }),
+      false,
+    );
+  });
+
+  it('stops reusing a token before it expires, to absorb clock skew and flight time', () => {
+    // 8s of life left is inside the safety margin: the server verifies at zero
+    // clock tolerance, so a client clock running fast would 401 on this.
+    assert.equal(
+      shouldReuseCachedClerkToken({
+        token: tokenExpiringAt(NOW + 8_000),
+        cachedAt: NOW - 1_000,
+        now: NOW,
+      }),
+      false,
+    );
+    // 20s of life left is comfortably outside it.
+    assert.equal(
+      shouldReuseCachedClerkToken({
+        token: tokenExpiringAt(NOW + 20_000),
+        cachedAt: NOW - 1_000,
+        now: NOW,
+      }),
+      true,
+    );
+  });
+
+  it('still enforces the flat TTL for a long-lived token', () => {
+    // An hour of validity must not defeat the TTL — it is what bounds how long
+    // a revoked-but-unexpired session keeps working.
+    assert.equal(
+      shouldReuseCachedClerkToken({
+        token: tokenExpiringAt(NOW + 3_600_000),
+        cachedAt: NOW - 60_000,
+        now: NOW,
+      }),
+      false,
+    );
+  });
+
+  it('falls back to the flat TTL when exp cannot be read', () => {
+    // A Clerk token-format change must degrade to the previous behaviour, not
+    // sign every user out.
+    assert.equal(
+      shouldReuseCachedClerkToken({ token: 'opaque-token', cachedAt: NOW - 10_000, now: NOW }),
+      true,
+    );
+    assert.equal(
+      shouldReuseCachedClerkToken({ token: 'opaque-token', cachedAt: NOW - 60_000, now: NOW }),
+      false,
+    );
+  });
+
+  it('never reuses a missing token', () => {
+    assert.equal(shouldReuseCachedClerkToken({ token: null, cachedAt: NOW, now: NOW }), false);
+  });
+});


### PR DESCRIPTION
## Summary

Signed-in Pro users could intermittently lose premium access for tens of seconds and then recover on their own, with nothing wrong on the account or the endpoint — a step in the day-0 activation wizard failing, AI classification pausing itself for 120 s after a 401.

The cause is two caches stacked. Clerk's `session.getToken()` is stale-while-revalidate: within 15 s of expiry it returns the *cached* token immediately and refreshes in the background. `getClerkToken()` then stamped whatever it received with a flat 50 s TTL, on the premise written into its own comment — *"Tokens are cached for 50s (Clerk tokens expire at 60s)"* — which assumes every token arrives freshly minted. When our refresh lands inside Clerk's stale window we cache a token with ≤15 s of life and keep serving it for the full 50 s. The remainder signs requests the server rejects outright: `server/auth-session.ts` verifies with `jose`'s `jwtVerify` and sets no `clockTolerance`, so an expired `exp` is a hard 401.

Reuse is now bounded by **both** the flat TTL and the token's own `exp`, minus a 10 s margin for clock skew and flight time.

## How this was traced

Sentry alone pointed at the endpoints (`WORLDMONITOR-XR`/`XQ`, one Pro user, two unrelated endpoints 401ing inside the same second). Joining that user's IP to Axiom `wm_api_usage` is what localised it to the credential — `/api/intelligence/v1/classify-event`:

```
16:03:21  429  customer_id=user_3Goez…  plan_key=pro_monthly
16:04:22  401  customer_id=NULL         plan_key=NULL          <- identity lost
16:06:22  429  customer_id=user_3Goez…  plan_key=pro_monthly   <- healed by itself
```

Identity lost for a short window and then restored, bracketed by authenticated requests, is a client credential-cache signature — an endpoint or entitlement fault would not repair itself, and an outage would have hit neighbouring routes too.

## Two decisions worth a look

- **The TTL stays on top of the `exp` bound.** It does a different job: it caps how long a session that was *revoked but not yet expired* keeps working. Dropping it in favour of `exp` alone would widen that window to the token's full lifetime.
- **An unreadable token falls back to the flat TTL** rather than being treated as expired, so a Clerk token-format change degrades to today's behaviour instead of signing everyone out. Reading `exp` needs no signature check — the server is the authority, and a forged `exp` can only make this client refresh sooner.

## Validation

`tsc --noEmit` and biome clean; 284/284 clerk-touching tests and the full unit suite (17,681) pass.

The 9 new tests were written red-first, then **mutation-tested**: dropping the `exp` bound turns exactly 2 red, dropping the TTL bound turns a different 2 red. Both bounds are therefore independently load-bearing rather than one masking the other.

Not verified in production — the causal link between this defect and that specific 401 is inferred from the trace above, not proven. The defect itself is proven independently by the tests.

Related: #5752 — the server sets no `clockTolerance`, so a client whose clock runs fast still 401s on a validly-issued token. This fix cannot close that (the reuse decision uses the client's own clock), and adding tolerance widens the replay window for a leaked token, so it is filed as a deliberate call rather than folded in here.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
