### PR TITLE
fix(ops): prune the recovered gdeltIntel freshness suppression (#5770)

### DIFF
--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -26,12 +26,6 @@
       "reason": "Japan MOD route returns proxy CONNECT 403; candidate country-specific routes return 407. Second cause independent of the #5689 Decodo exhaustion. No verified replacement endpoint installed."
     },
     {
-      "name": "gdeltIntel",
-      "status": "SEED_ERROR",
-      "issue": 5770,
-      "reason": "GDELT's DOC API is supply-side load-shed, not IP-blocked: a virgin residential IP 429s on its first-ever request and the dedicated GDELT_PROXY_URL exit from #5805 429s identically (#5843), so no proxy route can fix it. The bulk materializer (#5863) removes the DOC dependency entirely; this entry stays only until production reports gdeltIntel healthy on sourceVersion gdelt-bulk-v2, then it must be pruned."
-    },
-    {
       "name": "humanitarianSummary",
       "status": "SEED_ERROR",
       "issue": 5769,

--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -28,8 +28,8 @@
     {
       "name": "gdeltIntel",
       "status": "SEED_ERROR",
-      "issue": 5768,
-      "reason": "GDELT DOC blocks Railway direct egress and the shared proxy has returned 429, timeout, and TLS failures. GDELT_PROXY_URL now provides an independent route, but production still needs a verified source-specific exit before this baseline can be removed."
+      "issue": 5770,
+      "reason": "GDELT's DOC API is supply-side load-shed, not IP-blocked: a virgin residential IP 429s on its first-ever request and the dedicated GDELT_PROXY_URL exit from #5805 429s identically (#5843), so no proxy route can fix it. The bulk materializer (#5863) removes the DOC dependency entirely; this entry stays only until production reports gdeltIntel healthy on sourceVersion gdelt-bulk-v2, then it must be pruned."
     },
     {
       "name": "humanitarianSummary",

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -287,6 +287,22 @@ describe('scheduled seed freshness monitor', () => {
         false,
         'shippingRates recovered across the canonical cadence; do not suppress it again',
       );
+      assert.equal(
+        committed.acknowledged.some((entry) => entry.name === 'gdeltIntel'),
+        false,
+        'gdeltIntel recovered after the bulk-materializer cutover; do not suppress it again',
+      );
+      const gdeltFailure = applyAcceptanceBaseline(
+        [{ name: 'gdeltIntel', status: 'SEED_ERROR' }],
+        committed,
+        Date.parse('2026-08-01'),
+      );
+      assert.deepEqual(
+        gdeltFailure.blocking.map((problem) => problem.name),
+        ['gdeltIntel'],
+        'a recovered gdeltIntel failure must block the committed acceptance gate',
+      );
+      assert.deepEqual(gdeltFailure.acknowledged, []);
       assert.ok(
         Date.parse(committed.expiresAt) > Date.parse('2026-07-28'),
         'committed baseline must not ship already expired',


### PR DESCRIPTION
Closes #5770. Closes #5868.

## What changed while this PR was open

It opened as an ownership fix: the `gdeltIntel` acceptance-baseline entry pointed at **closed** issue #5768, which this file's own `$comment` forbids — *"a suppression pointing at a closed PR has no owner"* — so the entry keeping the ingestion gate from paging on `gdeltIntel SEED_ERROR` had nobody tracking it, and `expiresAt: 2026-08-27` hard-fails the gate regardless.

Since then the source **recovered**, so the correct end state is no longer a repoint — it is removal. Both commits are kept so the history is honest: repoint while it was still failing, then prune once recovery was observed.

## Why the entry can go

The bulk materializer (#5863) is live in production. The Railway cutover it needed — start command, `*/15` cron, and the watch-path closure — was applied and verified (#5868), and the suppression is no longer describing anything real:

```
seed-meta:intelligence:gdelt-intel
  sourceVersion: "gdelt-bulk-v2"    (was "gdelt-doc-v2", the retired DOC seeder)
  status:        clean              (was "error" / GDELT_SOURCE_PROXY_HTTP_429)
  age:           ~1-3 min           (was 110 min on a 4h cron)
```

Three consecutive clean ticks observed, cursor advancing on the quarter hour (`20260730140000` → `141500` → `143000`), and every derived geo event carrying a real latitude — 109/109, 111/111 non-zero across ticks. That last check matters because the pre-merge P0 in #5863 was a GKG column mis-parse that published every geo event at latitude 0; the fix is confirmed working on live data, not just in tests.

All six intel topics went from 18–29 days stale to minutes-fresh in the first tick.

## Effect of the removal

`gdeltIntel SEED_ERROR` becomes **blocking** again — which is the point. The ingestion acceptance gate will fail on it rather than passing quietly, so a materializer regression pages instead of hiding behind an acknowledgement. `check-seed-freshness` was already reporting the entry as `recovered: … remove it from scripts/seed-freshness-baseline.json`.

The `crossStraitActivityJapanMod` (#5714) and `humanitarianSummary` (#5769) entries are untouched.

## Validation

- `scripts/seed-freshness-baseline.json` parses; `validateAcceptanceBaseline` contract unchanged.
- `tests/seed-freshness-monitor.test.mjs` 19/19, `tests/seed-freshness-workflow.test.mjs` 3/3 (both use inline fixtures, so neither depends on the real file's contents), biome clean.
- Rebased onto current `main`.

## Follow-up (deliberately not here)

Nothing *enforces* the closed-issue rule — it is prose in a `$comment`, which is exactly why this rotted unnoticed for days. A guard that resolves each entry's issue state (hard-fail on closed, soft-fail when GitHub is unreachable, per this repo's third-party-rot convention) would make the rule self-checking. Worth doing while the memory of it is fresh.

https://claude.ai/code/session_01A27Vd4tKbMQkbr81Bdh7s4