### PR TITLE
fix(china): distinguish decision group unavailability

### DIFF
--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -15,6 +15,53 @@ const RESILIENCE_INTERVAL_SOURCE_VERSION = `resilience-intervals:${RESILIENCE_IN
 const RESILIENCE_INTERVAL_PROBE_KEY = `${RESILIENCE_INTERVAL_KEY_PREFIX}US`;
 const RESILIENCE_INTERVAL_SCORE_MIN = 0;
 const RESILIENCE_INTERVAL_SCORE_MAX = 100;
+const CHINA_DECISION_SIGNAL_GROUP_IDS = Object.freeze([
+  'macro',
+  'policy-enforcement',
+  'cross-strait-activity',
+  'corporate-disclosures',
+  'corridor-conditions',
+  'activity-nowcast',
+]);
+const CHINA_DECISION_SIGNAL_STATES = new Set([
+  'available',
+  'partial',
+  'stale',
+  'unavailable',
+]);
+
+function projectChinaDecisionGroupDiagnostics(meta) {
+  const states = meta?.groupStates;
+  const counts = meta?.groupCounts;
+  if (
+    !states
+    || typeof states !== 'object'
+    || Array.isArray(states)
+    || !counts
+    || typeof counts !== 'object'
+    || Array.isArray(counts)
+  ) return null;
+  const groupStates = Object.fromEntries(
+    CHINA_DECISION_SIGNAL_GROUP_IDS.map((groupId) => [groupId, states[groupId]]),
+  );
+  if (
+    Object.values(groupStates).some((state) => !CHINA_DECISION_SIGNAL_STATES.has(state))
+    || !['populated', 'partial', 'stale', 'unavailable'].every(
+      (key) => Number.isInteger(counts[key])
+        && counts[key] >= 0
+        && counts[key] <= CHINA_DECISION_SIGNAL_GROUP_IDS.length,
+    )
+  ) return null;
+  return {
+    groupStates,
+    groupCounts: {
+      populated: counts.populated,
+      partial: counts.partial,
+      stale: counts.stale,
+      unavailable: counts.unavailable,
+    },
+  };
+}
 
 const SEED_DOMAINS = {
   'health:china-coverage':    { key: 'seed-meta:health:china-coverage',    intervalMin: 60, activationKey: 'seed-activated:health:china-coverage' },
@@ -475,6 +522,10 @@ export default async function handler(req) {
     // seed entry keeps its exact shape.
     if (typeof meta.lastErrorCode === 'string' && meta.lastErrorCode) {
       seeds[domain].lastErrorCode = meta.lastErrorCode;
+    }
+    if (domain === 'intelligence:china-decision-signals') {
+      const diagnostics = projectChinaDecisionGroupDiagnostics(meta);
+      if (diagnostics) Object.assign(seeds[domain], diagnostics);
     }
   }
 

--- a/docs/china-decision-signals.mdx
+++ b/docs/china-decision-signals.mdx
@@ -19,6 +19,27 @@ outage or invalid provenance envelope fails closed inside that group without
 hiding unrelated healthy groups. Public responses include at most four items
 per group and state how many additional valid items were omitted.
 
+Those group states are not source-health verdicts. Three separate questions
+must stay distinct:
+
+- **Source coverage** asks whether the launched upstream lanes are reachable,
+  fresh, and producing contract-valid snapshots.
+- **Decision-group population** asks whether a reviewed source snapshot
+  contains at least one qualifying, provenance-valid decision item. A healthy
+  corporate-disclosure query can therefore be an unpopulated
+  `healthy_quiet_window` without being an incident.
+- **Contract parity** asks whether the RPC and bootstrap projections both
+  satisfy the same ordered six-group schema. Parity can be healthy while one
+  or more groups are quiet, insufficient, stale, or unavailable.
+
+Unavailable groups carry a bounded `metadata.unavailableCause`. Known causes
+include `healthy_quiet_window`, `insufficient_data`,
+`provenance_rejected`, and `upstream_unavailable`; the generic reason is used
+only when composition cannot determine a more specific truthful cause.
+Insufficient activity-nowcast groups retain their exact bounded
+`missingInputs` and `missingInputFamilies` diagnostics rather than discarding
+them with the absent derived item.
+
 ## One contract across surfaces
 
 The same `china-decision-signals/v1` JSON contract backs:
@@ -127,6 +148,22 @@ rejected, because the probe reports reachability and latency for whatever it is
 pointed at. The live probe validates both the composition RPC and the public
 `chinaDecisionSignals`
 bootstrap projection, including a one-hour maximum canonical age. It prints only
-route status, latency, generation time, and group states. It never prints
+route status, latency, generation time, group states, and the prominent
+`populated`, `partial`, `stale`, and `unavailable` group counts. It never prints
 environment variables, API keys, Redis values, source documents, or detailed
 trade records.
+
+Ordinary parity remains schema-only and accepts legitimately unpopulated
+groups. A release or operator audit that requires specific populated groups can
+opt into an explicit assertion:
+
+```bash
+node scripts/audit-china-decision-parity.mjs \
+  --require-live \
+  --url https://api-staging.example \
+  --require-populated macro,corporate-disclosures
+```
+
+The operator-only `/api/seed-health` entry and seed log expose the same bounded
+per-group states and counts. Anonymous compact `/api/health?compact=1` continues
+to omit `chinaDecisionSignals` entirely.

--- a/scripts/audit-china-decision-parity.mjs
+++ b/scripts/audit-china-decision-parity.mjs
@@ -10,7 +10,11 @@ import {
 } from './lib/js-source-structure.mjs';
 import { isMainModule } from './lib/main-module.mjs';
 import { readChinaDecisionSignalWireContract } from './lib/openapi-codegen.mjs';
-import { validateChinaDecisionSignalSnapshot } from './seed-china-decision-signals.mjs';
+import {
+  chinaDecisionSignalGroupDiagnostics,
+  summarizeChinaDecisionGroups,
+  validateChinaDecisionSignalSnapshot,
+} from './seed-china-decision-signals.mjs';
 
 export { isMainModule } from './lib/main-module.mjs';
 
@@ -24,6 +28,9 @@ const BOOTSTRAP_ROUTE = '/api/bootstrap?keys=chinaDecisionSignals&public=1';
 const CANONICAL_KEY = 'intelligence:china-decision-signals:v1';
 const META_KEY = 'seed-meta:intelligence:china-decision-signals';
 const ROUTE_CACHE_TIER = 'fast';
+const GROUP_IDS = Object.freeze(
+  CHINA_DECISION_PARITY_MANIFEST.map(({ groupId }) => groupId),
+);
 
 const ACCESS_TIERS = Object.freeze([
   Object.freeze(['anonymous', 'bounded_public_summary']),
@@ -63,6 +70,20 @@ const REQUIRED_REGISTRATIONS = Object.freeze([
 // finding instead of a pass. Each `verify` is a pure function of source text so
 // its truth table can be exercised against mutated sources in tests.
 export const CHINA_DECISION_STRUCTURAL_CHECKS = Object.freeze([
+  Object.freeze({
+    id: 'edge-seed-health-group-ids',
+    file: 'api/seed-health.js',
+    intent: 'seed-health keeps its Edge-local China decision group mirror in canonical order',
+    verify(source) {
+      const body = extractDelimitedBlock(source, 'const CHINA_DECISION_SIGNAL_GROUP_IDS', '[', ']');
+      if (body === null) return 'the CHINA_DECISION_SIGNAL_GROUP_IDS array literal is missing or was renamed';
+      const groupIds = [...body.matchAll(/'([^']+)'/g)].map(([, groupId]) => groupId);
+      if (groupIds.length !== GROUP_IDS.length || groupIds.some((groupId, index) => groupId !== GROUP_IDS[index])) {
+        return `CHINA_DECISION_SIGNAL_GROUP_IDS is ${JSON.stringify(groupIds)}, expected ${JSON.stringify(GROUP_IDS)}`;
+      }
+      return null;
+    },
+  }),
   Object.freeze({
     id: 'gateway-cache-tier',
     file: 'server/gateway.ts',
@@ -271,9 +292,12 @@ const PROBE_HEADERS = Object.freeze({
   'User-Agent': CHINA_DECISION_PARITY_USER_AGENT,
 });
 
+export { summarizeChinaDecisionGroups };
+
 export async function probeChinaDecisionParity(baseUrl, {
   fetchImpl = fetch,
   now = () => Date.now(),
+  requiredPopulatedGroups = [],
 } = {}) {
   const url = new URL(ROUTE, `${baseUrl.replace(/\/+$/, '')}/`);
   const startedAt = now();
@@ -317,9 +341,7 @@ export async function probeChinaDecisionParity(baseUrl, {
       error: 'invalid_contract',
     };
   }
-  const groupStates = Object.fromEntries(
-    snapshot.groups.map((candidate) => [candidate.id, candidate.state]),
-  );
+  const { groupStates, groupCounts } = chinaDecisionSignalGroupDiagnostics(snapshot);
 
   const bootstrapUrl = new URL(BOOTSTRAP_ROUTE, `${baseUrl.replace(/\/+$/, '')}/`);
   const bootstrapStartedAt = now();
@@ -372,7 +394,28 @@ export async function probeChinaDecisionParity(baseUrl, {
       error: 'stale_bootstrap_contract',
     };
   }
-  return {
+  const {
+    groupStates: bootstrapGroupStates,
+    groupCounts: bootstrapGroupCounts,
+  } = chinaDecisionSignalGroupDiagnostics(bootstrapSnapshot);
+  // The validator rejects state/item contradictions; retain that invariant here
+  // so a malformed payload can never satisfy --require-populated.
+  const populated = new Set(
+    snapshot.groups
+      .filter((candidate) => candidate.state !== 'unavailable'
+        && Array.isArray(candidate.items) && candidate.items.length > 0)
+      .map((candidate) => candidate.id),
+  );
+  const bootstrapPopulated = new Set(
+    bootstrapSnapshot.groups
+      .filter((candidate) => candidate.state !== 'unavailable'
+        && Array.isArray(candidate.items) && candidate.items.length > 0)
+      .map((candidate) => candidate.id),
+  );
+  const unpopulatedRequiredGroups = requiredPopulatedGroups.filter(
+    (groupId) => !populated.has(groupId) || !bootstrapPopulated.has(groupId),
+  );
+  const result = {
     ok: true,
     route: ROUTE,
     bootstrapRoute: BOOTSTRAP_ROUTE,
@@ -383,9 +426,17 @@ export async function probeChinaDecisionParity(baseUrl, {
     generatedAt: typeof snapshot?.generatedAt === 'string' ? snapshot.generatedAt : null,
     bootstrapGeneratedAt: bootstrapSnapshot.generatedAt,
     groupStates,
-    bootstrapGroupStates: Object.fromEntries(
-      bootstrapSnapshot.groups.map((candidate) => [candidate.id, candidate.state]),
-    ),
+    bootstrapGroupStates,
+    groupCounts,
+    bootstrapGroupCounts,
+  };
+  if (unpopulatedRequiredGroups.length === 0) return result;
+  return {
+    ...result,
+    ok: false,
+    error: 'required_groups_unpopulated',
+    requiredPopulatedGroups,
+    unpopulatedRequiredGroups,
   };
 }
 
@@ -399,7 +450,12 @@ export async function probeChinaDecisionParity(baseUrl, {
  * reason.
  *
  * @param {string[]} args argv without the node binary and script path
- * @returns {{ url: string | null, requireLive: boolean, error: string | null }}
+ * @returns {{
+ *   url: string | null,
+ *   requireLive: boolean,
+ *   requiredPopulatedGroups: string[],
+ *   error: string | null,
+ * }}
  */
 // Hosts that must never be probe targets. The probe reports HTTP status and
 // latency, so an operator-supplied URL is a (weak) oracle against whatever it
@@ -447,7 +503,13 @@ export function validateProbeBaseUrl(value) {
 export function parseChinaParityAuditArgs(args) {
   let url = null;
   let requireLive = false;
-  const fail = (error) => ({ url: null, requireLive: false, error });
+  const requiredPopulatedGroups = new Set();
+  const fail = (error) => ({
+    url: null,
+    requireLive: false,
+    requiredPopulatedGroups: [],
+    error,
+  });
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -464,11 +526,39 @@ export function parseChinaParityAuditArgs(args) {
       requireLive = true;
       continue;
     }
+    if (arg === '--require-populated') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('--')) {
+        return fail('--require-populated requires a comma-separated group list');
+      }
+      const groupIds = value.split(',').map((candidate) => candidate.trim()).filter(Boolean);
+      const unknown = groupIds.filter((groupId) => !GROUP_IDS.includes(groupId));
+      if (groupIds.length === 0 || unknown.length > 0) {
+        return fail(
+          unknown.length > 0
+            ? `--require-populated contains unknown group(s): ${unknown.join(', ')}`
+            : '--require-populated requires at least one group',
+        );
+      }
+      for (const groupId of groupIds) {
+        requiredPopulatedGroups.add(groupId);
+      }
+      i += 1;
+      continue;
+    }
     return fail(`unknown argument ${arg}`);
   }
 
   if (requireLive && url === null) return fail('--require-live requires --url <base-url>');
-  return { url, requireLive, error: null };
+  if (requiredPopulatedGroups.size > 0 && url === null) {
+    return fail('--require-populated requires --url <base-url>');
+  }
+  return {
+    url,
+    requireLive,
+    requiredPopulatedGroups: [...requiredPopulatedGroups],
+    error: null,
+  };
 }
 
 /**
@@ -484,7 +574,12 @@ export function resolveChinaParityExitCode({ staticOk, live = null, requireLive 
 
 async function main() {
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-  const { url, requireLive, error } = parseChinaParityAuditArgs(process.argv.slice(2));
+  const {
+    url,
+    requireLive,
+    requiredPopulatedGroups,
+    error,
+  } = parseChinaParityAuditArgs(process.argv.slice(2));
   if (error !== null) {
     console.error(`audit-china-decision-parity: ${error}`);
     process.exitCode = 2;
@@ -495,7 +590,7 @@ async function main() {
   let live = null;
   if (url !== null) {
     try {
-      live = await probeChinaDecisionParity(url);
+      live = await probeChinaDecisionParity(url, { requiredPopulatedGroups });
     } catch (probeError) {
       // A thrown fetch (DNS, TLS, timeout, non-JSON body) is a failed probe,
       // not a crash: report it in the same sanitized shape the probe uses so

--- a/scripts/seed-china-decision-signals.mjs
+++ b/scripts/seed-china-decision-signals.mjs
@@ -46,7 +46,11 @@ export function validateChinaDecisionSignalSnapshot(value) {
       candidate?.id === CHINA_DECISION_SIGNAL_GROUP_IDS[index]
       && ['available', 'partial', 'stale', 'unavailable'].includes(candidate?.state)
       && Array.isArray(candidate?.items)
-      && candidate.items.length <= 4
+      // An unavailable source cannot expose an item. Every other state asserts
+      // that at least one bounded public item is available.
+      && (candidate.state === 'unavailable'
+        ? candidate.items.length === 0
+        : candidate.items.length >= 1 && candidate.items.length <= 4)
       && candidate.items.every((item) => (
         typeof item?.id === 'string'
         && typeof item?.lineageId === 'string'
@@ -88,6 +92,29 @@ export function declareChinaDecisionSignalRecords(snapshot) {
   return Array.isArray(snapshot?.groups)
     ? snapshot.groups.filter((group) => group?.state !== 'unavailable').length
     : 0;
+}
+
+export function summarizeChinaDecisionGroups(groups) {
+  const candidates = Array.isArray(groups) ? groups : [];
+  return {
+    populated: candidates.filter((group) => Array.isArray(group?.items) && group.items.length > 0).length,
+    partial: candidates.filter((group) => group?.state === 'partial').length,
+    stale: candidates.filter((group) => group?.state === 'stale').length,
+    unavailable: candidates.filter((group) => group?.state === 'unavailable').length,
+  };
+}
+
+export function chinaDecisionSignalGroupDiagnostics(snapshot) {
+  const groups = Array.isArray(snapshot?.groups) ? snapshot.groups : [];
+  return {
+    groupStates: Object.fromEntries(
+      CHINA_DECISION_SIGNAL_GROUP_IDS.map((groupId) => [
+        groupId,
+        groups.find((group) => group?.id === groupId)?.state ?? 'unavailable',
+      ]),
+    ),
+    groupCounts: summarizeChinaDecisionGroups(groups),
+  };
 }
 
 export async function publishChinaDecisionSignalAlerts(
@@ -152,8 +179,33 @@ export async function deliverChinaDecisionSignalAlertOutbox(
   return result;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+/**
+ * Diagnostics are returned from afterPublish so runSeed can write them with
+ * seed-meta before alert delivery. Delivery remains durable and visible: an
+ * outbox error rejects afterFreshness rather than silently swallowing it.
+ */
+export function createChinaDecisionSignalSeedHooks({
+  prepareAlerts = prepareChinaDecisionSignalAlertEvents,
+  deliverAlerts = deliverChinaDecisionSignalAlertOutbox,
+  diagnosticsFor = chinaDecisionSignalGroupDiagnostics,
+  log = console.log,
+} = {}) {
   let preparedAlertEvents = [];
+  return {
+    beforePublish: async (snapshot) => {
+      preparedAlertEvents = await prepareAlerts(snapshot);
+    },
+    afterPublish: async (snapshot) => {
+      const diagnostics = diagnosticsFor(snapshot);
+      log(`[china-decision-signals] group diagnostics ${JSON.stringify(diagnostics)}`);
+      return { freshnessMetaPatch: diagnostics };
+    },
+    afterFreshness: async () => deliverAlerts(preparedAlertEvents),
+  };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const hooks = createChinaDecisionSignalSeedHooks();
   runSeed(
     'intelligence',
     'china-decision-signals',
@@ -172,15 +224,7 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
       // Prepare against the previous canonical value without sending anything.
       // runSeed publishes the validated snapshot between this callback and
       // afterPublish, preventing phantom alerts for a state that never landed.
-      beforePublish: async (snapshot) => {
-        preparedAlertEvents = await prepareChinaDecisionSignalAlertEvents(snapshot);
-      },
-      // Delivery is post-commit and durable: failures remain in a bounded
-      // outbox and are retried on the next seed even though canonical state has
-      // advanced.
-      afterPublish: async () => {
-        await deliverChinaDecisionSignalAlertOutbox(preparedAlertEvents);
-      },
+      ...hooks,
     },
   ).catch((error) => {
     console.error(`FATAL: ${error instanceof Error ? error.message : String(error)}`);

--- a/shared/china-decision-signals.ts
+++ b/shared/china-decision-signals.ts
@@ -25,6 +25,13 @@ export type ChinaDecisionSignalState =
   | 'stale'
   | 'unavailable';
 
+export type ChinaDecisionSignalUnavailableCause =
+  | 'healthy_quiet_window'
+  | 'insufficient_data'
+  | 'provenance_rejected'
+  | 'upstream_unavailable'
+  | 'unknown';
+
 export interface ChinaDecisionSignalItem {
   id: string;
   lineageId: string;
@@ -229,11 +236,38 @@ function group(
   id: ChinaDecisionSignalGroupId,
   candidates: Array<ChinaDecisionSignalItem | null>,
   upstreamState: string | null,
-  metadata: Record<string, unknown> = {},
+  {
+    metadata = {},
+    unavailableDiagnostic,
+  }: {
+    metadata?: Record<string, unknown>;
+    unavailableDiagnostic?: {
+      cause: Exclude<ChinaDecisionSignalUnavailableCause, 'provenance_rejected' | 'unknown'>;
+      reason: string;
+    };
+  } = {},
 ): ChinaDecisionSignalGroup {
   const items = candidates.filter((item): item is ChinaDecisionSignalItem => item !== null);
   const rejected = candidates.length - items.length;
   const state = stateFor(items, upstreamState, rejected);
+  const upstreamUnavailable = ['unavailable', 'degraded'].includes(upstreamState ?? '');
+  const unavailable = state === 'unavailable'
+    ? unavailableDiagnostic
+      ?? (rejected > 0
+        ? {
+            cause: 'provenance_rejected' as const,
+            reason: `provenance_rejected: ${rejected} candidate signal${rejected === 1 ? '' : 's'} failed the launch/provenance boundary.`,
+          }
+        : upstreamUnavailable
+          ? {
+              cause: 'upstream_unavailable' as const,
+              reason: 'upstream_unavailable: The upstream snapshot explicitly reports unavailable or degraded state.',
+            }
+        : {
+            cause: 'unknown' as const,
+            reason: 'No launched, provenance-valid signal is currently available.',
+          })
+    : null;
   const omittedItemCount = Math.max(
     0,
     items.length - CHINA_DECISION_SIGNAL_MAX_ITEMS_PER_GROUP,
@@ -242,13 +276,17 @@ function group(
     id,
     state,
     reason: state === 'unavailable'
-      ? 'No launched, provenance-valid signal is currently available.'
+      ? unavailable?.reason ?? 'No launched, provenance-valid signal is currently available.'
       : rejected > 0
         ? `${rejected} signal${rejected === 1 ? '' : 's'} failed the launch/provenance boundary.`
         : null,
     items: items.slice(0, CHINA_DECISION_SIGNAL_MAX_ITEMS_PER_GROUP),
     metadata: {
       ...metadata,
+      ...(unavailable ? { unavailableCause: unavailable.cause } : {}),
+      ...(rejected > 0 && (state === 'partial' || unavailable?.cause === 'provenance_rejected')
+        ? { rejectedItemCount: rejected }
+        : {}),
       totalValidItems: items.length,
       omittedItemCount,
     },
@@ -286,6 +324,12 @@ function compactGroupMetadata(
     ...(serializationOmittedItemCount > 0
       ? { serializationOmittedItemCount }
       : {}),
+    ...(typeof group.metadata.unavailableCause === 'string'
+      ? { unavailableCause: group.metadata.unavailableCause }
+      : {}),
+    ...(Array.isArray(group.metadata.missingInputFamilies)
+      ? { missingInputFamilies: group.metadata.missingInputFamilies }
+      : {}),
     metadataOmittedForSerialization: true,
   };
 }
@@ -296,6 +340,8 @@ function isCompactGroupMetadata(metadata: Record<string, unknown>): boolean {
       'totalValidItems',
       'omittedItemCount',
       'serializationOmittedItemCount',
+      'unavailableCause',
+      'missingInputFamilies',
       'metadataOmittedForSerialization',
     ].includes(key));
 }
@@ -420,6 +466,34 @@ function summarizeValues(value: unknown): string {
     .slice(0, 4)
     .map(([key, candidate]) => `${key}: ${String(candidate)}`);
   return parts.length > 0 ? parts.join(' · ') : 'Reviewed activity record';
+}
+
+function boundedNowcastMissingInputs(nowcast: UnknownRecord | null): UnknownRecord[] {
+  const missingInputs: UnknownRecord[] = [];
+  const candidates = Array.isArray(nowcast?.missingInputs) ? nowcast.missingInputs : [];
+  for (const value of candidates) {
+    const candidate = record(value);
+    if (candidate === null) continue;
+    const family = text(candidate.family)?.slice(0, 80);
+    if (!family) continue;
+    missingInputs.push({
+      family,
+      seriesId: text(candidate.seriesId)?.slice(0, 120) ?? 'unknown',
+      reason: text(candidate.reason)?.slice(0, 120) ?? 'unspecified',
+    });
+    if (missingInputs.length === 16) break;
+  }
+  return missingInputs;
+}
+
+function missingInputReason(missingInputs: UnknownRecord[]): string {
+  if (missingInputs.length === 0) {
+    return 'insufficient_data: Deterministic input requirements are not currently met.';
+  }
+  const details = missingInputs
+    .map((candidate) => `${String(candidate.family)} (${String(candidate.reason)})`)
+    .join(', ');
+  return `insufficient_data: Missing or stale input families: ${details}.`;
 }
 
 function buildDerivedNowcastProvenance(
@@ -598,9 +672,11 @@ export function composeChinaDecisionSignals(
     })),
     text(crossStrait?.status),
     {
-      baselineSemantics: text(record(crossStrait?.baselines)?.semantics),
-      baselineBands: distillBaselineBands(crossStrait),
-      coverage: record(crossStrait?.coverage),
+      metadata: {
+        baselineSemantics: text(record(crossStrait?.baselines)?.semantics),
+        baselineBands: distillBaselineBands(crossStrait),
+        coverage: record(crossStrait?.coverage),
+      },
     },
   );
 
@@ -627,6 +703,20 @@ export function composeChinaDecisionSignals(
       });
     }),
     text(corporate?.status),
+    {
+      unavailableDiagnostic: corporate === null
+        || ['unavailable', 'degraded'].includes(text(corporate.status) ?? '')
+        ? {
+            cause: 'upstream_unavailable',
+            reason: 'upstream_unavailable: The corporate-disclosure upstream snapshot is unavailable or degraded.',
+          }
+        : text(corporate.status) === 'healthy' && corporateEvents.length === 0
+          ? {
+              cause: 'healthy_quiet_window',
+              reason: 'healthy_quiet_window: Healthy exchange queries contained no qualifying disclosure events.',
+            }
+          : undefined,
+    },
   );
 
   const corridorGroup = group(
@@ -649,6 +739,10 @@ export function composeChinaDecisionSignals(
   const nowcastProvenance = nowcast === null
     ? null
     : buildDerivedNowcastProvenance(nowcast, input.generatedAt);
+  const nowcastMissingInputs = boundedNowcastMissingInputs(nowcast);
+  const nowcastMissingInputFamilies = [
+    ...new Set(nowcastMissingInputs.map((candidate) => String(candidate.family))),
+  ];
   const nowcastGroup = group(
     'activity-nowcast',
     [itemFromProvenance({
@@ -667,10 +761,26 @@ export function composeChinaDecisionSignals(
     })],
     text(record(nowcast?.confidence)?.level),
     {
-      methodVersion: text(nowcast?.methodVersion),
-      comparisonWindow: record(nowcast?.comparisonWindow),
-      deterministic: record(nowcast?.audit)?.deterministic === true,
-      llmNumericComputation: record(nowcast?.audit)?.llmNumericComputation === true,
+      metadata: {
+        methodVersion: text(nowcast?.methodVersion),
+        comparisonWindow: record(nowcast?.comparisonWindow),
+        confidence: record(nowcast?.confidence),
+        missingInputs: nowcastMissingInputs,
+        missingInputFamilies: nowcastMissingInputFamilies,
+        deterministic: record(nowcast?.audit)?.deterministic === true,
+        llmNumericComputation: record(nowcast?.audit)?.llmNumericComputation === true,
+      },
+      unavailableDiagnostic: nowcast === null
+        ? {
+            cause: 'upstream_unavailable',
+            reason: 'upstream_unavailable: The activity-nowcast upstream snapshot is unavailable.',
+          }
+        : text(nowcast.state) === 'insufficient_data'
+          ? {
+              cause: 'insufficient_data',
+              reason: missingInputReason(nowcastMissingInputs),
+            }
+          : undefined,
     },
   );
 

--- a/shared/china-decision-signals.ts
+++ b/shared/china-decision-signals.ts
@@ -312,6 +312,11 @@ function compactGroupMetadata(
     group.metadata.serializationOmittedItemCount,
     0,
   );
+  const missingInputs = boundedNowcastMissingInputs(
+    Array.isArray(group.metadata.missingInputs)
+      ? { missingInputs: group.metadata.missingInputs }
+      : null,
+  );
   return {
     totalValidItems: nonNegativeInteger(
       group.metadata.totalValidItems,
@@ -330,6 +335,9 @@ function compactGroupMetadata(
     ...(Array.isArray(group.metadata.missingInputFamilies)
       ? { missingInputFamilies: group.metadata.missingInputFamilies }
       : {}),
+    ...(Array.isArray(group.metadata.missingInputs)
+      ? { missingInputs }
+      : {}),
     metadataOmittedForSerialization: true,
   };
 }
@@ -342,6 +350,7 @@ function isCompactGroupMetadata(metadata: Record<string, unknown>): boolean {
       'serializationOmittedItemCount',
       'unavailableCause',
       'missingInputFamilies',
+      'missingInputs',
       'metadataOmittedForSerialization',
     ].includes(key));
 }
@@ -635,6 +644,14 @@ export function composeChinaDecisionSignals(
       },
     })),
     bool(macro?.unavailable) ? 'unavailable' : null,
+    {
+      unavailableDiagnostic: input.macro === null
+        ? {
+            cause: 'upstream_unavailable',
+            reason: 'upstream_unavailable: The macro upstream snapshot is unavailable.',
+          }
+        : undefined,
+    },
   );
 
   const policyGroup = group(
@@ -656,6 +673,14 @@ export function composeChinaDecisionSignals(
     Object.values(record(policy?.agencies) ?? {}).some((agency) => record(agency)?.status !== 'ok')
       ? 'degraded'
       : null,
+    {
+      unavailableDiagnostic: input.policy === null
+        ? {
+            cause: 'upstream_unavailable',
+            reason: 'upstream_unavailable: The policy-enforcement upstream snapshot is unavailable.',
+          }
+        : undefined,
+    },
   );
 
   const crossStraitGroup = group(
@@ -677,6 +702,12 @@ export function composeChinaDecisionSignals(
         baselineBands: distillBaselineBands(crossStrait),
         coverage: record(crossStrait?.coverage),
       },
+      unavailableDiagnostic: input.crossStrait === null
+        ? {
+            cause: 'upstream_unavailable',
+            reason: 'upstream_unavailable: The cross-Strait upstream snapshot is unavailable.',
+          }
+        : undefined,
     },
   );
 

--- a/tests/china-decision-access-contract.test.mts
+++ b/tests/china-decision-access-contract.test.mts
@@ -35,7 +35,14 @@ afterEach(() => {
   }
 });
 
-function installSeedHealthPipelineMock(chinaMeta: { fetchedAt: number; recordCount: number }) {
+type ChinaMeta = {
+  fetchedAt: number;
+  recordCount: number;
+  groupStates?: Record<string, string>;
+  groupCounts?: Record<string, number>;
+};
+
+function installSeedHealthPipelineMock(chinaMeta: ChinaMeta) {
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
   process.env.WORLDMONITOR_VALID_KEYS = OPERATOR_KEY;
@@ -78,7 +85,7 @@ function installSeedHealthPipelineMock(chinaMeta: { fetchedAt: number; recordCou
   };
 }
 
-function classifyMainHealth(chinaMeta: { fetchedAt: number; recordCount: number }) {
+function classifyMainHealth(chinaMeta: ChinaMeta) {
   return healthTesting.classifyKey(
     'chinaDecisionSignals',
     CHINA_DATA_KEY,
@@ -93,7 +100,7 @@ function classifyMainHealth(chinaMeta: { fetchedAt: number; recordCount: number 
   );
 }
 
-async function readSeedHealth(chinaMeta: { fetchedAt: number; recordCount: number }) {
+async function readSeedHealth(chinaMeta: ChinaMeta) {
   installSeedHealthPipelineMock(chinaMeta);
   const response = await seedHealthHandler(new Request(
     'https://api.worldmonitor.app/api/seed-health',
@@ -193,5 +200,37 @@ describe('China decision-signal access tiers (#5580)', () => {
       assert.equal(seedEntry.recordCount, expectation.recordCount);
       assert.equal(seedEntry.minRecordCount, 6);
     }
+  });
+
+  it('projects bounded per-group diagnostics only through operator seed health', async () => {
+    const groupStates = {
+      macro: 'available',
+      'policy-enforcement': 'partial',
+      'cross-strait-activity': 'stale',
+      'corporate-disclosures': 'unavailable',
+      'corridor-conditions': 'available',
+      'activity-nowcast': 'unavailable',
+    };
+    const groupCounts = {
+      populated: 4,
+      partial: 1,
+      stale: 1,
+      unavailable: 2,
+    };
+    const { body } = await readSeedHealth({
+      fetchedAt: Date.now() - 60_000,
+      recordCount: 4,
+      groupStates,
+      groupCounts,
+    });
+
+    assert.deepEqual(
+      body.seeds['intelligence:china-decision-signals'].groupStates,
+      groupStates,
+    );
+    assert.deepEqual(
+      body.seeds['intelligence:china-decision-signals'].groupCounts,
+      groupCounts,
+    );
   });
 });

--- a/tests/china-decision-access-contract.test.mts
+++ b/tests/china-decision-access-contract.test.mts
@@ -233,4 +233,72 @@ describe('China decision-signal access tiers (#5580)', () => {
       groupCounts,
     );
   });
+
+  it('omits both per-group diagnostics when either bounded projection is malformed', async () => {
+    const validGroupStates = {
+      macro: 'available',
+      'policy-enforcement': 'partial',
+      'cross-strait-activity': 'stale',
+      'corporate-disclosures': 'unavailable',
+      'corridor-conditions': 'available',
+      'activity-nowcast': 'unavailable',
+    };
+    const validGroupCounts = {
+      populated: 4,
+      partial: 1,
+      stale: 1,
+      unavailable: 2,
+    };
+    const malformedDiagnostics = [
+      {
+        name: 'invalid state',
+        groupStates: { ...validGroupStates, macro: 'healthy' },
+        groupCounts: validGroupCounts,
+      },
+      {
+        name: 'missing canonical group',
+        groupStates: {
+          macro: 'available',
+          'policy-enforcement': 'partial',
+          'cross-strait-activity': 'stale',
+          'corporate-disclosures': 'unavailable',
+          'corridor-conditions': 'available',
+        },
+        groupCounts: validGroupCounts,
+      },
+      {
+        name: 'fractional count',
+        groupStates: validGroupStates,
+        groupCounts: { ...validGroupCounts, populated: 1.5 },
+      },
+      {
+        name: 'negative count',
+        groupStates: validGroupStates,
+        groupCounts: { ...validGroupCounts, partial: -1 },
+      },
+      {
+        name: 'count above group total',
+        groupStates: validGroupStates,
+        groupCounts: { ...validGroupCounts, unavailable: 7 },
+      },
+    ];
+
+    for (const malformed of malformedDiagnostics) {
+      const { response, body } = await readSeedHealth({
+        fetchedAt: Date.now() - 60_000,
+        recordCount: 4,
+        groupStates: malformed.groupStates,
+        groupCounts: malformed.groupCounts,
+      });
+      const seedEntry = body.seeds['intelligence:china-decision-signals'];
+
+      assert.equal(response.status, 200, malformed.name);
+      assert.equal(body.overall, 'warning', malformed.name);
+      assert.equal(seedEntry.status, 'coverage_partial', malformed.name);
+      assert.equal(seedEntry.recordCount, 4, malformed.name);
+      assert.equal(seedEntry.minRecordCount, 6, malformed.name);
+      assert.equal(Object.hasOwn(seedEntry, 'groupStates'), false, malformed.name);
+      assert.equal(Object.hasOwn(seedEntry, 'groupCounts'), false, malformed.name);
+    }
+  });
 });

--- a/tests/china-decision-alerts.test.mjs
+++ b/tests/china-decision-alerts.test.mjs
@@ -8,6 +8,8 @@ import {
 import {
   CHINA_DECISION_SIGNALS_KEY,
   CHINA_DECISION_SIGNALS_ROUTE,
+  chinaDecisionSignalGroupDiagnostics,
+  createChinaDecisionSignalSeedHooks,
   deliverChinaDecisionSignalAlertOutbox,
   declareChinaDecisionSignalRecords,
   fetchChinaDecisionSignals,
@@ -62,6 +64,18 @@ function snapshot(overrides = {}) {
 }
 
 describe('China decision-signal alert policy (#5580)', () => {
+  it('rejects contradictory state/item combinations in the published snapshot', () => {
+    const unavailableWithItem = snapshot({
+      macro: { items: [item('macro-contradiction')] },
+    });
+    const availableWithoutItem = snapshot({
+      macro: { state: 'available' },
+    });
+
+    assert.equal(validateChinaDecisionSignalSnapshot(unavailableWithItem), false);
+    assert.equal(validateChinaDecisionSignalSnapshot(availableWithoutItem), false);
+  });
+
   it('never fans out historical records on the first canonical snapshot', () => {
     const next = snapshot({
       'policy-enforcement': {
@@ -230,6 +244,55 @@ describe('China decision-signal alert policy (#5580)', () => {
       },
     });
     assert.deepEqual(failed, { events: [], enqueued: 0 });
+  });
+
+  it('builds bounded seed diagnostics without copying decision items', () => {
+    const value = snapshot({
+      macro: { state: 'available', items: [item('macro-item')] },
+      'policy-enforcement': { state: 'partial', items: [item('policy-item')] },
+      'cross-strait-activity': { state: 'stale', items: [item('cross-strait-item')] },
+    });
+    const diagnostics = chinaDecisionSignalGroupDiagnostics(value);
+
+    assert.deepEqual(diagnostics.groupCounts, {
+      populated: 3,
+      partial: 1,
+      stale: 1,
+      unavailable: 3,
+    });
+    assert.deepEqual(diagnostics.groupStates, {
+      macro: 'available',
+      'policy-enforcement': 'partial',
+      'cross-strait-activity': 'stale',
+      'corporate-disclosures': 'unavailable',
+      'corridor-conditions': 'unavailable',
+      'activity-nowcast': 'unavailable',
+    });
+    assert.doesNotMatch(JSON.stringify(diagnostics), /macro-item|policy-item|cross-strait-item/);
+  });
+
+  it('returns the diagnostics patch before a rejected durable alert delivery', async () => {
+    const writes = [];
+    const hooks = createChinaDecisionSignalSeedHooks({
+      prepareAlerts: async () => [{ eventType: 'china_policy_decision_signal' }],
+      diagnosticsFor: chinaDecisionSignalGroupDiagnostics,
+      log: () => {},
+      deliverAlerts: async () => {
+        throw new Error('outbox unavailable');
+      },
+    });
+    const value = snapshot({
+      macro: { state: 'available', items: [item('macro-published')] },
+    });
+
+    await hooks.beforePublish(value);
+    const afterPublishResult = await hooks.afterPublish(value);
+    // runSeed writes this patch before calling afterFreshness. Model that
+    // boundary explicitly so delivery rejection cannot regress seed-meta order.
+    writes.push(afterPublishResult.freshnessMetaPatch);
+    await assert.rejects(hooks.afterFreshness(value), /outbox unavailable/);
+
+    assert.deepEqual(writes, [chinaDecisionSignalGroupDiagnostics(value)]);
   });
 
   it('continues publishing after one alert publisher rejects', async () => {

--- a/tests/china-decision-parity-audit.test.mjs
+++ b/tests/china-decision-parity-audit.test.mjs
@@ -19,6 +19,7 @@ import {
   parseChinaParityAuditArgs,
   probeChinaDecisionParity,
   resolveChinaParityExitCode,
+  summarizeChinaDecisionGroups,
 } from '../scripts/audit-china-decision-parity.mjs';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
@@ -44,6 +45,7 @@ describe('China decision-signal static and staging audit (#5580)', () => {
       CHINA_DECISION_SIGNAL_GROUP_MANIFEST,
     );
     assert.deepEqual(result.structuralCheckIds, [
+      'edge-seed-health-group-ids',
       'gateway-cache-tier',
       'gateway-public-no-auth',
       'access-tier-composition',
@@ -124,8 +126,137 @@ describe('China decision-signal static and staging audit (#5580)', () => {
         'corridor-conditions': 'unavailable',
         'activity-nowcast': 'unavailable',
       },
+      groupCounts: {
+        populated: 0,
+        partial: 0,
+        stale: 0,
+        unavailable: 6,
+      },
+      bootstrapGroupCounts: {
+        populated: 0,
+        partial: 0,
+        stale: 0,
+        unavailable: 6,
+      },
     });
     assert.doesNotMatch(JSON.stringify(result), /apiKey|private-document|must-not-leak/);
+  });
+
+  it('reports population counts and can require named groups without changing ordinary parity', async () => {
+    assert.deepEqual(summarizeChinaDecisionGroups([
+      { state: 'available', items: [{}] },
+      { state: 'partial', items: [{}] },
+      { state: 'stale', items: [{}] },
+      { state: 'unavailable', items: [] },
+    ]), {
+      populated: 3,
+      partial: 1,
+      stale: 1,
+      unavailable: 1,
+    });
+
+    const groups = CHINA_DECISION_PARITY_MANIFEST.map(({ groupId }) => ({
+      id: groupId,
+      state: 'unavailable',
+      reason: 'No reviewed source observation is available.',
+      items: [],
+      metadata: {},
+    }));
+    const canonical = {
+      schemaVersion: 1,
+      generatedAt: '2026-07-26T12:00:00Z',
+      groups,
+      access: {
+        anonymous: 'bounded_public_summary',
+        pro: 'same_provenance_via_mcp',
+        operator: 'source_health_only',
+      },
+    };
+    const result = await probeChinaDecisionParity('https://staging.example', {
+      requiredPopulatedGroups: ['macro', 'corporate-disclosures'],
+      now: () => Date.parse('2026-07-26T12:00:00Z'),
+      fetchImpl: async (url) => ({
+        ok: true,
+        status: 200,
+        json: async () => String(url).includes('/api/bootstrap?')
+          ? { data: { chinaDecisionSignals: canonical } }
+          : { payloadJson: JSON.stringify(canonical) },
+      }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'required_groups_unpopulated');
+    assert.deepEqual(result.requiredPopulatedGroups, ['macro', 'corporate-disclosures']);
+    assert.deepEqual(result.unpopulatedRequiredGroups, ['macro', 'corporate-disclosures']);
+    assert.deepEqual(result.groupCounts, {
+      populated: 0,
+      partial: 0,
+      stale: 0,
+      unavailable: 6,
+    });
+  });
+
+  it('requires requested groups to be populated on both RPC and bootstrap surfaces', async () => {
+    const canonical = canonicalAccessSnapshot();
+    canonical.generatedAt = '2026-07-26T12:00:00Z';
+    const populated = structuredClone(canonical);
+    const item = {
+      id: 'macro-signal',
+      lineageId: 'macro-signal',
+      publisherType: 'government_official',
+      stale: false,
+      provenance: {
+        contractVersion: 'decision-signal-provenance/v1',
+        signalId: 'macro-signal',
+      },
+    };
+    populated.groups[0] = { ...populated.groups[0], state: 'available', items: [item] };
+    const probe = async (rpcSnapshot, bootstrapSnapshot) => probeChinaDecisionParity('https://staging.example', {
+      requiredPopulatedGroups: ['macro'],
+      now: () => Date.parse('2026-07-26T12:00:00Z'),
+      fetchImpl: async (url) => ({
+        ok: true,
+        status: 200,
+        json: async () => String(url).includes('/api/bootstrap?')
+          ? { data: { chinaDecisionSignals: bootstrapSnapshot } }
+          : { payloadJson: JSON.stringify(rpcSnapshot) },
+      }),
+    });
+
+    assert.equal((await probe(populated, populated)).ok, true);
+    const onlyRpc = await probe(populated, canonical);
+    assert.equal(onlyRpc.error, 'required_groups_unpopulated');
+    assert.deepEqual(onlyRpc.unpopulatedRequiredGroups, ['macro']);
+  });
+
+  it('rejects contradictory unavailable groups from either public surface', async () => {
+    const canonical = canonicalAccessSnapshot();
+    const contradictory = structuredClone(canonical);
+    contradictory.groups[0] = {
+      ...contradictory.groups[0],
+      items: [{
+        id: 'macro-contradiction',
+        lineageId: 'macro-contradiction',
+        publisherType: 'government_official',
+        stale: false,
+        provenance: {
+          contractVersion: 'decision-signal-provenance/v1',
+          signalId: 'macro-contradiction',
+        },
+      }],
+    };
+    const probe = async (rpcSnapshot, bootstrapSnapshot) => probeChinaDecisionParity('https://staging.example', {
+      fetchImpl: async (url) => ({
+        ok: true,
+        status: 200,
+        json: async () => String(url).includes('/api/bootstrap?')
+          ? { data: { chinaDecisionSignals: bootstrapSnapshot } }
+          : { payloadJson: JSON.stringify(rpcSnapshot) },
+      }),
+    });
+
+    assert.equal((await probe(contradictory, canonical)).error, 'invalid_contract');
+    assert.equal((await probe(canonical, contradictory)).error, 'invalid_bootstrap_contract');
   });
 
   it('fails closed when staging returns malformed group states', async () => {
@@ -182,6 +313,15 @@ describe('China decision-signal static and staging audit (#5580)', () => {
 // ordinary regression tests; with it they are the standing proof that presence
 // of a token is not evidence of wiring (#5643).
 const STRUCTURAL_MUTATIONS = [
+  {
+    checkId: 'edge-seed-health-group-ids',
+    name: 'the Edge-local group mirror has the right tokens in the wrong order',
+    substringStillPresent: "'macro'",
+    mutate: (source) => source.replace(
+      "  'macro',\n  'policy-enforcement',",
+      "  'policy-enforcement',\n  'macro',",
+    ),
+  },
   {
     checkId: 'gateway-cache-tier',
     name: 'the cache-tier entry is commented out',
@@ -352,14 +492,35 @@ describe('China decision-signal audit CLI (#5643)', () => {
     assert.deepEqual(parseChinaParityAuditArgs(['--url', 'https://staging.example']), {
       url: 'https://staging.example',
       requireLive: false,
+      requiredPopulatedGroups: [],
       error: null,
     });
     assert.deepEqual(parseChinaParityAuditArgs(['--require-live', '--url', 'https://staging.example']), {
       url: 'https://staging.example',
       requireLive: true,
+      requiredPopulatedGroups: [],
       error: null,
     });
-    assert.deepEqual(parseChinaParityAuditArgs([]), { url: null, requireLive: false, error: null });
+    assert.deepEqual(
+      parseChinaParityAuditArgs([
+        '--url',
+        'https://staging.example',
+        '--require-populated',
+        'macro,corporate-disclosures',
+      ]),
+      {
+        url: 'https://staging.example',
+        requireLive: false,
+        requiredPopulatedGroups: ['macro', 'corporate-disclosures'],
+        error: null,
+      },
+    );
+    assert.deepEqual(parseChinaParityAuditArgs([]), {
+      url: null,
+      requireLive: false,
+      requiredPopulatedGroups: [],
+      error: null,
+    });
   });
 
   it('refuses probe targets that are not public https endpoints', () => {
@@ -392,11 +553,20 @@ describe('China decision-signal audit CLI (#5643)', () => {
   it('refuses argument shapes that would silently skip the live probe', () => {
     // Each of these would have run the static half only and exited 0 before
     // --require-live existed, reporting a staging audit that never happened.
-    for (const args of [['--url'], ['--url', '--require-live'], ['--require-live'], ['--require_live', '--url', 'https://x']]) {
+    for (const args of [
+      ['--url'],
+      ['--url', '--require-live'],
+      ['--require-live'],
+      ['--require-populated', 'macro'],
+      ['--url', 'https://x', '--require-populated'],
+      ['--url', 'https://x', '--require-populated', 'not-a-group'],
+      ['--require_live', '--url', 'https://x'],
+    ]) {
       const parsed = parseChinaParityAuditArgs(args);
       assert.ok(parsed.error, `expected an error for ${JSON.stringify(args)}`);
       assert.equal(parsed.url, null);
       assert.equal(parsed.requireLive, false);
+      assert.deepEqual(parsed.requiredPopulatedGroups, []);
     }
   });
 

--- a/tests/china-decision-signals.test.mts
+++ b/tests/china-decision-signals.test.mts
@@ -269,6 +269,7 @@ describe('China decision-signal final composition (#5580)', () => {
     const policy = snapshot.groups.find((candidate) => candidate.id === 'policy-enforcement');
     assert.equal(policy?.state, 'partial');
     assert.equal(policy?.items.length, 1);
+    assert.equal(policy?.metadata.rejectedItemCount, 1);
     assert.match(policy?.reason ?? '', /failed the launch\/provenance boundary/);
     assert.equal(
       snapshot.groups.filter((candidate) => candidate.id !== 'policy-enforcement')
@@ -276,6 +277,175 @@ describe('China decision-signal final composition (#5580)', () => {
       true,
       'an outage in one domain does not manufacture data in another',
     );
+  });
+
+  it('distinguishes quiet disclosures, rejected provenance, upstream loss, and insufficient nowcast inputs', () => {
+    const generatedAt = '2026-07-30T15:30:00Z';
+    const corporateGroup = (corporate: unknown) => composeChinaDecisionSignals({
+      generatedAt,
+      corporate,
+    }).groups.find((candidate) => candidate.id === 'corporate-disclosures');
+
+    const quiet = corporateGroup({
+      status: 'healthy',
+      coverageThrough: '2026-07-30',
+      sources: [
+        { id: 'sse', launchStatus: 'launched', transportStatus: 'fresh', contentStatus: 'current' },
+        { id: 'szse', launchStatus: 'launched', transportStatus: 'fresh', contentStatus: 'current' },
+      ],
+      events: [],
+    });
+    assert.equal(quiet?.state, 'unavailable');
+    assert.equal(quiet?.metadata.unavailableCause, 'healthy_quiet_window');
+    assert.match(quiet?.reason ?? '', /^healthy_quiet_window:/);
+
+    const rejected = corporateGroup({
+      status: 'healthy',
+      events: [{
+        announcementId: 'sse-invalid-provenance',
+        exchange: 'SSE',
+        status: 'current',
+        titleOriginal: 'Invalid provenance fixture',
+        provenance: { signalId: 'missing-contract' },
+      }],
+    });
+    assert.equal(rejected?.state, 'unavailable');
+    assert.equal(rejected?.metadata.unavailableCause, 'provenance_rejected');
+    assert.equal(rejected?.metadata.rejectedItemCount, 1);
+    assert.match(rejected?.reason ?? '', /^provenance_rejected:/);
+
+    const upstream = corporateGroup(null);
+    assert.equal(upstream?.state, 'unavailable');
+    assert.equal(upstream?.metadata.unavailableCause, 'upstream_unavailable');
+    assert.equal(Object.hasOwn(upstream?.metadata ?? {}, 'rejectedItemCount'), false);
+    assert.match(upstream?.reason ?? '', /^upstream_unavailable:/);
+
+    const nonCorporateUpstream = composeChinaDecisionSignals({
+      generatedAt,
+      macro: { unavailable: true, indicators: [] },
+    }).groups.find((candidate) => candidate.id === 'macro');
+    assert.equal(nonCorporateUpstream?.state, 'unavailable');
+    assert.equal(nonCorporateUpstream?.metadata.unavailableCause, 'upstream_unavailable');
+    assert.equal(Object.hasOwn(nonCorporateUpstream?.metadata ?? {}, 'rejectedItemCount'), false);
+    assert.match(nonCorporateUpstream?.reason ?? '', /^upstream_unavailable:/);
+
+    const indeterminate = composeChinaDecisionSignals({ generatedAt })
+      .groups.find((candidate) => candidate.id === 'macro');
+    assert.equal(indeterminate?.metadata.unavailableCause, 'unknown');
+
+    const nowcast = composeChinaDecisionSignals({
+      generatedAt,
+      nowcast: {
+        methodVersion: 'china-activity-nowcast/v1',
+        evaluatedAt: generatedAt,
+        comparisonWindow: { endsAt: generatedAt },
+        state: 'insufficient_data',
+        confidence: {
+          level: 'insufficient',
+          reason: 'Two eligible proxy families are required.',
+        },
+        missingInputs: [
+          {
+            family: 'maritime',
+            seriesId: 'portwatch_tanker_calls_trend',
+            reason: 'freshness_budget_exceeded',
+          },
+          {
+            family: 'aviation',
+            seriesId: 'aviation_hub_disruption_balance',
+            reason: 'marked_stale',
+          },
+        ],
+        contributions: [],
+        sensitivity: [],
+        limitations: [],
+        audit: { deterministic: true, llmNumericComputation: false },
+      },
+    }).groups.find((candidate) => candidate.id === 'activity-nowcast');
+
+    assert.equal(nowcast?.state, 'unavailable');
+    assert.equal(nowcast?.metadata.unavailableCause, 'insufficient_data');
+    assert.equal(Object.hasOwn(nowcast?.metadata ?? {}, 'rejectedItemCount'), false);
+    assert.deepEqual(nowcast?.metadata.missingInputFamilies, ['maritime', 'aviation']);
+    assert.deepEqual(nowcast?.metadata.missingInputs, [
+      {
+        family: 'maritime',
+        seriesId: 'portwatch_tanker_calls_trend',
+        reason: 'freshness_budget_exceeded',
+      },
+      {
+        family: 'aviation',
+        seriesId: 'aviation_hub_disruption_balance',
+        reason: 'marked_stale',
+      },
+    ]);
+    assert.match(nowcast?.reason ?? '', /^insufficient_data:/);
+    assert.match(nowcast?.reason ?? '', /maritime.*freshness_budget_exceeded/);
+    assert.match(nowcast?.reason ?? '', /aviation.*marked_stale/);
+  });
+
+  it('bounds nowcast missing inputs and preserves unavailable diagnostics through metadata compaction', () => {
+    const generatedAt = '2026-07-30T15:30:00Z';
+    const validMissingInputs = Array.from({ length: 18 }, (_, index) => ({
+      family: `family-${index}-${'f'.repeat(100)}`,
+      seriesId: `series-${index}-${'s'.repeat(140)}`,
+      reason: `reason-${index}-${'r'.repeat(140)}`,
+    }));
+    const bounded = composeChinaDecisionSignals({
+      generatedAt,
+      nowcast: {
+        state: 'insufficient_data',
+        confidence: { level: 'insufficient' },
+        missingInputs: [null, {}, { family: '' }, ...validMissingInputs],
+      },
+    }).groups.find((candidate) => candidate.id === 'activity-nowcast');
+    const boundedMissingInputs = bounded?.metadata.missingInputs as Array<Record<string, unknown>>;
+    assert.equal(boundedMissingInputs.length, 16);
+    assert.deepEqual(boundedMissingInputs[0], {
+      family: validMissingInputs[0].family.slice(0, 80),
+      seriesId: validMissingInputs[0].seriesId.slice(0, 120),
+      reason: validMissingInputs[0].reason.slice(0, 120),
+    });
+    assert.equal(boundedMissingInputs.at(-1)?.family, validMissingInputs[15].family.slice(0, 80));
+
+    const snapshot = composeChinaDecisionSignals({
+      generatedAt,
+      nowcast: {
+        methodVersion: 'china-activity-nowcast/v1',
+        evaluatedAt: generatedAt,
+        comparisonWindow: { endsAt: generatedAt },
+        state: 'insufficient_data',
+        confidence: {
+          level: 'insufficient',
+          coverage: 'coverage'.repeat(10_000),
+        },
+        missingInputs: [null, {}, { family: '' }, ...validMissingInputs],
+        contributions: [],
+        sensitivity: [],
+        limitations: [],
+        audit: { deterministic: true, llmNumericComputation: false },
+      },
+    });
+    const nowcast = snapshot.groups.find((candidate) => candidate.id === 'activity-nowcast');
+
+    assert.equal(nowcast?.state, 'unavailable');
+    assert.equal(nowcast?.metadata.metadataOmittedForSerialization, true);
+    assert.equal(nowcast?.metadata.unavailableCause, 'insufficient_data');
+    assert.deepEqual(
+      nowcast?.metadata.missingInputFamilies,
+      validMissingInputs.slice(0, 16).map((candidate) => candidate.family.slice(0, 80)),
+    );
+    assert.equal(new TextEncoder().encode(JSON.stringify(snapshot)).byteLength <= CHINA_DECISION_SIGNAL_MAX_SERIALIZED_BYTES, true);
+
+    const fallback = composeChinaDecisionSignals({
+      generatedAt,
+      nowcast: {
+        state: 'insufficient_data',
+        confidence: { level: 'insufficient' },
+        missingInputs: [null, {}, { family: '' }],
+      },
+    }).groups.find((candidate) => candidate.id === 'activity-nowcast');
+    assert.match(fallback?.reason ?? '', /^insufficient_data: Deterministic input requirements/);
   });
 
   it('launches the existing deterministic comparison family only at the final composition boundary', () => {

--- a/tests/china-decision-signals.test.mts
+++ b/tests/china-decision-signals.test.mts
@@ -329,9 +329,30 @@ describe('China decision-signal final composition (#5580)', () => {
     assert.equal(Object.hasOwn(nonCorporateUpstream?.metadata ?? {}, 'rejectedItemCount'), false);
     assert.match(nonCorporateUpstream?.reason ?? '', /^upstream_unavailable:/);
 
-    const indeterminate = composeChinaDecisionSignals({ generatedAt })
-      .groups.find((candidate) => candidate.id === 'macro');
-    assert.equal(indeterminate?.metadata.unavailableCause, 'unknown');
+    const explicitNull = composeChinaDecisionSignals({
+      generatedAt,
+      macro: null,
+      policy: null,
+      crossStrait: null,
+    });
+    for (const id of ['macro', 'policy-enforcement', 'cross-strait-activity']) {
+      const group = explicitNull.groups.find((candidate) => candidate.id === id);
+      assert.equal(group?.metadata.unavailableCause, 'upstream_unavailable');
+      assert.match(group?.reason ?? '', /^upstream_unavailable:/);
+    }
+
+    for (const malformed of [undefined, 'not-a-snapshot']) {
+      const indeterminate = composeChinaDecisionSignals({
+        generatedAt,
+        macro: malformed,
+        policy: malformed,
+        crossStrait: malformed,
+      });
+      for (const id of ['macro', 'policy-enforcement', 'cross-strait-activity']) {
+        const group = indeterminate.groups.find((candidate) => candidate.id === id);
+        assert.equal(group?.metadata.unavailableCause, 'unknown');
+      }
+    }
 
     const nowcast = composeChinaDecisionSignals({
       generatedAt,
@@ -434,6 +455,14 @@ describe('China decision-signal final composition (#5580)', () => {
     assert.deepEqual(
       nowcast?.metadata.missingInputFamilies,
       validMissingInputs.slice(0, 16).map((candidate) => candidate.family.slice(0, 80)),
+    );
+    assert.deepEqual(
+      nowcast?.metadata.missingInputs,
+      validMissingInputs.slice(0, 16).map((candidate) => ({
+        family: candidate.family.slice(0, 80),
+        seriesId: candidate.seriesId.slice(0, 120),
+        reason: candidate.reason.slice(0, 120),
+      })),
     );
     assert.equal(new TextEncoder().encode(JSON.stringify(snapshot)).byteLength <= CHINA_DECISION_SIGNAL_MAX_SERIALIZED_BYTES, true);
 


### PR DESCRIPTION
## Summary

Healthy China ingestion no longer looks identical to decision-pipeline failure. Corporate disclosure groups now report a truthful quiet-window cause, insufficient nowcasts retain their exact bounded missing-input families, and known provenance or upstream failures stay distinct; `unknown` is reserved for cases where no more specific cause is available.

Operators also get bounded per-group states and counts in seed logs and detailed seed health, while anonymous compact health remains unchanged. The parity audit keeps its ordinary behavior and adds an explicit `--require-populated` deployment assertion plus a structural guard against Edge group-manifest drift.

Fixes #5885.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: China decision-signal seed, parity audit, and operator health

## Validation

- `378` China tests across `52` suites pass after rebasing onto current `origin/main`.
- Focused decision-signal, parity, access-contract, and alert tests pass (`62/62`).
- `npm run typecheck` and `npm run typecheck:api` pass.
- Changed-file Biome lint and `git diff --check` pass.
- `node scripts/audit-china-decision-parity.mjs` reports all five structural checks healthy with no findings.
- The broader data-suite attempt reached an unrelated sandbox-only failure: `tests/auth-resource-timeout.test.mts` cannot bind `127.0.0.1` (`listen EPERM`). The same test reproduces alone before exercising this change.

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant (not applicable: no UI behavior changed)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (not applicable: no variant behavior changed)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation alignment

- The documentation now distinguishes source coverage, group population, and cross-surface parity.
- No proto, generated API documentation, fixture-backed examples, or new Redis keys are introduced.
- The existing decision-signal payload and `seed-meta:intelligence:china-decision-signals` writer/readers remain the contract under test.

## Post-Deploy Monitoring & Validation

- **Window:** observe the first two China decision-signal seed cycles (at least 30 minutes) and the next scheduled parity run.
- **Logs:** confirm `[china-decision-signals] group diagnostics` reports all six bounded states/counts; alert delivery failures must not suppress the freshness metadata.
- **Operator health:** verify the China decision-signal seed entry exposes `groupStates` and `groupCounts`.
- **Privacy:** verify anonymous compact `/api/health?compact=1` still omits China group diagnostics.
- **Parity:** run the ordinary audit, then the explicit populated assertion for the groups required by the deployment.
- **Failure signals:** invalid group contracts, missing diagnostics, unexpected `required_groups_unpopulated`, Edge manifest drift, or anonymous diagnostic leakage.
- **Rollback:** revert `9bb58e35363681e8cc6b03d2035c72d62236d8fd` and redeploy the previous application/seed revision.

## Screenshots

Not applicable; this changes operator diagnostics and audit behavior without a visual surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
