### PR TITLE
fix(api-keys): tolerate transient auth races

### DIFF
--- a/convex/__tests__/apiKeys.test.ts
+++ b/convex/__tests__/apiKeys.test.ts
@@ -337,6 +337,19 @@ describe("listApiKeys", () => {
     const otherKeys = await t.withIdentity(OTHER_USER).query(api.apiKeys.listApiKeys, {});
     expect(otherKeys).toEqual([]);
   });
+
+  test("returns empty during an unauthenticated query race", async () => {
+    // WORLDMONITOR-XM: the settings query can fire while Convex auth briefly
+    // disappears during initial auth, sign-out, or token rotation. Seed a real
+    // user's key to prove the unauthenticated result is empty rather than a
+    // throw or an accidental cross-user read.
+    const t = convexTest(schema, modules);
+    await seedApiEntitlement(t, "user-api");
+    await t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+
+    const keys = await t.query(api.apiKeys.listApiKeys, {});
+    expect(keys).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -1,6 +1,6 @@
 import { ConvexError, v } from "convex/values";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
-import { requireUserId } from "./lib/auth";
+import { requireUserId, resolveUserId } from "./lib/auth";
 
 /** Maximum number of active (non-revoked) API keys per user. */
 const MAX_KEYS_PER_USER = 5;
@@ -103,7 +103,15 @@ export const createApiKey = mutation({
 export const listApiKeys = query({
   args: {},
   handler: async (ctx) => {
-    const userId = await requireUserId(ctx);
+    // This query is called from the settings UI after a best-effort auth
+    // readiness wait, but the Convex WebSocket can still observe a brief
+    // unauthenticated window during sign-out, initial auth, or token rotation.
+    // Throwing AUTH_REQUIRED from that race pages through Convex auto-Sentry
+    // (WORLDMONITOR-XM). The UI already gates this query behind a signed-in
+    // shell, so [] is the honest transient result and cannot expose another
+    // user's keys.
+    const userId = await resolveUserId(ctx);
+    if (!userId) return [];
     const keys = await ctx.db
       .query("userApiKeys")
       .withIndex("by_userId", (q) => q.eq("userId", userId))


### PR DESCRIPTION
## Summary

API-key settings could briefly show `AUTH_REQUIRED` and page Sentry when Convex auth disappeared during initial load, sign-out, or token rotation. The list query now treats that transient state as an empty result—the same safe behavior already used by the sibling MCP-token settings query—while authenticated reads remain scoped to the current user. A regression test seeds another user's key and proves the unauthenticated path neither throws nor exposes records.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Config / Settings
- [x] Other: Convex API-key query

## Related

Related: [WORLDMONITOR-XM](https://elie-habib.sentry.io/issues/7633554146/)

## Validation

- `vitest run convex/__tests__/apiKeys.test.ts` — 26 passed
- Mutation check: restoring the old `requireUserId` path makes the new regression fail with `AUTH_REQUIRED`
- `npm run typecheck`
- `npm run typecheck:api`
- Repository pre-push Convex and safety gates passed

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
