### PR TITLE
fix(correlation): suppress isolated slow-run warnings

### DIFF
--- a/src/services/correlation-engine/engine.test.ts
+++ b/src/services/correlation-engine/engine.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/panel-gating', () => ({
+  hasPremiumAccess: () => false,
+}));
+vi.mock('@/services/premium-fetch', () => ({
+  premiumFetch: vi.fn(),
+}));
+vi.mock('@/services/generated-rpc-clients', () => ({
+  IntelligenceServiceClient: class {},
+}));
+
+import { CorrelationEngine } from './engine';
+import type { DomainAdapter } from './types';
+
+Object.defineProperty(globalThis, 'document', {
+  value: { dispatchEvent() {} },
+  configurable: true,
+});
+
+const emptyAdapter: DomainAdapter = {
+  domain: 'military',
+  label: 'Performance warning test',
+  clusterMode: 'geographic',
+  spatialRadius: 500,
+  timeWindow: 24,
+  threshold: 0,
+  weights: {},
+  collectSignals: () => [],
+  generateTitle: () => 'test',
+};
+
+function createEngine(): CorrelationEngine {
+  const engine = new CorrelationEngine();
+  engine.registerAdapter(emptyAdapter);
+  return engine;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CorrelationEngine performance warning', () => {
+  it('does not warn for an isolated cold-start breach', async () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(158)
+      .mockReturnValueOnce(200)
+      .mockReturnValueOnce(240);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const engine = createEngine();
+
+    await engine.run({} as Parameters<CorrelationEngine['run']>[0]);
+    await engine.run({} as Parameters<CorrelationEngine['run']>[0]);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns once when the target is breached on consecutive runs', async () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(158)
+      .mockReturnValueOnce(200)
+      .mockReturnValueOnce(342)
+      .mockReturnValueOnce(400)
+      .mockReturnValueOnce(580);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const engine = createEngine();
+
+    await engine.run({} as Parameters<CorrelationEngine['run']>[0]);
+    await engine.run({} as Parameters<CorrelationEngine['run']>[0]);
+    await engine.run({} as Parameters<CorrelationEngine['run']>[0]);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      '[CorrelationEngine] run() exceeded 100ms for 2 consecutive runs '
+      + '(latest 142ms, peak 158ms)',
+    );
+  });
+});

--- a/src/services/correlation-engine/engine.ts
+++ b/src/services/correlation-engine/engine.ts
@@ -16,6 +16,8 @@ import { IntelligenceServiceClient } from '@/services/generated-rpc-clients';
 const LLM_SCORE_THRESHOLD = 60;
 const LLM_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const LLM_MAX_CONCURRENT = 3;
+const RUN_TARGET_MS = 100;
+const SLOW_RUNS_BEFORE_WARNING = 2;
 
 interface LlmCacheEntry {
   assessment: string;
@@ -30,6 +32,9 @@ export class CorrelationEngine {
   private intelligenceClient: InstanceType<typeof IntelligenceServiceClient>;
   private running = false;
   private llmInFlight = 0;
+  private consecutiveSlowRuns = 0;
+  private peakSlowRunMs = 0;
+  private warnedForCurrentSlowStreak = false;
 
   constructor() {
     // Use '' base URL — requests go to current origin, same as other panels.
@@ -75,9 +80,7 @@ export class CorrelationEngine {
       }
 
       const elapsed = performance.now() - t0;
-      if (elapsed > 100) {
-        console.warn(`[CorrelationEngine] run() took ${elapsed.toFixed(0)}ms (>100ms target)`);
-      }
+      this.recordRunDuration(elapsed);
 
       document.dispatchEvent(new CustomEvent('wm:correlation-updated', {
         detail: { domains: this.adapters.map(a => a.domain) },
@@ -93,6 +96,31 @@ export class CorrelationEngine {
 
   getAllCards(): ConvergenceCard[] {
     return Array.from(this.cards.values()).flat();
+  }
+
+  private recordRunDuration(elapsedMs: number): void {
+    if (!Number.isFinite(elapsedMs) || elapsedMs <= RUN_TARGET_MS) {
+      this.consecutiveSlowRuns = 0;
+      this.peakSlowRunMs = 0;
+      this.warnedForCurrentSlowStreak = false;
+      return;
+    }
+
+    this.consecutiveSlowRuns++;
+    this.peakSlowRunMs = Math.max(this.peakSlowRunMs, elapsedMs);
+    if (
+      this.consecutiveSlowRuns < SLOW_RUNS_BEFORE_WARNING
+      || this.warnedForCurrentSlowStreak
+    ) {
+      return;
+    }
+
+    this.warnedForCurrentSlowStreak = true;
+    console.warn(
+      `[CorrelationEngine] run() exceeded ${RUN_TARGET_MS}ms for `
+      + `${this.consecutiveSlowRuns} consecutive runs `
+      + `(latest ${elapsedMs.toFixed(0)}ms, peak ${this.peakSlowRunMs.toFixed(0)}ms)`,
+    );
   }
 
   // ── Clustering ──────────────────────────────────────────────

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,9 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   test: {
     environment: "edge-runtime",
     server: { deps: { inline: ["convex-test"] } },
-    include: ["convex/__tests__/**/*.test.ts", "server/__tests__/**/*.test.ts"],
+    include: [
+      "convex/__tests__/**/*.test.ts",
+      "server/__tests__/**/*.test.ts",
+      "src/services/correlation-engine/**/*.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
## Summary

On mobile, an isolated cold-start spike such as 158ms no longer emits a performance warning. The 100ms target remains enforced: the engine warns after two consecutive breaches, reports the latest and peak durations, and emits once per slow streak until a healthy run resets it. Regression coverage locks both isolated-spike suppression and sustained-slow behavior.

## Test plan

- `npm run test:convex` — 59 files and 1,196 tests passed
- `npm run typecheck`
- all repository pre-push gates passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
