### PR TITLE
fix(widgets): block beforeunload in custom widget sandbox

### DIFF
--- a/e2e/widget-sandbox.spec.ts
+++ b/e2e/widget-sandbox.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Frame, type Page } from '@playwright/test';
+
+type SandboxProbeWindow = Window & typeof globalThis & {
+  __bodyBeforeUnloadCalls: number;
+  __clickCalls: number;
+  __framesetBeforeUnloadCalls: number;
+};
+
+async function mountSandboxWidget(page: Page, id: string, html: string): Promise<Frame> {
+  const token = `token-${id}`;
+
+  await page.evaluate(({ html: widgetHtml, id: widgetId, token: widgetToken }) => {
+    const iframe = document.createElement('iframe');
+    iframe.dataset.testid = widgetId;
+    iframe.setAttribute('sandbox', 'allow-scripts');
+    iframe.src = `/wm-widget-sandbox.html#id=${encodeURIComponent(widgetId)}&token=${encodeURIComponent(widgetToken)}`;
+
+    function handleReady(event: MessageEvent): void {
+      if (
+        event.source !== iframe.contentWindow
+        || !event.data
+        || event.data.type !== 'wm-widget-ready'
+        || event.data.id !== widgetId
+        || event.data.token !== widgetToken
+      ) {
+        return;
+      }
+
+      document.documentElement.dataset.widgetReady = widgetId;
+      iframe.contentWindow?.postMessage(
+        { type: 'wm-html', id: widgetId, token: widgetToken, html: widgetHtml },
+        '*',
+      );
+      window.removeEventListener('message', handleReady);
+    }
+
+    window.addEventListener('message', handleReady);
+    document.body.appendChild(iframe);
+  }, { html, id, token });
+
+  const iframe = page.locator(`iframe[data-testid="${id}"]`);
+  await expect(iframe).toHaveAttribute('sandbox', 'allow-scripts');
+  await expect.poll(
+    () => page.evaluate(() => document.documentElement.dataset.widgetReady),
+  ).toBe(id);
+
+  const handle = await iframe.elementHandle();
+  const frame = await handle?.contentFrame();
+  expect(frame).not.toBeNull();
+  return frame!;
+}
+
+test.describe('PRO widget sandbox', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/widget-sandbox-parent', (route) => route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><html><body></body></html>',
+    }));
+    await page.goto('/widget-sandbox-parent');
+  });
+
+  test('stops reflected body and frameset beforeunload handlers after document.open', async ({ page }) => {
+    const bodyFrame = await mountSandboxWidget(page, 'body-widget', `<!doctype html>
+<html>
+<body onbeforeunload="window.__bodyBeforeUnloadCalls += 1">
+  <script>
+    window.__bodyBeforeUnloadCalls = 0;
+    window.__clickCalls = 0;
+
+    window.addEventListener('click', function () { window.__clickCalls += 1; });
+    window.dispatchEvent(new Event('beforeunload'));
+    window.dispatchEvent(new Event('click'));
+    document.body.dataset.widgetReady = 'true';
+  </script>
+</body>
+</html>`);
+
+    await expect.poll(
+      () => bodyFrame.evaluate(() => document.body?.dataset.widgetReady),
+    ).toBe('true');
+
+    expect(await bodyFrame.evaluate(() => {
+      const probe = window as SandboxProbeWindow;
+      return {
+        body: probe.__bodyBeforeUnloadCalls,
+        click: probe.__clickCalls,
+      };
+    })).toEqual({ body: 0, click: 1 });
+
+    await bodyFrame.evaluate(() => window.dispatchEvent(new Event('beforeunload')));
+    expect(await bodyFrame.evaluate(() => {
+      const probe = window as SandboxProbeWindow;
+      return probe.__bodyBeforeUnloadCalls;
+    })).toBe(0);
+
+    const framesetFrame = await mountSandboxWidget(page, 'frameset-widget', `<!doctype html>
+<html>
+<head><script>window.__framesetBeforeUnloadCalls = 0;</script></head>
+<frameset onbeforeunload="window.__framesetBeforeUnloadCalls += 1">
+  <frame src="about:blank">
+</frameset>
+</html>`);
+
+    await expect.poll(
+      () => framesetFrame.evaluate(() => Boolean(document.querySelector('frameset'))),
+    ).toBe(true);
+    await framesetFrame.evaluate(() => window.dispatchEvent(new Event('beforeunload')));
+    expect(
+      await framesetFrame.evaluate(
+        () => (window as SandboxProbeWindow).__framesetBeforeUnloadCalls,
+      ),
+    ).toBe(0);
+  });
+});

--- a/public/wm-widget-sandbox.html
+++ b/public/wm-widget-sandbox.html
@@ -51,6 +51,15 @@
     }
   }
 
+  var nativeAddEventListener = EventTarget.prototype.addEventListener;
+  var nativeStopImmediatePropagation = Event.prototype.stopImmediatePropagation;
+
+  function installBeforeUnloadStopper() {
+    nativeAddEventListener.call(window, 'beforeunload', function (event) {
+      nativeStopImmediatePropagation.call(event);
+    }, true);
+  }
+
   function installBeforeUnloadGuard() {
     Object.defineProperty(window, 'onbeforeunload', {
       configurable: false,
@@ -60,10 +69,9 @@
       set: function () {},
     });
 
-    var addEventListener = EventTarget.prototype.addEventListener;
     EventTarget.prototype.addEventListener = function (type, listener, options) {
       if (this === window && type === 'beforeunload') return;
-      return addEventListener.call(this, type, listener, options);
+      return nativeAddEventListener.call(this, type, listener, options);
     };
   }
 
@@ -84,6 +92,10 @@
     if (typeof e.data.html !== 'string') return;
     handled = true;
     document.open();
+    // document.open() clears Window listeners. Reinstall through the saved
+    // native method before widget parsing so reflected body/frameset handlers
+    // and registrations through another realm are later than this stopper.
+    installBeforeUnloadStopper();
     document.write(e.data.html);
     document.close();
   });

--- a/public/wm-widget-sandbox.html
+++ b/public/wm-widget-sandbox.html
@@ -51,11 +51,29 @@
     }
   }
 
+  function installBeforeUnloadGuard() {
+    Object.defineProperty(window, 'onbeforeunload', {
+      configurable: false,
+      get: function () {
+        return null;
+      },
+      set: function () {},
+    });
+
+    var addEventListener = EventTarget.prototype.addEventListener;
+    EventTarget.prototype.addEventListener = function (type, listener, options) {
+      if (this === window && type === 'beforeunload') return;
+      return addEventListener.call(this, type, listener, options);
+    };
+  }
+
   try {
     parentOrigin = document.referrer ? new URL(document.referrer).origin : '';
   } catch (_err) {
     parentOrigin = '';
   }
+
+  installBeforeUnloadGuard();
 
   window.addEventListener('message', function (e) {
     if (handled) return;

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1365,9 +1365,17 @@ describe('PRO widget — store and sanitizer', () => {
           readyMessages.push({ payload, targetOrigin });
         },
       };
+      function FakeEventTarget() {}
+      FakeEventTarget.prototype.addEventListener = (type, listener) => {
+        listeners.set(type, listener);
+      };
+      const sandboxWindow = new FakeEventTarget();
+      sandboxWindow.location = { hash: '#id=wm-1&token=test-token' };
+      sandboxWindow.parent = parent;
       const context = {
         URL,
         URLSearchParams,
+        EventTarget: FakeEventTarget,
         document: {
           referrer,
           open() {},
@@ -1376,13 +1384,7 @@ describe('PRO widget — store and sanitizer', () => {
           },
           close() {},
         },
-        window: {
-          location: { hash: '#id=wm-1&token=test-token' },
-          parent,
-          addEventListener(type, listener) {
-            listeners.set(type, listener);
-          },
-        },
+        window: sandboxWindow,
       };
       vm.runInNewContext(script, context);
       const message = listeners.get('message');
@@ -1404,6 +1406,40 @@ describe('PRO widget — store and sanitizer', () => {
       source: allowed.parent,
     });
     assert.deepEqual(allowed.writes, ['<p>ok</p>']);
+    allowed.message({
+      data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: '<p>second</p>' },
+      origin: 'https://worldmonitor-git-feature-eliewm.vercel.app',
+      source: allowed.parent,
+    });
+    assert.deepEqual(allowed.writes, ['<p>ok</p>'], 'only the first accepted message may write');
+
+    const invalidMessages = [
+      {
+        data: { type: 'other', id: 'wm-1', token: 'test-token', html: '<p>bad type</p>' },
+        origin: 'https://worldmonitor.app',
+      },
+      {
+        data: { type: 'wm-html', id: 'wrong-id', token: 'test-token', html: '<p>bad id</p>' },
+        origin: 'https://worldmonitor.app',
+      },
+      {
+        data: { type: 'wm-html', id: 'wm-1', token: 'wrong-token', html: '<p>bad token</p>' },
+        origin: 'https://worldmonitor.app',
+      },
+    ];
+    for (const invalidMessage of invalidMessages) {
+      const rejected = runSandbox('https://worldmonitor.app/dashboard');
+      rejected.message({ ...invalidMessage, source: rejected.parent });
+      assert.deepEqual(rejected.writes, []);
+    }
+
+    const wrongSource = runSandbox('https://worldmonitor.app/dashboard');
+    wrongSource.message({
+      data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: '<p>bad source</p>' },
+      origin: 'https://worldmonitor.app',
+      source: {},
+    });
+    assert.deepEqual(wrongSource.writes, []);
 
     const spoofed = runSandbox('https://worldmonitor-git-feature-eliewm.vercel.app.evil.com/');
     assert.deepEqual(spoofed.readyMessages, []);
@@ -1413,6 +1449,117 @@ describe('PRO widget — store and sanitizer', () => {
       source: spoofed.parent,
     });
     assert.deepEqual(spoofed.writes, []);
+  });
+
+  it('widget sandbox blocks beforeunload without breaking normal events before widget execution', () => {
+    const script = sandbox.match(/<script>\r?\n([\s\S]*?)\r?\n<\/script>/)?.[1];
+    assert.ok(script, 'sandbox inline script not found');
+
+    function FakeEvent(type) {
+      this.type = type;
+    }
+
+    function FakeEventTarget() {
+      this.listeners = new Map();
+    }
+
+    FakeEventTarget.prototype.addEventListener = function (type, listener, options) {
+      const entries = this.listeners.get(type) ?? [];
+      entries.push({ listener, options });
+      this.listeners.set(type, entries);
+    };
+
+    FakeEventTarget.prototype.dispatchEvent = function (event) {
+      const entries = [...(this.listeners.get(event.type) ?? [])];
+      for (const entry of entries) {
+        if (typeof entry.listener === 'function') {
+          entry.listener.call(this, event);
+        } else {
+          entry.listener.handleEvent.call(entry.listener, event);
+        }
+        if (entry.options?.once) {
+          const current = this.listeners.get(event.type) ?? [];
+          this.listeners.set(event.type, current.filter((candidate) => candidate !== entry));
+        }
+      }
+      return true;
+    };
+
+    const parent = { postMessage() {} };
+    const sandboxWindow = new FakeEventTarget();
+    sandboxWindow.location = { hash: '#id=wm-1&token=test-token' };
+    sandboxWindow.parent = parent;
+
+    let guardedAtWrite = false;
+    let vmContext;
+    const document = {
+      referrer: 'https://worldmonitor.app/dashboard',
+      open() {},
+      write(html) {
+        sandboxWindow.onbeforeunload = () => 'too late';
+        sandboxWindow.addEventListener('beforeunload', () => {
+          sandboxWindow.beforeUnloadCalls++;
+        });
+        guardedAtWrite = sandboxWindow.onbeforeunload === null
+          && (sandboxWindow.listeners.get('beforeunload')?.length ?? 0) === 0;
+
+        for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/gi)) {
+          vm.runInContext(match[1], vmContext);
+        }
+      },
+      close() {},
+    };
+
+    vmContext = vm.createContext({
+      URL,
+      URLSearchParams,
+      Event: FakeEvent,
+      EventTarget: FakeEventTarget,
+      document,
+      window: sandboxWindow,
+    });
+    vm.runInContext(script, vmContext);
+
+    const message = sandboxWindow.listeners.get('message')?.[0]?.listener;
+    assert.equal(typeof message, 'function', 'message listener must be registered');
+
+    const widgetHtml = `<script>
+window.beforeUnloadCalls = 0;
+window.clickCalls = 0;
+window.onbeforeunload = function () {
+  window.beforeUnloadCalls++;
+  return 'blocked';
+};
+window.addEventListener('beforeunload', function () {
+  window.beforeUnloadCalls++;
+});
+EventTarget.prototype.addEventListener.call(window, 'beforeunload', function () {
+  window.beforeUnloadCalls++;
+});
+window.addEventListener('click', {
+  handleEvent: function () {
+    window.clickCalls++;
+  }
+}, { once: true, passive: true });
+window.dispatchEvent(new Event('beforeunload'));
+window.dispatchEvent(new Event('click'));
+window.dispatchEvent(new Event('click'));
+</script>`;
+
+    assert.doesNotThrow(() => {
+      message.call(sandboxWindow, {
+        data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: widgetHtml },
+        origin: 'https://worldmonitor.app',
+        source: parent,
+      });
+    });
+
+    assert.equal(guardedAtWrite, true, 'beforeunload guard must be active when document.write starts');
+    assert.equal(sandboxWindow.onbeforeunload, null, 'onbeforeunload assignments must remain inert');
+    sandboxWindow.onbeforeunload = () => 'still blocked';
+    assert.equal(sandboxWindow.onbeforeunload, null, 'ordinary reassignment must not restore onbeforeunload');
+    assert.equal(sandboxWindow.beforeUnloadCalls, 0, 'beforeunload listeners must not be registered');
+    assert.equal(sandboxWindow.clickCalls, 1, 'listener objects and normal event options must still work');
   });
 
   it('PRO widget message listener has AbortController cleanup wired to iframe removal', () => {

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1369,12 +1369,15 @@ describe('PRO widget — store and sanitizer', () => {
       FakeEventTarget.prototype.addEventListener = (type, listener) => {
         listeners.set(type, listener);
       };
+      function FakeEvent() {}
+      FakeEvent.prototype.stopImmediatePropagation = () => {};
       const sandboxWindow = new FakeEventTarget();
       sandboxWindow.location = { hash: '#id=wm-1&token=test-token' };
       sandboxWindow.parent = parent;
       const context = {
         URL,
         URLSearchParams,
+        Event: FakeEvent,
         EventTarget: FakeEventTarget,
         document: {
           referrer,
@@ -1457,7 +1460,12 @@ describe('PRO widget — store and sanitizer', () => {
 
     function FakeEvent(type) {
       this.type = type;
+      this.immediatePropagationStopped = false;
     }
+
+    FakeEvent.prototype.stopImmediatePropagation = function () {
+      this.immediatePropagationStopped = true;
+    };
 
     function FakeEventTarget() {
       this.listeners = new Map();
@@ -1477,6 +1485,7 @@ describe('PRO widget — store and sanitizer', () => {
         } else {
           entry.listener.handleEvent.call(entry.listener, event);
         }
+        if (event.immediatePropagationStopped) break;
         if (entry.options?.once) {
           const current = this.listeners.get(event.type) ?? [];
           this.listeners.set(event.type, current.filter((candidate) => candidate !== entry));
@@ -1494,14 +1503,18 @@ describe('PRO widget — store and sanitizer', () => {
     let vmContext;
     const document = {
       referrer: 'https://worldmonitor.app/dashboard',
-      open() {},
+      open() {
+        // Real document.open() clears Window listeners. The guard must restore
+        // its stopper after this reset and before widget HTML begins parsing.
+        sandboxWindow.listeners.clear();
+      },
       write(html) {
         sandboxWindow.onbeforeunload = () => 'too late';
         sandboxWindow.addEventListener('beforeunload', () => {
           sandboxWindow.beforeUnloadCalls++;
         });
         guardedAtWrite = sandboxWindow.onbeforeunload === null
-          && (sandboxWindow.listeners.get('beforeunload')?.length ?? 0) === 0;
+          && (sandboxWindow.listeners.get('beforeunload')?.length ?? 0) === 1;
 
         for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/gi)) {
           vm.runInContext(match[1], vmContext);
@@ -1558,7 +1571,7 @@ window.dispatchEvent(new Event('click'));
     assert.equal(sandboxWindow.onbeforeunload, null, 'onbeforeunload assignments must remain inert');
     sandboxWindow.onbeforeunload = () => 'still blocked';
     assert.equal(sandboxWindow.onbeforeunload, null, 'ordinary reassignment must not restore onbeforeunload');
-    assert.equal(sandboxWindow.beforeUnloadCalls, 0, 'beforeunload listeners must not be registered');
+    assert.equal(sandboxWindow.beforeUnloadCalls, 0, 'the native stopper must block later beforeunload handlers');
     assert.equal(sandboxWindow.clickCalls, 1, 'listener objects and normal event options must still work');
   });
 


### PR DESCRIPTION
## Summary

Fixes #5730.

Prevents AI-generated custom-widget HTML from arming unload-confirmation handlers inside the isolated widget iframe.

The sandbox now installs a guard before executing widget HTML that:

- ignores assignments to `window.onbeforeunload`
- ignores `beforeunload` registrations through `addEventListener`, including direct prototype calls targeting the sandbox window
- preserves normal event registration and existing sandbox message handling

This removes a source of browser Intervention warnings without weakening the iframe sandbox, origin validation, widget-token validation, or ready/message handshake.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Custom-widget sandbox

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Validation

Passed:

- `node --test tests/widget-builder.test.mjs` (214 passed, 0 failed)
- `./node_modules/.bin/tsx --test tests/deploy-config.test.mjs` (169 passed, 0 failed)
- `./node_modules/.bin/biome check tests/widget-builder.test.mjs` (1 file checked, 0 errors)
- `npm run lint` (passed; 33 existing warnings and 7 informational findings outside the changed files)
- `npm run typecheck`
- `npm run typecheck:api`
- `npx --yes --package=node@22.17.0 -- npm run build:full`

Focused coverage verifies inert `window.onbeforeunload`, ignored window `beforeunload` listener registration through both normal and direct prototype calls, preserved normal listeners and options, guard installation before `document.write`, and unchanged authenticated sandbox message flow.

The broad `npm run test:data` surface remains non-green for unrelated baseline failures. A supported-Node-22 comparison after a full build produced the same 24 failure events on this branch and unchanged upstream `main`; this branch had one additional passing event. The matching failures are in `bootstrap-r2-reader`, `locale-staleness`, `notification-channels-relay-timeout`, and `renewable-energy-last-known-good`.

Manual browser verification was not performed because the in-app browser control runtime was unavailable.

## Documentation Alignment Checklist

N/A. This changes sandbox runtime hardening and does not alter public documentation, API contracts, generated methodology, Redis schemas, CII, or CRI behavior.

## Screenshots

N/A. Sandbox hardening with no intended visual changes.