### PR TITLE
fix(sentry): attribute events to deployed builds

### DIFF
--- a/src/bootstrap/sentry-build-metadata.ts
+++ b/src/bootstrap/sentry-build-metadata.ts
@@ -1,0 +1,35 @@
+const VERCEL_COMMIT_SHA = /^[0-9a-f]{40}$/i;
+
+interface SentryBuildMetadata {
+  release: string;
+  dist?: string;
+  initialScope?: {
+    tags: {
+      build_sha: string;
+    };
+  };
+}
+
+/**
+ * Keep the semver release stable while making each Vercel deployment
+ * attributable. Sentry's `dist` is the build within a release; the explicit
+ * tag keeps the SHA available in issue/event searches and exports.
+ */
+export function getSentryBuildMetadata(
+  appVersion: string,
+  buildHash: string,
+): SentryBuildMetadata {
+  const release = `worldmonitor@${appVersion}`;
+  const normalizedBuildHash = buildHash.trim();
+  if (!VERCEL_COMMIT_SHA.test(normalizedBuildHash)) return { release };
+
+  return {
+    release,
+    dist: normalizedBuildHash,
+    initialScope: {
+      tags: {
+        build_sha: normalizedBuildHash,
+      },
+    },
+  };
+}

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -7,6 +7,7 @@
  */
 
 import { isDebugBearRumScriptFrame } from './debugbear-rum';
+import { getSentryBuildMetadata } from './sentry-build-metadata';
 
 type SentryNs = typeof import('@sentry/browser');
 
@@ -58,7 +59,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
   return {
     dsn: sentryDsn || undefined,
-    release: `worldmonitor@${__APP_VERSION__}`,
+    ...getSentryBuildMetadata(__APP_VERSION__, __BUILD_HASH__),
     environment: (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
       : location.hostname.includes('vercel.app') ? 'preview'
       : 'development',

--- a/tests/sentry-build-metadata.test.mts
+++ b/tests/sentry-build-metadata.test.mts
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getSentryBuildMetadata } from '../src/bootstrap/sentry-build-metadata';
+
+describe('Sentry build attribution', () => {
+  it('uses the Vercel commit SHA as dist and build_sha without changing release grouping', () => {
+    const sha = 'aa74d8947a7cd59afef896078a606d31e0bd388b';
+
+    assert.deepEqual(getSentryBuildMetadata('2.10.0', sha), {
+      release: 'worldmonitor@2.10.0',
+      dist: sha,
+      initialScope: {
+        tags: {
+          build_sha: sha,
+        },
+      },
+    });
+  });
+
+  it('omits build attribution for local and malformed build markers', () => {
+    for (const buildHash of ['dev', '', 'abc123', 'g'.repeat(40), 'a'.repeat(41)]) {
+      assert.deepEqual(
+        getSentryBuildMetadata('2.10.0', buildHash),
+        { release: 'worldmonitor@2.10.0' },
+      );
+    }
+  });
+
+  it('normalizes surrounding whitespace from the injected SHA', () => {
+    const sha = '0123456789abcdef0123456789abcdef01234567';
+    const metadata = getSentryBuildMetadata('2.10.0', `  ${sha}\n`);
+
+    assert.equal(metadata.dist, sha);
+    assert.equal(metadata.initialScope?.tags.build_sha, sha);
+  });
+});


### PR DESCRIPTION
## Summary

Browser errors can now be traced to the exact Vercel deployment that emitted them, making stale-client events distinguishable from regressions in the current build. The semantic `worldmonitor@<version>` release remains stable, while valid commit SHAs become both the Sentry `dist` and a searchable `build_sha` tag; local or malformed build markers remain untagged.

## Validation

- 11 focused Sentry build-attribution and deferred-replay tests passed
- 227 Sentry filtering tests passed
- `npm run typecheck`
- Full pre-push gate passed, including change-scoped tests and repository guardrails

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)
