### PR TITLE
sec(seed): stop seeder imports from loading production credentials (#5767)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ Heavy checks (`test:data`, typechecks, edge-bundle) must run **sequentially** in
 - Yahoo Finance requests must be staggered (150ms delays)
 - New data sources MUST have bootstrap hydration wired in `api/bootstrap.js`
 - Redis seed scripts MUST write `seed-meta:<key>` for health monitoring
-- Seed credentials come from the current checkout only — call `loadEnvFile()`, never resolve a `.env` path from `$HOME` or an absolute literal
+- Seed credentials load only via `loadEnvFile()` (inert under test runtimes, resolves `.env.local` at the checkout root, `only:` narrows the keys) — never hand-roll a `.env` reader or resolve one from `$HOME` or an absolute literal. Note `worktree:bootstrap` symlinks the source checkout's `.env.local`, so a bootstrapped worktree shares real credentials when a seeder is actually run
 
 ## External References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ Heavy checks (`test:data`, typechecks, edge-bundle) must run **sequentially** in
 - Yahoo Finance requests must be staggered (150ms delays)
 - New data sources MUST have bootstrap hydration wired in `api/bootstrap.js`
 - Redis seed scripts MUST write `seed-meta:<key>` for health monitoring
-- Seed credentials load from the current checkout only (`.env.local` beside the repo root, or an explicit `WM_SEED_ENV_FILE` path). `loadEnvFile()` is inert under a test runtime — never resolve a credential file from `$HOME` or an absolute path, or worktree isolation stops isolating (#5767)
+- Seed credentials come from the current checkout only — call `loadEnvFile()`, never resolve a `.env` path from `$HOME` or an absolute literal
 
 ## External References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,7 @@ Heavy checks (`test:data`, typechecks, edge-bundle) must run **sequentially** in
 - Yahoo Finance requests must be staggered (150ms delays)
 - New data sources MUST have bootstrap hydration wired in `api/bootstrap.js`
 - Redis seed scripts MUST write `seed-meta:<key>` for health monitoring
+- Seed credentials load from the current checkout only (`.env.local` beside the repo root, or an explicit `WM_SEED_ENV_FILE` path). `loadEnvFile()` is inert under a test runtime — never resolve a credential file from `$HOME` or an absolute path, or worktree isolation stops isolating (#5767)
 
 ## External References
 

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -211,18 +211,63 @@ export function loadSharedConfig(filename) {
 // Env vars set by the runners that import seeder modules without running them.
 // 149 seeders call loadEnvFile() at module scope, so under one of these the
 // import alone would hand production credentials to the test process (#5767).
-const TEST_RUNTIME_MARKERS = ['NODE_TEST_CONTEXT', 'VITEST', 'VITEST_WORKER_ID', 'JEST_WORKER_ID'];
+// Known gap: `node --test --experimental-test-isolation=none` runs tests in the
+// main process and sets NO marker at all. The repo uses that flag nowhere, but
+// adding it would disable this guard for the whole suite in one edit.
+const TEST_RUNTIME_MARKERS = [
+  'NODE_TEST_CONTEXT', // node --test and tsx --test
+  'VITEST',
+  'VITEST_WORKER_ID',
+  'JEST_WORKER_ID',
+  'PLAYWRIGHT_TEST_BASE_URL', // playwright sets neither NODE_ENV nor a generic marker
+  'PW_TEST_SOURCE_LOCATION',
+];
 
 export function isTestRuntime(env = process.env) {
   if (env.NODE_ENV === 'test') return true;
   return TEST_RUNTIME_MARKERS.some((key) => typeof env[key] === 'string' && env[key] !== '');
 }
 
-export function loadEnvFile(metaUrl) {
+// Walk up to the checkout this file lives in. `.git` is a directory in a normal
+// clone and a file in a worktree, so `existsSync` covers both. Bounded so a
+// detached path cannot spin.
+function findCheckoutRoot(startDir) {
+  let dir = startDir;
+  for (let depth = 0; depth < 24; depth += 1) {
+    if (existsSync(join(dir, '.git'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Load the checkout's `.env.local` into process.env.
+ *
+ * `only` restricts the import to the named keys, for callers that want their
+ * two credentials rather than every variable in the file. It exists so those
+ * callers do not need a private loader — a private loader silently opts out of
+ * the test-runtime guard and the checkout scoping, which is exactly how #5767
+ * survived in two files.
+ */
+export function loadEnvFile(metaUrl, { only } = {}) {
   // Loading credentials is part of *running* a seeder, never part of importing
   // one. CI already runs the whole suite with no .env.local present, so staying
   // inert here just makes local runs match CI instead of hitting production.
-  if (isTestRuntime() && process.env.WM_ALLOW_ENV_LOAD_IN_TESTS !== '1') return;
+  if (isTestRuntime() && process.env.WM_ALLOW_ENV_LOAD_IN_TESTS !== '1') {
+    // Under a real test runner this is the expected path and would be pure
+    // noise across 150+ seeder imports. NODE_ENV=test with no runner marker is
+    // a person running a seeder in a shell that exports it, where silently
+    // ignoring a .env.local that IS present reads as "my credentials vanished".
+    if (process.env.NODE_ENV === 'test' && !TEST_RUNTIME_MARKERS.some((k) => process.env[k])) {
+      console.error(
+        '[seed] loadEnvFile skipped: NODE_ENV=test looks like a test runtime. ' +
+          'Set WM_ALLOW_ENV_LOAD_IN_TESTS=1 to load credentials anyway.',
+      );
+    }
+    return;
+  }
 
   const __dirname = metaUrl ? dirname(fileURLToPath(metaUrl)) : process.cwd();
   const candidates = [];
@@ -230,8 +275,27 @@ export function loadEnvFile(metaUrl) {
   // Replaces the old hardcoded $HOME/Documents/GitHub/worldmonitor candidate,
   // which reached out of whichever worktree the seeder lived in and so made
   // worktree isolation ineffective by design.
-  if (process.env.WM_SEED_ENV_FILE) candidates.push(process.env.WM_SEED_ENV_FILE);
-  candidates.push(join(__dirname, '..', '.env.local'), join(__dirname, '..', '..', '.env.local'));
+  if (process.env.WM_SEED_ENV_FILE) {
+    // Falling through to the checkout file on a typo would silently seed with
+    // the wrong credentials — the failure mode this whole change is about.
+    if (!existsSync(process.env.WM_SEED_ENV_FILE)) {
+      console.error(
+        `[seed] WM_SEED_ENV_FILE does not exist: ${process.env.WM_SEED_ENV_FILE} — ` +
+          'falling back to the checkout .env.local.',
+      );
+    }
+    candidates.push(process.env.WM_SEED_ENV_FILE);
+  }
+  // Anchored to the checkout root rather than guessed with `..` and `../..`.
+  // The old pair had to guess because a nested `scripts/<dir>/x.mjs` needs two
+  // levels while a top-level seeder needs one — but `../..` from a top-level
+  // seeder lands OUTSIDE the checkout, and it really did load a `.env.local`
+  // sitting next to the repo. Resolving the root makes both depths correct and
+  // neither of them able to escape.
+  const checkoutRoot = findCheckoutRoot(__dirname);
+  // No VCS metadata means a container image, where env comes from the platform
+  // and the only sane guess is the directory above the script.
+  candidates.push(join(checkoutRoot ?? join(__dirname, '..'), '.env.local'));
   for (const envPath of candidates) {
     if (!existsSync(envPath)) continue;
     const lines = readFileSync(envPath, 'utf8').split('\n');
@@ -241,6 +305,7 @@ export function loadEnvFile(metaUrl) {
       const eqIdx = trimmed.indexOf('=');
       if (eqIdx === -1) continue;
       const key = trimmed.slice(0, eqIdx).trim();
+      if (only && !only.includes(key)) continue;
       let val = trimmed.slice(eqIdx + 1).trim();
       if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
         val = val.slice(1, -1);

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -208,15 +208,30 @@ export function loadSharedConfig(filename) {
   throw new Error(`Cannot find shared/${filename} — checked ../shared/ and ./shared/`);
 }
 
+// Env vars set by the runners that import seeder modules without running them.
+// 149 seeders call loadEnvFile() at module scope, so under one of these the
+// import alone would hand production credentials to the test process (#5767).
+const TEST_RUNTIME_MARKERS = ['NODE_TEST_CONTEXT', 'VITEST', 'VITEST_WORKER_ID', 'JEST_WORKER_ID'];
+
+export function isTestRuntime(env = process.env) {
+  if (env.NODE_ENV === 'test') return true;
+  return TEST_RUNTIME_MARKERS.some((key) => typeof env[key] === 'string' && env[key] !== '');
+}
+
 export function loadEnvFile(metaUrl) {
+  // Loading credentials is part of *running* a seeder, never part of importing
+  // one. CI already runs the whole suite with no .env.local present, so staying
+  // inert here just makes local runs match CI instead of hitting production.
+  if (isTestRuntime() && process.env.WM_ALLOW_ENV_LOAD_IN_TESTS !== '1') return;
+
   const __dirname = metaUrl ? dirname(fileURLToPath(metaUrl)) : process.cwd();
-  const candidates = [
-    join(__dirname, '..', '.env.local'),
-    join(__dirname, '..', '..', '.env.local'),
-  ];
-  if (process.env.HOME) {
-    candidates.push(join(process.env.HOME, 'Documents/GitHub/worldmonitor', '.env.local'));
-  }
+  const candidates = [];
+  // Explicit opt-in for checkouts that deliberately borrow another env file.
+  // Replaces the old hardcoded $HOME/Documents/GitHub/worldmonitor candidate,
+  // which reached out of whichever worktree the seeder lived in and so made
+  // worktree isolation ineffective by design.
+  if (process.env.WM_SEED_ENV_FILE) candidates.push(process.env.WM_SEED_ENV_FILE);
+  candidates.push(join(__dirname, '..', '.env.local'), join(__dirname, '..', '..', '.env.local'));
   for (const envPath of candidates) {
     if (!existsSync(envPath)) continue;
     const lines = readFileSync(envPath, 'utf8').split('\n');

--- a/scripts/fetch-pizzint-bases.mjs
+++ b/scripts/fetch-pizzint-bases.mjs
@@ -13,33 +13,12 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { loadEnvFile } from './_seed-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 
-// ---------------------------------------------------------------------------
-// .env.local loader (manual dotenv for ESM)
-// ---------------------------------------------------------------------------
-function loadEnvLocal() {
-  const envPath = path.join(projectRoot, '.env.local');
-  if (!existsSync(envPath)) return;
-  const lines = readFileSync(envPath, 'utf-8').split('\n');
-  for (const raw of lines) {
-    const line = raw.trim();
-    if (!line || line.startsWith('#')) continue;
-    const eqIdx = line.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = line.slice(0, eqIdx).trim();
-    let val = line.slice(eqIdx + 1).trim();
-    // Strip surrounding quotes
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1);
-    }
-    if (!process.env[key]) process.env[key] = val;
-  }
-}
-
-loadEnvLocal();
+loadEnvFile(import.meta.url);
 
 // ---------------------------------------------------------------------------
 // Config

--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -3,6 +3,7 @@
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { loadEnvFile } from './_seed-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -52,28 +53,6 @@ function getKeyPrefix(env, sha) {
 function maskToken(token) {
   if (!token || token.length < 8) return '***';
   return token.slice(0, 4) + '***' + token.slice(-4);
-}
-
-function loadEnvFile() {
-  const envPath = join(__dirname, '..', '.env.local');
-  if (!existsSync(envPath)) return;
-
-  const lines = readFileSync(envPath, 'utf8').split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIdx = trimmed.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = trimmed.slice(0, eqIdx).trim();
-    let val = trimmed.slice(eqIdx + 1).trim();
-    // Strip surrounding quotes
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1);
-    }
-    if (!process.env[key]) {
-      process.env[key] = val;
-    }
-  }
 }
 
 async function pipelineRequest(url, token, commands, attempt = 1) {
@@ -223,7 +202,7 @@ async function cleanupOldVersion(url, token, prefix, newVersion) {
 }
 
 async function main() {
-  loadEnvFile();
+  loadEnvFile(import.meta.url);
 
   const { env, sha } = parseArgs();
   const prefix = getKeyPrefix(env, sha);

--- a/scripts/seed-ucdp-events.mjs
+++ b/scripts/seed-ucdp-events.mjs
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 
-import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve } from 'node:path';
+import { resolve } from 'node:path';
+import { loadEnvFile } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { compactUcdpDashboardPayload } from './_ucdp-dashboard.mjs';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const REDIS_KEY = 'conflict:ucdp-events:v1';
 // Dashboard-sized projection. The bootstrap slow tier hydrates from THIS key so
@@ -30,29 +28,6 @@ const VIOLENCE_TYPE_MAP = {
 };
 
 const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
-
-function loadEnvFile() {
-  let envPath = join(__dirname, '..', '.env.local');
-  if (!existsSync(envPath)) {
-    envPath = join('/Users/eliehabib/Documents/GitHub/worldmonitor', '.env.local');
-  }
-  if (!existsSync(envPath)) return;
-  const lines = readFileSync(envPath, 'utf8').split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIdx = trimmed.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = trimmed.slice(0, eqIdx).trim();
-    let val = trimmed.slice(eqIdx + 1).trim();
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1);
-    }
-    if (!process.env[key]) {
-      process.env[key] = val;
-    }
-  }
-}
 
 function maskToken(token) {
   if (!token || token.length < 8) return '***';
@@ -107,7 +82,7 @@ function getMaxDateMs(events) {
 }
 
 async function main() {
-  loadEnvFile();
+  loadEnvFile(import.meta.url);
 
   const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
   const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/scripts/seed-wb-indicators.mjs
+++ b/scripts/seed-wb-indicators.mjs
@@ -13,6 +13,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { loadEnvFile } from './_seed-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -77,27 +78,6 @@ function getKeyPrefix(env, sha) {
 function maskToken(token) {
   if (!token || token.length < 8) return '***';
   return token.slice(0, 4) + '***' + token.slice(-4);
-}
-
-function loadEnvFile() {
-  const envPath = join(__dirname, '..', '.env.local');
-  if (!existsSync(envPath)) return;
-
-  const lines = readFileSync(envPath, 'utf8').split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIdx = trimmed.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = trimmed.slice(0, eqIdx).trim();
-    let val = trimmed.slice(eqIdx + 1).trim();
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1);
-    }
-    if (!process.env[key]) {
-      process.env[key] = val;
-    }
-  }
 }
 
 function sleep(ms) {
@@ -374,7 +354,7 @@ async function fetchRenewableData() {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  loadEnvFile();
+  loadEnvFile(import.meta.url);
 
   const { env, sha } = parseArgs();
   const prefix = getKeyPrefix(env, sha);

--- a/scripts/seed-wb-indicators.mjs
+++ b/scripts/seed-wb-indicators.mjs
@@ -10,12 +10,9 @@
  *   node scripts/seed-wb-indicators.mjs [--env production|preview|development] [--sha <sha>]
  */
 
-import { readFileSync, existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { loadEnvFile } from './_seed-utils.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const BOOTSTRAP_KEY = 'economic:worldbank-techreadiness:v1';
 const PROGRESS_KEY = 'economic:worldbank-progress:v1';

--- a/scripts/shadow-score-report.mjs
+++ b/scripts/shadow-score-report.mjs
@@ -7,8 +7,10 @@
 //        SHADOW_SCORE_KEY=shadow:score-log:v2 to read pre-weight-rebalance data
 //        SHADOW_SCORE_KEY=shadow:score-log:v1 to read pre-PR #3069 data
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
+
+import { loadEnvFile } from './_seed-utils.mjs';
 
 // v2 is the post-fix key (JSON members). v1 is the legacy key (compact strings).
 // Override with SHADOW_SCORE_KEY=shadow:score-log:v2 (pre-weight-rebalance) or v1 (pre-PR #3069).
@@ -18,18 +20,12 @@ const GATE_MIN = 40;     // current IMPORTANCE_SCORE_MIN default
 const HIGH = 65;         // current shouldNotify "high" sensitivity threshold
 const CRITICAL = 85;     // current shouldNotify "critical" sensitivity threshold
 
-function loadEnv() {
-  if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) return;
-  const envPath = resolve(process.cwd(), '.env.local');
-  if (!existsSync(envPath)) return;
-  // Only hydrate the two Upstash creds we actually need — don't bulk-import
-  // every uppercase var from .env.local into this process.
-  const NEEDED = new Set(['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN']);
-  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
-    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*"?([^"\n]+)"?\s*$/);
-    if (m && NEEDED.has(m[1]) && !process.env[m[1]]) process.env[m[1]] = m[2];
-  }
-}
+// Only the two Upstash creds we actually need — not every var in .env.local.
+// `only` on the shared helper preserves that narrowing; a private loader here
+// used to, but it also opted out of the test-runtime guard and the checkout
+// scoping, and this file runs at module scope with no direct-run guard (#5767).
+const NEEDED = ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN'];
+const loadEnv = () => loadEnvFile(import.meta.url, { only: NEEDED });
 
 async function redis(cmd) {
   const res = await fetch(`${process.env.UPSTASH_REDIS_REST_URL}/${cmd.join('/')}`, {

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -93,18 +93,39 @@ function runFixture({ root, fakeHome }, extraEnv = {}) {
  */
 function findCheckoutEscapingEnvPaths(source) {
   const offenders = [];
-  // An absolute path into somebody's home directory, baked into the repo.
+  // An absolute path into somebody's home directory, baked into the repo. This
+  // shape IS reliably regex-detectable — the literal has to appear verbatim.
   for (const match of source.matchAll(/['"`](\/(?:Users|home)\/[^'"`\n]+)['"`]/g)) {
     offenders.push(match[1]);
   }
-  // $HOME (or os.homedir()) joined with a checkout-shaped path — reaches out of
-  // whichever worktree the script actually lives in.
-  for (const match of source.matchAll(
-    /(?:process\.env\.HOME|homedir\(\))\s*,\s*['"`]([^'"`\n]*(?:GitHub|Documents|worldmonitor)[^'"`\n]*)['"`]/g,
-  )) {
-    offenders.push(match[1]);
-  }
   return offenders;
+}
+
+// Every way a script can learn where the user's home directory is. Matching the
+// SOURCE rather than the assembled path is what makes this alias-proof: the
+// earlier version keyed on `join(process.env.HOME, 'Documents/...')` and was
+// trivially evaded by `process.env['HOME']`, a `homedir as getHome` alias, a
+// template literal, or plain concatenation — all five went green against the
+// verbatim #5767 bug. A path still has to come from one of these names.
+const HOME_DIR_SOURCES = [
+  [/\bhomedir\b/, 'os.homedir (including an aliased import)'],
+  [/process\.env\.HOME\b/, 'process.env.HOME'],
+  [/process\.env\[\s*['"`]HOME['"`]\s*\]/, "process.env['HOME']"],
+  [/process\.env\.(?:USERPROFILE|HOMEPATH|HOMEDRIVE)\b/, 'Windows home env var'],
+  [
+    /process\.env\[\s*['"`](?:USERPROFILE|HOMEPATH|HOMEDRIVE)['"`]\s*\]/,
+    'Windows home env var (bracket)',
+  ],
+  [/['"`]~\//, 'a literal ~/ path'],
+];
+
+/**
+ * Pure predicate: does this source reach for the user's home directory at all?
+ * Only meaningful when applied to a file that also parses a `.env` file — a
+ * script may legitimately use homedir() for a cache path.
+ */
+function findHomeDirReferences(source) {
+  return HOME_DIR_SOURCES.filter(([re]) => re.test(source)).map(([, label]) => label);
 }
 
 // Files under scripts/ allowed to parse a .env file into process.env themselves.
@@ -207,6 +228,28 @@ describe('seeder env hermeticity (#5767)', () => {
       assert.equal(result.url, EXPLICIT_SENTINEL);
     });
 
+    it('falls through to the checkout when WM_SEED_ENV_FILE does not exist', () => {
+      // The candidate loop skips a missing path silently, so a typo degrades to
+      // the checkout-local file rather than failing loudly. Pinning the
+      // behaviour either way so a refactor cannot change it unnoticed.
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true });
+      const result = runFixture(fixture, {
+        WM_SEED_ENV_FILE: join(fixture.root, 'does-not-exist.env'),
+      });
+      assert.equal(result.url, CHECKOUT_SENTINEL);
+    });
+
+    it('only accepts the exact opt-in value', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true });
+      for (const value of ['true', 'yes', '0', '']) {
+        const result = runFixture(fixture, {
+          NODE_TEST_CONTEXT: 'child-v8',
+          WM_ALLOW_ENV_LOAD_IN_TESTS: value,
+        });
+        assert.equal(result.url, null, `WM_ALLOW_ENV_LOAD_IN_TESTS=${JSON.stringify(value)}`);
+      }
+    });
+
     it('ignores WM_SEED_ENV_FILE under a test runtime', () => {
       const fixture = makeFixtureCheckout({ withLocalEnvFile: false });
       const explicit = join(fixture.root, 'explicit.env');
@@ -220,26 +263,43 @@ describe('seeder env hermeticity (#5767)', () => {
   });
 
   describe('no script resolves credentials from outside its checkout', () => {
-    it('findCheckoutEscapingEnvPaths flags the shapes that broke worktree isolation', () => {
+    it('findCheckoutEscapingEnvPaths flags a home path baked into the repo', () => {
       assert.deepEqual(
         findCheckoutEscapingEnvPaths(`envPath = join('/Users/someone/Documents/GitHub/worldmonitor', '.env.local');`),
         ['/Users/someone/Documents/GitHub/worldmonitor'],
       );
       assert.deepEqual(
-        findCheckoutEscapingEnvPaths(`candidates.push(join(process.env.HOME, 'Documents/GitHub/worldmonitor', '.env.local'));`),
-        ['Documents/GitHub/worldmonitor'],
-      );
-      assert.deepEqual(
-        findCheckoutEscapingEnvPaths(`const p = join(homedir(), 'Documents/GitHub/worldmonitor');`),
-        ['Documents/GitHub/worldmonitor'],
+        findCheckoutEscapingEnvPaths(`const p = '/home/ci/worldmonitor/.env.local';`),
+        ['/home/ci/worldmonitor/.env.local'],
       );
       // Negatives: checkout-relative and explicitly-configured paths are fine.
       assert.deepEqual(findCheckoutEscapingEnvPaths(`join(__dirname, '..', '.env.local')`), []);
       assert.deepEqual(findCheckoutEscapingEnvPaths(`process.env.WM_SEED_ENV_FILE`), []);
-      assert.deepEqual(findCheckoutEscapingEnvPaths(`join(process.env.HOME, '.cache')`), []);
     });
 
-    it('finds no offenders anywhere under scripts/', async () => {
+    it('findHomeDirReferences survives every rewrite of the #5767 escape', () => {
+      // Each of these is the same bug in a different costume, and each one
+      // defeated the previous `join(process.env.HOME, '<literal>')` regex.
+      const disguises = [
+        `join(process.env.HOME, 'Documents/GitHub/worldmonitor', '.env.local')`,
+        `join(process.env['HOME'], 'Documents/GitHub/worldmonitor', '.env.local')`,
+        `import { homedir as getHome } from 'node:os';\nconst p = join(getHome(), 'wm/.env.local');`,
+        'const p = `${process.env.HOME}/Documents/GitHub/worldmonitor/.env.local`;',
+        `const p = process.env.HOME + '/Documents/GitHub/worldmonitor/.env.local';`,
+        `const p = join(process.env.USERPROFILE, 'wm', '.env.local');`,
+        `const p = '~/Documents/GitHub/worldmonitor/.env.local';`,
+      ];
+      for (const source of disguises) {
+        assert.ok(
+          findHomeDirReferences(source).length > 0,
+          `home-directory escape went undetected:\n${source}`,
+        );
+      }
+      // Negative: nothing here reaches for a home directory.
+      assert.deepEqual(findHomeDirReferences(`join(__dirname, '..', '.env.local')`), []);
+    });
+
+    it('no script bakes a home path into the repo', async () => {
       const offenders = [];
       let scanned = 0;
       for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
@@ -249,7 +309,28 @@ describe('seeder env hermeticity (#5767)', () => {
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
       }
       assert.ok(scanned > 100, `expected to scan the seeder fleet, scanned ${scanned}`);
-      assert.deepEqual(offenders, [], `scripts reaching outside the checkout:\n${offenders.join('\n')}`);
+      assert.deepEqual(offenders, [], `scripts with a hardcoded home path:\n${offenders.join('\n')}`);
+    });
+
+    it('no .env parser reaches for a home directory', async () => {
+      // Scoped to the files that parse .env at all, which the sweep below pins
+      // to the allowlist. Any NEW file that escapes to $HOME for credentials
+      // must parse .env to use them, so it is caught there first and here
+      // second — the two sweeps close each other's gap.
+      const offenders = [];
+      for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
+        if (entry.includes('node_modules')) continue;
+        const source = readFileSync(join(REPO_ROOT, entry), 'utf8');
+        if (!parsesEnvFileItself(source)) continue;
+        const found = findHomeDirReferences(source);
+        if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
+      }
+      assert.deepEqual(
+        offenders,
+        [],
+        `these resolve credentials from the home directory, defeating worktree ` +
+          `isolation:\n${offenders.join('\n')}`,
+      );
     });
   });
 

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -1,0 +1,228 @@
+// Guard for #5767: importing a seeder module must never load production
+// credentials into process.env.
+//
+// 149 seeder modules call `loadEnvFile(import.meta.url)` at module scope, and
+// 103 of them are imported by at least one test. Before this guard, importing
+// any of them populated process.env with every key in the developer's
+// .env.local — Upstash Redis credentials included — so a test that touched any
+// Redis code path operated against production.
+//
+// Two invariants are pinned here:
+//   1. loadEnvFile() is inert under a test runtime (unless explicitly opted in).
+//   2. loadEnvFile() never reaches outside the current checkout for credentials,
+//      so worktree isolation actually isolates.
+//
+// Both are exercised against the REAL scripts/_seed-utils.mjs through a fixture
+// checkout in a temp dir, so the assertions are meaningful in CI (which has no
+// .env.local) as well as on developer machines. Deliberately no real seeder is
+// imported here — that is its own repo landmine (top-level execution).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { glob } from 'node:fs/promises';
+
+import { isTestRuntime } from '../scripts/_seed-utils.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SEED_UTILS_URL = pathToFileURL(join(REPO_ROOT, 'scripts', '_seed-utils.mjs')).href;
+
+const CHECKOUT_SENTINEL = 'https://checkout-local.invalid';
+const ESCAPED_SENTINEL = 'https://escaped-home.invalid';
+const EXPLICIT_SENTINEL = 'https://explicit-opt-in.invalid';
+
+const envFileBody = (url) => `# fixture\nUPSTASH_REDIS_REST_URL=${url}\nUPSTASH_REDIS_REST_TOKEN=fixture-token\n`;
+
+/**
+ * Build a throwaway checkout shaped like the real repo: `<root>/scripts/` next
+ * to an optional `<root>/.env.local`, plus a fake `$HOME` that always contains
+ * the hardcoded `Documents/GitHub/worldmonitor/.env.local` the old candidate
+ * list reached for.
+ */
+function makeFixtureCheckout({ withLocalEnvFile }) {
+  const root = mkdtempSync(join(tmpdir(), 'wm-seed-env-'));
+  mkdirSync(join(root, 'scripts'));
+
+  if (withLocalEnvFile) {
+    writeFileSync(join(root, '.env.local'), envFileBody(CHECKOUT_SENTINEL));
+  }
+
+  const fakeHome = join(root, 'fake-home');
+  const escapedDir = join(fakeHome, 'Documents/GitHub/worldmonitor');
+  mkdirSync(escapedDir, { recursive: true });
+  writeFileSync(join(escapedDir, '.env.local'), envFileBody(ESCAPED_SENTINEL));
+
+  writeFileSync(
+    join(root, 'scripts', 'fixture-seeder.mjs'),
+    [
+      `import { loadEnvFile } from ${JSON.stringify(SEED_UTILS_URL)};`,
+      'loadEnvFile(import.meta.url);',
+      'process.stdout.write(`__RESULT__${JSON.stringify({',
+      '  url: process.env.UPSTASH_REDIS_REST_URL ?? null,',
+      '  token: process.env.UPSTASH_REDIS_REST_TOKEN ?? null,',
+      '})}`);',
+      '',
+    ].join('\n'),
+  );
+
+  return { root, fakeHome };
+}
+
+/**
+ * Run the fixture module in a clean child process — no inherited UPSTASH_* and
+ * no inherited NODE_TEST_CONTEXT — and report what loadEnvFile() put in env.
+ */
+function runFixture({ root, fakeHome }, extraEnv = {}) {
+  const stdout = execFileSync(process.execPath, [join(root, 'scripts', 'fixture-seeder.mjs')], {
+    encoding: 'utf8',
+    env: { PATH: process.env.PATH ?? '', HOME: fakeHome, ...extraEnv },
+  });
+  const marker = stdout.lastIndexOf('__RESULT__');
+  assert.notEqual(marker, -1, `fixture produced no result marker:\n${stdout}`);
+  return JSON.parse(stdout.slice(marker + '__RESULT__'.length));
+}
+
+/**
+ * Pure predicate: does this source text resolve a credential file from outside
+ * the checkout it lives in? Kept as a data-in/data-out function so the truth
+ * table below can prove it has teeth, rather than trusting a bare repo grep.
+ */
+function findCheckoutEscapingEnvPaths(source) {
+  const offenders = [];
+  // An absolute path into somebody's home directory, baked into the repo.
+  for (const match of source.matchAll(/['"`](\/(?:Users|home)\/[^'"`\n]+)['"`]/g)) {
+    offenders.push(match[1]);
+  }
+  // $HOME (or os.homedir()) joined with a checkout-shaped path — reaches out of
+  // whichever worktree the script actually lives in.
+  for (const match of source.matchAll(
+    /(?:process\.env\.HOME|homedir\(\))\s*,\s*['"`]([^'"`\n]*(?:GitHub|Documents|worldmonitor)[^'"`\n]*)['"`]/g,
+  )) {
+    offenders.push(match[1]);
+  }
+  return offenders;
+}
+
+describe('seeder env hermeticity (#5767)', () => {
+  describe('isTestRuntime()', () => {
+    it('detects the runners that import seeder modules', () => {
+      const cases = [
+        [{ NODE_TEST_CONTEXT: 'child-v8' }, true, 'node:test child process'],
+        [{ NODE_TEST_CONTEXT: 'child' }, true, 'node:test child process (json)'],
+        [{ VITEST: 'true' }, true, 'vitest'],
+        [{ VITEST_WORKER_ID: '3' }, true, 'vitest worker'],
+        [{ JEST_WORKER_ID: '1' }, true, 'jest worker'],
+        [{ NODE_ENV: 'test' }, true, 'NODE_ENV=test'],
+        [{}, false, 'plain node process'],
+        [{ NODE_ENV: 'production' }, false, 'production'],
+        [{ NODE_TEST_CONTEXT: '' }, false, 'empty marker is not a test runtime'],
+      ];
+      for (const [env, expected, label] of cases) {
+        assert.equal(isTestRuntime(env), expected, label);
+      }
+    });
+
+    it('reads process.env by default', () => {
+      // This suite itself runs under node:test, so the default must be `true`.
+      assert.equal(isTestRuntime(), true);
+    });
+  });
+
+  describe('loadEnvFile() against a fixture checkout', () => {
+    it('loads the checkout-local .env.local when a seeder is actually run', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true });
+      const result = runFixture(fixture);
+      assert.equal(result.url, CHECKOUT_SENTINEL);
+      assert.equal(result.token, 'fixture-token');
+    });
+
+    it('loads nothing when the process is a node:test runtime', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true });
+      const result = runFixture(fixture, { NODE_TEST_CONTEXT: 'child-v8' });
+      assert.equal(result.url, null, 'credentials must not reach a test process');
+      assert.equal(result.token, null);
+    });
+
+    it('loads nothing when the process is a vitest runtime', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true });
+      const result = runFixture(fixture, { VITEST: 'true' });
+      assert.equal(result.url, null);
+      assert.equal(result.token, null);
+    });
+
+    it('still loads under a test runtime when explicitly opted in', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true });
+      const result = runFixture(fixture, {
+        NODE_TEST_CONTEXT: 'child-v8',
+        WM_ALLOW_ENV_LOAD_IN_TESTS: '1',
+      });
+      assert.equal(result.url, CHECKOUT_SENTINEL, 'escape hatch must still work');
+    });
+
+    it('never reaches into $HOME/Documents/GitHub/worldmonitor for credentials', () => {
+      // The checkout has no .env.local of its own — exactly the worktree case
+      // from #5767. The fake $HOME does have one; it must not be found.
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: false });
+      const result = runFixture(fixture);
+      assert.equal(result.url, null, 'loadEnvFile escaped the checkout via $HOME');
+      assert.equal(result.token, null);
+    });
+
+    it('honours an explicit WM_SEED_ENV_FILE path', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: false });
+      const explicit = join(fixture.root, 'explicit.env');
+      writeFileSync(explicit, envFileBody(EXPLICIT_SENTINEL));
+      const result = runFixture(fixture, { WM_SEED_ENV_FILE: explicit });
+      assert.equal(result.url, EXPLICIT_SENTINEL);
+    });
+
+    it('ignores WM_SEED_ENV_FILE under a test runtime', () => {
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: false });
+      const explicit = join(fixture.root, 'explicit.env');
+      writeFileSync(explicit, envFileBody(EXPLICIT_SENTINEL));
+      const result = runFixture(fixture, {
+        WM_SEED_ENV_FILE: explicit,
+        NODE_TEST_CONTEXT: 'child-v8',
+      });
+      assert.equal(result.url, null, 'the opt-in path must not defeat test hermeticity');
+    });
+  });
+
+  describe('no script resolves credentials from outside its checkout', () => {
+    it('findCheckoutEscapingEnvPaths flags the shapes that broke worktree isolation', () => {
+      assert.deepEqual(
+        findCheckoutEscapingEnvPaths(`envPath = join('/Users/someone/Documents/GitHub/worldmonitor', '.env.local');`),
+        ['/Users/someone/Documents/GitHub/worldmonitor'],
+      );
+      assert.deepEqual(
+        findCheckoutEscapingEnvPaths(`candidates.push(join(process.env.HOME, 'Documents/GitHub/worldmonitor', '.env.local'));`),
+        ['Documents/GitHub/worldmonitor'],
+      );
+      assert.deepEqual(
+        findCheckoutEscapingEnvPaths(`const p = join(homedir(), 'Documents/GitHub/worldmonitor');`),
+        ['Documents/GitHub/worldmonitor'],
+      );
+      // Negatives: checkout-relative and explicitly-configured paths are fine.
+      assert.deepEqual(findCheckoutEscapingEnvPaths(`join(__dirname, '..', '.env.local')`), []);
+      assert.deepEqual(findCheckoutEscapingEnvPaths(`process.env.WM_SEED_ENV_FILE`), []);
+      assert.deepEqual(findCheckoutEscapingEnvPaths(`join(process.env.HOME, '.cache')`), []);
+    });
+
+    it('finds no offenders anywhere under scripts/', async () => {
+      const offenders = [];
+      let scanned = 0;
+      for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
+        if (entry.includes('node_modules')) continue;
+        scanned += 1;
+        const found = findCheckoutEscapingEnvPaths(readFileSync(join(REPO_ROOT, entry), 'utf8'));
+        if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
+      }
+      assert.ok(scanned > 100, `expected to scan the seeder fleet, scanned ${scanned}`);
+      assert.deepEqual(offenders, [], `scripts reaching outside the checkout:\n${offenders.join('\n')}`);
+    });
+  });
+});

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -7,15 +7,29 @@
 // .env.local — Upstash Redis credentials included — so a test that touched any
 // Redis code path operated against production.
 //
-// Two invariants are pinned here:
+// Three invariants are pinned here:
 //   1. loadEnvFile() is inert under a test runtime (unless explicitly opted in).
-//   2. loadEnvFile() never reaches outside the current checkout for credentials,
-//      so worktree isolation actually isolates.
+//   2. loadEnvFile() never reaches outside the current checkout for credentials
+//      — not into $HOME, and not into the directory next to the checkout. Note
+//      this alone does NOT make a worktree credential-isolated: worktree:bootstrap
+//      symlinks the source checkout's .env.local in, so a seeder RUN there still
+//      sees production. Invariant 1 is what protects test processes.
+//   3. loadEnvFile() is the ONLY thing that loads a .env file. A private copy of
+//      the loader opts out of 1 and 2 silently, which is exactly how the second
+//      instance of this bug survived in fetch-pizzint-bases.mjs.
 //
-// Both are exercised against the REAL scripts/_seed-utils.mjs through a fixture
-// checkout in a temp dir, so the assertions are meaningful in CI (which has no
-// .env.local) as well as on developer machines. Deliberately no real seeder is
-// imported here — that is its own repo landmine (top-level execution).
+// 1 and 2 are exercised against the REAL scripts/_seed-utils.mjs through a
+// fixture checkout in a temp dir, so the assertions are meaningful in CI (which
+// has no .env.local) as well as on developer machines. Deliberately no real
+// seeder is imported — that is its own repo landmine (top-level execution) — so
+// invariant 3 is what closes the gap between "the helper is hermetic" and "every
+// seeder is hermetic".
+//
+// The source sweeps for 3 are written to survive rewording, because an earlier
+// version of this file did not: keying on `join(process.env.HOME, '<literal>')`
+// and on `process.env[key] = value` let bracket notation, an aliased homedir
+// import, a template literal, string concatenation, Object.assign, Reflect.set,
+// process.loadEnvFile and a fixed-key write all through with working leaks.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -27,6 +41,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { glob } from 'node:fs/promises';
 
 import { isTestRuntime } from '../scripts/_seed-utils.mjs';
+import { stripJsComments } from '../scripts/lib/js-source-structure.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SEED_UTILS_URL = pathToFileURL(join(REPO_ROOT, 'scripts', '_seed-utils.mjs')).href;
@@ -34,6 +49,7 @@ const SEED_UTILS_URL = pathToFileURL(join(REPO_ROOT, 'scripts', '_seed-utils.mjs
 const CHECKOUT_SENTINEL = 'https://checkout-local.invalid';
 const ESCAPED_SENTINEL = 'https://escaped-home.invalid';
 const EXPLICIT_SENTINEL = 'https://explicit-opt-in.invalid';
+const PARENT_SENTINEL = 'https://parent-of-checkout.invalid';
 
 const envFileBody = (url) => `# fixture\nUPSTASH_REDIS_REST_URL=${url}\nUPSTASH_REDIS_REST_TOKEN=fixture-token\n`;
 
@@ -43,9 +59,19 @@ const envFileBody = (url) => `# fixture\nUPSTASH_REDIS_REST_URL=${url}\nUPSTASH_
  * the hardcoded `Documents/GitHub/worldmonitor/.env.local` the old candidate
  * list reached for.
  */
-function makeFixtureCheckout({ withLocalEnvFile }) {
-  const root = mkdtempSync(join(tmpdir(), 'wm-seed-env-'));
-  mkdirSync(join(root, 'scripts'));
+function makeFixtureCheckout({ withLocalEnvFile, nested = false, only = null }) {
+  const outer = mkdtempSync(join(tmpdir(), 'wm-seed-env-'));
+  // The fixture checkout sits INSIDE a temp dir that also holds a .env.local,
+  // so every case doubles as a check that resolution stops at the checkout
+  // boundary. `loadEnvFile` used to probe `<checkout>/../.env.local` and really
+  // did read this one.
+  writeFileSync(join(outer, '.env.local'), envFileBody(PARENT_SENTINEL));
+
+  const root = join(outer, 'checkout');
+  const scriptDir = nested ? join(root, 'scripts', 'nested') : join(root, 'scripts');
+  mkdirSync(scriptDir, { recursive: true });
+  // Marks the checkout boundary the same way a worktree does — a `.git` file.
+  writeFileSync(join(root, '.git'), 'gitdir: /nowhere\n');
 
   if (withLocalEnvFile) {
     writeFileSync(join(root, '.env.local'), envFileBody(CHECKOUT_SENTINEL));
@@ -57,10 +83,10 @@ function makeFixtureCheckout({ withLocalEnvFile }) {
   writeFileSync(join(escapedDir, '.env.local'), envFileBody(ESCAPED_SENTINEL));
 
   writeFileSync(
-    join(root, 'scripts', 'fixture-seeder.mjs'),
+    join(scriptDir, 'fixture-seeder.mjs'),
     [
       `import { loadEnvFile } from ${JSON.stringify(SEED_UTILS_URL)};`,
-      'loadEnvFile(import.meta.url);',
+      `loadEnvFile(import.meta.url${only ? `, { only: ${JSON.stringify(only)} }` : ''});`,
       'process.stdout.write(`__RESULT__${JSON.stringify({',
       '  url: process.env.UPSTASH_REDIS_REST_URL ?? null,',
       '  token: process.env.UPSTASH_REDIS_REST_TOKEN ?? null,',
@@ -69,15 +95,15 @@ function makeFixtureCheckout({ withLocalEnvFile }) {
     ].join('\n'),
   );
 
-  return { root, fakeHome };
+  return { root, fakeHome, entry: join(scriptDir, 'fixture-seeder.mjs') };
 }
 
 /**
  * Run the fixture module in a clean child process — no inherited UPSTASH_* and
  * no inherited NODE_TEST_CONTEXT — and report what loadEnvFile() put in env.
  */
-function runFixture({ root, fakeHome }, extraEnv = {}) {
-  const stdout = execFileSync(process.execPath, [join(root, 'scripts', 'fixture-seeder.mjs')], {
+function runFixture({ entry, fakeHome }, extraEnv = {}) {
+  const stdout = execFileSync(process.execPath, [entry], {
     encoding: 'utf8',
     env: { PATH: process.env.PATH ?? '', HOME: fakeHome, ...extraEnv },
   });
@@ -128,31 +154,89 @@ function findHomeDirReferences(source) {
   return HOME_DIR_SOURCES.filter(([re]) => re.test(source)).map(([, label]) => label);
 }
 
-// Files under scripts/ allowed to parse a .env file into process.env themselves.
-// Every other script must route through the shared `loadEnvFile`, which is where
-// the test-runtime and checkout-scoping rules live — a private copy of the parser
-// silently opts out of both, which is how #5767's second instance survived.
+// Every tree that can reach a seeder or run server-side. Wider than scripts/ on
+// purpose: a loader in api/ or cli/ leaks exactly the same credentials, and the
+// sweeps cost nothing to extend.
+const SCANNED_TREES = ['scripts', 'api', 'server', 'cli', 'middleware.ts'];
+
+async function* scanSources() {
+  for (const tree of SCANNED_TREES) {
+    const pattern = tree.includes('.') ? tree : `${tree}/**/*.{mjs,cjs,js,mts,ts}`;
+    for await (const entry of glob(pattern, { cwd: REPO_ROOT })) {
+      if (entry.includes('node_modules')) continue;
+      yield entry;
+    }
+  }
+}
+
+// Files allowed to name a `.env` path directly. Everything else must route
+// through the shared `loadEnvFile`, which is where the test-runtime and
+// checkout-scoping rules live — a private copy of the loader silently opts out
+// of both, which is how #5767's second instance survived in fetch-pizzint-bases.
 const ENV_PARSER_ALLOWLIST = new Set([
-  // The one implementation.
+  // The one implementation. Nothing else — shadow-score-report.mjs used to be
+  // here too, exempted on the claim that it was main()-scoped; it is a bare
+  // top-level IIFE with no direct-run guard, so importing it loaded credentials
+  // at module scope with no isTestRuntime() check. It now takes the shared
+  // helper's `only` option instead, which keeps its 2-key narrowing.
   'scripts/_seed-utils.mjs',
-  // Deliberately narrower than the shared helper: hydrates only the two Upstash
-  // keys it needs rather than bulk-importing every var, and is main()-scoped.
-  'scripts/shadow-score-report.mjs',
 ]);
 
+// Every way a script can get at a `.env` file's contents.
+const ENV_FILE_ACCESS = [
+  // Naming the file. Unavoidable for any hand-rolled loader, whatever it does
+  // with the contents afterwards.
+  [/['"`][^'"`\n]*\.env(?:\.[A-Za-z0-9_-]+)?['"`]/, 'a .env path'],
+  // Node's built-in parser, which needs no path at all (defaults to ./.env).
+  [/\bprocess\.loadEnvFile\b/, 'process.loadEnvFile()'],
+  [/\bloadEnvFile\s*\(\s*\)/, 'a no-arg loadEnvFile()'],
+  // Third-party loaders.
+  [/['"`]dotenv(?:\/[^'"`]*)?['"`]/, 'dotenv'],
+  [/\bdotenv\s*\.\s*config\b/, 'dotenv.config()'],
+];
+
+// Every way a script can get parsed values INTO process.env. The earlier
+// version of this guard listed only `process.env[key] = value`, which made it
+// hostage to the write primitive: `Object.assign(process.env, parsed)`,
+// `process.loadEnvFile(p)`, `dotenv.config()`, `Reflect.set(process.env, ...)`
+// and a plain fixed-key assignment each carried a working leak straight past it.
+const ENV_WRITE_PRIMITIVES = [
+  [/process\.env\[[^\n]*?\]\s*=[^=]/, 'a computed process.env subscript'],
+  [/process\.env\.[A-Za-z_$][\w$]*\s*=[^=]/, 'a fixed process.env key'],
+  [/Object\.(?:assign|defineProperty|defineProperties)\s*\(\s*process\.env\b/, 'Object.assign'],
+  [/Reflect\.set\s*\(\s*process\.env\b/, 'Reflect.set'],
+  // These both read and write in one call, so they satisfy either half.
+  [/\bprocess\.loadEnvFile\b/, 'process.loadEnvFile()'],
+  [/\bdotenv\s*\.\s*config\b/, 'dotenv.config()'],
+  [/['"`]dotenv(?:\/[^'"`]*)?['"`]/, 'dotenv'],
+];
+
 /**
- * Pure predicate: does this source parse a `.env` file into `process.env` itself?
- * Keyed on the two halves that must both be present — reading a `.env` path and
- * writing a computed key into `process.env` — so merely mentioning `.env.local`
- * in a comment, or symlinking it (bootstrap-worktree.mjs), does not trip it.
+ * Pure predicate: does this source load a `.env` file into `process.env` itself?
+ *
+ * Both halves are required, and both are matched broadly. The read half is
+ * effectively unavoidable — to load a `.env` file you must name it or call a
+ * loader that is itself named. The write half is what the previous version got
+ * wrong by enumerating one primitive; it now covers the bulk and fixed-key
+ * forms too.
+ *
+ * Requiring the write half is what keeps the legitimate `.env` *scanners*
+ * (check-vite-env-secrets, check-local-secret-dumps, the provenance generator)
+ * out of the offender list without an allowlist entry each: they read env files
+ * to audit them and never put anything into process.env.
+ *
+ * Comments are blanked first (the repo's own scanner) so a file that merely
+ * documents `.env.local` is not an offender.
+ *
+ * Known residual: a deliberate split across two files — one naming the path,
+ * another doing the write — evades a per-file predicate. That is obfuscation,
+ * not the accidental copy-paste this guards against.
  */
-function parsesEnvFileItself(source) {
-  const readsEnvFile = /['"`][^'"`\n]*\.env(?:\.local)?['"`]/.test(source);
-  // `[^\n]*?` rather than `[^\]]+` so a nested subscript still matches — the real
-  // loaders write `process.env[m[1]] = m[2]`, which a bracket-excluding class
-  // silently skips. The trailing `[^=]` keeps `===` comparisons out.
-  const writesComputedEnvKey = /process\.env\[[^\n]*?\]\s*=[^=]/.test(source);
-  return readsEnvFile && writesComputedEnvKey;
+function accessesEnvFileItself(source) {
+  const code = stripJsComments(source);
+  const reads = ENV_FILE_ACCESS.some(([re]) => re.test(code));
+  const writes = ENV_WRITE_PRIMITIVES.some(([re]) => re.test(code));
+  return reads && writes;
 }
 
 describe('seeder env hermeticity (#5767)', () => {
@@ -180,6 +264,19 @@ describe('seeder env hermeticity (#5767)', () => {
     it('reads process.env by default', () => {
       // This suite itself runs under node:test, so the default must be `true`.
       assert.equal(isTestRuntime(), true);
+    });
+
+    it('the opt-in is not set in the process actually running the suite', () => {
+      // Every other case here runs in a child process built from a scrubbed
+      // env, so nothing else observes the process the real suite runs in. One
+      // stray `export WM_ALLOW_ENV_LOAD_IN_TESTS=1` disables the fix for all
+      // 16k+ tests at once and every other assertion stays green.
+      assert.notEqual(
+        process.env.WM_ALLOW_ENV_LOAD_IN_TESTS,
+        '1',
+        'WM_ALLOW_ENV_LOAD_IN_TESTS=1 is set in this environment — seeder imports ' +
+          'are loading real credentials into every test in this run',
+      );
     });
   });
 
@@ -212,6 +309,46 @@ describe('seeder env hermeticity (#5767)', () => {
         WM_ALLOW_ENV_LOAD_IN_TESTS: '1',
       });
       assert.equal(result.url, CHECKOUT_SENTINEL, 'escape hatch must still work');
+    });
+
+    it('honours the `only` key filter', () => {
+      // shadow-score-report.mjs needs exactly two keys, not the whole file. It
+      // used to get that with a private loader, which is how it stayed outside
+      // the test-runtime guard; `only` is what let it drop the private copy.
+      const fixture = makeFixtureCheckout({
+        withLocalEnvFile: true,
+        only: ['UPSTASH_REDIS_REST_URL'],
+      });
+      const result = runFixture(fixture);
+      assert.equal(result.url, CHECKOUT_SENTINEL, 'the requested key must load');
+      assert.equal(result.token, null, '`only` must exclude every other key');
+    });
+
+    it('applies the test-runtime guard to `only` callers too', () => {
+      const fixture = makeFixtureCheckout({
+        withLocalEnvFile: true,
+        only: ['UPSTASH_REDIS_REST_URL'],
+      });
+      const result = runFixture(fixture, { NODE_TEST_CONTEXT: 'child-v8' });
+      assert.equal(result.url, null);
+    });
+
+    it('never reads the .env.local sitting next to the checkout', () => {
+      // The checkout has no .env.local; its PARENT does. `loadEnvFile` probed
+      // `<checkout>/../.env.local`, so it read that one and the suite still
+      // called itself hermetic.
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: false });
+      const result = runFixture(fixture);
+      assert.equal(result.url, null, 'loadEnvFile escaped into the parent directory');
+    });
+
+    it('resolves the checkout root from a nested script directory', () => {
+      // The depth the removed `../..` candidate existed to serve. Anchoring to
+      // the checkout root has to handle it without reintroducing the escape,
+      // and the parent .env.local must still lose.
+      const fixture = makeFixtureCheckout({ withLocalEnvFile: true, nested: true });
+      const result = runFixture(fixture);
+      assert.equal(result.url, CHECKOUT_SENTINEL);
     });
 
     it('never reaches into $HOME/Documents/GitHub/worldmonitor for credentials', () => {
@@ -302,30 +439,30 @@ describe('seeder env hermeticity (#5767)', () => {
       assert.deepEqual(findHomeDirReferences(`join(__dirname, '..', '.env.local')`), []);
     });
 
-    it('no script bakes a home path into the repo', async () => {
+    it('no source bakes a home path into the repo', async () => {
       const offenders = [];
       let scanned = 0;
-      for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
-        if (entry.includes('node_modules')) continue;
+      for await (const entry of scanSources()) {
         scanned += 1;
         const found = findCheckoutEscapingEnvPaths(readFileSync(join(REPO_ROOT, entry), 'utf8'));
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
       }
       assert.ok(scanned > 100, `expected to scan the seeder fleet, scanned ${scanned}`);
-      assert.deepEqual(offenders, [], `scripts with a hardcoded home path:\n${offenders.join('\n')}`);
+      assert.deepEqual(offenders, [], `sources with a hardcoded home path:\n${offenders.join('\n')}`);
     });
 
-    it('no .env parser reaches for a home directory', async () => {
-      // Scoped to the files that parse .env at all, which the sweep below pins
-      // to the allowlist. Any NEW file that escapes to $HOME for credentials
-      // must parse .env to use them, so it is caught there first and here
-      // second — the two sweeps close each other's gap.
+    it('no env-loading source reaches for a home directory', async () => {
+      // Gated on accessesEnvFileItself, NOT on the write-half predicate this
+      // used to use. Under the old gating, escaping the parser check also
+      // switched this one off — so a file doing plain `homedir()` +
+      // `process.loadEnvFile()` passed BOTH sweeps with a working leak. The
+      // read-half gate has no such bypass: naming a `.env` file (or a loader)
+      // is unavoidable, so anything reaching for $HOME to find one lands here.
       const offenders = [];
-      for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
-        if (entry.includes('node_modules')) continue;
+      for await (const entry of scanSources()) {
         const source = readFileSync(join(REPO_ROOT, entry), 'utf8');
-        if (!parsesEnvFileItself(source)) continue;
-        const found = findHomeDirReferences(source);
+        if (!accessesEnvFileItself(source)) continue;
+        const found = findHomeDirReferences(stripJsComments(source));
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
       }
       assert.deepEqual(
@@ -337,50 +474,54 @@ describe('seeder env hermeticity (#5767)', () => {
     });
   });
 
-  describe('only the shared helper parses .env files', () => {
-    it('parsesEnvFileItself needs both halves — a read AND a computed process.env write', () => {
+  describe('only the shared helper reads .env files', () => {
+    it('accessesEnvFileItself catches every write primitive, not just a computed subscript', () => {
+      // The write half is unconstrained — each of these is a working bulk load
+      // and every one of them defeated the earlier `process.env[k] = v` gate.
+      const loaders = [
+        `const p = join(root, '.env.local');\nprocess.env[key] = val;`,
+        `const parsed = parse(readFileSync('.env.local'));\nObject.assign(process.env, parsed);`,
+        `process.loadEnvFile(join(root, '.env.local'));`,
+        `process.loadEnvFile();`,
+        `import 'dotenv/config';`,
+        `dotenv.config({ path: p });`,
+        `Reflect.set(process.env, k, v); readFileSync('.env.local');`,
+        `readFileSync('.env.local');\nprocess.env.UPSTASH_REDIS_REST_URL = m[2];`,
+      ];
+      for (const source of loaders) {
+        assert.ok(accessesEnvFileItself(source), `env loader went undetected:\n${source}`);
+      }
+      // Negatives: documenting or symlinking an env file is not reading one.
+      assert.equal(accessesEnvFileItself(`// documented in .env.local`), false, 'line comment');
       assert.equal(
-        parsesEnvFileItself(`const p = join(root, '.env.local');\nprocess.env[key] = val;`),
-        true,
-      );
-      assert.equal(
-        // The shape both real loaders use — a nested subscript on the left.
-        parsesEnvFileItself(
-          `readFileSync('.env.local');\nif (!process.env[m[1]]) process.env[m[1]] = m[2];`,
-        ),
-        true,
-        'a nested subscript must not evade the guard',
-      );
-      assert.equal(
-        parsesEnvFileItself(`const p = '.env.local';\nif (process.env[key] === val) return;`),
+        accessesEnvFileItself(`/*\n * Reads .env.local at project root.\n */\nconst x = 1;`),
         false,
-        'a comparison is not a write',
+        'block comment',
       );
-      // Negatives: each half alone, and the shapes that legitimately touch either.
-      assert.equal(parsesEnvFileItself(`// documented in .env.local`), false, 'comment only');
-      assert.equal(parsesEnvFileItself(`process.env[key] = val;`), false, 'no env file read');
+      assert.equal(accessesEnvFileItself(`process.env[key] = val;`), false, 'no env file read');
       assert.equal(
-        parsesEnvFileItself(`symlinkSync(join(src, '.env.local'), dest);`),
+        accessesEnvFileItself(`symlinkSync(join(src, '.env.local'), dest);`),
         false,
-        'symlinking an env file is not parsing it',
+        'symlinking an env file is not loading it',
       );
       assert.equal(
-        parsesEnvFileItself(`const p = '.env.local';\nprocess.env.FOO = 'bar';`),
+        // The scanners: they read env files to audit them, never to apply them.
+        accessesEnvFileItself(`const body = readFileSync('.env.local', 'utf8');\nreturn findSecrets(body);`),
         false,
-        'a fixed-key write is not a bulk import',
+        'auditing an env file is not loading it',
       );
     });
 
-    it('no script under scripts/ re-implements the loader', async () => {
+    it('no source outside the allowlist reads a .env file', async () => {
       const offenders = [];
-      for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
-        if (entry.includes('node_modules') || ENV_PARSER_ALLOWLIST.has(entry)) continue;
-        if (parsesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8'))) offenders.push(entry);
+      for await (const entry of scanSources()) {
+        if (ENV_PARSER_ALLOWLIST.has(entry)) continue;
+        if (accessesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8'))) offenders.push(entry);
       }
       assert.deepEqual(
         offenders,
         [],
-        `these parse .env themselves instead of calling loadEnvFile(), so they bypass the ` +
+        `these read .env themselves instead of calling loadEnvFile(), so they bypass the ` +
           `test-runtime guard entirely:\n${offenders.join('\n')}`,
       );
     });
@@ -388,8 +529,8 @@ describe('seeder env hermeticity (#5767)', () => {
     it('the allowlist has no stale entries', async () => {
       for (const entry of ENV_PARSER_ALLOWLIST) {
         assert.ok(
-          parsesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8')),
-          `${entry} no longer parses .env itself — drop it from ENV_PARSER_ALLOWLIST`,
+          accessesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8')),
+          `${entry} no longer reads .env itself — drop it from ENV_PARSER_ALLOWLIST`,
         );
       }
     });

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -107,6 +107,33 @@ function findCheckoutEscapingEnvPaths(source) {
   return offenders;
 }
 
+// Files under scripts/ allowed to parse a .env file into process.env themselves.
+// Every other script must route through the shared `loadEnvFile`, which is where
+// the test-runtime and checkout-scoping rules live — a private copy of the parser
+// silently opts out of both, which is how #5767's second instance survived.
+const ENV_PARSER_ALLOWLIST = new Set([
+  // The one implementation.
+  'scripts/_seed-utils.mjs',
+  // Deliberately narrower than the shared helper: hydrates only the two Upstash
+  // keys it needs rather than bulk-importing every var, and is main()-scoped.
+  'scripts/shadow-score-report.mjs',
+]);
+
+/**
+ * Pure predicate: does this source parse a `.env` file into `process.env` itself?
+ * Keyed on the two halves that must both be present — reading a `.env` path and
+ * writing a computed key into `process.env` — so merely mentioning `.env.local`
+ * in a comment, or symlinking it (bootstrap-worktree.mjs), does not trip it.
+ */
+function parsesEnvFileItself(source) {
+  const readsEnvFile = /['"`][^'"`\n]*\.env(?:\.local)?['"`]/.test(source);
+  // `[^\n]*?` rather than `[^\]]+` so a nested subscript still matches — the real
+  // loaders write `process.env[m[1]] = m[2]`, which a bracket-excluding class
+  // silently skips. The trailing `[^=]` keeps `===` comparisons out.
+  const writesComputedEnvKey = /process\.env\[[^\n]*?\]\s*=[^=]/.test(source);
+  return readsEnvFile && writesComputedEnvKey;
+}
+
 describe('seeder env hermeticity (#5767)', () => {
   describe('isTestRuntime()', () => {
     it('detects the runners that import seeder modules', () => {
@@ -223,6 +250,64 @@ describe('seeder env hermeticity (#5767)', () => {
       }
       assert.ok(scanned > 100, `expected to scan the seeder fleet, scanned ${scanned}`);
       assert.deepEqual(offenders, [], `scripts reaching outside the checkout:\n${offenders.join('\n')}`);
+    });
+  });
+
+  describe('only the shared helper parses .env files', () => {
+    it('parsesEnvFileItself needs both halves — a read AND a computed process.env write', () => {
+      assert.equal(
+        parsesEnvFileItself(`const p = join(root, '.env.local');\nprocess.env[key] = val;`),
+        true,
+      );
+      assert.equal(
+        // The shape both real loaders use — a nested subscript on the left.
+        parsesEnvFileItself(
+          `readFileSync('.env.local');\nif (!process.env[m[1]]) process.env[m[1]] = m[2];`,
+        ),
+        true,
+        'a nested subscript must not evade the guard',
+      );
+      assert.equal(
+        parsesEnvFileItself(`const p = '.env.local';\nif (process.env[key] === val) return;`),
+        false,
+        'a comparison is not a write',
+      );
+      // Negatives: each half alone, and the shapes that legitimately touch either.
+      assert.equal(parsesEnvFileItself(`// documented in .env.local`), false, 'comment only');
+      assert.equal(parsesEnvFileItself(`process.env[key] = val;`), false, 'no env file read');
+      assert.equal(
+        parsesEnvFileItself(`symlinkSync(join(src, '.env.local'), dest);`),
+        false,
+        'symlinking an env file is not parsing it',
+      );
+      assert.equal(
+        parsesEnvFileItself(`const p = '.env.local';\nprocess.env.FOO = 'bar';`),
+        false,
+        'a fixed-key write is not a bulk import',
+      );
+    });
+
+    it('no script under scripts/ re-implements the loader', async () => {
+      const offenders = [];
+      for await (const entry of glob('scripts/**/*.{mjs,cjs,js}', { cwd: REPO_ROOT })) {
+        if (entry.includes('node_modules') || ENV_PARSER_ALLOWLIST.has(entry)) continue;
+        if (parsesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8'))) offenders.push(entry);
+      }
+      assert.deepEqual(
+        offenders,
+        [],
+        `these parse .env themselves instead of calling loadEnvFile(), so they bypass the ` +
+          `test-runtime guard entirely:\n${offenders.join('\n')}`,
+      );
+    });
+
+    it('the allowlist has no stale entries', async () => {
+      for (const entry of ENV_PARSER_ALLOWLIST) {
+        assert.ok(
+          parsesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8')),
+          `${entry} no longer parses .env itself — drop it from ENV_PARSER_ALLOWLIST`,
+        );
+      }
     });
   });
 });

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -163,6 +163,9 @@ describe('seeder env hermeticity (#5767)', () => {
         [{ NODE_TEST_CONTEXT: 'child' }, true, 'node:test child process (json)'],
         [{ VITEST: 'true' }, true, 'vitest'],
         [{ VITEST_WORKER_ID: '3' }, true, 'vitest worker'],
+        // The value vitest actually uses for its first worker. Pinned because a
+        // refactor to a truthiness check would keep every other case green.
+        [{ VITEST_WORKER_ID: '0' }, true, 'vitest worker zero'],
         [{ JEST_WORKER_ID: '1' }, true, 'jest worker'],
         [{ NODE_ENV: 'test' }, true, 'NODE_ENV=test'],
         [{}, false, 'plain node process'],


### PR DESCRIPTION
Closes #5767.

## The bug, reproduced before fixing

149 seeder modules call `loadEnvFile(import.meta.url)` at module scope; 103 are imported by at least one test. Importing any of them loaded ~100 production credentials (Upstash Redis, Convex deploy key, Cloudflare tokens, `DATABASE_URL`, dozens of API keys) into `process.env` before a single test body ran. CI never caught it — CI has no `.env.local`.

Verified against the real helper in clean child processes, with a fixture checkout:

| scenario | before |
|---|---|
| run a seeder directly, checkout has `.env.local` | loads creds (correct) |
| **test process** (`NODE_TEST_CONTEXT` set) | **loads creds** |
| **worktree with no `.env.local`** | **loads creds from `$HOME/Documents/GitHub/worldmonitor`** |
| **checkout with a `.env.local` beside it** | **loads creds from the parent directory** |

The last row was not in the issue — found while verifying, and it made the AGENTS.md line I had just written ("current checkout only") false.

## The fix

- **`loadEnvFile()` is inert under a test runtime**, via the exported pure predicate `isTestRuntime()`. Covers node:test, tsx, vitest, jest and Playwright — each probed empirically, not assumed. `WM_ALLOW_ENV_LOAD_IN_TESTS=1` is the deliberate escape hatch. CI already ran the whole suite with no `.env.local`, so this only makes local runs match CI.
- **Resolution anchored to the checkout root** (nearest `.git`, file or dir, so worktrees count) instead of guessing with `..` and `../..`. Correct for both top-level and nested `scripts/<dir>/` modules, and unable to escape. `WM_SEED_ENV_FILE` replaces the removed hardcoded `$HOME` candidate.
- **`loadEnvFile()` is now the only thing in the repo that reads a `.env` file.** Four scripts carried private copies of the parser that bypassed the guard entirely — `fetch-pizzint-bases.mjs` at **module scope** (the same bug, which the first commit would have missed), plus `seed-ucdp-events.mjs` (with an absolute personal path hardcoded), `seed-wb-indicators.mjs` and `seed-military-bases.mjs`. All routed through the shared helper, which gained `{ only }` so `shadow-score-report.mjs` keeps its 2-key narrowing without a private loader.

## Guard test

`tests/seed-env-hermeticity.test.mjs` pins three invariants against the real helper through a fixture checkout in a temp dir, so it is meaningful in CI too. No real seeder is imported — that is its own repo landmine.

Every guard is mutation-tested: reverting either half of the fix reds exactly the tests that should, and all 10 demonstrated bypass shapes red the suite, each caught by two independent sweeps.

## Review found two defects in my own work

Six reviewers ran. The two that mattered most were mine:

- The allowlist exempted `shadow-score-report.mjs` as "main()-scoped". It is a bare top-level IIFE with no direct-run guard — so the guard was blessing the last remaining instance of the exact #5767 shape. **The allowlist is now a single entry**: the implementation itself.
- A comment claimed two source sweeps "close each other's gap". They did not — one gated the other, so a `homedir()` + `process.loadEnvFile()` loader passed both with a working leak. Decoupled; the predicates now match every write primitive (`Object.assign`, `Reflect.set`, `process.loadEnvFile`, dotenv, fixed-key) and every home-dir source, with comments stripped via the repo's own scanner.

Sweeps also widened past `scripts/` to `api/`, `server/`, `cli/`, `middleware.ts`.

## Verification

- **18,333 tests passing.** The only 2 failures are pre-existing `dashboard-critical-css` tests requiring a prior `vite build` (no `dist/` in the worktree) — identical on `origin/main`, no coupling to this change.
- biome + markdownlint clean; rebased onto current `main` (which had picked up #5756 — its test passes).

## Reported, not fixed

- `tests/source-proxy-fallback.test.mjs` keeps its per-file credential clearing on purpose: it defends a vector this fix cannot — credentials already exported in your **shell**. Closing that at `getRedisCredentials()` would break the 136 test files that legitimately set stub credentials.
- `seed-wb-indicators.mjs` / `seed-military-bases.mjs` call `main()` with no main-module guard, so importing them runs the seeder. Pre-existing, identical on `origin/main`, nothing imports them; a guard here carries its own hazard and belongs in a separate change.
- `consumer-prices-core` loads env via `import 'dotenv/config'` under its own vitest CI job. Same class, much smaller blast radius (separate package, its own `.env`), and structurally invisible to these sweeps — worth its own issue.

https://claude.ai/code/session_01EGMG5w6EtLepy19uEbPznh