### PR TITLE
fix(china): require sustained SZSE recovery

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1729,6 +1729,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     preserveKeys = [],
     beforePublish,
     afterPublish,
+    afterValidationSkip,
     afterPreservedValidationSkip,
     afterFreshness,
     publishTransform,
@@ -2012,6 +2013,20 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       const durationMs = Date.now() - startMs;
       const preserved = await extendExistingTtl(preservationKeys(), ttlSeconds || 600);
       const strictFailure = Boolean(opts.emptyDataIsFailure);
+      const validationSkipContext = {
+        canonicalKey,
+        ttlSeconds,
+        recordCount: contractRecordCount,
+        runId,
+        preservationSucceeded: preserved,
+      };
+      // Some rejected snapshots carry failure evidence that must survive even
+      // when there is no complete last-good cohort to preserve. Keep this hook
+      // in the publish phase so its persistence cannot make withRetry(fetchFn)
+      // repeat upstream source requests.
+      if (!strictFailure && afterValidationSkip) {
+        await afterValidationSkip(data, validationSkipContext);
+      }
       if (strictFailure) {
         // Strict-floor seeders (e.g. IMF-External, floor=180 countries) treat
         // empty data as a real upstream failure. Do NOT refresh seed-meta —
@@ -2067,12 +2082,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         }
       }
       if (!strictFailure && preserved && afterPreservedValidationSkip) {
-        await afterPreservedValidationSkip(data, {
-          canonicalKey,
-          ttlSeconds,
-          recordCount: contractRecordCount,
-          runId,
-        });
+        await afterPreservedValidationSkip(data, validationSkipContext);
       }
       console.log(`\n=== Done (${Math.round(durationMs)}ms, no write) ===`);
       await releaseLock(`${domain}:${resource}`, runId);

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -14,6 +14,7 @@ export const CHINA_CORPORATE_DISCLOSURE_KEY = 'market:china:corporate-disclosure
 
 export const DISCLOSURE_TYPES = CHINA_CORPORATE_DISCLOSURE_TYPES;
 export const EMPTY_RESULT_DEGRADE_AFTER = 3;
+export const SZSE_TRANSPORT_RECOVERY_SUCCESS_RUNS = 2;
 
 export const REVIEWED_DISCLOSURE_ISSUERS = Object.freeze([
   { id: 'issuer:sse:600519', exchange: 'SSE', securityCode: '600519', symbol: '600519.SS', name: 'Kweichow Moutai', nameOriginal: '贵州茅台', mappingConfidence: 1 },
@@ -78,6 +79,7 @@ export const OFFICIAL_EXCHANGE_SOURCE_CONTRACTS = Object.freeze({
     maxDirectRequestsPerRun: 1,
     maxProxyRequestsPerRun: 2,
     maxEdgeRequestsPerRun: 1,
+    transportRecoverySuccessRuns: SZSE_TRANSPORT_RECOVERY_SUCCESS_RUNS,
     fallbackPolicy: 'direct_then_proxy_then_edge_on_transport_failure',
     // SZSE_PROXY_URL is an optional source-specific override; Railway requires
     // the shared PROXY_URL fallback and the fixed edge hop's
@@ -855,7 +857,103 @@ function nextEmptyResultCount(outcome, previous) {
     : previousCount + 1;
 }
 
-function sourceStates(outcomes, previousSnapshot, generatedAt) {
+function priorTransportReliability(previous, previousFailure) {
+  const previousCheckedAt = Date.parse(previous?.checkedAt);
+  const previousFailureAt = Date.parse(previousFailure?.checkedAt);
+  if (
+    Number.isFinite(previousFailureAt)
+    && (!Number.isFinite(previousCheckedAt) || previousFailureAt > previousCheckedAt)
+  ) {
+    const failureReason = typeof previousFailure?.errorCode === 'string'
+      && /^[a-z0-9_]{1,80}$/iu.test(previousFailure.errorCode)
+      ? previousFailure.errorCode
+      : 'FETCH_FAILED';
+    return {
+      status: 'degraded',
+      consecutiveSuccesses: 0,
+      consecutiveFailures: Number.isInteger(previousFailure?.consecutiveFailures)
+        && previousFailure.consecutiveFailures > 0
+        ? previousFailure.consecutiveFailures
+        : 1,
+      lastFailureAt: new Date(previousFailureAt).toISOString(),
+      lastFailureReason: failureReason,
+    };
+  }
+  const value = previous?.transportReliability;
+  if (
+    value
+    && ['stable', 'recovering', 'degraded'].includes(value.status)
+    && Number.isInteger(value.consecutiveSuccesses)
+    && value.consecutiveSuccesses >= 0
+    && Number.isInteger(value.consecutiveFailures)
+    && value.consecutiveFailures >= 0
+  ) {
+    return value;
+  }
+  if (!previous) return null;
+  if (previous.transportStatus === 'error') {
+    return {
+      status: 'degraded',
+      consecutiveSuccesses: 0,
+      consecutiveFailures: 1,
+      ...(previous.checkedAt ? { lastFailureAt: previous.checkedAt } : {}),
+      ...(previous.errorCode ? { lastFailureReason: previous.errorCode } : {}),
+    };
+  }
+  return {
+    status: 'stable',
+    consecutiveSuccesses: 1,
+    consecutiveFailures: 0,
+  };
+}
+
+function nextTransportReliability(
+  outcome,
+  previous,
+  previousFailure,
+  checkedAt,
+  requiredSuccessRuns = 1,
+) {
+  const prior = priorTransportReliability(previous, previousFailure);
+  const transportSucceeded = outcome?.ok === true
+    || (outcome?.partial === true && outcome?.transportOk === true);
+  if (!transportSucceeded) {
+    return {
+      status: 'degraded',
+      consecutiveSuccesses: 0,
+      consecutiveFailures: prior?.status === 'degraded'
+        ? prior.consecutiveFailures + 1
+        : 1,
+      lastFailureAt: checkedAt,
+      lastFailureReason: outcome?.errorCode ?? 'NOT_ATTEMPTED',
+    };
+  }
+
+  const recovering = prior?.status === 'degraded' || prior?.status === 'recovering';
+  const consecutiveSuccesses = recovering
+    ? prior.consecutiveSuccesses + 1
+    : Math.min(
+        requiredSuccessRuns,
+        Math.max(1, (prior?.consecutiveSuccesses ?? 0) + 1),
+      );
+  return {
+    status: recovering && consecutiveSuccesses < requiredSuccessRuns
+      ? 'recovering'
+      : 'stable',
+    consecutiveSuccesses,
+    consecutiveFailures: 0,
+    ...(prior?.lastFailureAt ? { lastFailureAt: prior.lastFailureAt } : {}),
+    ...(prior?.lastFailureReason ? { lastFailureReason: prior.lastFailureReason } : {}),
+  };
+}
+
+function sourceIsOperationallyHealthy(source) {
+  return source.transportStatus === 'fresh'
+    && source.contentStatus === 'current'
+    && source.transportReliability?.status === 'stable';
+}
+
+function sourceStates(outcomes, previousSnapshot, previousTransportFailures, generatedAt) {
   const outcomeMap = new Map(outcomes.map((outcome) => [outcome.sourceId, outcome]));
   const previousMap = new Map(
     (Array.isArray(previousSnapshot?.sources) ? previousSnapshot.sources : [])
@@ -875,6 +973,11 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         requestCount: 0,
         transportPath: 'not_applicable',
         emptyResultCount: 0,
+        transportReliability: {
+          status: 'not_applicable',
+          consecutiveSuccesses: 0,
+          consecutiveFailures: 0,
+        },
         errorCode: contract.blockedReason,
       };
     }
@@ -882,6 +985,13 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
     const previous = previousMap.get(id);
     const emptyResultCount = nextEmptyResultCount(outcome, previous);
     const coverageGap = emptyResultCount >= EMPTY_RESULT_DEGRADE_AFTER;
+    const transportReliability = nextTransportReliability(
+      outcome,
+      previous,
+      previousTransportFailures[id],
+      generatedAt,
+      contract.transportRecoverySuccessRuns ?? 1,
+    );
     if (outcome?.ok) {
       return {
         id,
@@ -898,6 +1008,7 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
           ? { proxyFailureReason: outcome.proxyFailureReason }
           : {}),
         emptyResultCount,
+        transportReliability,
         errorCode: coverageGap ? 'COVERAGE_GAP' : null,
       };
     }
@@ -918,6 +1029,7 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
           ? { proxyFailureReason: outcome.proxyFailureReason }
           : {}),
         emptyResultCount,
+        transportReliability,
         errorCode: outcome.errorCode ?? (coverageGap ? 'COVERAGE_GAP' : 'PARTIAL_FETCH'),
       };
     }
@@ -939,6 +1051,7 @@ function sourceStates(outcomes, previousSnapshot, generatedAt) {
         ? { edgeFailureReason: outcome.edgeFailureReason }
         : {}),
       emptyResultCount,
+      transportReliability,
       errorCode: outcome?.errorCode ?? 'NOT_ATTEMPTED',
     };
   });
@@ -1249,10 +1362,16 @@ function buildEvents(announcements, sources, generatedAt) {
 export function buildChinaCorporateDisclosureSnapshot({
   outcomes,
   previousSnapshot = null,
+  previousTransportFailures = {},
   generatedAt = new Date().toISOString(),
 }) {
   const checkedAt = ensureIsoInstant(generatedAt, 'GENERATED_AT');
-  const sources = sourceStates(outcomes, previousSnapshot, checkedAt);
+  const sources = sourceStates(
+    outcomes,
+    previousSnapshot,
+    previousTransportFailures,
+    checkedAt,
+  );
   const announcements = previousAnnouncements(previousSnapshot);
   for (const outcome of outcomes) {
     if ((outcome?.ok || outcome?.partial) && Array.isArray(outcome.announcements)) {
@@ -1265,7 +1384,7 @@ export function buildChinaCorporateDisclosureSnapshot({
     (source) => source.contentStatus === 'current' || source.contentStatus === 'partial',
   );
   const status = launched.every(
-    (source) => source.transportStatus === 'fresh' && source.contentStatus === 'current',
+    sourceIsOperationallyHealthy,
   )
     ? 'healthy'
     : usable.length > 0
@@ -1299,6 +1418,9 @@ export function buildChinaCorporateDisclosureSnapshot({
       ...(contract.maxEdgeRequestsPerRun
         ? { maxEdgeRequestsPerRun: contract.maxEdgeRequestsPerRun }
         : {}),
+      ...(contract.transportRecoverySuccessRuns
+        ? { transportRecoverySuccessRuns: contract.transportRecoverySuccessRuns }
+        : {}),
       maxResponseBytes: contract.maxResponseBytes,
       redirectPolicy: contract.redirectPolicy,
       documentRetrieval: contract.documentRetrieval,
@@ -1324,6 +1446,7 @@ export async function fetchChinaCorporateDisclosureSnapshot({
   edgeRequestFn = globalThis.fetch,
   now = Date.now(),
   previousSnapshot = null,
+  previousTransportFailures = {},
   onDecision = (entry) => console.log(JSON.stringify({ event: 'china_corporate_disclosure_source', ...entry })),
 } = {}) {
   const resolvedProxyFetchFn = proxyUrl
@@ -1376,18 +1499,31 @@ export async function fetchChinaCorporateDisclosureSnapshot({
   const snapshot = buildChinaCorporateDisclosureSnapshot({
     outcomes,
     previousSnapshot,
+    previousTransportFailures,
     generatedAt: new Date(now).toISOString(),
   });
   for (const source of snapshot.sources) {
+    const transportRecoverySuccessRuns = source.launchStatus === 'launched'
+      ? OFFICIAL_EXCHANGE_SOURCE_CONTRACTS[source.id].transportRecoverySuccessRuns ?? 1
+      : null;
+    const operationallyHealthy = source.launchStatus === 'launched'
+      && sourceIsOperationallyHealthy(source);
+    const reliabilityReason = source.transportReliability?.status === 'recovering'
+      ? 'TRANSPORT_RECOVERING'
+      : null;
     onDecision({
       sourceId: source.id,
       status: source.launchStatus === 'blocked'
         ? 'blocked'
-        : source.transportStatus === 'fresh' && source.contentStatus === 'current'
+        : operationallyHealthy
           ? 'accepted'
           : 'degraded',
       requestCount: source.requestCount,
-      ...(source.errorCode ? { reason: source.errorCode } : {}),
+      ...(source.errorCode
+        ? { reason: source.errorCode }
+        : reliabilityReason
+          ? { reason: reliabilityReason }
+          : {}),
       ...(source.launchStatus === 'launched'
         ? { emptyResultCount: source.emptyResultCount }
         : {}),
@@ -1398,6 +1534,22 @@ export async function fetchChinaCorporateDisclosureSnapshot({
         : {}),
       ...(source.edgeFailureReason
         ? { edgeFailureReason: source.edgeFailureReason }
+        : {}),
+      ...(source.launchStatus === 'launched'
+        ? {
+            reliabilityStatus: source.transportReliability.status,
+            requiredRecoverySuccesses: transportRecoverySuccessRuns,
+            consecutiveTransportSuccesses:
+              source.transportReliability.consecutiveSuccesses,
+            consecutiveTransportFailures:
+              source.transportReliability.consecutiveFailures,
+          }
+        : {}),
+      ...(source.transportReliability?.lastFailureAt
+        ? { lastTransportFailureAt: source.transportReliability.lastFailureAt }
+        : {}),
+      ...(source.transportReliability?.lastFailureReason
+        ? { lastTransportFailureReason: source.transportReliability.lastFailureReason }
         : {}),
       checkedAt: source.checkedAt,
     });

--- a/scripts/seed-china-corporate-disclosures.mjs
+++ b/scripts/seed-china-corporate-disclosures.mjs
@@ -142,7 +142,7 @@ if (process.argv[1]?.endsWith('seed-china-corporate-disclosures.mjs')) {
       maxStaleMin: CHINA_CORPORATE_DISCLOSURE_MAX_STALE_MIN,
       contentMeta: chinaCorporateDisclosureContentMeta,
       maxContentAgeMin: 90 * DAY_MIN,
-      afterPreservedValidationSkip: async (snapshot) =>
+      afterValidationSkip: async (snapshot) =>
         recordSzseTransportFailure(snapshot),
     },
   );

--- a/scripts/seed-china-corporate-disclosures.mjs
+++ b/scripts/seed-china-corporate-disclosures.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, readSeedSnapshot, runSeed } from './_seed-utils.mjs';
+import {
+  loadEnvFile,
+  readSeedSnapshot,
+  runSeed,
+  writeFreshnessMetadata,
+} from './_seed-utils.mjs';
 import { DAY_MIN, tokensToContentMeta } from './_content-age-helpers.mjs';
 import {
   CHINA_CORPORATE_DISCLOSURE_KEY,
@@ -11,6 +16,11 @@ loadEnvFile(import.meta.url);
 
 export const CHINA_CORPORATE_DISCLOSURE_TTL_SECONDS = 3 * DAY_MIN * 60;
 export const CHINA_CORPORATE_DISCLOSURE_MAX_STALE_MIN = 180;
+
+const SZSE_FAILURE_RESOURCE = 'china-corporate-disclosures-szse-failure';
+const SZSE_FAILURE_SOURCE_VERSION = 'china-official-exchange-szse-failure-v1';
+export const CHINA_CORPORATE_DISCLOSURE_SZSE_FAILURE_META_KEY =
+  `seed-meta:market:${SZSE_FAILURE_RESOURCE}`;
 
 export function validateChinaCorporateDisclosureSnapshot(snapshot) {
   if (
@@ -45,14 +55,74 @@ export function chinaCorporateDisclosureContentMeta(snapshot) {
   return tokensToContentMeta(tokens);
 }
 
-export async function buildChinaCorporateDisclosureSeedSnapshot() {
+export function szseTransportFailureFromMarker(marker) {
+  if (marker == null) return null;
+  const failureAt = Number(marker.fetchedAt);
+  if (!Number.isFinite(failureAt) || failureAt <= 0) {
+    throw new Error('SZSE transport failure marker has an invalid fetchedAt');
+  }
+  return {
+    checkedAt: new Date(failureAt).toISOString(),
+    errorCode: typeof marker.errorCode === 'string'
+      && /^[a-z0-9_]{1,80}$/iu.test(marker.errorCode)
+      ? marker.errorCode
+      : 'FETCH_FAILED',
+    consecutiveFailures: Number.isInteger(marker.consecutiveFailures)
+      && marker.consecutiveFailures > 0
+      ? marker.consecutiveFailures
+      : 1,
+  };
+}
+
+export async function recordSzseTransportFailure(
+  snapshot,
+  writeMetadata = writeFreshnessMetadata,
+) {
+  const source = snapshot?.sources?.find((candidate) => candidate?.id === 'szse');
+  if (source?.transportStatus !== 'error') return false;
+  const failureAt = Date.parse(source.checkedAt);
+  if (!Number.isFinite(failureAt)) {
+    throw new Error('SZSE transport failure is missing a valid checkedAt');
+  }
+  const errorCode = typeof source.errorCode === 'string'
+    && /^[a-z0-9_]{1,80}$/iu.test(source.errorCode)
+    ? source.errorCode
+    : 'FETCH_FAILED';
+  const consecutiveFailures = Number.isInteger(
+    source.transportReliability?.consecutiveFailures,
+  ) && source.transportReliability.consecutiveFailures > 0
+    ? source.transportReliability.consecutiveFailures
+    : 1;
+  await writeMetadata(
+    'market',
+    SZSE_FAILURE_RESOURCE,
+    0,
+    SZSE_FAILURE_SOURCE_VERSION,
+    CHINA_CORPORATE_DISCLOSURE_TTL_SECONDS,
+    failureAt,
+    null,
+    { errorCode, consecutiveFailures },
+  );
+  return true;
+}
+
+export async function buildChinaCorporateDisclosureSeedSnapshot({
+  readSnapshot = readSeedSnapshot,
+  fetchSnapshot = fetchChinaCorporateDisclosureSnapshot,
+} = {}) {
   // History and per-source last-good state are part of the product contract.
   // A failed cache read must abort rather than silently replace that history.
-  const previousSnapshot = await readSeedSnapshot(
-    CHINA_CORPORATE_DISCLOSURE_KEY,
-    { strict: true },
-  );
-  return fetchChinaCorporateDisclosureSnapshot({ previousSnapshot });
+  const [previousSnapshot, szseFailureMarker] = await Promise.all([
+    readSnapshot(CHINA_CORPORATE_DISCLOSURE_KEY, { strict: true }),
+    readSnapshot(CHINA_CORPORATE_DISCLOSURE_SZSE_FAILURE_META_KEY, { strict: true }),
+  ]);
+  const previousSzseFailure = szseTransportFailureFromMarker(szseFailureMarker);
+  return fetchSnapshot({
+    previousSnapshot,
+    previousTransportFailures: previousSzseFailure
+      ? { szse: previousSzseFailure }
+      : {},
+  });
 }
 
 if (process.argv[1]?.endsWith('seed-china-corporate-disclosures.mjs')) {
@@ -72,6 +142,7 @@ if (process.argv[1]?.endsWith('seed-china-corporate-disclosures.mjs')) {
       maxStaleMin: CHINA_CORPORATE_DISCLOSURE_MAX_STALE_MIN,
       contentMeta: chinaCorporateDisclosureContentMeta,
       maxContentAgeMin: 90 * DAY_MIN,
+      afterPreservedValidationSkip: recordSzseTransportFailure,
     },
   );
 }

--- a/scripts/seed-china-corporate-disclosures.mjs
+++ b/scripts/seed-china-corporate-disclosures.mjs
@@ -142,7 +142,8 @@ if (process.argv[1]?.endsWith('seed-china-corporate-disclosures.mjs')) {
       maxStaleMin: CHINA_CORPORATE_DISCLOSURE_MAX_STALE_MIN,
       contentMeta: chinaCorporateDisclosureContentMeta,
       maxContentAgeMin: 90 * DAY_MIN,
-      afterPreservedValidationSkip: recordSzseTransportFailure,
+      afterPreservedValidationSkip: async (snapshot) =>
+        recordSzseTransportFailure(snapshot),
     },
   );
 }

--- a/tests/china-corporate-disclosure-production-registration.test.mts
+++ b/tests/china-corporate-disclosure-production-registration.test.mts
@@ -85,8 +85,8 @@ describe('China corporate disclosure production registration (#5577)', () => {
     );
     assert.match(
       seed,
-      /afterPreservedValidationSkip:\s*async \(snapshot\) =>\s*recordSzseTransportFailure\(snapshot\)/,
-      'the validation-skip callback must adapt runSeed context instead of passing it as the marker writer',
+      /afterValidationSkip:\s*async \(snapshot\) =>\s*recordSzseTransportFailure\(snapshot\)/,
+      'every validation rejection must record the SZSE failure independently of last-good preservation',
     );
     assert.match(
       read('scripts/china-coverage-manifest.mjs'),

--- a/tests/china-corporate-disclosure-production-registration.test.mts
+++ b/tests/china-corporate-disclosure-production-registration.test.mts
@@ -85,8 +85,8 @@ describe('China corporate disclosure production registration (#5577)', () => {
     );
     assert.match(
       seed,
-      /afterPreservedValidationSkip:\s*recordSzseTransportFailure/,
-      'a rejected total-outage snapshot must retain SZSE recovery state outside the canonical key',
+      /afterPreservedValidationSkip:\s*async \(snapshot\) =>\s*recordSzseTransportFailure\(snapshot\)/,
+      'the validation-skip callback must adapt runSeed context instead of passing it as the marker writer',
     );
     assert.match(
       read('scripts/china-coverage-manifest.mjs'),

--- a/tests/china-corporate-disclosure-production-registration.test.mts
+++ b/tests/china-corporate-disclosure-production-registration.test.mts
@@ -77,6 +77,17 @@ describe('China corporate disclosure production registration (#5577)', () => {
       read('scripts/china-corporate-disclosures/adapters.mjs'),
       /proxyUrl = process\.env\.SZSE_PROXY_URL \|\| process\.env\.PROXY_URL \|\| ''/,
     );
+    const seed = read('scripts/seed-china-corporate-disclosures.mjs');
+    assert.match(
+      seed,
+      /readSnapshot\(CHINA_CORPORATE_DISCLOSURE_SZSE_FAILURE_META_KEY, \{ strict: true \}\)/,
+      'the next run must read a durable SZSE failure that could not enter the last-good snapshot',
+    );
+    assert.match(
+      seed,
+      /afterPreservedValidationSkip:\s*recordSzseTransportFailure/,
+      'a rejected total-outage snapshot must retain SZSE recovery state outside the canonical key',
+    );
     assert.match(
       read('scripts/china-coverage-manifest.mjs'),
       /id:\s*'market\.china-corporate-disclosures'[\s\S]*?ownerIssue:\s*5577[\s\S]*?launchStatus:\s*'launched'/,

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -21,7 +21,10 @@ import {
   resolveChinaExchangeEdgeEgress,
 } from '../scripts/china-corporate-disclosures/adapters.mjs';
 import {
+  CHINA_CORPORATE_DISCLOSURE_SZSE_FAILURE_META_KEY,
+  buildChinaCorporateDisclosureSeedSnapshot,
   chinaCorporateDisclosureContentMeta,
+  recordSzseTransportFailure,
   validateChinaCorporateDisclosureSnapshot,
 } from '../scripts/seed-china-corporate-disclosures.mjs';
 
@@ -76,6 +79,7 @@ describe('official China corporate disclosures (#5577)', () => {
     }
 
     const hkex = OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.hkex;
+    assert.equal(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.transportRecoverySuccessRuns, 2);
     assert.equal(hkex.preflight.reachable, true);
     assert.equal(hkex.admissionDecision, 'rejected');
     assert.equal(hkex.blockedReason, 'TERMS_PROHIBIT_AUTOMATED_ACCESS');
@@ -540,6 +544,254 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(validateChinaCorporateDisclosureSnapshot(totalOutage), false);
   });
 
+  it('requires two consecutive successful runs before transport recovery is stable', async () => {
+    const announcements = {
+      sse: normalizeSseAnnouncements(fixture('sse.json'), { retrievedAt }),
+      szse: normalizeSzseAnnouncements(fixture('szse.json'), { retrievedAt }),
+    };
+    const successfulOutcomes = [
+      {
+        sourceId: 'sse',
+        ok: true,
+        transportOk: true,
+        requestCount: 4,
+        announcements: announcements.sse,
+      },
+      {
+        sourceId: 'szse',
+        ok: true,
+        transportOk: true,
+        requestCount: 2,
+        transportPath: 'proxy',
+        fallbackReason: 'ETIMEDOUT',
+        announcements: announcements.szse,
+      },
+    ];
+    const healthy = buildChinaCorporateDisclosureSnapshot({
+      generatedAt: retrievedAt,
+      outcomes: successfulOutcomes,
+    });
+    const failedAt = '2026-07-25T10:30:00.000Z';
+    const failed = buildChinaCorporateDisclosureSnapshot({
+      generatedAt: failedAt,
+      previousSnapshot: healthy,
+      outcomes: [
+        successfulOutcomes[0],
+        {
+          sourceId: 'szse',
+          ok: false,
+          requestCount: 3,
+          errorCode: 'HTTP_522',
+          transportPath: 'proxy',
+          fallbackReason: 'ETIMEDOUT',
+          proxyFailureReason: 'HTTP_522',
+        },
+      ],
+    });
+    const recoveryFetch = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('query.sse.com.cn')) {
+        const productId = new URL(url).searchParams.get('productId');
+        return new Response(JSON.stringify(
+          productId === '600519'
+            ? fixture('sse.json')
+            : { pageHelp: { pageNo: 1, pageSize: 100, total: 0 }, result: [] },
+        ), { status: 200 });
+      }
+      return new Response(JSON.stringify(fixture('szse.json')), { status: 200 });
+    };
+    const legacyFailed = structuredClone(failed);
+    for (const source of legacyFailed.sources) {
+      delete source.transportReliability;
+    }
+    const legacyRecovery = buildChinaCorporateDisclosureSnapshot({
+      generatedAt: '2026-07-25T10:45:00.000Z',
+      previousSnapshot: legacyFailed,
+      outcomes: successfulOutcomes,
+    });
+    assert.equal(
+      legacyRecovery.sources.find((source) => source.id === 'szse')
+        ?.transportReliability.status,
+      'recovering',
+    );
+    const firstRecoveryAt = '2026-07-25T11:00:00.000Z';
+    const firstRecoveryDecisions: Array<Record<string, unknown>> = [];
+    const firstRecovery = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(firstRecoveryAt),
+      previousSnapshot: healthy,
+      previousTransportFailures: {
+        szse: {
+          checkedAt: failedAt,
+          errorCode: 'HTTP_522',
+        },
+      },
+      fetchFn: recoveryFetch,
+      onDecision: (decision) => firstRecoveryDecisions.push(decision),
+    });
+    const firstRecoverySzse = firstRecovery.sources.find((source) => source.id === 'szse');
+
+    assert.equal(firstRecovery.status, 'degraded');
+    assert.equal(firstRecovery.coverageThrough, null);
+    assert.equal(firstRecoverySzse?.transportStatus, 'fresh');
+    assert.equal(firstRecoverySzse?.contentStatus, 'current');
+    assert.deepEqual(firstRecoverySzse?.transportReliability, {
+      status: 'recovering',
+      consecutiveSuccesses: 1,
+      consecutiveFailures: 0,
+      lastFailureAt: failedAt,
+      lastFailureReason: 'HTTP_522',
+    });
+    assert.deepEqual(
+      firstRecoveryDecisions.find((decision) => decision.sourceId === 'szse'),
+      {
+        sourceId: 'szse',
+        status: 'degraded',
+        requestCount: 1,
+        reason: 'TRANSPORT_RECOVERING',
+        emptyResultCount: 0,
+        transportPath: 'direct',
+        reliabilityStatus: 'recovering',
+        requiredRecoverySuccesses: 2,
+        consecutiveTransportSuccesses: 1,
+        consecutiveTransportFailures: 0,
+        lastTransportFailureAt: failedAt,
+        lastTransportFailureReason: 'HTTP_522',
+        checkedAt: firstRecoveryAt,
+      },
+    );
+
+    const secondRecoveryAt = '2026-07-25T11:30:00.000Z';
+    const secondRecoveryDecisions: Array<Record<string, unknown>> = [];
+    const secondRecovery = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(secondRecoveryAt),
+      previousSnapshot: firstRecovery,
+      fetchFn: recoveryFetch,
+      onDecision: (decision) => secondRecoveryDecisions.push(decision),
+    });
+    const stableSzse = secondRecovery.sources.find((source) => source.id === 'szse');
+
+    assert.equal(secondRecovery.status, 'healthy');
+    assert.equal(secondRecovery.coverageThrough, secondRecoveryAt.slice(0, 10));
+    assert.deepEqual(stableSzse?.transportReliability, {
+      status: 'stable',
+      consecutiveSuccesses: 2,
+      consecutiveFailures: 0,
+      lastFailureAt: failedAt,
+      lastFailureReason: 'HTTP_522',
+    });
+    assert.deepEqual(
+      secondRecoveryDecisions.find((decision) => decision.sourceId === 'szse'),
+      {
+        sourceId: 'szse',
+        status: 'accepted',
+        requestCount: 1,
+        emptyResultCount: 0,
+        transportPath: 'direct',
+        reliabilityStatus: 'stable',
+        requiredRecoverySuccesses: 2,
+        consecutiveTransportSuccesses: 2,
+        consecutiveTransportFailures: 0,
+        lastTransportFailureAt: failedAt,
+        lastTransportFailureReason: 'HTTP_522',
+        checkedAt: secondRecoveryAt,
+      },
+    );
+  });
+
+  it('persists and replays an SZSE failure rejected by last-good validation', async () => {
+    const failedAt = '2026-07-25T10:30:00.000Z';
+    const writeCalls: unknown[][] = [];
+    const recorded = await recordSzseTransportFailure(
+      {
+        sources: [{
+          id: 'szse',
+          transportStatus: 'error',
+          checkedAt: failedAt,
+          errorCode: 'HTTP_522',
+        }],
+      },
+      async (...args: unknown[]) => {
+        writeCalls.push(args);
+      },
+    );
+
+    assert.equal(recorded, true);
+    assert.deepEqual(writeCalls, [[
+      'market',
+      'china-corporate-disclosures-szse-failure',
+      0,
+      'china-official-exchange-szse-failure-v1',
+      259_200,
+      Date.parse(failedAt),
+      null,
+      { errorCode: 'HTTP_522', consecutiveFailures: 1 },
+    ]]);
+    assert.equal(
+      await recordSzseTransportFailure(
+        { sources: [{ id: 'szse', transportStatus: 'fresh' }] },
+        async () => {
+          throw new Error('writer must not run for a successful source');
+        },
+      ),
+      false,
+    );
+    assert.equal(
+      CHINA_CORPORATE_DISCLOSURE_SZSE_FAILURE_META_KEY,
+      'seed-meta:market:china-corporate-disclosures-szse-failure',
+    );
+
+    const previousSnapshot = { schemaVersion: 1, sources: [] };
+    const reads: Array<[string, { strict: boolean }]> = [];
+    let fetchInput: Record<string, unknown> | undefined;
+    const result = await buildChinaCorporateDisclosureSeedSnapshot({
+      readSnapshot: async (key: string, options: { strict: boolean }) => {
+        reads.push([key, options]);
+        return key === CHINA_CORPORATE_DISCLOSURE_KEY
+          ? previousSnapshot
+          : {
+              fetchedAt: Date.parse(failedAt),
+              errorCode: 'HTTP_522',
+              consecutiveFailures: 3,
+            };
+      },
+      fetchSnapshot: async (input: Record<string, unknown>) => {
+        fetchInput = input;
+        return { status: 'degraded' };
+      },
+    });
+
+    assert.deepEqual(result, { status: 'degraded' });
+    assert.deepEqual(reads, [
+      [CHINA_CORPORATE_DISCLOSURE_KEY, { strict: true }],
+      [CHINA_CORPORATE_DISCLOSURE_SZSE_FAILURE_META_KEY, { strict: true }],
+    ]);
+    assert.deepEqual(fetchInput, {
+      previousSnapshot,
+      previousTransportFailures: {
+        szse: {
+          checkedAt: failedAt,
+          errorCode: 'HTTP_522',
+          consecutiveFailures: 3,
+        },
+      },
+    });
+
+    const continuedOutage = buildChinaCorporateDisclosureSnapshot({
+      generatedAt: '2026-07-25T11:00:00.000Z',
+      previousSnapshot,
+      previousTransportFailures: fetchInput?.previousTransportFailures,
+      outcomes: [
+        { sourceId: 'sse', ok: false, requestCount: 4, errorCode: 'TIMEOUT' },
+        { sourceId: 'szse', ok: false, requestCount: 4, errorCode: 'HTTP_522' },
+      ],
+    });
+    assert.equal(
+      continuedOutage.sources.find((source) => source.id === 'szse')
+        ?.transportReliability.consecutiveFailures,
+      4,
+    );
+  });
+
   it('degrades consecutive empty source results and resets the counter after observed disclosures', async () => {
     assert.equal(EMPTY_RESULT_DEGRADE_AFTER, 3);
     const emptyOutcomes = [
@@ -871,6 +1123,10 @@ describe('official China corporate disclosures (#5577)', () => {
       emptyResultCount: 0,
       transportPath: 'proxy',
       fallbackReason: 'UND_ERR_CONNECT_TIMEOUT',
+      reliabilityStatus: 'stable',
+      requiredRecoverySuccesses: 2,
+      consecutiveTransportSuccesses: 1,
+      consecutiveTransportFailures: 0,
       checkedAt: retrievedAt,
     });
     assert.doesNotMatch(JSON.stringify(decisions), /proxy-user|proxy-secret/);
@@ -948,6 +1204,10 @@ describe('official China corporate disclosures (#5577)', () => {
           emptyResultCount: 0,
           transportPath: 'proxy',
           fallbackReason: 'ETIMEDOUT',
+          reliabilityStatus: 'stable',
+          requiredRecoverySuccesses: 2,
+          consecutiveTransportSuccesses: 1,
+          consecutiveTransportFailures: 0,
           checkedAt: retrievedAt,
         },
       );
@@ -1042,6 +1302,10 @@ describe('official China corporate disclosures (#5577)', () => {
         transportPath: 'edge',
         fallbackReason: 'ETIMEDOUT',
         proxyFailureReason: 'HTTP_522',
+        reliabilityStatus: 'stable',
+        requiredRecoverySuccesses: 2,
+        consecutiveTransportSuccesses: 1,
+        consecutiveTransportFailures: 0,
         checkedAt: retrievedAt,
       },
     );
@@ -1206,6 +1470,13 @@ describe('official China corporate disclosures (#5577)', () => {
     assert.equal(szse?.proxyFailureReason, 'EAI_AGAIN');
     assert.equal(szse?.edgeFailureReason, 'upstream_fetch_failed');
     assert.equal(szse?.errorCode, 'upstream_fetch_failed');
+    assert.deepEqual(szse?.transportReliability, {
+      status: 'degraded',
+      consecutiveSuccesses: 0,
+      consecutiveFailures: 1,
+      lastFailureAt: degradedAt,
+      lastFailureReason: 'upstream_fetch_failed',
+    });
     assert.deepEqual(
       decisions.find((decision) => decision.sourceId === 'szse'),
       {
@@ -1218,6 +1489,12 @@ describe('official China corporate disclosures (#5577)', () => {
         fallbackReason: 'ECONNRESET',
         proxyFailureReason: 'EAI_AGAIN',
         edgeFailureReason: 'upstream_fetch_failed',
+        reliabilityStatus: 'degraded',
+        requiredRecoverySuccesses: 2,
+        consecutiveTransportSuccesses: 0,
+        consecutiveTransportFailures: 1,
+        lastTransportFailureAt: degradedAt,
+        lastTransportFailureReason: 'upstream_fetch_failed',
         checkedAt: degradedAt,
       },
     );

--- a/tests/china-coverage-health.test.mjs
+++ b/tests/china-coverage-health.test.mjs
@@ -335,6 +335,53 @@ describe('China coverage manifest', () => {
     );
   });
 
+  it('keeps disclosure coverage degraded during a successful transport recovery run', () => {
+    const disclosures = CHINA_COVERAGE_ENTRIES.find(
+      (entry) => entry.id === 'market.china-corporate-disclosures',
+    );
+    const result = evaluate(
+      disclosures,
+      {
+        'market:china:corporate-disclosures:v1': {
+          status: 'degraded',
+          coverageThrough: null,
+          events: [],
+          sources: [
+            {
+              id: 'sse',
+              transportStatus: 'fresh',
+              contentStatus: 'current',
+              transportReliability: { status: 'stable' },
+            },
+            {
+              id: 'szse',
+              transportStatus: 'fresh',
+              contentStatus: 'current',
+              transportReliability: {
+                status: 'recovering',
+                consecutiveSuccesses: 1,
+                consecutiveFailures: 0,
+              },
+            },
+          ],
+        },
+      },
+      {
+        'seed-meta:market:china-corporate-disclosures': {
+          fetchedAt: NOW,
+          status: 'ok',
+        },
+      },
+    );
+
+    assert.equal(result.entries[0].status, 'degraded');
+    assert.equal(result.entries[0].content.status, 'partial');
+    assert.deepEqual(
+      result.entries[0].reasonCodes,
+      [CHINA_COVERAGE_REASON_CODES.CHINA_COVERAGE_PARTIAL],
+    );
+  });
+
   it('keeps a healthy zero-event disclosure window healthy when fetched filings are outside the owned taxonomy', () => {
     const disclosures = CHINA_COVERAGE_ENTRIES.find(
       (entry) => entry.id === 'market.china-corporate-disclosures',

--- a/tests/seed-utils-meta-write-degrades.test.mjs
+++ b/tests/seed-utils-meta-write-degrades.test.mjs
@@ -124,6 +124,7 @@ test('validate-skip path: seed-meta mirror write exhausting retries degrades to 
 
 test('validate-skip path calls the completion hook after last-good preservation succeeds', async () => {
   let completed = 0;
+  let rejected = 0;
   const { exitCode, threw } = await runWithExitTrap(() =>
     runSeed('test', 'preserved-complete', 'test:preserved-complete:v1',
       async () => ({ items: [] }),
@@ -134,6 +135,10 @@ test('validate-skip path calls the completion hook after last-good preservation 
         sourceVersion: 'test-v1',
         schemaVersion: 1,
         maxStaleMin: 720,
+        afterValidationSkip: async (_data, context) => {
+          rejected += 1;
+          assert.equal(context.preservationSucceeded, true);
+        },
         afterPreservedValidationSkip: async (_data, context) => {
           completed += 1;
           assert.equal(context.canonicalKey, 'test:preserved-complete:v1');
@@ -144,11 +149,13 @@ test('validate-skip path calls the completion hook after last-good preservation 
 
   assert.equal(threw, null);
   assert.equal(exitCode, 0);
+  assert.equal(rejected, 1);
   assert.equal(completed, 1);
 });
 
-test('validate-skip path does not complete a run when last-good preservation fails', async () => {
+test('validate-skip path reports rejection but does not complete when last-good preservation fails', async () => {
   let completed = 0;
+  let rejected = 0;
   const fetchWithCanonical = globalThis.fetch;
   globalThis.fetch = async (url, opts = {}) => {
     const u = String(url);
@@ -169,11 +176,61 @@ test('validate-skip path does not complete a run when last-good preservation fai
           sourceVersion: 'test-v1',
           schemaVersion: 1,
           maxStaleMin: 720,
+          afterValidationSkip: async (_data, context) => {
+            rejected += 1;
+            assert.equal(context.canonicalKey, 'test:preserve-failed:v1');
+            assert.equal(context.preservationSucceeded, false);
+          },
           afterPreservedValidationSkip: async () => { completed += 1; },
         }),
     );
     assert.equal(threw, null);
     assert.equal(exitCode, 0);
+    assert.equal(rejected, 1);
+    assert.equal(completed, 0);
+  } finally {
+    globalThis.fetch = fetchWithCanonical;
+  }
+});
+
+test('validate-skip path reports rejection when only part of the preservation cohort exists', async () => {
+  let completed = 0;
+  let rejected = 0;
+  const fetchWithCanonical = globalThis.fetch;
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    if (u.includes('/get/')) {
+      return jsonResponse({ result: JSON.stringify(CANONICAL_ENVELOPE) });
+    }
+    if (u.endsWith('/pipeline')) {
+      return jsonResponse(body.map((_command, index) => ({ result: index === 0 ? 1 : 0 })));
+    }
+    return jsonResponse({ result: 'OK' });
+  };
+
+  try {
+    const { exitCode, threw } = await runWithExitTrap(() =>
+      runSeed('test', 'preserve-partial', 'test:preserve-partial:v1',
+        async () => ({ items: [] }),
+        {
+          validateFn: () => false,
+          ttlSeconds: 3600,
+          declareRecords: () => 1,
+          sourceVersion: 'test-v1',
+          schemaVersion: 1,
+          maxStaleMin: 720,
+          afterValidationSkip: async (_data, context) => {
+            rejected += 1;
+            assert.equal(context.canonicalKey, 'test:preserve-partial:v1');
+            assert.equal(context.preservationSucceeded, false);
+          },
+          afterPreservedValidationSkip: async () => { completed += 1; },
+        }),
+    );
+    assert.equal(threw, null);
+    assert.equal(exitCode, 0);
+    assert.equal(rejected, 1);
     assert.equal(completed, 0);
   } finally {
     globalThis.fetch = fetchWithCanonical;


### PR DESCRIPTION
## Summary

China corporate-disclosure coverage no longer turns healthy after one lucky SZSE request. After an observed SZSE transport failure, the next successful cycle remains degraded with `TRANSPORT_RECOVERING`; only a second consecutive success restores healthy coverage. A bounded failure marker preserves that recovery state when a simultaneous source outage is rejected by last-good validation, without increasing the existing direct, proxy, or edge request budgets.

The refreshed 29-run Railway sample ending 2026-07-29 10:30 UTC contained 15 accepted and 14 degraded SZSE runs. Direct transport timed out in all 29; final failures were ten HTTP 522s, three connection resets, and one timeout. The named and shared proxy settings resolve to the same route, while the newly merged edge path had not yet been exercised. The exact SZSE workload is one sequential CATL metadata POST over the first bounded 50-row page, so neither pagination nor in-process concurrency explains this transport pattern.

This change makes coverage truth reflect sustained recovery instead of adding retries. Source decision logs now expose recovery status, required successes, success/failure streaks, and the last transport failure so post-deploy acceptance can distinguish a recovering source from a stable one.

Related: #5786, #5771

## Validation

- Repository pre-push gate passed, including frontend and API typechecks, Unicode/version checks, and all 51 changed-file tests.
- Eight adjacent proxy-fallback and China decision-signal tests passed.
- Biome lint passed for all five changed files.
- Two internal structured review passes completed. The first found that a total outage could lose recovery history behind last-good validation; the durable marker fixes that path, and the second pass found no remaining internal finding.
- Greptile then found that the initial validation-skip registration passed `runSeed` context where the marker function expected a writer. Follow-up commit `8b75fb8b7` adapts that callback and mutation-pins the production wiring; 30 targeted tests and all 51 changed-file pre-push tests passed afterward.
- The all-data command could not complete in this worktree: its `tsx` launcher hit an IPC `EPERM`; the direct Node runner then stalled in four unrelated long-lived tests and was interrupted. All changed and adjacent suites completed independently.

## New concepts

### Recovery hysteresis

Recovery hysteresis requires stronger evidence to declare a flaky source recovered than to declare it degraded. It fits SZSE because one proxy success has repeatedly been followed by another 522, reset, or timeout; a one-cycle green state is not operational proof.

```mermaid
flowchart LR
  stable["Stable coverage"] -->|transport failure| degraded["Degraded"]
  degraded -->|first success| recovering["Recovering"]
  recovering -->|second consecutive success| stable
  recovering -->|any transport failure| degraded
```

The durable failure marker supplies the degraded starting state when a total-outage snapshot cannot replace last-good data. This pattern should not be used for deterministic sources where a single validated response is sufficient, or where delaying recovery would violate a stronger availability contract.

## Post-deploy monitoring

- **Owner:** @koala73
- **Window:** Inspect the first two `seed-bundle-market-backup` disclosure cycles after deployment, then retain a 24-hour view because the observed failure rate is close to 50%.
- **Logs:** Filter `event=china_corporate_disclosure_source` and `sourceId=szse`; track `transportPath`, fallback reasons, `reliabilityStatus`, required successes, both streaks, and last failure fields.
- **Expected transition:** After a failure, the first successful run is `degraded` / `TRANSPORT_RECOVERING`; the second consecutive success is `accepted` / `stable`. Request count remains within the existing four-attempt ceiling.
- **Last-good check:** A simultaneous SSE/SZSE outage must preserve the canonical snapshot and write the bounded SZSE failure marker; the next valid run must consume that marker.
- **Health:** Check `/api/health?compact=1`, the corporate-disclosure source states, and `chinaCoverage`. Do not close operationally from a single accepted run.
- **Rollback:** Revert if marker read/write failures prevent the seeder from completing, recovery remains stuck after two verified consecutive successes, or request volume exceeds the established source contract.

## Remaining source risk

This PR improves recovery truth; it does not repair the upstream network. Direct SZSE transport still failed in all 29 sampled attempts, both configured proxy names currently share one route, and the edge fallback remains operationally unproven. SSE can fail independently, HKEX remains intentionally blocked by policy, and the current unclassified-disclosure taxonomy gap is separate from transport reliability.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)