### PR TITLE
fix(hooks): stop the green-tree cache attesting a tree the gates never ran (#5800)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -151,6 +151,16 @@ read_paths() {
 # so a consumer never sees a phantom blank entry.
 nul_list() { [ "$#" -eq 0 ] || printf '%s\0' "$@"; }
 
+# show_paths: NUL stdin -> an indented list for a human. Strips control bytes
+# first: whoever authored the commit chose these filenames, and an embedded ESC
+# or CR could repaint the line and scroll the error that follows out of view.
+# Octal ranges: keep \011 (tab) and \012 (newline), drop everything else below
+# \040 plus \177 — note \015 (CR) sits between them and must be inside the
+# range, not skipped.
+show_paths() {
+  tr '\0' '\n' | LC_ALL=C tr -d '\001-\010\013-\037\177' | sed 's/^/  /'
+}
+
 RUN_ALL=false
 RUN_ALL_REASON=""
 DIFF_RESOLVED=true
@@ -178,7 +188,16 @@ else
   if bash "$ATTEST" changed HEAD~1 > "$CHANGED_NUL" 2>/dev/null; then
     read_paths < "$CHANGED_NUL"
     CHANGED_PATHS=("${_collected[@]}")
-    bash "$ATTEST" changed-live HEAD~1 > "$CHANGED_LIVE_NUL" 2>/dev/null
+    # Checked for the same reason as the resolved branch above, even though the
+    # sibling call that just succeeded makes a failure here all but impossible:
+    # the redirect truncates the file, so an unchecked failure hands the
+    # partition an EMPTY list, which reads as "no test files changed" and skips
+    # every changed test with exit 0. That is the precise bug this file exists
+    # to close, so it must not survive in the fallback.
+    if ! bash "$ATTEST" changed-live HEAD~1 > "$CHANGED_LIVE_NUL" 2>/dev/null; then
+      echo "ERROR: could not enumerate the pushed files — refusing to guess which tests to run."
+      exit 1
+    fi
     read_paths < "$CHANGED_LIVE_NUL"
     CHANGED_LIVE=("${_collected[@]}")
   fi
@@ -244,7 +263,7 @@ if [ "$DIFF_RESOLVED" = true ] && [ -z "${WM_ALLOW_WORKTREE_DRIFT:-}" ]; then
     echo ""
     echo "============================================================"
     echo "ERROR: these files differ between your worktree and the commit being pushed:"
-    tr '\0' '\n' < "$WORKTREE_NUL" | sed 's/^/  /'
+    show_paths < "$WORKTREE_NUL"
     echo "The gates run your worktree; git pushes HEAD. Testing one and"
     echo "shipping the other is how a green push lands broken bytes."
     echo "Fix: commit these changes, or stash them, then push again."
@@ -266,7 +285,7 @@ if [ "$DIRTY_STATUS" -eq 0 ]; then
   ATTESTABLE=true
 elif [ "$DIRTY_STATUS" -eq 3 ]; then
   echo "Worktree is not byte-identical to HEAD — this run will not be cached:"
-  tr '\0' '\n' < "$WORKTREE_NUL" | sed 's/^/  /'
+  show_paths < "$WORKTREE_NUL"
 else
   # Fail closed, and say which failure it was: printing the "not byte-identical"
   # list when the list is empty because the CHECK broke reads as a lie.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -119,46 +119,158 @@ fi
 # (mirroring how the test categories were already scoped), and a tree that
 # passed the full gate once is cached so an immediate re-push (remote-side
 # failure, message-only amend) doesn't re-pay minutes of checks.
+#
+# Every changed-path read below goes through scripts/prepush-attest.sh, which
+# talks to git NUL-delimited and answers the three questions that decide
+# whether this run may be cached at all (#5800). The path list is a bash array
+# from here down: `git diff --name-only` C-quotes unicode, backslash and
+# newline paths under git's default core.quotePath, and a C-quoted path matches
+# no file on disk — so the old line-read string dropped those paths silently
+# and the gate went green having run nothing.
+ATTEST="scripts/prepush-attest.sh"
+CHANGED_NUL=$(mktemp) || exit 1
+CHANGED_LIVE_NUL=$(mktemp) || exit 1
+NODE_TESTS_NUL=$(mktemp) || exit 1
+DOM_TESTS_NUL=$(mktemp) || exit 1
+WORKTREE_NUL=$(mktemp) || exit 1
+trap 'rm -f "$CHANGED_NUL" "$CHANGED_LIVE_NUL" "$NODE_TESTS_NUL" "$DOM_TESTS_NUL" "$WORKTREE_NUL"' EXIT
+
+# read_paths: NUL stdin -> the _collected array (bash 3.2 has no namerefs, so
+# callers copy it out immediately).
+_collected=()
+read_paths() {
+  local path
+  _collected=()
+  while IFS= read -r -d '' path; do
+    [ -n "$path" ] || continue
+    _collected+=("$path")
+  done
+}
+
+# nul_list: emit an array as a NUL stream, and emit NOTHING for an empty array
+# so a consumer never sees a phantom blank entry.
+nul_list() { [ "$#" -eq 0 ] || printf '%s\0' "$@"; }
+
 RUN_ALL=false
 RUN_ALL_REASON=""
 DIFF_RESOLVED=true
-if CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null); then
-  :
+CHANGED_PATHS=()
+CHANGED_LIVE=()
+if bash "$ATTEST" changed origin/main > "$CHANGED_NUL" 2>/dev/null; then
+  read_paths < "$CHANGED_NUL"
+  CHANGED_PATHS=("${_collected[@]}")
+  # The same diff minus what the push deletes. Test runners get THIS list: a
+  # path that exists in the pushed commit but not on disk means the worktree
+  # drifted, which is a blocked push (below), never a file to quietly skip.
+  if ! bash "$ATTEST" changed-live origin/main > "$CHANGED_LIVE_NUL" 2>/dev/null; then
+    echo "ERROR: could not enumerate the pushed files — refusing to guess which tests to run."
+    exit 1
+  fi
+  read_paths < "$CHANGED_LIVE_NUL"
+  CHANGED_LIVE=("${_collected[@]}")
 else
   # origin/main is not resolvable (offline, fresh clone, missing remote ref).
   # Force EVERYTHING: the HEAD~1 fallback only sees the last commit, so using
   # it to scope safety gates would silently skip typechecks/lints for earlier
-  # commits in the push — and then the green-tree cache would stamp that tree.
-  # HEAD~1 is kept ONLY to narrow the changed-test list (informational).
-  CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || echo "")
+  # commits in the push. HEAD~1 is kept ONLY to narrow the changed-test list
+  # (informational) — and this run may not be cached at all, because RUN_ALL
+  # skips the local unit suite (see the cache write at the end).
+  if bash "$ATTEST" changed HEAD~1 > "$CHANGED_NUL" 2>/dev/null; then
+    read_paths < "$CHANGED_NUL"
+    CHANGED_PATHS=("${_collected[@]}")
+    bash "$ATTEST" changed-live HEAD~1 > "$CHANGED_LIVE_NUL" 2>/dev/null
+    read_paths < "$CHANGED_LIVE_NUL"
+    CHANGED_LIVE=("${_collected[@]}")
+  fi
   RUN_ALL=true
   DIFF_RESOLVED=false
   RUN_ALL_REASON="changed files could not be resolved from origin/main"
   echo "WARNING: Could not resolve branch diff from origin/main — running ALL invariant checks as safety fallback."
 fi
-if echo "$CHANGED_FILES" | grep -q "package.json\|tsconfig"; then
+
+# path_matches <ERE>: true when any changed path matches. Pure bash rather than
+# `echo "$list" | grep`, which re-linearizes the array and would split a path
+# containing a newline back into two paths that match nothing.
+path_matches() {
+  local regex="$1" path
+  for path in "${CHANGED_PATHS[@]}"; do
+    if [[ $path =~ $regex ]]; then return 0; fi
+  done
+  return 1
+}
+
+# changed <ERE>: true when RUN_ALL is forced or any changed path matches.
+changed() { [ "$RUN_ALL" = true ] || path_matches "$1"; }
+
+if path_matches 'package\.json|tsconfig'; then
   RUN_ALL=true
   RUN_ALL_REASON="${RUN_ALL_REASON:-config changed}"
 fi
 
-# changed <ERE>: true when RUN_ALL is forced or any changed file matches.
-changed() { [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -qE "$1"; }
-
 # Green-tree cache: if this exact tree already passed the full gate, skip the
 # tree-dependent checks. State-dependent checks (secrets, PR state, branch
-# contamination, lockfile sync) have already run above and always do.
-#
-# Cache READS are disabled when the branch diff could not be resolved: the
-# tree hash captures content-derived plan inputs (a package.json change is in
-# the tree), but NOT state-derived ones — a blind run must not trust an
-# attestation minted under a scoped plan it can no longer verify. Writes stay
-# enabled: a fallback run executes everything, the strongest attestation.
+# contamination, lockfile sync) have already run above and always do. The
+# read/write rules live in prepush-attest.sh, where tests execute them.
 GATE_CACHE="$(git rev-parse --git-dir)/wm-prepush-green"
 TREE_HASH=$(git rev-parse 'HEAD^{tree}' 2>/dev/null || echo "")
-if [ "$DIFF_RESOLVED" = true ] && [ -n "$TREE_HASH" ] && [ -f "$GATE_CACHE" ] && grep -qxF "$TREE_HASH" "$GATE_CACHE" 2>/dev/null; then
+if bash "$ATTEST" cache-read "$GATE_CACHE" "$TREE_HASH" "$DIFF_RESOLVED"; then
   echo "Pre-push gates: this exact tree already passed ($TREE_HASH)."
   echo "  Skipping tree-dependent checks (delete $GATE_CACHE to force a re-run)."
   exit 0
+fi
+
+# Everything below runs against the WORKTREE, git pushes HEAD, and the cache at
+# the end stamps HEAD^{tree}. Those are the same bytes only when the worktree
+# matches HEAD, so measure that NOW — before `make generate` and the pro-test
+# build touch anything.
+#
+# Two tiers, because they cost differently. Drift INSIDE the branch diff is the
+# dangerous one and blocks the push: an unstaged fix makes the suite pass over
+# the broken bytes being pushed, an unstaged delete drops a changed test from
+# the run entirely. Dirt anywhere else only costs the attestation — blocking
+# every push that has an unrelated scratch edit would be a gate nobody passes.
+#
+# Escape hatch for a deliberate "push the committed state, keep editing":
+# WM_ALLOW_WORKTREE_DRIFT=1 (same convention as WM_ALLOW_FOREIGN_HOOKS). It is
+# scoped on purpose — unlike `--no-verify` every other gate still runs, and it
+# cannot mint a false attestation, because a drifted worktree is by definition
+# dirty and the cache write below refuses on that. It also does not cover a
+# changed test file that is MISSING from the worktree: the partition refuses
+# that separately, because there is no way to run a file that is not there.
+if [ "$DIFF_RESOLVED" = true ] && [ -z "${WM_ALLOW_WORKTREE_DRIFT:-}" ]; then
+  bash "$ATTEST" drift origin/main > "$WORKTREE_NUL" 2>/dev/null
+  DRIFT_STATUS=$?
+  if [ "$DRIFT_STATUS" -eq 3 ]; then
+    echo ""
+    echo "============================================================"
+    echo "ERROR: these files differ between your worktree and the commit being pushed:"
+    tr '\0' '\n' < "$WORKTREE_NUL" | sed 's/^/  /'
+    echo "The gates run your worktree; git pushes HEAD. Testing one and"
+    echo "shipping the other is how a green push lands broken bytes."
+    echo "Fix: commit these changes, or stash them, then push again."
+    echo "Deliberate? Re-run with WM_ALLOW_WORKTREE_DRIFT=1 — every other gate"
+    echo "still runs, and the run still will not be cached. (A changed test file"
+    echo "that is missing from the worktree still stops the push: it cannot run.)"
+    echo "============================================================"
+    exit 1
+  fi
+  if [ "$DRIFT_STATUS" -ne 0 ]; then
+    echo "WARNING: could not compare the worktree against HEAD (status $DRIFT_STATUS)."
+  fi
+fi
+
+ATTESTABLE=false
+bash "$ATTEST" dirty > "$WORKTREE_NUL" 2>/dev/null
+DIRTY_STATUS=$?
+if [ "$DIRTY_STATUS" -eq 0 ]; then
+  ATTESTABLE=true
+elif [ "$DIRTY_STATUS" -eq 3 ]; then
+  echo "Worktree is not byte-identical to HEAD — this run will not be cached:"
+  tr '\0' '\n' < "$WORKTREE_NUL" | sed 's/^/  /'
+else
+  # Fail closed, and say which failure it was: printing the "not byte-identical"
+  # list when the list is empty because the CHECK broke reads as a lie.
+  echo "Could not compare the worktree against HEAD (status $DIRTY_STATUS) — this run will not be cached."
 fi
 
 if changed '^(src/|tests/|e2e/|middleware|index\.html|vite\.config|scripts/|types/)'; then
@@ -191,7 +303,12 @@ fi
 if changed '^scripts/.*\.cjs$'; then
   echo "Running CJS syntax check..."
   for f in scripts/*.cjs; do
-    [ -f "$f" ] && node -c "$f" || exit 1
+    # An unmatched glob expands to the literal pattern, and
+    # `[ -f "$f" ] && node -c "$f" || exit 1` then took the `|| exit 1` branch —
+    # so "there are no .cjs files" failed the push with no message at all.
+    # Split so only a real syntax error exits.
+    [ -f "$f" ] || continue
+    node -c "$f" || exit 1
   done
 fi
 
@@ -252,16 +369,16 @@ else
 fi
 
 # Determine which test categories to run based on changed files
-# (CHANGED_FILES + RUN_ALL were computed above, before the invariant gates.)
+# (CHANGED_PATHS + RUN_ALL were computed above, before the invariant gates.)
 RUN_RESILIENCE=false
 RUN_SEED=false
 RUN_SERVER=false
 RUN_FRONTEND=false
 
-if echo "$CHANGED_FILES" | grep -q "^scripts/"; then RUN_SEED=true; fi
-if echo "$CHANGED_FILES" | grep -q "^server/"; then RUN_SERVER=true; fi
-if echo "$CHANGED_FILES" | grep -q "resilience"; then RUN_RESILIENCE=true; fi
-if echo "$CHANGED_FILES" | grep -q "^src/\|^api/"; then RUN_FRONTEND=true; fi
+if path_matches '^scripts/'; then RUN_SEED=true; fi
+if path_matches '^server/'; then RUN_SERVER=true; fi
+if path_matches 'resilience'; then RUN_RESILIENCE=true; fi
+if path_matches '^(src/|api/)'; then RUN_FRONTEND=true; fi
 # RUN_ALL means "run broad invariant checks below", not "run every unit test".
 # Touching tests/ used to trigger the full local suite, but that suite now
 # exceeds this hook's 300s budget. CI remains the full-suite merge gate; this
@@ -283,25 +400,41 @@ if echo "$CHANGED_FILES" | grep -q "^src/\|^api/"; then RUN_FRONTEND=true; fi
 # missing or errors would otherwise substitute to an empty list, and empty
 # reads here as "no test files changed" — the gate would sail past every
 # changed test instead of saying anything. Fail loudly instead.
-if ! TESTS_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/prepush-changed-tests.sh node); then
+# The list handed over is CHANGED_LIVE, not CHANGED_PATHS: git already removed
+# what this push deletes, so the partition never has to infer deletion from
+# `[ -f ]` — the inference that turned an unstaged `rm` into a silently skipped
+# test (#5800). NUL in, NUL out, via files: command substitution cannot carry
+# NUL bytes, and a newline-delimited round trip is what loses quoted paths.
+if ! nul_list "${CHANGED_LIVE[@]}" | bash scripts/prepush-changed-tests.sh node > "$NODE_TESTS_NUL"; then
   echo "ERROR: scripts/prepush-changed-tests.sh node failed — cannot decide which tests to run."
   exit 1
 fi
-if ! DOM_TESTS_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/prepush-changed-tests.sh dom); then
+read_paths < "$NODE_TESTS_NUL"
+TESTS_CHANGED=("${_collected[@]}")
+
+if ! nul_list "${CHANGED_LIVE[@]}" | bash scripts/prepush-changed-tests.sh dom > "$DOM_TESTS_NUL"; then
   echo "ERROR: scripts/prepush-changed-tests.sh dom failed — cannot decide which tests to run."
   exit 1
 fi
+read_paths < "$DOM_TESTS_NUL"
+DOM_TESTS_CHANGED=("${_collected[@]}")
 
-# The routing contract spans four files: this hook, the partition script, the
-# vitest project that defines what "a DOM test" is, and the package.json script
-# the DOM half invokes. Its test must run when ANY of them changes, not only
-# when the test file itself is edited — otherwise the assertions are absent
-# exactly when the contract they pin is being rewritten. Same convention as the
-# invariant lints above, which each fire on their own implementation script.
-if echo "$CHANGED_FILES" | grep -qE '^(\.husky/pre-push|scripts/prepush-changed-tests\.sh|vitest\.dom\.config\.mts|package\.json)$' \
-  && [ -f tests/prepush-changed-tests.test.mjs ] \
-  && ! echo "$TESTS_CHANGED" | grep -qxF 'tests/prepush-changed-tests.test.mjs'; then
-  TESTS_CHANGED=$(printf '%s\ntests/prepush-changed-tests.test.mjs\n' "$TESTS_CHANGED" | grep -v '^$')
+# The routing and attestation contract spans this hook, the two scripts it
+# delegates to, the vitest project that defines what "a DOM test" is, and the
+# package.json script the DOM half invokes. Their tests must run when ANY of
+# those changes, not only when a test file itself is edited — otherwise the
+# assertions are absent exactly when the contract they pin is being rewritten.
+# Same convention as the invariant lints above, which each fire on their own
+# implementation script.
+if path_matches '^(\.husky/pre-push|scripts/prepush-changed-tests\.sh|scripts/prepush-attest\.sh|vitest\.dom\.config\.mts|package\.json)$'; then
+  for contract_test in tests/prepush-changed-tests.test.mjs tests/prepush-attest.test.mjs; do
+    [ -f "$contract_test" ] || continue
+    already_listed=false
+    for listed in "${TESTS_CHANGED[@]}"; do
+      if [ "$listed" = "$contract_test" ]; then already_listed=true; break; fi
+    done
+    if [ "$already_listed" = false ]; then TESTS_CHANGED+=("$contract_test"); fi
+  done
 fi
 
 # Compute SEED_TESTS and SERVER_TESTS up-front (rather than inside their
@@ -310,8 +443,19 @@ fi
 # RUN_SEED / RUN_SERVER blocks consume these same variables — single
 # source of truth prevents drift between "what runs" and "what's
 # subtracted from TESTS_CHANGED".
-SEED_TESTS=$(echo "$CHANGED_FILES" | grep "^scripts/" | sed 's|scripts/seed-\(.*\)\.mjs|tests/\1-seed.test.mjs|' | grep "^tests/" | while read -r t; do [ -f "$t" ] && echo "$t"; done)
-SERVER_TESTS=$(printf '%s\n' "tests/handlers.test.mts" "tests/server-handlers.test.mjs")
+SEED_TESTS=()
+for changed_path in "${CHANGED_PATHS[@]}"; do
+  case "$changed_path" in
+    scripts/seed-*.mjs) ;;
+    *) continue ;;
+  esac
+  seed_stem="${changed_path#scripts/seed-}"
+  seed_candidate="tests/${seed_stem%.mjs}-seed.test.mjs"
+  # Filesystem check on a DERIVED name, not an inference about the push: this
+  # naming convention is a guess, and most seeders have no matching test.
+  [ -f "$seed_candidate" ] && SEED_TESTS+=("$seed_candidate")
+done
+SERVER_TESTS=("tests/handlers.test.mts" "tests/server-handlers.test.mjs")
 
 # Subtract any test file that's already going to be run by a category
 # glob (RUN_RESILIENCE's resilience-* glob, RUN_SERVER's SERVER_TESTS
@@ -326,23 +470,27 @@ SERVER_TESTS=$(printf '%s\n' "tests/handlers.test.mts" "tests/server-handlers.te
 # would silently drop them from the TESTS_CHANGED runner too, since that
 # block runs regardless of RUN_ALL. Net effect of an unconditional dedup:
 # changed test files don't run anywhere locally when RUN_ALL fires.
-if [ "$RUN_ALL" != true ] && [ -n "$TESTS_CHANGED" ]; then
-  if [ "$RUN_RESILIENCE" = true ]; then
-    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -v "^tests/resilience-" || true)
-  fi
-  if [ "$RUN_SERVER" = true ]; then
-    # grep -vxF -f <(...): drop lines from TESTS_CHANGED that exactly
-    # match (full line, literal string, no regex) the SERVER_TESTS list.
-    # Exact literal match here — not a regex like (handlers|server-handlers)
-    # over (mjs|mts) — so we never strip a file from TESTS_CHANGED that
-    # the category run isn't actually going to execute.
-    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -vxF -f <(echo "$SERVER_TESTS") || true)
-  fi
-  if [ -n "$SEED_TESTS" ]; then
-    # grep -vxF -f <(...): drop lines from TESTS_CHANGED that exactly
-    # match (full line, literal string, no regex) any line in SEED_TESTS.
-    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -vxF -f <(echo "$SEED_TESTS") || true)
-  fi
+if [ "$RUN_ALL" != true ] && [ "${#TESTS_CHANGED[@]}" -gt 0 ]; then
+  # Exact string comparison against the SAME arrays the category runs execute —
+  # not a regex like (handlers|server-handlers) over (mjs|mts) — so we never
+  # strip a file from TESTS_CHANGED that the category run isn't going to run.
+  ALREADY_COVERED=()
+  if [ "$RUN_SERVER" = true ]; then ALREADY_COVERED+=("${SERVER_TESTS[@]}"); fi
+  if [ "${#SEED_TESTS[@]}" -gt 0 ]; then ALREADY_COVERED+=("${SEED_TESTS[@]}"); fi
+
+  DEDUPED=()
+  for candidate in "${TESTS_CHANGED[@]}"; do
+    # RUN_RESILIENCE runs a `tests/resilience-*` glob, so match it by prefix.
+    if [ "$RUN_RESILIENCE" = true ]; then
+      case "$candidate" in tests/resilience-*) continue ;; esac
+    fi
+    covered=false
+    for other in "${ALREADY_COVERED[@]}"; do
+      if [ "$candidate" = "$other" ]; then covered=true; break; fi
+    done
+    if [ "$covered" = false ]; then DEDUPED+=("$candidate"); fi
+  done
+  TESTS_CHANGED=("${DEDUPED[@]}")
 fi
 
 if [ "$RUN_ALL" = true ]; then
@@ -356,18 +504,20 @@ if [ "$RUN_ALL" != true ]; then
   fi
   if [ "$RUN_SEED" = true ]; then
     echo "Running seed tests (scripts/ changed)..."
-    if [ -n "$SEED_TESTS" ]; then
-      timeout 120 npx tsx --test $SEED_TESTS || exit 1
+    if [ "${#SEED_TESTS[@]}" -gt 0 ]; then
+      # Quoted expansion, not word-splitting: `tests/trade flows-seed.test.mjs`
+      # is one argument, not two nonexistent ones.
+      timeout 120 npx tsx --test "${SEED_TESTS[@]}" || exit 1
     else
       echo "  No matching seed tests found, skipping."
     fi
   fi
   if [ "$RUN_SERVER" = true ]; then
     echo "Running server handler tests (server/ changed)..."
-    # shellcheck disable=SC2086 — intentional word-split for tsx --test arglist
-    timeout 120 npx tsx --test $SERVER_TESTS || exit 1
+    timeout 120 npx tsx --test "${SERVER_TESTS[@]}" || exit 1
   fi
-  if [ "$RUN_RESILIENCE" = false ] && [ "$RUN_SEED" = false ] && [ "$RUN_SERVER" = false ] && [ -z "$TESTS_CHANGED" ] && [ -z "$DOM_TESTS_CHANGED" ]; then
+  if [ "$RUN_RESILIENCE" = false ] && [ "$RUN_SEED" = false ] && [ "$RUN_SERVER" = false ] \
+    && [ "${#TESTS_CHANGED[@]}" -eq 0 ] && [ "${#DOM_TESTS_CHANGED[@]}" -eq 0 ]; then
     echo "Skipping unit tests (frontend-only changes; CI runs the full suite on PR open)."
   fi
 fi
@@ -377,8 +527,8 @@ fi
 # stubbed runners. Held inline here, they could only be guarded by grepping
 # this file's source — and a source grep stays green when `-n` is flipped to
 # `-z` or `|| exit 1` is dropped, which is a silent skip of the whole suite.
-printf '%s\n' "$TESTS_CHANGED" | bash scripts/prepush-changed-tests.sh run-node || exit 1
-printf '%s\n' "$DOM_TESTS_CHANGED" | bash scripts/prepush-changed-tests.sh run-dom || exit 1
+nul_list "${TESTS_CHANGED[@]}" | bash scripts/prepush-changed-tests.sh run-node || exit 1
+nul_list "${DOM_TESTS_CHANGED[@]}" | bash scripts/prepush-changed-tests.sh run-dom || exit 1
 
 echo "Running edge function tests..."
 if [ "$RUN_FRONTEND" = true ] || [ "$RUN_ALL" = true ]; then
@@ -388,14 +538,14 @@ else
 fi
 
 echo "Running markdown lint..."
-if echo "$CHANGED_FILES" | grep -qE "\.md$|\.mdx$" || [ "$RUN_ALL" = true ]; then
+if path_matches '\.(md|mdx)$' || [ "$RUN_ALL" = true ]; then
   npm run lint:md || exit 1
 else
   echo "  Skipped (no markdown changes)."
 fi
 
 echo "Running MDX lint (Mintlify compatibility)..."
-if echo "$CHANGED_FILES" | grep -q "\.mdx$" || [ "$RUN_ALL" = true ]; then
+if path_matches '\.mdx$' || [ "$RUN_ALL" = true ]; then
   node --test tests/mdx-lint.test.mjs || exit 1
 else
   echo "  Skipped (no MDX changes)."
@@ -459,7 +609,7 @@ echo "Running pro-test bundle freshness check..."
 # (see PR #3227 → #3228: source fix merged but deploy still broken because
 # public/pro/ was stale).
 #
-# Scope to the BRANCH delta ($CHANGED_FILES, computed earlier from
+# Scope to the BRANCH delta ($CHANGED_PATHS, computed earlier from
 # `git diff origin/main...HEAD`), not the worktree, so unstaged local
 # pro-test/ scratch edits don't trigger a slow rebuild on unrelated
 # branches. RUN_ALL forces the check when the branch delta couldn't be
@@ -469,7 +619,7 @@ echo "Running pro-test bundle freshness check..."
 # pro-test/src/generated/tiers.json. Catalog-only pricing-copy changes are
 # otherwise able to ship stale /pro bundles because Vercel serves public/pro/
 # as committed bytes.
-if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -qE "^(pro-test|public/pro)/|^convex/config/productCatalog\.ts$|^scripts/generate-product-config\.mjs$"; then
+if [ "$RUN_ALL" = true ] || path_matches '^(pro-test|public/pro)/|^convex/config/productCatalog\.ts$|^scripts/generate-product-config\.mjs$'; then
   npx tsx scripts/generate-product-config.mjs >/dev/null || {
     echo "ERROR: product config generation failed"
     exit 1
@@ -520,10 +670,19 @@ fi
 echo "Running version sync check..."
 npm run version:check || exit 1
 
+echo "All pre-push gates passed."
+
 # Record this tree as gate-green: a re-push of the identical tree (remote-side
 # failure, network blip, commit-message-only amend) skips straight past the
 # tree-dependent checks above. Any content change produces a new tree hash.
-if [ -n "$TREE_HASH" ]; then
-  echo "$TREE_HASH" > "$GATE_CACHE"
+#
+# prepush-attest.sh refuses the write when the run cannot honestly vouch for
+# HEAD — an unresolved branch diff (RUN_ALL skipped the unit suite) or a
+# worktree that is not byte-identical to HEAD. A refusal prints its reason and
+# is NOT a failed push: the gates all passed, they just do not get to suppress
+# the next run. Hence the explicit `exit 0` — the refusal's status must not
+# become the hook's.
+if bash "$ATTEST" cache-write "$GATE_CACHE" "$TREE_HASH" "$DIFF_RESOLVED" "$ATTESTABLE"; then
+  echo "  Tree cached — an identical re-push skips straight to the end."
 fi
-echo "All pre-push gates passed — tree cached."
+exit 0

--- a/docs/solutions/logic-errors/pre-push-green-tree-cache-attested-a-tree-the-gates-never-ran.md
+++ b/docs/solutions/logic-errors/pre-push-green-tree-cache-attested-a-tree-the-gates-never-ran.md
@@ -1,0 +1,145 @@
+---
+module: pre-push-gate
+date: 2026-07-29
+problem_type: logic_error
+component: build_system
+severity: high
+symptoms:
+  - "A changed test file is in the pushed commit but never appears in any runner invocation, and the gate exits 0"
+  - "A push whose branch diff contains a unicode or backslash path runs nothing for that path"
+  - "A tree that only ever passed the origin/main-unresolvable fallback later cache-hits and skips every gate"
+root_cause: logic_error
+resolution_type: workflow_improvement
+related_components: [development_workflow, tooling, testing_framework]
+tags: [pre-push, husky, green-while-dead, quotepath, nul-delimited, worktree-drift, attestation, bash, git-diff]
+---
+
+# The pre-push green-tree cache attested a tree the gates never ran against
+
+## Problem
+
+`.husky/pre-push` caches `HEAD^{tree}` after a green run and, on a later push of that tree, skips every tree-dependent gate. Three separate defects let it write that entry after a run that never exercised the pushed bytes — so each one was not "a bad run" but **a bad run that suppresses all future runs of that tree** (#5800, fixed in PR #5809).
+
+## Symptoms
+
+The unifying tell is silence: a file is unmistakably in the push, and no runner invocation ever names it, and the gate exits 0.
+
+```
+# committed diff says two tests changed
+tests/alpha.test.mjs
+tests/beta.test.mjs
+
+# what the gate actually ran
+tests/alpha.test.mjs
+exit=0                       # beta.test.mjs never ran, tree stamped green
+```
+
+## What Didn't Work
+
+**Reading the hook and reasoning about it.** All three defects are invisible in the source — every line is individually plausible. `[ -f "$file" ] || continue` reads as sensible deletion handling; `git diff --name-only` reads as the obvious way to list changed paths; the cache write sits under a comment that confidently explains why it is safe. Each was only provable by building a git fixture and watching the gate return 0 over a file it should have run.
+
+**Trusting a green push as verification of the fix.** After landing the change, the push succeeded and printed `All pre-push gates passed — tree cached.` — the *old* hook's wording. `core.hooksPath` in the shared `.git/config` was an absolute path to the main checkout, so the worktree's hook never ran (see [Why the verification almost lied](#why-the-verification-almost-lied)).
+
+## Solution
+
+### 1. The gates run the WORKTREE; the cache claims HEAD
+
+`CHANGED_FILES` came from `git diff origin/main...HEAD` (the committed tree) but the runners execute against the worktree, and the cache records `HEAD^{tree}`. Existence was then inferred from the filesystem:
+
+```sh
+[ -f "$file" ] || continue          # "the push deleted it" — or the worktree drifted
+```
+
+Those two states are indistinguishable to `[ -f ]`, and the second one is the bug: an unstaged `rm` of a changed test dropped it from the run; an unstaged **fix** made the suite pass over the broken bytes actually being pushed. Either way `HEAD^{tree}` went into the cache.
+
+Deletion is now git's answer, not the filesystem's, and drift is measured explicitly:
+
+```sh
+# scripts/prepush-attest.sh — "paths that exist in the pushed commit"
+git diff --name-only -z --no-renames --diff-filter=d "$base...HEAD"
+```
+
+`--diff-filter=d` is the lowercase *exclude* form ("everything except deletions"), chosen over an `ACMR` allow-list so a status letter git adds later lands on the "exists" side rather than vanishing from the run.
+
+Two tiers, because they cost differently:
+
+- Drift **inside the branch diff** blocks the push. `WM_ALLOW_WORKTREE_DRIFT=1` opts out and still cannot cache — a drifted worktree is dirty by definition, and the cache write refuses on that.
+- Dirt **anywhere else** (including a non-ignored untracked file — a forgotten `git add` the gates can import and the push cannot deliver) only forfeits the attestation. Blocking every push carrying an unrelated scratch edit would be a gate nobody passes.
+
+### 2. `core.quotePath` silently renamed paths out of existence
+
+Git's **default** `core.quotePath=true` C-quotes non-ASCII paths in `--name-only`, and backslash/quote/newline paths are C-quoted regardless of that setting. The quoted form matches no file, so `[ -f ]` dropped it:
+
+```
+$ git diff --name-only origin-main...HEAD
+tests/alpha.test.mjs
+"tests/back\\slash.test.mjs"        -> DROPPED
+"tests/caf\303\251.test.mjs"        -> DROPPED
+tests/with space.test.mjs
+```
+
+`core.quotePath=false` is **not** the fix — it only governs the non-ASCII case. `-z` is:
+
+```sh
+git diff --name-only -z --no-renames "$base...HEAD"
+```
+
+Since command substitution cannot carry NUL bytes, the string variable had to go: the list is a bash array end to end, moved between the hook and `scripts/prepush-changed-tests.sh` through temp files, with `read -r -d ''` on both sides. That also removed a live word-splitting bug — `npx tsx --test $SEED_TESTS` turned `tests/trade flows-seed.test.mjs` into two nonexistent arguments.
+
+`--no-renames` for a related reason: rename detection reports only the *destination*, so moving any `scripts/seed-NAME.mjs` to `tests/NAME-seed.test.mjs` left nothing under `scripts/` for the seed category to scope on. Every gate here scopes by path prefix, so a path that stopped existing is exactly as interesting as one that started.
+
+### 3. The fallback cached a partial run as fully green
+
+When `origin/main` is unresolvable the hook sets `RUN_ALL`, and `RUN_ALL` **explicitly skips** the local unit suite — yet the write fired anyway, under a comment asserting the opposite:
+
+```sh
+# Writes stay enabled: a fallback run executes everything, the strongest attestation.
+```
+
+It does not execute everything. The write now refuses when the branch diff was unresolvable, and the refusal states its reason.
+
+### Why the decisions moved into a script
+
+Every one of these is a "can this report green while the thing is dead" question, and the hook is the one file that cannot be executed cheaply in a test (it runs tsc, esbuild, vite). Grepping its source is not a substitute — a source guard stays green when a `true` becomes `false`. So the git-facing decisions live in `scripts/prepush-attest.sh` with three-valued exits (`0` yes / `3` no / `2` usage / `1` internal), and two test files cover it from both sides:
+
+- `tests/prepush-attest.test.mjs` — executes each mode against real git fixtures.
+- `tests/prepush-hook-gate.test.mjs` — runs the **real hook** end to end in a fixture repo with `npm`/`npx`/`node`/`gh`/`make` stubbed, then asserts what it dispatched and whether it cached.
+
+## Why This Works
+
+The invariant is one sentence: **the cache attests `HEAD^{tree}`, so it may only be written when the gates ran against `HEAD^{tree}`.** Everything else follows — a dirty worktree is not that tree, and a fallback run that skipped the unit suite did not gate that tree.
+
+The exit codes matter as much as the logic. "The gate says no" and "the gate could not run" must never collapse into the same status as "the gate says yes", which is why `dirty` returning non-zero for *any* reason leaves `ATTESTABLE=false`.
+
+## Prevention
+
+**Never infer a git fact from the filesystem.** `[ -f ]` cannot distinguish "the push deleted it" from "your worktree is not what you are pushing". Ask git; it knows both.
+
+**`git diff --name-only` is not a path list.** It is a *display* format, lossy by default. Any consumer that will `test`, `open`, or `exec` those paths needs `-z`. If the surrounding design cannot carry NUL (command substitution cannot), that design has to change — files and pipes carry it fine.
+
+**Prove a gate by making it fail.** Each fix here was mutation-checked: revert it, confirm a test goes red, restore. Drift check removed -> 2 red; unconditional cache write -> 6; `-z` dropped -> 13; silent `[ -f ]` skip restored -> 1; `--no-renames` dropped -> 2. A guard nobody has watched fail is not known to work.
+
+```sh
+# the shape of the harness that made the hook itself testable
+for cmd in npm npx node gh make; do printf '#!/bin/sh\necho "%s $*" >> "$LOG"\nexit 0\n' "$cmd" > "$BIN/$cmd"; done
+PATH="$BIN:$PATH" WM_ALLOW_FOREIGN_HOOKS=1 bash .husky/pre-push origin <url>
+```
+
+Keep the stub directory and its log **outside** the fixture repo — untracked stub files inside it make the worktree dirty, and the gate correctly refuses to attest.
+
+**A green push is not evidence your hook change ran.** Confirm `git config --show-origin --get core.hooksPath` is relative *first*, clear `$(git rev-parse --git-dir)/wm-prepush-green`, then invoke the hook directly. The fastest tell that a foreign hook executed is its **last output line**: stale copies betray themselves with wording the current source no longer contains. See [git-push-timeout-stale-core-hookspath](../performance-issues/git-push-timeout-stale-core-hookspath.md) — the in-hook self-identity tripwire cannot catch this case, because a stale copy that predates the tripwire does not contain it (tracked as #5810).
+
+**Watch for the unmatched-glob `&&`/`||` trap**, found by this harness in the same file:
+
+```sh
+for f in scripts/*.cjs; do
+  [ -f "$f" ] && node -c "$f" || exit 1   # no .cjs files -> exit 1, no message
+done
+```
+
+An unmatched glob expands to the literal pattern, `[ -f ]` fails, and the `||` fires — so "there is nothing to check" failed every `RUN_ALL` push silently. Split the test from the action: `[ -f "$f" ] || continue` then `node -c "$f" || exit 1`.
+
+## Related
+
+- [Pre-push fed vitest DOM tests to the node:test runner](../test-failures/pre-push-fed-vitest-dom-tests-to-the-node-test-runner.md) — the same hook; its cross-model review is what surfaced these three.
+- [git-push-timeout-stale-core-hookspath](../performance-issues/git-push-timeout-stale-core-hookspath.md) — the absolute `core.hooksPath` that hid this fix's verification.

--- a/docs/solutions/test-failures/pre-push-fed-vitest-dom-tests-to-the-node-test-runner.md
+++ b/docs/solutions/test-failures/pre-push-fed-vitest-dom-tests-to-the-node-test-runner.md
@@ -18,7 +18,7 @@ tags: [pre-push, husky, vitest, node-test-runner, happy-dom, ci-gate, green-whil
 
 ## Problem
 
-`.husky/pre-push` swept every changed test file into one runner. The repo has **two** runners that are not interchangeable, so every push touching `tests/dom/` failed inside the runner rather than in the test — and the gate was unpassable for that whole file class (#5795; fix opened in PR #5801, unmerged as of this writing).
+`.husky/pre-push` swept every changed test file into one runner. The repo has **two** runners that are not interchangeable, so every push touching `tests/dom/` failed inside the runner rather than in the test — and the gate was unpassable for that whole file class (#5795; fixed in PR #5801, merged 2026-07-29).
 
 ## Symptoms
 

--- a/scripts/prepush-attest.sh
+++ b/scripts/prepush-attest.sh
@@ -106,22 +106,27 @@ case "$mode" in
     require_base "$base"
 
     read_nul < <(git diff --name-only -z --no-renames "$base...HEAD")
-    branch_paths=("${collected[@]}")
+    # No paths in the branch diff means nothing this push changes can have
+    # drifted. Guarding is not just an optimisation: `diff -- ` with an empty
+    # pathspec list means ALL paths, which would report every unrelated
+    # worktree edit as drift and block the push.
+    [ "${#collected[@]}" -gt 0 ] || exit 0
 
+    # Intersect via git rather than a nested bash loop: `git diff HEAD` limited
+    # to the branch paths IS the intersection, matched in C. `--literal-pathspecs`
+    # because a path containing `*`, `?` or `[` is a legal filename but glob
+    # magic to a pathspec. (`--pathspec-from-file` is not supported by
+    # `git diff`, so the list goes through argv; on overflow git fails loudly,
+    # which the caller reports as "could not compare" rather than "clean".)
+    #
     # `git diff HEAD` covers staged and unstaged alike — the index is not what
     # gets pushed either.
-    read_nul < <(git diff --name-only -z HEAD --)
-
     found=0
-    for worktree_path in "${collected[@]}"; do
-      for branch_path in "${branch_paths[@]}"; do
-        if [ "$worktree_path" = "$branch_path" ]; then
-          printf '%s\0' "$worktree_path"
-          found=1
-          break
-        fi
-      done
-    done
+    while IFS= read -r -d '' drifted; do
+      [ -n "$drifted" ] || continue
+      printf '%s\0' "$drifted"
+      found=1
+    done < <(git --literal-pathspecs diff --name-only -z HEAD -- "${collected[@]}")
     [ "$found" -eq 0 ] || exit 3
     ;;
 

--- a/scripts/prepush-attest.sh
+++ b/scripts/prepush-attest.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Green-tree attestation primitives for .husky/pre-push (#5800).
+#
+# The hook's cache records `HEAD^{tree}` and, on a later push of that same tree,
+# skips every tree-dependent gate. That makes each of these a "bad run that
+# suppresses future runs" rather than "one bad run", so the decisions below are
+# the sharp edge of the whole gate:
+#
+#   * WHICH paths changed         — read NUL-delimited, so `core.quotePath`
+#                                   C-quoting (unicode, backslash, newline)
+#                                   cannot rename a path into one that no
+#                                   longer exists and gets silently skipped.
+#   * WHICH of those exist in HEAD — asked of git (`--diff-filter=d`), never
+#                                   inferred from `[ -f ]` against a worktree
+#                                   that may have drifted from HEAD.
+#   * WHETHER the run attests HEAD — the gates execute the WORKTREE; the cache
+#                                   claims HEAD. Those are the same bytes only
+#                                   when the tracked tree is clean.
+#
+# They live here, in modes a test can execute against real git fixtures
+# (tests/prepush-attest.test.mjs), instead of inline in the hook where only a
+# grep over its source text could guard them — and a source grep stays green
+# when `true` is flipped to `false`.
+#
+# Usage:
+#   bash scripts/prepush-attest.sh changed      <base-ref>   # NUL list
+#   bash scripts/prepush-attest.sh changed-live <base-ref>   # NUL list, minus deletions
+#   bash scripts/prepush-attest.sh drift        <base-ref>   # NUL list of offenders
+#   bash scripts/prepush-attest.sh dirty                     # NUL list of offenders
+#   bash scripts/prepush-attest.sh cache-read   <file> <tree> <diff-resolved>
+#   bash scripts/prepush-attest.sh cache-write  <file> <tree> <diff-resolved> <attestable>
+#
+# Exit codes are three-valued on purpose. A gate that answers "no" and a gate
+# that could not run must never collapse into the same status as "yes":
+#
+#   0  yes / clean / hit / written
+#   3  no  / drift / dirty / miss / refused   (the list, or the reason, on stdout)
+#   2  usage error
+#   1  internal failure (git unavailable, unwritable cache, ...)
+
+mode="${1:-}"
+case "$mode" in
+  changed | changed-live | drift | dirty | cache-read | cache-write) ;;
+  *)
+    echo "usage: $0 <changed|changed-live|drift|dirty|cache-read|cache-write> [args]" >&2
+    exit 2
+    ;;
+esac
+
+usage_error() {
+  echo "usage: $0 $mode $1" >&2
+  exit 2
+}
+
+# require_base: the three-dot diff the hook scopes with needs both a resolvable
+# base ref AND a merge base with HEAD. Checking up front means a later `git
+# diff` failure cannot half-emit a path list that reads as a complete one.
+require_base() {
+  git rev-parse --verify -q "${1}^{commit}" >/dev/null 2>&1 || exit 3
+  git merge-base "$1" HEAD >/dev/null 2>&1 || exit 3
+}
+
+# read_nul <array-name-less loop>: appends NUL-delimited stdin into `collected`.
+# `read -d ''` rather than a line read — a path may legally contain a newline,
+# and the whole point of this file is that no legal path goes missing.
+collected=()
+read_nul() {
+  local path
+  collected=()
+  while IFS= read -r -d '' path; do
+    [ -n "$path" ] || continue
+    collected+=("$path")
+  done
+}
+
+case "$mode" in
+  changed | changed-live)
+    base="${2:-}"
+    [ -n "$base" ] || usage_error "<base-ref>"
+    require_base "$base"
+    # `--diff-filter=d` excludes deletions (lowercase = exclude), i.e. "the
+    # paths that exist in the pushed commit". Spelled as an exclusion rather
+    # than an ACMR allow-list so a status letter git adds later still lands on
+    # the "exists" side instead of vanishing from the run.
+    #
+    # `--no-renames` because rename detection reports ONLY the destination:
+    # `scripts/seed-x.mjs` -> `tests/x.test.mjs` would leave nothing under
+    # scripts/ in the list, so the seed category never fires for a push that
+    # unmistakably touched it. Every gate here scopes by path prefix, and a
+    # path that stopped existing is exactly as interesting as one that started.
+    if [ "$mode" = changed-live ]; then
+      git diff --name-only -z --no-renames --diff-filter=d "$base...HEAD" || exit 1
+    else
+      git diff --name-only -z --no-renames "$base...HEAD" || exit 1
+    fi
+    ;;
+
+  drift)
+    # Paths this push CHANGES whose worktree bytes differ from HEAD. The gates
+    # would test the worktree copy while git pushes the HEAD copy: an unstaged
+    # fix reads as a passing suite over broken committed bytes, an unstaged
+    # delete drops the file from the run entirely. Both then cache HEAD green.
+    base="${2:-}"
+    [ -n "$base" ] || usage_error "<base-ref>"
+    require_base "$base"
+
+    read_nul < <(git diff --name-only -z --no-renames "$base...HEAD")
+    branch_paths=("${collected[@]}")
+
+    # `git diff HEAD` covers staged and unstaged alike — the index is not what
+    # gets pushed either.
+    read_nul < <(git diff --name-only -z HEAD --)
+
+    found=0
+    for worktree_path in "${collected[@]}"; do
+      for branch_path in "${branch_paths[@]}"; do
+        if [ "$worktree_path" = "$branch_path" ]; then
+          printf '%s\0' "$worktree_path"
+          found=1
+          break
+        fi
+      done
+    done
+    [ "$found" -eq 0 ] || exit 3
+    ;;
+
+  dirty)
+    # Anything that makes the worktree differ from HEAD, in scope or not. This
+    # governs only whether the run may be CACHED as an attestation of
+    # `HEAD^{tree}` — an unrelated edit still means the gates ran against bytes
+    # that are not the ones being stamped green. Untracked-but-not-ignored
+    # counts: a forgotten `git add` is a file the gates can import and the push
+    # cannot deliver.
+    found=0
+    read_nul < <(git diff --name-only -z HEAD --)
+    for path in "${collected[@]}"; do
+      printf '%s\0' "$path"
+      found=1
+    done
+    read_nul < <(git ls-files -z --others --exclude-standard)
+    for path in "${collected[@]}"; do
+      printf '%s\0' "$path"
+      found=1
+    done
+    [ "$found" -eq 0 ] || exit 3
+    ;;
+
+  cache-read)
+    cache_file="${2:-}"
+    tree="${3:-}"
+    diff_resolved="${4:-}"
+    [ -n "$cache_file" ] && [ -n "$diff_resolved" ] || usage_error "<file> <tree> <diff-resolved>"
+    # Reads stay disabled when the branch diff could not be resolved: the tree
+    # hash captures content-derived plan inputs (a package.json change is in
+    # the tree) but NOT state-derived ones, so a blind run must not trust an
+    # attestation minted under a scoped plan it can no longer verify.
+    [ "$diff_resolved" = true ] || exit 3
+    [ -n "$tree" ] || exit 3
+    [ -f "$cache_file" ] || exit 3
+    grep -qxF "$tree" "$cache_file" 2>/dev/null || exit 3
+    ;;
+
+  cache-write)
+    cache_file="${2:-}"
+    tree="${3:-}"
+    diff_resolved="${4:-}"
+    attestable="${5:-}"
+    [ -n "$cache_file" ] && [ -n "$diff_resolved" ] && [ -n "$attestable" ] ||
+      usage_error "<file> <tree> <diff-resolved> <attestable>"
+
+    if [ -z "$tree" ]; then
+      echo "not caching: HEAD has no resolvable tree hash."
+      exit 3
+    fi
+    if [ "$diff_resolved" != true ]; then
+      # The fallback run is NOT "everything ran, the strongest attestation" —
+      # it sets RUN_ALL, and RUN_ALL explicitly skips the local unit suite. On
+      # a multi-commit branch the HEAD~1 fallback never even looked at the
+      # earlier commits. Stamping HEAD green here lets a later run, once
+      # origin/main resolves again, cache-hit straight past all of it.
+      echo "not caching: the branch diff could not be resolved, so this run skipped the unit suite."
+      exit 3
+    fi
+    if [ "$attestable" != true ]; then
+      # The gates ran against a worktree that is not HEAD. Whatever they
+      # proved, they did not prove it about the tree being stamped.
+      echo "not caching: the worktree is not byte-identical to HEAD."
+      exit 3
+    fi
+    printf '%s\n' "$tree" > "$cache_file" || exit 1
+    ;;
+esac
+
+exit 0

--- a/scripts/prepush-changed-tests.sh
+++ b/scripts/prepush-changed-tests.sh
@@ -23,16 +23,26 @@
 # source grep stays green when `-n` is flipped to `-z` or `|| exit 1` is
 # dropped. Here it is a behavior a test can execute against stubbed runners.
 #
-# Usage:
-#   printf '%s\n' "$CHANGED_FILES"     | bash scripts/prepush-changed-tests.sh node
-#   printf '%s\n' "$CHANGED_FILES"     | bash scripts/prepush-changed-tests.sh dom
-#   printf '%s\n' "$TESTS_CHANGED"     | bash scripts/prepush-changed-tests.sh run-node
-#   printf '%s\n' "$DOM_TESTS_CHANGED" | bash scripts/prepush-changed-tests.sh run-dom
+# Usage (every list is NUL-delimited, in and out):
+#   printf '%s\0' "${CHANGED_LIVE[@]}"     | bash scripts/prepush-changed-tests.sh node
+#   printf '%s\0' "${CHANGED_LIVE[@]}"     | bash scripts/prepush-changed-tests.sh dom
+#   printf '%s\0' "${TESTS_CHANGED[@]}"    | bash scripts/prepush-changed-tests.sh run-node
+#   printf '%s\0' "${DOM_TESTS_CHANGED[@]}"| bash scripts/prepush-changed-tests.sh run-dom
 #
-# The two partition modes read a newline-separated list of repo-relative
-# changed paths on stdin and write the subset owned by that runner to stdout,
-# skipping paths the push deleted (a runner invoked with a removed file fails
-# on the missing file, not on the code).
+# NUL rather than newlines because `git diff --name-only` C-quotes unicode,
+# backslash and newline paths under git's default core.quotePath — a line
+# reader then holds `"tests/caf\303\251.test.mjs"`, which names no file, and the
+# gate sails past a changed test having run nothing (#5800). The hook reads the
+# diff with `-z` (scripts/prepush-attest.sh) and the list stays raw bytes from
+# there to `tsx --test`.
+#
+# The two partition modes write the subset of stdin owned by that runner to
+# stdout. Deletion filtering is NOT done here: the caller supplies the paths
+# that exist in the pushed commit (`prepush-attest.sh changed-live`), because
+# `[ -f ]` cannot tell "the push deleted it" from "the worktree drifted from
+# what is being pushed" — and inferring the first while it was the second is
+# how a changed test silently stopped running. A test path that is missing on
+# disk is therefore a broken invariant, and fails loudly.
 #
 # The two run modes read that runner's final file list and exit non-zero when
 # the runner fails. An empty list is a no-op, not a failure.
@@ -48,19 +58,21 @@ case "$mode" in
     ;;
 esac
 
-# read_list: stdin -> the `selected` array, dropping blank lines.
+# read_list: NUL-delimited stdin -> the `selected` array, dropping blanks.
 selected=()
 read_list() {
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    selected+=("$line")
+  local entry
+  while IFS= read -r -d '' entry; do
+    [ -n "$entry" ] || continue
+    selected+=("$entry")
   done
 }
 
-# partition: stdin -> the `selected` array, filtered to files this runner owns.
+# partition: NUL-delimited stdin -> the `selected` array, filtered to files this
+# runner owns.
 partition() {
   local want="$1" file owner
-  while IFS= read -r file; do
+  while IFS= read -r -d '' file; do
     [ -n "$file" ] || continue
 
     # Ownership first, extension second. Both extensions live under tests/dom/ —
@@ -72,8 +84,21 @@ partition() {
     esac
     [ "$owner" = "$want" ] || continue
 
-    printf '%s\n' "$file" | grep -qE '^tests/.*\.test\.(mjs|mts)$' || continue
-    [ -f "$file" ] || continue
+    # `case` rather than a `grep` subshell: one fork per changed path, and a
+    # path containing a newline would reach grep as two lines.
+    case "$file" in
+      tests/*.test.mjs | tests/*.test.mts) ;;
+      *) continue ;;
+    esac
+
+    # The caller passes paths that exist in the pushed commit, so a missing one
+    # means the worktree no longer holds what is being pushed. Skipping it here
+    # is what let a changed test disappear from the gate with exit 0 (#5800).
+    if [ ! -f "$file" ]; then
+      echo "ERROR: '$file' is in this push but missing from the worktree — cannot run it." >&2
+      echo "  Commit the deletion, or restore the file, then push again." >&2
+      exit 1
+    fi
 
     selected+=("$file")
   done
@@ -82,7 +107,7 @@ partition() {
 case "$mode" in
   node | dom)
     partition "$mode"
-    [ "${#selected[@]}" -eq 0 ] || printf '%s\n' "${selected[@]}"
+    [ "${#selected[@]}" -eq 0 ] || printf '%s\0' "${selected[@]}"
     ;;
 
   run-node)

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -245,6 +245,44 @@ describe('drift: the gates test the worktree, the cache claims HEAD', () => {
     assert.equal(attest(root, ['drift', 'base']).status, 3);
   });
 
+  test('a path containing glob metacharacters is matched literally', () => {
+    // The intersection hands the branch paths to git as pathspecs, and `*`,
+    // `?` and `[` are legal in a filename but magic in a pathspec. The push
+    // changes `tests/b[1].test.mjs`; the dirty file is `tests/b1.test.mjs`,
+    // which the push does NOT touch. Read as a character class, the pathspec
+    // matches the dirty file and blocks the push over an unrelated edit.
+    const root = makeRepo({
+      baseFiles: { 'README.md': 'base\n', 'tests/b1.test.mjs': 'x\n' },
+      branchFiles: { 'tests/b[1].test.mjs': 'x\n' },
+    });
+    write(root, 'tests/b1.test.mjs', 'unrelated edit\n');
+
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 0, 'an edit outside the push must not be drift');
+    assert.deepEqual(paths, []);
+  });
+
+  test('drift in a glob-metacharacter path is still caught', () => {
+    // The other half: matching literally must not mean matching nothing.
+    const root = makeRepo({ branchFiles: { 'tests/b[1].test.mjs': 'broken\n' } });
+    write(root, 'tests/b[1].test.mjs', 'fixed\n');
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 3);
+    assert.deepEqual(paths, ['tests/b[1].test.mjs']);
+  });
+
+  test('an empty branch diff reports no drift, however dirty the worktree', () => {
+    // `git diff HEAD -- ` with an empty pathspec list means ALL paths, so an
+    // unguarded intersection would report every unrelated edit as drift and
+    // block a push that changes nothing.
+    const root = makeRepo({ baseFiles: { 'README.md': 'base\n', 'notes.md': 'base\n' } });
+    write(root, 'notes.md', 'scratch\n');
+    write(root, 'README.md', 'scratch\n');
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 0);
+    assert.deepEqual(paths, []);
+  });
+
   test('drift ignores edits to files this push does not change', () => {
     // Scoped on purpose: blocking every push that has an unrelated scratch
     // edit would be a gate nobody can pass. Out-of-scope dirt is handled by

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -1,0 +1,446 @@
+// Green-tree attestation primitives for the pre-push gate (#5800).
+//
+// `.husky/pre-push` caches `HEAD^{tree}` after a green run and skips every
+// tree-dependent gate on a later push of that tree. Three ways it could stamp a
+// tree the gates never actually exercised, all reproduced here first:
+//
+//   1. The gates run the WORKTREE, the cache claims HEAD. An unstaged delete
+//      dropped a changed test from the run; an unstaged fix made the suite pass
+//      over broken committed bytes. Either way HEAD went in the cache.
+//   2. `git diff --name-only` C-quotes unicode/backslash/newline paths under
+//      git's default `core.quotePath`, so those paths matched nothing on disk
+//      and were silently dropped — file changed, nothing ran, gate green.
+//   3. The unresolvable-origin/main fallback sets RUN_ALL, RUN_ALL *skips* the
+//      local unit suite, and the cache was written anyway.
+//
+// Every assertion below executes the real scripts/prepush-attest.sh against a
+// real git fixture. A source grep over the hook could not carry these: it stays
+// green when `true` is flipped to `false` or a `|| exit` is dropped.
+//
+// Exit codes are asserted, not just output: 0 (clean/hit/written) and 3
+// (drift/dirty/miss/refused) must never collapse, because "the gate could not
+// answer" reading as "the gate said yes" is exactly the failure being closed.
+
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = join(REPO_ROOT, 'scripts', 'prepush-attest.sh');
+
+// git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE... to hook children, and
+// those OVERRIDE cwd — a fixture built without stripping them writes its
+// commits and its `git config user.email` into the REAL repo. Strip the list
+// git itself publishes rather than guessing at it.
+const GIT_LOCAL_ENV_VARS = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n');
+
+function isolatedGitEnv(overrides = {}) {
+  const env = { ...process.env, ...overrides, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+  for (const name of GIT_LOCAL_ENV_VARS) delete env[name];
+  return env;
+}
+
+const fixtures = [];
+process.on('exit', () => {
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, env: isolatedGitEnv(), encoding: 'utf8' });
+}
+
+function write(root, relativePath, contents = 'fixture\n') {
+  const target = join(root, relativePath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+/**
+ * A repo with `base` standing in for origin/main and one branch commit on top.
+ * `branchFiles` are added by that commit — they are the "pushed bytes".
+ */
+function makeRepo({ baseFiles = { 'README.md': 'base\n' }, branchFiles = {} } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'wm-prepush-attest-'));
+  fixtures.push(root);
+  git(root, ['init', '--quiet', '--initial-branch=main', '.']);
+  git(root, ['config', 'user.email', 'prepush-attest@example.invalid']);
+  git(root, ['config', 'user.name', 'Prepush Attest Fixture']);
+  for (const [path, contents] of Object.entries(baseFiles)) write(root, path, contents);
+  git(root, ['add', '-A']);
+  git(root, ['commit', '--quiet', '-m', 'base']);
+  git(root, ['branch', '--quiet', 'base']);
+  if (Object.keys(branchFiles).length > 0) {
+    for (const [path, contents] of Object.entries(branchFiles)) write(root, path, contents);
+    git(root, ['add', '-A']);
+    git(root, ['commit', '--quiet', '-m', 'branch work']);
+  }
+  return root;
+}
+
+/** Runs a mode and returns its exit status plus the NUL-delimited stdout, split. */
+function attest(cwd, args) {
+  let status = 0;
+  let stdout = '';
+  try {
+    stdout = execFileSync('bash', [SCRIPT, ...args], {
+      cwd,
+      env: isolatedGitEnv(),
+      encoding: 'utf8',
+    });
+  } catch (err) {
+    status = err.status;
+    stdout = err.stdout ?? '';
+  }
+  return { status, paths: stdout.split('\0').filter(Boolean), stdout };
+}
+
+describe('changed-path enumeration survives every legal git path', () => {
+  // core.quotePath=true is git's DEFAULT. `--name-only` then emits
+  // `"tests/caf\303\251.test.mjs"` — quotes, escapes and all — which matches no
+  // file on disk, so the hook's existence filter dropped it and the gate went
+  // green having run nothing. Backslash and newline paths are C-quoted even
+  // with core.quotePath=false, so -z is the only complete fix.
+  const HOSTILE = {
+    'tests/plain.test.mjs': 'x\n',
+    'tests/café.test.mjs': 'x\n',
+    'tests/back\\slash.test.mjs': 'x\n',
+    'tests/with space.test.mjs': 'x\n',
+  };
+
+  test('the unicode/backslash/space paths a plain --name-only read loses', () => {
+    const root = makeRepo({ branchFiles: HOSTILE });
+
+    // The old plumbing, reproduced: line-read `git diff --name-only`, then
+    // infer existence from the filesystem.
+    const quoted = git(root, ['diff', '--name-only', 'base...HEAD']).split('\n').filter(Boolean);
+    const dropped = quoted.filter((path) => path.startsWith('"'));
+    assert.deepEqual(
+      dropped.sort(),
+      ['"tests/back\\\\slash.test.mjs"', '"tests/caf\\303\\251.test.mjs"'],
+      'baseline: git C-quotes these, so they no longer name a file that exists',
+    );
+
+    const { status, paths } = attest(root, ['changed', 'base']);
+    assert.equal(status, 0);
+    assert.deepEqual(paths.sort(), Object.keys(HOSTILE).sort(), 'every legal path must survive');
+  });
+
+  test('a path containing a newline stays one path', () => {
+    // The reason this is NUL-delimited rather than `core.quotePath=false`: a
+    // line-oriented reader splits this path into two nonexistent ones.
+    const root = makeRepo({ branchFiles: { 'tests/two\nlines.test.mjs': 'x\n' } });
+    const { status, paths } = attest(root, ['changed', 'base']);
+    assert.equal(status, 0);
+    assert.deepEqual(paths, ['tests/two\nlines.test.mjs']);
+  });
+});
+
+describe('deletions come from git, never from the filesystem', () => {
+  test('changed-live excludes paths the push deletes', () => {
+    const root = makeRepo({
+      baseFiles: { 'README.md': 'base\n', 'tests/gone.test.mjs': 'x\n' },
+      branchFiles: { 'tests/kept.test.mjs': 'x\n' },
+    });
+    git(root, ['rm', '--quiet', 'tests/gone.test.mjs']);
+    git(root, ['commit', '--quiet', '-m', 'drop a test']);
+
+    assert.deepEqual(attest(root, ['changed', 'base']).paths.sort(), [
+      'tests/gone.test.mjs',
+      'tests/kept.test.mjs',
+    ]);
+    assert.deepEqual(
+      attest(root, ['changed-live', 'base']).paths,
+      ['tests/kept.test.mjs'],
+      'changed-live is "exists in the pushed commit", so a deleted path is gone',
+    );
+  });
+
+  test('a rename lists BOTH paths, not just the destination', () => {
+    // Rename detection reports only the destination, so a
+    // `scripts/seed-x.mjs` -> `tests/x-seed.test.mjs` move left NOTHING under
+    // scripts/ in the list and the seed category never fired for a push that
+    // plainly touched it. Every gate here scopes by path prefix, so the
+    // vacated path matters as much as the new one.
+    const root = makeRepo({
+      baseFiles: { 'scripts/seed-x.mjs': 'same bytes\n', 'tests/other.test.mjs': 'x\n' },
+    });
+    git(root, ['mv', 'scripts/seed-x.mjs', 'tests/x-seed.test.mjs']);
+    git(root, ['commit', '--quiet', '-m', 'move it']);
+
+    assert.deepEqual(attest(root, ['changed', 'base']).paths.sort(), [
+      'scripts/seed-x.mjs',
+      'tests/x-seed.test.mjs',
+    ]);
+    assert.deepEqual(
+      attest(root, ['changed-live', 'base']).paths,
+      ['tests/x-seed.test.mjs'],
+      'only the destination survives into the pushed commit',
+    );
+  });
+
+  test('changed-live still lists a file the worktree deleted but the push keeps', () => {
+    // The exact #5800 case. `[ -f ]` called this "deleted by the push" and
+    // dropped it; git knows the pushed commit still contains it.
+    const root = makeRepo({ branchFiles: { 'tests/beta.test.mjs': 'x\n' } });
+    rmSync(join(root, 'tests/beta.test.mjs'));
+
+    assert.deepEqual(
+      attest(root, ['changed-live', 'base']).paths,
+      ['tests/beta.test.mjs'],
+      'the pushed commit contains it, so the gate owes it a run',
+    );
+  });
+
+  test('an unresolvable base is exit 3, not an empty changed list', () => {
+    // An empty list reads as "nothing changed, skip everything" — the loudest
+    // possible thing to get wrong quietly.
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    for (const mode of ['changed', 'changed-live', 'drift']) {
+      const { status, paths } = attest(root, [mode, 'origin/nope']);
+      assert.equal(status, 3, `${mode} must report "cannot resolve", not "nothing"`);
+      assert.deepEqual(paths, []);
+    }
+  });
+});
+
+describe('drift: the gates test the worktree, the cache claims HEAD', () => {
+  test('a clean worktree reports no drift', () => {
+    const root = makeRepo({ branchFiles: { 'tests/beta.test.mjs': 'x\n' } });
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 0);
+    assert.deepEqual(paths, []);
+  });
+
+  test('an unstaged delete of a pushed test is drift', () => {
+    const root = makeRepo({ branchFiles: { 'tests/beta.test.mjs': 'x\n' } });
+    rmSync(join(root, 'tests/beta.test.mjs'));
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 3);
+    assert.deepEqual(paths, ['tests/beta.test.mjs']);
+  });
+
+  test('an unstaged FIX over broken committed bytes is drift', () => {
+    // The worse variant: the suite passes on the worktree copy while the
+    // broken committed copy is what git pushes — and gets cached green.
+    const root = makeRepo({ branchFiles: { 'src/broken.ts': 'export const x = BROKEN\n' } });
+    write(root, 'src/broken.ts', 'export const x = 1;\n');
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 3);
+    assert.deepEqual(paths, ['src/broken.ts']);
+  });
+
+  test('a STAGED but uncommitted fix is drift too', () => {
+    // `git push` delivers HEAD, not the index.
+    const root = makeRepo({ branchFiles: { 'src/broken.ts': 'export const x = BROKEN\n' } });
+    write(root, 'src/broken.ts', 'export const x = 1;\n');
+    git(root, ['add', 'src/broken.ts']);
+    assert.equal(attest(root, ['drift', 'base']).status, 3);
+  });
+
+  test('drift ignores edits to files this push does not change', () => {
+    // Scoped on purpose: blocking every push that has an unrelated scratch
+    // edit would be a gate nobody can pass. Out-of-scope dirt is handled by
+    // withholding the cache instead — see the `dirty` suite.
+    const root = makeRepo({
+      baseFiles: { 'README.md': 'base\n', 'notes.md': 'base\n' },
+      branchFiles: { 'src/a.ts': 'x\n' },
+    });
+    write(root, 'notes.md', 'scratch\n');
+    const { status, paths } = attest(root, ['drift', 'base']);
+    assert.equal(status, 0);
+    assert.deepEqual(paths, []);
+  });
+});
+
+describe('dirty: what may be stamped as an attestation of HEAD', () => {
+  test('a pristine worktree is attestable', () => {
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    const { status, paths } = attest(root, ['dirty']);
+    assert.equal(status, 0);
+    assert.deepEqual(paths, []);
+  });
+
+  test('an out-of-scope tracked edit blocks attestation', () => {
+    const root = makeRepo({
+      baseFiles: { 'README.md': 'base\n', 'notes.md': 'base\n' },
+      branchFiles: { 'src/a.ts': 'x\n' },
+    });
+    write(root, 'notes.md', 'scratch\n');
+    const { status, paths } = attest(root, ['dirty']);
+    assert.equal(status, 3, 'the gates ran against bytes that are not HEAD');
+    assert.deepEqual(paths, ['notes.md']);
+  });
+
+  test('a forgotten git add blocks attestation', () => {
+    // The gates can import an untracked module; the push cannot deliver it.
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    write(root, 'src/uncommitted.ts', 'export const y = 1;\n');
+    const { status, paths } = attest(root, ['dirty']);
+    assert.equal(status, 3);
+    assert.deepEqual(paths, ['src/uncommitted.ts']);
+  });
+
+  test('an ignored file does not block attestation', () => {
+    const root = makeRepo({ baseFiles: { 'README.md': 'base\n', '.gitignore': 'build/\n' } });
+    write(root, 'build/output.js', 'x\n');
+    assert.equal(attest(root, ['dirty']).status, 0);
+  });
+});
+
+describe('cache reads', () => {
+  function cacheFile(root, contents) {
+    const path = join(root, 'gate-cache');
+    writeFileSync(path, contents);
+    return path;
+  }
+
+  test('hits on an exact tree recorded by an earlier green run', () => {
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    const tree = git(root, ['rev-parse', 'HEAD^{tree}']).trim();
+    const path = cacheFile(root, `${tree}\n`);
+    assert.equal(attest(root, ['cache-read', path, tree, 'true']).status, 0);
+  });
+
+  test('misses on a different tree, an absent file, and an empty tree hash', () => {
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    const tree = git(root, ['rev-parse', 'HEAD^{tree}']).trim();
+    const path = cacheFile(root, 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n');
+    assert.equal(attest(root, ['cache-read', path, tree, 'true']).status, 3);
+    assert.equal(attest(root, ['cache-read', join(root, 'absent'), tree, 'true']).status, 3);
+    assert.equal(attest(root, ['cache-read', path, '', 'true']).status, 3);
+  });
+
+  test('refuses to read when the branch diff could not be resolved', () => {
+    // The tree hash captures content-derived plan inputs but not state-derived
+    // ones, so a blind run must not trust an attestation minted under a scoped
+    // plan it can no longer verify.
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    const tree = git(root, ['rev-parse', 'HEAD^{tree}']).trim();
+    const path = cacheFile(root, `${tree}\n`);
+    assert.equal(attest(root, ['cache-read', path, tree, 'false']).status, 3);
+  });
+});
+
+describe('cache writes only attest what actually ran', () => {
+  function setup() {
+    const root = makeRepo({ branchFiles: { 'src/a.ts': 'x\n' } });
+    return { root, tree: git(root, ['rev-parse', 'HEAD^{tree}']).trim(), path: join(root, 'gate-cache') };
+  }
+
+  test('writes after a resolved, clean run', () => {
+    const { root, tree, path } = setup();
+    assert.equal(attest(root, ['cache-write', path, tree, 'true', 'true']).status, 0);
+    assert.equal(readFileSync(path, 'utf8').trim(), tree);
+  });
+
+  test('refuses when the branch diff was unresolvable', () => {
+    // RUN_ALL fires in that fallback and RUN_ALL explicitly SKIPS the local
+    // unit suite, so "a fallback run executes everything" was never true.
+    const { root, tree, path } = setup();
+    const { status, stdout } = attest(root, ['cache-write', path, tree, 'false', 'true']);
+    assert.equal(status, 3);
+    assert.match(stdout, /not caching/);
+    assert.throws(() => readFileSync(path, 'utf8'));
+  });
+
+  test('refuses when the worktree is not byte-identical to HEAD', () => {
+    const { root, tree, path } = setup();
+    const { status, stdout } = attest(root, ['cache-write', path, tree, 'true', 'false']);
+    assert.equal(status, 3);
+    assert.match(stdout, /not caching/);
+    assert.throws(() => readFileSync(path, 'utf8'));
+  });
+
+  test('refuses when HEAD has no resolvable tree hash', () => {
+    const { root, path } = setup();
+    assert.equal(attest(root, ['cache-write', path, '', 'true', 'true']).status, 3);
+    assert.throws(() => readFileSync(path, 'utf8'));
+  });
+
+  test('a refused write leaves an earlier honest attestation intact', () => {
+    // Refusing is "I cannot vouch for this run", not "the previous run lied".
+    const { root, tree, path } = setup();
+    writeFileSync(path, `${tree}\n`);
+    assert.equal(attest(root, ['cache-write', path, tree, 'true', 'false']).status, 3);
+    assert.equal(readFileSync(path, 'utf8').trim(), tree);
+  });
+});
+
+describe('mode and argument handling fails loudly', () => {
+  test('an unknown mode exits 2 rather than emitting an empty list', () => {
+    const root = makeRepo();
+    const { status, paths } = attest(root, ['drfit', 'base']);
+    assert.equal(status, 2);
+    assert.deepEqual(paths, []);
+  });
+
+  test('every mode that needs a base ref rejects a missing one', () => {
+    const root = makeRepo();
+    for (const mode of ['changed', 'changed-live', 'drift']) {
+      assert.equal(attest(root, [mode]).status, 2, `${mode} needs a base ref`);
+    }
+  });
+
+  test('the cache modes reject missing arguments', () => {
+    const root = makeRepo();
+    assert.equal(attest(root, ['cache-read', join(root, 'c'), 'tree']).status, 2);
+    assert.equal(attest(root, ['cache-write', join(root, 'c'), 'tree', 'true']).status, 2);
+  });
+});
+
+describe('pre-push wiring: the hook must consume these decisions', () => {
+  // Weaker than the executable cases above — it can only prove the calls are
+  // present, not that they behave. It exists because the hook is the one place
+  // that cannot be executed cheaply in a test (it runs tsc, esbuild and vite),
+  // so a silently unwired script would otherwise be invisible.
+  const hook = readFileSync(join(REPO_ROOT, '.husky', 'pre-push'), 'utf8');
+
+  // assert.ok over a boolean rather than assert.match over the file: a failure
+  // here otherwise prints all 500 lines of the hook as the "actual" value.
+  const has = (pattern, message) => assert.ok(pattern.test(hook), message);
+  const lacks = (pattern, message) => assert.ok(!pattern.test(hook), message);
+
+  test('binds $ATTEST to this script', () => {
+    // The calls below are spelled `"$ATTEST" <mode>`, so the binding is what
+    // makes them mean anything.
+    has(/^ATTEST="scripts\/prepush-attest\.sh"$/m);
+  });
+
+  test('routes the changed-path enumeration through prepush-attest.sh', () => {
+    has(/"\$ATTEST" changed origin\/main/, 'scoping list must come from the NUL-safe enumeration');
+    has(/"\$ATTEST" changed-live /, 'the runner list must exclude pushed deletions');
+  });
+
+  test('checks drift and dirt, and blocks the push on drift', () => {
+    has(/"\$ATTEST" drift /, 'drift is the P1 — pushing bytes the gates never ran');
+    has(/"\$ATTEST" dirty/, 'dirt decides whether the run may be cached');
+  });
+
+  test('delegates both cache decisions instead of writing the file inline', () => {
+    has(/"\$ATTEST" cache-read /);
+    has(/"\$ATTEST" cache-write /);
+    lacks(
+      /^\s*echo "\$TREE_HASH" > "\$GATE_CACHE"/m,
+      'an inline write bypasses every refusal rule tested above',
+    );
+  });
+
+  test('no changed-path consumer reads the quote-prone plain --name-only diff', () => {
+    // `git diff --name-only origin/main...HEAD` without -z is the read that
+    // loses unicode and backslash paths. Scoping diffs at fixed ASCII paths
+    // (`-- scripts/package.json`) only ask "did anything change", so they are
+    // unaffected; a bare three-dot branch diff is not.
+    lacks(
+      /git diff --name-only [^|\n]*\.\.\.HEAD/,
+      'a plain three-dot --name-only read silently drops C-quoted paths',
+    );
+  });
+});

--- a/tests/prepush-changed-tests.test.mjs
+++ b/tests/prepush-changed-tests.test.mjs
@@ -18,15 +18,35 @@
 // wiring exists, not that it behaves — the executable cases above carry that.
 
 import { strict as assert } from 'node:assert';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = join(REPO_ROOT, 'scripts', 'prepush-changed-tests.sh');
+
+// Every mkdtemp below funnels through here so the run leaves nothing behind.
+// These fixtures used to accumulate one directory per call in $TMPDIR forever.
+const FIXTURE_DIRS = [];
+function fixtureDir(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  FIXTURE_DIRS.push(dir);
+  return dir;
+}
+after(() => {
+  for (const dir of FIXTURE_DIRS) rmSync(dir, { recursive: true, force: true });
+});
 
 /** Files that exist on disk in the fixture worktree. */
 const EXISTING = [
@@ -52,7 +72,7 @@ const CHANGED = [...EXISTING];
 const RUNNABLE_TESTS = EXISTING.filter((f) => /\.test\.(mjs|mts)$/.test(f));
 
 function makeFixtureWorktree(files = EXISTING) {
-  const root = mkdtempSync(join(tmpdir(), 'wm-prepush-partition-'));
+  const root = fixtureDir('wm-prepush-partition-');
   for (const file of files) {
     mkdirSync(join(root, dirname(file)), { recursive: true });
     writeFileSync(join(root, file), '// fixture\n');
@@ -194,7 +214,7 @@ describe('partition stays in step with the vitest DOM project', () => {
   // vitest/config (~220MB RSS) into the shared `npm run test:data` runner,
   // which already OOMs at the tail of its ~390-file single-process run.
   const include = (() => {
-    const probe = join(mkdtempSync(join(tmpdir(), 'wm-dom-config-probe-')), 'probe.mts');
+    const probe = join(fixtureDir('wm-dom-config-probe-'), 'probe.mts');
     writeFileSync(
       probe,
       `const m = await import(${JSON.stringify(join(REPO_ROOT, 'vitest.dom.config.mts'))});\n` +
@@ -259,7 +279,7 @@ describe('runner dispatch', () => {
   // the suite. The decision now lives in the script, so these run it for real
   // against stubbed runners and assert what was invoked.
   function runDispatch(mode, list, { stubExit = 0 } = {}) {
-    const dir = mkdtempSync(join(tmpdir(), 'wm-prepush-dispatch-'));
+    const dir = fixtureDir('wm-prepush-dispatch-');
     const log = join(dir, 'invocations.log');
     for (const bin of ['npm', 'npx']) {
       const stub = join(dir, bin);

--- a/tests/prepush-changed-tests.test.mjs
+++ b/tests/prepush-changed-tests.test.mjs
@@ -40,8 +40,13 @@ const EXISTING = [
   'src/services/thing.ts',
 ];
 
-/** Changed-file list handed to the script — a superset of what exists. */
-const CHANGED = [...EXISTING, 'tests/removed.test.mjs', 'tests/dom/removed.test.mts'];
+/**
+ * Changed-file list handed to the script. Every entry exists on disk: the hook
+ * now passes the paths that exist in the pushed commit
+ * (`prepush-attest.sh changed-live`), so a missing one is a broken invariant
+ * rather than "the push deleted it" — see the loud-failure case below.
+ */
+const CHANGED = [...EXISTING];
 
 /** Every changed path that is a test file the repo expects to run somewhere. */
 const RUNNABLE_TESTS = EXISTING.filter((f) => /\.test\.(mjs|mts)$/.test(f));
@@ -64,13 +69,18 @@ function expandBraces(glob) {
     .flatMap((option) => expandBraces(glob.replace(match[0], option.trim())));
 }
 
+/** NUL-delimited both ways — a C-quoted or newline-bearing path must survive. */
+function nulList(paths) {
+  return paths.map((path) => `${path}\0`).join('');
+}
+
 function partition(mode, { cwd, changed = CHANGED } = {}) {
   const out = execFileSync('bash', [SCRIPT, mode], {
     cwd,
-    input: `${changed.join('\n')}\n`,
+    input: nulList(changed),
     encoding: 'utf8',
   });
-  return out.split('\n').filter(Boolean);
+  return out.split('\0').filter(Boolean);
 }
 
 describe('pre-push changed-test partition', () => {
@@ -119,20 +129,41 @@ describe('pre-push changed-test partition', () => {
     );
   });
 
-  test('drops non-test files and files deleted by the push', () => {
+  test('drops helpers and fixtures that are not test files', () => {
     for (const mode of ['node', 'dom']) {
-      const picked = partition(mode, { cwd });
       assert.deepEqual(
-        picked.filter((f) => !/\.test\.(mjs|mts)$/.test(f)),
+        partition(mode, { cwd }).filter((f) => !/\.test\.(mjs|mts)$/.test(f)),
         [],
         `${mode} mode must not run helpers or fixtures`,
       );
-      assert.deepEqual(
-        picked.filter((f) => f.endsWith('removed.test.mjs') || f.endsWith('removed.test.mts')),
-        [],
-        `${mode} mode must skip paths the push deleted`,
+    }
+  });
+
+  test('a test file missing from the worktree fails loudly instead of vanishing', () => {
+    // #5800: the old `[ -f "$file" ] || continue` read "absent from disk" as
+    // "the push deleted it". It could just as easily mean the worktree drifted
+    // from the commit being pushed — an unstaged `rm` of a changed test made
+    // the gate skip it and report green. Deletion is now filtered upstream by
+    // git, so absence here has exactly one meaning and must stop the push.
+    for (const [mode, missing] of [
+      ['node', 'tests/never-written.test.mjs'],
+      ['dom', 'tests/dom/never-written.test.mts'],
+    ]) {
+      assert.throws(
+        () => partition(mode, { cwd, changed: [...EXISTING, missing] }),
+        (err) => err.status === 1 && /missing from the worktree/.test(String(err.stderr)),
+        `${mode} mode must refuse a path it cannot run`,
       );
     }
+  });
+
+  test('a path containing a newline stays one path', () => {
+    // The reason the list is NUL-delimited: a line reader would split this
+    // into two entries, neither of which exists, and the old code would have
+    // silently dropped both.
+    const weird = 'tests/two\nlines.test.mjs';
+    const root = makeFixtureWorktree([weird]);
+    assert.deepEqual(partition('node', { cwd: root, changed: [weird] }), [weird]);
   });
 
   test('an unknown mode fails loudly instead of silently emitting nothing', () => {
@@ -240,7 +271,7 @@ describe('runner dispatch', () => {
     try {
       execFileSync('bash', [SCRIPT, mode], {
         cwd: REPO_ROOT,
-        input: `${list.join('\n')}\n`,
+        input: nulList(list),
         encoding: 'utf8',
         env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
       });
@@ -317,27 +348,50 @@ describe('pre-push hook wiring', () => {
   });
 
   test('treats a partition failure as a blocked push, not an empty test list', () => {
-    // Command substitution discards the exit status: a missing or broken
-    // helper would yield an empty list, which the hook reads as "no test files
-    // changed" and skips everything. The gate must fail loudly instead.
-    assert.match(hook, /if ! TESTS_CHANGED=\$\(/);
-    assert.match(hook, /if ! DOM_TESTS_CHANGED=\$\(/);
+    // A discarded exit status yields an empty list, which the hook reads as
+    // "no test files changed" and skips everything. The gate must fail loudly.
+    for (const mode of ['node', 'dom']) {
+      const guarded = new RegExp(
+        `if ! [^\\n]*prepush-changed-tests\\.sh ${mode} >[^\\n]*\\n\\s*echo "ERROR[^\\n]*\\n\\s*exit 1`,
+      );
+      assert.ok(guarded.test(hook), `the ${mode} partition must be checked and abort the push`);
+    }
   });
 
-  test('runs the partition test when any file in the routing contract changes', () => {
-    // The contract spans four files. Guarding only the partition script left
-    // the assertions absent exactly when the hook, the vitest project, or the
-    // npm script they pin was the thing being rewritten.
+  test('hands the partition NUL-delimited paths, not a newline-joined string', () => {
+    // `printf '%s\\n' "$LIST"` is what lost C-quoted and space-bearing paths
+    // (#5800); command substitution cannot carry NUL, so the lists move
+    // through files and `nul_list`.
+    assert.ok(
+      !/printf '%s\\n'[^\n]*prepush-changed-tests\.sh/.test(hook),
+      'a newline-joined round trip re-introduces the quoting loss',
+    );
+    for (const mode of ['node', 'dom', 'run-node', 'run-dom']) {
+      assert.ok(
+        new RegExp(`nul_list [^\\n]*prepush-changed-tests\\.sh ${mode}`).test(hook),
+        `${mode} must receive a NUL-delimited list`,
+      );
+    }
+  });
+
+  test('runs the contract tests when any file in the routing contract changes', () => {
+    // The contract spans the hook, both scripts it delegates to, the vitest
+    // project, and the npm script. Guarding only the partition script left the
+    // assertions absent exactly when the thing they pin was being rewritten.
     for (const path of [
       '\\.husky/pre-push',
       'scripts/prepush-changed-tests\\.sh',
+      'scripts/prepush-attest\\.sh',
       'vitest\\.dom\\.config\\.mts',
       'package\\.json',
     ]) {
       assert.ok(
         hook.includes(path),
-        `pre-push must re-run the partition test when ${path} changes`,
+        `pre-push must re-run the contract tests when ${path} changes`,
       );
+    }
+    for (const testFile of ['tests/prepush-changed-tests.test.mjs', 'tests/prepush-attest.test.mjs']) {
+      assert.ok(hook.includes(testFile), `${testFile} must be in the contract-test list`);
     }
   });
 });

--- a/tests/prepush-changed-tests.test.mjs
+++ b/tests/prepush-changed-tests.test.mjs
@@ -99,6 +99,13 @@ function partition(mode, { cwd, changed = CHANGED } = {}) {
     cwd,
     input: nulList(changed),
     encoding: 'utf8',
+    // execFileSync echoes child stderr to the parent unless stdio is explicit.
+    // The cases below deliberately trigger the script's error paths, and this
+    // suite runs INSIDE the pre-push gate — so without piping, a successful
+    // push prints "ERROR: ... missing from the worktree" twice and reads as a
+    // gate that failed. `err.stderr` is still populated, which is what the
+    // loud-failure assertions match on.
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
   return out.split('\0').filter(Boolean);
 }

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -76,7 +76,7 @@ let fixtureCount = 0;
  * A repo carrying the real hook and the two scripts it delegates to, with
  * `refs/remotes/origin/main` at the base commit so branch scoping resolves.
  */
-function makeFixture({ branchFiles = {}, scriptsCjs = true } = {}) {
+function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = null } = {}) {
   const id = fixtureCount++;
   const root = join(WORK, `repo-${id}`);
   const { bin, log } = makeStubs(join(WORK, `aux-${id}`));
@@ -89,6 +89,17 @@ function makeFixture({ branchFiles = {}, scriptsCjs = true } = {}) {
   copyFileSync(HOOK, join(root, '.husky', 'pre-push'));
   for (const script of ['prepush-attest.sh', 'prepush-changed-tests.sh']) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(root, 'scripts', script));
+  }
+  // Fault injection: make one attest mode fail while its siblings still work,
+  // so the hook's handling of a broken enumeration can be executed rather than
+  // reasoned about.
+  if (failAttestMode) {
+    writeFileSync(
+      join(root, 'scripts', 'prepush-attest.sh'),
+      `#!/usr/bin/env bash\n` +
+        `if [ "$1" = ${JSON.stringify(failAttestMode)} ]; then exit 1; fi\n` +
+        `exec bash ${JSON.stringify(join(REPO_ROOT, 'scripts', 'prepush-attest.sh'))} "$@"\n`,
+    );
   }
   writeFileSync(join(root, 'package.json'), '{"name":"fixture"}\n');
   writeFileSync(join(root, 'README.md'), 'base\n');
@@ -157,16 +168,24 @@ function makeFixture({ branchFiles = {}, scriptsCjs = true } = {}) {
   };
 }
 
-/** The arguments of the first `npx tsx --test ...` the hook issued, exactly. */
-function tsxArgs(invocations) {
+/**
+ * The argument list of EVERY `npx tsx --test ...` the hook issued, in order.
+ * All of them, not just the first: asserting one invocation cannot see a
+ * second, duplicate dispatch — which is the failure the TESTS_CHANGED dedup
+ * exists to prevent, so it has to be visible here.
+ */
+function tsxRuns(invocations) {
   const lines = invocations.split('\n');
-  const start = lines.findIndex((line, i) => line === '== npx' && lines[i + 1] === '>tsx');
-  if (start === -1) return null;
-  const args = [];
-  for (let i = start + 1; i < lines.length && lines[i].startsWith('>'); i += 1) {
-    args.push(lines[i].slice(1));
+  const runs = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i] !== '== npx' || lines[i + 1] !== '>tsx') continue;
+    const args = [];
+    for (let j = i + 1; j < lines.length && lines[j].startsWith('>'); j += 1) {
+      args.push(lines[j].slice(1));
+    }
+    runs.push(args);
   }
-  return args;
+  return runs;
 }
 
 describe('a clean push runs the changed tests and attests the tree', () => {
@@ -175,7 +194,7 @@ describe('a clean push runs the changed tests and attests the tree', () => {
     const { status, stdout, invocations } = fixture.run();
 
     assert.equal(status, 0, stdout);
-    assert.deepEqual(tsxArgs(invocations), ['tsx', '--test', 'tests/alpha.test.mjs']);
+    assert.deepEqual(tsxRuns(invocations), [['tsx', '--test', 'tests/alpha.test.mjs']]);
     assert.equal(fixture.cached(), fixture.tree(), 'a clean, resolved, green run is attestable');
   });
 
@@ -186,7 +205,7 @@ describe('a clean push runs the changed tests and attests the tree', () => {
     const second = fixture.run();
     assert.equal(second.status, 0);
     assert.match(second.stdout, /this exact tree already passed/);
-    assert.equal(tsxArgs(second.invocations), null, 'a cache hit must not re-run anything');
+    assert.deepEqual(tsxRuns(second.invocations), [], 'a cache hit must not re-run anything');
   });
 });
 
@@ -201,7 +220,7 @@ describe('worktree drift blocks the push (#5800 item 1)', () => {
     assert.equal(status, 1);
     assert.match(stdout, /differ between your worktree and the commit being pushed/);
     assert.match(stdout, /tests\/beta\.test\.mjs/);
-    assert.equal(tsxArgs(invocations), null);
+    assert.deepEqual(tsxRuns(invocations), []);
     assert.equal(fixture.cached(), null, 'nothing may be attested');
   });
 
@@ -249,7 +268,7 @@ describe('worktree drift blocks the push (#5800 item 1)', () => {
 
     const { status, stdout, invocations } = fixture.run();
     assert.equal(status, 0, stdout);
-    assert.deepEqual(tsxArgs(invocations), ['tsx', '--test', 'tests/gamma.test.mjs']);
+    assert.deepEqual(tsxRuns(invocations), [['tsx', '--test', 'tests/gamma.test.mjs']]);
     assert.match(stdout, /not byte-identical to HEAD/);
     assert.equal(fixture.cached(), null);
   });
@@ -280,8 +299,8 @@ describe('C-quoted and space-bearing paths still reach the runner (#5800 item 2)
     const { status, stdout, invocations } = fixture.run();
     assert.equal(status, 0, stdout);
     assert.deepEqual(
-      tsxArgs(invocations),
-      ['tsx', '--test', 'tests/back\\slash.test.mjs', 'tests/café.test.mjs', 'tests/with space.test.mjs'],
+      tsxRuns(invocations),
+      [['tsx', '--test', 'tests/back\\slash.test.mjs', 'tests/café.test.mjs', 'tests/with space.test.mjs']],
       'every path must arrive intact and as a single argument',
     );
   });
@@ -317,6 +336,32 @@ describe('the unresolved-diff fallback may not attest (#5800 item 3)', () => {
   });
 });
 
+describe('a broken enumeration blocks the push, it does not empty the list', () => {
+  // Every path that produces the changed-file list writes it through a `>`
+  // redirect, which truncates on failure. An unchecked failure therefore hands
+  // the partition an EMPTY list — indistinguishable from "no test files
+  // changed" — and the gate skips every changed test with exit 0. Both call
+  // sites are asserted because only one of them was checked originally.
+  for (const [label, breakOrigin] of [
+    ['with origin/main resolvable', false],
+    ['in the origin/main-unresolvable fallback', true],
+  ]) {
+    test(`refuses to run when changed-live fails ${label}`, () => {
+      const fixture = makeFixture({
+        branchFiles: { 'tests/critical.test.mjs': 'x\n' },
+        failAttestMode: 'changed-live',
+      });
+      if (breakOrigin) fixture.git(['update-ref', '-d', 'refs/remotes/origin/main']);
+
+      const { status, stdout, invocations } = fixture.run();
+      assert.equal(status, 1, 'a gate that cannot enumerate its input must not report success');
+      assert.match(stdout, /refusing to guess which tests to run/);
+      assert.deepEqual(tsxRuns(invocations), []);
+      assert.equal(fixture.cached(), null);
+    });
+  }
+});
+
 describe('the gate does not fail closed on its own edge cases', () => {
   test('a repo with no scripts/*.cjs does not fail the RUN_ALL push', () => {
     // `for f in scripts/*.cjs; do [ -f "$f" ] && node -c "$f" || exit 1; done`
@@ -337,7 +382,7 @@ describe('the gate does not fail closed on its own edge cases', () => {
     const { status, stdout, invocations } = fixture.run();
 
     assert.equal(status, 0, stdout);
-    assert.equal(tsxArgs(invocations), null);
+    assert.deepEqual(tsxRuns(invocations), []);
     assert.equal(fixture.cached(), fixture.tree());
   });
 });

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -1,0 +1,343 @@
+// The pre-push gate, executed end to end (#5800).
+//
+// tests/prepush-attest.test.mjs proves the attestation primitives; this file
+// proves the HOOK — the 500 lines of bash that decide which of those answers
+// to act on. That plumbing is where the failure being fixed actually lived:
+// a changed-path list that lost quoted paths, a `[ -f ]` that read worktree
+// drift as "the push deleted it", and a cache write that fired regardless.
+// None of it is reachable from a unit test of the scripts, and a grep over the
+// hook's source cannot tell a working gate from one whose `true` became
+// `false`.
+//
+// So: a real git fixture, the real hook, and stubs for every external command
+// it shells out to (npm/npx/node/gh/make). Only the hook's own control flow
+// runs, and the stub log is the record of what it decided to execute.
+
+import { strict as assert } from 'node:assert';
+import { after, describe, test } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const HOOK = join(REPO_ROOT, '.husky', 'pre-push');
+
+// git exports GIT_DIR/GIT_WORK_TREE/... to hook children and those override
+// cwd, so a fixture built without stripping them commits into the REAL repo.
+const GIT_LOCAL_ENV_VARS = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n');
+
+const WORK = mkdtempSync(join(tmpdir(), 'wm-prepush-hook-'));
+after(() => rmSync(WORK, { recursive: true, force: true }));
+
+// One argument per line, `>` prefixed, so an assertion can tell a single
+// argument containing a space from two separate arguments.
+const STUB_BODY = (name, log) =>
+  `#!/bin/sh\necho "== ${name}" >> ${JSON.stringify(log)}\n` +
+  `for a in "$@"; do echo ">$a" >> ${JSON.stringify(log)}; done\nexit 0\n`;
+
+/**
+ * Stubs live OUTSIDE the fixture repo: an untracked `stub-bin/` inside it would
+ * make the worktree dirty, which the hook (correctly) refuses to attest.
+ */
+function makeStubs(auxDir) {
+  const bin = join(auxDir, 'bin');
+  const log = join(auxDir, 'invocations.log');
+  mkdirSync(bin, { recursive: true });
+  for (const name of ['npm', 'npx', 'node', 'gh', 'make']) {
+    const stub = join(bin, name);
+    writeFileSync(stub, STUB_BODY(name, log));
+    chmodSync(stub, 0o755);
+  }
+  return { bin, log };
+}
+
+function hookEnv(bin) {
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    // The fixture's .husky is not the outer worktree's, which is exactly what
+    // the self-identity tripwire is for. It is not what this file tests.
+    WM_ALLOW_FOREIGN_HOOKS: '1',
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_SYSTEM: '/dev/null',
+  };
+  for (const name of GIT_LOCAL_ENV_VARS) delete env[name];
+  return env;
+}
+
+let fixtureCount = 0;
+/**
+ * A repo carrying the real hook and the two scripts it delegates to, with
+ * `refs/remotes/origin/main` at the base commit so branch scoping resolves.
+ */
+function makeFixture({ branchFiles = {}, scriptsCjs = true } = {}) {
+  const id = fixtureCount++;
+  const root = join(WORK, `repo-${id}`);
+  const { bin, log } = makeStubs(join(WORK, `aux-${id}`));
+  const env = hookEnv(bin);
+  const git = (args) => execFileSync('git', args, { cwd: root, env, encoding: 'utf8' });
+
+  for (const dir of ['.husky', 'scripts', 'tests', 'node_modules']) {
+    mkdirSync(join(root, dir), { recursive: true });
+  }
+  copyFileSync(HOOK, join(root, '.husky', 'pre-push'));
+  for (const script of ['prepush-attest.sh', 'prepush-changed-tests.sh']) {
+    copyFileSync(join(REPO_ROOT, 'scripts', script), join(root, 'scripts', script));
+  }
+  writeFileSync(join(root, 'package.json'), '{"name":"fixture"}\n');
+  writeFileSync(join(root, 'README.md'), 'base\n');
+  // RUN_ALL fires the CJS syntax check, which iterates `scripts/*.cjs`.
+  if (scriptsCjs) writeFileSync(join(root, 'scripts', 'noop.cjs'), 'module.exports = {};\n');
+
+  // RUN_ALL also forces the pro-test bundle freshness check. Its `git diff
+  // --exit-code` lists these paths explicitly and git exits 128 on an unknown
+  // one, so they all have to exist and be tracked for the gate to reach its
+  // own verdict. An empty pro-test/node_modules skips the install branch
+  // (git does not track empty directories, so it stays invisible to `dirty`).
+  mkdirSync(join(root, 'pro-test', 'node_modules'), { recursive: true });
+  for (const [path, contents] of Object.entries({
+    'src/config/products.generated.ts': 'export const PRODUCTS = [];\n',
+    'src/config/product-ids.generated.ts': 'export const PRODUCT_IDS = [];\n',
+    'pro-test/src/generated/tiers.json': '[]\n',
+    'pro-test/src/locales/en.json': '{}\n',
+    'public/pro/index.html': '<!doctype html>\n',
+  })) {
+    mkdirSync(join(root, dirname(path)), { recursive: true });
+    writeFileSync(join(root, path), contents);
+  }
+
+  git(['init', '--quiet', '--initial-branch=main', '.']);
+  git(['config', 'user.email', 'prepush-hook@example.invalid']);
+  git(['config', 'user.name', 'Prepush Hook Fixture']);
+  git(['add', '-A']);
+  git(['commit', '--quiet', '-m', 'base']);
+  git(['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+
+  if (Object.keys(branchFiles).length > 0) {
+    for (const [path, contents] of Object.entries(branchFiles)) {
+      mkdirSync(join(root, dirname(path)), { recursive: true });
+      writeFileSync(join(root, path), contents);
+    }
+    git(['add', '-A']);
+    git(['commit', '--quiet', '-m', 'branch work']);
+  }
+
+  const run = (extraEnv = {}) => {
+    let status = 0;
+    let stdout = '';
+    try {
+      stdout = execFileSync('bash', ['.husky/pre-push', 'origin'], {
+        cwd: root,
+        env: { ...env, ...extraEnv },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      status = err.status;
+      stdout = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+    }
+    const invocations = existsSync(log) ? readFileSync(log, 'utf8') : '';
+    rmSync(log, { force: true });
+    return { status, stdout, invocations };
+  };
+
+  const cachePath = join(root, '.git', 'wm-prepush-green');
+  return {
+    root,
+    git,
+    run,
+    tree: () => git(['rev-parse', 'HEAD^{tree}']).trim(),
+    cached: () => (existsSync(cachePath) ? readFileSync(cachePath, 'utf8').trim() : null),
+  };
+}
+
+/** The arguments of the first `npx tsx --test ...` the hook issued, exactly. */
+function tsxArgs(invocations) {
+  const lines = invocations.split('\n');
+  const start = lines.findIndex((line, i) => line === '== npx' && lines[i + 1] === '>tsx');
+  if (start === -1) return null;
+  const args = [];
+  for (let i = start + 1; i < lines.length && lines[i].startsWith('>'); i += 1) {
+    args.push(lines[i].slice(1));
+  }
+  return args;
+}
+
+describe('a clean push runs the changed tests and attests the tree', () => {
+  test('dispatches the changed test and caches HEAD^{tree}', () => {
+    const fixture = makeFixture({ branchFiles: { 'tests/alpha.test.mjs': 'x\n' } });
+    const { status, stdout, invocations } = fixture.run();
+
+    assert.equal(status, 0, stdout);
+    assert.deepEqual(tsxArgs(invocations), ['tsx', '--test', 'tests/alpha.test.mjs']);
+    assert.equal(fixture.cached(), fixture.tree(), 'a clean, resolved, green run is attestable');
+  });
+
+  test('the second push of that tree skips the gates entirely', () => {
+    const fixture = makeFixture({ branchFiles: { 'tests/alpha.test.mjs': 'x\n' } });
+    assert.equal(fixture.run().status, 0);
+
+    const second = fixture.run();
+    assert.equal(second.status, 0);
+    assert.match(second.stdout, /this exact tree already passed/);
+    assert.equal(tsxArgs(second.invocations), null, 'a cache hit must not re-run anything');
+  });
+});
+
+describe('worktree drift blocks the push (#5800 item 1)', () => {
+  test('an unstaged delete of a changed test stops the push instead of skipping it', () => {
+    // Previously: `[ -f ]` dropped the file, the gate reported green, and
+    // HEAD^{tree} — which still CONTAINS that test — went into the cache.
+    const fixture = makeFixture({ branchFiles: { 'tests/beta.test.mjs': 'x\n' } });
+    rmSync(join(fixture.root, 'tests/beta.test.mjs'));
+
+    const { status, stdout, invocations } = fixture.run();
+    assert.equal(status, 1);
+    assert.match(stdout, /differ between your worktree and the commit being pushed/);
+    assert.match(stdout, /tests\/beta\.test\.mjs/);
+    assert.equal(tsxArgs(invocations), null);
+    assert.equal(fixture.cached(), null, 'nothing may be attested');
+  });
+
+  test('an unstaged FIX over the committed bytes stops the push', () => {
+    const fixture = makeFixture({ branchFiles: { 'tests/beta.test.mjs': 'broken\n' } });
+    writeFileSync(join(fixture.root, 'tests/beta.test.mjs'), 'fixed\n');
+
+    const { status, stdout } = fixture.run();
+    assert.equal(status, 1);
+    assert.match(stdout, /differ between your worktree and the commit being pushed/);
+    assert.equal(fixture.cached(), null);
+  });
+
+  test('WM_ALLOW_WORKTREE_DRIFT lets it through but still refuses to attest', () => {
+    // A scoped escape hatch is the alternative to people reaching for
+    // `--no-verify`, which skips every gate. It must not be able to buy a
+    // green-tree entry — the drifted worktree is dirty, so the write refuses.
+    const fixture = makeFixture({ branchFiles: { 'tests/beta.test.mjs': 'broken\n' } });
+    writeFileSync(join(fixture.root, 'tests/beta.test.mjs'), 'fixed\n');
+
+    const { status, stdout } = fixture.run({ WM_ALLOW_WORKTREE_DRIFT: '1' });
+    assert.equal(status, 0, stdout);
+    assert.doesNotMatch(stdout, /differ between your worktree/);
+    assert.equal(fixture.cached(), null, 'the hatch must not mint an attestation');
+  });
+
+  test('the hatch does NOT cover a changed test missing from the worktree', () => {
+    // The hatch says "test what is here" — but a file that is not here cannot
+    // be run at all, so the partition refuses separately. The failure has to
+    // stay loud: silently skipping it is the original bug, hatch or no hatch.
+    const fixture = makeFixture({ branchFiles: { 'tests/beta.test.mjs': 'x\n' } });
+    rmSync(join(fixture.root, 'tests/beta.test.mjs'));
+
+    const { status, stdout } = fixture.run({ WM_ALLOW_WORKTREE_DRIFT: '1' });
+    assert.equal(status, 1);
+    assert.match(stdout, /missing from the worktree/);
+    assert.equal(fixture.cached(), null);
+  });
+
+  test('an unrelated dirty file lets the push through but forfeits the cache', () => {
+    // Blocking every push with a scratch edit would be a gate nobody passes;
+    // silently attesting a tree the gates did not run is the actual bug.
+    const fixture = makeFixture({ branchFiles: { 'tests/gamma.test.mjs': 'x\n' } });
+    writeFileSync(join(fixture.root, 'README.md'), 'scratch\n');
+
+    const { status, stdout, invocations } = fixture.run();
+    assert.equal(status, 0, stdout);
+    assert.deepEqual(tsxArgs(invocations), ['tsx', '--test', 'tests/gamma.test.mjs']);
+    assert.match(stdout, /not byte-identical to HEAD/);
+    assert.equal(fixture.cached(), null);
+  });
+
+  test('an untracked file also forfeits the cache', () => {
+    const fixture = makeFixture({ branchFiles: { 'tests/gamma.test.mjs': 'x\n' } });
+    writeFileSync(join(fixture.root, 'src-forgotten.ts'), 'export const x = 1;\n');
+
+    const { status } = fixture.run();
+    assert.equal(status, 0);
+    assert.equal(fixture.cached(), null, 'the gates can import it, the push cannot deliver it');
+  });
+});
+
+describe('C-quoted and space-bearing paths still reach the runner (#5800 item 2)', () => {
+  test('unicode, backslash and space test paths are run, each as one argument', () => {
+    // With git's default core.quotePath, `git diff --name-only` emits
+    // `"tests/caf\303\251.test.mjs"` — quotes and escapes included — which
+    // matches nothing on disk. All three used to vanish from the run silently.
+    const fixture = makeFixture({
+      branchFiles: {
+        'tests/café.test.mjs': 'x\n',
+        'tests/back\\slash.test.mjs': 'x\n',
+        'tests/with space.test.mjs': 'x\n',
+      },
+    });
+
+    const { status, stdout, invocations } = fixture.run();
+    assert.equal(status, 0, stdout);
+    assert.deepEqual(
+      tsxArgs(invocations),
+      ['tsx', '--test', 'tests/back\\slash.test.mjs', 'tests/café.test.mjs', 'tests/with space.test.mjs'],
+      'every path must arrive intact and as a single argument',
+    );
+  });
+});
+
+describe('the unresolved-diff fallback may not attest (#5800 item 3)', () => {
+  test('RUN_ALL skips the unit suite, so the tree is not cached', () => {
+    // The comment justifying the old unconditional write reasoned that "a
+    // fallback run executes everything, the strongest attestation". It does
+    // not: RUN_ALL explicitly skips the local unit suite. A later run, once
+    // origin/main resolved again, could then cache-hit straight past it.
+    const fixture = makeFixture({ branchFiles: { 'tests/delta.test.mjs': 'x\n' } });
+    fixture.git(['update-ref', '-d', 'refs/remotes/origin/main']);
+
+    const { status, stdout } = fixture.run();
+    assert.equal(status, 0, stdout);
+    assert.match(stdout, /Could not resolve branch diff from origin\/main/);
+    assert.match(stdout, /Skipping local full unit test suite/);
+    assert.match(stdout, /not caching: the branch diff could not be resolved/);
+    assert.equal(fixture.cached(), null);
+  });
+
+  test('a tree attested by an earlier honest run is not read back blind', () => {
+    // Reads stay disabled in the fallback: the tree hash captures
+    // content-derived plan inputs but not state-derived ones.
+    const fixture = makeFixture({ branchFiles: { 'tests/delta.test.mjs': 'x\n' } });
+    assert.equal(fixture.run().status, 0);
+    assert.equal(fixture.cached(), fixture.tree());
+
+    fixture.git(['update-ref', '-d', 'refs/remotes/origin/main']);
+    const blind = fixture.run();
+    assert.doesNotMatch(blind.stdout, /this exact tree already passed/);
+  });
+});
+
+describe('the gate does not fail closed on its own edge cases', () => {
+  test('a repo with no scripts/*.cjs does not fail the RUN_ALL push', () => {
+    // `for f in scripts/*.cjs; do [ -f "$f" ] && node -c "$f" || exit 1; done`
+    // exited 1 on the unmatched glob — "there are no .cjs files" failed the
+    // push with no message at all.
+    const fixture = makeFixture({
+      branchFiles: { 'tests/delta.test.mjs': 'x\n' },
+      scriptsCjs: false,
+    });
+    fixture.git(['update-ref', '-d', 'refs/remotes/origin/main']); // forces RUN_ALL
+
+    const { status, stdout } = fixture.run();
+    assert.equal(status, 0, stdout);
+  });
+
+  test('a push that changes no test file still passes and attests', () => {
+    const fixture = makeFixture({ branchFiles: { 'docs/notes.md': 'hello\n' } });
+    const { status, stdout, invocations } = fixture.run();
+
+    assert.equal(status, 0, stdout);
+    assert.equal(tsxArgs(invocations), null);
+    assert.equal(fixture.cached(), fixture.tree());
+  });
+});


### PR DESCRIPTION
Closes #5800.

The pre-push cache records `HEAD^{tree}` and, on a later push of that tree, skips every tree-dependent gate. That turns each of these three from "one bad run" into **a bad run that suppresses future runs**. All three were reproduced in git fixtures before any code changed.

## 1. The gates run the WORKTREE, the cache claims HEAD (P1)

`[ -f "$file" ]` read "absent from disk" as *"the push deleted it"*. It can just as easily mean the worktree drifted from the commit being pushed — so an unstaged `rm` of a changed test dropped it from the run and the gate reported green; an unstaged **fix** made the suite pass over the broken bytes actually being pushed. Either way `HEAD^{tree}` went into the cache.

- Deletions now come from git (`--diff-filter=d`), never inferred from the filesystem.
- Drift **inside the branch diff** blocks the push (`WM_ALLOW_WORKTREE_DRIFT=1` opts out; it still cannot cache — a drifted worktree is dirty by definition).
- Dirt **anywhere else** only forfeits the attestation. Blocking every push with an unrelated scratch edit would be a gate nobody passes.

## 2. `core.quotePath` silently dropped legal paths (P2)

git's default C-quotes unicode/backslash/newline paths in `--name-only`, so `"tests/caf\303\251.test.mjs"` matched nothing on disk — file changed, nothing ran, gate green. Every changed-path read is now `-z` NUL-delimited and the list is a bash array end to end, which also removes the unquoted `$SEED_TESTS` word-split (`tests/trade flows-seed.test.mjs` became two nonexistent arguments).

`--no-renames` too: rename detection reports only the destination, so a `scripts/seed-x.mjs` -> `tests/x-seed.test.mjs` move left nothing under `scripts/` for the seed category to scope on.

## 3. The unresolved-diff fallback cached a partial run as fully green (P2)

It sets `RUN_ALL`, `RUN_ALL` explicitly **skips** the local unit suite, and the write fired anyway — contradicting the comment claiming a fallback run "executes everything, the strongest attestation". It now refuses to cache.

## Why it is testable

The decisions live in `scripts/prepush-attest.sh` so tests execute them against real git fixtures, instead of grepping the hook's source — a source grep stays green when a `true` becomes `false`. `tests/prepush-hook-gate.test.mjs` runs the **real hook** end to end with stubbed binaries and asserts what it dispatched and whether it cached.

Every fix was mutation-checked: reverting each one turns a test red (drift check removed -> 2 fail; unconditional cache write -> 6; `-z` dropped -> 13; silent `[ -f ]` skip restored -> 1; `--no-renames` dropped -> 2).

Also verified by running the real hook against this repo: full run caches `HEAD^{tree}`, second run cache-hits in 3.5s.

## Incidental

`for f in scripts/*.cjs; do [ -f "$f" ] && node -c "$f" || exit 1; done` exited 1 on the unmatched glob, so a repo with no `.cjs` files failed **every** `RUN_ALL` push with no message at all. Found by the new harness; split so only a real syntax error exits.

https://claude.ai/code/session_01S9giKyMaPrnHB2RpUodvPC