### PR TITLE
fix(china): normalize Decodo host before sticky-port detection

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -61,8 +61,12 @@ function parseProxyConfigForAttempt(raw, attempt = 0) {
   const config = parseProxyConfig(raw);
   if (!config) return null;
   const port = Number(config.port);
+  // Normalize for provider detection only: the host:port:user:pass form keeps
+  // whatever casing the operator typed, while the URL form is lowercased by the
+  // URL parser. config.host stays verbatim so the connection is unchanged.
+  const host = String(config.host || '').toLowerCase().replace(/\.$/u, '');
   if (
-    config.host !== DECODO_GATE_HOST
+    host !== DECODO_GATE_HOST
     || !Number.isInteger(port)
     || port < DECODO_STICKY_PORT_MIN
     || port > DECODO_STICKY_PORT_MAX

--- a/tests/china-corporate-disclosures.test.mts
+++ b/tests/china-corporate-disclosures.test.mts
@@ -1489,6 +1489,72 @@ describe('official China corporate disclosures (#5577)', () => {
     );
   });
 
+  it('drops intermediary routing identifiers that fail the allowlist', async () => {
+    const runWithEdgeHeaders = async (headers: Record<string, string>) => {
+      const decisions: Array<Record<string, unknown>> = [];
+      const snapshot = await fetchChinaCorporateDisclosureSnapshot({
+        now: Date.parse(retrievedAt),
+        previousSnapshot: null,
+        proxyUrl: '',
+        edgeEgress: {
+          url: 'https://api.example.test/api/internal/china-exchange-egress',
+          secret: 'edge-relay-secret',
+        },
+        onDecision: (decision) => decisions.push(decision),
+        fetchFn: async (input) => {
+          const url = String(input);
+          if (url.includes('query.sse.com.cn')) {
+            return new Response(JSON.stringify({
+              pageHelp: { pageNo: 1, pageSize: 100, total: 0 },
+              result: [],
+            }), { status: 200 });
+          }
+          throw Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('connect timed out'), { code: 'ETIMEDOUT' }),
+          });
+        },
+        edgeRequestFn: async () => new Response(
+          '<html>intermediary-response-secret</html>',
+          {
+            status: 502,
+            headers: { 'Content-Type': 'text/html; charset=utf-8', ...headers },
+          },
+        ),
+      });
+      return {
+        decision: decisions.find((decision) => decision.sourceId === 'szse'),
+        serialized: JSON.stringify({ snapshot, decisions }),
+      };
+    };
+
+    const rejectedCfRay = 'not-a-valid-ray';
+    // Allowlisted charset, but 102 characters -- rejected on length alone.
+    const rejectedVercelId = `iad1::${'x'.repeat(96)}`;
+
+    // A rejected identifier is dropped on its own; an allowlisted sibling in the
+    // same response still survives, so the guards must reject per field rather
+    // than pass the whole header set through or withhold all of it.
+    const partial = await runWithEdgeHeaders({
+      Server: 'vercel',
+      'CF-Ray': rejectedCfRay,
+      'X-Vercel-Id': rejectedVercelId,
+    });
+    assert.deepEqual(partial.decision?.edgeFailureDiagnostic, {
+      contentType: 'text/html',
+      server: 'vercel',
+    });
+    assert.doesNotMatch(partial.serialized, /not-a-valid-ray|xxxxxxxx/);
+
+    // Nothing allowlisted: the diagnostic is withheld entirely.
+    const none = await runWithEdgeHeaders({
+      Server: 'nginx',
+      'CF-Ray': rejectedCfRay,
+      'X-Vercel-Id': rejectedVercelId,
+    });
+    assert.equal('edgeFailureDiagnostic' in (none.decision ?? {}), false);
+    assert.doesNotMatch(none.serialized, /nginx|not-a-valid-ray|xxxxxxxx/);
+  });
+
   it('retains last-good SZSE data and all transport reasons after edge failure', async () => {
     const healthy = await fetchChinaCorporateDisclosureSnapshot({
       now: Date.parse(retrievedAt),

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -47,6 +47,25 @@ describe('proxy utilities', () => {
         rotatingPort,
       );
     }
+    // The host:port:user:pass form preserves hostname casing (the URL form does
+    // not), so provider detection must normalize rather than compare verbatim.
+    for (const equivalentHost of ['GATE.DECODO.COM', 'Gate.Decodo.Com', 'gate.decodo.com.']) {
+      assert.equal(
+        parseProxyConfigForAttempt(
+          `${equivalentHost}:10001:proxy-user:proxy-secret`,
+          1,
+        ).port,
+        10002,
+        equivalentHost,
+      );
+      assert.equal(
+        parseProxyConfigForAttempt(
+          `${equivalentHost}:10001:proxy-user:proxy-secret`,
+          1,
+        ).host,
+        equivalentHost,
+      );
+    }
     assert.equal(
       parseProxyConfigForAttempt(
         'https://proxy-user:proxy-secret@proxy.test:443',


### PR DESCRIPTION
## Summary

Follow-up to #5833 (merged as 5b87393aa), from a multi-lens review of that PR.

`parseProxyConfigForAttempt` decided whether to advance the Decodo sticky gateway port by comparing `config.host` byte-for-byte against the lowercase `gate.decodo.com` constant. The two supported proxy-config formats do not agree on hostname casing:

- the URL form (`http://user:pass@gate.decodo.com:10001`) is lowercased by the WHATWG URL parser via `u.hostname`;
- the Decodo `host:port:user:pass` form takes `parts[0]` verbatim, preserving whatever the operator typed.

So a case-variant or trailing-dot spelling — `GATE.DECODO.COM:10001:...`, `gate.decodo.com.:10001:...` — parsed fine and connected fine, but fell through the early `return config`. Every bounded retry then reused the configured sticky port, making #5833's exit diversification a silent no-op for that config shape. `SZSE_PROXY_URL` / `PROXY_URL` are operator-edited Railway env vars, so the spelling is not guaranteed.

This normalizes the hostname **for provider detection only** (lowercase, strip one terminal dot). `config.host` is passed through verbatim, so the connection itself is byte-identical to before.

Also adds the missing negative-path coverage for the `edgeFailureDiagnostic` header allowlist introduced in #5833. Those three guards (`server` allowlist, `cfRay` regex, `vercelId` charset/length) are the entire boundary keeping intermediary-controlled header text out of the per-run decision log, and every existing test fed them only well-formed, allowlisted values.

Related: #5640

## Validation

- **Proof-first.** The host-normalization regression failed before the fix (`actual: 10001, expected: 10002`) and passes after. It covers `GATE.DECODO.COM`, `Gate.Decodo.Com` and `gate.decodo.com.`, and separately asserts `config.host` is preserved verbatim so the connection host is not silently rewritten.
- **Mutation-tested.** Stripping all three `edgeFailureDiagnostic` guards — passing raw `server` / `cf-ray` / `x-vercel-id` values through — leaves the 26 pre-existing tests in `tests/china-corporate-disclosures.test.mts` green and fails only the new test. That is the gap this test closes: the allowlist could have been loosened or deleted with no red signal.
- `tests/proxy-utils.test.mjs` 3/3 (plain `node --test`, no deps), `tests/china-corporate-disclosures.test.mts` 27/27, biome clean on all three files, unicode-safety gate clean. Re-verified after rebasing onto current `main`, not only on the #5833 branch.

## Not in this PR

The same review surfaced three findings on #5833 that need a judgement call rather than a mechanical fix, and they are now live on `main`. Filing them here so they are not lost:

1. **A proxy-leg `HTTP_403` exits the retry loop before the rotated exit is dialled** (`scripts/china-corporate-disclosures/adapters.mjs`, `shouldRetrySzseProxyFailure`). `shouldProxySzseFailure` treats `HTTP_403` as "this egress is blocked, switch egress", but the retry predicate does not, so the newly-distinct second sticky session is never tried in the exact IP-block scenario #5833 was built for. Three independent reviewers converged on this. The open question is shape: whether an SZSE-origin 403 should be distinguished from a proxy CONNECT/auth 403 so `HTTP_407` stays non-retryable — relevant because prior Decodo incidents in this repo were account-level 407s that no port rotation can fix.
2. **Edge failures arriving with a 2xx status skip diagnostic extraction entirely.** `edgeFailureDiagnostic` is computed only under `if (!response.ok)`, so a 200 HTML challenge page or a 200 with a malformed body reaches the decision log as `MALFORMED_RESPONSE` with no diagnostic — the exact intermediary-vs-handler ambiguity the diagnostics were added to resolve.
3. **Nothing emitted says whether sticky-port rotation engaged.** No field records the exit port or whether advancement applied, so "repeated HTTP_522 across both proxy attempts" reads identically whether two distinct exits are both blocked (escalate) or rotation never engaged (fix config). This PR removes one silent-no-op cause but does not make the remaining ones observable.

## Post-Deploy Monitoring & Validation

- **Surface:** Railway `seed-bundle-market-backup` logs filtered to `event=china_corporate_disclosure_source` and `sourceId=szse`.
- **Healthy:** unchanged from #5833 — at least two consecutive accepted SZSE cycles, then `reliabilityStatus=stable`.
- **What this PR changes operationally:** nothing when `PROXY_URL` / `SZSE_PROXY_URL` is already lowercase `gate.decodo.com` on a sticky port; that path is byte-identical. It only starts advancing the port for spellings that previously fell through.
- **Failure:** a new `HTTP_407` or routing failure on the second proxy attempt where the first succeeded would indicate the account does not have the adjacent sticky port provisioned.
- **Rollback:** revert this PR; the pre-change behaviour is "never rotate for that host spelling", which is the current production behaviour, so rollback is a strict no-op for the already-working config.

---

https://claude.ai/code/session_01AhRWRDqqMmPCrQCMD3Vuga
