### PR TITLE
fix(entitlements): enforce declared export formats

### DIFF
--- a/convex/config/productCatalog.ts
+++ b/convex/config/productCatalog.ts
@@ -66,13 +66,11 @@ export type PlanFeatures = {
   planLimits?: PlanLimits;
   prioritySupport: boolean;
   /**
-   * Display metadata ONLY — the formats a tier ADVERTISES. As of #4974 NO
-   * code consumes this array to gate any behavior, and formats listed here
-   * are not guaranteed to have exporters ("xlsx" was advertised for months
-   * with zero implementation). The enforcement field for data export is
-   * `dataExport` below: gate on that, never on this array's contents or
-   * length. Keep the two in agreement — a tier with `dataExport: false`
-   * advertises nothing.
+   * Format allowlist for an entitled export surface. `dataExport` below is
+   * the first-stage lock: when it is false the entire surface is unavailable.
+   * Once that gate is open, consumers expose only supported CSV/JSON/PDF
+   * values declared here and ignore unknown values. Keep the two fields in
+   * agreement — a tier with `dataExport: false` advertises no formats.
    */
   exportFormats: string[];
   /**
@@ -102,10 +100,11 @@ export type PlanFeatures = {
    */
   apiDailyAllowance?: number;
   /**
-   * Data-export entitlement — the ENFORCEMENT field for CSV/JSON/PDF export
-   * (plan 2026-07-25-001). Distinct from `exportFormats`, which only says
-   * what a tier advertises. `tier` cannot stand in for it: Pro Business
-   * shares `tier: 1` with Pro but exports, and Pro does not.
+   * First-stage data-export entitlement for CSV/JSON/PDF export (plan
+   * 2026-07-25-001). Once this gate is open, `exportFormats` narrows the
+   * actions exposed by each export surface. `tier` cannot stand in for this
+   * field: Pro Business shares `tier: 1` with Pro but exports, and Pro does
+   * not.
    *
    * Optional for the same reason as `apiDailyAllowance`: rows written before
    * the field existed omit it. Consumers treat `undefined` on a `tier >= 2`

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -92,7 +92,8 @@ import { TvModeController } from '@/services/tv-mode';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { onEntitlementChange } from '@/services/entitlements';
 import { primeExportGateActivation } from '@/services/export-gate';
-import { evaluateExportGate, evaluatePlaybackGate, exportLockToGateReason, resolveGateAction, type PanelGateReason } from '@/services/panel-gating';
+import { evaluateAvailableExportFormats, evaluateExportGate, evaluatePlaybackGate, exportLockToGateReason, resolveGateAction, type PanelGateReason } from '@/services/panel-gating';
+import type { DataExportFormat } from '@/services/export-gate';
 import { ExportGateControl } from '@/components/ExportGateControl';
 import { h, setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { scheduleAfterFirstPaint } from '@/utils/after-paint';
@@ -1708,8 +1709,11 @@ export class EventHandlerManager implements AppModule {
       }
     };
 
+    let currentExportFormats: readonly DataExportFormat[] = [];
+
     const ensureExportPanel = (): Promise<NonNullable<AppContext['exportPanel']>> => {
       if (this.ctx.exportPanel) {
+        this.ctx.exportPanel.setAvailableFormats(currentExportFormats);
         attachExportPanel(this.ctx.exportPanel);
         return Promise.resolve(this.ctx.exportPanel);
       }
@@ -1720,7 +1724,7 @@ export class EventHandlerManager implements AppModule {
           if (this.ctx.isDestroyed) {
             throw new Error('EventHandlerManager destroyed before export panel loaded');
           }
-          const panel = new ExportPanel(getExportData);
+          const panel = new ExportPanel(getExportData, currentExportFormats);
           this.ctx.exportPanel = panel;
           attachExportPanel(panel);
           return panel;
@@ -1777,13 +1781,17 @@ export class EventHandlerManager implements AppModule {
       headerRight?.insertBefore(lockedControl.getElement(), headerRight.firstChild);
     };
 
-    const unlock = (): void => {
+    const unlock = (formats: readonly DataExportFormat[]): void => {
+      currentExportFormats = formats;
       const wasLocked = lockedControl !== null;
       // Change-detection guard: gating re-fires on every auth AND entitlement
       // emission, most with an unchanged verdict — skip the re-import/DOM
       // write when already unlocked (same pattern as Panel.showGatedCta's
       // repeat-verdict skip).
-      if (!wasLocked && isUnlocked) return;
+      if (!wasLocked && isUnlocked) {
+        this.ctx.exportPanel?.setAvailableFormats(currentExportFormats);
+        return;
+      }
       isUnlocked = true;
       removeLockedControl();
       void ensureExportPanel()
@@ -1795,6 +1803,7 @@ export class EventHandlerManager implements AppModule {
             panel.getElement().style.display = 'none';
             return;
           }
+          panel.setAvailableFormats(currentExportFormats);
           panel.getElement().style.display = '';
           if (wasLocked) liveRegion.textContent = t('components.exportGate.unlockedAnnouncement');
         })
@@ -1808,7 +1817,8 @@ export class EventHandlerManager implements AppModule {
 
     const applyGate = (): void => {
       if (this.ctx.isDestroyed) return;
-      const verdict = evaluateExportGate(getAuthState());
+      const authState = getAuthState();
+      const verdict = evaluateExportGate(authState);
       if (verdict.locked) {
         showLocked(exportLockToGateReason(verdict.reason));
         return;
@@ -1821,7 +1831,7 @@ export class EventHandlerManager implements AppModule {
           if (active) applyGate();
         });
       }
-      unlock();
+      unlock(evaluateAvailableExportFormats(authState));
     };
 
     applyGate();

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -18,7 +18,12 @@ import { ME_STRIKE_BOUNDS } from '@/services/country-geometry';
 import { toFlagEmoji } from '@/utils/country-flag';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { getAuthState } from '@/services/auth-state';
-import { evaluateExportGate, exportLockToGateReason, hasPremiumAccess } from '@/services/panel-gating';
+import {
+  evaluateAvailableExportFormats,
+  evaluateExportGate,
+  exportLockToGateReason,
+  hasPremiumAccess,
+} from '@/services/panel-gating';
 import { primeExportGateActivation } from '@/services/export-gate';
 import { exportGateCopy } from '@/components/ExportGateControl';
 import { trackGateHit } from '@/services/analytics';
@@ -127,6 +132,7 @@ export class CountryBriefPage implements CountryBriefPanel {
       if (target.closest('.cb-export-btn')) {
         e.stopPropagation();
         const exportMenu = this.overlay.querySelector('.cb-export-menu');
+        this.syncStructuredExportOptions();
         exportMenu?.classList.toggle('hidden');
         return;
       }
@@ -142,7 +148,7 @@ export class CountryBriefPage implements CountryBriefPanel {
         } else if (format === 'pdf') {
           this.exportPdf();
         } else if (format === 'json' || format === 'csv') {
-          if (this.canExportStructuredData()) this.exportBrief(format);
+          if (this.canExportStructuredData(format)) this.exportBrief(format);
         } else if (format === 'evidence-md') {
           this.exportBrief(format);
         }
@@ -753,11 +759,32 @@ export class CountryBriefPage implements CountryBriefPanel {
    * free — they carry no machine-readable payload — and the evidence bundle
    * keeps its own Pro gate below.
    */
-  private canExportStructuredData(): boolean {
-    const verdict = evaluateExportGate(getAuthState());
+  private syncStructuredExportOptions(): void {
+    const authState = getAuthState();
+    const verdict = evaluateExportGate(authState);
+    // Keep the locked rows visible so they remain an entry point to the
+    // billing-aware gate. Once unlocked, the catalog is the format allowlist.
+    const availableFormats = verdict.locked
+      ? null
+      : new Set(evaluateAvailableExportFormats(authState));
+
+    this.overlay
+      .querySelectorAll<HTMLButtonElement>('.cb-export-option')
+      .forEach((button) => {
+        const format = button.dataset.format;
+        if (format !== 'json' && format !== 'csv') return;
+        button.hidden = availableFormats !== null && !availableFormats.has(format);
+      });
+  }
+
+  private canExportStructuredData(format: 'json' | 'csv'): boolean {
+    const authState = getAuthState();
+    const verdict = evaluateExportGate(authState);
     if (!verdict.locked) {
       if (verdict.pendingActivation) void primeExportGateActivation();
-      return true;
+      // Re-evaluate at click time so a stale/open menu cannot bypass a live
+      // entitlement change.
+      return evaluateAvailableExportFormats(authState).includes(format);
     }
     trackGateHit('export');
     showToast(exportGateCopy(exportLockToGateReason(verdict.reason)).desc);

--- a/src/services/entitlements.ts
+++ b/src/services/entitlements.ts
@@ -39,9 +39,10 @@ export interface EntitlementState {
      */
     mcpAccess?: boolean;
     /**
-     * Data-export entitlement (plan 2026-07-25-001). The enforcement field for
-     * CSV/JSON/PDF export — `exportFormats` is display metadata only, and
-     * `tier` cannot discriminate (Pro Business shares tier 1 with Pro).
+     * Data-export entitlement (plan 2026-07-25-001). This controls the locked
+     * state while `exportFormats` controls which CSV/JSON/PDF actions the
+     * unlocked menu exposes; `tier` cannot discriminate because Pro Business
+     * shares tier 1 with Pro.
      * Undefined on legacy snapshots: the export gate treats undefined on a
      * `tier >= 2` snapshot as entitled (permanent fail-open) so a stale row
      * never locks a paying customer out of their own data.

--- a/src/services/export-gate.ts
+++ b/src/services/export-gate.ts
@@ -21,6 +21,15 @@
 
 import { getBillingGateOverride, type BillingUxState } from './billing-state';
 
+/** Formats the dashboard can genuinely produce. Keep this list aligned with
+ * `src/utils/export.ts`; unknown catalog values must never become UI actions. */
+export const SUPPORTED_EXPORT_FORMATS = ['csv', 'json', 'pdf'] as const;
+export type DataExportFormat = (typeof SUPPORTED_EXPORT_FORMATS)[number];
+
+function allExportFormats(): DataExportFormat[] {
+  return [...SUPPORTED_EXPORT_FORMATS];
+}
+
 /**
  * Locked-state reasons. Values mirror the `PanelGateReason` string enum in
  * panel-gating.ts (kept as plain strings here so this module stays a leaf —
@@ -44,6 +53,11 @@ export interface ExportGateFeatures {
    * fail-open below.
    */
   dataExport?: boolean;
+  /**
+   * Formats this plan may expose. Optional only for legacy entitlement rows;
+   * the current schema requires it.
+   */
+  exportFormats?: readonly string[];
   /**
    * Per-plan dashboard allowance (KTD8). Required in the schema, the cache
    * validator and the client type, so unlike `dataExport` there is no legacy
@@ -120,6 +134,39 @@ export function resolveExportGate(input: ExportGateInputs): ExportGateVerdict {
   if (reason === null) return { locked: false, pendingActivation: false };
   if (!input.gateActive) return { locked: false, pendingActivation: true };
   return { locked: true, reason };
+}
+
+/**
+ * Resolve the export actions the menu may expose. This deliberately follows
+ * the same affirmative-denial rule as `resolveExportGate`: before the
+ * Pro-Business catalog is live, and while identity or entitlement data is
+ * unknown, preserve the pre-gate menu instead of turning a transient read
+ * failure into a paid-user lockout.
+ *
+ * Once the gate is active and a paid row is loaded, `exportFormats` is the
+ * source of truth. `dataExport` still owns the locked-versus-unlocked decision
+ * because it distinguishes Pro Business from Pro even though both are tier 1.
+ */
+export function resolveAvailableExportFormats(input: ExportGateInputs): DataExportFormat[] {
+  if (!input.gateActive || input.desktopKeyPresent || input.authPending) {
+    return allExportFormats();
+  }
+  if (!input.signedIn) return [];
+
+  const features = input.features;
+  if (features === null) return allExportFormats();
+
+  if (features.dataExport === true) {
+    // `exportFormats` predates this gate. A legacy paid row that lacks it must
+    // retain all currently supported exports until its next entitlement write.
+    const declaredFormats = features.exportFormats;
+    if (!Array.isArray(declaredFormats)) return allExportFormats();
+    return SUPPORTED_EXPORT_FORMATS.filter((format) => declaredFormats.includes(format));
+  }
+  if (features.dataExport === undefined && features.tier >= 2) {
+    return allExportFormats();
+  }
+  return [];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/panel-gating.ts
+++ b/src/services/panel-gating.ts
@@ -4,11 +4,13 @@ import { deriveBillingUxState, getBillingGateOverride, getReactivationHref } fro
 import { getEntitlementState } from './entitlements';
 import {
   isExportGateActive,
+  resolveAvailableExportFormats,
   resolveExportGate,
   resolveTabCap,
   type ExportGateInputs,
   type ExportGateLockReason,
   type ExportGateVerdict,
+  type DataExportFormat,
   type TabCapVerdict,
 } from './export-gate';
 import {
@@ -147,6 +149,7 @@ export function readExportGateInputs(authState: AuthSession): ExportGateInputs {
       ? {
           tier: entitlement.features.tier,
           dataExport: entitlement.features.dataExport,
+          exportFormats: entitlement.features.exportFormats,
           maxDashboards: entitlement.features.maxDashboards,
         }
       : null,
@@ -157,6 +160,11 @@ export function readExportGateInputs(authState: AuthSession): ExportGateInputs {
 /** Current data-export verdict for the given auth session. */
 export function evaluateExportGate(authState: AuthSession): ExportGateVerdict {
   return resolveExportGate(readExportGateInputs(authState));
+}
+
+/** Formats the unlocked export menu may expose for this live session. */
+export function evaluateAvailableExportFormats(authState: AuthSession): DataExportFormat[] {
+  return resolveAvailableExportFormats(readExportGateInputs(authState));
 }
 
 /**

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9643,6 +9643,10 @@ a.prediction-link:hover {
   cursor: pointer;
 }
 
+.export-option[hidden] {
+  display: none;
+}
+
 .export-option:hover {
   background: var(--border);
 }
@@ -21961,6 +21965,10 @@ body.has-breaking-alert .panels-grid {
   text-align: left;
   border-radius: 6px;
   cursor: pointer;
+}
+
+.cb-export-option[hidden] {
+  display: none;
 }
 
 .cb-export-option:hover {

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -7,13 +7,14 @@ import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { showToast } from '@/utils/toast';
 import { buildDataReportDocument, printReportDocument, sanitizeExportData } from '@/utils/export-report';
+import { SUPPORTED_EXPORT_FORMATS, type DataExportFormat } from '@/services/export-gate';
 
 // Iran-events domain sunset (war ended 2026-07). Default OFF: omit the IRAN
 // EVENTS CSV block. Set VITE_ENABLE_IRAN_ATTACKS=true to restore. Guarded so
 // node:test never dereferences import.meta.env.
 const IRAN_ATTACKS_ENABLED = typeof window !== 'undefined' && import.meta.env.VITE_ENABLE_IRAN_ATTACKS === 'true';
 
-type ExportFormat = 'json' | 'csv' | 'pdf';
+type ExportFormat = DataExportFormat;
 
 export interface ExportMeta {
   exportedAt: string;
@@ -743,8 +744,9 @@ export class ExportPanel {
   private element: HTMLElement;
   private isOpen = false;
   private getData: () => ExportData;
+  private availableFormats = new Set<DataExportFormat>();
 
-  constructor(getDataFn: () => ExportData) {
+  constructor(getDataFn: () => ExportData, formats: readonly DataExportFormat[] = SUPPORTED_EXPORT_FORMATS) {
     this.getData = getDataFn;
     this.element = document.createElement('div');
     this.element.className = 'export-panel-container';
@@ -757,7 +759,17 @@ export class ExportPanel {
       </div>
     `, "legacy direct innerHTML migration"));
 
+    this.setAvailableFormats(formats);
     this.setupEventListeners();
+  }
+
+  /** Update the menu in place when a live entitlement snapshot changes. */
+  public setAvailableFormats(formats: readonly DataExportFormat[]): void {
+    this.availableFormats = new Set(formats);
+    this.element.querySelectorAll<HTMLButtonElement>('.export-option').forEach((button) => {
+      const format = button.dataset.format as DataExportFormat;
+      button.hidden = !this.availableFormats.has(format);
+    });
   }
 
   private setupEventListeners(): void {
@@ -780,6 +792,7 @@ export class ExportPanel {
       option.addEventListener('click', () => {
         const button = option as HTMLButtonElement;
         const format = button.dataset.format as ExportFormat;
+        if (!this.availableFormats.has(format)) return;
         if (format === 'pdf') {
           // The report renders and prints asynchronously, so the menu stays
           // open with the option in a busy state until it settles — and a

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -118,9 +118,16 @@ function zeroCountryBriefSignals() {
   };
 }
 
-async function loadCountryBriefPage(options: { premiumAccess?: boolean; exportGateLocked?: boolean } = {}) {
+type CountryBriefHarnessOptions = {
+  premiumAccess?: boolean;
+  exportGateLocked?: boolean;
+  availableExportFormats?: Array<'csv' | 'json' | 'pdf'>;
+};
+
+async function loadCountryBriefPage(options: CountryBriefHarnessOptions = {}) {
   const premiumAccess = options.premiumAccess === true;
   const exportGateLocked = options.exportGateLocked === true;
+  const availableExportFormats = options.availableExportFormats ?? ['csv', 'json', 'pdf'];
   const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-brief-page-'));
   const outfile = join(tempDir, 'CountryBriefPage.bundle.mjs');
   const entry = resolve(process.cwd(), 'src/components/CountryBriefPage.ts');
@@ -171,6 +178,8 @@ async function loadCountryBriefPage(options: { premiumAccess?: boolean; exportGa
         if (!String(html).includes('cb-export-option')) return;
         const page = document.createElement('div');
         page.className = 'country-brief-page';
+        const trigger = document.createElement('button');
+        trigger.className = 'cb-export-btn';
         const menu = document.createElement('div');
         menu.className = 'cb-export-menu hidden';
         for (const match of String(html).matchAll(/<button\\s+([^>]*class="[^"]*cb-export-option[^"]*"[^>]*)>([\\s\\S]*?)<\\/button>/g)) {
@@ -179,6 +188,7 @@ async function loadCountryBriefPage(options: { premiumAccess?: boolean; exportGa
           button.textContent = textFromHtml(match[2]);
           menu.appendChild(button);
         }
+        page.appendChild(trigger);
         page.appendChild(menu);
         root.appendChild(page);
       }
@@ -198,6 +208,9 @@ async function loadCountryBriefPage(options: { premiumAccess?: boolean; exportGa
         return ${exportGateLocked
           ? `{ locked: true, reason: 'free_tier' }`
           : '{ locked: false, pendingActivation: false }'};
+      }
+      export function evaluateAvailableExportFormats() {
+        return ${JSON.stringify(availableExportFormats)};
       }
       export function exportLockToGateReason(reason) { return reason; }
     `],
@@ -266,7 +279,7 @@ async function loadCountryBriefPage(options: { premiumAccess?: boolean; exportGa
   };
 }
 
-async function createCountryBriefPageHarness(options: { premiumAccess?: boolean; exportGateLocked?: boolean } = {}) {
+async function createCountryBriefPageHarness(options: CountryBriefHarnessOptions = {}) {
   const originalGlobals = {
     document: snapshotGlobal('document'),
     window: snapshotGlobal('window'),
@@ -580,7 +593,8 @@ describe('country evidence bundle export', () => {
     // U5 (plan 2026-07-25-001): json/csv route through the data-export gate;
     // evidence-md keeps its own Pro gate, and image/pdf/print stay free.
     assert.match(legacySource, /format === 'json' \|\| format === 'csv'/);
-    assert.match(legacySource, /if \(this\.canExportStructuredData\(\)\) this\.exportBrief\(format\);/);
+    assert.match(legacySource, /if \(this\.canExportStructuredData\(format\)\) this\.exportBrief\(format\);/);
+    assert.match(legacySource, /evaluateAvailableExportFormats\(authState\)/);
     assert.match(legacySource, /else if \(format === 'evidence-md'\) \{\n\s+this\.exportBrief\(format\);/);
     assert.match(legacySource, /if \(format === 'evidence-md' && !this\.canExportEvidenceBundle\(\)\) return;/);
     assert.match(legacySource, /if \(format === 'evidence-md'\) exportCountryEvidenceMarkdown\(data\)/);
@@ -653,6 +667,49 @@ describe('country evidence bundle export', () => {
       assert.ok(jsonButton, 'expected json export option');
       dispatchDelegatedClick(overlay, jsonButton);
 
+      assert.equal(harness.getJsonExports().length, 1);
+      assert.deepEqual(harness.getGateHits(), []);
+      assert.deepEqual(harness.getToasts(), []);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it('enforces declared Country Brief formats at menu-open and click time', async () => {
+    const harness = await createCountryBriefPageHarness({
+      premiumAccess: false,
+      exportGateLocked: false,
+      availableExportFormats: ['json'],
+    });
+    try {
+      const page = harness.createPage();
+      page.show('France', 'FR', null, zeroCountryBriefSignals());
+
+      const overlay = harness.getOverlay();
+      assert.ok(overlay, 'expected country brief overlay');
+      const trigger = overlay.querySelector('.cb-export-btn') as HTMLElement | null;
+      const jsonButton = overlay.querySelector('[data-format="json"]') as HTMLButtonElement | null;
+      const csvButton = overlay.querySelector('[data-format="csv"]') as HTMLButtonElement | null;
+      const pdfButton = overlay.querySelector('[data-format="pdf"]') as HTMLButtonElement | null;
+      assert.ok(trigger, 'expected country brief export trigger');
+      assert.ok(jsonButton, 'expected json export option');
+      assert.ok(csvButton, 'expected csv export option');
+      assert.ok(pdfButton, 'expected pdf export option');
+
+      dispatchDelegatedClick(overlay, trigger);
+
+      assert.equal(jsonButton.hidden, false);
+      assert.equal(csvButton.hidden, true);
+      // The Country Brief print-based PDF remains free and outside the
+      // structured-data format allowlist.
+      assert.notEqual(pdfButton.hidden, true);
+
+      // A synthetic click proves the action itself re-checks the allowlist;
+      // hiding alone must not be the security boundary.
+      dispatchDelegatedClick(overlay, csvButton);
+      dispatchDelegatedClick(overlay, jsonButton);
+
+      assert.equal(harness.getCsvExports().length, 0);
       assert.equal(harness.getJsonExports().length, 1);
       assert.deepEqual(harness.getGateHits(), []);
       assert.deepEqual(harness.getToasts(), []);

--- a/tests/dom/export-gate-wiring.test.mts
+++ b/tests/dom/export-gate-wiring.test.mts
@@ -32,6 +32,7 @@ type Verdict =
   | { locked: true; reason: string };
 
 const verdict = vi.fn<() => Verdict>(() => ({ locked: false, pendingActivation: false }));
+const availableFormats = vi.fn<() => Array<'csv' | 'json' | 'pdf'>>(() => ['csv', 'json', 'pdf']);
 const trackGateHit = vi.fn<(feature: string) => void>();
 /** Auth/entitlement listeners registered by setupExportPanel. */
 const emitters: Array<() => void> = [];
@@ -39,6 +40,7 @@ const emitters: Array<() => void> = [];
 vi.mock('@/services/panel-gating', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/services/panel-gating')>()),
   evaluateExportGate: () => verdict(),
+  evaluateAvailableExportFormats: () => availableFormats(),
 }));
 
 // Partial, like the others: a full replacement would silently turn any other
@@ -114,6 +116,7 @@ beforeEach(() => {
   document.body.replaceChildren();
   emitters.length = 0;
   trackGateHit.mockClear();
+  availableFormats.mockReset().mockReturnValue(['csv', 'json', 'pdf']);
   verdict.mockReset().mockReturnValue({ locked: false, pendingActivation: false });
   openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
   authModalOpen = vi.fn<() => void>();
@@ -211,6 +214,18 @@ describe('setupExportPanel — CTA routing through resolveGateAction', () => {
 });
 
 describe('setupExportPanel — aria-live announcements', () => {
+  it('uses the newest entitlement formats when the exporter chunk resolves after an update', async () => {
+    manager.setupExportPanel();
+    availableFormats.mockReturnValue(['json']);
+    emit({ locked: false, pendingActivation: false });
+
+    await vi.waitFor(() => expect(formatOptions().length).toBeGreaterThan(0), { timeout: 5000 });
+
+    expect(container.querySelector<HTMLButtonElement>('[data-format="json"]')!.hidden).toBe(false);
+    expect(container.querySelector<HTMLButtonElement>('[data-format="csv"]')!.hidden).toBe(true);
+    expect(container.querySelector<HTMLButtonElement>('[data-format="pdf"]')!.hidden).toBe(true);
+  });
+
   it('puts the live region in the accessibility tree empty, before anything is announced', () => {
     // An aria-live region only announces content injected AFTER it is in the
     // tree — creating it together with its message announces nothing.

--- a/tests/dom/export-gate-wiring.test.mts
+++ b/tests/dom/export-gate-wiring.test.mts
@@ -226,6 +226,18 @@ describe('setupExportPanel — aria-live announcements', () => {
     expect(container.querySelector<HTMLButtonElement>('[data-format="pdf"]')!.hidden).toBe(true);
   });
 
+  it('updates formats after an unlocked exporter is already attached', async () => {
+    manager.setupExportPanel();
+    await vi.waitFor(() => expect(formatOptions().length).toBeGreaterThan(0), { timeout: 5000 });
+
+    availableFormats.mockReturnValue(['json']);
+    emit({ locked: false, pendingActivation: false });
+
+    expect(container.querySelector<HTMLButtonElement>('[data-format="json"]')!.hidden).toBe(false);
+    expect(container.querySelector<HTMLButtonElement>('[data-format="csv"]')!.hidden).toBe(true);
+    expect(container.querySelector<HTMLButtonElement>('[data-format="pdf"]')!.hidden).toBe(true);
+  });
+
   it('puts the live region in the accessibility tree empty, before anything is announced', () => {
     // An aria-live region only announces content injected AFTER it is in the
     // tree — creating it together with its message announces nothing.

--- a/tests/dom/export-pdf-cycle.test.mts
+++ b/tests/dom/export-pdf-cycle.test.mts
@@ -15,6 +15,8 @@
  * `helpers/print-recorder.mts`.
  */
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock, type MockInstance } from 'vitest';
 
 import { ExportPanel, type ExportData } from '@/utils/export';
@@ -33,6 +35,7 @@ const PRINT_DELAY_MS = 300;
 const CLEANUP_DELAY_MS = 5000;
 
 const TS = Date.parse('2026-07-25T12:00:00.000Z');
+const MAIN_CSS = readFileSync(resolve(process.cwd(), 'src/styles/main.css'), 'utf8');
 
 function exportData(overrides: Partial<ExportData> = {}): ExportData {
   return {
@@ -107,6 +110,26 @@ describe('Export PDF click cycle — button to printed document', () => {
     expect(root().querySelector<HTMLButtonElement>('[data-format="json"]')!.hidden).toBe(false);
     expect(root().querySelector<HTMLButtonElement>('[data-format="csv"]')!.hidden).toBe(true);
     expect(root().querySelector<HTMLButtonElement>('[data-format="pdf"]')!.hidden).toBe(true);
+  });
+
+  it('keeps unavailable options out of layout under the production CSS cascade', () => {
+    const productionExportRules = MAIN_CSS
+      .match(/\.export-option(?:\[hidden\])?\s*\{[^}]*\}/g)
+      ?.join('\n');
+    expect(productionExportRules).toBeTruthy();
+
+    const style = document.createElement('style');
+    style.textContent = productionExportRules!;
+    document.head.appendChild(style);
+    try {
+      panel.setAvailableFormats(['json']);
+
+      expect(getComputedStyle(root().querySelector('[data-format="csv"]')!).display).toBe('none');
+      expect(getComputedStyle(root().querySelector('[data-format="pdf"]')!).display).toBe('none');
+      expect(getComputedStyle(root().querySelector('[data-format="json"]')!).display).toBe('block');
+    } finally {
+      style.remove();
+    }
   });
 
   it('prints a report built from the data the panel holds at CLICK time', async () => {

--- a/tests/dom/export-pdf-cycle.test.mts
+++ b/tests/dom/export-pdf-cycle.test.mts
@@ -101,6 +101,14 @@ async function clickExportPdf(): Promise<void> {
 }
 
 describe('Export PDF click cycle — button to printed document', () => {
+  it('only exposes the formats selected by the entitlement-backed menu', () => {
+    panel.setAvailableFormats(['json']);
+
+    expect(root().querySelector<HTMLButtonElement>('[data-format="json"]')!.hidden).toBe(false);
+    expect(root().querySelector<HTMLButtonElement>('[data-format="csv"]')!.hidden).toBe(true);
+    expect(root().querySelector<HTMLButtonElement>('[data-format="pdf"]')!.hidden).toBe(true);
+  });
+
   it('prints a report built from the data the panel holds at CLICK time', async () => {
     // Not construction time: the dashboard mutates constantly, and a report
     // built from a stale snapshot is the whole reason getData is a callback.

--- a/tests/export-gate.test.mts
+++ b/tests/export-gate.test.mts
@@ -20,6 +20,7 @@ import {
   catalogExposesProBusiness,
   isExportGateActive,
   primeExportGateActivation,
+  resolveAvailableExportFormats,
   resolveExportGate,
   resolveExportLock,
   __resetExportGateActivationForTests,
@@ -100,6 +101,48 @@ describe('resolveExportGate — KTD2 decision chain', () => {
     assert.deepEqual(
       resolveExportGate(inputs({ features: { tier: 2, dataExport: false } })),
       { locked: true, reason: 'free_tier' },
+    );
+  });
+});
+
+describe('resolveAvailableExportFormats — catalog-backed export menu', () => {
+  it('uses the loaded entitlement row to expose only its declared formats', () => {
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({
+        features: { tier: 1, dataExport: true, maxDashboards: 25, exportFormats: ['pdf', 'csv'] },
+      })),
+      ['csv', 'pdf'],
+    );
+  });
+
+  it('does not turn a pre-activation or pending snapshot into an export lockout', () => {
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({ gateActive: false })),
+      ['csv', 'json', 'pdf'],
+    );
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({ features: null })),
+      ['csv', 'json', 'pdf'],
+    );
+  });
+
+  it('filters unsupported catalog values and cannot expose formats to a known free row', () => {
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({
+        features: {
+          tier: 1,
+          dataExport: true,
+          maxDashboards: 25,
+          exportFormats: ['xlsx', 'json', 'json'],
+        },
+      })),
+      ['json'],
+    );
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({
+        features: { tier: 0, dataExport: false, maxDashboards: 3, exportFormats: ['csv'] },
+      })),
+      [],
     );
   });
 });
@@ -238,7 +281,10 @@ describe('setupExportPanel wiring', () => {
   });
 
   it('routes the verdict through the shared resolver and gate action', () => {
-    assert.match(exportPanelBody, /evaluateExportGate\(getAuthState\(\)\)/);
+    assert.match(exportPanelBody, /evaluateExportGate\(authState\)/);
+    assert.match(exportPanelBody, /evaluateAvailableExportFormats\(authState\)/);
+    assert.match(exportPanelBody, /currentExportFormats = formats/);
+    assert.match(exportPanelBody, /setAvailableFormats\(currentExportFormats\)/);
     assert.match(exportPanelBody, /exportLockToGateReason\(verdict\.reason\)/);
     assert.match(exportPanelBody, /resolveGateAction\(/);
   });

--- a/tests/export-gate.test.mts
+++ b/tests/export-gate.test.mts
@@ -126,6 +126,24 @@ describe('resolveAvailableExportFormats — catalog-backed export menu', () => {
     );
   });
 
+  it('keeps every format for an entitled legacy row without exportFormats', () => {
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({
+        features: { tier: 1, dataExport: true, maxDashboards: 25 },
+      })),
+      ['csv', 'json', 'pdf'],
+    );
+  });
+
+  it('keeps every format for a legacy tier-2 row without dataExport', () => {
+    assert.deepEqual(
+      resolveAvailableExportFormats(inputs({
+        features: { tier: 2, maxDashboards: 50 },
+      })),
+      ['csv', 'json', 'pdf'],
+    );
+  });
+
   it('filters unsupported catalog values and cannot expose formats to a known free row', () => {
     assert.deepEqual(
       resolveAvailableExportFormats(inputs({

--- a/tests/product-catalog-data-export.test.mts
+++ b/tests/product-catalog-data-export.test.mts
@@ -1,7 +1,7 @@
 // U1 (plan 2026-07-25-001) — Pro Business catalog entries + the `dataExport`
-// entitlement flag. `dataExport` is the ENFORCEMENT field for data export
-// (KTD1); `exportFormats` stays display metadata that gates nothing. These
-// assertions are the source-of-truth guard for both, mirroring the
+// entitlement flag. `dataExport` controls the locked state and
+// `exportFormats` controls the unlocked export actions. These assertions are
+// the source-of-truth guard for both, mirroring the
 // apiDailyAllowance guard in product-catalog-api-allowance.test.mts.
 
 import { describe, it } from 'node:test';
@@ -89,7 +89,7 @@ describe('U1 — dataExport is the export enforcement field', () => {
     assert.equal(getEntitlementFeatures('enterprise').dataExport, true);
   });
 
-  it('exportFormats stays display metadata that agrees with dataExport', () => {
+  it('exportFormats agrees with dataExport and the menu capabilities it grants', () => {
     for (const [planKey, entry] of Object.entries(PRODUCT_CATALOG)) {
       const { dataExport, exportFormats } = entry.features;
       assert.deepEqual(


### PR DESCRIPTION
## Summary

Entitlement formats now determine which export actions users can access, so catalog claims and the export menu cannot silently diverge. Activation and stale-entitlement states keep the existing permissive behavior, avoiding a paid-user lockout during rollout or data lag.

The lazy exporter also adopts the latest entitlement format list if a newer snapshot arrives while its module is loading, preventing stale export actions from remaining visible.

Fixes #5604.

## Validation

- `TMPDIR=/private/tmp node --import tsx --test tests/export-gate.test.mts tests/product-catalog-data-export.test.mts` (53 passing)
- `vitest run --config vitest.dom.config.mts tests/dom/export-gate-wiring.test.mts tests/dom/export-pdf-cycle.test.mts` (23 passing)
- `npm run test:data`
- `npm run lint`
- `npm run typecheck:dom-tests`
- `npm run typecheck`

## Post-Deploy Monitoring & Validation

- Window/owner: first 24 hours after deploy, WorldMonitor on-call.
- Healthy signal: Pro Business and API entitlement snapshots expose only their declared CSV/JSON/PDF actions; Free and Pro remain on the locked export control.
- Watch browser/error telemetry for `[export-panel] Failed to lazy-load ExportPanel` and export-related entitlement reports.
- Roll back this commit if an entitled customer with `dataExport: true` loses a declared action or if any stale-entitlement path presents a locked/empty menu.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
