### PR TITLE
docs(mcp): document prediction market categories

### DIFF
--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -1155,7 +1155,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     name: 'get_prediction_markets',
     _uiResourceUri: PREDICTION_MARKETS_UI_URI,
     _outputBudgetBytes: 131072,
-    description: 'Active Polymarket event contracts with current probabilities. Covers geopolitical, economic, and election prediction markets.',
+    description: 'Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -1155,17 +1155,17 @@ export const CACHE_TOOLS: ToolDef[] = [
     name: 'get_prediction_markets',
     _uiResourceUri: PREDICTION_MARKETS_UI_URI,
     _outputBudgetBytes: 131072,
-    description: 'Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue.',
+    description: 'Prediction markets: geopolitical/elections, tagged tech (AI/crypto/science), finance/economics or untagged fallback. Contracts include current probabilities. Kalshi currently supplies no classifier tags, so source=kalshi with category=tech returns no records and other non-geopolitical Kalshi records fall back to finance.',
     inputSchema: {
       type: 'object',
       properties: {
         category: {
           type: 'string',
           enum: ['geopolitical', 'tech', 'finance'],
-          description: 'Restrict to one market category bucket. Omit for all three.',
+          description: 'Restrict to one market category bucket. Omit for all three. Finance also owns untagged non-geopolitical records.',
         },
         query: { type: 'string', description: 'Keep only markets whose title contains this text (case-insensitive).' },
-        source: { type: 'string', enum: ['kalshi', 'polymarket'], description: 'Filter to one prediction-market source.' },
+        source: { type: 'string', enum: ['kalshi', 'polymarket'], description: 'Filter to one prediction-market source. Kalshi currently provides no classifier tags, so source=kalshi with category=tech returns no records.' },
         limit: { type: 'number', description: 'Cap each category bucket to at most this many markets (default 30, pass 0 for no cap).' },
       },
       required: [],

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -215,7 +215,7 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 | `get_eu_housing_cycle` | Eurostat annual house price index (prc_hpi_a), 10-yr sparkline per EU member + EA20/EU27. |
 | `get_eu_quarterly_gov_debt` | Eurostat quarterly gross government debt (%GDP), 8-quarter sparkline. |
 | `get_eu_industrial_production` | Eurostat monthly industrial production index, 12-month sparkline. |
-| `get_prediction_markets` | Active prediction-market odds grouped as geopolitical (geopolitics/elections), tech (AI/crypto/science), or finance (financial/economic). |
+| `get_prediction_markets` | Prediction markets with current probabilities: geopolitical/elections, tagged tech (AI/crypto/science), finance/economics or untagged fallback. |
 | `get_supply_chain_data` | Dry bulk shipping stress index, customs flows, COMTRADE bilateral trade. |
 | `get_tariff_trends` | Global trade and pricing indicators: US tariff trends (HTS-coded), BigMac index, FAO Food Price Index, and per-country national debt levels. |
 | `get_chokepoint_status` | Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc. |

--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -215,7 +215,7 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 | `get_eu_housing_cycle` | Eurostat annual house price index (prc_hpi_a), 10-yr sparkline per EU member + EA20/EU27. |
 | `get_eu_quarterly_gov_debt` | Eurostat quarterly gross government debt (%GDP), 8-quarter sparkline. |
 | `get_eu_industrial_production` | Eurostat monthly industrial production index, 12-month sparkline. |
-| `get_prediction_markets` | Active Polymarket event contracts with live probabilities. |
+| `get_prediction_markets` | Active prediction-market odds grouped as geopolitical (geopolitics/elections), tech (AI/crypto/science), or finance (financial/economic). |
 | `get_supply_chain_data` | Dry bulk shipping stress index, customs flows, COMTRADE bilateral trade. |
 | `get_tariff_trends` | Global trade and pricing indicators: US tariff trends (HTS-coded), BigMac index, FAO Food Price Index, and per-country national debt levels. |
 | `get_chokepoint_status` | Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc. |

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -512,15 +512,15 @@ curl -s https://worldmonitor.app/mcp \
 
 ### `get_prediction_markets`
 
-Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue.
+Prediction markets: geopolitical/elections, tagged tech (AI/crypto/science), finance/economics or untagged fallback. Contracts include current probabilities. Kalshi currently supplies no classifier tags, so source=kalshi with category=tech returns no records and other non-geopolitical Kalshi records fall back to finance.
 
 **Parameters (tool-specific):**
 
 | Name | Type | Description |
 |------|------|-------------|
-| `category` | string: geopolitical / tech / finance | Restrict to one market category bucket. Omit for all three. |
+| `category` | string: geopolitical / tech / finance | Restrict to one market category bucket. Omit for all three. `finance` also owns untagged non-geopolitical records. |
 | `query` | string | Keep only markets whose title contains this text (case-insensitive). |
-| `source` | string: kalshi / polymarket | Filter to one prediction-market source. |
+| `source` | string: kalshi / polymarket | Filter to one prediction-market source. Kalshi currently provides no classifier tags, so combining `source=kalshi` with `category=tech` returns no records. |
 | `limit` | number | Cap each category bucket to at most this many markets (default 30, pass 0 for no cap). |
 
 - **API endpoints:** `GET /api/prediction/v1/list-prediction-markets`

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -518,9 +518,9 @@ Prediction markets: geopolitical/elections, tagged tech (AI/crypto/science), fin
 
 | Name | Type | Description |
 |------|------|-------------|
-| `category` | string: geopolitical / tech / finance | Restrict to one market category bucket. Omit for all three. `finance` also owns untagged non-geopolitical records. |
+| `category` | string: geopolitical / tech / finance | Restrict to one market category bucket. Omit for all three. Finance also owns untagged non-geopolitical records. |
 | `query` | string | Keep only markets whose title contains this text (case-insensitive). |
-| `source` | string: kalshi / polymarket | Filter to one prediction-market source. Kalshi currently provides no classifier tags, so combining `source=kalshi` with `category=tech` returns no records. |
+| `source` | string: kalshi / polymarket | Filter to one prediction-market source. Kalshi currently provides no classifier tags, so source=kalshi with category=tech returns no records. |
 | `limit` | number | Cap each category bucket to at most this many markets (default 30, pass 0 for no cap). |
 
 - **API endpoints:** `GET /api/prediction/v1/list-prediction-markets`

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -512,7 +512,7 @@ curl -s https://worldmonitor.app/mcp \
 
 ### `get_prediction_markets`
 
-Active Polymarket event contracts with current probabilities. Covers geopolitical, economic, and election prediction markets.
+Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue.
 
 **Parameters (tool-specific):**
 

--- a/docs/zh/mcp-overview.mdx
+++ b/docs/zh/mcp-overview.mdx
@@ -215,7 +215,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 | `get_eu_housing_cycle` | Eurostat 年度房价指数（prc_hpi_a），每个欧盟成员国 + EA20/EU27 的 10 年迷你图。 |
 | `get_eu_quarterly_gov_debt` | Eurostat 季度政府总债务（占 GDP 比例），8 个季度迷你图。 |
 | `get_eu_industrial_production` | Eurostat 月度工业生产指数，12 个月迷你图。 |
-| `get_prediction_markets` | 活跃的 Polymarket 事件合约及实时概率。 |
+| `get_prediction_markets` | 按 `geopolitical`（地缘政治/选举）、`tech`（科技：人工智能/加密货币/科学）或 `finance`（金融/经济）分组的活跃预测市场赔率。 |
 | `get_supply_chain_data` | 干散货航运压力指数、海关流量、COMTRADE 双边贸易。 |
 | `get_tariff_trends` | 全球贸易和定价指标：美国关税趋势（HTS 编码）、巨无霸指数、FAO 食品价格指数以及各国国债水平。 |
 | `get_chokepoint_status` | 实时海上咽喉要道状态：每个咽喉要道的船舶过境计数（10 分钟节奏）、滚动过境摘要、每个港口的活动，以及静态参考数据和流量汇总。覆盖苏伊士、霍尔木兹、马六甲、曼德海峡、巴拿马等。 |

--- a/docs/zh/mcp-overview.mdx
+++ b/docs/zh/mcp-overview.mdx
@@ -215,7 +215,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 | `get_eu_housing_cycle` | Eurostat 年度房价指数（prc_hpi_a），每个欧盟成员国 + EA20/EU27 的 10 年迷你图。 |
 | `get_eu_quarterly_gov_debt` | Eurostat 季度政府总债务（占 GDP 比例），8 个季度迷你图。 |
 | `get_eu_industrial_production` | Eurostat 月度工业生产指数，12 个月迷你图。 |
-| `get_prediction_markets` | 按 `geopolitical`（地缘政治/选举）、`tech`（科技：人工智能/加密货币/科学）或 `finance`（金融/经济）分组的活跃预测市场赔率。 |
+| `get_prediction_markets` | 含当前概率的预测市场：`geopolitical`（地缘政治/选举）、`tech`（有标签的科技：人工智能/加密货币/科学）以及 `finance`（金融/经济或未分类回退）。 |
 | `get_supply_chain_data` | 干散货航运压力指数、海关流量、COMTRADE 双边贸易。 |
 | `get_tariff_trends` | 全球贸易和定价指标：美国关税趋势（HTS 编码）、巨无霸指数、FAO 食品价格指数以及各国国债水平。 |
 | `get_chokepoint_status` | 实时海上咽喉要道状态：每个咽喉要道的船舶过境计数（10 分钟节奏）、滚动过境摘要、每个港口的活动，以及静态参考数据和流量汇总。覆盖苏伊士、霍尔木兹、马六甲、曼德海峡、巴拿马等。 |

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -512,7 +512,7 @@ curl -s https://worldmonitor.app/mcp \
 
 ### `get_prediction_markets`
 
-带有当前概率的活跃 Polymarket 事件合约。涵盖地缘政治、经济和选举预测市场。
+活跃预测市场：`geopolitical`（地缘政治/选举）、`tech`（科技，包括人工智能、加密货币和科学）、`finance`（金融/经济）。合约包含当前概率；`tech` 类别要求分类器标签匹配，因此覆盖范围因交易平台而异。
 
 **参数（工具特定）：**
 

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -512,15 +512,15 @@ curl -s https://worldmonitor.app/mcp \
 
 ### `get_prediction_markets`
 
-活跃预测市场：`geopolitical`（地缘政治/选举）、`tech`（科技，包括人工智能、加密货币和科学）、`finance`（金融/经济）。合约包含当前概率；`tech` 类别要求分类器标签匹配，因此覆盖范围因交易平台而异。
+预测市场：`geopolitical`（地缘政治/选举）、`tech`（有标签的科技，包括人工智能、加密货币和科学）、`finance`（金融/经济或未分类回退）。合约包含当前概率。Kalshi 目前不提供分类器标签，因此 `source=kalshi` 与 `category=tech` 组合不会返回记录；其他非地缘政治 Kalshi 记录会回退到 `finance`。
 
 **参数（工具特定）：**
 
 | 名称 | 类型 | 描述 |
 |------|------|-------------|
-| `category` | string: geopolitical / tech / finance | 限制为一个市场类别桶。省略则返回全部三类。 |
+| `category` | string: geopolitical / tech / finance | 限制为一个市场类别桶。省略则返回全部三类。`finance` 也接收未分类的非地缘政治记录。 |
 | `query` | string | 仅保留标题包含此文本的市场（不区分大小写）。 |
-| `source` | string: kalshi / polymarket | 筛选为一个预测市场来源。 |
+| `source` | string: kalshi / polymarket | 筛选为一个预测市场来源。Kalshi 目前不提供分类器标签，因此与 `category=tech` 组合不会返回记录。 |
 | `limit` | number | 将每个类别桶限制为最多这么多市场（默认 30，传 0 表示不限）。 |
 
 - **API 端点：** `GET /api/prediction/v1/list-prediction-markets`

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -82,7 +82,7 @@
     },
     {
       "name": "get_prediction_markets",
-      "description": "Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue."
+      "description": "Prediction markets: geopolitical/elections, tagged tech (AI/crypto/science), finance/economics or untagged fallback. Contracts include current probabilities. Kalshi currently supplies no classifier tags, so source=kalshi with category=tech returns no records and other non-geopolitical Kalshi records fall back to finance."
     },
     {
       "name": "get_sanctions_data",

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -82,7 +82,7 @@
     },
     {
       "name": "get_prediction_markets",
-      "description": "Active Polymarket event contracts with current probabilities. Covers geopolitical, economic, and election prediction markets."
+      "description": "Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue."
     },
     {
       "name": "get_sanctions_data",

--- a/tests/mcp-prediction-market-description.test.mjs
+++ b/tests/mcp-prediction-market-description.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  TOOL_LIST_RESPONSE,
+  TOOL_REGISTRY,
+} from '../api/mcp/registry/index.ts';
+
+const EXPECTED_CATEGORIES = ['geopolitical', 'tech', 'finance'];
+const TOOL_NAME = 'get_prediction_markets';
+
+const englishReference = readFileSync(
+  new URL('../docs/mcp-tools-reference.mdx', import.meta.url),
+  'utf8',
+);
+const chineseReference = readFileSync(
+  new URL('../docs/zh/mcp-tools-reference.mdx', import.meta.url),
+  'utf8',
+);
+const englishOverview = readFileSync(
+  new URL('../docs/mcp-overview.mdx', import.meta.url),
+  'utf8',
+);
+const chineseOverview = readFileSync(
+  new URL('../docs/zh/mcp-overview.mdx', import.meta.url),
+  'utf8',
+);
+const serverCard = JSON.parse(readFileSync(
+  new URL('../public/.well-known/mcp/server-card.json', import.meta.url),
+  'utf8',
+));
+
+function sectionForTool(markdown, toolName) {
+  const heading = `### \`${toolName}\``;
+  const start = markdown.indexOf(heading);
+  assert.notEqual(start, -1, `missing ${heading}`);
+  const next = markdown.indexOf('\n### `', start + heading.length);
+  return markdown.slice(start, next === -1 ? markdown.length : next);
+}
+
+function overviewRow(markdown) {
+  const row = markdown
+    .split('\n')
+    .find((line) => line.includes(`| \`${TOOL_NAME}\` |`));
+  assert.ok(row, `missing overview row for ${TOOL_NAME}`);
+  return row;
+}
+
+function assertEnglishCategoryMeaning(text, label) {
+  for (const category of EXPECTED_CATEGORIES) {
+    assert.match(text, new RegExp(`\\b${category}\\b`, 'i'), `${label} omits ${category}`);
+  }
+  assert.match(
+    text,
+    /geopolitical[^.]*geopolitic[^.]*election/i,
+    `${label} does not associate geopolitical with geopolitics and elections`,
+  );
+  assert.match(
+    text,
+    /tech[^.]*\bAI\b[^.]*crypto[^.]*science/i,
+    `${label} does not associate tech with AI, crypto, and science`,
+  );
+  assert.match(
+    text,
+    /finance[^.]*financial[^.]*economic/i,
+    `${label} does not associate finance with financial and economic markets`,
+  );
+}
+
+function assertNoGeopoliticalDefault(text, label) {
+  assert.doesNotMatch(
+    text,
+    /(?:default|omit|omission)[^.]{0,60}geopolitical|geopolitical[^.]{0,60}(?:default|omit|omission)/i,
+    `${label} must not describe geopolitical as the omission/default bucket`,
+  );
+}
+
+describe('get_prediction_markets agent-facing category contract', () => {
+  const tool = TOOL_REGISTRY.find((entry) => entry.name === TOOL_NAME);
+
+  it('uses the registered tool object to expose the exact enum and meaningful categories', () => {
+    assert.ok(tool, `${TOOL_NAME} must be registered`);
+    assert.deepEqual(tool.inputSchema.properties.category.enum, EXPECTED_CATEGORIES);
+    assertEnglishCategoryMeaning(tool.description, 'registry description');
+    assert.match(tool.description, /classifier tags/i);
+    assert.match(tool.description, /coverage varies by venue/i);
+    assert.doesNotMatch(
+      tool.description,
+      /Polymarket/i,
+      'the registry description must not imply the multi-venue payload is Polymarket-only',
+    );
+    assert.match(
+      tool.inputSchema.properties.category.description,
+      /Omit for all three/i,
+      'the category schema must preserve omission as all pools',
+    );
+    assertNoGeopoliticalDefault(tool.description, 'registry description');
+
+    const data = {
+      'markets-bootstrap': {
+        geopolitical: [{ title: 'geopolitical fixture' }],
+        tech: [{ title: 'tech fixture' }],
+        finance: [{ title: 'finance fixture' }],
+      },
+    };
+    const filtered = tool._postFilter(structuredClone(data), {});
+    for (const category of EXPECTED_CATEGORIES) {
+      assert.equal(
+        filtered['markets-bootstrap'][category].length,
+        1,
+        `omitting category must preserve the ${category} pool`,
+      );
+    }
+  });
+
+  it('keeps every category discoverable in the actual compressed tools/list description', () => {
+    const publicTool = TOOL_LIST_RESPONSE.find((entry) => entry.name === TOOL_NAME);
+    assert.ok(publicTool, `${TOOL_NAME} must be published by tools/list`);
+    assert.ok(
+      Buffer.byteLength(publicTool.description, 'utf8') <= 120,
+      'tools/list description must stay within the registry compression budget',
+    );
+    assertEnglishCategoryMeaning(publicTool.description, 'tools/list description');
+    assertNoGeopoliticalDefault(publicTool.description, 'tools/list description');
+  });
+
+  it('keeps generated public server-card metadata equal to the canonical registry', () => {
+    const cardTool = serverCard.tools.find((entry) => entry.name === TOOL_NAME);
+    assert.ok(cardTool, `${TOOL_NAME} must be published in the server card`);
+    assert.equal(cardTool.description, tool.description);
+  });
+
+  it('keeps the detailed English reference equal to the canonical description', () => {
+    const section = sectionForTool(englishReference, TOOL_NAME);
+    assert.ok(
+      section.includes(tool.description),
+      'English reference description must equal the canonical registry description',
+    );
+    assertEnglishCategoryMeaning(section, 'English reference');
+    assert.match(section, /Omit for all three/i);
+    assertNoGeopoliticalDefault(section, 'English reference');
+  });
+
+  it('keeps the detailed Chinese reference translated and semantically synchronized', () => {
+    const section = sectionForTool(chineseReference, TOOL_NAME);
+    for (const category of EXPECTED_CATEGORIES) {
+      assert.match(section, new RegExp(`\`${category}\``), `Chinese reference omits ${category}`);
+    }
+    for (const term of [
+      '预测市场',
+      '地缘政治',
+      '选举',
+      '科技',
+      '人工智能',
+      '加密货币',
+      '科学',
+      '金融',
+      '经济',
+      '分类器标签',
+      '交易平台',
+    ]) {
+      assert.ok(section.includes(term), `Chinese reference omits ${term}`);
+    }
+    assert.doesNotMatch(section, /Active prediction markets:/);
+    assert.match(section, /省略则返回全部三类/);
+  });
+
+  it('keeps both overview rows concise without contradicting the detailed contract', () => {
+    const englishRow = overviewRow(englishOverview);
+    assertEnglishCategoryMeaning(englishRow, 'English overview');
+    assertNoGeopoliticalDefault(englishRow, 'English overview');
+    assert.doesNotMatch(englishRow, /Polymarket/i);
+
+    const chineseRow = overviewRow(chineseOverview);
+    for (const category of EXPECTED_CATEGORIES) {
+      assert.match(chineseRow, new RegExp(`\`${category}\``), `Chinese overview omits ${category}`);
+    }
+    for (const term of ['地缘政治', '选举', '科技', '人工智能', '加密货币', '科学', '金融', '经济']) {
+      assert.ok(chineseRow.includes(term), `Chinese overview omits ${term}`);
+    }
+    assert.doesNotMatch(chineseRow, /Polymarket/i);
+  });
+});

--- a/tests/mcp-prediction-market-description.test.mjs
+++ b/tests/mcp-prediction-market-description.test.mjs
@@ -53,8 +53,8 @@ function assertEnglishCategoryMeaning(text, label) {
   }
   assert.match(
     text,
-    /geopolitical[^.]*geopolitic[^.]*election/i,
-    `${label} does not associate geopolitical with geopolitics and elections`,
+    /geopolitical[^.]*election/i,
+    `${label} does not associate geopolitical with elections`,
   );
   assert.match(
     text,
@@ -63,8 +63,8 @@ function assertEnglishCategoryMeaning(text, label) {
   );
   assert.match(
     text,
-    /finance[^.]*financial[^.]*economic/i,
-    `${label} does not associate finance with financial and economic markets`,
+    /finance[^.]*econom(?:ic|ics)[^.]*fallback/i,
+    `${label} does not associate finance/economics with the fallback`,
   );
 }
 
@@ -83,8 +83,9 @@ describe('get_prediction_markets agent-facing category contract', () => {
     assert.ok(tool, `${TOOL_NAME} must be registered`);
     assert.deepEqual(tool.inputSchema.properties.category.enum, EXPECTED_CATEGORIES);
     assertEnglishCategoryMeaning(tool.description, 'registry description');
-    assert.match(tool.description, /classifier tags/i);
-    assert.match(tool.description, /coverage varies by venue/i);
+    assert.match(tool.description, /Kalshi currently supplies no classifier tags/i);
+    assert.match(tool.description, /source=kalshi[^.]*category=tech[^.]*returns no records/i);
+    assert.match(tool.description, /fall back to finance/i);
     assert.doesNotMatch(
       tool.description,
       /Polymarket/i,
@@ -94,6 +95,16 @@ describe('get_prediction_markets agent-facing category contract', () => {
       tool.inputSchema.properties.category.description,
       /Omit for all three/i,
       'the category schema must preserve omission as all pools',
+    );
+    assert.match(
+      tool.inputSchema.properties.category.description,
+      /Finance also owns untagged non-geopolitical records/i,
+      'the category schema must expose the finance fallback',
+    );
+    assert.match(
+      tool.inputSchema.properties.source.description,
+      /Kalshi[^.]*no classifier tags[^.]*source=kalshi[^.]*category=tech[^.]*returns no records/i,
+      'the source schema must expose the Kalshi tech limitation',
     );
     assertNoGeopoliticalDefault(tool.description, 'registry description');
 
@@ -122,7 +133,13 @@ describe('get_prediction_markets agent-facing category contract', () => {
       'tools/list description must stay within the registry compression budget',
     );
     assertEnglishCategoryMeaning(publicTool.description, 'tools/list description');
+    assert.match(publicTool.description, /untagged fallback/i);
     assertNoGeopoliticalDefault(publicTool.description, 'tools/list description');
+    assert.match(
+      publicTool.inputSchema.properties.source.description,
+      /Kalshi[^.]*source=kalshi[^.]*category=tech[^.]*returns no records/i,
+      'tools/list source metadata must expose the Kalshi tech limitation',
+    );
   });
 
   it('keeps generated public server-card metadata equal to the canonical registry', () => {
@@ -139,6 +156,8 @@ describe('get_prediction_markets agent-facing category contract', () => {
     );
     assertEnglishCategoryMeaning(section, 'English reference');
     assert.match(section, /Omit for all three/i);
+    assert.match(section, /source=kalshi[^.]*category=tech[^.]*returns no records/i);
+    assert.match(section, /fall back to finance/i);
     assertNoGeopoliticalDefault(section, 'English reference');
   });
 
@@ -158,17 +177,21 @@ describe('get_prediction_markets agent-facing category contract', () => {
       '金融',
       '经济',
       '分类器标签',
-      '交易平台',
+      '未分类',
+      '回退',
+      'Kalshi',
     ]) {
       assert.ok(section.includes(term), `Chinese reference omits ${term}`);
     }
     assert.doesNotMatch(section, /Active prediction markets:/);
     assert.match(section, /省略则返回全部三类/);
+    assert.match(section, /`source=kalshi` 与 `category=tech` 组合不会返回记录/);
   });
 
   it('keeps both overview rows concise without contradicting the detailed contract', () => {
     const englishRow = overviewRow(englishOverview);
     assertEnglishCategoryMeaning(englishRow, 'English overview');
+    assert.match(englishRow, /untagged fallback/i);
     assertNoGeopoliticalDefault(englishRow, 'English overview');
     assert.doesNotMatch(englishRow, /Polymarket/i);
 
@@ -176,7 +199,7 @@ describe('get_prediction_markets agent-facing category contract', () => {
     for (const category of EXPECTED_CATEGORIES) {
       assert.match(chineseRow, new RegExp(`\`${category}\``), `Chinese overview omits ${category}`);
     }
-    for (const term of ['地缘政治', '选举', '科技', '人工智能', '加密货币', '科学', '金融', '经济']) {
+    for (const term of ['地缘政治', '选举', '人工智能', '加密货币', '科学', '金融', '经济', '未分类', '回退']) {
       assert.ok(chineseRow.includes(term), `Chinese overview omits ${term}`);
     }
     assert.doesNotMatch(chineseRow, /Polymarket/i);


### PR DESCRIPTION
## Summary

Fixes #5874.

`get_prediction_markets` exposed `geopolitical`, `tech`, and `finance`, but its description omitted the now-reliable tech bucket and incorrectly described the multi-venue payload as Polymarket-only.
This PR updates the canonical MCP registry description, synchronizes the English and Chinese detailed references and overviews, regenerates the public server card, and adds executable contract coverage for the registry, compressed `tools/list` metadata, generated card, translations, and omission behavior.

Canonical English description:

> Active prediction markets: geopolitical (geopolitics/elections), tech (AI/crypto/science), finance (financial/economic). Contracts include current probabilities; tech membership requires matching classifier tags, so coverage varies by venue.

Category meaning:

- `geopolitical` contains geopolitical and election-oriented markets.
- `tech` contains classifier-tagged AI, crypto, science, and other technology-oriented markets.
- `finance` contains financial and economic markets.
- Omitting `category` continues to return all three MCP pools.

The description now says "prediction markets" instead of "Polymarket" because the producer and source filter both support Kalshi and Polymarket.
The tech caveat is retained because tech classification requires venue tags, while Kalshi records currently carry empty tag arrays.

The Chinese reference and overview preserve the literal enum values and translate the distinctions using 地缘政治, 选举, 科技, 人工智能, 加密货币, 科学, 金融, and 经济.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: MCP registry metadata, public server card, and MCP documentation

## Checklist

- [x] Tested on worldmonitor.app variant: N/A, agent metadata and documentation only
- [x] Tested on tech.worldmonitor.app variant: N/A, agent metadata and documentation only
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist: N/A, no feeds changed
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [x] Claim ledger attached below
- [x] Audit Council role signoffs: N/A for this scoped single-tool correction; maintainer-style adversarial review is recorded below
- [x] Generated docs regenerated from proto where applicable: server card regenerated from the MCP registry; no proto changed
- [x] Fixture-backed examples recomputed: N/A, no example payload changed
- [x] Redis writers/readers enumerated for every documented key

### Claim ledger

| Claim | Type | Source of truth | Publishing surfaces | Evidence |
|---|---|---|---|---|
| MCP categories are exactly `geopolitical`, `tech`, and `finance` | Enum contract | `api/mcp/registry/cache-tools.ts` category schema and producer `CATEGORIES` | Registry, compressed `tools/list`, English and Chinese references and overviews, server card | Focused contract test reads `TOOL_REGISTRY` and `TOOL_LIST_RESPONSE` |
| Geopolitical means geopolitics/elections, tech means AI/crypto/science, and finance means financial/economic | Classifier semantics | `scripts/_prediction-classify.mjs` and `scripts/data/prediction-tags.json` | Canonical description and documentation mirrors | Focused semantic assertions plus existing classifier fixture suite |
| Omitting MCP `category` returns all three pools | Default behavior | Registry `_postFilter` and category parameter description | MCP tool metadata and English/Chinese references | Focused test invokes the registered `_postFilter` with all pools populated |
| The endpoint is multi-venue and tech coverage varies by venue | Data-source identity and limitation | `scripts/seed-prediction-markets.mjs` Kalshi and Polymarket producers; Kalshi `tags: []` | Canonical description, references, and overviews | Focused test rejects Polymarket-only wording and requires the classifier-tag caveat |

Redis inventory for `prediction:markets-bootstrap:v1`:

- Writer: `scripts/seed-prediction-markets.mjs`.
- MCP reader: `get_prediction_markets` in `api/mcp/registry/cache-tools.ts`.
- REST/RPC reader: `server/worldmonitor/prediction/v1/list-prediction-markets.ts`.
- Other unchanged consumers: app hydration and prediction services, forecast detectors/calibration, forecast resolution, and prompt builders identified by the repository-wide pool search and #5733 solution notes.

## Generated surfaces

- Canonical source: `api/mcp/registry/cache-tools.ts`.
- Generated mirror: `public/.well-known/mcp/server-card.json`.
- Generator: `npm run product:facts`.
- Manual mirrors: English and Chinese tool references and overview rows.
- `npm run product:facts` was run twice after restoration.
- The server-card SHA-1 remained `a13261a55d7cb1481662b4786f3c7a9055a00905` across the second run.
- `npm run product:facts:check` reported `public product facts check OK`.
- `npm run docs:stats` produced no tracked stats diff.
- `npm run docs:check` reported 91 documentation claims aligned.

## Mutation proof

- Removing the tech contents from the canonical registry description made the focused registry test fail with `registry description does not associate tech with AI, crypto, and science`.
- Restoring the old English reference sentence made the focused parity test fail with `English reference description must equal the canonical registry description`.
- Regenerating from the intentionally stale canonical source produced a server-card diff that removed the tech contents.
- Restoring the canonical source and regenerating returned the focused suite to 6/6 passing and the worktree to clean.

## REST geopolitical-category scope

This PR does not change `shared/openapi-filter-param-contracts.json` or runtime REST/RPC selection.
The current REST contract lists classifier tag values for tech and finance, while the handler sends every other nonempty value to the geopolitical pool.
That means unknown values remain an accidental geopolitical selector, so adding a `geopolitical` enum value would not satisfy the issue's contract-only conditions and would silently expand this documentation repair into behavior validation and error-semantics work.
A separate follow-up should define explicit geopolitical selectors, reject unknown values, preserve omission as all pools, and add RPC tests for those cases.

## Adversarial review

- Canonical source: one authoritative registry description remains, the server card is generated from it, and manual mirrors are pinned by the new test.
- Semantics: category wording matches the disjoint producer partition, omission remains all pools, the tag-only tech limitation is explicit, and no venue-wide tech promise is made.
- Consumers: registry, compressed `tools/list`, `describe_tool`, server card, English reference, Chinese reference, both overviews, product-facts generation, docs stats, and existing parity tests were traced.
- Translation: the Chinese text preserves literal enum values and all required translated concepts, with no English description copied into the Chinese reference.
- Test quality: every category is asserted independently, mappings are positionally associated, omission invokes the real post-filter, server-card equality derives from the live registry, and both source and mirror mutations fail for the intended reason.
- Runtime scope: no classifier, handler, enum, parameter, default, Redis key, proto, or OpenAPI behavior changed.
- Residual risk: the separate REST unknown-category fallthrough described above remains intentionally out of scope.

## Validation

Runtime:

- Node `v24.18.1`
- npm `11.16.0`

Commands and outcomes:

- `./node_modules/.bin/tsx --test tests/mcp-prediction-market-description.test.mjs tests/mcp-tools-reference-docs.test.mjs tests/mcp-tools-list-compression.test.mjs tests/docs-i18n-parity.test.mjs tests/public-product-facts.test.mjs tests/prediction-market-classification.test.mjs tests/prediction-market-rpc.test.mts`: 352 tests passed, 0 failed.
- `./node_modules/.bin/tsx --test tests/mcp-prediction-market-description.test.mjs`: 6 tests passed, 0 failed after mutation restoration.
- `./node_modules/.bin/biome check api/mcp/registry/cache-tools.ts tests/mcp-prediction-market-description.test.mjs`: passed with no fixes.
- `npm run product:facts`: passed and regenerated the server card.
- `npm run product:facts:check`: passed.
- `npm run docs:stats`: passed with no tracked stats diff.
- `npm run docs:check`: passed, 91 claims matched code.
- `npm run lint`: passed; Biome reported 36 existing warnings and 9 informational diagnostics, with no errors, and safe-HTML passed.
- `npm run typecheck`: passed.
- `npm run typecheck:api`: passed, including the Convex string-call audit.
- Direct pre-push invariant run: Unicode, architectural boundaries, safe HTML, Sentry coverage, rate-limit policies, premium-fetch parity, and the edge-function bundle check passed.
- `node --test tests/edge-functions.test.mjs`: 240 tests passed, 0 failed.
- `npm run lint:md`: 193 files checked, 0 errors.
- `node --test tests/mdx-lint.test.mjs`: 504 tests passed, 0 failed.
- `npm run version:check`: passed at version 2.10.0.
- `git diff --check`: passed.

The direct pre-push script later attempted unrelated server tests because contributor-fork `origin/main` was seven commits behind the requested `upstream/main`.
That false scope reached `timeout`, which is unavailable on macOS.
The actual diff against `upstream/main` contains only the seven files in this PR, and all actual-scope gates listed above passed.

## Screenshots

N/A.
This changes agent metadata and documentation only.
