### PR TITLE
test(mcp): reject hidden intel-history fetches

### DIFF
--- a/tests/mcp-intel-history-post-body.test.mts
+++ b/tests/mcp-intel-history-post-body.test.mts
@@ -62,9 +62,9 @@ function rpcTool(name: string) {
 describe('MCP intel-history request privacy contract (#5741)', () => {
   it('POSTs analyst text in the signed JSON body and never in the request URL', async () => {
     for (const testCase of cases) {
-      let captured: { url: string; init: RequestInit } | undefined;
+      const requests: Array<{ url: string; init: RequestInit }> = [];
       globalThis.fetch = (async (input: string | URL | Request, init: RequestInit = {}) => {
-        captured = { url: String(input), init };
+        requests.push({ url: String(input), init });
         return new Response(JSON.stringify({
           records: [],
           [testCase.textField]: testCase.sensitiveText,
@@ -83,6 +83,12 @@ describe('MCP intel-history request privacy contract (#5741)', () => {
         {},
       );
 
+      assert.equal(
+        requests.length,
+        1,
+        `${testCase.toolName} must make exactly one outbound request`,
+      );
+      const [captured] = requests;
       assert.ok(captured, `${testCase.toolName} must make an outbound request`);
       const url = new URL(captured.url);
       assert.equal(url.pathname, testCase.path);


### PR DESCRIPTION
## Summary

The intel-history privacy regression now fails if either MCP executor makes an additional outbound request before its signed POST. This closes the false-negative where a leaking request could be overwritten by the later capture and leave CI green.

Related: #5821

## Validation

- Earlier-fetch mutation: preloading a GET containing the analyst text now fails with `2 !== 1` on the request-count assertion.
- `TMPDIR=/private/tmp node --import tsx --test tests/intel-history-endpoints.test.mts tests/mcp-intel-history-post-body.test.mts` — 51 passed.
- `./node_modules/.bin/biome check tests/mcp-intel-history-post-body.test.mts` — passed.
- Repository pre-push gate — passed, including TypeScript, the changed regression test, Unicode safety, and version synchronization.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
