### PR TITLE
fix(conflict): make the GDELT bulk export primary and demote the DOC country sweep to fallback (#5849)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -20,6 +20,10 @@ A companion cache key holding a *view* of a dataset sized to what the dashboard 
 
 A cache key whose only writer is a dedicated seeder or relay process; edge endpoints read and serve it but never write it back on a miss — a missing value is answered with a short-TTL computed fallback while the owning seeder's next cycle restores the key. The consequence runs both ways: the reader stays cheap and can never poison the key with a degraded payload, but purging a seed-owned key does not force regeneration at read time — freshness after a purge returns only on the owner's schedule, and a purge issued while an outdated owner is still running is simply overwritten with outdated data. See also: Bootstrap Tier, On-Demand Key.
 
+### Source Tag
+
+The field a seeder stamps on its published snapshot naming which rung of its source ladder produced the payload — the credentialed primary, the preferred bulk feed, or an emergency sweep. Consumers of the data itself ignore it, but stateful merge logic keys on it: a run only carries forward accumulated state (such as a rolling event window) from a predecessor snapshot bearing the expected tag, so a single tick published under a different tag resets that accumulation. Inverting which rung is primary changes how often each tag is published and therefore how exposed that accumulated state is. See also: Seed-Owned Key.
+
 ### One-Shot Hydration
 
 The delivery contract of the boot payload: a hydrated value can be read exactly once, and reading it consumes it. Its consequence is the important part — any *recurring* reader (a periodic refresh tick, a retry) is guaranteed to miss hydration and fall through to whatever fallback path exists. When that fallback is not CDN-shielded, one-shot hydration plus a refresh timer silently manufactures origin traffic. Audit every refresh path's fallthrough whenever a payload is one-shot. See also: The Lever Test, On-Demand Key.

--- a/docs/solutions/design-patterns/primary-fallback-inversion-budget-transfer.md
+++ b/docs/solutions/design-patterns/primary-fallback-inversion-budget-transfer.md
@@ -1,0 +1,111 @@
+---
+title: Inverting a primary/fallback order silently transfers the shared time budget to the new primary
+module: seed-conflict-intel
+date: 2026-07-30
+problem_type: design_pattern
+component: background_job
+severity: high
+applies_when:
+  - "Swapping which of two data sources is primary vs fallback inside a deadline-bounded fetch phase"
+  - "A budget/deadline invariant test models the two paths ADDITIVELY (primary window + fallback worst-case)"
+  - "The demoted path keeps a launch-cutoff computed from an absolute deadline anchored before either path runs"
+tags:
+  - fallback-ordering
+  - time-budget
+  - deadline-invariant
+  - gdelt
+  - seeder
+  - review-checklist
+related_components:
+  - testing_framework
+---
+
+# Inverting a primary/fallback order silently transfers the shared time budget
+
+## Context
+
+Issue #5849 (PR #5855) inverted `seed-conflict-intel`'s GDELT sourcing: the bulk
+export became primary and the DOC per-country sweep became the fallback. The
+sweep's launch cutoff (`scripts/seed-conflict-intel.mjs:489-490`) is derived
+from an absolute `deadlineAt` anchored at fetch-phase start — under the old
+order the sweep ran first and consumed that window directly, and the bulk
+attempt's worst case was budgeted ON TOP of it: the deadline invariant test
+computes `max(HAPI, SWEEP_BUDGET + worstBatch) + GDELT_BULK_WORST_NETWORK_MS + slack`
+(`tests/seed-fetch-deadline-budget-invariants.test.mjs:105-107`) — the two
+paths are modeled ADDITIVELY. A naive inversion (move the bulk block above the
+sweep, change nothing else) makes the bulk attempt eat the sweep's window: a
+slow-failing mirror (up to ~60s of `GDELT_BULK_WORST_NETWORK_MS` timeouts,
+`scripts/_conflict-gdelt-bulk.mjs:22-23`) hands the healthy fallback an
+already-expired budget, so the sweep's `overBudget` check trips on iteration
+zero and every 15-minute tick reports a combined "no usable source" failure
+without a single fallback request being made. The reliability reviewer caught
+this in review; it never reached production.
+
+## Guidance
+
+When inverting which path is primary, transfer the budget explicitly:
+
+1. **Credit the new primary's elapsed time back to the demoted path's cutoff,
+   clamped to the constant the invariant models:**
+
+   ```js
+   const bulkStartedAt = now();            // before the primary attempt
+   // ... primary attempt fails ...
+   const launchCutoffAt = deadlineAt != null
+     ? deadlineAt + Math.min(now() - bulkStartedAt, GDELT_BULK_WORST_NETWORK_MS)
+     : now() + GDELT_SWEEP_BUDGET_MS;
+   ```
+
+   (`scripts/seed-conflict-intel.mjs:415` and `scripts/seed-conflict-intel.mjs:489-490`.) The credit restores exactly
+   the window the demoted path had under the old order; the clamp keeps the
+   code's worst case equal to the constant the invariant test asserts, so
+   model and reality cannot drift apart silently.
+
+2. **Prove it with an injected-clock test** where the primary consumes most of
+   the window before failing, asserting the fallback still attempts its full
+   sweep — and a companion test where the deadline expired *before* entry,
+   asserting the credit cannot resurrect a dead window (algebraically the
+   credited cutoff equals "budget remaining at function entry", so aux-stage
+   overruns still cancel the sweep). Both are in `tests/conflict-gdelt.test.mjs`
+   ("slow-failing bulk export does not starve" / "cannot resurrect a window").
+
+## Why This Matters
+
+The failure mode is invisible in every ordinary test: synchronous mock failures
+consume zero clock, so the fallback always appears to get its full window. In
+production it means a *slow* (not down) primary permanently disables the
+emergency fallback — the exact insurance the fallback exists to provide — while
+each tick degrades to a preserved-last-good no-publish and freshness quietly
+ages toward the health threshold. The pre-inversion code never had this bug
+because the fallback ran first; the inversion *created* it without touching a
+line of the fallback.
+
+## When to Apply
+
+Any reorder of attempt sequence inside a deadline- or lock-bounded phase:
+seeders with primary/fallback data sources, retry ladders with per-rung
+budgets, multi-provider fetch chains. Trigger question for review: "whose
+clock does the demoted path now run on, and does the total-envelope invariant
+model these paths additively or shared?"
+
+## Examples
+
+The rest of the inversion checklist from the same review (two model families
+converged on these independently):
+
+- **Cold-start thin-window floor** — the promoted path's success predicate was
+  weaker than the demoted path's (any non-empty window vs. a 16/20 coverage
+  floor). With no retained rolling window, a partially-degraded source serving
+  a single-country handful would overwrite last-good and suppress the fallback.
+  Fix: `scripts/seed-conflict-intel.mjs:439` gates cold-start publishes on
+  ≥3 countries with events, falling through to the fallback instead.
+- **Snapshot-shape consumers** — the promoted path published different
+  pagination telemetry; audit every reader of the snapshot before dropping the
+  demoted path's fields (none read them here, verified by repo-wide grep).
+- **Stateful-window coupling** — the promoted path's rolling window is rebuilt
+  from the previous snapshot, and a fallback tick publishing a different
+  `source` tag erases it on recovery. Pre-existing mechanism, tracked as
+  issue #5852 rather than fixed in the inversion PR (its acceptance criteria
+  pinned merge semantics unchanged).
+
+Fix state: opened in PR #5855 (CI green), unmerged as of this writing.

--- a/scripts/_conflict-gdelt-bulk.mjs
+++ b/scripts/_conflict-gdelt-bulk.mjs
@@ -1,7 +1,7 @@
-// Resilient GDELT conflict-event fallback using the official 15-minute bulk
-// event export. The DOC API is aggressively per-IP throttled; the bulk stream
-// is a single global stream and therefore remains usable when country-by-country
-// DOC queries all return 429.
+// Primary GDELT conflict-event source using the official 15-minute bulk
+// event export (#5849). The DOC API is aggressively per-IP throttled; the bulk
+// stream is a single global stream and therefore remains usable when
+// country-by-country DOC queries all return 429.
 
 import { createHash } from 'node:crypto';
 import { inflateRawSync } from 'node:zlib';

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -402,6 +402,16 @@ export async function fetchGdeltCountryEvents(cc) {
   return { country: cc, ok: true, events: mapGdeltArticlesToEvents(data?.articles, cc) };
 }
 
+// #5855 review: a programming defect in our own code must crash loud and
+// attributable to the deploy — never be reclassified as an upstream outage and
+// quietly degraded to sourceUnavailable/exit 0 under the mirror-outage runbook.
+function isProgrammingDefect(error) {
+  return error instanceof TypeError
+    || error instanceof ReferenceError
+    || error instanceof RangeError
+    || error instanceof SyntaxError;
+}
+
 export async function fetchGdeltConflictEvents({
   fetchCountryEvents = fetchGdeltCountryEvents,
   fetchBulkEvents = fetchGdeltBulkConflictEvents,
@@ -418,9 +428,11 @@ export async function fetchGdeltConflictEvents({
     const bulk = await fetchBulkEvents();
     if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
     let previousSnapshot = null;
+    let previousSnapshotReadFailed = false;
     try {
       previousSnapshot = await loadPreviousSnapshot();
     } catch (snapshotError) {
+      previousSnapshotReadFailed = true;
       console.warn(
         '  GDELT bulk previous snapshot unavailable; publishing current exports only:'
         + ` ${snapshotError?.message || snapshotError}`,
@@ -429,6 +441,16 @@ export async function fetchGdeltConflictEvents({
     const rolling = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now());
     if (!rolling.events.length) throw new Error('rolling bulk window contained no priority-country material-conflict events');
     const countriesWithEvents = new Set(rolling.events.map(event => event.country)).size;
+    if (bulk.exportsSucceeded < bulk.exportsRequested) {
+      // Partial mirror degradation normally still publishes (each 15-min slice
+      // gets ~RECENT_EXPORT_COUNT retries before aging out of the manifest
+      // tail, and the rolling merge retains prior events), but say so — a
+      // silent thin tick is how a persistent asymmetric outage hides (#5849
+      // review). Logged ahead of the cold-start floor so a thin cold-start
+      // tick — exactly the degraded-mirror shape — still reports the ratio
+      // (#5855 review).
+      console.warn(`  GDELT bulk exports partially degraded: ${bulk.exportsSucceeded}/${bulk.exportsRequested} export files fetched`);
+    }
     // Cold-start coverage floor (#5849 review, flagged independently by two
     // reviewers): with no retained rolling window, an implausibly thin bulk
     // result — a partially-degraded mirror serving one usable export — must not
@@ -436,18 +458,18 @@ export async function fetchGdeltConflictEvents({
     // both-fail, to runSeed's sourceUnavailable last-good preservation) instead.
     // Steady-state ticks always retain prior-window events, so this never fires
     // there; a genuine 2h window of material violence spans many countries.
-    if (rolling.retainedPreviousEvents === 0 && countriesWithEvents < GDELT_BULK_COLD_START_MIN_COUNTRIES) {
+    // A transient snapshot-read failure must NOT arm the floor (#5855 review):
+    // retained=0 then means "could not read", not "first-ever run", and
+    // publishing the fresh bulk window beats routing to the load-shed sweep.
+    if (
+      !previousSnapshotReadFailed
+      && rolling.retainedPreviousEvents === 0
+      && countriesWithEvents < GDELT_BULK_COLD_START_MIN_COUNTRIES
+    ) {
       throw new Error(
         `cold-start bulk window too thin: ${countriesWithEvents} countries with events`
         + ` (min ${GDELT_BULK_COLD_START_MIN_COUNTRIES})`,
       );
-    }
-    if (bulk.exportsSucceeded < bulk.exportsRequested) {
-      // Partial mirror degradation still publishes (each 15-min slice gets
-      // ~RECENT_EXPORT_COUNT retries before aging out of the manifest tail, and
-      // the rolling merge retains prior events), but say so — a silent thin
-      // tick is how a persistent asymmetric outage hides (#5849 review).
-      console.warn(`  GDELT bulk exports partially degraded: ${bulk.exportsSucceeded}/${bulk.exportsRequested} export files fetched`);
     }
     console.log(
       `  GDELT bulk conflict-events: ${rolling.events.length} events through export ${bulk.exportTimestamp}`
@@ -468,6 +490,10 @@ export async function fetchGdeltConflictEvents({
       source: 'gdelt-bulk',
     };
   } catch (bulkError) {
+    // Reclassified as a "bulk failure", a code defect would route to the
+    // load-shed DOC sweep and end in a quiet sourceUnavailable exit 0,
+    // sending operators down the mirror-outage runbook (#5855 review).
+    if (isProgrammingDefect(bulkError)) throw bulkError;
     bulkFailure = `GDELT bulk event export failed: ${bulkError?.message || bulkError}`;
     console.warn(`  ${bulkFailure}; falling back to the DOC country sweep`);
   }
@@ -1009,6 +1035,9 @@ export async function fetchAll({ fetchGdeltFallback = fetchGdeltConflictEvents }
       // credentialed-but-empty ACLED result is trusted (returns `ac`) rather than
       // overwritten by GDELT volume.
       const gdeltEvents = await fetchGdeltFallback({ deadlineAt: sweepDeadlineAt }).catch((e) => {
+        // Outages degrade to sourceUnavailable below; our own defects must
+        // escape to runSeed and fail attributably (#5855 review).
+        if (isProgrammingDefect(e)) throw e;
         console.warn(`  GDELT conflict-events fallback failed: ${e.message}`);
         return null;
       });

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -29,7 +29,7 @@ import {
 } from './_seed-utils.mjs';
 import { fetchGdeltJson } from './_gdelt-fetch.mjs';
 import { buildGdeltConflictUrl, mapGdeltArticlesToEvents, GDELT_COUNTRY_NAMES } from './_conflict-gdelt.mjs';
-import { fetchGdeltBulkConflictEvents, GDELT_ROLLING_WINDOW_MS, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
+import { fetchGdeltBulkConflictEvents, GDELT_BULK_WORST_NETWORK_MS, GDELT_ROLLING_WINDOW_MS, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
 import {
   HAPI_HDX_MAX_RESPONSE_BYTES,
   HAPI_HDX_PACKAGE_URL,
@@ -158,6 +158,11 @@ const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_
 // ACLED_INTEL_LOCK_TTL_MS's 540s fetch deadline (lockTtlMs+120s)
 // below (re-verified #5554 review after growing HAPI_COUNTRIES to 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
+// Cold-start floor for the bulk-primary path (#5849 review): only consulted
+// when the rolling merge retained nothing from a prior bulk window. Kept
+// deliberately low — a quiet-but-healthy 2h export window still clears it,
+// while a partially-degraded mirror serving a single-country handful does not.
+const GDELT_BULK_COLD_START_MIN_COUNTRIES = 3;
 // The shared GDELT transport enforces one selected-route attempt. These explicit
 // values pin that contract at this high-fanout caller. timeoutMs is pinned too:
 // _gdelt-fetch.mjs's default rose from 15s to 30s for seed-gdelt-intel's slow
@@ -407,6 +412,7 @@ export async function fetchGdeltConflictEvents({
 } = {}) {
   // Bulk export first (#5849). On any bulk failure — mirror outage, empty
   // exports, empty rolling window — fall through to the DOC sweep below.
+  const bulkStartedAt = now();
   let bulkFailure;
   try {
     const bulk = await fetchBulkEvents();
@@ -422,6 +428,27 @@ export async function fetchGdeltConflictEvents({
     }
     const rolling = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now());
     if (!rolling.events.length) throw new Error('rolling bulk window contained no priority-country material-conflict events');
+    const countriesWithEvents = new Set(rolling.events.map(event => event.country)).size;
+    // Cold-start coverage floor (#5849 review, flagged independently by two
+    // reviewers): with no retained rolling window, an implausibly thin bulk
+    // result — a partially-degraded mirror serving one usable export — must not
+    // overwrite last-good as the primary feed. Fall through to the sweep (and,
+    // both-fail, to runSeed's sourceUnavailable last-good preservation) instead.
+    // Steady-state ticks always retain prior-window events, so this never fires
+    // there; a genuine 2h window of material violence spans many countries.
+    if (rolling.retainedPreviousEvents === 0 && countriesWithEvents < GDELT_BULK_COLD_START_MIN_COUNTRIES) {
+      throw new Error(
+        `cold-start bulk window too thin: ${countriesWithEvents} countries with events`
+        + ` (min ${GDELT_BULK_COLD_START_MIN_COUNTRIES})`,
+      );
+    }
+    if (bulk.exportsSucceeded < bulk.exportsRequested) {
+      // Partial mirror degradation still publishes (each 15-min slice gets
+      // ~RECENT_EXPORT_COUNT retries before aging out of the manifest tail, and
+      // the rolling merge retains prior events), but say so — a silent thin
+      // tick is how a persistent asymmetric outage hides (#5849 review).
+      console.warn(`  GDELT bulk exports partially degraded: ${bulk.exportsSucceeded}/${bulk.exportsRequested} export files fetched`);
+    }
     console.log(
       `  GDELT bulk conflict-events: ${rolling.events.length} events through export ${bulk.exportTimestamp}`
       + ` (${rolling.retainedPreviousEvents} retained from prior runs)`,
@@ -432,7 +459,7 @@ export async function fetchGdeltConflictEvents({
         exportTimestamp: bulk.exportTimestamp,
         exportsRequested: bulk.exportsRequested,
         exportsSucceeded: bulk.exportsSucceeded,
-        countriesWithEvents: new Set(rolling.events.map(event => event.country)).size,
+        countriesWithEvents,
         rollingWindowHours: GDELT_ROLLING_WINDOW_MS / (60 * 60 * 1000),
         rollingWindowStartedAt: rolling.rollingWindowStartedAt,
         rollingWindowComplete: rolling.rollingWindowComplete,
@@ -446,12 +473,22 @@ export async function fetchGdeltConflictEvents({
   }
 
   // DOC sweep fallback — canary, batch, budget, floor, and circuit semantics
-  // unchanged from when it was primary (#5140).
+  // unchanged from when it was primary (#5140). The bulk attempt's elapsed time
+  // is credited back to the cutoff: the deadline invariant already budgets
+  // GDELT_BULK_WORST_NETWORK_MS ON TOP of the sweep window (seed-fetch-deadline-
+  // budget-invariants.test.mjs), and without the credit a slow-failing mirror
+  // (up to ~60s of timeouts) would hand the healthy DOC fallback an already-
+  // expired budget every tick. Aux-stage time still comes out of the window,
+  // and the credit is clamped to the same GDELT_BULK_WORST_NETWORK_MS constant
+  // the invariant test models, so the modelled and actual worst-case envelopes
+  // stay the same number (#5140 arithmetic unchanged).
   const events = [];
   const failedCountries = [];
   let successfulCountries = 0;
   const CONCURRENCY = 4;
-  const launchCutoffAt = deadlineAt ?? now() + GDELT_SWEEP_BUDGET_MS;
+  const launchCutoffAt = deadlineAt != null
+    ? deadlineAt + Math.min(now() - bulkStartedAt, GDELT_BULK_WORST_NETWORK_MS)
+    : now() + GDELT_SWEEP_BUDGET_MS;
   for (let i = 0; i < CONFLICT_COUNTRIES.length;) {
     // #5140: stop LAUNCHING batches once the phase cutoff passes or the floor can
     // no longer be reached — either way the caller degrades to aux-only and exits 0,
@@ -467,8 +504,9 @@ export async function fetchGdeltConflictEvents({
       break;
     }
     // Probe one country before widening. A selected-route failure on the canary
-    // falls straight through to the official bulk export instead of repeating
-    // the same blocked path across a four-country batch.
+    // aborts the sweep after a single request (bulk has already failed by this
+    // point — see top of function) instead of repeating the same blocked path
+    // across a four-country batch.
     const batchSize = successfulCountries === 0 ? 1 : CONCURRENCY;
     const batch = remaining.slice(0, batchSize);
     const results = await Promise.all(batch.map(cc => fetchCountryEvents(cc)));

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -375,11 +375,13 @@ async function fetchAcledEvents({
 
 // ─── GDELT conflict-events fallback (used when ACLED has no credentials) ───
 // ACLED requires a registered account. When its credentials are absent, keep a
-// near-real-time conflict signal from GDELT. The DOC 2.0 path counts recent
-// conflict-tagged articles per priority country and emits synthetic events in the
-// SAME {country, event_date} shape the EMA engine reads (_ema-threat-engine.mjs).
-// When DOC coverage is throttled or yields no events, the official 15-minute bulk
-// event export supplies material-conflict records instead.
+// near-real-time conflict signal from GDELT. The official 15-minute bulk event
+// export is PRIMARY (#5849): it serves real material-conflict records from the
+// unthrottled GCS mirror with no proxy involvement. The DOC 2.0 per-country
+// sweep — which counts recent conflict-tagged articles and emits synthetic
+// events in the SAME {country, event_date} shape the EMA engine reads
+// (_ema-threat-engine.mjs) — is supply-side load-shed (#5843: 0/20 countries
+// for weeks) and runs only when the bulk path itself fails.
 export async function fetchGdeltCountryEvents(cc) {
   if (!GDELT_COUNTRY_NAMES[cc]) {
     return { country: cc, ok: false, events: [], error: 'unknown country code' };
@@ -403,6 +405,48 @@ export async function fetchGdeltConflictEvents({
   deadlineAt,
   loadPreviousSnapshot = () => readSeedSnapshot(ACLED_CACHE_KEY, { strict: true }),
 } = {}) {
+  // Bulk export first (#5849). On any bulk failure — mirror outage, empty
+  // exports, empty rolling window — fall through to the DOC sweep below.
+  let bulkFailure;
+  try {
+    const bulk = await fetchBulkEvents();
+    if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
+    let previousSnapshot = null;
+    try {
+      previousSnapshot = await loadPreviousSnapshot();
+    } catch (snapshotError) {
+      console.warn(
+        '  GDELT bulk previous snapshot unavailable; publishing current exports only:'
+        + ` ${snapshotError?.message || snapshotError}`,
+      );
+    }
+    const rolling = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now());
+    if (!rolling.events.length) throw new Error('rolling bulk window contained no priority-country material-conflict events');
+    console.log(
+      `  GDELT bulk conflict-events: ${rolling.events.length} events through export ${bulk.exportTimestamp}`
+      + ` (${rolling.retainedPreviousEvents} retained from prior runs)`,
+    );
+    return {
+      events: rolling.events,
+      pagination: {
+        exportTimestamp: bulk.exportTimestamp,
+        exportsRequested: bulk.exportsRequested,
+        exportsSucceeded: bulk.exportsSucceeded,
+        countriesWithEvents: new Set(rolling.events.map(event => event.country)).size,
+        rollingWindowHours: GDELT_ROLLING_WINDOW_MS / (60 * 60 * 1000),
+        rollingWindowStartedAt: rolling.rollingWindowStartedAt,
+        rollingWindowComplete: rolling.rollingWindowComplete,
+        retainedPreviousEvents: rolling.retainedPreviousEvents,
+      },
+      source: 'gdelt-bulk',
+    };
+  } catch (bulkError) {
+    bulkFailure = `GDELT bulk event export failed: ${bulkError?.message || bulkError}`;
+    console.warn(`  ${bulkFailure}; falling back to the DOC country sweep`);
+  }
+
+  // DOC sweep fallback — canary, batch, budget, floor, and circuit semantics
+  // unchanged from when it was primary (#5140).
   const events = [];
   const failedCountries = [];
   let successfulCountries = 0;
@@ -457,48 +501,9 @@ export async function fetchGdeltConflictEvents({
       ? `GDELT conflict-events coverage below floor: ${successfulCountries}/${CONFLICT_COUNTRIES.length} countries succeeded ` +
         `(min ${GDELT_MIN_SUCCESSFUL_COUNTRIES})${sample ? `; failures: ${sample}` : ''}`
       : `GDELT conflict-events returned zero events across ${successfulCountries}/${CONFLICT_COUNTRIES.length} successful countries`;
-    console.warn(`  ${docFailure}; trying official bulk event export`);
-    try {
-      const bulk = await fetchBulkEvents();
-      if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
-      let previousSnapshot = null;
-      try {
-        previousSnapshot = await loadPreviousSnapshot();
-      } catch (snapshotError) {
-        console.warn(
-          '  GDELT bulk previous snapshot unavailable; publishing current exports only:'
-          + ` ${snapshotError?.message || snapshotError}`,
-        );
-      }
-      const rolling = mergeGdeltBulkRollingWindow(bulk, previousSnapshot, now());
-      if (!rolling.events.length) throw new Error('rolling bulk window contained no priority-country material-conflict events');
-      console.log(
-        `  GDELT bulk conflict-events fallback: ${rolling.events.length} events through export ${bulk.exportTimestamp}`
-        + ` (${rolling.retainedPreviousEvents} retained from prior runs)`,
-      );
-      return {
-        events: rolling.events,
-        pagination: {
-          countriesTotal: CONFLICT_COUNTRIES.length,
-          countriesSucceeded: successfulCountries,
-          countriesFailed: failedCountries.length,
-          minSuccessfulCountries: GDELT_MIN_SUCCESSFUL_COUNTRIES,
-          exportTimestamp: bulk.exportTimestamp,
-          exportsRequested: bulk.exportsRequested,
-          exportsSucceeded: bulk.exportsSucceeded,
-          countriesWithEvents: new Set(rolling.events.map(event => event.country)).size,
-          rollingWindowHours: GDELT_ROLLING_WINDOW_MS / (60 * 60 * 1000),
-          rollingWindowStartedAt: rolling.rollingWindowStartedAt,
-          rollingWindowComplete: rolling.rollingWindowComplete,
-          retainedPreviousEvents: rolling.retainedPreviousEvents,
-        },
-        source: 'gdelt-bulk',
-      };
-    } catch (bulkError) {
-      throw new Error(`${docFailure}; bulk fallback failed: ${bulkError?.message || bulkError}`);
-    }
+    throw new Error(`${bulkFailure}; DOC sweep fallback failed: ${docFailure}`);
   }
-  console.log(`  GDELT conflict-events (ACLED fallback): ${events.length} events across ${successfulCountries}/${CONFLICT_COUNTRIES.length} successful country fetches`);
+  console.log(`  GDELT conflict-events DOC sweep fallback: ${events.length} events across ${successfulCountries}/${CONFLICT_COUNTRIES.length} successful country fetches`);
   return {
     events,
     pagination: {
@@ -959,8 +964,9 @@ export async function fetchAll({ fetchGdeltFallback = fetchGdeltConflictEvents }
     // when ACLED credentials ARE present but the display fetch failed (#5106).
     const missingCredentials = acled.status === 'fulfilled';
     if (missingCredentials) {
-      // No ACLED credentials → fall back to the GDELT article-volume proxy so the
-      // conflict escalation EMA keeps a near-real-time signal (#5099). This runs only
+      // No ACLED credentials → fall back to GDELT (bulk event export primary, DOC
+      // article-volume sweep as emergency fallback — #5849) so the conflict
+      // escalation EMA keeps a near-real-time signal (#5099). This runs only
       // on the no-creds path: a credentialed-but-failed fetch still throws below, and a
       // credentialed-but-empty ACLED result is trusted (returns `ac`) rather than
       // overwritten by GDELT volume.

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -29,7 +29,7 @@ import {
 } from './_seed-utils.mjs';
 import { fetchGdeltJson } from './_gdelt-fetch.mjs';
 import { buildGdeltConflictUrl, mapGdeltArticlesToEvents, GDELT_COUNTRY_NAMES } from './_conflict-gdelt.mjs';
-import { fetchGdeltBulkConflictEvents, GDELT_BULK_WORST_NETWORK_MS, GDELT_ROLLING_WINDOW_MS, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
+import { fetchGdeltBulkConflictEvents, GDELT_BULK_WORST_NETWORK_MS, GDELT_ROLLING_WINDOW_MS, gdeltTimestampToMs, mergeGdeltBulkRollingWindow } from './_conflict-gdelt-bulk.mjs';
 import {
   HAPI_HDX_MAX_RESPONSE_BYTES,
   HAPI_HDX_PACKAGE_URL,
@@ -159,10 +159,17 @@ const GDELT_ROUTE_FAILURE = /\bGDELT_(?:SOURCE_PROXY|SHARED_PROXY|PROXY|DIRECT)_
 // below (re-verified #5554 review after growing HAPI_COUNTRIES to 38).
 export const GDELT_SWEEP_BUDGET_MS = 120_000;
 // Cold-start floor for the bulk-primary path (#5849 review): only consulted
-// when the rolling merge retained nothing from a prior bulk window. Kept
+// on a TRUE cold start (no previous snapshot of any kind — #5855 review). Kept
 // deliberately low — a quiet-but-healthy 2h export window still clears it,
 // while a partially-degraded mirror serving a single-country handful does not.
 const GDELT_BULK_COLD_START_MIN_COUNTRIES = 3;
+// Freshness gate for the bulk-primary path (#5855 review): a mirror that stops
+// updating keeps serving the same aging exports, and without an age check every
+// tick publishes a "fresh" seed-meta write while a possibly-healthy DOC route
+// is never consulted. 3h = 12 export cycles of lag — beyond any routine GDELT
+// publication gap, far under the 24h rolling window. An unparseable newest
+// export timestamp fails closed (treated as stale).
+export const GDELT_BULK_MAX_EXPORT_AGE_MS = 3 * 60 * 60 * 1000;
 // The shared GDELT transport enforces one selected-route attempt. These explicit
 // values pin that contract at this high-fanout caller. timeoutMs is pinned too:
 // _gdelt-fetch.mjs's default rose from 15s to 30s for seed-gdelt-intel's slow
@@ -420,13 +427,23 @@ export async function fetchGdeltConflictEvents({
   deadlineAt,
   loadPreviousSnapshot = () => readSeedSnapshot(ACLED_CACHE_KEY, { strict: true }),
 } = {}) {
-  // Bulk export first (#5849). On any bulk failure — mirror outage, empty
-  // exports, empty rolling window — fall through to the DOC sweep below.
+  // Bulk export first (#5849). On any bulk failure — mirror outage, stale
+  // mirror, empty rolling window — fall through to the DOC sweep below. An
+  // empty CURRENT tick is not by itself a failure: the retained rolling window
+  // still publishes, and only empty-current + nothing-retained falls through
+  // (#5855 review).
   const bulkStartedAt = now();
   let bulkFailure;
   try {
     const bulk = await fetchBulkEvents();
-    if (!bulk?.events?.length) throw new Error('latest export contained no priority-country material-conflict events');
+    const newestExportAgeMs = now() - gdeltTimestampToMs(bulk?.exportTimestamp);
+    if (!Number.isFinite(newestExportAgeMs) || newestExportAgeMs > GDELT_BULK_MAX_EXPORT_AGE_MS) {
+      throw new Error(
+        `bulk export stale or unparseable: newest export ${bulk?.exportTimestamp}`
+        + ` is ${Number.isFinite(newestExportAgeMs) ? Math.round(newestExportAgeMs / 60000) : '?'}min old`
+        + ` (max ${GDELT_BULK_MAX_EXPORT_AGE_MS / 60000}min)`,
+      );
+    }
     let previousSnapshot = null;
     let previousSnapshotReadFailed = false;
     try {
@@ -452,17 +469,20 @@ export async function fetchGdeltConflictEvents({
       console.warn(`  GDELT bulk exports partially degraded: ${bulk.exportsSucceeded}/${bulk.exportsRequested} export files fetched`);
     }
     // Cold-start coverage floor (#5849 review, flagged independently by two
-    // reviewers): with no retained rolling window, an implausibly thin bulk
-    // result — a partially-degraded mirror serving one usable export — must not
-    // overwrite last-good as the primary feed. Fall through to the sweep (and,
-    // both-fail, to runSeed's sourceUnavailable last-good preservation) instead.
-    // Steady-state ticks always retain prior-window events, so this never fires
-    // there; a genuine 2h window of material violence spans many countries.
-    // A transient snapshot-read failure must NOT arm the floor (#5855 review):
-    // retained=0 then means "could not read", not "first-ever run", and
-    // publishing the fresh bulk window beats routing to the load-shed sweep.
+    // reviewers): on a true first-ever run, an implausibly thin bulk result —
+    // a partially-degraded mirror serving one usable export — must not become
+    // the primary feed. Fall through to the sweep (and, both-fail, to
+    // runSeed's sourceUnavailable last-good preservation) instead.
+    // The floor arms ONLY on a true cold start (#5855 review):
+    // - a transient snapshot-read failure means "could not read", not
+    //   "first-ever run" (previousSnapshotReadFailed guard), and
+    // - a previous snapshot that exists but is DOC-sourced also zeroes
+    //   retainedPreviousEvents; flooring that state ping-pongs recovery back
+    //   onto the load-shed DOC route every time DOC briefly succeeds (#5852's
+    //   floor half). Publishing thin-but-real bulk re-primes the window.
     if (
       !previousSnapshotReadFailed
+      && previousSnapshot == null
       && rolling.retainedPreviousEvents === 0
       && countriesWithEvents < GDELT_BULK_COLD_START_MIN_COUNTRIES
     ) {

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -134,7 +134,11 @@ test('fetchGdeltConflictEvents uses the bulk export as PRIMARY: a healthy bulk p
       return { country: cc, ok: true, events: [{ country: 'Sudan', event_date: '2026-07-13' }] };
     },
     fetchBulkEvents: async () => ({
-      events: [{ id: 'gdelt-event-primary', country: 'Sudan' }],
+      events: [
+        { id: 'gdelt-event-primary-1', country: 'Sudan' },
+        { id: 'gdelt-event-primary-2', country: 'Yemen' },
+        { id: 'gdelt-event-primary-3', country: 'Ukraine' },
+      ],
       exportTimestamp: '20260713110000',
       exportsRequested: 8,
       exportsSucceeded: 8,
@@ -143,7 +147,10 @@ test('fetchGdeltConflictEvents uses the bulk export as PRIMARY: a healthy bulk p
 
   assert.equal(docCalls, 0, `healthy bulk path must make zero DOC API requests, made ${docCalls}`);
   assert.equal(result.source, 'gdelt-bulk');
-  assert.deepEqual(result.events.map(event => event.id), ['gdelt-event-primary']);
+  assert.deepEqual(
+    result.events.map(event => event.id).sort(),
+    ['gdelt-event-primary-1', 'gdelt-event-primary-2', 'gdelt-event-primary-3'],
+  );
 });
 
 test('fetchGdeltConflictEvents rejects when bulk fails and the DOC sweep succeeds but yields zero events', async () => {
@@ -169,14 +176,18 @@ test('fetchGdeltConflictEvents publishes bulk pagination telemetry on the primar
     loadPreviousSnapshot: async () => null,
     fetchCountryEvents: async () => { throw new Error('DOC sweep must not run when bulk is healthy'); },
     fetchBulkEvents: async () => ({
-      events: [{
-        id: 'gdelt-event-1',
-        country: 'Sudan',
-        event_date: '2026-07-13',
-        occurredAt: Date.parse('2026-07-13'),
-        source: 'example.com',
-        url: 'https://example.com/conflict',
-      }],
+      events: [
+        {
+          id: 'gdelt-event-1',
+          country: 'Sudan',
+          event_date: '2026-07-13',
+          occurredAt: Date.parse('2026-07-13'),
+          source: 'example.com',
+          url: 'https://example.com/conflict',
+        },
+        { id: 'gdelt-event-2', country: 'Yemen', event_date: '2026-07-13' },
+        { id: 'gdelt-event-3', country: 'Ukraine', event_date: '2026-07-13' },
+      ],
       exportTimestamp: '20260713110000',
       exportsRequested: 8,
       exportsSucceeded: 8,
@@ -184,12 +195,11 @@ test('fetchGdeltConflictEvents publishes bulk pagination telemetry on the primar
   });
 
   assert.equal(result.source, 'gdelt-bulk');
-  assert.equal(result.events.length, 1);
-  assert.equal(result.events[0].country, 'Sudan');
+  assert.equal(result.events.length, 3);
   assert.equal(result.pagination.exportTimestamp, '20260713110000');
   assert.equal(result.pagination.exportsRequested, 8);
   assert.equal(result.pagination.exportsSucceeded, 8);
-  assert.equal(result.pagination.countriesWithEvents, 1);
+  assert.equal(result.pagination.countriesWithEvents, 3);
   assert.equal(result.pagination.rollingWindowHours, 24);
   // The sweep never ran, so its telemetry must not appear at all — 0/20 would
   // read as a failed sweep to anyone inspecting the published snapshot.
@@ -246,13 +256,17 @@ test('fetchGdeltConflictEvents publishes fresh bulk events when the previous sna
     now: () => now,
     fetchCountryEvents: async (cc) => ({ country: cc, ok: false, events: [], error: 'HTTP 429' }),
     fetchBulkEvents: async () => ({
-      events: [{
-        id: 'fresh-after-redis-blip',
-        country: 'Sudan',
-        event_date: '2026-07-13',
-        occurredAt: now - 60 * 60 * 1000,
-        gdeltAddedAt: now - 60 * 60 * 1000,
-      }],
+      events: [
+        {
+          id: 'fresh-after-redis-blip',
+          country: 'Sudan',
+          event_date: '2026-07-13',
+          occurredAt: now - 60 * 60 * 1000,
+          gdeltAddedAt: now - 60 * 60 * 1000,
+        },
+        { id: 'fresh-2', country: 'Yemen', event_date: '2026-07-13', occurredAt: now - 60 * 60 * 1000, gdeltAddedAt: now - 60 * 60 * 1000 },
+        { id: 'fresh-3', country: 'Ukraine', event_date: '2026-07-13', occurredAt: now - 60 * 60 * 1000, gdeltAddedAt: now - 60 * 60 * 1000 },
+      ],
       oldestExportTimestamp: '20260713160000',
       exportTimestamp: '20260713170000',
       exportsRequested: 8,
@@ -264,22 +278,54 @@ test('fetchGdeltConflictEvents publishes fresh bulk events when the previous sna
   });
 
   assert.equal(result.source, 'gdelt-bulk');
-  assert.deepEqual(result.events.map(event => event.id), ['fresh-after-redis-blip']);
+  assert.ok(result.events.some(event => event.id === 'fresh-after-redis-blip'));
+  assert.equal(result.events.length, 3);
   assert.equal(result.pagination.retainedPreviousEvents, 0);
   assert.equal(result.pagination.rollingWindowComplete, false);
 });
 
+test('a slow-failing bulk export does not starve the DOC sweep window (#5849)', async () => {
+  // The deadline invariant budgets the bulk path's worst case (GDELT_BULK_WORST_NETWORK_MS)
+  // ON TOP of the sweep window (seed-fetch-deadline-budget-invariants.test.mjs), so time the
+  // bulk attempt burns must be credited back to the sweep cutoff — otherwise a hanging-then-
+  // failing mirror leaves the healthy DOC fallback an already-expired budget every tick.
+  let fakeTime = 0;
+  let calls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => fakeTime,
+    deadlineAt: 120_000,
+    loadPreviousSnapshot: async () => null,
+    fetchBulkEvents: async () => {
+      fakeTime += 110_000; // mirror hangs through timeouts, consuming nearly the whole window
+      throw new Error('mirror hanging');
+    },
+    fetchCountryEvents: async (cc) => {
+      calls += 1;
+      fakeTime += 2_000;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+  });
+
+  assert.equal(calls, 20, `sweep must still get its full window after a slow bulk failure, attempted ${calls}/20`);
+  assert.equal(result.source, 'gdelt');
+});
+
 test('fetchGdeltConflictEvents falls back to the DOC sweep when the bulk export fails', async () => {
+  // Mixed DOC outcomes landing exactly on the floor, so the sweep's
+  // countriesSucceeded/countriesFailed telemetry stays asserted post-#5849.
   let bulkCalls = 0;
+  let docCalls = 0;
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
     now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
-    fetchCountryEvents: async (cc) => ({
-      country: cc,
-      ok: true,
-      events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }],
-    }),
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return docCalls <= GDELT_MIN_SUCCESSFUL_COUNTRIES
+        ? { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] }
+        : { country: cc, ok: false, events: [], error: 'proxy unavailable' };
+    },
     fetchBulkEvents: async () => {
       bulkCalls += 1;
       throw new Error('mirror unreachable');
@@ -288,11 +334,145 @@ test('fetchGdeltConflictEvents falls back to the DOC sweep when the bulk export 
 
   assert.equal(bulkCalls, 1);
   assert.equal(result.source, 'gdelt');
-  assert.equal(result.events.length, Object.keys(GDELT_COUNTRY_NAMES).length);
+  assert.equal(result.events.length, GDELT_MIN_SUCCESSFUL_COUNTRIES);
   assert.equal(result.pagination.countriesTotal, Object.keys(GDELT_COUNTRY_NAMES).length);
-  assert.equal(result.pagination.countriesSucceeded, Object.keys(GDELT_COUNTRY_NAMES).length);
-  assert.equal(result.pagination.countriesFailed, 0);
+  assert.equal(result.pagination.countriesSucceeded, GDELT_MIN_SUCCESSFUL_COUNTRIES);
+  assert.equal(
+    result.pagination.countriesFailed,
+    Object.keys(GDELT_COUNTRY_NAMES).length - GDELT_MIN_SUCCESSFUL_COUNTRIES,
+  );
   assert.equal(result.pagination.minSuccessfulCountries, GDELT_MIN_SUCCESSFUL_COUNTRIES);
+});
+
+test('partial bulk export coverage logs a degradation warning; full coverage stays silent (#5849)', async (t) => {
+  const warns = [];
+  t.mock.method(console, 'warn', (...args) => { warns.push(args.join(' ')); });
+  const bulkFixture = (exportsSucceeded) => ({
+    events: [
+      { id: `warn-${exportsSucceeded}-1`, country: 'Sudan' },
+      { id: `warn-${exportsSucceeded}-2`, country: 'Yemen' },
+      { id: `warn-${exportsSucceeded}-3`, country: 'Ukraine' },
+    ],
+    exportTimestamp: '20260713110000',
+    exportsRequested: 8,
+    exportsSucceeded,
+  });
+  const opts = {
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    loadPreviousSnapshot: async () => null,
+    fetchCountryEvents: async () => { throw new Error('DOC sweep must not run'); },
+  };
+
+  await fetchGdeltConflictEvents({ ...opts, fetchBulkEvents: async () => bulkFixture(6) });
+  assert.ok(
+    warns.some((w) => w.includes('partially degraded: 6/8')),
+    `expected partial-degradation warn, got: ${warns.join(' | ')}`,
+  );
+
+  warns.length = 0;
+  await fetchGdeltConflictEvents({ ...opts, fetchBulkEvents: async () => bulkFixture(8) });
+  assert.ok(
+    !warns.some((w) => w.includes('partially degraded')),
+    'full export coverage must not warn',
+  );
+});
+
+test('the bulk-elapsed credit cannot resurrect a window that expired before entry (#5849)', async () => {
+  // deadlineAt already passed when fetchGdeltConflictEvents was entered (aux
+  // feeds burned it) AND bulk fails slowly: the credit shifts the cutoff by
+  // bulk time only, so the sweep still sees the pre-entry (expired) window
+  // and must launch nothing.
+  let fakeTime = 200_000;
+  let calls = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      now: () => fakeTime,
+      deadlineAt: 120_000,
+      loadPreviousSnapshot: async () => null,
+      fetchBulkEvents: async () => {
+        fakeTime += 50_000;
+        throw new Error('mirror hanging');
+      },
+      fetchCountryEvents: async (cc) => {
+        calls += 1;
+        return { country: cc, ok: true, events: [] };
+      },
+    }),
+    /coverage below floor: 0\/20/,
+  );
+  assert.equal(calls, 0);
+});
+
+test('a thin cold-start bulk window falls through to the DOC sweep instead of publishing as primary (#5849)', async () => {
+  // No retained rolling window + a single-country handful of events (the
+  // partially-degraded-mirror shape: 1/8 exports usable) must not overwrite
+  // last-good as the primary feed — it should fall through to the sweep.
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    loadPreviousSnapshot: async () => null,
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'thin-1', country: 'Sudan' }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 1,
+    }),
+  });
+
+  assert.equal(result.source, 'gdelt');
+  assert.equal(docCalls, Object.keys(GDELT_COUNTRY_NAMES).length);
+});
+
+test('fetchGdeltConflictEvents falls through to the DOC sweep when bulk resolves with zero events (#5849)', async () => {
+  // "Empty exports" is a named bulk-failure mode distinct from a thrown mirror
+  // error — the guard is a resolved-but-empty payload, not a rejection.
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    loadPreviousSnapshot: async () => null,
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({ events: [], exportTimestamp: '20260713110000', exportsRequested: 8, exportsSucceeded: 8 }),
+  });
+
+  assert.equal(result.source, 'gdelt');
+  assert.equal(docCalls, Object.keys(GDELT_COUNTRY_NAMES).length);
+});
+
+test('fetchGdeltConflictEvents falls through to the DOC sweep when the rolling window prunes all bulk events (#5849)', async () => {
+  // Third named failure mode: exports resolve with events, but every one is
+  // older than the 24h rolling window and no previous snapshot backfills it.
+  const staleAddedAt = BULK_FIXTURE_NOW - 25 * 60 * 60 * 1000;
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    loadPreviousSnapshot: async () => null,
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'stale-26h', country: 'Sudan', event_date: '2026-07-12', occurredAt: staleAddedAt, gdeltAddedAt: staleAddedAt }],
+      oldestExportTimestamp: '20260712100000',
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+  });
+
+  assert.equal(result.source, 'gdelt');
+  assert.equal(docCalls, Object.keys(GDELT_COUNTRY_NAMES).length);
 });
 
 // #5140: the sweep's former retry fanout exceeded runSeed's fetch deadline, so

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -676,3 +676,100 @@ test('a programming defect in the bulk block crashes loud instead of impersonati
   );
   assert.equal(docCalls, 0, 'a code defect must not be reclassified as a bulk outage and routed to the sweep');
 });
+
+test('an empty current tick publishes the retained rolling window instead of discarding it (#5855 review)', async () => {
+  // One quiet/glitchy 15-min tick must not abandon a healthy multi-hour window
+  // for the load-shed DOC sweep: "empty exports" is a bulk failure only when
+  // nothing is retained either.
+  const now = Date.parse('2026-07-13T18:00:00Z');
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => now,
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({
+      events: [],
+      exportTimestamp: '20260713174500',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+    loadPreviousSnapshot: async () => ({
+      source: 'gdelt-bulk',
+      events: [
+        { id: 'retained-1', country: 'Sudan', event_date: '2026-07-13', occurredAt: now - 2 * 60 * 60 * 1000, gdeltAddedAt: now - 2 * 60 * 60 * 1000 },
+        { id: 'retained-2', country: 'Yemen', event_date: '2026-07-13', occurredAt: now - 3 * 60 * 60 * 1000, gdeltAddedAt: now - 3 * 60 * 60 * 1000 },
+      ],
+      pagination: { exportTimestamp: '20260713173000', rollingWindowStartedAt: now - 14 * 60 * 60 * 1000 },
+    }),
+  });
+
+  assert.equal(docCalls, 0, 'an empty tick with a healthy retained window must not run the DOC sweep');
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.deepEqual(result.events.map(event => event.id).sort(), ['retained-1', 'retained-2']);
+  assert.equal(result.pagination.retainedPreviousEvents, 2);
+});
+
+test('a stale bulk export (frozen mirror) is treated as a bulk failure and falls through to the DOC sweep (#5855 review)', async () => {
+  // A mirror that stops updating keeps serving the same aging exports: without
+  // an age gate every tick would publish "fresh" writes while a possibly
+  // healthy DOC route is never consulted.
+  const now = Date.parse('2026-07-13T18:00:00Z');
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => now,
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({
+      // newest export 4h old — beyond the 3h freshness gate
+      events: [
+        { id: 'frozen-1', country: 'Sudan', event_date: '2026-07-13', occurredAt: now - 4 * 60 * 60 * 1000, gdeltAddedAt: now - 4 * 60 * 60 * 1000 },
+        { id: 'frozen-2', country: 'Yemen', event_date: '2026-07-13', occurredAt: now - 4 * 60 * 60 * 1000, gdeltAddedAt: now - 4 * 60 * 60 * 1000 },
+        { id: 'frozen-3', country: 'Ukraine', event_date: '2026-07-13', occurredAt: now - 4 * 60 * 60 * 1000, gdeltAddedAt: now - 4 * 60 * 60 * 1000 },
+      ],
+      exportTimestamp: '20260713140000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+    loadPreviousSnapshot: async () => null,
+  });
+
+  assert.equal(result.source, 'gdelt', 'a frozen mirror must fall through to the DOC sweep');
+  assert.equal(docCalls, Object.keys(GDELT_COUNTRY_NAMES).length);
+});
+
+test('a thin bulk window after a DOC-published tick is NOT floored — the floor arms only on a true cold start (#5855 review)', async () => {
+  // After GDELT DOC briefly recovers, one sweep-published tick (source 'gdelt')
+  // zeroes retainedPreviousEvents on the next bulk tick. That must not re-arm
+  // the cold-start floor, or recovery ping-pongs on the DOC route (#5852's
+  // floor half): a previous snapshot EXISTS, so this is not a cold start.
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'thin-recovery', country: 'Sudan' }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+    loadPreviousSnapshot: async () => ({
+      source: 'gdelt',
+      events: [{ id: 'doc-published', country: 'Sudan', event_date: '2026-07-13' }],
+      pagination: { countriesSucceeded: 16 },
+    }),
+  });
+
+  assert.equal(docCalls, 0, 'a DOC-sourced previous snapshot must not re-arm the cold-start floor');
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.deepEqual(result.events.map(event => event.id), ['thin-recovery']);
+});

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -121,37 +121,53 @@ test('fetchGdeltConflictEvents fails closed when too many country fetches fail',
   );
 });
 
-test('fetchGdeltConflictEvents falls through to bulk when the DOC sweep succeeds but yields zero events', async () => {
+test('fetchGdeltConflictEvents uses the bulk export as PRIMARY: a healthy bulk path makes zero DOC requests (#5849)', async () => {
+  let docCalls = 0;
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
     now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
-    fetchCountryEvents: async (cc) => ({ country: cc, ok: true, events: [] }),
+    // A DOC route that would happily serve every country — the old DOC-first
+    // order returns source 'gdelt' with 20 requests here; bulk-first makes none.
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ country: 'Sudan', event_date: '2026-07-13' }] };
+    },
     fetchBulkEvents: async () => ({
-      events: [{ id: 'gdelt-event-empty-doc', country: 'Sudan' }],
+      events: [{ id: 'gdelt-event-primary', country: 'Sudan' }],
       exportTimestamp: '20260713110000',
       exportsRequested: 8,
       exportsSucceeded: 8,
     }),
   });
 
+  assert.equal(docCalls, 0, `healthy bulk path must make zero DOC API requests, made ${docCalls}`);
   assert.equal(result.source, 'gdelt-bulk');
-  assert.equal(result.events.length, 1);
-  assert.equal(result.pagination.countriesSucceeded, 20);
-  assert.equal(result.pagination.countriesFailed, 0);
+  assert.deepEqual(result.events.map(event => event.id), ['gdelt-event-primary']);
 });
 
-test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk event feed', async () => {
+test('fetchGdeltConflictEvents rejects when bulk fails and the DOC sweep succeeds but yields zero events', async () => {
+  // Post-#5849 the zero-yield sweep has nothing left to fall through to: bulk
+  // already failed ahead of it. The run must throw (runSeed retries / preserves
+  // last-good), never resolve to a legitimate-looking empty payload.
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      now: () => BULK_FIXTURE_NOW,
+      loadPreviousSnapshot: async () => null,
+      fetchCountryEvents: async (cc) => ({ country: cc, ok: true, events: [] }),
+      fetchBulkEvents: async () => { throw new Error('mirror unreachable'); },
+    }),
+    /bulk event export failed: mirror unreachable.*returned zero events across 20\/20 successful countries/s,
+  );
+});
+
+test('fetchGdeltConflictEvents publishes bulk pagination telemetry on the primary path', async () => {
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
     now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
-    fetchCountryEvents: async (cc) => ({
-      country: cc,
-      ok: false,
-      events: [],
-      error: 'HTTP 429',
-    }),
+    fetchCountryEvents: async () => { throw new Error('DOC sweep must not run when bulk is healthy'); },
     fetchBulkEvents: async () => ({
       events: [{
         id: 'gdelt-event-1',
@@ -170,13 +186,15 @@ test('fetchGdeltConflictEvents recovers from a throttled DOC sweep with the bulk
   assert.equal(result.source, 'gdelt-bulk');
   assert.equal(result.events.length, 1);
   assert.equal(result.events[0].country, 'Sudan');
-  assert.equal(result.pagination.countriesTotal, Object.keys(GDELT_COUNTRY_NAMES).length);
-  assert.equal(result.pagination.countriesSucceeded, 0);
-  assert.equal(result.pagination.countriesFailed, Object.keys(GDELT_COUNTRY_NAMES).length);
   assert.equal(result.pagination.exportTimestamp, '20260713110000');
   assert.equal(result.pagination.exportsRequested, 8);
   assert.equal(result.pagination.exportsSucceeded, 8);
   assert.equal(result.pagination.countriesWithEvents, 1);
+  assert.equal(result.pagination.rollingWindowHours, 24);
+  // The sweep never ran, so its telemetry must not appear at all — 0/20 would
+  // read as a failed sweep to anyone inspecting the published snapshot.
+  assert.ok(!('countriesSucceeded' in result.pagination));
+  assert.ok(!('countriesFailed' in result.pagination));
 });
 
 test('fetchGdeltConflictEvents carries prior bulk events through the EMA 24h window', async () => {
@@ -251,32 +269,30 @@ test('fetchGdeltConflictEvents publishes fresh bulk events when the previous sna
   assert.equal(result.pagination.rollingWindowComplete, false);
 });
 
-test('fetchGdeltConflictEvents preserves partial DOC coverage telemetry after bulk recovery', async () => {
-  let calls = 0;
+test('fetchGdeltConflictEvents falls back to the DOC sweep when the bulk export fails', async () => {
+  let bulkCalls = 0;
   const result = await fetchGdeltConflictEvents({
     pace: async () => {},
     now: () => BULK_FIXTURE_NOW,
     loadPreviousSnapshot: async () => null,
-    fetchCountryEvents: async (cc) => {
-      calls += 1;
-      return calls <= GDELT_MIN_SUCCESSFUL_COUNTRIES
-        ? { country: cc, ok: true, events: [] }
-        : { country: cc, ok: false, events: [], error: 'HTTP 429' };
-    },
-    fetchBulkEvents: async () => ({
-      events: [{ id: 'gdelt-event-partial-doc', country: 'Sudan' }],
-      exportTimestamp: '20260713110000',
-      exportsRequested: 8,
-      exportsSucceeded: 8,
+    fetchCountryEvents: async (cc) => ({
+      country: cc,
+      ok: true,
+      events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }],
     }),
+    fetchBulkEvents: async () => {
+      bulkCalls += 1;
+      throw new Error('mirror unreachable');
+    },
   });
 
-  assert.equal(result.source, 'gdelt-bulk');
-  assert.equal(result.pagination.countriesSucceeded, GDELT_MIN_SUCCESSFUL_COUNTRIES);
-  assert.equal(
-    result.pagination.countriesFailed,
-    Object.keys(GDELT_COUNTRY_NAMES).length - GDELT_MIN_SUCCESSFUL_COUNTRIES,
-  );
+  assert.equal(bulkCalls, 1);
+  assert.equal(result.source, 'gdelt');
+  assert.equal(result.events.length, Object.keys(GDELT_COUNTRY_NAMES).length);
+  assert.equal(result.pagination.countriesTotal, Object.keys(GDELT_COUNTRY_NAMES).length);
+  assert.equal(result.pagination.countriesSucceeded, Object.keys(GDELT_COUNTRY_NAMES).length);
+  assert.equal(result.pagination.countriesFailed, 0);
+  assert.equal(result.pagination.minSuccessfulCountries, GDELT_MIN_SUCCESSFUL_COUNTRIES);
 });
 
 // #5140: the sweep's former retry fanout exceeded runSeed's fetch deadline, so

--- a/tests/conflict-gdelt.test.mjs
+++ b/tests/conflict-gdelt.test.mjs
@@ -574,3 +574,105 @@ test('early-stop reason names BOTH conditions when budget and floor trip togethe
     `expected combined stop reason in warns: ${warns.join(' | ')}`,
   );
 });
+
+test('a transient snapshot-read failure does not arm the cold-start floor (#5855 review)', async () => {
+  // readSeedSnapshot(strict:true) throwing on a Redis blip must not be
+  // conflated with a true first-ever run: the thin-but-real bulk window still
+  // publishes instead of falling through to the load-shed DOC sweep.
+  let docCalls = 0;
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    loadPreviousSnapshot: async () => { throw new Error('redis read failed: HTTP 500'); },
+    fetchCountryEvents: async (cc) => {
+      docCalls += 1;
+      return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+    },
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'thin-but-real', country: 'Sudan' }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 8,
+    }),
+  });
+
+  assert.equal(docCalls, 0, 'a snapshot-read blip must not route a healthy bulk tick to the DOC sweep');
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.deepEqual(result.events.map(event => event.id), ['thin-but-real']);
+});
+
+test('partial mirror degradation is reported even when the cold-start floor rejects the tick (#5855 review)', async (t) => {
+  // The 1-usable-export cold start is exactly the partially-degraded-mirror
+  // shape the warning exists to expose; the floor throw must not silence it.
+  const warns = [];
+  t.mock.method(console, 'warn', (...args) => { warns.push(args.join(' ')); });
+  const result = await fetchGdeltConflictEvents({
+    pace: async () => {},
+    now: () => BULK_FIXTURE_NOW,
+    loadPreviousSnapshot: async () => null,
+    fetchCountryEvents: async (cc) => (
+      { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] }
+    ),
+    fetchBulkEvents: async () => ({
+      events: [{ id: 'thin-degraded', country: 'Sudan' }],
+      exportTimestamp: '20260713110000',
+      exportsRequested: 8,
+      exportsSucceeded: 1,
+    }),
+  });
+
+  assert.equal(result.source, 'gdelt', 'thin cold start still falls through to the sweep');
+  assert.ok(
+    warns.some((w) => w.includes('partially degraded: 1/8')),
+    `expected the degradation warn to fire before the floor throw, got: ${warns.join(' | ')}`,
+  );
+});
+
+test('the sweep-budget credit is clamped to GDELT_BULK_WORST_NETWORK_MS on a bulk overrun (#5855 review)', async () => {
+  // Bulk burns 100s against a 60s worst-case budget. The clamped credit moves
+  // the 20s-old cutoff to 80s — already expired when the sweep starts at 100s —
+  // so nothing launches. An unclamped credit (raw elapsed) would resurrect a
+  // 120s cutoff and launch the sweep: this test goes red under that mutant.
+  let fakeTime = 0;
+  let docCalls = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      now: () => fakeTime,
+      deadlineAt: 20_000,
+      loadPreviousSnapshot: async () => null,
+      fetchBulkEvents: async () => {
+        fakeTime += 100_000;
+        throw new Error('mirror hanging');
+      },
+      fetchCountryEvents: async (cc) => {
+        docCalls += 1;
+        fakeTime += 2_000;
+        return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+      },
+    }),
+    /sweep budget exhausted/,
+  );
+  assert.equal(docCalls, 0, 'the clamped credit must not resurrect the pre-bulk sweep window');
+});
+
+test('a programming defect in the bulk block crashes loud instead of impersonating a mirror outage (#5855 review)', async () => {
+  // With DOC load-shed, "bulk failed" routes to a dead sweep and a quiet
+  // sourceUnavailable exit 0 — the wrong runbook for a shipped code defect.
+  // TypeError/ReferenceError/RangeError/SyntaxError must escape the bulk catch.
+  let docCalls = 0;
+  await assert.rejects(
+    fetchGdeltConflictEvents({
+      pace: async () => {},
+      now: () => BULK_FIXTURE_NOW,
+      loadPreviousSnapshot: async () => null,
+      fetchCountryEvents: async (cc) => {
+        docCalls += 1;
+        return { country: cc, ok: true, events: [{ id: `doc-${cc}`, country: GDELT_COUNTRY_NAMES[cc], event_date: '2026-07-13' }] };
+      },
+      fetchBulkEvents: async () => { throw new TypeError('bulk.events.map is not a function'); },
+    }),
+    TypeError,
+  );
+  assert.equal(docCalls, 0, 'a code defect must not be reclassified as a bulk outage and routed to the sweep');
+});

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -433,10 +433,14 @@ test('bulk-first: a healthy bulk export short-circuits the DOC route entirely (#
     fetchBulkEvents: async () => {
       bulkCalls += 1;
       return {
-        events: [{ id: 'bulk-primary', country: 'Sudan' }],
+        events: [
+          { id: 'bulk-primary', country: 'Sudan' },
+          { id: 'bulk-primary-2', country: 'Yemen' },
+          { id: 'bulk-primary-3', country: 'Ukraine' },
+        ],
         exportTimestamp: '20260729110000',
-        exportsRequested: 1,
-        exportsSucceeded: 1,
+        exportsRequested: 8,
+        exportsSucceeded: 8,
       };
     },
     pace: async () => {},
@@ -448,7 +452,7 @@ test('bulk-first: a healthy bulk export short-circuits the DOC route entirely (#
   assert.equal(attempted.length, 0, 'zero DOC requests when the bulk path is healthy');
   assert.equal(bulkCalls, 1);
   assert.equal(result.source, 'gdelt-bulk');
-  assert.deepEqual(result.events.map(event => event.id), ['bulk-primary']);
+  assert.equal(result.events.length, 3);
 });
 
 test('GDELT route circuit stays closed for a request-specific HTTP failure', async () => {

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -190,6 +190,21 @@ test('fetchAll: no ACLED creds but GDELT fallback WORKS -> not sourceUnavailable
   );
 });
 
+test('fetchAll: a programming defect in the GDELT fallback escapes to runSeed instead of degrading to sourceUnavailable (#5855 review)', async () => {
+  delete process.env.ACLED_EMAIL;
+  delete process.env.ACLED_PASSWORD;
+  delete process.env.ACLED_ACCESS_TOKEN;
+  globalThis.fetch = async () => new Response('rate limited', { status: 429 });
+
+  await assert.rejects(
+    fetchAll({
+      fetchGdeltFallback: async () => { throw new TypeError('bulk.events.map is not a function'); },
+    }),
+    TypeError,
+    'a deploy defect must fail the fetch phase attributably, not impersonate an upstream outage',
+  );
+});
+
 // ─── SECURITY: proxy credentials must never reach the logs ───
 
 test('redactProxyCredentials scrubs inline proxy user:pass from surfaced errors', () => {

--- a/tests/seed-conflict-intel-no-source-exit0.test.mjs
+++ b/tests/seed-conflict-intel-no-source-exit0.test.mjs
@@ -349,7 +349,7 @@ test('GDELT route circuit opens after one SSL/timeout canary failure', async () 
         error: 'curl failed: curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL', // no 429 anywhere
       };
     },
-    fetchBulkEvents: async () => { throw new Error('bulk unused'); },
+    fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
     pace: async () => {},
     now: () => 0,
     deadlineAt: 10_000_000,
@@ -383,48 +383,72 @@ test('GDELT route circuit opens after one proxy-auth canary failure', async () =
     assert.equal(
       attempted.length,
       1,
-      `HTTP ${status} proxy auth failure must fall through to bulk without another country request`,
+      `HTTP ${status} proxy auth failure must not be repeated for another country`,
     );
   }
 });
 
 test('GDELT route circuit opens after one endpoint-wide HTTP canary failure', async () => {
+  // Post-#5849 the sweep only runs after a bulk failure, so the circuit's job
+  // is to stop a dead DOC route from burning the remaining 19 requests before
+  // the combined failure surfaces to runSeed.
   for (const status of [404, 406, 410, 451]) {
     const attempted = [];
-    let bulkCalls = 0;
     const now = Date.parse('2026-07-29T12:00:00Z');
-    const result = await fetchGdeltConflictEvents({
-      fetchCountryEvents: async (cc) => {
-        attempted.push(cc);
-        return {
-          country: cc, ok: false, events: [],
-          error: `GDELT_SOURCE_PROXY_HTTP_${status}`,
-        };
-      },
-      fetchBulkEvents: async () => {
-        bulkCalls += 1;
-        return {
-          events: [{ id: `route-failure-${status}`, country: 'Sudan' }],
-          exportTimestamp: '20260729110000',
-          exportsRequested: 1,
-          exportsSucceeded: 1,
-        };
-      },
-      pace: async () => {},
-      now: () => now,
-      deadlineAt: now + 10_000_000,
-      loadPreviousSnapshot: async () => null,
-    });
+    await assert.rejects(
+      fetchGdeltConflictEvents({
+        fetchCountryEvents: async (cc) => {
+          attempted.push(cc);
+          return {
+            country: cc, ok: false, events: [],
+            error: `GDELT_SOURCE_PROXY_HTTP_${status}`,
+          };
+        },
+        fetchBulkEvents: async () => { throw new Error('mirror unreachable'); },
+        pace: async () => {},
+        now: () => now,
+        deadlineAt: now + 10_000_000,
+        loadPreviousSnapshot: async () => null,
+      }),
+      /bulk event export failed: mirror unreachable.*coverage below floor/s,
+    );
 
     assert.equal(
       attempted.length,
       1,
-      `HTTP ${status} endpoint failure must fall through to bulk without another country request`,
+      `HTTP ${status} endpoint failure must not be repeated for another country`,
     );
-    assert.equal(bulkCalls, 1);
-    assert.equal(result.source, 'gdelt-bulk');
-    assert.deepEqual(result.events.map(event => event.id), [`route-failure-${status}`]);
   }
+});
+
+test('bulk-first: a healthy bulk export short-circuits the DOC route entirely (#5849)', async () => {
+  const attempted = [];
+  let bulkCalls = 0;
+  const now = Date.parse('2026-07-29T12:00:00Z');
+  const result = await fetchGdeltConflictEvents({
+    fetchCountryEvents: async (cc) => {
+      attempted.push(cc);
+      return { country: cc, ok: true, events: [] };
+    },
+    fetchBulkEvents: async () => {
+      bulkCalls += 1;
+      return {
+        events: [{ id: 'bulk-primary', country: 'Sudan' }],
+        exportTimestamp: '20260729110000',
+        exportsRequested: 1,
+        exportsSucceeded: 1,
+      };
+    },
+    pace: async () => {},
+    now: () => now,
+    deadlineAt: now + 10_000_000,
+    loadPreviousSnapshot: async () => null,
+  });
+
+  assert.equal(attempted.length, 0, 'zero DOC requests when the bulk path is healthy');
+  assert.equal(bulkCalls, 1);
+  assert.equal(result.source, 'gdelt-bulk');
+  assert.deepEqual(result.events.map(event => event.id), ['bulk-primary']);
 });
 
 test('GDELT route circuit stays closed for a request-specific HTTP failure', async () => {
@@ -444,7 +468,7 @@ test('GDELT route circuit stays closed for a request-specific HTTP failure', asy
         events: [{ id: `country-${cc}`, country: cc, event_date: '2026-07-29' }],
       };
     },
-    fetchBulkEvents: async () => { throw new Error('bulk unused'); },
+    fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
     pace: async () => {},
     now: () => 0,
     deadlineAt: 10_000_000,
@@ -466,7 +490,7 @@ test('GDELT storm abort does NOT fire when a country in the batch succeeds', asy
       if (attempted.length % 4 === 1) return { country: cc, ok: true, events: [{ country: cc, event_date: '2026-07-13' }] };
       return { country: cc, ok: false, events: [], error: 'HTTP 429' };
     },
-    fetchBulkEvents: async () => { throw new Error('bulk unused'); },
+    fetchBulkEvents: async () => { throw new Error('bulk unavailable'); },
     pace: async () => {},
     now: () => 0,
     deadlineAt: 10_000_000,


### PR DESCRIPTION
Closes #5849 (parent #5843, mitigation M2).

## What changed

`seed-conflict-intel`'s GDELT fallback (the prod path while ACLED credentials are absent) now tries the **official bulk event export first** and runs the DOC 2.0 per-country sweep **only when the bulk path fails**. The DOC route is supply-side load-shed (0/20 countries per #5843's diagnosis), so the old order burned a doomed canary + up to 15s of latency (and residential-proxy budget) every 15-minute tick before landing on bulk anyway.

- `fetchGdeltConflictEvents` (scripts/seed-conflict-intel.mjs): bulk + rolling-window merge moved to the top; the sweep (canary, batches of 4, budget, 16/20 floor, route circuit — all #5140 semantics) is unchanged and runs only after a bulk failure; both-fail throws a combined error, so `fetchAll`'s `sourceUnavailable` / exit-0 degrade path is preserved.
- **Sweep budget credit (review finding, reliability P1):** the bulk attempt's elapsed time is credited back to the sweep's `launchCutoffAt`, clamped to `GDELT_BULK_WORST_NETWORK_MS` — a slow-failing mirror (~60s of timeouts) can no longer hand the healthy fallback an already-expired window, and the clamp keeps the code and the deadline-invariant model (`seed-fetch-deadline-budget-invariants.test.mjs`) the same number. Worst-case envelope still fits `ACLED_INTEL_LOCK_TTL_MS` (420s).
- **Cold-start coverage floor (review finding, flagged independently by two model families):** with no retained rolling window, a thin bulk result (<3 countries with events — the 1-of-8-exports partially-degraded-mirror shape) falls through to the sweep instead of overwriting last-good as the primary feed. Steady-state ticks always retain prior-window events, so the floor never fires there.
- Partial export coverage now logs `GDELT bulk exports partially degraded: N/M export files fetched`.
- Bulk-path pagination no longer carries sweep telemetry (`countriesSucceeded: 0/20` would read as a failed sweep); repo-wide grep confirms no consumer reads those fields or branches on `source: 'gdelt-bulk'`.

## Acceptance criteria (from #5849)

| Criterion | Evidence |
|---|---|
| Failing test first: healthy bulk makes zero DOC requests | `tests/conflict-gdelt.test.mjs` "uses the bulk export as PRIMARY" — observed red (20 !== 0) before the inversion, green after |
| Bulk failure falls through to DOC sweep with existing canary + floor semantics | all #5140 budget/circuit/floor tests green unchanged; new fallback tests for thrown, resolved-empty, and rolling-pruned bulk failures |
| Both-fail keeps throw/degrade behavior | combined-error tests + full `seed-conflict-intel-no-source-exit0` suite green |
| Rolling-window merge semantics unchanged | `tests/conflict-gdelt-bulk.test.mjs` untouched and green |
| No consumer treats `gdelt-bulk` as an error state | audited: forecasts read `.events` only; the RPC reads per-event source domains; health reads seed-meta staleness; MCP `get_conflict_events` uses different keys entirely |

Proxy egress in the happy path drops to zero — bulk goes direct to the GCS mirror, no `PROXY_URL`/`GDELT_PROXY_URL` involvement.

## Review

Multi-model review (run `20260730-081019-1af0315e`): 8 reviewer lenses in-process plus an independent **Codex cross-model adversarial pass** and a **Codex correctness pass** (clean, 148k-token analysis of the budget arithmetic). An Anthropic-side 529 storm killed the session-model correctness/adversarial agents mid-run; correctness re-ran to completion on Opus (confirms all five acceptance criteria and the credit algebra), and the Codex adversarial pass stands as the adversarial lens. Applied findings: budget starvation (P1, fixed + regression test), cold-start floor (cross-family agreement, fixed + test), stale canary comment (P2), untested non-throw bulk-failure modes + lost mixed-coverage telemetry (testing P2/P3, fixed), unclamped credit (P3, fixed).

## Known Residuals

- **#5852** — a successful DOC-fallback tick erases the accumulated 24h bulk rolling window on bulk recovery (`mergeGdeltBulkRollingWindow` only retains from `gdelt-bulk`-sourced snapshots). Pre-existing mechanism, out of this issue's pinned scope ("rolling-window merge semantics unchanged"); dormant while DOC is load-shed. Filed with two candidate fixes.
- `GDELT_ROLLING_WINDOW_MAX_EVENTS` (5000) truncation is newly reachable in steady state; truncation is uniform by recency, so the EMA deflates consistently rather than skewing — measure real daily volume after a few days of bulk-primary ticks.
- The bulk try-block's catch is broad: a code defect in that block would be reported as a bulk failure and routed to the (dead) DOC sweep → `sourceUnavailable` exit 0, visible in Railway logs but not a loud crash.
- Steady-state request volume against the GCS mirror rises (manifest + up to 8 export downloads per tick vs. only-during-brownouts before) — watch during rollout, no code change needed.

## Post-Deploy Monitoring & Validation

- **Logs (Railway, `seed-conflict-intel`):** healthy = `GDELT bulk conflict-events: N events through export <ts> (M retained from prior runs)` each ~15min tick with **zero** `GDELT <CC>:` DOC lines. Failure signals = recurring `falling back to the DOC country sweep`, `partially degraded: N/M`, or `cold-start bulk window too thin` → probe the GCS mirror (`storage.googleapis.com/data.gdeltproject.org/gdeltv2/masterfilelist.txt`).
- **Health:** `/api/health` `acledIntel` stays fresh (maxStaleMin 38); `conflict:acled:v1:all:0:0` snapshot carries `source: 'gdelt-bulk'` with `rollingWindowComplete: true` after 24h of ticks.
- **Proxy budget:** Decodo traffic attributable to this seeder should drop to ~0 in the happy path.
- **Rollback trigger:** acledIntel STALE/EMPTY for >2 consecutive hours with bulk-failure logs → revert this PR (the DOC-first order and all its semantics are preserved in history; revert is clean).
- **Window / owner:** 24h post-deploy; elie.

## Testing

45 tests across `tests/conflict-gdelt.test.mjs` + `tests/seed-conflict-intel-no-source-exit0.test.mjs` (12 new/rewritten for bulk-first semantics, budget credit, cold-start floor, degradation warn, expired-window pin); 164 green across the full 10-file importer sweep; biome clean. Red→green observed for the acceptance test, the slow-bulk starvation test, and the thin cold-start test.

---
🤖 Compound-engineered with [Claude Code](https://claude.com/claude-code) (Fable 5) — multi-model review: Claude (Fable/Opus) + Codex (gpt-5.5).

https://claude.ai/code/session_01JxMNYdxzq2zwURAkBUVCRo
