### PR TITLE
fix(prefs): serialize cloud preference writes

### DIFF
--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -29,6 +29,8 @@ import {
   rearmTemporaryCloudPrefsRetry,
 } from './cloud-prefs-retry';
 import { applyObservableCloudPrefsFlushSuccess } from './cloud-prefs-flush';
+import { SerializedAsyncQueue } from './serialized-async-queue';
+import { TimeoutError, withTimeout } from './with-timeout';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 export { isTemporaryCloudPrefsStatus, parseRetryAfterSeconds } from './cloud-prefs-retry';
@@ -57,6 +59,7 @@ const KEY_DIRTY_KEYS = 'wm-cloud-prefs-dirty-keys';
 const KEY_LOCAL_SCHEMA_VERSION = 'wm-cloud-prefs-local-schema-version';
 
 const CURRENT_PREFS_SCHEMA_VERSION = 2;
+const CLOUD_PREFS_REQUEST_TIMEOUT_MS = 15_000;
 
 // Migrations live in cloud-prefs-migrations.ts to keep them testable —
 // cloud-prefs-sync.ts has a transitive `import.meta.env.DEV` dep via
@@ -166,15 +169,9 @@ function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
 
 let _retryTimer: ReturnType<typeof setTimeout> | null = null;
 let _authGeneration = 0;
-
-// Count of uploadNow calls currently in their async phase. `_debounceTimer`
-// alone can't tell "no upload of any kind in progress" — the debounce
-// callback nulls the timer synchronously BEFORE uploadNow starts awaiting,
-// so a late flush response checking only the timer would claim 'synced'
-// mid-upload (and observers would see a synced → conflict/error regression
-// if that upload then fails). onSignIn doesn't need this: it bumps
-// _authGeneration on entry, which already makes stale flush handlers bail.
-let _uploadsInFlight = 0;
+const _syncOperations = new SerializedAsyncQueue();
+let _activeUploadPromise: Promise<void> | null = null;
+let _queuedUploadVariant = 'full';
 
 function clearRetryTimer(): void {
   if (_retryTimer !== null) {
@@ -356,10 +353,36 @@ export class ServiceUnavailableError extends Error {
   }
 }
 
+function asTemporaryCloudPrefsError(error: unknown): never {
+  const name = (error as { name?: unknown } | null)?.name;
+  if (error instanceof TimeoutError || name === 'TimeoutError' || name === 'AbortError') {
+    throw new ServiceUnavailableError(parseRetryAfterSeconds(new Headers()), 504);
+  }
+  throw error;
+}
+
+async function getCloudPrefsToken(): Promise<string | null> {
+  try {
+    return await withTimeout(
+      getClerkToken(),
+      CLOUD_PREFS_REQUEST_TIMEOUT_MS,
+      'cloud prefs token',
+    );
+  } catch (error) {
+    return asTemporaryCloudPrefsError(error);
+  }
+}
+
 async function fetchCloudPrefs(token: string, variant: string): Promise<CloudPrefs | null> {
-  const res = await fetch(`/api/user-prefs?variant=${encodeURIComponent(variant)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  let res: Response;
+  try {
+    res = await fetch(`/api/user-prefs?variant=${encodeURIComponent(variant)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(CLOUD_PREFS_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    return asTemporaryCloudPrefsError(error);
+  }
   if (res.status === 401) return null;
   if (isTemporaryCloudPrefsStatus(res.status)) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers), res.status);
   if (!res.ok) throw new Error(`fetch prefs: ${res.status}`);
@@ -372,14 +395,20 @@ async function postCloudPrefs(
   data: Record<string, string>,
   expectedSyncVersion: number,
 ): Promise<{ syncVersion: number } | { conflict: true; actualSyncVersion?: number }> {
-  const res = await fetch('/api/user-prefs', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ variant, data, expectedSyncVersion, schemaVersion: CURRENT_PREFS_SCHEMA_VERSION }),
-  });
+  let res: Response;
+  try {
+    res = await fetch('/api/user-prefs', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ variant, data, expectedSyncVersion, schemaVersion: CURRENT_PREFS_SCHEMA_VERSION }),
+      signal: AbortSignal.timeout(CLOUD_PREFS_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    return asTemporaryCloudPrefsError(error);
+  }
   if (res.status === 409) {
     // Server now echoes the row's current syncVersion in the 409 body
     // (when available) so we can advance local state without a follow-up
@@ -410,6 +439,7 @@ async function postCloudPrefs(
  */
 async function resolveConflictWithMerge(token: string, variant: string, callerGeneration: number): Promise<boolean> {
   const fresh = await fetchCloudPrefs(token, variant);
+  if (_authGeneration !== callerGeneration) return false;
   if (!fresh) {
     setState('error');
     return false;
@@ -420,6 +450,7 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   setSyncVersion(fresh.syncVersion);
   setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
   const retry = await postCloudPrefs(token, variant, merged, fresh.syncVersion);
+  if (_authGeneration !== callerGeneration) return false;
   if ('conflict' in retry) {
     setState('conflict');
     return false;
@@ -428,7 +459,6 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   // signed-in user switched during the awaits above, do not clear/persist
   // settled dirty keys — _dirtyKeys now belongs to another user and the
   // write would durably corrupt their persisted dirty-key entry.
-  if (_authGeneration !== callerGeneration) return false;
   setSyncVersion(retry.syncVersion);
   clearSettledDirtyKeys(merged);
   Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
@@ -436,8 +466,8 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   return true;
 }
 
-export async function onSignIn(userId: string, variant: string): Promise<void> {
-  if (!isEnabled()) return;
+export function onSignIn(userId: string, variant: string): Promise<void> {
+  if (!isEnabled()) return Promise.resolve();
 
   // New onSignIn entry — invalidate any pending 503 retry so a stale
   // closure can't fire mid-flight, and bump generation so any timer that
@@ -446,116 +476,140 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
   clearRetryTimer();
   _authGeneration += 1;
   const myGeneration = _authGeneration;
+  // Establish dirty-key ownership synchronously. Preference writes may happen
+  // while this sign-in waits behind an older queued writer; hydrating inside
+  // the queued callback would then clear those new edits or attribute them to
+  // the previous account.
   hydrateDirtyKeysFromStorage(userId);
 
-  _currentVariant = variant;
-  setState('syncing');
+  return _syncOperations.run(async () => {
+    if (_authGeneration !== myGeneration) return;
 
-  const token = await getClerkToken();
-  if (!token) { setState('error'); return; }
-  _cachedToken = token;
+    _currentVariant = variant;
+    setState('syncing');
 
-  try {
-    const cloud = await fetchCloudPrefs(token, variant);
+    try {
+      const token = await getCloudPrefsToken();
+      if (_authGeneration !== myGeneration) return;
+      if (!token) { setState('error'); return; }
+      _cachedToken = token;
 
-    if (cloud && cloud.syncVersion > getSyncVersion()) {
-      const isFirstEverSync = getSyncVersion() === 0;
-      const prevBlobJson = isFirstEverSync ? JSON.stringify(buildCloudBlob()) : null;
+      const cloud = await fetchCloudPrefs(token, variant);
+      if (_authGeneration !== myGeneration) return;
 
-      const migrated = applyMigrations(cloud.data, cloud.schemaVersion ?? 1);
-      const migrationChanged = (cloud.schemaVersion ?? 1) < CURRENT_PREFS_SCHEMA_VERSION;
-      // Cloud is ahead, but the user may have un-uploaded local edits — e.g.
-      // onSignIn re-fired by a 503 retry after the user changed a pref. Merge
-      // those dirty keys over the cloud blob instead of clobbering them.
-      const hasDirty = _dirtyKeys.size > 0;
-      const toApply = hasDirty
-        ? mergeCloudWithLocalDirty(migrated, buildCloudBlob(), _dirtyKeys)
-        : migrated;
-      applyCloudBlob(toApply);
-      setSyncVersion(cloud.syncVersion);
-      // After applyCloudBlob, local data IS at CURRENT schema (applyMigrations
-      // ran every step from cloud.schemaVersion to CURRENT). Mark it so the
-      // post paths don't redundantly re-run migrations on already-clean data.
-      setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
-      // Force an upload when the cloud row's schemaVersion is behind (so it
-      // catches up — otherwise the migration re-runs every load) OR when we
-      // merged in local dirty keys the cloud row doesn't have yet.
-      if (migrationChanged || hasDirty) schedulePrefUpload(variant);
-      Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+      if (cloud && cloud.syncVersion > getSyncVersion()) {
+        const isFirstEverSync = getSyncVersion() === 0;
+        const prevBlobJson = isFirstEverSync ? JSON.stringify(buildCloudBlob()) : null;
 
-      if (isFirstEverSync && prevBlobJson && Object.keys(cloud.data).length > 0) {
-        showUndoToast(prevBlobJson);
-      }
-
-      setState('synced');
-    } else {
-      // Local is at-or-ahead of cloud → post local. Migrate first so we
-      // never stamp CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data
-      // (the failure mode flagged in PR #3524 review: a user already synced
-      // to a poisoned cloud row would skip Branch A's inbound migration on
-      // subsequent sign-ins and post the bad blob back at schema 2,
-      // cementing the poisoning at the new schema).
-      const blob = migrateLocalBlobIfNeeded();
-      const result = await postCloudPrefs(token, variant, blob, getSyncVersion());
-
-      if ('conflict' in result) {
-        // Merge instead of clobber — see resolveConflictWithMerge. The old
-        // path here applied the cloud blob over localStorage and stopped,
-        // discarding the local edits this branch was trying to upload.
-        await resolveConflictWithMerge(token, variant, myGeneration);
-      } else {
-        setSyncVersion(result.syncVersion);
-        clearSettledDirtyKeys(blob);
+        const migrated = applyMigrations(cloud.data, cloud.schemaVersion ?? 1);
+        const migrationChanged = (cloud.schemaVersion ?? 1) < CURRENT_PREFS_SCHEMA_VERSION;
+        // Cloud is ahead, but the user may have un-uploaded local edits — e.g.
+        // onSignIn re-fired by a 503 retry after the user changed a pref. Merge
+        // those dirty keys over the cloud blob instead of clobbering them.
+        const hasDirty = _dirtyKeys.size > 0;
+        const toApply = hasDirty
+          ? mergeCloudWithLocalDirty(migrated, buildCloudBlob(), _dirtyKeys)
+          : migrated;
+        applyCloudBlob(toApply);
+        setSyncVersion(cloud.syncVersion);
+        // After applyCloudBlob, local data IS at CURRENT schema (applyMigrations
+        // ran every step from cloud.schemaVersion to CURRENT). Mark it so the
+        // post paths don't redundantly re-run migrations on already-clean data.
+        setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
+        // Force an upload when the cloud row's schemaVersion is behind (so it
+        // catches up — otherwise the migration re-runs every load) OR when we
+        // merged in local dirty keys the cloud row doesn't have yet.
+        if (migrationChanged || hasDirty) schedulePrefUpload(variant);
         Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
-        setState('synced');
-      }
-    }
 
-    Storage.prototype.setItem.call(localStorage, KEY_LAST_SIGNED_IN_AS, userId);
-  } catch (err) {
-    if (err instanceof ServiceUnavailableError) {
-      // Temporary edge response — transient. Set 'pending' (not 'error') and
-      // re-attempt sign-in sync after the server-suggested delay. This is
-      // the user-facing "transient outage shouldn't be permanent" fix
-      // (PR #3479): without this branch the catch would fall through to
-      // 'error' and the user's prefs would silently not sync until they
-      // reload.
-      //
-      // Generation guard: cancel any prior pending retry, then schedule a
-      // new one whose callback bails if `_authGeneration` has advanced
-      // (sign-out, user-switch, or another onSignIn invocation since this
-      // attempt began). Without the guard, a 5s delayed retry from user A
-      // could fire after sign-out (no token) or after user B signed in
-      // (wrong token in cache).
-      console.warn(`[cloud-prefs] onSignIn ${err.status}; retrying in ${err.retryAfterSec}s`);
-      setState('pending');
-      clearRetryTimer();
-      _retryTimer = setTimeout(() => {
-        _retryTimer = null;
+        if (isFirstEverSync && prevBlobJson && Object.keys(cloud.data).length > 0) {
+          showUndoToast(prevBlobJson);
+        }
+
+        setState('synced');
+      } else {
+        // Local is at-or-ahead of cloud → post local. Migrate first so we
+        // never stamp CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data
+        // (the failure mode flagged in PR #3524 review: a user already synced
+        // to a poisoned cloud row would skip Branch A's inbound migration on
+        // subsequent sign-ins and post the bad blob back at schema 2,
+        // cementing the poisoning at the new schema).
+        const blob = migrateLocalBlobIfNeeded();
+        const result = await postCloudPrefs(token, variant, blob, getSyncVersion());
         if (_authGeneration !== myGeneration) return;
-        void onSignIn(userId, variant);
-      }, err.retryAfterSec * 1000);
-      return;
+
+        if ('conflict' in result) {
+          // Merge instead of clobber — see resolveConflictWithMerge. The old
+          // path here applied the cloud blob over localStorage and stopped,
+          // discarding the local edits this branch was trying to upload.
+          await resolveConflictWithMerge(token, variant, myGeneration);
+        } else {
+          setSyncVersion(result.syncVersion);
+          clearSettledDirtyKeys(blob);
+          Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+          setState('synced');
+        }
+      }
+
+      if (_authGeneration === myGeneration) {
+        Storage.prototype.setItem.call(localStorage, KEY_LAST_SIGNED_IN_AS, userId);
+      }
+    } catch (err) {
+      if (_authGeneration !== myGeneration) return;
+      if (err instanceof ServiceUnavailableError) {
+        // Temporary edge response — transient. Set 'pending' (not 'error') and
+        // re-attempt sign-in sync after the server-suggested delay. This is
+        // the user-facing "transient outage shouldn't be permanent" fix
+        // (PR #3479): without this branch the catch would fall through to
+        // 'error' and the user's prefs would silently not sync until they
+        // reload.
+        //
+        // Generation guard: cancel any prior pending retry, then schedule a
+        // new one whose callback bails if `_authGeneration` has advanced
+        // (sign-out, user-switch, or another onSignIn invocation since this
+        // attempt began). Without the guard, a 5s delayed retry from user A
+        // could fire after sign-out (no token) or after user B signed in
+        // (wrong token in cache).
+        console.warn(`[cloud-prefs] onSignIn ${err.status}; retrying in ${err.retryAfterSec}s`);
+        setState('pending');
+        clearRetryTimer();
+        _retryTimer = setTimeout(() => {
+          _retryTimer = null;
+          if (_authGeneration !== myGeneration) return;
+          void onSignIn(userId, variant);
+        }, err.retryAfterSec * 1000);
+        return;
+      }
+      console.warn('[cloud-prefs] onSignIn failed:', err);
+      setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
     }
-    console.warn('[cloud-prefs] onSignIn failed:', err);
-    setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
-  }
+  });
 }
 
 export function onSignOut(): void {
   if (!isEnabled()) return;
 
+  const preservePersistedDirtyKeys = _syncOperations.busy && _dirtyKeys.size > 0;
   if (_debounceTimer !== null && _cachedToken) {
     // Flush pending upload synchronously before clearing credentials
     clearTimeout(_debounceTimer);
     _debounceTimer = null;
-    const blob = buildCloudBlob();
-    fetch('/api/user-prefs', {
-      method: 'POST',
-      keepalive: true,
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${_cachedToken}` },
-      body: JSON.stringify({ variant: _currentVariant, data: blob, expectedSyncVersion: getSyncVersion(), schemaVersion: CURRENT_PREFS_SCHEMA_VERSION }),
-    }).catch(() => { /* best-effort on sign-out */ });
+    // Never launch a second stale-version writer while sign-in reconciliation
+    // or a normal upload is already running. Dirty keys remain persisted and
+    // the active operation / next sign-in remains the recovery path.
+    if (!_syncOperations.busy) {
+      const blob = buildCloudBlob();
+      const token = _cachedToken;
+      void _syncOperations.run(async () => {
+        await fetch('/api/user-prefs', {
+          method: 'POST',
+          keepalive: true,
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ variant: _currentVariant, data: blob, expectedSyncVersion: getSyncVersion(), schemaVersion: CURRENT_PREFS_SCHEMA_VERSION }),
+          signal: AbortSignal.timeout(CLOUD_PREFS_REQUEST_TIMEOUT_MS),
+        });
+      }).catch(() => { /* best-effort on sign-out */ });
+    }
   } else if (_debounceTimer !== null) {
     clearTimeout(_debounceTimer);
     _debounceTimer = null;
@@ -568,10 +622,12 @@ export function onSignOut(): void {
   clearRetryTimer();
   _authGeneration += 1;
   _cachedToken = null;
-  // Dirty-key tracking is per-user session state — drop it so edits made by
-  // the next signed-in user don't merge against the prior user's pending set.
+  // Dirty-key tracking is user-scoped. Clear the in-memory owner on sign-out,
+  // but retain its persisted marker when an interrupted writer still owns
+  // unsynced edits; hydrateDirtyKeysFromStorage validates the user id before
+  // restoring it and removes mismatched markers for the next account.
   _dirtyKeys.clear();
-  persistDirtyKeys();
+  if (!preservePersistedDirtyKeys) persistDirtyKeys();
   _dirtyKeysUserId = null;
 
   // Preserve prefs; only clear sync metadata
@@ -580,7 +636,12 @@ export function onSignOut(): void {
   setState('signed-out');
 }
 
-async function uploadNow(variant: string): Promise<void> {
+/**
+ * Execute one cloud write while the caller owns the serialized sync queue.
+ * The outcome tells the upload drain whether it may replay a mutation that
+ * arrived after this pass captured its snapshot.
+ */
+async function performUploadNow(variant: string): Promise<'completed' | 'retry-deferred' | 'stopped'> {
   // Capture the auth generation at entry. If sign-out / user-switch happens
   // while we're awaiting fetch, the generation guard on any 503 retry below
   // will detect it and abort the scheduled retry. We do NOT increment the
@@ -588,17 +649,18 @@ async function uploadNow(variant: string): Promise<void> {
   // called by the debounced upload path), so we want to inherit the current
   // generation, not start a new one.
   const myGeneration = _authGeneration;
-  _uploadsInFlight += 1;
 
   try {
-    const token = await getClerkToken();
-    if (!token) return;
+    const token = await getCloudPrefsToken();
+    if (_authGeneration !== myGeneration) return 'stopped';
+    if (!token) return 'stopped';
     _cachedToken = token;
 
     setState('syncing');
 
     const postedBlob = migrateLocalBlobIfNeeded();
     const result = await postCloudPrefs(token, variant, postedBlob, getSyncVersion());
+    if (_authGeneration !== myGeneration) return 'stopped';
 
     if ('conflict' in result) {
       setState('conflict');
@@ -606,7 +668,7 @@ async function uploadNow(variant: string): Promise<void> {
       // of overwriting localStorage with cloud (the old path did
       // applyCloudBlob(cloud) then re-posted buildCloudBlob() — which by then
       // WAS the cloud blob, so the user's just-made edit was silently lost).
-      await resolveConflictWithMerge(token, variant, myGeneration);
+      if (!await resolveConflictWithMerge(token, variant, myGeneration)) return 'stopped';
     } else {
       // Generation guard: a sign-out / account-switch during the awaits above
       // repoints _dirtyKeys and _dirtyKeysUserId to a different user. Clearing
@@ -614,13 +676,13 @@ async function uploadNow(variant: string): Promise<void> {
       // user's dirty-key entry using this upload's stale postedBlob. Match the
       // 503 retry branch and the flush-success path — bail if the generation
       // moved.
-      if (_authGeneration !== myGeneration) return;
       setSyncVersion(result.syncVersion);
       clearSettledDirtyKeys(postedBlob);
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
       setState('synced');
     }
   } catch (err) {
+    if (_authGeneration !== myGeneration) return 'stopped';
     if (err instanceof ServiceUnavailableError) {
       // Temporary edge response — transient. Re-queue the upload after the
       // server-suggested delay so the unsaved blob isn't lost. Setting
@@ -639,13 +701,43 @@ async function uploadNow(variant: string): Promise<void> {
         if (_authGeneration !== myGeneration) return;
         void uploadNow(variant);
       }, err.retryAfterSec * 1000);
-      return;
+      return 'retry-deferred';
     }
     console.warn('[cloud-prefs] uploadNow failed:', err);
     setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
-  } finally {
-    _uploadsInFlight -= 1;
+    return 'stopped';
   }
+  return 'completed';
+}
+
+/**
+ * Coalesce upload requests behind the shared sign-in/write queue.
+ *
+ * Calls share one active promise. After a successful pass, dirty-key tracking
+ * determines whether a preference changed after its snapshot and needs one
+ * more pass; duplicate callers alone never cause a redundant POST.
+ */
+function uploadNow(variant: string): Promise<void> {
+  _queuedUploadVariant = variant;
+  if (_activeUploadPromise !== null) {
+    setState('pending');
+    return _activeUploadPromise;
+  }
+
+  const requestedGeneration = _authGeneration;
+  const queuedUpload = _syncOperations.run(async () => {
+    if (_authGeneration !== requestedGeneration) return;
+
+    while (_authGeneration === requestedGeneration) {
+      const outcome = await performUploadNow(_queuedUploadVariant);
+      if (outcome !== 'completed' || _dirtyKeys.size === 0) return;
+    }
+  });
+  const activeUpload = queuedUpload.finally(() => {
+    if (_activeUploadPromise === activeUpload) _activeUploadPromise = null;
+  });
+  _activeUploadPromise = activeUpload;
+  return activeUpload;
 }
 
 function schedulePrefUpload(variant: string): void {
@@ -729,63 +821,73 @@ export function install(variant: string): void {
     clearTimeout(_debounceTimer);
     _debounceTimer = null;
 
+    // A sign-in reconciliation or upload already owns the current
+    // expectedSyncVersion. Fold this final snapshot into that serialized
+    // writer instead of launching a competing keepalive POST.
+    if (_syncOperations.busy) {
+      void uploadNow(_currentVariant);
+      return;
+    }
+
     // Same defensive migration as the synchronous post paths — never stamp
     // CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data, even on
     // best-effort unload flush.
     const blob = migrateLocalBlobIfNeeded();
     const myGeneration = _authGeneration;
     const payload = JSON.stringify({ variant: _currentVariant, data: blob, expectedSyncVersion: getSyncVersion(), schemaVersion: CURRENT_PREFS_SCHEMA_VERSION });
-    fetch('/api/user-prefs', {
-      method: 'POST',
-      keepalive: true,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${_cachedToken}`,
-      },
-      body: payload,
-    }).then(async (res) => {
-      // The flush's most common trigger is NOT a real unload — it's
-      // visibilitychange→hidden on a tab switch, after which the tab stays
-      // alive. A successful flush advances the server row's syncVersion, so
-      // skipping the response here strands local KEY_SYNC_VERSION one
-      // version behind and GUARANTEES a 409 on the next pref save. Adopt
-      // the new version when the response is observable (true unloads never
-      // get here; the next boot's onSignIn GET heals those instead).
-      //
-      // Non-2xx: 409 keeps the stale version and dirty keys so the next
-      // upload resolves through the conflict-merge path. Temporary 429/5xx
-      // responses are observable during tab switches, so re-arm the normal
-      // retry machinery instead of stranding the final save.
-      if (!res.ok) {
-        rearmTemporaryCloudPrefsRetry({
-          status: res.status,
-          headers: res.headers,
+    void _syncOperations.run(async () => {
+      await fetch('/api/user-prefs', {
+        method: 'POST',
+        keepalive: true,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${_cachedToken}`,
+        },
+        body: payload,
+        signal: AbortSignal.timeout(CLOUD_PREFS_REQUEST_TIMEOUT_MS),
+      }).then(async (res) => {
+        // The flush's most common trigger is NOT a real unload — it's
+        // visibilitychange→hidden on a tab switch, after which the tab stays
+        // alive. A successful flush advances the server row's syncVersion, so
+        // skipping the response here strands local KEY_SYNC_VERSION one
+        // version behind and GUARANTEES a 409 on the next pref save. Adopt
+        // the new version when the response is observable (true unloads never
+        // get here; the next boot's onSignIn GET heals those instead).
+        //
+        // Non-2xx: 409 keeps the stale version and dirty keys so the next
+        // upload resolves through the conflict-merge path. Temporary 429/5xx
+        // responses are observable during tab switches, so re-arm the normal
+        // retry machinery instead of stranding the final save.
+        if (!res.ok) {
+          rearmTemporaryCloudPrefsRetry({
+            status: res.status,
+            headers: res.headers,
+            myGeneration,
+            getAuthGeneration: () => _authGeneration,
+            setPending: () => setState('pending'),
+            clearRetryTimer,
+            setRetryTimer: (timer) => { _retryTimer = timer; },
+            uploadNow: () => uploadNow(_currentVariant),
+          });
+          return;
+        }
+        const body = (await res.json().catch(() => null)) as { syncVersion?: number } | null;
+        applyObservableCloudPrefsFlushSuccess({
+          syncVersion: body?.syncVersion,
           myGeneration,
           getAuthGeneration: () => _authGeneration,
-          setPending: () => setState('pending'),
-          clearRetryTimer,
-          setRetryTimer: (timer) => { _retryTimer = timer; },
-          uploadNow: () => uploadNow(_currentVariant),
+          getSyncVersion,
+          setSyncVersion,
+          clearSettledDirtyKeys: () => clearSettledDirtyKeys(blob),
+          setLastSyncAt: (timestampMs) => {
+            Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(timestampMs));
+          },
+          // Only claim 'synced' when no newer edit re-armed the debounce AND no
+          // uploadNow is active or queued (performUploadNow does not start
+          // until the keepalive task releases the serialized queue).
+          isIdle: () => _debounceTimer === null && _activeUploadPromise === null,
+          setSynced: () => setState('synced'),
         });
-        return;
-      }
-      const body = (await res.json().catch(() => null)) as { syncVersion?: number } | null;
-      applyObservableCloudPrefsFlushSuccess({
-        syncVersion: body?.syncVersion,
-        myGeneration,
-        getAuthGeneration: () => _authGeneration,
-        getSyncVersion,
-        setSyncVersion,
-        clearSettledDirtyKeys: () => clearSettledDirtyKeys(blob),
-        setLastSyncAt: (timestampMs) => {
-          Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(timestampMs));
-        },
-        // Only claim 'synced' when no newer edit re-armed the debounce AND no
-        // uploadNow is mid-flight (the debounce callback nulls the timer
-        // synchronously before uploadNow's async work, so the timer alone
-        // can't distinguish "idle" from "upload in progress").
-        isIdle: () => _debounceTimer === null && _uploadsInFlight === 0,
-        setSynced: () => setState('synced'),
       });
     }).catch(() => { /* best-effort on unload */ });
   };

--- a/src/utils/serialized-async-queue.ts
+++ b/src/utils/serialized-async-queue.ts
@@ -1,0 +1,63 @@
+interface QueueEntry {
+  reject: (reason?: unknown) => void;
+  resolve: (value: unknown) => void;
+  task: () => Promise<unknown> | unknown;
+}
+
+/**
+ * Small FIFO executor for browser-side async work that must not overlap.
+ *
+ * The first task starts synchronously so unload/visibility handlers can begin
+ * a keepalive fetch before returning. Later tasks wait without allowing a
+ * rejection to poison the queue.
+ */
+export class SerializedAsyncQueue {
+  private active = false;
+  private readonly entries: QueueEntry[] = [];
+
+  get busy(): boolean {
+    return this.active || this.entries.length > 0;
+  }
+
+  run<T>(task: () => Promise<T> | T): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.entries.push({
+        task,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      this.startNext();
+    });
+  }
+
+  private startNext(): void {
+    if (this.active) return;
+
+    const entry = this.entries.shift();
+    if (!entry) return;
+
+    this.active = true;
+    let result: Promise<unknown> | unknown;
+    try {
+      result = entry.task();
+    } catch (error) {
+      this.active = false;
+      this.startNext();
+      entry.reject(error);
+      return;
+    }
+
+    void Promise.resolve(result).then(
+      (value) => {
+        this.active = false;
+        this.startNext();
+        entry.resolve(value);
+      },
+      (error) => {
+        this.active = false;
+        this.startNext();
+        entry.reject(error);
+      },
+    );
+  }
+}

--- a/tests/cloud-prefs-flush-version-guard.test.mjs
+++ b/tests/cloud-prefs-flush-version-guard.test.mjs
@@ -57,32 +57,32 @@ describe('cloud prefs flush version guardrails', () => {
     );
   });
 
-  it('only claims synced when nothing newer is pending or in flight', () => {
-    // The debounce callback nulls _debounceTimer synchronously BEFORE
-    // uploadNow starts awaiting, so the timer alone cannot distinguish
-    // "idle" from "upload mid-flight" — a late flush response would flash
-    // 'synced' during an active upload (Greptile P2 on PR #4267).
+  it('queues hidden-tab snapshots behind an active preference writer', () => {
     assert.match(
       flushBody,
-      /isIdle: \(\) => _debounceTimer === null && _uploadsInFlight === 0,[\s\S]*setSynced: \(\) => setState\('synced'\)/,
-      'flushOnUnload must not claim synced while a debounce is armed or an upload is in flight',
-    );
-    const uploadNowBody = (() => {
-      const start = cloudSyncSrc.indexOf('async function uploadNow');
-      assert.notEqual(start, -1, 'uploadNow must exist in cloud-prefs-sync.ts');
-      const end = cloudSyncSrc.indexOf('function schedulePrefUpload', start);
-      assert.notEqual(end, -1, 'uploadNow must precede schedulePrefUpload');
-      return cloudSyncSrc.slice(start, end);
-    })();
-    assert.match(
-      uploadNowBody,
-      /_uploadsInFlight \+= 1;/,
-      'uploadNow must mark itself in flight before any async work',
+      /if \(_syncOperations\.busy\) \{[\s\S]*void uploadNow\(_currentVariant\);[\s\S]*return;[\s\S]*\}/,
+      'flushOnUnload must fold its latest snapshot into the serialized upload drain when another writer is active',
     );
     assert.match(
-      uploadNowBody,
-      /\} finally \{\s*_uploadsInFlight -= 1;\s*\}/,
-      'uploadNow must balance the in-flight counter on every exit path',
+      flushBody,
+      /void _syncOperations\.run\(async \(\) => \{[\s\S]*await fetch\('\/api\/user-prefs'/,
+      'an idle keepalive flush must own the same serialized write queue as sign-in and normal uploads',
+    );
+  });
+
+  it('only claims synced when nothing newer is pending or in flight', () => {
+    // The debounce callback nulls _debounceTimer synchronously BEFORE
+    // uploadNow starts awaiting, and an upload can also be queued behind the
+    // flush itself. The shared promise covers both active and queued phases.
+    assert.match(
+      flushBody,
+      /isIdle: \(\) => _debounceTimer === null && _activeUploadPromise === null,[\s\S]*setSynced: \(\) => setState\('synced'\)/,
+      'flushOnUnload must not claim synced while a debounce is armed or an upload is active or queued',
+    );
+    assert.doesNotMatch(
+      cloudSyncSrc,
+      /_uploadsInFlight/,
+      'a perform-only counter cannot represent an upload waiting in the serialized queue',
     );
   });
 });

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -127,8 +127,8 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       cloudSyncSrc,
-      /_dirtyKeys\.clear\(\);\s*persistDirtyKeys\(\);\s*_dirtyKeysUserId = null;/,
-      'sign-out must clear the persisted dirty-key marker before dropping the current user id',
+      /const preservePersistedDirtyKeys = _syncOperations\.busy && _dirtyKeys\.size > 0;[\s\S]*_dirtyKeys\.clear\(\);\s*if \(!preservePersistedDirtyKeys\) persistDirtyKeys\(\);\s*_dirtyKeysUserId = null;/,
+      'sign-out must retain user-scoped dirty metadata only when an interrupted writer still needs recovery',
     );
   });
 
@@ -137,7 +137,7 @@ describe('cloud prefs panel sync guardrails', () => {
 
     assert.match(
       cloudSyncSrc,
-      /if \(_authGeneration !== myGeneration\) return;[\s\S]*clearSettledDirtyKeys\(postedBlob\)/,
+      /if \(_authGeneration !== myGeneration\) return 'stopped';[\s\S]*clearSettledDirtyKeys\(postedBlob\)/,
       'uploadNow success branch must bail before clearing settled dirty keys when the auth generation advanced (sign-out / account switch mid-upload)',
     );
     assert.match(

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -1,0 +1,441 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { after, describe, it } from 'node:test';
+
+import { build, stop } from 'esbuild';
+
+import { MiniStorage } from './helpers/mini-dom.mts';
+
+const root = resolve(import.meta.dirname, '..');
+const stubs: Record<string, string> = {
+  '@/services/runtime': 'export const isDesktopRuntime = () => false;',
+  '@/services/clerk': 'export const getClerkToken = async () => globalThis.__cloudPrefsToken;',
+  '@/config/feeds': 'export const FEEDS = {};',
+  '@/utils/dom-utils': [
+    'export const trustedHtml = (value) => value;',
+    'export const setTrustedHtml = (element, value) => { element.innerHTML = value; };',
+  ].join('\n'),
+  '@/services/source-cap': 'export const findFullyDisabledCategories = () => [];',
+};
+
+interface HarnessResult {
+  acceptedDataByToken: Record<string, Record<string, string>>;
+  conflictCount: number;
+  localSyncVersion: number;
+  postCount: number;
+  serverSyncVersion: number;
+  state: string | null;
+  stateHistory: string[];
+}
+
+interface HeldRequest {
+  release: () => void;
+  started: Promise<void>;
+}
+
+interface HarnessControls {
+  dispatchHidden: () => void;
+  holdNextPost: () => HeldRequest;
+  seedRow: (token: string, data: Record<string, string>, syncVersion: number) => void;
+  setToken: (token: string) => void;
+  stateHistory: string[];
+  timeoutNextRequest: () => void;
+}
+
+let harnessSequence = 0;
+let bundledSourcePromise: Promise<string> | null = null;
+
+after(() => {
+  stop();
+});
+
+async function getBundledSource(): Promise<string> {
+  bundledSourcePromise ??= build({
+    absWorkingDir: root,
+    entryPoints: ['src/utils/cloud-prefs-sync.ts'],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    write: false,
+    define: {
+      'import.meta.env.VITE_CLOUD_PREFS_ENABLED': '"true"',
+    },
+    plugins: [{
+      name: 'cloud-prefs-test-stubs',
+      setup(buildApi) {
+        buildApi.onLoad({ filter: /src\/utils\/cloud-prefs-sync\.ts$/ }, async (args) => ({
+          contents: await readFile(args.path, 'utf8'),
+          loader: 'ts',
+        }));
+        buildApi.onResolve({ filter: /^@\// }, (args) => {
+          if (!(args.path in stubs)) throw new Error(`unexpected alias import: ${args.path}`);
+          return { path: args.path, namespace: 'stub' };
+        });
+        buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+          contents: stubs[args.path],
+          loader: 'js',
+        }));
+      },
+    }],
+  }).then((bundled) => bundled.outputFiles[0]!.text);
+  return bundledSourcePromise;
+}
+
+async function loadCloudPrefsModule() {
+  const source = await getBundledSource();
+  const encoded = Buffer.from(source).toString('base64');
+  harnessSequence += 1;
+  return import(`data:text/javascript;base64,${encoded}#harness-${harnessSequence}`);
+}
+
+async function runHarness(
+  invoke: (
+    cloudPrefs: Awaited<ReturnType<typeof loadCloudPrefsModule>>,
+    controls: HarnessControls,
+  ) => Promise<void>,
+): Promise<HarnessResult> {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  const originalCloudPrefsToken = Object.getOwnPropertyDescriptor(globalThis, '__cloudPrefsToken');
+  const originalAbortSignalTimeout = AbortSignal.timeout;
+  const originalFetch = globalThis.fetch;
+  const originals = {
+    CustomEvent: globalThis.CustomEvent,
+    Storage: globalThis.Storage,
+    document: globalThis.document,
+    localStorage: globalThis.localStorage,
+    window: globalThis.window,
+  };
+  const stateHistory: string[] = [];
+  class TestStorage extends MiniStorage {
+    override setItem(key: string, value: string): void {
+      super.setItem(key, value);
+      if (key === 'wm-cloud-sync-state') stateHistory.push(value);
+    }
+  }
+  const storage = new TestStorage();
+  const documentListeners = new Map<string, Array<() => void>>();
+  const windowListeners = new Map<string, Array<() => void>>();
+  const documentStub = {
+    visibilityState: 'visible',
+    addEventListener(type: string, listener: () => void) {
+      const listeners = documentListeners.get(type) ?? [];
+      listeners.push(listener);
+      documentListeners.set(type, listeners);
+    },
+    body: {
+      appendChild(element: { dismissForTest?: () => void }) {
+        element.dismissForTest?.();
+      },
+    },
+    createElement() {
+      let clickListener: ((event: unknown) => void) | null = null;
+      return {
+        addEventListener(type: string, listener: (event: unknown) => void) {
+          if (type === 'click') clickListener = listener;
+        },
+        className: '',
+        dismissForTest() {
+          clickListener?.({
+            target: {
+              closest: () => ({ getAttribute: () => 'dismiss' }),
+            },
+          });
+        },
+        innerHTML: '',
+        remove() {},
+      };
+    },
+    querySelector() {
+      return null;
+    },
+  };
+
+  Object.assign(globalThis, {
+    __cloudPrefsToken: 'test-token',
+    CustomEvent: class TestCustomEvent {},
+    Storage: TestStorage,
+    document: documentStub,
+    localStorage: storage,
+    window: {
+      addEventListener(type: string, listener: () => void) {
+        const listeners = windowListeners.get(type) ?? [];
+        listeners.push(listener);
+        windowListeners.set(type, listeners);
+      },
+      dispatchEvent() {},
+    },
+  });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { onLine: true },
+  });
+
+  interface ServerRow {
+    data: Record<string, string>;
+    syncVersion: number;
+  }
+  const rows = new Map<string, ServerRow>();
+  let postCount = 0;
+  let conflictCount = 0;
+  let pendingHold: {
+    releasePromise: Promise<void>;
+    resolveRelease: () => void;
+    resolveStarted: () => void;
+  } | null = null;
+  let timeoutNextRequest = false;
+
+  AbortSignal.timeout = ((_delay: number) => {
+    const controller = new AbortController();
+    if (timeoutNextRequest) {
+      timeoutNextRequest = false;
+      queueMicrotask(() => {
+        controller.abort(new DOMException('cloud prefs request timed out', 'TimeoutError'));
+      });
+    }
+    return controller.signal;
+  }) as typeof AbortSignal.timeout;
+
+  globalThis.fetch = async (_input, init = {}) => {
+    const method = init.method ?? 'GET';
+    const authorization = new Headers(init.headers).get('Authorization') ?? '';
+    const token = authorization.replace(/^Bearer\s+/, '') || 'anonymous';
+    const row = rows.get(token) ?? { data: {}, syncVersion: 0 };
+    if (method === 'GET') {
+      return Response.json({
+        data: row.data,
+        schemaVersion: 2,
+        syncVersion: row.syncVersion,
+      });
+    }
+
+    postCount += 1;
+    const body = JSON.parse(String(init.body));
+
+    const held = pendingHold;
+    if (held) {
+      pendingHold = null;
+      held.resolveStarted();
+      await held.releasePromise;
+    }
+
+    await new Promise<void>((resolveDelay, rejectDelay) => {
+      const timer = setTimeout(resolveDelay, 5);
+      const signal = init.signal;
+      signal?.addEventListener('abort', () => {
+        clearTimeout(timer);
+        rejectDelay(signal.reason);
+      }, { once: true });
+    });
+
+    if (body.expectedSyncVersion !== row.syncVersion) {
+      conflictCount += 1;
+      return Response.json(
+        { error: 'CONFLICT', actualSyncVersion: row.syncVersion },
+        { status: 409 },
+      );
+    }
+
+    const nextRow = {
+      data: body.data as Record<string, string>,
+      syncVersion: row.syncVersion + 1,
+    };
+    rows.set(token, nextRow);
+    return Response.json({ syncVersion: nextRow.syncVersion });
+  };
+
+  const controls: HarnessControls = {
+    dispatchHidden: () => {
+      documentStub.visibilityState = 'hidden';
+      for (const listener of documentListeners.get('visibilitychange') ?? []) listener();
+    },
+    holdNextPost: () => {
+      let resolveRelease!: () => void;
+      let resolveStarted!: () => void;
+      const releasePromise = new Promise<void>((resolveReleasePromise) => {
+        resolveRelease = resolveReleasePromise;
+      });
+      const started = new Promise<void>((resolveStartedPromise) => {
+        resolveStarted = resolveStartedPromise;
+      });
+      pendingHold = { releasePromise, resolveRelease, resolveStarted };
+      return { release: resolveRelease, started };
+    },
+    seedRow: (token, data, syncVersion) => {
+      rows.set(token, { data: { ...data }, syncVersion });
+    },
+    setToken: (token) => {
+      Object.assign(globalThis, { __cloudPrefsToken: token });
+    },
+    stateHistory,
+    timeoutNextRequest: () => {
+      timeoutNextRequest = true;
+    },
+  };
+
+  try {
+    const cloudPrefs = await loadCloudPrefsModule();
+    await invoke(cloudPrefs, controls);
+    const activeToken = String(Reflect.get(globalThis, '__cloudPrefsToken'));
+    const activeRow = rows.get(activeToken) ?? { data: {}, syncVersion: 0 };
+    return {
+      acceptedDataByToken: Object.fromEntries(
+        [...rows].map(([token, row]) => [token, { ...row.data }]),
+      ),
+      conflictCount,
+      localSyncVersion: Number(localStorage.getItem('wm-cloud-sync-version') ?? 0),
+      postCount,
+      serverSyncVersion: activeRow.syncVersion,
+      state: localStorage.getItem('wm-cloud-sync-state'),
+      stateHistory: [...stateHistory],
+    };
+  } finally {
+    globalThis.fetch = originalFetch;
+    AbortSignal.timeout = originalAbortSignalTimeout;
+    Object.assign(globalThis, originals);
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, 'navigator', originalNavigator);
+    } else {
+      Reflect.deleteProperty(globalThis, 'navigator');
+    }
+    if (originalCloudPrefsToken) {
+      Object.defineProperty(globalThis, '__cloudPrefsToken', originalCloudPrefsToken);
+    } else {
+      Reflect.deleteProperty(globalThis, '__cloudPrefsToken');
+    }
+  }
+}
+
+describe('cloud preference write serialization', () => {
+  it('coalesces overlapping uploads instead of racing stale sync versions', async () => {
+    const result = await runHarness(async (cloudPrefs) => {
+      await Promise.all(Array.from({ length: 6 }, () => cloudPrefs.syncNow()));
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(result.postCount, 1);
+    assert.equal(result.localSyncVersion, result.serverSyncVersion);
+    assert.equal(result.state, 'synced');
+  });
+
+  it('replays once when a preference changes after the active snapshot', async () => {
+    const result = await runHarness(async (cloudPrefs) => {
+      cloudPrefs.install('full');
+      const sync = cloudPrefs.syncNow();
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 1));
+      localStorage.setItem('wm-market-watchlist-v1', 'changed-mid-flight');
+      await Promise.all([sync, cloudPrefs.syncNow()]);
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(result.postCount, 2);
+    assert.equal(result.localSyncVersion, result.serverSyncVersion);
+    assert.equal(result.state, 'synced');
+  });
+
+  it('serializes sign-in reconciliation with startup preference uploads', async () => {
+    const result = await runHarness(async (cloudPrefs) => {
+      await Promise.all([
+        cloudPrefs.onSignIn('user-1', 'full'),
+        ...Array.from({ length: 5 }, () => cloudPrefs.syncNow()),
+      ]);
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(result.postCount, 2);
+    assert.equal(result.localSyncVersion, result.serverSyncVersion);
+    assert.equal(result.state, 'synced');
+  });
+
+  it('serializes a sign-out keepalive before a rapid re-sign-in', async () => {
+    const result = await runHarness(async (cloudPrefs) => {
+      await cloudPrefs.onSignIn('user-1', 'full');
+      cloudPrefs.install('full');
+      localStorage.setItem('wm-market-watchlist-v1', 'save-before-sign-out');
+      cloudPrefs.onSignOut();
+      await cloudPrefs.onSignIn('user-1', 'full');
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(result.postCount, 2);
+    assert.equal(result.localSyncVersion, result.serverSyncVersion);
+    assert.equal(result.state, 'synced');
+  });
+
+  it('preserves edits made for a new account while its sign-in waits in the queue', async () => {
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.setToken('user-a-token');
+      await cloudPrefs.onSignIn('user-a', 'full');
+      cloudPrefs.install('full');
+
+      localStorage.setItem('wm-market-watchlist-v1', 'user-a-edit');
+      const heldPost = controls.holdNextPost();
+      const userAUpload = cloudPrefs.syncNow();
+      await heldPost.started;
+
+      cloudPrefs.onSignOut();
+      controls.seedRow('user-b-token', {
+        'wm-market-watchlist-v1': 'user-b-cloud',
+      }, 1);
+      controls.setToken('user-b-token');
+      const userBSignIn = cloudPrefs.onSignIn('user-b', 'full');
+      localStorage.setItem('wm-market-watchlist-v1', 'user-b-edit');
+
+      heldPost.release();
+      await Promise.all([userAUpload, userBSignIn]);
+      await cloudPrefs.syncNow();
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(
+      result.acceptedDataByToken['user-b-token']?.['wm-market-watchlist-v1'],
+      'user-b-edit',
+    );
+    assert.equal(result.localSyncVersion, result.serverSyncVersion);
+    assert.equal(result.state, 'synced');
+  });
+
+  it('does not report synced between an observable flush and its queued newer upload', async () => {
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      await cloudPrefs.onSignIn('user-1', 'full');
+      cloudPrefs.install('full');
+
+      localStorage.setItem('wm-market-watchlist-v1', 'first-hidden-edit');
+      const heldFlush = controls.holdNextPost();
+      controls.dispatchHidden();
+      await heldFlush.started;
+
+      localStorage.setItem('wm-market-watchlist-v1', 'second-hidden-edit');
+      const transitionStart = controls.stateHistory.length;
+      controls.dispatchHidden();
+      heldFlush.release();
+      await cloudPrefs.syncNow();
+
+      assert.deepEqual(
+        controls.stateHistory.slice(transitionStart),
+        ['pending', 'syncing', 'synced'],
+      );
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(result.postCount, 3);
+    assert.equal(result.localSyncVersion, result.serverSyncVersion);
+    assert.equal(result.state, 'synced');
+  });
+
+  it('releases the serialized writer after a timed-out request', async () => {
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      controls.timeoutNextRequest();
+      await cloudPrefs.syncNow();
+      assert.equal(cloudPrefs.getSyncState(), 'pending');
+
+      await cloudPrefs.syncNow();
+      assert.equal(cloudPrefs.getSyncState(), 'synced');
+      cloudPrefs.onSignOut();
+    });
+
+    assert.equal(result.conflictCount, 0);
+    assert.equal(result.postCount, 2);
+    assert.equal(result.serverSyncVersion, 1);
+  });
+});

--- a/tests/serialized-async-queue.test.mts
+++ b/tests/serialized-async-queue.test.mts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { SerializedAsyncQueue } from '../src/utils/serialized-async-queue.ts';
+
+describe('SerializedAsyncQueue', () => {
+  it('starts the first task synchronously and runs later tasks in FIFO order', async () => {
+    const queue = new SerializedAsyncQueue();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = queue.run(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+      return 1;
+    });
+    const second = queue.run(async () => {
+      events.push('second');
+      return 2;
+    });
+
+    assert.equal(queue.busy, true);
+    assert.deepEqual(events, ['first:start']);
+
+    releaseFirst();
+    assert.deepEqual(await Promise.all([first, second]), [1, 2]);
+    assert.deepEqual(events, ['first:start', 'first:end', 'second']);
+    assert.equal(queue.busy, false);
+  });
+
+  it('continues draining after a task rejects', async () => {
+    const queue = new SerializedAsyncQueue();
+    const failure = queue.run(() => {
+      throw new Error('expected failure');
+    });
+    const recovery = queue.run(() => 'recovered');
+
+    await assert.rejects(failure, /expected failure/);
+    assert.equal(await recovery, 'recovered');
+    assert.equal(queue.busy, false);
+  });
+
+  it('continues draining after an asynchronous rejection', async () => {
+    const queue = new SerializedAsyncQueue();
+    const events: string[] = [];
+    const failure = queue.run(async () => {
+      events.push('failure:start');
+      await Promise.resolve();
+      events.push('failure:reject');
+      throw new Error('expected async failure');
+    });
+    const recovery = queue.run(async () => {
+      events.push('recovery');
+      return 'recovered';
+    });
+
+    assert.equal(queue.busy, true);
+    await assert.rejects(failure, /expected async failure/);
+    assert.equal(await recovery, 'recovered');
+    assert.deepEqual(events, ['failure:start', 'failure:reject', 'recovery']);
+    assert.equal(queue.busy, false);
+  });
+});


### PR DESCRIPTION
## Summary

- serialize sign-in reconciliation, debounced uploads, sign-out keepalives, and hidden-tab flushes behind one FIFO writer
- coalesce duplicate uploads while replaying edits that arrive after an active snapshot
- keep account-generation and dirty-key ownership safe across rapid sign-out/sign-in transitions
- bound Clerk token acquisition and preference API requests to 15 seconds so a stalled request cannot pin the writer queue

## Why

The client could launch several POST `/api/user-prefs` writers with the same `expectedSyncVersion` during startup and layout initialization. The server correctly rejected the stale writers with 409, but the same-tab race produced noisy conflict storms and unnecessary merge work.

## Validation

- 153 cloud-preference and user-preference tests passed
- frontend typecheck passed
- lint and safe-HTML checks passed; only pre-existing unrelated warnings remain
- pre-push gate passed, including 18 changed tests and 235 edge-function checks
- isolated loopback-sensitive auth timeout suite passed 6/6 outside the filesystem sandbox

## Known residuals

- independent browser tabs still coordinate through the existing 409 fetch-merge-retry protocol; this queue is intentionally tab-local
- if the page is truly discarded while another writer owns the queue, persisted dirty-key metadata remains the recovery path on the next same-browser sign-in