### PR TITLE
fix(ci): preserve gate status API order

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -43,10 +43,12 @@ jobs:
             # schedule / workflow_dispatch — sweep open PRs whose gate status
             # is still pending. Public-repo reads need no extra permission.
             shas=$(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[].head.sha' | sort -u | while read -r s; do
+              # The API guarantees newest-first status history. Preserve that
+              # order because updated_at ties within the same second.
               state=$(
                 gh api --paginate --slurp \
                   "repos/$REPO/commits/$s/statuses?per_page=100" |
-                  jq -r 'flatten | map(select(.context == "gate")) | sort_by(.updated_at) | last | .state // "missing"'
+                  jq -r 'flatten | map(select(.context == "gate")) | first | .state // "missing"'
               )
               if [ "$state" = "pending" ]; then echo "$s"; fi
             done)

--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -30,10 +30,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
+          # GitHub guarantees newest-first status history. Preserve that order:
+          # updated_at has only second resolution, so sorting can invert ties.
           gate_state=$(
             gh api --paginate --slurp \
               "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/statuses?per_page=100" |
-              jq -r 'flatten | map(select(.context == "gate")) | sort_by(.updated_at) | last | .state // "missing"'
+              jq -r 'flatten | map(select(.context == "gate")) | first | .state // "missing"'
           )
           echo "gate_state=$gate_state"
           if [ "$gate_state" != "success" ]; then

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -216,8 +216,9 @@ describe('CI workflow coverage', () => {
     assert.match(deployGateJob, /commits\/\$s\/statuses\?per_page=100/);
     assert.match(
       deployGateJob,
-      /flatten \| map\(select\(\.context == "gate"\)\) \| sort_by\(\.updated_at\) \| last/,
+      /flatten \| map\(select\(\.context == "gate"\)\) \| first/,
     );
+    assert.doesNotMatch(deployGateJob, /sort_by\(\.updated_at\)/);
     assert.doesNotMatch(
       deployGateJob,
       /commits\/\$s\/status"/,

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -48,20 +48,21 @@ function runScheduledGate(gateState) {
     : [
         {
           context: 'gate',
-          state: 'success',
-          updated_at: '2026-07-29T12:00:00Z',
+          state: gateState,
+          updated_at: '2026-07-29T12:01:00Z',
         },
         {
           context: 'gate',
-          state: gateState,
+          state: gateState === 'success' ? 'failure' : 'success',
           updated_at: '2026-07-29T12:01:00Z',
         },
       ];
 
   try {
-    // Put the latest `gate` status on a second API page. Replacing gh at PATH
-    // level executes the exact checked-in shell block and proves it cannot
-    // regress to GitHub's truncated default status response.
+    // Put the latest `gate` status on a second API page followed by an older
+    // status with the same second-resolution timestamp. GitHub returns status
+    // history newest-first, so this proves the workflow neither truncates the
+    // response nor reorders equal timestamps into stale state.
     mkdirSync(fakeBin);
     writeFileSync(
       fakeGh,
@@ -160,6 +161,8 @@ describe('seed freshness workflow control plane', () => {
     assert.doesNotMatch(gate.run, /should_run|Skipping seed freshness/);
     assert.match(gate.run, /gh api --paginate --slurp/);
     assert.match(gate.run, /statuses\?per_page=100/);
+    assert.match(gate.run, /map\(select\(\.context == "gate"\)\) \| first/);
+    assert.doesNotMatch(gate.run, /sort_by\(\.updated_at\)/);
     const acceptance = stepNamed('Check ingestion operational acceptance');
     assert.equal(
       acceptance.if,


### PR DESCRIPTION
## Summary
- preserve GitHub commit-status API order when choosing the latest gate state
- avoid timestamp sorting because status timestamps have only second resolution
- add an equal-timestamp behavioral regression that fails under the merged selector

## Context
Follow-up to #5826 and its Greptile equal-timestamp review finding. GitHub documents this endpoint as reverse chronological, with the first status being the latest.

## Evidence
- mutation proof: API-order selection returns current success while timestamp-sort selection returns stale failure
- 66 focused workflow and Railway contract tests passed
- both workflow files parse as valid YAML
- pre-push typecheck and changed-test gates passed