### PR TITLE
fix(cross-source-signals): unwrap seed envelopes and align extractors with their writers (#5870)

### DIFF
--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -15,6 +15,13 @@ const SOURCE_KEYS = [
   'thermal:escalation:v1',
   'intelligence:gpsjam:v2',
   'military:flights:v1',
+  // extractMilitaryFlightSurge already falls back to the stale key, but it was
+  // never fetched. The writer publishes the same payload to both
+  // (seed-military-flights.mjs:1327) with a 600s live TTL against this seeder's
+  // 15min cadence, so the live key is absent on most runs and the stale key is
+  // the one that actually carries the data. seed-correlation.mjs:14 registers
+  // the same pair.
+  'military:flights:stale:v1',
   'unrest:events:v1',
   'intelligence:advisories-bootstrap:v1',
   'market:stocks-bootstrap:v1',
@@ -28,7 +35,6 @@ const SOURCE_KEYS = [
   'wildfire:fires:v1',
   `displacement:summary:v1:${new Date().getFullYear()}`,
   'forecast:predictions:v2',
-  'intelligence:gdelt-intel:v1',
   'gdelt:intel:tone:military',
   'gdelt:intel:tone:nuclear',
   'gdelt:intel:tone:maritime',
@@ -159,6 +165,25 @@ function safeNum(v) {
   return Number.isFinite(n) ? n : 0;
 }
 
+// Writers publish proto enum strings for status/severity ('THERMAL_STATUS_SPIKE',
+// 'CRITICALITY_LEVEL_HIGH', 'OUTAGE_SEVERITY_MAJOR', ...) while several
+// extractors here compared against the bare lowercase tier. Accept both forms so
+// the comparison cannot go dead again if a writer changes representation — the
+// same tolerance seed-correlation.mjs:212 already applies to outage severity.
+function enumMatches(value, ...tiers) {
+  const normalized = String(value ?? '').toLowerCase();
+  return tiers.some((tier) => normalized === tier || normalized.endsWith(`_${tier}`));
+}
+
+// Writers are not consistent about epoch-ms numbers vs ISO strings for the same
+// concept (thermal lastDetectedAt is ISO, unrest occurredAt is epoch ms).
+// Returns 0 for anything undatable so callers can fall back.
+function toEpochMs(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 // ── Read all source keys in parallel via Upstash pipeline ─────────────────────
 async function readAllSourceKeys() {
   const { url, token } = getRedisCredentials();
@@ -201,20 +226,24 @@ function extractThermalSpike(d) {
   const payload = d['thermal:escalation:v1'];
   if (!payload) return [];
   const clusters = Array.isArray(payload.clusters) ? payload.clusters : [];
-  const spikes = clusters.filter(c => c.status === 'spike' || (safeNum(c.anomalyScore) > 2));
+  // Cluster shape: lib/thermal-escalation.mjs:308 — status is the proto enum,
+  // the anomaly measure is zScore (there is no anomalyScore anywhere in the
+  // repo), the label is regionLabel/countryName, and lastDetectedAt is ISO.
+  const spikes = clusters.filter(c => enumMatches(c.status, 'spike') || safeNum(c.zScore) > 2);
   if (spikes.length === 0) return [];
   const signals = [];
   for (const c of spikes.slice(0, 5)) {
-    const theater = normalizeTheater(c.region || c.name || '');
-    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_THERMAL_SPIKE'] * Math.min(3, safeNum(c.anomalyScore) || 1.5);
+    const label = c.regionLabel || c.countryName || '';
+    const theater = normalizeTheater(label);
+    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_THERMAL_SPIKE'] * Math.min(3, safeNum(c.zScore) || 1.5);
     signals.push({
-      id: `thermal:${c.id || (c.name || c.region || 'unknown').replace(/\s+/g, '-').toLowerCase()}`,
+      id: `thermal:${c.id || (label || 'unknown').replace(/\s+/g, '-').toLowerCase()}`,
       type: 'CROSS_SOURCE_SIGNAL_TYPE_THERMAL_SPIKE',
       theater,
-      summary: `Thermal spike detected: ${c.name || c.region || 'unknown'} — anomaly score ${safeNum(c.anomalyScore).toFixed(1)}`,
+      summary: `Thermal spike detected: ${label || 'unknown'} — z-score ${safeNum(c.zScore).toFixed(1)}`,
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: safeNum(c.detectedAt) || Date.now(),
+      detectedAt: toEpochMs(c.lastDetectedAt) || Date.now(),
       contributingTypes: [],
       signalCount: 0,
     });
@@ -245,7 +274,8 @@ function extractGpsJamming(d) {
       summary: `GPS jamming detected: ${count} high-interference hexagons in ${theater}`,
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: safeNum(payload.fetchedAt) || Date.now(),
+      // fetch-gpsjam.mjs:160 writes an ISO string, so safeNum() read 0 here.
+      detectedAt: toEpochMs(payload.fetchedAt) || Date.now(),
       contributingTypes: [],
       signalCount: 0,
     };
@@ -257,10 +287,14 @@ function extractMilitaryFlightSurge(d) {
   if (!payload) return [];
   const flights = Array.isArray(payload.flights) ? payload.flights : [];
   if (flights.length < 5) return [];
-  // Group by callsign country prefix / region
+  // The flight record (seed-military-flights.mjs:1099) carries operatorCountry;
+  // it has no region, country or origin field, so every flight used to fall
+  // through normalizeTheater('') into a single 'Global' bucket. operatorCountry
+  // is whose air force is flying, not where — the closest theater proxy this
+  // payload exposes.
   const regionMap = new Map();
   for (const f of flights) {
-    const theater = normalizeTheater(f.region || f.country || f.origin || '');
+    const theater = normalizeTheater(f.operatorCountry || '');
     regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
   }
   const signals = [];
@@ -288,10 +322,15 @@ function extractUnrestSurge(d) {
   const events = Array.isArray(payload.events) ? payload.events : (Array.isArray(payload) ? payload : []);
   if (events.length === 0) return [];
   const cutoff = Date.now() - 24 * 3600 * 1000;
-  const recent = events.filter(e => safeNum(e.date || e.timestamp || e.created_at) > cutoff || !e.date);
+  // seed-unrest-events.mjs:218 publishes occurredAt (epoch ms); date/timestamp/
+  // created_at were never written, so the cutoff read 0 for every event and the
+  // `|| !e.date` escape hatch let the whole feed through as "recent".
+  const recent = events.filter(e => toEpochMs(e.occurredAt) > cutoff);
   const regionMap = new Map();
   for (const ev of recent) {
-    const theater = normalizeTheater(ev.region || ev.country || ev.location || '');
+    // ev.location is { latitude, longitude } (:214) — including it in the chain
+    // stringified an object into the theater name.
+    const theater = normalizeTheater(ev.region || ev.country || ev.city || '');
     regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
   }
   const signals = [];
@@ -317,7 +356,12 @@ function extractOrefAlertCluster(d) {
   const payload = d['intelligence:advisories-bootstrap:v1'];
   if (!payload) return [];
   const advisories = Array.isArray(payload.advisories) ? payload.advisories : [];
-  const critical = advisories.filter(a => String(a.level || '').toLowerCase() === 'do not travel');
+  // seed-security-advisories.mjs:46 emits the hyphenated slug 'do-not-travel';
+  // comparing against the spaced form never matched. Normalize separators so
+  // both spellings resolve.
+  const critical = advisories.filter(
+    a => String(a.level || '').toLowerCase().replace(/[\s_]+/g, '-') === 'do-not-travel',
+  );
   if (critical.length === 0) return [];
   return critical.slice(0, 3).map(a => {
     const theater = normalizeTheater(a.region || a.country || '');
@@ -386,11 +430,14 @@ function extractCyberEscalation(d) {
   const payload = d['cyber:threats-bootstrap:v2'];
   if (!payload) return [];
   const threats = Array.isArray(payload.threats) ? payload.threats : (Array.isArray(payload) ? payload : []);
-  const critical = threats.filter(t => t.severity === 'critical' || t.severity === 'high');
+  // seed-cyber-threats.mjs:587 publishes CRITICALITY_LEVEL_*; the lowercase
+  // tiers this used to compare against are the pre-proto internal form.
+  const critical = threats.filter(t => enumMatches(t.severity, 'critical', 'high'));
   if (critical.length === 0) return [];
   const regionMap = new Map();
   for (const t of critical) {
-    const theater = normalizeTheater(t.targetCountry || t.region || t.country || '');
+    // The record has country only (:586) — no targetCountry, no region.
+    const theater = normalizeTheater(t.country || '');
     regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
   }
   const signals = [];
@@ -414,17 +461,22 @@ function extractCyberEscalation(d) {
 function extractShippingDisruption(d) {
   const payload = d['supply_chain:shipping:v2'];
   if (!payload) return [];
-  const routes = Array.isArray(payload.routes) ? payload.routes : (Array.isArray(payload) ? payload : []);
-  const disrupted = routes.filter(r => r.disrupted || r.status === 'disrupted' || safeNum(r.rerouting) > 10);
+  // supply_chain:shipping:v2 publishes rate indices, not routes:
+  // { indexId, name, currentValue, previousValue, changePct, unit, history,
+  // spikeAlert } (seed-supply-chain-trade.mjs:129). There is no route or
+  // disruption concept in the payload, so this keys off the writer's own
+  // published spike flag rather than a threshold invented here.
+  const indices = Array.isArray(payload.indices) ? payload.indices : [];
+  const disrupted = indices.filter(idx => idx.spikeAlert === true);
   if (disrupted.length === 0) return [];
-  const theater = disrupted.some(r => String(r.name || '').toLowerCase().includes('red sea') || String(r.route || '').toLowerCase().includes('red sea'))
+  const theater = disrupted.some(idx => String(idx.name || '').toLowerCase().includes('red sea'))
     ? 'Red Sea' : 'Global';
   const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_SHIPPING_DISRUPTION'] * Math.min(2, 1 + disrupted.length / 3);
   return [{
     id: `shipping:${theater.replace(/\s+/g, '-').toLowerCase()}`,
     type: 'CROSS_SOURCE_SIGNAL_TYPE_SHIPPING_DISRUPTION',
     theater,
-    summary: `Shipping disruption: ${disrupted.length} route${disrupted.length > 1 ? 's' : ''} affected in ${theater}`,
+    summary: `Shipping disruption: ${disrupted.length} freight rate index${disrupted.length > 1 ? 'es' : ''} spiking (${disrupted.map(idx => idx.name || idx.indexId).join(', ')})`,
     severity: scoreTier(score),
     severityScore: score,
     detectedAt: Date.now(),
@@ -471,7 +523,9 @@ function extractEarthquakeSignificant(d) {
       summary: `M${mag.toFixed(1)} earthquake — ${q.place || theater}`,
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: safeNum(q.time) || safeNum(q.timestamp) || Date.now(),
+      // seed-earthquakes.mjs:87 publishes occurredAt; time/timestamp were never
+      // written, so every quake was stamped with the run clock.
+      detectedAt: toEpochMs(q.occurredAt) || Date.now(),
       contributingTypes: [],
       signalCount: 0,
     };
@@ -482,20 +536,25 @@ function extractRadiationAnomaly(d) {
   const payload = d['radiation:observations:v1'];
   if (!payload) return [];
   const observations = Array.isArray(payload.observations) ? payload.observations : (Array.isArray(payload) ? payload : []);
-  const anomalies = observations.filter(o => o.alert || o.status === 'alert' || safeNum(o.value) > safeNum(o.threshold) * 1.5);
+  // The observation record (seed-radiation-watch.mjs:172) publishes a severity
+  // enum classified from delta/zScore; alert, status and threshold do not
+  // exist, so the old filter compared value against NaN and never matched.
+  // SPIKE only: BASE_WEIGHT is 3.5, so a single ELEVATED reading would page as
+  // CRITICAL on its own.
+  const anomalies = observations.filter(o => enumMatches(o.severity, 'spike'));
   if (anomalies.length === 0) return [];
   return anomalies.slice(0, 2).map(a => {
-    const locationStr = a.locationName || a.stationName || a.country || a.region || 'unknown station';
-    const theater = normalizeTheater(a.country || a.region || locationStr);
+    const locationStr = a.locationName || a.country || 'unknown station';
+    const theater = normalizeTheater(a.country || locationStr);
     const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_RADIATION_ANOMALY'];
     return {
-      id: `radiation:${a.id || a.stationId || locationStr.replace(/\s+/g, '-').toLowerCase()}`,
+      id: `radiation:${a.id || a.anchorId || locationStr.replace(/\s+/g, '-').toLowerCase()}`,
       type: 'CROSS_SOURCE_SIGNAL_TYPE_RADIATION_ANOMALY',
       theater,
-      summary: `Radiation anomaly: ${locationStr} — ${a.value || 'elevated'} reading`,
+      summary: `Radiation anomaly: ${locationStr} — ${safeNum(a.value).toFixed(1)} ${a.unit || ''} reading (z-score ${safeNum(a.zScore).toFixed(1)})`.replace(/\s{2,}/g, ' '),
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: safeNum(a.timestamp) || safeNum(a.measuredAt) || Date.now(),
+      detectedAt: toEpochMs(a.observedAt) || Date.now(),
       contributingTypes: [],
       signalCount: 0,
     };
@@ -506,11 +565,17 @@ function extractInfrastructureOutage(d) {
   const payload = d['infra:outages:v1'];
   if (!payload) return [];
   const outages = Array.isArray(payload.outages) ? payload.outages : (Array.isArray(payload) ? payload : []);
-  const major = outages.filter(o => o.severity === 'major' || o.severity === 'critical' || safeNum(o.affectedUsers) > 100000);
+  // seed-internet-outages.mjs:58 publishes OUTAGE_SEVERITY_TOTAL/MAJOR/PARTIAL.
+  // There is no CRITICAL tier and no affectedUsers field, so the old filter
+  // matched nothing.
+  const major = outages.filter(o => enumMatches(o.severity, 'total', 'major'));
   if (major.length === 0) return [];
   const regionMap = new Map();
   for (const o of major) {
-    const theater = normalizeTheater(o.region || o.country || o.location || 'Global');
+    // region is written as a hardcoded '' (:115) — kept in the chain so a later
+    // writer change is picked up, but country is what actually resolves today.
+    // o.location is { latitude, longitude }, so it is not a theater source.
+    const theater = normalizeTheater(o.region || o.country || 'Global');
     regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
   }
   const signals = [];
@@ -534,12 +599,21 @@ function extractInfrastructureOutage(d) {
 function extractWildfireEscalation(d) {
   const payload = d['wildfire:fires:v1'];
   if (!payload) return [];
-  const fires = Array.isArray(payload.fires) ? payload.fires : (Array.isArray(payload) ? payload : []);
-  const extreme = fires.filter(f => f.radiativePower > 5000 || f.severity === 'extreme' || safeNum(f.brightness) > 400);
+  // wildfire:fires:v1 publishes fireDetections, and each detection carries frp
+  // (fire radiative power, MW) — not `fires` with `radiativePower`, and it has
+  // no severity field at all (seed-fire-detections.mjs:93). The old
+  // radiativePower > 5000 clause was also two orders off the scale FIRMS
+  // reports, so rather than pick a new number this reuses possibleExplosion,
+  // the significance flag the writer itself publishes (frp > 80 && brightness
+  // > 380, :106). brightness > 400 was already correct and is kept.
+  const detections = Array.isArray(payload.fireDetections) ? payload.fireDetections : [];
+  const extreme = detections.filter(f => f.possibleExplosion === true || safeNum(f.brightness) > 400);
   if (extreme.length === 0) return [];
   const regionMap = new Map();
   for (const f of extreme) {
-    const theater = normalizeTheater(f.region || f.country || '');
+    // region is the monitored bbox name ('Ukraine', 'Saudi Arabia', ...);
+    // there is no country field on a detection.
+    const theater = normalizeTheater(f.region || '');
     regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
   }
   const signals = [];
@@ -561,34 +635,33 @@ function extractWildfireEscalation(d) {
   return signals.slice(0, 2);
 }
 
-function extractDisplacementSurge(d) {
-  const payload = d[`displacement:summary:v1:${new Date().getFullYear()}`];
-  if (!payload) return [];
-  const crises = Array.isArray(payload.crises) ? payload.crises : (Array.isArray(payload) ? payload : []);
-  const surges = crises.filter(c => safeNum(c.newDisplacements) > 50000 || c.trend === 'rising');
-  if (surges.length === 0) return [];
-  return surges.slice(0, 2).map(c => {
-    const theater = normalizeTheater(c.country || c.region || '');
-    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_DISPLACEMENT_SURGE'] * Math.min(2, 1 + safeNum(c.newDisplacements) / 100000);
-    return {
-      id: `displacement:${theater.replace(/\s+/g, '-').toLowerCase()}`,
-      type: 'CROSS_SOURCE_SIGNAL_TYPE_DISPLACEMENT_SURGE',
-      theater,
-      summary: `Displacement surge: ${c.country || theater} — ${safeNum(c.newDisplacements).toLocaleString()} new displaced persons`,
-      severity: scoreTier(score),
-      severityScore: score,
-      detectedAt: Date.now(),
-      contributingTypes: [],
-      signalCount: 0,
-    };
-  });
+// Intentionally silent, and documented as such rather than "fixed".
+//
+// This extractor was written against a `crises[]` array carrying
+// `newDisplacements` and `trend`. displacement:summary:v1:<year> has never
+// published that shape: the writer emits an annual UNHCR *stock* —
+// `summary.countries[]` with code/name/refugees/idps/totalDisplaced
+// (seed-displacement-summary.mjs:175) — and carries no flow, delta or trend
+// field anywhere in the payload.
+//
+// So this is not a field-name mismatch that a rename fixes. A surge is a flow,
+// and choosing a totalDisplaced cutoff to stand in for one would be inventing a
+// calibration rather than repairing a read — the opposite of what the rest of
+// this change does. It stays silent until the signal is either sourced from a
+// flow series or redefined as a stock-level signal. See #5870.
+function extractDisplacementSurge() {
+  return [];
 }
 
 function extractForecastDeterioration(d) {
   const payload = d['forecast:predictions:v2'];
   if (!payload) return [];
   const predictions = Array.isArray(payload.predictions) ? payload.predictions : (Array.isArray(payload) ? payload : []);
-  const deteriorating = predictions.filter(p => p.trend === 'deteriorating' || p.direction === 'negative' || safeNum(p.probability) > 0.65);
+  // computeTrends (seed-forecasts.mjs:2720) only ever assigns
+  // 'stable' | 'rising' | 'falling', and there is no `direction` field, so both
+  // of those clauses were dead. Probability is the one live criterion; whether
+  // a 'rising' trend should also qualify is a calibration call, not a read fix.
+  const deteriorating = predictions.filter(p => safeNum(p.probability) > 0.65);
   if (deteriorating.length === 0) return [];
   return deteriorating.slice(0, 2).map(p => {
     const theater = normalizeTheater(p.region || p.country || p.theater || '');
@@ -633,13 +706,15 @@ function extractWeatherExtreme(d) {
   const payload = d['weather:alerts:v1'];
   if (!payload) return [];
   const alerts = Array.isArray(payload.alerts) ? payload.alerts : (Array.isArray(payload) ? payload : []);
-  const extreme = alerts.filter(a => a.severity === 'extreme' || a.category === 'extreme');
+  // NWS passes severity through title-cased ('Extreme' / 'Severe',
+  // seed-weather-alerts.mjs:49) and publishes no category field.
+  const extreme = alerts.filter(a => enumMatches(a.severity, 'extreme'));
   if (extreme.length === 0) return [];
-  const regionMap = new Map();
-  for (const a of extreme) {
-    const theater = normalizeTheater(a.area || a.country || a.region || '');
-    regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
-  }
+  // The alert carries areaDesc ('Kern County, CA; Tulare County, CA') and no
+  // country/region. Bucketing by that string would give almost every alert its
+  // own theater, which can never join a composite. The feed is NWS-only, so the
+  // theater is North America by construction.
+  const regionMap = new Map([['North America', extreme.length]]);
   const signals = [];
   for (const [theater, count] of regionMap) {
     const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_WEATHER_EXTREME'] * Math.min(2, 1 + count / 5);
@@ -721,29 +796,15 @@ function extractMediaToneDeterioration(d) {
       signalCount: 0,
     });
   }
-  // Fallback: bundled gdelt-intel topics array if per-topic keys unavailable
-  if (signals.length === 0) {
-    const payload = d['intelligence:gdelt-intel:v1'];
-    const topics = Array.isArray(payload?.topics) ? payload.topics : [];
-    for (const topic of topics) {
-      const avgTone = safeNum(topic.avgTone || topic.tone);
-      if (avgTone > -3) continue;
-      const theater = normalizeTheater(topic.region || topic.country || '');
-      const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_MEDIA_TONE_DETERIORATION'] * Math.min(2, Math.abs(avgTone) / 3);
-      signals.push({
-        id: `gdelt-tone:${(topic.id || topic.label || 'unknown').replace(/\s+/g, '-').toLowerCase().slice(0, 40)}`,
-        type: 'CROSS_SOURCE_SIGNAL_TYPE_MEDIA_TONE_DETERIORATION',
-        theater,
-        summary: `Media tone deterioration: "${topic.label || topic.topic}" avg tone ${avgTone.toFixed(1)}`,
-        severity: scoreTier(score),
-        severityScore: score,
-        detectedAt: Date.now(),
-        contributingTypes: [],
-        signalCount: 0,
-      });
-      if (signals.length >= 2) break;
-    }
-  }
+  // The bundled-canonical fallback that used to sit here read
+  // intelligence:gdelt-intel:v1 topics for `avgTone` / `tone`. A topic object is
+  // { id, articles, fetchedAt, attemptedAt, _tone, _vol }
+  // (seed-gdelt-intel.mjs:438) — neither field has ever existed, so safeNum()
+  // returned 0, `0 > -3` skipped every topic, and the branch could not fire even
+  // once the envelope was unwrapped. Reconstructing it against topic._tone would
+  // mean re-deriving the trend and staleness rules the per-topic path above
+  // already implements under #5478/#5863 review, so the dead branch is removed
+  // and intelligence:gdelt-intel:v1 is dropped from SOURCE_KEYS with it.
   return signals.slice(0, 2);
 }
 
@@ -754,6 +815,10 @@ function extractRiskScoreSpike(d) {
   const spiking = ciiScores.filter(s => safeNum(s.combinedScore) > 80 || s.trend === 'TREND_DIRECTION_RISING');
   if (spiking.length === 0) return [];
   return spiking.slice(0, 3).map(s => {
+    // s.region is an uppercase ISO2 code (get-risk-scores.ts:1206), so it
+    // title-cases into 'Ua'/'Cn' rather than mapping to a theater. Left as-is:
+    // resolving codes to theater names needs a country resolver this seeder does
+    // not have, and the value is at least stable and unique per country.
     const theater = normalizeTheater(s.region || '');
     const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_RISK_SCORE_SPIKE'] * Math.min(2, safeNum(s.combinedScore) / 60);
     return {

--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -2,6 +2,7 @@
 
 import { pathToFileURL } from 'node:url';
 import { loadEnvFile, runSeed, getRedisCredentials } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.mjs';
 
 loadEnvFile(import.meta.url);
@@ -174,7 +175,22 @@ async function readAllSourceKeys() {
   for (let i = 0; i < SOURCE_KEYS.length; i++) {
     const raw = results[i]?.result;
     if (!raw) continue;
-    try { data[SOURCE_KEYS[i]] = JSON.parse(raw); } catch { /* skip malformed */ }
+    try {
+      // Most of these keys are written by contract-mode seeders, which store
+      // `{ _seed, data }` (_seed-utils.mjs:499). Parsing without unwrapping
+      // handed every extractor the envelope, so `payload.<field>` was undefined
+      // and the signal silently never fired. unwrapEnvelope only unwraps when
+      // `_seed.fetchedAt` is a number (_seed-envelope-source.mjs:59), so the
+      // legacy bare-shape keys pass through byte-identical.
+      //
+      // JSON.parse stays out here on purpose: unwrapEnvelope accepts a raw
+      // string, but on a parse failure it returns that string as `data`, which
+      // would register a malformed value as a found key and inflate the
+      // "Found N/M" line below. Parsing first preserves skip-malformed.
+      const { data: payload } = unwrapEnvelope(JSON.parse(raw));
+      if (payload == null) continue;
+      data[SOURCE_KEYS[i]] = payload;
+    } catch { /* skip malformed */ }
   }
   return data;
 }

--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from 'node:url';
 import { loadEnvFile, runSeed, getRedisCredentials } from './_seed-utils.mjs';
 import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.mjs';
 
@@ -789,6 +790,35 @@ function extractRegulatoryAction(d) {
   });
 }
 
+// ── Extractor registry ────────────────────────────────────────────────────────
+// Module scope (rather than inline in the aggregator) so the envelope-regression
+// suite can drive every extractor from one list: an extractor added without a
+// fixture fails tests/cross-source-signals-envelope-reads.test.mjs by
+// construction. Each handles missing data gracefully and returns [].
+const EXTRACTORS = Object.freeze([
+  extractThermalSpike,
+  extractGpsJamming,
+  extractMilitaryFlightSurge,
+  extractUnrestSurge,
+  extractOrefAlertCluster,
+  extractVixSpike,
+  extractCommodityShock,
+  extractCyberEscalation,
+  extractShippingDisruption,
+  extractSanctionsSurge,
+  extractEarthquakeSignificant,
+  extractRadiationAnomaly,
+  extractInfrastructureOutage,
+  extractWildfireEscalation,
+  extractDisplacementSurge,
+  extractForecastDeterioration,
+  extractMarketStress,
+  extractWeatherExtreme,
+  extractMediaToneDeterioration,
+  extractRiskScoreSpike,
+  extractRegulatoryAction,
+]);
+
 // ── Composite escalation detector ─────────────────────────────────────────────
 // Fires when >=3 signals from DIFFERENT categories share the same theater.
 function detectCompositeEscalation(signals) {
@@ -844,32 +874,7 @@ async function aggregateCrossSourceSignals() {
 
   const allSignals = [];
 
-  // Run all extractors; each handles missing data gracefully (returns [])
-  const extractors = [
-    extractThermalSpike,
-    extractGpsJamming,
-    extractMilitaryFlightSurge,
-    extractUnrestSurge,
-    extractOrefAlertCluster,
-    extractVixSpike,
-    extractCommodityShock,
-    extractCyberEscalation,
-    extractShippingDisruption,
-    extractSanctionsSurge,
-    extractEarthquakeSignificant,
-    extractRadiationAnomaly,
-    extractInfrastructureOutage,
-    extractWildfireEscalation,
-    extractDisplacementSurge,
-    extractForecastDeterioration,
-    extractMarketStress,
-    extractWeatherExtreme,
-    extractMediaToneDeterioration,
-    extractRiskScoreSpike,
-    extractRegulatoryAction,
-  ];
-
-  for (const extractor of extractors) {
+  for (const extractor of EXTRACTORS) {
     try {
       const extracted = extractor(sourceData);
       allSignals.push(...extracted);
@@ -908,24 +913,67 @@ export function declareRecords(data) {
   return Array.isArray(data?.signals) ? data.signals.length : 0;
 }
 
-runSeed('intelligence', 'cross-source-signals', CANONICAL_KEY, aggregateCrossSourceSignals, {
-  ttlSeconds: CACHE_TTL,
-  validateFn: validate,
-  sourceVersion: 'cross-source-v1',
-  recordCount: (data) => data.signals?.length ?? 0,
-  afterPublish: async (data) => {
-    const { url, token } = getRedisCredentials();
-    const metaKey = 'seed-meta:intelligence:cross-source-signals';
-    const meta = { fetchedAt: Date.now(), recordCount: data.signals?.length ?? 0 };
-    await fetch(url, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify(['SET', metaKey, JSON.stringify(meta), 'EX', 86400 * 7]),
-      signal: AbortSignal.timeout(5_000),
-    }).catch(err => console.warn(`  seed-meta write failed: ${err.message}`));
-  },
+// Direct-run guard (scripts/seed-regulatory-actions.mjs:319 idiom). The Railway
+// bundle spawns this file as its own process — scripts/_bundle-runner.mjs does
+// `spawn(process.execPath, [scriptPath])` — so production still seeds. The guard
+// exists so tests can import the extractors instead of reconstructing the module
+// with vm + regex source surgery, which is what hid the envelope bug: the old
+// harness deleted readAllSourceKeys, the exact seam where the defect lives.
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 30,
-});
+if (isDirectRun) {
+  runSeed('intelligence', 'cross-source-signals', CANONICAL_KEY, aggregateCrossSourceSignals, {
+    ttlSeconds: CACHE_TTL,
+    validateFn: validate,
+    sourceVersion: 'cross-source-v1',
+    recordCount: (data) => data.signals?.length ?? 0,
+    afterPublish: async (data) => {
+      const { url, token } = getRedisCredentials();
+      const metaKey = 'seed-meta:intelligence:cross-source-signals';
+      const meta = { fetchedAt: Date.now(), recordCount: data.signals?.length ?? 0 };
+      await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(['SET', metaKey, JSON.stringify(meta), 'EX', 86400 * 7]),
+        signal: AbortSignal.timeout(5_000),
+      }).catch(err => console.warn(`  seed-meta write failed: ${err.message}`));
+    },
+
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 30,
+  });
+}
+
+export {
+  BASE_WEIGHT,
+  EXTRACTORS,
+  SOURCE_KEYS,
+  TYPE_CATEGORY,
+  aggregateCrossSourceSignals,
+  detectCompositeEscalation,
+  extractCommodityShock,
+  extractCyberEscalation,
+  extractDisplacementSurge,
+  extractEarthquakeSignificant,
+  extractForecastDeterioration,
+  extractGpsJamming,
+  extractInfrastructureOutage,
+  extractMarketStress,
+  extractMediaToneDeterioration,
+  extractMilitaryFlightSurge,
+  extractOrefAlertCluster,
+  extractRadiationAnomaly,
+  extractRegulatoryAction,
+  extractRiskScoreSpike,
+  extractSanctionsSurge,
+  extractShippingDisruption,
+  extractThermalSpike,
+  extractUnrestSurge,
+  extractVixSpike,
+  extractWeatherExtreme,
+  extractWildfireEscalation,
+  normalizeTheater,
+  readAllSourceKeys,
+  scoreTier,
+};

--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -14,16 +14,12 @@ const CACHE_TTL = 1800; // 30min TTL, 15min cron cadence
 const SOURCE_KEYS = [
   'thermal:escalation:v1',
   'intelligence:gpsjam:v2',
-  'military:flights:v1',
-  // extractMilitaryFlightSurge already falls back to the stale key, but it was
-  // never fetched. The writer publishes the same payload to both
-  // (seed-military-flights.mjs:1327) with a 600s live TTL against this seeder's
-  // 15min cadence, so the live key is absent on most runs and the stale key is
-  // the one that actually carries the data. seed-correlation.mjs:14 registers
-  // the same pair.
-  'military:flights:stale:v1',
+  // This writer already derives geospatial theater surges from flight
+  // coordinates. Reading the 24h stale key avoids the live key's 10min TTL
+  // racing this seeder's 15min cadence.
+  'military:surges:stale:v1',
   'unrest:events:v1',
-  'intelligence:advisories-bootstrap:v1',
+  'relay:oref:history:v1',
   'market:stocks-bootstrap:v1',
   'market:commodities-bootstrap:v1',
   'cyber:threats-bootstrap:v2',
@@ -43,12 +39,34 @@ const SOURCE_KEYS = [
   'regulatory:actions:v1',
 ];
 
+// Reject preserved contract envelopes after the same age budgets used by
+// api/health.js. runSeed deliberately extends last-good keys on an upstream
+// failure without advancing _seed.fetchedAt; without this gate, unwrapping the
+// envelope can revive stale observations and stamp them as new signals.
+const SOURCE_MAX_AGE_MIN = Object.freeze({
+  'thermal:escalation:v1': 360,
+  'unrest:events:v1': 120,
+  'market:stocks-bootstrap:v1': 30,
+  'market:commodities-bootstrap:v1': 30,
+  'cyber:threats-bootstrap:v2': 240,
+  'supply_chain:shipping:v2': 420,
+  'sanctions:pressure:v1': 720,
+  'seismology:earthquakes:v1': 30,
+  'radiation:observations:v1': 30,
+  'infra:outages:v1': 30,
+  'wildfire:fires:v1': 360,
+  'forecast:predictions:v2': 90,
+  'weather:alerts:v1': 45,
+});
+
 // ── Theater classification helpers ────────────────────────────────────────────
 const REGION_THEATER_MAP = {
   'eastern europe': 'Eastern Europe',
   'ukraine': 'Eastern Europe',
   'russia': 'Eastern Europe',
   'belarus': 'Eastern Europe',
+  'baltic': 'Eastern Europe',
+  'blacksea': 'Eastern Europe',
   'middle east': 'Middle East',
   'israel': 'Middle East',
   'gaza': 'Middle East',
@@ -56,8 +74,11 @@ const REGION_THEATER_MAP = {
   'iraq': 'Middle East',
   'syria': 'Middle East',
   'lebanon': 'Middle East',
+  'yemen redsea': 'Red Sea',
   'yemen': 'Middle East',
   'saudi': 'Middle East',
+  'east med': 'Middle East',
+  'israel gaza': 'Middle East',
   'red sea': 'Red Sea',
   'gulf of aden': 'Red Sea',
   'persian gulf': 'Persian Gulf',
@@ -212,9 +233,16 @@ async function readAllSourceKeys() {
       // string, but on a parse failure it returns that string as `data`, which
       // would register a malformed value as a found key and inflate the
       // "Found N/M" line below. Parsing first preserves skip-malformed.
-      const { data: payload } = unwrapEnvelope(JSON.parse(raw));
+      const { _seed, data: payload } = unwrapEnvelope(JSON.parse(raw));
       if (payload == null) continue;
-      data[SOURCE_KEYS[i]] = payload;
+      const key = SOURCE_KEYS[i];
+      const maxAgeMin = SOURCE_MAX_AGE_MIN[key];
+      if (
+        _seed &&
+        maxAgeMin != null &&
+        Date.now() - _seed.fetchedAt > maxAgeMin * 60_000
+      ) continue;
+      data[key] = payload;
     } catch { /* skip malformed */ }
   }
   return data;
@@ -283,37 +311,32 @@ function extractGpsJamming(d) {
 }
 
 function extractMilitaryFlightSurge(d) {
-  const payload = d['military:flights:v1'] || d['military:flights:stale:v1'];
+  const payload = d['military:surges:stale:v1'];
   if (!payload) return [];
-  const flights = Array.isArray(payload.flights) ? payload.flights : [];
-  if (flights.length < 5) return [];
-  // The flight record (seed-military-flights.mjs:1099) carries operatorCountry;
-  // it has no region, country or origin field, so every flight used to fall
-  // through normalizeTheater('') into a single 'Global' bucket. operatorCountry
-  // is whose air force is flying, not where — the closest theater proxy this
-  // payload exposes.
-  const regionMap = new Map();
-  for (const f of flights) {
-    const theater = normalizeTheater(f.operatorCountry || '');
-    regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
-  }
-  const signals = [];
-  for (const [theater, count] of regionMap) {
-    if (count < 3) continue;
-    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_MILITARY_FLIGHT_SURGE'] * Math.min(2, 1 + count / 20);
-    signals.push({
-      id: `mil-flights:${theater.replace(/\s+/g, '-').toLowerCase()}`,
+  const fetchedAt = toEpochMs(payload.fetchedAt);
+  if (!fetchedAt || Date.now() - fetchedAt > 30 * 60_000) return [];
+  const surges = Array.isArray(payload.surges) ? payload.surges : [];
+  return surges.map((surge) => {
+    const theater = normalizeTheater(String(surge.theaterId || '').replace(/-/g, ' '));
+    const multiple = Math.max(1, safeNum(surge.surgeMultiple));
+    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_MILITARY_FLIGHT_SURGE'] * Math.min(2, multiple);
+    const surgeLabel = String(surge.surgeType || 'air activity').replace(/_/g, ' ');
+    return {
+      id: `mil-surge:${surge.id || `${surgeLabel}-${surge.theaterId || 'global'}`}`,
       type: 'CROSS_SOURCE_SIGNAL_TYPE_MILITARY_FLIGHT_SURGE',
       theater,
-      summary: `Military flight surge: ${count} active sorties tracked in ${theater}`,
+      summary: `Military flight surge: ${surgeLabel} activity at ${multiple.toFixed(1)}x baseline in ${theater}`,
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: safeNum(payload.fetchedAt) || Date.now(),
+      detectedAt: toEpochMs(surge.assessedAt) || fetchedAt,
       contributingTypes: [],
       signalCount: 0,
-    });
-  }
-  return signals.slice(0, 3);
+    };
+  }).sort((a, b) =>
+    (b.severityScore - a.severityScore) ||
+    (b.detectedAt - a.detectedAt) ||
+    a.id.localeCompare(b.id)
+  ).slice(0, 3);
 }
 
 function extractUnrestSurge(d) {
@@ -330,7 +353,7 @@ function extractUnrestSurge(d) {
   for (const ev of recent) {
     // ev.location is { latitude, longitude } (:214) — including it in the chain
     // stringified an object into the theater name.
-    const theater = normalizeTheater(ev.region || ev.country || ev.city || '');
+    const theater = normalizeTheater(ev.country || ev.region || ev.city || '');
     regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
   }
   const signals = [];
@@ -353,31 +376,31 @@ function extractUnrestSurge(d) {
 }
 
 function extractOrefAlertCluster(d) {
-  const payload = d['intelligence:advisories-bootstrap:v1'];
+  const payload = d['relay:oref:history:v1'];
   if (!payload) return [];
-  const advisories = Array.isArray(payload.advisories) ? payload.advisories : [];
-  // seed-security-advisories.mjs:46 emits the hyphenated slug 'do-not-travel';
-  // comparing against the spaced form never matched. Normalize separators so
-  // both spellings resolve.
-  const critical = advisories.filter(
-    a => String(a.level || '').toLowerCase().replace(/[\s_]+/g, '-') === 'do-not-travel',
+  const cutoff = Date.now() - 24 * 3600 * 1000;
+  const recentWaves = (Array.isArray(payload.history) ? payload.history : [])
+    .map((wave) => ({ wave, detectedAt: toEpochMs(wave.timestamp) }))
+    .filter(({ detectedAt }) => detectedAt > cutoff);
+  if (recentWaves.length === 0) return [];
+  const alertCount = recentWaves.reduce(
+    (sum, { wave }) => sum + (Array.isArray(wave.alerts) ? wave.alerts : [])
+      .reduce((waveSum, alert) => waveSum + (Array.isArray(alert.data) ? alert.data.length : 1), 0),
+    0,
   );
-  if (critical.length === 0) return [];
-  return critical.slice(0, 3).map(a => {
-    const theater = normalizeTheater(a.region || a.country || '');
-    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_OREF_ALERT_CLUSTER'];
-    return {
-      id: `advisory:${(a.country || a.region || 'unknown').replace(/\s+/g, '-').toLowerCase()}`,
-      type: 'CROSS_SOURCE_SIGNAL_TYPE_OREF_ALERT_CLUSTER',
-      theater,
-      summary: `"Do Not Travel" advisory: ${a.country || a.region || 'unknown'}${a.reason ? ` — ${a.reason}` : ''}`,
-      severity: scoreTier(score),
-      severityScore: score,
-      detectedAt: Date.now(),
-      contributingTypes: [],
-      signalCount: 0,
-    };
-  });
+  if (alertCount === 0) return [];
+  const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_OREF_ALERT_CLUSTER'] * Math.min(2, 1 + alertCount / 10);
+  return [{
+    id: 'oref:israel-24h',
+    type: 'CROSS_SOURCE_SIGNAL_TYPE_OREF_ALERT_CLUSTER',
+    theater: 'Middle East',
+    summary: `OREF alert cluster: ${alertCount} alert${alertCount === 1 ? '' : 's'} in Israel in past 24h`,
+    severity: scoreTier(score),
+    severityScore: score,
+    detectedAt: Math.max(...recentWaves.map(({ detectedAt }) => detectedAt)),
+    contributingTypes: [],
+    signalCount: 0,
+  }];
 }
 
 function extractVixSpike(d) {
@@ -434,28 +457,27 @@ function extractCyberEscalation(d) {
   // tiers this used to compare against are the pre-proto internal form.
   const critical = threats.filter(t => enumMatches(t.severity, 'critical', 'high'));
   if (critical.length === 0) return [];
-  const regionMap = new Map();
-  for (const t of critical) {
-    // The record has country only (:586) — no targetCountry, no region.
-    const theater = normalizeTheater(t.country || '');
-    regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
-  }
-  const signals = [];
-  for (const [theater, count] of regionMap) {
-    const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_CYBER_ESCALATION'] * Math.min(2, 1 + count / 5);
-    signals.push({
-      id: `cyber:${theater.replace(/\s+/g, '-').toLowerCase()}`,
-      type: 'CROSS_SOURCE_SIGNAL_TYPE_CYBER_ESCALATION',
-      theater,
-      summary: `Cyber escalation: ${count} critical/high threat${count > 1 ? 's' : ''} targeting ${theater}`,
-      severity: scoreTier(score),
-      severityScore: score,
-      detectedAt: Date.now(),
-      contributingTypes: [],
-      signalCount: 0,
-    });
-  }
-  return signals.slice(0, 2);
+  const cutoff = Date.now() - 14 * 24 * 3600 * 1000;
+  const recent = critical
+    .map((threat) => ({
+      threat,
+      detectedAt: toEpochMs(threat.lastSeenAt) || toEpochMs(threat.firstSeenAt),
+    }))
+    .filter(({ detectedAt }) => detectedAt > cutoff);
+  if (recent.length === 0) return [];
+  const countries = new Set(recent.map(({ threat }) => threat.country).filter(Boolean));
+  const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_CYBER_ESCALATION'] * Math.min(2, 1 + recent.length / 5);
+  return [{
+    id: 'cyber:global',
+    type: 'CROSS_SOURCE_SIGNAL_TYPE_CYBER_ESCALATION',
+    theater: 'Global',
+    summary: `Cyber escalation: ${recent.length} critical/high infrastructure indicator${recent.length === 1 ? '' : 's'}${countries.size ? ` geolocated across ${countries.size} countr${countries.size === 1 ? 'y' : 'ies'}` : ''}`,
+    severity: scoreTier(score),
+    severityScore: score,
+    detectedAt: Math.max(...recent.map(({ detectedAt }) => detectedAt)),
+    contributingTypes: [],
+    signalCount: 0,
+  }];
 }
 
 function extractShippingDisruption(d) {
@@ -510,7 +532,10 @@ function extractEarthquakeSignificant(d) {
   const payload = d['seismology:earthquakes:v1'];
   if (!payload) return [];
   const quakes = Array.isArray(payload.earthquakes) ? payload.earthquakes : (Array.isArray(payload) ? payload : []);
-  const significant = quakes.filter(q => safeNum(q.magnitude) >= 6.5);
+  const cutoff = Date.now() - 24 * 3600 * 1000;
+  const significant = quakes.filter(
+    q => safeNum(q.magnitude) >= 6.5 && toEpochMs(q.occurredAt) > cutoff,
+  );
   if (significant.length === 0) return [];
   return significant.slice(0, 2).map(q => {
     const theater = normalizeTheater(q.place || q.region || q.country || '');
@@ -568,7 +593,11 @@ function extractInfrastructureOutage(d) {
   // seed-internet-outages.mjs:58 publishes OUTAGE_SEVERITY_TOTAL/MAJOR/PARTIAL.
   // There is no CRITICAL tier and no affectedUsers field, so the old filter
   // matched nothing.
-  const major = outages.filter(o => enumMatches(o.severity, 'total', 'major'));
+  const now = Date.now();
+  const major = outages.filter((o) => {
+    const endedAt = toEpochMs(o.endedAt);
+    return enumMatches(o.severity, 'total', 'major') && (!endedAt || endedAt > now);
+  });
   if (major.length === 0) return [];
   const regionMap = new Map();
   for (const o of major) {
@@ -576,10 +605,13 @@ function extractInfrastructureOutage(d) {
     // writer change is picked up, but country is what actually resolves today.
     // o.location is { latitude, longitude }, so it is not a theater source.
     const theater = normalizeTheater(o.region || o.country || 'Global');
-    regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
+    const group = regionMap.get(theater) || { count: 0, detectedAt: 0 };
+    group.count += 1;
+    group.detectedAt = Math.max(group.detectedAt, toEpochMs(o.detectedAt));
+    regionMap.set(theater, group);
   }
   const signals = [];
-  for (const [theater, count] of regionMap) {
+  for (const [theater, { count, detectedAt }] of regionMap) {
     const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_INFRASTRUCTURE_OUTAGE'] * Math.min(2, 1 + count / 3);
     signals.push({
       id: `outage:${theater.replace(/\s+/g, '-').toLowerCase()}`,
@@ -588,7 +620,7 @@ function extractInfrastructureOutage(d) {
       summary: `Infrastructure outage: ${count} major service failure${count > 1 ? 's' : ''} in ${theater}`,
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: Date.now(),
+      detectedAt: detectedAt || now,
       contributingTypes: [],
       signalCount: 0,
     });
@@ -607,17 +639,23 @@ function extractWildfireEscalation(d) {
   // the significance flag the writer itself publishes (frp > 80 && brightness
   // > 380, :106). brightness > 400 was already correct and is kept.
   const detections = Array.isArray(payload.fireDetections) ? payload.fireDetections : [];
-  const extreme = detections.filter(f => f.possibleExplosion === true || safeNum(f.brightness) > 400);
+  const cutoff = Date.now() - 24 * 3600 * 1000;
+  const extreme = detections.filter(
+    f => (f.possibleExplosion === true || safeNum(f.brightness) > 400) && toEpochMs(f.detectedAt) > cutoff,
+  );
   if (extreme.length === 0) return [];
   const regionMap = new Map();
   for (const f of extreme) {
     // region is the monitored bbox name ('Ukraine', 'Saudi Arabia', ...);
     // there is no country field on a detection.
     const theater = normalizeTheater(f.region || '');
-    regionMap.set(theater, (regionMap.get(theater) || 0) + 1);
+    const group = regionMap.get(theater) || { count: 0, detectedAt: 0 };
+    group.count += 1;
+    group.detectedAt = Math.max(group.detectedAt, toEpochMs(f.detectedAt));
+    regionMap.set(theater, group);
   }
   const signals = [];
-  for (const [theater, count] of regionMap) {
+  for (const [theater, { count, detectedAt }] of regionMap) {
     if (count < 5) continue;
     const score = BASE_WEIGHT['CROSS_SOURCE_SIGNAL_TYPE_WILDFIRE_ESCALATION'] * Math.min(2, 1 + count / 50);
     signals.push({
@@ -627,7 +665,7 @@ function extractWildfireEscalation(d) {
       summary: `Wildfire escalation: ${count} extreme thermal detections in ${theater}`,
       severity: scoreTier(score),
       severityScore: score,
-      detectedAt: Date.now(),
+      detectedAt,
       contributingTypes: [],
       signalCount: 0,
     });
@@ -661,7 +699,25 @@ function extractForecastDeterioration(d) {
   // 'stable' | 'rising' | 'falling', and there is no `direction` field, so both
   // of those clauses were dead. Probability is the one live criterion; whether
   // a 'rising' trend should also qualify is a calibration call, not a read fix.
-  const deteriorating = predictions.filter(p => safeNum(p.probability) > 0.65);
+  // A prediction's probability is the probability of its proposition, not an
+  // escalation score. The canonical writer uses the same polarity distinction
+  // when calibrating against prediction markets: a likely ceasefire is not a
+  // likely deterioration, while a likely ceasefire failure is.
+  const deEscalationTerms = /\b(?:ceasefire|truce|peace|peaceful|agreement|diplomatic solution|withdrawal|reopen(?:ed)?|restored|resolution|resolved|de-?escalat\w*|stabili[sz]\w*|normali[sz]\w*)\b/i;
+  const failedDeEscalation = /\b(?:ceasefire|truce|peace|agreement)\b.{0,40}\b(?:fail\w*|collaps\w*|break(?:s|ing)? down|breakdown|breach\w*|violat\w*|reject\w*|expir\w*|end(?:s|ed|ing)?\b(?!\s+of\b))|\b(?:fail\w*|collaps\w*|break(?:s|ing)? down|breakdown|breach\w*|violat\w*|reject\w*|expir\w*|end(?:s|ed|ing)?\b(?!\s+of\b)).{0,40}\b(?:ceasefire|truce|peace|agreement)\b/i;
+  const adverseResumption = /\b(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)\b.{0,24}\b(?:resum\w*|renew\w*)\b|\b(?:resum\w*|renew\w*)\b.{0,24}\b(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)\b/i;
+  const adverseConditionEnds = /\b(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)\b.{0,40}\bend(?:s|ed|ing)?\b|\bend(?:s|ed|ing)?\b(?:\s+of)?.{0,40}\b(?:war|conflict|fighting|hostilities|violence|offensive|attacks?)\b/i;
+  const deteriorating = predictions.filter((p) => {
+    if (safeNum(p.probability) <= 0.65) return false;
+    const signalText = (Array.isArray(p.signals) ? p.signals : [])
+      .map(signal => `${signal?.type || ''} ${signal?.value || ''}`)
+      .join(' ');
+    const outcomeText = `${p.title || ''} ${p.scenario || ''} ${signalText}`;
+    if (adverseConditionEnds.test(outcomeText)) return false;
+    if (adverseResumption.test(outcomeText)) return true;
+    if (deEscalationTerms.test(outcomeText) && !failedDeEscalation.test(outcomeText)) return false;
+    return true;
+  });
   if (deteriorating.length === 0) return [];
   return deteriorating.slice(0, 2).map(p => {
     const theater = normalizeTheater(p.region || p.country || p.theater || '');

--- a/tests/cross-source-signals-envelope-reads.test.mjs
+++ b/tests/cross-source-signals-envelope-reads.test.mjs
@@ -1,0 +1,121 @@
+// Regression test for issue #5870: seed-cross-source-signals read its 20+ input
+// keys with a bare JSON.parse and no envelope unwrap.
+//
+// Most of those keys are written by contract-mode seeders, which store
+// `{ _seed, data }` (scripts/_seed-utils.mjs:499). So `d['<key>']` was the
+// envelope, every extractor's `payload.<field>` was undefined, and the signal
+// silently never fired — the seeder still exited 0 and published, just with
+// fewer signals than it should. Same failure shape as the one
+// tests/regional-snapshot-envelope-unwrap.test.mjs pins one layer down.
+//
+// The existing suites could not catch this: their vm harness deleted
+// readAllSourceKeys and fed extractors hand-built bare fixtures, i.e. the
+// pre-envelope world, at exactly the seam where the defect lives.
+
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { SOURCE_KEYS, readAllSourceKeys } from '../scripts/seed-cross-source-signals.mjs';
+import { unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
+
+const REDIS_URL = 'https://cross-source-signals.test.upstash.io';
+
+function seedEnvelope(data) {
+  return {
+    _seed: {
+      fetchedAt: Date.now(),
+      sourceVersion: 'test-v1',
+      schemaVersion: 1,
+      recordCount: 1,
+    },
+    data,
+  };
+}
+
+// Drive a value through exactly what readAllSourceKeys does to a Redis string,
+// so a fixture can never accidentally test a shape the reader does not produce.
+function asReadByTheSeeder(redisValue) {
+  return unwrapEnvelope(JSON.parse(JSON.stringify(redisValue))).data;
+}
+
+describe('readAllSourceKeys envelope handling', () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  before(() => {
+    process.env.UPSTASH_REDIS_REST_URL = REDIS_URL;
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+    if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+  });
+
+  // Stub the Upstash pipeline: `byKey` maps a source key to the raw string
+  // Redis would return; anything unlisted comes back as a null result.
+  function stubPipeline(byKey) {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => SOURCE_KEYS.map((key) => ({ result: byKey[key] ?? null })),
+    });
+  }
+
+  it('unwraps a contract-mode envelope down to its payload', async () => {
+    const payload = { earthquakes: [{ id: 'us1', magnitude: 7.1 }] };
+    stubPipeline({ 'seismology:earthquakes:v1': JSON.stringify(seedEnvelope(payload)) });
+
+    const data = await readAllSourceKeys();
+    assert.deepEqual(data['seismology:earthquakes:v1'], payload);
+  });
+
+  it('passes a legacy bare payload through unchanged', async () => {
+    const payload = { flights: [{ id: 'opensky-1' }], fetchedAt: 1_700_000_000_000 };
+    stubPipeline({ 'military:flights:v1': JSON.stringify(payload) });
+
+    const data = await readAllSourceKeys();
+    assert.deepEqual(data['military:flights:v1'], payload);
+  });
+
+  // gdelt:intel:tone:* is the one live payload shaped like half an envelope: a
+  // top-level `data` array plus a `fetchedAt`, but no `_seed`. unwrapEnvelope
+  // only unwraps when `_seed.fetchedAt` is a number, so it must pass through —
+  // unwrapping it would hand the tone extractor a bare array and kill the one
+  // signal path that works today.
+  it('does not unwrap a legacy payload that has its own top-level data field', async () => {
+    const tone = {
+      data: [{ date: '2026-07-20', value: -2.4 }],
+      fetchedAt: new Date().toISOString(),
+    };
+    stubPipeline({ 'gdelt:intel:tone:military': JSON.stringify(tone) });
+
+    const data = await readAllSourceKeys();
+    assert.deepEqual(data['gdelt:intel:tone:military'], tone);
+  });
+
+  it('skips malformed JSON instead of registering the raw string as a found key', async () => {
+    stubPipeline({ 'unrest:events:v1': '{"events":[' });
+
+    const data = await readAllSourceKeys();
+    assert.equal('unrest:events:v1' in data, false);
+  });
+
+  it('skips an envelope whose payload is null', async () => {
+    stubPipeline({ 'infra:outages:v1': JSON.stringify(seedEnvelope(null)) });
+
+    const data = await readAllSourceKeys();
+    assert.equal('infra:outages:v1' in data, false);
+  });
+
+  it('returns no keys when every pipeline slot is empty', async () => {
+    stubPipeline({});
+
+    const data = await readAllSourceKeys();
+    assert.deepEqual(Object.keys(data), []);
+  });
+});
+
+export { asReadByTheSeeder, seedEnvelope };

--- a/tests/cross-source-signals-envelope-reads.test.mjs
+++ b/tests/cross-source-signals-envelope-reads.test.mjs
@@ -43,6 +43,7 @@ import {
   extractVixSpike,
   extractWeatherExtreme,
   extractWildfireEscalation,
+  normalizeTheater,
   readAllSourceKeys,
 } from '../scripts/seed-cross-source-signals.mjs';
 import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
@@ -53,10 +54,10 @@ const HOUR = 3600 * 1000;
 const now = Date.now();
 const iso = (msAgo = 0) => new Date(now - msAgo).toISOString();
 
-function seedEnvelope(data) {
+function seedEnvelope(data, fetchedAt = now) {
   return {
     _seed: {
-      fetchedAt: now,
+      fetchedAt,
       sourceVersion: 'test-v1',
       schemaVersion: 1,
       recordCount: 1,
@@ -108,11 +109,11 @@ describe('readAllSourceKeys envelope handling', () => {
   });
 
   it('passes a legacy bare payload through unchanged', async () => {
-    const payload = { flights: [{ id: 'opensky-1' }], fetchedAt: 1_700_000_000_000 };
-    stubPipeline({ 'military:flights:v1': JSON.stringify(payload) });
+    const payload = { hexes: [{ region: 'Eastern Europe', level: 'high' }], fetchedAt: 1_700_000_000_000 };
+    stubPipeline({ 'intelligence:gpsjam:v2': JSON.stringify(payload) });
 
     const data = await readAllSourceKeys();
-    assert.deepEqual(data['military:flights:v1'], payload);
+    assert.deepEqual(data['intelligence:gpsjam:v2'], payload);
   });
 
   // gdelt:intel:tone:* is the one live payload shaped like half an envelope: a
@@ -142,6 +143,30 @@ describe('readAllSourceKeys envelope handling', () => {
     assert.equal('infra:outages:v1' in data, false);
   });
 
+  it('skips a preserved contract envelope after its source freshness budget', async () => {
+    const staleFetchedAt = now - 31 * 60_000;
+    stubPipeline({
+      'seismology:earthquakes:v1': JSON.stringify(seedEnvelope({
+        earthquakes: [{ id: 'stale-us1', magnitude: 7.1, occurredAt: now - HOUR }],
+      }, staleFetchedAt)),
+    });
+
+    const data = await readAllSourceKeys();
+    assert.equal('seismology:earthquakes:v1' in data, false);
+  });
+
+  it('keeps recent OREF waves when the quiet-history envelope is older than 15 minutes', async () => {
+    const payload = {
+      history: [{ timestamp: iso(HOUR), alerts: [{ data: ['Tel Aviv'] }] }],
+    };
+    stubPipeline({
+      'relay:oref:history:v1': JSON.stringify(seedEnvelope(payload, now - 2 * HOUR)),
+    });
+
+    const data = await readAllSourceKeys();
+    assert.deepEqual(data['relay:oref:history:v1'], payload);
+  });
+
   it('returns no keys when every pipeline slot is empty', async () => {
     stubPipeline({});
 
@@ -149,8 +174,9 @@ describe('readAllSourceKeys envelope handling', () => {
     assert.deepEqual(Object.keys(data), []);
   });
 
-  it('fetches the stale military flights key the extractor already falls back to', () => {
-    assert.ok(SOURCE_KEYS.includes('military:flights:stale:v1'));
+  it('fetches the geospatial military surge key instead of inferring theater from operator nationality', () => {
+    assert.ok(SOURCE_KEYS.includes('military:surges:stale:v1'));
+    assert.equal(SOURCE_KEYS.includes('military:flights:stale:v1'), false);
   });
 });
 
@@ -195,22 +221,24 @@ const FIXTURES = [
   },
   {
     extractor: extractMilitaryFlightSurge,
-    expectTheater: 'Eastern Europe',
-    expectDetectedAt: (p) => p.fetchedAt,
-    key: 'military:flights:stale:v1',
-    enveloped: false, // seed-military-flights.mjs:1328 raw redisSet
-    // Flight shape: scripts/seed-military-flights.mjs:1099 + classify* spread.
+    expectTheater: 'East Asia',
+    expectDetectedAt: (p) => p.surges[0].assessedAt,
+    key: 'military:surges:stale:v1',
+    enveloped: false, // seed-military-flights.mjs:1388 raw redisSet
+    // Surge shape: scripts/_military-surges.mjs:124.
     payload: {
-      flights: Array.from({ length: 5 }, (_, i) => ({
-        id: `opensky-ae${i}`,
-        callsign: `RSD${i}`,
-        operator: 'vks',
-        operatorCountry: 'Russia',
-        aircraftType: 'bomber',
-        lastSeenMs: now - 5 * 60_000,
-      })),
+      surges: [{
+        id: 'fighter-taiwan-theater',
+        theaterId: 'taiwan-theater',
+        surgeType: 'fighter',
+        currentCount: 8,
+        baselineCount: 3,
+        surgeMultiple: 2.7,
+        postureLevel: 'elevated',
+        strikeCapable: true,
+        assessedAt: now,
+      }],
       fetchedAt: now,
-      stats: { total: 5, byType: { bomber: 5 } },
     },
   },
   {
@@ -220,11 +248,11 @@ const FIXTURES = [
     enveloped: true, // seed-unrest-events.mjs:525 declareRecords
     // Event shape: scripts/seed-unrest-events.mjs:211.
     payload: {
-      events: Array.from({ length: 3 }, (_, i) => ({
+      events: ['Beirut', 'Mount Lebanon', 'North'].map((region, i) => ({
         id: `acled-${i}`,
         city: 'Beirut',
         country: 'Lebanon',
-        region: '',
+        region,
         location: { latitude: 33.88, longitude: 35.49 },
         occurredAt: now - (i + 1) * HOUR,
       })),
@@ -233,19 +261,24 @@ const FIXTURES = [
   {
     extractor: extractOrefAlertCluster,
     expectTheater: 'Middle East',
-    key: 'intelligence:advisories-bootstrap:v1',
-    enveloped: true, // seed-security-advisories.mjs:241 extraKeys + declareRecords
-    // Advisory shape: scripts/seed-security-advisories.mjs:170.
+    expectDetectedAt: (p) => Date.parse(p.history[0].timestamp),
+    key: 'relay:oref:history:v1',
+    enveloped: true, // ais-relay.cjs:1401 envelopeWrite
+    // OREF history shape: scripts/ais-relay.cjs:1352.
     payload: {
-      advisories: [{
-        title: 'Syria Travel Advisory',
-        link: 'https://travel.state.gov/syria',
-        pubDate: iso(3 * HOUR),
-        source: 'US State Dept',
-        sourceCountry: 'US',
-        level: 'do-not-travel',
-        country: 'Syria',
+      history: [{
+        timestamp: iso(3 * HOUR),
+        alerts: [{
+          id: '1-0-20260730120000',
+          cat: '1',
+          title: 'Missiles',
+          data: ['Tel Aviv', 'Ramat Gan'],
+        }],
       }],
+      historyCount24h: 2,
+      totalHistoryCount: 2,
+      activeAlertCount: 0,
+      persistedAt: iso(),
     },
   },
   {
@@ -265,7 +298,8 @@ const FIXTURES = [
   },
   {
     extractor: extractCyberEscalation,
-    expectTheater: 'Eastern Europe',
+    expectTheater: 'Global',
+    expectDetectedAt: (p) => p.threats[0].lastSeenAt,
     key: 'cyber:threats-bootstrap:v2',
     enveloped: true, // seed-cyber-threats.mjs:665 extraKeys + declareRecords
     // Threat shape: scripts/seed-cyber-threats.mjs:578 toProto.
@@ -276,6 +310,8 @@ const FIXTURES = [
         country: 'Ukraine',
         severity: 'CRITICALITY_LEVEL_CRITICAL',
         malwareFamily: 'Sandworm',
+        firstSeenAt: now - 3 * HOUR,
+        lastSeenAt: now - HOUR,
       }],
     },
   },
@@ -353,6 +389,7 @@ const FIXTURES = [
   {
     extractor: extractInfrastructureOutage,
     expectTheater: 'Middle East',
+    expectDetectedAt: (p) => p.outages[0].detectedAt,
     key: 'infra:outages:v1',
     enveloped: true, // seed-internet-outages.mjs:246 declareRecords
     // Outage shape: scripts/seed-internet-outages.mjs:111.
@@ -363,12 +400,14 @@ const FIXTURES = [
         country: 'Iran',
         region: '',
         severity: 'OUTAGE_SEVERITY_MAJOR',
+        endedAt: 0,
       }],
     },
   },
   {
     extractor: extractWildfireEscalation,
     expectTheater: 'Eastern Europe',
+    expectDetectedAt: (p) => p.fireDetections[0].detectedAt,
     key: 'wildfire:fires:v1',
     enveloped: true, // seed-fire-detections.mjs:121 declareRecords
     // Detection shape: scripts/seed-fire-detections.mjs:93. Five in one region
@@ -509,6 +548,170 @@ describe('every extractor fires on the shape its writer actually publishes', () 
       assert.deepEqual(extractor({ [key]: seedEnvelope(payload) }), []);
     });
   }
+});
+
+describe('newly readable sources preserve semantics and time', () => {
+  it('does not turn a high-probability ceasefire into forecast deterioration', () => {
+    assert.deepEqual(extractForecastDeterioration({
+      'forecast:predictions:v2': {
+        predictions: [{
+          id: 'ceasefire',
+          title: 'Will the Sudan conflict reach a ceasefire by Q3?',
+          region: 'Africa',
+          probability: 0.85,
+          trend: 'rising',
+        }],
+      },
+    }), []);
+  });
+
+  it('still emits a high-probability failed ceasefire as deterioration', () => {
+    const signals = extractForecastDeterioration({
+      'forecast:predictions:v2': {
+        predictions: [{
+          id: 'ceasefire-failure',
+          title: 'Will the Sudan ceasefire fail by Q3?',
+          region: 'Africa',
+          probability: 0.85,
+          trend: 'rising',
+        }],
+      },
+    });
+    assert.equal(signals.length, 1);
+  });
+
+  it('does not invert renewed ceasefires or resumed peace talks', () => {
+    for (const title of [
+      'Will the ceasefire agreement be renewed?',
+      'Will peace talks resume this quarter?',
+    ]) {
+      assert.deepEqual(extractForecastDeterioration({
+        'forecast:predictions:v2': {
+          predictions: [{ id: title, title, region: 'Africa', probability: 0.8 }],
+        },
+      }), []);
+    }
+  });
+
+  it('does treat resumed hostilities as deterioration', () => {
+    const signals = extractForecastDeterioration({
+      'forecast:predictions:v2': {
+        predictions: [{
+          id: 'hostilities-resume',
+          title: 'Will hostilities resume after the ceasefire?',
+          region: 'Africa',
+          probability: 0.8,
+        }],
+      },
+    });
+    assert.equal(signals.length, 1);
+  });
+
+  it('does not invert a forecast that renewed fighting will end', () => {
+    assert.deepEqual(extractForecastDeterioration({
+      'forecast:predictions:v2': {
+        predictions: [{
+          id: 'fighting-ends',
+          title: 'Will renewed fighting end this month?',
+          region: 'Africa',
+          probability: 0.8,
+        }],
+      },
+    }), []);
+  });
+
+  it('does not revive a week-old earthquake as a current critical signal', () => {
+    assert.deepEqual(extractEarthquakeSignificant({
+      'seismology:earthquakes:v1': {
+        earthquakes: [{
+          id: 'old-quake',
+          place: 'Japan',
+          magnitude: 7.2,
+          occurredAt: now - 6 * 24 * HOUR,
+        }],
+      },
+    }), []);
+  });
+
+  it('does not revive an outage that already ended', () => {
+    assert.deepEqual(extractInfrastructureOutage({
+      'infra:outages:v1': {
+        outages: [{
+          id: 'ended-outage',
+          country: 'Iran',
+          severity: 'OUTAGE_SEVERITY_TOTAL',
+          detectedAt: now - 9 * 24 * HOUR,
+          endedAt: now - 8 * 24 * HOUR,
+        }],
+      },
+    }), []);
+  });
+
+  it('maps every military surge theater id to a composite-compatible theater', () => {
+    const expected = {
+      'iran-theater': 'Middle East',
+      'taiwan-theater': 'East Asia',
+      'baltic-theater': 'Eastern Europe',
+      'blacksea-theater': 'Eastern Europe',
+      'korea-theater': 'East Asia',
+      'south-china-sea': 'East Asia',
+      'east-med-theater': 'Middle East',
+      'israel-gaza-theater': 'Middle East',
+      'yemen-redsea-theater': 'Red Sea',
+    };
+    for (const [theaterId, theater] of Object.entries(expected)) {
+      assert.equal(normalizeTheater(theaterId.replace(/-/g, ' ')), theater);
+    }
+  });
+
+  it('ranks military surges before applying the three-signal cap', () => {
+    const signals = extractMilitaryFlightSurge({
+      'military:surges:stale:v1': {
+        fetchedAt: now,
+        surges: [
+          { id: 'weak-1', theaterId: 'iran-theater', surgeType: 'fighter', surgeMultiple: 1.1, assessedAt: now },
+          { id: 'weak-2', theaterId: 'taiwan-theater', surgeType: 'fighter', surgeMultiple: 1.2, assessedAt: now },
+          { id: 'weak-3', theaterId: 'baltic-theater', surgeType: 'fighter', surgeMultiple: 1.3, assessedAt: now },
+          { id: 'strong', theaterId: 'yemen-redsea-theater', surgeType: 'fighter', surgeMultiple: 2.0, assessedAt: now },
+        ],
+      },
+    });
+    assert.equal(signals.length, 3);
+    assert.equal(signals[0].id, 'mil-surge:strong');
+  });
+
+  it('does not revive old wildfire or cyber records with the run clock', () => {
+    const old = now - 20 * 24 * HOUR;
+    assert.deepEqual(extractWildfireEscalation({
+      'wildfire:fires:v1': {
+        fireDetections: Array.from({ length: 5 }, (_, i) => ({
+          id: `old-fire-${i}`,
+          region: 'Ukraine',
+          possibleExplosion: true,
+          detectedAt: old,
+        })),
+      },
+    }), []);
+    assert.deepEqual(extractCyberEscalation({
+      'cyber:threats-bootstrap:v2': {
+        threats: [{
+          id: 'old-ioc',
+          country: 'Ukraine',
+          severity: 'CRITICALITY_LEVEL_CRITICAL',
+          firstSeenAt: old,
+          lastSeenAt: old,
+        }],
+      },
+    }), []);
+  });
+
+  it('does not treat travel advisories as kinetic OREF alerts', () => {
+    assert.deepEqual(extractOrefAlertCluster({
+      'intelligence:advisories-bootstrap:v1': {
+        advisories: [{ country: 'Syria', level: 'do-not-travel' }],
+      },
+    }), []);
+  });
 });
 
 describe('extractor registry stays covered', () => {

--- a/tests/cross-source-signals-envelope-reads.test.mjs
+++ b/tests/cross-source-signals-envelope-reads.test.mjs
@@ -1,4 +1,4 @@
-// Regression test for issue #5870: seed-cross-source-signals read its 20+ input
+// Regression test for issue #5870: seed-cross-source-signals read its source
 // keys with a bare JSON.parse and no envelope unwrap.
 //
 // Most of those keys are written by contract-mode seeders, which store
@@ -11,18 +11,52 @@
 // The existing suites could not catch this: their vm harness deleted
 // readAllSourceKeys and fed extractors hand-built bare fixtures, i.e. the
 // pre-envelope world, at exactly the seam where the defect lives.
+//
+// Every fixture below is annotated with the writer file:line it was derived
+// from. Enveloped fixtures additionally assert that the pre-fix shape (the raw
+// envelope handed straight to the extractor) produces nothing, so the bug
+// itself stays pinned and cannot be reintroduced silently.
 
 import { after, before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { SOURCE_KEYS, readAllSourceKeys } from '../scripts/seed-cross-source-signals.mjs';
+import {
+  EXTRACTORS,
+  SOURCE_KEYS,
+  extractCommodityShock,
+  extractCyberEscalation,
+  extractDisplacementSurge,
+  extractEarthquakeSignificant,
+  extractForecastDeterioration,
+  extractGpsJamming,
+  extractInfrastructureOutage,
+  extractMarketStress,
+  extractMediaToneDeterioration,
+  extractMilitaryFlightSurge,
+  extractOrefAlertCluster,
+  extractRadiationAnomaly,
+  extractRegulatoryAction,
+  extractRiskScoreSpike,
+  extractSanctionsSurge,
+  extractShippingDisruption,
+  extractThermalSpike,
+  extractUnrestSurge,
+  extractVixSpike,
+  extractWeatherExtreme,
+  extractWildfireEscalation,
+  readAllSourceKeys,
+} from '../scripts/seed-cross-source-signals.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
 import { unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
 
 const REDIS_URL = 'https://cross-source-signals.test.upstash.io';
+const HOUR = 3600 * 1000;
+const now = Date.now();
+const iso = (msAgo = 0) => new Date(now - msAgo).toISOString();
 
 function seedEnvelope(data) {
   return {
     _seed: {
-      fetchedAt: Date.now(),
+      fetchedAt: now,
       sourceVersion: 'test-v1',
       schemaVersion: 1,
       recordCount: 1,
@@ -32,9 +66,10 @@ function seedEnvelope(data) {
 }
 
 // Drive a value through exactly what readAllSourceKeys does to a Redis string,
-// so a fixture can never accidentally test a shape the reader does not produce.
-function asReadByTheSeeder(redisValue) {
-  return unwrapEnvelope(JSON.parse(JSON.stringify(redisValue))).data;
+// so a fixture can never accidentally exercise a shape the reader cannot
+// produce.
+function asReadByTheSeeder(storedValue) {
+  return unwrapEnvelope(JSON.parse(JSON.stringify(storedValue))).data;
 }
 
 describe('readAllSourceKeys envelope handling', () => {
@@ -86,10 +121,7 @@ describe('readAllSourceKeys envelope handling', () => {
   // unwrapping it would hand the tone extractor a bare array and kill the one
   // signal path that works today.
   it('does not unwrap a legacy payload that has its own top-level data field', async () => {
-    const tone = {
-      data: [{ date: '2026-07-20', value: -2.4 }],
-      fetchedAt: new Date().toISOString(),
-    };
+    const tone = { data: [{ date: '2026-07-20', value: -2.4 }], fetchedAt: iso() };
     stubPipeline({ 'gdelt:intel:tone:military': JSON.stringify(tone) });
 
     const data = await readAllSourceKeys();
@@ -116,6 +148,402 @@ describe('readAllSourceKeys envelope handling', () => {
     const data = await readAllSourceKeys();
     assert.deepEqual(Object.keys(data), []);
   });
+
+  it('fetches the stale military flights key the extractor already falls back to', () => {
+    assert.ok(SOURCE_KEYS.includes('military:flights:stale:v1'));
+  });
 });
 
-export { asReadByTheSeeder, seedEnvelope };
+// ── Per-extractor fixture matrix ─────────────────────────────────────────────
+// `enveloped` mirrors how the writer actually stores the key: true when its
+// seeder passes declareRecords to runSeed (contract mode, _seed-utils.mjs:1758),
+// false for the keys still written with a raw SET.
+
+const FIXTURES = [
+  {
+    extractor: extractThermalSpike,
+    expectTheater: 'Eastern Europe',
+    expectDetectedAt: (p) => Date.parse(p.clusters[0].lastDetectedAt),
+    key: 'thermal:escalation:v1',
+    enveloped: true, // seed-thermal-escalation.mjs:53 declareRecords
+    // Cluster shape: scripts/lib/thermal-escalation.mjs:308.
+    payload: {
+      clusters: [{
+        id: 'ua:cell-49-36:2026073012',
+        countryCode: 'UA',
+        countryName: 'Ukraine',
+        regionLabel: 'Ukraine',
+        status: 'THERMAL_STATUS_SPIKE',
+        zScore: 3.1,
+        totalFrp: 210.4,
+        firstDetectedAt: iso(6 * HOUR),
+        lastDetectedAt: iso(2 * HOUR),
+      }],
+    },
+  },
+  {
+    extractor: extractGpsJamming,
+    expectTheater: 'Eastern Europe',
+    expectDetectedAt: (p) => Date.parse(p.fetchedAt),
+    key: 'intelligence:gpsjam:v2',
+    enveloped: false, // fetch-gpsjam.mjs writes with a raw SET
+    // Hex shape: scripts/_gpsjam-parse.mjs:83.
+    payload: {
+      hexes: [{ level: 'high', region: 'Eastern Europe', pct: 24.5, npAvg: 0.3 }],
+      fetchedAt: iso(HOUR),
+    },
+  },
+  {
+    extractor: extractMilitaryFlightSurge,
+    expectTheater: 'Eastern Europe',
+    expectDetectedAt: (p) => p.fetchedAt,
+    key: 'military:flights:stale:v1',
+    enveloped: false, // seed-military-flights.mjs:1328 raw redisSet
+    // Flight shape: scripts/seed-military-flights.mjs:1099 + classify* spread.
+    payload: {
+      flights: Array.from({ length: 5 }, (_, i) => ({
+        id: `opensky-ae${i}`,
+        callsign: `RSD${i}`,
+        operator: 'vks',
+        operatorCountry: 'Russia',
+        aircraftType: 'bomber',
+        lastSeenMs: now - 5 * 60_000,
+      })),
+      fetchedAt: now,
+      stats: { total: 5, byType: { bomber: 5 } },
+    },
+  },
+  {
+    extractor: extractUnrestSurge,
+    expectTheater: 'Middle East',
+    key: 'unrest:events:v1',
+    enveloped: true, // seed-unrest-events.mjs:525 declareRecords
+    // Event shape: scripts/seed-unrest-events.mjs:211.
+    payload: {
+      events: Array.from({ length: 3 }, (_, i) => ({
+        id: `acled-${i}`,
+        city: 'Beirut',
+        country: 'Lebanon',
+        region: '',
+        location: { latitude: 33.88, longitude: 35.49 },
+        occurredAt: now - (i + 1) * HOUR,
+      })),
+    },
+  },
+  {
+    extractor: extractOrefAlertCluster,
+    expectTheater: 'Middle East',
+    key: 'intelligence:advisories-bootstrap:v1',
+    enveloped: true, // seed-security-advisories.mjs:241 extraKeys + declareRecords
+    // Advisory shape: scripts/seed-security-advisories.mjs:170.
+    payload: {
+      advisories: [{
+        title: 'Syria Travel Advisory',
+        link: 'https://travel.state.gov/syria',
+        pubDate: iso(3 * HOUR),
+        source: 'US State Dept',
+        sourceCountry: 'US',
+        level: 'do-not-travel',
+        country: 'Syria',
+      }],
+    },
+  },
+  {
+    extractor: extractVixSpike,
+    expectTheater: 'Global Markets',
+    key: 'market:stocks-bootstrap:v1',
+    enveloped: true, // seed-market-quotes.mjs:121 declareRecords
+    // Quote shape: scripts/seed-market-quotes.mjs:64.
+    payload: { quotes: [{ symbol: '^VIX', display: 'VIX', price: 32.4, change: 4.1 }] },
+  },
+  {
+    extractor: extractCommodityShock,
+    expectTheater: 'Persian Gulf',
+    key: 'market:commodities-bootstrap:v1',
+    enveloped: true, // seed-commodity-quotes.mjs:230 declareRecords
+    payload: { quotes: [{ symbol: 'CL=F', display: 'Crude Oil', price: 91.2, change: 7.4 }] },
+  },
+  {
+    extractor: extractCyberEscalation,
+    expectTheater: 'Eastern Europe',
+    key: 'cyber:threats-bootstrap:v2',
+    enveloped: true, // seed-cyber-threats.mjs:665 extraKeys + declareRecords
+    // Threat shape: scripts/seed-cyber-threats.mjs:578 toProto.
+    payload: {
+      threats: [{
+        id: 'otx-1',
+        type: 'CYBER_THREAT_TYPE_APT',
+        country: 'Ukraine',
+        severity: 'CRITICALITY_LEVEL_CRITICAL',
+        malwareFamily: 'Sandworm',
+      }],
+    },
+  },
+  {
+    extractor: extractShippingDisruption,
+    expectTheater: 'Global',
+    key: 'supply_chain:shipping:v2',
+    enveloped: true, // seed-supply-chain-trade.mjs:796 declareRecords
+    // Index shape: scripts/seed-supply-chain-trade.mjs:129.
+    payload: {
+      indices: [{
+        indexId: 'WCIDCOMP',
+        name: 'Drewry World Container Index',
+        currentValue: 3820,
+        previousValue: 3100,
+        changePct: 23.2,
+        unit: 'USD/FEU',
+        history: [],
+        spikeAlert: true,
+      }],
+      fetchedAt: iso(),
+      upstreamUnavailable: false,
+    },
+  },
+  {
+    extractor: extractSanctionsSurge,
+    expectTheater: 'Eastern Europe',
+    key: 'sanctions:pressure:v1',
+    enveloped: true, // seed-sanctions-pressure.mjs:550 declareRecords
+    payload: {
+      totalCount: 412,
+      newEntryCount: 12,
+      countries: [{ countryName: 'Russia', count: 180 }],
+    },
+  },
+  {
+    extractor: extractEarthquakeSignificant,
+    expectTheater: 'East Asia',
+    expectDetectedAt: (p) => p.earthquakes[0].occurredAt,
+    key: 'seismology:earthquakes:v1',
+    enveloped: true, // seed-earthquakes.mjs:98 declareRecords
+    // Quake shape: scripts/seed-earthquakes.mjs:79.
+    payload: {
+      earthquakes: [{
+        id: 'us7000abcd',
+        place: '120km E of Honshu, Japan',
+        magnitude: 7.2,
+        occurredAt: now - 4 * HOUR,
+      }],
+    },
+  },
+  {
+    extractor: extractRadiationAnomaly,
+    expectTheater: 'East Asia',
+    expectDetectedAt: (p) => p.observations[0].observedAt,
+    key: 'radiation:observations:v1',
+    enveloped: true, // seed-radiation-watch.mjs:465 declareRecords
+    // Observation shape: scripts/seed-radiation-watch.mjs:172.
+    payload: {
+      observations: [{
+        id: 'jp-fukushima-1',
+        anchorId: 'jp-fukushima',
+        locationName: 'Fukushima',
+        country: 'Japan',
+        value: 48.2,
+        unit: 'nSv/h',
+        observedAt: now - 2 * HOUR,
+        baselineValue: 30.1,
+        delta: 18.1,
+        zScore: 3.4,
+        severity: 'RADIATION_SEVERITY_SPIKE',
+      }],
+    },
+  },
+  {
+    extractor: extractInfrastructureOutage,
+    expectTheater: 'Middle East',
+    key: 'infra:outages:v1',
+    enveloped: true, // seed-internet-outages.mjs:246 declareRecords
+    // Outage shape: scripts/seed-internet-outages.mjs:111.
+    payload: {
+      outages: [{
+        id: 'ioda-1',
+        detectedAt: now - 90 * 60_000,
+        country: 'Iran',
+        region: '',
+        severity: 'OUTAGE_SEVERITY_MAJOR',
+      }],
+    },
+  },
+  {
+    extractor: extractWildfireEscalation,
+    expectTheater: 'Eastern Europe',
+    key: 'wildfire:fires:v1',
+    enveloped: true, // seed-fire-detections.mjs:121 declareRecords
+    // Detection shape: scripts/seed-fire-detections.mjs:93. Five in one region
+    // clears the per-theater floor.
+    payload: {
+      fireDetections: Array.from({ length: 5 }, (_, i) => ({
+        id: `48.1-37.${i}-2026-07-30-0312`,
+        location: { latitude: 48.1, longitude: 37.5 + i / 10 },
+        brightness: 392.4,
+        frp: 145.2,
+        confidence: 'FIRE_CONFIDENCE_HIGH',
+        satellite: 'N',
+        detectedAt: now - 3 * HOUR,
+        region: 'Ukraine',
+        dayNight: 'D',
+        possibleExplosion: true,
+      })),
+      pagination: undefined,
+    },
+  },
+  {
+    extractor: extractForecastDeterioration,
+    expectTheater: 'Eastern Europe',
+    key: 'forecast:predictions:v2',
+    enveloped: true, // seed-forecasts.mjs:17260 declareRecords
+    payload: {
+      predictions: [{
+        id: 'fc-1',
+        title: 'Escalation along the Black Sea corridor',
+        region: 'Eastern Europe',
+        probability: 0.72,
+        trend: 'rising',
+      }],
+    },
+  },
+  {
+    extractor: extractMarketStress,
+    expectTheater: 'Global Markets',
+    key: 'market:stocks-bootstrap:v1',
+    enveloped: true, // seed-market-quotes.mjs:121 declareRecords
+    payload: { quotes: [{ symbol: '^GSPC', display: 'S&P 500', price: 5120, change: -3.4 }] },
+  },
+  {
+    extractor: extractWeatherExtreme,
+    expectTheater: 'North America',
+    key: 'weather:alerts:v1',
+    enveloped: true, // seed-weather-alerts.mjs:67 declareRecords
+    // Alert shape: scripts/seed-weather-alerts.mjs:44.
+    payload: {
+      alerts: [{
+        id: 'nws-1',
+        event: 'Tornado Warning',
+        severity: 'Extreme',
+        areaDesc: 'Kern County, CA; Tulare County, CA',
+      }],
+    },
+  },
+  {
+    extractor: extractMediaToneDeterioration,
+    expectTheater: 'Global',
+    key: 'gdelt:intel:tone:military',
+    enveloped: false, // seed-gdelt-intel.mjs:613 writeExtraKey without envelopeMeta
+    payload: {
+      data: [
+        { date: iso(72 * HOUR), value: -0.5 },
+        { date: iso(36 * HOUR), value: -1.2 },
+        { date: iso(HOUR), value: -2.4 },
+      ],
+      fetchedAt: iso(HOUR),
+    },
+  },
+  {
+    extractor: extractRiskScoreSpike,
+    // 'UA' is an ISO2 code with no theater mapping — pinned so the known
+    // limitation is visible rather than silently drifting.
+    expectTheater: 'UA',
+    key: CII_RISK_SCORE_CACHE_KEYS.stale,
+    enveloped: false, // written by get-risk-scores.ts via setCachedJson, not a seeder
+    payload: {
+      ciiScores: [{ region: 'UA', combinedScore: 84.2, trend: 'TREND_DIRECTION_RISING' }],
+      degraded: false,
+      stale: true,
+    },
+  },
+  {
+    extractor: extractRegulatoryAction,
+    expectTheater: 'Global Markets',
+    expectDetectedAt: (p) => Date.parse(p.actions[0].publishedAt),
+    key: 'regulatory:actions:v1',
+    enveloped: false, // seed-regulatory-actions.mjs:311 runSeed without declareRecords
+    payload: {
+      actions: [{
+        id: 'sec-1',
+        agency: 'SEC',
+        title: 'SEC Charges Issuer',
+        publishedAt: iso(2 * HOUR),
+        tier: 'high',
+      }],
+      recordCount: 1,
+    },
+  },
+];
+
+// extractDisplacementSurge is deliberately absent from FIXTURES: its key
+// publishes an annual UNHCR stock with no flow field, so the extractor is
+// documented-silent rather than fixed. It is pinned separately below.
+const INTENTIONALLY_SILENT = new Set([extractDisplacementSurge]);
+
+describe('every extractor fires on the shape its writer actually publishes', () => {
+  for (const { extractor, key, enveloped, payload, expectTheater, expectDetectedAt } of FIXTURES) {
+    it(`${extractor.name} fires on a ${enveloped ? 'contract-mode' : 'legacy bare'} ${key}`, () => {
+      const stored = enveloped ? seedEnvelope(payload) : payload;
+      const signals = extractor({ [key]: asReadByTheSeeder(stored) });
+      assert.ok(signals.length >= 1, `${extractor.name} produced no signal`);
+      assert.ok(signals.every((s) => Number.isFinite(s.severityScore) && s.severityScore > 0));
+      assert.ok(signals.every((s) => Number.isFinite(s.detectedAt) && s.detectedAt > 0));
+
+      // Pinned rather than "non-empty": a theater that quietly collapses to
+      // 'Global' is how the military-flight signal sat outside every composite,
+      // and only an exact assertion catches that.
+      assert.equal(signals[0].theater, expectTheater);
+
+      // Only asserted where the extractor sources its stamp from the payload.
+      // Without this, reverting to a field the writer never published still
+      // passes: detectedAt just falls back to the run clock.
+      if (expectDetectedAt) {
+        assert.equal(signals[0].detectedAt, expectDetectedAt(payload),
+          `${extractor.name} did not carry the timestamp its payload published`);
+      }
+    });
+  }
+
+  // The bug itself, pinned: before the unwrap the extractors were handed the
+  // envelope, and this is what that produced.
+  for (const { extractor, key, enveloped, payload } of FIXTURES.filter((f) => f.enveloped)) {
+    it(`${extractor.name} produces nothing from the raw envelope (the pre-fix shape)`, () => {
+      void enveloped;
+      assert.deepEqual(extractor({ [key]: seedEnvelope(payload) }), []);
+    });
+  }
+});
+
+describe('extractor registry stays covered', () => {
+  it('every registered extractor has a fixture or a documented reason not to', () => {
+    const covered = new Set([...FIXTURES.map((f) => f.extractor), ...INTENTIONALLY_SILENT]);
+    const uncovered = EXTRACTORS.filter((e) => !covered.has(e)).map((e) => e.name);
+    assert.deepEqual(uncovered, []);
+  });
+
+  it('every fixture key is registered in SOURCE_KEYS', () => {
+    const unregistered = FIXTURES.map((f) => f.key).filter((key) => !SOURCE_KEYS.includes(key));
+    assert.deepEqual(unregistered, []);
+  });
+
+  it('the media-tone fallback key is gone now that the fallback is gone', () => {
+    assert.equal(SOURCE_KEYS.includes('intelligence:gdelt-intel:v1'), false);
+  });
+});
+
+describe('extractDisplacementSurge is intentionally silent', () => {
+  // displacement:summary:v1:<year> publishes summary.countries[] — an annual
+  // UNHCR stock with no flow, delta or trend field (seed-displacement-summary.mjs:175).
+  // A surge is not derivable from it, so the extractor stays silent rather than
+  // firing off an invented totalDisplaced threshold. See #5870.
+  it('emits nothing for a realistic annual stock payload', () => {
+    const payload = {
+      summary: {
+        year: 2026,
+        globalTotals: { refugees: 43_000_000, asylumSeekers: 6_900_000, idps: 68_000_000, stateless: 4_400_000, total: 122_300_000 },
+        countries: [{ code: 'SYR', name: 'Syria', refugees: 6_400_000, idps: 7_200_000, totalDisplaced: 13_600_000 }],
+        topFlows: [],
+      },
+    };
+    assert.deepEqual(extractDisplacementSurge({
+      [`displacement:summary:v1:${new Date().getFullYear()}`]: asReadByTheSeeder(seedEnvelope(payload)),
+    }), []);
+  });
+});

--- a/tests/cross-source-signals-regulatory.test.mjs
+++ b/tests/cross-source-signals-regulatory.test.mjs
@@ -1,36 +1,18 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import vm from 'node:vm';
-import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
+import {
+  BASE_WEIGHT,
+  EXTRACTORS,
+  SOURCE_KEYS,
+  TYPE_CATEGORY,
+  detectCompositeEscalation,
+  extractRegulatoryAction,
+  scoreTier,
+} from '../scripts/seed-cross-source-signals.mjs';
 
 function normalize(value) {
   return JSON.parse(JSON.stringify(value));
 }
-
-const seedSrc = readFileSync('scripts/seed-cross-source-signals.mjs', 'utf8');
-
-const pureSrc = seedSrc
-  .replace(/^import\s.*$/gm, '')
-  .replace(/loadEnvFile\([^)]+\);\r?\n/, '')
-  .replace(/async function readAllSourceKeys[\s\S]*?\r?\n}\r?\n\r?\n\/\/ ── Signal extractors/m, '// readAllSourceKeys removed for unit test\n\n// ── Signal extractors')
-  .replace(/runSeed\('intelligence'[\s\S]*$/m, '')
-  // Contract migration added `export function declareRecords`; vm.runInContext
-  // cannot execute ESM export syntax. Strip the keyword so the function
-  // body still evaluates as a plain declaration.
-  .replace(/^export\s+(function\s+declareRecords)/m, '$1');
-
-const ctx = vm.createContext({ console, Date, Math, Number, Array, Map, Set, String, RegExp, CII_RISK_SCORE_CACHE_KEYS });
-vm.runInContext(`${pureSrc}\n;globalThis.__exports = { SOURCE_KEYS, TYPE_CATEGORY, BASE_WEIGHT, scoreTier, extractRegulatoryAction, detectCompositeEscalation };`, ctx);
-
-const {
-  SOURCE_KEYS,
-  TYPE_CATEGORY,
-  BASE_WEIGHT,
-  scoreTier,
-  extractRegulatoryAction,
-  detectCompositeEscalation,
-} = ctx.__exports;
 
 describe('source registration', () => {
   it('adds the regulatory seed key to SOURCE_KEYS', () => {
@@ -43,7 +25,7 @@ describe('source registration', () => {
   });
 
   it('registers the extractor in the extractor list', () => {
-    assert.match(seedSrc, /extractRegulatoryAction,/);
+    assert.ok(EXTRACTORS.includes(extractRegulatoryAction));
   });
 });
 

--- a/tests/cross-source-signals-tone-staleness.test.mjs
+++ b/tests/cross-source-signals-tone-staleness.test.mjs
@@ -8,7 +8,11 @@
 // week-old declining trend would keep emitting "media tone deterioration"
 // cross-source signals stamped as freshly detected for days. The extractor
 // must skip payloads it cannot date or that are older than the signal-grade
-// window, falling through to the bundled-canonical fallback.
+// window.
+//
+// (#5870 removed the bundled-canonical fallback this used to fall through to:
+// it read topic.avgTone/tone, which intelligence:gdelt-intel:v1 has never
+// published, so it could not fire even once the envelope was unwrapped.)
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/cross-source-signals-tone-staleness.test.mjs
+++ b/tests/cross-source-signals-tone-staleness.test.mjs
@@ -12,23 +12,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import vm from 'node:vm';
-import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
-
-const seedSrc = readFileSync('scripts/seed-cross-source-signals.mjs', 'utf8');
-
-const pureSrc = seedSrc
-  .replace(/^import\s.*$/gm, '')
-  .replace(/loadEnvFile\([^)]+\);\r?\n/, '')
-  .replace(/async function readAllSourceKeys[\s\S]*?\r?\n}\r?\n\r?\n\/\/ ── Signal extractors/m, '// readAllSourceKeys removed for unit test\n\n// ── Signal extractors')
-  .replace(/runSeed\('intelligence'[\s\S]*$/m, '')
-  .replace(/^export\s+(function\s+declareRecords)/m, '$1');
-
-const ctx = vm.createContext({ console, Date, Math, Number, Array, Map, Set, String, RegExp, CII_RISK_SCORE_CACHE_KEYS });
-vm.runInContext(`${pureSrc}\n;globalThis.__exports = { extractMediaToneDeterioration };`, ctx);
-
-const { extractMediaToneDeterioration } = ctx.__exports;
+import { extractMediaToneDeterioration } from '../scripts/seed-cross-source-signals.mjs';
 
 const DECLINING_SERIES = [
   { date: '2026-07-18', value: -0.5 },
@@ -81,9 +65,7 @@ describe('extractMediaToneDeterioration trend-span guard (#5863 review)', () => 
     const signals = extractMediaToneDeterioration({
       'gdelt:intel:tone:military': { data: dense, fetchedAt: new Date().toISOString() },
     });
-    // Length, not deepEqual: the extractor runs in a vm realm, so its arrays
-    // have a different prototype and deepStrictEqual([], []) fails.
-    assert.equal(signals.length, 0, '45 minutes of small-sample tone is not a deterioration trend');
+    assert.deepEqual(signals, [], '45 minutes of small-sample tone is not a deterioration trend');
   });
 
   it('still emits when a dense series covers a real multi-day decline', () => {

--- a/tests/cross-source-signals-wildfire.test.mjs
+++ b/tests/cross-source-signals-wildfire.test.mjs
@@ -1,0 +1,113 @@
+// Acceptance criterion 2 of issue #5870: extractWildfireEscalation must produce
+// a signal from a realistic wildfire:fires:v1 payload.
+//
+// It could not, for three independent reasons stacked on one key:
+//   1. the key is contract-mode, so the extractor was handed { _seed, data };
+//   2. it read `payload.fires`, but seed-fire-detections.mjs:118 publishes
+//      `fireDetections`;
+//   3. it read `f.radiativePower > 5000` and `f.severity === 'extreme'`, but a
+//      detection carries `frp` (MW, seed-fire-detections.mjs:96) and has no
+//      severity field at all — and 5000 MW is two orders above what FIRMS
+//      reports for these detections.
+//
+// Only the `brightness > 400` clause was ever correct, which is why the signal
+// looked plausible in review and produced nothing in production.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractWildfireEscalation } from '../scripts/seed-cross-source-signals.mjs';
+import { unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
+
+const KEY = 'wildfire:fires:v1';
+const now = Date.now();
+
+// Field-for-field the record seed-fire-detections.mjs:93-107 builds from a
+// FIRMS VIIRS row.
+function detection({ index = 0, region = 'Ukraine', brightness = 366.1, frp = 42.7 }) {
+  return {
+    id: `48.${index}-37.5-2026-07-30-0312`,
+    location: { latitude: 48 + index / 10, longitude: 37.5 },
+    brightness,
+    frp,
+    confidence: 'FIRE_CONFIDENCE_HIGH',
+    satellite: 'N',
+    detectedAt: now - 3 * 3600 * 1000,
+    region,
+    dayNight: 'D',
+    // frp > 80 && brightness > 380 — the writer's own significance flag.
+    possibleExplosion: frp > 80 && brightness > 380,
+  };
+}
+
+// What runSeed stores for a contract-mode key (_seed-utils.mjs:499), read back
+// the way readAllSourceKeys now reads it.
+function storedAsSeeded(payload) {
+  const envelope = {
+    _seed: { fetchedAt: now, sourceVersion: 'firms-viirs-v1', schemaVersion: 1, recordCount: payload.fireDetections.length },
+    data: payload,
+  };
+  return unwrapEnvelope(JSON.parse(JSON.stringify(envelope))).data;
+}
+
+describe('extractWildfireEscalation on a realistic wildfire:fires:v1 payload', () => {
+  it('fires on a cluster of explosion-grade detections in one monitored region', () => {
+    const payload = {
+      fireDetections: Array.from({ length: 6 }, (_, i) =>
+        detection({ index: i, region: 'Ukraine', brightness: 392.4, frp: 145.2 })),
+      pagination: undefined,
+    };
+
+    const signals = extractWildfireEscalation({ [KEY]: storedAsSeeded(payload) });
+
+    assert.equal(signals.length, 1);
+    assert.equal(signals[0].type, 'CROSS_SOURCE_SIGNAL_TYPE_WILDFIRE_ESCALATION');
+    assert.equal(signals[0].theater, 'Eastern Europe');
+    assert.match(signals[0].summary, /6 extreme thermal detections in Eastern Europe/);
+    assert.equal(signals[0].severity, 'CROSS_SOURCE_SIGNAL_SEVERITY_MEDIUM');
+  });
+
+  it('fires on brightness alone, the one clause that was already correct', () => {
+    const payload = {
+      fireDetections: Array.from({ length: 6 }, (_, i) =>
+        // frp below the explosion flag, brightness above 400.
+        detection({ index: i, region: 'Saudi Arabia', brightness: 415.8, frp: 24.1 })),
+    };
+
+    const signals = extractWildfireEscalation({ [KEY]: storedAsSeeded(payload) });
+    assert.equal(signals.length, 1);
+    assert.equal(signals[0].theater, 'Middle East');
+  });
+
+  it('stays silent on ordinary agricultural burns', () => {
+    const payload = {
+      fireDetections: Array.from({ length: 20 }, (_, i) =>
+        detection({ index: i, region: 'Turkey', brightness: 341.2, frp: 12.5 })),
+    };
+
+    assert.deepEqual(extractWildfireEscalation({ [KEY]: storedAsSeeded(payload) }), []);
+  });
+
+  it('holds the per-region floor: four detections are not an escalation', () => {
+    const payload = {
+      fireDetections: Array.from({ length: 4 }, (_, i) =>
+        detection({ index: i, region: 'Ukraine', brightness: 392.4, frp: 145.2 })),
+    };
+
+    assert.deepEqual(extractWildfireEscalation({ [KEY]: storedAsSeeded(payload) }), []);
+  });
+
+  it('produces nothing from the envelope itself, which is what production saw', () => {
+    const payload = {
+      fireDetections: Array.from({ length: 6 }, (_, i) =>
+        detection({ index: i, region: 'Ukraine', brightness: 392.4, frp: 145.2 })),
+    };
+    const envelope = { _seed: { fetchedAt: now }, data: payload };
+
+    assert.deepEqual(extractWildfireEscalation({ [KEY]: envelope }), []);
+  });
+
+  it('tolerates a payload with no detections', () => {
+    assert.deepEqual(extractWildfireEscalation({ [KEY]: storedAsSeeded({ fireDetections: [] }) }), []);
+    assert.deepEqual(extractWildfireEscalation({}), []);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5870.

`readAllSourceKeys()` bare-parsed every value it read:

```js
try { data[SOURCE_KEYS[i]] = JSON.parse(raw); } catch { /* skip malformed */ }
```

Most of those keys are written by contract-mode seeders, which store `{ _seed, data }` (`scripts/_seed-utils.mjs:499`). So `d['<key>']` was the envelope, `payload.clusters` / `payload.quotes` / `payload.threats` were `undefined`, the `Array.isArray(...)` guard on the next line was `false`, and the extractor returned `[]`. No throw, so the `try/catch` in the aggregator never logged. The seeder still exited 0 and published a shorter array.

Auditing all of it turned up a second, independent layer: **even after a correct unwrap, most extractors read field names and enum spellings their writer has never published.** `extractWildfireEscalation` is the clearest case — it filters on `f.radiativePower > 5000 || f.severity === 'extreme'` against a payload whose detections carry `frp` and have no `severity` field at all, with FRP reported in MW (the writer's own significance threshold is 80, not 5000). Only its `brightness > 400` clause was ever correct, which is why the code reads plausibly and produces nothing.

So this is three fixes on one seeder: unwrap the envelope, align every extractor with its writer, and make the suite able to see both.

## The audit

The issue asks for all source keys to be checked against their writers, so here is the result. "Enveloped" = the writer passes `declareRecords` to `runSeed`, which is what turns on contract mode (`_seed-utils.mjs:1758`).

| Extractor | Key | Enveloped | Verdict |
|---|---|---|---|
| `extractThermalSpike` | `thermal:escalation:v1` | yes | fixed — `THERMAL_STATUS_*` enum, `zScore`, `regionLabel`, ISO `lastDetectedAt` |
| `extractGpsJamming` | `intelligence:gpsjam:v2` | no | fixed — `fetchedAt` is an ISO string, so `safeNum()` read 0 |
| `extractMilitaryFlightSurge` | `military:flights:{v1,stale:v1}` | no | fixed — the record has `operatorCountry`, not `region`/`country`/`origin` |
| `extractUnrestSurge` | `unrest:events:v1` | yes | fixed — `occurredAt`; `location` is a coordinate object |
| `extractOrefAlertCluster` | `intelligence:advisories-bootstrap:v1` | yes | fixed — the level slug is `do-not-travel`, hyphenated |
| `extractVixSpike` | `market:stocks-bootstrap:v1` | yes | correct as written — unwrap alone revives it |
| `extractCommodityShock` | `market:commodities-bootstrap:v1` | yes | correct as written |
| `extractCyberEscalation` | `cyber:threats-bootstrap:v2` | yes | fixed — `CRITICALITY_LEVEL_*`, and `country` (no `targetCountry`) |
| `extractShippingDisruption` | `supply_chain:shipping:v2` | yes | rebased — the key publishes rate indices, not routes |
| `extractSanctionsSurge` | `sanctions:pressure:v1` | yes | correct as written |
| `extractEarthquakeSignificant` | `seismology:earthquakes:v1` | yes | fixed — `occurredAt` |
| `extractRadiationAnomaly` | `radiation:observations:v1` | yes | fixed — `RADIATION_SEVERITY_*`, `observedAt` |
| `extractInfrastructureOutage` | `infra:outages:v1` | yes | fixed — `OUTAGE_SEVERITY_TOTAL/MAJOR`; no `affectedUsers`, no `CRITICAL` tier |
| `extractWildfireEscalation` | `wildfire:fires:v1` | yes | fixed — `fireDetections`, `frp`, `possibleExplosion` |
| `extractDisplacementSurge` | `displacement:summary:v1:<year>` | yes | **documented, not fixed** — see below |
| `extractForecastDeterioration` | `forecast:predictions:v2` | yes | fixed — two dead clauses removed |
| `extractMarketStress` | `market:stocks-bootstrap:v1` | yes | correct as written |
| `extractWeatherExtreme` | `weather:alerts:v1` | yes | fixed — title-cased severity, `areaDesc`, no `category` |
| `extractMediaToneDeterioration` | `gdelt:intel:tone:*` | no | primary path correct; dead fallback removed |
| `extractRiskScoreSpike` | `risk:scores:sebuf:stale:v8` | no | correct as written; ISO2 `region` limitation documented in place |
| `extractRegulatoryAction` | `regulatory:actions:v1` | no | correct as written |

`military:flights:stale:v1` is now registered in `SOURCE_KEYS`. `extractMilitaryFlightSurge` already falls back to it, but it was never fetched, so `d['military:flights:stale:v1']` was always `undefined`. The writer publishes the same payload to both keys (`seed-military-flights.mjs:1327`) with `LIVE_TTL = 600` against this seeder's 15-minute cadence, so the live key is absent on most runs and the stale key is the one that carries the data. `seed-correlation.mjs:14` registers the same pair.

`intelligence:gdelt-intel:v1` is dropped from `SOURCE_KEYS`: its only reader was the media-tone fallback, which read `topic.avgTone || topic.tone` against topic objects shaped `{ id, articles, fetchedAt, attemptedAt, _tone, _vol }` (`seed-gdelt-intel.mjs:438`). `safeNum()` returned 0, `0 > -3` skipped every topic, so the branch could not fire even after the unwrap. Rebuilding it on `topic._tone` would mean re-deriving the trend and staleness rules the per-topic path already implements under #5478/#5863 review, so it is removed rather than half-restored.

## Why `JSON.parse` stays outside `unwrapEnvelope`

`unwrapEnvelope` accepts a raw string, so `unwrapEnvelope(raw).data` would have been shorter. It also returns that string as `data` when the parse fails, which would register a malformed value as a found key and inflate the `Found N/M source keys populated` line. Parsing first preserves the existing skip-malformed behaviour exactly, and `unwrapEnvelope` short-circuits its own string branch when handed an object, so nothing is parsed twice.

Legacy safety is structural rather than by-key: `unwrapEnvelope` only unwraps when `_seed.fetchedAt` is a number (`_seed-envelope-source.mjs:59`). The one live payload that looks like a half-envelope is `gdelt:intel:tone:*` — a top-level `data` array plus a `fetchedAt`, no `_seed` — and there is a dedicated test pinning that it passes through untouched, since unwrapping it would kill the one tone path that works today.

## Design decisions for maintainer review

These are calibration questions, not read fixes. I took the conservative option in each case and left the alternative here rather than deciding it in code.

1. **Displacement is left silent.** `displacement:summary:v1:<year>` publishes an annual UNHCR *stock* — `summary.countries[]` with `refugees`/`idps`/`totalDisplaced` (`seed-displacement-summary.mjs:175`) — and carries no flow, delta or trend field anywhere. The extractor read `crises[].newDisplacements` and `.trend`, which the key has never published. This is not a rename away from working: a surge is a flow, and picking a `totalDisplaced` cutoff to stand in for one would invent a calibration rather than repair a read. It returns `[]` with the reason in place. The alternative is to redefine the signal as stock-level and rename it; happy to do that here or in a follow-up if you prefer.
2. **Wildfire threshold.** Rather than rescale `frp > 5000`, this uses `possibleExplosion` — the significance flag the writer itself publishes (`frp > 80 && brightness > 380`). The per-theater `count < 5` floor and the `/50` score divisor are untouched, but both were calibrated against a shape that never produced anything, so they have never actually been exercised.
3. **Shipping.** Same principle: the payload has no route or disruption concept, so this keys off the writer's own `spikeAlert` rather than a new `changePct` threshold.
4. **Radiation fires on `SPIKE` only,** not `ELEVATED`. `BASE_WEIGHT` is 3.5, so a single `ELEVATED` reading would score `CRITICAL` on its own.
5. **Weather theater is `North America`.** NWS alerts carry `areaDesc` ("Kern County, CA; Tulare County, CA") and no country or region. Bucketing on that string gives almost every alert its own theater, which can never join a composite; the feed is US-only, so the theater is fixed by construction.
6. **Military flight theater uses `operatorCountry`.** That is whose air force is flying, not where — the closest proxy this payload exposes. The writer also publishes geo-bucketed theaters to `theater-posture:sebuf:v1`, which would be more accurate and a larger change; say the word and I will use it instead.
7. **Forecast deterioration keeps probability as the only criterion.** `computeTrends` (`seed-forecasts.mjs:2720`) only assigns `stable`/`rising`/`falling`, so `trend === 'deteriorating'` and `direction === 'negative'` were dead. Whether `rising` should also qualify is your call.

Enum comparisons use dual-accept (`OUTAGE_SEVERITY_MAJOR` and `major` both match), following `seed-correlation.mjs:212`. That makes every change strictly additive — no signal that fires today can stop firing.

## Why the tests could not see this

Both existing suites reconstructed the module with `readFileSync` + regex + `vm.runInContext`, because `runSeed(...)` ran unconditionally at import time. One of those regexes deleted `readAllSourceKeys` outright:

```js
.replace(/async function readAllSourceKeys[\s\S]*?\r?\n}\r?\n\r?\n\/\/ ── Signal extractors/m, '// readAllSourceKeys removed for unit test\n\n// ── Signal extractors')
```

and the fixtures were hand-built bare payloads, i.e. the pre-envelope world, at exactly the seam where the defect lives.

So this adds the direct-run guard 118 of the 163 `scripts/seed-*.mjs` files already use (`seed-regulatory-actions.mjs:319` is the template) and exports the extractors, and both suites now import the real module. The guard is a no-op in production: `scripts/_bundle-runner.mjs` spawns each section as its own process with the script path as `argv[1]`, and `seed-china-decision-signals.mjs:155` in this same bundle is both guarded and imported by `seed-bundle-derived-signals.mjs:3`. Existing assertions are unchanged, except that the extractor-registration check now asserts membership in the exported `EXTRACTORS` registry instead of grepping the source text.

## Verification

Targeted suites, all on this branch:

```
tests/cross-source-signals-envelope-reads.test.mjs    46 pass, 0 fail
tests/cross-source-signals-wildfire.test.mjs           6 pass, 0 fail
tests/cross-source-signals-regulatory.test.mjs         7 pass, 0 fail
tests/cross-source-signals-tone-staleness.test.mjs     5 pass, 0 fail
                                                      64 pass, 0 fail
```

**Every guard is mutation-proven.** Reverting any one of the 23 corrections to the code it replaced turns the suite red — 23 mutants, no survivors:

| Mutant | Result | Mutant | Result |
|---|---|---|---|
| envelope unwrap | 2 red | outage enum | 1 red |
| thermal fields | 1 red | outage theater | 1 red |
| thermal label | 1 red | radiation enum | 1 red |
| thermal stamp | 1 red | radiation stamp | 1 red |
| gpsjam `fetchedAt` | 1 red | wildfire fields | 1 red |
| military `operatorCountry` | 1 red | wildfire threshold | 1 red |
| unrest `occurredAt` | 1 red | forecast probability | 1 red |
| unrest theater | 1 red | weather enum | 1 red |
| advisory slug | 1 red | weather theater | 1 red |
| cyber enum | 1 red | shipping `indices` | 1 red |
| cyber country | 1 red | shipping flag | 1 red |
| earthquake `occurredAt` | 1 red | | |

Three of those only started failing after the fixture matrix asserted the expected `theater` and payload-sourced `detectedAt` rather than just non-empty output — `military`, `earthquake` and `gpsjam` all survived a "does it fire" assertion, because a signal that silently falls back to `theater: 'Global'` and `detectedAt: Date.now()` still fires. That is precisely how the military-flight signal sat outside every theater composite, so the assertions are pinned exactly.

Every fixture is field-for-field the record its writer builds, with a `file:line` provenance comment, and each one is driven through the exact transform `readAllSourceKeys` performs rather than hand-unwrapped. Enveloped fixtures additionally assert that the raw envelope produces nothing, which pins the bug itself.

Other gates:

```
npm run typecheck        clean
npx biome check          clean (5 files)
npm run lint:boundaries  no violations
check-unicode-safety     2601 files scanned, clean
```

`npm run test:data`: **identical failure set to `origin/main`** — 45 failing test names on both, `comm` diff empty in both directions (OpenAPI contract, docs/i18n, pricing and Docker suites that are already red on a clean checkout).

The seeder was not run against production Redis.

## Out of scope

- `scripts/seed-correlation.mjs:40` reads its own `INPUT_KEYS` with the same bare `JSON.parse` and sits next to this file in the same Railway bundle. Its inputs are mostly legacy bare keys so the blast radius is smaller, but it is the same defect and worth its own issue.
- The `MAX_SIGNALS = 30` cap and the per-extractor `.slice(0, 2..5)` limits are untouched. More signals will now reach `list-cross-source-signals` and the composite detector — that is the point of the fix — but both consumers already take a bounded array, and changing the caps in the same PR would mix a bug fix with a tuning change.
- Extractor thresholds beyond the seven listed above are left exactly as they were.
- The `_country-brief-context` / prompt-context work in #5881 is unrelated and not touched here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [x] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: `scripts/seed-cross-source-signals.mjs` (Railway seeder feeding `intelligence:cross-source-signals:v1`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A. This is a Railway seeder; its output is only observable after a scheduled run writes `intelligence:cross-source-signals:v1`. Verified through the extractor suites instead, against fixtures derived field-for-field from each writer.
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A, no variant-specific behaviour.
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A, no feeds added.
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — this PR does not publish or change any documentation claim. It changes how one seeder reads existing Redis keys and does not alter the published shape of `intelligence:cross-source-signals:v1`, the OpenAPI contract for `list-cross-source-signals`, methodology, or any generated doc. Listed for completeness:

- [ ] Claim ledger attached or linked — N/A, no documented claim changes.
- [ ] All required Audit Council role signoffs attached — N/A, no methodology or contract change.
- [ ] Generated docs regenerated from proto where applicable — N/A, no proto change.
- [ ] Fixture-backed examples recomputed — N/A, no published example depends on this seeder's input reads.
- [x] Redis writers/readers enumerated for every documented key — done in the audit table above: every `SOURCE_KEYS` entry is mapped to its writer and its envelope mode.
