### PR TITLE
fix(test): stop transient seed fixtures from reding the unit job

### DIFF
--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -159,12 +159,31 @@ function findHomeDirReferences(source) {
 // sweeps cost nothing to extend.
 const SCANNED_TREES = ['scripts', 'api', 'server', 'cli', 'middleware.ts'];
 
+/**
+ * Yields `[entry, source]` for every scanned file.
+ *
+ * The read lives HERE rather than at each call site so the tolerance below
+ * cannot be forgotten by a future sweep. A glob-then-read over a live working
+ * tree is inherently TOCTOU — a concurrent test's temp file, a build artifact,
+ * an editor swap file — and one such file vanishing mid-walk used to fail the
+ * whole `unit` job with an ENOENT unrelated to the change under test. Skipping
+ * a file that no longer exists cannot hide a committed leak: it is not in the
+ * tree. Only ENOENT is tolerated; a file that IS there but unreadable still
+ * throws, because that is a real signal.
+ */
 async function* scanSources() {
   for (const tree of SCANNED_TREES) {
     const pattern = tree.includes('.') ? tree : `${tree}/**/*.{mjs,cjs,js,mts,ts}`;
     for await (const entry of glob(pattern, { cwd: REPO_ROOT })) {
       if (entry.includes('node_modules')) continue;
-      yield entry;
+      let source;
+      try {
+        source = readFileSync(join(REPO_ROOT, entry), 'utf8');
+      } catch (err) {
+        if (err?.code === 'ENOENT') continue;
+        throw err;
+      }
+      yield [entry, source];
     }
   }
 }
@@ -442,9 +461,9 @@ describe('seeder env hermeticity (#5767)', () => {
     it('no source bakes a home path into the repo', async () => {
       const offenders = [];
       let scanned = 0;
-      for await (const entry of scanSources()) {
+      for await (const [entry, source] of scanSources()) {
         scanned += 1;
-        const found = findCheckoutEscapingEnvPaths(readFileSync(join(REPO_ROOT, entry), 'utf8'));
+        const found = findCheckoutEscapingEnvPaths(source);
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
       }
       assert.ok(scanned > 100, `expected to scan the seeder fleet, scanned ${scanned}`);
@@ -459,8 +478,7 @@ describe('seeder env hermeticity (#5767)', () => {
       // read-half gate has no such bypass: naming a `.env` file (or a loader)
       // is unavoidable, so anything reaching for $HOME to find one lands here.
       const offenders = [];
-      for await (const entry of scanSources()) {
-        const source = readFileSync(join(REPO_ROOT, entry), 'utf8');
+      for await (const [entry, source] of scanSources()) {
         if (!accessesEnvFileItself(source)) continue;
         const found = findHomeDirReferences(stripJsComments(source));
         if (found.length > 0) offenders.push(`${entry}: ${found.join(', ')}`);
@@ -514,9 +532,9 @@ describe('seeder env hermeticity (#5767)', () => {
 
     it('no source outside the allowlist reads a .env file', async () => {
       const offenders = [];
-      for await (const entry of scanSources()) {
+      for await (const [entry, source] of scanSources()) {
         if (ENV_PARSER_ALLOWLIST.has(entry)) continue;
-        if (accessesEnvFileItself(readFileSync(join(REPO_ROOT, entry), 'utf8'))) offenders.push(entry);
+        if (accessesEnvFileItself(source)) offenders.push(entry);
       }
       assert.deepEqual(
         offenders,

--- a/tests/seed-utils-sigterm-cleanup.test.mjs
+++ b/tests/seed-utils-sigterm-cleanup.test.mjs
@@ -13,15 +13,55 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const SCRIPTS_DIR = fileURLToPath(new URL('../scripts/', import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const SEED_UTILS_SPECIFIER = './_seed-utils.mjs';
+const SEED_UTILS_URL = new URL('../scripts/_seed-utils.mjs', import.meta.url).href;
+
+/**
+ * Write a spawnable fixture OUTSIDE the checkout.
+ *
+ * These fixtures used to land in `scripts/` so their `./_seed-utils.mjs`
+ * import would resolve. That put transient files inside a tree
+ * tests/seed-env-hermeticity.test.mjs walks: it enumerates every source file
+ * and then reads it, so a fixture deleted in between failed the whole `unit`
+ * job with an ENOENT unrelated to the change under test. A private temp dir
+ * makes the interference structurally impossible; the relative import is
+ * rewritten to an absolute URL to survive the move.
+ *
+ * All four spawn helpers below share this placement — they differ only in how
+ * they signal the child and what they assert, which is why only the file
+ * placement is factored out here.
+ */
+function writeFixture(bodyJs) {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-sigterm-fixture-'));
+  const path = join(dir, 'fixture.mjs');
+  // Executable invariant, not a comment: if a fixture ever lands back inside
+  // the checkout, the hermeticity scan can race it again and red an unrelated
+  // job. Asserting here covers all four spawn helpers at their single shared
+  // placement point.
+  assert.ok(
+    !path.startsWith(REPO_ROOT),
+    `fixture must be written outside the checkout, got ${path}`,
+  );
+  writeFileSync(
+    path,
+    bodyJs.replaceAll(`'${SEED_UTILS_SPECIFIER}'`, JSON.stringify(SEED_UTILS_URL)),
+  );
+  return {
+    path,
+    cleanup: () => {
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    },
+  };
+}
 
 function runFixture(bodyJs) {
-  const path = join(SCRIPTS_DIR, `_sigterm-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, bodyJs);
+  const { path, cleanup } = writeFixture(bodyJs);
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [path], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -36,7 +76,7 @@ function runFixture(bodyJs) {
     child.stdout.on('data', (c) => { stdout += c; });
     child.stderr.on('data', (c) => { stderr += c; });
     child.on('close', (code, signal) => {
-      try { unlinkSync(path); } catch {}
+      cleanup();
       resolve({ code, signal, stdout, stderr });
     });
     // Let runSeed register the SIGTERM handler and enter fetchFn before we kill.
@@ -152,8 +192,7 @@ test('runSeed SIGTERM handler fires once even if multiple SIGTERMs arrive', { sk
       lockTtlMs: 60_000,
     });
   `;
-  const path = join(SCRIPTS_DIR, `_sigterm-once-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, body);
+  const { path, cleanup } = writeFixture(body);
   try {
     await new Promise((resolve) => {
       const child = spawn(process.execPath, [path], {
@@ -188,7 +227,7 @@ test('runSeed SIGTERM handler fires once even if multiple SIGTERMs arrive', { sk
       setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10_000);
     });
   } finally {
-    try { unlinkSync(path); } catch {}
+    cleanup();
   }
 });
 
@@ -260,8 +299,7 @@ test('publish-phase SIGTERM releases lock but does NOT extend TTL (strict-floor 
       lockTtlMs: 60_000,
     });
   `;
-  const path = join(SCRIPTS_DIR, `_sigterm-postfetch-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, body);
+  const { path, cleanup } = writeFixture(body);
   try {
     await new Promise((resolve) => {
       const child = spawn(process.execPath, [path], {
@@ -324,7 +362,7 @@ test('publish-phase SIGTERM releases lock but does NOT extend TTL (strict-floor 
       setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10_000);
     });
   } finally {
-    try { unlinkSync(path); } catch {}
+    cleanup();
   }
 });
 
@@ -399,8 +437,7 @@ test('SIGTERM during fetch-failure cleanup still triggers handler (no leak windo
       maxRetries: 0,  // fail fast — no withRetry retries
     });
   `;
-  const path = join(SCRIPTS_DIR, `_sigterm-fetchfail-fixture-${Date.now()}.mjs`);
-  writeFileSync(path, body);
+  const { path, cleanup } = writeFixture(body);
   try {
     await new Promise((resolve) => {
       const child = spawn(process.execPath, [path], {
@@ -437,6 +474,6 @@ test('SIGTERM during fetch-failure cleanup still triggers handler (no leak windo
       setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10_000);
     });
   } finally {
-    try { unlinkSync(path); } catch {}
+    cleanup();
   }
 });


### PR DESCRIPTION
## Summary

Two test files on `main` race each other and can fail the `unit` job on **any** PR, with an error that has nothing to do with the change under test.

- `tests/seed-utils-sigterm-cleanup.test.mjs` writes a spawnable fixture into `scripts/` — it has to, so the fixture's `./_seed-utils.mjs` import resolves — and deletes it when the child exits.
- `tests/seed-env-hermeticity.test.mjs` (from #5775) walks `scripts/` and `readFileSync`s every file it enumerates.

The scan lists the fixture, the sigterm test deletes it, the read throws `ENOENT`. Observed on #5606, where **18719/18726 tests passed** and the sole failure was:

```
✖ no env-loading source reaches for a home directory
  Error: ENOENT: no such file or directory, open
    '.../worldmonitor/scripts/_sigterm-fixture-1785278808342.mjs'
```

## Fix

**Placement (root cause).** All four spawn helpers now write their fixture into a private `mkdtemp` directory outside the checkout, through one shared `writeFixture()`. Only the *placement* is factored out — the four helpers legitimately differ in how they signal the child and what they assert, so unifying them wholesale would risk their semantics. The relative `./_seed-utils.mjs` import is rewritten to an absolute `file://` URL so it still resolves from outside the tree.

Fixing only the one helper I first noticed would have left three more inline writers doing the same thing, which is why this goes through a single placement point — and that point asserts the path is outside `REPO_ROOT`, so a future fixture cannot quietly move back in.

**Scanning (defence in depth).** `scanSources()` now performs the read itself and yields `[entry, source]`, skipping a file that vanished between the glob and the read. A glob-then-read over a live working tree is inherently TOCTOU — a build artifact or an editor swap file would do the same thing — and putting the read in the generator means no future sweep can forget the guard. Only `ENOENT` is tolerated; a file that IS present but unreadable still throws, because that is a real signal. Skipping a file that no longer exists cannot hide a committed leak: it is not in the tree.

The security guarantee of #5775 is unchanged — every committed source is still read and checked.

## Type of change

- [x] CI / Build / Infrastructure

## Affected areas

- [x] Other: test suite hygiene (`tests/seed-utils-sigterm-cleanup`, `tests/seed-env-hermeticity`)

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — test-only change; no documented contract, generated doc, or Redis key is touched.

## Verification

- Both suites: **27/27 green**, including **3 rounds at `--test-concurrency=16`** (the shape `test:data` runs in CI).
- **Mutation-verified:** pointing `writeFixture` back at `scripts/` (the pre-fix placement) reds all 4 sigterm tests with `fixture must be written outside the checkout, got /home/user/worldmonitor/scripts/fixture.mjs` — the invariant is executable, not a comment.
- `npm run typecheck` and `biome check` clean on both files.

## Note

This unblocks #5606, whose only red check is this flake.