### PR TITLE
fix(china): add bounded SZSE edge fallback

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -602,6 +602,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/internal/china-exchange-egress.js",
+      "category": "internal-helper",
+      "reason": "Fixed-target SZSE metadata egress for the Railway corporate-disclosure seed (#5771). RELAY_SHARED_SECRET-authenticated, POST-only, and constrained to the reviewed issuer, channel, page, and 92-day window; it is deployment plumbing for one source adapter rather than a user-facing data API.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/internal/mcp-grant-mint.ts",
       "category": "internal-helper",
       "reason": "Apex-domain bridge endpoint for the cross-subdomain Pro MCP authorization flow (plan 2026-05-10-001 U3). POST {nonce} from the Clerk-protected /mcp-grant SPA on worldmonitor.app; returns a fixed-host redirect URL with a HMAC-signed grant token to api.worldmonitor.app/oauth/authorize-pro. Shape is an implementation detail of the bounce-via-apex consent flow — exposing it as a versioned product API would publish internal OAuth plumbing.",

--- a/api/internal/china-exchange-egress.js
+++ b/api/internal/china-exchange-egress.js
@@ -1,0 +1,182 @@
+import { timingSafeEqualSecret } from '../_crypto.js';
+import { jsonResponse } from '../_json-response.js';
+
+export const config = { runtime: 'edge' };
+
+const SZSE_METADATA_URL = 'https://www.szse.cn/api/disc/announcement/annList?random=0.5';
+const SZSE_REQUEST_TIMEOUT_MS = 12_000;
+const MAX_REQUEST_BYTES = 2_048;
+const MAX_WINDOW_DAYS = 92;
+const DAY_MS = 86_400_000;
+const EXPECTED_BODY_KEYS = Object.freeze([
+  'channelCode',
+  'pageNum',
+  'pageSize',
+  'seDate',
+  'stock',
+]);
+
+export const SZSE_EGRESS_MAX_RESPONSE_BYTES = 131_072;
+
+function isPlainObject(value) {
+  return value != null
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function parseIsoDay(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(String(value ?? ''))) return null;
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isFinite(timestamp)
+    && new Date(timestamp).toISOString().slice(0, 10) === value
+    ? timestamp
+    : null;
+}
+
+function isValidSzseEgressRequest(body) {
+  if (!isPlainObject(body)) return false;
+  if (JSON.stringify(Object.keys(body).sort()) !== JSON.stringify(EXPECTED_BODY_KEYS)) return false;
+  if (
+    !Array.isArray(body.seDate)
+    || body.seDate.length !== 2
+    || !Array.isArray(body.channelCode)
+    || body.channelCode.length !== 1
+    || body.channelCode[0] !== 'listedNotice_disc'
+    || !Array.isArray(body.stock)
+    || body.stock.length !== 1
+    || body.stock[0] !== '300750'
+    || body.pageSize !== 50
+    || body.pageNum !== 1
+  ) {
+    return false;
+  }
+
+  const begin = parseIsoDay(body.seDate[0]);
+  const end = parseIsoDay(body.seDate[1]);
+  return begin != null
+    && end != null
+    && begin <= end
+    && end - begin <= MAX_WINDOW_DAYS * DAY_MS;
+}
+
+async function readBoundedBody(message, maxBytes) {
+  const contentLength = Number(message.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) return null;
+
+  if (!message.body?.getReader) {
+    const bytes = new Uint8Array(await message.arrayBuffer());
+    return bytes.byteLength <= maxBytes ? bytes : null;
+  }
+
+  const reader = message.body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function internalHeaders(contentType = 'application/json') {
+  return {
+    'Cache-Control': 'no-store',
+    'Content-Type': contentType,
+    'X-Content-Type-Options': 'nosniff',
+  };
+}
+
+function upstreamFailureResponse(error) {
+  const timeout = error?.name === 'TimeoutError' || error?.name === 'AbortError';
+  return jsonResponse(
+    { error: timeout ? 'upstream_timeout' : 'upstream_fetch_failed' },
+    timeout ? 504 : 502,
+    internalHeaders(),
+  );
+}
+
+export default async function handler(req) {
+  if (req.method !== 'POST') {
+    return jsonResponse(
+      { error: 'method_not_allowed' },
+      405,
+      { ...internalHeaders(), Allow: 'POST' },
+    );
+  }
+
+  const expected = process.env.RELAY_SHARED_SECRET ?? '';
+  const authorization = req.headers.get('authorization') ?? '';
+  if (!expected || !(await timingSafeEqualSecret(authorization, `Bearer ${expected}`))) {
+    return jsonResponse({ error: 'unauthorized' }, 401, internalHeaders());
+  }
+
+  const declaredLength = Number(req.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_REQUEST_BYTES) {
+    return jsonResponse({ error: 'invalid_request' }, 400, internalHeaders());
+  }
+
+  let body;
+  try {
+    const bytes = await readBoundedBody(req, MAX_REQUEST_BYTES);
+    if (!bytes) {
+      return jsonResponse({ error: 'invalid_request' }, 400, internalHeaders());
+    }
+    body = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return jsonResponse({ error: 'invalid_request' }, 400, internalHeaders());
+  }
+  if (!isValidSzseEgressRequest(body)) {
+    return jsonResponse({ error: 'invalid_request' }, 400, internalHeaders());
+  }
+
+  let upstream;
+  try {
+    upstream = await fetch(SZSE_METADATA_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Referer: 'https://www.szse.cn/',
+        'Content-Type': 'application/json',
+        'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
+      },
+      body: JSON.stringify(body),
+      redirect: 'error',
+      signal: AbortSignal.timeout(SZSE_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    return upstreamFailureResponse(error);
+  }
+
+  let bytes;
+  try {
+    bytes = await readBoundedBody(upstream, SZSE_EGRESS_MAX_RESPONSE_BYTES);
+  } catch (error) {
+    return upstreamFailureResponse(error);
+  }
+  if (!bytes) {
+    return jsonResponse(
+      { error: 'upstream_response_too_large' },
+      502,
+      internalHeaders(),
+    );
+  }
+
+  return new Response(bytes, {
+    status: upstream.status,
+    headers: internalHeaders(upstream.headers.get('content-type') || 'application/json'),
+  });
+}

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -467,8 +467,8 @@ continuous metric.
 | **Watch paths** | See `scripts/railway-services.json` (exact runtime closure; run `node scripts/audit-railway-watch-paths.mjs`) |
 | **Replaces** | 5 services |
 | **Net savings** | 4 slots |
-| **Members** | Crypto Quotes (5min), Stablecoin Markets (10min), ETF Flows (15min), Gulf Quotes (10min), Token Panels (30min), SEC CIK Map (daily), SEC 8-K Stream (30min) |
-| **Required env** | `SZSE_PROXY_URL` (China corporate disclosures) and `PROXY_URL` (Gulf Quotes / ETF Flows reach it bare through `_yahoo-fetch.mjs`) |
+| **Members** | Crypto Quotes (5min), Hyperliquid Flow (5min), Stablecoin Markets (10min), ETF Flows (15min), China Corporate Disclosures (30min), Gulf Quotes (10min), Token Panels (30min), Gold ETF Flows (2h), Gold CB Reserves (daily), SEC CIK Map (daily), SEC 8-K Stream (30min) |
+| **Required env** | `PROXY_URL` (Gulf Quotes / ETF Flows require it and SZSE uses it when `SZSE_PROXY_URL` is unset) and `RELAY_SHARED_SECRET` (authenticates China Corporate Disclosures' fixed `https://api.worldmonitor.app/api/internal/china-exchange-egress` fallback after direct/proxy failures). This is the deployment contract; production provisioning and live fallback acceptance require separate verification. |
 | **Note** | These are BACKUP for ais-relay inline loops. ais-relay is the primary seeder. The bundle provides redundancy if relay goes down. Gulf Quotes uses Alpha Vantage (richer than relay's Yahoo-only). SEC CIK Map + SEC 8-K Stream (#5695) are primary (not backups): the ticker→CIK registry and the material-events stream for the corporate-intelligence endpoints. |
 
 ### Bundle 11: seed-bundle-relay-backup

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -74,14 +74,14 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     metadataEndpoint: 'https://www.szse.cn/api/disc/announcement/annList',
     metadataHost: 'www.szse.cn',
     documentHosts: CHINA_DISCLOSURE_DOCUMENT_HOSTS.SZSE,
-    maxRequestsPerRun: 3,
+    maxRequestsPerRun: 4,
     maxDirectRequestsPerRun: 1,
     maxProxyRequestsPerRun: 2,
-    fallbackPolicy: 'direct_then_proxy_on_transport_failure',
-    // Railway registers SZSE_PROXY_URL as required config for this service: without
-    // it the source still runs direct-only (no hard failure), but it loses
-    // the one capability this contract exists to provide, so an unset
-    // SZSE_PROXY_URL in production is a deployment gap worth alerting on.
+    maxEdgeRequestsPerRun: 1,
+    fallbackPolicy: 'direct_then_proxy_then_edge_on_transport_failure',
+    // SZSE_PROXY_URL is an optional source-specific override; Railway requires
+    // the shared PROXY_URL fallback and the fixed edge hop's
+    // RELAY_SHARED_SECRET at the bundle boundary.
     proxyEnvironmentVariable: 'SZSE_PROXY_URL',
     maxResponseBytes: 131_072,
     redirectPolicy: 'error',
@@ -160,12 +160,19 @@ const MAX_UNCLASSIFIED_REVISIONS = 100;
 const SSE_PAGE_SIZE = 100;
 const SSE_REQUEST_TIMEOUT_MS = 30_000;
 const SZSE_PAGE_SIZE = 50;
-// Worst case (direct attempt times out, then both proxy attempts time out) this
-// source can take about 39s before the bundle moves on. Keep this comfortably
+// Worst case (direct, two proxy attempts, then edge fallback all time out) this
+// source can take about 55s before the bundle moves on. Keep this comfortably
 // inside the per-section timeoutMs configured in seed-bundle-market-backup.mjs.
 const SZSE_DIRECT_TIMEOUT_MS = 15_000;
 const SZSE_PROXY_TIMEOUT_MS = 12_000;
 const SZSE_PROXY_RETRY_DELAY_MS = 250;
+const SZSE_EDGE_TIMEOUT_MS = 16_000;
+const CHINA_EXCHANGE_EDGE_EGRESS_URL = 'https://api.worldmonitor.app/api/internal/china-exchange-egress';
+const CHINA_EXCHANGE_EDGE_ERROR_CODES = new Set([
+  'upstream_timeout',
+  'upstream_fetch_failed',
+  'upstream_response_too_large',
+]);
 export const CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS = (
   Math.ceil(
     OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse.maxRequestsPerRun
@@ -175,6 +182,7 @@ export const CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS = (
   + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun * SZSE_PROXY_TIMEOUT_MS
   + (OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun - 1)
     * SZSE_PROXY_RETRY_DELAY_MS
+  + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxEdgeRequestsPerRun * SZSE_EDGE_TIMEOUT_MS
 );
 const LAUNCHED_SOURCE_FETCHERS = Object.freeze([
   Object.freeze(['sse', fetchSseAnnouncements]),
@@ -386,19 +394,16 @@ export function normalizeSzseAnnouncements(payload, { retrievedAt = new Date().t
   return normalized;
 }
 
-export async function readBoundedJsonResponse(response, maxBytes) {
+async function readBoundedResponseBytes(response, maxBytes) {
   const contentLength = Number(response?.headers?.get?.('content-length'));
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
     throw sourceError('RESPONSE_TOO_LARGE');
   }
   if (!response?.body?.getReader) {
     const text = await response.text();
-    if (new TextEncoder().encode(text).byteLength > maxBytes) throw sourceError('RESPONSE_TOO_LARGE');
-    try {
-      return JSON.parse(text);
-    } catch (error) {
-      throw sourceError('MALFORMED_RESPONSE', error);
-    }
+    const bytes = new TextEncoder().encode(text);
+    if (bytes.byteLength > maxBytes) throw sourceError('RESPONSE_TOO_LARGE');
+    return bytes;
   }
 
   const reader = response.body.getReader();
@@ -420,6 +425,11 @@ export async function readBoundedJsonResponse(response, maxBytes) {
     bytes.set(chunk, offset);
     offset += chunk.byteLength;
   }
+  return bytes;
+}
+
+export async function readBoundedJsonResponse(response, maxBytes) {
+  const bytes = await readBoundedResponseBytes(response, maxBytes);
   try {
     return JSON.parse(new TextDecoder().decode(bytes));
   } catch (error) {
@@ -536,6 +546,61 @@ async function fetchViaConfiguredProxy(input, init, {
   });
 }
 
+export function resolveChinaExchangeEdgeEgress(env = process.env) {
+  const isRailwayProduction = env.RAILWAY_ENVIRONMENT === 'production'
+    || env.RAILWAY_ENVIRONMENT_NAME === 'production';
+  const secret = String(env.RELAY_SHARED_SECRET || '');
+  if (!isRailwayProduction || !secret) return null;
+  return { url: CHINA_EXCHANGE_EDGE_EGRESS_URL, secret };
+}
+
+async function readEdgeEgressFailureCode(response, maxBytes) {
+  const fallback = `HTTP_${Number(response?.status) || 0}`;
+  try {
+    const bytes = await readBoundedResponseBytes(response, maxBytes);
+    const contentType = String(response?.headers?.get?.('content-type') || '')
+      .split(';', 1)[0]
+      .trim()
+      .toLowerCase();
+    if (contentType !== 'application/json') return fallback;
+    const payload = JSON.parse(new TextDecoder().decode(bytes));
+    return CHINA_EXCHANGE_EDGE_ERROR_CODES.has(payload?.error)
+      ? payload.error
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function fetchViaEdgeEgress(_input, init, {
+  edgeEgress,
+  maxBytes,
+  edgeRequestFn,
+}) {
+  const response = await edgeRequestFn(edgeEgress.url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${edgeEgress.secret}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
+    },
+    body: init?.body,
+    redirect: 'error',
+    signal: init?.signal,
+  });
+  if (!response.ok) {
+    throw sourceError(await readEdgeEgressFailureCode(response, maxBytes));
+  }
+  const bytes = await readBoundedResponseBytes(response, maxBytes);
+  return new Response(bytes, {
+    status: response.status,
+    headers: {
+      'Content-Length': String(bytes.byteLength),
+      'Content-Type': response.headers.get('content-type') || 'application/json',
+    },
+  });
+}
+
 async function fetchSseAnnouncements(fetchFn, now) {
   const contract = OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.sse;
   const issuers = REVIEWED_DISCLOSURE_ISSUERS.filter((issuer) => issuer.exchange === 'SSE');
@@ -611,6 +676,7 @@ async function fetchSseAnnouncements(fetchFn, now) {
 
 async function fetchSzseAnnouncements(fetchFn, now, {
   proxyFetchFn = null,
+  edgeFetchFn = null,
 } = {}) {
   const contract = OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse;
   const { begin, end } = dateWindow(now);
@@ -651,39 +717,61 @@ async function fetchSzseAnnouncements(fetchFn, now, {
   let requestCount = 1;
   let transportPath = 'direct';
   let fallbackReason = null;
+  let proxyFailureReason = null;
   try {
     fetched = await request(fetchFn, SZSE_DIRECT_TIMEOUT_MS);
   } catch (directError) {
     fallbackReason = transportFailureReason(directError);
-    if (!proxyFetchFn || !shouldProxySzseFailure(directError)) throw directError;
-    transportPath = 'proxy';
+    if (!shouldProxySzseFailure(directError)) throw directError;
     let proxyError = null;
-    for (let attempt = 0; attempt < contract.maxProxyRequestsPerRun; attempt += 1) {
+    if (proxyFetchFn) {
+      transportPath = 'proxy';
+      for (let attempt = 0; attempt < contract.maxProxyRequestsPerRun; attempt += 1) {
+        requestCount += 1;
+        try {
+          fetched = await request(proxyFetchFn, SZSE_PROXY_TIMEOUT_MS);
+          proxyError = null;
+          break;
+        } catch (error) {
+          proxyError = error;
+          if (
+            attempt + 1 < contract.maxProxyRequestsPerRun
+            && shouldRetrySzseProxyFailure(error)
+          ) {
+            await new Promise((resolve) => setTimeout(resolve, SZSE_PROXY_RETRY_DELAY_MS));
+            continue;
+          }
+          break;
+        }
+      }
+      proxyFailureReason = proxyError ? transportFailureReason(proxyError) : null;
+    }
+
+    if (!fetched && edgeFetchFn) {
+      transportPath = 'edge';
       requestCount += 1;
       try {
-        fetched = await request(proxyFetchFn, SZSE_PROXY_TIMEOUT_MS);
-        proxyError = null;
-        break;
-      } catch (error) {
-        proxyError = error;
-        if (
-          attempt + 1 < contract.maxProxyRequestsPerRun
-          && shouldRetrySzseProxyFailure(error)
-        ) {
-          await new Promise((resolve) => setTimeout(resolve, SZSE_PROXY_RETRY_DELAY_MS));
-          continue;
-        }
-        break;
+        fetched = await request(edgeFetchFn, SZSE_EDGE_TIMEOUT_MS);
+      } catch (edgeError) {
+        const failure = sourceError(errorCodeFor(edgeError), edgeError);
+        failure.requestCount = requestCount;
+        failure.transportPath = transportPath;
+        failure.fallbackReason = fallbackReason;
+        if (proxyFailureReason) failure.proxyFailureReason = proxyFailureReason;
+        failure.edgeFailureReason = transportFailureReason(edgeError);
+        throw failure;
       }
     }
-    if (proxyError) {
+
+    if (!fetched && proxyError) {
       const failure = sourceError(errorCodeFor(proxyError), proxyError);
       failure.requestCount = requestCount;
       failure.transportPath = transportPath;
       failure.fallbackReason = fallbackReason;
-      failure.proxyFailureReason = transportFailureReason(proxyError);
+      failure.proxyFailureReason = proxyFailureReason;
       throw failure;
     }
+    if (!fetched) throw directError;
   }
 
   const contentTruncated = Number(fetched.payload.announceCount) > SZSE_PAGE_SIZE;
@@ -697,6 +785,7 @@ async function fetchSzseAnnouncements(fetchFn, now, {
     errorCode: contentTruncated ? 'PAGE_LIMIT_REACHED' : null,
     transportPath,
     ...(fallbackReason ? { fallbackReason } : {}),
+    ...(proxyFailureReason ? { proxyFailureReason } : {}),
   };
 }
 
@@ -805,6 +894,9 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         requestCount: outcome.requestCount,
         transportPath: outcome.transportPath ?? 'direct',
         ...(outcome.fallbackReason ? { fallbackReason: outcome.fallbackReason } : {}),
+        ...(outcome.proxyFailureReason
+          ? { proxyFailureReason: outcome.proxyFailureReason }
+          : {}),
         emptyResultCount,
         errorCode: coverageGap ? 'COVERAGE_GAP' : null,
       };
@@ -822,6 +914,9 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         requestCount: outcome.requestCount,
         transportPath: outcome.transportPath ?? 'direct',
         ...(outcome.fallbackReason ? { fallbackReason: outcome.fallbackReason } : {}),
+        ...(outcome.proxyFailureReason
+          ? { proxyFailureReason: outcome.proxyFailureReason }
+          : {}),
         emptyResultCount,
         errorCode: outcome.errorCode ?? (coverageGap ? 'COVERAGE_GAP' : 'PARTIAL_FETCH'),
       };
@@ -839,6 +934,9 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
       ...(outcome?.fallbackReason ? { fallbackReason: outcome.fallbackReason } : {}),
       ...(outcome?.proxyFailureReason
         ? { proxyFailureReason: outcome.proxyFailureReason }
+        : {}),
+      ...(outcome?.edgeFailureReason
+        ? { edgeFailureReason: outcome.edgeFailureReason }
         : {}),
       emptyResultCount,
       errorCode: outcome?.errorCode ?? 'NOT_ATTEMPTED',
@@ -1198,6 +1296,9 @@ export function buildChinaCorporateDisclosureSnapshot({
       ...(contract.maxProxyRequestsPerRun
         ? { maxProxyRequestsPerRun: contract.maxProxyRequestsPerRun }
         : {}),
+      ...(contract.maxEdgeRequestsPerRun
+        ? { maxEdgeRequestsPerRun: contract.maxEdgeRequestsPerRun }
+        : {}),
       maxResponseBytes: contract.maxResponseBytes,
       redirectPolicy: contract.redirectPolicy,
       documentRetrieval: contract.documentRetrieval,
@@ -1219,6 +1320,8 @@ export async function fetchChinaCorporateDisclosureSnapshot({
   fetchFn = globalThis.fetch,
   proxyUrl = process.env.SZSE_PROXY_URL || process.env.PROXY_URL || '',
   proxyRequestFn = proxyFetch,
+  edgeEgress = undefined,
+  edgeRequestFn = globalThis.fetch,
   now = Date.now(),
   previousSnapshot = null,
   onDecision = (entry) => console.log(JSON.stringify({ event: 'china_corporate_disclosure_source', ...entry })),
@@ -1230,6 +1333,16 @@ export async function fetchChinaCorporateDisclosureSnapshot({
         proxyRequestFn,
       })
     : null;
+  const resolvedEdgeEgress = edgeEgress === undefined
+    ? resolveChinaExchangeEdgeEgress()
+    : edgeEgress;
+  const resolvedEdgeFetchFn = resolvedEdgeEgress?.url && resolvedEdgeEgress?.secret
+    ? (input, init) => fetchViaEdgeEgress(input, init, {
+        edgeEgress: resolvedEdgeEgress,
+        maxBytes: OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
+        edgeRequestFn,
+      })
+    : null;
   const outcomes = [];
   for (const [sourceId, fetchSource] of LAUNCHED_SOURCE_FETCHERS) {
     let requestCount = 0;
@@ -1239,6 +1352,7 @@ export async function fetchChinaCorporateDisclosureSnapshot({
         return fetchFn(input, init);
       }, now, {
         proxyFetchFn: sourceId === 'szse' ? resolvedProxyFetchFn : null,
+        edgeFetchFn: sourceId === 'szse' ? resolvedEdgeFetchFn : null,
       });
       outcomes.push(outcome);
     } catch (error) {
@@ -1251,6 +1365,9 @@ export async function fetchChinaCorporateDisclosureSnapshot({
         ...(error?.fallbackReason ? { fallbackReason: error.fallbackReason } : {}),
         ...(error?.proxyFailureReason
           ? { proxyFailureReason: error.proxyFailureReason }
+          : {}),
+        ...(error?.edgeFailureReason
+          ? { edgeFailureReason: error.edgeFailureReason }
           : {}),
       };
       outcomes.push(outcome);
@@ -1278,6 +1395,9 @@ export async function fetchChinaCorporateDisclosureSnapshot({
       ...(source.fallbackReason ? { fallbackReason: source.fallbackReason } : {}),
       ...(source.proxyFailureReason
         ? { proxyFailureReason: source.proxyFailureReason }
+        : {}),
+      ...(source.edgeFailureReason
+        ? { edgeFailureReason: source.edgeFailureReason }
         : {}),
       checkedAt: source.checkedAt,
     });

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -387,7 +387,8 @@
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-bundle-market-backup",
     "requiredEnv": [
-      "PROXY_URL"
+      "PROXY_URL",
+      "RELAY_SHARED_SECRET"
     ],
     "watchPatterns": [
       "scripts/_bundle-runner.mjs",

--- a/scripts/seed-bundle-market-backup.mjs
+++ b/scripts/seed-bundle-market-backup.mjs
@@ -6,7 +6,7 @@ await runBundle('market-backup', [
   { label: 'Hyperliquid-Flow', script: 'seed-hyperliquid-flow.mjs', seedMetaKey: 'market:hyperliquid-flow', canonicalKey: 'market:hyperliquid:flow:v1', intervalMs: 5 * MIN, timeoutMs: 60_000 },
   { label: 'Stablecoin-Markets', script: 'seed-stablecoin-markets.mjs', seedMetaKey: 'market:stablecoins', canonicalKey: 'market:stablecoins:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
   { label: 'ETF-Flows', script: 'seed-etf-flows.mjs', seedMetaKey: 'market:etf-flows', canonicalKey: 'market:etf-flows:v1', intervalMs: 15 * MIN, timeoutMs: 120_000 },
-  { label: 'China-Corporate-Disclosures', script: 'seed-china-corporate-disclosures.mjs', seedMetaKey: 'market:china-corporate-disclosures', canonicalKey: 'market:china:corporate-disclosures:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },
+  { label: 'China-Corporate-Disclosures', script: 'seed-china-corporate-disclosures.mjs', seedMetaKey: 'market:china-corporate-disclosures', canonicalKey: 'market:china:corporate-disclosures:v1', intervalMs: 30 * MIN, timeoutMs: 150_000, requiredEnv: ['RELAY_SHARED_SECRET'] },
   { label: 'Gulf-Quotes', script: 'seed-gulf-quotes.mjs', seedMetaKey: 'market:gulf-quotes', canonicalKey: 'market:gulf-quotes:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
   { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', canonicalKey: 'market:defi-tokens:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },
   // SPDR GLD publishes holdings once daily (~16:30 ET). 2h cadence = retries on Cloudflare blocks + catches late publish.

--- a/tests/china-corporate-disclosure-production-registration.test.mts
+++ b/tests/china-corporate-disclosure-production-registration.test.mts
@@ -43,7 +43,12 @@ describe('China corporate disclosure production registration (#5577)', () => {
       'market:china:corporate-disclosures:v1',
     );
     assert.equal(BOOTSTRAP_TIERS.chinaCorporateDisclosures, 'slow');
-    assert.match(read('scripts/seed-bundle-market-backup.mjs'), /seed-china-corporate-disclosures\.mjs/);
+    const bundle = read('scripts/seed-bundle-market-backup.mjs');
+    assert.match(
+      bundle,
+      /\{\s*label:\s*'China-Corporate-Disclosures'[^}]*script:\s*'seed-china-corporate-disclosures\.mjs'[^}]*requiredEnv:\s*\['RELAY_SHARED_SECRET'\][^}]*\}/,
+      'the bundle must fail the China disclosure section when fixed edge auth is unavailable',
+    );
     const railwayServices = JSON.parse(
       read('scripts/railway-services.json'),
     ) as Array<{ service: string; requiredEnv?: (string | string[])[] }>;
@@ -55,13 +60,18 @@ describe('China corporate disclosure production registration (#5577)', () => {
       // alternative, so dropping it would remove the only alerting path for a
       // variable those members still require.
       //
+      // RELAY_SHARED_SECRET is independently mandatory: it authenticates the
+      // fixed Vercel edge fallback after direct and proxy SZSE transports fail.
+      // Without this registry contract a green Railway reconciliation could
+      // leave the runtime fallback silently disabled.
+      //
       // SZSE_PROXY_URL is deliberately NOT declared. The adapter resolves
       // `SZSE_PROXY_URL || PROXY_URL`, so requiring it would make the audit
       // stricter than the runtime it guards: a production environment carrying
       // only the shared exit routes SZSE fine, but would report drift and throw
       // out of buildRailwayServiceConfigPatch -- vetoing reconciliation for
       // every other service in the same run.
-      ['PROXY_URL'],
+      ['PROXY_URL', 'RELAY_SHARED_SECRET'],
     );
     assert.match(
       read('scripts/china-corporate-disclosures/adapters.mjs'),

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -18,6 +18,7 @@ import {
   normalizeSseAnnouncements,
   normalizeSzseAnnouncements,
   readBoundedJsonResponse,
+  resolveChinaExchangeEdgeEgress,
 } from '../scripts/china-corporate-disclosures/adapters.mjs';
 import {
   chinaCorporateDisclosureContentMeta,
@@ -91,7 +92,7 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.ok(timeoutMatch, 'China disclosure bundle section must declare timeoutMs');
     const sectionTimeoutMs = Number(timeoutMatch[1].replaceAll('_', ''));
 
-    assert.equal(CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS, 99_250);
+    assert.equal(CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS, 115_250);
     assert.ok(
       sectionTimeoutMs - CHINA_CORPORATE_DISCLOSURE_MAX_NETWORK_MS >= 20_000,
       'network attempts must leave at least 20s for startup, parsing, publication, and shutdown',
@@ -848,17 +849,18 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(szse?.requestCount, 2);
     assert.equal(szse?.transportPath, 'proxy');
     assert.equal(szse?.fallbackReason, 'UND_ERR_CONNECT_TIMEOUT');
-    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 3);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 4);
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun, 1);
     assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun, 2);
     assert.equal(
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun,
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun
-        + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun,
+        + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun
+        + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxEdgeRequestsPerRun,
     );
     assert.equal(
       OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.fallbackPolicy,
-      'direct_then_proxy_on_transport_failure',
+      'direct_then_proxy_then_edge_on_transport_failure',
     );
 
     const szseDecision = decisions.find((decision) => decision.sourceId === 'szse');
@@ -950,6 +952,312 @@ describe('official China corporate disclosures (#5577)', () => {
         },
       );
     }
+  });
+
+  it('uses the authenticated edge egress after direct and proxy transports are exhausted', async () => {
+    let proxyCalls = 0;
+    const edgeCalls: Array<{ url: string; init?: RequestInit }> = [];
+    const decisions: Array<Record<string, unknown>> = [];
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      edgeEgress: {
+        url: 'https://api.example.test/api/internal/china-exchange-egress',
+        secret: 'edge-relay-secret',
+      },
+      onDecision: (decision) => decisions.push(decision),
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+        });
+      },
+      proxyRequestFn: async () => {
+        proxyCalls += 1;
+        throw Object.assign(new Error('Proxy upstream timeout'), { status: 522 });
+      },
+      edgeRequestFn: async (input, init) => {
+        edgeCalls.push({ url: String(input), init });
+        return new Response(JSON.stringify(fixture('szse.json')), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal(snapshot.status, 'healthy');
+    assert.equal(proxyCalls, 2);
+    assert.equal(edgeCalls.length, 1);
+    assert.equal(
+      edgeCalls[0].url,
+      'https://api.example.test/api/internal/china-exchange-egress',
+    );
+    assert.equal(
+      new Headers(edgeCalls[0].init?.headers).get('Authorization'),
+      'Bearer edge-relay-secret',
+    );
+    assert.deepEqual(
+      JSON.parse(String(edgeCalls[0].init?.body)),
+      {
+        seDate: ['2026-04-26', '2026-07-25'],
+        channelCode: ['listedNotice_disc'],
+        stock: ['300750'],
+        pageSize: 50,
+        pageNum: 1,
+      },
+    );
+    assert.equal(szse?.transportStatus, 'fresh');
+    assert.equal(szse?.contentStatus, 'current');
+    assert.equal(szse?.requestCount, 4);
+    assert.equal(szse?.transportPath, 'edge');
+    assert.equal(szse?.fallbackReason, 'ETIMEDOUT');
+    assert.equal(szse?.proxyFailureReason, 'HTTP_522');
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun, 4);
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxEdgeRequestsPerRun, 1);
+    assert.equal(
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxRequestsPerRun,
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxDirectRequestsPerRun
+        + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxProxyRequestsPerRun
+        + OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxEdgeRequestsPerRun,
+    );
+    assert.equal(
+      OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.fallbackPolicy,
+      'direct_then_proxy_then_edge_on_transport_failure',
+    );
+    assert.deepEqual(
+      decisions.find((decision) => decision.sourceId === 'szse'),
+      {
+        sourceId: 'szse',
+        status: 'accepted',
+        requestCount: 4,
+        emptyResultCount: 0,
+        transportPath: 'edge',
+        fallbackReason: 'ETIMEDOUT',
+        proxyFailureReason: 'HTTP_522',
+        checkedAt: retrievedAt,
+      },
+    );
+    assert.doesNotMatch(JSON.stringify(decisions), /proxy-secret|edge-relay-secret/);
+  });
+
+  it('preserves only allowlisted bounded edge error reasons', async () => {
+    const cases = [
+      {
+        name: 'timeout',
+        body: JSON.stringify({ error: 'upstream_timeout' }),
+        expected: 'upstream_timeout',
+      },
+      {
+        name: 'fetch failure',
+        body: JSON.stringify({ error: 'upstream_fetch_failed' }),
+        expected: 'upstream_fetch_failed',
+      },
+      {
+        name: 'oversized upstream response',
+        body: JSON.stringify({ error: 'upstream_response_too_large' }),
+        expected: 'upstream_response_too_large',
+      },
+      {
+        name: 'unknown JSON error',
+        body: JSON.stringify({
+          error: 'untrusted_edge_error',
+          detail: 'edge-response-secret',
+        }),
+        expected: 'HTTP_502',
+      },
+      {
+        name: 'malformed JSON error',
+        body: 'not-json edge-response-secret',
+        expected: 'HTTP_502',
+      },
+      {
+        name: 'oversized internal error envelope',
+        body: JSON.stringify({
+          error: 'upstream_fetch_failed',
+          detail: `${'x'.repeat(
+            OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
+          )}edge-response-secret`,
+        }),
+        expected: 'HTTP_502',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const decisions: Array<Record<string, unknown>> = [];
+      const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        proxyUrl: '',
+        edgeEgress: {
+          url: 'https://api.example.test/api/internal/china-exchange-egress',
+          secret: 'edge-relay-secret',
+        },
+        onDecision: (decision) => decisions.push(decision),
+        fetchFn: async (input) => {
+          const url = String(input);
+          if (url.includes('query.sse.com.cn')) {
+            return new Response(JSON.stringify({
+              pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+              result: [],
+            }), { status: 200 });
+          }
+          throw Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+          });
+        },
+        edgeRequestFn: async () => new Response(testCase.body, {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      });
+
+      const szse = snapshot.sources.find((source) => source.id === 'szse');
+      assert.equal(szse?.requestCount, 2, testCase.name);
+      assert.equal(szse?.transportPath, 'edge', testCase.name);
+      assert.equal(szse?.fallbackReason, 'ETIMEDOUT', testCase.name);
+      assert.equal(szse?.edgeFailureReason, testCase.expected, testCase.name);
+      assert.equal(szse?.errorCode, testCase.expected, testCase.name);
+      assert.doesNotMatch(
+        JSON.stringify({ snapshot, decisions }),
+        /edge-relay-secret|edge-response-secret|untrusted_edge_error/,
+        testCase.name,
+      );
+    }
+  });
+
+  it('retains last-good SZSE data and all transport reasons after edge failure', async () => {
+    const healthy = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      onDecision: () => {},
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify(fixture('szse.json')), { status: 200 });
+      },
+    });
+    const decisions: Array<Record<string, unknown>> = [];
+    let proxyCalls = 0;
+    let edgeCalls = 0;
+
+    const degradedAt = '2026-07-25T11:00:00.000Z';
+    const degraded = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(degradedAt),
+      previousSnapshot: healthy,
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      edgeEgress: {
+        url: 'https://api.example.test/api/internal/china-exchange-egress',
+        secret: 'edge-relay-secret',
+      },
+      onDecision: (decision) => decisions.push(decision),
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }),
+        });
+      },
+      proxyRequestFn: async () => {
+        proxyCalls += 1;
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('proxy DNS failed'), { code: 'EAI_AGAIN' }),
+        });
+      },
+      edgeRequestFn: async () => {
+        edgeCalls += 1;
+        return new Response(JSON.stringify({
+          error: 'upstream_fetch_failed',
+          detail: 'edge-response-secret',
+        }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    const szse = degraded.sources.find((source) => source.id === 'szse');
+    assert.equal(degraded.status, 'degraded');
+    assert.equal(szse?.transportStatus, 'error');
+    assert.equal(szse?.contentStatus, 'stale');
+    assert.equal(szse?.lastSuccessAt, retrievedAt);
+    assert.equal(proxyCalls, 2);
+    assert.equal(edgeCalls, 1);
+    assert.equal(szse?.requestCount, 4);
+    assert.equal(szse?.transportPath, 'edge');
+    assert.equal(szse?.fallbackReason, 'ECONNRESET');
+    assert.equal(szse?.proxyFailureReason, 'EAI_AGAIN');
+    assert.equal(szse?.edgeFailureReason, 'upstream_fetch_failed');
+    assert.equal(szse?.errorCode, 'upstream_fetch_failed');
+    assert.deepEqual(
+      decisions.find((decision) => decision.sourceId === 'szse'),
+      {
+        sourceId: 'szse',
+        status: 'degraded',
+        requestCount: 4,
+        reason: 'upstream_fetch_failed',
+        emptyResultCount: 0,
+        transportPath: 'edge',
+        fallbackReason: 'ECONNRESET',
+        proxyFailureReason: 'EAI_AGAIN',
+        edgeFailureReason: 'upstream_fetch_failed',
+        checkedAt: degradedAt,
+      },
+    );
+    const withoutProvenance = (events: typeof healthy.events) => JSON.parse(
+      JSON.stringify(events, (key, value) => (key === 'provenance' ? undefined : value)),
+    );
+    assert.deepEqual(
+      withoutProvenance(degraded.events.filter((event) => event.exchange === 'SZSE')),
+      withoutProvenance(healthy.events.filter((event) => event.exchange === 'SZSE')),
+    );
+    assert.doesNotMatch(
+      JSON.stringify({ degraded, decisions }),
+      /proxy-user|proxy-secret|edge-relay-secret|edge-response-secret/,
+    );
+  });
+
+  it('pins edge egress to the canonical endpoint for Railway production', () => {
+    assert.equal(resolveChinaExchangeEdgeEgress({}), null);
+    assert.equal(resolveChinaExchangeEdgeEgress({
+      RAILWAY_ENVIRONMENT: 'production',
+    }), null);
+    assert.deepEqual(resolveChinaExchangeEdgeEgress({
+      RAILWAY_ENVIRONMENT_NAME: 'production',
+      RELAY_SHARED_SECRET: 'relay-secret',
+    }), {
+      url: 'https://api.worldmonitor.app/api/internal/china-exchange-egress',
+      secret: 'relay-secret',
+    });
+    assert.equal(resolveChinaExchangeEdgeEgress({
+      CHINA_EXCHANGE_EDGE_URL: 'https://preview.example.test/api/internal/china-exchange-egress',
+      RELAY_SHARED_SECRET: 'relay-secret',
+    }), null);
+    assert.deepEqual(resolveChinaExchangeEdgeEgress({
+      RAILWAY_ENVIRONMENT: 'production',
+      CHINA_EXCHANGE_EDGE_URL: 'https://attacker.example/internal-egress',
+      RELAY_SHARED_SECRET: 'relay-secret',
+    }), {
+      url: 'https://api.worldmonitor.app/api/internal/china-exchange-egress',
+      secret: 'relay-secret',
+    });
   });
 
   it('does not retry a non-transport SZSE proxy rejection', async () => {

--- a/tests/china-exchange-egress.test.mjs
+++ b/tests/china-exchange-egress.test.mjs
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import handler, {
+  SZSE_EGRESS_MAX_RESPONSE_BYTES,
+} from '../api/internal/china-exchange-egress.js';
+
+const originalFetch = globalThis.fetch;
+const originalSecret = process.env.RELAY_SHARED_SECRET;
+
+const validBody = {
+  seDate: ['2026-04-30', '2026-07-28'],
+  channelCode: ['listedNotice_disc'],
+  stock: ['300750'],
+  pageSize: 50,
+  pageNum: 1,
+};
+
+function request(body = validBody, {
+  authorization = 'Bearer test-relay-secret',
+  method = 'POST',
+} = {}) {
+  return new Request('https://api.worldmonitor.app/api/internal/china-exchange-egress', {
+    method,
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+    ...(method === 'POST' ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+async function assertUpstreamFailureResponse(response, status, error) {
+  assert.equal(response.status, status);
+  assert.equal(response.headers.get('Cache-Control'), 'no-store');
+  assert.equal(response.headers.get('Content-Type'), 'application/json');
+  assert.equal(response.headers.get('X-Content-Type-Options'), 'nosniff');
+  assert.deepEqual(await response.json(), { error });
+}
+
+beforeEach(() => {
+  process.env.RELAY_SHARED_SECRET = 'test-relay-secret';
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalSecret === undefined) delete process.env.RELAY_SHARED_SECRET;
+  else process.env.RELAY_SHARED_SECRET = originalSecret;
+});
+
+describe('internal China exchange egress', () => {
+  it('fails closed before contacting SZSE when internal auth is invalid', async () => {
+    let called = false;
+    globalThis.fetch = async () => {
+      called = true;
+      return new Response('{}');
+    };
+
+    const response = await handler(request(validBody, { authorization: 'Bearer wrong' }));
+
+    assert.equal(response.status, 401);
+    assert.equal(called, false);
+    assert.deepEqual(await response.json(), { error: 'unauthorized' });
+  });
+
+  it('fails closed when the shared secret is not configured', async () => {
+    delete process.env.RELAY_SHARED_SECRET;
+    let called = false;
+    globalThis.fetch = async () => {
+      called = true;
+      return new Response('{}');
+    };
+
+    const response = await handler(request(validBody, { authorization: 'Bearer ' }));
+
+    assert.equal(response.status, 401);
+    assert.equal(called, false);
+    assert.deepEqual(await response.json(), { error: 'unauthorized' });
+  });
+
+  it('accepts only the fixed reviewed SZSE request shape', async () => {
+    const invalidBodies = [
+      { ...validBody, stock: ['000001'] },
+      { ...validBody, pageSize: 100 },
+      { ...validBody, pageNum: 2 },
+      { ...validBody, channelCode: ['other'] },
+      { ...validBody, seDate: ['2025-01-01', '2026-07-28'] },
+      { ...validBody, seDate: ['2026-02-31', '2026-04-30'] },
+      { ...validBody, extra: 'unexpected' },
+    ];
+
+    for (const body of invalidBodies) {
+      const response = await handler(request(body));
+      assert.equal(response.status, 400, JSON.stringify(body));
+      assert.deepEqual(await response.json(), { error: 'invalid_request' });
+    }
+  });
+
+  it('cancels an oversized streaming request as soon as it crosses the byte cap', async () => {
+    let cancelled = false;
+    let reads = 0;
+    const oversizedRequest = {
+      method: 'POST',
+      headers: new Headers({ Authorization: 'Bearer test-relay-secret' }),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            reads += 1;
+            return {
+              done: false,
+              value: new Uint8Array(2_049),
+            };
+          },
+          cancel: async () => {
+            cancelled = true;
+          },
+        }),
+      },
+    };
+
+    const response = await handler(oversizedRequest);
+
+    assert.equal(response.status, 400);
+    assert.equal(reads, 1);
+    assert.equal(cancelled, true);
+    assert.deepEqual(await response.json(), { error: 'invalid_request' });
+  });
+
+  it('forwards the bounded official metadata request and returns the upstream JSON', async () => {
+    const calls = [];
+    const payload = {
+      announceCount: 1,
+      data: [{
+        secCode: ['300750'],
+        annId: '1225441596',
+        title: '宁德时代：《董事会秘书工作细则》（2026年7月修订）',
+        attachPath: '/disc/disk03/finalpage/2026-07-25/example.PDF',
+        publishTime: '2026-07-25',
+      }],
+    };
+    globalThis.fetch = async (input, init) => {
+      calls.push({ input: String(input), init });
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const response = await handler(request());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('Cache-Control'), 'no-store');
+    assert.equal(response.headers.get('Content-Type'), 'application/json');
+    assert.deepEqual(await response.json(), payload);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].input,
+      'https://www.szse.cn/api/disc/announcement/annList?random=0.5',
+    );
+    assert.equal(calls[0].init.method, 'POST');
+    assert.equal(calls[0].init.redirect, 'error');
+    assert.deepEqual(JSON.parse(calls[0].init.body), validBody);
+    assert.deepEqual(calls[0].init.headers, {
+      Accept: 'application/json',
+      Referer: 'https://www.szse.cn/',
+      'Content-Type': 'application/json',
+      'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
+    });
+  });
+
+  it('preserves upstream failure status for the seeder fallback chain', async () => {
+    globalThis.fetch = async () => new Response('upstream timeout', { status: 522 });
+
+    const response = await handler(request());
+
+    assert.equal(response.status, 522);
+    assert.equal(await response.text(), 'upstream timeout');
+  });
+
+  it('maps an upstream TimeoutError to a no-store 504 JSON response', async () => {
+    globalThis.fetch = async () => {
+      throw Object.assign(new Error('upstream timed out'), { name: 'TimeoutError' });
+    };
+
+    const response = await handler(request());
+
+    await assertUpstreamFailureResponse(response, 504, 'upstream_timeout');
+  });
+
+  it('maps an upstream AbortError to a no-store 504 JSON response', async () => {
+    globalThis.fetch = async () => {
+      throw Object.assign(new Error('upstream aborted'), { name: 'AbortError' });
+    };
+
+    const response = await handler(request());
+
+    await assertUpstreamFailureResponse(response, 504, 'upstream_timeout');
+  });
+
+  it('maps an ordinary upstream fetch rejection to a no-store 502 JSON response', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('upstream connection failed');
+    };
+
+    const response = await handler(request());
+
+    await assertUpstreamFailureResponse(response, 502, 'upstream_fetch_failed');
+  });
+
+  it('maps a post-header upstream body failure to a no-store 502 JSON response', async () => {
+    globalThis.fetch = async () => new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(new Error('upstream body failed'));
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const response = await handler(request());
+
+    await assertUpstreamFailureResponse(response, 502, 'upstream_fetch_failed');
+  });
+
+  it('rejects an oversized upstream response without forwarding it', async () => {
+    globalThis.fetch = async () => new Response(
+      'x'.repeat(SZSE_EGRESS_MAX_RESPONSE_BYTES + 1),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+
+    const response = await handler(request());
+
+    assert.equal(response.status, 502);
+    assert.deepEqual(await response.json(), { error: 'upstream_response_too_large' });
+  });
+
+  it('rejects methods other than POST', async () => {
+    const response = await handler(request(undefined, { method: 'GET' }));
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get('Allow'), 'POST');
+  });
+});


### PR DESCRIPTION
## Summary

SZSE disclosures can now recover when both Railway's direct route and its proxy route are unavailable. The final attempt goes through a fixed, shared-secret-authenticated WorldMonitor Edge endpoint that accepts only the reviewed CATL announcement query and enforces strict request, response, redirect, and timeout bounds.

The seeder retains last-good disclosures if all four attempts fail and records the direct, proxy, and edge reasons separately. Railway now treats the shared secret as required deployment configuration, so a green reconciliation cannot silently omit the recovery path.

Issue #5771 subsequently recovered through the direct/proxy paths and was closed by #5785 without requiring this edge fallback. This PR is now defense in depth for a future simultaneous direct-and-proxy outage; it is not required for the accepted recovery or baseline removal.

Related: #5771

## Validation

- 51 focused endpoint, adapter, last-good, and deployment-contract tests passed.
- Frontend/API typechecks, Biome/safe-HTML lint, the sebuf API-contract guard, the Edge-function guard, and the full Vite build passed.
- The full data suite completed with 18,665 passes and two unrelated high-concurrency fixture races; both failing seams then passed in isolation (27/27).
- Full structured code review resolved every validated security, reliability, correctness, and testing finding; no actionable finding remains.

## Post-Deploy Monitoring & Validation

- **Owner:** @koala73
- **Window:** The first two `seed-bundle-market-backup` China disclosure cycles after production deployment (about 60 minutes).
- **Logs:** Inspect `china_corporate_disclosure_source` for `sourceId=szse`, `transportPath=edge`, `fallbackReason`, `proxyFailureReason`, and `edgeFailureReason`.
- **Health:** Check `/api/health?compact=1`, the corporate-disclosure bootstrap source state, and `chinaCoverage`.
- **Expected:** SZSE remains fresh/current, corporate disclosures remain healthy, and `chinaCoverage` stays absent from `problems`.
- **Failure signals:** `401` indicates shared-secret mismatch; `502`/`504` or stale SZSE indicates the fixed edge route still cannot reach the exchange; section duration approaching the 150-second budget indicates timeout pressure.
- **Rollback:** Revert the edge fallback if it consumes the section budget or degrades healthy disclosure publication. Any newly accepted degradation requires a new owner issue rather than reopening #5771's retired baseline exception.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
