### PR TITLE
fix(proxy): match the Decodo curl-endpoint rewrite case-insensitively

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -6,6 +6,8 @@ const https = require('node:https');
 const zlib = require('node:zlib');
 
 const DECODO_GATE_HOST = 'gate.decodo.com';
+// Decodo's curl endpoint differs from its CONNECT endpoint.
+const DECODO_CURL_HOST = 'us.decodo.com';
 const DECODO_STICKY_PORT_MIN = 10_001;
 const DECODO_STICKY_PORT_MAX = 49_999;
 
@@ -106,12 +108,16 @@ function resolveProxyConfigWithFallback() {
 function resolveProxyString(raw = process.env.PROXY_URL || '') {
   const cfg = parseProxyConfig(raw);
   if (!cfg) return '';
-  // Case-insensitive: the host:port:user:pass branch of parseProxyConfig returns
-  // parts[0] verbatim, so an operator's casing reaches this compare unchanged. A
-  // case-sensitive match would silently skip the rewrite and leave a curl caller
-  // pointed at the CONNECT endpoint. Only the matched prefix is replaced — the
-  // rest of the host keeps its spelling, and DNS is case-insensitive anyway.
-  const host = cfg.host.replace(/^gate\./i, 'us.');
+  // Exact provider match, not a `gate.` prefix rewrite. Two reasons:
+  //   - parseProxyConfig's host:port:user:pass branch returns parts[0] verbatim,
+  //     so an operator's casing reaches this compare unchanged; a case-sensitive
+  //     match silently skipped the rewrite and left a curl caller pointed at the
+  //     CONNECT endpoint.
+  //   - a prefix match rewrites ANY `gate.*` host, so an unrelated proxy would be
+  //     redirected to a Decodo endpoint with its credentials attached. Matching
+  //     the one host we actually mean keeps every other provider untouched.
+  const normalizedHost = String(cfg.host || '').toLowerCase().replace(/\.$/u, '');
+  const host = normalizedHost === DECODO_GATE_HOST ? DECODO_CURL_HOST : cfg.host;
   return cfg.auth ? `${cfg.auth}@${host}:${cfg.port}` : `${host}:${cfg.port}`;
 }
 

--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -106,7 +106,12 @@ function resolveProxyConfigWithFallback() {
 function resolveProxyString(raw = process.env.PROXY_URL || '') {
   const cfg = parseProxyConfig(raw);
   if (!cfg) return '';
-  const host = cfg.host.replace(/^gate\./, 'us.');
+  // Case-insensitive: the host:port:user:pass branch of parseProxyConfig returns
+  // parts[0] verbatim, so an operator's casing reaches this compare unchanged. A
+  // case-sensitive match would silently skip the rewrite and leave a curl caller
+  // pointed at the CONNECT endpoint. Only the matched prefix is replaced — the
+  // rest of the host keeps its spelling, and DNS is case-insensitive anyway.
+  const host = cfg.host.replace(/^gate\./i, 'us.');
   return cfg.auth ? `${cfg.auth}@${host}:${cfg.port}` : `${host}:${cfg.port}`;
 }
 

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -7,6 +7,7 @@ const {
   _readBoundedResponseStream,
   parseProxyConfig,
   parseProxyConfigForAttempt,
+  resolveProxyString,
 } = createRequire(import.meta.url)('../scripts/_proxy-utils.cjs');
 
 describe('proxy utilities', () => {
@@ -21,6 +22,27 @@ describe('proxy utilities', () => {
       },
     );
     assert.equal(parseProxyConfig('ftp://proxy.test/resource'), null);
+  });
+
+  it('rewrites the Decodo CONNECT host to the curl endpoint regardless of case', () => {
+    // The curl endpoint differs from the CONNECT endpoint, so this rewrite is
+    // what routes a curl-based caller correctly. parseProxyConfig's
+    // host:port:user:pass branch returns the host verbatim, so an operator's
+    // casing reaches the compare un-normalized -- a case-sensitive prefix
+    // match silently leaves the caller pointed at the CONNECT endpoint.
+    for (const equivalentHost of ['gate.decodo.com', 'GATE.DECODO.COM', 'Gate.Decodo.Com']) {
+      assert.match(
+        resolveProxyString(`${equivalentHost}:10001:proxy-user:proxy-secret`),
+        /^proxy-user:proxy-secret@us\.[Dd][Ee][Cc][Oo][Dd][Oo]\.[Cc][Oo][Mm]:10001$/u,
+        equivalentHost,
+      );
+    }
+    // A non-Decodo provider keeps its configured route untouched.
+    assert.equal(
+      resolveProxyString('https://proxy-user:proxy-secret@proxy.test:443'),
+      'proxy-user:proxy-secret@proxy.test:443',
+    );
+    assert.equal(resolveProxyString(''), '');
   });
 
   it('uses a distinct Decodo sticky port per attempt and preserves other routes', () => {

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -30,14 +30,35 @@ describe('proxy utilities', () => {
     // host:port:user:pass branch returns the host verbatim, so an operator's
     // casing reaches the compare un-normalized -- a case-sensitive prefix
     // match silently leaves the caller pointed at the CONNECT endpoint.
-    for (const equivalentHost of ['gate.decodo.com', 'GATE.DECODO.COM', 'Gate.Decodo.Com']) {
-      assert.match(
+    for (const equivalentHost of [
+      'gate.decodo.com',
+      'GATE.DECODO.COM',
+      'Gate.Decodo.Com',
+      'gate.decodo.com.',
+    ]) {
+      assert.equal(
         resolveProxyString(`${equivalentHost}:10001:proxy-user:proxy-secret`),
-        /^proxy-user:proxy-secret@us\.[Dd][Ee][Cc][Oo][Dd][Oo]\.[Cc][Oo][Mm]:10001$/u,
+        'proxy-user:proxy-secret@us.decodo.com:10001',
         equivalentHost,
       );
     }
-    // A non-Decodo provider keeps its configured route untouched.
+
+    // Only the Decodo gateway is rewritten. A prefix match would send these to a
+    // Decodo endpoint with their credentials attached, so each must pass through
+    // untouched: a same-prefix foreign host, its uppercase spelling, and a host
+    // that merely contains `gate.` away from the start.
+    for (const foreignHost of [
+      'gate.proxy.test',
+      'GATE.PROXY.TEST',
+      'proxy.gate.example.com',
+    ]) {
+      assert.equal(
+        resolveProxyString(`${foreignHost}:10001:proxy-user:proxy-secret`),
+        `proxy-user:proxy-secret@${foreignHost}:10001`,
+        foreignHost,
+      );
+    }
+
     assert.equal(
       resolveProxyString('https://proxy-user:proxy-secret@proxy.test:443'),
       'proxy-user:proxy-secret@proxy.test:443',


### PR DESCRIPTION
## Summary

Closes #5844.

`resolveProxyString` rewrites `gate.decodo.com` → `us.decodo.com` because, per its own comment, *"the curl endpoint differs from the CONNECT endpoint."* The match was case-sensitive:

```js
const host = cfg.host.replace(/^gate\./, 'us.');
```

`parseProxyConfig`'s `host:port:user:pass` branch returns `parts[0]` verbatim, so an operator's casing in `PROXY_URL` reaches that compare un-normalized. A `GATE.` or `Gate.` spelling silently skipped the rewrite and handed a curl caller the **CONNECT** endpoint instead. Nothing threw — the result is still a syntactically valid proxy spec.

Fixed by matching the exact Decodo host rather than rewriting a `gate.` prefix. Before / after, against this branch:

```
                          before                        after
gate.decodo.com        -> u:p@us.decodo.com:10001    -> u:p@us.decodo.com:10001
GATE.DECODO.COM        -> u:p@GATE.DECODO.COM:10001  -> u:p@us.decodo.com:10001   (bug fixed)
Gate.Decodo.Com        -> u:p@Gate.Decodo.Com:10001  -> u:p@us.decodo.com:10001   (bug fixed)
gate.decodo.com.       -> u:p@us.decodo.com.:10001   -> u:p@us.decodo.com:10001   (canonicalized)
gate.proxy.test        -> u:p@us.proxy.test:10001    -> u:p@gate.proxy.test:10001 (over-match closed)
GATE.PROXY.TEST        -> u:p@GATE.PROXY.TEST:10001  -> u:p@GATE.PROXY.TEST:10001
proxy.gate.example.com -> u:p@proxy.gate.example.com -> u:p@proxy.gate.example.com
proxy.test             -> u:p@proxy.test:10001       -> u:p@proxy.test:10001
```

**This narrows behaviour as well as fixing the bug.** The original `/^gate\./` rewrote *any* host starting `gate.`, so an unrelated provider would have been redirected to a Decodo endpoint with its credentials attached. Matching the exact host closes that. No non-Decodo `gate.*` proxy host is configured anywhere in the repo (only Decodo and Froxy's `proxy.froxy.com`), so nothing depended on the loose behaviour.

`resolveProxyStringConnect` is deliberately untouched: CONNECT wants the `gate.` host, and it still returns it verbatim.

## Why this matters

Same bug class as #5837, and four months older. This consumer has compared against the same parser's output since #2205 (2026-03-24), while the format that yields un-normalized hosts landed in #2399 (2026-03-28). The failure mode is invisible in the same way — no throw, no log — and `PROXY_URL` is an operator-edited Railway env var whose spelling is not machine-verified anywhere.

This is a **latent-configuration** fix, not a live-outage fix: it only changes behaviour if a deployed `PROXY_URL` is spelled with a non-lowercase `gate.`. Nobody has confirmed the deployed value's spelling; that check is worth doing separately and is not a blocker for making the code correct.

## Validation

- **Proof-first.** `resolveProxyString` had **no test coverage at all**; this adds the first. The new test failed before the fix with `actual: 'proxy-user:proxy-secret@GATE.DECODO.COM:10001'` and passes after.
- **Mutation-verified.** Restoring the case-sensitive regex reds exactly this test and nothing else.
- The test loops the three equivalent spellings, plus a non-Decodo URL route and the empty-config case, so it pins both the rewrite and the leave-alone paths.
- Green: `proxy-utils` 4/4, `oref-proxy` 1/1, `portwatch-port-activity` 105/105, `portwatch-chokepoints-ref` 27/27, `seed-fatf-listing` 33/33, `seed-unrest-gdelt-fetch` 12/12, `ais-relay-opensky-proxy-tls` 2/2, `dockerfile-relay-imports` 4/4, `resilience-validation-import-graph` 20/20. Biome and the CJS syntax check clean; full pre-push gate passed.

## Blast radius

`resolveProxyString` reaches curl-based callers via `scripts/_seed-utils.mjs:1036` (`resolveProxy`) and `scripts/ais-relay.cjs:2125` (Yahoo quote-summary fallback). Both pass the string straight to `curl -x`; nothing parses or compares it, so widening the match cannot break a consumer.

Related: #5833, #5837, #5839, #5640

---

https://claude.ai/code/session_01AhRWRDqqMmPCrQCMD3Vuga

## Review record

Reviewed by an independent correctness pass and a cross-model adversarial pass; they disagreed, and the cross-model one was right.

- The in-process reviewer returned `ship`, reasoning that the old regex already rewrote any lowercase `gate.*`, so case-sensitivity was never a provider guard. True, but incomplete.
- The cross-model reviewer returned `fix-first`: making the match case-insensitive *widened* that pre-existing over-match to `GATE.*` spellings that had previously been safe. Its suggested fix — exact-host match — resolves the reported bug and the over-match together.

The first cut of this PR (`/^gate\./i`) is now itself a caught mutation: it reds the test.

The in-process reviewer also filed a P3 that the original test could not pin the `^` anchor — every input started `gate.`, so deleting `^` kept the suite green. `proxy.gate.example.com` now covers it.

Mutation matrix, all four caught:

| Reverted to | Test result |
|---|---|
| `/^gate\./` (case-sensitive prefix) | red |
| `/^gate\./i` (this PR's first cut) | red |
| exact match without trailing-dot strip | red |
| exact match without lowercasing | red |
