### PR TITLE
fix(mcp): preserve conflict events within output budget

### DIFF
--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -110,7 +110,7 @@ export async function executeTool(
   // the filter so it composes (`country: "DE", summary: true` → counts/samples
   // for DE). Independent of filter success: a thrown filter still pristine-
   // summarises.
-  if (argBool(params.summary)) result = summarizeData(result);
+  if (argBool(params.summary)) result = tool._summarize ? tool._summarize(result) : summarizeData(result);
 
   return { cached_at, stale, data: result };
 }

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -30,6 +30,7 @@ import {
   pickMapKeysLike,
   pickNestedMap,
   selectDatasets,
+  summarizeData,
 } from '../filters';
 import type { ToolDef } from '../types';
 import { utf8ByteLength } from '../utils';
@@ -117,6 +118,32 @@ function fitConflictEventsToBudget(data: Record<string, unknown>): void {
     caps.set(label, feedLow);
     applyCaps();
   }
+}
+
+function summarizeConflictEvents(data: Record<string, unknown>): Record<string, unknown> {
+  const summary = summarizeData(data);
+  if (utf8ByteLength(JSON.stringify(summary)) <= CONFLICT_EVENTS_DATA_BUDGET_BYTES) return summary;
+
+  const samples = CONFLICT_EVENT_LISTS.flatMap((label) => {
+    const parent = summary[label];
+    if (!parent || typeof parent !== 'object' || Array.isArray(parent)) return [];
+    const events = (parent as Record<string, unknown>).events;
+    if (!events || typeof events !== 'object' || Array.isArray(events)) return [];
+    const sample = (events as Record<string, unknown>).sample;
+    return Array.isArray(sample) ? [{ sample, original: [...sample] }] : [];
+  });
+
+  for (const { sample } of samples) sample.length = 0;
+  const maxSampleLength = Math.max(0, ...samples.map(({ original }) => original.length));
+  for (let index = 0; index < maxSampleLength; index++) {
+    for (const { sample, original } of samples) {
+      if (index >= original.length) continue;
+      sample.push(original[index]);
+      if (utf8ByteLength(JSON.stringify(summary)) > CONFLICT_EVENTS_DATA_BUDGET_BYTES) sample.pop();
+    }
+  }
+
+  return summary;
 }
 
 function addNewsSourceProvenance(value: unknown): unknown {
@@ -404,6 +431,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       },
     }),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    _summarize: summarizeConflictEvents,
     _postFilter: (data, params) => {
       const country = argStr(params.country);
       const minFatal = argNum(params.min_fatalities);

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -32,6 +32,7 @@ import {
   selectDatasets,
 } from '../filters';
 import type { ToolDef } from '../types';
+import { utf8ByteLength } from '../utils';
 import {
   CHOKEPOINT_MONITOR_UI_URI,
   CONFLICT_EVENTS_UI_URI,
@@ -48,6 +49,75 @@ import {
 // The output schema still documents an iran-events field (harmless when absent).
 // Set IRAN_EVENTS_ENABLED=true to restore. See api/health.js.
 const IRAN_EVENTS_ENABLED = (process.env.IRAN_EVENTS_ENABLED ?? 'false').toLowerCase() === 'true';
+// Leave headroom for the cache envelope (`cached_at`, `stale`, and `data`) so
+// the dispatcher never replaces a useful conflict response with the generic
+// `_budget_exceeded` envelope.
+const CONFLICT_EVENTS_OUTPUT_BUDGET_BYTES = 128 * 1024;
+const CONFLICT_EVENTS_DATA_BUDGET_BYTES = CONFLICT_EVENTS_OUTPUT_BUDGET_BYTES - 1024;
+const CONFLICT_EVENT_LISTS = ['ucdp-events', 'iran-events', 'events'] as const;
+
+function fitConflictEventsToBudget(data: Record<string, unknown>): void {
+  const lists = CONFLICT_EVENT_LISTS.flatMap((label) => {
+    const parent = data[label];
+    if (!parent || typeof parent !== 'object' || Array.isArray(parent)) return [];
+    const events = (parent as Record<string, unknown>).events;
+    return Array.isArray(events) ? [{ label, events }] : [];
+  });
+  const originalEventCount = lists.reduce((sum, { events }) => sum + events.length, 0);
+  if (originalEventCount === 0) return;
+
+  const byteLength = () => utf8ByteLength(JSON.stringify(data));
+  if (byteLength() <= CONFLICT_EVENTS_DATA_BUDGET_BYTES) return;
+
+  data.partial = true;
+  const truncation = {
+    reason: 'output_budget',
+    original_event_count: originalEventCount,
+    returned_event_count: 0,
+  };
+  data.truncation = truncation;
+
+  const caps = new Map(lists.map(({ label }) => [label, 0]));
+  const applyCaps = () => {
+    let returnedEventCount = 0;
+    for (const { label, events } of lists) {
+      const parent = data[label] as Record<string, unknown>;
+      const bounded = events.slice(0, caps.get(label) ?? 0);
+      parent.events = bounded;
+      returnedEventCount += bounded.length;
+    }
+    truncation.returned_event_count = returnedEventCount;
+  };
+
+  let low = 0;
+  let high = Math.max(...lists.map(({ events }) => events.length));
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    for (const { label } of lists) caps.set(label, mid);
+    applyCaps();
+    if (byteLength() <= CONFLICT_EVENTS_DATA_BUDGET_BYTES) low = mid;
+    else high = mid - 1;
+  }
+  for (const { label } of lists) caps.set(label, low);
+  applyCaps();
+
+  // Spend any remaining budget per feed. This preserves the fair common
+  // prefix above while ensuring one oversized feed cannot force every other
+  // source to return zero usable events.
+  for (const { label, events } of lists) {
+    let feedLow = caps.get(label) ?? 0;
+    let feedHigh = events.length;
+    while (feedLow < feedHigh) {
+      const mid = Math.ceil((feedLow + feedHigh) / 2);
+      caps.set(label, mid);
+      applyCaps();
+      if (byteLength() <= CONFLICT_EVENTS_DATA_BUDGET_BYTES) feedLow = mid;
+      else feedHigh = mid - 1;
+    }
+    caps.set(label, feedLow);
+    applyCaps();
+  }
+}
 
 function addNewsSourceProvenance(value: unknown): unknown {
   if (!Array.isArray(value)) return value;
@@ -262,7 +332,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   {
     name: 'get_conflict_events',
     _uiResourceUri: CONFLICT_EVENTS_UI_URI,
-    _outputBudgetBytes: 131072,
+    _outputBudgetBytes: CONFLICT_EVENTS_OUTPUT_BUDGET_BYTES,
     description: 'Active armed conflict events (UCDP, Iran), unrest events with geo-coordinates, and country risk scores. Covers ongoing conflicts, protests, and instability indices worldwide.',
     inputSchema: {
       type: 'object',
@@ -323,6 +393,15 @@ export const CACHE_TOOLS: ToolDef[] = [
           strategicRisks: { type: ['array', 'object', 'null'] },
         },
       },
+      partial: { type: 'boolean', description: 'True when event lists were shortened to fit the MCP output budget.' },
+      truncation: {
+        type: 'object',
+        properties: {
+          reason: { type: 'string' },
+          original_event_count: { type: 'number' },
+          returned_event_count: { type: 'number' },
+        },
+      },
     }),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _postFilter: (data, params) => {
@@ -338,7 +417,8 @@ export const CACHE_TOOLS: ToolDef[] = [
         narrowNested(data, 'ucdp-events', 'events', (e) => (argNum(e.deathsBest) ?? 0) >= minFatal);
         narrowNested(data, 'events', 'events', (e) => (argNum(e.fatalities) ?? 0) >= minFatal);
       }
-      for (const label of ['ucdp-events', 'iran-events', 'events']) capNested(data, label, 'events', limit);
+      for (const label of CONFLICT_EVENT_LISTS) capNested(data, label, 'events', limit);
+      if (!argBool(params.summary) && !argStr(params.jmespath)) fitConflictEventsToBudget(data);
       return data;
     },
     _cacheKeys: [

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -152,6 +152,10 @@ export interface CacheToolDef extends BaseToolDef {
   // declared in the same tool's `inputSchema.properties` (schema and behaviour
   // co-located so the advertised contract can never drift from what runs).
   _postFilter?: (data: Record<string, unknown>, params: Record<string, unknown>) => Record<string, unknown>;
+  // Optional tool-specific summary transform. Most cache tools use the shared
+  // `summarizeData`; tools with tighter output invariants can preserve the
+  // shared count/sample shape while additionally bounding optional samples.
+  _summarize?: (data: Record<string, unknown>) => Record<string, unknown>;
   // U3 (Tier-4 parity): REQUIRED. Every OpenAPI operation served by this
   // tool's cache keys ("METHOD path") so the U5 MCP↔API parity test can
   // verify every op in docs/api/*.openapi.json is covered by some tool's

--- a/api/mcp/ui/conflict-events-app.ts
+++ b/api/mcp/ui/conflict-events-app.ts
@@ -91,9 +91,19 @@ const RENDER = `
         : "Conflict event data is temporarily unavailable."));
     }
 
-    q("foot").textContent = data.cached_at
-      ? "Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : "")
-      : "";
+    var footParts = [];
+    if (d.partial === true && d.truncation && typeof d.truncation === "object") {
+      var returnedCount = num(d.truncation.returned_event_count);
+      var originalCount = num(d.truncation.original_event_count);
+      if (returnedCount != null && originalCount != null) {
+        footParts.push("Source response includes " + returnedCount.toLocaleString() + " of "
+          + originalCount.toLocaleString() + " events (output limit).");
+      }
+    }
+    if (data.cached_at) {
+      footParts.push("Snapshot: " + collapseWs(data.cached_at) + (data.stale ? " (stale)" : ""));
+    }
+    q("foot").textContent = footParts.join(" ");
 `;
 
 export const CONFLICT_EVENTS_APP_HTML = buildAppHtml({

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -749,6 +749,30 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     }
   });
 
+  it('conflict-events widget distinguishes byte-truncated responses from complete results', async () => {
+    const res = await handler(envKeyReq(readBody('ui://worldmonitor/conflict-events.html')));
+    const html = (await res.json()).result.contents[0].text;
+    const payload = {
+      data: {
+        'ucdp-events': { events: [{ sideA: 'Side A', sideB: 'Side B' }] },
+        partial: true,
+        truncation: {
+          reason: 'output_budget',
+          original_event_count: 1000,
+          returned_event_count: 375,
+        },
+      },
+    };
+
+    const partialView = mountWidgetHtml(html);
+    partialView.sendToolResult(payload);
+    assert.match(partialView.text('foot'), /Source response includes 375 of 1,000 events \(output limit\)\./);
+
+    const completeView = mountWidgetHtml(html);
+    completeView.sendToolResult({ data: { 'ucdp-events': { events: [] } } });
+    assert.doesNotMatch(completeView.text('foot'), /output limit/i, 'complete responses must not show truncation copy');
+  });
+
   it('EXPANSION WIDGETS: hostile tool text stays literal textContent in all five renderers', async () => {
     const hostile = '<img src=x onerror="globalThis.pwned=true">';
     const cases = [

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -1389,6 +1389,23 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(out.data.partial, undefined, 'summary mode fits naturally and must not report source truncation');
   });
 
+  it('get_conflict_events preserves summary counts when one sample event exceeds the output budget', async () => {
+    mockCacheKeys(
+      {
+        'conflict:ucdp-events:v1': {
+          events: [{ id: 'oversized', country: 'X', sourceOriginal: 'x'.repeat(140 * 1024) }],
+        },
+      },
+      { 'seed-meta:conflict:ucdp-events': { fetchedAt: Date.now() - 60_000, recordCount: 1 } },
+    );
+
+    const out = await callTool('get_conflict_events', { limit: 0, summary: true });
+
+    assert.equal(out._budget_exceeded, undefined, 'oversized summary samples must not erase the full count');
+    assert.equal(out.data['ucdp-events'].events.count, 1, 'summary count must still describe the full matching set');
+    assert.deepEqual(out.data['ucdp-events'].events.sample, [], 'an individually oversized sample cannot be returned');
+  });
+
   it('get_conflict_events applies JMESPath to the full oversized no-cap response before byte fitting', async () => {
     const events = Array.from({ length: 1000 }, (_, i) => ({
       id: `event-${i}`,

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -1343,6 +1343,97 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(out.data['ucdp-events'].events.length, 50, 'limit: 0 must opt out of the default cap and return the full list');
   });
 
+  it('get_conflict_events truncates oversized no-cap responses instead of returning a budget envelope', async () => {
+    const events = Array.from({ length: 1000 }, (_, i) => ({
+      id: `event-${i}`,
+      country: 'Syrian Arab Republic',
+      sideA: 'Government forces and aligned armed groups',
+      sideB: 'Opposition forces and aligned armed groups',
+      deathsBest: i,
+      sourceOriginal: 'A deliberately verbose source description that makes the fixture exceed the MCP output budget',
+    }));
+    mockCacheKeys(
+      { 'conflict:ucdp-events:v1': { events } },
+      { 'seed-meta:conflict:ucdp-events': { fetchedAt: Date.now() - 60_000, recordCount: events.length } },
+    );
+
+    const out = await callTool('get_conflict_events', { limit: 0 });
+
+    assert.equal(out._budget_exceeded, undefined, 'oversized conflict responses must preserve usable event data');
+    assert.equal(out.data.partial, true, 'truncated responses must be explicitly marked partial');
+    assert.equal(out.data.truncation.reason, 'output_budget');
+    assert.equal(out.data.truncation.original_event_count, events.length);
+    assert.ok(out.data.truncation.returned_event_count > 0, 'truncation must retain a useful event subset');
+    assert.ok(out.data.truncation.returned_event_count < events.length, 'truncation must actually reduce the payload');
+    assert.equal(
+      out.data['ucdp-events'].events.length,
+      out.data.truncation.returned_event_count,
+      'truncation metadata must describe the returned lists',
+    );
+  });
+
+  it('get_conflict_events summarizes the full oversized no-cap response before byte fitting', async () => {
+    const events = Array.from({ length: 1000 }, (_, i) => ({
+      id: `event-${i}`,
+      country: 'Syrian Arab Republic',
+      sourceOriginal: 'A deliberately verbose source description that makes the fixture exceed the MCP output budget',
+    }));
+    mockCacheKeys(
+      { 'conflict:ucdp-events:v1': { events } },
+      { 'seed-meta:conflict:ucdp-events': { fetchedAt: Date.now() - 60_000, recordCount: events.length } },
+    );
+
+    const out = await callTool('get_conflict_events', { limit: 0, summary: true });
+
+    assert.equal(out.data['ucdp-events'].events.count, events.length, 'summary count must describe the full matching set');
+    assert.equal(out.data.partial, undefined, 'summary mode fits naturally and must not report source truncation');
+  });
+
+  it('get_conflict_events applies JMESPath to the full oversized no-cap response before byte fitting', async () => {
+    const events = Array.from({ length: 1000 }, (_, i) => ({
+      id: `event-${i}`,
+      country: 'Syrian Arab Republic',
+      sourceOriginal: 'A deliberately verbose source description that makes the fixture exceed the MCP output budget',
+    }));
+    mockCacheKeys(
+      { 'conflict:ucdp-events:v1': { events } },
+      { 'seed-meta:conflict:ucdp-events': { fetchedAt: Date.now() - 60_000, recordCount: events.length } },
+    );
+
+    const out = await callTool('get_conflict_events', {
+      limit: 0,
+      jmespath: 'data."ucdp-events".events[-1].id',
+    });
+
+    assert.equal(out, 'event-999', 'a selective projection must still reach events beyond the byte-fitted prefix');
+  });
+
+  it('get_conflict_events keeps usable feeds when another feed has an individually oversized event', async () => {
+    const unrestEvents = Array.from({ length: 10 }, (_, i) => ({
+      id: `unrest-${i}`,
+      country: 'France',
+      fatalities: 0,
+    }));
+    mockCacheKeys(
+      {
+        'conflict:ucdp-events:v1': {
+          events: [{ id: 'oversized', country: 'X', sourceOriginal: 'x'.repeat(140 * 1024) }],
+        },
+        'unrest:events:v1': { events: unrestEvents },
+      },
+      { 'seed-meta:conflict:ucdp-events': { fetchedAt: Date.now() - 60_000, recordCount: 11 } },
+    );
+
+    const out = await callTool('get_conflict_events', { limit: 0 });
+
+    assert.equal(out._budget_exceeded, undefined, 'one oversized feed must not void the complete response');
+    assert.equal(out.data.partial, true);
+    assert.equal(out.data['ucdp-events'].events.length, 0, 'an event larger than the full budget cannot be returned');
+    assert.equal(out.data.events.events.length, unrestEvents.length, 'other feeds must retain their usable events');
+    assert.equal(out.data.truncation.original_event_count, unrestEvents.length + 1);
+    assert.equal(out.data.truncation.returned_event_count, unrestEvents.length);
+  });
+
   // --- limit on country/EU/displacement tools ---
   //
   // Five tools — get_country_macro, get_eu_housing_cycle,


### PR DESCRIPTION
## Summary

Large `get_conflict_events` requests now return the largest usable event subset instead of a successful-looking empty budget envelope. Truncated responses expose `partial` plus original and returned event counts, while `summary` and JMESPath still operate on the full matching set. Summary samples are independently byte-bounded so one oversized source record cannot erase the full count. The linked conflict-events widget also surfaces the partial-result state.

Fixes #5797.

## Validation

- 270 focused MCP, resource, schema, and output-budget tests passed after rebasing onto current `origin/main`.
- Frontend and API typechecks, edge bundle checks, architectural boundaries, policy lints, edge tests, and the full pre-push gate passed.

## Post-Deploy Monitoring & Validation

- Watch MCP tool-call telemetry for `tool=get_conflict_events` and `budget_exceeded=true`; healthy behavior is no budget overflow for ordinary large or no-cap conflict calls.
- Sample a large `limit: 0` call and confirm non-empty `data`, `partial: true`, accurate `truncation` counts, and a response below 131072 bytes.
- Verify `summary: true` reports the full matched count and a selective JMESPath tail projection still resolves.
- Failure trigger: renewed `_budget_exceeded` envelopes, mismatched counts, or empty non-oversized feeds. Mitigate by reverting this commit.
- Validation window and owner: first 24 hours after production deployment; WorldMonitor maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
