### PR TITLE
fix(pro): prevent post-checkout entitlement reload loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 179
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 179 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (216 service modules and domain directories)
+│   ├── services/           # Business logic (217 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 179,
-  "serviceTopLevelEntries": 216,
+  "serviceTopLevelEntries": 217,
   "apiEndpointEntries": 89,
   "panelClasses": 107,
   "protoFiles": 290,

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -44,7 +44,8 @@ import { trackCriticalBannerAction, trackCheckoutSuccess, trackCheckoutFailed, t
 import { getStoredMapModePreference } from '@/services/map-mode-preference';
 import { loadWidgets, saveWidget, isProUser } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
-import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, hasTier, getEntitlementState, onEntitlementChange, shouldReloadOnEntitlementChange } from '@/services/entitlements';
+import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, hasTier, getEntitlementState, onEntitlementChange } from '@/services/entitlements';
+import { createEntitlementReloadController } from '@/services/entitlement-reload-controller';
 import { initSubscriptionWatch, destroySubscriptionWatch, onSubscriptionChange } from '@/services/billing';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
@@ -492,10 +493,10 @@ export class PanelLayoutManager implements AppModule {
       email: getAuthState().user?.email ?? null,
     }));
 
-    // Reload only on a free→pro transition. Legacy-pro users whose first
-    // snapshot is already pro (lastEntitled === null) must not trigger a
-    // reload loop, but a user who pays mid-session (false → true) must see
-    // their panels unlock without manual refresh.
+    // Reload at most once per account and browser tab on a free→pro
+    // transition. Legacy-pro users whose first snapshot is already pro must
+    // not reload, while a newly upgraded user gets one clean boot with every
+    // premium panel initialized against the paid entitlement.
     //
     // When we just returned from a Dodo full-page redirect checkout, seed
     // lastEntitled = false instead of null. The webhook may have already
@@ -505,31 +506,30 @@ export class PanelLayoutManager implements AppModule {
     // the user would see locked panels until a manual refresh — exactly the
     // symptom that caused the 2026-04-17/18 duplicate-subscription incident.
     //
-    // REQUIRES_SKIP_INITIAL_SNAPSHOT_BEHAVIOR — the watcher is the SOLE
-    // automatic reload source for post-checkout success (the overlay
-    // handler in checkout.ts deliberately does NOT reload). If PR #3163's
-    // fix to `skipInitialSnapshot` is ever reverted, this detector
-    // swallows the activation silently and users see locked panels for
-    // 30s until the extended-unlock timeout fires a manual-refresh CTA.
-    // Regression guard: tests/entitlement-transition.test.mts locks the
-    // "incident sequence" semantics; see mirror marker in checkout.ts.
-    let lastEntitled: boolean | null = returnedFromCheckout ? false : null;
-    this.unsubscribeEntitlementChange = onEntitlementChange(() => {
-      const entitled = isEntitled();
-      const reload = shouldReloadOnEntitlementChange(lastEntitled, entitled);
-      lastEntitled = entitled;
-      if (reload) {
-        console.log('[entitlements] Subscription activated — reloading to unlock panels');
+    // The guard is persisted and verified BEFORE navigation. If storage is
+    // blocked, we fail closed to updatePanelGating() without reloading. This
+    // prevents the customer-visible failure where each new page boot receives
+    // another transient free→pro sequence and reloads again every ~500ms.
+    //
+    // REQUIRES_SKIP_INITIAL_SNAPSHOT_BEHAVIOR — this remains the sole
+    // automatic reload source for post-checkout success (the overlay handler
+    // in checkout.ts deliberately does NOT reload). Regression guards:
+    // tests/entitlement-transition.test.mts locks the raw transition semantics;
+    // tests/entitlement-reload-controller.test.mts locks the cross-boot
+    // one-navigation invariant from the daypesta customer recording.
+    const entitlementReloadController = createEntitlementReloadController({
+      returnedFromCheckout,
+      onSnapshot: () => this.updatePanelGating(getAuthState()),
+      reload: () => {
+        console.log('[entitlements] Subscription activated — reloading once to unlock panels');
         window.location.reload();
-        return;
-      }
-      // Re-run panel gating on every entitlement snapshot. hasPremiumAccess()
-      // now consults isEntitled(), so a legacy-pro user whose first snapshot
-      // is already pro (null→true — intentionally not reloaded to avoid a
-      // loop) still needs the paywall overlay lifted; likewise on WS reconnect
-      // or entitlement revocation, the lock state must follow the current
-      // snapshot synchronously rather than waiting for the next auth event.
-      this.updatePanelGating(getAuthState());
+      },
+    });
+    this.unsubscribeEntitlementChange = onEntitlementChange(() => {
+      entitlementReloadController.handleSnapshot(
+        isEntitled(),
+        getAuthState().user?.id ?? null,
+      );
     });
 
     // #4771: billing-state transitions can arrive on the SUBSCRIPTION row

--- a/src/services/entitlement-reload-controller.ts
+++ b/src/services/entitlement-reload-controller.ts
@@ -1,0 +1,90 @@
+import { shouldReloadOnEntitlementChange } from './entitlements';
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+interface EntitlementReloadControllerOptions {
+  returnedFromCheckout?: boolean;
+  storage?: StorageLike;
+  reload?: () => void;
+  onSnapshot?: () => void;
+}
+
+const ENTITLEMENT_RELOAD_GUARD_PREFIX = 'wm-entitlement-reload-account:v1:';
+
+function getSessionStorage(): StorageLike | undefined {
+  try {
+    return typeof window === 'undefined' ? undefined : window.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function guardKey(accountId: string): string | null {
+  if (accountId.length === 0 || accountId.length > 256) return null;
+  return `${ENTITLEMENT_RELOAD_GUARD_PREFIX}${accountId}`;
+}
+
+function hasGuard(storage: StorageLike | undefined, accountId: string): boolean {
+  const key = guardKey(accountId);
+  if (!storage || !key) return false;
+  try {
+    return storage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persist and verify the one-shot marker before allowing navigation.
+ *
+ * This is deliberately fail-closed: sessionStorage can throw in restricted
+ * browsing modes. In that case panel gating still updates in place, but the
+ * app must not perform an automatic reload that it cannot prove will be
+ * suppressed after the next boot.
+ */
+function persistGuard(storage: StorageLike | undefined, accountId: string): boolean {
+  const key = guardKey(accountId);
+  if (!storage || !key) return false;
+  if (hasGuard(storage, accountId)) return true;
+  try {
+    storage.setItem(key, '1');
+  } catch {
+    return false;
+  }
+  return hasGuard(storage, accountId);
+}
+
+export function createEntitlementReloadController(
+  options: EntitlementReloadControllerOptions = {},
+): { handleSnapshot(entitled: boolean, accountId?: string | null): boolean } {
+  const storage = options.storage ?? getSessionStorage();
+  const reload = options.reload ?? (() => window.location.reload());
+  let lastEntitled: boolean | null = options.returnedFromCheckout ? false : null;
+
+  return {
+    handleSnapshot(entitled, accountId = null) {
+      const isUnlockTransition = shouldReloadOnEntitlementChange(lastEntitled, entitled);
+      lastEntitled = entitled;
+
+      // Gating is the primary unlock path and must run even when navigation is
+      // suppressed. Calling it before reload also leaves the page usable if
+      // the browser refuses the navigation.
+      options.onSnapshot?.();
+
+      if (!isUnlockTransition || !accountId) return false;
+      if (hasGuard(storage, accountId)) return false;
+      if (!persistGuard(storage, accountId)) return false;
+
+      try {
+        reload();
+        return true;
+      } catch (err) {
+        console.warn('[entitlements] Automatic unlock reload failed; panels were unlocked in place:', err);
+        return false;
+      }
+    },
+  };
+}

--- a/tests/entitlement-reload-controller.test.mts
+++ b/tests/entitlement-reload-controller.test.mts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+import { createEntitlementReloadController } from '@/services/entitlement-reload-controller';
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+class BlockedStorage {
+  getItem(): string | null {
+    throw new DOMException('storage blocked', 'SecurityError');
+  }
+
+  setItem(): void {
+    throw new DOMException('storage blocked', 'SecurityError');
+  }
+}
+
+describe('entitlement reload controller', () => {
+  it('reproduces daypesta cadence without a page reload loop', () => {
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    let gatingPasses = 0;
+    const order: string[] = [];
+    const options = {
+      storage,
+      reload: () => {
+        order.push('reload');
+        reloads += 1;
+      },
+      onSnapshot: () => {
+        order.push('gating');
+        gatingPasses += 1;
+      },
+    };
+
+    // First page boot: the authenticated snapshot changes free → Pro.
+    const firstBoot = createEntitlementReloadController(options);
+    firstBoot.handleSnapshot(false, 'daypesta');
+    firstBoot.handleSnapshot(true, 'daypesta');
+    assert.equal(reloads, 1);
+    assert.deepEqual(order.slice(-2), ['gating', 'reload']);
+
+    // New JS realm after that navigation. The customer's recording shows
+    // this free/Pro sequence recurring roughly every half-second. The
+    // persisted one-shot guard must stop every later navigation while
+    // gating still follows every snapshot in place.
+    const secondBoot = createEntitlementReloadController(options);
+    for (const entitled of [false, true, false, true, false, true]) {
+      secondBoot.handleSnapshot(entitled, 'daypesta');
+    }
+
+    assert.equal(reloads, 1, 'an activation episode may navigate only once across page boots');
+    assert.equal(gatingPasses, 8, 'suppressed navigations must still update panel gating');
+  });
+
+  it('allows the seeded checkout-return activation to navigate once', () => {
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    const options = {
+      storage,
+      reload: () => { reloads += 1; },
+    };
+
+    const checkoutBoot = createEntitlementReloadController({
+      ...options,
+      returnedFromCheckout: true,
+    });
+    checkoutBoot.handleSnapshot(true, 'daypesta');
+
+    const nextBoot = createEntitlementReloadController(options);
+    nextBoot.handleSnapshot(false, 'daypesta');
+    nextBoot.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 1);
+  });
+
+  it('does not let one account suppress another account activation', () => {
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    const options = {
+      storage,
+      reload: () => { reloads += 1; },
+    };
+
+    const firstAccount = createEntitlementReloadController(options);
+    firstAccount.handleSnapshot(false, 'daypesta');
+    firstAccount.handleSnapshot(true, 'daypesta');
+
+    const secondAccount = createEntitlementReloadController(options);
+    secondAccount.handleSnapshot(false, 'another-user');
+    secondAccount.handleSnapshot(true, 'another-user');
+
+    const firstAccountAgain = createEntitlementReloadController(options);
+    firstAccountAgain.handleSnapshot(false, 'daypesta');
+    firstAccountAgain.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 2);
+  });
+
+  it('fails closed to in-place gating when a cross-reload guard cannot persist', () => {
+    let reloads = 0;
+    let gatingPasses = 0;
+    const controller = createEntitlementReloadController({
+      storage: new BlockedStorage(),
+      reload: () => { reloads += 1; },
+      onSnapshot: () => { gatingPasses += 1; },
+    });
+
+    controller.handleSnapshot(false, 'daypesta');
+    controller.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 0, 'never navigate when the loop guard cannot survive navigation');
+    assert.equal(gatingPasses, 2, 'Pro access must still unlock in place');
+  });
+
+  it('fails closed to in-place gating when the activation cannot be account-scoped', () => {
+    let reloads = 0;
+    let gatingPasses = 0;
+    const controller = createEntitlementReloadController({
+      storage: new MemoryStorage(),
+      reload: () => { reloads += 1; },
+      onSnapshot: () => { gatingPasses += 1; },
+    });
+
+    controller.handleSnapshot(false, null);
+    controller.handleSnapshot(true, null);
+
+    assert.equal(reloads, 0);
+    assert.equal(gatingPasses, 2);
+  });
+
+  it('never navigates for an already-Pro first snapshot', () => {
+    let reloads = 0;
+    const controller = createEntitlementReloadController({
+      storage: new MemoryStorage(),
+      reload: () => { reloads += 1; },
+    });
+
+    controller.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 0);
+  });
+
+  it('wires the guarded controller into the live panel entitlement watcher', async () => {
+    const panelLayout = await readFile(
+      new URL('../src/app/panel-layout.ts', import.meta.url),
+      'utf8',
+    );
+
+    assert.match(
+      panelLayout,
+      /createEntitlementReloadController\(\{\s*returnedFromCheckout,/,
+      'checkout-return seeding must flow into the guarded controller',
+    );
+    assert.match(
+      panelLayout,
+      /onSnapshot:\s*\(\)\s*=>\s*this\.updatePanelGating\(getAuthState\(\)\)/,
+      'every entitlement snapshot must continue to update gating in place',
+    );
+    assert.match(
+      panelLayout,
+      /entitlementReloadController\.handleSnapshot\(\s*isEntitled\(\),\s*getAuthState\(\)\.user\?\.id \?\? null,/,
+      'the live watcher must scope the cross-reload guard to the authenticated account',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

A customer-provided recording showed the full dashboard rebuilding roughly every half-second after a Pro purchase. A fresh boot could receive another transient free-to-Pro snapshot sequence, so the entitlement watcher reloaded again and created a self-sustaining loop.

This change makes entitlement activation navigation account-scoped and one-shot per browser tab. It persists and verifies the guard before navigating; if storage is blocked or no authenticated account is available, panel gating updates in place without an automatic reload.

## Behavior

| Case | Before | After |
|---|---|---|
| First authenticated free-to-Pro transition | Reload | Update gating, persist the guard, then reload once |
| Later snapshot flaps after the reload | Reload again on every free-to-Pro edge | Update gating in place; never reload that account again in the tab |
| Restricted or blocked session storage | Could navigate without a cross-boot guard | Fail closed to in-place gating |
| Existing Pro first snapshot | No reload | No reload |
| Different account in the same tab | Shared behavior | Independent one-shot guard |

Follow-up to #5836, which fixed the separate Pro-banner flicker but did not address the page-level reload loop visible in the customer recording.

## Validation

- 288 focused entitlement, checkout, activation, billing, and auth-handoff tests passed.
- 8 related DOM tests passed.
- Source and API TypeScript checks passed.
- Production Vite bundle completed successfully.
- Pre-push gates passed, including the new 7-test regression file and 240 edge-function checks.
- Mutation check: disabling the persisted guard changed the reproduced cadence from 1 reload to 4 and failed the regression as intended.
- The sandbox-wide `test:data` run was not counted as a pass because unrelated local-server suites did not terminate; GitHub CI remains the complete repository-wide gate.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
