### PR TITLE
fix(seed): reject ACLED events without stable IDs

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -233,6 +233,12 @@ function buildAcledParams({ startDate, endDate, limit, page }) {
   return params;
 }
 
+function stableAcledEventId(event) {
+  if (typeof event?.event_id_cnty !== 'string') return null;
+  const id = event.event_id_cnty.trim();
+  return id || null;
+}
+
 async function fetchAcledPage(token, params) {
   const resp = await fetch(`${ACLED_API_URL}?${params}`, {
     headers: { Accept: 'application/json', Authorization: `Bearer ${token}`, 'User-Agent': CHROME_UA },
@@ -244,15 +250,24 @@ async function fetchAcledPage(token, params) {
   return Array.isArray(data.data) ? data.data : [];
 }
 
-function normalizeAcledConflictEvents(rawEvents) {
-  return rawEvents
-    .filter(e => {
-      const lat = parseFloat(e.latitude || '');
-      const lon = parseFloat(e.longitude || '');
-      return Number.isFinite(lat) && Number.isFinite(lon) && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
-    })
-    .map(e => ({
-      id: `acled-${e.event_id_cnty}`,
+export function normalizeAcledConflictEvents(rawEvents) {
+  return rawEvents.flatMap((e) => {
+    const eventId = stableAcledEventId(e);
+    const lat = parseFloat(e?.latitude || '');
+    const lon = parseFloat(e?.longitude || '');
+    if (
+      !eventId
+      || !Number.isFinite(lat)
+      || !Number.isFinite(lon)
+      || lat < -90
+      || lat > 90
+      || lon < -180
+      || lon > 180
+    ) {
+      return [];
+    }
+    return [{
+      id: `acled-${eventId}`,
       eventType: e.event_type || '',
       country: e.country || '',
       // event_date ('YYYY-MM-DD') is the field the EMA engine reads
@@ -265,7 +280,17 @@ function normalizeAcledConflictEvents(rawEvents) {
       actors: [e.actor1, e.actor2].filter(Boolean),
       source: e.source || '',
       admin1: e.admin1 || '',
-    }));
+    }];
+  });
+}
+
+export function shouldStopAcledPagination({
+  pageSize,
+  limit,
+  stableEventIdCount,
+  addedEventCount,
+}) {
+  return pageSize < limit || (stableEventIdCount === pageSize && addedEventCount === 0);
 }
 
 async function fetchAcledEvents({
@@ -287,6 +312,7 @@ async function fetchAcledEvents({
   const seen = new Set();
   let pagesFetched = 0;
   let lastPageCount = 0;
+  let missingEventIdCount = 0;
   const pageLimit = paginated ? Math.max(1, maxPages) : 1;
 
   for (let page = 1; page <= pageLimit; page += 1) {
@@ -300,17 +326,39 @@ async function fetchAcledEvents({
     pagesFetched = page;
     lastPageCount = pageEvents.length;
     const before = rawEvents.length;
+    let stableEventIdCount = 0;
     for (const event of pageEvents) {
-      const id = event.event_id_cnty || `${event.event_date}:${event.country}:${event.latitude}:${event.longitude}:${event.notes || event.source || ''}`;
+      // ACLED documents event_id_cnty as the stable identifier that survives
+      // detail updates. A composite fallback changes when notes/source details
+      // are revised and therefore cannot safely key history or retractions.
+      const id = stableAcledEventId(event);
+      if (!id) {
+        missingEventIdCount += 1;
+        continue;
+      }
+      stableEventIdCount += 1;
       if (seen.has(id)) continue;
       seen.add(id);
       rawEvents.push(event);
     }
-    if (!paginated || pageEvents.length < limit || rawEvents.length === before) break;
+    if (
+      !paginated
+      || shouldStopAcledPagination({
+        pageSize: pageEvents.length,
+        limit,
+        stableEventIdCount,
+        addedEventCount: rawEvents.length - before,
+      })
+    ) {
+      break;
+    }
     await sleep(ACLED_PAGE_DELAY_MS);
   }
 
   const events = normalizeAcledConflictEvents(rawEvents);
+  if (missingEventIdCount > 0) {
+    console.warn(`  ${label}: dropped ${missingEventIdCount} event(s) missing stable event_id_cnty`);
+  }
   const pagination = paginated
     ? { lookbackDays, limit, pagesFetched, maxPages, truncated: pagesFetched >= maxPages && lastPageCount >= limit }
     : undefined;

--- a/tests/acled-conflict-identity.test.mjs
+++ b/tests/acled-conflict-identity.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  normalizeAcledConflictEvents,
+  shouldStopAcledPagination,
+} from '../scripts/seed-conflict-intel.mjs';
+
+const BASE_EVENT = {
+  event_id_cnty: 'SUD12345',
+  event_type: 'Battles',
+  event_date: '2026-07-20',
+  country: 'Sudan',
+  latitude: '15.5',
+  longitude: '32.5',
+  fatalities: '1',
+  actor1: 'RSF',
+  actor2: 'SAF',
+  source: 'ACLED',
+  admin1: 'Khartoum',
+};
+
+describe('ACLED conflict event identity', () => {
+  it('publishes only events carrying ACLED stable identifiers', () => {
+    const events = normalizeAcledConflictEvents([
+      BASE_EVENT,
+      { ...BASE_EVENT, event_id_cnty: undefined, notes: 'missing id' },
+      { ...BASE_EVENT, event_id_cnty: '', notes: 'empty id' },
+      { ...BASE_EVENT, event_id_cnty: '   ', notes: 'blank id' },
+    ]);
+
+    assert.deepEqual(events.map((event) => event.id), ['acled-SUD12345']);
+    assert.ok(events.every((event) => event.id !== 'acled-undefined'));
+  });
+
+  it('continues past a full malformed page so later valid events remain reachable', () => {
+    assert.equal(shouldStopAcledPagination({
+      pageSize: 5000,
+      limit: 5000,
+      stableEventIdCount: 0,
+      addedEventCount: 0,
+    }), false);
+    assert.equal(shouldStopAcledPagination({
+      pageSize: 5000,
+      limit: 5000,
+      stableEventIdCount: 1,
+      addedEventCount: 0,
+    }), false);
+    assert.equal(shouldStopAcledPagination({
+      pageSize: 5000,
+      limit: 5000,
+      stableEventIdCount: 5000,
+      addedEventCount: 0,
+    }), true);
+    assert.equal(shouldStopAcledPagination({
+      pageSize: 4999,
+      limit: 5000,
+      stableEventIdCount: 4999,
+      addedEventCount: 4999,
+    }), true);
+  });
+});


### PR DESCRIPTION
## Summary

ACLED conflict seeding now rejects upstream rows that do not carry ACLED's stable `event_id_cnty`, so malformed rows can no longer publish or enter intelligence history under the shared `acled-undefined` identity. Valid records keep the existing `acled-<event_id_cnty>` shape, and dropped-row counts are logged for source-health observation.

Fail-closed filtering also preserves bounded pagination: full malformed or mixed pages continue to later results, while genuinely duplicate-only and short pages retain their existing stop behavior.

Fixes #5782.

## Validation

- Focused ACLED, resolution-feed, history-wiring, no-source, and HAPI circuit-breaker tests: 59 passed, 0 failed.
- `npm run typecheck` and `npm run typecheck:api`: passed.
- `npm run lint`: passed with only existing unrelated warnings; scoped Biome lint and `git diff --check` were clean.
- The full data suite ran 18,501 tests; its only two failures were missing-prebuilt-`dist/dashboard.html` assertions. After `VITE_VARIANT=full npx vite build`, the affected dashboard critical-CSS suite passed 9/9.

## Post-Deploy

- Owner: data-ingestion on-call.
- Window: observe two consecutive 15-minute conflict-intel schedules (within 30 minutes of deployment).
- Expected signals: both runs exit successfully; `/api/health?compact=1` reports fresh `acledIntel` metadata with `recordCount > 0` when ACLED or its configured fallback is available; published event IDs contain no `acled-undefined`.
- Source-health signal: `dropped N event(s) missing stable event_id_cnty` may appear, but every reported row must be absent from both the display payload and new history writes. Investigate if `N > 0` persists for both observed runs or rises sharply.
- Failure trigger: repeated seed failures, non-fresh `acledIntel` after both runs, or an unexpected valid-record collapse. Prefer pausing the Railway seeder and preserving last-good data while inspecting the upstream schema; rolling back would restore the known malformed-identity behavior.

## Known Residuals

- Existing `acled-undefined` records already present in intelligence history are not deleted here. This change prevents new writes; cleanup should use the separate retraction-capable operational path or normal retention.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
