### PR TITLE
fix(markets): alarm on empty prediction pools

### DIFF
--- a/api/_pool-coverage.js
+++ b/api/_pool-coverage.js
@@ -31,5 +31,8 @@ export function parsePoolCounts(value, minimums) {
 export function hasPoolCoverageShortfall(counts, minimums) {
   if (!minimums) return false;
   if (!counts) return true;
-  return Object.entries(minimums).some(([pool, minimum]) => counts[pool] < minimum);
+  return Object.entries(minimums).some(([pool, minimum]) => {
+    const count = counts[pool];
+    return !Number.isSafeInteger(count) || count < minimum;
+  });
 }

--- a/api/_pool-coverage.js
+++ b/api/_pool-coverage.js
@@ -1,9 +1,17 @@
+// Must stay aligned with CATEGORIES in scripts/_prediction-classify.mjs.
+// Edge functions cannot import seeder modules; the parity test in
+// tests/prediction-market-classification.test.mjs guards against drift.
 export const PREDICTION_MARKET_MIN_POOL_COUNTS = Object.freeze({
   geopolitical: 1,
   tech: 1,
   finance: 1,
 });
 
+/**
+ * Parse producer-published poolCounts for the configured minimums.
+ * Fail closed: any missing key, non-integer, or negative value → null
+ * (treated as a shortfall by hasPoolCoverageShortfall).
+ */
 export function parsePoolCounts(value, minimums) {
   if (!minimums || !value || typeof value !== 'object' || Array.isArray(value)) return null;
   const counts = {};
@@ -15,6 +23,11 @@ export function parsePoolCounts(value, minimums) {
   return counts;
 }
 
+/**
+ * True when counts are missing (fail closed) or any configured pool is below
+ * its floor. Callers that want "unknown vs empty" should inspect parse results
+ * separately — this helper only answers "is coverage proven?".
+ */
 export function hasPoolCoverageShortfall(counts, minimums) {
   if (!minimums) return false;
   if (!counts) return true;

--- a/api/_pool-coverage.js
+++ b/api/_pool-coverage.js
@@ -1,0 +1,22 @@
+export const PREDICTION_MARKET_MIN_POOL_COUNTS = Object.freeze({
+  geopolitical: 1,
+  tech: 1,
+  finance: 1,
+});
+
+export function parsePoolCounts(value, minimums) {
+  if (!minimums || !value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const counts = {};
+  for (const pool of Object.keys(minimums)) {
+    const count = value[pool];
+    if (!Number.isSafeInteger(count) || count < 0) return null;
+    counts[pool] = count;
+  }
+  return counts;
+}
+
+export function hasPoolCoverageShortfall(counts, minimums) {
+  if (!minimums) return false;
+  if (!counts) return true;
+  return Object.entries(minimums).some(([pool, minimum]) => counts[pool] < minimum);
+}

--- a/api/health.js
+++ b/api/health.js
@@ -1,6 +1,11 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { USER_API_KEY_GATEWAY_VALIDATION_ERROR, validateApiKey } from './_api-key.js';
+import {
+  hasPoolCoverageShortfall,
+  parsePoolCounts,
+  PREDICTION_MARKET_MIN_POOL_COUNTS,
+} from './_pool-coverage.js';
 // Seed-envelope helper. PR 1 imports it here so PR 2 can wire envelope-aware
 // reads at specific call sites without further plumbing. It's a no-op on
 // legacy-shape seed-meta values (they have no `_seed` wrapper and pass through
@@ -390,7 +395,14 @@ const SEED_META = {
   hkoWarnings:      { key: 'seed-meta:weather:hko-warnings',    maxStaleMin: 540 }, // successful HKO responses publish a snapshot even when no tropical-cyclone warning is active.
   flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 90 }, // CACHE_TTL=7200s; matches notamClosures from same cron
   notamClosures:    { key: 'seed-meta:aviation:notam',          maxStaleMin: 240 }, // 2h interval; 240min = 2x interval
-  predictionMarkets: { key: 'seed-meta:prediction:markets',     maxStaleMin: 90, minRecordCount: 20 }, // #5733: declareRecords now counts DISTINCT markets (it triple-counted across the pre-partition near-duplicate pools, reporting ~75 for 46 real markets), so a volume collapse is finally measurable. Floor is deliberately well under the ~46 steady state and well over a broken run — the publish gate only catches mislabeling, so without this a run that shrinks every pool while each stays non-empty stays GREEN.
+  predictionMarkets: {
+    key: 'seed-meta:prediction:markets',
+    maxStaleMin: 90,
+    minRecordCount: 20,
+    // #5875: one is the narrowest floor that detects a dead category signal
+    // without treating ordinary pool-volume variation as an incident.
+    minPoolCounts: PREDICTION_MARKET_MIN_POOL_COUNTS,
+  },
   newsInsights:     { key: 'seed-meta:news:insights',           maxStaleMin: 30 },
   // #4920: daily GH Actions cadence; 2880 = 2x — one fully missed day alarms
   newsFeedHealth:   { key: 'seed-meta:news:feed-health',        maxStaleMin: 2880 },
@@ -919,6 +931,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // the dependency so behavior stays byte-identical in PR 1.
   const meta = unwrapEnvelope(parseRedisValue(keyMetaValues.get(seedCfg.key))).data;
   const metaCount = meta?.count ?? meta?.recordCount ?? null;
+  const poolCounts = parsePoolCounts(meta?.poolCounts, seedCfg.minPoolCounts);
   const errorCode = typeof meta?.errorCode === 'string'
     && /^[A-Z0-9_]{1,64}$/.test(meta.errorCode)
     ? meta.errorCode
@@ -933,6 +946,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       sourceBlocked: false,
       metaReadFailed: false,
       metaCount,
+      poolCounts,
       contentAge: null,
       errorCode,
     };
@@ -997,6 +1011,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     sourceBlocked,
     metaReadFailed: false,
     metaCount,
+    poolCounts,
     contentAge,
     errorCode,
   };
@@ -1042,6 +1057,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     sourceUnavailable,
     sourceBlocked,
     metaCount,
+    poolCounts,
     contentAge,
     errorCode,
   } = meta;
@@ -1084,6 +1100,10 @@ function classifyKey(name, redisKey, opts, ctx) {
   // to COVERAGE_PARTIAL (warn) instead of reporting OK. Producer must write
   // seed-meta.recordCount using the *covered* count, not the shape size.
   else if (seedCfg?.minRecordCount != null && records < seedCfg.minRecordCount) status = 'COVERAGE_PARTIAL';
+  // Per-pool coverage is independent of aggregate volume. Missing/malformed
+  // diagnostics fail closed: without all configured counts health cannot prove
+  // that every category consumer has data.
+  else if (hasPoolCoverageShortfall(poolCounts, seedCfg?.minPoolCounts)) status = 'COVERAGE_PARTIAL';
   // Content-age check (opt-in via runSeed contentMeta + maxContentAgeMin).
   // Fires AFTER all earlier failure paths so STALE_SEED, COVERAGE_PARTIAL,
   // EMPTY_*, etc. take precedence — STALE_CONTENT is "the seeder is healthy
@@ -1111,6 +1131,8 @@ function classifyKey(name, redisKey, opts, ctx) {
   if (seedAge !== null) entry.seedAgeMin = seedAge;
   if (seedCfg) entry.maxStaleMin = seedCfg.maxStaleMin;
   if (seedCfg?.minRecordCount != null) entry.minRecordCount = seedCfg.minRecordCount;
+  if (seedCfg?.minPoolCounts) entry.minPoolCounts = seedCfg.minPoolCounts;
+  if (poolCounts) entry.poolCounts = poolCounts;
   if (status === 'SEED_ERROR' && errorCode) entry.errorCode = errorCode;
   // Surface content-age fields when seeder opted in (presence of
   // meta.maxContentAgeMin). Operators can distinguish "stale content" from

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -1,6 +1,11 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateApiKey } from './_api-key.js';
 import { jsonResponse } from './_json-response.js';
+import {
+  hasPoolCoverageShortfall,
+  parsePoolCounts,
+  PREDICTION_MARKET_MIN_POOL_COUNTS,
+} from './_pool-coverage.js';
 import { unwrapEnvelope } from './_seed-envelope.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline } from './_upstash-json.js';
@@ -136,7 +141,14 @@ const SEED_DOMAINS = {
   'supply_chain:chokepoints': { key: 'seed-meta:supply_chain:chokepoints', intervalMin: 30 },
   'cable-health':             { key: 'seed-meta:cable-health',             intervalMin: 30 },
   'infrastructure:submarine-cables': { key: 'seed-meta:infrastructure:submarine-cables', intervalMin: 12600 },
-  'prediction:markets':       { key: 'seed-meta:prediction:markets',       intervalMin: 8, minRecordCount: 20 }, // minRecordCount mirrors api/health.js (#5733)
+  'prediction:markets': {
+    key: 'seed-meta:prediction:markets',
+    intervalMin: 8,
+    minRecordCount: 20,
+    // Mirrors api/health.js (#5875). A one-market floor detects an empty pool
+    // without asserting that a naturally quiet category must sustain volume.
+    minPoolCounts: PREDICTION_MARKET_MIN_POOL_COUNTS,
+  },
   'aviation:intl':            { key: 'seed-meta:aviation:intl',            intervalMin: 45 }, // intervalMin*2 = 90min staleness. seed-aviation's freshness gate (AVIATIONSTACK_MIN_REFRESH_MIN, default 55) lets fetchedAt age to ~55+cron between paid fetches; 90min matches the aviation:faa sibling + api/health.js intlDelays maxStaleMin:90. Was 15 (30min) and false-WARNed every cycle once the gate landed.
   'theater-posture':          { key: 'seed-meta:theater-posture',          intervalMin: 8 },
   'economic:worldbank-techreadiness': { key: 'seed-meta:economic:worldbank-techreadiness:v1', intervalMin: 5040 },
@@ -457,13 +469,18 @@ export default async function handler(req) {
       }
       seeds[domain] = { status: 'missing', fetchedAt: null, recordCount: null, stale: true };
       if (cfg.minRecordCount != null) seeds[domain].minRecordCount = cfg.minRecordCount;
+      if (cfg.minPoolCounts) seeds[domain].minPoolCounts = cfg.minPoolCounts;
       missingCount++;
       continue;
     }
 
     const ageMs = now - (meta.fetchedAt || 0);
     const recordCount = parseFiniteRecordCount(meta.recordCount);
-    const coveragePartial = cfg.minRecordCount != null && (recordCount == null || recordCount < cfg.minRecordCount);
+    const poolCounts = parsePoolCounts(meta.poolCounts, cfg.minPoolCounts);
+    const recordCoveragePartial = cfg.minRecordCount != null
+      && (recordCount == null || recordCount < cfg.minRecordCount);
+    const poolCoveragePartial = hasPoolCoverageShortfall(poolCounts, cfg.minPoolCounts);
+    const coveragePartial = recordCoveragePartial || poolCoveragePartial;
     // Source-specific seed projections retain their last-good records while
     // reporting a current upstream failure through sourceState. Treat that as
     // an immediate operator error instead of waiting for the freshness window.
@@ -486,8 +503,15 @@ export default async function handler(req) {
       meta.sourceVersion !== '' &&
       meta.sourceVersion !== cfg.dataProbe.sourceVersion
     );
-    const stale = ageMs > maxStalenessMs || coveragePartial || isError || sourceMismatch || probe?.ok === false;
-    if (stale) staleCount++;
+    // Keep the new pool-coverage verdict distinct from freshness. The legacy
+    // scalar minRecordCount path still contributes to `stale` for wire
+    // compatibility, but an empty pool is fresh data with partial coverage.
+    const stale = ageMs > maxStalenessMs
+      || recordCoveragePartial
+      || isError
+      || sourceMismatch
+      || probe?.ok === false;
+    if (stale || poolCoveragePartial) staleCount++;
 
     seeds[domain] = {
       status: sourceUnavailable
@@ -512,6 +536,8 @@ export default async function handler(req) {
       stale,
     };
     if (cfg.minRecordCount != null) seeds[domain].minRecordCount = cfg.minRecordCount;
+    if (cfg.minPoolCounts) seeds[domain].minPoolCounts = cfg.minPoolCounts;
+    if (poolCounts) seeds[domain].poolCounts = poolCounts;
     if (probe) seeds[domain].dataProbe = probe;
     // #5736: without this, `status: "error"` names no cause and an operator has
     // to read raw Redis to learn WHY — which is the log-diving the issue exists

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -539,6 +539,9 @@ export default async function handler(req) {
     if (cfg.minRecordCount != null) seeds[domain].minRecordCount = cfg.minRecordCount;
     if (cfg.minPoolCounts) seeds[domain].minPoolCounts = cfg.minPoolCounts;
     if (poolCounts) seeds[domain].poolCounts = poolCounts;
+    // Explicit coverage flag so consumers that only inspect `stale` still see
+    // pool/aggregate shortfalls (pool shortfall keeps stale:false by design).
+    if (coveragePartial) seeds[domain].coveragePartial = true;
     if (probe) seeds[domain].dataProbe = probe;
     // #5736: without this, `status: "error"` names no cause and an operator has
     // to read raw Redis to learn WHY — which is the log-diving the issue exists

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -506,7 +506,8 @@ export default async function handler(req) {
     // Keep the new pool-coverage verdict distinct from freshness. The legacy
     // scalar minRecordCount path still contributes to `stale` for wire
     // compatibility, but an empty pool is fresh data with partial coverage.
-    const stale = ageMs > maxStalenessMs
+    const freshnessStale = ageMs > maxStalenessMs;
+    const stale = freshnessStale
       || recordCoveragePartial
       || isError
       || sourceMismatch
@@ -522,13 +523,13 @@ export default async function handler(req) {
           ? 'source_version_mismatch'
           : probe?.ok === false
             ? probe.status
-            : coveragePartial
-              ? 'coverage_partial'
-              : stale
+            : freshnessStale
               ? 'stale'
-              : sourceBlocked
-                ? 'source_blocked'
-              : 'ok',
+              : coveragePartial
+                ? 'coverage_partial'
+                : sourceBlocked
+                  ? 'source_blocked'
+                  : 'ok',
       fetchedAt: meta.fetchedAt,
       recordCount: recordCount ?? meta.recordCount ?? null,
       sourceVersion: meta.sourceVersion || null,

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -79,7 +79,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `SOURCE_BLOCKED` | Green | The Japan MOD adapter proved no transport path reaches the publisher while retaining fresh reviewed records — either an upstream HTTP 403 after a successful proxy CONNECT (`HTTP_403`), or a target-scoped proxy CONNECT refusal corroborated by a successful control tunnel (`PROXY_TARGET_FORBIDDEN`). Uncorroborated CONNECT refusals, stale, empty, or unreviewed states still fail closed |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
 | `STALE_CONTENT` | Warn | Seeder is fresh but the upstream content stopped advancing (frozen feed); counted in `summary.staleContent` |
-| `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints or 139/174 PortWatch port-activity countries) |
+| `COVERAGE_PARTIAL` | Warn | Aggregate records or a required subgroup is below the key's declared coverage floor (for example, 139/174 PortWatch countries or an empty prediction-market pool) |
 | `SEED_ERROR` | Warn | `seed-meta` reports `status: "error"` from the last seed run |
 | `REDIS_PARTIAL` | Warn | A single per-command Redis error on this key's STRLEN/GET (not a full outage) |
 | `EMPTY_ON_DEMAND` | Warn | On-demand key has no data yet (expected until first request); counted in `summary.onDemandWarn` |
@@ -164,6 +164,11 @@ health entries where those feeds publish seed metadata.
 PortWatch cache entries, but the canonical country list and healthy seed-meta
 signal do not advance until full 174-country coverage returns.
 
+`predictionMarkets` also requires at least one published market in each
+`geopolitical`, `tech`, and `finance` pool. Its seed metadata publishes
+`poolCounts`; missing, malformed, or under-floor counts report
+`COVERAGE_PARTIAL` even when the aggregate market count is healthy.
+
 ### Staleness Thresholds (maxStaleMin)
 
 Selected thresholds from `SEED_META`:
@@ -246,6 +251,24 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
       "sourceVersion": null,
       "ageMinutes": 5,
       "stale": true
+    },
+    "prediction:markets": {
+      "status": "coverage_partial",
+      "fetchedAt": 1710158100000,
+      "recordCount": 87,
+      "poolCounts": {
+        "geopolitical": 52,
+        "tech": 0,
+        "finance": 35
+      },
+      "minPoolCounts": {
+        "geopolitical": 1,
+        "tech": 1,
+        "finance": 1
+      },
+      "sourceVersion": null,
+      "ageMinutes": 5,
+      "stale": false
     }
   }
 }
@@ -253,7 +276,7 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
 
 ### Staleness Logic
 
-A seed is considered stale when its age exceeds **2x the configured interval**. This accounts for normal jitter in cron/relay timing. Seeds with an explicit `minRecordCount` also report `coverage_partial` and `stale: true` until their coverage floor is met.
+A seed is considered stale when its age exceeds **2x the configured interval**. This accounts for normal jitter in cron/relay timing. Seeds below an aggregate `minRecordCount` report `coverage_partial` and `stale: true`. Seeds below a subgroup floor such as prediction-market `minPoolCounts` also report `coverage_partial`, but retain `stale: false` while their producer heartbeat remains fresh so freshness and coverage stay distinct.
 
 | Domain | Interval (min) | Stale After (min) |
 |--------|---------------|-------------------|

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -266,6 +266,7 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
         "tech": 1,
         "finance": 1
       },
+      "coveragePartial": true,
       "sourceVersion": null,
       "ageMinutes": 5,
       "stale": false
@@ -277,6 +278,8 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
 ### Staleness Logic
 
 A seed is considered stale when its age exceeds **2x the configured interval**. This accounts for normal jitter in cron/relay timing. Seeds below an aggregate `minRecordCount` report `coverage_partial` and `stale: true`. Seeds below a subgroup floor such as prediction-market `minPoolCounts` also report `coverage_partial`, but retain `stale: false` while their producer heartbeat remains fresh so freshness and coverage stay distinct.
+
+**Consumers:** treat `status` and `overall` as authoritative for coverage. Do not rely on `stale` alone — pool shortfalls keep `stale: false` by design. When either coverage floor fails, the entry also sets `coveragePartial: true` so clients that only inspect booleans still see the shortfall.
 
 | Domain | Interval (min) | Stale After (min) |
 |--------|---------------|-------------------|

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -206,6 +206,7 @@ curl -o /dev/null -s -w "%{http_code}" "https://api.worldmonitor.app/api/health?
         "tech": 1,
         "finance": 1
       },
+      "coveragePartial": true,
       "sourceVersion": null,
       "ageMinutes": 5,
       "stale": false
@@ -217,6 +218,8 @@ curl -o /dev/null -s -w "%{http_code}" "https://api.worldmonitor.app/api/health?
 ### 过期逻辑
 
 当种子的年龄超过**配置间隔的 2 倍**时，即被视为过期。这考虑了 cron/中继计时的正常抖动。低于总量 `minRecordCount` 的种子会报告 `coverage_partial` 和 `stale: true`。低于预测市场 `minPoolCounts` 等子组下限的种子也会报告 `coverage_partial`，但只要生产者心跳仍然新鲜，就保持 `stale: false`，从而区分新鲜度与覆盖率。
+
+**消费者：** 以 `status` 和 `overall` 作为覆盖率的权威信号。不要只依赖 `stale`——池覆盖不足按设计保持 `stale: false`。当任一覆盖率下限失败时，条目还会设置 `coveragePartial: true`，以便只检查布尔字段的客户端仍能看到不足。
 
 | 领域 | 间隔（分钟） | 过期阈值（分钟） |
 |--------|---------------|-------------------|

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -78,7 +78,7 @@ description: "World Monitor 提供两个健康检查端点用于持续监控数�
 | `NOT_CONFIGURED` | 绿色 | 本部署从未为该可选数据源适配器配置凭据（生产者写入 `sourceState: "unavailable"`，例如未配置 `SAM_GOV_API_KEY` 的全球招标 SAM.gov 适配器）。这不是故障，也不计入问题；添加凭据后的首次运行即转为 `OK` |
 | `STALE_SEED` | 警告 | 数据存在但 `seed-meta` 年龄超过 `maxStaleMin` |
 | `STALE_CONTENT` | 警告 | 种子器新鲜但上游内容停止推进（冻结的订阅源）；计入 `summary.staleContent` |
-| `COVERAGE_PARTIAL` | 警告 | 记录数低于该键声明的 `minRecordCount`（例如 10/13 个咽喉点或 139/174 个 PortWatch 港口活动国家） |
+| `COVERAGE_PARTIAL` | 警告 | 总记录数或必需子组低于该键声明的覆盖率下限（例如 139/174 个 PortWatch 国家，或某个预测市场池为空） |
 | `SEED_ERROR` | 警告 | `seed-meta` 报告上次种子运行的 `status: "error"` |
 | `REDIS_PARTIAL` | 警告 | 该键的 STRLEN/GET 上出现单个每命令 Redis 错误（非完全中断） |
 | `EMPTY_ON_DEMAND` | 警告 | 按需键尚无数据（在首次请求之前为预期情况）；计入 `summary.onDemandWarn` |
@@ -103,6 +103,11 @@ description: "World Monitor 提供两个健康检查端点用于持续监控数�
 `COVERAGE_PARTIAL` 而非 `OK`；部分运行仍可刷新按国家的
 PortWatch 缓存条目，但规范国家列表和健康的 seed-meta
 信号在完整 174 国覆盖恢复之前不会推进。
+
+`predictionMarkets` 还要求 `geopolitical`、`tech` 和 `finance`
+每个发布池中至少有一个市场。其种子元数据会发布 `poolCounts`；
+计数缺失、格式错误或低于下限时，即使市场总数健康，也会报告
+`COVERAGE_PARTIAL`。
 
 ### 过期阈值（maxStaleMin）
 
@@ -186,6 +191,24 @@ curl -o /dev/null -s -w "%{http_code}" "https://api.worldmonitor.app/api/health?
       "sourceVersion": null,
       "ageMinutes": 5,
       "stale": true
+    },
+    "prediction:markets": {
+      "status": "coverage_partial",
+      "fetchedAt": 1710158100000,
+      "recordCount": 87,
+      "poolCounts": {
+        "geopolitical": 52,
+        "tech": 0,
+        "finance": 35
+      },
+      "minPoolCounts": {
+        "geopolitical": 1,
+        "tech": 1,
+        "finance": 1
+      },
+      "sourceVersion": null,
+      "ageMinutes": 5,
+      "stale": false
     }
   }
 }
@@ -193,7 +216,7 @@ curl -o /dev/null -s -w "%{http_code}" "https://api.worldmonitor.app/api/health?
 
 ### 过期逻辑
 
-当种子的年龄超过**配置间隔的 2 倍**时，即被视为过期。这考虑了 cron/中继计时的正常抖动。具有显式 `minRecordCount` 的种子还会报告 `coverage_partial` 和 `stale: true`，直到满足其覆盖率下限。
+当种子的年龄超过**配置间隔的 2 倍**时，即被视为过期。这考虑了 cron/中继计时的正常抖动。低于总量 `minRecordCount` 的种子会报告 `coverage_partial` 和 `stale: true`。低于预测市场 `minPoolCounts` 等子组下限的种子也会报告 `coverage_partial`，但只要生产者心跳仍然新鲜，就保持 `stale: false`，从而区分新鲜度与覆盖率。
 
 | 领域 | 间隔（分钟） | 过期阈值（分钟） |
 |--------|---------------|-------------------|

--- a/scripts/_prediction-classify.mjs
+++ b/scripts/_prediction-classify.mjs
@@ -69,6 +69,11 @@ export const DEFAULT_CATEGORY = 'finance';
 // Health metadata deliberately uses published counts, not pre-ranking
 // classification counts: these are the records each category consumer can
 // actually retrieve from the canonical snapshot.
+//
+// Absent/malformed pools report 0 (producer-side fail closed) so a partial
+// payload cannot look healthy. Health consumers parse with parsePoolCounts,
+// which treats a missing/malformed whole object as null (unproven coverage) —
+// different from an explicit zero for a single pool.
 export function predictionPoolCounts(data) {
   return Object.fromEntries(
     CATEGORIES.map((category) => [

--- a/scripts/_prediction-classify.mjs
+++ b/scripts/_prediction-classify.mjs
@@ -66,6 +66,18 @@ export const MIN_PUBLISHED_MARKETS = 5;
 // Pool that owns records matching no category tag (see header).
 export const DEFAULT_CATEGORY = 'finance';
 
+// Health metadata deliberately uses published counts, not pre-ranking
+// classification counts: these are the records each category consumer can
+// actually retrieve from the canonical snapshot.
+export function predictionPoolCounts(data) {
+  return Object.fromEntries(
+    CATEGORIES.map((category) => [
+      category,
+      Array.isArray(data?.[category]) ? data[category].length : 0,
+    ]),
+  );
+}
+
 const CLASSIFY_TAGS = Object.freeze(Object.fromEntries(
   CATEGORIES.map((category) => [
     category,

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -545,6 +545,53 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, 
   );
 }
 
+// Fields the shared seed-meta writer owns. afterPublish freshnessMetaPatch
+// (and any preserve-on-skip merge) may add other diagnostics, but never
+// re-anchor these — they come from the current runSeed outcome only.
+export const FRESHNESS_META_RESERVED_FIELDS = Object.freeze([
+  'fetchedAt',
+  'recordCount',
+  'sourceVersion',
+  'newestItemAt',
+  'oldestItemAt',
+  'maxContentAgeMin',
+]);
+
+/**
+ * Strip reserved freshness fields from an existing seed-meta object so the
+ * remainder can be re-applied as a freshnessMetaPatch. Used when a validation
+ * skip rewrites seed-meta while preserving last-good data — without this,
+ * diagnostics such as prediction poolCounts are wiped and fail-closed health
+ * false-alarms (#5875 review).
+ */
+export function freshnessMetaDiagnosticsPatch(existingMeta) {
+  if (!existingMeta || typeof existingMeta !== 'object' || Array.isArray(existingMeta)) {
+    return null;
+  }
+  const reserved = new Set(FRESHNESS_META_RESERVED_FIELDS);
+  const patch = {};
+  for (const [key, value] of Object.entries(existingMeta)) {
+    if (!reserved.has(key)) patch[key] = value;
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
+/**
+ * Best-effort read of the current seed-meta value for a domain/resource.
+ * Returns the bare meta object, or null when missing / unreadable. Never throws.
+ */
+export async function readExistingSeedMeta(domain, resource) {
+  try {
+    const { url, token } = getRedisCredentials();
+    const metaKey = `seed-meta:${domain}:${resource}`;
+    const value = await redisGet(url, token, metaKey);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
 export async function writeFreshnessMetadata(
   domain,
   resource,
@@ -578,14 +625,7 @@ export async function writeFreshnessMetadata(
   if (metaPatch && typeof metaPatch === 'object') {
     // Hooks may add bounded diagnostics, but the shared writer owns freshness
     // and record-count truth. Never let a hook silently re-anchor those fields.
-    const reservedFields = new Set([
-      'fetchedAt',
-      'recordCount',
-      'sourceVersion',
-      'newestItemAt',
-      'oldestItemAt',
-      'maxContentAgeMin',
-    ]);
+    const reservedFields = new Set(FRESHNESS_META_RESERVED_FIELDS);
     for (const [key, value] of Object.entries(metaPatch)) {
       if (!reservedFields.has(key)) meta[key] = value;
     }
@@ -2127,6 +2167,13 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         //   - canonical envelope is malformed / legacy bare shape
         //   - canonical envelope has recordCount <= 0
         const canonicalMeta = await readCanonicalEnvelopeMeta(canonicalKey);
+        // Preserve non-reserved diagnostics (poolCounts, GDELT errorReason, …)
+        // from the previous seed-meta write. The SET below replaces the whole
+        // key; without this merge a validate-skip after a healthy publish wipes
+        // afterPublish patches and fail-closed consumers false-alarm.
+        const preservedDiagnostics = freshnessMetaDiagnosticsPatch(
+          await readExistingSeedMeta(domain, resource),
+        );
         if (canonicalMeta) {
           // Pass-through canonical's contentAge so health doesn't lose the
           // STALE_CONTENT signal exactly when last-good-with-stale-content
@@ -2137,6 +2184,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             ttlSeconds,
             canonicalMeta.fetchedAt,
             canonicalMeta.contentAge,
+            preservedDiagnostics,
           );
           console.log(
             `  SKIPPED: validation failed (empty/partial fetch) — seed-meta mirrors canonical ` +
@@ -2145,6 +2193,8 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             `existing cache TTL extended`,
           );
         } else {
+          // No last-good envelope: quiet-period zero write. Drop prior
+          // diagnostics — they described a different cohort and would lie.
           await writeFreshnessMetadataSafely(domain, resource, 0, opts.sourceVersion, ttlSeconds);
           console.log(`  SKIPPED: validation failed (empty data) — seed-meta refreshed (recordCount=0), existing cache TTL extended`);
         }

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, sleep, runSeed } from './_seed-utils.mjs';
-import { buildBootstrapPools, validateBootstrapPayload } from './_prediction-classify.mjs';
+import {
+  buildBootstrapPools,
+  predictionPoolCounts,
+  validateBootstrapPayload,
+} from './_prediction-classify.mjs';
 import {
   isExcluded, isMemeCandidate, tagRegions, parseYesPrice, selectPricedKalshiMarket,
   shouldInclude, scoreMarket, isExpired,
@@ -209,6 +213,11 @@ await runSeed('prediction', 'markets', CANONICAL_KEY, fetchAllPredictions, {
   validateFn: validateBootstrapPayload,
 
   declareRecords,
+  afterPublish: (data) => ({
+    freshnessMetaPatch: {
+      poolCounts: predictionPoolCounts(data),
+    },
+  }),
   schemaVersion: 1,
   maxStaleMin: 90,
   sourceVersion: 'prediction-markets-v1',

--- a/tests/china-decision-access-contract.test.mts
+++ b/tests/china-decision-access-contract.test.mts
@@ -12,6 +12,7 @@ import {
 const PATH = '/api/intelligence/v1/get-china-decision-signals';
 const CHINA_DATA_KEY = 'intelligence:china-decision-signals:v1';
 const CHINA_META_KEY = 'seed-meta:intelligence:china-decision-signals';
+const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
 const OPERATOR_KEY = 'china-decision-test-operator-key';
 const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
@@ -66,6 +67,15 @@ function installSeedHealthPipelineMock(chinaMeta: ChinaMeta) {
         };
       }
       if (key === CHINA_META_KEY) return { result: JSON.stringify(chinaMeta) };
+      if (key === PREDICTION_META_KEY) {
+        return {
+          result: JSON.stringify({
+            fetchedAt: chinaMeta.fetchedAt,
+            recordCount: 38,
+            poolCounts: { geopolitical: 18, tech: 12, finance: 8 },
+          }),
+        };
+      }
       return {
         result: JSON.stringify({
           fetchedAt: chinaMeta.fetchedAt,

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -138,6 +138,23 @@ test('classifyKey: predictionMarkets with one empty pool → COVERAGE_PARTIAL', 
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: stale prediction snapshot outranks per-pool coverage', () => {
+  const entry = classifyKey('predictionMarkets', BOOTSTRAP_KEYS.predictionMarkets, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.predictionMarkets]: 1234 },
+      metaValues: {
+        'seed-meta:prediction:markets': seedMeta({
+          fetchedAt: NOW - 100 * ONE_MIN_MS,
+          recordCount: 38,
+          poolCounts: { geopolitical: 18, tech: 0, finance: 20 },
+        }),
+      },
+    }));
+
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
+});
+
 test('classifyKey: predictionMarkets requires valid per-pool metadata', () => {
   const entry = classifyKey('predictionMarkets', BOOTSTRAP_KEYS.predictionMarkets, { allowOnDemand: false },
     makeCtx({

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -119,6 +119,55 @@ test('classifyKey: portwatchPortActivity below 174 countries → COVERAGE_PARTIA
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: predictionMarkets with one empty pool → COVERAGE_PARTIAL', () => {
+  const entry = classifyKey('predictionMarkets', BOOTSTRAP_KEYS.predictionMarkets, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.predictionMarkets]: 1234 },
+      metaValues: {
+        'seed-meta:prediction:markets': seedMeta({
+          recordCount: 38,
+          poolCounts: { geopolitical: 18, tech: 0, finance: 20 },
+        }),
+      },
+    }));
+
+  assert.equal(entry.status, 'COVERAGE_PARTIAL');
+  assert.equal(entry.records, 38);
+  assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
+  assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: predictionMarkets requires valid per-pool metadata', () => {
+  const entry = classifyKey('predictionMarkets', BOOTSTRAP_KEYS.predictionMarkets, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.predictionMarkets]: 1234 },
+      metaValues: {
+        'seed-meta:prediction:markets': seedMeta({ recordCount: 38 }),
+      },
+    }));
+
+  assert.equal(entry.status, 'COVERAGE_PARTIAL');
+  assert.equal(Object.hasOwn(entry, 'poolCounts'), false);
+  assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
+});
+
+test('classifyKey: predictionMarkets is OK when every pool meets its floor', () => {
+  const entry = classifyKey('predictionMarkets', BOOTSTRAP_KEYS.predictionMarkets, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.predictionMarkets]: 1234 },
+      metaValues: {
+        'seed-meta:prediction:markets': seedMeta({
+          recordCount: 20,
+          poolCounts: { geopolitical: 1, tech: 1, finance: 18 },
+        }),
+      },
+    }));
+
+  assert.equal(entry.status, 'OK');
+  assert.deepEqual(entry.poolCounts, { geopolitical: 1, tech: 1, finance: 18 });
+});
+
 test('classifyKey: socialVelocity error seed-meta → SEED_ERROR while data is preserved', () => {
   const entry = classifyKey('socialVelocity', BOOTSTRAP_KEYS.socialVelocity, { allowOnDemand: false },
     makeCtx({

--- a/tests/pool-coverage.test.mjs
+++ b/tests/pool-coverage.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  hasPoolCoverageShortfall,
+  parsePoolCounts,
+  PREDICTION_MARKET_MIN_POOL_COUNTS,
+} from '../api/_pool-coverage.js';
+
+const FLOORS = PREDICTION_MARKET_MIN_POOL_COUNTS;
+
+test('parsePoolCounts accepts a complete non-negative integer map', () => {
+  assert.deepEqual(
+    parsePoolCounts({ geopolitical: 18, tech: 12, finance: 8, extra: 99 }, FLOORS),
+    { geopolitical: 18, tech: 12, finance: 8 },
+  );
+});
+
+test('parsePoolCounts fails closed on missing, malformed, or negative values', () => {
+  assert.equal(parsePoolCounts(null, FLOORS), null);
+  assert.equal(parsePoolCounts(undefined, FLOORS), null);
+  assert.equal(parsePoolCounts([], FLOORS), null);
+  assert.equal(parsePoolCounts('nope', FLOORS), null);
+  assert.equal(parsePoolCounts({ geopolitical: 1, tech: 1 }, FLOORS), null);
+  assert.equal(parsePoolCounts({ geopolitical: 1, tech: '1', finance: 1 }, FLOORS), null);
+  assert.equal(parsePoolCounts({ geopolitical: 1.5, tech: 1, finance: 1 }, FLOORS), null);
+  assert.equal(parsePoolCounts({ geopolitical: -1, tech: 1, finance: 1 }, FLOORS), null);
+  assert.equal(parsePoolCounts({ geopolitical: 1, tech: 1, finance: Number.MAX_SAFE_INTEGER + 1 }, FLOORS), null);
+});
+
+test('parsePoolCounts is a no-op when no floors are configured', () => {
+  assert.equal(parsePoolCounts({ geopolitical: 1 }, null), null);
+  assert.equal(parsePoolCounts({ geopolitical: 1 }, undefined), null);
+});
+
+test('hasPoolCoverageShortfall fails closed on missing counts and respects floors', () => {
+  assert.equal(hasPoolCoverageShortfall(null, FLOORS), true);
+  assert.equal(hasPoolCoverageShortfall(undefined, FLOORS), true);
+  assert.equal(hasPoolCoverageShortfall({ geopolitical: 0, tech: 1, finance: 1 }, FLOORS), true);
+  assert.equal(hasPoolCoverageShortfall({ geopolitical: 1, tech: 1, finance: 1 }, FLOORS), false);
+  assert.equal(hasPoolCoverageShortfall({ geopolitical: 1, tech: 1, finance: 36 }, FLOORS), false);
+  assert.equal(hasPoolCoverageShortfall(null, null), false);
+});

--- a/tests/pool-coverage.test.mjs
+++ b/tests/pool-coverage.test.mjs
@@ -36,6 +36,8 @@ test('parsePoolCounts is a no-op when no floors are configured', () => {
 test('hasPoolCoverageShortfall fails closed on missing counts and respects floors', () => {
   assert.equal(hasPoolCoverageShortfall(null, FLOORS), true);
   assert.equal(hasPoolCoverageShortfall(undefined, FLOORS), true);
+  assert.equal(hasPoolCoverageShortfall({ geopolitical: 1, tech: 1 }, FLOORS), true);
+  assert.equal(hasPoolCoverageShortfall({ geopolitical: 1, tech: '1', finance: 1 }, FLOORS), true);
   assert.equal(hasPoolCoverageShortfall({ geopolitical: 0, tech: 1, finance: 1 }, FLOORS), true);
   assert.equal(hasPoolCoverageShortfall({ geopolitical: 1, tech: 1, finance: 1 }, FLOORS), false);
   assert.equal(hasPoolCoverageShortfall({ geopolitical: 1, tech: 1, finance: 36 }, FLOORS), false);

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -30,6 +30,7 @@ import {
   hasCategoryTag,
   marketIdentity,
   partitionMarkets,
+  predictionPoolCounts,
   poolIntegrityViolations,
   validateBootstrapPayload,
 } from '../scripts/_prediction-classify.mjs';
@@ -480,6 +481,25 @@ describe('per-pool ranking: relaxation and truncation', () => {
   });
 });
 
+describe('predictionPoolCounts (seed-meta coverage signal)', () => {
+  it('reports the published count for every canonical pool', () => {
+    const pools = buildPools(RAW);
+    assert.deepEqual(predictionPoolCounts(pools), {
+      geopolitical: pools.geopolitical.length,
+      tech: pools.tech.length,
+      finance: pools.finance.length,
+    });
+  });
+
+  it('reports absent or malformed pools as zero so health fails closed', () => {
+    assert.deepEqual(predictionPoolCounts({ geopolitical: [{}], tech: null, finance: 'nope' }), {
+      geopolitical: 1,
+      tech: 0,
+      finance: 0,
+    });
+  });
+});
+
 describe('validateBootstrapPayload (the seeder\'s validateFn)', () => {
   const silent = { log: () => {} };
 
@@ -556,6 +576,13 @@ describe('the seeder is wired to the tested pool-building path', () => {
 
   it('uses the shared validateFn instead of an inline population check', () => {
     assert.match(source, /validateFn:\s*validateBootstrapPayload/);
+  });
+
+  it('publishes the tested per-pool counts through seed freshness metadata', () => {
+    assert.match(
+      source,
+      /afterPublish:[\s\S]{0,300}freshnessMetaPatch:[\s\S]{0,200}poolCounts:\s*predictionPoolCounts\(data\)/,
+    );
   });
 });
 

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -498,6 +498,16 @@ describe('predictionPoolCounts (seed-meta coverage signal)', () => {
       finance: 0,
     });
   });
+
+  it('keys stay aligned with api/_pool-coverage health floors', async () => {
+    // Edge helpers cannot import seeder modules; both lists must name the same
+    // pools or a new category would publish counts health never floors.
+    const { PREDICTION_MARKET_MIN_POOL_COUNTS } = await import('../api/_pool-coverage.js');
+    assert.deepEqual(
+      Object.keys(PREDICTION_MARKET_MIN_POOL_COUNTS).sort(),
+      [...CATEGORIES].sort(),
+    );
+  });
 });
 
 describe('validateBootstrapPayload (the seeder\'s validateFn)', () => {

--- a/tests/seed-health-prediction-pools.test.mjs
+++ b/tests/seed-health-prediction-pools.test.mjs
@@ -93,6 +93,7 @@ test('seed-health flags a fresh prediction snapshot with an empty pool as covera
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'coverage_partial');
   assert.equal(entry.stale, false);
+  assert.equal(entry.coveragePartial, true);
   assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
   assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
 });
@@ -109,6 +110,7 @@ test('seed-health reports stale before per-pool coverage when both apply', async
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'stale');
   assert.equal(entry.stale, true);
+  assert.equal(entry.coveragePartial, true);
   assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
 });
 
@@ -120,6 +122,7 @@ test('seed-health fails closed when prediction pool metadata is missing', async 
 
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'coverage_partial');
+  assert.equal(entry.coveragePartial, true);
   assert.equal(Object.hasOwn(entry, 'poolCounts'), false);
   assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
 });
@@ -132,6 +135,7 @@ test('seed-health fails closed when prediction pool metadata is malformed', asyn
 
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'coverage_partial');
+  assert.equal(entry.coveragePartial, true);
   assert.equal(Object.hasOwn(entry, 'poolCounts'), false);
 });
 
@@ -145,5 +149,6 @@ test('seed-health keeps prediction markets healthy when every pool is populated'
   assert.equal(body.overall, 'healthy');
   assert.equal(entry.status, 'ok');
   assert.equal(entry.stale, false);
+  assert.equal(Object.hasOwn(entry, 'coveragePartial'), false);
   assert.deepEqual(entry.poolCounts, { geopolitical: 1, tech: 1, finance: 36 });
 });

--- a/tests/seed-health-prediction-pools.test.mjs
+++ b/tests/seed-health-prediction-pools.test.mjs
@@ -38,7 +38,7 @@ after(() => {
   }
 });
 
-function installSeedHealthPipelineMock(poolCounts) {
+function installSeedHealthPipelineMock(poolCounts, { fetchedAt = Date.now() } = {}) {
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
     const results = commands.map((command) => {
@@ -48,7 +48,7 @@ function installSeedHealthPipelineMock(poolCounts) {
       if (key === PREDICTION_META_KEY) {
         return {
           result: JSON.stringify({
-            fetchedAt: Date.now(),
+            fetchedAt,
             recordCount: 38,
             ...(poolCounts === undefined ? {} : { poolCounts }),
           }),
@@ -95,6 +95,21 @@ test('seed-health flags a fresh prediction snapshot with an empty pool as covera
   assert.equal(entry.stale, false);
   assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
   assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
+});
+
+test('seed-health reports stale before per-pool coverage when both apply', async () => {
+  installSeedHealthPipelineMock(
+    { geopolitical: 18, tech: 0, finance: 20 },
+    { fetchedAt: Date.now() - 100 * 60_000 },
+  );
+
+  const { body } = await readSeedHealth();
+  const entry = body.seeds['prediction:markets'];
+
+  assert.equal(body.overall, 'warning');
+  assert.equal(entry.status, 'stale');
+  assert.equal(entry.stale, true);
+  assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
 });
 
 test('seed-health fails closed when prediction pool metadata is missing', async () => {

--- a/tests/seed-health-prediction-pools.test.mjs
+++ b/tests/seed-health-prediction-pools.test.mjs
@@ -18,7 +18,6 @@ process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 
 const { default: handler } = await import('../api/seed-health.js');
 
-const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
 const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
@@ -39,28 +38,19 @@ after(() => {
   }
 });
 
-function installSeedHealthPipelineMock(portwatchRecordCount, { missingPortwatchMeta = false } = {}) {
+function installSeedHealthPipelineMock(poolCounts) {
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
     const results = commands.map((command) => {
       const [op, key] = command;
-      // #4927: activation-gated entries add EXISTS probes on their
-      // seed-activated:* markers; absent in this harness.
-      if (op === 'EXISTS') {
-        assert.match(String(key), /^seed-activated:/, 'EXISTS is only used for activation markers');
-        return { result: 0 };
-      }
+      if (op === 'EXISTS') return { result: 0 };
       assert.equal(op, 'GET');
-      if (key === PORTWATCH_META_KEY) {
-        if (missingPortwatchMeta) return { result: null };
-        return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: portwatchRecordCount }) };
-      }
       if (key === PREDICTION_META_KEY) {
         return {
           result: JSON.stringify({
             fetchedAt: Date.now(),
             recordCount: 38,
-            poolCounts: { geopolitical: 18, tech: 12, finance: 8 },
+            ...(poolCounts === undefined ? {} : { poolCounts }),
           }),
         };
       }
@@ -75,9 +65,6 @@ function installSeedHealthPipelineMock(portwatchRecordCount, { missingPortwatchM
           }),
         };
       }
-      // This fixture isolates the PortWatch entry. Keep every unrelated
-      // coverage-gated feed above its floor so a new minRecordCount contract
-      // cannot turn the aggregate warning for an unrelated reason.
       return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 10_000 }) };
     });
     return new Response(JSON.stringify(results), {
@@ -96,58 +83,52 @@ async function readSeedHealth() {
   return { res, body };
 }
 
-test('seed-health flags fresh PortWatch port activity below 174 countries as coverage_partial', async () => {
-  installSeedHealthPipelineMock(139);
+test('seed-health flags a fresh prediction snapshot with an empty pool as coverage_partial', async () => {
+  installSeedHealthPipelineMock({ geopolitical: 18, tech: 0, finance: 20 });
 
   const { res, body } = await readSeedHealth();
-  const entry = body.seeds['supply_chain:portwatch-ports'];
+  const entry = body.seeds['prediction:markets'];
 
   assert.equal(res.status, 200);
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'coverage_partial');
-  assert.equal(entry.stale, true);
-  assert.equal(entry.recordCount, 139);
-  assert.equal(entry.minRecordCount, 174);
+  assert.equal(entry.stale, false);
+  assert.deepEqual(entry.poolCounts, { geopolitical: 18, tech: 0, finance: 20 });
+  assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
 });
 
-test('seed-health treats missing PortWatch recordCount as coverage_partial', async () => {
+test('seed-health fails closed when prediction pool metadata is missing', async () => {
   installSeedHealthPipelineMock(undefined);
 
-  const { res, body } = await readSeedHealth();
-  const entry = body.seeds['supply_chain:portwatch-ports'];
+  const { body } = await readSeedHealth();
+  const entry = body.seeds['prediction:markets'];
 
-  assert.equal(res.status, 200);
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'coverage_partial');
-  assert.equal(entry.stale, true);
-  assert.equal(entry.recordCount, null);
-  assert.equal(entry.minRecordCount, 174);
+  assert.equal(Object.hasOwn(entry, 'poolCounts'), false);
+  assert.deepEqual(entry.minPoolCounts, { geopolitical: 1, tech: 1, finance: 1 });
 });
 
-test('seed-health includes PortWatch minRecordCount when seed-meta is missing', async () => {
-  installSeedHealthPipelineMock(undefined, { missingPortwatchMeta: true });
+test('seed-health fails closed when prediction pool metadata is malformed', async () => {
+  installSeedHealthPipelineMock({ geopolitical: 18, tech: '0', finance: 20 });
 
-  const { res, body } = await readSeedHealth();
-  const entry = body.seeds['supply_chain:portwatch-ports'];
+  const { body } = await readSeedHealth();
+  const entry = body.seeds['prediction:markets'];
 
-  assert.equal(res.status, 503);
-  assert.equal(body.overall, 'degraded');
-  assert.equal(entry.status, 'missing');
-  assert.equal(entry.stale, true);
-  assert.equal(entry.recordCount, null);
-  assert.equal(entry.minRecordCount, 174);
+  assert.equal(body.overall, 'warning');
+  assert.equal(entry.status, 'coverage_partial');
+  assert.equal(Object.hasOwn(entry, 'poolCounts'), false);
 });
 
-test('seed-health keeps PortWatch port activity OK at the 174-country recovery floor', async () => {
-  installSeedHealthPipelineMock(174);
+test('seed-health keeps prediction markets healthy when every pool is populated', async () => {
+  installSeedHealthPipelineMock({ geopolitical: 1, tech: 1, finance: 36 });
 
   const { res, body } = await readSeedHealth();
-  const entry = body.seeds['supply_chain:portwatch-ports'];
+  const entry = body.seeds['prediction:markets'];
 
   assert.equal(res.status, 200);
   assert.equal(body.overall, 'healthy');
   assert.equal(entry.status, 'ok');
   assert.equal(entry.stale, false);
-  assert.equal(entry.recordCount, 174);
-  assert.equal(entry.minRecordCount, 174);
+  assert.deepEqual(entry.poolCounts, { geopolitical: 1, tech: 1, finance: 36 });
 });

--- a/tests/seed-history-ingest-health.test.mjs
+++ b/tests/seed-history-ingest-health.test.mjs
@@ -994,6 +994,8 @@ describe('a prolonged relay rejection is visible in /api/health', () => {
 });
 
 describe('a prolonged relay rejection is visible in /api/seed-health', () => {
+  const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
+
   /**
    * Answer every seed-meta GET with a fresh, healthy record so the assertions
    * below isolate the ingest entries — including the resilience-intervals data
@@ -1018,6 +1020,15 @@ describe('a prolonged relay rejection is visible in /api/seed-health', () => {
               _formula: 'pc',
               methodology: RESILIENCE_INTERVAL_METHODOLOGY,
               computedAt: '2026-06-11T12:00:00.000Z',
+            }),
+          };
+        }
+        if (key === PREDICTION_META_KEY) {
+          return {
+            result: JSON.stringify({
+              fetchedAt: Date.now(),
+              recordCount: 38,
+              poolCounts: { geopolitical: 18, tech: 12, finance: 8 },
             }),
           };
         }

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -276,7 +276,15 @@ test('skipWhenEmpty preserves the last-good extra key without refreshing its see
 // EMPTY_DATA even though the canonical data was fine. The mirror behavior
 // keeps health honest while preserving STALE_SEED honesty (mirrored
 // fetchedAt is the canonical's ORIGINAL value, not now).
-function withCanonicalEnvelope({ canonicalKey, fetchedAt, recordCount, sourceVersion = 'test-v1', contentAge }) {
+function withCanonicalEnvelope({
+  canonicalKey,
+  fetchedAt,
+  recordCount,
+  sourceVersion = 'test-v1',
+  contentAge,
+  existingSeedMeta,
+  seedMetaKey,
+}) {
   const seed = {
     fetchedAt,
     recordCount,
@@ -303,6 +311,11 @@ function withCanonicalEnvelope({ canonicalKey, fetchedAt, recordCount, sourceVer
     // Match GET on the canonical key — return the envelope wrapped in {result}.
     if (u.includes(`/get/${encodeURIComponent(canonicalKey)}`) || u.endsWith(`/get/${canonicalKey}`)) {
       return new Response(JSON.stringify({ result: JSON.stringify(envelope) }), { status: 200 });
+    }
+    // Prior seed-meta (poolCounts etc.) so validate-skip can re-apply diagnostics.
+    if (existingSeedMeta && seedMetaKey
+      && (u.includes(`/get/${encodeURIComponent(seedMetaKey)}`) || u.endsWith(`/get/${seedMetaKey}`))) {
+      return new Response(JSON.stringify({ result: JSON.stringify(existingSeedMeta) }), { status: 200 });
     }
     if (Array.isArray(body) && Array.isArray(body[0])) {
       return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
@@ -440,4 +453,69 @@ test('Sprint 1: validation failure with canonical envelope BUT no contentAge wri
   assert.ok(!('newestItemAt' in meta), 'newestItemAt absent for legacy seeders');
   assert.ok(!('oldestItemAt' in meta), 'oldestItemAt absent for legacy seeders');
   assert.ok(!('maxContentAgeMin' in meta), 'maxContentAgeMin absent for legacy seeders');
+});
+
+// #5875 review P1: validate-skip rewrites seed-meta as a full SET. Without
+// merging prior afterPublish diagnostics (poolCounts, errorReason, …),
+// fail-closed health surfaces false-alarm after the first healthy publish.
+test('validation skip preserves prior seed-meta diagnostics (poolCounts)', async () => {
+  const FROZEN_FETCHED_AT = 1700000000000;
+  const RECORD_COUNT = 38;
+  const POOL_COUNTS = { geopolitical: 18, tech: 12, finance: 8 };
+  const SEED_META_KEY = 'seed-meta:test:pool-diag-preserve';
+
+  globalThis.fetch = withCanonicalEnvelope({
+    canonicalKey: 'test:pool-diag-preserve:v1',
+    fetchedAt: FROZEN_FETCHED_AT,
+    recordCount: RECORD_COUNT,
+    sourceVersion: 'prediction-markets-v1',
+    seedMetaKey: SEED_META_KEY,
+    existingSeedMeta: {
+      fetchedAt: FROZEN_FETCHED_AT - 60_000,
+      recordCount: RECORD_COUNT,
+      sourceVersion: 'prediction-markets-v1',
+      poolCounts: POOL_COUNTS,
+      status: 'ok',
+    },
+  });
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'pool-diag-preserve', 'test:pool-diag-preserve:v1', async () => ({ items: [] }), {
+      validateFn: (d) => d?.items?.length >= 10,
+      ttlSeconds: 3600,
+    }),
+  );
+
+  const meta = lastMetaSetBody('pool-diag-preserve');
+  assert.ok(meta, 'seed-meta must be rewritten on the mirror path');
+  assert.equal(meta.recordCount, RECORD_COUNT, 'canonical recordCount still mirrored');
+  assert.equal(meta.fetchedAt, FROZEN_FETCHED_AT, 'canonical fetchedAt still mirrored');
+  assert.deepEqual(
+    meta.poolCounts,
+    POOL_COUNTS,
+    'prior poolCounts must survive validate-skip so fail-closed health stays honest',
+  );
+  assert.equal(meta.status, 'ok', 'other non-reserved diagnostics are preserved too');
+});
+
+test('validation skip with no prior diagnostics still writes a clean mirror', async () => {
+  const FROZEN_FETCHED_AT = 1700000000000;
+  globalThis.fetch = withCanonicalEnvelope({
+    canonicalKey: 'test:no-prior-diag:v1',
+    fetchedAt: FROZEN_FETCHED_AT,
+    recordCount: 50,
+  });
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'no-prior-diag', 'test:no-prior-diag:v1', async () => ({ items: [] }), {
+      validateFn: (d) => d?.items?.length >= 10,
+      ttlSeconds: 3600,
+    }),
+  );
+
+  const meta = lastMetaSetBody('no-prior-diag');
+  assert.ok(meta);
+  assert.equal(meta.recordCount, 50);
+  assert.equal(meta.fetchedAt, FROZEN_FETCHED_AT);
+  assert.equal(Object.hasOwn(meta, 'poolCounts'), false);
 });


### PR DESCRIPTION
## Summary

Prediction-market health now warns when any site-facing category pool empties, even if the aggregate market count remains healthy. The canonical seeder publishes the counts that consumers can actually retrieve, and both health surfaces fail closed when those counts are missing, malformed, or below the one-market floor.

The operator contract keeps freshness separate from coverage: a newly published snapshot with an empty pool reports `coverage_partial` while remaining `stale: false`. The first deployment can therefore warn until the next prediction-market seed run writes the new metadata; that transitional warning is intentional.

Fixes #5875.

## Validation

- Full data suite: 19,722 passed, 0 failed, 6 skipped.
- Focused producer and health regressions: 109 passed, including empty, missing, malformed, and recovered pool metadata.
- `npm run typecheck:api` and `npm run lint` passed; lint retained only pre-existing diagnostics outside this change.
- The repository pre-push gate passed frontend/API typechecks, edge bundling, changed tests, docs/MDX checks, and freshness guards.
- A full-variant Vite production build passed with the three locally guarded `VITE_` secret variables explicitly blanked.

## Post-Deploy Monitoring & Validation

- Watch the `seed-prediction-markets` Railway run through at least two scheduled cycles and confirm it publishes `poolCounts`.
- Check `/api/health?compact=1` at `predictionMarkets` and `/api/seed-health` at `prediction:markets`.
- Accept when the aggregate count remains at least 20, every `geopolitical`, `tech`, and `finance` count is at least 1, and both surfaces recover to `OK` / `ok`.
- Treat `COVERAGE_PARTIAL` before the first post-deploy seed cycle as the expected metadata transition. Treat missing, malformed, or zero counts after two cycles as a real incident and inspect venue taxonomy/tag drift plus seeder output.
- Validation window: the first two prediction-market seed cycles after deployment. Owner: the deployment maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
