### PR TITLE
test(e2e): wait for degraded digest retry condition

### DIFF
--- a/e2e/dashboard-news-request-budget.spec.ts
+++ b/e2e/dashboard-news-request-budget.spec.ts
@@ -443,13 +443,17 @@ test.describe('dashboard news request budget (#5376)', () => {
       () => document.documentElement.dataset.wmEventHandlersReady === 'true',
     );
     await firstDigest;
-    await page.waitForTimeout(SECOND_LOAD_SETTLE_MS);
-
-    expect(
-      log.digestUrls.length,
-      `a 200 digest carrying no categories leaves every panel empty, so it must stay ` +
-        `retryable exactly like a failed request (attempts: ${log.digestUrls.length})`,
-    ).toBeGreaterThanOrEqual(2);
+    await expect
+      .poll(
+        () => log.digestUrls.length,
+        {
+          message:
+            'a 200 digest carrying no categories leaves every panel empty, so it must stay ' +
+            'retryable exactly like a failed request',
+          timeout: 30_000,
+        },
+      )
+      .toBeGreaterThanOrEqual(2);
   });
 
   // The same degraded 200, one layer down: what it does to the fallback rather


### PR DESCRIPTION
## Summary

Fixes #5890.

The required news-budget Playwright test waited a fixed eight seconds and then counted digest requests.
Under CI load, the queued recovery load could issue its second request after that fixed window, failing unrelated PRs even though the runtime retry contract remained intact.

This change replaces the fixed correctness wait with `expect.poll()` over the routed `list-feed-digest` request count.
The poll returns immediately once request two is observed and has a 30-second timeout, which is generous for the overlapping boot hydration work but still far below the normal 20-minute news refresh interval.

## Retry contract

The merged #5883 degraded-digest behavior was inspected.
`tryFetchDigest()` rejects a zero-category HTTP 200 through the normal digest failure path.
`loadNews()` then leaves `loadedNewsSignature` unset because no digest category or news item landed.
The already queued second `loadAllData()` run therefore remains eligible to issue the recovery request.

The test route still serves a zero-category response only for request one and a healthy digest for request two.
The test does not reload the page or manually trigger request two.
Because the poll is bounded at 30 seconds, it cannot pass through the unrelated 20-minute periodic refresh scheduler.

No production behavior changed.

## Stability and mutation evidence

- Unmodified focused test: 1/1 passed.
- Unmodified focused repetition: 5/5 passed with `--retries=0`, so the known CI flake did not reproduce locally.
- Repaired focused test: 1/1 passed with `--retries=0` in 2.4 seconds.
- Repaired stress run: 20/20 passed with `--repeat-each=20 --retries=0` in 39.3 seconds.
- Complete news-budget file: 8/8 passed independently.
- Exact `variant-smoke-full` sequence: full variant smoke 1/1, MCP grant 28/28, then news budget 8/8 after the preceding workload.

Retry-path mutant killed: focused test observed only one request and timed out waiting for the required second attempt.
The temporary mutant recorded the first empty load as landed, suppressing the queued recovery request.
The failure reported the intended poll message, `Expected: >= 2`, `Received: 1`, and the 30-second predicate timeout.
The production source was restored before all final validation.

## Adversarial review

- No fixed wait remains in the target assertion.
- The poll observes the actual routed digest request count and returns immediately on success.
- The request counter and route are installed before navigation and are scoped to the test's fresh browser context.
- The degraded fixture, landed-state contract, healthy recovery response, and all other request-budget assertions remain unchanged.
- The 30-second bound cannot be satisfied by the 20-minute refresh scheduler.
- Playwright retries, global timeouts, production retry policy, storage setup, route order, and parallelism were not changed.
- The final diff contains only the targeted E2E test hunk.

PR #5894 remains open and is not stacked or copied.
Its E2E diff appends a separate scroll-hydration suite after the existing request-budget suite.
This patch changes only the degraded-digest assertion inside the existing suite and does not change shared imports, helpers, constants, or #5894's appended hunk.

## Validation

- `npm run test:e2e:news-budget -- -g "degraded 200 digest with no categories"`: passed before the fix.
- `npm run test:e2e:news-budget -- -g "degraded 200 digest with no categories" --repeat-each=5 --retries=0`: 5/5 passed before the fix.
- `npm run test:e2e:news-budget -- -g "degraded 200 digest with no categories" --retries=0`: passed after the fix.
- `npm run test:e2e:news-budget -- -g "degraded 200 digest with no categories" --repeat-each=20 --retries=0`: 20/20 passed.
- `npm run test:e2e:news-budget`: 8/8 passed independently.
- `npm run test:e2e:variant-smoke:full`: 1/1 passed.
- `npm run test:e2e:mcp-grant`: 28/28 passed.
- `npm run test:e2e:news-budget`: 8/8 passed after the preceding CI sequence.
- `./node_modules/.bin/biome check e2e/dashboard-news-request-budget.spec.ts`: passed.
- `npm run typecheck`: passed.
- `npm run typecheck:api`: passed.
- `npm run lint`: passed with 36 existing warnings and 9 informational diagnostics, plus the safe HTML guard passed.
- `node scripts/check-unicode-safety.mjs`: passed.
- `git diff --check`: passed.

The contributor fork's `origin/main` is nine commits behind `upstream/main`, while the hook scopes changed files against `origin/main`.
The actual branch diff against its upstream base contains only the E2E test file, so the actual-scope gates above were run directly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Required Playwright E2E synchronization

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) full variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (N/A, full-variant-only required test)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (N/A, no feeds added)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A.
This PR changes only test synchronization and publishes no documentation, methodology, API/MCP, Redis, digest, or briefing claim.

- [ ] Claim ledger attached or linked (N/A)
- [ ] All required Audit Council role signoffs attached (N/A)
- [ ] Generated docs regenerated from proto where applicable (N/A)
- [ ] Fixture-backed examples recomputed (N/A)
- [ ] Redis writers/readers enumerated for every documented key (N/A)

## Screenshots

N/A.
This is a non-visual E2E reliability change.
