### PR TITLE
fix(china): diversify SZSE proxy exits

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -4,6 +4,11 @@ const net = require('node:net');
 const tls = require('node:tls');
 const https = require('node:https');
 const zlib = require('node:zlib');
+
+const DECODO_GATE_HOST = 'gate.decodo.com';
+const DECODO_STICKY_PORT_MIN = 10_001;
+const DECODO_STICKY_PORT_MAX = 49_999;
+
 function parseProxyConfig(raw) {
   if (!raw) return null;
 
@@ -45,6 +50,32 @@ function parseProxyConfig(raw) {
   }
 
   return null;
+}
+
+/**
+ * Parse a proxy configuration and, for Decodo sticky gateway ports, advance
+ * each retry to a distinct sticky session. Other providers and Decodo rotating
+ * ports retain their configured route exactly.
+ */
+function parseProxyConfigForAttempt(raw, attempt = 0) {
+  const config = parseProxyConfig(raw);
+  if (!config) return null;
+  const port = Number(config.port);
+  if (
+    config.host !== DECODO_GATE_HOST
+    || !Number.isInteger(port)
+    || port < DECODO_STICKY_PORT_MIN
+    || port > DECODO_STICKY_PORT_MAX
+  ) {
+    return config;
+  }
+
+  const stickyPortCount = DECODO_STICKY_PORT_MAX - DECODO_STICKY_PORT_MIN + 1;
+  return {
+    ...config,
+    port: DECODO_STICKY_PORT_MIN
+      + ((port - DECODO_STICKY_PORT_MIN + attempt) % stickyPortCount),
+  };
 }
 
 /**
@@ -267,6 +298,7 @@ function proxyFetch(url, proxyConfig, {
 
 module.exports = {
   parseProxyConfig,
+  parseProxyConfigForAttempt,
   resolveProxyConfig,
   resolveProxyConfigWithFallback,
   resolveProxyString,

--- a/scripts/china-corporate-disclosures/adapters.mjs
+++ b/scripts/china-corporate-disclosures/adapters.mjs
@@ -6,7 +6,7 @@ import {
 } from '../shared/china-corporate-disclosure-policy.js';
 
 const {
-  parseProxyConfig,
+  parseProxyConfigForAttempt,
   proxyFetch,
 } = createRequire(import.meta.url)('../_proxy-utils.cjs');
 
@@ -516,10 +516,11 @@ function shouldRetrySzseProxyFailure(error) {
 
 async function fetchViaConfiguredProxy(input, init, {
   proxyUrl,
+  attempt,
   maxBytes,
   proxyRequestFn,
 }) {
-  const proxyConfig = parseProxyConfig(proxyUrl);
+  const proxyConfig = parseProxyConfigForAttempt(proxyUrl, attempt);
   if (!proxyConfig) throw sourceError('PROXY_NOT_CONFIGURED');
   // init.headers carries the same Referer/User-Agent/Content-Type the direct
   // request used (requestInit() below), deliberately: we're routing the exact
@@ -556,21 +557,60 @@ export function resolveChinaExchangeEdgeEgress(env = process.env) {
   return { url: CHINA_EXCHANGE_EDGE_EGRESS_URL, secret };
 }
 
-async function readEdgeEgressFailureCode(response, maxBytes) {
+function normalizedResponseContentType(response) {
+  return String(response?.headers?.get?.('content-type') || '')
+    .split(';', 1)[0]
+    .trim()
+    .toLowerCase();
+}
+
+function edgeFailureDiagnostic(response, rawContentType = normalizedResponseContentType(response)) {
+  const cfRay = String(response?.headers?.get?.('cf-ray') || '');
+  const vercelId = String(response?.headers?.get?.('x-vercel-id') || '');
+  const rawServer = String(response?.headers?.get?.('server') || '').toLowerCase();
+  const server = rawServer === 'cloudflare' || rawServer === 'vercel'
+    ? rawServer
+    : null;
+  const safeCfRay = /^[a-f0-9]{8,32}-[A-Z]{3}$/u.test(cfRay) ? cfRay : null;
+  const safeVercelId = /^[A-Za-z0-9:_-]{1,96}$/u.test(vercelId) ? vercelId : null;
+  if (!server && !safeCfRay && !safeVercelId) return null;
+
+  const contentType = ['application/json', 'text/html', 'text/plain'].includes(rawContentType)
+    ? rawContentType
+    : rawContentType
+      ? 'other'
+      : 'missing';
+  return {
+    contentType,
+    ...(server ? { server } : {}),
+    ...(safeCfRay ? { cfRay: safeCfRay } : {}),
+    ...(safeVercelId ? { vercelId: safeVercelId } : {}),
+  };
+}
+
+async function readEdgeEgressFailure(response, maxBytes) {
   const fallback = `HTTP_${Number(response?.status) || 0}`;
+  const contentType = normalizedResponseContentType(response);
+  const diagnostic = edgeFailureDiagnostic(response, contentType);
+  if (contentType !== 'application/json') {
+    try {
+      await response?.body?.cancel?.();
+    } catch {
+      // A diagnostic must never fail because an intermediary body could not be cancelled.
+    }
+    return { code: fallback, diagnostic };
+  }
   try {
     const bytes = await readBoundedResponseBytes(response, maxBytes);
-    const contentType = String(response?.headers?.get?.('content-type') || '')
-      .split(';', 1)[0]
-      .trim()
-      .toLowerCase();
-    if (contentType !== 'application/json') return fallback;
     const payload = JSON.parse(new TextDecoder().decode(bytes));
-    return CHINA_EXCHANGE_EDGE_ERROR_CODES.has(payload?.error)
-      ? payload.error
-      : fallback;
+    return {
+      code: CHINA_EXCHANGE_EDGE_ERROR_CODES.has(payload?.error)
+        ? payload.error
+        : fallback,
+      diagnostic,
+    };
   } catch {
-    return fallback;
+    return { code: fallback, diagnostic };
   }
 }
 
@@ -591,7 +631,10 @@ async function fetchViaEdgeEgress(_input, init, {
     signal: init?.signal,
   });
   if (!response.ok) {
-    throw sourceError(await readEdgeEgressFailureCode(response, maxBytes));
+    const failure = await readEdgeEgressFailure(response, maxBytes);
+    const error = sourceError(failure.code);
+    if (failure.diagnostic) error.edgeFailureDiagnostic = failure.diagnostic;
+    throw error;
   }
   const bytes = await readBoundedResponseBytes(response, maxBytes);
   return new Response(bytes, {
@@ -731,7 +774,10 @@ async function fetchSzseAnnouncements(fetchFn, now, {
       for (let attempt = 0; attempt < contract.maxProxyRequestsPerRun; attempt += 1) {
         requestCount += 1;
         try {
-          fetched = await request(proxyFetchFn, SZSE_PROXY_TIMEOUT_MS);
+          fetched = await request(
+            (input, init) => proxyFetchFn(input, init, attempt),
+            SZSE_PROXY_TIMEOUT_MS,
+          );
           proxyError = null;
           break;
         } catch (error) {
@@ -761,6 +807,9 @@ async function fetchSzseAnnouncements(fetchFn, now, {
         failure.fallbackReason = fallbackReason;
         if (proxyFailureReason) failure.proxyFailureReason = proxyFailureReason;
         failure.edgeFailureReason = transportFailureReason(edgeError);
+        if (edgeError?.edgeFailureDiagnostic) {
+          failure.edgeFailureDiagnostic = edgeError.edgeFailureDiagnostic;
+        }
         throw failure;
       }
     }
@@ -1450,8 +1499,9 @@ export async function fetchChinaCorporateDisclosureSnapshot({
   onDecision = (entry) => console.log(JSON.stringify({ event: 'china_corporate_disclosure_source', ...entry })),
 } = {}) {
   const resolvedProxyFetchFn = proxyUrl
-    ? (input, init) => fetchViaConfiguredProxy(input, init, {
+    ? (input, init, attempt = 0) => fetchViaConfiguredProxy(input, init, {
         proxyUrl,
+        attempt,
         maxBytes: OFFICIAL_EXCHANGE_SOURCE_CONTRACTS.szse.maxResponseBytes,
         proxyRequestFn,
       })
@@ -1492,6 +1542,9 @@ export async function fetchChinaCorporateDisclosureSnapshot({
         ...(error?.edgeFailureReason
           ? { edgeFailureReason: error.edgeFailureReason }
           : {}),
+        ...(error?.edgeFailureDiagnostic
+          ? { edgeFailureDiagnostic: error.edgeFailureDiagnostic }
+          : {}),
       };
       outcomes.push(outcome);
     }
@@ -1502,7 +1555,9 @@ export async function fetchChinaCorporateDisclosureSnapshot({
     previousTransportFailures,
     generatedAt: new Date(now).toISOString(),
   });
+  const outcomeMap = new Map(outcomes.map((outcome) => [outcome.sourceId, outcome]));
   for (const source of snapshot.sources) {
+    const outcome = outcomeMap.get(source.id);
     const transportRecoverySuccessRuns = source.launchStatus === 'launched'
       ? OFFICIAL_EXCHANGE_SOURCE_CONTRACTS[source.id].transportRecoverySuccessRuns ?? 1
       : null;
@@ -1534,6 +1589,9 @@ export async function fetchChinaCorporateDisclosureSnapshot({
         : {}),
       ...(source.edgeFailureReason
         ? { edgeFailureReason: source.edgeFailureReason }
+        : {}),
+      ...(outcome?.edgeFailureDiagnostic
+        ? { edgeFailureDiagnostic: outcome.edgeFailureDiagnostic }
         : {}),
       ...(source.launchStatus === 'launched'
         ? {

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -1214,6 +1214,46 @@ describe('official China corporate disclosures (#5577)', () => {
     }
   });
 
+  it('uses a distinct Decodo sticky gateway port for each proxy attempt', async () => {
+    const proxyPorts: number[] = [];
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: 'gate.decodo.com:10001:proxy-user:proxy-secret',
+      onDecision: () => {},
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+        });
+      },
+      proxyRequestFn: async (_input, proxyConfig) => {
+        proxyPorts.push(proxyConfig.port);
+        if (proxyPorts.length === 1) {
+          throw Object.assign(new Error('Proxy upstream timeout'), { status: 522 });
+        }
+        return {
+          buffer: Buffer.from(JSON.stringify(fixture('szse.json'))),
+          status: 200,
+          contentType: 'application/json',
+        };
+      },
+    });
+
+    assert.deepEqual(proxyPorts, [10001, 10002]);
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal(szse?.transportStatus, 'fresh');
+    assert.equal(szse?.requestCount, 3);
+    assert.equal(szse?.transportPath, 'proxy');
+    assert.doesNotMatch(JSON.stringify(snapshot), /proxy-user|proxy-secret/);
+  });
+
   it('uses the authenticated edge egress after direct and proxy transports are exhausted', async () => {
     let proxyCalls = 0;
     const edgeCalls: Array<{ url: string; init?: RequestInit }> = [];
@@ -1395,6 +1435,58 @@ describe('official China corporate disclosures (#5577)', () => {
         testCase.name,
       );
     }
+  });
+
+  it('logs bounded edge routing identifiers without persisting the response body', async () => {
+    const decisions: Array<Record<string, unknown>> = [];
+    const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      proxyUrl: '',
+      edgeEgress: {
+        url: 'https://api.example.test/api/internal/china-exchange-egress',
+        secret: 'edge-relay-secret',
+      },
+      onDecision: (decision) => decisions.push(decision),
+      fetchFn: async (input) => {
+        const url = String(input);
+        if (url.includes('query.sse.com.cn')) {
+          return new Response(JSON.stringify({
+            pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+            result: [],
+          }), { status: 200 });
+        }
+        throw Object.assign(new TypeError('fetch failed'), {
+          cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+        });
+      },
+      edgeRequestFn: async () => new Response(
+        '<html>intermediary-response-secret</html>',
+        {
+          status: 502,
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'CF-Ray': 'abc123def456-CDG',
+            'Server': 'cloudflare',
+            'X-Vercel-Id': 'iad1::sfo1::request_123',
+          },
+        },
+      ),
+    });
+
+    const szseDecision = decisions.find((decision) => decision.sourceId === 'szse');
+    assert.deepEqual(szseDecision?.edgeFailureDiagnostic, {
+      contentType: 'text/html',
+      server: 'cloudflare',
+      cfRay: 'abc123def456-CDG',
+      vercelId: 'iad1::sfo1::request_123',
+    });
+    const szse = snapshot.sources.find((source) => source.id === 'szse');
+    assert.equal('edgeFailureDiagnostic' in (szse ?? {}), false);
+    assert.doesNotMatch(
+      JSON.stringify({ snapshot, decisions }),
+      /edge-relay-secret|intermediary-response-secret/,
+    );
   });
 
   it('retains last-good SZSE data and all transport reasons after edge failure', async () => {

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 const {
   _readBoundedResponseStream,
   parseProxyConfig,
+  parseProxyConfigForAttempt,
 } = createRequire(import.meta.url)('../scripts/_proxy-utils.cjs');
 
 describe('proxy utilities', () => {
@@ -20,6 +21,39 @@ describe('proxy utilities', () => {
       },
     );
     assert.equal(parseProxyConfig('ftp://proxy.test/resource'), null);
+  });
+
+  it('uses a distinct Decodo sticky port per attempt and preserves other routes', () => {
+    assert.equal(
+      parseProxyConfigForAttempt(
+        'gate.decodo.com:10001:proxy-user:proxy-secret',
+        1,
+      ).port,
+      10002,
+    );
+    assert.equal(
+      parseProxyConfigForAttempt(
+        'gate.decodo.com:49999:proxy-user:proxy-secret',
+        1,
+      ).port,
+      10001,
+    );
+    for (const rotatingPort of [7000, 10000]) {
+      assert.equal(
+        parseProxyConfigForAttempt(
+          `gate.decodo.com:${rotatingPort}:proxy-user:proxy-secret`,
+          1,
+        ).port,
+        rotatingPort,
+      );
+    }
+    assert.equal(
+      parseProxyConfigForAttempt(
+        'https://proxy-user:proxy-secret@proxy.test:443',
+        1,
+      ).port,
+      443,
+    );
   });
 
   it('rejects a response stream as soon as it exceeds the byte limit', async () => {


### PR DESCRIPTION
## Summary

SZSE ingestion no longer repeats the same Decodo sticky session when a direct request fails: bounded proxy retries advance across sticky gateway ports, while Decodo rotating ports and other proxy providers retain their configured routes.

When direct, proxy, and edge transports are exhausted, per-run decision logs now include allowlisted intermediary metadata (normalized content type, known server, and bounded request identifiers) without storing response bodies, credentials, or those diagnostics in the public snapshot. This does not guess a geographic route or mutate Railway configuration.

Related: #5640

## Validation

- A proof-first regression failed with proxy ports `[10001, 10001]` before the fix and passes with `[10001, 10002]`.
- The pre-push hook passed source/API typechecks, syntax and Unicode checks, version sync, and all 29 changed-file tests.
- Focused China disclosure, production-registration, exchange-egress, proxy-fallback, and Railway watch-path suites passed.
- Formal multi-lens review found no actionable issues.
- The repository-wide data runner was attempted, but stalled on four unrelated auth/cache/telemetry workers after surfacing an unrelated Clerk plan-lookup timeout; it was stopped after sustained 0% CPU. No SZSE-scoped gate failed.

## Post-Deploy Monitoring & Validation

- **Surface:** Railway `seed-bundle-market-backup` logs filtered to `event=china_corporate_disclosure_source` and `sourceId=szse`.
- **Inspect:** `status`, `transportPath`, `fallbackReason`, `proxyFailureReason`, `edgeFailureReason`, `edgeFailureDiagnostic`, and `reliabilityStatus`.
- **Healthy:** at least two consecutive accepted SZSE cycles, followed by `reliabilityStatus=stable`; compact health no longer lists `market.china-corporate-disclosures` under degraded China coverage.
- **Failure:** repeated `HTTP_522` across both proxy attempts, an edge `HTTP_502`, or new `HTTP_407` authentication failures. Use bounded `cfRay` / `vercelId` values to distinguish an intermediary failure from a handler response.
- **Window/owner:** WorldMonitor ops should observe 10–20 production cycles, with at least two consecutive successful cycles before operational closeout.
- **Rollback:** revert this PR if sticky-port advancement increases proxy authentication/routing failures or lowers SZSE success rate. Last-good snapshot preservation remains the safety net during rollback.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
