### PR TITLE
fix(sentry): suppress SnapTube WebView bridge JSON.parse noise

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -587,6 +587,14 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       if (!hasFirstParty && /Cannot read properties of null \(reading 'contains'\)|null is not an object \(evaluating '\w+\.contains'\)/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
       // Suppress Convex WS onmessage JSON.parse truncation (intermittent WS frame splits on Ping/Updated control messages)
       if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && !hasFirstParty && frames.some(f => /onmessage/.test(f.function ?? ''))) return null;
+      // Suppress SnapTube (Android video-downloader in-app WebView) JS-bridge JSON.parse
+      // noise: its injected bridge parses its own `undefined` message payload inside a
+      // setTimeout our SDK instruments, so only vendor sentry-*.js + `<anonymous>` bridge
+      // frames appear. `/SnapTube/` in ignoreErrors already covers the variants that name
+      // the bridge in the MESSAGE; this closes the case where the attribution exists only
+      // in a frame function. Double-gated on !hasFirstParty AND the named bridge frame so a
+      // genuine first-party `JSON.parse(undefined)` still surfaces (WORLDMONITOR-RA).
+      if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && !hasFirstParty && frames.some(f => /^SnapTube\./.test(f.function ?? ''))) return null;
       // Suppress errors originating from UV proxy (Ultraviolet service worker)
       if (frames.some(f => /\/uv\/service\//.test(f.filename ?? '') || /uv\.handler/.test(f.filename ?? ''))) return null;
       // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script, stay-userscript.html)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -897,6 +897,39 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'first-party onmessage regression must surface');
   });
 
+  // WORLDMONITOR-RA: SnapTube (Android video-downloader in-app WebView) JS bridge
+  // parses its own `undefined` payload. `/SnapTube/` already sits in ignoreErrors,
+  // but that layer matches the MESSAGE only — here the attribution lives purely in a
+  // frame function, so it needs the stack-aware layer.
+  it('suppresses SyntaxError "is not valid JSON" from the SnapTube WebView bridge', () => {
+    const event = makeEvent('"undefined" is not valid JSON', 'SyntaxError', [
+      { filename: '/assets/sentry-DMxp_zBn.js', lineno: 488, function: 'r' },
+      { filename: '<anonymous>', lineno: 1, function: 'SnapTube.value' },
+      { filename: '<anonymous>', lineno: 1, function: 'Object.jsReceiveMessages' },
+      { filename: '<anonymous>', lineno: 1, function: 'JSON.parse' },
+    ]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('does NOT suppress SnapTube-shaped JSON errors when a first-party frame is present', () => {
+    const event = makeEvent('"undefined" is not valid JSON', 'SyntaxError', [
+      firstPartyFrame('src/services/panel-storage.ts', 'readCached'),
+      { filename: '<anonymous>', lineno: 1, function: 'SnapTube.value' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party JSON.parse regression must surface');
+  });
+
+  it('does NOT suppress "is not valid JSON" from an unnamed anonymous bridge', () => {
+    const event = makeEvent('"undefined" is not valid JSON', 'SyntaxError', [
+      { filename: '<anonymous>', lineno: 1, function: 'e.value' },
+      { filename: '<anonymous>', lineno: 1, function: 'JSON.parse' },
+    ]);
+    assert.ok(
+      beforeSend(event) !== null,
+      'suppression must key off the named SnapTube bridge, not bare !hasFirstParty',
+    );
+  });
+
   // WORLDMONITOR-NR: deck.gl/maplibre internal null-access on Layer.isHidden
   // during render (Safari 26.4 beta, empty stacks preceded by DeckGLMap map-error
   // breadcrumbs). `\w{1,3}\.isHidden` is gated on !hasFirstParty so a genuine


### PR DESCRIPTION
`SyntaxError: "undefined" is not valid JSON` (WORLDMONITOR-RA) reaches Sentry from SnapTube's injected Android in-app-WebView JS bridge, which parses its own `undefined` message payload inside a `setTimeout` our SDK instruments; the stack carries a vendor `sentry-*.js` frame plus `<anonymous>` bridge frames (`SnapTube.value`, `Object.jsReceiveMessages`) and nothing first-party.

SnapTube is already classified as noise — `/SnapTube/` sits in `ignoreErrors` next to `iabjs_unified_bridge` and `window.videoSniffer` — but that layer matches the message only, so an event whose attribution lives solely in a frame function slips through. This closes the message-vs-stack gap in `beforeSend` rather than making a new call about the source. The arm is double-gated on `!hasFirstParty` and a named `SnapTube.` frame, so a genuine first-party `JSON.parse(undefined)` still surfaces.

Validation: the suppression test was red before the fix; `tests/sentry-beforesend.test.mjs` is now 230/230 (227 before) and `npm run typecheck` is clean. Mutation-tested — deleting the arm, dropping the `!hasFirstParty` gate, and dropping the named-frame predicate each turn exactly one test red, so every guard and every new test is independently load-bearing.

Related: WORLDMONITOR-RA — https://elie-habib.sentry.io/issues/7481779354/

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
