### PR TITLE
fix(ops): retire recovered China coverage exception

### DIFF
--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -14,13 +14,9 @@
     "Every entry carries a real tracking issue, never the PR that introduced the entry:",
     "a merged PR closes, and a suppression pointing at a closed PR has no owner.",
     "",
-    "chinaCoverage and shippingRates are both in api/health.js ON_DEMAND_KEYS, but the",
-    "onDemand marker does NOT make either entry redundant, for two different reasons.",
-    "chinaCoverage is also in ACTIVATION_MARKERS and seed-china-coverage-health.mjs writes",
-    "that marker unconditionally in afterPublish with no TTL -- the seeder is publishing, so",
-    "isOnDemand is permanently FALSE for it and the marker is never emitted. shippingRates",
-    "does carry the marker permanently (it has no activation entry), but the monitor only",
-    "excuses on-demand sources in the empty/absent states, so its STALE_SEED still blocks.",
+    "shippingRates is in api/health.js ON_DEMAND_KEYS and has no ACTIVATION_MARKERS",
+    "entry, so it carries the marker permanently. The monitor only excuses on-demand",
+    "sources in the empty/absent states, so its STALE_SEED still blocks.",
     "Softening fault statuses is the marketImplications blind spot the ON_DEMAND_KEYS policy",
     "block in api/health.js exists to prevent."
   ],
@@ -43,12 +39,6 @@
       "status": "SEED_ERROR",
       "issue": 5769,
       "reason": "HAPI returns 'Blocked due to bot activity' to Railway egress (same signature as #5713, which was closed). Recovers intermittently between health snapshots, so one green poll is not evidence of recovery."
-    },
-    {
-      "name": "chinaCoverage",
-      "status": "CHINA_DEGRADED",
-      "issue": 5771,
-      "reason": "Stale CCFI transport (TRANSPORT_STALE) plus partial official-exchange disclosures (CHINA_COVERAGE_PARTIAL). Activation-gated on-demand key: the activation marker is already written, so isOnDemand is permanently false and this entry is load-bearing, not transitional."
     },
     {
       "name": "shippingRates",

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -215,6 +215,10 @@ describe('scheduled seed freshness monitor', () => {
       // closed PR with nobody owning them. Distinct issue numbers is the
       // cheapest offline proxy for "somebody actually filed these".
       const issues = committed.acknowledged.map((entry) => entry.issue);
+      assert.ok(
+        !issues.includes(5771),
+        'recovered chinaCoverage degradation must not remain acknowledged',
+      );
       assert.equal(
         new Set(issues).size,
         issues.length,


### PR DESCRIPTION
## Summary

`chinaCoverage` has recovered in production, so the ingestion acceptance gate no longer suppresses its former `CHINA_DEGRADED` state. A regression assertion prevents the closed recovery record for issue #5771 from remaining in the committed baseline.

Production evidence before pruning:

- `seed-supply-chain-trade` reached `SUCCESS` with `CCFI: 1`.
- `seed-bundle-market-backup` recorded SSE as accepted and consecutive SZSE runs as accepted through the dedicated proxy.
- A no-cache compact health request omitted `chinaCoverage` from `problems`.
- The production-facing freshness gate passed with no unacknowledged health problems.

Fixes #5771.

## Validation

- `node --test tests/seed-freshness-monitor.test.mjs` — 17/17 passed.
- `node scripts/check-seed-freshness.mjs` — passed against production health.
- Focused Biome lint and the safe-HTML guard passed.
- Full `ce-code-review` returned Ready to merge with no actionable findings.
- The pre-push gate passed frontend/API typechecks, Unicode safety, changed tests, and version sync.

## Post-Deploy Monitoring & Validation

- **Window:** From merge through the next two scheduled freshness-monitor runs; owner: repository maintainer.
- **Watch:** GitHub `Seed Freshness Monitor` results and `https://api.worldmonitor.app/api/health?compact=1`.
- **Expected:** `chinaCoverage` remains absent from `problems`; the monitor reports no unacknowledged `chinaCoverage` failure.
- **Failure signal:** `chinaCoverage` returns as `CHINA_DEGRADED`, `TRANSPORT_STALE`, or `CHINA_COVERAGE_PARTIAL`, or the freshness workflow turns red.
- **Mitigation:** Inspect `seed-supply-chain-trade` for CCFI execution and `seed-bundle-market-backup` for SSE/SZSE source decisions. Revert this baseline prune only if the recovery evidence was invalid; any newly accepted degradation requires a new owner issue rather than reusing #5771.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
