### PR TITLE
ci(gate): give each changes job a distinct check-run name (#5822)

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -34,6 +34,13 @@ concurrency:
 
 jobs:
   changes:
+    # Distinct check-run name — see the note in typecheck.yml (#5822). This
+    # workflow is push-to-main only, so it never competes on a PR head SHA, but
+    # the deploy gate evaluates main pushes too and `changes` is one of its
+    # required names: sharing the name would let this job's result stand in for
+    # test.yml's there. Not gated itself — deploy-gate.yml only aggregates Test,
+    # Typecheck, Lint Code and Security Audit.
+    name: convex-changes
     runs-on: ubuntu-latest
     outputs:
       convex: ${{ steps.diff.outputs.convex }}

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -43,7 +43,13 @@ jobs:
           # `audit-lockfile (root)`, `audit-lockfile (scripts)`, … so a bare
           # entry would wait on a check run that is never published; the
           # always()-running `security-audit` aggregate blocks for it instead.
-          required='["changes","docs-stats","unit","consumer-prices","sidecar","convex-tests","dom-tests","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","mintlify-slugs","security-audit"]'
+          #
+          # Entries are check-run NAMES, and the lookup below keeps only the
+          # last-completed run per name. Test, Typecheck and Lint Code each
+          # define a job with the id `changes`; the latter two publish under
+          # `typecheck-changes` / `lint-changes` so all three are evaluated
+          # instead of two being masked by the third (#5822).
+          required='["changes","typecheck-changes","lint-changes","docs-stats","unit","consumer-prices","sidecar","convex-tests","dom-tests","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","mintlify-slugs","security-audit"]'
 
           if [ -n "$SHA" ]; then
             # workflow_run event — evaluate exactly the triggering SHA.

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   changes:
+    # Distinct check-run name — see the note in typecheck.yml (#5822). The job
+    # id stays `changes` so `needs: changes` below keeps resolving.
+    name: lint-changes
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,6 +10,12 @@ permissions:
 
 jobs:
   changes:
+    # Distinct check-run name: test.yml and lint-code.yml each define a job with
+    # the same `changes` id, and the deploy gate matches check runs by name only
+    # — same-named runs collapse to whichever finished last, hiding the others'
+    # failures behind it (#5822). The job id stays `changes` so `needs: changes`
+    # below keeps resolving; only the published check-run name changes.
+    name: typecheck-changes
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -347,6 +347,56 @@ describe('CI workflow coverage', () => {
     );
   });
 
+  // #5822: the gate matches check runs by name alone, then keeps only the one
+  // that finished last. Two jobs publishing the same name — in different
+  // workflows or the same one — collapse to that single run and the others'
+  // conclusions are discarded, so a failure in any of them is invisible.
+  //
+  // For a `changes`-style filter job that is fail-open twice over: its
+  // dependents are `if: needs.changes.outputs.code == 'true'`, so when it fails
+  // they are *skipped* rather than failed, and the gate deliberately counts
+  // `skipped` as passing (docs-only PRs). A masked `changes` failure therefore
+  // takes an entire required suite green with it.
+  //
+  // Scan every workflow, not just the four the gate aggregates: the gate reads
+  // all check runs on the SHA regardless of which workflow published them, and
+  // it evaluates main pushes too, where a push- or schedule-triggered workflow
+  // lands its check runs on the very same commit.
+  it('keeps every gate-required check-run name published by exactly one job', () => {
+    const publishers = new Map<string, string[]>();
+
+    for (const file of readdirSync(workflowsDir).filter((n) => n.endsWith('.yml') || n.endsWith('.yaml'))) {
+      const source = read(resolve(workflowsDir, file));
+
+      for (const job of workflowJobNames(source, file)) {
+        const { name, templated } = effectiveCheckName(source, job);
+        if (templated) {
+          continue;
+        }
+        publishers.set(name, [...(publishers.get(name) ?? []), `${file}:${job}`]);
+      }
+    }
+
+    // Every gated job's effective name has to be in `required` (asserted
+    // above), so keying off `required` still covers all four gated workflows
+    // while leaving harmless duplicates alone — two cron-only workflows may
+    // both call a job `monitor` without the gate ever reading either.
+    //
+    // Exactly one, not at-least-one: a zero-publisher name hangs the gate at
+    // "pending" forever, and checking both directions means an empty or
+    // mis-parsed scan above fails here instead of vacuously passing.
+    const misrouted = deployGateRequiredChecks()
+      .map((check) => ({ check, sites: publishers.get(check) ?? [] }))
+      .filter(({ sites }) => sites.length !== 1)
+      .map(({ check, sites }) => `${check} <- ${sites.length > 0 ? sites.join(', ') : 'no job publishes it'}`);
+
+    assert.deepEqual(
+      misrouted,
+      [],
+      `deploy-gate.yml keys on the check-run name only and keeps just the last-completed run, so a required name published by more than one job masks every other publisher's failure, and one published by none never leaves "pending" (#5822). Give each job a distinct name: ${misrouted.join('; ')}`,
+    );
+  });
+
   it('paginates gate status history during the scheduled self-healing sweep', () => {
     const deployGateJob = workflowJobBlock(deployGateWorkflow, 'gate');
 


### PR DESCRIPTION
## Summary

Closes #5822.

`test.yml`, `typecheck.yml` and `lint-code.yml` each define a job with the id `changes`, and none overrode `name:`, so all three published a check run literally named `changes` on the same head SHA. `deploy-gate.yml` matches check runs by **name** and keeps only the last-completed one (`sorted(matches, …)[-1]`), so two of the three were silently discarded on every PR.

This is fail-open on an entire required suite, not on one job. Every gated job in those workflows is `if: needs.changes.outputs.code == 'true'`, so when a `changes` job fails its dependents are **skipped**, not failed — and the gate deliberately counts `skipped` as passing (for docs-only PRs). A `changes` failure therefore took its whole workflow green, masked by a sibling that finished a second later.

Implements the issue's recommended Option 1.

## Changes

| File | Change |
|---|---|
| `typecheck.yml` | `changes` job publishes `name: typecheck-changes` |
| `lint-code.yml` | `changes` job publishes `name: lint-changes` |
| `convex-deploy.yml` | `changes` job publishes `name: convex-changes` |
| `deploy-gate.yml` | `typecheck-changes` + `lint-changes` added to `required` |
| `tests/ci-workflow-coverage.test.mts` | new uniqueness guard |

`test.yml` keeps `changes`. **Job ids are unchanged**, so every `needs: changes` / `needs.changes.outputs.*` reference still resolves — only the published check-run name changes.

Convex Deploy is included because it also defines a `changes` job. It is push-to-main only so it never competes on a PR head SHA, but the gate evaluates main pushes too, where it would otherwise stand in for `test.yml`'s. It is not itself gated (the gate only aggregates Test, Typecheck, Lint Code, Security Audit), so it is renamed but not added to `required`.

## The guard #5402 added could not catch this

All three jobs were named `changes` and `changes` was present in the required list, so the existing drift guard was satisfied. This adds a uniqueness assertion over **effective check-run names** (the `name:` override when present, else the job id).

Two deliberate scope choices:

- **Scans every workflow, not just the four the gate aggregates.** The gate reads all check runs on the SHA regardless of which workflow published them, and it evaluates main pushes — where a push- or schedule-triggered workflow lands check runs on the same commit. Scoping to the gated four would have missed `convex-deploy.yml` entirely.
- **Asserts exactly one publisher, not at-least-one.** A zero-publisher required entry hangs the gate at `pending` forever, so checking both directions means an empty or mis-parsed scan fails loudly instead of passing vacuously.

## Validation

**Reproduced first.** `gh api …/commits/ac4fce50/check-runs` returns three check runs named `changes` in three different check suites, exactly as the issue reports.

**The real gate logic, before and after.** Ran `deploy-gate.yml`'s actual `jq` filter and `python3` block against a synthetic payload where the Typecheck filter job fails and finishes *first*, with two siblings succeeding after:

```
BEFORE - single required entry, 3 same-named runs   gate => SUCCESS
                                                    evaluated changes as: success
AFTER  - three distinct names, all required         gate => FAILURE: typecheck-changes
```

Also confirmed `changes` at index 0 survives the gate's `select(… index($name))` filter — jq treats `0` as truthy, so the first required entry is not silently dropped.

**Test-first.** The new guard was written before the fix and observed red for the right reason:

```
changes <- convex-deploy.yml:changes, lint-code.yml:changes, test.yml:changes, typecheck.yml:changes
```

Green after the fix: `tests 14 / pass 14 / fail 0`.

**Mutation-tested (8 mutations, every one caught).** Because the deliverable *is* a CI alarm, each way of restoring the bug was applied and the suite re-run:

| Mutation | Result |
|---|---|
| M1 drop `name: typecheck-changes` | caught (new guard + phantom guard) |
| M2 drop `name: lint-changes` | caught (new guard + phantom guard) |
| M3 drop `name: convex-changes` | **caught by new guard only** |
| M4 set typecheck job's name back to `changes` | caught (new guard + phantom guard) |
| M5 drop `typecheck-changes` from `required` | caught (existing every-job guard) |
| M6 drop `lint-changes` from `required` | caught (existing every-job guard) |
| M7 new workflow publishing a colliding `unit` | **caught by new guard only** |
| M8 `biome` job renamed to publish `unit` | caught (new guard + phantom guard) |

M3 and M7 prove the guard adds coverage no existing test had.

**Other checks:** all four edited workflows re-parsed as YAML to confirm job ids, `name:` overrides and `needs:` edges (`typecheck [needs:changes]`, `biome [needs:changes]`, `deploy [needs:changes]` all intact); `npm run lint:unicode` clean; `npx biome check` clean on the changed test.

## Rollout note

`required` gains two entries, so a PR whose workflows already ran under the old names will read `Waiting for required PR gates: typecheck-changes,lint-changes` until its branch is updated and CI re-runs. This fails **closed**, not open, and clears on the next push or `gh pr update-branch`.

Spot-checking open PRs, the affected set is small: stale/conflicting PRs (#5461, #5488, #5496, #5515, #5799) currently publish no gated check runs at all — no merge ref, so Test/Typecheck/Lint never dispatch — so they are already stuck for an unrelated reason and are not made worse. Only PRs with live CI whose head predates this merge are affected, and those are the actively-worked ones.

## Post-Deploy Monitoring & Validation

`deploy-gate.yml` is a `workflow_run` workflow, so it always executes the **default-branch** copy of its own file — this change is *not* exercised on this PR and goes live only on merge. Pre-merge proof therefore comes from `tests/ci-workflow-coverage.test.mts` and the synthetic before/after run above.

- **Watch:** the first 2–3 PRs merged after this lands.
- **Healthy signal:** the gate's own log line lists all three, e.g. `changes=success typecheck-changes=success lint-changes=success …`, and the posted `gate` status reads `All required PR gates passed`.
  ```bash
  gh api repos/koala73/worldmonitor/commits/$SHA/statuses?per_page=100 \
    --jq '[.[]|select(.context=="gate")]|first|"\(.state) :: \(.description)"'
  ```
- **Failure signal / rollback trigger:** a PR with all checks green stuck at `Waiting for required PR gates: typecheck-changes` or `lint-changes` for longer than one scheduled sweep (30 min) on a branch that *has* been updated past this merge. That would mean the published name does not match the `required` entry. Mitigation: revert the two `required` additions on `main` (the `name:` overrides are harmless on their own); the 30-minute self-healing sweep then clears stranded PRs with no manual re-run.
- **Window / owner:** first business day after merge, @koala73.

## Note on main

`main` is currently red on `docs-stats` (AGENTS.md says 215 services, code has 216) and `unit`, so `gate` reports `failure` there and this PR's own gate will reflect that. Both are already fixed in #5840 — verified pre-existing by running `node scripts/docs-stats.mjs --check` on a pristine `origin/main` with zero local changes. Nothing filed, since #5840 covers it.
