### PR TITLE
fix(boot): handle the variant stylesheet preload rejection

### DIFF
--- a/src/bootstrap/variant-theme.ts
+++ b/src/bootstrap/variant-theme.ts
@@ -1,0 +1,50 @@
+import { enqueueSentryCall } from './sentry-defer';
+
+/**
+ * Variant stylesheets load through a fire-and-forget dynamic import so they stay
+ * off the other variants' eager CSS graph (see `main.ts`). Vite's preload helper
+ * appends a `<link rel="stylesheet">` for a CSS-only dynamic import and rejects
+ * the promise it returns with `Unable to preload CSS for <url>` when that link
+ * fires `error`, so an uncaught `void import('./styles/<variant>-theme.css')`
+ * surfaces as an onunhandledrejection ERROR in Sentry — even though the user is
+ * unaffected, because the same helper dispatches `vite:preloadError` first and
+ * `installChunkReloadGuard` (chunk-reload.ts) turns that into a one-shot reload
+ * (WORLDMONITOR-XT: happy-theme.css, 2026-07-28; the asset itself served 200, so
+ * the failure was client-local, not deploy skew).
+ *
+ * Consume the rejection here and re-report it as deliberate warning-level
+ * telemetry instead: a stylesheet genuinely missing from a deploy still
+ * escalates by volume, while a lone client-side network blip stops reading as an
+ * unhandled error. Every other dynamic import under `bootstrap/` already
+ * terminates in a `.catch`; this is the same contract, made testable.
+ */
+export function reportVariantThemeLoadFailure(variant: string, error: unknown): void {
+  enqueueSentryCall((s) => {
+    s.captureMessage(`Variant theme stylesheet failed to load: ${variant}`, {
+      level: 'warning',
+      tags: { kind: 'variant_theme_load_failed', variant },
+      extra: { reason: error instanceof Error ? error.message : String(error) },
+    });
+  });
+}
+
+export function loadVariantThemeStylesheet(
+  variant: string,
+  importTheme: () => Promise<unknown>,
+  report: (variant: string, error: unknown) => void = reportVariantThemeLoadFailure,
+): Promise<void> {
+  return Promise.resolve()
+    .then(importTheme)
+    .then(
+      () => undefined,
+      (error: unknown) => {
+        // The reporter runs inside the rejection handler, so a throw here would
+        // re-reject this promise and recreate the exact leak being closed.
+        try {
+          report(variant, error);
+        } catch {
+          // Telemetry must never resurrect the rejection it exists to report.
+        }
+      },
+    );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,18 @@ import { registerClsReporting } from '@/bootstrap/cls-report';
 import { registerInpReporting } from '@/bootstrap/inp-report';
 import { registerLcpReporting } from '@/bootstrap/lcp-report';
 import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
+import { loadVariantThemeStylesheet } from '@/bootstrap/variant-theme';
 import { App } from './App';
 import { installUtmInterceptor } from './utils/utm';
 
 if (SITE_VARIANT === 'happy') {
   // Keeps happy-theme.css off other variants' eager CSS graph. On happy, the
   // stylesheet applies asynchronously, so a brief base-theme flash is possible.
-  void import('./styles/happy-theme.css');
+  // The import is fire-and-forget, so its rejection must be consumed: Vite's
+  // preload helper rejects with `Unable to preload CSS for <url>` when the
+  // injected <link> errors, and a bare `void import(...)` let that escape to
+  // onunhandledrejection (WORLDMONITOR-XT). See bootstrap/variant-theme.ts.
+  void loadVariantThemeStylesheet('happy', () => import('./styles/happy-theme.css'));
 }
 
 // Activate the deferred dashboard app stylesheet. The build

--- a/tests/variant-theme-preload-rejection.test.mts
+++ b/tests/variant-theme-preload-rejection.test.mts
@@ -1,0 +1,120 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * WORLDMONITOR-XT — `Error: Unable to preload CSS for /assets/happy-theme-DInLuQYM.css`,
+ * onunhandledrejection, error level, 2026-07-28.
+ *
+ * `main.ts` loaded the happy variant stylesheet with a bare
+ * `void import('./styles/happy-theme.css')`. Vite's preload helper rejects that
+ * promise when the injected `<link rel="stylesheet">` fires `error`, and `void`
+ * discards the promise rather than handling it — so the rejection escaped to
+ * `onunhandledrejection`. These tests pin the contract that the variant theme
+ * loader consumes its own rejection: the failure is reported, and nothing ever
+ * reaches the process-level unhandled-rejection handler.
+ */
+
+const REJECTION = new Error('Unable to preload CSS for /assets/happy-theme-DInLuQYM.css');
+
+const { loadVariantThemeStylesheet } = await import('../src/bootstrap/variant-theme.ts');
+
+const leaked: unknown[] = [];
+const captureLeak = (reason: unknown): void => {
+  leaked.push(reason);
+};
+
+/**
+ * Node emits `unhandledRejection` at the end of the turn in which the rejected
+ * promise was left unhandled, so a macrotask hop is required before asserting.
+ */
+function flushRejectionQueue(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe('loadVariantThemeStylesheet', () => {
+  beforeEach(() => {
+    leaked.length = 0;
+    process.on('unhandledRejection', captureLeak);
+  });
+
+  afterEach(() => {
+    process.off('unhandledRejection', captureLeak);
+  });
+
+  it('never leaks an unhandled rejection when the stylesheet fails to preload', async () => {
+    const reported: Array<[string, unknown]> = [];
+
+    await loadVariantThemeStylesheet('happy', () => Promise.reject(REJECTION), (variant, error) => {
+      reported.push([variant, error]);
+    });
+    await flushRejectionQueue();
+
+    assert.deepEqual(
+      leaked,
+      [],
+      'the CSS preload rejection reached process unhandledRejection — this is exactly WORLDMONITOR-XT',
+    );
+    assert.deepEqual(reported, [['happy', REJECTION]], 'the failure must be reported exactly once');
+  });
+
+  it('handles an importer that throws synchronously', async () => {
+    const reported: Array<[string, unknown]> = [];
+
+    await loadVariantThemeStylesheet('happy', () => {
+      throw REJECTION;
+    }, (variant, error) => {
+      reported.push([variant, error]);
+    });
+    await flushRejectionQueue();
+
+    assert.deepEqual(leaked, []);
+    assert.deepEqual(reported, [['happy', REJECTION]]);
+  });
+
+  it('does not resurrect the leak when the reporter itself throws', async () => {
+    await loadVariantThemeStylesheet('happy', () => Promise.reject(REJECTION), () => {
+      throw new Error('sentry queue blew up');
+    });
+    await flushRejectionQueue();
+
+    assert.deepEqual(leaked, [], 'a throwing reporter must not re-reject the loader promise');
+  });
+
+  it('reports nothing when the stylesheet loads', async () => {
+    const reported: Array<[string, unknown]> = [];
+
+    await loadVariantThemeStylesheet('happy', () => Promise.resolve({}), (variant, error) => {
+      reported.push([variant, error]);
+    });
+    await flushRejectionQueue();
+
+    assert.deepEqual(leaked, []);
+    assert.deepEqual(reported, []);
+  });
+});
+
+describe('main.ts variant stylesheet call site', () => {
+  const mainSource = readFileSync(
+    fileURLToPath(new URL('../src/main.ts', import.meta.url)),
+    'utf8',
+  );
+
+  it('routes the variant stylesheet through the guarded loader', () => {
+    assert.match(
+      mainSource,
+      /loadVariantThemeStylesheet\(\s*'happy',\s*\(\)\s*=>\s*import\('\.\/styles\/happy-theme\.css'\)\s*\)/,
+      'main.ts must load the happy theme through loadVariantThemeStylesheet',
+    );
+  });
+
+  it('has no bare fire-and-forget variant stylesheet import left', () => {
+    const bareThemeImports = mainSource.match(/void import\(['"]\.\/styles\/[\w-]+\.css['"]\)/g) ?? [];
+    assert.deepEqual(
+      bareThemeImports,
+      [],
+      'a bare `void import(<theme>.css)` discards the preload rejection — route it through loadVariantThemeStylesheet',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

On `happy.worldmonitor.app`, a failed stylesheet load reported itself as an unhandled error even though the page had already healed itself. `main.ts` loaded the variant theme with a bare `void import('./styles/happy-theme.css')`, which discards the promise Vite's preload helper returns — and that helper rejects with `Unable to preload CSS for <url>` whenever the `<link>` it injects fires `error`. The rejection escaped to `onunhandledrejection` and surfaced as an error-level Sentry event (WORLDMONITOR-XT).

That event was misleading in both directions. The asset was fine — the CSS and its referencing chunk both serve 200 in production, so the failure was client-local, not deploy skew. And the user was never stuck: the deployed helper dispatches `vite:preloadError` *before* it throws, which `installChunkReloadGuard` already turns into a one-shot reload.

The load now goes through `loadVariantThemeStylesheet`, which consumes the rejection and re-reports it as warning-level telemetry instead of swallowing it, so a stylesheet genuinely missing from a deploy still escalates by volume while a lone network blip stops reading as an unhandled error.

Two decisions worth a reviewer's attention:

- **Fixed at the call site, not with a `beforeSend` filter.** The existing owned-asset suppression matches only `/assets/*.js` plus the phrase `dynamically imported module`, and its `!hasFirstParty` arm cannot fire when the helper frame is itself a first-party chunk. A CSS arm would have hidden a first-party leak rather than closing it.
- **The reporter is `try`/`catch`-wrapped.** It runs inside the rejection handler, so a throwing reporter would re-reject the promise and recreate the exact leak being closed.

Every other dynamic import in `src/` already terminates in a `.catch`, so this was the sole omission and no broader sweep is needed.

## Validation

`tests/variant-theme-preload-rejection.test.mts` asserts the rejection never reaches Node's `unhandledRejection` handler across a rejecting importer, a synchronously throwing importer, and a throwing reporter. It was written against the pre-fix shape first — 5 of 6 red, then 6 of 6 green — and mutation-tested per guard: removing the rejection handler reds 3 tests, removing the reporter `try`/`catch` reds exactly 1.

`npm run typecheck` and `biome` are clean, and the 527 tests in the existing suites that read `main.ts` source (including `sentry-beforesend` and `chunk-reload`) still pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
