### PR TITLE
fix(finance): derive the news/data panel-key collision so commodities-news is created (#5871)

### DIFF
--- a/src/app/news-panel-keys.ts
+++ b/src/app/news-panel-keys.ts
@@ -1,0 +1,131 @@
+/**
+ * Which panel key a generic NewsPanel takes for a CANONICAL_FEEDS category.
+ *
+ * A feed-category key is not automatically free to use as a panel key. Several
+ * categories share a name with a DATA panel registered earlier in the same pass
+ * — `markets` (MarketPanel), `commodities` (CommoditiesPanel), `crypto`
+ * (CryptoPanel), `economic` (EconomicPanel), `supply-chain` (SupplyChainPanel).
+ * The registration dedup guard makes the second claim on a key a silent no-op,
+ * so a NewsPanel asking for the colliding key is simply never created. It has to
+ * take `${key}-news` instead — which is exactly what the `markets-news` /
+ * `crypto-news` / `economic-news` / `commodities-news` entries in the panel
+ * catalog are for.
+ *
+ * That collision used to be an enumerated set in panel-layout
+ * (`COLLIDING_NEWS_PANEL_KEYS`) and it omitted `commodities`: the finance
+ * variant shipped a "Commodities News" settings toggle and a mission preset
+ * (`finCommodities`) that both referenced a panel nothing ever created (#5871).
+ * #5376 hit the mirror image of this on the data-resolution side and replaced
+ * its constant with a registry derived at registration time; this is the same
+ * treatment for the panel-creation side. The caller knows, synchronously,
+ * whether something already owns a key — so ask it instead of keeping a
+ * hand-maintained list in sync with the panel registry.
+ */
+
+/** The `has(key)` surface of a Set or Map — all this module needs from either. */
+export interface KeyMembership {
+  has: (key: string) => boolean;
+}
+
+export interface NewsPanelKeyLookups {
+  /** `true` when CANONICAL_FEEDS carries a feed list under this key. */
+  isFeedCategory: (key: string) => boolean;
+  /** `true` when a NewsPanel has already been registered for this category. */
+  hasNewsPanel: (categoryKey: string) => boolean;
+  /**
+   * `true` when some panel already owns this panel key — created, or registered
+   * lazily and not yet loaded. Both count: a lazy registration reserves the key
+   * long before `ctx.panels` gains an entry, and that reservation is what makes
+   * the second claim a no-op.
+   */
+  isPanelKeyClaimed: (panelKey: string) => boolean;
+  /** `true` when `panelSettings` carries an entry for this panel key. */
+  hasPanelSetting: (panelKey: string) => boolean;
+}
+
+/**
+ * The panel key to register a NewsPanel for `categoryKey` under, or `null` when
+ * no NewsPanel should be created for it.
+ *
+ * `null` covers every reason the pass has to skip a category: it carries no feed
+ * list, it already has a NewsPanel, the key it resolves to is already taken (so
+ * the registration would be a no-op), or that key has no settings entry — which
+ * is how a data-panel collision with no `${key}-news` catalog entry stays
+ * invisible rather than spawning a phantom panel under the data panel's own
+ * settings entry.
+ *
+ * Returning the key that will actually be claimed (rather than the key we would
+ * *like* to claim) is what makes this answerable in a test: "every `*-news`
+ * settings entry is reachable from some feed category" is checkable only if the
+ * caller can tell a resolution that lands a panel from one that silently does
+ * nothing.
+ */
+export function newsPanelKeyForCategory(
+  categoryKey: string,
+  lookups: NewsPanelKeyLookups,
+): string | null {
+  if (!lookups.isFeedCategory(categoryKey)) return null;
+  if (lookups.hasNewsPanel(categoryKey)) return null;
+
+  const panelKey = lookups.isPanelKeyClaimed(categoryKey) ? `${categoryKey}-news` : categoryKey;
+
+  if (lookups.isPanelKeyClaimed(panelKey)) return null;
+  if (!lookups.hasPanelSetting(panelKey)) return null;
+
+  return panelKey;
+}
+
+/**
+ * Whether `panelSettings` carries an entry for `key`.
+ *
+ * Presence, not truthiness — this is what every panel registration in
+ * panel-layout gates on (`shouldCreatePanel`), so the news pass has to ask the
+ * same question or it would resolve to a key the registration then refuses.
+ */
+export function hasPanelSettingEntry(panelSettings: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(panelSettings, key);
+}
+
+/**
+ * Live registration state the CANONICAL_FEEDS pass reads. Field names mirror the
+ * panel-layout members they are fed from.
+ */
+export interface NewsPanelRegistrationState {
+  /** `CANONICAL_FEEDS` — a key with an array value is a feed category. */
+  canonicalFeeds: Record<string, unknown>;
+  /** `ctx.panels` — panels already created. */
+  panels: Record<string, unknown>;
+  /** `lazyPanelRegistrations` — keys reserved by a registration that has not loaded yet. */
+  lazyPanelRegistrations: KeyMembership;
+  /** `ctx.newsCategoryPanelKeys` — categories whose NewsPanel registration was claimed. */
+  newsCategoryPanelKeys: KeyMembership;
+  /** `ctx.panelSettings` — the effective panel catalog for this session. */
+  panelSettings: object;
+  /** Keys owned by a panel registered AFTER the pass (`LATE_REGISTERED_PANEL_KEYS`). */
+  lateRegisteredPanelKeys: KeyMembership;
+}
+
+/**
+ * Bind `newsPanelKeyForCategory` to live registration state.
+ *
+ * This adapter is the half a resolver test could otherwise never reach. The
+ * resolver only asks *questions*; whether the answers describe reality is
+ * decided here — most load-bearingly that a key counts as claimed when it is
+ * merely REGISTERED (`lazyPanelRegistrations`) and not yet created. That is the
+ * whole mechanism of #5871: a lazy registration reserves the key long before
+ * `ctx.panels` gains an entry, so an adapter that consulted only `ctx.panels`
+ * would report `commodities` unclaimed, hand back the data panel's own key, and
+ * let the registration no-op exactly as the hardcoded set did. Building it here
+ * rather than inline in `createPanels()` is what lets the guard bind it.
+ */
+export function newsPanelKeyLookupsFor(state: NewsPanelRegistrationState): NewsPanelKeyLookups {
+  return {
+    isFeedCategory: (key) => Array.isArray(state.canonicalFeeds[key]),
+    hasNewsPanel: (categoryKey) => state.newsCategoryPanelKeys.has(categoryKey),
+    isPanelKeyClaimed: (panelKey) =>
+      state.lateRegisteredPanelKeys.has(panelKey)
+      || state.panels[panelKey] != null
+      || state.lazyPanelRegistrations.has(panelKey),
+    hasPanelSetting: (panelKey) => hasPanelSettingEntry(state.panelSettings, panelKey),
+  };
+}

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1,6 +1,7 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { normalizeExclusiveChoropleths } from '@/components/resilience-choropleth-utils';
 import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
+import { hasPanelSettingEntry, newsPanelKeyForCategory, newsPanelKeyLookupsFor } from '@/app/news-panel-keys';
 import {
   createDeferredPanelShell,
   getDeferredPanelShellFootprint as resolveDeferredPanelShellFootprint,
@@ -139,7 +140,27 @@ const WEB_CLERK_PRO_ONLY_PANELS = new Set([
   'latest-brief',
 ]);
 
-const COLLIDING_NEWS_PANEL_KEYS = new Set(['markets', 'crypto', 'economic']);
+/**
+ * Panel keys a dedicated panel owns but registers for AFTER the CANONICAL_FEEDS
+ * NewsPanel pass — the one thing that pass cannot derive for itself.
+ *
+ * Everything else it needs is live by the time it runs: `ctx.panels` and
+ * `lazyPanelRegistrations` already hold every panel registered above it, which is
+ * what lets the news/data key collision be derived instead of enumerated (#5871).
+ * A registration BELOW it is invisible to both.
+ *
+ * `live-news` is the only one. CANONICAL_FEEDS['live-news'] exists to seed the
+ * energy variant's headline sources, not to render a panel; the key belongs to
+ * LiveNewsPanel (24/7 video), registered near the end of createPanels(). Letting
+ * the pass claim it registers a generic NewsPanel first, and lazyPanel()'s dedup
+ * guard then blocks the real video panel — regression #4382, which shipped
+ * "LIVE NEWS / No items in the last 7 days" to the live dashboard. Declaring it
+ * claimed remaps it to `live-news-news`, which has no settings entry, so no panel
+ * is created on any variant. Guarded by tests/live-news-panel-guard.test.mts, and
+ * tests/news-panel-key-reachability.test.mts fails if a SECOND feed-category panel
+ * ever moves below the pass without being listed here.
+ */
+const LATE_REGISTERED_PANEL_KEYS = new Set(['live-news']);
 
 const DASHBOARD_REFERENCE_LINKS = [
   { label: 'Countries', path: '/countries/' },
@@ -1516,7 +1537,7 @@ export class PanelLayoutManager implements AppModule {
   }
 
   private shouldCreatePanel(key: string): boolean {
-    return Object.prototype.hasOwnProperty.call(this.ctx.panelSettings, key);
+    return hasPanelSettingEntry(this.ctx.panelSettings, key);
   }
 
   private static readonly NEWS_PANEL_TOOLTIPS: Record<string, string> = {
@@ -1982,29 +2003,28 @@ export class PanelLayoutManager implements AppModule {
     // Iterate CANONICAL_FEEDS (union of all variants), not just the active
     // variant's FEEDS preset — so a news panel the user customized in from
     // another variant (e.g. Finance `forex` added to a `full` session) still
-    // gets a NewsPanel created. The panelSettings gate below ensures only
-    // panels the user actually enabled are instantiated.
+    // gets a NewsPanel created. The panelSettings gate inside
+    // newsPanelKeyForCategory ensures only panels the user actually has an entry
+    // for are instantiated.
+    //
+    // Every registration above has already run, so `isPanelKeyClaimed` is the
+    // live answer to "does a data panel already own this feed-category key?" —
+    // the fact the collision remap is derived from, instead of the hardcoded
+    // `markets`/`crypto`/`economic` set that silently omitted `commodities`
+    // (#5871). See src/app/news-panel-keys.ts.
+    const newsPanelKeyLookups = newsPanelKeyLookupsFor({
+      canonicalFeeds: CANONICAL_FEEDS,
+      panels: this.ctx.panels,
+      lazyPanelRegistrations: this.lazyPanelRegistrations,
+      newsCategoryPanelKeys: this.ctx.newsCategoryPanelKeys,
+      panelSettings: this.ctx.panelSettings,
+      lateRegisteredPanelKeys: LATE_REGISTERED_PANEL_KEYS,
+    });
     for (const key of Object.keys(CANONICAL_FEEDS)) {
-      if (this.ctx.newsPanels[key]) continue;
-      if (!Array.isArray((CANONICAL_FEEDS as Record<string, unknown>)[key])) continue;
-      // 'live-news' is the dedicated LiveNewsPanel (24/7 video) key, registered
-      // lazily below — NOT a generic RSS feed panel. CANONICAL_FEEDS['live-news']
-      // exists only to feed the energy variant's headlines; if we let it spawn a
-      // NewsPanel here it registers first and lazyPanel()'s dedup guard then
-      // blocks the real video panel (regression #4382 → "LIVE NEWS / No items in
-      // the last 7 days" on the live dashboard). Skip it so the video panel owns
-      // the key on every variant (happy has no 'live-news' panel at all).
-      if (key === 'live-news') continue;
-      const panelKey = COLLIDING_NEWS_PANEL_KEYS.has(key) && !this.ctx.newsPanels[key] ? `${key}-news` : key;
-      if (this.ctx.panels[panelKey]) continue;
-      // Gate on panelKey, NOT key. When `key` collided with a non-news data
-      // panel (panelKey became `${key}-news` — e.g. `markets`/`crypto`/`economic`
-      // in the full variant), that data panel's own settings entry must NOT
-      // spawn a phantom news panel: the remapped key has to be explicitly
-      // enabled. When there's no collision, panelKey === key so this is unchanged.
+      const panelKey = newsPanelKeyForCategory(key, newsPanelKeyLookups);
+      if (!panelKey) continue;
       const panelConfig = this.ctx.panelSettings[panelKey];
-      if (!panelConfig) continue;
-      const label = panelConfig.name ?? key.charAt(0).toUpperCase() + key.slice(1);
+      const label = panelConfig?.name ?? key.charAt(0).toUpperCase() + key.slice(1);
       const tooltip = PanelLayoutManager.NEWS_PANEL_TOOLTIPS[panelKey] ?? PanelLayoutManager.NEWS_PANEL_TOOLTIPS[key];
       this.createNewsPanelWithLabel(panelKey, label, tooltip, key);
     }

--- a/tests/live-news-panel-guard.test.mts
+++ b/tests/live-news-panel-guard.test.mts
@@ -19,6 +19,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { newsPanelKeyForCategory } from '../src/app/news-panel-keys.ts';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
@@ -151,6 +153,14 @@ describe('LiveNewsPanel instantiation guard', () => {
 //    rendered "LIVE NEWS … No items in the last 7 days" instead of the 24/7
 //    video streams. The loop must exclude 'live-news' so the dedicated video
 //    panel owns the key.
+//
+//    #5871 removed `COLLIDING_NEWS_PANEL_KEYS` — that hardcoded set was itself
+//    a bug source (it omitted `commodities`) and the collision is derived from
+//    the live registry now. `live-news` still needs naming because it is the one
+//    panel registered BELOW the loop, so the registry cannot answer for it; the
+//    exception moved to `LATE_REGISTERED_PANEL_KEYS`. Both spellings are still
+//    accepted below so the guard survives either shape, and the behavioural half
+//    of the check now runs the real resolver rather than only grepping.
 // ---------------------------------------------------------------------------
 
 describe("live-news must not be shadowed by a generic NewsPanel (regression #4382)", () => {
@@ -173,12 +183,53 @@ describe("live-news must not be shadowed by a generic NewsPanel (regression #438
 
     const skipsLiveNews = /key\s*===\s*['"]live-news['"]/.test(loopRegion);
     const collidesLiveNews = /COLLIDING_NEWS_PANEL_KEYS\s*=\s*new Set\(\[[^\]]*['"]live-news['"]/.test(layout);
+    const lateRegistersLiveNews = /LATE_REGISTERED_PANEL_KEYS\s*=\s*new Set\(\[[^\]]*['"]live-news['"]/.test(layout);
 
     assert.ok(
-      skipsLiveNews || collidesLiveNews,
+      skipsLiveNews || collidesLiveNews || lateRegistersLiveNews,
       "panel-layout.ts must exclude 'live-news' from the CANONICAL_FEEDS NewsPanel loop " +
         "(it is the dedicated LiveNewsPanel video key). Without this, the generic NewsPanel " +
         "shadows the video panel and lazyPanel's dedup guard blocks the real one (regression #4382).",
+    );
+  });
+
+  it("the real resolver refuses to create a NewsPanel for 'live-news'", () => {
+    // The grep above cannot tell whether the exclusion is actually consulted. This
+    // runs the production resolver with `live-news` declared claimed — the state
+    // `LATE_REGISTERED_PANEL_KEYS` puts it in — and asserts it yields no panel.
+    // The `live-news-news` remap must find no settings entry on any variant, so a
+    // catalog entry appearing under that name would resurrect #4382 by another route.
+    // The catalog, NOT panel-layout: `hasPanelSetting` reads `panelSettings`, which
+    // App.ts builds from ALL_PANELS in src/config/panels.ts. Grepping panel-layout
+    // for this would be an assertion that cannot fire for the case it describes.
+    assert.doesNotMatch(
+      src('src/config/panels.ts'),
+      /['"]live-news-news['"]/,
+      "nothing may define a 'live-news-news' panel — that is the key the remap parks live-news on",
+    );
+
+    assert.equal(
+      newsPanelKeyForCategory('live-news', {
+        isFeedCategory: () => true,
+        hasNewsPanel: () => false,
+        isPanelKeyClaimed: (panelKey) => panelKey === 'live-news',
+        // Deliberately generous: even if every key had a settings entry, the
+        // remapped key must still not be 'live-news'.
+        hasPanelSetting: () => true,
+      }),
+      'live-news-news',
+      "a claimed 'live-news' key must remap away from the video panel's key",
+    );
+
+    assert.equal(
+      newsPanelKeyForCategory('live-news', {
+        isFeedCategory: () => true,
+        hasNewsPanel: () => false,
+        isPanelKeyClaimed: (panelKey) => panelKey === 'live-news',
+        hasPanelSetting: (panelKey) => panelKey !== 'live-news-news',
+      }),
+      null,
+      "with no 'live-news-news' catalog entry — the real state — no panel may be created",
     );
   });
 });

--- a/tests/news-panel-key-reachability.test.mts
+++ b/tests/news-panel-key-reachability.test.mts
@@ -1,0 +1,549 @@
+/**
+ * "A settings entry with no panel" — the class of bug #5871 was.
+ *
+ * `commodities-news` shipped enabled by default on the finance variant
+ * (`FINANCE_PANELS`) and inside the `finCommodities` mission preset, but the
+ * CANONICAL_FEEDS pass in panel-layout only remapped a colliding feed category
+ * to `${key}-news` for a hardcoded `markets`/`crypto`/`economic` set. The
+ * `commodities` key is BOTH a FINANCE_FEEDS category and the key CommoditiesPanel
+ * registers under, so the NewsPanel asked for `commodities`, the dedup guard
+ * dropped it, and no panel was ever created. Users got a "Commodities News"
+ * toggle that did nothing.
+ *
+ * Two things are asserted here, and they need each other:
+ *
+ *  1. The REAL resolver (`newsPanelKeyForCategory`, extracted from the loop so
+ *     it is reachable from a test at all) is driven over the REAL catalog. A
+ *     source regex asserting "panel-layout no longer has a hardcoded set" would
+ *     go green the moment someone reintroduced one under a different name, and
+ *     could never tell which catalog entries are actually reachable.
+ *  2. The pass is replayed in registration ORDER, because the collision only
+ *     exists because CommoditiesPanel registers first. A test that ignored order
+ *     could not distinguish "remapped to commodities-news" from "silently lost".
+ *
+ * Mutation-verified: restoring the hardcoded `new Set(['markets','crypto',
+ * 'economic'])` inside `newsPanelKeyForCategory` fails
+ * "every *-news catalog entry is reachable" with `commodities-news` orphaned.
+ *
+ * The catalog and the registration order are read from source rather than
+ * imported: `src/config/panels.ts` and `src/config/feeds.ts` both reach
+ * `import.meta.env` transitively (via `@/utils/proxy`), which the tsx runner
+ * behind `npm run test:data` cannot provide. Only literal object keys and
+ * literal registration keys are extracted — no behavior is mirrored here; every
+ * decision below comes from the imported production function.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  hasPanelSettingEntry,
+  newsPanelKeyForCategory,
+  newsPanelKeyLookupsFor,
+  type NewsPanelKeyLookups,
+} from '../src/app/news-panel-keys.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const src = (relPath: string): string => readFileSync(resolve(root, relPath), 'utf-8');
+
+const feedsSrc = src('src/config/feeds.ts');
+const panelsSrc = src('src/config/panels.ts');
+const layoutSrc = src('src/app/panel-layout.ts');
+
+// Order matches `mergeCanonicalFeeds([...])` in src/config/feeds.ts, so the replay
+// visits categories in the same order `Object.keys(CANONICAL_FEEDS)` does. No two
+// categories compete for one panel key today, but matching the order costs nothing
+// and removes a way for the replay to diverge from production later.
+const FEED_PRESETS = ['FULL_FEEDS', 'TECH_FEEDS', 'FINANCE_FEEDS', 'COMMODITY_FEEDS', 'ENERGY_FEEDS', 'HAPPY_FEEDS'];
+const PANEL_PRESETS = ['FULL_PANELS', 'TECH_PANELS', 'FINANCE_PANELS', 'HAPPY_PANELS', 'COMMODITY_PANELS', 'ENERGY_PANELS'];
+
+/**
+ * Index just past the `{` that opens `const <name> ... = {`, and the index of
+ * its matching `}`. Quote- and comment-aware so a `//` inside one of the many
+ * feed URLs, or a brace inside a comment, cannot desynchronize the walk.
+ */
+function objectLiteralBody(source: string, name: string): string {
+  const decl = source.search(new RegExp(`(?:export\\s+)?const\\s+${name}\\b`));
+  assert.notEqual(decl, -1, `const ${name} not found`);
+  const open = source.indexOf('= {', decl) + 2;
+  assert.ok(open > 1, `opening brace of ${name} not found`);
+
+  let depth = 0;
+  let quote: string | null = null;
+  let lineComment = false;
+  let blockComment = false;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (lineComment) {
+      if (ch === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (ch === '*' && next === '/') { blockComment = false; i++; }
+      continue;
+    }
+    if (quote) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') { lineComment = true; i++; continue; }
+    if (ch === '/' && next === '*') { blockComment = true; i++; continue; }
+    if (ch === "'" || ch === '"' || ch === '`') { quote = ch; continue; }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unterminated object literal for ${name}`);
+}
+
+/**
+ * Top-level keys of an object literal.
+ *
+ * Three filters, each closing a way this could over-collect: brace depth (so a
+ * nested `name:` inside a panel config or a feed entry never counts), "inside a
+ * comment" (so a commented-out entry is not resurrected), and "starts its own
+ * line" (so a `Foo:` inside a string VALUE cannot masquerade as a key — every
+ * one of these files is biome-formatted one-entry-per-line).
+ */
+function topLevelKeys(source: string, name: string): string[] {
+  const body = objectLiteralBody(source, name);
+  const depthAt = new Array<number>(body.length).fill(0);
+  const inComment = new Array<boolean>(body.length).fill(false);
+  let depth = 0;
+  let quote: string | null = null;
+  let lineComment = false;
+  let blockComment = false;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    const next = body[i + 1];
+    depthAt[i] = depth;
+    inComment[i] = lineComment || blockComment;
+    if (lineComment) {
+      if (ch === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (ch === '*' && next === '/') { blockComment = false; i++; }
+      continue;
+    }
+    if (quote) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') { lineComment = true; inComment[i] = true; continue; }
+    if (ch === '/' && next === '*') { blockComment = true; inComment[i] = true; continue; }
+    if (ch === "'" || ch === '"' || ch === '`') { quote = ch; continue; }
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+  }
+
+  const startsLine = (index: number): boolean => {
+    for (let i = index - 1; i >= 0; i--) {
+      if (body[i] === '\n') return true;
+      if (body[i] !== ' ' && body[i] !== '\t') return false;
+    }
+    return true;
+  };
+
+  const keys: string[] = [];
+  const keyRe = /(?:'([A-Za-z][\w-]*)'|"([A-Za-z][\w-]*)"|([A-Za-z][\w-]*))\s*:/g;
+  let m: RegExpExecArray | null;
+  while ((m = keyRe.exec(body)) !== null) {
+    if (depthAt[m.index] !== 0) continue;
+    if (inComment[m.index]) continue;
+    if (!startsLine(m.index)) continue;
+    keys.push(m[1] ?? m[2] ?? m[3]!);
+  }
+  return keys;
+}
+
+function unionOfPresets(source: string, names: string[]): Set<string> {
+  const out = new Set<string>();
+  for (const name of names) for (const key of topLevelKeys(source, name)) out.add(key);
+  return out;
+}
+
+/** CANONICAL_FEEDS keys — the union the pass iterates. */
+const feedCategories = unionOfPresets(feedsSrc, FEED_PRESETS);
+/** ALL_PANELS keys — every panel key any variant can put in `panelSettings`. */
+const catalogPanelKeys = unionOfPresets(panelsSrc, PANEL_PRESETS);
+
+type Registration = { key: string; index: number; viaCreateNewsPanel: boolean };
+
+/**
+ * Every panel key panel-layout claims, in source order, with the ones that go
+ * through `createNewsPanel` flagged — those record a category→panel-key entry in
+ * `ctx.newsCategoryPanelKeys`, which is what `hasNewsPanel` reads.
+ */
+function panelRegistrations(): Registration[] {
+  const out: Registration[] = [];
+  for (const m of layoutSrc.matchAll(/this\.lazy(?:Panel|DefaultPanel|ImportedPanel)\(\s*'([^']+)'/g)) {
+    out.push({ key: m[1]!, index: m.index!, viaCreateNewsPanel: false });
+  }
+  for (const m of layoutSrc.matchAll(/this\.createNewsPanel\(\s*'([^']+)'/g)) {
+    out.push({ key: m[1]!, index: m.index!, viaCreateNewsPanel: true });
+  }
+  return out.sort((a, b) => a.index - b.index);
+}
+
+const loopIndex = layoutSrc.indexOf('for (const key of Object.keys(CANONICAL_FEEDS))');
+const registrations = panelRegistrations();
+
+/**
+ * Feed-category panels registered BELOW the pass — invisible to `ctx.panels` and
+ * `lazyPanelRegistrations` while it runs, so panel-layout names them in
+ * `LATE_REGISTERED_PANEL_KEYS` instead. Mirrored here from the same source order
+ * the production constant is maintained against, and the "declares every
+ * feed-category panel registered after the loop" test asserts the two agree —
+ * which is what stops this mirror from quietly diverging.
+ */
+const lateRegisteredFeedCategories = [...new Set(
+  registrations.filter(reg => reg.index > loopIndex && feedCategories.has(reg.key)).map(reg => reg.key),
+)].sort();
+
+/**
+ * Replay the pass the way `createPanels()` runs it: everything registered above
+ * the loop has already claimed its key, so the loop sees those claims and only
+ * those. `shouldCreatePanel` gates every registration on `key in panelSettings`,
+ * and App.ts merges ALL_PANELS into panelSettings on every variant, so a
+ * registration claims its key exactly when the catalog carries it.
+ *
+ * Returns panelKey → the feed category it renders, for every panel the pass
+ * actually creates.
+ */
+function replayNewsPanelPass(): Map<string, string> {
+  // Shaped like the real members panel-layout hands the adapter, not like a
+  // convenient stand-in: registration reserves the key in `lazyPanelRegistrations`
+  // and `ctx.panels` stays EMPTY for the whole synchronous pass (a lazy panel only
+  // lands in `ctx.panels` once its chunk loads, long after). Modelling those as one
+  // merged "claimed" set is what would let an adapter that consults only
+  // `ctx.panels` — the #5871 bug in adapter form — replay green.
+  const lazyPanelRegistrations = new Set<string>();
+  const panels: Record<string, unknown> = {};
+  const newsCategoryPanelKeys = new Set<string>();
+  for (const reg of registrations) {
+    if (reg.index > loopIndex) continue;
+    if (!catalogPanelKeys.has(reg.key)) continue;
+    if (reg.viaCreateNewsPanel && !lazyPanelRegistrations.has(reg.key)) newsCategoryPanelKeys.add(reg.key);
+    lazyPanelRegistrations.add(reg.key);
+  }
+
+  const lookups = newsPanelKeyLookupsFor({
+    canonicalFeeds: Object.fromEntries([...feedCategories].map(key => [key, []])),
+    panels,
+    lazyPanelRegistrations,
+    newsCategoryPanelKeys,
+    panelSettings: Object.fromEntries([...catalogPanelKeys].map(key => [key, {}])),
+    lateRegisteredPanelKeys: new Set(lateRegisteredFeedCategories),
+  });
+
+  const created = new Map<string, string>();
+  for (const categoryKey of feedCategories) {
+    const panelKey = newsPanelKeyForCategory(categoryKey, lookups);
+    if (!panelKey) continue;
+    created.set(panelKey, categoryKey);
+    lazyPanelRegistrations.add(panelKey);
+    newsCategoryPanelKeys.add(categoryKey);
+  }
+  return created;
+}
+
+/** Panel keys with their own dedicated registration (not created by the pass). */
+const dedicatedPanelKeys = new Set(registrations.map(reg => reg.key));
+/** Of those, the ones that are NOT a generic NewsPanel — the collision sources. */
+const nonNewsPanelKeys = new Set(registrations.filter(reg => !reg.viaCreateNewsPanel).map(reg => reg.key));
+
+/**
+ * Lookups where nothing is claimed and everything has a settings entry, so each
+ * case below can turn exactly ONE guard on and know which one fired.
+ */
+function permissiveLookups(overrides: Partial<NewsPanelKeyLookups> = {}): NewsPanelKeyLookups {
+  return {
+    isFeedCategory: () => true,
+    hasNewsPanel: () => false,
+    isPanelKeyClaimed: () => false,
+    hasPanelSetting: () => true,
+    ...overrides,
+  };
+}
+
+describe('newsPanelKeyForCategory guards (#5871)', () => {
+  // The composite replay below exercises the resolver only through the ONE state
+  // the real catalog happens to produce, which leaves most of its guards free to
+  // be deleted without failing anything. Each case here makes a single guard the
+  // reason for the answer, so removing that guard changes this file's result.
+
+  it('takes the category key when nothing owns it', () => {
+    assert.equal(newsPanelKeyForCategory('forex', permissiveLookups()), 'forex');
+  });
+
+  it('remaps to ${key}-news when a data panel owns the category key', () => {
+    assert.equal(
+      newsPanelKeyForCategory('commodities', permissiveLookups({
+        isPanelKeyClaimed: (panelKey) => panelKey === 'commodities',
+      })),
+      'commodities-news',
+    );
+  });
+
+  it('skips a key with no feed list', () => {
+    assert.equal(
+      newsPanelKeyForCategory('climate-news', permissiveLookups({ isFeedCategory: () => false })),
+      null,
+    );
+  });
+
+  it('skips a category that already has a NewsPanel', () => {
+    // `createNewsPanel('politics')` runs before the pass; without this guard the
+    // pass sees the key claimed by that very registration and remaps the category
+    // onto a phantom `politics-news`.
+    assert.equal(
+      newsPanelKeyForCategory('politics', permissiveLookups({
+        hasNewsPanel: (categoryKey) => categoryKey === 'politics',
+        isPanelKeyClaimed: (panelKey) => panelKey === 'politics',
+      })),
+      null,
+    );
+  });
+
+  it('skips when the remapped key is itself already claimed', () => {
+    // Both `X` and `X-news` taken: any key this returned would be a registration
+    // no-op, and reporting it as created is what made #5871 invisible.
+    assert.equal(
+      newsPanelKeyForCategory('markets', permissiveLookups({ isPanelKeyClaimed: () => true })),
+      null,
+    );
+  });
+
+  it('skips when the resolved key has no settings entry', () => {
+    // `supply-chain` today: SupplyChainPanel owns the key, and no
+    // `supply-chain-news` catalog entry exists to remap onto.
+    assert.equal(
+      newsPanelKeyForCategory('supply-chain', permissiveLookups({
+        isPanelKeyClaimed: (panelKey) => panelKey === 'supply-chain',
+        hasPanelSetting: (panelKey) => panelKey !== 'supply-chain-news',
+      })),
+      null,
+    );
+  });
+});
+
+describe('newsPanelKeyLookupsFor (#5871)', () => {
+  const stateWith = (over: Partial<Parameters<typeof newsPanelKeyLookupsFor>[0]> = {}) =>
+    newsPanelKeyLookupsFor({
+      canonicalFeeds: { commodities: [], forex: [] },
+      panels: {},
+      lazyPanelRegistrations: new Set<string>(),
+      newsCategoryPanelKeys: new Set<string>(),
+      panelSettings: { commodities: {}, 'commodities-news': {}, forex: {} },
+      lateRegisteredPanelKeys: new Set<string>(),
+      ...over,
+    });
+
+  it('counts a key claimed by a lazy registration that has not loaded yet', () => {
+    // The mechanism of #5871. During createPanels() the whole registration pass is
+    // synchronous and `ctx.panels` is still EMPTY — a lazy panel only lands there
+    // when its chunk resolves. An adapter that consulted only `ctx.panels` would
+    // call `commodities` unclaimed, hand the NewsPanel the data panel's own key,
+    // and the registration would silently no-op exactly as the hardcoded set did.
+    const lookups = stateWith({ lazyPanelRegistrations: new Set(['commodities']) });
+    assert.equal(lookups.isPanelKeyClaimed('commodities'), true);
+    assert.equal(newsPanelKeyForCategory('commodities', lookups), 'commodities-news');
+  });
+
+  it('counts a key claimed by an already-created panel', () => {
+    const lookups = stateWith({ panels: { commodities: { id: 'commodities' } } });
+    assert.equal(newsPanelKeyForCategory('commodities', lookups), 'commodities-news');
+  });
+
+  it('counts a late-registered key as claimed', () => {
+    const lookups = stateWith({ lateRegisteredPanelKeys: new Set(['commodities']) });
+    assert.equal(newsPanelKeyForCategory('commodities', lookups), 'commodities-news');
+  });
+
+  it('leaves an unclaimed key alone', () => {
+    assert.equal(newsPanelKeyForCategory('forex', stateWith()), 'forex');
+  });
+
+  it('reads panelSettings by presence, matching shouldCreatePanel', () => {
+    // `hasOwnProperty`, not truthiness — every other registration in panel-layout
+    // gates on presence, so resolving on a stricter rule would hand back a key the
+    // registration then refuses.
+    assert.equal(hasPanelSettingEntry({ 'markets-news': undefined }, 'markets-news'), true);
+    assert.equal(hasPanelSettingEntry({}, 'markets-news'), false);
+    assert.equal(
+      stateWith({ panelSettings: { commodities: {}, 'commodities-news': undefined } })
+        .hasPanelSetting('commodities-news'),
+      true,
+    );
+  });
+});
+
+describe('news panel key reachability (#5871)', () => {
+  it('parsers resolve non-empty sets (guards against silent regex drift)', () => {
+    assert.ok(feedCategories.size > 40, `expected >40 feed categories, got ${feedCategories.size}`);
+    assert.ok(catalogPanelKeys.size > 100, `expected >100 catalog panels, got ${catalogPanelKeys.size}`);
+    assert.ok(registrations.length > 100, `expected >100 panel registrations, got ${registrations.length}`);
+    assert.notEqual(loopIndex, -1, 'CANONICAL_FEEDS loop not found in panel-layout.ts');
+    // Spot-check both sides of the collision this file exists for, so a parser
+    // that silently stopped seeing FINANCE_* fails here rather than vacuously
+    // passing the reachability assertion with an empty work-list.
+    for (const key of ['commodities', 'markets', 'crypto', 'economic', 'supply-chain', 'live-news']) {
+      assert.ok(feedCategories.has(key), `expected '${key}' among feed categories`);
+    }
+    for (const key of ['commodities', 'commodities-news', 'markets', 'markets-news', 'climate-news']) {
+      assert.ok(catalogPanelKeys.has(key), `expected '${key}' in the panel catalog`);
+    }
+  });
+
+  it('every *-news catalog entry is reachable from a feed category', () => {
+    const created = replayNewsPanelPass();
+    const orphans = [...catalogPanelKeys]
+      .filter(key => key.endsWith('-news'))
+      .filter(key => !created.has(key))
+      // A key with its own registration (climate-news → ClimateNewsPanel,
+      // live-news → LiveNewsPanel) is created directly, not by this pass.
+      .filter(key => !dedicatedPanelKeys.has(key))
+      .sort();
+    assert.deepEqual(
+      orphans,
+      [],
+      `panel catalog entries that no feed category resolves to — the settings toggle and any ` +
+        `mission preset referencing them do nothing: ${orphans.join(', ')}`,
+    );
+  });
+
+  it("maps the 'commodities' feed category onto the 'commodities-news' panel", () => {
+    const created = replayNewsPanelPass();
+    assert.equal(
+      created.get('commodities-news'),
+      'commodities',
+      "'commodities' is a FINANCE_FEEDS category AND CommoditiesPanel's key, so its NewsPanel " +
+        "must be remapped to 'commodities-news' — the key the finance catalog and the " +
+        'finCommodities mission preset both reference (#5871)',
+    );
+    assert.equal(
+      created.has('commodities'),
+      false,
+      "the NewsPanel must not claim 'commodities' — CommoditiesPanel owns it",
+    );
+  });
+
+  it('keeps the pre-existing markets/crypto/economic remaps intact', () => {
+    const created = replayNewsPanelPass();
+    for (const base of ['markets', 'crypto', 'economic']) {
+      assert.equal(created.get(`${base}-news`), base, `expected ${base} → ${base}-news`);
+      assert.equal(created.has(base), false, `NewsPanel must not claim the '${base}' data-panel key`);
+    }
+  });
+
+  it('never creates a generic NewsPanel for a key another panel owns', () => {
+    const created = replayNewsPanelPass();
+    for (const [panelKey] of created) {
+      assert.equal(
+        dedicatedPanelKeys.has(panelKey),
+        false,
+        `'${panelKey}' already has its own registration in panel-layout — a NewsPanel claiming it ` +
+          'is a silent no-op, or shadows the real panel (regression #4382)',
+      );
+    }
+  });
+
+  it('declares every feed-category panel registered after the loop as late-registered', () => {
+    // The one thing the pass cannot derive. `ctx.panels` and `lazyPanelRegistrations`
+    // only hold what registered ABOVE the loop, so a feed-category panel registered
+    // below it is invisible and gets shadowed by a generic NewsPanel (regression
+    // #4382, which is what happened to `live-news`). `LATE_REGISTERED_PANEL_KEYS`
+    // is the hand-maintained half; this binds it to the actual source order, so
+    // moving a panel below the loop — or dropping a key from the set — fails here.
+    const declaredBlock = layoutSrc.match(/LATE_REGISTERED_PANEL_KEYS\s*=\s*new Set\(\[([^\]]*)\]\)/);
+    assert.ok(declaredBlock, 'LATE_REGISTERED_PANEL_KEYS declaration not found in panel-layout.ts');
+    const declared = [...declaredBlock[1]!.matchAll(/'([^']+)'/g)].map(m => m[1]!).sort();
+    assert.deepEqual(
+      lateRegisteredFeedCategories,
+      declared,
+      'every feed-category panel registered after the CANONICAL_FEEDS pass must be listed in ' +
+        'LATE_REGISTERED_PANEL_KEYS, and nothing else should be',
+    );
+  });
+
+  it('records every colliding feed category that still resolves to no panel', () => {
+    const created = replayNewsPanelPass();
+    const renderedCategories = new Set(created.values());
+    // The mirror image of the reachability check above: a feed category whose key
+    // a NON-news panel owns and which has no `${key}-news` outlet either. Nothing
+    // is user-visible for it, so only the guard can see it — this is exactly the
+    // shape `commodities` had before #5871.
+    const collidingWithoutOutlet = [...feedCategories]
+      .filter(key => nonNewsPanelKeys.has(key))
+      .filter(key => !renderedCategories.has(key))
+      .sort();
+    assert.deepEqual(
+      collidingWithoutOutlet,
+      [
+        // The dedicated LiveNewsPanel (24/7 video) owns this key on every variant.
+        // CANONICAL_FEEDS['live-news'] exists to seed the energy variant's headline
+        // sources, not to render a panel — deliberate since #4382.
+        'live-news',
+        // COMMODITY_FEEDS/ENERGY_FEEDS category whose key SupplyChainPanel owns.
+        // No `supply-chain-news` catalog entry exists, so nothing is user-visible
+        // and #5376 already removed it from the client's news work-list. Shipping a
+        // panel for it is a product decision, not part of this fix (#5871).
+        'supply-chain',
+      ],
+      'a feed category whose key another panel owns renders nowhere — add a `${key}-news` catalog ' +
+        'entry, or record it here with the reason it is intentional',
+    );
+  });
+
+  it('knows every panel-registration primitive panel-layout defines', () => {
+    // `panelRegistrations()` discovers registration ORDER by grepping three method
+    // names. A fourth primitive would be invisible to it, so a feed-category panel
+    // registered through it could move below the pass with LATE_REGISTERED_PANEL_KEYS
+    // never updated — and the drift guard above would stay green while a generic
+    // NewsPanel shadowed it (regression #4382, through a seam nothing tracks).
+    const primitives = [...layoutSrc.matchAll(/^\s*private (lazy\w*Panel|createNewsPanel\w*)\b/gm)]
+      .map(m => m[1]!)
+      .sort();
+    assert.deepEqual(
+      primitives,
+      ['createNewsPanel', 'createNewsPanelWithLabel', 'lazyDefaultPanel', 'lazyImportedPanel', 'lazyPanel'],
+      'a new panel-registration primitive appeared in panel-layout.ts — teach panelRegistrations() ' +
+        'about it (or this file stops seeing part of the registration order it replays)',
+    );
+  });
+
+  it('panel-layout resolves the panel key through newsPanelKeyForCategory', () => {
+    const createCall = layoutSrc.indexOf('createNewsPanelWithLabel(panelKey', loopIndex);
+    assert.notEqual(createCall, -1, 'createNewsPanelWithLabel call not found inside the loop');
+    const loopRegion = layoutSrc.slice(loopIndex, createCall);
+    assert.match(
+      loopRegion,
+      /newsPanelKeyForCategory\(/,
+      'the CANONICAL_FEEDS loop must delegate panel-key resolution to newsPanelKeyForCategory — ' +
+        'the assertions above only bind production behaviour while it does',
+    );
+    assert.doesNotMatch(
+      layoutSrc,
+      /COLLIDING_NEWS_PANEL_KEYS/,
+      'the hardcoded collision set is what omitted `commodities` (#5871); the collision is derived ' +
+        'from the live registry now',
+    );
+    assert.match(
+      layoutSrc,
+      /newsPanelKeyLookupsFor\(/,
+      'panel-layout must build the lookups through newsPanelKeyLookupsFor — an inline adapter here ' +
+        'would be the half no test can reach, and consulting only ctx.panels reproduces #5871',
+    );
+  });
+});

--- a/tests/news-panel-key-reachability.test.mts
+++ b/tests/news-panel-key-reachability.test.mts
@@ -173,6 +173,26 @@ function unionOfPresets(source: string, names: string[]): Set<string> {
   return out;
 }
 
+/**
+ * Every preset const of `type` actually declared in `source` — i.e. what
+ * FEED_PRESETS / PANEL_PRESETS above are supposed to name.
+ *
+ * Derived rather than listed, because a hand-maintained list that silently drifts
+ * from the registry it mirrors is the entire bug this file guards against, and a
+ * guard is not exempt from its own lesson. A preset here is a const of the right
+ * annotation assigned an object literal with at least one top-level key of its
+ * own — which excludes the derived aggregates for free: `ALL_PANELS` is an object
+ * literal but spreads-only (no keys), and `CANONICAL_FEEDS` / `DEFAULT_PANELS`
+ * are assigned function calls rather than literals.
+ */
+function declaredPresetConsts(source: string, type: string): string[] {
+  const re = new RegExp(`const\\s+(\\w+)\\s*:\\s*${type}\\s*=\\s*\\{`, 'g');
+  return [...source.matchAll(re)]
+    .map(m => m[1]!)
+    .filter(name => topLevelKeys(source, name).length > 0)
+    .sort();
+}
+
 /** CANONICAL_FEEDS keys — the union the pass iterates. */
 const feedCategories = unionOfPresets(feedsSrc, FEED_PRESETS);
 /** ALL_PANELS keys — every panel key any variant can put in `panelSettings`. */
@@ -404,6 +424,24 @@ describe('news panel key reachability (#5871)', () => {
     for (const key of ['commodities', 'commodities-news', 'markets', 'markets-news', 'climate-news']) {
       assert.ok(catalogPanelKeys.has(key), `expected '${key}' in the panel catalog`);
     }
+  });
+
+  it('names every feed and panel preset that actually exists', () => {
+    // Without this, FEED_PRESETS / PANEL_PRESETS are exactly the shape of the bug
+    // this file exists to catch: a hand-maintained list that drifts from the
+    // registry it mirrors. A renamed or newly-added preset would silently shrink
+    // the key sets, and the reachability assertion below would keep passing over
+    // a smaller world — the same way `commodities` fell off COLLIDING_NEWS_PANEL_KEYS.
+    assert.deepEqual(
+      declaredPresetConsts(feedsSrc, 'Record<string, Feed\\[\\]>'),
+      [...FEED_PRESETS].sort(),
+      'src/config/feeds.ts declares a different set of feed presets than FEED_PRESETS names',
+    );
+    assert.deepEqual(
+      declaredPresetConsts(panelsSrc, 'Record<string, PanelConfig>'),
+      [...PANEL_PRESETS].sort(),
+      'src/config/panels.ts declares a different set of panel presets than PANEL_PRESETS names',
+    );
   });
 
   it('every *-news catalog entry is reachable from a feed category', () => {

--- a/tests/news-panel-key-reachability.test.mts
+++ b/tests/news-panel-key-reachability.test.mts
@@ -561,7 +561,31 @@ describe('news panel key reachability (#5871)', () => {
     );
   });
 
-  it('panel-layout resolves the panel key through newsPanelKeyForCategory', () => {
+  it('panel-layout binds the production resolver and lookup adapter', () => {
+    const lookupStart = layoutSrc.lastIndexOf('const newsPanelKeyLookups =', loopIndex);
+    assert.notEqual(lookupStart, -1, 'newsPanelKeyLookups construction not found before the loop');
+    const lookupEnd = layoutSrc.indexOf('});', lookupStart);
+    assert.notEqual(lookupEnd, -1, 'newsPanelKeyLookups construction has no closing object');
+    const lookupRegion = layoutSrc.slice(lookupStart, lookupEnd + 3);
+    assert.match(
+      lookupRegion,
+      /newsPanelKeyLookupsFor\(\{/,
+      'panel-layout must build the production lookups through newsPanelKeyLookupsFor',
+    );
+    for (const binding of [
+      'canonicalFeeds: CANONICAL_FEEDS',
+      'panels: this.ctx.panels',
+      'lazyPanelRegistrations: this.lazyPanelRegistrations',
+      'newsCategoryPanelKeys: this.ctx.newsCategoryPanelKeys',
+      'panelSettings: this.ctx.panelSettings',
+      'lateRegisteredPanelKeys: LATE_REGISTERED_PANEL_KEYS',
+    ]) {
+      assert.ok(
+        lookupRegion.includes(binding),
+        `newsPanelKeyLookupsFor must receive the live production binding: ${binding}`,
+      );
+    }
+
     const createCall = layoutSrc.indexOf('createNewsPanelWithLabel(panelKey', loopIndex);
     assert.notEqual(createCall, -1, 'createNewsPanelWithLabel call not found inside the loop');
     const loopRegion = layoutSrc.slice(loopIndex, createCall);
@@ -576,12 +600,6 @@ describe('news panel key reachability (#5871)', () => {
       /COLLIDING_NEWS_PANEL_KEYS/,
       'the hardcoded collision set is what omitted `commodities` (#5871); the collision is derived ' +
         'from the live registry now',
-    );
-    assert.match(
-      layoutSrc,
-      /newsPanelKeyLookupsFor\(/,
-      'panel-layout must build the lookups through newsPanelKeyLookupsFor — an inline adapter here ' +
-        'would be the half no test can reach, and consulting only ctx.panels reproduces #5871',
     );
   });
 });


### PR DESCRIPTION
## Problem

`commodities-news` is enabled by default on the **finance** variant (`src/config/panels.ts:460`) and listed in the `finCommodities` mission preset (`:1424`), but **no panel was ever created for it**. Finance users got a "Commodities News" toggle — and a mission preset that referenced it — that did nothing.

Reproduced in the browser on a finance dev build before touching anything: the dashboard rendered **57** panels with no `[data-panel="commodities-news"]`.

## Root cause

`src/app/panel-layout.ts` remapped a news panel to `${key}-news` only for a hardcoded set:

```js
const COLLIDING_NEWS_PANEL_KEYS = new Set(['markets', 'crypto', 'economic']);
```

`commodities` is **both** a FINANCE_FEEDS category **and** the key `CommoditiesPanel` registers under ~100 lines earlier — it collides exactly like those three, but was absent from the set. So `panelKey` stayed `'commodities'`, `lazyPanel` early-returned because `lazyPanelRegistrations` already held that key, and the NewsPanel registration was a silent no-op. The feed items were still fetched and then discarded.

## Fix — derived, not enumerated

#5376 hit the mirror image of this on the *data-resolution* side and replaced its constant with a registry filled at registration time. This is the same treatment for the *panel-creation* side: the pass already knows, synchronously, whether `ctx.panels` / `lazyPanelRegistrations` holds a key, so the collision is read from that instead of from a list nothing kept in sync.

Extracted into `src/app/news-panel-keys.ts` as two pure functions:

- `newsPanelKeyForCategory` — the decision.
- `newsPanelKeyLookupsFor` — the adapter binding it to live registration state.

The adapter is extracted for the same reason as the resolver. The load-bearing fact is that a key counts as claimed when it is merely **registered**, not yet created — `ctx.panels` is empty for the whole synchronous pass. An adapter reading only `ctx.panels` reproduces this bug in a place no resolver test could reach, so it needed to be bindable too.

After: **58** panels, "Commodities News" present alongside the `commodities` price panel.

## No new network requests

Verified rather than assumed. `resolveNewsCategories` adds every key in the active variant's own FEEDS preset unconditionally, so `commodities` was **already** in the finance work-list before this change (that is why the bytes were being paid for and discarded), and its second loop skips keys already in `presetKeys`. On every other variant App.ts seeds `commodities-news` `enabled: false`, so `enabledNewsCategoryKeys` never promotes the category. Cross-enabling it routes through the capped custom-category path from #5376.

All 5 cases of `e2e/dashboard-news-request-budget.spec.ts` (the #5376 gate) still pass.

## Guards

`tests/news-panel-key-reachability.test.mts` is the guard the issue asked for: **every `*-news` catalog entry must resolve to a created panel**. It replays the real pass in registration order over the real catalog, driving the production resolver and adapter — so it is not a mirror of the logic it checks. It also pins the resolver's individual guards, that the adapter consults lazy registrations, that `LATE_REGISTERED_PANEL_KEYS` matches actual source order, and that no new registration primitive appears that its scan cannot see.

Every guard is mutation-verified to fail with the defect restored:

| Mutation | Result |
|---|---|
| Restore the hardcoded `new Set(['markets','crypto','economic'])` | RED — `commodities-news` orphaned |
| Remove the delegation from panel-layout's loop | RED |
| Drop `'live-news'` from `LATE_REGISTERED_PANEL_KEYS` | RED (2 suites) |
| Delete the `hasNewsPanel` / post-remap-claimed / `isFeedCategory` guard | RED (one case each) |
| Adapter stops consulting `lazyPanelRegistrations` | RED (6 cases) |
| A `live-news-news` catalog entry appears | RED (2 cases) |

`supply-chain` and `live-news` — feed categories a non-news panel owns with no `-news` outlet — are recorded with reasons rather than left silent. Shipping a `supply-chain-news` panel is a product decision, so it is deliberately **not** in this PR.

## The #4382 exception moved, not deleted

`COLLIDING_NEWS_PANEL_KEYS` also carried the `live-news` exception. That key belongs to the one panel registered **below** the pass, so the registry genuinely cannot answer for it; it moves to a narrower, documented `LATE_REGISTERED_PANEL_KEYS`, and the reachability guard now fails if a second feed-category panel ever moves below the pass without being listed.

`tests/live-news-panel-guard.test.mts` accepts the new shape and gains a behavioural assertion through the real resolver, since its old check was a grep for the now-deleted constant. Review also caught that its `live-news-news` assertion read `panel-layout.ts`, where a catalog entry would never appear — it now reads `src/config/panels.ts`, which is what `hasPanelSetting` actually consults.

## Verification

- `npm run typecheck` — clean
- `npx biome check` on all 4 files — clean
- 32 unit assertions across both guard suites; full `tests/` sweep in 4 chunks — only the known fresh-worktree `dashboard-critical-css` build prerequisite fails (needs `vite build`, unrelated)
- `npm run test:dom` — 125 pass
- `npm run test:e2e:news-budget` — 5 pass
- Browser, finance variant — panel absent before, present after

Closes #5871

https://claude.ai/code/session_013jZWcQxhssxedAW96N4jHN