### PR TITLE
fix(portwatch): make port-activity recovery converge

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -29,9 +29,10 @@ const TTL = 259_200; // 3 days — 6× the 12h cron interval
 // advance seed-meta/canonical when they meet the recovery publish floor below
 // so fetchedAt does not freeze and incremental coverage gains reach consumers.
 export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
-// Coverage gate for per-country WRITES. Lowered to 5 on 2026-05-18 (was
-// 50 → 25 → 20) so partial-success runs (6-10/30) can persist their fresh
-// per-country payloads to Redis. Below this floor, NOTHING is written.
+// Coverage gate for treating a run as a usable partial data snapshot. Lowered
+// to 5 on 2026-05-18 (was 50 → 25 → 20). Per-country recovery state now
+// persists even below this floor so failed attempts cannot monopolise every
+// future run, but CANONICAL_KEY and META_KEY remain unchanged.
 //
 // PAIRED with MIN_CANONICAL_PUBLISH below: this gate lets per-country
 // writes through (so the cache-fresh rotation accumulates), but a
@@ -44,7 +45,7 @@ export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
 //
 // Floor at 5 matches MIN_FRESH_FETCH_FOR_CAP_BYPASS (the silent-loss
 // safety): cap-mode bypass still requires 5 fresh upstream contacts,
-// so zero-fresh "everything-stale" runs still trip the 80% guard.
+// so zero-fresh "everything-stale" runs preserve canonical + seed-meta.
 //
 // Revert path: bump to 20 when success rate consistently exceeds ~70%,
 // then 30 / 50 as upstream stabilises. Target review: 2026-05-25.
@@ -159,18 +160,14 @@ const ERROR_BODY_CAPTURE_EXTRA_MS = 40_000;
 // is module-local and resets at process start (next cron tick).
 const INVALID_PARAMS_RETRY_THRESHOLD = 5;
 // Minimum FRESH upstream successes (cache-fresh OR fetched-fresh) required
-// for cap-mode to bypass the 80% degradation guard. Pre-fix the bypass was
-// unconditional, which meant a run with `servedStale=27, freshSuccess=0,
-// dropped=117` could pass `countryData.size >= MIN_VALID_COUNTRIES` (all
-// stale-served entries) AND bypass the degradation guard (capTriggered),
-// shrinking the canonical list from ~174 → 27 stale-only entries and
-// advancing seed-meta — hiding the upstream outage.
+// before any run can advance canonical + seed-meta. Cap-mode with enough
+// contact may bypass the 80% degradation guard because its partial shape is
+// deliberate; without enough contact, last-good data and retry state persist
+// while the freshness pointers remain unchanged.
 //
 // Floor at 5 fresh successes: meaningful upstream contact this run.
-// Below that, cap-mode is NOT a rotational steady-state — it's an
-// ArcGIS-completely-down scenario, and the 80% guard should fire (which
-// extendExistingTtl-only on prior payloads, preserves canonical list,
-// keeps WARNING visible to the operator).
+// Below that, the run is an ArcGIS-completely-down scenario, not a
+// rotational publish.
 const MIN_FRESH_FETCH_FOR_CAP_BYPASS = 5;
 // Two aggregation windows, hardcoded in fetchCountryAccum:
 //   last30 = days  0-30 → tankerCalls30d, avg30d, import/export sums
@@ -210,13 +207,15 @@ const MAX_CACHE_AGE_MS = 7 * 86_400_000;
 // 570s bundle budget (observed 2026-05-13: preflight alone took 360s, batch 1
 // of 15 hit 12 errors in 45s before container died at the budget cap).
 //
-// With this cap, a "everything stale" run refreshes a random subset and
-// serves the remainder from prior cache (marked staleAsof=true so downstream
-// can see they're a window behind). A full rotation completes in ~6 runs
-// = ~3 days at the 12h cron cadence, well within the 7-day MAX_CACHE_AGE_MS.
+// With this cap, an "everything stale" run refreshes the 30 countries with
+// the oldest persisted attempt timestamps and serves the remainder from prior
+// cache (marked staleAsof=true so downstream can see they're a window behind).
+// A full attempt sweep completes in 6 runs = 3 days at the 12h cron cadence,
+// well within the 7-day MAX_CACHE_AGE_MS.
 //
 // 30 is sized so the cold-fetch path (30 × ~3-5s/country with concurrency
-// 12 ≈ 12-15s) easily fits the 570s budget even when ArcGIS is slow.
+// 6 ≈ 15-25s, plus 20s of backoff) easily fits the 570s budget even when
+// ArcGIS is slow.
 const MAX_COLD_FETCH_PER_RUN = 30;
 // Concurrency for the cheap per-country maxDate preflight. These are tiny
 // outStatistics queries (returns 1 row), so we can push harder than the
@@ -842,6 +841,69 @@ async function redisPipeline(commands) {
   return resp.json();
 }
 
+export async function publishPortActivitySnapshot(
+  {
+    countryData,
+    retryState = new Map(),
+    countries,
+    metaPayload,
+    canonicalAdvances,
+  },
+  {
+    fetchFn = fetch,
+    credentials = getRedisCredentials(),
+  } = {},
+) {
+  // State-only entries retain the last successful payload (or a bounded
+  // failure marker for a never-cached country) without adding that country to
+  // the published canonical list. Published data wins if a key appears in
+  // both maps.
+  const stateByCountry = new Map(retryState);
+  for (const entry of countryData) stateByCountry.set(...entry);
+
+  const commands = [...stateByCountry.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([iso2, payload]) => [
+      'SET',
+      `${KEY_PREFIX}${iso2}`,
+      JSON.stringify(payload),
+      'EX',
+      TTL,
+    ]);
+  if (canonicalAdvances) {
+    commands.push(['SET', CANONICAL_KEY, JSON.stringify(countries), 'EX', TTL]);
+    commands.push(['SET', META_KEY, JSON.stringify(metaPayload), 'EX', TTL]);
+  }
+  if (commands.length === 0) return [];
+
+  // Upstash /pipeline preserves command order but is explicitly non-atomic.
+  // The canonical list and seed-meta are the publication pointers, so they
+  // must commit in the same transaction as the per-country state they name.
+  const resp = await fetchFn(`${credentials.url}/multi-exec`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${credentials.token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': CHROME_UA,
+    },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`Redis transaction failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+  }
+  const results = await resp.json();
+  if (!Array.isArray(results)) {
+    throw new Error(`Redis transaction failed: ${results?.error || 'invalid response'}`);
+  }
+  const failures = results.filter((result) => result?.error || result?.result === 'ERR');
+  if (failures.length > 0) {
+    throw new Error(`Redis transaction: ${failures.length}/${commands.length} commands failed`);
+  }
+  return results;
+}
+
 // MGET-style batch read via the Upstash REST /pipeline endpoint. Returns an
 // array aligned with `keys` where each element is either the parsed JSON
 // payload or null (for missing/unparseable/errored keys). Used to prime the
@@ -867,24 +929,103 @@ async function redisMgetJson(keys) {
 // `progress` (optional) is mutated in-place so a SIGTERM handler in main()
 // can report which batch / country we died on.
 //
-// Orders the cold-fetch queue no-prior-cache-FIRST (shuffled within each group
-// for rotation fairness). Never-cached countries have no served-stale fallback,
-// so they must win cold-fetch slots ahead of cached-but-stale ones — otherwise
-// the random shuffle starves them out of the canonical (coverage frozen < 174).
-// Pure + exported for unit testing; rng is injectable for determinism. #4293.
-export function orderColdFetchQueue(needsFetch, rng = Math.random) {
-  const shuffle = (arr) => {
-    const a = [...arr];
-    for (let i = a.length - 1; i > 0; i--) {
-      const j = Math.floor(rng() * (i + 1));
-      [a[i], a[j]] = [a[j], a[i]];
-    }
-    return a;
+// Orders cold-fetches by the oldest ATTEMPT, using the last successful cache
+// write as the legacy fallback. This is the durable rotation cursor:
+//
+//   - never-attempted countries have no timestamp and go first;
+//   - a successful fetch updates cacheWrittenAt + refreshAttemptedAt;
+//   - a failed fetch updates only refreshAttemptedAt, so it stays truthfully
+//     stale but cannot monopolise every subsequent 30-country batch.
+//
+// The previous random shuffle did not encode progress. A deterministic
+// reproduction that supplied the same RNG selected the same 30 countries in
+// all six runs, and production dropped 21 seven-day-old cached countries while
+// refreshing younger misses. Oldest-attempt-first guarantees one complete
+// attempt sweep in ceil(174 / 30) = 6 runs, independent of process restarts.
+// ISO2 is the deterministic tie-breaker so equal-age cohorts do not depend on
+// ArcGIS row order. Pure + exported for unit testing.
+export function orderColdFetchQueue(needsFetch) {
+  const lastAttemptAt = (item) => {
+    const prev = item?.prevPayload;
+    if (!prev || typeof prev !== 'object') return Number.NEGATIVE_INFINITY;
+    if (Number.isFinite(prev.refreshAttemptedAt)) return prev.refreshAttemptedAt;
+    if (Number.isFinite(prev.cacheWrittenAt)) return prev.cacheWrittenAt;
+    return Number.NEGATIVE_INFINITY;
   };
-  const hasCache = (it) => Boolean(it && it.prevPayload && typeof it.prevPayload === 'object');
-  const noCache = needsFetch.filter((it) => !hasCache(it));
-  const cached = needsFetch.filter(hasCache);
-  return [...shuffle(noCache), ...shuffle(cached)];
+  const stableId = (item) => String(item?.iso2 || item?.iso3 || '');
+  return [...needsFetch].sort((a, b) => {
+    const ageOrder = lastAttemptAt(a) - lastAttemptAt(b);
+    return ageOrder || stableId(a).localeCompare(stableId(b));
+  });
+}
+
+export function classifyDeferredPayload(
+  prevPayload,
+  now = Date.now(),
+  maxCacheAgeMs = MAX_CACHE_AGE_MS,
+) {
+  if (!prevPayload || typeof prevPayload !== 'object' || !Number.isFinite(prevPayload.cacheWrittenAt)) {
+    return { status: 'missing', payload: null };
+  }
+  if ((now - prevPayload.cacheWrittenAt) >= maxCacheAgeMs) {
+    return { status: 'expired', payload: null };
+  }
+  return { status: 'stale', payload: { ...prevPayload, staleAsof: true } };
+}
+
+function refreshFailureCode(reason) {
+  if (reason?.refreshFailureCode) return reason.refreshFailureCode;
+  const text = `${reason?.code || ''} ${reason?.message || reason || ''}`;
+  if (/timeout|timed out|abort/i.test(text)) return 'timeout';
+  if (/invalid query parameters/i.test(text)) return 'invalid_query';
+  if (/\b429\b|rate.?limit/i.test(text)) return 'rate_limited';
+  return 'fetch_error';
+}
+
+export function buildRefreshFailureState(item, reason, attemptedAt = Date.now()) {
+  const prev = item?.prevPayload && typeof item.prevPayload === 'object'
+    ? item.prevPayload
+    : { iso2: item?.iso2 };
+  const previousFailures = Number(prev.refreshFailure?.consecutiveFailures);
+  return {
+    ...prev,
+    iso2: item?.iso2 || prev.iso2,
+    refreshAttemptedAt: attemptedAt,
+    refreshFailure: {
+      code: refreshFailureCode(reason),
+      consecutiveFailures: Number.isFinite(previousFailures) ? previousFailures + 1 : 1,
+      lastAttemptAt: attemptedAt,
+    },
+  };
+}
+
+export function buildCoverageReport({
+  eligibleCountries,
+  countryData,
+  retryState = new Map(),
+  refreshFailures = [],
+}) {
+  const eligible = [...new Set(eligibleCountries)].sort();
+  const missingCountries = eligible.filter((iso2) => !countryData.has(iso2));
+  const failureByCountry = new Map();
+  for (const [iso2, state] of retryState) {
+    if (typeof state?.refreshFailure?.code === 'string') {
+      failureByCountry.set(iso2, state.refreshFailure.code);
+    }
+  }
+  for (const { iso2, code } of refreshFailures) {
+    if (typeof code === 'string') failureByCountry.set(iso2, code);
+  }
+  const failures = [...failureByCountry]
+    .map(([iso2, code]) => ({ iso2, code }))
+    .sort((a, b) => a.iso2.localeCompare(b.iso2));
+  return {
+    target: eligible.length,
+    published: countryData.size,
+    complete: missingCountries.length === 0,
+    missingCountries,
+    refreshFailures: failures,
+  };
 }
 
 // fetchAll is the orchestrator (refs → schema → preflight → cache-partition
@@ -984,11 +1125,11 @@ export async function fetchAll(progress, { signal } = {}) {
   console.log(`  [port-activity] Cache: ${cacheHits} hits, ${needsFetch.length} misses`);
 
   // Cold-fetch cap (WM 2026-05-13 incident): when needsFetch exceeds the
-  // per-run cap, refresh a random subset and serve the rest from prior
-  // cache marked staleAsof=true. Prevents the catastrophic "everything
+  // per-run cap, refresh the oldest-attempt subset and serve the rest from
+  // prior cache marked staleAsof=true. Prevents the catastrophic "everything
   // stale → 174 cold-fetches → bundle SIGTERM" failure mode that produced
-  // 37h of stale data after a single upstream-advance event. A full
-  // rotation completes in ~ceil(174/30) = 6 runs ≈ 3 days at 12h cadence.
+  // 37h of stale data after a single upstream-advance event. A full attempt
+  // sweep completes in ceil(174/30) = 6 runs = 3 days at 12h cadence.
   // Cap-mode signaling. Surfaces to the caller so main() can bypass the 80%
   // degradation guard for an intentionally-partial publish. Greptile PR #3694
   // round 3 P1: pre-fix, cap-mode + temp-gate=25 would clear the coverage gate
@@ -999,64 +1140,55 @@ export async function fetchAll(progress, { signal } = {}) {
   let servedStaleCount = 0;
   let droppedTooOldCount = 0;
   let droppedNoCacheCount = 0;
+  // Payloads retained for scheduler state but intentionally excluded from the
+  // canonical publication (expired last-good data or a failed never-cached
+  // attempt). Writing these keeps the durable attempt cursor alive without
+  // claiming the country is covered.
+  const retryState = new Map();
+  const refreshFailures = [];
+  const retainPriorState = (iso2, payload, evaluatedAt) => {
+    const deferredState = classifyDeferredPayload(payload, evaluatedAt);
+    if (deferredState.status === 'stale') {
+      countryData.set(iso2, deferredState.payload);
+      servedStaleCount++;
+      return;
+    }
+    if (payload && typeof payload === 'object') retryState.set(iso2, payload);
+    if (deferredState.status === 'expired') droppedTooOldCount++;
+    else droppedNoCacheCount++;
+  };
   // Counts fresh upstream successes this run (fetched-fresh path, line ~904).
   // cacheHits is counted separately and also contributes to "fresh upstream
   // contact" — both are aggregated into the cap-mode bypass gate in main().
-  // Servet-stale entries do NOT count: they're prior-run data being held
+  // Served-stale entries do NOT count: they're prior-run data being held
   // over, no upstream contact this run.
   let freshFetchedCount = 0;
 
   if (needsFetch.length > MAX_COLD_FETCH_PER_RUN) {
     capTriggered = true;
-    // Order the queue no-prior-cache-FIRST, shuffled within each group for
-    // rotation fairness. Never-cached countries have no served-stale fallback:
-    // if deferred past the cap they're dropped entirely (droppedNoCache),
-    // whereas cached-but-stale countries survive the deferral via served-stale.
-    // A plain random shuffle therefore repeatedly starved the same uncached
-    // countries (MY, IE, EC, …) out of the canonical, freezing coverage below
-    // the 174 target. Prioritising them guarantees each a fetch slot every run
-    // (uncached count << cap), so they get cached and then held over. See #4293.
+    // Oldest-attempt-first provides the durable rotation state that a random
+    // shuffle cannot: successful and failed attempts both move behind work that
+    // has not received a slot in the current sweep. Never-attempted countries
+    // naturally sort first, retaining #4293's no-cache recovery property.
     const ordered = orderColdFetchQueue(needsFetch);
     const deferred = ordered.slice(MAX_COLD_FETCH_PER_RUN);
-    let servedStale = 0;
-    let droppedTooOld = 0;
-    let droppedNoCache = 0;
+    const countsBefore = {
+      servedStale: servedStaleCount,
+      droppedTooOld: droppedTooOldCount,
+      droppedNoCache: droppedNoCacheCount,
+    };
     for (const item of deferred) {
-      const prev = item.prevPayload;
-      if (!prev || typeof prev !== 'object') {
-        // No prior payload (new country, first-ever miss). Drop — same as
-        // pre-fix behavior for hard misses.
-        droppedNoCache++;
-        continue;
-      }
-      // MAX_CACHE_AGE_MS hard-drop boundary (Greptile PR #3676 review P1):
-      // the deferred-stale path MUST respect the same age gate the
-      // cacheFresh check enforces, otherwise a country deferred across
-      // enough runs while upstream was frozen ≥4 days could publish data
-      // older than the intended 7d hard-drop threshold. Without this,
-      // window-drift accumulates past MAX_CACHE_AGE_MS and the PR's claim
-      // that hard-drop behavior is unchanged would be false.
-      const cacheWrittenAt = prev.cacheWrittenAt;
-      if (typeof cacheWrittenAt !== 'number' || (now - cacheWrittenAt) >= MAX_CACHE_AGE_MS) {
-        droppedTooOld++;
-        continue;
-      }
-      // Mark as stale-asof so downstream consumers know this country is one
-      // window behind. The canonical payload structure is unchanged.
-      countryData.set(item.iso2, { ...prev, staleAsof: true });
-      servedStale++;
+      retainPriorState(item.iso2, item.prevPayload, now);
     }
+    const servedStale = servedStaleCount - countsBefore.servedStale;
+    const droppedTooOld = droppedTooOldCount - countsBefore.droppedTooOld;
+    const droppedNoCache = droppedNoCacheCount - countsBefore.droppedNoCache;
     needsFetch = ordered.slice(0, MAX_COLD_FETCH_PER_RUN);
     // Rotation arithmetic uses MAX_COLD_FETCH_PER_RUN directly rather than
     // needsFetch.length — needsFetch was just reassigned to the cap-sized
     // slice, so the two are numerically equal here, but using the constant
     // keeps the intent unambiguous if this log block is ever reordered.
     const originalMisses = MAX_COLD_FETCH_PER_RUN + servedStale + droppedTooOld + droppedNoCache;
-    // Surface the bucket counts to the outer-scope fields so main()'s
-    // degradation-guard bypass can include them in the partial-publish log.
-    servedStaleCount = servedStale;
-    droppedTooOldCount = droppedTooOld;
-    droppedNoCacheCount = droppedNoCache;
     console.warn(
       `  [port-activity] Cold-fetch capped at ${MAX_COLD_FETCH_PER_RUN}/run — ` +
       `refreshing ${MAX_COLD_FETCH_PER_RUN} now, serving ${servedStale} on stale cache (asof behind), ` +
@@ -1075,10 +1207,23 @@ export async function fetchAll(progress, { signal } = {}) {
 
   const errors = progress?.errors ?? [];
   const activityStart = Date.now();
+  const retainFailedAttempt = (item, reason, attemptedAt) => {
+    const state = buildRefreshFailureState(item, reason, attemptedAt);
+    refreshFailures.push({
+      iso2: item.iso2,
+      code: state.refreshFailure.code,
+    });
+    // A transient refresh failure must not discard still-usable data.
+    // refreshAttemptedAt advances rotation fairness; cacheWrittenAt remains
+    // unchanged, so the hard-expiry decision stays truthful.
+    retainPriorState(item.iso2, state, attemptedAt);
+  };
 
+  const completedFetches = new Set();
   for (let i = 0; i < needsFetch.length; i += CONCURRENCY) {
     const batch = needsFetch.slice(i, i + CONCURRENCY);
     const batchIdx = Math.floor(i / CONCURRENCY) + 1;
+    const attemptedAt = Date.now();
     if (progress) progress.batchIdx = batchIdx;
 
     const promises = batch.map(({ iso3, upstreamMaxDate }) => {
@@ -1101,20 +1246,40 @@ export async function fetchAll(progress, { signal } = {}) {
     for (let j = 0; j < batch.length; j++) {
       const { iso3, iso2, upstreamMaxDate } = batch[j];
       const outcome = settled[j];
-      if (outcome.status === 'rejected') continue; // already recorded via .catch
+      completedFetches.add(iso2);
+      if (outcome.status === 'rejected') {
+        retainFailedAttempt(batch[j], outcome.reason, attemptedAt);
+        continue; // diagnostic already recorded via eager .catch
+      }
       const portAccumMap = outcome.value;
-      if (!portAccumMap || portAccumMap.size === 0) continue;
+      if (!portAccumMap || portAccumMap.size === 0) {
+        const reason = Object.assign(new Error('empty activity result'), {
+          refreshFailureCode: 'empty_activity',
+        });
+        errors.push(`${iso3}: ${reason.message}`);
+        retainFailedAttempt(batch[j], reason, attemptedAt);
+        continue;
+      }
       const ports = finalisePortsForCountry(portAccumMap, refsByIso3.get(iso3));
-      if (!ports.length) continue;
+      if (!ports.length) {
+        const reason = Object.assign(new Error('empty final port list'), {
+          refreshFailureCode: 'empty_ports',
+        });
+        errors.push(`${iso3}: ${reason.message}`);
+        retainFailedAttempt(batch[j], reason, attemptedAt);
+        continue;
+      }
+      const refreshedAt = Date.now();
       countryData.set(iso2, {
         iso2,
         ports,
-        fetchedAt: new Date().toISOString(),
+        fetchedAt: new Date(refreshedAt).toISOString(),
         // Cache fields. `asof` may be null if preflight failed; that's fine —
         // next run will always be a miss (null !== any string) so we'll
         // re-fetch and repopulate.
         asof: upstreamMaxDate,
-        cacheWrittenAt: Date.now(),
+        cacheWrittenAt: refreshedAt,
+        refreshAttemptedAt: attemptedAt,
       });
       freshFetchedCount++;
     }
@@ -1128,17 +1293,17 @@ export async function fetchAll(progress, { signal } = {}) {
     // Circuit-breaker: if batch 1 is ≥80% rejected with the SAME class of
     // error, treat it as an upstream global regression (schema rename, policy
     // change, dataset moved) — not a flake that more retries will clear.
-    // Skip the remaining batches and let the catch-path extendExistingTtl
-    // preserve prior payloads. Cuts failure cost ~30s → ~2s and keeps Sentry
-    // signal-to-noise sane during incidents like the 2026-04-29 IMF
-    // PortWatch `date` → `date_` rename.
+    // Skip the remaining batches and preserve their last-good state below.
+    // Cuts failure cost ~30s → ~2s and keeps Sentry signal-to-noise sane
+    // during incidents like the 2026-04-29 IMF PortWatch `date` → `date_`
+    // rename.
     if (batchIdx === 1 && batches > 1 && batch.length >= 5) {
       const sameClassRate = errors.filter(e => /Invalid query parameters/i.test(e)).length / batch.length;
       if (sameClassRate >= 0.8) {
         console.error(
           `  [port-activity] CIRCUIT-BREAKER: ${(sameClassRate * 100).toFixed(0)}% of batch 1 rejected with "Invalid query parameters" — ` +
           `assuming upstream schema/policy regression. Skipping remaining ${batches - 1} batches; ` +
-          `catch-path will extend TTLs on prior payloads. First error: ${errors[0]}`,
+          `unattempted countries will retain last-good state. First error: ${errors[0]}`,
         );
         break;
       }
@@ -1176,14 +1341,43 @@ export async function fetchAll(progress, { signal } = {}) {
     }
   }
 
+  const unattemptedFetches = needsFetch.filter(({ iso2 }) => !completedFetches.has(iso2));
+  if (unattemptedFetches.length > 0) {
+    const evaluatedAt = Date.now();
+    for (const item of unattemptedFetches) {
+      retainPriorState(item.iso2, item.prevPayload, evaluatedAt);
+    }
+    console.warn(
+      `  [port-activity] ${unattemptedFetches.length} queued countries were not attempted; ` +
+      'retained last-good or scheduler-only state without advancing their attempt cursor.',
+    );
+  }
+
   if (errors.length) {
     console.warn(`  [port-activity] ${errors.length} country errors: ${errors.slice(0, 5).join('; ')}${errors.length > 5 ? ' ...' : ''}`);
   }
 
-  if (countryData.size === 0) throw new Error('No country port data returned from ArcGIS');
-  return {
-    countries: [...countryData.keys()],
+  const countries = [...countryData.keys()];
+  const coverage = buildCoverageReport({
+    eligibleCountries: eligibleIso3.map((iso3) => iso3ToIso2.get(iso3)),
     countryData,
+    retryState,
+    refreshFailures,
+  });
+  if (!coverage.complete) {
+    const failureCodes = coverage.refreshFailures.length > 0
+      ? ` Refresh failures: ${coverage.refreshFailures.map(({ iso2, code }) => `${iso2}:${code}`).join(', ')}.`
+      : '';
+    console.error(
+      `  [port-activity] COVERAGE GAPS: ${coverage.published}/${coverage.target}; ` +
+      `unpublished countries: ${coverage.missingCountries.join(', ') || 'none'}.${failureCodes}`,
+    );
+  }
+  return {
+    countries,
+    countryData,
+    retryState,
+    coverage,
     fetchedAt: new Date().toISOString(),
     // Cap-mode signaling — see capTriggered declaration. main() reads these
     // to bypass the 80% degradation guard for an intentionally-partial
@@ -1210,6 +1404,28 @@ export function validateFn(data) {
 export function shouldAdvanceCanonical(countryCount, floor = MIN_CANONICAL_PUBLISH) {
   const count = Number(countryCount);
   return Number.isFinite(count) && count >= floor;
+}
+
+export function shouldAdvanceCanonicalForRun(
+  {
+    countryCount,
+    previousCountryCount,
+    capTriggered,
+    upstreamContactCount,
+  },
+  {
+    publishFloor = MIN_CANONICAL_PUBLISH,
+    minUpstreamContacts = MIN_FRESH_FETCH_FOR_CAP_BYPASS,
+  } = {},
+) {
+  if (!shouldAdvanceCanonical(countryCount, publishFloor)) return false;
+  if (upstreamContactCount < minUpstreamContacts) return false;
+  if (
+    !capTriggered
+    && previousCountryCount > 0
+    && countryCount < previousCountryCount * 0.8
+  ) return false;
+  return true;
 }
 
 async function main() {
@@ -1276,14 +1492,15 @@ async function main() {
       droppedNoCacheCount,
       freshFetchedCount,
       cacheHitCount,
+      retryState,
+      coverage,
     } = await fetchAll(progress, { signal: shutdownController.signal });
 
     console.log(`  Fetched ${countryData.size} countries`);
 
-    if (!validateFn({ countries })) {
+    const coverageGatePassed = validateFn({ countries });
+    if (!coverageGatePassed) {
       console.error(`  COVERAGE GATE FAILED: only ${countryData.size} countries, need >=${MIN_VALID_COUNTRIES}`);
-      await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
-      return;
     }
 
     // Degradation guard — bypass when capTriggered (Greptile PR #3694 round 3 P1).
@@ -1307,9 +1524,8 @@ async function main() {
     // (countryData.size=27 ≥ 25) and bypass the degradation guard, shrinking
     // the canonical list from ~174 → 27 stale-only entries and advancing
     // seed-meta as healthy — hiding the upstream outage. With this gate,
-    // such a run falls through to the 80% guard (which fires and
-    // extendExistingTtl-only), preserving the canonical list and the
-    // operator-facing WARNING.
+    // per-country recovery state persists but the canonical list and seed-meta
+    // remain at last-good, preserving the operator-facing warning.
     const upstreamContactCount = freshFetchedCount + cacheHitCount;
     const capBypassEarned = capTriggered && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS;
     if (capBypassEarned) {
@@ -1320,24 +1536,25 @@ async function main() {
         `Degradation guard bypassed (≥${MIN_FRESH_FETCH_FOR_CAP_BYPASS} fresh upstream contacts); seed-meta will advance.`,
       );
     } else if (capTriggered) {
-      // Cap-mode WITHOUT enough fresh upstream contact — fall through to the
-      // 80% guard. If we got here, freshFetched + cacheHits < threshold,
-      // which means this is an upstream-degraded run, not a rotational one.
-      // Log explicitly so the operator sees why the bypass didn't fire.
+      // Cap-mode without enough fresh upstream contact is an outage, not a
+      // rotational publish. Persist per-country attempt state so the next run
+      // advances to other countries, but preserve canonical + seed-meta so
+      // last-good data cannot masquerade as a fresh successful run.
       console.error(
         `  CAP-MODE BYPASS REFUSED: only ${upstreamContactCount} fresh upstream contacts ` +
         `(${freshFetchedCount} fetched + ${cacheHitCount} cache-fresh, threshold ${MIN_FRESH_FETCH_FOR_CAP_BYPASS}). ` +
-        `Stale-only published would hide the upstream outage. Falling through to 80% degradation guard.`,
+        'Canonical + seed-meta will be preserved; recovery state will persist.',
       );
-      if (prevCount > 0 && countryData.size < prevCount * 0.8) {
-        console.error(`  DEGRADATION GUARD: ${countryData.size} countries vs ${prevCount} previous — refusing to overwrite (need ≥${Math.ceil(prevCount * 0.8)})`);
-        await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
-        return;
-      }
     } else if (prevCount > 0 && countryData.size < prevCount * 0.8) {
-      console.error(`  DEGRADATION GUARD: ${countryData.size} countries vs ${prevCount} previous — refusing to overwrite (need ≥${Math.ceil(prevCount * 0.8)})`);
-      await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
-      return;
+      console.error(
+        `  DEGRADATION GUARD: ${countryData.size} countries vs ${prevCount} previous — ` +
+        `preserving canonical + seed-meta (need ≥${Math.ceil(prevCount * 0.8)}); recovery state will persist.`,
+      );
+    } else if (upstreamContactCount < MIN_FRESH_FETCH_FOR_CAP_BYPASS) {
+      console.error(
+        `  UPSTREAM CONTACT GATE: only ${upstreamContactCount} fresh upstream contacts — ` +
+        `preserving canonical + seed-meta (need ≥${MIN_FRESH_FETCH_FOR_CAP_BYPASS}); recovery state will persist.`,
+      );
     }
 
     // PR #3760 round 2 P1: split per-country writes from canonical/meta
@@ -1345,22 +1562,22 @@ async function main() {
     // accumulates), but CANONICAL + META only advance when total coverage
     // crosses MIN_CANONICAL_PUBLISH — protects consumers from seeing a
     // 5-country canonical published as fresh during recovery.
-    const canonicalAdvances = shouldAdvanceCanonical(countryData.size);
-    const metaPayload = { fetchedAt: Date.now(), recordCount: countryData.size };
+    const canonicalAdvances = coverageGatePassed && shouldAdvanceCanonicalForRun({
+      countryCount: countryData.size,
+      previousCountryCount: prevCount,
+      capTriggered,
+      upstreamContactCount,
+    });
+    const metaPayload = {
+      fetchedAt: Date.now(),
+      recordCount: countryData.size,
+      coverage,
+    };
 
-    const commands = [];
-    for (const [iso2, payload] of countryData) {
-      commands.push(['SET', `${KEY_PREFIX}${iso2}`, JSON.stringify(payload), 'EX', TTL]);
-    }
-    if (canonicalAdvances) {
-      commands.push(['SET', CANONICAL_KEY, JSON.stringify(countries), 'EX', TTL]);
-      commands.push(['SET', META_KEY, JSON.stringify(metaPayload), 'EX', TTL]);
-    } else {
-      // Per-country fresh data persists, but canonical list + seed-meta
-      // stay at the prior version. extendExistingTtl preserves the
-      // operator-facing state stable — consumers reading CANONICAL see the
-      // prior canonical list with their existing data (mostly stale for
-      // not-yet-rotated entries, fresh for the ones we just wrote).
+    if (!canonicalAdvances) {
+      // Per-country data and attempt state persist, but canonical + seed-meta
+      // stay at the prior version. This keeps the durable sweep moving without
+      // making a low-coverage or no-upstream-contact run look fresh.
       //
       // Greptile PR #3760 round 3 P1: prevCountryKeys MUST be extended
       // here too, mirroring the COVERAGE GATE / DEGRADATION GUARD
@@ -1372,17 +1589,27 @@ async function main() {
       // `commands` below get their own SET ... EX TTL, so this only
       // affects the un-refreshed entries from the prior list.
       await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
+      const persistedStateCount = new Set([
+        ...countryData.keys(),
+        ...retryState.keys(),
+      ]).size;
       console.warn(
-        `  PARTIAL PERSIST: ${countryData.size}/${MIN_CANONICAL_PUBLISH} below canonical-publish floor — ` +
-        `${countryData.size} per-country payload(s) written (cache rotation accumulates), ` +
-        `canonical + seed-meta + prior per-country keys preserved.`,
+        `  PARTIAL PERSIST: ${persistedStateCount} per-country recovery state(s) written; ` +
+        'canonical + seed-meta + prior per-country keys preserved.',
       );
     }
 
-    const results = await redisPipeline(commands);
-    const failures = results.filter(r => r?.error || r?.result === 'ERR');
-    if (failures.length > 0) {
-      throw new Error(`Redis pipeline: ${failures.length}/${commands.length} commands failed`);
+    await publishPortActivitySnapshot({
+      countryData,
+      retryState,
+      countries,
+      metaPayload,
+      canonicalAdvances,
+    });
+
+    if (!coverageGatePassed) {
+      if (countryData.size === 0) throw new Error('No country port data returned from ArcGIS');
+      return;
     }
 
     logSeedResult('supply_chain', countryData.size, Date.now() - startedAt, { source: 'portwatch-ports' });

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -25,9 +25,9 @@ const LOCK_TTL_MS = 60 * 60 * 1000;
 const TTL = 259_200; // 3 days — 6× the 12h cron interval
 // PortWatch currently has 174 ISO2-mapped countries with port references.
 // This is the issue #3613 health target. Runs below this count must stay
-// non-green in /api/health and /api/seed-health, but they still need to
-// advance seed-meta/canonical when they meet the recovery publish floor below
-// so fetchedAt does not freeze and incremental coverage gains reach consumers.
+// non-green in /api/health and /api/seed-health. Partial activity snapshots
+// may still advance when the reference feed proves the full universe, but a
+// truncated reference feed must preserve the prior canonical + seed-meta.
 export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
 // Coverage gate for treating a run as a usable partial data snapshot. Lowered
 // to 5 on 2026-05-18 (was 50 → 25 → 20). Per-country recovery state now
@@ -976,9 +976,9 @@ export function classifyDeferredPayload(
 function refreshFailureCode(reason) {
   if (reason?.refreshFailureCode) return reason.refreshFailureCode;
   const text = `${reason?.code || ''} ${reason?.message || reason || ''}`;
-  if (/timeout|timed out|abort/i.test(text)) return 'timeout';
   if (/invalid query parameters/i.test(text)) return 'invalid_query';
   if (/\b429\b|rate.?limit/i.test(text)) return 'rate_limited';
+  if (/timeout|timed out|abort/i.test(text)) return 'timeout';
   return 'fetch_error';
 }
 
@@ -1001,12 +1001,16 @@ export function buildRefreshFailureState(item, reason, attemptedAt = Date.now())
 
 export function buildCoverageReport({
   eligibleCountries,
+  expectedCountries = [],
   countryData,
   retryState = new Map(),
   refreshFailures = [],
 }) {
   const eligible = [...new Set(eligibleCountries)].sort();
-  const missingCountries = eligible.filter((iso2) => !countryData.has(iso2));
+  const expected = [...new Set([...expectedCountries, ...eligible])].sort();
+  const target = Math.max(PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES, expected.length);
+  const missingCountries = expected.filter((iso2) => !countryData.has(iso2));
+  const unidentifiedMissingCount = Math.max(0, target - expected.length);
   const failureByCountry = new Map();
   for (const [iso2, state] of retryState) {
     if (typeof state?.refreshFailure?.code === 'string') {
@@ -1020,10 +1024,12 @@ export function buildCoverageReport({
     .map(([iso2, code]) => ({ iso2, code }))
     .sort((a, b) => a.iso2.localeCompare(b.iso2));
   return {
-    target: eligible.length,
+    target,
+    referenceCountryCount: eligible.length,
     published: countryData.size,
-    complete: missingCountries.length === 0,
+    complete: missingCountries.length === 0 && unidentifiedMissingCount === 0,
     missingCountries,
+    unidentifiedMissingCount,
     refreshFailures: failures,
   };
 }
@@ -1032,7 +1038,7 @@ export function buildCoverageReport({
 // → batched fetch → finalise); splitting it would move complexity into a
 // hidden seam and obscure the linear pipeline. Each stage is short and
 // well-commented.
-export async function fetchAll(progress, { signal } = {}) {
+export async function fetchAll(progress, { signal, expectedCountries = [] } = {}) {
   const { iso3ToIso2 } = createCountryResolvers();
 
   // Resolve the queryable date-column name once per run, before any
@@ -1360,6 +1366,7 @@ export async function fetchAll(progress, { signal } = {}) {
   const countries = [...countryData.keys()];
   const coverage = buildCoverageReport({
     eligibleCountries: eligibleIso3.map((iso3) => iso3ToIso2.get(iso3)),
+    expectedCountries,
     countryData,
     retryState,
     refreshFailures,
@@ -1370,7 +1377,8 @@ export async function fetchAll(progress, { signal } = {}) {
       : '';
     console.error(
       `  [port-activity] COVERAGE GAPS: ${coverage.published}/${coverage.target}; ` +
-      `unpublished countries: ${coverage.missingCountries.join(', ') || 'none'}.${failureCodes}`,
+      `unpublished countries: ${coverage.missingCountries.join(', ') || 'none'}; ` +
+      `unidentified shortfall: ${coverage.unidentifiedMissingCount}.${failureCodes}`,
     );
   }
   return {
@@ -1410,15 +1418,22 @@ export function shouldAdvanceCanonicalForRun(
   {
     countryCount,
     previousCountryCount,
+    referenceCountryCount,
     capTriggered,
     upstreamContactCount,
   },
   {
     publishFloor = MIN_CANONICAL_PUBLISH,
     minUpstreamContacts = MIN_FRESH_FETCH_FOR_CAP_BYPASS,
+    minReferenceCountries = PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES,
   } = {},
 ) {
   if (!shouldAdvanceCanonical(countryCount, publishFloor)) return false;
+  const currentReferenceCount = Number(referenceCountryCount);
+  if (
+    !Number.isFinite(currentReferenceCount)
+    || currentReferenceCount < minReferenceCountries
+  ) return false;
   if (upstreamContactCount < minUpstreamContacts) return false;
   if (
     !capTriggered
@@ -1494,7 +1509,10 @@ async function main() {
       cacheHitCount,
       retryState,
       coverage,
-    } = await fetchAll(progress, { signal: shutdownController.signal });
+    } = await fetchAll(progress, {
+      signal: shutdownController.signal,
+      expectedCountries: Array.isArray(prevIso2List) ? prevIso2List : [],
+    });
 
     console.log(`  Fetched ${countryData.size} countries`);
 
@@ -1527,8 +1545,20 @@ async function main() {
     // per-country recovery state persists but the canonical list and seed-meta
     // remain at last-good, preserving the operator-facing warning.
     const upstreamContactCount = freshFetchedCount + cacheHitCount;
-    const capBypassEarned = capTriggered && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS;
-    if (capBypassEarned) {
+    const referenceGatePassed =
+      coverage.referenceCountryCount >= PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES;
+    const capBypassEarned = capTriggered
+      && referenceGatePassed
+      && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS;
+    if (!referenceGatePassed) {
+      console.error(
+        `  REFERENCE COVERAGE GATE: ${coverage.referenceCountryCount}/` +
+        `${PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES} reference countries; ` +
+        `${coverage.missingCountries.length} named gap(s), ` +
+        `${coverage.unidentifiedMissingCount} unidentified gap(s). ` +
+        'Canonical + seed-meta will be preserved.',
+      );
+    } else if (capBypassEarned) {
       console.warn(
         `  PARTIAL PUBLISH (cap-mode): ${countryData.size}/${prevCount} countries — ` +
         `${freshFetchedCount} fresh-fetched, ${cacheHitCount} cache-fresh, ${servedStaleCount} stale-served, ` +
@@ -1565,6 +1595,7 @@ async function main() {
     const canonicalAdvances = coverageGatePassed && shouldAdvanceCanonicalForRun({
       countryCount: countryData.size,
       previousCountryCount: prevCount,
+      referenceCountryCount: coverage.referenceCountryCount,
       capTriggered,
       upstreamContactCount,
     });

--- a/server/worldmonitor/intelligence/v1/get-country-port-activity.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-port-activity.ts
@@ -27,6 +27,7 @@ interface SeederPayload {
   iso2?: string | null;
   ports?: SeederPort[] | null;
   fetchedAt?: string | null;
+  cacheWrittenAt?: number | null;
 }
 
 const EMPTY: CountryPortActivityResponse = {
@@ -34,6 +35,24 @@ const EMPTY: CountryPortActivityResponse = {
   ports: [],
   fetchedAt: '',
 };
+
+// Keep the consumer's hard-expiry boundary aligned with the PortWatch seeder.
+// The scheduler can retain an expired payload under its Redis key solely to
+// preserve the durable refresh cursor while the last-good canonical pointer is
+// held. That state must never become consumer-visible again.
+export const PORTWATCH_PORT_ACTIVITY_MAX_CACHE_AGE_MS = 7 * 86_400_000;
+
+export function isCurrentPortActivityPayload(
+  payload: unknown,
+  now = Date.now(),
+  maxCacheAgeMs = PORTWATCH_PORT_ACTIVITY_MAX_CACHE_AGE_MS,
+): payload is SeederPayload {
+  if (!payload || typeof payload !== 'object') return false;
+  const cacheWrittenAt = (payload as SeederPayload).cacheWrittenAt;
+  return typeof cacheWrittenAt === 'number'
+    && Number.isFinite(cacheWrittenAt)
+    && (now - cacheWrittenAt) < maxCacheAgeMs;
+}
 
 export async function getCountryPortActivity(
   _ctx: ServerContext,
@@ -50,6 +69,7 @@ export async function getCountryPortActivity(
   if (!data) return EMPTY;
 
   const payload = data as SeederPayload;
+  if (!isCurrentPortActivityPayload(payload)) return EMPTY;
   const rawPorts = Array.isArray(payload.ports) ? payload.ports : [];
   const topPorts = rawPorts.slice(0, 25);
 

--- a/tests/country-port-activity-freshness.test.mts
+++ b/tests/country-port-activity-freshness.test.mts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+
+import type {
+  GetCountryPortActivityRequest,
+  ServerContext,
+} from '../src/generated/server/worldmonitor/intelligence/v1/service_server.ts';
+import {
+  getCountryPortActivity,
+  isCurrentPortActivityPayload,
+  PORTWATCH_PORT_ACTIVITY_MAX_CACHE_AGE_MS,
+} from '../server/worldmonitor/intelligence/v1/get-country-port-activity.ts';
+
+const DAY = 86_400_000;
+const NOW = Date.parse('2026-07-29T12:00:00.000Z');
+const CTX: ServerContext = {
+  request: new Request('https://example.test/'),
+  pathParams: {},
+  headers: {},
+};
+const REQ: GetCountryPortActivityRequest = { countryCode: 'US' };
+
+describe('country port-activity consumer freshness', () => {
+  it('uses the same strict seven-day boundary as the seeder', () => {
+    assert.equal(PORTWATCH_PORT_ACTIVITY_MAX_CACHE_AGE_MS, 7 * DAY);
+    assert.equal(isCurrentPortActivityPayload({
+      cacheWrittenAt: NOW - PORTWATCH_PORT_ACTIVITY_MAX_CACHE_AGE_MS + 1,
+    }, NOW), true);
+    assert.equal(isCurrentPortActivityPayload({
+      cacheWrittenAt: NOW - PORTWATCH_PORT_ACTIVITY_MAX_CACHE_AGE_MS,
+    }, NOW), false);
+    assert.equal(isCurrentPortActivityPayload({}, NOW), false);
+  });
+
+  describe('handler read path', () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    before(() => {
+      process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+      process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    });
+
+    after(() => {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    });
+
+    it('does not serve an expired state payload still named by the canonical list', async () => {
+      globalThis.fetch = async (input) => {
+        const key = decodeURIComponent(new URL(String(input)).pathname.replace('/get/', ''));
+        const value = key.endsWith('_countries')
+          ? ['US']
+          : {
+              iso2: 'US',
+              cacheWrittenAt: Date.now() - 8 * DAY,
+              fetchedAt: '2026-07-20T00:00:00.000Z',
+              ports: [{ portId: 'US-1', portName: 'Expired port' }],
+            };
+        return new Response(JSON.stringify({ result: JSON.stringify(value) }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      };
+
+      const response = await getCountryPortActivity(CTX, REQ);
+
+      assert.deepEqual(response, {
+        available: false,
+        ports: [],
+        fetchedAt: '',
+      });
+    });
+  });
+});

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -108,6 +108,49 @@ describe('PortWatch last-good and gap reporting', () => {
     assert.deepEqual(report.refreshFailures, [{ iso2: 'CY', code: 'timeout' }]);
     assert.equal(report.complete, false);
   });
+
+  it('reports a truncated reference feed against the durable country target', () => {
+    const report = portwatchSeed.buildCoverageReport({
+      eligibleCountries: ['US'],
+      expectedCountries: ['US', 'CY'],
+      countryData: new Map([['US', cachedCountry('US', 10 * DAY).prevPayload]]),
+    });
+
+    assert.equal(report.target, 174);
+    assert.equal(report.referenceCountryCount, 1);
+    assert.equal(report.published, 1);
+    assert.equal(report.complete, false);
+    assert.deepEqual(report.missingCountries, ['CY']);
+    assert.equal(report.unidentifiedMissingCount, 172);
+  });
+
+  it('classifies the root cause before transport wording in composite errors', () => {
+    const invalidQueryState = portwatchSeed.buildRefreshFailureState(
+      cachedCountry('US'),
+      new Error('ArcGIS error (via proxy after timeout): Invalid query parameters'),
+      10 * DAY,
+    );
+    const rateLimitedState = portwatchSeed.buildRefreshFailureState(
+      cachedCountry('CY'),
+      new Error('Proxy timeout after upstream HTTP 429 rate limit'),
+      10 * DAY,
+    );
+
+    assert.equal(invalidQueryState.refreshFailure.code, 'invalid_query');
+    assert.equal(rateLimitedState.refreshFailure.code, 'rate_limited');
+  });
+});
+
+describe('PortWatch canonical reference guard', () => {
+  it('refuses to publish a shrunken canonical when the reference feed is partial', () => {
+    assert.equal(portwatchSeed.shouldAdvanceCanonicalForRun({
+      countryCount: 153,
+      previousCountryCount: 174,
+      referenceCountryCount: 153,
+      capTriggered: true,
+      upstreamContactCount: 30,
+    }), false);
+  });
 });
 
 describe('PortWatch atomic publication', () => {

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -1,0 +1,229 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as portwatchSeed from '../scripts/seed-portwatch-port-activity.mjs';
+
+const { orderColdFetchQueue } = portwatchSeed;
+const DAY = 86_400_000;
+
+function cachedCountry(iso2, cacheWrittenAt = 0) {
+  return {
+    iso2,
+    prevPayload: {
+      iso2,
+      ports: [{ portId: `${iso2}-port` }],
+      asof: '2026-07-24',
+      cacheWrittenAt,
+    },
+  };
+}
+
+describe('PortWatch cold-fetch recovery rotation', () => {
+  it('attempts all 174 countries within six 30-country runs', () => {
+    const countries = Array.from({ length: 174 }, (_, index) =>
+      cachedCountry(`C${String(index).padStart(3, '0')}`),
+    );
+    const attempted = new Set();
+
+    for (let run = 1; run <= 6; run += 1) {
+      const selected = orderColdFetchQueue(countries).slice(0, 30);
+      const attemptedAt = run * 1_000;
+      for (const item of selected) {
+        attempted.add(item.iso2);
+        item.prevPayload.cacheWrittenAt = attemptedAt;
+        item.prevPayload.refreshAttemptedAt = attemptedAt;
+      }
+    }
+
+    assert.equal(
+      attempted.size,
+      countries.length,
+      'the scheduler must finish a durable sweep instead of reselecting recent work',
+    );
+  });
+
+  it('does not let partial failures monopolize the next capped run', () => {
+    const countries = Array.from({ length: 40 }, (_, index) =>
+      cachedCountry(`C${String(index).padStart(2, '0')}`),
+    );
+    const first = orderColdFetchQueue(countries).slice(0, 10);
+    const firstIds = new Set(first.map((item) => item.iso2));
+
+    for (const [index, item] of first.entries()) {
+      item.prevPayload.refreshAttemptedAt = 1_000;
+      if (index >= 3) item.prevPayload.cacheWrittenAt = 1_000;
+    }
+
+    const second = orderColdFetchQueue(countries).slice(0, 10);
+    assert.ok(
+      second.every((item) => !firstIds.has(item.iso2)),
+      'failed attempts must rotate behind countries that have not received a slot',
+    );
+  });
+});
+
+describe('PortWatch last-good and gap reporting', () => {
+  it('serves only caches strictly inside the seven-day boundary', () => {
+    const classify = portwatchSeed.classifyDeferredPayload;
+    assert.equal(typeof classify, 'function');
+    const now = 10 * DAY;
+
+    const usable = classify(cachedCountry('US', now - 7 * DAY + 1).prevPayload, now);
+    assert.equal(usable.status, 'stale');
+    assert.equal(usable.payload.staleAsof, true);
+
+    assert.deepEqual(
+      classify(cachedCountry('CY', now - 7 * DAY).prevPayload, now),
+      { status: 'expired', payload: null },
+    );
+    assert.deepEqual(classify(null, now), { status: 'missing', payload: null });
+  });
+
+  it('records a failed attempt without refreshing the last-good data age', () => {
+    const buildFailure = portwatchSeed.buildRefreshFailureState;
+    assert.equal(typeof buildFailure, 'function');
+    const now = 10 * DAY;
+    const item = cachedCountry('CY', now - 6 * DAY);
+    item.prevPayload.refreshFailure = {
+      code: 'timeout',
+      consecutiveFailures: 1,
+      lastAttemptAt: now - DAY,
+    };
+
+    const state = buildFailure(item, new Error('per-country timeout after 90s'), now);
+    assert.equal(state.cacheWrittenAt, now - 6 * DAY, 'failure must not make stale data fresh');
+    assert.equal(state.refreshAttemptedAt, now);
+    assert.deepEqual(state.refreshFailure, {
+      code: 'timeout',
+      consecutiveFailures: 2,
+      lastAttemptAt: now,
+    });
+
+    const report = portwatchSeed.buildCoverageReport({
+      eligibleCountries: ['US', 'CY'],
+      countryData: new Map([['US', cachedCountry('US', now).prevPayload]]),
+      retryState: new Map([['CY', state]]),
+    });
+    assert.deepEqual(report.missingCountries, ['CY']);
+    assert.deepEqual(report.refreshFailures, [{ iso2: 'CY', code: 'timeout' }]);
+    assert.equal(report.complete, false);
+  });
+});
+
+describe('PortWatch atomic publication', () => {
+  function publicationInput() {
+    const now = 10 * DAY;
+    return {
+      countryData: new Map([['US', cachedCountry('US', now).prevPayload]]),
+      retryState: new Map([['CY', {
+        ...cachedCountry('CY', now - 8 * DAY).prevPayload,
+        refreshAttemptedAt: now,
+        refreshFailure: {
+          code: 'timeout',
+          consecutiveFailures: 2,
+          lastAttemptAt: now,
+        },
+      }]]),
+      countries: ['US'],
+      metaPayload: {
+        fetchedAt: now,
+        recordCount: 1,
+        coverage: {
+          target: 2,
+          published: 1,
+          complete: false,
+          missingCountries: ['CY'],
+          refreshFailures: [{ iso2: 'CY', code: 'timeout' }],
+        },
+      },
+      canonicalAdvances: true,
+    };
+  }
+
+  it('commits country state, canonical, and seed-meta through one transaction', async () => {
+    const publish = portwatchSeed.publishPortActivitySnapshot;
+    assert.equal(typeof publish, 'function');
+    const calls = [];
+    const fetchFn = async (url, init) => {
+      const commands = JSON.parse(init.body);
+      calls.push({ url: String(url), commands });
+      return new Response(JSON.stringify(commands.map(() => ({ result: 'OK' }))), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    await publish(publicationInput(), {
+      fetchFn,
+      credentials: { url: 'https://redis.example.test', token: 'token' },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://redis.example.test/multi-exec');
+    assert.deepEqual(
+      calls[0].commands.map((command) => command[1]),
+      [
+        'supply_chain:portwatch-ports:v1:CY',
+        'supply_chain:portwatch-ports:v1:US',
+        'supply_chain:portwatch-ports:v1:_countries',
+        'seed-meta:supply_chain:portwatch-ports',
+      ],
+    );
+  });
+
+  it('preserves the last-good canonical and seed-meta below the publish floor', async () => {
+    const publish = portwatchSeed.publishPortActivitySnapshot;
+    assert.equal(typeof publish, 'function');
+    const calls = [];
+    const fetchFn = async (_url, init) => {
+      const commands = JSON.parse(init.body);
+      calls.push(commands);
+      return new Response(JSON.stringify(commands.map(() => ({ result: 'OK' }))), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const input = publicationInput();
+    input.countryData = new Map();
+    input.countries = [];
+    input.canonicalAdvances = false;
+
+    await publish(input, {
+      fetchFn,
+      credentials: { url: 'https://redis.example.test', token: 'token' },
+    });
+
+    assert.ok(
+      calls[0].every((command) =>
+        command[1] !== 'supply_chain:portwatch-ports:v1:_countries'
+        && command[1] !== 'seed-meta:supply_chain:portwatch-ports'),
+    );
+    assert.deepEqual(
+      calls[0].map((command) => command[1]),
+      ['supply_chain:portwatch-ports:v1:CY'],
+      'scheduler-only failure state must persist even with zero publishable countries',
+    );
+  });
+
+  it('fails loudly when any transaction command reports an error', async () => {
+    const publish = portwatchSeed.publishPortActivitySnapshot;
+    assert.equal(typeof publish, 'function');
+    const fetchFn = async (_url, init) => {
+      const commands = JSON.parse(init.body);
+      return new Response(JSON.stringify(
+        commands.map((_, index) => index === 1 ? { error: 'ERR injected' } : { result: 'OK' }),
+      ), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    await assert.rejects(
+      publish(publicationInput(), {
+        fetchFn,
+        credentials: { url: 'https://redis.example.test', token: 'token' },
+      }),
+      /transaction: 1\/4 commands failed/,
+    );
+  });
+});

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -4,7 +4,10 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
-import { orderColdFetchQueue } from '../scripts/seed-portwatch-port-activity.mjs';
+import {
+  classifyDeferredPayload,
+  orderColdFetchQueue,
+} from '../scripts/seed-portwatch-port-activity.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -182,14 +185,13 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
   });
 
   it('canonical/seed-meta advance at the recovery publish floor, below the 174 health target', () => {
-    // Gate=5 lets per-country writes through (cache rotation accumulates)
-    // but CANONICAL_KEY + META_KEY require a higher coverage floor before
-    // they advance — protects consumers from a 5-country canonical
-    // published as fresh during a recovery from full outage.
+    // Per-country recovery state persists at every coverage level, but
+    // CANONICAL_KEY + META_KEY require a higher coverage floor before they
+    // advance — protecting consumers from a tiny canonical published fresh.
     assert.match(src, /export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES\s*=\s*174/);
     assert.match(src, /const MIN_CANONICAL_PUBLISH\s*=\s*50/);
     // The gate is evaluated and used to conditionally write canonical/meta:
-    assert.match(src, /const canonicalAdvances = shouldAdvanceCanonical\(countryData\.size\)/);
+    assert.match(src, /const canonicalAdvances = coverageGatePassed && shouldAdvanceCanonicalForRun\(\{/);
     assert.match(src, /if\s*\(canonicalAdvances\)\s*\{[\s\S]{0,300}SET',\s*CANONICAL_KEY/);
     // Below the floor, extendExistingTtl preserves canonical + meta +
     // prior per-country keys, and a PARTIAL PERSIST log line surfaces
@@ -218,10 +220,10 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // main() gates the bypass on the combined fresh upstream contact:
     assert.match(src, /const upstreamContactCount = freshFetchedCount \+ cacheHitCount/);
     assert.match(src, /const capBypassEarned = capTriggered && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS/);
-    // When cap-mode is triggered but bypass NOT earned, refuse to publish
-    // a stale-only set and fall through to the 80% guard (which will fire
-    // and extendExistingTtl).
+    // When cap-mode is triggered but bypass is not earned, canonical + meta
+    // must stay at last-good even when stale fallback keeps recordCount high.
     assert.match(src, /CAP-MODE BYPASS REFUSED/);
+    assert.match(src, /Canonical \+ seed-meta will be preserved/);
   });
 
   it('inter-batch sleep is abort-aware (PR #3701 review P2)', () => {
@@ -285,6 +287,16 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /setTimeout\(resolve,\s*BATCH_BACKOFF_MS\)/);
   });
 
+  it('circuit-breaker retains selected countries that were never attempted', () => {
+    assert.match(src, /const completedFetches\s*=\s*new Set\(\)/);
+    assert.match(src, /completedFetches\.add\(iso2\)/);
+    assert.match(
+      src,
+      /const unattemptedFetches\s*=\s*needsFetch\.filter\(\(\{\s*iso2\s*\}\)\s*=>\s*!completedFetches\.has\(iso2\)\)/,
+    );
+    assert.match(src, /retainPriorState\(item\.iso2,\s*item\.prevPayload,\s*evaluatedAt\)/);
+  });
+
   it('MIN_VALID_COUNTRIES is temporarily lowered to 5 (ArcGIS degraded further)', () => {
     // 2026-05-18: lowered 20 → 5 because actual success rate dropped to
     // 6-10/30 per cold-fetch batch — well below the gate=20 set on
@@ -319,7 +331,7 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /droppedNoCacheCount,/);
     // main() must read those fields off the fetchAll result (plus the
     // PR #3701 review P1 additions: freshFetchedCount + cacheHitCount).
-    assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,\s*\n\s*droppedTooOldCount,\s*\n\s*droppedNoCacheCount,\s*\n\s*freshFetchedCount,\s*\n\s*cacheHitCount,\s*\n\s*\}\s*=\s*await fetchAll/);
+    assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,\s*\n\s*droppedTooOldCount,\s*\n\s*droppedNoCacheCount,\s*\n\s*freshFetchedCount,\s*\n\s*cacheHitCount,\s*\n\s*retryState,\s*\n\s*coverage,\s*\n\s*\}\s*=\s*await fetchAll/);
     // The earned-bypass branch (PR #3701 review P1) must lead to the
     // PARTIAL PUBLISH log; falling through to the 80%-degradation-guard
     // branch is the silent-loss protection.
@@ -348,19 +360,10 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // Assert by structure: a DEGRADATION GUARD error+return follows the
     // prevCount × 0.8 comparison.
     assert.match(src, /prevCount\s*\*\s*0\.8[\s\S]{0,400}DEGRADATION GUARD/);
-    // PR #3701 review P1 introduces a SECOND 80%-guard branch inside the
-    // `capTriggered && !capBypassEarned` block (cap-mode without enough
-    // fresh upstream contact also falls back to the 80% guard). So the
-    // threshold now appears in two condition + two Math.ceil sites = 4.
-    // More than 4 would imply a duplicated check leaked outside the
-    // guard scoping.
+    // The runtime branch has one comparison plus one Math.ceil in its log.
+    // Cap-mode uses upstream-contact gating instead.
     const matches = src.match(/prevCount\s*\*\s*0\.8/g) ?? [];
-    assert.equal(
-      matches.length,
-      4,
-      `expected exactly 4 prevCount × 0.8 references (2 conditions + 2 Math.ceil error-msg suggestions, ` +
-      `one set per guard branch — cap-mode-without-bypass-earned + non-cap-mode), found ${matches.length}`,
-    );
+    assert.equal(matches.length, 2, `expected condition + operator-log prevCount × 0.8 references, found ${matches.length}`);
   });
 
   it('batch loop wires eager .catch for mid-batch SIGTERM diagnostics', () => {
@@ -412,9 +415,10 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /MAX_CACHE_AGE_MS/);
   });
 
-  it('cached payloads store asof + cacheWrittenAt for next-run invalidation', () => {
+  it('cached payloads store asof plus success and attempt timestamps', () => {
     assert.match(src, /asof:\s*upstreamMaxDate/);
-    assert.match(src, /cacheWrittenAt:\s*Date\.now\(\)/);
+    assert.match(src, /cacheWrittenAt:\s*refreshedAt/);
+    assert.match(src, /refreshAttemptedAt:\s*attemptedAt/);
   });
 
   it('redisMgetJson failure degrades to cold-path (does not abort the seed)', () => {
@@ -916,22 +920,24 @@ describe('proxyFetch signal propagation (runtime)', () => {
 describe('validateFn', () => {
   let validateFn;
   let shouldAdvanceCanonical;
+  let shouldAdvanceCanonicalForRun;
   let PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES;
 
   before(async () => {
     ({
       validateFn,
       shouldAdvanceCanonical,
+      shouldAdvanceCanonicalForRun,
       PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES,
     } = await import('../scripts/seed-portwatch-port-activity.mjs'));
   });
 
-  it('keeps the per-country write gate permissive so partial recovery can accumulate', () => {
+  it('accepts five countries as a usable partial snapshot', () => {
     const data = { countries: Array.from({ length: 5 }, (_, i) => `C${i}`), fetchedAt: new Date().toISOString() };
     assert.equal(validateFn(data), true);
   });
 
-  it('returns false below the per-country write gate', () => {
+  it('rejects fewer than five countries as a usable partial snapshot', () => {
     const data = { countries: ['US', 'SA', 'GB', 'JP'], fetchedAt: new Date().toISOString() };
     assert.equal(validateFn(data), false);
   });
@@ -948,6 +954,27 @@ describe('validateFn', () => {
     assert.equal(shouldAdvanceCanonical(173), true);
     assert.equal(shouldAdvanceCanonical(174), true);
     assert.equal(shouldAdvanceCanonical(175), true);
+  });
+
+  it('requires real upstream contact before canonical + seed-meta advance', () => {
+    assert.equal(shouldAdvanceCanonicalForRun({
+      countryCount: 174,
+      previousCountryCount: 174,
+      capTriggered: true,
+      upstreamContactCount: 0,
+    }), false);
+    assert.equal(shouldAdvanceCanonicalForRun({
+      countryCount: 174,
+      previousCountryCount: 174,
+      capTriggered: true,
+      upstreamContactCount: 30,
+    }), true);
+    assert.equal(shouldAdvanceCanonicalForRun({
+      countryCount: 120,
+      previousCountryCount: 174,
+      capTriggered: false,
+      upstreamContactCount: 30,
+    }), false);
   });
 });
 
@@ -1107,8 +1134,8 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
   it('MAX_COLD_FETCH_PER_RUN constant is declared with a sane value', () => {
     // The cap value must allow the cold-fetch loop to fit comfortably inside
     // the 570s bundle budget at the observed ~3-5s/country with concurrency
-    // 12. 30 × 5s / 12 ≈ 13s — well under budget, with plenty of room for
-    // preflight + write phases.
+    // 6. 30 × 5s / 6 + four 5s backoffs ≈ 45s — well under budget, with
+    // plenty of room for preflight + write phases.
     assert.match(src, /const MAX_COLD_FETCH_PER_RUN\s*=\s*30/);
   });
 
@@ -1124,7 +1151,11 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
     // output — that's the same as a hard-fail for the consumer. Marking
     // staleAsof preserves the country's data shape but signals "one window
     // behind" so downstream can render or warn accordingly.
-    assert.match(src, /\.\.\.prev,\s*staleAsof:\s*true/);
+    const prior = { iso2: 'US', cacheWrittenAt: 1_000, ports: [{ portId: 'US-1' }] };
+    const classified = classifyDeferredPayload(prior, 2_000);
+    assert.equal(classified.status, 'stale');
+    assert.deepEqual(classified.payload, { ...prior, staleAsof: true });
+    assert.match(src, /countryData\.set\(iso2,\s*deferredState\.payload\)/);
   });
 
   it('deferred-stale path respects MAX_CACHE_AGE_MS hard-drop (Greptile P1)', () => {
@@ -1134,18 +1165,14 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
     // upstream was frozen >4 days could publish data older than the intended
     // hard-drop threshold (window-drift). Greptile review P1 on PR #3676.
     //
-    // Assert the age comparison appears inside the cap block (between the
-    // shuffle and the needsFetch reassignment) — using a multi-line regex
-    // that requires shuffle → cacheWrittenAt → MAX_CACHE_AGE_MS in order.
+    // The cap path must delegate to the shared classifier, and that classifier
+    // must use the same strict hard-expiry boundary as the cache-hit path.
     const capBlock = src.match(
       /needsFetch\.length\s*>\s*MAX_COLD_FETCH_PER_RUN[\s\S]+?needsFetch\s*=\s*ordered\.slice/,
     );
     assert.ok(capBlock, 'cap block found');
-    assert.match(
-      capBlock[0],
-      /cacheWrittenAt[\s\S]{0,200}MAX_CACHE_AGE_MS/,
-      'deferred-stale path must compare prev.cacheWrittenAt against MAX_CACHE_AGE_MS',
-    );
+    assert.match(capBlock[0], /retainPriorState\(item\.iso2,\s*item\.prevPayload,\s*now\)/);
+    assert.match(src, /\(now\s*-\s*prevPayload\.cacheWrittenAt\)\s*>=\s*maxCacheAgeMs/);
     // And the failure-bucket counter exists so operators can see how many
     // countries dropped via the age gate (vs no-cache).
     assert.match(src, /droppedTooOld/);
@@ -1174,7 +1201,7 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
   });
 
   it('rotation arithmetic uses MAX_COLD_FETCH_PER_RUN directly, not needsFetch.length (Greptile P2)', () => {
-    // After `needsFetch = shuffled.slice(0, MAX_COLD_FETCH_PER_RUN)`,
+    // After `needsFetch = ordered.slice(0, MAX_COLD_FETCH_PER_RUN)`,
     // `needsFetch.length` numerically equals MAX_COLD_FETCH_PER_RUN — so the
     // pre-fix arithmetic was coincidentally correct. But if the log block
     // is ever reordered above the reassignment (or the cap value changes
@@ -1220,18 +1247,17 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
 });
 
 // ── cold-fetch prioritisation (WM #4293 coverage-freeze fix) ──────────────────
-// Never-cached countries (prevPayload=null) have no served-stale fallback, so if
-// the random cap deferred them they were dropped entirely (droppedNoCache),
-// freezing /api/health coverage below the 174 target (observed stuck at 158).
-// orderColdFetchQueue must sort them ahead of cached-but-stale countries so they
-// always win a cold-fetch slot (uncached count << MAX_COLD_FETCH_PER_RUN).
-describe('orderColdFetchQueue — never-cached-first prioritisation', () => {
+// Never-cached countries (prevPayload=null) have no served-stale fallback.
+// The oldest-attempt scheduler treats them as never-attempted, so they sort
+// ahead of legacy cached countries while retaining a durable cursor once an
+// attempt succeeds or fails.
+describe('orderColdFetchQueue — never-attempted prioritisation', () => {
   const noCache = (iso2) => ({ iso2, prevPayload: null });
   const cached = (iso2) => ({ iso2, prevPayload: { asof: '2026-06-26', cacheWrittenAt: Date.now() } });
 
   it('places every no-prior-cache country ahead of every cached one', () => {
     const q = [cached('US'), noCache('MY'), cached('GB'), noCache('IE'), noCache('EC')];
-    const ordered = orderColdFetchQueue(q, () => 0);
+    const ordered = orderColdFetchQueue(q);
     const firstCachedIdx = ordered.findIndex((it) => it.prevPayload);
     const noCacheIdxs = ordered.flatMap((it, i) => (it.prevPayload ? [] : [i]));
     assert.ok(Math.max(...noCacheIdxs) < firstCachedIdx, 'all uncached must sort before all cached');

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -186,8 +186,9 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
 
   it('canonical/seed-meta advance at the recovery publish floor, below the 174 health target', () => {
     // Per-country recovery state persists at every coverage level, but
-    // CANONICAL_KEY + META_KEY require a higher coverage floor before they
-    // advance — protecting consumers from a tiny canonical published fresh.
+    // CANONICAL_KEY + META_KEY require a higher activity coverage floor and
+    // the complete reference universe before they advance — protecting
+    // consumers from a tiny or reference-truncated canonical published fresh.
     assert.match(src, /export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES\s*=\s*174/);
     assert.match(src, /const MIN_CANONICAL_PUBLISH\s*=\s*50/);
     // The gate is evaluated and used to conditionally write canonical/meta:
@@ -217,9 +218,11 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /freshFetchedCount\+\+/);
     // Counts are surfaced out of fetchAll:
     assert.match(src, /freshFetchedCount,[\s\n]+cacheHitCount: cacheHits/);
-    // main() gates the bypass on the combined fresh upstream contact:
+    // main() gates the bypass on the complete reference universe plus the
+    // combined fresh upstream contact:
     assert.match(src, /const upstreamContactCount = freshFetchedCount \+ cacheHitCount/);
-    assert.match(src, /const capBypassEarned = capTriggered && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS/);
+    assert.match(src, /const referenceGatePassed =[\s\S]{0,100}coverage\.referenceCountryCount >= PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES/);
+    assert.match(src, /const capBypassEarned = capTriggered[\s\n]+&& referenceGatePassed[\s\n]+&& upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS/);
     // When cap-mode is triggered but bypass is not earned, canonical + meta
     // must stay at last-good even when stale fallback keeps recordCount high.
     assert.match(src, /CAP-MODE BYPASS REFUSED/);
@@ -960,18 +963,21 @@ describe('validateFn', () => {
     assert.equal(shouldAdvanceCanonicalForRun({
       countryCount: 174,
       previousCountryCount: 174,
+      referenceCountryCount: 174,
       capTriggered: true,
       upstreamContactCount: 0,
     }), false);
     assert.equal(shouldAdvanceCanonicalForRun({
       countryCount: 174,
       previousCountryCount: 174,
+      referenceCountryCount: 174,
       capTriggered: true,
       upstreamContactCount: 30,
     }), true);
     assert.equal(shouldAdvanceCanonicalForRun({
       countryCount: 120,
       previousCountryCount: 174,
+      referenceCountryCount: 174,
       capTriggered: false,
       upstreamContactCount: 30,
     }), false);


### PR DESCRIPTION
## Summary

PortWatch port-activity recovery currently has enough scheduled fetch capacity to cover all 174 known countries, but the capped queue had no durable progress marker. Once cached data aged past seven days, random per-process ordering could repeatedly skip the same countries: the latest production run fetched 30/30 selected countries successfully yet published only 153/174 because 21 deferred entries had expired.

This change makes recovery converge without weakening health thresholds:

- order capped refreshes by a persisted per-country attempt timestamp, so all 174 countries get an attempt within six 30-country runs (72 hours at the existing 12-hour cadence)
- record failed attempts without refreshing the last-good data age, allowing partial failures to rotate behind other due countries
- continue serving usable last-good data and exclude data at or beyond the seven-day boundary
- enforce that seven-day boundary again on the RPC read path, so scheduler-only state retained under a last-good canonical pointer cannot become consumer-visible
- compare publication against the durable 174-country target and the prior canonical universe, with named and unidentified gap counts
- refuse to advance canonical or seed metadata when the current PortWatch reference feed is truncated below 174 countries
- preserve canonical and seed-meta freshness during upstream outages or below-floor runs while still persisting retry progress
- classify concrete upstream causes such as invalid-query and rate-limit failures ahead of generic timeout wording
- publish per-country state, the canonical snapshot, and seed metadata in one Upstash `/multi-exec` transaction when the snapshot advances

The existing source protections remain unchanged: 30 cold fetches per run, concurrency 6, 90-second per-country timeout, batch backoff, and the invalid-query circuit breaker.

Refs #3613. This intentionally does not auto-close the issue: its operational definition of done requires three consecutive production runs at 174/174.

## Production Evidence

Read-only inspection before this change:

- Railway schedule: `0 */12 * * *`
- known/cached countries: 174
- latest run: 30 cache hits, 144 misses, cold-fetch cap 30
- result: 30 fresh fetched + 30 cache-fresh + 93 stale served = 153 published
- dropped: 21 entries older than seven days
- selected fetch result: 30/30 succeeded, 0 errors, 27.4 seconds

That evidence rules out current rate-limit, concurrency, timeout, or run-budget exhaustion as the active cause. At 30 attempts per run, the configured cadence can complete a sweep in six runs; the missing durable ordering was the convergence failure.

## Validation

- `node --check scripts/seed-portwatch-port-activity.mjs`
- Biome lint on all five changed files
- deterministic PortWatch recovery, consumer-expiry, handler, seed, and health tests: 152 passed, 0 failed
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run typecheck:all`
- pre-push change-scoped gates: passed, including 105 PortWatch seed tests, 107 server-handler tests, 12 changed-file tests, edge bundling, architecture boundaries, Unicode safety, proto freshness, version sync, and both typechecks
- initial-PR full `npm run test:data`: 18,664 passed, 6 skipped, 2 unrelated fixture-precondition failures because `dist/dashboard.html` was not built

The recovery tests cover:

- all 174 countries attempted within six capped rotations
- retry fairness after partial failures
- strict seven-day expiry at both scheduler and consumer boundaries
- failure state that preserves last-good age
- durable target reporting when the reference feed is truncated
- canonical publication refusal for incomplete reference coverage
- root-cause classification for composite invalid-query, rate-limit, and timeout failures
- atomic snapshot publication
- preservation of the last-good canonical/meta below the publication floor
- transaction command-error propagation

An independent multi-persona review of the follow-up patch found no additional actionable findings.

## Post-Deploy Monitoring & Validation

No deployment or production mutation was performed as part of this PR.

After merge and normal deployment:

1. Confirm the Railway log reports `Refs loaded: 174 countries with ports`. Any `REFERENCE COVERAGE GATE` line means the canonical and seed metadata correctly stayed at last-good and the run must not count toward acceptance.
2. Watch the next scheduled run for the 21 currently expired countries to be selected ahead of newer attempts. If the complete reference feed and observed 30/30 source success continue, that run should recover all 21 plus nine next-oldest entries and publish 174/174.
3. Until those expired countries refresh successfully, their RPC responses should remain unavailable rather than serving data older than seven days.
4. Confirm compact health returns PortWatch port activity to full coverage and that the coverage metadata contains no named or unidentified gaps.
5. Keep #3613 open until three consecutive scheduled runs publish 174/174 (or at most two transient failures that recover on the next run) and the heavy-country set remains represented.
6. Treat a non-shrinking missing-country list, fewer than five upstream contacts, incomplete reference coverage, or any Redis transaction error as a failed rollout. The seeder will retain the last-good canonical/meta and log the exact gap/failure codes instead of advertising a fresh complete snapshot.

Normal bounded convergence is one complete attempt sweep in six scheduled runs / 72 hours, comfortably inside the seven-day expiry window. Full coverage still depends on each missing country eventually succeeding; persistent source failures remain truthfully visible. During a global upstream failure, the circuit breaker deliberately slows attempt rotation to protect the source.

Rollback is a normal revert and redeploy of this PR; there is no data migration.

---

[![Compound Engineering](https://img.shields.io/badge/Compound-Engineering-blueviolet)](https://every.to/source-code/compound-engineering)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
