### PR TITLE
fix(mcp): expose commodities news to agents

### DIFF
--- a/api/mcp/registry/nlp-tools.ts
+++ b/api/mcp/registry/nlp-tools.ts
@@ -59,7 +59,7 @@ const DIGEST_ACCUMULATOR_KEY_MCP = 'digest:accumulator:v1:full:en';
 const FULL_DIGEST_CATEGORIES = [
   'politics', 'us', 'europe', 'middleeast', 'tech', 'ai', 'finance',
   'commodities', 'gov', 'africa', 'latam', 'asia', 'energy', 'thinktanks',
-  'crisis', 'layoffs',
+  'crisis', 'layoffs', 'intel',
 ] as const;
 const FULL_DIGEST_CATEGORY_DESC =
   'Restrict to one full-digest category: ' +

--- a/api/mcp/registry/nlp-tools.ts
+++ b/api/mcp/registry/nlp-tools.ts
@@ -52,6 +52,20 @@ const KEYWORD_SPIKE_MAX_STORIES = 800;
 const KEYWORD_SPIKE_MAX_STORED = 25;
 const DIGEST_ACCUMULATOR_KEY_MCP = 'digest:accumulator:v1:full:en';
 
+// Full-variant digest category keys (VARIANT_FEEDS.full). Kept as a local
+// enum so Edge MCP tools never import server/ — parity with _feeds.ts is
+// asserted by tests/agent-commodities-news-parity.test.mts adjacent coverage
+// and the tools/list enum check in mcp-nlp-tools.test.mjs.
+const FULL_DIGEST_CATEGORIES = [
+  'politics', 'us', 'europe', 'middleeast', 'tech', 'ai', 'finance',
+  'commodities', 'gov', 'africa', 'latam', 'asia', 'energy', 'thinktanks',
+  'crisis', 'layoffs',
+] as const;
+const FULL_DIGEST_CATEGORY_DESC =
+  'Restrict to one full-digest category: ' +
+  FULL_DIGEST_CATEGORIES.join(', ') +
+  '. Echoed as `category` in the result; an unknown value yields headlineCount 0 and a `note` listing categories present in the current digest.';
+
 function nlpClampInt(value: unknown, min: number, max: number, fallback: number): number {
   return Number.isInteger(value)
     ? Math.min(max, Math.max(min, value as number))
@@ -65,7 +79,22 @@ function patternEntityKind(value: string): 'cve' | 'apt' | 'fin' | 'leader' {
   return 'leader';
 }
 
-type NlpDigestFetch = { items: NewsItemCore[]; generatedAt: string };
+type NlpDigestCategoryGroup = {
+  items?: Array<{
+    source?: string; title?: string; link?: string; publishedAt?: number;
+    isAlert?: boolean;
+    threat?: { level?: string; category?: string; confidence?: number; source?: string };
+  }>;
+};
+
+type NlpDigestFetch = {
+  items: NewsItemCore[];
+  generatedAt: string;
+  /** Applied category filter, or null when aggregating every full-digest bucket. */
+  category: string | null;
+  /** Present when a non-empty category filter did not match any digest key. */
+  note?: string;
+};
 
 // Caching asymmetry among these four tools is deliberate. get_keyword_spikes
 // caches its result because it fans out across many Redis round trips over a
@@ -80,6 +109,11 @@ type NlpDigestFetch = { items: NewsItemCore[]; generatedAt: string };
  * get_news_clusters: the canonical full/en feed digest (~150-200 titles).
  * Digest items carry no per-source tier, so every item gets a neutral tier
  * and the shared algorithm's primary selection falls back to recency.
+ *
+ * When `category` is set, only that digest bucket is scanned. A miss
+ * (typo or pre-deploy cache) returns zero items plus a `note` that lists
+ * the keys present in the current snapshot so agents can self-correct —
+ * empty-but-valid buckets stay silent (headlineCount 0, no note).
  */
 async function fetchNlpDigestItems(
   base: string,
@@ -94,20 +128,31 @@ async function fetchNlpDigestItems(
   });
   assertToolFetchOk(res, 'list-feed-digest');
   const body = await res.json() as {
-    categories?: Record<string, { items?: Array<{
-      source?: string; title?: string; link?: string; publishedAt?: number;
-      isAlert?: boolean;
-      threat?: { level?: string; category?: string; confidence?: number; source?: string };
-    }> }>;
+    categories?: Record<string, NlpDigestCategoryGroup>;
     generatedAt?: string;
   };
 
   const seen = new Set<string>();
   const items: NewsItemCore[] = [];
   const categories = body.categories ?? {};
-  const groups = category
-    ? (categories[category] ? [categories[category]] : [])
-    : Object.values(categories);
+  const availableCategories = Object.keys(categories).sort();
+  let groups: NlpDigestCategoryGroup[];
+  let note: string | undefined;
+
+  if (!category) {
+    groups = Object.values(categories);
+  } else if (Object.prototype.hasOwnProperty.call(categories, category)) {
+    groups = [categories[category]!];
+  } else {
+    groups = [];
+    // Prefer the live snapshot keys so agents see what this cycle actually
+    // carries; fall back to the static enum when the digest is empty.
+    const listed = availableCategories.length > 0
+      ? availableCategories.join(', ')
+      : FULL_DIGEST_CATEGORIES.join(', ');
+    note = `Unknown digest category "${category}". Available: ${listed}.`;
+  }
+
   for (const group of groups) {
     for (const raw of group.items ?? []) {
       if (!raw?.title || !raw.source) continue;
@@ -130,7 +175,12 @@ async function fetchNlpDigestItems(
       });
     }
   }
-  return { items, generatedAt: body.generatedAt ?? '' };
+  return {
+    items,
+    generatedAt: body.generatedAt ?? '',
+    category: category || null,
+    ...(note ? { note } : {}),
+  };
 }
 
 function nlpRegistryEntities(titles: string[], limit: number) {
@@ -250,12 +300,16 @@ export const NLP_TOOLS: ToolDef[] = [
   {
     name: 'extract_entities',
     _outputBudgetBytes: 16384,
-    description: 'Extract named entities deterministically — registry entities (companies, indices, commodities, crypto, sectors, countries) plus pattern entities (CVE IDs, APT/FIN threat-group designators, tracked world leaders). Supply text (max 2 KB) to extract from it, or omit text to aggregate entities across the current headline digest. No LLM involved.',
+    description: 'Extract named entities deterministically — registry entities (companies, indices, commodities, crypto, sectors, countries) plus pattern entities (CVE IDs, APT/FIN threat-group designators, tracked world leaders). Supply text (max 2 KB) to extract from it, or omit text to aggregate entities across the current headline digest (optionally restricted with category, e.g. "commodities"). No LLM involved.',
     inputSchema: {
       type: 'object',
       properties: {
         text: { type: 'string', maxLength: EXTRACT_TEXT_MAX_CHARS, description: 'Optional text to extract from (max 2048 characters; longer input is rejected). When omitted, the tool aggregates entities across recent headlines.' },
-        category: { type: 'string', description: 'When text is omitted, restrict headline aggregation to one full-digest category (for example "commodities", "politics", or "finance").' },
+        category: {
+          type: 'string',
+          enum: [...FULL_DIGEST_CATEGORIES],
+          description: 'When text is omitted, ' + FULL_DIGEST_CATEGORY_DESC,
+        },
         limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum entities per list. Defaults to 20.' },
       },
       required: [],
@@ -282,6 +336,8 @@ export const NLP_TOOLS: ToolDef[] = [
         },
         headlineCount: { type: 'number', description: 'Headlines scanned (headlines mode only).' },
         generatedAt: { type: 'string', description: 'Digest snapshot time (headlines mode only).' },
+        category: { type: ['string', 'null'], description: 'Applied full-digest category filter in headlines mode; null when scanning every category. Omitted in text mode.' },
+        note: { type: 'string', description: 'Present in headlines mode when category did not match any digest key (typo or missing bucket).' },
         error: { type: 'string', description: 'Present instead of a result when input validation fails.' },
       },
     },
@@ -317,13 +373,17 @@ export const NLP_TOOLS: ToolDef[] = [
         };
       }
 
+      // Accept enum values plus non-enum strings so non-validating clients still
+      // get a corrective note instead of a hard schema failure at the edge.
       const category = argStr(params.category);
-      const { items, generatedAt } = await fetchNlpDigestItems(base, context, category);
-      const aggregated = nlpRegistryEntities(items.map(item => item.title), limit);
+      const digest = await fetchNlpDigestItems(base, context, category);
+      const aggregated = nlpRegistryEntities(digest.items.map(item => item.title), limit);
       return {
         mode: 'headlines',
-        headlineCount: items.length,
-        generatedAt,
+        headlineCount: digest.items.length,
+        generatedAt: digest.generatedAt,
+        category: digest.category,
+        ...(digest.note ? { note: digest.note } : {}),
         ...aggregated,
       };
     },
@@ -334,19 +394,23 @@ export const NLP_TOOLS: ToolDef[] = [
   {
     name: 'get_news_clusters',
     _outputBudgetBytes: 32768,
-    description: 'Current topic clusters over the live headline digest, computed with the same Jaccard clustering the dashboard uses. Each cluster reports its primary headline, member count, distinct sources, top keywords, threat level, and time span. Deterministic — no LLM.',
+    description: 'Current topic clusters over the live headline digest, computed with the same Jaccard clustering the dashboard uses. Optional category restricts clustering to one full-digest bucket (e.g. "commodities"). Each cluster reports its primary headline, member count, distinct sources, top keywords, threat level, and time span. Deterministic — no LLM.',
     inputSchema: {
       type: 'object',
       properties: {
         limit: { type: 'integer', minimum: 1, maximum: 25, description: 'Maximum clusters returned. Defaults to 10.' },
         min_sources: { type: 'integer', minimum: 1, maximum: 10, description: 'Only return clusters carrying at least this many DISTINCT sources (outlets), not merely this many member headlines. Defaults to 1.' },
-        category: { type: 'string', description: 'Restrict clustering to one full-digest category (for example "commodities", "politics", or "finance").' },
+        category: {
+          type: 'string',
+          enum: [...FULL_DIGEST_CATEGORIES],
+          description: FULL_DIGEST_CATEGORY_DESC,
+        },
       },
       required: [],
     },
     outputSchema: {
       type: 'object',
-      required: ['clusters', 'totalClusters', 'headlineCount', 'generatedAt'],
+      required: ['clusters', 'totalClusters', 'headlineCount', 'generatedAt', 'category'],
       properties: {
         clusters: {
           type: 'array',
@@ -366,6 +430,8 @@ export const NLP_TOOLS: ToolDef[] = [
         totalClusters: { type: 'number', description: 'Cluster count before limit/min_sources filtering.' },
         headlineCount: { type: 'number' },
         generatedAt: { type: 'string' },
+        category: { type: ['string', 'null'], description: 'Applied full-digest category filter; null when clustering every category.' },
+        note: { type: 'string', description: 'Present when category did not match any digest key (typo or missing bucket).' },
       },
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
@@ -373,8 +439,8 @@ export const NLP_TOOLS: ToolDef[] = [
       const limit = nlpClampInt(params.limit, 1, 25, 10);
       const minSources = nlpClampInt(params.min_sources, 1, 10, 1);
       const category = argStr(params.category);
-      const { items, generatedAt } = await fetchNlpDigestItems(base, context, category);
-      const clusters = clusterNewsCore(items, () => 3);
+      const digest = await fetchNlpDigestItems(base, context, category);
+      const clusters = clusterNewsCore(digest.items, () => 3);
       const projected = clusters.map(cluster => {
         const sources = [...new Set(cluster.allItems.map(item => item.source))];
         return {
@@ -400,8 +466,10 @@ export const NLP_TOOLS: ToolDef[] = [
           .filter(cluster => cluster.distinctSourceCount >= minSources)
           .slice(0, limit),
         totalClusters: clusters.length,
-        headlineCount: items.length,
-        generatedAt,
+        headlineCount: digest.items.length,
+        generatedAt: digest.generatedAt,
+        category: digest.category,
+        ...(digest.note ? { note: digest.note } : {}),
       };
     },
     _apiPaths: [

--- a/api/mcp/registry/nlp-tools.ts
+++ b/api/mcp/registry/nlp-tools.ts
@@ -25,6 +25,7 @@ import { clusterNewsCore, protoThreatLevelToLabel, topClusterKeywords } from '..
 import type { NewsItemCore } from '../../../shared/news-clustering-core.js';
 import { buildAuthHeaders } from '../auth';
 import { assertToolFetchOk } from '../billing-denial';
+import { argStr } from '../filters';
 import type { ToolDef } from '../types';
 
 // ── #5697 on-demand NLP intelligence utilities ──────────────────────────────
@@ -83,6 +84,7 @@ type NlpDigestFetch = { items: NewsItemCore[]; generatedAt: string };
 async function fetchNlpDigestItems(
   base: string,
   context: Parameters<typeof buildAuthHeaders>[0],
+  category = '',
 ): Promise<NlpDigestFetch> {
   const digestUrl = `${base}/api/news/v1/list-feed-digest?variant=full&lang=en`;
   const auth = await buildAuthHeaders(context, 'GET', digestUrl, null);
@@ -102,7 +104,11 @@ async function fetchNlpDigestItems(
 
   const seen = new Set<string>();
   const items: NewsItemCore[] = [];
-  for (const group of Object.values(body.categories ?? {})) {
+  const categories = body.categories ?? {};
+  const groups = category
+    ? (categories[category] ? [categories[category]] : [])
+    : Object.values(categories);
+  for (const group of groups) {
     for (const raw of group.items ?? []) {
       if (!raw?.title || !raw.source) continue;
       const key = raw.link || `${raw.source}|${raw.title}`;
@@ -249,6 +255,7 @@ export const NLP_TOOLS: ToolDef[] = [
       type: 'object',
       properties: {
         text: { type: 'string', maxLength: EXTRACT_TEXT_MAX_CHARS, description: 'Optional text to extract from (max 2048 characters; longer input is rejected). When omitted, the tool aggregates entities across recent headlines.' },
+        category: { type: 'string', description: 'When text is omitted, restrict headline aggregation to one full-digest category (for example "commodities", "politics", or "finance").' },
         limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum entities per list. Defaults to 20.' },
       },
       required: [],
@@ -310,7 +317,8 @@ export const NLP_TOOLS: ToolDef[] = [
         };
       }
 
-      const { items, generatedAt } = await fetchNlpDigestItems(base, context);
+      const category = argStr(params.category);
+      const { items, generatedAt } = await fetchNlpDigestItems(base, context, category);
       const aggregated = nlpRegistryEntities(items.map(item => item.title), limit);
       return {
         mode: 'headlines',
@@ -332,6 +340,7 @@ export const NLP_TOOLS: ToolDef[] = [
       properties: {
         limit: { type: 'integer', minimum: 1, maximum: 25, description: 'Maximum clusters returned. Defaults to 10.' },
         min_sources: { type: 'integer', minimum: 1, maximum: 10, description: 'Only return clusters carrying at least this many DISTINCT sources (outlets), not merely this many member headlines. Defaults to 1.' },
+        category: { type: 'string', description: 'Restrict clustering to one full-digest category (for example "commodities", "politics", or "finance").' },
       },
       required: [],
     },
@@ -363,7 +372,8 @@ export const NLP_TOOLS: ToolDef[] = [
     _execute: async (params, base, context) => {
       const limit = nlpClampInt(params.limit, 1, 25, 10);
       const minSources = nlpClampInt(params.min_sources, 1, 10, 1);
-      const { items, generatedAt } = await fetchNlpDigestItems(base, context);
+      const category = argStr(params.category);
+      const { items, generatedAt } = await fetchNlpDigestItems(base, context, category);
       const clusters = clusterNewsCore(items, () => 3);
       const projected = clusters.map(cluster => {
         const sources = [...new Set(cluster.allItems.map(item => item.source))];

--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -413,6 +413,7 @@ The public server digest feed inventory below is source-backed from `server/worl
 | `full` | `tech` | Hacker News; Ars Technica; The Verge; MIT Tech Review |
 | `full` | `ai` | AI News; VentureBeat AI; The Verge AI; MIT Tech Review; ArXiv AI |
 | `full` | `finance` | CNBC; MarketWatch; Yahoo Finance; Financial Times; Reuters Business |
+| `full` | `commodities` | Oil & Gas; Gold & Metals |
 | `full` | `gov` | White House; White House Actions; State Dept; Pentagon; Federal Reserve; SEC; UN News; CISA; Treasury; DOJ |
 | `full` | `africa` | BBC Africa; News24; Africanews; Jeune Afrique (fr); Premium Times |
 | `full` | `latam` | BBC Latin America; Guardian Americas; Primicias (es); Infobae Americas (es); El Universo (es); Clarín (es); InSight Crime |

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -737,7 +737,7 @@ Deterministic named-entity extraction shared with the dashboard: registry entiti
 | Name | Type | Description |
 |------|------|-------------|
 | `text` | string | Optional text to extract from, max 2048 characters (longer input is rejected with an `error`). When omitted, the tool aggregates entities across the current headline digest instead. |
-| `category` | string | In headlines mode, restrict aggregation to one full-digest category, such as `commodities`, `politics`, or `finance`. |
+| `category` | string (enum) | In headlines mode, restrict aggregation to one full-digest category (`politics`, `us`, `europe`, `middleeast`, `tech`, `ai`, `finance`, `commodities`, `gov`, `africa`, `latam`, `asia`, `energy`, `thinktanks`, `crisis`, `layoffs`). Echoed as `category` in the result (`null` when omitted). An unknown value yields `headlineCount: 0` and a `note` listing categories present in the current digest. |
 | `limit` | integer | Maximum entities per list (1-50). Defaults to 20. |
 
 - **API endpoint:** `GET /api/news/v1/list-feed-digest` (headlines mode only; text mode performs no fetch).
@@ -769,7 +769,7 @@ Current topic clusters computed over the live headline digest with the same Jacc
 |------|------|-------------|
 | `limit` | integer | Maximum clusters returned (1-25). Defaults to 10. |
 | `min_sources` | integer | Only return clusters carrying at least this many **distinct outlets** (1-10) — real corroboration, not one outlet filing twice. Defaults to 1. |
-| `category` | string | Restrict clustering to one full-digest category, such as `commodities`, `politics`, or `finance`. |
+| `category` | string (enum) | Restrict clustering to one full-digest category (`politics`, `us`, `europe`, `middleeast`, `tech`, `ai`, `finance`, `commodities`, `gov`, `africa`, `latam`, `asia`, `energy`, `thinktanks`, `crisis`, `layoffs`). Echoed as `category` in the result (`null` when omitted). An unknown value yields `headlineCount: 0` and a `note` listing categories present in the current digest. |
 
 - **API endpoint:** `GET /api/news/v1/list-feed-digest`
 - **Kind:** deterministic local compute — clustering runs per call over the ~150-200 digest headlines (CDN/Redis-cached upstream, 15-min cadence).

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -737,7 +737,7 @@ Deterministic named-entity extraction shared with the dashboard: registry entiti
 | Name | Type | Description |
 |------|------|-------------|
 | `text` | string | Optional text to extract from, max 2048 characters (longer input is rejected with an `error`). When omitted, the tool aggregates entities across the current headline digest instead. |
-| `category` | string (enum) | In headlines mode, restrict aggregation to one full-digest category (`politics`, `us`, `europe`, `middleeast`, `tech`, `ai`, `finance`, `commodities`, `gov`, `africa`, `latam`, `asia`, `energy`, `thinktanks`, `crisis`, `layoffs`). Echoed as `category` in the result (`null` when omitted). An unknown value yields `headlineCount: 0` and a `note` listing categories present in the current digest. |
+| `category` | string (enum) | In headlines mode, restrict aggregation to one full-digest category (`politics`, `us`, `europe`, `middleeast`, `tech`, `ai`, `finance`, `commodities`, `gov`, `africa`, `latam`, `asia`, `energy`, `thinktanks`, `crisis`, `layoffs`, `intel`). Echoed as `category` in the result (`null` when omitted). An unknown value yields `headlineCount: 0` and a `note` listing categories present in the current digest. |
 | `limit` | integer | Maximum entities per list (1-50). Defaults to 20. |
 
 - **API endpoint:** `GET /api/news/v1/list-feed-digest` (headlines mode only; text mode performs no fetch).
@@ -769,7 +769,7 @@ Current topic clusters computed over the live headline digest with the same Jacc
 |------|------|-------------|
 | `limit` | integer | Maximum clusters returned (1-25). Defaults to 10. |
 | `min_sources` | integer | Only return clusters carrying at least this many **distinct outlets** (1-10) — real corroboration, not one outlet filing twice. Defaults to 1. |
-| `category` | string (enum) | Restrict clustering to one full-digest category (`politics`, `us`, `europe`, `middleeast`, `tech`, `ai`, `finance`, `commodities`, `gov`, `africa`, `latam`, `asia`, `energy`, `thinktanks`, `crisis`, `layoffs`). Echoed as `category` in the result (`null` when omitted). An unknown value yields `headlineCount: 0` and a `note` listing categories present in the current digest. |
+| `category` | string (enum) | Restrict clustering to one full-digest category (`politics`, `us`, `europe`, `middleeast`, `tech`, `ai`, `finance`, `commodities`, `gov`, `africa`, `latam`, `asia`, `energy`, `thinktanks`, `crisis`, `layoffs`, `intel`). Echoed as `category` in the result (`null` when omitted). An unknown value yields `headlineCount: 0` and a `note` listing categories present in the current digest. |
 
 - **API endpoint:** `GET /api/news/v1/list-feed-digest`
 - **Kind:** deterministic local compute — clustering runs per call over the ~150-200 digest headlines (CDN/Redis-cached upstream, 15-min cadence).

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -737,6 +737,7 @@ Deterministic named-entity extraction shared with the dashboard: registry entiti
 | Name | Type | Description |
 |------|------|-------------|
 | `text` | string | Optional text to extract from, max 2048 characters (longer input is rejected with an `error`). When omitted, the tool aggregates entities across the current headline digest instead. |
+| `category` | string | In headlines mode, restrict aggregation to one full-digest category, such as `commodities`, `politics`, or `finance`. |
 | `limit` | integer | Maximum entities per list (1-50). Defaults to 20. |
 
 - **API endpoint:** `GET /api/news/v1/list-feed-digest` (headlines mode only; text mode performs no fetch).
@@ -768,6 +769,7 @@ Current topic clusters computed over the live headline digest with the same Jacc
 |------|------|-------------|
 | `limit` | integer | Maximum clusters returned (1-25). Defaults to 10. |
 | `min_sources` | integer | Only return clusters carrying at least this many **distinct outlets** (1-10) — real corroboration, not one outlet filing twice. Defaults to 1. |
+| `category` | string | Restrict clustering to one full-digest category, such as `commodities`, `politics`, or `finance`. |
 
 - **API endpoint:** `GET /api/news/v1/list-feed-digest`
 - **Kind:** deterministic local compute — clustering runs per call over the ~150-200 digest headlines (CDN/Redis-cached upstream, 15-min cadence).
@@ -782,7 +784,7 @@ curl -s https://worldmonitor.app/mcp \
   -d '{
     "jsonrpc":"2.0","id":1,
     "method":"tools/call",
-    "params":{"name":"get_news_clusters","arguments":{"min_sources":2,"limit":10}}
+    "params":{"name":"get_news_clusters","arguments":{"category":"commodities","min_sources":2,"limit":10}}
   }'
 ```
 

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -737,7 +737,7 @@ curl -s https://worldmonitor.app/mcp \
 | 名称 | 类型 | 描述 |
 |------|------|------|
 | `text` | string | 可选的提取文本，最长 2048 字符（超长输入返回 `error`）。省略时，工具转而跨当前头条摘要聚合实体。 |
-| `category` | string（枚举） | 在头条模式下，将聚合限制为一个完整摘要类别（`politics`、`us`、`europe`、`middleeast`、`tech`、`ai`、`finance`、`commodities`、`gov`、`africa`、`latam`、`asia`、`energy`、`thinktanks`、`crisis`、`layoffs`）。结果中以 `category` 回显（省略时为 `null`）。未知值返回 `headlineCount: 0`，并以 `note` 列出当前摘要中存在的类别。 |
+| `category` | string（枚举） | 在头条模式下，将聚合限制为一个完整摘要类别（`politics`、`us`、`europe`、`middleeast`、`tech`、`ai`、`finance`、`commodities`、`gov`、`africa`、`latam`、`asia`、`energy`、`thinktanks`、`crisis`、`layoffs`、`intel`）。结果中以 `category` 回显（省略时为 `null`）。未知值返回 `headlineCount: 0`，并以 `note` 列出当前摘要中存在的类别。 |
 | `limit` | integer | 每个列表的最大实体数（1-50）。默认 20。 |
 
 - **API 端点：** `GET /api/news/v1/list-feed-digest`（仅头条模式；文本模式不发起任何请求）。
@@ -769,7 +769,7 @@ curl -s https://worldmonitor.app/mcp \
 |------|------|------|
 | `limit` | integer | 返回簇的上限（1-25）。默认 10。 |
 | `min_sources` | integer | 仅返回覆盖**不同媒体来源数**不低于该值的簇（1-10）—— 真正的交叉印证，而非同一家媒体重复发稿。默认 1。 |
-| `category` | string（枚举） | 将聚类限制为一个完整摘要类别（`politics`、`us`、`europe`、`middleeast`、`tech`、`ai`、`finance`、`commodities`、`gov`、`africa`、`latam`、`asia`、`energy`、`thinktanks`、`crisis`、`layoffs`）。结果中以 `category` 回显（省略时为 `null`）。未知值返回 `headlineCount: 0`，并以 `note` 列出当前摘要中存在的类别。 |
+| `category` | string（枚举） | 将聚类限制为一个完整摘要类别（`politics`、`us`、`europe`、`middleeast`、`tech`、`ai`、`finance`、`commodities`、`gov`、`africa`、`latam`、`asia`、`energy`、`thinktanks`、`crisis`、`layoffs`、`intel`）。结果中以 `category` 回显（省略时为 `null`）。未知值返回 `headlineCount: 0`，并以 `note` 列出当前摘要中存在的类别。 |
 
 - **API 端点：** `GET /api/news/v1/list-feed-digest`
 - **类型：** 确定性本地计算 —— 每次调用对约 150-200 条摘要头条运行聚类（上游为 CDN/Redis 缓存，15 分钟节奏）。

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -737,6 +737,7 @@ curl -s https://worldmonitor.app/mcp \
 | 名称 | 类型 | 描述 |
 |------|------|------|
 | `text` | string | 可选的提取文本，最长 2048 字符（超长输入返回 `error`）。省略时，工具转而跨当前头条摘要聚合实体。 |
+| `category` | string | 在头条模式下，将聚合限制为一个完整摘要类别，例如 `commodities`、`politics` 或 `finance`。 |
 | `limit` | integer | 每个列表的最大实体数（1-50）。默认 20。 |
 
 - **API 端点：** `GET /api/news/v1/list-feed-digest`（仅头条模式；文本模式不发起任何请求）。
@@ -768,6 +769,7 @@ curl -s https://worldmonitor.app/mcp \
 |------|------|------|
 | `limit` | integer | 返回簇的上限（1-25）。默认 10。 |
 | `min_sources` | integer | 仅返回覆盖**不同媒体来源数**不低于该值的簇（1-10）—— 真正的交叉印证，而非同一家媒体重复发稿。默认 1。 |
+| `category` | string | 将聚类限制为一个完整摘要类别，例如 `commodities`、`politics` 或 `finance`。 |
 
 - **API 端点：** `GET /api/news/v1/list-feed-digest`
 - **类型：** 确定性本地计算 —— 每次调用对约 150-200 条摘要头条运行聚类（上游为 CDN/Redis 缓存，15 分钟节奏）。
@@ -782,7 +784,7 @@ curl -s https://worldmonitor.app/mcp \
   -d '{
     "jsonrpc":"2.0","id":1,
     "method":"tools/call",
-    "params":{"name":"get_news_clusters","arguments":{"min_sources":2,"limit":10}}
+    "params":{"name":"get_news_clusters","arguments":{"category":"commodities","min_sources":2,"limit":10}}
   }'
 ```
 

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -737,7 +737,7 @@ curl -s https://worldmonitor.app/mcp \
 | 名称 | 类型 | 描述 |
 |------|------|------|
 | `text` | string | 可选的提取文本，最长 2048 字符（超长输入返回 `error`）。省略时，工具转而跨当前头条摘要聚合实体。 |
-| `category` | string | 在头条模式下，将聚合限制为一个完整摘要类别，例如 `commodities`、`politics` 或 `finance`。 |
+| `category` | string（枚举） | 在头条模式下，将聚合限制为一个完整摘要类别（`politics`、`us`、`europe`、`middleeast`、`tech`、`ai`、`finance`、`commodities`、`gov`、`africa`、`latam`、`asia`、`energy`、`thinktanks`、`crisis`、`layoffs`）。结果中以 `category` 回显（省略时为 `null`）。未知值返回 `headlineCount: 0`，并以 `note` 列出当前摘要中存在的类别。 |
 | `limit` | integer | 每个列表的最大实体数（1-50）。默认 20。 |
 
 - **API 端点：** `GET /api/news/v1/list-feed-digest`（仅头条模式；文本模式不发起任何请求）。
@@ -769,7 +769,7 @@ curl -s https://worldmonitor.app/mcp \
 |------|------|------|
 | `limit` | integer | 返回簇的上限（1-25）。默认 10。 |
 | `min_sources` | integer | 仅返回覆盖**不同媒体来源数**不低于该值的簇（1-10）—— 真正的交叉印证，而非同一家媒体重复发稿。默认 1。 |
-| `category` | string | 将聚类限制为一个完整摘要类别，例如 `commodities`、`politics` 或 `finance`。 |
+| `category` | string（枚举） | 将聚类限制为一个完整摘要类别（`politics`、`us`、`europe`、`middleeast`、`tech`、`ai`、`finance`、`commodities`、`gov`、`africa`、`latam`、`asia`、`energy`、`thinktanks`、`crisis`、`layoffs`）。结果中以 `category` 回显（省略时为 `null`）。未知值返回 `headlineCount: 0`，并以 `note` 列出当前摘要中存在的类别。 |
 
 - **API 端点：** `GET /api/news/v1/list-feed-digest`
 - **类型：** 确定性本地计算 —— 每次调用对约 150-200 条摘要头条运行聚类（上游为 CDN/Redis 缓存，15 分钟节奏）。

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -258,11 +258,11 @@
     },
     {
       "name": "extract_entities",
-      "description": "Extract named entities deterministically — registry entities (companies, indices, commodities, crypto, sectors, countries) plus pattern entities (CVE IDs, APT/FIN threat-group designators, tracked world leaders). Supply text (max 2 KB) to extract from it, or omit text to aggregate entities across the current headline digest. No LLM involved."
+      "description": "Extract named entities deterministically — registry entities (companies, indices, commodities, crypto, sectors, countries) plus pattern entities (CVE IDs, APT/FIN threat-group designators, tracked world leaders). Supply text (max 2 KB) to extract from it, or omit text to aggregate entities across the current headline digest (optionally restricted with category, e.g. \"commodities\"). No LLM involved."
     },
     {
       "name": "get_news_clusters",
-      "description": "Current topic clusters over the live headline digest, computed with the same Jaccard clustering the dashboard uses. Each cluster reports its primary headline, member count, distinct sources, top keywords, threat level, and time span. Deterministic — no LLM."
+      "description": "Current topic clusters over the live headline digest, computed with the same Jaccard clustering the dashboard uses. Optional category restricts clustering to one full-digest bucket (e.g. \"commodities\"). Each cluster reports its primary headline, member count, distinct sources, top keywords, threat level, and time span. Deterministic — no LLM."
     },
     {
       "name": "get_keyword_spikes",

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -89,6 +89,13 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Financial Times', url: 'https://www.ft.com/rss/home' },
       { name: 'Reuters Business', url: gn('site:reuters.com business markets when:1d') },
     ],
+    // MCP digest-backed tools consume `full`, while the finance dashboard
+    // consumes `finance`. Keep this literal array aligned with the finance
+    // bucket below; the static per-variant feed-key guard requires literals.
+    commodities: [
+      { name: 'Oil & Gas', url: gn('(oil price OR OPEC OR "natural gas" OR pipeline OR LNG) when:2d') },
+      { name: 'Gold & Metals', url: gn('("gold price" OR "silver price" OR "precious metals" OR "copper price") when:2d') },
+    ],
     gov: [
       // White House: two direct WordPress RSS feeds. Replaces
       // gn('site:whitehouse.gov ...') so the publisher's pubDate is

--- a/tests/agent-commodities-news-parity.test.mts
+++ b/tests/agent-commodities-news-parity.test.mts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { VARIANT_FEEDS } from '../server/worldmonitor/news/v1/_feeds.ts';
+import { INTEL_SOURCES, VARIANT_FEEDS } from '../server/worldmonitor/news/v1/_feeds.ts';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -29,11 +29,29 @@ describe('commodities news agent parity (#5889)', () => {
     );
     assert.ok(match, 'FULL_DIGEST_CATEGORIES must be declared in nlp-tools.ts');
     const enumKeys = [...match[1].matchAll(/'([a-z0-9_-]+)'/g)].map((m) => m[1]).sort();
-    const feedKeys = Object.keys(VARIANT_FEEDS.full ?? {}).sort();
+    const feedKeys = [
+      ...Object.keys(VARIANT_FEEDS.full ?? {}),
+      ...(INTEL_SOURCES.length > 0 ? ['intel'] : []),
+    ].sort();
     assert.deepEqual(
       enumKeys,
       feedKeys,
-      'FULL_DIGEST_CATEGORIES must list every VARIANT_FEEDS.full key (and no extras)',
+      'FULL_DIGEST_CATEGORIES must list every category emitted by the full digest (and no extras)',
     );
+  });
+
+  it('keeps the published MCP server card discoverable for category filtering', () => {
+    const card = JSON.parse(readFileSync(
+      join(ROOT, 'public/.well-known/mcp/server-card.json'),
+      'utf8',
+    ));
+    const tools = new Map((card.tools ?? []).map((tool) => [tool.name, tool.description]));
+    for (const name of ['extract_entities', 'get_news_clusters']) {
+      const description = tools.get(name) ?? '';
+      assert.match(description, /category/,
+        `${name} server-card description must advertise category filtering`);
+      assert.match(description, /commodities/,
+        `${name} server-card description must advertise commodities filtering`);
+    }
   });
 });

--- a/tests/agent-commodities-news-parity.test.mts
+++ b/tests/agent-commodities-news-parity.test.mts
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { VARIANT_FEEDS } from '../server/worldmonitor/news/v1/_feeds.ts';
+
+describe('commodities news agent parity (#5889)', () => {
+  it('exposes the finance dashboard commodities bucket in the full digest used by agents', () => {
+    const financeCommodities = VARIANT_FEEDS.finance?.commodities;
+    const agentCommodities = VARIANT_FEEDS.full?.commodities;
+
+    assert.ok(financeCommodities?.length, 'finance dashboard commodities feeds must exist');
+    assert.ok(agentCommodities?.length, 'full agent digest must expose a commodities category');
+    assert.deepEqual(
+      agentCommodities,
+      financeCommodities,
+      'agents and the finance dashboard must read the same commodities headline sources',
+    );
+  });
+});

--- a/tests/agent-commodities-news-parity.test.mts
+++ b/tests/agent-commodities-news-parity.test.mts
@@ -1,7 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { VARIANT_FEEDS } from '../server/worldmonitor/news/v1/_feeds.ts';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 describe('commodities news agent parity (#5889)', () => {
   it('exposes the finance dashboard commodities bucket in the full digest used by agents', () => {
@@ -14,6 +19,21 @@ describe('commodities news agent parity (#5889)', () => {
       agentCommodities,
       financeCommodities,
       'agents and the finance dashboard must read the same commodities headline sources',
+    );
+  });
+
+  it('keeps the MCP full-digest category enum aligned with VARIANT_FEEDS.full keys', () => {
+    const nlpSrc = readFileSync(join(ROOT, 'api/mcp/registry/nlp-tools.ts'), 'utf8');
+    const match = nlpSrc.match(
+      /const FULL_DIGEST_CATEGORIES = \[([\s\S]*?)\] as const;/,
+    );
+    assert.ok(match, 'FULL_DIGEST_CATEGORIES must be declared in nlp-tools.ts');
+    const enumKeys = [...match[1].matchAll(/'([a-z0-9_-]+)'/g)].map((m) => m[1]).sort();
+    const feedKeys = Object.keys(VARIANT_FEEDS.full ?? {}).sort();
+    assert.deepEqual(
+      enumKeys,
+      feedKeys,
+      'FULL_DIGEST_CATEGORIES must list every VARIANT_FEEDS.full key (and no extras)',
     );
   });
 });

--- a/tests/mcp-nlp-tools.test.mjs
+++ b/tests/mcp-nlp-tools.test.mjs
@@ -205,11 +205,19 @@ describe('#5697 NLP MCP tools', () => {
       byName.get('extract_entities')?.inputSchema.properties.category.enum?.includes('commodities'),
       'extract_entities category enum must include commodities',
     );
+    assert.ok(
+      byName.get('extract_entities')?.inputSchema.properties.category.enum?.includes('intel'),
+      'extract_entities category enum must include intel',
+    );
     assert.equal(byName.get('get_news_clusters')?.inputSchema.properties.limit.maximum, 25);
     assert.equal(byName.get('get_news_clusters')?.inputSchema.properties.category.type, 'string');
     assert.ok(
       byName.get('get_news_clusters')?.inputSchema.properties.category.enum?.includes('commodities'),
       'get_news_clusters category enum must include commodities',
+    );
+    assert.ok(
+      byName.get('get_news_clusters')?.inputSchema.properties.category.enum?.includes('intel'),
+      'get_news_clusters category enum must include intel',
     );
     assert.equal(byName.get('get_keyword_spikes')?.inputSchema.properties.window_hours.maximum, 12);
     const classifyOutput = byName.get('classify_event')?.outputSchema;
@@ -396,6 +404,54 @@ describe('#5697 NLP MCP tools', () => {
       });
     });
 
+    it('can restrict digest aggregation to the intel category', async () => {
+      await withDigestCategories({
+        politics: {
+          items: [
+            { source: 'AP', title: 'CVE-2026-9999 prompts an emergency regional summit', link: 'https://n/politics', publishedAt: 1785405600000 },
+          ],
+        },
+        intel: {
+          items: [
+            { source: 'Defense One', title: 'CVE-2026-7777 tracked by APT28 in military networks', link: 'https://n/intel', publishedAt: 1785405700000 },
+          ],
+        },
+      }, async () => {
+        const { result } = await callTool('extract_entities', { category: 'intel' });
+        assert.equal(result.headlineCount, 1);
+        assert.equal(result.category, 'intel');
+        assert.equal(result.note, undefined);
+        assert.ok(result.patternEntities.some((entity) => entity.value === 'CVE-2026-7777'));
+        assert.equal(
+          result.patternEntities.some((entity) => entity.value === 'CVE-2026-9999'),
+          false,
+        );
+      });
+    });
+
+    it('keeps a present but empty category distinct from an unknown category', async () => {
+      await withDigestCategories({ commodities: { items: [] } }, async () => {
+        const { result } = await callTool('extract_entities', { category: 'commodities' });
+        assert.equal(result.headlineCount, 0);
+        assert.equal(result.category, 'commodities');
+        assert.equal(result.note, undefined);
+        assert.deepEqual(result.entities, []);
+        assert.deepEqual(result.patternEntities, []);
+      });
+    });
+
+    it('lists the static category inventory when the digest has no buckets', async () => {
+      await withDigestCategories({}, async () => {
+        const { result } = await callTool('extract_entities', { category: 'commodities' });
+        assert.equal(result.headlineCount, 0);
+        assert.equal(result.category, 'commodities');
+        assert.match(result.note, /Unknown digest category "commodities"/);
+        assert.match(result.note, /intel/);
+        assert.deepEqual(result.entities, []);
+        assert.deepEqual(result.patternEntities, []);
+      });
+    });
+
     it('returns a corrective note when category is unknown', async () => {
       await withDigestCategories({
         politics: {
@@ -462,6 +518,51 @@ describe('#5697 NLP MCP tools', () => {
         assert.equal(result.category, 'commodities');
         assert.equal(result.note, undefined);
         assert.match(result.clusters[0].title, /Crude oil/);
+      });
+    });
+
+    it('can restrict clustering to the intel category', async () => {
+      await withDigestCategories({
+        politics: {
+          items: [
+            { source: 'AP', title: 'Diplomatic talks resume after regional summit', link: 'https://n/politics', publishedAt: 1785405600000 },
+          ],
+        },
+        intel: {
+          items: [
+            { source: 'Defense One', title: 'Military networks targeted by APT28 operators', link: 'https://n/intel', publishedAt: 1785405700000 },
+          ],
+        },
+      }, async () => {
+        const { result } = await callTool('get_news_clusters', { category: 'intel' });
+        assert.equal(result.headlineCount, 1);
+        assert.equal(result.totalClusters, 1);
+        assert.equal(result.category, 'intel');
+        assert.equal(result.note, undefined);
+        assert.match(result.clusters[0].title, /Military networks/);
+      });
+    });
+
+    it('keeps a present but empty category distinct from an unknown category', async () => {
+      await withDigestCategories({ commodities: { items: [] } }, async () => {
+        const { result } = await callTool('get_news_clusters', { category: 'commodities' });
+        assert.equal(result.headlineCount, 0);
+        assert.equal(result.totalClusters, 0);
+        assert.equal(result.category, 'commodities');
+        assert.equal(result.note, undefined);
+        assert.deepEqual(result.clusters, []);
+      });
+    });
+
+    it('lists the static category inventory when the digest has no buckets', async () => {
+      await withDigestCategories({}, async () => {
+        const { result } = await callTool('get_news_clusters', { category: 'commodities' });
+        assert.equal(result.headlineCount, 0);
+        assert.equal(result.totalClusters, 0);
+        assert.equal(result.category, 'commodities');
+        assert.match(result.note, /Unknown digest category "commodities"/);
+        assert.match(result.note, /intel/);
+        assert.deepEqual(result.clusters, []);
       });
     });
 

--- a/tests/mcp-nlp-tools.test.mjs
+++ b/tests/mcp-nlp-tools.test.mjs
@@ -201,8 +201,16 @@ describe('#5697 NLP MCP tools', () => {
     assert.deepEqual(byName.get('classify_event')?.inputSchema.required, ['text']);
     assert.equal(byName.get('extract_entities')?.inputSchema.properties.text.maxLength, 2048);
     assert.equal(byName.get('extract_entities')?.inputSchema.properties.category.type, 'string');
+    assert.ok(
+      byName.get('extract_entities')?.inputSchema.properties.category.enum?.includes('commodities'),
+      'extract_entities category enum must include commodities',
+    );
     assert.equal(byName.get('get_news_clusters')?.inputSchema.properties.limit.maximum, 25);
     assert.equal(byName.get('get_news_clusters')?.inputSchema.properties.category.type, 'string');
+    assert.ok(
+      byName.get('get_news_clusters')?.inputSchema.properties.category.enum?.includes('commodities'),
+      'get_news_clusters category enum must include commodities',
+    );
     assert.equal(byName.get('get_keyword_spikes')?.inputSchema.properties.window_hours.maximum, 12);
     const classifyOutput = byName.get('classify_event')?.outputSchema;
     assert.deepEqual(classifyOutput.properties.classification.required,
@@ -376,6 +384,8 @@ describe('#5697 NLP MCP tools', () => {
       }, async () => {
         const { result } = await callTool('extract_entities', { category: 'commodities' });
         assert.equal(result.headlineCount, 1);
+        assert.equal(result.category, 'commodities');
+        assert.equal(result.note, undefined, 'known category must not emit a corrective note');
         assert.ok(result.entities.some((entity) => entity.entityId === 'GC=F'));
         assert.ok(result.entities.some((entity) => entity.entityId === 'HG=F'));
         assert.equal(
@@ -383,6 +393,30 @@ describe('#5697 NLP MCP tools', () => {
           false,
           'entities from sibling digest categories must not leak through the filter',
         );
+      });
+    });
+
+    it('returns a corrective note when category is unknown', async () => {
+      await withDigestCategories({
+        politics: {
+          items: [
+            { source: 'AP', title: 'Summit talks resume in Geneva', link: 'https://n/politics', publishedAt: 1785405600000 },
+          ],
+        },
+        commodities: {
+          items: [
+            { source: 'Oil & Gas', title: 'Crude oil futures rise on supply concerns', link: 'https://n/commodities', publishedAt: 1785405700000 },
+          ],
+        },
+      }, async () => {
+        const { result } = await callTool('extract_entities', { category: 'commodity' });
+        assert.equal(result.mode, 'headlines');
+        assert.equal(result.headlineCount, 0);
+        assert.equal(result.category, 'commodity');
+        assert.match(result.note, /Unknown digest category "commodity"/);
+        assert.match(result.note, /commodities/);
+        assert.match(result.note, /politics/);
+        assert.deepEqual(result.entities, []);
       });
     });
   });
@@ -425,7 +459,27 @@ describe('#5697 NLP MCP tools', () => {
         const { result } = await callTool('get_news_clusters', { category: 'commodities' });
         assert.equal(result.headlineCount, 1);
         assert.equal(result.totalClusters, 1);
+        assert.equal(result.category, 'commodities');
+        assert.equal(result.note, undefined);
         assert.match(result.clusters[0].title, /Crude oil/);
+      });
+    });
+
+    it('returns a corrective note when category is unknown', async () => {
+      await withDigestCategories({
+        finance: {
+          items: [
+            { source: 'CNBC', title: 'Markets open higher on rate-cut bets', link: 'https://n/finance', publishedAt: 1785405600000 },
+          ],
+        },
+      }, async () => {
+        const { result } = await callTool('get_news_clusters', { category: 'markets' });
+        assert.equal(result.headlineCount, 0);
+        assert.equal(result.totalClusters, 0);
+        assert.equal(result.category, 'markets');
+        assert.deepEqual(result.clusters, []);
+        assert.match(result.note, /Unknown digest category "markets"/);
+        assert.match(result.note, /finance/);
       });
     });
 

--- a/tests/mcp-nlp-tools.test.mjs
+++ b/tests/mcp-nlp-tools.test.mjs
@@ -170,6 +170,26 @@ describe('#5697 NLP MCP tools', () => {
     return { response, body, result, pipe };
   }
 
+  async function withDigestCategories(categories, run) {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init = {}) => {
+      const url = String(input);
+      if (url.includes('/api/news/v1/list-feed-digest')) {
+        requests.push({ url, init });
+        return Response.json({
+          generatedAt: '2026-07-28T12:00:00.000Z',
+          categories,
+        });
+      }
+      return previousFetch(input, init);
+    };
+    try {
+      return await run();
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  }
+
   it('lists all four tools with their caps in tools/list', async () => {
     const listed = await mcpHandler(new Request('https://worldmonitor.app/mcp', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -180,7 +200,9 @@ describe('#5697 NLP MCP tools', () => {
     assert.equal(byName.get('classify_event')?.inputSchema.properties.text.maxLength, 500);
     assert.deepEqual(byName.get('classify_event')?.inputSchema.required, ['text']);
     assert.equal(byName.get('extract_entities')?.inputSchema.properties.text.maxLength, 2048);
+    assert.equal(byName.get('extract_entities')?.inputSchema.properties.category.type, 'string');
     assert.equal(byName.get('get_news_clusters')?.inputSchema.properties.limit.maximum, 25);
+    assert.equal(byName.get('get_news_clusters')?.inputSchema.properties.category.type, 'string');
     assert.equal(byName.get('get_keyword_spikes')?.inputSchema.properties.window_hours.maximum, 12);
     const classifyOutput = byName.get('classify_event')?.outputSchema;
     assert.deepEqual(classifyOutput.properties.classification.required,
@@ -338,6 +360,31 @@ describe('#5697 NLP MCP tools', () => {
       const cve = result.patternEntities.find((p) => p.kind === 'cve');
       assert.equal(cve?.value, 'CVE-2026-12345');
     });
+
+    it('can restrict digest aggregation to the commodities category', async () => {
+      await withDigestCategories({
+        politics: {
+          items: [
+            { source: 'AP', title: 'CVE-2026-9999 prompts emergency cyber summit', link: 'https://n/politics', publishedAt: 1785405600000 },
+          ],
+        },
+        commodities: {
+          items: [
+            { source: 'Gold & Metals', title: 'Gold and copper futures rise on supply concerns', link: 'https://n/commodities', publishedAt: 1785405700000 },
+          ],
+        },
+      }, async () => {
+        const { result } = await callTool('extract_entities', { category: 'commodities' });
+        assert.equal(result.headlineCount, 1);
+        assert.ok(result.entities.some((entity) => entity.entityId === 'GC=F'));
+        assert.ok(result.entities.some((entity) => entity.entityId === 'HG=F'));
+        assert.equal(
+          result.patternEntities.some((entity) => entity.value === 'CVE-2026-9999'),
+          false,
+          'entities from sibling digest categories must not leak through the filter',
+        );
+      });
+    });
   });
 
   describe('get_news_clusters', () => {
@@ -360,6 +407,26 @@ describe('#5697 NLP MCP tools', () => {
       assert.equal(result.clusters[0].memberCount, 2);
       assert.equal(result.clusters[0].distinctSourceCount, 2);
       assert.equal(result.totalClusters, 2, 'totalClusters reports the pre-filter count');
+    });
+
+    it('can restrict clustering to the commodities category', async () => {
+      await withDigestCategories({
+        politics: {
+          items: [
+            { source: 'AP', title: 'Diplomatic talks resume after regional summit', link: 'https://n/politics', publishedAt: 1785405600000 },
+          ],
+        },
+        commodities: {
+          items: [
+            { source: 'Oil & Gas', title: 'Crude oil futures rise as OPEC supply tightens', link: 'https://n/commodities', publishedAt: 1785405700000 },
+          ],
+        },
+      }, async () => {
+        const { result } = await callTool('get_news_clusters', { category: 'commodities' });
+        assert.equal(result.headlineCount, 1);
+        assert.equal(result.totalClusters, 1);
+        assert.match(result.clusters[0].title, /Crude oil/);
+      });
     });
 
     it('filters min_sources on distinct outlets, not repeat headlines from one outlet', async () => {

--- a/tests/news-digest-methodology-parity.test.mjs
+++ b/tests/news-digest-methodology-parity.test.mjs
@@ -467,7 +467,7 @@ describe('news digest methodology parity', () => {
     const rows = extractFeedInventoryRows(feedsSrc);
     assert.equal(
       rows.length,
-      65,
+      66,
       'server news feed inventory row count changed; update _feeds.ts, docs/data-sources.mdx, and this assertion together',
     );
     for (const row of rows) {


### PR DESCRIPTION
## Summary

Commodities headlines that were visible in the finance dashboard but absent from every agent surface are now reachable through MCP. The full Feed Digest exposes the same Oil & Gas and Gold & Metals sources as the finance variant, and `extract_entities` plus `get_news_clusters` accept `category: "commodities"` without changing their default all-category behavior.

Runtime parity and real tool execution are covered so source drift or sibling-category leakage turns the regression tests red. The English and Chinese MCP references now document the filter and a commodities call.

Fixes #5889

## Validation

- Pre-push gate passed: frontend/API typechecks, Edge bundle and boundary checks, server handler suite (105), changed tests (36), Edge tests (240), and MDX compatibility suite (504).
- Focused and adjacent digest/MCP suites passed: 89 tests.
- GitHub's full `unit` suite, full-variant smoke test, typecheck, lint, DOM, sidecar, security, and required-gates checks passed on the final PR head.

## Post-Deploy Monitoring & Validation

- **Window/owner:** repo maintainer or on-call watches the first two full-digest refresh cycles after deployment (about 30 minutes).
- **Digest proof:** request `/api/news/v1/list-feed-digest?variant=full&lang=en` and confirm `categories.commodities.items` is populated with recent timestamps; inspect `feedStatuses["Oil & Gas"]` and `feedStatuses["Gold & Metals"]` for `timeout`, `empty`, or `all-undated`.
- **Agent proof:** call `get_news_clusters` and `extract_entities` with `category: "commodities"`; both should succeed, report a non-zero `headlineCount` when the digest bucket is populated, and emit normal `mcp.toolcall` latency/error telemetry.
- **Failure trigger:** treat a missing/empty commodities bucket for two consecutive refreshes, sustained feed timeout/all-undated status, or a material MCP error/latency increase as a failed rollout.
- **Rollback:** revert this PR; there is no migration or persistent-data rollback.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
