### PR TITLE
fix(self-hosting): support optional AIS and Windows seeders

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -57,9 +57,7 @@ const API_KEY = process.env.AISSTREAM_API_KEY || process.env.VITE_AISSTREAM_API_
 const PORT = process.env.PORT || 3004;
 
 if (!API_KEY) {
-  console.error('[Relay] Error: AISSTREAM_API_KEY environment variable not set');
-  console.error('[Relay] Get a free key at https://aisstream.io');
-  process.exit(1);
+  console.warn('[Relay] AIS disabled: AISSTREAM_API_KEY is not set (other relay and seed services remain available)');
 }
 
 const MAX_WS_CLIENTS = 10; // Cap WS clients — app uses HTTP snapshots, not WS
@@ -11480,6 +11478,8 @@ function switchTab(btn, key) {
 // ─── End Widget Agent ────────────────────────────────────────────────────────
 
 function connectUpstream() {
+  if (!API_KEY) return;
+
   // Skip if already connected or connecting
   if (upstreamSocket?.readyState === WebSocket.OPEN ||
       upstreamSocket?.readyState === WebSocket.CONNECTING) return;

--- a/scripts/run-seeders.sh
+++ b/scripts/run-seeders.sh
@@ -91,11 +91,18 @@ caps_seed() {
 }
 
 run_seed() {
+  node_file="$1"
+  # Native Windows Node does not understand MSYS paths such as /c/Users/...
+  # and resolves them as C:\c\Users\.... Convert only when cygpath is present.
+  if command -v cygpath >/dev/null 2>&1; then
+    node_file="$(cygpath -w "$node_file")"
+  fi
+
   if caps_seed "$1"; then
     # -k: if it ignores SIGTERM, SIGKILL it 30s later so the run can move on.
-    timeout -k 30 "$SEED_TIMEOUT" node "$1" 2>&1
+    timeout -k 30 "$SEED_TIMEOUT" node "$node_file" 2>&1
   else
-    node "$1" 2>&1
+    node "$node_file" 2>&1
   fi
 }
 

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { describe, it } from 'node:test';
 
 // Regression coverage for issue #3804: the self-hosted Docker stack must
@@ -8,8 +11,9 @@ import { describe, it } from 'node:test';
 // "wm-local-token"; flipping the redis-rest binding from 127.0.0.1 to
 // 0.0.0.0 instantly exposed an authenticated interface with a known token.
 //
-// These tests grep the relevant repo files for forbidden patterns rather
-// than starting containers, because:
+// Most tests grep the relevant repo files for forbidden patterns rather
+// than starting containers, while cross-platform execution paths use
+// hermetic command stubs. This keeps the suite deterministic because:
 //   - the dangerous shape is a literal default in YAML / shell, which a
 //     literal-absence regex catches deterministically without any harness;
 //   - any future contributor who reintroduces the default in any of the
@@ -29,6 +33,11 @@ function serviceBlock(compose: string, serviceName: string): string {
   );
   assert.ok(match, `docker-compose.yml must define ${serviceName} service`);
   return match[1];
+}
+
+async function writeExecutable(path: string, contents: string): Promise<void> {
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
 }
 
 // Allow a documentation note that EXPLAINS the historical default while
@@ -52,6 +61,22 @@ const SHIPPED_DEFAULT_PATTERNS: RegExp[] = [
 ];
 
 describe('docker self-hosting — no default credentials (#3804)', () => {
+  it('parses service blocks from CRLF Compose input', () => {
+    const compose = [
+      'services:',
+      '  ais-relay:',
+      '    environment:',
+      '      AISSTREAM_API_KEY: optional',
+      '  redis:',
+      '    image: redis:7',
+      'volumes:',
+      '  redis-data:',
+      '',
+    ].join('\r\n');
+
+    assert.match(serviceBlock(compose, 'ais-relay'), /AISSTREAM_API_KEY: optional/);
+  });
+
   it('docker-compose.yml does not default REDIS_TOKEN or UPSTASH_REDIS_REST_TOKEN to a literal', async () => {
     const compose = await read('docker-compose.yml');
     assert.ok(
@@ -172,16 +197,56 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
     );
   });
 
-  it('scripts/run-seeders.sh converts MSYS paths before invoking native Windows Node', async () => {
-    const sh = await read('scripts/run-seeders.sh');
-    assert.match(sh, /command -v cygpath/);
-    assert.match(sh, /node_file="\$\(cygpath -w "\$node_file"\)"/);
-    assert.match(sh, /node "\$node_file"/);
-    assert.match(
-      sh,
-      /if caps_seed "\$1"/,
-      'timeout classification must continue to inspect the original POSIX path',
-    );
+  it('scripts/run-seeders.sh passes converted MSYS paths to Node with and without timeout', async () => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'wm-run-seeders-msys-'));
+    const scriptsDir = join(fixtureRoot, 'scripts');
+    const binDir = join(fixtureRoot, 'bin');
+    const nodeArgLog = join(fixtureRoot, 'node-args.log');
+
+    try {
+      await mkdir(scriptsDir);
+      await mkdir(binDir);
+      await writeFile(join(fixtureRoot, '.env'), 'REDIS_TOKEN=fixture-token\n');
+      await writeFile(join(scriptsDir, 'run-seeders.sh'), await read('scripts/run-seeders.sh'));
+      await writeFile(join(scriptsDir, 'seed-probe.mjs'), '// fixture seeder\n');
+      await writeExecutable(join(binDir, 'cygpath'), `#!/bin/sh
+[ "$1" = "-w" ] || exit 64
+printf '%s\n' 'C:\\fixture\\seed-probe.mjs'
+`);
+      await writeExecutable(join(binDir, 'node'), `#!/bin/sh
+printf '%s\n' "$1" >> "$NODE_ARG_LOG"
+printf '%s\n' 'probe ok'
+`);
+      await writeExecutable(join(binDir, 'timeout'), `#!/bin/sh
+if [ "$1" = "-k" ]; then shift 2; fi
+shift
+exec "$@"
+`);
+
+      const env = {
+        ...process.env,
+        PATH: `${binDir}${delimiter}${process.env.PATH || ''}`,
+        NODE_ARG_LOG: nodeArgLog,
+      };
+      for (const seedTimeout of ['0', '30']) {
+        const result = spawnSync('sh', [join(scriptsDir, 'run-seeders.sh')], {
+          encoding: 'utf8',
+          env: { ...env, SEED_TIMEOUT: seedTimeout },
+        });
+        assert.equal(
+          result.status,
+          0,
+          `run-seeders.sh failed with SEED_TIMEOUT=${seedTimeout}\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+        );
+      }
+
+      assert.deepEqual(
+        (await readFile(nodeArgLog, 'utf8')).trim().split('\n'),
+        ['C:\\fixture\\seed-probe.mjs', 'C:\\fixture\\seed-probe.mjs'],
+      );
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it('.env.example documents REDIS_PASSWORD and REDIS_TOKEN as self-hosted Docker vars', async () => {

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -23,7 +23,8 @@ async function read(rel: string): Promise<string> {
 }
 
 function serviceBlock(compose: string, serviceName: string): string {
-  const match = compose.match(
+  const normalizedCompose = compose.replaceAll('\r\n', '\n');
+  const match = normalizedCompose.match(
     new RegExp(`^  ${serviceName}:\\n([\\s\\S]*?)(?=^  [a-zA-Z0-9_-]+:\\n|^volumes:)`, 'm'),
   );
   assert.ok(match, `docker-compose.yml must define ${serviceName} service`);
@@ -168,6 +169,18 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
     assert.ok(
       /if \[ -n "\$\{REDIS_TOKEN[^}]*}" \]/.test(sh),
       'scripts/run-seeders.sh must unconditionally prefer REDIS_TOKEN when set (PR #3829 P1)',
+    );
+  });
+
+  it('scripts/run-seeders.sh converts MSYS paths before invoking native Windows Node', async () => {
+    const sh = await read('scripts/run-seeders.sh');
+    assert.match(sh, /command -v cygpath/);
+    assert.match(sh, /node_file="\$\(cygpath -w "\$node_file"\)"/);
+    assert.match(sh, /node "\$node_file"/);
+    assert.match(
+      sh,
+      /if caps_seed "\$1"/,
+      'timeout classification must continue to inspect the original POSIX path',
     );
   });
 

--- a/tests/relay-auth.test.mjs
+++ b/tests/relay-auth.test.mjs
@@ -79,11 +79,9 @@ function spawnRelay(envOverrides = {}) {
   const child = spawn(process.execPath, [RELAY_SCRIPT], {
     env: {
       // Inherit PATH, HOME, etc. but start from a clean slate for any env var
-      // we care about. We DO need a few unrelated vars to be present so the
-      // relay only fails on the auth guard, not the AIS upstream key check.
+      // we care about. Keep AIS configured by default; degraded-mode tests can
+      // explicitly blank it when they need to exercise the optional upstream.
       ...process.env,
-      // The AIS upstream key is checked BEFORE the auth guard. Tests that want
-      // to reach the auth guard must provide it.
       AISSTREAM_API_KEY: 'test-aisstream-key',
       // Strip every env var the auth guard cares about so tests start from a
       // known state. Each test then sets only what it needs.
@@ -194,6 +192,25 @@ describe('relay startup auth guard (#3801)', () => {
     try {
       await r.waitForLog('WebSocket relay on port', 15_000);
       assert.doesNotMatch(r.stderr(), /\[SECURITY\] relay is running WITHOUT auth/, 'should NOT warn when auth is on');
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+
+  it('boots with auth enabled when AISSTREAM_API_KEY is absent', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      AISSTREAM_API_KEY: '',
+      VITE_AISSTREAM_API_KEY: '',
+      RELAY_SHARED_SECRET: 'good-secret',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      assert.match(r.stderr(), /AIS disabled: AISSTREAM_API_KEY is not set/);
+      assert.equal(r.child.exitCode, null, 'relay should remain available without the optional AIS upstream');
+      const res = await httpGet(port, '/health');
+      assert.equal(res.status, 200);
     } finally {
       await killRelay(r.child);
     }

--- a/tests/relay-auth.test.mjs
+++ b/tests/relay-auth.test.mjs
@@ -211,6 +211,15 @@ describe('relay startup auth guard (#3801)', () => {
       assert.equal(r.child.exitCode, null, 'relay should remain available without the optional AIS upstream');
       const res = await httpGet(port, '/health');
       assert.equal(res.status, 200);
+      assert.equal(JSON.parse(res.body).connected, false);
+
+      const snapshot = await httpGet(port, '/ais/snapshot', { 'x-relay-key': 'good-secret' });
+      assert.equal(snapshot.status, 200);
+      assert.doesNotMatch(
+        r.stdout(),
+        /\[Relay\] Connecting to aisstream\.io/,
+        'missing AIS credentials must suppress upstream connection attempts',
+      );
     } finally {
       await killRelay(r.child);
     }


### PR DESCRIPTION
## Summary

- keep the self-hosted relay available when the optional `AISSTREAM_API_KEY` is absent while disabling only the AIS upstream connection
- convert MSYS paths with `cygpath` before invoking native Windows Node from `run-seeders.sh`
- add regression coverage for AIS-degraded startup, Windows seeder paths, and CRLF-tolerant Compose test parsing

## Testing

- `node --check scripts/ais-relay.cjs`
- `sh -n scripts/run-seeders.sh`
- `./node_modules/.bin/tsx --test tests/relay-auth.test.mjs tests/docker-compose-no-default-secrets.test.mts` - 21/21 passed
- `npm run lint` - passed (pre-existing warnings only)
- `npm run typecheck` - passed
- `npm run test:data` - not fully green on this Windows shallow checkout: 18,197 passed, 64 failed, 18 cancelled; failures span unrelated generated-artifact, shallow-history, registry, and environment-sensitive contracts, while both changed focused suites pass
