### PR TITLE
fix(china): classify the Japan MOD proxy target block

### DIFF
--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -76,7 +76,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `OK` | Green | Data present, seed fresh |
 | `OK_CASCADE` | Green | Key empty but a sibling in the cascade group has data (e.g., theater posture fallback chain) |
 | `NOT_CONFIGURED` | Green | An optional source adapter this deployment never supplied a credential for (producer wrote `sourceState: "unavailable"`, e.g. the Global Tenders SAM.gov adapter without `SAM_GOV_API_KEY`). Not a fault and not counted as a problem; flips to `OK` on the first run after the credential is added |
-| `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved a direct HTTP 403 and another upstream HTTP 403 after a successful proxy CONNECT while retaining fresh reviewed records. CONNECT-layer refusals, stale, empty, or unreviewed states still fail closed |
+| `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved no transport path reaches the publisher while retaining fresh reviewed records — either an upstream HTTP 403 after a successful proxy CONNECT (`HTTP_403`), or a target-scoped proxy CONNECT refusal corroborated by a successful control tunnel (`PROXY_TARGET_FORBIDDEN`). Uncorroborated CONNECT refusals, stale, empty, or unreviewed states still fail closed |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
 | `STALE_CONTENT` | Warn | Seeder is fresh but the upstream content stopped advancing (frozen feed); counted in `summary.staleContent` |
 | `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints or 139/174 PortWatch port-activity countries) |
@@ -113,12 +113,21 @@ observations are regional augmentation and do not satisfy the Taiwan MND
 content requirement. `/api/health` separately monitors
 `military:cross-strait-activity-bootstrap:v1`; fresh canonical data cannot hide
 a missing compact UI projection. It also exposes dedicated MND and Japan Joint
-Staff transport records. Japan Joint Staff alone reports `SOURCE_BLOCKED` when
-retained reviewed records exist and the current direct request plus an
-upstream response after a successful proxy CONNECT both return HTTP 403.
-CONNECT-layer refusals, stale metadata, a missing source record, or any other
-source using the blocked state still fail closed through the existing
-`STALE_SEED`, `EMPTY`, or `SEED_ERROR` statuses. Other current fetch failures
+Staff transport records. Japan Joint Staff alone reports `SOURCE_BLOCKED`, and
+only when retained reviewed records exist and one of two evidenced conditions
+holds. `HTTP_403` means the direct request and an upstream response received
+after a successful proxy CONNECT both returned HTTP 403 — the publisher itself
+refused both paths. `PROXY_TARGET_FORBIDDEN` means the direct request returned
+HTTP 403 and the proxy refused CONNECT for the target *while a control CONNECT
+to a different contracted host succeeded in the same run through the same
+credentials* — the proxy provider forbids this destination specifically, so no
+configured transport path exists. An uncorroborated CONNECT refusal, a control
+tunnel that also fails, `PROXY_AUTH_FAILED`, stale metadata, a missing source
+record, or any other source using the blocked state still fail closed through
+the existing `STALE_SEED`, `EMPTY`, or `SEED_ERROR` statuses. The distinction
+matters operationally: `PROXY_TARGET_FORBIDDEN` is durable and needs a
+different egress to change, whereas a bare CONNECT refusal is a proxy fault to
+remediate. Other current fetch failures
 report `SEED_ERROR` while the last-good archive remains available.
 The bundle freshness gate advances only after the archive, projection, and
 both source-health records publish successfully. The public bootstrap retains

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2053,9 +2053,28 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
       // Only a CONNECT refusal is ambiguous enough to be worth a control
       // tunnel; every other proxy failure already reached Japan MOD or names
       // its own cause, so it must not spend an extra outbound connection.
+      //
+      // The probe is a diagnostic and must never be able to fail the run that
+      // uses it: this sits inside the proxy catch block and the caller awaits
+      // the Japan outcome unguarded, so an escaping throw would take down the
+      // healthy Taiwan MND feed too. Any failure -- rejection, synchronous
+      // throw, or a non-thenable return -- resolves to `unreachable`, which
+      // fails closed and keeps the source degraded and operator-visible.
       const proxyControlProbe = failureCode === 'PROXY_CONNECT_FORBIDDEN' && proxyConnectProbeFn
-        ? await proxyConnectProbeFn(contract.proxyControlProbeHost)
-          .then(() => 'reachable', () => 'unreachable')
+        ? await (async () => {
+            try {
+              const pending = proxyConnectProbeFn(contract.proxyControlProbeHost);
+              // Only an awaited tunnel counts as evidence. A probe that returns
+              // a non-thenable never opened anything, and `await` on it would
+              // resolve immediately and read as `reachable` -- a false green on
+              // exactly the axis this probe exists to guard.
+              if (typeof pending?.then !== 'function') return 'unreachable';
+              await pending;
+              return 'reachable';
+            } catch {
+              return 'unreachable';
+            }
+          })()
         : undefined;
       const blockedReason = blockedJapanProxyReason(
         fallbackReason,

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 
 const {
   parseProxyConfig,
+  proxyConnectTunnel,
   proxyFetch,
 } = createRequire(import.meta.url)('../_proxy-utils.cjs');
 
@@ -14,6 +15,18 @@ export const MND_REQUIRED_REPORTING_DAYS = 91;
 export const MND_RETENTION_REPORTING_DAYS = 365;
 export const MND_MAX_REVISION_VINTAGES_PER_DAY = 20;
 export const CROSS_STRAIT_ACTIVITY_MAX_SERIALIZED_BYTES = 4 * 1024 * 1024;
+/**
+ * Reasons that justify reporting a source as durably blocked rather than
+ * failing. Both mean no configured transport path can reach the publisher, so
+ * retained reviewed records are the best obtainable truth and health must not
+ * be pinned on an outage that will never clear on its own. Every consumer that
+ * branches on `blockedReason` reads this list — widening it in one place only
+ * is how a new reason silently degrades to `error`.
+ */
+export const CROSS_STRAIT_BLOCKED_SOURCE_REASONS = Object.freeze([
+  'HTTP_403',
+  'PROXY_TARGET_FORBIDDEN',
+]);
 
 const USER_AGENT = 'WorldMonitor/2.10 (+https://worldmonitor.app)';
 const MND_LIST_URL = 'https://www.mnd.gov.tw/en/news/plaactlist';
@@ -86,6 +99,14 @@ export const CROSS_STRAIT_SOURCE_CONTRACTS = Object.freeze({
     fallbackPolicy: 'direct_then_proxy_on_transport_failure',
     documentAdmission: 'manual_review_required',
     runtimePdfRequestsPerRun: 0,
+    // A proxy CONNECT refusal is emitted before the tunnel reaches Japan MOD,
+    // so on its own it cannot separate "this provider forbids this destination"
+    // from "the proxy is down for everything". One CONNECT-only control tunnel
+    // to a host we already contract with settles that, and is torn down without
+    // sending a byte — so it is transport telemetry, not a source request, and
+    // it deliberately targets a host other than the one under test.
+    proxyControlProbeHost: 'www.mnd.gov.tw',
+    maxProxyControlProbesPerRun: 1,
     preflight: Object.freeze({
       environment: 'railway-production',
       checkedAt: '2026-07-26',
@@ -1820,6 +1841,9 @@ export function buildCrossStraitActivitySnapshot({
       ...(japanOutcome?.proxyFailureDetail
         ? { proxyFailureDetail: japanOutcome.proxyFailureDetail }
         : {}),
+      ...(japanOutcome?.proxyControlProbe
+        ? { proxyControlProbe: japanOutcome.proxyControlProbe }
+        : {}),
       errorCodes: japanOutcome?.errorCodes ?? [],
       lastSuccessAt: japanOutcome?.ok
         ? generatedAt
@@ -1927,12 +1951,42 @@ function proxyErrorCode(error) {
   return String(error?.message ?? '').match(/PROXY_[A-Z0-9_]+/)?.[0] ?? code;
 }
 
-function blockedJapanProxyReason(directFailureCode, proxyFailureCode) {
+function blockedJapanProxyReason(directFailureCode, proxyFailureCode, proxyControlProbe) {
   if (directFailureCode !== 'HTTP_403') return null;
-  // A CONNECT refusal is emitted by the proxy before the TLS tunnel reaches
-  // Japan MOD. Only a 403 response received after CONNECT proves that both
-  // source-facing transport paths are externally blocked.
-  return proxyFailureCode === 'HTTP_403' ? proxyFailureCode : null;
+  // A 403 received *after* CONNECT is Japan MOD itself refusing the proxied
+  // request, so both source-facing paths are externally blocked.
+  if (proxyFailureCode === 'HTTP_403') return 'HTTP_403';
+  // A CONNECT refusal never reaches Japan MOD, so it cannot prove a source
+  // block on its own — that is why #5718 left it degraded. What it does prove,
+  // once a control tunnel to a different host succeeds in the same run through
+  // the same credentials, is that the provider forbids this destination
+  // specifically. Direct egress is refused by the source and the only proxy
+  // refuses the target, so no configured transport path exists and the state is
+  // durable rather than an outage awaiting remediation. Without that control
+  // evidence a proxy-wide failure would masquerade as an upstream block, so the
+  // unprobed and probe-failed cases stay degraded and operator-visible.
+  if (proxyFailureCode === 'PROXY_CONNECT_FORBIDDEN' && proxyControlProbe === 'reachable') {
+    return 'PROXY_TARGET_FORBIDDEN';
+  }
+  return null;
+}
+
+/**
+ * Opens a CONNECT tunnel through the configured proxy to the control host and
+ * immediately tears it down. No HTTP request is issued and no application byte
+ * is written, so this measures exactly one thing: whether the proxy is willing
+ * to tunnel anywhere at all.
+ */
+async function probeJapanProxyControlTunnel(host, {
+  proxyUrl,
+  proxyConnectFn,
+}) {
+  const proxyConfig = parseProxyConfig(proxyUrl);
+  if (!proxyConfig) throw new Error('PROXY_CONFIG_INVALID');
+  const tunnel = await proxyConnectFn(host, proxyConfig, {
+    timeoutMs: REQUEST_TIMEOUT_MS,
+  });
+  tunnel?.destroy?.();
 }
 
 function rotatingRefreshCandidates(previousMnd, excludedUrls, now) {
@@ -1965,6 +2019,7 @@ function hasMndOutboundBudget({ runStartedAt, nowFn, cadenceMs }) {
 
 async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
   proxyFetchFn = null,
+  proxyConnectProbeFn = null,
 } = {}) {
   const contract = CROSS_STRAIT_SOURCE_CONTRACTS.japanMod;
   let html;
@@ -1995,7 +2050,18 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
       proxyResponseDetail = proxyResult.detail;
     } catch (proxyError) {
       const failureCode = proxyErrorCode(proxyError);
-      const blockedReason = blockedJapanProxyReason(fallbackReason, failureCode);
+      // Only a CONNECT refusal is ambiguous enough to be worth a control
+      // tunnel; every other proxy failure already reached Japan MOD or names
+      // its own cause, so it must not spend an extra outbound connection.
+      const proxyControlProbe = failureCode === 'PROXY_CONNECT_FORBIDDEN' && proxyConnectProbeFn
+        ? await proxyConnectProbeFn(contract.proxyControlProbeHost)
+          .then(() => 'reachable', () => 'unreachable')
+        : undefined;
+      const blockedReason = blockedJapanProxyReason(
+        fallbackReason,
+        failureCode,
+        proxyControlProbe,
+      );
       return {
         ok: false,
         ...(blockedReason ? { blockedReason } : {}),
@@ -2004,6 +2070,7 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
         fallbackReason,
         proxyFailureReason: failureCode,
         proxyFailureDetail: proxyFailureDetail(proxyError),
+        ...(proxyControlProbe ? { proxyControlProbe } : {}),
         availableDocumentUrls: [],
         errorCodes: [...new Set([fallbackReason, failureCode])],
       };
@@ -2058,6 +2125,8 @@ export async function fetchCrossStraitActivitySnapshot({
   sleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   proxyUrl = process.env.JAPAN_MOD_PROXY_URL || process.env.PROXY_URL || '',
   proxyRequestFn = proxyFetch,
+  proxyConnectFn = proxyConnectTunnel,
+  proxyConnectProbeFn = null,
 } = {}) {
   const generatedAt = new Date(now).toISOString();
   const previousMnd = (previousSnapshot?.observations ?? [])
@@ -2077,8 +2146,15 @@ export async function fetchCrossStraitActivitySnapshot({
         proxyRequestFn,
       })
     : null;
+  const resolvedJapanProxyConnectProbeFn = proxyUrl
+    ? (proxyConnectProbeFn ?? ((host) => probeJapanProxyControlTunnel(host, {
+        proxyUrl,
+        proxyConnectFn,
+      })))
+    : null;
   const japanOutcomePromise = fetchJapanIndexOutcome(fetchFn, sleepFn, {
     proxyFetchFn: resolvedJapanProxyFetchFn,
+    proxyConnectProbeFn: resolvedJapanProxyConnectProbeFn,
   });
   let discoveredCount = 0;
   let requestCount = 0;

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -40,8 +40,20 @@ function withoutRevisionHistory(observation) {
   return currentRevision;
 }
 
-function withoutProxyFailureDetail(source) {
-  const { proxyFailureDetail: _proxyFailureDetail, ...publicSource } = source;
+/**
+ * Strips operator-only proxy diagnostics from the anonymous bootstrap. Both
+ * fields describe OUR egress rather than the source: the response detail can
+ * carry upstream body text, and the control probe reports whether our own proxy
+ * is currently working. The bounded reason codes that remain (`blockedReason`,
+ * `fallbackReason`, `proxyFailureReason`) are what the disclosure UI reads, and
+ * they explain the state without publishing our transport's health.
+ */
+function withoutProxyOperatorDiagnostics(source) {
+  const {
+    proxyFailureDetail: _proxyFailureDetail,
+    proxyControlProbe: _proxyControlProbe,
+    ...publicSource
+  } = source;
   return publicSource;
 }
 
@@ -61,7 +73,7 @@ export function projectCrossStraitActivityBootstrap(snapshot) {
     schemaVersion: snapshot?.schemaVersion,
     generatedAt: snapshot?.generatedAt,
     status: snapshot?.status,
-    sources: (snapshot?.sources ?? []).map(withoutProxyFailureDetail),
+    sources: (snapshot?.sources ?? []).map(withoutProxyOperatorDiagnostics),
     coverage: snapshot?.coverage ?? {},
     observations: [...mnd, ...reviewedJapan].map(withoutRevisionHistory),
     baselines: snapshot?.baselines ?? {},

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import {
   CROSS_STRAIT_ACTIVITY_KEY,
+  CROSS_STRAIT_BLOCKED_SOURCE_REASONS,
   fetchCrossStraitActivitySnapshot,
   validateCrossStraitActivitySnapshot,
 } from './cross-strait-activity/adapters.mjs';
@@ -89,7 +90,7 @@ function sourceRecordCount(snapshot, sourceId) {
 export async function writeSourceHealth(snapshot, writer = writeExtraKey) {
   const outcomes = await Promise.allSettled((snapshot?.sources ?? []).map(async (source) => {
     const healthy = source?.transportStatus === 'fresh';
-    const blocked = source?.blockedReason === 'HTTP_403';
+    const blocked = CROSS_STRAIT_BLOCKED_SOURCE_REASONS.includes(source?.blockedReason);
     const fetchedAt = Date.parse(
       blocked ? snapshot?.generatedAt ?? '' : source?.lastSuccessAt ?? '',
     );

--- a/src/components/cross-strait-activity-summary.ts
+++ b/src/components/cross-strait-activity-summary.ts
@@ -1,8 +1,10 @@
-import type {
-  CrossStraitActivitySourceHealth,
-  CrossStraitActivitySnapshot,
-  CrossStraitBaselineWindow,
-  TaiwanMndActivityCategories,
+import {
+  CROSS_STRAIT_BLOCKED_SOURCE_REASONS,
+  type CrossStraitActivitySourceHealth,
+  type CrossStraitActivitySnapshot,
+  type CrossStraitBaselineWindow,
+  type CrossStraitBlockedReason,
+  type TaiwanMndActivityCategories,
 } from '@/types/cross-strait-activity';
 
 export interface CrossStraitComparisonModel {
@@ -223,7 +225,14 @@ function isSourceHealth(value: unknown): boolean {
     )
     && (
       value.blockedReason === undefined
-      || value.blockedReason === 'HTTP_403'
+      || CROSS_STRAIT_BLOCKED_SOURCE_REASONS.includes(
+        value.blockedReason as CrossStraitBlockedReason,
+      )
+    )
+    && (
+      value.proxyControlProbe === undefined
+      || value.proxyControlProbe === 'reachable'
+      || value.proxyControlProbe === 'unreachable'
     )
     && (
       value.fallbackReason === undefined
@@ -362,7 +371,8 @@ export function buildCrossStraitActivityPanelModel(
 
   const progress = `${snapshot.coverage.usableMndReportingDays} usable reporting days`;
   const hasBlockedSource = snapshot.sources.some(
-    (source) => source.blockedReason === 'HTTP_403',
+    (source) => source.blockedReason !== undefined
+      && CROSS_STRAIT_BLOCKED_SOURCE_REASONS.includes(source.blockedReason),
   );
   const sourceHealth = snapshot.status === 'degraded'
     || snapshot.status === 'unavailable'

--- a/src/types/cross-strait-activity.ts
+++ b/src/types/cross-strait-activity.ts
@@ -94,6 +94,22 @@ export interface CrossStraitProxyFailureDetail {
   errorMessage: string | null;
 }
 
+/**
+ * Mirrors CROSS_STRAIT_BLOCKED_SOURCE_REASONS in
+ * scripts/cross-strait-activity/adapters.mjs. The producer lives under scripts/
+ * because Railway's nixpacks service copies only that directory, so this list
+ * is a hand-kept mirror rather than an import; the production-registration test
+ * pins the two together, because a producer reason missing here is not a type
+ * error — it silently fails the runtime source-health guard and drops the whole
+ * snapshot on the client.
+ */
+export const CROSS_STRAIT_BLOCKED_SOURCE_REASONS = [
+  'HTTP_403',
+  'PROXY_TARGET_FORBIDDEN',
+] as const;
+
+export type CrossStraitBlockedReason = typeof CROSS_STRAIT_BLOCKED_SOURCE_REASONS[number];
+
 export interface CrossStraitActivitySourceHealth {
   id: CrossStraitSourceId;
   publisher: string;
@@ -102,10 +118,12 @@ export interface CrossStraitActivitySourceHealth {
   transportStatus: 'fresh' | 'error';
   requestCount: number;
   transportPath?: 'direct' | 'proxy';
-  blockedReason?: 'HTTP_403';
+  blockedReason?: CrossStraitBlockedReason;
   fallbackReason?: string;
   proxyFailureReason?: string;
   proxyFailureDetail?: CrossStraitProxyFailureDetail;
+  /** Present only when a proxy CONNECT refusal was tested against a control host. */
+  proxyControlProbe?: 'reachable' | 'unreachable';
   errorCodes: string[];
   lastSuccessAt: string | null;
   admittedDocumentCount?: number;

--- a/src/types/cross-strait-activity.ts
+++ b/src/types/cross-strait-activity.ts
@@ -121,8 +121,19 @@ export interface CrossStraitActivitySourceHealth {
   blockedReason?: CrossStraitBlockedReason;
   fallbackReason?: string;
   proxyFailureReason?: string;
+  /**
+   * Operator-only. Stripped from the anonymous bootstrap projection, so this is
+   * never populated on a client-hydrated snapshot -- it is modelled here because
+   * this interface describes the durable source-health record the seeder writes,
+   * of which the bootstrap is a narrowed projection.
+   */
   proxyFailureDetail?: CrossStraitProxyFailureDetail;
-  /** Present only when a proxy CONNECT refusal was tested against a control host. */
+  /**
+   * Operator-only, same projection carve-out as `proxyFailureDetail`. Present
+   * only when a proxy CONNECT refusal was tested against a control host:
+   * `reachable` means the proxy tunnels elsewhere and refuses this target
+   * specifically, which is what licenses `PROXY_TARGET_FORBIDDEN`.
+   */
   proxyControlProbe?: 'reachable' | 'unreachable';
   errorCodes: string[];
   lastSuccessAt: string | null;

--- a/tests/cross-strait-activity-production-registration.test.mts
+++ b/tests/cross-strait-activity-production-registration.test.mts
@@ -4,6 +4,8 @@ import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 
 import { BOOTSTRAP_CACHE_KEYS, BOOTSTRAP_TIERS } from '../shared/bootstrap-tier-keys.js';
+import { CROSS_STRAIT_BLOCKED_SOURCE_REASONS as PRODUCER_BLOCKED_REASONS } from '../scripts/cross-strait-activity/adapters.mjs';
+import { CROSS_STRAIT_BLOCKED_SOURCE_REASONS as CLIENT_BLOCKED_REASONS } from '../src/types/cross-strait-activity';
 
 const root = resolve(import.meta.dirname, '..');
 const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
@@ -15,6 +17,16 @@ describe('cross-Strait activity production registration (#5575)', () => {
     assert.match(registry, /'Japan Joint Staff': 'gov'/);
     assert.match(registry, /'Taiwan Ministry of National Defense': \{[\s\S]*?risk: 'high'/);
     assert.match(registry, /'Japan Joint Staff': \{[\s\S]*?risk: 'high'/);
+  });
+
+  it('keeps the client blocked-reason mirror identical to the producer list', () => {
+    // The client copy cannot import the producer (Railway's nixpacks service
+    // copies only scripts/), and a missing reason is NOT a type error: the
+    // runtime source-health guard would reject the whole snapshot and the panel
+    // would render nothing. Compare the executable values, not their source
+    // text, so an added-but-unmirrored reason fails here instead of in prod.
+    assert.deepEqual([...CLIENT_BLOCKED_REASONS], [...PRODUCER_BLOCKED_REASONS]);
+    assert.ok(PRODUCER_BLOCKED_REASONS.includes('PROXY_TARGET_FORBIDDEN'));
   });
 
   it('schedules the bounded seeder and registers bootstrap, China coverage, and health', () => {

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -50,6 +50,7 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
         id: 'japan-mod',
         transportStatus: 'error',
         blockedReason: 'HTTP_403',
+        proxyControlProbe: 'reachable',
         proxyFailureDetail: {
           stage: 'response',
           httpStatus: 403,
@@ -78,12 +79,27 @@ test('cross-Strait bootstrap is a bounded current projection, not the durable re
   ]);
   assert.ok(projection.observations.every((row) => !('history' in row)));
   assert.deepEqual(projection.sources, snapshot.sources.map((source) => {
-    const { proxyFailureDetail: _proxyFailureDetail, ...publicSource } = source;
+    const {
+      proxyFailureDetail: _proxyFailureDetail,
+      proxyControlProbe: _proxyControlProbe,
+      ...publicSource
+    } = source;
     return publicSource;
   }));
   assert.equal(
     projection.sources.some((source) => 'proxyFailureDetail' in source),
     false,
+  );
+  // The control probe reports whether OUR egress is working, which is operator
+  // diagnostics, not source disclosure -- and no client surface reads it. The
+  // public reason codes already explain the blocked state on their own.
+  assert.equal(
+    projection.sources.some((source) => 'proxyControlProbe' in source),
+    false,
+  );
+  assert.equal(
+    projection.sources.find((source) => source.id === 'japan-mod')?.blockedReason,
+    'HTTP_403',
   );
   assert.deepEqual(projection.coverage, snapshot.coverage);
   assert.deepEqual(projection.baselines, snapshot.baselines);

--- a/tests/cross-strait-activity-shipping.test.mts
+++ b/tests/cross-strait-activity-shipping.test.mts
@@ -250,6 +250,69 @@ test('blocked source health never publishes fresh metadata before its detail rec
   assert.deepEqual(writes, ['military:cross-strait-activity:v1:source:japan-mod']);
 });
 
+test('a control-verified proxy target block clears fleet health like an upstream refusal', async () => {
+  const { classifyKey, STATUS_COUNTS, SEED_META, STANDALONE_KEYS } = __testing__;
+  const now = Date.parse('2026-07-28T20:00:00.000Z');
+  const writes = new Map<string, unknown>();
+
+  await writeSourceHealth({
+    generatedAt: new Date(now).toISOString(),
+    observations: [{ sourceId: 'japan-mod' }, { sourceId: 'japan-mod' }],
+    sources: [{
+      id: 'japan-mod',
+      transportStatus: 'error',
+      blockedReason: 'PROXY_TARGET_FORBIDDEN',
+      proxyFailureReason: 'PROXY_CONNECT_FORBIDDEN',
+      proxyControlProbe: 'reachable',
+      lastSuccessAt: null,
+    }],
+  }, async (key: string, value: unknown) => {
+    writes.set(key, value);
+  });
+
+  const metaKey = SEED_META.crossStraitActivityJapanMod.key;
+  const dataKey = STANDALONE_KEYS.crossStraitActivityJapanMod;
+  assert.deepEqual(writes.get(metaKey), {
+    fetchedAt: now,
+    recordCount: 2,
+    sourceState: 'blocked',
+    stale: false,
+  });
+
+  const entry = classifyKey('crossStraitActivityJapanMod', dataKey, { allowOnDemand: true }, {
+    keyStrens: new Map([[dataKey, 1024]]),
+    keyErrors: new Map(),
+    keyMetaValues: new Map([[metaKey, JSON.stringify(writes.get(metaKey))]]),
+    keyMetaErrors: new Map(),
+    now,
+  });
+  assert.equal(entry.status, 'SOURCE_BLOCKED');
+  assert.equal(STATUS_COUNTS[entry.status], 'ok');
+});
+
+test('an uncorroborated proxy CONNECT refusal never reaches the blocked state', async () => {
+  const writes = new Map<string, unknown>();
+  await writeSourceHealth({
+    generatedAt: '2026-07-28T20:00:00.000Z',
+    observations: [{ sourceId: 'japan-mod' }],
+    sources: [{
+      id: 'japan-mod',
+      transportStatus: 'error',
+      proxyFailureReason: 'PROXY_CONNECT_FORBIDDEN',
+      proxyControlProbe: 'unreachable',
+      lastSuccessAt: null,
+    }],
+  }, async (key: string, value: unknown) => {
+    writes.set(key, value);
+  });
+
+  assert.equal(
+    (writes.get('seed-meta:military:cross-strait-activity:japan-mod') as { sourceState: string })
+      .sourceState,
+    'error',
+  );
+});
+
 test('a proxy CONNECT refusal remains an operator-visible source error', async () => {
   const writes = new Map<string, unknown>();
   await writeSourceHealth({

--- a/tests/cross-strait-activity-ui.test.mts
+++ b/tests/cross-strait-activity-ui.test.mts
@@ -335,6 +335,38 @@ describe('Force Posture official-activity supplement (#5575)', () => {
       crossStraitSourceHealthHeading(unavailable.sourceHealth?.state ?? 'degraded'),
       'Official activity unavailable',
     );
+
+    // A proxy-target block reaches the reader through the same disclosure as an
+    // upstream refusal: both mean no transport path exists and the displayed
+    // counts are retained reviewed records, not current ones.
+    const proxyBlockedSource = {
+      ...snapshot.sources[1],
+      transportStatus: 'error' as const,
+      blockedReason: 'PROXY_TARGET_FORBIDDEN' as const,
+      proxyFailureReason: 'PROXY_CONNECT_FORBIDDEN',
+      proxyControlProbe: 'reachable' as const,
+      errorCodes: ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN'],
+      lastSuccessAt: null,
+    };
+    const proxyBlockedSnapshot = {
+      ...snapshot,
+      status: 'healthy' as const,
+      sources: [snapshot.sources[0], proxyBlockedSource],
+    };
+    assert.ok(
+      isCrossStraitActivitySnapshot(proxyBlockedSnapshot),
+      'the runtime guard must admit the new reason or the panel renders nothing',
+    );
+    const proxyBlocked = buildCrossStraitActivityPanelModel(proxyBlockedSnapshot);
+    assert.equal(proxyBlocked.sourceHealth?.state, 'blocked');
+    assert.equal(
+      proxyBlocked.sourceHealth?.sources[1]?.blockedReason,
+      'PROXY_TARGET_FORBIDDEN',
+    );
+    assert.equal(
+      crossStraitSourceHealthHeading(proxyBlocked.sourceHealth?.state ?? 'degraded'),
+      'Official activity source blocked',
+    );
   });
 
   it('rejects malformed nested cache snapshots and soft-fails the supplement model', () => {

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -127,6 +127,13 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(jmod.preflight.observedIndexStatus, 403);
     assert.equal(jmod.documentAdmission, 'manual_review_required');
     assert.equal(jmod.runtimePdfRequestsPerRun, 0);
+    // The control tunnel exists to tell a target-scoped proxy policy apart from
+    // a proxy-wide outage, so it must target a host we already contract with —
+    // and never Japan MOD, whose refusal is the thing under test.
+    assert.equal(jmod.maxProxyControlProbesPerRun, 1);
+    assert.equal(jmod.proxyControlProbeHost, 'www.mnd.gov.tw');
+    assert.ok(mnd.allowedHosts.includes(jmod.proxyControlProbeHost));
+    assert.ok(!jmod.allowedHosts.includes(jmod.proxyControlProbeHost));
   });
 
   it('parses MND list links and preserves the publisher reporting window and categories', () => {
@@ -1244,7 +1251,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     );
   });
 
-  it('keeps a proxy CONNECT 403 degraded because the request never reached Japan MOD', async () => {
+  it('keeps a proxy CONNECT 403 degraded when no control tunnel can corroborate it', async () => {
     const previousSnapshot = await fetchCrossStraitActivitySnapshot({
       fetchFn: crossStraitFixtureFetch(
         () => new Response(fixture('jmod-index.html')),
@@ -1275,6 +1282,9 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(japan?.blockedReason, undefined);
     assert.equal(japan?.fallbackReason, 'HTTP_403');
     assert.equal(japan?.proxyFailureReason, 'PROXY_CONNECT_FORBIDDEN');
+    // No probe is injected here, so the production control tunnel runs against
+    // the unroutable test proxy and cannot corroborate the refusal.
+    assert.equal(japan?.proxyControlProbe, 'unreachable');
     assert.deepEqual(japan?.errorCodes, ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN']);
     assert.equal(snapshot.status, 'degraded');
     assert.deepEqual(japan?.proxyFailureDetail, {
@@ -1297,6 +1307,134 @@ describe('quantified cross-Strait activity (#5575)', () => {
         (row: { sourceId: string }) => row.sourceId === 'japan-mod',
       ),
     );
+  });
+
+  it('classifies a proxy CONNECT 403 as a target block once a control tunnel proves the proxy healthy', async () => {
+    const probedHosts: string[] = [];
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => {
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+          { status: 403 },
+        );
+      },
+      proxyConnectProbeFn: async (host: string) => {
+        probedHosts.push(host);
+      },
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.transportStatus, 'error');
+    assert.equal(japan?.blockedReason, 'PROXY_TARGET_FORBIDDEN');
+    assert.equal(japan?.fallbackReason, 'HTTP_403');
+    assert.equal(japan?.proxyFailureReason, 'PROXY_CONNECT_FORBIDDEN');
+    assert.equal(japan?.proxyControlProbe, 'reachable');
+    assert.deepEqual(japan?.errorCodes, ['HTTP_403', 'PROXY_CONNECT_FORBIDDEN']);
+    // The control tunnel must never be opened to the blocked source itself —
+    // that would prove nothing about the proxy's willingness to tunnel.
+    assert.deepEqual(probedHosts, [CROSS_STRAIT_SOURCE_CONTRACTS.japanMod.proxyControlProbeHost]);
+    assert.ok(!probedHosts.some((host) => host.includes('mod.go.jp')));
+    // Source-facing requests stay within the documented two-leg budget; the
+    // control tunnel is transport telemetry, not a Japan MOD request.
+    assert.equal(japan?.requestCount, 2);
+    assert.equal(japan?.lastSuccessAt, null);
+  });
+
+  it('keeps a proxy CONNECT 403 degraded when the control tunnel is also refused', async () => {
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => {
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+          { status: 403 },
+        );
+      },
+      proxyConnectProbeFn: async () => {
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+          { status: 403 },
+        );
+      },
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.transportStatus, 'error');
+    assert.equal(
+      japan?.blockedReason,
+      undefined,
+      'a proxy-wide CONNECT refusal must stay operator-visible, not read as an upstream block',
+    );
+    assert.equal(japan?.proxyControlProbe, 'unreachable');
+    assert.equal(snapshot.status, 'degraded');
+  });
+
+  it('never opens a control tunnel for a proxy failure that is not a CONNECT refusal', async () => {
+    for (const proxyError of [
+      Object.assign(new Error('Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required'), { status: 407 }),
+      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+    ]) {
+      let probeCalls = 0;
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        fetchFn: crossStraitFixtureFetch(
+          () => new Response('Forbidden', { status: 403 }),
+        ),
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        sleepFn: async () => {},
+        proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+        proxyRequestFn: async () => { throw proxyError; },
+        proxyConnectProbeFn: async () => { probeCalls += 1; },
+      });
+
+      const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+      assert.equal(probeCalls, 0);
+      assert.equal(japan?.blockedReason, undefined);
+      assert.equal(japan?.proxyControlProbe, undefined);
+    }
+  });
+
+  it('never promotes a control-verified CONNECT refusal to blocked without a direct 403', async () => {
+    for (const [directResult, fallbackReason] of [
+      [() => { throw new Error('network reset'); }, 'SOURCE_ERROR'],
+      [() => new Response('Unavailable', { status: 500 }), 'HTTP_500'],
+    ] as const) {
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        fetchFn: crossStraitFixtureFetch(directResult),
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        sleepFn: async () => {},
+        proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+        proxyRequestFn: async () => {
+          throw Object.assign(
+            new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+            { status: 403 },
+          );
+        },
+        proxyConnectProbeFn: async () => {},
+      });
+
+      const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+      assert.equal(japan?.fallbackReason, fallbackReason);
+      assert.equal(japan?.proxyControlProbe, 'reachable');
+      assert.equal(
+        japan?.blockedReason,
+        undefined,
+        'only a direct HTTP 403 evidences a source-side refusal on the direct leg',
+      );
+    }
   });
 
   it('classifies direct and proxied Japan MOD HTTP 403 responses as explicitly blocked', async () => {

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1381,6 +1381,45 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(snapshot.status, 'degraded');
   });
 
+  it('never lets a misbehaving control probe take down the whole cross-Strait run', async () => {
+    // The probe runs inside the proxy catch block and the caller awaits the
+    // Japan outcome unguarded, so a probe that throws synchronously or returns
+    // a non-thenable would reject the entire snapshot -- killing the healthy
+    // Taiwan MND feed because a diagnostic misbehaved. Degrade, never propagate.
+    for (const badProbe of [
+      () => { throw new Error('probe exploded'); },
+      () => 'not a promise',
+      () => null,
+    ] as const) {
+      const snapshot = await fetchCrossStraitActivitySnapshot({
+        fetchFn: crossStraitFixtureFetch(
+          () => new Response('Forbidden', { status: 403 }),
+        ),
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        sleepFn: async () => {},
+        proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+        proxyRequestFn: async () => {
+          throw Object.assign(
+            new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+            { status: 403 },
+          );
+        },
+        proxyConnectProbeFn: badProbe as unknown as (host: string) => Promise<void>,
+      });
+
+      const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+      assert.equal(japan?.transportStatus, 'error');
+      assert.equal(japan?.proxyControlProbe, 'unreachable');
+      assert.equal(japan?.blockedReason, undefined);
+      // The rest of the run still published -- the Taiwan MND leg is untouched
+      // by a Japan-side diagnostic and its observations must survive.
+      assert.ok(
+        snapshot.observations.some((row: { sourceId: string }) => row.sourceId === 'taiwan-mnd'),
+      );
+    }
+  });
+
   it('never opens a control tunnel for a proxy failure that is not a CONNECT refusal', async () => {
     for (const proxyError of [
       Object.assign(new Error('Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required'), { status: 407 }),

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1347,6 +1347,53 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(japan?.lastSuccessAt, null);
   });
 
+  it('uses the configured proxy tunnel for the Japan MOD control probe', async () => {
+    const connectCalls: Array<{
+      host: string;
+      proxyConfig: Record<string, unknown>;
+      options: Record<string, unknown>;
+    }> = [];
+    let destroyCalls = 0;
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => {
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 403 Forbidden'),
+          { status: 403 },
+        );
+      },
+      proxyConnectFn: async (host, proxyConfig, options) => {
+        connectCalls.push({ host, proxyConfig, options });
+        return {
+          destroy() {
+            destroyCalls += 1;
+          },
+        };
+      },
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.blockedReason, 'PROXY_TARGET_FORBIDDEN');
+    assert.equal(japan?.proxyControlProbe, 'reachable');
+    assert.deepEqual(connectCalls, [{
+      host: CROSS_STRAIT_SOURCE_CONTRACTS.japanMod.proxyControlProbeHost,
+      proxyConfig: {
+        host: 'proxy.test',
+        port: 443,
+        auth: 'proxy-user:proxy-secret',
+        tls: true,
+      },
+      options: { timeoutMs: 20_000 },
+    }]);
+    assert.equal(destroyCalls, 1);
+  });
+
   it('keeps a proxy CONNECT 403 degraded when the control tunnel is also refused', async () => {
     const snapshot = await fetchCrossStraitActivitySnapshot({
       fetchFn: crossStraitFixtureFetch(


### PR DESCRIPTION
## Summary

`crossStraitActivityJapanMod` has never succeeded since #5657. #5718 shipped the diagnostics that made this classifiable and correctly left the CONNECT-refusal case as `SEED_ERROR`, explicitly deferring production acceptance. This closes that out.

## Root cause (probed live, not inferred)

The current production record is `fallbackReason: HTTP_403` + `proxyFailureReason: PROXY_CONNECT_FORBIDDEN`. Probing the configured proxy directly with the adapter's own `parseProxyConfig`/`proxyFetch`:

| target | result through the production proxy |
|---|---|
| `www.mod.go.jp` | `Proxy CONNECT: HTTP/1.1 403 Forbidden` |
| `www.mofa.go.jp` | `Proxy CONNECT: HTTP/1.1 403 Forbidden` |
| `www.kantei.go.jp` | `Proxy CONNECT: HTTP/1.1 403 Forbidden` |
| `www.stat.go.jp` | `Proxy CONNECT: HTTP/1.1 403 Forbidden` |
| `www.japantimes.co.jp` | HTTP 403 (the site's own, tunnel opened) |
| `example.com` | HTTP 200 |
| `www.mnd.gov.tw` | HTTP 200 |

The provider refuses CONNECT to the whole `.go.jp` zone — it is provider policy, not the #5689 quota outage (that was 407) and not a Japan MOD decision. Direct egress is refused by Japan MOD (403) and the only proxy refuses the destination, so **no configured transport path exists** and none will without a different egress. A permanent `SEED_ERROR` pins fleet health on a fault that can never clear on its own.

Username-suffix country targeting (`-country-jp`) is not supported on this endpoint (407), so it does not route around the block either.

## Fix

On a CONNECT refusal the adapter opens **one CONNECT-only control tunnel** to a host it already contracts with (`www.mnd.gov.tw`) and tears it down without sending a byte.

- control tunnel opens -> the proxy tunnels, but refuses *this* destination -> `blockedReason: PROXY_TARGET_FORBIDDEN` -> `sourceState: blocked` -> `SOURCE_BLOCKED` (green)
- control tunnel also fails -> the proxy is degraded -> stays `SEED_ERROR`, operator-visible

That discriminator is the point: without it a proxy-wide outage would masquerade as an upstream block and turn health green — the failure mode #5689 already taught us to fear. `PROXY_AUTH_FAILED`, a non-403 direct leg, and an uncorroborated refusal all still fail closed.

The blocked-reason list is now one exported constant read by the seed writer, the client type, the runtime source-health guard, and the panel, with a registration test comparing producer and client **values** (not source text). A missing mirror entry is not a type error — it silently fails the runtime guard and renders nothing.

## Self-review caught two defects in the first commit (second commit)

- The bootstrap projection strips proxy diagnostics with a **denylist**, so `proxyControlProbe` leaked into the anonymous bootstrap. It describes our own egress and no client surface reads it — now stripped and pinned.
- The probe ran inside the proxy `catch` while the caller awaits the Japan outcome unguarded, so a throwing probe would reject the whole snapshot and take the healthy Taiwan MND feed with it. A diagnostic must never fail the run that uses it. Also, a probe returning a non-thenable would `await` instantly and read as `reachable` — a false green on exactly the axis the probe guards. Both now degrade to `unreachable`.

## Validation

- **Live**: the real adapter against the real proxy and real Japan MOD returns `blockedReason: PROXY_TARGET_FORBIDDEN`, `proxyControlProbe: reachable`.
- 147 tests across 8 affected suites pass.
- **Mutation-tested** every new guard — dropping the control-probe requirement, reverting the writer predicate, dropping the client mirror entry, breaking the validator, and restoring the projection leak each turn the suites red.
- `npm run typecheck`, biome, markdownlint, `docs:check`, `git diff --check`, full pre-push gate.

## Acceptance criteria (#5714)

- [x] Reclassified `blocked` with a documented reason code (`PROXY_TARGET_FORBIDDEN`), verified live
- [x] The proxy leg records enough detail to classify without a live re-probe (`proxyFailureDetail` from #5718 + `proxyControlProbe` here)
- [x] A test covers `direct HTTP_403 -> proxy SOURCE_ERROR` and cannot conflate it with `PROXY_AUTH_FAILED`

## Post-deploy

After the next 3h run, `crossStraitActivityJapanMod` should report `SOURCE_BLOCKED` with `recordCount: 2`. Treat as rollout failure: a `blocked` state while `proxyControlProbe` is absent or `unreachable`, loss of the reviewed records, or parent-feed degradation.

Follow-up filed separately: the provider cannot reach **any** `.go.jp` host, so every future Japanese-government source hits this same wall.

Refs #5714.

https://claude.ai/code/session_018KEiganN9AA8QNH6jbYmDT
