### PR TITLE
fix(pro): stop upgrade banner flickering for Pro users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 179
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 179 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (214 service modules and domain directories)
+│   ├── services/           # Business logic (215 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 179,
-  "serviceTopLevelEntries": 214,
+  "serviceTopLevelEntries": 215,
   "apiEndpointEntries": 89,
   "panelClasses": 107,
   "protoFiles": 290,

--- a/src/App.ts
+++ b/src/App.ts
@@ -105,9 +105,10 @@ import { PanelLayoutManager } from '@/app/panel-layout';
 import { DataLoaderManager } from '@/app/data-loader';
 import { EventHandlerManager } from '@/app/event-handlers';
 import { replaceRawI18nKeyPlaceholders } from '@/app/i18n-raw-key-healer';
+import { startAccountAuthHandoff } from '@/app/account-auth-handoff';
 import { resolveUserRegion, resolvePreciseUserCoordinates, type PreciseCoordinates } from '@/utils/user-location';
 import { showProBanner } from '@/components/ProBanner';
-import { initAuthState, subscribeAuthState } from '@/services/auth-state';
+import { getAuthState, initAuthState, subscribeAuthState } from '@/services/auth-state';
 import {
   CLOUD_PREFS_APPLIED_EVENT,
   install as installCloudPrefsSync,
@@ -115,7 +116,18 @@ import {
   onSignOut as cloudPrefsSignOut,
   type CloudPrefsAppliedDetail,
 } from '@/utils/cloud-prefs-sync';
-import { getConvexClient, getConvexApi, waitForConvexAuth } from '@/services/convex-client';
+import {
+  getConvexClient,
+  getConvexApi,
+  invalidateConvexAuthForSignOut,
+  rebindConvexAuthForWatchHandoff,
+  waitForConvexAuthForUser,
+} from '@/services/convex-client';
+import {
+  assertAccountStillCurrent,
+  isAccountStillCurrent,
+  settleAccountOperation,
+} from '@/services/account-operation';
 import type { Id } from '../convex/_generated/dataModel';
 import { initEntitlementSubscription, destroyEntitlementSubscription, resetEntitlementState, onEntitlementChange } from '@/services/entitlements';
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
@@ -1403,6 +1415,7 @@ export class App {
     this.enforceFreeTierLimits();
 
     let _prevUserId: string | null = null;
+    let _convexWatchHandoffGeneration = 0;
     // Track the last-seen PRO entitlement so we can re-fire PRO-gated loaders
     // ONCE on a false→true transition (user signs in / purchase lands mid-session).
     // Without this, loaders gated behind hasPremiumAccess() at init time (e.g.
@@ -1453,10 +1466,9 @@ export class App {
 
       const userId = session.user?.id ?? null;
       if (userId !== null && userId !== _prevUserId) {
-        void cloudPrefsSignIn(userId, SITE_VARIANT);
+        const handoffGeneration = ++_convexWatchHandoffGeneration;
 
         // Rebind Convex watches to the real Clerk userId (was bound to anon UUID at init)
-        destroyEntitlementSubscription();
         // destroyEntitlementSubscription deliberately PRESERVES the last
         // snapshot so a WebSocket reconnect doesn't flash paying users back to
         // locked. That preservation is wrong across an account change: until
@@ -1466,10 +1478,22 @@ export class App {
         // legitimate 403 as A's entitlement desync and retry instead of
         // showing the upgrade CTA. Sign-out already resets for this reason;
         // an account switch carries the same hazard.
-        resetEntitlementState();
-        destroySubscriptionWatch();
-        void initEntitlementSubscription(userId);
-        void initSubscriptionWatch(userId);
+        void startAccountAuthHandoff({
+          userId,
+          isCurrent: () => (
+            handoffGeneration === _convexWatchHandoffGeneration &&
+            getAuthState().user?.id === userId
+          ),
+          effects: {
+            destroyEntitlementSubscription,
+            resetEntitlementState,
+            destroySubscriptionWatch,
+            rebindConvexAuthForWatchHandoff,
+            initEntitlementSubscription,
+            initSubscriptionWatch,
+            cloudPrefsSignIn: (nextUserId) => cloudPrefsSignIn(nextUserId, SITE_VARIANT),
+          },
+        });
 
         // Claim any anonymous purchase made before sign-in (anon → real user migration)
         const anonId = getStoredAnonId();
@@ -1480,16 +1504,21 @@ export class App {
             // Wait for ConvexClient WebSocket auth handshake to complete.
             // Without this, mutations arrive at Convex before the server
             // has the JWT → "Authentication required" errors.
-            const ready = await waitForConvexAuth(10_000);
+            const ready = await waitForConvexAuthForUser(userId, 10_000);
             if (!ready) {
               console.warn('[billing] claimSubscription skipped — Convex auth not ready');
               return;
             }
             const claimToken = getFreshStoredAnonClaimToken() ?? undefined;
-            const result = await client.mutation(api.payments.billing.claimSubscription, {
-              anonId,
-              ...(claimToken ? { claimToken } : {}),
-            });
+            const result = await settleAccountOperation(
+              userId,
+              'claiming the anonymous subscription',
+              () => client.mutation(api.payments.billing.claimSubscription, {
+                anonId,
+                ...(claimToken ? { claimToken } : {}),
+              }),
+            );
+            assertAccountStillCurrent(userId, 'claiming the anonymous subscription');
             const claimed = result.claimed;
             const totalClaimed = claimed.subscriptions + claimed.entitlements +
                                  claimed.customers + claimed.payments;
@@ -1500,6 +1529,7 @@ export class App {
             // Prevents cold Convex init + mutation on every sign-in for non-purchasers.
             clearStoredAnonIdentity();
           })().catch((err: unknown) => {
+            if (!isAccountStillCurrent(userId)) return;
             console.warn('[billing] claimSubscription failed:', err);
             // Non-fatal — anon ID preserved for retry on next page load
           });
@@ -1514,18 +1544,24 @@ export class App {
           void (async () => {
             const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
             if (!client || !api) return;
-            const ready = await waitForConvexAuth(10_000);
+            const ready = await waitForConvexAuthForUser(userId, 10_000);
             if (!ready) {
               console.warn('[business-seats] acceptBusinessInvite skipped — Convex auth not ready');
               return;
             }
             try {
-              await client.mutation(api.payments.businessSeats.acceptBusinessInvite, {
-                grantId: businessInviteGrantId as Id<'businessProGrants'>,
-                token: businessInviteToken,
-              });
+              await settleAccountOperation(
+                userId,
+                'accepting the Business Pro seat invite',
+                () => client.mutation(api.payments.businessSeats.acceptBusinessInvite, {
+                  grantId: businessInviteGrantId as Id<'businessProGrants'>,
+                  token: businessInviteToken,
+                }),
+              );
+              assertAccountStillCurrent(userId, 'accepting the Business Pro seat invite');
               showToast('Pro seat activated');
             } catch (err) {
+              if (!isAccountStillCurrent(userId)) return;
               const msg = err instanceof Error ? err.message : 'Failed to accept invite';
               if (msg.includes('INVITE_EMAIL_MISMATCH')) {
                 showToast('This invite is for a different email address');
@@ -1552,6 +1588,13 @@ export class App {
           openAuth: () => this.state.authModal?.open(),
         });
       } else if (userId === null && _prevUserId !== null) {
+        // Clerk's mounted UserButton signs out through the SDK directly, so
+        // this observed transition is the authoritative place to invalidate
+        // cached/in-flight HTTP tokens and the authenticated Convex socket.
+        invalidateConvexAuthForSignOut();
+        // Supersede any server-auth wait that was started for the account
+        // being signed out before it gets a chance to attach user watches.
+        _convexWatchHandoffGeneration++;
         destroyEntitlementSubscription();
         destroySubscriptionWatch();
         cloudPrefsSignOut();

--- a/src/app/account-auth-handoff.ts
+++ b/src/app/account-auth-handoff.ts
@@ -1,0 +1,48 @@
+export interface AccountAuthHandoffEffects {
+  destroyEntitlementSubscription: () => void;
+  resetEntitlementState: () => void;
+  destroySubscriptionWatch: () => void;
+  rebindConvexAuthForWatchHandoff: (
+    isCurrent: () => boolean,
+    attachWatches: () => void,
+  ) => Promise<boolean>;
+  initEntitlementSubscription: (
+    userId: string,
+    isCurrent: () => boolean,
+  ) => void | Promise<void>;
+  initSubscriptionWatch: (
+    userId: string,
+    isCurrent: () => boolean,
+  ) => void | Promise<void>;
+  cloudPrefsSignIn: (userId: string) => void | Promise<void>;
+}
+
+/**
+ * Reset user-scoped client state and start the authenticated watch handoff.
+ *
+ * The rebind effect is deliberately invoked before cloud preferences. Its
+ * production implementation invalidates the old Clerk token synchronously
+ * before its first await, after which Convex and cloud prefs may safely share
+ * the new account's in-flight token fetch.
+ */
+export function startAccountAuthHandoff(input: {
+  userId: string;
+  isCurrent: () => boolean;
+  effects: AccountAuthHandoffEffects;
+}): Promise<boolean> {
+  const { userId, isCurrent, effects } = input;
+
+  effects.destroyEntitlementSubscription();
+  effects.resetEntitlementState();
+  effects.destroySubscriptionWatch();
+
+  const handoff = effects.rebindConvexAuthForWatchHandoff(
+    isCurrent,
+    () => {
+      void effects.initEntitlementSubscription(userId, isCurrent);
+      void effects.initSubscriptionWatch(userId, isCurrent);
+    },
+  );
+  void effects.cloudPrefsSignIn(userId);
+  return handoff;
+}

--- a/src/components/BusinessSeatsSection.ts
+++ b/src/components/BusinessSeatsSection.ts
@@ -25,6 +25,7 @@ export class BusinessSeatsSection {
   // corporate" rejection during the async listBusinessSeats() round-trip —
   // the server call is the authoritative gate at submit time regardless.
   private ownerIsCorporateDomain = true;
+  private accountGeneration = 0;
   // grantIds with a removeSeat mutation currently in flight — lets two
   // DIFFERENT seats be removed concurrently while still preventing a
   // double-click on the SAME seat's button from firing twice.
@@ -33,20 +34,36 @@ export class BusinessSeatsSection {
   /** `overlay` is the settings modal's root element; content is rendered into `#usBusinessSeats` within it. */
   constructor(private readonly overlay: HTMLElement) {}
 
+  resetForAccountChange(): void {
+    this.accountGeneration += 1;
+    this.seats = [];
+    this.loading = false;
+    this.error = '';
+    this.ownerDomain = null;
+    this.ownerIsCorporateDomain = true;
+    this.removingGrantIds.clear();
+    this.renderInPlace();
+  }
+
   async load(): Promise<void> {
     if (this.loading) return;
+    const generation = this.accountGeneration;
     this.loading = true;
     this.error = '';
     try {
       const result = await listBusinessSeats();
+      if (generation !== this.accountGeneration) return;
       this.seats = result.seats;
       this.ownerDomain = result.ownerDomain;
       this.ownerIsCorporateDomain = result.ownerIsCorporateDomain;
     } catch (err) {
+      if (generation !== this.accountGeneration) return;
       this.error = err instanceof Error ? err.message : 'Failed to load seats';
     } finally {
-      this.loading = false;
-      this.renderInPlace();
+      if (generation === this.accountGeneration) {
+        this.loading = false;
+        this.renderInPlace();
+      }
     }
   }
 
@@ -124,6 +141,7 @@ export class BusinessSeatsSection {
   }
 
   async handleInvite(): Promise<void> {
+    const generation = this.accountGeneration;
     const input = this.overlay.querySelector<HTMLInputElement>('.business-seats-email-input');
     const btn = this.overlay.querySelector<HTMLButtonElement>('.business-seats-invite-btn');
     const email = input?.value.trim();
@@ -134,6 +152,7 @@ export class BusinessSeatsSection {
     this.error = '';
     try {
       const result = await inviteBusinessSeats([email]);
+      if (generation !== this.accountGeneration) return;
       if (result.invited[0]?.status === 'created') {
         showToast('Invite sent');
       } else {
@@ -141,6 +160,7 @@ export class BusinessSeatsSection {
       }
       await this.load();
     } catch (err) {
+      if (generation !== this.accountGeneration) return;
       const msg = err instanceof Error ? err.message : 'Failed to send invite';
       if (msg.includes('SEAT_CAP_REACHED')) {
         this.error = 'All 4 seats are used. Remove a seat first.';
@@ -162,6 +182,7 @@ export class BusinessSeatsSection {
   }
 
   async handleRemove(grantId: string): Promise<void> {
+    const generation = this.accountGeneration;
     if (this.removingGrantIds.has(grantId)) return;
     if (!confirm('Remove this seat? The invitee will lose Pro access immediately.')) return;
 
@@ -169,14 +190,18 @@ export class BusinessSeatsSection {
     this.renderInPlace();
     try {
       const result = await removeBusinessSeat(grantId);
+      if (generation !== this.accountGeneration) return;
       showToast(result.status === 'already_inactive' ? 'Seat was already inactive' : 'Seat removed');
       await this.load();
     } catch (err) {
+      if (generation !== this.accountGeneration) return;
       this.error = err instanceof Error ? err.message : 'Failed to remove seat';
       this.renderInPlace();
     } finally {
-      this.removingGrantIds.delete(grantId);
-      this.renderInPlace();
+      if (generation === this.accountGeneration) {
+        this.removingGrantIds.delete(grantId);
+        this.renderInPlace();
+      }
     }
   }
 }

--- a/src/components/ProBanner.ts
+++ b/src/components/ProBanner.ts
@@ -12,7 +12,9 @@ import {
   decideProBannerMount,
   isPremiumEntitlementHint,
   resolveBannerPremium,
+  stabilizeProBannerPremium,
   PRO_BANNER_ENTITLEMENT_HINT_KEY,
+  type ProBannerPremiumStabilityState,
 } from '@/services/pro-banner-policy';
 import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -20,6 +22,9 @@ import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 let bannerEl: HTMLElement | null = null;
 let pendingBannerRemoval: ReturnType<typeof setTimeout> | null = null;
+let premiumStabilityState: ProBannerPremiumStabilityState | null = null;
+let premiumStabilityRecheck: ReturnType<typeof setTimeout> | null = null;
+let premiumStabilityRecheckAt: number | null = null;
 let dismissedThisSession = false;
 // Cached at first showProBanner() call (App.ts always calls it once at init,
 // regardless of premium state — the early-returns inside decide whether to
@@ -135,16 +140,45 @@ function hasAccountBackedPremium(): boolean {
   );
 }
 
-function resolveEffectiveBannerPremium(): ReturnType<typeof resolveBannerPremium> {
+function schedulePremiumStabilityRecheck(recheckAt: number | null): void {
+  if (premiumStabilityRecheck !== null && premiumStabilityRecheckAt === recheckAt) {
+    return;
+  }
+  if (premiumStabilityRecheck !== null) {
+    clearTimeout(premiumStabilityRecheck);
+    premiumStabilityRecheck = null;
+  }
+  premiumStabilityRecheckAt = recheckAt;
+  if (recheckAt === null) return;
+
+  premiumStabilityRecheck = setTimeout(() => {
+    premiumStabilityRecheck = null;
+    premiumStabilityRecheckAt = null;
+    syncProBanner();
+  }, Math.max(0, recheckAt - Date.now()));
+}
+
+function resolveEffectiveBannerPremium(): ReturnType<typeof stabilizeProBannerPremium> {
   const auth = getAuthState();
-  const signedIn = getCurrentClerkUser() !== null || auth.user !== null;
-  return resolveBannerPremium({
+  const clerkUser = getCurrentClerkUser();
+  const userId = clerkUser?.id ?? auth.user?.id ?? null;
+  const live = resolveBannerPremium({
     authPending: auth.isPending,
-    signedIn,
+    signedIn: userId !== null,
     localUnlockPremium: hasLocalUnlockPremium(),
     rawPremium: hasPremiumAccess(auth),
     accountBackedPremium: hasAccountBackedPremium(),
   });
+  const stable = stabilizeProBannerPremium({
+    now: Date.now(),
+    userId,
+    premiumHint: readPremiumHint(),
+    live,
+    previous: premiumStabilityState,
+  });
+  premiumStabilityState = stable.state;
+  schedulePremiumStabilityRecheck(stable.recheckAt);
+  return stable;
 }
 
 export function showProBanner(container: HTMLElement): void {

--- a/src/components/ProBanner.ts
+++ b/src/components/ProBanner.ts
@@ -1,6 +1,5 @@
 import { trackGateHit } from '@/services/analytics';
-import { hasPremiumAccess } from '@/services/panel-gating';
-import { onEntitlementChange, getEntitlementState, isEntitled } from '@/services/entitlements';
+import { onEntitlementChange, getEntitlementState, isEntitlementActive } from '@/services/entitlements';
 import { getSubscription, onSubscriptionChange } from '@/services/billing';
 import { deriveBillingUxState, getReactivationHref } from '@/services/billing-state';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
@@ -25,6 +24,10 @@ let pendingBannerRemoval: ReturnType<typeof setTimeout> | null = null;
 let premiumStabilityState: ProBannerPremiumStabilityState | null = null;
 let premiumStabilityRecheck: ReturnType<typeof setTimeout> | null = null;
 let premiumStabilityRecheckAt: number | null = null;
+// A direct Clerk A -> B notification can run before App resets A's preserved
+// Convex snapshot. Keep that user-unscoped evidence blocked across nested
+// sync/show evaluations until resetEntitlementState() publishes null.
+let blockedEntitlementUserId: string | null = null;
 let dismissedThisSession = false;
 // Cached at first showProBanner() call (App.ts always calls it once at init,
 // regardless of premium state — the early-returns inside decide whether to
@@ -130,16 +133,6 @@ function hasLocalUnlockPremium(): boolean {
   );
 }
 
-function hasAccountBackedPremium(): boolean {
-  const clerkUser = getCurrentClerkUser();
-  const auth = getAuthState();
-  return (
-    isEntitled() ||
-    auth.user?.role === 'pro' ||
-    clerkUser?.plan === 'pro'
-  );
-}
-
 function schedulePremiumStabilityRecheck(recheckAt: number | null): void {
   if (premiumStabilityRecheck !== null && premiumStabilityRecheckAt === recheckAt) {
     return;
@@ -158,19 +151,52 @@ function schedulePremiumStabilityRecheck(recheckAt: number | null): void {
   }, Math.max(0, recheckAt - Date.now()));
 }
 
-function resolveEffectiveBannerPremium(): ReturnType<typeof stabilizeProBannerPremium> {
+type EffectiveBannerPremium = ReturnType<typeof stabilizeProBannerPremium> & {
+  acceptedEntitlementLoaded: boolean;
+};
+
+function resolveEffectiveBannerPremium(): EffectiveBannerPremium {
   const auth = getAuthState();
   const clerkUser = getCurrentClerkUser();
   const userId = clerkUser?.id ?? auth.user?.id ?? null;
+  const entitlement = getEntitlementState();
+  const now = Date.now();
+  const identityBoundPremium = (
+    (clerkUser?.id === userId && clerkUser.plan === 'pro') ||
+    (auth.user?.id === userId && auth.user.role === 'pro')
+  );
+  const previousUserId = premiumStabilityState?.userId ?? null;
+  const directAccountSwitch = (
+    previousUserId !== null &&
+    userId !== null &&
+    previousUserId !== userId
+  );
+  if (userId === null) {
+    blockedEntitlementUserId = null;
+  } else if (directAccountSwitch) {
+    // If App's listener ran first, the null snapshot already proves the old
+    // account was cleared and there is no stale evidence left to quarantine.
+    blockedEntitlementUserId = entitlement === null ? null : userId;
+  } else if (
+    blockedEntitlementUserId === userId &&
+    entitlement === null
+  ) {
+    blockedEntitlementUserId = null;
+  }
+  const acceptedEntitlementLoaded = (
+    entitlement !== null &&
+    blockedEntitlementUserId !== userId
+  );
   const live = resolveBannerPremium({
     authPending: auth.isPending,
     signedIn: userId !== null,
     localUnlockPremium: hasLocalUnlockPremium(),
-    rawPremium: hasPremiumAccess(auth),
-    accountBackedPremium: hasAccountBackedPremium(),
+    identityBoundPremium,
+    unscopedAccountPremium: isEntitlementActive(entitlement, now),
+    acceptUnscopedAccountPremium: acceptedEntitlementLoaded,
   });
   const stable = stabilizeProBannerPremium({
-    now: Date.now(),
+    now,
     userId,
     premiumHint: readPremiumHint(),
     live,
@@ -178,7 +204,7 @@ function resolveEffectiveBannerPremium(): ReturnType<typeof stabilizeProBannerPr
   });
   premiumStabilityState = stable.state;
   schedulePremiumStabilityRecheck(stable.recheckAt);
-  return stable;
+  return { ...stable, acceptedEntitlementLoaded };
 }
 
 export function showProBanner(container: HTMLElement): void {
@@ -194,7 +220,11 @@ export function showProBanner(container: HTMLElement): void {
   if (bannerEl) return;
 
   const auth = getAuthState();
-  const { premium, accountBacked } = resolveEffectiveBannerPremium();
+  const {
+    premium,
+    accountBacked,
+    acceptedEntitlementLoaded,
+  } = resolveEffectiveBannerPremium();
   // Persist only account-backed premium. Local unlock keys suppress the
   // banner this session via `premium` without poisoning pre-paint for free web.
   if (accountBacked) {
@@ -213,7 +243,7 @@ export function showProBanner(container: HTMLElement): void {
     authPending: auth.isPending,
     clerkConfigured: isClerkAuthEnabled(),
     signedIn: getCurrentClerkUser() !== null || auth.user !== null,
-    entitlementLoaded: getEntitlementState() !== null,
+    entitlementLoaded: acceptedEntitlementLoaded,
   });
 
   if (decision === 'suppress') {
@@ -301,7 +331,11 @@ export function isProBannerVisible(): boolean {
 //     → re-mount via showProBanner. Same gate set as the initial mount path,
 //       so we can never surface a banner the user has already ✕'d this week.
 function syncProBanner(): void {
-  const { premium, accountBacked } = resolveEffectiveBannerPremium();
+  const {
+    premium,
+    accountBacked,
+    acceptedEntitlementLoaded,
+  } = resolveEffectiveBannerPremium();
   if (premium) {
     if (accountBacked) writePremiumHint(true);
     if (!bannerEl) {
@@ -312,11 +346,26 @@ function syncProBanner(): void {
     scheduleBannerRemoval();
     return;
   }
-  // Settled free / sign-out: clear a stale pro hint even when the banner was
-  // never mounted (premium branch above would re-affirm it before #5728 fix).
   const auth = getAuthState();
+  const signedIn = getCurrentClerkUser() !== null || auth.user !== null;
+  // Settled free / account handoff: clear a stale Pro hint even when the
+  // banner was never mounted. A direct switch must not let A's hint suppress
+  // B's eventual free banner.
   if (!auth.isPending) {
     writePremiumHint(false);
+  }
+  if (signedIn && !acceptedEntitlementLoaded) {
+    // An already-mounted free banner belongs to the previous account. During
+    // a direct identity handoff, remove it until the current account's first
+    // accepted Convex snapshot arrives; otherwise a Pro B briefly inherits
+    // A's "Upgrade" UI even though new mounts correctly defer.
+    if (bannerEl) {
+      cancelPendingBannerRemoval();
+      bannerEl.remove();
+      bannerEl = null;
+      setReservation(false);
+    }
+    return;
   }
   // A premium snapshot may have started the fade-out immediately before a
   // non-premium snapshot arrived. Keep the banner visible for the restored

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -28,7 +28,7 @@ import { escapeHtml } from '@/utils/sanitize';
 import type { PanelConfig } from '@/types';
 import { renderPreferences } from '@/services/preferences-content';
 import { renderNotificationsSettings, type NotificationsSettingsResult } from '@/services/notifications-settings';
-import { getAuthState } from '@/services/auth-state';
+import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { track } from '@/services/analytics';
 import { isEntitled, hasFeature, onEntitlementChange, getEntitlementState } from '@/services/entitlements';
 import { hasPremiumAccess } from '@/services/panel-gating';
@@ -69,6 +69,7 @@ export interface UnifiedSettingsConfig {
 }
 
 type TabId = UnifiedSettingsTabId;
+type AccountRequest = { userId: string; generation: number };
 
 export class UnifiedSettings {
   private overlay: HTMLElement;
@@ -92,6 +93,7 @@ export class UnifiedSettings {
   private newlyCreatedKey: string | null = null;
   private planLimitNotices: ApiPlanLimitNotice[] = [];
   private planLimitNoticesLoading = false;
+  private planLimitNoticesError = '';
   // ---- Business Pro seats (plan 2026-07-24-001 U7) ----
   private readonly businessSeatsSection: BusinessSeatsSection;
   // ---- Connected MCP clients tab (plan 2026-05-10-001 U9) ----
@@ -101,6 +103,10 @@ export class UnifiedSettings {
   private mcpQuota: McpQuota | null = null;
   /** setInterval handle for quota auto-refresh; cleared on close()/destroy()/tab-switch. */
   private mcpQuotaTimer: ReturnType<typeof setInterval> | null = null;
+  private accountUserId: string | null = getAuthState().user?.id ?? null;
+  private accountDataGeneration = 0;
+  private accountEntitlementRefreshPending = false;
+  private unsubscribeAuth: (() => void) | null = null;
   private unsubscribeEntitlement: (() => void) | null = null;
   private unsubscribeSubscription: (() => void) | null = null;
   // Bounded "entitlement snapshot might still arrive" window. Starts false
@@ -360,6 +366,49 @@ export class UnifiedSettings {
 
     this.render();
     document.body.appendChild(this.overlay);
+    this.unsubscribeAuth = subscribeAuthState((state) => {
+      this.handleAccountIdentityChange(state.user?.id ?? null);
+    });
+  }
+
+  private handleAccountIdentityChange(nextUserId: string | null): void {
+    if (nextUserId === this.accountUserId) return;
+
+    this.accountUserId = nextUserId;
+    this.accountDataGeneration += 1;
+    this.accountEntitlementRefreshPending = true;
+    this.apiKeys = [];
+    this.apiKeysLoading = false;
+    this.apiKeysError = '';
+    this.newlyCreatedKey = null;
+    this.planLimitNotices = [];
+    this.planLimitNoticesLoading = false;
+    this.planLimitNoticesError = '';
+    this.mcpClients = [];
+    this.mcpClientsLoading = false;
+    this.mcpClientsError = '';
+    this.mcpQuota = null;
+    this.stopMcpQuotaPolling();
+    this.businessSeatsSection.resetForAccountChange();
+
+    // Replace any rendered A-owned plaintext/list data synchronously. Account
+    // loaders stay suppressed until the new entitlement snapshot rerenders.
+    if (this.overlay.classList.contains('active')) {
+      this.entitlementReady = false;
+      this.render(false);
+    }
+  }
+
+  private captureAccountRequest(): AccountRequest | null {
+    const userId = getAuthState().user?.id ?? null;
+    if (!userId || userId !== this.accountUserId) return null;
+    return { userId, generation: this.accountDataGeneration };
+  }
+
+  private isAccountRequestCurrent(request: AccountRequest): boolean {
+    return request.generation === this.accountDataGeneration
+      && request.userId === this.accountUserId
+      && request.userId === getAuthState().user?.id;
   }
 
   public open(tab?: TabId): void {
@@ -383,12 +432,30 @@ export class UnifiedSettings {
     // hasFeature('apiAccess') returns false until the Convex subscription
     // delivers data, so a paid API Starter user sees the upgrade CTA briefly).
     this.unsubscribeEntitlement?.();
-    this.unsubscribeEntitlement = onEntitlementChange(() => {
+    this.unsubscribeEntitlement = onEntitlementChange((state) => {
       this.entitlementReady = true;
+      if (this.accountEntitlementRefreshPending) {
+        // Entitlements are account-scoped. Rebuild every account surface so a
+        // direct A→B handoff removes/adds MCP and API tabs using B's snapshot.
+        // Keep the marker through the reset(null) emission; the first real B
+        // snapshot must rebuild once more before ordinary targeted refreshes.
+        if (state !== null) this.accountEntitlementRefreshPending = false;
+        this.render();
+        return;
+      }
+
+      const hasMcpClientsTab = this.overlay.querySelector('[data-tab="mcp-clients"]') !== null;
+      if (hasMcpClientsTab !== hasFeature('mcpAccess')) {
+        // Entitlements can legitimately progress from a free/default snapshot
+        // to Pro after the account handoff's first non-null emission. Rebuild
+        // the tab shape whenever MCP capability changes in either direction.
+        this.render();
+        return;
+      }
+
       const panel = this.overlay.querySelector<HTMLElement>('[data-panel-id="api-keys"]');
       if (panel) {
         setTrustedHtml(panel, trustedHtml(this.renderApiKeysContent(), "legacy direct innerHTML migration"));
-        // Re-attach CTA and input handlers for the refreshed content
         this.attachApiKeysHandlers();
         if (this.activeTab === 'api-keys' && getAuthState().user && hasFeature('apiAccess')) {
           void this.loadApiKeys();
@@ -497,6 +564,8 @@ export class UnifiedSettings {
     this.unsubscribeEntitlement = null;
     this.unsubscribeSubscription?.();
     this.unsubscribeSubscription = null;
+    this.unsubscribeAuth?.();
+    this.unsubscribeAuth = null;
     // Mirror close() — without this, a destroy() during the 12s fallback
     // window leaves the timer live; it fires after teardown and calls
     // replaceUpgradeSection() against a detached overlay (no-op via the
@@ -529,7 +598,7 @@ export class UnifiedSettings {
     nextTab.focus();
   }
 
-  private render(): void {
+  private render(loadAccountData = true): void {
     this.prefsCleanup?.();
     this.prefsCleanup = null;
     this.notifCleanup?.();
@@ -646,15 +715,17 @@ export class UnifiedSettings {
     this.updateSourcesCounter();
 
     this.attachApiKeysHandlers();
-    if (this.activeTab === 'api-keys' || this.activeTab === 'mcp-clients') {
-      void this.loadPlanLimitNotices();
-    }
-    if (this.activeTab === 'api-keys' && getAuthState().user && hasFeature('apiAccess')) {
-      void this.loadApiKeys();
-    }
-    if (this.activeTab === 'mcp-clients' && getAuthState().user && hasFeature('mcpAccess')) {
-      void this.loadMcpClients();
-      this.startMcpQuotaPolling();
+    if (loadAccountData) {
+      if (this.activeTab === 'api-keys' || this.activeTab === 'mcp-clients') {
+        void this.loadPlanLimitNotices();
+      }
+      if (this.activeTab === 'api-keys' && getAuthState().user && hasFeature('apiAccess')) {
+        void this.loadApiKeys();
+      }
+      if (this.activeTab === 'mcp-clients' && getAuthState().user && hasFeature('mcpAccess')) {
+        void this.loadMcpClients();
+        this.startMcpQuotaPolling();
+      }
     }
   }
 
@@ -1109,16 +1180,25 @@ export class UnifiedSettings {
   }
 
   private async loadPlanLimitNotices(): Promise<void> {
-    if (!getAuthState().user || this.planLimitNoticesLoading) return;
+    const request = this.captureAccountRequest();
+    if (!request || this.planLimitNoticesLoading) return;
     this.planLimitNoticesLoading = true;
+    this.planLimitNoticesError = '';
     try {
-      this.planLimitNotices = await listCurrentPlanLimitNotices();
+      const notices = await listCurrentPlanLimitNotices();
+      if (!this.isAccountRequestCurrent(request)) return;
+      this.planLimitNotices = notices;
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       console.warn('[settings] Failed to load API plan-limit notices:', err);
-      this.planLimitNotices = [];
+      this.planLimitNoticesError = err instanceof Error
+        ? err.message
+        : 'Failed to load API plan-limit notices';
     } finally {
-      this.planLimitNoticesLoading = false;
-      this.renderPlanLimitNoticeBlocks();
+      if (this.isAccountRequestCurrent(request)) {
+        this.planLimitNoticesLoading = false;
+        this.renderPlanLimitNoticeBlocks();
+      }
     }
   }
 
@@ -1145,10 +1225,14 @@ export class UnifiedSettings {
   }
 
   private renderPlanLimitNotices(): string {
-    if (this.planLimitNotices.length === 0) return '';
+    if (!this.planLimitNoticesError && this.planLimitNotices.length === 0) return '';
+    const error = this.planLimitNoticesError
+      ? `<div class="api-keys-error api-plan-limit-notices-error" role="alert">${escapeHtml(this.planLimitNoticesError)}</div>`
+      : '';
     const nf = new Intl.NumberFormat();
     return `
       <div class="api-plan-limit-notices" aria-live="polite">
+        ${error}
         ${this.planLimitNotices.map((notice) => {
           const limit = notice.limit == null ? 'unlimited' : nf.format(notice.limit);
           const usage = nf.format(notice.usage);
@@ -1181,11 +1265,15 @@ export class UnifiedSettings {
   }
 
   private async handleAcknowledgePlanLimitNotice(noticeId: string): Promise<void> {
+    const request = this.captureAccountRequest();
+    if (!request) return;
     try {
       await acknowledgePlanLimitNotice(noticeId);
+      if (!this.isAccountRequestCurrent(request)) return;
       this.planLimitNotices = this.planLimitNotices.filter((notice) => notice._id !== noticeId);
       this.renderPlanLimitNoticeBlocks();
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       console.warn('[settings] Failed to acknowledge API plan-limit notice:', err);
       showToast('Could not dismiss this notice. Try again.');
     }
@@ -1308,17 +1396,24 @@ export class UnifiedSettings {
   }
 
   private async loadApiKeys(): Promise<void> {
+    const request = this.captureAccountRequest();
+    if (!request || this.apiKeysLoading) return;
     this.apiKeysLoading = true;
     this.apiKeysError = '';
     this.renderApiKeysList();
 
     try {
-      this.apiKeys = await listApiKeys();
+      const keys = await listApiKeys();
+      if (!this.isAccountRequestCurrent(request)) return;
+      this.apiKeys = keys;
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       this.apiKeysError = err instanceof Error ? err.message : 'Failed to load keys';
     } finally {
-      this.apiKeysLoading = false;
-      this.renderApiKeysList();
+      if (this.isAccountRequestCurrent(request)) {
+        this.apiKeysLoading = false;
+        this.renderApiKeysList();
+      }
     }
   }
 
@@ -1327,6 +1422,8 @@ export class UnifiedSettings {
     const btn = this.overlay.querySelector<HTMLButtonElement>('.api-keys-create-btn');
     const name = input?.value.trim();
     if (!name || !input || !btn) return;
+    const request = this.captureAccountRequest();
+    if (!request) return;
 
     btn.disabled = true;
     btn.textContent = 'Creating...';
@@ -1336,11 +1433,13 @@ export class UnifiedSettings {
 
     try {
       const result = await createApiKey(name);
+      if (!this.isAccountRequestCurrent(request)) return;
       this.newlyCreatedKey = result.key;
       input.value = '';
       this.showCreatedBanner(result.key);
       await this.loadApiKeys();
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       const msg = err instanceof Error ? err.message : 'Failed to create key';
       this.apiKeysError = msg.includes('KEY_LIMIT_REACHED')
         ? 'Maximum of 5 active keys reached. Revoke an existing key first.'
@@ -1349,20 +1448,26 @@ export class UnifiedSettings {
         : msg;
       this.renderApiKeysError();
     } finally {
-      btn.disabled = false;
-      btn.textContent = 'Create Key';
+      if (this.isAccountRequestCurrent(request)) {
+        btn.disabled = false;
+        btn.textContent = 'Create Key';
+      }
     }
   }
 
   private async handleRevokeApiKey(keyId: string): Promise<void> {
+    const request = this.captureAccountRequest();
+    if (!request) return;
     const keyInfo = this.apiKeys.find(k => k.id === keyId);
     const keyName = keyInfo?.name ?? 'this key';
     if (!confirm(`Revoke "${keyName}"? This cannot be undone. Any applications using this key will stop working.`)) return;
 
     try {
       await revokeApiKey(keyId);
+      if (!this.isAccountRequestCurrent(request)) return;
       await this.loadApiKeys();
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       this.apiKeysError = err instanceof Error ? err.message : 'Failed to revoke key';
       this.renderApiKeysError();
     }
@@ -1521,32 +1626,44 @@ export class UnifiedSettings {
   }
 
   private async loadMcpClients(): Promise<void> {
+    const request = this.captureAccountRequest();
+    if (!request || this.mcpClientsLoading) return;
     this.mcpClientsLoading = true;
     this.mcpClientsError = '';
     this.renderMcpClientsList();
 
     try {
-      this.mcpClients = await listMcpClients();
+      const clients = await listMcpClients();
+      if (!this.isAccountRequestCurrent(request)) return;
+      this.mcpClients = clients;
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       this.mcpClientsError = err instanceof Error ? err.message : 'Failed to load MCP clients';
     } finally {
-      this.mcpClientsLoading = false;
-      this.renderMcpClientsList();
+      if (this.isAccountRequestCurrent(request)) {
+        this.mcpClientsLoading = false;
+        this.renderMcpClientsList();
+      }
     }
 
     // Kick a fresh quota fetch alongside the list so the user sees current
     // numbers immediately on tab open (the polling timer takes 30s otherwise).
-    void this.refreshMcpQuota();
+    if (this.isAccountRequestCurrent(request)) void this.refreshMcpQuota();
   }
 
   private async refreshMcpQuota(): Promise<void> {
+    const request = this.captureAccountRequest();
+    if (!request) return;
     try {
-      this.mcpQuota = await fetchMcpQuota();
+      const quota = await fetchMcpQuota();
+      if (!this.isAccountRequestCurrent(request)) return;
+      this.mcpQuota = quota;
     } catch {
+      if (!this.isAccountRequestCurrent(request)) return;
       // fetchMcpQuota already returns sane fallbacks, but defensive catch.
       this.mcpQuota = null;
     }
-    this.renderMcpQuotaInPlace();
+    if (this.isAccountRequestCurrent(request)) this.renderMcpQuotaInPlace();
   }
 
   private renderMcpQuotaInPlace(): void {
@@ -1576,17 +1693,21 @@ export class UnifiedSettings {
   }
 
   private async handleRevokeMcpClient(tokenId: string): Promise<void> {
+    const request = this.captureAccountRequest();
+    if (!request) return;
     const client = this.mcpClients.find(c => c.id === tokenId);
     const label = client?.name?.trim() ? `"${client.name}"` : 'this client';
     if (!confirm(`Revoke ${label}? The connected AI client will need to re-authorize before its next request.`)) return;
 
     try {
       await revokeMcpClient(tokenId);
+      if (!this.isAccountRequestCurrent(request)) return;
       // Refresh both list (Convex query result cached locally) and quota
       // (revoke does not change the daily counter, but the user might have
       // crossed the boundary while the modal was open).
       await this.loadMcpClients();
     } catch (err) {
+      if (!this.isAccountRequestCurrent(request)) return;
       this.mcpClientsError = err instanceof Error ? err.message : 'Failed to revoke MCP client';
       this.renderMcpClientsError();
     }

--- a/src/services/account-operation.ts
+++ b/src/services/account-operation.ts
@@ -1,0 +1,32 @@
+import { getCurrentClerkUser } from './clerk';
+
+/**
+ * Account-scoped requests may settle after Clerk has selected another user.
+ * Never let a result (or an account-specific error) cross that handoff.
+ */
+export function isAccountStillCurrent(userId: string): boolean {
+  return getCurrentClerkUser()?.id === userId;
+}
+
+export function assertAccountStillCurrent(userId: string, action: string): void {
+  if (!isAccountStillCurrent(userId)) {
+    throw new Error(`Account changed while ${action}. Try again.`);
+  }
+}
+
+export async function settleAccountOperation<T>(
+  userId: string,
+  action: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  assertAccountStillCurrent(userId, action);
+  let result: T;
+  try {
+    result = await operation();
+  } catch (err) {
+    assertAccountStillCurrent(userId, action);
+    throw err;
+  }
+  assertAccountStillCurrent(userId, action);
+  return result;
+}

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -7,8 +7,16 @@
  * that could log it.
  */
 
-import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
-import { getClerkToken } from './clerk';
+import {
+  getConvexClient,
+  getConvexApi,
+  waitForConvexAuthForUser,
+} from './convex-client';
+import { getClerkToken, getCurrentClerkUser } from './clerk';
+import {
+  assertAccountStillCurrent,
+  settleAccountOperation,
+} from './account-operation';
 
 export interface ApiKeyInfo {
   id: string;
@@ -46,55 +54,89 @@ async function sha256Hex(input: string): Promise<string> {
  * Returns the full plaintext key (shown once) and metadata.
  */
 export async function createApiKey(name: string): Promise<CreateApiKeyResult> {
-  const client = await getConvexClient();
-  const api = await getConvexApi();
-  if (!client || !api) throw new Error('Convex unavailable');
-
-  await waitForConvexAuth();
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) throw new Error('Sign in to create an API key.');
 
   const plaintext = generateKey();
   const keyPrefix = plaintext.slice(0, 8);
   const keyHash = await sha256Hex(plaintext);
 
-  const result = await client.mutation(
-    (api as any).apiKeys.createApiKey,
-    { name: name.trim(), keyPrefix, keyHash },
+  const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
+  if (!client || !api) throw new Error('Convex unavailable');
+  if (!await waitForConvexAuthForUser(userId)) {
+    throw new Error('Account changed while creating the API key. Try again.');
+  }
+
+  const result = await settleAccountOperation(
+    userId,
+    'creating the API key',
+    () => client.mutation(
+      (api as any).apiKeys.createApiKey,
+      { name: name.trim(), keyPrefix, keyHash },
+    ),
   );
+  assertAccountStillCurrent(userId, 'creating the API key');
 
   return { id: result.id, name: result.name, keyPrefix: result.keyPrefix, key: plaintext };
 }
 
 /** List all API keys for the current user. */
 export async function listApiKeys(): Promise<ApiKeyInfo[]> {
-  const client = await getConvexClient();
-  const api = await getConvexApi();
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) return [];
+
+  const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
   if (!client || !api) return [];
+  if (!await waitForConvexAuthForUser(userId)) {
+    assertAccountStillCurrent(userId, 'loading API keys');
+    throw new Error('Authentication unavailable while loading API keys. Try again.');
+  }
 
-  await waitForConvexAuth();
-
-  return client.query((api as any).apiKeys.listApiKeys, {});
+  return settleAccountOperation(
+    userId,
+    'loading API keys',
+    () => client.query((api as any).apiKeys.listApiKeys, {}),
+  );
 }
 
 /** Revoke an API key by its Convex document ID. */
 export async function revokeApiKey(keyId: string): Promise<void> {
-  const client = await getConvexClient();
-  const api = await getConvexApi();
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) throw new Error('Sign in to revoke API keys.');
+
+  const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
   if (!client || !api) throw new Error('Convex unavailable');
+  if (!await waitForConvexAuthForUser(userId)) {
+    throw new Error('Account changed while revoking the API key. Try again.');
+  }
 
-  await waitForConvexAuth();
-
-  const result = await client.mutation((api as any).apiKeys.revokeApiKey, { keyId });
+  const result = await settleAccountOperation(
+    userId,
+    'revoking the API key',
+    () => client.mutation((api as any).apiKeys.revokeApiKey, { keyId }),
+  );
+  assertAccountStillCurrent(userId, 'revoking the API key');
 
   // Await cache bust so the gateway stops accepting the revoked key immediately.
   // If this fails, the 60s cache TTL limits the staleness window.
   if (result?.keyHash) {
-    const token = await getClerkToken();
+    const token = await settleAccountOperation(
+      userId,
+      'invalidating the API key cache',
+      getClerkToken,
+    );
     if (token) {
-      const resp = await fetch('/api/invalidate-user-api-key-cache', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ keyHash: result.keyHash }),
-      });
+      assertAccountStillCurrent(userId, 'invalidating the API key cache');
+      const resp = await settleAccountOperation(
+        userId,
+        'invalidating the API key cache',
+        () => fetch('/api/invalidate-user-api-key-cache', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ keyHash: result.keyHash }),
+        }),
+      );
+      assertAccountStillCurrent(userId, 'invalidating the API key cache');
       if (!resp.ok) {
         console.warn('[api-keys] cache invalidation failed:', resp.status);
       }

--- a/src/services/api-plan-limit-notices.ts
+++ b/src/services/api-plan-limit-notices.ts
@@ -1,4 +1,13 @@
-import { getConvexApi, getConvexClient } from './convex-client';
+import {
+  getConvexApi,
+  getConvexClient,
+  waitForConvexAuthForUser,
+} from './convex-client';
+import { getCurrentClerkUser } from './clerk';
+import {
+  assertAccountStillCurrent,
+  settleAccountOperation,
+} from './account-operation';
 
 export type ApiPlanLimitNoticeState = 'warning' | 'over_limit' | 'sustained_burst';
 export type ApiPlanLimitDimension =
@@ -24,15 +33,32 @@ export interface ApiPlanLimitNotice {
 }
 
 export async function listCurrentPlanLimitNotices(): Promise<ApiPlanLimitNotice[]> {
-  const client = await getConvexClient();
-  const api = await getConvexApi();
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) return [];
+  const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
   if (!client || !api) return [];
-  return await client.query((api as any).apiPlanLimitNotices.listCurrentForUser, {});
+  if (!await waitForConvexAuthForUser(userId)) {
+    assertAccountStillCurrent(userId, 'loading API plan-limit notices');
+    throw new Error('Authentication unavailable while loading API plan-limit notices. Try again.');
+  }
+  return settleAccountOperation(
+    userId,
+    'loading API plan-limit notices',
+    () => client.query((api as any).apiPlanLimitNotices.listCurrentForUser, {}),
+  );
 }
 
 export async function acknowledgePlanLimitNotice(noticeId: string): Promise<void> {
-  const client = await getConvexClient();
-  const api = await getConvexApi();
-  if (!client || !api) return;
-  await client.mutation((api as any).apiPlanLimitNotices.acknowledgeNotice, { noticeId });
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) throw new Error('Sign in to acknowledge API plan-limit notices.');
+  const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
+  if (!client || !api) throw new Error('Convex unavailable');
+  if (!await waitForConvexAuthForUser(userId)) {
+    throw new Error('Account changed while acknowledging the API plan-limit notice. Try again.');
+  }
+  await settleAccountOperation(
+    userId,
+    'acknowledging the API plan-limit notice',
+    () => client.mutation((api as any).apiPlanLimitNotices.acknowledgeNotice, { noticeId }),
+  );
 }

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -10,7 +10,17 @@
  */
 
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
+import {
+  getConvexClient,
+  getConvexApi,
+  waitForConvexAuthForUser,
+} from './convex-client';
+import { getCurrentClerkUser } from './clerk';
+import {
+  assertAccountStillCurrent,
+  isAccountStillCurrent,
+  settleAccountOperation,
+} from './account-operation';
 import { extractBillingErrorKind } from './_billing-error';
 import type { Id } from '../../convex/_generated/dataModel';
 
@@ -56,13 +66,35 @@ function normalizeCaughtError(action: string, err: unknown): Error {
   return wrapped;
 }
 
+function requireSignedInUserId(action: string): string {
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) throw new Error(`Sign in to ${action}.`);
+  return userId;
+}
+
+async function requireCurrentConvexUser(
+  userId: string,
+  action: string,
+): Promise<void> {
+  if (!await waitForConvexAuthForUser(userId)) {
+    throw new Error(`Account changed while ${action}. Try again.`);
+  }
+  assertAccountStillCurrent(userId, action);
+}
+
 /**
  * Initialize the subscription watch for the authenticated user.
  * Idempotent -- calling multiple times is a no-op after the first.
  * Failures are logged but never thrown (dashboard must not break).
  */
-export async function initSubscriptionWatch(_userId?: string): Promise<void> {
-  if (initialized) return;
+export async function initSubscriptionWatch(
+  _userId?: string,
+  isCurrent: () => boolean = () => true,
+): Promise<void> {
+  const isExpectedAccount = (): boolean => (
+    isCurrent() && (_userId === undefined || getCurrentClerkUser()?.id === _userId)
+  );
+  if (initialized || !isExpectedAccount()) return;
 
   try {
     const client = await getConvexClient();
@@ -76,16 +108,19 @@ export async function initSubscriptionWatch(_userId?: string): Promise<void> {
       console.warn('[billing] Could not load Convex API -- skipping subscription watch');
       return;
     }
+    if (!isExpectedAccount()) return;
 
     unsubscribeConvex = client.onUpdate(
       api.payments.billing.getSubscriptionForUser,
       {},
       (result: SubscriptionInfo | null) => {
+        if (!isExpectedAccount()) return;
         currentSubscription = result;
         subscriptionLoaded = true;
         for (const cb of listeners) cb(result);
       },
       (err: Error) => {
+        if (!isExpectedAccount()) return;
         console.warn('[billing] Subscription query error:', err.message);
         // Clear stale cached value so getSubscription() returns null (not old plan).
         currentSubscription = null;
@@ -162,14 +197,20 @@ export async function claimProActivationPresentation(
   activationKey: string,
   claimNonce: string,
 ): Promise<ProActivationClaimOutcome> {
+  const userId = requireSignedInUserId('claim Pro activation');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  const result = await client.mutation(
-    (api as any).payments.billing.claimProActivationPresentation,
-    { activationKey, claimNonce },
+  await requireCurrentConvexUser(userId, 'claiming Pro activation');
+  const result = await settleAccountOperation(
+    userId,
+    'claiming Pro activation',
+    () => client.mutation(
+      (api as any).payments.billing.claimProActivationPresentation,
+      { activationKey, claimNonce },
+    ),
   ) as { status: ProActivationClaimOutcome };
+  assertAccountStillCurrent(userId, 'claiming Pro activation');
   return result.status;
 }
 
@@ -178,14 +219,19 @@ export async function confirmProActivationPresentation(
   activationKey: string,
   claimNonce: string,
 ): Promise<boolean> {
+  const userId = requireSignedInUserId('confirm Pro activation');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  return await client.mutation(
-    (api as any).payments.billing.confirmProActivationPresentation,
-    { activationKey, claimNonce, outcomeTrackingVersion: 1 },
-  ) as boolean;
+  await requireCurrentConvexUser(userId, 'confirming Pro activation');
+  return settleAccountOperation(
+    userId,
+    'confirming Pro activation',
+    () => client.mutation(
+      (api as any).payments.billing.confirmProActivationPresentation,
+      { activationKey, claimNonce, outcomeTrackingVersion: 1 },
+    ) as Promise<boolean>,
+  );
 }
 
 export type ProActivationDay0Outcome =
@@ -209,14 +255,20 @@ export async function openProActivationDay0Presentation(
   claimNonce: string,
   sessionStartedAt: number,
 ): Promise<ProActivationDay0Outcome> {
+  const userId = requireSignedInUserId('open Pro activation');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  const result = await client.mutation(
-    (api as any).payments.billing.openProActivationDay0Presentation,
-    { activationKey, claimNonce, sessionStartedAt },
+  await requireCurrentConvexUser(userId, 'opening Pro activation');
+  const result = await settleAccountOperation(
+    userId,
+    'opening Pro activation',
+    () => client.mutation(
+      (api as any).payments.billing.openProActivationDay0Presentation,
+      { activationKey, claimNonce, sessionStartedAt },
+    ),
   ) as { status: ProActivationDay0Outcome };
+  assertAccountStillCurrent(userId, 'opening Pro activation');
   return result.status;
 }
 
@@ -250,14 +302,19 @@ export async function recordProActivationOutcome(
   claimNonce: string,
   outcome: ProActivationOutcomeSnapshot,
 ): Promise<boolean> {
+  const userId = requireSignedInUserId('record Pro activation');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  return await client.mutation(
-    (api as any).payments.billing.recordProActivationOutcome,
-    { activationKey, claimNonce, ...outcome },
-  ) as boolean;
+  await requireCurrentConvexUser(userId, 'recording Pro activation');
+  return settleAccountOperation(
+    userId,
+    'recording Pro activation',
+    () => client.mutation(
+      (api as any).payments.billing.recordProActivationOutcome,
+      { activationKey, claimNonce, ...outcome },
+    ) as Promise<boolean>,
+  );
 }
 
 const DODO_PORTAL_FALLBACK_URL = 'https://customer.dodopayments.com';
@@ -284,7 +341,8 @@ export function prereserveBillingPortalTab(): Window | null {
 
 export type OpenBillingPortalOutcome =
   | { outcome: 'opened'; url: string }
-  | { outcome: 'no-customer' };
+  | { outcome: 'no-customer' }
+  | { outcome: 'account-changed' };
 
 export async function openBillingPortal(
   preopened?: Window | null,
@@ -314,21 +372,36 @@ export async function openBillingPortal(
     if (reservedWin && !reservedWin.closed) reservedWin.close();
   };
 
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) return navigate(DODO_PORTAL_FALLBACK_URL);
+
   try {
     const client = await getConvexClient();
+    assertAccountStillCurrent(userId, 'opening the billing portal');
     if (!client) {
       return navigate(DODO_PORTAL_FALLBACK_URL);
     }
 
     const api = await getConvexApi();
+    assertAccountStillCurrent(userId, 'opening the billing portal');
     if (!api) {
       return navigate(DODO_PORTAL_FALLBACK_URL);
     }
 
-    const result = await client.action(api.payments.billing.getCustomerPortalUrl, {});
+    await requireCurrentConvexUser(userId, 'opening the billing portal');
+    const result = await settleAccountOperation(
+      userId,
+      'opening the billing portal',
+      () => client.action(api.payments.billing.getCustomerPortalUrl, {}),
+    );
+    assertAccountStillCurrent(userId, 'opening the billing portal');
     const url = (result?.portal_url as string | undefined) ?? DODO_PORTAL_FALLBACK_URL;
     return navigate(url);
   } catch (err) {
+    if (!isAccountStillCurrent(userId)) {
+      closeReserved();
+      return { outcome: 'account-changed' };
+    }
     // Convex object-data ConvexError surfaces `err.data.kind` reliably on the
     // wire; string-data and plain-Error throws arrive as
     // `[Request ID: X] Server Error` with `err.data === undefined`. Read kind
@@ -379,42 +452,74 @@ export interface ListBusinessSeatsResult {
 
 /** List the caller's Business Pro seats. Only the owner sees their own grants. */
 export async function listBusinessSeats(): Promise<ListBusinessSeatsResult> {
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) {
+    return { businessSubscriptionId: null, ownerDomain: null, ownerIsCorporateDomain: false, seats: [] };
+  }
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) {
     return { businessSubscriptionId: null, ownerDomain: null, ownerIsCorporateDomain: false, seats: [] };
   }
-  await waitForConvexAuth();
-  return client.query(api.payments.businessSeats.listSeats, {});
+  if (!await waitForConvexAuthForUser(userId)) {
+    assertAccountStillCurrent(userId, 'loading Business Pro seats');
+    throw new Error('Authentication unavailable while loading Business Pro seats. Try again.');
+  }
+  return settleAccountOperation(
+    userId,
+    'loading Business Pro seats',
+    () => client.query(api.payments.businessSeats.listSeats, {}),
+  );
 }
 
 /** Invite up to 4 same-domain teammates to Business Pro seats. */
 export async function inviteBusinessSeats(emails: string[]): Promise<{
   invited: Array<{ email: string; grantId: string; status: 'created' | 'already_pending' | 'already_accepted' }>;
 }> {
+  const userId = requireSignedInUserId('invite Business Pro seats');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  return client.mutation(api.payments.businessSeats.inviteSeats, { emails });
+  await requireCurrentConvexUser(userId, 'inviting Business Pro seats');
+  return settleAccountOperation(
+    userId,
+    'inviting Business Pro seats',
+    () => client.mutation(api.payments.businessSeats.inviteSeats, { emails }),
+  );
 }
 
 /** Remove a Business Pro seat (owner-only). */
 export async function removeBusinessSeat(
   grantId: string,
 ): Promise<{ ok: true; status: 'revoked' | 'already_inactive' }> {
+  const userId = requireSignedInUserId('remove a Business Pro seat');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  return client.mutation(api.payments.businessSeats.removeSeat, { grantId: grantId as Id<'businessProGrants'> });
+  await requireCurrentConvexUser(userId, 'removing a Business Pro seat');
+  return settleAccountOperation(
+    userId,
+    'removing a Business Pro seat',
+    () => client.mutation(
+      api.payments.businessSeats.removeSeat,
+      { grantId: grantId as Id<'businessProGrants'> },
+    ),
+  );
 }
 
 /** Accept a Business Pro seat invite using the token from the email link. */
 export async function acceptBusinessInvite(grantId: string, token: string): Promise<void> {
+  const userId = requireSignedInUserId('accept a Business Pro seat invite');
   const client = await getConvexClient();
   const api = await getConvexApi();
   if (!client || !api) throw new Error('Convex unavailable');
-  await waitForConvexAuth();
-  await client.mutation(api.payments.businessSeats.acceptBusinessInvite, { grantId: grantId as Id<'businessProGrants'>, token });
+  await requireCurrentConvexUser(userId, 'accepting a Business Pro seat invite');
+  await settleAccountOperation(
+    userId,
+    'accepting a Business Pro seat invite',
+    () => client.mutation(
+      api.payments.businessSeats.acceptBusinessInvite,
+      { grantId: grantId as Id<'businessProGrants'>, token },
+    ),
+  );
 }

--- a/src/services/convex-client.ts
+++ b/src/services/convex-client.ts
@@ -14,11 +14,26 @@ import { getClerkToken, clearClerkTokenCache, getCurrentClerkUser } from './cler
 
 // Use typeof to get the exact generated API type without importing statically
 type ConvexApi = typeof import('../../convex/_generated/api').api;
+type ConvexClientFactory = (url: string) => ConvexClient | Promise<ConvexClient>;
 
 let client: ConvexClient | null = null;
+let clientInitPromise: Promise<ConvexClient | null> | null = null;
+let clientFactoryForTests: ConvexClientFactory | null = null;
 let apiRef: ConvexApi | null = null;
-let authReadyResolve: (() => void) | null = null;
-let authReadyPromise: Promise<void> | null = null;
+
+interface ConvexAuthBarrier {
+  generation: number;
+  userId: string | null;
+  promise: Promise<boolean>;
+  settle: (ready: boolean) => void;
+}
+
+let authGeneration = 0;
+let authBarrier: ConvexAuthBarrier | null = null;
+let authRebindRequestGeneration = 0;
+let forceSignedOutAuth = false;
+
+const AUTH_REBIND_RETRY_DELAYS_MS = [1_000, 5_000, 15_000, 30_000] as const;
 
 // Per-Clerk-userId trigger for users:ensureRecord. The boolean flag is
 // per-app-lifetime; the userId guard is per-user. Sign-out clears the
@@ -31,31 +46,44 @@ let ensureRecordInFlight = false;
  * Returns the shared ConvexClient instance, creating it on first call.
  * Returns null if VITE_CONVEX_URL is not configured.
  */
-export async function getConvexClient(): Promise<ConvexClient | null> {
-  if (client) return client;
+function createAuthBarrier(
+  generation: number,
+  userId: string | null,
+): ConvexAuthBarrier {
+  let settled = false;
+  let resolvePromise: (ready: boolean) => void = () => {};
+  const promise = new Promise<boolean>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    generation,
+    userId,
+    promise,
+    settle: (ready) => {
+      if (settled) return;
+      settled = true;
+      resolvePromise(ready);
+    },
+  };
+}
 
-  const convexUrl = import.meta.env.VITE_CONVEX_URL;
-  if (!convexUrl) return null;
+/**
+ * Install a fresh Convex auth configuration and return the barrier owned by
+ * that exact configuration. Replacing the config pauses the SDK WebSocket
+ * while it fetches a token and waits for the server's auth transition.
+ */
+function installConvexAuth(
+  c: ConvexClient,
+  userId = getCurrentClerkUser()?.id ?? null,
+): ConvexAuthBarrier {
+  // Release any waiter owned by the superseded identity immediately. Its
+  // callback is generation-guarded below and can never settle this new barrier.
+  authBarrier?.settle(false);
+  const generation = ++authGeneration;
+  const barrier = createAuthBarrier(generation, userId);
+  authBarrier = barrier;
 
-  authReadyPromise = new Promise<void>((resolve) => { authReadyResolve = resolve; });
-
-  const { ConvexClient: CC } = await import('convex/browser');
-  try {
-    client = new CC(convexUrl);
-  } catch (err) {
-    // Firefox 149/Linux has been observed to reject the Convex constructor with
-    // "t is not a constructor" (WORLDMONITOR-N0/MX). Degrade to the null-client
-    // path instead of letting init error-bubble into Sentry — subscription features
-    // silently no-op, which matches the behavior when VITE_CONVEX_URL is unset.
-    // Also reset authReadyPromise: it was just created at the top of this function
-    // and would otherwise leave waitForConvexAuth() blocking for the full timeout
-    // for any future caller that doesn't pre-check the client is non-null.
-    console.warn('[convex-client] ConvexClient constructor rejected:', (err as Error).message);
-    authReadyPromise = null;
-    authReadyResolve = null;
-    return null;
-  }
-  client.setAuth(
+  c.setAuth(
     async ({ forceRefreshToken }: { forceRefreshToken?: boolean } = {}) => {
       if (forceRefreshToken) {
         clearClerkTokenCache();
@@ -63,18 +91,28 @@ export async function getConvexClient(): Promise<ConvexClient | null> {
       return getClerkToken();
     },
     (isAuthenticated: boolean) => {
+      // setAuth configs can overlap during a rapid A -> B -> C switch. A late
+      // server response from A/B belongs only to its captured generation.
+      if (
+        generation !== authGeneration ||
+        authBarrier !== barrier
+      ) {
+        return;
+      }
+
       if (isAuthenticated) {
-        if (authReadyResolve) {
-          authReadyResolve();
-          authReadyResolve = null;
-        }
+        barrier.settle(true);
         // Fire-and-forget: capture locale/timezone/country for this user.
         // Failure must not break the auth path. See callEnsureRecord docstring.
-        if (client) void callEnsureRecord(client);
+        void callEnsureRecord(c);
       } else {
-        // Sign-out or token expiry: reset the promise so the next
-        // waitForConvexAuth() blocks until re-authentication completes.
-        authReadyPromise = new Promise<void>((resolve) => { authReadyResolve = resolve; });
+        // Auth failure is terminal for this SDK config. Replace even an
+        // already-confirmed barrier with a false barrier so a true -> false
+        // callback pair cannot attach watches from the stale true result.
+        barrier.settle(false);
+        const failedBarrier = createAuthBarrier(generation, userId);
+        failedBarrier.settle(false);
+        authBarrier = failedBarrier;
         // Clear the ensureRecord flag so a subsequent sign-in (same OR
         // different user) re-fires. Cheap and safe; same-user re-sign-in
         // just rewrites the same data.
@@ -82,7 +120,73 @@ export async function getConvexClient(): Promise<ConvexClient | null> {
       }
     },
   );
+
+  return barrier;
+}
+
+function installSignedOutConvexAuth(c: ConvexClient): ConvexAuthBarrier {
+  authBarrier?.settle(false);
+  const generation = ++authGeneration;
+  const barrier = createAuthBarrier(generation, null);
+  authBarrier = barrier;
+
+  c.setAuth(
+    async () => null,
+    () => {
+      if (
+        generation !== authGeneration ||
+        authBarrier !== barrier
+      ) {
+        return;
+      }
+      // This config never supplies a credential. Treat every callback as
+      // signed-out and never run authenticated-user side effects.
+      barrier.settle(false);
+      lastEnsuredUserId = null;
+    },
+  );
+  return barrier;
+}
+
+async function createConvexClient(): Promise<ConvexClient | null> {
+  const convexUrl = typeof import.meta.env !== 'undefined'
+    ? import.meta.env.VITE_CONVEX_URL
+    : undefined;
+  if (!convexUrl && !clientFactoryForTests) return null;
+
+  try {
+    if (clientFactoryForTests) {
+      client = await clientFactoryForTests(convexUrl ?? 'test://convex');
+    } else {
+      const { ConvexClient: CC } = await import('convex/browser');
+      client = new CC(convexUrl!);
+    }
+  } catch (err) {
+    // Firefox 149/Linux has been observed to reject the Convex constructor with
+    // "t is not a constructor" (WORLDMONITOR-N0/MX). Degrade to the null-client
+    // path instead of letting init error-bubble into Sentry — subscription features
+    // silently no-op, which matches the behavior when VITE_CONVEX_URL is unset.
+    console.warn('[convex-client] ConvexClient constructor rejected:', (err as Error).message);
+    return null;
+  }
+  if (forceSignedOutAuth) {
+    installSignedOutConvexAuth(client);
+  } else {
+    installConvexAuth(client);
+  }
   return client;
+}
+
+export async function getConvexClient(): Promise<ConvexClient | null> {
+  if (client) return client;
+  if (clientInitPromise) return clientInitPromise;
+
+  clientInitPromise = createConvexClient();
+  try {
+    return await clientInitPromise;
+  } finally {
+    clientInitPromise = null;
+  }
 }
 
 /**
@@ -190,10 +294,203 @@ async function callEnsureRecord(c: ConvexClient): Promise<void> {
  * Times out after 10s to prevent indefinite hangs for unauthenticated users.
  */
 export async function waitForConvexAuth(timeoutMs = 10_000): Promise<boolean> {
-  if (!authReadyPromise) return false;
-  const timeout = new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), timeoutMs));
-  const result = await Promise.race([authReadyPromise.then(() => 'ready' as const), timeout]);
-  return result === 'ready';
+  const barrier = authBarrier;
+  if (!barrier) return false;
+
+  return waitForAuthBarrier(barrier, timeoutMs);
+}
+
+/**
+ * Wait for the exact Clerk user that initiated an account-bound operation.
+ *
+ * ConvexClient is shared across account switches. A plain auth wait can be
+ * superseded by another user's `setAuth`, so callers that mutate or reveal
+ * user-scoped data must capture their initiating user ID before any await and
+ * use this identity-bound gate immediately before the client operation.
+ */
+export async function waitForConvexAuthForUser(
+  userId: string,
+  timeoutMs = 10_000,
+): Promise<boolean> {
+  const barrier = authBarrier;
+  if (
+    !barrier ||
+    barrier.userId !== userId ||
+    getCurrentClerkUser()?.id !== userId
+  ) {
+    return false;
+  }
+
+  const ready = await waitForAuthBarrier(barrier, timeoutMs);
+  return (
+    ready &&
+    authBarrier === barrier &&
+    barrier.userId === userId &&
+    getCurrentClerkUser()?.id === userId
+  );
+}
+
+async function waitForAuthBarrier(
+  barrier: ConvexAuthBarrier,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<boolean>((resolve) => {
+    timeoutId = setTimeout(() => resolve(false), timeoutMs);
+  });
+  const ready = await Promise.race([barrier.promise, timeout]);
+  if (timeoutId !== null) clearTimeout(timeoutId);
+  return (
+    ready &&
+    barrier.generation === authGeneration &&
+    authBarrier === barrier
+  );
+}
+
+/**
+ * Rebind the singleton WebSocket to the Clerk identity that is current now.
+ *
+ * Clearing Clerk's cache invalidates both cached and in-flight tokens from the
+ * previous user. Repeating setAuth makes the Convex SDK pause the socket, fetch
+ * that current token, and wait for server confirmation. Each call owns a new
+ * generation, so an older callback cannot satisfy a newer user's barrier.
+ */
+async function startConvexAuthRebind(
+  isCurrent?: () => boolean,
+): Promise<ConvexAuthBarrier | null> {
+  // This must precede the first await. App starts the rebind before cloud-prefs
+  // work so both consumers can safely share the new user's subsequent token
+  // fetch; clearing again after an await would invalidate that in-flight token.
+  const requestGeneration = ++authRebindRequestGeneration;
+  const userId = getCurrentClerkUser()?.id ?? null;
+  forceSignedOutAuth = false;
+  clearClerkTokenCache();
+  try {
+    const c = await getConvexClient();
+    if (!c) return null;
+    if (
+      requestGeneration !== authRebindRequestGeneration ||
+      (isCurrent && !isCurrent()) ||
+      (userId !== null && getCurrentClerkUser()?.id !== userId)
+    ) {
+      return null;
+    }
+
+    return installConvexAuth(c, userId);
+  } catch (err) {
+    console.warn('[convex-client] Auth rebind failed:', (err as Error)?.message ?? err);
+    return null;
+  }
+}
+
+/**
+ * Complete a user-switch auth handoff before attaching user-scoped watches.
+ * `isCurrent` also covers sign-out, which does not need another setAuth call
+ * but must still invalidate an in-flight watch attachment.
+ */
+export async function rebindConvexAuthForWatchHandoff(
+  isCurrent: () => boolean,
+  attachWatches: () => void,
+  timeoutMs = 10_000,
+  retryDelaysMs: readonly number[] = AUTH_REBIND_RETRY_DELAYS_MS,
+): Promise<boolean> {
+  let attached = false;
+  const attachIfCurrent = (barrier: ConvexAuthBarrier): boolean => {
+    if (attached) return true;
+    if (
+      authBarrier !== barrier ||
+      barrier.generation !== authGeneration ||
+      !isCurrent()
+    ) {
+      return false;
+    }
+    attached = true;
+    attachWatches();
+    return true;
+  };
+
+  for (let attempt = 0; isCurrent(); attempt += 1) {
+    const barrier = await startConvexAuthRebind(isCurrent);
+    if (!barrier) return false;
+
+    const ready = await waitForAuthBarrier(barrier, timeoutMs);
+    if (ready) return attachIfCurrent(barrier);
+    if (!isCurrent()) return false;
+
+    // A slow/offline handshake may confirm just after the bounded wait. Keep a
+    // generation-scoped continuation so watches attach promptly while the
+    // bounded retry delay runs.
+    if (authBarrier === barrier) {
+      void barrier.promise.then((lateReady) => {
+        if (lateReady) attachIfCurrent(barrier);
+      }).catch((err: unknown) => {
+        console.warn('[convex-client] Late auth handoff failed:', (err as Error)?.message ?? err);
+      });
+    }
+
+    const retryDelayMs = retryDelaysMs[attempt];
+    if (retryDelayMs === undefined) return false;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, retryDelayMs);
+    });
+    if (attached) return true;
+  }
+  return false;
+}
+
+/**
+ * Invalidate every previous-user credential as soon as Clerk reports sign-out.
+ *
+ * Clearing the WebSocket identity and installing a fresh null-token config
+ * prevents both cached HTTP JWT reuse and late prior-generation Convex auth.
+ */
+export function invalidateConvexAuthForSignOut(): void {
+  forceSignedOutAuth = true;
+  clearClerkTokenCache();
+  authRebindRequestGeneration++;
+  authBarrier?.settle(false);
+  authBarrier = null;
+  authGeneration++;
+  lastEnsuredUserId = null;
+  ensureRecordInFlight = false;
+
+  if (!client) return;
+  try {
+    // setAuth synchronously resets the SDK auth manager and pauses its socket;
+    // this dedicated config can only return null, so the departing Clerk
+    // session can never be fetched again during the transition.
+    installSignedOutConvexAuth(client);
+  } catch (err) {
+    console.warn('[convex-client] Failed to install signed-out auth config:', (err as Error)?.message ?? err);
+  }
+}
+
+/**
+ * Install a structural Convex auth client for focused node tests.
+ * Production callers must never use this hook.
+ */
+export function __setConvexClientForTests(
+  testClient: Pick<ConvexClient, 'setAuth'> | null,
+): void {
+  authBarrier?.settle(false);
+  authBarrier = null;
+  authGeneration = 0;
+  authRebindRequestGeneration = 0;
+  forceSignedOutAuth = false;
+  clientInitPromise = null;
+  client = testClient as ConvexClient | null;
+  apiRef = null;
+  lastEnsuredUserId = null;
+  ensureRecordInFlight = false;
+  if (client) installConvexAuth(client);
+}
+
+/** Inject a cold-start client factory for singleton serialization tests. */
+export function __setConvexClientFactoryForTests(
+  factory: ConvexClientFactory | null,
+): void {
+  __setConvexClientForTests(null);
+  clientFactoryForTests = factory;
 }
 
 /**

--- a/src/services/entitlements.ts
+++ b/src/services/entitlements.ts
@@ -7,7 +7,13 @@
  * is not configured or ConvexClient is unavailable.
  */
 
-import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
+import {
+  getConvexClient,
+  getConvexApi,
+  waitForConvexAuth,
+  waitForConvexAuthForUser,
+} from './convex-client';
+import { getCurrentClerkUser } from './clerk';
 
 export interface EntitlementState {
   planKey: string;
@@ -76,8 +82,14 @@ function notifyListeners(state: EntitlementState | null): void {
  * Idempotent — calling multiple times is a no-op after the first.
  * Failures are logged but never thrown (dashboard must not break).
  */
-export async function initEntitlementSubscription(_userId?: string): Promise<void> {
-  if (initialized) return;
+export async function initEntitlementSubscription(
+  _userId?: string,
+  isCurrent: () => boolean = () => true,
+): Promise<void> {
+  const isExpectedAccount = (): boolean => (
+    isCurrent() && (_userId === undefined || getCurrentClerkUser()?.id === _userId)
+  );
+  if (initialized || !isExpectedAccount()) return;
 
   try {
     const client = await getConvexClient();
@@ -98,20 +110,25 @@ export async function initEntitlementSubscription(_userId?: string): Promise<voi
     // decision (the UI renders as free before the auth-ready pro snapshot
     // arrives). Unauthenticated visitors time out after 10s and we skip the
     // subscription entirely — they don't need entitlement updates.
-    const authed = await waitForConvexAuth(10_000);
+    const authed = _userId
+      ? await waitForConvexAuthForUser(_userId, 10_000)
+      : await waitForConvexAuth(10_000);
     if (!authed) {
       console.log('[entitlements] Convex auth not established — skipping subscription');
       return;
     }
+    if (!isExpectedAccount()) return;
 
     const watch = client.onUpdate(
       api.entitlements.getEntitlementsForUser,
       {},
       (result: EntitlementState | null) => {
+        if (!isExpectedAccount()) return;
         currentState = result;
         notifyListeners(result);
       },
       (err: Error) => {
+        if (!isExpectedAccount()) return;
         console.warn('[entitlements] Subscription query error:', err.message);
       },
     );

--- a/src/services/followed-countries.ts
+++ b/src/services/followed-countries.ts
@@ -46,7 +46,7 @@ import { subscribeAuthState as _subscribeAuthState } from './auth-state';
 import {
   getConvexClient as _getConvexClient,
   getConvexApi as _getConvexApi,
-  waitForConvexAuth as _waitForConvexAuth,
+  waitForConvexAuthForUser as _waitForConvexAuthForUser,
 } from './convex-client';
 import type {
   FollowMutationResult as ServerFollowMutationResult,
@@ -189,15 +189,17 @@ let _convexApiGetter: () => Promise<ConvexApiLike | null> = async () =>
  * was previously classified as PERMANENT, which clears localStorage
  * and loses the anonymous follows on every transient auth lag.
  *
- * Resolves to `true` when Convex auth lands; `false` if it doesn't
- * within the timeout window (which still falls through to the
- * mergeAnonymousLocal call — the catch path now treats UNAUTHENTICATED
- * as transient and the visibilitychange retry will succeed once
- * Convex catches up).
+ * Resolves to `true` when Convex auth lands for the captured Clerk user;
+ * `false` if it does not. A false result schedules the normal transient
+ * retry instead of letting another account's shared client perform the merge.
  */
-let _waitForConvexAuthFn: (timeoutMs?: number) => Promise<boolean> = (
+let _waitForConvexAuthFn: (
+  userId: string,
+  timeoutMs?: number,
+) => Promise<boolean> = (
+  userId,
   timeoutMs,
-) => _waitForConvexAuth(timeoutMs);
+) => _waitForConvexAuthForUser(userId, timeoutMs);
 
 /**
  * Test-only override hook. Pass `null` to restore the real
@@ -253,8 +255,10 @@ export function _setDepsForTests(deps: {
     }
   }
   if (deps.waitForConvexAuth !== undefined) {
-    _waitForConvexAuthFn =
-      deps.waitForConvexAuth ?? ((tm) => _waitForConvexAuth(tm));
+    const waitOverride = deps.waitForConvexAuth;
+    _waitForConvexAuthFn = waitOverride
+      ? (_userId, timeoutMs) => waitOverride(timeoutMs)
+      : (userId, timeoutMs) => _waitForConvexAuthForUser(userId, timeoutMs);
   }
 }
 
@@ -714,10 +718,10 @@ async function onAuthStateChange(
  * every transient auth lag. Two-part fix:
  *   (a) await `_waitForConvexAuthFn()` BEFORE the mutation call so the
  *       race usually doesn't fire at all;
- *   (b) treat UNAUTHENTICATED as transient if it still fires (e.g.,
- *       waitForConvexAuth timed out, or Convex auth dropped mid-call) —
- *       visibilitychange + max-retry path will re-attempt once Convex
- *       auth lands. UNAUTHENTICATED IS counted toward the max-retry
+ *   (b) fail closed and schedule a transient retry when the identity-bound
+ *       auth wait times out or is superseded; still treat UNAUTHENTICATED as
+ *       transient if auth drops after the guard and while the mutation is
+ *       in flight. UNAUTHENTICATED IS counted toward the max-retry
  *       budget (it's the same state-machine state as a network
  *       failure); a real persistent auth mismatch will eventually
  *       transition to 'failed-permanent' after MAX_HANDOFF_RETRIES.
@@ -773,10 +777,15 @@ async function _runHandoff(
     // setAuth callback runs on the next event-loop tick) and the server
     // throws UNAUTHENTICATED. waitForConvexAuth resolves to true once
     // the server confirms the client is authenticated, false on timeout.
-    // On timeout we still attempt the call — the catch below will treat
-    // any resulting UNAUTHENTICATED as transient and schedule a retry.
-    await _waitForConvexAuthFn();
+    // A timeout or superseded account is transient, but must fail closed:
+    // proceeding could merge this user's local list through another user's
+    // shared Convex socket.
+    const authed = await _waitForConvexAuthFn(userIdAtStart);
     if (!_authStillMatches(userIdAtStart, gen)) return;
+    if (!authed) {
+      _markFailedAndScheduleRetry(userIdAtStart, gen);
+      return;
+    }
     result = await client.mutation(
       api.followedCountries.mergeAnonymousLocal,
       { countries: localList },

--- a/src/services/mcp-clients.ts
+++ b/src/services/mcp-clients.ts
@@ -14,8 +14,16 @@
  *     of truth — no client-side enforcement, just display).
  */
 
-import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
-import { getClerkToken } from './clerk';
+import {
+  getConvexClient,
+  getConvexApi,
+  waitForConvexAuthForUser,
+} from './convex-client';
+import { getClerkToken, getCurrentClerkUser } from './clerk';
+import {
+  assertAccountStillCurrent,
+  settleAccountOperation,
+} from './account-operation';
 
 export interface McpClientInfo {
   id: string;
@@ -34,17 +42,26 @@ export interface McpQuota {
 
 /** List all Pro MCP tokens for the current user. */
 export async function listMcpClients(): Promise<McpClientInfo[]> {
-  const client = await getConvexClient();
-  const api = await getConvexApi();
-  if (!client || !api) return [];
+  const userId = getCurrentClerkUser()?.id;
+  if (!userId) return [];
 
-  await waitForConvexAuth();
+  const [client, api] = await Promise.all([getConvexClient(), getConvexApi()]);
+  if (!client || !api) return [];
+  if (!await waitForConvexAuthForUser(userId)) {
+    assertAccountStillCurrent(userId, 'loading MCP clients');
+    throw new Error('Authentication unavailable while loading MCP clients. Try again.');
+  }
 
   // Mirror services/api-keys.ts:listApiKeys cast pattern — the generated
   // Convex `api` is fully typed at module level but each service casts
   // `as any` at the call-site to avoid pulling the entire generated index
   // type into every service file.
-  const rows = await client.query((api as any).mcpProTokens.listProMcpTokens, {});
+  const rows = await settleAccountOperation(
+    userId,
+    'loading MCP clients',
+    () => client.query((api as any).mcpProTokens.listProMcpTokens, {}),
+  );
+  assertAccountStillCurrent(userId, 'loading MCP clients');
   return rows as McpClientInfo[];
 }
 

--- a/src/services/pro-banner-policy.ts
+++ b/src/services/pro-banner-policy.ts
@@ -73,6 +73,41 @@ export interface BannerPremiumResolution {
 }
 
 /**
+ * How long a previously confirmed account must report non-premium
+ * continuously before the banner may treat it as a real downgrade.
+ *
+ * Entitlement/auth transports can briefly disagree while reconnecting. The
+ * banner changes page geometry, so reacting to every contradictory snapshot
+ * turns a 500 ms transport flap into a full-page flicker.
+ */
+export const PRO_BANNER_DOWNGRADE_SETTLE_MS = 2_000;
+
+export interface ProBannerPremiumStabilityState {
+  /** Clerk identity the remembered account-backed verdict belongs to. */
+  userId: string | null;
+  /** True after a live Pro signal or a bounded post-checkout/browser hint. */
+  accountPremiumConfirmed: boolean;
+  /** First continuous non-premium observation for that confirmed account. */
+  freeSince: number | null;
+}
+
+export interface StableBannerPremiumInput {
+  now: number;
+  userId: string | null;
+  premiumHint: boolean;
+  live: BannerPremiumResolution;
+  previous: ProBannerPremiumStabilityState | null;
+}
+
+export interface StableBannerPremiumResolution extends BannerPremiumResolution {
+  state: ProBannerPremiumStabilityState;
+  /** True only while a contradictory non-premium snapshot is settling. */
+  heldPremium: boolean;
+  /** Caller should re-evaluate at this time if no newer snapshot arrives. */
+  recheckAt: number | null;
+}
+
+/**
  * Resolve effective premium for the Pro banner.
  *
  * Settled signed-out without local unlock keys → free, even if the entitlement
@@ -88,6 +123,107 @@ export function resolveBannerPremium(
   return {
     premium: input.rawPremium,
     accountBacked: input.accountBackedPremium,
+  };
+}
+
+/**
+ * Debounce only the dangerous Pro → free direction for the banner.
+ *
+ * A live account-backed Pro verdict is accepted immediately. Once confirmed,
+ * non-premium must remain continuous for PRO_BANNER_DOWNGRADE_SETTLE_MS before
+ * the upsell may mount. Any intervening Pro snapshot cancels that downgrade.
+ * The memory is scoped to a Clerk user and is cleared immediately on sign-out
+ * or account change, so one account can never keep another account's upsell
+ * hidden. A persisted premium hint seeds the same bounded window when a user
+ * first hydrates on a cold/post-checkout load; it is not trusted across a
+ * direct account switch or beyond the settle interval.
+ */
+export function stabilizeProBannerPremium(
+  input: StableBannerPremiumInput,
+): StableBannerPremiumResolution {
+  const identityChanged = input.previous?.userId !== input.userId;
+  const maySeedFromHint = input.previous === null || input.previous.userId === null;
+  let state: ProBannerPremiumStabilityState = identityChanged
+    ? {
+        userId: input.userId,
+        accountPremiumConfirmed:
+          input.userId !== null && maySeedFromHint && input.premiumHint,
+        freeSince: null,
+      }
+    : input.previous ?? {
+        userId: input.userId,
+        accountPremiumConfirmed: false,
+        freeSince: null,
+      };
+
+  if (input.userId === null) {
+    return {
+      ...input.live,
+      state: { userId: null, accountPremiumConfirmed: false, freeSince: null },
+      heldPremium: false,
+      recheckAt: null,
+    };
+  }
+
+  if (input.live.premium && input.live.accountBacked) {
+    state = {
+      userId: input.userId,
+      accountPremiumConfirmed: true,
+      freeSince: null,
+    };
+    return {
+      ...input.live,
+      state,
+      heldPremium: false,
+      recheckAt: null,
+    };
+  }
+
+  // A desktop/tester key already suppresses the banner. It must not become
+  // account evidence, but it also must not advance an account downgrade while
+  // the local unlock is active.
+  if (input.live.premium) {
+    state = { ...state, freeSince: null };
+    return {
+      ...input.live,
+      state,
+      heldPremium: false,
+      recheckAt: null,
+    };
+  }
+
+  if (!state.accountPremiumConfirmed) {
+    return {
+      ...input.live,
+      state,
+      heldPremium: false,
+      recheckAt: null,
+    };
+  }
+
+  const freeSince = state.freeSince ?? input.now;
+  const recheckAt = freeSince + PRO_BANNER_DOWNGRADE_SETTLE_MS;
+  if (input.now < recheckAt) {
+    state = { ...state, freeSince };
+    return {
+      premium: true,
+      accountBacked: false,
+      state,
+      heldPremium: true,
+      recheckAt,
+    };
+  }
+
+  state = {
+    userId: input.userId,
+    accountPremiumConfirmed: false,
+    freeSince: null,
+  };
+  return {
+    ...input.live,
+    state,
+    heldPremium: false,
+    recheckAt: null,
   };
 }
 

--- a/src/services/pro-banner-policy.ts
+++ b/src/services/pro-banner-policy.ts
@@ -59,10 +59,12 @@ export interface BannerPremiumResolutionInput {
   signedIn: boolean;
   /** Desktop API key / browser tester keys — local unlock, not an account. */
   localUnlockPremium: boolean;
-  /** hasPremiumAccess() (may include stale Convex entitlement). */
-  rawPremium: boolean;
-  /** Convex isEntitled() or Clerk plan/role pro. */
-  accountBackedPremium: boolean;
+  /** Clerk plan/role evidence bound to the current signed-in user ID. */
+  identityBoundPremium: boolean;
+  /** Convex entitlement evidence whose snapshot carries no user ID. */
+  unscopedAccountPremium: boolean;
+  /** Whether the unscoped snapshot has been rebound to the current identity. */
+  acceptUnscopedAccountPremium: boolean;
 }
 
 export interface BannerPremiumResolution {
@@ -112,7 +114,9 @@ export interface StableBannerPremiumResolution extends BannerPremiumResolution {
  *
  * Settled signed-out without local unlock keys → free, even if the entitlement
  * module still holds a previous-account snapshot (sign-out races App's
- * resetEntitlementState against ProBanner's auth listener).
+ * resetEntitlementState against ProBanner's auth listener). Direct account
+ * switches may likewise quarantine that unscoped snapshot until App publishes
+ * its reset; current-user Clerk plan/role and local unlock evidence remain safe.
  */
 export function resolveBannerPremium(
   input: BannerPremiumResolutionInput,
@@ -120,9 +124,13 @@ export function resolveBannerPremium(
   if (!input.authPending && !input.signedIn && !input.localUnlockPremium) {
     return { premium: false, accountBacked: false };
   }
+  const accountBacked = (
+    input.identityBoundPremium ||
+    (input.acceptUnscopedAccountPremium && input.unscopedAccountPremium)
+  );
   return {
-    premium: input.rawPremium,
-    accountBacked: input.accountBackedPremium,
+    premium: input.localUnlockPremium || accountBacked,
+    accountBacked,
   };
 }
 

--- a/tests/business-invite-wiring.test.mts
+++ b/tests/business-invite-wiring.test.mts
@@ -21,11 +21,29 @@ describe('App.ts accept-business-invite URL flow wiring', () => {
 
   it('waits for Convex auth before calling acceptBusinessInvite, and bails without side effects if it times out', async () => {
     const src = await read('src/App.ts');
-    assert.match(src, /const ready = await waitForConvexAuth\(10_000\);/);
+    assert.match(src, /const ready = await waitForConvexAuthForUser\(userId, 10_000\);/);
     assert.match(
       src,
       /if \(!ready\) \{\s*\n\s*console\.warn\('\[business-seats\] acceptBusinessInvite skipped — Convex auth not ready'\);\s*\n\s*return;\s*\n\s*\}/,
       'a timed-out auth wait must return before calling the mutation, not attempt it anonymously',
+    );
+  });
+
+  it('binds the mutation settlement and success toast to the initiating account', async () => {
+    const src = await read('src/App.ts');
+    assert.match(
+      src,
+      /await settleAccountOperation\(\s*userId,\s*'accepting the Business Pro seat invite',\s*\(\) => client\.mutation\(/,
+    );
+    assert.match(
+      src,
+      /assertAccountStillCurrent\(userId, 'accepting the Business Pro seat invite'\);\s*\n\s*showToast\('Pro seat activated'\)/,
+      'a late A mutation must not show its success toast after Clerk selects B',
+    );
+    assert.match(
+      src,
+      /\} catch \(err\) \{\s*\n\s*if \(!isAccountStillCurrent\(userId\)\) return;/,
+      'errors from a departed account must stay silent in the new account UI',
     );
   });
 

--- a/tests/convex-auth-handoff.test.mts
+++ b/tests/convex-auth-handoff.test.mts
@@ -1,0 +1,778 @@
+/**
+ * Direct-account handoff coverage for the shared Convex client.
+ *
+ * The entitlement and billing watches are user-scoped on the server even
+ * though their query args are empty. They therefore must not attach until the
+ * singleton WebSocket has confirmed the newly selected Clerk identity.
+ */
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  __setConvexClientFactoryForTests,
+  __setConvexClientForTests,
+  getConvexClient,
+  invalidateConvexAuthForSignOut,
+  rebindConvexAuthForWatchHandoff,
+  waitForConvexAuth,
+} from '../src/services/convex-client.ts';
+import { createApiKey, listApiKeys } from '../src/services/api-keys.ts';
+import {
+  acknowledgePlanLimitNotice,
+  listCurrentPlanLimitNotices,
+} from '../src/services/api-plan-limit-notices.ts';
+import { listMcpClients } from '../src/services/mcp-clients.ts';
+import { settleAccountOperation } from '../src/services/account-operation.ts';
+import {
+  __setClerkInstanceForTests,
+  getClerkToken,
+} from '../src/services/clerk.ts';
+import { startAccountAuthHandoff } from '../src/app/account-auth-handoff.ts';
+import {
+  destroyEntitlementSubscription,
+  initEntitlementSubscription,
+} from '../src/services/entitlements.ts';
+import {
+  destroySubscriptionWatch,
+  getSubscription,
+  initSubscriptionWatch,
+  listBusinessSeats,
+  openBillingPortal,
+} from '../src/services/billing.ts';
+
+type TokenFetcher = (args?: { forceRefreshToken?: boolean }) => Promise<string | null>;
+type AuthCallback = (isAuthenticated: boolean) => void;
+
+class FakeConvexClient {
+  readonly authConfigs: Array<{
+    fetchToken: TokenFetcher;
+    onChange: AuthCallback;
+  }> = [];
+  readonly watchAttachments: unknown[] = [];
+  readonly mutations: unknown[][] = [];
+  readonly queries: unknown[][] = [];
+  readonly actions: unknown[][] = [];
+  mutationResult: Promise<unknown> | null = null;
+  queryResult: Promise<unknown> | null = null;
+  actionResult: Promise<unknown> | null = null;
+
+  setAuth(fetchToken: TokenFetcher, onChange: AuthCallback): void {
+    this.authConfigs.push({ fetchToken, onChange });
+  }
+
+  onUpdate(...args: unknown[]): (() => void) & { unsubscribe: () => void } {
+    this.watchAttachments.push(args);
+    const unsubscribe = () => {};
+    return Object.assign(unsubscribe, { unsubscribe });
+  }
+
+  mutation(...args: unknown[]): Promise<unknown> {
+    this.mutations.push(args);
+    if (this.mutationResult) return this.mutationResult;
+    const input = args[1] as { name?: string; keyPrefix?: string } | undefined;
+    return Promise.resolve({
+      id: 'key_1',
+      name: input?.name ?? '',
+      keyPrefix: input?.keyPrefix ?? '',
+    });
+  }
+
+  query(...args: unknown[]): Promise<unknown> {
+    this.queries.push(args);
+    return this.queryResult ?? Promise.resolve([]);
+  }
+
+  action(...args: unknown[]): Promise<unknown> {
+    this.actions.push(args);
+    return this.actionResult ?? Promise.resolve({});
+  }
+}
+
+const flushMicrotasks = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+async function waitForCalls(calls: unknown[][], expected: number): Promise<void> {
+  for (let attempt = 0; attempt < 20 && calls.length < expected; attempt += 1) {
+    await flushMicrotasks();
+  }
+  assert.equal(calls.length, expected);
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolvePromise: (value: T) => void = () => {};
+  let rejectPromise: (reason: unknown) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function installFakeClient(): FakeConvexClient {
+  const fake = new FakeConvexClient();
+  __setConvexClientForTests(fake);
+  assert.equal(fake.authConfigs.length, 1, 'test install should model the initial A auth binding');
+  return fake;
+}
+
+afterEach(() => {
+  destroyEntitlementSubscription();
+  destroySubscriptionWatch();
+  __setConvexClientFactoryForTests(null);
+  __setConvexClientForTests(null);
+  __setClerkInstanceForTests(null);
+});
+
+describe('generation-scoped Convex auth handoff', () => {
+  it('does not let A readiness satisfy B and attaches B watches only after B server confirmation', async () => {
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(true);
+    assert.equal(await waitForConvexAuth(50), true, 'A starts from an already-confirmed socket');
+
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => attached.push('B'),
+      1_000,
+      [],
+    );
+    await flushMicrotasks();
+
+    assert.equal(fake.authConfigs.length, 2, 'B must install a fresh Convex auth config');
+    assert.deepEqual(attached, [], 'A readiness must not attach B watches');
+
+    // Even a late callback from A cannot resolve B's generation.
+    fake.authConfigs[0].onChange(true);
+    await flushMicrotasks();
+    assert.deepEqual(attached, [], 'an old auth callback must not resolve the B barrier');
+
+    fake.authConfigs[1].onChange(true);
+    assert.equal(await handoff, true);
+    assert.deepEqual(attached, ['B'], 'B watches attach after B is confirmed by the server');
+  });
+
+  it('supersedes an overlapping B rebind so only current C can attach watches', async () => {
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(true);
+
+    let currentUserId = 'B';
+    const attached: string[] = [];
+    const handoffB = rebindConvexAuthForWatchHandoff(
+      () => currentUserId === 'B',
+      () => attached.push('B'),
+      1_000,
+    );
+    await flushMicrotasks();
+    assert.equal(fake.authConfigs.length, 2);
+
+    currentUserId = 'C';
+    const handoffC = rebindConvexAuthForWatchHandoff(
+      () => currentUserId === 'C',
+      () => attached.push('C'),
+      1_000,
+    );
+    await flushMicrotasks();
+    assert.equal(fake.authConfigs.length, 3);
+
+    // B's server response arrives after C became current. Its callback belongs
+    // to a superseded auth generation and must be inert.
+    fake.authConfigs[1].onChange(true);
+    assert.equal(await handoffB, false);
+    assert.deepEqual(attached, []);
+
+    fake.authConfigs[2].onChange(true);
+    assert.equal(await handoffC, true);
+    assert.deepEqual(attached, ['C']);
+  });
+
+  it('treats a same-config true then false callback as unauthenticated', async () => {
+    const fake = installFakeClient();
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => attached.push('B'),
+      1_000,
+      [],
+    );
+    await flushMicrotasks();
+
+    fake.authConfigs[1].onChange(true);
+    fake.authConfigs[1].onChange(false);
+
+    assert.equal(await handoff, false);
+    assert.deepEqual(attached, []);
+    assert.equal(await waitForConvexAuth(10), false);
+  });
+
+  it('fails closed on terminal auth failure while the identity remains current', async () => {
+    const fake = installFakeClient();
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => attached.push('B'),
+      1_000,
+      [],
+    );
+    await flushMicrotasks();
+
+    fake.authConfigs[1].onChange(false);
+
+    assert.equal(await handoff, false);
+    assert.deepEqual(attached, []);
+  });
+
+  it('retries a transient terminal token failure for the current identity', async () => {
+    const fake = installFakeClient();
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => attached.push('B'),
+      1_000,
+      [1],
+    );
+    await flushMicrotasks();
+
+    fake.authConfigs[1].onChange(false);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+    assert.equal(fake.authConfigs.length, 3, 'current B should install one bounded retry config');
+
+    fake.authConfigs[2].onChange(true);
+    assert.equal(await handoff, true);
+    assert.deepEqual(attached, ['B']);
+  });
+
+  it('recovers current-user watches after a bounded wait times out', async () => {
+    const fake = installFakeClient();
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => attached.push('B'),
+      5,
+      [],
+    );
+    await flushMicrotasks();
+
+    assert.equal(await handoff, false);
+    assert.deepEqual(attached, []);
+
+    fake.authConfigs[1].onChange(true);
+    await flushMicrotasks();
+    assert.deepEqual(attached, ['B']);
+  });
+
+  it('does not attach after auth succeeds for an identity that signed out', async () => {
+    const fake = installFakeClient();
+    let current = true;
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => current,
+      () => attached.push('B'),
+      1_000,
+    );
+    await flushMicrotasks();
+
+    current = false;
+    fake.authConfigs[1].onChange(true);
+
+    assert.equal(await handoff, false);
+    assert.deepEqual(attached, []);
+  });
+
+  it('invalidates the old token before, but not during, the new token fetch', async () => {
+    const fake = installFakeClient();
+    const token = deferred<string | null>();
+    let tokenFetches = 0;
+    __setClerkInstanceForTests({
+      session: {
+        getToken: async () => {
+          tokenFetches += 1;
+          return token.promise;
+        },
+      },
+      user: {
+        id: 'B',
+      },
+    } as never);
+
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => {},
+      1_000,
+    );
+    const cloudPrefsToken = getClerkToken();
+    await flushMicrotasks();
+
+    assert.equal(fake.authConfigs.length, 2);
+    const convexToken = fake.authConfigs[1].fetchToken();
+    token.resolve('token-b');
+
+    assert.equal(await cloudPrefsToken, 'token-b');
+    assert.equal(await convexToken, 'token-b');
+    assert.equal(tokenFetches, 1, 'Convex and cloud prefs should share B token fetch');
+
+    fake.authConfigs[1].onChange(true);
+    assert.equal(await handoff, true);
+  });
+
+  it('cancels async watch initialization when the selected identity changes', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-b' },
+      user: { id: 'B' },
+    } as never);
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(true);
+    let current = true;
+
+    const entitlementInit = initEntitlementSubscription('B', () => current);
+    const billingInit = initSubscriptionWatch('B', () => current);
+    current = false;
+
+    await Promise.all([entitlementInit, billingInit]);
+    assert.equal(fake.watchAttachments.length, 0);
+  });
+
+  it('invalidates cached, in-flight, and Convex credentials on sign-out', async () => {
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(true);
+    const oldAuthCallback = fake.authConfigs[0].onChange;
+    const token = deferred<string | null>();
+    __setClerkInstanceForTests({
+      session: {
+        getToken: async () => token.promise,
+      },
+      user: {
+        id: 'B',
+      },
+    } as never);
+
+    const inFlightToken = getClerkToken();
+    invalidateConvexAuthForSignOut();
+    assert.equal(fake.authConfigs.length, 2);
+
+    // Model Clerk completing the same observed sign-out transition.
+    __setClerkInstanceForTests(null);
+    token.resolve('token-b');
+    assert.equal(await inFlightToken, null);
+    assert.equal(await getClerkToken(), null);
+
+    // The old server callback is inert, and the dedicated replacement config
+    // can never fetch the departing session.
+    oldAuthCallback(true);
+    assert.equal(await fake.authConfigs[1].fetchToken(), null);
+    fake.authConfigs[1].onChange(false);
+    assert.equal(await waitForConvexAuth(10), false);
+  });
+
+  it('does not dispatch an API-key create if A changes while auth is pending', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const fake = installFakeClient();
+
+    // Leave A's barrier unresolved so the sensitive operation is in flight
+    // when Clerk selects B.
+    const createRejected = assert.rejects(
+      createApiKey('A key'),
+      /Account changed while creating the API key/,
+    );
+    await flushMicrotasks();
+
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-b' },
+      user: { id: 'B' },
+    } as never);
+    const handoffB = rebindConvexAuthForWatchHandoff(
+      () => true,
+      () => {},
+      1_000,
+      [],
+    );
+    await flushMicrotasks();
+
+    await createRejected;
+    assert.equal(fake.mutations.length, 0, 'no account-bound mutation may cross the switch');
+
+    fake.authConfigs[1].onChange(true);
+    assert.equal(await handoffB, true);
+  });
+
+  it('checks the initiating account immediately before dispatch', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-b' },
+      user: { id: 'B' },
+    } as never);
+    let dispatched = false;
+
+    await assert.rejects(
+      settleAccountOperation('A', 'running the operation', async () => {
+        dispatched = true;
+      }),
+      /Account changed while running the operation/,
+    );
+    assert.equal(dispatched, false);
+  });
+
+  it('masks an A-specific rejection when the operation rejects after B is selected', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const operation = deferred<string>();
+    const rejected = assert.rejects(
+      settleAccountOperation('A', 'loading private account data', () => operation.promise),
+      /Account changed while loading private account data/,
+    );
+
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-b' },
+      user: { id: 'B' },
+    } as never);
+    operation.reject(new Error('A-specific backend detail'));
+
+    await rejected;
+  });
+
+  it('preserves the original rejection while the initiating account remains current', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const operation = deferred<string>();
+    const original = new Error('same-account backend detail');
+    const rejected = assert.rejects(
+      settleAccountOperation('A', 'loading private account data', () => operation.promise),
+      (err) => err === original,
+    );
+
+    operation.reject(original);
+    await rejected;
+  });
+
+  it('surfaces current-account auth outages instead of rendering empty account lists', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(false);
+
+    const cases: Array<[string, () => Promise<unknown>]> = [
+      ['API keys', listApiKeys],
+      ['MCP clients', listMcpClients],
+      ['API plan-limit notices', listCurrentPlanLimitNotices],
+      ['Business Pro seats', listBusinessSeats],
+    ];
+    for (const [label, operation] of cases) {
+      await assert.rejects(
+        operation(),
+        new RegExp(`Authentication unavailable while loading ${label}`),
+      );
+    }
+  });
+
+  it('rejects an A API key that resolves after Clerk selects B', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(true);
+    const mutation = deferred<{
+      id: string;
+      name: string;
+      keyPrefix: string;
+    }>();
+    fake.mutationResult = mutation.promise;
+
+    const rejected = assert.rejects(
+      createApiKey('A key'),
+      /Account changed while creating the API key/,
+    );
+    await waitForCalls(fake.mutations, 1);
+
+    mutation.resolve({ id: 'key_a', name: 'A key', keyPrefix: 'wm_a' });
+    queueMicrotask(() => {
+      __setClerkInstanceForTests({
+        session: { getToken: async () => 'token-b' },
+        user: { id: 'B' },
+      } as never);
+    });
+
+    await rejected;
+    assert.equal(fake.mutations.length, 1, 'the A mutation completed, but its plaintext stayed discarded');
+  });
+
+  it('rejects a notice acknowledgement when the identity-bound auth gate fails', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(false);
+
+    await assert.rejects(
+      acknowledgePlanLimitNotice('notice-a'),
+      /Account changed while acknowledging the API plan-limit notice/,
+    );
+    assert.equal(fake.mutations.length, 0);
+  });
+
+  it('discards account-scoped list results that settle after A changes to B', async () => {
+    const cases = [
+      ['API keys', listApiKeys],
+      ['MCP clients', listMcpClients],
+      ['plan-limit notices', listCurrentPlanLimitNotices],
+      ['Business seats', listBusinessSeats],
+    ] as const;
+
+    for (const [label, load] of cases) {
+      __setClerkInstanceForTests({
+        session: { getToken: async () => 'token-a' },
+        user: { id: 'A' },
+      } as never);
+      const fake = installFakeClient();
+      fake.authConfigs[0].onChange(true);
+      const query = deferred<unknown>();
+      fake.queryResult = query.promise;
+
+      const rejected = assert.rejects(
+        load(),
+        /Account changed while/,
+        `${label} must not cross the account handoff`,
+      );
+      await waitForCalls(fake.queries, 1);
+
+      __setClerkInstanceForTests({
+        session: { getToken: async () => 'token-b' },
+        user: { id: 'B' },
+      } as never);
+      query.resolve([]);
+
+      await rejected;
+      __setConvexClientForTests(null);
+    }
+  });
+
+  it('closes the reserved tab instead of navigating B to A billing portal', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const fake = installFakeClient();
+    fake.authConfigs[0].onChange(true);
+    const action = deferred<{ portal_url: string }>();
+    fake.actionResult = action.promise;
+    const reserved = {
+      closed: false,
+      location: { href: '' },
+      close() {
+        this.closed = true;
+      },
+    };
+
+    const opening = openBillingPortal(reserved as never);
+    await waitForCalls(fake.actions, 1);
+
+    action.resolve({ portal_url: 'https://portal.example/account-a-secret' });
+    queueMicrotask(() => {
+      __setClerkInstanceForTests({
+        session: { getToken: async () => 'token-b' },
+        user: { id: 'B' },
+      } as never);
+    });
+
+    assert.deepEqual(await opening, { outcome: 'account-changed' });
+    assert.equal(reserved.closed, true);
+    assert.equal(reserved.location.href, '', 'A portal URL must never be assigned');
+  });
+
+  it('drops a late billing-watch snapshot after its account handoff is stale', async () => {
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-a' },
+      user: { id: 'A' },
+    } as never);
+    const fake = installFakeClient();
+    await initSubscriptionWatch('A');
+    assert.equal(fake.watchAttachments.length, 1);
+
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-b' },
+      user: { id: 'B' },
+    } as never);
+    const onResult = fake.watchAttachments[0]?.[2] as (
+      result: { planKey: string } | null,
+    ) => void;
+    onResult({ planKey: 'pro' });
+
+    assert.equal(getSubscription(), null);
+  });
+});
+
+describe('cold Convex singleton initialization', () => {
+  it('constructs one client and installs one auth config for concurrent callers', async () => {
+    const fake = new FakeConvexClient();
+    const releaseFactory = deferred<void>();
+    let factoryCalls = 0;
+    __setConvexClientFactoryForTests(async () => {
+      factoryCalls += 1;
+      await releaseFactory.promise;
+      return fake as never;
+    });
+
+    const first = getConvexClient();
+    const second = getConvexClient();
+    assert.equal(factoryCalls, 1);
+
+    releaseFactory.resolve();
+    const [firstClient, secondClient] = await Promise.all([first, second]);
+
+    assert.equal(factoryCalls, 1);
+    assert.strictEqual(firstClient, secondClient);
+    assert.strictEqual(firstClient, fake);
+    assert.equal(fake.authConfigs.length, 1);
+  });
+
+  it('keeps only the latest account rebind when cold initialization resolves out of order', async () => {
+    const fake = new FakeConvexClient();
+    const releaseFactory = deferred<void>();
+    __setConvexClientFactoryForTests(async () => {
+      await releaseFactory.promise;
+      return fake as never;
+    });
+
+    let currentUserId = 'B';
+    const attached: string[] = [];
+    const handoffB = rebindConvexAuthForWatchHandoff(
+      () => currentUserId === 'B',
+      () => attached.push('B'),
+      1_000,
+      [],
+    );
+    currentUserId = 'C';
+    const handoffC = rebindConvexAuthForWatchHandoff(
+      () => currentUserId === 'C',
+      () => attached.push('C'),
+      1_000,
+      [],
+    );
+
+    releaseFactory.resolve();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    assert.equal(await handoffB, false);
+    assert.equal(fake.authConfigs.length, 2, 'initial config plus latest C rebind only');
+    fake.authConfigs[1].onChange(true);
+    assert.equal(await handoffC, true);
+    assert.deepEqual(attached, ['C']);
+  });
+
+  it('installs only a null-token auth config when sign-out wins cold creation', async () => {
+    const fake = new FakeConvexClient();
+    const releaseFactory = deferred<void>();
+    __setClerkInstanceForTests({
+      session: { getToken: async () => 'token-b' },
+      user: { id: 'B' },
+    } as never);
+    __setConvexClientFactoryForTests(async () => {
+      await releaseFactory.promise;
+      return fake as never;
+    });
+
+    let current = true;
+    const attached: string[] = [];
+    const handoff = rebindConvexAuthForWatchHandoff(
+      () => current,
+      () => attached.push('B'),
+      1_000,
+      [],
+    );
+
+    current = false;
+    invalidateConvexAuthForSignOut();
+    __setClerkInstanceForTests(null);
+    releaseFactory.resolve();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    assert.equal(await handoff, false);
+    assert.deepEqual(attached, []);
+    assert.equal(fake.authConfigs.length, 1, 'cold client must install only signed-out auth');
+    assert.equal(await fake.authConfigs[0].fetchToken(), null);
+  });
+});
+
+describe('App account-switch controller', () => {
+  it('resets state, starts rebind before cloud prefs, and nests watch attachment', async () => {
+    const events: string[] = [];
+    const completion = deferred<boolean>();
+    let attachWatches: (() => void) | null = null;
+
+    const handoff = startAccountAuthHandoff({
+      userId: 'B',
+      isCurrent: () => true,
+      effects: {
+        destroyEntitlementSubscription: () => events.push('destroy-entitlement'),
+        resetEntitlementState: () => events.push('reset-entitlement'),
+        destroySubscriptionWatch: () => events.push('destroy-billing'),
+        rebindConvexAuthForWatchHandoff: (isCurrent, attach) => {
+          events.push('rebind');
+          assert.equal(isCurrent(), true);
+          attachWatches = attach;
+          return completion.promise;
+        },
+        initEntitlementSubscription: (userId) => {
+          events.push(`attach-entitlement:${userId}`);
+        },
+        initSubscriptionWatch: (userId) => {
+          events.push(`attach-billing:${userId}`);
+        },
+        cloudPrefsSignIn: (userId) => {
+          events.push(`cloud-prefs:${userId}`);
+        },
+      },
+    });
+
+    assert.deepEqual(events, [
+      'destroy-entitlement',
+      'reset-entitlement',
+      'destroy-billing',
+      'rebind',
+      'cloud-prefs:B',
+    ]);
+
+    assert.ok(attachWatches);
+    attachWatches();
+    assert.deepEqual(events.slice(-2), [
+      'attach-entitlement:B',
+      'attach-billing:B',
+    ]);
+
+    completion.resolve(true);
+    assert.equal(await handoff, true);
+  });
+
+  it('wires App through the tested account-handoff controller', async () => {
+    const app = await readFile(new URL('../src/App.ts', import.meta.url), 'utf8');
+    const branch = app.match(
+      /if \(userId !== null && userId !== _prevUserId\) \{[\s\S]*?\/\/ Claim any anonymous purchase/,
+    )?.[0];
+    assert.ok(branch, 'expected the signed-in identity-change branch');
+    assert.match(branch, /startAccountAuthHandoff\(\{/);
+    assert.match(branch, /getAuthState\(\)\.user\?\.id === userId/);
+    assert.match(branch, /resetEntitlementState,/);
+    assert.match(branch, /rebindConvexAuthForWatchHandoff,/);
+    assert.match(branch, /cloudPrefsSignIn: \(nextUserId\)/);
+    assert.match(
+      app,
+      /else if \(userId === null && _prevUserId !== null\) \{[\s\S]*?invalidateConvexAuthForSignOut\(\);/,
+    );
+  });
+});

--- a/tests/dom/entitlement-watch-fanout.test.mts
+++ b/tests/dom/entitlement-watch-fanout.test.mts
@@ -23,6 +23,8 @@ type UpdateCallback = (result: Snapshot) => void;
 /** The callback `initEntitlementSubscription` registers with `client.onUpdate`. */
 let captured: UpdateCallback | null = null;
 let unsubscribed = 0;
+let watchCurrent = true;
+let watchUserId = 'user_1';
 
 vi.mock('@/services/convex-client', () => ({
   getConvexClient: async () => ({
@@ -33,6 +35,10 @@ vi.mock('@/services/convex-client', () => ({
   }),
   getConvexApi: async () => ({ entitlements: { getEntitlementsForUser: 'q' } }),
   waitForConvexAuth: async () => true,
+  waitForConvexAuthForUser: async () => true,
+}));
+vi.mock('@/services/clerk', () => ({
+  getCurrentClerkUser: () => ({ id: watchUserId }),
 }));
 
 const {
@@ -50,10 +56,12 @@ let cleanup: Array<() => void> = [];
 beforeEach(async () => {
   captured = null;
   unsubscribed = 0;
+  watchCurrent = true;
+  watchUserId = 'user_1';
   cleanup = [];
   // `initialized` latches after the first success, so tear down between cases.
   destroyEntitlementSubscription();
-  await initEntitlementSubscription('user_1');
+  await initEntitlementSubscription('user_1', () => watchCurrent);
   expect(captured).not.toBeNull();
 });
 
@@ -93,5 +101,16 @@ describe('Convex watch fan-out (#5632)', () => {
     captured!(PRO);
 
     expect(getEntitlementState()).toEqual(PRO);
+  });
+
+  it('drops a late snapshot after the account handoff becomes stale', () => {
+    const seen: Snapshot[] = [];
+    subscribe((state) => seen.push(state));
+    watchUserId = 'user_2';
+
+    captured!(PRO);
+
+    expect(getEntitlementState()).toBeNull();
+    expect(seen).toEqual([]);
   });
 });

--- a/tests/dom/pro-banner-premium-stability.test.mts
+++ b/tests/dom/pro-banner-premium-stability.test.mts
@@ -1,0 +1,157 @@
+/**
+ * Runtime DOM coverage for the confirmed-Pro banner anti-flap path.
+ *
+ * The pure policy suite proves the time/state reducer. This test drives the
+ * real ProBanner subscriptions, timer, reservation class, and DOM mount/remove
+ * behavior so a future wiring regression cannot pass on the reducer alone.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Session = import('@/services/auth-state').AuthSession;
+type Entitlement = import('@/services/entitlements').EntitlementState;
+
+let livePremium = true;
+const session: Session = {
+  user: {
+    id: 'user_pro',
+    name: 'Pro User',
+    email: 'pro@example.com',
+    role: 'free',
+  },
+  isPending: false,
+};
+const entitlementListeners: Array<() => void> = [];
+const storageValues = new Map<string, string>();
+const storage: Storage = {
+  get length() { return storageValues.size; },
+  clear: () => storageValues.clear(),
+  getItem: (key) => storageValues.get(key) ?? null,
+  key: (index) => [...storageValues.keys()][index] ?? null,
+  removeItem: (key) => { storageValues.delete(key); },
+  setItem: (key, value) => { storageValues.set(key, value); },
+};
+
+function entitlement(): Entitlement {
+  return {
+    planKey: livePremium ? 'pro' : 'free',
+    features: {
+      tier: livePremium ? 1 : 0,
+      apiAccess: livePremium,
+      apiRateLimit: livePremium ? 1_000 : 0,
+      maxDashboards: livePremium ? 10 : 3,
+      prioritySupport: false,
+      exportFormats: [],
+    },
+    validUntil: Date.now() + 86_400_000,
+  };
+}
+
+vi.mock('@/services/analytics', () => ({ trackGateHit: vi.fn() }));
+vi.mock('@/services/panel-gating', () => ({
+  hasPremiumAccess: () => livePremium,
+}));
+vi.mock('@/services/entitlements', () => ({
+  getEntitlementState: () => entitlement(),
+  isEntitled: () => livePremium,
+  onEntitlementChange: (fn: () => void) => {
+    entitlementListeners.push(fn);
+    return () => {};
+  },
+}));
+vi.mock('@/services/billing', () => ({
+  getSubscription: () => null,
+  onSubscriptionChange: () => () => {},
+}));
+vi.mock('@/services/billing-state', () => ({
+  deriveBillingUxState: () => 'free',
+  getReactivationHref: () => '/pro#pricing',
+}));
+vi.mock('@/services/auth-state', () => ({
+  getAuthState: () => session,
+  subscribeAuthState: (fn: (value: Session) => void) => {
+    fn(session);
+    return () => {};
+  },
+}));
+vi.mock('@/services/clerk', () => ({
+  getCurrentClerkUser: () => ({
+    id: session.user!.id,
+    name: session.user!.name,
+    email: session.user!.email,
+    image: null,
+    plan: 'free' as const,
+  }),
+  isClerkAuthEnabled: () => true,
+}));
+vi.mock('@/services/runtime-config', () => ({
+  getSecretState: () => ({ present: false }),
+}));
+vi.mock('@/services/widget-store', () => ({
+  isProWidgetEnabled: () => false,
+  isWidgetFeatureEnabled: () => false,
+}));
+vi.mock('@/services/i18n', () => ({ t: (key: string) => key }));
+
+let showProBanner: typeof import('@/components/ProBanner').showProBanner;
+
+beforeAll(async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  // Node exposes an undefined experimental `localStorage` unless a backing
+  // file is configured. Supply the browser contract explicitly so ProBanner
+  // exercises the same global a real page sees.
+  vi.stubGlobal('localStorage', storage);
+  ({ showProBanner } = await import('@/components/ProBanner'));
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  livePremium = true;
+  document.body.replaceChildren();
+  document.documentElement.classList.remove('wm-pro-banner-reserved');
+  storage.clear();
+  vi.setSystemTime(0);
+});
+
+function emitEntitlement(premium: boolean, at: number): void {
+  livePremium = premium;
+  vi.setSystemTime(at);
+  for (const listener of entitlementListeners) listener();
+}
+
+describe('ProBanner confirmed-Pro stability', () => {
+  it('never mounts during 500 ms flaps, then mounts only after free is continuous', () => {
+    const container = document.createElement('main');
+    const slot = document.createElement('div');
+    slot.id = 'proBannerSlot';
+    container.appendChild(slot);
+    document.body.appendChild(container);
+
+    showProBanner(container);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(false);
+
+    emitEntitlement(false, 500);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+
+    emitEntitlement(true, 1_000);
+    emitEntitlement(false, 1_500);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+
+    vi.advanceTimersByTime(1_999);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(container.querySelector('.pro-banner')).not.toBeNull();
+    expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(true);
+
+    emitEntitlement(true, 4_000);
+    vi.advanceTimersByTime(300);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(false);
+  });
+});

--- a/tests/dom/pro-banner-premium-stability.test.mts
+++ b/tests/dom/pro-banner-premium-stability.test.mts
@@ -6,12 +6,20 @@
  * behavior so a future wiring regression cannot pass on the reducer alone.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PRO_BANNER_DOWNGRADE_SETTLE_MS,
+  PRO_BANNER_ENTITLEMENT_HINT_KEY,
+  PRO_BANNER_ENTITLEMENT_HINT_VALUE,
+} from '@/services/pro-banner-policy';
+import { startAccountAuthHandoff } from '@/app/account-auth-handoff';
+import type { EntitlementState as Entitlement } from '@/services/entitlements';
 
 type Session = import('@/services/auth-state').AuthSession;
-type Entitlement = import('@/services/entitlements').EntitlementState;
 
-let livePremium = true;
-const session: Session = {
+type EntitlementSnapshot = 'pro' | 'free' | null;
+
+let entitlementSnapshot: EntitlementSnapshot = null;
+let session: Session = {
   user: {
     id: 'user_pro',
     name: 'Pro User',
@@ -20,7 +28,14 @@ const session: Session = {
   },
   isPending: false,
 };
-const entitlementListeners: Array<() => void> = [];
+let clerkRole: 'free' | 'pro' = 'free';
+const localUnlock = {
+  apiKey: false,
+  proWidget: false,
+  widgetFeature: false,
+};
+const entitlementListeners: Array<(state: Entitlement | null) => void> = [];
+const authListeners: Array<(value: Session) => void> = [];
 const storageValues = new Map<string, string>();
 const storage: Storage = {
   get length() { return storageValues.size; },
@@ -31,14 +46,16 @@ const storage: Storage = {
   setItem: (key, value) => { storageValues.set(key, value); },
 };
 
-function entitlement(): Entitlement {
+function entitlement(): Entitlement | null {
+  if (entitlementSnapshot === null) return null;
+  const premium = entitlementSnapshot === 'pro';
   return {
-    planKey: livePremium ? 'pro' : 'free',
+    planKey: entitlementSnapshot,
     features: {
-      tier: livePremium ? 1 : 0,
-      apiAccess: livePremium,
-      apiRateLimit: livePremium ? 1_000 : 0,
-      maxDashboards: livePremium ? 10 : 3,
+      tier: premium ? 1 : 0,
+      apiAccess: premium,
+      apiRateLimit: premium ? 1_000 : 0,
+      maxDashboards: premium ? 10 : 3,
       prioritySupport: false,
       exportFormats: [],
     },
@@ -47,17 +64,18 @@ function entitlement(): Entitlement {
 }
 
 vi.mock('@/services/analytics', () => ({ trackGateHit: vi.fn() }));
-vi.mock('@/services/panel-gating', () => ({
-  hasPremiumAccess: () => livePremium,
-}));
-vi.mock('@/services/entitlements', () => ({
-  getEntitlementState: () => entitlement(),
-  isEntitled: () => livePremium,
-  onEntitlementChange: (fn: () => void) => {
-    entitlementListeners.push(fn);
-    return () => {};
-  },
-}));
+vi.mock('@/services/entitlements', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/entitlements')>();
+  return {
+    ...actual,
+    getEntitlementState: () => entitlement(),
+    isEntitled: () => actual.isEntitlementActive(entitlement(), Date.now()),
+    onEntitlementChange: (fn: (state: Entitlement | null) => void) => {
+      entitlementListeners.push(fn);
+      return () => {};
+    },
+  };
+});
 vi.mock('@/services/billing', () => ({
   getSubscription: () => null,
   onSubscriptionChange: () => () => {},
@@ -69,26 +87,29 @@ vi.mock('@/services/billing-state', () => ({
 vi.mock('@/services/auth-state', () => ({
   getAuthState: () => session,
   subscribeAuthState: (fn: (value: Session) => void) => {
+    authListeners.push(fn);
     fn(session);
     return () => {};
   },
 }));
 vi.mock('@/services/clerk', () => ({
-  getCurrentClerkUser: () => ({
-    id: session.user!.id,
-    name: session.user!.name,
-    email: session.user!.email,
-    image: null,
-    plan: 'free' as const,
-  }),
+  getCurrentClerkUser: () => session.user
+    ? {
+        id: session.user.id,
+        name: session.user.name,
+        email: session.user.email,
+        image: null,
+        plan: clerkRole,
+      }
+    : null,
   isClerkAuthEnabled: () => true,
 }));
 vi.mock('@/services/runtime-config', () => ({
-  getSecretState: () => ({ present: false }),
+  getSecretState: () => ({ present: localUnlock.apiKey }),
 }));
 vi.mock('@/services/widget-store', () => ({
-  isProWidgetEnabled: () => false,
-  isWidgetFeatureEnabled: () => false,
+  isProWidgetEnabled: () => localUnlock.proWidget,
+  isWidgetFeatureEnabled: () => localUnlock.widgetFeature,
 }));
 vi.mock('@/services/i18n', () => ({ t: (key: string) => key }));
 
@@ -110,36 +131,111 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  livePremium = true;
+  entitlementSnapshot = null;
+  clerkRole = 'free';
+  localUnlock.apiKey = false;
+  localUnlock.proWidget = false;
+  localUnlock.widgetFeature = false;
   document.body.replaceChildren();
   document.documentElement.classList.remove('wm-pro-banner-reserved');
   storage.clear();
   vi.setSystemTime(0);
 });
 
-function emitEntitlement(premium: boolean, at: number): void {
-  livePremium = premium;
+function emitEntitlement(snapshot: EntitlementSnapshot, at: number): void {
+  entitlementSnapshot = snapshot;
   vi.setSystemTime(at);
-  for (const listener of entitlementListeners) listener();
+  const state = entitlement();
+  for (const listener of entitlementListeners) listener(state);
+}
+
+function emitAuth(user: Session['user'], at: number): void {
+  session = { user, isPending: false };
+  vi.setSystemTime(at);
+  for (const listener of authListeners) listener(session);
+}
+
+/**
+ * App.ts resets the preserved Convex snapshot on an identity transition. Keep
+ * that reset in the actual auth subscriber dispatch, rather than mutating the
+ * snapshot around emitAuth(), so this DOM test covers either registration
+ * order with ProBanner's production auth callback.
+ */
+function installAppEntitlementResetListener(
+  order: 'before-pro-banner' | 'after-pro-banner',
+): () => void {
+  let previousUserId = session.user?.id ?? null;
+  const appListener = (next: Session): void => {
+    const userId = next.user?.id ?? null;
+    if (userId !== previousUserId) {
+      previousUserId = userId;
+      if (userId === null) {
+        entitlementSnapshot = null;
+        const state = entitlement();
+        for (const listener of entitlementListeners) listener(state);
+        return;
+      }
+      void startAccountAuthHandoff({
+        userId,
+        isCurrent: () => session.user?.id === userId,
+        effects: {
+          destroyEntitlementSubscription: () => {},
+          resetEntitlementState: () => {
+            entitlementSnapshot = null;
+            const state = entitlement();
+            for (const listener of entitlementListeners) listener(state);
+          },
+          destroySubscriptionWatch: () => {},
+          rebindConvexAuthForWatchHandoff: async () => false,
+          initEntitlementSubscription: () => {},
+          initSubscriptionWatch: () => {},
+          cloudPrefsSignIn: () => {},
+        },
+      });
+    }
+  };
+
+  if (order === 'before-pro-banner') {
+    authListeners.unshift(appListener);
+  } else {
+    authListeners.push(appListener);
+  }
+  return () => {
+    const index = authListeners.indexOf(appListener);
+    if (index >= 0) authListeners.splice(index, 1);
+  };
 }
 
 describe('ProBanner confirmed-Pro stability', () => {
-  it('never mounts during 500 ms flaps, then mounts only after free is continuous', () => {
+  it('stabilizes same-user flaps, quarantines cross-account snapshots, and respects safe premium sources', () => {
     const container = document.createElement('main');
     const slot = document.createElement('div');
     slot.id = 'proBannerSlot';
     container.appendChild(slot);
     document.body.appendChild(container);
 
+    // A pre-paint reservation must survive ordinary signed-in hydration while
+    // the first entitlement is still unknown. Clearing it here would recreate
+    // the layout shift the reservation exists to prevent.
+    document.documentElement.classList.add('wm-pro-banner-reserved');
     showProBanner(container);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(true);
+
+    emitEntitlement('free', 100);
+    expect(container.querySelector('.pro-banner')).not.toBeNull();
+    expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(true);
+
+    emitEntitlement('pro', 200);
+    vi.advanceTimersByTime(300);
     expect(container.querySelector('.pro-banner')).toBeNull();
     expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(false);
 
-    emitEntitlement(false, 500);
+    emitEntitlement('free', 500);
     expect(container.querySelector('.pro-banner')).toBeNull();
 
-    emitEntitlement(true, 1_000);
-    emitEntitlement(false, 1_500);
+    emitEntitlement('pro', 1_000);
+    emitEntitlement('free', 1_500);
     expect(container.querySelector('.pro-banner')).toBeNull();
 
     vi.advanceTimersByTime(1_999);
@@ -149,9 +245,132 @@ describe('ProBanner confirmed-Pro stability', () => {
     expect(container.querySelector('.pro-banner')).not.toBeNull();
     expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(true);
 
-    emitEntitlement(true, 4_000);
+    emitEntitlement('pro', 4_000);
     vi.advanceTimersByTime(300);
     expect(container.querySelector('.pro-banner')).toBeNull();
     expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(false);
+
+    // ProBanner can receive the Clerk callback before App's auth subscriber
+    // resets the old Convex snapshot. It must quarantine A's unscoped Pro
+    // evidence, defer B's banner through reset, then mount only after B's
+    // current free snapshot arrives.
+    const removeAfterProBannerReset = installAppEntitlementResetListener('after-pro-banner');
+    emitAuth({
+      id: 'user_free',
+      name: 'Free User',
+      email: 'free@example.com',
+      role: 'free',
+    }, 4_500);
+    expect(storage.getItem(PRO_BANNER_ENTITLEMENT_HINT_KEY)).toBeNull();
+
+    // App's subscriber published null during the auth dispatch above. The
+    // reset alone is deliberately not free evidence: B's snapshot is needed.
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    emitEntitlement('free', 4_600);
+    expect(container.querySelector('.pro-banner')).not.toBeNull();
+
+    // A mounted free banner belongs to B. Switching directly to a Convex-only
+    // Pro C must remove that old account's upgrade UI throughout C's unknown
+    // window, then keep it absent once C's own Pro snapshot arrives.
+    emitAuth({
+      id: 'user_convex_pro',
+      name: 'Convex Pro User',
+      email: 'convex-pro@example.com',
+      role: 'free',
+    }, 4_700);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    expect(document.documentElement.classList.contains('wm-pro-banner-reserved')).toBe(false);
+
+    emitEntitlement('pro', 4_800);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+
+    removeAfterProBannerReset();
+
+    // Exercise the reverse dispatch order. App clears A's snapshot before
+    // ProBanner observes the new Clerk identity; B's current Pro snapshot is
+    // still accepted and remains banner-suppressing.
+    emitEntitlement('pro', 9_700);
+    const removeBeforeProBannerReset = installAppEntitlementResetListener('before-pro-banner');
+    emitAuth({
+      id: 'user_pro_next',
+      name: 'Next Pro User',
+      email: 'next-pro@example.com',
+      role: 'free',
+    }, 9_800);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    emitEntitlement('pro', 10_300);
+    vi.advanceTimersByTime(300);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    removeBeforeProBannerReset();
+
+    // A current Clerk role is identity-bound and may suppress the banner and
+    // seed the UX-only hint, even while the previous account's Convex Pro
+    // snapshot is quarantined during a direct switch.
+    const removeClerkReset = installAppEntitlementResetListener('after-pro-banner');
+    storage.clear();
+    clerkRole = 'pro';
+    emitAuth({
+      id: 'clerk_pro',
+      name: 'Clerk Pro',
+      email: 'clerk-pro@example.com',
+      role: 'free',
+    }, 10_700);
+    vi.advanceTimersByTime(300);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    expect(storage.getItem(PRO_BANNER_ENTITLEMENT_HINT_KEY)).toBe(PRO_BANNER_ENTITLEMENT_HINT_VALUE);
+
+    // Each local unlock is safe only for the present device/session. It must
+    // suppress the banner while cross-account Convex evidence is quarantined,
+    // but never write the cross-session account hint.
+    const localUnlockCases: Array<{
+      name: string;
+      enable: () => void;
+      disable: () => void;
+    }> = [
+      {
+        name: 'API key',
+        enable: () => { localUnlock.apiKey = true; },
+        disable: () => { localUnlock.apiKey = false; },
+      },
+      {
+        name: 'Pro widget',
+        enable: () => { localUnlock.proWidget = true; },
+        disable: () => { localUnlock.proWidget = false; },
+      },
+      {
+        name: 'widget feature',
+        enable: () => { localUnlock.widgetFeature = true; },
+        disable: () => { localUnlock.widgetFeature = false; },
+      },
+    ];
+    for (const [index, unlock] of localUnlockCases.entries()) {
+      clerkRole = 'free';
+      emitEntitlement('pro', 14_000 + index * 1_000);
+      storage.clear();
+      unlock.enable();
+      emitAuth({
+        id: `local_unlock_${index}`,
+        name: unlock.name,
+        email: `local-unlock-${index}@example.com`,
+        role: 'free',
+      }, 14_100 + index * 1_000);
+      vi.advanceTimersByTime(300);
+      expect(container.querySelector('.pro-banner')).toBeNull();
+      expect(storage.getItem(PRO_BANNER_ENTITLEMENT_HINT_KEY)).toBeNull();
+      unlock.disable();
+    }
+
+    // Confirm the final signed-in account through its current Convex
+    // snapshot, start a downgrade, then sign out. Sign-out owns the
+    // transition and must bypass the remaining settle window.
+    emitEntitlement('pro', 18_000);
+    emitEntitlement('free', 18_100);
+    expect(container.querySelector('.pro-banner')).toBeNull();
+    emitAuth(null, 18_200);
+    expect(container.querySelector('.pro-banner')).not.toBeNull();
+    expect(storage.getItem(PRO_BANNER_ENTITLEMENT_HINT_KEY)).toBeNull();
+    vi.advanceTimersByTime(PRO_BANNER_DOWNGRADE_SETTLE_MS);
+    expect(container.querySelector('.pro-banner')).not.toBeNull();
+    removeClerkReset();
   });
 });

--- a/tests/dom/unified-settings-account-handoff.test.mts
+++ b/tests/dom/unified-settings-account-handoff.test.mts
@@ -1,0 +1,515 @@
+/**
+ * The settings modal owns account-scoped plaintext and lists. Exercise the
+ * real class and its real subscribeAuthState wiring so removing the
+ * constructor subscription cannot leave account A's data rendered for B.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestI18n } from './helpers/i18n.mts';
+import type { UnifiedSettingsConfig } from '@/components/UnifiedSettings';
+import type { ApiKeyInfo, CreateApiKeyResult } from '@/services/api-keys';
+import type { ApiPlanLimitNotice } from '@/services/api-plan-limit-notices';
+import type { AuthSession } from '@/services/auth-state';
+import type { EntitlementState } from '@/services/entitlements';
+import type { McpClientInfo, McpQuota } from '@/services/mcp-clients';
+
+let session: AuthSession = signedIn('A');
+const authListeners: Array<(state: AuthSession) => void> = [];
+
+const apiKeyMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(),
+  revoke: vi.fn(),
+}));
+const noticeMocks = vi.hoisted(() => ({
+  acknowledge: vi.fn(),
+  list: vi.fn(),
+}));
+const mcpMocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  quota: vi.fn(),
+  revoke: vi.fn(),
+}));
+const entitlementMocks = vi.hoisted(() => ({
+  state: null as EntitlementState | null,
+  listeners: [] as Array<(state: EntitlementState | null) => void>,
+}));
+const storageValues = new Map<string, string>();
+const storage: Storage = {
+  get length() { return storageValues.size; },
+  clear: () => storageValues.clear(),
+  getItem: (key) => storageValues.get(key) ?? null,
+  key: (index) => [...storageValues.keys()][index] ?? null,
+  removeItem: (key) => { storageValues.delete(key); },
+  setItem: (key, value) => { storageValues.set(key, value); },
+};
+
+vi.mock('@/services/auth-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/auth-state')>()),
+  getAuthState: () => session,
+  subscribeAuthState: (listener: (state: AuthSession) => void) => {
+    authListeners.push(listener);
+    listener(session);
+    return () => {
+      const index = authListeners.indexOf(listener);
+      if (index >= 0) authListeners.splice(index, 1);
+    };
+  },
+}));
+
+vi.mock('@/services/entitlements', () => ({
+  getEntitlementState: () => entitlementMocks.state,
+  hasFeature: (feature: string) => Boolean(
+    (entitlementMocks.state?.features as Record<string, unknown> | undefined)?.[feature],
+  ),
+  isEntitled: (planKey?: string) => (
+    entitlementMocks.state !== null
+    && (planKey === undefined || entitlementMocks.state.planKey === planKey)
+  ),
+  onEntitlementChange: (listener: (state: EntitlementState | null) => void) => {
+    entitlementMocks.listeners.push(listener);
+    if (entitlementMocks.state !== null) listener(entitlementMocks.state);
+    return () => {
+      const index = entitlementMocks.listeners.indexOf(listener);
+      if (index >= 0) entitlementMocks.listeners.splice(index, 1);
+    };
+  },
+}));
+
+vi.mock('@/services/panel-gating', () => ({
+  hasPremiumAccess: () => true,
+}));
+
+vi.mock('@/services/widget-store', () => ({
+  isProUser: () => true,
+}));
+
+vi.mock('@/services/preferences-content', () => ({
+  renderPreferences: () => ({
+    html: '',
+    attach: () => () => {},
+  }),
+}));
+
+vi.mock('@/services/notifications-settings', () => ({
+  renderNotificationsSettings: () => ({
+    html: '',
+    attach: () => () => {},
+  }),
+}));
+
+vi.mock('@/config/feeds', () => ({
+  CANONICAL_FEEDS: {},
+  INTEL_SOURCES: [],
+  SOURCE_REGION_MAP: {},
+}));
+
+vi.mock('@/config/panels', () => ({
+  PANEL_CATEGORY_MAP: {},
+  ALL_PANELS: {},
+  VARIANT_DEFAULTS: { full: [] },
+  getEffectivePanelConfig: () => ({ name: '', enabled: false }),
+  getVariantPanelCategories: () => [],
+  isPanelEntitled: () => true,
+  FREE_MAX_PANELS: 3,
+  countFreePanelCapUsage: () => 0,
+  isFreePanelCapCounted: () => false,
+}));
+
+vi.mock('@/config/variant', () => ({
+  SITE_VARIANT: 'full',
+}));
+
+vi.mock('@/services/billing', () => ({
+  getSubscription: () => null,
+  onSubscriptionChange: () => () => {},
+  openBillingPortal: async () => ({ outcome: 'no-customer' as const }),
+  prereserveBillingPortalTab: () => null,
+  listBusinessSeats: async () => ({
+    businessSubscriptionId: null,
+    ownerDomain: null,
+    ownerIsCorporateDomain: false,
+    seats: [],
+  }),
+  inviteBusinessSeats: async () => ({ invited: [] }),
+  removeBusinessSeat: async () => ({ status: 'removed' as const }),
+}));
+
+vi.mock('@/services/billing-state', () => ({
+  deriveBillingUxState: () => 'active',
+  getReactivationHref: () => '/pro#pricing',
+}));
+
+vi.mock('@/services/api-keys', () => ({
+  createApiKey: (...args: unknown[]) => apiKeyMocks.create(...args),
+  listApiKeys: (...args: unknown[]) => apiKeyMocks.list(...args),
+  revokeApiKey: (...args: unknown[]) => apiKeyMocks.revoke(...args),
+}));
+
+vi.mock('@/services/api-plan-limit-notices', () => ({
+  acknowledgePlanLimitNotice: (...args: unknown[]) => noticeMocks.acknowledge(...args),
+  listCurrentPlanLimitNotices: (...args: unknown[]) => noticeMocks.list(...args),
+}));
+
+vi.mock('@/services/mcp-clients', () => ({
+  listMcpClients: (...args: unknown[]) => mcpMocks.list(...args),
+  fetchMcpQuota: (...args: unknown[]) => mcpMocks.quota(...args),
+  revokeMcpClient: (...args: unknown[]) => mcpMocks.revoke(...args),
+}));
+
+const { UnifiedSettings } = await import('@/components/UnifiedSettings');
+
+type SettingsInternals = {
+  overlay: HTMLElement;
+  activeTab: 'api-keys' | 'mcp-clients';
+  accountDataGeneration: number;
+  accountEntitlementRefreshPending: boolean;
+  apiKeys: ApiKeyInfo[];
+  apiKeysLoading: boolean;
+  apiKeysError: string;
+  newlyCreatedKey: string | null;
+  planLimitNotices: ApiPlanLimitNotice[];
+  planLimitNoticesLoading: boolean;
+  planLimitNoticesError: string;
+  mcpClients: McpClientInfo[];
+  mcpClientsLoading: boolean;
+  mcpClientsError: string;
+  mcpQuota: McpQuota | null;
+  render(loadAccountData?: boolean): void;
+  renderApiKeysList(): void;
+  renderMcpClientsList(): void;
+  renderMcpQuotaInPlace(): void;
+  showCreatedBanner(key: string): void;
+  loadApiKeys(): Promise<void>;
+  loadPlanLimitNotices(): Promise<void>;
+  loadMcpClients(): Promise<void>;
+  refreshMcpQuota(): Promise<void>;
+  handleCreateApiKey(): Promise<void>;
+  handleRevokeApiKey(keyId: string): Promise<void>;
+  handleAcknowledgePlanLimitNotice(noticeId: string): Promise<void>;
+  handleRevokeMcpClient(tokenId: string): Promise<void>;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason: unknown): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => {};
+  let rejectPromise: (reason: unknown) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function signedIn(id: string): AuthSession {
+  return {
+    user: {
+      id,
+      name: `User ${id}`,
+      email: `${id.toLowerCase()}@example.com`,
+      role: 'pro',
+    },
+    isPending: false,
+  };
+}
+
+function emitAccount(id: string): void {
+  session = signedIn(id);
+  for (const listener of [...authListeners]) listener(session);
+}
+
+function entitlement(options: {
+  planKey: string;
+  apiAccess: boolean;
+  mcpAccess: boolean;
+}): EntitlementState {
+  return {
+    planKey: options.planKey,
+    features: {
+      tier: options.planKey === 'free' ? 0 : 1,
+      apiAccess: options.apiAccess,
+      apiRateLimit: options.apiAccess ? 10_000 : 0,
+      maxDashboards: options.planKey === 'free' ? 1 : 10,
+      prioritySupport: options.planKey !== 'free',
+      exportFormats: options.apiAccess ? ['json'] : [],
+      mcpAccess: options.mcpAccess,
+    },
+    validUntil: Date.now() + 86_400_000,
+  };
+}
+
+function emitEntitlement(state: EntitlementState | null): void {
+  entitlementMocks.state = state;
+  for (const listener of [...entitlementMocks.listeners]) listener(state);
+}
+
+function apiKey(id = 'key-a'): ApiKeyInfo {
+  return {
+    id,
+    name: 'A private key',
+    keyPrefix: 'wm_A_PREFIX',
+    createdAt: Date.now(),
+  };
+}
+
+function notice(id = 'notice-a'): ApiPlanLimitNotice {
+  return {
+    _id: id,
+    userId: 'A',
+    planKey: 'api_business',
+    dimension: 'api_daily_requests',
+    state: 'warning',
+    windowKey: 'A private window',
+    usage: 90,
+    limit: 100,
+    usageRatio: 0.9,
+    ctaKind: 'none',
+  };
+}
+
+function mcpClient(id = 'client-a', name = 'A private MCP client'): McpClientInfo {
+  return {
+    id,
+    name,
+    createdAt: Date.now(),
+  };
+}
+
+const config: UnifiedSettingsConfig = {
+  getPanelSettings: () => ({}),
+  savePanelSettings: () => {},
+  getDisabledSources: () => new Set(),
+  toggleSource: () => {},
+  setSourcesEnabled: () => {},
+  getAllSourceNames: () => [],
+  getLocalizedPanelName: (_key, fallback) => fallback,
+  resetLayout: () => {},
+  isDesktopApp: false,
+};
+
+let settings: InstanceType<typeof UnifiedSettings>;
+let internal: SettingsInternals;
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  authListeners.length = 0;
+  entitlementMocks.listeners.length = 0;
+  entitlementMocks.state = entitlement({
+    planKey: 'api_business',
+    apiAccess: true,
+    mcpAccess: true,
+  });
+  storageValues.clear();
+  vi.stubGlobal('localStorage', storage);
+  session = signedIn('A');
+  apiKeyMocks.create.mockReset().mockResolvedValue({
+    id: 'default',
+    name: 'default',
+    keyPrefix: 'wm_default',
+    key: 'wm_default_plaintext',
+  });
+  apiKeyMocks.list.mockReset().mockResolvedValue([]);
+  apiKeyMocks.revoke.mockReset().mockResolvedValue(undefined);
+  noticeMocks.acknowledge.mockReset().mockResolvedValue(undefined);
+  noticeMocks.list.mockReset().mockResolvedValue([]);
+  mcpMocks.list.mockReset().mockResolvedValue([]);
+  mcpMocks.quota.mockReset().mockResolvedValue({
+    used: 0,
+    limit: 50,
+    resetsAt: new Date(Date.now() + 86_400_000).toISOString(),
+  });
+  mcpMocks.revoke.mockReset().mockResolvedValue(undefined);
+
+  settings = new UnifiedSettings(config);
+  internal = settings as unknown as SettingsInternals;
+  internal.overlay.classList.add('active');
+  internal.activeTab = 'api-keys';
+});
+
+afterEach(() => {
+  settings.destroy();
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe('UnifiedSettings real auth-subscription handoff', () => {
+  it('synchronously purges A plaintext and rendered account lists when auth emits B', () => {
+    internal.apiKeys = [apiKey()];
+    internal.planLimitNotices = [notice()];
+    internal.mcpClients = [mcpClient()];
+    internal.mcpQuota = {
+      used: 41,
+      limit: 50,
+      resetsAt: new Date(Date.now() + 86_400_000).toISOString(),
+    };
+    internal.render(false);
+    internal.showCreatedBanner('wm_A_PLAINTEXT_SECRET');
+    internal.renderApiKeysList();
+    internal.renderMcpClientsList();
+    internal.renderMcpQuotaInPlace();
+
+    expect(internal.overlay.textContent).toContain('wm_A_PLAINTEXT_SECRET');
+    expect(internal.overlay.textContent).toContain('A private key');
+    expect(internal.overlay.textContent).toContain('A private MCP client');
+    expect(internal.overlay.textContent).toContain('A private window');
+    expect(internal.overlay.textContent).toContain('41 / 50');
+
+    emitAccount('B');
+
+    expect(internal.accountDataGeneration).toBe(1);
+    expect(internal.apiKeys).toEqual([]);
+    expect(internal.planLimitNotices).toEqual([]);
+    expect(internal.mcpClients).toEqual([]);
+    expect(internal.mcpQuota).toBeNull();
+    expect(internal.newlyCreatedKey).toBeNull();
+    expect(internal.overlay.textContent).not.toContain('wm_A_PLAINTEXT_SECRET');
+    expect(internal.overlay.textContent).not.toContain('A private key');
+    expect(internal.overlay.textContent).not.toContain('A private MCP client');
+    expect(internal.overlay.textContent).not.toContain('A private window');
+    expect(internal.overlay.textContent).not.toContain('41 / 50');
+  });
+
+  it('drops every deferred A settlement after the real auth subscription selects B', async () => {
+    const listKeys = deferred<ApiKeyInfo[]>();
+    const createKey = deferred<CreateApiKeyResult>();
+    const revokeKey = deferred<void>();
+    const listNotices = deferred<ApiPlanLimitNotice[]>();
+    const acknowledgeNotice = deferred<void>();
+    const listClients = deferred<McpClientInfo[]>();
+    const quota = deferred<McpQuota>();
+    const revokeClient = deferred<void>();
+
+    apiKeyMocks.list.mockReturnValue(listKeys.promise);
+    apiKeyMocks.create.mockReturnValue(createKey.promise);
+    apiKeyMocks.revoke.mockReturnValue(revokeKey.promise);
+    noticeMocks.list.mockReturnValue(listNotices.promise);
+    noticeMocks.acknowledge.mockReturnValue(acknowledgeNotice.promise);
+    mcpMocks.list.mockReturnValue(listClients.promise);
+    mcpMocks.quota.mockReturnValue(quota.promise);
+    mcpMocks.revoke.mockReturnValue(revokeClient.promise);
+    vi.stubGlobal('confirm', vi.fn(() => true));
+
+    internal.apiKeys = [apiKey()];
+    internal.planLimitNotices = [notice()];
+    internal.mcpClients = [mcpClient()];
+    internal.render(false);
+    internal.renderApiKeysList();
+    const input = internal.overlay.querySelector<HTMLInputElement>('.api-keys-name-input');
+    expect(input).not.toBeNull();
+    input!.value = 'A create request';
+
+    const pending = [
+      internal.loadApiKeys(),
+      internal.loadPlanLimitNotices(),
+      internal.loadMcpClients(),
+      internal.refreshMcpQuota(),
+      internal.handleCreateApiKey(),
+      internal.handleRevokeApiKey('key-a'),
+      internal.handleAcknowledgePlanLimitNotice('notice-a'),
+      internal.handleRevokeMcpClient('client-a'),
+    ];
+
+    emitAccount('B');
+
+    listKeys.resolve([apiKey('late-key-a')]);
+    createKey.resolve({
+      id: 'created-a',
+      name: 'A create request',
+      keyPrefix: 'wm_A_CREATED',
+      key: 'wm_A_LATE_PLAINTEXT',
+    });
+    revokeKey.reject(new Error('A key revoke detail'));
+    listNotices.resolve([notice('late-notice-a')]);
+    acknowledgeNotice.reject(new Error('A notice detail'));
+    listClients.resolve([mcpClient('late-client-a')]);
+    quota.resolve({
+      used: 49,
+      limit: 50,
+      resetsAt: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+    revokeClient.reject(new Error('A MCP revoke detail'));
+    await Promise.all(pending);
+
+    expect(internal.apiKeys).toEqual([]);
+    expect(internal.planLimitNotices).toEqual([]);
+    expect(internal.mcpClients).toEqual([]);
+    expect(internal.mcpQuota).toBeNull();
+    expect(internal.newlyCreatedKey).toBeNull();
+    expect(internal.apiKeysError).toBe('');
+    expect(internal.planLimitNoticesError).toBe('');
+    expect(internal.mcpClientsError).toBe('');
+    expect(internal.overlay.textContent).not.toContain('wm_A_LATE_PLAINTEXT');
+    expect(internal.overlay.textContent).not.toContain('late-key-a');
+    expect(internal.overlay.textContent).not.toContain('late-notice-a');
+    expect(internal.overlay.textContent).not.toContain('late-client-a');
+    expect(internal.overlay.textContent).not.toContain('49 / 50');
+    expect(document.querySelector('.toast-notification')).toBeNull();
+    expect(apiKeyMocks.list).toHaveBeenCalledTimes(1);
+    expect(mcpMocks.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves notices and renders a current-account authentication error', async () => {
+    internal.planLimitNotices = [notice()];
+    internal.render(false);
+    noticeMocks.list.mockRejectedValue(
+      new Error('Authentication unavailable while loading API plan-limit notices. Try again.'),
+    );
+
+    await internal.loadPlanLimitNotices();
+
+    expect(internal.planLimitNotices).toEqual([notice()]);
+    expect(internal.planLimitNoticesError).toBe(
+      'Authentication unavailable while loading API plan-limit notices. Try again.',
+    );
+    expect(internal.overlay.textContent).toContain('A private window');
+    expect(internal.overlay.textContent).toContain(
+      'Authentication unavailable while loading API plan-limit notices. Try again.',
+    );
+  });
+
+  it('rebuilds MCP capability from B across reset, free, and Pro snapshots', async () => {
+    mcpMocks.list.mockResolvedValue([mcpClient('client-b', 'B private MCP client')]);
+    settings.open('api-keys');
+    expect(internal.overlay.querySelector('[data-tab="mcp-clients"]')).not.toBeNull();
+
+    emitAccount('B');
+    expect(internal.accountEntitlementRefreshPending).toBe(true);
+
+    emitEntitlement(null);
+    expect(internal.accountEntitlementRefreshPending).toBe(true);
+    expect(internal.overlay.querySelector('[data-tab="mcp-clients"]')).toBeNull();
+    expect(mcpMocks.list).not.toHaveBeenCalled();
+
+    emitEntitlement(entitlement({
+      planKey: 'free',
+      apiAccess: false,
+      mcpAccess: false,
+    }));
+    expect(internal.accountEntitlementRefreshPending).toBe(false);
+    expect(internal.overlay.querySelector('[data-tab="mcp-clients"]')).toBeNull();
+    expect(mcpMocks.list).not.toHaveBeenCalled();
+
+    emitEntitlement(entitlement({
+      planKey: 'pro',
+      apiAccess: false,
+      mcpAccess: true,
+    }));
+    const mcpTab = internal.overlay.querySelector<HTMLButtonElement>('[data-tab="mcp-clients"]');
+    expect(mcpTab).not.toBeNull();
+    mcpTab!.click();
+
+    await vi.waitFor(() => {
+      expect(mcpMocks.list).toHaveBeenCalledTimes(1);
+      expect(internal.overlay.textContent).toContain('B private MCP client');
+    });
+  });
+});

--- a/tests/followed-countries-sign-in-handoff.test.mjs
+++ b/tests/followed-countries-sign-in-handoff.test.mjs
@@ -274,6 +274,7 @@ function setupSignedIn(userId, { tier = 1, fakeClient }) {
     featureFlagEnabled: true,
     convexClient: fakeClient,
     convexApi: FAKE_API,
+    waitForConvexAuth: async () => true,
   });
 }
 
@@ -1326,5 +1327,32 @@ describe('Codex round-4 P1 — UNAUTHENTICATED transient retry path', () => {
       'merge fires only AFTER waitForConvexAuth resolves',
     );
     assert.equal(authResolved, true);
+  });
+
+  it('fails closed without merging when the identity-bound auth wait is superseded', async () => {
+    setLocalStorageList(['US']);
+    let mergeCalls = 0;
+    const fake = makeFakeConvex({ tier: 1 });
+    const innerMutation = fake.mutation.bind(fake);
+    fake.mutation = async (ref, args) => {
+      if (ref === FAKE_API.followedCountries.mergeAnonymousLocal) mergeCalls += 1;
+      return innerMutation(ref, args);
+    };
+    _setDepsForTests({
+      getCurrentClerkUser: () => ({ id: 'user_guarded' }),
+      getEntitlementState: () => ({ features: { tier: 1 } }),
+      hasTier: (n) => n <= 1,
+      featureFlagEnabled: true,
+      convexClient: fake,
+      convexApi: FAKE_API,
+      waitForConvexAuth: async () => false,
+    });
+
+    await _emitAuthStateForTests({ id: 'user_guarded' });
+    await flushMicrotasks();
+
+    assert.equal(mergeCalls, 0, 'a superseded auth wait must not mutate through the shared client');
+    assert.equal(_getInternalStateForTests().handoffState, 'failed');
+    assert.notEqual(getLocalStorageRaw(), null, 'local follows remain available for a safe retry');
   });
 });

--- a/tests/pro-banner-entitlement-race.test.mts
+++ b/tests/pro-banner-entitlement-race.test.mts
@@ -16,9 +16,12 @@ import {
   decideProBannerMount,
   isPremiumEntitlementHint,
   resolveBannerPremium,
+  stabilizeProBannerPremium,
+  PRO_BANNER_DOWNGRADE_SETTLE_MS,
   PRO_BANNER_ENTITLEMENT_HINT_KEY,
   PRO_BANNER_ENTITLEMENT_HINT_VALUE,
   type ProBannerDecisionInput,
+  type ProBannerPremiumStabilityState,
 } from '@/services/pro-banner-policy';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -52,6 +55,35 @@ describe('decideProBannerMount (#5728)', () => {
       })),
       'suppress',
     );
+  });
+
+  it('never mounts the free upsell between half-second snapshots for a confirmed Pro session', () => {
+    let state: ProBannerPremiumStabilityState | null = null;
+    const decisions = [true, false, true, false, true].map((premium, index) => {
+      const stable = stabilizeProBannerPremium({
+        now: index * 500,
+        userId: 'user_pro',
+        premiumHint: true,
+        live: { premium, accountBacked: premium },
+        previous: state,
+      });
+      state = stable.state;
+      return decideProBannerMount(base({
+        hasPremiumAccess: stable.premium,
+        premiumHint: true,
+        authPending: false,
+        signedIn: true,
+        entitlementLoaded: true,
+      }));
+    });
+
+    assert.deepEqual(decisions, [
+      'suppress',
+      'suppress',
+      'suppress',
+      'suppress',
+      'suppress',
+    ]);
   });
 
   it('defers while Clerk auth is still hydrating (the init race)', () => {
@@ -194,6 +226,104 @@ describe('resolveBannerPremium (#5728 sign-out + local keys)', () => {
   });
 });
 
+describe('stabilizeProBannerPremium (confirmed Pro anti-flap)', () => {
+  it('requires a continuous settled-free window before showing a downgrade', () => {
+    const confirmed = stabilizeProBannerPremium({
+      now: 0,
+      userId: 'user_pro',
+      premiumHint: false,
+      live: { premium: true, accountBacked: true },
+      previous: null,
+    });
+    const transientFree = stabilizeProBannerPremium({
+      now: 500,
+      userId: 'user_pro',
+      premiumHint: true,
+      live: { premium: false, accountBacked: false },
+      previous: confirmed.state,
+    });
+    assert.equal(transientFree.premium, true);
+    assert.equal(transientFree.heldPremium, true);
+    assert.equal(transientFree.recheckAt, 500 + PRO_BANNER_DOWNGRADE_SETTLE_MS);
+
+    const settledFree = stabilizeProBannerPremium({
+      now: 500 + PRO_BANNER_DOWNGRADE_SETTLE_MS,
+      userId: 'user_pro',
+      premiumHint: true,
+      live: { premium: false, accountBacked: false },
+      previous: transientFree.state,
+    });
+    assert.equal(settledFree.premium, false);
+    assert.equal(settledFree.heldPremium, false);
+    assert.equal(settledFree.recheckAt, null);
+  });
+
+  it('bounds a stale post-checkout hint for a genuinely free account', () => {
+    const hinted = stabilizeProBannerPremium({
+      now: 10_000,
+      userId: 'user_free',
+      premiumHint: true,
+      live: { premium: false, accountBacked: false },
+      previous: null,
+    });
+    assert.equal(hinted.premium, true);
+    assert.equal(hinted.recheckAt, 10_000 + PRO_BANNER_DOWNGRADE_SETTLE_MS);
+
+    const expired = stabilizeProBannerPremium({
+      now: 10_000 + PRO_BANNER_DOWNGRADE_SETTLE_MS,
+      userId: 'user_free',
+      premiumHint: true,
+      live: { premium: false, accountBacked: false },
+      previous: hinted.state,
+    });
+    assert.equal(expired.premium, false);
+    assert.equal(expired.state.accountPremiumConfirmed, false);
+  });
+
+  it('clears remembered Pro immediately on sign-out', () => {
+    const confirmed = stabilizeProBannerPremium({
+      now: 0,
+      userId: 'user_pro',
+      premiumHint: false,
+      live: { premium: true, accountBacked: true },
+      previous: null,
+    });
+    const signedOut = stabilizeProBannerPremium({
+      now: 500,
+      userId: null,
+      premiumHint: true,
+      live: { premium: false, accountBacked: false },
+      previous: confirmed.state,
+    });
+    assert.equal(signedOut.premium, false);
+    assert.deepEqual(signedOut.state, {
+      userId: null,
+      accountPremiumConfirmed: false,
+      freeSince: null,
+    });
+  });
+
+  it('does not carry a Pro hint across a direct account switch', () => {
+    const accountA = stabilizeProBannerPremium({
+      now: 0,
+      userId: 'user_pro_a',
+      premiumHint: true,
+      live: { premium: true, accountBacked: true },
+      previous: null,
+    });
+    const accountB = stabilizeProBannerPremium({
+      now: 500,
+      userId: 'user_free_b',
+      premiumHint: true,
+      live: { premium: false, accountBacked: false },
+      previous: accountA.state,
+    });
+    assert.equal(accountB.premium, false);
+    assert.equal(accountB.heldPremium, false);
+    assert.equal(accountB.recheckAt, null);
+  });
+});
+
 describe('entitlement hint helpers', () => {
   it('recognizes only the canonical pro value', () => {
     assert.equal(isPremiumEntitlementHint(PRO_BANNER_ENTITLEMENT_HINT_VALUE), true);
@@ -275,6 +405,8 @@ describe('wiring contracts (#5728)', () => {
     const src = readFileSync(resolve(root, 'src/components/ProBanner.ts'), 'utf-8');
     assert.match(src, /decideProBannerMount\(/);
     assert.match(src, /resolveBannerPremium\(/);
+    assert.match(src, /stabilizeProBannerPremium\(/);
+    assert.match(src, /schedulePremiumStabilityRecheck\(/);
     assert.match(src, /subscribeAuthState\(/);
     assert.match(src, /isClerkAuthEnabled\(/);
     assert.match(src, /accountBacked/);

--- a/tests/pro-banner-entitlement-race.test.mts
+++ b/tests/pro-banner-entitlement-race.test.mts
@@ -179,8 +179,9 @@ describe('resolveBannerPremium (#5728 sign-out + local keys)', () => {
         authPending: false,
         signedIn: false,
         localUnlockPremium: false,
-        rawPremium: true, // stale isEntitled from previous account
-        accountBackedPremium: true,
+        identityBoundPremium: false,
+        unscopedAccountPremium: true,
+        acceptUnscopedAccountPremium: true,
       }),
       { premium: false, accountBacked: false },
     );
@@ -192,8 +193,9 @@ describe('resolveBannerPremium (#5728 sign-out + local keys)', () => {
         authPending: false,
         signedIn: false,
         localUnlockPremium: true,
-        rawPremium: true,
-        accountBackedPremium: false,
+        identityBoundPremium: false,
+        unscopedAccountPremium: false,
+        acceptUnscopedAccountPremium: true,
       }),
       { premium: true, accountBacked: false },
     );
@@ -205,10 +207,50 @@ describe('resolveBannerPremium (#5728 sign-out + local keys)', () => {
         authPending: false,
         signedIn: true,
         localUnlockPremium: false,
-        rawPremium: true,
-        accountBackedPremium: true,
+        identityBoundPremium: false,
+        unscopedAccountPremium: true,
+        acceptUnscopedAccountPremium: true,
       }),
       { premium: true, accountBacked: true },
+    );
+  });
+
+  it('ignores stale Convex premium during a direct account switch', () => {
+    assert.deepEqual(
+      resolveBannerPremium({
+        authPending: false,
+        signedIn: true,
+        localUnlockPremium: false,
+        identityBoundPremium: false,
+        unscopedAccountPremium: true,
+        acceptUnscopedAccountPremium: false,
+      }),
+      { premium: false, accountBacked: false },
+    );
+  });
+
+  it('preserves current-user and local-unlock premium while Convex is blocked', () => {
+    assert.deepEqual(
+      resolveBannerPremium({
+        authPending: false,
+        signedIn: true,
+        localUnlockPremium: false,
+        identityBoundPremium: true,
+        unscopedAccountPremium: true,
+        acceptUnscopedAccountPremium: false,
+      }),
+      { premium: true, accountBacked: true },
+    );
+    assert.deepEqual(
+      resolveBannerPremium({
+        authPending: false,
+        signedIn: true,
+        localUnlockPremium: true,
+        identityBoundPremium: false,
+        unscopedAccountPremium: true,
+        acceptUnscopedAccountPremium: false,
+      }),
+      { premium: true, accountBacked: false },
     );
   });
 
@@ -218,8 +260,9 @@ describe('resolveBannerPremium (#5728 sign-out + local keys)', () => {
         authPending: true,
         signedIn: false,
         localUnlockPremium: false,
-        rawPremium: false,
-        accountBackedPremium: false,
+        identityBoundPremium: false,
+        unscopedAccountPremium: false,
+        acceptUnscopedAccountPremium: true,
       }),
       { premium: false, accountBacked: false },
     );
@@ -256,6 +299,46 @@ describe('stabilizeProBannerPremium (confirmed Pro anti-flap)', () => {
     assert.equal(settledFree.premium, false);
     assert.equal(settledFree.heldPremium, false);
     assert.equal(settledFree.recheckAt, null);
+  });
+
+  it('restarts the downgrade window after a local unlock clears', () => {
+    const confirmed = stabilizeProBannerPremium({
+      now: 0,
+      userId: 'user_pro',
+      premiumHint: false,
+      live: { premium: true, accountBacked: true },
+      previous: null,
+    });
+    const settlingFree = stabilizeProBannerPremium({
+      now: 500,
+      userId: 'user_pro',
+      premiumHint: false,
+      live: { premium: false, accountBacked: false },
+      previous: confirmed.state,
+    });
+    assert.equal(settlingFree.recheckAt, 500 + PRO_BANNER_DOWNGRADE_SETTLE_MS);
+
+    const locallyUnlocked = stabilizeProBannerPremium({
+      now: 1_000,
+      userId: 'user_pro',
+      premiumHint: false,
+      live: { premium: true, accountBacked: false },
+      previous: settlingFree.state,
+    });
+    assert.equal(locallyUnlocked.state.accountPremiumConfirmed, true);
+    assert.equal(locallyUnlocked.state.freeSince, null);
+    assert.equal(locallyUnlocked.recheckAt, null);
+
+    const freeAgain = stabilizeProBannerPremium({
+      now: 1_500,
+      userId: 'user_pro',
+      premiumHint: false,
+      live: { premium: false, accountBacked: false },
+      previous: locallyUnlocked.state,
+    });
+    assert.equal(freeAgain.premium, true);
+    assert.equal(freeAgain.heldPremium, true);
+    assert.equal(freeAgain.recheckAt, 1_500 + PRO_BANNER_DOWNGRADE_SETTLE_MS);
   });
 
   it('bounds a stale post-checkout hint for a genuinely free account', () => {

--- a/tests/unified-settings-account-handoff.test.mjs
+++ b/tests/unified-settings-account-handoff.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import ts from 'typescript';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const settingsSource = readFileSync(
+  resolve(root, 'src/components/UnifiedSettings.ts'),
+  'utf8',
+);
+const seatsSource = readFileSync(
+  resolve(root, 'src/components/BusinessSeatsSection.ts'),
+  'utf8',
+);
+
+function extractMethod(source, signature) {
+  const start = source.indexOf(signature);
+  assert.ok(start >= 0, `expected method ${signature}`);
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let index = braceStart; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+  }
+  throw new Error(`unbalanced method ${signature}`);
+}
+
+function transpileHarness(methods, dependencies = []) {
+  const js = ts.transpileModule(
+    `class Harness { ${methods.join('\n')} }`,
+    {
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.None,
+      },
+    },
+  ).outputText;
+  // eslint-disable-next-line no-new-func
+  return new Function(...dependencies, `${js}\nreturn Harness;`);
+}
+
+describe('UnifiedSettings account handoff', () => {
+  it('synchronously clears every account-owned cache and invalidates old requests', async () => {
+    let currentUserId = 'A';
+    let resolveKeys = () => {};
+    const keysResult = new Promise((resolve) => {
+      resolveKeys = resolve;
+    });
+    const Harness = transpileHarness(
+      [
+        extractMethod(settingsSource, 'private handleAccountIdentityChange('),
+        extractMethod(settingsSource, 'private captureAccountRequest('),
+        extractMethod(settingsSource, 'private isAccountRequestCurrent('),
+        extractMethod(settingsSource, 'private async loadApiKeys('),
+      ],
+      ['getAuthState', 'listApiKeys'],
+    )(
+      () => ({ user: currentUserId ? { id: currentUserId } : null }),
+      () => keysResult,
+    );
+    const instance = new Harness();
+    const renders = [];
+    let seatsReset = 0;
+    instance.accountUserId = 'A';
+    instance.accountDataGeneration = 4;
+    instance.accountEntitlementRefreshPending = false;
+    instance.apiKeys = [{ id: 'key-a' }];
+    instance.apiKeysLoading = false;
+    instance.apiKeysError = 'A error';
+    instance.newlyCreatedKey = 'wm_a_plaintext';
+    instance.planLimitNotices = [{ _id: 'notice-a' }];
+    instance.planLimitNoticesLoading = true;
+    instance.mcpClients = [{ id: 'client-a' }];
+    instance.mcpClientsLoading = true;
+    instance.mcpClientsError = 'A error';
+    instance.mcpQuota = { used: 41, limit: 50, resetsAt: 'tomorrow' };
+    instance.stopMcpQuotaPolling = () => {};
+    instance.businessSeatsSection = {
+      resetForAccountChange: () => {
+        seatsReset += 1;
+      },
+    };
+    instance.overlay = { classList: { contains: () => true } };
+    instance.entitlementReady = true;
+    instance.render = (loadAccountData) => renders.push(loadAccountData);
+    let listRenders = 0;
+    instance.renderApiKeysList = () => {
+      listRenders += 1;
+    };
+
+    const requestA = instance.captureAccountRequest();
+    const loadA = instance.loadApiKeys();
+    currentUserId = 'B';
+    instance.handleAccountIdentityChange('B');
+    resolveKeys([{ id: 'late-key-a', name: 'A secret' }]);
+    await loadA;
+
+    assert.equal(instance.accountDataGeneration, 5);
+    assert.equal(instance.accountEntitlementRefreshPending, true);
+    assert.deepEqual(instance.apiKeys, []);
+    assert.equal(instance.apiKeysLoading, false);
+    assert.equal(instance.apiKeysError, '');
+    assert.equal(instance.newlyCreatedKey, null);
+    assert.deepEqual(instance.planLimitNotices, []);
+    assert.equal(instance.planLimitNoticesLoading, false);
+    assert.deepEqual(instance.mcpClients, []);
+    assert.equal(instance.mcpClientsLoading, false);
+    assert.equal(instance.mcpClientsError, '');
+    assert.equal(instance.mcpQuota, null);
+    assert.equal(seatsReset, 1);
+    assert.equal(instance.entitlementReady, false);
+    assert.deepEqual(renders, [false], 'the synchronous rerender must suppress account loads');
+    assert.equal(listRenders, 1, 'A settlement must not render after B clears the surface');
+    assert.equal(instance.isAccountRequestCurrent(requestA), false);
+  });
+
+  it('generation-guards every account-scoped async settings path', () => {
+    const guardedMethods = [
+      'loadPlanLimitNotices',
+      'handleAcknowledgePlanLimitNotice',
+      'loadApiKeys',
+      'handleCreateApiKey',
+      'handleRevokeApiKey',
+      'loadMcpClients',
+      'refreshMcpQuota',
+      'handleRevokeMcpClient',
+    ];
+    for (const method of guardedMethods) {
+      const body = extractMethod(settingsSource, `private async ${method}(`);
+      assert.match(body, /captureAccountRequest\(\)/, `${method} must capture the initiating account`);
+      assert.match(body, /isAccountRequestCurrent\(request\)/, `${method} must discard stale settlement`);
+    }
+  });
+});
+
+describe('BusinessSeatsSection account handoff', () => {
+  it('drops an A seat list that settles after the section resets for B', async () => {
+    let resolveList = () => {};
+    const listResult = new Promise((resolve) => {
+      resolveList = resolve;
+    });
+    const Harness = transpileHarness(
+      [
+        extractMethod(seatsSource, 'resetForAccountChange('),
+        extractMethod(seatsSource, 'async load('),
+      ],
+      ['listBusinessSeats'],
+    )(() => listResult);
+    const instance = new Harness();
+    let renders = 0;
+    instance.accountGeneration = 0;
+    instance.seats = [];
+    instance.loading = false;
+    instance.error = '';
+    instance.ownerDomain = null;
+    instance.ownerIsCorporateDomain = true;
+    instance.removingGrantIds = new Set();
+    instance.renderInPlace = () => {
+      renders += 1;
+    };
+
+    const loadA = instance.load();
+    instance.resetForAccountChange();
+    resolveList({
+      businessSubscriptionId: 'sub-a',
+      ownerDomain: 'a.example',
+      ownerIsCorporateDomain: true,
+      seats: [{ grantId: 'grant-a', inviteeEmail: 'secret@a.example' }],
+    });
+    await loadA;
+
+    assert.deepEqual(instance.seats, []);
+    assert.equal(instance.ownerDomain, null);
+    assert.equal(instance.loading, false);
+    assert.equal(renders, 1, 'only the B reset may render; A settlement stays inert');
+  });
+});


### PR DESCRIPTION
## Summary

Confirmed Pro users no longer see the free upgrade banner mount and disappear when auth and entitlement snapshots briefly disagree. The banner accepts a Pro verdict immediately but requires a continuous two-second non-premium signal before treating the account as downgraded; sign-out and account switches still clear the remembered verdict immediately.

This preserves the upgrade path for genuinely free or lapsed accounts while eliminating the half-second page-layout flicker.

## Related

Related: #5728

## Validation

- Reproduced on unpatched `main`: alternating 500 ms Pro/free snapshots produced `suppress → mount → suppress → mount → suppress`.
- The runtime DOM regression keeps the banner absent throughout those flaps, mounts it only after the free signal remains continuous, and removes it again when Pro returns.
- 213 focused checkout, entitlement, banner, and Pro-activation tests passed.
- 120 DOM tests passed.
- `npm run typecheck`
- `npm run typecheck:dom-tests`
- `npx biome lint src/components/ProBanner.ts src/services/pro-banner-policy.ts tests/pro-banner-entitlement-race.test.mts tests/dom/pro-banner-premium-stability.test.mts`
- `npm run docs:stats -- --check`
- `npx vite build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
