### PR TITLE
fix(dashboard): gate playback on entitlements, not a dead Clerk field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 179
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 179 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (213 service modules and domain directories)
+│   ├── services/           # Business logic (214 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -158,6 +158,14 @@ The per-user record granting feature access — a plan key, feature flags with a
 
 Feature flags are resolved by merging the plan's catalog defaults under the stored row, so a record written before a flag existed still reports that flag's current default for its plan — "the row predates the field" is therefore never on its own a reason a capability would read as absent.
 
+### Affirmative Denial
+
+The rule governing every client-side premium gate: a surface may be withheld only on positive evidence that the session is unentitled — a settled signed-out session, or a loaded entitlement snapshot that fails the access predicate — never on the mere absence of evidence. Reading "no snapshot yet" as "not entitled" is what locks paying customers out, because a snapshot that has not arrived is indistinguishable from one that never will.
+
+Which way an unknown resolves depends on whether waiting terminates. A *bounded* unknown — one guaranteed to settle on its own within a known window, such as auth hydration — may withhold briefly, since the cost is a delay rather than a lockout; it must not be counted as a denial in funnel metrics, because no user was gated. An *unbounded* unknown — one that may simply never arrive, such as an entitlement subscription that gives up silently when its backend is unreachable or unconfigured — must resolve to access. A corollary follows from that asymmetry: a gate that fails open can revoke access mid-use, so any surface reachable during the open window must define what happens when the verdict flips. A fail-open gate is only safe when losing access has a specified behavior instead of stranding the user in a state whose exit affordance was just hidden. See also: Entitlement, Billing UX State.
+
+A gate is also only as live as the signal it reads. A predicate keyed on a field nothing in the system writes denies every caller forever while looking perfectly reasonable in review, and it raises no error and draws no complaint, because the surface never renders for anyone to miss.
+
 ### Plan Family
 
 The grouping of plan keys — pro-family (personal and business dashboard plans), API-family (programmatic-access plans), and enterprise — that billing and quota rules discriminate on. Checkout duplicate-detection, seat licensing, and quota scoping are all stated per-family, and a family is not recoverable from the tier number or from which credential a caller presents: tier gates are thresholds, so a higher-tier API-family plan clears every gate written with the pro family in mind, and an API-family subscriber can hold pro-class credentials. Rules written against any proxy for family (tier, credential class, feature flag) will misfire on the plans where the proxy and the family diverge. See also: Credential Class, Entitlement.

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 179,
-  "serviceTopLevelEntries": 213,
+  "serviceTopLevelEntries": 214,
   "apiEndpointEntries": 89,
   "panelClasses": 107,
   "protoFiles": 290,

--- a/docs/solutions/logic-errors/playback-control-gated-on-a-clerk-role-field-with-no-writer.md
+++ b/docs/solutions/logic-errors/playback-control-gated-on-a-clerk-role-field-with-no-writer.md
@@ -1,0 +1,169 @@
+---
+title: "Historical-playback control gated on a Clerk role field that no writer ever populates"
+date: 2026-07-29
+category: logic-errors
+module: playback-gate
+problem_type: logic_error
+component: payments
+severity: high
+symptoms:
+  - "Historical-playback control was invisible to every user, including paying Pro subscribers, for months, with no bug report and no alarm - the feature simply did not exist from the user's point of view"
+  - "setupPlaybackControl gated the control behind getAuthState().user?.role === 'pro', a field sourced from Clerk publicMetadata that zero code paths ever write, so it read 'free' for every account and the gate could never pass"
+  - "Found incidentally during unrelated work rather than through a support ticket, since a permanently-false gate produces no error, no failed request, and no monitoring signal"
+root_cause: logic_error
+resolution_type: code_fix
+related_components: [authentication, development_workflow]
+tags: [entitlements, premium-gating, clerk, convex, fail-closed, playback-control, unwritten-signal, affirmative-denial]
+---
+
+# Historical-playback control gated on a Clerk role field that no writer ever populates
+
+## Problem
+
+The dashboard's historical-playback control (the header "rewind" toggle that scrubs through saved snapshots) was invisible to every user, including paying Pro subscribers, for months. `setupPlaybackControl` in `src/app/event-handlers.ts` gated the control's visibility on `getAuthState().user?.role === 'pro'`. That `role` field lives on `AuthUser` (`src/services/auth-state.ts:10`) and is populated from Clerk `publicMetadata` — but nothing in the codebase writes it. A repo-wide sweep for the writer side (`grep -rln "clerkClient\|updateUser" src/ api/ server/`) returns zero matches: no code path ever calls Clerk's admin API to set `publicMetadata.plan`/`role`. Every account, including a customer with an active Dodo subscription, therefore reads `role: 'free'` forever, and `role === 'pro'` could never evaluate true.
+
+**The generalizable bug class: a premium feature gated on a signal that no writer ever populates fails closed for 100% of users, silently.** There is no error to log and no user to complain, because the feature never renders at all. Contrast the loud failure mode — a paying user hits a paywall and files a ticket — with this silent one, where nobody sees anything and so nobody reports it.
+
+This is the same dead-field trap the codebase had already diagnosed once for panel gating: `src/services/panel-gating.ts:41-46` documents that Clerk `publicMetadata.plan` is untrustworthy for exactly this reason, and `hasPremiumAccess()` instead resolves through `isProUser()`, which uses `role === 'pro'` only as one arm of a boolean union (`src/services/widget-store.ts:223-230`). The playback control's gate had never been migrated to that pattern and read the raw, unwritten field directly.
+
+Fixed in three commits on `fix/playback-gate-entitlement`, closing [#5632](https://github.com/koala73/worldmonitor/issues/5632). Unmerged as of this writing; the commits are identified below by what they change rather than by SHA, since a squash merge rewrites them.
+
+## Symptoms
+
+- The historical-playback toggle never appeared in the dashboard header for any account — free, Pro, or desktop-API-key — regardless of subscription status.
+- No error was thrown, nothing was logged, and no Sentry event fired: the code path evaluated a false boolean and skipped rendering.
+- No support tickets and no internal alert, because there was no failure signature to notice. The feature read as "doesn't exist" rather than "broken."
+- Invisible to a source-grep style "did we wire the gate" check: a test asserting `evaluatePlaybackGate` appears in the source would pass with the original `role === 'pro'` gate fully in place, because a grep cannot see that the gate's *input* is dead.
+
+## What Didn't Work
+
+- **A source-grep "wiring guard" test.** An early idea for locking in the fix was asserting the new `evaluatePlaybackGate`/`resolvePlaybackGate` symbols appear in `src/app/event-handlers.ts`. That check goes green with the original bug restored verbatim — it never drives the decision, only confirms a name exists in the file. The suite that shipped instead (`tests/dom/playback-gate-wiring.test.mts`) mounts the real `EventHandlerManager`, calls the real `setupPlaybackControl()`, and asserts what `.playback-control`'s `style.display` and `document.body.classList` actually contain. Only a behavioral test that drives production code has teeth against this bug class.
+- **A regex-targeted mutation round produced a false negative.** The first mutation pass targeted `if (this.ctx.isDestroyed) return;` by pattern rather than line number. That exact line appears five times in `src/app/event-handlers.ts` (lines 837, 1644, 1785, 1804, and 1975 — the last being the one inside `setupPlaybackControl`'s `applyGate`). The pattern matched an earlier occurrence inside `setupExportPanel`, so the suite stayed green and looked like a real coverage gap when it was actually a mistargeted mutant. Switching to line-number-targeted mutation killed it.
+
+## Solution
+
+**Before** — `setupPlaybackControl`, reduced to the gate:
+
+```ts
+const isPro = getAuthState().user?.role === 'pro'; // always false: nothing writes this field
+el.style.display = isPro ? '' : 'none';
+```
+
+**After**, in three commits.
+
+**1. The gate itself** — a zero-import pure leaf, `src/services/playback-gate.ts`, wired through `src/services/panel-gating.ts`:
+
+```ts
+// src/services/playback-gate.ts
+export function resolvePlaybackGate(input: PlaybackGateInputs): PlaybackGateVerdict {
+  if (input.premiumAccess) return 'visible';
+  if (input.authPending) return 'pending';
+  if (!input.signedIn) return 'denied';
+  if (!input.entitlementLoaded) return 'visible';
+  return 'denied';
+}
+```
+
+```ts
+// src/services/panel-gating.ts
+export function readPlaybackGateInputs(authState: AuthSession): PlaybackGateInputs {
+  return {
+    premiumAccess: hasPremiumAccess(authState),
+    authPending: authState.isPending,
+    signedIn: Boolean(authState.user),
+    entitlementLoaded: getEntitlementState() !== null,
+  };
+}
+```
+
+```ts
+// src/app/event-handlers.ts — setupPlaybackControl
+let gateHitTracked = false;
+const applyGate = (): void => {
+  if (this.ctx.isDestroyed) return;
+  const verdict = evaluatePlaybackGate(getAuthState());
+  const visible = verdict === 'visible';
+  el.style.display = visible ? '' : 'none';
+  if (!visible) this.ctx.playbackControl?.exitPlayback();
+  if (verdict === 'denied' && !gateHitTracked) {
+    gateHitTracked = true;
+    trackGateHit('playback');
+  }
+};
+
+applyGate();
+this.proGateUnsubscribers.push(subscribeAuthState(() => applyGate()));
+this.proGateUnsubscribers.push(onEntitlementChange(() => applyGate()));
+```
+
+**2. Mid-replay revocation** — `PlaybackControl.exitPlayback()`, called from `applyGate` on every non-visible verdict:
+
+```ts
+// src/components/PlaybackControl.ts
+public exitPlayback(): void {
+  if (!this.isPlaybackMode) return;
+  this.element.querySelector('.playback-panel')?.classList.add('hidden');
+  this.goLive();
+}
+```
+
+**3. Test-drift removal** — `isEntitlementActive(state, now)` extracted from `isEntitled()`:
+
+```ts
+// src/services/entitlements.ts
+export function isEntitlementActive(state: EntitlementState | null, now: number): boolean {
+  return state !== null && state.planKey !== 'free' && state.validUntil >= now;
+}
+
+export function isEntitled(): boolean {
+  return isEntitlementActive(currentState, Date.now());
+}
+```
+
+so the DOM test's mock delegates instead of re-implementing:
+
+```ts
+// tests/dom/playback-gate-wiring.test.mts
+isEntitled: () => actual.isEntitlementActive(entitlement, Date.now()),
+```
+
+## Why This Works
+
+**The gate now reads a signal that is actually written.** `hasPremiumAccess()` (`src/services/panel-gating.ts:53-58`) unions the desktop `WORLDMONITOR_API_KEY` secret with `isProUser()`, which itself unions the widget-tester keys, the dead Clerk `role` field, and `isEntitled()` (`src/services/widget-store.ts:223-230`). Because `isEntitled()` is fed by the real Dodo-to-Convex webhook pipeline, a paying subscriber now has an actually-true path into the gate regardless of whether Clerk's `role` is ever populated.
+
+**The two "unknown" states resolve asymmetrically on purpose, and the asymmetry is load-bearing:**
+
+- `authPending → 'pending'` is a **bounded** unknown. Clerk hydrates within its idle window (`src/services/auth-state.ts:19` sets the boot default `isPending: true`), and `subscribeAuthState` re-runs `applyGate()` immediately after. Hiding here costs a brief delay, not a lockout. Because it is not an affirmative denial it is deliberately excluded from the `trackGateHit('playback')` funnel metric, so a boot state cannot be miscounted as a denial for a user who was never gated.
+- `!entitlementLoaded → 'visible'` is an **unbounded** unknown. `initEntitlementSubscription()` (`src/services/entitlements.ts:59-105`) returns without ever assigning `currentState` when `VITE_CONVEX_URL` is unset or when `waitForConvexAuth(10_000)` times out. In either case no snapshot is ever coming for that session, so failing closed would turn a boot blip into a permanent lockout for a paying customer — precisely the failure `src/app/panel-layout.ts:723-748` already records as a prior mistake ("Prior iterations of this code tried the opposite — gating positively on `hasTier(1)` — and locked legitimate Pro users out whenever the Convex snapshot was late, skipped, or failed").
+
+**`exitPlayback()`'s guard is what makes the fail-open branch safe.** Because a signed-in free user is shown the control until their snapshot proves otherwise, that user can enter playback before the snapshot lands and denies them. Hiding the element alone strands the dashboard on historical data — the only "Live" button lives *inside* the element that just received `display: none`. But `applyGate()` fires on every page load, including the ordinary pending transition, so an unguarded `exitPlayback()` would trigger `goLive()` → `onSnapshotChange(null)` → a full `loadAllData()` on every boot. The `if (!this.isPlaybackMode) return;` guard makes it a true no-op unless the user was mid-replay, which the DOM suite pins with `expect(loadAllData).not.toHaveBeenCalled()` on a mere pending-auth hide.
+
+**Subscribing to both emitters closes the post-checkout gap.** The Convex entitlement watcher and Clerk's auth state are separate, independently-firing sources. An auth-only subscription would never re-run `applyGate()` when a snapshot lands after sign-in — exactly the moment a user finishes checkout. `setupExportPanel` already subscribed to both for the same reason.
+
+**Extracting `isEntitlementActive` removes a silent-drift hazard in the test.** `isEntitled()` read the module-private `currentState` with no setter, so any test simulating "entitled" had to hand-copy its three conditions into a mock — and if the real predicate later changed, the copy would silently diverge while the suite stayed green testing the wrong rule. Verified empirically: with the hand-copied mock, mutating the real predicate left the suite green; after the extraction, the same mutation reds 5 tests.
+
+## Prevention
+
+**Detecting this bug class.** For every premium/paywalled gate, ask "who writes this signal, and can I point at the writer?" A gate on a value nothing writes fails closed for 100% of users with no error, no log line, and no complaint to notice it by.
+
+- Run `grep -rn "role === 'pro'" src/` periodically. It should only ever appear as one arm of a boolean union inside `hasPremiumAccess()` (`src/services/panel-gating.ts:56`) or `isProUser()` (`src/services/widget-store.ts:227`) — never as the sole condition gating a feature. `src/components/ProBanner.ts:133` is another correct usage (it leads with `isEntitled()`).
+- Before shipping a new gate, verify the writer side exists. `grep -rln "clerkClient\|updateUser" src/ api/ server/` currently returns nothing, confirming Clerk `publicMetadata` has no writer here — so any new code reading `user.role` as an authoritative signal is reading a field that can never become true. Route new gates through `hasPremiumAccess()`/`isProUser()`.
+- A source-text "is the gate wired" test does not catch this class; it cannot see that the gate's input is dead. Regression tests for a gate must drive the real function that renders or hides the UI and assert on rendered state.
+
+**The affirmative-denial rule, and which way an unknown should fail.** Never let an unknown resolve to a denial. Resolve to `denied` only on affirmative evidence — signed-out with no snapshot to check, or a loaded snapshot that positively fails the predicate. For every unknown, ask whether it is bounded or unbounded:
+
+- **Bounded** unknowns (guaranteed to resolve within a known window, like Clerk hydration) may hide briefly, because the cost is a delay rather than a lockout — and should be excluded from denial metrics, since they are not denials.
+- **Unbounded** unknowns (a value that may never arrive) must fail open, because failing closed is indistinguishable from a permanent lockout for a paying customer. This is the second place in this codebase where that reasoning had to be applied, which is a signal it belongs in any new premium-gate design from the start rather than being rediscovered per feature.
+- When a fail-open branch can be entered mid-use, the consumer must handle the `visible → non-visible` transition explicitly. A fail-open design is only safe if losing access mid-use has defined, tested behavior instead of stranding the UI.
+
+**Mutation-testing pitfall.** Target mutants by line number, not by regex, in files that repeat a guard idiom. A pattern match can silently mutate the wrong occurrence and produce a false-negative "coverage gap" — as happened here with a line that appears five times in one file.
+
+## Related Issues
+
+- [`billing-state-cancelled-but-paid-through-misclassified-as-lapsed.md`](billing-state-cancelled-but-paid-through-misclassified-as-lapsed.md) — closest sibling. Different root cause (a late Convex snapshot causing misclassification rather than a field nobody writes), but the same prevention instinct: a missing or not-yet-loaded entitlement signal must not be treated as denial. Also touches `panel-gating.ts`.
+- [`verify-the-verifier-mutation-test-every-detection-layer.md`](../conventions/verify-the-verifier-mutation-test-every-detection-layer.md) — names the exact anti-pattern the `isEntitlementActive` extraction fixes: "a companion test has its own private read-and-match loop instead of calling the real scan, so it can never observe a regression."
+- [`denied-push-permission-rendered-as-retryable-failure.md`](denied-push-permission-rendered-as-retryable-failure.md) — shares two shapes: widening a binary result into a three-state union, and folding logic into a single accessor so there is no second implementation to drift.
+- [`checks-must-fail-closed-when-they-lose-their-target.md`](../best-practices/checks-must-fail-closed-when-they-lose-their-target.md) — **not** contradicted by this doc's fail-open choice, despite the surface tension. That doc governs CI/contract checks losing observability of their target; this is a product gating decision reasoned against a specific bounded-vs-unbounded tradeoff.
+- GitHub [#5632](https://github.com/koala73/worldmonitor/issues/5632) — the source issue.
+- GitHub [#5604](https://github.com/koala73/worldmonitor/issues/5604) — opposite-direction sibling: `exportFormats` and `maxDashboards` are advertised capabilities with no enforcement at all. Worth a sweep for other dead or unwired entitlement config keys.
+- GitHub [#4276](https://github.com/koala73/worldmonitor/issues/4276) — the tier-gated playback epic that spawned the original gate.

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -92,7 +92,7 @@ import { TvModeController } from '@/services/tv-mode';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { onEntitlementChange } from '@/services/entitlements';
 import { primeExportGateActivation } from '@/services/export-gate';
-import { evaluateExportGate, exportLockToGateReason, resolveGateAction, type PanelGateReason } from '@/services/panel-gating';
+import { evaluateExportGate, evaluatePlaybackGate, exportLockToGateReason, resolveGateAction, type PanelGateReason } from '@/services/panel-gating';
 import { ExportGateControl } from '@/components/ExportGateControl';
 import { h, setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { scheduleAfterFirstPaint } from '@/utils/after-paint';
@@ -1967,12 +1967,30 @@ export class EventHandlerManager implements AppModule {
       headerRight.insertBefore(el, headerRight.firstChild);
     }
 
-    const applyProGate = (isPro: boolean, initial = false) => {
-      el.style.display = isPro ? '' : 'none';
-      if (initial && !isPro) trackGateHit('playback');
+    // #5632: gate on the entitlement chain, NOT `user.role === 'pro'` — nothing
+    // writes Clerk publicMetadata, so that field read 'free' for paying
+    // subscribers and the control rendered for nobody.
+    let gateHitTracked = false;
+    const applyGate = (): void => {
+      if (this.ctx.isDestroyed) return;
+      const verdict = evaluatePlaybackGate(getAuthState());
+      el.style.display = verdict === 'visible' ? '' : 'none';
+      // Affirmative denials only, once per session. 'pending' also hides, but
+      // counting it would tick the funnel on every page load — including for
+      // subscribers whose control appears a moment later.
+      if (verdict === 'denied' && !gateHitTracked) {
+        gateHitTracked = true;
+        trackGateHit('playback');
+      }
     };
-    applyProGate(getAuthState().user?.role === 'pro', true);
-    this.proGateUnsubscribers.push(subscribeAuthState(state => applyProGate(state.user?.role === 'pro')));
+
+    applyGate();
+    // BOTH subscriptions, same as setupExportPanel above: the Convex
+    // entitlement watcher (services/entitlements.ts) is a separate emitter from
+    // Clerk's, so an auth-only subscription never re-runs when a snapshot lands
+    // after sign-in — exactly the post-checkout unlock path.
+    this.proGateUnsubscribers.push(subscribeAuthState(() => applyGate()));
+    this.proGateUnsubscribers.push(onEntitlementChange(() => applyGate()));
   }
 
   setupSnapshotSaving(): void {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -1974,7 +1974,12 @@ export class EventHandlerManager implements AppModule {
     const applyGate = (): void => {
       if (this.ctx.isDestroyed) return;
       const verdict = evaluatePlaybackGate(getAuthState());
-      el.style.display = verdict === 'visible' ? '' : 'none';
+      const visible = verdict === 'visible';
+      el.style.display = visible ? '' : 'none';
+      // Losing access mid-replay must also LEAVE playback. `display: none`
+      // alone strands the dashboard on historical data — the "Live" button is
+      // inside the element we just hid. No-ops unless playback is active.
+      if (!visible) this.ctx.playbackControl?.exitPlayback();
       // Affirmative denials only, once per session. 'pending' also hides, but
       // counting it would tick the funnel on every page load — including for
       // subscribers whose control appears a moment later.

--- a/src/components/PlaybackControl.ts
+++ b/src/components/PlaybackControl.ts
@@ -167,6 +167,24 @@ export class PlaybackControl {
     }
   }
 
+  /**
+   * Return to live data and close the panel — for the premium gate revoking
+   * access while a snapshot is being replayed (#5632). Hiding the control is
+   * not enough on its own: the "Live" button lives INSIDE the element being
+   * hidden, so the dashboard would be stranded on historical data with no way
+   * back.
+   *
+   * The `isPlaybackMode` guard is load-bearing. The gate evaluates to a
+   * non-visible verdict at least once on every page load ('pending' while
+   * Clerk hydrates), and an unguarded call would fire `onSnapshotChange(null)`
+   * — and therefore a full `loadAllData()` — on each of them.
+   */
+  public exitPlayback(): void {
+    if (!this.isPlaybackMode) return;
+    this.element.querySelector('.playback-panel')?.classList.add('hidden');
+    this.goLive();
+  }
+
   public onSnapshot(callback: (snapshot: DashboardSnapshot | null) => void): void {
     this.onSnapshotChange = callback;
   }

--- a/src/services/entitlements.ts
+++ b/src/services/entitlements.ts
@@ -52,6 +52,26 @@ let initialized = false;
 let unsubscribeFn: (() => void) | null = null;
 
 /**
+ * Fan a new snapshot out to every subscriber, isolating failures.
+ *
+ * One listener must not block the rest: subscribers are independent UI
+ * surfaces, and an unguarded loop silently stops updating every listener
+ * registered after the one that threw — a failure with no error path, since
+ * the survivors just quietly hold their last verdict. Both emission sites
+ * (the Convex watch below and `resetEntitlementState`) route through here so
+ * they cannot drift apart on that guarantee.
+ */
+function notifyListeners(state: EntitlementState | null): void {
+  for (const cb of listeners) {
+    try {
+      cb(state);
+    } catch (err) {
+      console.warn('[entitlements] listener threw; continuing fan-out:', err);
+    }
+  }
+}
+
+/**
  * Initialize the entitlement subscription for the authenticated user.
  * Idempotent — calling multiple times is a no-op after the first.
  * Failures are logged but never thrown (dashboard must not break).
@@ -89,7 +109,7 @@ export async function initEntitlementSubscription(_userId?: string): Promise<voi
       {},
       (result: EntitlementState | null) => {
         currentState = result;
-        for (const cb of listeners) cb(result);
+        notifyListeners(result);
       },
       (err: Error) => {
         console.warn('[entitlements] Subscription query error:', err.message);
@@ -133,13 +153,7 @@ export function destroyEntitlementSubscription(): void {
  */
 export function resetEntitlementState(): void {
   currentState = null;
-  for (const cb of listeners) {
-    try {
-      cb(null);
-    } catch {
-      // One listener must not block the rest of the sign-out fan-out.
-    }
-  }
+  notifyListeners(null);
 }
 
 /**

--- a/src/services/entitlements.ts
+++ b/src/services/entitlements.ts
@@ -186,15 +186,26 @@ export function hasTier(minTier: number): boolean {
 }
 
 /**
+ * The "is this a paying user" predicate, over an injected snapshot and clock.
+ *
+ * Split out of `isEntitled()` so tests can evaluate the REAL rule against a
+ * snapshot they control — `currentState` is module-private and has no setter,
+ * so the alternative is re-implementing these three conditions in a mock,
+ * where they silently drift the moment this rule changes (#5632).
+ */
+export function isEntitlementActive(
+  state: EntitlementState | null,
+  now: number,
+): boolean {
+  return state !== null && state.planKey !== 'free' && state.validUntil >= now;
+}
+
+/**
  * Simple "is this a paying user" check.
  * Returns true if entitlement data exists, plan is not free, and hasn't expired.
  */
 export function isEntitled(): boolean {
-  return (
-    currentState !== null &&
-    currentState.planKey !== 'free' &&
-    currentState.validUntil >= Date.now()
-  );
+  return isEntitlementActive(currentState, Date.now());
 }
 
 /**

--- a/src/services/panel-gating.ts
+++ b/src/services/panel-gating.ts
@@ -11,6 +11,11 @@ import {
   type ExportGateVerdict,
   type TabCapVerdict,
 } from './export-gate';
+import {
+  resolvePlaybackGate,
+  type PlaybackGateInputs,
+  type PlaybackGateVerdict,
+} from './playback-gate';
 import type { ClientEntitlementBelief } from './premium-denial';
 import { getSecretState } from './runtime-config';
 import { isProUser } from './widget-store';
@@ -160,6 +165,27 @@ export function evaluateExportGate(authState: AuthSession): ExportGateVerdict {
  */
 export function evaluateTabCap(authState: AuthSession, currentTabCount: number): TabCapVerdict {
   return resolveTabCap(readExportGateInputs(authState), currentTabCount);
+}
+
+/**
+ * Snapshot the live inputs of the historical-playback gate (#5632). Separate
+ * from `readExportGateInputs` because playback is a Pro takeaway resolved by
+ * `hasPremiumAccess()`, not a Pro Business one — it needs neither the catalog
+ * activation probe nor the billing-state refinement (the control has no CTA to
+ * route, so there is no denial reason to display).
+ */
+export function readPlaybackGateInputs(authState: AuthSession): PlaybackGateInputs {
+  return {
+    premiumAccess: hasPremiumAccess(authState),
+    authPending: authState.isPending,
+    signedIn: Boolean(authState.user),
+    entitlementLoaded: getEntitlementState() !== null,
+  };
+}
+
+/** Current playback-control verdict for the given auth session. */
+export function evaluatePlaybackGate(authState: AuthSession): PlaybackGateVerdict {
+  return resolvePlaybackGate(readPlaybackGateInputs(authState));
 }
 
 /**

--- a/src/services/playback-gate.ts
+++ b/src/services/playback-gate.ts
@@ -1,0 +1,77 @@
+/**
+ * Historical-playback gate (#5632).
+ *
+ * The control used to be hidden behind `authState.user?.role === 'pro'`.
+ * Nothing in this codebase writes Clerk `publicMetadata.plan`/`role` — there
+ * are zero `clerkClient`/`updateUser` writers, and three call sites document
+ * the gap (`panel-gating.ts` hasPremiumAccess, `api/widget-agent.ts`,
+ * `server/gateway.ts`) — so that field reads `'free'` for every account
+ * including paying subscribers. The control rendered for nobody.
+ *
+ * Playback is a Pro takeaway (tier >= 1), not a Pro Business one, so the
+ * positive signal is `hasPremiumAccess()` — the union of the desktop API key,
+ * the browser tester keys, the Clerk role and the Convex entitlement. What is
+ * NOT delegated to it is the failure direction: `hasPremiumAccess()` returns
+ * `false` for every "we don't know yet" state, and shipping that verbatim
+ * would trade a permanent gate on a dead field for a permanent gate on a
+ * missing snapshot.
+ *
+ * Zero-import leaf on purpose: it is unit-tested under `tsx --test` (no jsdom,
+ * no Vite globals), and both the services and app layers consume it. Keep it
+ * that way — see the same constraint on `export-gate.ts`.
+ */
+
+export interface PlaybackGateInputs {
+  /**
+   * `hasPremiumAccess(authState)` — desktop WORLDMONITOR_API_KEY, browser
+   * tester keys, Clerk pro role, or a live Convex entitlement.
+   */
+  premiumAccess: boolean;
+  /** Clerk auth still resolving (the boot default — auth-state.ts:19). */
+  authPending: boolean;
+  signedIn: boolean;
+  /**
+   * An entitlement snapshot has arrived. `false` covers both "still in flight"
+   * and "never coming" — `initEntitlementSubscription` gives up silently when
+   * VITE_CONVEX_URL is unset or Convex auth misses its 10s window.
+   */
+  entitlementLoaded: boolean;
+}
+
+/**
+ * `'pending'` and `'denied'` both hide the control; they differ in what we
+ * KNOW. Only `'denied'` is an affirmative "this session is not entitled" and
+ * therefore the only verdict that may be counted as a gate hit — folding the
+ * boot state into the funnel metric would bury real denials under a tick from
+ * every page load, including subscribers who were never gated at all.
+ */
+export type PlaybackGateVerdict = 'visible' | 'pending' | 'denied';
+
+/**
+ * Decide whether the playback control is shown.
+ *
+ * Order matters, and the two "unknown" states resolve DIFFERENTLY on purpose:
+ *
+ *   1. premium access      → visible (covers every entitlement path at once)
+ *   2. auth pending        → pending. Bounded: Clerk hydrates within its ~4s
+ *      idle window and the subscription re-runs this immediately after. Waiting
+ *      costs a subscriber a brief delay; the alternative flashes a Pro-only
+ *      control into the header of every anonymous visitor and then yanks it.
+ *   3. signed out          → denied. The only affirmative denial available
+ *      without a snapshot — anonymous sessions have no entitlement row to read.
+ *   4. no snapshot yet     → VISIBLE. Unbounded, unlike step 2: a skipped or
+ *      failed Convex subscription never resolves, so hiding here would be a
+ *      permanent lockout for a paying customer rather than a boot blip. Never
+ *      over-gate (post-mortem: src/app/panel-layout.ts:710-735).
+ *   5. otherwise           → denied. Signed in, snapshot loaded, and no premium
+ *      path matched — the one state we affirmatively know is unentitled. An
+ *      expired or lapsed row lands here too, which is correct: `isEntitled()`
+ *      already rejected it on `validUntil`.
+ */
+export function resolvePlaybackGate(input: PlaybackGateInputs): PlaybackGateVerdict {
+  if (input.premiumAccess) return 'visible';
+  if (input.authPending) return 'pending';
+  if (!input.signedIn) return 'denied';
+  if (!input.entitlementLoaded) return 'visible';
+  return 'denied';
+}

--- a/src/services/playback-gate.ts
+++ b/src/services/playback-gate.ts
@@ -1,20 +1,15 @@
 /**
  * Historical-playback gate (#5632).
  *
- * The control used to be hidden behind `authState.user?.role === 'pro'`.
- * Nothing in this codebase writes Clerk `publicMetadata.plan`/`role` — there
- * are zero `clerkClient`/`updateUser` writers, and three call sites document
- * the gap (`panel-gating.ts` hasPremiumAccess, `api/widget-agent.ts`,
- * `server/gateway.ts`) — so that field reads `'free'` for every account
- * including paying subscribers. The control rendered for nobody.
+ * The control used to be hidden behind `authState.user?.role === 'pro'`, but
+ * nothing in this codebase writes Clerk `publicMetadata.plan`/`role`, so that
+ * field reads `'free'` for every account — the control rendered for nobody.
  *
  * Playback is a Pro takeaway (tier >= 1), not a Pro Business one, so the
- * positive signal is `hasPremiumAccess()` — the union of the desktop API key,
- * the browser tester keys, the Clerk role and the Convex entitlement. What is
- * NOT delegated to it is the failure direction: `hasPremiumAccess()` returns
- * `false` for every "we don't know yet" state, and shipping that verbatim
- * would trade a permanent gate on a dead field for a permanent gate on a
- * missing snapshot.
+ * positive signal is `hasPremiumAccess()`. What is NOT delegated to it is the
+ * failure direction: it returns `false` for every "we don't know yet" state,
+ * and shipping that verbatim would trade a permanent gate on a dead field for
+ * a permanent gate on a missing snapshot.
  *
  * Zero-import leaf on purpose: it is unit-tested under `tsx --test` (no jsdom,
  * no Vite globals), and both the services and app layers consume it. Keep it
@@ -53,16 +48,22 @@ export type PlaybackGateVerdict = 'visible' | 'pending' | 'denied';
  * Order matters, and the two "unknown" states resolve DIFFERENTLY on purpose:
  *
  *   1. premium access      → visible (covers every entitlement path at once)
- *   2. auth pending        → pending. Bounded: Clerk hydrates within its ~4s
- *      idle window and the subscription re-runs this immediately after. Waiting
- *      costs a subscriber a brief delay; the alternative flashes a Pro-only
- *      control into the header of every anonymous visitor and then yanks it.
+ *   2. auth pending        → pending. Bounded whenever Clerk is configured: it
+ *      hydrates within its ~4s idle window and the subscription re-runs this
+ *      immediately after. (With no publishable key `isPending` is sticky —
+ *      clerk.ts's `isClerkAuthEnabled` exists for that case — but no entitled
+ *      session can be stuck behind it, since every premium path short-circuits
+ *      at step 1 and `isEntitled()` transitively requires Clerk anyway.)
+ *      Waiting costs a subscriber a brief delay; the alternative flashes a
+ *      Pro-only control into every anonymous visitor's header and then yanks it.
  *   3. signed out          → denied. The only affirmative denial available
  *      without a snapshot — anonymous sessions have no entitlement row to read.
  *   4. no snapshot yet     → VISIBLE. Unbounded, unlike step 2: a skipped or
  *      failed Convex subscription never resolves, so hiding here would be a
  *      permanent lockout for a paying customer rather than a boot blip. Never
- *      over-gate (post-mortem: src/app/panel-layout.ts:710-735).
+ *      over-gate (post-mortem: src/app/panel-layout.ts:723-748). A signed-in
+ *      free user therefore sees the control until their snapshot lands; the
+ *      caller must handle losing it mid-use (event-handlers.ts exitPlayback).
  *   5. otherwise           → denied. Signed in, snapshot loaded, and no premium
  *      path matched — the one state we affirmatively know is unentitled. An
  *      expired or lapsed row lands here too, which is correct: `isEntitled()`

--- a/tests/dom/entitlement-watch-fanout.test.mts
+++ b/tests/dom/entitlement-watch-fanout.test.mts
@@ -1,0 +1,97 @@
+/**
+ * The Convex watch path's listener fan-out (#5632 review follow-up).
+ *
+ * `tests/entitlement-listener-fanout.test.mts` proves the isolation itself, but
+ * it can only reach `resetEntitlementState()` — the one emission site that
+ * works without a Convex client. That leaves the site that actually matters
+ * uncovered: reverting the watch callback to a raw `for (const cb of listeners)
+ * cb(result)` loop keeps that suite green, so the guard's own regression would
+ * be invisible. This file drives the real `initEntitlementSubscription` with
+ * the Convex client stubbed, captures the update callback the module hands to
+ * `onUpdate`, and invokes it — the same path a live snapshot takes.
+ *
+ * Lives under `tests/dom/` because that is the repo's only vitest project
+ * covering `tests/`, and `vi.mock` is what makes the convex-client seam
+ * stubbable; it needs no DOM of its own.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Snapshot = { planKey: string; features: { tier: number }; validUntil: number } | null;
+type UpdateCallback = (result: Snapshot) => void;
+
+/** The callback `initEntitlementSubscription` registers with `client.onUpdate`. */
+let captured: UpdateCallback | null = null;
+let unsubscribed = 0;
+
+vi.mock('@/services/convex-client', () => ({
+  getConvexClient: async () => ({
+    onUpdate: (_query: unknown, _args: unknown, cb: UpdateCallback) => {
+      captured = cb;
+      return { unsubscribe: () => unsubscribed++ };
+    },
+  }),
+  getConvexApi: async () => ({ entitlements: { getEntitlementsForUser: 'q' } }),
+  waitForConvexAuth: async () => true,
+}));
+
+const {
+  initEntitlementSubscription,
+  destroyEntitlementSubscription,
+  onEntitlementChange,
+  getEntitlementState,
+  resetEntitlementState,
+} = await import('@/services/entitlements');
+
+const PRO: Snapshot = { planKey: 'pro', features: { tier: 1 }, validUntil: Date.now() + 86_400_000 };
+
+let cleanup: Array<() => void> = [];
+
+beforeEach(async () => {
+  captured = null;
+  unsubscribed = 0;
+  cleanup = [];
+  // `initialized` latches after the first success, so tear down between cases.
+  destroyEntitlementSubscription();
+  await initEntitlementSubscription('user_1');
+  expect(captured).not.toBeNull();
+});
+
+afterEach(() => {
+  for (const off of cleanup) off();
+  cleanup = [];
+  resetEntitlementState();
+  destroyEntitlementSubscription();
+});
+
+function subscribe(fn: (state: Snapshot) => void): void {
+  cleanup.push(onEntitlementChange(fn as (s: unknown) => void));
+}
+
+describe('Convex watch fan-out (#5632)', () => {
+  it('keeps notifying later listeners when an earlier one throws', () => {
+    const order: string[] = [];
+    subscribe(() => {
+      order.push('first');
+      throw new Error('listener blew up');
+    });
+    subscribe(() => order.push('second'));
+
+    // The real path a live entitlement snapshot takes.
+    expect(() => captured!(PRO)).not.toThrow();
+
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('still commits the snapshot when a listener throws', () => {
+    // The throw must not strand `currentState` on the previous value — every
+    // later reader (hasTier, isEntitled, the gates) reads that field directly.
+    subscribe(() => {
+      throw new Error('bad');
+    });
+
+    captured!(PRO);
+
+    expect(getEntitlementState()).toEqual(PRO);
+  });
+});

--- a/tests/dom/playback-gate-wiring.test.mts
+++ b/tests/dom/playback-gate-wiring.test.mts
@@ -63,23 +63,27 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
   },
 }));
 
-// `isEntitled` is re-implemented rather than passed through because the real
-// one reads a module-private `currentState` this test cannot write. The three
-// conditions are entitlements.ts:192-198 verbatim; `isProUser()` (widget-store)
-// consumes it for real, which is the path a paying subscriber actually takes.
-vi.mock('@/services/entitlements', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/services/entitlements')>()),
-  getEntitlementState: () => entitlement,
-  isEntitled: () =>
-    entitlement !== null && entitlement.planKey !== 'free' && entitlement.validUntil >= Date.now(),
-  onEntitlementChange: (fn: (state: Entitlement) => void) => {
-    entitlementListeners.push(fn);
-    // Real behaviour: late subscribers get the current value immediately, but
-    // ONLY when a snapshot already exists (entitlements.ts:156-158).
-    if (entitlement !== null) fn(entitlement);
-    return () => entitlementUnsubscribed++;
-  },
-}));
+// `isEntitled` delegates to the REAL predicate rather than re-implementing it.
+// The real `isEntitled()` reads a module-private `currentState` this test
+// cannot write, but `isEntitlementActive` is that same rule over an injected
+// snapshot — so a change to what "entitled" means cannot drift away from this
+// suite. `isProUser()` (widget-store) consumes it for real, which is the path
+// a paying subscriber actually takes.
+vi.mock('@/services/entitlements', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/entitlements')>();
+  return {
+    ...actual,
+    getEntitlementState: () => entitlement,
+    isEntitled: () => actual.isEntitlementActive(entitlement, Date.now()),
+    onEntitlementChange: (fn: (state: Entitlement) => void) => {
+      entitlementListeners.push(fn);
+      // Real behaviour: late subscribers get the current value immediately, but
+      // ONLY when a snapshot already exists (entitlements.ts:156-158).
+      if (entitlement !== null) fn(entitlement);
+      return () => entitlementUnsubscribed++;
+    },
+  };
+});
 
 const trackGateHit = vi.fn<(feature: string) => void>();
 vi.mock('@/services/analytics', async (importOriginal) => ({

--- a/tests/dom/playback-gate-wiring.test.mts
+++ b/tests/dom/playback-gate-wiring.test.mts
@@ -22,26 +22,29 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock }
 
 import { initTestI18n } from './helpers/i18n.mts';
 
-type Session = {
-  user: { id: string; name: string; email: string; role: 'free' | 'pro' } | null;
-  isPending: boolean;
-};
-
-type Entitlement = {
-  planKey: string;
-  features: { tier: number };
-  validUntil: number;
-} | null;
+// Both aliased to the REAL exported interfaces rather than re-declared. A
+// hand-rolled shape here would let the fixtures drift from production silently;
+// this way a field added to either interface fails `npm run typecheck:dom-tests`
+// until the fixtures below are updated.
+type Session = import('@/services/auth-state').AuthSession;
+type Entitlement = import('@/services/entitlements').EntitlementState | null;
 
 /** Live Clerk session, mutated per case. Boot default mirrors auth-state.ts. */
 let session: Session = { user: null, isPending: true };
 /** Live Convex entitlement snapshot; `null` means "no snapshot has arrived". */
 let entitlement: Entitlement = null;
+/** Desktop runtime with WORLDMONITOR_API_KEY configured. */
+let desktopKeyPresent = false;
 // Kept apart, and each replayed with the argument its real emitter passes, so
 // the test cannot accidentally certify a listener that only works when called
 // with the other source's payload (or with none at all).
 const authListeners: Array<(state: Session) => void> = [];
 const entitlementListeners: Array<(state: Entitlement) => void> = [];
+// Real unsubscribe counters. With the previous `() => {}` stubs, a regression
+// that never pushed an unsubscriber onto `proGateUnsubscribers` — or that
+// stopped calling them in destroy() — passed every assertion in this file.
+let authUnsubscribed = 0;
+let entitlementUnsubscribed = 0;
 
 // Partial mocks throughout: a full replacement would turn every other export
 // these modules provide into `undefined` somewhere in the event-handlers import
@@ -51,7 +54,12 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
   getAuthState: () => session,
   subscribeAuthState: (fn: (state: Session) => void) => {
     authListeners.push(fn);
-    return () => {};
+    // The real one emits the current state synchronously on subscribe
+    // (auth-state.ts:69). Replicated so the suite runs production's actual
+    // multi-fire mount path, not a quieter one that only fires when the test
+    // says so — the gate-hit latch's whole job is to survive that re-entry.
+    fn(session);
+    return () => authUnsubscribed++;
   },
 }));
 
@@ -66,7 +74,10 @@ vi.mock('@/services/entitlements', async (importOriginal) => ({
     entitlement !== null && entitlement.planKey !== 'free' && entitlement.validUntil >= Date.now(),
   onEntitlementChange: (fn: (state: Entitlement) => void) => {
     entitlementListeners.push(fn);
-    return () => {};
+    // Real behaviour: late subscribers get the current value immediately, but
+    // ONLY when a snapshot already exists (entitlements.ts:156-158).
+    if (entitlement !== null) fn(entitlement);
+    return () => entitlementUnsubscribed++;
   },
 }));
 
@@ -76,10 +87,41 @@ vi.mock('@/services/analytics', async (importOriginal) => ({
   trackGateHit: (feature: string) => trackGateHit(feature),
 }));
 
+// Snapshot store, so a test can actually ENTER playback. The real one opens
+// IndexedDB, which happy-dom does not provide.
+const SNAPSHOT_TS = 1_700_000_000_000;
+vi.mock('@/services/storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/storage')>()),
+  getSnapshotTimestamps: async () => [SNAPSHOT_TS],
+  getSnapshotAt: async () => ({
+    timestamp: SNAPSHOT_TS,
+    events: [],
+    marketPrices: {},
+    predictions: [],
+    hotspotLevels: {},
+  }),
+}));
+
+// The desktop runtime's WORLDMONITOR_API_KEY branch of `hasPremiumAccess`.
+// Without this the suite reaches `premiumAccess` ONLY through `isEntitled()`,
+// so dropping the desktop-key path from `readPlaybackGateInputs` would go
+// unnoticed. Everything else keeps the real (absent-secret) behaviour.
+vi.mock('@/services/runtime-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/runtime-config')>();
+  return {
+    ...actual,
+    getSecretState: (key: string) =>
+      key === 'WORLDMONITOR_API_KEY' && desktopKeyPresent
+        ? { present: true, valid: true, source: 'env' as const }
+        : actual.getSecretState(key as Parameters<typeof actual.getSecretState>[0]),
+  };
+});
+
 const { EventHandlerManager } = await import('@/app/event-handlers');
 
 let container: HTMLElement;
 let manager: InstanceType<typeof EventHandlerManager>;
+let ctx: ConstructorParameters<typeof EventHandlerManager>[0];
 let loadAllData: Mock<() => void>;
 
 const control = () => container.querySelector<HTMLElement>('.playback-control');
@@ -93,15 +135,27 @@ function signedIn(): Session {
   };
 }
 
+/** Feature blocks matching the real `EntitlementState['features']` contract. */
+function features(tier: number): NonNullable<Entitlement>['features'] {
+  return {
+    tier,
+    apiAccess: tier >= 1,
+    apiRateLimit: tier >= 1 ? 1000 : 0,
+    maxDashboards: tier >= 1 ? 10 : 3,
+    prioritySupport: false,
+    exportFormats: [],
+  };
+}
+
 const PRO_SNAPSHOT: Entitlement = {
   planKey: 'pro',
-  features: { tier: 1 },
+  features: features(1),
   validUntil: Date.now() + 86_400_000,
 };
 
 const FREE_SNAPSHOT: Entitlement = {
   planKey: 'free',
-  features: { tier: 0 },
+  features: features(0),
   validUntil: Date.now() + 86_400_000,
 };
 
@@ -123,9 +177,12 @@ beforeEach(() => {
   document.body.replaceChildren();
   authListeners.length = 0;
   entitlementListeners.length = 0;
+  authUnsubscribed = 0;
+  entitlementUnsubscribed = 0;
   trackGateHit.mockClear();
   session = { user: null, isPending: true };
   entitlement = null;
+  desktopKeyPresent = false;
   loadAllData = vi.fn<() => void>();
 
   container = document.createElement('div');
@@ -134,7 +191,7 @@ beforeEach(() => {
   container.appendChild(headerRight);
   document.body.appendChild(container);
 
-  const ctx = {
+  ctx = {
     container,
     isDestroyed: false,
     isPlaybackMode: false,
@@ -210,6 +267,10 @@ describe('setupPlaybackControl — entitlement gate (#5632)', () => {
 
     expect(isVisible()).toBe(false);
     expect(trackGateHit).not.toHaveBeenCalled();
+    // Pins the `isPlaybackMode` guard inside exitPlayback: this hidden verdict
+    // happens on EVERY page load, and an unguarded exit would fire a full
+    // data reload each time.
+    expect(loadAllData).not.toHaveBeenCalled();
   });
 
   it('reveals the control when the entitlement snapshot lands after boot', () => {
@@ -251,5 +312,144 @@ describe('setupPlaybackControl — entitlement gate (#5632)', () => {
     emitEntitlement();
 
     expect(trackGateHit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setupPlaybackControl — revocation (#5632)', () => {
+  it('hides the control when a subscriber signs out', () => {
+    // The security-relevant direction. Every other reveal case proves the
+    // control can APPEAR; a regression that leaves the previous account's
+    // premium control mounted would pass all of them.
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+
+    manager.setupPlaybackControl();
+    expect(isVisible()).toBe(true);
+
+    session = { user: null, isPending: false };
+    entitlement = null;
+    emitEntitlement();
+    emitAuth();
+
+    expect(isVisible()).toBe(false);
+  });
+
+  it('hides the control when the entitlement lapses without a sign-out', () => {
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+
+    manager.setupPlaybackControl();
+    expect(isVisible()).toBe(true);
+
+    entitlement = FREE_SNAPSHOT;
+    emitEntitlement();
+
+    expect(isVisible()).toBe(false);
+  });
+
+  it('keeps the control up across an account switch until the new snapshot lands', () => {
+    // App.ts resets the entitlement snapshot on a userId change while the NEW
+    // user is already signed in, so the chain sees signedIn + no snapshot and
+    // fails open. Pinned deliberately: it is the widest fail-open window in
+    // the design, and any future narrowing should be a conscious change.
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+    manager.setupPlaybackControl();
+
+    session = {
+      user: { id: 'user_2', name: 'B', email: 'b@example.com', role: 'free' },
+      isPending: false,
+    };
+    entitlement = null;
+    emitEntitlement();
+    emitAuth();
+
+    expect(isVisible()).toBe(true);
+
+    entitlement = FREE_SNAPSHOT;
+    emitEntitlement();
+
+    expect(isVisible()).toBe(false);
+  });
+});
+
+describe('setupPlaybackControl — non-Convex premium paths (#5632)', () => {
+  it('shows the control on a desktop API key with no session and no snapshot', () => {
+    // `hasPremiumAccess` short-circuits on WORLDMONITOR_API_KEY before any
+    // Clerk or Convex signal. Without this case the suite reaches
+    // `premiumAccess` only through isEntitled(), so dropping the desktop-key
+    // path from readPlaybackGateInputs would go unnoticed.
+    desktopKeyPresent = true;
+    session = { user: null, isPending: false };
+    entitlement = null;
+
+    manager.setupPlaybackControl();
+
+    expect(isVisible()).toBe(true);
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+});
+
+describe('setupPlaybackControl — teardown and active playback (#5632)', () => {
+  it('releases BOTH subscriptions on destroy', () => {
+    // Two emitters means two leaks if either unsubscriber is dropped, and a
+    // leaked listener keeps writing to a detached element for the rest of the
+    // page's life.
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+    manager.setupPlaybackControl();
+
+    expect(authUnsubscribed).toBe(0);
+    expect(entitlementUnsubscribed).toBe(0);
+
+    manager.destroy();
+
+    expect(authUnsubscribed).toBe(1);
+    expect(entitlementUnsubscribed).toBe(1);
+  });
+
+  it('stops touching the control once the manager is destroyed', () => {
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+    manager.setupPlaybackControl();
+    expect(isVisible()).toBe(true);
+
+    (ctx as { isDestroyed: boolean }).isDestroyed = true;
+    session = { user: null, isPending: false };
+    entitlement = null;
+    emitAuth();
+
+    // The guard leaves the last verdict in place rather than writing to a
+    // control whose owner is tearing down.
+    expect(isVisible()).toBe(true);
+  });
+
+  it('leaves playback mode when access is revoked mid-replay', async () => {
+    // Reachable in ordinary use, not just on downgrade: a signed-in free user
+    // is shown the control during the never-over-gate window (Clerk hydrated,
+    // Convex snapshot still in flight for up to 10s) and can enter playback
+    // before the snapshot lands and denies them. Hiding the element alone
+    // strands the dashboard on historical data — the "Live" button is INSIDE
+    // the element being hidden, so there is no way back.
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+    manager.setupPlaybackControl();
+
+    const el = control()!;
+    el.querySelector<HTMLButtonElement>('.playback-toggle')!.click();
+    await vi.waitFor(() => {
+      expect(el.querySelector<HTMLInputElement>('.playback-slider')!.max).toBe('0');
+    });
+    el.querySelector<HTMLButtonElement>('.playback-btn[data-action="start"]')!.click();
+    await vi.waitFor(() => {
+      expect(document.body.classList.contains('playback-mode')).toBe(true);
+    });
+
+    entitlement = FREE_SNAPSHOT;
+    emitEntitlement();
+
+    expect(isVisible()).toBe(false);
+    expect(document.body.classList.contains('playback-mode')).toBe(false);
+    expect(loadAllData).toHaveBeenCalled();
   });
 });

--- a/tests/dom/playback-gate-wiring.test.mts
+++ b/tests/dom/playback-gate-wiring.test.mts
@@ -1,0 +1,255 @@
+/**
+ * #5632 — the playback control's premium gate.
+ *
+ * `setupPlaybackControl` used to hide the control behind
+ * `getAuthState().user?.role === 'pro'`. Nothing in this codebase writes Clerk
+ * `publicMetadata.plan`/`role` (zero `clerkClient`/`updateUser` writers; the
+ * gap is documented at src/services/panel-gating.ts, api/widget-agent.ts and
+ * server/gateway.ts), so that field is `'free'` for EVERY account including
+ * paying subscribers — the control rendered for nobody.
+ *
+ * A source grep for `evaluatePlaybackGate` would go green with the bug
+ * restored verbatim, so this file drives the real `setupPlaybackControl`
+ * against a minimal AppContext and asserts what the header actually contains.
+ *
+ * Only the reactive EDGES are stubbed — the Clerk session and the Convex
+ * entitlement snapshot. `hasPremiumAccess`, `isProUser`, `readPlaybackGateInputs`
+ * and `resolvePlaybackGate` all run for real, so the mapping from live state to
+ * verdict is under test and not just the closure that reads it.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+type Session = {
+  user: { id: string; name: string; email: string; role: 'free' | 'pro' } | null;
+  isPending: boolean;
+};
+
+type Entitlement = {
+  planKey: string;
+  features: { tier: number };
+  validUntil: number;
+} | null;
+
+/** Live Clerk session, mutated per case. Boot default mirrors auth-state.ts. */
+let session: Session = { user: null, isPending: true };
+/** Live Convex entitlement snapshot; `null` means "no snapshot has arrived". */
+let entitlement: Entitlement = null;
+// Kept apart, and each replayed with the argument its real emitter passes, so
+// the test cannot accidentally certify a listener that only works when called
+// with the other source's payload (or with none at all).
+const authListeners: Array<(state: Session) => void> = [];
+const entitlementListeners: Array<(state: Entitlement) => void> = [];
+
+// Partial mocks throughout: a full replacement would turn every other export
+// these modules provide into `undefined` somewhere in the event-handlers import
+// graph, failing later with an unrelated-looking error.
+vi.mock('@/services/auth-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/auth-state')>()),
+  getAuthState: () => session,
+  subscribeAuthState: (fn: (state: Session) => void) => {
+    authListeners.push(fn);
+    return () => {};
+  },
+}));
+
+// `isEntitled` is re-implemented rather than passed through because the real
+// one reads a module-private `currentState` this test cannot write. The three
+// conditions are entitlements.ts:192-198 verbatim; `isProUser()` (widget-store)
+// consumes it for real, which is the path a paying subscriber actually takes.
+vi.mock('@/services/entitlements', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/entitlements')>()),
+  getEntitlementState: () => entitlement,
+  isEntitled: () =>
+    entitlement !== null && entitlement.planKey !== 'free' && entitlement.validUntil >= Date.now(),
+  onEntitlementChange: (fn: (state: Entitlement) => void) => {
+    entitlementListeners.push(fn);
+    return () => {};
+  },
+}));
+
+const trackGateHit = vi.fn<(feature: string) => void>();
+vi.mock('@/services/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/analytics')>()),
+  trackGateHit: (feature: string) => trackGateHit(feature),
+}));
+
+const { EventHandlerManager } = await import('@/app/event-handlers');
+
+let container: HTMLElement;
+let manager: InstanceType<typeof EventHandlerManager>;
+let loadAllData: Mock<() => void>;
+
+const control = () => container.querySelector<HTMLElement>('.playback-control');
+const isVisible = () => control()!.style.display !== 'none';
+
+/** A signed-in Clerk session. `role` is ALWAYS 'free' — nothing writes 'pro'. */
+function signedIn(): Session {
+  return {
+    user: { id: 'user_1', name: 'A', email: 'a@example.com', role: 'free' },
+    isPending: false,
+  };
+}
+
+const PRO_SNAPSHOT: Entitlement = {
+  planKey: 'pro',
+  features: { tier: 1 },
+  validUntil: Date.now() + 86_400_000,
+};
+
+const FREE_SNAPSHOT: Entitlement = {
+  planKey: 'free',
+  features: { tier: 0 },
+  validUntil: Date.now() + 86_400_000,
+};
+
+/** Replay a Clerk session change through the auth subscription. */
+function emitAuth(): void {
+  for (const fn of [...authListeners]) fn(session);
+}
+
+/** Replay a Convex entitlement push through the entitlement subscription. */
+function emitEntitlement(): void {
+  for (const fn of [...entitlementListeners]) fn(entitlement);
+}
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  authListeners.length = 0;
+  entitlementListeners.length = 0;
+  trackGateHit.mockClear();
+  session = { user: null, isPending: true };
+  entitlement = null;
+  loadAllData = vi.fn<() => void>();
+
+  container = document.createElement('div');
+  const headerRight = document.createElement('div');
+  headerRight.className = 'header-right';
+  container.appendChild(headerRight);
+  document.body.appendChild(container);
+
+  const ctx = {
+    container,
+    isDestroyed: false,
+    isPlaybackMode: false,
+    panels: {},
+    newsPanels: {},
+  } as unknown as ConstructorParameters<typeof EventHandlerManager>[0];
+
+  manager = new EventHandlerManager(ctx, {
+    loadAllData,
+  } as unknown as ConstructorParameters<typeof EventHandlerManager>[1]);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('setupPlaybackControl — entitlement gate (#5632)', () => {
+  it('shows the control to a paying subscriber whose Clerk role is still "free"', () => {
+    // The whole bug: Clerk `role` is never written to 'pro', so the old gate
+    // hid the control from the exact users who paid for it.
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+
+    manager.setupPlaybackControl();
+
+    expect(isVisible()).toBe(true);
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+
+  it('keeps the control visible for a signed-in user with NO entitlement snapshot', () => {
+    // Never over-gate. A late, failed or skipped Convex subscription is an
+    // UNKNOWN, not a denial — `initEntitlementSubscription` gives up entirely
+    // when Convex auth misses its 10s window or VITE_CONVEX_URL is unset, so a
+    // fail-closed branch here would be a permanent lockout, not a boot blip
+    // (post-mortem: src/app/panel-layout.ts:710-735).
+    session = signedIn();
+    entitlement = null;
+
+    manager.setupPlaybackControl();
+
+    expect(isVisible()).toBe(true);
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+
+  it('hides the control from a signed-in free user once the snapshot proves it', () => {
+    session = signedIn();
+    entitlement = FREE_SNAPSHOT;
+
+    manager.setupPlaybackControl();
+
+    expect(isVisible()).toBe(false);
+    expect(trackGateHit).toHaveBeenCalledWith('playback');
+  });
+
+  it('hides the control from an anonymous visitor once auth settles', () => {
+    session = { user: null, isPending: false };
+
+    manager.setupPlaybackControl();
+
+    expect(isVisible()).toBe(false);
+    expect(trackGateHit).toHaveBeenCalledWith('playback');
+  });
+
+  it('hides the control while auth is still pending WITHOUT recording a gate hit', () => {
+    // `isPending` is the boot default and resolves within Clerk's bounded ~4s
+    // idle window, so hiding costs a signed-in Pro user a brief delay instead
+    // of flashing a Pro control at every anonymous visitor. It is an unknown,
+    // though — counting it as a denial would drown the funnel metric in boot
+    // noise from users who were never gated.
+    session = { user: null, isPending: true };
+
+    manager.setupPlaybackControl();
+
+    expect(isVisible()).toBe(false);
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+
+  it('reveals the control when the entitlement snapshot lands after boot', () => {
+    // The post-checkout unlock path. Auth state does not re-emit when Convex
+    // pushes a new entitlement row, so an auth-only subscription leaves a
+    // freshly-upgraded subscriber staring at a hidden control until reload.
+    session = signedIn();
+    entitlement = FREE_SNAPSHOT;
+
+    manager.setupPlaybackControl();
+    expect(isVisible()).toBe(false);
+
+    entitlement = PRO_SNAPSHOT;
+    emitEntitlement();
+
+    expect(isVisible()).toBe(true);
+  });
+
+  it('reveals the control when a pending session resolves to a subscriber', () => {
+    session = { user: null, isPending: true };
+    entitlement = null;
+
+    manager.setupPlaybackControl();
+    expect(isVisible()).toBe(false);
+
+    session = signedIn();
+    entitlement = PRO_SNAPSHOT;
+    emitAuth();
+
+    expect(isVisible()).toBe(true);
+    expect(trackGateHit).not.toHaveBeenCalled();
+  });
+
+  it('records the playback gate hit at most once per session', () => {
+    session = { user: null, isPending: false };
+
+    manager.setupPlaybackControl();
+    emitAuth();
+    emitEntitlement();
+
+    expect(trackGateHit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/entitlement-listener-fanout.test.mts
+++ b/tests/entitlement-listener-fanout.test.mts
@@ -1,0 +1,102 @@
+/**
+ * Entitlement listener fan-out isolation (#5632 review follow-up).
+ *
+ * Subscribers to `onEntitlementChange` are independent UI surfaces — the panel
+ * gate, the Pro banner, the export gate, the playback gate. They share one
+ * emission loop, so an unguarded loop means the FIRST listener to throw
+ * silently stops every listener registered after it from ever updating again.
+ * There is no error path for that: the survivors quietly hold their last
+ * verdict, which is the same "green while dead" shape the gate this landed
+ * beside was fixed for.
+ *
+ * `resetEntitlementState()` is the one emission site reachable without a live
+ * Convex client, so it is what these tests drive. The Convex watch path shares
+ * the same `notifyListeners` helper by construction, which is the point of the
+ * extraction — the guarantee cannot hold on one path and not the other.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { onEntitlementChange, resetEntitlementState } from '@/services/entitlements';
+
+/** Unsubscribers for every listener a test registers. */
+let cleanup: Array<() => void> = [];
+
+function subscribe(fn: (state: unknown) => void): void {
+  cleanup.push(onEntitlementChange(fn));
+}
+
+beforeEach(() => {
+  cleanup = [];
+});
+
+afterEach(() => {
+  for (const off of cleanup) off();
+  cleanup = [];
+});
+
+describe('entitlement listener fan-out', () => {
+  it('keeps notifying later listeners after an earlier one throws', () => {
+    const order: string[] = [];
+
+    subscribe(() => {
+      order.push('first');
+      throw new Error('listener blew up');
+    });
+    subscribe(() => order.push('second'));
+    subscribe(() => order.push('third'));
+
+    // Must not propagate: the emitter's caller is a Convex callback (or a
+    // sign-out handler) with no meaningful way to recover from one subscriber.
+    assert.doesNotThrow(() => resetEntitlementState());
+
+    assert.deepEqual(order, ['first', 'second', 'third']);
+  });
+
+  it('survives every listener throwing', () => {
+    let calls = 0;
+    for (let i = 0; i < 3; i++) {
+      subscribe(() => {
+        calls++;
+        throw new Error(`listener ${i}`);
+      });
+    }
+
+    assert.doesNotThrow(() => resetEntitlementState());
+    assert.equal(calls, 3);
+  });
+
+  it('still delivers on later emissions after a listener threw once', () => {
+    // The isolation must not be one-shot: a listener that throws on the first
+    // emission and recovers has to keep receiving, and its siblings must not
+    // be dropped from the set.
+    let thrown = 0;
+    let healthy = 0;
+
+    subscribe(() => {
+      thrown++;
+      if (thrown === 1) throw new Error('transient');
+    });
+    subscribe(() => healthy++);
+
+    resetEntitlementState();
+    resetEntitlementState();
+
+    assert.equal(thrown, 2);
+    assert.equal(healthy, 2);
+  });
+
+  it('unsubscribing a throwing listener removes it from the fan-out', () => {
+    let healthy = 0;
+    const off = onEntitlementChange(() => {
+      throw new Error('bad');
+    });
+    subscribe(() => healthy++);
+
+    resetEntitlementState();
+    off();
+    resetEntitlementState();
+
+    assert.equal(healthy, 2);
+  });
+});

--- a/tests/playback-gate.test.mts
+++ b/tests/playback-gate.test.mts
@@ -1,0 +1,110 @@
+/**
+ * #5632 — the playback-gate decision chain.
+ *
+ * `src/services/playback-gate.ts` is a zero-import leaf, so this suite needs no
+ * DOM, no Convex and no Vite globals. The wiring that feeds it live state is
+ * covered separately by `tests/dom/playback-gate-wiring.test.mts`.
+ *
+ * The shape under test is affirmative denial with ONE deliberate asymmetry: a
+ * pending Clerk session hides the control (bounded wait) while a missing
+ * entitlement snapshot shows it (unbounded — a skipped Convex subscription
+ * never resolves, and hiding there is the permanent lockout this issue is
+ * about).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolvePlaybackGate, type PlaybackGateInputs } from '@/services/playback-gate';
+
+/** Signed-in free user with a loaded snapshot — the one state that must deny. */
+function inputs(overrides: Partial<PlaybackGateInputs> = {}): PlaybackGateInputs {
+  return {
+    premiumAccess: false,
+    authPending: false,
+    signedIn: true,
+    entitlementLoaded: true,
+    ...overrides,
+  };
+}
+
+describe('resolvePlaybackGate — decision chain', () => {
+  it('denies the baseline: signed in, snapshot loaded, no premium path', () => {
+    assert.equal(resolvePlaybackGate(inputs()), 'denied');
+  });
+
+  it('shows the control whenever a premium path matched', () => {
+    assert.equal(resolvePlaybackGate(inputs({ premiumAccess: true })), 'visible');
+  });
+
+  it('shows the control to a signed-in user with NO entitlement snapshot', () => {
+    // The regression this issue exists for. A late, failed or skipped Convex
+    // subscription is an unknown that may never resolve — never over-gate.
+    assert.equal(resolvePlaybackGate(inputs({ entitlementLoaded: false })), 'visible');
+  });
+
+  it('denies an anonymous visitor even though they have no snapshot either', () => {
+    // Signed-out is the one affirmative denial reachable without a snapshot,
+    // so it must be checked BEFORE the null-snapshot allowance above —
+    // otherwise every anonymous visitor falls through to `visible`.
+    assert.equal(
+      resolvePlaybackGate(inputs({ signedIn: false, entitlementLoaded: false })),
+      'denied',
+    );
+  });
+
+  it('reports pending — not denied — while Clerk auth is still resolving', () => {
+    // Distinct from `denied` so the caller can hide the control without
+    // charging the funnel a gate hit for a user who was never gated.
+    assert.equal(
+      resolvePlaybackGate(inputs({ authPending: true, signedIn: false, entitlementLoaded: false })),
+      'pending',
+    );
+  });
+
+  it('shows the control to a premium session before auth or Convex settle', () => {
+    // The desktop runtime path: WORLDMONITOR_API_KEY present, no Clerk session
+    // will ever exist, no entitlement row will ever arrive.
+    assert.equal(
+      resolvePlaybackGate(
+        inputs({
+          premiumAccess: true,
+          authPending: true,
+          signedIn: false,
+          entitlementLoaded: false,
+        }),
+      ),
+      'visible',
+    );
+  });
+
+  it('never denies a signed-in session on the strength of a pending auth read', () => {
+    // A cookie-backed subscriber mid-hydration must not be denied — pending
+    // outranks every affirmative-denial branch below it.
+    assert.equal(resolvePlaybackGate(inputs({ authPending: true })), 'pending');
+  });
+
+  it('only ever denies when we hold affirmative evidence', () => {
+    // Exhaustive sweep of the 16-state input space: assert that no combination
+    // reaches `denied` without either a settled signed-out session or a loaded
+    // snapshot on a signed-in one. A future reordering that lets an unknown
+    // fall through to denial fails here, not in production.
+    for (const premiumAccess of [false, true]) {
+      for (const authPending of [false, true]) {
+        for (const signedIn of [false, true]) {
+          for (const entitlementLoaded of [false, true]) {
+            const state = { premiumAccess, authPending, signedIn, entitlementLoaded };
+            const verdict = resolvePlaybackGate(state);
+            if (verdict !== 'denied') continue;
+
+            assert.equal(premiumAccess, false, `premium session denied: ${JSON.stringify(state)}`);
+            assert.equal(authPending, false, `pending session denied: ${JSON.stringify(state)}`);
+            assert.ok(
+              !signedIn || entitlementLoaded,
+              `signed-in session denied with no snapshot: ${JSON.stringify(state)}`,
+            );
+          }
+        }
+      }
+    }
+  });
+});

--- a/tests/pro-banner-entitlement-race.test.mts
+++ b/tests/pro-banner-entitlement-race.test.mts
@@ -298,13 +298,27 @@ describe('wiring contracts (#5728)', () => {
     assert.doesNotMatch(failureFn, /\.splice\(/);
   });
 
-  it('resetEntitlementState notifies listeners so free surfaces re-evaluate', () => {
-    const src = readFileSync(resolve(root, 'src/services/entitlements.ts'), 'utf-8');
-    assert.match(
-      src,
-      /export function resetEntitlementState\(\): void \{[\s\S]*?for \(const cb of listeners\)/,
+  it('resetEntitlementState notifies listeners so free surfaces re-evaluate', async () => {
+    // Was a source grep for `for (const cb of listeners)` inside
+    // resetEntitlementState. That pinned the loop's LOCATION, not its
+    // behaviour, so hoisting the fan-out into a shared helper reddened it
+    // while the guarantee was intact. Driving the real functions covers the
+    // same regression and also catches a fan-out that runs but delivers the
+    // wrong value — which the grep could not see.
+    const { onEntitlementChange, resetEntitlementState } = await import(
+      '@/services/entitlements'
     );
-    assert.match(src, /cb\(null\)/);
+
+    resetEntitlementState(); // normalise: a null currentState means no replay on subscribe
+    const seen: Array<unknown> = [];
+    const off = onEntitlementChange((state) => seen.push(state));
+    try {
+      resetEntitlementState();
+    } finally {
+      off();
+    }
+
+    assert.deepEqual(seen, [null]);
   });
 
   it('checkout success paths write the pro banner entitlement hint', () => {


### PR DESCRIPTION
## Summary

The dashboard's historical-playback control was invisible to **every** user — including paying Pro subscribers — and had been for months. It was gated on `getAuthState().user?.role === 'pro'`, a Clerk `publicMetadata` field that nothing in this codebase writes: `grep -rln "clerkClient\|updateUser" src/ api/ server/ convex/ scripts/` returns zero. That field reads `'free'` for every account ever created, so the gate could never pass. Pro users now see the control; nobody filed a bug because the feature never rendered for anyone to miss.

That silence is the point. The loud version of this bug — a paying user hits a paywall — files a ticket in hours. A gate on an unwritten signal produces no error, no log line, and no complaint, because there is nothing for a user to report.

Fixes #5632

## The design decision worth reviewing

The new chain (`src/services/playback-gate.ts`) resolves its two "unknown" states in **opposite** directions, which is the one thing here that isn't self-evident from the diff:

| State | Verdict | Why |
|---|---|---|
| Auth still hydrating | hide (`pending`) | **Bounded** — Clerk settles within its idle window and the subscription immediately re-runs. Cost is a brief delay, not a lockout. Deliberately not counted as a denial, so boot states don't pollute the gate-hit funnel. |
| Signed in, no entitlement snapshot | **show** (`visible`) | **Unbounded** — `initEntitlementSubscription` returns without ever assigning `currentState` when `VITE_CONVEX_URL` is unset or Convex auth misses its 10s window. Failing closed here is indistinguishable from a permanent lockout for a paying customer. |

Failing open has a real consequence, so it's worth stating what it exposes: playback replays snapshots from the user's own IndexedDB (`src/services/storage.ts`), and snapshot *saving* is already ungated for everyone. A signed-in free user with a dead Convex connection can replay dashboard state their own browser already holds — no server call, no premium data. This mirrors the affirmative-denial shape `export-gate.ts` already uses and the post-mortem at `panel-layout.ts:723-748`.

Also added the `onEntitlementChange` subscription the old wiring lacked. Convex's watcher is a separate emitter from Clerk's, so an auth-only subscription never re-ran when a snapshot landed after sign-in — exactly the post-checkout unlock path.

## Two follow-ups from review

**Losing access mid-replay stranded the dashboard.** Hiding the control isn't enough: the "Live" button lives *inside* the element being hidden, so a user replaying a snapshot when their verdict flipped had no way back to live data. Reachable in ordinary use, not just on downgrade — the fail-open window above shows the control to a signed-in free user, who can enter playback before their snapshot lands and denies them. `PlaybackControl.exitPlayback()` now returns them to live. Its `isPlaybackMode` guard is load-bearing: the gate resolves non-visible on *every* page load while Clerk hydrates, and an unguarded exit would fire a full `loadAllData()` each time.

**A test mock was re-implementing the entitlement predicate.** `isEntitled()` reads module-private state with no setter, so the DOM suite had hand-copied its three conditions — and mutating the real predicate left the suite green. `isEntitlementActive(state, now)` is that rule over an injected snapshot; the mock now delegates to it, and the same mutation reds 5 tests. Behavior is unchanged.

## Validation

Test-level and mutation-based; no live browser session, since reproducing the original bug needs a real signed-in Pro account against Convex.

- **Red before green** — 5 of 8 DOM tests failed against the original code.
- **15 mutants killed** across three rounds: reordered chain branches, dropped subscription, removed gate-hit latch, restored `role === 'pro'` verbatim, deleted `isDestroyed` guard, removed `exitPlayback` call and its guard, and — the decisive one — mutating `isEntitlementActive`, which the old hand-copied mock survived.
- One mutant initially appeared to survive; it was a flaw in my mutation regex (`if (this.ctx.isDestroyed) return;` appears 5 times in that file and the pattern hit `setupExportPanel`'s copy). Line-targeted mutation killed it.
- Gates: `typecheck`, `typecheck:api`, `typecheck:dom-tests`, `test:dom` (117), `tests/playback-gate.test.mts` (8), 235 entitlement-touching tsx tests, `biome`, `lint:boundaries`, `lint:api-contract`, `docs:check`, `lint:safe-html`.

A sweep confirmed no other consumer gates solely on the dead field: the remaining `role === 'pro'` reads are union members inside `hasPremiumAccess()` / `isProUser()`, and `ProBanner` leads with `isEntitled()`.

Related: #5604 — the mirror image (advertised capabilities with no enforcement at all), worth a sweep for other dead entitlement config.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
