### PR TITLE
fix(notifications): guide denied push users to browser settings

### DIFF
--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -481,11 +481,12 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
           ? t('components.proActivation.summary.lineFailed', {
               defaultValue: "We couldn't set this up — try again from settings.",
             })
-          : line.outcome === 'blocked' && line.id === 'alerts'
-            ? t('components.proActivation.steps.alerts.blockedNote', {
-                defaultValue:
-                  "Notifications are blocked in your browser. Turn them on in your browser's site settings to get alerts.",
-              })
+          : line.outcome === 'blocked'
+            ? // Reuse the single per-step-id source of truth (blockedNote also
+              // handles ids other than 'alerts' with generic copy) so a future
+              // blockable step can never fall through to the app-settings
+              // promise this branch exists to avoid.
+              blockedNote(line.id, false)
           : t('components.proActivation.summary.linePending', {
               defaultValue: 'Not set up yet — finish any time in settings.',
             });

--- a/src/components/ProActivationInterstitial.ts
+++ b/src/components/ProActivationInterstitial.ts
@@ -481,6 +481,11 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
           ? t('components.proActivation.summary.lineFailed', {
               defaultValue: "We couldn't set this up — try again from settings.",
             })
+          : line.outcome === 'blocked' && line.id === 'alerts'
+            ? t('components.proActivation.steps.alerts.blockedNote', {
+                defaultValue:
+                  "Notifications are blocked in your browser. Turn them on in your browser's site settings to get alerts.",
+              })
           : t('components.proActivation.summary.linePending', {
               defaultValue: 'Not set up yet — finish any time in settings.',
             });
@@ -498,19 +503,22 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
   const summaryHtml = (): string => {
     const lines = buildExitSummary(buildResults());
     const anyVerified = lines.some((line) => line.status === 'verified');
+    const anyBlocked = lines.some((line) => line.outcome === 'blocked');
     const sub = anyVerified
       ? t('components.proActivation.summary.subVerified', {
           defaultValue: "Here's what's running on your account.",
         })
-      : t('components.proActivation.summary.subPending', {
-          defaultValue: 'You can finish setup any time from settings.',
-        });
+      : anyBlocked
+        ? null
+        : t('components.proActivation.summary.subPending', {
+            defaultValue: 'You can finish setup any time from settings.',
+          });
     return `
       <div class="pro-activation-summary">
         <h2 class="pro-activation-heading">${escapeHtml(
           t('components.proActivation.summary.heading', { defaultValue: "You're all set" }),
         )}</h2>
-        <p class="pro-activation-summary-sub">${escapeHtml(sub)}</p>
+        ${sub ? `<p class="pro-activation-summary-sub">${escapeHtml(sub)}</p>` : ''}
         <ul class="pro-activation-summary-list">${lines.map(summaryLineHtml).join('')}</ul>
         <div class="pro-activation-actions">
           <button type="button" class="btn btn-primary pro-activation-primary" data-action="finish">${escapeHtml(
@@ -733,8 +741,8 @@ export function openProActivationInterstitial(options: ProActivationInterstitial
           case 'advance-skip': {
             // `blocked` (mount-time or mid-flow) records as its own outcome so
             // the durable record can still tell a browser refusal from a
-            // voluntary skip. The exit summary still reads it as pending, so
-            // nothing changes for the user (#5617).
+            // voluntary skip. The exit summary keeps the pending status/icon
+            // while rendering browser-specific guidance (#5617, #5727).
             const advanced = selectAdvanceOutcome(effectiveState(step));
             reportAdvanceEvent(step.id, advanced);
             outcomes.set(step.id, advanced);

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -601,6 +601,8 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
       // Last web-push state actually rendered, so the permission watchers below
       // only re-render when it really changed.
       let renderedWebPushState: WebPushSettingsState | null = null;
+      let requestedWebPushState: WebPushSettingsState | null = null;
+      let notifReloadGeneration = 0;
 
       // Fire-and-forget settings writes MUST NOT surface as unhandled promise
       // rejections. A debounced auto-save that 401s (expired Clerk session) or
@@ -615,6 +617,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
       }
 
       function reloadNotifSection(): void {
+        const generation = ++notifReloadGeneration;
         const loadingEl = container.querySelector<HTMLElement>('#usNotifLoading');
         const contentEl = container.querySelector<HTMLElement>('#usNotifContent');
         if (!loadingEl || !contentEl) return;
@@ -625,8 +628,9 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           getChannelsData(undefined, signal),
           readWebPushSettingsState(),
         ]).then(([data, webPushState]) => {
-          if (signal.aborted) return;
+          if (signal.aborted || generation !== notifReloadGeneration) return;
           renderedWebPushState = webPushState;
+          requestedWebPushState = null;
           setTrustedHtml(contentEl, trustedHtml(renderNotifContent(data, webPushState), "legacy direct innerHTML migration"));
           loadingEl.style.display = 'none';
           contentEl.style.display = 'block';
@@ -677,7 +681,8 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             },
           });
         }).catch((err) => {
-          if (signal.aborted) return;
+          if (signal.aborted || generation !== notifReloadGeneration) return;
+          requestedWebPushState = null;
           console.error('[notifications] Failed to load settings:', err);
           if (loadingEl) loadingEl.textContent = 'Failed to load notification settings.';
         });
@@ -759,10 +764,14 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
         if (signal.aborted) return;
         void readWebPushSettingsState().then((state) => {
           if (signal.aborted) return;
-          if (renderedWebPushState === null || state === renderedWebPushState) return;
-          // Claim the new state before the async reload lands so the permission
-          // listener and the focus fallback firing together only re-render once.
-          renderedWebPushState = state;
+          if (
+            renderedWebPushState === null
+            || state === renderedWebPushState
+            || state === requestedWebPushState
+          ) return;
+          // Coalesce the permission listener and focus fallback without
+          // claiming the state as rendered until the reload actually wins.
+          requestedWebPushState = state;
           reloadNotifSection();
         });
       }

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -79,11 +79,26 @@ function appendNotificationError(rowEl: HTMLElement, message: string): void {
 
 type WebPushSettingsState = 'available' | 'denied' | 'unsupported';
 
+const WEB_PUSH_BLOCKED_BADGE = 'Blocked';
+const WEB_PUSH_UNSUPPORTED_BADGE = 'Not supported';
+
 function browserPushBlockedMessage(): string {
   return t('components.proActivation.steps.alerts.blockedNote', {
     defaultValue:
       "Notifications are blocked in your browser. Turn them on in your browser's site settings to get alerts.",
   });
+}
+
+function browserPushUnsupportedMessage(): string {
+  return 'This browser or in-app webview does not support web push notifications.';
+}
+
+// User-Agent is long and ugly. Surface a short label only: "Chrome",
+// "Firefox", "Safari", etc. Shared by the connected row and the
+// connected-but-denied row so the two can't drift.
+function webPushDeviceLabel(channel: NotificationChannel): string {
+  const ua = channel.userAgent ?? '';
+  return /Firefox\/|Chrome\/|Edge\/|Safari\//.exec(ua)?.[0]?.replace('/', '') ?? 'This device';
 }
 
 async function readWebPushSettingsState(): Promise<WebPushSettingsState> {
@@ -96,40 +111,57 @@ async function readWebPushSettingsState(): Promise<WebPushSettingsState> {
   }
 }
 
-function showWebPushBlockedState(rowEl: HTMLElement): void {
-  rowEl.dataset.webPushState = 'denied';
+// Single writer for the two runtime web-push transitions, so the imperative
+// path can't drift from the equivalent template branches in renderChannelRow.
+function applyWebPushRowState(
+  rowEl: HTMLElement,
+  state: 'denied' | 'unsupported',
+  message: string,
+  badgeClass: string,
+  badgeLabel: string,
+): void {
+  rowEl.dataset.webPushState = state;
   rowEl.querySelector('.us-notif-error')?.remove();
   const sub = rowEl.querySelector<HTMLElement>('.us-notif-ch-sub');
   if (sub) {
-    sub.textContent = browserPushBlockedMessage();
+    // Role FIRST: a live region that is created already-populated has no
+    // content change for assistive tech to announce.
+    if (state === 'denied') sub.setAttribute('role', 'status');
+    else sub.removeAttribute('role');
     sub.classList.add('us-notif-ch-sub-wrap');
-    sub.setAttribute('role', 'status');
+    sub.textContent = message;
   }
   const actions = rowEl.querySelector<HTMLElement>('.us-notif-ch-actions');
   if (actions) {
     const badge = document.createElement('span');
-    badge.className = 'us-notif-ch-badge us-notif-ch-badge-blocked';
-    badge.textContent = 'Blocked';
+    badge.className = badgeClass;
+    badge.textContent = badgeLabel;
+    // Preserve Remove: a channel registered on this account stays removable
+    // even once this browser can no longer subscribe.
+    const remove = actions.querySelector('.us-notif-disconnect');
     actions.replaceChildren(badge);
+    if (remove) actions.appendChild(remove);
   }
 }
 
+function showWebPushBlockedState(rowEl: HTMLElement): void {
+  applyWebPushRowState(
+    rowEl,
+    'denied',
+    browserPushBlockedMessage(),
+    'us-notif-ch-badge us-notif-ch-badge-blocked',
+    WEB_PUSH_BLOCKED_BADGE,
+  );
+}
+
 function showWebPushUnsupportedState(rowEl: HTMLElement): void {
-  rowEl.dataset.webPushState = 'unsupported';
-  rowEl.querySelector('.us-notif-error')?.remove();
-  const sub = rowEl.querySelector<HTMLElement>('.us-notif-ch-sub');
-  if (sub) {
-    sub.textContent = 'This browser or in-app webview does not support web push notifications.';
-    sub.classList.add('us-notif-ch-sub-wrap');
-    sub.removeAttribute('role');
-  }
-  const actions = rowEl.querySelector<HTMLElement>('.us-notif-ch-actions');
-  if (actions) {
-    const badge = document.createElement('span');
-    badge.className = 'us-notif-ch-badge';
-    badge.textContent = 'Not supported';
-    actions.replaceChildren(badge);
-  }
+  applyWebPushRowState(
+    rowEl,
+    'unsupported',
+    browserPushUnsupportedMessage(),
+    'us-notif-ch-badge',
+    WEB_PUSH_UNSUPPORTED_BADGE,
+  );
 }
 
 function getTelegramBotUsername(): string {
@@ -212,9 +244,31 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
         const name = CHANNEL_LABELS[type];
 
         if (type === 'web_push' && webPushState === 'denied') {
-          const removeAction = channel?.verified
-            ? '<button type="button" class="us-notif-ch-btn us-notif-disconnect" data-channel="web_push">Remove</button>'
-            : '';
+          // Push permission is per-BROWSER; the web_push channel record is
+          // per-ACCOUNT (convex keys it by userId + channelType and transfers
+          // it across devices). So a denial here says nothing about whether the
+          // account is receiving push — it may be live on another device.
+          //
+          // A connected account therefore keeps the connected presentation, and
+          // critically keeps `us-notif-ch-on`: getCurrentAlertRuleFormState()
+          // derives the persisted `channels` array from that class, so dropping
+          // it would silently delete web_push from the alert rule on the next
+          // autosave (sensitivity, quiet hours, country picker, connecting any
+          // other channel...) with no way to re-add it while denied.
+          if (channel?.verified) {
+            return `<div class="us-notif-ch-row us-notif-ch-on" data-channel-type="web_push" data-web-push-state="denied">
+              <div class="us-notif-ch-icon">${icon}</div>
+              <div class="us-notif-ch-body">
+                <div class="us-notif-ch-name">${name}</div>
+                <div class="us-notif-ch-sub">${escapeHtml(webPushDeviceLabel(channel))}</div>
+                <div class="us-notif-ch-sub us-notif-ch-sub-wrap us-notif-ch-sub-warn" role="status">${escapeHtml(browserPushBlockedMessage())}</div>
+              </div>
+              <div class="us-notif-ch-actions">
+                <span class="us-notif-ch-badge">Connected</span>
+                <button type="button" class="us-notif-ch-btn us-notif-disconnect" data-channel="web_push">Remove</button>
+              </div>
+            </div>`;
+          }
           return `<div class="us-notif-ch-row" data-channel-type="web_push" data-web-push-state="denied">
             <div class="us-notif-ch-icon">${icon}</div>
             <div class="us-notif-ch-body">
@@ -222,8 +276,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
               <div class="us-notif-ch-sub us-notif-ch-sub-wrap" role="status">${escapeHtml(browserPushBlockedMessage())}</div>
             </div>
             <div class="us-notif-ch-actions">
-              <span class="us-notif-ch-badge us-notif-ch-badge-blocked">Blocked</span>
-              ${removeAction}
+              <span class="us-notif-ch-badge us-notif-ch-badge-blocked">${WEB_PUSH_BLOCKED_BADGE}</span>
             </div>
           </div>`;
         }
@@ -240,11 +293,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           } else if (type === 'webhook') {
             sub = channel.webhookLabel ? escapeHtml(channel.webhookLabel) : 'Connected';
           } else if (type === 'web_push') {
-            // User-Agent is long and ugly. Surface a short label only:
-            // "Chrome", "Firefox", "Safari", etc.
-            const ua = channel.userAgent ?? '';
-            const browser = /Firefox\/|Chrome\/|Edge\/|Safari\//.exec(ua)?.[0]?.replace('/', '') ?? 'This device';
-            sub = escapeHtml(browser);
+            sub = escapeHtml(webPushDeviceLabel(channel));
           } else {
             const rawCh = channel.slackChannelName ?? '';
             const ch = rawCh ? `#${escapeHtml(rawCh.startsWith('#') ? rawCh.slice(1) : rawCh)}` : 'connected';
@@ -345,10 +394,10 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
               <div class="us-notif-ch-icon">${icon}</div>
               <div class="us-notif-ch-body">
                 <div class="us-notif-ch-name">${name}</div>
-                <div class="us-notif-ch-sub us-notif-ch-sub-wrap">This browser or in-app webview does not support web push notifications.</div>
+                <div class="us-notif-ch-sub us-notif-ch-sub-wrap">${escapeHtml(browserPushUnsupportedMessage())}</div>
               </div>
               <div class="us-notif-ch-actions">
-                <span class="us-notif-ch-badge">Not supported</span>
+                <span class="us-notif-ch-badge">${WEB_PUSH_UNSUPPORTED_BADGE}</span>
               </div>
             </div>`;
           }
@@ -549,6 +598,10 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
       let qhDebounceTimer: ReturnType<typeof setTimeout> | null = null;
       let digestDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+      // Last web-push state actually rendered, so the permission watchers below
+      // only re-render when it really changed.
+      let renderedWebPushState: WebPushSettingsState | null = null;
+
       // Fire-and-forget settings writes MUST NOT surface as unhandled promise
       // rejections. A debounced auto-save that 401s (expired Clerk session) or
       // hits a transient network error is expected and non-fatal — swallow it
@@ -573,6 +626,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           readWebPushSettingsState(),
         ]).then(([data, webPushState]) => {
           if (signal.aborted) return;
+          renderedWebPushState = webPushState;
           setTrustedHtml(contentEl, trustedHtml(renderNotifContent(data, webPushState), "legacy direct innerHTML migration"));
           loadingEl.style.display = 'none';
           contentEl.style.display = 'block';
@@ -694,6 +748,42 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
       }
 
       reloadNotifSection();
+
+      // The blocked copy sends the user to their BROWSER's site settings, which
+      // is an in-page action: nothing here remounts afterwards (a settings
+      // tab-switch is a guarded no-op in UnifiedSettings.attachNotificationsTab).
+      // Without a watcher the row would stay on "Blocked" with no Enable button
+      // after the user did exactly what we asked, so re-read the permission and
+      // re-render when it actually changes.
+      function resyncWebPushState(): void {
+        if (signal.aborted) return;
+        void readWebPushSettingsState().then((state) => {
+          if (signal.aborted) return;
+          if (renderedWebPushState === null || state === renderedWebPushState) return;
+          // Claim the new state before the async reload lands so the permission
+          // listener and the focus fallback firing together only re-render once.
+          renderedWebPushState = state;
+          reloadNotifSection();
+        });
+      }
+
+      // Chromium/Firefox fire this the moment the site-settings toggle flips.
+      void (async () => {
+        try {
+          const status = await navigator.permissions.query({
+            name: 'notifications' as PermissionName,
+          });
+          if (signal.aborted) return;
+          status.addEventListener('change', resyncWebPushState, { signal });
+        } catch {
+          // Safari and older browsers don't expose the notifications
+          // permission descriptor — the focus fallback below covers them.
+        }
+      })();
+
+      // Fallback for browsers without the permission descriptor: changing site
+      // settings there takes focus away and returns it.
+      window.addEventListener('focus', resyncWebPushState, { signal });
 
       function saveRuleWithNewChannel(newChannel: ChannelType): void {
         const state = getCurrentAlertRuleFormState();
@@ -1107,7 +1197,17 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
 
         if (target.closest('#usConnectWebPush')) {
           const btn = target.closest<HTMLButtonElement>('#usConnectWebPush');
-          const rowEl = btn?.closest<HTMLElement>('[data-channel-type="web_push"]') ?? null;
+          // Re-query rather than capture: Notification.requestPermission() has
+          // no timeout, and any sibling channel action (webhook cancel/save,
+          // email connect, a disconnect, a Slack/Discord OAuth message, the
+          // Telegram pairing poll) can call reloadNotifSection() meanwhile,
+          // which replaces the whole content subtree. A node captured before
+          // the prompt would then be detached and the blocked/unsupported/error
+          // result would be written somewhere the user can never see.
+          const liveRow = (): HTMLElement | null =>
+            container.querySelector<HTMLElement>('[data-channel-type="web_push"]');
+          const liveBtn = (): HTMLButtonElement | null =>
+            container.querySelector<HTMLButtonElement>('#usConnectWebPush');
           if (btn) {
             btn.disabled = true;
             btn.textContent = 'Requesting…';
@@ -1116,12 +1216,15 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             let pushRuntime: typeof import('@/services/push-notifications') | null = null;
             try {
               pushRuntime = await import('@/services/push-notifications');
+              if (signal.aborted) return;
               if (!pushRuntime.isWebPushSupported()) {
-                if (rowEl && !signal.aborted) showWebPushUnsupportedState(rowEl);
+                const row = liveRow();
+                if (row) showWebPushUnsupportedState(row);
                 return;
               }
               if (pushRuntime.getPushPermission() === 'denied') {
-                if (rowEl && !signal.aborted) showWebPushBlockedState(rowEl);
+                const row = liveRow();
+                if (row) showWebPushBlockedState(row);
                 return;
               }
               await pushRuntime.subscribeToPush();
@@ -1129,22 +1232,24 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             } catch (err) {
               console.warn('[notif] web_push subscribe failed:', err);
               if (signal.aborted) return;
+              const row = liveRow();
               const permission = pushRuntime?.getPushPermission();
               if (permission === 'denied') {
-                if (rowEl) showWebPushBlockedState(rowEl);
+                if (row) showWebPushBlockedState(row);
                 return;
               }
               if (pushRuntime && !pushRuntime.isWebPushSupported()) {
-                if (rowEl) showWebPushUnsupportedState(rowEl);
+                if (row) showWebPushUnsupportedState(row);
                 return;
               }
-              if (btn) {
-                btn.disabled = false;
-                btn.textContent = 'Enable';
+              const enableBtn = liveBtn();
+              if (enableBtn) {
+                enableBtn.disabled = false;
+                enableBtn.textContent = 'Enable';
               }
-              if (rowEl) {
+              if (row) {
                 appendNotificationError(
-                  rowEl,
+                  row,
                   'Could not enable browser notifications. Try again.',
                 );
               }

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -20,6 +20,7 @@ import {
 } from '@/services/notification-channels';
 import { getCurrentClerkUser } from '@/services/clerk';
 import { hasTier } from '@/services/entitlements';
+import { t } from '@/services/i18n';
 import { getMarketWatchlistEntries } from '@/services/market-watchlist';
 import { SITE_VARIANT } from '@/config/variant';
 import { mountCountryChipPicker, loadFollowedCountriesSafe, type CountryChipPickerHandle } from '@/utils/country-chip-picker';
@@ -71,8 +72,64 @@ function appendNotificationError(rowEl: HTMLElement, message: string): void {
   rowEl.querySelector('.us-notif-error')?.remove();
   const errorEl = document.createElement('span');
   errorEl.className = 'us-notif-error';
+  errorEl.setAttribute('role', 'alert');
   errorEl.textContent = message;
   rowEl.appendChild(errorEl);
+}
+
+type WebPushSettingsState = 'available' | 'denied' | 'unsupported';
+
+function browserPushBlockedMessage(): string {
+  return t('components.proActivation.steps.alerts.blockedNote', {
+    defaultValue:
+      "Notifications are blocked in your browser. Turn them on in your browser's site settings to get alerts.",
+  });
+}
+
+async function readWebPushSettingsState(): Promise<WebPushSettingsState> {
+  try {
+    const { getPushPermission, isWebPushSupported } = await import('@/services/push-notifications');
+    if (!isWebPushSupported()) return 'unsupported';
+    return getPushPermission() === 'denied' ? 'denied' : 'available';
+  } catch {
+    return 'unsupported';
+  }
+}
+
+function showWebPushBlockedState(rowEl: HTMLElement): void {
+  rowEl.dataset.webPushState = 'denied';
+  rowEl.querySelector('.us-notif-error')?.remove();
+  const sub = rowEl.querySelector<HTMLElement>('.us-notif-ch-sub');
+  if (sub) {
+    sub.textContent = browserPushBlockedMessage();
+    sub.classList.add('us-notif-ch-sub-wrap');
+    sub.setAttribute('role', 'status');
+  }
+  const actions = rowEl.querySelector<HTMLElement>('.us-notif-ch-actions');
+  if (actions) {
+    const badge = document.createElement('span');
+    badge.className = 'us-notif-ch-badge us-notif-ch-badge-blocked';
+    badge.textContent = 'Blocked';
+    actions.replaceChildren(badge);
+  }
+}
+
+function showWebPushUnsupportedState(rowEl: HTMLElement): void {
+  rowEl.dataset.webPushState = 'unsupported';
+  rowEl.querySelector('.us-notif-error')?.remove();
+  const sub = rowEl.querySelector<HTMLElement>('.us-notif-ch-sub');
+  if (sub) {
+    sub.textContent = 'This browser or in-app webview does not support web push notifications.';
+    sub.classList.add('us-notif-ch-sub-wrap');
+    sub.removeAttribute('role');
+  }
+  const actions = rowEl.querySelector<HTMLElement>('.us-notif-ch-actions');
+  if (actions) {
+    const badge = document.createElement('span');
+    badge.className = 'us-notif-ch-badge';
+    badge.textContent = 'Not supported';
+    actions.replaceChildren(badge);
+  }
 }
 
 function getTelegramBotUsername(): string {
@@ -146,9 +203,30 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
 
       const CHANNEL_LABELS: Record<ChannelType, string> = { telegram: 'Telegram', email: 'Email', slack: 'Slack', discord: 'Discord', webhook: 'Webhook', web_push: 'Browser Push' };
 
-      function renderChannelRow(channel: NotificationChannel | null, type: ChannelType): string {
+      function renderChannelRow(
+        channel: NotificationChannel | null,
+        type: ChannelType,
+        webPushState: WebPushSettingsState,
+      ): string {
         const icon = channelIcon(type);
         const name = CHANNEL_LABELS[type];
+
+        if (type === 'web_push' && webPushState === 'denied') {
+          const removeAction = channel?.verified
+            ? '<button type="button" class="us-notif-ch-btn us-notif-disconnect" data-channel="web_push">Remove</button>'
+            : '';
+          return `<div class="us-notif-ch-row" data-channel-type="web_push" data-web-push-state="denied">
+            <div class="us-notif-ch-icon">${icon}</div>
+            <div class="us-notif-ch-body">
+              <div class="us-notif-ch-name">${name}</div>
+              <div class="us-notif-ch-sub us-notif-ch-sub-wrap" role="status">${escapeHtml(browserPushBlockedMessage())}</div>
+            </div>
+            <div class="us-notif-ch-actions">
+              <span class="us-notif-ch-badge us-notif-ch-badge-blocked">Blocked</span>
+              ${removeAction}
+            </div>
+          </div>`;
+        }
 
         if (channel?.verified) {
           let sub: string;
@@ -262,7 +340,19 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
         }
 
         if (type === 'web_push') {
-          return `<div class="us-notif-ch-row" data-channel-type="web_push">
+          if (webPushState === 'unsupported') {
+            return `<div class="us-notif-ch-row" data-channel-type="web_push" data-web-push-state="unsupported">
+              <div class="us-notif-ch-icon">${icon}</div>
+              <div class="us-notif-ch-body">
+                <div class="us-notif-ch-name">${name}</div>
+                <div class="us-notif-ch-sub us-notif-ch-sub-wrap">This browser or in-app webview does not support web push notifications.</div>
+              </div>
+              <div class="us-notif-ch-actions">
+                <span class="us-notif-ch-badge">Not supported</span>
+              </div>
+            </div>`;
+          }
+          return `<div class="us-notif-ch-row" data-channel-type="web_push" data-web-push-state="available">
             <div class="us-notif-ch-icon">${icon}</div>
             <div class="us-notif-ch-body">
               <div class="us-notif-ch-name">${name}</div>
@@ -279,7 +369,10 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
 
       const detectedTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-      function renderNotifContent(data: Awaited<ReturnType<typeof getChannelsData>>): string {
+      function renderNotifContent(
+        data: Awaited<ReturnType<typeof getChannelsData>>,
+        webPushState: WebPushSettingsState,
+      ): string {
         const channelTypes: ChannelType[] = ['telegram', 'email', 'slack', 'discord', 'webhook', 'web_push'];
         const alertRule = data.alertRules?.[0] ?? null;
         const sensitivity = alertRule?.sensitivity ?? 'all';
@@ -287,7 +380,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
         let html = '<div class="ai-flow-section-label">Channels</div>';
         for (const type of channelTypes) {
           const channel = data.channels.find(c => c.channelType === type) ?? null;
-          html += renderChannelRow(channel, type);
+          html += renderChannelRow(channel, type, webPushState);
         }
 
         const qhEnabled = alertRule?.quietHoursEnabled ?? false;
@@ -475,9 +568,12 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
         loadingEl.style.display = 'block';
         contentEl.style.display = 'none';
         if (signal.aborted) return;
-        getChannelsData(undefined, signal).then((data) => {
+        Promise.all([
+          getChannelsData(undefined, signal),
+          readWebPushSettingsState(),
+        ]).then(([data, webPushState]) => {
           if (signal.aborted) return;
-          setTrustedHtml(contentEl, trustedHtml(renderNotifContent(data), "legacy direct innerHTML migration"));
+          setTrustedHtml(contentEl, trustedHtml(renderNotifContent(data, webPushState), "legacy direct innerHTML migration"));
           loadingEl.style.display = 'none';
           contentEl.style.display = 'block';
 
@@ -1011,28 +1107,46 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
 
         if (target.closest('#usConnectWebPush')) {
           const btn = target.closest<HTMLButtonElement>('#usConnectWebPush');
+          const rowEl = btn?.closest<HTMLElement>('[data-channel-type="web_push"]') ?? null;
           if (btn) {
             btn.disabled = true;
             btn.textContent = 'Requesting…';
           }
           (async () => {
+            let pushRuntime: typeof import('@/services/push-notifications') | null = null;
             try {
-              const { subscribeToPush, isWebPushSupported } = await import('@/services/push-notifications');
-              if (!isWebPushSupported()) {
-                if (btn) {
-                  btn.disabled = false;
-                  btn.textContent = 'Not supported';
-                  btn.setAttribute('title', 'This browser (or in-app webview) does not support web push notifications.');
-                }
+              pushRuntime = await import('@/services/push-notifications');
+              if (!pushRuntime.isWebPushSupported()) {
+                if (rowEl && !signal.aborted) showWebPushUnsupportedState(rowEl);
                 return;
               }
-              await subscribeToPush();
+              if (pushRuntime.getPushPermission() === 'denied') {
+                if (rowEl && !signal.aborted) showWebPushBlockedState(rowEl);
+                return;
+              }
+              await pushRuntime.subscribeToPush();
               if (!signal.aborted) { saveRuleWithNewChannel('web_push'); reloadNotifSection(); }
             } catch (err) {
               console.warn('[notif] web_push subscribe failed:', err);
-              if (btn && !signal.aborted) {
+              if (signal.aborted) return;
+              const permission = pushRuntime?.getPushPermission();
+              if (permission === 'denied') {
+                if (rowEl) showWebPushBlockedState(rowEl);
+                return;
+              }
+              if (pushRuntime && !pushRuntime.isWebPushSupported()) {
+                if (rowEl) showWebPushUnsupportedState(rowEl);
+                return;
+              }
+              if (btn) {
                 btn.disabled = false;
                 btn.textContent = 'Enable';
+              }
+              if (rowEl) {
+                appendNotificationError(
+                  rowEl,
+                  'Could not enable browser notifications. Try again.',
+                );
               }
             }
           })();

--- a/src/services/pro-activation-state.ts
+++ b/src/services/pro-activation-state.ts
@@ -678,13 +678,13 @@ export function buildCriticalAlertsPayload(
 /**
  * What actually happened to a step during the flow.
  *
- * `blocked` is deliberately distinct from `skipped` (#5617). Both mean the step
- * was not set up, and both read as `pending` to the user, but only `blocked`
- * says the BROWSER refused — the subscriber never got a choice. Collapsing the
- * two makes the push-permission-denial cohort unsizeable after the fact, and
- * makes "is re-prompting this account worth anything?" unanswerable (it never
- * is, once permission is `denied`). It is equally not `failed`: we never
- * attempted a write, so "we couldn't set this up" would be a false claim.
+ * `blocked` is deliberately distinct from `skipped` (#5617). Both keep the
+ * aggregate `pending` status, but `blocked` says the BROWSER refused and lets
+ * the UI render browser-specific recovery guidance (#5727). Collapsing the two
+ * makes the push-permission-denial cohort unsizeable after the fact, and makes
+ * "is re-prompting this account worth anything?" unanswerable (it never is,
+ * once permission is `denied`). It is equally not `failed`: we never attempted
+ * a write, so "we couldn't set this up" would be a false claim.
  */
 export type ActivationStepOutcome = 'confirmed' | 'skipped' | 'blocked' | 'done' | 'failed';
 
@@ -708,9 +708,10 @@ function outcomeStatus(outcome: ActivationStepOutcome): ActivationSummaryStatus 
     case 'done':
       return 'verified';
     case 'skipped':
-    // A browser refusal is durably distinct (#5617) but reads as `pending` to
-    // the user, NOT `failed`: the summary renders `failed` as "we couldn't set
-    // this up", which claims an attempt we were never allowed to make.
+      // A browser refusal is durably distinct (#5617) but keeps the `pending`
+      // status, NOT `failed`: the summary renders `failed` as "we couldn't set
+      // this up", which claims an attempt we were never allowed to make. Its
+      // detail copy can still explain the browser block (#5727).
     case 'blocked':
       return 'pending';
     case 'failed':

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -26550,6 +26550,10 @@ body.map-width-resizing {
   white-space: normal;
 }
 
+.us-notif-ch-sub-warn {
+  color: var(--settings-red);
+}
+
 .us-notif-ch-actions {
   display: flex;
   align-items: center;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -26544,6 +26544,12 @@ body.map-width-resizing {
   white-space: nowrap;
 }
 
+.us-notif-ch-sub-wrap {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+}
+
 .us-notif-ch-actions {
   display: flex;
   align-items: center;
@@ -26560,6 +26566,11 @@ body.map-width-resizing {
   background: rgba(52, 211, 153, 0.12);
   padding: 2px 7px;
   border-radius: 4px;
+}
+
+.us-notif-ch-badge-blocked {
+  color: var(--settings-red);
+  background: rgba(239, 68, 68, 0.12);
 }
 
 .us-notif-ch-btn {

--- a/tests/dom/notifications-settings-web-push.test.mts
+++ b/tests/dom/notifications-settings-web-push.test.mts
@@ -13,6 +13,7 @@ const pushState = vi.hoisted(() => ({
 const channelMocks = vi.hoisted(() => ({
   getChannelsData: vi.fn(),
   saveAlertRules: vi.fn(),
+  deleteChannel: vi.fn(),
 }));
 
 vi.mock('@/services/push-notifications', () => ({
@@ -30,7 +31,7 @@ vi.mock('@/services/notification-channels', () => ({
   setWebhookChannel: vi.fn(),
   startSlackOAuth: vi.fn(),
   startDiscordOAuth: vi.fn(),
-  deleteChannel: vi.fn(),
+  deleteChannel: channelMocks.deleteChannel,
   setQuietHours: vi.fn(),
   setDigestSettings: vi.fn(),
   setNotificationConfig: vi.fn(),
@@ -65,6 +66,17 @@ vi.mock('uqr', () => ({
 import { renderNotificationsSettings } from '@/services/notifications-settings';
 
 const EMPTY_DATA: ChannelsData = { channels: [], alertRules: [] };
+const CONNECTED_WEB_PUSH: ChannelsData = {
+  channels: [
+    {
+      channelType: 'web_push',
+      verified: true,
+      linkedAt: 1,
+      userAgent: 'Chrome/140.0',
+    },
+  ],
+  alertRules: [],
+};
 const cleanups: Array<() => void> = [];
 
 async function mount(data: ChannelsData = EMPTY_DATA): Promise<HTMLElement> {
@@ -106,6 +118,8 @@ beforeEach(() => {
   channelMocks.getChannelsData.mockReset();
   channelMocks.saveAlertRules.mockReset();
   channelMocks.saveAlertRules.mockResolvedValue(undefined);
+  channelMocks.deleteChannel.mockReset();
+  channelMocks.deleteChannel.mockResolvedValue(undefined);
 });
 
 afterAll(() => {
@@ -241,17 +255,7 @@ describe('notification Settings browser push', () => {
 
   it('preserves the connected browser display while permission is usable', async () => {
     pushState.permission = 'granted';
-    const container = await mount({
-      channels: [
-        {
-          channelType: 'web_push',
-          verified: true,
-          linkedAt: 1,
-          userAgent: 'Chrome/140.0',
-        },
-      ],
-      alertRules: [],
-    });
+    const container = await mount(CONNECTED_WEB_PUSH);
     const row = webPushRow(container);
 
     expect(row.classList.contains('us-notif-ch-on')).toBe(true);
@@ -260,26 +264,145 @@ describe('notification Settings browser push', () => {
     expect(row.querySelector('#usConnectWebPush')).toBeNull();
   });
 
-  it('keeps Remove available while warning a connected browser that permission is denied', async () => {
+  it('keeps a connected account connected while warning that this browser is denied', async () => {
     pushState.permission = 'denied';
-    const container = await mount({
-      channels: [
-        {
-          channelType: 'web_push',
-          verified: true,
-          linkedAt: 1,
-          userAgent: 'Chrome/140.0',
-        },
-      ],
-      alertRules: [],
-    });
+    const container = await mount(CONNECTED_WEB_PUSH);
     const row = webPushRow(container);
 
     expect(row.dataset.webPushState).toBe('denied');
-    expect(row.querySelector('.us-notif-ch-sub')?.textContent).toBe(
-      tt('components.proActivation.steps.alerts.blockedNote'),
-    );
+    // Permission is per-browser; the channel record is per-account. A denial
+    // here must not present the account as disconnected.
+    expect(row.classList.contains('us-notif-ch-on')).toBe(true);
+    expect(row.querySelector('.us-notif-ch-badge')?.textContent).toBe('Connected');
     expect(row.querySelector('.us-notif-disconnect')).not.toBeNull();
     expect(row.querySelector('#usConnectWebPush')).toBeNull();
+
+    const subs = Array.from(row.querySelectorAll('.us-notif-ch-sub')).map(el => el.textContent);
+    expect(subs[0]).toBe('Chrome');
+    expect(subs[1]).toBe(tt('components.proActivation.steps.alerts.blockedNote'));
+  });
+
+  it('keeps web_push in the saved alert rule when this browser is denied', async () => {
+    // Regression: the denied row used to drop `us-notif-ch-on`, and
+    // getCurrentAlertRuleFormState derives the persisted `channels` array from
+    // that class -- so any incidental autosave silently deleted browser push
+    // from the rule, account-wide, with no way to re-add it while denied.
+    pushState.permission = 'denied';
+    const container = await mount(CONNECTED_WEB_PUSH);
+    expect(webPushRow(container).classList.contains('us-notif-ch-on')).toBe(true);
+
+    const sensitivity = container.querySelector<HTMLSelectElement>('#usNotifSensitivity');
+    expect(sensitivity).not.toBeNull();
+    sensitivity!.value = 'high';
+    sensitivity!.dispatchEvent(new Event('change', { bubbles: true }));
+
+    await vi.waitFor(
+      () => {
+        expect(channelMocks.saveAlertRules).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 4000 },
+    );
+    expect(channelMocks.saveAlertRules.mock.calls[0]?.[0]?.channels).toContain('web_push');
+  });
+
+  it('restores the Enable action when permission is re-granted in browser settings', async () => {
+    // The blocked copy sends the user to BROWSER site settings, which never
+    // remounts this panel. Without a permission re-sync the row would stay on
+    // "Blocked" after the user did exactly what we asked.
+    pushState.permission = 'denied';
+    const container = await mount();
+    expect(webPushRow(container).querySelector('#usConnectWebPush')).toBeNull();
+
+    pushState.permission = 'granted';
+    window.dispatchEvent(new Event('focus'));
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).dataset.webPushState).toBe('available');
+    });
+    expect(webPushRow(container).querySelector('#usConnectWebPush')).not.toBeNull();
+  });
+
+  it('shows unsupported guidance when support disappears during the subscribe', async () => {
+    const container = await mount();
+    pushState.subscribeToPush.mockImplementation(async () => {
+      pushState.supported = false;
+      pushState.permission = 'unsupported';
+      throw new Error('push manager went away');
+    });
+
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).dataset.webPushState).toBe('unsupported');
+    });
+    const row = webPushRow(container);
+    expect(row.textContent).toContain('Not supported');
+    expect(row.querySelector('.us-notif-error')).toBeNull();
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+  });
+
+  it('writes the failure result into the live row after a concurrent reload', async () => {
+    // reloadNotifSection() replaces the whole content subtree. A row captured
+    // before the (untimed) permission prompt would be detached by the time the
+    // result lands, so the guidance would be written where nobody can see it.
+    pushState.permission = 'default';
+    const container = await mount({
+      channels: [
+        { channelType: 'email', verified: true, linkedAt: 1, email: 'a@b.test' },
+      ],
+      alertRules: [],
+    });
+
+    let rejectSubscribe: ((err: Error) => void) | undefined;
+    pushState.subscribeToPush.mockImplementation(
+      () => new Promise((_resolve, reject) => { rejectSubscribe = reject; }),
+    );
+
+    const originalRow = webPushRow(container);
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+    await vi.waitFor(() => {
+      expect(rejectSubscribe).toBeDefined();
+    });
+
+    // Sibling action re-renders the section while the subscribe is in flight.
+    container.querySelector<HTMLElement>('.us-notif-disconnect[data-channel="email"]')!.click();
+    await vi.waitFor(() => {
+      expect(webPushRow(container)).not.toBe(originalRow);
+    });
+
+    pushState.permission = 'denied';
+    rejectSubscribe!(new Error('permission rejected'));
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).dataset.webPushState).toBe('denied');
+    });
+    expect(webPushRow(container).isConnected).toBe(true);
+  });
+
+  it('leaves the row untouched when the panel is torn down mid-subscribe', async () => {
+    const container = await mount();
+
+    let rejectSubscribe: ((err: Error) => void) | undefined;
+    pushState.subscribeToPush.mockImplementation(
+      () => new Promise((_resolve, reject) => { rejectSubscribe = reject; }),
+    );
+
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+    await vi.waitFor(() => {
+      expect(rejectSubscribe).toBeDefined();
+    });
+
+    // Abort the section (what UnifiedSettings does on teardown).
+    cleanups.pop()?.();
+
+    pushState.permission = 'denied';
+    rejectSubscribe!(new Error('permission rejected'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = webPushRow(container);
+    expect(row.dataset.webPushState).toBe('available');
+    expect(row.querySelector('.us-notif-error')).toBeNull();
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
   });
 });

--- a/tests/dom/notifications-settings-web-push.test.mts
+++ b/tests/dom/notifications-settings-web-push.test.mts
@@ -1,0 +1,285 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChannelsData } from '@/services/notification-channels';
+
+import { initTestI18n, tt } from './helpers/i18n.mts';
+
+const pushState = vi.hoisted(() => ({
+  supported: true,
+  permission: 'default' as 'default' | 'granted' | 'denied' | 'unsupported',
+  subscribeToPush: vi.fn<() => Promise<unknown>>(),
+}));
+
+const channelMocks = vi.hoisted(() => ({
+  getChannelsData: vi.fn(),
+  saveAlertRules: vi.fn(),
+}));
+
+vi.mock('@/services/push-notifications', () => ({
+  isWebPushSupported: () => pushState.supported,
+  getPushPermission: () => pushState.permission,
+  subscribeToPush: pushState.subscribeToPush,
+  unsubscribeFromPush: vi.fn(),
+}));
+
+vi.mock('@/services/notification-channels', () => ({
+  getChannelsData: channelMocks.getChannelsData,
+  saveAlertRules: channelMocks.saveAlertRules,
+  createPairingToken: vi.fn(),
+  setEmailChannel: vi.fn(),
+  setWebhookChannel: vi.fn(),
+  startSlackOAuth: vi.fn(),
+  startDiscordOAuth: vi.fn(),
+  deleteChannel: vi.fn(),
+  setQuietHours: vi.fn(),
+  setDigestSettings: vi.fn(),
+  setNotificationConfig: vi.fn(),
+  IncompatibleDeliveryError: class IncompatibleDeliveryError extends Error {},
+}));
+
+vi.mock('@/services/clerk', () => ({
+  getCurrentClerkUser: () => ({ id: 'user_push', email: 'push@worldmonitor.test' }),
+}));
+
+vi.mock('@/services/entitlements', () => ({
+  hasTier: () => true,
+}));
+
+vi.mock('@/services/market-watchlist', () => ({
+  getMarketWatchlistEntries: () => [],
+}));
+
+vi.mock('@/utils/country-chip-picker', () => ({
+  loadFollowedCountriesSafe: () => [],
+  mountCountryChipPicker: () => ({
+    getValue: () => [],
+    setValue: () => {},
+    destroy: () => {},
+  }),
+}));
+
+vi.mock('uqr', () => ({
+  renderSVG: () => '<svg></svg>',
+}));
+
+import { renderNotificationsSettings } from '@/services/notifications-settings';
+
+const EMPTY_DATA: ChannelsData = { channels: [], alertRules: [] };
+const cleanups: Array<() => void> = [];
+
+async function mount(data: ChannelsData = EMPTY_DATA): Promise<HTMLElement> {
+  channelMocks.getChannelsData.mockResolvedValue(data);
+  const container = document.createElement('div');
+  const rendered = renderNotificationsSettings({ isSignedIn: true });
+  container.innerHTML = rendered.html;
+  document.body.appendChild(container);
+  cleanups.push(rendered.attach(container));
+
+  await vi.waitFor(() => {
+    expect(container.querySelector<HTMLElement>('#usNotifContent')?.style.display).toBe('block');
+  });
+  return container;
+}
+
+function webPushRow(container: HTMLElement): HTMLElement {
+  const row = container.querySelector<HTMLElement>('[data-channel-type="web_push"]');
+  expect(row).not.toBeNull();
+  return row!;
+}
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+beforeEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+  document.body.replaceChildren();
+  pushState.supported = true;
+  pushState.permission = 'default';
+  pushState.subscribeToPush.mockReset();
+  pushState.subscribeToPush.mockResolvedValue({
+    endpoint: 'https://push.test/subscription',
+    p256dh: 'key',
+    auth: 'auth',
+    userAgent: 'test',
+  });
+  channelMocks.getChannelsData.mockReset();
+  channelMocks.saveAlertRules.mockReset();
+  channelMocks.saveAlertRules.mockResolvedValue(undefined);
+});
+
+afterAll(() => {
+  while (cleanups.length) cleanups.pop()?.();
+  document.body.replaceChildren();
+});
+
+describe('notification Settings browser push', () => {
+  it('renders denied permission as browser site-settings guidance without Enable', async () => {
+    pushState.permission = 'denied';
+    const container = await mount();
+    const row = webPushRow(container);
+
+    expect(row.dataset.webPushState).toBe('denied');
+    expect(row.querySelector('.us-notif-ch-sub')?.textContent).toBe(
+      tt('components.proActivation.steps.alerts.blockedNote'),
+    );
+    expect(row.querySelector('#usConnectWebPush')).toBeNull();
+    expect(row.querySelector('.us-notif-ch-badge')?.textContent).toBe('Blocked');
+
+    expect(container.querySelector('#usConnectTelegram')).not.toBeNull();
+    expect(container.querySelector('#usConnectEmail')).not.toBeNull();
+    expect(container.querySelector('#usConnectSlack')).not.toBeNull();
+    expect(container.querySelector('#usConnectDiscord')).not.toBeNull();
+    expect(container.querySelector('#usConnectWebhook')).not.toBeNull();
+  });
+
+  it('re-checks live permission before subscribing', async () => {
+    const container = await mount();
+    const button = container.querySelector<HTMLButtonElement>('#usConnectWebPush');
+    expect(button).not.toBeNull();
+
+    pushState.permission = 'denied';
+    button!.click();
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).dataset.webPushState).toBe('denied');
+    });
+    expect(pushState.subscribeToPush).not.toHaveBeenCalled();
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+    expect(webPushRow(container).textContent).not.toContain('Requesting');
+  });
+
+  it('shows blocked guidance when denial is discovered through rejection', async () => {
+    const container = await mount();
+    pushState.subscribeToPush.mockImplementation(async () => {
+      pushState.permission = 'denied';
+      throw new Error('permission rejected');
+    });
+
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).dataset.webPushState).toBe('denied');
+    });
+    const row = webPushRow(container);
+    expect(pushState.subscribeToPush).toHaveBeenCalledTimes(1);
+    expect(row.querySelector('#usConnectWebPush')).toBeNull();
+    expect(row.querySelector('.us-notif-ch-sub')?.textContent).toBe(
+      tt('components.proActivation.steps.alerts.blockedNote'),
+    );
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a safe retryable error when subscription fails without denial', async () => {
+    const container = await mount();
+    pushState.subscribeToPush.mockRejectedValue(
+      new Error('secret endpoint https://internal.example/token/123 failed'),
+    );
+
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).querySelector('.us-notif-error')).not.toBeNull();
+    });
+    const row = webPushRow(container);
+    const button = row.querySelector<HTMLButtonElement>('#usConnectWebPush');
+    const error = row.querySelector<HTMLElement>('.us-notif-error');
+    expect(error?.textContent).toBe('Could not enable browser notifications. Try again.');
+    expect(error?.getAttribute('role')).toBe('alert');
+    expect(row.textContent).not.toContain('internal.example');
+    expect(button?.disabled).toBe(false);
+    expect(button?.textContent).toBe('Enable');
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+  });
+
+  it('preserves the successful subscription and rule-update path', async () => {
+    const container = await mount();
+
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+
+    await vi.waitFor(() => {
+      expect(channelMocks.getChannelsData).toHaveBeenCalledTimes(2);
+    });
+    expect(pushState.subscribeToPush).toHaveBeenCalledTimes(1);
+    expect(channelMocks.saveAlertRules).toHaveBeenCalledTimes(1);
+    expect(channelMocks.saveAlertRules.mock.calls[0]?.[0]).toMatchObject({
+      channels: ['web_push'],
+    });
+    const row = webPushRow(container);
+    expect(row.dataset.webPushState).toBe('available');
+    expect(row.querySelector('.us-notif-error')).toBeNull();
+    expect(row.querySelector('.us-notif-ch-badge-blocked')).toBeNull();
+  });
+
+  it('keeps unsupported browsers non-actionable', async () => {
+    pushState.supported = false;
+    pushState.permission = 'unsupported';
+    const container = await mount();
+    const row = webPushRow(container);
+
+    expect(row.dataset.webPushState).toBe('unsupported');
+    expect(row.querySelector('#usConnectWebPush')).toBeNull();
+    expect(row.textContent).toContain('Not supported');
+    expect(pushState.subscribeToPush).not.toHaveBeenCalled();
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+  });
+
+  it('becomes non-actionable if support disappears before the click', async () => {
+    const container = await mount();
+    pushState.supported = false;
+    pushState.permission = 'unsupported';
+
+    container.querySelector<HTMLButtonElement>('#usConnectWebPush')!.click();
+
+    await vi.waitFor(() => {
+      expect(webPushRow(container).dataset.webPushState).toBe('unsupported');
+    });
+    expect(webPushRow(container).querySelector('#usConnectWebPush')).toBeNull();
+    expect(pushState.subscribeToPush).not.toHaveBeenCalled();
+    expect(channelMocks.saveAlertRules).not.toHaveBeenCalled();
+  });
+
+  it('preserves the connected browser display while permission is usable', async () => {
+    pushState.permission = 'granted';
+    const container = await mount({
+      channels: [
+        {
+          channelType: 'web_push',
+          verified: true,
+          linkedAt: 1,
+          userAgent: 'Chrome/140.0',
+        },
+      ],
+      alertRules: [],
+    });
+    const row = webPushRow(container);
+
+    expect(row.classList.contains('us-notif-ch-on')).toBe(true);
+    expect(row.textContent).toContain('Connected');
+    expect(row.querySelector('.us-notif-disconnect')).not.toBeNull();
+    expect(row.querySelector('#usConnectWebPush')).toBeNull();
+  });
+
+  it('keeps Remove available while warning a connected browser that permission is denied', async () => {
+    pushState.permission = 'denied';
+    const container = await mount({
+      channels: [
+        {
+          channelType: 'web_push',
+          verified: true,
+          linkedAt: 1,
+          userAgent: 'Chrome/140.0',
+        },
+      ],
+      alertRules: [],
+    });
+    const row = webPushRow(container);
+
+    expect(row.dataset.webPushState).toBe('denied');
+    expect(row.querySelector('.us-notif-ch-sub')?.textContent).toBe(
+      tt('components.proActivation.steps.alerts.blockedNote'),
+    );
+    expect(row.querySelector('.us-notif-disconnect')).not.toBeNull();
+    expect(row.querySelector('#usConnectWebPush')).toBeNull();
+  });
+});

--- a/tests/dom/notifications-settings-web-push.test.mts
+++ b/tests/dom/notifications-settings-web-push.test.mts
@@ -322,6 +322,70 @@ describe('notification Settings browser push', () => {
     expect(webPushRow(container).querySelector('#usConnectWebPush')).not.toBeNull();
   });
 
+  it('ignores an older reload that resolves after a newer channel state', async () => {
+    pushState.permission = 'granted';
+    const initialData: ChannelsData = {
+      channels: [
+        ...CONNECTED_WEB_PUSH.channels,
+        { channelType: 'email', verified: true, linkedAt: 1, email: 'a@b.test' },
+      ],
+      alertRules: [],
+    };
+    const container = await mount(initialData);
+
+    let resolveOlderReload: ((data: ChannelsData) => void) | undefined;
+    channelMocks.getChannelsData
+      .mockImplementationOnce(
+        () => new Promise<ChannelsData>((resolve) => { resolveOlderReload = resolve; }),
+      )
+      .mockResolvedValueOnce(EMPTY_DATA);
+
+    pushState.permission = 'denied';
+    window.dispatchEvent(new Event('focus'));
+    await vi.waitFor(() => {
+      expect(resolveOlderReload).toBeDefined();
+    });
+
+    container
+      .querySelector<HTMLElement>('.us-notif-disconnect[data-channel="email"]')!
+      .click();
+    await vi.waitFor(() => {
+      expect(channelMocks.getChannelsData).toHaveBeenCalledTimes(3);
+      expect(webPushRow(container).classList.contains('us-notif-ch-on')).toBe(false);
+    });
+
+    resolveOlderReload!(CONNECTED_WEB_PUSH);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(webPushRow(container).classList.contains('us-notif-ch-on')).toBe(false);
+    expect(webPushRow(container).dataset.webPushState).toBe('denied');
+  });
+
+  it('retries permission recovery after a reload failure', async () => {
+    pushState.permission = 'denied';
+    const container = await mount();
+    channelMocks.getChannelsData
+      .mockRejectedValueOnce(new Error('temporary channels failure'))
+      .mockResolvedValueOnce(EMPTY_DATA);
+
+    pushState.permission = 'granted';
+    window.dispatchEvent(new Event('focus'));
+    await vi.waitFor(() => {
+      expect(channelMocks.getChannelsData).toHaveBeenCalledTimes(2);
+      expect(container.querySelector('#usNotifLoading')?.textContent).toBe(
+        'Failed to load notification settings.',
+      );
+    });
+
+    window.dispatchEvent(new Event('focus'));
+    await vi.waitFor(() => {
+      expect(channelMocks.getChannelsData).toHaveBeenCalledTimes(3);
+      expect(webPushRow(container).dataset.webPushState).toBe('available');
+    });
+    expect(webPushRow(container).querySelector('#usConnectWebPush')).not.toBeNull();
+  });
+
   it('shows unsupported guidance when support disappears during the subscribe', async () => {
     const container = await mount();
     pushState.subscribeToPush.mockImplementation(async () => {

--- a/tests/pro-activation-alerts-blocked.test.mts
+++ b/tests/pro-activation-alerts-blocked.test.mts
@@ -616,6 +616,109 @@ describe('activation interstitial blocked transition (#5609)', () => {
     assert.doesNotMatch(html, /steps\.alerts\.declinedNote/);
   });
 
+  it('renders blocked-specific summary guidance while preserving pending status', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const { dom, exits } = openAlertsStep(mod, async () => 'blocked', 'blocked');
+
+    assert.equal(clickPrimary(dom), 'advance-skip');
+    const html = renderedHtml(dom);
+    assert.match(html, /summary-line status-pending/, 'blocked keeps the pending icon/status');
+    assert.match(
+      html,
+      /steps\.alerts\.blockedNote/,
+      'blocked summary detail must point to browser site settings',
+    );
+    assert.doesNotMatch(
+      html,
+      /summary\.linePending/,
+      'blocked alerts must not reuse the generic app-settings promise',
+    );
+    assert.doesNotMatch(html, /summary\.lineFailed/, 'a browser refusal is not a failed write');
+    assert.doesNotMatch(
+      html,
+      /summary\.subPending/,
+      'a blocked-only summary must not repeat the false app-settings promise',
+    );
+
+    assert.equal(clickPrimary(dom), 'finish');
+    assert.deepEqual(exits, [[{ id: 'alerts', outcome: 'blocked' }]]);
+  });
+
+  it('keeps an ordinary skipped alert on the generic pending summary path', async () => {
+    installPushState('default', false);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const { dom, exits } = openAlertsStep(mod, async () => 'verified');
+
+    const skip = dom.document.body.querySelector('.pro-activation-skip');
+    assert.ok(skip, 'a confirmable alert step must offer Skip');
+    skip!.dispatchEvent(new Event('click'));
+
+    const html = renderedHtml(dom);
+    assert.match(html, /summary-line status-pending/);
+    assert.match(html, /summary\.linePending/, 'a real skip keeps ordinary pending guidance');
+    assert.match(html, /summary\.subPending/, 'skip-only setup can still be finished in settings');
+    assert.doesNotMatch(
+      html,
+      /steps\.alerts\.blockedNote/,
+      'ordinary skips must not receive browser-blocked copy',
+    );
+    assert.doesNotMatch(html, /summary\.lineFailed/);
+
+    assert.equal(clickPrimary(dom), 'finish');
+    assert.deepEqual(exits, [[{ id: 'alerts', outcome: 'skipped' }]]);
+  });
+
+  it('renders blocked and skipped details distinctly in a mixed summary', async () => {
+    installPushState('denied', true);
+    activeDom = installDom();
+    const mod = await loadInterstitial();
+    const dom = activeDom!;
+    const exits: Array<Array<{ id: string; outcome: string }>> = [];
+    mod.openProActivationInterstitial({
+      steps: [
+        { id: 'alerts', state: 'blocked' },
+        { id: 'power', state: 'confirmable' },
+      ],
+      accountEmail: 'pro@worldmonitor.test',
+      onConfirmStep: (async () => 'verified') as never,
+      onSkipStep: () => {},
+      onExit: (results) => exits.push(results as never),
+    });
+    activeClose = mod.closeProActivationInterstitial;
+
+    assert.equal(clickPrimary(dom), 'advance-skip');
+    const skip = dom.document.body.querySelector('.pro-activation-skip');
+    assert.ok(skip, 'the ordinary power step must remain skippable');
+    skip!.dispatchEvent(new Event('click'));
+
+    const html = renderedHtml(dom);
+    assert.equal(
+      (html.match(/steps\.alerts\.blockedNote/g) ?? []).length,
+      1,
+      'only the blocked alert line gets browser guidance',
+    );
+    assert.equal(
+      (html.match(/summary\.linePending/g) ?? []).length,
+      1,
+      'only the ordinary skipped line gets app-settings guidance',
+    );
+    assert.doesNotMatch(
+      html,
+      /summary\.subPending/,
+      'the overall subtitle must not promise app Settings can resolve every unfinished step',
+    );
+    assert.doesNotMatch(html, /summary\.lineFailed/);
+
+    assert.equal(clickPrimary(dom), 'finish');
+    assert.deepEqual(exits, [[
+      { id: 'alerts', outcome: 'blocked' },
+      { id: 'power', outcome: 'skipped' },
+    ]]);
+  });
+
   it('keeps offering "Try again" when the confirm merely failed', async () => {
     installPushState('default', true);
     activeDom = installDom();

--- a/tests/pro-activation-state.test.mts
+++ b/tests/pro-activation-state.test.mts
@@ -906,9 +906,9 @@ describe('buildExitSummary — R15 pending/verified/failed', () => {
     ]);
   });
 
-  // #5617: a browser refusal is durably distinct from a voluntary skip, but the
-  // USER-facing line must stay identical — 'failed' renders "We couldn't set
-  // this up", which is wrong for a permission we were never allowed to attempt.
+  // #5617/#5727: a browser refusal is durably distinct from a voluntary skip.
+  // Its status stays pending, while the rendering layer is free to give the
+  // denied cohort truthful browser-settings guidance.
   it('blocked reads as pending, never failed (#5617)', () => {
     assert.deepEqual(buildExitSummary([{ id: 'alerts', outcome: 'blocked' }]), [
       { id: 'alerts', outcome: 'blocked', status: 'pending' },


### PR DESCRIPTION
## Summary

Fixes #5727.

Prevents users with browser push permission set to `denied` from being directed to an application Settings action that cannot succeed.

This change:

- gives blocked activation steps browser-specific site-settings guidance
- keeps ordinary skipped steps on the existing pending path
- removes the dead-end Enable action when permission is already denied
- re-checks live permission before attempting subscription
- surfaces a visible retryable error for non-denial subscription failures
- preserves successful, unsupported, and already-connected push behavior

The durable `blocked` activation outcome and existing telemetry semantics remain unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [x] Config / Settings
- [x] Other: Pro activation and browser-push onboarding

## Checklist

- [ ] Tested on worldmonitor.app variant
- [ ] Tested on tech.worldmonitor.app variant, if applicable
- [ ] New RSS feed domains added to allowlist - N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors

## Validation

Passed:

- `./node_modules/.bin/tsx --test tests/pro-activation-alerts-blocked.test.mts` - 23/23
- `./node_modules/.bin/tsx --test tests/pro-activation-state.test.mts` - 128/128
- `node --test tests/notifications-settings-ui-invariants.test.mjs` - 17/17
- `./node_modules/.bin/tsx --test tests/notifications-settings-country-picker.test.mts` - 44/44
- `./node_modules/.bin/vitest run --config vitest.dom.config.mts tests/dom/notifications-settings-web-push.test.mts` - 9/9
- `npm run test:dom` - 95/95
- `npm run typecheck:dom-tests`
- `npm run sync:locales:check` - 24 locale files, 2,593 keys each
- Biome on all changed source and test files
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:api`
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx --yes --package=node@24 -- npm run build:full`
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx --yes --package=node@24 -- ./node_modules/.bin/playwright test e2e/pro-activation.spec.ts` - 35/35

Coverage includes:

- blocked-specific activation summary
- ordinary skipped and mixed summaries
- denied Settings rendering
- live denial before click
- denial discovered after subscription rejection
- visible non-denial error with retry
- successful subscription and rule update
- connected and unsupported browser behavior

Broad-suite baseline:

- `npm_config_cache=/tmp/worldmonitor-npm-cache npx --yes --package=node@24 -- npm run test:data` - 18,125/18,132 passed, 1 failed, 6 skipped
- The sole failure is `tests/mcp.test.mjs: get_economic_data: China v2 aliases, dataset filter, country filter, and schema stay aligned`, where a dated fixture is now `stale` instead of `fresh`.
- The same assertion fails on unchanged upstream `main` at `750374149ee47159be415b967c4f6820f3a91974`: 147/148 in `tests/mcp.test.mjs`.

## Documentation Alignment Checklist

N/A - this changes activation and notification Settings behavior without altering public API contracts, methodology, Redis schemas, CII, or CRI behavior.

## Screenshots

No visual artifact was captured.
Manual authenticated notification Settings verification was not performed because live notification backend credentials were unavailable; deterministic DOM and Playwright coverage exercised the affected behavior.
