### PR TITLE
test(mcp): pin intel history POST body privacy

### DIFF
--- a/tests/mcp-intel-history-post-body.test.mts
+++ b/tests/mcp-intel-history-post-body.test.mts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TOOL_REGISTRY } from '../api/mcp/registry/index.ts';
+import { verifyInternalMcpRequest } from '../server/_shared/mcp-internal-hmac.ts';
+
+const BASE_URL = 'https://worldmonitor.app';
+const HMAC_SECRET = 'test-secret-mcp-intel-history-post-body';
+const USER_ID = 'user_mcp_intel_history_post_body';
+const originalFetch = globalThis.fetch;
+const originalHmacSecret = process.env.MCP_INTERNAL_HMAC_SECRET;
+
+const cases = [
+  {
+    toolName: 'search_intel_history',
+    path: '/api/intelligence/v1/search-intel-history',
+    textField: 'query',
+    sensitiveText: "our supplier's plant in Côte d'Ivoire",
+    params: {
+      query: "our supplier's plant in Côte d'Ivoire",
+      domain: 'energy',
+      country: 'CI',
+      from: 1_767_225_600_000,
+      to: 1_767_312_000_000,
+      limit: 7,
+    },
+  },
+  {
+    toolName: 'get_similar_events',
+    path: '/api/intelligence/v1/get-similar-events',
+    textField: 'situation',
+    sensitiveText: 'a privately operated terminal has stopped loading strategic cargo',
+    params: {
+      situation: 'a privately operated terminal has stopped loading strategic cargo',
+      domain: 'energy',
+      country: 'CI',
+      limit: 5,
+    },
+  },
+] as const;
+
+beforeEach(() => {
+  process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalHmacSecret === undefined) {
+    delete process.env.MCP_INTERNAL_HMAC_SECRET;
+  } else {
+    process.env.MCP_INTERNAL_HMAC_SECRET = originalHmacSecret;
+  }
+});
+
+function rpcTool(name: string) {
+  const tool = TOOL_REGISTRY.find((candidate) => candidate.name === name);
+  assert.ok(tool, `${name} must be registered`);
+  assert.equal(typeof tool._execute, 'function', `${name} must be an RPC tool`);
+  return tool;
+}
+
+describe('MCP intel-history request privacy contract (#5741)', () => {
+  it('POSTs analyst text in the signed JSON body and never in the request URL', async () => {
+    for (const testCase of cases) {
+      let captured: { url: string; init: RequestInit } | undefined;
+      globalThis.fetch = (async (input: string | URL | Request, init: RequestInit = {}) => {
+        captured = { url: String(input), init };
+        return new Response(JSON.stringify({
+          records: [],
+          [testCase.textField]: testCase.sensitiveText,
+          partial: false,
+          upstreamUnavailable: false,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch;
+
+      await rpcTool(testCase.toolName)._execute!(
+        testCase.params,
+        BASE_URL,
+        { kind: 'pro', userId: USER_ID, mcpTokenId: 'mcp_token_5741' },
+        {},
+      );
+
+      assert.ok(captured, `${testCase.toolName} must make an outbound request`);
+      const url = new URL(captured.url);
+      assert.equal(url.pathname, testCase.path);
+      assert.equal(
+        url.searchParams.has(testCase.textField),
+        false,
+        `${testCase.textField} must not be present in the URL`,
+      );
+      assert.equal(
+        decodeURIComponent(url.href).includes(testCase.sensitiveText),
+        false,
+        'analyst text must not appear anywhere in the URL',
+      );
+      assert.equal(captured.init.method, 'POST');
+      assert.match(
+        new Headers(captured.init.headers).get('Content-Type') ?? '',
+        /^application\/json\b/i,
+      );
+
+      const body = String(captured.init.body);
+      assert.equal(JSON.parse(body)[testCase.textField], testCase.sensitiveText);
+
+      const signedRequest = new Request(captured.url, {
+        method: captured.init.method,
+        headers: captured.init.headers,
+        body,
+      });
+      const verified = await verifyInternalMcpRequest(signedRequest, HMAC_SECRET);
+      assert.equal(
+        verified?.userId,
+        USER_ID,
+        'HMAC must bind the same POST URL and body bytes sent on the wire',
+      );
+
+      const tamperedBody = JSON.stringify({
+        ...JSON.parse(body),
+        [testCase.textField]: `${testCase.sensitiveText} tampered`,
+      });
+      const tamperedRequest = new Request(captured.url, {
+        method: captured.init.method,
+        headers: captured.init.headers,
+        body: tamperedBody,
+      });
+      assert.equal(
+        await verifyInternalMcpRequest(tamperedRequest, HMAC_SECRET),
+        null,
+        'changing the analyst text must invalidate the outbound signature',
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The MCP intel-history privacy contract is now executable: `search_intel_history` and `get_similar_events` must keep analyst text out of the URL, send it in a POST JSON body, and produce an HMAC that verifies against the exact method, URL, and body bytes sent on the wire. A request-shape regression now fails before sensitive search intent can reappear in access logs, while a tampered-body assertion proves the signature is binding the payload rather than merely being present.

Fixes #5741.

## Validation

- Mutation check: temporarily restored `?query=...`; the new test failed on the URL-privacy assertion.
- `TMPDIR=/private/tmp node --import tsx --test tests/intel-history-endpoints.test.mts tests/mcp-intel-history-post-body.test.mts` — 51 passed.
- `./node_modules/.bin/biome check tests/mcp-intel-history-post-body.test.mts` — passed.
- Repository pre-push gate — passed, including TypeScript, the changed test, Unicode safety, version synchronization, and applicable repository guards.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
