### PR TITLE
test(china): pin Japan MOD Cloudflare fallback contract

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -461,8 +461,9 @@ use an approved authenticated HTTPS integration instead.
 After provisioning, recovery is accepted only when:
 
 1. `crossStraitActivityJapanMod` reports `OK` for two consecutive scheduled
-   three-hour runs;
-2. `lastSuccessAt` is non-null and later than the configuration change;
+   three-hour runs from distinct scheduled executions;
+2. `lastSuccessAt` is non-null, later than the configuration change, and
+   advances between those two successful runs;
 3. newly admitted Japan MOD records are tied to the successful index fetch;
 4. the combined cross-Strait publication remains available and explicitly
    source-degraded when a later Japan MOD request fails.

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -432,6 +432,41 @@ continuous metric.
 | **Required env** | `JAPAN_MOD_PROXY_URL` or `PROXY_URL` (Cross-Strait Activity's Japan MOD exit; the section declares an any-of group, so either satisfies it and only an environment with neither fails as `CONFIG_ERROR`) |
 | **Note** | Cross-Strait Activity is the only direct external-source member; it uses bounded MND/Japan MOD requests and a 3h freshness gate. China Decision Signals validates and republishes the bounded public composition after reading its domain lanes. Other members are Redis-derived. The bundle enforces a 570s wall-time admission budget so a non-fitting due section defers before Railway's 10-minute container limit. |
 
+#### Japan MOD transport recovery gate
+
+The official Japan Joint Staff index is
+`https://www.mod.go.jp/js/press/index-en.html`. The runtime makes one direct
+index request and, after a transport failure, one request through
+`JAPAN_MOD_PROXY_URL` (falling back to `PROXY_URL`). It never downloads linked
+PDFs during a scheduled run.
+
+As of 2026-07-31, destination allowlisting is not recovery: direct Railway
+egress and the configured Decodo gateway both receive an HTTP 403 Cloudflare
+managed challenge (`Just a moment...`). Production therefore remains
+truthfully `SOURCE_BLOCKED` with `blockedReason: HTTP_403`; its two reviewed
+rows are retained context, not proof of a successful fetch.
+
+Recovery requires an account-approved managed-browser/unblocker route that
+returns the authentic official index. For the current provider, the concrete
+external dependency is an active
+[Decodo Site Unblocker](https://help.decodo.com/docs/site-unblocker-quick-start)
+subscription with source-specific credentials and a successful target test.
+The ordinary residential gateway credential is not a substitute for that
+product. Do not repoint `JAPAN_MOD_PROXY_URL` until the exact adapter request
+returns a 2xx response containing valid Japan Joint Staff PDF links within the
+existing 524,288-byte bound. If the provider requires disabling TLS
+verification, do not weaken the adapter; provision a trusted provider CA or
+use an approved authenticated HTTPS integration instead.
+
+After provisioning, recovery is accepted only when:
+
+1. `crossStraitActivityJapanMod` reports `OK` for two consecutive scheduled
+   three-hour runs;
+2. `lastSuccessAt` is non-null and later than the configuration change;
+3. newly admitted Japan MOD records are tied to the successful index fetch;
+4. the combined cross-Strait publication remains available and explicitly
+   source-degraded when a later Japan MOD request fails.
+
 ### Bundle 6: seed-bundle-climate
 
 | Setting | Value |

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1531,12 +1531,25 @@ describe('quantified cross-Strait activity (#5575)', () => {
       'via https://proxy-user:proxy-secret@proxy.test',
       '</head></html>',
     ].join('');
-    const snapshot = await fetchCrossStraitActivitySnapshot({
+    const previousSnapshot = await fetchCrossStraitActivitySnapshot({
       fetchFn: crossStraitFixtureFetch(
-        () => new Response('Forbidden', { status: 403 }),
+        () => new Response(fixture('jmod-index.html')),
       ),
       now: Date.parse(retrievedAt),
       previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: '',
+    });
+    const nextAt = '2026-07-25T11:30:00.000Z';
+    const fetchBlockedSnapshot = (
+      now: string,
+      priorSnapshot: typeof previousSnapshot | null,
+    ) => fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('Forbidden', { status: 403 }),
+      ),
+      now: Date.parse(now),
+      previousSnapshot: priorSnapshot,
       sleepFn: async () => {},
       proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
       proxyRequestFn: async () => ({
@@ -1545,6 +1558,18 @@ describe('quantified cross-Strait activity (#5575)', () => {
         contentType: 'text/html; charset=UTF-8',
       }),
     });
+    const firstRunSnapshot = await fetchBlockedSnapshot(retrievedAt, null);
+    const firstRunJapan = firstRunSnapshot.sources.find(
+      (source: { id: string }) => source.id === 'japan-mod',
+    );
+    assert.equal(firstRunJapan?.lastSuccessAt, null);
+    assert.ok(
+      firstRunSnapshot.observations
+        .filter((row: { sourceId: string }) => row.sourceId === 'japan-mod')
+        .every((row: { indexPresence?: string }) => row.indexPresence === 'unknown'),
+      'a first-run source failure must stay explicitly unknown',
+    );
+    const snapshot = await fetchBlockedSnapshot(nextAt, previousSnapshot);
 
     const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
     assert.equal(japan?.transportStatus, 'error');
@@ -1552,7 +1577,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(japan?.fallbackReason, 'HTTP_403');
     assert.equal(japan?.proxyFailureReason, 'HTTP_403');
     assert.equal(japan?.requestCount, 2);
-    assert.equal(japan?.lastSuccessAt, null);
+    assert.equal(japan?.lastSuccessAt, retrievedAt);
     assert.deepEqual(japan?.errorCodes, ['HTTP_403']);
     assert.deepEqual(japan?.proxyFailureDetail, {
       stage: 'response',
@@ -1569,9 +1594,15 @@ describe('quantified cross-Strait activity (#5575)', () => {
     const retainedJapanRows = snapshot.observations
       .filter((row: { sourceId: string }) => row.sourceId === 'japan-mod');
     assert.equal(retainedJapanRows.length, REVIEWED_JAPAN_MOD_OBSERVATIONS.length);
-    assert.ok(
-      retainedJapanRows.every((row: { indexPresence?: string }) => row.indexPresence === 'unknown'),
-      'a blocked transport must not present retained rows as evidence of a successful index fetch',
+    const previousIndexPresence = previousSnapshot.observations
+      .filter((row: { sourceId: string }) => row.sourceId === 'japan-mod')
+      .map((row: { id: string; indexPresence?: string }) => [row.id, row.indexPresence]);
+    const currentIndexPresence = retainedJapanRows
+      .map((row: { id: string; indexPresence?: string }) => [row.id, row.indexPresence]);
+    assert.deepEqual(
+      currentIndexPresence,
+      previousIndexPresence,
+      'a blocked transport must retain prior index presence without refreshing success',
     );
     assert.doesNotMatch(JSON.stringify(japan), /proxy-user|proxy-secret/);
     assert.doesNotMatch(JSON.stringify(japan), /cHJveHktdXNlcjpwcm94eS1zZWNyZXQ=/);

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1523,8 +1523,14 @@ describe('quantified cross-Strait activity (#5575)', () => {
     }
   });
 
-  it('classifies direct and proxied Japan MOD HTTP 403 responses as explicitly blocked', async () => {
-    const responseBody = `Denied via https://proxy-user:proxy-secret@proxy.test ${'x'.repeat(500)}`;
+  it('retains reviewed Japan MOD rows when direct and proxy paths receive the Cloudflare challenge', async () => {
+    const responseBody = [
+      '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>',
+      '<meta name="robots" content="noindex,nofollow">',
+      'Proxy-Authorization: Basic cHJveHktdXNlcjpwcm94eS1zZWNyZXQ=',
+      'via https://proxy-user:proxy-secret@proxy.test',
+      '</head></html>',
+    ].join('');
     const snapshot = await fetchCrossStraitActivitySnapshot({
       fetchFn: crossStraitFixtureFetch(
         () => new Response('Forbidden', { status: 403 }),
@@ -1545,16 +1551,30 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.equal(japan?.blockedReason, 'HTTP_403');
     assert.equal(japan?.fallbackReason, 'HTTP_403');
     assert.equal(japan?.proxyFailureReason, 'HTTP_403');
+    assert.equal(japan?.requestCount, 2);
+    assert.equal(japan?.lastSuccessAt, null);
     assert.deepEqual(japan?.errorCodes, ['HTTP_403']);
     assert.deepEqual(japan?.proxyFailureDetail, {
       stage: 'response',
       httpStatus: 403,
       contentType: 'text/html; charset=UTF-8',
-      bodyPrefix: `Denied via https://[redacted]@proxy.test ${'x'.repeat(500)}`.slice(0, 256),
+      bodyPrefix: [
+        '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>',
+        '<meta name="robots" content="noindex,nofollow">',
+        'Proxy-Authorization: [redacted]',
+      ].join(''),
       errorCode: null,
       errorMessage: 'HTTP_403',
     });
+    const retainedJapanRows = snapshot.observations
+      .filter((row: { sourceId: string }) => row.sourceId === 'japan-mod');
+    assert.equal(retainedJapanRows.length, REVIEWED_JAPAN_MOD_OBSERVATIONS.length);
+    assert.ok(
+      retainedJapanRows.every((row: { indexPresence?: string }) => row.indexPresence === 'unknown'),
+      'a blocked transport must not present retained rows as evidence of a successful index fetch',
+    );
     assert.doesNotMatch(JSON.stringify(japan), /proxy-user|proxy-secret/);
+    assert.doesNotMatch(JSON.stringify(japan), /cHJveHktdXNlcjpwcm94eS1zZWNyZXQ=/);
   });
 
   it('does not classify mixed direct failures and proxy 403 as a two-path block', async () => {


### PR DESCRIPTION
## Summary

Japan MOD transport failures now have a precise recovery contract instead of
being mistaken for a successful allowlist or ordinary-proxy rollout. The
regression proves that direct and proxied Cloudflare challenges remain
`SOURCE_BLOCKED`, retain reviewed context without refreshing success, stay
inside the two-request/no-PDF budget, and redact proxy credentials.

Production is not restored by this PR. Recovery still depends on an
account-approved managed-unblocker route passing the exact official-index
request, followed by two consecutive successful three-hour runs with a newer
`lastSuccessAt` and newly admitted records.

## Validation

- Focused cross-Strait suites: 72 passed, 0 failed.
- Pre-push gate: typecheck, 68 changed-file tests, full markdown lint, and
  version sync passed.
- Documentation contract: 91 code-backed claims matched.
- Structured review: no actionable findings.

## Operational acceptance

The source remains blocked until `crossStraitActivityJapanMod` reports `OK` for
two consecutive scheduled runs. Any later failure must continue publishing the
combined feed with an explicit source-degraded state; configuration provisioning
and the production observation window remain separate operational work.

Related: #5904

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
