### PR TITLE
fix(gdelt): reduce rate-limited ingestion fanout

### DIFF
--- a/scripts/_gdelt-fetch.mjs
+++ b/scripts/_gdelt-fetch.mjs
@@ -96,7 +96,7 @@ export const _PROXY_DEFAULTS = Object.freeze({
 export async function fetchGdeltJson(url, opts = {}) {
   const {
     label = 'unknown',
-    timeoutMs = 15_000,
+    timeoutMs = 30_000,
     maxRetries = 0,
     proxyMaxAttempts = 1,
     _fetch = globalThis.fetch,
@@ -135,6 +135,7 @@ export async function fetchGdeltJson(url, opts = {}) {
           url,
           proxyAuth,
           { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+          { timeoutMs },
         ),
       );
       const parsed = JSON.parse(text);

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1055,8 +1055,14 @@ export function redactProxyCredentials(text) {
 //
 // `exec` is an injection seam for tests ONLY — the credential scrubbing below lives in a
 // catch around execFileSync, and there is no other way to drive that branch deterministically.
-export function curlFetch(url, proxyAuth, headers = {}, { exec = execFileSync } = {}) {
-  const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
+export function curlFetch(
+  url,
+  proxyAuth,
+  headers = {},
+  { exec = execFileSync, timeoutMs = 15_000 } = {},
+) {
+  const curlTimeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+  const args = ['-sS', '--compressed', '--max-time', String(curlTimeoutSeconds), '-L'];
   if (proxyAuth) {
     const proxyUrl = /^https?:\/\//i.test(proxyAuth) ? proxyAuth : `http://${proxyAuth}`;
     args.push('-x', proxyUrl);
@@ -1066,7 +1072,11 @@ export function curlFetch(url, proxyAuth, headers = {}, { exec = execFileSync } 
   args.push(url);
   let raw;
   try {
-    raw = exec('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
+    raw = exec('curl', args, {
+      encoding: 'utf8',
+      timeout: timeoutMs + 5_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
   } catch (err) {
     // SECURITY: when curl itself exits non-zero (SSL_ERROR_SYSCALL, "CONNECT tunnel
     // failed", DNS), execFileSync builds an Error whose message is the ENTIRE argv —

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -159,8 +159,14 @@ const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_
 // below (re-verified #5554 review after growing HAPI_COUNTRIES to 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
 // The shared GDELT transport enforces one selected-route attempt. These explicit
-// values pin that contract at this high-fanout caller.
-export const GDELT_COUNTRY_FETCH_OPTS = Object.freeze({ maxRetries: 0, proxyMaxAttempts: 1 });
+// values pin that contract at this high-fanout caller. timeoutMs is pinned too:
+// _gdelt-fetch.mjs's default rose from 15s to 30s for seed-gdelt-intel's slow
+// residential-proxy route (issue #5830), but this sweep's own budget was never
+// re-tuned for that — GDELT_SWEEP_BUDGET_MS (120s) launches batches of 4 and
+// needs 16/20 countries to clear GDELT_MIN_SUCCESSFUL_COUNTRIES. Inheriting the
+// 30s default would let a single degraded batch eat a quarter of the whole
+// sweep budget, so this call site keeps the prior 15s ceiling explicitly.
+export const GDELT_COUNTRY_FETCH_OPTS = Object.freeze({ maxRetries: 0, proxyMaxAttempts: 1, timeoutMs: 15_000 });
 // Lock must outlive the worst legitimate run (runSeed's documented invariant —
 // _seed-utils.mjs: "a healthy seeder is designed never to outlive its own lock");
 // it also sets the fetch deadline (lockTtlMs + 120s margin = 540s). The default

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -36,7 +36,7 @@ const GDELT_REQUEST_DELAY_MS = 5_500;
 // hours preserves a wide scheduling margin without blocking the next 4h cron
 // tick if a process dies before its owner-token release runs.
 export const GDELT_LOCK_TTL_MS = 2 * 60 * 60_000;
-const RUN_SEED_FETCH_PHASE_TIMEOUT_MS = 270_000;
+const RUN_SEED_FETCH_PHASE_TIMEOUT_MS = 690_000;
 const TIMELINE_ERROR_REASON = 'timeline_keys_missing_or_unconfirmed';
 const GDELT_UPSTREAM_ERROR_REASON = 'gdelt_upstream_unavailable';
 const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
@@ -45,8 +45,14 @@ const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
 // an injected/hung implementation, but a budget timeout opens the run circuit:
 // the abandoned promise is allowed to settle and no timeline or later-topic
 // request is launched alongside it.
-const FETCH_SOFT_BUDGET_MS = 180_000; // 3min — 90s headroom under the 270s hard deadline for merge + publish
-const MIN_REQUEST_BUDGET_MS = 25_000; // don't start a curl that cannot finish before the budget
+// The production residential route completed the real ArticleList query in
+// roughly 22s, with most of that time in the target TLS handshake. A healthy
+// sweep is 18 sequential DOC calls plus 17 pacing gaps, so the former 3-minute
+// budget could never finish even though the route was returning valid data.
+// Ten minutes covers that measured envelope without adding retries; the
+// runSeed deadline keeps 90s for cache merge and fetch-phase cleanup.
+const FETCH_SOFT_BUDGET_MS = 600_000;
+const MIN_REQUEST_BUDGET_MS = 35_000; // 30s curl ceiling plus scheduling headroom
 
 const INTEL_TOPICS = [
   { id: 'military',     query: '(military exercise OR troop deployment OR airstrike OR "naval exercise") sourcelang:eng' },

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -36,7 +36,7 @@ const GDELT_REQUEST_DELAY_MS = 5_500;
 // hours preserves a wide scheduling margin without blocking the next 4h cron
 // tick if a process dies before its owner-token release runs.
 export const GDELT_LOCK_TTL_MS = 2 * 60 * 60_000;
-const RUN_SEED_FETCH_PHASE_TIMEOUT_MS = 690_000;
+const RUN_SEED_FETCH_PHASE_TIMEOUT_MS = 390_000;
 const TIMELINE_ERROR_REASON = 'timeline_keys_missing_or_unconfirmed';
 const GDELT_UPSTREAM_ERROR_REASON = 'gdelt_upstream_unavailable';
 const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
@@ -46,12 +46,13 @@ const GDELT_DOC_API = 'https://api.gdeltproject.org/api/v2/doc/doc';
 // the abandoned promise is allowed to settle and no timeline or later-topic
 // request is launched alongside it.
 // The production residential route completed the real ArticleList query in
-// roughly 22s, with most of that time in the target TLS handshake. A healthy
-// sweep is 18 sequential DOC calls plus 17 pacing gaps, so the former 3-minute
-// budget could never finish even though the route was returning valid data.
-// Ten minutes covers that measured envelope without adding retries; the
-// runSeed deadline keeps 90s for cache merge and fetch-phase cleanup.
-const FETCH_SOFT_BUDGET_MS = 600_000;
+// roughly 22s, with most of that time in the target TLS handshake. Each 4h run
+// now performs six article calls plus one topic's tone/volume pair (8 total);
+// the UTC slot rotation refreshes all six 14-day timeline pairs once per day.
+// At the 30s transport ceiling plus seven pacing gaps that sweep needs at most
+// ~279s. Five minutes bounds it without retries, and the runSeed deadline keeps
+// 90s for cache merge and fetch-phase cleanup.
+const FETCH_SOFT_BUDGET_MS = 300_000;
 const MIN_REQUEST_BUDGET_MS = 35_000; // 30s curl ceiling plus scheduling headroom
 
 const INTEL_TOPICS = [
@@ -212,7 +213,8 @@ export async function fetchAllTopics(deps = {}) {
     _minRequestBudgetMs = MIN_REQUEST_BUDGET_MS,
     _interRequestDelayMs = GDELT_REQUEST_DELAY_MS,
   } = deps;
-  const deadlineAt = _now() + _softBudgetMs;
+  const runStartedAt = _now();
+  const deadlineAt = runStartedAt + _softBudgetMs;
   const remaining = () => deadlineAt - _now();
 
   const topics = [];
@@ -255,6 +257,9 @@ export async function fetchAllTopics(deps = {}) {
       () => console.warn(`    ${INTEL_TOPICS[i].id}: article budget reached — falling back to cached`),
     );
     console.log(`    ${result.articles.length} articles`);
+    for (const series of TIMELINE_SERIES) {
+      result[series.topicField] = [];
+    }
     topics.push(result);
 
     if (result.budgetExceeded || result.failureCode) {
@@ -264,19 +269,36 @@ export async function fetchAllTopics(deps = {}) {
     }
 
     if (result.articles.length > 0) freshTopicCount += 1;
+  }
 
-    // Timeline calls are sequential. A failed route opens the same run circuit
-    // as an article failure, so Tone and Vol cannot simultaneously hammer an
-    // already failing proxy and no later topic is launched.
+  if (!failureCode && freshTopicCount === 0) {
+    failureCode = 'GDELT_EMPTY_ARTICLE_RESULTS';
+  }
+
+  // Timeline queries cover 14 days and are materially more expensive on
+  // GDELT's rate-limited search cluster than the 24h ArticleList queries.
+  // Refresh exactly one topic pair per 4h UTC slot, after all six article
+  // requests have completed. This caps a healthy run at eight DOC requests,
+  // refreshes every pair daily, and ensures a timeline 429 cannot starve later
+  // article topics. Skipped series remain empty so afterPublish extends their
+  // existing TTL without falsely stamping cached points as freshly fetched.
+  if (!failureCode && topics.length === INTEL_TOPICS.length) {
+    const fourHourSlot = Math.floor(runStartedAt / (4 * 60 * 60_000));
+    const slotIndex =
+      ((fourHourSlot % INTEL_TOPICS.length) + INTEL_TOPICS.length)
+      % INTEL_TOPICS.length;
+    const timelineTopic = INTEL_TOPICS[slotIndex];
+    const result = topics.find((topic) => topic.id === timelineTopic.id);
+    console.log(`  Refreshing ${timelineTopic.id} timeline pair...`);
     for (const series of TIMELINE_SERIES) {
       const timelineFallback = { points: [], errorCode: 'GDELT_FETCH_BUDGET_EXCEEDED' };
       const hasBudget = await paceNextRequest();
       const outcome = hasBudget
         ? await withBudget(
-            () => _fetchTimeline(INTEL_TOPICS[i], series.mode),
+            () => _fetchTimeline(timelineTopic, series.mode),
             remaining(),
             timelineFallback,
-            () => console.warn(`    ${INTEL_TOPICS[i].id}: ${series.id} timeline budget reached`),
+            () => console.warn(`    ${timelineTopic.id}: ${series.id} timeline budget reached`),
           )
         : timelineFallback;
       const normalized = Array.isArray(outcome)
@@ -285,22 +307,26 @@ export async function fetchAllTopics(deps = {}) {
       result[series.topicField] = Array.isArray(normalized?.points) ? normalized.points : [];
       if (normalized?.errorCode) {
         failureCode = normalized.errorCode;
-        console.warn(`    ${INTEL_TOPICS[i].id}: opening run circuit (${failureCode}); remaining DOC requests will use cached data`);
+        console.warn(`    ${timelineTopic.id}: opening run circuit (${failureCode}); remaining DOC requests will use cached data`);
         break;
       }
     }
-    for (const series of TIMELINE_SERIES) {
-      if (!Array.isArray(result[series.topicField])) result[series.topicField] = [];
-    }
     console.log(`    timeline: ${result._tone.length} tone pts, ${result._vol.length} vol pts`);
-    if (failureCode) break;
   }
 
   // Represent every topic so the cache-merge can backfill both the ones we
   // skipped (soft budget) and the ones that came back empty (429).
   const fetchedIds = new Set(topics.map((t) => t.id));
   for (const t of INTEL_TOPICS) {
-    if (!fetchedIds.has(t.id)) topics.push({ id: t.id, articles: [], fetchedAt: new Date().toISOString() });
+    if (!fetchedIds.has(t.id)) {
+      topics.push({
+        id: t.id,
+        articles: [],
+        fetchedAt: new Date().toISOString(),
+        _tone: [],
+        _vol: [],
+      });
+    }
   }
 
   // For topics that returned 0 articles (rate-limited or budget-skipped), preserve
@@ -326,10 +352,6 @@ export async function fetchAllTopics(deps = {}) {
   // Restore canonical topic order (backfilled entries were appended out of order).
   const order = new Map(INTEL_TOPICS.map((t, idx) => [t.id, idx]));
   topics.sort((a, b) => (order.get(a.id) ?? INTEL_TOPICS.length) - (order.get(b.id) ?? INTEL_TOPICS.length));
-  if (!failureCode && freshTopicCount === 0) {
-    failureCode = 'GDELT_EMPTY_ARTICLE_RESULTS';
-  }
-
   return {
     topics,
     fetchedAt: new Date().toISOString(),

--- a/tests/gdelt-fetch.test.mjs
+++ b/tests/gdelt-fetch.test.mjs
@@ -69,6 +69,57 @@ test('GDELT_PROXY_URL wins over PROXY_URL and skips the known-blocked direct rou
   assert.doesNotMatch(proxyAuths[0], /shared-proxy/);
 });
 
+test('the GDELT proxy path gives curl 30 seconds for slow residential TLS handshakes', async () => {
+  setProxyEnv({ GDELT_PROXY_URL: 'http://user:pass@gdelt-proxy.test:8100' });
+  let transportOptions;
+
+  await fetchGdeltJson(URL, {
+    label: 'military',
+    _proxyCurlFetcher: (_url, _proxyAuth, _headers, options) => {
+      transportOptions = options;
+      return JSON.stringify(PAYLOAD);
+    },
+  });
+
+  assert.deepEqual(transportOptions, { timeoutMs: 30_000 });
+});
+
+test('curlFetch applies its caller timeout to curl and leaves a bounded process grace period', () => {
+  let invocation;
+  const result = curlFetch(
+    URL,
+    'user:pass@gdelt-proxy.test:8100',
+    { Accept: 'application/json' },
+    {
+      timeoutMs: 30_000,
+      exec: (command, args, options) => {
+        invocation = { command, args, options };
+        return `${JSON.stringify(PAYLOAD)}\n200`;
+      },
+    },
+  );
+
+  const maxTimeIndex = invocation.args.indexOf('--max-time');
+  assert.equal(invocation.command, 'curl');
+  assert.equal(invocation.args[maxTimeIndex + 1], '30');
+  assert.equal(invocation.options.timeout, 35_000);
+  assert.deepEqual(JSON.parse(result), PAYLOAD);
+});
+
+test('curlFetch keeps the 15-second ceiling for callers that do not override it', () => {
+  let invocation;
+  curlFetch(URL, null, {}, {
+    exec: (_command, args, options) => {
+      invocation = { args, options };
+      return `${JSON.stringify(PAYLOAD)}\n200`;
+    },
+  });
+
+  const maxTimeIndex = invocation.args.indexOf('--max-time');
+  assert.equal(invocation.args[maxTimeIndex + 1], '15');
+  assert.equal(invocation.options.timeout, 20_000);
+});
+
 test('PROXY_URL remains the compatibility route when GDELT_PROXY_URL is absent', async () => {
   setProxyEnv({ PROXY_URL: 'http://user:pass@shared-proxy.test:8200' });
   const proxyAuths = [];

--- a/tests/seed-fetch-deadline-budget-invariants.test.mjs
+++ b/tests/seed-fetch-deadline-budget-invariants.test.mjs
@@ -42,8 +42,8 @@ describe('seed fetch-phase deadline & TTL invariants (issue #4864)', () => {
     assert.ok(minRequest && minRequest > 0 && minRequest < soft, 'MIN_REQUEST_BUDGET_MS must be a positive fraction of the soft budget');
     assert.ok(requestDelay && requestDelay >= 5_000, 'healthy DOC requests must remain evenly paced');
     assert.ok(
-      (17 * requestDelay) + minRequest < soft,
-      '18 paced DOC calls must leave response-time budget before the final request starts',
+      (7 * requestDelay) + minRequest < soft,
+      '8 paced DOC calls must leave response-time budget before the final request starts',
     );
   });
 

--- a/tests/seed-gdelt-intel-fetch-budget.test.mjs
+++ b/tests/seed-gdelt-intel-fetch-budget.test.mjs
@@ -18,7 +18,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-import { fetchAllTopics } from '../scripts/seed-gdelt-intel.mjs';
+import { fetchAllTopics, RUN_SEED_OPTS } from '../scripts/seed-gdelt-intel.mjs';
 
 const TOPIC_IDS = ['military', 'cyber', 'nuclear', 'sanctions', 'intelligence', 'maritime'];
 const cachedSnapshot = () => ({
@@ -95,6 +95,39 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
       assert.equal(t.articles[0].title, `fresh ${t.id}`);
       assert.ok(Array.isArray(t._tone) && Array.isArray(t._vol), 'timelines attached');
     }
+  });
+
+  it('default budgets complete all 18 DOC calls at the measured residential-proxy latency', async () => {
+    let now = 0;
+    let articleCalls = 0;
+    let timelineCalls = 0;
+    const measuredRequestMs = 22_000;
+
+    const out = await fetchAllTopics({
+      _now: () => now,
+      _sleep: async (ms) => { now += ms; },
+      _fetchArticles: async (topic) => {
+        articleCalls += 1;
+        now += measuredRequestMs;
+        return {
+          id: topic.id,
+          articles: [{ title: `fresh ${topic.id}`, url: `https://example.test/live/${topic.id}` }],
+          fetchedAt: 'NOW',
+        };
+      },
+      _fetchTimeline: async () => {
+        timelineCalls += 1;
+        now += measuredRequestMs;
+        return { points: [{ date: '2026-07-29', value: 1 }], errorCode: null };
+      },
+      _loadPrevious: async () => { throw new Error('a complete sweep must not read cache'); },
+    });
+
+    assert.equal(articleCalls, 6);
+    assert.equal(timelineCalls, 12);
+    assert.equal(out._gdeltFailureCode, null);
+    assert.equal(out._freshTopicCount, 6);
+    assert.equal(RUN_SEED_OPTS.fetchPhaseTimeoutMs, 690_000);
   });
 
   it('paces every healthy DOC request instead of bursting article/tone/volume', async () => {

--- a/tests/seed-gdelt-intel-fetch-budget.test.mjs
+++ b/tests/seed-gdelt-intel-fetch-budget.test.mjs
@@ -78,8 +78,9 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
     }
   });
 
-  it('happy path: topics that succeed in time publish FRESH articles (transparent, no cache read)', async () => {
+  it('happy path: all topics publish fresh articles while one timeline pair refreshes', async () => {
     const out = await fetchAllTopics({
+      _now: () => 0,
       _softBudgetMs: 60_000,
       _sleep: async () => {},
       _fetchArticles: async (topic) => ({
@@ -91,13 +92,15 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
       _loadPrevious: async () => { throw new Error('cache must not be consulted on the happy path'); },
     });
     assert.deepEqual(out.topics.map((t) => t.id), TOPIC_IDS);
-    for (const t of out.topics) {
+    for (const [index, t] of out.topics.entries()) {
       assert.equal(t.articles[0].title, `fresh ${t.id}`);
       assert.ok(Array.isArray(t._tone) && Array.isArray(t._vol), 'timelines attached');
+      assert.equal(t._tone.length, index === 0 ? 1 : 0);
+      assert.equal(t._vol.length, index === 0 ? 1 : 0);
     }
   });
 
-  it('default budgets complete all 18 DOC calls at the measured residential-proxy latency', async () => {
+  it('default budgets complete the bounded eight-call sweep at measured residential-proxy latency', async () => {
     let now = 0;
     let articleCalls = 0;
     let timelineCalls = 0;
@@ -124,13 +127,13 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
     });
 
     assert.equal(articleCalls, 6);
-    assert.equal(timelineCalls, 12);
+    assert.equal(timelineCalls, 2);
     assert.equal(out._gdeltFailureCode, null);
     assert.equal(out._freshTopicCount, 6);
-    assert.equal(RUN_SEED_OPTS.fetchPhaseTimeoutMs, 690_000);
+    assert.equal(RUN_SEED_OPTS.fetchPhaseTimeoutMs, 390_000);
   });
 
-  it('paces every healthy DOC request instead of bursting article/tone/volume', async () => {
+  it('paces all eight healthy DOC requests instead of bursting article/tone/volume', async () => {
     const sleeps = [];
     await fetchAllTopics({
       _softBudgetMs: 60_000,
@@ -145,7 +148,7 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
       _loadPrevious: async () => { throw new Error('cache must not be consulted'); },
     });
 
-    assert.equal(sleeps.length, 17, '18 DOC calls have exactly 17 inter-request gaps');
+    assert.equal(sleeps.length, 7, '8 DOC calls have exactly 7 inter-request gaps');
     assert.equal(sleeps.every((ms) => ms === 5_500), true);
   });
 
@@ -153,6 +156,7 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
     const articleCalls = [];
     const timelineCalls = [];
     const out = await fetchAllTopics({
+      _now: () => 0,
       _softBudgetMs: 60_000,
       _sleep: async () => {},
       _fetchArticles: async (topic) => {
@@ -179,10 +183,11 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
     }
   });
 
-  it('first timeline transport failure is sequential and stops the remaining DOC fanout', async () => {
+  it('fetches all articles before a timeline failure opens the remaining DOC circuit', async () => {
     const articleCalls = [];
     const timelineCalls = [];
     const out = await fetchAllTopics({
+      _now: () => 0,
       _softBudgetMs: 60_000,
       _sleep: async () => {},
       _fetchArticles: async (topic) => {
@@ -199,12 +204,37 @@ describe('seed-gdelt-intel fetchAllTopics soft budget (issue #4864)', () => {
       },
       _loadPrevious: async () => cachedSnapshot(),
     });
-    assert.deepEqual(articleCalls, ['military']);
+    assert.deepEqual(articleCalls, TOPIC_IDS);
     assert.deepEqual(timelineCalls, ['military/TimelineTone']);
     assert.equal(out._gdeltFailureCode, 'GDELT_SHARED_PROXY_TLS');
-    assert.equal(out._freshTopicCount, 1);
+    assert.equal(out._freshTopicCount, 6);
     assert.equal(out.topics[0].articles[0].title, 'fresh military');
-    assert.equal(out.topics[1].articles[0].title, 'cached cyber');
+    assert.equal(out.topics[1].articles[0].title, 'fresh cyber');
+  });
+
+  it('rotates the one refreshed timeline pair across UTC four-hour slots', async () => {
+    const timelineCalls = [];
+    const slotMs = 4 * 60 * 60_000;
+    await fetchAllTopics({
+      _now: () => 4 * slotMs,
+      _softBudgetMs: 60_000,
+      _sleep: async () => {},
+      _fetchArticles: async (topic) => ({
+        id: topic.id,
+        articles: [{ title: `fresh ${topic.id}`, url: `https://x/${topic.id}` }],
+        fetchedAt: 'NOW',
+      }),
+      _fetchTimeline: async (topic, mode) => {
+        timelineCalls.push(`${topic.id}/${mode}`);
+        return { points: [{ date: '2026-07-29', value: 1 }], errorCode: null };
+      },
+      _loadPrevious: async () => { throw new Error('cache must not be consulted'); },
+    });
+
+    assert.deepEqual(timelineCalls, [
+      'intelligence/TimelineTone',
+      'intelligence/TimelineVol',
+    ]);
   });
 
   it('does not launch a timeline after the article consumes the remaining budget', async () => {


### PR DESCRIPTION
## Summary

GDELT's production ingestion now accounts for both slow residential TLS handshakes and the upstream search cluster's rate limits.

- Give the source-specific GDELT proxy route 30 seconds per request while preserving the shared 15-second default for unrelated curl callers.
- Reduce the normal four-hour sweep from 18 DOC searches to 8: fetch all six 24-hour ArticleList topics first, then refresh one topic's 14-day tone/volume pair.
- Rotate that timeline pair by UTC four-hour slot so all six pairs refresh once per day.
- Keep requests sequential and spaced by 5.5 seconds. No retries were added, and the first route error still opens the run circuit.
- Preserve honest degradation: skipped timelines extend last-good TTL without restamping their stored `fetchedAt`; absent keys remain reported as missing until naturally rebuilt.

This ordering prevents a timeline 429 from starving later article topics. The five-minute soft budget covers eight requests at the measured 22-second residential-proxy latency, with a separate 90-second hard-deadline margin for cache merge and cleanup.

## Validation

- 75 focused GDELT transport, budget, timeline-resilience, deadline, and credential-redaction tests passed.
- `npm run typecheck:api` passed.
- The full pre-push gate passed, including frontend/API typechecks and changed tests.
- Railway production has a non-empty source-specific `GDELT_PROXY_URL`; deployment `af691055-9761-46e3-8644-ba8ec9682afc` succeeded.
- Candidate-route evidence: control HTTP 200 in 1.26s; exact GDELT ArticleList HTTP 200 in 21.91s. Two subsequent timeline probes returned HTTP 429, motivating the reduced fanout rather than more retries.
- Read-only production Redis inspection found all 12 timeline keys currently absent. The rotating cadence rebuilds one pair per successful four-hour run, so full timeline recovery requires up to six successful runs after deployment.

## Operational acceptance

- Keep the `gdeltIntel:SEED_ERROR` baseline until the code is deployed and natural cron runs have rebuilt all 12 timeline keys.
- Then require two successful natural four-hour runs with non-problem compact health before removing the baseline.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
