### PR TITLE
fix(markets): classify each prediction market into exactly one pool (#5733)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -112,6 +112,14 @@ A term — an ordinary word, a vulnerability identifier, or a threat-group desig
 
 The stretch of time a derived statistic was *actually* computed over, as distinct from the retention horizon of the store it drew from. The two diverge whenever a bounded read — a row cap, a page size, a top-N — returns fewer rows than the horizon contains, and the divergence is silent: the read succeeds, the arithmetic runs, and only the result is wrong. Any rate, baseline, or per-unit-time figure must be divided by the span its rows demonstrably cover, and a consumer-facing statistic should report that measured span rather than the horizon constant, since a caller has no other way to tell the two apart. Truncation is also biased rather than random — a newest-first read starves the historical side of a recent-versus-baseline comparison, an oldest-first read starves the recent side. See also: Story Accumulator, Keyword Spike.
 
+## Prediction Markets
+
+### Market Pool
+
+One of the named category buckets a published prediction-market payload is divided into — geopolitical, tech, finance — where every market belongs to exactly one.
+
+The pools are a *partition*, not a set of overlapping views: membership is a single primary category assigned by a fixed precedence, so no market appears twice and no market is dropped. That property is load-bearing rather than incidental, because every consumer selects a pool **by name** — a site variant, an agent-facing category argument, a prompt builder — and a pool that quietly contains everything makes all of those selections meaningless while still looking healthy. Precedence, not tag exclusivity, is what resolves a market carrying signals from several categories; reordering the categories therefore moves real markets between pools. The complete set of markets is deliberately *not* a pool: a reader wanting every market asks for the union explicitly, because reaching for a single pool to mean "all" is only ever correct by accident. See also: Seed-Owned Key.
+
 ## MCP & Agent Discovery
 
 ### MCP Server Card
@@ -253,3 +261,7 @@ Provenance is what makes staleness detectable at all: a translation whose record
 A translated value whose English source has changed since the translation was made.
 
 Distinct from a *missing* translation, which has no value at all, and from an *orphaned* one, which is a value the current English no longer has a key for. The distinction is load-bearing because only the stale class is fixable by retranslation — no translation of a source string that no longer exists can be correct, so orphans must be pruned instead. Inserting an element into an English list makes every later entry stale at once, since each index then points at a different source string; removing the last element produces an orphan instead, leaving every earlier index matching so nothing registers as stale. See also: Translation Provenance.
+
+## Flagged ambiguities
+
+- *"Pool"* had been used for both a labelled market category and the complete set of markets — these are distinct. A pool is always a labelled subset; the complete set has no pool and must be requested as an explicit union.

--- a/api/health.js
+++ b/api/health.js
@@ -390,7 +390,7 @@ const SEED_META = {
   hkoWarnings:      { key: 'seed-meta:weather:hko-warnings',    maxStaleMin: 540 }, // successful HKO responses publish a snapshot even when no tropical-cyclone warning is active.
   flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 90 }, // CACHE_TTL=7200s; matches notamClosures from same cron
   notamClosures:    { key: 'seed-meta:aviation:notam',          maxStaleMin: 240 }, // 2h interval; 240min = 2x interval
-  predictionMarkets: { key: 'seed-meta:prediction:markets',     maxStaleMin: 90 },
+  predictionMarkets: { key: 'seed-meta:prediction:markets',     maxStaleMin: 90, minRecordCount: 20 }, // #5733: declareRecords now counts DISTINCT markets (it triple-counted across the pre-partition near-duplicate pools, reporting ~75 for 46 real markets), so a volume collapse is finally measurable. Floor is deliberately well under the ~46 steady state and well over a broken run — the publish gate only catches mislabeling, so without this a run that shrinks every pool while each stays non-empty stays GREEN.
   newsInsights:     { key: 'seed-meta:news:insights',           maxStaleMin: 30 },
   // #4920: daily GH Actions cadence; 2880 = 2x — one fully missed day alarms
   newsFeedHealth:   { key: 'seed-meta:news:feed-health',        maxStaleMin: 2880 },

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -89,7 +89,7 @@ const SEED_DOMAINS = {
   'supply_chain:chokepoints': { key: 'seed-meta:supply_chain:chokepoints', intervalMin: 30 },
   'cable-health':             { key: 'seed-meta:cable-health',             intervalMin: 30 },
   'infrastructure:submarine-cables': { key: 'seed-meta:infrastructure:submarine-cables', intervalMin: 12600 },
-  'prediction:markets':       { key: 'seed-meta:prediction:markets',       intervalMin: 8 },
+  'prediction:markets':       { key: 'seed-meta:prediction:markets',       intervalMin: 8, minRecordCount: 20 }, // minRecordCount mirrors api/health.js (#5733)
   'aviation:intl':            { key: 'seed-meta:aviation:intl',            intervalMin: 45 }, // intervalMin*2 = 90min staleness. seed-aviation's freshness gate (AVIATIONSTACK_MIN_REFRESH_MIN, default 55) lets fetchedAt age to ~55+cron between paid fetches; 90min matches the aviation:faa sibling + api/health.js intlDelays maxStaleMin:90. Was 15 (30min) and false-WARNed every cycle once the gate landed.
   'theater-posture':          { key: 'seed-meta:theater-posture',          intervalMin: 8 },
   'economic:worldbank-techreadiness': { key: 'seed-meta:economic:worldbank-techreadiness:v1', intervalMin: 5040 },

--- a/docs/solutions/logic-errors/catch-all-pool-becoming-a-real-partition-silently-narrows-consumers.md
+++ b/docs/solutions/logic-errors/catch-all-pool-becoming-a-real-partition-silently-narrows-consumers.md
@@ -1,0 +1,159 @@
+---
+module: prediction-markets
+date: 2026-07-30
+problem_type: logic_error
+component: service_object
+severity: high
+symptoms:
+  - "A producer published three labelled pools that were near-duplicates of each other — 75 records covering only 46 distinct markets"
+  - "The pool named 'geopolitical' was topped by a Fed-rates market at $45.6M while genuine geopolitics sat below it"
+  - "Downstream consumers that selected a pool by name were reading meaningless labels, with no test or health signal failing"
+root_cause: logic_error
+resolution_type: code_fix
+related_components:
+  - forecast-engine
+  - mcp-tools
+tags:
+  - classification
+  - partition
+  - catch-all
+  - consumer-enumeration
+  - seeder
+  - prediction-markets
+---
+
+# A catch-all pool that becomes a real partition silently narrows every consumer that used it as "all"
+
+## Problem
+
+`scripts/seed-prediction-markets.mjs` published `prediction:markets-bootstrap:v1` as three
+labelled pools — `geopolitical`, `tech`, `finance`. They were built as three *independent*
+filters over one candidate array, and the first took no predicate at all:
+
+```js
+const geopolitical = filterAndScore(markets, null);                                        // NO filter
+const tech         = filterAndScore(markets, m => m.tags?.some(t => TECH_TAGS.includes(t)));
+const finance      = filterAndScore(markets, m => m.source === 'kalshi' || m.tags?.some(t => FINANCE_TAGS.includes(t)));
+```
+
+Because the fetch tag list is the **union** of all three domains, `filterAndScore(markets, null)`
+made `geopolitical` a copy of everything fetched. The `tech` and `finance` tag lists separately
+shared `economy`, `crypto`, and `business`, so those two overlapped as well.
+
+Fixing that is easy. The expensive part is what fixing it *does to everyone downstream*.
+
+## Symptoms
+
+Measured against the live envelope on 2026-07-30:
+
+| | before |
+|---|---|
+| records published | 75 |
+| distinct markets | 46 |
+| duplicate records | 29 (39%) |
+| non-geopolitical titles in the "geopolitical" pool | 12 of 25 |
+| top of the geopolitical pool by volume | *"Will no Fed rate cuts happen in 2026?"* ($45.6M) |
+
+Nothing was red. No test failed, no health check fired — the seeder was fresh and publishing,
+it was just publishing meaningless labels.
+
+## What Didn't Work
+
+**Enumerating consumers by grepping the obvious directories.** The initial sweep searched
+`src/`, `server/`, and `api/` for readers of the pool keys and found five, all of which the
+fix handled. It missed three more in `scripts/`, because a seeder reading another seeder's
+output is not where you look for "consumers of an API". Adversarial review found them:
+
+- `seed-forecasts.mjs` → `detectFromPredictionMarkets`
+- `seed-forecasts.mjs` → `calibrateWithMarkets`
+- `_forecast-resolution.mjs` → the title→endDate settlement index
+
+All three read `.geopolitical` as a stand-in for "all markets" — correct while it *was* all
+markets, silently wrong the moment it became a real partition. They would have lost every
+macro, rates, crypto and AI anchor, degrading the exact calibration slice the fix existed to
+unblock.
+
+**Trusting the existing test suite to catch it.** Those three consumers had tests. Every one
+built its fixture as `{ geopolitical: [...] }` — mirroring the old catch-all shape — so the
+regression passed green. A fixture that encodes the buggy assumption cannot detect the bug.
+
+## Solution
+
+Assign exactly one primary category per record by explicit precedence, then treat every
+whole-universe read as a distinct concern from a pool read.
+
+```js
+// One primary category, precedence-ordered. Disjoint tag lists mean no single TAG maps to
+// two categories — but a market routinely carries tags from several lists, so the ORDER is
+// load-bearing, not a tie-breaker.
+export function classifyMarket(market) {
+  if (isGeopoliticalMarket(market?.title) || hasCategoryTag(market?.tags, 'geopolitical')) return 'geopolitical';
+  if (hasCategoryTag(market?.tags, 'tech')) return 'tech';
+  if (hasCategoryTag(market?.tags, 'finance')) return 'finance';
+  return DEFAULT_CATEGORY;
+}
+
+// The named alternative to `payload.geopolitical` for whole-universe reads.
+export function allBootstrapMarkets(payload) {
+  return [payload?.geopolitical, payload?.tech, payload?.finance].filter(Array.isArray).flat();
+}
+```
+
+The `allBootstrapMarkets` helper is the load-bearing part of the fix, not the classifier.
+It gives the three forecast consumers a name for what they actually wanted, so the next
+person cannot reach for `.geopolitical` and accidentally mean "everything".
+
+Opened as PR #5872 against issue #5733; unmerged as of this writing.
+
+## Why This Works
+
+The bug is not "the predicate was `null`". It is that **one field was serving two contracts**:
+a *label* ("these are the geopolitical markets") and a *catch-all* ("these are all the
+markets"). Both were satisfied while the pool was unfiltered, so nothing distinguished the
+consumers relying on each. Splitting the contracts — one pool per label, one named helper for
+the universe — makes the two reads impossible to confuse.
+
+That is also why the fix's blast radius is entirely downstream: correcting the *label* is a
+one-line change, and every bug it exposed was a consumer that had quietly been depending on
+the *catch-all*.
+
+## Prevention
+
+**When a field stops being a superset, enumerate its readers before you change it.** The
+search is for the semantic role, not the identifier — and it must cover every directory that
+can read the value, including sibling scripts and seeders, not just the app tiers:
+
+```bash
+# Not just src/ server/ api/ — a seeder reading another seeder's output is still a consumer.
+grep -rn "\.geopolitical" --include=*.mjs --include=*.ts --include=*.tsx . | grep -v node_modules
+```
+
+**Ask of each reader: does it want this LABEL, or does it want EVERYTHING?** Readers wanting
+"everything" get the explicit union helper. Readers wanting the label keep the pool. A reader
+you cannot classify is the one to investigate, not the one to skip.
+
+**Distrust green tests whose fixtures encode the old shape.** Before believing a consumer is
+unaffected, mutate it: revert the consumer to the old read and confirm its test goes red.
+
+```js
+// Guards the union. Reverting this consumer to `.geopolitical` turns the suite red.
+it('calibrates from an anchor that lives in the finance pool, not geopolitical', () => {
+  calibrateWithMarkets([pred], {
+    geopolitical: [],
+    tech: [],
+    finance: [{ title: 'US recession by end of 2026?', yesPrice: 30, source: 'polymarket', volume: 50000 }],
+  });
+  assert.ok(pred.calibration !== null, 'a finance-pool market must still calibrate');
+});
+```
+
+**Watch for the same trap in the deploy window.** A cached envelope keeps the *old* semantics
+for its TTL after the new code ships, so a consumer rewritten to union the pools will
+double- or triple-count while the pre-fix payload is still served. Dedupe the union rather
+than assuming the payload matches the code that reads it.
+
+**A self-consistency check is not a correctness check.** The integrity gate added here
+re-runs the same classifier that built the partition, so it catches a regression in the
+pipeline *shape* but can never tell you the taxonomy is right — an empty or misfiled pool is
+trivially self-consistent. Say so in the code, or the next reader will over-trust a green
+gate. Independent ground truth has to come from fixtures with hand-verified expected values.

--- a/scripts/_bet-templates-markets-classify.mjs
+++ b/scripts/_bet-templates-markets-classify.mjs
@@ -3,10 +3,33 @@
 // bet-family is split into a dedicated geopolitical slice (long horizon, top
 // ensemble priority) and a general slice — and the split is driven by the
 // market TEXT, deliberately NOT by the bootstrap feed's geopolitical/tech/
-// finance pools. Those pools are unreliable: the same market appears in all
-// three and the "geopolitical" pool is dominated by crypto/finance titles
-// (#5733). Classifying from the title keeps this robust to the broken producer
-// labels.
+// finance pools.
+//
+// Originally that was a workaround: the pools were near-duplicates and the
+// "geopolitical" pool was dominated by crypto/finance titles. The producer now
+// assigns exactly one primary pool per market (see _prediction-classify.mjs,
+// which reuses isGeopoliticalMarket below as its title signal), so the labels
+// are trustworthy — but the bet families still classify from the title, for two
+// reasons that outlive the fix:
+//   1. the feed's 3h TTL means a pre-fix payload can still be served for hours
+//      after a deploy, and the partition must not depend on when Redis last
+//      refreshed;
+//   2. the two families read the UNION of all three pools anyway (they need
+//      every market, partitioned by their own horizon), so pool membership is
+//      not the axis they split on.
+//
+// THE TWO CLASSIFICATIONS ARE NOT IDENTICAL, and that is deliberate. The
+// producer treats a market as geopolitical when the TITLE matches (this
+// predicate) OR the venue tags do; the bet families use the title signal only.
+// So a market that is geopolitical purely by tag — "Will AfD win the most seats
+// in the 2026 Berlin state elections?" (tags: elections/global-elections/
+// world-elections), or a bilateral trade-deal line tagged `geopolitics` — lands
+// in the producer's geopolitical POOL but in the GENERAL bet family, not the
+// long-horizon geo one. That is an accepted consequence of this predicate being
+// precision-first (a false geo tag would steal a flagship ensemble slot, which
+// is worse than a missed one), not a bug to fix by importing the tag rescue.
+// What the shared predicate does guarantee is that the two can never disagree
+// about a TITLE — the axis both actually key on.
 //
 // Precision over recall: a FALSE geopolitical tag pollutes the flagship slice
 // (a company/crypto market stealing a geo ensemble slot), which is worse than a

--- a/scripts/_forecast-resolution.mjs
+++ b/scripts/_forecast-resolution.mjs
@@ -306,7 +306,18 @@ function getInputsIndex(inputs) {
   // truncated title lets the lookup be an exact Map.get on pred.title, which
   // subsumes the exact + prefix match cases (FIX 7). First writer wins.
   const endDateByTitle = new Map();
-  const markets = inputs.predictionMarkets?.geopolitical || [];
+  // All three pools (#5733): settlement endDates must be resolvable for every
+  // market-anchored forecast, not just the geopolitical ones. Reading only
+  // `.geopolitical` was equivalent to "all markets" until the producer's pools
+  // became a disjoint partition. Inlined rather than importing
+  // allBootstrapMarkets from _prediction-classify.mjs so this module stays
+  // import-free (see the header contract); tests/forecast-resolution.test.mjs
+  // pins that both this and seed-forecasts read all three pools.
+  const markets = [
+    inputs.predictionMarkets?.geopolitical,
+    inputs.predictionMarkets?.tech,
+    inputs.predictionMarkets?.finance,
+  ].filter(Array.isArray).flat();
   for (const m of markets) {
     const mt = String(m?.title ?? '');
     if (!mt) continue;

--- a/scripts/_prediction-classify.mjs
+++ b/scripts/_prediction-classify.mjs
@@ -1,0 +1,301 @@
+// Primary-category classification for prediction-market records (#5733).
+//
+// THE BUG THIS REPLACES. seed-prediction-markets used to build its three pools
+// as three independent filters over the SAME candidate list:
+//
+//   geopolitical = filterAndScore(markets, null)                      // no filter at all
+//   tech         = filterAndScore(markets, m => m.tags ∈ TECH_TAGS)
+//   finance      = filterAndScore(markets, m => kalshi || tags ∈ FINANCE_TAGS)
+//
+// so `geopolitical` was an unfiltered copy of every market fetched (the fetch
+// tag list is the UNION of all three domains), and the tech/finance tag lists
+// shared `economy`, `crypto`, and `business`. The pools came out as near-
+// duplicates: production on 2026-07-30 published 75 records covering only 46
+// distinct markets, with a Fed-rates market at $45.6M sitting at the top of the
+// "geopolitical" pool while the genuine Iran/Ukraine/Taiwan lines were buried.
+// Because every consumer picks ONE pool by name — the RPC (site variant), the
+// MCP `category` argument, the deduct-situation prompt builder — the labels were
+// load-bearing and meaningless at the same time.
+//
+// THE MODEL. Each market gets exactly ONE primary category, decided by a fixed
+// precedence: geopolitical, then tech, then finance. Precedence (rather than
+// three independent predicates) is what makes the pools disjoint by
+// construction, and the tag lists in prediction-tags.json `classify` are kept
+// mutually disjoint so precedence never silently decides a coin-flip.
+//
+// WHY GEOPOLITICAL IS FIRST, AND WHY IT READS BOTH TITLE AND TAGS.
+// WorldMonitor's identity is geopolitical intelligence, so a genuine geo market
+// must never be filed elsewhere. The two signals cover each other's blind spots:
+//   - the TITLE matcher (isGeopoliticalMarket, shared with the bet families) is
+//     precision-first and deliberately misses e.g. "Berlin state elections",
+//     but it is the ONLY signal for Kalshi records, which always ship tags: [].
+//   - the venue TAGS catch what the title matcher declines to guess, but only
+//     for Polymarket.
+// `politics` is deliberately NOT a geo tag: Polymarket puts it on crypto
+// legislation ("Clarity Act") and any market a US politician appears in. The geo
+// tag list sticks to statecraft / conflict / national-election vocabulary.
+//
+// WHY FINANCE IS THE DEFAULT. Something has to own the untagged tail, which in
+// practice is every Kalshi record whose title is not geopolitical. Finance was
+// already that bucket (the old `source === 'kalshi'` rule), so defaulting there
+// keeps those records where consumers already found them; what changes is that
+// a Kalshi record with a geopolitical title (a next-Prime-Minister-of-Israel
+// line) is now correctly promoted to the geo pool instead.
+
+import { isGeopoliticalMarket } from './_bet-templates-markets-classify.mjs';
+import { filterAndScore } from './_prediction-scoring.mjs';
+import predictionTags from './data/prediction-tags.json' with { type: 'json' };
+
+// Canonical pool names, in precedence order. Also the MCP tool's `category`
+// enum and the bootstrap payload's top-level keys — do not reorder casually.
+export const CATEGORIES = Object.freeze(['geopolitical', 'tech', 'finance']);
+
+// Pool that owns records matching no category tag (see header).
+export const DEFAULT_CATEGORY = 'finance';
+
+const CLASSIFY_TAGS = Object.freeze(Object.fromEntries(
+  CATEGORIES.map((category) => [
+    category,
+    new Set((predictionTags.classify?.[category] ?? []).map((tag) => String(tag).toLowerCase())),
+  ]),
+));
+
+// Venue tag slugs are not case-normalized upstream — Polymarket ships both
+// `interest-rates` and `Global-Rates` — so compare lowercased and trimmed.
+export function normalizeTags(tags) {
+  if (!Array.isArray(tags)) return [];
+  const out = [];
+  for (const tag of tags) {
+    if (typeof tag !== 'string') continue;
+    const slug = tag.trim().toLowerCase();
+    if (slug) out.push(slug);
+  }
+  return out;
+}
+
+export function hasCategoryTag(tags, category) {
+  const slugs = CLASSIFY_TAGS[category];
+  if (!slugs) return false;
+  return normalizeTags(tags).some((tag) => slugs.has(tag));
+}
+
+// The single primary category for one raw market record. Pure and total: any
+// input, including junk, resolves to exactly one member of CATEGORIES.
+export function classifyMarket(market) {
+  const title = market?.title;
+  const tags = market?.tags;
+  if (isGeopoliticalMarket(typeof title === 'string' ? title : '') || hasCategoryTag(tags, 'geopolitical')) {
+    return 'geopolitical';
+  }
+  if (hasCategoryTag(tags, 'tech')) return 'tech';
+  if (hasCategoryTag(tags, 'finance')) return 'finance';
+  return DEFAULT_CATEGORY;
+}
+
+// Every market in a published bootstrap payload, across all three pools.
+//
+// USE THIS, NOT `payload.geopolitical`, for any whole-universe read. Before
+// #5733 the geopolitical pool WAS every market, so several consumers used it as
+// a cheap stand-in for "all markets" — scripts/seed-forecasts.mjs's
+// detectFromPredictionMarkets and calibrateWithMarkets, and
+// scripts/_forecast-resolution.mjs's title->endDate settlement index. Now that
+// the pools are a disjoint partition, `payload.geopolitical` means only
+// geopolitical, and those readers would silently lose every macro, rates,
+// crypto, and AI market. One helper so they cannot drift apart again.
+export function allBootstrapMarkets(payload) {
+  return [payload?.geopolitical, payload?.tech, payload?.finance]
+    .filter(Array.isArray)
+    .flat();
+}
+
+// Split candidates into the three disjoint pools. Every valid record lands in
+// exactly one; nothing is duplicated and nothing is dropped.
+export function partitionMarkets(markets) {
+  const pools = { geopolitical: [], tech: [], finance: [] };
+  if (!Array.isArray(markets)) return pools;
+  for (const market of markets) {
+    if (!market || typeof market !== 'object') continue;
+    pools[classifyMarket(market)].push(market);
+  }
+  return pools;
+}
+
+// Stable identity for duplicate detection. The venue url is the real key (the
+// bet families derive their slug from it); title is the fallback so a record
+// with an unusable url still participates in the check.
+//
+// "Unusable" matters more than it looks: both producer paths build the url from
+// a template (`.../event/${event.slug}`, `.../markets/${topMarket.ticker}`), so a
+// missing slug/ticker yields the literal string ".../undefined" — identical for
+// every such record. Keying on that would collapse unrelated markets onto one
+// identity and silently drop all but one of them. Fall back to the title
+// instead, which still distinguishes them.
+const DEGENERATE_SLUGS = new Set(['undefined', 'null', 'nan', '']);
+
+export function marketIdentity(market) {
+  const url = String(market?.url ?? '').trim();
+  if (url) {
+    const slug = url.split(/[?#]/)[0].replace(/\/+$/, '').split('/').pop() ?? '';
+    if (!DEGENERATE_SLUGS.has(slug.toLowerCase())) return `url:${url}`;
+  }
+  return `title:${String(market?.title ?? '').trim().toLowerCase()}`;
+}
+
+// Collapse same-identity records, keeping the highest-volume one.
+//
+// WHY THIS EXISTS AND WHY IT MUST NOT BE A HARD FAILURE. Upstream can legitimately
+// hand us two records with one identity: the Polymarket url is built from
+// `event.slug` while the fetch loop dedupes on `event.id`, so a parent event and
+// its derivative (the feed really does carry a `parent-for-derivative` tag) can
+// share a slug under two ids. If those two land in different pools, the payload
+// contains a cross-pool duplicate through no fault of the classifier — and
+// because the integrity gate refuses the whole publish, an upstream fan-out
+// quirk would freeze ALL THREE pools until a human shipped a fix, with
+// /api/health only noticing 90 minutes later. Deduping here keeps that a data
+// condition we absorb, not an outage. Highest volume wins so the choice is
+// deterministic run-to-run rather than dependent on tag-iteration order.
+export function dedupeMarkets(markets) {
+  if (!Array.isArray(markets)) return [];
+  const best = new Map();
+  for (const market of markets) {
+    if (!market || typeof market !== 'object') continue;
+    const identity = marketIdentity(market);
+    const incumbent = best.get(identity);
+    if (!incumbent) {
+      best.set(identity, market);
+      continue;
+    }
+    const incumbentVolume = Number(incumbent.volume);
+    const challengerVolume = Number(market.volume);
+    const incumbentRank = Number.isFinite(incumbentVolume) ? incumbentVolume : -Infinity;
+    const challengerRank = Number.isFinite(challengerVolume) ? challengerVolume : -Infinity;
+    if (challengerRank > incumbentRank) best.set(identity, market);
+  }
+  return [...best.values()];
+}
+
+// Assemble the published payload's three pools from the raw candidate list:
+// dedupe by identity, assign one primary category each, then rank WITHIN each
+// pool. This is the producer's real pool-building path — seed-prediction-markets
+// calls exactly this, and so do the tests, so a regression in the wiring (for
+// example reverting `geopolitical` to an unfiltered `filterAndScore(markets,
+// null)`) cannot pass the suite. Keeping the wiring here rather than inline in
+// the seeder is deliberate: the seeder calls runSeed at module scope and can
+// never be imported by a test.
+//
+// Returns the pools plus the pre-truncation classification counts, so the
+// seeder can log how many candidates each category actually had versus how many
+// survived the per-pool ranking cap.
+export function buildBootstrapPools(markets, { limit } = {}) {
+  const source = Array.isArray(markets) ? markets : [];
+  const deduped = dedupeMarkets(source);
+  const partitioned = partitionMarkets(deduped);
+  return {
+    pools: {
+      geopolitical: filterAndScore(partitioned.geopolitical, null, limit),
+      tech: filterAndScore(partitioned.tech, null, limit),
+      finance: filterAndScore(partitioned.finance, null, limit),
+    },
+    classified: {
+      geopolitical: partitioned.geopolitical.length,
+      tech: partitioned.tech.length,
+      finance: partitioned.finance.length,
+    },
+    duplicatesDropped: source.length - deduped.length,
+  };
+}
+
+// Category-integrity check over an assembled payload (#5733 item 3). Returns
+// the list of violations — empty means the pools are disjoint AND every entry
+// sits in the pool its own classification demands. Both properties hold by
+// construction when the payload came from buildBootstrapPools, so a non-empty
+// result means the producer regressed, not that upstream data was odd. That is
+// why the seeder treats it as a publish gate rather than a warning.
+//
+// WHAT THIS CANNOT CATCH — do not over-trust a green gate. The mismatch check
+// re-runs the SAME classifyMarket that built the partition, so it is a
+// SELF-CONSISTENCY check, not a correctness one. It catches a regression in the
+// pipeline SHAPE — someone reverting `geopolitical` to an unfiltered
+// filterAndScore(markets, null), a merge that copies a pool, a hand-assembled
+// payload — which is exactly the #5733 defect. It can NOT tell you the taxonomy
+// itself is right: if the title regex or the classify tag lists start misfiling
+// real markets, every pool still agrees with its own classifier and this gate
+// stays green. The independent ground truth for the taxonomy lives in
+// tests/prediction-market-classification.test.mjs, which asserts hand-verified
+// expected categories for named real production titles.
+//
+// A pool key that is absent is vacuously clean: whether a partial payload is
+// publishable is the caller's own validation, not this function's business.
+export function poolIntegrityViolations(pools) {
+  const violations = [];
+  const owner = new Map();
+  for (const category of CATEGORIES) {
+    const pool = pools?.[category];
+    if (pool == null) continue;
+    if (!Array.isArray(pool)) {
+      violations.push({ kind: 'pool-not-array', category });
+      continue;
+    }
+    for (const market of pool) {
+      const title = String(market?.title ?? '');
+      const expected = classifyMarket(market);
+      if (expected !== category) {
+        violations.push({ kind: 'category-mismatch', category, expected, title });
+      }
+      const identity = marketIdentity(market);
+      const previous = owner.get(identity);
+      if (previous) {
+        violations.push({ kind: 'duplicate-market', category, otherCategory: previous, title });
+      } else {
+        owner.set(identity, category);
+      }
+    }
+  }
+  return violations;
+}
+
+// One-line summary for seeder logs.
+export function formatIntegrityViolations(violations, limit = 10) {
+  return violations.slice(0, limit).map((v) => {
+    if (v.kind === 'pool-not-array') return `pool-not-array: ${v.category}`;
+    if (v.kind === 'duplicate-market') return `duplicate-market: "${v.title}" in ${v.category} and ${v.otherCategory}`;
+    return `category-mismatch: "${v.title}" in ${v.category}, classifies as ${v.expected}`;
+  });
+}
+
+// The seeder's atomicPublish validateFn, lifted here so the publish gate itself
+// is unit-testable — seed-prediction-markets.mjs cannot be imported by a test
+// (it calls runSeed at module scope). Returns true iff the payload is
+// publishable.
+//
+// A rejection makes runSeed preserve last-good and mirror its original
+// fetchedAt into seed-meta, so /api/health flips to STALE_SEED past maxStaleMin
+// rather than serving pools whose labels lie — which is how #5733 stayed
+// invisible. That also means a WRONG rejection is a 90-minute-latent data
+// outage, so the population floor below is deliberately the weakest one that
+// still protects last-good.
+//
+// WHY THE PER-POOL FLOOR IS GONE. The pre-#5733 check required
+// `(geopolitical || tech) && finance` to be non-empty. That was safe only
+// because `finance` was then a catch-all — every Kalshi record landed there via
+// the old `source === 'kalshi'` rule. Now that pool membership is decided by
+// CONTENT, a legitimate run can empty any single pool: a cycle whose Kalshi
+// records are all geopolitical by title and whose Polymarket finance tags all
+// 429'd yields real, publishable geo+tech data that the old floor would have
+// thrown away, freezing the feed. Any non-empty classified payload is therefore
+// publishable; a genuinely empty fetch is already caught upstream by runSeed's
+// contract mode (declareRecords === 0 -> RETRY, which preserves last-good
+// without ever reaching validateFn). Detecting a partial-volume collapse is a
+// coverage-floor job (api/health.js minRecordCount), not this gate's.
+export function validateBootstrapPayload(data, { log = console.error } = {}) {
+  const total = CATEGORIES.reduce(
+    (sum, category) => sum + (Array.isArray(data?.[category]) ? data[category].length : 0),
+    0,
+  );
+  if (total === 0) return false;
+  const violations = poolIntegrityViolations(data);
+  if (violations.length === 0) return true;
+  log(`  INTEGRITY: ${violations.length} pool-classification violation(s) — refusing to publish mislabeled pools (#5733)`);
+  for (const line of formatIntegrityViolations(violations)) log(`    ${line}`);
+  return false;
+}

--- a/scripts/_prediction-classify.mjs
+++ b/scripts/_prediction-classify.mjs
@@ -20,8 +20,16 @@
 // THE MODEL. Each market gets exactly ONE primary category, decided by a fixed
 // precedence: geopolitical, then tech, then finance. Precedence (rather than
 // three independent predicates) is what makes the pools disjoint by
-// construction, and the tag lists in prediction-tags.json `classify` are kept
-// mutually disjoint so precedence never silently decides a coin-flip.
+// construction.
+//
+// PRECEDENCE IS LOAD-BEARING, not a tie-breaker of last resort. The `classify`
+// tag lists in prediction-tags.json are mutually disjoint, which guarantees no
+// single TAG maps to two categories — but a market routinely carries tags from
+// more than one list, and then the ORDER decides. "Kraken IPO by December 31,
+// 2026?" is tagged both `crypto` (tech) and `business`/`finance` (finance), and
+// lands in tech purely because tech is checked first. So reordering CATEGORIES
+// silently moves real markets between published pools; the order is pinned by
+// tests/prediction-market-classification.test.mjs, not merely documented here.
 //
 // WHY GEOPOLITICAL IS FIRST, AND WHY IT READS BOTH TITLE AND TAGS.
 // WorldMonitor's identity is geopolitical intelligence, so a genuine geo market

--- a/scripts/_prediction-classify.mjs
+++ b/scripts/_prediction-classify.mjs
@@ -58,6 +58,11 @@ import predictionTags from './data/prediction-tags.json' with { type: 'json' };
 // enum and the bootstrap payload's top-level keys — do not reorder casually.
 export const CATEGORIES = Object.freeze(['geopolitical', 'tech', 'finance']);
 
+// The smallest healthy single-pool cycle in the production fixture contains
+// eight records. Keep this floor below that so a legitimate category outage
+// can still publish, while refusing a one-record partial fetch outright.
+export const MIN_PUBLISHED_MARKETS = 5;
+
 // Pool that owns records matching no category tag (see header).
 export const DEFAULT_CATEGORY = 'finance';
 
@@ -111,9 +116,11 @@ export function classifyMarket(market) {
 // geopolitical, and those readers would silently lose every macro, rates,
 // crypto, and AI market. One helper so they cannot drift apart again.
 export function allBootstrapMarkets(payload) {
-  return [payload?.geopolitical, payload?.tech, payload?.finance]
-    .filter(Array.isArray)
-    .flat();
+  return dedupeMarkets(
+    [payload?.geopolitical, payload?.tech, payload?.finance]
+      .filter(Array.isArray)
+      .flat(),
+  );
 }
 
 // Split candidates into the three disjoint pools. Every valid record lands in
@@ -281,7 +288,7 @@ export function formatIntegrityViolations(violations, limit = 10) {
 // rather than serving pools whose labels lie — which is how #5733 stayed
 // invisible. That also means a WRONG rejection is a 90-minute-latent data
 // outage, so the population floor below is deliberately the weakest one that
-// still protects last-good.
+// still protects last-good while allowing a legitimate single-pool cycle.
 //
 // WHY THE PER-POOL FLOOR IS GONE. The pre-#5733 check required
 // `(geopolitical || tech) && finance` to be non-empty. That was safe only
@@ -290,8 +297,8 @@ export function formatIntegrityViolations(violations, limit = 10) {
 // CONTENT, a legitimate run can empty any single pool: a cycle whose Kalshi
 // records are all geopolitical by title and whose Polymarket finance tags all
 // 429'd yields real, publishable geo+tech data that the old floor would have
-// thrown away, freezing the feed. Any non-empty classified payload is therefore
-// publishable; a genuinely empty fetch is already caught upstream by runSeed's
+// thrown away, freezing the feed. Any payload at or above MIN_PUBLISHED_MARKETS
+// is therefore publishable; a genuinely empty fetch is already caught upstream by runSeed's
 // contract mode (declareRecords === 0 -> RETRY, which preserves last-good
 // without ever reaching validateFn). Detecting a partial-volume collapse is a
 // coverage-floor job (api/health.js minRecordCount), not this gate's.
@@ -300,7 +307,10 @@ export function validateBootstrapPayload(data, { log = console.error } = {}) {
     (sum, category) => sum + (Array.isArray(data?.[category]) ? data[category].length : 0),
     0,
   );
-  if (total === 0) return false;
+  if (total < MIN_PUBLISHED_MARKETS) {
+    log(`  COVERAGE: only ${total} published market(s); refusing a partial snapshot below ${MIN_PUBLISHED_MARKETS} (#5733)`);
+    return false;
+  }
   const violations = poolIntegrityViolations(data);
   if (violations.length === 0) return true;
   log(`  INTEGRITY: ${violations.length} pool-classification violation(s) — refusing to publish mislabeled pools (#5733)`);

--- a/scripts/data/prediction-tags.json
+++ b/scripts/data/prediction-tags.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "TWO DIFFERENT JOBS, do not conflate (#5733). Top-level geopolitical/tech/finance = Polymarket tag SLUGS TO FETCH; the seeder queries their union, so overlap between them is harmless and expected. `classify` = which pool a fetched market is PUBLISHED under; those three lists must stay mutually DISJOINT, because overlap there is exactly what made the published pools near-duplicates. Editing a fetch list changes coverage; editing a classify list moves markets between the pools every consumer reads by name. classify.tech/classify.finance must remain supersets of shared/openapi-filter-param-contracts.json's predictionMarketTechCategories/predictionMarketFinanceCategories (the RPC routes a requested category to a pool with those), and may add venue-only tags the RPC does not expose.",
   "geopolitical": [
     "politics", "geopolitics", "elections", "world",
     "ukraine", "china", "middle-east", "europe",
@@ -13,6 +14,21 @@
     "trade", "tariffs", "debt-ceiling",
     "crypto", "business", "markets"
   ],
+  "classify": {
+    "geopolitical": [
+      "geopolitics", "geopolitical", "world", "elections", "global-elections",
+      "world-elections", "international-election-props", "main-election",
+      "middle-east", "ukraine", "nato", "diplomacy-ceasefire",
+      "foreign-policy", "war", "military", "defense", "sanctions"
+    ],
+    "tech": [
+      "ai", "tech", "crypto", "science", "elon-musk"
+    ],
+    "finance": [
+      "economy", "fed", "inflation", "interest-rates", "recession",
+      "trade", "tariffs", "debt-ceiling", "markets", "business"
+    ]
+  },
   "excludeKeywords": [
     "nba", "nfl", "mlb", "nhl", "fifa", "world cup", "super bowl", "championship",
     "playoffs", "oscar", "grammy", "emmy", "box office", "movie", "album", "song",

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -7,6 +7,7 @@ import { readFileSync } from 'node:fs';
 import { loadEnvFile, runSeed, CHROME_UA, withRetry, parseRetryAfterMs, getResponseHeader, isRetryableHttpStatus } from './_seed-utils.mjs';
 import { compactForecastDashboardPayload } from './_forecast-dashboard.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+import { allBootstrapMarkets } from './_prediction-classify.mjs';
 import { tagRegions } from './_prediction-scoring.mjs';
 import { attachResolutionSpecs } from './_forecast-resolution.mjs';
 import { assessFunnelDiversity } from './_forecast-funnel.mjs';
@@ -2437,7 +2438,10 @@ function capMarketCalibrationProbability(domain, probability) {
 
 function detectFromPredictionMarkets(inputs) {
   const predictions = [];
-  const markets = inputs.predictionMarkets?.geopolitical || [];
+  // All three pools (#5733). This detector scores any market whose title tags a
+  // region, so it wants the whole universe; `.geopolitical` only meant that
+  // while the producer's pools were near-duplicates.
+  const markets = allBootstrapMarkets(inputs.predictionMarkets);
 
   for (const m of markets) {
     if (!Number.isFinite(m?.yesPrice)) continue;
@@ -2607,7 +2611,11 @@ function computeProjections(predictions) {
 }
 
 function calibrateWithMarkets(predictions, markets) {
-  if (!markets?.geopolitical) return;
+  // All three pools (#5733): a prediction is calibrated against whichever market
+  // best matches its region and title, and the best anchor is often a macro,
+  // rates, or commodity line that now lives outside the geopolitical pool.
+  const marketUniverse = allBootstrapMarkets(markets);
+  if (marketUniverse.length === 0) return;
   const stats = {
     applied: 0,
     noPrice: 0,
@@ -2624,7 +2632,7 @@ function calibrateWithMarkets(predictions, markets) {
     const titleTokens = extractMeaningfulTokens(pred.title, regionTerms);
     const predictionDeEscalatoryOutcome = predictionYesOutcomeLooksDeEscalatory(pred);
     if (keywords.length === 0 && regionTerms.length === 0) continue;
-    const candidates = markets.geopolitical
+    const candidates = marketUniverse
       .map(m => {
         const mRegions = tagRegions(m.title);
         const sameMacroRegion = keywords.length > 0 && mRegions.some(r => keywords.includes(r));

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, sleep, runSeed } from './_seed-utils.mjs';
+import { buildBootstrapPools, validateBootstrapPayload } from './_prediction-classify.mjs';
 import {
   isExcluded, isMemeCandidate, tagRegions, parseYesPrice, selectPricedKalshiMarket,
-  shouldInclude, scoreMarket, filterAndScore, isExpired,
+  shouldInclude, scoreMarket, isExpired,
 } from './_prediction-scoring.mjs';
 import predictionTags from './data/prediction-tags.json' with { type: 'json' };
 
@@ -171,16 +172,26 @@ async function fetchAllPredictions() {
 
   console.log(`  total raw markets: ${markets.length}`);
 
-  const geopolitical = filterAndScore(markets, null);
-  const tech = filterAndScore(markets, m => m.tags?.some(t => TECH_TAGS.includes(t)));
-  const finance = filterAndScore(markets, m => m.source === 'kalshi' || m.tags?.some(t => FINANCE_TAGS.includes(t)));
+  // #5733: assign each market ONE primary category, then rank WITHIN that pool.
+  // The pools used to be three independent filters over `markets` — with
+  // `geopolitical` taking no filter at all, so it was a copy of everything, and
+  // tech/finance overlapping on the economy/crypto/business tags. Partitioning
+  // first is what makes the published labels mean something and stops the same
+  // record being published three times. The whole pool-building path lives in
+  // _prediction-classify.mjs so the tests exercise THIS wiring, not a replica of
+  // it (this module can never be imported by a test — runSeed runs at import).
+  const { pools, classified, duplicatesDropped } = buildBootstrapPools(markets);
 
-  console.log(`  geopolitical: ${geopolitical.length}, tech: ${tech.length}, finance: ${finance.length}`);
+  if (duplicatesDropped > 0) {
+    console.log(`  deduped ${duplicatesDropped} same-identity record(s) before classification`);
+  }
+  console.log(
+    `  classified: geopolitical ${classified.geopolitical}, tech ${classified.tech}, finance ${classified.finance}`
+    + ` → published: ${pools.geopolitical.length}/${pools.tech.length}/${pools.finance.length}`,
+  );
 
   return {
-    geopolitical,
-    tech,
-    finance,
+    ...pools,
     fetchedAt: Date.now(),
   };
 }
@@ -192,7 +203,10 @@ export function declareRecords(data) {
 await runSeed('prediction', 'markets', CANONICAL_KEY, fetchAllPredictions, {
   ttlSeconds: CACHE_TTL,
   lockTtlMs: 60_000,
-  validateFn: (data) => (data?.geopolitical?.length > 0 || data?.tech?.length > 0) && data?.finance?.length > 0,
+  // Population requirement + #5733 category-integrity gate. Lives in
+  // _prediction-classify.mjs so the gate is unit-testable (this module runs
+  // runSeed at import time, so a test can never import it).
+  validateFn: validateBootstrapPayload,
 
   declareRecords,
   schemaVersion: 1,

--- a/server/worldmonitor/prediction/v1/list-prediction-markets.ts
+++ b/server/worldmonitor/prediction/v1/list-prediction-markets.ts
@@ -67,9 +67,19 @@ export const listPredictionMarkets: PredictionServiceHandler['listPredictionMark
 
     const isTech = category && TECH_CATEGORY_TAGS.includes(category);
     const isFinance = !isTech && category && FINANCE_CATEGORY_TAGS.includes(category);
+    // `category` is optional on this public endpoint, and omitting it must keep
+    // meaning "every market" (#5733). Before the producer's pools were made
+    // disjoint, `bootstrap.geopolitical` WAS every market, so the no-category
+    // caller and an explicit geopolitical-ish category (the site variant sends
+    // 'politics') could share one branch. Now they must not: the pool is
+    // strictly geopolitical, so an empty category has to union all three or the
+    // documented default response silently narrows to geo-only. Volume-sorted so
+    // the union is ranked rather than concatenated pool-by-pool.
     const variant = isTech ? bootstrap.tech
       : isFinance ? (bootstrap.finance ?? bootstrap.geopolitical)
-      : bootstrap.geopolitical;
+      : category ? bootstrap.geopolitical
+      : [...(bootstrap.geopolitical ?? []), ...(bootstrap.tech ?? []), ...(bootstrap.finance ?? [])]
+        .sort((a, b) => (Number(b?.volume) || 0) - (Number(a?.volume) || 0));
 
     if (!variant || variant.length === 0) return { markets: [], pagination: undefined, fetchedAt, dataAvailable: false };
 

--- a/server/worldmonitor/prediction/v1/list-prediction-markets.ts
+++ b/server/worldmonitor/prediction/v1/list-prediction-markets.ts
@@ -38,6 +38,36 @@ interface BootstrapData {
   fetchedAt?: number;
 }
 
+const DEGENERATE_MARKET_SLUGS = new Set(['undefined', 'null', 'nan', '']);
+
+function bootstrapMarketIdentity(market: BootstrapMarket): string {
+  const url = String(market?.url ?? '').trim();
+  if (url) {
+    const path = url.split(/[?#]/)[0] ?? '';
+    const slug = path.replace(/\/+$/, '').split('/').pop() ?? '';
+    if (!DEGENERATE_MARKET_SLUGS.has(slug.toLowerCase())) return `url:${url}`;
+  }
+  return `title:${String(market?.title ?? '').trim().toLowerCase()}`;
+}
+
+function dedupeBootstrapMarkets(markets: BootstrapMarket[]): BootstrapMarket[] {
+  const best = new Map<string, BootstrapMarket>();
+  for (const market of markets) {
+    const identity = bootstrapMarketIdentity(market);
+    const incumbent = best.get(identity);
+    if (!incumbent) {
+      best.set(identity, market);
+      continue;
+    }
+    const incumbentVolume = Number(incumbent.volume);
+    const challengerVolume = Number(market.volume);
+    const incumbentRank = Number.isFinite(incumbentVolume) ? incumbentVolume : -Infinity;
+    const challengerRank = Number.isFinite(challengerVolume) ? challengerVolume : -Infinity;
+    if (challengerRank > incumbentRank) best.set(identity, market);
+  }
+  return [...best.values()];
+}
+
 function toProtoMarket(m: BootstrapMarket, category: string): PredictionMarket {
   return {
     id: m.url?.split('/').pop() || '',
@@ -82,15 +112,11 @@ export const listPredictionMarkets: PredictionServiceHandler['listPredictionMark
     // correct for either payload vintage. Volume-sorted so it stays ranked
     // rather than ordered pool-by-pool.
     const unionAllPools = () => {
-      const seen = new Set<string>();
-      const out: BootstrapMarket[] = [];
-      for (const m of [...(bootstrap.geopolitical ?? []), ...(bootstrap.tech ?? []), ...(bootstrap.finance ?? [])]) {
-        const id = String(m?.url || m?.title || '');
-        if (id && seen.has(id)) continue;
-        if (id) seen.add(id);
-        out.push(m);
-      }
-      return out.sort((a, b) => (Number(b?.volume) || 0) - (Number(a?.volume) || 0));
+      return dedupeBootstrapMarkets([
+        ...(bootstrap.geopolitical ?? []),
+        ...(bootstrap.tech ?? []),
+        ...(bootstrap.finance ?? []),
+      ]).sort((a, b) => (Number(b?.volume) || 0) - (Number(a?.volume) || 0));
     };
 
     // A finance request must NOT fall back to the geopolitical pool. That was

--- a/server/worldmonitor/prediction/v1/list-prediction-markets.ts
+++ b/server/worldmonitor/prediction/v1/list-prediction-markets.ts
@@ -73,13 +73,33 @@ export const listPredictionMarkets: PredictionServiceHandler['listPredictionMark
     // caller and an explicit geopolitical-ish category (the site variant sends
     // 'politics') could share one branch. Now they must not: the pool is
     // strictly geopolitical, so an empty category has to union all three or the
-    // documented default response silently narrows to geo-only. Volume-sorted so
-    // the union is ranked rather than concatenated pool-by-pool.
+    // documented default response silently narrows to geo-only.
+    //
+    // The union is DEDUPED, not just concatenated: for up to the seeder's cron
+    // interval after this ships, Redis still holds a pre-#5733 payload whose
+    // pools are near-duplicates, and a naive concat would answer the default
+    // request with the same market three times. Deduping keeps the response
+    // correct for either payload vintage. Volume-sorted so it stays ranked
+    // rather than ordered pool-by-pool.
+    const unionAllPools = () => {
+      const seen = new Set<string>();
+      const out: BootstrapMarket[] = [];
+      for (const m of [...(bootstrap.geopolitical ?? []), ...(bootstrap.tech ?? []), ...(bootstrap.finance ?? [])]) {
+        const id = String(m?.url || m?.title || '');
+        if (id && seen.has(id)) continue;
+        if (id) seen.add(id);
+        out.push(m);
+      }
+      return out.sort((a, b) => (Number(b?.volume) || 0) - (Number(a?.volume) || 0));
+    };
+
+    // A finance request must NOT fall back to the geopolitical pool. That was
+    // harmless while geopolitical was a superset of every market; now it would
+    // answer "give me finance" with conflict and election markets.
     const variant = isTech ? bootstrap.tech
-      : isFinance ? (bootstrap.finance ?? bootstrap.geopolitical)
+      : isFinance ? bootstrap.finance
       : category ? bootstrap.geopolitical
-      : [...(bootstrap.geopolitical ?? []), ...(bootstrap.tech ?? []), ...(bootstrap.finance ?? [])]
-        .sort((a, b) => (Number(b?.volume) || 0) - (Number(a?.volume) || 0));
+      : unionAllPools();
 
     if (!variant || variant.length === 0) return { markets: [], pagination: undefined, fetchedAt, dataAvailable: false };
 

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -142,9 +142,15 @@ export async function fetchCountryMarkets(country: string): Promise<PredictionMa
   const terms = countrySearchTerms(country);
   const allMarkets: PredictionMarket[] = [];
 
-  // Try RPC across geopolitics + finance (parallel, both cover most country markets)
+  // Try RPC across geopolitics + finance + tech (parallel; together they cover
+  // every pool). `tech` is not optional here: since #5733 made the producer's
+  // pools a disjoint partition, a tech-classified country market (a Chinese AI
+  // model line, say) lives ONLY in the tech pool, and the early return below
+  // fires as soon as any geopolitics/economy match is found — so without this
+  // category the bootstrap fallback that also unions tech would never be reached
+  // for any country that has a single geo or finance market.
   const rpcResults = await Promise.allSettled(
-    (['geopolitics', 'economy'] as const).map(category =>
+    (['geopolitics', 'economy', 'tech'] as const).map(category =>
       client.listPredictionMarkets({ category, query: country, pageSize: 30, cursor: '' })
     )
   );
@@ -164,10 +170,14 @@ export async function fetchCountryMarkets(country: string): Promise<PredictionMa
     if (matched.length > 0) return matched;
   }
 
-  // Fallback: search bootstrap data across all buckets
+  // Fallback: search bootstrap data across all buckets. `tech` must be included
+  // explicitly — until #5733 the geopolitical bucket was an unfiltered copy of
+  // every market, so omitting tech here was invisible; now the buckets are a
+  // disjoint partition and a tech-classified country market (e.g. a Chinese AI
+  // model line) would be unreachable without it.
   const hydrated = getHydratedData('predictions') as BootstrapPredictionData | undefined;
   if (hydrated) {
-    const buckets = [...(hydrated.geopolitical ?? []), ...(hydrated.finance ?? [])];
+    const buckets = [...(hydrated.geopolitical ?? []), ...(hydrated.tech ?? []), ...(hydrated.finance ?? [])];
     const filtered = buckets
       .filter(m => !isExpired(m.endDate) && matchesCountryTerms(m.title, terms))
       .sort((a, b) => (b.volume ?? 0) - (a.volume ?? 0))

--- a/tests/bet-templates-markets-geo.test.mjs
+++ b/tests/bet-templates-markets-geo.test.mjs
@@ -254,3 +254,50 @@ describe('geopolitical bets reach the seeder snapshot end-to-end', () => {
     assert.ok(Number.isFinite(geoBet.probability), 'carries a base-rate probability (Stage A)');
   });
 });
+
+// #5733: the PRODUCER's geo pool and this family's geo partition are deliberately
+// NOT the same predicate. The producer treats a market as geopolitical when the
+// title matches isGeopoliticalMarket OR the venue tags say so; this family uses
+// the title signal only, because a false geo tag would steal a flagship
+// long-horizon ensemble slot. So a market that is geopolitical purely by TAG
+// lands in the published `geopolitical` pool but in the GENERAL bet family.
+//
+// That asymmetry is an accepted exception, documented in
+// _bet-templates-markets-classify.mjs. It is pinned here so a future
+// half-alignment — importing the producer's tag rescue into one family but not
+// the other, or "fixing" this to match the pool label — cannot pass silently.
+describe('producer geo POOL vs geo bet family (accepted #5733 asymmetry)', () => {
+  const tagOnlyGeo = market({
+    title: 'Will AfD win the most seats in the 2026 Berlin state elections?',
+    url: 'https://polymarket.com/event/berlin-state-election-winner',
+    tags: ['world-elections', 'world', 'main-election', 'global-elections', 'elections'],
+    volume: 3_139_438,
+    yesPrice: 17.8,
+  });
+
+  it('the title matcher does not claim a tag-only geopolitical market', () => {
+    assert.ok(!isGeopoliticalMarket(tagOnlyGeo.title));
+  });
+
+  it('so the geo family declines it even when the producer published it as geopolitical', () => {
+    assert.equal(eligibleGeoMarkets(feedFixture([tagOnlyGeo]), NOW).length, 0);
+  });
+
+  it('and the general family owns it whenever it fits the general 45d horizon', () => {
+    const nearDated = { ...tagOnlyGeo, endDate: '2026-08-25T00:00:00Z' }; // ~28d out
+    const eligible = eligibleMarkets(feedFixture([nearDated]), NOW);
+    assert.equal(eligible.length, 1);
+    assert.equal(eligible[0].slug, 'berlin-state-election-winner');
+  });
+
+  it('a LONG-dated tag-only geo market is claimed by neither family — the #5525 horizon gate, not a classification bug', () => {
+    // The real Berlin market closes 2026-09-20, ~54d out: past the general
+    // family's 45d cap, and the geo family (which would take a 210d horizon)
+    // declines it on the title predicate. Both refusals are deliberate. This is
+    // pinned so the gap is a KNOWN consequence of the precision-first title
+    // matcher plus the general family's fast-resolution cap, not a surprise
+    // rediscovered later as "the producer says geo but no bet was generated".
+    assert.equal(eligibleGeoMarkets(feedFixture([tagOnlyGeo]), NOW).length, 0);
+    assert.equal(eligibleMarkets(feedFixture([tagOnlyGeo]), NOW).length, 0);
+  });
+});

--- a/tests/fixtures/prediction-markets-raw-candidates.json
+++ b/tests/fixtures/prediction-markets-raw-candidates.json
@@ -1,0 +1,419 @@
+{
+  "_comment": "Real prediction:markets-bootstrap:v1 records captured from production on 2026-07-30 (union of the geopolitical/tech/finance pools, deduplicated by url). This is the shape scripts/seed-prediction-markets.mjs holds in its `markets` array before classification. Used by tests/prediction-market-classification.test.mjs to exercise the classifier against real venue titles + real Polymarket tag slugs (including Kalshi records, which always carry an empty tags array). Fixture for #5733.",
+  "markets": [
+    {
+      "title": "Will no Fed rate cuts happen in 2026?",
+      "yesPrice": 89.6,
+      "volume": 45643309.60632901,
+      "url": "https://polymarket.com/event/how-many-fed-rate-cuts-in-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["rewards-200-4pt5-50", "fed-rates", "economic-policy", "fed", "business", "jerome-powell", "economy", "finance"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Ledger IPO before 2027?",
+      "yesPrice": 10,
+      "volume": 6908572.301751993,
+      "url": "https://polymarket.com/event/ipos-before-2027",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["business", "big-tech", "ipos", "finance"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Iran agrees to surrender enriched uranium stockpile by December 31, 2026?",
+      "yesPrice": 12.5,
+      "volume": 17601283.10192198,
+      "url": "https://polymarket.com/event/iran-agrees-to-surrender-enriched-uranium-stockpile-by",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["geopolitics", "trump", "middle-east", "diplomacy-ceasefire", "politics", "trump-iran", "iran", "nuclear", "negotiations"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Anthropic have the highest IPO Market Cap 2026?",
+      "yesPrice": 11.3,
+      "volume": 5000707.113035,
+      "url": "https://polymarket.com/event/largest-ipo-by-market-cap-in-2026-287",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["climate-science", "ipo", "science", "elon-musk", "openai", "business", "ipos", "sam-altman", "big-tech", "spacex", "space", "finance", "openai-ipo"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Renan Santos finish in second place in the first round of the 2026 Brazilian presidential election?",
+      "yesPrice": 11.2,
+      "volume": 4338171.918163002,
+      "url": "https://polymarket.com/event/brazil-presidential-election-first-round-2nd-place",
+      "endDate": "2026-10-04T00:00:00Z",
+      "tags": ["brazil", "politics", "world", "global-elections", "elections", "international-election-props"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Nebius Group be acquired before 2027?",
+      "yesPrice": 14.5,
+      "volume": 18108105.184368998,
+      "url": "https://polymarket.com/event/which-companies-will-be-acquired-before-2027",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["business", "big-tech", "prediction-markets", "finance", "tech", "ai", "acquisitions", "buy"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will the Democratic Party control the House after the 2026 Midterm elections?",
+      "yesPrice": 85.5,
+      "volume": 8901325.340096,
+      "url": "https://polymarket.com/event/which-party-will-win-the-house-in-2026",
+      "endDate": "2026-11-03T00:00:00Z",
+      "tags": ["parent-for-derivative", "united-states", "us-presidential-election", "politics", "midterms", "world-elections", "elections", "global-elections", "earn-4", "main-election"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Pump.fun perform an airdrop by December 31, 2026",
+      "yesPrice": 12,
+      "volume": 2769869.6437140005,
+      "url": "https://polymarket.com/event/pumpfun-airdop-by",
+      "endDate": "2027-01-01T05:00:00Z",
+      "tags": ["airdrops", "crypto", "pre-market", "pumpptfun"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will China invade Taiwan by December 31, 2027?",
+      "yesPrice": 12,
+      "volume": 2285897.0355969993,
+      "url": "https://polymarket.com/event/will-china-invade-taiwan-by-december-31-2027",
+      "endDate": "2027-12-31T00:00:00Z",
+      "tags": ["china", "politics", "world", "geopolitics"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Opensea FDV above $500M one day after launch?",
+      "yesPrice": 15.3,
+      "volume": 6597454.164707,
+      "url": "https://polymarket.com/event/opensea-fdv-above-one-day-after-launch",
+      "endDate": "2027-01-01T05:00:00Z",
+      "tags": ["fdv", "crypto", "pre-market"],
+      "source": "polymarket"
+    },
+    {
+      "title": "US recession by end of 2026?",
+      "yesPrice": 11.5,
+      "volume": 1686201.7278130003,
+      "url": "https://polymarket.com/event/us-recession-by-end-of-2026",
+      "endDate": "2027-01-31T00:00:00Z",
+      "tags": ["business", "economy", "economic-policy", "macro-graph"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Iran coup attempt by December 31?",
+      "yesPrice": 13,
+      "volume": 2107208.933681993,
+      "url": "https://polymarket.com/event/iran-coup-attempt-by-june-30",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["geopolitics", "iranian-leadership-regime", "reza-pahlavi", "iran", "israel", "world", "trump", "middle-east"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Sam Altman out as OpenAI CEO before 2027?",
+      "yesPrice": 10,
+      "volume": 709135.2601169988,
+      "url": "https://polymarket.com/event/which-ceos-will-be-out-before-2027",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["business", "ai", "big-tech", "tech", "economy", "finance"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Sorin Grindeanu be the next Prime Minister of Romania?",
+      "yesPrice": 15.3,
+      "volume": 3240126.18847,
+      "url": "https://polymarket.com/event/next-prime-minister-of-romania-732",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["politics", "main-election", "global-elections", "elections", "romania", "bolojat", "romania-government"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will the Doge-1 Lunar Mission launch by December 31, 2026?",
+      "yesPrice": 11.9,
+      "volume": 871734.9197680003,
+      "url": "https://polymarket.com/event/will-the-doge-1-lunar-mission-launch-before-2027",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["pop-culture", "spacex", "space", "science"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Ukraine agree to cede territory to Russia before 2027?",
+      "yesPrice": 11.5,
+      "volume": 721283.1255290001,
+      "url": "https://polymarket.com/event/will-ukraine-agree-to-cede-territory-to-russia-before-2027",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["zelenskyy", "russia", "trump", "geopolitics", "politics", "ukraine", "world", "ukraine-peace-deal"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Ukraine peace referendum scheduled by December 31?",
+      "yesPrice": 10.5,
+      "volume": 521481.775878,
+      "url": "https://polymarket.com/event/ukraine-calls-a-referendum-on-peace-deal-with-russia-by-january-31",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["ukraine", "geopolitics", "trump", "zelensky", "putin", "politics", "russia", "ukraine-peace-deal"],
+      "source": "polymarket"
+    },
+    {
+      "title": "NATO/EU troops fighting in Ukraine by December 31, 2026?",
+      "yesPrice": 10.5,
+      "volume": 419486.2576090001,
+      "url": "https://polymarket.com/event/natoeu-troops-fighting-in-ukraine-in-2025",
+      "endDate": "2026-12-31T12:00:00Z",
+      "tags": ["ukraine", "politics", "geopolitics", "russia", "nato", "eu", "world", "trump-zelenskyy", "security-guarantee"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will China invade Taiwan by June 30, 2027?",
+      "yesPrice": 10.5,
+      "volume": 404551.09925800015,
+      "url": "https://polymarket.com/event/will-china-invade-taiwan-by-june-30-2027",
+      "endDate": "2027-06-30T00:00:00Z",
+      "tags": ["china", "politics", "geopolitics", "taiwan"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Zelenskyy talk to Putin by December 31?",
+      "yesPrice": 13,
+      "volume": 904530.4867650004,
+      "url": "https://polymarket.com/event/will-zelenskyy-talk-to-putin-by-november-30-821",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["geopolitics", "ukraine", "putin", "zelenskyy", "politics", "russia"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will MegaETH perform an airdrop by December 31, 2026?",
+      "yesPrice": 16.5,
+      "volume": 2646716.878486997,
+      "url": "https://polymarket.com/event/megaeth-airdrop-by",
+      "endDate": "2027-01-01T05:00:00Z",
+      "tags": ["airdrops", "crypto", "megaeth", "pre-market"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Mojtaba Khamenei be head of state in Iran end of 2026?",
+      "yesPrice": 79.3,
+      "volume": 37097100.816747,
+      "url": "https://polymarket.com/event/iran-leader-end-of-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["middle-east", "iran", "world", "geopolitics", "politics", "iranian-leadership-regime", "rewards-50-4pt5-100"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will 7-8 SpaceX Starship launches successfully reach Space in 2026?",
+      "yesPrice": 11.8,
+      "volume": 490085.63151499996,
+      "url": "https://polymarket.com/event/how-many-spacex-starship-launches-reach-space-in-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["spacex", "space", "science", "elon-musk", "climate-science"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will AfD win the most seats in the 2026 Berlin state elections?",
+      "yesPrice": 17.8,
+      "volume": 3139438.4668219998,
+      "url": "https://polymarket.com/event/berlin-state-election-winner",
+      "endDate": "2026-09-20T00:00:00Z",
+      "tags": ["world-elections", "world", "german-elections", "main-election", "global-elections", "politics", "elections", "germany"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Iran leadership change by December 31?",
+      "yesPrice": 21.5,
+      "volume": 21324457.626913022,
+      "url": "https://polymarket.com/event/iran-leadership-change-by",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["politics", "iran", "iranian-leadership-regime", "geopolitics", "mojtaba", "ayatollah", "khamenei", "mojtaba-khamenei", "khamenei-out", "mojtaba-out"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Anthropic or OpenAI IPO first?",
+      "yesPrice": 89.5,
+      "volume": 243958.46079199994,
+      "url": "https://polymarket.com/event/will-anthropic-or-openai-ipo-first",
+      "endDate": "2027-12-31T00:00:00Z",
+      "tags": ["sam-altman", "openai", "business", "ipos", "ipo", "finance", "ai", "claude-5", "openai-ipo", "anthropic-ipo", "anthropic"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Major meteor strike (10kt+) in 2026?",
+      "yesPrice": 10,
+      "volume": 178617.20540100013,
+      "url": "https://polymarket.com/event/major-meteor-strike-10kt-in-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["climate-science", "spacex", "science", "space", "astroid", "weather", "nasa", "natural-disaster"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will OpenAI IPO by December 31 2026?",
+      "yesPrice": 18.5,
+      "volume": 2666893.5167150036,
+      "url": "https://polymarket.com/event/openai-ipo-by",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["openai-ipo", "ipos", "big-tech", "ai", "finance", "business", "ipo", "openai"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Anthropic's market cap be less than $1.25T at market close on IPO day?",
+      "yesPrice": 10.5,
+      "volume": 181328.51955,
+      "url": "https://polymarket.com/event/anthropic-ipo-closing-market-cap-higher-strikes",
+      "endDate": "2026-12-31T23:55:00Z",
+      "tags": ["finance", "big-tech", "anthropic", "ipo", "claude", "ipos", "ai", "anthropic-ipo", "rewards-200-4pt5-50"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will a Chinese company have the best AI model by December 31?",
+      "yesPrice": 11,
+      "volume": 117536.64933199997,
+      "url": "https://polymarket.com/event/will-a-chinese-company-have-the-best-ai-model-by-december-31",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["tech", "ai", "china", "airdrops", "big-tech", "ai-rankings"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Predict.fun FDV above $200M one day after launch?",
+      "yesPrice": 76,
+      "volume": 6008300.814157001,
+      "url": "https://polymarket.com/event/predictfun-fdv-above-one-day-after-launch",
+      "endDate": "2028-01-01T05:00:00Z",
+      "tags": ["crypto", "fdv", "pre-market", "predictptfun"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Hyperliquid reach $100 by December 31, 2026?",
+      "yesPrice": 21,
+      "volume": 1793110.0578889996,
+      "url": "https://polymarket.com/event/what-price-will-hyperliquid-hit-before-2027",
+      "endDate": "2027-01-01T05:00:00Z",
+      "tags": ["hyperliquid", "crypto", "yearly", "hit-price", "crypto-prices"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will there be between 11 and 13 earthquakes of magnitude 7.0 or higher worldwide in 2026?",
+      "yesPrice": 20.5,
+      "volume": 1364579.1847659997,
+      "url": "https://polymarket.com/event/how-many-7pt0-or-above-earthquakes-in-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["weather", "climate-science", "science", "earthquakes", "natural-disasters"],
+      "source": "polymarket"
+    },
+    {
+      "title": "AI bubble burst in 2026?",
+      "yesPrice": 23.1,
+      "volume": 2919068.237889004,
+      "url": "https://polymarket.com/event/ai-bubble-burst-by",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["business", "tech", "finance", "big-tech"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will the ECB announce a 25 bps increase at the September 2026 meeting?",
+      "yesPrice": 85.5,
+      "volume": 163418.667147,
+      "url": "https://polymarket.com/event/ecb-interest-rates-september-2026-20260616222636097",
+      "endDate": "2026-09-10T11:59:00Z",
+      "tags": ["ecb", "euro", "europe", "economy", "eurozone", "Global-Rates", "interest-rates", "monetary-policy", "macro-indicators", "european-central-bank"],
+      "source": "polymarket"
+    },
+    {
+      "title": "ECB rate cut in 2026?",
+      "yesPrice": 11.5,
+      "volume": 30456.509546999998,
+      "url": "https://polymarket.com/event/ecb-rate-cut-in-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["Global-Rates", "economy", "europe", "eu", "economic-policy"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Natural Disaster in 2026?",
+      "yesPrice": 18,
+      "volume": 229823.07414900002,
+      "url": "https://polymarket.com/event/natural-disaster-in-2026",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["parlays", "hurricane", "nasa", "astroid", "science", "earthquake", "weather", "climate", "space", "natural-disaster", "natural-disasters", "climate-science"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will the Reserve Bank of India make no change to the policy repo rate after the August Meeting?",
+      "yesPrice": 89,
+      "volume": 13530.476868,
+      "url": "https://polymarket.com/event/reserve-bank-of-india-decision-in-august-20260630194149522",
+      "endDate": "2026-08-05T00:00:00Z",
+      "tags": ["rbi", "economy", "Global-Rates", "interest-rates", "economic-policy"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Kraken IPO by December 31, 2026?",
+      "yesPrice": 26,
+      "volume": 1590045.474205,
+      "url": "https://polymarket.com/event/kraken-ipo-in-2025",
+      "endDate": "2027-01-01T05:00:00Z",
+      "tags": ["crypto", "exchange", "finance", "business", "2025-predictions", "featured", "ipos", "crypto-listings"],
+      "source": "polymarket"
+    },
+    {
+      "title": "U.S. agrees to a new trade deal with \"Pakistan\" before 2027?",
+      "yesPrice": 12,
+      "volume": 360614.04719799996,
+      "url": "https://polymarket.com/event/which-countries-will-trump-make-new-trade-deals-with-before-2027-921",
+      "endDate": "2026-12-31T00:00:00Z",
+      "tags": ["tariffs", "trade-war", "politics", "geopolitics", "trump", "world"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Clarity Act (H.R.3633) signed into law in 2026?",
+      "yesPrice": 28.5,
+      "volume": 3314337.6252710004,
+      "url": "https://polymarket.com/event/clarity-act-signed-into-law-in-2026",
+      "endDate": "2027-01-01T05:00:00Z",
+      "tags": ["crypto", "trump", "politics", "us-law", "crypto-legal", "clarity-act"],
+      "source": "polymarket"
+    },
+    {
+      "title": "Will Elon Musk visit Mars in his lifetime?: Mars",
+      "yesPrice": 12,
+      "volume": 114574.56,
+      "url": "https://kalshi.com/markets/KXELONMARS-99",
+      "endDate": "2099-08-01T04:59:00Z",
+      "tags": [],
+      "source": "kalshi"
+    },
+    {
+      "title": "Will Zohran Mamdani become President of the United States before 2045?: Before 2045",
+      "yesPrice": 11,
+      "volume": 37573.98,
+      "url": "https://kalshi.com/markets/KXPERSONPRESMAM-45",
+      "endDate": "2045-01-29T15:00:00Z",
+      "tags": [],
+      "source": "kalshi"
+    },
+    {
+      "title": "Will OpenAI or Anthropic IPO first?: Anthropic",
+      "yesPrice": 83,
+      "volume": 168166.92,
+      "url": "https://kalshi.com/markets/KXOAIANTH-40-ANTH",
+      "endDate": "2040-01-01T04:59:00Z",
+      "tags": [],
+      "source": "kalshi"
+    },
+    {
+      "title": "Who will succeed Netanyahu as Prime Minister of Israel?: Naftali Bennett",
+      "yesPrice": 14,
+      "volume": 37318.27,
+      "url": "https://kalshi.com/markets/KXNEXTISRAELPM-45JAN01-NBEN",
+      "endDate": "2045-01-01T15:00:00Z",
+      "tags": [],
+      "source": "kalshi"
+    },
+    {
+      "title": "Will Nick Fuentes become President of the United States before 2045?: Before 2045",
+      "yesPrice": 16,
+      "volume": 52854.74,
+      "url": "https://kalshi.com/markets/KXPERSONPRESFUENTES-45",
+      "endDate": "2045-01-08T15:00:00Z",
+      "tags": [],
+      "source": "kalshi"
+    }
+  ]
+}

--- a/tests/fixtures/prediction-markets-raw-candidates.json
+++ b/tests/fixtures/prediction-markets-raw-candidates.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Real prediction:markets-bootstrap:v1 records captured from production on 2026-07-30 (union of the geopolitical/tech/finance pools, deduplicated by url). This is the shape scripts/seed-prediction-markets.mjs holds in its `markets` array before classification. Used by tests/prediction-market-classification.test.mjs to exercise the classifier against real venue titles + real Polymarket tag slugs (including Kalshi records, which always carry an empty tags array). Fixture for #5733.",
+  "_comment": "Real prediction:markets-bootstrap:v1 records captured from production on 2026-07-30 (union of the geopolitical/tech/finance pools, deduplicated by url). NOTE ON PROVENANCE: these are PUBLISHED records, so each already passed the seeder's shouldInclude gates (price band, volume floor, exclude/meme keywords) and carries the added `regions` field's inputs — it is the raw-candidate SHAPE, but a pre-filtered SAMPLE, not an unfiltered fetch. That is what makes it the right fixture for classification (real venue titles and real Polymarket tag slugs, including Kalshi records which always carry an empty tags array) and the wrong one for exercising shouldInclude's own thresholds. Fixture for #5733.",
   "markets": [
     {
       "title": "Will no Fed rate cuts happen in 2026?",

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -295,6 +295,50 @@ describe('calibrateWithMarkets', () => {
     assert.equal(pred.probability, 0.45);
   });
 
+  // #5733: these two readers used `markets.geopolitical` as a stand-in for "all
+  // markets", which was true only while the producer published near-duplicate
+  // pools. Now that the pools are a disjoint partition, a macro/rates/crypto
+  // anchor lives ONLY in tech or finance, and reading one pool would silently
+  // drop it. Every other test in this describe passes a geopolitical-only
+  // fixture, so without these the regression ships green.
+  it('calibrates from an anchor that lives in the finance pool, not geopolitical', () => {
+    const pred = makePrediction(
+      'economic', 'United States', 'US recession',
+      0.7, 0.6, '7d', [],
+    );
+    pred.region = 'United States';
+    calibrateWithMarkets([pred], {
+      geopolitical: [],
+      tech: [],
+      finance: [{ title: 'US recession by end of 2026?', yesPrice: 30, source: 'polymarket', volume: 50000 }],
+    });
+    assert.ok(pred.calibration !== null, 'a finance-pool market must still calibrate');
+    assert.equal(pred.probability, +(0.4 * 0.3 + 0.6 * 0.7).toFixed(3));
+  });
+
+  it('calibrates from an anchor that lives in the tech pool', () => {
+    const pred = makePrediction(
+      'economic', 'United States', 'US AI market correction',
+      0.7, 0.6, '7d', [],
+    );
+    pred.region = 'United States';
+    calibrateWithMarkets([pred], {
+      geopolitical: [],
+      tech: [{ title: 'US AI market correction in 2026?', yesPrice: 30, source: 'polymarket', volume: 50000 }],
+      finance: [],
+    });
+    assert.ok(pred.calibration !== null, 'a tech-pool market must still calibrate');
+  });
+
+  it('returns early only when every pool is empty', () => {
+    const pred = makePrediction('economic', 'United States', 'US recession', 0.7, 0.6, '7d', []);
+    const original = pred.probability;
+    calibrateWithMarkets([pred], { geopolitical: [], tech: [], finance: [] });
+    assert.equal(pred.probability, original);
+    calibrateWithMarkets([pred], undefined);
+    assert.equal(pred.probability, original);
+  });
+
   it('does not calibrate de-escalation risk from an adverse YES market', () => {
     const pred = makePrediction(
       'conflict', 'Sudan', 'Ceasefire holds in Sudan',
@@ -2756,6 +2800,37 @@ describe('detectFromPredictionMarkets', () => {
       title: `Will Europe face crisis ${i}?`, yesPrice: 70,
     })) };
     assert.ok(detectFromPredictionMarkets({ predictionMarkets: markets }).length <= 5);
+  });
+
+  // #5733: reads every pool, not just geopolitical. The detector's own gate is
+  // "the title tags a region", so a tech- or finance-classified market with a
+  // regional title is in scope — and since the producer's pools became a
+  // disjoint partition those markets no longer appear in `geopolitical`.
+  it('detects from the tech and finance pools, not only geopolitical', () => {
+    const fromTech = detectFromPredictionMarkets({
+      predictionMarkets: {
+        geopolitical: [],
+        tech: [{ title: 'Will China ship the best AI model by December 31?', yesPrice: 70, source: 'polymarket' }],
+        finance: [],
+      },
+    });
+    assert.equal(fromTech.length, 1, 'a tech-pool market must still produce a prediction');
+    assert.equal(fromTech[0].region, 'Asia-Pacific');
+
+    const fromFinance = detectFromPredictionMarkets({
+      predictionMarkets: {
+        geopolitical: [],
+        tech: [],
+        finance: [{ title: 'Will the ECB cut rates in 2026?', yesPrice: 70, source: 'polymarket' }],
+      },
+    });
+    assert.equal(fromFinance.length, 1, 'a finance-pool market must still produce a prediction');
+    assert.equal(fromFinance[0].region, 'Europe');
+  });
+
+  it('tolerates a payload missing pools entirely', () => {
+    assert.equal(detectFromPredictionMarkets({ predictionMarkets: {} }).length, 0);
+    assert.equal(detectFromPredictionMarkets({}).length, 0);
   });
 });
 

--- a/tests/forecast-resolution.test.mjs
+++ b/tests/forecast-resolution.test.mjs
@@ -387,6 +387,32 @@ describe('buildResolutionSpec — prediction_market deadline is the market endDa
     assert.notEqual(spec.deadline, GENERATED_AT + HORIZON_MS['30d']);
   });
 
+  // #5733: the endDate index reads all three pools. It used to read only
+  // `.geopolitical`, which was every market while the producer published
+  // near-duplicate pools; now the pools are a disjoint partition, so a
+  // market-anchored forecast whose market classifies as tech or finance would
+  // silently lose its real settlement deadline and fall back to the horizon.
+  for (const pool of ['tech', 'finance']) {
+    it(`deadline resolves from a market in the ${pool} pool`, () => {
+      const endDateMs = Date.parse('2026-12-31');
+      const forecast = pred({
+        domain: 'economic',
+        region: 'United States',
+        title: 'Will no Fed rate cuts happen in 2026?',
+        timeHorizon: '30d',
+        signals: [{ type: 'prediction_market', value: 'Polymarket: 62%', weight: 0.8 }],
+      });
+      const spec = buildResolutionSpec(forecast, {
+        predictionMarkets: {
+          geopolitical: [],
+          [pool]: [{ title: 'Will no Fed rate cuts happen in 2026?', yesPrice: 62, endDate: '2026-12-31' }],
+        },
+      }, GENERATED_AT);
+      assert.equal(spec.deadline, endDateMs, `${pool}-pool market must supply the settlement deadline`);
+      assert.notEqual(spec.deadline, GENERATED_AT + HORIZON_MS['30d']);
+    });
+  }
+
   it('falls back to the horizon deadline when the market endDate is missing (still non-null)', () => {
     const forecast = pred({
       domain: 'political',

--- a/tests/prediction-country-markets-pools.test.mts
+++ b/tests/prediction-country-markets-pools.test.mts
@@ -1,0 +1,173 @@
+// fetchCountryMarkets must reach every pool after #5733 made the producer's
+// geopolitical/tech/finance buckets a disjoint partition.
+//
+// Before the fix, `bootstrap.geopolitical` was an unfiltered copy of every
+// market, so BOTH of this function's paths could ignore the tech pool and still
+// see tech-classified markets. Now they cannot:
+//   - the RPC fan-out must query a tech category, because it early-returns as
+//     soon as any geopolitics/economy match is found and would otherwise never
+//     reach the fallback below;
+//   - the bootstrap fallback must union all three buckets.
+// Both holes were live in the same function, so this pins both.
+//
+// Loaded through an esbuild stub bundle (the pattern in
+// tests/giving-service-recovery.test.mts) because the module is browser-side and
+// imports the generated RPC client, the bootstrap hydration cache, and config.
+
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { after, describe, it } from 'node:test';
+import { build } from 'esbuild';
+
+const root = resolve(import.meta.dirname, '..');
+const entryPath = resolve(root, 'src/services/prediction/index.ts');
+
+interface CountryMarketsTestState {
+  rpcCalls: { category: string; query: string }[];
+  rpcMarketsByCategory: Record<string, unknown[]>;
+  hydrated?: unknown;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __wmCountryMarketsTestState: CountryMarketsTestState | undefined;
+}
+
+function protoMarket(title: string, volume: number) {
+  return {
+    id: title,
+    title,
+    yesPrice: 0.5,
+    volume,
+    url: `https://polymarket.com/event/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    closesAt: Date.parse('2099-01-01T00:00:00Z'),
+    category: '',
+    source: 'MARKET_SOURCE_POLYMARKET',
+  };
+}
+
+function bootstrapMarket(title: string, volume: number) {
+  return {
+    title,
+    yesPrice: 50,
+    volume,
+    url: `https://polymarket.com/event/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    endDate: '2099-01-01T00:00:00Z',
+    source: 'polymarket',
+  };
+}
+
+async function loadPredictionService() {
+  const stubModules = new Map<string, string>([
+    ['rpc-client-stub', `export function getRpcBaseUrl() { return 'https://example.test'; }`],
+    ['config-stub', `export const SITE_VARIANT = 'full';`],
+    ['utils-stub', `
+      export function createCircuitBreaker() {
+        return { execute: async (fn, fallback) => { try { return await fn(); } catch { return fallback; } } };
+      }
+    `],
+    ['bootstrap-stub', `
+      export function getHydratedData() {
+        return globalThis.__wmCountryMarketsTestState?.hydrated;
+      }
+    `],
+    ['generated-rpc-clients-stub', `
+      export class PredictionServiceClient {
+        async listPredictionMarkets(req) {
+          const state = globalThis.__wmCountryMarketsTestState;
+          state.rpcCalls.push({ category: req.category, query: req.query });
+          return { markets: state.rpcMarketsByCategory[req.category] ?? [] };
+        }
+      }
+    `],
+  ]);
+  const aliases = new Map([
+    ['@/services/rpc-client', 'rpc-client-stub'],
+    ['@/config', 'config-stub'],
+    ['@/utils', 'utils-stub'],
+    ['@/services/bootstrap', 'bootstrap-stub'],
+    ['@/services/generated-rpc-clients', 'generated-rpc-clients-stub'],
+  ]);
+
+  const result = await build({
+    entryPoints: [entryPath],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    loader: { '.json': 'json' },
+    plugins: [{
+      name: 'country-markets-pool-test-stubs',
+      setup(buildApi) {
+        buildApi.onResolve({ filter: /.*/ }, (args) => {
+          const target = aliases.get(args.path);
+          return target ? { path: target, namespace: 'stub' } : null;
+        });
+        buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+          contents: stubModules.get(args.path),
+          loader: 'ts',
+        }));
+      },
+    }],
+  });
+
+  const bundleUrl =
+    `data:text/javascript;base64,${Buffer.from(result.outputFiles[0]!.text).toString('base64')}`;
+  return import(bundleUrl);
+}
+
+after(() => {
+  delete globalThis.__wmCountryMarketsTestState;
+});
+
+describe('fetchCountryMarkets reaches every pool (#5733)', () => {
+  it('queries a tech category in the RPC fan-out, not just geopolitics + economy', async () => {
+    globalThis.__wmCountryMarketsTestState = { rpcCalls: [], rpcMarketsByCategory: {} };
+    const service = await loadPredictionService();
+    await service.fetchCountryMarkets('China');
+
+    const categories = globalThis.__wmCountryMarketsTestState!.rpcCalls.map((c) => c.category).sort();
+    assert.deepEqual(categories, ['economy', 'geopolitics', 'tech']);
+  });
+
+  it('does not let a geopolitics hit early-return past the tech pool', async () => {
+    // This is the actual defect: the function returns as soon as any
+    // geopolitics/economy market matches the country, so a tech-only category
+    // would never be seen if it were not in the fan-out above.
+    globalThis.__wmCountryMarketsTestState = {
+      rpcCalls: [],
+      rpcMarketsByCategory: {
+        geopolitics: [protoMarket('Will China invade Taiwan by 2027?', 5_000_000)],
+        tech: [protoMarket('Will China ship the best AI model?', 9_000_000)],
+      },
+    };
+    const service = await loadPredictionService();
+    const out = await service.fetchCountryMarkets('China');
+
+    const titles = out.map((m: { title: string }) => m.title);
+    assert.ok(titles.some((t: string) => t.includes('invade Taiwan')), `geo market missing: ${titles}`);
+    assert.ok(titles.some((t: string) => t.includes('best AI model')), `tech market missing: ${titles}`);
+  });
+
+  it('unions all three buckets in the bootstrap fallback', async () => {
+    // RPC returns nothing, so the bootstrap fallback is the only path. A
+    // tech-classified country market lives ONLY in the tech bucket now.
+    globalThis.__wmCountryMarketsTestState = {
+      rpcCalls: [],
+      rpcMarketsByCategory: {},
+      hydrated: {
+        geopolitical: [],
+        tech: [bootstrapMarket('Will China ship the best AI model', 9_000_000)],
+        finance: [bootstrapMarket('Will China cut its policy rate', 4_000_000)],
+        fetchedAt: Date.now(),
+      },
+    };
+    const service = await loadPredictionService();
+    const out = await service.fetchCountryMarkets('China');
+
+    const titles = out.map((m: { title: string }) => m.title);
+    assert.ok(titles.some((t: string) => t.includes('best AI model')), `tech bucket missing: ${titles}`);
+    assert.ok(titles.some((t: string) => t.includes('policy rate')), `finance bucket missing: ${titles}`);
+  });
+});

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -1,0 +1,562 @@
+// Producer-side pool classification for prediction:markets-bootstrap:v1 (#5733).
+//
+// The bug: seed-prediction-markets built its pools as
+//   geopolitical = filterAndScore(markets, null)                     // NO filter
+//   tech         = filterAndScore(markets, m => m.tags ∈ TECH_TAGS)
+//   finance      = filterAndScore(markets, m => kalshi || tags ∈ FINANCE_TAGS)
+// so (a) `geopolitical` was an unfiltered copy of EVERY market, and (b) the tech
+// and finance tag lists shared `economy`/`crypto`/`business`, which made the
+// three pools near-duplicates. Production on 2026-07-30 published 75 records
+// covering only 46 distinct markets, and the geopolitical pool's top-volume
+// entry was a Fed-rates market at $45.6M.
+//
+// These tests run the REAL classifier against the REAL production records in
+// tests/fixtures/prediction-markets-raw-candidates.json.
+
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import { isGeopoliticalMarket } from '../scripts/_bet-templates-markets-classify.mjs';
+import {
+  CATEGORIES,
+  DEFAULT_CATEGORY,
+  buildBootstrapPools,
+  classifyMarket,
+  dedupeMarkets,
+  formatIntegrityViolations,
+  hasCategoryTag,
+  marketIdentity,
+  partitionMarkets,
+  poolIntegrityViolations,
+  validateBootstrapPayload,
+} from '../scripts/_prediction-classify.mjs';
+import { filterAndScore } from '../scripts/_prediction-scoring.mjs';
+import predictionTags from '../scripts/data/prediction-tags.json' with { type: 'json' };
+import filterParamContracts from '../shared/openapi-filter-param-contracts.json' with { type: 'json' };
+import fixture from './fixtures/prediction-markets-raw-candidates.json' with { type: 'json' };
+
+const RAW = fixture.markets;
+
+// The seeder's REAL pool-building path — buildBootstrapPools is what
+// seed-prediction-markets.mjs calls, not a replica of it. This matters: an
+// earlier version of this file re-implemented the partition-then-rank wiring
+// locally, which meant reverting the seeder to the #5733 shape
+// (`filterAndScore(markets, null)` for geopolitical) left the whole suite green.
+function buildPools(markets) {
+  return buildBootstrapPools(markets).pools;
+}
+
+function titles(pool) {
+  return pool.map((m) => m.title);
+}
+
+describe('#5733 fixture actually exhibits the bug (guards the assertions below from being vacuous)', () => {
+  // Without this, "pools are disjoint" could pass simply because the fixture
+  // happens to contain no market matching two pools. Replays the OLD pool
+  // construction verbatim and pins the duplication it produced.
+  const TECH_TAGS = predictionTags.tech;
+  const FINANCE_TAGS = predictionTags.finance;
+
+  const legacy = {
+    geopolitical: filterAndScore(RAW, null),
+    tech: filterAndScore(RAW, (m) => m.tags?.some((t) => TECH_TAGS.includes(t))),
+    finance: filterAndScore(RAW, (m) => m.source === 'kalshi' || m.tags?.some((t) => FINANCE_TAGS.includes(t))),
+  };
+
+  it('the legacy geopolitical pool was an unfiltered draw from every category', () => {
+    // filterAndScore caps at 25, which is exactly the pool size production
+    // published — the pool was the top 25 of ALL markets, not of geo markets.
+    assert.equal(legacy.geopolitical.length, 25);
+    const drawn = new Set(legacy.geopolitical.map((m) => classifyMarket(m)));
+    assert.deepEqual([...drawn].sort(), ['finance', 'geopolitical', 'tech']);
+  });
+
+  it('the legacy pools cross-duplicated many markets', () => {
+    const counts = new Map();
+    for (const category of CATEGORIES) {
+      for (const m of legacy[category]) {
+        counts.set(marketIdentity(m), (counts.get(marketIdentity(m)) ?? 0) + 1);
+      }
+    }
+    const duplicated = [...counts.values()].filter((n) => n > 1).length;
+    assert.ok(duplicated >= 20, `expected the legacy pools to cross-duplicate many markets, got ${duplicated}`);
+  });
+
+  it('the legacy geopolitical pool was topped by a non-geopolitical market', () => {
+    const top = legacy.geopolitical.slice().sort((a, b) => b.volume - a.volume)[0];
+    assert.equal(top.title, 'Will no Fed rate cuts happen in 2026?');
+    assert.ok(!isGeopoliticalMarket(top.title));
+  });
+});
+
+describe('classifyMarket', () => {
+  it('assigns exactly one of the three canonical categories', () => {
+    for (const m of RAW) {
+      assert.ok(CATEGORIES.includes(classifyMarket(m)), `${m.title} → ${classifyMarket(m)}`);
+    }
+  });
+
+  it('classifies conflict / statecraft / national-election markets as geopolitical', () => {
+    for (const title of [
+      'Iran agrees to surrender enriched uranium stockpile by December 31, 2026?',
+      'Iran coup attempt by December 31?',
+      'Iran leadership change by December 31?',
+      'Will China invade Taiwan by December 31, 2027?',
+      'NATO/EU troops fighting in Ukraine by December 31, 2026?',
+      'Will Ukraine agree to cede territory to Russia before 2027?',
+      'Will Mojtaba Khamenei be head of state in Iran end of 2026?',
+      'Will the Democratic Party control the House after the 2026 Midterm elections?',
+      'Will Renan Santos finish in second place in the first round of the 2026 Brazilian presidential election?',
+    ]) {
+      const market = RAW.find((m) => m.title === title);
+      assert.ok(market, `fixture is missing ${title}`);
+      assert.equal(classifyMarket(market), 'geopolitical', title);
+    }
+  });
+
+  it('keeps the crypto / AI / company markets that polluted the geo pool OUT of it', () => {
+    for (const title of [
+      'Will no Fed rate cuts happen in 2026?',
+      'Ledger IPO before 2027?',
+      'Will Nebius Group be acquired before 2027?',
+      'Will Anthropic have the highest IPO Market Cap 2026?',
+      'Will Pump.fun perform an airdrop by December 31, 2026',
+      'Opensea FDV above $500M one day after launch?',
+      'US recession by end of 2026?',
+      'Sam Altman out as OpenAI CEO before 2027?',
+      'Will MegaETH perform an airdrop by December 31, 2026?',
+      'Will 7-8 SpaceX Starship launches successfully reach Space in 2026?',
+      'Will the Doge-1 Lunar Mission launch by December 31, 2026?',
+    ]) {
+      const market = RAW.find((m) => m.title === title);
+      assert.ok(market, `fixture is missing ${title}`);
+      assert.notEqual(classifyMarket(market), 'geopolitical', title);
+    }
+  });
+
+  it('rescues geopolitical markets whose venue tags are absent (Kalshi) via the title', () => {
+    // Kalshi records always carry tags: [] — the legacy `source === 'kalshi'`
+    // rule filed every one of these under finance.
+    for (const title of [
+      'Who will succeed Netanyahu as Prime Minister of Israel?: Naftali Bennett',
+      'Will Zohran Mamdani become President of the United States before 2045?: Before 2045',
+      'Will Nick Fuentes become President of the United States before 2045?: Before 2045',
+    ]) {
+      const market = RAW.find((m) => m.title === title);
+      assert.ok(market, `fixture is missing ${title}`);
+      assert.deepEqual(market.tags, []);
+      assert.equal(classifyMarket(market), 'geopolitical', title);
+    }
+  });
+
+  it('rescues geopolitical markets whose title the strict matcher misses, via venue tags', () => {
+    // "Berlin state elections" is not in the title matcher's qualified-election
+    // vocabulary (it is deliberately precision-first), but the venue tags
+    // elections/global-elections/world-elections are unambiguous.
+    const market = RAW.find((m) => m.title === 'Will AfD win the most seats in the 2026 Berlin state elections?');
+    assert.ok(!isGeopoliticalMarket(market.title), 'title matcher is expected to miss this one');
+    assert.ok(hasCategoryTag(market.tags, 'geopolitical'));
+    assert.equal(classifyMarket(market), 'geopolitical');
+  });
+
+  it('routes rates / macro markets to finance, not tech', () => {
+    for (const title of [
+      'Will no Fed rate cuts happen in 2026?',
+      'US recession by end of 2026?',
+      'Will the ECB announce a 25 bps increase at the September 2026 meeting?',
+      'ECB rate cut in 2026?',
+      'Will the Reserve Bank of India make no change to the policy repo rate after the August Meeting?',
+    ]) {
+      const market = RAW.find((m) => m.title === title);
+      assert.ok(market, `fixture is missing ${title}`);
+      assert.equal(classifyMarket(market), 'finance', title);
+    }
+  });
+
+  it('routes AI / crypto / science markets to tech', () => {
+    for (const title of [
+      'Will a Chinese company have the best AI model by December 31?',
+      'Will Hyperliquid reach $100 by December 31, 2026?',
+      'Kraken IPO by December 31, 2026?',
+      'Will there be between 11 and 13 earthquakes of magnitude 7.0 or higher worldwide in 2026?',
+      'AI bubble burst in 2026?',
+    ]) {
+      const market = RAW.find((m) => m.title === title);
+      assert.ok(market, `fixture is missing ${title}`);
+      assert.equal(classifyMarket(market), 'tech', title);
+    }
+  });
+
+  it('falls back to the documented default when nothing matches', () => {
+    // Hardcoded, NOT compared against DEFAULT_CATEGORY: round-tripping through
+    // the constant under test would let a flip to 'geopolitical' pass here and
+    // silently recreate the #5733 catch-all geo pool.
+    assert.equal(classifyMarket({ title: 'Will an unclassifiable thing happen?', tags: [] }), 'finance');
+    assert.equal(classifyMarket({ title: 'Untagged', tags: undefined }), 'finance');
+    assert.equal(DEFAULT_CATEGORY, 'finance', 'the exported default must stay finance');
+  });
+
+  it('is total — never throws and never returns a non-category for junk input', () => {
+    for (const junk of [null, undefined, {}, { title: null, tags: null }, { title: 42, tags: 'nope' }]) {
+      assert.ok(CATEGORIES.includes(classifyMarket(junk)), JSON.stringify(junk));
+    }
+  });
+
+  it('matches tags case-insensitively (Polymarket ships mixed-case slugs like Global-Rates)', () => {
+    assert.ok(hasCategoryTag(['GLOBAL-RATES', 'Interest-Rates'], 'finance'));
+    assert.ok(hasCategoryTag([' Crypto '], 'tech'));
+  });
+});
+
+describe('partitionMarkets / published pools', () => {
+  const pools = buildPools(RAW);
+
+  it('publishes every market exactly once across the three pools', () => {
+    const seen = new Map();
+    for (const category of CATEGORIES) {
+      for (const m of pools[category]) {
+        const id = marketIdentity(m);
+        assert.ok(!seen.has(id), `${m.title} appears in both ${seen.get(id)} and ${category}`);
+        seen.set(id, category);
+      }
+    }
+    assert.equal(seen.size, RAW.length, 'no market may be dropped by the partition');
+  });
+
+  it('no longer inflates the record count with cross-pool copies', () => {
+    const total = CATEGORIES.reduce((n, c) => n + pools[c].length, 0);
+    assert.equal(total, RAW.length, 'declared record count must equal the distinct market count');
+  });
+
+  it('every geopolitical pool entry meets the geo criteria (keyword OR venue category)', () => {
+    for (const m of pools.geopolitical) {
+      assert.ok(
+        isGeopoliticalMarket(m.title) || hasCategoryTag(m.tags, 'geopolitical'),
+        `non-geopolitical market in the geo pool: ${m.title}`,
+      );
+    }
+  });
+
+  it('surfaces genuine geopolitics at the top of the geo pool instead of burying it', () => {
+    const top = pools.geopolitical.slice().sort((a, b) => b.volume - a.volume)[0];
+    assert.equal(top.title, 'Will Mojtaba Khamenei be head of state in Iran end of 2026?');
+  });
+
+  it('leaves every pool populated for the site variants that read them', () => {
+    for (const category of CATEGORIES) {
+      assert.ok(pools[category].length > 0, `${category} pool is empty`);
+    }
+  });
+
+  it('keeps the pools recognisably distinct rather than near-copies', () => {
+    assert.ok(
+      pools.geopolitical.length < RAW.length,
+      'the geo pool must no longer be a copy of every market',
+    );
+    for (const title of titles(pools.geopolitical)) {
+      assert.ok(!titles(pools.tech).includes(title), `${title} in both geo and tech`);
+      assert.ok(!titles(pools.finance).includes(title), `${title} in both geo and finance`);
+    }
+  });
+
+  it('drops nothing on the floor: partition sizes sum to the input', () => {
+    const partitioned = partitionMarkets(RAW);
+    const total = CATEGORIES.reduce((n, c) => n + partitioned[c].length, 0);
+    assert.equal(total, RAW.length);
+  });
+
+  it('tolerates junk entries without dropping valid ones', () => {
+    const partitioned = partitionMarkets([null, RAW[0], 'nope', undefined, RAW[2]]);
+    const total = CATEGORIES.reduce((n, c) => n + partitioned[c].length, 0);
+    assert.equal(total, 2);
+  });
+
+  it('returns empty pools for a non-array input instead of throwing', () => {
+    for (const junk of [null, undefined, {}, 'markets']) {
+      const partitioned = partitionMarkets(junk);
+      assert.deepEqual(partitioned, { geopolitical: [], tech: [], finance: [] });
+    }
+  });
+});
+
+describe('poolIntegrityViolations (the publish gate)', () => {
+  it('passes the pools the producer actually builds', () => {
+    assert.deepEqual(poolIntegrityViolations(buildPools(RAW)), []);
+  });
+
+  it('catches a market copied across two pools', () => {
+    const geo = RAW.find((m) => m.title === 'Iran coup attempt by December 31?');
+    const violations = poolIntegrityViolations({ geopolitical: [geo], tech: [], finance: [geo] });
+    assert.ok(violations.some((v) => v.kind === 'duplicate-market'));
+  });
+
+  it('catches a mislabeled market — the exact #5733 regression', () => {
+    const fed = RAW.find((m) => m.title === 'Will no Fed rate cuts happen in 2026?');
+    const violations = poolIntegrityViolations({ geopolitical: [fed], tech: [], finance: [] });
+    assert.ok(violations.some((v) => v.kind === 'category-mismatch' && v.expected === 'finance'));
+  });
+
+  it('catches the legacy unfiltered geopolitical pool wholesale', () => {
+    const violations = poolIntegrityViolations({
+      geopolitical: filterAndScore(RAW, null),
+      tech: [],
+      finance: [],
+    });
+    assert.ok(violations.length > 0);
+  });
+
+  it('reports a pool that is not an array rather than throwing', () => {
+    const violations = poolIntegrityViolations({ geopolitical: 'nope', tech: [], finance: [] });
+    assert.ok(violations.some((v) => v.kind === 'pool-not-array'));
+  });
+
+  it('formats a readable log line for every violation kind, not just mismatch', () => {
+    const fed = RAW.find((m) => m.title === 'Will no Fed rate cuts happen in 2026?');
+    const geo = RAW.find((m) => m.title === 'Iran coup attempt by December 31?');
+    const lines = formatIntegrityViolations([
+      ...poolIntegrityViolations({ geopolitical: [fed], tech: [], finance: [] }),
+      ...poolIntegrityViolations({ geopolitical: [geo], tech: [], finance: [geo] }),
+      ...poolIntegrityViolations({ geopolitical: 'nope', tech: [], finance: [] }),
+    ]);
+    const joined = lines.join('\n');
+    for (const kind of ['category-mismatch', 'duplicate-market', 'pool-not-array']) {
+      assert.ok(joined.includes(kind), `${kind} must render a log line:\n${joined}`);
+    }
+    assert.ok(!joined.includes('undefined'), `no log line may render "undefined":\n${joined}`);
+  });
+
+  it('caps the log at the requested number of lines', () => {
+    const many = RAW.slice(0, 8).map((m) => ({ ...m, tags: [] }));
+    const violations = poolIntegrityViolations({ geopolitical: many, tech: [], finance: [] });
+    assert.ok(violations.length > 3);
+    assert.equal(formatIntegrityViolations(violations, 3).length, 3);
+  });
+
+  it('treats a missing pool as vacuously clean (partial payloads are the caller\'s gate)', () => {
+    assert.deepEqual(poolIntegrityViolations({ tech: [], finance: [] }), []);
+    assert.deepEqual(poolIntegrityViolations({}), []);
+  });
+});
+
+describe('dedupeMarkets (upstream fan-out must not freeze the feed)', () => {
+  // The Polymarket url is built from `event.slug` while the fetch loop dedupes
+  // on `event.id`, so a parent event and its derivative can arrive as two
+  // records with one identity. If they classified differently they would land in
+  // two pools, and the integrity gate would refuse the WHOLE publish over an
+  // upstream quirk — freezing all three pools for 90+ minutes.
+  const geo = RAW.find((m) => m.title === 'Iran coup attempt by December 31?');
+
+  it('collapses same-url records, keeping the highest-volume one', () => {
+    const low = { ...geo, volume: 1_000_000, title: 'low volume twin' };
+    const high = { ...geo, volume: 9_000_000, title: 'high volume twin' };
+    const out = dedupeMarkets([low, high]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].title, 'high volume twin');
+  });
+
+  it('is order-independent (deterministic run to run)', () => {
+    const low = { ...geo, volume: 1_000_000, title: 'low' };
+    const high = { ...geo, volume: 9_000_000, title: 'high' };
+    assert.equal(dedupeMarkets([low, high])[0].title, 'high');
+    assert.equal(dedupeMarkets([high, low])[0].title, 'high');
+  });
+
+  it('does not collapse records whose url slug is degenerate', () => {
+    // Both producer paths build the url from a template, so a missing
+    // slug/ticker yields the literal ".../undefined" for every such record.
+    // Keying on that would fuse unrelated markets and drop all but one.
+    const a = { ...geo, url: 'https://polymarket.com/event/undefined', title: 'first orphan' };
+    const b = { ...geo, url: 'https://polymarket.com/event/undefined', title: 'second orphan' };
+    assert.notEqual(marketIdentity(a), marketIdentity(b));
+    assert.equal(dedupeMarkets([a, b]).length, 2);
+    const kalshi = { ...geo, url: 'https://kalshi.com/markets/undefined', title: 'kalshi orphan' };
+    assert.equal(marketIdentity(kalshi), 'title:kalshi orphan');
+  });
+
+  it('keeps distinct markets and tolerates junk / non-finite volume', () => {
+    assert.equal(dedupeMarkets(RAW).length, RAW.length);
+    assert.equal(dedupeMarkets([null, 'x', undefined]).length, 0);
+    const noVol = { ...geo, volume: undefined, title: 'no volume' };
+    const withVol = { ...geo, volume: 5, title: 'has volume' };
+    assert.equal(dedupeMarkets([noVol, withVol])[0].title, 'has volume');
+  });
+
+  it('a duplicate that would straddle two pools is absorbed, not published twice', () => {
+    // Same url, but tags that classify differently — geo by tag vs tech by tag.
+    const asGeo = { ...geo, tags: ['geopolitics'], volume: 2_000_000 };
+    const asTech = { ...geo, tags: ['ai'], volume: 1_000_000 };
+    const { pools } = buildBootstrapPools([...RAW, asTech, asGeo]);
+    assert.deepEqual(poolIntegrityViolations(pools), []);
+    const appearances = CATEGORIES.flatMap((c) => pools[c]).filter((m) => marketIdentity(m) === marketIdentity(geo));
+    assert.equal(appearances.length, 1, 'the straddling duplicate must be published exactly once');
+  });
+
+  it('reports how many duplicates it dropped so the seeder can log it', () => {
+    const twin = { ...geo, volume: 1 };
+    assert.equal(buildBootstrapPools([...RAW, twin]).duplicatesDropped, 1);
+    assert.equal(buildBootstrapPools(RAW).duplicatesDropped, 0);
+  });
+});
+
+describe('per-pool ranking: relaxation and truncation', () => {
+  function synth(n, { tag, price, volume = 50_000 }) {
+    return Array.from({ length: n }, (_, i) => ({
+      title: `Synthetic market ${i} about nothing in particular`,
+      yesPrice: price,
+      volume: volume + i,
+      url: `https://polymarket.com/event/synthetic-${tag}-${i}`,
+      endDate: '2099-01-01T00:00:00Z',
+      tags: [tag],
+      source: 'polymarket',
+    }));
+  }
+
+  it('truncates a pool above the 25 cap, dropping the lowest-ranked entries', () => {
+    // 30 tech candidates -> the published tech pool caps at 25.
+    const { pools, classified } = buildBootstrapPools(synth(30, { tag: 'ai', price: 60 }));
+    assert.equal(classified.tech, 30);
+    assert.equal(pools.tech.length, 25);
+    assert.deepEqual(poolIntegrityViolations(pools), []);
+  });
+
+  it('relaxes the price band for a pool under 15, as filterAndScore intends', () => {
+    // yesPrice 7 fails the strict [10,90] band but passes relaxed [5,95]; with
+    // only 3 candidates the pool is under the 15 threshold so relaxation fires.
+    const { pools } = buildBootstrapPools(synth(3, { tag: 'ai', price: 7 }));
+    assert.equal(pools.tech.length, 3, 'narrow pools relax rather than publish empty');
+  });
+
+  it('does NOT relax a pool that already has 15+ strict passers', () => {
+    const strict = synth(20, { tag: 'ai', price: 60 });
+    const edge = synth(1, { tag: 'ai', price: 7 }).map((m) => ({ ...m, url: `${m.url}-edge`, title: 'Edge at 7 percent' }));
+    const { pools } = buildBootstrapPools([...strict, ...edge]);
+    assert.ok(!pools.tech.some((m) => m.title === 'Edge at 7 percent'));
+  });
+
+  it('per-pool caps mean a pool cannot crowd out another (the #5733 inversion)', () => {
+    // 40 tech candidates + 2 geo: pre-fix a single ranked list would let the
+    // tech flood bury both geo markets; per-pool caps keep geo addressable.
+    const geoTwo = RAW.filter((m) => classifyMarket(m) === 'geopolitical').slice(0, 2);
+    const { pools } = buildBootstrapPools([...synth(40, { tag: 'ai', price: 60, volume: 90_000_000 }), ...geoTwo]);
+    assert.equal(pools.geopolitical.length, 2);
+    assert.equal(pools.tech.length, 25);
+  });
+});
+
+describe('validateBootstrapPayload (the seeder\'s validateFn)', () => {
+  const silent = { log: () => {} };
+
+  it('accepts the payload the producer actually builds', () => {
+    assert.equal(validateBootstrapPayload({ ...buildPools(RAW), fetchedAt: 1 }, silent), true);
+  });
+
+  it('rejects a payload with no markets at all', () => {
+    assert.equal(validateBootstrapPayload({ geopolitical: [], tech: [], finance: [] }, silent), false);
+    assert.equal(validateBootstrapPayload({}, silent), false);
+    assert.equal(validateBootstrapPayload(null, silent), false);
+  });
+
+  it('accepts a legitimately single-pool cycle instead of freezing the feed', () => {
+    // The pre-#5733 floor demanded `finance` be non-empty, which was only safe
+    // while finance was the catch-all for every Kalshi record. Now that pool
+    // membership is content-decided, a cycle whose Kalshi records are all
+    // geopolitical by title and whose Polymarket finance tags all failed yields
+    // real, publishable data — rejecting it would strand last-good until
+    // /api/health noticed 90 minutes later.
+    const pools = buildPools(RAW);
+    assert.equal(validateBootstrapPayload({ geopolitical: pools.geopolitical, tech: [], finance: [] }, silent), true);
+    assert.equal(validateBootstrapPayload({ geopolitical: [], tech: pools.tech, finance: [] }, silent), true);
+    assert.equal(validateBootstrapPayload({ geopolitical: [], tech: [], finance: pools.finance }, silent), true);
+  });
+
+  it('rejects a payload whose pools are mislabeled — the #5733 regression gate', () => {
+    // The exact pre-fix shape: geopolitical is an unfiltered copy of everything.
+    const legacyShaped = {
+      geopolitical: filterAndScore(RAW, null),
+      tech: filterAndScore(RAW, (m) => m.tags?.some((t) => predictionTags.tech.includes(t))),
+      finance: filterAndScore(RAW, (m) => m.source === 'kalshi' || m.tags?.some((t) => predictionTags.finance.includes(t))),
+    };
+    assert.equal(validateBootstrapPayload(legacyShaped, silent), false);
+  });
+
+  it('reports why it refused, so a blocked publish is diagnosable in the Railway log', () => {
+    const lines = [];
+    const fed = RAW.find((m) => m.title === 'Will no Fed rate cuts happen in 2026?');
+    const pools = buildPools(RAW);
+    validateBootstrapPayload(
+      { geopolitical: [...pools.geopolitical, fed], tech: pools.tech, finance: pools.finance },
+      { log: (line) => lines.push(line) },
+    );
+    assert.ok(lines.some((l) => l.includes('INTEGRITY')), lines.join('\n'));
+    assert.ok(lines.some((l) => l.includes('Fed rate cuts')), lines.join('\n'));
+  });
+});
+
+describe('the seeder is wired to the tested pool-building path', () => {
+  // buildBootstrapPools is the real guard: the partition-then-rank logic that
+  // carried the #5733 bug now lives in ONE function that both the seeder and
+  // these tests call, so it cannot be tested in replica. This source assertion
+  // is only a supplement for the remaining hole — seed-prediction-markets.mjs
+  // calls runSeed at module scope, so no test can import it and prove the call
+  // happens. Treat it as a tripwire for a literal revert, NOT as proof of
+  // wiring: a determined rewrite could satisfy the regex and still be wrong.
+  const source = readFileSync(new URL('../scripts/seed-prediction-markets.mjs', import.meta.url), 'utf8');
+
+  it('calls buildBootstrapPools rather than assembling pools inline', () => {
+    assert.match(source, /buildBootstrapPools\(markets\)/);
+  });
+
+  it('no longer builds an unfiltered geopolitical pool — the #5733 defect', () => {
+    assert.doesNotMatch(source, /filterAndScore\(\s*markets\s*,\s*null\s*\)/);
+    assert.doesNotMatch(source, /from '\.\/_prediction-scoring\.mjs'[\s\S]{0,400}filterAndScore/);
+  });
+
+  it('uses the shared validateFn instead of an inline population check', () => {
+    assert.match(source, /validateFn:\s*validateBootstrapPayload/);
+  });
+});
+
+describe('classification tag data', () => {
+  const classify = predictionTags.classify;
+
+  it('declares a tag list for every category', () => {
+    for (const category of CATEGORIES) {
+      assert.ok(Array.isArray(classify?.[category]) && classify[category].length > 0, category);
+    }
+  });
+
+  it('keeps the classification tag lists mutually disjoint', () => {
+    // The root cause of the near-duplicate pools was `economy`, `crypto`, and
+    // `business` living in more than one list. Overlap here silently reintroduces
+    // it, since precedence would decide membership invisibly.
+    for (const a of CATEGORIES) {
+      for (const b of CATEGORIES) {
+        if (a >= b) continue;
+        const shared = classify[a].filter((t) => classify[b].includes(t));
+        assert.deepEqual(shared, [], `${a} and ${b} share tags: ${shared.join(', ')}`);
+      }
+    }
+  });
+
+  it('is lowercase and de-duplicated', () => {
+    for (const category of CATEGORIES) {
+      const list = classify[category];
+      assert.deepEqual(list, list.map((t) => t.toLowerCase()), `${category} must be lowercase`);
+      assert.equal(new Set(list).size, list.length, `${category} has duplicate entries`);
+    }
+  });
+
+  it('stays consistent with the RPC category contracts that select these pools', () => {
+    // server/.../list-prediction-markets.ts maps a requested category to a pool
+    // using these contracts. A category the RPC calls "tech" must not be
+    // classified into a different pool by the producer, or the RPC serves the
+    // wrong bucket for it.
+    for (const tag of filterParamContracts.predictionMarketTechCategories) {
+      assert.equal(classifyMarket({ title: 'x', tags: [tag] }), 'tech', `rpc tech category ${tag}`);
+    }
+    for (const tag of filterParamContracts.predictionMarketFinanceCategories) {
+      assert.equal(classifyMarket({ title: 'x', tags: [tag] }), 'finance', `rpc finance category ${tag}`);
+    }
+  });
+});

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -203,6 +203,26 @@ describe('classifyMarket', () => {
     }
   });
 
+  it('resolves a multi-list market by PRECEDENCE, not by tag disjointness', () => {
+    // Disjoint classify lists guarantee no single tag maps to two categories.
+    // They do NOT make markets unambiguous: a market routinely carries tags from
+    // several lists, and then the order in CATEGORIES decides. Reordering
+    // CATEGORIES would silently move these between published pools.
+    assert.deepEqual([...CATEGORIES], ['geopolitical', 'tech', 'finance'], 'precedence order is a contract');
+
+    // crypto (tech) + business/finance (finance) -> tech wins, because tech is first.
+    const kraken = RAW.find((m) => m.title === 'Kraken IPO by December 31, 2026?');
+    assert.ok(kraken.tags.includes('crypto') && kraken.tags.includes('business'));
+    assert.equal(classifyMarket(kraken), 'tech');
+
+    // A geo tag beats both, whatever else the market carries.
+    assert.equal(classifyMarket({ title: 'x', tags: ['geopolitics', 'ai', 'economy'] }), 'geopolitical');
+    // Title geo beats every tag.
+    assert.equal(classifyMarket({ title: 'Iran coup attempt by December 31?', tags: ['ai', 'economy'] }), 'geopolitical');
+    // tech beats finance when both match and neither is geo.
+    assert.equal(classifyMarket({ title: 'x', tags: ['ai', 'economy'] }), 'tech');
+  });
+
   it('matches tags case-insensitively (Polymarket ships mixed-case slugs like Global-Rates)', () => {
     assert.ok(hasCategoryTag(['GLOBAL-RATES', 'Interest-Rates'], 'finance'));
     assert.ok(hasCategoryTag([' Crypto '], 'tech'));

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -21,6 +21,8 @@ import { isGeopoliticalMarket } from '../scripts/_bet-templates-markets-classify
 import {
   CATEGORIES,
   DEFAULT_CATEGORY,
+  MIN_PUBLISHED_MARKETS,
+  allBootstrapMarkets,
   buildBootstrapPools,
   classifyMarket,
   dedupeMarkets,
@@ -300,6 +302,20 @@ describe('partitionMarkets / published pools', () => {
   });
 });
 
+describe('allBootstrapMarkets', () => {
+  it('dedupes the legacy near-duplicate pools and keeps the highest-volume record', () => {
+    const market = RAW[0];
+    const result = allBootstrapMarkets({
+      geopolitical: [{ ...market, volume: 10 }],
+      tech: [{ ...market, volume: 30 }],
+      finance: [{ ...market, volume: 20 }],
+    });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].volume, 30);
+  });
+});
+
 describe('poolIntegrityViolations (the publish gate)', () => {
   it('passes the pools the producer actually builds', () => {
     assert.deepEqual(poolIntegrityViolations(buildPools(RAW)), []);
@@ -488,6 +504,12 @@ describe('validateBootstrapPayload (the seeder\'s validateFn)', () => {
     assert.equal(validateBootstrapPayload({ geopolitical: pools.geopolitical, tech: [], finance: [] }, silent), true);
     assert.equal(validateBootstrapPayload({ geopolitical: [], tech: pools.tech, finance: [] }, silent), true);
     assert.equal(validateBootstrapPayload({ geopolitical: [], tech: [], finance: pools.finance }, silent), true);
+  });
+
+  it('rejects a non-empty but severely partial snapshot', () => {
+    const oneMarket = { geopolitical: [RAW[0]], tech: [], finance: [] };
+    assert.equal(MIN_PUBLISHED_MARKETS, 5);
+    assert.equal(validateBootstrapPayload(oneMarket, silent), false);
   });
 
   it('rejects a payload whose pools are mislabeled — the #5733 regression gate', () => {

--- a/tests/prediction-market-rpc.test.mts
+++ b/tests/prediction-market-rpc.test.mts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { listPredictionMarkets } from '../server/worldmonitor/prediction/v1/list-prediction-markets.ts';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+beforeEach(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalEnv.url === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalEnv.url;
+  if (originalEnv.token === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalEnv.token;
+});
+
+describe('listPredictionMarkets legacy bootstrap compatibility', () => {
+  it('dedupes the old three-pool payload and keeps the highest-volume copy', async () => {
+    const base = {
+      title: 'Will Iran strike Israel?',
+      yesPrice: 70,
+      volume: 10,
+      url: 'https://polymarket.com/event/iran-strike-israel',
+      endDate: '2099-01-01T00:00:00Z',
+      source: 'polymarket',
+    } as const;
+    const payload = {
+      geopolitical: [base],
+      tech: [{ ...base, volume: 30 }],
+      finance: [{ ...base, volume: 20 }],
+      fetchedAt: 123,
+    };
+
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      result: JSON.stringify(payload),
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+
+    const response = await listPredictionMarkets({} as never, {
+      category: '',
+      query: '',
+      pageSize: 100,
+      cursor: '',
+    });
+
+    assert.equal(response.dataAvailable, true);
+    assert.equal(response.markets.length, 1);
+    assert.equal(response.markets[0].volume, 30);
+    assert.equal(response.fetchedAt, 123);
+  });
+});


### PR DESCRIPTION
## Problem

The `prediction:markets-bootstrap:v1` producer built its three pools as three independent filters over the same candidate array:

```js
geopolitical = filterAndScore(markets, null)                                  // NO predicate at all
tech         = filterAndScore(markets, m => m.tags ∈ TECH_TAGS)
finance      = filterAndScore(markets, m => kalshi || tags ∈ FINANCE_TAGS)
```

The fetch tag list is the **union** of all three domains, so `geopolitical` was a copy of every market fetched. Compounding it, the tech and finance tag lists shared `economy`, `crypto`, and `business`.

Every consumer selects a pool **by name** — the RPC by site variant, the MCP `category` argument, the `deduct-situation` and `chat-analyst` prompt builders — so the labels were load-bearing and meaningless at the same time.

## Measured against production

Live `prediction:markets-bootstrap:v1`, fetched 2026-07-30:

| | before | after |
|---|---|---|
| records published | 75 | 46 |
| distinct markets | 46 | 46 |
| duplicate records | **29 (39%)** | 0 |
| pool sizes (geo/tech/fin) | 25/25/25 | 18/20/8 |
| non-geo titles in geo pool | **12/25** | 2/18 |
| top of geo pool by volume | *"Will no Fed rate cuts happen in 2026?"* ($45.6M) | *"Will Mojtaba Khamenei be head of state in Iran end of 2026?"* ($37M) |
| integrity violations | 63 | 0 |

The 2 remaining non-title-matching geo entries are genuine geopolitics rescued by venue tags — a German state election and a bilateral trade deal — not residual pollution.

## Fix

Each market gets exactly one primary category by precedence (**geopolitical → tech → finance**, default finance).

Geopolitical reads the title predicate already shared with the bet families **OR** the venue tags, because they cover each other's blind spots:

- the **title** matcher is the only signal for Kalshi records (always `tags: []`) — its next-Prime-Minister-of-Israel and President-of-the-United-States lines were previously filed as *finance*;
- the **tags** catch what the deliberately precision-first title matcher declines to guess (`"Berlin state elections"` is not in its qualified-election vocabulary).

`politics` is deliberately *not* a geo tag — Polymarket puts it on crypto legislation. The `classify` tag lists are kept mutually disjoint so precedence never silently decides a coin flip. **Payload shape is unchanged**, since five consumers read those exact keys.

## Consequences of the pools becoming a real partition — also fixed

These were latent only because `geopolitical` used to mean "everything":

- **`seed-forecasts`' `detectFromPredictionMarkets` + `calibrateWithMarkets`, and `_forecast-resolution`'s settlement endDate index** read `.geopolitical` as a stand-in for all markets. Post-partition they would have silently lost every macro, rates, crypto and AI anchor — degrading the market-anchored calibration slice this issue exists to unblock. Existing tests used inline `{geopolitical: [...]}` fixtures, so this would have shipped green.
- **The RPC's default branch** served `bootstrap.geopolitical` for *both* an omitted category and an explicit non-tech/finance one. `category` is optional on a public endpoint, so omitting it must still mean "all markets"; those two cases are now separated and the site variant's `'politics'` still resolves to geo.
- **`fetchCountryMarkets`** queried only `geopolitics`+`economy` and early-returned before ever reaching its own tech-including fallback.
- **Same-identity dedupe before partitioning.** The Polymarket url comes from `event.slug` while the fetch loop dedupes on `event.id`, so a parent/derivative pair can share a url. Landing in two pools would have tripped the integrity gate and frozen **all three pools** until a human shipped a fix, with `/api/health` only noticing 90 minutes later. A degenerate `/undefined` slug falls back to the title so unrelated records can't fuse.
- **The publish gate's population floor is total-based.** The old `finance.length > 0` requirement was safe only while finance was the Kalshi catch-all; with content-decided membership a legitimate geo-heavy cycle would have been rejected, stranding last-good.

## The integrity gate, honestly scoped

A category-integrity check gates the publish (rejection preserves last-good and surfaces as `STALE_SEED` past `maxStaleMin: 90`). It catches a regression in the pipeline **shape** — exactly this defect — but it re-runs the same `classifyMarket` that built the partition, so it is documented in-code as a **self-consistency** check, *not* proof the taxonomy is right. The independent ground truth is the fixture's hand-verified expected categories.

## Verification

- **52 new cases** over a 46-record real production fixture, plus pool guards for the three forecast consumers.
- `lint`, `typecheck`, `lint:api-contract`, `lint:boundaries` pass.
- ~13,000 tests green across the full suite in chunks; the only failures are `dashboard-critical-css`'s two built-output assertions, which require `VITE_VARIANT=full vite build` first in a fresh worktree and are unrelated to this diff.
- **Mutation-verified.** Each of these turns the suite red: restoring the unfiltered geo pool, dropping either geo rescue path, flipping the default category, re-adding the `crypto` overlap, neutering the integrity check, neutering the gate, disabling dedupe, restoring the per-pool floor, removing the degenerate-url guard, bypassing `buildBootstrapPools` in the seeder, and reverting each of the three forecast consumers to geo-only.

## Notes

- The `:v1` key and `schemaVersion` are unchanged. Nothing gates on `schemaVersion` for this key, so a bump would be inert; the stale-label window is bounded by the 30-min cron and self-heals, and during it consumers serve the pre-fix pools they already were.
- Follow-up worth filing: the MCP `get_prediction_markets` description never mentions `tech`, which is now a bucket agents can rely on. Left out here because it spans the tool registry, two docs pages, a zh mirror, and the server card.

Closes #5733

https://claude.ai/code/session_01GJaoAndAbin9SGXW1NY1ng
