### PR TITLE
fix(ci): validate Railway project token context

### DIFF
--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install pinned Railway CLI
         run: npm install --global @railway/cli@5.30.1
 
-      - name: Link Railway production context
+      - name: Verify Railway production context
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
@@ -54,7 +54,8 @@ jobs:
             echo "::error::RAILWAY_PROJECT_ID Actions environment variable is required for the production config audit."
             exit 1
           fi
-          railway link --project "$RAILWAY_PROJECT_ID" --environment production --json
+          railway status --project "$RAILWAY_PROJECT_ID" --environment production --json > /dev/null
+          echo "Project-scoped Railway token is valid for the expected production context."
 
       - name: Audit Railway ingestion deployment controls
         env:

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -68,6 +68,44 @@ function runScheduledGate(gateState) {
   }
 }
 
+function runRailwayContext({ token = 'project-token', projectId = 'project-123' } = {}) {
+  const tempDir = mkdtempSync(join(repoRoot, '.tmp-seed-freshness-railway-'));
+  const fakeBin = join(tempDir, 'bin');
+  const fakeRailway = join(fakeBin, 'railway');
+
+  try {
+    mkdirSync(fakeBin);
+    writeFileSync(
+      fakeRailway,
+      [
+        '#!/bin/sh',
+        '[ "$RAILWAY_TOKEN" = "project-token" ] || exit 91',
+        '[ "$*" = "status --project project-123 --environment production --json" ] || exit 92',
+        "printf '{}\\n'",
+        '',
+      ].join('\n'),
+    );
+    chmodSync(fakeRailway, 0o755);
+
+    return spawnSync(
+      'bash',
+      ['-e', '-c', stepNamed('Verify Railway production context').run],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          RAILWAY_TOKEN: token,
+          RAILWAY_PROJECT_ID: projectId,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        },
+      },
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe('seed freshness workflow control plane', () => {
   it('fails closed unless the exact checked-out main SHA has a successful gate', () => {
     const success = runScheduledGate('success');
@@ -123,8 +161,8 @@ describe('seed freshness workflow control plane', () => {
     const installIndex = monitorSteps.findIndex(
       (step) => step.name === 'Install pinned Railway CLI',
     );
-    const linkIndex = monitorSteps.findIndex(
-      (step) => step.name === 'Link Railway production context',
+    const contextIndex = monitorSteps.findIndex(
+      (step) => step.name === 'Verify Railway production context',
     );
     const auditIndex = monitorSteps.findIndex(
       (step) => step.name === 'Audit Railway ingestion deployment controls',
@@ -135,7 +173,7 @@ describe('seed freshness workflow control plane', () => {
 
     assert.ok(installIndex >= 0, 'workflow must install the Railway CLI');
     assert.ok(
-      installIndex < linkIndex && linkIndex < auditIndex && auditIndex < healthIndex,
+      installIndex < contextIndex && contextIndex < auditIndex && auditIndex < healthIndex,
       'Railway context and watch-path drift must be checked before compact health',
     );
 
@@ -145,14 +183,19 @@ describe('seed freshness workflow control plane', () => {
       'scheduled audits must use a deterministic Railway CLI version',
     );
 
-    const link = monitorSteps[linkIndex];
-    assert.equal(link.env.RAILWAY_TOKEN, '${{ secrets.RAILWAY_PRODUCTION_TOKEN }}');
-    assert.equal(link.env.RAILWAY_PROJECT_ID, '${{ vars.RAILWAY_PROJECT_ID }}');
-    assert.match(link.run, /RAILWAY_TOKEN/);
-    assert.match(link.run, /RAILWAY_PROJECT_ID/);
+    const context = monitorSteps[contextIndex];
+    assert.equal(context.env.RAILWAY_TOKEN, '${{ secrets.RAILWAY_PRODUCTION_TOKEN }}');
+    assert.equal(context.env.RAILWAY_PROJECT_ID, '${{ vars.RAILWAY_PROJECT_ID }}');
+    assert.match(context.run, /RAILWAY_TOKEN/);
+    assert.match(context.run, /RAILWAY_PROJECT_ID/);
     assert.match(
-      link.run,
-      /railway link --project "\$RAILWAY_PROJECT_ID" --environment production --json/,
+      context.run,
+      /railway status --project "\$RAILWAY_PROJECT_ID" --environment production --json > \/dev\/null/,
+    );
+    assert.doesNotMatch(
+      context.run,
+      /railway link/,
+      'project tokens resolve their own context and must not invoke account-scoped linking',
     );
 
     const audit = monitorSteps[auditIndex];
@@ -169,5 +212,21 @@ describe('seed freshness workflow control plane', () => {
       /RAILWAY_API_TOKEN/,
       'the workflow must not use an account-scoped Railway credential',
     );
+  });
+
+  it('validates the project token against the expected production context without linking', () => {
+    const success = runRailwayContext();
+    assert.equal(success.status, 0, success.stderr);
+    assert.match(success.stdout, /valid for the expected production context/);
+
+    for (const [label, options] of [
+      ['missing project token', { token: '' }],
+      ['missing project id', { projectId: '' }],
+      ['wrong project token', { token: 'wrong-token' }],
+      ['wrong project id', { projectId: 'wrong-project' }],
+    ]) {
+      const result = runRailwayContext(options);
+      assert.notEqual(result.status, 0, `${label} must fail before the Railway audit`);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- replace the account-scoped `railway link` call with an explicit project/environment status validation
- keep the production audit on the environment-scoped `RAILWAY_TOKEN` credential
- execute the checked-in shell step in tests and fail for missing or mismatched token/project inputs

## Root cause

The post-merge acceptance run reached Railway but failed at context linking: https://github.com/koala73/worldmonitor/actions/runs/30458792237

Railway project tokens already resolve their project and environment. The `link` command first enumerates workspaces, which rejects project-scoped credentials. The pinned CLI supports validating the expected context directly with `railway status --project ... --environment production`.

## Verification

- `node --test --test-concurrency=1 tests/seed-freshness-workflow.test.mjs tests/railway-watch-path-audit.test.mjs` (36 passed)
- pre-push TypeScript and change-scoped gates passed
- live production watch-path audit repaired and verified the registry-derived `seed-conflict-intel` closure