### PR TITLE
Surface account and billing in one user menu

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -1953,12 +1953,14 @@ export class EventHandlerManager implements AppModule {
     const modal = new AuthLauncher();
     this.ctx.authModal = modal;
 
-    // The settings gear is rendered once by the standalone unifiedSettings
-    // button (#unifiedSettingsMount), which is mounted regardless of auth state
-    // (so signed-out users keep it too). Passing onSettingsClick here makes
-    // AuthHeaderWidget render a second gear next to the avatar for signed-in
-    // users — a duplicate. Leave it unset.
-    const widget = new AuthHeaderWidget(() => modal.open());
+    // The standalone gear remains available to every user. Signed-in users
+    // also get explicit Settings and Plan & billing destinations inside the
+    // avatar menu, keeping account and subscription actions in one place.
+    const widget = new AuthHeaderWidget(
+      () => modal.open(),
+      () => this.ctx.unifiedSettings?.open('settings'),
+      () => this.ctx.unifiedSettings?.open('billing'),
+    );
     this.ctx.authHeaderWidget = widget;
     const mount = document.getElementById('authWidgetMount');
     if (mount) {

--- a/src/components/AuthHeaderWidget.ts
+++ b/src/components/AuthHeaderWidget.ts
@@ -3,17 +3,22 @@ import { mountUserButton, openSignIn, openSignUp } from '@/services/clerk';
 import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
-
 export class AuthHeaderWidget {
   private container: HTMLElement;
   private unsubscribeAuth: (() => void) | null = null;
   private unmountUserButton: (() => void) | null = null;
   private onSignInClick?: () => void;
   private onSettingsClick?: () => void;
+  private onBillingClick?: () => void;
 
-  constructor(onSignInClick?: () => void, onSettingsClick?: () => void) {
+  constructor(
+    onSignInClick?: () => void,
+    onSettingsClick?: () => void,
+    onBillingClick?: () => void,
+  ) {
     this.onSignInClick = onSignInClick;
     this.onSettingsClick = onSettingsClick;
+    this.onBillingClick = onBillingClick;
     this.container = document.createElement('div');
     this.container.className = 'auth-header-widget';
 
@@ -44,7 +49,7 @@ export class AuthHeaderWidget {
     this.unmountUserButton = null;
     this.container.classList.remove('auth-header-widget-pending');
     this.container.removeAttribute('aria-busy');
-    setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
+    setTrustedHtml(this.container, trustedHtml('', 'legacy direct innerHTML migration'));
 
     if (!state.user) {
       this.renderSignedOut();
@@ -58,7 +63,7 @@ export class AuthHeaderWidget {
     this.unmountUserButton = null;
     this.container.classList.add('auth-header-widget-pending');
     this.container.setAttribute('aria-busy', 'true');
-    setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
+    setTrustedHtml(this.container, trustedHtml('', 'legacy direct innerHTML migration'));
 
     const signInSkeleton = document.createElement('span');
     signInSkeleton.className = 'auth-header-skeleton auth-header-skeleton-signin';
@@ -92,19 +97,9 @@ export class AuthHeaderWidget {
     const userBtnEl = document.createElement('div');
     userBtnEl.className = 'auth-clerk-user-button';
     this.container.appendChild(userBtnEl);
-    this.unmountUserButton = mountUserButton(userBtnEl);
-
-    if (this.onSettingsClick) {
-      const settingsBtn = document.createElement('button');
-      settingsBtn.className = 'auth-settings-btn';
-      settingsBtn.type = 'button';
-      settingsBtn.setAttribute('aria-label', t('auth.settings'));
-      settingsBtn.title = t('auth.settings');
-      setTrustedHtml(settingsBtn, trustedHtml(SETTINGS_ICON, "legacy direct innerHTML migration"));
-      settingsBtn.addEventListener('click', () => this.onSettingsClick?.());
-      this.container.appendChild(settingsBtn);
-    }
+    this.unmountUserButton = mountUserButton(userBtnEl, {
+      onBillingClick: this.onBillingClick,
+      onSettingsClick: this.onSettingsClick,
+    });
   }
 }
-
-const SETTINGS_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -618,6 +618,7 @@ export class UnifiedSettings {
     const showMcpClientsTab = hasFeature('mcpAccess');
     const availableTabs: TabId[] = [
       'settings',
+      ...(isSignedIn ? ['billing' as const] : []),
       'panels',
       'sources',
       ...(showNotificationsTab ? ['notifications' as const] : []),
@@ -635,6 +636,7 @@ export class UnifiedSettings {
         </div>
         <div class="unified-settings-tabs" role="tablist" aria-label="Settings">
           <button class="${tabClass('settings')}" tabindex="${this.activeTab === 'settings' ? 0 : -1}" data-tab="settings" role="tab" aria-selected="${this.activeTab === 'settings'}" id="us-tab-settings" aria-controls="us-tab-panel-settings">${t('header.tabSettings')}</button>
+          ${isSignedIn ? `<button class="${tabClass('billing')}" tabindex="${this.activeTab === 'billing' ? 0 : -1}" data-tab="billing" role="tab" aria-selected="${this.activeTab === 'billing'}" id="us-tab-billing" aria-controls="us-tab-panel-billing">Plan &amp; billing</button>` : ''}
           <button class="${tabClass('panels')}" tabindex="${this.activeTab === 'panels' ? 0 : -1}" data-tab="panels" role="tab" aria-selected="${this.activeTab === 'panels'}" id="us-tab-panels" aria-controls="us-tab-panel-panels">${t('header.tabPanels')}</button>
           <button class="${tabClass('sources')}" tabindex="${this.activeTab === 'sources' ? 0 : -1}" data-tab="sources" role="tab" aria-selected="${this.activeTab === 'sources'}" id="us-tab-sources" aria-controls="us-tab-panel-sources">${t('header.tabSources')}</button>
           ${showNotificationsTab ? `<button class="${tabClass('notifications')}" tabindex="${this.activeTab === 'notifications' ? 0 : -1}" data-tab="notifications" role="tab" aria-selected="${this.activeTab === 'notifications'}" id="us-tab-notifications" aria-controls="us-tab-panel-notifications">${t('header.tabNotifications')}</button>` : ''}
@@ -643,8 +645,16 @@ export class UnifiedSettings {
         </div>
         <div class="unified-settings-tab-panel${this.activeTab === 'settings' ? ' active' : ''}" data-panel-id="settings" id="us-tab-panel-settings" role="tabpanel" aria-labelledby="us-tab-settings">
           ${prefs.html}
+        </div>
+        ${isSignedIn ? `
+        <div class="unified-settings-tab-panel${this.activeTab === 'billing' ? ' active' : ''}" data-panel-id="billing" id="us-tab-panel-billing" role="tabpanel" aria-labelledby="us-tab-billing">
+          <div class="billing-settings-intro">
+            <h2>Plan &amp; billing</h2>
+            <p>See your current plan and manage payment details, invoices, or cancellation.</p>
+          </div>
           ${this.renderUpgradeSection()}
         </div>
+        ` : ''}
         <div class="unified-settings-tab-panel${this.activeTab === 'panels' ? ' active' : ''}" data-panel-id="panels" id="us-tab-panel-panels" role="tabpanel" aria-labelledby="us-tab-panels">
           <div class="unified-settings-region-wrapper">
             <div class="unified-settings-region-bar" id="usPanelCatBar"></div>
@@ -769,11 +779,15 @@ export class UnifiedSettings {
   private renderUpgradeSection(): string {
     // Non-Dodo premium (API key / tester key / Clerk pro role without a
     // Convex subscription): neither "Upgrade" nor "Manage Billing" is
-    // actionable. Checked FIRST so these users don't get stuck on the
-    // loading placeholder below — their Convex entitlement snapshot may
-    // never arrive at all.
+    // actionable. Still explain the account state here; a hidden billing
+    // section would recreate the discoverability problem this tab fixes.
     if (!isEntitled() && hasPremiumAccess()) {
-      return '<div class="upgrade-pro-section upgrade-pro-hidden" hidden></div>';
+      return `
+        <div class="upgrade-pro-section upgrade-pro-external" data-billing-state="external">
+          <div class="upgrade-pro-title">Premium access</div>
+          <div class="upgrade-pro-desc">This access is not billed through your WorldMonitor account. No payment method or invoices are available here.</div>
+        </div>
+      `;
     }
     const sub = getSubscription();
     const billingState = deriveBillingUxState(sub, getEntitlementState(), Date.now());
@@ -798,14 +812,12 @@ export class UnifiedSettings {
     // where currentState would otherwise stay null forever and strand a
     // signed-in free user on an empty placeholder).
     if (!this.entitlementReady && getAuthState().user && getEntitlementState() === null) {
-      // `hidden` so the browser's default `[hidden] { display: none }`
-      // suppresses the empty card — without it, the base `.upgrade-pro-
-      // section` styles (margin + padding + border + surface background
-      // in main.css:22833) paint a visibly empty bordered box during the
-      // Convex cold-load window, which is exactly the state we're trying
-      // to clean up. Element stays queryable for the replaceWith swap in
-      // open().
-      return '<div class="upgrade-pro-section upgrade-pro-loading" hidden aria-hidden="true"></div>';
+      return `
+        <div class="upgrade-pro-section upgrade-pro-loading" role="status" aria-live="polite">
+          <div class="upgrade-pro-title">Checking your plan…</div>
+          <div class="upgrade-pro-desc">This usually takes only a moment.</div>
+        </div>
+      `;
     }
     if (isEntitled()) {
       const sub = getSubscription();
@@ -839,6 +851,9 @@ export class UnifiedSettings {
       // billing surface remains owner-only. Show their plan status without
       // the Manage Billing CTA that would 404 against Dodo.
       const hasOwnSubscription = sub !== null;
+      if (!hasOwnSubscription) {
+        statusLine = 'Billing is managed by your plan owner.';
+      }
 
       return `
         <div class="upgrade-pro-section upgrade-pro-active" style="margin-top:16px;padding:14px 16px;border:1px solid ${statusBorderColor};border-radius:6px;background:${statusBgColor};">
@@ -868,17 +883,17 @@ export class UnifiedSettings {
     if (getAuthState().user && getEntitlementState() === null) {
       return `
         <div class="upgrade-pro-section upgrade-pro-fallback">
-          <div class="upgrade-pro-title">Upgrade to Pro</div>
-          <div class="upgrade-pro-desc">Unlock all panels, AI analysis, and priority data refresh.</div>
+          <div class="upgrade-pro-title">Plan status unavailable</div>
+          <div class="upgrade-pro-desc">We could not verify your current plan. View plans in a new tab or try again later.</div>
           <a class="upgrade-pro-cta-link" href="/pro" target="_blank" rel="noopener">View plans →</a>
         </div>
       `;
     }
 
     return `
-      <div class="upgrade-pro-section">
-        <div class="upgrade-pro-title">Upgrade to Pro</div>
-        <div class="upgrade-pro-desc">Unlock all panels, AI analysis, and priority data refresh.</div>
+      <div class="upgrade-pro-section" data-billing-state="free">
+        <div class="upgrade-pro-title">WorldMonitor Free</div>
+        <div class="upgrade-pro-desc">Your current plan is Free. Upgrade for all panels, AI analysis, and priority data refresh.</div>
         <button class="upgrade-pro-cta">Upgrade to Pro</button>
       </div>
     `;

--- a/src/components/settings-types.ts
+++ b/src/components/settings-types.ts
@@ -6,6 +6,7 @@
  */
 export type UnifiedSettingsTabId =
   | 'settings'
+  | 'billing'
   | 'panels'
   | 'sources'
   | 'notifications'

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -245,6 +245,11 @@ export async function initClerk(): Promise<void> {
       await clerk.load({
         clerkUICtor: getClerkUICtor(),
         appearance: getAppearance(),
+        localization: {
+          userButton: {
+            action__manageAccount: 'Profile & security',
+          },
+        },
         afterSignOutUrl: getAfterSignOutUrl(),
       } as Parameters<typeof clerk.load>[0]);
       clerkInstance = clerk;
@@ -675,7 +680,77 @@ export function subscribeClerk(callback: () => void): () => void {
  * Mount Clerk's UserButton component into a DOM element.
  * Returns an unmount function.
  */
-export function mountUserButton(el: HTMLDivElement): () => void {
+export interface UserButtonMenuActions {
+  onBillingClick?: () => void;
+  onSettingsClick?: () => void;
+}
+
+type UserButtonProps = NonNullable<Parameters<ClerkInstance['mountUserButton']>[1]>;
+type CustomMenuItem = NonNullable<UserButtonProps['customMenuItems']>[number];
+type MenuIconKind = 'billing' | 'settings';
+
+function mountMenuIcon(el: HTMLDivElement, kind: MenuIconKind): void {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '16');
+  svg.setAttribute('height', '16');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+
+  const paths = kind === 'billing'
+    ? [
+        'M3 6h18v12H3z',
+        'M3 10h18',
+        'M7 15h3',
+      ]
+    : [
+        'M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z',
+        'M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6v.2h-4V21a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 0 0 .3-1.9A1.7 1.7 0 0 0 3 14H2.8v-4H3a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.2 7 7 4.2l.1.1a1.7 1.7 0 0 0 1.9.3A1.7 1.7 0 0 0 10 3V2.8h4V3a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.2v4H21a1.7 1.7 0 0 0-1.6 1z',
+      ];
+  for (const d of paths) {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', d);
+    svg.appendChild(path);
+  }
+  el.replaceChildren(svg);
+}
+
+export function createAccountMenuItems(actions: UserButtonMenuActions): CustomMenuItem[] {
+  const items: CustomMenuItem[] = [];
+  if (actions.onBillingClick) {
+    items.push({
+      label: 'Plan & billing',
+      onClick: actions.onBillingClick,
+      mountIcon: (el) => mountMenuIcon(el, 'billing'),
+      unmountIcon: (el) => el?.replaceChildren(),
+    });
+  }
+  if (actions.onSettingsClick) {
+    items.push({
+      label: 'Settings',
+      onClick: actions.onSettingsClick,
+      mountIcon: (el) => mountMenuIcon(el, 'settings'),
+      unmountIcon: (el) => el?.replaceChildren(),
+    });
+  }
+  return items;
+}
+
+function getUserButtonProps(actions: UserButtonMenuActions): UserButtonProps {
+  return {
+    appearance: getAppearance(),
+    customMenuItems: createAccountMenuItems(actions),
+  };
+}
+
+export function mountUserButton(
+  el: HTMLDivElement,
+  actions: UserButtonMenuActions = {},
+): () => void {
   if (!clerkInstance) {
     // Deferred-load path: the avatar widget asked to mount before Clerk
     // finished its idle-callback load. Trigger an immediate load and
@@ -685,9 +760,7 @@ export function mountUserButton(el: HTMLDivElement): () => void {
     let realUnmount: (() => void) | null = null;
     void initClerk().then(() => {
       if (cancelled || !clerkInstance) return;
-      clerkInstance.mountUserButton(el, {
-        appearance: getAppearance(),
-      });
+      clerkInstance.mountUserButton(el, getUserButtonProps(actions));
       realUnmount = () => clerkInstance?.unmountUserButton(el);
     });
     return () => {
@@ -695,8 +768,6 @@ export function mountUserButton(el: HTMLDivElement): () => void {
       realUnmount?.();
     };
   }
-  clerkInstance.mountUserButton(el, {
-    appearance: getAppearance(),
-  });
+  clerkInstance.mountUserButton(el, getUserButtonProps(actions));
   return () => clerkInstance?.unmountUserButton(el);
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -19190,7 +19190,7 @@ a.prediction-link:hover {
 }
 
 .unified-settings-modal {
-  max-width: 600px;
+  max-width: 640px;
   width: 95%;
   max-height: 80vh;
 }
@@ -19199,10 +19199,18 @@ a.prediction-link:hover {
   display: flex;
   border-bottom: 1px solid var(--border);
   margin-bottom: 12px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: none;
+}
+
+.unified-settings-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .unified-settings-tab {
-  flex: 1;
+  flex: 1 0 auto;
+  min-height: 44px;
   padding: 10px 12px;
   background: none;
   border: none;
@@ -19215,6 +19223,7 @@ a.prediction-link:hover {
   text-transform: uppercase;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
 }
 
 .unified-settings-tab:hover {
@@ -19233,6 +19242,27 @@ a.prediction-link:hover {
 
 .unified-settings-tab-panel.active {
   display: block;
+}
+
+.billing-settings-intro {
+  display: grid;
+  gap: 4px;
+  padding: 4px 0 8px;
+}
+
+.billing-settings-intro h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.billing-settings-intro p {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.6;
 }
 
 /* Source region pills */

--- a/tests/a11y-issue-5059-invariants.test.mjs
+++ b/tests/a11y-issue-5059-invariants.test.mjs
@@ -143,6 +143,12 @@ describe('keyboard — roving tablist', () => {
       'mcp-clients',
     );
   });
+
+  it('renders Plan & billing as its own signed-in tab and panel', () => {
+    assert.match(settings, /data-tab="billing"[\s\S]*?>Plan &amp; billing<\/button>/);
+    assert.match(settings, /data-panel-id="billing"[\s\S]*?id="us-tab-panel-billing"/);
+    assert.match(settings, /See your current plan and manage payment details, invoices, or cancellation\./);
+  });
 });
 
 describe('keyboard — toggle focus continuity', () => {

--- a/tests/dom/account-menu.test.mts
+++ b/tests/dom/account-menu.test.mts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAccountMenuItems } from '@/services/clerk';
+
+describe('account menu', () => {
+  it('keeps profile, billing, settings, and sign-out actions in Clerk’s user menu', () => {
+    const openBilling = vi.fn();
+    const openSettings = vi.fn();
+    const items = createAccountMenuItems({
+      onBillingClick: openBilling,
+      onSettingsClick: openSettings,
+    });
+
+    expect(items.map((item) => item.label)).toEqual([
+      'Plan & billing',
+      'Settings',
+    ]);
+
+    items[0]?.onClick?.();
+    items[1]?.onClick?.();
+    expect(openBilling).toHaveBeenCalledOnce();
+    expect(openSettings).toHaveBeenCalledOnce();
+  });
+
+  it('mounts quiet decorative icons without exposing them to assistive technology', () => {
+    const items = createAccountMenuItems({
+      onBillingClick: () => {},
+      onSettingsClick: () => {},
+    });
+
+    for (const item of items) {
+      const iconMount = document.createElement('div');
+      item.mountIcon?.(iconMount);
+
+      const svg = iconMount.querySelector('svg');
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute('aria-hidden')).toBe('true');
+      expect(svg?.getAttribute('fill')).toBe('none');
+
+      item.unmountIcon?.(iconMount);
+      expect(iconMount.childElementCount).toBe(0);
+    }
+  });
+
+  it('omits unavailable destinations instead of rendering dead menu items', () => {
+    expect(createAccountMenuItems({})).toEqual([]);
+  });
+});

--- a/tests/seed-gdelt-intel-merge-read-warns.test.mjs
+++ b/tests/seed-gdelt-intel-merge-read-warns.test.mjs
@@ -27,11 +27,14 @@ afterEach(() => {
 
 test('default _loadPrevious retries the Redis read and warns loudly when it stays down', async () => {
   let redisCalls = 0;
+  let nowCalls = 0;
   const warns = [];
   console.warn = (...args) => { warns.push(args.join(' ')); };
-  // Collapse retry backoffs so exhaustion doesn't sleep for real.
+  // Collapse only the Redis retry backoffs so exhaustion doesn't sleep for
+  // real. Keep the ordering-read budget timer intact: collapsing every large
+  // timer also collapses the operation's deadline and races the retry ladder.
   globalThis.setTimeout = (cb, ms, ...args) =>
-    originalSetTimeout(cb, ms >= 500 ? 0 : ms, ...args);
+    originalSetTimeout(cb, ms === 1000 || ms === 2000 ? 0 : ms, ...args);
   globalThis.fetch = async () => {
     redisCalls += 1;
     const err = new Error('The operation was aborted due to timeout');
@@ -39,11 +42,14 @@ test('default _loadPrevious retries the Redis read and warns loudly when it stay
     throw err;
   };
 
-  // Soft budget pre-spent: no topic fetch starts, all 6 topics are empty, so
-  // the cache-merge consults the DEFAULT _loadPrevious (deliberately not
-  // injected here — this test exercises the real wiring).
+  // Give the ordering read a deterministic budget, then advance the injected
+  // run clock before the topic loop. A real 1ms budget made this test
+  // load-dependent: slow CI could spend it before the ordering operation was
+  // even invoked, observing only the later cache-merge read.
   const out = await fetchAllTopics({
-    _softBudgetMs: 1,
+    _now: () => (++nowCalls <= 2 ? 0 : 40_000),
+    _softBudgetMs: 40_000,
+    _minRequestBudgetMs: 35_000,
     _sleep: async () => {},
     _fetchArticles: async () => { throw new Error('must not fetch topics'); },
     _fetchTimeline: async () => [],


### PR DESCRIPTION
## Summary
- rename Clerk's Manage account action to Profile & security
- add Plan & billing and Settings destinations to the signed-in avatar menu
- split billing into a dedicated settings tab with clear free, paid, loading, external, and unavailable states
- keep the expanded tab strip usable on desktop and mobile

## Verification
- npm run typecheck
- npm run test:dom -- tests/dom/account-menu.test.mts tests/dom/unified-settings-account-handoff.test.mts
- TMPDIR=/private/tmp node --import tsx --test tests/a11y-issue-5059-invariants.test.mjs
- VITE_VARIANT=full ./node_modules/.bin/vite build
- full pre-push gate (147 DOM tests, 240 edge tests)