### PR TITLE
fix(ops): fail closed on ingestion acceptance drift

### DIFF
--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -13,8 +13,11 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment:
+      name: ingestion-acceptance-production
+      deployment: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -48,7 +51,7 @@ jobs:
             exit 1
           fi
           if [ -z "$RAILWAY_PROJECT_ID" ]; then
-            echo "::error::RAILWAY_PROJECT_ID repository variable is required for the production config audit."
+            echo "::error::RAILWAY_PROJECT_ID Actions environment variable is required for the production config audit."
             exit 1
           fi
           railway link --project "$RAILWAY_PROJECT_ID" --environment production --json

--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Require green main for scheduled alerts
+      - name: Require green main for scheduled acceptance
         id: gate
         if: github.event_name == 'schedule'
         env:
@@ -29,13 +29,34 @@ jobs:
           gate_state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
             --jq '[.statuses[] | select(.context == "gate")] | sort_by(.updated_at) | last | .state // "missing"')
           echo "gate_state=$gate_state"
-          if [ "$gate_state" = "success" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping seed freshness alert because main gate is $gate_state."
+          if [ "$gate_state" != "success" ]; then
+            echo "::error::Cannot establish ingestion operational acceptance because main gate is $gate_state."
+            exit 1
           fi
+          echo "Exact main revision passed repository gates."
+
+      - name: Install pinned Railway CLI
+        run: npm install --global @railway/cli@5.30.1
+
+      - name: Link Railway production context
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_PRODUCTION_TOKEN is required for the read-only production config audit."
+            exit 1
+          fi
+          if [ -z "$RAILWAY_PROJECT_ID" ]; then
+            echo "::error::RAILWAY_PROJECT_ID repository variable is required for the production config audit."
+            exit 1
+          fi
+          railway link --project "$RAILWAY_PROJECT_ID" --environment production --json
+
+      - name: Audit Railway ingestion deployment controls
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
+        run: node scripts/audit-railway-watch-paths.mjs
 
       - name: Check ingestion operational acceptance
-        if: github.event_name == 'workflow_dispatch' || steps.gate.outputs.should_run == 'true'
         run: node scripts/check-seed-freshness.mjs

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -68,6 +68,16 @@ publisher, while still auditing their watch paths and required environment.
 Run the audit after adding or replacing a standalone seeder, changing a bundle
 dependency, or changing a production cron.
 
+The scheduled operational-acceptance workflow performs the same audit in
+read-only mode before checking compact health. Configure the GitHub Actions
+secret `RAILWAY_PRODUCTION_TOKEN` with a Railway project token scoped to the
+production environment, and set the non-secret repository variable
+`RAILWAY_PROJECT_ID` to the `world-monitor` project ID. The workflow maps the
+project token to the CLI's standard `RAILWAY_TOKEN` variable, links only inside
+the ephemeral runner, and never passes `--apply`. Do not use the broader
+account-scoped `RAILWAY_API_TOKEN`. Missing context intentionally fails the
+acceptance run rather than silently skipping the live audit.
+
 ### Bootstrap R2 publisher contract
 
 The public bootstrap tiers use the dedicated private bucket
@@ -124,13 +134,18 @@ incident note.
 
 `.github/workflows/seed-freshness-monitor.yml` runs every 15 minutes on the
 default branch. Scheduled runs first require the latest `main` commit's `gate`
-status to be green; manual runs execute directly. The monitor checks public
-compact health and fails on every actionable problem, including `SEED_ERROR`,
-`STALE_SEED`, `STALE_CONTENT`, and degraded composed coverage. Statuses that
-explicitly end in `_ON_DEMAND` remain informational. It deliberately does not
-run on an ingestion push because Railway may not have deployed or executed that
-revision yet. This is the operational acceptance gate for the "merged and
-green, but production data is still unhealthy" gap.
+status to be green; a missing, pending, or failed gate makes the workflow fail
+closed instead of producing a green skipped run. Manual runs execute directly.
+After the repository gate, the workflow checks live Railway watch paths, cron
+schedules, required routing variables, and service presence against
+`scripts/railway-services.json`, then checks public compact health. It fails on
+every actionable problem, including `SEED_ERROR`, `STALE_SEED`,
+`STALE_CONTENT`, and degraded composed coverage. Statuses that explicitly end
+in `_ON_DEMAND` remain informational. It deliberately does not run on an
+ingestion push because Railway may not have deployed or executed that revision
+yet. This is the operational acceptance gate for the "merged and green, but
+production data is still unhealthy or running under stale deployment
+controls" gap.
 
 Do not use `railway redeploy` to recover a bad or stale source deployment.
 Railway documents redeploy as rebuilding the most recent deployment with the

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -69,14 +69,23 @@ Run the audit after adding or replacing a standalone seeder, changing a bundle
 dependency, or changing a production cron.
 
 The scheduled operational-acceptance workflow performs the same audit in
-read-only mode before checking compact health. Configure the GitHub Actions
-secret `RAILWAY_PRODUCTION_TOKEN` with a Railway project token scoped to the
-production environment, and set the non-secret repository variable
-`RAILWAY_PROJECT_ID` to the `world-monitor` project ID. The workflow maps the
-project token to the CLI's standard `RAILWAY_TOKEN` variable, links only inside
-the ephemeral runner, and never passes `--apply`. Do not use the broader
-account-scoped `RAILWAY_API_TOKEN`. Missing context intentionally fails the
-acceptance run rather than silently skipping the live audit.
+read-only mode before checking compact health. Create the dedicated GitHub
+Actions environment `ingestion-acceptance-production`, restrict its deployment
+branch policy to `main`, and configure:
+
+- environment secret `RAILWAY_PRODUCTION_TOKEN`: a Railway project token scoped
+  to the production environment;
+- environment variable `RAILWAY_PROJECT_ID`: the `world-monitor` project ID.
+
+Do not define the Railway token as a repository or organization secret:
+`workflow_dispatch` can target another ref, while the environment's server-side
+branch policy keeps the production credential unavailable there. The workflow
+references the environment with deployment tracking disabled, maps the project
+token to the CLI's standard `RAILWAY_TOKEN` variable only for the link and audit
+steps, links only inside the ephemeral runner, and never passes `--apply`. Do not
+use the broader account-scoped `RAILWAY_API_TOKEN`. Missing or inaccessible
+context intentionally fails the acceptance run rather than silently skipping
+the live audit.
 
 ### Bootstrap R2 publisher contract
 

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -99,12 +99,13 @@ their exact closures and every other live seeder against the broad floor, so
 opted in. Read-back verification prevents a Railway CLI no-op from being
 mistaken for a successful mutation.
 
-The scheduled workflow checks operational health only after the current main
-commit has a successful `gate` status. It deliberately does not run on an
-ingestion push because Railway may not have deployed or executed that revision
-yet. That separates a code failure from the operational case this guard
-targets: repository checks are green while a Railway producer or composed
-coverage is still unhealthy.
+The scheduled workflow checks live Railway config and operational health only
+after the current main commit has a successful `gate` status. A missing,
+pending, or failed gate fails the workflow; it is never converted into a green
+skip. It deliberately does not run on an ingestion push because Railway may not
+have deployed or executed that revision yet. That separates a code failure from
+the operational case this guard targets: repository checks are green while a
+Railway producer, deployment trigger, or composed coverage is still unhealthy.
 
 ## Prevention
 

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -118,6 +118,10 @@ Railway producer, deployment trigger, or composed coverage is still unhealthy.
   push back to the broad contract on the next `--apply`.
 - Keep the healthy compact-response case in monitor tests; absence of
   `problems` is success when `status` is `HEALTHY`.
+- Keep the Railway project token in the main-only
+  `ingestion-acceptance-production` GitHub Actions environment. Do not move it
+  to repository or organization secret scope, where a manually dispatched
+  non-default ref could access it.
 - Recover stale source deployments with a clean current-main `railway up` or
   Railway's **Deploy Latest Commit** action, then verify both deployment SHA and
   compact health.

--- a/scripts/audit-railway-watch-paths.mjs
+++ b/scripts/audit-railway-watch-paths.mjs
@@ -366,18 +366,17 @@ function readEnvironmentConfig(environment) {
 }
 
 function readServiceIds(environment) {
-  const statuses = JSON.parse(runRailway([
+  const services = JSON.parse(runRailway([
     'service',
-    'status',
-    '--all',
+    'list',
     '--environment',
     environment,
     '--json',
   ]));
-  if (!Array.isArray(statuses)) {
-    throw new Error('railway service status --all must return an array');
+  if (!Array.isArray(services)) {
+    throw new Error('railway service list must return an array');
   }
-  return new Map(statuses.map((service) => [service.name, service.id]));
+  return new Map(services.map((service) => [service.name, service.id]));
 }
 
 function readRegistry() {

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowSource = readFileSync(
+  resolve(repoRoot, '.github/workflows/seed-freshness-monitor.yml'),
+  'utf8',
+);
+const workflow = YAML.parse(workflowSource);
+const monitorSteps = workflow.jobs.monitor.steps;
+
+function stepNamed(name) {
+  const step = monitorSteps.find((candidate) => candidate.name === name);
+  assert.ok(step, `seed freshness workflow must define "${name}"`);
+  return step;
+}
+
+function scheduledGateStep() {
+  const step = monitorSteps.find((candidate) => candidate.id === 'gate');
+  assert.ok(step, 'seed freshness workflow must define its scheduled gate step');
+  return step;
+}
+
+function runScheduledGate(gateState) {
+  const tempDir = mkdtempSync(join(repoRoot, '.tmp-seed-freshness-gate-'));
+  const fakeBin = join(tempDir, 'bin');
+  const fakeGh = join(fakeBin, 'gh');
+
+  try {
+    // The workflow's only external input is the latest `gate` commit status.
+    // Replacing gh at PATH level executes the exact checked-in shell block
+    // without relying on GitHub's API or duplicating its branching logic.
+    mkdirSync(fakeBin);
+    writeFileSync(fakeGh, '#!/bin/sh\nprintf \'%s\\n\' "$FAKE_GATE_STATE"\n');
+    chmodSync(fakeGh, 0o755);
+
+    return spawnSync(
+      'bash',
+      ['-e', '-c', scheduledGateStep().run],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          FAKE_GATE_STATE: gateState,
+          GH_TOKEN: 'test-token',
+          GITHUB_REPOSITORY: 'koala73/worldmonitor',
+          GITHUB_SHA: '0123456789abcdef',
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        },
+      },
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe('seed freshness workflow control plane', () => {
+  it('fails closed unless the exact checked-out main SHA has a successful gate', () => {
+    const success = runScheduledGate('success');
+    assert.equal(success.status, 0, success.stderr);
+
+    for (const state of ['missing', 'pending', 'failure', 'error']) {
+      const result = runScheduledGate(state);
+      assert.notEqual(
+        result.status,
+        0,
+        `${state} must fail the workflow instead of producing a green skipped acceptance`,
+      );
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        new RegExp(`main gate is ${state}`),
+      );
+    }
+
+    const gate = scheduledGateStep();
+    assert.equal(gate.if, "github.event_name == 'schedule'");
+    assert.equal(gate['continue-on-error'], undefined);
+    assert.equal(workflow.jobs.monitor['continue-on-error'], undefined);
+    assert.doesNotMatch(gate.run, /should_run|Skipping seed freshness/);
+    const acceptance = stepNamed('Check ingestion operational acceptance');
+    assert.equal(
+      acceptance.if,
+      undefined,
+      'default success() semantics must keep acceptance behind the fail-closed gate',
+    );
+    assert.equal(acceptance['continue-on-error'], undefined);
+  });
+
+  it('audits read-only Railway production config before grading data health', () => {
+    const installIndex = monitorSteps.findIndex(
+      (step) => step.name === 'Install pinned Railway CLI',
+    );
+    const linkIndex = monitorSteps.findIndex(
+      (step) => step.name === 'Link Railway production context',
+    );
+    const auditIndex = monitorSteps.findIndex(
+      (step) => step.name === 'Audit Railway ingestion deployment controls',
+    );
+    const healthIndex = monitorSteps.findIndex(
+      (step) => step.name === 'Check ingestion operational acceptance',
+    );
+
+    assert.ok(installIndex >= 0, 'workflow must install the Railway CLI');
+    assert.ok(
+      installIndex < linkIndex && linkIndex < auditIndex && auditIndex < healthIndex,
+      'Railway context and watch-path drift must be checked before compact health',
+    );
+
+    assert.match(
+      monitorSteps[installIndex].run,
+      /npm install --global @railway\/cli@5\.30\.1/,
+      'scheduled audits must use a deterministic Railway CLI version',
+    );
+
+    const link = monitorSteps[linkIndex];
+    assert.equal(link.env.RAILWAY_TOKEN, '${{ secrets.RAILWAY_PRODUCTION_TOKEN }}');
+    assert.equal(link.env.RAILWAY_PROJECT_ID, '${{ vars.RAILWAY_PROJECT_ID }}');
+    assert.match(link.run, /RAILWAY_TOKEN/);
+    assert.match(link.run, /RAILWAY_PROJECT_ID/);
+    assert.match(
+      link.run,
+      /railway link --project "\$RAILWAY_PROJECT_ID" --environment production --json/,
+    );
+
+    const audit = monitorSteps[auditIndex];
+    assert.equal(audit.env.RAILWAY_TOKEN, '${{ secrets.RAILWAY_PRODUCTION_TOKEN }}');
+    assert.equal(audit.run.trim(), 'node scripts/audit-railway-watch-paths.mjs');
+    assert.equal(audit['continue-on-error'], undefined);
+    assert.doesNotMatch(
+      audit.run,
+      /--apply/,
+      'scheduled acceptance must detect Railway drift without mutating production',
+    );
+    assert.doesNotMatch(
+      workflowSource,
+      /RAILWAY_API_TOKEN/,
+      'the workflow must not use an account-scoped Railway credential',
+    );
+  });
+});

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -101,6 +101,25 @@ describe('seed freshness workflow control plane', () => {
   });
 
   it('audits read-only Railway production config before grading data health', () => {
+    assert.deepEqual(
+      workflow.jobs.monitor.environment,
+      {
+        name: 'ingestion-acceptance-production',
+        deployment: false,
+      },
+      'production credentials must come from the main-only ingestion acceptance environment',
+    );
+
+    const checkout = monitorSteps.find(
+      (step) => typeof step.uses === 'string' && step.uses.startsWith('actions/checkout@'),
+    );
+    assert.ok(checkout, 'workflow must check out the audited repository revision');
+    assert.equal(
+      checkout.uses,
+      'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10',
+      'credential-bearing workflows must pin checkout to the repository-standard immutable SHA',
+    );
+
     const installIndex = monitorSteps.findIndex(
       (step) => step.name === 'Install pinned Railway CLI',
     );


### PR DESCRIPTION
## Summary

Scheduled ingestion acceptance can no longer finish green without proving the
exact `main` revision passed the repository gate. Missing, pending, failed, and
errored gate states now fail the run instead of skipping every operational
check.

The same workflow now establishes scoped, ephemeral Railway production context
and runs the repository's live deployment-control audit before compact-health
acceptance. A dedicated GitHub Actions environment exposes the production
credential only to `main`, without creating deployment records; checkout and
the Railway CLI are pinned, and the token is injected only into the link and
read-only audit steps. Dependency closures remain derived and tested from the
seeder import graph rather than copied into workflow logic.

The Railway adapter also uses the supported `service list` command for the
pinned CLI version.

Related: #3613

## Validation

- 63 focused tests pass:
  - workflow control plane: 2/2
  - freshness monitor: 17/17
  - Railway audit and derived closures: 33/33, including
    `seed-bundle-derived-signals`, `seed-bundle-market-backup`, and
    `seed-conflict-intel`
  - Railway registry coverage: 11/11
- Mutation checks prove the workflow test fails if:
  - a non-success gate is allowed through;
  - the protected environment starts recording deployments;
  - checkout returns to the mutable `@v4` tag.
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint` and repository-wide markdownlint
- `npm run docs:check`
- Full worktree-local pre-push gate passed at `96030d18a`.

Read-only production evidence on 2026-07-29:

- The live Railway audit fails only on the three known stale watch
  configurations above.
- Compact-health acceptance remains correctly red on unacknowledged
  `chinaCoverage: CHINA_DEGRADED` and
  `portwatchPortActivity: COVERAGE_PARTIAL`.
- GitHub environment `ingestion-acceptance-production` exists with a custom
  branch policy allowing only `main`; `RAILWAY_PROJECT_ID` is configured there,
  and no secret was created or copied.
- No Railway setting, deployment, secret, baseline, or production data was
  changed.

## Required configuration and rollout

Before relying on the scheduled workflow:

1. Add environment secret `RAILWAY_PRODUCTION_TOKEN` to
   `ingestion-acceptance-production`, using a Railway project token scoped to
   the production environment. Do not define it as a repository or organization
   secret.
2. From an authorized, clean checkout at current `origin/main`, reconcile the
   three live watch-path drifts with the documented `--apply` procedure and
   verify read-back.
3. Deploy current `main` for the three affected services through the documented
   production path so previously skipped source revisions are not left dormant.
4. Keep PortWatch and China coverage as explicit operational blockers; do not
   baseline or soften them in this PR.

CI intentionally has no `--apply` path and does not use the broader
account-scoped `RAILWAY_API_TOKEN`. The project token itself is
production-capable; the safety boundary is the server-enforced main-only
environment plus the checked-in read-only command path.

## Post-Deploy Monitoring & Validation

- **Owner/window:** release or ingestion ops; inspect the first configured run,
  then require two consecutive successful 15-minute scheduled runs after
  Railway reconciliation and current-main deployments.
- **Logs/search terms:** `Cannot establish ingestion operational acceptance`,
  `Railway operational-config audit found`,
  `Ingestion operational acceptance failed`, and Railway
  `No changes to watched files`.
- **Healthy signals:** exact-main gate logs `success`; Railway audit reports
  zero drift; affected services show current-main deployments rather than
  `SKIPPED`; compact health has no unacknowledged problems.
- **Failure signals:** any non-success or missing gate, inaccessible Actions
  environment context, named Railway drift, stale affected deployment SHA, or
  unacknowledged compact-health problem.
- **Mitigation:** fix the failing prerequisite or reconcile/deploy through the
  documented authorized procedure. Do not add `continue-on-error`, skip the
  audit, broaden the accepted-problem baseline, or introduce a production
  mutation command into scheduled CI.
- **Rollback trigger:** revert the workflow integration only for a demonstrated
  credential-scope or pinned-CLI incompatibility; a red result caused by real
  gate, config, deployment, or health drift is the intended behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
