### PR TITLE
fix(pro): fail closed on entitlement reload guard

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -44,7 +44,7 @@ import { trackCriticalBannerAction, trackCheckoutSuccess, trackCheckoutFailed, t
 import { getStoredMapModePreference } from '@/services/map-mode-preference';
 import { loadWidgets, saveWidget, isProUser } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
-import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, hasTier, getEntitlementState, onEntitlementChange } from '@/services/entitlements';
+import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitlementActive, hasTier, getEntitlementState, onEntitlementChange } from '@/services/entitlements';
 import { createEntitlementReloadController } from '@/services/entitlement-reload-controller';
 import { initSubscriptionWatch, destroySubscriptionWatch, onSubscriptionChange } from '@/services/billing';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
@@ -525,9 +525,9 @@ export class PanelLayoutManager implements AppModule {
         window.location.reload();
       },
     });
-    this.unsubscribeEntitlementChange = onEntitlementChange(() => {
+    this.unsubscribeEntitlementChange = onEntitlementChange((state) => {
       entitlementReloadController.handleSnapshot(
-        isEntitled(),
+        state === null ? null : isEntitlementActive(state, Date.now()),
         getAuthState().user?.id ?? null,
       );
     });

--- a/src/services/entitlement-reload-controller.ts
+++ b/src/services/entitlement-reload-controller.ts
@@ -27,9 +27,33 @@ function guardKey(accountId: string): string | null {
   return `${ENTITLEMENT_RELOAD_GUARD_PREFIX}${accountId}`;
 }
 
-function hasGuard(storage: StorageLike | undefined, accountId: string): boolean {
+/**
+ * Claim and verify a new one-shot marker before allowing navigation.
+ *
+ * This is deliberately fail-closed: sessionStorage can throw in restricted
+ * browsing modes. In that case panel gating still updates in place, but the
+ * app must not perform an automatic reload that it cannot prove will be
+ * suppressed after the next boot.
+ */
+function persistNewGuard(storage: StorageLike | undefined, accountId: string): boolean {
   const key = guardKey(accountId);
   if (!storage || !key) return false;
+
+  // A failed read is not evidence that the marker is absent. Do not retry the
+  // read inside this navigation attempt: a later successful read of an
+  // existing marker must never be mistaken for a newly persisted marker.
+  try {
+    if (storage.getItem(key) === '1') return false;
+  } catch {
+    return false;
+  }
+
+  try {
+    storage.setItem(key, '1');
+  } catch {
+    return false;
+  }
+
   try {
     return storage.getItem(key) === '1';
   } catch {
@@ -37,46 +61,42 @@ function hasGuard(storage: StorageLike | undefined, accountId: string): boolean 
   }
 }
 
-/**
- * Persist and verify the one-shot marker before allowing navigation.
- *
- * This is deliberately fail-closed: sessionStorage can throw in restricted
- * browsing modes. In that case panel gating still updates in place, but the
- * app must not perform an automatic reload that it cannot prove will be
- * suppressed after the next boot.
- */
-function persistGuard(storage: StorageLike | undefined, accountId: string): boolean {
-  const key = guardKey(accountId);
-  if (!storage || !key) return false;
-  if (hasGuard(storage, accountId)) return true;
-  try {
-    storage.setItem(key, '1');
-  } catch {
-    return false;
-  }
-  return hasGuard(storage, accountId);
-}
-
 export function createEntitlementReloadController(
   options: EntitlementReloadControllerOptions = {},
-): { handleSnapshot(entitled: boolean, accountId?: string | null): boolean } {
+): { handleSnapshot(entitled: boolean | null, accountId?: string | null): boolean } {
   const storage = options.storage ?? getSessionStorage();
   const reload = options.reload ?? (() => window.location.reload());
-  let lastEntitled: boolean | null = options.returnedFromCheckout ? false : null;
+  const lastEntitledByAccount = new Map<string, boolean>();
+  let checkoutSeedAvailable = options.returnedFromCheckout === true;
 
   return {
     handleSnapshot(entitled, accountId = null) {
-      const isUnlockTransition = shouldReloadOnEntitlementChange(lastEntitled, entitled);
-      lastEntitled = entitled;
-
       // Gating is the primary unlock path and must run even when navigation is
       // suppressed. Calling it before reload also leaves the page usable if
       // the browser refuses the navigation.
       options.onSnapshot?.();
 
-      if (!isUnlockTransition || !accountId) return false;
-      if (hasGuard(storage, accountId)) return false;
-      if (!persistGuard(storage, accountId)) return false;
+      // resetEntitlementState() publishes null during auth handoff. It is an
+      // unavailable snapshot, not evidence of a free plan, so it must not turn
+      // an existing Pro user's first real snapshot into a false free→Pro edge.
+      // The checkout-return false seed is intentionally preserved as well.
+      if (entitled === null || !accountId) return false;
+
+      const hasAccountSnapshot = lastEntitledByAccount.has(accountId);
+      const lastEntitled = hasAccountSnapshot
+        ? lastEntitledByAccount.get(accountId)!
+        : checkoutSeedAvailable
+          ? false
+          : null;
+      if (!hasAccountSnapshot && checkoutSeedAvailable) {
+        checkoutSeedAvailable = false;
+      }
+
+      const isUnlockTransition = shouldReloadOnEntitlementChange(lastEntitled, entitled);
+      lastEntitledByAccount.set(accountId, entitled);
+
+      if (!isUnlockTransition) return false;
+      if (!persistNewGuard(storage, accountId)) return false;
 
       try {
         reload();

--- a/tests/entitlement-reload-controller.test.mts
+++ b/tests/entitlement-reload-controller.test.mts
@@ -26,6 +26,34 @@ class BlockedStorage {
   }
 }
 
+class ExistingGuardWithTransientReadFailureStorage {
+  reads = 0;
+  writes = 0;
+
+  getItem(): string | null {
+    this.reads += 1;
+    if (this.reads === 1) {
+      throw new DOMException('transient storage read failure', 'UnknownError');
+    }
+    return '1';
+  }
+
+  setItem(): void {
+    this.writes += 1;
+    throw new Error('an existing guard must never be rewritten');
+  }
+}
+
+class DroppedWriteStorage {
+  getItem(): string | null {
+    return null;
+  }
+
+  setItem(): void {
+    // Some storage shims accept writes without actually persisting them.
+  }
+}
+
 describe('entitlement reload controller', () => {
   it('reproduces daypesta cadence without a page reload loop', () => {
     const storage = new MemoryStorage();
@@ -124,6 +152,41 @@ describe('entitlement reload controller', () => {
     assert.equal(gatingPasses, 2, 'Pro access must still unlock in place');
   });
 
+  it('fails closed when the first read of an existing guard is unavailable', () => {
+    const storage = new ExistingGuardWithTransientReadFailureStorage();
+    let reloads = 0;
+    let gatingPasses = 0;
+    const controller = createEntitlementReloadController({
+      storage,
+      reload: () => { reloads += 1; },
+      onSnapshot: () => { gatingPasses += 1; },
+    });
+
+    controller.handleSnapshot(false, 'daypesta');
+    controller.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 0, 'an unavailable guard read must never be retried into a reload');
+    assert.equal(storage.reads, 1, 'a failed guard read must end the navigation attempt');
+    assert.equal(storage.writes, 0, 'a failed guard read must not rewrite an existing marker');
+    assert.equal(gatingPasses, 2, 'Pro access must still unlock in place');
+  });
+
+  it('fails closed when a guard write is accepted but not persisted', () => {
+    let reloads = 0;
+    let gatingPasses = 0;
+    const controller = createEntitlementReloadController({
+      storage: new DroppedWriteStorage(),
+      reload: () => { reloads += 1; },
+      onSnapshot: () => { gatingPasses += 1; },
+    });
+
+    controller.handleSnapshot(false, 'daypesta');
+    controller.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 0, 'navigation requires a verified persisted guard');
+    assert.equal(gatingPasses, 2, 'Pro access must still unlock in place');
+  });
+
   it('fails closed to in-place gating when the activation cannot be account-scoped', () => {
     let reloads = 0;
     let gatingPasses = 0;
@@ -152,6 +215,42 @@ describe('entitlement reload controller', () => {
     assert.equal(reloads, 0);
   });
 
+  it('does not turn an unavailable auth-handoff snapshot into a free state', () => {
+    const storage = new MemoryStorage();
+    let reloads = 0;
+    const existingPro = createEntitlementReloadController({
+      storage,
+      reload: () => { reloads += 1; },
+    });
+
+    existingPro.handleSnapshot(null, 'daypesta');
+    existingPro.handleSnapshot(true, 'daypesta');
+    assert.equal(reloads, 0, 'an existing Pro first snapshot must not look like a free-to-Pro transition');
+
+    const checkoutReturn = createEntitlementReloadController({
+      returnedFromCheckout: true,
+      storage,
+      reload: () => { reloads += 1; },
+    });
+    checkoutReturn.handleSnapshot(null, 'another-user');
+    checkoutReturn.handleSnapshot(true, 'another-user');
+    assert.equal(reloads, 1, 'an unavailable snapshot must preserve the checkout-return activation seed');
+  });
+
+  it('does not carry a free transition state into an existing Pro account', () => {
+    let reloads = 0;
+    const controller = createEntitlementReloadController({
+      storage: new MemoryStorage(),
+      reload: () => { reloads += 1; },
+    });
+
+    controller.handleSnapshot(false, 'free-user');
+    controller.handleSnapshot(null, 'daypesta');
+    controller.handleSnapshot(true, 'daypesta');
+
+    assert.equal(reloads, 0, 'each account must establish its own first real entitlement snapshot');
+  });
+
   it('wires the guarded controller into the live panel entitlement watcher', async () => {
     const panelLayout = await readFile(
       new URL('../src/app/panel-layout.ts', import.meta.url),
@@ -170,8 +269,8 @@ describe('entitlement reload controller', () => {
     );
     assert.match(
       panelLayout,
-      /entitlementReloadController\.handleSnapshot\(\s*isEntitled\(\),\s*getAuthState\(\)\.user\?\.id \?\? null,/,
-      'the live watcher must scope the cross-reload guard to the authenticated account',
+      /onEntitlementChange\(\(state\) => \{\s*entitlementReloadController\.handleSnapshot\(\s*state === null \? null : isEntitlementActive\(state, Date\.now\(\)\),\s*getAuthState\(\)\.user\?\.id \?\? null,/,
+      'the live watcher must preserve unavailable snapshots and scope the guard to the authenticated account',
     );
   });
 });

--- a/tests/tab-cap.test.mts
+++ b/tests/tab-cap.test.mts
@@ -262,10 +262,19 @@ describe('tab-cap wiring', () => {
   it('the cap re-evaluates on BOTH auth and entitlement emissions', () => {
     // updatePanelGating is the single gating pass; it is driven by
     // subscribeAuthState AND onEntitlementChange (the auth-only-subscription
-    // bug is documented in this file at the proBlock wiring).
+    // bug is documented in this file at the proBlock wiring). Entitlement
+    // emissions now flow through the reload controller so a null auth-handoff
+    // snapshot is not collapsed to a false entitlement transition.
     assert.match(gatingBody, /this\.updateTabCapLock\(\)/);
     assert.match(panelLayout, /subscribeAuthState\(\(state\) => \{\s*this\.updatePanelGating\(state\);/);
-    assert.match(panelLayout, /onEntitlementChange\(\(\) => \{[\s\S]*?this\.updatePanelGating\(getAuthState\(\)\)/);
+    assert.match(
+      panelLayout,
+      /onSnapshot:\s*\(\) => this\.updatePanelGating\(getAuthState\(\)\)/,
+    );
+    assert.match(
+      panelLayout,
+      /onEntitlementChange\(\(state\) => \{[\s\S]*?entitlementReloadController\.handleSnapshot\(/,
+    );
   });
 
   it('panel-gating forwards the dashboard allowance into the shared inputs', () => {


### PR DESCRIPTION
## Summary

A transient `sessionStorage` read failure could still turn an existing one-shot marker into another page reload, while auth handoff could misclassify an unavailable entitlement snapshot as free. Pro activation now reloads only after a confirmed-absent marker is written and read back, and transition state is isolated per account. Existing Pro and account-switch sessions therefore stay in place, while a genuine checkout activation retains its one clean reload.

Related: #5846

## Validation

- Reproduced the transient-read failure before the patch: the controller reloaded once despite a pre-existing guard.
- 94 focused auth, entitlement, activation, and Pro-banner tests passed; 3 related DOM tests passed.
- Source typecheck and the Vite production build passed (2,440 modules).
- Both key invariants were mutation-tested: continuing after a failed guard read and treating `null` as free each caused the new regressions to fail.
- Pre-push gates passed, including the 11-case controller suite, architectural checks, premium-fetch parity, 240 edge-function tests, and version sync.
- The aggregate `npm run build` could not reach Vite because this isolated worktree lacks the unchanged blog generator's `satori` package; the direct production Vite build completed successfully.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT 5](https://img.shields.io/badge/GPT_5-000000)
