### PR TITLE
fix(wildfire): cap the canonical fires payload under the 5MB publish limit (#5866)

### DIFF
--- a/api/_wildfire-dashboard.js
+++ b/api/_wildfire-dashboard.js
@@ -1,5 +1,23 @@
 export const WILDFIRE_DASHBOARD_DETECTION_LIMIT = 500;
 
+// Cap for the CANONICAL wildfire:fires:v1 key, applied by seed-fire-detections as a
+// publishTransform (#5866). FIRMS detection volume is seasonal and unbounded: on 2026-07-30 a
+// clean run (27/27 sources OK) accumulated 20,442 detections, serialized to 5.2MB, and
+// atomicPublish hard-threw above its 5MB cap — so the seeder exited 1 and published NOTHING,
+// letting the deliberately-short 2h TTL expire the key.
+//
+// Sized from measured bytes, not guessed: a FIRMS-shaped detection serializes to ~270B, and
+// the widest one MONITORED_REGIONS can emit (180E/82N coordinates, 'Saudi Arabia',
+// FIRE_CONFIDENCE_UNSPECIFIED) to ~288B. 15,000 x 288B = 4.1MB, ~21% under the 5MB cap even
+// in that worst case. tests/wildfire-payload-cap.test.mts pins the budget at 90% of
+// MAX_PAYLOAD_BYTES, so raising this limit or widening FireDetection goes red in CI rather
+// than crashing the seeder in production.
+//
+// This is far above WILDFIRE_DASHBOARD_DETECTION_LIMIT — the dashboard never renders more
+// than 500. The canonical key is sized for the ANALYTICAL consumers that read it whole
+// (seed-thermal-escalation clustering, seed-cross-source-signals, CII risk scores).
+export const WILDFIRE_CANONICAL_DETECTION_LIMIT = 15_000;
+
 function numeric(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : 0;

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -25,7 +25,7 @@ const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024; // 5MB per key
 
 const __seed_dirname = dirname(fileURLToPath(import.meta.url));
 
-export { CHROME_UA };
+export { CHROME_UA, MAX_PAYLOAD_BYTES };
 
 /**
  * Resolve the CoinGecko base URL + auth header for the configured key tier.

--- a/scripts/_wildfire-dashboard.mjs
+++ b/scripts/_wildfire-dashboard.mjs
@@ -1,5 +1,23 @@
 export const WILDFIRE_DASHBOARD_DETECTION_LIMIT = 500;
 
+// Cap for the CANONICAL wildfire:fires:v1 key, applied by seed-fire-detections as a
+// publishTransform (#5866). FIRMS detection volume is seasonal and unbounded: on 2026-07-30 a
+// clean run (27/27 sources OK) accumulated 20,442 detections, serialized to 5.2MB, and
+// atomicPublish hard-threw above its 5MB cap — so the seeder exited 1 and published NOTHING,
+// letting the deliberately-short 2h TTL expire the key.
+//
+// Sized from measured bytes, not guessed: a FIRMS-shaped detection serializes to ~270B, and
+// the widest one MONITORED_REGIONS can emit (180E/82N coordinates, 'Saudi Arabia',
+// FIRE_CONFIDENCE_UNSPECIFIED) to ~288B. 15,000 x 288B = 4.1MB, ~21% under the 5MB cap even
+// in that worst case. tests/wildfire-payload-cap.test.mts pins the budget at 90% of
+// MAX_PAYLOAD_BYTES, so raising this limit or widening FireDetection goes red in CI rather
+// than crashing the seeder in production.
+//
+// This is far above WILDFIRE_DASHBOARD_DETECTION_LIMIT — the dashboard never renders more
+// than 500. The canonical key is sized for the ANALYTICAL consumers that read it whole
+// (seed-thermal-escalation clustering, seed-cross-source-signals, CII risk scores).
+export const WILDFIRE_CANONICAL_DETECTION_LIMIT = 15_000;
+
 function numeric(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : 0;

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, CHROME_UA, sleep } from './_seed-utils.mjs';
-import { compactWildfireDashboardPayload } from './_wildfire-dashboard.mjs';
+import { compactWildfireDashboardPayload, WILDFIRE_CANONICAL_DETECTION_LIMIT } from './_wildfire-dashboard.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -122,6 +122,27 @@ export function declareRecords(data) {
   return Array.isArray(data?.fireDetections) ? data.fireDetections.length : 0;
 }
 
+// Bound the canonical payload before it reaches atomicPublish (#5866). FIRMS detection volume
+// is seasonal and unbounded: on 2026-07-30 a clean run (27/27 sources ok, zero upstream
+// failures) accumulated 20,442 detections, serialized to 5.2MB, and atomicPublish hard-threw
+// above its 5MB cap. That throw escapes to main().catch — exit 1, nothing published, TTL not
+// extended — so the deliberately short 2h TTL below then blanked the panel.
+//
+// Ranking is the dashboard comparator (possibleExplosion -> confidence -> brightness -> frp ->
+// detectedAt), so what gets dropped is always the lowest-signal tail, and the real FIRMS count
+// survives in `pagination.totalCount`.
+function capCanonicalPayload(data) {
+  const capped = compactWildfireDashboardPayload(data, WILDFIRE_CANONICAL_DETECTION_LIMIT);
+  // Same reference back = already under the cap (or an unrecognized shape). Never dereference
+  // blindly here: a throw inside publishTransform is the exact FATAL this function exists to
+  // prevent.
+  if (capped === data) return data;
+  const total = data.fireDetections.length;
+  const kept = capped.fireDetections.length;
+  console.log(`  canonical cap: publishing ${kept} of ${total} detections (dropped ${total - kept} lowest-signal to stay under the 5MB publish cap)`);
+  return capped;
+}
+
 async function main() {
   const apiKey = process.env.NASA_FIRMS_API_KEY || process.env.FIRMS_API_KEY || '';
   if (!apiKey) {
@@ -144,6 +165,11 @@ async function main() {
     // exactly what makes a dead fire feed loud. A longer TTL keeps stale data alive past
     // the gate and turns that crit into a warn (and, inside the gate, into a green).
     ttlSeconds: 7200,
+    // Applied to the CANONICAL key only. runSeed feeds extraKey transforms the RAW fetcher
+    // output, not publishData (scripts/_seed-utils.mjs), so the bootstrap key below still
+    // ranks its top-500 over every detection FIRMS returned — capping here cannot change what
+    // the dashboard renders. Capping inside fetchAllRegions would not have that property.
+    publishTransform: capCanonicalPayload,
     lockTtlMs: 2_400_000, // 40 min — 27 slots × ~72s worst case (30s timeout + 6s backoff + 30s retry + 6s pace) ≈ 32.4 min; pad headroom. Next cron tick sees lock held and safely skips.
     sourceVersion: FIRMS_SOURCES.join('+'),
     extraKeys: [{

--- a/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/infrastructure/v1/service_server';
 
 import { getCachedJson, setCachedJson } from '../../../_shared/redis';
+import { resolveFireDetectionTotalCount } from '../../../../src/services/wildfires/payload';
 import {
   BASELINE_TTL,
   MIN_SAMPLES,
@@ -127,8 +128,15 @@ export async function listTemporalAnomalies(
           const stories = (data as { topStories?: unknown[] })?.topStories;
           counts[type] = stories?.length ?? 0;
         } else if (type === 'satellite_fires') {
+          // wildfire:fires:v1 is itself capped at WILDFIRE_CANONICAL_DETECTION_LIMIT (#5866)
+          // and carries the pre-cap FIRMS total in `pagination`. Counting the array instead
+          // would saturate this baseline at the cap, silently flattening every fire-volume
+          // anomaly above it — the z-score would read "normal" during a record fire season.
           const fires = (data as { fireDetections?: unknown[] })?.fireDetections;
-          counts[type] = fires?.length ?? 0;
+          counts[type] = resolveFireDetectionTotalCount({
+            fireDetections: fires ?? [],
+            pagination: (data as { pagination?: { totalCount?: number } })?.pagination,
+          });
         }
       }
 

--- a/server/worldmonitor/wildfire/v1/list-fire-detections.ts
+++ b/server/worldmonitor/wildfire/v1/list-fire-detections.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/wildfire/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { resolveFireDetectionTotalCount } from '../../../../src/services/wildfires/payload';
 import { limitFireDetectionsForDashboard } from '../../../../api/_wildfire-dashboard.js';
 export { WILDFIRE_DASHBOARD_DETECTION_LIMIT, limitFireDetectionsForDashboard } from '../../../../api/_wildfire-dashboard.js';
 
@@ -46,10 +47,14 @@ export const listFireDetections: WildfireServiceHandler['listFireDetections'] = 
     const rawDetections = result.fireDetections ?? [];
     const fireDetections = limitFireDetectionsForDashboard(rawDetections);
     const capped = fireDetections.length < rawDetections.length;
+    // The canonical key is itself capped at WILDFIRE_CANONICAL_DETECTION_LIMIT (#5866) and
+    // carries the pre-cap FIRMS total in `pagination`. Re-deriving the count from the array we
+    // received would silently report the seeder's cap as the number of fires burning.
+    const totalCount = resolveFireDetectionTotalCount({ fireDetections: rawDetections, pagination: result.pagination });
 
     return {
       fireDetections,
-      pagination: capped ? { nextCursor: '', totalCount: rawDetections.length } : result.pagination,
+      pagination: capped ? { nextCursor: '', totalCount } : result.pagination,
       fetchedAt: Number(result.fetchedAt || meta?.fetchedAt || 0),
       dataAvailable: true,
     };

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { __testing__ } from '../api/health.js';
 import { TEMPORAL_ANOMALIES_TTL } from '../server/worldmonitor/infrastructure/v1/_shared.ts';
+import { listTemporalAnomalies } from '../server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,5 +30,50 @@ describe('temporal anomalies cache freshness', () => {
     assert.match(src, /setCachedJson\(TEMPORAL_ANOMALIES_KEY, snapshot, TEMPORAL_ANOMALIES_TTL\)/);
     assert.match(src, /writeTemporalAnomaliesSeedMeta\(snapshot\)/);
     assert.match(src, /await refreshTemporalAnomaliesCacheHit\(cached\)/);
+  });
+
+  it('counts the pre-cap FIRMS total, not the capped canonical array (#5866)', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    // Stands in for the capped wildfire:fires:v1: seed-fire-detections publishes at most
+    // WILDFIRE_CANONICAL_DETECTION_LIMIT detections and records the real FIRMS count in
+    // `pagination`. Counting the array would report the cap as the fire volume.
+    const FIRMS_TOTAL = 21_600;
+    const firesPayload = {
+      fireDetections: Array.from({ length: 10 }, (_, index) => ({ id: `fire-${index}` })),
+      pagination: { nextCursor: '', totalCount: FIRMS_TOTAL },
+    };
+    // stdDev 100 around a mean of 1000: both the correct count (21,600) and the buggy one (10)
+    // clear the anomaly threshold, so the assertion below turns on currentCount alone.
+    const baseline = { mean: 1000, m2: 290_000, sampleCount: 30, lastUpdated: '' };
+
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = (async (input: unknown, init: { method?: string } = {}) => {
+      if (init.method === 'POST') return Response.json({ result: 'OK' }); // lock + every write
+      const key = decodeURIComponent(new URL(String(input)).pathname.replace('/get/', ''));
+      const value = key === 'wildfire:fires:v1'
+        ? firesPayload
+        : key.startsWith('baseline:v2:satellite_fires:global:')
+          ? baseline
+          : null; // no cached snapshot, no news payload
+      return Response.json({ result: value == null ? null : JSON.stringify(value) });
+    }) as typeof globalThis.fetch;
+
+    try {
+      const response = await listTemporalAnomalies({} as never, {});
+      const fires = response.anomalies.find((anomaly) => anomaly.type === 'satellite_fires');
+
+      assert.ok(fires, 'satellite_fires anomaly should be emitted');
+      assert.equal(fires.currentCount, FIRMS_TOTAL);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    }
   });
 });

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -11,6 +11,12 @@ import {
   limitFireDetectionsForDashboard,
 } from '../server/worldmonitor/wildfire/v1/list-fire-detections.ts';
 import { resolveFireDetectionTotalCount } from '../src/services/wildfires/payload.ts';
+import {
+  WILDFIRE_CANONICAL_DETECTION_LIMIT,
+  compactWildfireDashboardPayload,
+} from '../scripts/_wildfire-dashboard.mjs';
+import { MAX_PAYLOAD_BYTES } from '../scripts/_seed-utils.mjs';
+import { buildEnvelope } from '../scripts/_seed-envelope-source.mjs';
 import type { FireDetection } from '../src/generated/server/worldmonitor/wildfire/v1/service_server';
 
 const REGIONS = ['Ukraine', 'Russia', 'Iran', 'Israel/Gaza', 'Syria', 'Taiwan', 'North Korea', 'Saudi Arabia', 'Turkey'];
@@ -243,5 +249,180 @@ describe('wildfire dashboard payload cap', () => {
     assert.ok(Buffer.byteLength(full) > 600_000, 'fixture should represent the DebugBear payload-growth shape');
     assert.ok(Buffer.byteLength(compacted) < 160_000, `compacted payload is too large: ${Buffer.byteLength(compacted)} bytes`);
     assert.ok(gzipSync(compacted).byteLength < 20_000, `gzip payload is too large: ${gzipSync(compacted).byteLength} bytes`);
+  });
+});
+
+// The volume of the run that crashed seed-fire-detections (Railway deployment 8008ae7a,
+// 2026-07-30): 20,442 deduped VIIRS detections across 3 sources x 9 regions, every upstream
+// fetch OK. atomicPublish threw `Payload too large: 5.2MB > 5MB limit`, main().catch printed
+// FATAL and exited 1 — so nothing published and the 2h TTL was never extended.
+const FIRMS_PEAK_DETECTIONS = 20_442;
+
+// The canonical envelope must stay at or under 90% of the hard atomicPublish cap. This is the
+// headroom guard #5866 asks for: raising WILDFIRE_CANONICAL_DETECTION_LIMIT or widening
+// FireDetection turns the worst-case test below red in CI instead of crashing the seeder in
+// production.
+const CANONICAL_PAYLOAD_BYTE_BUDGET = Math.floor(MAX_PAYLOAD_BYTES * 0.9);
+
+const FIRMS_SATELLITES = ['N', 'N20', 'N21'];
+const FIRMS_CONFIDENCE = ['FIRE_CONFIDENCE_HIGH', 'FIRE_CONFIDENCE_NOMINAL', 'FIRE_CONFIDENCE_LOW'];
+
+/**
+ * A detection with production byte-width: FIRMS area/csv gives 5dp lat/lon and 2dp
+ * bright_ti4/frp, and seed-fire-detections derives `id` from those raw cells. Sized against
+ * the real incident — 20,442 of these serialize to ~5.2MB, matching the crash log.
+ */
+function firmsDetection(index: number): FireDetection {
+  const latitude = Math.round((48.90554 + (index % 1000) / 1e5) * 1e5) / 1e5;
+  const longitude = Math.round((37.55219 + (index % 997) / 1e5) * 1e5) / 1e5;
+  const brightness = Math.round((295.05 + (index % 12_000) / 100) * 100) / 100;
+  const frp = Math.round((1.06 + (index % 9000) / 100) * 100) / 100;
+  return {
+    id: `${latitude}-${longitude}-2026-07-30-${String(index % 2400).padStart(4, '0')}`,
+    location: { latitude, longitude },
+    brightness,
+    frp,
+    confidence: FIRMS_CONFIDENCE[index % FIRMS_CONFIDENCE.length]!,
+    satellite: FIRMS_SATELLITES[index % FIRMS_SATELLITES.length]!,
+    detectedAt: 1_785_416_460_000 + index * 1000,
+    region: REGIONS[index % REGIONS.length]!,
+    dayNight: index % 2 ? 'N' : 'D',
+    possibleExplosion: frp > 80 && brightness > 380,
+  };
+}
+
+/**
+ * The widest detection MONITORED_REGIONS can actually produce: Russia's bbox reaches 180E/82N
+ * (longest coordinate strings), 'Saudi Arabia' is the longest region name, and a FIRMS
+ * confidence code outside h/n/l maps to the longest enum member.
+ */
+function widestFirmsDetection(index: number): FireDetection {
+  const latitude = Math.round((81.99999 - (index % 1000) / 1e5) * 1e5) / 1e5;
+  const longitude = Math.round((179.99999 - (index % 997) / 1e5) * 1e5) / 1e5;
+  return {
+    id: `${latitude}-${longitude}-2026-07-30-${String(index % 2400).padStart(4, '0')}`,
+    location: { latitude, longitude },
+    brightness: 367.05,
+    frp: 1234.56,
+    confidence: 'FIRE_CONFIDENCE_UNSPECIFIED',
+    satellite: 'N21',
+    detectedAt: 1_785_416_460_000 + index * 1000,
+    region: 'Saudi Arabia',
+    dayNight: 'N',
+    possibleExplosion: true,
+  };
+}
+
+/** Serialized size of exactly what atomicPublish measures for wildfire:fires:v1. */
+function canonicalEnvelopeBytes(data: { fireDetections: FireDetection[] }): number {
+  return Buffer.byteLength(JSON.stringify(buildEnvelope({
+    fetchedAt: 1_785_416_460_000,
+    recordCount: data.fireDetections.length,
+    sourceVersion: 'VIIRS_SNPP_NRT+VIIRS_NOAA20_NRT+VIIRS_NOAA21_NRT',
+    schemaVersion: 1,
+    state: 'OK',
+    data,
+  })), 'utf8');
+}
+
+describe('canonical wildfire payload cap (#5866)', () => {
+  // One allocation shared by the tests below — 20k detections is ~8MB resident and test:data
+  // runs the whole tests/ tree in a single process.
+  const peakDetections = Array.from({ length: FIRMS_PEAK_DETECTIONS }, (_, index) => firmsDetection(index));
+
+  it('reproduces the crash: an uncapped peak-volume payload exceeds the atomicPublish cap', () => {
+    const uncapped = canonicalEnvelopeBytes({ fireDetections: peakDetections });
+
+    assert.ok(
+      uncapped > MAX_PAYLOAD_BYTES,
+      `fixture must reproduce the 5.2MB > 5MB crash, got ${(uncapped / 1024 / 1024).toFixed(2)}MB`,
+    );
+  });
+
+  it('caps the published payload under the atomicPublish limit and keeps the true total', () => {
+    const capped = compactWildfireDashboardPayload(
+      { fireDetections: peakDetections, pagination: undefined },
+      WILDFIRE_CANONICAL_DETECTION_LIMIT,
+    );
+    const bytes = canonicalEnvelopeBytes(capped);
+
+    assert.equal(capped.fireDetections.length, WILDFIRE_CANONICAL_DETECTION_LIMIT);
+    assert.deepEqual(capped.pagination, { nextCursor: '', totalCount: FIRMS_PEAK_DETECTIONS });
+    assert.ok(
+      bytes <= CANONICAL_PAYLOAD_BYTE_BUDGET,
+      `capped payload ${(bytes / 1024 / 1024).toFixed(2)}MB exceeds the ${(CANONICAL_PAYLOAD_BYTE_BUDGET / 1024 / 1024).toFixed(2)}MB budget`,
+    );
+  });
+
+  it('holds the byte budget at the cap even for the widest detections FIRMS can emit', () => {
+    const widest = Array.from({ length: WILDFIRE_CANONICAL_DETECTION_LIMIT }, (_, index) => widestFirmsDetection(index));
+    const bytes = canonicalEnvelopeBytes({ fireDetections: widest });
+
+    assert.ok(
+      bytes <= CANONICAL_PAYLOAD_BYTE_BUDGET,
+      `a full cap of widest-case detections serializes to ${(bytes / 1024 / 1024).toFixed(2)}MB, over the ${(CANONICAL_PAYLOAD_BYTE_BUDGET / 1024 / 1024).toFixed(2)}MB budget — lower WILDFIRE_CANONICAL_DETECTION_LIMIT or shrink FireDetection`,
+    );
+    assert.ok(CANONICAL_PAYLOAD_BYTE_BUDGET < MAX_PAYLOAD_BYTES, 'budget must leave headroom under the hard cap');
+  });
+
+  it('leaves the bootstrap top-500 identical to the uncapped selection', () => {
+    const capped = compactWildfireDashboardPayload(
+      { fireDetections: peakDetections, pagination: undefined },
+      WILDFIRE_CANONICAL_DETECTION_LIMIT,
+    );
+
+    // runSeed feeds extraKey transforms the RAW fetcher output, so the bootstrap key still
+    // ranks over all 20,442. Capping the canonical by the same comparator must not be able to
+    // change what the dashboard shows even if that ever stops being true.
+    assert.deepEqual(
+      limitFireDetectionsForDashboard(capped.fireDetections).map((detection) => detection.id),
+      limitFireDetectionsForDashboard(peakDetections).map((detection) => detection.id),
+    );
+  });
+
+  it('passes the pre-cap total through the RPC canonical fallback', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const canonical = compactWildfireDashboardPayload(
+      { fireDetections: peakDetections, pagination: undefined },
+      WILDFIRE_CANONICAL_DETECTION_LIMIT,
+    );
+
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = async (input) => {
+      const key = decodeURIComponent(new URL(String(input)).pathname.replace('/get/', ''));
+      const value = key === 'wildfire:fires:v1'
+        ? { ...canonical, dataAvailable: true }
+        : key === 'seed-meta:wildfire:fires'
+          ? { fetchedAt: 1_785_416_460_000 }
+          : null;
+      return Response.json({ result: value == null ? null : JSON.stringify(value) });
+    };
+
+    try {
+      const response = await listFireDetections({} as never, {});
+
+      assert.equal(response.fireDetections.length, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
+      // Not WILDFIRE_CANONICAL_DETECTION_LIMIT — the seeder already dropped detections, so the
+      // count the RPC reports must be the FIRMS total, not what survived the cap.
+      assert.deepEqual(response.pagination, { nextCursor: '', totalCount: FIRMS_PEAK_DETECTIONS });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    }
+  });
+
+  it('wires the canonical cap into the seeder publish path', () => {
+    const seeder = readFileSync(new URL('../scripts/seed-fire-detections.mjs', import.meta.url), 'utf8');
+
+    // publishTransform (not fetchAllRegions) is the required seam: runSeed feeds extraKey
+    // transforms the RAW fetcher output, so capping there keeps the bootstrap top-500 intact.
+    assert.match(seeder, /publishTransform\s*:/);
+    assert.match(seeder, /WILDFIRE_CANONICAL_DETECTION_LIMIT/);
   });
 });

--- a/tests/wildfire-payload-cap.test.mts
+++ b/tests/wildfire-payload-cap.test.mts
@@ -15,8 +15,8 @@ import {
   WILDFIRE_CANONICAL_DETECTION_LIMIT,
   compactWildfireDashboardPayload,
 } from '../scripts/_wildfire-dashboard.mjs';
-import { MAX_PAYLOAD_BYTES } from '../scripts/_seed-utils.mjs';
-import { buildEnvelope } from '../scripts/_seed-envelope-source.mjs';
+import { MAX_PAYLOAD_BYTES, runSeed } from '../scripts/_seed-utils.mjs';
+import { buildEnvelope, unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
 import type { FireDetection } from '../src/generated/server/worldmonitor/wildfire/v1/service_server';
 
 const REGIONS = ['Ukraine', 'Russia', 'Iran', 'Israel/Gaza', 'Syria', 'Taiwan', 'North Korea', 'Saudi Arabia', 'Turkey'];
@@ -424,5 +424,103 @@ describe('canonical wildfire payload cap (#5866)', () => {
     // transforms the RAW fetcher output, so capping there keeps the bootstrap top-500 intact.
     assert.match(seeder, /publishTransform\s*:/);
     assert.match(seeder, /WILDFIRE_CANONICAL_DETECTION_LIMIT/);
+  });
+
+  it('executes the runSeed publish seam with capped canonical and raw bootstrap inputs', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalExit = process.exit;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const values = new Map<string, string>();
+    const canonicalKey = 'test:wildfire:fires:v1';
+    const bootstrapKey = 'test:wildfire:fires-bootstrap:v1';
+
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      const body = init?.body == null ? null : JSON.parse(String(init.body));
+      calls.push({ url, body });
+
+      if (url.endsWith('/pipeline')) {
+        return Response.json(Array.isArray(body) ? body.map(() => ({ result: 1 })) : []);
+      }
+      if (url.includes('/get/')) {
+        const key = decodeURIComponent(url.slice(url.indexOf('/get/') + 5));
+        return Response.json({ result: values.get(key) ?? null });
+      }
+      if (Array.isArray(body)) {
+        if (body[0] === 'SET' && typeof body[1] === 'string') values.set(body[1], body[2]);
+        if (body[0] === 'DEL' && typeof body[1] === 'string') values.delete(body[1]);
+      }
+      return Response.json({ result: 'OK' });
+    };
+    process.exit = ((code = 0) => {
+      const error = new Error(`__test_exit__:${code}`) as Error & { exitCode: number };
+      error.exitCode = code;
+      throw error;
+    }) as typeof process.exit;
+
+    try {
+      let exitCode: number | null = null;
+      try {
+        await runSeed(
+          'test',
+          'wildfire-publish-seam',
+          canonicalKey,
+          async () => ({ fireDetections: peakDetections, pagination: undefined, dataAvailable: true }),
+          {
+            validateFn: (data) => Array.isArray(data?.fireDetections) && data.fireDetections.length > 0,
+            ttlSeconds: 3600,
+            publishTransform: (data) => compactWildfireDashboardPayload(data, WILDFIRE_CANONICAL_DETECTION_LIMIT),
+            extraKeys: [{ key: bootstrapKey, transform: compactWildfireDashboardPayload }],
+            declareRecords: (data) => data.fireDetections.length,
+            sourceVersion: 'wildfire-test',
+            schemaVersion: 1,
+            maxStaleMin: 1440,
+          },
+        );
+      } catch (error) {
+        if (String((error as Error).message).startsWith('__test_exit__:')) {
+          exitCode = (error as Error & { exitCode: number }).exitCode;
+        } else {
+          throw error;
+        }
+      }
+
+      assert.equal(exitCode, 0, 'runSeed should publish successfully');
+
+      const lastSet = (key: string) => {
+        const matching = calls.filter((call) => {
+          const body = call.body;
+          return Array.isArray(body) && body[0] === 'SET' && body[1] === key;
+        });
+        assert.ok(matching.length > 0, `expected a SET for ${key}`);
+        return JSON.parse(String((matching.at(-1)!.body as unknown[])[2]));
+      };
+      const canonicalEnvelope = lastSet(canonicalKey);
+      const bootstrapEnvelope = lastSet(bootstrapKey);
+      const canonical = unwrapEnvelope(canonicalEnvelope).data;
+      const bootstrap = unwrapEnvelope(bootstrapEnvelope).data;
+
+      assert.equal(canonical.fireDetections.length, WILDFIRE_CANONICAL_DETECTION_LIMIT);
+      assert.deepEqual(canonical.pagination, { nextCursor: '', totalCount: FIRMS_PEAK_DETECTIONS });
+      assert.equal(bootstrap.fireDetections.length, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
+      assert.deepEqual(bootstrap.pagination, { nextCursor: '', totalCount: FIRMS_PEAK_DETECTIONS });
+      assert.equal(canonicalEnvelope._seed.recordCount, WILDFIRE_CANONICAL_DETECTION_LIMIT);
+      assert.equal(bootstrapEnvelope._seed.recordCount, WILDFIRE_DASHBOARD_DETECTION_LIMIT);
+      assert.ok(
+        Buffer.byteLength(JSON.stringify(canonicalEnvelope), 'utf8') <= CANONICAL_PAYLOAD_BYTE_BUDGET,
+        'the real canonical publish must stay under the byte budget',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.exit = originalExit;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    }
   });
 });


### PR DESCRIPTION
Fixes #5866.

## The crash

`seed-fire-detections` exited FATAL at publish on a run where **every upstream fetch succeeded** (27/27 sources ok, 0 failed). `fetchAllRegions` accumulates every deduped VIIRS detection with no cap; at the 2026-07-30 peak of 20,442 detections the envelope serialized to 5.2MB and `atomicPublish` hard-throws above `MAX_PAYLOAD_BYTES` (5MB). The throw escapes to `main().catch` — **exit 1, nothing published, TTL never extended** — and the deliberately short 2h TTL (below the 6h health gate, on purpose) then expires the key.

This also cascades: `seed-thermal-escalation` reads `wildfire:fires:v1`, so an expired canonical key makes it publish an empty escalation watch.

## The fix

A `publishTransform` capped at `WILDFIRE_CANONICAL_DETECTION_LIMIT = 15_000`, ranked by the comparator the dashboard already uses (`possibleExplosion` -> confidence -> brightness -> frp -> detectedAt), with the true pre-cap FIRMS count recorded in `pagination.totalCount` and the drop count logged.

**Why `publishTransform` and not `fetchAllRegions`:** `runSeed` feeds extraKey transforms the RAW fetcher output, not `publishData`. Capping at the publish seam means the bootstrap key still ranks its top-500 over every detection FIRMS returned, so the dashboard is untouched. Capping inside the fetcher would not have that property.

**Why 15,000** — sized from measured bytes, not guessed. A FIRMS-shaped detection serializes to ~270B (the model reproduces the incident: 20,442 x 270B = 5.26MB vs the logged 5.2MB); the widest one `MONITORED_REGIONS` can emit (180E/82N coordinates, `Saudi Arabia`, `FIRE_CONFIDENCE_UNSPECIFIED`) is ~288B. 15,000 x 288B = 4.1MB, ~21% under the cap in the worst case. A test pins the budget at 90% of `MAX_PAYLOAD_BYTES`, so raising the limit or widening `FireDetection` goes red in CI instead of crashing the seeder in production.

Raising `MAX_PAYLOAD_BYTES` was not considered — it is a fleet-wide cap and the growth here is unbounded.

## Two read paths that would have reported the cap as the fire volume

Both now resolve through the existing `resolveFireDetectionTotalCount`:

- `listFireDetections` re-derived `totalCount` from the array it received, so the canonical-fallback path would have reported 15,000 fires instead of 21,600.
- `listTemporalAnomalies` counted `fireDetections.length` for its z-score baseline. Left alone, that saturates at the cap and reads **"normal" during a record fire season** — an alarm going green while the world burns.

## Verification

Bug Fix Protocol: failing test before the fix. Reds observed were `totalCount: 15000` vs expected `21600` (RPC passthrough) and the unwired seeder guard.

**End-to-end, real seeder against a stubbed FIRMS + Redis at 21,600 detections:**

| | before | after |
|---|---|---|
| exit code | `1` (`FATAL: Payload too large: 5.5MB > 5MB limit`) | `0` |
| canonical key | **never written** | 3.82MB, 15,000 detections |
| `pagination.totalCount` | — | 21,600 (true pre-cap count) |
| bootstrap key | never written | 500 detections, all present in the capped canonical |

**Mutation-tested** (each reverted from a file copy, then restored): unwiring `publishTransform` -> wiring test red; raising the limit to 25,000 -> both byte-budget tests red; reverting the temporal-anomalies count -> red with `actual: 10, expected: 21600`.

**Gates:** `typecheck`, `typecheck:api`, `lint:boundaries`, biome, edge esbuild bundle (48 entries) all clean. Full `test:data` equivalent run in 4 sequential chunks: **19,365 tests, 0 failures**.

## Known effects

- On peak days ~26% of the lowest-signal detections are dropped from the canonical key (logged per run). The dashboard is unaffected (it renders 500). CII fire scoring and thermal-escalation clustering see fewer low-signal observations — strictly better than today, where they see nothing at all once the seeder crashes.
- Considered and rejected as insufficient: rounding lat/lon to 4dp saves only 4B/record (1.5%, measured), and omitting `possibleExplosion: false` saves 25B/record (9%) but changes the payload shape. Neither removes the need for a bound.

https://claude.ai/code/session_01BBAumpUmJ7VLm4h6ybY62y