### PR TITLE
fix(intel): give history ingestion a durable health signal (#5736)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -346,6 +346,16 @@ const STANDALONE_KEYS = {
   forecastBets:                  'forecast:bets:history:v1',
   forecastFunnel:                'forecast:funnel:health:v1',
   researchArxivHnTrending:       'research:arxiv:v1:cs.AI::50',
+  // #5736 — historical-intelligence ingest health, one record per collector.
+  // These are NOT the collectors' canonical keys: scripts/_seed-history.mjs
+  // appends to the Convex intel-history store fail-open, so a permanently
+  // broken relay leg (missing RELAY_SHARED_SECRET, rejecting relay, dead
+  // embedder) left every canonical key fresh and the store empty. The paired
+  // seed-meta below carries the last HEALTHY append, so "history stopped
+  // accumulating" ages into STALE_SEED while canonical publication stays OK.
+  intelHistoryIngestConflictAcled:    'intel-history:ingest-health:conflict:acled-intel:v1',
+  intelHistoryIngestMilitaryCrossStrait: 'intel-history:ingest-health:military:cross-strait-activity:v1',
+  intelHistoryIngestEnergyIntelligence:  'intel-history:ingest-health:energy:intelligence:v1',
 };
 
 const SEED_META = {
@@ -620,6 +630,16 @@ const SEED_META = {
   fossilElectricityShare:  { key: 'seed-meta:resilience:fossil-electricity-share',  maxStaleMin: 11520 },
   powerLosses:             { key: 'seed-meta:resilience:power-losses',              maxStaleMin: 11520 },
   webcams:                 { key: 'seed-meta:webcam:cameras:geo',                   maxStaleMin: 1440 }, // seed-webcams writes 24h geo/meta keys plus a 30h active pointer; stale at 24h before the layer goes blank.
+  // #5736 — history-ingest freshness per collector. `fetchedAt` here is the
+  // last HEALTHY append (success, or a correctly-detected unconfigured run),
+  // NEVER the last attempt, so a relay that rejects every chunk ages this out
+  // while the collector's own seed-meta stays fresh. Budgets mirror each
+  // collector's canonical maxStaleMin above — the hook runs once per successful
+  // publish, so a tighter budget would alarm on the parent's cadence, not on
+  // history. Keep in step with api/seed-health.js (intervalMin = maxStaleMin/2).
+  intelHistoryIngestConflictAcled:       { key: 'seed-meta:intel-history:conflict:acled-intel',            maxStaleMin: 38 },  // mirrors acledIntel
+  intelHistoryIngestMilitaryCrossStrait: { key: 'seed-meta:intel-history:military:cross-strait-activity',  maxStaleMin: 720 }, // mirrors crossStraitActivity
+  intelHistoryIngestEnergyIntelligence:  { key: 'seed-meta:intel-history:energy:intelligence',             maxStaleMin: 720 }, // mirrors energyIntelligence
 };
 
 // Iran-events sunset: when disabled (default), drop it from all health
@@ -720,6 +740,14 @@ const ON_DEMAND_KEYS = new Set([
                                    // behind). STALE_SEED still fires if data goes stale after first seed.
                                    // Remove from this set after ~7 days of clean cron runs so
                                    // never-provisioned Railway promotes EMPTY_ON_DEMAND → EMPTY (CRIT).
+  // #5736 deployment-order bridge, activation-gated like chinaCoverage: Vercel
+  // ships this registry the moment the PR merges, but the record only exists
+  // after the collector's next Railway tick (up to 6h for energy/intelligence).
+  // Softening is revoked the instant the durable marker appears — after the
+  // first report, an absent record is EMPTY and a stalled one is STALE_SEED.
+  'intelHistoryIngestConflictAcled',
+  'intelHistoryIngestMilitaryCrossStrait',
+  'intelHistoryIngestEnergyIntelligence',
 ]);
 
 // Legacy broad empty-data exemptions. classifyKey uses this set in both the
@@ -737,6 +765,12 @@ const ACTIVATION_MARKERS = {
   chinaCoverage: 'seed-activated:health:china-coverage',
   newsFeedHealth: 'seed-activated:news:feed-health',
   newsRecallBenchmark: 'seed-activated:news:recall-benchmark',
+  // Written by scripts/_seed-history.mjs on every ingest-health report,
+  // including an `unconfigured` one — "the hook ran" is the activation signal,
+  // not "the relay answered". See historyIngestActivationKey there.
+  intelHistoryIngestConflictAcled: 'seed-activated:intel-history:conflict:acled-intel',
+  intelHistoryIngestMilitaryCrossStrait: 'seed-activated:intel-history:military:cross-strait-activity',
+  intelHistoryIngestEnergyIntelligence: 'seed-activated:intel-history:energy:intelligence',
 };
 
 const EMPTY_DATA_OK_KEYS = new Set([
@@ -808,6 +842,14 @@ const ZERO_RECORD_DATA_OK_KEYS = new Set([
   // exists after a successful query, but a quiet 90-day window can validly
   // contain zero owned-category events.
   'chinaCorporateDisclosures',
+  // #5736 ingest-health records. `recordCount` is the volume the relay accepted
+  // on the last successful append, and zero is legitimate — a run whose records
+  // were all deduped, or one with no noteworthy records at all. The record key
+  // itself must still exist, so this is the NARROW set: a vanished record is a
+  // real gap, not a quiet period.
+  'intelHistoryIngestConflictAcled',
+  'intelHistoryIngestMilitaryCrossStrait',
+  'intelHistoryIngestEnergyIntelligence',
 ]);
 
 // Cascade groups: if any key in the group has data, all empty siblings are OK.
@@ -1703,4 +1745,8 @@ export const __testing__ = {
   EMPTY_DATA_OK_KEYS,
   MISSING_DATA_IS_FAILURE_KEYS,
   ZERO_RECORD_DATA_OK_KEYS,
+  // Exposed so a registration test can prove a key's deployment-order softening
+  // is actually wired — membership here is what keeps a not-yet-published key
+  // out of CRIT, and nothing could assert it before (#5736).
+  ON_DEMAND_KEYS,
 };

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -165,6 +165,31 @@ const SEED_DOMAINS = {
   'economic:eurostat-industrial-production': { key: 'seed-meta:economic:eurostat-industrial-production', intervalMin: 3600 }, // daily cron, monthly data; intervalMin = health.js maxStaleMin / 2 (7200 / 2)
   'resilience:recovery:reexport-share':   { key: 'seed-meta:resilience:recovery:reexport-share',   intervalMin: 43200 }, // monthly bundle cron (30d); intervalMin*2 = 60d matches health.js maxStaleMin
   'resilience:recovery:sovereign-wealth': { key: 'seed-meta:resilience:recovery:sovereign-wealth', intervalMin: 43200 }, // monthly bundle cron (30d); intervalMin*2 = 60d matches health.js maxStaleMin
+  // #5736 — historical-intelligence ingest health. Distinct from each
+  // collector's own seed key above: scripts/_seed-history.mjs appends to the
+  // Convex intel-history store fail-open, so a permanently broken relay leg
+  // used to leave the collector green and the store empty. `fetchedAt` on these
+  // keys is the last HEALTHY append, so a prolonged rejection reads `stale`
+  // here while the collector stays `ok`; `sourceState: 'unavailable'` reports
+  // an un-provisioned relay as `not_configured` rather than an eternal warn.
+  // activationKey: the record only exists after the collector's next Railway
+  // tick, so absence before the first report is pending-activation, not a
+  // degraded 503. intervalMin*2 mirrors api/health.js maxStaleMin.
+  'intel-history:conflict:acled-intel': {
+    key: 'seed-meta:intel-history:conflict:acled-intel',
+    intervalMin: 19,
+    activationKey: 'seed-activated:intel-history:conflict:acled-intel',
+  },
+  'intel-history:military:cross-strait-activity': {
+    key: 'seed-meta:intel-history:military:cross-strait-activity',
+    intervalMin: 360,
+    activationKey: 'seed-activated:intel-history:military:cross-strait-activity',
+  },
+  'intel-history:energy:intelligence': {
+    key: 'seed-meta:intel-history:energy:intelligence',
+    intervalMin: 360,
+    activationKey: 'seed-activated:intel-history:energy:intelligence',
+  },
 };
 
 // Iran-events sunset (war ended 2026-07); mirrors api/health.js. Default OFF:
@@ -441,6 +466,16 @@ export default async function handler(req) {
     };
     if (cfg.minRecordCount != null) seeds[domain].minRecordCount = cfg.minRecordCount;
     if (probe) seeds[domain].dataProbe = probe;
+    // #5736: without this, `status: "error"` names no cause and an operator has
+    // to read raw Redis to learn WHY — which is the log-diving the issue exists
+    // to end. Bounded, producer-controlled vocabulary only (`http_401`,
+    // `budget_exhausted`, `config_removed`, a clamped error-class name); the
+    // free-text `lastErrorReason` carries a relay-controlled body snippet and
+    // is deliberately NOT echoed. Emitted only when present, so every existing
+    // seed entry keeps its exact shape.
+    if (typeof meta.lastErrorCode === 'string' && meta.lastErrorCode) {
+      seeds[domain].lastErrorCode = meta.lastErrorCode;
+    }
   }
 
   const overall = missingCount > 0 ? 'degraded' : staleCount > 0 ? 'warning' : 'healthy';

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -265,6 +265,28 @@ A seed is considered stale when its age exceeds **2x the configured interval**. 
 | GPS jamming, displacement | 360 | 720 |
 | Iran events, UCDP | 210-5040 | 420-10080 |
 
+### History ingestion (`intel-history:*`)
+
+Domains prefixed `intel-history:` do **not** describe a seeder's canonical publish. They track whether that collector's post-publish append to the historical intelligence store is still landing:
+
+| Domain | Tracks |
+|--------|--------|
+| `intel-history:conflict:acled-intel` | history appends from `seed-conflict-intel` |
+| `intel-history:military:cross-strait-activity` | history appends from `seed-cross-strait-activity` |
+| `intel-history:energy:intelligence` | history appends from `seed-energy-intelligence` |
+
+The append is fail-open by design — the canonical publish has already committed when it runs, so a failure must never fail the run. That means the collector's own entry (`conflict:acled-intel`, …) stays `ok` while history silently stops accumulating. These entries are the separate signal:
+
+- `fetchedAt` is the last **healthy** append, never the last attempt. A run that reached the relay advances it; a run that delivered nothing (every chunk rejected, or the wall-clock budget died before the first request) does not. So a broken relay freezes it and the entry goes `stale` on the ordinary 2x-interval rule.
+- `status: "error"` means the append failed on two consecutive runs — or, on the very first tick, that a relay credential present during an earlier successful append has since been removed.
+- `lastErrorCode` names the cause when there is one: `http_401`, `budget_exhausted`, `all_chunks_failed`, `config_removed`, or a clamped error-class name. Absent when the ingest has never failed.
+- `status: "not_configured"` means this deployment has **never** had relay credentials. It is visible but never an alarm — no operator action clears it except provisioning the relay. Losing credentials after a successful append is not this state; it reports `error` with `lastErrorCode: "config_removed"`.
+- `recordCount` is the volume the relay accepted on the last successful append. Zero is valid: a run whose records were all deduped still proves the pipeline works.
+
+The richer per-run detail — `lastErrorReason`, `consecutiveFailures`, `missingConfig`, and the inserted/deduped/abandoned counts — is **not** returned by either endpoint. It lives in the Redis record `intel-history:ingest-health:<domain>:<resource>:v1`, which the endpoints project from.
+
+A `stale` or `error` here alongside an `ok` collector means canonical data is fine and the history store is the thing to investigate.
+
 ### Example Request
 
 ```bash

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -205,6 +205,28 @@ curl -o /dev/null -s -w "%{http_code}" "https://api.worldmonitor.app/api/health?
 | GPS 干扰、流离失所 | 360 | 720 |
 | 伊朗事件、UCDP | 210-5040 | 420-10080 |
 
+### 历史情报写入（`intel-history:*`）
+
+以 `intel-history:` 为前缀的领域**不**描述种子的规范化发布，而是跟踪该采集器在发布之后向历史情报库追加数据的链路是否仍然正常：
+
+| 领域 | 跟踪对象 |
+|--------|--------|
+| `intel-history:conflict:acled-intel` | 来自 `seed-conflict-intel` 的历史追加 |
+| `intel-history:military:cross-strait-activity` | 来自 `seed-cross-strait-activity` 的历史追加 |
+| `intel-history:energy:intelligence` | 来自 `seed-energy-intelligence` 的历史追加 |
+
+该追加按设计为「失败即放行」：它运行时规范化发布已经提交，因此追加失败绝不能让整次运行失败。这意味着采集器自身的条目（`conflict:acled-intel` 等）会保持 `ok`，而历史数据却在悄悄停止累积。这些条目就是那个独立信号：
+
+- `fetchedAt` 是最近一次**成功**追加的时间，而不是最近一次尝试的时间。抵达了中继的运行会推进它；什么都没送达的运行（所有分块被拒，或整体时间预算在首个请求发出前就耗尽）则不会。因此中继一旦损坏该时间戳就会冻结，于是条目按通常的 2 倍间隔规则变为 `stale`。
+- `status: "error"` 表示追加已连续两次运行失败——或者在首个刻度上，表示此前成功追加时存在的中继凭据现已被移除。
+- `lastErrorCode` 在存在失败原因时给出原因：`http_401`、`budget_exhausted`、`all_chunks_failed`、`config_removed`，或一个截断后的错误类名。若该写入链路从未失败过则不存在此字段。
+- `status: "not_configured"` 表示该部署**从未**拥有过中继凭据。它可见但绝不告警——除了配置中继之外，没有任何运维操作能消除该状态。成功追加之后再丢失凭据不属于此状态，那会报告 `error` 并附带 `lastErrorCode: "config_removed"`。
+- `recordCount` 是最近一次成功追加时中继接受的记录量。零是合法值：一次记录全部被去重的运行同样证明链路是通的。
+
+更细粒度的单次运行详情——`lastErrorReason`、`consecutiveFailures`、`missingConfig`，以及写入/去重/放弃的计数——**不会**由任一端点返回。它们保存在 Redis 记录 `intel-history:ingest-health:<domain>:<resource>:v1` 中，端点正是从该记录投影而来。
+
+若此处为 `stale` 或 `error` 而采集器条目为 `ok`，说明规范化数据没有问题，需要排查的是历史情报库。
+
 ### 示例请求
 
 ```bash

--- a/scripts/_seed-history.mjs
+++ b/scripts/_seed-history.mjs
@@ -18,6 +18,14 @@
  *      try/catch — this module deliberately does not swallow real
  *      failures, so the seeder decides whether to log or ignore.
  *
+ * Because of (1) and (2) the log stream was, until #5736, the ONLY place a
+ * broken history pipeline showed up: a missing RELAY_SHARED_SECRET or a
+ * systematically rejecting relay produced a healthy-looking seed run forever
+ * while the store received nothing. `recordHistoryIngestHealth` closes that
+ * hole by persisting a durable per-(domain, resource) ingest-health record on
+ * BOTH the success and the failure path, separate from the seeder's own
+ * seed-meta (which must keep reflecting canonical publication only).
+ *
  * Boundary rules: `scripts/**` ships to Railway via nixpacks with
  * `root_dir=scripts`, so this file may only import from within
  * `scripts/`, `node:*`, and bare packages in scripts/package.json.
@@ -326,16 +334,22 @@ async function postHistoryChunk({
  * seeder, so those are the parameters; the failure semantics are not
  * per-seeder policy and are deliberately not overridable.
  *
- * The returned hook keeps runSeed's `(data, meta)` shape with the
- * appender in a third, injectable slot for tests.
+ * The returned hook keeps runSeed's `(data, meta)` shape with both
+ * injectable seams — the appender and the ingest-health recorder — in a
+ * third options slot for tests.
  */
 export function makeSeedHistoryAfterPublish({ domain, resource, buildRecords }) {
-  return async function seedHistoryAfterPublish(data, meta, append = appendSeedHistory) {
+  return async function seedHistoryAfterPublish(data, meta, deps = {}) {
+    const append = deps.append ?? appendSeedHistory;
+    const recordHealth = deps.recordHealth ?? recordHistoryIngestHealth;
+    const runId = String(meta?.runId ?? '');
+    let result = null;
+    let error = null;
     try {
-      const result = await append({
+      result = await append({
         domain,
         resource,
-        runId: String(meta?.runId ?? ''),
+        runId,
         records: buildRecords(data),
       });
       if (result?.skipped !== 'unconfigured') {
@@ -351,11 +365,370 @@ export function makeSeedHistoryAfterPublish({ domain, resource, buildRecords }) 
         );
       }
     } catch (err) {
+      error = err;
       console.warn(
         `  [intel-history] ${domain}/${resource} append failed (non-fatal): ${err?.message || err}`,
       );
     }
+
+    // #5736. The outcome above — including "the relay refused every chunk" and
+    // "this deployment has no relay credentials" — is otherwise visible only in
+    // the log stream. Persist it so an operator surface can see it. Fail-open
+    // for the same reason as the append itself: runSeed's freshness write is
+    // still ahead of us and must not be skipped.
+    try {
+      await recordHealth({ domain, resource, runId, result, error });
+    } catch (err) {
+      console.warn(
+        `  [intel-history] ${domain}/${resource} ingest-health record failed (non-fatal): ${err?.message || err}`,
+      );
+    }
   };
+}
+
+// ── History-ingest health (#5736) ────────────────────────────────────────────
+//
+// The seeder's own `seed-meta:<domain>:<resource>` describes canonical
+// publication and MUST NOT move because history failed — that conflation is the
+// scripts/seed-gdelt-intel.mjs:286 hazard. So ingest health gets its own pair of
+// keys per (domain, resource):
+//
+//   intel-history:ingest-health:<domain>:<resource>:v1
+//       the durable record: current state, last success, last error, and the
+//       consecutive-failure count. Registered as a /api/health data key.
+//   seed-meta:intel-history:<domain>:<resource>
+//       the freshness projection /api/health + /api/seed-health classify. Its
+//       `fetchedAt` is the last HEALTHY observation, never the last attempt, so
+//       "no successful append in N intervals" ages into STALE_SEED on its own.
+//
+// Both surfaces read `sourceState` for the three states the issue asks for:
+//   'unavailable' → NOT_CONFIGURED / not_configured (visible, never an alarm —
+//                   no operator action clears it except opting in)
+//   'degraded'    → SEED_ERROR / error (warn)
+//   'ok'          → OK, subject to the ordinary staleness budget
+
+export const HISTORY_INGEST_SOURCE_VERSION = 'intel-history-ingest-v1';
+
+// Matches writeFreshnessMetadata's 7-day seed-meta floor so a record outlives
+// any single missed run of even the slowest history collector (6h cron).
+export const HISTORY_INGEST_TTL_SECONDS = 86_400 * 7;
+
+/**
+ * Consecutive failed runs before `sourceState` escalates to 'degraded'.
+ *
+ * The record flips to `state: 'failing'` on the FIRST failure — that is simply
+ * what happened — but one failed run is already 3 relay attempts inside a
+ * single seed tick, and escalating on it would let one bad tick warn for a
+ * whole cron interval (6h for energy/intelligence). Two consecutive runs is
+ * the "prolonged" the issue asks to alarm on. Staleness is the independent
+ * second alarm: `fetchedAt` stops advancing from the first failure onward.
+ */
+export const HISTORY_INGEST_ALARM_AFTER_FAILURES = 2;
+
+// Deliberately tighter than the module's other timeouts and without retries:
+// these two round-trips sit AFTER the canonical publish and BEFORE runSeed's
+// freshness write, the same window HISTORY_TOTAL_BUDGET_MS exists to bound.
+const HISTORY_INGEST_REDIS_TIMEOUT_MS = 2_000;
+const HISTORY_INGEST_REASON_MAX_CHARS = 200;
+const HISTORY_INGEST_CODE_MAX_CHARS = 64;
+
+export function historyIngestHealthKey(domain, resource) {
+  return `intel-history:ingest-health:${domain}:${resource}:v1`;
+}
+
+export function historyIngestMetaKey(domain, resource) {
+  return `seed-meta:intel-history:${domain}:${resource}`;
+}
+
+/**
+ * Durable "this ingest has reported at least once" marker, written with NO TTL.
+ * Both health surfaces soften an absent record while the marker is missing, so
+ * a Vercel deploy that lands before the first Railway tick does not alarm; once
+ * the marker exists the softening is revoked forever (#4927 convention).
+ */
+export function historyIngestActivationKey(domain, resource) {
+  return `seed-activated:intel-history:${domain}:${resource}`;
+}
+
+/**
+ * Short, groupable code for the failure. Prefers the transport-level facts the
+ * relay/embedder attach (`status`, `budgetExhausted`) because those are what an
+ * operator acts on; falls back to the error class name so an unfamiliar failure
+ * still gets a stable code rather than a free-text blob.
+ */
+export function historyIngestErrorCode(error) {
+  if (!error) return null;
+  if (error.budgetExhausted) return 'budget_exhausted';
+  if (Number.isFinite(error.status)) return `http_${error.status}`;
+  const name = typeof error.name === 'string' && error.name ? error.name : 'Error';
+  // Clamped because this one IS echoed by /api/seed-health (unlike the free-text
+  // `lastErrorReason`, which carries a relay-controlled body snippet and stays
+  // in Redis only). Every current producer sets a fixed class name, but an
+  // unbounded code would be a bounded-response-shape regression waiting for the
+  // first caller that throws something exotic.
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase().slice(0, HISTORY_INGEST_CODE_MAX_CHARS);
+}
+
+/**
+ * Reduce one append attempt — the resolved value or the thrown error — to the
+ * outcome the projection consumes. Pure.
+ */
+export function describeHistoryAppendOutcome(result, error) {
+  if (error) {
+    return {
+      state: 'failing',
+      errorCode: historyIngestErrorCode(error),
+      errorReason: trimmedString(
+        String(error?.message ?? error ?? ''),
+        HISTORY_INGEST_REASON_MAX_CHARS,
+      ),
+    };
+  }
+  if (result?.skipped === 'unconfigured') {
+    return {
+      state: 'unconfigured',
+      missing: Array.isArray(result.missing) ? result.missing : [],
+    };
+  }
+
+  const chunks = Number(result?.chunks) || 0;
+  const abandoned = Number(result?.abandoned) || 0;
+  const failedChunks = Number(result?.failedChunks) || 0;
+
+  // `appendSeedHistory` RESOLVES rather than throws when its wall-clock budget
+  // dies before a single chunk is POSTed — the embedding phase overran, or the
+  // relay was slow enough that the first attempt ate the budget. It only throws
+  // on `chunks === 0 && failedChunks > 0`. Records were offered and none
+  // arrived, so folding that into `healthy` would advance `fetchedAt` on a run
+  // that delivered nothing: exactly the silent-pass this record exists to close
+  // (a permanently degraded relay would report OK forever).
+  //
+  // A run with NO candidate records is a different thing and stays healthy —
+  // nothing was offered, so nothing was lost.
+  if (chunks === 0 && (abandoned > 0 || failedChunks > 0)) {
+    return {
+      state: 'failing',
+      errorCode: abandoned > 0 ? 'budget_exhausted' : 'all_chunks_failed',
+      errorReason: `no chunk reached the relay (abandoned ${abandoned}, failed ${failedChunks})`,
+    };
+  }
+
+  return {
+    state: 'healthy',
+    inserted: Number(result?.inserted) || 0,
+    deduped: Number(result?.skipped) || 0,
+    // Relay-side tombstone hits (#5743). Not part of `lastAcceptedRecords` —
+    // a retraction REMOVES a row rather than accepting one — but a nonzero
+    // count belongs in the durable record for the same reason it is logged:
+    // it means a retraction is still fighting a feed that keeps re-serving
+    // the item.
+    retracted: Number(result?.retracted) || 0,
+    chunks,
+    abandoned,
+    failedChunks,
+  };
+}
+
+function finiteOr(value, fallback = null) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * Fold one outcome into the previous record. Pure — no clock, no network — so
+ * the state machine is testable without Redis.
+ *
+ * `lastHealthyAt` (mirrored to the meta's `fetchedAt`) advances on a successful
+ * append AND on an unconfigured run of a deployment that never succeeded. The
+ * second case matters: a genuinely un-provisioned deployment must read as
+ * NOT_CONFIGURED forever rather than decaying into an eternal staleness warn
+ * nobody can clear. Losing the credential AFTER a success is the opposite —
+ * see `regressedToUnconfigured` below.
+ *
+ * @param {object|null} previous  last persisted record, or null on first write
+ * @param {{domain: string, resource: string, runId?: string, at: number,
+ *   outcome: ReturnType<typeof describeHistoryAppendOutcome>}} observation
+ * @returns {{record: object, meta: object}}
+ */
+export function projectHistoryIngestHealth(previous, { domain, resource, runId, at, outcome }) {
+  const prev = previous && typeof previous === 'object' && !Array.isArray(previous) ? previous : null;
+  const failing = outcome.state === 'failing';
+  const healthy = outcome.state === 'healthy';
+
+  // A deployment that has appended before is PROVISIONED. Losing the relay
+  // credential afterwards is a regression, not an opt-out — and it is the
+  // issue's own headline scenario ("a missing RELAY_SHARED_SECRET produces a
+  // healthy-looking seed run forever"). Without this branch, `unconfigured`
+  // short-circuits to NOT_CONFIGURED — an `ok` bucket — while `fetchedAt` keeps
+  // advancing, so neither alarm can fire and the fix would relocate the bug
+  // rather than close it. `lastSuccessAt` is what distinguishes the two: a
+  // never-provisioned deployment has none and keeps the silent path.
+  const regressedToUnconfigured =
+    outcome.state === 'unconfigured' && finiteOr(prev?.lastSuccessAt) != null;
+
+  // A run that reached the relay but still lost records to failed or abandoned
+  // chunks counts toward the streak. It is NOT a clean run: a collector losing
+  // chunks on every tick is losing history just as surely as one that cannot
+  // reach the relay at all, and only counting total failures would leave that
+  // at zero forever. `fetchedAt` still advances — the relay demonstrably works,
+  // so the honest report is "reachable, but dropping records", not "stale".
+  const lossy = healthy && (outcome.failedChunks > 0 || outcome.abandoned > 0);
+
+  const alarming = failing || regressedToUnconfigured;
+  const priorFailures = finiteOr(prev?.consecutiveFailures, 0);
+  const consecutiveFailures = alarming || lossy ? priorFailures + 1 : 0;
+  const lastHealthyAt = alarming ? finiteOr(prev?.lastHealthyAt) : at;
+  const lastSuccessAt = healthy ? at : finiteOr(prev?.lastSuccessAt);
+  // Held across failures so /api/health keeps reporting the last known good
+  // volume instead of flipping to a contradictory zero while the relay is down.
+  const lastAcceptedRecords = healthy
+    ? outcome.inserted + outcome.deduped
+    : finiteOr(prev?.lastAcceptedRecords, 0);
+
+  const record = {
+    state: outcome.state,
+    domain,
+    resource,
+    lastAttemptAt: at,
+    lastRunId: runId || null,
+    lastHealthyAt,
+    lastSuccessAt,
+    lastAcceptedRecords,
+    lastInserted: healthy ? outcome.inserted : finiteOr(prev?.lastInserted),
+    lastDeduped: healthy ? outcome.deduped : finiteOr(prev?.lastDeduped),
+    lastRetracted: healthy ? outcome.retracted : finiteOr(prev?.lastRetracted),
+    lastChunks: healthy ? outcome.chunks : finiteOr(prev?.lastChunks),
+    lastAbandoned: healthy ? outcome.abandoned : finiteOr(prev?.lastAbandoned),
+    lastFailedChunks: healthy ? outcome.failedChunks : finiteOr(prev?.lastFailedChunks),
+    consecutiveFailures,
+    // Retained after recovery: knowing WHAT broke is the whole point of a
+    // post-mortem, and a success only proves the failure stopped.
+    lastErrorAt: alarming ? at : finiteOr(prev?.lastErrorAt),
+    lastErrorCode: failing
+      ? outcome.errorCode
+      : regressedToUnconfigured
+        ? 'config_removed'
+        : (prev?.lastErrorCode ?? null),
+    lastErrorReason: failing
+      ? outcome.errorReason
+      : regressedToUnconfigured
+        ? `relay configuration removed after a successful append (missing: ${outcome.missing.join(', ')})`
+        : (prev?.lastErrorReason ?? null),
+    // Only meaningful while unconfigured; carrying it further would name
+    // variables that are now present.
+    missingConfig: outcome.state === 'unconfigured' ? outcome.missing : null,
+    updatedAt: at,
+  };
+
+  const meta = {
+    // Bare shape, not an envelope: every seed-meta reader parses top-level
+    // (see shouldEnvelopeKey in scripts/_seed-utils.mjs).
+    fetchedAt: lastHealthyAt,
+    recordCount: lastAcceptedRecords,
+    sourceVersion: HISTORY_INGEST_SOURCE_VERSION,
+    // A removed credential escalates on the FIRST tick, with no threshold: the
+    // failure threshold exists to absorb a transient relay blip, and there is
+    // no transient class here — the variable is either configured or it is not.
+    sourceState: regressedToUnconfigured
+      ? 'degraded'
+      : outcome.state === 'unconfigured'
+        ? 'unavailable'
+        : consecutiveFailures >= HISTORY_INGEST_ALARM_AFTER_FAILURES
+          ? 'degraded'
+          : 'ok',
+    consecutiveFailures,
+    lastSuccessAt,
+    lastErrorCode: record.lastErrorCode,
+  };
+
+  return { record, meta };
+}
+
+/**
+ * Read the previous record. Throws on a failed read so the caller skips the
+ * write entirely: rebuilding the record from a lost `previous` would silently
+ * reset the consecutive-failure count and drop `lastSuccessAt` — turning an
+ * Upstash blip into "the relay looks fine again".
+ */
+async function readHistoryIngestRecord({ fetchImpl, url, token, domain, resource }) {
+  const key = historyIngestHealthKey(domain, resource);
+  const resp = await fetchImpl(`${url}/get/${encodeURIComponent(key)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(HISTORY_INGEST_REDIS_TIMEOUT_MS),
+  });
+  if (!resp.ok) throw new Error(`ingest-health GET ${key} failed: HTTP ${resp.status}`);
+  const body = await resp.json();
+  if (!body?.result) return null;
+  try {
+    return JSON.parse(body.result);
+  } catch {
+    // A corrupt record is recoverable — the next write replaces it wholesale.
+    return null;
+  }
+}
+
+async function writeHistoryIngestRecord({ fetchImpl, url, token, domain, resource, record, meta }) {
+  const resp = await fetchImpl(`${url}/pipeline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify([
+      ['SET', historyIngestHealthKey(domain, resource), JSON.stringify(record), 'EX', HISTORY_INGEST_TTL_SECONDS],
+      ['SET', historyIngestMetaKey(domain, resource), JSON.stringify(meta), 'EX', HISTORY_INGEST_TTL_SECONDS],
+      // No TTL: "has ever reported" must outlive the 7-day record.
+      ['SET', historyIngestActivationKey(domain, resource), '1'],
+    ]),
+    signal: AbortSignal.timeout(HISTORY_INGEST_REDIS_TIMEOUT_MS),
+  });
+  if (!resp.ok) throw new Error(`ingest-health pipeline failed: HTTP ${resp.status}`);
+  const results = await resp.json();
+  const failed = Array.isArray(results) ? results.find((entry) => entry?.error) : null;
+  if (failed) throw new Error(`ingest-health pipeline command failed: ${failed.error}`);
+}
+
+/**
+ * Persist one run's history-ingest health. Never throws and never rejects —
+ * this runs inside a fail-open hook, and losing the health record must not cost
+ * the seeder its freshness write.
+ *
+ * @param {{domain: string, resource: string, runId?: string, result?: unknown,
+ *   error?: unknown}} observation
+ * @param {{env?: Record<string, string|undefined>, fetchImpl?: typeof fetch,
+ *   now?: () => number}} [deps]
+ * @returns {Promise<object|null>} the persisted record, or null when skipped
+ */
+export async function recordHistoryIngestHealth({ domain, resource, runId, result, error }, deps = {}) {
+  const env = deps.env ?? process.env;
+  const url = env.UPSTASH_REDIS_REST_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    // Not an error: a local run without Upstash credentials never published a
+    // canonical key either. Warn once so it is not silent.
+    console.warn(
+      `[seed-history] ${domain}/${resource} ingest-health not recorded — no Upstash credentials`,
+    );
+    return null;
+  }
+
+  const fetchImpl = deps.fetchImpl ?? ((...args) => globalThis.fetch(...args));
+  const at = (deps.now ?? (() => Date.now()))();
+  const outcome = describeHistoryAppendOutcome(result, error);
+
+  try {
+    const previous = await readHistoryIngestRecord({ fetchImpl, url, token, domain, resource });
+    const { record, meta } = projectHistoryIngestHealth(previous, {
+      domain,
+      resource,
+      runId,
+      at,
+      outcome,
+    });
+    await writeHistoryIngestRecord({ fetchImpl, url, token, domain, resource, record, meta });
+    return record;
+  } catch (err) {
+    console.warn(
+      `[seed-history] ${domain}/${resource} ingest-health write failed (non-fatal): ${err?.message || err}`,
+    );
+    return null;
+  }
 }
 
 /**
@@ -376,7 +749,7 @@ export function makeSeedHistoryAfterPublish({ domain, resource, buildRecords }) 
  * @param {number} [deps.budgetMs]         aggregate wall-clock budget override
  * @returns {Promise<{inserted: number, skipped: number, retracted: number,
  *   chunks: number, abandoned: number, failedChunks: number}
- *   | {skipped: 'unconfigured'}>}
+ *   | {skipped: 'unconfigured', missing: string[]}>}
  *
  * Throws SeedHistoryError on a hard runtime failure; propagates the
  * embedder's own EmbeddingProviderError / EmbeddingTimeoutError. Never
@@ -390,7 +763,9 @@ export async function appendSeedHistory({ domain, resource, runId, records }, de
     console.warn(
       `[seed-history] not configured — skipping history append (missing: ${config.missing.join(', ')})`,
     );
-    return { skipped: 'unconfigured' };
+    // `missing` rides along so the ingest-health record can name the absent
+    // variables (#5736) instead of leaving an operator to grep Railway logs.
+    return { skipped: 'unconfigured', missing: config.missing };
   }
 
   if (typeof domain !== 'string' || !domain.trim()) {

--- a/scripts/_seed-history.mjs
+++ b/scripts/_seed-history.mjs
@@ -682,6 +682,13 @@ async function writeHistoryIngestRecord({ fetchImpl, url, token, domain, resourc
   const results = await resp.json();
   const failed = Array.isArray(results) ? results.find((entry) => entry?.error) : null;
   if (failed) throw new Error(`ingest-health pipeline command failed: ${failed.error}`);
+  // The pipeline is not transactional, so a per-command failure can land the
+  // record without the meta. That degrades the DIAGNOSTIC, never the alarm:
+  // a skipped meta write leaves the PREVIOUS meta in place, and `fetchedAt`
+  // there can only ever be an earlier healthy observation — nothing on this
+  // path can advance it. So the staleness backstop keeps counting on schedule
+  // and only the faster `degraded` signal waits for the next tick. Pinned by
+  // "a meta write that never lands cannot hide a stalled ingest".
 }
 
 /**

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -361,6 +361,12 @@ const EXCLUDED_FROM_MCP = new Map([
     'operational: relay loop heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
   ['digest:last-run',
     'operational: digest-notifications cron heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
+  ['intel-history:ingest-health:conflict:acled-intel:v1',
+    'operational: per-collector intel-history ingest state (last successful append, last relay error, consecutive failures) published by scripts/_seed-history.mjs for /api/health + /api/seed-health (#5736). The history CONTENT it guards is already queryable through search_intel_history / get_intel_timeline / get_similar_events.'],
+  ['intel-history:ingest-health:military:cross-strait-activity:v1',
+    'operational: per-collector intel-history ingest state (last successful append, last relay error, consecutive failures) published by scripts/_seed-history.mjs for /api/health + /api/seed-health (#5736). The history CONTENT it guards is already queryable through search_intel_history / get_intel_timeline / get_similar_events.'],
+  ['intel-history:ingest-health:energy:intelligence:v1',
+    'operational: per-collector intel-history ingest state (last successful append, last relay error, consecutive failures) published by scripts/_seed-history.mjs for /api/health + /api/seed-health (#5736). The history CONTENT it guards is already queryable through search_intel_history / get_intel_timeline / get_similar_events.'],
 ]);
 
 // -----------------------------------------------------------------------------

--- a/tests/seed-history-ingest-health.test.mjs
+++ b/tests/seed-history-ingest-health.test.mjs
@@ -490,6 +490,53 @@ describe('recordHistoryIngestHealth', () => {
     }
   });
 
+  it('a meta write that never lands cannot hide a stalled ingest', async () => {
+    // The 3-command pipeline is not transactional, so a per-command failure can
+    // land the record while the meta write is skipped. The meta then keeps its
+    // PREVIOUS value — and on this path that value can only be an earlier
+    // healthy observation, never a newer one. Prove the staleness backstop is
+    // therefore untouched: the retained meta ages exactly as it would have.
+    const healthy = project(null, { result: SUCCESS });
+    const { fetchImpl, calls } = stubUpstash({
+      getResult: JSON.stringify(healthy.record),
+      pipelineBody: [{ result: 'OK' }, { error: 'ERR backend unavailable' }, { result: 'OK' }],
+    });
+
+    const { value, warns } = await withCapturedWarn(() => recordHistoryIngestHealth(
+      { domain: DOMAIN, resource: RESOURCE, result: null, error: relayRejection(500) },
+      { env: ENV, fetchImpl, now: () => AT + MINUTE },
+    ));
+
+    assert.equal(value, null, 'the caller learns the write did not fully land');
+    assert.equal(warns.length, 1);
+
+    // Health still reads the retained meta. Its fetchedAt is the last healthy
+    // append, so the ordinary budget still expires on schedule.
+    const retained = healthy.meta;
+    assert.equal(retained.fetchedAt, AT);
+
+    const ingestKey = healthTesting.STANDALONE_KEYS.intelHistoryIngestConflictAcled;
+    const maxStaleMin = healthTesting.SEED_META.intelHistoryIngestConflictAcled.maxStaleMin;
+    const entry = healthTesting.classifyKey(
+      'intelHistoryIngestConflictAcled',
+      ingestKey,
+      { allowOnDemand: true },
+      {
+        keyStrens: new Map([[ingestKey, 512]]),
+        keyErrors: new Map(),
+        keyMetaValues: new Map([[
+          healthTesting.SEED_META.intelHistoryIngestConflictAcled.key,
+          JSON.stringify(retained),
+        ]]),
+        keyMetaErrors: new Map(),
+        activatedNames: new Set(['intelHistoryIngestConflictAcled']),
+        now: AT + (maxStaleMin + 1) * MINUTE,
+      },
+    );
+    assert.equal(entry.status, 'STALE_SEED', 'the alarm survives a lost meta write');
+    assert.equal(calls.pipelines.length, 1);
+  });
+
   it('no-ops without Upstash credentials instead of exiting the seeder', async () => {
     const { fetchImpl, calls } = stubUpstash();
     const { value, warns } = await withCapturedWarn(() => recordHistoryIngestHealth(

--- a/tests/seed-history-ingest-health.test.mjs
+++ b/tests/seed-history-ingest-health.test.mjs
@@ -1,0 +1,1123 @@
+/**
+ * Issue #5736 — history ingestion needs a durable health signal.
+ *
+ * `appendSeedHistory` is fail-open by contract: the canonical publish has
+ * already committed when the hook runs, so every history failure logs a warning
+ * and returns. Before this, nothing outside the log stream could tell that
+ * history had stopped accumulating — a missing RELAY_SHARED_SECRET or a
+ * systematically rejecting relay produced a healthy-looking seed run forever.
+ *
+ * These tests pin the three halves of the fix:
+ *   1. the pure state machine (`describeHistoryAppendOutcome` +
+ *      `projectHistoryIngestHealth`) — states, error codes, and which fields
+ *      freeze while the relay is down;
+ *   2. `recordHistoryIngestHealth` — what it writes, and that it stays
+ *      fail-open and read-consistent when Upstash misbehaves;
+ *   3. the end-to-end gap that motivated the issue: a prolonged relay rejection
+ *      MUST become visible in /api/health and /api/seed-health while the
+ *      collector's own canonical publication keeps reporting healthy.
+ *
+ * Run: ./node_modules/.bin/tsx --test tests/seed-history-ingest-health.test.mjs
+ */
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  WORLDMONITOR_VALID_KEYS: process.env.WORLDMONITOR_VALID_KEYS,
+  RESILIENCE_PILLAR_COMBINE_ENABLED: process.env.RESILIENCE_PILLAR_COMBINE_ENABLED,
+  RESILIENCE_SCHEMA_V2_ENABLED: process.env.RESILIENCE_SCHEMA_V2_ENABLED,
+};
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+// Pins currentResilienceCacheFormula() to 'pc' so the seed-health data probe
+// below is answerable — mirrors tests/seed-health-portwatch-port-activity.test.mjs.
+process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
+process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
+
+const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
+const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
+
+const {
+  appendSeedHistory,
+  makeSeedHistoryAfterPublish,
+  HISTORY_INGEST_ALARM_AFTER_FAILURES,
+  HISTORY_INGEST_SOURCE_VERSION,
+  HISTORY_INGEST_TTL_SECONDS,
+  describeHistoryAppendOutcome,
+  historyIngestActivationKey,
+  historyIngestErrorCode,
+  historyIngestHealthKey,
+  historyIngestMetaKey,
+  projectHistoryIngestHealth,
+  recordHistoryIngestHealth,
+} = await import('../scripts/_seed-history.mjs');
+
+const { __testing__: healthTesting } = await import('../api/health.js');
+const { default: seedHealthHandler } = await import('../api/seed-health.js');
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+const DOMAIN = 'conflict';
+const RESOURCE = 'acled-intel';
+const AT = Date.UTC(2026, 6, 28, 12, 0, 0);
+const MINUTE = 60_000;
+
+/** One successful relay append. */
+const SUCCESS = { inserted: 7, skipped: 3, chunks: 1, abandoned: 0, failedChunks: 0 };
+
+function project(previous, { result = null, error = null, at = AT, runId = 'run-1' } = {}) {
+  return projectHistoryIngestHealth(previous, {
+    domain: DOMAIN,
+    resource: RESOURCE,
+    runId,
+    at,
+    outcome: describeHistoryAppendOutcome(result, error),
+  });
+}
+
+function relayRejection(status = 401) {
+  const err = new Error(`intel-history relay returned HTTP ${status}: unauthorized`);
+  err.name = 'SeedHistoryError';
+  err.status = status;
+  return err;
+}
+
+// ── The pure state machine ────────────────────────────────────────────────────
+
+describe('projectHistoryIngestHealth', () => {
+  it('records a successful append as healthy and advances fetchedAt', () => {
+    const { record, meta } = project(null, { result: SUCCESS });
+
+    assert.equal(record.state, 'healthy');
+    assert.equal(record.consecutiveFailures, 0);
+    assert.equal(record.lastSuccessAt, AT);
+    assert.equal(record.lastHealthyAt, AT);
+    assert.equal(record.lastInserted, 7);
+    assert.equal(record.lastDeduped, 3);
+    assert.equal(record.lastErrorCode, null);
+
+    assert.equal(meta.fetchedAt, AT);
+    assert.equal(meta.recordCount, 10, 'relay-accepted volume is inserted + deduped');
+    assert.equal(meta.sourceState, 'ok');
+    assert.equal(meta.sourceVersion, HISTORY_INGEST_SOURCE_VERSION);
+  });
+
+  it('reports an unconfigured relay as a distinct, non-alarming state', () => {
+    const { record, meta } = project(null, {
+      result: { skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET', 'OPENROUTER_API_KEY'] },
+    });
+
+    assert.equal(record.state, 'unconfigured');
+    assert.deepEqual(record.missingConfig, ['RELAY_SHARED_SECRET', 'OPENROUTER_API_KEY']);
+    assert.equal(record.lastSuccessAt, null, 'nothing was ever appended');
+    // fetchedAt advances so an un-provisioned deployment reads as
+    // NOT_CONFIGURED forever instead of decaying into an unclearable stale warn.
+    assert.equal(meta.fetchedAt, AT);
+    assert.equal(meta.sourceState, 'unavailable');
+    assert.equal(meta.consecutiveFailures, 0);
+  });
+
+  it('freezes fetchedAt from the first failure and escalates at the alarm threshold', () => {
+    const healthy = project(null, { result: SUCCESS }).record;
+
+    const first = project(healthy, { result: null, error: relayRejection(401), at: AT + MINUTE });
+    assert.equal(first.record.state, 'failing');
+    assert.equal(first.record.consecutiveFailures, 1);
+    assert.equal(first.record.lastAttemptAt, AT + MINUTE);
+    assert.equal(first.meta.fetchedAt, AT, 'the last HEALTHY append, not the last attempt');
+    assert.equal(
+      first.meta.sourceState,
+      'ok',
+      'one failed tick is not yet the prolonged failure worth alarming on',
+    );
+
+    const second = project(first.record, {
+      result: null,
+      error: relayRejection(401),
+      at: AT + 2 * MINUTE,
+    });
+    assert.equal(second.record.consecutiveFailures, 2);
+    assert.equal(second.meta.fetchedAt, AT);
+    assert.equal(second.meta.sourceState, 'degraded');
+    assert.equal(second.meta.lastErrorCode, 'http_401');
+    assert.equal(second.record.lastErrorReason, 'intel-history relay returned HTTP 401: unauthorized');
+
+    assert.equal(
+      HISTORY_INGEST_ALARM_AFTER_FAILURES,
+      2,
+      'the escalation point is a pinned contract, not an implementation detail',
+    );
+  });
+
+  it('holds the last known good volume while the relay is down', () => {
+    const healthy = project(null, { result: SUCCESS }).record;
+    const failing = project(healthy, { error: relayRejection(500), at: AT + MINUTE });
+
+    assert.equal(
+      failing.meta.recordCount,
+      10,
+      'a down relay must not be reported as a contradictory zero-record run',
+    );
+    assert.equal(failing.record.lastSuccessAt, AT);
+  });
+
+  it('has no healthy timestamp when the very first append fails', () => {
+    const { record, meta } = project(null, { error: relayRejection(403) });
+
+    assert.equal(record.lastHealthyAt, null);
+    assert.equal(record.lastSuccessAt, null);
+    assert.equal(meta.fetchedAt, null, 'never-ingested + failing must classify as stale');
+    assert.equal(meta.recordCount, 0);
+  });
+
+  it('clears the failure count on recovery but keeps the last error for post-mortem', () => {
+    let state = project(null, { error: relayRejection(401) }).record;
+    state = project(state, { error: relayRejection(401), at: AT + MINUTE }).record;
+    const recovered = project(state, { result: SUCCESS, at: AT + 2 * MINUTE });
+
+    assert.equal(recovered.record.state, 'healthy');
+    assert.equal(recovered.record.consecutiveFailures, 0);
+    assert.equal(recovered.meta.sourceState, 'ok');
+    assert.equal(recovered.meta.fetchedAt, AT + 2 * MINUTE);
+    assert.equal(recovered.record.lastErrorCode, 'http_401');
+    assert.equal(recovered.record.lastErrorAt, AT + MINUTE);
+  });
+
+  it('ignores a corrupt or non-object previous record instead of throwing', () => {
+    for (const previous of [null, undefined, 'garbage', 42, []]) {
+      const { record } = project(previous, { error: relayRejection(500) });
+      assert.equal(record.consecutiveFailures, 1);
+    }
+  });
+
+  // ── Runs that reached nothing ──────────────────────────────────────────────
+  //
+  // appendSeedHistory RESOLVES rather than throws when its wall-clock budget
+  // dies before a single chunk is POSTed; it only throws on
+  // `chunks === 0 && failedChunks > 0`. Treating that as healthy would advance
+  // fetchedAt on a run that delivered nothing.
+
+  it('treats a run where no chunk reached the relay as failing, not healthy', () => {
+    const healthy = project(null, { result: SUCCESS }).record;
+    const budgetDied = {
+      inserted: 0, skipped: 0, chunks: 0, abandoned: 12, failedChunks: 0,
+    };
+
+    const { record, meta } = project(healthy, { result: budgetDied, at: AT + MINUTE });
+
+    assert.equal(record.state, 'failing');
+    assert.equal(record.lastErrorCode, 'budget_exhausted');
+    assert.equal(record.consecutiveFailures, 1);
+    assert.equal(
+      meta.fetchedAt,
+      AT,
+      'a run that delivered nothing must not advance the healthy clock',
+    );
+  });
+
+  it('escalates a relay that eats the budget on every run', () => {
+    const budgetDied = {
+      inserted: 0, skipped: 0, chunks: 0, abandoned: 12, failedChunks: 0,
+    };
+    let state = project(null, { result: SUCCESS }).record;
+    let projected;
+    for (let tick = 1; tick <= 2; tick++) {
+      projected = project(state, { result: budgetDied, at: AT + tick * MINUTE });
+      state = projected.record;
+    }
+    assert.equal(projected.meta.sourceState, 'degraded');
+  });
+
+  it('keeps a run with no candidate records healthy', () => {
+    // Nothing was offered, so nothing was lost — distinct from "offered and
+    // dropped" above. appendSeedHistory returns this without touching the relay.
+    const empty = { inserted: 0, skipped: 0, chunks: 0, abandoned: 0, failedChunks: 0 };
+    const { record, meta } = project(null, { result: empty });
+
+    assert.equal(record.state, 'healthy');
+    assert.equal(meta.fetchedAt, AT);
+    assert.equal(meta.sourceState, 'ok');
+  });
+
+  it('escalates a collector that loses chunks on every run', () => {
+    const lossy = { inserted: 4, skipped: 0, chunks: 1, abandoned: 0, failedChunks: 2 };
+
+    // Never a hard failure — every run reaches the relay and delivers
+    // something, so the total-failure counter alone would sit at zero forever
+    // while records are dropped on every tick.
+    let state = project(null, { result: SUCCESS }).record;
+    let projected;
+    for (let tick = 1; tick <= 2; tick++) {
+      projected = project(state, { result: lossy, at: AT + tick * MINUTE });
+      state = projected.record;
+    }
+
+    assert.equal(projected.record.state, 'healthy');
+    assert.equal(projected.record.lastFailedChunks, 2);
+    assert.equal(
+      projected.meta.fetchedAt,
+      AT + 2 * MINUTE,
+      'the relay is reachable, so this is not staleness',
+    );
+    assert.equal(projected.meta.sourceState, 'degraded', 'but the loss must surface');
+  });
+
+  it('lets a clean run clear a lossy streak', () => {
+    const lossy = { inserted: 4, skipped: 0, chunks: 1, abandoned: 0, failedChunks: 2 };
+    const dropped = project(project(null, { result: SUCCESS }).record, {
+      result: lossy,
+      at: AT + MINUTE,
+    }).record;
+    assert.equal(dropped.consecutiveFailures, 1);
+
+    const clean = project(dropped, { result: SUCCESS, at: AT + 2 * MINUTE });
+    assert.equal(clean.record.consecutiveFailures, 0);
+    assert.equal(clean.meta.sourceState, 'ok');
+  });
+
+  // ── Credential removed after a success ────────────────────────────────────
+
+  it('treats a credential removed after a success as a regression, not an opt-out', () => {
+    const healthy = project(null, { result: SUCCESS }).record;
+    const { record, meta } = project(healthy, {
+      result: { skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] },
+      at: AT + MINUTE,
+    });
+
+    assert.equal(record.state, 'unconfigured');
+    assert.deepEqual(record.missingConfig, ['RELAY_SHARED_SECRET']);
+    assert.equal(record.lastErrorCode, 'config_removed');
+    assert.equal(record.consecutiveFailures, 1);
+    assert.equal(
+      meta.fetchedAt,
+      AT,
+      'the staleness clock must not reset when a working relay loses its credential',
+    );
+    assert.equal(
+      meta.sourceState,
+      'degraded',
+      'no threshold: a variable is either configured or it is not',
+    );
+  });
+
+  it('keeps a never-provisioned deployment silent', () => {
+    // The distinguishing fact is lastSuccessAt: absent here, present above.
+    let state = project(null, {
+      result: { skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] },
+    }).record;
+    assert.equal(state.lastSuccessAt, null);
+
+    for (let tick = 1; tick <= 5; tick++) {
+      const next = project(state, {
+        result: { skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] },
+        at: AT + tick * MINUTE,
+      });
+      state = next.record;
+      assert.equal(next.meta.sourceState, 'unavailable');
+      assert.equal(next.meta.fetchedAt, AT + tick * MINUTE);
+      assert.equal(next.record.consecutiveFailures, 0);
+    }
+  });
+});
+
+describe('historyIngestErrorCode', () => {
+  it('prefers the transport facts an operator acts on', () => {
+    assert.equal(historyIngestErrorCode(relayRejection(429)), 'http_429');
+
+    const budget = new Error('intel-history relay budget exhausted');
+    budget.budgetExhausted = true;
+    budget.name = 'SeedHistoryError';
+    assert.equal(historyIngestErrorCode(budget), 'budget_exhausted');
+  });
+
+  it('falls back to a stable code derived from the error class', () => {
+    const embedder = new Error('embeddings provider returned HTTP 402');
+    embedder.name = 'EmbeddingProviderError';
+    assert.equal(historyIngestErrorCode(embedder), 'embedding_provider_error');
+    assert.equal(historyIngestErrorCode(new Error('boom')), 'error');
+    assert.equal(historyIngestErrorCode(null), null);
+  });
+});
+
+// ── The Redis writer ──────────────────────────────────────────────────────────
+
+/**
+ * Upstash stub. `getResult` is the raw string the record GET returns (null =
+ * key absent). Captures every pipeline body so key names and TTLs are testable.
+ */
+function stubUpstash({ getResult = null, getStatus = 200, pipelineStatus = 200, pipelineBody } = {}) {
+  const calls = { gets: [], pipelines: [] };
+  const fetchImpl = async (url, init) => {
+    if (String(url).includes('/pipeline')) {
+      calls.pipelines.push(JSON.parse(init.body));
+      return {
+        ok: pipelineStatus >= 200 && pipelineStatus < 300,
+        status: pipelineStatus,
+        json: async () => pipelineBody ?? [{ result: 'OK' }, { result: 'OK' }, { result: 'OK' }],
+      };
+    }
+    calls.gets.push(String(url));
+    return {
+      ok: getStatus >= 200 && getStatus < 300,
+      status: getStatus,
+      json: async () => ({ result: getResult }),
+    };
+  };
+  return { fetchImpl, calls };
+}
+
+async function withCapturedWarn(fn) {
+  const warns = [];
+  const original = console.warn;
+  console.warn = (...args) => warns.push(args.map(String).join(' '));
+  try {
+    return { value: await fn(), warns };
+  } finally {
+    console.warn = original;
+  }
+}
+
+const ENV = {
+  UPSTASH_REDIS_REST_URL: 'https://redis.example.test',
+  UPSTASH_REDIS_REST_TOKEN: 'token',
+};
+
+describe('recordHistoryIngestHealth', () => {
+  it('writes the record, the seed-meta projection, and the activation marker', async () => {
+    const { fetchImpl, calls } = stubUpstash();
+
+    const record = await recordHistoryIngestHealth(
+      { domain: DOMAIN, resource: RESOURCE, runId: 'run-9', result: SUCCESS },
+      { env: ENV, fetchImpl, now: () => AT },
+    );
+
+    assert.equal(record.state, 'healthy');
+    assert.equal(calls.gets.length, 1);
+    assert.match(calls.gets[0], /intel-history%3Aingest-health%3Aconflict%3Aacled-intel%3Av1$/);
+
+    assert.equal(calls.pipelines.length, 1);
+    const [recordCmd, metaCmd, activationCmd] = calls.pipelines[0];
+
+    assert.deepEqual(recordCmd.slice(0, 2), ['SET', historyIngestHealthKey(DOMAIN, RESOURCE)]);
+    assert.deepEqual(recordCmd.slice(3), ['EX', HISTORY_INGEST_TTL_SECONDS]);
+    assert.equal(JSON.parse(recordCmd[2]).lastRunId, 'run-9');
+
+    assert.deepEqual(metaCmd.slice(0, 2), ['SET', historyIngestMetaKey(DOMAIN, RESOURCE)]);
+    assert.deepEqual(metaCmd.slice(3), ['EX', HISTORY_INGEST_TTL_SECONDS]);
+    const meta = JSON.parse(metaCmd[2]);
+    assert.equal(meta.fetchedAt, AT);
+    assert.equal(meta.sourceState, 'ok');
+    assert.equal(
+      typeof meta._seed,
+      'undefined',
+      'seed-meta must stay bare-shape — every reader parses it top-level',
+    );
+
+    assert.deepEqual(
+      activationCmd,
+      ['SET', historyIngestActivationKey(DOMAIN, RESOURCE), '1'],
+      'the activation marker carries NO TTL: it must outlive the 7-day record',
+    );
+  });
+
+  it('continues the failure streak from the persisted record', async () => {
+    const previous = project(project(null, { result: SUCCESS }).record, {
+      error: relayRejection(401),
+      at: AT,
+    }).record;
+    const { fetchImpl, calls } = stubUpstash({ getResult: JSON.stringify(previous) });
+
+    const { value: record } = await withCapturedWarn(() => recordHistoryIngestHealth(
+      { domain: DOMAIN, resource: RESOURCE, result: null, error: relayRejection(401) },
+      { env: ENV, fetchImpl, now: () => AT + MINUTE },
+    ));
+
+    assert.equal(record.consecutiveFailures, 2);
+    assert.equal(JSON.parse(calls.pipelines[0][1][2]).sourceState, 'degraded');
+  });
+
+  it('skips the write entirely when the previous record cannot be read', async () => {
+    const { fetchImpl, calls } = stubUpstash({ getStatus: 500 });
+
+    const { value, warns } = await withCapturedWarn(() => recordHistoryIngestHealth(
+      { domain: DOMAIN, resource: RESOURCE, result: SUCCESS },
+      { env: ENV, fetchImpl, now: () => AT },
+    ));
+
+    assert.equal(value, null);
+    assert.deepEqual(
+      calls.pipelines,
+      [],
+      'rebuilding from a lost previous would reset the failure count and drop lastSuccessAt',
+    );
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /ingest-health write failed \(non-fatal\)/);
+  });
+
+  it('treats a corrupt stored record as absent rather than failing the write', async () => {
+    const { fetchImpl, calls } = stubUpstash({ getResult: '{not json' });
+
+    const record = await recordHistoryIngestHealth(
+      { domain: DOMAIN, resource: RESOURCE, result: SUCCESS },
+      { env: ENV, fetchImpl, now: () => AT },
+    );
+
+    assert.equal(record.state, 'healthy');
+    assert.equal(calls.pipelines.length, 1);
+  });
+
+  it('never throws when the pipeline write fails', async () => {
+    for (const options of [{ pipelineStatus: 503 }, { pipelineBody: [{ result: 'OK' }, { error: 'ERR wrongtype' }] }]) {
+      const { fetchImpl } = stubUpstash(options);
+      const { value, warns } = await withCapturedWarn(() => recordHistoryIngestHealth(
+        { domain: DOMAIN, resource: RESOURCE, result: SUCCESS },
+        { env: ENV, fetchImpl, now: () => AT },
+      ));
+      assert.equal(value, null);
+      assert.equal(warns.length, 1);
+    }
+  });
+
+  it('no-ops without Upstash credentials instead of exiting the seeder', async () => {
+    const { fetchImpl, calls } = stubUpstash();
+    const { value, warns } = await withCapturedWarn(() => recordHistoryIngestHealth(
+      { domain: DOMAIN, resource: RESOURCE, result: SUCCESS },
+      { env: {}, fetchImpl, now: () => AT },
+    ));
+
+    assert.equal(value, null);
+    assert.deepEqual(calls.gets, []);
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /no Upstash credentials/);
+  });
+});
+
+describe('makeSeedHistoryAfterPublish', () => {
+  it('records a projection failure as an ingest failure without appending', async () => {
+    // buildRecords runs inside the same try as append, so a payload the
+    // projection cannot handle throws before the relay is ever contacted. That
+    // is still an ingest failure and must reach the health record rather than
+    // vanishing into a log line.
+    const observations = [];
+    let appendCalls = 0;
+    const hook = makeSeedHistoryAfterPublish({
+      domain: DOMAIN,
+      resource: RESOURCE,
+      buildRecords: () => {
+        throw new TypeError('cannot read properties of undefined');
+      },
+    });
+
+    const { warns } = await withCapturedWarn(() => hook({}, { runId: 'run-7' }, {
+      append: async () => {
+        appendCalls++;
+        return SUCCESS;
+      },
+      recordHealth: async (observation) => {
+        observations.push(observation);
+        return null;
+      },
+    }));
+
+    assert.equal(appendCalls, 0, 'nothing can be appended when the projection failed');
+    assert.equal(observations.length, 1);
+    assert.equal(observations[0].result, null);
+    assert.equal(observations[0].error.name, 'TypeError');
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /append failed \(non-fatal\)/);
+
+    // ...and it lands as a failing outcome, not a silent healthy one.
+    const { record, meta } = projectHistoryIngestHealth(null, {
+      domain: DOMAIN,
+      resource: RESOURCE,
+      runId: 'run-7',
+      at: AT,
+      outcome: describeHistoryAppendOutcome(observations[0].result, observations[0].error),
+    });
+    assert.equal(record.state, 'failing');
+    assert.equal(record.lastErrorCode, 'type_error');
+    assert.equal(meta.fetchedAt, null);
+  });
+});
+
+// ── Real producer -> real projection ─────────────────────────────────────────
+//
+// Everything above pins the projection against a hand-written result literal.
+// That leaves one seam unguarded: if `appendSeedHistory`'s own return contract
+// drifts — a renamed counter, a path that starts resolving where it used to
+// throw — the projection keeps reading a shape the producer no longer emits and
+// the alarm goes quiet with every test still green. These drive the REAL
+// producer, with only the network stubbed, into the REAL reducer.
+
+describe('appendSeedHistory outcomes reach the projection intact', () => {
+  const RELAY_ENV = {
+    CONVEX_SITE_URL: 'https://example.convex.site',
+    RELAY_SHARED_SECRET: 'test-secret',
+    OPENROUTER_API_KEY: 'sk-test',
+  };
+
+  const candidates = Array.from({ length: 3 }, (_, i) => ({
+    dedupeKey: `conflict:acled-intel:evt-${i}`,
+    title: `Event ${i}`,
+    occurredAt: AT + i * 1000,
+  }));
+
+  const stubEmbed = async (texts) => texts.map(() => new Array(512).fill(0.1));
+
+  async function runProducerThenProject(deps) {
+    let result = null;
+    let error = null;
+    try {
+      result = await appendSeedHistory(
+        { domain: DOMAIN, resource: RESOURCE, runId: 'run-1', records: candidates },
+        { env: RELAY_ENV, embed: stubEmbed, ...deps },
+      );
+    } catch (err) {
+      error = err;
+    }
+    return projectHistoryIngestHealth(null, {
+      domain: DOMAIN,
+      resource: RESOURCE,
+      runId: 'run-1',
+      at: AT,
+      outcome: describeHistoryAppendOutcome(result, error),
+    });
+  }
+
+  it('a relay rejecting every chunk lands as failing with the HTTP code', async () => {
+    const { record, meta } = await withCapturedWarn(() => runProducerThenProject({
+      fetchImpl: async () => ({
+        ok: false,
+        status: 401,
+        text: async () => 'unauthorized',
+        json: async () => ({}),
+      }),
+      sleep: async () => {},
+    })).then((r) => r.value);
+
+    assert.equal(record.state, 'failing');
+    assert.equal(record.lastErrorCode, 'http_401');
+    assert.equal(meta.fetchedAt, null);
+    assert.equal(meta.sourceState, 'ok', 'one failed run is below the alarm threshold');
+  });
+
+  it('a budget that dies before the first POST lands as failing, not healthy', async () => {
+    // The producer RESOLVES here rather than throwing — the exact shape that
+    // used to be folded into `healthy` and kept the alarm green forever.
+    let calls = 0;
+    const { value: projected, warns } = await withCapturedWarn(() => runProducerThenProject({
+      // Clock jumps past the deadline during embedding, so the chunk loop never
+      // sends anything and the run is reported as fully abandoned.
+      now: () => (calls++ === 0 ? AT : AT + 10 * MINUTE),
+      budgetMs: 1_000,
+      fetchImpl: async () => {
+        throw new Error('the relay must never be contacted in this scenario');
+      },
+    }));
+
+    assert.equal(projected.record.state, 'failing');
+    assert.equal(projected.record.lastErrorCode, 'budget_exhausted');
+    assert.equal(projected.meta.fetchedAt, null, 'nothing was delivered');
+    assert.match(warns.join(' '), /budget exhausted/);
+  });
+
+  it('a fully accepted run lands as healthy with the relay-accepted volume', async () => {
+    const { record, meta } = await runProducerThenProject({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ inserted: 2, skipped: 1 }),
+      }),
+    });
+
+    assert.equal(record.state, 'healthy');
+    assert.equal(meta.fetchedAt, AT);
+    assert.equal(meta.recordCount, 3, 'inserted + deduped, straight from the relay');
+    assert.equal(meta.sourceState, 'ok');
+  });
+
+  it('carries every counter the relay reports into the record', () => {
+    // The producer's return shape and this reducer are edited by different
+    // changes at different times (`retracted` arrived with #5743 while this
+    // record was in review). Pin that a counter the producer emits reaches the
+    // durable record, so the next addition cannot land silently half-wired.
+    const producerShape = {
+      inserted: 2, skipped: 1, retracted: 4, chunks: 1, abandoned: 0, failedChunks: 0,
+    };
+    const { record, meta } = project(null, { result: producerShape });
+
+    assert.equal(record.lastInserted, 2);
+    assert.equal(record.lastDeduped, 1);
+    assert.equal(record.lastRetracted, 4);
+    assert.equal(record.lastChunks, 1);
+    assert.equal(
+      meta.recordCount,
+      3,
+      'a retraction removes a row rather than accepting one, so it stays out of the volume',
+    );
+  });
+
+  it('an unconfigured relay lands as unconfigured and names the missing variable', async () => {
+    const { value: projected } = await withCapturedWarn(() => runProducerThenProject({
+      env: {},
+      fetchImpl: async () => {
+        throw new Error('no network when unconfigured');
+      },
+    }));
+
+    assert.equal(projected.record.state, 'unconfigured');
+    assert.deepEqual(projected.record.missingConfig, [
+      'CONVEX_SITE_URL (or CONVEX_URL)',
+      'RELAY_SHARED_SECRET',
+      'OPENROUTER_API_KEY',
+    ]);
+    assert.equal(projected.meta.sourceState, 'unavailable');
+  });
+});
+
+// ── The gap that motivated the issue ─────────────────────────────────────────
+
+const COLLECTORS = [
+  {
+    domain: 'conflict',
+    resource: 'acled-intel',
+    healthName: 'intelHistoryIngestConflictAcled',
+    seedHealthDomain: 'intel-history:conflict:acled-intel',
+    collectorHealthName: 'acledIntel',
+    collectorMetaKey: 'seed-meta:conflict:acled-intel',
+    collectorDataKey: 'conflict:acled:v1:all:0:0',
+  },
+  {
+    domain: 'military',
+    resource: 'cross-strait-activity',
+    healthName: 'intelHistoryIngestMilitaryCrossStrait',
+    seedHealthDomain: 'intel-history:military:cross-strait-activity',
+    collectorHealthName: 'crossStraitActivity',
+    collectorMetaKey: 'seed-meta:military:cross-strait-activity',
+    collectorDataKey: 'military:cross-strait-activity:v1',
+  },
+  {
+    domain: 'energy',
+    resource: 'intelligence',
+    healthName: 'intelHistoryIngestEnergyIntelligence',
+    seedHealthDomain: 'intel-history:energy:intelligence',
+    collectorHealthName: 'energyIntelligence',
+    collectorMetaKey: 'seed-meta:energy:intelligence',
+    collectorDataKey: 'energy:intelligence:feed:v1',
+  },
+];
+
+describe('registration parity', () => {
+  for (const collector of COLLECTORS) {
+    it(`${collector.domain}/${collector.resource} keys match what the writer publishes`, () => {
+      const {
+        STANDALONE_KEYS,
+        SEED_META,
+        ACTIVATION_MARKERS,
+        ZERO_RECORD_DATA_OK_KEYS,
+        ON_DEMAND_KEYS,
+      } = healthTesting;
+
+      assert.ok(
+        ON_DEMAND_KEYS.has(collector.healthName),
+        'without this membership the pre-first-report window is EMPTY (crit), not EMPTY_ON_DEMAND (warn)',
+      );
+
+      assert.equal(
+        STANDALONE_KEYS[collector.healthName],
+        historyIngestHealthKey(collector.domain, collector.resource),
+      );
+      assert.equal(
+        SEED_META[collector.healthName]?.key,
+        historyIngestMetaKey(collector.domain, collector.resource),
+      );
+      assert.equal(
+        ACTIVATION_MARKERS[collector.healthName],
+        historyIngestActivationKey(collector.domain, collector.resource),
+      );
+      assert.ok(
+        ZERO_RECORD_DATA_OK_KEYS.has(collector.healthName),
+        'a fully-deduped run legitimately accepts zero records',
+      );
+    });
+
+    it(`${collector.domain}/${collector.resource} budgets agree across both health surfaces`, async () => {
+      const { SEED_META } = healthTesting;
+      const source = await import('node:fs/promises')
+        .then((fs) => fs.readFile(new URL('../api/seed-health.js', import.meta.url), 'utf8'));
+
+      const metaKey = historyIngestMetaKey(collector.domain, collector.resource);
+      const entry = new RegExp(
+        `'${collector.seedHealthDomain}':\\s*\\{[^}]*key:\\s*'${metaKey}'[^}]*intervalMin:\\s*(\\d+)[^}]*activationKey:\\s*'${historyIngestActivationKey(collector.domain, collector.resource)}'`,
+      ).exec(source);
+
+      assert.ok(entry, `api/seed-health.js must register ${collector.seedHealthDomain}`);
+      assert.equal(
+        Number(entry[1]) * 2,
+        SEED_META[collector.healthName].maxStaleMin,
+        'intervalMin*2 must equal api/health.js maxStaleMin so both surfaces alarm together',
+      );
+    });
+  }
+});
+
+describe('a prolonged relay rejection is visible in /api/health', () => {
+  const { classifyKey, BOOTSTRAP_KEYS, STANDALONE_KEYS, SEED_META } = healthTesting;
+
+  /**
+   * Classify one ingest-health entry alongside its collector, from the exact
+   * bytes the writer would have persisted.
+   */
+  function classifyPair(collector, { ingestMeta, ingestRecord }) {
+    const now = AT + 5 * MINUTE;
+    const ingestKey = STANDALONE_KEYS[collector.healthName];
+    // crossStraitActivity is a bootstrap key; the other two are standalone.
+    const collectorKey = BOOTSTRAP_KEYS[collector.collectorHealthName]
+      ?? STANDALONE_KEYS[collector.collectorHealthName];
+
+    const ctx = {
+      keyStrens: new Map([
+        [ingestKey, ingestRecord ? JSON.stringify(ingestRecord).length : 0],
+        [collectorKey, 4_096],
+      ]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([
+        [SEED_META[collector.healthName].key, ingestMeta ? JSON.stringify(ingestMeta) : null],
+        // The collector itself published normally throughout.
+        [collector.collectorMetaKey, JSON.stringify({ fetchedAt: now, recordCount: 120, sourceVersion: 'x' })],
+      ]),
+      keyMetaErrors: new Map(),
+      // Past the deployment window: softening is revoked, so this is the real
+      // classification an operator would see in production.
+      activatedNames: new Set([collector.healthName]),
+      now,
+    };
+
+    return {
+      ingest: classifyKey(collector.healthName, ingestKey, { allowOnDemand: true }, ctx),
+      collector: classifyKey(collector.collectorHealthName, collectorKey, { allowOnDemand: true }, ctx),
+    };
+  }
+
+  for (const collector of COLLECTORS) {
+    it(`${collector.domain}/${collector.resource}: SEED_ERROR on the ingest key, OK on the collector`, () => {
+      let state = projectHistoryIngestHealth(null, {
+        domain: collector.domain,
+        resource: collector.resource,
+        runId: 'run-1',
+        at: AT,
+        outcome: describeHistoryAppendOutcome(SUCCESS, null),
+      }).record;
+
+      // Two consecutive ticks where the relay refuses every chunk.
+      let projected;
+      for (let tick = 1; tick <= 2; tick++) {
+        projected = projectHistoryIngestHealth(state, {
+          domain: collector.domain,
+          resource: collector.resource,
+          runId: `run-${tick + 1}`,
+          at: AT + tick * MINUTE,
+          outcome: describeHistoryAppendOutcome(null, relayRejection(401)),
+        });
+        state = projected.record;
+      }
+
+      const { ingest, collector: canonical } = classifyPair(collector, {
+        ingestMeta: projected.meta,
+        ingestRecord: projected.record,
+      });
+
+      assert.equal(ingest.status, 'SEED_ERROR', 'the store is silently receiving nothing');
+      assert.equal(
+        canonical.status,
+        'OK',
+        'canonical publication is genuinely fine — seed-meta semantics are unchanged',
+      );
+    });
+
+    it(`${collector.domain}/${collector.resource}: softens the pre-first-report window`, () => {
+      // A Vercel deploy ships this registry immediately; the record only exists
+      // after the collector's next Railway tick (up to 6h for energy). Without
+      // the ON_DEMAND softening asserted above, that window is EMPTY -> crit.
+      const ingestKey = healthTesting.STANDALONE_KEYS[collector.healthName];
+      const ctx = {
+        keyStrens: new Map([[ingestKey, 0]]),
+        keyErrors: new Map(),
+        keyMetaValues: new Map([[SEED_META[collector.healthName].key, null]]),
+        keyMetaErrors: new Map(),
+        activatedNames: new Set(),   // marker absent: nothing has reported yet
+        now: AT,
+      };
+
+      const entry = classifyKey(collector.healthName, ingestKey, { allowOnDemand: true }, ctx);
+      assert.equal(entry.status, 'EMPTY_ON_DEMAND');
+      assert.equal(entry.onDemand, true);
+      assert.equal(healthTesting.STATUS_COUNTS.EMPTY_ON_DEMAND, 'warn');
+
+      // ...and the softening is revoked the moment the durable marker lands.
+      const activated = classifyKey(
+        collector.healthName,
+        ingestKey,
+        { allowOnDemand: true },
+        { ...ctx, activatedNames: new Set([collector.healthName]) },
+      );
+      assert.equal(activated.status, 'EMPTY');
+      assert.equal(healthTesting.STATUS_COUNTS.EMPTY, 'crit');
+    });
+
+    it(`${collector.domain}/${collector.resource}: healthy ingest classifies OK`, () => {
+      const { record, meta } = projectHistoryIngestHealth(null, {
+        domain: collector.domain,
+        resource: collector.resource,
+        runId: 'run-1',
+        at: AT + 5 * MINUTE,
+        outcome: describeHistoryAppendOutcome(SUCCESS, null),
+      });
+
+      const { ingest } = classifyPair(collector, { ingestMeta: meta, ingestRecord: record });
+      assert.equal(ingest.status, 'OK');
+      assert.equal(ingest.records, 10);
+    });
+
+    it(`${collector.domain}/${collector.resource}: an unconfigured relay is visible but never an alarm`, () => {
+      const { record, meta } = projectHistoryIngestHealth(null, {
+        domain: collector.domain,
+        resource: collector.resource,
+        runId: 'run-1',
+        at: AT + 5 * MINUTE,
+        outcome: describeHistoryAppendOutcome({ skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] }, null),
+      });
+
+      const { ingest } = classifyPair(collector, { ingestMeta: meta, ingestRecord: record });
+      assert.equal(ingest.status, 'NOT_CONFIGURED');
+      assert.equal(healthTesting.STATUS_COUNTS.NOT_CONFIGURED, 'ok');
+    });
+
+    it(`${collector.domain}/${collector.resource}: staleness catches a sub-threshold failure`, () => {
+      const healthy = projectHistoryIngestHealth(null, {
+        domain: collector.domain,
+        resource: collector.resource,
+        runId: 'run-1',
+        at: AT,
+        outcome: describeHistoryAppendOutcome(SUCCESS, null),
+      }).record;
+
+      // ONE failure — below HISTORY_INGEST_ALARM_AFTER_FAILURES, so sourceState
+      // is still 'ok' and SEED_ERROR cannot fire. The frozen fetchedAt is the
+      // independent second alarm: if the collector's cadence never delivers a
+      // second failing tick, "no successful append in N intervals" must still
+      // surface on its own.
+      const { record, meta } = projectHistoryIngestHealth(healthy, {
+        domain: collector.domain,
+        resource: collector.resource,
+        runId: 'run-2',
+        at: AT + MINUTE,
+        outcome: describeHistoryAppendOutcome(null, relayRejection(500)),
+      });
+      assert.equal(meta.sourceState, 'ok', 'the SEED_ERROR path must not be what makes this red');
+
+      const maxStaleMin = SEED_META[collector.healthName].maxStaleMin;
+      const ingestKey = STANDALONE_KEYS[collector.healthName];
+      const ctx = {
+        keyStrens: new Map([[ingestKey, JSON.stringify(record).length]]),
+        keyErrors: new Map(),
+        keyMetaValues: new Map([[SEED_META[collector.healthName].key, JSON.stringify(meta)]]),
+        keyMetaErrors: new Map(),
+        activatedNames: new Set([collector.healthName]),
+        now: AT + (maxStaleMin + 1) * MINUTE,
+      };
+
+      const entry = classifyKey(collector.healthName, ingestKey, { allowOnDemand: true }, ctx);
+      assert.equal(entry.status, 'STALE_SEED');
+      assert.equal(entry.maxStaleMin, maxStaleMin);
+    });
+  }
+});
+
+describe('a prolonged relay rejection is visible in /api/seed-health', () => {
+  /**
+   * Answer every seed-meta GET with a fresh, healthy record so the assertions
+   * below isolate the ingest entries — including the resilience-intervals data
+   * probe, whose absence would otherwise stale the aggregate for an unrelated
+   * reason and make `overall` untrustworthy. `ingestMetaByKey` overrides
+   * specific keys.
+   */
+  function installSeedHealthMock(ingestMetaByKey, { activated = true } = {}) {
+    globalThis.fetch = async (_url, init) => {
+      const commands = JSON.parse(init.body);
+      const results = commands.map(([op, key]) => {
+        if (op === 'EXISTS') return { result: activated ? 1 : 0 };
+        if (Object.hasOwn(ingestMetaByKey, key)) {
+          const value = ingestMetaByKey[key];
+          return { result: value == null ? null : JSON.stringify(value) };
+        }
+        if (key === RESILIENCE_INTERVAL_PROBE_KEY) {
+          return {
+            result: JSON.stringify({
+              p05: 65.2,
+              p95: 72.8,
+              _formula: 'pc',
+              methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+              computedAt: '2026-06-11T12:00:00.000Z',
+            }),
+          };
+        }
+        return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 10_000 }) };
+      });
+      return new Response(JSON.stringify(results), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+  }
+
+  async function readSeedHealth() {
+    const res = await seedHealthHandler(new Request('https://api.worldmonitor.app/api/seed-health', {
+      headers: { 'X-WorldMonitor-Key': 'test-key' },
+    }));
+    return { res, body: await res.json() };
+  }
+
+  /**
+   * Build each collector's seed-meta by running the REAL state machine over a
+   * scripted sequence of outcomes, so these assertions break if the writer
+   * changes. A hand-typed fixture would keep passing through a projection
+   * regression — the /api/health half of this file already projects for the
+   * same reason.
+   */
+  function projectMetaForAll(outcomes, { startAt = Date.now() - 10 * MINUTE } = {}) {
+    const overrides = {};
+    for (const collector of COLLECTORS) {
+      let state = null;
+      let projected = null;
+      outcomes.forEach((outcome, i) => {
+        projected = projectHistoryIngestHealth(state, {
+          domain: collector.domain,
+          resource: collector.resource,
+          runId: `run-${i + 1}`,
+          at: startAt + i * MINUTE,
+          outcome: describeHistoryAppendOutcome(outcome.result ?? null, outcome.error ?? null),
+        });
+        state = projected.record;
+      });
+      overrides[historyIngestMetaKey(collector.domain, collector.resource)] = projected.meta;
+    }
+    return overrides;
+  }
+
+  it('reports a rejecting relay as error while the collector stays ok', async () => {
+    installSeedHealthMock(projectMetaForAll([
+      { result: SUCCESS },
+      { error: relayRejection(401) },
+      { error: relayRejection(401) },
+    ]));
+
+    const { res, body } = await readSeedHealth();
+    assert.equal(res.status, 200);
+
+    for (const collector of COLLECTORS) {
+      const entry = body.seeds[collector.seedHealthDomain];
+      assert.equal(entry.status, 'error', `${collector.seedHealthDomain} must alarm`);
+      assert.equal(entry.stale, true);
+      assert.equal(entry.lastErrorCode, 'http_401', 'the cause must be diagnosable from the API');
+    }
+    assert.equal(body.seeds['conflict:acled-intel'].status, 'ok');
+    assert.equal(body.overall, 'warning');
+  });
+
+  it('reports a never-provisioned relay as not_configured, not a warning', async () => {
+    installSeedHealthMock(projectMetaForAll(
+      [{ result: { skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] } }],
+      { startAt: Date.now() },
+    ));
+
+    const { res, body } = await readSeedHealth();
+    assert.equal(res.status, 200);
+    assert.equal(body.overall, 'healthy');
+    for (const collector of COLLECTORS) {
+      const entry = body.seeds[collector.seedHealthDomain];
+      assert.equal(entry.status, 'not_configured');
+      assert.equal(entry.stale, false);
+      assert.equal(entry.lastErrorCode, undefined, 'nothing has failed');
+    }
+  });
+
+  it('alarms when a working relay loses its credential', async () => {
+    // The issue's headline scenario. Distinguished from the never-provisioned
+    // case above only by the earlier successful append.
+    installSeedHealthMock(projectMetaForAll([
+      { result: SUCCESS },
+      { result: { skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] } },
+    ]));
+
+    const { res, body } = await readSeedHealth();
+    assert.equal(res.status, 200);
+    assert.equal(body.overall, 'warning');
+    for (const collector of COLLECTORS) {
+      const entry = body.seeds[collector.seedHealthDomain];
+      assert.equal(entry.status, 'error');
+      assert.equal(entry.stale, true);
+      assert.equal(entry.lastErrorCode, 'config_removed');
+    }
+    assert.equal(body.seeds['conflict:acled-intel'].status, 'ok');
+  });
+
+  it('does not echo the relay-controlled error reason', async () => {
+    // lastErrorReason carries up to 200 chars of relay response body. It stays
+    // in Redis; only the bounded lastErrorCode reaches the wire.
+    installSeedHealthMock(projectMetaForAll([
+      { result: SUCCESS },
+      { error: relayRejection(401) },
+      { error: relayRejection(401) },
+    ]));
+
+    const { body } = await readSeedHealth();
+    for (const collector of COLLECTORS) {
+      const entry = body.seeds[collector.seedHealthDomain];
+      assert.equal(entry.lastErrorReason, undefined);
+      assert.equal(entry.consecutiveFailures, undefined);
+      assert.equal(entry.missingConfig, undefined);
+    }
+  });
+
+  it('does not 503 before the first ingest report lands', async () => {
+    const overrides = {};
+    for (const collector of COLLECTORS) {
+      overrides[historyIngestMetaKey(collector.domain, collector.resource)] = null;
+    }
+    installSeedHealthMock(overrides, { activated: false });
+
+    const { res, body } = await readSeedHealth();
+    assert.equal(res.status, 200, 'a Vercel deploy ahead of the first Railway tick must not page');
+    assert.equal(body.overall, 'healthy');
+    for (const collector of COLLECTORS) {
+      assert.equal(body.seeds[collector.seedHealthDomain].status, 'pending-activation');
+    }
+  });
+
+  it('alarms once the marker exists but the record has vanished', async () => {
+    const overrides = {};
+    for (const collector of COLLECTORS) {
+      overrides[historyIngestMetaKey(collector.domain, collector.resource)] = null;
+    }
+    installSeedHealthMock(overrides, { activated: true });
+
+    const { res, body } = await readSeedHealth();
+    assert.equal(res.status, 503);
+    for (const collector of COLLECTORS) {
+      assert.equal(body.seeds[collector.seedHealthDomain].status, 'missing');
+    }
+  });
+});

--- a/tests/seed-history-wiring.test.mjs
+++ b/tests/seed-history-wiring.test.mjs
@@ -182,12 +182,20 @@ const HOOKS = [
     { observations: [CROSS_STRAIT_OBSERVATION] }],
 ];
 
+// The ingest-health recorder (#5736) is the hook's second injectable seam; stub
+// it out here so these wiring tests stay offline and keep asserting only the
+// append leg. tests/seed-history-ingest-health.test.mjs owns its behavior.
+const noopRecordHealth = async () => null;
+
 for (const [domain, resource, hook, payload] of HOOKS) {
   test(`${domain}/${resource} afterPublish passes projected records to append`, async () => {
     const calls = [];
-    await hook(payload, { runId: 'run-42' }, async (args) => {
-      calls.push(args);
-      return { inserted: 1, skipped: 0, chunks: 1 };
+    await hook(payload, { runId: 'run-42' }, {
+      append: async (args) => {
+        calls.push(args);
+        return { inserted: 1, skipped: 0, chunks: 1 };
+      },
+      recordHealth: noopRecordHealth,
     });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].domain, domain);
@@ -201,8 +209,11 @@ for (const [domain, resource, hook, payload] of HOOKS) {
     const originalWarn = console.warn;
     console.warn = (...args) => warns.push(args.join(' '));
     try {
-      await hook(payload, { runId: 'run-42' }, async () => {
-        throw new Error('convex 503');
+      await hook(payload, { runId: 'run-42' }, {
+        append: async () => {
+          throw new Error('convex 503');
+        },
+        recordHealth: noopRecordHealth,
       });
     } finally {
       console.warn = originalWarn;
@@ -221,16 +232,14 @@ for (const [domain, resource, hook, payload] of HOOKS) {
     const originalLog = console.log;
     console.log = (...args) => logs.push(args.join(' '));
     try {
-      await hook(payload, { runId: 'run-42' }, async () => ({
-        inserted: 0,
-        skipped: 3,
-        retracted: 2,
-      }));
-      await hook(payload, { runId: 'run-42' }, async () => ({
-        inserted: 1,
-        skipped: 0,
-        retracted: 0,
-      }));
+      await hook(payload, { runId: 'run-42' }, {
+        append: async () => ({ inserted: 0, skipped: 3, retracted: 2 }),
+        recordHealth: noopRecordHealth,
+      });
+      await hook(payload, { runId: 'run-42' }, {
+        append: async () => ({ inserted: 1, skipped: 0, retracted: 0 }),
+        recordHealth: noopRecordHealth,
+      });
     } finally {
       console.log = originalLog;
     }
@@ -244,11 +253,71 @@ for (const [domain, resource, hook, payload] of HOOKS) {
     const originalLog = console.log;
     console.log = (...args) => logs.push(args.join(' '));
     try {
-      await hook(payload, { runId: 'run-42' }, async () => ({ skipped: 'unconfigured' }));
+      await hook(payload, { runId: 'run-42' }, {
+        append: async () => ({ skipped: 'unconfigured', missing: ['RELAY_SHARED_SECRET'] }),
+        recordHealth: noopRecordHealth,
+      });
     } finally {
       console.log = originalLog;
     }
     assert.deepEqual(logs.filter((line) => line.includes('intel-history')), []);
+  });
+
+  test(`${domain}/${resource} afterPublish reports both outcomes to ingest health`, async () => {
+    const observations = [];
+    const recordHealth = async (observation) => {
+      observations.push(observation);
+      return null;
+    };
+    const originalWarn = console.warn;
+    const originalLog = console.log;
+    console.warn = () => {};
+    console.log = () => {};
+    try {
+      await hook(payload, { runId: 'run-42' }, {
+        append: async () => ({ inserted: 2, skipped: 1, chunks: 1, abandoned: 0, failedChunks: 0 }),
+        recordHealth,
+      });
+      await hook(payload, { runId: 'run-43' }, {
+        append: async () => {
+          throw new Error('convex 503');
+        },
+        recordHealth,
+      });
+    } finally {
+      console.warn = originalWarn;
+      console.log = originalLog;
+    }
+
+    assert.equal(observations.length, 2);
+    assert.equal(observations[0].domain, domain);
+    assert.equal(observations[0].resource, resource);
+    assert.equal(observations[0].runId, 'run-42');
+    assert.deepEqual(observations[0].result, { inserted: 2, skipped: 1, chunks: 1, abandoned: 0, failedChunks: 0 });
+    assert.equal(observations[0].error, null);
+    assert.equal(observations[1].result, null);
+    assert.match(observations[1].error.message, /convex 503/);
+  });
+
+  test(`${domain}/${resource} afterPublish survives an ingest-health recorder that throws`, async () => {
+    const warns = [];
+    const originalWarn = console.warn;
+    const originalLog = console.log;
+    console.warn = (...args) => warns.push(args.join(' '));
+    console.log = () => {};
+    try {
+      await hook(payload, { runId: 'run-42' }, {
+        append: async () => ({ inserted: 1, skipped: 0, chunks: 1 }),
+        recordHealth: async () => {
+          throw new Error('upstash down');
+        },
+      });
+    } finally {
+      console.warn = originalWarn;
+      console.log = originalLog;
+    }
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /ingest-health record failed \(non-fatal\).*upstash down/);
   });
 }
 

--- a/tests/seed-history.test.mjs
+++ b/tests/seed-history.test.mjs
@@ -249,7 +249,7 @@ describe('buildHistoryEmbeddingText', () => {
 // ── appendSeedHistory — env guard ─────────────────────────────────────────────
 
 describe('appendSeedHistory env guard', () => {
-  it('returns { skipped: "unconfigured" } with exactly one warn and no fetch', async () => {
+  it('returns the unconfigured skip plus the missing names, with one warn and no fetch', async () => {
     const { fetchImpl, calls } = stubFetch({ body: { inserted: 1, skipped: 0 } });
     const { embed, batches } = stubEmbed();
 
@@ -260,7 +260,12 @@ describe('appendSeedHistory env guard', () => {
       ),
     );
 
-    assert.deepEqual(result, { skipped: 'unconfigured' });
+    // `missing` feeds the ingest-health record's `missingConfig` (#5736), so an
+    // operator reading /api/health learns WHICH variable is absent.
+    assert.deepEqual(result, {
+      skipped: 'unconfigured',
+      missing: ['CONVEX_SITE_URL (or CONVEX_URL)', 'RELAY_SHARED_SECRET', 'OPENROUTER_API_KEY'],
+    });
     assert.equal(calls.length, 0);
     assert.equal(batches.length, 0);
     assert.equal(warns.length, 1);


### PR DESCRIPTION
Closes #5736.

## Problem

`appendSeedHistory` is fail-open by design: the canonical publish has already committed when `afterPublish` runs, so a throw there would skip runSeed's `writeFreshnessMetadataSafely` and age seed-meta out on genuinely fresh data (the `scripts/seed-gdelt-intel.mjs:286` hazard). Every history failure logs a warning and returns.

The consequence: **nothing outside the log stream could tell that history had stopped accumulating.** A missing `RELAY_SHARED_SECRET`, a wrong `CONVEX_SITE_URL`, a systematically rejecting relay, or an expired `OPENROUTER_API_KEY` all produced a healthy-looking seed run forever while the store received nothing.

## Fix

A durable per-`(domain, resource)` ingest-health record written on **both** the success and failure paths, kept entirely separate from the collector's own seed-meta:

| Key | Holds |
|---|---|
| `intel-history:ingest-health:<domain>:<resource>:v1` | state, last success, last error code + reason, consecutive failures, accepted volume |
| `seed-meta:intel-history:<domain>:<resource>` | the freshness projection both health surfaces classify |

`fetchedAt` is the **last healthy append, never the last attempt**, so "no successful append in N intervals" ages into `STALE_SEED` on its own while canonical publication keeps reporting OK. The state machine (`projectHistoryIngestHealth`) is pure — no clock, no network — so it is testable without Redis.

The three states the issue asked for map onto machinery both surfaces already have:

- `unconfigured` -> `sourceState: 'unavailable'` -> `NOT_CONFIGURED` / `not_configured`. Visible, never an alarm — matching the repo's existing policy that an un-provisioned adapter is not a fault.
- `failing` -> `sourceState: 'degraded'` -> `SEED_ERROR` / `error` after 2 consecutive failed runs. One failed run is already 3 relay attempts inside a tick; escalating on it would warn for a whole cron interval (6h for energy).
- `healthy` -> `OK`, subject to the ordinary staleness budget.

Registered for all three wired collectors in `/api/health` and `/api/seed-health` with `intervalMin * 2 == maxStaleMin` so both surfaces alarm together, and activation-marker gated so a Vercel deploy landing ahead of the first Railway tick does not page.

`/api/seed-health` now echoes the bounded `lastErrorCode` so an operator can name the cause without reading Redis. The relay-controlled `lastErrorReason` (up to 200 chars of relay response body) stays in Redis and is deliberately not echoed.

## Silent-pass paths caught in review

The change is itself an alarm mechanism, so it got an adversarial pass whose only question was "can this report green while ingestion is dead?" Three ways it could, all closed before merge:

1. **A run that delivered nothing counted as healthy.** `appendSeedHistory` *resolves* rather than throws when its wall-clock budget dies before a single chunk is POSTed (`chunks: 0, abandoned: N`) — it only throws on `chunks === 0 && failedChunks > 0`. Folding that into `healthy` advanced `fetchedAt`, so a relay slow enough to eat the budget every tick stayed green forever. A run with *no candidate records* is deliberately still healthy: nothing was offered, so nothing was lost.
2. **Losing the credential after a success never alarmed.** Removing `RELAY_SHARED_SECRET` from a working deployment reported `NOT_CONFIGURED` — an `ok` bucket — while the staleness clock kept resetting. That is the issue's own headline scenario, relocated rather than fixed. `lastSuccessAt` now separates "never provisioned" (stays silent, correctly) from "credential removed" (escalates on the first tick, `lastErrorCode: config_removed`).
3. **Sustained partial loss counted as clean.** A run that reached the relay but dropped chunks reset the failure streak, so a collector losing records on every tick never escalated. Such a run now counts toward the streak while still advancing `fetchedAt` — the honest report is "reachable, but dropping records", not "stale".

## Verification

Acceptance criterion 4 asked for a test proving a prolonged relay rejection becomes visible in health while canonical publication stays successful. That exists per collector, driving the real state machine into the real `api/health.js` classifier and the real `/api/seed-health` handler — plus an end-to-end pass that runs the actual `appendSeedHistory` (network stubbed only) into the actual reducer, so a producer contract drift cannot silently break the alarm.

Every load-bearing assertion was mutation-tested rather than trusted green:

| Mutation | Tests killed |
|---|---|
| `sourceState` never escalates to `degraded` | 5 |
| `lastHealthyAt` advances on failure | 5 |
| nothing-delivered guard removed | 3 |
| credential removal is never a regression | 2 |
| lossy runs stop counting | 2 |

All reverted. Also green: 973 tests across the full blast radius (everything importing `api/health.js`, `api/seed-health.js`, or `_seed-history`), `typecheck`, `typecheck:api`, `lint:api-contract`, `docs:check`, biome.

## Rollout note

If the relay leg is broken in production **today** — the premise of the issue — these three keys start reporting `SEED_ERROR`/`STALE_SEED` on the first Railway tick after deploy. That is the intended behaviour, but it means the scheduled seed-freshness monitor will start failing until the underlying relay problem is fixed. Worth confirming the three `seed-activated:intel-history:*` markers appear in production Redis after the first ticks.

https://claude.ai/code/session_014qYBRvQ3DGQPeEyx7wgKVn