### PR TITLE
fix(test): stop the China macro fixture rotting on a calendar date (#5762)

### DIFF
--- a/tests/china-macro-fixture-freshness.test.mts
+++ b/tests/china-macro-fixture-freshness.test.mts
@@ -1,0 +1,152 @@
+// Guards the recorded China macro fixture against wall-clock rot (#5762).
+//
+// The fixture is a snapshot of a moment in time, but two read paths re-derive
+// freshness against Date.now():
+//
+//   transport  now - (lastSuccessAt ?? retrievalTime) vs CHINA_MACRO_MAX_TRANSPORT_AGE_MIN (72h)
+//   content    now - observationPeriod                vs CHINA_MACRO_SERIES_MAX_AGE_DAYS  (75d)
+//
+// Both expire on a calendar date. When the transport window lapsed on
+// 2026-07-28T14:30Z it turned `tests/mcp.test.mjs` red on every branch at once
+// and blocked every open PR, with a failure message ('stale' !== 'fresh') that
+// said nothing about the cause.
+//
+// Both are now structurally fixed. Consumers that re-derive freshness build the
+// fixture with the live clock, and the recorded dates are rebased per build so
+// the snapshot always describes "last month's release, published days ago"
+// rather than one literal moment. This file locks both properties in.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  CHINA_MACRO_SERIES_MAX_AGE_DAYS,
+  chinaMacroObservationDateMs,
+  isChinaMacroObservationStale,
+} from '../scripts/_china-macro-contract.mjs';
+import {
+  buildOfficialChinaMacroFixture,
+  CHINA_MACRO_FIXTURE_RETRIEVAL_TIME,
+} from './helpers/china-macro-fixture.mjs';
+
+// The rebased period is the previous whole month, so age peaks at ~31 days.
+// The tightest series budget is SAFE at 45 days, leaving a guaranteed floor of
+// ~14 days. Sit just under that: firing means the rebase or a budget changed.
+const REQUIRED_HEADROOM_DAYS = 10;
+const DAY_MS = 86_400_000;
+
+describe('China macro fixture freshness', () => {
+  it('reads as freshly retrieved when built with the live clock', async () => {
+    // This is the invariant #5762 broke. Building with the live clock is what
+    // makes every wall-clock-re-deriving consumer time-invariant; if this
+    // regresses, `tests/mcp.test.mjs` goes red on a calendar date again.
+    const snapshot = await buildOfficialChinaMacroFixture(Date.now());
+    const observations = (snapshot as { observations?: Record<string, unknown>[] }).observations ?? [];
+    assert.ok(observations.length > 0, 'fixture must produce observations');
+
+    const succeeded = observations.filter((o) => o.transportStatus === 'fresh');
+    assert.ok(
+      succeeded.length > 0,
+      'at least one fixture source must transport successfully, or the guard proves nothing',
+    );
+    for (const observation of succeeded) {
+      const age = Date.now() - Date.parse(String(observation.retrievalTime));
+      assert.ok(
+        age < 60_000,
+        `${observation.seriesId} retrievalTime must track the clock the fixture was built with, got age ${Math.round(age / 1000)}s`,
+      );
+    }
+  });
+
+  it('keeps the pinned default for snapshot-asserting consumers', async () => {
+    // tests/china-macro-rpc.test.mts and tests/macro-tiles-china-ui.test.mts
+    // assert against CHINA_MACRO_FIXTURE_RETRIEVAL_TIME directly, so the
+    // no-argument default must stay byte-stable.
+    const snapshot = await buildOfficialChinaMacroFixture();
+    const observations = (snapshot as { observations?: Record<string, unknown>[] }).observations ?? [];
+    const fresh = observations.find((o) => o.transportStatus === 'fresh');
+    assert.equal(fresh?.retrievalTime, CHINA_MACRO_FIXTURE_RETRIEVAL_TIME);
+  });
+
+  it('recorded observation periods retain content-window headroom', async () => {
+    const snapshot = await buildOfficialChinaMacroFixture(Date.now());
+    const observations = (snapshot as { observations?: Record<string, unknown>[] }).observations ?? [];
+    const now = Date.now();
+    const expiring: string[] = [];
+
+    for (const observation of observations) {
+      const seriesId = String(observation.seriesId);
+      const period = String(observation.observationPeriod);
+      const maxAgeDays = (CHINA_MACRO_SERIES_MAX_AGE_DAYS as Record<string, number>)[seriesId];
+      const observedAt = chinaMacroObservationDateMs(period);
+      if (!Number.isFinite(maxAgeDays) || observedAt == null) continue;
+      // Already stale is a hard failure; nearly stale is the early warning.
+      const expiresAt = observedAt + maxAgeDays * DAY_MS;
+      const headroomDays = (expiresAt - now) / DAY_MS;
+      if (headroomDays < REQUIRED_HEADROOM_DAYS) {
+        expiring.push(
+          `${seriesId} (period ${period}, ${maxAgeDays}d budget) goes stale at ${new Date(expiresAt).toISOString()} -- ${headroomDays.toFixed(1)}d left`,
+        );
+      }
+      assert.equal(
+        isChinaMacroObservationStale(seriesId, period, now),
+        false,
+        `${seriesId} recorded content has already aged out; refresh tests/fixtures/china-macro/*.html`,
+      );
+    }
+
+    assert.deepEqual(
+      expiring,
+      [],
+      `Recorded China macro fixture content is within ${REQUIRED_HEADROOM_DAYS} days of aging out of its content-freshness budget.\n`
+      + 'Refresh tests/fixtures/china-macro/*.html with a more recent NBS/SAFE release (and update the\n'
+      + 'route URLs plus CHINA_MACRO_FIXTURE_RETRIEVAL_TIME to match) before it turns mcp.test.mjs red.\n'
+      + `Expiring:\n  ${expiring.join('\n  ')}`,
+    );
+  });
+});
+
+describe('China macro fixture time-invariance', () => {
+  // The regression #5762 was: a property that held on the day it was written
+  // and expired on a calendar date. Asserting it at `Date.now()` alone would
+  // reproduce exactly that mistake, so pin it across clocks instead -- month
+  // boundaries, month lengths, leap day, and hour-of-day edges.
+  const clocks: number[] = [];
+  for (let month = 0; month < 30; month += 1) {
+    for (const day of [1, 2, 15, 28, 31]) {
+      for (const hour of [0, 23]) {
+        const at = new Date(Date.UTC(2026, 6 + month, day, hour, 30, 0));
+        if (at.getUTCDate() === day) clocks.push(at.getTime());
+      }
+    }
+  }
+
+  it(`builds a fresh, non-stale snapshot at every one of ${clocks.length} clocks over 30 months`, async () => {
+    const failures: string[] = [];
+    for (const now of clocks) {
+      let snapshot: { observations?: Record<string, unknown>[] };
+      try {
+        snapshot = await buildOfficialChinaMacroFixture(now);
+      } catch (error) {
+        failures.push(`${new Date(now).toISOString()} threw ${(error as Error).message}`);
+        continue;
+      }
+      for (const observation of snapshot.observations ?? []) {
+        if (observation.transportStatus !== 'fresh') continue;
+        const seriesId = String(observation.seriesId);
+        if (isChinaMacroObservationStale(seriesId, String(observation.observationPeriod), now)) {
+          failures.push(`${new Date(now).toISOString()} ${seriesId} content stale`);
+        }
+        const transportAgeMs = now - Date.parse(String(observation.retrievalTime));
+        if (transportAgeMs > 60_000) {
+          failures.push(`${new Date(now).toISOString()} ${seriesId} transport age ${transportAgeMs}ms`);
+        }
+      }
+    }
+    assert.deepEqual(
+      failures.slice(0, 10),
+      [],
+      `The rebased fixture must be valid at any clock; ${failures.length} failed.`,
+    );
+  });
+});

--- a/tests/china-macro-fixture-freshness.test.mts
+++ b/tests/china-macro-fixture-freshness.test.mts
@@ -121,32 +121,77 @@ describe('China macro fixture time-invariance', () => {
     }
   }
 
-  it(`builds a fresh, non-stale snapshot at every one of ${clocks.length} clocks over 30 months`, async () => {
+  // The complete expected outcome, pinned. Asserting freshness only over the
+  // observations that happen to BE fresh would let a clock-specific route or
+  // parsing regression pass unnoticed: the degraded source would simply drop
+  // out of the checked set while its healthy siblings kept the guard green.
+  // The blocked entries are deliberate -- the fixture serves robots.txt
+  // disallow for PBoC and a self-signed certificate for GACC -- so pinning them
+  // also proves the rebase does not accidentally "repair" a source.
+  const EXPECTED_TRANSPORT: ReadonlyArray<readonly [string, string, string]> = [
+    ['nbs_industrial_value_added_yoy', 'fresh', ''],
+    ['nbs_fixed_asset_investment_yoy', 'fresh', ''],
+    ['nbs_real_estate_investment_yoy', 'fresh', ''],
+    ['safe_fx_reserves', 'fresh', ''],
+    ['safe_bank_fx_settlement', 'fresh', ''],
+    ['pboc_aggregate_financing_flow', 'blocked', 'ROBOTS_DISALLOW'],
+    ['pboc_new_rmb_loans', 'blocked', 'ROBOTS_DISALLOW'],
+    ['pboc_m2_yoy', 'blocked', 'ROBOTS_DISALLOW'],
+    ['pboc_policy_liquidity_operation', 'blocked', 'ROBOTS_DISALLOW'],
+    ['gacc_exports', 'blocked', 'TLS_CERTIFICATE_ERROR'],
+    ['gacc_imports', 'blocked', 'TLS_CERTIFICATE_ERROR'],
+    ['gacc_trade_balance', 'blocked', 'TLS_CERTIFICATE_ERROR'],
+  ];
+
+  it(`builds the complete expected snapshot at every one of ${clocks.length} clocks over 30 months`, async () => {
     const failures: string[] = [];
     for (const now of clocks) {
+      const at = new Date(now).toISOString();
       let snapshot: { observations?: Record<string, unknown>[] };
       try {
         snapshot = await buildOfficialChinaMacroFixture(now);
       } catch (error) {
-        failures.push(`${new Date(now).toISOString()} threw ${(error as Error).message}`);
+        failures.push(`${at} threw ${(error as Error).message}`);
         continue;
       }
-      for (const observation of snapshot.observations ?? []) {
+      const observations = snapshot.observations ?? [];
+
+      // 1. The whole observation set, in order, with its exact transport state.
+      const actual = observations.map((o) => [
+        String(o.seriesId), String(o.transportStatus), String(o.transportFailureReason ?? ''),
+      ].join('|'));
+      const expected = EXPECTED_TRANSPORT.map((row) => row.join('|'));
+      if (actual.join('\n') !== expected.join('\n')) {
+        // Pair each row with the actual at the SAME position -- filtering first
+        // and then indexing would report mismatched pairs and send the reader
+        // to the wrong series.
+        const drifted = expected
+          .map((row, index) => (actual[index] === row ? null : `[${index}] want ${row} got ${actual[index] ?? '<missing>'}`))
+          .filter((row): row is string => row !== null);
+        const extra = actual.length > expected.length
+          ? ` (+${actual.length - expected.length} unexpected)`
+          : '';
+        failures.push(`${at} transport set drift${extra}: ${drifted.slice(0, 3).join('; ')}`);
+        continue;
+      }
+
+      // 2. Freshness of the sources that are supposed to be fresh.
+      for (const observation of observations) {
         if (observation.transportStatus !== 'fresh') continue;
         const seriesId = String(observation.seriesId);
         if (isChinaMacroObservationStale(seriesId, String(observation.observationPeriod), now)) {
-          failures.push(`${new Date(now).toISOString()} ${seriesId} content stale`);
+          failures.push(`${at} ${seriesId} content stale`);
         }
         const transportAgeMs = now - Date.parse(String(observation.retrievalTime));
         if (transportAgeMs > 60_000) {
-          failures.push(`${new Date(now).toISOString()} ${seriesId} transport age ${transportAgeMs}ms`);
+          failures.push(`${at} ${seriesId} transport age ${transportAgeMs}ms`);
         }
       }
     }
     assert.deepEqual(
       failures.slice(0, 10),
       [],
-      `The rebased fixture must be valid at any clock; ${failures.length} failed.`,
+      `The rebased fixture must produce the complete expected snapshot at any clock; ${failures.length} failed.`,
     );
   });
 });

--- a/tests/helpers/china-macro-fixture.mjs
+++ b/tests/helpers/china-macro-fixture.mjs
@@ -6,15 +6,91 @@ const fixture = (name) => readFileSync(
   new URL(`../fixtures/china-macro/${name}`, import.meta.url),
   'utf8',
 );
-const routes = new Map([
-  ['https://www.stats.gov.cn/english/PressRelease/', fixture('nbs-list.html')],
-  ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964159.html', fixture('nbs-industrial.html')],
-  ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964158.html', fixture('nbs-fai.html')],
-  ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964157.html', fixture('nbs-property.html')],
-  ['https://www.safe.gov.cn/safe/sjjd/index.html', fixture('safe-list.html')],
-  ['https://www.safe.gov.cn/safe/2026/0706/27661.html', fixture('safe-reserves.html')],
-  ['https://www.safe.gov.cn/safe/2026/0717/27704.html', fixture('safe-settlement.html')],
-]);
+
+// The recorded HTML describes a real release: June 2026 data, published
+// mid-July 2026. Those dates are load-bearing -- the adapter derives
+// observationPeriod and releaseTime from them, and two read paths then age
+// those against the wall clock (transport 72h, content 45-75d per series).
+// Left literal, the fixture rots on a calendar date and reddens `main` for
+// every branch at once (#5762).
+//
+// So the dates are rebased per build instead. The shape is preserved exactly --
+// "previous month's data, published recently" -- which is what the fixture is
+// actually asserting about. Rebasing keeps `observed <= published <= retrieved`
+// and both freshness budgets satisfied for ANY clock, so no calendar date can
+// expire it.
+const MONTHS_EN = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const pad = (n) => String(n).padStart(2, '0');
+
+function fixtureDates(now) {
+  // Publication: two days back. Two rather than one because the recorded NBS
+  // release carries a 10:00 clock time -- a same-day or one-day-back date could
+  // still land in the future relative to `now` and break the
+  // published <= retrieved ordering the adapter enforces.
+  const pub = new Date(now - 2 * 86_400_000);
+  // Observation period: the month BEFORE the publication month. A statistical
+  // release always reports a month that has already ended, and the adapter
+  // rejects a release dated inside its own reporting month as schema drift.
+  // Age is then at most ~32 days, inside even the tightest series budget
+  // (SAFE, 45d), for every possible `now`.
+  const period = new Date(Date.UTC(pub.getUTCFullYear(), pub.getUTCMonth() - 1, 1));
+  return {
+    periodYear: period.getUTCFullYear(),
+    periodMonth: period.getUTCMonth() + 1,
+    periodNameEn: MONTHS_EN[period.getUTCMonth()],
+    pubYear: pub.getUTCFullYear(),
+    pubMonth: pub.getUTCMonth() + 1,
+    pubDay: pub.getUTCDate(),
+  };
+}
+
+// Ordered longest-first: '20260717' and '2026/0717' must not be partially
+// rewritten by the shorter '202607' rule.
+function rebase(text, d) {
+  const { periodYear, periodMonth, periodNameEn, pubYear, pubMonth, pubDay } = d;
+  return text
+    .replaceAll('20260717', `${pubYear}${pad(pubMonth)}${pad(pubDay)}`)
+    .replaceAll('2026/0717', `${pubYear}/${pad(pubMonth)}${pad(pubDay)}`)
+    .replaceAll('2026/0706', `${pubYear}/${pad(pubMonth)}${pad(pubDay)}`)
+    .replaceAll('2026/07/16', `${pubYear}/${pad(pubMonth)}/${pad(pubDay)}`)
+    .replaceAll('2026-07-07', `${pubYear}-${pad(pubMonth)}-${pad(pubDay)}`)
+    .replaceAll('2026-07-17', `${pubYear}-${pad(pubMonth)}-${pad(pubDay)}`)
+    .replaceAll('202607', `${pubYear}${pad(pubMonth)}`)
+    .replaceAll('June 2026', `${periodNameEn} ${periodYear}`)
+    .replaceAll('2026年1-6月', `${periodYear}年1-${periodMonth}月`)
+    .replaceAll('2026年6月', `${periodYear}年${periodMonth}月`);
+}
+
+function buildRoutes(now) {
+  // now === null means "recorded verbatim": the no-argument default reproduces
+  // the fixture exactly as captured, because tests that assert on the snapshot
+  // itself pin literal release times (tests/macro-tiles-china-ui.test.mts).
+  // Rebasing is opt-in, for the consumers that re-derive freshness live.
+  if (now === null) {
+    return new Map([
+      ['https://www.stats.gov.cn/english/PressRelease/', fixture('nbs-list.html')],
+      ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964159.html', fixture('nbs-industrial.html')],
+      ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964158.html', fixture('nbs-fai.html')],
+      ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964157.html', fixture('nbs-property.html')],
+      ['https://www.safe.gov.cn/safe/sjjd/index.html', fixture('safe-list.html')],
+      ['https://www.safe.gov.cn/safe/2026/0706/27661.html', fixture('safe-reserves.html')],
+      ['https://www.safe.gov.cn/safe/2026/0717/27704.html', fixture('safe-settlement.html')],
+    ]);
+  }
+  const d = fixtureDates(now);
+  return new Map([
+    ['https://www.stats.gov.cn/english/PressRelease/', rebase(fixture('nbs-list.html'), d)],
+    [rebase('https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964159.html', d), rebase(fixture('nbs-industrial.html'), d)],
+    [rebase('https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964158.html', d), rebase(fixture('nbs-fai.html'), d)],
+    [rebase('https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964157.html', d), rebase(fixture('nbs-property.html'), d)],
+    ['https://www.safe.gov.cn/safe/sjjd/index.html', rebase(fixture('safe-list.html'), d)],
+    [rebase('https://www.safe.gov.cn/safe/2026/0706/27661.html', d), rebase(fixture('safe-reserves.html'), d)],
+    [rebase('https://www.safe.gov.cn/safe/2026/0717/27704.html', d), rebase(fixture('safe-settlement.html'), d)],
+  ]);
+}
 
 export const CHINA_MACRO_FIXTURE_RETRIEVAL_TIME = '2026-07-25T14:30:00.000Z';
 
@@ -33,9 +109,32 @@ export const CHINA_MACRO_FIXTURE_SERIES_IDS = Object.freeze([
   'gacc_trade_balance',
 ]);
 
-export async function buildOfficialChinaMacroFixture() {
+/**
+ * Build the recorded official China macro snapshot.
+ *
+ * `now` sets the snapshot's retrieval clock. It defaults to the pinned
+ * CHINA_MACRO_FIXTURE_RETRIEVAL_TIME, which keeps the snapshot byte-stable for
+ * tests that assert on it directly.
+ *
+ * Tests that go through a read path which RE-DERIVES freshness against the wall
+ * clock must pass `Date.now()` instead. The MCP projection
+ * (api/mcp/registry/cache-tools.ts -> normalizeChinaMacroObservations) does
+ * exactly that, and against the pinned literal it flips
+ * `transportStatus: 'fresh'` to `'stale'` once real time passes
+ * CHINA_MACRO_MAX_TRANSPORT_AGE_MIN (72h) after it -- turning the assertion into
+ * a calendar time bomb that reddens `main` for every branch at once (#5762).
+ * Passing the live clock makes those tests time-invariant rather than re-armed.
+ *
+ * Note the adapter derives all provenance and vintage lineage from this clock,
+ * so the snapshot stays internally consistent; re-stamping a built snapshot by
+ * hand does not, because the vintage ledger carries its own provenance claims.
+ */
+export async function buildOfficialChinaMacroFixture(now) {
+  const rebase = now !== undefined;
+  const clock = rebase ? now : Date.parse(CHINA_MACRO_FIXTURE_RETRIEVAL_TIME);
+  const routes = buildRoutes(rebase ? clock : null);
   return fetchChinaMacroSnapshot({
-    now: Date.parse(CHINA_MACRO_FIXTURE_RETRIEVAL_TIME),
+    now: clock,
     readCachedFn: async () => null,
     fetchFn: async (input) => {
       const url = String(input);

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -1057,7 +1057,10 @@ describe('api/mcp.ts — PRO MCP Server', () => {
   });
 
   it('get_economic_data: China v2 aliases, dataset filter, country filter, and schema stay aligned', async () => {
-    const macro = await buildOfficialChinaMacroFixture();
+    // Live clock: this test asserts on the MCP projection, which re-derives
+    // transport freshness against Date.now(). A pinned fixture time expires
+    // 72h later and reddens main for every branch (#5762).
+    const macro = await buildOfficialChinaMacroFixture(Date.now());
     const releaseCalendar = {
       events: [{ countryCode: 'CN', event: 'NBS release' }],
     };
@@ -1130,7 +1133,10 @@ describe('api/mcp.ts — PRO MCP Server', () => {
   });
 
   it('get_economic_data: China MCP projection keeps retained transport failures explicit', async () => {
-    const macro = await buildOfficialChinaMacroFixture();
+    // Live clock: this test asserts on the MCP projection, which re-derives
+    // transport freshness against Date.now(). A pinned fixture time expires
+    // 72h later and reddens main for every branch (#5762).
+    const macro = await buildOfficialChinaMacroFixture(Date.now());
     const nbsDecision = macro.sourceDecisions.find(
       (decision) => decision.publisherId === 'publisher:nbs-cn',
     );


### PR DESCRIPTION
Fixes #5762.

## The failure

`tests/mcp.test.mjs` went red at **2026-07-28T14:30:00Z** on every branch at once, blocking every open PR, with a message that named nothing:

```
AssertionError: 'stale' !== 'fresh'   at tests/mcp.test.mjs:1087
```

Nothing had changed. `main`'s last green run beat the threshold by **eight minutes** (14:22Z). The fixture had simply aged past it.

## Why

The fixture records a real release (June 2026 data, published mid-July) at a literal retrieval time. Two read paths re-derive freshness against the wall clock, and neither can be pinned from a test — `api/mcp/registry/cache-tools.ts:70` hard-calls `Date.now()`:

| window | rule | budget |
|---|---|---|
| transport | `now - (lastSuccessAt ?? retrievalTime)` | `CHINA_MACRO_MAX_TRANSPORT_AGE_MIN` = 72h |
| content | `now - observationPeriod` | `CHINA_MACRO_SERIES_MAX_AGE_DAYS` = 45d SAFE, 75d NBS |

`2026-07-25T14:30Z + 72h` is exactly when it fired.

## Why not just re-pin the literal

Because it buys 72 hours. And verifying that revealed the second bomb: the **SAFE content window is 45 days**, so even after fixing transport the suite would have broken again on **2026-08-14** — 17 days later. Confirmed by simulating the suite at a future clock.

## The fix — both clocks float

- **`buildOfficialChinaMacroFixture(now)`** sets the retrieval clock. The adapter derives all provenance and vintage lineage from it, so the snapshot stays internally consistent.
  *Rejected alternative:* re-stamping a built snapshot by hand. The vintage ledger carries its own provenance claims and `validProvenance` cross-checks every one against its row, so hand-editing silently invalidates the whole projection.
- **The recorded dates are rebased per build**, so the fixture always describes *"last month's release, published two days ago"* rather than one literal moment.

Two details both found by sweeping clocks rather than by reading the code:

- Publication is **two** days back, not one — the recorded NBS release carries a `10:00` clock time that could otherwise land in the future and break `published <= retrieved`.
- The observation period is the month **before** publication — the adapter rejects a release dated inside its own reporting month as `SCHEMA_DRIFT` (this failed on the 1st of every month).

The no-argument default still reproduces the fixture **verbatim**, so `tests/china-macro-rpc.test.mts` and `tests/macro-tiles-china-ui.test.mts`, which assert literal release times, are untouched.

## Verification

`tests/china-macro-fixture-freshness.test.mts` locks the properties in. Asserting them at `Date.now()` would repeat the original mistake, so it sweeps **276 clocks over 30 months** — month boundaries, month lengths, leap day, hour-of-day edges. A wider **855-clock** sweep ran during development: 0 failures.

Both halves mutation-tested:

| mutation | result |
|---|---|
| revert the live clock in `mcp.test.mjs` | `mcp.test.mjs` red (the original bug) |
| revert date rebasing | freshness guard red |

187 tests pass across the affected suites (`mcp`, `china-macro-rpc`, `macro-tiles-china-ui`, `china-decision-access-contract`, `china-coverage-health`, the new guard). `npm run typecheck` and biome clean.

## Note

This is test-infrastructure only — no production code changes. The underlying design smell is that `cache-tools.ts:70` takes no clock; threading one through the MCP handler would let tests pin freshness directly, but that is a larger change and not needed to unblock `main`.
