### PR TITLE
fix(gdelt): bound ingestion recovery

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -916,8 +916,24 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // true envelope reads at the canonical-key layer; this import establishes
   // the dependency so behavior stays byte-identical in PR 1.
   const meta = unwrapEnvelope(parseRedisValue(keyMetaValues.get(seedCfg.key))).data;
+  const metaCount = meta?.count ?? meta?.recordCount ?? null;
+  const errorCode = typeof meta?.errorCode === 'string'
+    && /^[A-Z0-9_]{1,64}$/.test(meta.errorCode)
+    ? meta.errorCode
+    : null;
   if (meta?.status === 'error') {
-    return { hasMeta: true, seedAge: null, seedStale: true, seedError: true, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return {
+      hasMeta: true,
+      seedAge: null,
+      seedStale: true,
+      seedError: true,
+      sourceUnavailable: false,
+      sourceBlocked: false,
+      metaReadFailed: false,
+      metaCount,
+      contentAge: null,
+      errorCode,
+    };
   }
   let seedAge = null;
   let seedStale = true;
@@ -926,7 +942,6 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     seedAge = Math.round((now - fetchedAt) / 60_000);
     seedStale = seedAge > seedCfg.maxStaleMin;
   }
-  const metaCount = meta?.count ?? meta?.recordCount ?? null;
   // `unavailable` is the one sourceState that means "this deployment never opted
   // into the adapter" (the producer had no credential to try with), as opposed to
   // "the adapter was tried and is broken" (`stale`/`error`). Grading the two the
@@ -971,7 +986,18 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
-  return { hasMeta: meta != null, seedAge, seedStale, seedError: sourceDegraded, sourceUnavailable, sourceBlocked, metaReadFailed: false, metaCount, contentAge };
+  return {
+    hasMeta: meta != null,
+    seedAge,
+    seedStale,
+    seedError: sourceDegraded,
+    sourceUnavailable,
+    sourceBlocked,
+    metaReadFailed: false,
+    metaCount,
+    contentAge,
+    errorCode,
+  };
 }
 
 function isCascadeCovered(name, hasData, keyStrens, keyErrors) {
@@ -1006,7 +1032,17 @@ function classifyKey(name, redisKey, opts, ctx) {
 
   const strlen = keyStrens.get(redisKey) ?? 0;
   const hasData = keyHasData(redisKey, strlen);
-  const { hasMeta, seedAge, seedStale, seedError, sourceUnavailable, sourceBlocked, metaCount, contentAge } = meta;
+  const {
+    hasMeta,
+    seedAge,
+    seedStale,
+    seedError,
+    sourceUnavailable,
+    sourceBlocked,
+    metaCount,
+    contentAge,
+    errorCode,
+  } = meta;
 
   // When the data key is gone the meta count is meaningless; force records=0
   // so we never display the contradictory "EMPTY records=N>0" pair (item 1).
@@ -1073,6 +1109,7 @@ function classifyKey(name, redisKey, opts, ctx) {
   if (seedAge !== null) entry.seedAgeMin = seedAge;
   if (seedCfg) entry.maxStaleMin = seedCfg.maxStaleMin;
   if (seedCfg?.minRecordCount != null) entry.minRecordCount = seedCfg.minRecordCount;
+  if (status === 'SEED_ERROR' && errorCode) entry.errorCode = errorCode;
   // Surface content-age fields when seeder opted in (presence of
   // meta.maxContentAgeMin). Operators can distinguish "stale content" from
   // "stale seeder run" at a glance.

--- a/scripts/_gdelt-fetch.mjs
+++ b/scripts/_gdelt-fetch.mjs
@@ -1,220 +1,174 @@
-// GDELT API fetch helper with curl-only Decodo proxy fallback + multi-retry.
+// Bounded GDELT DOC API transport.
 //
-// GDELT (api.gdeltproject.org) is a public free API with strict per-IP
-// throttling (HTTP 429). Railway egress IPs share a small pool and hit
-// 429 storms. seed-gdelt-intel currently has no proxy fallback.
+// GDELT rate-limits shared cloud egress aggressively. Railway's direct route
+// is persistently blocked, while the shared proxy has separately returned 429,
+// timed out, and failed TLS. Retrying either route in the same run only
+// amplifies the outage, so production selects exactly one route and attempts it
+// once:
 //
-// PROXY STRATEGY — CURL-ONLY WITH MULTI-RETRY
+//   GDELT_PROXY_URL -> PROXY_URL -> direct (only when no proxy is configured)
 //
-// Probed 2026-04-16:
-//   api.gdeltproject.org via direct (residential):     200
-//   api.gdeltproject.org via Decodo curl (5 attempts): 200/200/429/timeout/429
-//                                                      = 2/5 success (~40%)
-//   api.gdeltproject.org via Decodo CONNECT:            not probed cleanly
-//                                                      (proxy URL format issue)
-//
-// Decodo's curl egress is session-rotating: each call may get a different
-// IP from the pool. Some IPs are throttled by GDELT, others are not. ~40%
-// per-attempt success rate; 5 attempts gives expected success ~92%
-// (1 - 0.6^5 = 0.922).
-//
-// CONNECT path is omitted for now: not yet probed cleanly against GDELT,
-// and adding an unverified leg costs time on each call. If Yahoo's
-// pattern holds (CONNECT → 404 from blocked egress IPs), CONNECT for
-// GDELT may behave the same. Add only after a clean Railway probe.
-//
-// Direct retry uses LONGER backoff than Yahoo's 5s base — GDELT's
-// per-IP throttle window is wider, so quick retries usually re-hit the
-// same throttle.
+// GDELT_PROXY_URL gives this mandatory-proxy source an independently
+// replaceable exit. PROXY_URL remains a compatibility fallback while operators
+// provision that source-specific route.
 
-import { CHROME_UA, sleep, resolveProxy, curlFetch } from './_seed-utils.mjs';
+import { CHROME_UA, resolveProxy, curlFetch } from './_seed-utils.mjs';
 
-const RETRYABLE_STATUSES = new Set([429, 503]);
-const MAX_RETRY_AFTER_MS = 60_000;
+const ERROR_CODE_RE = /^[A-Z0-9_]{1,64}$/;
 
-/**
- * Production defaults. Exported so tests can lock the wiring at the
- * helper level. Mixing these up — e.g. swapping in resolveProxyForConnect
- * — would route through an egress pool that has not been verified
- * against GDELT.
- */
+export class GdeltFetchError extends Error {
+  constructor(code, route, label, cause) {
+    const safeCode = ERROR_CODE_RE.test(code) ? code : 'GDELT_FETCH_FAILED';
+    super(
+      `GDELT ${route} fetch failed for ${label}: ${safeCode}`
+        + (cause?.message ? ` (${cause.message})` : ''),
+      cause ? { cause } : undefined,
+    );
+    this.name = 'GdeltFetchError';
+    this.code = safeCode;
+    this.route = route;
+  }
+}
+
+function routeErrorPrefix(route) {
+  if (route === 'source-proxy') return 'GDELT_SOURCE_PROXY';
+  if (route === 'shared-proxy') return 'GDELT_SHARED_PROXY';
+  if (route === 'proxy') return 'GDELT_PROXY';
+  return 'GDELT_DIRECT';
+}
+
+function errorText(error) {
+  const parts = [];
+  let current = error;
+  for (let depth = 0; current && depth < 3; depth += 1) {
+    parts.push(current?.code, current?.name, current?.message);
+    current = current?.cause;
+  }
+  return parts.filter(Boolean).join(' ');
+}
+
+export function classifyGdeltFetchError(error, route) {
+  const prefix = routeErrorPrefix(route);
+  const numericStatus = Number(error?.status);
+  const text = errorText(error);
+  const messageStatus = text.match(/\bHTTP\s+([1-5]\d{2})\b/i)?.[1];
+  const status = Number.isInteger(numericStatus) && numericStatus >= 100 && numericStatus <= 599
+    ? numericStatus
+    : (messageStatus ? Number(messageStatus) : null);
+  if (status) return `${prefix}_HTTP_${status}`;
+  if (error instanceof SyntaxError || /\bJSON\b|Unexpected token/i.test(text)) {
+    return `${prefix}_INVALID_JSON`;
+  }
+  if (/SSL_ERROR_SYSCALL|certificate|TLS|SSL/i.test(text)) return `${prefix}_TLS`;
+  if (/timed?\s*out|timeout|AbortError|UND_ERR_HEADERS_TIMEOUT/i.test(text)) {
+    return `${prefix}_TIMEOUT`;
+  }
+  if (/ENOTFOUND|EAI_AGAIN|DNS/i.test(text)) return `${prefix}_DNS`;
+  return `${prefix}_TRANSPORT`;
+}
+
+export function resolveGdeltProxy() {
+  return resolveProxy(process.env.GDELT_PROXY_URL || process.env.PROXY_URL || '');
+}
+
+export function resolveGdeltProxyRoute() {
+  if (process.env.GDELT_PROXY_URL) return 'source-proxy';
+  if (process.env.PROXY_URL) return 'shared-proxy';
+  return 'direct';
+}
+
+// Exported so tests exercise the same production binding rather than a
+// source-text approximation.
 export const _PROXY_DEFAULTS = Object.freeze({
-  curlProxyResolver: resolveProxy,
+  curlProxyResolver: resolveGdeltProxy,
+  proxyRouteResolver: resolveGdeltProxyRoute,
   curlFetcher: curlFetch,
 });
 
-export function parseRetryAfterMs(value) {
-  if (!value) return null;
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds > 0) {
-    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
-  }
-  const retryAt = Date.parse(value);
-  if (Number.isFinite(retryAt)) {
-    return Math.min(Math.max(retryAt - Date.now(), 1000), MAX_RETRY_AFTER_MS);
-  }
-  return null;
-}
-
 /**
- * Fetch JSON from a GDELT API endpoint with retry + proxy multi-retry.
+ * Fetch one GDELT DOC JSON response through exactly one selected route.
  *
- * @param {string} url - GDELT API URL (typically
- *   `https://api.gdeltproject.org/api/v2/...?query=...&format=json`).
- * @param {object} [opts]
- * @param {string} [opts.label]              - Symbol or label for log lines (default 'unknown').
- * @param {number} [opts.timeoutMs]          - Per-attempt timeout (default 15_000 — GDELT can be slow).
- * @param {number} [opts.maxRetries]         - Direct retries (default 3 → 4 attempts total).
- * @param {number} [opts.retryBaseMs]        - Linear direct backoff base (default 10_000 — GDELT throttle window is wider than Yahoo's).
- * @param {number} [opts.proxyMaxAttempts]   - Curl proxy attempts (default 5 — Decodo rotates session per call).
- * @param {number} [opts.proxyRetryBaseMs]   - Fixed (constant, NOT linear) backoff between proxy attempts (default 5_000). Constant because Decodo rotates the session IP per call — exponential growth wouldn't help; the next attempt's success is independent of the previous attempt's wait.
- * @returns {Promise<unknown>} Parsed JSON. Throws on exhaustion.
+ * Same-route retries are intentionally unsupported. When no proxy is
+ * configured, proxyMaxAttempts: 0 selects the direct route. A configured proxy
+ * cannot be bypassed, and values above one are rejected so a future call site
+ * cannot silently restore the retry storm.
  */
 export async function fetchGdeltJson(url, opts = {}) {
   const {
     label = 'unknown',
     timeoutMs = 15_000,
-    maxRetries = 3,
-    retryBaseMs = 10_000,
-    proxyMaxAttempts = 5,
-    proxyRetryBaseMs = 5_000,
-    // Test hooks. Production callers leave unset and get _PROXY_DEFAULTS.
-    // `_sleep` lets tests assert backoff values without sleeping in real
-    // time. Mirrors the seam pattern from PR #3120's _yahoo-fetch.mjs.
+    maxRetries = 0,
+    proxyMaxAttempts = 1,
+    _fetch = globalThis.fetch,
     _curlProxyResolver = _PROXY_DEFAULTS.curlProxyResolver,
+    _proxyRouteResolver = _PROXY_DEFAULTS.proxyRouteResolver,
     _proxyCurlFetcher = _PROXY_DEFAULTS.curlFetcher,
-    _sleep = sleep,
   } = opts;
 
-  let lastDirectError = null;
+  if (maxRetries !== 0) {
+    throw new RangeError('GDELT same-route direct retries are disabled; maxRetries must be 0');
+  }
+  if (proxyMaxAttempts !== 0 && proxyMaxAttempts !== 1) {
+    throw new RangeError('GDELT same-route proxy retries are disabled; proxyMaxAttempts must be 0 or 1');
+  }
 
-  // ─── Direct retry loop ───
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    let resp;
+  const resolvedProxyRoute = _proxyRouteResolver();
+  const proxyConfigured = resolvedProxyRoute !== 'direct';
+  if (proxyConfigured && proxyMaxAttempts === 0) {
+    throw new RangeError(
+      'GDELT direct fallback is disabled when a proxy is configured; proxyMaxAttempts must be 1',
+    );
+  }
+
+  const proxyAuth = proxyMaxAttempts === 1 ? _curlProxyResolver() : null;
+  if (proxyConfigured && !proxyAuth) {
+    const code = `${routeErrorPrefix(resolvedProxyRoute)}_CONFIG`;
+    const error = new Error(`${resolvedProxyRoute} is configured but could not be parsed`);
+    console.warn(`  [GDELT] ${resolvedProxyRoute} failed for ${label}: ${code}`);
+    throw new GdeltFetchError(code, resolvedProxyRoute, label, error);
+  }
+  if (proxyAuth) {
+    const proxyRoute = proxyConfigured ? resolvedProxyRoute : 'proxy';
     try {
-      resp = await fetch(url, {
-        headers: { 'User-Agent': CHROME_UA },
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-    } catch (err) {
-      lastDirectError = err;
-      if (attempt < maxRetries) {
-        const retryMs = retryBaseMs * (attempt + 1);
-        console.warn(`  [GDELT] ${label} ${err?.message ?? err}; retrying in ${Math.round(retryMs / 1000)}s (${attempt + 1}/${maxRetries})`);
-        await _sleep(retryMs);
-        continue;
-      }
-      // Final direct attempt threw — fall through to proxy. NEVER throw
-      // here (PR #3118 review: throwing bypasses the proxy path).
-      break;
-    }
-
-    if (resp.ok) {
-      // Guard the parse: a 200 OK with HTML/garbage body (WAF challenge,
-      // partial response, gzip mismatch) would otherwise throw SyntaxError
-      // and escape the helper entirely, bypassing the proxy fallback. The
-      // proxy leg already parses inside its own catch — make the direct
-      // leg symmetric.
-      try {
-        return await resp.json();
-      } catch (parseErr) {
-        lastDirectError = parseErr;
-        break;
-      }
-    }
-
-    lastDirectError = new Error(`HTTP ${resp.status}`);
-
-    if (RETRYABLE_STATUSES.has(resp.status) && attempt < maxRetries) {
-      const retryAfter = parseRetryAfterMs(resp.headers.get('retry-after'));
-      const retryMs = retryAfter ?? retryBaseMs * (attempt + 1);
-      console.warn(`  [GDELT] ${label} ${resp.status} — waiting ${Math.round(retryMs / 1000)}s (${attempt + 1}/${maxRetries})`);
-      await _sleep(retryMs);
-      continue;
-    }
-
-    break;
-  }
-
-  // ─── Curl proxy multi-retry loop ───
-  // Decodo's session-rotating egress gives a different IP per call. GDELT
-  // throttles ~60% of attempts, so we retry until one IP isn't throttled.
-  // Only retry on retryable upstream status (429/503); non-retryable
-  // proxy errors (auth failure, malformed JSON, network) bail immediately
-  // since they're not transient — repeated attempts won't help.
-  const curlProxyAuth = _curlProxyResolver();
-  let lastProxyError = null;
-  let proxyAttemptsRun = 0;
-  // Skip the proxy block entirely when the caller opted out via
-  // proxyMaxAttempts:0 (best-effort callers that want fast-fail —
-  // e.g. fetchTopicTimeline in seed-gdelt-intel which discards failures).
-  // Avoids both the wasted log line and the no-op for loop.
-  if (curlProxyAuth && proxyMaxAttempts > 0) {
-    console.log(`  [GDELT] direct exhausted on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy (curl) up to ${proxyMaxAttempts}× (Decodo session-rotates per call)`);
-    for (let attempt = 1; attempt <= proxyMaxAttempts; attempt++) {
-      proxyAttemptsRun = attempt;
-      try {
-        // _proxyCurlFetcher (curlFetch / execFileSync) is sync today; wrap
-        // with await Promise.resolve so a future async refactor silently
-        // keeps working (Greptile P2 from PR #3119).
-        const text = await Promise.resolve(_proxyCurlFetcher(url, curlProxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' }));
-        // Parse BEFORE logging success so a malformed response doesn't
-        // emit a contradictory "succeeded" log + then throw (Greptile P2
-        // from PR #3120).
-        const parsed = JSON.parse(text);
-        console.log(`  [GDELT] proxy (curl) succeeded for ${label} on attempt ${attempt}/${proxyMaxAttempts}`);
-        return parsed;
-      } catch (curlErr) {
-        lastProxyError = curlErr;
-        // Decide whether retrying this proxy call is worthwhile.
-        //
-        // Probed Decodo curl egress against GDELT (2026-04-16) gave
-        // 200 / 200 / 429 / TIMEOUT / 429 over 5 attempts. The TIMEOUT
-        // is part of the normal transient mix — rotating to another
-        // Decodo session usually clears it. The pre-fix logic only
-        // retried on `HTTP 429`/`503` substring matches, so a timeout
-        // bailed on the first attempt and defeated the multi-retry
-        // design. Reframed:
-        //
-        //   curlErr.status = number      → retry only if 429/503
-        //   curlErr instanceof SyntaxError → bail (parse failure is
-        //                                    structural, not transient)
-        //   otherwise (timeout, ECONNRESET, DNS, curl exec failure,
-        //              CONNECT tunnel failure)  → RETRY (next Decodo
-        //                                        session likely different)
-        //
-        // curlFetch attaches `.status` only when curl succeeded but the
-        // upstream returned non-2xx, so this property reliably
-        // discriminates the HTTP-status case from network/timeout cases.
-        const status = curlErr?.status;
-        const isParseFailure = curlErr instanceof SyntaxError;
-        let isRetryable;
-        if (typeof status === 'number') {
-          isRetryable = RETRYABLE_STATUSES.has(status);
-        } else if (isParseFailure) {
-          isRetryable = false;
-        } else {
-          // Network / timeout / curl exec error — assume transient.
-          isRetryable = true;
-        }
-        if (attempt < proxyMaxAttempts && isRetryable) {
-          const retryMs = proxyRetryBaseMs;
-          console.warn(`  [GDELT] proxy (curl) attempt ${attempt}/${proxyMaxAttempts} failed: ${curlErr?.message ?? curlErr}; retrying in ${Math.round(retryMs / 1000)}s`);
-          await _sleep(retryMs);
-          continue;
-        }
-        // Non-retryable (parse failure, HTTP 4xx other than 429) OR last
-        // attempt — give up, throw exhausted with both errors.
-        console.warn(`  [GDELT] proxy (curl) attempt ${attempt}/${proxyMaxAttempts} failed${isRetryable ? ' (last attempt)' : ' (non-retryable)'}: ${curlErr?.message ?? curlErr}`);
-        break;
-      }
+      const text = await Promise.resolve(
+        _proxyCurlFetcher(
+          url,
+          proxyAuth,
+          { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+        ),
+      );
+      const parsed = JSON.parse(text);
+      console.log(`  [GDELT] ${proxyRoute} succeeded for ${label}`);
+      return parsed;
+    } catch (error) {
+      const code = classifyGdeltFetchError(error, proxyRoute);
+      console.warn(`  [GDELT] ${proxyRoute} failed for ${label}: ${code}`);
+      throw new GdeltFetchError(code, proxyRoute, label, error);
     }
   }
 
-  throw new Error(
-    `GDELT retries exhausted for ${label}` +
-    (lastDirectError ? ` (last direct: ${lastDirectError.message})` : '') +
-    (lastProxyError ? ` (last proxy: ${lastProxyError.message} after ${proxyAttemptsRun}/${proxyMaxAttempts} attempts)` : ''),
-    lastDirectError ? { cause: lastDirectError } : (lastProxyError ? { cause: lastProxyError } : undefined),
-  );
+  try {
+    const response = await _fetch(url, {
+      headers: { 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      throw Object.assign(new Error(`HTTP ${response.status}`), { status: response.status });
+    }
+    try {
+      return await response.json();
+    } catch (error) {
+      throw new GdeltFetchError(
+        classifyGdeltFetchError(error, 'direct'),
+        'direct',
+        label,
+        error,
+      );
+    }
+  } catch (error) {
+    if (error instanceof GdeltFetchError) throw error;
+    const code = classifyGdeltFetchError(error, 'direct');
+    console.warn(`  [GDELT] direct failed for ${label}: ${code}`);
+    throw new GdeltFetchError(code, 'direct', label, error);
+  }
 }

--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -68,8 +68,8 @@ function resolveProxyConfigWithFallback() {
  * Decodo: gate.decodo.com → us.decodo.com (curl endpoint differs from CONNECT endpoint).
  * Returns empty string if no proxy configured.
  */
-function resolveProxyString() {
-  const cfg = resolveProxyConfigWithFallback();
+function resolveProxyString(raw = process.env.PROXY_URL || '') {
+  const cfg = parseProxyConfig(raw);
   if (!cfg) return '';
   const host = cfg.host.replace(/^gate\./, 'us.');
   return cfg.auth ? `${cfg.auth}@${host}:${cfg.port}` : `${host}:${cfg.port}`;

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1032,8 +1032,8 @@ export function sleep(ms) {
 // ─── Proxy helpers for sources that block Railway container IPs ───
 const { resolveProxyString, resolveProxyStringConnect } = createRequire(import.meta.url)('./_proxy-utils.cjs');
 
-export function resolveProxy() {
-  return resolveProxyString();
+export function resolveProxy(raw = process.env.PROXY_URL || '') {
+  return resolveProxyString(raw);
 }
 
 // For HTTP CONNECT tunneling (httpsProxyFetchJson); keeps gate.decodo.com, not us.decodo.com.
@@ -1076,12 +1076,10 @@ export function curlFetch(url, proxyAuth, headers = {}, { exec = execFileSync } 
     // with curl's own stderr, which names the failure without echoing the command.
     //
     // Dropping `.status` is load-bearing, not incidental: execFileSync sets it to curl's
-    // EXIT CODE (35, 56, 7…). _gdelt-fetch.mjs discriminates "upstream returned non-2xx"
-    // from "network/curl failure" purely on `typeof status === 'number'`, so leaking the
-    // exit code through made it read curl exit 35 as an HTTP status, find it absent from
-    // RETRYABLE_STATUSES, and refuse to retry the proxy — defeating the Decodo per-attempt
-    // IP rotation on exactly the TLS tears it exists to survive. Only a genuine HTTP
-    // status may carry `.status`.
+    // EXIT CODE (35, 56, 7…). _gdelt-fetch.mjs uses `.status` to distinguish upstream
+    // HTTP responses from transport failures, so leaking the exit code would classify
+    // curl exit 35 as an HTTP response and publish the wrong route diagnostic. Only a
+    // genuine HTTP status may carry `.status`.
     const stderr = redactProxyCredentials(err?.stderr || '').trim().split('\n').filter(Boolean).pop();
     throw Object.assign(
       new Error(`curl failed: ${stderr || redactProxyCredentials(err?.message) || 'unknown error'}`),

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -45,7 +45,10 @@
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-conflict-intel",
     "requiredEnv": [
-      "PROXY_URL"
+      [
+        "GDELT_PROXY_URL",
+        "PROXY_URL"
+      ]
     ],
     "watchPatterns": [
       "scripts/_conflict-gdelt-bulk.mjs",
@@ -79,7 +82,10 @@
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-gdelt-intel",
     "requiredEnv": [
-      "PROXY_URL"
+      [
+        "GDELT_PROXY_URL",
+        "PROXY_URL"
+      ]
     ],
     "watchPatterns": [
       "scripts/_gdelt-fetch.mjs",

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -120,7 +120,7 @@ const HAPI_COUNTRIES = [...new Set([...HAPI_ONLY_COUNTRIES, ...HAPI_DASHBOARD_CO
 // The bounded transport emits stable route-specific failure codes. Treat the
 // failures known to implicate the selected route as a run-scoped circuit
 // signal; repeating them for another country cannot improve source reachability.
-const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_(?:CONFIG|HTTP_(?:403|408|429|5\d\d)|INVALID_JSON|TLS|TIMEOUT|DNS|TRANSPORT)\b|\bHTTP 429\b|SSL_ERROR_SYSCALL|\b(?:timed?\s*out|timeout)\b/i;
+const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_(?:CONFIG|HTTP_(?:401|403|407|408|429|5\d\d)|INVALID_JSON|TLS|TIMEOUT|DNS|TRANSPORT)\b|\bHTTP 429\b|SSL_ERROR_SYSCALL|\b(?:timed?\s*out|timeout)\b/i;
 // #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
 // fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
 // an absolute deadline down, so slow aux feeds automatically shrink the sweep

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -117,18 +117,19 @@ export const HAPI_REQUIRED_COUNTRIES = [
   ...new Set([...HAPI_CRISIS_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES]),
 ];
 const HAPI_COUNTRIES = [...new Set([...HAPI_ONLY_COUNTRIES, ...HAPI_DASHBOARD_COUNTRIES, ...CONFLICT_COUNTRIES])];
-// A throttled failure, as it reaches us: fetchGdeltCountryEvents flattens the direct and
-// proxy attempts into one message, e.g. "...(last direct: HTTP 429) (last proxy: HTTP 429)".
-const RATE_LIMIT_ERROR = /\b429\b|rate.?limit|too many requests/i;
+// The bounded transport emits stable route-specific failure codes. Treat the
+// failures known to implicate the selected route as a run-scoped circuit
+// signal; repeating them for another country cannot improve source reachability.
+const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_(?:CONFIG|HTTP_(?:403|408|429|5\d\d)|INVALID_JSON|TLS|TIMEOUT|DNS|TRANSPORT)\b|\bHTTP 429\b|SSL_ERROR_SYSCALL|\b(?:timed?\s*out|timeout)\b/i;
 // #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
 // fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
 // an absolute deadline down, so slow aux feeds automatically shrink the sweep
 // window instead of stacking on top of it). HAPI now uses one bounded bulk request
 // instead of a 38-country sequential sweep. One
 // in-flight batch may still drain past the cutoff: ≤~100s at the knobs below
-// (15s concurrent direct legs + 4 × 20s SERIALIZED sync proxy curls — curlFetch is
-// execFileSync, so "concurrent" proxy attempts block the event loop one at a time;
-// 92s observed live 2026-07-10). Worst single fetchAll attempt before the bulk
+// (either 15s concurrent direct legs when no proxy is configured, or 4 × 20s
+// SERIALIZED sync proxy curls — curlFetch is execFileSync, so "concurrent"
+// proxy attempts block the event loop one at a time). Worst single fetchAll attempt before the bulk
 // fallback is now dominated by the GDELT path. Without this cap a
 // GDELT brownout ran 5 batches ≈ 375s+ → deadline breach → exit 75 every tick.
 // The bulk fallback runs after those parallel feeds settle, so its 60s bound
@@ -136,11 +137,8 @@ const RATE_LIMIT_ERROR = /\b429\b|rate.?limit|too many requests/i;
 // comfortably under ACLED_INTEL_LOCK_TTL_MS's 540s fetch deadline (lockTtlMs+120s)
 // below (re-verified #5554 review after growing HAPI_COUNTRIES to 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
-// maxRetries: 0 — a second direct attempt would honor GDELT's Retry-After header
-// (≤60s sleep, _gdelt-fetch.mjs MAX_RETRY_AFTER_MS), blowing any per-batch bound;
-// the proxy leg (IP-rotating) is the designed 429 answer, not a same-IP retry.
-// proxyMaxAttempts: 1 — proxy curls are synchronous (execFileSync, ≤20s each) and
-// serialize across the whole batch: each extra attempt adds 4 × 20s of worst case.
+// The shared GDELT transport enforces one selected-route attempt. These explicit
+// values pin that contract at this high-fanout caller.
 export const GDELT_COUNTRY_FETCH_OPTS = Object.freeze({ maxRetries: 0, proxyMaxAttempts: 1 });
 // Lock must outlive the worst legitimate run (runSeed's documented invariant —
 // _seed-utils.mjs: "a healthy seeder is designed never to outlive its own lock");
@@ -399,9 +397,9 @@ export async function fetchGdeltConflictEvents({
   const events = [];
   const failedCountries = [];
   let successfulCountries = 0;
-  const CONCURRENCY = 4; // bound the run window (20 countries × proxy retries)
+  const CONCURRENCY = 4;
   const launchCutoffAt = deadlineAt ?? now() + GDELT_SWEEP_BUDGET_MS;
-  for (let i = 0; i < CONFLICT_COUNTRIES.length; i += CONCURRENCY) {
+  for (let i = 0; i < CONFLICT_COUNTRIES.length;) {
     // #5140: stop LAUNCHING batches once the phase cutoff passes or the floor can
     // no longer be reached — either way the caller degrades to aux-only and exits 0,
     // instead of grinding retries into the fetch-phase deadline (exit 75).
@@ -415,7 +413,11 @@ export async function fetchGdeltConflictEvents({
       console.warn(`  [GDELT] conflict sweep stopped early (${why}) with ${i}/${CONFLICT_COUNTRIES.length} countries attempted`);
       break;
     }
-    const batch = remaining.slice(0, CONCURRENCY);
+    // Probe one country before widening. A selected-route failure on the canary
+    // falls straight through to the official bulk export instead of repeating
+    // the same blocked path across a four-country batch.
+    const batchSize = successfulCountries === 0 ? 1 : CONCURRENCY;
+    const batch = remaining.slice(0, batchSize);
     const results = await Promise.all(batch.map(cc => fetchCountryEvents(cc)));
     for (const result of results) {
       if (result?.ok) {
@@ -425,26 +427,20 @@ export async function fetchGdeltConflictEvents({
         failedCountries.push({ country: result?.country || 'unknown', error: result?.error || 'unknown failure' });
       }
     }
-    // #5256: back off out of a rate-limit storm instead of grinding into it. On
-    // 2026-07-13 GDELT 429'd every country, direct AND through the proxy — reproducible
-    // off-Railway, so it is a GLOBAL throttle, not our egress. Once a whole batch comes
-    // back throttled with zero successes anywhere, the remaining batches cannot succeed
-    // either; they just burn the run window and deepen the limit we are already hitting.
-    // (The floor check above would stop us eventually, but only after ~2× the requests.)
-    // A throttled batch rarely comes back UNIFORMLY 429: under load GDELT also times out and
-    // tears TLS mid-handshake, so a real storm looks like 3×429 + 1×SSL. Requiring every
-    // result to be a 429 would miss that and grind on for another batch. Trigger on the
-    // honest signal instead — the whole batch failed, nothing has succeeded anywhere, and at
-    // least one failure is an explicit rate-limit.
+    i += batch.length;
+
+    // A whole batch of selected-route failures means the route, not a country
+    // query, is unavailable. Open the circuit for 429, TLS, timeout, DNS,
+    // malformed upstream JSON, and transient upstream statuses alike.
     const batchAllFailed = results.every(r => !r?.ok);
-    const anyRateLimited = results.some(r => RATE_LIMIT_ERROR.test(String(r?.error ?? '')));
-    if (batchAllFailed && anyRateLimited && successfulCountries === 0) {
-      const why = 'GDELT rate-limit storm (batch fully throttled, 0 successes)';
-      for (const cc of remaining.slice(CONCURRENCY)) failedCountries.push({ country: cc, error: why });
-      console.warn(`  [GDELT] conflict sweep backed off (${why}) after ${i + batch.length}/${CONFLICT_COUNTRIES.length} countries`);
+    const routeFailed = results.some(r => GDELT_ROUTE_FAILURE.test(String(r?.error ?? '')));
+    if (batchAllFailed && routeFailed) {
+      const why = 'GDELT selected-route circuit open (batch fully failed)';
+      for (const cc of CONFLICT_COUNTRIES.slice(i)) failedCountries.push({ country: cc, error: why });
+      console.warn(`  [GDELT] conflict sweep backed off (${why}) after ${i}/${CONFLICT_COUNTRIES.length} countries`);
       break;
     }
-    if (i + CONCURRENCY < CONFLICT_COUNTRIES.length) await pace(500); // inter-batch only; no trailing wait
+    if (i < CONFLICT_COUNTRIES.length) await pace(500); // inter-batch only; no trailing wait
   }
   if (successfulCountries < GDELT_MIN_SUCCESSFUL_COUNTRIES || events.length === 0) {
     const sample = failedCountries.slice(0, 6).map(({ country, error }) => `${country}:${error}`).join(', ');

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -120,7 +120,7 @@ const HAPI_COUNTRIES = [...new Set([...HAPI_ONLY_COUNTRIES, ...HAPI_DASHBOARD_CO
 // The bounded transport emits stable route-specific failure codes. Treat the
 // failures known to implicate the selected route as a run-scoped circuit
 // signal; repeating them for another country cannot improve source reachability.
-const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_(?:CONFIG|HTTP_(?:401|403|407|408|429|5\d\d)|INVALID_JSON|TLS|TIMEOUT|DNS|TRANSPORT)\b|\bHTTP 429\b|SSL_ERROR_SYSCALL|\b(?:timed?\s*out|timeout)\b/i;
+const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_(?:CONFIG|HTTP_(?:401|403|404|406|407|408|410|429|451|5\d\d)|INVALID_JSON|TLS|TIMEOUT|DNS|TRANSPORT)\b|\bHTTP 429\b|SSL_ERROR_SYSCALL|\b(?:timed?\s*out|timeout)\b/i;
 // #5140: the GDELT fallback sweep may not LAUNCH a batch after this much of the
 // fetch phase has elapsed (fetchAll anchors the clock at its own entry and passes
 // an absolute deadline down, so slow aux feeds automatically shrink the sweep
@@ -431,7 +431,7 @@ export async function fetchGdeltConflictEvents({
 
     // A whole batch of selected-route failures means the route, not a country
     // query, is unavailable. Open the circuit for 429, TLS, timeout, DNS,
-    // malformed upstream JSON, and transient upstream statuses alike.
+    // malformed upstream JSON, and route-wide HTTP statuses alike.
     const batchAllFailed = results.every(r => !r?.ok);
     const routeFailed = results.some(r => GDELT_ROUTE_FAILURE.test(String(r?.error ?? '')));
     if (batchAllFailed && routeFailed) {

--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -32,7 +32,7 @@
       "name": "gdeltIntel",
       "status": "SEED_ERROR",
       "issue": 5768,
-      "reason": "GDELT repair route fails TLS (SSL_ERROR_SYSCALL). GDELT blocks Railway egress outright, so PROXY_URL is mandatory rather than a fallback, and seed-gdelt-intel is deliberately not part of the per-source proxy split."
+      "reason": "GDELT DOC blocks Railway direct egress and the shared proxy has returned 429, timeout, and TLS failures. GDELT_PROXY_URL now provides an independent route, but production still needs a verified source-specific exit before this baseline can be removed."
     },
     {
       "name": "humanitarianSummary",

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -19,7 +19,7 @@ const CANONICAL_KEY = 'intelligence:gdelt-intel:v1';
 const SEED_DOMAIN_RESOURCE = 'intelligence:gdelt-intel';
 const SEED_META_KEY = `seed-meta:${SEED_DOMAIN_RESOURCE}`;
 const SEED_META_TTL = 86400 * 7;
-const CACHE_TTL = 86400; // 24h — intentionally much longer than the 2h cron so verifySeedKey always has a prior snapshot to merge from when GDELT 429s all topics
+const CACHE_TTL = 86400; // 24h — intentionally much longer than the 4h cron so verifySeedKey always has a prior snapshot to merge from when GDELT is unavailable
 // 7d — brownout-scale, NOT one-missed-tick-scale. The per-run EXPIRE-extend in
 // afterPublish keeps last-good timelines alive up to this TTL while GDELT is
 // unreachable; at the previous 12h (2× cron) the 2026-07 brownout expired all
@@ -27,34 +27,26 @@ const CACHE_TTL = 86400; // 24h — intentionally much longer than the 2h cron s
 // re-seeds it until GDELT answers again (issue #5478). Consumers get the
 // stored fetchedAt alongside the data to judge staleness.
 export const TIMELINE_TTL = 604800;
-const TIMELINE_REPAIR_DELAY_MS = 5_500;
+const GDELT_REQUEST_DELAY_MS = 5_500;
 // Both entrypoints mutate the same canonical/timeline cohort, so their shared
 // ownership lease must cover the full bounded retry envelope, not just healthy
 // latency. Under simultaneous GDELT and Upstash throttling, 12 sequential
 // timeline reads/fetches/writes plus metadata reconciliation can take roughly
 // 75 minutes (Retry-After is capped at 60s in the shared Redis helpers). Two
-// hours preserves a wide scheduling margin without blocking the next 6h cron
+// hours preserves a wide scheduling margin without blocking the next 4h cron
 // tick if a process dies before its owner-token release runs.
 export const GDELT_LOCK_TTL_MS = 2 * 60 * 60_000;
 const RUN_SEED_FETCH_PHASE_TIMEOUT_MS = 270_000;
 const TIMELINE_ERROR_REASON = 'timeline_keys_missing_or_unconfirmed';
+const GDELT_UPSTREAM_ERROR_REASON = 'gdelt_upstream_unavailable';
 const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
-const INTER_TOPIC_DELAY_MS = 20_000; // 20s between topics on success
-const POST_EXHAUST_DELAY_MS = 120_000; // 2min extra cooldown after a topic exhausts all retries
-
-// Wall-clock soft budget for the whole fetch phase (issue #4864). Kept well
-// under runSeed's explicit 270s hard #4786 deadline, while the 10min lock also
-// covers canonical/timeline publication after the 150s fetch budget, so
-// that under a GDELT/Decodo throttle storm the loop stops fetching and falls
-// through to the cached-snapshot merge below — publishing partial+cached data
-// and exiting 0 — instead of two independent budget-blowers pushing the phase
-// past 240s and tripping the deadline into a graceful exit-75 "crash" email:
-//   1. a single topic's fetchGdeltJson can churn ~3.5min under full retry
-//      exhaustion (4×15s direct + 60s backoff + 5×15s proxy + 20s backoff);
-//   2. the inter-topic (20s×5) + post-exhaust (120s) cooldowns alone exceed 240s.
-// The 24h CACHE_TTL guarantees a prior snapshot exists to merge from.
-const FETCH_SOFT_BUDGET_MS = 150_000; // 2.5min — >80s headroom under the 240s hard deadline for merge + publish
-const MIN_TOPIC_BUDGET_MS = 25_000;   // don't start a topic we can't plausibly finish before the budget
+// Wall-clock soft budget for the whole fetch phase (issue #4864). The transport
+// now selects one route and attempts it once. This remains as a final guard for
+// an injected/hung implementation, but a budget timeout opens the run circuit:
+// the abandoned promise is allowed to settle and no timeline or later-topic
+// request is launched alongside it.
+const FETCH_SOFT_BUDGET_MS = 180_000; // 3min — 90s headroom under the 270s hard deadline for merge + publish
+const MIN_REQUEST_BUDGET_MS = 25_000; // don't start a curl that cannot finish before the budget
 
 const INTEL_TOPICS = [
   { id: 'military',     query: '(military exercise OR troop deployment OR airstrike OR "naval exercise") sourcelang:eng' },
@@ -95,7 +87,8 @@ function normalizeArticle(raw) {
   };
 }
 
-async function fetchTopicArticles(topic) {
+export async function fetchTopicArticles(topic, opts = {}) {
+  const { _fetchJson = fetchGdeltJson } = opts;
   const url = new URL(GDELT_DOC_API);
   url.searchParams.set('query', topic.query);
   url.searchParams.set('mode', 'artlist');
@@ -104,10 +97,11 @@ async function fetchTopicArticles(topic) {
   url.searchParams.set('sort', 'date');
   url.searchParams.set('timespan', '24h');
 
-  // fetchGdeltJson does direct retry + curl proxy multi-retry internally.
-  // Throws on exhaustion with HTTP 429 in message — outer fetchWithRetry's
-  // is429 substring match still works against the new error format.
-  const data = await fetchGdeltJson(url.toString(), { label: topic.id });
+  const data = await _fetchJson(url.toString(), {
+    label: topic.id,
+    maxRetries: 0,
+    proxyMaxAttempts: 1,
+  });
   const articles = (data.articles || [])
     .map(normalizeArticle)
     .filter(Boolean);
@@ -127,7 +121,7 @@ function normalizeTimeline(data, mode) {
   })).filter((pt) => pt.date);
 }
 
-export async function fetchTopicTimeline(topic, mode, opts = {}) {
+export async function fetchTopicTimelineResult(topic, mode, opts = {}) {
   const {
     strict = false,
     _fetchJson = fetchGdeltJson,
@@ -139,54 +133,47 @@ export async function fetchTopicTimeline(topic, mode, opts = {}) {
   url.searchParams.set('timespan', '14d');
 
   try {
-    // Best-effort: timelines degrade silently to [] on any failure.
-    // Pre-helper code did a single direct fetch with no retry. The
-    // article-fetch defaults (3 direct retries + 5 proxy attempts ≈ 90s)
-    // are too aggressive for discarded-on-failure data — would burn up to
-    // ~18 min/seed-run across 12 timeline calls under GDELT 429 storms.
-    //
-    // Compromise: 1 direct + 2 proxy (Decodo session rotation) attempts.
-    // Worst case ~25s per call × 12 = ~5 min ceiling. Gives timelines a
-    // realistic chance to succeed via proxy without blocking the seeder
-    // for the full article-fetch budget.
     const data = await _fetchJson(url.toString(), {
       label: `${topic.id}/${mode}`,
       maxRetries: 0,
-      proxyMaxAttempts: 2,
+      proxyMaxAttempts: 1,
     });
-    return normalizeTimeline(data, mode === 'TimelineTone' ? 'tone' : 'value');
+    return {
+      points: normalizeTimeline(data, mode === 'TimelineTone' ? 'tone' : 'value'),
+      errorCode: null,
+    };
   } catch (err) {
     if (strict) throw err;
-    return [];
+    return {
+      points: [],
+      errorCode: typeof err?.code === 'string' ? err.code : 'GDELT_TIMELINE_FETCH_FAILED',
+    };
   }
 }
 
-async function fetchWithRetry(topic) {
-  // Pre-helper: this function did 3 outer retries with 60/120/240s backoff
-  // on top of fetchTopicArticles. Now fetchGdeltJson handles ALL retry +
-  // proxy multi-retry internally (3 direct retries + 5 curl proxy attempts
-  // per call), so the outer loop is gone. This function's only remaining
-  // job is to translate thrown exhaustion into the {exhausted, articles:[]}
-  // shape that fetchAllTopics expects (used to drive POST_EXHAUST_DELAY_MS
-  // cooldown decisions).
+export async function fetchTopicTimeline(topic, mode, opts = {}) {
+  return (await fetchTopicTimelineResult(topic, mode, opts)).points;
+}
+
+async function fetchArticlesOnce(topic) {
   try {
     return await fetchTopicArticles(topic);
   } catch (err) {
-    // Helper's exhausted-throw includes "HTTP 429" in the message when
-    // 429 was the upstream signal — substring match preserved.
-    const is429 = err.message?.includes('429');
     console.warn(`    ${topic.id}: giving up (${err.message})`);
-    return { id: topic.id, articles: [], fetchedAt: new Date().toISOString(), exhausted: is429 };
+    return {
+      id: topic.id,
+      articles: [],
+      fetchedAt: new Date().toISOString(),
+      failureCode: typeof err?.code === 'string' ? err.code : 'GDELT_ARTICLE_FETCH_FAILED',
+    };
   }
 }
 
-// Resolve `promise` but never let it run past `budgetMs`; on timeout resolve to
-// `fallback` (and run `onTimeout` for a log line). Unlike raceFetchDeadline this
-// RESOLVES rather than rejects, because a topic that overruns is not a failure —
-// the caller backfills it from the cached snapshot. The abandoned fetch keeps
-// running but every socket underneath it is bounded by AbortSignal.timeout /
-// curl --max-time, so it settles and is GC'd (no leak).
-function withBudget(promise, budgetMs, fallback, onTimeout) {
+// Start `operation` only when budget remains, and never let it run past
+// `budgetMs`; on timeout resolve to `fallback` (and run `onTimeout` for a log
+// line). The fallback opens the run-scoped circuit below, so the abandoned
+// bounded request is never overlapped by timeline or later-topic calls.
+function withBudget(operation, budgetMs, fallback, onTimeout) {
   if (!(budgetMs > 0)) return Promise.resolve(fallback);
   let timer;
   const budget = new Promise((resolve) => {
@@ -195,7 +182,8 @@ function withBudget(promise, budgetMs, fallback, onTimeout) {
       resolve(fallback);
     }, budgetMs);
   });
-  return Promise.race([Promise.resolve(promise), budget]).finally(() => clearTimeout(timer));
+  const pending = Promise.resolve().then(operation);
+  return Promise.race([pending, budget]).finally(() => clearTimeout(timer));
 }
 
 // Exported for tests. Deps are injectable so the soft-budget + cache-merge
@@ -204,8 +192,8 @@ export async function fetchAllTopics(deps = {}) {
   const {
     _now = () => Date.now(),
     _sleep = sleep,
-    _fetchArticles = fetchWithRetry,
-    _fetchTimeline = fetchTopicTimeline,
+    _fetchArticles = fetchArticlesOnce,
+    _fetchTimeline = fetchTopicTimelineResult,
     // The cache-merge fallback is what keeps seed-meta fresh through a GDELT
     // outage — when this read dies the run degrades to a no-write skip and
     // freshness silently rots (21h stale before the gate fired, issue #5437),
@@ -215,57 +203,91 @@ export async function fetchAllTopics(deps = {}) {
       return null;
     }),
     _softBudgetMs = FETCH_SOFT_BUDGET_MS,
-    _minTopicBudgetMs = MIN_TOPIC_BUDGET_MS,
-    _interTopicDelayMs = INTER_TOPIC_DELAY_MS,
-    _postExhaustDelayMs = POST_EXHAUST_DELAY_MS,
+    _minRequestBudgetMs = MIN_REQUEST_BUDGET_MS,
+    _interRequestDelayMs = GDELT_REQUEST_DELAY_MS,
   } = deps;
   const deadlineAt = _now() + _softBudgetMs;
   const remaining = () => deadlineAt - _now();
 
   const topics = [];
+  let failureCode = null;
+  let freshTopicCount = 0;
+  let requestCount = 0;
+  const paceNextRequest = async () => {
+    if (requestCount > 0 && _interRequestDelayMs > 0) {
+      const delay = Math.min(
+        _interRequestDelayMs,
+        Math.max(0, remaining() - _minRequestBudgetMs),
+      );
+      if (delay > 0) await _sleep(delay);
+    }
+    if (remaining() < _minRequestBudgetMs) return false;
+    requestCount += 1;
+    return true;
+  };
+
   for (let i = 0; i < INTEL_TOPICS.length; i++) {
     // Stop fetching once we can't plausibly finish another topic in time — the
     // cache-merge below backfills every topic we skip from the prior snapshot,
     // so the run publishes partial+cached data and exits 0 instead of churning
     // past the hard #4786 deadline into a graceful exit-75 crash (issue #4864).
-    if (remaining() < _minTopicBudgetMs) {
+    if (remaining() < _minRequestBudgetMs) {
       console.log(`  Soft budget (${Math.round(_softBudgetMs / 1000)}s) reached after ${i}/${INTEL_TOPICS.length} topic(s) — remaining ${INTEL_TOPICS.length - i} will fall back to cached snapshot`);
+      failureCode = 'GDELT_FETCH_BUDGET_EXCEEDED';
       break;
     }
-    if (i > 0) await _sleep(Math.min(_interTopicDelayMs, Math.max(0, remaining() - _minTopicBudgetMs)));
+    if (!(await paceNextRequest())) {
+      failureCode = 'GDELT_FETCH_BUDGET_EXCEEDED';
+      break;
+    }
     console.log(`  Fetching ${INTEL_TOPICS[i].id}...`);
-    // Bound this single topic against the remaining budget: its own retry ladder
-    // can reach ~3.5min under a 429 storm, which alone would blow the phase.
     const emptyTopic = () => ({ id: INTEL_TOPICS[i].id, articles: [], fetchedAt: new Date().toISOString() });
     const result = await withBudget(
-      _fetchArticles(INTEL_TOPICS[i]),
+      () => _fetchArticles(INTEL_TOPICS[i]),
       remaining(),
       { ...emptyTopic(), budgetExceeded: true },
       () => console.warn(`    ${INTEL_TOPICS[i].id}: article budget reached — falling back to cached`),
     );
     console.log(`    ${result.articles.length} articles`);
-    // Fetch tone/vol timelines in parallel — best-effort, 429s silently return [].
-    // Also bounded so a slow timeline pair can't overrun the phase.
-    const timelines = await withBudget(
-      Promise.all(TIMELINE_SERIES.map(
-        (series) => _fetchTimeline(INTEL_TOPICS[i], series.mode),
-      )),
-      remaining(),
-      [[], []],
-      () => console.warn(`    ${INTEL_TOPICS[i].id}: timeline budget reached — skipping timelines`),
-    );
-    for (let j = 0; j < TIMELINE_SERIES.length; j++) {
-      result[TIMELINE_SERIES[j].topicField] = timelines[j];
+    topics.push(result);
+
+    if (result.budgetExceeded || result.failureCode) {
+      failureCode = result.failureCode || 'GDELT_FETCH_BUDGET_EXCEEDED';
+      console.warn(`    ${INTEL_TOPICS[i].id}: opening run circuit (${failureCode}); remaining DOC requests will use cached data`);
+      break;
+    }
+
+    if (result.articles.length > 0) freshTopicCount += 1;
+
+    // Timeline calls are sequential. A failed route opens the same run circuit
+    // as an article failure, so Tone and Vol cannot simultaneously hammer an
+    // already failing proxy and no later topic is launched.
+    for (const series of TIMELINE_SERIES) {
+      const timelineFallback = { points: [], errorCode: 'GDELT_FETCH_BUDGET_EXCEEDED' };
+      const hasBudget = await paceNextRequest();
+      const outcome = hasBudget
+        ? await withBudget(
+            () => _fetchTimeline(INTEL_TOPICS[i], series.mode),
+            remaining(),
+            timelineFallback,
+            () => console.warn(`    ${INTEL_TOPICS[i].id}: ${series.id} timeline budget reached`),
+          )
+        : timelineFallback;
+      const normalized = Array.isArray(outcome)
+        ? { points: outcome, errorCode: null }
+        : outcome;
+      result[series.topicField] = Array.isArray(normalized?.points) ? normalized.points : [];
+      if (normalized?.errorCode) {
+        failureCode = normalized.errorCode;
+        console.warn(`    ${INTEL_TOPICS[i].id}: opening run circuit (${failureCode}); remaining DOC requests will use cached data`);
+        break;
+      }
+    }
+    for (const series of TIMELINE_SERIES) {
+      if (!Array.isArray(result[series.topicField])) result[series.topicField] = [];
     }
     console.log(`    timeline: ${result._tone.length} tone pts, ${result._vol.length} vol pts`);
-    topics.push(result);
-    // After a topic exhausts all retries, give GDELT a longer cooldown before hitting
-    // it again with the next topic — the rate limit window for popular queries exceeds 50s.
-    // Skip the cooldown when it would eat the remaining budget.
-    if (result.exhausted && i < INTEL_TOPICS.length - 1 && remaining() - _postExhaustDelayMs >= _minTopicBudgetMs) {
-      console.log(`    Rate-limit cooldown: waiting ${_postExhaustDelayMs / 1000}s before next topic...`);
-      await _sleep(_postExhaustDelayMs);
-    }
+    if (failureCode) break;
   }
 
   // Represent every topic so the cache-merge can backfill both the ones we
@@ -298,8 +320,16 @@ export async function fetchAllTopics(deps = {}) {
   // Restore canonical topic order (backfilled entries were appended out of order).
   const order = new Map(INTEL_TOPICS.map((t, idx) => [t.id, idx]));
   topics.sort((a, b) => (order.get(a.id) ?? INTEL_TOPICS.length) - (order.get(b.id) ?? INTEL_TOPICS.length));
+  if (!failureCode && freshTopicCount === 0) {
+    failureCode = 'GDELT_EMPTY_ARTICLE_RESULTS';
+  }
 
-  return { topics, fetchedAt: new Date().toISOString() };
+  return {
+    topics,
+    fetchedAt: new Date().toISOString(),
+    _gdeltFailureCode: failureCode,
+    _freshTopicCount: freshTopicCount,
+  };
 }
 
 function validate(data) {
@@ -308,11 +338,23 @@ function validate(data) {
   return populated.length >= 3; // at least 3 of 6 topics must have articles; partial 429s handled by per-topic merge above
 }
 
-// Strip private fields (_tone, _vol, exhausted) before writing to the canonical Redis key.
+// Strip transport/timeline implementation fields before writing the canonical
+// Redis payload. They are consumed only by afterPublish and seed-meta.
 function publishTransform(data) {
+  const {
+    _gdeltFailureCode: _failure,
+    _freshTopicCount: _fresh,
+    ...publicData
+  } = data;
   return {
-    ...data,
-    topics: (data.topics ?? []).map(({ _tone: _t, _vol: _v, exhausted: _e, ...rest }) => rest),
+    ...publicData,
+    topics: (data.topics ?? []).map(({
+      _tone: _t,
+      _vol: _v,
+      failureCode: _failureCode,
+      budgetExceeded: _budgetExceeded,
+      ...rest
+    }) => rest),
   };
 }
 
@@ -373,16 +415,26 @@ export async function afterPublish(data, _meta) {
       + `run \`node scripts/seed-gdelt-intel.mjs --repair-timelines\` to restore them outside the article-fetch budget`,
     );
   }
-  const completionState = missingOrUnconfirmedKeys.length > 0 ? 'DEGRADED' : 'OK';
+  const upstreamFailed = typeof data?._gdeltFailureCode === 'string';
+  const completionState = upstreamFailed || missingOrUnconfirmedKeys.length > 0
+    ? 'DEGRADED'
+    : 'OK';
+  const freshnessMetaPatch = completionState === 'DEGRADED'
+    ? {
+        status: 'error',
+        errorReason: upstreamFailed ? GDELT_UPSTREAM_ERROR_REASON : TIMELINE_ERROR_REASON,
+        ...(upstreamFailed ? { errorCode: data._gdeltFailureCode } : {}),
+        ...(Number.isInteger(data?._freshTopicCount)
+          ? { freshTopicCount: data._freshTopicCount }
+          : {}),
+        ...(missingOrUnconfirmedKeys.length > 0
+          ? { missingTimelineKeys: missingOrUnconfirmedKeys }
+          : {}),
+      }
+    : null;
   return {
     completionState,
-    freshnessMetaPatch: completionState === 'DEGRADED'
-      ? {
-          status: 'error',
-          errorReason: TIMELINE_ERROR_REASON,
-          missingTimelineKeys: missingOrUnconfirmedKeys,
-        }
-      : null,
+    freshnessMetaPatch,
   };
 }
 
@@ -391,10 +443,10 @@ function hasTimelineData(value) {
   return Array.isArray(points) && points.length > 0;
 }
 
-// Dedicated operator repair path for issue #5712. The regular seed's 150s
-// article budget is intentionally unable to walk all 12 timeline requests
-// during a GDELT throttle storm. This path does no article work, paces each
-// timeline request independently, and writes every missing key with SET.
+// Dedicated operator repair path for issue #5712. Healthy requests are paced,
+// but the first transport failure opens a run-scoped circuit. Remaining keys
+// are still read/preserved and reported as failed without repeating the same
+// blocked route up to eleven more times.
 export async function repairTimelines(deps = {}) {
   const {
     _readTimeline = verifySeedKey,
@@ -402,13 +454,14 @@ export async function repairTimelines(deps = {}) {
     _writeTimeline = writeExtraKey,
     _extendTtl = extendExistingTtl,
     _sleep = sleep,
-    _interRequestDelayMs = TIMELINE_REPAIR_DELAY_MS,
+    _interRequestDelayMs = GDELT_REQUEST_DELAY_MS,
     _now = () => Date.now(),
   } = deps;
   const repairedKeys = [];
   const preservedKeys = [];
   const failedKeys = [];
   let fetchCount = 0;
+  let failureCode = null;
 
   for (const topic of INTEL_TOPICS) {
     for (const series of TIMELINE_SERIES) {
@@ -425,6 +478,11 @@ export async function repairTimelines(deps = {}) {
         continue;
       }
 
+      if (failureCode) {
+        failedKeys.push(key);
+        continue;
+      }
+
       if (fetchCount > 0 && _interRequestDelayMs > 0) {
         await _sleep(_interRequestDelayMs);
       }
@@ -435,6 +493,9 @@ export async function repairTimelines(deps = {}) {
         timeline = await _fetchTimeline(topic, series.mode);
       } catch (err) {
         failedKeys.push(key);
+        failureCode = typeof err?.code === 'string'
+          ? err.code
+          : 'GDELT_TIMELINE_FETCH_FAILED';
         console.warn(`  ${key}: repair fetch failed (${err?.message || err})`);
         continue;
       }
@@ -465,6 +526,7 @@ export async function repairTimelines(deps = {}) {
     repairedKeys,
     preservedKeys,
     failedKeys,
+    ...(failureCode ? { errorCode: failureCode } : {}),
   };
   return result;
 }
@@ -502,6 +564,7 @@ export async function reconcileTimelineRepairMetadata(repairResult, deps = {}) {
     if (!unrelatedErrorOwnsRecord) {
       nextMeta.status = 'error';
       nextMeta.errorReason = TIMELINE_ERROR_REASON;
+      nextMeta.errorCode = repairResult.errorCode || 'GDELT_TIMELINE_REPAIR_INCOMPLETE';
     }
     nextMeta.missingTimelineKeys = failedKeys;
   } else {
@@ -509,6 +572,7 @@ export async function reconcileTimelineRepairMetadata(repairResult, deps = {}) {
     if (nextMeta.errorReason === TIMELINE_ERROR_REASON) {
       delete nextMeta.status;
       delete nextMeta.errorReason;
+      delete nextMeta.errorCode;
     }
   }
   await _writeMeta(nextMeta, SEED_META_TTL);
@@ -522,6 +586,7 @@ function logTimelineRepairResult(result) {
     repairedCount: result.repairedCount,
     preservedCount: result.preservedCount,
     failedCount: result.failedKeys?.length ?? 0,
+    errorCode: result.errorCode,
     metadataReconciled: result.metadataReconciled === true,
     lockReason: result.lockReason,
     repairError: result.repairError,
@@ -659,7 +724,7 @@ export const RUN_SEED_OPTS = {
   schemaVersion: 1,
   maxStaleMin: 420,
   contentMeta,
-  // 24h = 4× the 6h cadence. Normal runs refresh at least topic[0] every
+  // 24h = 6× the 4h cadence. Normal runs refresh at least topic[0] every
   // tick, so only a real brownout (every topic failing every run for a day)
   // flips health to STALE_CONTENT (warn).
   maxContentAgeMin: 1440,

--- a/scripts/seed-recall-benchmark.mjs
+++ b/scripts/seed-recall-benchmark.mjs
@@ -87,11 +87,10 @@ async function main() {
   // 2. External reference set from GDELT.
   const seenUrls = new Set();
   const externalItems = [];
-  // #4929 external review: production retry defaults (3 retries × 10s
-  // backoff + 5 proxy attempts, ×4 sequential queries) could consume much
-  // of the 25-minute workflow. Benchmark-grade fast-fail limits + a shared
-  // wall-clock deadline: partial reference sets are fine, a hung workflow
-  // is not.
+  // #4929 external review: partial reference sets are fine, a hung workflow
+  // is not. The shared GDELT transport now enforces one selected-route attempt,
+  // and the first route failure opens a circuit across the remaining queries.
+  // The wall-clock deadline remains a final bound for a healthy but slow route.
   const GDELT_DEADLINE_MS = 4 * 60 * 1000;
   const gdeltStartedAt = Date.now();
   for (const { label, q } of REFERENCE_QUERIES) {
@@ -103,8 +102,7 @@ async function main() {
       const json = await fetchGdeltJson(gdeltUrl(q), {
         label: `recall-${label}`,
         timeoutMs: 10_000,
-        maxRetries: 1,
-        retryBaseMs: 2_000,
+        maxRetries: 0,
         proxyMaxAttempts: 1,
       });
       const articles = Array.isArray(json?.articles) ? json.articles : [];
@@ -118,7 +116,8 @@ async function main() {
       }
       console.log(`  [gdelt:${label}] ${articles.length} articles`);
     } catch (err) {
-      console.warn(`  [gdelt:${label}] failed: ${err.message} — continuing with remaining verticals`);
+      console.warn(`  [gdelt:${label}] failed: ${err.message} — opening GDELT circuit; remaining verticals skipped`);
+      break;
     }
   }
   if (externalItems.length < 20) {

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -279,8 +279,8 @@ test('fetchGdeltConflictEvents preserves partial DOC coverage telemetry after bu
   );
 });
 
-// #5140: the sweep's worst case (20 countries × direct+proxy retries ÷ 4
-// concurrency ≈ 375s+) exceeded runSeed's fetch deadline, so a GDELT brownout
+// #5140: the sweep's former retry fanout exceeded runSeed's fetch deadline, so
+// a GDELT brownout
 // crashed the seeder (exit 75) instead of reaching the caught coverage-floor →
 // aux-only → exit 0 path. The sweep must stop launching batches once its
 // launch cutoff passes, regardless of per-country outcome. (The deadline
@@ -296,16 +296,16 @@ test('fetchGdeltConflictEvents stops launching batches once the launch cutoff pa
       fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
-        // Each batch of 4 consumes 40s of fake wall clock — a degraded-GDELT batch.
+        // Each request consumes 10s. The route canary is one request; healthy
+        // coverage then widens to batches of four.
         fakeTime += 40_000 / 4;
         return { country: cc, ok: true, events: [] };
       },
     }),
     /coverage below floor.*sweep budget exhausted/s,
   );
-  // Cutoff at 75s: batch 1 ends at 40s (< 75s → batch 2 launches), batch 2 ends
-  // at 80s (≥ 75s → stop). Only 8 of 20 countries may be attempted.
-  assert.equal(calls, 8);
+  // Cutoff at 75s: canary ends at 10s, batches end at 50s and 90s, then stop.
+  assert.equal(calls, 9);
 });
 
 test('fetchGdeltConflictEvents launches nothing when the phase cutoff already passed at entry (#5140)', async () => {
@@ -341,8 +341,9 @@ test('fetchGdeltConflictEvents stops sweeping once the coverage floor is unreach
     }),
     /coverage below floor/,
   );
-  // After 2 all-failed batches: 0 successes + 12 remaining < 16 floor → no third batch.
-  assert.equal(calls, 8);
+  // With no successful canary, requests stay sequential. After 5 failures:
+  // 0 successes + 15 remaining < the 16-country floor.
+  assert.equal(calls, 5);
 });
 
 test('early-stop reason names BOTH conditions when budget and floor trip together (#5140)', async (t) => {
@@ -354,12 +355,12 @@ test('early-stop reason names BOTH conditions when budget and floor trip togethe
     fetchGdeltConflictEvents({
       pace: async () => {},
       now: () => fakeTime,
-      deadlineAt: 115_000,
+      deadlineAt: 85_000,
       fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
       fetchCountryEvents: async (cc) => {
         calls += 1;
         fakeTime += 10_000;
-        // Batch 1 succeeds; later batches fail → the floor drifts out of reach
+        // Canary/first batch succeed; the next batch fails → the floor drifts out of reach
         // while the clock runs out, so both stop conditions hold at once.
         return calls <= 4
           ? { country: cc, ok: true, events: [] }
@@ -368,8 +369,9 @@ test('early-stop reason names BOTH conditions when budget and floor trip togethe
     }),
     /coverage below floor/,
   );
-  // Before batch 4: clock 120s ≥ 115s cutoff AND 4 successes + 8 remaining < 16.
-  assert.equal(calls, 12);
+  // Before the next batch: clock 90s ≥ 85s cutoff AND
+  // 4 successes + 11 remaining < 16.
+  assert.equal(calls, 9);
   assert.ok(
     warns.some((w) => w.includes('sweep budget exhausted + coverage floor unreachable')),
     `expected combined stop reason in warns: ${warns.join(' | ')}`,

--- a/tests/gdelt-fetch.test.mjs
+++ b/tests/gdelt-fetch.test.mjs
@@ -1,541 +1,241 @@
-// Tests for scripts/_gdelt-fetch.mjs.
+// Executable transport regressions for the GDELT production route.
 //
-// Locks every learning from PRs #3118, #3119, #3120 + adds GDELT-specific
-// multi-retry-proxy assertions:
-//
-//   1. lastError accumulator → final throw embeds last status + cause chain.
-//   2. Catch block uses `break` (not throw) so thrown errors reach proxy.
-//   3. DI seams (_curlProxyResolver, _proxyCurlFetcher, _sleep) for hermetic
-//      tests with no real network / curl exec / wall-clock waits.
-//   4. _PROXY_DEFAULTS exported + production-default lock tests catch
-//      wiring regressions (no CONNECT leg, correct curl resolver).
-//   5. Sync curlFetch wrapped with `await Promise.resolve()` (no-op today,
-//      future-safe).
-//   6. Success log fires AFTER JSON.parse — malformed proxy response
-//      doesn't emit contradictory log lines.
-//   7. Pair branch tests when picking numeric values (Retry-After vs
-//      default backoff).
-//   8. GDELT-specific: proxy multi-retry is the marquee feature. Test that
-//      attempts 1-4 fail with 429, attempt 5 succeeds → returns data.
-//   9. GDELT-specific: non-retryable proxy error (parse failure) bails
-//      immediately, doesn't burn all 5 attempts.
+// The outage this guards against was amplification, not a missing retry:
+// Railway direct was blocked, the shared proxy was also failing, and one DOC
+// query repeated those paths before the seeder launched more DOC queries.
 
-import { test, afterEach } from 'node:test';
-import { strict as assert } from 'node:assert';
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
 
-process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
-process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+import {
+  _PROXY_DEFAULTS,
+  classifyGdeltFetchError,
+  fetchGdeltJson,
+  resolveGdeltProxy,
+  resolveGdeltProxyRoute,
+} from '../scripts/_gdelt-fetch.mjs';
+import { curlFetch } from '../scripts/_seed-utils.mjs';
 
 const URL = 'https://api.gdeltproject.org/api/v2/doc/doc?query=climate&mode=ArtList&format=json';
-const VALID_PAYLOAD = { articles: [{ url: 'https://example.com/x', title: 'foo' }] };
-
-const COMMON_OPTS = {
-  label: 'climate',
-  maxRetries: 1,         // direct retries — keep tests fast
-  retryBaseMs: 10,
-  timeoutMs: 1000,
-  proxyMaxAttempts: 3,   // proxy retries
-  proxyRetryBaseMs: 10,
+const PAYLOAD = { articles: [{ url: 'https://example.com/x', title: 'foo' }] };
+const savedProxyEnv = {
+  GDELT_PROXY_URL: process.env.GDELT_PROXY_URL,
+  PROXY_URL: process.env.PROXY_URL,
 };
 
-const originalFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = originalFetch; });
+function setProxyEnv(values = {}) {
+  delete process.env.GDELT_PROXY_URL;
+  delete process.env.PROXY_URL;
+  Object.assign(process.env, values);
+}
 
-// ─── Production defaults: lock the wiring ───────────────────────────────
+afterEach(() => {
+  for (const [name, value] of Object.entries(savedProxyEnv)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
 
-test('production defaults: curl leg uses resolveProxy + curlFetch', async () => {
-  const { _PROXY_DEFAULTS } = await import('../scripts/_gdelt-fetch.mjs');
-  const { resolveProxy, curlFetch } = await import('../scripts/_seed-utils.mjs');
-  assert.equal(_PROXY_DEFAULTS.curlProxyResolver, resolveProxy);
+test('production defaults bind the GDELT-specific resolver and curl transport', () => {
+  assert.equal(_PROXY_DEFAULTS.curlProxyResolver, resolveGdeltProxy);
+  assert.equal(_PROXY_DEFAULTS.proxyRouteResolver, resolveGdeltProxyRoute);
   assert.equal(_PROXY_DEFAULTS.curlFetcher, curlFetch);
 });
 
-test('production defaults: NO CONNECT leg (Decodo CONNECT not yet probed against GDELT)', async () => {
-  const { _PROXY_DEFAULTS } = await import('../scripts/_gdelt-fetch.mjs');
-  // Asserting absence prevents a future "let's add CONNECT" refactor from
-  // routing requests through an unverified egress pool. If you need to
-  // add CONNECT, also re-probe GDELT and update the helper module header.
-  assert.equal(_PROXY_DEFAULTS.connectProxyResolver, undefined);
-  assert.equal(_PROXY_DEFAULTS.connectFetcher, undefined);
-});
-
-// ─── Direct path ────────────────────────────────────────────────────────
-
-test('200 OK: returns parsed JSON, never touches proxy', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: true, status: 200,
-    headers: { get: () => null },
-    json: async () => VALID_PAYLOAD,
+test('GDELT_PROXY_URL wins over PROXY_URL and skips the known-blocked direct route', async () => {
+  setProxyEnv({
+    GDELT_PROXY_URL: 'http://gdelt-user:gdelt-pass@gdelt-proxy.test:8100',
+    PROXY_URL: 'http://shared-user:shared-pass@shared-proxy.test:8200',
   });
-  let proxyCalls = 0;
+  const proxyAuths = [];
+  let directCalls = 0;
+
   const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    _curlProxyResolver: () => 'should-not-be-used',
-    _proxyCurlFetcher: () => { proxyCalls += 1; throw new Error('not reached'); },
-  });
-  assert.deepEqual(result, VALID_PAYLOAD);
-  assert.equal(proxyCalls, 0);
-});
-
-test('429 with no proxy: throws exhausted with HTTP 429 in message', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-  await assert.rejects(
-    () => fetchGdeltJson(URL, { ...COMMON_OPTS, _curlProxyResolver: () => null }),
-    (err) => {
-      assert.match(err.message, /GDELT retries exhausted/);
-      assert.match(err.message, /HTTP 429/);
-      return true;
+    label: 'military',
+    _fetch: async () => {
+      directCalls += 1;
+      throw new Error('direct route must not run when a proxy is configured');
     },
-  );
-});
-
-// ─── Backoff math (paired branches) ─────────────────────────────────────
-
-test('Retry-After header parsed: backoff respects upstream hint (DI _sleep capture)', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  let calls = 0;
-  globalThis.fetch = async () => {
-    calls += 1;
-    return {
-      ok: calls > 1, status: calls > 1 ? 200 : 429,
-      headers: { get: (name) => name.toLowerCase() === 'retry-after' ? '7' : null },
-      json: async () => VALID_PAYLOAD,
-    };
-  };
-  const sleepDurations = [];
-  const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    _curlProxyResolver: () => null,
-    _sleep: async (ms) => { sleepDurations.push(ms); },
+    _proxyCurlFetcher: (_url, proxyAuth) => {
+      proxyAuths.push(proxyAuth);
+      return JSON.stringify(PAYLOAD);
+    },
   });
-  assert.deepEqual(result, VALID_PAYLOAD);
-  assert.deepEqual(sleepDurations, [7000], 'Retry-After: 7 → 7000ms (not retryBaseMs default 10ms)');
+
+  assert.deepEqual(result, PAYLOAD);
+  assert.equal(directCalls, 0);
+  assert.equal(proxyAuths.length, 1, 'selected route is attempted exactly once');
+  assert.match(proxyAuths[0], /@gdelt-proxy\.test:8100$/);
+  assert.doesNotMatch(proxyAuths[0], /shared-proxy/);
 });
 
-test('Retry-After absent: linear backoff retryBaseMs * (attempt+1)', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  let calls = 0;
-  globalThis.fetch = async () => {
-    calls += 1;
-    return {
-      ok: calls > 1, status: calls > 1 ? 200 : 429,
-      headers: { get: () => null },
-      json: async () => VALID_PAYLOAD,
-    };
-  };
-  const sleepDurations = [];
+test('PROXY_URL remains the compatibility route when GDELT_PROXY_URL is absent', async () => {
+  setProxyEnv({ PROXY_URL: 'http://user:pass@shared-proxy.test:8200' });
+  const proxyAuths = [];
+
   await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    _curlProxyResolver: () => null,
-    _sleep: async (ms) => { sleepDurations.push(ms); },
-  });
-  assert.deepEqual(sleepDurations, [10], 'no Retry-After → retryBaseMs * 1 = 10ms');
-});
-
-// ─── Proxy multi-retry (GDELT marquee feature) ──────────────────────────
-
-test('proxy multi-retry: 4 attempts fail HTTP 429, attempt 5 succeeds → returns data', async () => {
-  // Mirrors the probed Decodo behavior: ~40% per-attempt success because
-  // session rotates per call. Without multi-retry, GDELT would fail the
-  // first 60% of attempts and stop. This is the marquee feature.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  let proxyCalls = 0;
-  const sleepDurations = [];
-  const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    proxyMaxAttempts: 5,
-    proxyRetryBaseMs: 50,
-    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-    _proxyCurlFetcher: () => {
-      proxyCalls += 1;
-      if (proxyCalls < 5) throw new Error('HTTP 429');
-      return JSON.stringify(VALID_PAYLOAD);
-    },
-    _sleep: async (ms) => { sleepDurations.push(ms); },
-  });
-
-  assert.deepEqual(result, VALID_PAYLOAD);
-  assert.equal(proxyCalls, 5, 'must retry through all attempts until success');
-  // 4 backoffs between proxy attempts (no sleep AFTER success).
-  // Plus 1 direct backoff (maxRetries=1, attempt 0 → backoff → attempt 1).
-  // Total: 1 direct + 4 proxy = 5 sleeps.
-  assert.equal(sleepDurations.length, 5, '1 direct + 4 inter-proxy sleeps');
-  assert.deepEqual(sleepDurations.slice(1), [50, 50, 50, 50], 'proxy backoffs are proxyRetryBaseMs');
-});
-
-test('proxy non-retryable error (parse failure) bails immediately, does NOT burn all attempts', async () => {
-  // Distinguish "transient throttle, retry might help" from "structural
-  // failure, retry will not help". Burning 5 attempts on a parse failure
-  // is wasted time + noisy logs.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  let proxyCalls = 0;
-  await assert.rejects(
-    () => fetchGdeltJson(URL, {
-      ...COMMON_OPTS,
-      proxyMaxAttempts: 5,
-      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-      _proxyCurlFetcher: () => {
-        proxyCalls += 1;
-        return 'not-valid-json';  // parse will throw — non-retryable
-      },
-    }),
-    /GDELT retries exhausted/,
-  );
-  assert.equal(proxyCalls, 1, 'parse failure must bail after first attempt');
-});
-
-test('proxy timeout (no .status, not SyntaxError) RETRIES — Decodo session rotation may clear it', async () => {
-  // P1 from PR #3122 review: probed Decodo egress gave
-  // 200/200/429/TIMEOUT/429. Pre-fix logic only retried on HTTP 429/503
-  // substring, so a curl timeout bailed on the first attempt and
-  // defeated the multi-retry design. Lock that timeouts trigger the
-  // same retry behavior as 429s.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  let proxyCalls = 0;
-  const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    proxyMaxAttempts: 3,
-    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-    _proxyCurlFetcher: () => {
-      proxyCalls += 1;
-      if (proxyCalls === 1) {
-        // Mimic a curl exec timeout: Node Error with no .status, not a
-        // SyntaxError. Real shape from execFileSync timeout:
-        // "Command failed: curl ..." or ETIMEDOUT.
-        throw Object.assign(new Error('Command failed: curl ... timed out'), { code: 'ETIMEDOUT' });
-      }
-      return JSON.stringify(VALID_PAYLOAD);
+    label: 'military',
+    _fetch: async () => { throw new Error('direct route must not run'); },
+    _proxyCurlFetcher: (_url, proxyAuth) => {
+      proxyAuths.push(proxyAuth);
+      return JSON.stringify(PAYLOAD);
     },
   });
-  assert.equal(proxyCalls, 2, 'timeout MUST trigger retry — Decodo session rotates per call');
-  assert.deepEqual(result, VALID_PAYLOAD);
+
+  assert.equal(proxyAuths.length, 1);
+  assert.match(proxyAuths[0], /@shared-proxy\.test:8200$/);
 });
 
-test('proxy ECONNRESET (no .status) RETRIES', async () => {
-  // Same logic — any non-status non-parse error is treated as transient.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  let proxyCalls = 0;
-  const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    proxyMaxAttempts: 3,
-    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-    _proxyCurlFetcher: () => {
-      proxyCalls += 1;
-      if (proxyCalls === 1) {
-        throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
-      }
-      return JSON.stringify(VALID_PAYLOAD);
-    },
-  });
-  assert.equal(proxyCalls, 2);
-  assert.deepEqual(result, VALID_PAYLOAD);
-});
-
-test('proxy HTTP 4xx (non-429, e.g. 401 auth) does NOT retry', async () => {
-  // 401/403/404 from upstream are structural — not transient. Retrying
-  // wastes attempts. Locks the bail-on-non-retryable-status branch.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  let proxyCalls = 0;
-  await assert.rejects(
-    () => fetchGdeltJson(URL, {
-      ...COMMON_OPTS,
-      proxyMaxAttempts: 5,
-      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-      _proxyCurlFetcher: () => {
-        proxyCalls += 1;
-        // curlFetch attaches .status when curl returned a clean HTTP status.
-        throw Object.assign(new Error('HTTP 401'), { status: 401 });
-      },
-    }),
-    /GDELT retries exhausted/,
-  );
-  assert.equal(proxyCalls, 1, 'HTTP 401 is non-retryable — must bail after 1 attempt');
-});
-
-test('proxy retryable + non-retryable mix: retries on 429, bails on parse failure', async () => {
-  // First two attempts 429 (retryable, keep going), third returns garbage
-  // (non-retryable, bail). Locks the distinction.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  let proxyCalls = 0;
-  await assert.rejects(
-    () => fetchGdeltJson(URL, {
-      ...COMMON_OPTS,
-      proxyMaxAttempts: 5,
-      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-      _proxyCurlFetcher: () => {
-        proxyCalls += 1;
-        if (proxyCalls < 3) throw new Error('HTTP 429');
-        return 'not-valid-json';
-      },
-    }),
-    /GDELT retries exhausted/,
-  );
-  assert.equal(proxyCalls, 3, '2× 429 retries + 1× parse failure = 3 attempts');
-});
-
-test('thrown fetch error on final direct retry → proxy multi-retry runs (P1 regression guard)', async () => {
-  // PR #3118 P1: catch block must `break` not `throw` so thrown errors
-  // reach the proxy path. Lock for GDELT too.
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  let directCalls = 0;
-  globalThis.fetch = async () => {
-    directCalls += 1;
-    throw Object.assign(new Error('Connect Timeout Error'), { code: 'UND_ERR_CONNECT_TIMEOUT' });
-  };
-  let proxyCalls = 0;
-  const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-    _proxyCurlFetcher: () => { proxyCalls += 1; return JSON.stringify(VALID_PAYLOAD); },
-  });
-  assert.equal(directCalls, 2, 'direct attempts exhausted before proxy');
-  assert.equal(proxyCalls, 1, 'proxy MUST run on thrown-error path');
-  assert.deepEqual(result, VALID_PAYLOAD);
-});
-
-test('429 + ALL proxy attempts fail: throws with attempt count + both errors', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-  await assert.rejects(
-    () => fetchGdeltJson(URL, {
-      ...COMMON_OPTS,
-      proxyMaxAttempts: 3,
-      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-      _proxyCurlFetcher: () => { throw new Error('HTTP 429'); },
-    }),
-    (err) => {
-      assert.match(err.message, /GDELT retries exhausted/);
-      assert.match(err.message, /HTTP 429/, 'direct status preserved');
-      assert.match(err.message, /3\/3 attempts/, 'proxy attempt count in message');
-      assert.ok(err.cause, 'Error.cause chain set');
-      return true;
-    },
-  );
-});
-
-// ─── Log ordering (P2 from PR #3120) ───────────────────────────────────
-
-test('proxy malformed JSON does NOT emit "succeeded" log before throwing', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-
-  const logs = [];
-  const originalLog = console.log;
-  console.log = (msg) => { logs.push(String(msg)); };
-  try {
+test('malformed configured proxies fail closed instead of falling through to direct', async () => {
+  for (const [env, expectedCode] of [
+    [{ GDELT_PROXY_URL: 'not-a-proxy' }, 'GDELT_SOURCE_PROXY_CONFIG'],
+    [{ PROXY_URL: 'not-a-proxy' }, 'GDELT_SHARED_PROXY_CONFIG'],
+  ]) {
+    setProxyEnv(env);
+    let directCalls = 0;
     await assert.rejects(
-      () => fetchGdeltJson(URL, {
-        ...COMMON_OPTS,
-        _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-        _proxyCurlFetcher: () => 'not-valid-json',
+      fetchGdeltJson(URL, {
+        label: 'military',
+        _fetch: async () => {
+          directCalls += 1;
+          throw new Error('known-blocked direct route must not run');
+        },
       }),
-      /GDELT retries exhausted/,
+      (error) => {
+        assert.equal(error.code, expectedCode);
+        return true;
+      },
     );
-  } finally {
-    console.log = originalLog;
+    assert.equal(directCalls, 0);
   }
-
-  const succeededLogged = logs.some((l) => l.includes('proxy (curl) succeeded'));
-  assert.equal(succeededLogged, false, 'success log MUST NOT fire when JSON.parse throws');
 });
 
-// ─── Direct-leg parse-failure must reach proxy (P2 from PR #3122 review) ──
-//
-// Previously `resp.json()` was called outside the try/catch that guards
-// fetch(), so a 200 OK with HTML/garbage body (WAF challenge, partial
-// response, gzip mismatch) would throw SyntaxError and escape the helper
-// — the proxy fallback never ran. The proxy leg already parsed inside
-// its own catch; the direct leg is now symmetric.
-
-test('direct 200 OK with malformed JSON: proxy fallback runs (P2 regression guard)', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-
+test('a caller cannot opt into direct while a proxy route is configured', async () => {
+  setProxyEnv({ GDELT_PROXY_URL: 'http://user:pass@gdelt-proxy.test:8100' });
   let directCalls = 0;
-  globalThis.fetch = async () => {
-    directCalls += 1;
-    return {
-      ok: true, status: 200,
-      headers: { get: () => null },
-      json: async () => { throw new SyntaxError('Unexpected token < in JSON'); },
-    };
-  };
-
-  let proxyCalls = 0;
-  const result = await fetchGdeltJson(URL, {
-    ...COMMON_OPTS,
-    maxRetries: 0,           // single direct attempt is enough to prove the path
-    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-    _proxyCurlFetcher: () => { proxyCalls += 1; return JSON.stringify(VALID_PAYLOAD); },
-  });
-
-  assert.equal(directCalls, 1);
-  assert.equal(proxyCalls, 1, 'direct parse-failure MUST reach the proxy fallback');
-  assert.deepEqual(result, VALID_PAYLOAD);
-});
-
-// ─── Helper API: caller-supplied budgets (knob behavior) ───────────────
-//
-// These tests lock the HELPER'S contract for arbitrary callers — they
-// assert the helper correctly honors caller-supplied budget overrides,
-// independent of any specific seeder's choice. Useful as documentation
-// of the helper API and as guard against future regressions where the
-// helper accidentally ignores a budget knob.
-//
-// NOTE: seed-gdelt-intel.mjs's fetchTopicTimeline currently uses 0/2
-// (1 direct + 2 proxy attempts). The 0/0 tests below cover the
-// minimal-budget extreme — they do NOT lock seed-gdelt-intel's choice.
-// A separate test below mirrors the seeder's actual 0/2 choice.
-
-test('maxRetries:0 + proxyMaxAttempts:0 → single direct attempt, no proxy, throws on first failure', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  let directCalls = 0;
-  let proxyCalls = 0;
-  globalThis.fetch = async () => {
-    directCalls += 1;
-    return { ok: false, status: 429, headers: { get: () => null }, json: async () => ({}) };
-  };
   await assert.rejects(
-    () => fetchGdeltJson(URL, {
-      label: 'best-effort',
-      maxRetries: 0,
+    fetchGdeltJson(URL, {
       proxyMaxAttempts: 0,
-      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-      _proxyCurlFetcher: () => { proxyCalls += 1; return JSON.stringify(VALID_PAYLOAD); },
-      _sleep: async () => {},
+      _fetch: async () => {
+        directCalls += 1;
+        throw new Error('known-blocked direct route must not run');
+      },
     }),
-    /GDELT retries exhausted/,
+    /direct fallback is disabled when a proxy is configured/,
   );
-  assert.equal(directCalls, 1, 'maxRetries:0 → single direct attempt');
-  assert.equal(proxyCalls, 0, 'proxyMaxAttempts:0 → proxy loop must NOT execute even when curl resolver is configured');
+  assert.equal(directCalls, 0);
 });
 
-test('proxyMaxAttempts:0 → no "trying proxy" log emitted (no misleading "up to 0×" line)', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  globalThis.fetch = async () => ({
-    ok: false, status: 429, headers: { get: () => null }, json: async () => ({}),
-  });
-  const logs = [];
-  const originalLog = console.log;
-  console.log = (msg) => { logs.push(String(msg)); };
-  try {
-    await assert.rejects(
-      () => fetchGdeltJson(URL, {
-        label: 'best-effort',
-        maxRetries: 0,
-        proxyMaxAttempts: 0,
-        _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-        _proxyCurlFetcher: () => JSON.stringify(VALID_PAYLOAD),
-        _sleep: async () => {},
-      }),
-      /GDELT retries exhausted/,
-    );
-  } finally { console.log = originalLog; }
-  const tryingLogged = logs.some((l) => l.includes('trying proxy'));
-  assert.equal(tryingLogged, false, 'no "trying proxy (curl) up to 0×" line — would be both wrong and noisy');
-});
-
-// ─── Seeder-mirror: 0/2 (matches seed-gdelt-intel:fetchTopicTimeline) ─
-
-test('maxRetries:0 + proxyMaxAttempts:2 (timeline budget): 1 direct + up to 2 proxy attempts, returns on first proxy success', async () => {
-  // Mirrors the budget seed-gdelt-intel.mjs:fetchTopicTimeline currently
-  // uses for best-effort timeline calls. Locks that 0/2 actually gives
-  // the timeline path a real recovery chance via proxy session rotation
-  // (which 0/0 would not).
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
+test('without a configured proxy, direct is attempted once', async () => {
+  setProxyEnv();
   let directCalls = 0;
-  let proxyCalls = 0;
-  globalThis.fetch = async () => {
-    directCalls += 1;
-    return { ok: false, status: 429, headers: { get: () => null }, json: async () => ({}) };
-  };
   const result = await fetchGdeltJson(URL, {
-    label: 'climate/TimelineTone',
-    maxRetries: 0,
-    proxyMaxAttempts: 2,
-    proxyRetryBaseMs: 10,
-    timeoutMs: 1000,
-    _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-    _proxyCurlFetcher: () => {
-      proxyCalls += 1;
-      if (proxyCalls === 1) throw new Error('HTTP 429');
-      return JSON.stringify(VALID_PAYLOAD);
+    label: 'military',
+    _fetch: async () => {
+      directCalls += 1;
+      return new Response(JSON.stringify(PAYLOAD), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
     },
-    _sleep: async () => {},
+    _proxyCurlFetcher: () => { throw new Error('proxy must not run'); },
   });
-  assert.equal(directCalls, 1, '0 direct retries → 1 direct attempt only');
-  assert.equal(proxyCalls, 2, '2 proxy attempts: 1st 429, 2nd succeeds');
-  assert.deepEqual(result, VALID_PAYLOAD);
+  assert.deepEqual(result, PAYLOAD);
+  assert.equal(directCalls, 1);
 });
 
-test('maxRetries:0 + proxyMaxAttempts:2: both proxy attempts fail → exhausted (no extra direct retries)', async () => {
-  const { fetchGdeltJson } = await import('../scripts/_gdelt-fetch.mjs');
-  let directCalls = 0;
+test('proxy HTTP 429 is classified and not retried', async () => {
+  setProxyEnv({ GDELT_PROXY_URL: 'http://user:pass@gdelt-proxy.test:8100' });
   let proxyCalls = 0;
-  globalThis.fetch = async () => {
-    directCalls += 1;
-    return { ok: false, status: 429, headers: { get: () => null }, json: async () => ({}) };
-  };
   await assert.rejects(
-    () => fetchGdeltJson(URL, {
-      label: 'climate/TimelineVol',
-      maxRetries: 0,
-      proxyMaxAttempts: 2,
-      proxyRetryBaseMs: 10,
-      timeoutMs: 1000,
-      _curlProxyResolver: () => 'user:pass@us.decodo.com:10001',
-      _proxyCurlFetcher: () => { proxyCalls += 1; throw new Error('HTTP 429'); },
-      _sleep: async () => {},
+    fetchGdeltJson(URL, {
+      label: 'military',
+      _fetch: async () => { throw new Error('direct must not run'); },
+      _proxyCurlFetcher: () => {
+        proxyCalls += 1;
+        throw Object.assign(new Error('HTTP 429'), { status: 429 });
+      },
     }),
-    (err) => {
-      assert.match(err.message, /GDELT retries exhausted/);
-      assert.match(err.message, /2\/2 attempts/, 'attempt count in message reflects the budget');
+    (error) => {
+      assert.equal(error.code, 'GDELT_SOURCE_PROXY_HTTP_429');
+      assert.equal(error.route, 'source-proxy');
       return true;
     },
   );
-  assert.equal(directCalls, 1, '0 direct retries → 1 direct attempt only');
-  assert.equal(proxyCalls, 2, 'proxy budget exhausted at 2');
+  assert.equal(proxyCalls, 1);
 });
 
-// ─── parseRetryAfterMs unit ─────────────────────────────────────────────
+test('proxy SSL_ERROR_SYSCALL is classified as TLS and not retried', async () => {
+  setProxyEnv({ GDELT_PROXY_URL: 'http://user:pass@gdelt-proxy.test:8100' });
+  let proxyCalls = 0;
+  await assert.rejects(
+    fetchGdeltJson(URL, {
+      label: 'military',
+      _proxyCurlFetcher: () => {
+        proxyCalls += 1;
+        throw new Error('curl failed: OpenSSL SSL_connect: SSL_ERROR_SYSCALL');
+      },
+    }),
+    (error) => {
+      assert.equal(error.code, 'GDELT_SOURCE_PROXY_TLS');
+      return true;
+    },
+  );
+  assert.equal(proxyCalls, 1);
+});
 
-test('parseRetryAfterMs: seconds + HTTP-date + null cases', async () => {
-  const { parseRetryAfterMs } = await import('../scripts/_gdelt-fetch.mjs');
-  assert.equal(parseRetryAfterMs(null), null);
-  assert.equal(parseRetryAfterMs(''), null);
-  assert.equal(parseRetryAfterMs('5'), 5_000);
-  assert.equal(parseRetryAfterMs('70'), 60_000, 'capped at MAX_RETRY_AFTER_MS=60_000');
-  const past = new Date(Date.now() - 30_000).toUTCString();
-  assert.equal(parseRetryAfterMs(past), 1000);
+test('direct 429 and timeout failures retain bounded route-specific codes', async () => {
+  setProxyEnv();
+  for (const [failure, expected] of [
+    [Object.assign(new Error('HTTP 429'), { status: 429 }), 'GDELT_DIRECT_HTTP_429'],
+    [Object.assign(new Error('connect timed out'), { code: 'UND_ERR_CONNECT_TIMEOUT' }), 'GDELT_DIRECT_TIMEOUT'],
+  ]) {
+    let directCalls = 0;
+    await assert.rejects(
+      fetchGdeltJson(URL, {
+        _fetch: async () => {
+          directCalls += 1;
+          throw failure;
+        },
+      }),
+      (error) => {
+        assert.equal(error.code, expected);
+        return true;
+      },
+    );
+    assert.equal(directCalls, 1);
+  }
+});
+
+test('malformed JSON is distinct from transport failure on both routes', async () => {
+  assert.equal(
+    classifyGdeltFetchError(new SyntaxError('Unexpected token <'), 'proxy'),
+    'GDELT_PROXY_INVALID_JSON',
+  );
+
+  setProxyEnv();
+  await assert.rejects(
+    fetchGdeltJson(URL, {
+      _fetch: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => { throw new SyntaxError('Unexpected token <'); },
+      }),
+    }),
+    (error) => {
+      assert.equal(error.code, 'GDELT_DIRECT_INVALID_JSON');
+      return true;
+    },
+  );
+});
+
+test('same-route retry knobs fail closed instead of restoring the retry storm', async () => {
+  await assert.rejects(
+    fetchGdeltJson(URL, { maxRetries: 1 }),
+    /same-route direct retries are disabled/,
+  );
+  await assert.rejects(
+    fetchGdeltJson(URL, { proxyMaxAttempts: 2 }),
+    /same-route proxy retries are disabled/,
+  );
 });

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -16,7 +16,14 @@ import assert from 'node:assert/strict';
 
 import { __testing__ } from '../api/health.js';
 
-const { classifyKey, STATUS_COUNTS, BOOTSTRAP_KEYS, STANDALONE_KEYS, SEED_META } = __testing__;
+const {
+  classifyKey,
+  healthResponseBody,
+  STATUS_COUNTS,
+  BOOTSTRAP_KEYS,
+  STANDALONE_KEYS,
+  SEED_META,
+} = __testing__;
 
 const NOW = 1_700_000_000_000;
 const ONE_MIN_MS = 60_000;
@@ -125,7 +132,7 @@ test('classifyKey: socialVelocity error seed-meta → SEED_ERROR while data is p
     }));
   assert.equal(entry.status, 'SEED_ERROR');
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
-  assert.equal(entry.records, 1);
+  assert.equal(entry.records, 5);
 });
 
 test('classifyKey: gdelt timeline repair metadata → SEED_ERROR while canonical articles remain available', () => {
@@ -137,14 +144,53 @@ test('classifyKey: gdelt timeline repair metadata → SEED_ERROR while canonical
           recordCount: 6,
           status: 'error',
           errorReason: 'timeline_keys_missing_or_unconfirmed',
+          errorCode: 'GDELT_SHARED_PROXY_TLS',
           missingTimelineKeys: ['gdelt:intel:vol:military'],
         }),
       },
     }));
   assert.equal(entry.status, 'SEED_ERROR');
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
-  assert.equal(entry.records, 1,
-    'SEED_ERROR preserves the canonical data-presence signal while surfacing the timeline outage');
+  assert.equal(entry.records, 6,
+    'SEED_ERROR preserves the declared canonical record count while surfacing the timeline outage');
+  assert.equal(entry.errorCode, 'GDELT_SHARED_PROXY_TLS');
+});
+
+test('classifyKey: unsafe free-form error codes are not reflected into health', () => {
+  const entry = classifyKey('gdeltIntel', BOOTSTRAP_KEYS.gdeltIntel, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.gdeltIntel]: 4096 },
+      metaValues: {
+        'seed-meta:intelligence:gdelt-intel': seedMeta({
+          status: 'error',
+          errorCode: 'proxy failed at https://user:pass@example.test',
+        }),
+      },
+    }));
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(Object.hasOwn(entry, 'errorCode'), false);
+});
+
+test('compact health preserves the bounded GDELT failure code', () => {
+  const snapshot = {
+    status: 'WARNING',
+    summary: { ok: 1, warn: 1, crit: 0 },
+    checkedAt: '2026-07-29T08:00:00.000Z',
+    checks: {
+      gdeltIntel: {
+        status: 'SEED_ERROR',
+        records: 6,
+        maxStaleMin: 720,
+        errorCode: 'GDELT_SHARED_PROXY_TLS',
+      },
+    },
+  };
+  assert.deepEqual(healthResponseBody(snapshot, true).problems.gdeltIntel, {
+    status: 'SEED_ERROR',
+    records: 6,
+    maxStaleMin: 720,
+    errorCode: 'GDELT_SHARED_PROXY_TLS',
+  });
 });
 
 test('classifyKey: degraded source with a non-positive or invalid fetchedAt exposes unknown age', () => {

--- a/tests/markets-news-wiring.test.mjs
+++ b/tests/markets-news-wiring.test.mjs
@@ -255,10 +255,11 @@ describe('misplaced-opts guard (#4929 external review)', () => {
 });
 
 describe('recall benchmark fast-fail wiring (source-textual)', () => {
-  it('uses benchmark-grade limits and a shared GDELT deadline', () => {
+  it('uses one selected-route attempt and a shared GDELT deadline', () => {
     const src = readSrc('scripts/seed-recall-benchmark.mjs');
-    assert.match(src, /maxRetries: 1/);
+    assert.match(src, /maxRetries: 0/);
     assert.match(src, /proxyMaxAttempts: 1/);
     assert.match(src, /GDELT_DEADLINE_MS = 4 \* 60 \* 1000/);
+    assert.match(src, /opening GDELT circuit; remaining verticals skipped[\s\S]*?\n\s*break;/);
   });
 });

--- a/tests/railway-services-registry-coverage.test.mts
+++ b/tests/railway-services-registry-coverage.test.mts
@@ -148,6 +148,7 @@ describe('Railway service registry coverage', () => {
     const PROXY_FALLBACK_RE =
       /process\.env\.([A-Z][A-Z0-9_]*_PROXY_URL)\s*\|\|\s*process\.env\.(PROXY_URL)\b/g;
     for (const file of [
+      'scripts/_gdelt-fetch.mjs',
       'scripts/seed-conflict-intel.mjs',
       'scripts/china-corporate-disclosures/adapters.mjs',
       'scripts/cross-strait-activity/adapters.mjs',
@@ -158,8 +159,8 @@ describe('Railway service registry coverage', () => {
       }
     }
     assert.ok(
-      fallbackPairs.length >= 3,
-      'expected the HAPI, SZSE and Japan MOD adapters to resolve a source-specific proxy with a PROXY_URL fallback',
+      fallbackPairs.length >= 4,
+      'expected the GDELT, HAPI, SZSE and Japan MOD adapters to resolve a source-specific proxy with a PROXY_URL fallback',
     );
 
     for (const [specific, shared] of fallbackPairs) {

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -291,7 +291,7 @@ test('GDELT 429 storm: sweep aborts after the first all-throttled batch', async 
   const result = await fetchGdeltConflictEvents({
     fetchCountryEvents: async (cc) => {
       attempted.push(cc);
-      return { country: cc, ok: false, events: [], error: 'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)' };
+      return { country: cc, ok: false, events: [], error: 'GDELT_SHARED_PROXY_HTTP_429' };
     },
     fetchBulkEvents: async () => { throw new Error('bulk export also throttled'); },
     pace: async () => {},
@@ -314,10 +314,10 @@ test('GDELT storm: aborts on a MIXED throttled batch (429 + SSL tear), not just 
   // and at least one failure is an explicit rate-limit.
   const attempted = [];
   const errors = [
-    'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)',
-    'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)',
-    'GDELT retries exhausted (last direct: HTTP 429) (last proxy: HTTP 429)',
-    'curl failed: curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL', // no 429 in this one
+    'GDELT_SHARED_PROXY_HTTP_429',
+    'GDELT_SHARED_PROXY_HTTP_429',
+    'GDELT_SHARED_PROXY_HTTP_429',
+    'GDELT_SHARED_PROXY_TLS',
   ];
   const result = await fetchGdeltConflictEvents({
     fetchCountryEvents: async (cc) => {
@@ -339,11 +339,7 @@ test('GDELT storm: aborts on a MIXED throttled batch (429 + SSL tear), not just 
   );
 });
 
-test('GDELT storm abort does NOT fire on an all-failed batch with NO rate-limit (SSL/timeout only)', async () => {
-  // PR#5290 review: without this, deleting `anyRateLimited` from the abort condition still
-  // passed every test. It is the clause that distinguishes "we are being throttled — backing
-  // off helps" from "transient per-country network failures — backing off just gives up
-  // early". A pure SSL/timeout wipeout must keep sweeping and let floorUnreachable decide.
+test('GDELT route circuit opens after one SSL/timeout canary failure', async () => {
   const attempted = [];
   await fetchGdeltConflictEvents({
     fetchCountryEvents: async (cc) => {
@@ -361,8 +357,8 @@ test('GDELT storm abort does NOT fire on an all-failed batch with NO rate-limit 
   }).catch(() => {});
 
   assert.ok(
-    attempted.length > 4,
-    `a non-throttled wipeout must not be mislabelled a rate-limit storm and cut short: attempted ${attempted.length}`,
+    attempted.length === 1,
+    `a selected-route TLS failure must not be repeated for another country: attempted ${attempted.length}`,
   );
 });
 

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -362,6 +362,32 @@ test('GDELT route circuit opens after one SSL/timeout canary failure', async () 
   );
 });
 
+test('GDELT route circuit opens after one proxy-auth canary failure', async () => {
+  for (const status of [401, 407]) {
+    const attempted = [];
+    await fetchGdeltConflictEvents({
+      fetchCountryEvents: async (cc) => {
+        attempted.push(cc);
+        return {
+          country: cc, ok: false, events: [],
+          error: `GDELT_SOURCE_PROXY_HTTP_${status}`,
+        };
+      },
+      fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
+      pace: async () => {},
+      now: () => 0,
+      deadlineAt: 10_000_000,
+      loadPreviousSnapshot: async () => null,
+    }).catch(() => {});
+
+    assert.equal(
+      attempted.length,
+      1,
+      `HTTP ${status} proxy auth failure must fall through to bulk without another country request`,
+    );
+  }
+});
+
 test('GDELT storm abort does NOT fire when a country in the batch succeeds', async () => {
   // The abort must never cut short a sweep that is actually working. One success in the
   // batch means we are not being uniformly throttled — keep going.

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -388,6 +388,73 @@ test('GDELT route circuit opens after one proxy-auth canary failure', async () =
   }
 });
 
+test('GDELT route circuit opens after one endpoint-wide HTTP canary failure', async () => {
+  for (const status of [404, 406, 410, 451]) {
+    const attempted = [];
+    let bulkCalls = 0;
+    const now = Date.parse('2026-07-29T12:00:00Z');
+    const result = await fetchGdeltConflictEvents({
+      fetchCountryEvents: async (cc) => {
+        attempted.push(cc);
+        return {
+          country: cc, ok: false, events: [],
+          error: `GDELT_SOURCE_PROXY_HTTP_${status}`,
+        };
+      },
+      fetchBulkEvents: async () => {
+        bulkCalls += 1;
+        return {
+          events: [{ id: `route-failure-${status}`, country: 'Sudan' }],
+          exportTimestamp: '20260729110000',
+          exportsRequested: 1,
+          exportsSucceeded: 1,
+        };
+      },
+      pace: async () => {},
+      now: () => now,
+      deadlineAt: now + 10_000_000,
+      loadPreviousSnapshot: async () => null,
+    });
+
+    assert.equal(
+      attempted.length,
+      1,
+      `HTTP ${status} endpoint failure must fall through to bulk without another country request`,
+    );
+    assert.equal(bulkCalls, 1);
+    assert.equal(result.source, 'gdelt-bulk');
+    assert.deepEqual(result.events.map(event => event.id), [`route-failure-${status}`]);
+  }
+});
+
+test('GDELT route circuit stays closed for a request-specific HTTP failure', async () => {
+  const attempted = [];
+  const result = await fetchGdeltConflictEvents({
+    fetchCountryEvents: async (cc) => {
+      attempted.push(cc);
+      if (attempted.length === 1) {
+        return {
+          country: cc, ok: false, events: [],
+          error: 'GDELT_SOURCE_PROXY_HTTP_400',
+        };
+      }
+      return {
+        country: cc,
+        ok: true,
+        events: [{ id: `country-${cc}`, country: cc, event_date: '2026-07-29' }],
+      };
+    },
+    fetchBulkEvents: async () => { throw new Error('bulk unused'); },
+    pace: async () => {},
+    now: () => 0,
+    deadlineAt: 10_000_000,
+    loadPreviousSnapshot: async () => null,
+  });
+
+  assert.equal(attempted.length, CONFLICT_COUNTRIES.length);
+  assert.equal(result.source, 'gdelt');
+});
+
 test('GDELT storm abort does NOT fire when a country in the batch succeeds', async () => {
   // The abort must never cut short a sweep that is actually working. One success in the
   // batch means we are not being uniformly throttled — keep going.

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -31,13 +31,20 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
   it('gdelt-intel: soft budget fires before the hard deadline, leaving merge+publish headroom', () => {
     const src = read('seed-gdelt-intel.mjs');
     const soft = optValue(src, 'FETCH_SOFT_BUDGET_MS');
-    const minTopic = optValue(src, 'MIN_TOPIC_BUDGET_MS');
+    const minRequest = optValue(src, 'MIN_REQUEST_BUDGET_MS');
+    const requestDelay = optValue(src, 'GDELT_REQUEST_DELAY_MS');
+    const hardDeadline = optValue(src, 'RUN_SEED_FETCH_PHASE_TIMEOUT_MS');
     assert.ok(soft, 'FETCH_SOFT_BUDGET_MS must be defined');
-    // gdelt keeps the default lock (120s) → hard deadline 240s. The soft budget must
-    // trip well before that so the cache-merge + publish complete inside the deadline.
-    const hardDeadline = deadlineFromLock(120_000);
+    assert.ok(hardDeadline, 'RUN_SEED_FETCH_PHASE_TIMEOUT_MS must be defined');
+    // The soft budget must trip well before the explicit hard deadline so the
+    // cache-merge + publish complete inside it.
     assert.ok(soft + 60_000 <= hardDeadline, `soft budget ${soft}ms + merge headroom must stay under the ${hardDeadline}ms hard deadline`);
-    assert.ok(minTopic && minTopic > 0 && minTopic < soft, 'MIN_TOPIC_BUDGET_MS must be a positive fraction of the soft budget');
+    assert.ok(minRequest && minRequest > 0 && minRequest < soft, 'MIN_REQUEST_BUDGET_MS must be a positive fraction of the soft budget');
+    assert.ok(requestDelay && requestDelay >= 5_000, 'healthy DOC requests must remain evenly paced');
+    assert.ok(
+      (17 * requestDelay) + minRequest < soft,
+      '18 paced DOC calls must leave response-time budget before the final request starts',
+    );
   });
 
   it('grocery-basket: lock/deadline covers its ~600s degraded serial runtime (24 serial countries)', () => {
@@ -68,21 +75,19 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
     } = await import('../scripts/seed-conflict-intel.mjs');
     const { GDELT_BULK_WORST_NETWORK_MS } = await import('../scripts/_conflict-gdelt-bulk.mjs');
 
-    // maxRetries MUST stay 0: a second direct attempt honors GDELT's Retry-After
-    // header (≤60s sleep, MAX_RETRY_AFTER_MS in _gdelt-fetch.mjs), voiding any
-    // per-batch bound computed below.
+    // The transport rejects same-route retries; this caller pins that contract.
     assert.equal(GDELT_COUNTRY_FETCH_OPTS.maxRetries, 0,
-      'direct retries reintroduce the ≤60s Retry-After sleep into the batch bound');
+      'direct same-route retries must remain disabled');
 
-    // Worst in-flight batch: 4 concurrent direct legs (15s AbortSignal timeout,
-    // _gdelt-fetch.mjs default) + CONCURRENCY × proxyMaxAttempts SERIALIZED sync
-    // proxy curls (curlFetch is execFileSync with a 20s ceiling — proxy attempts
-    // block the event loop one at a time, so they sum across the whole batch).
+    // One route is selected. Direct legs overlap; proxy curls are synchronous
+    // and therefore serialize across the batch.
     const DIRECT_LEG_MS = 15_000;
     const PROXY_CURL_CEILING_MS = 20_000;
     const SWEEP_CONCURRENCY = 4;
-    const worstBatch = DIRECT_LEG_MS
-      + SWEEP_CONCURRENCY * GDELT_COUNTRY_FETCH_OPTS.proxyMaxAttempts * PROXY_CURL_CEILING_MS;
+    const worstBatch = Math.max(
+      DIRECT_LEG_MS,
+      SWEEP_CONCURRENCY * GDELT_COUNTRY_FETCH_OPTS.proxyMaxAttempts * PROXY_CURL_CEILING_MS,
+    );
 
     // HAPI aux worst: 20 sequential countries × (15s timeout + 300ms pace). It
     // precedes the sweep inside the same fetch phase, and the sweep cutoff is

--- a/tests/seed-gdelt-intel-fetch-budget.test.mjs
+++ b/tests/seed-gdelt-intel-fetch-budget.test.mjs
@@ -3,8 +3,8 @@
 // "crash" email) instead of falling through to its 24h cached-snapshot merge.
 //
 // The bug: the hard raceFetchDeadline wraps the WHOLE fetch phase, so a slow
-// topic ladder (~3.5min each) plus the inter-topic (20s×5) + post-exhaust (120s)
-// cooldowns pushed fetchAllTopics past 240s and it was killed BEFORE reaching the
+// retry-heavy topic ladder pushed fetchAllTopics past 240s and it was killed
+// BEFORE reaching the
 // cache-merge that backfills 429'd topics from the prior snapshot.
 //
 // The fix: an internal wall-clock soft budget that (a) bounds each single topic
@@ -32,7 +32,7 @@ const cachedSnapshot = () => ({
 describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
   it('fatal runSeed rejection exits nonzero so Railway/bundles see the failure', () => {
     const source = readFileSync(new URL('../scripts/seed-gdelt-intel.mjs', import.meta.url), 'utf8');
-    const fatalCatch = source.match(/\.catch\(\(err\) => \{[\s\S]*?console\.error\('FATAL:'[\s\S]*?\n  \}\);/);
+    const fatalCatch = source.match(/\.catch\(\(err\) => \{[\s\S]*?console\.error\('FATAL:'[\s\S]*?\n {2}\}\);/);
 
     assert.ok(fatalCatch, 'seed-gdelt-intel must keep an explicit fatal catch');
     assert.match(fatalCatch[0], /process\.exit\(1\)/);
@@ -62,7 +62,7 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
     const started = Date.now();
     const out = await fetchAllTopics({
       _softBudgetMs: 150,
-      _minTopicBudgetMs: 20,       // allow one topic to be attempted, then break
+      _minRequestBudgetMs: 20,     // allow one request to be attempted, then break
       _sleep: async () => {},
       _fetchArticles: () => { attempts++; return new Promise(() => {}); }, // never settles
       _fetchTimeline: async () => [],
@@ -97,20 +97,125 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
     }
   });
 
-  it('mixed: fresh where the fetch succeeds, cached where it 429s', async () => {
-    let n = 0;
+  it('paces every healthy DOC request instead of bursting article/tone/volume', async () => {
+    const sleeps = [];
+    await fetchAllTopics({
+      _softBudgetMs: 60_000,
+      _interRequestDelayMs: 5_500,
+      _sleep: async (ms) => { sleeps.push(ms); },
+      _fetchArticles: async (topic) => ({
+        id: topic.id,
+        articles: [{ title: `fresh ${topic.id}`, url: `https://example.test/live/${topic.id}` }],
+        fetchedAt: 'NOW',
+      }),
+      _fetchTimeline: async () => ({ points: [{ date: '2026-07-05', value: 1 }], errorCode: null }),
+      _loadPrevious: async () => { throw new Error('cache must not be consulted'); },
+    });
+
+    assert.equal(sleeps.length, 17, '18 DOC calls have exactly 17 inter-request gaps');
+    assert.equal(sleeps.every((ms) => ms === 5_500), true);
+  });
+
+  it('article transport failure opens the run circuit before timelines or later topics', async () => {
+    const articleCalls = [];
+    const timelineCalls = [];
     const out = await fetchAllTopics({
       _softBudgetMs: 60_000,
       _sleep: async () => {},
       _fetchArticles: async (topic) => {
-        n++;
-        if (n <= 2) return { id: topic.id, articles: [{ title: `fresh ${topic.id}`, url: `https://x/${topic.id}` }], fetchedAt: 'NOW' };
-        return { id: topic.id, articles: [], fetchedAt: 'NOW', exhausted: true }; // 429 → empty
+        articleCalls.push(topic.id);
+        return {
+          id: topic.id,
+          articles: [],
+          fetchedAt: 'NOW',
+          failureCode: 'GDELT_SHARED_PROXY_HTTP_429',
+        };
       },
-      _fetchTimeline: async () => [],
+      _fetchTimeline: async (topic, mode) => {
+        timelineCalls.push(`${topic.id}/${mode}`);
+        return { points: [], errorCode: null };
+      },
       _loadPrevious: async () => cachedSnapshot(),
     });
-    assert.equal(out.topics.find((t) => t.id === TOPIC_IDS[0]).articles[0].title, `fresh ${TOPIC_IDS[0]}`);
-    assert.equal(out.topics.find((t) => t.id === TOPIC_IDS[5]).articles[0].title, `cached ${TOPIC_IDS[5]}`);
+    assert.deepEqual(articleCalls, ['military']);
+    assert.deepEqual(timelineCalls, [], 'a failed article route must not launch tone/vol');
+    assert.equal(out._gdeltFailureCode, 'GDELT_SHARED_PROXY_HTTP_429');
+    assert.equal(out._freshTopicCount, 0);
+    for (const id of TOPIC_IDS) {
+      assert.equal(out.topics.find((t) => t.id === id).articles[0].title, `cached ${id}`);
+    }
+  });
+
+  it('first timeline transport failure is sequential and stops the remaining DOC fanout', async () => {
+    const articleCalls = [];
+    const timelineCalls = [];
+    const out = await fetchAllTopics({
+      _softBudgetMs: 60_000,
+      _sleep: async () => {},
+      _fetchArticles: async (topic) => {
+        articleCalls.push(topic.id);
+        return {
+          id: topic.id,
+          articles: [{ title: `fresh ${topic.id}`, url: `https://x/${topic.id}` }],
+          fetchedAt: 'NOW',
+        };
+      },
+      _fetchTimeline: async (topic, mode) => {
+        timelineCalls.push(`${topic.id}/${mode}`);
+        return { points: [], errorCode: 'GDELT_SHARED_PROXY_TLS' };
+      },
+      _loadPrevious: async () => cachedSnapshot(),
+    });
+    assert.deepEqual(articleCalls, ['military']);
+    assert.deepEqual(timelineCalls, ['military/TimelineTone']);
+    assert.equal(out._gdeltFailureCode, 'GDELT_SHARED_PROXY_TLS');
+    assert.equal(out._freshTopicCount, 1);
+    assert.equal(out.topics[0].articles[0].title, 'fresh military');
+    assert.equal(out.topics[1].articles[0].title, 'cached cyber');
+  });
+
+  it('does not launch a timeline after the article consumes the remaining budget', async () => {
+    let now = 0;
+    let timelineCalls = 0;
+    const out = await fetchAllTopics({
+      _now: () => now,
+      _softBudgetMs: 100,
+      _minRequestBudgetMs: 1,
+      _sleep: async () => {},
+      _fetchArticles: async (topic) => {
+        now = 100;
+        return {
+          id: topic.id,
+          articles: [{ title: `fresh ${topic.id}`, url: `https://x/${topic.id}` }],
+          fetchedAt: 'NOW',
+        };
+      },
+      _fetchTimeline: async () => {
+        timelineCalls += 1;
+        return { points: [], errorCode: null };
+      },
+      _loadPrevious: async () => cachedSnapshot(),
+    });
+
+    assert.equal(timelineCalls, 0, 'an exhausted budget must not create another request');
+    assert.equal(out._gdeltFailureCode, 'GDELT_FETCH_BUDGET_EXCEEDED');
+    assert.equal(out._freshTopicCount, 1);
+  });
+
+  it('all-empty successful ArticleList responses remain honestly degraded after cache backfill', async () => {
+    const out = await fetchAllTopics({
+      _softBudgetMs: 60_000,
+      _sleep: async () => {},
+      _fetchArticles: async (topic) => ({
+        id: topic.id,
+        articles: [],
+        fetchedAt: 'NOW',
+      }),
+      _fetchTimeline: async () => ({ points: [], errorCode: null }),
+      _loadPrevious: async () => cachedSnapshot(),
+    });
+    assert.equal(out._gdeltFailureCode, 'GDELT_EMPTY_ARTICLE_RESULTS');
+    assert.equal(out._freshTopicCount, 0);
+    assert.equal(out.topics.every((topic) => topic.fetchedAt === 'PREV'), true);
   });
 });

--- a/tests/seed-gdelt-intel-timeline-resilience.test.mjs
+++ b/tests/seed-gdelt-intel-timeline-resilience.test.mjs
@@ -152,6 +152,32 @@ test('afterPublish reports only the failed key from mixed EXPIRE results', async
   assert.deepEqual(outcome.freshnessMetaPatch.missingTimelineKeys, ['gdelt:intel:vol:cyber']);
 });
 
+test('afterPublish surfaces the bounded transport code even while last-good timelines survive', async () => {
+  globalThis.fetch = async (url, opts = {}) => {
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u: String(url), body });
+    if (String(url).endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    return jsonResponse({ result: 'OK' });
+  };
+
+  const outcome = await afterPublish({
+    fetchedAt: '2026-07-29T08:00:00.000Z',
+    _gdeltFailureCode: 'GDELT_SHARED_PROXY_TLS',
+    _freshTopicCount: 0,
+    topics: [{ id: 'military', _tone: [], _vol: [] }],
+  });
+
+  assert.deepEqual(outcome, {
+    completionState: 'DEGRADED',
+    freshnessMetaPatch: {
+      status: 'error',
+      errorReason: 'gdelt_upstream_unavailable',
+      errorCode: 'GDELT_SHARED_PROXY_TLS',
+      freshTopicCount: 0,
+    },
+  });
+});
+
 test('fetchTopicTimeline keeps normal fetches best-effort but rethrows in strict repair mode', async () => {
   const exhausted = new Error('GDELT exhausted after proxy attempts: HTTP 429');
   const topic = { id: 'military', query: 'military sourcelang:eng' };
@@ -218,6 +244,29 @@ test('repairTimelines does not report OK when any absent key cannot be fetched',
       && warning.includes('GDELT exhausted after proxy attempts: HTTP 429')),
     `repair warning must retain the exhausted fetch error; warnings were: ${JSON.stringify(warns)}`,
   );
+});
+
+test('repairTimelines opens a circuit after the first transport failure', async () => {
+  let fetchCount = 0;
+  const transportError = Object.assign(new Error('SSL_ERROR_SYSCALL'), {
+    code: 'GDELT_SHARED_PROXY_TLS',
+  });
+  const result = await repairTimelines({
+    _readTimeline: async () => null,
+    _fetchTimeline: async () => {
+      fetchCount += 1;
+      throw transportError;
+    },
+    _writeTimeline: async () => assert.fail('failed transport must not write'),
+    _extendTtl: async () => false,
+    _sleep: async () => {},
+    _interRequestDelayMs: 0,
+  });
+
+  assert.equal(fetchCount, 1, 'the remaining eleven keys must not repeat the failed route');
+  assert.equal(result.completionState, 'DEGRADED');
+  assert.equal(result.errorCode, 'GDELT_SHARED_PROXY_TLS');
+  assert.equal(result.failedKeys.length, 12);
 });
 
 test('repairTimelines preserves existing data when TTL extension succeeds and repairs when it fails', async () => {
@@ -609,7 +658,7 @@ test('contentMeta ignores articleless topics so a total outage cannot mask STALE
 test('runSeed opts wire in the content-age trio and the resilient afterPublish', () => {
   assert.equal(RUN_SEED_OPTS.contentMeta, contentMeta, 'content-age opt-in must use the exported contentMeta');
   assert.equal(RUN_SEED_OPTS.maxContentAgeMin, 1440,
-    '24h = 4x the 6h cadence; only a real brownout (every topic failing every run for a day) trips STALE_CONTENT');
+    '24h = 6x the 4h cadence; only a real brownout (every topic failing every run for a day) trips STALE_CONTENT');
   assert.equal(RUN_SEED_OPTS.lockTtlMs, GDELT_LOCK_TTL_MS,
     'scheduled seed and repair must share the same full-operation ownership budget');
   assert.ok(RUN_SEED_OPTS.lockTtlMs > 75 * 60_000,
@@ -617,4 +666,23 @@ test('runSeed opts wire in the content-age trio and the resilient afterPublish',
   assert.equal(RUN_SEED_OPTS.afterPublish, afterPublish, 'main entry must run the degrade-not-crash afterPublish');
   assert.equal(typeof RUN_SEED_OPTS.validateFn, 'function');
   assert.equal(RUN_SEED_OPTS.declareRecords.length, 1);
+});
+
+test('canonical publication strips run diagnostics while seed-meta can still consume them', () => {
+  const published = RUN_SEED_OPTS.publishTransform({
+    fetchedAt: '2026-07-29T08:00:00.000Z',
+    _gdeltFailureCode: 'GDELT_SHARED_PROXY_HTTP_429',
+    _freshTopicCount: 0,
+    topics: [{
+      id: 'military',
+      articles: [{ title: 'cached', url: 'https://example.test/cached' }],
+      failureCode: 'GDELT_SHARED_PROXY_HTTP_429',
+      budgetExceeded: false,
+      _tone: [],
+      _vol: [],
+    }],
+  });
+  assert.equal(Object.hasOwn(published, '_gdeltFailureCode'), false);
+  assert.equal(Object.hasOwn(published, '_freshTopicCount'), false);
+  assert.deepEqual(Object.keys(published.topics[0]).sort(), ['articles', 'id']);
 });


### PR DESCRIPTION
## Summary

- Replace the retry ladder with one selected GDELT DOC route: `GDELT_PROXY_URL`, then `PROXY_URL`, then direct only when no proxy is configured. Each request is attempted once, and malformed proxy configuration fails closed.
- Pace the healthy 18-request intelligence sweep and open a run-scoped circuit after the first article, timeline, or budget failure. Preserve last-good content, but publish an honest bounded `SEED_ERROR` code instead of making cached data look fresh.
- Probe one conflict country before widening; on a selected-route failure, fall through to the existing official GDELT Events bulk export. Apply the same run circuit to recall benchmarking and timeline repair.
- Preserve true record counts and safe route-specific error codes in compact health output.

## Root cause and scope

Read-only production evidence showed that one ArticleList operation expanded into four direct attempts and five proxy curls before later Tone/Volume queries continued on the same failing route. Railway direct traffic returned HTTP 429; the configured shared proxy returned 429, timed out, or failed TLS with `SSL_ERROR_SYSCALL`.

The production service currently declares `PROXY_URL` but not `GDELT_PROXY_URL`. This change creates a source-specific replacement seam without bypassing a configured proxy or silently returning to direct Railway egress.

GDELT DOC ArticleList, TimelineTone, and TimelineVol are the required semantic surface for this payload. The official raw Events export remains valid for conflict events, but raw GKG/Event files and Web NGrams do not preserve article-list plus topic-timeline semantics, so this PR does not substitute them into the intelligence payload.

No Railway variables, deployments, schedules, Redis records, or production seed runs were mutated while validating this change.

## Verification

- `TMPDIR=/private/tmp node --import tsx --test ...` — 183 focused executable-seam tests passed after rebasing onto current `origin/main`.
- `env -u UPSTASH_REDIS_REST_URL -u UPSTASH_REDIS_REST_TOKEN TMPDIR=/private/tmp npm run test:data` — 18,795 passed, 6 skipped, 0 failed.
- `npm run typecheck` — passed.
- `npm run typecheck:api` — passed.
- `npm run lint` — passed with existing repository warnings; safe HTML guard passed.
- `TMPDIR=/private/tmp VITE_VARIANT=full ./node_modules/.bin/vite build` — passed.
- Full pre-push gate — passed, including edge bundling, architecture/security guards, 1,018 resilience tests, 157 changed-file tests, and 240 edge tests.

## Post-Deploy Monitoring & Validation

Owner: ingestion operations.

1. Provision and verify a dedicated `GDELT_PROXY_URL` from the `seed-gdelt-intel` Railway environment before treating this as source recovery. The existing shared `PROXY_URL` is known-bad for this source.
2. After deployment, observe the first scheduled run and at least one complete four-hour cadence.
3. Search logs for `source-proxy succeeded`, `opening run circuit`, `GDELT_SOURCE_PROXY_`, `seed_complete`, and `gdelt_timeline_repair`.
4. Acceptance requires fresh articles from the scheduled run, all twelve tone/volume timeline keys present, and `/api/health?compact=1` no longer reporting `gdeltIntel` as `SEED_ERROR`.
5. If the source-specific route still returns 429/TLS/timeout errors, replace or rotate that route. Do not restore same-route retries. Roll back only for a publication/health contract regression, since rollback restores the request storm.

## Related

Refs #5768 and #5770. These issues should remain open until the deployed source-specific route survives the production cadence and the read-only health gates above.

---

[![Compound Engineering](https://img.shields.io/badge/Compound%20Engineering-enabled-6f42c1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)