### PR TITLE
fix(ci): paginate gate status lookup

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -33,6 +33,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
+          set -o pipefail
           required='["changes","docs-stats","unit","consumer-prices","sidecar","convex-tests","dom-tests","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","security-audit"]'
 
           if [ -n "$SHA" ]; then
@@ -42,8 +43,11 @@ jobs:
             # schedule / workflow_dispatch — sweep open PRs whose gate status
             # is still pending. Public-repo reads need no extra permission.
             shas=$(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[].head.sha' | sort -u | while read -r s; do
-              state=$(gh api "repos/$REPO/commits/$s/status" \
-                --jq '[.statuses[] | select(.context == "gate")] | sort_by(.updated_at) | last | .state // "missing"')
+              state=$(
+                gh api --paginate --slurp \
+                  "repos/$REPO/commits/$s/statuses?per_page=100" |
+                  jq -r 'flatten | map(select(.context == "gate")) | sort_by(.updated_at) | last | .state // "missing"'
+              )
               if [ "$state" = "pending" ]; then echo "$s"; fi
             done)
             if [ -z "$shas" ]; then

--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -29,8 +29,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gate_state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
-            --jq '[.statuses[] | select(.context == "gate")] | sort_by(.updated_at) | last | .state // "missing"')
+          set -o pipefail
+          gate_state=$(
+            gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/statuses?per_page=100" |
+              jq -r 'flatten | map(select(.context == "gate")) | sort_by(.updated_at) | last | .state // "missing"'
+          )
           echo "gate_state=$gate_state"
           if [ "$gate_state" != "success" ]; then
             echo "::error::Cannot establish ingestion operational acceptance because main gate is $gate_state."

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -209,6 +209,22 @@ describe('CI workflow coverage', () => {
     );
   });
 
+  it('paginates gate status history during the scheduled self-healing sweep', () => {
+    const deployGateJob = workflowJobBlock(deployGateWorkflow, 'gate');
+
+    assert.match(deployGateJob, /gh api --paginate --slurp/);
+    assert.match(deployGateJob, /commits\/\$s\/statuses\?per_page=100/);
+    assert.match(
+      deployGateJob,
+      /flatten \| map\(select\(\.context == "gate"\)\) \| sort_by\(\.updated_at\) \| last/,
+    );
+    assert.doesNotMatch(
+      deployGateJob,
+      /commits\/\$s\/status"/,
+      'the combined status endpoint silently truncates large commit-status histories',
+    );
+  });
+
   it('treats sidecar changes as code for PR smoke gating', () => {
     assert.ok(
       testWorkflow.includes('^src-tauri\\/sidecar\\/'),

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -38,13 +38,42 @@ function runScheduledGate(gateState) {
   const tempDir = mkdtempSync(join(repoRoot, '.tmp-seed-freshness-gate-'));
   const fakeBin = join(tempDir, 'bin');
   const fakeGh = join(fakeBin, 'gh');
+  const nonGateStatuses = Array.from({ length: 100 }, (_, index) => ({
+    context: `railway-${index}`,
+    state: 'success',
+    updated_at: '2026-07-29T12:00:00Z',
+  }));
+  const gateStatuses = gateState === 'missing'
+    ? []
+    : [
+        {
+          context: 'gate',
+          state: 'success',
+          updated_at: '2026-07-29T12:00:00Z',
+        },
+        {
+          context: 'gate',
+          state: gateState,
+          updated_at: '2026-07-29T12:01:00Z',
+        },
+      ];
 
   try {
-    // The workflow's only external input is the latest `gate` commit status.
-    // Replacing gh at PATH level executes the exact checked-in shell block
-    // without relying on GitHub's API or duplicating its branching logic.
+    // Put the latest `gate` status on a second API page. Replacing gh at PATH
+    // level executes the exact checked-in shell block and proves it cannot
+    // regress to GitHub's truncated default status response.
     mkdirSync(fakeBin);
-    writeFileSync(fakeGh, '#!/bin/sh\nprintf \'%s\\n\' "$FAKE_GATE_STATE"\n');
+    writeFileSync(
+      fakeGh,
+      [
+        '#!/bin/sh',
+        'case " $* " in *" --paginate "*) ;; *) exit 91 ;; esac',
+        'case " $* " in *" --slurp "*) ;; *) exit 92 ;; esac',
+        'case "$*" in *"/statuses?per_page=100"*) ;; *) exit 93 ;; esac',
+        'printf \'%s\\n\' "$FAKE_STATUS_PAGES"',
+        '',
+      ].join('\n'),
+    );
     chmodSync(fakeGh, 0o755);
 
     return spawnSync(
@@ -55,7 +84,7 @@ function runScheduledGate(gateState) {
         encoding: 'utf8',
         env: {
           ...process.env,
-          FAKE_GATE_STATE: gateState,
+          FAKE_STATUS_PAGES: JSON.stringify([nonGateStatuses, gateStatuses]),
           GH_TOKEN: 'test-token',
           GITHUB_REPOSITORY: 'koala73/worldmonitor',
           GITHUB_SHA: '0123456789abcdef',
@@ -129,6 +158,8 @@ describe('seed freshness workflow control plane', () => {
     assert.equal(gate['continue-on-error'], undefined);
     assert.equal(workflow.jobs.monitor['continue-on-error'], undefined);
     assert.doesNotMatch(gate.run, /should_run|Skipping seed freshness/);
+    assert.match(gate.run, /gh api --paginate --slurp/);
+    assert.match(gate.run, /statuses\?per_page=100/);
     const acceptance = stepNamed('Check ingestion operational acceptance');
     assert.equal(
       acceptance.if,


### PR DESCRIPTION
## Summary
- paginate the full commit-status history before scheduled ingestion acceptance evaluates the main gate
- apply the same invariant to the Deploy Gate self-healing sweep
- fail on API/pipeline errors and add a two-page behavioral regression

## Evidence
- exact main combined status response exposed 30 of 108 statuses and reported gate missing
- the paginated history recovered the latest successful gate
- 66 focused workflow and Railway contract tests passed
- both workflow files parse as valid YAML
- live Railway production watch-path audit passed
- pre-push typecheck and changed-test gates passed