### PR TITLE
fix(checkout): preserve success body read failures

### DIFF
--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -976,7 +976,7 @@ export async function startCheckout(
     // which skipped the contract-violation reporter below, discarded the
     // upstream snapshot that would name the emitter, and split one bug
     // across a Sentry fingerprint per browser engine. WORLDMONITOR-XV.
-    const rawSuccessText = await resp.text().catch(() => '');
+    const rawSuccessText = await resp.text();
     const result = parseCheckoutSuccessBody(rawSuccessText);
     if (result === null) {
       // A 200 we cannot parse is a different contract violation from a

--- a/tests/checkout-unparsable-success-body.test.mts
+++ b/tests/checkout-unparsable-success-body.test.mts
@@ -23,6 +23,7 @@ import { build, type Plugin } from 'esbuild';
 
 interface CapturedReport {
   message: string;
+  exception?: unknown;
   level?: string;
   tags?: Record<string, string>;
   extra?: Record<string, unknown>;
@@ -34,6 +35,7 @@ interface HarnessState {
   /** Body + headers the stub fetch should answer the create-checkout POST with. */
   responseBody: string;
   responseHeaders: Record<string, string>;
+  bodyReadError?: unknown;
 }
 
 declare global {
@@ -90,7 +92,10 @@ function installBrowserGlobals(): void {
       return {
         ok: true,
         status: 200,
-        text: async () => harness.responseBody,
+        text: async () => {
+          if (harness.bodyReadError !== undefined) throw harness.bodyReadError;
+          return harness.responseBody;
+        },
         json: async () => JSON.parse(harness.responseBody),
         headers: { get: (name: string) => harness.responseHeaders[name.toLowerCase()] ?? null },
       };
@@ -98,8 +103,12 @@ function installBrowserGlobals(): void {
   });
 }
 
-function resetHarness(responseBody: string, responseHeaders: Record<string, string> = {}): void {
-  globalThis.__xvHarness = { reports: [], assignedUrls: [], responseBody, responseHeaders };
+function resetHarness(
+  responseBody: string,
+  responseHeaders: Record<string, string> = {},
+  bodyReadError?: unknown,
+): void {
+  globalThis.__xvHarness = { reports: [], assignedUrls: [], responseBody, responseHeaders, bodyReadError };
   installBrowserGlobals();
 }
 
@@ -110,7 +119,11 @@ const stubSources: Record<string, string> = {
       fn({
         addBreadcrumb: () => {},
         captureMessage: (message, payload) => globalThis.__xvHarness.reports.push({ message, ...payload }),
-        captureException: (err, payload) => globalThis.__xvHarness.reports.push({ message: String(err && err.message || err), ...payload }),
+        captureException: (err, payload) => globalThis.__xvHarness.reports.push({
+          message: String(err && err.message || err),
+          exception: err,
+          ...payload,
+        }),
       });
     }
   `,
@@ -214,6 +227,26 @@ function soleReport(): CapturedReport {
 }
 
 describe('create-checkout 200 with an unparsable body (WORLDMONITOR-XV)', () => {
+  it('preserves a rejected body read as the original transport exception', async () => {
+    const bodyReadError = new DOMException('The operation was aborted.', 'AbortError');
+    resetHarness('', {}, bodyReadError);
+    const checkout = await loadCheckoutModule();
+
+    assert.equal(await checkout.startCheckout('prod_monthly'), false);
+    assert.deepEqual(globalThis.__xvHarness.assignedUrls, ['https://worldmonitor.app/pro']);
+
+    const report = soleReport();
+    assert.strictEqual(report.exception, bodyReadError);
+    assert.equal((report.exception as Error).name, 'AbortError');
+    assert.equal((report.exception as Error).stack, bodyReadError.stack);
+    assert.equal(report.message, 'The operation was aborted.');
+    assert.equal(report.tags?.action, 'exception');
+    assert.notEqual(report.tags?.action, 'unparsable-success-body');
+    assert.equal(report.tags?.code, 'service_unavailable');
+    assert.equal(report.extra?.serverMessage, 'The operation was aborted.');
+    assert.equal(Object.hasOwn(report.extra ?? {}, 'upstream'), false);
+  });
+
   it('reports the contract violation instead of letting the parse error escape', async () => {
     // An HTML interstitial served with 200 — the shape a middlebox or edge
     // challenge produces, and what a bare resp.json() choked on.


### PR DESCRIPTION
## Summary

Addresses the unresolved body-read diagnostic concern on #5761.

PR #5761 correctly distinguishes malformed successful checkout payloads from parsed-but-unusable payloads.
However, its success-body read currently converts a rejected `Response.text()` call into an empty string, causing abort or transport failures to be reported as synthetic non-JSON 200 responses.

This follow-up lets body-read failures propagate to the existing exception path so the original error type, message, stack, and exception object remain available to telemetry.

It also adds a behavioral regression proving:

- rejected body reads use `action: exception`
- the original exception reaches `captureException`
- no fake empty-body upstream snapshot is created
- readable malformed bodies still use `unparsable-success-body`

## Relationship

This PR is intentionally based on and targets:

`koala73:fix/checkout-unparsable-success-body`

It is intended to be merged into #5761 before #5761 merges to `main`.

## Validation

- `npx --yes node@24 ./node_modules/tsx/dist/cli.mjs --test tests/checkout-unparsable-success-body.test.mts tests/checkout-success-body-contract.test.mts` - 22 passed
- `./node_modules/.bin/tsx --test tests/checkout-overlay-lifecycle.test.mts tests/checkout-pending-dialog.test.mts tests/checkout-report-error.test.mts` - 20 passed
- `npm run typecheck` - passed
- `npm run typecheck:api` - passed
- `npm run lint` - passed
- `./node_modules/.bin/biome check src/services/checkout.ts tests/checkout-unparsable-success-body.test.mts` - passed
- `VITE_VARIANT=full npx --yes node@24 ./node_modules/vite/bin/vite.js build` - passed
- Node 24 repository data suite - 18,144 passed, 1 failed, 6 skipped

The sole Node 24 data-suite failure is the date-sensitive China freshness assertion in `tests/mcp.test.mjs`.
The same failure reproduces against untouched PR #5761 head `c8df340df02c1dabd1b7e318fe464051866e9516` and is unrelated to checkout.
