### PR TITLE
docs(china): document complete data coverage

### DIFF
--- a/docs/china-corporate-disclosures.mdx
+++ b/docs/china-corporate-disclosures.mdx
@@ -1,0 +1,126 @@
+---
+title: "China Corporate Disclosures"
+description: "SSE, SZSE, and HKEX source admission, reviewed issuers, metadata-only collection, transport fallback, revisions, and health semantics."
+---
+
+The China corporate-disclosure lane monitors a small reviewed issuer basket
+against official exchange metadata. It is not a general-purpose exchange
+scraper, a full-market announcement archive, or a document redistribution
+service.
+
+## Source admission
+
+| Exchange | Launch status | Admission decision | Collection contract |
+| --- | --- | --- | --- |
+| `SSE` | `launched` | `admitted_metadata_only` | Public announcement metadata, bounded first page, document links retained but bodies not fetched |
+| `SZSE` | `launched` | `admitted_metadata_only` | Public announcement metadata, bounded first page, document links retained but bodies not fetched |
+| `HKEX` | `blocked` | `rejected` | No automated collection; `TERMS_PROHIBIT_AUTOMATED_ACCESS` |
+
+The reviewed terms records are:
+
+- SSE: [official legal terms](https://www.sse.com.cn/home/legal/)
+- SZSE: [applicable rules and notices](https://www.szse.cn/application/laws/)
+- HKEX: [terms of use](https://www2.hkexnews.hk/Global/Exchange/Terms-of-Use?sc_lang=en)
+
+SSE and SZSE are metadata-only because commercial reuse of document bodies can
+require written permission. `documentRetrieval` is `lazy-link-only`: consumers
+receive the official link but WorldMonitor does not ingest or redistribute the
+linked body. HKEX terms prohibit programmatic systematic retrieval without
+permission, so the source remains blocked even when its website is reachable.
+
+## Reviewed issuer basket
+
+| Exchange | Code | Symbol | Issuer |
+| --- | --- | --- | --- |
+| SSE | `600519` | `600519.SS` | Kweichow Moutai |
+| SSE | `601318` | `601318.SS` | Ping An Insurance |
+| SSE | `600900` | `600900.SS` | China Yangtze Power |
+| SSE | `688981` | `688981.SS` | SMIC |
+| SZSE | `300750` | `300750.SZ` | CATL |
+| HKEX, blocked | `0700` | `0700.HK` | Tencent |
+| HKEX, blocked | `1211` | `1211.HK` | BYD |
+| HKEX, blocked | `0939` | `0939.HK` | China Construction Bank |
+| HKEX, blocked | `0857` | `0857.HK` | PetroChina |
+
+HKEX issuers remain in the reviewed registry so the source decision is visible;
+they do not cause HKEX network requests.
+
+## Event classification and revisions
+
+Only reviewed title patterns become typed events:
+
+- trading halt and resumption;
+- share pledge;
+- investigation;
+- exchange risk alert;
+- earnings warning; and
+- major restructuring.
+
+Each event retains official exchange identity, issuer mapping, original title,
+publication time, metadata URL, document link, extraction/classification
+confidence, content hash, transport/content freshness, and a stable lineage.
+Corrections, revisions, withdrawals, and cancellations attach to that lineage
+instead of appearing as unrelated new events. Unclassified revisions are kept
+in a bounded diagnostic collection rather than promoted to decision signals.
+
+## Bounded collection
+
+SSE requests at most 100 rows from one reviewed 90-day page. SZSE requests at
+most 50 rows from one reviewed page. Neither adapter silently follows
+additional pages. A saturated page reports `PAGE_LIMIT_REACHED`; three
+consecutive empty results report `COVERAGE_GAP`.
+
+The combined snapshot retains at most 100 classified events, at most 20
+revisions per event, and at most 100 unclassified revisions. The Railway
+market-backup member runs every 30 minutes and publishes
+`market:china:corporate-disclosures:v1`.
+
+## Transport fallback
+
+SSE and SZSE first try direct Railway egress. At process start, each source
+selects the first non-empty proxy setting in this precedence order:
+
+```text
+SSE:  SSE_PROXY_URL → SZSE_PROXY_URL → PROXY_URL
+SZSE: SZSE_PROXY_URL → PROXY_URL
+```
+
+This is configuration precedence, not sequential URL failover. After a proxy
+URL is selected, a failed attempt does not advance to the next environment
+variable. Distinct SZSE proxy attempts rotate eligible Decodo sticky gateway
+ports within the selected proxy configuration.
+
+SSE uses up to four direct and four proxy requests with bounded concurrency.
+SZSE uses one direct attempt, up to two proxy attempts on distinct eligible
+gateway ports, and then the fixed
+`https://api.worldmonitor.app/api/internal/china-exchange-egress` edge hop.
+The edge hop is authenticated with `RELAY_SHARED_SECRET`; the secret is never
+sent to the exchange.
+
+The fallback order applies only to transport failures. HTTP or schema results
+that prove an application-level response are recorded and do not trigger
+unbounded route guessing. SZSE requires two consecutive successful runs to
+clear its durable transport-failure state.
+
+`SSE_PROXY_URL` is an optional SSE-specific override. `SZSE_PROXY_URL` is an
+optional shared China exit. `PROXY_URL` is selected only when the corresponding
+source-specific setting is absent and is also required by other market-bundle
+members. `RELAY_SHARED_SECRET` is required for the fixed edge fallback.
+
+## Coverage and health
+
+The snapshot can be:
+
+- `healthy` when every launched exchange has usable reviewed coverage;
+- `degraded` when SSE or SZSE is missing, stale, saturated, repeatedly empty,
+  or in transport error while another launched exchange remains usable; or
+- unavailable when no launched exchange can provide a usable result.
+
+A fresh seed heartbeat does not override a degraded embedded source state.
+Failed refreshes preserve valid last-good events with their original
+publication times and current transport failure. The blocked HKEX decision is
+reported separately and does not masquerade as a runtime outage.
+
+The public China decision-signal surface includes at most four valid classified
+events. Proxy credentials, raw per-attempt source diagnostics, and unclassified
+revisions are operator-only.

--- a/docs/china-data-coverage.mdx
+++ b/docs/china-data-coverage.mdx
@@ -1,0 +1,144 @@
+---
+title: "China Data Coverage"
+description: "Complete inventory of WorldMonitor's China data lanes, public surfaces, source status, cadence, freshness, and access boundaries."
+---
+
+This page is the entry point for WorldMonitor's China data. It describes the
+launched and explicitly blocked source contracts; it is not a claim that every
+upstream source is healthy at this moment. Current transport and content health
+remain visible through the China projection in `/api/health`.
+`/api/seed-health` reports whether the China coverage evaluator itself ran
+recently; a fresh evaluator heartbeat does not prove healthy China content.
+
+## Coverage inventory
+
+| Lane | Sources and method | Primary surface | Refresh contract |
+| --- | --- | --- | --- |
+| Global China projection | BIS, IMF, China energy spine, UN Comtrade reporter 156, CCFI, China market index, China news sources, eight reviewed aviation hubs, HKO, and Western Pacific hazards | China country summary and operator health | Source-specific; evaluated hourly |
+| Official macro | NBS and SAFE revision-aware observations; PBoC and GACC candidates remain explicit unavailable rows | REST snapshot and Pro MCP `get_economic_data` with dataset `china-macro` | 36 hours |
+| Official release calendar | NBS release calendar plus provisional PBoC LPR dates verified against ChinaMoney/CFETS notices | China macro bootstrap and Pro MCP `get_economic_data` with dataset `china-release-calendar` | 36 hours |
+| Policy and enforcement | CAC, SAMR, MIIT, MOFCOM, NDRC, and PBOC official documents | China country brief and `chinaPolicyEvents` bootstrap | 6 hours |
+| Cross-Strait activity | Taiwan Ministry of National Defense daily claims with separately attributed Japan Joint Staff context | Force Posture and China decision signals | 3 hours |
+| Corporate disclosures | SSE and SZSE public metadata for a reviewed issuer basket; HKEX is explicitly blocked | `chinaCorporateDisclosures` bootstrap and China decision signals | 30 minutes |
+| Logistics corridors | Four reviewed corridors composed from six named source families | REST/UI detail; MCP receives a bounded decision-signal summary | On request; healthy aggregate cached 5 minutes |
+| Activity nowcast | Deterministic comparison of official macro vintages with seven reviewed proxy families | REST/UI detail; MCP receives a bounded decision-signal summary | On request; healthy result cached 15 minutes |
+| Decision-signal composition | Bounded composition of macro, policy, Cross-Strait, disclosures, corridors, and nowcast | Country brief, public RPC, bootstrap, and Pro MCP | 15 minutes |
+| Bilateral HS4 continuity | Annual UN Comtrade import baskets for the reviewed country/strategic-product registry | PRO `GET /api/supply-chain/v1/get-country-products` and route-exposure workflows | `0 6 1 * *` |
+
+## Health projection registry
+
+The China health projection tracks these stable contracts. `launched` means the
+lane is admitted to the China projection; it does not override the lane's live
+freshness or content status.
+
+| Contract ID | Coverage | Launch state |
+| --- | --- | --- |
+| `economic.bis-policy` | BIS policy rate | `launched` |
+| `economic.imf-macro` | IMF macro snapshot | `launched` |
+| `energy.jodi-oil` | JODI oil | `blocked` — `CHINA_UPSTREAM_ROW_UNAVAILABLE` |
+| `energy.jodi-gas` | JODI gas | `blocked` — `CHINA_UPSTREAM_ROW_UNAVAILABLE` |
+| `energy.spine` | China energy spine | `launched` |
+| `trade.comtrade-reporter-156` | UN Comtrade reporter 156 | `launched` |
+| `supply-chain.ccfi` | China Containerized Freight Index | `launched` |
+| `market.china-index` | China country market index | `launched` |
+| `market.china-corporate-disclosures` | Official SSE/SZSE corporate disclosures | `launched` |
+| `news.china` | China news digest | `launched` |
+| `aviation.china-hubs` | Eight reviewed China aviation hubs | `launched` |
+| `macro.china-snapshot` | Normalized China macro snapshot | `launched` |
+| `macro.china-release-calendar` | China release calendar | `launched` |
+| `policy.official-events` | Official policy and enforcement events | `launched` |
+| `hazards.western-pacific-cyclones` | Western Pacific cyclone identity | `launched` |
+| `hazards.hko-warnings` | Hong Kong Observatory warnings | `launched` |
+| `military.cross-strait-activity` | Official Cross-Strait activity baseline | `launched` |
+
+JODI remains available to existing global energy products. Its China oil and
+gas contracts stay blocked because the reviewed upstream country index does not
+currently publish substantive `CN` rows. A healthy global JODI heartbeat
+therefore cannot be presented as China coverage.
+
+Detailed method and source contracts:
+
+- [Official macro and policy](/china-official-macro-policy)
+- [Corporate disclosures](/china-corporate-disclosures)
+- [Logistics corridors](/china-logistics-corridors)
+- [Cross-domain decision signals](/china-decision-signals)
+- [Activity nowcast methodology](/methodology/china-activity-nowcast)
+- [Shared provenance contract](/decision-signal-provenance)
+
+## Status and missingness
+
+Source arrival is not the same as usable content. China health evaluates
+transport freshness and content freshness separately. A successful request can
+still publish stale, partial, empty, or timestamp-unknown content.
+
+The public contracts use explicit states:
+
+- `available` or `healthy` means the required payload passed its domain
+  validation and freshness rules;
+- `partial` or `degraded` means some reviewed coverage is missing, stale, or
+  invalid while other evidence remains usable;
+- `stale` means the last valid observation is outside its content budget;
+- `unavailable` means no usable observation can be published; and
+- `blocked` means a source was deliberately not launched, normally because
+  robots, terms, transport, or source-substance review did not pass.
+
+Missing categories are never converted to zero, normal, unchanged, or current.
+Last-good preservation keeps its original observation time and reports the
+current transport failure.
+
+## Bilateral HS4 import baskets
+
+The bilateral store covers the 20 reviewed `bilateralHs4Code` entries in
+`scripts/shared/comtrade-strategic-products.json`. Each country shard contains
+annual imports by HS4 product and the leading exporter partners. It supports
+country exposure, route impact, multi-sector shock, and the PRO
+`get-country-products` route. Detailed bilateral rows are not part of the
+anonymous China summary.
+
+The authenticated Comtrade route sends one four-year period window, `Y-2`
+through `Y-5`, for each of the two HS4 batches. The normalizer keeps the newest
+year per product-and-partner pair, so a response cannot silently mix annual
+values. When `COMTRADE_API_KEYS` is absent, the public preview route cannot
+accept a period list and instead tries `Y-2` followed by `Y-3`.
+
+The scheduled production contract is deliberately quota-bound:
+
+| Control | Contract |
+| --- | --- |
+| Railway cron | `0 6 1 * *` — 06:00 UTC on the first day of each month |
+| Provider quota | 500 keyed calls per month |
+| Seeder request budget | 480 |
+| Freshness gate | 24 days, bypassed only by an explicit `FORCE_RESEED=true` |
+| Country payload TTL | 40 days |
+| Health staleness threshold | 35 days |
+| Coverage floor | 110 country shards |
+
+A run below the 110-shard floor writes `partial` seed metadata rather than
+claiming full success. Failed reporters preserve an existing shard for at most
+two consecutive runs; after that, the shard may expire so the on-demand public
+fallback can probe it again. Rate limits, quota exhaustion, and request-budget
+exhaustion publish partial coverage and stop the run instead of overwriting
+last-good country data with empty payloads.
+
+## Access boundaries
+
+- Country summary, corridor conditions, decision-signal summaries, provenance,
+  and aggregate health are available through bounded public surfaces.
+- Detailed corridor control towers and activity-nowcast evidence are REST/UI
+  surfaces. MCP does not expose dedicated tools for either route; Pro MCP
+  receives their bounded summaries through `get_china_decision_signals`.
+- Pro MCP reads the canonical macro and release-calendar caches through
+  `get_economic_data` with dataset `china-macro` or
+  `china-release-calendar`.
+- Detailed bilateral HS4 product rows and route exposure are PRO-only.
+- The Pro MCP decision-signal tool receives the same bounded items and
+  provenance as the public composition, not raw exchange documents or
+  unrestricted source expansion.
+- Proxy credentials, raw per-attempt request diagnostics, cache names, and
+  detailed freshness thresholds remain operator-only. Public documentation
+  names the configuration keys and selection semantics, not their values.
+
+No China surface should be interpreted as independent verification merely
+because its publisher is official. Publisher identity, extraction confidence,
+classification confidence, corroboration, and freshness remain separate
+claims.

--- a/docs/china-logistics-corridors.mdx
+++ b/docs/china-logistics-corridors.mdx
@@ -1,0 +1,109 @@
+---
+title: "China Logistics Corridors"
+description: "Four reviewed China logistics corridors, six source families, composition rules, provenance, freshness, and API behavior."
+---
+
+The China logistics control towers are transparent source compositions over
+reviewed geographic corridors. They report evidence availability and
+freshness by family. They do not generate an opaque logistics-risk score,
+forecast disruption, or infer activity from source presence alone.
+
+## Reviewed corridors
+
+| Corridor ID | Name | Reviewed scope |
+| --- | --- | --- |
+| `china-yangtze-river-delta` | Yangtze River Delta | Shanghai, Jiangsu, and Zhejiang ports, aviation, and advanced-manufacturing nodes |
+| `china-greater-bay-area` | Greater Bay Area | Guangdong, Hong Kong, and Macao-facing ports, airports, hazards, and industrial gateways |
+| `china-bohai-rim` | Bohai Rim | Beijing-Tianjin, Hebei, Shandong, and Liaoning maritime-industrial gateways |
+| `china-western-land-sea-corridor` | Western Land-Sea Corridor | Inland manufacturing hubs, Xinjiang land crossings, and Guangxi maritime gateways |
+
+Each corridor has a reviewed polygon, node registry, node owner, and source
+selector. A source record contributes only when its selector or reviewed
+geography maps it to that corridor. National inputs are clearly marked as
+national and can apply to all four corridors.
+
+## Six signal families
+
+| Family ID | Source contract | Scope and observation |
+| --- | --- | --- |
+| `port` | IMF PortWatch | Reviewed China/Hong Kong port IDs; calls, DWT measures, trend deltas, and anomaly flag when published |
+| `aviation` | AviationStack | Reviewed PEK, PVG, CAN, SZX, CTU, KMG, URC, and HKG provider coverage |
+| `hazard` | Western Pacific cyclone sources and Hong Kong Observatory | Events inside a corridor boundary plus explicit HKO warning coverage for the Greater Bay Area |
+| `power_energy` | WorldMonitor energy spine | National China energy dependency coverage and latest source observation time |
+| `strategic_industry` | UN Comtrade | Annual strategic-product observations for reporter 156 |
+| `trade` | UN Comtrade and Shanghai Shipping Exchange CCFI | Annual reporter-156 trade observations and the current China Containerized Freight Index |
+
+IMF PortWatch and AviationStack are node-scoped. Hazard observations are
+regional. WorldMonitor energy spine, UN Comtrade, and Shanghai Shipping
+Exchange inputs are national. The output keeps those scopes visible rather
+than presenting national evidence as a measured node value.
+
+## Availability composition
+
+Every source signal carries:
+
+- publisher identity and class;
+- source URL when applicable;
+- node, regional, or national scope;
+- observation, release, and retrieval time with precision;
+- revision metadata when available;
+- transport and content freshness;
+- an inspectable summary and source metrics.
+
+Each family condition is `available`, `partial`, `stale`, or `unavailable`.
+A corridor is:
+
+- `available` only when all six conditions are available;
+- `stale` when every condition is available or stale and at least one is
+  stale;
+- `unavailable` when all six are unavailable; or
+- `partial` for every mixed or provenance-invalid state.
+
+An absent configured port or airport becomes an explicit unavailable signal.
+A healthy feed with zero hazards can establish feed coverage, but it does not
+create a hazard event. A present energy-spine payload does not establish an
+activity direction. A current CCFI level without a prior comparison does not
+become a freight change.
+
+## Freshness budgets
+
+The composer evaluates source timestamps at request time:
+
+| Input | Transport budget | Content handling |
+| --- | --- | --- |
+| PortWatch | 36 hours | Individual observations stale after 72 hours |
+| AviationStack | 90 minutes | Individual observations stale after 180 minutes |
+| Western Pacific hazards / HKO | 9 hours | Observations stale after 9 hours |
+| Energy spine | 48 hours | Year/month/day precision gets a corresponding periodic budget |
+| UN Comtrade | 48 hours | Annual observations use a 550-day budget |
+| CCFI | 7 hours | Index content stale after 28 days |
+
+Transport freshness proves that collection ran. Content freshness proves that
+the observation itself is timely. Neither substitutes for the other.
+
+## API and caching
+
+`GET /api/supply-chain/v1/get-china-corridor-control-towers` reads the
+canonical Redis source seeds in one batch and isolates missing dependencies.
+It validates every composed provenance envelope before returning the wire
+payload.
+
+Healthy aggregates use a five-minute server cache. An all-unavailable result
+is not positively cached, so a recovery can appear immediately. The client
+circuit breaker deliberately retains no last-good aggregate that could hide a
+current fail-closed response. The panel refresh interval is 15 minutes.
+
+The response exposes `upstreamUnavailable: true` only when every corridor is
+unavailable. Partial corridor evidence remains inspectable rather than being
+collapsed into total outage or false health.
+
+This detailed control-tower response is a REST/UI surface. MCP has no dedicated
+corridor-control-tower tool; Pro MCP receives only its bounded contribution to
+`get_china_decision_signals`.
+
+## Relationship to the nowcast
+
+The [China Activity Nowcast](/methodology/china-activity-nowcast) can use a
+corridor-family breadth change only when a comparable prior corridor snapshot
+exists. The control-tower response itself remains a source composition and does
+not publish a directional economic conclusion.

--- a/docs/china-official-macro-policy.mdx
+++ b/docs/china-official-macro-policy.mdx
@@ -1,0 +1,121 @@
+---
+title: "China Official Macro and Policy"
+description: "Official China macro observations, release-calendar verification, policy-event taxonomy, source admission, revisions, and missingness."
+---
+
+WorldMonitor maintains two independent official-document lanes: revision-aware
+numeric macro observations and typed policy/enforcement events. They share the
+[decision-signal provenance contract](/decision-signal-provenance), but they
+do not share fetchers, scoring, or freshness rules.
+
+## Official macro observations
+
+The launched macro snapshot requires five series:
+
+| Series ID | Publisher | Pillar | Unit | Maximum observation age |
+| --- | --- | --- | --- | --- |
+| `nbs_industrial_value_added_yoy` | National Bureau of Statistics of China | Activity | Percent | 75 days |
+| `nbs_fixed_asset_investment_yoy` | National Bureau of Statistics of China | Investment/property | Percent | 75 days |
+| `nbs_real_estate_investment_yoy` | National Bureau of Statistics of China | Investment/property | Percent | 75 days |
+| `safe_fx_reserves` | State Administration of Foreign Exchange | External pressure | USD 100 million | 45 days |
+| `safe_bank_fx_settlement` | State Administration of Foreign Exchange | External pressure | CNY 100 million | 45 days |
+
+NBS is collected from `www.stats.gov.cn/english/PressRelease/`; SAFE is
+collected from `www.safe.gov.cn/safe/`. Both sources have bounded request
+budgets, manual redirect handling, response-size limits, robots preflight,
+source-host allowlists, and reviewed attribution requirements. The macro
+seeder does not use a proxy to bypass a rejected source decision.
+
+The following reviewed candidates remain explicit unavailable observations
+instead of being silently omitted:
+
+- `pboc_aggregate_financing_flow`
+- `pboc_new_rmb_loans`
+- `pboc_m2_yoy`
+- `pboc_policy_liquidity_operation`
+- `gacc_exports`
+- `gacc_imports`
+- `gacc_trade_balance`
+
+PBoC candidates remain blocked when `www.pbc.gov.cn` robots policy disallows
+the reviewed paths or terms review is incomplete. GACC candidates remain
+blocked when `english.customs.gov.cn` cannot pass the TLS/source preflight.
+Their pillars therefore remain `unavailable`; another publisher is not
+substituted.
+
+## Revisions and direction
+
+Each official observation retains its observation period, publication time,
+retrieval time, source URL, vintage ID, revision sequence, and supersession
+state. A correction creates or updates a traceable vintage; it does not rewrite
+the historical point-in-time record.
+
+Direction is calculated only when the published series contract supplies a
+valid comparison. Missing comparison values remain unavailable. The snapshot
+is launch-ready only when all five required observations are valid and within
+their individual age budgets. Transport freshness and snapshot completeness
+are written as separate seed metadata.
+
+`GET /api/economic/v1/get-china-macro-snapshot` reads the canonical
+`economic:china:macro:v2` seed and never fans out to upstream publishers on a
+cache miss. The macro Railway member runs every 36 hours.
+
+## Release calendar
+
+The release calendar reads the current NBS calendar from `www.stats.gov.cn`.
+Loan Prime Rate dates are generated from the reviewed Chinese business-day
+calendar and marked `provisional`, then promoted to `verified` only when the
+corresponding ChinaMoney/CFETS notice is found on `www.chinamoney.com.cn`.
+
+Failure of the required NBS calendar fails the calendar build. Failure of
+ChinaMoney verification leaves LPR dates provisional and records the source
+decision; it does not relabel them as verified.
+
+## Policy and enforcement events
+
+The policy lane polls six official agencies:
+
+| Agency | Publisher | Listing host |
+| --- | --- | --- |
+| `CAC` | Cyberspace Administration of China | `www.cac.gov.cn` |
+| `SAMR` | State Administration for Market Regulation | `www.samr.gov.cn` |
+| `MIIT` | Ministry of Industry and Information Technology | `www.miit.gov.cn` |
+| `MOFCOM` | Ministry of Commerce | `www.mofcom.gov.cn` |
+| `NDRC` | National Development and Reform Commission | `zfxxgk.ndrc.gov.cn` |
+| `PBOC` | People's Bank of China | `www.pbc.gov.cn` |
+
+Each agency is limited to one listing request and at most three reviewed
+document fetches per run, with a 400 ms same-host cadence. Listing responses
+are capped at 750 KB and documents at 2 MB. URLs must match the reviewed host
+and path contract.
+
+The deterministic taxonomy emits:
+
+- `consultation_draft`
+- `announcement_guidance`
+- `final_rule`
+- `administrative_approval_restriction`
+- `investigation`
+- `enforcement_penalty`
+- `effective_date_change`
+- `amendment_correction_repeal_supersession`
+- `unknown`
+
+The published event keeps the original Chinese title and text, translation
+state, document number, publication and effective dates, reviewed sector/entity
+links, content hash, classification evidence, lineage, revisions, and full
+provenance. Unknown classification is retained as unknown; it is not promoted
+to enforcement.
+
+The Railway macro bundle refreshes this lane every 6 hours. It retains at most
+120 events across complete lineages for 180 days. A failed agency preserves
+still-valid last-good events with transport freshness changed to `error`;
+healthy agencies continue independently.
+
+## Alert boundary
+
+Consultation drafts, guidance, and unknown policy classifications do not alert.
+Reviewed policy/enforcement alerts require a new stable lineage. Corrections
+and repeat ingestion retain the same lineage for deduplication. The bounded
+China decision-signal composition publishes at most four valid items from this
+lane.

--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -186,12 +186,30 @@ The Security Advisories panel displays advisories with colored level badges and 
 
 ### China Coverage, Attribution, and Freshness
 
-The China country deep-dive composes existing global product contracts rather
-than operating a China-only fetch path. Its attributable signals come from
-BIS, IMF, JODI, UN Comtrade, CCFI, AviationStack, NBS/PBoC, JMA, and HKO.
-Every displayed signal carries its source and observation or release date; a
-missing, stale, or partial source is shown as unavailable or degraded rather
-than as a zero value.
+The China country deep-dive composes source-specific contracts rather than
+operating one opaque China fetch path. The complete contract inventory,
+cadences, surfaces, and access boundaries are maintained on
+[China Data Coverage](/china-data-coverage).
+
+Its China-specific official lanes currently include:
+
+- revision-aware macro observations from NBS and SAFE, with reviewed PBoC and
+  GACC candidates kept explicitly unavailable when their source preflight does
+  not pass;
+- official policy and enforcement documents from CAC, SAMR, MIIT, MOFCOM,
+  NDRC, and PBoC;
+- metadata-only corporate disclosures from SSE and SZSE, with HKEX explicitly
+  blocked by its automated-access terms;
+- Taiwan Ministry of National Defense claims with separately attributed Japan
+  Joint Staff context; and
+- HKO warnings and Western Pacific hazard observations.
+
+The composition also uses attributable global contracts for BIS, IMF, UN
+Comtrade reporter 156 and bilateral HS4 data, CCFI, IMF PortWatch,
+AviationStack, the China energy spine, the China market index, and reviewed
+China news sources. Every displayed signal carries its publisher and
+observation or release date. A missing, stale, blocked, or partial source is
+shown as unavailable or degraded rather than as zero.
 
 JODI remains enabled for its existing global energy product, but the China
 contract stays explicitly blocked until a reviewed update verifies that JODI
@@ -212,6 +230,14 @@ presentation-only airport rows—so an upstream omission remains observable.
 The audit records aggregate status and reason codes only: it never logs
 credentials or raw upstream payloads. Detailed bilateral trade data remains
 Pro-only and is not included in the public China summary.
+
+Source-specific collection and missingness details:
+
+- [Official macro and policy](/china-official-macro-policy)
+- [Corporate disclosures](/china-corporate-disclosures)
+- [Logistics corridors](/china-logistics-corridors)
+- [China decision signals](/china-decision-signals)
+- [Activity nowcast methodology](/methodology/china-activity-nowcast)
 
 #### Cross-Strait Official Activity Claims
 
@@ -558,8 +584,18 @@ WorldMonitor is grateful to the following organizations for making their data pu
 | USA Spending | US federal spending and contracts | [api.usaspending.gov](https://api.usaspending.gov) |
 | Global procurement opportunities | US SAM.gov, EU TED, UK Contracts Finder, CanadaBuys, New Zealand GETS, and World Bank procurement notices | [Coverage and freshness](/global-procurement-intelligence) |
 | UN Comtrade | Global merchandise trade flows | [comtradeapi.un.org](https://comtradeapi.un.org) |
-| National Bureau of Statistics of China | China release-calendar context | [stats.gov.cn](https://www.stats.gov.cn/english/) |
-| People's Bank of China | Loan-prime-rate calendar context | [pbc.gov.cn](http://www.pbc.gov.cn/en/3688110/index.html) |
+| National Bureau of Statistics of China | Official activity/investment observations and release calendar | [stats.gov.cn](https://www.stats.gov.cn/english/) |
+| State Administration of Foreign Exchange | Official reserves and bank FX settlement observations | [safe.gov.cn](https://www.safe.gov.cn/safe/sjjd/index.html) |
+| ChinaMoney / CFETS | Realized Loan Prime Rate publication-date verification | [chinamoney.com.cn](https://www.chinamoney.com.cn/) |
+| Cyberspace Administration of China | Official policy documents | [cac.gov.cn](https://www.cac.gov.cn/wxzw/zcfg/) |
+| State Administration for Market Regulation | Official regulation and enforcement documents | [samr.gov.cn](https://www.samr.gov.cn/zw/zfxxgk/) |
+| Ministry of Industry and Information Technology | Official industrial and technology policy documents | [miit.gov.cn](https://www.miit.gov.cn/zwgk/zcwj/) |
+| Ministry of Commerce | Official trade policy and enforcement documents | [mofcom.gov.cn](https://www.mofcom.gov.cn/zcfb/) |
+| National Development and Reform Commission | Official economic policy documents | [ndrc.gov.cn](https://zfxxgk.ndrc.gov.cn/web/zclist.jsp?dirid=41&pid=39) |
+| People's Bank of China | Official policy documents and LPR calendar rule | [pbc.gov.cn](https://www.pbc.gov.cn/) |
+| Shanghai Stock Exchange | Reviewed issuer public disclosure metadata | [sse.com.cn](https://www.sse.com.cn/) |
+| Shenzhen Stock Exchange | Reviewed issuer public disclosure metadata | [szse.cn](https://www.szse.cn/) |
+| Shanghai Shipping Exchange | China Containerized Freight Index | [sse.net.cn](https://en.sse.net.cn/indices/ccfinew.jsp) |
 | CoinGecko | Cryptocurrency prices and market data | [coingecko.com](https://www.coingecko.com) |
 
 ### Geopolitics & Conflict
@@ -570,6 +606,8 @@ WorldMonitor is grateful to the following organizations for making their data pu
 | UCDP | Uppsala Conflict Data Program — conflict events | [ucdp.uu.se](https://ucdp.uu.se) |
 | GDELT | Global event, language, and tone database | [gdeltproject.org](https://www.gdeltproject.org) |
 | IMF PortWatch | Chokepoint transit intelligence | [portwatch.imf.org](https://portwatch.imf.org) |
+| Taiwan Ministry of National Defense | Official daily Cross-Strait activity claims | [mnd.gov.tw](https://www.mnd.gov.tw/english/) |
+| Japan Joint Staff | Separately attributed regional activity context | [mod.go.jp/js](https://www.mod.go.jp/js/) |
 
 ### Environment & Disasters
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,10 @@
                 "pages": [
                   "signal-intelligence",
                   "ai-intelligence",
+                  "china-data-coverage",
+                  "china-official-macro-policy",
+                  "china-corporate-disclosures",
+                  "china-logistics-corridors",
                   "methodology/china-activity-nowcast",
                   "methodology/news-digest-and-briefing",
                   "country-instability-index",
@@ -554,6 +558,10 @@
                 "pages": [
                   "zh/signal-intelligence",
                   "zh/ai-intelligence",
+                  "zh/china-data-coverage",
+                  "zh/china-official-macro-policy",
+                  "zh/china-corporate-disclosures",
+                  "zh/china-logistics-corridors",
                   "zh/methodology/china-activity-nowcast",
                   "zh/methodology/news-digest-and-briefing",
                   "zh/country-instability-index",
@@ -693,6 +701,7 @@
                   "zh/health-endpoints",
                   "zh/relay-parameters",
                   "zh/decision-signal-provenance",
+                  "zh/china-decision-signals",
                   "zh/data-sources"
                 ]
               },

--- a/docs/finance-data.mdx
+++ b/docs/finance-data.mdx
@@ -50,6 +50,8 @@ These tables are the human-facing route map for finance, market, macro, energy, 
 | World Bank indicators | `GET /api/economic/v1/list-world-bank-indicators` | World Bank country indicators and tech-readiness data. |
 | Energy prices | `GET /api/economic/v1/get-energy-prices` | Oil & Energy analytics for WTI, Brent, production, and inventory metrics. |
 | Macro signals | `GET /api/economic/v1/get-macro-signals` | Market Radar / Macro Signals panel; bootstrap-first via `macroSignals`. |
+| China macro snapshot | `GET /api/economic/v1/get-china-macro-snapshot` | Revision-aware NBS/SAFE official observations and release-calendar context; see [China Official Macro and Policy](/china-official-macro-policy). |
+| China activity nowcast | `GET /api/economic/v1/get-china-activity-nowcast` | Deterministic official-vintage versus reviewed-proxy comparison; see [methodology](/methodology/china-activity-nowcast). |
 | Energy capacity | `GET /api/economic/v1/get-energy-capacity` | Installed solar, wind, and coal capacity timeseries. |
 | BIS policy rates | `GET /api/economic/v1/get-bis-policy-rates` | Economic panel BIS policy-rate table; bootstrap-first via `bisPolicy`. |
 | BIS exchange rates | `GET /api/economic/v1/get-bis-exchange-rates` | BIS real effective exchange-rate table; bootstrap-first via `bisExchange`. |

--- a/docs/methodology/china-activity-nowcast.mdx
+++ b/docs/methodology/china-activity-nowcast.mdx
@@ -120,6 +120,10 @@ missing input. The wrapper's `upstream_unavailable` flag is true only when no
 official vintage or proxy contribution is available; otherwise healthy but
 non-directional inputs remain methodological insufficiency, not an outage.
 
+Detailed nowcast evidence is a REST/UI surface. MCP has no dedicated
+activity-nowcast tool; Pro MCP receives only its bounded contribution through
+`get_china_decision_signals`.
+
 The endpoint composes:
 
 - the official China macro snapshot;

--- a/docs/panels/supply-chain.mdx
+++ b/docs/panels/supply-chain.mdx
@@ -37,6 +37,7 @@ The panel and adjacent supply-chain workflows mix generated sebuf REST RPCs, boo
 | Bypass corridors | `GET /api/supply-chain/v1/get-bypass-options` | PRO ranked maritime and land bypass options for a chokepoint / cargo type. |
 | Country cost shock | `GET /api/supply-chain/v1/get-country-cost-shock` | PRO cost-shock and war-risk estimates for a country + chokepoint + HS2 slice. |
 | Country import basket | `GET /api/supply-chain/v1/get-country-products` | PRO seeded bilateral-HS4 import basket for country drill-downs. |
+| China logistics corridors | `GET /api/supply-chain/v1/get-china-corridor-control-towers` | Four reviewed China corridors composed from six provenance-bearing source families; see [China Logistics Corridors](/china-logistics-corridors). |
 | Multi-sector shock | `GET /api/supply-chain/v1/get-multi-sector-cost-shock` | PRO sector-level cost-shock estimates over a closure window. |
 | Sector dependency | `GET /api/supply-chain/v1/get-sector-dependency` | PRO dependency flags, primary exporter share, and primary chokepoint exposure. |
 | Route Explorer lane | `GET /api/supply-chain/v1/get-route-explorer-lane` | PRO primary route geometry, chokepoint exposures, bypass geometry, war-risk tier, and disruption score. |

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -428,9 +428,9 @@ continuous metric.
 | **Watch paths** | See `scripts/railway-services.json` (exact runtime closure; run `node scripts/audit-railway-watch-paths.mjs`) |
 | **Replaces** | 2 services |
 | **Net savings** | 1 slot |
-| **Members** | Correlation (5min), Cross-Source Signals (15min), Cross-Strait Activity (3h), Regional Snapshots (6h) |
+| **Members** | Correlation (5min), Cross-Source Signals (15min), Cross-Strait Activity (3h), China Decision Signals (15min), Regional Snapshots (6h) |
 | **Required env** | `JAPAN_MOD_PROXY_URL` or `PROXY_URL` (Cross-Strait Activity's Japan MOD exit; the section declares an any-of group, so either satisfies it and only an environment with neither fails as `CONFIG_ERROR`) |
-| **Note** | Cross-Strait Activity is the only external-source member; it uses bounded MND/Japan MOD requests and a 3h freshness gate. Other members are Redis-derived. The bundle enforces a 570s wall-time admission budget so a non-fitting due section defers before Railway's 10-minute container limit. |
+| **Note** | Cross-Strait Activity is the only direct external-source member; it uses bounded MND/Japan MOD requests and a 3h freshness gate. China Decision Signals validates and republishes the bounded public composition after reading its domain lanes. Other members are Redis-derived. The bundle enforces a 570s wall-time admission budget so a non-fitting due section defers before Railway's 10-minute container limit. |
 
 ### Bundle 6: seed-bundle-climate
 
@@ -467,7 +467,7 @@ continuous metric.
 | **Watch paths** | `scripts/**`, `shared/**` |
 | **Replaces** | 6 services |
 | **Net savings** | 5 slots |
-| **Members** | BIS Data (12h), BLS Series (daily), Eurostat (daily), IMF Macro (monthly), National Debt (monthly), FAO FFPI (daily, catches monthly release window) |
+| **Members** | BIS Data (12h), China Macro (36h), China Release Calendar (36h), China Policy Events (6h), BIS Extended (12h), BLS Series (daily), Eurostat (daily), Eurostat House Prices (7d), Eurostat Government Debt (2d), Eurostat Industrial Production (daily), IMF Macro (30d), National Debt (30d), FAO FFPI (daily), World Bank External Debt (30d), BIS LBS (7d), FATF Listing (30d) |
 
 ### Bundle 9: seed-bundle-health
 
@@ -492,8 +492,8 @@ continuous metric.
 | **Replaces** | 5 services |
 | **Net savings** | 4 slots |
 | **Members** | Crypto Quotes (5min), Hyperliquid Flow (5min), Stablecoin Markets (10min), ETF Flows (15min), China Corporate Disclosures (30min), Gulf Quotes (10min), Token Panels (30min), Gold ETF Flows (2h), Gold CB Reserves (daily), SEC CIK Map (daily), SEC 8-K Stream (30min) |
-| **Required env** | `PROXY_URL` (Gulf Quotes / ETF Flows require it and SZSE uses it when `SZSE_PROXY_URL` is unset) and `RELAY_SHARED_SECRET` (authenticates China Corporate Disclosures' fixed `https://api.worldmonitor.app/api/internal/china-exchange-egress` fallback after direct/proxy failures). This is the deployment contract; production provisioning and live fallback acceptance require separate verification. |
-| **Note** | These are BACKUP for ais-relay inline loops. ais-relay is the primary seeder. The bundle provides redundancy if relay goes down. Gulf Quotes uses Alpha Vantage (richer than relay's Yahoo-only). SEC CIK Map + SEC 8-K Stream (#5695) are primary (not backups): the ticker→CIK registry and the material-events stream for the corporate-intelligence endpoints. |
+| **Required env** | `PROXY_URL` (required independently by Gulf Quotes / ETF Flows and selected for an exchange only when its source-specific setting is absent) and `RELAY_SHARED_SECRET` (authenticates China Corporate Disclosures' fixed `https://api.worldmonitor.app/api/internal/china-exchange-egress` fallback after direct/proxy SZSE failures). Proxy configuration precedence is `SSE_PROXY_URL` → `SZSE_PROXY_URL` → `PROXY_URL` for SSE and `SZSE_PROXY_URL` → `PROXY_URL` for SZSE; the process selects the first non-empty setting rather than attempting each URL sequentially. This is the deployment contract; production provisioning and live fallback acceptance require separate verification. |
+| **Note** | Crypto Quotes, Stablecoin Markets, ETF Flows, Gulf Quotes, and Token Panels back up ais-relay inline loops. Hyperliquid Flow, China Corporate Disclosures, Gold ETF Flows, Gold CB Reserves, SEC CIK Map, and SEC 8-K Stream are primary in this bundle. China Corporate Disclosures reads official metadata only: SSE uses direct then the selected proxy, while SZSE uses direct, distinct port attempts within the selected proxy, then the authenticated fixed edge hop. Gulf Quotes uses Alpha Vantage (richer than relay's Yahoo-only). |
 
 ### Bundle 11: seed-bundle-relay-backup
 
@@ -665,6 +665,15 @@ fetch('https://backboard.railway.com/graphql/v2',{method:'POST',
 | seed-comtrade-bilateral-hs4 | `node scripts/seed-comtrade-bilateral-hs4.mjs` | **`0 6 1 * *` (monthly, verified 2026-07-27)** | UN Comtrade bilateral HS4 trade flows — only scheduled consumer of the keyed 500/mo Comtrade quota |
 | seed-hs2-chokepoint-exposure | `node scripts/seed-hs2-chokepoint-exposure.mjs` | periodic (TTL-extended) | HS2 chokepoint trade-exposure (derived) |
 | seed-service-statuses | `node scripts/seed-service-statuses.mjs` | frequent (relay-fallback) | Service-status warm-ping; primary seeder is the AIS relay loop |
+
+The bilateral HS4 cron uses `COMTRADE_API_KEYS` and a 480-request hard budget
+under the provider's 500-call monthly quota. The authenticated route requests
+one four-year window (`Y-2` through `Y-5`) in each of two HS4 batches and keeps
+the newest row per product/partner. The public-preview fallback cannot accept
+that period list and tries `Y-2`, then `Y-3`. A 24-day freshness gate prevents
+accidental repeat runs; health reports `COVERAGE_PARTIAL` below 110 country
+shards and stale after 35 days. Country payloads live for 40 days so a missed
+monthly tick becomes visible before last-good data expires.
 
 **Not standalone services (documented here to avoid confusion):**
 

--- a/docs/zh/china-corporate-disclosures.mdx
+++ b/docs/zh/china-corporate-disclosures.mdx
@@ -1,0 +1,110 @@
+---
+title: "中国企业披露"
+description: "SSE、SZSE、HKEX 来源准入、审核发行人、仅元数据采集、传输回退、修订与健康语义。"
+---
+
+中国企业披露管线使用官方交易所元数据监测一个小型审核发行人篮子。它不是通用
+交易所爬虫、全市场公告归档或文件再分发服务。
+
+## 来源准入
+
+| 交易所 | 上线状态 | 准入决定 | 采集契约 |
+| --- | --- | --- | --- |
+| `SSE` | `launched` | `admitted_metadata_only` | 公共公告元数据、有界第一页；保留文件链接但不抓取正文 |
+| `SZSE` | `launched` | `admitted_metadata_only` | 公共公告元数据、有界第一页；保留文件链接但不抓取正文 |
+| `HKEX` | `blocked` | `rejected` | 不自动采集；`TERMS_PROHIBIT_AUTOMATED_ACCESS` |
+
+审核条款记录为：
+
+- SSE：[官方法律条款](https://www.sse.com.cn/home/legal/)
+- SZSE：[适用规则与公告](https://www.szse.cn/application/laws/)
+- HKEX：[使用条款](https://www2.hkexnews.hk/Global/Exchange/Terms-of-Use?sc_lang=en)
+
+SSE 与 SZSE 采用仅元数据模式，因为文件正文的商业再利用可能需要书面许可。
+`documentRetrieval` 为 `lazy-link-only`：消费者获得官方链接，但 WorldMonitor
+不摄取或再分发链接正文。HKEX 条款禁止未经许可的程序化系统检索，因此即使网站
+可访问，该来源仍保持阻止。
+
+## 审核发行人篮子
+
+| 交易所 | 代码 | Symbol | 发行人 |
+| --- | --- | --- | --- |
+| SSE | `600519` | `600519.SS` | 贵州茅台 |
+| SSE | `601318` | `601318.SS` | 中国平安 |
+| SSE | `600900` | `600900.SS` | 长江电力 |
+| SSE | `688981` | `688981.SS` | 中芯国际 |
+| SZSE | `300750` | `300750.SZ` | 宁德时代 |
+| HKEX，已阻止 | `0700` | `0700.HK` | 腾讯控股 |
+| HKEX，已阻止 | `1211` | `1211.HK` | 比亚迪股份 |
+| HKEX，已阻止 | `0939` | `0939.HK` | 建设银行 |
+| HKEX，已阻止 | `0857` | `0857.HK` | 中国石油股份 |
+
+HKEX 发行人保留在审核注册表中，以便来源决定可见；它们不会触发 HKEX 网络请求。
+
+## 事件分类与修订
+
+只有审核标题模式会成为类型化事件：
+
+- 停牌与复牌；
+- 股份质押；
+- 立案调查；
+- 交易所风险提示；
+- 业绩预警；
+- 重大资产重组。
+
+每个事件保留官方交易所身份、发行人映射、原标题、发布时间、元数据 URL、文件链接、
+提取/分类置信度、内容 hash、传输/内容新鲜度和稳定 lineage。更正、修订、撤回和
+取消连接到同一 lineage，而不会成为无关新事件。未分类修订保留在有界诊断集合中，
+不会提升为决策信号。
+
+## 有界采集
+
+SSE 在一个审核 90 天页面最多请求 100 行；SZSE 在一个审核页面最多请求 50 行。
+适配器不会静默追踪更多页面。页面饱和报告 `PAGE_LIMIT_REACHED`；连续三次空结果
+报告 `COVERAGE_GAP`。
+
+组合快照最多保留 100 个分类事件、每个事件 20 个修订，以及 100 个未分类修订。
+Railway market-backup 成员每 30 分钟运行并发布
+`market:china:corporate-disclosures:v1`。
+
+## 传输回退
+
+SSE 与 SZSE 首先尝试 Railway 直接出口。进程启动时，每个来源按以下优先级
+选择第一个非空代理设置：
+
+```text
+SSE:  SSE_PROXY_URL → SZSE_PROXY_URL → PROXY_URL
+SZSE: SZSE_PROXY_URL → PROXY_URL
+```
+
+这是配置优先级，不是按 URL 顺序回退。选定代理 URL 后，失败的尝试不会继续
+切换到下一个环境变量。SZSE 的不同代理尝试只会在已选代理配置内轮换符合条件的
+Decodo sticky gateway 端口。
+
+SSE 最多使用四个直接请求和四个代理请求，并限制并发。SZSE 使用一次直接尝试、
+最多两次符合条件的不同 gateway 端口代理尝试，然后使用固定
+`https://api.worldmonitor.app/api/internal/china-exchange-egress` edge hop。
+Edge hop 通过 `RELAY_SHARED_SECRET` 鉴权；该 secret 不会发送给交易所。
+
+回退顺序只用于传输失败。能证明应用层响应的 HTTP 或 schema 结果会被记录，不会
+触发无界路线猜测。SZSE 需要连续两次成功运行才能清除持久传输失败状态。
+
+`SSE_PROXY_URL` 是可选 SSE 专用覆盖；`SZSE_PROXY_URL` 是可选共享中国出口；
+只有对应来源专用设置缺失时才会选择 `PROXY_URL`，且其他市场 bundle 成员仍要求该变量。
+`RELAY_SHARED_SECRET` 是固定 edge 回退的必需配置。
+
+## 覆盖与健康
+
+快照状态可以是：
+
+- `healthy`：每个已上线交易所都有可用审核覆盖；
+- `degraded`：SSE 或 SZSE 缺失、过期、页面饱和、重复为空或发生传输错误，
+  而另一已上线交易所仍可用；
+- unavailable：没有已上线交易所能提供可用结果。
+
+新鲜 seed heartbeat 不会覆盖内部来源的降级状态。刷新失败会保留有效最后良好事件，
+同时保留原始发布时间并记录当前传输失败。被阻止的 HKEX 决定单独报告，不会伪装成
+运行时中断。
+
+公共中国决策信号界面最多包含四个有效分类事件。代理凭据、逐次来源原始诊断与
+未分类修订仅限 operator。

--- a/docs/zh/china-data-coverage.mdx
+++ b/docs/zh/china-data-coverage.mdx
@@ -1,0 +1,121 @@
+---
+title: "中国数据覆盖"
+description: "WorldMonitor 中国数据管线、公共界面、来源状态、更新频率、新鲜度与访问边界的完整清单。"
+---
+
+本页是 WorldMonitor 中国数据的总入口。它说明已上线和明确阻止的来源契约，
+并不表示每个上游来源此刻都健康。当前传输与内容健康通过 `/api/health`
+中的中国覆盖投影呈现。`/api/seed-health` 只报告中国覆盖 evaluator
+本身是否近期运行；新鲜 evaluator heartbeat 不证明中国内容健康。
+
+## 覆盖清单
+
+| 管线 | 来源与方法 | 主要界面 | 更新契约 |
+| --- | --- | --- | --- |
+| 全球中国投影 | BIS、IMF、中国能源脊柱、UN Comtrade reporter 156、CCFI、中国市场指数、中国新闻源、八个审核航空枢纽、HKO 与西太平洋灾害 | 中国国家摘要与 operator 健康 | 按来源更新；每小时评估 |
+| 官方宏观 | NBS 与 SAFE 的修订感知观测；PBoC 和 GACC 候选项保持显式不可用 | REST 快照与 Pro MCP `get_economic_data` 的 `china-macro` dataset | 36 小时 |
+| 官方发布日历 | NBS 发布日历，以及由 ChinaMoney/CFETS 公告核验的暂定 PBoC LPR 日期 | 中国宏观 bootstrap 与 Pro MCP `get_economic_data` 的 `china-release-calendar` dataset | 36 小时 |
+| 政策与执法 | CAC、SAMR、MIIT、MOFCOM、NDRC、PBOC 官方文件 | 中国国家简报与 `chinaPolicyEvents` bootstrap | 6 小时 |
+| 台海活动 | 台湾国防部每日声明；日本统合幕僚监部背景单独归因 | Force Posture 与中国决策信号 | 3 小时 |
+| 企业披露 | 经审核发行人篮子的 SSE、SZSE 公共元数据；HKEX 明确被阻止 | `chinaCorporateDisclosures` bootstrap 与中国决策信号 | 30 分钟 |
+| 物流走廊 | 由六个具名来源族组成的四条审核走廊 | REST/UI 详情；MCP 接收受限决策信号摘要 | 按请求；健康聚合缓存 5 分钟 |
+| 活动 nowcast | 官方宏观版本与七个审核代理指标族的确定性比较 | REST/UI 详情；MCP 接收受限决策信号摘要 | 按请求；健康结果缓存 15 分钟 |
+| 决策信号组合 | 宏观、政策、台海、披露、走廊与 nowcast 的受限组合 | 国家简报、公共 RPC、bootstrap 与 Pro MCP | 15 分钟 |
+| 双边 HS4 连续性 | 审核国家/战略产品注册表的年度 UN Comtrade 进口篮 | PRO `GET /api/supply-chain/v1/get-country-products` 与航线暴露工作流 | `0 6 1 * *` |
+
+## 健康投影注册表
+
+中国健康投影跟踪以下稳定契约。`launched` 表示该管线已纳入中国投影，
+但不会覆盖它的实时新鲜度或内容状态。
+
+| 契约 ID | 覆盖 | 上线状态 |
+| --- | --- | --- |
+| `economic.bis-policy` | BIS 政策利率 | `launched` |
+| `economic.imf-macro` | IMF 宏观快照 | `launched` |
+| `energy.jodi-oil` | JODI 石油 | `blocked` — `CHINA_UPSTREAM_ROW_UNAVAILABLE` |
+| `energy.jodi-gas` | JODI 天然气 | `blocked` — `CHINA_UPSTREAM_ROW_UNAVAILABLE` |
+| `energy.spine` | 中国能源脊柱 | `launched` |
+| `trade.comtrade-reporter-156` | UN Comtrade reporter 156 | `launched` |
+| `supply-chain.ccfi` | 中国出口集装箱运价指数 | `launched` |
+| `market.china-index` | 中国国家市场指数 | `launched` |
+| `market.china-corporate-disclosures` | SSE/SZSE 官方企业披露 | `launched` |
+| `news.china` | 中国新闻摘要 | `launched` |
+| `aviation.china-hubs` | 八个审核中国航空枢纽 | `launched` |
+| `macro.china-snapshot` | 规范化中国宏观快照 | `launched` |
+| `macro.china-release-calendar` | 中国发布日历 | `launched` |
+| `policy.official-events` | 官方政策与执法事件 | `launched` |
+| `hazards.western-pacific-cyclones` | 西太平洋气旋身份 | `launched` |
+| `hazards.hko-warnings` | 香港天文台警报 | `launched` |
+| `military.cross-strait-activity` | 官方台海活动基线 | `launched` |
+
+JODI 仍可用于现有全球能源产品。其中国石油与天然气契约保持阻止，
+因为审核后的上游国家索引目前没有发布实质性的 `CN` 行。因此，
+健康的全球 JODI heartbeat 不能被呈现为中国覆盖。
+
+详细方法与来源契约：
+
+- [官方宏观与政策](/zh/china-official-macro-policy)
+- [企业披露](/zh/china-corporate-disclosures)
+- [物流走廊](/zh/china-logistics-corridors)
+- [跨领域决策信号](/zh/china-decision-signals)
+- [活动 nowcast 方法](/zh/methodology/china-activity-nowcast)
+- [共享溯源契约](/zh/decision-signal-provenance)
+
+## 状态与缺失值
+
+来源请求成功不等于内容可用。中国健康检查会分别评估传输新鲜度和内容新鲜度。
+成功请求仍可能发布过期、部分、空或时间戳未知的内容。
+
+公共契约使用显式状态：
+
+- `available` 或 `healthy` 表示所需负载通过领域验证和新鲜度规则；
+- `partial` 或 `degraded` 表示部分审核覆盖缺失、过期或无效，但其他证据仍可用；
+- `stale` 表示最后有效观测超出内容预算；
+- `unavailable` 表示没有可发布的有效观测；
+- `blocked` 表示来源被刻意禁止上线，通常因为 robots、条款、传输或来源实质性审核未通过。
+
+缺失类别绝不会被转换为零、正常、不变或当前。保留最后良好值时，会保留原始
+观测时间，并同时报告当前传输失败。
+
+## 双边 HS4 进口篮
+
+双边存储覆盖 `scripts/shared/comtrade-strategic-products.json` 中 20 个经过审核的
+`bilateralHs4Code`。每个国家分片包含按 HS4 产品划分的年度进口额和主要出口伙伴，
+用于国家暴露、航线影响、多部门冲击以及 PRO `get-country-products` 路由。
+详细双边数据行不进入匿名中国摘要。
+
+认证 Comtrade 路由对两个 HS4 批次分别发送一个从 `Y-2` 到 `Y-5` 的四年窗口。
+规范化器按“产品 + 伙伴”保留最新年份，因此响应不会静默混合不同年份。
+缺少 `COMTRADE_API_KEYS` 时，公共 preview 路由不接受年份列表，因此依次尝试
+`Y-2` 和 `Y-3`。
+
+生产计划被明确限制在配额内：
+
+| 控制项 | 契约 |
+| --- | --- |
+| Railway cron | `0 6 1 * *` — 每月第一天 06:00 UTC |
+| 提供商配额 | 每月 500 次带 key 请求 |
+| Seeder 请求预算 | 480 |
+| 新鲜度门禁 | 24 天；仅显式 `FORCE_RESEED=true` 可绕过 |
+| 国家负载 TTL | 40 天 |
+| 健康过期阈值 | 35 天 |
+| 覆盖下限 | 110 个国家分片 |
+
+低于 110 个分片的运行写入 `partial` 元数据，而不会声称完全成功。失败 reporter
+最多连续两次运行保留已有分片；之后允许分片过期，使按需公共回退可以再次探测。
+限流、配额耗尽和请求预算耗尽会发布部分覆盖并停止运行，不会用空负载覆盖最后良好数据。
+
+## 访问边界
+
+- 国家摘要、走廊状态、决策信号摘要、溯源与聚合健康通过受限公共界面提供。
+- 详细走廊控制塔与活动 nowcast 证据只通过 REST/UI 提供。MCP 没有这两个路由的
+  专用工具；Pro MCP 通过 `get_china_decision_signals` 接收其受限摘要。
+- Pro MCP 通过 `get_economic_data` 的 `china-macro` 或
+  `china-release-calendar` dataset 读取规范宏观与发布日历缓存。
+- 详细双边 HS4 产品行和航线暴露仅限 PRO。
+- Pro MCP 决策信号工具获得与公共组合相同的受限条目和溯源，不获得原始交易所文件或不受限来源扩展。
+- 代理凭据、逐次请求原始诊断、缓存名称和详细新鲜度阈值仅限 operator。
+  公共文档只说明配置键与选择语义，不公开其值。
+
+官方发布者身份不等于独立验证。发布者身份、提取置信度、分类置信度、佐证和
+新鲜度始终是独立声明。

--- a/docs/zh/china-logistics-corridors.mdx
+++ b/docs/zh/china-logistics-corridors.mdx
@@ -1,0 +1,94 @@
+---
+title: "中国物流走廊"
+description: "四条审核中国物流走廊、六个来源族、组合规则、溯源、新鲜度与 API 行为。"
+---
+
+中国物流控制塔是在审核地理走廊上进行的透明来源组合。它按来源族报告证据可用性和
+新鲜度，不生成不透明物流风险分数、不预测中断，也不从“来源存在”推断经济活动。
+
+## 审核走廊
+
+| 走廊 ID | 名称 | 审核范围 |
+| --- | --- | --- |
+| `china-yangtze-river-delta` | 长三角 | 上海、江苏、浙江港口、航空与先进制造节点 |
+| `china-greater-bay-area` | 粤港澳大湾区 | 广东、香港、面向澳门的港口、机场、灾害与工业门户 |
+| `china-bohai-rim` | 环渤海 | 京津、河北、山东、辽宁海运与工业门户 |
+| `china-western-land-sea-corridor` | 西部陆海新通道 | 内陆制造枢纽、新疆陆路口岸与广西海运门户 |
+
+每条走廊都有审核 polygon、节点注册表、节点所有者与来源 selector。来源记录只有在
+selector 或审核地理映射到该走廊时才贡献。全国输入会明确标记为全国范围，并可应用
+到四条走廊。
+
+## 六个信号族
+
+| Family ID | 来源契约 | 范围与观测 |
+| --- | --- | --- |
+| `port` | IMF PortWatch | 审核中国/香港港口 ID；发布时提供靠港次数、DWT、趋势差值和异常标志 |
+| `aviation` | AviationStack | PEK、PVG、CAN、SZX、CTU、KMG、URC、HKG 的审核提供商覆盖 |
+| `hazard` | 西太平洋气旋来源与 Hong Kong Observatory | 走廊边界内事件，以及大湾区明确的 HKO 警告覆盖 |
+| `power_energy` | WorldMonitor energy spine | 中国全国能源依赖覆盖与最新来源观测时间 |
+| `strategic_industry` | UN Comtrade | reporter 156 的年度战略产品观测 |
+| `trade` | UN Comtrade 与 Shanghai Shipping Exchange CCFI | reporter 156 年度贸易观测与当前中国出口集装箱运价指数 |
+
+IMF PortWatch 和 AviationStack 是节点范围；灾害观测为区域范围；WorldMonitor
+energy spine、UN Comtrade 和 Shanghai Shipping Exchange 输入为全国范围。输出
+保留这些范围，不会把全国证据表现成节点实测值。
+
+## 可用性组合
+
+每个来源信号携带：
+
+- 发布者身份与类别；
+- 适用时的来源 URL；
+- 节点、区域或全国范围；
+- 带精度的观测、发布与检索时间；
+- 可用时的修订元数据；
+- 传输与内容新鲜度；
+- 可检查摘要与来源指标。
+
+每个来源族状态为 `available`、`partial`、`stale` 或 `unavailable`。走廊状态为：
+
+- 只有六项都可用才是 `available`；
+- 所有条件均为可用或过期且至少一项过期时为 `stale`；
+- 六项都不可用时为 `unavailable`；
+- 其他混合状态或溯源无效状态均为 `partial`。
+
+配置港口或机场缺失会成为显式不可用信号。健康灾害 feed 中没有事件只能证明
+feed 覆盖，不能创建灾害事件。存在 energy-spine 负载不代表活动方向。没有前值的
+当前 CCFI 水平不能成为运价变化。
+
+## 新鲜度预算
+
+Composer 在请求时评估来源时间戳：
+
+| 输入 | 传输预算 | 内容处理 |
+| --- | --- | --- |
+| PortWatch | 36 小时 | 单项观测 72 小时后过期 |
+| AviationStack | 90 分钟 | 单项观测 180 分钟后过期 |
+| 西太平洋灾害 / HKO | 9 小时 | 观测 9 小时后过期 |
+| Energy spine | 48 小时 | 年/月/日精度使用对应周期预算 |
+| UN Comtrade | 48 小时 | 年度观测使用 550 天预算 |
+| CCFI | 7 小时 | 指数内容 28 天后过期 |
+
+传输新鲜度证明采集运行；内容新鲜度证明观测本身及时。二者不能相互替代。
+
+## API 与缓存
+
+`GET /api/supply-chain/v1/get-china-corridor-control-towers` 批量读取规范 Redis
+来源 seed，并隔离缺失依赖。它在返回 wire payload 前验证每个组合溯源信封。
+
+健康聚合使用五分钟服务端缓存。全部不可用结果不进行正向缓存，因此恢复可以立即
+出现。客户端断路器刻意不保留可能隐藏当前失败即关闭响应的最后良好聚合。面板刷新
+间隔为 15 分钟。
+
+只有每条走廊都不可用时，响应才设置 `upstreamUnavailable: true`。部分走廊证据
+保持可检查，不会被折叠为完全中断或虚假健康。
+
+详细控制塔响应只通过 REST/UI 提供。MCP 没有专用走廊控制塔工具；Pro MCP
+只通过 `get_china_decision_signals` 接收其受限贡献。
+
+## 与 nowcast 的关系
+
+[中国经济活动即时预测](/zh/methodology/china-activity-nowcast) 只有在存在可比较的
+历史走廊快照时才可使用走廊来源族广度变化。控制塔响应本身仍是来源组合，不发布
+方向性经济结论。

--- a/docs/zh/china-official-macro-policy.mdx
+++ b/docs/zh/china-official-macro-policy.mdx
@@ -1,0 +1,102 @@
+---
+title: "中国官方宏观与政策"
+description: "中国官方宏观观测、发布日历核验、政策事件分类、来源准入、修订与缺失值契约。"
+---
+
+WorldMonitor 维护两条独立官方文件管线：修订感知的数值宏观观测，以及类型化
+政策/执法事件。二者共享[决策信号溯源契约](/zh/decision-signal-provenance)，
+但不共享 fetcher、评分或新鲜度规则。
+
+## 官方宏观观测
+
+已上线宏观快照要求以下五个序列：
+
+| 序列 ID | 发布者 | 支柱 | 单位 | 最大观测年龄 |
+| --- | --- | --- | --- | --- |
+| `nbs_industrial_value_added_yoy` | 中国国家统计局 | 活动 | 百分比 | 75 天 |
+| `nbs_fixed_asset_investment_yoy` | 中国国家统计局 | 投资/房地产 | 百分比 | 75 天 |
+| `nbs_real_estate_investment_yoy` | 中国国家统计局 | 投资/房地产 | 百分比 | 75 天 |
+| `safe_fx_reserves` | 国家外汇管理局 | 外部压力 | 1 亿美元 | 45 天 |
+| `safe_bank_fx_settlement` | 国家外汇管理局 | 外部压力 | 1 亿元人民币 | 45 天 |
+
+NBS 从 `www.stats.gov.cn/english/PressRelease/` 采集；SAFE 从
+`www.safe.gov.cn/safe/` 采集。两者都有有界请求预算、手动重定向处理、响应大小
+限制、robots 预检、来源 host allowlist 与审核归因要求。宏观 seeder 不使用代理
+绕过被拒绝的来源决定。
+
+以下审核候选项保持显式不可用，而不是被静默省略：
+
+- `pboc_aggregate_financing_flow`
+- `pboc_new_rmb_loans`
+- `pboc_m2_yoy`
+- `pboc_policy_liquidity_operation`
+- `gacc_exports`
+- `gacc_imports`
+- `gacc_trade_balance`
+
+当 `www.pbc.gov.cn` robots 策略禁止审核路径或条款审核未完成时，PBoC 候选项保持
+阻止。`english.customs.gov.cn` 无法通过 TLS/来源预检时，GACC 候选项保持阻止。
+相应支柱为 `unavailable`，不会替换为其他发布者。
+
+## 修订与方向
+
+每个官方观测保留观测期、发布时间、检索时间、来源 URL、版本 ID、修订序号与
+替代状态。更正会创建或更新可追踪版本，不会改写历史时点记录。
+
+只有发布序列契约提供有效比较时才计算方向。缺失比较值保持不可用。只有五个必需
+观测都有效并位于各自年龄预算内，快照才是 launch-ready。传输新鲜度与快照完整性
+写入独立 seed metadata。
+
+`GET /api/economic/v1/get-china-macro-snapshot` 仅读取规范
+`economic:china:macro:v2` seed，缓存缺失时不会向上游发布者扇出。Railway 宏观成员
+每 36 小时运行一次。
+
+## 发布日历
+
+发布日历从 `www.stats.gov.cn` 读取当年 NBS 日历。贷款市场报价利率日期由审核的
+中国工作日日历生成并标记为 `provisional`；只有在 `www.chinamoney.com.cn`
+找到对应 ChinaMoney/CFETS 公告后才提升为 `verified`。
+
+必需 NBS 日历失败会让日历构建失败。ChinaMoney 核验失败会保留 LPR 暂定状态并
+记录来源决定，不会把它改标为已核验。
+
+## 政策与执法事件
+
+政策管线轮询六个官方机构：
+
+| 机构 | 发布者 | 列表 host |
+| --- | --- | --- |
+| `CAC` | 国家互联网信息办公室 | `www.cac.gov.cn` |
+| `SAMR` | 国家市场监督管理总局 | `www.samr.gov.cn` |
+| `MIIT` | 工业和信息化部 | `www.miit.gov.cn` |
+| `MOFCOM` | 商务部 | `www.mofcom.gov.cn` |
+| `NDRC` | 国家发展和改革委员会 | `zfxxgk.ndrc.gov.cn` |
+| `PBOC` | 中国人民银行 | `www.pbc.gov.cn` |
+
+每个机构每次运行最多一个列表请求和三个审核文件请求，同 host 请求间隔 400 ms。
+列表响应上限 750 KB，文件上限 2 MB；URL 必须符合审核 host 与路径契约。
+
+确定性分类法输出：
+
+- `consultation_draft`
+- `announcement_guidance`
+- `final_rule`
+- `administrative_approval_restriction`
+- `investigation`
+- `enforcement_penalty`
+- `effective_date_change`
+- `amendment_correction_repeal_supersession`
+- `unknown`
+
+发布事件保留中文原标题与文本、翻译状态、文号、发布/生效日期、审核行业与实体链接、
+内容 hash、分类证据、lineage、修订和完整溯源。未知分类保持未知，不会被提升为执法。
+
+Railway macro bundle 每 6 小时刷新该管线，在 180 天内最多保留 120 个事件，并保持
+完整 lineage。某机构失败时，仍有效的最后良好事件会被保留，其传输新鲜度改为
+`error`；健康机构继续独立运行。
+
+## 告警边界
+
+征求意见稿、指导文件和未知政策分类不触发告警。审核政策/执法告警要求新的稳定
+lineage。更正和重复摄取保留相同 lineage 以便去重。受限中国决策信号组合最多发布
+该管线的四个有效条目。

--- a/docs/zh/data-sources.mdx
+++ b/docs/zh/data-sources.mdx
@@ -172,6 +172,55 @@ GPS 干扰和欺骗 — 在冲突区域越来越多地被用作电子战 — 通
 
 **严重性阈值**：平均延误 ≥15 分钟或 ≥15% 航班延误 = 轻微；≥30 分钟/30% = 中度；≥45 分钟/45% = 重大；≥60 分钟/60% = 严重。取消率 ≥80% 且航班 ≥10 = 关闭。所有结果在 Redis 中缓存 30 分钟。当未配置 AviationStack API key 时，系统会生成概率性模拟延误以供演示 — 高峰时段和高流量机场获得更高的延误概率。
 
+### 中国覆盖、归因与新鲜度
+
+中国国家下钻由多个来源专属契约组成，而不是一个不透明的“中国抓取路径”。完整
+契约清单、更新频率、界面和访问边界见[中国数据覆盖](/zh/china-data-coverage)。
+
+当前中国专属官方管线包括：
+
+- NBS 与 SAFE 的修订感知宏观观测；未通过来源预检的 PBoC 与 GACC 候选项保持显式不可用；
+- CAC、SAMR、MIIT、MOFCOM、NDRC 与 PBoC 的官方政策和执法文件；
+- SSE 与 SZSE 的仅元数据企业披露；HKEX 因自动访问条款明确被阻止；
+- 台湾国防部声明，以及单独归因的日本统合幕僚监部背景；
+- HKO 警告与西太平洋灾害观测。
+
+组合还使用 BIS、IMF、UN Comtrade reporter 156 与双边 HS4、CCFI、IMF PortWatch、
+AviationStack、中国能源脊柱、中国市场指数和审核中国新闻源等可归因全球契约。
+每个展示信号都保留发布者和观测或发布日期。缺失、过期、阻止或部分来源显示为
+不可用或降级，而不是零。
+
+JODI 继续用于现有全球能源产品，但在确认相关油气数据集发布实质性 `CN` 行之前，
+中国契约保持 `blocked`。全球排名 insights 也不作为中国来源健康证据：当前前八条
+完全可能没有中国故事，因此 seeder 会单独持久化 Xinhua、MIIT 和 MOFCOM 的
+中国来源投影。
+
+每小时 Railway 中国覆盖评估器分别检查传输 heartbeat 和内容新鲜度。航空覆盖使用
+规范八枢纽 `coverage` 记录，而不是 bootstrap 的展示用机场行。审计只记录聚合状态
+和原因码，不记录凭据或原始上游负载。详细双边贸易数据仅限 Pro，不进入公共中国摘要。
+
+来源专属细节：
+
+- [官方宏观与政策](/zh/china-official-macro-policy)
+- [企业披露](/zh/china-corporate-disclosures)
+- [物流走廊](/zh/china-logistics-corridors)
+- [中国决策信号](/zh/china-decision-signals)
+- [活动 nowcast 方法](/zh/methodology/china-activity-nowcast)
+
+#### 台海官方活动声明
+
+持久 Railway 归档为 `military:cross-strait-activity:v1`；Force Posture 面板从
+`military:cross-strait-activity-bootstrap:v1` 水合紧凑投影。台湾国防部每日发布
+按官方 Asia/Taipei 06:00 至次日 06:00 报告窗口存储。解放军军机、军舰、其他
+公务船、越过海峡中线和进入 ADIZ 保持独立可空类别；未报告类别为未知，不是零。
+
+每次运行最多累积 20 个新的台湾国防部详情页，并将更正保留为关联版本。30/90 天
+中位数只使用当前报告之前的有效台湾国防部报告日；样本不足时比较保持不可用。
+审核日本统合幕僚监部发布仅作为单独归因区域背景，不进入台湾国防部基线。
+
+这些官方声明不是 ADS-B 飞机轨迹、AIS 船舶轨迹、NOTAM、新闻或市场观测。
+面板明确标注区别，不把这些来源族合并成单一活动计数。
+
 ### 航空情报面板
 
 航空情报面板提供了一个 6 标签页的航空监测界面，覆盖运营、航班、航空公司、跟踪、新闻和价格：
@@ -490,6 +539,18 @@ WorldMonitor 感谢以下组织将其数据公开可访问。
 | U.S. BLS | 美国劳工统计 | [bls.gov/developers](https://www.bls.gov/developers) |
 | USA Spending | 美国联邦支出和合同 | [api.usaspending.gov](https://api.usaspending.gov) |
 | UN Comtrade | 全球商品贸易流向 | [comtradeapi.un.org](https://comtradeapi.un.org) |
+| 中国国家统计局 | 官方活动/投资观测与发布日历 | [stats.gov.cn](https://www.stats.gov.cn/english/) |
+| 国家外汇管理局 | 官方外汇储备与银行结售汇观测 | [safe.gov.cn](https://www.safe.gov.cn/safe/sjjd/index.html) |
+| ChinaMoney / CFETS | 贷款市场报价利率实际发布日期核验 | [chinamoney.com.cn](https://www.chinamoney.com.cn/) |
+| 国家互联网信息办公室 | 官方政策文件 | [cac.gov.cn](https://www.cac.gov.cn/wxzw/zcfg/) |
+| 国家市场监督管理总局 | 官方监管与执法文件 | [samr.gov.cn](https://www.samr.gov.cn/zw/zfxxgk/) |
+| 工业和信息化部 | 官方工业与技术政策文件 | [miit.gov.cn](https://www.miit.gov.cn/zwgk/zcwj/) |
+| 商务部 | 官方贸易政策与执法文件 | [mofcom.gov.cn](https://www.mofcom.gov.cn/zcfb/) |
+| 国家发展和改革委员会 | 官方经济政策文件 | [ndrc.gov.cn](https://zfxxgk.ndrc.gov.cn/web/zclist.jsp?dirid=41&pid=39) |
+| 中国人民银行 | 官方政策文件与 LPR 日历规则 | [pbc.gov.cn](https://www.pbc.gov.cn/) |
+| 上海证券交易所 | 审核发行人公共披露元数据 | [sse.com.cn](https://www.sse.com.cn/) |
+| 深圳证券交易所 | 审核发行人公共披露元数据 | [szse.cn](https://www.szse.cn/) |
+| 上海航运交易所 | 中国出口集装箱运价指数 | [sse.net.cn](https://en.sse.net.cn/indices/ccfinew.jsp) |
 | CoinGecko | 加密货币价格和市场数据 | [coingecko.com](https://www.coingecko.com) |
 
 ### 地缘政治与冲突
@@ -500,6 +561,8 @@ WorldMonitor 感谢以下组织将其数据公开可访问。
 | UCDP | 乌普萨拉冲突数据项目 — 冲突事件 | [ucdp.uu.se](https://ucdp.uu.se) |
 | GDELT | 全球事件、语言和语调数据库 | [gdeltproject.org](https://www.gdeltproject.org) |
 | IMF PortWatch | 咽喉要道过境情报 | [portwatch.imf.org](https://portwatch.imf.org) |
+| 台湾国防部 | 官方每日台海活动声明 | [mnd.gov.tw](https://www.mnd.gov.tw/english/) |
+| 日本统合幕僚监部 | 单独归因的区域活动背景 | [mod.go.jp/js](https://www.mod.go.jp/js/) |
 
 ### 环境与灾害
 

--- a/docs/zh/finance-data.mdx
+++ b/docs/zh/finance-data.mdx
@@ -50,6 +50,8 @@ description: "World Monitor 金融变体中的市场雷达、海湾国家 FDI �
 | 世界银行指标 | `GET /api/economic/v1/list-world-bank-indicators` | 世界银行国家指标与技术准备度数据。 |
 | 能源价格 | `GET /api/economic/v1/get-energy-prices` | 用于 WTI、Brent、产量与库存指标的石油与能源分析。 |
 | 宏观信号 | `GET /api/economic/v1/get-macro-signals` | 市场雷达 / 宏观信号面板；bootstrap 优先经由 `macroSignals`。 |
+| 中国宏观快照 | `GET /api/economic/v1/get-china-macro-snapshot` | 修订感知的 NBS/SAFE 官方观测与发布日历背景；见[中国官方宏观与政策](/zh/china-official-macro-policy)。 |
+| 中国活动 nowcast | `GET /api/economic/v1/get-china-activity-nowcast` | 官方版本与审核代理指标的确定性比较；见[方法](/zh/methodology/china-activity-nowcast)。 |
 | 能源装机容量 | `GET /api/economic/v1/get-energy-capacity` | 已装机太阳能、风能与煤炭装机容量时间序列。 |
 | BIS 政策利率 | `GET /api/economic/v1/get-bis-policy-rates` | 经济面板 BIS 政策利率表；bootstrap 优先经由 `bisPolicy`。 |
 | BIS 汇率 | `GET /api/economic/v1/get-bis-exchange-rates` | BIS 实际有效汇率表；bootstrap 优先经由 `bisExchange`。 |

--- a/docs/zh/methodology/china-activity-nowcast.mdx
+++ b/docs/zh/methodology/china-activity-nowcast.mdx
@@ -105,6 +105,9 @@ JODI 数据可用，并不能证明需求方向；同样，只有当前 CCFI 水
 均不存在时，包装对象的 `upstream_unavailable` 才为 true；其他健康但
 缺少方向的信息属于方法证据不足，而不是上游故障。
 
+详细 nowcast 证据只通过 REST/UI 提供。MCP 没有专用活动 nowcast 工具；
+Pro MCP 只通过 `get_china_decision_signals` 接收其受限贡献。
+
 端点组合以下数据：
 
 - 官方中国宏观快照；

--- a/docs/zh/panels/supply-chain.mdx
+++ b/docs/zh/panels/supply-chain.mdx
@@ -37,6 +37,7 @@ description: "供应链面板是 WorldMonitor 仪表盘的供应链指挥中心�
 | 绕行走廊 | `GET /api/supply-chain/v1/get-bypass-options` | 针对咽喉要道/货物类型的 PRO 排名海运和陆运绕行选项。 |
 | 国家成本冲击 | `GET /api/supply-chain/v1/get-country-cost-shock` | 针对国家 + 咽喉要道 + HS2 切片的 PRO 成本冲击和战争风险估算。 |
 | 国家进口篮 | `GET /api/supply-chain/v1/get-country-products` | 用于国家下钻的 PRO 已种子化双边 HS4 进口篮。 |
+| 中国物流走廊 | `GET /api/supply-chain/v1/get-china-corridor-control-towers` | 由六个携带溯源的来源族组合而成的四条审核中国走廊；见[中国物流走廊](/zh/china-logistics-corridors)。 |
 | 多部门冲击 | `GET /api/supply-chain/v1/get-multi-sector-cost-shock` | 封闭窗口上的 PRO 部门级成本冲击估算。 |
 | 部门依赖 | `GET /api/supply-chain/v1/get-sector-dependency` | PRO 依赖标志、主要出口商份额和主要咽喉要道暴露。 |
 | Route Explorer 航线 | `GET /api/supply-chain/v1/get-route-explorer-lane` | PRO 主航线几何、咽喉要道暴露、绕行几何、战争风险层级和中断分数。 |

--- a/tests/china-coverage-production-registration.test.mts
+++ b/tests/china-coverage-production-registration.test.mts
@@ -55,7 +55,10 @@ describe('China coverage production registration', () => {
 
   it('documents the public China source contract and its operator health projection', () => {
     assert.match(dataSources, /### China Coverage, Attribution, and Freshness/);
-    assert.match(dataSources, /BIS, IMF, JODI, UN Comtrade, CCFI, AviationStack, NBS\/PBoC, JMA, and HKO/);
+    assert.match(dataSources, /\[China Data Coverage\]\(\/china-data-coverage\)/);
+    assert.match(dataSources, /UN\s+Comtrade reporter 156 and bilateral HS4 data/);
+    assert.match(dataSources, /JODI remains enabled for its existing global energy product/);
+    assert.match(dataSources, /China\s+contract stays explicitly blocked/);
     assert.match(dataSources, /detailed bilateral trade data remains\s+Pro-only/i);
     assert.match(healthDocs, /### China Coverage Projection/);
     assert.match(healthDocs, /CHINA_DEGRADED/);

--- a/tests/china-documentation-contract.test.mts
+++ b/tests/china-documentation-contract.test.mts
@@ -1,0 +1,306 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  CHINA_MACRO_REQUIRED_SERIES,
+  CHINA_MACRO_SERIES_CONTRACT,
+} from '../shared/china-macro-contract.js';
+import {
+  CHINA_CORRIDOR_SIGNAL_FAMILIES,
+  CHINA_LOGISTICS_CORRIDORS,
+} from '../shared/china-logistics-corridors';
+import {
+  OFFICIAL_EXCHANGE_SOURCE_CONTRACTS,
+  REVIEWED_DISCLOSURE_ISSUERS,
+} from '../scripts/china-corporate-disclosures/adapters.mjs';
+import { CHINA_COVERAGE_ENTRIES } from '../scripts/china-coverage-manifest.mjs';
+import { CHINA_POLICY_SOURCES } from '../scripts/china-policy/adapters.mjs';
+import { CHINA_POLICY_AGENCIES } from '../scripts/china-policy/normalize.mjs';
+import {
+  MIN_COUNTRY_COVERAGE,
+  REQUEST_BUDGET,
+} from '../scripts/seed-comtrade-bilateral-hs4.mjs';
+
+const root = resolve(import.meta.dirname, '..');
+const read = (relativePath: string) =>
+  readFileSync(resolve(root, relativePath), 'utf8').replaceAll('\r\n', '\n');
+
+const docsConfig = JSON.parse(read('docs/docs.json'));
+
+function collectPagePaths(node: unknown, pages: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectPagePaths(item, pages);
+    return pages;
+  }
+  if (node && typeof node === 'object') {
+    const record = node as Record<string, unknown>;
+    if (typeof record.pages === 'string') pages.push(record.pages);
+    if (Array.isArray(record.pages)) {
+      for (const page of record.pages) {
+        if (typeof page === 'string') pages.push(page);
+        else collectPagePaths(page, pages);
+      }
+    }
+    for (const [key, value] of Object.entries(record)) {
+      if (key !== 'pages' && value && typeof value === 'object') {
+        collectPagePaths(value, pages);
+      }
+    }
+  }
+  return pages;
+}
+
+const englishNavigation = docsConfig.navigation.languages.find(
+  (entry: { language?: string }) => entry.language === 'en',
+);
+const chineseNavigation = docsConfig.navigation.languages.find(
+  (entry: { language?: string }) => entry.language === 'zh-Hans',
+);
+const englishPages = new Set(collectPagePaths(englishNavigation));
+const chinesePages = new Set(collectPagePaths(chineseNavigation));
+
+const CHINA_DOC_PAGES = [
+  'china-data-coverage',
+  'china-official-macro-policy',
+  'china-corporate-disclosures',
+  'china-logistics-corridors',
+  'china-decision-signals',
+  'decision-signal-provenance',
+  'methodology/china-activity-nowcast',
+] as const;
+function assertIncludesEvery(content: string, values: readonly string[], label: string) {
+  const missing = values.filter((value) => !content.includes(value));
+  assert.deepEqual(missing, [], `${label} is missing: ${missing.join(', ')}`);
+}
+
+describe('China documentation contract', () => {
+  it('keeps every China capability page discoverable in English and Chinese navigation', () => {
+    for (const page of CHINA_DOC_PAGES) {
+      assert.ok(englishPages.has(page), `English navigation is missing ${page}`);
+      assert.ok(chinesePages.has(`zh/${page}`), `Chinese navigation is missing zh/${page}`);
+      assert.ok(existsSync(resolve(root, `docs/${page}.mdx`)), `Missing docs/${page}.mdx`);
+      assert.ok(existsSync(resolve(root, `docs/zh/${page}.mdx`)), `Missing docs/zh/${page}.mdx`);
+    }
+  });
+
+  it('documents every launched official macro series and policy agency from runtime declarations', () => {
+    const english = read('docs/china-official-macro-policy.mdx');
+    const chinese = read('docs/zh/china-official-macro-policy.mdx');
+
+    assertIncludesEvery(english, CHINA_MACRO_REQUIRED_SERIES, 'English macro documentation');
+    assertIncludesEvery(chinese, CHINA_MACRO_REQUIRED_SERIES, 'Chinese macro documentation');
+    assertIncludesEvery(
+      english,
+      [...new Set(CHINA_MACRO_REQUIRED_SERIES.map(
+        (seriesId) => CHINA_MACRO_SERIES_CONTRACT[seriesId].source,
+      ))],
+      'English macro source documentation',
+    );
+    assertIncludesEvery(english, CHINA_POLICY_AGENCIES, 'English policy documentation');
+    assertIncludesEvery(chinese, CHINA_POLICY_AGENCIES, 'Chinese policy documentation');
+
+    for (const source of Object.values(CHINA_POLICY_SOURCES)) {
+      const host = new URL(source.listUrl).host;
+      assert.ok(english.includes(host), `English policy documentation is missing ${host}`);
+      assert.ok(chinese.includes(host), `Chinese policy documentation is missing ${host}`);
+    }
+
+    const requiredSeries = new Set(CHINA_MACRO_REQUIRED_SERIES);
+    const unavailableSeriesIds = Object.keys(CHINA_MACRO_SERIES_CONTRACT)
+      .filter((seriesId) => !requiredSeries.has(seriesId));
+    for (const unavailableSeries of unavailableSeriesIds) {
+      assert.ok(
+        english.includes(unavailableSeries),
+        `English macro documentation must disclose unavailable ${unavailableSeries}`,
+      );
+      assert.ok(
+        chinese.includes(unavailableSeries),
+        `Chinese macro documentation must disclose unavailable ${unavailableSeries}`,
+      );
+    }
+  });
+
+  it('documents every stable China health projection contract and launch state', () => {
+    const english = read('docs/china-data-coverage.mdx');
+    const chinese = read('docs/zh/china-data-coverage.mdx');
+
+    for (const entry of CHINA_COVERAGE_ENTRIES) {
+      for (const content of [english, chinese]) {
+        assert.ok(content.includes(entry.id), `China inventory is missing ${entry.id}`);
+        assert.ok(
+          content.includes(`\`${entry.launchStatus}\``),
+          `China inventory is missing the ${entry.launchStatus} launch state`,
+        );
+        if (entry.launchStatus === 'blocked') {
+          assert.ok(
+            content.includes(entry.blockedReason),
+            `China inventory is missing ${entry.id} reason ${entry.blockedReason}`,
+          );
+        }
+      }
+    }
+    assert.ok(
+      english.includes('/api/seed-health')
+        && english.includes('fresh evaluator heartbeat does not prove healthy China content'),
+      'English inventory must not present evaluator freshness as content health',
+    );
+    assert.ok(
+      chinese.includes('/api/seed-health')
+        && chinese.includes('heartbeat 不证明中国内容健康'),
+      'Chinese inventory must not present evaluator freshness as content health',
+    );
+  });
+
+  it('documents every exchange decision, reviewed issuer, and transport fallback', () => {
+    const english = read('docs/china-corporate-disclosures.mdx');
+    const chinese = read('docs/zh/china-corporate-disclosures.mdx');
+
+    for (const contract of Object.values(OFFICIAL_EXCHANGE_SOURCE_CONTRACTS)) {
+      for (const value of [
+        contract.exchange,
+        contract.launchStatus,
+        contract.admissionDecision,
+        contract.termsUrl,
+      ]) {
+        assert.ok(english.includes(value), `English disclosure documentation is missing ${value}`);
+        assert.ok(chinese.includes(value), `Chinese disclosure documentation is missing ${value}`);
+      }
+    }
+
+    const securityCodes = REVIEWED_DISCLOSURE_ISSUERS.map((issuer) => issuer.securityCode);
+    assertIncludesEvery(english, securityCodes, 'English reviewed-issuer documentation');
+    assertIncludesEvery(chinese, securityCodes, 'Chinese reviewed-issuer documentation');
+    assertIncludesEvery(
+      english,
+      ['SSE_PROXY_URL', 'SZSE_PROXY_URL', 'PROXY_URL', 'RELAY_SHARED_SECRET'],
+      'English disclosure transport documentation',
+    );
+    assertIncludesEvery(
+      chinese,
+      [
+        'SSE_PROXY_URL',
+        'SZSE_PROXY_URL',
+        'PROXY_URL',
+        'RELAY_SHARED_SECRET',
+        '不是按 URL 顺序回退',
+      ],
+      'Chinese disclosure transport documentation',
+    );
+    assert.ok(
+      english.includes('not sequential URL failover'),
+      'English disclosure transport documentation must distinguish precedence from failover',
+    );
+  });
+
+  it('documents every configured logistics corridor, signal family, and source family', () => {
+    const english = read('docs/china-logistics-corridors.mdx');
+    const chinese = read('docs/zh/china-logistics-corridors.mdx');
+
+    for (const corridor of CHINA_LOGISTICS_CORRIDORS) {
+      assert.ok(english.includes(corridor.id), `English corridor documentation is missing ${corridor.id}`);
+      assert.ok(chinese.includes(corridor.id), `Chinese corridor documentation is missing ${corridor.id}`);
+    }
+    assertIncludesEvery(english, CHINA_CORRIDOR_SIGNAL_FAMILIES, 'English corridor family documentation');
+    assertIncludesEvery(chinese, CHINA_CORRIDOR_SIGNAL_FAMILIES, 'Chinese corridor family documentation');
+    assertIncludesEvery(
+      english,
+      [
+        'IMF PortWatch',
+        'AviationStack',
+        'Hong Kong Observatory',
+        'WorldMonitor energy spine',
+        'UN Comtrade',
+        'Shanghai Shipping Exchange',
+      ],
+      'English corridor source documentation',
+    );
+  });
+
+  it('documents bilateral HS4 period selection, quota, coverage, cadence, and consumer route', () => {
+    const english = read('docs/china-data-coverage.mdx');
+    const chinese = read('docs/zh/china-data-coverage.mdx');
+    for (const content of [english, chinese]) {
+      assertIncludesEvery(
+        content,
+        [
+          '0 6 1 * *',
+          'COMTRADE_API_KEYS',
+          String(REQUEST_BUDGET),
+          String(MIN_COUNTRY_COVERAGE),
+          'get-country-products',
+          'Y-2',
+          'Y-3',
+          'Y-5',
+        ],
+        'Bilateral HS4 documentation',
+      );
+    }
+  });
+
+  it('keeps human route maps synchronized with the China RPC surface', () => {
+    for (const path of ['docs/finance-data.mdx', 'docs/zh/finance-data.mdx']) {
+      const content = read(path);
+      assertIncludesEvery(
+        content,
+        [
+          '/api/economic/v1/get-china-macro-snapshot',
+          '/api/economic/v1/get-china-activity-nowcast',
+        ],
+        path,
+      );
+    }
+    for (const path of ['docs/panels/supply-chain.mdx', 'docs/zh/panels/supply-chain.mdx']) {
+      assert.ok(
+        read(path).includes('/api/supply-chain/v1/get-china-corridor-control-towers'),
+        `${path} is missing the China corridor RPC`,
+      );
+    }
+  });
+
+  it('documents REST, UI, and MCP access boundaries without implying tool parity', () => {
+    for (const path of ['docs/china-data-coverage.mdx', 'docs/zh/china-data-coverage.mdx']) {
+      assertIncludesEvery(
+        read(path),
+        [
+          'REST/UI',
+          'get_china_decision_signals',
+          'get_economic_data',
+          'china-macro',
+          'china-release-calendar',
+        ],
+        path,
+      );
+    }
+    for (const path of [
+      'docs/china-logistics-corridors.mdx',
+      'docs/zh/china-logistics-corridors.mdx',
+      'docs/methodology/china-activity-nowcast.mdx',
+      'docs/zh/methodology/china-activity-nowcast.mdx',
+    ]) {
+      assertIncludesEvery(
+        read(path),
+        ['REST/UI', 'get_china_decision_signals'],
+        path,
+      );
+    }
+  });
+
+  it('keeps the Railway runbook synchronized with China bundle membership and proxy order', () => {
+    const runbook = read('docs/railway-seed-consolidation-runbook.md');
+    assertIncludesEvery(
+      runbook,
+      [
+        'China Decision Signals (15min)',
+        'China Macro (36h)',
+        'China Release Calendar (36h)',
+        'China Policy Events (6h)',
+        'China Corporate Disclosures (30min)',
+        '`SSE_PROXY_URL` → `SZSE_PROXY_URL` → `PROXY_URL`',
+        'selects the first non-empty setting rather than attempting each URL sequentially',
+      ],
+      'Railway runbook',
+    );
+  });
+});

--- a/tests/china-documentation-contract.test.mts
+++ b/tests/china-documentation-contract.test.mts
@@ -18,10 +18,14 @@ import {
 import { CHINA_COVERAGE_ENTRIES } from '../scripts/china-coverage-manifest.mjs';
 import { CHINA_POLICY_SOURCES } from '../scripts/china-policy/adapters.mjs';
 import { CHINA_POLICY_AGENCIES } from '../scripts/china-policy/normalize.mjs';
-import {
-  MIN_COUNTRY_COVERAGE,
-  REQUEST_BUDGET,
-} from '../scripts/seed-comtrade-bilateral-hs4.mjs';
+
+// The seeder resolves REQUEST_BUDGET from COMTRADE_REQUEST_BUDGET at module
+// evaluation, while the docs state the default contract. Clear the override
+// before a lazy import so an operator env cannot fail the docs assertion.
+delete process.env.COMTRADE_REQUEST_BUDGET;
+const { MIN_COUNTRY_COVERAGE, REQUEST_BUDGET } = await import(
+  '../scripts/seed-comtrade-bilateral-hs4.mjs'
+);
 
 const root = resolve(import.meta.dirname, '..');
 const read = (relativePath: string) =>


### PR DESCRIPTION
## Summary

China data coverage was spread across implementation notes, source catalogs,
and individual feature pages, leaving important distinctions easy to miss:
blocked versus degraded sources, evaluator freshness versus content health,
configuration precedence versus transport failover, and REST/UI versus MCP
access.

This establishes one bilingual source of truth for the full China stack:

- every launched and explicitly blocked health-projection lane, including the
  blocked JODI oil and gas contracts;
- official macro, release-calendar, policy, Cross-Strait, corporate-disclosure,
  corridor, nowcast, decision-signal, and bilateral HS4 coverage;
- source admission, cadence, freshness, missingness, retention, proxy-selection,
  and last-good semantics;
- exact REST, UI, Pro, and MCP access boundaries; and
- current Railway bundle membership and primary-versus-backup ownership.

A runtime-linked documentation contract now detects drift in the China
coverage manifest, macro series, policy agencies, corporate issuer/source
decisions, corridor registry, Comtrade limits, navigation, routes, access
boundaries, and Railway configuration language.

## Validation

- China documentation contract: 9/9 passing
- MDX compatibility: 504/504 passing
- Markdown lint: 189 files, 0 errors
- Documentation statistics: 91 claims synchronized
- Mintlify slug and public-doc reference checks: passing
- English/Chinese navigation parity: 245/245 passing
- China decision-parity audit: passing
- TypeScript typecheck and all pre-push gates: passing
- Independent review validation: all 8 review findings resolved

## Post-Deploy Monitoring & Validation

This changes documentation and drift tests only; it does not alter ingestion,
runtime routing, credentials, or deployment configuration.

After the docs deployment:

1. Confirm the Mintlify build and link checks stay green.
2. Spot-check the English and Chinese China coverage, macro/policy, corporate
   disclosure, logistics corridor, and nowcast pages from navigation.
3. Verify REST/UI/MCP boundaries and `/api/health` versus `/api/seed-health`
   semantics render intact.

Rollback trigger: a failed docs deployment, missing navigation entry, broken
internal link, or materially malformed table. Roll back this commit and
redeploy the prior docs version.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
