### PR TITLE
feat(globe): add Desk context overlay

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -68,7 +68,7 @@ import type { SatellitePosition } from '@/services/satellites';
 import type { ImageryScene } from '@/generated/server/worldmonitor/imagery/v1/service_server';
 import { isAllowedPreviewUrl } from '@/utils/imagery-preview';
 import { getCategoryStyle } from '@/services/webcams';
-import { loadDeskOverlay, type DeskOverlayCaseFile, type DeskOverlayResult } from '@/services/desk-overlay';
+import { loadDeskOverlay, parseDeskOverlayCaseId, type DeskOverlayCaseFile, type DeskOverlayResult } from '@/services/desk-overlay';
 import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
 import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor/webcam/v1/service_client';
 import type { TrafficAnomaly as ProtoTrafficAnomaly, DdosLocationHit } from '@/generated/client/worldmonitor/infrastructure/v1/service_client';
@@ -577,6 +577,7 @@ export class GlobeMap {
   private markerBudgetProfile: 'mobile' | 'desktop' = 'desktop';
   private deskOverlayMarkers: DeskOverlayMarker[] = [];
   private deskOverlayCaseFiles: DeskOverlayCaseFile[] = [];
+  private readonly deskOverlayRequestedCaseId = parseDeskOverlayCaseId(window.location.search);
   private deskOverlayVisible = true;
   private deskOverlayDrawerEl: HTMLElement | null = null;
   private deskOverlayStatusEl: HTMLElement | null = null;
@@ -1450,6 +1451,20 @@ export class GlobeMap {
       }));
     this.renderDeskOverlayStatus(overlay);
     this.flushMarkers();
+
+    const requestedCase = this.deskOverlayRequestedCaseId
+      ? overlay.caseFiles.find((caseFile) => caseFile.id === this.deskOverlayRequestedCaseId)
+      : null;
+    if (requestedCase) {
+      if (requestedCase.mapLocation && this.globe) {
+        this.globe.pointOfView({
+          lat: requestedCase.mapLocation.lat,
+          lng: requestedCase.mapLocation.lon,
+          altitude: 1.45,
+        }, 700);
+      }
+      this.openDeskOverlayDrawer(requestedCase);
+    }
   }
 
   private renderDeskOverlayStatus(overlay: DeskOverlayResult): void {

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -68,6 +68,7 @@ import type { SatellitePosition } from '@/services/satellites';
 import type { ImageryScene } from '@/generated/server/worldmonitor/imagery/v1/service_server';
 import { isAllowedPreviewUrl } from '@/utils/imagery-preview';
 import { getCategoryStyle } from '@/services/webcams';
+import { loadDeskOverlay, type DeskOverlayCaseFile, type DeskOverlayResult } from '@/services/desk-overlay';
 import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
 import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor/webcam/v1/service_client';
 import type { TrafficAnomaly as ProtoTrafficAnomaly, DdosLocationHit } from '@/generated/client/worldmonitor/infrastructure/v1/service_client';
@@ -427,6 +428,12 @@ interface WebcamClusterData extends BaseMarker {
   count: number;
   categories: string[];
 }
+interface DeskOverlayMarker extends BaseMarker {
+  _kind: 'deskOverlay';
+  id: string;
+  caseFile: DeskOverlayCaseFile;
+}
+
 interface GlobePath {
   id: string;
   name: string;
@@ -462,7 +469,7 @@ type GlobeMarker =
   | EarthquakeMarker | RadiationMarker | EconomicMarker | DatacenterMarker | WaterwayMarker | MineralMarker
   | FlightDelayMarker | NotamRingMarker | CableAdvisoryMarker | RepairShipMarker | AisDisruptionMarker
   | NewsLocationMarker | FlashMarker | SatelliteMarker | SatFootprintMarker | ImagerySceneMarker
-  | WebcamMarkerData | WebcamClusterData;
+  | WebcamMarkerData | WebcamClusterData | DeskOverlayMarker;
 
 interface GlobeControlsLike {
   autoRotate: boolean;
@@ -568,6 +575,11 @@ export class GlobeMap {
   /** HTML markers handed to globe.gl on the last flush — the per-frame cost driver. */
   private renderedMarkerCount = 0;
   private markerBudgetProfile: 'mobile' | 'desktop' = 'desktop';
+  private deskOverlayMarkers: DeskOverlayMarker[] = [];
+  private deskOverlayCaseFiles: DeskOverlayCaseFile[] = [];
+  private deskOverlayVisible = true;
+  private deskOverlayDrawerEl: HTMLElement | null = null;
+  private deskOverlayStatusEl: HTMLElement | null = null;
   private webcamMarkerMode: string = (() => {
     try {
       return localStorage.getItem('wm-webcam-marker-mode') || 'icon';
@@ -984,6 +996,10 @@ export class GlobeMap {
     this.layers.dayNight = false;
     this.hideLayerToggle('dayNight');
 
+    // Desk publishes only a small, context-only case-file artifact. It is optional:
+    // overlay load failure must never delay or break the primary WorldMonitor renderer.
+    void this.loadDeskOverlay();
+
     // Flush any data that arrived before init completed
     this.flushMarkers();
     this.flushArcs();
@@ -1281,6 +1297,11 @@ export class GlobeMap {
     } else if (d._kind === 'imageryScene') {
       setTrustedHtml(el, trustedHtml(GlobeMap.wrapHit(`<div style="font-size:11px;color:#00b4ff;text-shadow:0 0 4px #00b4ff88;">&#128752;</div>`), "legacy direct innerHTML migration"));
       el.title = `${d.satellite} ${d.datetime}`;
+    } else if (d._kind === 'deskOverlay') {
+      const color = d.caseFile.severity === 'elevated' ? '#ff9f1a' : '#57d9ff';
+      el.style.cursor = 'pointer';
+      setTrustedHtml(el, trustedHtml(GlobeMap.wrapHit(`<div style="position:relative;width:18px;height:18px;"><div style="position:absolute;inset:0;border-radius:50%;background:${color}33;border:2px solid ${color};box-shadow:0 0 10px 3px ${color}77;"></div><div style="position:absolute;inset:4px;border-radius:50%;background:${color};${this.pulseStyle('2.4s')}"></div></div>`), "static Desk overlay marker"));
+      el.title = `Desk Overlay · ${d.caseFile.title}`;
     } else if (d._kind === 'webcam') {
       const style = getCategoryStyle(d.category);
       const emoji = this.webcamMarkerMode === 'emoji' ? style.emoji : '\u{1F4F7}';
@@ -1309,6 +1330,11 @@ export class GlobeMap {
   }
 
   private handleMarkerClick(d: GlobeMarker, anchor: HTMLElement): void {
+    if (d._kind === 'deskOverlay') {
+      this.openDeskOverlayDrawer(d.caseFile);
+      return;
+    }
+
     if (d._kind === 'hotspot' && this.onHotspotClickCb) {
       this.onHotspotClickCb({
         id: d.id,
@@ -1401,6 +1427,111 @@ export class GlobeMap {
       return;
     }
     this.showMarkerTooltip(d, anchor);
+  }
+
+  private async loadDeskOverlay(): Promise<void> {
+    const overlay = await loadDeskOverlay().catch(() => ({
+      status: 'unavailable' as const,
+      generatedAt: null,
+      caveats: ['Desk Overlay public artifact could not be loaded.'],
+      caseFiles: [],
+    }));
+    if (this.destroyed) return;
+
+    this.deskOverlayCaseFiles = overlay.caseFiles;
+    this.deskOverlayMarkers = overlay.caseFiles
+      .filter((caseFile) => caseFile.mapLocation)
+      .map((caseFile) => ({
+        _kind: 'deskOverlay' as const,
+        _lat: caseFile.mapLocation!.lat,
+        _lng: caseFile.mapLocation!.lon,
+        id: caseFile.id,
+        caseFile,
+      }));
+    this.renderDeskOverlayStatus(overlay);
+    this.flushMarkers();
+  }
+
+  private renderDeskOverlayStatus(overlay: DeskOverlayResult): void {
+    this.deskOverlayStatusEl?.remove();
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = 'desk-overlay-status';
+    card.style.cssText = [
+      'position:absolute', 'left:12px', 'bottom:30px', 'z-index:12',
+      'max-width:240px', 'padding:7px 9px', 'border-radius:4px',
+      'border:1px solid rgba(87,217,255,.55)', 'background:rgba(4,12,20,.9)',
+      'color:#d8f7ff', 'font:10px/1.35 var(--font-mono,monospace)', 'text-align:left', 'cursor:pointer',
+    ].join(';');
+    const pinCount = this.deskOverlayMarkers.length;
+    const detail = overlay.status === 'ok'
+      ? (overlay.caseFiles.length ? `${overlay.caseFiles.length} case · ${pinCount} pin` : '기준선 유지 · 새 변경 없음')
+      : overlay.status === 'baseline' ? '기준선 생성 중' : '데이터 확인 필요';
+    card.textContent = `DESK OVERLAY  |  ${detail}`;
+    card.title = 'Desk가 선별한 맥락 변화. 클릭하면 케이스 파일을 엽니다.';
+    card.addEventListener('click', () => {
+      const first = this.deskOverlayCaseFiles[0];
+      if (first) this.openDeskOverlayDrawer(first);
+    });
+    this.container.appendChild(card);
+    this.deskOverlayStatusEl = card;
+  }
+
+  private openDeskOverlayDrawer(caseFile: DeskOverlayCaseFile): void {
+    this.deskOverlayDrawerEl?.remove();
+    const drawer = document.createElement('aside');
+    drawer.className = 'desk-overlay-drawer';
+    drawer.style.cssText = [
+      'position:absolute', 'top:12px', 'right:12px', 'bottom:12px', 'z-index:1010',
+      'width:min(360px,calc(100% - 24px))', 'overflow:auto', 'box-sizing:border-box',
+      'padding:16px', 'border:1px solid rgba(87,217,255,.62)', 'border-radius:6px',
+      'background:rgba(4,10,17,.97)', 'box-shadow:0 14px 40px rgba(0,0,0,.48)',
+      'color:#e7f7ff', 'font:12px/1.5 var(--font-mono,monospace)',
+    ].join(';');
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.textContent = '×';
+    close.setAttribute('aria-label', 'Desk Overlay 닫기');
+    close.style.cssText = 'float:right;border:0;background:transparent;color:#a7c8d6;font-size:22px;line-height:1;cursor:pointer;';
+    close.addEventListener('click', () => {
+      drawer.remove();
+      if (this.deskOverlayDrawerEl === drawer) this.deskOverlayDrawerEl = null;
+    });
+
+    const eyebrow = document.createElement('div');
+    eyebrow.textContent = `DESK CASE FILE · ${caseFile.severity.toUpperCase()}`;
+    eyebrow.style.cssText = `font-size:10px;letter-spacing:.08em;color:${caseFile.severity === 'elevated' ? '#ffae42' : '#61dfff'};`;
+    const title = document.createElement('h2');
+    title.textContent = caseFile.title;
+    title.style.cssText = 'margin:7px 28px 10px 0;font-size:17px;line-height:1.35;color:#fff;';
+    const summary = document.createElement('p');
+    summary.textContent = caseFile.summary;
+    summary.style.cssText = 'margin:0 0 12px;color:#c7d8df;white-space:pre-wrap;';
+    const meta = document.createElement('div');
+    meta.textContent = [caseFile.mapLocation?.label, caseFile.observedAt, caseFile.impactAreas.length ? `영향: ${caseFile.impactAreas.join(', ')}` : null]
+      .filter(Boolean)
+      .join(' · ');
+    meta.style.cssText = 'margin:0 0 12px;color:#8cacb8;font-size:10px;';
+    const safety = document.createElement('div');
+    safety.textContent = '맥락·리서치 전용 · 주문·승인 신호 아님 · 브로커/주문 연결 없음';
+    safety.style.cssText = 'margin:14px 0 10px;padding:8px;border-left:2px solid #57d9ff;background:rgba(87,217,255,.08);color:#a8dfe9;font-size:10px;';
+
+    drawer.append(close, eyebrow, title, summary, meta, safety);
+    if (caseFile.deskUrl) drawer.append(this.createDeskOverlayLink('Desk Cockpit 열기', caseFile.deskUrl));
+    if (caseFile.evidenceUrl) drawer.append(this.createDeskOverlayLink('근거 원문 열기', caseFile.evidenceUrl));
+    this.container.appendChild(drawer);
+    this.deskOverlayDrawerEl = drawer;
+  }
+
+  private createDeskOverlayLink(label: string, href: string): HTMLAnchorElement {
+    const link = document.createElement('a');
+    link.textContent = label;
+    link.href = href;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.style.cssText = 'display:block;margin-top:8px;padding:8px 10px;border:1px solid rgba(87,217,255,.45);border-radius:3px;color:#8eeaff;text-decoration:none;font-size:11px;';
+    return link;
   }
 
   private showMarkerTooltip(d: GlobeMarker, anchor: HTMLElement): void {
@@ -2185,6 +2316,9 @@ export class GlobeMap {
       add('cables', this.repairShipMarkers);
     }
     if (this.layers.webcams) add('webcams', this.webcamMarkers);
+    // Desk cases are curated and few; retain the explicit event pin under the
+    // general marker budget, especially for an inbound Desk deep link.
+    if (this.deskOverlayVisible) add('deskOverlay', this.deskOverlayMarkers, { exempt: true });
     // Exempt like flash: `news` has no layer-toggle row, so a truncation here
     // would have nowhere to be disclosed. It was ungated before this change too.
     add('news', this.newsLocationMarkers, { exempt: true });
@@ -3853,6 +3987,10 @@ export class GlobeMap {
   public destroy(): void {
     this.popup?.hide();
     this.popup = null;
+    this.deskOverlayDrawerEl?.remove();
+    this.deskOverlayDrawerEl = null;
+    this.deskOverlayStatusEl?.remove();
+    this.deskOverlayStatusEl = null;
     this.flightData.clear();
     this.vesselData.clear();
     this.clusterData.clear();

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -55,6 +55,7 @@ import type { ChinaCorridorControlTower } from '../../shared/china-corridor-cont
 import { projectChinaCorridorOverlay } from './map/china-corridor-overlay';
 import type { ScenarioVisualState, ScenarioResult } from '@/config/scenario-templates';
 import { getAuthState } from '@/services/auth-state';
+import { parseDeskOverlayCaseId } from '@/services/desk-overlay';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { trackGateHit } from '@/services/analytics';
 
@@ -219,7 +220,7 @@ export class MapContainer {
     this.initialState = initialState;
     this.chrome = options.chrome ?? true;
     this.isMobile = isMobileDevice();
-    this.useGlobe = preferGlobe && this.hasGlobeSupport();
+    this.useGlobe = (preferGlobe || parseDeskOverlayCaseId(window.location.search) !== null) && this.hasGlobeSupport();
 
     this.useDeckGL = !this.useGlobe && this.shouldUseDeckGL();
 

--- a/src/services/desk-overlay.ts
+++ b/src/services/desk-overlay.ts
@@ -1,4 +1,6 @@
 export const DESK_OVERLAY_URL = 'https://dev.westkite.dev/desk/data/world_case_files.json';
+const DESK_OVERLAY_CASE_QUERY_KEY = 'desk_case';
+const DESK_OVERLAY_CASE_ID = /^[a-z0-9][a-z0-9:_/-]{0,127}$/i;
 
 export type DeskOverlayStatus = 'ok' | 'baseline' | 'partial' | 'data_check' | 'unavailable';
 
@@ -26,6 +28,12 @@ export interface DeskOverlayResult {
   generatedAt: string | null;
   caveats: string[];
   caseFiles: DeskOverlayCaseFile[];
+}
+
+/** Returns a bounded Desk case ID only when a deep-link query is safe to render. */
+export function parseDeskOverlayCaseId(search: string): string | null {
+  const caseId = new URLSearchParams(search).get(DESK_OVERLAY_CASE_QUERY_KEY)?.trim() ?? '';
+  return DESK_OVERLAY_CASE_ID.test(caseId) ? caseId : null;
 }
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<{ ok: boolean; json(): Promise<unknown> }>;

--- a/src/services/desk-overlay.ts
+++ b/src/services/desk-overlay.ts
@@ -1,0 +1,180 @@
+export const DESK_OVERLAY_URL = 'https://dev.westkite.dev/desk/data/world_case_files.json';
+
+export type DeskOverlayStatus = 'ok' | 'baseline' | 'partial' | 'data_check' | 'unavailable';
+
+export interface DeskOverlayMapLocation {
+  label: string;
+  lat: number;
+  lon: number;
+}
+
+export interface DeskOverlayCaseFile {
+  id: string;
+  category: string;
+  severity: 'elevated' | 'observe';
+  title: string;
+  summary: string;
+  impactAreas: string[];
+  observedAt: string | null;
+  evidenceUrl: string | null;
+  deskUrl: string | null;
+  mapLocation: DeskOverlayMapLocation | null;
+}
+
+export interface DeskOverlayResult {
+  status: DeskOverlayStatus;
+  generatedAt: string | null;
+  caveats: string[];
+  caseFiles: DeskOverlayCaseFile[];
+}
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<{ ok: boolean; json(): Promise<unknown> }>;
+
+const REQUIRED_SAFETY_FLAGS = Object.freeze({
+  context_only: true,
+  research_only: true,
+  use_as_execution_signal: false,
+  paper_live_approval_signal: false,
+  no_broker_connection: true,
+  no_order_submission: true,
+  no_live_orders: true,
+  no_actual_trades: true,
+});
+
+/** Fetches a public, Desk-owned overlay with no cookies or ambient credentials. */
+export async function loadDeskOverlay({
+  fetchImpl = fetch as FetchLike,
+  url = DESK_OVERLAY_URL,
+}: {
+  fetchImpl?: FetchLike;
+  url?: string;
+} = {}): Promise<DeskOverlayResult> {
+  try {
+    const response = await fetchImpl(url, {
+      cache: 'no-store',
+      credentials: 'omit',
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) return unavailableResult('Desk Overlay public artifact was unavailable.');
+    return parseDeskOverlay(await response.json());
+  } catch {
+    return unavailableResult('Desk Overlay public artifact could not be loaded.');
+  }
+}
+
+/** Validates an untrusted public artifact before it reaches globe rendering. */
+export function parseDeskOverlay(payload: unknown): DeskOverlayResult {
+  if (!isRecord(payload)
+    || payload.schema_version !== 'desk-world-case-files/v1'
+    || payload.source !== 'desk_worldmonitor_context_hub'
+    || !isRecord(payload.data_quality)
+    || !hasSafeFlags(payload.safety)
+    || !Array.isArray(payload.case_files)) {
+    return dataCheckResult('Desk Overlay artifact was malformed or did not preserve context-only safety flags.');
+  }
+
+  const status = normalizeStatus(payload.data_quality.status);
+  const caveats = stringList(payload.data_quality.caveats);
+  if (status !== 'ok') {
+    return {
+      status,
+      generatedAt: stringOrNull(payload.generated_at),
+      caveats,
+      caseFiles: [],
+    };
+  }
+
+  return {
+    status,
+    generatedAt: stringOrNull(payload.generated_at),
+    caveats,
+    caseFiles: payload.case_files
+      .map(normalizeCaseFile)
+      .filter((row): row is DeskOverlayCaseFile => row !== null)
+      .slice(0, 8),
+  };
+}
+
+function normalizeCaseFile(value: unknown): DeskOverlayCaseFile | null {
+  if (!isRecord(value) || !hasSafeFlags(value)) return null;
+  const id = stringOrNull(value.id);
+  const title = stringOrNull(value.title);
+  const summary = stringOrNull(value.summary);
+  if (!id || !title || !summary) return null;
+
+  return {
+    id,
+    category: stringOrNull(value.category) ?? 'general',
+    severity: value.severity === 'elevated' ? 'elevated' : 'observe',
+    title,
+    summary,
+    impactAreas: stringList(value.impact_areas),
+    observedAt: stringOrNull(value.observed_at),
+    evidenceUrl: safeHttpUrl(value.evidence_url),
+    deskUrl: safeDeskUrl(value.desk_url),
+    mapLocation: parseMapLocation(value.map_location),
+  };
+}
+
+function parseMapLocation(value: unknown): DeskOverlayMapLocation | null {
+  if (!isRecord(value)) return null;
+  const label = stringOrNull(value.label);
+  const lat = finiteNumber(value.lat);
+  const lon = finiteNumber(value.lon);
+  if (!label || lat === null || lon === null || lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+  return { label, lat, lon };
+}
+
+function safeHttpUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeDeskUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = new URL(value);
+    return parsed.origin === 'https://dev.westkite.dev' && parsed.pathname.startsWith('/desk/') ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasSafeFlags(value: unknown): boolean {
+  return isRecord(value) && Object.entries(REQUIRED_SAFETY_FLAGS).every(([key, expected]) => value[key] === expected);
+}
+
+function normalizeStatus(value: unknown): DeskOverlayStatus {
+  return value === 'ok' || value === 'baseline' || value === 'partial' || value === 'data_check' ? value : 'data_check';
+}
+
+function unavailableResult(caveat: string): DeskOverlayResult {
+  return { status: 'unavailable', generatedAt: null, caveats: [caveat], caseFiles: [] };
+}
+
+function dataCheckResult(caveat: string): DeskOverlayResult {
+  return { status: 'data_check', generatedAt: null, caveats: [caveat], caseFiles: [] };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((item) => item.trim())
+    : [];
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}

--- a/tests/desk-overlay-contract.test.mts
+++ b/tests/desk-overlay-contract.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { loadDeskOverlay, parseDeskOverlay } from '../src/services/desk-overlay';
+import { loadDeskOverlay, parseDeskOverlay, parseDeskOverlayCaseId } from '../src/services/desk-overlay';
 
 const SAFE_FLAGS = {
   context_only: true,
@@ -71,5 +71,12 @@ describe('Desk Overlay public contract', () => {
     assert.equal(result.status, 'ok');
     assert.equal(init?.credentials, 'omit');
     assert.equal(init?.cache, 'no-store');
+  });
+
+  it('accepts only bounded Desk case IDs for a globe deep link', () => {
+    assert.equal(parseDeskOverlayCaseId('?desk_case=energy%3Ahormuz-supply-risk'), 'energy:hormuz-supply-risk');
+    assert.equal(parseDeskOverlayCaseId('?desk_case=market%3AUSD%2FKRW'), 'market:USD/KRW');
+    assert.equal(parseDeskOverlayCaseId('?desk_case=../private'), null);
+    assert.equal(parseDeskOverlayCaseId(`?desk_case=${'a'.repeat(129)}`), null);
   });
 });

--- a/tests/desk-overlay-contract.test.mts
+++ b/tests/desk-overlay-contract.test.mts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { loadDeskOverlay, parseDeskOverlay } from '../src/services/desk-overlay';
+
+const SAFE_FLAGS = {
+  context_only: true,
+  research_only: true,
+  use_as_execution_signal: false,
+  paper_live_approval_signal: false,
+  no_broker_connection: true,
+  no_order_submission: true,
+  no_live_orders: true,
+  no_actual_trades: true,
+};
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: 'desk-world-case-files/v1',
+    source: 'desk_worldmonitor_context_hub',
+    generated_at: '2026-07-27T06:00:00.000Z',
+    data_quality: { status: 'ok', caveats: [] },
+    safety: SAFE_FLAGS,
+    case_files: [
+      {
+        id: 'energy:hormuz-supply-risk',
+        category: 'energy',
+        severity: 'elevated',
+        title: 'Hormuz supply risk',
+        summary: 'Energy disruption context changed.',
+        impact_areas: ['energy', 'krw'],
+        observed_at: '2026-07-27T05:59:00.000Z',
+        evidence_url: 'https://evidence.example.test/hormuz',
+        desk_url: 'https://dev.westkite.dev/desk/cockpit#worldmonitor-context',
+        map_location: { label: 'Strait of Hormuz', lat: 26.566, lon: 56.25 },
+        ...SAFE_FLAGS,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('Desk Overlay public contract', () => {
+  it('keeps only safe context-only geographic pins and trusted Desk drill-down URLs', () => {
+    const result = parseDeskOverlay(payload());
+
+    assert.equal(result.status, 'ok');
+    assert.equal(result.caseFiles.length, 1);
+    assert.deepEqual(result.caseFiles[0]?.mapLocation, { label: 'Strait of Hormuz', lat: 26.566, lon: 56.25 });
+    assert.equal(result.caseFiles[0]?.deskUrl, 'https://dev.westkite.dev/desk/cockpit#worldmonitor-context');
+  });
+
+  it('fails closed on unsafe safety flags and strips untrusted external links', () => {
+    const unsafe = parseDeskOverlay(payload({ safety: { ...SAFE_FLAGS, no_order_submission: false } }));
+    const sanitized = parseDeskOverlay(payload({ case_files: [{ ...payload().case_files[0], evidence_url: 'javascript:alert(1)', desk_url: 'https://evil.example.test/' }] }));
+
+    assert.equal(unsafe.status, 'data_check');
+    assert.deepEqual(unsafe.caseFiles, []);
+    assert.equal(sanitized.caseFiles[0]?.evidenceUrl, null);
+    assert.equal(sanitized.caseFiles[0]?.deskUrl, null);
+  });
+
+  it('fetches the public artifact without ambient credentials', async () => {
+    let init: RequestInit | undefined;
+    const result = await loadDeskOverlay({
+      fetchImpl: async (_url, requestInit) => {
+        init = requestInit;
+        return new Response(JSON.stringify(payload()), { status: 200, headers: { 'content-type': 'application/json' } });
+      },
+    });
+
+    assert.equal(result.status, 'ok');
+    assert.equal(init?.credentials, 'omit');
+    assert.equal(init?.cache, 'no-store');
+  });
+});

--- a/tests/desk-overlay-globe-renderer.test.mts
+++ b/tests/desk-overlay-globe-renderer.test.mts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const readSrc = (path: string) => readFileSync(resolve(root, path), 'utf-8');
+
+describe('Desk Overlay globe renderer', () => {
+  const src = readSrc('src/components/GlobeMap.ts');
+
+  it('loads only the public validated Desk Overlay and retains it as a distinct marker kind', () => {
+    assert.match(src, /import \{ loadDeskOverlay, type DeskOverlayCaseFile(?:, type DeskOverlayResult)? \} from '@\/services\/desk-overlay';/);
+    assert.match(src, /interface DeskOverlayMarker extends BaseMarker[\s\S]*_kind: 'deskOverlay'/);
+    assert.match(src, /this\.deskOverlayMarkers/);
+    assert.match(src, /void this\.loadDeskOverlay\(\)/);
+  });
+
+  it('opens a dedicated context-only Desk drawer from an overlay pin instead of treating it as a trade action', () => {
+    assert.match(src, /private openDeskOverlayDrawer\(caseFile: DeskOverlayCaseFile\)/);
+    assert.match(src, /주문·승인 신호 아님/);
+    assert.match(src, /this\.deskOverlayDrawerEl/);
+    assert.match(src, /d\._kind === 'deskOverlay'/);
+  });
+
+  it('keeps public artifact failure non-fatal and never invents a point for global-only rows', () => {
+    assert.match(src, /loadDeskOverlay\(\)[\s\S]*\.catch\(\(\) =>/);
+    assert.match(src, /\.filter\(\(caseFile\) => caseFile\.mapLocation\)/);
+  });
+});

--- a/tests/desk-overlay-globe-renderer.test.mts
+++ b/tests/desk-overlay-globe-renderer.test.mts
@@ -12,7 +12,7 @@ describe('Desk Overlay globe renderer', () => {
   const src = readSrc('src/components/GlobeMap.ts');
 
   it('loads only the public validated Desk Overlay and retains it as a distinct marker kind', () => {
-    assert.match(src, /import \{ loadDeskOverlay, type DeskOverlayCaseFile(?:, type DeskOverlayResult)? \} from '@\/services\/desk-overlay';/);
+    assert.match(src, /import \{[^}]*loadDeskOverlay[^}]*\} from '@\/services\/desk-overlay';/);
     assert.match(src, /interface DeskOverlayMarker extends BaseMarker[\s\S]*_kind: 'deskOverlay'/);
     assert.match(src, /this\.deskOverlayMarkers/);
     assert.match(src, /void this\.loadDeskOverlay\(\)/);
@@ -28,5 +28,15 @@ describe('Desk Overlay globe renderer', () => {
   it('keeps public artifact failure non-fatal and never invents a point for global-only rows', () => {
     assert.match(src, /loadDeskOverlay\(\)[\s\S]*\.catch\(\(\) =>/);
     assert.match(src, /\.filter\(\(caseFile\) => caseFile\.mapLocation\)/);
+  });
+
+  it('opens a validated Desk deep link directly in globe mode and focuses the requested case', () => {
+    const mapContainer = readSrc('src/components/MapContainer.ts');
+
+    assert.match(mapContainer, /parseDeskOverlayCaseId\(window\.location\.search\)/);
+    assert.match(mapContainer, /preferGlobe \|\| parseDeskOverlayCaseId\(window\.location\.search\)/);
+    assert.match(src, /this\.deskOverlayRequestedCaseId/);
+    assert.match(src, /this\.openDeskOverlayDrawer\(requestedCase\)/);
+    assert.match(src, /this\.globe\.pointOfView\(/);
   });
 });


### PR DESCRIPTION
## Summary
- load validated Desk WorldMonitor case files as a distinct context-only globe overlay
- support safe `?desk_case=` deep links that open the requested globe case drawer
- preserve non-fatal fallback behavior when the Desk public artifact is unavailable

## Verification
- `tsx --test tests/desk-overlay-contract.test.mts tests/desk-overlay-globe-renderer.test.mts`
- `npm run typecheck`
- Biome lint for touched files
- `npm run lint:safe-html`
- `vite build`