### PR TITLE
fix(session): recover when cookies cannot persist

### DIFF
--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -23,6 +23,7 @@ const SESSION_RATE_LIMIT_WINDOW = '60 s';
 function jsonResponse(body, status, headers) {
   const out = headers instanceof Headers ? headers : new Headers(headers);
   out.set('Content-Type', 'application/json');
+  out.set('Cache-Control', 'no-store');
   return new Response(JSON.stringify(body), {
     status,
     headers: out,
@@ -229,5 +230,15 @@ export default async function handler(req, ctx) {
     headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, PRO_KEY_COOKIE, proKey));
   }
 
-  return respond({ ok: true, exp: issued.exp, hadSession }, 200, headers, 'ok');
+  // The HttpOnly cookie remains the primary transport. The anonymous token is
+  // also returned so browsers that demonstrably refuse the shared-domain
+  // cookie can use the existing X-WorldMonitor-Key validation path. This does
+  // not expose user or premium authority: wms_ tokens are freely mintable,
+  // anonymous-only, and forceKey routes reject them.
+  return respond({
+    ok: true,
+    exp: issued.exp,
+    hadSession,
+    token: issued.token,
+  }, 200, headers, 'ok');
 }

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -110,15 +110,18 @@ function makeWaitUntilCtx() {
   };
 }
 
-test('POST from trusted origin sets a valid HttpOnly wms_ session cookie without exposing token JSON', async () => {
+test('POST sets a valid HttpOnly cookie and returns the anonymous-only fallback token', async () => {
   const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
   assert.equal(resp.status, 200);
   const body = await resp.json();
-  assert.equal(body.token, undefined);
+  assert.match(body.token, /^wms_/);
+  assert.equal(await validateSessionToken(body.token), true);
   assert.equal(typeof body.exp, 'number');
+  assert.equal(resp.headers.get('cache-control'), 'no-store');
   const cookies = setCookies(resp);
   const token = cookieValue(cookies, 'wm-session');
   assert.match(token, /^wms_/);
+  assert.equal(body.token, token, 'cookie and fallback header must carry the same anonymous token');
   assert.equal(await validateSessionToken(token), true);
   assert.match(cookies.join('\n'), /wm-session=.*HttpOnly/);
   assert.match(cookies.join('\n'), /wm-session=.*Domain=\.worldmonitor\.app/);
@@ -289,8 +292,10 @@ test('No origin (curl) is allowed (rate limit + token TTL are the throttles)', a
   const resp = await handler(makeReq('POST', {}));
   assert.equal(resp.status, 200);
   const body = await resp.json();
-  assert.equal(body.token, undefined);
-  assert.match(cookieValue(setCookies(resp), 'wm-session'), /^wms_/);
+  const cookieToken = cookieValue(setCookies(resp), 'wm-session');
+  assert.match(body.token, /^wms_/);
+  assert.equal(body.token, cookieToken);
+  assert.equal(await validateSessionToken(body.token), true);
 });
 
 test('POST returns degraded 503 without issuing a token when Redis limiter config is missing', async () => {

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -856,6 +856,17 @@ export function installWmSessionFetchInterceptor(): void {
           if (isCurrentSessionIdentity()) noteRecoveryFailure('mint_failed', path);
           return null;
         }
+        // Recovery already has stronger evidence than a page-boot mint: the
+        // request that brought us here was rejected, and this fresh mint handed
+        // back an anonymous-only token. Use it for the verification replay now.
+        // This also covers reloads where sessionStorage retained a fresh expiry
+        // but the HttpOnly cookie was dropped: cookieIssuedThisSession starts
+        // false, so hadSession:false alone cannot safely prove persistence is
+        // broken, while replaying without the returned token would send every
+        // concurrent follower into the retry_401 quorum.
+        if (anonymousSessionHeaderToken) {
+          useAnonymousSessionHeader = true;
+        }
         const retryResp = await replayAndReport();
         return retryResp.status === 401 ? null : retryResp;
       })();

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -423,6 +423,7 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
   // would otherwise let the first response to land make the others look like
   // follow-up mints that came back empty. See noteMintCookieEvidence.
   const aCookieExistedWhenSent = cookieIssuedThisSession;
+  const identityGenerationWhenSent = sessionIdentityGeneration;
   // AbortSignal.timeout is Baseline 2024 and absent on older Safari/WebView and
   // Smart-TV engines still present in production. Calling it directly throws
   // before fetch is dispatched and looks exactly like a server-side
@@ -444,7 +445,11 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
     if (!resp.ok) return null;
     const data = await resp.json() as { exp?: unknown; hadSession?: unknown; token?: unknown };
     if (typeof data?.exp !== 'number') return null;
-    if (typeof data.token === 'string' && data.token.startsWith('wms_')) {
+    if (
+      sessionIdentityGeneration === identityGenerationWhenSent &&
+      typeof data.token === 'string' &&
+      data.token.startsWith('wms_')
+    ) {
       anonymousSessionHeaderToken = data.token;
     }
     // Absent on an older deployment: treat as "no evidence either way" and
@@ -864,7 +869,7 @@ export function installWmSessionFetchInterceptor(): void {
         // false, so hadSession:false alone cannot safely prove persistence is
         // broken, while replaying without the returned token would send every
         // concurrent follower into the retry_401 quorum.
-        if (anonymousSessionHeaderToken) {
+        if (isCurrentSessionIdentity() && anonymousSessionHeaderToken) {
           useAnonymousSessionHeader = true;
         }
         const retryResp = await replayAndReport();

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -72,6 +72,11 @@ type WmSessionDeadReason = 'mint_failed' | 'retry_401' | 'cookie_not_persisted';
 let cookieIssuedThisSession = false;
 // Latched once a mint proves the browser did not keep the previous cookie.
 let cookiePersistenceBroken = false;
+// Anonymous-only fallback for clients that reject the shared-domain HttpOnly
+// cookie. Kept in memory (never local/session storage) and activated only
+// after the server proves a prior cookie did not make the round trip.
+let anonymousSessionHeaderToken: string | null = null;
+let useAnonymousSessionHeader = false;
 
 interface StoredSession {
   exp: number;
@@ -393,6 +398,7 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
     // direct evidence outranks inference, same doctrine as noteRouteSuccess.
     cookieIssuedThisSession = true;
     cookiePersistenceBroken = false;
+    useAnonymousSessionHeader = false;
     return;
   }
   cookieIssuedThisSession = true;
@@ -409,6 +415,7 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
   // without one: the browser is not storing it (strict cookie settings, an
   // in-app WebView, partitioned storage, a privacy extension).
   cookiePersistenceBroken = true;
+  useAnonymousSessionHeader = anonymousSessionHeaderToken !== null;
 }
 
 async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): Promise<StoredSession | null> {
@@ -416,6 +423,15 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
   // would otherwise let the first response to land make the others look like
   // follow-up mints that came back empty. See noteMintCookieEvidence.
   const aCookieExistedWhenSent = cookieIssuedThisSession;
+  // AbortSignal.timeout is Baseline 2024 and absent on older Safari/WebView and
+  // Smart-TV engines still present in production. Calling it directly throws
+  // before fetch is dispatched and looks exactly like a server-side
+  // mint_failed episode. AbortController has materially wider support.
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(
+    () => timeoutController.abort(),
+    fetchNewSessionTimeoutMs,
+  );
   try {
     const fetchImpl = nativeSessionFetch ?? globalThis.fetch;
     const resp = await fetchImpl(toApiUrl('/api/wm-session'), {
@@ -423,11 +439,14 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: body ? JSON.stringify(body) : undefined,
-      signal: AbortSignal.timeout(fetchNewSessionTimeoutMs),
+      signal: timeoutController.signal,
     });
     if (!resp.ok) return null;
-    const data = await resp.json() as { exp?: unknown; hadSession?: unknown };
+    const data = await resp.json() as { exp?: unknown; hadSession?: unknown; token?: unknown };
     if (typeof data?.exp !== 'number') return null;
+    if (typeof data.token === 'string' && data.token.startsWith('wms_')) {
+      anonymousSessionHeaderToken = data.token;
+    }
     // Absent on an older deployment: treat as "no evidence either way" and
     // leave the latch alone rather than accusing a healthy browser.
     if (typeof data.hadSession === 'boolean') {
@@ -436,6 +455,8 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
     return { exp: data.exp };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -461,6 +482,10 @@ export async function ensureWmSession(): Promise<boolean> {
       // name the real cause, instead of letting the retry_401 quorum report it
       // as the API rejecting a good cookie (WORLDMONITOR-WG/XP).
       if (cookiePersistenceBroken) {
+        if (anonymousSessionHeaderToken) {
+          useAnonymousSessionHeader = true;
+          return true;
+        }
         markWmSessionDead('cookie_not_persisted', '/api/wm-session');
         return false;
       }
@@ -495,6 +520,8 @@ export async function establishWmKeySession(keys: { widgetKey?: string; proKey?:
   routeStrikes.clear();
   recentRouteFailures.clear();
   cookiePersistenceBroken = false;
+  anonymousSessionHeaderToken = null;
+  useAnonymousSessionHeader = false;
   saveToStorage(fresh);
   return true;
 }
@@ -526,6 +553,8 @@ export function __resetWmSessionForTests(): void {
   recentRouteFailures.clear();
   cookieIssuedThisSession = false;
   cookiePersistenceBroken = false;
+  anonymousSessionHeaderToken = null;
+  useAnonymousSessionHeader = false;
   sentryEnqueue = enqueueSentryCall;
   fetchNewSessionTimeoutMs = 10_000;
 }
@@ -717,11 +746,21 @@ export function installWmSessionFetchInterceptor(): void {
     const requestClone = input instanceof Request ? input.clone() : null;
 
     const sendWith = (h: Headers, src: typeof input): Promise<Response> => {
+      const requestHeaders = new Headers(h);
+      if (
+        useAnonymousSessionHeader &&
+        anonymousSessionHeaderToken &&
+        !requestHeaders.has('Authorization') &&
+        !requestHeaders.has('X-WorldMonitor-Key') &&
+        !requestHeaders.has('X-Api-Key')
+      ) {
+        requestHeaders.set('X-WorldMonitor-Key', anonymousSessionHeaderToken);
+      }
       if (src instanceof Request) {
-        const cloned = new Request(src, { ...withCredentials(init), headers: h });
+        const cloned = new Request(src, { ...withCredentials(init), headers: requestHeaders });
         return original(cloned);
       }
-      return original(src, { ...withCredentials(init), headers: h });
+      return original(src, { ...withCredentials(init), headers: requestHeaders });
     };
 
     // Replay once with whatever cookie is current now and record what that

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1864,7 +1864,55 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 // ---------------------------------------------------------------------------
 
 describe('wm-session cookie-persistence detection (Layer 3)', () => {
-  it('reports cookie_not_persisted and stops spending mints once the cookie proves unstorable', async () => {
+  it('mints on browsers that do not implement AbortSignal.timeout', async () => {
+    memoryStorage.clear();
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: false,
+          token: 'wms_legacy-browser-token',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    const originalTimeout = AbortSignal.timeout;
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      assert.equal(
+        await mod.ensureWmSession(),
+        true,
+        'missing AbortSignal.timeout must not fail before the mint request is dispatched',
+      );
+    } finally {
+      Object.defineProperty(AbortSignal, 'timeout', {
+        configurable: true,
+        value: originalTimeout,
+      });
+    }
+  });
+
+  it('still aborts a stalled mint without AbortSignal.timeout', async () => {
+    memoryStorage.clear();
+    mod.__setWmSessionFetchTimeoutForTests(5);
+    currentFetchHandler = (_input, init) => new Promise((_resolve, reject) => {
+      const signal = init?.signal;
+      assert.ok(signal, 'the compatible timeout must pass an AbortSignal');
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+
+    assert.equal(await mod.ensureWmSession(), false, 'a stalled mint must fail closed after the timeout');
+  });
+
+  it('falls back to the anonymous session header once the cookie proves unstorable', async () => {
     memoryStorage.clear();
 
     const captures: Array<{ ctx: { tags?: Record<string, string> } }> = [];
@@ -1876,41 +1924,68 @@ describe('wm-session cookie-persistence detection (Layer 3)', () => {
     }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
 
     let mints = 0;
-    currentFetchHandler = (input) => {
+    const fallbackToken = 'wms_header-fallback-token';
+    let premiumFallbackHeader: string | null = null;
+    currentFetchHandler = (input, init) => {
       const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
       if (url.includes('/api/wm-session')) {
         mints += 1;
         // The browser stores nothing, so EVERY mint arrives without a cookie.
-        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE, hadSession: false }), {
+        return Promise.resolve(new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: false,
+          token: fallbackToken,
+        }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         }));
       }
-      return Promise.resolve(new Response('no cookie presented', { status: 401 }));
+      const headers = new Headers(init?.headers);
+      if (url.includes('/api/market/v1/analyze-stock')) {
+        premiumFallbackHeader = headers.get('X-WorldMonitor-Key');
+        return Promise.resolve(new Response('premium auth remains separate', { status: 401 }));
+      }
+      if (headers.get('X-WorldMonitor-Key') === 'wm_explicit-user-key') {
+        return Promise.resolve(new Response('explicit user key preserved', { status: 200 }));
+      }
+      return Promise.resolve(headers.get('X-WorldMonitor-Key') === fallbackToken
+        ? new Response('header session accepted', { status: 200 })
+        : new Response('no cookie presented', { status: 401 }));
     };
 
     const originalWarn = console.warn;
     console.warn = () => {};
     try {
-      await wrappedFetch('https://api.worldmonitor.app/api/conflict/v1/get-humanitarian-summary-batch');
+      const recovered = await wrappedFetch('https://api.worldmonitor.app/api/conflict/v1/get-humanitarian-summary-batch');
+      assert.equal(recovered.status, 200, 'the request that proves cookie loss must recover through the header');
       const afterFirstRoute = mints;
-      await wrappedFetch('https://api.worldmonitor.app/api/military/v1/get-aircraft-details-batch');
+      const next = await wrappedFetch('https://api.worldmonitor.app/api/military/v1/get-aircraft-details-batch');
+      assert.equal(next.status, 200, 'later requests must use the in-memory anonymous header token');
       assert.equal(
         mints,
         afterFirstRoute,
-        'a cookie proven unstorable must not be re-minted for the next route',
+        'a cookie proven unstorable must not require another mint for the next route',
+      );
+      const explicit = await wrappedFetch(
+        'https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health',
+        { headers: { 'X-WorldMonitor-Key': 'wm_explicit-user-key' } },
+      );
+      assert.equal(explicit.status, 200, 'an explicit user key must outrank the anonymous fallback');
+
+      const premium = await wrappedFetch('https://api.worldmonitor.app/api/market/v1/analyze-stock');
+      assert.equal(premium.status, 401, 'premium auth remains owned by its dedicated injector');
+      assert.equal(
+        premiumFallbackHeader,
+        null,
+        'the anonymous fallback must never be injected into a premium route',
       );
     } finally {
       console.warn = originalWarn;
     }
 
     const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
-    assert.equal(dead.length, 1, 'exactly one session-dead episode');
-    assert.equal(
-      dead[0].ctx.tags?.reason,
-      'cookie_not_persisted',
-      'must name the browser-side storage failure, not blame the server with retry_401',
-    );
+    assert.equal(dead.length, 0, 'a working header fallback is not a dead-session episode');
+    assert.equal(mod.isWmSessionDead(), false, 'cookie rejection must not black out anonymous data');
   });
 
   it('does not accuse a brand-new browser whose first mint legitimately carries no cookie', async () => {

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1988,6 +1988,53 @@ describe('wm-session cookie-persistence detection (Layer 3)', () => {
     assert.equal(mod.isWmSessionDead(), false, 'cookie rejection must not black out anonymous data');
   });
 
+  it('activates the header fallback for concurrent recovery after a reload drops the cookie', async () => {
+    memoryStorage.clear();
+    memoryStorage.set('wm-session-exp', JSON.stringify({ exp: FAR_FUTURE }));
+
+    let mints = 0;
+    const fallbackToken = 'wms_concurrent-reload-token';
+    const routeAttempts = new Map<string, number>();
+    currentFetchHandler = async (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mints += 1;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: false,
+          token: fallbackToken,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      const attempts = (routeAttempts.get(url) ?? 0) + 1;
+      routeAttempts.set(url, attempts);
+      const headers = new Headers(init?.headers);
+      return headers.get('X-WorldMonitor-Key') === fallbackToken
+        ? new Response('header session accepted', { status: 200 })
+        : new Response('cookie missing after reload', { status: 401 });
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const [first, second] = await Promise.all([
+        wrappedFetch('https://api.worldmonitor.app/api/conflict/v1/get-humanitarian-summary-batch'),
+        wrappedFetch('https://api.worldmonitor.app/api/military/v1/get-aircraft-details-batch'),
+      ]);
+
+      assert.equal(first.status, 200, 'the recovery leader must replay with the minted fallback token');
+      assert.equal(second.status, 200, 'the recovery follower must share the same working fallback');
+      assert.equal(mints, 1, 'concurrent recovery must share exactly one mint');
+      assert.equal(mod.isWmSessionDead(), false, 'successful fallback recovery must not enter cooldown');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('does not accuse a brand-new browser whose first mint legitimately carries no cookie', async () => {
     // Every first-time visitor mints without a cookie. Reading that as
     // non-persistence would black out the whole anonymous surface on arrival.

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1671,25 +1671,44 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 
   it('ignores an anonymous recovery result that settles after a key-session upgrade', async () => {
     memoryStorage.clear();
+    memoryStorage.set('wm-session-exp', JSON.stringify({ exp: FAR_FUTURE }));
     const { captures } = collectSentry();
     const gated = 'https://api.worldmonitor.app/api/intelligence/v1/get-risk-scores';
     let gatedAttempts = 0;
-    let releaseAnonymousRetry: (() => void) | null = null;
+    let releaseAnonymousMint: (() => void) | null = null;
+    const anonymousToken = 'wms_stale-anonymous-recovery';
+    const fallbackHeaders: Array<string | null> = [];
 
-    currentFetchHandler = (input) => {
+    currentFetchHandler = (input, init) => {
       const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
       if (url.includes('/api/wm-session')) {
-        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE }), {
+        const body = typeof init?.body === 'string' ? JSON.parse(init.body) as { proKey?: string } : {};
+        if (!body.proKey) {
+          return new Promise((resolve) => {
+            releaseAnonymousMint = () => resolve(new Response(JSON.stringify({
+              exp: FAR_FUTURE,
+              hadSession: false,
+              token: anonymousToken,
+            }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }));
+          });
+        }
+        return Promise.resolve(new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: false,
+          token: 'wms_key-upgrade-mint',
+        }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         }));
       }
 
+      fallbackHeaders.push(new Headers(init?.headers).get('X-WorldMonitor-Key'));
       gatedAttempts += 1;
       if (gatedAttempts === 1) return Promise.resolve(new Response('stale', { status: 401 }));
-      return new Promise((resolve) => {
-        releaseAnonymousRetry = () => resolve(new Response('old identity denied', { status: 401 }));
-      });
+      return Promise.resolve(new Response('key cookie accepted', { status: 200 }));
     };
 
     const originalWarn = console.warn;
@@ -1697,19 +1716,29 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
     try {
       const anonymousRequest = wrappedFetch(gated);
       await new Promise((resolve) => { setImmediate(resolve); });
-      assert.ok(releaseAnonymousRetry, 'the anonymous fresh-cookie retry should still be in flight');
+      assert.ok(releaseAnonymousMint, 'the anonymous recovery mint should still be in flight');
 
       assert.equal(
         await mod.establishWmKeySession({ proKey: 'pk_test' }),
         true,
         'the key-bound identity should replace the anonymous one',
       );
-      releaseAnonymousRetry?.();
-      assert.equal((await anonymousRequest).status, 401, 'the stale caller still receives its server verdict');
+      releaseAnonymousMint?.();
+      assert.equal((await anonymousRequest).status, 200, 'the stale caller replays through the upgraded identity');
+      assert.equal(
+        (await wrappedFetch(gated)).status,
+        200,
+        'later requests continue through the upgraded key session',
+      );
     } finally {
       console.warn = originalWarn;
     }
 
+    assert.deepEqual(
+      fallbackHeaders,
+      [null, null, null],
+      'a stale anonymous mint must never inject its token after a key-session upgrade',
+    );
     assert.deepEqual(mod.getStruckRoutes(), [], 'the old identity must not repopulate route suppression');
     assert.equal(mod.isWmSessionDead(), false, 'the old identity must not degrade the key-bound session');
     assert.equal(captures.length, 0, 'the stale anonymous denial must not be reported against the key-bound identity');


### PR DESCRIPTION
## Summary

Anonymous dashboard sessions no longer enter a 15-minute blackout when an older browser cannot construct `AbortSignal.timeout()` or refuses the shared-domain session cookie. Mint requests now use a broadly supported `AbortController` timeout, and a client that proves cookie persistence is unavailable can carry the anonymous-only `wms_` token through the existing in-memory header path.

The fallback never persists the token in browser storage, never overrides an explicit Clerk or API credential, and is excluded from premium routes. The mint response is explicitly non-cacheable, and premium `forceKey` validation continues to reject anonymous session tokens.

## Validation

- Reproduced both failure modes with red-before/green-after regression tests: missing `AbortSignal.timeout()` and a browser that drops every session cookie.
- `tests/wm-session-auto-refresh.test.mts`: 42 passed.
- `api/wm-session.test.mjs`, `api/_api-key.test.mjs`, and `api/_cors.test.mjs`: 57 passed.
- Edge-function checks: 239 passed.
- `npm run typecheck` and `npm run typecheck:api`.
- Full pre-push gate passed, including boundary, safe-HTML, Sentry coverage, rate-limit, premium-fetch, Edge bundle, and version checks.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
